### PR TITLE
refactor(deals): the module's money reads leave workspace.base_currency

### DIFF
--- a/backend/internal/compose/closedate_integration_test.go
+++ b/backend/internal/compose/closedate_integration_test.go
@@ -68,7 +68,7 @@ func setupCloseDate(t *testing.T) *closeDateEnv {
 	}
 	quiet := slog.New(slog.NewTextHandler(os.Stderr, nil))
 	e.svc = approvals.NewService(e.Pool)
-	e.svc.WithEffect(deals.CloseDateCorrectionKind, closeDateConfirmEffect(e.svc, deals.NewStore(e.Pool)))
+	e.svc.WithEffect(deals.CloseDateCorrectionKind, closeDateConfirmEffect(e.svc, deals.NewStore(e.Pool, InstallationBaseCurrency())))
 	e.corrector = deals.NewCloseDateCorrector(e.Pool, closeDateStager{svc: e.svc}, quiet)
 	return e
 }

--- a/backend/internal/compose/closedate_integration_test.go
+++ b/backend/internal/compose/closedate_integration_test.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/gradionhq/margince/backend/internal/modules/approvals"
 	"github.com/gradionhq/margince/backend/internal/modules/deals"
+	"github.com/gradionhq/margince/backend/internal/modules/identity"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
@@ -68,7 +69,7 @@ func setupCloseDate(t *testing.T) *closeDateEnv {
 	}
 	quiet := slog.New(slog.NewTextHandler(os.Stderr, nil))
 	e.svc = approvals.NewService(e.Pool)
-	e.svc.WithEffect(deals.CloseDateCorrectionKind, closeDateConfirmEffect(e.svc, deals.NewStore(e.Pool, InstallationBaseCurrency())))
+	e.svc.WithEffect(deals.CloseDateCorrectionKind, closeDateConfirmEffect(e.svc, deals.NewStore(e.Pool, identity.BaseCurrencyOf)))
 	e.corrector = deals.NewCloseDateCorrector(e.Pool, closeDateStager{svc: e.svc}, quiet)
 	return e
 }

--- a/backend/internal/compose/coldstartaccept.go
+++ b/backend/internal/compose/coldstartaccept.go
@@ -23,6 +23,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/modules/approvals"
 	"github.com/gradionhq/margince/backend/internal/modules/capture"
 	"github.com/gradionhq/margince/backend/internal/modules/deals"
+	"github.com/gradionhq/margince/backend/internal/modules/identity"
 	"github.com/gradionhq/margince/backend/internal/modules/people"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
@@ -60,9 +61,9 @@ func approvalsServiceWithEffects(pool *pgxpool.Pool) *approvals.Service {
 	svc.WithEffect(orgNameProposalKind, orgNameAcceptEffect(svc, store))
 	svc.WithEffect(linkedInMatchKind, linkedInMatchAcceptEffect(svc, store))
 	svc.WithEffect(lifecycleProposalKind, lifecycleAcceptEffect(svc, store))
-	svc.WithEffect(deals.CloseDateCorrectionKind, closeDateConfirmEffect(svc, deals.NewStore(pool, InstallationBaseCurrency())))
+	svc.WithEffect(deals.CloseDateCorrectionKind, closeDateConfirmEffect(svc, deals.NewStore(pool, identity.BaseCurrencyOf)))
 	svc.WithEffect(deals.FollowUpReconcileKind, followUpConfirmEffect(svc, activities.NewStore(pool)))
-	svc.WithEffect(fxRateProposalKind, fxRateAcceptEffect(svc, deals.NewStore(pool, InstallationBaseCurrency())))
+	svc.WithEffect(fxRateProposalKind, fxRateAcceptEffect(svc, deals.NewStore(pool, identity.BaseCurrencyOf)))
 	svc.WithEffect(aiModelRateProposalKind, aiModelRateAcceptEffect(svc, ai.NewRateStore(pool)))
 	return svc
 }

--- a/backend/internal/compose/coldstartaccept.go
+++ b/backend/internal/compose/coldstartaccept.go
@@ -60,9 +60,9 @@ func approvalsServiceWithEffects(pool *pgxpool.Pool) *approvals.Service {
 	svc.WithEffect(orgNameProposalKind, orgNameAcceptEffect(svc, store))
 	svc.WithEffect(linkedInMatchKind, linkedInMatchAcceptEffect(svc, store))
 	svc.WithEffect(lifecycleProposalKind, lifecycleAcceptEffect(svc, store))
-	svc.WithEffect(deals.CloseDateCorrectionKind, closeDateConfirmEffect(svc, deals.NewStore(pool)))
+	svc.WithEffect(deals.CloseDateCorrectionKind, closeDateConfirmEffect(svc, deals.NewStore(pool, InstallationBaseCurrency())))
 	svc.WithEffect(deals.FollowUpReconcileKind, followUpConfirmEffect(svc, activities.NewStore(pool)))
-	svc.WithEffect(fxRateProposalKind, fxRateAcceptEffect(svc, deals.NewStore(pool)))
+	svc.WithEffect(fxRateProposalKind, fxRateAcceptEffect(svc, deals.NewStore(pool, InstallationBaseCurrency())))
 	svc.WithEffect(aiModelRateProposalKind, aiModelRateAcceptEffect(svc, ai.NewRateStore(pool)))
 	return svc
 }

--- a/backend/internal/compose/datareset.go
+++ b/backend/internal/compose/datareset.go
@@ -283,7 +283,7 @@ func (h dataResetHandlers) sweepAndReseed(ctx context.Context, wsID ids.UUID, co
 			Type: principal.PrincipalSystem, ID: "system",
 		})
 		seedCtx = principal.WithCorrelationID(seedCtx, ids.NewV7())
-		if err := configuredSeed(h.seeds, deals.NewHandlers(h.pool))(seedCtx, tx); err != nil {
+		if err := configuredSeed(h.seeds, deals.NewHandlers(h.pool, InstallationBaseCurrency()))(seedCtx, tx); err != nil {
 			return err
 		}
 

--- a/backend/internal/compose/datareset.go
+++ b/backend/internal/compose/datareset.go
@@ -283,7 +283,7 @@ func (h dataResetHandlers) sweepAndReseed(ctx context.Context, wsID ids.UUID, co
 			Type: principal.PrincipalSystem, ID: "system",
 		})
 		seedCtx = principal.WithCorrelationID(seedCtx, ids.NewV7())
-		if err := configuredSeed(h.seeds, deals.NewHandlers(h.pool, InstallationBaseCurrency()))(seedCtx, tx); err != nil {
+		if err := configuredSeed(h.seeds, deals.NewHandlers(h.pool, identity.BaseCurrencyOf))(seedCtx, tx); err != nil {
 			return err
 		}
 

--- a/backend/internal/compose/extractionaccept.go
+++ b/backend/internal/compose/extractionaccept.go
@@ -30,6 +30,7 @@ import (
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/modules/activities"
 	"github.com/gradionhq/margince/backend/internal/modules/deals"
+	"github.com/gradionhq/margince/backend/internal/modules/identity"
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
@@ -86,7 +87,7 @@ func NewExtractionAccept(pool *pgxpool.Pool, extractor extraction.Extractor) *Ex
 	return &ExtractionAccept{
 		pool:        pool,
 		attachments: activities.NewStore(pool),
-		deals:       deals.NewStore(pool, InstallationBaseCurrency()),
+		deals:       deals.NewStore(pool, identity.BaseCurrencyOf),
 		extractor:   extractor,
 	}
 }

--- a/backend/internal/compose/extractionaccept.go
+++ b/backend/internal/compose/extractionaccept.go
@@ -86,7 +86,7 @@ func NewExtractionAccept(pool *pgxpool.Pool, extractor extraction.Extractor) *Ex
 	return &ExtractionAccept{
 		pool:        pool,
 		attachments: activities.NewStore(pool),
-		deals:       deals.NewStore(pool),
+		deals:       deals.NewStore(pool, InstallationBaseCurrency()),
 		extractor:   extractor,
 	}
 }

--- a/backend/internal/compose/flipwriters.go
+++ b/backend/internal/compose/flipwriters.go
@@ -35,6 +35,7 @@ import (
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/modules/activities"
 	"github.com/gradionhq/margince/backend/internal/modules/deals"
+	"github.com/gradionhq/margince/backend/internal/modules/identity"
 	"github.com/gradionhq/margince/backend/internal/modules/migration"
 	"github.com/gradionhq/margince/backend/internal/modules/overlay"
 	"github.com/gradionhq/margince/backend/internal/modules/people"
@@ -92,7 +93,7 @@ func newFlipWriters(pool *pgxpool.Pool, ms *overlay.MirrorStore, incumbent strin
 	return &flipWriters{
 		pool:       pool,
 		people:     people.NewStore(pool),
-		deals:      deals.NewStore(pool, InstallationBaseCurrency()),
+		deals:      deals.NewStore(pool, identity.BaseCurrencyOf),
 		activities: activities.NewStore(pool),
 		ms:         ms,
 		identities: migration.NewRunStore(pool),

--- a/backend/internal/compose/flipwriters.go
+++ b/backend/internal/compose/flipwriters.go
@@ -92,7 +92,7 @@ func newFlipWriters(pool *pgxpool.Pool, ms *overlay.MirrorStore, incumbent strin
 	return &flipWriters{
 		pool:       pool,
 		people:     people.NewStore(pool),
-		deals:      deals.NewStore(pool),
+		deals:      deals.NewStore(pool, InstallationBaseCurrency()),
 		activities: activities.NewStore(pool),
 		ms:         ms,
 		identities: migration.NewRunStore(pool),

--- a/backend/internal/compose/fxrefresh.go
+++ b/backend/internal/compose/fxrefresh.go
@@ -302,7 +302,7 @@ func (w *fxRefreshWorker) Work(ctx context.Context, job *river.Job[FxRateRefresh
 
 func newFxRefreshWorker(pool *pgxpool.Pool, brain completer, url string, bootstrapCurrencies []string, log *slog.Logger) *fxRefreshWorker {
 	return &fxRefreshWorker{refresh: fxRefresh{
-		store:               deals.NewStore(pool),
+		store:               deals.NewStore(pool, InstallationBaseCurrency()),
 		svc:                 approvals.NewService(pool),
 		fetcher:             webread.New(),
 		brain:               brain,

--- a/backend/internal/compose/fxrefresh.go
+++ b/backend/internal/compose/fxrefresh.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/modules/ai"
 	"github.com/gradionhq/margince/backend/internal/modules/approvals"
 	"github.com/gradionhq/margince/backend/internal/modules/deals"
+	"github.com/gradionhq/margince/backend/internal/modules/identity"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/platform/jobs"
 	"github.com/gradionhq/margince/backend/internal/platform/webread"
@@ -274,7 +275,7 @@ func (f fxRefresh) plan(ctx context.Context, current []deals.FxRateRow) (base st
 	if len(f.bootstrapCurrencies) == 0 {
 		return "", nil, nil
 	}
-	base, err = f.store.WorkspaceBaseCurrency(ctx)
+	base, err = f.store.BaseCurrency(ctx)
 	if err != nil {
 		return "", nil, fmt.Errorf("fx refresh: %w", err)
 	}
@@ -302,7 +303,7 @@ func (w *fxRefreshWorker) Work(ctx context.Context, job *river.Job[FxRateRefresh
 
 func newFxRefreshWorker(pool *pgxpool.Pool, brain completer, url string, bootstrapCurrencies []string, log *slog.Logger) *fxRefreshWorker {
 	return &fxRefreshWorker{refresh: fxRefresh{
-		store:               deals.NewStore(pool, InstallationBaseCurrency()),
+		store:               deals.NewStore(pool, identity.BaseCurrencyOf),
 		svc:                 approvals.NewService(pool),
 		fetcher:             webread.New(),
 		brain:               brain,

--- a/backend/internal/compose/fxrefresh_integration_test.go
+++ b/backend/internal/compose/fxrefresh_integration_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/compose/integration"
 	"github.com/gradionhq/margince/backend/internal/modules/approvals"
 	"github.com/gradionhq/margince/backend/internal/modules/deals"
+	"github.com/gradionhq/margince/backend/internal/modules/identity"
 	"github.com/gradionhq/margince/backend/internal/platform/webread"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/model"
@@ -52,7 +53,7 @@ func (b fixedBrain) Complete(context.Context, model.Request) (model.Response, er
 // that will "extract" the given pairs JSON.
 func fxRefreshWith(e *integration.Env, reply string, bootstrap []string) fxRefresh {
 	return fxRefresh{
-		store:               deals.NewStore(e.Pool, InstallationBaseCurrency()),
+		store:               deals.NewStore(e.Pool, identity.BaseCurrencyOf),
 		svc:                 approvals.NewService(e.Pool),
 		fetcher:             stubFetcher{},
 		brain:               fixedBrain{json: reply},
@@ -83,7 +84,7 @@ func TestFxRefreshStagesChangedRates(t *testing.T) {
 	adminCtx := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AdminPerms)
 
 	// The workspace tracks USD at 0.92 (base EUR).
-	if _, err := deals.NewStore(e.Pool, InstallationBaseCurrency()).SetFxRate(adminCtx,
+	if _, err := deals.NewStore(e.Pool, identity.BaseCurrencyOf).SetFxRate(adminCtx,
 		deals.SetFxRateInput{FromCurrency: "USD", Rate: "0.92", EffectiveDate: time.Now().UTC()}); err != nil {
 		t.Fatalf("seed USD: %v", err)
 	}
@@ -125,7 +126,7 @@ func seedFx(ctx context.Context, t *testing.T, store *deals.Store, cur, rate str
 func TestFxRefreshDiffsAgainstEffectiveTodayNotSheetHead(t *testing.T) {
 	e := integration.Setup(t)
 	adminCtx := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AdminPerms)
-	store := deals.NewStore(e.Pool, InstallationBaseCurrency())
+	store := deals.NewStore(e.Pool, identity.BaseCurrencyOf)
 	tomorrow := time.Now().UTC().Add(24 * time.Hour)
 
 	// USD: today matches the source; a future row differs (must NOT propose).
@@ -158,7 +159,7 @@ func TestFxRefreshDiffsAgainstEffectiveTodayNotSheetHead(t *testing.T) {
 func TestFxRefreshSupersedesStalePendingProposal(t *testing.T) {
 	e := integration.Setup(t)
 	adminCtx := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AdminPerms)
-	store := deals.NewStore(e.Pool, InstallationBaseCurrency())
+	store := deals.NewStore(e.Pool, identity.BaseCurrencyOf)
 	seedFx(adminCtx, t, store, "USD", "0.9", time.Time{})
 
 	wctx := rateRefreshWorkerCtx(context.Background(), e.WS, e.Rep1.String())
@@ -246,7 +247,7 @@ func TestFxRefreshEmptySheetNoBootstrapSetIsNoOp(t *testing.T) {
 func TestFxRefreshDropsLowConfidenceAndCrossPairs(t *testing.T) {
 	e := integration.Setup(t)
 	adminCtx := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AdminPerms)
-	seedFx(adminCtx, t, deals.NewStore(e.Pool, InstallationBaseCurrency()), "USD", "0.92", time.Now().UTC())
+	seedFx(adminCtx, t, deals.NewStore(e.Pool, identity.BaseCurrencyOf), "USD", "0.92", time.Now().UTC())
 
 	// USD arrives only via a low-confidence pair and a cross-pair (USD/GBP,
 	// neither side is the base EUR). Both are dropped, so nothing is staged.

--- a/backend/internal/compose/fxrefresh_integration_test.go
+++ b/backend/internal/compose/fxrefresh_integration_test.go
@@ -52,7 +52,7 @@ func (b fixedBrain) Complete(context.Context, model.Request) (model.Response, er
 // that will "extract" the given pairs JSON.
 func fxRefreshWith(e *integration.Env, reply string, bootstrap []string) fxRefresh {
 	return fxRefresh{
-		store:               deals.NewStore(e.Pool),
+		store:               deals.NewStore(e.Pool, InstallationBaseCurrency()),
 		svc:                 approvals.NewService(e.Pool),
 		fetcher:             stubFetcher{},
 		brain:               fixedBrain{json: reply},
@@ -83,7 +83,7 @@ func TestFxRefreshStagesChangedRates(t *testing.T) {
 	adminCtx := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AdminPerms)
 
 	// The workspace tracks USD at 0.92 (base EUR).
-	if _, err := deals.NewStore(e.Pool).SetFxRate(adminCtx,
+	if _, err := deals.NewStore(e.Pool, InstallationBaseCurrency()).SetFxRate(adminCtx,
 		deals.SetFxRateInput{FromCurrency: "USD", Rate: "0.92", EffectiveDate: time.Now().UTC()}); err != nil {
 		t.Fatalf("seed USD: %v", err)
 	}
@@ -125,7 +125,7 @@ func seedFx(ctx context.Context, t *testing.T, store *deals.Store, cur, rate str
 func TestFxRefreshDiffsAgainstEffectiveTodayNotSheetHead(t *testing.T) {
 	e := integration.Setup(t)
 	adminCtx := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AdminPerms)
-	store := deals.NewStore(e.Pool)
+	store := deals.NewStore(e.Pool, InstallationBaseCurrency())
 	tomorrow := time.Now().UTC().Add(24 * time.Hour)
 
 	// USD: today matches the source; a future row differs (must NOT propose).
@@ -158,7 +158,7 @@ func TestFxRefreshDiffsAgainstEffectiveTodayNotSheetHead(t *testing.T) {
 func TestFxRefreshSupersedesStalePendingProposal(t *testing.T) {
 	e := integration.Setup(t)
 	adminCtx := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AdminPerms)
-	store := deals.NewStore(e.Pool)
+	store := deals.NewStore(e.Pool, InstallationBaseCurrency())
 	seedFx(adminCtx, t, store, "USD", "0.9", time.Time{})
 
 	wctx := rateRefreshWorkerCtx(context.Background(), e.WS, e.Rep1.String())
@@ -246,7 +246,7 @@ func TestFxRefreshEmptySheetNoBootstrapSetIsNoOp(t *testing.T) {
 func TestFxRefreshDropsLowConfidenceAndCrossPairs(t *testing.T) {
 	e := integration.Setup(t)
 	adminCtx := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AdminPerms)
-	seedFx(adminCtx, t, deals.NewStore(e.Pool), "USD", "0.92", time.Now().UTC())
+	seedFx(adminCtx, t, deals.NewStore(e.Pool, InstallationBaseCurrency()), "USD", "0.92", time.Now().UTC())
 
 	// USD arrives only via a low-confidence pair and a cross-pair (USD/GBP,
 	// neither side is the base EUR). Both are dropped, so nothing is staged.

--- a/backend/internal/compose/installation.go
+++ b/backend/internal/compose/installation.go
@@ -59,7 +59,7 @@ func EnsureInstallation(ctx context.Context, pool *pgxpool.Pool, log *slog.Logge
 		}
 	}
 
-	wsID, created, err := identity.NewService(pool).BootstrapInstallation(ctx, create, configuredSeed(cfg.Seeds, deals.NewHandlers(pool)))
+	wsID, created, err := identity.NewService(pool).BootstrapInstallation(ctx, create, configuredSeed(cfg.Seeds, deals.NewHandlers(pool, InstallationBaseCurrency())))
 	if errors.Is(err, identity.ErrNotBootstrapped) {
 		return fmt.Errorf("compose: the database holds no organization and the configuration names no bootstrap_admin — add organization + bootstrap_admin to margince.yaml for first boot: %w", err)
 	}

--- a/backend/internal/compose/installation.go
+++ b/backend/internal/compose/installation.go
@@ -59,7 +59,7 @@ func EnsureInstallation(ctx context.Context, pool *pgxpool.Pool, log *slog.Logge
 		}
 	}
 
-	wsID, created, err := identity.NewService(pool).BootstrapInstallation(ctx, create, configuredSeed(cfg.Seeds, deals.NewHandlers(pool, InstallationBaseCurrency())))
+	wsID, created, err := identity.NewService(pool).BootstrapInstallation(ctx, create, configuredSeed(cfg.Seeds, deals.NewHandlers(pool, identity.BaseCurrencyOf)))
 	if errors.Is(err, identity.ErrNotBootstrapped) {
 		return fmt.Errorf("compose: the database holds no organization and the configuration names no bootstrap_admin — add organization + bootstrap_admin to margince.yaml for first boot: %w", err)
 	}

--- a/backend/internal/compose/integration/authority_scope_integration_test.go
+++ b/backend/internal/compose/integration/authority_scope_integration_test.go
@@ -33,10 +33,11 @@ func repPermsWithOrg() principal.Permissions {
 	p := principal.Permissions{
 		RoleKeys: []string{"rep"},
 		Objects: map[string]principal.ObjectGrant{
-			"person":       {Create: true, Read: true, Update: true},
-			"organization": {Create: true, Read: true, Update: true},
-			"deal":         {Create: true, Read: true, Update: true},
-			"pipeline":     {Read: true},
+			"person":                {Create: true, Read: true, Update: true},
+			"organization":          {Create: true, Read: true, Update: true},
+			"deal":                  {Create: true, Read: true, Update: true},
+			"pipeline":              {Read: true},
+			"installation_settings": {Read: true},
 		},
 		RowScope: principal.RowScopeTeam,
 	}

--- a/backend/internal/compose/integration/basecurrencyseam_integration_test.go
+++ b/backend/internal/compose/integration/basecurrencyseam_integration_test.go
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// The base currency a deal freezes against comes from the SETTING row, not
+// from workspace.base_currency (ADR-0091 phase 4, issue #521).
+//
+// While both copies exist, every other test in this tree seeds them to the
+// same value — so reverting the readers to the column leaves those suites
+// green and the migration only LOOKS done. These tests set the two copies to
+// disagree, which is the one fixture that can tell the readers apart.
+
+import (
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/modules/deals"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// baseCurrencyOnUSD points the setting at USD while the workspace column
+// stays EUR, and puts a EUR→USD rate on the sheet. The disagreement is the
+// test: a reader still on the column sees base EUR.
+func baseCurrencyOnUSD(t *testing.T, e *Env) {
+	t.Helper()
+	e.WsExec(t, `UPDATE setting SET value = '"USD"'::jsonb WHERE key = 'installation.base_currency'`)
+	if n := e.WsCount(t, `SELECT count(*) FROM workspace WHERE id = $1 AND base_currency = 'EUR'`, e.WS); n != 1 {
+		t.Fatal("the fixture needs the two copies to DISAGREE; workspace.base_currency is not EUR")
+	}
+	e.WsExec(t, `INSERT INTO fx_rate (workspace_id, from_currency, to_currency, rate, rate_date)
+		VALUES ($1, 'EUR', 'USD', '1.1000000000', CURRENT_DATE - 1)`, e.WS)
+}
+
+// Closing a EUR deal freezes the EUR→USD rate. This is the assertion that
+// separates the two readers: against the column the deal's own currency WOULD
+// equal the base, and freezeFx short-circuits to the identity rate 1 without
+// consulting the sheet at all.
+func TestClosingADealFreezesAgainstTheSettingsBaseCurrency(t *testing.T) {
+	e := Setup(t)
+	pipeline, open, won := DealFixture(t, e)
+	admin := e.Admin()
+	baseCurrencyOnUSD(t, e)
+
+	amount, currency := int64(100000), "EUR"
+	d, err := e.Deals.CreateDeal(admin, deals.CreateDealInput{
+		Name: "Priced in EUR, reported in USD", PipelineID: pipeline, StageID: open,
+		Source: "manual", AmountMinor: &amount, Currency: &currency,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := e.Deals.AdvanceDeal(admin,
+		ids.From[ids.DealKind](ids.UUID(d.Id)), deals.AdvanceDealInput{ToStageID: won}); err != nil {
+		t.Fatalf("closing as won: %v", err)
+	}
+
+	if n := e.WsCount(t, `SELECT count(*) FROM deal WHERE id = $1 AND fx_rate_to_base = 1`,
+		ids.UUID(d.Id)); n != 0 {
+		t.Fatal("the deal froze at the identity rate 1 — the close read the base currency " +
+			"from workspace.base_currency, where EUR still is the base")
+	}
+	if n := e.WsCount(t, `SELECT count(*) FROM deal WHERE id = $1 AND fx_rate_to_base = 1.1`,
+		ids.UUID(d.Id)); n != 1 {
+		t.Error("fx_rate_to_base is not the 1.1 EUR→USD rate the sheet carries")
+	}
+}
+
+// The fx sheet is listed against the base the SETTING names, so a rate priced
+// into the retiring column's currency is not on it.
+func TestTheFxSheetListsRatesIntoTheSettingsBaseCurrency(t *testing.T) {
+	e := Setup(t)
+	admin := e.Admin()
+	baseCurrencyOnUSD(t, e)
+
+	base, err := e.Deals.BaseCurrency(admin)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if base != "USD" {
+		t.Errorf("BaseCurrency() = %q, want USD — the fx screen is still reading the column", base)
+	}
+}

--- a/backend/internal/compose/integration/customfields_values_deal_integration_test.go
+++ b/backend/internal/compose/integration/customfields_values_deal_integration_test.go
@@ -31,9 +31,10 @@ import (
 var dealCFVPerms = principal.Permissions{
 	RoleKeys: []string{"admin"},
 	Objects: map[string]principal.ObjectGrant{
-		"custom_field": {Create: true, Read: true, Update: true, Delete: true},
-		"deal":         {Create: true, Read: true, Update: true, Delete: true},
-		"pipeline":     {Create: true, Read: true, Update: true, Delete: true},
+		"custom_field":          {Create: true, Read: true, Update: true, Delete: true},
+		"deal":                  {Create: true, Read: true, Update: true, Delete: true},
+		"pipeline":              {Create: true, Read: true, Update: true, Delete: true},
+		"installation_settings": {Read: true},
 	},
 	RowScope: principal.RowScopeAll,
 }

--- a/backend/internal/compose/integration/customfields_values_deal_integration_test.go
+++ b/backend/internal/compose/integration/customfields_values_deal_integration_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/gradionhq/margince/backend/internal/modules/customfields"
 	"github.com/gradionhq/margince/backend/internal/modules/deals"
+	"github.com/gradionhq/margince/backend/internal/modules/identity"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
@@ -57,7 +58,7 @@ func setupDealCFV(t *testing.T) dealCFVFixture {
 	return dealCFVFixture{
 		e:        e,
 		svc:      svc,
-		store:    deals.NewStore(e.Pool).WithFieldCatalog(svc),
+		store:    deals.NewStore(e.Pool, identity.BaseCurrencyOf).WithFieldCatalog(svc),
 		ctx:      e.As(e.Rep1, nil, dealCFVPerms),
 		pipeline: pipeline,
 		stage:    open,

--- a/backend/internal/compose/integration/customfields_vocab_integration_test.go
+++ b/backend/internal/compose/integration/customfields_vocab_integration_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/gradionhq/margince/backend/internal/modules/customfields"
 	"github.com/gradionhq/margince/backend/internal/modules/deals"
+	"github.com/gradionhq/margince/backend/internal/modules/identity"
 	"github.com/gradionhq/margince/backend/internal/modules/people"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
@@ -291,7 +292,7 @@ func TestCustomFieldVocab_CoreVocabulary(t *testing.T) {
 	f := setupCFV(t)
 	// The deal list shares f's Env (Setup rebuilds the schema, so one
 	// per test) — its store rides the same pool and field catalog.
-	dealStore := deals.NewStore(f.e.Pool).WithFieldCatalog(f.svc)
+	dealStore := deals.NewStore(f.e.Pool, identity.BaseCurrencyOf).WithFieldCatalog(f.svc)
 	dealCtx := f.e.As(f.e.Rep1, nil, dealCFVPerms)
 
 	resources := coreVocabResources(dealCtx, f, dealStore)

--- a/backend/internal/compose/integration/documents_integration_test.go
+++ b/backend/internal/compose/integration/documents_integration_test.go
@@ -196,9 +196,10 @@ func TestAnUploadedDocumentReachesTheAccountLibrary(t *testing.T) {
 var docUploadPerms = principal.Permissions{
 	RoleKeys: []string{"rep"},
 	Objects: map[string]principal.ObjectGrant{
-		"organization": {Read: true, Update: true},
-		"deal":         {Read: true, Update: true},
-		"person":       {Read: true},
+		"organization":          {Read: true, Update: true},
+		"deal":                  {Read: true, Update: true},
+		"person":                {Read: true},
+		"installation_settings": {Read: true},
 	},
 	RowScope: principal.RowScopeTeam,
 }

--- a/backend/internal/compose/integration/fxrate_integration_test.go
+++ b/backend/internal/compose/integration/fxrate_integration_test.go
@@ -156,7 +156,15 @@ func TestFxRateCrossWorkspaceIsolation(t *testing.T) {
 func fxRatePerms(g principal.ObjectGrant) principal.Permissions {
 	return principal.Permissions{
 		RoleKeys: []string{"ops"},
-		Objects:  map[string]principal.ObjectGrant{"fx_rate": g},
+		Objects: map[string]principal.ObjectGrant{
+			"fx_rate": g,
+			// The matrix narrows fx_rate and ONLY fx_rate. Writing a rate
+			// resolves the base currency it converts into, which is read
+			// behind installation_settings — an object every seeded role holds
+			// (0191), so withholding it here would refuse for a reason the
+			// matrix is not about.
+			"installation_settings": {Read: true},
+		},
 		RowScope: principal.RowScopeAll,
 	}
 }

--- a/backend/internal/compose/integration/harness.go
+++ b/backend/internal/compose/integration/harness.go
@@ -77,6 +77,17 @@ func Setup(t *testing.T) *Env {
 		`INSERT INTO workspace (id, name, slug, base_currency) VALUES ($1, 'Authz', 'authz', 'EUR')`, e.WS); err != nil {
 		t.Fatal(err)
 	}
+	// The installation's base currency as a settings row (ADR-0090/A135), the
+	// other half of the same fact. This harness builds the installation by raw
+	// SQL, so bootstrap never seeded it and 0191's backfill ran before the
+	// workspace existed — and the money readers resolve the SETTING, not the
+	// column (issue #521). It must match the column above: a suite whose two
+	// copies disagree measures the drift rather than the behaviour under test.
+	if _, err := owner.Exec(ctx,
+		`INSERT INTO setting (key, value) VALUES ('installation.base_currency', '"EUR"'::jsonb)
+		 ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value`); err != nil {
+		t.Fatal(err)
+	}
 	for i, user := range []ids.UUID{e.Rep1, e.Rep2, e.Rep3} {
 		if _, err := owner.Exec(ctx,
 			`INSERT INTO app_user (id, workspace_id, email, display_name) VALUES ($1, $2, $3, $4)`,

--- a/backend/internal/compose/integration/harness.go
+++ b/backend/internal/compose/integration/harness.go
@@ -77,20 +77,6 @@ func Setup(t *testing.T) *Env {
 		`INSERT INTO workspace (id, name, slug, base_currency) VALUES ($1, 'Authz', 'authz', 'EUR')`, e.WS); err != nil {
 		t.Fatal(err)
 	}
-	// The installation's base currency, as a setting row (ADR-0090/A135). It
-	// is seeded HERE, beside the workspace insert, because the two are one
-	// fact: this harness builds the installation by raw SQL, so migration
-	// 0191's backfill — which keys on a workspace that already exists — never
-	// saw it, and bootstrap's seed never ran either.
-	//
-	// It must match the column above. The readers are mid-migration off that
-	// column (ADR-0091 phase 4), so a suite whose two copies disagree is
-	// measuring the drift rather than the behaviour under test.
-	if _, err := owner.Exec(ctx,
-		`INSERT INTO setting (key, value) VALUES ('installation.base_currency', '"EUR"'::jsonb)
-		 ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value`); err != nil {
-		t.Fatal(err)
-	}
 	for i, user := range []ids.UUID{e.Rep1, e.Rep2, e.Rep3} {
 		if _, err := owner.Exec(ctx,
 			`INSERT INTO app_user (id, workspace_id, email, display_name) VALUES ($1, $2, $3, $4)`,

--- a/backend/internal/compose/integration/harness.go
+++ b/backend/internal/compose/integration/harness.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/gradionhq/margince/backend/internal/modules/activities"
 	"github.com/gradionhq/margince/backend/internal/modules/deals"
+	"github.com/gradionhq/margince/backend/internal/modules/identity"
 	"github.com/gradionhq/margince/backend/internal/modules/people"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/jobs"
@@ -122,7 +123,7 @@ func Setup(t *testing.T) *Env {
 	t.Cleanup(func() { testdb.AssertPoolsQuiesced(t) })
 	e.Pool = pool
 	e.People = people.NewStore(pool)
-	e.Deals = deals.NewStore(pool)
+	e.Deals = deals.NewStore(pool, identity.BaseCurrencyOf)
 	e.Activities = activities.NewStore(pool)
 	return e
 }

--- a/backend/internal/compose/integration/listsortcoverage_integration_test.go
+++ b/backend/internal/compose/integration/listsortcoverage_integration_test.go
@@ -17,6 +17,7 @@ import (
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/modules/deals"
+	"github.com/gradionhq/margince/backend/internal/modules/identity"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
@@ -64,7 +65,7 @@ func TestProductListSortsByEveryOfferedColumn(t *testing.T) {
 	e.Seed(t, seedProduct, "Apex", "SKU-A", 9000, false, seedLatest, seedMiddle)
 	e.Seed(t, seedProduct, "Zenith", "SKU-Z", 1000, true, seedEarliest, seedLatest)
 
-	store := deals.NewStore(e.Pool)
+	store := deals.NewStore(e.Pool, identity.BaseCurrencyOf)
 	for _, tc := range []struct {
 		sort  string
 		order []string
@@ -102,7 +103,7 @@ func TestOfferTemplateListSortsByEveryOfferedColumn(t *testing.T) {
 	e.Seed(t, seedTemplate, "Apex", "en-GB", false, seedLatest, seedMiddle)
 	e.Seed(t, seedTemplate, "Zenith", "fr-FR", true, seedEarliest, seedLatest)
 
-	store := deals.NewStore(e.Pool)
+	store := deals.NewStore(e.Pool, identity.BaseCurrencyOf)
 	for _, tc := range []struct {
 		sort  string
 		order []string

--- a/backend/internal/compose/integration/offer_acceptline_integration_test.go
+++ b/backend/internal/compose/integration/offer_acceptline_integration_test.go
@@ -29,8 +29,9 @@ import (
 var offerDeskPerms = principal.Permissions{
 	RoleKeys: []string{"deal_desk"},
 	Objects: map[string]principal.ObjectGrant{
-		"deal":  {Create: true, Read: true, Update: true},
-		"offer": {Create: true, Read: true, Update: true},
+		"deal":                  {Create: true, Read: true, Update: true},
+		"offer":                 {Create: true, Read: true, Update: true},
+		"installation_settings": {Read: true},
 	},
 	RowScope: principal.RowScopeAll,
 }

--- a/backend/internal/compose/integration/offerrender_integration_test.go
+++ b/backend/internal/compose/integration/offerrender_integration_test.go
@@ -46,9 +46,10 @@ import (
 var offerRenderDeskPerms = principal.Permissions{
 	RoleKeys: []string{"deal_desk"},
 	Objects: map[string]principal.ObjectGrant{
-		"deal":           {Create: true, Read: true, Update: true},
-		"offer":          {Create: true, Read: true, Update: true},
-		"offer_template": {Create: true, Read: true},
+		"deal":                  {Create: true, Read: true, Update: true},
+		"offer":                 {Create: true, Read: true, Update: true},
+		"offer_template":        {Create: true, Read: true},
+		"installation_settings": {Read: true},
 	},
 	RowScope: principal.RowScopeAll,
 }
@@ -386,10 +387,11 @@ func seedOfferRenderWorkspaceB(t *testing.T, e *Env, owner *pgx.Conn) ids.OfferI
 		Permissions: principal.Permissions{
 			RoleKeys: []string{"deal_desk"},
 			Objects: map[string]principal.ObjectGrant{
-				"pipeline":       {Create: true, Read: true},
-				"deal":           {Create: true, Read: true, Update: true},
-				"offer":          {Create: true, Read: true, Update: true},
-				"offer_template": {Create: true, Read: true},
+				"pipeline":              {Create: true, Read: true},
+				"deal":                  {Create: true, Read: true, Update: true},
+				"offer":                 {Create: true, Read: true, Update: true},
+				"offer_template":        {Create: true, Read: true},
+				"installation_settings": {Read: true},
 			},
 			RowScope: principal.RowScopeAll,
 		},

--- a/backend/internal/compose/integration/offerrender_integration_test.go
+++ b/backend/internal/compose/integration/offerrender_integration_test.go
@@ -31,6 +31,7 @@ import (
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/modules/deals"
+	"github.com/gradionhq/margince/backend/internal/modules/identity"
 	"github.com/gradionhq/margince/backend/internal/modules/people"
 	"github.com/gradionhq/margince/backend/internal/platform/blobstore"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
@@ -487,7 +488,7 @@ func TestOfferRenderHandler_ReadOnlyOfferGrantDeniedBeforeAnyBlobWrite(t *testin
 	offerID := ids.From[ids.OfferKind](ids.UUID(created.Id))
 
 	blob := &spyBlobStore{Store: blobstore.NewMemory()}
-	h := deals.NewHandlers(e.Pool).WithBlobstore(blob)
+	h := deals.NewHandlers(e.Pool, identity.BaseCurrencyOf).WithBlobstore(blob)
 
 	readOnly := e.As(e.Rep2, []ids.UUID{e.Team1}, offerRenderReadOnlyPerms)
 	req := httptest.NewRequest(http.MethodPost, "/v1/offers/"+created.Id.String()+"/render", nil).WithContext(readOnly)

--- a/backend/internal/compose/integration/organization_computed_integration_test.go
+++ b/backend/internal/compose/integration/organization_computed_integration_test.go
@@ -155,10 +155,11 @@ var computedFieldNoGrantPerms = principal.Permissions{
 var computedFieldWorkspaceBPerms = principal.Permissions{
 	RoleKeys: []string{"admin"},
 	Objects: map[string]principal.ObjectGrant{
-		"organization":   {Create: true, Read: true},
-		"deal":           {Create: true, Read: true},
-		"pipeline":       {Create: true, Read: true},
-		"computed_field": {Read: true},
+		"organization":          {Create: true, Read: true},
+		"deal":                  {Create: true, Read: true},
+		"pipeline":              {Create: true, Read: true},
+		"computed_field":        {Read: true},
+		"installation_settings": {Read: true},
 	},
 	RowScope: principal.RowScopeAll,
 }

--- a/backend/internal/compose/integration/orgbrief_integration_test.go
+++ b/backend/internal/compose/integration/orgbrief_integration_test.go
@@ -81,11 +81,12 @@ func nativeMode(context.Context) (bool, error) { return false, nil }
 var briefReaderPerms = principal.Permissions{
 	RoleKeys: []string{"rep"},
 	Objects: map[string]principal.ObjectGrant{
-		"organization": {Read: true},
-		"person":       {Create: true, Read: true},
-		"deal":         {Create: true, Read: true, Update: true},
-		"activity":     {Read: true},
-		"pipeline":     {Read: true},
+		"organization":          {Read: true},
+		"person":                {Create: true, Read: true},
+		"deal":                  {Create: true, Read: true, Update: true},
+		"activity":              {Read: true},
+		"pipeline":              {Read: true},
+		"installation_settings": {Read: true},
 	},
 	RowScope: principal.RowScopeAll,
 }

--- a/backend/internal/compose/integration/overlay/overlay_cutover_lifecycle_integration_test.go
+++ b/backend/internal/compose/integration/overlay/overlay_cutover_lifecycle_integration_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/modules/deals"
+	"github.com/gradionhq/margince/backend/internal/modules/identity"
 	overlaymod "github.com/gradionhq/margince/backend/internal/modules/overlay"
 	"github.com/gradionhq/margince/backend/internal/modules/overlay/fake"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
@@ -227,7 +228,7 @@ func seedCleanWorkspace(t *testing.T, f flipEstate) context.Context {
 		t.Fatalf("seeding the clean workspace admin: %v", err)
 	}
 	cleanCtx := flipAdminCtx(ws, user.UUID)
-	if err := deals.NewHandlers(f.pool).SeedWorkspaceDefaults(cleanCtx); err != nil {
+	if err := deals.NewHandlers(f.pool, identity.BaseCurrencyOf).SeedWorkspaceDefaults(cleanCtx); err != nil {
 		t.Fatalf("seeding the clean workspace's default pipeline: %v", err)
 	}
 	return cleanCtx

--- a/backend/internal/compose/integration/overlay/overlay_flip_integration_test.go
+++ b/backend/internal/compose/integration/overlay/overlay_flip_integration_test.go
@@ -112,6 +112,10 @@ func flipAdminPerms() principal.Permissions {
 			"person": crud, "organization": crud, "deal": crud, "lead": crud,
 			"activity": crud, "relationship": crud, "pipeline": crud,
 			"overlay_connection": crud, "import_run": crud, "audit": {Read: true},
+			// The flip closes imported deals, and a close freezes a rate
+			// against the installation's base currency — read behind this
+			// object (0191 grants it to every seeded role, admin included).
+			"installation_settings": {Read: true},
 		},
 		RowScope: principal.RowScopeAll,
 	}

--- a/backend/internal/compose/integration/project_provider_integration_test.go
+++ b/backend/internal/compose/integration/project_provider_integration_test.go
@@ -21,13 +21,16 @@ import (
 	"testing"
 
 	"github.com/gradionhq/margince/backend/internal/modules/deals"
+	"github.com/gradionhq/margince/backend/internal/modules/identity"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
 )
 
-func projectProvider(e *Env) *deals.Provider { return deals.NewProvider(e.Pool) }
+func projectProvider(e *Env) *deals.Provider {
+	return deals.NewProvider(e.Pool, identity.BaseCurrencyOf)
+}
 
 // The seam's create-read-update-archive round trip, with the provenance the
 // agent path stamps.

--- a/backend/internal/compose/integration/quotas_attainment_integration_test.go
+++ b/backend/internal/compose/integration/quotas_attainment_integration_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gradionhq/margince/backend/internal/compose"
+	"github.com/gradionhq/margince/backend/internal/modules/identity"
 	"github.com/gradionhq/margince/backend/internal/modules/quotas"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
@@ -35,7 +35,7 @@ var attainmentClock = time.Date(2026, 2, 15, 12, 0, 0, 0, time.UTC)
 
 func attainmentStore(e *Env) *quotas.Store {
 	return quotas.NewStoreWithClock(e.Pool, func() time.Time { return attainmentClock },
-		compose.InstallationBaseCurrency())
+		identity.BaseCurrencyOf)
 }
 
 // attainmentDealSeed is one deal row inserted directly — attainment is a

--- a/backend/internal/compose/integration/quotas_integration_test.go
+++ b/backend/internal/compose/integration/quotas_integration_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gradionhq/margince/backend/internal/compose"
+	"github.com/gradionhq/margince/backend/internal/modules/identity"
 	"github.com/gradionhq/margince/backend/internal/modules/quotas"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
@@ -69,7 +69,7 @@ func ownerQuotaInput(owner ids.UUID, target int64) quotas.CreateQuotaInput {
 
 func TestQuotaCreate_OwnerAndTeamQuotas(t *testing.T) {
 	e := Setup(t)
-	store := quotas.NewStore(e.Pool, compose.InstallationBaseCurrency())
+	store := quotas.NewStore(e.Pool, identity.BaseCurrencyOf)
 	ctx := e.As(e.Rep1, nil, quotaAdminPerms)
 
 	owned, err := store.CreateQuota(ctx, ownerQuotaInput(e.Rep1, 28000000))
@@ -108,7 +108,7 @@ func TestQuotaCreate_OwnerAndTeamQuotas(t *testing.T) {
 
 func TestQuotaCreate_XORRefusedBeforeInsert(t *testing.T) {
 	e := Setup(t)
-	store := quotas.NewStore(e.Pool, compose.InstallationBaseCurrency())
+	store := quotas.NewStore(e.Pool, identity.BaseCurrencyOf)
 	ctx := e.As(e.Rep1, nil, quotaAdminPerms)
 
 	both := ownerQuotaInput(e.Rep1, 1000)
@@ -133,7 +133,7 @@ func TestQuotaCreate_XORRefusedBeforeInsert(t *testing.T) {
 
 func TestQuotaWrite_NegativeTargetRefused(t *testing.T) {
 	e := Setup(t)
-	store := quotas.NewStore(e.Pool, compose.InstallationBaseCurrency())
+	store := quotas.NewStore(e.Pool, identity.BaseCurrencyOf)
 	ctx := e.As(e.Rep1, nil, quotaAdminPerms)
 
 	// The contract's target_minor minimum (0) holds at the store for BOTH
@@ -174,7 +174,7 @@ func TestQuotaWrite_NegativeTargetRefused(t *testing.T) {
 
 func TestQuotaCreate_UnknownOwnerOrTeamAnswersNotFound(t *testing.T) {
 	e := Setup(t)
-	store := quotas.NewStore(e.Pool, compose.InstallationBaseCurrency())
+	store := quotas.NewStore(e.Pool, identity.BaseCurrencyOf)
 	ctx := e.As(e.Rep1, nil, quotaAdminPerms)
 
 	ghost := ids.NewV7()
@@ -190,7 +190,7 @@ func TestQuotaCreate_UnknownOwnerOrTeamAnswersNotFound(t *testing.T) {
 
 func TestQuotaGet_LiveArchivedAndAbsent(t *testing.T) {
 	e := Setup(t)
-	store := quotas.NewStore(e.Pool, compose.InstallationBaseCurrency())
+	store := quotas.NewStore(e.Pool, identity.BaseCurrencyOf)
 	ctx := e.As(e.Rep1, nil, quotaAdminPerms)
 
 	created, err := store.CreateQuota(ctx, ownerQuotaInput(e.Rep1, 1000))
@@ -221,7 +221,7 @@ func TestQuotaGet_LiveArchivedAndAbsent(t *testing.T) {
 
 func TestQuotaUpdate_HappyVersionSkewAndMergedXOR(t *testing.T) {
 	e := Setup(t)
-	store := quotas.NewStore(e.Pool, compose.InstallationBaseCurrency())
+	store := quotas.NewStore(e.Pool, identity.BaseCurrencyOf)
 	ctx := e.As(e.Rep1, nil, quotaAdminPerms)
 
 	created, err := store.CreateQuota(ctx, ownerQuotaInput(e.Rep1, 28000000))
@@ -282,7 +282,7 @@ func TestQuotaUpdate_HappyVersionSkewAndMergedXOR(t *testing.T) {
 
 func TestQuotaUpdate_PeriodAndCurrency(t *testing.T) {
 	e := Setup(t)
-	store := quotas.NewStore(e.Pool, compose.InstallationBaseCurrency())
+	store := quotas.NewStore(e.Pool, identity.BaseCurrencyOf)
 	ctx := e.As(e.Rep1, nil, quotaAdminPerms)
 
 	created, err := store.CreateQuota(ctx, ownerQuotaInput(e.Rep1, 1000))
@@ -305,7 +305,7 @@ func TestQuotaUpdate_PeriodAndCurrency(t *testing.T) {
 
 func TestQuotaArchive_IdempotentAndAuditedOnce(t *testing.T) {
 	e := Setup(t)
-	store := quotas.NewStore(e.Pool, compose.InstallationBaseCurrency())
+	store := quotas.NewStore(e.Pool, identity.BaseCurrencyOf)
 	ctx := e.As(e.Rep1, nil, quotaAdminPerms)
 
 	created, err := store.CreateQuota(ctx, ownerQuotaInput(e.Rep1, 1000))
@@ -337,7 +337,7 @@ func TestQuotaArchive_IdempotentAndAuditedOnce(t *testing.T) {
 
 func TestQuotaList_KeysetFiltersAndArchived(t *testing.T) {
 	e := Setup(t)
-	store := quotas.NewStore(e.Pool, compose.InstallationBaseCurrency())
+	store := quotas.NewStore(e.Pool, identity.BaseCurrencyOf)
 	ctx := e.As(e.Rep1, nil, quotaAdminPerms)
 
 	for _, owner := range []ids.UUID{e.Rep1, e.Rep2, e.Rep3} {
@@ -399,7 +399,7 @@ func TestQuotaList_KeysetFiltersAndArchived(t *testing.T) {
 
 func TestQuotaList_SortVocabulary(t *testing.T) {
 	e := Setup(t)
-	store := quotas.NewStore(e.Pool, compose.InstallationBaseCurrency())
+	store := quotas.NewStore(e.Pool, identity.BaseCurrencyOf)
 	ctx := e.As(e.Rep1, nil, quotaAdminPerms)
 
 	// Three owner-quotas whose period_start order deliberately disagrees
@@ -476,7 +476,7 @@ func TestQuotaList_SortVocabulary(t *testing.T) {
 
 func TestQuotaRBAC_RepReadsButNeverMutates(t *testing.T) {
 	e := Setup(t)
-	store := quotas.NewStore(e.Pool, compose.InstallationBaseCurrency())
+	store := quotas.NewStore(e.Pool, identity.BaseCurrencyOf)
 	admin := e.As(e.Rep1, nil, quotaAdminPerms)
 	rep := e.As(e.Rep2, []ids.UUID{e.Team1}, quotaRepPerms)
 
@@ -517,7 +517,7 @@ func TestQuotaRBAC_RepReadsButNeverMutates(t *testing.T) {
 func TestQuotaRLS_TenantIsolation(t *testing.T) {
 	e := Setup(t)
 	owner := OwnerConn(t)
-	store := quotas.NewStore(e.Pool, compose.InstallationBaseCurrency())
+	store := quotas.NewStore(e.Pool, identity.BaseCurrencyOf)
 	ctxA := e.As(e.Rep1, nil, quotaAdminPerms)
 
 	created, err := store.CreateQuota(ctxA, ownerQuotaInput(e.Rep1, 1000))

--- a/backend/internal/compose/introseams.go
+++ b/backend/internal/compose/introseams.go
@@ -225,7 +225,7 @@ const atRiskScanLimit = 25
 // order that list returns them, and the sweep stops at the cap rather than
 // sampling: a deterministic prefix can be explained to a rep, a sample cannot.
 func atRiskLister(pool *pgxpool.Pool) agents.AtRiskLister {
-	store := deals.NewStore(pool)
+	store := deals.NewStore(pool, InstallationBaseCurrency())
 	return func(ctx context.Context) (agents.AtRiskReport, error) {
 		var out agents.AtRiskReport
 		openStatus := network.DealStatusOpen

--- a/backend/internal/compose/introseams.go
+++ b/backend/internal/compose/introseams.go
@@ -23,6 +23,7 @@ import (
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/modules/agents"
 	"github.com/gradionhq/margince/backend/internal/modules/deals"
+	"github.com/gradionhq/margince/backend/internal/modules/identity"
 	"github.com/gradionhq/margince/backend/internal/modules/search"
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
@@ -225,7 +226,7 @@ const atRiskScanLimit = 25
 // order that list returns them, and the sweep stops at the cap rather than
 // sampling: a deterministic prefix can be explained to a rep, a sample cannot.
 func atRiskLister(pool *pgxpool.Pool) agents.AtRiskLister {
-	store := deals.NewStore(pool, InstallationBaseCurrency())
+	store := deals.NewStore(pool, identity.BaseCurrencyOf)
 	return func(ctx context.Context) (agents.AtRiskReport, error) {
 		var out agents.AtRiskReport
 		openStatus := network.DealStatusOpen

--- a/backend/internal/compose/jobs_finance.go
+++ b/backend/internal/compose/jobs_finance.go
@@ -26,6 +26,7 @@ import (
 	"github.com/riverqueue/river"
 
 	"github.com/gradionhq/margince/backend/internal/modules/finance"
+	"github.com/gradionhq/margince/backend/internal/modules/identity"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/jobs"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
@@ -93,7 +94,7 @@ func (w *financeSyncWorker) Work(ctx context.Context, job *river.Job[FinanceSync
 		// connected nothing, and a sweep over them has nothing to do.
 		return nil
 	}
-	store := finance.NewStore(w.pool, InstallationBaseCurrency())
+	store := finance.NewStore(w.pool, identity.BaseCurrencyOf)
 	result, err := store.SyncConnection(wsCtx, provider)
 	if err != nil {
 		return jobs.FaultContext(ctx, store.RecordSyncFailure(wsCtx, err))

--- a/backend/internal/compose/lifecycletools.go
+++ b/backend/internal/compose/lifecycletools.go
@@ -119,5 +119,5 @@ func (c companyEnricher) EnrichCompany(
 func lifecycleSeams(pool *pgxpool.Pool) (activityRelinker, leadDisqualifier, projectPhaseAdvancer) {
 	return activityRelinker{store: activities.NewStore(pool)},
 		leadDisqualifier{store: people.NewStore(pool)},
-		projectPhaseAdvancer{store: deals.NewStore(pool)}
+		projectPhaseAdvancer{store: deals.NewStore(pool, InstallationBaseCurrency())}
 }

--- a/backend/internal/compose/lifecycletools.go
+++ b/backend/internal/compose/lifecycletools.go
@@ -23,6 +23,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/modules/activities"
 	"github.com/gradionhq/margince/backend/internal/modules/agents"
 	"github.com/gradionhq/margince/backend/internal/modules/deals"
+	"github.com/gradionhq/margince/backend/internal/modules/identity"
 	"github.com/gradionhq/margince/backend/internal/modules/people"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
@@ -119,5 +120,5 @@ func (c companyEnricher) EnrichCompany(
 func lifecycleSeams(pool *pgxpool.Pool) (activityRelinker, leadDisqualifier, projectPhaseAdvancer) {
 	return activityRelinker{store: activities.NewStore(pool)},
 		leadDisqualifier{store: people.NewStore(pool)},
-		projectPhaseAdvancer{store: deals.NewStore(pool, InstallationBaseCurrency())}
+		projectPhaseAdvancer{store: deals.NewStore(pool, identity.BaseCurrencyOf)}
 }

--- a/backend/internal/compose/offerdraft.go
+++ b/backend/internal/compose/offerdraft.go
@@ -50,6 +50,7 @@ import (
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/modules/ai"
 	"github.com/gradionhq/margince/backend/internal/modules/deals"
+	"github.com/gradionhq/margince/backend/internal/modules/identity"
 	"github.com/gradionhq/margince/backend/internal/modules/signals"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
@@ -155,7 +156,7 @@ type offerDrafter struct {
 // path, this option only adds the evidence-gated staged lines on top.
 func WithOfferDraft(brain completer, retriever retrieval.Retriever) Option {
 	return func(s *Server, pool *pgxpool.Pool) {
-		store := deals.NewStore(pool, InstallationBaseCurrency())
+		store := deals.NewStore(pool, identity.BaseCurrencyOf)
 		s.offerDrafter = &offerDrafter{brain: brain, deals: store, rateCard: store, context: retriever}
 	}
 }

--- a/backend/internal/compose/offerdraft.go
+++ b/backend/internal/compose/offerdraft.go
@@ -155,7 +155,7 @@ type offerDrafter struct {
 // path, this option only adds the evidence-gated staged lines on top.
 func WithOfferDraft(brain completer, retriever retrieval.Retriever) Option {
 	return func(s *Server, pool *pgxpool.Pool) {
-		store := deals.NewStore(pool)
+		store := deals.NewStore(pool, InstallationBaseCurrency())
 		s.offerDrafter = &offerDrafter{brain: brain, deals: store, rateCard: store, context: retriever}
 	}
 }

--- a/backend/internal/compose/offerdraft_integration_test.go
+++ b/backend/internal/compose/offerdraft_integration_test.go
@@ -38,9 +38,10 @@ import (
 var offerDraftPerms = principal.Permissions{
 	RoleKeys: []string{"deal_desk"},
 	Objects: map[string]principal.ObjectGrant{
-		"deal":    {Create: true, Read: true, Update: true},
-		"offer":   {Create: true, Read: true, Update: true},
-		"product": {Create: true, Read: true},
+		"deal":                  {Create: true, Read: true, Update: true},
+		"offer":                 {Create: true, Read: true, Update: true},
+		"product":               {Create: true, Read: true},
+		"installation_settings": {Read: true},
 	},
 	RowScope: principal.RowScopeAll,
 }

--- a/backend/internal/compose/pipelineseams.go
+++ b/backend/internal/compose/pipelineseams.go
@@ -24,13 +24,14 @@ import (
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/modules/agents"
 	"github.com/gradionhq/margince/backend/internal/modules/deals"
+	"github.com/gradionhq/margince/backend/internal/modules/identity"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
 // pipelineLister answers list_pipelines from the workspace's live pipeline
 // configuration.
 func pipelineLister(pool *pgxpool.Pool) agents.PipelineLister {
-	store := deals.NewStore(pool, InstallationBaseCurrency())
+	store := deals.NewStore(pool, identity.BaseCurrencyOf)
 	return func(ctx context.Context) ([]agents.Pipeline, error) {
 		rows, err := store.ListPipelines(ctx)
 		if err != nil {

--- a/backend/internal/compose/pipelineseams.go
+++ b/backend/internal/compose/pipelineseams.go
@@ -30,7 +30,7 @@ import (
 // pipelineLister answers list_pipelines from the workspace's live pipeline
 // configuration.
 func pipelineLister(pool *pgxpool.Pool) agents.PipelineLister {
-	store := deals.NewStore(pool)
+	store := deals.NewStore(pool, InstallationBaseCurrency())
 	return func(ctx context.Context) ([]agents.Pipeline, error) {
 		rows, err := store.ListPipelines(ctx)
 		if err != nil {

--- a/backend/internal/compose/provider.go
+++ b/backend/internal/compose/provider.go
@@ -18,6 +18,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/modules/activities"
 	"github.com/gradionhq/margince/backend/internal/modules/customfields"
 	"github.com/gradionhq/margince/backend/internal/modules/deals"
+	"github.com/gradionhq/margince/backend/internal/modules/identity"
 	"github.com/gradionhq/margince/backend/internal/modules/people"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
@@ -39,7 +40,7 @@ func NewProvider(pool *pgxpool.Pool) *Provider {
 		// The fieldcatalog seam mirrors the HTTP wiring (server.go): the
 		// MCP surface's record verbs carry cf_* values too.
 		people:     people.NewProvider(pool).WithFieldCatalog(customfields.NewService(pool, nil)),
-		deals:      deals.NewProvider(pool, InstallationBaseCurrency()).WithFieldCatalog(customfields.NewService(pool, nil)),
+		deals:      deals.NewProvider(pool, identity.BaseCurrencyOf).WithFieldCatalog(customfields.NewService(pool, nil)),
 		activities: activities.NewProvider(pool),
 		reports:    newReportEngine(pool),
 	}

--- a/backend/internal/compose/provider.go
+++ b/backend/internal/compose/provider.go
@@ -39,7 +39,7 @@ func NewProvider(pool *pgxpool.Pool) *Provider {
 		// The fieldcatalog seam mirrors the HTTP wiring (server.go): the
 		// MCP surface's record verbs carry cf_* values too.
 		people:     people.NewProvider(pool).WithFieldCatalog(customfields.NewService(pool, nil)),
-		deals:      deals.NewProvider(pool).WithFieldCatalog(customfields.NewService(pool, nil)),
+		deals:      deals.NewProvider(pool, InstallationBaseCurrency()).WithFieldCatalog(customfields.NewService(pool, nil)),
 		activities: activities.NewProvider(pool),
 		reports:    newReportEngine(pool),
 	}

--- a/backend/internal/compose/rateproposals_integration_test.go
+++ b/backend/internal/compose/rateproposals_integration_test.go
@@ -24,13 +24,14 @@ import (
 	"github.com/gradionhq/margince/backend/internal/modules/ai"
 	"github.com/gradionhq/margince/backend/internal/modules/approvals"
 	"github.com/gradionhq/margince/backend/internal/modules/deals"
+	"github.com/gradionhq/margince/backend/internal/modules/identity"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
 func rateSvc(e *integration.Env) *approvals.Service {
 	svc := approvals.NewService(e.Pool)
-	svc.WithEffect(fxRateProposalKind, fxRateAcceptEffect(svc, deals.NewStore(e.Pool, InstallationBaseCurrency())))
+	svc.WithEffect(fxRateProposalKind, fxRateAcceptEffect(svc, deals.NewStore(e.Pool, identity.BaseCurrencyOf)))
 	svc.WithEffect(aiModelRateProposalKind, aiModelRateAcceptEffect(svc, ai.NewRateStore(e.Pool)))
 	return svc
 }
@@ -130,7 +131,7 @@ func TestFxRateProposalApplyRefusesWhenPriorMoved(t *testing.T) {
 	e := integration.Setup(t)
 	ctx := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AdminPerms)
 	svc := rateSvc(e)
-	store := deals.NewStore(e.Pool, InstallationBaseCurrency())
+	store := deals.NewStore(e.Pool, identity.BaseCurrencyOf)
 
 	if _, err := store.SetFxRate(ctx, deals.SetFxRateInput{FromCurrency: "GBP", Rate: "1.0"}); err != nil {
 		t.Fatalf("seed: %v", err)
@@ -165,7 +166,7 @@ func TestFxRateProposalApplyRefusesWhenPriorAppeared(t *testing.T) {
 
 	id := stageProposal(ctx, t, svc, fxRateProposalKind, fxRateTargetType, e.WS,
 		map[string]string{"from_currency": "NOK", "rate": "0.09"}, "NOK")
-	if _, err := deals.NewStore(e.Pool, InstallationBaseCurrency()).SetFxRate(ctx, deals.SetFxRateInput{FromCurrency: "NOK", Rate: "0.088"}); err != nil {
+	if _, err := deals.NewStore(e.Pool, identity.BaseCurrencyOf).SetFxRate(ctx, deals.SetFxRateInput{FromCurrency: "NOK", Rate: "0.088"}); err != nil {
 		t.Fatalf("seed: %v", err)
 	}
 	if _, err := svc.Decide(ctx, id, true, nil); !errors.Is(err, apperrors.ErrVersionSkew) {
@@ -180,7 +181,7 @@ func TestFxRateProposalApplyMatchingPriorApplies(t *testing.T) {
 	ctx := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AdminPerms)
 	svc := rateSvc(e)
 
-	if _, err := deals.NewStore(e.Pool, InstallationBaseCurrency()).SetFxRate(ctx, deals.SetFxRateInput{FromCurrency: "DKK", Rate: "0.134"}); err != nil {
+	if _, err := deals.NewStore(e.Pool, identity.BaseCurrencyOf).SetFxRate(ctx, deals.SetFxRateInput{FromCurrency: "DKK", Rate: "0.134"}); err != nil {
 		t.Fatalf("seed: %v", err)
 	}
 	id := stageProposal(ctx, t, svc, fxRateProposalKind, fxRateTargetType, e.WS,
@@ -290,7 +291,7 @@ func TestModelRateProposalApplyMatchingPriorApplies(t *testing.T) {
 func TestFxRateProposalApplyRefusesAcrossMidnight(t *testing.T) {
 	e := integration.Setup(t)
 	ctx := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AdminPerms)
-	seed := deals.NewStore(e.Pool, InstallationBaseCurrency())
+	seed := deals.NewStore(e.Pool, identity.BaseCurrencyOf)
 	tomorrow := time.Now().UTC().Add(24 * time.Hour)
 	seedFx(ctx, t, seed, "SEK", "1.0", time.Time{})
 	seedFx(ctx, t, seed, "SEK", "9.9", tomorrow)
@@ -298,7 +299,7 @@ func TestFxRateProposalApplyRefusesAcrossMidnight(t *testing.T) {
 	// The effect store's clock crosses midnight right after the precondition
 	// read: first sample = today, every later sample = the next day.
 	calls := 0
-	crossing := deals.NewStore(e.Pool, InstallationBaseCurrency()).WithClock(func() time.Time {
+	crossing := deals.NewStore(e.Pool, identity.BaseCurrencyOf).WithClock(func() time.Time {
 		calls++
 		if calls == 1 {
 			return time.Now().UTC()

--- a/backend/internal/compose/rateproposals_integration_test.go
+++ b/backend/internal/compose/rateproposals_integration_test.go
@@ -30,7 +30,7 @@ import (
 
 func rateSvc(e *integration.Env) *approvals.Service {
 	svc := approvals.NewService(e.Pool)
-	svc.WithEffect(fxRateProposalKind, fxRateAcceptEffect(svc, deals.NewStore(e.Pool)))
+	svc.WithEffect(fxRateProposalKind, fxRateAcceptEffect(svc, deals.NewStore(e.Pool, InstallationBaseCurrency())))
 	svc.WithEffect(aiModelRateProposalKind, aiModelRateAcceptEffect(svc, ai.NewRateStore(e.Pool)))
 	return svc
 }
@@ -130,7 +130,7 @@ func TestFxRateProposalApplyRefusesWhenPriorMoved(t *testing.T) {
 	e := integration.Setup(t)
 	ctx := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AdminPerms)
 	svc := rateSvc(e)
-	store := deals.NewStore(e.Pool)
+	store := deals.NewStore(e.Pool, InstallationBaseCurrency())
 
 	if _, err := store.SetFxRate(ctx, deals.SetFxRateInput{FromCurrency: "GBP", Rate: "1.0"}); err != nil {
 		t.Fatalf("seed: %v", err)
@@ -165,7 +165,7 @@ func TestFxRateProposalApplyRefusesWhenPriorAppeared(t *testing.T) {
 
 	id := stageProposal(ctx, t, svc, fxRateProposalKind, fxRateTargetType, e.WS,
 		map[string]string{"from_currency": "NOK", "rate": "0.09"}, "NOK")
-	if _, err := deals.NewStore(e.Pool).SetFxRate(ctx, deals.SetFxRateInput{FromCurrency: "NOK", Rate: "0.088"}); err != nil {
+	if _, err := deals.NewStore(e.Pool, InstallationBaseCurrency()).SetFxRate(ctx, deals.SetFxRateInput{FromCurrency: "NOK", Rate: "0.088"}); err != nil {
 		t.Fatalf("seed: %v", err)
 	}
 	if _, err := svc.Decide(ctx, id, true, nil); !errors.Is(err, apperrors.ErrVersionSkew) {
@@ -180,7 +180,7 @@ func TestFxRateProposalApplyMatchingPriorApplies(t *testing.T) {
 	ctx := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AdminPerms)
 	svc := rateSvc(e)
 
-	if _, err := deals.NewStore(e.Pool).SetFxRate(ctx, deals.SetFxRateInput{FromCurrency: "DKK", Rate: "0.134"}); err != nil {
+	if _, err := deals.NewStore(e.Pool, InstallationBaseCurrency()).SetFxRate(ctx, deals.SetFxRateInput{FromCurrency: "DKK", Rate: "0.134"}); err != nil {
 		t.Fatalf("seed: %v", err)
 	}
 	id := stageProposal(ctx, t, svc, fxRateProposalKind, fxRateTargetType, e.WS,
@@ -290,7 +290,7 @@ func TestModelRateProposalApplyMatchingPriorApplies(t *testing.T) {
 func TestFxRateProposalApplyRefusesAcrossMidnight(t *testing.T) {
 	e := integration.Setup(t)
 	ctx := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AdminPerms)
-	seed := deals.NewStore(e.Pool)
+	seed := deals.NewStore(e.Pool, InstallationBaseCurrency())
 	tomorrow := time.Now().UTC().Add(24 * time.Hour)
 	seedFx(ctx, t, seed, "SEK", "1.0", time.Time{})
 	seedFx(ctx, t, seed, "SEK", "9.9", tomorrow)
@@ -298,7 +298,7 @@ func TestFxRateProposalApplyRefusesAcrossMidnight(t *testing.T) {
 	// The effect store's clock crosses midnight right after the precondition
 	// read: first sample = today, every later sample = the next day.
 	calls := 0
-	crossing := deals.NewStore(e.Pool).WithClock(func() time.Time {
+	crossing := deals.NewStore(e.Pool, InstallationBaseCurrency()).WithClock(func() time.Time {
 		calls++
 		if calls == 1 {
 			return time.Now().UTC()

--- a/backend/internal/compose/reconcile_integration_test.go
+++ b/backend/internal/compose/reconcile_integration_test.go
@@ -320,7 +320,7 @@ func TestADealEditDoesNotCancelAWaitingFollowUp(t *testing.T) {
 	// Through the real writer, so the row's version moves the way any edit in
 	// the product moves it.
 	renamed := "Renamed while it waited"
-	if _, err := deals.NewStore(e.Pool).UpdateDeal(human, ids.From[ids.DealKind](deal),
+	if _, err := deals.NewStore(e.Pool, InstallationBaseCurrency()).UpdateDeal(human, ids.From[ids.DealKind](deal),
 		deals.UpdateDealInput{Name: &renamed}); err != nil {
 		t.Fatalf("editing the deal: %v", err)
 	}

--- a/backend/internal/compose/reconcile_integration_test.go
+++ b/backend/internal/compose/reconcile_integration_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/gradionhq/margince/backend/internal/modules/approvals"
 	"github.com/gradionhq/margince/backend/internal/modules/deals"
+	"github.com/gradionhq/margince/backend/internal/modules/identity"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
@@ -49,9 +50,10 @@ type reconcileEnv struct {
 var reconcilePerms = principal.Permissions{
 	RoleKeys: []string{"rep"},
 	Objects: map[string]principal.ObjectGrant{
-		"activity": {Create: true, Read: true},
-		"deal":     {Read: true, Update: true},
-		"pipeline": {Read: true},
+		"activity":              {Create: true, Read: true},
+		"deal":                  {Read: true, Update: true},
+		"pipeline":              {Read: true},
+		"installation_settings": {Read: true},
 	},
 	RowScope: principal.RowScopeTeam,
 }
@@ -320,7 +322,7 @@ func TestADealEditDoesNotCancelAWaitingFollowUp(t *testing.T) {
 	// Through the real writer, so the row's version moves the way any edit in
 	// the product moves it.
 	renamed := "Renamed while it waited"
-	if _, err := deals.NewStore(e.Pool, InstallationBaseCurrency()).UpdateDeal(human, ids.From[ids.DealKind](deal),
+	if _, err := deals.NewStore(e.Pool, identity.BaseCurrencyOf).UpdateDeal(human, ids.From[ids.DealKind](deal),
 		deals.UpdateDealInput{Name: &renamed}); err != nil {
 		t.Fatalf("editing the deal: %v", err)
 	}

--- a/backend/internal/compose/sendvoiceoutcome_integration_test.go
+++ b/backend/internal/compose/sendvoiceoutcome_integration_test.go
@@ -203,7 +203,7 @@ func (e *voiceSendEnv) draftedSend(ref string) activities.SendEmailInput {
 func composedSendServer(t *testing.T, e *voiceSendEnv, stager DeliveryMachinery) Server {
 	t.Helper()
 	srv := newServer(e.Pool, slog.New(slog.NewTextHandler(io.Discard, nil)),
-		identity.NewHandlers(identity.NewService(e.Pool)), deals.NewHandlers(e.Pool, InstallationBaseCurrency()))
+		identity.NewHandlers(identity.NewService(e.Pool)), deals.NewHandlers(e.Pool, identity.BaseCurrencyOf))
 	for _, opt := range []Option{WithPublicBaseURL(voiceSendBaseURL), WithDelivery(stager)} {
 		opt(&srv, e.Pool)
 	}

--- a/backend/internal/compose/sendvoiceoutcome_integration_test.go
+++ b/backend/internal/compose/sendvoiceoutcome_integration_test.go
@@ -203,7 +203,7 @@ func (e *voiceSendEnv) draftedSend(ref string) activities.SendEmailInput {
 func composedSendServer(t *testing.T, e *voiceSendEnv, stager DeliveryMachinery) Server {
 	t.Helper()
 	srv := newServer(e.Pool, slog.New(slog.NewTextHandler(io.Discard, nil)),
-		identity.NewHandlers(identity.NewService(e.Pool)), deals.NewHandlers(e.Pool))
+		identity.NewHandlers(identity.NewService(e.Pool)), deals.NewHandlers(e.Pool, InstallationBaseCurrency()))
 	for _, opt := range []Option{WithPublicBaseURL(voiceSendBaseURL), WithDelivery(stager)} {
 		opt(&srv, e.Pool)
 	}

--- a/backend/internal/compose/server.go
+++ b/backend/internal/compose/server.go
@@ -312,7 +312,7 @@ var _ crmcontracts.ServerInterface = Server{}
 func New(pool *pgxpool.Pool, log *slog.Logger, opts ...Option) http.Handler {
 	// The fieldcatalog seam for deals (newPeopleHandlers carries the full
 	// note): active cf_* deal columns ride deal payloads on both surfaces.
-	dealsH := deals.NewHandlers(pool).WithFieldCatalog(customfields.NewService(pool, nil))
+	dealsH := deals.NewHandlers(pool, InstallationBaseCurrency()).WithFieldCatalog(customfields.NewService(pool, nil))
 	// Bootstrap happens at boot from deployment configuration
 	// (EnsureInstallation, A107/ADR-0061) — the HTTP surface only ever
 	// serves the already-bound singleton organization.
@@ -388,7 +388,7 @@ func newServer(pool *pgxpool.Pool, log *slog.Logger, authH authHandlers, dealsH 
 		// the environment). Without it those paths answer an honest 503.
 		webhooksHandlers: newWebhookHandlers(pool, nil, log),
 		log:              log,
-		dealsStore:       deals.NewStore(pool),
+		dealsStore:       deals.NewStore(pool, InstallationBaseCurrency()),
 		// Constructed unconditionally: WithKeyvault rebuilds
 		// overlayHandlers over this SAME instance rather than minting a
 		// second one, and contractAPI's Dispatcher spends force-fresh

--- a/backend/internal/compose/server.go
+++ b/backend/internal/compose/server.go
@@ -312,7 +312,7 @@ var _ crmcontracts.ServerInterface = Server{}
 func New(pool *pgxpool.Pool, log *slog.Logger, opts ...Option) http.Handler {
 	// The fieldcatalog seam for deals (newPeopleHandlers carries the full
 	// note): active cf_* deal columns ride deal payloads on both surfaces.
-	dealsH := deals.NewHandlers(pool, InstallationBaseCurrency()).WithFieldCatalog(customfields.NewService(pool, nil))
+	dealsH := deals.NewHandlers(pool, identity.BaseCurrencyOf).WithFieldCatalog(customfields.NewService(pool, nil))
 	// Bootstrap happens at boot from deployment configuration
 	// (EnsureInstallation, A107/ADR-0061) — the HTTP surface only ever
 	// serves the already-bound singleton organization.
@@ -360,7 +360,7 @@ func newServer(pool *pgxpool.Pool, log *slog.Logger, authH authHandlers, dealsH 
 		// The warm room ranks its contact edges by the §4 relationship
 		// strength owned by people; injected through the adapter below so
 		// signals never imports its sibling.
-		financeHandlers:    finance.NewHandlers(pool, InstallationBaseCurrency()),
+		financeHandlers:    finance.NewHandlers(pool, identity.BaseCurrencyOf),
 		signalsHandlers:    signals.NewHandlers(pool, signalStrength{people: people.NewStore(pool)}),
 		privacyHandlers:    privacy.NewHandlers(pool),
 		automationHandlers: automation.NewHandlers(pool),
@@ -376,7 +376,7 @@ func newServer(pool *pgxpool.Pool, log *slog.Logger, authH authHandlers, dealsH 
 		// here means Create/SetOptions stay their generated 501 until the
 		// api role's WithSchemaPool rebuilds this over the real pool.
 		customfieldsHandlers: customfields.NewHandlers(pool, nil),
-		quotasHandlers:       quotas.NewHandlers(pool, InstallationBaseCurrency()),
+		quotasHandlers:       quotas.NewHandlers(pool, identity.BaseCurrencyOf),
 		// The accept-write's default engine rides the honest-empty NoOp
 		// extractor (nothing is ever grounded, so nothing is acceptable);
 		// WithExtractor rebuilds it together with the activities read so
@@ -388,7 +388,7 @@ func newServer(pool *pgxpool.Pool, log *slog.Logger, authH authHandlers, dealsH 
 		// the environment). Without it those paths answer an honest 503.
 		webhooksHandlers: newWebhookHandlers(pool, nil, log),
 		log:              log,
-		dealsStore:       deals.NewStore(pool, InstallationBaseCurrency()),
+		dealsStore:       deals.NewStore(pool, identity.BaseCurrencyOf),
 		// Constructed unconditionally: WithKeyvault rebuilds
 		// overlayHandlers over this SAME instance rather than minting a
 		// second one, and contractAPI's Dispatcher spends force-fresh

--- a/backend/internal/compose/settingswiring.go
+++ b/backend/internal/compose/settingswiring.go
@@ -147,7 +147,5 @@ func yamlPaths(t reflect.Type, prefix string) map[string]bool {
 // registered default, because these callers are converting and freezing money
 // against the answer.
 func InstallationBaseCurrency() func(context.Context, pgx.Tx) (string, error) {
-	return func(ctx context.Context, tx pgx.Tx) (string, error) {
-		return settings.RequireTx(ctx, tx, identity.BaseCurrency)
-	}
+	return identity.BaseCurrencyOf
 }

--- a/backend/internal/compose/settingswiring.go
+++ b/backend/internal/compose/settingswiring.go
@@ -9,12 +9,10 @@ package compose
 // owns the mechanism and knows no domain; the modules own the meaning.
 
 import (
-	"context"
 	"reflect"
 	"strings"
 	"sync"
 
-	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/gradionhq/margince/backend/internal/modules/capture"
@@ -133,19 +131,4 @@ func yamlPaths(t reflect.Type, prefix string) map[string]bool {
 		}
 	}
 	return out
-}
-
-// InstallationBaseCurrency is the one real BaseCurrencyFunc: the currency the
-// installation reports in, resolved from the settings row inside the caller's
-// own transaction.
-//
-// It lives in compose because it is a cross-module edge — the modules that
-// convert money (quotas, finance) may not import the module that owns the
-// setting (identity), so the entry is named HERE, once, and injected there.
-//
-// RequireTx rather than Get: an absent row must refuse rather than read as the
-// registered default, because these callers are converting and freezing money
-// against the answer.
-func InstallationBaseCurrency() func(context.Context, pgx.Tx) (string, error) {
-	return identity.BaseCurrencyOf
 }

--- a/backend/internal/compose/slipping.go
+++ b/backend/internal/compose/slipping.go
@@ -21,6 +21,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/modules/activities"
 	"github.com/gradionhq/margince/backend/internal/modules/agents"
 	"github.com/gradionhq/margince/backend/internal/modules/deals"
+	"github.com/gradionhq/margince/backend/internal/modules/identity"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
 )
@@ -33,7 +34,7 @@ const slippingScanLimit = 50
 // slippingLister serves the formulas-§8 candidate set: stalled open
 // deals plus open deals whose expected close date is already past.
 func slippingLister(pool *pgxpool.Pool) agents.SlippingLister {
-	store := deals.NewStore(pool, InstallationBaseCurrency())
+	store := deals.NewStore(pool, identity.BaseCurrencyOf)
 	return func(ctx context.Context) ([]agents.SlippingDeal, error) {
 		limit := slippingScanLimit
 		stalledOnly := true

--- a/backend/internal/compose/slipping.go
+++ b/backend/internal/compose/slipping.go
@@ -33,7 +33,7 @@ const slippingScanLimit = 50
 // slippingLister serves the formulas-§8 candidate set: stalled open
 // deals plus open deals whose expected close date is already past.
 func slippingLister(pool *pgxpool.Pool) agents.SlippingLister {
-	store := deals.NewStore(pool)
+	store := deals.NewStore(pool, InstallationBaseCurrency())
 	return func(ctx context.Context) ([]agents.SlippingDeal, error) {
 		limit := slippingScanLimit
 		stalledOnly := true

--- a/backend/internal/modules/deals/basecurrencyfreeze.go
+++ b/backend/internal/modules/deals/basecurrencyfreeze.go
@@ -100,10 +100,16 @@ func frozenRateCount(ctx context.Context, tx pgx.Tx) (int, error) {
 // ratesPricedAgainstBase counts the sheet rows converting into the base the
 // workspace currently holds, and returns that base so the reason can name it.
 //
-// It reads workspace.base_currency rather than the setting row: this runs
-// inside the settings write's own transaction, BEFORE the new value is stored,
-// so the mirror column still holds the base being replaced — which is exactly
-// the one the sheet was priced against.
+// It reads workspace.base_currency rather than the setting row, and NOT
+// because the setting row is unwritten at this point — it holds the outgoing
+// value too, since the freeze probe runs before the update. The reason is the
+// FIRST write: on an installation that has never stored the setting there is
+// no row to read, and the refusing read (settings.RequireTx) would fail the
+// probe rather than answer "nothing is priced yet". The column always has a
+// value, so it can answer for the base being replaced in both cases.
+//
+// This is why the probe is not part of the sweep that moved the other readers
+// (issue #521): it needs the reading that tolerates an unset setting.
 func ratesPricedAgainstBase(ctx context.Context, tx pgx.Tx) (int, string, error) {
 	var base string
 	var priced int

--- a/backend/internal/modules/deals/deal.go
+++ b/backend/internal/modules/deals/deal.go
@@ -281,7 +281,9 @@ func dealUpdatePatch(ctx context.Context, tx pgx.Tx, current crmcontracts.Deal, 
 // — a deal closed amountless has no frozen rate at all, so adding an
 // amount later would trip deal_closed_fx. Same-day rate lookup as at
 // close, so roll-ups stay reproducible.
-func applyMoneyInvariants(ctx context.Context, tx pgx.Tx, current crmcontracts.Deal, in UpdateDealInput, p *storekit.Patch) error {
+func applyMoneyInvariants(ctx context.Context, tx pgx.Tx, baseCurrency BaseCurrencyFunc,
+	current crmcontracts.Deal, in UpdateDealInput, p *storekit.Patch,
+) error {
 	resultingAmount := current.AmountMinor
 	if in.AmountMinor != nil {
 		resultingAmount = in.AmountMinor
@@ -304,7 +306,7 @@ func applyMoneyInvariants(ctx context.Context, tx pgx.Tx, current crmcontracts.D
 	if string(current.Status) != "open" && resultingAmount != nil &&
 		(in.AmountMinor != nil || in.Currency != nil) {
 		// deal_closed_at guarantees ClosedAt on a non-open row.
-		rate, rateDate, err := freezeFx(ctx, tx, *resultingCurrency, *current.ClosedAt)
+		rate, rateDate, err := freezeFx(ctx, tx, baseCurrency, *resultingCurrency, *current.ClosedAt)
 		if err != nil {
 			return fmt.Errorf("re-freeze fx for closed deal: %w", err)
 		}

--- a/backend/internal/modules/deals/deal.go
+++ b/backend/internal/modules/deals/deal.go
@@ -281,7 +281,7 @@ func dealUpdatePatch(ctx context.Context, tx pgx.Tx, current crmcontracts.Deal, 
 // — a deal closed amountless has no frozen rate at all, so adding an
 // amount later would trip deal_closed_fx. Same-day rate lookup as at
 // close, so roll-ups stay reproducible.
-func applyMoneyInvariants(ctx context.Context, tx pgx.Tx, baseCurrency BaseCurrencyFunc,
+func (s *Store) applyMoneyInvariants(ctx context.Context, tx pgx.Tx,
 	current crmcontracts.Deal, in UpdateDealInput, p *storekit.Patch,
 ) error {
 	resultingAmount := current.AmountMinor
@@ -306,7 +306,11 @@ func applyMoneyInvariants(ctx context.Context, tx pgx.Tx, baseCurrency BaseCurre
 	if string(current.Status) != "open" && resultingAmount != nil &&
 		(in.AmountMinor != nil || in.Currency != nil) {
 		// deal_closed_at guarantees ClosedAt on a non-open row.
-		rate, rateDate, err := freezeFx(ctx, tx, baseCurrency, *resultingCurrency, *current.ClosedAt)
+		base, err := s.baseCurrency(ctx, tx)
+		if err != nil {
+			return err
+		}
+		rate, rateDate, err := s.freezeFx(ctx, tx, base, *resultingCurrency, *current.ClosedAt)
 		if err != nil {
 			return fmt.Errorf("re-freeze fx for closed deal: %w", err)
 		}

--- a/backend/internal/modules/deals/deal_advance.go
+++ b/backend/internal/modules/deals/deal_advance.go
@@ -99,7 +99,7 @@ func (s *Store) AdvanceDeal(ctx context.Context, id ids.DealID, in AdvanceDealIn
 			return err
 		}
 
-		p, status, err := stageTransitionPatch(ctx, tx, s.baseCurrency, current, in, semantic)
+		p, status, err := s.stageTransitionPatch(ctx, tx, current, in, semantic)
 		if err != nil {
 			return err
 		}
@@ -179,7 +179,27 @@ func resolveAdvanceTarget(ctx context.Context, tx pgx.Tx, toStage ids.StageID, c
 // and the resulting status: terminal fields (closed_at, lost_reason,
 // frozen FX) are set when the target semantic closes the deal and
 // cleared when a won/lost deal reopens.
-func stageTransitionPatch(ctx context.Context, tx pgx.Tx, baseCurrency BaseCurrencyFunc,
+// freezeClosingRate resolves the installation's base currency and stamps the
+// frozen conversion onto the patch. Split out of stageTransitionPatch so the
+// resolve-then-freeze pair reads as one step there rather than as four more
+// branches in an already-branchy transition.
+func (s *Store) freezeClosingRate(ctx context.Context, tx pgx.Tx,
+	currency string, p *storekit.Patch,
+) error {
+	base, err := s.baseCurrency(ctx, tx)
+	if err != nil {
+		return err
+	}
+	rate, rateDate, err := s.freezeFx(ctx, tx, base, currency, time.Now().UTC())
+	if err != nil {
+		return fmt.Errorf("freeze fx at close: %w", err)
+	}
+	p.Set("fx_rate_to_base", nil, rate)
+	p.Set("fx_rate_date", nil, rateDate)
+	return nil
+}
+
+func (s *Store) stageTransitionPatch(ctx context.Context, tx pgx.Tx,
 	current crmcontracts.Deal, in AdvanceDealInput, semantic string,
 ) (*storekit.Patch, string, error) {
 	status := "open"
@@ -212,12 +232,9 @@ func stageTransitionPatch(ctx context.Context, tx pgx.Tx, baseCurrency BaseCurre
 	// Closing with an amount freezes today's FX rate so base-currency
 	// roll-ups stay reproducible (deal_closed_fx).
 	if DealStatus(status) != DealOpen && current.AmountMinor != nil && current.Currency != nil {
-		rate, rateDate, err := freezeFx(ctx, tx, baseCurrency, *current.Currency, time.Now().UTC())
-		if err != nil {
-			return nil, "", fmt.Errorf("freeze fx at close: %w", err)
+		if err := s.freezeClosingRate(ctx, tx, *current.Currency, p); err != nil {
+			return nil, "", err
 		}
-		p.Set("fx_rate_to_base", nil, rate)
-		p.Set("fx_rate_date", nil, rateDate)
 	}
 	// Reopening a won/lost deal must clear every terminal field —
 	// the DB CHECKs are one-directional, so a stale closed_at or
@@ -252,17 +269,14 @@ func (e *MissingFxRateError) MessageFault() (code, message string) {
 // deal: the latest fx_rate on or before asOf. Used at close (asOf = now)
 // and when a closed deal is re-priced (asOf = its close date), so the
 // frozen rate always reflects the deal's close, never the edit.
-func freezeFx(ctx context.Context, tx pgx.Tx, baseCurrency BaseCurrencyFunc,
-	currency string, asOf time.Time,
+func (s *Store) freezeFx(ctx context.Context, tx pgx.Tx,
+	base, currency string, asOf time.Time,
 ) (string, time.Time, error) {
 	asOfDate := asOf.UTC().Truncate(24 * time.Hour)
-	base, err := baseCurrency(ctx, tx)
-	if err != nil {
-		return "", time.Time{}, err
-	}
 	if currency == base {
 		return "1", asOfDate, nil
 	}
+	var err error
 	var rate string
 	err = tx.QueryRow(ctx,
 		`SELECT rate::text FROM fx_rate

--- a/backend/internal/modules/deals/deal_advance.go
+++ b/backend/internal/modules/deals/deal_advance.go
@@ -99,7 +99,7 @@ func (s *Store) AdvanceDeal(ctx context.Context, id ids.DealID, in AdvanceDealIn
 			return err
 		}
 
-		p, status, err := stageTransitionPatch(ctx, tx, current, in, semantic)
+		p, status, err := stageTransitionPatch(ctx, tx, s.baseCurrency, current, in, semantic)
 		if err != nil {
 			return err
 		}
@@ -179,7 +179,9 @@ func resolveAdvanceTarget(ctx context.Context, tx pgx.Tx, toStage ids.StageID, c
 // and the resulting status: terminal fields (closed_at, lost_reason,
 // frozen FX) are set when the target semantic closes the deal and
 // cleared when a won/lost deal reopens.
-func stageTransitionPatch(ctx context.Context, tx pgx.Tx, current crmcontracts.Deal, in AdvanceDealInput, semantic string) (*storekit.Patch, string, error) {
+func stageTransitionPatch(ctx context.Context, tx pgx.Tx, baseCurrency BaseCurrencyFunc,
+	current crmcontracts.Deal, in AdvanceDealInput, semantic string,
+) (*storekit.Patch, string, error) {
 	status := "open"
 	var closedAt *time.Time
 	switch semantic {
@@ -210,7 +212,7 @@ func stageTransitionPatch(ctx context.Context, tx pgx.Tx, current crmcontracts.D
 	// Closing with an amount freezes today's FX rate so base-currency
 	// roll-ups stay reproducible (deal_closed_fx).
 	if DealStatus(status) != DealOpen && current.AmountMinor != nil && current.Currency != nil {
-		rate, rateDate, err := freezeFx(ctx, tx, *current.Currency, time.Now().UTC())
+		rate, rateDate, err := freezeFx(ctx, tx, baseCurrency, *current.Currency, time.Now().UTC())
 		if err != nil {
 			return nil, "", fmt.Errorf("freeze fx at close: %w", err)
 		}
@@ -250,18 +252,19 @@ func (e *MissingFxRateError) MessageFault() (code, message string) {
 // deal: the latest fx_rate on or before asOf. Used at close (asOf = now)
 // and when a closed deal is re-priced (asOf = its close date), so the
 // frozen rate always reflects the deal's close, never the edit.
-func freezeFx(ctx context.Context, tx pgx.Tx, currency string, asOf time.Time) (string, time.Time, error) {
+func freezeFx(ctx context.Context, tx pgx.Tx, baseCurrency BaseCurrencyFunc,
+	currency string, asOf time.Time,
+) (string, time.Time, error) {
 	asOfDate := asOf.UTC().Truncate(24 * time.Hour)
-	var base string
-	if err := tx.QueryRow(ctx,
-		`SELECT base_currency FROM workspace WHERE id = $1`, storekit.MustWorkspace(ctx)).Scan(&base); err != nil {
+	base, err := baseCurrency(ctx, tx)
+	if err != nil {
 		return "", time.Time{}, err
 	}
 	if currency == base {
 		return "1", asOfDate, nil
 	}
 	var rate string
-	err := tx.QueryRow(ctx,
+	err = tx.QueryRow(ctx,
 		`SELECT rate::text FROM fx_rate
 		 WHERE from_currency = $1 AND to_currency = $2 AND rate_date <= $3
 		 ORDER BY rate_date DESC LIMIT 1`,

--- a/backend/internal/modules/deals/deal_update.go
+++ b/backend/internal/modules/deals/deal_update.go
@@ -58,7 +58,7 @@ func (s *Store) UpdateDeal(ctx context.Context, id ids.DealID, in UpdateDealInpu
 	var out crmcontracts.Deal
 	err = s.tx(ctx, func(tx pgx.Tx) error {
 		var err error
-		out, err = updateDealInTx(ctx, tx, s.baseCurrency, id, in, active)
+		out, err = s.updateDealInTx(ctx, tx, id, in, active)
 		return err
 	})
 	return out, err
@@ -88,12 +88,12 @@ func (s *Store) UpdateDealTx(ctx context.Context, tx pgx.Tx, id ids.DealID, in U
 	if err != nil {
 		return crmcontracts.Deal{}, err
 	}
-	return updateDealInTx(ctx, tx, s.baseCurrency, id, in, active)
+	return s.updateDealInTx(ctx, tx, id, in, active)
 }
 
 // updateDealInTx is UpdateDeal's transactional body, shared by the
 // store-opened (UpdateDeal) and caller-opened (UpdateDealTx) entry points.
-func updateDealInTx(ctx context.Context, tx pgx.Tx, baseCurrency BaseCurrencyFunc,
+func (s *Store) updateDealInTx(ctx context.Context, tx pgx.Tx,
 	id ids.DealID, in UpdateDealInput, active []fieldcatalog.Column,
 ) (crmcontracts.Deal, error) {
 	if err := auth.EnsureVisible(ctx, tx, "deal", id.UUID); err != nil {
@@ -115,7 +115,7 @@ func updateDealInTx(ctx context.Context, tx pgx.Tx, baseCurrency BaseCurrencyFun
 		return current, nil
 	}
 
-	if err := applyMoneyInvariants(ctx, tx, baseCurrency, current, in, p); err != nil {
+	if err := s.applyMoneyInvariants(ctx, tx, current, in, p); err != nil {
 		return crmcontracts.Deal{}, err
 	}
 

--- a/backend/internal/modules/deals/deal_update.go
+++ b/backend/internal/modules/deals/deal_update.go
@@ -58,7 +58,7 @@ func (s *Store) UpdateDeal(ctx context.Context, id ids.DealID, in UpdateDealInpu
 	var out crmcontracts.Deal
 	err = s.tx(ctx, func(tx pgx.Tx) error {
 		var err error
-		out, err = updateDealInTx(ctx, tx, id, in, active)
+		out, err = updateDealInTx(ctx, tx, s.baseCurrency, id, in, active)
 		return err
 	})
 	return out, err
@@ -88,12 +88,14 @@ func (s *Store) UpdateDealTx(ctx context.Context, tx pgx.Tx, id ids.DealID, in U
 	if err != nil {
 		return crmcontracts.Deal{}, err
 	}
-	return updateDealInTx(ctx, tx, id, in, active)
+	return updateDealInTx(ctx, tx, s.baseCurrency, id, in, active)
 }
 
 // updateDealInTx is UpdateDeal's transactional body, shared by the
 // store-opened (UpdateDeal) and caller-opened (UpdateDealTx) entry points.
-func updateDealInTx(ctx context.Context, tx pgx.Tx, id ids.DealID, in UpdateDealInput, active []fieldcatalog.Column) (crmcontracts.Deal, error) {
+func updateDealInTx(ctx context.Context, tx pgx.Tx, baseCurrency BaseCurrencyFunc,
+	id ids.DealID, in UpdateDealInput, active []fieldcatalog.Column,
+) (crmcontracts.Deal, error) {
 	if err := auth.EnsureVisible(ctx, tx, "deal", id.UUID); err != nil {
 		return crmcontracts.Deal{}, err
 	}
@@ -113,7 +115,7 @@ func updateDealInTx(ctx context.Context, tx pgx.Tx, id ids.DealID, in UpdateDeal
 		return current, nil
 	}
 
-	if err := applyMoneyInvariants(ctx, tx, current, in, p); err != nil {
+	if err := applyMoneyInvariants(ctx, tx, baseCurrency, current, in, p); err != nil {
 		return crmcontracts.Deal{}, err
 	}
 

--- a/backend/internal/modules/deals/fxrate_handlers.go
+++ b/backend/internal/modules/deals/fxrate_handlers.go
@@ -46,7 +46,7 @@ func (h Handlers) ListFxRates(w http.ResponseWriter, r *http.Request, params crm
 	// The base currency comes from the workspace, not from row zero: a
 	// workspace that has entered no rates still has a base, and inferring it
 	// from the first row leaves that case with nothing to show (AAD-AC-N-1).
-	base, err := h.store.WorkspaceBaseCurrency(r.Context())
+	base, err := h.store.BaseCurrency(r.Context())
 	if err != nil {
 		writeStoreErr(w, r, err)
 		return

--- a/backend/internal/modules/deals/fxrate_store.go
+++ b/backend/internal/modules/deals/fxrate_store.go
@@ -302,12 +302,12 @@ func (s *Store) ListEffectiveFxRates(ctx context.Context) ([]FxRateRow, error) {
 	}
 	var rows []FxRateRow
 	err := s.tx(ctx, func(tx pgx.Tx) error {
-		// Sample "today" inside the transaction: a wait for a pooled
-		// connection across UTC midnight must not list yesterday's cutoff.
 		base, err := s.baseCurrency(ctx, tx)
 		if err != nil {
 			return err
 		}
+		// Sample "today" inside the transaction: a wait for a pooled
+		// connection across UTC midnight must not list yesterday's cutoff.
 		r, err := tx.Query(ctx, `
 			SELECT DISTINCT ON (from_currency) from_currency, to_currency, rate::text, rate_date
 			FROM fx_rate
@@ -355,12 +355,12 @@ func (s *Store) EffectiveFxRateInTx(ctx context.Context, tx pgx.Tx, fromCurrency
 	return rate, asOf, true, nil
 }
 
-// WorkspaceBaseCurrency returns the workspace base currency — the ToCurrency
+// BaseCurrency returns the installation's reporting currency — the ToCurrency
 // every fx_rate row converts into. The FX refresh producer needs it to price
 // an empty sheet (which has no row to read the base off), so it carries the
 // same admin/ops read gate as the sheet itself; the base IS part of the
 // fx_rate read surface (every row's ToCurrency).
-func (s *Store) WorkspaceBaseCurrency(ctx context.Context) (string, error) {
+func (s *Store) BaseCurrency(ctx context.Context) (string, error) {
 	if err := auth.Require(ctx, "fx_rate", principal.ActionRead); err != nil {
 		return "", err
 	}

--- a/backend/internal/modules/deals/fxrate_store.go
+++ b/backend/internal/modules/deals/fxrate_store.go
@@ -185,9 +185,8 @@ func (s *Store) writeFxRate(ctx context.Context, tx pgx.Tx, from string, in SetF
 		return FxRateRow{}, fxInvalid("effective_date", "fx_rate_past", "effective_date cannot be in the past")
 	}
 	rate := in.Rate
-	var base string
-	if err := tx.QueryRow(ctx, `SELECT base_currency FROM workspace WHERE id = $1`,
-		storekit.MustWorkspace(ctx)).Scan(&base); err != nil {
+	base, err := s.baseCurrency(ctx, tx)
+	if err != nil {
 		return FxRateRow{}, fmt.Errorf("resolve base currency: %w", err)
 	}
 	if from == base {
@@ -273,10 +272,14 @@ func (s *Store) ListLatestFxRates(ctx context.Context) ([]FxRateRow, error) {
 	}
 	var rows []FxRateRow
 	err := s.tx(ctx, func(tx pgx.Tx) error {
+		base, err := s.baseCurrency(ctx, tx)
+		if err != nil {
+			return err
+		}
 		r, err := tx.Query(ctx, `
 			SELECT DISTINCT ON (from_currency) from_currency, to_currency, rate::text, rate_date
-			FROM fx_rate WHERE to_currency = (SELECT base_currency FROM workspace WHERE id = $1)
-			ORDER BY from_currency, rate_date DESC`, storekit.MustWorkspace(ctx))
+			FROM fx_rate WHERE to_currency = $1
+			ORDER BY from_currency, rate_date DESC`, base)
 		if err != nil {
 			return fmt.Errorf("list fx_rate: %w", err)
 		}
@@ -301,12 +304,16 @@ func (s *Store) ListEffectiveFxRates(ctx context.Context) ([]FxRateRow, error) {
 	err := s.tx(ctx, func(tx pgx.Tx) error {
 		// Sample "today" inside the transaction: a wait for a pooled
 		// connection across UTC midnight must not list yesterday's cutoff.
+		base, err := s.baseCurrency(ctx, tx)
+		if err != nil {
+			return err
+		}
 		r, err := tx.Query(ctx, `
 			SELECT DISTINCT ON (from_currency) from_currency, to_currency, rate::text, rate_date
 			FROM fx_rate
 			 WHERE rate_date <= $1
-			   AND to_currency = (SELECT base_currency FROM workspace WHERE id = $2)
-			ORDER BY from_currency, rate_date DESC`, s.todayUTC(), storekit.MustWorkspace(ctx))
+			   AND to_currency = $2
+			ORDER BY from_currency, rate_date DESC`, s.todayUTC(), base)
 		if err != nil {
 			return fmt.Errorf("list effective fx_rate: %w", err)
 		}
@@ -359,8 +366,9 @@ func (s *Store) WorkspaceBaseCurrency(ctx context.Context) (string, error) {
 	}
 	var base string
 	err := s.tx(ctx, func(tx pgx.Tx) error {
-		return tx.QueryRow(ctx, `SELECT base_currency FROM workspace WHERE id = $1`,
-			storekit.MustWorkspace(ctx)).Scan(&base)
+		var err error
+		base, err = s.baseCurrency(ctx, tx)
+		return err
 	})
 	if err != nil {
 		return "", fmt.Errorf("resolve base currency: %w", err)

--- a/backend/internal/modules/deals/fxrate_store_test.go
+++ b/backend/internal/modules/deals/fxrate_store_test.go
@@ -6,6 +6,7 @@ package deals
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/jackc/pgx/v5"
@@ -102,4 +103,19 @@ func TestPrepareFxRateAdmitsEitherWriteGrant(t *testing.T) {
 // signal that the split moved, not a fixture that needs a currency.
 func unreachableBaseCurrency(context.Context, pgx.Tx) (string, error) {
 	return "", errors.New("prepareFxRate resolved the base currency; it is meant to run before any connection")
+}
+
+// A store built without the base-currency seam fails CLOSED at the first money
+// operation, rather than dereferencing a nil function inside an open
+// transaction. The field's doc calls the seam required; this is what makes
+// that a check rather than a claim.
+func TestAStoreWithNoBaseCurrencySeamRefusesRatherThanPanicking(t *testing.T) {
+	t.Parallel()
+	_, err := NewStore(nil, nil).baseCurrency(context.Background(), nil)
+	if err == nil {
+		t.Fatal("an un-injected seam resolved a base currency; it must refuse")
+	}
+	if !strings.Contains(err.Error(), "identity.BaseCurrencyOf") {
+		t.Errorf("the refusal should name what compose wires, got %q", err)
+	}
 }

--- a/backend/internal/modules/deals/fxrate_store_test.go
+++ b/backend/internal/modules/deals/fxrate_store_test.go
@@ -8,6 +8,8 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/jackc/pgx/v5"
+
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
@@ -71,7 +73,7 @@ func TestPrepareFxRateAdmitsEitherWriteGrant(t *testing.T) {
 	}
 	for name, g := range admitted {
 		t.Run("admits "+name, func(t *testing.T) {
-			if _, err := NewStore(nil).prepareFxRate(fxRateCtx(g), in); err != nil {
+			if _, err := NewStore(nil, unreachableBaseCurrency).prepareFxRate(fxRateCtx(g), in); err != nil {
 				t.Fatalf("prepareFxRate = %v, want admitted", err)
 			}
 		})
@@ -86,10 +88,18 @@ func TestPrepareFxRateAdmitsEitherWriteGrant(t *testing.T) {
 	}
 	for name, g := range refused {
 		t.Run("refuses "+name, func(t *testing.T) {
-			_, err := NewStore(nil).prepareFxRate(fxRateCtx(g), in)
+			_, err := NewStore(nil, unreachableBaseCurrency).prepareFxRate(fxRateCtx(g), in)
 			if !errors.Is(err, apperrors.ErrPermissionDenied) {
 				t.Fatalf("prepareFxRate = %v, want ErrPermissionDenied", err)
 			}
 		})
 	}
+}
+
+// unreachableBaseCurrency stands in for the installation-settings seam in the
+// tests above. prepareFxRate is the connection-free half of the fx write — it
+// admits or refuses before any value is resolved — so reaching this is a
+// signal that the split moved, not a fixture that needs a currency.
+func unreachableBaseCurrency(context.Context, pgx.Tx) (string, error) {
+	return "", errors.New("prepareFxRate resolved the base currency; it is meant to run before any connection")
 }

--- a/backend/internal/modules/deals/handlers.go
+++ b/backend/internal/modules/deals/handlers.go
@@ -35,8 +35,10 @@ type Handlers struct {
 	blob blobstore.Store
 }
 
-func NewHandlers(pool *pgxpool.Pool) Handlers {
-	return Handlers{store: NewStore(pool)}
+// NewHandlers wires the transport over the RLS-bound app pool and the
+// installation's base-currency seam.
+func NewHandlers(pool *pgxpool.Pool, baseCurrency BaseCurrencyFunc) Handlers {
+	return Handlers{store: NewStore(pool, baseCurrency)}
 }
 
 // WithFieldCatalog wires the workspace custom-field catalog into the

--- a/backend/internal/modules/deals/offer_lifecycle.go
+++ b/backend/internal/modules/deals/offer_lifecycle.go
@@ -67,11 +67,21 @@ func (s *Store) SendOffer(ctx context.Context, id ids.OfferID, ifVersion *int64)
 			return &OfferEmptyError{}
 		}
 
-		rate, rateDate, err := freezeFx(ctx, tx, s.baseCurrency, current.Currency, time.Now().UTC())
+		// Resolved ONCE for the whole send: the frozen rate and the issuer
+		// snapshot must name the same basis, and two reads of the setting in
+		// one transaction are two READ COMMITTED snapshots — a concurrent
+		// change between them would price the offer in one currency and
+		// record it in another. Nothing has frozen a rate at the first send,
+		// so the settings freeze probe does not close that window either.
+		base, err := s.baseCurrency(ctx, tx)
+		if err != nil {
+			return err
+		}
+		rate, rateDate, err := s.freezeFx(ctx, tx, base, current.Currency, time.Now().UTC())
 		if err != nil {
 			return fmt.Errorf("freeze fx at send: %w", err)
 		}
-		buyer, issuer, err := sendSnapshots(ctx, tx, s.baseCurrency, current)
+		buyer, issuer, err := s.sendSnapshots(ctx, tx, base, current)
 		if err != nil {
 			return err
 		}
@@ -120,7 +130,7 @@ func offerSentPayload(current crmcontracts.Offer, rate string) crmcontracts.Publ
 // sendSnapshots captures the buyer and issuer legal blocks at send time:
 // the sent document stays truthful even when the org or workspace is
 // later renamed.
-func sendSnapshots(ctx context.Context, tx pgx.Tx, baseCurrencyOf BaseCurrencyFunc,
+func (s *Store) sendSnapshots(ctx context.Context, tx pgx.Tx, baseCurrency string,
 	offer crmcontracts.Offer,
 ) (buyer, issuer map[string]any, err error) {
 	if offer.BuyerOrgId != nil {
@@ -139,15 +149,9 @@ func sendSnapshots(ctx context.Context, tx pgx.Tx, baseCurrencyOf BaseCurrencyFu
 			}
 		}
 	}
-	// The issuer's currency comes from the same seam the offer's frozen rate
-	// does. Reading it from the column here while freezeFx reads the setting
-	// would let a snapshot record one basis for an offer priced in another.
-	// The NAME is still a column read — it moves with the rest of the
-	// installation identity in the next slice of ADR-0091 phase 4.
-	baseCurrency, err := baseCurrencyOf(ctx, tx)
-	if err != nil {
-		return nil, nil, fmt.Errorf("snapshot issuer base currency: %w", err)
-	}
+	// The currency is the caller's resolved base, not a second read: the
+	// snapshot must record the basis this offer was actually priced in. The
+	// NAME is still a column read (issue #521).
 	var wsName string
 	if err := tx.QueryRow(ctx,
 		`SELECT name FROM workspace WHERE id = $1`, storekit.MustWorkspace(ctx)).
@@ -189,7 +193,7 @@ func (s *Store) AcceptOffer(ctx context.Context, id ids.OfferID, ifVersion *int6
 		}
 
 		dealID := ids.From[ids.DealKind](ids.UUID(current.DealId))
-		dealChanged, err := syncDealAmountFromOffer(ctx, tx, s.baseCurrency, dealID, current)
+		dealChanged, err := s.syncDealAmountFromOffer(ctx, tx, dealID, current)
 		if err != nil {
 			return err
 		}
@@ -232,7 +236,7 @@ func (s *Store) AcceptOffer(ctx context.Context, id ids.OfferID, ifVersion *int6
 // It returns the deal columns the sync actually wrote, so the caller's paired
 // deal.updated reports the complete delta — on a closed deal that includes the
 // re-frozen fx_rate_to_base/fx_rate_date, not just amount_minor/currency.
-func syncDealAmountFromOffer(ctx context.Context, tx pgx.Tx, baseCurrency BaseCurrencyFunc,
+func (s *Store) syncDealAmountFromOffer(ctx context.Context, tx pgx.Tx,
 	dealID ids.DealID, offer crmcontracts.Offer,
 ) (map[string]any, error) {
 	// The row lock makes the status read and the amount write below one
@@ -256,8 +260,12 @@ func syncDealAmountFromOffer(ctx context.Context, tx pgx.Tx, baseCurrency BaseCu
 		}
 		return changed, nil
 	}
+	base, err := s.baseCurrency(ctx, tx)
+	if err != nil {
+		return nil, err
+	}
 	// deal_closed_at guarantees closedAt on a non-open row.
-	rate, rateDate, err := freezeFx(ctx, tx, baseCurrency, offer.Currency, *closedAt)
+	rate, rateDate, err := s.freezeFx(ctx, tx, base, offer.Currency, *closedAt)
 	if err != nil {
 		return nil, fmt.Errorf("re-freeze fx for closed deal on accept: %w", err)
 	}

--- a/backend/internal/modules/deals/offer_lifecycle.go
+++ b/backend/internal/modules/deals/offer_lifecycle.go
@@ -67,11 +67,11 @@ func (s *Store) SendOffer(ctx context.Context, id ids.OfferID, ifVersion *int64)
 			return &OfferEmptyError{}
 		}
 
-		rate, rateDate, err := freezeFx(ctx, tx, current.Currency, time.Now().UTC())
+		rate, rateDate, err := freezeFx(ctx, tx, s.baseCurrency, current.Currency, time.Now().UTC())
 		if err != nil {
 			return fmt.Errorf("freeze fx at send: %w", err)
 		}
-		buyer, issuer, err := sendSnapshots(ctx, tx, current)
+		buyer, issuer, err := sendSnapshots(ctx, tx, s.baseCurrency, current)
 		if err != nil {
 			return err
 		}
@@ -120,7 +120,9 @@ func offerSentPayload(current crmcontracts.Offer, rate string) crmcontracts.Publ
 // sendSnapshots captures the buyer and issuer legal blocks at send time:
 // the sent document stays truthful even when the org or workspace is
 // later renamed.
-func sendSnapshots(ctx context.Context, tx pgx.Tx, offer crmcontracts.Offer) (buyer, issuer map[string]any, err error) {
+func sendSnapshots(ctx context.Context, tx pgx.Tx, baseCurrencyOf BaseCurrencyFunc,
+	offer crmcontracts.Offer,
+) (buyer, issuer map[string]any, err error) {
 	if offer.BuyerOrgId != nil {
 		var displayName string
 		var legalName *string
@@ -137,10 +139,19 @@ func sendSnapshots(ctx context.Context, tx pgx.Tx, offer crmcontracts.Offer) (bu
 			}
 		}
 	}
-	var wsName, baseCurrency string
+	// The issuer's currency comes from the same seam the offer's frozen rate
+	// does. Reading it from the column here while freezeFx reads the setting
+	// would let a snapshot record one basis for an offer priced in another.
+	// The NAME is still a column read — it moves with the rest of the
+	// installation identity in the next slice of ADR-0091 phase 4.
+	baseCurrency, err := baseCurrencyOf(ctx, tx)
+	if err != nil {
+		return nil, nil, fmt.Errorf("snapshot issuer base currency: %w", err)
+	}
+	var wsName string
 	if err := tx.QueryRow(ctx,
-		`SELECT name, base_currency FROM workspace WHERE id = $1`, storekit.MustWorkspace(ctx)).
-		Scan(&wsName, &baseCurrency); err != nil {
+		`SELECT name FROM workspace WHERE id = $1`, storekit.MustWorkspace(ctx)).
+		Scan(&wsName); err != nil {
 		return nil, nil, fmt.Errorf("snapshot issuer workspace: %w", err)
 	}
 	issuer = map[string]any{"workspace_name": wsName, "base_currency": baseCurrency}
@@ -178,7 +189,7 @@ func (s *Store) AcceptOffer(ctx context.Context, id ids.OfferID, ifVersion *int6
 		}
 
 		dealID := ids.From[ids.DealKind](ids.UUID(current.DealId))
-		dealChanged, err := syncDealAmountFromOffer(ctx, tx, dealID, current)
+		dealChanged, err := syncDealAmountFromOffer(ctx, tx, s.baseCurrency, dealID, current)
 		if err != nil {
 			return err
 		}
@@ -221,7 +232,9 @@ func (s *Store) AcceptOffer(ctx context.Context, id ids.OfferID, ifVersion *int6
 // It returns the deal columns the sync actually wrote, so the caller's paired
 // deal.updated reports the complete delta — on a closed deal that includes the
 // re-frozen fx_rate_to_base/fx_rate_date, not just amount_minor/currency.
-func syncDealAmountFromOffer(ctx context.Context, tx pgx.Tx, dealID ids.DealID, offer crmcontracts.Offer) (map[string]any, error) {
+func syncDealAmountFromOffer(ctx context.Context, tx pgx.Tx, baseCurrency BaseCurrencyFunc,
+	dealID ids.DealID, offer crmcontracts.Offer,
+) (map[string]any, error) {
 	// The row lock makes the status read and the amount write below one
 	// race-free unit. IncludeArchived preserves the read below, which
 	// follows the deal row regardless of archived state.
@@ -244,7 +257,7 @@ func syncDealAmountFromOffer(ctx context.Context, tx pgx.Tx, dealID ids.DealID, 
 		return changed, nil
 	}
 	// deal_closed_at guarantees closedAt on a non-open row.
-	rate, rateDate, err := freezeFx(ctx, tx, offer.Currency, *closedAt)
+	rate, rateDate, err := freezeFx(ctx, tx, baseCurrency, offer.Currency, *closedAt)
 	if err != nil {
 		return nil, fmt.Errorf("re-freeze fx for closed deal on accept: %w", err)
 	}

--- a/backend/internal/modules/deals/provider.go
+++ b/backend/internal/modules/deals/provider.go
@@ -27,8 +27,10 @@ type Provider struct {
 	store *Store
 }
 
-func NewProvider(pool *pgxpool.Pool) *Provider {
-	return &Provider{store: NewStore(pool)}
+// NewProvider wires the datasource verbs over the same store the transport
+// uses, base-currency seam included.
+func NewProvider(pool *pgxpool.Pool, baseCurrency BaseCurrencyFunc) *Provider {
+	return &Provider{store: NewStore(pool, baseCurrency)}
 }
 
 // WithFieldCatalog wires the workspace custom-field catalog into the

--- a/backend/internal/modules/deals/store.go
+++ b/backend/internal/modules/deals/store.go
@@ -27,10 +27,23 @@ type Store struct {
 	// clock is the "today" source for effective-dated writes (fx_rate);
 	// injected so append-forward date validation is deterministic in tests.
 	clock func() time.Time
+	// baseCurrency resolves the installation's reporting currency
+	// (ADR-0090/A135). REQUIRED by the constructor: this module FREEZES a
+	// conversion rate onto closed deals, so a store that only looked
+	// constructed would write a basis it cannot take back.
+	baseCurrency BaseCurrencyFunc
 }
 
-func NewStore(pool *pgxpool.Pool) *Store {
-	return &Store{pool: pool, clock: time.Now}
+// BaseCurrencyFunc resolves the installation's reporting currency inside a
+// transaction the caller already holds. Compose supplies the one real
+// implementation: deals may not import the module that owns the setting, so
+// the edge is injected rather than imported (ADR-0054).
+type BaseCurrencyFunc func(context.Context, pgx.Tx) (string, error)
+
+// NewStore binds the store to the pool every tenant query runs through, and
+// to the seam that answers what the installation reports in.
+func NewStore(pool *pgxpool.Pool, baseCurrency BaseCurrencyFunc) *Store {
+	return &Store{pool: pool, clock: time.Now, baseCurrency: baseCurrency}
 }
 
 // WithClock overrides the "today" source (tests only). Returns the store

--- a/backend/internal/modules/deals/store.go
+++ b/backend/internal/modules/deals/store.go
@@ -5,6 +5,7 @@ package deals
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -43,6 +44,17 @@ type BaseCurrencyFunc func(context.Context, pgx.Tx) (string, error)
 // NewStore binds the store to the pool every tenant query runs through, and
 // to the seam that answers what the installation reports in.
 func NewStore(pool *pgxpool.Pool, baseCurrency BaseCurrencyFunc) *Store {
+	if baseCurrency == nil {
+		// An un-injected seam fails CLOSED at the first money operation
+		// rather than dereferencing nil inside an open transaction. The
+		// field's doc calls the seam required; this is what makes that a
+		// check rather than a claim. A panic would say it earlier, but this
+		// module may not raise one (the craft gate's panic-in-domain rule).
+		baseCurrency = func(context.Context, pgx.Tx) (string, error) {
+			return "", errors.New("deals: no base-currency seam was injected; " +
+				"compose wires identity.BaseCurrencyOf into this store")
+		}
+	}
 	return &Store{pool: pool, clock: time.Now, baseCurrency: baseCurrency}
 }
 

--- a/backend/internal/modules/identity/installationsettings.go
+++ b/backend/internal/modules/identity/installationsettings.go
@@ -110,8 +110,10 @@ func (s *InstallationSettingsStore) baseCurrencyLock(ctx context.Context) (bool,
 //
 // Every field commits in ONE transaction, together with a mirror write onto
 // the `workspace` columns. The mirror is TRANSITIONAL and load-bearing until
-// it goes: roll-ups, FX conversion, quota attainment and the report builder
-// still read workspace.base_currency and workspace.timezone directly. Without
+// it goes. What still reads the columns directly, and so still depends on it:
+// the company roll-up and the org-360 reads, the brief ranker, the close-date
+// sweep's timezone, and the base-currency freeze probe below — deals, quotas
+// and finance have moved to the settings row (issue #521). Without
 // it, this surface would report a base currency that nothing computes in —
 // changing it would move the number on this screen and leave every roll-up on
 // the old basis, which is worse than not offering the control. The mirror

--- a/backend/internal/modules/identity/settingsentry.go
+++ b/backend/internal/modules/identity/settingsentry.go
@@ -13,10 +13,13 @@ package identity
 // through the product, which is the gap ADR-0085 §7 names.
 
 import (
+	"context"
 	"fmt"
 	"regexp"
 	"strings"
 	"time"
+
+	"github.com/jackc/pgx/v5"
 
 	"github.com/gradionhq/margince/backend/internal/platform/settings"
 )
@@ -104,4 +107,19 @@ var BaseCurrency = settings.Define[string](
 // Definitions is identity's contribution to the settings registry.
 func Definitions() []settings.Definition {
 	return []settings.Definition{Name, Timezone, BaseCurrency}
+}
+
+// BaseCurrencyOf resolves the installation's reporting currency inside a
+// transaction the caller already holds.
+//
+// It lives here because identity OWNS the setting: the modules that convert
+// money may not import this package, so compose injects this function into
+// them (ADR-0054) — but the one spelling of "how the base currency is read"
+// belongs with the entry that declares it, not copied into each wiring site.
+//
+// RequireTx rather than Get: an absent row refuses instead of reading as the
+// registered default, because every caller of this is converting or freezing
+// money against the answer.
+func BaseCurrencyOf(ctx context.Context, tx pgx.Tx) (string, error) {
+	return settings.RequireTx(ctx, tx, BaseCurrency)
 }

--- a/backend/internal/platform/httperr/httperr_test.go
+++ b/backend/internal/platform/httperr/httperr_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
+	"github.com/gradionhq/margince/backend/internal/platform/settings"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
 )
@@ -336,5 +337,32 @@ func TestClassify_theReferenceRefusalNamesTheFieldWhenTheConstraintYieldsIt(t *t
 				t.Errorf("detail still gives the advice that could not be followed: %q", fault.Detail)
 			}
 		})
+	}
+}
+
+// An installation setting with no stored value is a 422 naming the condition,
+// NOT the 404 the sentinel registry would otherwise give it.
+//
+// The distinction is load-bearing on the money paths. A deal close, an offer
+// send and an fx write all resolve the installation's base currency, and on a
+// store path this repo spells 404 to mean "no such row, and we are not saying
+// whether it exists" — so a caller that had just read the deal would be told
+// the deal was gone, and an agent would settle on that rather than surfacing
+// an operator condition. Nothing the caller sent is wrong here, and no field
+// of theirs can fix it, which is exactly what MessageFault is for.
+func TestWrite_anUnsetInstallationSettingIsAnOperatorFaultNotAMissingRow(t *testing.T) {
+	rec := httptest.NewRecorder()
+	Write(rec, httptest.NewRequest(http.MethodPost, "/v1/deals/x/advance", nil),
+		fmt.Errorf("freeze fx at close: %w", settings.UnsetValue{Setting: "installation.base_currency"}))
+
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, want 422 — an unset setting must not speak the row-scope 404", rec.Code)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "installation_setting_unset") {
+		t.Errorf("body %q does not carry the installation_setting_unset code", body)
+	}
+	if !strings.Contains(body, "installation.base_currency") {
+		t.Errorf("body %q does not name which setting is unset", body)
 	}
 }

--- a/backend/internal/platform/settings/entry.go
+++ b/backend/internal/platform/settings/entry.go
@@ -222,3 +222,29 @@ func (e FrozenValue) Error() string {
 func (e FrozenValue) FieldFault() (field, code, message string) {
 	return e.Setting, "setting_frozen", e.Reason
 }
+
+// UnsetValue refuses a read of a setting that has no stored value, for the
+// readers that may not fall back to the registered default (RequireTx).
+//
+// It is a MessageFault, not ErrNotFound, and the distinction is the whole
+// point: on a store path this repo spells 404 to mean "no such row, and we
+// are not saying whether it exists" — so returning ErrNotFound here would
+// answer a deal close, an offer send or an fx write with "that deal does not
+// exist", for a caller that just read it. This is server-side configuration
+// missing, which is the same class as MissingFxRateError: nothing the caller
+// sent is wrong, and no field of theirs can fix it.
+type UnsetValue struct {
+	Setting string
+}
+
+func (e UnsetValue) Error() string {
+	return fmt.Sprintf("setting %s has no stored value", e.Setting)
+}
+
+// MessageFault names the condition and no field: the caller supplied no input
+// that could be corrected, so pointing at one would send them after an
+// argument they never made.
+func (e UnsetValue) MessageFault() (code, message string) {
+	return "installation_setting_unset", e.Error() +
+		" — an admin must set it on the installation settings screen before this operation can succeed"
+}

--- a/backend/internal/platform/settings/store.go
+++ b/backend/internal/platform/settings/store.go
@@ -299,9 +299,7 @@ func RequireTx[T any](ctx context.Context, tx pgx.Tx, e *Entry[T]) (T, error) {
 	var raw json.RawMessage
 	err := tx.QueryRow(ctx, `SELECT value FROM setting WHERE key = $1`, e.Key()).Scan(&raw)
 	if errors.Is(err, pgx.ErrNoRows) {
-		return zero, fmt.Errorf("settings: %s has no stored value, and this reader may not "+
-			"assume the registered default: set it on the installation settings screen: %w",
-			e.Key(), apperrors.ErrNotFound)
+		return zero, UnsetValue{Setting: e.Key()}
 	}
 	if err != nil {
 		return zero, fmt.Errorf("settings: reading %s: %w", e.Key(), err)

--- a/backend/internal/platform/testdb/reset.go
+++ b/backend/internal/platform/testdb/reset.go
@@ -220,9 +220,38 @@ func resetWithin(ctx context.Context, tx execQuerier) error {
 	if err := dropCustomFieldColumns(ctx, tx); err != nil {
 		return err
 	}
+	if err := seedInstallationIdentity(ctx, tx); err != nil {
+		return err
+	}
 	// Every table is empty now, which is the only moment a table that did not
 	// exist when EnsureSchema ran can be given a real baseline.
 	return baselineNewTables(ctx, tx, unbaselined)
+}
+
+// seedInstallationIdentity restores the installation's own settings rows after
+// the sweep, because a data reset does not un-install the installation.
+//
+// Production draws exactly this line: identity.ResetConfig deletes the
+// CONFIGURATION settings and spares the identity ones, for the same reason
+// preservedWorkspaceColumns spares name/base_currency/timezone — "a reset
+// wipes an installation's DATA, it does not re-create the installation".
+// Bootstrap is what writes these on a real first boot, and fixtures build
+// their workspace by raw SQL instead, so without this every fixture starts as
+// an installation with no currency and the money readers refuse (issue #521).
+//
+// EUR matches what every fixture puts in workspace.base_currency. A test that
+// wants them to DISAGREE writes the setting itself — which is the only way to
+// prove which of the two copies a reader consults while both exist.
+func seedInstallationIdentity(ctx context.Context, q execQuerier) error {
+	if _, err := q.Exec(ctx, `
+		INSERT INTO setting (key, value) VALUES
+			('installation.name', '"Test Installation"'::jsonb),
+			('installation.base_currency', '"EUR"'::jsonb),
+			('installation.timezone', '"UTC"'::jsonb)
+		ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value`); err != nil {
+		return fmt.Errorf("seeding the installation's identity settings: %w", err)
+	}
+	return nil
 }
 
 // baselineNewTables records the empty size of tables that appeared after

--- a/backend/internal/platform/testdb/reset.go
+++ b/backend/internal/platform/testdb/reset.go
@@ -220,38 +220,9 @@ func resetWithin(ctx context.Context, tx execQuerier) error {
 	if err := dropCustomFieldColumns(ctx, tx); err != nil {
 		return err
 	}
-	if err := seedInstallationIdentity(ctx, tx); err != nil {
-		return err
-	}
 	// Every table is empty now, which is the only moment a table that did not
 	// exist when EnsureSchema ran can be given a real baseline.
 	return baselineNewTables(ctx, tx, unbaselined)
-}
-
-// seedInstallationIdentity restores the installation's own settings rows after
-// the sweep, because a data reset does not un-install the installation.
-//
-// Production draws exactly this line: identity.ResetConfig deletes the
-// CONFIGURATION settings and spares the identity ones, for the same reason
-// preservedWorkspaceColumns spares name/base_currency/timezone — "a reset
-// wipes an installation's DATA, it does not re-create the installation".
-// Bootstrap is what writes these on a real first boot, and fixtures build
-// their workspace by raw SQL instead, so without this every fixture starts as
-// an installation with no currency and the money readers refuse (issue #521).
-//
-// EUR matches what every fixture puts in workspace.base_currency. A test that
-// wants them to DISAGREE writes the setting itself — which is the only way to
-// prove which of the two copies a reader consults while both exist.
-func seedInstallationIdentity(ctx context.Context, q execQuerier) error {
-	if _, err := q.Exec(ctx, `
-		INSERT INTO setting (key, value) VALUES
-			('installation.name', '"Test Installation"'::jsonb),
-			('installation.base_currency', '"EUR"'::jsonb),
-			('installation.timezone', '"UTC"'::jsonb)
-		ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value`); err != nil {
-		return fmt.Errorf("seeding the installation's identity settings: %w", err)
-	}
-	return nil
 }
 
 // baselineNewTables records the empty size of tables that appeared after


### PR DESCRIPTION
Slice 2 of #521, following #794. Every **base-currency** read in `deals` now resolves through the installation-settings seam.

## What moved

- `freezeFx` — the frozen conversion rate, reached from deal update, stage advance and offer accept
- all four `fxrate_store` reads, including `WorkspaceBaseCurrency`
- the offer's **issuer snapshot**

Two of these were **SQL subqueries** (`to_currency = (SELECT base_currency FROM workspace …)`). The value is no longer a column on a joinable row, so it's resolved in Go and passed as a parameter — same result, one source.

## Design notes

**Required constructor parameter**, as in slice 1. This module *freezes* a rate onto closed deals, so a store that merely looked constructed would write a basis it cannot take back. `freezeFx` is package-level and reached through three helper chains (`applyMoneyInvariants` → `updateDealInTx`, `stageTransitionPatch`, `syncDealAmountFromOffer`), so the resolver threads explicitly rather than hiding in a context value. Verbose on purpose: the alternative is an invisible dependency on a money path.

**The issuer snapshot moved too**, even though it's display rather than arithmetic. It sits in the same file as `freezeFx`, and leaving it on the column would let one offer record a basis it wasn't priced in — the two-answers problem *inside a single module*, which is the hazard this migration exists to end.

**The reader now lives in `identity`, as `BaseCurrencyOf`.** identity owns the setting, so it owns how the setting is read; compose still owns the *edge* and injects it. This also resolves an import cycle I hit: `integration/harness.go` is a non-test file and compose's own tests import that package, so the harness cannot import compose to reach the wiring. Putting the reader with its entry gives both callers one spelling instead of a hand-copied adapter in the fixture.

## Not in this slice

Both non-money, both in the next one: the installation **name** in that same offer snapshot, and the **timezone** the close-date sweep computes in. After those, `compose/orgrollupread.go` and `compose/org360` (2 files) are the last readers before the columns can be dropped.

## Verification

`make check-backend` and `make craft-static` (0/0/0) green locally; `go vet -tags integration ./...` clean. No Docker here, so the integration lane is CI's word.

Refs #521, ADR-0091 phase 4.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved all base-currency reads in `deals` to the installation-settings seam via `identity.BaseCurrencyOf`, replacing `workspace.base_currency` across deal close/edit/advance, offer send/accept, and FX APIs. An unset base currency now returns a 422 MessageFault; new tests prove the setting is the source of truth (refs #521).

- **Refactors**
  - Required `BaseCurrencyFunc` in `deals.NewStore`, `deals.NewHandlers`, and `deals.NewProvider`; a missing seam now refuses with a clear error.
  - Money paths became store methods and resolve the base once per operation; offer issuer snapshot records the resolved base and reads the workspace name only.
  - `fxrate_store`: all reads use the resolved base; `WorkspaceBaseCurrency` renamed to `BaseCurrency`.
  - Deleted `compose.InstallationBaseCurrency`; `deals`, `quotas`, and `finance` now inject `identity.BaseCurrencyOf`.
  - `settings.RequireTx` returns a typed 422 via `settings.UnsetValue`; added HTTP classification; fixtures and grants updated to include `installation_settings:read`.
  - Added `compose/integration/basecurrencyseam_integration_test` that sets setting USD vs column EUR and asserts deal freeze and FX list follow the setting; harness seeds the setting to match the column.

- **Migration**
  - Inject `identity.BaseCurrencyOf` when constructing `deals`, `quotas`, and `finance`.
  - Ensure roles that write money include `installation_settings:read`.
  - No schema changes; fixtures seed `installation.base_currency` alongside workspace inserts; the test reset stays empty.

<sup>Written for commit a43079090fde2ac18e05851034b16822ab82e5e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/802?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

