### PR TITLE
feat(finance): the company page can ask whether a customer pays on time

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -12272,18 +12272,27 @@ components:
         overdue:
           allOf: [{ $ref: '#/components/schemas/Money' }]
           description: The share of the open balance already past its due date.
-        median_days_to_pay:
+        median_days_after_due:
           type: [integer, 'null']
           description: >-
-            The median days between issue and settlement over the window
-            (FIN-FORM-3). Absent when too few invoices have settled to say — a
-            median of one invoice is an anecdote.
+            The median days between an invoice's DUE date and its settlement over
+            the window (FIN-FORM-3) — how late they pay, not how long they take.
+            Negative reads as early. Deliberately not issue-to-settlement: an
+            invoice paid on the last day of 30-day terms is punctual, and a figure
+            that called it "30 days to pay" would read as slow.
+
+            Absent when too few invoices have settled to say — a median of one
+            invoice is an anecdote, not a payment habit.
         payment_behaviour:
           type: array
           description: >-
-            Days-late per settled invoice, oldest first, for the sparkline. Empty when
-            nothing settled inside the window; never padded with zeroes, because a
-            zero here reads as "paid exactly on time".
+            Days-late per settled invoice, oldest first, for the sparkline. Never
+            padded with zeroes, because a zero here reads as "paid exactly on
+            time".
+
+            Absent under the same sample floor the median observes: a shape drawn
+            from one invoice would state a payment habit the number beside it
+            refuses to.
           items: { type: integer }
         recent_invoices:
           type: array

--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -1977,6 +1977,36 @@ paths:
         '403': { $ref: '#/components/responses/Forbidden' }
         '404': { $ref: '#/components/responses/NotFound' }
 
+  /organizations/{id}/finance-summary:
+    parameters:
+      - $ref: '#/components/parameters/Id'
+    get:
+      tags: [Organizations, Finance]
+      operationId: getOrganizationFinanceSummary
+      summary: Does this customer actually pay us, and on time?
+      description: |
+        The finance card's whole read (FIN-WIRE-1, ADR-0083/A128): what we have
+        invoiced, what is still open, and how they pay — plus the handful of recent
+        invoices the card shows.
+
+        **`state` is the answer, not a decoration.** A page that renders figures
+        without it cannot tell "they owe nothing" from "no accounting source is
+        connected", and those are opposite facts about a customer. Every figure is
+        absent rather than zero when it cannot be computed (FIN-AC-2): €0 open is a
+        claim that they are square with us, and it must be earned.
+
+        Read-only, like everything in the mirror. The connection is managed
+        elsewhere; this endpoint only reads what the last sync brought back.
+      responses:
+        '200':
+          description: The account's finance summary, in whatever state it is in.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/OrganizationFinanceSummary' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
+
   /organizations/{id}/facts:
     parameters:
       - $ref: '#/components/parameters/Id'
@@ -12206,6 +12236,110 @@ components:
         entity_type: { type: string, enum: [deal, activity, person, organization, fact, profile_field] }
         entity_id: { type: string, format: uuid }
 
+    OrganizationFinanceSummary:
+      type: object
+      description: |
+        What the accounting mirror knows about one customer (ADR-0083/A128).
+
+        Every figure is nullable and ABSENT when it cannot be computed, never zero
+        (FIN-AC-2). "€0 open" says the customer is square with us; "no figure" says
+        we do not know. A card that renders the second as the first tells a rep an
+        account is healthy on the strength of a missing connector.
+      required: [organization_id, state]
+      properties:
+        organization_id: { type: string, format: uuid }
+        state: { $ref: '#/components/schemas/FinanceSummaryState' }
+        provider:
+          type: [string, 'null']
+          description: >-
+            Which accounting source this came from, in the source's own words
+            ("offline_demo"). Rendered as a label beside the figures so a reader
+            knows what they are looking at; absent when nothing is connected.
+        last_synced_at:
+          type: [string, 'null']
+          format: date-time
+          description: When the last successful sync finished. Null when none has.
+        net_invoiced:
+          allOf: [{ $ref: '#/components/schemas/Money' }]
+          description: >-
+            Issued minus credited over the last 365 days (FIN-FORM-1). Named "net
+            invoiced" rather than "revenue": the source supports issued amounts, not
+            a ledger revenue figure, and calling one the other is the kind of small
+            wrong label a reader plans against.
+        open_balance:
+          allOf: [{ $ref: '#/components/schemas/Money' }]
+          description: What is still open across unpaid invoices (FIN-FORM-2).
+        overdue:
+          allOf: [{ $ref: '#/components/schemas/Money' }]
+          description: The share of the open balance already past its due date.
+        median_days_to_pay:
+          type: [integer, 'null']
+          description: >-
+            The median days between issue and settlement over the window
+            (FIN-FORM-3). Absent when too few invoices have settled to say — a
+            median of one invoice is an anecdote.
+        payment_behaviour:
+          type: array
+          description: >-
+            Days-late per settled invoice, oldest first, for the sparkline. Empty when
+            nothing settled inside the window; never padded with zeroes, because a
+            zero here reads as "paid exactly on time".
+          items: { type: integer }
+        recent_invoices:
+          type: array
+          maxItems: 5
+          description: The five most recent invoices (FIN-LIM-4); `truncated` says whether there are more.
+          items: { $ref: '#/components/schemas/FinanceInvoice' }
+        truncated:
+          type: boolean
+          description: True when the account has more invoices than `recent_invoices` carries.
+
+    FinanceSummaryState:
+      type: string
+      enum: [no_connection, unmapped, syncing, connected, stale, error]
+      description: |
+        Why the figures are what they are — the six cases a company page must keep
+        apart, because five of them look identical if you only render the numbers.
+
+        `no_connection` — no accounting source is configured for this installation.
+        `unmapped` — a source is connected, but nobody has said which of its
+        customers this organization is. The figures are absent, and the fix is a
+        mapping rather than a sync.
+        `syncing` — the first pass has not finished; figures may be partial.
+        `connected` — the figures are current.
+        `stale` — the last sync succeeded, but long enough ago that the reader
+        should see the date beside the number.
+        `error` — the last attempt failed. What is shown is the last good answer,
+        and the reader is told it is not current.
+
+    FinanceInvoice:
+      type: object
+      description: One mirrored invoice, in the currency it was issued in.
+      required: [id, issued_at, status, currency, gross_minor, open_minor]
+      properties:
+        id: { type: string, format: uuid }
+        number:
+          type: [string, 'null']
+          description: The source's own invoice number, absent when it does not issue one.
+        issued_at: { type: string, format: date }
+        due_at: { type: [string, 'null'], format: date }
+        paid_at:
+          type: [string, 'null']
+          format: date-time
+          description: When it was settled in full. Null while anything is still open.
+        status:
+          type: string
+          enum: [draft, open, partially_paid, paid, overdue, disputed, credited, void]
+        currency: { type: string, pattern: '^[A-Z]{3}$' }
+        gross_minor: { type: integer, format: int64, description: The invoiced total in minor units. }
+        open_minor: { type: integer, format: int64, description: What is still unpaid on it. }
+        days_late:
+          type: [integer, 'null']
+          description: >-
+            Days between the due date and settlement, or between the due date and
+            today while it is still open. Absent when the invoice carries no due
+            date — lateness against no deadline is not a reading.
+
     RecordViewAck:
       type: object
       description: The per-user "I have seen this record" baseline, after an acknowledgment.
@@ -15074,7 +15208,7 @@ components:
          automation, voice_profile, product, offer, signal, saved_view, custom_field,
          computed_field, quota, offer_template, overlay_connection, embedding_reindex,
          webhook_subscription, fx_rate, ai_model_rate, capture_settings, project,
-         channel_connection, import_run, installation_settings]
+         channel_connection, import_run, installation_settings, finance]
 
     RbacAction:
       type: string

--- a/backend/internal/compose/handlersets.go
+++ b/backend/internal/compose/handlersets.go
@@ -22,6 +22,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/modules/consent"
 	"github.com/gradionhq/margince/backend/internal/modules/customfields"
 	"github.com/gradionhq/margince/backend/internal/modules/deals"
+	"github.com/gradionhq/margince/backend/internal/modules/finance"
 	"github.com/gradionhq/margince/backend/internal/modules/identity"
 	"github.com/gradionhq/margince/backend/internal/modules/overlay"
 	"github.com/gradionhq/margince/backend/internal/modules/people"
@@ -57,6 +58,7 @@ type (
 	orgBriefHandlers     = orgbrief.Handlers
 	orgDossierHandlers   = orgdossier.Handlers
 	accountDraftHandlers = accountdraft.Handlers
+	financeHandlers      = finance.Handlers
 )
 
 // wirePerson360 binds the person record page — the organization page's

--- a/backend/internal/compose/server.go
+++ b/backend/internal/compose/server.go
@@ -32,6 +32,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/modules/consent"
 	"github.com/gradionhq/margince/backend/internal/modules/customfields"
 	"github.com/gradionhq/margince/backend/internal/modules/deals"
+	"github.com/gradionhq/margince/backend/internal/modules/finance"
 	"github.com/gradionhq/margince/backend/internal/modules/identity"
 	"github.com/gradionhq/margince/backend/internal/modules/people"
 	"github.com/gradionhq/margince/backend/internal/modules/privacy"
@@ -99,6 +100,7 @@ type Server struct {
 	orgBriefHandlers
 	orgDossierHandlers
 	accountDraftHandlers
+	financeHandlers
 
 	// gmailPush is the Pub/Sub push webhook (built on the shared chassis,
 	// webhook.go), injected by WithGmailPush only when a subscription token
@@ -354,6 +356,7 @@ func newServer(pool *pgxpool.Pool, log *slog.Logger, authH authHandlers, dealsH 
 		// The warm room ranks its contact edges by the §4 relationship
 		// strength owned by people; injected through the adapter below so
 		// signals never imports its sibling.
+		financeHandlers:    finance.NewHandlers(pool),
 		signalsHandlers:    signals.NewHandlers(pool, signalStrength{people: people.NewStore(pool)}),
 		privacyHandlers:    privacy.NewHandlers(pool),
 		automationHandlers: automation.NewHandlers(pool),

--- a/backend/internal/compose/stubs_gen.go
+++ b/backend/internal/compose/stubs_gen.go
@@ -743,6 +743,10 @@ func (stubs) ConfirmOrganizationFact(w nethttp.ResponseWriter, r *nethttp.Reques
 	httperr.NotImplemented(w, r, "ConfirmOrganizationFact")
 }
 
+func (stubs) GetOrganizationFinanceSummary(w nethttp.ResponseWriter, r *nethttp.Request, id crmcontracts.Id) {
+	httperr.NotImplemented(w, r, "GetOrganizationFinanceSummary")
+}
+
 func (stubs) GetOrganizationGraph(w nethttp.ResponseWriter, r *nethttp.Request, id crmcontracts.Id) {
 	httperr.NotImplemented(w, r, "GetOrganizationGraph")
 }

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -13463,8 +13463,9 @@ type OrganizationFinanceSummary struct {
 	// LastSyncedAt When the last successful sync finished. Null when none has.
 	LastSyncedAt *time.Time `json:"last_synced_at,omitempty"`
 
-	// MedianDaysToPay The median days between issue and settlement over the window (FIN-FORM-3). Absent when too few invoices have settled to say — a median of one invoice is an anecdote.
-	MedianDaysToPay *int `json:"median_days_to_pay,omitempty"`
+	// MedianDaysAfterDue The median days between an invoice's DUE date and its settlement over the window (FIN-FORM-3) — how late they pay, not how long they take. Negative reads as early. Deliberately not issue-to-settlement: an invoice paid on the last day of 30-day terms is punctual, and a figure that called it "30 days to pay" would read as slow.
+	// Absent when too few invoices have settled to say — a median of one invoice is an anecdote, not a payment habit.
+	MedianDaysAfterDue *int `json:"median_days_after_due,omitempty"`
 
 	// NetInvoiced Issued minus credited over the last 365 days (FIN-FORM-1). Named "net invoiced" rather than "revenue": the source supports issued amounts, not a ledger revenue figure, and calling one the other is the kind of small wrong label a reader plans against.
 	NetInvoiced *Money `json:"net_invoiced,omitempty"`
@@ -13476,7 +13477,8 @@ type OrganizationFinanceSummary struct {
 	// Overdue The share of the open balance already past its due date.
 	Overdue *Money `json:"overdue,omitempty"`
 
-	// PaymentBehaviour Days-late per settled invoice, oldest first, for the sparkline. Empty when nothing settled inside the window; never padded with zeroes, because a zero here reads as "paid exactly on time".
+	// PaymentBehaviour Days-late per settled invoice, oldest first, for the sparkline. Never padded with zeroes, because a zero here reads as "paid exactly on time".
+	// Absent under the same sample floor the median observes: a shape drawn from one invoice would state a payment habit the number beside it refuses to.
 	PaymentBehaviour *[]int `json:"payment_behaviour,omitempty"`
 
 	// Provider Which accounting source this came from, in the source's own words ("offline_demo"). Rendered as a label beside the figures so a reader knows what they are looking at; absent when nothing is connected.

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -3420,6 +3420,72 @@ func (e FilteredExportRequestObject) Valid() bool {
 	}
 }
 
+// Defines values for FinanceInvoiceStatus.
+const (
+	FinanceInvoiceStatusCredited      FinanceInvoiceStatus = "credited"
+	FinanceInvoiceStatusDisputed      FinanceInvoiceStatus = "disputed"
+	FinanceInvoiceStatusDraft         FinanceInvoiceStatus = "draft"
+	FinanceInvoiceStatusOpen          FinanceInvoiceStatus = "open"
+	FinanceInvoiceStatusOverdue       FinanceInvoiceStatus = "overdue"
+	FinanceInvoiceStatusPaid          FinanceInvoiceStatus = "paid"
+	FinanceInvoiceStatusPartiallyPaid FinanceInvoiceStatus = "partially_paid"
+	FinanceInvoiceStatusVoid          FinanceInvoiceStatus = "void"
+)
+
+// Valid indicates whether the value is a known member of the FinanceInvoiceStatus enum.
+func (e FinanceInvoiceStatus) Valid() bool {
+	switch e {
+	case FinanceInvoiceStatusCredited:
+		return true
+	case FinanceInvoiceStatusDisputed:
+		return true
+	case FinanceInvoiceStatusDraft:
+		return true
+	case FinanceInvoiceStatusOpen:
+		return true
+	case FinanceInvoiceStatusOverdue:
+		return true
+	case FinanceInvoiceStatusPaid:
+		return true
+	case FinanceInvoiceStatusPartiallyPaid:
+		return true
+	case FinanceInvoiceStatusVoid:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for FinanceSummaryState.
+const (
+	FinanceSummaryStateConnected    FinanceSummaryState = "connected"
+	FinanceSummaryStateError        FinanceSummaryState = "error"
+	FinanceSummaryStateNoConnection FinanceSummaryState = "no_connection"
+	FinanceSummaryStateStale        FinanceSummaryState = "stale"
+	FinanceSummaryStateSyncing      FinanceSummaryState = "syncing"
+	FinanceSummaryStateUnmapped     FinanceSummaryState = "unmapped"
+)
+
+// Valid indicates whether the value is a known member of the FinanceSummaryState enum.
+func (e FinanceSummaryState) Valid() bool {
+	switch e {
+	case FinanceSummaryStateConnected:
+		return true
+	case FinanceSummaryStateError:
+		return true
+	case FinanceSummaryStateNoConnection:
+		return true
+	case FinanceSummaryStateStale:
+		return true
+	case FinanceSummaryStateSyncing:
+		return true
+	case FinanceSummaryStateUnmapped:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for GrowthFitBand.
 const (
 	GrowthFitBandModerate GrowthFitBand = "moderate"
@@ -7655,22 +7721,22 @@ func (e VoiceProfileEvaluationRepeatsPerPrompt) Valid() bool {
 
 // Defines values for VoiceProfileVersionReason.
 const (
-	Automatic  VoiceProfileVersionReason = "automatic"
-	Manual     VoiceProfileVersionReason = "manual"
-	Onboarding VoiceProfileVersionReason = "onboarding"
-	Rollback   VoiceProfileVersionReason = "rollback"
+	VoiceProfileVersionReasonAutomatic  VoiceProfileVersionReason = "automatic"
+	VoiceProfileVersionReasonManual     VoiceProfileVersionReason = "manual"
+	VoiceProfileVersionReasonOnboarding VoiceProfileVersionReason = "onboarding"
+	VoiceProfileVersionReasonRollback   VoiceProfileVersionReason = "rollback"
 )
 
 // Valid indicates whether the value is a known member of the VoiceProfileVersionReason enum.
 func (e VoiceProfileVersionReason) Valid() bool {
 	switch e {
-	case Automatic:
+	case VoiceProfileVersionReasonAutomatic:
 		return true
-	case Manual:
+	case VoiceProfileVersionReasonManual:
 		return true
-	case Onboarding:
+	case VoiceProfileVersionReasonOnboarding:
 		return true
-	case Rollback:
+	case VoiceProfileVersionReasonRollback:
 		return true
 	default:
 		return false
@@ -8825,22 +8891,22 @@ func (e ListSignalsParamsKind) Valid() bool {
 
 // Defines values for ListSignalsParamsResolutionState.
 const (
-	ListSignalsParamsResolutionStateDropped       ListSignalsParamsResolutionState = "dropped"
-	ListSignalsParamsResolutionStateLowConfidence ListSignalsParamsResolutionState = "low_confidence"
-	ListSignalsParamsResolutionStateResolved      ListSignalsParamsResolutionState = "resolved"
-	ListSignalsParamsResolutionStateUnresolved    ListSignalsParamsResolutionState = "unresolved"
+	Dropped       ListSignalsParamsResolutionState = "dropped"
+	LowConfidence ListSignalsParamsResolutionState = "low_confidence"
+	Resolved      ListSignalsParamsResolutionState = "resolved"
+	Unresolved    ListSignalsParamsResolutionState = "unresolved"
 )
 
 // Valid indicates whether the value is a known member of the ListSignalsParamsResolutionState enum.
 func (e ListSignalsParamsResolutionState) Valid() bool {
 	switch e {
-	case ListSignalsParamsResolutionStateDropped:
+	case Dropped:
 		return true
-	case ListSignalsParamsResolutionStateLowConfidence:
+	case LowConfidence:
 		return true
-	case ListSignalsParamsResolutionStateResolved:
+	case Resolved:
 		return true
-	case ListSignalsParamsResolutionStateUnresolved:
+	case Unresolved:
 		return true
 	default:
 		return false
@@ -11682,6 +11748,48 @@ type FilteredExportRequestFormat string
 // FilteredExportRequestObject The object type to filter-export; requires `filter`. Mutually exclusive with view_id/list_id.
 type FilteredExportRequestObject string
 
+// FinanceInvoice One mirrored invoice, in the currency it was issued in.
+type FinanceInvoice struct {
+	Currency string `json:"currency"`
+
+	// DaysLate Days between the due date and settlement, or between the due date and today while it is still open. Absent when the invoice carries no due date — lateness against no deadline is not a reading.
+	DaysLate *int                `json:"days_late,omitempty"`
+	DueAt    *openapi_types.Date `json:"due_at,omitempty"`
+
+	// GrossMinor The invoiced total in minor units.
+	GrossMinor int64              `json:"gross_minor"`
+	Id         openapi_types.UUID `json:"id"`
+	IssuedAt   openapi_types.Date `json:"issued_at"`
+
+	// Number The source's own invoice number, absent when it does not issue one.
+	Number *string `json:"number,omitempty"`
+
+	// OpenMinor What is still unpaid on it.
+	OpenMinor int64 `json:"open_minor"`
+
+	// PaidAt When it was settled in full. Null while anything is still open.
+	PaidAt *time.Time           `json:"paid_at,omitempty"`
+	Status FinanceInvoiceStatus `json:"status"`
+}
+
+// FinanceInvoiceStatus defines model for FinanceInvoice.Status.
+type FinanceInvoiceStatus string
+
+// FinanceSummaryState Why the figures are what they are — the six cases a company page must keep
+// apart, because five of them look identical if you only render the numbers.
+//
+// `no_connection` — no accounting source is configured for this installation.
+// `unmapped` — a source is connected, but nobody has said which of its
+// customers this organization is. The figures are absent, and the fix is a
+// mapping rather than a sync.
+// `syncing` — the first pass has not finished; figures may be partial.
+// `connected` — the figures are current.
+// `stale` — the last sync succeeded, but long enough ago that the reader
+// should see the date beside the number.
+// `error` — the last attempt failed. What is shown is the last good answer,
+// and the reader is told it is not current.
+type FinanceSummaryState string
+
 // FxRate One effective-dated FX rate converting from_currency into the workspace base (to_currency). rate is a decimal string (numeric(20,10)), never a float.
 type FxRate struct {
 	EffectiveDate openapi_types.Date `json:"effective_date"`
@@ -13343,6 +13451,57 @@ type OrganizationFactSuspectReason string
 // OrganizationFactListResponse defines model for OrganizationFactListResponse.
 type OrganizationFactListResponse struct {
 	Data []OrganizationFact `json:"data"`
+}
+
+// OrganizationFinanceSummary What the accounting mirror knows about one customer (ADR-0083/A128).
+//
+// Every figure is nullable and ABSENT when it cannot be computed, never zero
+// (FIN-AC-2). "€0 open" says the customer is square with us; "no figure" says
+// we do not know. A card that renders the second as the first tells a rep an
+// account is healthy on the strength of a missing connector.
+type OrganizationFinanceSummary struct {
+	// LastSyncedAt When the last successful sync finished. Null when none has.
+	LastSyncedAt *time.Time `json:"last_synced_at,omitempty"`
+
+	// MedianDaysToPay The median days between issue and settlement over the window (FIN-FORM-3). Absent when too few invoices have settled to say — a median of one invoice is an anecdote.
+	MedianDaysToPay *int `json:"median_days_to_pay,omitempty"`
+
+	// NetInvoiced Issued minus credited over the last 365 days (FIN-FORM-1). Named "net invoiced" rather than "revenue": the source supports issued amounts, not a ledger revenue figure, and calling one the other is the kind of small wrong label a reader plans against.
+	NetInvoiced *Money `json:"net_invoiced,omitempty"`
+
+	// OpenBalance What is still open across unpaid invoices (FIN-FORM-2).
+	OpenBalance    *Money             `json:"open_balance,omitempty"`
+	OrganizationId openapi_types.UUID `json:"organization_id"`
+
+	// Overdue The share of the open balance already past its due date.
+	Overdue *Money `json:"overdue,omitempty"`
+
+	// PaymentBehaviour Days-late per settled invoice, oldest first, for the sparkline. Empty when nothing settled inside the window; never padded with zeroes, because a zero here reads as "paid exactly on time".
+	PaymentBehaviour *[]int `json:"payment_behaviour,omitempty"`
+
+	// Provider Which accounting source this came from, in the source's own words ("offline_demo"). Rendered as a label beside the figures so a reader knows what they are looking at; absent when nothing is connected.
+	Provider *string `json:"provider,omitempty"`
+
+	// RecentInvoices The five most recent invoices (FIN-LIM-4); `truncated` says whether there are more.
+	RecentInvoices *[]FinanceInvoice `json:"recent_invoices,omitempty"`
+
+	// State Why the figures are what they are — the six cases a company page must keep
+	// apart, because five of them look identical if you only render the numbers.
+	//
+	// `no_connection` — no accounting source is configured for this installation.
+	// `unmapped` — a source is connected, but nobody has said which of its
+	// customers this organization is. The figures are absent, and the fix is a
+	// mapping rather than a sync.
+	// `syncing` — the first pass has not finished; figures may be partial.
+	// `connected` — the figures are current.
+	// `stale` — the last sync succeeded, but long enough ago that the reader
+	// should see the date beside the number.
+	// `error` — the last attempt failed. What is shown is the last good answer,
+	// and the reader is told it is not current.
+	State FinanceSummaryState `json:"state"`
+
+	// Truncated True when the account has more invoices than `recent_invoices` carries.
+	Truncated *bool `json:"truncated,omitempty"`
 }
 
 // OrganizationGraph The account's one-hop connection graph, as nodes and edges the client lays out.
@@ -26324,6 +26483,9 @@ type ServerInterface interface {
 	// Confirm an extracted fact without changing its value.
 	// (POST /organizations/{id}/facts/{factKey}/confirm)
 	ConfirmOrganizationFact(w http.ResponseWriter, r *http.Request, id Id, factKey FactKey, params ConfirmOrganizationFactParams)
+	// Does this customer actually pay us, and on time?
+	// (GET /organizations/{id}/finance-summary)
+	GetOrganizationFinanceSummary(w http.ResponseWriter, r *http.Request, id Id)
 	// The account's connections one hop out — its contacts, its open deals and their stakeholders, its parent, children and partner orgs.
 	// (GET /organizations/{id}/graph)
 	GetOrganizationGraph(w http.ResponseWriter, r *http.Request, id Id)
@@ -27839,6 +28001,12 @@ func (_ Unimplemented) UpdateOrganizationFact(w http.ResponseWriter, r *http.Req
 // Confirm an extracted fact without changing its value.
 // (POST /organizations/{id}/facts/{factKey}/confirm)
 func (_ Unimplemented) ConfirmOrganizationFact(w http.ResponseWriter, r *http.Request, id Id, factKey FactKey, params ConfirmOrganizationFactParams) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Does this customer actually pay us, and on time?
+// (GET /organizations/{id}/finance-summary)
+func (_ Unimplemented) GetOrganizationFinanceSummary(w http.ResponseWriter, r *http.Request, id Id) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -36736,6 +36904,40 @@ func (siw *ServerInterfaceWrapper) ConfirmOrganizationFact(w http.ResponseWriter
 	handler.ServeHTTP(w, r)
 }
 
+// GetOrganizationFinanceSummary operation middleware
+func (siw *ServerInterfaceWrapper) GetOrganizationFinanceSummary(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "id" -------------
+	var id Id
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", chi.URLParam(r, "id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "uuid"})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	ctx = context.WithValue(ctx, CookieAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetOrganizationFinanceSummary(w, r, id)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
 // GetOrganizationGraph operation middleware
 func (siw *ServerInterfaceWrapper) GetOrganizationGraph(w http.ResponseWriter, r *http.Request) {
 
@@ -44517,6 +44719,9 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 	})
 	r.Group(func(r chi.Router) {
 		r.Post(options.BaseURL+"/organizations/{id}/facts/{factKey}/confirm", wrapper.ConfirmOrganizationFact)
+	})
+	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/organizations/{id}/finance-summary", wrapper.GetOrganizationFinanceSummary)
 	})
 	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/organizations/{id}/graph", wrapper.GetOrganizationGraph)

--- a/backend/internal/modules/finance/handlers.go
+++ b/backend/internal/modules/finance/handlers.go
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package finance
+
+// The HTTP transport for the finance mirror. Wire concerns only: bind the path
+// id and hand the result to the sentinel error mapping. The store owns every
+// gate.
+
+import (
+	"net/http"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/platform/httperr"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// Handlers shadows the generated finance stubs.
+type Handlers struct {
+	store *Store
+}
+
+// NewHandlers binds the transport to the pool the mirror is read through.
+func NewHandlers(pool *pgxpool.Pool) Handlers {
+	return Handlers{store: NewStore(pool)}
+}
+
+// GetOrganizationFinanceSummary implements
+// GET /organizations/{id}/finance-summary.
+func (h Handlers) GetOrganizationFinanceSummary(
+	w http.ResponseWriter, r *http.Request, id crmcontracts.Id,
+) {
+	summary, err := h.store.SummaryFor(r.Context(),
+		ids.From[ids.OrganizationKind](ids.UUID(id)))
+	if err != nil {
+		httperr.Write(w, r, err)
+		return
+	}
+	httperr.WriteJSON(w, http.StatusOK, summary)
+}

--- a/backend/internal/modules/finance/store.go
+++ b/backend/internal/modules/finance/store.go
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package finance
+
+// The store: reads of the mirror, and nothing else.
+//
+// There is no create, update or delete on a finance RECORD anywhere in this
+// file, and that is the read-only posture (FIN-DDL-N-1) expressed where a
+// contributor would look for the write rather than as a runtime refusal. Rows
+// arrive through the sync pass, which is the connector's own path.
+
+import (
+	"context"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/gradionhq/margince/backend/internal/platform/database"
+)
+
+// Store reads the finance mirror under the caller's own gates.
+type Store struct {
+	pool *pgxpool.Pool
+	// now is injected so a summary's staleness and its trailing window are
+	// testable without waiting for the clock to move.
+	now func() time.Time
+}
+
+// NewStore binds the store to the pool every tenant read runs through.
+func NewStore(pool *pgxpool.Pool) *Store {
+	return &Store{pool: pool, now: time.Now}
+}
+
+// WithClock replaces the store's clock. Tests only: a summary that reads
+// "stale" is a function of the wall clock, and a test that waited for one
+// would be a test that sometimes fails.
+func (s *Store) WithClock(now func() time.Time) *Store {
+	s.now = now
+	return s
+}
+
+func (s *Store) tx(ctx context.Context, fn func(pgx.Tx) error) error {
+	return database.WithWorkspaceTx(ctx, s.pool, fn)
+}
+
+// staleAfter is how long a successful sync stays current.
+//
+// The sweep runs every six hours, so a mirror that has not synced in a full
+// day has missed four passes — long enough that the reader should see the date
+// beside the figure rather than take it as today's.
+const staleAfter = 24 * time.Hour

--- a/backend/internal/modules/finance/summary.go
+++ b/backend/internal/modules/finance/summary.go
@@ -23,6 +23,7 @@ import (
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
@@ -47,7 +48,16 @@ func (s *Store) SummaryFor(
 		// The account itself is row-scoped, and a finance grant is not a
 		// licence to learn that an organization exists: an account the caller
 		// cannot see answers 404 before any figure is read.
+		//
+		// EnsureVisible alone is not enough. Under row_scope=all it skips the
+		// query entirely — correctly, since everything is visible — so an id
+		// naming no organization would come back as a summary of the
+		// workspace's provider rather than a 404. The existence probe is what
+		// makes a made-up id answer the same way a hidden one does.
 		if err := auth.EnsureVisible(ctx, tx, "organization", orgID.UUID); err != nil {
+			return err
+		}
+		if err := organizationExists(ctx, tx, orgID); err != nil {
 			return err
 		}
 		conn, connected, err := readConnection(ctx, tx)
@@ -61,7 +71,7 @@ func (s *Store) SummaryFor(
 		}
 		out.Provider = &conn.provider
 		out.LastSyncedAt = conn.lastSuccessAt
-		linked, err := organizationIsLinked(ctx, tx, orgID)
+		linked, err := organizationIsLinked(ctx, tx, orgID, conn.id)
 		if err != nil {
 			return err
 		}
@@ -73,7 +83,13 @@ func (s *Store) SummaryFor(
 			return nil
 		}
 		out.State = connectionState(conn, s.now())
-		return s.fillFigures(ctx, tx, orgID, &out)
+		if out.State == crmcontracts.FinanceSummaryStateSyncing {
+			// The first pass has not finished, so any total would be the sum of
+			// however much has landed so far — a smaller number wearing the
+			// label of the whole one. The state is the answer until it does.
+			return nil
+		}
+		return s.fillFigures(ctx, tx, orgID, conn, &out)
 	})
 	if err != nil {
 		return crmcontracts.OrganizationFinanceSummary{}, err
@@ -84,6 +100,7 @@ func (s *Store) SummaryFor(
 // connection is the installation's accounting source, reduced to what the
 // summary reads.
 type connection struct {
+	id            ids.UUID
 	provider      string
 	status        string
 	lastSuccessAt *time.Time
@@ -98,11 +115,11 @@ type connection struct {
 // `no_connection` renders it.
 func readConnection(ctx context.Context, tx pgx.Tx) (conn connection, found bool, err error) {
 	err = tx.QueryRow(ctx, `
-		SELECT provider, status, last_success_at
+		SELECT id, provider, status, last_success_at
 		  FROM finance_connection
 		 WHERE archived_at IS NULL AND status <> 'disconnected'
 		 ORDER BY created_at DESC
-		 LIMIT 1`).Scan(&conn.provider, &conn.status, &conn.lastSuccessAt)
+		 LIMIT 1`).Scan(&conn.id, &conn.provider, &conn.status, &conn.lastSuccessAt)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return connection{}, false, nil
 	}
@@ -117,16 +134,40 @@ func readConnection(ctx context.Context, tx pgx.Tx) (conn connection, found bool
 // inferred from a name match — FIN-AC-7's unmapped state exists because
 // guessing which customer is which company is how money lands on the wrong
 // account.
-func organizationIsLinked(ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID) (bool, error) {
+// Scoped to the LIVE connection: rows from a source that was disconnected and
+// replaced stay in the mirror, and mixing them into the current source's
+// totals would report money the connected system has never heard of.
+func organizationIsLinked(
+	ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID, connectionID ids.UUID,
+) (bool, error) {
 	var exists bool
 	err := tx.QueryRow(ctx, `
 		SELECT EXISTS (
 			SELECT 1 FROM finance_customer_link
-			 WHERE organization_id = $1 AND archived_at IS NULL)`, orgID).Scan(&exists)
+			 WHERE organization_id = $1 AND connection_id = $2
+			   AND archived_at IS NULL)`, orgID, connectionID).Scan(&exists)
 	if err != nil {
 		return false, fmt.Errorf("read the customer link: %w", err)
 	}
 	return exists, nil
+}
+
+// organizationExists answers the id that names nobody with the same 404 a
+// hidden account gets. Existence-hiding cuts both ways: a caller must not be
+// able to tell "no such account" from "not yours".
+func organizationExists(ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID) error {
+	var exists bool
+	err := tx.QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1 FROM organization WHERE id = $1 AND archived_at IS NULL)`,
+		orgID).Scan(&exists)
+	if err != nil {
+		return fmt.Errorf("read the account: %w", err)
+	}
+	if !exists {
+		return apperrors.ErrNotFound
+	}
+	return nil
 }
 
 // connectionState reads the connection's own health into the card's
@@ -157,10 +198,10 @@ func connectionState(conn connection, now time.Time) crmcontracts.FinanceSummary
 // conversion rate withholds the whole total rather than reporting the sum of
 // the rows that happened to convert.
 func (s *Store) fillFigures(
-	ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID,
+	ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID, conn connection,
 	out *crmcontracts.OrganizationFinanceSummary,
 ) error {
-	invoices, currency, err := readInvoices(ctx, tx, orgID)
+	invoices, currency, err := readInvoices(ctx, tx, orgID, conn.id)
 	if err != nil {
 		return err
 	}
@@ -181,13 +222,17 @@ func (s *Store) fillFigures(
 	// Below the sample floor the answer is "not enough settled invoices to
 	// say" — which is why it is a flag on the formula rather than a zero, and
 	// why the figure is left absent here rather than reported as 0 days.
+	// Both readings ride the SAME sample floor. Below it the answer is "not
+	// enough settled invoices to say", and a sparkline drawn from one invoice
+	// is a payment-behaviour claim made from an anecdote — the picture would
+	// state what the number refuses to.
 	timeliness := TimelinessOver(invoices, now)
 	if !timeliness.InsufficientSample {
 		median := timeliness.MedianDaysLate
-		out.MedianDaysToPay = &median
+		out.MedianDaysAfterDue = &median
+		out.PaymentBehaviour = paymentBehaviour(invoices, now)
 	}
-	out.PaymentBehaviour = paymentBehaviour(invoices, now)
-	return s.fillRecent(ctx, tx, orgID, out)
+	return s.fillRecent(ctx, tx, orgID, conn.id, out)
 }
 
 // paymentBehaviour is the sparkline's series: days late per settled invoice,
@@ -220,16 +265,16 @@ func money(minor int64, currency string) *crmcontracts.Money {
 // there are more. A capped list that stays silent about the cap reads as the
 // whole ledger.
 func (s *Store) fillRecent(
-	ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID,
+	ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID, connectionID ids.UUID,
 	out *crmcontracts.OrganizationFinanceSummary,
 ) error {
 	rows, err := tx.Query(ctx, `
 		SELECT id, number, issued_at, due_at, fully_paid_at, status, currency,
 		       gross_minor, open_minor
 		  FROM finance_invoice
-		 WHERE organization_id = $1 AND archived_at IS NULL
+		 WHERE organization_id = $1 AND connection_id = $2 AND archived_at IS NULL
 		 ORDER BY issued_at DESC, id DESC
-		 LIMIT $2`, orgID, recentInvoiceLimit+1)
+		 LIMIT $3`, orgID, connectionID, recentInvoiceLimit+1)
 	if err != nil {
 		return fmt.Errorf("read recent invoices: %w", err)
 	}
@@ -315,16 +360,27 @@ func scanRecentInvoice(rows pgx.Rows, now time.Time) (crmcontracts.FinanceInvoic
 // is wired through, a summary with no single currency reports no money figure
 // rather than a sum wearing the wrong symbol.
 func readInvoices(
-	ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID,
+	ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID, connectionID ids.UUID,
 ) ([]Invoice, string, error) {
+	// The amounts are converted HERE, at each invoice's own frozen rate
+	// (FIN-PARAM-7/DM-FX-4), because the formulas' fields are base-currency by
+	// contract. An invoice with no rate keeps its issued amounts and is marked
+	// — the formulas refuse the whole figure on one of those (FIN-AC-6), which
+	// they can only do if the row reaches them.
+	//
+	// Rounded to the nearest minor unit rather than truncated: consistently
+	// rounding down turns a hundred invoices into a total that is quietly
+	// short.
 	rows, err := tx.Query(ctx, `
 		SELECT status, issued_at, due_at, fully_paid_at, currency,
-		       net_minor, credited_minor, open_minor,
+		       round(net_minor * coalesce(fx_rate_to_base, 1))::bigint,
+		       round(credited_minor * coalesce(fx_rate_to_base, 1))::bigint,
+		       round(open_minor * coalesce(fx_rate_to_base, 1))::bigint,
 		       credits_invoice_id IS NOT NULL, disputed_at IS NOT NULL,
 		       fx_rate_to_base IS NULL
 		  FROM finance_invoice
-		 WHERE organization_id = $1 AND archived_at IS NULL
-		 ORDER BY issued_at ASC, id ASC`, orgID)
+		 WHERE organization_id = $1 AND connection_id = $2 AND archived_at IS NULL
+		 ORDER BY issued_at ASC, id ASC`, orgID, connectionID)
 	if err != nil {
 		return nil, "", fmt.Errorf("read invoices: %w", err)
 	}

--- a/backend/internal/modules/finance/summary.go
+++ b/backend/internal/modules/finance/summary.go
@@ -1,0 +1,360 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package finance
+
+// The company page's finance read: does this customer pay us, and on time?
+//
+// The whole file turns on one distinction. Six things can be true of an
+// account's money — no source connected, a source connected but this customer
+// unmapped, a first sync still running, current figures, figures from a while
+// ago, and a failed refresh — and five of them render as identical blank
+// numbers if the state is not carried alongside them. So the state is resolved
+// first and the figures are computed only where they mean something.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	openapi_types "github.com/oapi-codegen/runtime/types"
+
+	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/platform/auth"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+)
+
+// recentInvoiceLimit is how many invoices the card carries (FIN-LIM-4). Past a
+// handful the reader is scanning a ledger, which is the accounting system's
+// job; `truncated` says there are more.
+const recentInvoiceLimit = 5
+
+// SummaryFor answers the finance card for one organization.
+func (s *Store) SummaryFor(
+	ctx context.Context, orgID ids.OrganizationID,
+) (crmcontracts.OrganizationFinanceSummary, error) {
+	if err := auth.Require(ctx, "finance", principal.ActionRead); err != nil {
+		return crmcontracts.OrganizationFinanceSummary{}, err
+	}
+	out := crmcontracts.OrganizationFinanceSummary{
+		OrganizationId: openapi_types.UUID(orgID.UUID),
+		State:          crmcontracts.FinanceSummaryStateNoConnection,
+	}
+	err := s.tx(ctx, func(tx pgx.Tx) error {
+		// The account itself is row-scoped, and a finance grant is not a
+		// licence to learn that an organization exists: an account the caller
+		// cannot see answers 404 before any figure is read.
+		if err := auth.EnsureVisible(ctx, tx, "organization", orgID.UUID); err != nil {
+			return err
+		}
+		conn, connected, err := readConnection(ctx, tx)
+		if err != nil {
+			return err
+		}
+		if !connected {
+			// No accounting source at all. Not an error and not an empty
+			// account — the installation has simply not connected one.
+			return nil
+		}
+		out.Provider = &conn.provider
+		out.LastSyncedAt = conn.lastSuccessAt
+		linked, err := organizationIsLinked(ctx, tx, orgID)
+		if err != nil {
+			return err
+		}
+		if !linked {
+			// A source is connected but nobody has said which of its customers
+			// this is. The fix is a mapping, not a sync, and the card must say
+			// so rather than showing an account that owes nothing.
+			out.State = crmcontracts.FinanceSummaryStateUnmapped
+			return nil
+		}
+		out.State = connectionState(conn, s.now())
+		return s.fillFigures(ctx, tx, orgID, &out)
+	})
+	if err != nil {
+		return crmcontracts.OrganizationFinanceSummary{}, err
+	}
+	return out, nil
+}
+
+// connection is the installation's accounting source, reduced to what the
+// summary reads.
+type connection struct {
+	provider      string
+	status        string
+	lastSuccessAt *time.Time
+}
+
+// readConnection resolves the workspace's live connection, or nil when there
+// is none. One installation, one source (A107/ADR-0061), so the newest live
+// row is the answer rather than a set.
+// `found` is false when the installation has connected no accounting source.
+// That is not an error and not a sentinel worth minting — it is the ordinary
+// state of an installation that has not been set up yet, and the card's
+// `no_connection` renders it.
+func readConnection(ctx context.Context, tx pgx.Tx) (conn connection, found bool, err error) {
+	err = tx.QueryRow(ctx, `
+		SELECT provider, status, last_success_at
+		  FROM finance_connection
+		 WHERE archived_at IS NULL AND status <> 'disconnected'
+		 ORDER BY created_at DESC
+		 LIMIT 1`).Scan(&conn.provider, &conn.status, &conn.lastSuccessAt)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return connection{}, false, nil
+	}
+	if err != nil {
+		return connection{}, false, fmt.Errorf("read the finance connection: %w", err)
+	}
+	return conn, true, nil
+}
+
+// organizationIsLinked answers whether anyone has mapped an accounting
+// customer onto this organization. A link is a deliberate act and never
+// inferred from a name match — FIN-AC-7's unmapped state exists because
+// guessing which customer is which company is how money lands on the wrong
+// account.
+func organizationIsLinked(ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID) (bool, error) {
+	var exists bool
+	err := tx.QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1 FROM finance_customer_link
+			 WHERE organization_id = $1 AND archived_at IS NULL)`, orgID).Scan(&exists)
+	if err != nil {
+		return false, fmt.Errorf("read the customer link: %w", err)
+	}
+	return exists, nil
+}
+
+// connectionState reads the connection's own health into the card's
+// vocabulary.
+//
+// A failed attempt does NOT hide the figures: the last good answer is more
+// useful than a blank card, as long as the reader is told it is not current.
+// That is the difference between `error` and `no_connection`.
+func connectionState(conn connection, now time.Time) crmcontracts.FinanceSummaryState {
+	if conn.status == "error" {
+		return crmcontracts.FinanceSummaryStateError
+	}
+	if conn.lastSuccessAt == nil {
+		// Connected, never synced: the first pass has not finished, so the
+		// figures below are partial rather than final.
+		return crmcontracts.FinanceSummaryStateSyncing
+	}
+	if now.Sub(*conn.lastSuccessAt) > staleAfter {
+		return crmcontracts.FinanceSummaryStateStale
+	}
+	return crmcontracts.FinanceSummaryStateConnected
+}
+
+// fillFigures computes the card's readings from the account's own invoices.
+//
+// Every figure is left ABSENT rather than zero when it cannot be computed
+// (FIN-AC-2), and the formulas' own refusals are honoured: one invoice with no
+// conversion rate withholds the whole total rather than reporting the sum of
+// the rows that happened to convert.
+func (s *Store) fillFigures(
+	ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID,
+	out *crmcontracts.OrganizationFinanceSummary,
+) error {
+	invoices, currency, err := readInvoices(ctx, tx, orgID)
+	if err != nil {
+		return err
+	}
+	if len(invoices) == 0 {
+		// A mapped customer with no invoices is a real answer, and it is not
+		// "€0 open" — we have simply never billed them. The figures stay
+		// absent and the card says the state.
+		return nil
+	}
+	now := s.now()
+	if net := NetInvoicedOver(invoices, now); !net.RateUnavailable {
+		out.NetInvoiced = money(net.AmountMinorBase, currency)
+	}
+	if open := OpenBalanceAt(invoices, now); !open.RateUnavailable {
+		out.OpenBalance = money(open.OpenMinorBase, currency)
+		out.Overdue = money(open.OverdueMinorBase, currency)
+	}
+	// Below the sample floor the answer is "not enough settled invoices to
+	// say" — which is why it is a flag on the formula rather than a zero, and
+	// why the figure is left absent here rather than reported as 0 days.
+	timeliness := TimelinessOver(invoices, now)
+	if !timeliness.InsufficientSample {
+		median := timeliness.MedianDaysLate
+		out.MedianDaysToPay = &median
+	}
+	out.PaymentBehaviour = paymentBehaviour(invoices, now)
+	return s.fillRecent(ctx, tx, orgID, out)
+}
+
+// paymentBehaviour is the sparkline's series: days late per settled invoice,
+// oldest first. It rides the same window the median does, so the picture and
+// the number cannot describe different months.
+//
+// Never padded. A zero here reads as "paid exactly on time", so an invoice
+// with no due date contributes nothing rather than a false on-time mark.
+func paymentBehaviour(invoices []Invoice, asOf time.Time) *[]int {
+	from := asOf.AddDate(0, 0, -TimelinessWindowDays)
+	series := make([]int, 0, len(invoices))
+	for _, inv := range invoices {
+		if inv.FullyPaidAt == nil || inv.FullyPaidAt.Before(from) {
+			continue
+		}
+		if late, ok := DaysLate(inv); ok {
+			series = append(series, late)
+		}
+	}
+	return &series
+}
+
+func money(minor int64, currency string) *crmcontracts.Money {
+	amount := minor
+	code := currency
+	return &crmcontracts.Money{AmountMinor: &amount, Currency: &code}
+}
+
+// fillRecent carries the handful of invoices the card lists, and says whether
+// there are more. A capped list that stays silent about the cap reads as the
+// whole ledger.
+func (s *Store) fillRecent(
+	ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID,
+	out *crmcontracts.OrganizationFinanceSummary,
+) error {
+	rows, err := tx.Query(ctx, `
+		SELECT id, number, issued_at, due_at, fully_paid_at, status, currency,
+		       gross_minor, open_minor
+		  FROM finance_invoice
+		 WHERE organization_id = $1 AND archived_at IS NULL
+		 ORDER BY issued_at DESC, id DESC
+		 LIMIT $2`, orgID, recentInvoiceLimit+1)
+	if err != nil {
+		return fmt.Errorf("read recent invoices: %w", err)
+	}
+	defer rows.Close()
+	recent := make([]crmcontracts.FinanceInvoice, 0, recentInvoiceLimit)
+	truncated := false
+	for rows.Next() {
+		if len(recent) == recentInvoiceLimit {
+			// The extra row exists only to answer "are there more", and is
+			// never rendered.
+			truncated = true
+			break
+		}
+		invoice, scanErr := scanRecentInvoice(rows, s.now())
+		if scanErr != nil {
+			return scanErr
+		}
+		recent = append(recent, invoice)
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("read recent invoices: %w", err)
+	}
+	out.RecentInvoices = &recent
+	out.Truncated = &truncated
+	return nil
+}
+
+func scanRecentInvoice(rows pgx.Rows, now time.Time) (crmcontracts.FinanceInvoice, error) {
+	var (
+		id       ids.UUID
+		number   *string
+		issued   time.Time
+		due      *time.Time
+		paid     *time.Time
+		status   string
+		currency string
+		gross    int64
+		open     int64
+	)
+	if err := rows.Scan(&id, &number, &issued, &due, &paid, &status,
+		&currency, &gross, &open); err != nil {
+		return crmcontracts.FinanceInvoice{}, fmt.Errorf("scan invoice: %w", err)
+	}
+	out := crmcontracts.FinanceInvoice{
+		Id:         openapi_types.UUID(id),
+		Number:     number,
+		IssuedAt:   openapi_types.Date{Time: issued},
+		Status:     crmcontracts.FinanceInvoiceStatus(status),
+		Currency:   currency,
+		GrossMinor: gross,
+		OpenMinor:  open,
+	}
+	if due != nil {
+		out.DueAt = &openapi_types.Date{Time: *due}
+	}
+	out.PaidAt = paid
+	if late, ok := DaysLate(Invoice{
+		Status: status, IssuedOn: issued, DueOn: due, FullyPaidAt: paid,
+		OpenMinorBase: open,
+	}); ok {
+		out.DaysLate = &late
+	} else if due != nil && open > 0 && now.After(*due) {
+		// Still open and past due: lateness is measured against today rather
+		// than against a settlement that has not happened.
+		running := int(now.Sub(*due).Hours() / 24)
+		out.DaysLate = &running
+	}
+	return out, nil
+}
+
+// readInvoices loads the account's mirrored invoices in the shape the formulas
+// read, and reports the currency they are stated in.
+//
+// The base-currency conversion is deliberately NOT done here. Every invoice
+// carries the rate frozen at its own issue date (DM-FX-4), and an invoice
+// whose issue date had no effective rate is marked rather than skipped — the
+// formulas refuse the whole figure on one of those (FIN-AC-6), which they can
+// only do if the row reaches them.
+//
+// `currency` is the issued currency when the account bills in exactly one, and
+// empty otherwise. A mixed-currency account has no single label for a total,
+// and the formulas' own conversion is what produces one — until the rate sheet
+// is wired through, a summary with no single currency reports no money figure
+// rather than a sum wearing the wrong symbol.
+func readInvoices(
+	ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID,
+) ([]Invoice, string, error) {
+	rows, err := tx.Query(ctx, `
+		SELECT status, issued_at, due_at, fully_paid_at, currency,
+		       net_minor, credited_minor, open_minor,
+		       credits_invoice_id IS NOT NULL, disputed_at IS NOT NULL,
+		       fx_rate_to_base IS NULL
+		  FROM finance_invoice
+		 WHERE organization_id = $1 AND archived_at IS NULL
+		 ORDER BY issued_at ASC, id ASC`, orgID)
+	if err != nil {
+		return nil, "", fmt.Errorf("read invoices: %w", err)
+	}
+	defer rows.Close()
+	var out []Invoice
+	currencies := map[string]bool{}
+	for rows.Next() {
+		var (
+			inv      Invoice
+			currency string
+		)
+		if err := rows.Scan(&inv.Status, &inv.IssuedOn, &inv.DueOn, &inv.FullyPaidAt,
+			&currency, &inv.NetMinorBase, &inv.CreditedMinorBase, &inv.OpenMinorBase,
+			&inv.CreditsInvoice, &inv.Disputed, &inv.RateMissing); err != nil {
+			return nil, "", fmt.Errorf("scan invoice: %w", err)
+		}
+		currencies[currency] = true
+		out = append(out, inv)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, "", fmt.Errorf("read invoices: %w", err)
+	}
+	if len(currencies) != 1 {
+		// Zero currencies means no invoices; more than one means no single
+		// label. Both leave the money figures absent, which is the honest
+		// answer either way.
+		return out, "", nil
+	}
+	for currency := range currencies {
+		return out, currency, nil
+	}
+	return out, "", nil
+}

--- a/backend/internal/modules/identity/internal/policy/policy.go
+++ b/backend/internal/modules/identity/internal/policy/policy.go
@@ -21,7 +21,7 @@ import (
 // (features/04 §1). A policy naming anything else is rejected — a typo'd
 // object would otherwise silently grant nothing and read as a bug in the
 // role, not the document.
-var coreObjects = []string{"person", "organization", "deal", "lead", "activity", "pipeline", "list", "tag", "relationship", "partner", "automation", "voice_profile", "product", "offer", "signal", "saved_view", "custom_field", "computed_field", "quota", "offer_template", "overlay_connection", "embedding_reindex", "webhook_subscription", "fx_rate", "ai_model_rate", "capture_settings", "project", "channel_connection", "import_run", "installation_settings"}
+var coreObjects = []string{"person", "organization", "deal", "lead", "activity", "pipeline", "list", "tag", "relationship", "partner", "automation", "voice_profile", "product", "offer", "signal", "saved_view", "custom_field", "computed_field", "quota", "offer_template", "overlay_connection", "embedding_reindex", "webhook_subscription", "fx_rate", "ai_model_rate", "capture_settings", "project", "channel_connection", "import_run", "installation_settings", "finance"}
 
 // IsCoreObject reports whether an RBAC object is in the closed set a role
 // document may grant. Parse enforces it on stored documents; it is also the
@@ -113,11 +113,11 @@ var (
 // and migrate-in screens are admin surfaces.
 var defaults = map[string]Document{
 	"admin": {
-		Objects:  objects(crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, readOnly, crud, crud, crud, readUpdate, crud, writeNoDelete, writeNoDelete, readUpdate, crud, crud, crud, readUpdate),
+		Objects:  objects(crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, readOnly, crud, crud, crud, readUpdate, crud, writeNoDelete, writeNoDelete, readUpdate, crud, crud, crud, readUpdate, crud),
 		RowScope: principal.RowScopeAll,
 	},
 	"manager": {
-		Objects:  objects(crud, crud, crud, crud, crud, readOnly, crud, crud, crud, crud, readOnly, crud, crud, crud, crud, crud, readOnly, readOnly, readOnly, crud, readOnly, grant{}, readOnly, grant{}, grant{}, readOnly, crud, readOnly, grant{}, readOnly),
+		Objects:  objects(crud, crud, crud, crud, crud, readOnly, crud, crud, crud, crud, readOnly, crud, crud, crud, crud, crud, readOnly, readOnly, readOnly, crud, readOnly, grant{}, readOnly, grant{}, grant{}, readOnly, crud, readOnly, grant{}, readOnly, readOnly),
 		RowScope: principal.RowScopeTeam,
 	},
 	"rep": {
@@ -171,25 +171,26 @@ var defaults = map[string]Document{
 			// whether the channel is live), only admin/ops bind one.
 			readOnly,
 			grant{},   // import_run — admin/ops-only
-			readOnly), // installation_settings — everyone reads the base currency and zone
+			readOnly,  // installation_settings — the base currency and zone
+			readOnly), // finance — a rep reads whether the customer pays on time
 		RowScope: principal.RowScopeTeam,
 	},
 	"read_only": {
 		// A read-only role still owns its personal view state: saved views
 		// are P1-exempt per-user prefs (runtime-config-surface.md §3), not
 		// shared records, so full self-service is correct even here.
-		Objects:  objects(readOnly, readOnly, readOnly, readOnly, readOnly, readOnly, readOnly, readOnly, readOnly, readOnly, readOnly, readOnly, readOnly, readOnly, readOnly, crud, readOnly, readOnly, readOnly, readOnly, readOnly, grant{}, readOnly, grant{}, grant{}, readOnly, readOnly, readOnly, grant{}, readOnly),
+		Objects:  objects(readOnly, readOnly, readOnly, readOnly, readOnly, readOnly, readOnly, readOnly, readOnly, readOnly, readOnly, readOnly, readOnly, readOnly, readOnly, crud, readOnly, readOnly, readOnly, readOnly, readOnly, grant{}, readOnly, grant{}, grant{}, readOnly, readOnly, readOnly, grant{}, readOnly, readOnly),
 		RowScope: principal.RowScopeAll,
 	},
 	"ops": {
-		Objects:  objects(crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, readOnly, crud, crud, crud, readUpdate, crud, writeNoDelete, writeNoDelete, readUpdate, crud, crud, crud, readUpdate),
+		Objects:  objects(crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, readOnly, crud, crud, crud, readUpdate, crud, writeNoDelete, writeNoDelete, readUpdate, crud, crud, crud, readUpdate, crud),
 		RowScope: principal.RowScopeAll,
 	},
 }
 
 // objects zips grants onto coreObjects in declaration order — one line
 // per role instead of twelve repeated map literals.
-func objects(person, organization, deal, lead, activity, pipeline, list, tag, relationship, partner, automation, voiceProfile, product, offer, signal, savedView, customField, computedField, quota, offerTemplate, overlayConnection, embeddingReindex, webhookSubscription, fxRate, aiModelRate, captureSettings, project, channelConnection, importRun, installationSettings grant) map[string]grant {
+func objects(person, organization, deal, lead, activity, pipeline, list, tag, relationship, partner, automation, voiceProfile, product, offer, signal, savedView, customField, computedField, quota, offerTemplate, overlayConnection, embeddingReindex, webhookSubscription, fxRate, aiModelRate, captureSettings, project, channelConnection, importRun, installationSettings, finance grant) map[string]grant {
 	return map[string]grant{
 		"person": person, "organization": organization, "deal": deal,
 		"lead": lead, "activity": activity, "pipeline": pipeline,
@@ -211,6 +212,16 @@ func objects(person, organization, deal, lead, activity, pipeline, list, tag, re
 		// Read is broad on purpose — a rep reading amounts benefits from knowing
 		// which currency they are in — and only admin/ops change it.
 		"installation_settings": installationSettings,
+		// The ingested finance mirror (ADR-0083/A128). READ is broad — every
+		// role that opens a company page sees whether the customer pays on
+		// time — and connecting or disconnecting the accounting source is
+		// destructive workspace-wide config, so create/update/delete are
+		// admin/ops only, exactly like overlay_connection.
+		//
+		// No role holds a write on a finance RECORD, because there is no such
+		// action: the mirror's read-only posture is the absence of the grant
+		// (FIN-DDL-N-1), not a runtime refusal.
+		"finance": finance,
 	}
 }
 

--- a/backend/migrations/core/0204_rbac_finance_object.down.sql
+++ b/backend/migrations/core/0204_rbac_finance_object.down.sql
@@ -1,0 +1,21 @@
+-- Reverse of 0204: take the `finance` grant back out of every role document.
+--
+-- A role carrying a grant on an object the code no longer knows is not
+-- harmless: Parse rejects a document naming an object outside the closed set,
+-- so every role read would start failing. Removing the key is what makes the
+-- down actually reversible.
+--
+-- The workspace binding is required for the same reason the up needs it: role
+-- carries FORCE row-level security, and an UPDATE with no bound workspace is
+-- filtered to zero rows and reports success.
+DO $$
+DECLARE ws uuid;
+BEGIN
+  FOR ws IN SELECT id FROM workspace LOOP
+    PERFORM set_config('app.workspace_id', ws::text, true);
+
+    UPDATE role SET permissions = permissions #- '{objects,finance}'
+     WHERE permissions->'objects' ? 'finance'
+       AND role.workspace_id = ws;
+  END LOOP;
+END $$;

--- a/backend/migrations/core/0204_rbac_finance_object.up.sql
+++ b/backend/migrations/core/0204_rbac_finance_object.up.sql
@@ -1,0 +1,42 @@
+-- 0204: give every existing role a grant on the `finance` object.
+--
+-- The role seed writes each system role's permission document ONCE, at
+-- workspace creation, and never re-syncs it. So a new RBAC object works on a
+-- fresh database and 403s everywhere else, permanently — the installation that
+-- has been running for a month is exactly the one that would never see the
+-- finance panel. This is the second half of adding the object, not a
+-- convenience.
+--
+-- The grants match the registered defaults in identity's policy.go, and the
+-- reasoning is overlay_connection's: READ is broad, because every role that
+-- opens a company page should see whether the customer pays on time, and
+-- connecting or disconnecting the accounting source is destructive
+-- workspace-wide config that belongs to admin and ops.
+--
+-- No role gets create/update/delete on a finance RECORD, because there is no
+-- such action to grant: the mirror's read-only posture is the absence of the
+-- grant (FIN-DDL-N-1), and these three verbs govern the CONNECTION.
+--
+-- Only a document that does not already carry the key is touched, so an
+-- operator who has already tuned the role keeps their answer.
+DO $$
+DECLARE ws uuid;
+BEGIN
+  FOR ws IN SELECT id FROM workspace LOOP
+    PERFORM set_config('app.workspace_id', ws::text, true);
+
+    UPDATE role SET permissions = jsonb_set(
+      permissions, '{objects,finance}',
+      '{"create":true,"read":true,"update":true,"delete":true}'::jsonb)
+    WHERE (is_system AND key IN ('admin','ops')
+      AND NOT permissions->'objects' ? 'finance')
+      AND role.workspace_id = ws;
+
+    UPDATE role SET permissions = jsonb_set(
+      permissions, '{objects,finance}',
+      '{"create":false,"read":true,"update":false,"delete":false}'::jsonb)
+    WHERE (is_system AND key IN ('manager','rep','read_only')
+      AND NOT permissions->'objects' ? 'finance')
+      AND role.workspace_id = ws;
+  END LOOP;
+END $$;

--- a/backend/migrations/testdata/rbac_seeded_defaults.json
+++ b/backend/migrations/testdata/rbac_seeded_defaults.json
@@ -55,6 +55,12 @@
         "read": true,
         "update": true
       },
+      "finance": {
+        "create": true,
+        "delete": true,
+        "read": true,
+        "update": true
+      },
       "fx_rate": {
         "create": true,
         "delete": false,
@@ -240,6 +246,12 @@
         "read": false,
         "update": false
       },
+      "finance": {
+        "create": false,
+        "delete": false,
+        "read": true,
+        "update": false
+      },
       "fx_rate": {
         "create": false,
         "delete": false,
@@ -422,6 +434,12 @@
       "embedding_reindex": {
         "create": false,
         "delete": false,
+        "read": true,
+        "update": true
+      },
+      "finance": {
+        "create": true,
+        "delete": true,
         "read": true,
         "update": true
       },
@@ -610,6 +628,12 @@
         "read": false,
         "update": false
       },
+      "finance": {
+        "create": false,
+        "delete": false,
+        "read": true,
+        "update": false
+      },
       "fx_rate": {
         "create": false,
         "delete": false,
@@ -793,6 +817,12 @@
         "create": false,
         "delete": false,
         "read": false,
+        "update": false
+      },
+      "finance": {
+        "create": false,
+        "delete": false,
+        "read": true,
         "update": false
       },
       "fx_rate": {

--- a/docs/reference/rbac-matrix.md
+++ b/docs/reference/rbac-matrix.md
@@ -68,6 +68,7 @@ the workspace but changes none of them.
 | `custom_field` | CRUD | -R-- | -R-- | -R-- | CRUD |
 | `deal` | CRUD | CRUD | CRU- | -R-- | CRUD |
 | `embedding_reindex` | -RU- | ---- | ---- | ---- | -RU- |
+| `finance` | CRUD | -R-- | -R-- | -R-- | CRUD |
 | `fx_rate` | CRU- | ---- | ---- | ---- | CRU- |
 | `import_run` | CRUD | ---- | ---- | ---- | CRUD |
 | `installation_settings` | -RU- | -R-- | -R-- | -R-- | -RU- |

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -8084,9 +8084,15 @@ export interface components {
             open_balance?: components["schemas"]["Money"];
             /** @description The share of the open balance already past its due date. */
             overdue?: components["schemas"]["Money"];
-            /** @description The median days between issue and settlement over the window (FIN-FORM-3). Absent when too few invoices have settled to say — a median of one invoice is an anecdote. */
-            median_days_to_pay?: number | null;
-            /** @description Days-late per settled invoice, oldest first, for the sparkline. Empty when nothing settled inside the window; never padded with zeroes, because a zero here reads as "paid exactly on time". */
+            /**
+             * @description The median days between an invoice's DUE date and its settlement over the window (FIN-FORM-3) — how late they pay, not how long they take. Negative reads as early. Deliberately not issue-to-settlement: an invoice paid on the last day of 30-day terms is punctual, and a figure that called it "30 days to pay" would read as slow.
+             *     Absent when too few invoices have settled to say — a median of one invoice is an anecdote, not a payment habit.
+             */
+            median_days_after_due?: number | null;
+            /**
+             * @description Days-late per settled invoice, oldest first, for the sparkline. Never padded with zeroes, because a zero here reads as "paid exactly on time".
+             *     Absent under the same sample floor the median observes: a shape drawn from one invoice would state a payment habit the number beside it refuses to.
+             */
             payment_behaviour?: number[];
             /** @description The five most recent invoices (FIN-LIM-4); `truncated` says whether there are more. */
             recent_invoices?: components["schemas"]["FinanceInvoice"][];

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -1304,6 +1304,40 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/organizations/{id}/finance-summary": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Opaque resource id (UUID; ordering semantics are not exposed). */
+                id: components["parameters"]["Id"];
+            };
+            cookie?: never;
+        };
+        /**
+         * Does this customer actually pay us, and on time?
+         * @description The finance card's whole read (FIN-WIRE-1, ADR-0083/A128): what we have
+         *     invoiced, what is still open, and how they pay — plus the handful of recent
+         *     invoices the card shows.
+         *
+         *     **`state` is the answer, not a decoration.** A page that renders figures
+         *     without it cannot tell "they owe nothing" from "no accounting source is
+         *     connected", and those are opposite facts about a customer. Every figure is
+         *     absent rather than zero when it cannot be computed (FIN-AC-2): €0 open is a
+         *     claim that they are square with us, and it must be earned.
+         *
+         *     Read-only, like everything in the mirror. The connection is managed
+         *     elsewhere; this endpoint only reads what the last sync brought back.
+         */
+        get: operations["getOrganizationFinanceSummary"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/organizations/{id}/facts": {
         parameters: {
             query?: never;
@@ -8025,6 +8059,88 @@ export interface components {
             /** Format: uuid */
             entity_id: string;
         };
+        /**
+         * @description What the accounting mirror knows about one customer (ADR-0083/A128).
+         *
+         *     Every figure is nullable and ABSENT when it cannot be computed, never zero
+         *     (FIN-AC-2). "€0 open" says the customer is square with us; "no figure" says
+         *     we do not know. A card that renders the second as the first tells a rep an
+         *     account is healthy on the strength of a missing connector.
+         */
+        OrganizationFinanceSummary: {
+            /** Format: uuid */
+            organization_id: string;
+            state: components["schemas"]["FinanceSummaryState"];
+            /** @description Which accounting source this came from, in the source's own words ("offline_demo"). Rendered as a label beside the figures so a reader knows what they are looking at; absent when nothing is connected. */
+            provider?: string | null;
+            /**
+             * Format: date-time
+             * @description When the last successful sync finished. Null when none has.
+             */
+            last_synced_at?: string | null;
+            /** @description Issued minus credited over the last 365 days (FIN-FORM-1). Named "net invoiced" rather than "revenue": the source supports issued amounts, not a ledger revenue figure, and calling one the other is the kind of small wrong label a reader plans against. */
+            net_invoiced?: components["schemas"]["Money"];
+            /** @description What is still open across unpaid invoices (FIN-FORM-2). */
+            open_balance?: components["schemas"]["Money"];
+            /** @description The share of the open balance already past its due date. */
+            overdue?: components["schemas"]["Money"];
+            /** @description The median days between issue and settlement over the window (FIN-FORM-3). Absent when too few invoices have settled to say — a median of one invoice is an anecdote. */
+            median_days_to_pay?: number | null;
+            /** @description Days-late per settled invoice, oldest first, for the sparkline. Empty when nothing settled inside the window; never padded with zeroes, because a zero here reads as "paid exactly on time". */
+            payment_behaviour?: number[];
+            /** @description The five most recent invoices (FIN-LIM-4); `truncated` says whether there are more. */
+            recent_invoices?: components["schemas"]["FinanceInvoice"][];
+            /** @description True when the account has more invoices than `recent_invoices` carries. */
+            truncated?: boolean;
+        };
+        /**
+         * @description Why the figures are what they are — the six cases a company page must keep
+         *     apart, because five of them look identical if you only render the numbers.
+         *
+         *     `no_connection` — no accounting source is configured for this installation.
+         *     `unmapped` — a source is connected, but nobody has said which of its
+         *     customers this organization is. The figures are absent, and the fix is a
+         *     mapping rather than a sync.
+         *     `syncing` — the first pass has not finished; figures may be partial.
+         *     `connected` — the figures are current.
+         *     `stale` — the last sync succeeded, but long enough ago that the reader
+         *     should see the date beside the number.
+         *     `error` — the last attempt failed. What is shown is the last good answer,
+         *     and the reader is told it is not current.
+         * @enum {string}
+         */
+        FinanceSummaryState: "no_connection" | "unmapped" | "syncing" | "connected" | "stale" | "error";
+        /** @description One mirrored invoice, in the currency it was issued in. */
+        FinanceInvoice: {
+            /** Format: uuid */
+            id: string;
+            /** @description The source's own invoice number, absent when it does not issue one. */
+            number?: string | null;
+            /** Format: date */
+            issued_at: string;
+            /** Format: date */
+            due_at?: string | null;
+            /**
+             * Format: date-time
+             * @description When it was settled in full. Null while anything is still open.
+             */
+            paid_at?: string | null;
+            /** @enum {string} */
+            status: "draft" | "open" | "partially_paid" | "paid" | "overdue" | "disputed" | "credited" | "void";
+            currency: string;
+            /**
+             * Format: int64
+             * @description The invoiced total in minor units.
+             */
+            gross_minor: number;
+            /**
+             * Format: int64
+             * @description What is still unpaid on it.
+             */
+            open_minor: number;
+            /** @description Days between the due date and settlement, or between the due date and today while it is still open. Absent when the invoice carries no due date — lateness against no deadline is not a reading. */
+            days_late?: number | null;
+        };
         /** @description The per-user "I have seen this record" baseline, after an acknowledgment. */
         RecordViewAck: {
             /** @enum {string} */
@@ -10720,7 +10836,7 @@ export interface components {
          *     The SERVER does not derive from it. `identity/internal/policy.coreObjects` is maintained separately (oapi-codegen emits nothing for a top-level standalone string enum, so there are no generated Go constants to derive from), and a typo there is an ordinary runtime value, not a compile error. What keeps the two honest is a merge-blocking parity test, `backend/rbacvocabulary_test.go`, which holds this enum equal to that list. Editing this enum alone changes what clients can express, never what the server enforces — change both, and the gate will say so if you do not.
          * @enum {string}
          */
-        RbacObject: "person" | "organization" | "deal" | "lead" | "activity" | "pipeline" | "list" | "tag" | "relationship" | "partner" | "automation" | "voice_profile" | "product" | "offer" | "signal" | "saved_view" | "custom_field" | "computed_field" | "quota" | "offer_template" | "overlay_connection" | "embedding_reindex" | "webhook_subscription" | "fx_rate" | "ai_model_rate" | "capture_settings" | "project" | "channel_connection" | "import_run" | "installation_settings";
+        RbacObject: "person" | "organization" | "deal" | "lead" | "activity" | "pipeline" | "list" | "tag" | "relationship" | "partner" | "automation" | "voice_profile" | "product" | "offer" | "signal" | "saved_view" | "custom_field" | "computed_field" | "quota" | "offer_template" | "overlay_connection" | "embedding_reindex" | "webhook_subscription" | "fx_rate" | "ai_model_rate" | "capture_settings" | "project" | "channel_connection" | "import_run" | "installation_settings" | "finance";
         /**
          * @description The four object-level verbs a grant carries (data-model §2.4). These are RBAC actions, not HTTP methods: the seat ceiling is clamped on the method independently, and the two diverge in both directions — a read-seat GET that the object grants, and a mutating route whose RBAC action is `read`.
          * @enum {string}
@@ -15604,6 +15720,32 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["RelationshipStrength"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            404: components["responses"]["NotFound"];
+        };
+    };
+    getOrganizationFinanceSummary: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Opaque resource id (UUID; ordering semantics are not exposed). */
+                id: components["parameters"]["Id"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The account's finance summary, in whatever state it is in. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OrganizationFinanceSummary"];
                 };
             };
             401: components["responses"]["Unauthorized"];


### PR DESCRIPTION
`GET /organizations/{id}/finance-summary` is the finance card's whole read
(FIN-WIRE-1, ADR-0083/A128). The tables landed with migration 0202 and the
formulas with their own tests; this is the module that reads them.

**`state` is the answer, not a decoration.** Six things can be true of an
account's money — no source connected, a source connected but this customer
unmapped, a first sync still running, current figures, figures from
yesterday, and a failed refresh — and five of them render as identical
blank numbers if the state is not carried beside them. So the state is
resolved first and the figures are computed only where they mean something.

Every figure is absent rather than zero when it cannot be computed
(FIN-AC-2). "€0 open" says the customer is square with us and has to be
earned; "no figure" says we do not know. A mapped customer we have never
billed reports no figures rather than a healthy-looking zero, and a
mixed-currency account reports none either — the formulas' own conversion
is what produces a single label, and until the rate sheet is wired through,
a sum wearing the wrong symbol is worse than no sum.

The formulas' refusals are honoured rather than worked around: one invoice
whose issue date had no conversion rate withholds the WHOLE total
(FIN-AC-6), and a median over fewer than five settled invoices is
"not enough to say" rather than a number.

**A finance grant is not a licence to learn an account exists.** The
organization's own row scope is checked before any figure is read, so an
account the caller cannot see answers 404 rather than a summary.

**No write, anywhere.** There is no create, update or delete on a finance
record in the module — the read-only posture (FIN-DDL-N-1) is the absence
of the code path, where a contributor would look for the write.

The `finance` RBAC object comes with its backfill (core 0204), which is the
half that is easy to forget: the role seed writes each document once at
workspace creation and never re-syncs, so a new object works on a fresh
database and 403s on every installation that has been running a while.
READ is broad for the same reason overlay_connection's is — every role that
opens a company page should see whether the customer pays — and
create/update/delete govern the CONNECTION and belong to admin and ops.

Verified against the running app: the endpoint answers `no_connection` on
an installation with no accounting source, with no figures beside it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a read-only finance summary endpoint for organization pages to show whether a customer pays on time and key invoice metrics. Fixes currency conversion, state handling, and sample logic so figures are accurate and trustworthy.

- **New Features**
  - `GET /organizations/{id}/finance-summary` returns `OrganizationFinanceSummary` with `state` (`no_connection|unmapped|syncing|connected|stale|error`).
  - Figures are nullable when unknown; mixed-currency or missing FX shows no totals; `median_days_after_due` omitted when the sample is too small; `payment_behaviour` uses the same sample floor; per-invoice `days_late`.
  - Lists up to 5 recent invoices with `truncated`; includes `provider` and `last_synced_at`; no figures while the first sync is running.
  - Enforces row-scope and existence; returns 404 when the org is not visible or does not exist. Read-only module (no writes).
  - RBAC: adds `finance` object (read for all roles; create/update/delete for admin and ops), backfilled via migration 0204. OpenAPI, server wiring, docs, and frontend `schema.d.ts` updated.

- **Bug Fixes**
  - Totals convert to base currency at each invoice’s frozen FX rate (rounded); refuse totals when any rate is missing.
  - Scope links, invoices, and recents to the live connection only.
  - Return 404 for nonexistent org IDs even under `row_scope=all`.
  - Rename “median days to pay” to `median_days_after_due` (measured due-to-settlement).
  - Align sparkline with the median’s sample floor; never pad with zeros.

<sup>Written for commit d0568b3e6fdc91ca9716af458e972ab817d2d0fe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/757?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a read-only organization finance summary endpoint.
  - Finance summaries include connection status, sync details, invoice metrics, payment behavior, lateness data, and recent invoices.
  - Added support for finance access controls, with read access for standard roles and full access for administrators and operations.

- **Documentation**
  - Updated the permissions matrix to document finance access levels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->