### PR TITLE
feat(company): the coverage line, with only the counts the page can total

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -739,6 +739,9 @@ export const de = {
   "commercial.offer.rejected": "Abgelehnt",
   "commercial.offer.expired": "Abgelaufen",
   "commercial.offer.superseded": "Ersetzt",
+  "co.coverage.contacts": "{count} Kontakte",
+  "co.coverage.untried": "{count} nie angeschrieben",
+  "co.coverage.gaps": "{count} Rollenlücken",
   "co.section.restricted":
     "Ausgeblendet \u2014 deine Rolle darf das nicht lesen",
   "co.section.unsupported":

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -740,6 +740,7 @@ export const de = {
   "commercial.offer.expired": "Abgelaufen",
   "commercial.offer.superseded": "Ersetzt",
   "co.coverage.contacts": "{count} Kontakte",
+  "co.coverage.contactsAtLeast": "{count}+ Kontakte",
   "co.coverage.untried": "{count} nie angeschrieben",
   "co.coverage.gaps": "{count} Rollenlücken",
   "co.section.restricted":

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -737,6 +737,9 @@ export const en = {
   "commercial.offer.rejected": "Rejected",
   "commercial.offer.expired": "Expired",
   "commercial.offer.superseded": "Superseded",
+  "co.coverage.contacts": "{count} contacts",
+  "co.coverage.untried": "{count} never written to",
+  "co.coverage.gaps": "{count} role gaps",
   "co.section.restricted": "Hidden \u2014 your role cannot read this",
   "co.section.unsupported":
     "Not available in this mode \u2014 the connected system does not hold it",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -738,6 +738,7 @@ export const en = {
   "commercial.offer.expired": "Expired",
   "commercial.offer.superseded": "Superseded",
   "co.coverage.contacts": "{count} contacts",
+  "co.coverage.contactsAtLeast": "{count}+ contacts",
   "co.coverage.untried": "{count} never written to",
   "co.coverage.gaps": "{count} role gaps",
   "co.section.restricted": "Hidden \u2014 your role cannot read this",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -739,6 +739,7 @@ export const vi = {
   "commercial.offer.expired": "Hết hạn",
   "commercial.offer.superseded": "Đã thay thế",
   "co.coverage.contacts": "{count} liên hệ",
+  "co.coverage.contactsAtLeast": "{count}+ liên hệ",
   "co.coverage.untried": "{count} chưa từng viết cho",
   "co.coverage.gaps": "{count} vai trò còn trống",
   "co.section.restricted": "Đã ẩn — vai trò của bạn không đọc được phần này",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -738,6 +738,9 @@ export const vi = {
   "commercial.offer.rejected": "Đã từ chối",
   "commercial.offer.expired": "Hết hạn",
   "commercial.offer.superseded": "Đã thay thế",
+  "co.coverage.contacts": "{count} liên hệ",
+  "co.coverage.untried": "{count} chưa từng viết cho",
+  "co.coverage.gaps": "{count} vai trò còn trống",
   "co.section.restricted": "Đã ẩn — vai trò của bạn không đọc được phần này",
   "co.section.unsupported":
     "Không có ở chế độ này — hệ thống đang kết nối không lưu dữ liệu đó",

--- a/frontend/src/screens/company360.tsx
+++ b/frontend/src/screens/company360.tsx
@@ -415,6 +415,42 @@ export function SectionPart({
   );
 }
 
+// The coverage line the mockup draws above the contact rows: how many
+// contacts, how many nobody has written to, how many roles are unfilled.
+//
+// ONLY counts this page can total. The mockup also carries "11 connected
+// colleagues", which would mean summing each contact's routes — and those are
+// capped at the top three by strength, so the sum would count the same
+// colleague once per contact they know and report a bigger team than exists.
+// A number nobody can check is worse than a shorter line.
+//
+// Silent when the contact list was truncated: "7 contacts" off a capped page
+// is a count of the page, not of the account.
+function CoverageSummary({
+  contacts,
+  untried,
+  gaps,
+  truncated,
+}: Readonly<{
+  contacts: readonly Contact[];
+  untried: number;
+  gaps: number;
+  truncated: boolean;
+}>) {
+  const t = useT();
+  if (truncated || contacts.length === 0) {
+    return null;
+  }
+  const parts = [t("co.coverage.contacts", { count: contacts.length })];
+  if (untried > 0) {
+    parts.push(t("co.coverage.untried", { count: untried }));
+  }
+  if (gaps > 0) {
+    parts.push(t("co.coverage.gaps", { count: gaps }));
+  }
+  return <p className="co-empty">{parts.join(" · ")}</p>;
+}
+
 /**
  * SectionCard is the one shape a single-section rail card takes.
  *
@@ -535,6 +571,14 @@ export function PeopleCard({
         contacts.length,
       )}
       emptyLabel={t("co.people.empty")}
+      footer={
+        <CoverageSummary
+          contacts={contacts}
+          untried={untried.length}
+          gaps={missing.length}
+          truncated={truncated}
+        />
+      }
       // The per-row coverage says who to call. The explorer answers the other
       // question — where are we thin — for a handful of colleagues the reader
       // picks, rather than a column per person on a forty-strong team.

--- a/frontend/src/screens/company360.tsx
+++ b/frontend/src/screens/company360.tsx
@@ -431,21 +431,36 @@ function CoverageSummary({
   untried,
   gaps,
   truncated,
+  routesReadable,
 }: Readonly<{
   contacts: readonly Contact[];
   untried: number;
   gaps: number;
   truncated: boolean;
+  // Whether the routes this page read carry an answer at all. "Never written
+  // to" is derived from who has exchanged messages with whom, so a reader
+  // without that access must not be handed the aggregate — an activity-derived
+  // count is still activity data.
+  routesReadable: boolean;
 }>) {
   const t = useT();
-  if (truncated || contacts.length === 0) {
+  if (contacts.length === 0) {
     return null;
   }
-  const parts = [t("co.coverage.contacts", { count: contacts.length })];
-  if (untried > 0) {
+  // A truncated page still knows how many contacts it is showing, and saying
+  // "at least 25" beats saying nothing: the reader learns both that the
+  // account is large and that this is not the whole of it.
+  const parts = [
+    truncated
+      ? t("co.coverage.contactsAtLeast", { count: contacts.length })
+      : t("co.coverage.contacts", { count: contacts.length }),
+  ];
+  if (routesReadable && untried > 0) {
     parts.push(t("co.coverage.untried", { count: untried }));
   }
-  if (gaps > 0) {
+  // The gap count is only meaningful over a complete picture: a capped page
+  // hides the contacts who might hold the roles it would report as missing.
+  if (!truncated && gaps > 0) {
     parts.push(t("co.coverage.gaps", { count: gaps }));
   }
   return <p className="co-empty">{parts.join(" · ")}</p>;
@@ -577,6 +592,7 @@ export function PeopleCard({
           untried={untried.length}
           gaps={missing.length}
           truncated={truncated}
+          routesReadable={contacts.some((each) => each.routes)}
         />
       }
       // The per-row coverage says who to call. The explorer answers the other


### PR DESCRIPTION
See the commit message. The mockup's 'connected colleagues' count is deliberately absent — routes are capped at three per contact, so summing them would report a bigger team than exists.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a coverage summary line to the Company 360 People card with only counts the page can verify. Shows "25+ contacts" when the list is truncated, hides activity-derived counts without access, and avoids inflated team sizes.

- **New Features**
  - Added `CoverageSummary` and render it as the People card footer.
  - Shows: "{count} contacts" or "{count}+ contacts" when truncated; "{count} never written to" only if routes are readable; "{count} role gaps" only on full lists. Omits "connected colleagues" to avoid double-counting from capped per-contact routes.
  - Added i18n strings for `en`, `de`, and `vi`.

<sup>Written for commit ffce194cb77ed6a5de67a90b90c47e16cea26aef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/765?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

