### PR TITLE
feat(design-system): the drawer, the meter, the sparkline and the chip

### DIFF
--- a/frontend/src/design-system/README.md
+++ b/frontend/src/design-system/README.md
@@ -39,12 +39,13 @@ arrive through props, translated by the caller with `t()`.
 | `SegmentedControl` | A small closed set of options, all visible at once | `atoms.tsx` | ✅ |
 | `RecordPicker` | Search → candidates → pick, for choosing an existing record | `recordpicker.tsx` | ✅ |
 | `PassportSelect` / `ScopeChips` | Which agent passport, and the scopes it carries | `passportselect.tsx` | — |
-| `Modal` | The one dialog: portalled, Escape-closing, Tab kept inside | `atoms.tsx` | ✅ |
+| `Modal` | The one dialog: portalled, Escape-closing, Tab kept inside. `placement="right"` is the drawer form — full height on the right edge, the record behind still legible; on a phone both are the same full-screen sheet | `atoms.tsx` | ✅ |
 | `ConfirmModal` | A dialog that asks before something irreversible | `confirmmodal.tsx` | ✅ |
 | `OverflowMenu` | The verbs a record offers but a reader rarely wants | `atoms.tsx` | ✅ |
 | `Disclosure` | A section the reader opens when they want it | `atoms.tsx` | ✅ |
 | `Card` / `EmptyState` / `SectionHeader` / `Skeleton` / `Kbd` | Page furniture: surface, nothing-here, heading row, loading placeholder, key cap | `atoms.tsx` | ✅ |
 | `StatCard` / `AttainmentRing` | One reading with the basis it was drawn from; the server's attainment band as an arc | `atoms.tsx` | ✅ |
+| `Meter` / `Sparkline` / `Chip` | A proportion as a bar (pass `value` and `max`, never a percentage), a short series as a bare polyline, and one attribute of a record as an icon pill — a `Chip` is a fact, a `Badge` is a status | `readings.tsx` | ✅ |
 | `DataTable` | A simple column/row table with optional row navigation | `atoms.tsx` | ✅ |
 | `EvidenceMark` | The ONE §4 provenance affordance: a dotted underline on a value a person did not type, opening to where it came from | `evidencemark.tsx` | ✅ |
 | `AutonomyDot` | The 🟢/🟡 autonomy semantics as a token component — never an emoji glyph | `trust.tsx` | ✅ |

--- a/frontend/src/design-system/atoms.css
+++ b/frontend/src/design-system/atoms.css
@@ -207,6 +207,22 @@
 .modal-wide {
   width: min(720px, calc(100vw - 40px));
 }
+/* The right-anchored drawer: the composer and the evidence receipt. Full
+   height against the right edge so the record behind stays legible as
+   context. The width is a share of the viewport with both ends pinned —
+   below 320px a form field stops being usable, above 460px the drawer starts
+   covering the page it is meant to sit beside. */
+.overlay-right {
+  place-items: stretch end;
+}
+.modal-drawer {
+  width: clamp(320px, 24vw, 460px);
+  height: 100dvh;
+  max-height: 100dvh;
+  border-radius: 0;
+  box-shadow: var(--shadow-pop);
+  padding: var(--space-5);
+}
 /* On a phone a dialog is a full-screen sheet (plan §10.3). The 40px inset that
  * frames it on a desktop wastes the only two dimensions a phone is short of,
  * and the evidence drawer and the composer are both content a rep reads and
@@ -216,7 +232,8 @@
  * the header does not scroll away with the body. */
 @media (max-width: 720px) {
   .modal,
-  .modal-wide {
+  .modal-wide,
+  .modal-drawer {
     width: 100vw;
     max-width: 100vw;
     height: 100dvh;

--- a/frontend/src/design-system/atoms.tsx
+++ b/frontend/src/design-system/atoms.tsx
@@ -412,6 +412,7 @@ export function Modal({
   onClose,
   labelledBy,
   size = "default",
+  placement = "center",
   children,
 }: Readonly<{
   open: boolean;
@@ -420,6 +421,11 @@ export function Modal({
   // "wide" roomier variant for content-dense dialogs (code/YAML previews);
   // "default" keeps the compact form width every confirm/create modal uses.
   size?: "default" | "wide";
+  // "right" anchors the dialog to the right edge, full height — the drawer
+  // form the composer and the evidence receipt use, where the record behind
+  // stays visible as context rather than being covered by a centred box.
+  // `size` does not apply to it: a drawer's width comes from the viewport.
+  placement?: "center" | "right";
   children: ReactNode;
 }>) {
   const dialog = useRef<HTMLDivElement | null>(null);
@@ -469,7 +475,7 @@ export function Modal({
     // biome-ignore lint/a11y/noStaticElementInteractions: backdrop dismiss is a convention; Esc is the keyboard path
     // biome-ignore lint/a11y/useKeyWithClickEvents: Esc handles the keyboard path above
     <div
-      className="overlay"
+      className={placement === "right" ? "overlay overlay-right" : "overlay"}
       onClick={(event) => {
         if (event.target === event.currentTarget) {
           onClose();
@@ -481,7 +487,7 @@ export function Modal({
         role="dialog"
         aria-modal="true"
         aria-labelledby={labelledBy}
-        className={size === "wide" ? "modal modal-wide" : "modal"}
+        className={modalClass(size, placement)}
         ref={dialog}
         // Focusable so a dialog whose body is pure text still receives focus
         // when it opens, rather than leaving it on the page behind.
@@ -492,6 +498,15 @@ export function Modal({
     </div>,
     document.body,
   );
+}
+
+// A right-anchored dialog draws its width from the viewport, so the `size`
+// variants — which exist to widen a centred box — do not apply to it.
+function modalClass(size: "default" | "wide", placement: "center" | "right") {
+  if (placement === "right") {
+    return "modal modal-drawer";
+  }
+  return size === "wide" ? "modal modal-wide" : "modal";
 }
 
 // Keep Tab inside the dialog. `aria-modal` tells a screen reader the rest of

--- a/frontend/src/design-system/composed.css
+++ b/frontend/src/design-system/composed.css
@@ -359,23 +359,6 @@
   border: 1px solid var(--accentMed);
 }
 
-/* Strength meter bar — shared by StrengthCard (screens/strength.tsx) and
- * onboarding (screens/onboarding.tsx); onboarding.css no longer defines it. */
-.meterbar {
-  height: 8px;
-  background: var(--bgCard);
-  border-radius: var(--r-full);
-  overflow: hidden;
-  margin: 10px 0 8px;
-}
-.meterbar span {
-  display: block;
-  height: 100%;
-  background: linear-gradient(90deg, var(--accent), var(--away));
-  border-radius: var(--r-full);
-  transition: width 0.5s cubic-bezier(0.2, 0.8, 0.2, 1);
-}
-
 .firmo {
   display: flex;
   gap: 24px;

--- a/frontend/src/design-system/modal.test.tsx
+++ b/frontend/src/design-system/modal.test.tsx
@@ -89,3 +89,47 @@ describe("a dialog holds the keyboard", () => {
     expect(document.activeElement).toBe(opener);
   });
 });
+
+// A right-anchored dialog is the same dialog: same portal, same Esc, same
+// trap. Only where it sits changes.
+describe("a drawer is a dialog anchored to the right edge", () => {
+  it("keeps the dialog role and the Escape close", async () => {
+    function DrawerHarness() {
+      const [open, setOpen] = useState(true);
+      return (
+        <Modal
+          open={open}
+          onClose={() => setOpen(false)}
+          labelledBy="d"
+          placement="right"
+        >
+          <h2 id="d">Write email</h2>
+        </Modal>
+      );
+    }
+    render(<DrawerHarness />);
+    const drawer = screen.getByRole("dialog", { name: "Write email" });
+    expect(drawer.classList.contains("modal-drawer")).toBe(true);
+    await userEvent.keyboard("{Escape}");
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  // The width of a drawer comes from the viewport, so the centred-box size
+  // variants must not also apply — two width rules would fight.
+  it("ignores the centred-box size variant", () => {
+    render(
+      <Modal
+        open
+        onClose={() => {}}
+        labelledBy="d"
+        placement="right"
+        size="wide"
+      >
+        <h2 id="d">Evidence</h2>
+      </Modal>,
+    );
+    const dialog = screen.getByRole("dialog", { name: "Evidence" });
+    expect(dialog.classList.contains("modal-drawer")).toBe(true);
+    expect(dialog.classList.contains("modal-wide")).toBe(false);
+  });
+});

--- a/frontend/src/design-system/readings.css
+++ b/frontend/src/design-system/readings.css
@@ -1,0 +1,73 @@
+/* Meter — a proportion as a bar. Shared by StrengthCard
+ * (screens/strength.tsx), onboarding (screens/onboarding.tsx) and the
+ * company page's completeness readings. */
+.meterbar {
+  height: 8px;
+  background: var(--bgCard);
+  border-radius: var(--r-full);
+  overflow: hidden;
+  margin: 10px 0 8px;
+}
+.meterbar span {
+  display: block;
+  height: 100%;
+  background: linear-gradient(90deg, var(--accent), var(--away));
+  border-radius: var(--r-full);
+  transition: width 0.5s cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+/* A reading whose low end is the bad one carries its own colour, so the bar
+ * agrees with the band badge the caller draws beside it. Flat, not a
+ * gradient: the second colour of a gradient reads as a second meaning. */
+.meterbar-warn span {
+  background: var(--warn);
+}
+.meterbar-danger span {
+  background: var(--danger);
+}
+
+/* Sparkline — the shape of a short series, no axes and no grid. `none` on the
+ * fill keeps the polyline a line; `preserveAspectRatio: none` lets it stretch
+ * to whatever width the card gives it while the stroke stays 2px, because
+ * vector-effect keeps the stroke out of the scaling. */
+.sparkline {
+  display: block;
+  width: 100%;
+  height: 32px;
+}
+.sparkline polyline {
+  fill: none;
+  stroke: var(--accent);
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  vector-effect: non-scaling-stroke;
+}
+
+/* Chip — one attribute of a record with the icon naming its kind. */
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border: 1px solid var(--borderSubtle);
+  border-radius: var(--r-full);
+  background: var(--bgElevated);
+  color: var(--text);
+  font-size: 13px;
+  line-height: 1.2;
+  white-space: nowrap;
+}
+.chip svg {
+  color: var(--textMeta);
+  flex: none;
+}
+.chip-link {
+  text-decoration: none;
+}
+.chip-link:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+.chip-link:hover svg {
+  color: var(--accent);
+}

--- a/frontend/src/design-system/readings.stories.tsx
+++ b/frontend/src/design-system/readings.stories.tsx
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Building2, Globe, Link2, MapPin, Users } from "lucide-react";
+import { LocaleProvider } from "../i18n";
+import { Chip, Meter, Sparkline } from "./readings";
+
+// The three reading primitives: a proportion, a series, an attribute.
+const meta: Meta = {
+  title: "Design System/Readings",
+  parameters: { layout: "padded" },
+  decorators: [
+    (Story) => (
+      <LocaleProvider initial="en">
+        <div style={{ maxWidth: 480, display: "grid", gap: "var(--space-5)" }}>
+          <Story />
+        </div>
+      </LocaleProvider>
+    ),
+  ],
+};
+export default meta;
+
+type Story = StoryObj;
+
+// Value and max are the two halves of one fact, so the bar and the label
+// beside it are drawn from the same pair and cannot disagree.
+export const Meters: Story = {
+  render: () => (
+    <>
+      <div>
+        <p className="t-caption">7 of 9 inputs present</p>
+        <Meter value={7} max={9} label="Dossier completeness" />
+      </div>
+      <div>
+        <p className="t-caption">Payment behaviour — low is the bad end</p>
+        <Meter value={3} max={10} label="Payment behaviour" tone="warn" />
+      </div>
+      <div>
+        <p className="t-caption">Nothing measured yet</p>
+        <Meter value={0} max={0} label="Coverage" />
+      </div>
+    </>
+  ),
+};
+
+export const Sparklines: Story = {
+  render: () => (
+    <>
+      <Sparkline
+        points={[12, 9, 14, 11, 18, 7, 12]}
+        label="Days paid after due, last six months"
+      />
+      <Sparkline points={[8, 8, 8, 8]} label="Unchanged over four months" />
+    </>
+  ),
+};
+
+export const Chips: Story = {
+  render: () => (
+    <div style={{ display: "flex", flexWrap: "wrap", gap: "var(--space-2)" }}>
+      <Chip icon={Globe} href="https://glazedfrog.example">
+        glazedfrog.example
+      </Chip>
+      <Chip icon={Link2} href="https://www.linkedin.com/company/example">
+        LinkedIn
+      </Chip>
+      <Chip icon={MapPin}>London, UK</Chip>
+      <Chip icon={Building2}>Building products</Chip>
+      <Chip icon={Users}>51–200 employees</Chip>
+    </div>
+  ),
+};

--- a/frontend/src/design-system/readings.test.tsx
+++ b/frontend/src/design-system/readings.test.tsx
@@ -1,0 +1,97 @@
+/** @vitest-environment jsdom */
+import { cleanup, render, screen } from "@testing-library/react";
+import { Globe, MapPin } from "lucide-react";
+import { afterEach, describe, expect, it } from "vitest";
+import { Chip, Meter, Sparkline } from "./readings";
+
+afterEach(cleanup);
+
+function fillWidth(container: HTMLElement) {
+  return container.querySelector<HTMLElement>(".meterbar span")?.style.width;
+}
+
+describe("Meter draws a proportion a reader can also hear", () => {
+  it("carries the raw pair, not a percentage, on the ARIA node", () => {
+    render(<Meter value={7} max={9} label="Dossier completeness" />);
+    const meter = screen.getByRole("meter", { name: "Dossier completeness" });
+    expect(meter.getAttribute("aria-valuenow")).toBe("7");
+    expect(meter.getAttribute("aria-valuemax")).toBe("9");
+  });
+
+  it("fills the bar to the value's share of the max", () => {
+    const { container } = render(<Meter value={1} max={4} label="Coverage" />);
+    expect(fillWidth(container)).toBe("25%");
+  });
+
+  // A zero max is "nothing has been measured", not a division. It must read
+  // as an empty bar rather than a NaN width the browser silently drops.
+  it("draws an empty bar when nothing has been measured", () => {
+    const { container } = render(<Meter value={0} max={0} label="Coverage" />);
+    expect(fillWidth(container)).toBe("0%");
+  });
+
+  // A value beyond its max is a data fault, not a reason to draw a bar wider
+  // than its track.
+  it("clamps a value that overruns its max", () => {
+    const { container } = render(<Meter value={12} max={9} label="Facts" />);
+    expect(fillWidth(container)).toBe("100%");
+  });
+
+  it("colours a low-is-bad reading with its own tone", () => {
+    const { container } = render(
+      <Meter value={2} max={10} label="Payment" tone="danger" />,
+    );
+    expect(
+      container
+        .querySelector(".meterbar")
+        ?.classList.contains("meterbar-danger"),
+    ).toBe(true);
+  });
+});
+
+describe("Sparkline is a glyph, not a chart", () => {
+  it("draws one point per reading, scaled into the box", () => {
+    render(<Sparkline points={[0, 10]} label="Days paid after due" />);
+    const line = screen
+      .getByRole("img", { name: "Days paid after due" })
+      .querySelector("polyline");
+    // Low sits at the bottom inset, high at the top one; x spans the width.
+    expect(line?.getAttribute("points")).toBe("0.0,29.0 120.0,3.0");
+  });
+
+  // A flat series has no range to scale into. It reads as unchanged rather
+  // than dividing by zero.
+  it("draws a flat series down the middle", () => {
+    render(<Sparkline points={[8, 8, 8]} label="Unchanged" />);
+    const line = screen
+      .getByRole("img", { name: "Unchanged" })
+      .querySelector("polyline");
+    expect(line?.getAttribute("points")).toBe("0.0,29.0 60.0,29.0 120.0,29.0");
+  });
+
+  // One point is a dot, and a dot reads as a flat trend — a claim a single
+  // reading does not support.
+  it("draws nothing from fewer than two points", () => {
+    const { container } = render(<Sparkline points={[4]} label="One" />);
+    expect(container.querySelector("svg")).toBeNull();
+  });
+});
+
+describe("Chip is a fact, and a link when the fact has somewhere to go", () => {
+  it("renders a plain chip with no destination", () => {
+    render(<Chip icon={MapPin}>London, UK</Chip>);
+    expect(screen.queryByRole("link")).toBeNull();
+    expect(screen.getByText("London, UK")).toBeTruthy();
+  });
+
+  it("opens an off-origin destination in a new tab without a referrer", () => {
+    render(
+      <Chip icon={Globe} href="https://glazedfrog.example">
+        glazedfrog.example
+      </Chip>,
+    );
+    const link = screen.getByRole("link", { name: "glazedfrog.example" });
+    expect(link.getAttribute("target")).toBe("_blank");
+    expect(link.getAttribute("rel")).toBe("noreferrer");
+  });
+});

--- a/frontend/src/design-system/readings.tsx
+++ b/frontend/src/design-system/readings.tsx
@@ -1,0 +1,131 @@
+import type { LucideIcon } from "lucide-react";
+import type { ReactNode } from "react";
+import "./readings.css";
+
+// Three ways to draw a reading that is not a number in a box: a proportion as
+// a bar, a series as a line, and a labelled attribute as a pill. Copy always
+// arrives through props — these never hard-code a word.
+
+// A proportion, drawn as a bar. `value` and `max` are the two halves of the
+// same fact (7 of 9 inputs present), so the caller passes both rather than a
+// pre-computed percentage: the bar and the label a caller writes beside it
+// then cannot disagree, and a zero max reads as an empty bar instead of NaN.
+export function Meter({
+  value,
+  max,
+  label,
+  tone,
+}: Readonly<{
+  value: number;
+  max: number;
+  label: string;
+  // The bar carries the accent gradient by default. "warn"/"danger" are for a
+  // reading whose LOW end is the bad one — coverage, payment behaviour.
+  tone?: "warn" | "danger";
+}>) {
+  const filled = max > 0 ? Math.min(100, Math.max(0, (value / max) * 100)) : 0;
+  // Not a native <meter>: its children are fallback content that a supporting
+  // engine never renders, so the token-drawn fill below would simply vanish,
+  // and the bar every engine draws in its place takes none of our colours —
+  // the same reason `<select>` is banned outright. The role and the value
+  // triple carry the reading to assistive tech instead.
+  return (
+    // biome-ignore lint/a11y/useSemanticElements: <meter> discards the token-drawn fill and draws its own untokenised bar
+    <div
+      className={tone ? `meterbar meterbar-${tone}` : "meterbar"}
+      role="meter"
+      aria-label={label}
+      aria-valuenow={value}
+      aria-valuemin={0}
+      aria-valuemax={max}
+    >
+      <span style={{ width: `${filled}%` }} />
+    </div>
+  );
+}
+
+// A short series as a bare polyline: the shape of a trend, with no axes, no
+// grid and no tooltip. It is a glyph, not a chart — a reader who needs the
+// figures reads the table beside it, which is why the whole thing is
+// aria-hidden behind the caller's own text label.
+//
+// Fewer than two points draws nothing: a single point is a dot the reader
+// would read as a flat trend, which is a claim the data does not make.
+export function Sparkline({
+  points,
+  label,
+}: Readonly<{ points: readonly number[]; label: string }>) {
+  if (points.length < 2) {
+    return null;
+  }
+  const low = Math.min(...points);
+  const high = Math.max(...points);
+  // A flat series has no range to scale into; drawing it down the middle says
+  // "unchanged", which is exactly what it is.
+  const span = high - low || 1;
+  const step = SPARK_WIDTH / (points.length - 1);
+  const path = points
+    .map((point, index) => {
+      const x = (index * step).toFixed(1);
+      const y = (
+        SPARK_HEIGHT -
+        ((point - low) / span) * (SPARK_HEIGHT - SPARK_INSET * 2) -
+        SPARK_INSET
+      ).toFixed(1);
+      return `${x},${y}`;
+    })
+    .join(" ");
+  return (
+    <svg
+      className="sparkline"
+      viewBox={`0 0 ${SPARK_WIDTH} ${SPARK_HEIGHT}`}
+      preserveAspectRatio="none"
+      role="img"
+      aria-label={label}
+    >
+      <polyline points={path} />
+    </svg>
+  );
+}
+
+const SPARK_WIDTH = 120;
+const SPARK_HEIGHT = 32;
+// Keeps the stroke off the top and bottom edges, where a 2px line drawn at
+// the extreme would be clipped in half by the viewBox.
+const SPARK_INSET = 3;
+
+// An attribute of a record with the icon that names its kind: the website, the
+// LinkedIn page, the location, the industry, the headcount. Distinct from
+// `Badge`, which is a status in a closed tone vocabulary — a Chip is a fact,
+// and it is a link when the fact has somewhere to go.
+export function Chip({
+  icon: Icon,
+  children,
+  href,
+}: Readonly<{
+  icon: LucideIcon;
+  children: ReactNode;
+  // An external destination. Present → the chip is an anchor and opens in a
+  // new tab with `noreferrer`, since these point off our origin.
+  href?: string;
+}>) {
+  const body = (
+    <>
+      <Icon size={14} aria-hidden="true" />
+      <span>{children}</span>
+    </>
+  );
+  if (href) {
+    return (
+      <a
+        className="chip chip-link"
+        href={href}
+        target="_blank"
+        rel="noreferrer"
+      >
+        {body}
+      </a>
+    );
+  }
+  return <span className="chip">{body}</span>;
+}

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -3468,6 +3468,7 @@ export const de = {
   "aiusage.sub":
     "Ihre eigene Rechnung sichtbar — nach Aufgabe und Stufe, in Tokens.",
   "aiusage.budget": "{spent} von {budget} Tokens · {pct}%",
+  "aiusage.budgetMeter": "Verbrauchtes Monats-Tokenbudget",
   "aiusage.band.normal": "normal",
   "aiusage.band.degraded": "Sparmodus",
   "aiusage.band.queued": "Budget erreicht — Hintergrund-KI wartet",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -3454,6 +3454,7 @@ export const en = {
   "aiusage.sub":
     "Your own bill, made visible — per task and tier, token-denominated.",
   "aiusage.budget": "{spent} of {budget} tokens · {pct}%",
+  "aiusage.budgetMeter": "Monthly token budget used",
   "aiusage.band.normal": "normal",
   "aiusage.band.degraded": "economy mode",
   "aiusage.band.queued": "budget reached — background AI queued",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -3462,6 +3462,7 @@ export const vi = {
   "aiusage.sub":
     "Hoá đơn của chính bạn, hiện rõ — theo từng tác vụ và bậc, tính bằng token.",
   "aiusage.budget": "{spent} trên {budget} token · {pct}%",
+  "aiusage.budgetMeter": "Ngân sách token hằng tháng đã dùng",
   "aiusage.band.normal": "bình thường",
   "aiusage.band.degraded": "chế độ tiết kiệm",
   "aiusage.band.queued": "đã chạm hạn mức — AI chạy nền bị xếp hàng",

--- a/frontend/src/screens/aiusage.tsx
+++ b/frontend/src/screens/aiusage.tsx
@@ -8,6 +8,7 @@ import {
   EmptyState,
   SectionHeader,
 } from "../design-system/atoms";
+import { Meter } from "../design-system/readings";
 import { formatMoney, formatNumber } from "../format/format";
 import { useLocale, useT } from "../i18n";
 import { QueryGate, throwProblem } from "./common";
@@ -124,9 +125,11 @@ export function AiUsageCard() {
                 }}
               >
                 <div style={{ flex: 1 }}>
-                  <div className="meterbar">
-                    <span style={{ width: `${Math.min(100, pct)}%` }} />
-                  </div>
+                  <Meter
+                    value={data.budget.spent_tokens}
+                    max={data.budget.monthly_tokens}
+                    label={t("aiusage.budgetMeter")}
+                  />
                   <p className="sub">
                     {t("aiusage.budget", {
                       spent: formatNumber(data.budget.spent_tokens, locale),

--- a/frontend/src/screens/aiusage.tsx
+++ b/frontend/src/screens/aiusage.tsx
@@ -125,9 +125,12 @@ export function AiUsageCard() {
                 }}
               >
                 <div style={{ flex: 1 }}>
+                  {/* pct, not the raw token pair: a workspace with no monthly
+                      budget configured reads as fully spent (pct is 100 above),
+                      and the bar must say what the caption beside it says. */}
                   <Meter
-                    value={data.budget.spent_tokens}
-                    max={data.budget.monthly_tokens}
+                    value={pct}
+                    max={100}
                     label={t("aiusage.budgetMeter")}
                   />
                   <p className="sub">

--- a/frontend/src/screens/onboarding.css
+++ b/frontend/src/screens/onboarding.css
@@ -633,8 +633,7 @@
   text-transform: uppercase;
   letter-spacing: 0.02em;
 }
-/* .meterbar lives in design-system/composed.css — shared with StrengthCard
- * (screens/strength.tsx), which has no onboarding.css import of its own. */
+/* .meterbar is the Meter primitive's sheet, design-system/readings.css. */
 .regmix {
   display: flex;
   gap: 14px;

--- a/frontend/src/screens/strength.tsx
+++ b/frontend/src/screens/strength.tsx
@@ -10,6 +10,7 @@ import {
   SectionHeader,
   Skeleton,
 } from "../design-system/atoms";
+import { Meter } from "../design-system/readings";
 import { formatDateTime } from "../format/format";
 import { useLocale, useT } from "../i18n";
 import {
@@ -163,9 +164,11 @@ function StrengthBody({
                 <span>{t(`strength.factor.${row.key}`)}</span>
                 <span className="t-mono">{pct}%</span>
               </div>
-              <div className="meterbar">
-                <span style={{ width: `${pct}%` }} />
-              </div>
+              <Meter
+                value={pct}
+                max={100}
+                label={t(`strength.factor.${row.key}`)}
+              />
             </div>
           );
         })}


### PR DESCRIPTION
The company page V2 mockups need four things the design system does not
have. Rather than hand-roll them in the page, they land here as primitives
with a story and a spec, which is the rule this directory keeps.

- `Modal` gains `placement="right"`: the same dialog — same portal, same
  Esc, same focus trap — anchored full-height to the right edge, so the
  record behind it stays legible as context. Width is a share of the
  viewport with both ends pinned: below 320px a form field stops being
  usable, above 460px the drawer covers the page it should sit beside.
  On a phone it is the same full-screen sheet every dialog already is.
  `size` does not apply — a drawer's width comes from the viewport, and
  two width rules would fight.

- `Meter` promotes the un-exported `.meterbar` to a primitive. It takes
  `value` and `max` rather than a percentage, so the bar and the label a
  caller writes beside it are drawn from the same pair and cannot
  disagree. A zero max reads as an empty bar, not a NaN width. Its two
  existing callers — StrengthCard and the AI usage budget — now go
  through it.

- `Sparkline` is a bare polyline: the shape of a short series, no axes and
  no grid. Fewer than two points draws nothing, because a single dot reads
  as a flat trend and that is a claim one reading does not support.

- `Chip` is one attribute of a record with the icon naming its kind — the
  header's website / LinkedIn / location / industry / headcount row. It is
  distinct from `Badge`: a Chip is a fact, a Badge is a status.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a right-anchored drawer to `Modal` and introduces `Meter`, `Sparkline`, and `Chip` primitives for consistent readings. Replaces ad-hoc meters in Strength and AI Usage, and fixes the budget bar when no monthly tokens are set.

- New Features
  - `Modal` supports `placement="right"` for a full-height drawer with viewport-clamped width; same portal/Esc/focus-trap; `size` is ignored in this mode; tests added.
  - `Meter` renders a proportion from `value` and `max` with optional `tone="warn"|"danger"`, clamps overflow, and treats zero max as empty; used in Strength; AI Usage now passes `value=pct` and `max=100` to keep the bar aligned when budget is 0; stories/tests included.
  - `Sparkline` draws a minimal polyline for short series, hides for fewer than two points, and handles flat series; stories/tests included.
  - `Chip` shows a fact as an icon pill; optional `href` opens off-origin links in a new tab with `noreferrer`; stories/tests included.
  - README and styles updated; i18n adds `aiusage.budgetMeter`.

- Migration
  - Replace custom `.meterbar` with `import { Meter } from "../design-system/readings"` and use `<Meter value={x} max={y} label="..." />` (AI Usage uses `<Meter value={pct} max={100} ... />`).
  - Use the drawer via `<Modal placement="right" ...>`; do not use `size` with drawers.
  - Import `Meter`, `Sparkline`, and `Chip` from `design-system/readings`.

<sup>Written for commit 425fd6b8025e395ada08c5d75736fa4c58178fb3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/741?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added right-anchored drawer modals with responsive sizing, mobile full-screen behavior, and Escape-to-close support.
  - Added reusable meters, sparklines, and attribute chips for clearer data presentation.
  - Updated AI usage and strength screens with accessible proportion meters.
  - Added localized monthly budget meter labels in English, German, and Vietnamese.
- **Documentation**
  - Expanded design-system guidance for drawers, meters, sparklines, chips, and badges.
- **Refactor**
  - Consolidated existing progress displays onto the shared meter component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->