### PR TITLE
feat(company): the dossier reads as prose, and the historical label holds in every state

### DIFF
--- a/frontend/src/screens/companydossier.test.tsx
+++ b/frontend/src/screens/companydossier.test.tsx
@@ -75,30 +75,38 @@ function show() {
 }
 
 describe("what this company is", () => {
-  it("names each section it renders, in the reader's words", async () => {
+  it("reads as prose, without a heading over every few sentences", async () => {
     serving(DESCRIBED);
     show();
 
-    expect(await screen.findByText("In short")).toBeTruthy();
-    expect(screen.getByText("Where and to whom")).toBeTruthy();
     expect(
-      screen.getByText(/What they offer: load-shifting software/),
+      await screen.findByText(/What they offer: load-shifting software/),
     ).toBeTruthy();
+    // The card has ONE heading — its own. The sections still order the prose;
+    // they no longer announce themselves, because a label over three sentences
+    // about one company turned a reading into a form.
+    expect(screen.queryByRole("heading", { level: 3 })).toBeNull();
+    expect(screen.queryByText("In short")).toBeNull();
   });
 
-  it("renders a heading for each section it was given, and no others", async () => {
+  it("renders every sentence it was given, and invents none", async () => {
     // The server omits a section whose sentences all fell out of the grounding
     // filter, so the panel is handed only populated ones. This pins that the
-    // panel renders exactly those — a heading it invented for a kind with
-    // nothing under it would read as a finding of nothing.
+    // panel renders exactly those — prose it composed for a kind with nothing
+    // under it would read as a finding of nothing.
     serving(DESCRIBED);
     show();
 
-    await screen.findByText("In short");
-    const headings = screen
-      .getAllByRole("heading", { level: 3 })
-      .map((heading) => heading.textContent);
-    expect(headings).toEqual(["In short", "Where and to whom"]);
+    await screen.findByText(/What they offer: load-shifting software/);
+    const sentences = screen
+      .getAllByRole("listitem")
+      .map((item) => item.textContent?.trim());
+    expect(sentences).toEqual([
+      expect.stringContaining("What they offer: load-shifting software."),
+      expect.stringContaining(
+        "Ideal customer: energy-intensive manufacturers.",
+      ),
+    ]);
   });
 
   it("says a dossier is stale beside the content, never instead of it", async () => {

--- a/frontend/src/screens/companydossier.tsx
+++ b/frontend/src/screens/companydossier.tsx
@@ -108,16 +108,18 @@ export function DossierPanel({
         <EmptyState>{t("co.dossier.empty")}</EmptyState>
       ) : (
         <>
+          {/* One reading, not five labelled ones. The mockup draws the dossier
+              as continuous prose with its sources underneath; a heading per
+              section turned three sentences about one company into a form with
+              five fields, and the headings said less than the sentences under
+              them. The sections still ORDER the prose — the server decides
+              what comes first — they just no longer announce themselves. */}
           {readable.sections.map((section) => (
-            <div className="co-dossier-section" key={section.kind}>
-              <h3 className="co-part-sublabel">
-                {t(SECTION_LABELS[section.kind])}
-              </h3>
-              <SentenceList
-                sentences={section.sentences}
-                onOpenRecord={onOpenRecord}
-              />
-            </div>
+            <SentenceList
+              key={section.kind}
+              sentences={section.sentences}
+              onOpenRecord={onOpenRecord}
+            />
           ))}
           <p className="co-part-foot">
             <WrittenBy by={readable.generated_by} />{" "}

--- a/frontend/src/screens/companyfinance.test.tsx
+++ b/frontend/src/screens/companyfinance.test.tsx
@@ -1,11 +1,6 @@
 /** @vitest-environment jsdom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import {
-  cleanup,
-  render as rtlRender,
-  screen,
-  waitFor,
-} from "@testing-library/react";
+import { cleanup, render as rtlRender, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { components } from "../api/schema";
@@ -81,7 +76,11 @@ describe("the finance card is absent only where FIN-AC-3 says so", () => {
     async (lifecycle) => {
       stub();
       render(<CompanyFinanceCard orgId="o-1" lifecycle={lifecycle} />);
-      await waitFor(() => expect(screen.getByText(/Finance/)).toBeTruthy());
+      // A figure only the LOADED body draws. The card's title renders on the
+      // loading skeleton too, so asserting on it would pass before the read
+      // lands — and would then prove only that the lifecycle set said no,
+      // which is the set's own truth table restated.
+      expect(await screen.findByText("€186,420.00")).toBeTruthy();
     },
   );
 
@@ -90,7 +89,7 @@ describe("the finance card is absent only where FIN-AC-3 says so", () => {
   it("renders when the lifecycle is not known", async () => {
     stub();
     render(<CompanyFinanceCard orgId="o-1" />);
-    await waitFor(() => expect(screen.getByText(/Finance/)).toBeTruthy());
+    expect(await screen.findByText("€186,420.00")).toBeTruthy();
   });
 
   // FIN-AC-3's second half: a former customer's figures are history, and the
@@ -99,15 +98,24 @@ describe("the finance card is absent only where FIN-AC-3 says so", () => {
   it("labels a former customer's money historical", async () => {
     stub();
     render(<CompanyFinanceCard orgId="o-1" lifecycle="former_customer" />);
-    await waitFor(() =>
-      expect(screen.getByText("Finance · historical")).toBeTruthy(),
-    );
+    expect(await screen.findByText("Finance · historical")).toBeTruthy();
+  });
+
+  // The label belongs to every state the card can be in, not only the loaded
+  // one. `error` matters most: it keeps showing the last good figures, so a
+  // title reading "Finance" there puts money from a finished relationship
+  // under a heading that claims it is current.
+  it("keeps the historical label while the read is still in flight", () => {
+    stub();
+    render(<CompanyFinanceCard orgId="o-1" lifecycle="former_customer" />);
+    expect(screen.getByText("Finance · historical")).toBeTruthy();
   });
 
   it("leaves a current customer's card unqualified", async () => {
     stub();
     render(<CompanyFinanceCard orgId="o-1" lifecycle="customer" />);
-    await waitFor(() => expect(screen.getByText("Finance")).toBeTruthy());
+    expect(await screen.findByText("€186,420.00")).toBeTruthy();
+    expect(screen.getByText("Finance")).toBeTruthy();
     expect(screen.queryByText("Finance · historical")).toBeNull();
   });
 });

--- a/frontend/src/screens/companyfinance.tsx
+++ b/frontend/src/screens/companyfinance.tsx
@@ -85,13 +85,18 @@ export function CompanyFinanceCard({
   if (lifecycle && NEVER_INVOICED.has(lifecycle)) {
     return null;
   }
+  // Resolved ONCE, above the branches. A former customer's money is history in
+  // every state the card can be in, and the `error` state is where the mislabel
+  // would mislead most: it keeps showing the last good figures, so a title
+  // saying "Finance" there puts real money from a finished relationship under a
+  // heading that reads as current.
+  const title =
+    lifecycle === "former_customer"
+      ? t("finance.titleHistorical")
+      : t("finance.title");
   if (query.isPending) {
     return (
-      <SectionCard
-        title={t("finance.title")}
-        state="loading"
-        emptyLabel={t("finance.none")}
-      >
+      <SectionCard title={title} state="loading" emptyLabel={t("finance.none")}>
         {null}
       </SectionCard>
     );
@@ -103,7 +108,7 @@ export function CompanyFinanceCard({
     const withheld = problemCodeOf(query.error) === "permission_denied";
     return (
       <SectionCard
-        title={t("finance.title")}
+        title={title}
         state={withheld ? "withheld" : "failed"}
         emptyLabel={t("finance.none")}
         detail={withheld ? {} : { onRetry: () => void query.refetch() }}
@@ -115,17 +120,7 @@ export function CompanyFinanceCard({
   const summary = query.data;
   return (
     <SectionCard
-      // A former customer's money is HISTORY, and the title says so rather
-      // than letting figures from a finished relationship read as current
-      // (FIN-AC-3). The coverage period the criterion also asks for is not on
-      // the wire — `OrganizationFinanceSummary` carries `last_synced_at` and
-      // no coverage start or end — so the label states what it can stand
-      // behind and omits what it cannot.
-      title={
-        lifecycle === "former_customer"
-          ? t("finance.titleHistorical")
-          : t("finance.title")
-      }
+      title={title}
       state={CARD_STATE[summary.state]}
       emptyLabel={t(EMPTY_LABEL[summary.state] ?? "finance.none")}
       detail={{


### PR DESCRIPTION
The dossier drew a heading over every few sentences — five labelled fields where the mockup draws **one continuous reading** with its sources underneath. The headings said less than the sentences beneath them, and they turned what a company *is* into a form.

The sections still order the prose. They no longer announce themselves.

## The invariant the headings were carrying

The two tests that pinned those headings pinned something real with them: **the panel renders exactly the sections the server sent, and invents none**. A heading composed for a kind with nothing under it would read as a finding of nothing.

They now assert that through the sentences, which is where it was always true. Mutation-checked: adding a sentence the server never sent fails them.

## Two review findings from #806, fixed here

Both are in the same file, so they land together rather than as a separate round.

**The historical label was applied only to the loaded card.** A former customer lost it while the read was in flight and — worse — in the failed-refresh state, which *deliberately keeps showing the last good figures*. Real money from a finished relationship sat under a heading reading "Finance". The title is resolved once, above the branches.

**The new finance tests asserted on the card title**, which the loading skeleton also draws. They passed before the read landed, so they proved only that the lifecycle set returned false — the set's own truth table restated. They now assert on a figure only the loaded body renders. Breaking the fetch stub fails **six** of them; before, it failed one.

## Filed, not fixed

#815 — the finance summary has no coverage period, so FIN-AC-3's historical label is only half implemented. The sharper half:  is a rolling window ending today, so on a customer who stopped buying two years ago the label and the figure describe different periods. That needs a contract change.

## Verification

`make check-fe` green (2072 tests). The visual harness stays 8/8 against the live stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the company dossier read as continuous prose instead of five labeled sections. Ensure the Finance card keeps the "historical" title for former customers across loading, error, and loaded states, and tighten tests to check real content.

- **Refactors**
  - Dossier panel renders sentences as one reading; removed per-section headings.
  - Tests assert that only server-sent sentences render; mutation add fails as expected.

- **Bug Fixes**
  - Finance card keeps "Finance · historical" for former customers in all states.
  - Tests assert on a loaded figure, not the title, so they don’t pass on the skeleton.

<sup>Written for commit 7a31f16ff21b74f8839b45032b0546f4d20c69f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/818?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **User Interface**
  * Company dossiers now display content as continuous sentences without section headings.
  * Dossier section ordering and record-opening interactions remain unchanged.
  * Finance cards consistently show the appropriate title across loading, error, and loaded states.
  * Former customers now see a historical finance label, while current customers retain the standard “Finance” label.

* **Bug Fixes**
  * Improved finance card rendering and currency-value verification across card states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->