### PR TITLE
fix(approvals): an approval answers the workspace it belongs to (#645)

### DIFF
--- a/backend/internal/modules/approvals/handlers.go
+++ b/backend/internal/modules/approvals/handlers.go
@@ -227,15 +227,16 @@ func (h Handlers) wire(a row) crmcontracts.Approval { return wire(a, h.svc.now()
 // lazy expiry in so a stale pending row never reads as approvable.
 func wire(a row, now time.Time) crmcontracts.Approval {
 	out := crmcontracts.Approval{
-		Id:         openapi_types.UUID(a.ID.UUID),
-		Kind:       a.Kind,
-		Status:     crmcontracts.ApprovalStatus(a.effectiveStatus(now)),
-		ProposedBy: a.ProposedBy,
-		CreatedAt:  a.CreatedAt,
-		DiffHash:   &a.DiffHash,
-		Summary:    a.Summary,
-		ExpiresAt:  &a.ExpiresAt,
-		DecidedAt:  a.DecidedAt,
+		Id:          openapi_types.UUID(a.ID.UUID),
+		WorkspaceId: openapi_types.UUID(a.WorkspaceID),
+		Kind:        a.Kind,
+		Status:      crmcontracts.ApprovalStatus(a.effectiveStatus(now)),
+		ProposedBy:  a.ProposedBy,
+		CreatedAt:   a.CreatedAt,
+		DiffHash:    &a.DiffHash,
+		Summary:     a.Summary,
+		ExpiresAt:   &a.ExpiresAt,
+		DecidedAt:   a.DecidedAt,
 	}
 	if a.OnBehalfOf != nil {
 		v := openapi_types.UUID(a.OnBehalfOf.UUID)

--- a/backend/internal/modules/approvals/inbox.go
+++ b/backend/internal/modules/approvals/inbox.go
@@ -27,12 +27,17 @@ import (
 
 // row is the store shape of one approval.
 type row struct {
-	ID         ids.ApprovalID
-	Kind       string
-	Status     string
-	ProposedBy string
-	OnBehalfOf *ids.UserID
-	PassportID *ids.PassportID
+	ID ids.ApprovalID
+	// WorkspaceID is read back rather than assumed from the bound GUC: the
+	// contract declares it REQUIRED on every approval the API returns, and a
+	// field the wire shape promises is either read from the row or it is a
+	// zero uuid nobody can tell from a real one.
+	WorkspaceID ids.UUID
+	Kind        string
+	Status      string
+	ProposedBy  string
+	OnBehalfOf  *ids.UserID
+	PassportID  *ids.PassportID
 	// TargetType + TargetID are the polymorphic pointer to the entity the
 	// staging acts on (deal, org, person, lead, activity, …); the id stays
 	// untyped because the pair IS the discriminated reference.
@@ -52,14 +57,14 @@ type row struct {
 	BundleID *ids.UUID
 }
 
-const columns = `id, kind, status, proposed_by, on_behalf_of, passport_id,
+const columns = `id, workspace_id, kind, status, proposed_by, on_behalf_of, passport_id,
 	target_entity_type, target_entity_id, target_version, summary,
 	proposed_change, diff_hash, expires_at, decided_by, decided_at, consumed_at, created_at,
 	bundle_id`
 
 func scan(r pgx.Row) (row, error) {
 	var a row
-	err := r.Scan(&a.ID, &a.Kind, &a.Status, &a.ProposedBy, &a.OnBehalfOf, &a.PassportID,
+	err := r.Scan(&a.ID, &a.WorkspaceID, &a.Kind, &a.Status, &a.ProposedBy, &a.OnBehalfOf, &a.PassportID,
 		&a.TargetType, &a.TargetID, &a.TargetVersion, &a.Summary,
 		&a.ProposedChange, &a.DiffHash, &a.ExpiresAt, &a.DecidedBy, &a.DecidedAt, &a.ConsumedAt, &a.CreatedAt,
 		&a.BundleID)

--- a/backend/internal/modules/approvals/wirecompleteness_test.go
+++ b/backend/internal/modules/approvals/wirecompleteness_test.go
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package approvals
+
+// A field the contract declares REQUIRED is answered, or the API is lying in a
+// way no caller can detect.
+//
+// `workspace_id` was declared required and never mapped, so every approval this
+// module has ever returned carried the zero uuid — a well-formed value in the
+// right place that happens to name no workspace. Nothing failed: not the
+// contract gate, which checks shape rather than content; not the handler tests,
+// which assert the fields they were written to assert; and not any client,
+// because a uuid of zeroes deserializes perfectly.
+//
+// So the obligation is derived from the contract type itself rather than kept
+// as a list of fields somebody remembers to extend. A REQUIRED field in OpenAPI
+// 3.1 generates as a NON-POINTER on the Go struct, and an optional one as a
+// pointer — which makes "required" mechanically readable here, and makes a
+// field the contract promotes to required tomorrow covered on the day the
+// generator runs.
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// The floor that keeps this from certifying nothing: Approval really does
+// declare several required fields, and a reflection walk that suddenly finds
+// none has broken rather than been satisfied.
+const requiredApprovalFieldFloor = 5
+
+func TestEveryRequiredApprovalFieldIsAnswered(t *testing.T) {
+	wired := reflect.ValueOf(wire(fullyPopulatedRow(t), time.Now().UTC()))
+	required := 0
+	for i := range wired.NumField() {
+		field := wired.Type().Field(i)
+		// A pointer field is an OPTIONAL one, and nil is a legitimate answer for
+		// it — a pending approval has no decided_by. Only the required fields
+		// are the subject here.
+		if field.Type.Kind() == reflect.Pointer {
+			continue
+		}
+		required++
+		if !wired.Field(i).IsZero() {
+			continue
+		}
+		t.Errorf("Approval.%s is declared required by the contract and comes back as its zero "+
+			"value from a row where every column is set. Map it in wire(), and read its column "+
+			"in the store if it is not there yet — a required field nobody populates is a "+
+			"well-formed answer that names nothing, which no client can tell from a real one.",
+			field.Name)
+	}
+	if required < requiredApprovalFieldFloor {
+		t.Fatalf("found %d required fields on crmcontracts.Approval, expected at least %d — the "+
+			"reflection walk broke rather than the subject", required, requiredApprovalFieldFloor)
+	}
+}
+
+// fullyPopulatedRow is a store row with every field set to something a real one
+// could carry, so a zero on the OTHER side of wire() can only mean the mapper
+// dropped it.
+func fullyPopulatedRow(t *testing.T) row {
+	t.Helper()
+	targetType, summary, version := tableOrganization, "Rename Acme GmbH", int64(7)
+	targetID, bundleID := ids.NewV7(), ids.NewV7()
+	onBehalfOf := ids.New[ids.UserKind]()
+	passportID := ids.New[ids.PassportKind]()
+	decidedBy := ids.New[ids.UserKind]()
+	decidedAt := time.Now().UTC().Add(-time.Minute)
+	consumedAt := time.Now().UTC()
+	change, err := json.Marshal(map[string]string{"display_name": "Acme GmbH"})
+	if err != nil {
+		t.Fatalf("building the proposed change: %v", err)
+	}
+	return row{
+		ID:             ids.New[ids.ApprovalKind](),
+		WorkspaceID:    ids.NewV7(),
+		Kind:           "orgname",
+		Status:         statusPending,
+		ProposedBy:     "agent:test",
+		OnBehalfOf:     &onBehalfOf,
+		PassportID:     &passportID,
+		TargetType:     &targetType,
+		TargetID:       &targetID,
+		TargetVersion:  &version,
+		Summary:        &summary,
+		ProposedChange: change,
+		DiffHash:       "a-diff-hash",
+		ExpiresAt:      time.Now().UTC().Add(time.Hour),
+		DecidedBy:      &decidedBy,
+		DecidedAt:      &decidedAt,
+		ConsumedAt:     &consumedAt,
+		CreatedAt:      time.Now().UTC().Add(-time.Hour),
+		BundleID:       &bundleID,
+	}
+}

--- a/backend/internal/modules/approvals/wirecompleteness_test.go
+++ b/backend/internal/modules/approvals/wirecompleteness_test.go
@@ -26,6 +26,9 @@ import (
 	"testing"
 	"time"
 
+	openapi_types "github.com/oapi-codegen/runtime/types"
+
+	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
@@ -35,7 +38,25 @@ import (
 const requiredApprovalFieldFloor = 5
 
 func TestEveryRequiredApprovalFieldIsAnswered(t *testing.T) {
-	wired := reflect.ValueOf(wire(fullyPopulatedRow(t), time.Now().UTC()))
+	// A fixed instant, through the fixture and the mapper alike: nothing here
+	// asks what time it is, and a test that reads the wall clock can only
+	// answer differently on a slow machine.
+	now := time.Date(2026, time.January, 2, 12, 0, 0, 0, time.UTC)
+	source := fullyPopulatedRow(t, now)
+	wired := reflect.ValueOf(wire(source, now))
+
+	// Non-zero is not enough for the two uuid-valued required fields, because
+	// they are the pair a mapper can confuse: WorkspaceId taken from the
+	// approval's own id would satisfy every zero-check here and name the wrong
+	// thing everywhere. So these two are checked by VALUE, against the row they
+	// came from.
+	if got, want := wired.Interface().(crmcontracts.Approval).WorkspaceId, openapi_types.UUID(source.WorkspaceID); got != want {
+		t.Errorf("Approval.WorkspaceId = %s, want the row's own workspace %s", got, want)
+	}
+	if got, want := wired.Interface().(crmcontracts.Approval).Id, openapi_types.UUID(source.ID.UUID); got != want {
+		t.Errorf("Approval.Id = %s, want the row's own id %s", got, want)
+	}
+
 	required := 0
 	for i := range wired.NumField() {
 		field := wired.Type().Field(i)
@@ -64,15 +85,15 @@ func TestEveryRequiredApprovalFieldIsAnswered(t *testing.T) {
 // fullyPopulatedRow is a store row with every field set to something a real one
 // could carry, so a zero on the OTHER side of wire() can only mean the mapper
 // dropped it.
-func fullyPopulatedRow(t *testing.T) row {
+func fullyPopulatedRow(t *testing.T, now time.Time) row {
 	t.Helper()
 	targetType, summary, version := tableOrganization, "Rename Acme GmbH", int64(7)
 	targetID, bundleID := ids.NewV7(), ids.NewV7()
 	onBehalfOf := ids.New[ids.UserKind]()
 	passportID := ids.New[ids.PassportKind]()
 	decidedBy := ids.New[ids.UserKind]()
-	decidedAt := time.Now().UTC().Add(-time.Minute)
-	consumedAt := time.Now().UTC()
+	decidedAt := now.Add(-time.Minute)
+	consumedAt := now
 	change, err := json.Marshal(map[string]string{"display_name": "Acme GmbH"})
 	if err != nil {
 		t.Fatalf("building the proposed change: %v", err)
@@ -91,11 +112,11 @@ func fullyPopulatedRow(t *testing.T) row {
 		Summary:        &summary,
 		ProposedChange: change,
 		DiffHash:       "a-diff-hash",
-		ExpiresAt:      time.Now().UTC().Add(time.Hour),
+		ExpiresAt:      now.Add(time.Hour),
 		DecidedBy:      &decidedBy,
 		DecidedAt:      &decidedAt,
 		ConsumedAt:     &consumedAt,
-		CreatedAt:      time.Now().UTC().Add(-time.Hour),
+		CreatedAt:      now.Add(-time.Hour),
 		BundleID:       &bundleID,
 	}
 }


### PR DESCRIPTION
Closes #645.

`workspace_id` is declared **required** on every approval the API returns, and the store
never read the column. So every approval anyone has ever fetched — the inbox, a single
row, a bundle member — carried the zero uuid.

Nothing failed. The contract gate checks shape rather than content; the handler tests
assert the fields they were written to assert; and a uuid of zeroes deserializes
perfectly on the client. It is the widest kind of wrong answer wearing exactly the shape
of a right one.

## What changed

The column is read back rather than assumed from the bound GUC. Assuming it would be
true today and a lie the first time a row is served from anywhere but the transaction
that bound it.

**The gate is derived from the contract type, not from a list of fields.** OpenAPI
generates a required field as a NON-POINTER on the Go struct and an optional one as a
pointer, which makes "required" mechanically readable — so a field the contract promotes
to required tomorrow is covered on the day the generator runs.
`TestEveryRequiredApprovalFieldIsAnswered` maps a row with every column set and reports
any required field that comes back zero. That is exactly how this one was found, and it
fails on this defect:

```
Approval.WorkspaceId is declared required by the contract and comes back as its zero
value from a row where every column is set. Map it in wire(), and read its column in
the store if it is not there yet — a required field nobody populates is a well-formed
answer that names nothing, which no client can tell from a real one.
```

Verified by removing the mapping and re-running (fails as above), then restoring (passes).

## Proof

**UAT, live stack, before → after.** The same request on the pre-fix binary, during the
#744 UAT, returned:

```json
{ "kind": "linkedin_match", "workspace_id": "00000000-0000-0000-0000-000000000000" }
```

and on this branch:

```json
{ "id": "019fe992-2a2a-7191-9991-a9c15efbbaf3",
  "kind": "linkedin_match",
  "workspace_id": "019fe990-922c-7526-9854-1278df3a5dc1",
  "status": "pending" }
```

```
psql> SELECT id FROM workspace;
019fe990-922c-7526-9854-1278df3a5dc1     ← the same row
```

**Gates, locally, before pushing**: `make check-backend` green, `craft static --strict`
PASS (0/0/0), `make test-integration` `OK: integration passed with 0 skips (29 packages)`.

No prompt, tool description, contract or aicert corpus file is touched, so no paid lane is owed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes approvals returning a zero `workspace_id` by reading the column from the DB and wiring it into all approval responses. Adds a guard test to ensure required `Approval` fields are set, verifying `workspace_id` and `id` by value on a fixed clock.

- **Bug Fixes**
  - Read `workspace_id` in the approvals store and include it in `wire()` output, fixing zero UUIDs across inbox, bundle, and single-approval responses.
  - Add a reflection-based wire gate that fails on any zero required field and compares `workspace_id` and `id` by value.

<sup>Written for commit 872a60d2e7a15bc997882c31cc21614c2f7fe42c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/768?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Approval responses now include the associated workspace identifier.
  * Approval data is more complete and consistent across backend responses.

* **Tests**
  * Added coverage to verify approval fields are correctly populated and serialized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->