### PR TITLE
feat(company): the record page in the mockup's topology

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -632,6 +632,7 @@ export const de = {
   "timeline.group.mayContinue": "kann früher weitergehen",
   "tab.people": "Personen",
   "tab.timeline": "Verlauf",
+  "tab.documents": "Dokumente",
   // Das Briefing nach den Fragen, die es beantwortet, und die Art jeder
   // Aussage — eine Einschätzung darf nicht wie ein Fakt wirken.
   "co.brief.section.snapshot": "Was sie sind",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -625,6 +625,7 @@ export const en = {
   "timeline.group.mayContinue": "may continue earlier",
   "tab.people": "People",
   "tab.timeline": "History",
+  "tab.documents": "Documents",
   // The brief under the questions it answers, and what kind of claim each
   // sentence makes — a judgment must not read as a stored fact.
   "co.brief.section.snapshot": "What they are",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -627,6 +627,7 @@ export const vi = {
   "timeline.group.mayContinue": "có thể còn tiếp phía trước",
   "tab.people": "Người",
   "tab.timeline": "Lịch sử",
+  "tab.documents": "Tài liệu",
   // The brief under the questions it answers, and what kind of claim each
   // sentence makes — a judgment must not read as a stored fact.
   "co.brief.section.snapshot": "Họ là ai",

--- a/frontend/src/screens/company360.test.tsx
+++ b/frontend/src/screens/company360.test.tsx
@@ -12,8 +12,15 @@ import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { meFixture } from "../app/mefixture";
 import { LocaleProvider } from "../i18n";
-import { PeopleCard } from "./company360";
+import { taskWriteKeys } from "./activitykeys";
+import {
+  AccountBrief,
+  NextSteps,
+  PeopleCard,
+  type SuggestionAction,
+} from "./company360";
 import { CompanyScreen } from "./organizations";
+import { TaskQuickActions, useTaskUpdate } from "./taskactions";
 
 // The company view's honesty rules, which are the whole point of the
 // composite read:
@@ -220,6 +227,57 @@ function render(ui: ReactNode) {
 
 function renderCompany() {
   render(<CompanyScreen id="o-1" />);
+}
+
+// The brief and the open-task list are no longer ON the company page — no
+// mockup draws either, and the record page dropped them with its V2 topology.
+// Both components are still shipped and still carry the reading logic these
+// suites pin (what changed since the last visit, how a citation is counted,
+// what an overdue task says), so the suites mount them DIRECTLY instead of
+// reaching for them through a page that no longer renders them.
+function renderNextSteps(
+  three60: ReturnType<typeof view>,
+  onOpenTask?: (step: { activity_id: string }) => void,
+) {
+  render(<NextSteps view={three60 as never} onOpenTask={onOpenTask} />);
+}
+
+// NextSteps plus the per-row verbs, which the list takes as a render slot
+// rather than owning. Mounting the two together is what pins the pairing the
+// suite is about: a row offers Done always and Snooze only when there is a
+// date to move.
+function NextStepsWithVerbs({
+  three60,
+}: Readonly<{ three60: ReturnType<typeof view> }>) {
+  const update = useTaskUpdate(taskWriteKeys("organization", "o-1"));
+  return (
+    <NextSteps
+      view={three60 as never}
+      onOpenTask={() => {}}
+      renderAction={(step) => (
+        <TaskQuickActions
+          activityId={step.activity_id}
+          dueAt={step.due_at}
+          update={update}
+        />
+      )}
+    />
+  );
+}
+
+function renderBrief(
+  three60: ReturnType<typeof view>,
+  onPerform: (action: SuggestionAction) => void = () => {},
+) {
+  render(
+    <AccountBrief
+      orgId="o-1"
+      view={three60 as never}
+      enabled
+      onOpenRecord={() => {}}
+      onPerform={onPerform}
+    />,
+  );
 }
 
 describe("company view — withheld sections", () => {
@@ -500,19 +558,18 @@ describe("company view — overlay mode", () => {
 
 describe("company view — what changed since the last visit", () => {
   it("counts only the dimensions it was allowed to count", async () => {
-    stub(
-      view({
-        since_last_visit: {
-          baseline_at: "2026-05-30T09:00:00Z",
-          new_activities: 3,
-          // Null, not zero: the caller has no deal grant, so this dimension
-          // was not counted at all and must not read as "nothing moved".
-          deal_stage_moves: null,
-          pending_proposals: 2,
-        },
-      }),
-    );
-    renderCompany();
+    const three60 = view({
+      since_last_visit: {
+        baseline_at: "2026-05-30T09:00:00Z",
+        new_activities: 3,
+        // Null, not zero: the caller has no deal grant, so this dimension
+        // was not counted at all and must not read as "nothing moved".
+        deal_stage_moves: null,
+        pending_proposals: 2,
+      },
+    });
+    stub(three60);
+    renderBrief(three60);
 
     await waitFor(() =>
       expect(
@@ -528,17 +585,16 @@ describe("company view — what changed since the last visit", () => {
   });
 
   it("greets a first visit as a first visit, not as nothing having happened", async () => {
-    stub(
-      view({
-        since_last_visit: {
-          baseline_at: null,
-          new_activities: 0,
-          deal_stage_moves: 0,
-          pending_proposals: 0,
-        },
-      }),
-    );
-    renderCompany();
+    const three60 = view({
+      since_last_visit: {
+        baseline_at: null,
+        new_activities: 0,
+        deal_stage_moves: 0,
+        pending_proposals: 0,
+      },
+    });
+    stub(three60);
+    renderBrief(three60);
 
     await waitFor(() =>
       expect(
@@ -551,25 +607,24 @@ describe("company view — what changed since the last visit", () => {
 
 describe("company view — next steps", () => {
   it("marks an overdue task and names what it is linked to", async () => {
-    stub(
-      view({
-        next_steps: {
-          data: [
-            {
-              activity_id: "a-1",
-              subject: "Send the renewal paperwork",
-              due_at: "2026-05-01T09:00:00Z",
-              overdue: true,
-              linked_deal_id: null,
-              linked_person_id: null,
-              assignee_id: null,
-            },
-          ],
-          page: emptyPage,
-        },
-      }),
-    );
-    renderCompany();
+    const three60 = view({
+      next_steps: {
+        data: [
+          {
+            activity_id: "a-1",
+            subject: "Send the renewal paperwork",
+            due_at: "2026-05-01T09:00:00Z",
+            overdue: true,
+            linked_deal_id: null,
+            linked_person_id: null,
+            assignee_id: null,
+          },
+        ],
+        page: emptyPage,
+      },
+    });
+    stub(three60);
+    renderNextSteps(three60);
 
     await waitFor(() =>
       expect(screen.getByText("Send the renewal paperwork")).toBeTruthy(),
@@ -708,35 +763,33 @@ describe("company view — the citations under a finding", () => {
   });
 
   it("collapses several sources of one unopenable kind into one counted chip", async () => {
-    stub(
-      view({
-        suggestions: [
-          suggestion([
-            { entity_type: "activity", entity_id: "a-1" },
-            { entity_type: "activity", entity_id: "a-2" },
-            { entity_type: "activity", entity_id: "a-3" },
-          ]),
-        ],
-      }),
-    );
-    renderCompany();
+    const three60 = view({
+      suggestions: [
+        suggestion([
+          { entity_type: "activity", entity_id: "a-1" },
+          { entity_type: "activity", entity_id: "a-2" },
+          { entity_type: "activity", entity_id: "a-3" },
+        ]),
+      ],
+    });
+    stub(three60);
+    renderBrief(three60);
     // Not "activityactivityactivity": one chip that says how many.
     await waitFor(() => expect(screen.getByText("3 activities")).toBeTruthy());
     expect(screen.queryAllByText("activity")).toHaveLength(0);
   });
 
   it("counts one record cited twice as one source", async () => {
-    stub(
-      view({
-        suggestions: [
-          suggestion([
-            { entity_type: "activity", entity_id: "a-1" },
-            { entity_type: "activity", entity_id: "a-1" },
-          ]),
-        ],
-      }),
-    );
-    renderCompany();
+    const three60 = view({
+      suggestions: [
+        suggestion([
+          { entity_type: "activity", entity_id: "a-1" },
+          { entity_type: "activity", entity_id: "a-1" },
+        ]),
+      ],
+    });
+    stub(three60);
+    renderBrief(three60);
     await waitFor(() => expect(screen.getByText("activity")).toBeTruthy());
     expect(screen.queryByText("2 activities")).toBeNull();
   });
@@ -805,8 +858,9 @@ describe("company view — an open task can be acted on", () => {
   };
 
   it("renders the subject as a way to open the task, with the two verbs beside it", async () => {
-    stub(view({ next_steps: { data: [step], page: emptyPage } }));
-    renderCompany();
+    const three60 = view({ next_steps: { data: [step], page: emptyPage } });
+    stub(three60);
+    render(<NextStepsWithVerbs three60={three60} />);
     await waitFor(() =>
       expect(
         screen.getByRole("button", { name: "Send the retrofit proposal" }),
@@ -817,12 +871,11 @@ describe("company view — an open task can be acted on", () => {
   });
 
   it("offers no snooze for a task with no date to move", async () => {
-    stub(
-      view({
-        next_steps: { data: [{ ...step, due_at: null }], page: emptyPage },
-      }),
-    );
-    renderCompany();
+    const three60 = view({
+      next_steps: { data: [{ ...step, due_at: null }], page: emptyPage },
+    });
+    stub(three60);
+    render(<NextStepsWithVerbs three60={three60} />);
     await waitFor(() =>
       expect(screen.getByRole("button", { name: "Done" })).toBeTruthy(),
     );
@@ -1559,28 +1612,27 @@ describe("company view — the state strip", () => {
 
 describe("company view — advice you can act on", () => {
   it("offers the action the server named, and none where it named none", async () => {
-    stub(
-      view({
-        suggestions: [
-          {
-            kind: "no_reply",
-            fingerprint: "f1",
-            reason: "You reached out 15 days ago and nobody has come back.",
-            evidence: [],
-            action: { kind: "draft_reply", activity_id: "a-1" },
-          },
-          {
-            kind: "no_next_step",
-            fingerprint: "f2",
-            reason: "2 open deal(s) here and no task saying what happens next.",
-            evidence: [],
-            action: null,
-          },
-        ],
-        suggestions_dropped: 0,
-      }),
-    );
-    renderCompany();
+    const three60 = view({
+      suggestions: [
+        {
+          kind: "no_reply",
+          fingerprint: "f1",
+          reason: "You reached out 15 days ago and nobody has come back.",
+          evidence: [],
+          action: { kind: "draft_reply", activity_id: "a-1" },
+        },
+        {
+          kind: "no_next_step",
+          fingerprint: "f2",
+          reason: "2 open deal(s) here and no task saying what happens next.",
+          evidence: [],
+          action: null,
+        },
+      ],
+      suggestions_dropped: 0,
+    });
+    stub(three60);
+    renderBrief(three60);
     await screen.findByText(/nobody has come back/);
 
     expect(screen.getByRole("button", { name: "Draft a reply" })).toBeTruthy();
@@ -1620,18 +1672,6 @@ describe("company view — the account's own tabs", () => {
     expect(screen.getAllByText("Christian Hagemeyer").length).toBeGreaterThan(
       1,
     );
-  });
-
-  it("keeps Ask on the overview rather than following the history", async () => {
-    stub(view());
-    renderCompany();
-    await screen.findByRole("complementary", { name: "Business" });
-
-    // Asking is a tool for when the page did not answer the question. It
-    // belongs to the account, not to its chronology.
-    expect(screen.getByText("Ask Margince")).toBeTruthy();
-    await userEvent.click(screen.getByRole("button", { name: "History" }));
-    expect(screen.queryByText("Ask Margince")).toBeNull();
   });
 });
 

--- a/frontend/src/screens/company360.test.tsx
+++ b/frontend/src/screens/company360.test.tsx
@@ -229,12 +229,9 @@ function renderCompany() {
   render(<CompanyScreen id="o-1" />);
 }
 
-// The brief and the open-task list are no longer ON the company page — no
-// mockup draws either, and the record page dropped them with its V2 topology.
-// Both components are still shipped and still carry the reading logic these
-// suites pin (what changed since the last visit, how a citation is counted,
-// what an overdue task says), so the suites mount them DIRECTLY instead of
-// reaching for them through a page that no longer renders them.
+// The brief and the open-task list are components of their own, mounted here
+// directly rather than through the company page: the page does not render
+// either, so reaching for them through it would assert nothing.
 function renderNextSteps(
   three60: ReturnType<typeof view>,
   onOpenTask?: (step: { activity_id: string }) => void,
@@ -1671,6 +1668,32 @@ describe("company view — the account's own tabs", () => {
     // section of the one composite read, so they cannot disagree.
     expect(screen.getAllByText("Christian Hagemeyer").length).toBeGreaterThan(
       1,
+    );
+  });
+
+  it("offers the four tabs the record page has, in order", async () => {
+    stub(view());
+    renderCompany();
+    await screen.findByRole("complementary", { name: "Business" });
+
+    // An account with no partner programme still gets all four: Partner is
+    // the only conditional tab.
+    for (const name of ["Overview", "People", "History", "Documents"]) {
+      expect(screen.getByRole("button", { name })).toBeTruthy();
+    }
+    expect(screen.queryByRole("button", { name: "Partner" })).toBeNull();
+  });
+
+  it("gives Documents its own tab body", async () => {
+    stub(view());
+    renderCompany();
+    await screen.findByRole("complementary", { name: "Business" });
+
+    await userEvent.click(screen.getByRole("button", { name: "Documents" }));
+    // The grid keeps a compact card for "is there paperwork at all"; the tab
+    // is the files themselves, so the heading appears twice once it is open.
+    await waitFor(() =>
+      expect(screen.getAllByText("Documents").length).toBeGreaterThan(1),
     );
   });
 });

--- a/frontend/src/screens/organizations.test.tsx
+++ b/frontend/src/screens/organizations.test.tsx
@@ -1620,12 +1620,10 @@ const stalledSuggestion = {
   evidence: [{ entity_type: "deal", entity_id: "d-1" }],
 };
 
-// The suggestion rows and the ask card are no longer ON the company page: no
-// V2 mockup draws either, and the record page dropped both with its topology
-// change. The components still ship and still own this behaviour, so these
-// suites mount them DIRECTLY rather than through a page that no longer renders
-// them — mounting the page instead would leave every "the card is absent"
-// assertion below passing for the wrong reason.
+// The suggestion rows and the ask card are components of their own, mounted
+// here directly rather than through the company page, which renders neither.
+// This matters for the "the card is absent" cases below: asserted against a
+// page that never mounts one, they would hold no matter what the card did.
 function renderBriefFor(three60: unknown) {
   render(
     <AccountBrief
@@ -1727,7 +1725,7 @@ describe("CompanyScreen — next-step suggestions", () => {
     );
   });
 
-  it("dismisses by fingerprint, and re-reads the 360 rather than hiding the row itself", async () => {
+  it("dismisses by fingerprint and leaves the row for the server to remove", async () => {
     let dismissed: unknown;
     stubFetch(
       async (url, method, request) => {

--- a/frontend/src/screens/organizations.test.tsx
+++ b/frontend/src/screens/organizations.test.tsx
@@ -14,6 +14,8 @@ import type { ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { pickOption } from "../design-system/select-testing";
 import { LocaleProvider } from "../i18n";
+import { AssistantPanel } from "./assistant";
+import { AccountBrief } from "./company360";
 import {
   CompaniesScreen,
   CompanyScreen,
@@ -1618,12 +1620,29 @@ const stalledSuggestion = {
   evidence: [{ entity_type: "deal", entity_id: "d-1" }],
 };
 
+// The suggestion rows and the ask card are no longer ON the company page: no
+// V2 mockup draws either, and the record page dropped both with its topology
+// change. The components still ship and still own this behaviour, so these
+// suites mount them DIRECTLY rather than through a page that no longer renders
+// them — mounting the page instead would leave every "the card is absent"
+// assertion below passing for the wrong reason.
+function renderBriefFor(three60: unknown) {
+  render(
+    <AccountBrief
+      orgId="o-1"
+      view={three60 as never}
+      enabled
+      onOpenRecord={() => {}}
+      onPerform={() => {}}
+    />,
+  );
+}
+
 describe("CompanyScreen — next-step suggestions", () => {
   it("leads each suggestion with the reason the rule fired, and cites the record", async () => {
-    stubFetch(companyBackstop, {
-      org360: { ...org360, suggestions: [stalledSuggestion] },
-    });
-    render(<CompanyScreen id="o-1" />);
+    const three60 = { ...org360, suggestions: [stalledSuggestion] };
+    stubFetch(companyBackstop, { org360: three60 });
+    renderBriefFor(three60);
 
     await waitFor(() =>
       expect(screen.getByText(stalledSuggestion.reason)).toBeTruthy(),
@@ -1634,14 +1653,13 @@ describe("CompanyScreen — next-step suggestions", () => {
   });
 
   it("names how many suggestions the card left out", async () => {
-    stubFetch(companyBackstop, {
-      org360: {
-        ...org360,
-        suggestions: [stalledSuggestion],
-        suggestions_dropped: 3,
-      },
-    });
-    render(<CompanyScreen id="o-1" />);
+    const three60 = {
+      ...org360,
+      suggestions: [stalledSuggestion],
+      suggestions_dropped: 3,
+    };
+    stubFetch(companyBackstop, { org360: three60 });
+    renderBriefFor(three60);
 
     // A truncated list with no count reads as "that is everything".
     await waitFor(() =>
@@ -1652,14 +1670,13 @@ describe("CompanyScreen — next-step suggestions", () => {
   it("stays silent about what it left out when there is nothing left out", async () => {
     // Zero is the ordinary case, so the "N more" line must not render on it —
     // otherwise every card carries "0 more not shown here."
-    stubFetch(companyBackstop, {
-      org360: {
-        ...org360,
-        suggestions: [stalledSuggestion],
-        suggestions_dropped: 0,
-      },
-    });
-    render(<CompanyScreen id="o-1" />);
+    const three60 = {
+      ...org360,
+      suggestions: [stalledSuggestion],
+      suggestions_dropped: 0,
+    };
+    stubFetch(companyBackstop, { org360: three60 });
+    renderBriefFor(three60);
 
     await waitFor(() =>
       expect(screen.getByText(stalledSuggestion.reason)).toBeTruthy(),
@@ -1670,14 +1687,13 @@ describe("CompanyScreen — next-step suggestions", () => {
   it("stays silent about what it left out when the count is absent", async () => {
     // Absent means the section was never computed. A "0 more" line would state a
     // fact about an account this read did not look at.
-    stubFetch(companyBackstop, {
-      org360: {
-        ...org360,
-        suggestions: [stalledSuggestion],
-        suggestions_dropped: undefined,
-      },
-    });
-    render(<CompanyScreen id="o-1" />);
+    const three60 = {
+      ...org360,
+      suggestions: [stalledSuggestion],
+      suggestions_dropped: undefined,
+    };
+    stubFetch(companyBackstop, { org360: three60 });
+    renderBriefFor(three60);
 
     await waitFor(() =>
       expect(screen.getByText(stalledSuggestion.reason)).toBeTruthy(),
@@ -1687,35 +1703,33 @@ describe("CompanyScreen — next-step suggestions", () => {
 
   it("says nothing at all when the account needs nothing", async () => {
     stubFetch(companyBackstop);
-    render(<CompanyScreen id="o-1" />);
+    renderBriefFor(org360);
 
-    await waitFor(() =>
-      expect(screen.getByText("Brandt Automotive GmbH")).toBeTruthy(),
-    );
     // "No advice" is not something a rep acts on, so the card is absent
-    // rather than empty.
-    expect(screen.queryByText("Worth doing next")).toBeNull();
+    // rather than empty. Asserted against a MOUNTED brief: on a page that
+    // never renders one, this would hold no matter what the component did.
+    await waitFor(() =>
+      expect(screen.queryByText("Worth doing next")).toBeNull(),
+    );
   });
 
   it("stays silent rather than claiming no advice when the section is withheld", async () => {
-    stubFetch(companyBackstop, {
-      org360: {
-        ...org360,
-        suggestions: undefined,
-        sections_omitted: ["suggestions"],
-      },
-    });
-    render(<CompanyScreen id="o-1" />);
+    const three60 = {
+      ...org360,
+      suggestions: undefined,
+      sections_omitted: ["suggestions"],
+    };
+    stubFetch(companyBackstop, { org360: three60 });
+    renderBriefFor(three60);
 
     await waitFor(() =>
-      expect(screen.getByText("Brandt Automotive GmbH")).toBeTruthy(),
+      expect(screen.queryByText("Worth doing next")).toBeNull(),
     );
-    expect(screen.queryByText("Worth doing next")).toBeNull();
   });
 
   it("dismisses by fingerprint, and re-reads the 360 rather than hiding the row itself", async () => {
     let dismissed: unknown;
-    const { urls } = stubFetch(
+    stubFetch(
       async (url, method, request) => {
         if (method === "POST" && url.includes("/suggestions/dismiss")) {
           dismissed = await request.json();
@@ -1725,7 +1739,7 @@ describe("CompanyScreen — next-step suggestions", () => {
       },
       { org360: { ...org360, suggestions: [stalledSuggestion] } },
     );
-    render(<CompanyScreen id="o-1" />);
+    renderBriefFor({ ...org360, suggestions: [stalledSuggestion] });
 
     await waitFor(() =>
       expect(screen.getByText(stalledSuggestion.reason)).toBeTruthy(),
@@ -1733,11 +1747,11 @@ describe("CompanyScreen — next-step suggestions", () => {
     await userEvent.click(screen.getByRole("button", { name: "Not now" }));
 
     await waitFor(() => expect(dismissed).toBeTruthy());
+    // The server decides what survives: the card sends the fingerprint and
+    // does NOT hide the row itself. Whether the surrounding page then re-reads
+    // the 360 is the page's business, and this suite mounts the card alone.
     expect(dismissed).toEqual({ fingerprint: "fp-stalled-1" });
-    // The server decides what survives: the row goes when the re-read says so.
-    await waitFor(() =>
-      expect(urls.filter((u) => u.endsWith("/360")).length).toBeGreaterThan(1),
-    );
+    expect(screen.getByText(stalledSuggestion.reason)).toBeTruthy();
   });
 
   it("says a dismissal failed instead of leaving the click looking like a miss", async () => {
@@ -1750,7 +1764,7 @@ describe("CompanyScreen — next-step suggestions", () => {
       },
       { org360: { ...org360, suggestions: [stalledSuggestion] } },
     );
-    render(<CompanyScreen id="o-1" />);
+    renderBriefFor({ ...org360, suggestions: [stalledSuggestion] });
 
     await waitFor(() =>
       expect(screen.getByText(stalledSuggestion.reason)).toBeTruthy(),
@@ -1788,7 +1802,7 @@ describe("CompanyScreen — Ask Margince", () => {
       }
       return companyBackstop(url);
     });
-    render(<CompanyScreen id="o-1" />);
+    render(<AssistantPanel orgId="o-1" enabled onOpenRecord={() => {}} />);
 
     await waitFor(() =>
       expect(
@@ -1819,7 +1833,7 @@ describe("CompanyScreen — Ask Margince", () => {
       }
       return companyBackstop(url);
     });
-    render(<CompanyScreen id="o-1" />);
+    render(<AssistantPanel orgId="o-1" enabled onOpenRecord={() => {}} />);
 
     await waitFor(() =>
       expect(
@@ -1842,7 +1856,7 @@ describe("CompanyScreen — Ask Margince", () => {
       }
       return companyBackstop(url);
     });
-    render(<CompanyScreen id="o-1" />);
+    render(<AssistantPanel orgId="o-1" enabled onOpenRecord={() => {}} />);
 
     await waitFor(() =>
       expect(

--- a/frontend/src/screens/organizations.tsx
+++ b/frontend/src/screens/organizations.tsx
@@ -34,8 +34,6 @@ import {
 import { formatDateTime, formatMoney } from "../format/format";
 import { type Locale, useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
-import { taskWriteKeys } from "./activitykeys";
-import { AssistantPanel } from "./assistant";
 import {
   coldFieldLabel,
   LoadMoreButton,
@@ -49,17 +47,14 @@ import {
   useViewerId,
 } from "./common";
 import {
-  AccountBrief,
   DealsCard,
   HealthCard,
-  NextSteps,
   type Org360Result,
   OverlayFallback,
   PeopleCard,
   RECORD_ZONE,
   SignalsCard,
   StateStrip,
-  type SuggestionAction,
   TagsCard,
   useAcknowledgeOrganizationView,
   useOrganization360,
@@ -109,11 +104,6 @@ import { LogActivityAction } from "./logactivity";
 import { PartnerTab } from "./partners";
 import { activityTimeline } from "./people";
 import { RelationshipsTab } from "./relationships";
-import {
-  TaskDetailModal,
-  TaskQuickActions,
-  useTaskUpdate,
-} from "./taskactions";
 import { groupChronology } from "./timelinegroups";
 
 // Companies list + company 360 (B-EP09.10a/b). Firmographics render
@@ -1412,17 +1402,23 @@ function FactsCard({
   );
 }
 
-// Two tabs, not three. The company view is ONE scrolling page: the
-// relationship edges and the hierarchy roll-up moved into its rails, where a
-// rep reads them alongside everything else instead of hunting for them.
+// Overview · People · History · Documents, as both mockups draw the strip.
+// `timeline` IS the mockup's History — it presents as "Verlauf"/"History" and
+// carries the account's chronology; the id stays as it is because it is in
+// every saved URL. The audit spine is still not a tab: it is an inspection of
+// the record rather than part of its story, and it opens from the header's
+// overflow menu.
 //
-// History is no longer one of them. Field changes belong in the account's own
-// chronology (the timeline's Changes filter), and the audit spine is an
-// inspection of the record rather than part of its story — it opens from the
-// header's overflow menu. A tab of equal weight beside the account's story
-// said the two were the same kind of question. Partner stays a tab: it is a
-// form, not a reading of this account.
-const COMPANY_TABS = ["overview", "people", "timeline", "partner"] as const;
+// Documents is a tab rather than only a card because the mockup gives files
+// their own place in the strip, and the card cannot hold the table it draws.
+// Partner stays a tab: it is a form, not a reading of this account.
+const COMPANY_TABS = [
+  "overview",
+  "people",
+  "timeline",
+  "documents",
+  "partner",
+] as const;
 type CompanyTab = (typeof COMPANY_TABS)[number];
 
 // Partner is not a permanent tab. It renders the partner programme —
@@ -1446,7 +1442,7 @@ function companyTabsFor(
   const isPartner = (org.relationship_types ?? []).includes("partner");
   return isPartner || tab === "partner"
     ? COMPANY_TABS
-    : (["overview", "people", "timeline"] as const);
+    : (["overview", "people", "timeline", "documents"] as const);
 }
 
 // Which slice of the account's chronology is on screen. Activities is what
@@ -1538,6 +1534,7 @@ function CompanyRecord({
             overview: t("tab.overview"),
             people: t("tab.people"),
             timeline: t("tab.timeline"),
+            documents: t("tab.documents"),
             partner: t("tab.partner"),
           }}
         />
@@ -1943,7 +1940,6 @@ function CompanyPage({
   onTab: (next: CompanyTab) => void;
 }>) {
   const t = useT();
-  const [openTaskId, setOpenTaskId] = useState<string | null>(null);
   // The two surfaces a suggestion's action opens. Held here because both are
   // page-level: the composer anchors on a timeline message, and the task form
   // is the account's own log-activity surface.
@@ -1956,9 +1952,6 @@ function CompanyPage({
   const [decisionsOpen, setDecisionsOpen] = useState(false);
   const [auditOpen, setAuditOpen] = useState(false);
   const receipt = useCitedReceipt();
-  // A task written or completed from this page changes the account's timeline,
-  // its next steps (both read from the 360) and the standing work queue.
-  const taskUpdate = useTaskUpdate(taskWriteKeys("organization", org.id));
   const { slots, showChanges: filterToChanges } = useChronologySlots({
     org,
     view,
@@ -1967,10 +1960,6 @@ function CompanyPage({
     failed,
     active: tab === "timeline",
   });
-  // An evidence mark asks where a value came from, and the answer is the
-  // record's change history — which now lives on its own tab.
-  const openTask = (step: { activity_id: string }) =>
-    setOpenTaskId(step.activity_id);
   const showChanges = () => {
     onTab("timeline");
     filterToChanges();
@@ -2027,21 +2016,15 @@ function CompanyPage({
       // The Partner tab is a form, so it does not repeat it under itself.
       {...slots}
     >
-      {tabs}
-      {/* Overlay refuses the whole company page, not one tab of it: the
-          partner extension and the field history are native records the
-          mirror does not hold, so switching tabs must not walk around the
-          refusal into reads that can only fail. */}
-      {overlay && <OverlayFallback />}
-      {!overlay && tab === "partner" && <PartnerTab organizationId={org.id} />}
-      {tab === "overview" && failed && (
-        <EmptyState>{t("co.partial")}</EmptyState>
-      )}
-      {/* The strip leads, before any prose: where the account stands, whose
-          move it is, and what work is open. Three readings a rep can act on
-          without reading a sentence — and the one that replaced a number
-          nobody could scale. */}
-      {tab === "overview" && view && (
+      {/* The strip leads, ABOVE the tab strip: where the account stands, what
+          it is worth and whether it pays — the readings a rep opens the page
+          for, before being asked which part of it to read (mockup States A
+          and D put it directly under the header).
+          It belongs to the RECORD rather than to the overview for the same
+          reason the business grid does: it describes the account, not one
+          view of it, and a strip that vanished on the People tab would move
+          the tabs and re-flow the page under the reader. */}
+      {view && (
         <StateStrip
           orgId={org.id}
           view={view}
@@ -2061,6 +2044,16 @@ function CompanyPage({
           }
         />
       )}
+      {tabs}
+      {/* Overlay refuses the whole company page, not one tab of it: the
+          partner extension and the field history are native records the
+          mirror does not hold, so switching tabs must not walk around the
+          refusal into reads that can only fail. */}
+      {overlay && <OverlayFallback />}
+      {!overlay && tab === "partner" && <PartnerTab organizationId={org.id} />}
+      {tab === "overview" && failed && (
+        <EmptyState>{t("co.partial")}</EmptyState>
+      )}
       {/* What needs a person, before anything that merely reports state. It is
           assembled from sections the page already read — open tasks, the
           calendar, what changed since the last visit, the suggestions — put in
@@ -2073,11 +2066,8 @@ function CompanyPage({
           overlay={overlay}
           loading={loading}
           failed={failed}
-          taskUpdate={taskUpdate}
-          onOpenTask={openTask}
           onCompose={(id) => setComposing({ kind: "reply", id })}
           onDraftTo={(id) => setComposing({ kind: "account", id })}
-          onLogTask={() => setTaskFormOpen(true)}
           onOpenRecord={receipt.open}
         />
       )}
@@ -2114,21 +2104,16 @@ function CompanyPage({
         />
       )}
       {/* The People tab gives the account team the whole middle column. The
-          rail's card is a summary; this is the roster, with room for the title
+          grid's card is a summary; this is the roster, with room for the title
           and the last exchange beside each name. */}
-      {/* Asking sits UNDER the account's own story: it is the tool for when the
-          page did not already answer the question. It belongs to the account
-          rather than to its history, so it stays on the overview instead of
-          following the chronology onto its own tab. */}
       {tab === "people" && (
         <PeopleCard view={view} writable={!org.archived_at} orgId={org.id} />
       )}
-      {openTaskId && (
-        <TaskDetailModal
-          activityId={openTaskId}
-          onClose={() => setOpenTaskId(null)}
-          update={taskUpdate}
-        />
+      {/* Files get the whole column on their own tab, which is what the mockup
+          gives them. The grid keeps its compact card for the reader who only
+          wants to know whether there IS paperwork. */}
+      {!overlay && tab === "documents" && (
+        <CompanyDocumentsCard orgId={org.id} />
       )}
       {/* The decision queue belongs to the OVERVIEW. Leaving it standing over
           Partner put a panel from one tab on top of another, and a reader who
@@ -2182,21 +2167,18 @@ function CompanyPage({
   );
 }
 
-// The overview's own stack: what needs a person, then what the account looks
-// like, then the open commitments in full. Extracted from CompanyPage because
-// each section was its own `tab === "overview" && view &&` branch there, and the
-// page had become a list of conditions rather than a layout.
+// The overview's own stack: what needs a person today, then what the account
+// looks like. Extracted from CompanyPage because each section was its own
+// `tab === "overview" && view &&` branch there, and the page had become a list
+// of conditions rather than a layout.
 function CompanyOverviewStack({
   org,
   view,
   overlay,
   loading,
   failed,
-  taskUpdate,
-  onOpenTask,
   onCompose,
   onDraftTo,
-  onLogTask,
   onOpenRecord,
 }: Readonly<{
   org: Organization;
@@ -2204,11 +2186,8 @@ function CompanyOverviewStack({
   overlay: boolean;
   loading: boolean;
   failed: boolean;
-  taskUpdate: ReturnType<typeof useTaskUpdate>;
-  onOpenTask: (step: { activity_id: string }) => void;
   onCompose: (activityId: string) => void;
   onDraftTo: (personId: string) => void;
-  onLogTask: () => void;
   // Where a cited chip leads. Owned by the page, because the grid below this
   // stack cites the same records and two owners would mean two receipts open
   // over each other.
@@ -2225,24 +2204,19 @@ function CompanyOverviewStack({
         onPrepareMeeting={onCompose}
         onDraftTo={onDraftTo}
       />
-      {/* Then what the account looks like right now, in its own words and
-          ours. These three read the same evidence and cite it the same way, so
-          they lead the overview together — the grid of business cards below
-          them belongs to the record and renders on every tab. */}
-      {view && (
-        <AccountBrief
-          orgId={org.id}
-          view={view}
-          enabled={!overlay}
-          onOpenRecord={onOpenRecord}
-          onPerform={(action) =>
-            performSuggestion(action, {
-              compose: onCompose,
-              logTask: onLogTask,
-            })
-          }
-        />
-      )}
+      {/* Then what the account looks like, in its own words and ours. The two
+          read the same evidence and cite it the same way, so they lead the
+          overview together — the grid of business cards below them belongs to
+          the record and renders on every tab.
+
+          The account BRIEF is not among them, and neither is the open-task
+          list or the ask prompt. No mockup draws any of the three, and the
+          brief in particular was the page's largest departure: a column of
+          generated prose with a claim chip after every sentence, above the
+          cards a reader came for. Nothing is lost with it — the next
+          commitment and what changed are tiles on Today, the open tasks are
+          the Tasks screen and the Today tile that counts them, and asking is
+          the Ask Margince screen in the primary nav. */}
       <DossierPanel
         orgId={org.id}
         enabled={!overlay}
@@ -2253,23 +2227,6 @@ function CompanyOverviewStack({
         enabled={!overlay}
         onOpenRecord={onOpenRecord}
       />
-      {/* The open commitments in full, then the tool for when the page did not
-          answer the question. Neither is a card about the account — one is a
-          work list and one is a prompt — so neither belongs in the grid. */}
-      {view && (
-        <NextSteps
-          view={view}
-          onOpenTask={onOpenTask}
-          renderAction={(step) => (
-            <TaskQuickActions
-              activityId={step.activity_id}
-              dueAt={step.due_at}
-              update={taskUpdate}
-            />
-          )}
-        />
-      )}
-      <AssistantPanel orgId={org.id} enabled onOpenRecord={onOpenRecord} />
     </>
   );
 }
@@ -2363,33 +2320,6 @@ function CompanyBusinessGrid({
       </Disclosure>
     </aside>
   );
-}
-
-// performSuggestion carries out the advice the server named.
-//
-// It routes rather than acts: each kind opens the governed surface a rep would
-// have reached for anyway, prefilled from the evidence the rule fired on.
-// Nothing here writes, and nothing is staged — the card advises, the surface
-// it opens is where the human decides.
-//
-// draft_reply and add_task both land on the account's own timeline surfaces,
-// which is why the page owns this handler rather than the card: the composer
-// and the log-activity form live here.
-function performSuggestion(
-  action: SuggestionAction,
-  open: { compose: (activityId: string) => void; logTask: () => void },
-) {
-  if (action.kind === "open_deal" && action.deal_id) {
-    openCitation("deal", action.deal_id);
-    return;
-  }
-  if (action.kind === "draft_reply" && action.activity_id) {
-    open.compose(action.activity_id);
-    return;
-  }
-  if (action.kind === "add_task") {
-    open.logTask();
-  }
 }
 
 // openCitation routes a cited record to its own screen. The brief, the

--- a/frontend/src/screens/organizations.tsx
+++ b/frontend/src/screens/organizations.tsx
@@ -100,7 +100,6 @@ import {
   ListTable,
   useListQuery,
 } from "./listquery";
-import { LogActivityAction } from "./logactivity";
 import { PartnerTab } from "./partners";
 import { activityTimeline } from "./people";
 import { RelationshipsTab } from "./relationships";
@@ -1940,15 +1939,11 @@ function CompanyPage({
   onTab: (next: CompanyTab) => void;
 }>) {
   const t = useT();
-  // The two surfaces a suggestion's action opens. Held here because both are
-  // page-level: the composer anchors on a timeline message, and the task form
-  // is the account's own log-activity surface.
   // ONE composer, opened two ways. Anchored on a timeline message it answers
   // that message; anchored on a person it starts a new one and grounds on the
   // account instead of a thread (ADR-0087 §1). Two pieces of state would let
   // both open at once, which is two composers over each other.
   const [composing, setComposing] = useState<ComposeAnchor | null>(null);
-  const [taskFormOpen, setTaskFormOpen] = useState(false);
   const [decisionsOpen, setDecisionsOpen] = useState(false);
   const [auditOpen, setAuditOpen] = useState(false);
   const receipt = useCitedReceipt();
@@ -2018,13 +2013,14 @@ function CompanyPage({
     >
       {/* The strip leads, ABOVE the tab strip: where the account stands, what
           it is worth and whether it pays — the readings a rep opens the page
-          for, before being asked which part of it to read (mockup States A
-          and D put it directly under the header).
+          for, before being asked which part of it to read.
           It belongs to the RECORD rather than to the overview for the same
           reason the business grid does: it describes the account, not one
           view of it, and a strip that vanished on the People tab would move
-          the tabs and re-flow the page under the reader. */}
-      {view && (
+          the tabs and re-flow the page under the reader.
+          Guarded on overlay like every other body below, so the page's one
+          refusal stays the whole page's. */}
+      {!overlay && view && (
         <StateStrip
           orgId={org.id}
           view={view}
@@ -2092,15 +2088,6 @@ function CompanyPage({
           anchor={composing}
           orgId={org.id}
           onClose={() => setComposing(null)}
-        />
-      )}
-      {taskFormOpen && (
-        <LogActivityAction
-          entityType="organization"
-          entityId={org.id}
-          initialKind="task"
-          openOnMount
-          onClose={() => setTaskFormOpen(false)}
         />
       )}
       {/* The People tab gives the account team the whole middle column. The
@@ -2207,16 +2194,7 @@ function CompanyOverviewStack({
       {/* Then what the account looks like, in its own words and ours. The two
           read the same evidence and cite it the same way, so they lead the
           overview together — the grid of business cards below them belongs to
-          the record and renders on every tab.
-
-          The account BRIEF is not among them, and neither is the open-task
-          list or the ask prompt. No mockup draws any of the three, and the
-          brief in particular was the page's largest departure: a column of
-          generated prose with a claim chip after every sentence, above the
-          cards a reader came for. Nothing is lost with it — the next
-          commitment and what changed are tiles on Today, the open tasks are
-          the Tasks screen and the Today tile that counts them, and asking is
-          the Ask Margince screen in the primary nav. */}
+          the record and renders on every tab. */}
       <DossierPanel
         orgId={org.id}
         enabled={!overlay}


### PR DESCRIPTION
The company record page rendered tabs, then a four-slot strip, then a column of generated prose, then the cards. Both V2 mockups (`docs/explanation/assets/company-record-page-v2/`) draw the strip directly under the header, four tabs below it, and no prose block at all. Restyling cards inside that shape could not produce the mockup, so this changes the shape.

Depends on #784 (the visual acceptance harness), which is how the result is verified.

## What changes

**The KPI strip moves above the tab strip**, and becomes record-level rather than overview-only. It describes the account, not one view of it, and a strip that vanished on the People tab would move the tabs and re-flow the page under the reader.

**Tabs become Overview · People · History · Documents.** Three already existed — `timeline` IS the mockup's History and already presents as "Verlauf"/"History" — so only Documents is new, and it gets the whole column that the compact grid card cannot hold. The tab id stays `timeline` because it is in saved URLs.

**Three sections leave the overview**, none of which appear in any mockup:

- the account brief ("Before you talk to them") — the largest departure: generated prose with a claim chip after every sentence, standing above the cards a reader came for
- the open-task list ("Next steps")
- the ask panel ("Ask about this account")

Nothing is lost. The next commitment is already a Today tile, open tasks are the Tasks screen, and asking is Ask Margince in the primary nav.

Removing them orphaned the task-detail modal — its only opener was the next-step row — so it goes with them rather than staying as unreachable code. `performSuggestion` loses its last caller and goes too.

## Tests

The suites that covered those three sections through the **page** now mount the components **directly**, because both components still ship and still own the behaviour. This matters for more than tidiness: two of them assert that a card is *absent*, and through a page that no longer renders one, those assertions would have passed no matter what the component did.

One test is deleted rather than moved — "keeps Ask on the overview rather than following the history" asserts exactly the behaviour the mockup removes.

Mutation-checked: breaking `NextSteps` makes the moved test fail, so it still proves what it claims.

## Verification

`make check-fe` green (1622 tests). Against the live stack the harness from #784 goes from 1/8 to **5/8 passing**; the three still red are the phases not yet built — six KPI slots, six Today tiles, and the right rail.

Screenshotted on a populated account and a freshly imported one: strip above tabs, four tabs, prose block gone.

## Filed, not fixed

#789 — the header shows the owner's raw UUID until the roster read lands. Pre-existing, in code this PR does not touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reworks the company record page to match V2 mockups. The KPI strip now sits under the header on every tab; tabs are Overview, People, History (`timeline`), and Documents. Removes the Brief, Next Steps, and Ask panels from the overview.

- New Features
  - Move KPI strip above the tabs and make it record-level.
  - Add Documents tab with a full-column files view; add i18n keys for “Documents” (en/de/vi).
  - Keep `timeline` as the History tab id for existing URLs; keep Partner as a conditional tab.

- Bug Fixes
  - Guard `StateStrip` with the overlay check to match other tab bodies.
  - Remove dead `taskFormOpen`, unreachable `TaskDetailModal`, and unused `performSuggestion`.
  - Update tests to mount `AccountBrief`/`NextSteps` (and the assistant) directly; add tests for tab order and the Documents tab body.

<sup>Written for commit 7fc6ff5b2d9e7a1188012fbd0728f55f4e9640db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/790?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Documents tab to company pages, with English, German, and Vietnamese labels.
  * Added dedicated content areas for People and Documents.
* **Improvements**
  * Streamlined the company page layout and tab navigation.
  * Kept business information visible while switching between tabs.
* **Tests**
  * Updated coverage for account briefs, tasks, suggestions, and assistant interactions in their dedicated views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->