### PR TITLE
fix(settings): the installation fields are controls, not captions

### DIFF
--- a/frontend/src/screens/installation-settings.test.tsx
+++ b/frontend/src/screens/installation-settings.test.tsx
@@ -148,4 +148,26 @@ describe("InstallationSettingsCard", () => {
     )) as HTMLInputElement;
     expect(name.disabled).toBe(false);
   });
+
+  // An editable field must LOOK editable. `.input` is what carries the border,
+  // fill and padding that separate a control from the static text beside it, so
+  // a field that renders without it reads as a caption: the value is there, the
+  // affordance is not, and an operator concludes the setting is read-only. The
+  // class is the observable proof the control came from the design system
+  // rather than being hand-rolled again.
+  it("renders every field as a design-system input", async () => {
+    const { fetchMock } = backendFor(SETTINGS_EDITOR);
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<InstallationSettingsCard />);
+
+    for (const label of [
+      /organization name/i,
+      /reporting timezone/i,
+      /base currency/i,
+    ]) {
+      const control = await screen.findByLabelText(label);
+      expect(control.className.split(/\s+/)).toContain("input");
+    }
+  });
 });

--- a/frontend/src/screens/installation-settings.tsx
+++ b/frontend/src/screens/installation-settings.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from "react";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
 import { useCanWrite } from "../app/capability";
-import { SectionHeader } from "../design-system/atoms";
+import { Field, SectionHeader, TextInput } from "../design-system/atoms";
 import { useT } from "../i18n";
 import { problemMessage, QueryGate } from "./common";
 
@@ -132,23 +132,36 @@ function InstallationSettingsForm({
       style={{ display: "grid", gap: "var(--space-3)" }}
     >
       <Field
-        id="installation-name"
         label={t("installationSettings.name")}
         hint={t("installationSettings.nameHint")}
-        value={draft.name}
-        disabled={!canManage}
-        onChange={(name) => setDraft({ ...draft, name })}
-      />
+      >
+        {(control) => (
+          <TextInput
+            {...control}
+            value={draft.name}
+            disabled={!canManage}
+            onChange={(event) =>
+              setDraft({ ...draft, name: event.target.value })
+            }
+          />
+        )}
+      </Field>
       <Field
-        id="installation-timezone"
         label={t("installationSettings.timezone")}
         hint={t("installationSettings.timezoneHint")}
-        value={draft.timezone}
-        disabled={!canManage}
-        onChange={(timezone) => setDraft({ ...draft, timezone })}
-      />
+      >
+        {(control) => (
+          <TextInput
+            {...control}
+            value={draft.timezone}
+            disabled={!canManage}
+            onChange={(event) =>
+              setDraft({ ...draft, timezone: event.target.value })
+            }
+          />
+        )}
+      </Field>
       <Field
-        id="installation-base-currency"
         label={t("installationSettings.baseCurrency")}
         hint={
           settings.base_currency_locked
@@ -156,10 +169,18 @@ function InstallationSettingsForm({
               t("installationSettings.baseCurrencyLocked"))
             : t("installationSettings.baseCurrencyHint")
         }
-        value={draft.base_currency}
-        disabled={!canManage || settings.base_currency_locked}
-        onChange={(base_currency) => setDraft({ ...draft, base_currency })}
-      />
+      >
+        {(control) => (
+          <TextInput
+            {...control}
+            value={draft.base_currency}
+            disabled={!canManage || settings.base_currency_locked}
+            onChange={(event) =>
+              setDraft({ ...draft, base_currency: event.target.value })
+            }
+          />
+        )}
+      </Field>
 
       {update.isError ? (
         <p role="alert" className="form-error">
@@ -183,38 +204,5 @@ function InstallationSettingsForm({
         </div>
       ) : null}
     </form>
-  );
-}
-
-function Field({
-  id,
-  label,
-  hint,
-  value,
-  disabled,
-  onChange,
-}: {
-  id: string;
-  label: string;
-  hint: string;
-  value: string;
-  disabled: boolean;
-  onChange: (next: string) => void;
-}) {
-  return (
-    <div style={{ display: "grid", gap: "var(--space-1)" }}>
-      <label htmlFor={id}>{label}</label>
-      <input
-        id={id}
-        type="text"
-        value={value}
-        disabled={disabled}
-        aria-describedby={`${id}-hint`}
-        onChange={(e) => onChange(e.target.value)}
-      />
-      <small id={`${id}-hint`} className="muted">
-        {hint}
-      </small>
-    </div>
   );
 }


### PR DESCRIPTION
## What

Settings → Installation rendered its three fields through a `Field` defined locally in `installation-settings.tsx`, whose `<input>` carried no class. `.input` is what draws the border, fill and padding, so the control was visually indistinguishable from the static text beside it — the value showed, the affordance did not.

Reported as "the fields are not editable". They were editable the whole time:

```
id=installation-name  value="Margince"  disabled: false  readOnly: false
className: ""  borderWidth: 0px  background: rgba(0,0,0,0)  padding: 0px
```

## Why it happened

`frontend/src/design-system/` already owns both halves — `Field` (label, hint, `useId` wiring) and `TextInput` (the one spelling of the control's surface). The local `Field` shadowed the design-system one of the same name, so the miss was invisible at the call sites.

## Why nothing caught it

Two gaps that line up:

- Every existing assertion resolves the field by label and asks about `value` or `disabled` — all of which a bare `<input>` answers correctly. Behaviour was proven; appearance was not.
- `frontend/scripts/check-native-controls.sh` bans `<select>`/`<option>`/`<optgroup>` only. A hand-rolled `<input>` is outside its pattern.

The new test closes the first. The second is a wider change and is left for a follow-up — see below.

## Verification

Mutating one field back to a bare `<input>` fails the new test with `expected [ '' ] to include 'input'`, while the other three tests still pass — which is precisely why the original defect shipped.

`make check-fe` green: 170 files, 2054 tests, biome + tsc + build.

## Follow-up (not in this PR)

Widening the native-control gate to flag raw `<input>`/`<textarea>` outside `design-system/` would make this class of defect impossible rather than caught once. Filing separately so this fix stays reviewable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Installation Settings so inputs use the design system and clearly look editable. Fields now render `TextInput` inside design-system `Field`, applying the `.input` class for proper borders, fill, and padding.

- **Bug Fixes**
  - Replaced the local `Field` and bare inputs with design-system `Field` + `TextInput`; removed the shadowing local component while keeping existing values/disabled behavior.
  - Added a test asserting all three fields render with the `.input` class.

<sup>Written for commit f2c44f2f9c2e0383629b5b68307071b1d7100060. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/801?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

