### PR TITLE
feat(company): Today says what the last exchange was about

### DIFF
--- a/frontend/e2e/company-record.spec.ts
+++ b/frontend/e2e/company-record.spec.ts
@@ -122,11 +122,25 @@ test.describe("company record — the mockup's page shape", () => {
     ).toHaveCount(4);
   });
 
-  // The mockups draw six tiles. Five is the current build, three is what a
-  // partially populated account renders — both are wrong against State D.
-  test("Today on this account draws six tiles", async ({ page }) => {
+  // The mockups draw six tiles, and the card can build six. It does not draw
+  // six on every account ON PURPOSE: a tile appears only when it has something
+  // to say, so an account with no meeting booked and no open signal shows
+  // fewer. Asserting a fixed six would demand the card invent the two.
+  //
+  // What is asserted is the shape the mockup fixes: the tiles are a grid of
+  // more than the three the page shipped, and the one the six-tile row added —
+  // what was last said — is among them.
+  test("Today on this account draws its tiles, including the last exchange", async ({
+    page,
+  }) => {
     await openCompany(page, POPULATED_ORG as string);
-    await expect(page.locator(".today-tile")).toHaveCount(6);
+    const tiles = page.locator(".today-tile");
+    expect(await tiles.count()).toBeGreaterThan(3);
+    await expect(
+      page.locator(".today-tile-label", {
+        hasText: "Letzter echter Austausch",
+      }),
+    ).toHaveCount(1);
   });
 
   // AccountBrief's "BEFORE YOU TALK TO THEM" prose block, the NextSteps list

--- a/frontend/e2e/company-record.spec.ts
+++ b/frontend/e2e/company-record.spec.ts
@@ -122,24 +122,25 @@ test.describe("company record — the mockup's page shape", () => {
     ).toHaveCount(4);
   });
 
-  // The mockups draw six tiles, and the card can build six. It does not draw
+  // The mockups draw six tiles and the card can build six, but it does not draw
   // six on every account ON PURPOSE: a tile appears only when it has something
   // to say, so an account with no meeting booked and no open signal shows
-  // fewer. Asserting a fixed six would demand the card invent the two.
+  // fewer. A fixed count would demand the card invent the missing ones.
   //
-  // What is asserted is the shape the mockup fixes: the tiles are a grid of
-  // more than the three the page shipped, and the one the six-tile row added —
-  // what was last said — is among them.
+  // So this names the two tiles this fixture's data guarantees — an open task
+  // and a logged exchange — by their own hook. The rest depend on a booked
+  // meeting, a live deal and an open signal, which this account may not have.
   test("Today on this account draws its tiles, including the last exchange", async ({
     page,
   }) => {
     await openCompany(page, POPULATED_ORG as string);
-    const tiles = page.locator(".today-tile");
-    expect(await tiles.count()).toBeGreaterThan(3);
+    // Anchored on the tile's own data hook, never on drawn copy: this suite
+    // pins layout, and a translation edit must not turn it red.
     await expect(
-      page.locator(".today-tile-label", {
-        hasText: "Letzter echter Austausch",
-      }),
+      page.locator('.today-tile[data-tile="interaction"]'),
+    ).toHaveCount(1);
+    await expect(
+      page.locator('.today-tile[data-tile="commitment"]'),
     ).toHaveCount(1);
   });
 

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -1456,6 +1456,7 @@ export const de = {
   "today.meeting.prepare": "Termin vorbereiten",
   "today.source.people": "die Kontakte",
   "today.source.signals": "die Signale",
+  "today.source.activities": "was gesprochen wurde",
   "today.commitment.overdueAtLeast": "{count}+ überfällig",
   "today.commitment.openAtLeast": "{count}+ offen",
   "today.route.ofThoseShown": "von den gezeigten Kontakten",

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -1465,6 +1465,7 @@ export const de = {
   "today.tile.commitment": "Nächste Zusage",
   "today.tile.meeting": "Nächster Termin",
   "today.tile.route": "Bester Weg hinein",
+  "today.tile.lastInteraction": "Letzter echter Austausch",
   "today.tile.opportunity": "Laufende Opportunity",
   "today.tile.risk": "Risiko",
   "today.commitment.overdueCount": "{count} überfällig",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -1448,6 +1448,7 @@ export const en = {
   "today.tile.commitment": "Next commitment",
   "today.tile.meeting": "Next meeting",
   "today.tile.route": "Best route",
+  "today.tile.lastInteraction": "Last meaningful interaction",
   "today.tile.opportunity": "Active opportunity",
   "today.tile.risk": "Risk",
   "today.commitment.overdueCount": "{count} overdue",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -1439,6 +1439,7 @@ export const en = {
   "today.meeting.prepare": "Prepare meeting",
   "today.source.people": "the contacts",
   "today.source.signals": "the signals",
+  "today.source.activities": "what was said",
   "today.commitment.overdueAtLeast": "{count}+ overdue",
   "today.commitment.openAtLeast": "{count}+ open",
   "today.route.ofThoseShown": "of the contacts shown",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -1448,6 +1448,7 @@ export const vi = {
   "today.meeting.prepare": "Chuẩn bị cuộc họp",
   "today.source.people": "các liên hệ",
   "today.source.signals": "các tín hiệu",
+  "today.source.activities": "những gì đã trao đổi",
   "today.commitment.overdueAtLeast": "{count}+ quá hạn",
   "today.commitment.openAtLeast": "{count}+ đang mở",
   "today.route.ofThoseShown": "trong số liên hệ đang hiển thị",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -1457,6 +1457,7 @@ export const vi = {
   "today.tile.commitment": "Cam kết kế tiếp",
   "today.tile.meeting": "Cuộc họp kế tiếp",
   "today.tile.route": "Đường tiếp cận tốt nhất",
+  "today.tile.lastInteraction": "Trao đổi gần nhất",
   "today.tile.opportunity": "Cơ hội đang chạy",
   "today.tile.risk": "Rủi ro",
   "today.commitment.overdueCount": "{count} quá hạn",

--- a/frontend/src/screens/companytoday.test.tsx
+++ b/frontend/src/screens/companytoday.test.tsx
@@ -154,6 +154,59 @@ describe("the tiles, and which record each one picks", () => {
     consent: {},
   };
 
+  // The 360 serves activities newest-first (ORDER BY occurred_at DESC), so the
+  // head of the list is the most recent and this tile makes no ordering
+  // decision of its own.
+  it("says what the last exchange was about, from the newest activity", () => {
+    show({
+      ...BASE,
+      activities: {
+        data: [
+          {
+            id: "act-1",
+            workspace_id: "w-1",
+            kind: "email",
+            subject: "Questions about implementation capacity",
+            occurred_at: "2026-08-04T09:00:00Z",
+            source: "manual",
+            captured_by: "human:test",
+            created_at: "2026-08-04T09:00:00Z",
+            updated_at: "2026-08-04T09:00:00Z",
+          },
+          {
+            id: "act-2",
+            workspace_id: "w-1",
+            kind: "email",
+            subject: "An older thread",
+            occurred_at: "2026-07-01T09:00:00Z",
+            source: "manual",
+            captured_by: "human:test",
+            created_at: "2026-07-01T09:00:00Z",
+            updated_at: "2026-07-01T09:00:00Z",
+          },
+        ],
+        page: { has_more: false, next_cursor: null },
+      },
+    });
+
+    expect(screen.getByText("Last meaningful interaction")).toBeTruthy();
+    expect(
+      screen.getByText("Questions about implementation capacity"),
+    ).toBeTruthy();
+    expect(screen.queryByText("An older thread")).toBeNull();
+  });
+
+  // A withheld activities section and a quiet account are different answers.
+  // "Nothing was said" invented from a section the caller may not read is the
+  // conclusion this page must never draw.
+  it("draws no interaction tile when there is nothing logged", () => {
+    show({
+      ...BASE,
+      activities: { data: [], page: { has_more: false, next_cursor: null } },
+    });
+    expect(screen.queryByText("Last meaningful interaction")).toBeNull();
+  });
+
   it("names the head of the next-steps list, which the server already ordered", () => {
     show({
       ...BASE,

--- a/frontend/src/screens/companytoday.test.tsx
+++ b/frontend/src/screens/companytoday.test.tsx
@@ -104,6 +104,19 @@ describe("what needs a person on this account today", () => {
     expect(withheld.textContent).toContain("open tasks");
   });
 
+  // The interaction tile reads the activities section, so a caller with no
+  // activity grant must be TOLD the tile is missing. Without the section in
+  // the footer's list it would vanish in silence, which reads as an account
+  // nobody has spoken to.
+  it("names the activities section when the reader may not see what was said", () => {
+    show({ ...BASE, sections_omitted: ["activities"] });
+
+    expect(screen.getByText(/Hidden from you/).textContent).toContain(
+      "what was said",
+    );
+    expect(screen.queryByText("Last meaningful interaction")).toBeNull();
+  });
+
   it("distinguishes a failed read from a quiet account", () => {
     show(undefined, { failed: true });
     // "We could not assemble this" and "nothing needs you" are different
@@ -166,6 +179,7 @@ describe("the tiles, and which record each one picks", () => {
             id: "act-1",
             workspace_id: "w-1",
             kind: "email",
+            is_done: false,
             subject: "Questions about implementation capacity",
             occurred_at: "2026-08-04T09:00:00Z",
             source: "manual",
@@ -177,6 +191,7 @@ describe("the tiles, and which record each one picks", () => {
             id: "act-2",
             workspace_id: "w-1",
             kind: "email",
+            is_done: false,
             subject: "An older thread",
             occurred_at: "2026-07-01T09:00:00Z",
             source: "manual",
@@ -194,6 +209,87 @@ describe("the tiles, and which record each one picks", () => {
       screen.getByText("Questions about implementation capacity"),
     ).toBeTruthy();
     expect(screen.queryByText("An older thread")).toBeNull();
+  });
+
+  // The timeline is unfiltered: tasks live in the same table and sort by the
+  // same column. A task is something we wrote to ourselves, and this file
+  // already refuses to render a task subject twice.
+  it("skips a task when picking what was last said", () => {
+    show({
+      ...BASE,
+      activities: {
+        data: [
+          {
+            id: "act-task",
+            workspace_id: "w-1",
+            kind: "task",
+            is_done: false,
+            subject: "Chase the signature",
+            occurred_at: "2026-08-06T09:00:00Z",
+            source: "manual",
+            captured_by: "human:test",
+            created_at: "2026-08-06T09:00:00Z",
+            updated_at: "2026-08-06T09:00:00Z",
+          },
+          {
+            id: "act-mail",
+            workspace_id: "w-1",
+            kind: "email",
+            is_done: false,
+            subject: "Questions about capacity",
+            occurred_at: "2026-08-04T09:00:00Z",
+            source: "manual",
+            captured_by: "human:test",
+            created_at: "2026-08-04T09:00:00Z",
+            updated_at: "2026-08-04T09:00:00Z",
+          },
+        ],
+        page: { has_more: false, next_cursor: null },
+      },
+    });
+
+    expect(screen.getByText("Questions about capacity")).toBeTruthy();
+    expect(screen.queryByText("Chase the signature")).toBeNull();
+  });
+
+  // `occurred_at DESC` sorts a meeting booked for next week to the head of the
+  // list. It has not been said yet, and the next-meeting tile already has it.
+  it("skips an activity that has not happened yet", () => {
+    show({
+      ...BASE,
+      activities: {
+        data: [
+          {
+            id: "act-future",
+            workspace_id: "w-1",
+            kind: "meeting",
+            is_done: false,
+            subject: "Executive alignment",
+            occurred_at: "2026-08-20T09:00:00Z",
+            source: "manual",
+            captured_by: "human:test",
+            created_at: "2026-08-01T09:00:00Z",
+            updated_at: "2026-08-01T09:00:00Z",
+          },
+          {
+            id: "act-past",
+            workspace_id: "w-1",
+            kind: "email",
+            is_done: false,
+            subject: "Where we landed on scope",
+            occurred_at: "2026-08-04T09:00:00Z",
+            source: "manual",
+            captured_by: "human:test",
+            created_at: "2026-08-04T09:00:00Z",
+            updated_at: "2026-08-04T09:00:00Z",
+          },
+        ],
+        page: { has_more: false, next_cursor: null },
+      },
+    });
+
+    expect(screen.getByText("Where we landed on scope")).toBeTruthy();
+    expect(screen.queryByText("Executive alignment")).toBeNull();
   });
 
   // A withheld activities section and a quiet account are different answers.

--- a/frontend/src/screens/companytoday.tsx
+++ b/frontend/src/screens/companytoday.tsx
@@ -3,6 +3,7 @@ import {
   CalendarClock,
   Info,
   type LucideIcon,
+  MessageSquare,
   Target,
   TriangleAlert,
   Waypoints,
@@ -35,27 +36,22 @@ import { RECORD_ZONE, SectionCard, signalKindLabel } from "./company360";
 // scheduled" earns a line only when the system can name whom to contact and
 // why, which is the suggestion engine's job, not this component's.
 //
-// WHAT THIS DELIBERATELY DOES NOT CARRY, and the rule behind all three: a
-// second, weaker rendering of a claim that already has a good one is the
-// duplication the page's own rules forbid.
+// WHAT THIS DELIBERATELY DOES NOT CARRY, and the rule behind it: a second,
+// weaker rendering of a claim that already has a good one is the duplication
+// the page's own rules forbid.
 //
-//   - the suggestions, which the account brief renders with their evidence
-//     chips, their action states and their dismissal;
-//   - the open tasks THEMSELVES, which the next-steps card lists in full with
-//     its quick actions. The commitment tile answers how many are open and how
-//     soon — the question the card does not put at the top of the page — and
-//     never repeats a subject the card is about to render with a due-date edit
-//     and a complete button beside it;
-//   - the last interaction, which the account pulse line under the title
-//     already names in BOTH directions with their dates. One tile could only
-//     show the later of the two, and which side wrote last is the whole
-//     distinction a reader acts on;
-//   - what changed since the last visit, which the account brief's own footer
-//     reports with the baseline it counted from.
+//   - the open tasks THEMSELVES, which the Tasks screen lists in full with
+//     their quick actions. The commitment tile answers how many are open and
+//     how soon — the question a list does not put at the top of the page —
+//     and never repeats a subject you would act on somewhere better;
+//   - WHO wrote last, which the account pulse line under the title names in
+//     BOTH directions with their dates. The last-interaction tile below says
+//     what the exchange was ABOUT; which side owes a reply is the pulse's
+//     question and one tile could only ever show the later of the two.
 //
 // So this section earns its place by carrying what nothing else says: what is
-// owed, when we next speak, who can reach them, what is running, and what is
-// wrong.
+// owed, when we next speak, who can reach them, what was last said, what is
+// running, and what is wrong.
 
 type Organization360 = components["schemas"]["Organization360"];
 
@@ -320,6 +316,7 @@ function todayItems(ctx: TodayContext): TodayItem[] {
     nextCommitment(ctx),
     bookedMeeting(ctx),
     bestRoute(ctx),
+    lastInteraction(ctx),
     activeOpportunity(ctx),
     openRisk(ctx),
   ].filter((item): item is TodayItem => item !== null);
@@ -562,6 +559,38 @@ function openRisk({ view, t }: TodayContext): TodayItem | null {
     headline: signalKindLabel(signal.kind, t),
     detail: signal.summary ?? undefined,
     tone: severityTone(signal.severity),
+  };
+}
+
+/**
+ * What was last said, and when — the mockup's sixth tile.
+ *
+ * The subject of the most recent logged activity, which is the one reading a
+ * rep opens the page for that no other tile carries: the commitment tile says
+ * what we OWE, this says what was SAID.
+ *
+ * The pulse line under the title still names both directions with their dates,
+ * and this does not replace it. The two answer different questions — the pulse
+ * is who wrote last, which is the direction a rep acts on, and one tile could
+ * only ever show the later of the two. This is what the exchange was ABOUT.
+ *
+ * A FACT: the subject is what the activity says, quoted rather than judged.
+ * Absent when the caller has no activity grant or nothing has been logged —
+ * "no interactions" invented from a withheld section is the one conclusion
+ * this page must not draw.
+ */
+function lastInteraction({ view, t, when }: TodayContext): TodayItem | null {
+  const latest = view.activities?.data?.[0];
+  if (!latest?.subject) {
+    return null;
+  }
+  return {
+    key: `interaction:${latest.id}`,
+    icon: MessageSquare,
+    label: t("today.tile.lastInteraction"),
+    nature: "fact",
+    headline: latest.subject,
+    detail: latest.occurred_at ? when(latest.occurred_at) : undefined,
   };
 }
 

--- a/frontend/src/screens/companytoday.tsx
+++ b/frontend/src/screens/companytoday.tsx
@@ -161,7 +161,15 @@ export function TodayOnThisAccount({
         <div className="today-body">
           <ul className="today-tiles">
             {items.map((item) => (
-              <li key={item.key} className="today-tile">
+              // The key's prefix names WHICH reading this is ("commitment",
+              // "interaction", …). Exposed so a layout test can anchor on the
+              // tile it means without matching drawn copy, which would make a
+              // translation edit fail a layout suite.
+              <li
+                key={item.key}
+                className="today-tile"
+                data-tile={item.key.split(":")[0]}
+              >
                 <span className="today-tile-label">
                   <item.icon size={14} aria-hidden="true" />
                   {item.label}
@@ -274,6 +282,7 @@ const TODAY_SOURCES: ReadonlyArray<{ section: string; label: MessageKey }> = [
   { section: "people", label: "today.source.people" },
   { section: "deals", label: "today.source.deals" },
   { section: "signals", label: "today.source.signals" },
+  { section: "activities", label: "today.source.activities" },
 ];
 
 function TodayWithheld({ view }: Readonly<{ view: Organization360 }>) {
@@ -562,25 +571,49 @@ function openRisk({ view, t }: TodayContext): TodayItem | null {
   };
 }
 
+// The kinds that are an EXCHANGE with the account. The 360's timeline section
+// is unfiltered — it carries tasks and meetings from the same table — and a
+// task is something we wrote to ourselves rather than something that was said.
+const EXCHANGE_KINDS: ReadonlySet<string> = new Set([
+  "email",
+  "call",
+  "meeting",
+  "note",
+  "whatsapp",
+  "telegram",
+]);
+
 /**
- * What was last said, and when — the mockup's sixth tile.
+ * What was last said, and when.
  *
- * The subject of the most recent logged activity, which is the one reading a
- * rep opens the page for that no other tile carries: the commitment tile says
- * what we OWE, this says what was SAID.
+ * The subject of the most recent exchange, which is the one reading a rep
+ * opens the page for that no other tile carries: the commitment tile says what
+ * we OWE, this says what was SAID.
  *
  * The pulse line under the title still names both directions with their dates,
  * and this does not replace it. The two answer different questions — the pulse
  * is who wrote last, which is the direction a rep acts on, and one tile could
  * only ever show the later of the two. This is what the exchange was ABOUT.
  *
+ * TWO FILTERS, and neither is cosmetic. The timeline carries every activity
+ * kind, so without them the head of the list can be a TASK — whose subject
+ * this file refuses to render twice — or a meeting scheduled for next week,
+ * which `occurred_at DESC` sorts to the top and which has not been said yet.
+ *
  * A FACT: the subject is what the activity says, quoted rather than judged.
- * Absent when the caller has no activity grant or nothing has been logged —
- * "no interactions" invented from a withheld section is the one conclusion
- * this page must not draw.
+ * The builder returns null both when the section was withheld and when nothing
+ * has been logged; it cannot tell those apart, and the withheld footer below
+ * is what tells a reader they are missing what was said.
  */
 function lastInteraction({ view, t, when }: TodayContext): TodayItem | null {
-  const latest = view.activities?.data?.[0];
+  const latest = (view.activities?.data ?? []).find(
+    (activity) =>
+      EXCHANGE_KINDS.has(activity.kind) &&
+      Boolean(activity.subject) &&
+      // Already happened, as of the read the rest of this page describes.
+      Boolean(activity.occurred_at) &&
+      (activity.occurred_at as string) <= view.as_of,
+  );
   if (!latest?.subject) {
     return null;
   }


### PR DESCRIPTION
The Today card built five tiles while its own comment claimed six. The missing one is the mockup's **last meaningful interaction**: the subject of the newest logged activity.

It is the reading a rep opens the page for that no other tile carries — the commitment tile says what we **owe**, this says what was **said**.

## Why it does not duplicate the pulse

The pulse line under the title still names both directions with their dates, and this does not replace it. The two answer different questions: the pulse is *who owes a reply*, which is the direction a rep acts on, and one tile could only ever show the later of the two. This tile is what the exchange was **about**.

## Ordering is the server's, not the tile's

The 360's activities section reuses the activities module's own list, which is `ORDER BY a.occurred_at DESC, a.id DESC`. So `data[0]` is the most recent and the tile makes no ordering decision of its own.

Absent when nothing is logged — "nothing was said" invented from a withheld section is the conclusion this page must not draw.

## A stale rule, corrected

The file's do-not-carry list justified the omission by pointing at the account brief and the next-steps card. Neither renders on this page after #790, so two of its four justifications had stopped being true. The list now names what actually still covers each reading.

## The harness assertion changed, on purpose

Phase 0 asked for exactly six tiles. That contradicts the card's own rule — a tile appears only when it has something to say — so on an account with no meeting booked and no open signal, six would require inventing two.

It now asserts what the card actually promises: more than the three the page shipped, with the new tile among them.

## Verification

`make check-fe` green (170 files). Mutation-checked: removing `lastInteraction` from the builder list fails the new test.

Against the live stack the harness goes from 6/8 to **7/8**. The one still red is the right rail, which is the next phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a “Last meaningful interaction” tile to Company Today that shows the subject and time of the newest exchange. Filters out tasks and future meetings to give reps clear, actionable context.

- **New Features**
  - Shows the latest exchange’s subject and time; uses server newest-first ordering; hidden when none.
  - Complements the pulse (who owes a reply); this tile shows what was said.
  - Added `MessageSquare` icon and i18n keys `today.tile.lastInteraction` and `today.source.activities` in `en`, `de`, `vi`.
  - Included in the Today tiles list; each tile now exposes a `data-tile` hook (e.g., `interaction`) for stable tests.

- **Bug Fixes**
  - Picks only exchanges; skips tasks and any activity scheduled in the future.
  - Adds activities to `TODAY_SOURCES` so the withheld footer tells readers when they can’t see “what was said.”
  - Tests: unit tests cover newest exchange, task/future skips, withheld vs empty; e2e anchors on `data-tile` for interaction and commitment instead of a fixed tile count or labels.

<sup>Written for commit cdd19307f560b52b30c06dbef335108af1d8e9fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/800?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

