### PR TITLE
fix(agents): the REST door charges the read bound it refuses on (#646)

### DIFF
--- a/backend/internal/compose/agentgate.go
+++ b/backend/internal/compose/agentgate.go
@@ -58,7 +58,7 @@ func agentGate(reg *agents.Registry, staging agents.Approvals, stages agents.Sta
 				return
 			}
 			if !mutatingMethod(r.Method) {
-				refuseAgentRead(w, r, next, gate)
+				refuseAgentRead(w, r, next, gate, reg)
 				return
 			}
 			spec, resolve, pol, body, ok := prepareAgentGate(w, r, reg, deps)
@@ -107,7 +107,13 @@ func agentGate(reg *agents.Registry, staging agents.Approvals, stages agents.Sta
 // The bound itself binds BOTH doors: a Passport that spent its window through
 // the MCP surface must not keep reading the same records over /v1. One
 // credential governed two ways is the hole ADR-0055 exists to close.
-func refuseAgentRead(w http.ResponseWriter, r *http.Request, next http.Handler, gate *auth.Gate) {
+//
+// And the door that refuses on the bound PAYS INTO it: the handler answers
+// through a servedMeter, so the records this read hands over are charged where
+// they leave. Consulting a counter nothing increments bounds nobody — a
+// credential reading only over /v1 would sit at zero forever, however much it
+// read.
+func refuseAgentRead(w http.ResponseWriter, r *http.Request, next http.Handler, gate *auth.Gate, reg *agents.Registry) {
 	if refusedAsHumanOnly(w, r) {
 		return
 	}
@@ -115,7 +121,7 @@ func refuseAgentRead(w http.ResponseWriter, r *http.Request, next http.Handler, 
 		httperr.Write(w, r, err)
 		return
 	}
-	next.ServeHTTP(w, r)
+	next.ServeHTTP(&servedMeter{ResponseWriter: w, r: r, reg: reg, mayRefuse: nothingHasHappenedYet}, r)
 }
 
 // refusedAsHumanOnly applies x-agent-access to a NON-mutating agent call, and
@@ -225,11 +231,18 @@ func admitAgentCall(w http.ResponseWriter, r *http.Request, next http.Handler, o
 		// refused. A quota counts what an agent did, so a rejected mutation that
 		// spent a write would let a caller exhaust its own allowance on requests
 		// that changed nothing, which is a bound nobody wrote.
+		// The meter sits OUTSIDE the recorder, so the handler's WriteJSON finds
+		// it by a plain assertion while the recorder still sees every status.
+		// A mutation that answers with the row it changed handed over a record,
+		// and the MCP door charges that record at chargeAnswer whatever the tool
+		// kind — a read-back free on one door and charged on the other is the
+		// same asymmetry this gate exists to close.
 		performed := &effectRecorder{ResponseWriter: w}
+		metered := &servedMeter{ResponseWriter: performed, r: r, reg: outcome.registry, mayRefuse: theEffectAlreadyLanded}
 		if outcome.pol.Tool == "update_record" && !actionShapedUpdateOps[outcome.pol.Op] {
-			splitOrRedeemUpdate(performed, r, next, outcome.staging, outcome.ownership, outcome.pol, outcome.body)
+			splitOrRedeemUpdate(metered, r, next, outcome.staging, outcome.ownership, outcome.pol, outcome.body)
 		} else {
-			next.ServeHTTP(performed, r)
+			next.ServeHTTP(metered, r)
 		}
 		if performed.done() {
 			outcome.registry.ChargeEffect(r.Context(), outcome.spec)
@@ -241,7 +254,8 @@ func admitAgentCall(w http.ResponseWriter, r *http.Request, next http.Handler, o
 		// the effect for both would bill a refusal, so this arm charges only
 		// where redeemIfPresented actually forwarded.
 		performed := &effectRecorder{ResponseWriter: w}
-		ran := stageOrRedeem(performed, r, next, outcome.staging, outcome.pol, outcome.body)
+		metered := &servedMeter{ResponseWriter: performed, r: r, reg: outcome.registry, mayRefuse: theEffectAlreadyLanded}
+		ran := stageOrRedeem(metered, r, next, outcome.staging, outcome.pol, outcome.body)
 		if !ran {
 			return
 		}

--- a/backend/internal/compose/agentservedmeter.go
+++ b/backend/internal/compose/agentservedmeter.go
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// What the REST door OWES the read bound it refuses on.
+//
+// The admission half lives in agentgate.go: a non-mutating agent call is
+// admitted against MCP-SESS-READS before any handler runs. This file is the
+// other half — the records that answer actually hands over, charged where they
+// leave. A counter a door consults and never increments bounds nobody: a
+// credential reading only over /v1 would sit at zero forever, however much it
+// read, which is exactly the asymmetry ADR-0055 exists to close.
+
+import (
+	"net/http"
+
+	"github.com/gradionhq/margince/backend/internal/modules/agents"
+	"github.com/gradionhq/margince/backend/internal/platform/httperr"
+)
+
+// servedMeter counts the records one agent response hands over and charges them
+// against MCP-SESS-READS.
+//
+// It wraps the WRITER rather than threading a counter through ~290 handler
+// signatures: httperr.WriteJSON is the one place a record becomes a REST
+// response, and it reports what it is about to write to whatever meter the
+// writer carries. That is the seam newWireRecord is on the MCP door.
+type servedMeter struct {
+	http.ResponseWriter
+	r   *http.Request
+	reg *agents.Registry
+	// mayRefuse is agents/quota.go's one rule applied on this door: refuse only
+	// while nothing has happened yet.
+	//
+	// A READ has committed nothing, so an uncountable one is withheld — a charge
+	// lost to a blinking Redis is lost for good, and those records would be read
+	// again for free. A MUTATION's body is written after its effect landed, so
+	// withholding it would report a completed change as a failure and invite the
+	// retry of something that already happened.
+	mayRefuse refusability
+}
+
+// refusability names the two sides of that rule at the call sites, so a bare
+// true/false cannot silently pick the wrong one.
+type refusability bool
+
+const (
+	nothingHasHappenedYet  refusability = true
+	theEffectAlreadyLanded refusability = false
+)
+
+// NoteServed charges n records and answers whether the response may proceed. A
+// refusal is written here rather than reported upward because this is the layer
+// holding the request; httperr has neither it nor any notion of a quota.
+func (m *servedMeter) NoteServed(n int) bool {
+	err := m.reg.ChargeServedRecords(m.r.Context(), n)
+	if err == nil || !bool(m.mayRefuse) {
+		return true
+	}
+	httperr.Write(m.ResponseWriter, m.r, err)
+	return false
+}
+
+// Unwrap exposes the wrapped writer so http.NewResponseController still reaches
+// the real connection through this layer — an embedded-only wrapper silently
+// swallows Flush and SetWriteDeadline.
+func (m *servedMeter) Unwrap() http.ResponseWriter { return m.ResponseWriter }
+
+// remeter re-points an existing meter at a different sink, for a response that
+// is BUFFERED before it is replayed (the split-update path). Without it the
+// buffer — which carries no meter — would swallow the count, and the replay
+// writes raw bytes rather than going back through WriteJSON, so those records
+// would never be charged at all. An unmetered writer is left alone.
+func remeter(w http.ResponseWriter, sink http.ResponseWriter) http.ResponseWriter {
+	meter, metered := w.(*servedMeter)
+	if !metered {
+		return sink
+	}
+	resunk := *meter
+	resunk.ResponseWriter = sink
+	return &resunk
+}

--- a/backend/internal/compose/agentsplit.go
+++ b/backend/internal/compose/agentsplit.go
@@ -111,7 +111,10 @@ func applyAutoExecuteAndStageResidue(w http.ResponseWriter, r *http.Request, nex
 	r.Body = io.NopCloser(bytes.NewReader(split.AutoExecute))
 	r.ContentLength = int64(len(split.AutoExecute))
 	buffered := newBufferedResponse()
-	next.ServeHTTP(buffered, r)
+	// Metered onto the BUFFER: the replay below writes raw bytes rather than
+	// going back through WriteJSON, so the record this half serves is counted
+	// where the handler produces it or it is never counted at all.
+	next.ServeHTTP(remeter(w, buffered), r)
 	if buffered.status < 200 || buffered.status > 299 {
 		// The auto-execute half was refused (validation, version skew, …): that
 		// refusal is the whole answer, and nothing is staged — the agent

--- a/backend/internal/compose/connectors_imap.go
+++ b/backend/internal/compose/connectors_imap.go
@@ -9,7 +9,6 @@ package compose
 // connect flow in connectors.go.
 
 import (
-	"encoding/json"
 	"errors"
 	"log/slog"
 	"net/http"
@@ -147,15 +146,15 @@ func (h connectorHandlers) persistIMAPConnection(w http.ResponseWriter, r *http.
 	}
 	for _, v := range views {
 		if v.Provider == providerIMAP {
-			w.Header().Set("Content-Type", "application/json")
 			conn := toContractConnection(v)
-			if err := json.NewEncoder(w).Encode(crmcontracts.ConnectConnectorResponse{
+			// Through the shared writer, like every other record this surface
+			// answers with. That is the one place a record becomes a REST
+			// response, which is what lets the agent read bound count what
+			// leaves; a private encode here is a second spelling the meter
+			// cannot see.
+			httperr.WriteJSON(w, http.StatusOK, crmcontracts.ConnectConnectorResponse{
 				Connection: &conn,
-			}); err != nil {
-				// The status line is already gone; the log is the only place
-				// a truncated success can still be seen.
-				slog.ErrorContext(r.Context(), "imap connector: encoding connect response", "err", err)
-			}
+			})
 			return
 		}
 	}

--- a/backend/internal/compose/integration/agentreadbound_integration_test.go
+++ b/backend/internal/compose/integration/agentreadbound_integration_test.go
@@ -20,6 +20,7 @@ package integration
 // one credential presenting at a second door must meet the same counter.
 //
 import (
+	"context"
 	"net/http"
 	"testing"
 	"time"
@@ -43,20 +44,32 @@ func boundedApp(t *testing.T, slug string, limit int) (*apptest.AppEnv, *agentqu
 	return e, meter
 }
 
-// spendWindow charges the meter against one passport, as the MCP door would.
-func spendWindow(t *testing.T, e *apptest.AppEnv, meter *agentquota.Meter, passport ids.UUID, records int) {
+// asPassport builds the context the meter counts one passport against — the
+// same binding the gate resolves from a presented Bearer.
+func asPassport(t *testing.T, e *apptest.AppEnv, passport ids.UUID) context.Context {
 	t.Helper()
 	var ws ids.UUID
 	if err := e.Owner.QueryRow(t.Context(), `SELECT id FROM workspace LIMIT 1`).Scan(&ws); err != nil {
 		t.Fatalf("reading the workspace id: %v", err)
 	}
 	ctx := principal.WithWorkspaceID(t.Context(), ws)
-	ctx = principal.WithActor(ctx, principal.Principal{
+	return principal.WithActor(ctx, principal.Principal{
 		Type: principal.PrincipalAgent, ID: "agent:" + passport.String(), PassportID: passport,
 	})
-	if err := meter.Consume(ctx, agentquota.Reads, records); err != nil {
+}
+
+// spendWindow charges the meter against one passport, as the MCP door would.
+func spendWindow(t *testing.T, e *apptest.AppEnv, meter *agentquota.Meter, passport ids.UUID, records int) {
+	t.Helper()
+	if err := meter.Consume(asPassport(t, e, passport), agentquota.Reads, records); err != nil {
 		t.Fatalf("spending the window: %v", err)
 	}
+}
+
+// readsCharged is what the window has actually observed against one passport.
+func readsCharged(t *testing.T, e *apptest.AppEnv, meter *agentquota.Meter, passport ids.UUID) int {
+	t.Helper()
+	return meter.Read(asPassport(t, e, passport), agentquota.Reads).Observed
 }
 
 // A passport that has spent its window is refused on the REST door too. Before
@@ -102,6 +115,144 @@ func TestAHumanSessionIsUnaffectedByASpentAgentWindow(t *testing.T) {
 
 	if status := e.Call(t, "GET", "/v1/people", nil, nil, nil); status != http.StatusOK {
 		t.Errorf("a human read → %d after an agent spent its window; humans are outside this bound", status)
+	}
+}
+
+// The door that REFUSES on a counter pays into it. The refusal above proves /v1
+// consults MCP-SESS-READS; this proves it charges, which is what makes the
+// refusal reachable by reading rather than only by having read elsewhere.
+//
+// Counted in RECORDS, not requests: a page of one and a page of two hundred are
+// not the same read, and a per-request charge would price them alike.
+func TestARestReadChargesTheRecordsItServed(t *testing.T) {
+	e, meter := boundedApp(t, "read-bound-charge", 100)
+	bearer, passport := passportWithID(t, e, "reading agent", "read")
+	seedPeople(t, e, 3)
+
+	if status := e.Call(t, "GET", "/v1/people", nil, bearer, nil); status != http.StatusOK {
+		t.Fatalf("an agent read under the bound → %d, want 200", status)
+	}
+
+	if charged := readsCharged(t, e, meter, passport); charged != 3 {
+		t.Errorf("a page of 3 records charged %d against MCP-SESS-READS, want 3; "+
+			"a door that refuses on a counter nothing increments bounds nobody", charged)
+	}
+}
+
+// A single record read charges one, so the counter measures what was handed
+// over rather than how the caller happened to ask for it.
+func TestARestSingleRecordReadChargesOne(t *testing.T) {
+	e, meter := boundedApp(t, "read-bound-single", 100)
+	bearer, passport := passportWithID(t, e, "reading agent", "read")
+
+	var created struct {
+		ID ids.UUID `json:"id"`
+	}
+	if status := e.Call(t, "POST", "/v1/people", apptest.AnyMap{
+		"full_name": "Single Read",
+	}, nil, &created); status != http.StatusCreated {
+		t.Fatalf("seeding the person → %d", status)
+	}
+
+	if status := e.Call(t, "GET", "/v1/people/"+created.ID.String(), nil, bearer, nil); status != http.StatusOK {
+		t.Fatalf("an agent single read → %d, want 200", status)
+	}
+
+	if charged := readsCharged(t, e, meter, passport); charged != 1 {
+		t.Errorf("one record charged %d against MCP-SESS-READS, want 1", charged)
+	}
+}
+
+// THE DERIVED OBLIGATION, and the reason this file grew: every counter the
+// admission gate can REFUSE on has a charge point on the SAME door.
+//
+// platform/auth refuses on Calls and on agentquota.CounterFor(spec) — which is
+// Reads, Writes or Egress — so the REST door owes all four. Stated as one rule
+// it catches a half at a time: the mutating half was closed by C2 and the read
+// half sat open for a release, because nothing asserted the pair.
+//
+// Egress is not driven here and is not missing: CounterFor picks between Writes
+// and Egress at the SAME charge point (ChargeEffect), so the Writes row proves
+// the call site and CounterFor's own tests prove the choice. Reaching Egress
+// through this door additionally needs an approval staged and redeemed, since
+// every egress tool with a REST twin is confirm-first.
+// Each counter is measured across the ONE request that must charge it, not over
+// the suite. A total taken at the end cannot say which door paid: a mutation
+// answers with the row it changed, so its read-back charges Reads too, and a
+// read door charging nothing at all still reads as covered. That is not a
+// hypothetical — this test passed against the unmetered read door until it
+// measured per request.
+func TestEveryCounterTheRestDoorRefusesOnIsChargedOnIt(t *testing.T) {
+	e, meter := boundedApp(t, "read-bound-census", 1000)
+	bearer, passport := passportWithID(t, e, "counting agent", "read", "write")
+	seedPeople(t, e, 2)
+	ctx := asPassport(t, e, passport)
+
+	advance := func(during func()) map[agentquota.Counter]int {
+		counters := []agentquota.Counter{agentquota.Reads, agentquota.Writes, agentquota.Calls}
+		was := map[agentquota.Counter]int{}
+		for _, c := range counters {
+			was[c] = meter.Read(ctx, c).Observed
+		}
+		during()
+		moved := map[agentquota.Counter]int{}
+		for _, c := range counters {
+			moved[c] = meter.Read(ctx, c).Observed - was[c]
+		}
+		return moved
+	}
+
+	onRead := advance(func() {
+		if status := e.Call(t, "GET", "/v1/people", nil, bearer, nil); status != http.StatusOK {
+			t.Fatalf("the agent read → %d, want 200", status)
+		}
+	})
+	onWrite := advance(func() {
+		if status := e.Call(t, "POST", "/v1/people", apptest.AnyMap{
+			"full_name": "Charged By The Gate",
+		}, bearer, nil); status != http.StatusCreated {
+			t.Fatalf("the agent write → %d, want 201", status)
+		}
+	})
+
+	for _, owed := range []struct {
+		counter agentquota.Counter
+		moved   int
+		door    string
+	}{
+		{agentquota.Reads, onRead[agentquota.Reads], "a GET hands over records"},
+		{agentquota.Writes, onWrite[agentquota.Writes], "a POST mutates"},
+		{agentquota.Calls, onWrite[agentquota.Calls], "every admitted call sits under the ceiling"},
+	} {
+		if !owed.counter.Governed() {
+			continue
+		}
+		if owed.moved == 0 {
+			t.Errorf("the REST door refuses on %s and its own request charged it 0 — %s, so a credential using only this door never approaches it",
+				owed.counter, owed.door)
+		}
+	}
+}
+
+// The bound closes on REST reads ALONE. This is the property #623 names: an
+// agent that reads only over /v1 must approach the same ceiling as one reading
+// over /mcp, rather than being bounded by its MCP half alone.
+func TestRestReadsAloneCanSpendTheWindow(t *testing.T) {
+	e, _ := boundedApp(t, "read-bound-selfspend", 4)
+	bearer, _ := passportWithID(t, e, "reading agent", "read")
+	seedPeople(t, e, 3)
+
+	// 3 records served takes the window to 3 of 4 — admitted, not yet exceeded.
+	if status := e.Call(t, "GET", "/v1/people", nil, bearer, nil); status != http.StatusOK {
+		t.Fatalf("the first agent read → %d, want 200", status)
+	}
+	// Admitted on entry (3 < 4) and serves 3 more, taking it to 6 of 4.
+	if status := e.Call(t, "GET", "/v1/people", nil, bearer, nil); status != http.StatusOK {
+		t.Fatalf("the second agent read → %d, want 200", status)
+	}
+
+	if status := e.Call(t, "GET", "/v1/people", nil, bearer, nil); status != http.StatusTooManyRequests {
+		t.Errorf("the third agent read → %d, want 429; reading over /v1 never spends the window it is refused on", status)
 	}
 }
 

--- a/backend/internal/modules/agents/quota.go
+++ b/backend/internal/modules/agents/quota.go
@@ -222,6 +222,35 @@ func (r *Registry) ChargeAdmittedCall(ctx context.Context, spec mcp.ToolSpec) er
 	return r.chargeCall(ctx, spec, nothingHasHappenedYet)
 }
 
+// ChargeServedRecords records what ONE REST response handed over against
+// MCP-SESS-READS. It is the read twin of ChargeAdmittedCall and exists for the
+// same reason: the composition layer owns that door and this package may not
+// import it, so without a charge point here AdmitRead refuses on a counter
+// nothing increments and a credential reading only over /v1 is unbounded.
+//
+// It counts RECORDS, which is what the counter measures and what the MCP door
+// charges at chargeAnswer — a page of one and a page of two hundred are not the
+// same read, and a per-request charge would price them alike.
+//
+// It REPORTS a failed charge rather than deciding what it costs. That decision
+// is this file's one rule — refuse only while nothing has happened yet — and on
+// the REST door only the caller knows which side of it this response is on: a
+// read has committed nothing, while a mutation's body is written after its
+// effect landed.
+func (r *Registry) ChargeServedRecords(ctx context.Context, n int) error {
+	if r.quota == nil || n <= 0 {
+		return nil
+	}
+	if err := r.quota.Consume(ctx, agentquota.Reads, n); err != nil {
+		slog.ErrorContext(ctx, "recording the records a REST response served against the read bound failed",
+			"quota", string(agentquota.Reads), "records", n, "err", err)
+		return fmt.Errorf(
+			"crmagents: %d records could not be counted against this agent's read bound: %w",
+			n, apperrors.ErrBudgetExceeded)
+	}
+	return nil
+}
+
 // ChargeRedeemedCall is ChargeAdmittedCall for a call whose approval has
 // already been consumed. It never refuses, for the reason refusable states.
 func (r *Registry) ChargeRedeemedCall(ctx context.Context, spec mcp.ToolSpec) {

--- a/backend/internal/modules/approvals/handlers.go
+++ b/backend/internal/modules/approvals/handlers.go
@@ -46,7 +46,7 @@ func (h Handlers) ListApprovals(w http.ResponseWriter, r *http.Request, params c
 	for _, a := range rows {
 		data = append(data, h.wire(a))
 	}
-	writeJSON(w, http.StatusOK, crmcontracts.ApprovalListResponse{
+	httperr.WriteJSON(w, http.StatusOK, crmcontracts.ApprovalListResponse{
 		Data: data,
 		Page: pageInfo(page),
 	})
@@ -99,7 +99,7 @@ func (h Handlers) GetApproval(w http.ResponseWriter, r *http.Request, id crmcont
 		writeErr(w, r, err)
 		return
 	}
-	writeJSON(w, http.StatusOK, h.wire(a))
+	httperr.WriteJSON(w, http.StatusOK, h.wire(a))
 }
 
 func (h Handlers) ApproveApproval(w http.ResponseWriter, r *http.Request, id crmcontracts.Id, _ crmcontracts.ApproveApprovalParams) {
@@ -137,7 +137,7 @@ func (h Handlers) ApproveApproval(w http.ResponseWriter, r *http.Request, id crm
 		return
 	}
 	out.ApprovalToken = &token
-	writeJSON(w, http.StatusOK, out)
+	httperr.WriteJSON(w, http.StatusOK, out)
 }
 
 func (h Handlers) RejectApproval(w http.ResponseWriter, r *http.Request, id crmcontracts.Id) {
@@ -155,7 +155,7 @@ func (h Handlers) RejectApproval(w http.ResponseWriter, r *http.Request, id crmc
 		writeErr(w, r, err)
 		return
 	}
-	writeJSON(w, http.StatusOK, h.wire(a))
+	httperr.WriteJSON(w, http.StatusOK, h.wire(a))
 }
 
 // ApproveApprovalBundle decides every still-pending member of one bundle at
@@ -192,7 +192,7 @@ func (h Handlers) decideBundle(w http.ResponseWriter, r *http.Request, bundleID 
 			Outcome:  crmcontracts.ApprovalBundleMemberOutcome(member.Outcome),
 		})
 	}
-	writeJSON(w, http.StatusOK, crmcontracts.ApprovalBundleDecision{BundleId: bundleID, Data: data})
+	httperr.WriteJSON(w, http.StatusOK, crmcontracts.ApprovalBundleDecision{BundleId: bundleID, Data: data})
 }
 
 func writeErr(w http.ResponseWriter, r *http.Request, err error) {
@@ -264,11 +264,4 @@ func wire(a row, now time.Time) crmcontracts.Approval {
 		}
 	}
 	return out
-}
-
-func writeJSON[T any](w http.ResponseWriter, status int, body T) {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(status)
-	//craft:ignore swallowed-errors the status line is already written — a failed body encode has no channel left to report on
-	_ = json.NewEncoder(w).Encode(body)
 }

--- a/backend/internal/platform/httperr/servedmeter.go
+++ b/backend/internal/platform/httperr/servedmeter.go
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package httperr
+
+// How many records one response hands over, and the seam that lets the surface
+// bounding an agent's reads charge for them.
+
+import "reflect"
+
+// ServedMeter is implemented by a ResponseWriter its owner has wrapped to count
+// what leaves this door. WriteJSON reports every body it is about to write, so
+// the count is taken at the ONE place a record becomes a REST response instead
+// of in the ~290 handlers that would each have to remember.
+//
+// This package holds no request and knows nothing about quotas, so a meter that
+// cannot record its charge answers the request ITSELF and reports proceed=false;
+// WriteJSON then writes nothing more. That keeps the decision about what an
+// uncountable answer costs with the door that has the context to make it.
+type ServedMeter interface {
+	NoteServed(n int) (proceed bool)
+}
+
+// recordsIn counts the records a response body hands over.
+//
+// It reads the CONTRACT's own list envelope rather than a list of response type
+// names: every generated list response is a struct carrying a `Data` slice, so
+// the shape answers the question and a list added tomorrow is counted without an
+// edit here. TestEveryListResponseCarriesADataSlice holds that shape, so a list
+// this rule would silently count as one fails the build instead.
+//
+// Anything else is one thing handed over, and that deliberately counts a
+// settings or status body as a record: it is still an answer this credential was
+// given, and separating "real" records from the rest is the maintained list
+// again — with the tool added next missing from it.
+//
+//craft:ignore naked-any it counts WriteJSON's own body argument, and takes the same type that seam does
+func recordsIn(body any) int {
+	value := reflect.ValueOf(body)
+	for value.Kind() == reflect.Pointer || value.Kind() == reflect.Interface {
+		if value.IsNil() {
+			return 0
+		}
+		value = value.Elem()
+	}
+	switch value.Kind() {
+	case reflect.Invalid:
+		// A nil body writes JSON "null" and hands over nothing.
+		return 0
+	case reflect.Slice:
+		return value.Len()
+	case reflect.Struct:
+		if data := value.FieldByName("Data"); data.IsValid() && data.Kind() == reflect.Slice {
+			return data.Len()
+		}
+		return 1
+	default:
+		return 1
+	}
+}

--- a/backend/internal/platform/httperr/servedmeter_test.go
+++ b/backend/internal/platform/httperr/servedmeter_test.go
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package httperr
+
+// What a response body is worth to the read bound, and what a meter that cannot
+// charge for it does to the answer.
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+type page struct {
+	Data []string `json:"data"`
+	Next string   `json:"next"`
+}
+
+type record struct {
+	ID string `json:"id"`
+}
+
+// notAPage carries a Data field that is NOT a page, which is the case the
+// count rule has to get right rather than trust the field name.
+type notAPage struct {
+	Data string `json:"data"`
+}
+
+func TestRecordsInCountsThePageNotTheResponse(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		body any
+		want int
+	}{
+		{"a page counts its rows", page{Data: []string{"a", "b", "c"}}, 3},
+		{"an empty page hands over nothing", page{Data: []string{}}, 0},
+		{"a nil page hands over nothing", page{}, 0},
+		{"a pointer to a page is still a page", &page{Data: []string{"a"}}, 1},
+		{"a single record is one", record{ID: "r"}, 1},
+		{"a pointer to a single record is one", &record{ID: "r"}, 1},
+		{"a bare slice counts its members", []record{{ID: "a"}, {ID: "b"}}, 2},
+		{"a nil body hands over nothing", nil, 0},
+		{"a typed nil pointer hands over nothing", (*record)(nil), 0},
+		{"a Data field that is not a page is one record", notAPage{Data: "scalar"}, 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := recordsIn(tc.body); got != tc.want {
+				t.Errorf("recordsIn(%#v) = %d, want %d", tc.body, got, tc.want)
+			}
+		})
+	}
+}
+
+// meterStub records what it was told and answers whether the write proceeds.
+type meterStub struct {
+	http.ResponseWriter
+	noted   int
+	calls   int
+	proceed bool
+}
+
+func (m *meterStub) NoteServed(n int) bool {
+	m.calls++
+	m.noted += n
+	return m.proceed
+}
+
+func TestWriteJSONReportsWhatItIsAboutToServe(t *testing.T) {
+	rec := httptest.NewRecorder()
+	meter := &meterStub{ResponseWriter: rec, proceed: true}
+
+	WriteJSON(meter, http.StatusOK, page{Data: []string{"a", "b"}})
+
+	if meter.calls != 1 {
+		t.Errorf("the meter was consulted %d times, want exactly 1 per response", meter.calls)
+	}
+	if meter.noted != 2 {
+		t.Errorf("the meter was told %d records, want 2", meter.noted)
+	}
+	if rec.Code != http.StatusOK {
+		t.Errorf("status %d, want 200 — a proceeding meter must not change the answer", rec.Code)
+	}
+	var got page
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decoding the served body: %v", err)
+	}
+	if len(got.Data) != 2 {
+		t.Errorf("served %d rows, want 2", len(got.Data))
+	}
+}
+
+// A meter that refuses has already answered the request; WriteJSON must add
+// nothing to it. Writing the body anyway would hand over the very records the
+// surface just said it could not account for.
+func TestWriteJSONWritesNothingWhenTheMeterRefuses(t *testing.T) {
+	rec := httptest.NewRecorder()
+	meter := &meterStub{ResponseWriter: rec, proceed: false}
+
+	WriteJSON(meter, http.StatusOK, page{Data: []string{"a", "b"}})
+
+	if body := rec.Body.String(); body != "" {
+		t.Errorf("a refused response carried a body %q; the records were handed over anyway", body)
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "" {
+		t.Errorf("a refused response set Content-Type %q, overwriting whatever the refusal wrote", ct)
+	}
+}
+
+// An unmetered writer is every human request and every composition with no
+// volume meter. It must take exactly the path it always did.
+func TestWriteJSONServesAnUnmeteredWriterUnchanged(t *testing.T) {
+	rec := httptest.NewRecorder()
+
+	WriteJSON(rec, http.StatusCreated, record{ID: "r"})
+
+	if rec.Code != http.StatusCreated {
+		t.Errorf("status %d, want 201", rec.Code)
+	}
+	var got record
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decoding the served body: %v", err)
+	}
+	if got.ID != "r" {
+		t.Errorf("served %+v, want the record unchanged", got)
+	}
+}
+
+// recordsIn must not panic on a body no handler would send but a future one
+// might, because a panic here takes down a response that was about to succeed.
+func TestRecordsInSurvivesUnexpectedBodies(t *testing.T) {
+	for _, body := range []any{
+		map[string]int{"a": 1},
+		"a bare string",
+		42,
+		errors.New("an error as a body"),
+	} {
+		if got := recordsIn(body); got != 1 {
+			t.Errorf("recordsIn(%#v) = %d, want 1 — an unrecognized body is one thing handed over", body, got)
+		}
+	}
+}

--- a/backend/internal/platform/httperr/wire.go
+++ b/backend/internal/platform/httperr/wire.go
@@ -155,8 +155,18 @@ func bodyProbe(single json.RawMessage, probe any) error {
 
 // WriteJSON writes a JSON response with the given status.
 //
+// It is the one place a record becomes a REST response, which is what makes it
+// the place to count them: a writer carrying a ServedMeter is told what this
+// body hands over BEFORE any of it is written, so a door bounding an agent's
+// reads can still withhold an answer it cannot charge for. An unmetered writer —
+// every human request, and every composition with no volume meter — takes the
+// path it always did.
+//
 //craft:ignore naked-any the JSON serialization seam: body is whichever contract response struct the handler produced
 func WriteJSON(w http.ResponseWriter, status int, body any) {
+	if meter, metered := w.(ServedMeter); metered && !meter.NoteServed(recordsIn(body)) {
+		return
+	}
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
 	//craft:ignore swallowed-errors WriteHeader already committed the response — nothing can report an encode failure to the client anymore

--- a/backend/listenvelope_test.go
+++ b/backend/listenvelope_test.go
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package backendarch
+
+// The contract's list envelope has ONE shape, and something depends on that.
+//
+// httperr.recordsIn counts what a REST response hands over by reading the
+// envelope rather than a list of response type names: a struct carrying a `Data`
+// slice is a page, and its length is the record count charged against the agent
+// read bound (MCP-SESS-READS). A list response that spelled its page some other
+// way would be counted as ONE record however many it served — silently, because
+// a wrong number is still a number.
+//
+// So the rule the counter assumes is asserted here over the generated contract,
+// which is the only place it can be: a list shape added tomorrow either carries
+// `Data []T` or fails this test.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"strings"
+	"testing"
+)
+
+// contractGen is the generated contract surface every response type is declared in.
+const contractGen = "internal/contracts/api_gen.go"
+
+func TestEveryListResponseCarriesADataSlice(t *testing.T) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, contractGen, nil, 0)
+	if err != nil {
+		t.Fatalf("parsing %s: %v", contractGen, err)
+	}
+
+	var checked int
+	ast.Inspect(file, func(n ast.Node) bool {
+		spec, ok := n.(*ast.TypeSpec)
+		if !ok || !strings.HasSuffix(spec.Name.Name, "ListResponse") {
+			return true
+		}
+		structType, ok := spec.Type.(*ast.StructType)
+		if !ok {
+			return true
+		}
+		checked++
+		for _, field := range structType.Fields.List {
+			for _, name := range field.Names {
+				if name.Name != "Data" {
+					continue
+				}
+				if _, isSlice := field.Type.(*ast.ArrayType); !isSlice {
+					t.Errorf("%s.Data is not a slice; httperr.recordsIn counts a page by its length "+
+						"and would charge this response as one record however many it serves", spec.Name.Name)
+				}
+				return true
+			}
+		}
+		t.Errorf("%s declares no Data field; httperr.recordsIn reads the page off `Data` and would "+
+			"charge this response as one record however many it serves", spec.Name.Name)
+		return true
+	})
+
+	// A population of zero would pass every assertion above while proving
+	// nothing — the shape this whole file exists to refuse.
+	if checked == 0 {
+		t.Fatalf("no *ListResponse types found in %s; the census matched nothing and can only pass", contractGen)
+	}
+}


### PR DESCRIPTION
## The defect

`Gate.AdmitRead` consults MCP-SESS-READS on the REST door and refuses a passport past the threshold. **Nothing on that door ever increments it.** `agents/quota.go` declared exactly three charge points — `ChargeAdmittedCall`, `ChargeRedeemedCall`, `ChargeEffect` — and none is a read.

So a credential that reads only over `/v1` never accrues toward the bound at all, however much it reads. The cross-door refusal #622 added is real but one-directional: a window spent through `/mcp` does refuse `/v1`, and never the reverse.

The test that proves the refusal had to spend the window *by charging the meter directly*, because reading over REST could not spend it. That was the tell.

## The fix

The charge belongs where records **leave** the surface. On the MCP door that is `newWireRecord → noteRecord → chargeAnswer`. On the REST door it is `httperr.WriteJSON`, and it already exists — 288 call sites go through it.

- `httperr` grows a `ServedMeter` seam. `WriteJSON` reports what a body hands over **before** writing any of it, so a door bounding an agent's reads can still withhold an answer it cannot charge for. `httperr` holds no request and knows nothing about quotas, so a meter that cannot charge answers the request itself.
- `compose` wraps the writer in a `servedMeter` (the same trick `effectRecorder` already uses), so no handler signature changes.
- `Registry.ChargeServedRecords` is the read twin of `ChargeAdmittedCall`, exported for the same reason: compose owns that door and `agents` may not import it.

**Counted in records, not requests** — a page of one and a page of two hundred are not the same read. The count comes from the contract's own list envelope (`Data []T`), not a list of type names, so a list added tomorrow is counted without an edit.

**Refusal follows quota.go's one rule** — refuse only while nothing has happened yet. A read has committed nothing, so an uncountable one is withheld: a charge lost to a blinking Redis is lost for good, Redis recovers, the counter comes back short, and those records are read again for free. A mutation's body is written after its effect landed, so it is served and the undercount absorbed.

## What the work turned up that the issues did not

- **The buffered split-update path would have swallowed the count silently.** It replays raw bytes rather than going back through `WriteJSON`, so the meter is re-pointed onto the buffer.
- **`WriteJSON` was not quite the only spelling.** `approvals` carried a private `writeJSON` twin serving `ListApprovals`/`GetApproval` records the meter could not see; `connectors_imap` encoded inline. Both now go through the one writer — which is what makes the invariant the new comments state actually true.
- **`agentgate.go` crossed the 500-line hard cap.** Not trimmed: the meter is its own concept and moved to `compose/agentservedmeter.go`.

## The derived gate, and why it nearly shipped toothless

#646 asks for a fitness test that "every counter the gate READS on a door has a charge point on that same door" — the thing that would have caught the mutating and read halves together instead of one per release.

`TestEveryCounterTheRestDoorRefusesOnIsChargedOnIt` is that test, and **its first draft passed against the defect.** It read each counter's total at the end of the test; the POST's read-back charges `Reads` through the mutating door, so `Reads` moved even with the read door completely unmetered. It now measures the delta across the one request that must pay, and was re-verified by reintroducing the defect.

Generalised: when more than one path feeds a counter, a cumulative assertion cannot say which path paid.

## Scope

**`#623`'s `/readyz` half is deliberately not here.** A split-role api reports healthy while its whole agent surface refuses, because `/readyz` does not probe the meter's Redis on a role without the inline relay. That is a deployment trade — the fix takes the pod out of rotation for human traffic too — and it does not belong in a quota-accounting change. Filed as #785; **#623 stays open against it, #646 closes here.**

## Verification

- `make check-backend` — green
- `make craft-static` — 0 blocker, 0 major, 0 minor across `backend/`, `extensions/`, `fixtures/`
- `make test-integration` — `OK: integration passed with 0 skips (31 packages, parallel)`
- Guard verified by reintroducing the defect: the three new read tests and the census all fail, then pass

One unrelated flake surfaced during the first lane run and is filed as #786 — the finance card test seeds its ledger generator from a fresh workspace UUID each run, so it draws a random archetype and sometimes lands under the timeliness floor. It is not caused by this branch (the package passes clean at `20286c3f` and with this applied; the re-run is green).

Closes #646

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes REST agent reads so they actually charge the read quota they are refused on. Records served via `/v1` are now counted per record at `httperr.WriteJSON`, aligning REST with MCP and satisfying Linear #646.

- **Bug Fixes**
  - Added a read charge point on REST: `compose` wraps the writer in `servedMeter`; `httperr.WriteJSON` uses `ServedMeter.NoteServed(recordsIn(body))` before writing.
  - Introduced `agents.Registry.ChargeServedRecords` (read twin of `ChargeAdmittedCall`): follows “refuse only before anything happens”; uncountable reads are withheld, mutations are served.
  - Preserved metering through the buffered split-update path via `remeter` so replayed bytes don’t drop counts.
  - Consolidated JSON responses to `httperr.WriteJSON` in `approvals` and `connectors_imap` so all REST answers are visible to the meter.
  - Added guards and tests: REST read charges/per-record counting and self-spend of the window, `TestEveryCounterTheRestDoorRefusesOnIsChargedOnIt`, `httperr/servedmeter_test`, and `listenvelope_test` to lock the `Data []T` list envelope shape.

<sup>Written for commit 958eaf250c7fab36efcac18970f5f7863542a742. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/787?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

