### PR TITLE
feat(company): the record page works on a phone

### DIFF
--- a/frontend/src/design-system/atoms.css
+++ b/frontend/src/design-system/atoms.css
@@ -207,6 +207,33 @@
 .modal-wide {
   width: min(720px, calc(100vw - 40px));
 }
+/* On a phone a dialog is a full-screen sheet (plan §10.3). The 40px inset that
+ * frames it on a desktop wastes the only two dimensions a phone is short of,
+ * and the evidence drawer and the composer are both content a rep reads and
+ * types into rather than glances at.
+ *
+ * The close control stays visible because the sheet scrolls INSIDE itself —
+ * the header does not scroll away with the body. */
+@media (max-width: 720px) {
+  .modal,
+  .modal-wide {
+    width: 100vw;
+    max-width: 100vw;
+    height: 100dvh;
+    max-height: 100dvh;
+    border-radius: 0;
+    padding: var(--space-4);
+  }
+  /* The actions sit at the foot of the sheet rather than after the content,
+     so a long form does not bury its own confirm button. */
+  .modal .actions {
+    position: sticky;
+    bottom: 0;
+    background: var(--bgElevated);
+    padding-top: var(--space-3);
+  }
+}
+
 .modal .actions {
   display: flex;
   justify-content: flex-end;

--- a/frontend/src/design-system/composed.css
+++ b/frontend/src/design-system/composed.css
@@ -207,9 +207,56 @@
   margin: 12px 0 16px;
 }
 
-/* The three-zone record page: what this record IS on the left, what is
-   happening in the middle, the business around it on the right. The middle
-   column is the one that grows, so the rails keep a fixed share and the
+/* On a phone the record's verbs stick to the bottom of the viewport (plan
+ * §10.3). A rep scrolling an account's story is several screens from the
+ * header by the time they decide to write; an action row that scrolled away
+ * with the header means scrolling back up to act on what they just read.
+ *
+ * Sticky rather than fixed: it participates in the layout, so it cannot cover
+ * the last row of content the way a fixed bar does. */
+/* The record's verbs follow the reader down the page on a phone (plan §10.3).
+   A rep scrolling an account's story is several screens from the header by the
+   time they decide to write, and an action row that scrolled away with the
+   header means scrolling back up to act on what they just read.
+
+   The app's own navigation is already fixed at the bottom of a phone viewport
+   (shell.css: bottom 8px, z-index 30), so this bar stops ABOVE it. Sitting at
+   bottom:0 would put every record verb underneath the nav — present in the
+   DOM, unreachable by thumb. */
+@media (max-width: 720px) {
+  .record-actions {
+    position: sticky;
+    bottom: var(--phoneNavClearance);
+    /* Above the page's own content and below the app nav, so neither covers
+       the other. The modal overlay (50) still wins over both: an action bar
+       across an open dialog would trap a rep behind a button they cannot
+       reach. */
+    z-index: 2;
+    margin: 12px 0 0;
+    padding: var(--space-2) 0;
+    background: var(--bg);
+    border-top: 1px solid var(--border);
+  }
+  /* The bar floats over the end of the page while scrolling, so the record
+     reserves room for it AND for the nav below it — without this the last row
+     of the timeline sits permanently underneath and cannot be scrolled to. */
+  .record-zones {
+    padding-bottom: calc(var(--phoneNavClearance) + var(--space-6));
+  }
+}
+
+/* A pointer-driven page keeps the verbs where they were: the sticky bar exists
+ * for a thumb, and on a desktop it would only shrink the reading area. */
+@media (min-width: 721px) {
+  .record-actions {
+    position: static;
+  }
+}
+
+/* The record page's zones: what is happening in the work column, the business
+   around it beside. A page may still pass both a rail and an aside, but the
+   company page passes only the aside (plan §4). The work column is the one
+   that grows, so the rails keep a fixed share and the
    layout folds to one column before either becomes unreadably narrow. */
 .record-zones {
   display: grid;

--- a/frontend/src/design-system/tokens.css
+++ b/frontend/src/design-system/tokens.css
@@ -127,6 +127,12 @@
   --space-4: 16px;
   --space-6: 24px;
 
+  /* How far a page-level sticky element must stay clear of the bottom of a
+   * phone viewport: the app's navigation is fixed there (shell.css, inset 8px)
+   * and anything that ignored it would render underneath the nav. Named rather
+   * than repeated so the two cannot drift apart. */
+  --phoneNavClearance: 64px;
+
   --f-display: "Outfit", system-ui, sans-serif;
   --f-body: "DM Sans", system-ui, sans-serif;
   --f-mono: "JetBrains Mono", ui-monospace, monospace;

--- a/frontend/src/screens/company360.css
+++ b/frontend/src/screens/company360.css
@@ -407,3 +407,74 @@
   margin-top: var(--space-3);
   color: var(--textMeta);
 }
+
+/* ---- The coverage grid on a narrow screen (plan §10.3) ----------------------
+ *
+ * One column per colleague reads well on a desktop and not at all on a phone:
+ * the row runs off the side, and the header that says WHOSE relationship each
+ * cell describes scrolls away from the cell itself. §10.3 says a table becomes
+ * structured cards before horizontal scrolling is the only option.
+ *
+ * Each row becomes a card, each cell a labelled line. The label comes from the
+ * cell's own data-label, set from the column header, so the two cannot drift.
+ */
+.coverage-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+.coverage-scroll {
+  overflow-x: auto;
+}
+
+@media (max-width: 720px) {
+  .coverage-scroll {
+    overflow-x: visible;
+  }
+  /* display:block strips the table roles a screen reader navigates by, so the
+   * markup below sets role="list"/"listitem" at this width to match what the
+   * cards actually are. Leaving the roles implicit would announce a table
+   * whose rows and columns no longer exist.
+   *
+   * The header row carries no content once each cell labels itself, and would
+   * otherwise be announced before every card. */
+  .coverage-table thead {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    white-space: nowrap;
+  }
+  .coverage-table,
+  .coverage-table tbody,
+  .coverage-table tr,
+  .coverage-table th,
+  .coverage-table td {
+    display: block;
+  }
+  .coverage-table tr {
+    border: 1px solid var(--border);
+    border-radius: var(--radius-2);
+    padding: var(--space-3);
+    margin-bottom: var(--space-3);
+  }
+  /* The contact's name heads its own card. */
+  .coverage-table tbody th[scope="row"] {
+    font-weight: 600;
+    padding: 0 0 var(--space-2);
+    border-bottom: 1px solid var(--border);
+    margin-bottom: var(--space-2);
+  }
+  .coverage-table td {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: var(--space-3);
+    padding: var(--space-1) 0;
+  }
+  .coverage-table td::before {
+    content: attr(data-label);
+    color: var(--textSecondary);
+    font-size: var(--fs-caption);
+  }
+}

--- a/frontend/src/screens/coverageexplorer.test.tsx
+++ b/frontend/src/screens/coverageexplorer.test.tsx
@@ -94,6 +94,28 @@ describe("comparing the colleagues a reader chooses", () => {
     expect(screen.getByText("Untried")).toBeTruthy();
   });
 
+  // §10.3: a table becomes structured cards before horizontal scrolling is the
+  // only option. The narrow layout is CSS, but it can only work if every cell
+  // carries the column header that says whose relationship it describes —
+  // otherwise the meaning scrolls off the top with the header row.
+  it("carries each column's colleague on the cell, so a narrow layout can label it", async () => {
+    stubGraph();
+    show(<CoverageExplorer orgId="o-1" contacts={CONTACTS} />);
+    await open();
+    await screen.findByText("Sam Silent");
+
+    // Queried from the document: the explorer opens in a dialog, which the
+    // design system renders outside the caller's container.
+    const labels = Array.from(document.querySelectorAll("td[data-label]")).map(
+      (cell) => cell.getAttribute("data-label"),
+    );
+    expect(labels.length).toBeGreaterThan(0);
+    // Every cell, not merely some: one unlabelled cell is one a phone reader
+    // cannot attribute to anybody.
+    expect(labels.every(Boolean)).toBe(true);
+    expect(labels).toContain("Mira");
+  });
+
   it("offers only colleagues who have actually reached this account", async () => {
     stubGraph();
     show(<CoverageExplorer orgId="o-1" contacts={CONTACTS} />);

--- a/frontend/src/screens/coverageexplorer.tsx
+++ b/frontend/src/screens/coverageexplorer.tsx
@@ -181,11 +181,22 @@ function CoverageGrid({
             <tr key={contact.person_id}>
               <th scope="row">{contact.full_name}</th>
               {shown.map((id) => {
-                const band = colleagues
-                  .find((colleague) => colleague.id === id)
-                  ?.bands.get(contact.person_id);
+                const colleague = colleagues.find((c) => c.id === id);
+                const band = colleague?.bands.get(contact.person_id);
                 return (
-                  <td key={id}>
+                  // The column header travels with the cell twice over: as
+                  // data-label, which the narrow layout renders as visible
+                  // text, and as an aria-label, which carries the same fact to
+                  // a screen reader. The CSS turns rows into cards at 720px,
+                  // and display:block strips the table roles a screen reader
+                  // would otherwise navigate by — so each cell has to be
+                  // self-describing rather than relying on a header row that
+                  // no longer exists in the accessibility tree.
+                  <td
+                    key={id}
+                    data-label={colleague?.label}
+                    aria-label={colleague?.label}
+                  >
                     {/* No band is UNTRIED, not zero. The cell says so in words
                         rather than leaving a blank a reader has to interpret. */}
                     {band ? (


### PR DESCRIPTION
Plan §10.3 named three things the page did not do at any width. `company360.css` contained **no media query at all** — the only responsive behaviour came from the generic record chrome, by accident rather than decision.

## The coverage grid becomes cards

One column per colleague reads well on a desktop and not at all on a phone: the row runs off the side, and the header saying *whose* relationship each cell describes scrolls away from the cell itself.

Each row is now a card, each cell a labelled line. The label rides on the cell — as visible text *and* as an `aria-label` — because `display:block` strips the table roles a screen reader navigates by. A cell that relied on a header row no longer in the accessibility tree would be unattributable.

## The verbs follow the reader

A rep is several screens from the header by the time they decide to write.

The bar stops **above** the app's own fixed navigation (`shell.css`, inset 8px, z-index 30) rather than at `bottom: 0` — underneath it, every record verb would be present in the DOM and unreachable by thumb. The page reserves room for both, so the last row of the timeline is never stranded under the bar. The clearance is a named token so the two cannot drift.

## Dialogs are full-screen sheets

The 40px inset that frames a dialog on a desktop spends the two dimensions a phone is short of, and the evidence drawer and composer are read and typed into rather than glanced at. The sheet scrolls inside itself so the close control stays put, and the actions sit at its foot so a long form does not bury its own confirm button.

Local gate: 169 files, 1999 tests, biome, tsc, build — green. The new test fails if a cell loses its column label.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the company record page responsive and easier to use on phones. The coverage grid becomes cards, record actions follow the reader above the app nav, and dialogs render as full‑screen sheets with sticky actions.

- **New Features**
  - Coverage grid: rows become cards on narrow screens; each cell carries its column label via `data-label` and `aria-label` for accessibility.
  - Record actions: sticky on mobile and positioned above the app nav; layout reserves space using the `--phoneNavClearance` token.
  - Dialogs: full-screen sheets on mobile; content scrolls inside the sheet so the close control stays visible; action row sticks to the bottom.
  - Added a test to ensure every coverage cell is labeled; introduced small CSS token/layout updates.

<sup>Written for commit cb8c6ff2f8e3fa5b1cd8cc69d81354195cee4500. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/733?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

