### PR TITLE
fix(design-system): --space-5 was never defined, so every drawer lost its padding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
 # one target here that invokes the compiler directly instead of delegating.
 GO ?= go
 
-.PHONY: help install ai-routing-local dev-fresh check check-backend check-q check-go check-gates check-fe build test test-v test-cover test-integration e2e-ai e2e-ai-report ai-probe test-db-up test-it test-integration-serial bench-perf lint arch-lint vet gen gen-types gen-types-check drift composition check-composition test-extensions db-up db-init db-wait migrate migrate-up migrate-down run psql redis-cli tidy dev dev-stop dev-logs clean tools tools-go infra-up infra-down infra-logs infra-reset seed-dev seed-dev-db seed-reset verify-boot frontend-check frontend-e2e e2e-company fe-install fe-typecheck fe-lint fe-build fe-preview fe-format fe-test ds-purity font-lock icon-lint ds-spacing native-controls fitness-jurisdiction storybook fe-uat craft-static craft-residue check-craft-doc secret-scan test-secret-scan check-image-pins contract-breaking-check test-lanes go-file-length rls-store-path no-jurisdiction pkg-freeze hooks sbom sbom-normalize sbom-supplement sbom-parity sbom-validate sbom-sign sbom-check
+.PHONY: help install ai-routing-local dev-fresh check check-backend check-q check-go check-gates check-fe build test test-v test-cover test-integration e2e-ai e2e-ai-report ai-probe test-db-up test-it test-integration-serial bench-perf lint arch-lint vet gen gen-types gen-types-check drift composition check-composition test-extensions db-up db-init db-wait migrate migrate-up migrate-down run psql redis-cli tidy dev dev-stop dev-logs clean tools tools-go infra-up infra-down infra-logs infra-reset seed-dev seed-dev-db seed-reset verify-boot frontend-check frontend-e2e e2e-company fe-install fe-typecheck fe-lint fe-build fe-preview fe-format fe-test ds-purity font-lock icon-lint ds-spacing space-tokens native-controls fitness-jurisdiction storybook fe-uat craft-static craft-residue check-craft-doc secret-scan test-secret-scan check-image-pins contract-breaking-check test-lanes go-file-length rls-store-path no-jurisdiction pkg-freeze hooks sbom sbom-normalize sbom-supplement sbom-parity sbom-validate sbom-sign sbom-check
 
 # Bare `make` lists every command instead of running the first target.
 .DEFAULT_GOAL := help
@@ -170,6 +170,14 @@ icon-lint:
 ## the scale). Diff-scoped vs origin/main; use the --space-* scale or a layout class.
 ds-spacing:
 	frontend/scripts/check-ds-spacing.sh
+
+## space-tokens — every --space-* token a stylesheet USES is DEFINED. An
+## undefined custom property resolves to nothing rather than to a smaller
+## value, so the declaration is dropped silently and the element renders with
+## none: `--space-5` was missing while six rules spelled it, and the composer
+## drawer clipped its own heading against the viewport edge.
+space-tokens:
+	frontend/scripts/check-space-tokens.sh
 ## native-controls — no browser-drawn dropdown: `<select>`/`<option>` outside
 ## design-system/select.tsx, which is the ONE select this product renders.
 native-controls:
@@ -203,6 +211,7 @@ frontend-check:
 	frontend/scripts/check-font-lock.sh
 	frontend/scripts/check-icon-glyph.sh
 	frontend/scripts/check-ds-spacing.sh
+	frontend/scripts/check-space-tokens.sh
 	frontend/scripts/check-native-controls.sh
 	cd frontend && pnpm install --frozen-lockfile && pnpm gen:api && \
 		{ git diff --exit-code -- src/api/schema.d.ts src/api/public-events.ts || \

--- a/frontend/scripts/check-space-tokens.sh
+++ b/frontend/scripts/check-space-tokens.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Every --space-* token a stylesheet USES must be DEFINED in tokens.css.
+#
+# An undefined custom property does not fall back to a smaller value — it
+# resolves to nothing, and the declaration is dropped. `--space-5` was missing
+# from the scale while six rules across the tree spelled it, so a drawer that
+# declared `padding: var(--space-5)` rendered with NO padding and clipped its
+# own heading against the viewport edge. Nothing failed: not the typecheck, not
+# the unit tests (jsdom does not resolve custom properties), not the spacing
+# gate, which only reads raw px.
+#
+# This is the fitness-function form of that bug: derive the obligation from the
+# tree rather than maintain a list.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+TOKENS="src/design-system/tokens.css"
+if [[ ! -f "$TOKENS" ]]; then
+  echo "FAIL: $TOKENS not found"
+  exit 1
+fi
+
+defined=$(grep -oE -- '--space-[a-z0-9-]+:' "$TOKENS" | sed 's/:$//' | sort -u)
+sources=$(find src -type f \( -name '*.css' -o -name '*.tsx' -o -name '*.ts' \))
+used=$(echo "$sources" | tr '\n' '\0' | xargs -0 grep -hoE -- 'var\(--space-[a-z0-9-]+' 2>/dev/null \
+  | sed 's/^var(//' | sort -u)
+
+missing=$(comm -13 <(echo "$defined") <(echo "$used"))
+
+if [[ -n "$missing" ]]; then
+  echo "FAIL: stylesheets use --space tokens that tokens.css does not define"
+  echo ""
+  while read -r token; do
+    [[ -z "$token" ]] && continue
+    echo "  $token — used in:"
+    echo "$sources" | tr '\n' '\0' | xargs -0 grep -ln -- "var($token)" 2>/dev/null \
+      | sed 's/^/      /'
+  done <<< "$missing"
+  echo ""
+  echo "An undefined custom property resolves to NOTHING: the declaration is"
+  echo "dropped and the element renders with no value at all. Define it in"
+  echo "$TOKENS, or use a token that exists."
+  exit 1
+fi
+
+echo "OK: every --space token used is defined"

--- a/frontend/src/screens/companyheader.tsx
+++ b/frontend/src/screens/companyheader.tsx
@@ -1,6 +1,6 @@
 import { useQueryClient } from "@tanstack/react-query";
 import { Globe, Link2, MapPin, Tag, Users } from "lucide-react";
-import { type ReactElement, useState } from "react";
+import type { ReactElement } from "react";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
 import { ifMatch } from "../api/version";
@@ -65,7 +65,17 @@ type UpdateOrganizationRequest =
 // activity to reply to.
 export function CompanyPrimaryActions({
   org,
-}: Readonly<{ org: Organization }>) {
+  composerOpen,
+  onComposerOpen,
+}: Readonly<{
+  org: Organization;
+  // The composer's open state belongs to the PAGE, not to this button: the
+  // drawer opens into the right rail's column, so the rail has to know it is
+  // open in order to stand down. Held here as a controlled pair rather than
+  // privately, which is what kept the rail rendering underneath it.
+  composerOpen: boolean;
+  onComposerOpen: (open: boolean) => void;
+}>) {
   // Archived records take no new activity: the write is refused server-side,
   // so offering the verb would only produce a modal that fails on save.
   if (org.archived_at) {
@@ -73,7 +83,7 @@ export function CompanyPrimaryActions({
   }
   return (
     <>
-      <WriteEmailAction org={org} />
+      <WriteEmailAction org={org} open={composerOpen} onOpen={onComposerOpen} />
       <LogActivityAction entityType="organization" entityId={org.id} />
       <LogActivityAction
         entityType="organization"
@@ -89,12 +99,19 @@ export function CompanyPrimaryActions({
 // the consent gate and the refusal vocabulary; this owns only whether the
 // surface is offered and the open/close state, so the account-started and
 // reply surfaces stay one component.
-function WriteEmailAction({ org }: Readonly<{ org: Organization }>) {
+function WriteEmailAction({
+  org,
+  open,
+  onOpen,
+}: Readonly<{
+  org: Organization;
+  open: boolean;
+  onOpen: (open: boolean) => void;
+}>) {
   const t = useT();
-  const [open, setOpen] = useState(false);
   return (
     <>
-      <Button variant="primary" onClick={() => setOpen(true)}>
+      <Button variant="primary" onClick={() => onOpen(true)}>
         {t("co.writeEmail")}
       </Button>
       {open && (
@@ -108,7 +125,7 @@ function WriteEmailAction({ org }: Readonly<{ org: Organization }>) {
           entityType="organization"
           entityId={org.id}
           open={open}
-          onClose={() => setOpen(false)}
+          onClose={() => onOpen(false)}
         />
       )}
     </>

--- a/frontend/src/screens/companyrail.tsx
+++ b/frontend/src/screens/companyrail.tsx
@@ -34,6 +34,7 @@ export function CompanyRail({
   writable,
   onOpenRecord,
   withPeople,
+  composerOpen,
 }: Readonly<{
   orgId: string;
   view?: Organization360;
@@ -46,7 +47,14 @@ export function CompanyRail({
   onOpenRecord?: (entityType: string, entityId: string) => void;
   // False where the page's own body is already the roster in full.
   withPeople: boolean;
+  // A composer drawer is open in this column. The rail stands down entirely
+  // rather than narrowing: squeezed to a third of its width it is a column of
+  // broken cards, and no mockup draws the two side by side.
+  composerOpen: boolean;
 }>) {
+  if (composerOpen) {
+    return null;
+  }
   return (
     // A plain div: RecordView's own <aside> is the landmark around this, and a
     // second labelled region inside it would give a reader two names for one

--- a/frontend/src/screens/organizations.test.tsx
+++ b/frontend/src/screens/organizations.test.tsx
@@ -1919,6 +1919,26 @@ describe("CompanyScreen — State D's one column and its card grid", () => {
     }
   });
 
+  // The drawer opens INTO the rail's column. Both composers do — the header's
+  // Write-email and the one anchored on a message — so the rail stands down
+  // for either, and comes back when the drawer closes.
+  it("stands the rail down while a composer holds its column", async () => {
+    stubFetch(companyBackstop, { org360 });
+    const { container } = render(<CompanyScreen id="o-1" />);
+    await screen.findByText("Brandt Automotive GmbH");
+    await waitFor(() =>
+      expect(container.querySelector(".co-rail")).toBeTruthy(),
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "Write email" }));
+    await waitFor(() => expect(container.querySelector(".co-rail")).toBeNull());
+
+    await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    await waitFor(() =>
+      expect(container.querySelector(".co-rail")).toBeTruthy(),
+    );
+  });
+
   // A call or a note often carries no subject. Counting only the subjected
   // rows would draw "nothing logged with them yet" on an account that has been
   // called five times — a false statement about the account, made from a fact

--- a/frontend/src/screens/organizations.tsx
+++ b/frontend/src/screens/organizations.tsx
@@ -1944,9 +1944,33 @@ function CompanyPage({
   // account instead of a thread (ADR-0087 §1). Two pieces of state would let
   // both open at once, which is two composers over each other.
   const [composing, setComposing] = useState<ComposeAnchor | null>(null);
+  // The header's own Write-email drawer. Separate state from `composing`,
+  // which anchors on a message or a person — but the same consequence for the
+  // layout, because both open into the rail's column.
+  const [writingEmail, setWritingEmail] = useState(false);
   const [decisionsOpen, setDecisionsOpen] = useState(false);
   const [auditOpen, setAuditOpen] = useState(false);
   const receipt = useCitedReceipt();
+  // The rail, or nothing while a composer holds its column. Both drawers open
+  // into this space, so a rail beside them would be two things in one place —
+  // and absent rather than narrowed, because a rail squeezed to a third of its
+  // width is a column of broken cards.
+  const rail = (
+    <CompanyRail
+      orgId={org.id}
+      view={view}
+      locale={locale}
+      writable={!org.archived_at}
+      onOpenRecord={receipt.open}
+      // The People tab IS the roster in full, so the rail's summary of it
+      // stands down rather than repeating it beside itself.
+      withPeople={tab !== "people"}
+      // Either composer holds this column, and the rail does not care which.
+      // Passed rather than branched on here so the page keeps one decision
+      // about the rail instead of two.
+      composerOpen={Boolean(composing) || writingEmail}
+    />
+  );
   const { slots, showChanges: filterToChanges } = useChronologySlots({
     org,
     view,
@@ -1994,7 +2018,13 @@ function CompanyPage({
       // The composer opens from a button rather than standing open above the
       // page: a whole form in the header's action strip pushed the account's
       // own story below the fold before a word of it was read.
-      actions={<CompanyPrimaryActions org={org} />}
+      actions={
+        <CompanyPrimaryActions
+          org={org}
+          composerOpen={writingEmail}
+          onComposerOpen={setWritingEmail}
+        />
+      }
       // Lifecycle and owner, at the top right beside the verbs. Passing this
       // also moves the action row up into the header, which is the company
       // page's shape and no other record's.
@@ -2009,20 +2039,7 @@ function CompanyPage({
       // mockup draws. Absent rather than narrowed: a rail squeezed to a third
       // of its width is a column of broken cards.
       asideLabel={t("record.accountContext")}
-      aside={
-        composing ? undefined : (
-          <CompanyRail
-            orgId={org.id}
-            view={view}
-            locale={locale}
-            writable={!org.archived_at}
-            onOpenRecord={receipt.open}
-            // The People tab IS the roster in full, so the rail's summary of
-            // it stands down rather than repeating it beside itself.
-            withPeople={tab !== "people"}
-          />
-        )
-      }
+      aside={rail}
       // The chronology is the account's story and belongs to the overview.
       // The Partner tab is a form, so it does not repeat it under itself.
       {...slots}


### PR DESCRIPTION
The composer drawer clipped its own heading against the viewport edge.

The cause was not the drawer. `.modal-drawer` declares `padding: var(--space-5)`, and the scale runs **1, 2, 3, 4, 6**. An undefined custom property does not fall back to a smaller value — it resolves to *nothing*, the declaration is dropped, and the element renders with none.

Six rules across the tree spelled that token. Measured on the live page: `paddingTop: 0px`, heading at `y: 0`.

## Why nothing caught it

- the typecheck does not read CSS
- the unit tests run in jsdom, which does not resolve custom properties
- the spacing gate reads raw px, so a token that resolves to nothing looks correct to it

## The gate

`check-space-tokens.sh` is the fitness-function form: every `--space` token a stylesheet **uses** must be **defined**, derived from the tree rather than kept as a list. It runs inside `frontend-check` and standalone as `make space-tokens`.

Mutation-checked — deleting the token again fails the gate and names all six affected files.

## The rail never yielded to the header's composer

#803 claimed the rail stands down while a composer is open. It did for the composer anchored on a message, and the comment claimed both — but the header's Write-email state was private to its own button, so the rail could not know and kept rendering underneath the drawer.

That state is lifted to the page. The rail now takes one `composerOpen` prop rather than the page branching twice, which also brings `CompanyPage` back under the cognitive-complexity ceiling my change had pushed it past.

Verified on the live stack: rail present → **0 while open** → present again after close, with the drawer at 20px padding.

## Verification

`make check-fe` green (2141 tests). The visual harness stays 8/8. Mutation-checked in both directions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores drawer padding by defining `--space-5`. Hides the company rail while any composer is open and adds a `space-tokens` check to catch undefined spacing tokens.

- **Bug Fixes**
  - Defined `--space-5` in `tokens.css` to restore `.modal-drawer` padding.
  - Lifted header composer state to the page; `CompanyRail` now takes `composerOpen` and returns `null` while a composer is open.

- **New Features**
  - Added `frontend/scripts/check-space-tokens.sh`; available via `make space-tokens` and included in `frontend-check` to fail on undefined `--space-*` tokens.

<sup>Written for commit d98eddeb5c75ad0693ca9a125b8a663d5d4dbb22. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/821?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved email composition across company views with consistent open and close behavior.
  - The company rail automatically hides while the email composer is open and reappears after it closes.
  - Composer state is coordinated across company headers, timelines, and people views.

- **Bug Fixes**
  - Prevented the company rail from overlapping or competing with the email composer.

- **Tests**
  - Added coverage confirming the rail visibility changes correctly when composing and canceling an email.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->