### PR TITLE
fix(test): the review corrections #769 merged without, and a quiesce gate that waits

### DIFF
--- a/backend/internal/platform/testdb/execmode_integration_test.go
+++ b/backend/internal/platform/testdb/execmode_integration_test.go
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package testdb_test
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// TestSharedPoolSurvivesATypeItsParametersName pins the shared pool's exec mode to
+// one that no schema change can stale.
+//
+// A caching mode holds a statement's parameter type OIDs and assumes they keep
+// meaning the same thing. They do not: a suite that drops and remigrates the
+// schema recreates the pgvector extension with a fresh OID, and the next execution
+// of a statement whose parameter the server typed as vector — search's embedding
+// upsert binds $5::vector — draws XX000 "cache lookup failed for type N", in
+// whichever suite ran next rather than the one that remigrated.
+//
+// That soundness used to be argued in a comment and gated nowhere, so the mistake
+// was invisible until CI failed in an unrelated suite. This reproduces the
+// mechanism without pgvector and without a migration: declare a type, bind a
+// parameter the server types as it, recreate the type underneath the connection,
+// bind again. Verified by mutation — under cache_describe the second bind fails
+// with the real XX000. cache_statement is documented to fail the same class on its
+// named plans and is not separately exercised here.
+func TestSharedPoolSurvivesATypeItsParametersName(t *testing.T) {
+	pool := sharedAppPool(t)
+	owner := probeOwnerConn(t)
+	ctx := context.Background()
+
+	// Owned by the owner role and named for this test, so it cannot collide with
+	// a record table or with another package's clone.
+	const ddl = `execmode_probe`
+	if _, err := owner.Exec(ctx, `DROP TYPE IF EXISTS `+ddl+`; CREATE TYPE `+ddl+` AS ENUM ('a', 'b')`); err != nil {
+		t.Fatalf("declaring the probe type: %v", err)
+	}
+	t.Cleanup(func() {
+		if _, err := owner.Exec(context.Background(), `DROP TYPE IF EXISTS `+ddl); err != nil {
+			t.Errorf("dropping the probe type: %v", err)
+		}
+	})
+
+	// ONE connection for both probes, because pgx caches per connection. Through
+	// pool.QueryRow each probe is its own acquire, and a second probe served a
+	// different (or newly dialled) connection meets an empty cache and passes
+	// whatever the mode is — so a mutation test would be measuring puddle's idle
+	// ordering rather than this assertion. Pinning the connection makes the subject
+	// ("a connection may outlive a schema change") literally what runs.
+	conn, err := pool.Acquire(ctx)
+	if err != nil {
+		t.Fatalf("acquiring the probe connection: %v", err)
+	}
+	defer conn.Release()
+
+	// The cast is what makes the server type the parameter as the probe type,
+	// which is what a caching mode then holds an OID for.
+	bind := func() (string, error) {
+		var got string
+		err := conn.QueryRow(ctx, `SELECT ($1::`+ddl+`)::text`, "a").Scan(&got)
+		return got, err
+	}
+
+	// Before anything is recreated, a failure is the probe's own — no cache can be
+	// stale yet — so it must not be reported as a caching fault.
+	got, err := bind()
+	if err != nil {
+		t.Fatalf("the probe cannot bind its own type: %v — the probe is broken, not the exec mode", err)
+	}
+	if got != "a" {
+		t.Fatalf("the probe round-tripped %q, want \"a\"", got)
+	}
+
+	// Same name, new OID: what dropping and remigrating the schema does to an
+	// extension's types.
+	if _, err := owner.Exec(ctx, `DROP TYPE `+ddl+`; CREATE TYPE `+ddl+` AS ENUM ('a', 'b')`); err != nil {
+		t.Fatalf("recreating the probe type: %v", err)
+	}
+	got, err = bind()
+	if err != nil {
+		t.Fatalf("binding the probe type after recreating it: %v — this connection is caching parameter OIDs across a schema change, so a suite that remigrates will fail a later, unrelated one", err)
+	}
+	if got != "a" {
+		t.Fatalf("after recreating the type the probe round-tripped %q, want \"a\"", got)
+	}
+}
+
+// probeOwnerConn opens an owner connection for the DDL above. Its own rather than
+// the one reset_integration_test.go has, which is internal to the package while
+// this test is external — external because it asserts what a CALLER of the shared
+// pool sees, which is the thing that broke.
+func probeOwnerConn(t *testing.T) *pgx.Conn {
+	t.Helper()
+	dsn := os.Getenv("MARGINCE_TEST_DSN")
+	if dsn == "" {
+		t.Fatal("MARGINCE_TEST_DSN not set — run `make db-up` (integration tests fail loudly, they never skip)")
+	}
+	conn, err := pgx.Connect(context.Background(), dsn)
+	if err != nil {
+		t.Fatalf("connecting as owner: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := conn.Close(context.Background()); err != nil {
+			t.Errorf("closing owner connection: %v", err)
+		}
+	})
+	return conn
+}

--- a/backend/internal/platform/testdb/execmode_internal_integration_test.go
+++ b/backend/internal/platform/testdb/execmode_internal_integration_test.go
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package testdb
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// TestEveryPooledDSNRunsTheCacheFreeExecMode covers every pool this package has
+// handed out, not the one a test happened to ask for.
+//
+// Pool is keyed by DSN and memoizes two process-lived pools in practice: the app
+// role's, and the owner role's that ApplyRiverSchema takes. Their DSNs come from
+// DIFFERENT env vars (MARGINCE_TEST_APP_DSN, MARGINCE_TEST_DSN) whose query
+// strings scripts/lib-testdb.sh copies into every clone independently — so an
+// exported owner DSN carrying a caching mode would leave the owner pool caching
+// named statements across ApplyRiverSchema's DDL with an app-pool-only assertion
+// still green. Asserting over the map is what makes a third pooled DSN covered the
+// day it appears rather than the day someone remembers.
+//
+// Internal to the package because the map is; the caller-facing behaviour is
+// pinned by TestSharedPoolSurvivesATypeItsParametersName.
+func TestEveryPooledDSNRunsTheCacheFreeExecMode(t *testing.T) {
+	// ownerConn migrates, which is the precondition Pool refuses to run before.
+	// Opening both DSNs here means the map holds what the lane's fixtures hold,
+	// rather than whichever one a neighbouring test happened to ask for first.
+	ownerConn(t)
+	for _, env := range []string{"MARGINCE_TEST_APP_DSN", "MARGINCE_TEST_DSN"} {
+		dsn := os.Getenv(env)
+		if dsn == "" {
+			t.Fatalf("%s not set — run `make db-up` (integration tests fail loudly, they never skip)", env)
+		}
+		if _, err := Pool(context.Background(), dsn); err != nil {
+			t.Fatalf("opening the shared pool for %s: %v", env, err)
+		}
+	}
+
+	poolsMu.Lock()
+	defer poolsMu.Unlock()
+	if len(pools) == 0 {
+		t.Fatal("no pooled DSN to check — this gate would pass on a package that never shared a pool")
+	}
+	for dsn, pool := range pools {
+		if got := pool.Config().ConnConfig.DefaultQueryExecMode; got != pgx.QueryExecModeDescribeExec {
+			t.Errorf("the shared pool for %s runs exec mode %v, want describe_exec — a caching mode lets a connection outlive the schema it cached against, and a DSN's own parameter wins over testPoolParams, so check the env var that DSN comes from",
+				redactDSN(dsn), got)
+		}
+	}
+}

--- a/backend/internal/platform/testdb/pool.go
+++ b/backend/internal/platform/testdb/pool.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 
@@ -25,12 +26,24 @@ import (
 // runs several packages at once against one server with max_connections=100.
 
 // ErrSchemaNotReady is returned when a pool is asked for before EnsureSchema has
-// migrated the database. It is an error rather than a comment because the blast
-// radius is process-wide: a connection opened before the migration's DROP SCHEMA
-// holds descriptions of relations that no longer exist, and a shared pool would
-// carry that for the whole package rather than one test.
+// migrated the database.
+//
+// It is an error rather than a comment because the blast radius is process-wide,
+// and for two reasons that are demonstrable rather than plausible. A live session
+// from an early pool holds locks on the relations `DROP SCHEMA public CASCADE`
+// must take ACCESS EXCLUSIVE on, so the migration BLOCKS and the package dies at
+// its go-test timeout with nothing naming the cause. And any query in flight while
+// the schema is demolished and rebuilt fails inside whichever test happens to be
+// running, never the one that broke the ordering.
+//
+// Not because a pooled connection would hold stale plan descriptions: describe_exec
+// keeps none. That was true of the mode this pool used to run and is the kind of
+// reason worth deleting when it stops being one.
+//
+// Unrecoverable within the package either way, because the pool is memoized for
+// the process: nothing after the mistake re-opens it.
 var ErrSchemaNotReady = errors.New(
-	"testdb: the shared pool was requested before EnsureSchema migrated the database — call Setup (or EnsureSchema) first, or a pooled connection outlives the DROP SCHEMA that migration begins with")
+	"testdb: the shared pool was requested before EnsureSchema migrated the database — call Setup (or EnsureSchema) first; a session open across the migration's DROP SCHEMA blocks it, and the pool is memoized for the process so nothing later recovers")
 
 var (
 	poolsMu sync.Mutex
@@ -53,8 +66,14 @@ var (
 //	pool_max_conn_idle_time   a package that spiked hands its connections back
 //	                          promptly instead of holding its high-water mark
 //	                          for the rest of the run.
-//	default_query_exec_mode   the one mode a connection may outlive a schema
-//	                          change under — see the note on Pool.
+//	default_query_exec_mode   the only mode that is both cache-free and
+//	                          server-typed, which is what THIS pool's connections
+//	                          need in order to outlive a schema change — see the
+//	                          note on Pool.
+//
+// The first two change how many connections exist; the third is the only one that
+// changes how a query is executed, and so the only place this pool's behaviour
+// parts from the api's.
 var testPoolParams = map[string]string{
 	"pool_min_conns":          "0",
 	"pool_max_conn_idle_time": "30s",
@@ -69,31 +88,59 @@ var testPoolParams = map[string]string{
 // which is what makes it shared. Callers must not close it — a closed shared pool
 // fails every later test in the package with a use-after-close that names nothing.
 //
-// What sharing costs is the statement cache, and describe_exec is the price.
+// What sharing costs is the ability to cache a statement, and describe_exec is
+// how that is paid. It asks the server to describe the statement on every
+// execution, so no statement cache spans a schema change.
 //
-// pgx caches per connection, and every one of its caching modes assumes the schema
-// it cached against still stands. Here it does not: the customfields engine ALTERs
-// record tables mid-test, the reset drops those columns again, ApplyRiverSchema
-// creates River's tables, and a migration recreates the vector extension — which
-// changes the OID of a type that `$n::vector` makes the server infer for a bound
-// parameter. A cache that outlives any of those fails in whichever suite runs
-// next, as SQLSTATE 0A000 "cached plan must not change result type" or XX000
-// "cache lookup failed for type N", naming nothing that points back at the DDL
-// responsible.
+// That is narrower than "nothing is cached", and the difference is the next trap.
+// The per-connection pgtype.Map still memoizes encode plans, keyed by OID and
+// invalidated only by a type registration — never by DDL. It is harmless today
+// only because nothing here registers a schema-derived type: RegisterIDTypes maps
+// to the fixed system uuid OIDs, and no caller uses conn.LoadType or
+// RegisterType, so an extension's type falls to the same format-independent plan
+// whatever its OID is. The first caller to LoadType("vector") or register a
+// composite reopens this, and this mode alone will not cover it.
 //
-// Only describe_exec is immune, because it caches nothing: it re-describes on
-// every execution, which is exactly what pgx documents it for. The two cheaper
-// modes were both tried and both failed under the sharded lane — the default's
-// named plans on 0A000, cache_describe's cached parameter OIDs on the type-OID
-// form. Clearing the caches at each reset instead also works and is not worth it:
-// pgxpool.Reset measured 254s and DeallocateAll 215s but perturbs acquisition
-// ordering enough to surface stragglers, against 244s here.
+// This is also a property of THIS pool, not of the lane. Every other connection
+// the suites open — the owner pgx.Conn each fixture dials, SchemaPool, and every
+// pool a suite opens directly — still runs pgx's default cache_statement. Those
+// close with their test, so a stale plan costs one test rather than the process,
+// which is why they are left alone.
 //
-// So the lane does NOT run production's exec mode, and that is the one fidelity
-// gap in this pool. It costs a round trip per query on a round-trip-bound lane —
-// 244s against the 190s an unsound cache_describe managed. The alternative is
-// giving up the sharing, which is worth measuring before assuming this trade is
-// the best one available.
+// pgx offers four other modes and none of them will do here. The two that cache —
+// cache_statement, which is production's default, and cache_describe — both
+// document that the first execution after a schema change may fail; a cached
+// NAMED PLAN fails as SQLSTATE 0A000 "cached plan must not change result type",
+// and a cached PARAMETER OID fails as XX000 "cache lookup failed for type N" once
+// that type is recreated. The other two, exec and simple_protocol, cache nothing
+// and cost no extra round trip, but they infer parameter types from the Go values
+// instead of asking the server, which cannot encode the typed-id slices the record
+// stores bind through ANY($n) — pool_integration_test.go pins that bind for this
+// reason. describe_exec is the only mode that is both cache-free and server-typed.
+//
+// Only the XX000 form has been observed here, and it is the one this package
+// gates: execmode_integration_test.go reproduces it without pgvector, so the
+// choice above is enforced rather than argued. The mechanism it stands in for is
+// real — search's embedding upsert binds $5::vector, so the server types that
+// parameter as pgvector's, and a suite that drops the schema and remigrates gives
+// the type a new OID under a live pooled connection. The 0A000 form is pgx's
+// documented behaviour for a named plan; whether production meets it is a separate
+// question with its own issue.
+//
+// The delta from production is narrower than swapping a mode sounds. Parameter
+// OIDs and result formats still come from the server, so the encode and decode
+// paths the lane exercises are the ones cmd/api uses; what differs is one extra
+// round trip per statement that takes arguments, and the absent cache. That cost
+// is real on a lane bound by round trips — 244s against the 190s the unsound
+// cache_describe managed, same sitting, Postgres restarted before each run.
+// Clearing the caches at each reset instead of forgoing them measured no cheaper:
+// closing the connections cost 254s, and clearing them in place cost 215s but
+// acquires every idle connection at each reset, which perturbs who gets a
+// connection next.
+//
+// Two things this does not survive, neither of which applies: a connection pooler
+// that switches the underlying connection between the two round trips, and a
+// caller that queries before EnsureSchema has run — see ErrSchemaNotReady.
 func Pool(ctx context.Context, dsn string) (*pgxpool.Pool, error) {
 	if !schemaReady.Load() {
 		return nil, ErrSchemaNotReady
@@ -146,15 +193,84 @@ func withTestPoolParams(dsn string) (string, error) {
 // last: t.Cleanup is LIFO, and every cleanup a test adds later — the ones that
 // stop the runners — must have already run before this can honestly claim the
 // package is quiet.
+// It waits on the POOL rather than sampling it, and that is the difference
+// between a gate and a flake. A connection still checked out the instant cleanup
+// runs is a race, not necessarily a leak: a goroutine that was asked to stop can
+// be one round trip from releasing. Reading AcquiredConns() once failed real runs
+// for exactly that, twice, on a loaded machine — different suites each time, which
+// is the signature of a timing assumption rather than a defect. Taking every
+// connection instead answers the question that matters — can anything else still
+// be holding one — and gives a straggler that is finishing the time to finish,
+// without asserting anything about the clock.
 func AssertPoolsQuiesced(t *testing.T) {
 	t.Helper()
 	poolsMu.Lock()
 	defer poolsMu.Unlock()
 	for dsn, pool := range pools {
-		if n := pool.Stat().AcquiredConns(); n != 0 {
-			t.Errorf("the test ended holding %d connection(s) on the shared pool for %s — something it started is still running, and the next test resets the database under it",
-				n, redactDSN(dsn))
+		assertPoolQuiesced(t, dsn, pool)
+	}
+}
+
+// quiesceGrace bounds how long a finishing goroutine has to hand its connection
+// back, and quiescePoll is how often that is re-checked.
+//
+// Two seconds, not ten: the grace is paid per pool per leaking test, and a leak
+// that touches a few dozen tests would otherwise spend the package's whole
+// go-test budget waiting — reporting a package timeout instead of the straggler,
+// which loses the gate's output in exactly the case it fires.
+const (
+	quiesceGrace = 2 * time.Second
+	quiescePoll  = 20 * time.Millisecond
+)
+
+// poolQuiesced waits for pool to have nothing checked out, and reports what was
+// still out when it gave up. Zero means quiet.
+//
+// It OBSERVES rather than acquires, and that distinction is the whole gate.
+// Acquiring looks like waiting for a connection to come back and is not: pgxpool
+// hands out an idle connection if it has one and dials a new backend otherwise, so
+// asking for as many as are outstanding is satisfied at once while the straggler
+// keeps its own. Against MaxConns of 16, an acquire-based wait could only block
+// when nine or more were leaked together — never the one or two a straggler holds.
+// It also inverted priority: holding the free slots starved the shutdown it was
+// waiting for, then blamed it for the stall.
+//
+// What it does NOT catch is a straggler holding nothing at any instant. A poll
+// loop that acquires, queries and releases reads as quiet in between, and that is
+// a real shape — a River client whose Stop timed out. Catching it means watching
+// AcquireCount across a window, and a window costs its own duration on every one
+// of the lane's two thousand tests rather than only the ones that leak. #770
+// tracks doing it for free by comparing the count across the gap BETWEEN tests,
+// which is time the lane already spends. The leak that has actually fired here
+// held its connection, which is the class below.
+func poolQuiesced(pool *pgxpool.Pool, grace, poll time.Duration) int32 {
+	outstanding := pool.Stat().AcquiredConns()
+	if outstanding == 0 {
+		return 0
+	}
+	// Something is out. One reading cannot tell a goroutine a round trip from
+	// releasing apart from one still working, so give it the grace and then report
+	// whatever is left.
+	deadline := time.After(grace)
+	tick := time.NewTicker(poll)
+	defer tick.Stop()
+	for {
+		select {
+		case <-deadline:
+			return pool.Stat().AcquiredConns()
+		case <-tick.C:
+			if outstanding = pool.Stat().AcquiredConns(); outstanding == 0 {
+				return 0
+			}
 		}
+	}
+}
+
+func assertPoolQuiesced(t *testing.T, dsn string, pool *pgxpool.Pool) {
+	t.Helper()
+	if outstanding := poolQuiesced(pool, quiesceGrace, quiescePoll); outstanding != 0 {
+		t.Errorf("the shared pool for %s still had %d connection(s) checked out %s after this test ended. A goroutine this test started is still running, and the next test resets the database under it: stop it in the test's own cleanup, which runs BEFORE this gate by design.",
+			redactDSN(dsn), outstanding, quiesceGrace)
 	}
 }
 

--- a/backend/internal/platform/testdb/pool_integration_test.go
+++ b/backend/internal/platform/testdb/pool_integration_test.go
@@ -30,15 +30,27 @@ import (
 // The two halves fail differently, and only one of them is the detector.
 // Mutation-tested by rebuilding the pool from a bare pgxpool.ParseConfig: the jit
 // assertion goes red, the typed-id slice bind stays green. That is not a weak
-// assertion, it is what the exec mode does — under cache_describe the parameter
-// OID always arrives from the server, so pgx never has to consult the registered
-// type to encode []ids.PersonID. The bind is here to pin the idiom itself (a
-// future exec mode that guesses OIDs would break it, and ANY($n) is used
-// throughout the record stores); jit is here because it is the half that catches
-// the construction regressing.
+// assertion, it is what the exec mode does — the pool runs describe_exec, where
+// the parameter OID always arrives from the server, so pgx never has to consult
+// the registered type to encode []ids.PersonID. The bind is here to pin the idiom
+// itself: pgx's exec and simple_protocol modes infer parameter types from the Go
+// values instead, and would fail on this slice, so a future change of mode meets
+// this test rather than a record store. jit is the half that catches the
+// construction regressing.
 func TestSharedPoolKeepsTheProductionConnectionSetup(t *testing.T) {
 	pool := sharedAppPool(t)
 	ctx := context.Background()
+
+	// The EFFECTIVE mode, not the one testPoolParams asks for. withTestPoolParams
+	// lets a DSN that already names a parameter keep its own value, and
+	// scripts/lib-testdb.sh copies the base DSN's query string verbatim into every
+	// clone — so an exported MARGINCE_TEST_APP_DSN carrying a caching mode
+	// reinstates the unsoundness this pool exists to avoid, without touching any
+	// Go file. Asserted rather than trusted for that reason.
+	if got := pool.Config().ConnConfig.DefaultQueryExecMode; got != pgx.QueryExecModeDescribeExec {
+		t.Errorf("the shared pool runs exec mode %v, want describe_exec — a caching mode lets a connection outlive the schema it cached against, and the DSN wins over testPoolParams, so check MARGINCE_TEST_APP_DSN",
+			got)
+	}
 
 	want := ids.New[ids.PersonKind]()
 	other := ids.New[ids.PersonKind]()

--- a/backend/internal/platform/testdb/poolready_integration_test.go
+++ b/backend/internal/platform/testdb/poolready_integration_test.go
@@ -22,8 +22,9 @@ import (
 // and nothing here calls t.Parallel — and Pool returns before it touches the pool
 // map, so the process keeps whatever pools it already had.
 //
-// Without this, deleting the check leaves every suite green while a shared
-// connection is free to outlive the schema it was planned against.
+// Without this, deleting the check leaves every suite green while a session from
+// a too-early pool blocks the migration's DROP SCHEMA — see ErrSchemaNotReady for
+// why that costs the package rather than the one test.
 func TestPoolRefusesBeforeTheSchemaIsMigrated(t *testing.T) {
 	appDSN := os.Getenv("MARGINCE_TEST_APP_DSN")
 	if appDSN == "" {

--- a/backend/internal/platform/testdb/quiesce_integration_test.go
+++ b/backend/internal/platform/testdb/quiesce_integration_test.go
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package testdb
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// The quiesce observation had three mechanism bugs before it had a test, and
+// every one of them would have died here in a second: it sampled once and read a
+// finishing goroutine as a leak, and it then "waited" by acquiring, which pgxpool
+// satisfies from idle or by dialling — so it could only fire when nine of sixteen
+// connections were leaked at once. A gate whose own mechanism is untested is a
+// comment with a cost.
+//
+// The leak it cannot see per test — a poll loop holding nothing between
+// queries — is #770, and deliberately has no arm here: a test asserting a known
+// gap passes for the wrong reason.
+//
+// Internal to the package because poolQuiesced is not the caller-facing surface —
+// AssertPoolsQuiesced is, and what needs pinning is the observation underneath it.
+
+const quiesceTestGrace = 300 * time.Millisecond
+
+// TestQuiescedPoolReportsQuiet is the negative control: without it, a gate that
+// never reports quiet would look just as green as one that works.
+func TestQuiescedPoolReportsQuiet(t *testing.T) {
+	pool := quiesceProbePool(t)
+	// Use it first, so the pool has an idle connection and a non-zero acquire
+	// count. Observing a pool that has never been touched would prove nothing
+	// about telling an idle connection from a held one.
+	if _, err := pool.Exec(context.Background(), `SELECT 1`); err != nil {
+		t.Fatalf("warming the probe pool: %v", err)
+	}
+	if outstanding := poolQuiesced(pool, quiesceTestGrace, 10*time.Millisecond); outstanding != 0 {
+		t.Errorf("a pool nobody is using reported %d connection(s) checked out — the gate would fail every test in the lane", outstanding)
+	}
+}
+
+// TestAHeldConnectionIsNotQuiet is the arm the acquire-based version could not
+// pass: ONE connection checked out, fifteen slots free.
+func TestAHeldConnectionIsNotQuiet(t *testing.T) {
+	pool := quiesceProbePool(t)
+	held, err := pool.Acquire(context.Background())
+	if err != nil {
+		t.Fatalf("holding a connection: %v", err)
+	}
+	defer held.Release()
+
+	if outstanding := poolQuiesced(pool, quiesceTestGrace, 10*time.Millisecond); outstanding != 1 {
+		t.Errorf("one connection was checked out for the whole window and the gate saw %d — a straggler holds one or two, never MaxConns, so this is the only count that matters",
+			outstanding)
+	}
+}
+
+// quiesceProbePool is a pool of this package's own, never the shared one: these
+// tests deliberately leave a connection checked out and drive traffic, and the
+// shared pool is what AssertPoolsQuiesced inspects at the end of every OTHER test
+// in the process.
+func quiesceProbePool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	appDSN := os.Getenv("MARGINCE_TEST_APP_DSN")
+	ownerDSN := os.Getenv("MARGINCE_TEST_DSN")
+	if appDSN == "" || ownerDSN == "" {
+		t.Fatal("MARGINCE_TEST_DSN / MARGINCE_TEST_APP_DSN not set — run `make db-up` (integration tests fail loudly, they never skip)")
+	}
+	owner, err := pgx.Connect(context.Background(), ownerDSN)
+	if err != nil {
+		t.Fatalf("connecting as owner: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := owner.Close(context.Background()); err != nil {
+			t.Errorf("closing owner connection: %v", err)
+		}
+	})
+	if err := EnsureSchema(context.Background(), owner); err != nil {
+		t.Fatalf("migrating the test schema: %v", err)
+	}
+	pool, err := pgxpool.New(context.Background(), appDSN)
+	if err != nil {
+		t.Fatalf("opening the probe pool: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	return pool
+}

--- a/backend/internal/platform/testdb/reset.go
+++ b/backend/internal/platform/testdb/reset.go
@@ -46,9 +46,8 @@ var (
 	migrateErr  error
 
 	// schemaReady reports that EnsureSchema has migrated this process's database.
-	// Pool gates on it: a connection opened before the migration's DROP SCHEMA
-	// holds descriptions of relations that no longer exist, and a shared pool
-	// would carry that for the whole package rather than one test.
+	// Pool gates on it, and returns ErrSchemaNotReady while it is unset — see
+	// there for what a pool handed out too early does to the rest of the package.
 	schemaReady atomic.Bool
 
 	// emptySizes is the physical size of every table on the freshly migrated,


### PR DESCRIPTION
## Why this exists

#769's review round produced findings I applied and pushed — but auto-merge had been armed **before** the round, fired on the pre-review commit when a rerun went green, and my force-push then updated a branch whose PR had already merged. So `main` carries the version the review corrected.

**The lesson, for the next person:** do not arm auto-merge before a mandated review round. It can land the PR while you are still fixing what the round found.

## Three claims on `main` that are false

Worse than missing, because a reader will trust them:

- **"Only `describe_exec` is immune, because it caches nothing"** — wrong twice. `exec` and `simple_protocol` cache nothing either *and* cost no extra round trip. They're unusable here for a different reason: they infer parameter types from Go values rather than asking the server, so they can't encode the typed-id slices the record stores bind through `ANY($n)`.
- **The hazard list** blamed four DDL sources for two distinct errors; three can produce neither. It also dropped the previous version's one *true* caveat — under a describe mode a changed column is a silent decode mismatch, not an error, which holds only because no store here selects a star.
- **"Both tried and both failed under the sharded lane"** reports as observed what was only reasoned. `cache_describe`'s `XX000` was reproduced; the named-plan `0A000` is what pgx *documents* and this lane has never seen.

The mode switch also falsified `ErrSchemaNotReady`'s rationale in **three places at once** — all said a pooled connection "holds descriptions", which is precisely what `describe_exec` stops doing.

## Two gates, because prose is how the unsound mode shipped green

- `execmode_integration_test.go` — declares a type, binds a parameter the server types as it, recreates the type under the pool, binds again. Nine lines, no pgvector, fails `XX000` under `cache_describe`.
- The **effective** mode is now asserted, not trusted: `withTestPoolParams` lets a DSN keep its own value and `lib-testdb.sh` copies the base DSN's query string into every clone, so an exported `MARGINCE_TEST_APP_DSN` carrying a caching mode would reinstate the unsoundness **without touching a Go file**.

## And a flake of mine, repaired

`AssertPoolsQuiesced` sampled `AcquiredConns()` once and failed two real runs on a loaded machine, in different suites each time — the signature of a timing assumption, not a defect: a goroutine asked to stop can be one round trip from releasing.

It now waits for the connections that are actually outstanding. The fast path matters: the version without it acquired `MaxConns` per pool per test, exhausted `max_connections` (801 "too many clients"), and reported the server's refusal as a straggler. Measured 0 occurrences after the fix.

`make check-backend` and `make craft-static` green; the `testdb` package's own gates pass, including both new ones.

Refs #769, #770, #772.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins shared `testdb` pools to `describe_exec` and asserts the effective mode across all pooled DSNs to prevent unsafe statement caching during schema remigrations. Reworks the quiesce gate to wait on real in-flight connections and updates `ErrSchemaNotReady` to focus on lock/in-flight hazards.

- **New Features**
  - Integration tests: a type-recreate probe that reproduces `XX000` under caching modes, and assertions that every pooled DSN runs `describe_exec` (covers app and owner; guards DSN param overrides).
  - Quiesce tests that verify a quiet pool reports 0 and that a single held connection is detected.

- **Bug Fixes**
  - `AssertPoolsQuiesced` now observes/polls for up to 2s without acquiring connections; removes flakes and avoids `max_connections` spikes.
  - Docs clarified: `ErrSchemaNotReady` centers on blocking locks/in-flight queries; and `describe_exec` is the only cache-free, server-typed mode (`exec`/`simple_protocol` cache nothing but can’t encode `ANY($n)` typed slices).

<sup>Written for commit 87550cbeb5479f217d613d25269b9564ce3be772. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/796?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved database pool behavior during schema and enum type changes.
  - Prevented stale connection state from affecting subsequent queries.
  - Added reliable detection of active connections before pool shutdown or migration.

- **Tests**
  - Added coverage for pool execution modes, schema readiness, connection quiescence, and enum recreation scenarios.
  - Expanded validation for typed parameter binding and migration safety.

- **Documentation**
  - Clarified pool behavior during schema migrations, connection draining, and query execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->