### PR TITLE
ci: a docs edit under infra/ stops booting twelve Postgres shards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,10 @@ jobs:
   # everything. Draft PRs run nothing until marked ready (the swarm pushes many
   # WIP commits). A required job skipped this way counts as passing.
   #   backend  = Go/DB + the gate inputs (backend, infra, go.work, Makefile,
-  #              scripts, workflows, AGENTS.md) — gates the Go build/gate,
-  #              craft, integration, vuln
+  #              scripts, this workflow, AGENTS.md) — gates the Go build/gate,
+  #              craft, integration, vuln. A gate input earns its place by
+  #              being able to change what a gate DOES; prose that merely
+  #              describes one does not, hence the two extglobs below.
   #   frontend = frontend/ + backend/api (the contract drives FE types) —
   #              gates the frontend lane + UAT
   #   e2e      = backend/ + frontend/ + infra — gates the full-stack live-boot
@@ -73,7 +75,14 @@ jobs:
               # "two validators that disagree" outage the shared file exists to
               # make impossible.
               - 'frontend/src/mcp-apps/forbidden.json'
-              - 'infra/**'
+              # The dev compose stack the DB-backed lanes boot — but not the
+              # prose beside it. Editing infra/ci-pipeline.md, the file that
+              # DOCUMENTS this classifier, must not boot twelve Postgres
+              # shards. The extglob is one positive pattern on purpose: the
+              # action ORs its patterns, so a `!infra/**/*.md` entry would
+              # match every path OUTSIDE infra/ and fire the filter on
+              # everything.
+              - 'infra/**/!(*.md)'
               - 'go.work'
               - 'go.work.sum'
               - 'Makefile'
@@ -81,7 +90,10 @@ jobs:
               - 'extensions/**'
               - 'fixtures/**'
               - 'composition/**'
-              - '.github/workflows/**'
+              # Only the merge gate itself. patch.yml and sbom.yml run no
+              # backend gate, so editing one cannot invalidate a gate result —
+              # and each proves itself when it runs.
+              - '.github/workflows/ci.yml'
               - 'AGENTS.md'
               - 'sonar-project.properties'
             frontend:
@@ -90,7 +102,8 @@ jobs:
             e2e:
               - 'backend/**'
               - 'frontend/**'
-              - 'infra/**'
+              # Same cut as the backend scope: the compose stack, not the prose.
+              - 'infra/**/!(*.md)'
               # live-boot boots COMPOSED (ADR-0069): the enabled extension
               # tree and the composition inputs shape the binary under test.
               - 'extensions/**'
@@ -353,6 +366,17 @@ jobs:
       - name: the gate still catches
         working-directory: .
         run: make test-secret-scan
+      # The pin gate rides along here, and only here, because it reads the WHOLE
+      # workflow directory while the backend scope names one file: sbom.yml and
+      # patch.yml match no scope, so gated on the classifier this check would
+      # skip on exactly the PR that unpins an action — and Renovate, which bumps
+      # `uses:` across all three workflows, auto-merges on green. Same reason the
+      # two gates above run unconditionally: supply-chain surface is not a scope.
+      # `make check-backend` keeps running it too, so a laptop `make check`
+      # reproduces this verdict. Pure bash and grep — no toolchain to install.
+      - name: Action and image pins
+        working-directory: .
+        run: make check-image-pins
 
   # The real-Postgres lane, sharded across independent runners. One runner
   # already fans packages out onto per-package clone DBs, but the heaviest

--- a/infra/ci-pipeline.md
+++ b/infra/ci-pipeline.md
@@ -31,22 +31,40 @@ output. A required job skipped this way still counts as passing.
 
 | Scope | Paths | Gates |
 |---|---|---|
-| `backend` | `backend/**`, `infra/**`, `go.work[.sum]`, `Makefile`, `scripts/**`, `.github/workflows/**`, `AGENTS.md`, `sonar-project.properties` | Go build/gate, craftsmanship, integration, vuln |
+| `backend` | `backend/**`, `infra/**/!(*.md)`, `go.work[.sum]`, `Makefile`, `scripts/**`, `extensions/**`, `fixtures/**`, `composition/**`, `.github/workflows/ci.yml`, `AGENTS.md`, `sonar-project.properties`, `frontend/src/mcp-apps/forbidden.json` | Go build/gate, extension reference, craftsmanship, integration, vuln |
 | `frontend` | `frontend/**`, `backend/api/**` (the contract drives FE types) | frontend lane, UAT |
-| `e2e` | `backend/**`, `frontend/**`, `infra/**` | full-stack live-boot |
+| `e2e` | `backend/**`, `frontend/**`, `infra/**/!(*.md)`, `extensions/**`, `fixtures/**`, `composition/**` | full-stack live-boot |
 | `docker` | root `Dockerfile.*`, `.dockerignore` | the three image builds |
 
 Consequences:
 
-- A **docs-only PR** matches no scope → every code gate skips.
+- A **docs-only PR** matches no scope → every code gate skips. That includes
+  the prose under `infra/` — this file documents the classifier, it is not an
+  input to any gate, so the two `!(*.md)` extglobs keep an edit to it from
+  booting the twelve-shard integration fleet. Each is written as one positive
+  pattern because the action ORs its patterns: a separate `!infra/**/*.md`
+  entry would match every path outside `infra/` and fire the filter on
+  everything.
 - A **backend-only PR** skips the frontend + UAT lanes; a **frontend-only PR**
-  skips the Go build/gate + the integration lane.
+  skips the Go build/gate + the integration lane — except for
+  `frontend/src/mcp-apps/forbidden.json`, which is authored under `frontend/`
+  but copied into a Go package under a byte-equality test, so it is classified
+  backend too.
+- A **CI PR still runs the full backend lane** when it touches `ci.yml`, the
+  `Makefile`, or `scripts/**`: those change what a gate *does*, so the gates
+  re-run to prove they still pass under the new definition. `patch.yml` and
+  `sbom.yml` are outside the scope — neither runs a backend gate, and each
+  proves itself when it runs.
 - **Draft PRs run nothing** until marked ready (`draft == false` guards every
   job) — the swarm pushes many WIP commits.
 - `craft-residue` and `secret-scan` are the deliberate exceptions: both run on
   **every** non-draft change, docs included. A leaked `CRAFT-FIX`/`CRAFT-DISPUTE`
   marker, or a hardcoded credential, can land in any file type — neither can be
-  gated on the scope classifier.
+  gated on the scope classifier. The **image-pin gate rides in `secret-scan`**
+  for the same reason: it reads the whole workflow directory while the `backend`
+  scope names one file, so gated on the classifier it would skip on exactly the
+  PR that unpins an action in `sbom.yml` or `patch.yml` — and Renovate, which
+  bumps `uses:` across all three workflows, auto-merges on green.
 
 ## Job graph
 
@@ -63,7 +81,7 @@ changes ──┬─> deterministic-gates ──> craftsmanship
  deterministic-gates + integration + extension-reference + frontend ──> sonarcloud
   dco  (PR-only, independent)
   craft-residue  (every non-draft change, independent)
-  secret-scan    (every non-draft change, independent)
+  secret-scan    (every non-draft change, independent — + the image-pin gate)
 ```
 
 Two deliberate shapes here. The Playwright `uat` lane is **fail-fast**: it
@@ -87,7 +105,7 @@ one required check.
 | `extension-reference` | The composed-build lane (ADR-0069): proves the **empty** extension set still composes byte-identically to the committed `composition/` stub, then enables the reference fixture and runs the backend build + unit lane + `check-composition` against the composed workspace, plus every enabled unit's own module lane. Emits its own coverage profile — extension units are separate Go modules, unreachable by the shard profiles |
 | `craftsmanship` | `make craft-static` — strict: BLOCKER **and** MAJOR findings fail it, MINOR is advisory. Runs **after** `deterministic-gates` — a red build is never judged on style |
 | `craft-residue` | No unresolved `CRAFT-FIX`/`CRAFT-DISPUTE` markers reach `main` |
-| `secret-scan` | `make secret-scan` — gitleaks over a clean `git archive HEAD` export, policy in `.gitleaks.toml`. Scans the **committed** tree, never the working tree: gitleaks does not honour `.gitignore`, so an in-place scan reads sibling worktrees and local `.env` files and reaches a different verdict per machine. The job has no install step: `scripts/gitleaks-pin.sh` fetches the version- **and** checksum-pinned binary itself, so CI and a laptop resolve the same scanner through the same code — a scan's verdict is a function of its rule set, so a different version would be a different gate. The official gitleaks action is not used: it needs a paid licence key for organization repositories. Findings print redacted — CI logs on a public repo are public. Followed immediately by `make test-secret-scan`, which plants a token in each exempted file and requires the scan to fail anyway: an allowlist that grew too broad reports "no leaks found" exactly like a clean tree |
+| `secret-scan` | `make secret-scan` — gitleaks over a clean `git archive HEAD` export, policy in `.gitleaks.toml`. Scans the **committed** tree, never the working tree: gitleaks does not honour `.gitignore`, so an in-place scan reads sibling worktrees and local `.env` files and reaches a different verdict per machine. The job has no install step: `scripts/gitleaks-pin.sh` fetches the version- **and** checksum-pinned binary itself, so CI and a laptop resolve the same scanner through the same code — a scan's verdict is a function of its rule set, so a different version would be a different gate. The official gitleaks action is not used: it needs a paid licence key for organization repositories. Findings print redacted — CI logs on a public repo are public. Followed immediately by `make test-secret-scan`, which plants a token in each exempted file and requires the scan to fail anyway: an allowlist that grew too broad reports "no leaks found" exactly like a clean tree. Ends with `make check-image-pins` (pure bash and grep, no toolchain), which lives here rather than in the classifier-gated backend lane because it reads the whole workflow directory — see the classifier exceptions above. `make check-backend` keeps running it too, so a laptop `make check` reproduces this verdict |
 | `integration shard (k/12)` | `make test-integration` with `INTEGRATION_SHARD=k/12`: a deterministic per-test round-robin slice of the whole integration lane. Slices are count-based, not duration-based; the heavy e2e tail lands on whichever shard draws it, and `INTEGRATION_JOBS=16` (the tests wait on Postgres, not cores) lets that shard chew through its slice instead of running minutes over its siblings. Boots the dev compose stack (`make db-up`: digest-pinned Postgres 16 (pgvector) + Redis 7 + MinIO + the app role — one stack definition, no hand-mirrored GH services); each shard builds its own migrated `margince_test` template and clones per package. Uploads its slice manifests + binary coverage pods |
 | `integration unit coverage` | The unit `-cover` pass over every package, binary coverage pods only. Needed because the shards run just the integration-tagged packages, and without it SonarCloud would see the unit-only packages at a false ~0% new-code coverage. No services (the test-lanes gate guarantees untagged tests open no real DB) |
 | `integration` | The fan-in — and the required check, under the same name the single-runner lane carried, so branch protection is unchanged. Asserts every shard + the unit pass succeeded (a failed shard must turn this check red, not skipped), then `scripts/test-integration-reconcile.sh` proves the slices add up: every shard present, identical discovery, union complete + disjoint. Merges all coverage pods into `coverage.out`, uploads `go-coverage` |


### PR DESCRIPTION
## Why

The `backend` scope of the change classifier matched `infra/**` and
`.github/workflows/**` whole. Editing `infra/ci-pipeline.md` — the file that
*documents* this classifier — therefore ran the full backend lane: the build
gate, craftsmanship, vuln, and the twelve-shard integration fleet. Same for any
edit to `sbom.yml` or `patch.yml`.

A gate input earns its place by being able to change what a gate **does**. Prose
that merely describes one does not.

## What changed

| | before | after |
|---|---|---|
| `backend`, `e2e` | `infra/**` | `infra/**/!(*.md)` |
| `backend` | `.github/workflows/**` | `.github/workflows/ci.yml` |

Each cut is **one positive extglob, not a negated list entry**. paths-filter ORs
its patterns, so a `!infra/**/*.md` entry would match every path *outside*
`infra/` and fire the filter on everything. Both the YAML comment and the doc
record that trap.

### The gap the workflow cut opened, and how it is closed

`make check-image-pins` reads the **whole** workflow directory, but reached CI
only through `make check-backend` in the `backend`-gated `deterministic-gates`
job. Narrowed, it would skip on exactly the PR that unpins an action in
`sbom.yml` or `patch.yml` — and Renovate, which bumps `uses:` across all three
workflows, auto-merges on green. That is the same trap the `docker images`
fan-in was added for.

It now runs as a final step of `secret-scan`, which already runs on every
non-draft change for the same reason its two existing gates do: supply-chain
surface is not a scope. Pure bash and grep, no toolchain, no new check name — so
branch protection is unchanged. `make check-backend` keeps running it too, so a
laptop `make check` reproduces the verdict.

## Doc

`infra/ci-pipeline.md` was also stale independently of this change:
`extensions/`, `fixtures/`, `composition/` and the `forbidden.json` exception
were missing from the scope rows. Table, consequence bullets, job graph and the
`secret-scan` row are all updated.

## Verification

- `python3 yaml.safe_load` on the workflow **and** the nested `filters` string —
  both parse; `secret-scan` steps are `checkout, secret scan, the gate still
  catches, Action and image pins`.
- `make check-image-pins` → `image pins OK`.
- Classifier simulated with picomatch 4.0.5 (the matcher the action uses),
  parsing the scopes straight out of the edited YAML:

  | PR shape | scopes |
  |---|---|
  | edit `infra/ci-pipeline.md` | **(none)** — was backend+e2e |
  | Renovate bumps an action in `sbom.yml` | **(none)** — was backend; pin gate now always-on |
  | edit `infra/docker-compose.dev.yml` | backend+e2e |
  | ci.yml + Makefile | backend |
  | pure docs / pure frontend | (none) / frontend+e2e |

This PR touches `ci.yml`, so it runs the full backend lane itself — the new
classifier proving the gates still pass under its own definition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop running the backend lane when editing infra docs or non-merge workflows. Narrowed the change classifier, added missing backend paths, and moved the image/action pin check to the always-on `secret-scan`.

- **Bug Fixes**
  - Backend scope: `infra/**` → `infra/**/!(*.md)`, `.github/workflows/**` → `.github/workflows/ci.yml`; added `extensions/**`, `fixtures/**`, `composition/**`, and `frontend/src/mcp-apps/forbidden.json`.
  - E2E scope mirrors the `infra/**/!(*.md)` cut.
  - Moved `make check-image-pins` to `secret-scan` (still runs via `make check-backend` locally).
  - Updated `infra/ci-pipeline.md` to match scopes and note why the pin gate lives in `secret-scan`.

<sup>Written for commit 3875ef6486a62554edda43446c048bf85eaa9bff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/816?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

