### PR TITLE
fix(finance): the demo ledger keeps a real timeliness sample, and the suite reads it at the ledger's own clock (#786, #798)

### DIFF
--- a/backend/internal/modules/finance/offline.go
+++ b/backend/internal/modules/finance/offline.go
@@ -37,6 +37,12 @@ const OfflineProviderName = "offline_demo"
 // NOT time.Now(). A generator keyed on today produces a different ledger every
 // day for a customer nobody touched, so every sync would rewrite every row —
 // and the sync's whole job is to notice what actually changed.
+//
+// The cost of that choice is that the ledger ages: the figures are computed
+// over windows measured back from NOW, so as the calendar leaves the epoch
+// behind, fewer and fewer generated invoices fall inside them. Anything that
+// asserts a FIGURE over this ledger therefore reads it at a clock pinned to
+// this epoch, or it is measuring how long ago the epoch was.
 var offlineEpoch = time.Date(2026, time.August, 1, 0, 0, 0, 0, time.UTC)
 
 // OfflineProvider generates one workspace's demonstration ledger.
@@ -74,29 +80,24 @@ type archetype struct {
 	// disputeRate is how often an invoice is disputed, per thousand.
 	disputeRate int
 	// openTail is how many of the most recent invoices are still unpaid — the
-	// open balance a real account always carries.
-	//
-	// Bounded by what the timeliness window needs. Monthly invoices mean the
-	// 180-day window holds six, and FIN-FORM-3 refuses a median below five
-	// settled ones — so a tail of three would leave a generated customer
-	// demonstrating the refusal rather than the figure, which is the opposite
-	// of what a demo ledger is for. A dispute inside the window costs another,
-	// which is why the slow archetype's tail is the smallest.
+	// open balance a real account always carries, and the reading the card
+	// leads with. It grows with the archetype because a slower payer sitting on
+	// more open money is one of the differences the card exists to show.
 	openTail int
 }
 
 var archetypes = []archetype{
 	{name: "prompt", lateLow: -6, lateHigh: 2, disputeRate: 0, openTail: 1},
-	{name: "ordinary", lateLow: -2, lateHigh: 12, disputeRate: 30, openTail: 1},
-	{name: "slow", lateLow: 5, lateHigh: 38, disputeRate: 40, openTail: 1},
+	{name: "ordinary", lateLow: -2, lateHigh: 12, disputeRate: 30, openTail: 2},
+	{name: "slow", lateLow: 5, lateHigh: 38, disputeRate: 40, openTail: 3},
 }
 
 // InvoicesFor generates one customer's ledger.
 //
-// Eighteen months of monthly invoices, with at least five settled inside the
-// timeliness window — which is the sample floor FIN-FORM-3 refuses below, so
-// a generated customer that fell short would demonstrate the refusal rather
-// than the figure.
+// Eighteen months of fortnightly invoices, which leaves about a dozen settled
+// inside the timeliness window — comfortably clear of the five FIN-FORM-3
+// refuses below, so a generated customer demonstrates the figure rather than
+// the refusal.
 func (p *OfflineProvider) InvoicesFor(
 	_ context.Context, externalCustomerID string,
 ) (SourceLedger, error) {
@@ -115,12 +116,12 @@ func (p *OfflineProvider) InvoicesFor(
 	var out SourceLedger
 	// Oldest first, so the settled ones the timeliness window reads sit at the
 	// front and the open tail is genuinely the recent end.
-	for month := offlineMonths - 1; month >= 0; month-- {
-		issued := offlineEpoch.AddDate(0, -month, 0)
+	for period := offlineInvoices - 1; period >= 0; period-- {
+		issued := offlineEpoch.AddDate(0, 0, -period*offlineCadenceDays)
 		due := issued.AddDate(0, 0, paymentTermDays)
 		invoice := SourceInvoice{
-			ExternalID: fmt.Sprintf("%s-INV-%04d", externalCustomerID, offlineMonths-month),
-			Number:     fmt.Sprintf("INV-%s-%03d", issued.Format("2006"), offlineMonths-month),
+			ExternalID: fmt.Sprintf("%s-INV-%04d", externalCustomerID, offlineInvoices-period),
+			Number:     fmt.Sprintf("INV-%s-%03d", issued.Format("2006"), offlineInvoices-period),
 			IssuedOn:   issued,
 			DueOn:      &due,
 			Currency:   currency,
@@ -130,7 +131,7 @@ func (p *OfflineProvider) InvoicesFor(
 		invoice.TaxMinor = net * vatPercent / 100
 		invoice.GrossMinor = invoice.NetMinor + invoice.TaxMinor
 
-		if month < kind.openTail {
+		if period < kind.openTail {
 			// The recent end is still open. This is what gives every account a
 			// non-zero open balance, which is the reading the card leads with.
 			out.Invoices = append(out.Invoices, invoice)
@@ -153,10 +154,25 @@ func (p *OfflineProvider) InvoicesFor(
 }
 
 const (
-	// offlineMonths is the ledger's depth. Eighteen months puts well over the
-	// five settled invoices the timeliness floor needs inside the 180-day
-	// window, with room for an open tail.
-	offlineMonths = 18
+	// offlineInvoices and offlineCadenceDays are the ledger's depth and its
+	// billing rhythm: thirty-nine fortnights is eighteen months of invoices.
+	//
+	// The CADENCE is what puts a real sample inside the timeliness window, and
+	// it is fortnightly rather than monthly for that reason alone. FIN-FORM-3
+	// refuses a median below five settled invoices (FIN-PARAM-3) inside the
+	// 180-day window (FIN-PARAM-2); monthly billing offers barely six
+	// candidates there, so an open tail plus one dispute leaves a generated
+	// customer demonstrating the refusal rather than the figure. A fortnight
+	// offers about a dozen, which clears the floor with room for both.
+	//
+	// The DEPTH is what the trailing 365-day figure reads, and eighteen months
+	// covers it with a year of history to spare.
+	offlineInvoices    = 39
+	offlineCadenceDays = 14
+	// creditNoteDelayDays is how long after an invoice its credit note is
+	// issued. The note is a generated date like any other, so it may not land
+	// after the epoch — see creditNoteFor.
+	creditNoteDelayDays = 14
 	// paymentTermDays is the terms every generated invoice carries. One value
 	// rather than a range: the card measures lateness against the due date, so
 	// varying the terms would vary the reading without varying the behaviour.
@@ -184,11 +200,26 @@ func settle(invoice *SourceInvoice, kind archetype, rng *rand.Rand, due time.Tim
 // creditNoteFor issues one credit note against an older invoice, because a
 // ledger with none would never exercise FIN-FORM-1's negative term — and a
 // figure that has never been reduced is a figure nobody has checked.
+//
+// The target must be old enough that the note still lands on or before the
+// epoch. A note dated after it would be a generated row that moved past the
+// fixed point the whole ledger is measured back from — which is the one thing
+// this generator promises not to do.
 func creditNoteFor(
 	invoices []SourceInvoice, customerID string, rng *rand.Rand,
 ) SourceInvoice {
-	target := invoices[rng.IntN(len(invoices))]
-	issued := target.IssuedOn.AddDate(0, 0, 14)
+	// Oldest first (InvoicesFor builds them that way), so the eligible targets
+	// are a PREFIX of the ledger — and the oldest invoice, eighteen months
+	// back, always qualifies, which is what makes this count at least one.
+	eligible := 0
+	for _, inv := range invoices {
+		if inv.IssuedOn.AddDate(0, 0, creditNoteDelayDays).After(offlineEpoch) {
+			break
+		}
+		eligible++
+	}
+	target := invoices[rng.IntN(eligible)]
+	issued := target.IssuedOn.AddDate(0, 0, creditNoteDelayDays)
 	// A partial credit, not a full reversal: a full one is indistinguishable
 	// from a void, and the card should show a reduced total rather than a
 	// disappeared invoice.

--- a/backend/internal/modules/finance/offline_test.go
+++ b/backend/internal/modules/finance/offline_test.go
@@ -8,6 +8,7 @@ package finance
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -16,12 +17,37 @@ import (
 
 func ledgerFor(t *testing.T, customer string) SourceLedger {
 	t.Helper()
-	provider := NewOfflineProvider("ws-1", []SourceCustomer{{ExternalID: customer}})
+	return ledgerIn(t, "ws-1", customer)
+}
+
+func ledgerIn(t *testing.T, workspace, customer string) SourceLedger {
+	t.Helper()
+	provider := NewOfflineProvider(workspace, []SourceCustomer{{ExternalID: customer}})
 	ledger, err := provider.InvoicesFor(context.Background(), customer)
 	if err != nil {
 		t.Fatal(err)
 	}
 	return ledger
+}
+
+// The seed is sha256(workspace | customer), so any claim about "every
+// generated customer" is a claim about that whole space. A handful of fixed
+// names proves it for a handful of ledgers while production draws a fresh
+// archetype for every workspace it runs in — which is exactly how a generator
+// that cleared the timeliness floor only on most seeds went unnoticed.
+func eachGeneratedLedger(t *testing.T, check func(t *testing.T, ledger SourceLedger)) {
+	t.Helper()
+	for w := range 8 {
+		for _, customer := range []string{
+			"ACME-01", "BRANDT-02", "VOLTAQ-03", "GLAZED-04",
+			"NORDHAUS-05", "PELICAN-06", "QUILL-07", "SABATIER-08",
+		} {
+			workspace := fmt.Sprintf("ws-%d", w)
+			t.Run(workspace+"/"+customer, func(t *testing.T) {
+				check(t, ledgerIn(t, workspace, customer))
+			})
+		}
+	}
 }
 
 // The same customer must produce the same ledger everywhere — on a colleague's
@@ -57,26 +83,55 @@ func TestTwoCustomersGetDifferentLedgers(t *testing.T) {
 	}
 }
 
+// generatorSampleMargin is how far past FIN-PARAM-3's floor the generated
+// ledger is required to land, and it is the MEASURED worst case over the seed
+// space rather than a wish: the thinnest ledger the generator produces carries
+// eight settled invoices inside the window.
+//
+// Asserted as a margin rather than as the floor itself because a ledger that
+// clears the floor by nothing is one dispute away from demonstrating the
+// refusal — which is the state this suite found the generator in. A change to
+// the cadence, the terms or an archetype that eats the margin fails here,
+// where the arithmetic is, rather than in the integration lane months later.
+const generatorSampleMargin = 3
+
 // FIN-FORM-3 refuses a median below five settled invoices. A generated
 // customer that fell short would demonstrate the refusal rather than the
 // figure, which is the opposite of what a demo ledger is for.
+//
+// It reads the REAL formula, at a clock pinned to the epoch the ledger is
+// generated back from. The spelling this replaces counted every payment after
+// the window opened — no upper bound, no dispute exclusion, no floor — so it
+// passed while production answered insufficient-sample over the same ledger.
 func TestEveryGeneratedCustomerClearsTheTimelinessSampleFloor(t *testing.T) {
-	for _, customer := range []string{"ACME-01", "BRANDT-02", "VOLTAQ-03", "GLAZED-04"} {
-		t.Run(customer, func(t *testing.T) {
-			ledger := ledgerFor(t, customer)
-			window := offlineEpoch.AddDate(0, 0, -TimelinessWindowDays)
-			settled := 0
-			for _, inv := range ledger.Invoices {
-				if inv.FullyPaidAt != nil && inv.FullyPaidAt.After(window) {
-					settled++
-				}
-			}
-			if settled < MinTimelinessSample {
-				t.Fatalf("%d invoices settled inside the window, want at least %d",
-					settled, MinTimelinessSample)
-			}
+	eachGeneratedLedger(t, func(t *testing.T, ledger SourceLedger) {
+		got := timelinessSample(ledger)
+		if got.InsufficientSample {
+			t.Fatalf("%d settled invoices inside the window; FIN-FORM-3 wants %d",
+				got.SampleSize, MinTimelinessSample)
+		}
+		if want := MinTimelinessSample + generatorSampleMargin; got.SampleSize < want {
+			t.Fatalf("sample of %d clears the floor by %d, want a margin of %d",
+				got.SampleSize, got.SampleSize-MinTimelinessSample, generatorSampleMargin)
+		}
+	})
+}
+
+// timelinessSample runs FIN-FORM-3's own fold over a generated ledger, as of
+// the epoch every generated date is measured back from.
+//
+// The three fields are projected rather than round-tripped through the mirror
+// because the claim here is about the GENERATOR — whether the ledger it hands
+// over carries a sample at all. Whether the mirror stores it faithfully is the
+// integration suite's question, and it asks it against a real database.
+func timelinessSample(ledger SourceLedger) Timeliness {
+	invoices := make([]Invoice, 0, len(ledger.Invoices))
+	for _, inv := range ledger.Invoices {
+		invoices = append(invoices, Invoice{
+			DueOn: inv.DueOn, FullyPaidAt: inv.FullyPaidAt, Disputed: inv.Disputed,
 		})
 	}
+	return TimelinessOver(invoices, offlineEpoch)
 }
 
 // Every account carries an open balance, because "what do they owe us" is the
@@ -145,14 +200,21 @@ func TestTheHashIgnoresEverythingDerivedFromToday(t *testing.T) {
 // The generator must not key on the clock either, for the same reason: a
 // ledger regenerated tomorrow must hash the same as today's, or the sync
 // rewrites everything every day.
+//
+// Every row, on every seed. The credit note is dated FORWARD from the invoice
+// it reduces, so it is the one row that can cross the epoch — and it did, on
+// the seeds that happened to target a recent invoice, while a check over one
+// fixed ledger reported the property held.
 func TestTheGeneratorDoesNotMoveWithTheClock(t *testing.T) {
-	ledger := ledgerFor(t, "ACME-01")
-	for _, inv := range ledger.Invoices {
-		if inv.IssuedOn.After(offlineEpoch) {
-			t.Fatalf("invoice %s is issued after the fixed epoch, so the ledger tracks the clock",
-				inv.ExternalID)
+	eachGeneratedLedger(t, func(t *testing.T, ledger SourceLedger) {
+		for _, inv := range ledger.Invoices {
+			if inv.IssuedOn.After(offlineEpoch) {
+				t.Fatalf("row %s is dated %s, after the fixed epoch %s: the ledger tracks the clock",
+					inv.ExternalID, inv.IssuedOn.Format(time.DateOnly),
+					offlineEpoch.Format(time.DateOnly))
+			}
 		}
-	}
+	})
 }
 
 // FIN-FORM-1 reads `credited_minor` off the invoice being REDUCED — its term

--- a/backend/internal/modules/finance/sync_integration_test.go
+++ b/backend/internal/modules/finance/sync_integration_test.go
@@ -120,8 +120,48 @@ func setupFinance(t *testing.T) *financeEnv {
 	return e
 }
 
+// ledgerSeed is the workspace the GENERATOR is seeded from, and it is a
+// constant rather than this env's workspace on purpose.
+//
+// The generator's seed is sha256(workspace | customer), so passing a freshly
+// minted workspace would draw a different archetype — a different ledger, a
+// different sample, a different open balance — on every run. That is a lottery,
+// not a fixture: the assertions below would be about which archetype came up
+// rather than about what the sync and the formulas do.
+//
+// The workspace the ROWS live in is still e.ws, minted per run so parallel runs
+// do not share a tenant. Nothing but the seed reads this string.
+const ledgerSeed = "finance-integration-ledger"
+
 func (e *financeEnv) provider() Provider {
-	return NewOfflineProvider(e.ws.String(), []SourceCustomer{{ExternalID: e.external}})
+	return NewOfflineProvider(ledgerSeed, []SourceCustomer{{ExternalID: e.external}})
+}
+
+// summaryAtEpoch reads the card at a clock pinned to the ledger's own epoch.
+//
+// Every FIGURE on the card is folded over a window measured back from the
+// store's clock, and the generated ledger is anchored to a fixed date rather
+// than to today (see offlineEpoch). Read at wall-clock time, the assertions
+// over those figures measure how far the calendar has travelled since that
+// epoch: they thin out as the window slides off the ledger and eventually
+// report an empty card. Pinned, they measure the formulas, which is what they
+// are for.
+//
+// The STATE is deliberately not read through here. Staleness is a real
+// comparison between the connection's last_success_at — stamped by the
+// database's clock — and now; pinning one side of it would make the assertion
+// pass for the wrong reason.
+func (e *financeEnv) summaryAtEpoch(
+	t *testing.T, orgID ids.OrganizationID,
+) crmcontracts.OrganizationFinanceSummary {
+	t.Helper()
+	at := NewStore(e.store.pool, e.store.baseCurrency).
+		WithClock(func() time.Time { return offlineEpoch })
+	out, err := at.SummaryFor(e.ctx, orgID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return out
 }
 
 // THE claim. An invoice's status depends on today, so a hash that covered it
@@ -239,23 +279,27 @@ func TestAfterASyncTheCardHasFiguresToShow(t *testing.T) {
 	if after.State != crmcontracts.FinanceSummaryStateConnected {
 		t.Fatalf("state after the sync = %q, want connected", after.State)
 	}
-	if after.NetInvoiced == nil || after.NetInvoiced.AmountMinor == nil {
+
+	// The figures, as of the ledger's epoch — see summaryAtEpoch for why they
+	// are not read off the summary above.
+	figures := e.summaryAtEpoch(t, orgID)
+	if figures.NetInvoiced == nil || figures.NetInvoiced.AmountMinor == nil {
 		t.Fatal("no net invoiced after a sync that mirrored a ledger")
 	}
-	if *after.NetInvoiced.AmountMinor <= 0 {
-		t.Fatalf("net invoiced = %d, want a positive figure", *after.NetInvoiced.AmountMinor)
+	if *figures.NetInvoiced.AmountMinor <= 0 {
+		t.Fatalf("net invoiced = %d, want a positive figure", *figures.NetInvoiced.AmountMinor)
 	}
 	// The generator leaves an open tail on purpose, because "what do they owe
 	// us" is the reading the card leads with.
-	if after.OpenBalance == nil || *after.OpenBalance.AmountMinor <= 0 {
+	if figures.OpenBalance == nil || *figures.OpenBalance.AmountMinor <= 0 {
 		t.Fatal("no open balance after a sync; the card's lead reading is empty")
 	}
-	if after.RecentInvoices == nil || len(*after.RecentInvoices) == 0 {
+	if figures.RecentInvoices == nil || len(*figures.RecentInvoices) == 0 {
 		t.Fatal("no recent invoices after a sync")
 	}
 	// The generator clears the timeliness sample floor, so the payment reading
 	// is a figure rather than a refusal.
-	if after.MedianDaysAfterDue == nil {
+	if figures.MedianDaysAfterDue == nil {
 		t.Fatal("no payment-behaviour median after a sync over eighteen months")
 	}
 }
@@ -344,10 +388,7 @@ func TestASyncRepairsAnInvoiceThatIsMissingItsRate(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	before, err := e.store.SummaryFor(ctx, orgID)
-	if err != nil {
-		t.Fatal(err)
-	}
+	before := e.summaryAtEpoch(t, orgID)
 	if before.NetInvoiced != nil {
 		t.Fatal("a ledger with no rates reported a total; the rest of this test proves nothing")
 	}
@@ -359,11 +400,8 @@ func TestASyncRepairsAnInvoiceThatIsMissingItsRate(t *testing.T) {
 	if repair.InvoicesUpdate == 0 {
 		t.Fatal("the pass skipped every invoice, so the rates were never repaired")
 	}
-	after, err := e.store.SummaryFor(ctx, orgID)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if after.NetInvoiced == nil || after.NetInvoiced.AmountMinor == nil {
+	if after := e.summaryAtEpoch(t, orgID); after.NetInvoiced == nil ||
+		after.NetInvoiced.AmountMinor == nil {
 		t.Fatal("still no total after a repair pass")
 	}
 


### PR DESCRIPTION
Closes #798. Closes #786.

`TestAfterASyncTheCardHasFiguresToShow` failed intermittently and was on course
to fail unconditionally. Three separate causes, and all three had to go for the
test to be about the formulas again rather than about the calendar and the draw.

## The window slid off the ledger (#798)

The generator is anchored to a fixed epoch on purpose: a ledger keyed on today
produces different dates every morning, so every sync would rewrite every
mirrored row — the one thing the sync exists not to do, and the claim
`TestASecondSyncOverAnUnchangedSourceWritesNothing` is there to hold.

But the figures are folded over windows measured back from `now`. The ledger
stays put and the window walks away from it. Measured with the real
`TimelinessOver` over 20,000 seeds:

| as of | below FIN-PARAM-3's floor |
|---|---|
| 2026-08-01 (the epoch) | 0% |
| 2026-09-01 | 0.03% |
| 2026-10-01 | 62% |
| 2026-12-01 | 100% |

(The issue estimated the crossing as September from issue dates; membership is
by *payment* date, so it is really October. The direction and the outcome were
right.)

So **the suite reads FIGURES at a clock pinned to the epoch** — the `WithClock`
seam the store already offers, and the idiom
`TestCrossingADueDateDoesNotRewriteTheLedger` already uses in this file. The
**STATE** is deliberately still read at the real clock: staleness is a genuine
comparison against a `last_success_at` the database stamped, and pinning one
side of it would make that assertion pass for the wrong reason.

`TestASyncRepairsAnInvoiceThatIsMissingItsRate` gets the same treatment. It
would not have gone red — it would have gone *vacuous*, since an empty window
produces a zero total rather than the FIN-AC-6 refusal it is asserting the
absence of.

Anchoring the generator to `now`, which the issue suggested first, is the one
fix that is not available: it trades this failure for a mirror that rewrites
itself daily.

## The sample had no margin

Monthly billing puts barely six settled invoices inside FIN-PARAM-2's 180-day
window against FIN-PARAM-3's floor of five. The open tail took one and a dispute
took another, so **1.5% of generated customers demonstrated FIN-FORM-3's refusal
rather than the figure** — even at the epoch, with no calendar drift at all. The
generator's own comment claimed "well over the five settled invoices the
timeliness floor needs", which had not been true for some time.

Fortnightly billing over the same eighteen months fixes it. The **cadence**, not
the depth, decides how many settled invoices land inside a window measured in
days. The thinnest ledger the generator now produces carries eight, and the
archetypes can afford open tails that differ — which is one of the readings the
card exists to tell apart, and was previously flattened to 1 for all three by
the same arithmetic.

## The test drew a different ledger every run (#786)

The generator's seed is `sha256(workspace | customer)`, and the test minted a
fresh workspace on every run — so the archetype, the disputes and the amounts
were a lottery. The rows still live in a per-run workspace so parallel runs do
not share a tenant; only the generator's seed is pinned, and nothing but the
seed reads that string.

## The guards

Both were shown to fail against the defect before they were allowed to pass.

- **The floor guard** now reads the real FIN-FORM-3 fold. The spelling it
  replaces counted every payment after the window opened — no upper bound, no
  dispute exclusion, no floor — so it passed while production answered
  insufficient-sample over the very same ledger. Reverted to monthly billing it
  reports `sample of 5 clears the floor by 0, want a margin of 3`.
- **The epoch guard** now sweeps the seed space rather than checking one fixed
  ledger, and that is how it found a real defect nobody had filed: the credit
  note is dated *forward* from the invoice it reduces, so on **6% of seeds it
  was issued after the epoch** — a generated row that moved past the fixed point
  the whole ledger is measured back from. The note now targets an invoice old
  enough to land on or before it. Reverted, the guard names the row and the date.

Both sweep 64 workspace/customer pairs rather than four fixed names, because a
claim about "every generated customer" is a claim about the seed space.

## Verification

- `make check-backend` green.
- `make test-it DIR=backend/internal/modules/finance` green, unit + integration.
- **The drift claim, proved rather than argued:** with `offlineEpoch` moved back
  a year — i.e. a wall clock a year past it — the suite passes as written, and
  fails with `net invoiced = 0, want a positive figure` the moment the figures
  are read at the wall clock again.

No frontend file changed.

## Left open

The demo ledger itself still ages: an installation running well after the epoch
shows a card whose windows have moved off the generated data. That is a product
question about demo-data freshness rather than a test defect, and it is filed
separately.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes the finance tests and demo ledger by reading figures at the ledger’s epoch and adjusting the generator so every seed keeps a valid timeliness sample. Fixes intermittent and time-based failures in the sync suite.

- **Bug Fixes**
  - Read card figures at the ledger’s epoch using store `WithClock`; keep state at the real clock to test staleness correctly.
  - Pin the generator seed in integration tests (`ledgerSeed`) so archetypes don’t change per run; rows still live in per-run workspaces.
  - Ensure credit notes target sufficiently old invoices so their issue date never lands after `offlineEpoch`.

- **Refactors**
  - Switch the demo ledger to 18 months of fortnightly billing (39 invoices, 14-day cadence) and raise `openTail` for ordinary/slow archetypes to keep a real sample inside the 180-day window with a 3-invoice margin above the floor.
  - Add seed-sweeping guards that use the real timeliness fold to enforce the sample margin and verify no generated row is dated after `offlineEpoch`.

<sup>Written for commit 46648a2017795e899a33f53740e7573eabb94aa2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/819?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->