### PR TITLE
feat(finance): the payment-behaviour formulas, as provable arithmetic

### DIFF
--- a/backend/internal/modules/finance/formulas.go
+++ b/backend/internal/modules/finance/formulas.go
@@ -1,0 +1,247 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package finance
+
+// The five figures the company page reports about how a customer pays
+// (finance-ingestion.md FIN-FORM-1..5), as pure functions over mirrored rows.
+//
+// They are pure so the arithmetic can be proven without a database, because
+// what is at stake here is not SQL but honesty: which rows may enter a figure,
+// what a figure means when too few rows qualify, and when the answer is "not
+// enough to say" rather than a number. One unusually late invoice must not
+// become a "bad payer" label.
+
+import (
+	"sort"
+	"time"
+)
+
+// Window parameters (FIN-PARAM-1..3). Named rather than inlined because each
+// figure reports the window it used, and a figure whose stated window differs
+// from the one it applied is worse than no figure.
+const (
+	// IssuedWindowDays is FIN-PARAM-1: the trailing window for net invoiced.
+	IssuedWindowDays = 365
+	// TimelinessWindowDays is FIN-PARAM-2, deliberately shorter than the
+	// issued window — how a customer pays NOW matters more than last year.
+	TimelinessWindowDays = 180
+	// MinTimelinessSample is FIN-PARAM-3. Below it every timeliness figure
+	// answers insufficient-sample instead of a number: five settled invoices
+	// is the floor at which a pattern is a pattern rather than an anecdote.
+	MinTimelinessSample = 5
+)
+
+// Invoice is one mirrored invoice, reduced to what the formulas read.
+type Invoice struct {
+	Status string
+	// IssuedOn keys FIN-FORM-1's window — never a service or recognition
+	// period, because the issue date is the only field every provider carries.
+	IssuedOn time.Time
+	DueOn    *time.Time
+	// FullyPaidAt is set only when the invoice is completely settled. A
+	// partially paid invoice has no settlement date and therefore no
+	// punctuality (FIN-FORM-3).
+	FullyPaidAt *time.Time
+	// NetMinorBase and CreditedMinorBase are converted at the invoice's OWN
+	// frozen rate (FIN-PARAM-7).
+	NetMinorBase      int64
+	CreditedMinorBase int64
+	OpenMinorBase     int64
+	// CreditsInvoice marks this row as a credit note (FIN-DDL-N-3). It is
+	// excluded from FIN-FORM-1's positive term and reaches the figure only
+	// through the credited total of the invoice it reduces — counted in both,
+	// a credit is subtracted twice; counted in neither, it disappears.
+	CreditsInvoice bool
+	// Disputed excludes the invoice from timeliness: the delay is a
+	// disagreement, not a payment habit. It still counts as open and owed.
+	Disputed bool
+	// RateMissing marks an invoice whose issue date had no effective
+	// conversion rate. One of these refuses the WHOLE figure rather than
+	// converting some rows and not others (FIN-AC-6).
+	RateMissing bool
+}
+
+// NetInvoiced is FIN-FORM-1: what was issued over the trailing window, less
+// what was credited back.
+//
+// Refuses rather than converting part of the set: a total assembled from the
+// rows that happened to have a rate is a smaller number presented as the whole
+// one, and nothing on the surface would say so.
+type NetInvoiced struct {
+	AmountMinorBase int64
+	// Records counts ISSUED invoices, never credit notes — a credit note is
+	// not a fourth invoice, it is a reduction of one of the three.
+	Records    int
+	WindowDays int
+	// RateUnavailable reports the FIN-AC-6 refusal. When true the amount is
+	// not a figure and must not be rendered.
+	RateUnavailable bool
+}
+
+// NetInvoicedOver folds the invoices issued within the window ending at asOf.
+func NetInvoicedOver(invoices []Invoice, asOf time.Time) NetInvoiced {
+	out := NetInvoiced{WindowDays: IssuedWindowDays}
+	from := asOf.AddDate(0, 0, -IssuedWindowDays)
+	for _, inv := range invoices {
+		if !issuedInWindow(inv, from, asOf) {
+			continue
+		}
+		if inv.RateMissing {
+			// One unconvertible row refuses the whole figure. Reporting the
+			// rest would be a partial sum wearing the label of a total.
+			return NetInvoiced{WindowDays: IssuedWindowDays, RateUnavailable: true}
+		}
+		if inv.CreditsInvoice {
+			// Subtracted exactly once, through the credited total below.
+			continue
+		}
+		out.AmountMinorBase += inv.NetMinorBase - inv.CreditedMinorBase
+		out.Records++
+	}
+	return out
+}
+
+// issuedInWindow answers whether one row belongs to FIN-FORM-1's positive
+// term. A draft was never issued; a void invoice is excluded entirely rather
+// than netted to zero, so the record count stays honest.
+func issuedInWindow(inv Invoice, from, to time.Time) bool {
+	if inv.Status == "draft" || inv.Status == "void" {
+		return false
+	}
+	return !inv.IssuedOn.Before(from) && !inv.IssuedOn.After(to)
+}
+
+// OpenBalance is FIN-FORM-2: what is owed, and how much of it is late.
+type OpenBalance struct {
+	OpenMinorBase    int64
+	OverdueMinorBase int64
+	OverdueCount     int
+	// RateUnavailable is the same FIN-AC-6 refusal net invoiced makes. An open
+	// balance assembled from the invoices that happened to have a rate is a
+	// smaller debt presented as the whole one, which is the more dangerous of
+	// the two figures to get wrong.
+	RateUnavailable bool
+	// OldestOverdueDays is the age of the longest-outstanding overdue
+	// invoice, which is what tells a rep whether this is a slip or a problem.
+	OldestOverdueDays int
+}
+
+// OpenBalanceAt folds what is outstanding as of the given instant.
+//
+// A DISPUTED invoice counts as open, because it is genuinely owed, and is
+// reported separately as disputed elsewhere. Presenting it only as overdue
+// would describe a disagreement as a payment failure.
+func OpenBalanceAt(invoices []Invoice, asOf time.Time) OpenBalance {
+	var out OpenBalance
+	for _, inv := range invoices {
+		if inv.Status == "void" || inv.OpenMinorBase <= 0 {
+			continue
+		}
+		if inv.RateMissing {
+			return OpenBalance{RateUnavailable: true}
+		}
+		out.OpenMinorBase += inv.OpenMinorBase
+		if inv.DueOn == nil || !inv.DueOn.Before(asOf) {
+			continue
+		}
+		out.OverdueMinorBase += inv.OpenMinorBase
+		out.OverdueCount++
+		if age := daysBetween(*inv.DueOn, asOf); age > out.OldestOverdueDays {
+			out.OldestOverdueDays = age
+		}
+	}
+	return out
+}
+
+// DaysLate is FIN-FORM-3 for one invoice: negative is early, zero is on the
+// day, positive is late. The second return is false when the invoice has no
+// punctuality to report at all.
+//
+// The subtraction is between CALENDAR DATES, which is what the formula says
+// and what a human means by "eight days late". Measuring elapsed hours instead
+// gets it wrong twice: a settlement at 09:00 against a due date at 17:00 is
+// the same day and would read as early, and a DST transition inside the span
+// shifts the whole answer by one.
+func DaysLate(inv Invoice) (int, bool) {
+	if inv.Disputed || inv.DueOn == nil || inv.FullyPaidAt == nil {
+		return 0, false
+	}
+	return daysBetween(*inv.DueOn, *inv.FullyPaidAt), true
+}
+
+// daysBetween is `date(to) − date(from)`, counted in whole calendar days in
+// each timestamp's own location. Both dates are re-anchored to midnight UTC
+// first, so the difference is a count of dates rather than of hours, and no
+// zone offset or DST shift can move it.
+func daysBetween(from, to time.Time) int {
+	fy, fm, fd := from.Date()
+	ty, tm, td := to.Date()
+	fromDay := time.Date(fy, fm, fd, 0, 0, 0, 0, time.UTC)
+	toDay := time.Date(ty, tm, td, 0, 0, 0, 0, time.UTC)
+	return int(toDay.Sub(fromDay) / (24 * time.Hour))
+}
+
+// Timeliness is FIN-FORM-4 and FIN-FORM-5 together: they read the same sample,
+// so computing them apart would let the median and the on-time rate disagree
+// about which invoices they describe.
+type Timeliness struct {
+	// InsufficientSample is the answer below FIN-PARAM-3, and it is an answer
+	// rather than a missing value: "not enough settled invoices to say" is
+	// what stops one late payment becoming a reputation.
+	InsufficientSample bool
+	MedianDaysLate     int
+	// OnTimeRate is a share in [0,1]. Its DENOMINATOR is part of the figure,
+	// not a footnote — 100% over two invoices and over sixty are different
+	// claims and must never render the same.
+	OnTimeRate float64
+	SampleSize int
+	WindowDays int
+}
+
+// TimelinessOver folds the invoices settled inside the timeliness window.
+func TimelinessOver(invoices []Invoice, asOf time.Time) Timeliness {
+	out := Timeliness{WindowDays: TimelinessWindowDays}
+	from := asOf.AddDate(0, 0, -TimelinessWindowDays)
+	late := make([]int, 0, len(invoices))
+	onTime := 0
+	for _, inv := range invoices {
+		if inv.FullyPaidAt == nil || inv.FullyPaidAt.Before(from) || inv.FullyPaidAt.After(asOf) {
+			continue
+		}
+		days, ok := DaysLate(inv)
+		if !ok {
+			continue
+		}
+		late = append(late, days)
+		if days <= 0 {
+			onTime++
+		}
+	}
+	out.SampleSize = len(late)
+	if out.SampleSize < MinTimelinessSample {
+		out.InsufficientSample = true
+		return out
+	}
+	out.MedianDaysLate = medianOf(late)
+	out.OnTimeRate = float64(onTime) / float64(out.SampleSize)
+	return out
+}
+
+// medianOf is the middle value, or the mean of the two middle ones rounded
+// half AWAY FROM ZERO. Median rather than mean throughout, deliberately: one
+// disputed-then-settled invoice at 180 days would drag a mean into a false
+// story about a customer who otherwise pays on time.
+func medianOf(values []int) int {
+	sorted := append([]int(nil), values...)
+	sort.Ints(sorted)
+	mid := len(sorted) / 2
+	if len(sorted)%2 == 1 {
+		return sorted[mid]
+	}
+	sum := sorted[mid-1] + sorted[mid]
+	if sum < 0 {
+		return (sum - 1) / 2
+	}
+	return (sum + 1) / 2
+}

--- a/backend/internal/modules/finance/formulas_test.go
+++ b/backend/internal/modules/finance/formulas_test.go
@@ -1,0 +1,370 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package finance
+
+// The spec's own worked examples, run as tests (finance-ingestion.md
+// FIN-FORM-1..5). Using the chapter's numbers rather than invented ones is
+// deliberate: it makes a disagreement between this code and the specification
+// fail here, where a reader can see both.
+
+import (
+	"testing"
+	"time"
+)
+
+func on(t *testing.T, value string) time.Time {
+	t.Helper()
+	parsed, err := time.Parse(time.DateOnly, value)
+	if err != nil {
+		t.Fatalf("parsing %q: %v", value, err)
+	}
+	return parsed
+}
+
+func ptr(t time.Time) *time.Time { return &t }
+
+// FIN-FORM-1's worked example: three issued invoices of 8.750, 9.820 and
+// 12.430 euro, plus a credit note of 1.000 pointing at the first, whose
+// credited total therefore carries that same 1.000. Expected: 30.000 over
+// THREE records — the credit note is not the fourth.
+func TestNetInvoicedSubtractsACreditNoteExactlyOnce(t *testing.T) {
+	asOf := on(t, "2026-08-09")
+	issued := on(t, "2026-06-01")
+	out := NetInvoicedOver([]Invoice{
+		{Status: "paid", IssuedOn: issued, NetMinorBase: 875000, CreditedMinorBase: 100000},
+		{Status: "open", IssuedOn: issued, NetMinorBase: 982000},
+		{Status: "open", IssuedOn: issued, NetMinorBase: 1243000},
+		// The credit note itself: excluded from the positive term, and already
+		// subtracted through the first invoice's credited total above.
+		{Status: "credited", IssuedOn: issued, NetMinorBase: 100000, CreditsInvoice: true},
+	}, asOf)
+
+	if out.AmountMinorBase != 3000000 {
+		t.Fatalf("net invoiced = %d, want 3000000 (31.000 issued less 1.000 credited)", out.AmountMinorBase)
+	}
+	if out.Records != 3 {
+		t.Fatalf("records = %d, want 3 — the credit note is not a fourth invoice", out.Records)
+	}
+}
+
+// Counting the credit note in the positive term as well would subtract it
+// twice. This is the failure FIN-AC-N-1 exists to pin, so it gets its own case.
+func TestACreditNoteIsNotCountedInThePositiveTerm(t *testing.T) {
+	asOf := on(t, "2026-08-09")
+	issued := on(t, "2026-06-01")
+	withCredit := NetInvoicedOver([]Invoice{
+		{Status: "paid", IssuedOn: issued, NetMinorBase: 500000, CreditedMinorBase: 100000},
+		{Status: "credited", IssuedOn: issued, NetMinorBase: 100000, CreditsInvoice: true},
+	}, asOf)
+
+	// 5.000 issued less 1.000 credited is 4.000. Counting the note in both
+	// places gives 3.000; counting it in neither gives 5.000.
+	if withCredit.AmountMinorBase != 400000 {
+		t.Fatalf("net invoiced = %d, want 400000 — subtracted once, not twice or never",
+			withCredit.AmountMinorBase)
+	}
+}
+
+// A draft was never issued, and a void invoice is excluded entirely rather
+// than netted to zero — so the RECORD COUNT stays honest as well as the total.
+func TestNetInvoicedExcludesDraftsAndVoidedInvoices(t *testing.T) {
+	asOf := on(t, "2026-08-09")
+	issued := on(t, "2026-06-01")
+	out := NetInvoicedOver([]Invoice{
+		{Status: "open", IssuedOn: issued, NetMinorBase: 100000},
+		{Status: "draft", IssuedOn: issued, NetMinorBase: 999900},
+		{Status: "void", IssuedOn: issued, NetMinorBase: 999900},
+	}, asOf)
+
+	if out.AmountMinorBase != 100000 {
+		t.Fatalf("net invoiced = %d, want 100000", out.AmountMinorBase)
+	}
+	if out.Records != 1 {
+		t.Fatalf("records = %d, want 1 — a void invoice is not a record worth zero", out.Records)
+	}
+}
+
+// FIN-AC-6: one invoice with no conversion rate on its issue date refuses the
+// WHOLE figure. Converting the rest would report a smaller number under the
+// label of a complete one.
+func TestOneUnconvertibleInvoiceRefusesTheWholeFigure(t *testing.T) {
+	asOf := on(t, "2026-08-09")
+	issued := on(t, "2026-06-01")
+	out := NetInvoicedOver([]Invoice{
+		{Status: "open", IssuedOn: issued, NetMinorBase: 100000},
+		{Status: "open", IssuedOn: issued, NetMinorBase: 200000, RateMissing: true},
+	}, asOf)
+
+	if !out.RateUnavailable {
+		t.Fatal("figure was served despite an invoice with no rate; a partial sum must refuse")
+	}
+	if out.AmountMinorBase != 0 {
+		t.Fatalf("amount = %d, want 0 — a refused figure carries no number", out.AmountMinorBase)
+	}
+}
+
+func TestNetInvoicedIgnoresInvoicesOutsideTheWindow(t *testing.T) {
+	asOf := on(t, "2026-08-09")
+	out := NetInvoicedOver([]Invoice{
+		{Status: "open", IssuedOn: on(t, "2026-06-01"), NetMinorBase: 100000},
+		{Status: "open", IssuedOn: on(t, "2024-01-01"), NetMinorBase: 999900},
+	}, asOf)
+
+	if out.AmountMinorBase != 100000 || out.Records != 1 {
+		t.Fatalf("net invoiced = %d over %d records, want 100000 over 1",
+			out.AmountMinorBase, out.Records)
+	}
+	if out.WindowDays != IssuedWindowDays {
+		t.Fatalf("window = %d days, want %d — the figure reports the window it used",
+			out.WindowDays, IssuedWindowDays)
+	}
+}
+
+// FIN-FORM-2's worked example: open invoices of 19.750, 12.430 and 2.000, the
+// second due 19 days ago and the others not yet due.
+func TestOpenBalanceSeparatesWhatIsOverdueFromWhatIsMerelyOwed(t *testing.T) {
+	asOf := on(t, "2026-08-09")
+	out := OpenBalanceAt([]Invoice{
+		{Status: "open", OpenMinorBase: 1975000, DueOn: ptr(on(t, "2026-09-01"))},
+		{Status: "open", OpenMinorBase: 1243000, DueOn: ptr(on(t, "2026-07-21"))},
+		{Status: "open", OpenMinorBase: 200000, DueOn: ptr(on(t, "2026-08-20"))},
+	}, asOf)
+
+	if out.OpenMinorBase != 3418000 {
+		t.Fatalf("open = %d, want 3418000", out.OpenMinorBase)
+	}
+	if out.OverdueMinorBase != 1243000 || out.OverdueCount != 1 {
+		t.Fatalf("overdue = %d across %d, want 1243000 across 1",
+			out.OverdueMinorBase, out.OverdueCount)
+	}
+	if out.OldestOverdueDays != 19 {
+		t.Fatalf("oldest overdue = %d days, want 19", out.OldestOverdueDays)
+	}
+}
+
+// A disputed invoice is genuinely owed and genuinely contested. Counting it as
+// open is right; describing it only as overdue would call a disagreement a
+// payment failure.
+func TestADisputedInvoiceStillCountsAsOwed(t *testing.T) {
+	asOf := on(t, "2026-08-09")
+	out := OpenBalanceAt([]Invoice{
+		{Status: "disputed", OpenMinorBase: 500000, DueOn: ptr(on(t, "2026-07-01")), Disputed: true},
+	}, asOf)
+
+	if out.OpenMinorBase != 500000 {
+		t.Fatalf("open = %d, want 500000 — a disputed invoice is still owed", out.OpenMinorBase)
+	}
+}
+
+// FIN-FORM-3's worked examples: due 15 May settled 23 May is +8; due and
+// settled on 13 April is 0, not early.
+func TestDaysLateCountsFromTheDueDate(t *testing.T) {
+	late, ok := DaysLate(Invoice{
+		DueOn: ptr(on(t, "2026-05-15")), FullyPaidAt: ptr(on(t, "2026-05-23")),
+	})
+	if !ok || late != 8 {
+		t.Fatalf("days late = %d (ok=%v), want +8", late, ok)
+	}
+
+	onDay, ok := DaysLate(Invoice{
+		DueOn: ptr(on(t, "2026-04-13")), FullyPaidAt: ptr(on(t, "2026-04-13")),
+	})
+	if !ok || onDay != 0 {
+		t.Fatalf("days late = %d (ok=%v), want 0 — settled on the due date is not early", onDay, ok)
+	}
+}
+
+// Punctuality is defined only for a fully settled, undisputed invoice. A
+// partially paid one has no settlement date; a disputed one's delay is an
+// argument rather than a habit.
+func TestAnUnsettledOrDisputedInvoiceHasNoPunctuality(t *testing.T) {
+	if _, ok := DaysLate(Invoice{DueOn: ptr(on(t, "2026-05-15"))}); ok {
+		t.Fatal("an unsettled invoice reported a punctuality it cannot have")
+	}
+	if _, ok := DaysLate(Invoice{
+		DueOn: ptr(on(t, "2026-05-15")), FullyPaidAt: ptr(on(t, "2026-06-15")), Disputed: true,
+	}); ok {
+		t.Fatal("a disputed invoice reported punctuality; the delay is a disagreement")
+	}
+}
+
+// FIN-FORM-4's worked example: settled invoices at −2, 0, 3, 8, 12 give a
+// median of 3 over a sample of 5. The on-time rate over that same sample is
+// 2 of 5 — see the note on the assertion below.
+func TestMedianAndOnTimeRateReadTheSameSample(t *testing.T) {
+	asOf := on(t, "2026-08-09")
+	settle := func(daysLate int) Invoice {
+		due := on(t, "2026-06-01")
+		return Invoice{DueOn: ptr(due), FullyPaidAt: ptr(due.AddDate(0, 0, daysLate))}
+	}
+	out := TimelinessOver([]Invoice{
+		settle(-2), settle(0), settle(3), settle(8), settle(12),
+	}, asOf)
+
+	if out.InsufficientSample {
+		t.Fatal("five settled invoices is the floor, not below it")
+	}
+	if out.MedianDaysLate != 3 {
+		t.Fatalf("median = %d, want 3", out.MedianDaysLate)
+	}
+	if out.SampleSize != 5 {
+		t.Fatalf("sample = %d, want 5 — the denominator is part of the figure", out.SampleSize)
+	}
+	// Of −2, 0, 3, 8 and 12, exactly two are at or before due. FIN-FORM-5's
+	// prose says "4 of 5", which does not describe FIN-FORM-4's own sample —
+	// the two examples were written against different sets. The rule is what
+	// is implemented: count(days_late <= 0) over the sample.
+	if out.OnTimeRate != 0.4 {
+		t.Fatalf("on-time rate = %v, want 0.4 (2 of 5 at or before due)", out.OnTimeRate)
+	}
+}
+
+// The same customer with only three settled invoices: below FIN-PARAM-3, so
+// the answer is "not enough to say" rather than a number. This is what stops
+// one late payment becoming a reputation.
+func TestTooFewSettledInvoicesAnswerInsufficientSample(t *testing.T) {
+	asOf := on(t, "2026-08-09")
+	settle := func(daysLate int) Invoice {
+		due := on(t, "2026-06-01")
+		return Invoice{DueOn: ptr(due), FullyPaidAt: ptr(due.AddDate(0, 0, daysLate))}
+	}
+	out := TimelinessOver([]Invoice{settle(-2), settle(0), settle(8)}, asOf)
+
+	if !out.InsufficientSample {
+		t.Fatal("three settled invoices produced a timeliness figure; the floor is five")
+	}
+	if out.MedianDaysLate != 0 || out.OnTimeRate != 0 {
+		t.Fatalf("a refused figure carried values (median %d, rate %v)",
+			out.MedianDaysLate, out.OnTimeRate)
+	}
+	if out.SampleSize != 3 {
+		t.Fatalf("sample = %d, want 3 — the refusal still says how many it had", out.SampleSize)
+	}
+}
+
+// Median, not mean, is the whole point: one disputed-then-settled invoice at
+// 180 days would drag a mean into a false story about a customer who otherwise
+// pays on time.
+func TestOneVeryLateInvoiceDoesNotMoveTheMedian(t *testing.T) {
+	// The four prompt settlements land on the due date and just after it; the
+	// fifth lands 180 days later. asOf sits just past that last one, and the
+	// due date is chosen so all five settlements fall inside the trailing
+	// window — this case is about the median, not about the window.
+	asOf := on(t, "2026-10-30")
+	settle := func(daysLate int) Invoice {
+		due := on(t, "2026-05-03")
+		return Invoice{DueOn: ptr(due), FullyPaidAt: ptr(due.AddDate(0, 0, daysLate))}
+	}
+	out := TimelinessOver([]Invoice{
+		settle(0), settle(1), settle(2), settle(3), settle(180),
+	}, asOf)
+
+	// The mean here is 37 days — a story about a bad payer. The median is 2.
+	if out.MedianDaysLate != 2 {
+		t.Fatalf("median = %d, want 2 — a mean would report 37 and misdescribe them", out.MedianDaysLate)
+	}
+}
+
+// A settlement and a due date on the SAME calendar day is zero days late,
+// whatever time of day either carries and whatever zone they were recorded in.
+// Measuring elapsed hours instead reports −1 or +1 here.
+func TestSameDaySettlementIsZeroWhateverTheTimeOfDay(t *testing.T) {
+	due := time.Date(2026, 5, 15, 17, 0, 0, 0, time.UTC)
+	paid := time.Date(2026, 5, 15, 9, 0, 0, 0, time.UTC)
+
+	days, ok := DaysLate(Invoice{DueOn: &due, FullyPaidAt: &paid})
+
+	if !ok || days != 0 {
+		t.Fatalf("days late = %d (ok=%v), want 0 — settled the same day it was due", days, ok)
+	}
+}
+
+// A span crossing a daylight-saving transition is still a count of dates. An
+// hours-based subtraction loses or gains one here.
+func TestDaysLateSurvivesADaylightSavingTransition(t *testing.T) {
+	berlin, err := time.LoadLocation("Europe/Berlin")
+	if err != nil {
+		t.Fatalf("loading the zone: %v", err)
+	}
+	// 29 March 2026 is the spring-forward night in Europe/Berlin.
+	due := time.Date(2026, 3, 27, 12, 0, 0, 0, berlin)
+	paid := time.Date(2026, 3, 31, 12, 0, 0, 0, berlin)
+
+	days, ok := DaysLate(Invoice{DueOn: &due, FullyPaidAt: &paid})
+
+	if !ok || days != 4 {
+		t.Fatalf("days late = %d (ok=%v), want 4 calendar days across the DST change", days, ok)
+	}
+}
+
+// FIN-AC-6 governs the open balance exactly as it governs net invoiced: a
+// total assembled from the convertible rows is a smaller debt wearing the
+// label of the whole one.
+func TestOneUnconvertibleInvoiceRefusesTheOpenBalance(t *testing.T) {
+	asOf := on(t, "2026-08-09")
+	out := OpenBalanceAt([]Invoice{
+		{Status: "open", OpenMinorBase: 100000, DueOn: ptr(on(t, "2026-07-01"))},
+		{Status: "open", OpenMinorBase: 900000, DueOn: ptr(on(t, "2026-07-01")), RateMissing: true},
+	}, asOf)
+
+	if !out.RateUnavailable {
+		t.Fatal("open balance was served despite an invoice with no rate")
+	}
+	if out.OpenMinorBase != 0 {
+		t.Fatalf("open = %d, want 0 — a refused figure carries no number", out.OpenMinorBase)
+	}
+}
+
+// The oldest overdue age is a MAXIMUM over the overdue set, so it needs more
+// than one overdue invoice to be proven at all.
+func TestTheOldestOverdueAgeIsTheLongestOutstandingOne(t *testing.T) {
+	asOf := on(t, "2026-08-09")
+	out := OpenBalanceAt([]Invoice{
+		{Status: "open", OpenMinorBase: 100000, DueOn: ptr(on(t, "2026-07-21"))},
+		{Status: "open", OpenMinorBase: 100000, DueOn: ptr(on(t, "2026-03-01"))},
+		{Status: "open", OpenMinorBase: 100000, DueOn: ptr(on(t, "2026-08-01"))},
+	}, asOf)
+
+	if out.OverdueCount != 3 {
+		t.Fatalf("overdue count = %d, want 3", out.OverdueCount)
+	}
+	if out.OldestOverdueDays != 161 {
+		t.Fatalf("oldest overdue = %d days, want 161 (the March invoice, not the July one)",
+			out.OldestOverdueDays)
+	}
+}
+
+// The half-away-from-zero rule has two directions, and a naive integer divide
+// rounds the negative one the wrong way.
+func TestAnEvenSampleOfEarlyPaymentsRoundsAwayFromZero(t *testing.T) {
+	asOf := on(t, "2026-08-09")
+	settle := func(daysLate int) Invoice {
+		due := on(t, "2026-06-01")
+		return Invoice{DueOn: ptr(due), FullyPaidAt: ptr(due.AddDate(0, 0, daysLate))}
+	}
+	out := TimelinessOver([]Invoice{
+		settle(-9), settle(-6), settle(-4), settle(-3), settle(-2), settle(-1),
+	}, asOf)
+
+	// Middle two are −4 and −3; their mean is −3.5, which rounds to −4.
+	if out.MedianDaysLate != -4 {
+		t.Fatalf("median = %d, want -4 (−3.5 rounds away from zero)", out.MedianDaysLate)
+	}
+}
+
+func TestAnEvenSampleTakesTheMeanOfTheTwoMiddleValues(t *testing.T) {
+	asOf := on(t, "2026-08-09")
+	settle := func(daysLate int) Invoice {
+		due := on(t, "2026-05-01")
+		return Invoice{DueOn: ptr(due), FullyPaidAt: ptr(due.AddDate(0, 0, daysLate))}
+	}
+	out := TimelinessOver([]Invoice{
+		settle(0), settle(2), settle(3), settle(4), settle(10), settle(20),
+	}, asOf)
+
+	// Middle two are 3 and 4; rounded half away from zero that is 4.
+	if out.MedianDaysLate != 4 {
+		t.Fatalf("median = %d, want 4", out.MedianDaysLate)
+	}
+}


### PR DESCRIPTION
FIN-FORM-1..5 from `finance-ingestion.md`, as pure functions over mirrored invoices — the arithmetic behind "does this customer actually pay us, and on time?". Built on the schema from #689.

Pure so the rules can be proven without a database. What is at stake is not SQL but honesty: which rows may enter a figure, what a figure means when too few qualify, and when the answer is *not enough to say* rather than a number.

## The rules that are easy to get wrong

- **A credit note is subtracted exactly once** — excluded from the positive term, reaching the total only through the credited amount of the invoice it reduces. Counted in both it subtracts twice; in neither it disappears.
- **One missing conversion rate refuses the whole figure** (FIN-AC-6), for net invoiced *and* the open balance. A partial sum wearing the label of a total understates a debt.
- **Below five settled invoices there is no timeliness figure** — the floor that stops one late payment becoming a reputation.
- **Median, not mean** — one disputed-then-settled invoice at 180 days would drag a mean into a false story about a customer who otherwise pays on time.

## What Codex caught before push

- **Civil-date arithmetic.** Day counts used elapsed hours. An invoice settled 09:00 against a 17:00 due date read as *early*; a daylight-saving transition inside the span shifted every answer by one. Now calendar-date subtraction.
- **The open balance made no missing-rate refusal** while net invoiced did — the more dangerous of the two to get wrong, since it understates what is owed.

## Upstream

FIN-FORM-5's worked example says "4 of 5 on time" for the sample `−2, 0, 3, 8, 12`, where its own pseudocode `count(days_late ≤ 0) ÷ count(sample)` gives 2 of 5. The pseudocode is implemented; the contradiction is raised upstream rather than worked around here (contract-first, P3).

Tests use the chapter's own worked examples, so a disagreement between code and spec fails where a reader can see both. Reverting the credit-note exclusion or the sample floor turns their tests red.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements FIN-FORM-1..5 as pure functions in `backend/internal/modules/finance` to compute net invoiced, open balance, and timeliness. This makes payment-behaviour figures precise, explainable, and database‑independent.

- **New Features**
  - Pure functions: `NetInvoicedOver`, `OpenBalanceAt`, `DaysLate`, `TimelinessOver`; figures report their window and timeliness reports sample size.
  - Credit notes subtracted exactly once; drafts/voids excluded; disputed invoices excluded from timeliness but included in open balance.
  - Timeliness uses a 180‑day window, requires 5+ settled invoices, and uses median days late; on‑time is daysLate ≤ 0 from the same sample.

- **Bug Fixes**
  - Day counts use calendar-date subtraction to avoid time‑of‑day and DST shifts.
  - Open balance now refuses the figure when any invoice lacks a conversion rate (FIN-AC-6), matching net invoiced.

<sup>Written for commit 7b18063bf5adbc61f3f05b20ffc55a72abf852b9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/731?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

