### PR TITLE
fix(company): the finance card stops hiding money on imported accounts

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -716,6 +716,7 @@ export const de = {
   "co.section.unavailable":
     "Konnte nicht geladen werden — das ist möglicherweise nicht das ganze Bild",
   "finance.title": "Finanzen",
+  "finance.titleHistorical": "Finanzen · historisch",
   "finance.none": "Nichts erfasst.",
   "finance.noConnection":
     "Keine Finanzquelle verbunden — verbinde eine, um zu sehen, was diesem Kunden berechnet wurde und ob er pünktlich zahlt",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -710,6 +710,7 @@ export const en = {
   "co.section.unavailable":
     "Could not be loaded — this may not be the whole picture",
   "finance.title": "Finance",
+  "finance.titleHistorical": "Finance · historical",
   "finance.none": "Nothing recorded.",
   "finance.noConnection":
     "No financial source connected — connect one to see what this customer has been invoiced and whether they pay on time",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -712,6 +712,7 @@ export const vi = {
   "evidence.fullHistory": "Lịch sử đầy đủ",
   "co.section.unavailable": "Không tải được — đây có thể chưa phải toàn cảnh",
   "finance.title": "Tài chính",
+  "finance.titleHistorical": "Tài chính · lịch sử",
   "finance.none": "Chưa ghi nhận gì.",
   "finance.noConnection":
     "Chưa kết nối nguồn tài chính — hãy kết nối để thấy khách hàng này đã được xuất hóa đơn bao nhiêu và có trả đúng hạn không",

--- a/frontend/src/screens/company360.test.tsx
+++ b/frontend/src/screens/company360.test.tsx
@@ -1649,6 +1649,22 @@ describe("company view — advice you can act on", () => {
   });
 });
 
+describe("company view — where the record came from", () => {
+  // Which of a human, an agent, a connector or nobody wrote a record is the
+  // governance reading the provenance tag exists for. Suppressing the reader's
+  // OWN hand-typed entry — the one case that reports nothing they do not
+  // already know — must not suppress the rest.
+  it("names an agent that wrote the record", async () => {
+    stub(view(), 200, { ...org, captured_by: "agent:enricher" });
+    renderCompany();
+    await screen.findByText("Brandt Automotive GmbH");
+
+    await waitFor(() =>
+      expect(screen.getAllByText(/enricher/).length).toBeGreaterThan(0),
+    );
+  });
+});
+
 describe("company view — the account's own tabs", () => {
   it("gives People the whole middle column", async () => {
     stub(

--- a/frontend/src/screens/companyfinance.test.tsx
+++ b/frontend/src/screens/companyfinance.test.tsx
@@ -1,0 +1,113 @@
+/** @vitest-environment jsdom */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  cleanup,
+  render as rtlRender,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { components } from "../api/schema";
+import { LocaleProvider } from "../i18n";
+import { CompanyFinanceCard } from "./companyfinance";
+
+// FIN-AC-3 decides WHETHER this card exists, and it is the one rule on the
+// card that fails silently: a lifecycle wrongly treated as never-invoiced
+// renders nothing at all, so a reader is never told the money is missing.
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+beforeEach(() => {
+  globalThis.localStorage.setItem("margince.workspaceSlug", "acme");
+});
+
+type FinanceSummary = components["schemas"]["OrganizationFinanceSummary"];
+
+const CONNECTED: FinanceSummary = {
+  organization_id: "o-1",
+  state: "connected",
+  provider: "offline_demo",
+  net_invoiced: { amount_minor: 18642000, currency: "EUR" },
+};
+
+function stub(summary: FinanceSummary = CONNECTED) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (request: Request) => {
+      const body = new URL(request.url).pathname.endsWith("/finance-summary")
+        ? summary
+        : { data: [], page: { has_more: false, next_cursor: null } };
+      return new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }),
+  );
+}
+
+function render(ui: ReactNode) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return rtlRender(
+    <QueryClientProvider client={client}>
+      <LocaleProvider initial="en">{ui}</LocaleProvider>
+    </QueryClientProvider>,
+  );
+}
+
+describe("the finance card is absent only where FIN-AC-3 says so", () => {
+  // The criterion names exactly three, and the card must not add to them.
+  it.each(["target", "prospect", "opportunity"])(
+    "draws nothing for a %s, which has never been invoiced",
+    (lifecycle) => {
+      stub();
+      const { container } = render(
+        <CompanyFinanceCard orgId="o-1" lifecycle={lifecycle} />,
+      );
+      expect(container.textContent).toBe("");
+    },
+  );
+
+  // The overreach this suite exists for. Every IMPORTED company carries
+  // `unknown`, so treating it as never-invoiced hid finance from the majority
+  // of the book — and hid it silently, because the card simply did not render.
+  it.each(["unknown", "disqualified", "customer", "former_customer"])(
+    "renders for a %s, which may have been invoiced",
+    async (lifecycle) => {
+      stub();
+      render(<CompanyFinanceCard orgId="o-1" lifecycle={lifecycle} />);
+      await waitFor(() => expect(screen.getByText(/Finance/)).toBeTruthy());
+    },
+  );
+
+  // An account with no lifecycle recorded yet is not an account we know we
+  // never billed.
+  it("renders when the lifecycle is not known", async () => {
+    stub();
+    render(<CompanyFinanceCard orgId="o-1" />);
+    await waitFor(() => expect(screen.getByText(/Finance/)).toBeTruthy());
+  });
+
+  // FIN-AC-3's second half: a former customer's figures are history, and the
+  // card says so rather than letting money from a finished relationship read
+  // as current.
+  it("labels a former customer's money historical", async () => {
+    stub();
+    render(<CompanyFinanceCard orgId="o-1" lifecycle="former_customer" />);
+    await waitFor(() =>
+      expect(screen.getByText("Finance · historical")).toBeTruthy(),
+    );
+  });
+
+  it("leaves a current customer's card unqualified", async () => {
+    stub();
+    render(<CompanyFinanceCard orgId="o-1" lifecycle="customer" />);
+    await waitFor(() => expect(screen.getByText("Finance")).toBeTruthy());
+    expect(screen.queryByText("Finance · historical")).toBeNull();
+  });
+});

--- a/frontend/src/screens/companyfinance.tsx
+++ b/frontend/src/screens/companyfinance.tsx
@@ -47,22 +47,42 @@ const CARD_STATE: Record<FinanceState, SectionState> = {
   stale: "stale",
 };
 
+/**
+ * The lifecycles FIN-AC-3 authorises the card's absence for, and ONLY those.
+ *
+ * Named as the allowlist of absence rather than as an allowlist of presence,
+ * because the two fail in opposite directions. A lifecycle this list forgets
+ * gets a card that says "no accounting source connected" — a true statement
+ * and a prompt to connect one. A lifecycle wrongly ON it gets NO card, and a
+ * reader is never told the money is missing.
+ *
+ * `unknown` is the case that made this matter: every imported company carries
+ * it, so an allowlist of presence hid finance from the majority of the book.
+ * `disqualified` is the same shape — an account we stopped selling to may
+ * still owe us money.
+ */
+const NEVER_INVOICED: ReadonlySet<string> = new Set([
+  "target",
+  "prospect",
+  "opportunity",
+]);
+
 export function CompanyFinanceCard({
   orgId,
   lifecycle,
 }: Readonly<{
   orgId: string;
-  // The account's lifecycle. A target or a prospect has never been invoiced,
-  // so the card is ABSENT for them rather than empty (FIN-AC-3) — an empty
-  // finance card on a company we have never billed is a question nobody asked.
+  // The account's lifecycle. A target, a prospect or an opportunity has never
+  // been invoiced, so the card is ABSENT for them rather than empty (FIN-AC-3)
+  // — an empty finance card on a company we have never billed is a question
+  // nobody asked.
   lifecycle?: string;
 }>) {
   const t = useT();
   const { locale } = useLocale();
-  const billable = lifecycle === "customer" || lifecycle === "former_customer";
   const query = useFinanceSummary(orgId);
 
-  if (!billable) {
+  if (lifecycle && NEVER_INVOICED.has(lifecycle)) {
     return null;
   }
   if (query.isPending) {
@@ -95,7 +115,17 @@ export function CompanyFinanceCard({
   const summary = query.data;
   return (
     <SectionCard
-      title={t("finance.title")}
+      // A former customer's money is HISTORY, and the title says so rather
+      // than letting figures from a finished relationship read as current
+      // (FIN-AC-3). The coverage period the criterion also asks for is not on
+      // the wire — `OrganizationFinanceSummary` carries `last_synced_at` and
+      // no coverage start or end — so the label states what it can stand
+      // behind and omits what it cannot.
+      title={
+        lifecycle === "former_customer"
+          ? t("finance.titleHistorical")
+          : t("finance.title")
+      }
       state={CARD_STATE[summary.state]}
       emptyLabel={t(EMPTY_LABEL[summary.state] ?? "finance.none")}
       detail={{

--- a/frontend/src/screens/companyheader.tsx
+++ b/frontend/src/screens/companyheader.tsx
@@ -188,8 +188,12 @@ function CompanyLifecycleControl({ org }: Readonly<{ org: Organization }>) {
       }))}
       canEdit={canUpdate && !readOnlyReason}
       readOnlyReason={readOnlyReason}
+      // The account's standing is the one value in this block a reader looks
+      // for first, and both mockups draw it as the header's prominent
+      // control. An accent badge is that weight; the grey one beside Owner
+      // read as another piece of metadata.
       render={(value) => (
-        <Badge>{t(LIFECYCLE_LABELS[value as Lifecycle])}</Badge>
+        <Badge tone="accent">{t(LIFECYCLE_LABELS[value as Lifecycle])}</Badge>
       )}
       onSave={(next) =>
         patch({
@@ -603,6 +607,10 @@ export function CompanyPulse({
   const t = useT();
   const { locale } = useLocale();
   const viewerId = useViewerId();
+  const provenance = provenanceOf(org.captured_by, viewerId);
+  // The reader's own hand-typed entry: the one provenance that reports nothing
+  // they do not already know.
+  const selfTyped = provenance.kind === "human" && provenance.self;
   const strength = view?.strength;
   // Withheld or absent, the line says nothing at all: "never contacted" read
   // off missing data is a business conclusion the page has no basis for, and
@@ -638,11 +646,19 @@ export function CompanyPulse({
         </>
       )}
       {/* Where the RECORD came from — a different question from who owns it,
-          and the reason both now carry a word saying which is which. */}
-      <ProvenanceTag
-        provenance={provenanceOf(org.captured_by, viewerId)}
-        renderUser={(userId) => <EntityRef kind="user" id={userId} />}
-      />
+          and the reason both carry a word saying which is which.
+
+          Not when the reader typed it THEMSELVES. "Typed by you" on your own
+          entry is the one case that tells nobody anything, and it rode the
+          pulse line of every hand-created account. An agent, a connector or an
+          unknown source all still say so: which of those wrote a record is the
+          governance reading this tag exists for. */}
+      {!selfTyped && (
+        <ProvenanceTag
+          provenance={provenance}
+          renderUser={(userId) => <EntityRef kind="user" id={userId} />}
+        />
+      )}
       {/* What is waiting on a human decision here, and the way to make it.
           The count was a badge that led nowhere: a reader told that 27
           decisions are owed and given no way to pay them learns only that the


### PR DESCRIPTION
**FIN-AC-3 was implemented inverted, and it failed silently.**

The criterion authorises the finance card's absence for exactly three lifecycles — target, prospect, opportunity. The card was gated the other way round: present only for `customer` and `former_customer`. So it also withheld itself from `unknown` and `disqualified`.

`unknown` is what **every imported company carries**, which made this the majority of the book. And the failure mode is the quiet one: no card renders, so nobody is told the money is missing.

The gate is now an allowlist of **absence**, which fails in the safe direction:

- a lifecycle the list forgets gets a card saying no source is connected — true, and a prompt to connect one
- a lifecycle wrongly *on* it gets nothing at all, and the reader never learns

## FIN-AC-3's second half was also unimplemented

A former customer's figures now read **"Finance · historical"** rather than as current money. The coverage period the criterion also asks for is not on the wire — `OrganizationFinanceSummary` carries `last_synced_at` and no coverage start or end — so the label states what it can stand behind and omits what it cannot.

## The card had no test file

Which is how a gate this central survived inverted. It has one now, covering both halves of the criterion, table-driven over every lifecycle. Mutation-checked: restoring the old allowlist fails two cases.

## Two header changes the mockups ask for

- The account's **lifecycle is an accent badge**, not another piece of grey 12.5px metadata beside Owner. Both mockups draw it as the header's prominent control.
- The pulse no longer says **"typed by you"** on a record the reader typed — the one provenance that reports nothing they already know, and it rode the pulse of every hand-created account. An agent, a connector or an unknown source still say so; which of those wrote a record is the governance reading the tag exists for, and there is a test pinning that the suppression did not reach it.

## Verification

`make check-fe` green (2071 tests). Screenshotted: the lifecycle badge reads as an accent control, and the pulse line is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes finance card visibility so imported accounts with `unknown` or `disqualified` lifecycle no longer hide money, and marks former customers’ figures as historical per FIN-AC-3. Also updates the header badge and provenance copy for clarity.

- **Bug Fixes**
  - Finance card now renders for all lifecycles except `target`, `prospect`, and `opportunity` (allowlist of absence). Imported `unknown` and `disqualified` accounts now see the card.
  - Former customers show "Finance · historical"; coverage dates omitted (not available from `OrganizationFinanceSummary`).
  - Header: lifecycle shows as an accent `Badge`. Pulse no longer shows "typed by you" for records the viewer created; agent/connector/unknown still display.
  - Tests: added lifecycle gating and historical label tests; coverage across all lifecycles. Added provenance test. i18n key `finance.titleHistorical` added in `en`, `de`, `vi`.

<sup>Written for commit e2842dcf299b382b587b68b0571e4c54ef536f44. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/806?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

