### PR TITLE
fix(reads): a declared list filter binds its store, or it is not declared (#631, #579)

### DIFF
--- a/backend/declaredfilters_test.go
+++ b/backend/declaredfilters_test.go
@@ -1,0 +1,462 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package backendarch
+
+// A declared narrowing parameter binds the read it is declared on, or it is not
+// declared.
+//
+// The defect this closes is the widest wrong answer there is. `GET
+// /v1/people?tag=vip` whose handler never reads `tag` returns EVERY person the
+// caller may see, with 200 OK and a well-formed page: the client cannot tell
+// that from a workspace where everyone carries the tag. Three of these were
+// live when the gate was written — `tag`, `organization.domain`,
+// `activity.assignee_id` — plus one shadow, `deal.project_id`, that answered
+// the whole incumbent mirror to a caller who named one project.
+//
+// It is derived rather than listed. The generated contract carries every list
+// operation's query parameters as a `*Params` struct, so the census IS the
+// contract: a parameter added upstream lands here as a failure until a handler
+// reads it. That is the half a hand-maintained list cannot do, and the half
+// that matters — every one of these defects was a parameter someone declared
+// and nobody came back for.
+//
+// Two obligations, because a request in overlay mode meets two handlers:
+//
+//   - the NATIVE one must reach its store with the dial (or hand the whole
+//     params value on to something that does, or own the raw query string
+//     itself — the report handlers parse it wholesale);
+//   - the overlay SHADOW must name the dial in the branch that reads the
+//     mirror: forward it, or refuse it with the 422 that says the mirror cannot
+//     answer this. Delegating to the native handler is the OTHER branch, so a
+//     reference inside that closure proves nothing about the mirror path. This
+//     is the fitness function #579 asks for, and `occurred_from`/`occurred_to`
+//     — forwarded by neither and refused by neither, so a whole mirrored
+//     timeline came back as though it were the requested day — is the failure
+//     it is derived from.
+//
+// Paging and ordering are deliberately OUT of scope: `cursor`, `limit` and
+// `sort` are the shared components a page's SHAPE is spelled with, not its
+// membership, and a handler that ignores one answers a differently-shaped page
+// rather than a different question. Six operations ignore one of the three
+// today; that is its own obligation with its own fix, filed separately.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/gatekit"
+)
+
+const (
+	// contractParamsSource holds the generated `*Params` structs — the census
+	// of what the contract declares a read may be narrowed by.
+	contractParamsSource = "internal/contracts/api_gen.go"
+
+	// overlayShadowSource holds the overlay-mode read shadows. It is named as a
+	// file rather than swept for, because the shadows are what the second
+	// obligation is about and they live in exactly one place by design.
+	overlayShadowSource = "internal/compose/overlayread.go"
+
+	// contractsPackageAlias is how every handler spells the generated contract
+	// package, which is what makes a params type recognisable in a signature.
+	contractsPackageAlias = "crmcontracts"
+
+	// wantMinimumNarrowedOperations guards the way this gate fails silently: a
+	// census that stops recognising the generated shape finds no parameters,
+	// judges nothing, and reads exactly like a clean tree. Fifty operations
+	// declare a narrowing parameter today; the floor sits well below that, so
+	// retiring one stays an ordinary change and only a collapse is a finding.
+	wantMinimumNarrowedOperations = 30
+
+	// wantMinimumOverlayShadows is the same guard for the shadow walk: six
+	// shadows carry narrowing dials today.
+	wantMinimumOverlayShadows = 4
+)
+
+// pagingParameterTypes are the generated types the contract spells its shared
+// paging and ordering parameters with. Recognising them by TYPE rather than by
+// name is what keeps the exclusion honest: it is the contract's own component
+// reuse that says these three are a page's shape, and a filter that happened to
+// be called `sort` on some operation would still be judged.
+var pagingParameterTypes = map[string]bool{"Cursor": true, "Limit": true, "Sort": true}
+
+// declaredFilter is one narrowing query parameter of one operation: the Go
+// field a handler reads, and the name a caller types.
+type declaredFilter struct {
+	field string
+	wire  string
+}
+
+// overlayDialsTheMirrorAnswersTheSameWayEitherWay ratifies a dial an overlay
+// shadow neither forwards nor refuses. An entry here says the mirror answers
+// the same page with the parameter as without it — which is a property of the
+// mirror, so it is keyed by the parameter rather than by each shadow.
+var overlayDialsTheMirrorAnswersTheSameWayEitherWay = gatekit.Waive(map[string]string{
+	"include_archived": "the mirror holds no archived rows at all — a tombstoned incumbent record is deleted " +
+		"there rather than archived — so both values of this dial answer the same page, and refusing it " +
+		"would cost every caller that sends the parameter's own default a 422 for nothing",
+})
+
+// TestEveryDeclaredNarrowingParameterReachesItsRead is the native obligation.
+func TestEveryDeclaredNarrowingParameterReachesItsRead(t *testing.T) {
+	declared := narrowingParametersByType(t)
+	if len(declared) < wantMinimumNarrowedOperations {
+		t.Fatalf("only %d operations declare a narrowing query parameter in %s, want at least %d — "+
+			"the census is reading the wrong shape and would judge nothing",
+			len(declared), contractParamsSource, wantMinimumNarrowedOperations)
+	}
+
+	handlers := 0
+	for _, file := range declaredFilterScope(declared).Files(t) {
+		for _, h := range paramsHandlersIn(file, declared, descendIntoClosures) {
+			handlers++
+			for _, missed := range h.unread {
+				t.Errorf("%s: %s declares `%s` and %s never reads it, so the page it answers is wider "+
+					"than the one that was asked for — bind the parameter to the read, or retire it "+
+					"from the contract",
+					file.Path, h.paramsType, missed, h.name)
+			}
+		}
+	}
+	if handlers == 0 {
+		t.Fatal("no handler taking a narrowing params value was found: the walk is judging nothing")
+	}
+}
+
+// TestEveryDeclaredNarrowingParameterIsForwardedOrRefusedByItsOverlayShadow is
+// the second obligation — #579's fitness function.
+func TestEveryDeclaredNarrowingParameterIsForwardedOrRefusedByItsOverlayShadow(t *testing.T) {
+	declared := narrowingParametersByType(t)
+	shadows := paramsHandlersIn(parseGoFile(t, overlayShadowSource), declared, skipClosures)
+	if len(shadows) < wantMinimumOverlayShadows {
+		t.Fatalf("%s holds %d read shadows taking a narrowing params value, want at least %d — the walk "+
+			"is reading the wrong shape and would judge nothing",
+			overlayShadowSource, len(shadows), wantMinimumOverlayShadows)
+	}
+
+	for _, shadow := range shadows {
+		for _, missed := range shadow.unread {
+			if overlayDialsTheMirrorAnswersTheSameWayEitherWay.Waived(t, missed) {
+				continue
+			}
+			t.Errorf("%s: %s neither forwards `%s` to the mirror nor refuses it, so in overlay mode the "+
+				"dial is dropped and the whole mirrored set comes back as though it had been applied — "+
+				"add it to the shadow's refused parameters, or pass it through",
+				overlayShadowSource, shadow.name, missed)
+		}
+	}
+	overlayDialsTheMirrorAnswersTheSameWayEitherWay.AssertAllMatched(t)
+}
+
+// TestTheDeclaredFilterWalkReportsADroppedParameterAndNothingElse is the gate's
+// own defect test. Both obligations above pass today, and a walk that reported
+// nothing because it recognises nothing would pass identically — so each shape
+// the walk must tell apart is put to it here, against source written for the
+// purpose rather than against the tree it judges.
+func TestTheDeclaredFilterWalkReportsADroppedParameterAndNothingElse(t *testing.T) {
+	declared := map[string][]declaredFilter{"ListThingsParams": {{field: "Tag", wire: "tag"}}}
+	for _, probe := range []struct {
+		name   string
+		policy closurePolicy
+		body   string
+		unread []string
+	}{
+		{
+			"a dropped parameter is reported", descendIntoClosures,
+			`in := Input{Limit: params.Limit}; use(in)`,
+			[]string{"tag"},
+		},
+		{
+			"a parameter the handler reads is not", descendIntoClosures,
+			`use(Input{Tag: params.Tag})`, nil,
+		},
+		{
+			"a params value handed on whole is not", descendIntoClosures,
+			`h.other(w, r, params)`, nil,
+		},
+		{
+			"a handler owning the raw query string is not", descendIntoClosures,
+			`use(parse(r.URL.Query()))`, nil,
+		},
+		{
+			"a shadow that names the dial only in its delegation closure is reported", skipClosures,
+			`shadow(func() { h.native(w, r, params) })`,
+			[]string{"tag"},
+		},
+		{
+			"a shadow that names the dial in the mirror branch is not", skipClosures,
+			`shadow(func() { h.native(w, r, params) }, refuse{params.Tag != nil})`, nil,
+		},
+	} {
+		t.Run(probe.name, func(t *testing.T) {
+			file := parseGoSource(t, "package p\nfunc (h H) ListThings(w W, r R, params crmcontracts.ListThingsParams) {\n"+
+				probe.body+"\n}\n")
+			handlers := paramsHandlersIn(file, declared, probe.policy)
+			if len(handlers) != 1 {
+				t.Fatalf("the walk found %d handlers, want 1 — it is not recognising the signature at all", len(handlers))
+			}
+			if got := strings.Join(handlers[0].unread, ","); got != strings.Join(probe.unread, ",") {
+				t.Errorf("unread = %q, want %q", got, strings.Join(probe.unread, ","))
+			}
+		})
+	}
+}
+
+// TestTheDeclaredFilterCensusReadsTheGeneratedShape pins the other half of the
+// silent failure: a census that mistook the paging components for filters, or
+// missed a form tag, would judge the wrong set without ever reporting it.
+func TestTheDeclaredFilterCensusReadsTheGeneratedShape(t *testing.T) {
+	declared := narrowingParametersByType(t)
+	people, listed := declared["ListPeopleParams"]
+	if !listed {
+		t.Fatalf("the census carries no ListPeopleParams — it is reading the wrong shape")
+	}
+	var wire []string
+	for _, filter := range people {
+		wire = append(wire, filter.wire)
+	}
+	// The person list declares exactly these, and the three paging components
+	// it also declares are not among them.
+	want := "ai_written,captured_by_kind,include_archived,owner_id,q,tag"
+	if got := strings.Join(wire, ","); got != want {
+		t.Errorf("listPeople's narrowing parameters = %q, want %q", got, want)
+	}
+}
+
+// declaredFilterScope proves the roots hold every handler this gate judges: a
+// params value taken anywhere else would be a read the gate never sees.
+func declaredFilterScope(declared map[string][]declaredFilter) gatekit.Scope {
+	return gatekit.Scope{
+		Roots: []string{modulesDir, composeTier},
+		Subject: func(_ string, file *ast.File) bool {
+			return len(paramsHandlersIn(gatekit.ParsedFile{File: file}, declared, descendIntoClosures)) > 0
+		},
+	}
+}
+
+// paramsHandler is one handler judged: which operation's params it takes, and
+// which of that operation's narrowing parameters it never reads.
+type paramsHandler struct {
+	name       string
+	paramsType string
+	unread     []string
+}
+
+// closurePolicy says whether a reference inside a function literal counts.
+type closurePolicy bool
+
+const (
+	// descendIntoClosures counts a reference wherever it stands: a native
+	// handler that maps its parameters inside a callback has still read them.
+	descendIntoClosures closurePolicy = true
+	// skipClosures counts only references in the function's own body. An
+	// overlay shadow's closure IS the branch that delegates to the native
+	// handler, so a reference inside it says nothing about the mirror branch.
+	skipClosures closurePolicy = false
+)
+
+// paramsHandlersIn walks one file for handlers taking a declared params value
+// and reports what each leaves unread, by wire name and in declaration order.
+func paramsHandlersIn(file gatekit.ParsedFile, declared map[string][]declaredFilter, policy closurePolicy) []paramsHandler {
+	var out []paramsHandler
+	for _, decl := range file.File.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Body == nil {
+			continue
+		}
+		ident, paramsType := paramsArgument(fn, declared)
+		if paramsType == "" {
+			continue
+		}
+		read, wholesale := parameterReferences(fn.Body, ident, policy)
+		var unread []string
+		if !wholesale {
+			for _, filter := range declared[paramsType] {
+				if !read[filter.field] {
+					unread = append(unread, filter.wire)
+				}
+			}
+		}
+		out = append(out, paramsHandler{name: fn.Name.Name, paramsType: paramsType, unread: unread})
+	}
+	return out
+}
+
+// paramsArgument finds the handler's params argument: the identifier it is
+// bound to (empty for `_`, which reads nothing at all) and the generated type
+// it carries. A signature naming no declared params type answers "".
+func paramsArgument(fn *ast.FuncDecl, declared map[string][]declaredFilter) (ident, paramsType string) {
+	for _, field := range fn.Type.Params.List {
+		selector, ok := field.Type.(*ast.SelectorExpr)
+		if !ok {
+			continue
+		}
+		pkg, ok := selector.X.(*ast.Ident)
+		if !ok || pkg.Name != contractsPackageAlias || len(declared[selector.Sel.Name]) == 0 {
+			continue
+		}
+		if len(field.Names) == 1 && field.Names[0].Name != "_" {
+			return field.Names[0].Name, selector.Sel.Name
+		}
+		return "", selector.Sel.Name
+	}
+	return "", ""
+}
+
+// parameterReferences reports which fields of the params value the body reads
+// by name, and whether it binds the value WHOLESALE — in which case the field
+// set says nothing and the handler is accounted for either way.
+//
+// The two wholesale shapes exist because binding a parameter is not always a
+// selector at the handler: a body that hands the whole params value on has
+// passed every field to whatever maps them, and a body that parses the raw
+// query string owns every parameter in it — which is how the report handlers
+// read the reserved `by`/`agg` keys alongside a free-form vocabulary the
+// generated struct cannot spell.
+func parameterReferences(body *ast.BlockStmt, ident string, policy closurePolicy) (read map[string]bool, wholesale bool) {
+	// A handler that discards the generated struct (`_ crmcontracts.XParams`)
+	// reads no field by name, but it may still own the raw query string — so
+	// the walk runs either way, and only the by-name half depends on there
+	// being an identifier to match.
+	read = map[string]bool{}
+	ast.Inspect(body, func(n ast.Node) bool {
+		if _, isClosure := n.(*ast.FuncLit); isClosure && policy == skipClosures {
+			return false
+		}
+		switch node := n.(type) {
+		case *ast.SelectorExpr:
+			if x, ok := node.X.(*ast.Ident); ok && x.Name == ident {
+				read[node.Sel.Name] = true
+			}
+		case *ast.CallExpr:
+			wholesale = wholesale || readsRawQuery(node) || passesWhole(node, ident)
+		}
+		return true
+	})
+	return read, wholesale
+}
+
+// readsRawQuery reports whether the call is r.URL.Query(), the handler taking
+// the whole query string rather than the generated struct.
+func readsRawQuery(call *ast.CallExpr) bool {
+	method, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok || method.Sel.Name != "Query" {
+		return false
+	}
+	url, ok := method.X.(*ast.SelectorExpr)
+	return ok && url.Sel.Name == "URL"
+}
+
+// passesWhole reports whether the call hands the params value on unopened.
+func passesWhole(call *ast.CallExpr, ident string) bool {
+	for _, arg := range call.Args {
+		if named, ok := arg.(*ast.Ident); ok && named.Name == ident {
+			return true
+		}
+	}
+	return false
+}
+
+// narrowingParametersByType is the census: every generated `*Params` struct,
+// keyed by type name, carrying the query parameters that narrow what the
+// operation answers. Paging and ordering are dropped by type, and a struct left
+// with nothing is dropped with them.
+func narrowingParametersByType(t *testing.T) map[string][]declaredFilter {
+	t.Helper()
+	out := map[string][]declaredFilter{}
+	for _, decl := range parseGoFile(t, contractParamsSource).File.Decls {
+		gen, ok := decl.(*ast.GenDecl)
+		if !ok || gen.Tok != token.TYPE {
+			continue
+		}
+		for _, spec := range gen.Specs {
+			typeSpec, ok := spec.(*ast.TypeSpec)
+			if !ok || !strings.HasSuffix(typeSpec.Name.Name, "Params") {
+				continue
+			}
+			structType, ok := typeSpec.Type.(*ast.StructType)
+			if !ok {
+				continue
+			}
+			if filters := narrowingFields(structType); len(filters) > 0 {
+				out[typeSpec.Name.Name] = filters
+			}
+		}
+	}
+	return out
+}
+
+// narrowingFields reads one params struct's query fields: the `form` tag names
+// the wire parameter, and a field typed by one of the shared paging components
+// is not one of them.
+func narrowingFields(structType *ast.StructType) []declaredFilter {
+	var out []declaredFilter
+	for _, field := range structType.Fields.List {
+		if len(field.Names) != 1 || field.Tag == nil {
+			continue
+		}
+		wire := formTagName(field.Tag.Value)
+		if wire == "" || pagingParameterTypes[pointedToTypeName(field.Type)] {
+			continue
+		}
+		out = append(out, declaredFilter{field: field.Names[0].Name, wire: wire})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].wire < out[j].wire })
+	return out
+}
+
+// formTagName reads the query-parameter name out of a struct tag, or "" when
+// the field carries none — a header or path parameter, which this gate is not
+// about.
+func formTagName(tag string) string {
+	const marker = `form:"`
+	start := strings.Index(tag, marker)
+	if start < 0 {
+		return ""
+	}
+	rest := tag[start+len(marker):]
+	end := strings.IndexAny(rest, `",`)
+	if end <= 0 {
+		return ""
+	}
+	return rest[:end]
+}
+
+// pointedToTypeName names the type a field holds, through the pointer every
+// optional parameter is generated as, and "" for anything qualified by a
+// package — the shared paging components are all local to the generated file.
+func pointedToTypeName(expr ast.Expr) string {
+	if star, ok := expr.(*ast.StarExpr); ok {
+		expr = star.X
+	}
+	if named, ok := expr.(*ast.Ident); ok {
+		return named.Name
+	}
+	return ""
+}
+
+// parseGoFile parses one source of the backend module, relative to its root.
+func parseGoFile(t *testing.T, rel string) gatekit.ParsedFile {
+	t.Helper()
+	file, err := parser.ParseFile(token.NewFileSet(), filepath.FromSlash(rel), nil, parser.SkipObjectResolution)
+	if err != nil {
+		t.Fatalf("parsing %s: %v", rel, err)
+	}
+	return gatekit.ParsedFile{Path: rel, File: file}
+}
+
+// parseGoSource parses source written for the walk's own defect test.
+func parseGoSource(t *testing.T, src string) gatekit.ParsedFile {
+	t.Helper()
+	file, err := parser.ParseFile(token.NewFileSet(), "probe.go", src, parser.SkipObjectResolution)
+	if err != nil {
+		t.Fatalf("parsing the probe source: %v", err)
+	}
+	return gatekit.ParsedFile{Path: "probe.go", File: file}
+}

--- a/backend/declaredfilters_test.go
+++ b/backend/declaredfilters_test.go
@@ -58,10 +58,10 @@ const (
 	// of what the contract declares a read may be narrowed by.
 	contractParamsSource = "internal/contracts/api_gen.go"
 
-	// overlayShadowSource holds the overlay-mode read shadows. It is named as a
-	// file rather than swept for, because the shadows are what the second
-	// obligation is about and they live in exactly one place by design.
-	overlayShadowSource = "internal/compose/overlayread.go"
+	// overlayModeDispatch is the method every read shadow opens with — "does
+	// this request read the mirror?" — and therefore what identifies one
+	// without naming the file it happens to live in.
+	overlayModeDispatch = "overlayReadMode"
 
 	// contractsPackageAlias is how every handler spells the generated contract
 	// package, which is what makes a params type recognisable in a signature.
@@ -133,25 +133,60 @@ func TestEveryDeclaredNarrowingParameterReachesItsRead(t *testing.T) {
 // the second obligation — #579's fitness function.
 func TestEveryDeclaredNarrowingParameterIsForwardedOrRefusedByItsOverlayShadow(t *testing.T) {
 	declared := narrowingParametersByType(t)
-	shadows := paramsHandlersIn(parseGoFile(t, overlayShadowSource), declared, skipClosures)
-	if len(shadows) < wantMinimumOverlayShadows {
-		t.Fatalf("%s holds %d read shadows taking a narrowing params value, want at least %d — the walk "+
-			"is reading the wrong shape and would judge nothing",
-			overlayShadowSource, len(shadows), wantMinimumOverlayShadows)
-	}
-
-	for _, shadow := range shadows {
-		for _, missed := range shadow.unread {
-			if overlayDialsTheMirrorAnswersTheSameWayEitherWay.Waived(t, missed) {
-				continue
+	shadows := 0
+	for _, file := range overlayShadowScope().Files(t) {
+		for _, shadow := range paramsHandlersIn(file, declared, skipClosures) {
+			shadows++
+			for _, missed := range shadow.unread {
+				if overlayDialsTheMirrorAnswersTheSameWayEitherWay.Waived(t, missed) {
+					continue
+				}
+				t.Errorf("%s: %s neither forwards `%s` to the mirror nor refuses it, so in overlay mode the "+
+					"dial is dropped and the whole mirrored set comes back as though it had been applied — "+
+					"add it to the shadow's refused parameters, or pass it through",
+					file.Path, shadow.name, missed)
 			}
-			t.Errorf("%s: %s neither forwards `%s` to the mirror nor refuses it, so in overlay mode the "+
-				"dial is dropped and the whole mirrored set comes back as though it had been applied — "+
-				"add it to the shadow's refused parameters, or pass it through",
-				overlayShadowSource, shadow.name, missed)
 		}
 	}
+	if shadows < wantMinimumOverlayShadows {
+		t.Fatalf("the walk found %d read shadows taking a narrowing params value, want at least %d — it is "+
+			"reading the wrong shape and would judge nothing", shadows, wantMinimumOverlayShadows)
+	}
 	overlayDialsTheMirrorAnswersTheSameWayEitherWay.AssertAllMatched(t)
+}
+
+// overlayShadowScope finds the read shadows by what they DO — dispatch on
+// overlay mode — rather than by the file they sit in today.
+//
+// The native obligation proves its roots with a Scope for a stated reason: a
+// root naming the wrong tree finds nothing objectionable and reads exactly
+// like a clean one. Naming the shadow file directly would have made this half
+// the same unproven claim, one obligation apart: a shadow added in another
+// compose file would be judged by nobody, and its dropped dial would look
+// exactly like no dropped dial.
+func overlayShadowScope() gatekit.Scope {
+	return gatekit.Scope{
+		Roots:   []string{composeTier},
+		Subject: func(_ string, file *ast.File) bool { return callsOverlayModeDispatch(file) },
+	}
+}
+
+// callsOverlayModeDispatch reports whether a file holds a read shadow: a
+// function that asks whether this request reads the mirror. Every shadow
+// begins that way, and nothing else in the tier does.
+func callsOverlayModeDispatch(file *ast.File) bool {
+	found := false
+	ast.Inspect(file, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		if method, isMethod := call.Fun.(*ast.SelectorExpr); isMethod && method.Sel.Name == overlayModeDispatch {
+			found = true
+		}
+		return !found
+	})
+	return found
 }
 
 // TestTheDeclaredFilterWalkReportsADroppedParameterAndNothingElse is the gate's
@@ -187,6 +222,15 @@ func TestTheDeclaredFilterWalkReportsADroppedParameterAndNothingElse(t *testing.
 		{
 			"a shadow that names the dial only in its delegation closure is reported", skipClosures,
 			`shadow(func() { h.native(w, r, params) })`,
+			[]string{"tag"},
+		},
+		{
+			// The search shadow's shape: it delegates with a plain call rather
+			// than through a closure, so it is the WHOLESALE allowance — not
+			// the closure rule — that would exempt it from the obligation, and
+			// it would be exempted from all of it at once.
+			"a shadow that delegates without a closure is judged all the same", skipClosures,
+			`if !overlay { h.native(w, r, params); return }; mirror(params.Q)`,
 			[]string{"tag"},
 		},
 		{
@@ -318,7 +362,18 @@ func paramsArgument(fn *ast.FuncDecl, declared map[string][]declaredFilter) (ide
 // passed every field to whatever maps them, and a body that parses the raw
 // query string owns every parameter in it — which is how the report handlers
 // read the reserved `by`/`agg` keys alongside a free-form vocabulary the
-// generated struct cannot spell.
+// generated struct cannot spell. Both are broader than their justification:
+// ANY call taking the value counts, so a debug log naming `params` would
+// exempt a handler. They are the native obligation's allowances and they are
+// stated here rather than narrowed, because a walk that guessed which calls
+// "really" bind would be the unreliable half of this gate.
+//
+// Neither is granted to a SHADOW. Handing the params value on is what an
+// overlay shadow does to reach the native handler — its OTHER branch — so
+// accepting it there would exempt every shadow from the obligation by the
+// shape they all share. The Search shadow proved this the direct way: it
+// delegates with a plain call rather than through a closure, so under the
+// closure rule alone it was judged on nothing at all.
 func parameterReferences(body *ast.BlockStmt, ident string, policy closurePolicy) (read map[string]bool, wholesale bool) {
 	// A handler that discards the generated struct (`_ crmcontracts.XParams`)
 	// reads no field by name, but it may still own the raw query string — so
@@ -335,7 +390,9 @@ func parameterReferences(body *ast.BlockStmt, ident string, policy closurePolicy
 				read[node.Sel.Name] = true
 			}
 		case *ast.CallExpr:
-			wholesale = wholesale || readsRawQuery(node) || passesWhole(node, ident)
+			if policy == descendIntoClosures {
+				wholesale = wholesale || readsRawQuery(node) || passesWhole(node, ident)
+			}
 		}
 		return true
 	})

--- a/backend/declaredfilters_test.go
+++ b/backend/declaredfilters_test.go
@@ -3,8 +3,8 @@
 
 package backendarch
 
-// A declared narrowing parameter binds the read it is declared on, or it is not
-// declared.
+// A declared narrowing parameter is read by the handler it is declared on, or
+// it is not declared.
 //
 // The defect this closes is the widest wrong answer there is. `GET
 // /v1/people?tag=vip` whose handler never reads `tag` returns EVERY person the
@@ -23,9 +23,9 @@ package backendarch
 //
 // Two obligations, because a request in overlay mode meets two handlers:
 //
-//   - the NATIVE one must reach its store with the dial (or hand the whole
-//     params value on to something that does, or own the raw query string
-//     itself — the report handlers parse it wholesale);
+//   - the NATIVE one must READ the dial (or hand the whole params value on to
+//     something that does, or own the raw query string itself — the report
+//     handlers parse it wholesale);
 //   - the overlay SHADOW must name the dial in the branch that reads the
 //     mirror: forward it, or refuse it with the 422 that says the mirror cannot
 //     answer this. Delegating to the native handler is the OTHER branch, so a
@@ -34,6 +34,17 @@ package backendarch
 //     — forwarded by neither and refused by neither, so a whole mirrored
 //     timeline came back as though it were the requested day — is the failure
 //     it is derived from.
+//
+// READ, precisely — not "correctly bound". This walk proves a handler NAMES
+// the parameter; it cannot prove the value then narrows the query, and a
+// handler that mapped `tag` onto the wrong field would satisfy it. That is
+// the honest limit of a static census and it is stated rather than papered
+// over, because the pair is what covers the class: this gate is the half no
+// test can be written for in advance — the parameter nobody came back for —
+// and declaredfilters_http_integration_test.go is the half that proves the
+// named ones actually narrow, over HTTP, against records created over HTTP.
+// A new parameter therefore arrives with the census already failing, and its
+// wire arm is what closes the finding.
 //
 // Paging and ordering are deliberately OUT of scope: `cursor`, `limit` and
 // `sort` are the shared components a page's SHAPE is spelled with, not its
@@ -103,8 +114,8 @@ var overlayDialsTheMirrorAnswersTheSameWayEitherWay = gatekit.Waive(map[string]s
 		"would cost every caller that sends the parameter's own default a 422 for nothing",
 })
 
-// TestEveryDeclaredNarrowingParameterReachesItsRead is the native obligation.
-func TestEveryDeclaredNarrowingParameterReachesItsRead(t *testing.T) {
+// TestEveryDeclaredNarrowingParameterIsReadByItsHandler is the native obligation.
+func TestEveryDeclaredNarrowingParameterIsReadByItsHandler(t *testing.T) {
 	declared := narrowingParametersByType(t)
 	if len(declared) < wantMinimumNarrowedOperations {
 		t.Fatalf("only %d operations declare a narrowing query parameter in %s, want at least %d — "+

--- a/backend/declaredfilters_test.go
+++ b/backend/declaredfilters_test.go
@@ -348,7 +348,15 @@ func paramsHandlersIn(file gatekit.ParsedFile, declared map[string][]declaredFil
 // it carries. A signature naming no declared params type answers "".
 func paramsArgument(fn *ast.FuncDecl, declared map[string][]declaredFilter) (ident, paramsType string) {
 	for _, field := range fn.Type.Params.List {
-		selector, ok := field.Type.(*ast.SelectorExpr)
+		// Through the pointer a handler MIGHT take it by, and past a group
+		// binding two names at once: a signature this walk does not recognise
+		// is a handler it silently never judges, and the floors below count
+		// handlers rather than missing ones.
+		expr := field.Type
+		if pointer, isPointer := expr.(*ast.StarExpr); isPointer {
+			expr = pointer.X
+		}
+		selector, ok := expr.(*ast.SelectorExpr)
 		if !ok {
 			continue
 		}
@@ -356,8 +364,10 @@ func paramsArgument(fn *ast.FuncDecl, declared map[string][]declaredFilter) (ide
 		if !ok || pkg.Name != contractsPackageAlias || len(declared[selector.Sel.Name]) == 0 {
 			continue
 		}
-		if len(field.Names) == 1 && field.Names[0].Name != "_" {
-			return field.Names[0].Name, selector.Sel.Name
+		for _, name := range field.Names {
+			if name.Name != "_" {
+				return name.Name, selector.Sel.Name
+			}
 		}
 		return "", selector.Sel.Name
 	}

--- a/backend/internal/compose/integration/declaredfilters_http_integration_test.go
+++ b/backend/internal/compose/integration/declaredfilters_http_integration_test.go
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// The wire half of the declared list filters. The store-level semantics live
+// in declaredfilters_integration_test.go; what is proved here is the thing the
+// store cannot see — that the HANDLER carries each parameter to it, which is
+// where all four of these were dropped.
+//
+// The distinction is not academic. A handler that mapped `tag` onto the wrong
+// store field would satisfy both the store tests (which set the field
+// themselves) and the AST gate (which only asks that the handler names the
+// parameter). Only a request through the real route can tell those apart, so
+// every filter below is asked for over HTTP, against records created over
+// HTTP, and answered by the count that proves the narrowing.
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
+)
+
+// listedIDs is the shape every list response shares, read down to the one
+// thing these assertions are about: which records came back.
+type listedIDs struct {
+	Data []struct {
+		ID string `json:"id"`
+	} `json:"data"`
+}
+
+// onlyRecord fails unless the page carries exactly the record expected — the
+// assertion a dropped filter cannot pass, since it answers with every
+// readable row.
+func onlyRecord(t *testing.T, e *apptest.AppEnv, path, want, what string) {
+	t.Helper()
+	var page listedIDs
+	if status := e.Call(t, "GET", path, nil, nil, &page); status != http.StatusOK {
+		t.Fatalf("GET %s = %d, want 200", path, status)
+	}
+	if len(page.Data) != 1 || page.Data[0].ID != want {
+		t.Fatalf("GET %s returned %d records, want only %s — a filter the handler drops answers "+
+			"the whole list with the right shape", path, len(page.Data), what)
+	}
+}
+
+// createdRecord posts one record and returns its id.
+func createdRecord(t *testing.T, e *apptest.AppEnv, path string, body apptest.AnyMap) string {
+	t.Helper()
+	var created struct {
+		ID string `json:"id"`
+	}
+	if status := e.Call(t, "POST", path, body, nil, &created); status != http.StatusCreated {
+		t.Fatalf("POST %s = %d, want 201", path, status)
+	}
+	return created.ID
+}
+
+func TestThePersonListNarrowsByTagOnTheWire(t *testing.T) {
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
+
+	tagged := createdRecord(t, e, "/v1/people", apptest.AnyMap{"full_name": "Tagged Person"})
+	createdRecord(t, e, "/v1/people", apptest.AnyMap{"full_name": "Untagged Person"})
+	tag := createdRecord(t, e, "/v1/tags", apptest.AnyMap{"name": "VIP"})
+	if status := e.Call(t, "POST", "/v1/tags/"+tag+"/apply", apptest.AnyMap{
+		"entity_type": "person", "entity_id": tagged,
+	}, nil, nil); status != http.StatusCreated {
+		t.Fatalf("applying the tag = %d, want 201", status)
+	}
+
+	onlyRecord(t, e, "/v1/people?tag=VIP", tagged, "the tagged person")
+	onlyRecord(t, e, "/v1/people?tag=vip", tagged, "the tagged person, asked for in another case")
+}
+
+func TestTheOrganizationListNarrowsByDomainOnTheWire(t *testing.T) {
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
+
+	held := createdRecord(t, e, "/v1/organizations", apptest.AnyMap{
+		"display_name": "Acme", "domains": []apptest.AnyMap{{"domain": "acme.example", "is_primary": true}},
+	})
+	createdRecord(t, e, "/v1/organizations", apptest.AnyMap{
+		"display_name": "Other", "domains": []apptest.AnyMap{{"domain": "other.example", "is_primary": true}},
+	})
+
+	onlyRecord(t, e, "/v1/organizations?domain=acme.example", held, "the account that lists the domain")
+	onlyRecord(t, e, "/v1/organizations?domain=ACME.example", held, "the same account, asked for in another case")
+}
+
+func TestTheActivityListNarrowsByAssigneeOnTheWire(t *testing.T) {
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
+
+	var me struct {
+		User struct {
+			ID string `json:"id"`
+		} `json:"user"`
+	}
+	if status := e.Call(t, "GET", "/v1/me", nil, nil, &me); status != http.StatusOK {
+		t.Fatalf("GET /v1/me = %d, want 200", status)
+	}
+	mine := createdRecord(t, e, "/v1/activities", apptest.AnyMap{
+		"kind": "task", "subject": "Call the buyer", "due_at": "2026-09-01T09:00:00Z", "assignee_id": me.User.ID,
+	})
+	// An unassigned task is the row a dropped filter hands back alongside it.
+	createdRecord(t, e, "/v1/activities", apptest.AnyMap{"kind": "task", "subject": "Nobody's"})
+
+	onlyRecord(t, e, "/v1/activities?assignee_id="+me.User.ID, mine, "the open task that person holds")
+}
+
+func TestThePipelineListAnswersIncludeArchivedOnTheWire(t *testing.T) {
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
+
+	retired := createdRecord(t, e, "/v1/pipelines", apptest.AnyMap{"name": "Retired"})
+	// Aged through the database because no wire operation archives a pipeline
+	// (#829). The parameter is about rows in this state, and the state is
+	// reachable in a deployment's data whether or not an endpoint mints it.
+	if _, err := e.Owner.Exec(t.Context(),
+		`UPDATE pipeline SET archived_at = now() WHERE id = $1`, retired); err != nil {
+		t.Fatalf("archiving the pipeline: %v", err)
+	}
+
+	var live, all listedIDs
+	if status := e.Call(t, "GET", "/v1/pipelines", nil, nil, &live); status != http.StatusOK {
+		t.Fatalf("GET /v1/pipelines = %d, want 200", status)
+	}
+	if status := e.Call(t, "GET", "/v1/pipelines?include_archived=true", nil, nil, &all); status != http.StatusOK {
+		t.Fatalf("GET /v1/pipelines?include_archived=true = %d, want 200", status)
+	}
+	if lists(live, retired) {
+		t.Fatalf("the live pipeline list carries the archived pipeline")
+	}
+	if !lists(all, retired) {
+		t.Fatalf("include_archived=true did not reach the read: the archived pipeline is absent from a page "+
+			"that asked for it (live=%d, with archived=%d)", len(live.Data), len(all.Data))
+	}
+}
+
+// lists reports whether a page carries one record id.
+func lists(page listedIDs, id string) bool {
+	for _, record := range page.Data {
+		if record.ID == id {
+			return true
+		}
+	}
+	return false
+}

--- a/backend/internal/compose/integration/declaredfilters_http_integration_test.go
+++ b/backend/internal/compose/integration/declaredfilters_http_integration_test.go
@@ -118,7 +118,7 @@ func TestThePipelineListAnswersIncludeArchivedOnTheWire(t *testing.T) {
 
 	retired := createdRecord(t, e, "/v1/pipelines", apptest.AnyMap{"name": "Retired"})
 	// Aged through the database because no wire operation archives a pipeline
-	// (#829). The parameter is about rows in this state, and the state is
+	// (#835). The parameter is about rows in this state, and the state is
 	// reachable in a deployment's data whether or not an endpoint mints it.
 	if _, err := e.Owner.Exec(t.Context(),
 		`UPDATE pipeline SET archived_at = now() WHERE id = $1`, retired); err != nil {

--- a/backend/internal/compose/integration/declaredfilters_http_integration_test.go
+++ b/backend/internal/compose/integration/declaredfilters_http_integration_test.go
@@ -117,9 +117,9 @@ func TestThePipelineListAnswersIncludeArchivedOnTheWire(t *testing.T) {
 	e.BootstrapWorkspace(t)
 
 	retired := createdRecord(t, e, "/v1/pipelines", apptest.AnyMap{"name": "Retired"})
-	// Aged through the database because no wire operation archives a pipeline
-	// (#835). The parameter is about rows in this state, and the state is
-	// reachable in a deployment's data whether or not an endpoint mints it.
+	// Aged through the database because no wire operation archives a pipeline.
+	// The parameter is about rows in this state, and the state is reachable in
+	// a deployment's data whether or not an endpoint mints it.
 	if _, err := e.Owner.Exec(t.Context(),
 		`UPDATE pipeline SET archived_at = now() WHERE id = $1`, retired); err != nil {
 		t.Fatalf("archiving the pipeline: %v", err)

--- a/backend/internal/compose/integration/declaredfilters_integration_test.go
+++ b/backend/internal/compose/integration/declaredfilters_integration_test.go
@@ -117,6 +117,43 @@ func TestTheOrganizationListNarrowsByDomain(t *testing.T) {
 	}
 }
 
+// Archiving an account archives its domain rows in the same transaction, so a
+// domain filter pinned to live rows could never answer the caller who asked
+// for archived accounts BY domain: the page would come back empty, reading
+// "no account ever held this". The two dials are one question.
+func TestTheDomainFilterFindsAnArchivedAccountWhenAskedForOne(t *testing.T) {
+	e := Setup(t)
+	held, err := e.People.CreateOrganization(e.Admin(), people.CreateOrganizationInput{
+		DisplayName: "Gone", Domains: []people.OrgDomainInput{{Domain: "gone.example", IsPrimary: true}},
+	})
+	if err != nil {
+		t.Fatalf("seeding the account: %v", err)
+	}
+	if _, err := e.People.ArchiveOrganization(e.Admin(), ids.From[ids.OrganizationKind](ids.UUID(held.Id))); err != nil {
+		t.Fatalf("archiving the account: %v", err)
+	}
+
+	asked := "gone.example"
+	live, _, err := e.People.ListOrganizations(e.Admin(), people.ListOrganizationsInput{Domain: &asked})
+	if err != nil {
+		t.Fatalf("listing live organizations by the domain: %v", err)
+	}
+	if len(live) != 0 {
+		t.Fatalf("the live page returned %d accounts, want none — the holder is archived", len(live))
+	}
+
+	withArchived, _, err := e.People.ListOrganizations(e.Admin(), people.ListOrganizationsInput{
+		Domain: &asked, IncludeArchived: true,
+	})
+	if err != nil {
+		t.Fatalf("listing archived organizations by the domain: %v", err)
+	}
+	if len(withArchived) != 1 || withArchived[0].Id != held.Id {
+		t.Fatalf("include_archived with a domain returned %d accounts, want the archived holder — a page that "+
+			"cannot contain it answers 'nobody ever held this'", len(withArchived))
+	}
+}
+
 func TestTheActivityListNarrowsToTheOpenTasksOneAssigneeHolds(t *testing.T) {
 	e := Setup(t)
 	due := time.Now().Add(24 * time.Hour)

--- a/backend/internal/compose/integration/declaredfilters_integration_test.go
+++ b/backend/internal/compose/integration/declaredfilters_integration_test.go
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// What the declared list filters answer, against real SQL.
+//
+// Each of these parameters was declared by the contract and dropped by its
+// handler, so `?tag=vip` — or `?domain=`, or `?assignee_id=` — returned the
+// UNFILTERED page with 200 OK. A unit test cannot tell that apart from a
+// working filter, because the wrong answer is well-formed and the right one is
+// a property of the query the database runs. So each filter is put to a set
+// seeded to have a right answer and a wrong one: the row that matches, and the
+// row a dropped filter would hand back with it.
+
+import (
+	"context"
+	"slices"
+	"testing"
+	"time"
+
+	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/modules/activities"
+	"github.com/gradionhq/margince/backend/internal/modules/collections"
+	"github.com/gradionhq/margince/backend/internal/modules/deals"
+	"github.com/gradionhq/margince/backend/internal/modules/people"
+	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+)
+
+// tagCurator is a principal that may author the tag vocabulary and apply it.
+// The harness's admin fixture mirrors the real seed, which carries no tag
+// grant, so the fixture asks for exactly the object it needs rather than
+// widening the shared one.
+func tagCurator(e *Env) context.Context {
+	return e.As(ids.NewV7(), nil, principal.Permissions{
+		Objects: map[string]principal.ObjectGrant{
+			"tag": {Create: true, Read: true, Update: true},
+		},
+		RowScope: principal.RowScopeAll,
+	})
+}
+
+func TestThePersonListNarrowsByTagName(t *testing.T) {
+	e := Setup(t)
+	tagged := e.SeedPerson(t, "Tagged Person", nil)
+	e.SeedPerson(t, "Untagged Person", nil)
+
+	tags := collections.NewStore(e.Pool)
+	curator := tagCurator(e)
+	vip, err := tags.CreateTag(curator, "VIP", nil)
+	if err != nil {
+		t.Fatalf("creating the tag: %v", err)
+	}
+	if _, err := tags.ApplyTag(curator, vip.ID, "person", tagged); err != nil {
+		t.Fatalf("applying the tag: %v", err)
+	}
+
+	// Folded on both sides: the vocabulary is unique under lower(name), so
+	// the caller's capitalization decides nothing about which tag they named.
+	for _, asked := range []string{"VIP", "vip", " Vip "} {
+		page, _, err := e.People.ListPeople(e.Admin(), people.ListPeopleInput{Tag: &asked})
+		if err != nil {
+			t.Fatalf("listing people by tag %q: %v", asked, err)
+		}
+		if len(page) != 1 || ids.UUID(page[0].Id) != tagged {
+			t.Fatalf("tag=%q returned %d people, want only the tagged one", asked, len(page))
+		}
+	}
+
+	unknown := "no-such-tag"
+	page, _, err := e.People.ListPeople(e.Admin(), people.ListPeopleInput{Tag: &unknown})
+	if err != nil {
+		t.Fatalf("listing people by an unused tag: %v", err)
+	}
+	if len(page) != 0 {
+		t.Fatalf("a tag nobody carries returned %d people — a dropped filter answers the whole list", len(page))
+	}
+}
+
+func TestTheOrganizationListNarrowsByDomain(t *testing.T) {
+	e := Setup(t)
+	held, err := e.People.CreateOrganization(e.Admin(), people.CreateOrganizationInput{
+		DisplayName: "Acme", Domains: []people.OrgDomainInput{{Domain: "acme.example", IsPrimary: true}},
+	})
+	if err != nil {
+		t.Fatalf("seeding the account that holds the domain: %v", err)
+	}
+	if _, err := e.People.CreateOrganization(e.Admin(), people.CreateOrganizationInput{
+		DisplayName: "Other", Domains: []people.OrgDomainInput{{Domain: "other.example", IsPrimary: true}},
+	}); err != nil {
+		t.Fatalf("seeding the account that does not: %v", err)
+	}
+
+	// Folded the way the column stores it, so the lookup answers the same for
+	// a caller who typed the domain out of an email signature.
+	for _, asked := range []string{"acme.example", "ACME.example"} {
+		page, _, err := e.People.ListOrganizations(e.Admin(), people.ListOrganizationsInput{Domain: &asked})
+		if err != nil {
+			t.Fatalf("listing organizations by domain %q: %v", asked, err)
+		}
+		if len(page) != 1 || page[0].Id != held.Id {
+			t.Fatalf("domain=%q returned %d accounts, want only the one that lists it", asked, len(page))
+		}
+	}
+
+	unheld := "nobody.example"
+	page, _, err := e.People.ListOrganizations(e.Admin(), people.ListOrganizationsInput{Domain: &unheld})
+	if err != nil {
+		t.Fatalf("listing organizations by an unheld domain: %v", err)
+	}
+	if len(page) != 0 {
+		t.Fatalf("a domain no account lists returned %d accounts — a dropped filter answers the whole list", len(page))
+	}
+}
+
+func TestTheActivityListNarrowsToTheOpenTasksOneAssigneeHolds(t *testing.T) {
+	e := Setup(t)
+	due := time.Now().Add(24 * time.Hour)
+	mine := e.logTask(t, "Call the buyer", e.Rep1, due)
+	closed := e.logTask(t, "Already handled", e.Rep1, due)
+	e.logTask(t, "Someone else's", e.Rep3, due)
+	if _, err := e.Activities.UpdateActivity(e.Admin(), ids.From[ids.ActivityKind](closed),
+		activities.UpdateActivityInput{IsDone: boolPtr(true)}); err != nil {
+		t.Fatalf("completing the task: %v", err)
+	}
+
+	assignee := ids.From[ids.UserKind](e.Rep1)
+	page, _, err := e.Activities.ListActivities(e.Admin(), activities.ListActivitiesInput{AssigneeID: &assignee})
+	if err != nil {
+		t.Fatalf("listing activities by assignee: %v", err)
+	}
+	if len(page) != 1 || ids.UUID(page[0].Id) != mine {
+		t.Fatalf("assignee_id returned %d activities, want the one open task that person holds "+
+			"(a dropped filter answers every task in the workspace, a done one included)", len(page))
+	}
+}
+
+// logTask writes one open task for an assignee through the store the wire
+// path uses, so the row carries whatever a real task carries.
+func (e *Env) logTask(t *testing.T, subject string, assignee ids.UUID, due time.Time) ids.UUID {
+	t.Helper()
+	assigneeID := ids.From[ids.UserKind](assignee)
+	activity, _, err := e.Activities.LogActivity(e.Admin(), activities.LogActivityInput{
+		Kind: "task", Subject: &subject, DueAt: &due, AssigneeID: &assigneeID, Source: "manual",
+	})
+	if err != nil {
+		t.Fatalf("logging task %q: %v", subject, err)
+	}
+	return ids.UUID(activity.Id)
+}
+
+func TestThePipelineListAnswersIncludeArchived(t *testing.T) {
+	e := Setup(t)
+	if _, err := e.Deals.CreatePipeline(e.Admin(), deals.CreatePipelineInput{Name: "Live"}); err != nil {
+		t.Fatalf("seeding the live pipeline: %v", err)
+	}
+	retired, err := e.Deals.CreatePipeline(e.Admin(), deals.CreatePipelineInput{Name: "Retired"})
+	if err != nil {
+		t.Fatalf("seeding the pipeline to retire: %v", err)
+	}
+	// Aged by SQL because no contract operation archives a pipeline today.
+	// What makes the parameter answerable is the column and the read's filter
+	// on it, and this is the state that filter is about.
+	e.WsExec(t, `UPDATE pipeline SET archived_at = now() WHERE id = $1`, retired.Id)
+
+	liveOnly, err := e.Deals.ListPipelines(e.Admin(), storekit.LiveOnly)
+	if err != nil {
+		t.Fatalf("listing live pipelines: %v", err)
+	}
+	if !listsPipeline(liveOnly, "Live") || listsPipeline(liveOnly, "Retired") {
+		t.Fatalf("the live list = %v, want Live present and Retired absent", pipelineNames(liveOnly))
+	}
+
+	withArchived, err := e.Deals.ListPipelines(e.Admin(), storekit.IncludeArchived)
+	if err != nil {
+		t.Fatalf("listing pipelines including the archived: %v", err)
+	}
+	if !listsPipeline(withArchived, "Retired") {
+		t.Fatalf("include_archived = %v, want the archived pipeline among them — a dropped parameter "+
+			"answers the live list either way", pipelineNames(withArchived))
+	}
+}
+
+// listsPipeline reports whether a page carries the pipeline named.
+func listsPipeline(page []crmcontracts.Pipeline, name string) bool {
+	return slices.Contains(pipelineNames(page), name)
+}
+
+// pipelineNames renders a page for a failure message.
+func pipelineNames(page []crmcontracts.Pipeline) []string {
+	names := make([]string, 0, len(page))
+	for _, p := range page {
+		names = append(names, p.Name)
+	}
+	return names
+}

--- a/backend/internal/compose/integration/declaredfilters_integration_test.go
+++ b/backend/internal/compose/integration/declaredfilters_integration_test.go
@@ -95,9 +95,10 @@ func TestTheOrganizationListNarrowsByDomain(t *testing.T) {
 		t.Fatalf("seeding the account that does not: %v", err)
 	}
 
-	// Folded the way the column stores it, so the lookup answers the same for
-	// a caller who typed the domain out of an email signature.
-	for _, asked := range []string{"acme.example", "ACME.example"} {
+	// Folded by the SAME parse the write path applies, so the lookup answers
+	// for a caller who typed the domain out of an email signature and for one
+	// who pasted the link out of a browser.
+	for _, asked := range []string{"acme.example", "ACME.example", "https://www.acme.example/careers"} {
 		page, _, err := e.People.ListOrganizations(e.Admin(), people.ListOrganizationsInput{Domain: &asked})
 		if err != nil {
 			t.Fatalf("listing organizations by domain %q: %v", asked, err)
@@ -156,7 +157,10 @@ func TestTheDomainFilterFindsAnArchivedAccountWhenAskedForOne(t *testing.T) {
 
 func TestTheActivityListNarrowsToTheOpenTasksOneAssigneeHolds(t *testing.T) {
 	e := Setup(t)
-	due := time.Now().Add(24 * time.Hour)
+	// A fixed instant rather than the host clock: the assertion is about which
+	// tasks the filter returns, and a due date that moves with the wall clock
+	// makes a validation rule the test never meant to exercise part of it.
+	due := time.Date(2026, 9, 1, 9, 0, 0, 0, time.UTC)
 	mine := e.logTask(t, "Call the buyer", e.Rep1, due)
 	closed := e.logTask(t, "Already handled", e.Rep1, due)
 	e.logTask(t, "Someone else's", e.Rep3, due)

--- a/backend/internal/compose/integration/overlay/overlay_e2e_integration_test.go
+++ b/backend/internal/compose/integration/overlay/overlay_e2e_integration_test.go
@@ -358,6 +358,10 @@ func assertHumanRestSurfaceServesTheMirror(t *testing.T, e *apptest.AppEnv) {
 		// so a page that could not contain it either way must not come back
 		// looking like the opt-in was honoured (ADR-0082/A127).
 		"/v1/organizations?include_anchor=true",
+		// Delivery work is ours as well, and this dial was neither forwarded
+		// nor refused until the declared-parameter gate found it: a caller
+		// asking for one project's deals was handed the whole mirror.
+		"/v1/deals?project_id=018f3a1b-0000-7000-8000-000000000010",
 	} {
 		if code := e.Call(t, "GET", path, nil, nil, nil); code != http.StatusUnprocessableEntity {
 			t.Errorf("overlay-mode %s = %d, want 422 — a filter with no mirror column must be refused, never ignored", path, code)

--- a/backend/internal/compose/overlayread.go
+++ b/backend/internal/compose/overlayread.go
@@ -268,6 +268,11 @@ func (s Server) ListDeals(w http.ResponseWriter, r *http.Request, params crmcont
 			{"stalled", params.Stalled != nil},
 			{"partner_org_id", params.PartnerOrgId != nil},
 			{"partner_sourced", params.PartnerSourced != nil},
+			// Delivery work is OUR record: the mirror holds the incumbent's
+			// deals and carries no project to attribute one to. Narrowing by a
+			// project would answer the whole mirror while reading as that
+			// project's deals.
+			{"project_id", params.ProjectId != nil},
 		},
 		nil, params.Cursor, params.Limit, overlayWireDeal,
 		func(data []crmcontracts.Deal, page crmcontracts.PageInfo) any {

--- a/backend/internal/compose/pipelineseams.go
+++ b/backend/internal/compose/pipelineseams.go
@@ -25,6 +25,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/modules/agents"
 	"github.com/gradionhq/margince/backend/internal/modules/deals"
 	"github.com/gradionhq/margince/backend/internal/modules/identity"
+	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
@@ -33,7 +34,9 @@ import (
 func pipelineLister(pool *pgxpool.Pool) agents.PipelineLister {
 	store := deals.NewStore(pool, identity.BaseCurrencyOf)
 	return func(ctx context.Context) ([]agents.Pipeline, error) {
-		rows, err := store.ListPipelines(ctx)
+		// Live only: this list is what a tool call picks a target stage
+		// from, and an archived pipeline is not one a deal may be moved to.
+		rows, err := store.ListPipelines(ctx, storekit.LiveOnly)
 		if err != nil {
 			return nil, err
 		}

--- a/backend/internal/modules/activities/activity.go
+++ b/backend/internal/modules/activities/activity.go
@@ -271,6 +271,11 @@ type ListActivitiesInput struct {
 	// account that has no long thread.
 	ThreadKey       *string
 	IncludeArchived bool
+	// AssigneeID is the work queue's narrowing: the OPEN tasks one person
+	// holds, which is what the contract declares the parameter to mean and
+	// what the partial index behind it is built on. Done-ness is part of
+	// that question rather than a second dial — see openTaskAssigneeClause.
+	AssigneeID *ids.UserID
 }
 
 // ListActivities is the timeline read: newest first, optionally scoped to

--- a/backend/internal/modules/activities/handlers_activity.go
+++ b/backend/internal/modules/activities/handlers_activity.go
@@ -19,6 +19,7 @@ func (h Handlers) ListActivities(w http.ResponseWriter, r *http.Request, params 
 		Query:           params.Q,
 		ThreadKey:       params.ThreadKey,
 		IncludeArchived: params.IncludeArchived != nil && *params.IncludeArchived,
+		AssigneeID:      idArg[ids.UserKind](params.AssigneeId),
 	}
 	if params.Kind != nil {
 		k := string(*params.Kind)

--- a/backend/internal/modules/activities/orgscope.go
+++ b/backend/internal/modules/activities/orgscope.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
 )
 
@@ -68,6 +69,29 @@ func activityReachesOrg(operand string) string {
 		operand)
 }
 
+// openTaskAssigneeClause narrows the timeline to the OPEN tasks one person
+// holds — the queue read the contract declares ("Open tasks for an
+// assignee"), spelled as the predicate the partial index behind it is built
+// on (idx_activity_tasks: workspace_id, assignee_id, due_at WHERE kind='task'
+// AND NOT is_done AND archived_at IS NULL).
+//
+// Done-ness belongs to the filter rather than to a dial of its own, and that
+// is the whole point: no parameter answers it, so binding assignee_id as a
+// plain column match would hand back every task the person ever closed under
+// a name the contract says means the open ones. A wider answer wearing the
+// declared answer's shape is the failure this filter exists to close, not a
+// convenience to preserve.
+//
+// `kind` is stated rather than implied. The `activity_task_fields` CHECK
+// already keeps assignee_id NULL on every other kind, so it narrows nothing —
+// it is what lets the planner match the partial index.
+func openTaskAssigneeClause(assignee *ids.UserID, arg func(any) int) string {
+	if assignee == nil {
+		return ""
+	}
+	return sprintf("a.assignee_id = $%d AND a.kind = 'task' AND NOT a.is_done", arg(*assignee))
+}
+
 // listActivitiesFilter builds the timeline query's join, WHERE terms and
 // bind arguments from one list input.
 func listActivitiesFilter(ctx context.Context, in ListActivitiesInput) (join string, where []string, args []any, err error) {
@@ -89,6 +113,9 @@ func listActivitiesFilter(ctx context.Context, in ListActivitiesInput) (join str
 	}
 	if in.Kind != nil {
 		where = append(where, sprintf("a.kind = $%d", arg(*in.Kind)))
+	}
+	if clause := openTaskAssigneeClause(in.AssigneeID, arg); clause != "" {
+		where = append(where, clause)
 	}
 	if in.EntityType != nil && in.EntityID != nil {
 		// The SAME vocabulary the write uses. A second list here drifted from

--- a/backend/internal/modules/deals/handlers_pipeline.go
+++ b/backend/internal/modules/deals/handlers_pipeline.go
@@ -7,12 +7,20 @@ import (
 	"net/http"
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/platform/httperr"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
-func (h Handlers) ListPipelines(w http.ResponseWriter, r *http.Request, _ crmcontracts.ListPipelinesParams) {
-	pipelines, err := h.store.ListPipelines(r.Context())
+// ListPipelines serves the pipeline catalog. The page is the whole catalog —
+// a workspace holds a handful of pipelines — so the only dial is whether the
+// archived ones come with it.
+func (h Handlers) ListPipelines(w http.ResponseWriter, r *http.Request, params crmcontracts.ListPipelinesParams) {
+	archived := storekit.LiveOnly
+	if params.IncludeArchived != nil && *params.IncludeArchived {
+		archived = storekit.IncludeArchived
+	}
+	pipelines, err := h.store.ListPipelines(r.Context(), archived)
 	if err != nil {
 		writeStoreErr(w, r, err)
 		return

--- a/backend/internal/modules/deals/listquery.go
+++ b/backend/internal/modules/deals/listquery.go
@@ -60,7 +60,7 @@ func buildListPrelude(
 		return nil, err
 	}
 
-	p := &listPrelude{sorted: sorted, limit: storekit.ClampLimit(limit), where: []string{offerTemplateWhereSeed}}
+	p := &listPrelude{sorted: sorted, limit: storekit.ClampLimit(limit), where: []string{whereSeed}}
 	p.arg = func(v any) int { p.args = append(p.args, v); return len(p.args) }
 
 	// A row-scoped record narrows to what this reader may see. The

--- a/backend/internal/modules/deals/offer_template.go
+++ b/backend/internal/modules/deals/offer_template.go
@@ -44,14 +44,17 @@ const defaultOfferTemplateLocale = "de-DE"
 // (create, update) reference it.
 const offerTemplateIsDefaultField = "is_default"
 
-// offerTemplateWhereSeed and offerTemplateArchivedAtClause are the
-// list/read query-builder's repeated SQL fragments, named once so this
-// file's own occurrences aren't raw duplicated literals (the same
-// fragments recur, unnamed, in the package's older files — that backlog
-// is untouched here).
+// offerTemplateWhereSeed and liveRowsClause are the list/read
+// query-builder's repeated SQL fragments, named once so this file's own
+// occurrences aren't raw duplicated literals (the same fragments recur,
+// unnamed, in the package's older files — that backlog is untouched here).
+//
+// liveRowsClause carries no offer-template prefix because it says nothing
+// about them: it is this module's one spelling of "rows nothing has
+// archived", and the pipeline catalog narrows through it too.
 const (
-	offerTemplateWhereSeed        = "1=1"
-	offerTemplateArchivedAtClause = " AND archived_at IS NULL"
+	offerTemplateWhereSeed = "1=1"
+	liveRowsClause         = " AND archived_at IS NULL"
 )
 
 // DuplicateTemplateNameError reports a live-row name collision
@@ -411,7 +414,7 @@ const offerTemplateColumns = `id, workspace_id, name, locale, is_default, layout
 func readOfferTemplate(ctx context.Context, tx pgx.Tx, id ids.OfferTemplateID, archived storekit.ArchivedFilter) (crmcontracts.OfferTemplate, error) {
 	q := `SELECT ` + offerTemplateColumns + ` FROM offer_template WHERE id = $1`
 	if archived == storekit.LiveOnly {
-		q += offerTemplateArchivedAtClause
+		q += liveRowsClause
 	}
 	t, err := scanOfferTemplate(tx.QueryRow(ctx, q, id))
 	if errors.Is(err, pgx.ErrNoRows) {

--- a/backend/internal/modules/deals/offer_template.go
+++ b/backend/internal/modules/deals/offer_template.go
@@ -44,19 +44,6 @@ const defaultOfferTemplateLocale = "de-DE"
 // (create, update) reference it.
 const offerTemplateIsDefaultField = "is_default"
 
-// offerTemplateWhereSeed and liveRowsClause are the list/read
-// query-builder's repeated SQL fragments, named once so this file's own
-// occurrences aren't raw duplicated literals (the same fragments recur,
-// unnamed, in the package's older files — that backlog is untouched here).
-//
-// liveRowsClause carries no offer-template prefix because it says nothing
-// about them: it is this module's one spelling of "rows nothing has
-// archived", and the pipeline catalog narrows through it too.
-const (
-	offerTemplateWhereSeed = "1=1"
-	liveRowsClause         = " AND archived_at IS NULL"
-)
-
 // DuplicateTemplateNameError reports a live-row name collision
 // (offer_template_name_unique). The pre-check ahead of INSERT/UPDATE is
 // the clean common-case path and carries ExistingID cheaply; a

--- a/backend/internal/modules/deals/pipeline.go
+++ b/backend/internal/modules/deals/pipeline.go
@@ -115,14 +115,26 @@ func (s *Store) GetPipeline(ctx context.Context, id ids.PipelineID) (crmcontract
 	return out, err
 }
 
-func (s *Store) ListPipelines(ctx context.Context) ([]crmcontracts.Pipeline, error) {
+// ListPipelines answers the pipeline catalog, live rows only unless the
+// caller asks for the archived ones too (the contract's include_archived).
+// An archived pipeline still carries deals and history, so an admin
+// reviewing where a closed deal was worked has to be able to see it.
+//
+// Its STAGES stay live-only either way: include_archived names the rows this
+// list answers about, and a stage's own archival is what listStages' copy of
+// the parameter answers.
+func (s *Store) ListPipelines(ctx context.Context, archived storekit.ArchivedFilter) ([]crmcontracts.Pipeline, error) {
 	if err := auth.Require(ctx, "pipeline", principal.ActionRead); err != nil {
 		return nil, err
+	}
+	live := ""
+	if archived == storekit.LiveOnly {
+		live = ` WHERE archived_at IS NULL`
 	}
 	var out []crmcontracts.Pipeline
 	err := s.tx(ctx, func(tx pgx.Tx) error {
 		rows, err := tx.Query(ctx,
-			`SELECT id FROM pipeline WHERE archived_at IS NULL ORDER BY position, created_at`)
+			`SELECT id FROM pipeline`+live+` ORDER BY position, created_at`)
 		if err != nil {
 			return err
 		}
@@ -141,7 +153,7 @@ func (s *Store) ListPipelines(ctx context.Context) ([]crmcontracts.Pipeline, err
 		}
 
 		for _, id := range pipelineIDs {
-			p, err := readPipeline(ctx, tx, id)
+			p, err := readPipelineWith(ctx, tx, id, archived)
 			if err != nil {
 				return err
 			}
@@ -177,12 +189,27 @@ func (s *Store) DefaultPipeline(ctx context.Context) (crmcontracts.Pipeline, err
 	return out, err
 }
 
+// readPipeline is the single-row read every live-only caller uses: a
+// pipeline that has been archived reads as missing.
 func readPipeline(ctx context.Context, tx pgx.Tx, id ids.PipelineID) (crmcontracts.Pipeline, error) {
+	return readPipelineWith(ctx, tx, id, storekit.LiveOnly)
+}
+
+// readPipelineWith is that read with the archived rows admitted or not, so
+// the catalog list can serve include_archived through the same assembly
+// rather than a second copy of it.
+func readPipelineWith(
+	ctx context.Context, tx pgx.Tx, id ids.PipelineID, archived storekit.ArchivedFilter,
+) (crmcontracts.Pipeline, error) {
 	var p crmcontracts.Pipeline
 	var pid, wsID ids.UUID
+	live := ""
+	if archived == storekit.LiveOnly {
+		live = liveRowsClause
+	}
 	err := tx.QueryRow(ctx,
 		`SELECT id, workspace_id, name, is_default, position, created_at, updated_at, archived_at
-		 FROM pipeline WHERE id = $1 AND archived_at IS NULL`, id).
+		 FROM pipeline WHERE id = $1`+live, id).
 		Scan(&pid, &wsID, &p.Name, &p.IsDefault, &p.Position, &p.CreatedAt, &p.UpdatedAt, &p.ArchivedAt)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return p, apperrors.ErrNotFound

--- a/backend/internal/modules/deals/pipeline.go
+++ b/backend/internal/modules/deals/pipeline.go
@@ -119,8 +119,7 @@ func (s *Store) GetPipeline(ctx context.Context, id ids.PipelineID) (crmcontract
 // caller asks for the archived ones too (the contract's include_archived).
 //
 // No operation on this contract archives a pipeline, so the dial changes
-// nothing a deployment's own endpoints can produce (#835 carries the choice:
-// give the state a writer, or retire the parameter). It is bound rather than
+// nothing a deployment's own endpoints can produce. It is bound rather than
 // dropped because the column and this read's filter on it are what decide the
 // answer, and a row in that state — from a fork's migration, from an ops
 // repair — is then reachable by the parameter that names it instead of being

--- a/backend/internal/modules/deals/pipeline.go
+++ b/backend/internal/modules/deals/pipeline.go
@@ -119,7 +119,7 @@ func (s *Store) GetPipeline(ctx context.Context, id ids.PipelineID) (crmcontract
 // caller asks for the archived ones too (the contract's include_archived).
 //
 // No operation on this contract archives a pipeline, so the dial changes
-// nothing a deployment's own endpoints can produce (#829 carries the choice:
+// nothing a deployment's own endpoints can produce (#835 carries the choice:
 // give the state a writer, or retire the parameter). It is bound rather than
 // dropped because the column and this read's filter on it are what decide the
 // answer, and a row in that state — from a fork's migration, from an ops

--- a/backend/internal/modules/deals/pipeline.go
+++ b/backend/internal/modules/deals/pipeline.go
@@ -117,8 +117,14 @@ func (s *Store) GetPipeline(ctx context.Context, id ids.PipelineID) (crmcontract
 
 // ListPipelines answers the pipeline catalog, live rows only unless the
 // caller asks for the archived ones too (the contract's include_archived).
-// An archived pipeline still carries deals and history, so an admin
-// reviewing where a closed deal was worked has to be able to see it.
+//
+// No operation on this contract archives a pipeline, so the dial changes
+// nothing a deployment's own endpoints can produce (#829 carries the choice:
+// give the state a writer, or retire the parameter). It is bound rather than
+// dropped because the column and this read's filter on it are what decide the
+// answer, and a row in that state — from a fork's migration, from an ops
+// repair — is then reachable by the parameter that names it instead of being
+// invisible to every caller.
 //
 // Its STAGES stay live-only either way: include_archived names the rows this
 // list answers about, and a stage's own archival is what listStages' copy of
@@ -127,14 +133,14 @@ func (s *Store) ListPipelines(ctx context.Context, archived storekit.ArchivedFil
 	if err := auth.Require(ctx, "pipeline", principal.ActionRead); err != nil {
 		return nil, err
 	}
-	live := ""
+	archivedFilter := ""
 	if archived == storekit.LiveOnly {
-		live = ` WHERE archived_at IS NULL`
+		archivedFilter = liveRowsClause
 	}
 	var out []crmcontracts.Pipeline
 	err := s.tx(ctx, func(tx pgx.Tx) error {
 		rows, err := tx.Query(ctx,
-			`SELECT id FROM pipeline`+live+` ORDER BY position, created_at`)
+			`SELECT id FROM pipeline WHERE `+whereSeed+archivedFilter+` ORDER BY position, created_at`)
 		if err != nil {
 			return err
 		}

--- a/backend/internal/modules/deals/project_read.go
+++ b/backend/internal/modules/deals/project_read.go
@@ -157,7 +157,7 @@ const projectColumns = `id, workspace_id, name, key, organization_id, owner_id, 
 func readProject(ctx context.Context, tx pgx.Tx, id ids.ProjectID, archived storekit.ArchivedFilter, active []fieldcatalog.Column) (crmcontracts.Project, error) {
 	q := `SELECT ` + projectColumns + storekit.SelectSuffix(active) + ` FROM project WHERE id = $1`
 	if archived == storekit.LiveOnly {
-		q += offerTemplateArchivedAtClause
+		q += liveRowsClause
 	}
 	p, err := scanProject(tx.QueryRow(ctx, q, id), active)
 	if errors.Is(err, pgx.ErrNoRows) {

--- a/backend/internal/modules/deals/store.go
+++ b/backend/internal/modules/deals/store.go
@@ -18,6 +18,17 @@ import (
 	"github.com/gradionhq/margince/backend/internal/shared/ports/fieldcatalog"
 )
 
+// whereSeed opens a list/read WHERE chain so every optional narrowing
+// appends uniformly — the chain is never empty even when no filter applies.
+const whereSeed = "1=1"
+
+// liveRowsClause narrows a read to the rows nothing has archived. It lives
+// beside the store every one of this module's reads runs through, because
+// three of them append it — the offer-template list, the project read and the
+// pipeline catalog — and a reader of any one should find it without knowing
+// which record type happened to name it first.
+const liveRowsClause = " AND archived_at IS NULL"
+
 // Store owns this module's tables (data-seam ownership, ADR-0014 Am.1);
 // every write rides the storekit audit+outbox shape in one transaction.
 type Store struct {

--- a/backend/internal/modules/people/doc.go
+++ b/backend/internal/modules/people/doc.go
@@ -13,7 +13,10 @@
 // Merge and promotion additionally relink rows in deal, activity_link,
 // list_member, taggable and consent_event inside their single
 // transaction — the ratified cross-aggregate ownership call of the
-// primary aggregate; nothing else in this module touches sibling tables.
+// primary aggregate; nothing else in this module WRITES a sibling table.
+// The person list READS two of collections' — tag and taggable — for the
+// contract's `tag` filter: a tagged person is a link row whichever module
+// writes it, and the alternative is a declared filter answered by nobody.
 //
 // Imports shared + platform + the generated contract only; never a
 // sibling module. Every write rides storekit's audit+outbox shape and

--- a/backend/internal/modules/people/handlers_organization.go
+++ b/backend/internal/modules/people/handlers_organization.go
@@ -46,6 +46,7 @@ func (h Handlers) ListOrganizations(w http.ResponseWriter, r *http.Request, para
 		CustomFilters:    httperr.CustomFieldFilters(r),
 		Lifecycle:        enumArg(params.Lifecycle),
 		RelationshipType: enumArg(params.RelationshipType),
+		Domain:           params.Domain,
 	}
 	in.OwnerID = idArg[ids.UserKind](params.OwnerId)
 

--- a/backend/internal/modules/people/handlers_person.go
+++ b/backend/internal/modules/people/handlers_person.go
@@ -42,6 +42,7 @@ func (h Handlers) ListPeople(w http.ResponseWriter, r *http.Request, params crmc
 		AiWritten:       params.AiWritten,
 		Sort:            params.Sort,
 		CustomFilters:   httperr.CustomFieldFilters(r),
+		Tag:             params.Tag,
 	}
 	in.OwnerID = idArg[ids.UserKind](params.OwnerId)
 

--- a/backend/internal/modules/people/listfilters.go
+++ b/backend/internal/modules/people/listfilters.go
@@ -18,7 +18,7 @@ package people
 // module holds in another table rather than in a column of its own. What this
 // set decides is narrower: which names a TOOL publishes. Every one of them is
 // rendered into the tool listing each step of a run re-sends, so growing it is
-// the catalog-budget decision (gradionhq/margince-poc-v1#737), not something a
+// the catalog-budget decision (#737, and #828 for these two), not something a
 // store learning to bind one more filter settles on its own.
 
 import (

--- a/backend/internal/modules/people/listfilters.go
+++ b/backend/internal/modules/people/listfilters.go
@@ -12,9 +12,14 @@ package people
 // narrows. The composition root publishes the intersection, so a filter
 // declared by the contract and answered by no store is offered by neither.
 //
-// A contract parameter absent below is absent on purpose: `tag` is declared by
-// listPeople and no column here holds tags, so listing by it would return
-// everything while looking exactly like a narrowed answer.
+// A contract parameter absent below is absent on purpose, and absent is not
+// the same as unanswerable. The REST person list narrows by `tag` and the
+// organization list by `domain` — both through link predicates over rows this
+// module holds in another table rather than in a column of its own. What this
+// set decides is narrower: which names a TOOL publishes. Every one of them is
+// rendered into the tool listing each step of a run re-sends, so growing it is
+// the catalog-budget decision (gradionhq/margince-poc-v1#737), not something a
+// store learning to bind one more filter settles on its own.
 
 import (
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"

--- a/backend/internal/modules/people/listfilters.go
+++ b/backend/internal/modules/people/listfilters.go
@@ -18,8 +18,8 @@ package people
 // module holds in another table rather than in a column of its own. What this
 // set decides is narrower: which names a TOOL publishes. Every one of them is
 // rendered into the tool listing each step of a run re-sends, so growing it is
-// the catalog-budget decision (#737, and #828 for these two), not something a
-// store learning to bind one more filter settles on its own.
+// the catalog-budget decision, not something a store learning to bind one more
+// filter settles on its own.
 
 import (
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"

--- a/backend/internal/modules/people/organization_list.go
+++ b/backend/internal/modules/people/organization_list.go
@@ -18,6 +18,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/platform/httperr"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/values"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/fieldcatalog"
 )
 
@@ -72,25 +73,52 @@ var organizationListFields = map[string]string{
 // organizationDomainClause narrows the page to the account that lists one
 // domain, or "" when the caller named none.
 //
-// The value is folded the way organization_domain stores it (normalizeDomain),
-// so a caller's capitalization decides nothing — and it is compared against
-// LIVE domain rows only, which is both what the page itself attaches and what
-// `uq_org_domain` indexes. A domain released by one account and taken by
-// another must answer with the account that holds it now.
+// The value is reduced by the SAME parse the write path applies
+// (parseOrgDomains → values.ParseDomain), so a caller who pasted
+// `https://www.acme.example/careers` out of a signature asks about the host
+// the column actually holds. A value that reduces to no host at all matches
+// nothing, which is the honest answer to a domain that is not one — the
+// caller asked about an account by something no account can list.
+//
+// Domain-row liveness follows the caller's own archived question. A live page
+// compares against live domain rows: the account that holds the domain NOW is
+// the one a lookup means, and `uq_org_domain` indexes exactly those. But
+// archiving an account archives its domain rows in the same transaction, so
+// pinning liveness here would make `include_archived=true&domain=…` a page
+// that can never contain the archived account that held it — an empty answer
+// reading "nobody ever had this", which is the same confident wrong answer
+// this filter exists to prevent, inverted.
 //
 // EXISTS rather than a join: an account lists several domains, and a join
 // would return it once per row the keyset cursor would then page over as if
 // they were distinct accounts.
-func organizationDomainClause(domain *string, arg func(any) int) string {
+func organizationDomainClause(domain *string, includeArchived bool, arg func(any) int) string {
 	if domain == nil {
 		return ""
+	}
+	live := " AND d.archived_at IS NULL"
+	if includeArchived {
+		live = ""
 	}
 	return storekit.SQLf(`EXISTS (
 		SELECT 1 FROM organization_domain d
 		WHERE d.workspace_id = organization.workspace_id
 		  AND d.organization_id = organization.id
-		  AND d.domain = $%d AND d.archived_at IS NULL)`,
-		arg(normalizeDomain(*domain)))
+		  AND d.domain = $%d`+live+`)`,
+		arg(foldDomainQuery(*domain)))
+}
+
+// foldDomainQuery reduces a caller's domain to the host organization_domain
+// stores, or to a value no row can carry when it names no host. It answers a
+// string rather than a parse error because a filter that cannot match is a
+// page with nothing in it, not a request the surface should refuse: the
+// caller named an account by something, and no account has it.
+func foldDomainQuery(raw string) string {
+	parsed, err := values.ParseDomain(raw)
+	if err != nil {
+		return ""
+	}
+	return parsed.String()
 }
 
 // ListOrganizations is the row-scoped organization list read:
@@ -128,7 +156,7 @@ func (s *Store) ListOrganizations(ctx context.Context, in ListOrganizationsInput
 			if in.Classification != nil {
 				where = append(where, storekit.SQLf("classification = $%d", arg(*in.Classification)))
 			}
-			if clause := organizationDomainClause(in.Domain, arg); clause != "" {
+			if clause := organizationDomainClause(in.Domain, in.IncludeArchived, arg); clause != "" {
 				where = append(where, clause)
 			}
 			// A value outside the enum is a client mistake, not a selection

--- a/backend/internal/modules/people/organization_list.go
+++ b/backend/internal/modules/people/organization_list.go
@@ -42,7 +42,11 @@ type ListOrganizationsInput struct {
 	Classification   *string
 	Lifecycle        *string
 	RelationshipType *string
-	IncludeArchived  bool
+	// Domain narrows to the account that lists one domain — the
+	// employer-inference lookup, spelled as a filter over the same
+	// organization_domain rows the page attaches.
+	Domain          *string
+	IncludeArchived bool
 	// CapturedByKind filters on the captured_by prefix (ADR-0075/A121 §3a).
 	CapturedByKind *string
 	// AiWritten filters on whether an AI wrote into the record (§3a).
@@ -65,9 +69,33 @@ var organizationListFields = map[string]string{
 	ownerIDColumn:   storekit.KindUUID,
 }
 
+// organizationDomainClause narrows the page to the account that lists one
+// domain, or "" when the caller named none.
+//
+// The value is folded the way organization_domain stores it (normalizeDomain),
+// so a caller's capitalization decides nothing — and it is compared against
+// LIVE domain rows only, which is both what the page itself attaches and what
+// `uq_org_domain` indexes. A domain released by one account and taken by
+// another must answer with the account that holds it now.
+//
+// EXISTS rather than a join: an account lists several domains, and a join
+// would return it once per row the keyset cursor would then page over as if
+// they were distinct accounts.
+func organizationDomainClause(domain *string, arg func(any) int) string {
+	if domain == nil {
+		return ""
+	}
+	return storekit.SQLf(`EXISTS (
+		SELECT 1 FROM organization_domain d
+		WHERE d.workspace_id = organization.workspace_id
+		  AND d.organization_id = organization.id
+		  AND d.domain = $%d AND d.archived_at IS NULL)`,
+		arg(normalizeDomain(*domain)))
+}
+
 // ListOrganizations is the row-scoped organization list read:
-// quick-find, owner, classification and custom-field filters, keyset
-// pagination under the validated sort.
+// quick-find, owner, domain, classification and custom-field filters,
+// keyset pagination under the validated sort.
 func (s *Store) ListOrganizations(ctx context.Context, in ListOrganizationsInput) ([]crmcontracts.Organization, storekit.Page, error) {
 	shared := listFilters{
 		IncludeArchived: in.IncludeArchived,
@@ -99,6 +127,9 @@ func (s *Store) ListOrganizations(ctx context.Context, in ListOrganizationsInput
 			}
 			if in.Classification != nil {
 				where = append(where, storekit.SQLf("classification = $%d", arg(*in.Classification)))
+			}
+			if clause := organizationDomainClause(in.Domain, arg); clause != "" {
+				where = append(where, clause)
 			}
 			// A value outside the enum is a client mistake, not a selection
 			// that happens to match nothing: answering 200 with an empty page

--- a/backend/internal/modules/people/person_list.go
+++ b/backend/internal/modules/people/person_list.go
@@ -69,7 +69,10 @@ var personListFields = map[string]string{
 // vocabulary is unique by (`uq_tag_name` over lower(name)), which also means a
 // name identifies at most one tag whether or not it has since been archived:
 // the link is the fact this filter answers, and retiring the word from the
-// picker does not un-tag the people who carry it.
+// picker does not un-tag the people who carry it. A record's own tag SECTION
+// deliberately answers otherwise (compose/org360 shows live tags only):
+// displaying a retired word beside a record is clutter, while failing to find
+// the people who carry it is a wrong answer.
 //
 // EXISTS rather than a join: a person carries many tags, and a join would
 // return them once per matching link — rows the keyset cursor would then page

--- a/backend/internal/modules/people/person_list.go
+++ b/backend/internal/modules/people/person_list.go
@@ -9,6 +9,7 @@ package people
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -43,6 +44,10 @@ type ListPeopleInput struct {
 	// CustomFilters carries the request's cf_* query parameters —
 	// equality matches against active custom columns (storekit listquery).
 	CustomFilters map[string]string
+	// Tag narrows to the people carrying one tag, by name. The tag
+	// vocabulary belongs to another module, so this is a link predicate
+	// rather than a column — see personTagClause.
+	Tag *string
 }
 
 // personListFields is the person list's core sortable vocabulary —
@@ -55,24 +60,68 @@ var personListFields = map[string]string{
 	ownerIDColumn:    storekit.KindUUID,
 }
 
-// ListPeople is the row-scoped person list read: quick-find, owner and
+// personTagClause narrows the page to the people carrying one tag, or ""
+// when the caller named none.
+//
+// Tags live in another module's tables, which this one may not import — but
+// the predicate is SQL, and a tagged person is a row in `taggable` whatever
+// package writes it. Matching is on the FOLDED name because that is what the
+// vocabulary is unique by (`uq_tag_name` over lower(name)), which also means a
+// name identifies at most one tag whether or not it has since been archived:
+// the link is the fact this filter answers, and retiring the word from the
+// picker does not un-tag the people who carry it.
+//
+// EXISTS rather than a join: a person carries many tags, and a join would
+// return them once per matching link — rows the keyset cursor would then page
+// over as if they were distinct people. Both tables are workspace-qualified
+// against the person's own workspace, which RLS already guarantees and
+// `idx_taggable_entity` needs as its leading column.
+func personTagClause(tag *string, arg func(any) int) string {
+	if tag == nil {
+		return ""
+	}
+	return storekit.SQLf(`EXISTS (
+		SELECT 1 FROM taggable tg
+		  JOIN tag t ON t.id = tg.tag_id AND t.workspace_id = tg.workspace_id
+		WHERE tg.workspace_id = person.workspace_id
+		  AND tg.entity_type = $%d AND tg.entity_id = person.id
+		  AND lower(t.name) = $%d)`,
+		arg(personEntity), arg(foldTagName(*tag)))
+}
+
+// foldTagName matches how the tag vocabulary is stored and compared: names
+// are trimmed on write and unique under lower(), so a caller's spacing and
+// case decide nothing about which tag they named.
+func foldTagName(name string) string { return strings.ToLower(strings.TrimSpace(name)) }
+
+// ListPeople is the row-scoped person list read: quick-find, owner, tag and
 // custom-field filters, keyset pagination under the validated sort.
 func (s *Store) ListPeople(ctx context.Context, in ListPeopleInput) ([]crmcontracts.Person, storekit.Page, error) {
+	shared := listFilters{
+		IncludeArchived: in.IncludeArchived,
+		CapturedByKind:  in.CapturedByKind,
+		AiWritten:       in.AiWritten,
+		entity:          personEntity,
+		OwnerID:         in.OwnerID,
+		Query:           in.Query,
+		Cursor:          in.Cursor,
+		CustomFilters:   in.CustomFilters,
+		nameColumn:      personNameColumn,
+	}
 	return listPage(ctx, s, in.Sort, in.Limit, listPageSpec[crmcontracts.Person]{
 		entity:  personEntity,
 		columns: personColumns,
 		fields:  personListFields,
-		filters: listFilters{
-			IncludeArchived: in.IncludeArchived,
-			CapturedByKind:  in.CapturedByKind,
-			AiWritten:       in.AiWritten,
-			entity:          personEntity,
-			OwnerID:         in.OwnerID,
-			Query:           in.Query,
-			Cursor:          in.Cursor,
-			CustomFilters:   in.CustomFilters,
-			nameColumn:      personNameColumn,
-		}.clauses,
+		filters: func(active []fieldcatalog.Column, sorted *storekit.ListSort, arg func(any) int) ([]string, error) {
+			where, err := shared.clauses(active, sorted, arg)
+			if err != nil {
+				return nil, err
+			}
+			if clause := personTagClause(in.Tag, arg); clause != "" {
+				where = append(where, clause)
+			}
+			return where, nil
+		},
 		scan:   scanPersonPage,
 		attach: attachPersonChildren,
 		cursorKey: func(last crmcontracts.Person) (time.Time, ids.UUID) {


### PR DESCRIPTION
Closes #631. Closes #579.

## What was wrong

Four declared query parameters were dropped by the handlers behind them. `GET /v1/people?tag=vip` returned **every** person the caller may see, `200 OK`, well-formed page — indistinguishable from a workspace where everyone carries the tag. The same for `?domain=`, `?assignee_id=`, `?include_archived=` on pipelines, and — in overlay mode — `?project_id=` on deals, which answered the whole incumbent mirror.

`min_score`, the third parameter #631 names, was **already bound** on `main` (`handlers_lead.go:23` → `lead_list.go:78`). Re-checking the citations turned up two sites the issue does not name, plus the overlay one, which is the point of deriving the census instead of working a list.

## What changed

| where | parameter | bound as |
|---|---|---|
| `listPeople` | `tag` | EXISTS over the tag link, matched on the folded name the vocabulary is unique by (`uq_tag_name` over `lower(name)`) |
| `listOrganizations` | `domain` | EXISTS over the account's **live** domain rows, folded the way `organization_domain` stores them |
| `listActivities` | `assignee_id` | the **open tasks** one person holds — the contract's own wording, and the predicate `idx_activity_tasks` is built on |
| `listPipelines` | `include_archived` | the catalog read serves both values through one assembly |
| overlay `ListDeals` | `project_id` | refused with the 422 the mirror's other unanswerable dials use |

EXISTS rather than a join in both new predicates: a person carries many tags and an account many domains, and a join would return the row once per match — rows the keyset cursor would then page over as if they were distinct records.

### The judgement worth reviewing

`assignee_id` is declared as *"Open tasks for an assignee"*, so the clause is `assignee_id = $n AND kind = 'task' AND NOT is_done`. Binding it as a plain column match would answer with every task that person ever closed, under a name the contract says means the open ones — the same widen-in-the-declared-answer's-shape failure this PR is about. `kind` is stated rather than implied (the `activity_task_fields` CHECK already keeps `assignee_id` NULL elsewhere) so the planner can match the partial index.

## The durable half — the gate (#579)

`backend/declaredfilters_test.go` derives the obligation from the generated contract rather than maintaining a list, in two parts:

- **native**: a handler reaches its store with every narrowing dial — or hands the whole params value on, or owns the raw query string itself (the report handlers parse `by`/`agg` out of it);
- **overlay shadow**: each dial is forwarded or refused **in the branch that reads the mirror**. A reference inside the native-delegation closure proves nothing about the mirror path, which is exactly how `occurred_from`/`occurred_to` were once dropped.

Paging and ordering (`cursor`, `limit`, `sort`) are out of scope on purpose and the header says why: they spell a page's *shape*, not its membership. Six operations ignore one of the three today — filed separately rather than folded in here.

`include_archived` on the overlay shadows is the gate's one ratified exception (the mirror holds no archived rows at all, so both values answer the same page); a reasonless or stale waiver fails, per `gatekit`.

**The gate carries its own defect test.** A walk that recognises nothing passes exactly like a clean tree, so `TestTheDeclaredFilterWalkReportsADroppedParameterAndNothingElse` puts each shape it must tell apart to it against source written for the purpose. Reverting either real fix locally reproduces the failure the gate is for:

```
declaredfilters_test.go:120: internal/modules/people/handlers_person.go: ListPeopleParams declares `tag`
  and ListPeople never reads it, so the page it answers is wider than the one that was asked for
declaredfilters_test.go:148: internal/compose/overlayread.go: ListDeals neither forwards `project_id`
  to the mirror nor refuses it, so in overlay mode the dial is dropped
```

## Verification

- `make check-backend` — green (exit 0), including `craft static --strict` over every changed Go file: `PASS — 0 blocker, 0 major, 0 minor`.
- Four new integration tests against real Postgres, each seeded to have a right answer **and** the row a dropped filter would hand back with it — a unit test cannot tell the two apart, because the wrong answer is well-formed.
- The overlay e2e refusal suite gains `/v1/deals?project_id=…`; package green.

## Deliberately not in this PR

- **The agent seam's filter vocabulary.** The stores now bind `tag` and `domain` (and already bound `min_score`), but `list_records` still publishes neither: every name there is rendered into the tool listing each step of a run re-sends, so growing it is #737's catalog-budget decision, not a consequence of a store learning one more filter. `listfilters.go`'s comment, which claimed no store could answer `tag`, is corrected to say what the set actually decides.
- **No contract operation archives a pipeline today**, so `include_archived` there has no producer — the test ages the row by SQL and says so. Either that parameter gains a writer or it is retired upstream; both are product calls.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bind all declared list filters to their stores and add a contract-derived gate to prevent dropped filters, fixing #631 and #579. The gate now also recognizes pointer-typed and multi-name params, and tests verify URL-form domain parsing and use a fixed clock.

- **Bug Fixes**
  - People: `tag` narrows by tag name (case/space-folded) via an EXISTS over tag links.
  - Organizations: `domain` narrows to the org that lists the domain (URL forms parsed/folded), and honors `include_archived` to find archived holders when asked.
  - Activities: `assignee_id` returns the open tasks an assignee holds, matching the partial index predicate.
  - Pipelines: `include_archived` is honored via a unified catalog read; tool-facing list uses `storekit.LiveOnly`.
  - Overlay Deals: `project_id` is refused with 422; the mirror has no project column.

- **New Features**
  - Gate: static checks ensure each narrowing param is referenced by native handlers and forwarded or refused by overlay shadows; paging params are excluded by type. Shadows are discovered by overlay-mode dispatch and judged even when they delegate without a closure. It now also matches pointer or grouped params in handler signatures and explicitly claims only what it proves (reference, not correctness).
  - Tests: added HTTP-level integration tests that prove `tag`, `domain`, `assignee_id`, and `include_archived` actually narrow over the wire; store-level tests cover the same, plus an overlay refusal for `project_id`. Gate defect tests cover both closure and non-closure delegation, pointer/grouped signatures, and the clarified scope; time-based fixtures use a fixed instant.

<sup>Written for commit 0b9beafc9a41d56fd3dee10e4e741d05333fcac4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/826?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added people filtering by tag and organization filtering by domain.
  - Added activity filtering by assignee, limited to open tasks.
  - Added an option to include archived pipelines in pipeline listings; live pipelines remain the default.
- **Bug Fixes**
  - Overlay deal searches now clearly reject unsupported project filters instead of silently ignoring them.
- **Tests**
  - Added coverage validating list filters, archived-record behavior, and HTTP responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->