### PR TITLE
fix(agents): an auto-executed deal move is bound to the record its tier was read from (#614)

### DIFF
--- a/backend/internal/compose/agentgate.go
+++ b/backend/internal/compose/agentgate.go
@@ -28,6 +28,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 
 	"github.com/go-chi/chi/v5"
 
@@ -226,6 +227,9 @@ type admissionOutcome struct {
 func admitAgentCall(w http.ResponseWriter, r *http.Request, next http.Handler, outcome admissionOutcome) {
 	switch {
 	case outcome.err == nil:
+		if !pinAdmittedWrite(w, r) {
+			return
+		}
 		// The effect is charged on BOTH arms — the field split forwards to the
 		// same handler through its own path — and on NEITHER when the handler
 		// refused. A quota counts what an agent did, so a rejected mutation that
@@ -266,6 +270,51 @@ func admitAgentCall(w http.ResponseWriter, r *http.Request, next http.Handler, o
 			outcome.registry.ChargeEffect(r.Context(), outcome.spec)
 		}
 	}
+}
+
+// pinAdmittedWrite conditions an auto-executed agent write on the record state
+// its tier was decided from, by forwarding the gate's pin as the request's own
+// If-Match.
+//
+// This is redeemIfPresented's forward (agentgatestaging.go) one tier down, and
+// for the same reason: the gate resolved a dynamic tier by READING the record,
+// that read commits before the handler's transaction opens, and the agent
+// controls both sides of the window — its own 🟢 call can close a deal between
+// the two. Moving the compare inside the transaction that mutates is what makes
+// a record that changed lose to the version check instead of to timing.
+//
+// A caller that sent its own If-Match keeps it — but only if it names the
+// version the gate read, and that is CHECKED. The caller controls the header,
+// so a version the gate never saw is a version nothing proved: a caller naming
+// the version the racing close will PRODUCE walks straight through, because the
+// store's compare then passes on precisely the record the tier decision does not
+// describe. Preferring the caller unchecked would turn a coin-toss race into an
+// armable one. A disagreement is answered as skew, which is also what a caller
+// holding a genuinely stale version already gets, one layer down.
+//
+// It reports whether the request may proceed; a refusal has already been
+// written.
+func pinAdmittedWrite(w http.ResponseWriter, r *http.Request) bool {
+	version, pinned := auth.AutoExecutePin(r.Context())
+	if !pinned {
+		return true
+	}
+	if caller := r.Header.Get("If-Match"); caller != "" {
+		// Compared as the numbers they are: the contract's If-Match is a bare
+		// integer version, and two spellings of one number must not read as
+		// disagreement. A caller header this parser refuses is left for the
+		// handler's own IfMatchVersion to answer, which is where that message
+		// already lives.
+		if got, err := strconv.ParseInt(caller, 10, 64); err != nil || got == version {
+			return true
+		}
+		httperr.Write(w, r, fmt.Errorf(
+			"If-Match %s is not the version this record was read at (%d) — re-read it and retry: %w",
+			caller, version, apperrors.ErrVersionSkew))
+		return false
+	}
+	r.Header.Set("If-Match", strconv.FormatInt(version, 10))
+	return true
 }
 
 // effectRecorder answers whether the handler behind this door actually

--- a/backend/internal/compose/agentgatepin_test.go
+++ b/backend/internal/compose/agentgatepin_test.go
@@ -17,6 +17,7 @@ package compose
 // middleware produces rather than what a hand-set context claims.
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"net/http"
@@ -149,26 +150,53 @@ func TestACallerIfMatchTheGateDidNotReadIsRefused(t *testing.T) {
 
 // A call whose tier was not decided from a record has nothing to pin, and a
 // header invented here would refuse writes for a reason nobody can act on.
+//
+// It goes through the real Admit against the real create policy, so the absent
+// header is the STATIC tier's doing rather than a context no gate produced.
+// Handing this a request the gate never touched would have proved only that
+// admitAgentCall invents nothing out of thin air — and it would have kept
+// passing if pin forwarding regressed for every static call on the surface.
 func TestAWriteWithNoAdmittedPinIsForwardedUnconditioned(t *testing.T) {
 	stage := ids.NewV7()
-	reg, spec := advanceSpec(t, tierDeps{
+	deps := tierDeps{
 		stages:  reopenStages{semantics: map[ids.UUID]string{stage: "open"}},
 		records: versionedDeal{stageID: stage, version: 12},
-	})
-	// A create carries no id and no record to read, so its tier is static and
-	// the gate proved nothing about any row.
-	r := httptest.NewRequest(http.MethodPost, "/v1/people", http.NoBody)
+	}
+	reg := agents.NewRegistry(nil, auth.NewGate(fullSeat{}))
+	agents.RegisterCoreTools(reg, deps.records, deps.stages, nil, nil)
+	// A create names no record and reads none, so its tool twin is static-tier:
+	// there is nothing for the gate to have proved anything about.
+	pol := agentPolicies["POST /v1/people"]
+	spec, _, ok := operationSpec(pol, reg)
+	if !ok {
+		t.Fatal("the registry serves no create_record spec for the REST twin to admit against")
+	}
+	if spec.Tier == mcp.TierDynamic {
+		t.Fatalf("%s resolved a dynamic spec, so this case is not about a static tier", pol.Op)
+	}
+
+	body := []byte(`{"display_name":"Ada"}`)
+	r := httptest.NewRequest(http.MethodPost, "/v1/people", bytes.NewReader(body))
 	r = r.WithContext(agentRequestCtx(r.Context()))
+	resolve, known := tierInput(r.Context(), spec, pol, deps, r, body)
+	if !known {
+		t.Fatal("the gate has no tier input for a static-tier create")
+	}
+	ctx, err := auth.NewGate(fullSeat{}).Admit(r.Context(), spec, resolve)
+	if err != nil {
+		t.Fatalf("the create was refused: %v", err)
+	}
+	r = r.WithContext(ctx)
 
 	var seen string
 	next := http.HandlerFunc(func(_ http.ResponseWriter, got *http.Request) {
 		seen = got.Header.Get("If-Match")
 	})
-
 	admitAgentCall(httptest.NewRecorder(), r, next, admissionOutcome{
-		pol: agentPolicies["POST /v1/people"], spec: spec, registry: reg,
+		pol: pol, spec: spec, registry: reg,
 	})
 	if seen != "" {
-		t.Errorf("the handler saw If-Match %q, want none", seen)
+		t.Errorf("the handler saw If-Match %q, want none — a static tier read no record, so a "+
+			"precondition here would refuse writes for a reason nobody can act on", seen)
 	}
 }

--- a/backend/internal/compose/agentgatepin_test.go
+++ b/backend/internal/compose/agentgatepin_test.go
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The REST door's half of the auto-execute version pin.
+//
+// ADR-0055's claim is that a passport is governed the same way on both doors,
+// and the pin is part of what a 🟢 admission means: the tier was resolved by
+// reading a record, so the write it admits is conditioned on the version that
+// record was read at. On MCP the pin travels as the tool's `if_version`
+// argument; here it travels as the request's own If-Match — the header
+// redeemIfPresented already forwards for a released 🟡 call, one tier down.
+//
+// Admission runs through the real gate and the real resolver, in the two lines
+// agentGate itself uses, so what these assert about the pin is what the
+// middleware produces rather than what a hand-set context claims.
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/modules/agents"
+	"github.com/gradionhq/margince/backend/internal/platform/auth"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/mcp"
+)
+
+// versionedDeal is a deal sitting in one open stage at one known version — the
+// record the tier gate reads to decide that the move may run unattended.
+type versionedDeal struct {
+	datasource.SystemOfRecordProvider
+	stageID ids.UUID
+	version int64
+}
+
+func (p versionedDeal) Read(context.Context, datasource.EntityRef) (datasource.Record, error) {
+	return datasource.Record{
+		Fields:  json.RawMessage(`{"stage_id":"` + p.stageID.String() + `"}`),
+		Version: p.version,
+	}, nil
+}
+
+// advanceSpec is the registered advance_deal spec, resolved the way the gate
+// resolves it: through the generated policy table's op→tool mapping. The
+// registry comes back with it because the dispatch this door performs charges
+// its counters against that same surface.
+func advanceSpec(t *testing.T, deps tierDeps) (*agents.Registry, mcp.ToolSpec) {
+	t.Helper()
+	reg := agents.NewRegistry(nil, auth.NewGate(fullSeat{}))
+	agents.RegisterCoreTools(reg, deps.records, deps.stages, nil, nil)
+	spec, _, ok := operationSpec(agentPolicies["POST /v1/deals/{id}/advance"], reg)
+	if !ok {
+		t.Fatal("the registry serves no advance_deal spec for the REST twin to admit against")
+	}
+	return reg, spec
+}
+
+// admitOpenMove runs an open→open deal move through the real gate and answers
+// the If-Match the downstream contract handler would read, plus the status the
+// door answered. These are the two lines agentGate runs between resolving the
+// tier input and dispatching.
+//
+// seen is empty when the door refused, because then no handler ran.
+func admitOpenMove(t *testing.T, callerIfMatch string) (seen string, status int) {
+	t.Helper()
+	deal, stage := ids.NewV7(), ids.NewV7()
+	deps := tierDeps{
+		stages:  reopenStages{semantics: map[ids.UUID]string{stage: "open"}},
+		records: versionedDeal{stageID: stage, version: 12},
+	}
+	body := []byte(`{"to_stage_id":"` + stage.String() + `"}`)
+	r := requestForDeal(t, deal)
+	if callerIfMatch != "" {
+		r.Header.Set("If-Match", callerIfMatch)
+	}
+	r = r.WithContext(agentRequestCtx(r.Context()))
+
+	reg, spec := advanceSpec(t, deps)
+	ctx, err := auth.NewGate(fullSeat{}).Admit(r.Context(), spec, func() (mcp.TierResolverInput, error) {
+		return advanceDealTierInput(r.Context(), deps, agentPolicy{}, r, body)
+	})
+	if err != nil {
+		t.Fatalf("the open→open move was refused: %v", err)
+	}
+	r = r.WithContext(ctx)
+
+	next := http.HandlerFunc(func(_ http.ResponseWriter, got *http.Request) {
+		seen = got.Header.Get("If-Match")
+	})
+	recorder := httptest.NewRecorder()
+	admitAgentCall(recorder, r, next, admissionOutcome{
+		pol: agentPolicies["POST /v1/deals/{id}/advance"], spec: spec, registry: reg,
+	})
+	return seen, recorder.Code
+}
+
+// agentRequestCtx is the passport principal the gate governs: a full seat with
+// the scope a deal move needs.
+func agentRequestCtx(ctx context.Context) context.Context {
+	ctx = principal.WithWorkspaceID(ctx, ids.NewV7())
+	return principal.WithActor(ctx, principal.Principal{
+		Type: principal.PrincipalAgent, ID: "agent:rest-pin", OnBehalfOf: ids.NewV7(),
+		Scopes: principal.NewScopeSet(principal.ScopeWrite),
+	})
+}
+
+func TestAnAdmittedAgentWriteCarriesThePinItsTierWasResolvedFrom(t *testing.T) {
+	if got, _ := admitOpenMove(t, ""); got != "12" {
+		t.Errorf("the handler saw If-Match %q, want 12 — an unpinned 🟢 write lets a deal that "+
+			"closed since the tier was resolved be reopened on a decision that no longer holds", got)
+	}
+}
+
+// The caller may pin its own write, and does — as long as it names the record
+// the gate judged.
+func TestACallerIfMatchThatNamesTheGatesVersionIsForwardedUnchanged(t *testing.T) {
+	if got, status := admitOpenMove(t, "12"); got != "12" || status != http.StatusOK {
+		t.Errorf("the handler saw If-Match %q at status %d, want 12 and 200", got, status)
+	}
+}
+
+// A caller If-Match the gate did not read is refused rather than honoured. The
+// dangerous half is a FUTURE version: it names the row the racing close will
+// leave behind, so the store's compare passes on the one record the tier
+// decision does not describe.
+func TestACallerIfMatchTheGateDidNotReadIsRefused(t *testing.T) {
+	for name, caller := range map[string]string{
+		"a future version the gate never read": "13",
+		"a version the caller still holds":     "4",
+	} {
+		t.Run(name, func(t *testing.T) {
+			got, status := admitOpenMove(t, caller)
+			if status != http.StatusConflict {
+				t.Errorf("status = %d, want 409 — a pin the gate never proved anything about must "+
+					"not condition the write it admitted", status)
+			}
+			if got != "" {
+				t.Errorf("the handler ran with If-Match %q despite the refusal", got)
+			}
+		})
+	}
+}
+
+// A call whose tier was not decided from a record has nothing to pin, and a
+// header invented here would refuse writes for a reason nobody can act on.
+func TestAWriteWithNoAdmittedPinIsForwardedUnconditioned(t *testing.T) {
+	stage := ids.NewV7()
+	reg, spec := advanceSpec(t, tierDeps{
+		stages:  reopenStages{semantics: map[ids.UUID]string{stage: "open"}},
+		records: versionedDeal{stageID: stage, version: 12},
+	})
+	// A create carries no id and no record to read, so its tier is static and
+	// the gate proved nothing about any row.
+	r := httptest.NewRequest(http.MethodPost, "/v1/people", http.NoBody)
+	r = r.WithContext(agentRequestCtx(r.Context()))
+
+	var seen string
+	next := http.HandlerFunc(func(_ http.ResponseWriter, got *http.Request) {
+		seen = got.Header.Get("If-Match")
+	})
+
+	admitAgentCall(httptest.NewRecorder(), r, next, admissionOutcome{
+		pol: agentPolicies["POST /v1/people"], spec: spec, registry: reg,
+	})
+	if seen != "" {
+		t.Errorf("the handler saw If-Match %q, want none", seen)
+	}
+}

--- a/backend/internal/compose/dealmovepin_integration_test.go
+++ b/backend/internal/compose/dealmovepin_integration_test.go
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package compose
+
+// The race itself, against real Postgres.
+//
+// The unit lane proves the tool hands the store the version the gate read. What
+// it cannot prove is that the store then REFUSES on it: the version compare
+// lives in Patch.ApplyGuarded, inside the transaction deals.Store.AdvanceDeal
+// opens, and only a database answers that.
+//
+// So everything here is real except the timing: the deal, the pipeline, both
+// writes, the gate, the tier resolver and the version compare. The provider is
+// wrapped only to make the racing close land at the one instant that reproduces
+// the defect — inside the window between the gate's read and the write it
+// admits. A concurrent close is otherwise a coin toss, and a test that
+// reproduces a race one run in fifty is a test that reports green.
+//
+// The authority seam is stubbed (adminSeat) because this is not about who the
+// agent is; the gate's own suite covers that, and a real seat lookup would make
+// this file fail for reasons that are not the race.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/gradionhq/margince/backend/internal/compose/integration"
+	"github.com/gradionhq/margince/backend/internal/modules/agents"
+	"github.com/gradionhq/margince/backend/internal/modules/approvals"
+	"github.com/gradionhq/margince/backend/internal/platform/auth"
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/authz"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
+)
+
+// adminSeat is the authority seam under this race: a full seat with the grants
+// a deal move needs, so the call reaches the write and the refusal that follows
+// is the version compare rather than a missing grant.
+type adminSeat struct{}
+
+func (adminSeat) EffectiveRBAC(context.Context, ids.UUID, ids.UUID) (authz.RBAC, error) {
+	return authz.RBAC{Permissions: integration.AdminPerms}, nil
+}
+
+func (adminSeat) SeatType(context.Context, ids.UUID, ids.UUID) (principal.SeatType, error) {
+	return principal.SeatFull, nil
+}
+
+// closesDuringTheTierRead is the real provider with one instant of theatre: the
+// FIRST read of a deal answers the record as it stands and then, on its way
+// out, closes that deal for real. Every later read sees the closed deal, which
+// is what the racing actor left behind.
+type closesDuringTheTierRead struct {
+	datasource.SystemOfRecordProvider
+	t     *testing.T
+	as    context.Context
+	won   ids.UUID
+	raced bool
+}
+
+func (p *closesDuringTheTierRead) Read(ctx context.Context, ref datasource.EntityRef) (datasource.Record, error) {
+	rec, err := p.SystemOfRecordProvider.Read(ctx, ref)
+	if err != nil || p.raced || ref.Type != datasource.EntityDeal {
+		return rec, err
+	}
+	p.raced = true
+	// The real provider's own write, committed in its own transaction — the
+	// concurrent actor's close, not a hand-made row.
+	if _, err := p.AdvanceDeal(p.as, datasource.AdvanceDealInput{
+		DealID: ref.ID, ToStageID: p.won, Source: "test",
+	}); err != nil {
+		p.t.Fatalf("the racing close did not land, so this test is not about a race: %v", err)
+	}
+	return rec, nil
+}
+
+func TestAConcurrentCloseSurvivesTheAutoExecutedMoveThatRacedIt(t *testing.T) {
+	e := integration.Setup(t)
+	pipeline, open, won := integration.DealFixture(t, e)
+	human := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AdminPerms)
+
+	native := NewProvider(e.Pool)
+	racing := &closesDuringTheTierRead{
+		SystemOfRecordProvider: native, t: t, as: human, won: won.UUID,
+	}
+	registry := agents.NewRegistry(
+		approvalsAdapter{svc: approvals.NewService(e.Pool)}, auth.NewGate(adminSeat{}))
+	// The stage resolver reads pipeline configuration and nothing this race
+	// touches, so it goes straight to the real provider — only the RECORD read
+	// carries the interleaving.
+	agents.RegisterCoreTools(registry, racing, native, nil, fieldOwnership{pool: e.Pool})
+
+	deal := seedDealForPinRace(human, t, native, e.Rep1, pipeline, open)
+
+	// The move the agent asks for is open→open, which is 🟢 and runs unattended
+	// — decided from a read that is already stale by the time the write opens
+	// its transaction.
+	_, err := registry.Invoke(pinRaceAgent(e), "advance_deal",
+		json.RawMessage(`{"deal_id":"`+deal.String()+`","to_stage_id":"`+open.String()+`"}`))
+	if !errors.Is(err, apperrors.ErrVersionSkew) {
+		t.Fatalf("the racing move answered %v, want version skew — the tier gate proved both "+
+			"endpoints open against a deal that closed before the write, and nothing bound the two", err)
+	}
+
+	// The outcome, which is what the issue is actually about: the deal is still
+	// won, with the close the racing actor committed intact.
+	stage, closedAt := dealStageAndClose(t, e, deal)
+	if stage != won.String() {
+		t.Errorf("the deal sits in stage %s, want the won stage the concurrent actor closed it in — "+
+			"it was reopened by a call whose 🟢 tier was decided before that close", stage)
+	}
+	if !closedAt {
+		t.Error("the deal has no close date, so the reopen cleared it — along with the lost reason " +
+			"and the exchange rate frozen at close")
+	}
+}
+
+// seedDealForPinRace creates one deal in the pipeline's open stage, through the
+// real provider, and answers its id.
+func seedDealForPinRace(as context.Context, t *testing.T, p *Provider, owner ids.UUID,
+	pipeline ids.PipelineID, open ids.StageID,
+) ids.UUID {
+	t.Helper()
+	ref, err := p.Create(as, datasource.CreateInput{
+		EntityType: datasource.EntityDeal,
+		Fields: json.RawMessage(`{"name":"Pin race","owner_id":"` + owner.String() +
+			`","pipeline_id":"` + pipeline.String() + `","stage_id":"` + open.String() + `"}`),
+		Source: "test",
+	})
+	if err != nil {
+		t.Fatalf("seeding the deal: %v", err)
+	}
+	return ref.ID
+}
+
+// dealStageAndClose reads what the deal actually is now — the fact that decides
+// whether the refusal held.
+func dealStageAndClose(t *testing.T, e *integration.Env, deal ids.UUID) (string, bool) {
+	t.Helper()
+	var stage ids.UUID
+	var closedAt *string
+	seedAsAdmin(t, e, func(ctx context.Context, tx pgx.Tx) error {
+		return tx.QueryRow(ctx,
+			`SELECT stage_id, closed_at::text FROM deal WHERE id = $1`, deal).Scan(&stage, &closedAt)
+	}, "reading the deal back")
+	return stage.String(), closedAt != nil
+}
+
+// pinRaceAgent is a passport principal holding the write scope — the type the
+// tier gate governs, and the only one the pin is set for.
+func pinRaceAgent(e *integration.Env) context.Context {
+	ctx := principal.WithWorkspaceID(context.Background(), e.WS)
+	ctx = principal.WithCorrelationID(ctx, ids.NewV7())
+	return principal.WithActor(ctx, principal.Principal{
+		Type: principal.PrincipalAgent, ID: "agent:pin-race", SeatType: principal.SeatFull,
+		OnBehalfOf: e.Rep1, UserID: e.Rep1, PassportID: ids.NewV7(),
+		Scopes: principal.NewScopeSet(principal.ScopeRead, principal.ScopeWrite),
+		// Stamped as well as resolved: the tier resolver's read runs on the
+		// context the caller arrived with, and only the admitted context carries
+		// the authority the gate re-derived.
+		Permissions: integration.AdminPerms,
+	})
+}

--- a/backend/internal/modules/agents/approvals.go
+++ b/backend/internal/modules/agents/approvals.go
@@ -16,6 +16,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/gradionhq/margince/backend/internal/platform/auth"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
@@ -122,28 +123,61 @@ func ApprovalRedeemed(ctx context.Context) bool {
 	return ok && redeemed
 }
 
-// pinForWrite answers the version a released write must be conditioned on.
+// pinForWrite answers the version a write must be conditioned on, from the
+// three places a version is established — in the order of who established it.
 //
-// Redemption commits its OWN transaction and the handler then opens a fresh one,
-// so the skew check inside the redemption proves the row was at the approved
-// version when the approval was consumed — not that it still is when the effect
-// lands, and the agent controls both sides of that window (its own 🟢
-// update_record can commit in between). Carrying the pin into the write is what
-// moves the version compare inside the transaction that actually mutates. The
-// REST gate does the same thing by forwarding the pin as If-Match
-// (compose/agentgate.go); this is that fix on the MCP transport.
+// It answers for the tools that CALL it — the two deal moves and the project
+// phase advance — and not for every write on the surface: update_record passes
+// the caller's if_version straight through, so a redeemed retry there is not
+// carried by the released pin the way the REST door's If-Match forward carries
+// it. That asymmetry predates this function and is filed, not implied away.
 //
 // The CALLER's pin wins when it supplied one: it is bound into the diff_hash the
-// redemption verified, so it cannot disagree with what the human approved.
-func pinForWrite(ctx context.Context, callerPin *int64) *int64 {
+// redemption verified, so it cannot disagree with what the human approved. It
+// may not disagree with what the GATE read either, and that is CHECKED rather
+// than assumed. The caller controls this argument, so a version the gate never
+// saw is a version nothing proved — and a caller naming the version the racing
+// close will PRODUCE walks straight through the guard, because the store's
+// compare then passes on precisely the record the tier decision does not
+// describe. A disagreement answers skew rather than being silently overridden,
+// so a caller holding a stale version still learns that it is stale.
+//
+// The RELEASED pin comes next. Redemption commits its OWN transaction and the
+// handler then opens a fresh one, so the skew check inside the redemption proves
+// the row was at the approved version when the approval was consumed — not that
+// it still is when the effect lands, and the agent controls both sides of that
+// window (its own 🟢 update_record can commit in between). Carrying the pin into
+// the write moves the version compare inside the transaction that actually
+// mutates.
+//
+// The ADMITTED pin closes the same window on the auto-execute path, where there
+// is no approval to carry one. A dynamic tier is resolved by READING the record
+// — a deal move runs unattended only when the gate can prove BOTH endpoints of
+// the move open — and that read commits before the write just as a redemption
+// does. Without it a close landing in the window reopens a won deal at the 🟢
+// tier: the same race, one tier down.
+//
+// The REST gate does the same thing by forwarding the pin as If-Match
+// (compose/agentgate.go); this is that fix on the MCP transport.
+//
+//nolint:nilnil // no pin IS an answer here: a write with nothing to condition it on is the ordinary case for a static tier and an unapproved call, and a sentinel for it would make every call site branch on a condition none of them act on
+func pinForWrite(ctx context.Context, callerPin *int64) (*int64, error) {
+	admitted, gateRead := auth.AutoExecutePin(ctx)
 	if callerPin != nil {
-		return callerPin
+		if gateRead && *callerPin != admitted {
+			return nil, fmt.Errorf(
+				"if_version %d is not the version this record was read at (%d) — re-read it and retry: %w",
+				*callerPin, admitted, apperrors.ErrVersionSkew)
+		}
+		return callerPin, nil
 	}
-	released, pinned := ctx.Value(releasedPinKey{}).(int64)
-	if !pinned {
-		return nil
+	if released, pinned := ctx.Value(releasedPinKey{}).(int64); pinned {
+		return &released, nil
 	}
-	return &released
+	if gateRead {
+		return &admitted, nil
+	}
+	return nil, nil
 }
 
 // refuseStagingElsewhere refuses to stage a change whose target's authority

--- a/backend/internal/modules/agents/dealmove.go
+++ b/backend/internal/modules/agents/dealmove.go
@@ -67,19 +67,38 @@ func DealMoveTierInput(
 	if err != nil {
 		return mcp.TierResolverInput{}, err
 	}
-	source, err := dealStageSemantic(ctx, p, stages, dealID)
+	source, observed, err := dealStageSemantic(ctx, p, stages, dealID)
 	if err != nil {
 		return mcp.TierResolverInput{}, err
 	}
-	return mcp.TierResolverInput{
+	in := mcp.TierResolverInput{
 		Args:                args,
 		SourceStageSemantic: source,
 		TargetStageSemantic: target,
 		PipelineID:          pipelineID.String(),
-	}, nil
+	}
+	// The version of the deal the SOURCE semantic was read from, which is the
+	// whole of what this gate proved about the record. It travels so the write
+	// the gate admits can be conditioned on it: the read commits first, and an
+	// agent can close the deal in between with its own call. One read, one
+	// moment — the rule dealMoveSummary states for the approval sentence,
+	// applied to the auto-executed move.
+	//
+	// A record with NO version is left unreported rather than pinned at zero. A
+	// mirror row answers zero because the mirror keeps no version of its own,
+	// and zero is not a version any write can be conditioned on — the REST door
+	// would send `If-Match: 0`, which the contract's own parser rejects as a
+	// malformed header the caller never sent. Unreported means the gate raises
+	// to confirm-first, which is the honest answer: this server could not
+	// establish the record's state, so a human decides.
+	if observed > 0 {
+		in.ObservedVersion = &observed
+	}
+	return in, nil
 }
 
-// dealStageSemantic reads the semantic of the stage a deal is currently in.
+// dealStageSemantic reads the semantic of the stage a deal is currently in, and
+// the version of the deal it read it from.
 //
 // It goes through the same StageResolver the target does, so a renamed "Won"
 // column is judged by its semantic at both ends rather than by its label at one.
@@ -87,16 +106,22 @@ func DealMoveTierInput(
 // the resolver would treat empty as not-open and raise, which is safe, but the
 // caller deserves the real reason instead of an approval request for a deal this
 // server could not read.
-func dealStageSemantic(ctx context.Context, p datasource.SystemOfRecordProvider, stages StageResolver, dealID ids.UUID) (string, error) {
+//
+// The version comes back from the SAME record as the semantic. Reading it again
+// would be a second moment, and a tier decided at one moment and pinned at
+// another binds the write to a state nothing judged.
+func dealStageSemantic(
+	ctx context.Context, p datasource.SystemOfRecordProvider, stages StageResolver, dealID ids.UUID,
+) (semantic string, version int64, err error) {
 	rec, err := p.Read(ctx, datasource.EntityRef{Type: datasource.EntityDeal, ID: dealID})
 	if err != nil {
-		return "", err
+		return "", 0, err
 	}
 	var fields struct {
 		StageID ids.UUID `json:"stage_id"`
 	}
 	if err := json.Unmarshal(rec.Fields, &fields); err != nil {
-		return "", fmt.Errorf("crmagents: deal %s read back without a readable stage: %w", dealID, err)
+		return "", 0, fmt.Errorf("crmagents: deal %s read back without a readable stage: %w", dealID, err)
 	}
 	// An ABSENT stage_id decodes without error and leaves the zero id, which a
 	// resolver would answer with an empty semantic — a raise, so safe, but a
@@ -104,13 +129,13 @@ func dealStageSemantic(ctx context.Context, p datasource.SystemOfRecordProvider,
 	// whose current stage this server never established, and the human would
 	// have no way to know that is the question.
 	if fields.StageID.IsZero() {
-		return "", fmt.Errorf("crmagents: deal %s read back with no stage to resolve", dealID)
+		return "", 0, fmt.Errorf("crmagents: deal %s read back with no stage to resolve", dealID)
 	}
-	semantic, _, err := stages.StageSemantic(ctx, fields.StageID)
+	semantic, _, err = stages.StageSemantic(ctx, fields.StageID)
 	if err != nil {
-		return "", err
+		return "", 0, err
 	}
-	return semantic, nil
+	return semantic, rec.Version, nil
 }
 
 // dealMoveSummary is the sentence a human is asked to approve. It names the move

--- a/backend/internal/modules/agents/dealmovepin_test.go
+++ b/backend/internal/modules/agents/dealmovepin_test.go
@@ -1,0 +1,289 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package agents
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strconv"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/platform/auth"
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/mcp"
+)
+
+// The defect, written before the fix.
+//
+// #610 made the tier turn on BOTH endpoints, so a move that reopens a closed
+// deal raises to confirm-first. It proves both endpoints open from a read that
+// commits before the write does, and on the auto-execute path nothing binds the
+// two: the deal can close in the window, and the 🟢 write then lands on a
+// terminal deal — clearing closed_at, the lost reason and the FX rate frozen at
+// close, with no human in the loop.
+//
+// The interleaving is what has to be tested, so the racing close happens at the
+// one moment that reproduces it: inside the tier gate's own read. The provider
+// below supplies the TIMING and nothing else — the version compare it then
+// applies is the one deals.Store.AdvanceDeal applies through ApplyGuarded, and
+// the integration lane drives that same sequence against real Postgres.
+
+// closesUnderneath is a deal that a concurrent actor closes during the tier
+// gate's read: the FIRST read answers the deal as the gate must see it (open,
+// at the version it then holds) and, on its way out, moves the row to won and
+// bumps the version. Every later read sees the closed deal, which is what the
+// racing actor left behind.
+type closesUnderneath struct {
+	datasource.SystemOfRecordProvider
+	openStage, wonStage ids.UUID
+
+	version int64
+	stage   ids.UUID
+	raced   bool
+
+	// gotIfVersion is what the write was conditioned on, and whether it was
+	// conditioned at all — the whole question this file asks.
+	gotIfVersion *int64
+	wrote        bool
+}
+
+func (p *closesUnderneath) Read(context.Context, datasource.EntityRef) (datasource.Record, error) {
+	rec := datasource.Record{
+		Ref:     datasource.EntityRef{Type: datasource.EntityDeal, ID: ids.NewV7()},
+		Fields:  json.RawMessage(`{"name":"Acme renewal","stage_id":"` + p.stage.String() + `"}`),
+		Version: p.version,
+	}
+	if !p.raced {
+		// The concurrent close, landing in the window between the gate's read
+		// and the write it admits.
+		p.raced = true
+		p.stage, p.version = p.wonStage, p.version+1
+	}
+	return rec, nil
+}
+
+func (p *closesUnderneath) AdvanceDeal(_ context.Context, in datasource.AdvanceDealInput) (datasource.EntityRef, error) {
+	p.gotIfVersion = in.IfVersion
+	if in.IfVersion != nil && *in.IfVersion != p.version {
+		// The store's own answer: Patch.ApplyGuarded refuses a write whose
+		// pinned version is not the row's.
+		return datasource.EntityRef{}, apperrors.ErrVersionSkew
+	}
+	p.wrote = true
+	return datasource.EntityRef{Type: datasource.EntityDeal, ID: in.DealID}, nil
+}
+
+// agentInvoking is a full-seat agent principal with the scope a deal move
+// needs — the caller the gate exists to bound.
+func agentInvoking() context.Context {
+	ctx := principal.WithWorkspaceID(context.Background(), ids.NewV7())
+	return principal.WithActor(ctx, principal.Principal{
+		Type: principal.PrincipalAgent, ID: "agent:pin", OnBehalfOf: ids.NewV7(),
+		Scopes: principal.NewScopeSet(principal.ScopeWrite),
+	})
+}
+
+// racingRegistry registers one dynamic deal-move tool over a deal that closes
+// during the tier read.
+func racingRegistry(t *testing.T, build func(datasource.SystemOfRecordProvider, StageResolver) mcp.Tool) (*Registry, *closesUnderneath) {
+	t.Helper()
+	openStage, wonStage := ids.NewV7(), ids.NewV7()
+	provider := &closesUnderneath{
+		openStage: openStage, wonStage: wonStage,
+		version: 7, stage: openStage,
+	}
+	stages := &reopenProbeStages{semantics: map[ids.UUID]string{openStage: "open", wonStage: "won"}}
+	r := NewRegistry(nil, auth.NewGate(fullSeatAuthority{}))
+	r.Register(build(provider, stages))
+	return r, provider
+}
+
+func TestAConcurrentCloseCannotReopenADealThroughTheAutoExecutedMove(t *testing.T) {
+	for name, tc := range map[string]struct {
+		tool  string
+		build func(datasource.SystemOfRecordProvider, StageResolver) mcp.Tool
+	}{
+		"advance_deal": {"advance_deal", func(p datasource.SystemOfRecordProvider, s StageResolver) mcp.Tool {
+			return advanceDeal{p: p, stages: s}
+		}},
+		"progress_deal": {"progress_deal", func(p datasource.SystemOfRecordProvider, s StageResolver) mcp.Tool {
+			return progressDeal{p: p, stages: s}
+		}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			r, provider := racingRegistry(t, tc.build)
+			args := json.RawMessage(`{"deal_id":"` + ids.NewV7().String() +
+				`","to_stage_id":"` + provider.openStage.String() + `"}`)
+
+			_, err := r.Invoke(agentInvoking(), tc.tool, args)
+
+			if provider.gotIfVersion == nil {
+				t.Fatal("the write carried no version pin, so the tier gate's proof that both " +
+					"endpoints were open bound nothing — a close landing in that window reopens the deal")
+			}
+			if *provider.gotIfVersion != 7 {
+				t.Errorf("the write pinned version %d, want 7 — the version the tier decision was read from",
+					*provider.gotIfVersion)
+			}
+			if !errors.Is(err, apperrors.ErrVersionSkew) {
+				t.Errorf("the racing move answered %v, want version skew", err)
+			}
+			if provider.wrote {
+				t.Error("the deal was reopened by a call whose 🟢 tier was decided before it closed")
+			}
+		})
+	}
+}
+
+// The pin binds the read; it does not refuse the ordinary move. Without this a
+// fix could pass the test above by refusing every unattended deal move, which
+// would put a human in front of every routine stage change on the surface.
+func TestAnUncontendedMoveBetweenOpenStagesStillRunsUnattended(t *testing.T) {
+	openStage := ids.NewV7()
+	provider := &closesUnderneath{
+		// Both endpoints are the same open stage and the racing close never
+		// fires, so this is the routine move with nothing contending.
+		openStage: openStage, wonStage: openStage,
+		version: 3, stage: openStage, raced: true,
+	}
+	stages := &reopenProbeStages{semantics: map[ids.UUID]string{openStage: "open"}}
+	r := NewRegistry(nil, auth.NewGate(fullSeatAuthority{}))
+	r.Register(advanceDeal{p: provider, stages: stages})
+
+	args := json.RawMessage(`{"deal_id":"` + ids.NewV7().String() +
+		`","to_stage_id":"` + openStage.String() + `"}`)
+	if _, err := r.Invoke(agentInvoking(), "advance_deal", args); err != nil {
+		t.Fatalf("the routine open→open move was refused: %v", err)
+	}
+	if !provider.wrote {
+		t.Fatal("the routine move did not reach the store")
+	}
+	if provider.gotIfVersion == nil || *provider.gotIfVersion != 3 {
+		t.Errorf("the routine move pinned %v, want the observed version 3", provider.gotIfVersion)
+	}
+}
+
+// A caller's own if_version may not disagree with what the gate read.
+//
+// The caller controls this argument, so a pin the gate never saw is a pin
+// nothing proved: a FUTURE version defeats the guard outright — the deal closes
+// in the window, the row lands on exactly the version the caller named, and the
+// store's compare passes on a record the tier decision never described. A stale
+// one is the ordinary optimistic-concurrency case and was already refused, but
+// by the store rather than here.
+//
+// Both are one rule: on an auto-executed dynamic call the write is conditioned
+// on the version the tier was resolved from, and a caller who names a different
+// one is told so rather than served.
+func TestACallerPinThatDisagreesWithTheGatesReadIsRefused(t *testing.T) {
+	for name, tc := range map[string]struct {
+		callerPin int64
+		// racing says whether a concurrent close lands in the window. The FUTURE
+		// pin only bites when it does: the caller names the version the row will
+		// have AFTER the close, so the store's compare passes on exactly the
+		// record the tier decision does not describe.
+		racing bool
+	}{
+		"a FUTURE version the gate never read":   {callerPin: 8, racing: true},
+		"a stale version the caller still holds": {callerPin: 4, racing: false},
+	} {
+		t.Run(name, func(t *testing.T) {
+			openStage, wonStage := ids.NewV7(), ids.NewV7()
+			provider := &closesUnderneath{
+				openStage: openStage, wonStage: wonStage,
+				version: 7, stage: openStage, raced: !tc.racing,
+			}
+			stages := &reopenProbeStages{semantics: map[ids.UUID]string{
+				openStage: "open", wonStage: "won",
+			}}
+			r := NewRegistry(nil, auth.NewGate(fullSeatAuthority{}))
+			r.Register(advanceDeal{p: provider, stages: stages})
+
+			args := json.RawMessage(`{"deal_id":"` + ids.NewV7().String() +
+				`","to_stage_id":"` + openStage.String() +
+				`","if_version":` + strconv.FormatInt(tc.callerPin, 10) + `}`)
+			if _, err := r.Invoke(agentInvoking(), "advance_deal", args); !errors.Is(err, apperrors.ErrVersionSkew) {
+				t.Fatalf("answered %v, want version skew", err)
+			}
+			if provider.wrote {
+				t.Error("the write ran on a version the tier decision never described — a caller " +
+					"naming the version the racing close produces walks straight through the guard")
+			}
+		})
+	}
+}
+
+// A caller that names the version the gate read is served, because the two
+// agree about which record this is.
+func TestACallerPinThatMatchesTheGatesReadIsHonoured(t *testing.T) {
+	openStage := ids.NewV7()
+	provider := &closesUnderneath{
+		openStage: openStage, wonStage: openStage,
+		version: 7, stage: openStage, raced: true,
+	}
+	stages := &reopenProbeStages{semantics: map[ids.UUID]string{openStage: "open"}}
+	r := NewRegistry(nil, auth.NewGate(fullSeatAuthority{}))
+	r.Register(advanceDeal{p: provider, stages: stages})
+
+	args := json.RawMessage(`{"deal_id":"` + ids.NewV7().String() +
+		`","to_stage_id":"` + openStage.String() + `","if_version":7}`)
+	if _, err := r.Invoke(agentInvoking(), "advance_deal", args); err != nil {
+		t.Fatalf("a caller pinning the version the gate read was refused: %v", err)
+	}
+	if provider.gotIfVersion == nil || *provider.gotIfVersion != 7 {
+		t.Errorf("the write pinned %v, want 7", provider.gotIfVersion)
+	}
+}
+
+// The derived gate. A dynamic tier means the tool reads a record to decide
+// whether it may run unattended; a tool that then writes without binding that
+// read is #614. Deriving it from the registered set rather than naming the two
+// tools is what makes the third dynamic tool meet it on the day it registers.
+func TestEveryDynamicTierToolPinsTheReadItsTierTurnedOn(t *testing.T) {
+	openStage := ids.NewV7()
+	provider := &closesUnderneath{
+		openStage: openStage, wonStage: openStage,
+		version: 11, stage: openStage, raced: true,
+	}
+	stages := &reopenProbeStages{semantics: map[ids.UUID]string{openStage: "open"}}
+	r := NewRegistry(nil, auth.NewGate(fullSeatAuthority{}))
+	RegisterCoreTools(r, provider, stages, nil, nil)
+
+	args := json.RawMessage(`{"deal_id":"` + ids.NewV7().String() +
+		`","to_stage_id":"` + openStage.String() + `"}`)
+
+	var dynamic int
+	for _, spec := range r.Specs() {
+		if spec.Tier != mcp.TierDynamic {
+			continue
+		}
+		dynamic++
+		tool, ok := r.tools[spec.Name].(dynamicTool)
+		if !ok {
+			t.Errorf("%s declares a dynamic tier but cannot build a resolver input", spec.Name)
+			continue
+		}
+		in, err := tool.ResolverInput(context.Background(), args)
+		if err != nil {
+			t.Errorf("%s: resolving: %v", spec.Name, err)
+			continue
+		}
+		if in.ObservedVersion == nil {
+			t.Errorf("%s decides its tier from a record it read and reports no version for it, "+
+				"so an auto-executed write cannot be bound to what the gate saw", spec.Name)
+			continue
+		}
+		if *in.ObservedVersion != 11 {
+			t.Errorf("%s reported version %d, want the %d it read the record at",
+				spec.Name, *in.ObservedVersion, 11)
+		}
+	}
+	if dynamic == 0 {
+		t.Fatal("no dynamic-tier tool was registered, so this gate judged nothing")
+	}
+}

--- a/backend/internal/modules/agents/tools.go
+++ b/backend/internal/modules/agents/tools.go
@@ -364,12 +364,16 @@ func (t advanceDeal) Handle(ctx context.Context, in json.RawMessage) (json.RawMe
 	if err := decodeArgs(in, &args); err != nil {
 		return nil, err
 	}
+	pin, err := pinForWrite(ctx, args.IfVersion)
+	if err != nil {
+		return nil, err
+	}
 	ref, err := t.p.AdvanceDeal(ctx, datasource.AdvanceDealInput{
 		DealID:     args.DealID,
 		ToStageID:  args.ToStageID,
 		LostReason: args.LostReason,
 		Source:     toolSource,
-		IfVersion:  pinForWrite(ctx, args.IfVersion),
+		IfVersion:  pin,
 	})
 	if err != nil {
 		return nil, err

--- a/backend/internal/modules/agents/tools_lifecycle.go
+++ b/backend/internal/modules/agents/tools_lifecycle.go
@@ -237,9 +237,12 @@ func (t advanceProjectPhase) Handle(ctx context.Context, in json.RawMessage) (js
 	// approved call that named none — the version the human approved
 	// (pinForWrite). A version this tool read microseconds earlier would be
 	// compared against itself and could never detect skew: a pin in name only.
+	pin, err := pinForWrite(ctx, args.IfVersion)
+	if err != nil {
+		return nil, err
+	}
 	noteEvidence(ctx, datasource.EntityProject, args.ProjectID)
-	return t.advancer.AdvanceProjectPhase(ctx, args.ProjectID, args.ToPhase, args.Reason,
-		pinForWrite(ctx, args.IfVersion))
+	return t.advancer.AdvanceProjectPhase(ctx, args.ProjectID, args.ToPhase, args.Reason, pin)
 }
 
 // readArgs decodes and admits the phase in one place, so the staging path and

--- a/backend/internal/modules/agents/tools_progress.go
+++ b/backend/internal/modules/agents/tools_progress.go
@@ -101,12 +101,16 @@ func (t progressDeal) Handle(ctx context.Context, in json.RawMessage) (json.RawM
 	if err := decodeArgs(in, &args); err != nil {
 		return nil, err
 	}
+	pin, err := pinForWrite(ctx, args.IfVersion)
+	if err != nil {
+		return nil, err
+	}
 	if _, err := t.p.AdvanceDeal(ctx, datasource.AdvanceDealInput{
 		DealID:     args.DealID,
 		ToStageID:  args.ToStageID,
 		LostReason: args.LostReason,
 		Source:     toolSource,
-		IfVersion:  pinForWrite(ctx, args.IfVersion),
+		IfVersion:  pin,
 	}); err != nil {
 		return nil, err
 	}

--- a/backend/internal/platform/auth/admit.go
+++ b/backend/internal/platform/auth/admit.go
@@ -131,23 +131,87 @@ func (g *Gate) Admit(ctx context.Context, spec mcp.ToolSpec, resolve func() (mcp
 		return ctx, err
 	}
 
-	tier := spec.Tier
-	if tier == mcp.TierDynamic {
-		if spec.TierResolver == nil {
-			// Registration should have refused this spec; failing closed
-			// here keeps a mis-registered tool from defaulting to 🟢.
-			return ctx, fmt.Errorf("gate: %s is TierDynamic without a resolver", spec.Name)
-		}
-		in, err := resolve()
-		if err != nil {
-			return ctx, err
-		}
-		tier = spec.TierResolver(in)
+	tier, observed, err := resolveTier(spec, resolve)
+	if err != nil {
+		return ctx, err
+	}
+	// A dynamic tier that cannot name the record it was read from is RAISED, not
+	// admitted. Without this the bind below is advisory: a dynamic tool that
+	// answers no version would run unattended with nothing conditioning its
+	// write, which is the unpinned auto-execute this whole path exists to end —
+	// restored by omission rather than by decision. Raising is the shape the
+	// resolver contract already takes (it may only ever raise), and a human is
+	// the safe answer to "this server could not establish the record's state".
+	if tier == mcp.TierAutoExecute && spec.Tier == mcp.TierDynamic && observed == nil {
+		return ctx, fmt.Errorf(
+			"gate: %s resolved to auto-execute without naming the record version it was resolved from: %w",
+			spec.Name, apperrors.ErrRequiresApproval)
 	}
 	if tier != mcp.TierAutoExecute {
 		return ctx, fmt.Errorf("gate: %s is a confirm-first (🟡) action: %w", spec.Name, apperrors.ErrRequiresApproval)
 	}
+	// The tier said this call may run unattended, and for a dynamic tool it said
+	// so by reading a record. That read commits before the write it admits, and
+	// the agent controls both sides of the window, so the answer is only true of
+	// the record as it WAS. Binding the version here is what makes the write
+	// re-check it inside the transaction that mutates, where a record that moved
+	// in between loses to the version compare instead of to timing.
+	//
+	// Set HERE rather than by each dispatch layer: the MCP registry and the REST
+	// agent gate both come through Admit, and a rule spelled twice on this seam
+	// is how the tier itself came to judge both endpoints of a deal move on one
+	// door and only the destination on the other.
+	if observed != nil {
+		ctx = withAutoExecutePin(ctx, *observed)
+	}
 	return ctx, nil
+}
+
+// resolveTier answers the call's effective tier, plus the version of the record
+// a dynamic tier was decided from — nil when the tier turned on no record, which
+// is every static tier and any dynamic tool that reports none.
+func resolveTier(spec mcp.ToolSpec, resolve func() (mcp.TierResolverInput, error)) (mcp.RiskTier, *int64, error) {
+	if spec.Tier != mcp.TierDynamic {
+		// A static tier is the tool's whole tier: nothing was read to decide it,
+		// so a resolver input built for one names no record this call proved
+		// anything about.
+		return spec.Tier, nil, nil
+	}
+	if spec.TierResolver == nil {
+		// Registration should have refused this spec; failing closed
+		// here keeps a mis-registered tool from defaulting to 🟢.
+		return spec.Tier, nil, fmt.Errorf("gate: %s is TierDynamic without a resolver", spec.Name)
+	}
+	in, err := resolve()
+	if err != nil {
+		return spec.Tier, nil, err
+	}
+	return spec.TierResolver(in), in.ObservedVersion, nil
+}
+
+// autoExecutePinKey carries the version a dynamic tier was resolved from, on a
+// call this gate admitted at the auto-execute tier.
+type autoExecutePinKey struct{}
+
+// withAutoExecutePin is unexported and reached from exactly one place: the 🟢
+// outcome of Admit. The pin asserts that THIS gate proved THIS record's state,
+// and a caller able to mint one could condition its own write on a version
+// nothing ever checked.
+func withAutoExecutePin(ctx context.Context, version int64) context.Context {
+	return context.WithValue(ctx, autoExecutePinKey{}, version)
+}
+
+// AutoExecutePin answers the version the gate resolved this call's dynamic tier
+// from, for the transports that turn it into the write's precondition — an
+// `if_version` argument on the MCP door, an `If-Match` header on the REST one.
+//
+// ok is false for every call whose tier was not decided by reading a record: a
+// static tier, a tier raised to confirm-first (whose pin is the approval's,
+// taken at the moment the human was shown the record), and a human principal,
+// whom the gate's tier model does not govern.
+func AutoExecutePin(ctx context.Context) (version int64, ok bool) {
+	version, ok = ctx.Value(autoExecutePinKey{}).(int64)
+	return version, ok
 }
 
 // deniedIfGone maps a vanished granting human (revoked, archived,

--- a/backend/internal/platform/auth/admit_test.go
+++ b/backend/internal/platform/auth/admit_test.go
@@ -92,8 +92,11 @@ func TestDynamicTierIsResolvedPerCall(t *testing.T) {
 		Tier: mcp.TierDynamic, TierResolver: resolver,
 	}
 
+	// The 🟢 arm names the version its record was read at, because an
+	// auto-executed dynamic call that names none is raised rather than run —
+	// see TestADynamicTierThatNamesNoRecordVersionIsRaisedRatherThanRun.
 	open := func() (mcp.TierResolverInput, error) {
-		return mcp.TierResolverInput{TargetStageSemantic: "open"}, nil
+		return mcp.TierResolverInput{TargetStageSemantic: "open", ObservedVersion: version(1)}, nil
 	}
 	if _, err := fullSeatGate().Admit(agentCtx(principal.ScopeWrite), spec, open); err != nil {
 		t.Fatalf("open→open resolves 🟢: %v", err)

--- a/backend/internal/platform/auth/admitpin_test.go
+++ b/backend/internal/platform/auth/admitpin_test.go
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package auth
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/mcp"
+)
+
+// A dynamic tier is resolved from a record, and the read that resolves it
+// commits before the write it admits. Admit is the one place that knows both
+// what was read and what the tier came out as, so it is the one place that can
+// bind them — and being the ONE place is what keeps the two dispatch layers
+// from each having to remember.
+//
+// The pin is a consequence of admitting at 🟢. It appears on nothing else: not
+// on a static tier (nothing was read to decide it), not on a raised one (the
+// approval carries its own pin, taken at the moment the human was shown the
+// record), and not on a human (the gate does not govern them at all).
+
+func version(v int64) *int64 { return &v }
+
+// dynamicSpec is the one dynamic-tier tool on the surface, with its resolver
+// stubbed to the verdict a case is about: what Admit does with the version is
+// a property of the OUTCOME, not of how the resolver reached it.
+func dynamicSpec(resolved mcp.RiskTier) mcp.ToolSpec {
+	return mcp.ToolSpec{
+		Name: "advance_deal", RequiredScope: principal.ScopeWrite, Tier: mcp.TierDynamic,
+		TierResolver: func(mcp.TierResolverInput) mcp.RiskTier { return resolved },
+	}
+}
+
+func resolvesTo(in mcp.TierResolverInput) func() (mcp.TierResolverInput, error) {
+	return func() (mcp.TierResolverInput, error) { return in, nil }
+}
+
+func TestAdmitPinsTheVersionADynamicTierWasReadFrom(t *testing.T) {
+	spec := dynamicSpec(mcp.TierAutoExecute)
+	resolve := resolvesTo(mcp.TierResolverInput{
+		SourceStageSemantic: "open", TargetStageSemantic: "open", ObservedVersion: version(9),
+	})
+
+	admitted, err := fullSeatGate().Admit(agentCtx(principal.ScopeWrite), spec, resolve)
+	if err != nil {
+		t.Fatalf("the routine move was refused: %v", err)
+	}
+	pin, ok := AutoExecutePin(admitted)
+	if !ok {
+		t.Fatal("an auto-executed dynamic call carries no pin, so the write it admits binds nothing " +
+			"to the record state the tier was decided from")
+	}
+	if pin != 9 {
+		t.Errorf("pin = %d, want the 9 the tier was read at", pin)
+	}
+}
+
+// A dynamic tool that cannot say which record its tier was read from does not
+// get to run unattended.
+//
+// This is the seam's fail-CLOSED half, and without it the whole guard is
+// advisory: a dynamic tool answering no version would be admitted at 🟢 and
+// written with no pin — #614's exact shape, restored by omission. Raising is the
+// right refusal because a resolver may only ever raise, and because the safe
+// answer to "this server could not establish the record's state" is a human,
+// not a write.
+func TestADynamicTierThatNamesNoRecordVersionIsRaisedRatherThanRun(t *testing.T) {
+	spec := dynamicSpec(mcp.TierAutoExecute)
+	resolve := resolvesTo(mcp.TierResolverInput{SourceStageSemantic: "open", TargetStageSemantic: "open"})
+
+	admitted, err := fullSeatGate().Admit(agentCtx(principal.ScopeWrite), spec, resolve)
+	if !errors.Is(err, apperrors.ErrRequiresApproval) {
+		t.Fatalf("admitted → %v, want confirm-first: a 🟢 write with nothing to bind is the "+
+			"unpinned auto-execute this gate exists to end", err)
+	}
+	if pin, ok := AutoExecutePin(admitted); ok {
+		t.Errorf("a refused call carries pin %d", pin)
+	}
+}
+
+func TestAdmitPinsNothingItDidNotAdmitAtTheAutoExecuteTier(t *testing.T) {
+	for name, tc := range map[string]struct {
+		ctx     context.Context
+		spec    mcp.ToolSpec
+		resolve func() (mcp.TierResolverInput, error)
+	}{
+		"a static tier read no record to decide itself": {
+			agentCtx(principal.ScopeWrite),
+			mcp.ToolSpec{Name: "create_record", RequiredScope: principal.ScopeWrite, Tier: mcp.TierAutoExecute},
+			resolvesTo(mcp.TierResolverInput{ObservedVersion: version(4)}),
+		},
+		"a raised tier is carried by the approval's own pin": {
+			agentCtx(principal.ScopeWrite),
+			dynamicSpec(mcp.TierConfirmationRequired),
+			resolvesTo(mcp.TierResolverInput{ObservedVersion: version(4)}),
+		},
+		"a human does not ride the gate's tier model at all": {
+			principal.WithActor(principal.WithWorkspaceID(context.Background(), testWorkspace),
+				principal.Principal{Type: principal.PrincipalHuman, ID: "user:test"}),
+			dynamicSpec(mcp.TierAutoExecute),
+			resolvesTo(mcp.TierResolverInput{ObservedVersion: version(4)}),
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			admitted, _ := fullSeatGate().Admit(tc.ctx, tc.spec, tc.resolve)
+			if pin, ok := AutoExecutePin(admitted); ok {
+				t.Errorf("pinned version %d — a write conditioned on a version this call never "+
+					"proved anything about fails for a reason nobody can act on", pin)
+			}
+		})
+	}
+}

--- a/backend/internal/shared/ports/mcp/mcp.go
+++ b/backend/internal/shared/ports/mcp/mcp.go
@@ -131,6 +131,20 @@ type TierResolverInput struct {
 	SourceStageSemantic string
 	TargetStageSemantic string
 	PipelineID          string
+	// ObservedVersion is the version of the record the tier decision was read
+	// from, and it is what binds that decision to the write it admits.
+	//
+	// A dynamic tier is resolved from a record's state, and that read commits
+	// before the write does. Without the version, an auto-execute answer means
+	// only "the record permitted this when the gate looked" — the record can
+	// change in the window, and the agent controls both sides of it. The
+	// admission point carries this into the write as its precondition, so a
+	// record that moved in between loses to the version compare instead of to
+	// timing.
+	//
+	// nil means the tool's tier did not turn on a record's state, so there is
+	// nothing to bind.
+	ObservedVersion *int64
 }
 
 // Registry admits and dispatches tools. Registration is init()-time,


### PR DESCRIPTION
Closes #614.

## The hole

`#610` made the deal-move tier turn on **both** endpoints, so reopening a closed deal
raises to confirm-first. It proves both endpoints open from a read that commits before
the write does, and on the auto-execute path nothing bound the two:

| step | where |
|---|---|
| 1 | `agents.DealMoveTierInput` reads the deal to resolve the SOURCE semantic, and discards the record |
| 2 | `auth.Gate.Admit` resolves 🟢 and returns |
| 3 | `Handle` writes with `pinForWrite(ctx, args.IfVersion)` — **nil**, because `releasedPinKey` is only ever set by `RedeemAndMark` |

A close landing between (1) and (3) reopens a won deal at the 🟢 tier: `closed_at`, the
lost reason and the FX rate frozen at close are all cleared, with no human in the loop.
`pinForWrite`'s own comment already named the generalisation — *the agent controls both
sides of that window* — and applied it to the redeemed path only.

Both doors had it: MCP through `registry.tierResolverFor`, REST through
`compose/agentgate.go`'s `advanceDealTierInput`. One builder, so one fix.

## The fix

**The read that decides the tier already holds the version. Carry it.**

- `mcp.TierResolverInput` gains `ObservedVersion *int64`, filled by `DealMoveTierInput`
  from the record `dealStageSemantic` already reads — one read, one moment, no extra query.
- `auth.Gate.Admit`, the one admission point both doors call, puts it in the returned
  context **on the auto-execute outcome and nowhere else**. Set there rather than in each
  dispatch layer, for the reason `RedeemAndMark`'s comment already gives for redemption:
  a rule spelled twice on this seam is how the tier itself came to judge both endpoints
  on one door and only the destination on the other.
- MCP consumes it in `pinForWrite`; REST forwards it as `If-Match`, which is
  `redeemIfPresented`'s existing forward one tier down.

The store already refuses the mismatch — `Patch.ApplyGuarded` inside
`deals.Store.AdvanceDeal`'s transaction, which answers the contract's `version_skew` 409.

### Two things review changed, and both were real

**A caller's own pin may not disagree with what the gate read.** The first draft preferred
the caller's `if_version` / `If-Match` unchecked, on the reasoning that it is "stricter or
equal in every case that matters". That comment was false, and it is the defect class this
repo hunts by name. The caller controls the argument, so a version nobody read is a
version nothing proved: an agent that names the version the racing close will **produce**
walks straight through, because the store's compare then passes on precisely the record
the tier decision does not describe. That converts a coin-toss race into an armable trap —
**reproduced live, 25 reopens in 30 attempts** (table below). A disagreement now answers
skew, which is also what a caller holding a genuinely stale version already got, one layer
down.

**The seam fails closed as well as binding.** A dynamic tier that resolves to auto-execute
without naming the record it was read from is now **raised**, not run. Without it the
guard was advisory: a dynamic tool reporting no version would be admitted 🟢 and written
unpinned — #614's exact shape, restored by omission. Raising is the shape the resolver
contract already takes (it may only ever raise), and it is the honest answer for a record
carrying no version of its own: an overlay mirror row answers `0`, and zero conditions no
write (the REST door would emit `If-Match: 0`, which the contract's own parser rejects as
a malformed header the caller never sent).

## The derived gate

Review-loop rule 2 — derive the obligation, don't maintain a list.

- **`TestEveryDynamicTierToolPinsTheReadItsTierTurnedOn`** walks the registered tool set
  and requires every `TierDynamic` spec's `ResolverInput` to report the version its tier
  was read from.
- **`TestADynamicTierThatNamesNoRecordVersionIsRaisedRatherThanRun`** holds the production
  half, so the rule does not depend on the test finding every registrar.
- **`TestAdmitPinsNothingItDidNotAdmitAtTheAutoExecuteTier`** holds the other side: no pin
  on a static tier, on a raised tier, or for a human principal.

**Every one of these was verified by breaking it** — each guard was re-run against the
defect it describes and confirmed red first.

## Proof

### Unit and integration

The race is driven against **real Postgres** in
`compose/dealmovepin_integration_test.go`: the concurrent close is a real `AdvanceDeal`
committed through the real provider, inside the window between the gate's read and the
write it admits. Everything is real except the timing — a concurrent close is otherwise a
coin toss, and a test that reproduces a race one run in fifty is a test that reports green.

```
make check-backend      exit 0
make craft-static       PASS — 0 blocker, 0 major, 0 minor (backend, extensions, fixtures)
make test-integration   OK: integration passed with 0 skips (31 packages, parallel)
```

Coverage on the new code: `pinAdmittedWrite` 100%, `pinForWrite` 100%,
`dealStageSemantic` 100%, `AutoExecutePin` 100%, `withAutoExecutePin` 100%,
`DealMoveTierInput` 85.7%, `resolveTier` 87.5%, `Admit` 96.9%.

The `agent_loop` prompt-version gate is **byte-identical to `origin/main`**, so no
certification record went stale and the paid lane owes nothing. No tool description, input
schema or contract prose moved.

### Live UAT

Two racers fired at the same instant against a real stack (`DEV_SLUG=pin614`): an agent
passport doing an open→open 🟢 move on `POST /v1/deals/{id}/advance`, and a human closing
the same deal as won. A **reopen** is the defect signature — the close returns 200 and the
deal nevertheless ends in an open stage with no `closed_at`.

| build | agent's pin | runs | reopened | refused as skew |
|---|---|---|---|---|
| `origin/main` | none | 40 | **36** | 0 |
| first draft of this fix | predicts the post-close version as `If-Match` | 30 | **25** | 0 |
| this PR | predicts the post-close version as `If-Match` | 30 | **0** | 30 |
| this PR | none | 40 | **0** | 40 |

The window is genuinely being hit — the refusals are the race landing, not the race being
missed.

And the routine paths still work, on the same stack:

```
no race, no caller pin ............................. 200, stage moved, version 2
no race, caller pins the version it read (2) ....... 200
no race, caller pins a version nobody read (99) .... 409 version_skew
    "If-Match 99 is not the version this record was read at (3) — re-read it and retry"
```

Through the MCP surface, driven by the official Inspector CLI
(`npx @modelcontextprotocol/inspector --cli`, `protocolEra: modern`, passport bearer):

- `tools/list` — 30 tools, `advance_deal` and `progress_deal` present;
- routine open→open move — succeeds, answers the record at version 2;
- stale `if_version` — `isError: true` with an actionable message, *"The record changed
  since it was read; re-read it and retry with the new version."*;
- reopening the now-won deal — still 🟡, staged as an approval with the redemption
  instructions.

## What this deliberately does not do

Three findings from the two reviews are real, out of this change's scope, and filed rather
than implied away:

- **#811** — the tier is also resolved from stage **semantics**, which are mutable
  independently of any deal, so the deal's version cannot bind them. The racing actor
  there is a human admin (stage config is `x-agent-access: human-only`), not the agent, so
  it is a different risk needing a different mechanism.
- **#812** — the REST door ignores a presented `X-Approval-Token` when a dynamic call
  resolves 🟢, where MCP redeems it. Predates this branch.
- **#813** — `update_record`'s MCP write ignores the released approval pin that the REST
  door forwards as `If-Match`. Predates this branch; `disqualify_lead`'s seam cannot carry
  a version at all and belongs in the same change.

No tool copy changed: `advance_deal`'s description is rendered into the certified
`agent_loop` prompt, so editing it moves `prompt_version` and owes the paid lane — and copy
on this surface is measured, not reasoned. #773 already holds that question.

## Reviews

Reviewed independently by **Fable** and **Codex** before pushing. Both found the
caller-pin hole from opposite directions, which is why it is fixed here rather than filed;
Fable additionally found the fail-open seam, the overlay zero-version edge, and the
`pinForWrite` comment that had begun to overclaim. All four are addressed in the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bind auto-executed deal moves to the exact record version the tier was resolved from to prevent race-driven reopens. Fixes #614 by carrying the observed version through `auth.Gate.Admit` and enforcing it on both MCP and REST paths.

- **Bug Fixes**
  - Added `ObservedVersion` to `mcp.TierResolverInput`; `DealMoveTierInput` sets it from the source deal read (ignored if 0).
  - `auth.Gate.Admit` pins the observed version only for auto-execute and raises when a dynamic tool resolves 🟢 without a version.
  - REST: `pinAdmittedWrite` forwards the pin as `If-Match`; rejects a mismatched caller header with `409 version_skew` (keeps a matching caller pin). Static tiers forward no pin.
  - MCP: `pinForWrite` enforces pin precedence (caller → released approval → admitted) and returns `version_skew` if the caller pin disagrees with the gate’s read; applied to `advance_deal`, `progress_deal`, and `advance_project_phase`.
  - Added unit, REST door, and real Postgres integration tests; derived checks require every dynamic tool to report and bind the read version; added a REST test proving static-tier creates pin nothing.

- **Migration**
  - Dynamic tier resolvers must set `ObservedVersion` when the decision turns on a record; missing versions will raise to approval.
  - If a tool forwards a caller `if_version`, it must match the gate‑observed version when present; disagreements fail with `version_skew`.

<sup>Written for commit 5ec70843928f895255777d25f57d2b66537c1279. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/814?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented automatically executed updates from overwriting newer record changes.
  * Added version checks to reject stale or conflicting writes with a conflict response.
  * Preserved matching caller-provided version constraints.
  * Required approval when automatic execution cannot confirm the record version.
  * Prevented concurrent deal changes from being unintentionally reopened.

* **Tests**
  * Added coverage for version pinning, concurrent updates, dynamic actions, and approval fallbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->