### PR TITLE
fix(people): a LinkedIn match suggestion reaches the inbox, and an unrelated edit no longer cancels it (#677, #679)

### DIFF
--- a/backend/internal/compose/approval_contexttarget_test.go
+++ b/backend/internal/compose/approval_contexttarget_test.go
@@ -11,9 +11,10 @@ import (
 )
 
 // A staging's version pin is what stops a confirmed action executing against a
-// row that changed underneath it. Declining the pin is a waiver, so it is held
-// to the same discipline as the confirm-first one: every entry says why, and
-// an entry naming a kind nothing stages is removed rather than left to rot.
+// row that changed underneath it. Declining the pin is a waiver, so both maps
+// that decline it are held to the same discipline as the confirm-first one:
+// every entry says why, an entry naming a kind nothing stages is removed rather
+// than left to rot, and no kind may claim both reasons at once.
 
 func TestEveryContextTargetKindIsExplained(t *testing.T) {
 	declared := approvals.ContextTargetKinds()
@@ -29,13 +30,54 @@ func TestEveryContextTargetKindIsExplained(t *testing.T) {
 }
 
 func TestEveryContextTargetKindIsAKindWeStage(t *testing.T) {
-	registered := map[string]bool{}
-	for _, kind := range approvalsServiceWithEffects(nil).EffectKinds() {
-		registered[kind] = true
-	}
+	registered := registeredEffectKinds()
 	for kind := range approvals.ContextTargetKinds() {
 		if !registered[kind] {
 			t.Errorf("contextTargetKinds[%s] names no registered effect kind — stale waiver, remove it", kind)
 		}
 	}
+}
+
+func TestEveryUnpinnedKindIsExplained(t *testing.T) {
+	declared := approvals.UnpinnedKinds()
+	if len(declared) == 0 {
+		t.Fatal("no unpinned kinds declared — if the waiver is unused, delete the mechanism")
+	}
+	for kind, why := range declared {
+		if len(strings.TrimSpace(why)) < 40 {
+			t.Errorf("unpinnedKinds[%s] has no real rationale — a staging that declines its version "+
+				"pin over the very row its effect writes must say what the pin would have protected", kind)
+		}
+	}
+}
+
+func TestEveryUnpinnedKindIsAKindWeStage(t *testing.T) {
+	registered := registeredEffectKinds()
+	for kind := range approvals.UnpinnedKinds() {
+		if !registered[kind] {
+			t.Errorf("unpinnedKinds[%s] names no registered effect kind — stale waiver, remove it", kind)
+		}
+	}
+}
+
+// The two waivers make opposite claims about the same target — one says it is
+// context the proposal is merely ABOUT, the other that it is the operand the
+// effect writes. A kind declared in both asserts both, and whichever a reader
+// believes, the other is a rationale that reads true and is not.
+func TestNoKindIsBothContextOnlyAndUnpinned(t *testing.T) {
+	for kind := range approvals.UnpinnedKinds() {
+		if approvals.TargetIsContextOnly(kind) {
+			t.Errorf("%s is declared in BOTH contextTargetKinds and unpinnedKinds — its target is either "+
+				"context the proposal is about or the row its effect writes, and the two rationales say "+
+				"opposite things about what a pin would have bound", kind)
+		}
+	}
+}
+
+func registeredEffectKinds() map[string]bool {
+	registered := map[string]bool{}
+	for _, kind := range approvalsServiceWithEffects(nil).EffectKinds() {
+		registered[kind] = true
+	}
+	return registered
 }

--- a/backend/internal/compose/captureverdictreview_integration_test.go
+++ b/backend/internal/compose/captureverdictreview_integration_test.go
@@ -66,6 +66,76 @@ func TestCounterpartyAcceptCreatesTheRecordsAndClosesTheDisposition(t *testing.T
 	}
 }
 
+// The proposal is FILED under the message that carried the unrecognized sender,
+// because that message is the evidence a human judges it on — but the effect
+// creates a person and an organization and closes the disposition, and never
+// writes the activity. So the ordinary inbox work done to the message while the
+// question waits (a relink, a participant correction, a subject fix) must not be
+// able to cancel the answer.
+//
+// It could, and silently: the decision commits before the effect runs, so the
+// human saw an approved proposal whose records were never created.
+func TestEditingTheCapturedMessageDoesNotCancelItsWaitingReview(t *testing.T) {
+	e := integration.Setup(t)
+	activityID := seedCapturedMail(t, e, "dana@editco.example", "about your services")
+	dispositionID := seedPendingDisposition(t, e, "dana@editco.example", "editco.example", activityID)
+	retireToUnsure(t, e, dispositionID)
+
+	svc := approvalsServiceWithEffects(e.Pool)
+	engine := NewCounterpartyVerdictEngine(e.Pool, &scriptedVerdictBrain{}, slog.Default())
+	if err := engine.StageReviewsWorkspace(principal.WithWorkspaceID(context.Background(), e.WS), 0); err != nil {
+		t.Fatalf("staging reviews: %v", err)
+	}
+	approvalID := stagedProposalID(t, e, dispositionID)
+
+	before := activityVersion(t, e, activityID)
+	editCapturedSubject(t, e, activityID, "about your services (corrected)")
+	if after := activityVersion(t, e, activityID); after == before {
+		t.Fatalf("the message's version did not move (still %d), so this test would pass whether "+
+			"or not the pin is declined", after)
+	}
+
+	decider := e.As(e.Rep1, nil, integration.AdminPerms)
+	if _, err := svc.Decide(decider, ids.From[ids.ApprovalKind](approvalID), true, nil); err != nil {
+		t.Fatalf("approving after the message was edited: %v — editing the evidence must not "+
+			"cancel the question it raised", err)
+	}
+	if n := countIn(t, e, `
+		SELECT count(*) FROM person p JOIN person_email pe ON pe.person_id = p.id
+		 WHERE pe.email = 'dana@editco.example'`); n != 1 {
+		t.Errorf("%d persons after accept, want 1 — the approval was released but its effect did "+
+			"not run", n)
+	}
+}
+
+// editCapturedSubject makes the one edit this lane's own screens make to a
+// captured message, through a plain UPDATE: the version moves by database
+// trigger, so the row bumps the way any writer would bump it.
+func editCapturedSubject(t *testing.T, e *integration.Env, activityID ids.UUID, subject string) {
+	t.Helper()
+	err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		_, err := tx.Exec(context.Background(),
+			`UPDATE activity SET subject = $2 WHERE id = $1`, activityID, subject)
+		return err
+	})
+	if err != nil {
+		t.Fatalf("editing the captured message: %v", err)
+	}
+}
+
+func activityVersion(t *testing.T, e *integration.Env, activityID ids.UUID) int64 {
+	t.Helper()
+	var v int64
+	err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		return tx.QueryRow(context.Background(),
+			`SELECT version FROM activity WHERE id = $1`, activityID).Scan(&v)
+	})
+	if err != nil {
+		t.Fatalf("reading the message's version: %v", err)
+	}
+	return v
+}
+
 // retireToUnsure puts a disposition in the state a terminal below-floor
 // judgement leaves it in, without spending two scripted model calls to get there.
 func retireToUnsure(t *testing.T, e *integration.Env, id ids.UUID) {

--- a/backend/internal/compose/linkedinmatchgen.go
+++ b/backend/internal/compose/linkedinmatchgen.go
@@ -25,9 +25,15 @@ package compose
 //
 // It lives in compose because the call crosses modules — the events are the
 // people module's own, but the seam that reacts to them is nobody's private
-// business. Recomputing is idempotent, so the at-least-once bus costs nothing:
-// a redelivered event re-runs a match that has already been made and changes
-// no row, because only UNMATCHED ghosts are ever considered.
+// business.
+//
+// Both halves are idempotent, so the at-least-once bus costs nothing — for two
+// different reasons, which is worth saying because only one of them is the old
+// one. A redelivered event re-runs a match that changes no row, because only
+// UNMATCHED ghosts are ever matched. The proposal that now follows it considers
+// SUGGESTED ones too, which is the point of proposing at all, and is idempotent
+// because staging takes the proposal's identity lock and joins the live offer
+// rather than minting a second copy of the same question.
 
 import (
 	"context"
@@ -158,6 +164,14 @@ func (g *LinkedInMatchGen) matchWorkspace(ctx context.Context, workspace ids.UUI
 			// The whole network was matched here, so the whole outstanding set
 			// is what this pass owes a proposal over — the same scope rule the
 			// per-person arm above follows in the narrow direction.
+			//
+			// This arm therefore pays the per-event cost the narrow one
+			// refuses: one staging attempt per outstanding suggestion, per
+			// owner, per organization event. It is accepted rather than
+			// overlooked. A new or renamed account is exactly what unblocks
+			// ghosts belonging to many different contacts at once, so there is
+			// no narrower read that would still be complete — unlike the
+			// person arm, where the arrival names its own scope.
 			staged, err := StageLinkedInMatches(ownerCtx, g.approvals, g.store)
 			if err != nil {
 				return err

--- a/backend/internal/compose/linkedinmatchgen.go
+++ b/backend/internal/compose/linkedinmatchgen.go
@@ -35,6 +35,7 @@ import (
 
 	"github.com/jackc/pgx/v5/pgxpool"
 
+	"github.com/gradionhq/margince/backend/internal/modules/approvals"
 	"github.com/gradionhq/margince/backend/internal/modules/people"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/events"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
@@ -51,7 +52,8 @@ const (
 	matchEntityOrganization = "organization"
 )
 
-// LinkedInMatchGen attaches LinkedIn ghosts as the CRM learns who exists.
+// LinkedInMatchGen attaches LinkedIn ghosts as the CRM learns who exists, and
+// asks a human about the ones a string comparison cannot settle.
 type LinkedInMatchGen struct {
 	store *people.Store
 	// pool and authority are what lets each pass run under the GHOST OWNER's
@@ -61,12 +63,20 @@ type LinkedInMatchGen struct {
 	// which already runs under its caller.
 	pool      *pgxpool.Pool
 	authority authz.Resolver
+	// approvals is built ONCE, here, rather than per event or per owner: the
+	// registration list is a dozen effects over a dozen stores and produces the
+	// same service every time, while this consumer runs on every contact write
+	// in the workspace.
+	approvals *approvals.Service
 	log       *slog.Logger
 }
 
 // NewLinkedInMatchGen builds the matcher consumer over the people store.
 func NewLinkedInMatchGen(pool *pgxpool.Pool, store *people.Store, authority authz.Resolver, log *slog.Logger) *LinkedInMatchGen {
-	return &LinkedInMatchGen{store: store, pool: pool, authority: authority, log: log}
+	return &LinkedInMatchGen{
+		store: store, pool: pool, authority: authority,
+		approvals: approvalsServiceWithEffects(pool), log: log,
+	}
 }
 
 // HandleEvent routes one envelope to a match. An event this consumer does not
@@ -117,10 +127,18 @@ func (g *LinkedInMatchGen) matchPerson(ctx context.Context, workspace, person id
 			if err != nil {
 				return err
 			}
-			if matched.Confirmed+matched.Suggested > 0 {
+			// Proposed in the SAME pass, over the same contact that was
+			// matched. A suggestion the matcher writes and nobody is asked
+			// about is a suggestion that does not exist: the ghost row carries
+			// only the outcome, and the pending question lives in the approval.
+			staged, err := StageLinkedInMatchesForPerson(ownerCtx, g.approvals, g.store, person)
+			if err != nil {
+				return err
+			}
+			if matched.Confirmed+matched.Suggested+staged > 0 {
 				g.log.InfoContext(ownerCtx, "linkedin match: a contact met their ghost",
 					"person", person.String(), "owner", owner.String(),
-					"confirmed", matched.Confirmed, "suggested", matched.Suggested)
+					"confirmed", matched.Confirmed, "suggested", matched.Suggested, "staged", staged)
 			}
 			return nil
 		})
@@ -137,10 +155,17 @@ func (g *LinkedInMatchGen) matchWorkspace(ctx context.Context, workspace ids.UUI
 			if err != nil {
 				return err
 			}
-			if matched.Confirmed+matched.Suggested > 0 {
+			// The whole network was matched here, so the whole outstanding set
+			// is what this pass owes a proposal over — the same scope rule the
+			// per-person arm above follows in the narrow direction.
+			staged, err := StageLinkedInMatches(ownerCtx, g.approvals, g.store)
+			if err != nil {
+				return err
+			}
+			if matched.Confirmed+matched.Suggested+staged > 0 {
 				g.log.InfoContext(ownerCtx, "linkedin match: an account unblocked ghosts",
 					"owner", owner.String(),
-					"confirmed", matched.Confirmed, "suggested", matched.Suggested)
+					"confirmed", matched.Confirmed, "suggested", matched.Suggested, "staged", staged)
 			}
 			return nil
 		})

--- a/backend/internal/compose/linkedinmatchproposal.go
+++ b/backend/internal/compose/linkedinmatchproposal.go
@@ -72,10 +72,13 @@ func withGhostOwnerAsSubject(ctx context.Context) (context.Context, error) {
 }
 
 // linkedInMatchStager is the seam people.Handlers calls after an import. It
-// builds its own approvals service so the transport does not have to hold one.
+// holds the approvals service so the transport does not have to, and builds it
+// ONCE: the registration list is a dozen effects over a dozen stores, and
+// rebuilding it per upload produces the same service every time.
 func linkedInMatchStager(pool *pgxpool.Pool) func(context.Context) error {
+	svc, store := approvalsServiceWithEffects(pool), people.NewStore(pool)
 	return func(ctx context.Context) error {
-		_, err := StageLinkedInMatches(ctx, pool, approvalsServiceWithEffects(pool), people.NewStore(pool))
+		_, err := StageLinkedInMatches(ctx, svc, store)
 		return err
 	}
 }
@@ -86,11 +89,33 @@ func linkedInMatchStager(pool *pgxpool.Pool) func(context.Context) error {
 // It runs under the ghost owner's own authority — the caller establishes that,
 // as every other pass over these rows does — so a contact outside their row
 // scope never becomes a proposal they can see.
-func StageLinkedInMatches(ctx context.Context, pool *pgxpool.Pool, svc *approvals.Service, store *people.Store) (int, error) {
+func StageLinkedInMatches(ctx context.Context, svc *approvals.Service, store *people.Store) (int, error) {
 	pending, err := store.PendingLinkedInMatches(ctx)
 	if err != nil {
 		return 0, err
 	}
+	return stagePendingLinkedInMatches(ctx, svc, pending)
+}
+
+// StageLinkedInMatchesForPerson is the same pass narrowed to the matches about
+// ONE contact.
+//
+// The rule both entry points keep is that a pass proposes over the SAME scope it
+// matched. Matching against a single arrival can only have raised questions
+// about that arrival, so this is the complete answer for that caller as well as
+// the bounded one: proposing the member's entire outstanding set instead would
+// run once per person event and only ever rejoin rows that already exist.
+func StageLinkedInMatchesForPerson(ctx context.Context, svc *approvals.Service, store *people.Store, person ids.UUID) (int, error) {
+	pending, err := store.PendingLinkedInMatchesForPerson(ctx, person)
+	if err != nil {
+		return 0, err
+	}
+	return stagePendingLinkedInMatches(ctx, svc, pending)
+}
+
+// stagePendingLinkedInMatches turns the candidates a match produced into
+// proposals — the one place both scopes pass through.
+func stagePendingLinkedInMatches(ctx context.Context, svc *approvals.Service, pending []people.PendingLinkedInMatch) (int, error) {
 	// Staged ON BEHALF OF the member whose network produced it, so the audit
 	// trail records whose export raised the question. It grants nothing and
 	// withholds nothing: who may decide is the inbox's ordinary rule — the
@@ -98,7 +123,7 @@ func StageLinkedInMatches(ctx context.Context, pool *pgxpool.Pool, svc *approval
 	// about. ADR-0078/A123 settles that deliberately: who-knows-whom is
 	// workspace-shared metadata, guarded by "you only see edges for a person
 	// you can see at all", which is exactly what that rule already applies.
-	ctx, err = withGhostOwnerAsSubject(ctx)
+	ctx, err := withGhostOwnerAsSubject(ctx)
 	if err != nil {
 		return 0, err
 	}

--- a/backend/internal/compose/linkedinmatchproposal_integration_test.go
+++ b/backend/internal/compose/linkedinmatchproposal_integration_test.go
@@ -198,6 +198,46 @@ func TestTheSweepStagesALinkedInSuggestionNobodyWasEverAskedAbout(t *testing.T) 
 	onlyPendingLinkedInMatch(t, e)
 }
 
+// Refusing a match leaves the ghost at `suggested` — the reject path writes no
+// row here, by design, because the refusal IS the approval — so the widened
+// enumeration reaches that owner on every sweep from then on. What must not
+// happen is the sweep asking again.
+//
+// The durable-refusal property is not new, but the widening is what makes it
+// load-bearing: before it, an owner with nothing left but refused suggestions
+// dropped out of the enumeration and was never given the chance to be re-asked.
+func TestTheSweepNeverReasksALinkedInMatchThatWasRefused(t *testing.T) {
+	e := integration.Setup(t)
+	ctx := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AdminPerms)
+	linkedInMatchFixture(ctx, t, e)
+	grantReadPeopleRole(t, e, e.Rep1, "all")
+
+	store := people.NewStore(e.Pool)
+	if _, err := store.MatchLinkedInConnections(ctx, e.Rep1); err != nil {
+		t.Fatalf("matching: %v", err)
+	}
+	svc := approvalsServiceWithEffects(e.Pool)
+	if _, err := StageLinkedInMatches(ctx, svc, store); err != nil {
+		t.Fatalf("staging: %v", err)
+	}
+	if _, err := svc.Decide(ctx, onlyPendingLinkedInMatch(t, e), false, nil); err != nil {
+		t.Fatalf("rejecting: %v", err)
+	}
+
+	// The owner is still enumerated — the refusal is not on the ghost row — so
+	// the sweep runs their whole pass again.
+	sweep := newLinkedInRematchWorker(e.Pool, store, identity.NewService(e.Pool),
+		slog.New(slog.DiscardHandler))
+	if _, err := sweep.sweepWorkspace(context.Background(), e.WS); err != nil {
+		t.Fatalf("sweeping after the refusal: %v", err)
+	}
+
+	if pending := pendingLinkedInMatchCount(t, e); pending != 0 {
+		t.Errorf("%d pending proposals after a refused match was swept, want 0 — the sweep is "+
+			"re-asking a question the member already answered", pending)
+	}
+}
+
 // A contact edit must not cancel a LinkedIn match waiting to be decided.
 //
 // The proposal's claim is "this imported connection is this contact", and no

--- a/backend/internal/compose/linkedinmatchproposal_integration_test.go
+++ b/backend/internal/compose/linkedinmatchproposal_integration_test.go
@@ -15,11 +15,13 @@ package compose
 
 import (
 	"context"
+	"log/slog"
 	"testing"
 
 	"github.com/jackc/pgx/v5"
 
 	"github.com/gradionhq/margince/backend/internal/compose/integration"
+	"github.com/gradionhq/margince/backend/internal/modules/identity"
 	"github.com/gradionhq/margince/backend/internal/modules/people"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
@@ -68,7 +70,7 @@ func TestApprovingAStagedLinkedInMatchLinksTheConnectionAndWritesTheURL(t *testi
 		t.Fatalf("matching: %v", err)
 	}
 	svc := approvalsServiceWithEffects(e.Pool)
-	staged, err := StageLinkedInMatches(ctx, e.Pool, svc, store)
+	staged, err := StageLinkedInMatches(ctx, svc, store)
 	if err != nil {
 		t.Fatalf("staging: %v", err)
 	}
@@ -119,7 +121,7 @@ func TestARefusedLinkedInMatchIsNeverProposedAgain(t *testing.T) {
 		t.Fatalf("matching: %v", err)
 	}
 	svc := approvalsServiceWithEffects(e.Pool)
-	if _, err := StageLinkedInMatches(ctx, e.Pool, svc, store); err != nil {
+	if _, err := StageLinkedInMatches(ctx, svc, store); err != nil {
 		t.Fatalf("staging: %v", err)
 	}
 	if _, err := svc.Decide(ctx, onlyPendingLinkedInMatch(t, e), false, nil); err != nil {
@@ -127,13 +129,137 @@ func TestARefusedLinkedInMatchIsNeverProposedAgain(t *testing.T) {
 	}
 
 	// The stager runs again, exactly as a re-import or the hourly sweep would.
-	staged, err := StageLinkedInMatches(ctx, e.Pool, svc, store)
+	staged, err := StageLinkedInMatches(ctx, svc, store)
 	if err != nil {
 		t.Fatalf("re-staging: %v", err)
 	}
 	if staged != 0 {
 		t.Errorf("re-staging proposed %d matches, want 0 — a refusal must survive the next import", staged)
 	}
+}
+
+// A suggestion the EVENT path produces has to reach the inbox in that same
+// pass. It used to be matched, logged and dropped: the ghost row carried
+// `suggested` and no approval existed, so the member was never asked and
+// nothing in the product could tell them a question was waiting.
+//
+// No sweep runs here, deliberately — that is the whole claim. An hourly job
+// that repairs the event path is a feature that works an hour late, and only
+// for the owners that enumeration happens to reach.
+func TestAPersonEventStagesTheLinkedInSuggestionItProduced(t *testing.T) {
+	e := integration.Setup(t)
+	ctx := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AdminPerms)
+	person := linkedInMatchFixture(ctx, t, e)
+	// The pass runs under the ghost OWNER's own resolved authority, so the
+	// owner needs a real grant — a member the resolver reports as holding
+	// nothing is skipped, and the test would prove nothing about this path.
+	grantReadPeopleRole(t, e, e.Rep1, "all")
+
+	matcher := NewLinkedInMatchGen(e.Pool, people.NewStore(e.Pool), identity.NewService(e.Pool),
+		slog.New(slog.DiscardHandler))
+	if err := matcher.HandleEvent(context.Background(),
+		envelopeFor(e.WS, "person.created", "person", person)); err != nil {
+		t.Fatalf("handling person.created: %v", err)
+	}
+
+	// Exactly one, and it is the folded-name match: onlyPendingLinkedInMatch
+	// fails loudly on any other count.
+	onlyPendingLinkedInMatch(t, e)
+}
+
+// The sweep's rescue duty. A ghost the matcher already moved to `suggested`
+// without staging is the residue the event path used to leave behind, and it
+// was invisible twice over: `suggested` is not `unmatched`, so an owner holding
+// nothing else dropped out of the sweep's enumeration entirely and no later
+// pass could reach them.
+func TestTheSweepStagesALinkedInSuggestionNobodyWasEverAskedAbout(t *testing.T) {
+	e := integration.Setup(t)
+	ctx := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AdminPerms)
+	linkedInMatchFixture(ctx, t, e)
+	grantReadPeopleRole(t, e, e.Rep1, "all")
+
+	// The residue, seeded through the real matcher rather than by hand: match
+	// and do NOT stage, which is exactly the state the old event path left.
+	store := people.NewStore(e.Pool)
+	if _, err := store.MatchLinkedInConnections(ctx, e.Rep1); err != nil {
+		t.Fatalf("matching: %v", err)
+	}
+	if pending := pendingLinkedInMatchCount(t, e); pending != 0 {
+		t.Fatalf("%d proposals before the sweep, want 0 — the fixture is not the unstaged "+
+			"residue this test is about", pending)
+	}
+
+	sweep := newLinkedInRematchWorker(e.Pool, store, identity.NewService(e.Pool),
+		slog.New(slog.DiscardHandler))
+	if _, err := sweep.sweepWorkspace(context.Background(), e.WS); err != nil {
+		t.Fatalf("sweeping: %v", err)
+	}
+
+	onlyPendingLinkedInMatch(t, e)
+}
+
+// A contact edit must not cancel a LinkedIn match waiting to be decided.
+//
+// The proposal's claim is "this imported connection is this contact", and no
+// field on the contact can make that false. Pinning the person's version bound
+// the approval to content nobody judged, so any edit between staging and
+// decision — a title correction, an owner change, a second match applying —
+// failed the redemption's re-check and the member's yes did nothing.
+func TestAContactEditDoesNotCancelAWaitingLinkedInMatch(t *testing.T) {
+	e := integration.Setup(t)
+	ctx := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AdminPerms)
+	person := linkedInMatchFixture(ctx, t, e)
+
+	store := people.NewStore(e.Pool)
+	if _, err := store.MatchLinkedInConnections(ctx, e.Rep1); err != nil {
+		t.Fatalf("matching: %v", err)
+	}
+	svc := approvalsServiceWithEffects(e.Pool)
+	if _, err := StageLinkedInMatches(ctx, svc, store); err != nil {
+		t.Fatalf("staging: %v", err)
+	}
+	id := onlyPendingLinkedInMatch(t, e)
+
+	// Through the real writer, so the row's version moves exactly the way any
+	// edit in the product moves it.
+	title := "Head of Procurement"
+	if _, err := store.UpdatePerson(ctx, ids.From[ids.PersonKind](person), people.UpdatePersonInput{
+		Title: &title, Source: "manual",
+	}); err != nil {
+		t.Fatalf("editing the contact: %v", err)
+	}
+
+	if _, err := svc.Decide(ctx, id, true, nil); err != nil {
+		t.Fatalf("approving after the edit: %v — a contact edit must not cancel a waiting match", err)
+	}
+
+	var status string
+	var matched *ids.UUID
+	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		return tx.QueryRow(context.Background(), `
+			SELECT match_status, matched_person_id FROM linkedin_connection
+			 WHERE normalized_name = 'andreas muller'`).Scan(&status, &matched)
+	}); err != nil {
+		t.Fatalf("reading the outcome: %v", err)
+	}
+	if status != "confirmed" || matched == nil || *matched != person {
+		t.Errorf("the connection is %q → %v after an approved match, want confirmed → %s — "+
+			"the approval was released but its effect did not run", status, matched, person)
+	}
+}
+
+// pendingLinkedInMatchCount counts the pending proposals of this kind, for the
+// assertions that are about there being none.
+func pendingLinkedInMatchCount(t *testing.T, e *integration.Env) int {
+	t.Helper()
+	var n int
+	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		return tx.QueryRow(context.Background(),
+			`SELECT count(*) FROM approval WHERE kind = 'linkedin_match' AND status = 'pending'`).Scan(&n)
+	}); err != nil {
+		t.Fatalf("counting the staged proposals: %v", err)
+	}
+	return n
 }
 
 // onlyPendingLinkedInMatch returns the single pending proposal of this kind,

--- a/backend/internal/compose/linkedinowner.go
+++ b/backend/internal/compose/linkedinowner.go
@@ -47,14 +47,19 @@ import (
 // undecided ghosts count, because a workspace whose queue is clear should cost
 // one query rather than one query per member.
 //
-// UNDECIDED is both statuses a pass can leave behind, not just `unmatched`. A
-// `suggested` ghost is a question the matcher has answered and no human has:
-// until somebody approves or rejects it, the pass that turns it into an inbox
-// proposal still owes it one. Enumerating only `unmatched` meant an owner whose
-// ghosts were ALL already suggested was never reached at all, so a suggestion
+// UNDECIDED means the MATCHER has not settled it — `unmatched` or `suggested`.
+// It deliberately does not mean "no human has settled it", and the difference
+// matters: the ghost row records only the matcher's outcome plus `confirmed`,
+// which the accept effect writes back. A REFUSAL is not written here at all —
+// it lives in the approval, which is where this design puts the pending state,
+// and StageUnlessDeclined is what consults it. So this enumeration also reaches
+// members whose every question has already been refused, and the staging pass it
+// feeds correctly proposes nothing for them.
+//
+// Enumerating `unmatched` alone was narrower than the work. An owner whose
+// ghosts had ALL been matched to `suggested` was never reached, so a suggestion
 // that missed its proposal had no later pass that could rescue it and stayed
-// invisible for the row's lifetime. `confirmed` and `rejected` are decided, and
-// are correctly absent.
+// invisible for the row's lifetime.
 func ghostOwners(ctx context.Context, pool *pgxpool.Pool) ([]ids.UUID, error) {
 	var out []ids.UUID
 	err := database.WithWorkspaceTx(ctx, pool, func(tx pgx.Tx) error {

--- a/backend/internal/compose/linkedinowner.go
+++ b/backend/internal/compose/linkedinowner.go
@@ -46,12 +46,21 @@ import (
 // records, and the roster is readable by any authenticated member. Only
 // undecided ghosts count, because a workspace whose queue is clear should cost
 // one query rather than one query per member.
+//
+// UNDECIDED is both statuses a pass can leave behind, not just `unmatched`. A
+// `suggested` ghost is a question the matcher has answered and no human has:
+// until somebody approves or rejects it, the pass that turns it into an inbox
+// proposal still owes it one. Enumerating only `unmatched` meant an owner whose
+// ghosts were ALL already suggested was never reached at all, so a suggestion
+// that missed its proposal had no later pass that could rescue it and stayed
+// invisible for the row's lifetime. `confirmed` and `rejected` are decided, and
+// are correctly absent.
 func ghostOwners(ctx context.Context, pool *pgxpool.Pool) ([]ids.UUID, error) {
 	var out []ids.UUID
 	err := database.WithWorkspaceTx(ctx, pool, func(tx pgx.Tx) error {
 		rows, err := tx.Query(ctx, `
 			SELECT DISTINCT owner_user_id FROM linkedin_connection
-			 WHERE match_status = 'unmatched' AND tombstoned_at IS NULL`)
+			 WHERE match_status IN ('unmatched', 'suggested') AND tombstoned_at IS NULL`)
 		if err != nil {
 			return fmt.Errorf("compose: listing the members with ghosts to match: %w", err)
 		}

--- a/backend/internal/compose/linkedinrematch.go
+++ b/backend/internal/compose/linkedinrematch.go
@@ -27,6 +27,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/riverqueue/river"
 
+	"github.com/gradionhq/margince/backend/internal/modules/approvals"
 	"github.com/gradionhq/margince/backend/internal/modules/people"
 	"github.com/gradionhq/margince/backend/internal/platform/jobs"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
@@ -48,11 +49,19 @@ type linkedInRematchWorker struct {
 	pool      *pgxpool.Pool
 	store     *people.Store
 	authority authz.Resolver
+	// approvals is built ONCE, with the worker, rather than inside the
+	// per-owner loop: it registers a dozen effects over a dozen stores and
+	// answers the same service every time, so rebuilding it per member per
+	// sweep pass was work with no result.
+	approvals *approvals.Service
 	log       *slog.Logger
 }
 
 func newLinkedInRematchWorker(pool *pgxpool.Pool, store *people.Store, authority authz.Resolver, log *slog.Logger) *linkedInRematchWorker {
-	return &linkedInRematchWorker{pool: pool, store: store, authority: authority, log: log}
+	return &linkedInRematchWorker{
+		pool: pool, store: store, authority: authority,
+		approvals: approvalsServiceWithEffects(pool), log: log,
+	}
 }
 
 // Work re-matches each workspace's unmatched ghosts, one workspace at a time so
@@ -117,10 +126,19 @@ func (w *linkedInRematchWorker) renormalizeWorkspace(ctx context.Context, ws ids
 	return nil
 }
 
-// systemContext binds the workspace and the maintenance principal both passes
-// run under, spelled once so they cannot diverge.
+// systemContext binds the workspace, the trace and the maintenance principal
+// both passes run under, spelled once so they cannot diverge.
+//
+// The correlation id is bound HERE rather than at the job entry point because
+// this is the only context either pass runs under, and the write shape refuses
+// an unbound trace: the staging the sweep performs commits an audit row and an
+// outbox event, so a pass built without one fails on its first proposal and
+// takes the whole workspace's re-match down with it — permanently, since the
+// retry rebuilds the same context. A pass and a re-key are two operations and
+// carry a trace each.
 func (w *linkedInRematchWorker) systemContext(ctx context.Context, ws ids.UUID) context.Context {
 	ctx = principal.WithWorkspaceID(ctx, ws)
+	ctx = principal.WithCorrelationID(ctx, ids.NewV7())
 	return principal.WithActor(ctx, principal.Principal{
 		Type: principal.PrincipalSystem, ID: "system:linkedin_rematch",
 		Permissions: principal.Permissions{RowScope: principal.RowScopeAll},
@@ -145,7 +163,12 @@ func (w *linkedInRematchWorker) sweepWorkspace(ctx context.Context, ws ids.UUID)
 			// A suggestion is only useful once somebody can see it, and the
 			// member who owns it is not necessarily importing today: the sweep
 			// stages under the same authority it matched under.
-			_, err = StageLinkedInMatches(ownerCtx, w.pool, approvalsServiceWithEffects(w.pool), w.store)
+			//
+			// Over the WHOLE outstanding set, which is also this pass's
+			// rescue duty: an owner reached here because ghostOwners now
+			// enumerates `suggested` too may have suggestions that never
+			// became proposals, and this is the pass that repairs them.
+			_, err = StageLinkedInMatches(ownerCtx, w.approvals, w.store)
 			return err
 		})
 	return total, err

--- a/backend/internal/compose/linkedinrematch.go
+++ b/backend/internal/compose/linkedinrematch.go
@@ -17,8 +17,17 @@ package compose
 // in it by name, and the upload-time pass matched 13. The rest were people and
 // employers the CRM learned about minutes later.
 //
-// The pass only ever looks at UNMATCHED ghosts, so a human's confirmation or
-// rejection is never revisited and a caught-up workspace costs one query.
+// The MATCH only ever looks at unmatched ghosts, so a decision a human has
+// already made is never revisited. The pass around it is wider, deliberately:
+// it also PROPOSES, and a suggestion that never became a proposal is invisible
+// to everyone until some pass re-reaches it. So the enumeration takes undecided
+// ghosts of either status and runs the staging pass for each owner it finds.
+//
+// That costs one re-read plus one idempotent staging attempt per outstanding
+// suggestion, and it is paid even when every one of them has already been
+// refused — a refusal is recorded on the approval, not on the ghost row, so
+// nothing here can tell those apart. A caught-up workspace still costs one
+// query; a workspace holding refusals does not.
 
 import (
 	"context"
@@ -166,8 +175,14 @@ func (w *linkedInRematchWorker) sweepWorkspace(ctx context.Context, ws ids.UUID)
 			//
 			// Over the WHOLE outstanding set, which is also this pass's
 			// rescue duty: an owner reached here because ghostOwners now
-			// enumerates `suggested` too may have suggestions that never
-			// became proposals, and this is the pass that repairs them.
+			// enumerates `suggested` too may hold suggestions that never
+			// became proposals, and this is the pass that proposes them.
+			//
+			// It rescues what is still proposable. A suggestion whose contact
+			// has since been archived — or merged away, which archives the
+			// source and re-points nothing — is read by neither this pass nor
+			// the matcher, so it stays where it is; the ghost row has no
+			// terminal state for a contact that left the live set.
 			_, err = StageLinkedInMatches(ownerCtx, w.approvals, w.store)
 			return err
 		})

--- a/backend/internal/compose/reconcile.go
+++ b/backend/internal/compose/reconcile.go
@@ -34,6 +34,14 @@ import (
 // follow-up is a new activity, independent of the deal's current field
 // values, so a concurrent deal edit must not invalidate the human's yes
 // (unlike a close-date correction, which overwrites a deal field).
+//
+// Leaving TargetVersion unset is NOT what makes that true, which is worth
+// saying because it used to be. The pin is taken server-side now, at the one
+// place every stager passes through, so a stager cannot decline it by
+// omission — and for a while this comment described an intention the code had
+// silently stopped honouring. What declines it is the kind's entry in
+// approvals' contextTargetKinds, and this paragraph is accurate exactly as
+// long as that entry exists.
 type followUpStager struct {
 	svc *approvals.Service
 }

--- a/backend/internal/compose/reconcile_integration_test.go
+++ b/backend/internal/compose/reconcile_integration_test.go
@@ -296,6 +296,48 @@ func TestFollowUpConfirmCreatesTheTaskExactlyOnce(t *testing.T) {
 	}
 }
 
+// An overnight proposal waits until somebody works their morning inbox, and
+// that is exactly the window a rep moves the stage, edits the amount or
+// corrects the close date in. None of those can make "this deal was touched and
+// has no next step" false, and the effect creates an ACTIVITY — it reads no
+// field of the deal at all.
+//
+// The stager has always said it carries no pin. That stopped being true when
+// the pin moved server-side, and nothing failed until a human approved after an
+// edit: the decision commits first, so the refusal arrives as an approved
+// proposal whose task was never created.
+func TestADealEditDoesNotCancelAWaitingFollowUp(t *testing.T) {
+	e := setupReconcile(t)
+	deal := e.SeedDeal(t, "Edited while the question waited", e.pipeline, e.open, &e.Rep1)
+	e.seedInteraction(t, deal, "call", "Discovery", 1)
+	if err := e.reconcile(); err != nil {
+		t.Fatal(err)
+	}
+	approvalID, _ := e.followUpApproval(t, deal)
+
+	human := e.As(e.Rep1, []ids.UUID{e.Team1}, reconcilePerms)
+	before := e.dealVersion(t, deal)
+	// Through the real writer, so the row's version moves the way any edit in
+	// the product moves it.
+	renamed := "Renamed while it waited"
+	if _, err := deals.NewStore(e.Pool).UpdateDeal(human, ids.From[ids.DealKind](deal),
+		deals.UpdateDealInput{Name: &renamed}); err != nil {
+		t.Fatalf("editing the deal: %v", err)
+	}
+	if after := e.dealVersion(t, deal); after == before {
+		t.Fatalf("the deal's version did not move (still %d), so this test would pass whether or "+
+			"not the pin is declined", after)
+	}
+
+	if _, err := e.svc.Decide(human, approvalID, true, nil); err != nil {
+		t.Fatalf("approve after the edit: %v — a deal edit must not cancel a waiting follow-up", err)
+	}
+	if count, _, _, _ := e.dealTasks(t, deal); count != 1 {
+		t.Errorf("follow-up tasks created = %d, want 1 — the approval was released but its effect "+
+			"did not run", count)
+	}
+}
+
 func TestFollowUpRejectWritesNothing(t *testing.T) {
 	e := setupReconcile(t)
 	deal := e.SeedDeal(t, "Reject me", e.pipeline, e.open, &e.Rep1)

--- a/backend/internal/modules/approvals/authority.go
+++ b/backend/internal/modules/approvals/authority.go
@@ -38,6 +38,14 @@ type grantRequirement struct {
 	Action principal.Action
 }
 
+// kindLinkedInMatch is the staged kind for "this imported connection is this
+// contact". This module makes three separate statements about it — the grants
+// deciding it needs, that only the member it was staged for may decide it, and
+// that it declines the version pin — and a typo across them would leave the
+// kind half-governed with nothing saying so. Compose owns the registration
+// spelling; the compose-side waiver fitness tests bind the two together.
+const kindLinkedInMatch = "linkedin_match"
+
 // decisionGrants maps each stageable kind onto the RBAC its effect needs given
 // the KIND ALONE; approving requires every one of them. A kind whose grant also
 // depends on what the staging points at carries that half in
@@ -122,7 +130,7 @@ var decisionGrants = map[string][]grantRequirement{
 	// Approving a LinkedIn match links an imported connection to a contact and
 	// writes that contact's LinkedIn address — a person write, so deciding it
 	// needs the grant the write itself takes.
-	"linkedin_match": {{tablePerson, principal.ActionUpdate}},
+	kindLinkedInMatch: {{tablePerson, principal.ActionUpdate}},
 	// Accepting a capture_counterparty proposal (ADR-0072/A118: a first-time
 	// sender the verdict engine could not judge) creates the person and, unless
 	// the domain is free-mail, the organization behind them — so deciding it
@@ -250,7 +258,7 @@ const (
 // A step-up is the other: "may this agent keep reading" is a question about ONE
 // connection, and the only person who can answer it is the human whose authority
 // that connection borrows.
-var selfOnlyKinds = map[string]bool{"linkedin_match": true, KindQuotaRelease: true}
+var selfOnlyKinds = map[string]bool{kindLinkedInMatch: true, KindQuotaRelease: true}
 
 // decidable is the ONE visibility-and-authority predicate for the inbox
 // and the decision: true when p holds every grant approving a would

--- a/backend/internal/modules/approvals/redeem.go
+++ b/backend/internal/modules/approvals/redeem.go
@@ -182,6 +182,28 @@ var contextTargetKinds = map[string]string{
 		"the lead and every accept failed for the row's lifetime.",
 }
 
+// unpinnedKinds are the staging kinds whose target IS the row their effect
+// writes — so contextTargetKinds does not describe them — but for which the pin
+// protects nothing, and therefore only ever cancels the approval when the row
+// moves for an unrelated reason. The value is the reason why.
+//
+// Two waivers rather than one because they make different claims, and a reader
+// has to be able to tell which is being made. contextTargetKinds says the target
+// is context the proposal is merely ABOUT; this one says the target is the
+// operand and the pin still binds nothing. Filing a kind under the wrong one
+// leaves a label that reads true and is not, which is worse than the pin it
+// removes. TestEveryUnpinnedKindIsExplained holds each entry to its rationale,
+// and TestNoKindIsBothContextOnlyAndUnpinned holds the two maps apart.
+var unpinnedKinds = map[string]string{
+	kindLinkedInMatch: "The proposal's claim is \"this imported connection is this contact\", and no " +
+		"field edit on the contact can make that claim false — the founder decision is " +
+		"explicitly that editing a contact must not cancel a LinkedIn match waiting to be " +
+		"decided. The write it authorizes is an additive, idempotent person_social insert " +
+		"rather than a patch of any field a human could have seen, so there is no content " +
+		"state for a pin to protect. Pinning also broke the second of two matches onto one " +
+		"contact, because applying the first bumps that person's version.",
+}
+
 // TargetIsContextOnly reports whether this kind's target names context rather
 // than the row the effect operates on.
 func TargetIsContextOnly(kind string) bool {
@@ -189,11 +211,28 @@ func TargetIsContextOnly(kind string) bool {
 	return ok
 }
 
+// TargetVersionUnpinned reports whether this kind operates on its target but
+// declines the version pin, per unpinnedKinds.
+func TargetVersionUnpinned(kind string) bool {
+	_, ok := unpinnedKinds[kind]
+	return ok
+}
+
 // ContextTargetKinds reports the declared kinds and their rationales, so a
 // fitness test can hold each one to an explanation.
 func ContextTargetKinds() map[string]string {
-	out := make(map[string]string, len(contextTargetKinds))
-	for kind, why := range contextTargetKinds {
+	return copyRationales(contextTargetKinds)
+}
+
+// UnpinnedKinds reports the declared kinds and their rationales, for the same
+// reason ContextTargetKinds does.
+func UnpinnedKinds() map[string]string {
+	return copyRationales(unpinnedKinds)
+}
+
+func copyRationales(declared map[string]string) map[string]string {
+	out := make(map[string]string, len(declared))
+	for kind, why := range declared {
 		out[kind] = why
 	}
 	return out

--- a/backend/internal/modules/approvals/redeem.go
+++ b/backend/internal/modules/approvals/redeem.go
@@ -180,6 +180,19 @@ var contextTargetKinds = map[string]string{
 		"writes bump — and the same enrichment run that discovers the leads writes " +
 		"the company's profile fields, so the pin went stale before any human saw " +
 		"the lead and every accept failed for the row's lifetime.",
+	"deal_follow_up": "A reconciled follow-up is filed under the deal it is about, but the " +
+		"effect CREATES an activity and reads none of the deal's own fields. Its stager " +
+		"has always said it carries no pin, and stopped being right when the pin moved " +
+		"server-side: an overnight proposal waits until someone works their morning " +
+		"inbox, which is exactly the window a rep moves the stage, edits the amount or " +
+		"corrects the close date in — and any one of those cancelled the follow-up they " +
+		"had just approved.",
+	"capture_counterparty": "The proposal is filed under the ACTIVITY that carried the " +
+		"unrecognized sender, because that message is the evidence a human judges it on. " +
+		"The effect creates a person and an organization and closes the capture " +
+		"disposition; it never writes the activity. Pinning bound the answer to a row " +
+		"that relinking, a participant correction or a subject fix bumps — every one of " +
+		"which is ordinary inbox work on the very message the question is about.",
 }
 
 // unpinnedKinds are the staging kinds whose target IS the row their effect

--- a/backend/internal/modules/approvals/staging.go
+++ b/backend/internal/modules/approvals/staging.go
@@ -346,9 +346,12 @@ func resolveTargetVersion(ctx context.Context, tx pgx.Tx, in StageInput) (versio
 	if in.TargetID.IsZero() || !TargetVersionCheckable(in.TargetType) {
 		return 0, false, nil
 	}
-	// A kind whose target is context rather than operand binds to nothing:
-	// see contextTargetKinds for why pinning it was worse than not pinning it.
-	if TargetIsContextOnly(in.Kind) {
+	// Two declared waivers, both meaning "this kind stages with no pin", and
+	// each says a different thing about why: the target is context rather than
+	// operand (contextTargetKinds), or it is the operand and the pin still binds
+	// nothing the human judged (unpinnedKinds). Both are read here because this
+	// is the one place a pin is taken.
+	if TargetIsContextOnly(in.Kind) || TargetVersionUnpinned(in.Kind) {
 		return 0, false, nil
 	}
 	current, err := targetVersion(ctx, tx, in.TargetType, in.TargetID)

--- a/backend/internal/modules/people/linkedin_test.go
+++ b/backend/internal/modules/people/linkedin_test.go
@@ -4,9 +4,11 @@
 package people
 
 import (
+	"context"
 	"errors"
 	"testing"
 
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/values"
 )
 
@@ -45,5 +47,20 @@ func TestNormalizeLinkedInURLRefusesNonURLs(t *testing.T) {
 		if !errors.As(err, &parseErr) {
 			t.Errorf("NormalizeLinkedInURL(%q): got %v, want a values.ParseError", raw, err)
 		}
+	}
+}
+
+// The narrow pending read refuses the zero contact rather than answering the
+// wide list. The two reads share one gated query, and ids.Nil is exactly what
+// the unfiltered entry point passes it — so a caller that meant to name one
+// contact and computed the zero id would silently be handed every open match
+// the member has, staged as though each were about the arrival that triggered
+// the pass. The refusal comes before any pool use, which is why a nil store
+// answers it.
+func TestAPersonScopedPendingMatchReadRefusesTheZeroContact(t *testing.T) {
+	_, err := NewStore(nil).PendingLinkedInMatchesForPerson(context.Background(), ids.Nil)
+	if err == nil {
+		t.Fatal("the zero contact was accepted — a person-scoped read that names no person " +
+			"silently widens to every pending match the member has")
 	}
 }

--- a/backend/internal/modules/people/linkedinmatchapply.go
+++ b/backend/internal/modules/people/linkedinmatchapply.go
@@ -76,6 +76,16 @@ func (s *Store) PendingLinkedInMatchesForPerson(ctx context.Context, personID id
 	return s.suggestedMatches(ctx, personID)
 }
 
+// optionalPerson renders the contact filter the way SQL reads it: NULL for the
+// unfiltered entry point, so the predicate below is one expression rather than
+// two queries whose row-scope join would have to be kept in step by hand.
+func optionalPerson(id ids.UUID) *ids.UUID {
+	if id == ids.Nil {
+		return nil
+	}
+	return &id
+}
+
 // suggestedMatches is the one gated read both entry points land on. forPerson
 // is ids.Nil for every contact.
 func (s *Store) suggestedMatches(ctx context.Context, forPerson ids.UUID) ([]PendingLinkedInMatch, error) {
@@ -103,11 +113,7 @@ func (s *Store) suggestedMatches(ctx context.Context, forPerson ids.UUID) ([]Pen
 		}
 		// NULL is every contact, so one query serves both entry points without a
 		// second copy of the row-scope join to keep in step with this one.
-		var person *ids.UUID
-		if forPerson != ids.Nil {
-			person = &forPerson
-		}
-		personPos := arg(person)
+		personPos := arg(optionalPerson(forPerson))
 		rows, err := tx.Query(ctx, storekit.SQLf(`
 			SELECT c.id, c.full_name, coalesce(c.company_name, ''), p.id, p.full_name
 			  FROM linkedin_connection c

--- a/backend/internal/modules/people/linkedinmatchapply.go
+++ b/backend/internal/modules/people/linkedinmatchapply.go
@@ -14,6 +14,7 @@ package people
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/jackc/pgx/v5"
@@ -54,6 +55,30 @@ type PendingLinkedInMatch struct {
 // proposal is the caller's job, and skipping the ones already decided is too —
 // the approval row is the record of that, and this module does not read it.
 func (s *Store) PendingLinkedInMatches(ctx context.Context) ([]PendingLinkedInMatch, error) {
+	return s.suggestedMatches(ctx, ids.Nil)
+}
+
+// PendingLinkedInMatchesForPerson is the same list narrowed to ONE contact —
+// what a caller that matched a single arrival owes a proposal pass over.
+//
+// The narrow read exists because the whole-network one is O(the member's open
+// questions) and the caller runs once per person event: proposing every
+// outstanding match again on each capture write only ever joins rows that
+// already exist. Matching against one contact can raise questions about that
+// contact and no other, so this is the complete answer for that caller as well
+// as the cheap one.
+func (s *Store) PendingLinkedInMatchesForPerson(ctx context.Context, personID ids.UUID) ([]PendingLinkedInMatch, error) {
+	if personID == ids.Nil {
+		// The zero id is exactly what the unfiltered read passes, so accepting
+		// it here would silently widen a caller that meant to name one contact.
+		return nil, errors.New("people: a person-scoped pending-match read was given no contact")
+	}
+	return s.suggestedMatches(ctx, personID)
+}
+
+// suggestedMatches is the one gated read both entry points land on. forPerson
+// is ids.Nil for every contact.
+func (s *Store) suggestedMatches(ctx context.Context, forPerson ids.UUID) ([]PendingLinkedInMatch, error) {
 	actor, ok := principal.Actor(ctx)
 	if !ok || actor.UserID == ids.Nil {
 		return nil, apperrors.ErrPermissionDenied
@@ -76,6 +101,13 @@ func (s *Store) PendingLinkedInMatches(ctx context.Context) ([]PendingLinkedInMa
 		if scope != "" {
 			visible = scope
 		}
+		// NULL is every contact, so one query serves both entry points without a
+		// second copy of the row-scope join to keep in step with this one.
+		var person *ids.UUID
+		if forPerson != ids.Nil {
+			person = &forPerson
+		}
+		personPos := arg(person)
 		rows, err := tx.Query(ctx, storekit.SQLf(`
 			SELECT c.id, c.full_name, coalesce(c.company_name, ''), p.id, p.full_name
 			  FROM linkedin_connection c
@@ -83,7 +115,8 @@ func (s *Store) PendingLinkedInMatches(ctx context.Context) ([]PendingLinkedInMa
 			 WHERE c.owner_user_id = $%d
 			   AND c.match_status = 'suggested'
 			   AND c.tombstoned_at IS NULL
-			 ORDER BY c.full_name, c.id`, visible, ownerPos), args...)
+			   AND ($%d::uuid IS NULL OR c.matched_person_id = $%d::uuid)
+			 ORDER BY c.full_name, c.id`, visible, ownerPos, personPos, personPos), args...)
 		if err != nil {
 			return fmt.Errorf("people: reading the LinkedIn matches awaiting a decision: %w", err)
 		}


### PR DESCRIPTION
Closes #677, closes #679.

A member uploads their LinkedIn export during onboarding, and the contacts it could
match arrive over the following weeks. The event consumer that catches those arrivals
matched them, wrote `suggested` to the ghost row, logged a line, and stopped. The
pending question lives in the **approval**, not in `match_status` — so nobody was ever
asked, and nothing in the product could tell them a question existed.

The hourly sweep could not repair it either: it enumerated owners with `unmatched`
ghosts only, so a member whose ghosts had all been matched to `suggested` dropped out of
the enumeration entirely and their suggestions sat invisible for the row's lifetime.

And the ones that did reach the inbox were cancelled by an unrelated contact edit: the
staging pinned the person's version, so a title correction between staging and decision
made the redemption fail — against the founder decision that a contact edit must not
cancel a waiting match.

## What changed

**A pass proposes over the same scope it matched.** The per-person arm stages that
contact's pending matches; the workspace arm, the sweep and the import handler stage the
whole outstanding set. The narrow arm is what keeps the event path bounded — matching one
arrival can only raise questions about that arrival, so it is the complete answer as well
as the cheap one, and the whole-set alternative would cost one transaction per open
question on every contact write in the workspace.

**`ghostOwners` counts both undecided statuses**, so the sweep can reach residue at all.

**The approvals service is built once** per consumer, worker and stager rather than once
per member per pass — a dozen effect registrations that answer the same service every time.

**Writing the test found a second defect the issue does not name.** The sweep bound no
correlation id, and the write shape refuses one without it: its staging failed on the
first proposal it tried and failed the whole workspace's re-match with it — permanently,
since the retry rebuilds the same context. **The sweep's staging has never run in
production.** `systemContext` now binds a trace the way every other workspace job does.

**#679 gets a second, honestly-named pin waiver.** `linkedin_match` targets the person its
effect writes, so filing it under `contextTargetKinds` — "the target is context the
proposal is merely about" — would trade one lying label for another. `unpinnedKinds` says
the other thing: the target is the operand and the pin binds nothing a human judged. Both
maps are held to the same discipline, and a new gate keeps a kind from claiming both.

**Then both reviews found the same two sibling copies**, and they were right. `deal_follow_up`
and `capture_counterparty` were pinned to rows their effects never write. The follow-up
one is the sharper case: its stager has said "the proposal carries no target_version" in
prose the whole time, and that stopped being true when the pin moved server-side — an
overnight proposal waits for somebody's morning inbox, which is exactly the window a rep
edits the deal in. Neither failure is visible where it happens, because the decision
commits before the effect runs: the human sees an approved proposal whose work was never
done.

## Proof

**Every new test fails against the defect it describes** — verified by reverting each fix
and re-running:

| test | failure against the unfixed code |
|---|---|
| `TestAPersonEventStagesTheLinkedInSuggestionItProduced` | `0 pending linkedin_match proposals, want exactly 1` |
| `TestTheSweepStagesALinkedInSuggestionNobodyWasEverAskedAbout` | `0 pending linkedin_match proposals, want exactly 1` |
| `TestAContactEditDoesNotCancelAWaitingLinkedInMatch` | `target changed since approval (v1 → v2): version skew` |
| `TestADealEditDoesNotCancelAWaitingFollowUp` | same, on the deal |
| `TestEditingTheCapturedMessageDoesNotCancelItsWaitingReview` | same, on the activity |

Plus `TestTheSweepNeverReasksALinkedInMatchThatWasRefused` (the widened enumeration makes
durable refusal load-bearing in a new way), the `unpinnedKinds` discipline gates, and a
guard test for the narrow read's zero-contact refusal.

### UAT — a live stack, end to end through the real bus

`DEV_SLUG=lim`, worker on, events flowing through the outbox relay.

```
POST /v1/organizations                          201   Simio GmbH
POST /v1/me/linkedin-connections                200   {"imported":1,"suggested":0}   ← ghost waits, unmatched
GET  /v1/approvals?status=pending                     pending approvals: 0            ← nothing to ask yet
POST /v1/people            "Andreas Muller"     201   version 1
POST /v1/relationships     employment            201
                                                      t+3s  pending=1                 ← #677: the bus staged it
```

```json
{ "kind": "linkedin_match",
  "summary": "Andreas Müller at Simio GmbH looks like Andreas Muller",
  "target_entity_type": "person",
  "target_version": null }          ← #679: no pin on the wire
```

```
PATCH /v1/people/{id}  {"title":"Head of Procurement"}   200   version 1 → 2
POST  /v1/approvals/{id}/approve                         200   status approved, effect_error null
GET   /v1/people/{id}   → social {"linkedin": "https://www.linkedin.com/in/amueller-uat"}
psql  → linkedin_connection: Andreas Müller | confirmed | linked t
```

The edit bumped the contact to v2 while the question waited, and the approval still
applied.

**Negative case** — a colleague may not see or decide someone else's match question:

```
GET  /v1/approvals?status=pending   (rep@demo.test)   → 0 pending, kinds: []
GET  /v1/approvals/{admins-proposal}                  → 404 not_found      ← existence-hiding
POST /v1/approvals/{admins-proposal}/approve          → 404 not_found
```

### Gates, locally, before pushing

- `make check-backend` — green
- `craft static --strict` — PASS, 0 blocker / 0 major / 0 minor
- `make test-integration` — `OK: integration passed with 0 skips (29 packages)`
- new-code coverage — every new function 75–100% (`StageLinkedInMatchesForPerson` 75%,
  `stagePendingLinkedInMatches` 82%, `PendingLinkedInMatchesForPerson` 100%,
  `suggestedMatches` 85%, `TargetVersionUnpinned` / `UnpinnedKinds` 100%,
  `systemContext` 100%)

No prompt, tool description, contract or aicert corpus file is touched, so no paid lane is owed.

## Filed, not fixed

**#743** — a ghost row has no terminal state. A refusal is recorded on the approval and
never on the row, and a suggestion whose contact is archived or merged away can never be
proposed, matched again, or decided. Correctness holds in both cases; the cost does not —
the widened enumeration now sweeps those owners forever for a guaranteed-empty result.
Both reviews reached it independently, from opposite ends, and the honest fix is the
rejected-effect seam #678 asks for plus a release transition, which is a change of its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two onboarding issues: LinkedIn match suggestions now reach the inbox when they’re created, and unrelated edits no longer cancel pending approvals for `linkedin_match`, `deal_follow_up`, or `capture_counterparty` (addresses #677 and #679).

- **Bug Fixes**
  - Stage `linkedin_match` proposals in the same pass that matched them: per-person events stage that contact only; workspace and sweep paths stage all outstanding. Idempotent staging prevents duplicates.
  - Sweep now enumerates both `unmatched` and `suggested` owners and binds a correlation id, so staging actually runs and can rescue missed suggestions.
  - Approvals decline the version pin where it never protected content:
    - `linkedin_match` is declared in `UnpinnedKinds` (claim is “this connection is this contact”; no contact edit can falsify it).
    - `deal_follow_up` and `capture_counterparty` are declared as context-only targets, so edits to their filing rows don’t cancel approvals.
  - Contact/message/deal edits between staging and decision no longer break redemption; regression tests cover these paths and durable refusals are not re-asked.

- **Refactors**
  - Added person-scoped helpers: `PendingLinkedInMatchesForPerson` and `StageLinkedInMatchesForPerson`; zero-contact reads are rejected; the pending-match query uses `optionalPerson()` to express “all contacts” and keep the row-scope join single-sourced.
  - Built the approvals service once per consumer/worker/stager; event and sweep logs include `staged` counts.
  - Added `UnpinnedKinds` alongside `contextTargetKinds`, plus guard tests to ensure every waiver is explained, references a real kind, and no kind claims both.

<sup>Written for commit 7e6f837ada868c9bb7df9969ee028e9d022eae1f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/744?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

