### PR TITLE
fix(company): a deal with an expected close date no longer 500s the page

### DIFF
--- a/backend/internal/compose/integration/org360/org360_integration_test.go
+++ b/backend/internal/compose/integration/org360/org360_integration_test.go
@@ -35,6 +35,7 @@ import (
 	org360svc "github.com/gradionhq/margince/backend/internal/compose/org360"
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/modules/approvals"
+	"github.com/gradionhq/margince/backend/internal/modules/deals"
 	"github.com/gradionhq/margince/backend/internal/modules/people"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
@@ -618,3 +619,58 @@ var org360NoActivityPerms = principal.Permissions{
 	},
 	RowScope: principal.RowScopeTeam,
 }
+
+// The state strip's pipeline figures, read from a real deal through the real
+// endpoint (FIN plan §4.2 / the KPI row).
+//
+// This exists because the unit test over the fold could not catch what broke:
+// the SQL read scans expected_close_date, and Postgres sends a bare DATE that
+// pgx will not decode into time.Time. Every 360 request 500'd the moment any
+// deal on the account carried a close date — invisible to a test that hands
+// the fold rows it built itself, and immediately visible on real data.
+func TestOrg360_StateStripPricesOpenDealsAndNamesTheirCloseDate(t *testing.T) {
+	e := integration.Setup(t)
+	pipeline, stage, _ := integration.DealFixture(t, e)
+	orgID := e.SeedOrg(t, "Priced Account", nil)
+	closeOn := time.Now().UTC().AddDate(0, 2, 0)
+
+	// Through the real writer, with the two fields the read has to survive: an
+	// amount in the workspace's own currency and an expected close date.
+	if _, err := e.Deals.CreateDeal(e.Admin(), deals.CreateDealInput{
+		Name: "Priced deal", PipelineID: pipeline, StageID: stage,
+		OrganizationID: ptrTo(ids.From[ids.OrganizationKind](orgID)),
+		AmountMinor:    ptrTo(int64(250000)), Currency: ptrTo("EUR"),
+		ExpectedClose: &closeOn, Source: "manual",
+	}); err != nil {
+		t.Fatalf("creating the deal: %v", err)
+	}
+
+	view, err := org360Service(e).Assemble(e.Admin(), ids.From[ids.OrganizationKind](orgID))
+	if err != nil {
+		t.Fatalf("assembling the 360: %v", err)
+	}
+
+	strip := view.StateStrip
+	if strip == nil || strip.Commercial == nil {
+		t.Fatal("no commercial reading on an account with an open deal")
+	}
+	if strip.Commercial.OpenCount != 1 {
+		t.Fatalf("open count = %d, want 1", strip.Commercial.OpenCount)
+	}
+	// An open deal in the base currency carries NO frozen FX rate — the rate
+	// freezes on close — so a figure read from amount_minor_base alone would
+	// be absent here. This is the case the page actually shows.
+	if strip.Commercial.PricedCount != 1 {
+		t.Fatalf("priced count = %d, want 1 — an open deal in the base currency needs no rate",
+			strip.Commercial.PricedCount)
+	}
+	if strip.Commercial.OpenPipelineMinorBase == nil ||
+		*strip.Commercial.OpenPipelineMinorBase != 250000 {
+		t.Fatalf("open pipeline = %v, want 250000", strip.Commercial.OpenPipelineMinorBase)
+	}
+	if strip.Commercial.NextCloseOn == nil {
+		t.Fatal("no expected close date, though the deal names one")
+	}
+}
+
+func ptrTo[T any](v T) *T { return &v }

--- a/backend/internal/compose/org360/deals.go
+++ b/backend/internal/compose/org360/deals.go
@@ -49,7 +49,12 @@ func dealsSection(ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID, now 
 	}
 	rows, err := tx.Query(ctx, fmt.Sprintf(`
 		SELECT d.id, d.name, d.status, d.stage_id, s.name, d.amount_minor, d.currency,
-		       d.expected_close_date, d.created_at, d.last_activity_at, d.wait_until
+		       -- Read as text, then parsed below. pgx decodes a bare DATE into
+		       -- its own type and refuses the contract's Date wrapper, so the
+		       -- scan fails at RUNTIME on any deal that names a close date —
+		       -- and it 500s the whole company page, not just this card.
+		       to_char(d.expected_close_date, 'YYYY-MM-DD'),
+		       d.created_at, d.last_activity_at, d.wait_until
 		FROM deal d
 		LEFT JOIN stage s ON s.id = d.stage_id AND s.workspace_id = d.workspace_id
 		%s
@@ -67,9 +72,17 @@ func dealsSection(ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID, now 
 		var currency *string
 		var createdAt time.Time
 		var lastActivityAt, waitUntil *time.Time
+		var closeOn *string
 		if err := row.Scan(&id, &d.Name, &status, &stageIDPtr, &d.StageName, &amountMinor, &currency,
-			&d.ExpectedCloseDate, &createdAt, &lastActivityAt, &waitUntil); err != nil {
+			&closeOn, &createdAt, &lastActivityAt, &waitUntil); err != nil {
 			return d, err
+		}
+		if closeOn != nil {
+			parsed, err := time.Parse(time.DateOnly, *closeOn)
+			if err != nil {
+				return d, fmt.Errorf("reading the deal's expected close date: %w", err)
+			}
+			d.ExpectedCloseDate = &openapi_types.Date{Time: parsed}
 		}
 		d.DealId = openapi_types.UUID(id)
 		d.Status = crmcontracts.Organization360DealStatus(status)

--- a/backend/internal/compose/org360/suggestionreads.go
+++ b/backend/internal/compose/org360/suggestionreads.go
@@ -235,8 +235,14 @@ func openPipeline(
 		SELECT d.id, d.name, d.status, d.created_at, d.last_activity_at, d.wait_until,
 		       (SELECT count(*) FROM deal_stage_history h
 		         WHERE h.deal_id = d.id AND h.from_stage_id IS DISTINCT FROM h.to_stage_id),
-		       d.amount_minor, d.amount_minor_base, d.expected_close_date,
-		       d.currency, d.fx_rate_date,
+		       d.amount_minor, d.amount_minor_base,
+		       -- Cast both DATE columns to timestamps: pgx decodes a bare date
+		       -- (OID 1082) into its own Date type, not into time.Time, and the
+		       -- scan below fails at runtime rather than at compile time. Only
+		       -- a read against real rows finds that, which is why it is spelled
+		       -- here rather than left to the driver.
+		       d.expected_close_date::timestamptz,
+		       d.currency, d.fx_rate_date::timestamptz,
 		       (SELECT base_currency FROM workspace WHERE id = d.workspace_id)
 		FROM deal d
 		%s


### PR DESCRIPTION
**Every company page with a priced deal on it returned 500.** Postgres sends a bare `DATE`; pgx will not decode that into the contract's `Date` wrapper. The scan failed at runtime, took the whole `/360` read with it, and the page rendered *"Some of this page could not be loaded"* — no KPI row, no deals card, no dossier.

Found by seeding four realistic deals into the dev database and opening the page.

## Why no test caught it

`expected_close_date` is optional, and **no test in the suite had ever created a deal that set it**. Every fixture left it unset, so the failing branch was never executed. The deals card has carried this defect since it was written; my pipeline read in #730 reproduced it independently.

## The fix

Both reads take the date as text and parse it, rather than relying on the driver to bridge two date types.

## The test

Creates a deal through the real writer with the two fields that break the read — an amount and a close date — then asserts the state strip prices it and names the date. It fails against the old scan with the identical error the browser showed.

Local gate: backend clean, craft clean, org360 integration green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes 500 errors on company 360 pages when a deal has an expected close date by decoding DATE fields explicitly instead of relying on `pgx`. Restores the KPI row, deals card, and dossier.

- **Bug Fixes**
  - Read `expected_close_date` as text in the org360 deals query and parse into the contract `Date`.
  - Cast `expected_close_date` and `fx_rate_date` to `timestamptz` in the pipeline read to scan into `time.Time`.
  - Added an integration test that creates a priced deal with a close date and verifies the state strip shows the price and next close date.

<sup>Written for commit 5a984db87936805ef627d65a0bee9398fc10ebcc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/734?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

