### PR TITLE
docs(status): the lane's remaining cost, and the pgx mode that took three tries

### DIFF
--- a/STATUS-ARCHIVE.md
+++ b/STATUS-ARCHIVE.md
@@ -21,6 +21,90 @@
 > [CHANGELOG.md](CHANGELOG.md) and [README.md → *What works
 > today*](README.md#what-works-today).
 
+## 2026-08-10 — the integration lane, and three ways of being confidently wrong about pgx
+
+Closes #539, #524, #482. Landed as #552, #556, #561, #563, #568, #574, #584
+(splitting and harness promotion), #625 (Redis), #626 + #769 (the shared pool),
+#671 (Postgres locks), #775 (the last split). An earlier version of this entry
+was written in #640 and removed by #674's restructuring; this one replaces it and
+covers what came after.
+
+**The lane went from ~300s to ~192s.** Most of that was not the thing that looked
+promising.
+
+**What worked.** One Postgres pool per test PROCESS instead of one per test
+(#626), a per-package Redis logical db once the lane outgrew 15 packages (#625),
+a lock table sized for the lane rather than for one app (#671), and four package
+splits so the wall clock is not hostage to one long pole.
+
+**What did not.** Splitting is spent: the wall clock stopped being bound by the
+longest package, so the final split bought ~9% and the next would buy less.
+Raising `INTEGRATION_JOBS` from 8 to 16 made the lane *slower* (200s vs 185s) —
+it is bound by one Postgres container, not by CPU; only ~1.2 of 8 cores are busy
+during a run. Both are recorded so nobody re-runs the experiment.
+
+### The part worth reading: the exec mode
+
+Sharing a pool costs you the statement cache, and I got the reason wrong twice
+before getting it right.
+
+`cache_describe` was chosen on the reasoning that holding no server-side plan
+made it safe under a changing schema. pgx's own doc says otherwise in the same
+sentence for both caching modes — the cached description is *assumed* stable and
+the first execution after a schema change may fail. A craft reviewer said so at
+the time; I overrode it with a mechanism argument. The lane then failed in CI
+with `cache lookup failed for type N (SQLSTATE XX000)` in reembed's baseline
+seed, a suite with nothing to do with the cause: `search`'s embedding upsert
+binds `$5::vector`, the server types that parameter as pgvector's, and
+perfbench's ratified inline remigration recreates the extension with a new OID
+under the live pool.
+
+Four repairs were measured, same sitting, Postgres restarted before each:
+`cache_describe` 190s but unsound; `DeallocateAll` per reset 215s but it acquires
+every idle connection at each reset and surfaced a straggler; `describe_exec`
+244s and sound; `pgxpool.Reset` per reset 254s. `describe_exec` won, and it is
+the mode pgx documents for exactly this — the one the first reviewer named.
+
+**So correctness ate most of the sharing win.** Whether sharing still pays
+against per-test pools on today's tree is an open question, not a settled one,
+and `testdb.Pool`'s doc says so rather than implying the trade is obviously
+right.
+
+### Four things that generalize
+
+**Mutation-test the gate, not just the code.** Every fitness function this arc
+added was mutation-tested, and two of them changed what I believed. The typed-id
+slice assertion in `pool_integration_test.go` cannot fail under
+`describe_exec` — the server always supplies the OID — so `jit=off` is the half
+that actually detects a hand-built pool. And the first version of
+`retentionscope_test.go` matched call expressions only, so
+`var alias = RetentionPassCtx` was invisible to it *and* did not increment its
+liveness counter; the tree already had the right shape in
+`integrationmigrateonce_test.go`, which matches *references* and says why.
+
+**A baseline from another sitting is not a baseline.** A freshly restarted
+Postgres container is worth ~25%, so early numbers in this arc that compared
+across a restart were meaningless. Every claim above compares two runs taken
+today.
+
+**One package is one binary.** Process-global state does not follow a split and
+the compiler will not say so: `retention_jurisdiction_integration_test.go` arms a
+statutory retention floor in `init()`, and a retention suite moved to a sibling
+package would run with no floor and go green while asserting the opposite of its
+sibling. Harmless today, silent by construction, now written into the split rule.
+
+**Never retarget a PR with auto-merge armed.** #672 merged into a feature branch
+with a red shard because retargeting moved it from protected `main` to an
+unprotected base, and auto-merge does not re-check whether the new base has
+gates. Nothing unreviewed reached `main`, but the PR it landed in then described
+one file while carrying nineteen.
+
+Open follow-ups: #779 (River's clock, ~28s of real waiting), #548 (contention
+probes), #770 (a straggling connection), #639 (two hand-rolled pools), and #772 —
+the one that matters beyond the lane, because production runs
+`cache_statement` while `customfields` alters record tables at runtime, and the
+fixture that would have caught it is the one now made immune.
+
 ## Session pickup — 2026-08-09 (a meeting becomes an anchor, and what the tool copy cost, PR #686)
 
 `prep_for_meeting`, `catch_me_up_on` and `GET /records/{entity_type}/{id}/context`

--- a/STATUS.md
+++ b/STATUS.md
@@ -26,7 +26,7 @@ needs the whole file to start a session.
 - [Pick up here — ADR-0091 (A136): retiring the workspace tenant boundary](#pick-up-here--adr-0091-a136-retiring-the-workspace-tenant-boundary)
 - [Open — two follow-ups left by ADR-0082/A127 (the own company, and internal mail)](#open--two-follow-ups-left-by-adr-0082a127-the-own-company-and-internal-mail)
 - [Open — an install with no mailer AND no public base URL still onboards nobody](#open--an-install-with-no-mailer-and-no-public-base-url-still-onboards-nobody)
-- [Open — the integration lane's cost, profiled](#open--the-integration-lanes-cost-profiled)
+- [Open — the integration lane, what is left](#open--the-integration-lane-what-is-left)
 - [Open — contract drift: the reset's response gained five fields](#open--contract-drift-the-resets-response-gained-five-fields)
 - [Open — the data reset has no end-to-end proof](#open--the-data-reset-has-no-end-to-end-proof)
 - [Open — the brief's omitted sections are prompt-enforced, not code-enforced](#open--the-briefs-omitted-sections-are-prompt-enforced-not-code-enforced)
@@ -307,36 +307,48 @@ fallback), **#495** (auth rate limits are process-local, so N replicas multiply
 every ceiling by N), **#496** (audit-verb down migrations cannot see the rows
 their refusal probe checks for, under production RLS).
 
-## Open — the integration lane's cost, profiled
+## Open — the integration lane, what is left
 
-The lane is 1828 tests over 25 packages, ~493s summed (~300s wall, parallel).
-Profiled per test on 2026-08-06 because the suite *looked* inflated. It is not
-inflated by count: the slowest decile is 55% of the time and the fastest 1328
-tests together are 29%, so converting the small majority to unit tests would
-delete three-quarters of the suite to recover under a third of the runtime —
-and most of them assert database behaviour (RLS, CHECK→4xx, keyset pagination)
-that has no meaning without Postgres.
+The lane is ~2060 tests over 30 packages, ~192s wall. It was ~300s when this was
+first profiled on 2026-08-06. #524, #539 and #482 are closed; the narrative for
+each is in [STATUS-ARCHIVE.md](STATUS-ARCHIVE.md), and the entry for #539 is
+worth reading before optimizing further because it is mostly a record of things
+that did not work.
 
-Where the cost actually is, and what is worth doing about it:
+**Do not expect much more from splitting packages.** It was the obvious lever and
+it is spent: the lane's wall clock is no longer bound by its longest package, so
+the last split bought ~9% and the next would buy less. What is left sits in the
+~35s between the longest package and the lane's wall time, and in the suites
+below.
 
-- **#524** — closed; the per-package budget is 600s, both lanes resolve it
-  through one `resolve_it_timeout`, and the cost report prints each package's
-  share of it. Narrative in [STATUS-ARCHIVE.md](STATUS-ARCHIVE.md).
-- **#539** — that package's setup forks about five Postgres backends per test.
-  Sharing them measured ~18% (170.9s vs a 209.6s baseline) and is **blocked**:
-  the harness drops `cf_*` columns between tests, so a pooled connection
-  outliving that DDL serves a stale plan and fails with SQLSTATE 0A000 in a
-  suite unrelated to custom fields. The issue records the design that would
-  unblock it and the four cheaper approaches that were measured and do not pay.
+- **#779** — the periodic-dispatch suites wait ~28s in 12 tests on River's real
+  clock, the largest single concentration of real waiting. River can stub the
+  clock; the issue says why that is not a one-liner and which suite must stay on
+  the real clock as a control.
+- **#548** — the people contention probes spin ~7,500 queries/second at the
+  writer they are polling for, and still time out on a loaded runner. Time
+  bounding was added and was not enough; the shape needs to change.
 - **#535** — table-driven tests calling their harness inside `t.Run`, re-seeding
   Postgres per case (~44s), which also hides that the property under test is pure.
 - **#536** — a few tests assert pure logic through a booted app; `check-test-lanes.sh`
   forbids the mirror case (a unit test opening real infra) but cannot see this one.
+- **#639** — two packages hand-roll the process pool `testdb.Pool` now owns.
+- **#770** — the telegram-ingress suite leaves a connection checked out past its
+  own cleanup under lane load.
 
-Two measurement notes for whoever picks this up. Run-to-run variance on the same
-commit is ~15%, so compare within one sitting on an idle machine. And both
-failures found while attempting #539 were order-dependent — they appeared only
-in a full-package or full-lane run, never in isolation.
+Three measurement notes, each of which cost a wrong number before it was written
+down. **Restart Postgres between runs** — a fresh container is worth ~25% on its
+own, so two runs taken across a restart boundary are not comparable to each
+other. Run-to-run variance on the same commit is ~15%, so compare within one
+sitting on an idle machine. And **measure both sides today**: the lane's own
+baseline moves as the tree grows and as its fixtures change, so a number from
+last week is not a control.
+
+One thing the lane can no longer catch, which matters more than its runtime:
+**#772**. Production runs pgx's default `cache_statement` while `customfields`
+alters record tables at runtime, so a live request can draw SQLSTATE 0A000 — and
+the shared test pool now runs `describe_exec`, which is immune. The fixture that
+would have reproduced it is the one that was made safe.
 
 ## Open — contract drift: the reset's response gained five fields
 


### PR DESCRIPTION
STATUS.md's lane section still described 25 packages, ~300s wall and #539 as blocked. #524, #539 and #482 are all closed and the lane is ~2060 tests over 30 packages at ~192s.

The section now carries only what is still actionable — #779, #548, #535, #536, #639, #770 — plus **#772**, which is not about the lane's cost but about what the lane can no longer catch.

It also says plainly that **splitting packages is spent**, and why: the wall clock stopped being bound by the longest package, so the last split bought ~9% and the next would buy less. That is the question the section existed to answer, and leaving it open invites someone to spend a day re-deriving it.

## The archive entry

Gets the narrative, including the parts that are a record of being wrong. `cache_describe` was chosen over a craft reviewer's objection on a mechanism argument that turned out false, and cost a CI failure in a suite with nothing to do with the cause. The four measured repairs are listed with numbers so the next person reads the measurement instead of repeating it.

Three things in it generalize past this arc:

- **Mutation-test the gate, not just the code.** Two of the fitness functions this arc added changed what I believed once mutated — one assertion turned out unable to fail at all under the chosen exec mode, and the first version of the scope gate was bypassable by a function-value reference.
- **A baseline from another sitting is not a baseline.** A freshly restarted Postgres container is worth ~25%.
- **One package is one binary**, so process-global `init()` state does not follow a split and the compiler will not say so.

Note: an earlier version of that entry landed in #640 and was removed by #674's restructuring of the same file. This replaces and extends it.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes the integration lane docs to reflect today’s numbers and open work, and adds an archive entry on the `pgx` execution mode choice and its tradeoffs. Also clarifies that further package splitting won’t meaningfully reduce wall time.

- **Docs**
  - Update STATUS.md: lane is ~2060 tests across 30 packages at ~192s wall; close #524, #539, #482; list only what’s actionable now — #779, #548, #535, #536, #639, #770 — plus #772 (a gap the lane can’t catch).
  - State plainly that splitting is spent: the wall is no longer bound by the longest package; the last split bought ~9%, the next would buy less.
  - Add STATUS-ARCHIVE.md entry: documents the move to `describe_exec` in `pgx`, the measured options (`cache_describe` 190s but unsound; `DeallocateAll` ~215s; `describe_exec` ~244s and sound; `pgxpool.Reset` ~254s), and why correctness ate most of the pooling win. Captures lessons that generalize: mutation-test gates, don’t compare across a Postgres restart, and one package equals one binary.
  - Note production uses `cache_statement` while `customfields` alters tables at runtime; the shared test pool runs `describe_exec`, so #772 won’t surface in the lane.

<sup>Written for commit 352bbbfb5f6c415ed6cfb121b1090b4b68859de1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/781?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

