### PR TITLE
test(contract): a field the contract promises and nobody writes now fails a gate

### DIFF
--- a/backend/contractproducers_test.go
+++ b/backend/contractproducers_test.go
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package backendarch
+
+// A field the contract PROMISES and nobody WRITES is invisible.
+//
+// `make drift` proves the generated Go matches api/crm.yaml. Nothing proves a
+// handler fills what the contract advertises, so a schema property with no
+// producer ships as permanently absent — and absent, on these composites,
+// reads as a fact about the account. `last_meeting_at` sat on
+// Organization360Health for exactly that reason: promised, never set, and
+// rendering as "no meeting" on every company in the product.
+//
+// This is the shape of bug that adding fields to a composite creates, so it is
+// derived rather than listed: the struct's own field set is the obligation, and
+// a new property joins the check by existing.
+//
+// SCOPE is deliberately the page composites rather than every schema. Most
+// contract types are request bodies or are filled by a mapper the compiler
+// already forces to be total; these three are assembled field by field from
+// separate readers, which is where a field quietly goes unwritten (ADR-0095).
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// The composites the company record page reads. Each is assembled by hand from
+// several sources, which is the shape this gate guards.
+var producedSchemas = []string{
+	"Organization360Health",
+	"OrganizationGrowthFit",
+	"Organization360Suggestion",
+}
+
+// A Go field declaration inside a generated struct: `\tName Type `json:...“.
+var genField = regexp.MustCompile("^\t([A-Z][A-Za-z0-9]*)\\s+\\S")
+
+func TestEveryContractPropertyOnAPageCompositeHasAProducer(t *testing.T) {
+	fields := map[string][]string{}
+	for _, schema := range producedSchemas {
+		found := generatedFieldsOf(t, schema)
+		if len(found) == 0 {
+			t.Fatalf("%s: no fields found in the generated contract — the struct was renamed or removed, and this gate is now watching nothing", schema)
+		}
+		fields[schema] = found
+	}
+
+	// Every hand-written Go file under internal/, as one corpus. A producer is
+	// any non-generated file that names the field — assignment, struct literal
+	// or mapper alike, because all three are ways of filling it.
+	corpus := handWrittenGoUnderInternal(t)
+
+	for _, schema := range producedSchemas {
+		for _, field := range fields[schema] {
+			if strings.Contains(corpus, field) {
+				continue
+			}
+			t.Errorf(
+				"%s.%s is in the contract and no hand-written file under internal/ mentions it.\n"+
+					"A property nobody writes renders as absent forever, and on this composite absent is\n"+
+					"a claim about the account. Produce it where the section is assembled, or take it out\n"+
+					"of api/crm.yaml.",
+				schema, field,
+			)
+		}
+	}
+}
+
+// generatedFieldsOf reads one struct out of the generated contract and returns
+// its exported field names. Textual, like its sibling gates: the root fitness
+// package stays free of parser dependencies (the arch-lint boundary).
+func generatedFieldsOf(t *testing.T, schema string) []string {
+	t.Helper()
+	const path = "internal/contracts/api_gen.go"
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read the generated contract: %v", err)
+	}
+	lines := strings.Split(string(raw), "\n")
+	open := "type " + schema + " struct {"
+	var fields []string
+	inside := false
+	for _, line := range lines {
+		if !inside {
+			inside = line == open
+			continue
+		}
+		if line == "}" {
+			break
+		}
+		if match := genField.FindStringSubmatch(line); match != nil {
+			fields = append(fields, match[1])
+		}
+	}
+	return fields
+}
+
+// handWrittenGoUnderInternal is every .go file under internal/ that is not
+// generated and not a test, concatenated. Tests are excluded on purpose: a
+// field only a test writes has no producer in the product.
+func handWrittenGoUnderInternal(t *testing.T) string {
+	t.Helper()
+	var out strings.Builder
+	err := filepath.WalkDir("internal", func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() || !strings.HasSuffix(path, ".go") {
+			return nil
+		}
+		name := filepath.Base(path)
+		if strings.HasSuffix(name, "_gen.go") || strings.HasSuffix(name, "_test.go") {
+			return nil
+		}
+		// The generated contract package is the source of the obligation, never
+		// evidence of it being met.
+		if strings.HasPrefix(path, filepath.Join("internal", "contracts")) {
+			return nil
+		}
+		raw, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		out.Write(raw)
+		out.WriteString("\n")
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk internal/: %v", err)
+	}
+	return out.String()
+}

--- a/backend/internal/compose/org360/accountstate.go
+++ b/backend/internal/compose/org360/accountstate.go
@@ -12,8 +12,11 @@ package org360
 // date that hid which side it belonged to.
 
 import (
+	"errors"
+	"fmt"
 	"time"
 
+	"github.com/jackc/pgx/v5"
 	openapi_types "github.com/oapi-codegen/runtime/types"
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
@@ -223,6 +226,57 @@ func (a *assembly) readHealth() error {
 		health.OpenCommitments = &facts.OpenCommitments
 	}
 
+	lastMeeting, err := a.lastMeetingAt()
+	if err != nil {
+		return err
+	}
+	health.LastMeetingAt = lastMeeting
+
 	a.out.Health = &health
 	return nil
+}
+
+// lastMeetingAt is when this account was last actually IN a room with us —
+// the most recent meeting that has already happened.
+//
+// A different question from the next-meeting section, which looks forward and
+// excludes cancellations because a rep must not prepare for a meeting that will
+// not happen. Looking back, a canceled row is simply not a meeting that took
+// place, so it is excluded for the same reason from the other direction.
+//
+// Nil is "we have no meeting on record", which is a fact about the reading
+// rather than a claim that none happened — the caller may hold no scope over
+// the activity that would prove otherwise.
+func (a *assembly) lastMeetingAt() (*time.Time, error) {
+	var args []any
+	arg := func(v any) int { args = append(args, v); return len(args) }
+	orgPos := arg(a.orgID.UUID)
+	nowPos := arg(a.now)
+	activityScope, err := auth.ActivityScopeClause(a.ctx, "a", arg)
+	if err != nil {
+		return nil, err
+	}
+	if activityScope == "" {
+		activityScope = scopeAll
+	}
+	var occurred *time.Time
+	err = a.tx.QueryRow(a.ctx, fmt.Sprintf(`
+		SELECT a.occurred_at
+		  FROM activity a
+		 WHERE a.kind = 'meeting' AND a.archived_at IS NULL
+		   AND (a.meeting_status IS NULL OR a.meeting_status = 'booked')
+		   AND a.occurred_at <= $%[3]d
+		   AND %[1]s AND %[2]s
+		 ORDER BY a.occurred_at DESC, a.id DESC
+		 LIMIT 1`,
+		activityScope, activities.OrgLinkedActivityExists(orgPos), nowPos),
+		args...,
+	).Scan(&occurred)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read the last meeting: %w", err)
+	}
+	return occurred, nil
 }


### PR DESCRIPTION
`make drift` proves the generated Go matches `api/crm.yaml`. **Nothing proved a handler fills what the contract advertises**, so a schema property with no producer shipped as permanently absent — and on the page composites, absent is read as a fact about the account.

`Organization360Health.last_meeting_at` was exactly that: in the contract, set nowhere, rendering as "no meeting" on every company in the product.

This is the first phase of the ADR-0095/A146 build, and it comes first on purpose: it is the shape of bug that *adding* fields to a composite creates, and the next three phases add eight of them.

## How it works

The gate derives its obligation from the generated struct rather than from a list, so a property joins the check by existing. Textual parsing like its sibling gates (`contractrefs_test.go`, `rbacvocabulary_test.go`) — the root fitness package stays free of parser deps.

Scope is the three composites the record page assembles field by field from separate readers — that is where a field quietly goes unwritten. Request bodies and mapper-filled types are already total by the compiler, so including them would be noise.

Tests are excluded from the producer corpus: **a field only a test writes has no producer in the product.**

## The finding it forced

`last_meeting_at` is now **produced rather than deleted** — the data is there and the reading is one a rep wants.

It is the most recent meeting that has *already happened*, which is the opposite question from the next-meeting section. A cancelled row is excluded from both, for symmetric reasons: it is neither something to prepare for nor something that took place.

## Verification

Mutation-checked in both directions: the gate fails with a precise field name when the assignment is removed, and passes when it is restored. `go test .` (root fitness suite) green, `go build ./...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a gate to catch contract fields on page composites that have no producer, and implements the missing producer for `Organization360Health.last_meeting_at` so the UI shows the latest past meeting correctly.

- New Features
  - Added `backend/contractproducers_test.go` to ensure every exported field in the generated structs for `Organization360Health`, `OrganizationGrowthFit`, and `Organization360Suggestion` is produced by hand-written code.
  - The gate derives obligations from `internal/contracts/api_gen.go` and scans non-generated, non-test files under `internal/`; it fails with the precise field name.

- Bug Fixes
  - Populate `Health.LastMeetingAt` in `internal/compose/org360/accountstate.go` via `lastMeetingAt()`: selects the most recent meeting that already happened (not archived, not canceled), respects auth activity scope, and returns nil if none exists.

<sup>Written for commit ae53151537bcad7cc1c9c8195a8727fbe4616ebc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/829?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

