### PR TITLE
fix(test): the shared test pool needs the one exec mode that caches nothing

### DIFF
--- a/backend/internal/platform/testdb/pool.go
+++ b/backend/internal/platform/testdb/pool.go
@@ -53,11 +53,12 @@ var (
 //	pool_max_conn_idle_time   a package that spiked hands its connections back
 //	                          promptly instead of holding its high-water mark
 //	                          for the rest of the run.
-//	default_query_exec_mode   see the note on the statement cache below.
+//	default_query_exec_mode   the one mode a connection may outlive a schema
+//	                          change under — see the note on Pool.
 var testPoolParams = map[string]string{
 	"pool_min_conns":          "0",
 	"pool_max_conn_idle_time": "30s",
-	"default_query_exec_mode": "cache_describe",
+	"default_query_exec_mode": "describe_exec",
 }
 
 // Pool returns the process-wide pool for dsn, opening it on first use. Keyed by
@@ -68,24 +69,31 @@ var testPoolParams = map[string]string{
 // which is what makes it shared. Callers must not close it — a closed shared pool
 // fails every later test in the package with a use-after-close that names nothing.
 //
-// The exec mode is the price of sharing. pgx's default prepares each statement on
-// the server under a name and reuses that plan for the life of the connection,
-// which is safe only while a connection cannot outlive the schema it was planned
-// against. Here it can, and this schema changes constantly: the customfields
-// engine ALTERs record tables mid-test, the reset drops those columns again, and
-// ApplyRiverSchema creates River's tables the first time a suite asks for a real
-// worker. A named plan that survives any of those draws SQLSTATE 0A000 "cached
-// plan must not change result type" in whichever suite runs next — a failure with
-// nothing in it pointing back at the DDL that caused it.
+// What sharing costs is the statement cache, and describe_exec is the price.
 //
-// cache_describe holds no server-side plan, so that error has nowhere to come
-// from. What it caches is the client-side statement description — parameter OIDs
-// and result format codes — while Parse, Bind, Describe(portal) and Execute still
-// go to the server on every execution, so result field descriptions are always
-// the live ones. pgx documents the cached description itself as assumed stable
-// (a "SELECT *" whose column count changes under it may fail); that is a loud
-// bind or decode error rather than a wrong row, and no store in this tree selects
-// a star.
+// pgx caches per connection, and every one of its caching modes assumes the schema
+// it cached against still stands. Here it does not: the customfields engine ALTERs
+// record tables mid-test, the reset drops those columns again, ApplyRiverSchema
+// creates River's tables, and a migration recreates the vector extension — which
+// changes the OID of a type that `$n::vector` makes the server infer for a bound
+// parameter. A cache that outlives any of those fails in whichever suite runs
+// next, as SQLSTATE 0A000 "cached plan must not change result type" or XX000
+// "cache lookup failed for type N", naming nothing that points back at the DDL
+// responsible.
+//
+// Only describe_exec is immune, because it caches nothing: it re-describes on
+// every execution, which is exactly what pgx documents it for. The two cheaper
+// modes were both tried and both failed under the sharded lane — the default's
+// named plans on 0A000, cache_describe's cached parameter OIDs on the type-OID
+// form. Clearing the caches at each reset instead also works and is not worth it:
+// pgxpool.Reset measured 254s and DeallocateAll 215s but perturbs acquisition
+// ordering enough to surface stragglers, against 244s here.
+//
+// So the lane does NOT run production's exec mode, and that is the one fidelity
+// gap in this pool. It costs a round trip per query on a round-trip-bound lane —
+// 244s against the 190s an unsound cache_describe managed. The alternative is
+// giving up the sharing, which is worth measuring before assuming this trade is
+// the best one available.
 func Pool(ctx context.Context, dsn string) (*pgxpool.Pool, error) {
 	if !schemaReady.Load() {
 		return nil, ErrSchemaNotReady


### PR DESCRIPTION
Fixes a soundness bug I introduced in #626. It is live on `main`.

## What breaks

The shared test pool ran in `cache_describe`, on my reasoning that holding no server-side plan made it safe under a changing schema. It isn't. pgx's own doc for that mode says the cached description is *assumed* stable and the first execution after a schema change **may fail**; `describe_exec` is the mode it documents as safe under concurrent schema change.

`search`'s embedding upsert binds `$5::vector`, so the server infers that parameter **as** pgvector's type and the cached description carries its OID. A migration that recreates the extension changes that OID, and the next execution on a pooled connection draws:

```
reembed_integration_test.go:57: seeding the stale-identity baseline for Reembed One:
  search: upsert embedding: ERROR: cache lookup failed for type 68394 (SQLSTATE XX000)
```

— in a suite with nothing to do with vectors, naming nothing that points at the cause. It reproduces under the sharded lane (`INTEGRATION_SHARD=7/12`), and the OID differs every run, which is the tell.

## Why this repair and not a cheaper one

All same-sitting, Postgres restarted before each run:

| | lane | sound? |
|---|---|---|
| `cache_describe` (what `main` has) | ~190s | **no** — reproduced above |
| `DeallocateAll` at each reset | 215s | sound, but acquires every idle connection per reset, which perturbs acquisition ordering enough to surface stragglers as failures |
| **`describe_exec`** | **244s** | sound — re-describes every execution, so there is no cache to go stale |
| `pgxpool.Reset` at each reset | 254s | sound, but every test re-dials several connections |

Verified: the shard-7 reproduction goes green, and a full lane is green with zero `0A000` and zero `cache lookup failed`.

## The cost, stated plainly

A round trip per query on a lane bound by round trips — **244s against the 190s the unsound mode managed.** That is most of what sharing the pool bought in #626.

So whether sharing still pays against per-test pools on today's tree is now an open question rather than a settled one, and the note on `Pool` says so instead of implying the trade is obviously right. I have not measured per-test pools on today's `main`; that is the number to get before defending the current design.

Correctness first here regardless: this lane gates every merge, and a flake that surfaces in an unrelated suite costs more than 50s a run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the shared test DB pool to `describe_exec` to stop flaky failures from cached plans and parameter OIDs under schema changes. This removes the type OID and cached-plan errors seen in integration shards.

- **Bug Fixes**
  - Set `default_query_exec_mode=describe_exec` so each execution is re-described and nothing is cached.
  - Prevents 0A000 "cached plan must not change result type" and XX000 "cache lookup failed for type N" from `pgvector` OID churn; alternatives like `pgxpool.Reset` and `DEALLOCATE ALL` were measured and rejected due to overhead/instability.

<sup>Written for commit 36e6683536b0af6d92153a1b93e0b13dbad91fb3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/769?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

