### PR TITLE
fix(overlay): the mirror sweeps every type it advertises, and says where the page stopped (#599, #586)

### DIFF
--- a/backend/internal/compose/integration/overlay/overlay_search_sweep_integration_test.go
+++ b/backend/internal/compose/integration/overlay/overlay_search_sweep_integration_test.go
@@ -7,19 +7,15 @@ package overlay
 
 // The overlay search sweep, against a real mirror.
 //
-// Two defects meet here. `search_records` advertises that omitting
-// `record_type` sweeps every type, and the overlay provider refused any query
-// that did not name exactly one — so an agent doing exactly what the schema
-// says was refused on an overlay workspace, for a rule the schema never
-// stated. And the REST search shadow, which DID walk every type, reported
-// `has_more` with no `next_cursor`, so whatever the first page did not carry
-// was unreachable by any means the contract offers.
+// Two claims are under test. A query naming no record type sweeps every type
+// the mirror holds — which is what the tool surface advertises, and what the
+// native provider answers. And the walk is RESUMABLE: it has no ranking to
+// interleave types by, so it goes one type at a time, and every page that
+// reports more carries the position to continue from.
 //
-// The sweep answers both, and what makes it more than a loop is that the
-// position is resumable: a walk with no ranking to interleave types by can
-// still say where it stopped. This asks it to page a set it cannot fit, one
-// hit at a time, and holds it to the invariant that a page claiming more
-// carries somewhere to go.
+// It is driven one hit at a time over a set it cannot fit, so each step
+// either crosses into a new type or resumes inside one, and both cursor
+// shapes are exercised rather than described.
 
 import (
 	"encoding/json"
@@ -56,6 +52,7 @@ func TestOverlaySearchSweepsEveryMirroredTypeAndPagesThroughThem(t *testing.T) {
 	e.seed(t, "organization", "9403", map[string]any{"display_name": "Sweepable Org"})
 	e.seed(t, "deal", "9404", map[string]any{"name": "Sweepable Renewal", "currency": "EUR"})
 	e.seed(t, "lead", "9405", map[string]any{"full_name": "Sweepable Lead"})
+	e.seed(t, "activity", "9406", map[string]any{"kind": "call", "subject": "Sweepable Call"})
 
 	// One hit per page, so every step of the walk crosses or exhausts a type
 	// and the cursor is exercised in both of its shapes: resuming INSIDE a
@@ -77,8 +74,8 @@ func TestOverlaySearchSweepsEveryMirroredTypeAndPagesThroughThem(t *testing.T) {
 			}
 			seen[hit.ID] = hit.Type
 		}
-		// The invariant #586 was filed for: more is only true when there is
-		// somewhere to go, and somewhere to go only when there is more.
+		// More is only true when there is somewhere to go, and there is
+		// somewhere to go only when more is true.
 		if page.Page.HasMore != (page.Page.NextCursor != nil && *page.Page.NextCursor != "") {
 			t.Fatalf("has_more = %v with next_cursor = %v — a page that claims more and offers no way to reach "+
 				"it leaves those records unreachable", page.Page.HasMore, page.Page.NextCursor)
@@ -89,10 +86,10 @@ func TestOverlaySearchSweepsEveryMirroredTypeAndPagesThroughThem(t *testing.T) {
 		path = "/v1/search?q=Sweepable&limit=1&cursor=" + *page.Page.NextCursor
 	}
 
-	if len(seen) != 5 {
-		t.Fatalf("the sweep reached %d of the 5 seeded records: %v", len(seen), seen)
+	if len(seen) != 6 {
+		t.Fatalf("the sweep reached %d of the 6 seeded records: %v", len(seen), seen)
 	}
-	for _, want := range []string{"person", "organization", "deal", "lead"} {
+	for _, want := range []string{"person", "organization", "deal", "lead", "activity"} {
 		found := false
 		for _, recordType := range seen {
 			found = found || recordType == want
@@ -103,11 +100,9 @@ func TestOverlaySearchSweepsEveryMirroredTypeAndPagesThroughThem(t *testing.T) {
 	}
 }
 
-// The tool this was filed against. `search_records` says `record_type` may be
-// omitted to sweep all five, and the overlay provider used to refuse exactly
-// that — an agent doing what the schema told it to was answered with an error
-// about a rule the schema never stated. This drives the tool itself, through
-// the registry a real call comes in on.
+// The same claim, driven through the tool rather than the route: the schema
+// says `record_type` may be omitted to sweep every type, and this is the
+// registry a real agent call arrives on.
 func TestTheSearchRecordsToolSweepsWithoutARecordTypeInOverlayMode(t *testing.T) {
 	e := integration.Setup(t)
 	ws, actorID := seedOverlayModeWorkspace(t)

--- a/backend/internal/compose/integration/overlay/overlay_search_sweep_integration_test.go
+++ b/backend/internal/compose/integration/overlay/overlay_search_sweep_integration_test.go
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package overlay
+
+// The overlay search sweep, against a real mirror.
+//
+// Two defects meet here. `search_records` advertises that omitting
+// `record_type` sweeps every type, and the overlay provider refused any query
+// that did not name exactly one — so an agent doing exactly what the schema
+// says was refused on an overlay workspace, for a rule the schema never
+// stated. And the REST search shadow, which DID walk every type, reported
+// `has_more` with no `next_cursor`, so whatever the first page did not carry
+// was unreachable by any means the contract offers.
+//
+// The sweep answers both, and what makes it more than a loop is that the
+// position is resumable: a walk with no ranking to interleave types by can
+// still say where it stopped. This asks it to page a set it cannot fit, one
+// hit at a time, and holds it to the invariant that a page claiming more
+// carries somewhere to go.
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/compose"
+	"github.com/gradionhq/margince/backend/internal/compose/integration"
+	overlaymod "github.com/gradionhq/margince/backend/internal/modules/overlay"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// sweptPage is one /v1/search response, read down to what these assertions
+// are about: which records came back, and whether the page says more exist.
+type sweptPage struct {
+	Data []struct {
+		ID   string `json:"id"`
+		Type string `json:"type"`
+	} `json:"data"`
+	Page struct {
+		HasMore    bool    `json:"has_more"`
+		NextCursor *string `json:"next_cursor"`
+	} `json:"page"`
+}
+
+func TestOverlaySearchSweepsEveryMirroredTypeAndPagesThroughThem(t *testing.T) {
+	e := setupOverlayWrite(t)
+	// One token in a string field of each record, so the sweep's substring
+	// filter reaches all five and the assertion is about the WALK rather than
+	// about matching.
+	e.seed(t, "person", "9401", map[string]any{"first_name": "Sweepable", "last_name": "One"})
+	e.seed(t, "person", "9402", map[string]any{"first_name": "Sweepable", "last_name": "Two"})
+	e.seed(t, "organization", "9403", map[string]any{"display_name": "Sweepable Org"})
+	e.seed(t, "deal", "9404", map[string]any{"name": "Sweepable Renewal", "currency": "EUR"})
+	e.seed(t, "lead", "9405", map[string]any{"full_name": "Sweepable Lead"})
+
+	// One hit per page, so every step of the walk crosses or exhausts a type
+	// and the cursor is exercised in both of its shapes: resuming INSIDE a
+	// type, and starting the next one.
+	seen := map[string]string{}
+	path := "/v1/search?q=Sweepable&limit=1"
+	for pages := 0; ; pages++ {
+		if pages > 10 {
+			t.Fatalf("the sweep did not terminate after %d pages, holding %d records", pages, len(seen))
+		}
+		var page sweptPage
+		if status := e.Call(t, "GET", path, nil, nil, &page); status != http.StatusOK {
+			t.Fatalf("GET %s = %d, want 200", path, status)
+		}
+		for _, hit := range page.Data {
+			if _, repeated := seen[hit.ID]; repeated {
+				t.Fatalf("the sweep returned %s (%s) twice — a resumed walk must not re-serve what it already handed over",
+					hit.ID, hit.Type)
+			}
+			seen[hit.ID] = hit.Type
+		}
+		// The invariant #586 was filed for: more is only true when there is
+		// somewhere to go, and somewhere to go only when there is more.
+		if page.Page.HasMore != (page.Page.NextCursor != nil && *page.Page.NextCursor != "") {
+			t.Fatalf("has_more = %v with next_cursor = %v — a page that claims more and offers no way to reach "+
+				"it leaves those records unreachable", page.Page.HasMore, page.Page.NextCursor)
+		}
+		if !page.Page.HasMore {
+			break
+		}
+		path = "/v1/search?q=Sweepable&limit=1&cursor=" + *page.Page.NextCursor
+	}
+
+	if len(seen) != 5 {
+		t.Fatalf("the sweep reached %d of the 5 seeded records: %v", len(seen), seen)
+	}
+	for _, want := range []string{"person", "organization", "deal", "lead"} {
+		found := false
+		for _, recordType := range seen {
+			found = found || recordType == want
+		}
+		if !found {
+			t.Errorf("the sweep never reached a %s — it walks every mirrored type or it is not a sweep", want)
+		}
+	}
+}
+
+// The tool this was filed against. `search_records` says `record_type` may be
+// omitted to sweep all five, and the overlay provider used to refuse exactly
+// that — an agent doing what the schema told it to was answered with an error
+// about a rule the schema never stated. This drives the tool itself, through
+// the registry a real call comes in on.
+func TestTheSearchRecordsToolSweepsWithoutARecordTypeInOverlayMode(t *testing.T) {
+	e := integration.Setup(t)
+	ws, actorID := seedOverlayModeWorkspace(t)
+	ctx := overlayActorCtxWith(ws, actorID, nativeToolReaderPerms())
+
+	mirror := overlaymod.NewMirrorStore(e.Pool, stubOwnerEmails{})
+	if err := mirror.UpsertUserMap(ctx, ids.From[ids.UserKind](actorID), "hubspot", "owner-1", "manual"); err != nil {
+		t.Fatalf("mapping the acting user to the incumbent owner: %v", err)
+	}
+	if err := mirror.Ingest(ctx, overlaymod.Record{
+		ObjectClass: "person", ExternalID: "100214862044", OwnerExternalID: "owner-1",
+		Fields: map[string]any{"firstname": "Unrestricted", "lastname": "Sweep"}, ModifiedAt: seedModifiedAt,
+	}); err != nil {
+		t.Fatalf("seeding the mirrored person: %v", err)
+	}
+
+	out, err := compose.NewRegistry(e.Pool, compose.SendPath{}).
+		Invoke(ctx, "search_records", json.RawMessage(`{"q":"Unrestricted"}`))
+	if err != nil {
+		t.Fatalf("search_records with no record_type in overlay mode: %v — the schema says omitting it sweeps "+
+			"every type, and a surface that refuses what it advertises misleads the only caller that reads it", err)
+	}
+	if !strings.Contains(string(out), "Unrestricted") {
+		t.Fatalf("the sweep answered without the mirrored person, so it did not reach the person arm: %s", out)
+	}
+}
+
+// A type the mirror cannot hold is refused rather than answered with an empty
+// page. The contract's `types` enum carries six values and the mirror carries
+// five, so the alternative reads as "this workspace has no projects" when the
+// truth is about the mode.
+func TestOverlaySearchRefusesATypeTheMirrorDoesNotHold(t *testing.T) {
+	e := setupOverlayWrite(t)
+	e.seed(t, "person", "9410", map[string]any{"first_name": "Present", "last_name": "Person"})
+
+	if status := e.Call(t, "GET", "/v1/search?q=Present&types=project", nil, nil, nil); status != http.StatusUnprocessableEntity {
+		t.Errorf("GET /v1/search?types=project = %d, want 422 — an unmirrored type must be refused, not "+
+			"answered with a page that says the records do not exist", status)
+	}
+	if status := e.Call(t, "GET", "/v1/search?q=Present&types=person", nil, nil, nil); status != http.StatusOK {
+		t.Errorf("GET /v1/search?types=person = %d, want 200 — the refusal above is about the type, not the parameter", status)
+	}
+}

--- a/backend/internal/compose/overlayread.go
+++ b/backend/internal/compose/overlayread.go
@@ -27,6 +27,7 @@ import (
 	"net/http"
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/modules/overlay"
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
 	"github.com/gradionhq/margince/backend/internal/platform/httperr"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
@@ -327,20 +328,16 @@ func (s Server) ListActivities(w http.ResponseWriter, r *http.Request, params cr
 		})
 }
 
-// overlaySearchTypes is the entity-type order the overlay search union
-// walks — fixed, so a capped page is deterministic.
-var overlaySearchTypes = []datasource.EntityType{
-	datasource.EntityPerson,
-	datasource.EntityOrganization,
-	datasource.EntityDeal,
-	datasource.EntityLead,
-	datasource.EntityActivity,
-}
+// overlaySearchTypes is the entity-type order the overlay search walks. It is
+// the MODULE's own list rather than a copy: the provider refuses a class the
+// mirror cannot hold, and a second list here would let this door refuse one it
+// can, or admit one it cannot, the moment a sixth is mirrored.
+var overlaySearchTypes = overlay.MirroredEntityTypes()
 
-// overlayMirroredTypes is the set of record types the mirror holds — the same
-// five the read shadows serve, keyed by the string form that is both
-// datasource.EntityType and the generated agentPolicy.RecordType. Derived from
-// overlaySearchTypes rather than re-listed, so reads and writes cannot drift.
+// overlayMirroredTypes is the set of record types the mirror holds, keyed by
+// the string form that is both datasource.EntityType and the generated
+// agentPolicy.RecordType. Derived from overlaySearchTypes rather than
+// re-listed, so reads and writes cannot drift.
 var overlayMirroredTypes = func() map[string]bool {
 	set := make(map[string]bool, len(overlaySearchTypes))
 	for _, et := range overlaySearchTypes {
@@ -380,11 +377,10 @@ func clampOverlaySearchLimit(v int) int {
 // the provider's own sweep so the MCP tool and this route answer one
 // implementation rather than two.
 //
-// It PAGES. The walk has no ranking to interleave types by, but the sweep's
-// cursor names where it stopped — the type plus that type's mirror cursor —
-// so `has_more` now comes with somewhere to go. It previously refused
-// `cursor` outright and still reported more, which told a caller rows existed
-// and left them unreachable.
+// It PAGES. The walk has no ranking to interleave types by, so the sweep's
+// cursor names where it stopped — the type plus that type's own mirror
+// cursor — and `has_more` is true exactly when there is such a position to
+// hand back.
 func (s Server) Search(w http.ResponseWriter, r *http.Request, params crmcontracts.SearchParams) {
 	ov, ok := s.overlayReadMode(w, r)
 	if !ok {
@@ -407,13 +403,16 @@ func (s Server) Search(w http.ResponseWriter, r *http.Request, params crmcontrac
 	} else {
 		query.Limit = overlaySearchDefaultLimit
 	}
-	// An empty scope is an answerable question with an empty answer: the seat
-	// may read none of the types it asked about. Serving it here rather than
-	// through the provider keeps that a page, not a 403 — search shows the
-	// object classes a seat can read and says nothing about the rest, which is
-	// the native surface's own posture (search/store.go's branchScope).
+	// An empty scope is an answerable question with an empty answer: the one
+	// type the caller named is one they may not read. Serving it here rather
+	// than through the provider is what keeps it a page instead of the 403 the
+	// seam answers a tool with (overlaySearchScope's own rationale).
 	res := datasource.SearchResult{}
 	if len(types) > 0 {
+		// An unmapped caller's existence-hiding ErrNotFound answers an EMPTY
+		// page here, the same reading every list shadow gives it: a collection
+		// read row-scopes down to nothing rather than 404ing, and both modes
+		// must answer one contract the same way.
 		var err error
 		if res, err = s.sorDispatch.Search(r.Context(), query); err != nil && !errors.Is(err, apperrors.ErrNotFound) {
 			httperr.Write(w, r, err)
@@ -432,14 +431,22 @@ func (s Server) Search(w http.ResponseWriter, r *http.Request, params crmcontrac
 	httperr.WriteJSON(w, http.StatusOK, crmcontracts.SearchResponse{Data: hits, Page: page})
 }
 
-// overlaySearchScope resolves which entity types this request sweeps: the
-// ones it named, or every mirrored one, minus those the seat may not read.
+// overlaySearchScope resolves which entity types this request sweeps.
 //
 // A named type the mirror does not hold is REFUSED rather than walked past.
 // The mirror carries five object classes and the contract's `types` enum
 // carries six, so a caller asking for projects would otherwise be handed an
 // empty page reading "this workspace has no projects" — an answer about the
 // records, when the truth is about the mode.
+//
+// It resolves ONE denial itself and leaves the rest to the provider, because
+// the two doors answer a denial differently and each rule belongs where it is
+// kept. Search shows a seat the object classes it can read and says nothing
+// about the rest, so a caller who named a single type they may not read gets
+// an empty page here rather than the 403 the seam gives a tool. Everything
+// wider goes through unfiltered: the provider omits what the seat cannot see,
+// and narrowing the list here as well would make the sweep's own posture
+// depend on a filter applied a layer above it.
 func (s Server) overlaySearchScope(
 	w http.ResponseWriter, r *http.Request, named *[]crmcontracts.SearchParamsTypes,
 ) ([]datasource.EntityType, bool) {
@@ -455,13 +462,23 @@ func (s Server) overlaySearchScope(
 			asked = append(asked, et)
 		}
 	}
-	readable := make([]datasource.EntityType, 0, len(asked))
-	for _, et := range asked {
-		if auth.Require(r.Context(), string(et), principal.ActionRead) == nil {
-			readable = append(readable, et)
-		}
+	if len(asked) != 1 {
+		return asked, true
 	}
-	return readable, true
+	err := auth.Require(r.Context(), string(asked[0]), principal.ActionRead)
+	switch {
+	case err == nil:
+		return asked, true
+	case errors.Is(err, apperrors.ErrPermissionDenied):
+		// The empty scope, which Search answers as an empty page.
+		return nil, true
+	default:
+		// Not a fact about the caller's grants — this server not working.
+		// Reading it as "may not see it" would answer a broken request chain
+		// with an empty page and a 200.
+		httperr.Write(w, r, err)
+		return nil, false
+	}
 }
 
 // overlaySearchHits assembles one swept page onto the wire, titling each hit

--- a/backend/internal/compose/overlayread.go
+++ b/backend/internal/compose/overlayread.go
@@ -375,10 +375,16 @@ func clampOverlaySearchLimit(v int) int {
 	}
 }
 
-// Search shadows the global search: in overlay mode it is a best-effort
-// visibility-filtered union across entity types (design.md §4.5) — a
-// single capped page with no cross-type cursor, so a supplied cursor is
-// refused rather than silently restarting the walk.
+// Search shadows the global search: in overlay mode it is a
+// visibility-filtered walk across entity types (design.md §4.5), served by
+// the provider's own sweep so the MCP tool and this route answer one
+// implementation rather than two.
+//
+// It PAGES. The walk has no ranking to interleave types by, but the sweep's
+// cursor names where it stopped — the type plus that type's mirror cursor —
+// so `has_more` now comes with somewhere to go. It previously refused
+// `cursor` outright and still reported more, which told a caller rows existed
+// and left them unreachable.
 func (s Server) Search(w http.ResponseWriter, r *http.Request, params crmcontracts.SearchParams) {
 	ov, ok := s.overlayReadMode(w, r)
 	if !ok {
@@ -388,79 +394,88 @@ func (s Server) Search(w http.ResponseWriter, r *http.Request, params crmcontrac
 		s.searchHandlers.Search(w, r, params)
 		return
 	}
-	if params.Cursor != nil {
-		unsupportedOverlayParam(w, r, "cursor")
+	types, ok := s.overlaySearchScope(w, r, params.Types)
+	if !ok {
 		return
 	}
-	types := overlaySearchTypes
-	if params.Types != nil {
-		types = make([]datasource.EntityType, 0, len(*params.Types))
-		for _, t := range *params.Types {
-			types = append(types, datasource.EntityType(t))
-		}
+	query := datasource.SearchQuery{Text: params.Q, EntityTypes: types}
+	if params.Cursor != nil {
+		query.Cursor = *params.Cursor
 	}
-	limit := overlaySearchDefaultLimit
 	if params.Limit != nil {
-		limit = clampOverlaySearchLimit(*params.Limit)
+		query.Limit = clampOverlaySearchLimit(*params.Limit)
+	} else {
+		query.Limit = overlaySearchDefaultLimit
 	}
-	hits := make([]crmcontracts.SearchResult, 0, limit)
-	// hasMore turns true when the page filled before every requested type
-	// was fully walked — there is no cross-type cursor to resume with, so
-	// the flag is the one honest signal that narrowing the query would
-	// surface more.
-	hasMore := false
-	for _, et := range types {
-		if len(hits) >= limit {
-			hasMore = true
-			break
-		}
-		typed, more, err := s.overlaySearchOneType(r.Context(), et, params.Q, limit-len(hits))
-		if err != nil {
+	// An empty scope is an answerable question with an empty answer: the seat
+	// may read none of the types it asked about. Serving it here rather than
+	// through the provider keeps that a page, not a 403 — search shows the
+	// object classes a seat can read and says nothing about the rest, which is
+	// the native surface's own posture (search/store.go's branchScope).
+	res := datasource.SearchResult{}
+	if len(types) > 0 {
+		var err error
+		if res, err = s.sorDispatch.Search(r.Context(), query); err != nil && !errors.Is(err, apperrors.ErrNotFound) {
 			httperr.Write(w, r, err)
 			return
 		}
-		hits = append(hits, typed...)
-		if more {
-			hasMore = true
-		}
 	}
-	httperr.WriteJSON(w, http.StatusOK, crmcontracts.SearchResponse{Data: hits, Page: crmcontracts.PageInfo{HasMore: hasMore}})
+	hits, err := overlaySearchHits(res)
+	if err != nil {
+		httperr.Write(w, r, err)
+		return
+	}
+	page := crmcontracts.PageInfo{HasMore: res.HasMore}
+	if res.NextCursor != "" {
+		page.NextCursor = &res.NextCursor
+	}
+	httperr.WriteJSON(w, http.StatusOK, crmcontracts.SearchResponse{Data: hits, Page: page})
 }
 
-// overlaySearchOneType pages one entity type's visibility-joined mirror
-// hits for the overlay search union, titled per type. A type the caller
-// may not read answers empty, not a query-wide 403 — search shows only
-// the object classes the seat can read, the native surface's own
-// posture; an unmapped caller likewise sees the empty world
-// (overlayList's rationale). Anything else is a real failure and
-// surfaces.
-func (s Server) overlaySearchOneType(ctx context.Context, et datasource.EntityType, text string, remaining int) (typed []crmcontracts.SearchResult, hasMore bool, err error) {
-	if err := auth.Require(ctx, string(et), principal.ActionRead); err != nil {
-		if errors.Is(err, apperrors.ErrPermissionDenied) {
-			return nil, false, nil
+// overlaySearchScope resolves which entity types this request sweeps: the
+// ones it named, or every mirrored one, minus those the seat may not read.
+//
+// A named type the mirror does not hold is REFUSED rather than walked past.
+// The mirror carries five object classes and the contract's `types` enum
+// carries six, so a caller asking for projects would otherwise be handed an
+// empty page reading "this workspace has no projects" — an answer about the
+// records, when the truth is about the mode.
+func (s Server) overlaySearchScope(
+	w http.ResponseWriter, r *http.Request, named *[]crmcontracts.SearchParamsTypes,
+) ([]datasource.EntityType, bool) {
+	asked := overlaySearchTypes
+	if named != nil {
+		asked = make([]datasource.EntityType, 0, len(*named))
+		for _, t := range *named {
+			et := datasource.EntityType(t)
+			if !overlayMirroredTypes[string(et)] {
+				unsupportedOverlayParam(w, r, "types")
+				return nil, false
+			}
+			asked = append(asked, et)
 		}
-		return nil, false, err
 	}
-	res, err := s.sorDispatch.Search(ctx, datasource.SearchQuery{
-		Text:        text,
-		EntityTypes: []datasource.EntityType{et},
-		Limit:       remaining,
-	})
-	if err != nil {
-		if errors.Is(err, apperrors.ErrNotFound) {
-			return nil, false, nil
+	readable := make([]datasource.EntityType, 0, len(asked))
+	for _, et := range asked {
+		if auth.Require(r.Context(), string(et), principal.ActionRead) == nil {
+			readable = append(readable, et)
 		}
-		return nil, false, err
 	}
-	typed = ContractSearchResults(res)
+	return readable, true
+}
+
+// overlaySearchHits assembles one swept page onto the wire, titling each hit
+// by the type it came from.
+func overlaySearchHits(res datasource.SearchResult) ([]crmcontracts.SearchResult, error) {
+	typed := ContractSearchResults(res)
 	for i, rec := range res.Records {
-		fields, fieldsErr := overlayRecordFields(rec)
-		if fieldsErr != nil {
-			return nil, false, fieldsErr
+		fields, err := overlayRecordFields(rec)
+		if err != nil {
+			return nil, err
 		}
-		if title := overlayWireTitle(et, fields); title != "" {
+		if title := overlayWireTitle(rec.Ref.Type, fields); title != "" {
 			typed[i].Title = &title
 		}
 	}
-	return typed, res.HasMore, nil
+	return typed, nil
 }

--- a/backend/internal/modules/overlay/mirrorstore.go
+++ b/backend/internal/modules/overlay/mirrorstore.go
@@ -396,6 +396,21 @@ const (
 	maxListLimit     = 200
 )
 
+// clampListLimit maps a caller's page size onto the bounds above: absent or
+// nonsensical takes the default, oversized takes the ceiling. Every paged read
+// in this package resolves it here, so a page's size cannot mean one thing on
+// the mirror walk and another on the user map.
+func clampListLimit(limit int) int {
+	switch {
+	case limit <= 0:
+		return defaultListLimit
+	case limit > maxListLimit:
+		return maxListLimit
+	default:
+		return limit
+	}
+}
+
 const selectVisibleMirrorPageSQL = `
 SELECT m.object_class, m.external_id, m.fields, m.updated_at_baseline,
        coalesce(m.owner_external_id, ''), m.sync_state, m.last_synced_at
@@ -416,12 +431,7 @@ func (s *MirrorStore) List(ctx context.Context, objectClass, cursor string, limi
 	if err != nil {
 		return nil, "", err
 	}
-	switch {
-	case limit <= 0:
-		limit = defaultListLimit
-	case limit > maxListLimit:
-		limit = maxListLimit
-	}
+	limit = clampListLimit(limit)
 
 	var rows []Row
 	err = database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {

--- a/backend/internal/modules/overlay/provider.go
+++ b/backend/internal/modules/overlay/provider.go
@@ -197,69 +197,6 @@ func (p *Provider) Read(ctx context.Context, ref datasource.EntityRef) (datasour
 	return recordFromRow(ref.Type, row)
 }
 
-// Search pages one entity type's mirror rows (visibility-joined via
-// MirrorStore.List) and applies q.Text as a naive case-insensitive
-// substring filter over the row's string-valued fields — a branch-1
-// scope limit, not the FTS/RRF hybrid search's own retrieval path.
-func (p *Provider) Search(ctx context.Context, q datasource.SearchQuery) (datasource.SearchResult, error) {
-	if p.ms == nil {
-		return datasource.SearchResult{}, errNoMirrorStore()
-	}
-	if len(q.EntityTypes) != 1 {
-		return datasource.SearchResult{}, fmt.Errorf("overlay: search requires exactly one entity type in this branch, got %d", len(q.EntityTypes))
-	}
-	et := q.EntityTypes[0]
-	// Object RBAC before any mirror read — the MCP search_records path
-	// reaches the provider directly, so the gate the REST search shadow
-	// applies must also live here (see Read's rationale).
-	if err := auth.Require(ctx, string(et), principal.ActionRead); err != nil {
-		return datasource.SearchResult{}, err
-	}
-	// A structured filter the mirror cannot evaluate is REFUSED, never dropped.
-	// The mirror holds the incumbent's rows as opaque fields, so a narrowing by
-	// owner or stage has nothing to bind to — and answering the unnarrowed page
-	// instead would return a superset of what was asked for, in the shape of the
-	// right answer. That is the silent break AC-OV-2 forbids: a tool either
-	// behaves identically across modes or declares it cannot serve this one.
-	//
-	// It lands AFTER the object gate on purpose. A caller with no read grant
-	// must hear the same thing whether or not they attached a filter; refusing
-	// first would let an unauthorized caller learn this workspace's
-	// system-of-record mode by adding one.
-	if len(q.Filters) > 0 {
-		return datasource.SearchResult{}, apperrors.ErrUnsupportedBySoR
-	}
-	rows, next, err := p.ms.List(ctx, string(et), q.Cursor, q.Limit)
-	if err != nil {
-		return datasource.SearchResult{}, err
-	}
-
-	text := strings.ToLower(strings.TrimSpace(q.Text))
-	records := make([]datasource.Record, 0, len(rows))
-	for _, row := range rows {
-		if text != "" && !mirrorRowMatchesText(row, text) {
-			continue
-		}
-		rec, err := recordFromRow(et, row)
-		if err != nil {
-			return datasource.SearchResult{}, err
-		}
-		records = append(records, rec)
-	}
-	return datasource.SearchResult{Records: records, NextCursor: next, HasMore: next != ""}, nil
-}
-
-// mirrorRowMatchesText reports whether any string-valued field of row
-// contains lowerText.
-func mirrorRowMatchesText(row Row, lowerText string) bool {
-	for _, v := range row.Fields {
-		if s, ok := v.(string); ok && strings.Contains(strings.ToLower(s), lowerText) {
-			return true
-		}
-	}
-	return false
-}
-
 // knownEntityTypes is the set of entity types the overlay mirror can hold — a
 // SUBSET of the seam's vocabulary, not a copy of it. `project` and
 // `relationship` are full members of datasource.EntityTypes() and have no

--- a/backend/internal/modules/overlay/provider_test.go
+++ b/backend/internal/modules/overlay/provider_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/base64"
 	"errors"
+	"slices"
 	"testing"
 
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
@@ -263,39 +264,105 @@ func TestProviderSearchRefusesATypeTheMirrorCannotHold(t *testing.T) {
 	}
 }
 
-// TestASweepCursorResumesItsOwnSweepAndRefusesAnother pins the resume token
-// #586 turns on: it round-trips the position, and a cursor minted for a sweep
-// that walked OTHER types is malformed rather than silently reindexed.
-// Reading it as position zero would restart the walk; reading it as some
-// arbitrary index would skip whatever lies between the two scopes.
-func TestASweepCursorResumesItsOwnSweepAndRefusesAnother(t *testing.T) {
-	walked := []datasource.EntityType{datasource.EntityPerson, datasource.EntityOrganization, datasource.EntityDeal}
-
-	from, inner, err := decodeSweepCursor(encodeSweepCursor(datasource.EntityOrganization, "mirror-42"), walked)
+// TestASweepCursorNamesAPositionInTheMirrorRatherThanInOneRequest pins the
+// resume token and the reason it names a TYPE rather than an index: the same
+// token has to mean the same place when the request presenting it is not the
+// one that minted it.
+func TestASweepCursorNamesAPositionInTheMirrorRatherThanInOneRequest(t *testing.T) {
+	minted, err := encodeSweepCursor(datasource.EntityOrganization, "mirror-42")
 	if err != nil {
-		t.Fatalf("decoding a cursor this sweep minted: %v", err)
+		t.Fatalf("encoding a sweep position: %v", err)
 	}
-	if from != 1 || inner != "mirror-42" {
-		t.Errorf("resume position = (%d, %q), want the organization arm at its own mirror cursor", from, inner)
+	resumeAt, inner, err := decodeSweepCursor(minted)
+	if err != nil {
+		t.Fatalf("decoding a cursor the sweep minted: %v", err)
+	}
+	if resumeAt != datasource.EntityOrganization || inner != "mirror-42" {
+		t.Errorf("resume position = (%q, %q), want the organization stream at its own mirror cursor", resumeAt, inner)
 	}
 
 	// An empty cursor is the start of the walk, not a malformed one.
-	if from, inner, err = decodeSweepCursor("", walked); err != nil || from != 0 || inner != "" {
-		t.Errorf("the empty cursor decoded to (%d, %q, %v), want the beginning", from, inner, err)
+	if resumeAt, inner, err = decodeSweepCursor(""); err != nil || resumeAt != "" || inner != "" {
+		t.Errorf("the empty cursor decoded to (%q, %q, %v), want the beginning", resumeAt, inner, err)
 	}
 
+	// Malformed is reserved for a token this package could not have minted.
 	for _, probe := range []struct{ name, cursor string }{
-		{"minted for a sweep this one does not walk", encodeSweepCursor(datasource.EntityLead, "mirror-7")},
 		{"not base64 at all", "not a cursor!!"},
 		{"base64 of something that is not a position", base64.RawURLEncoding.EncodeToString([]byte("nonsense"))},
+		{"naming an object class the mirror cannot hold", mustEncodeSweepCursor(t, datasource.EntityProject)},
 	} {
 		t.Run(probe.name, func(t *testing.T) {
-			_, _, err := decodeSweepCursor(probe.cursor, walked)
+			_, _, err := decodeSweepCursor(probe.cursor)
 			var malformed *storekit.MalformedCursorError
 			if !errors.As(err, &malformed) {
 				t.Errorf("decoding a cursor %s = %v, want the malformed-cursor answer", probe.name, err)
 			}
 		})
+	}
+}
+
+// mustEncodeSweepCursor mints a position for a probe, failing the test rather
+// than swallowing an encoding error into an empty cursor.
+func mustEncodeSweepCursor(t *testing.T, et datasource.EntityType) string {
+	t.Helper()
+	cursor, err := encodeSweepCursor(et, "mirror-7")
+	if err != nil {
+		t.Fatalf("encoding a sweep position for %s: %v", et, err)
+	}
+	return cursor
+}
+
+// TestAResumedSweepSurvivesTheWalkChangingUnderIt is the half a cursor over a
+// per-request slice could not answer. A caller's readable types change between
+// pages — a narrowed `types`, a revoked grant — and the position they hold is
+// still a token this server minted.
+func TestAResumedSweepSurvivesTheWalkChangingUnderIt(t *testing.T) {
+	all := []datasource.EntityType{
+		datasource.EntityPerson, datasource.EntityOrganization,
+		datasource.EntityDeal, datasource.EntityLead, datasource.EntityActivity,
+	}
+	for _, probe := range []struct {
+		name     string
+		walk     []datasource.EntityType
+		resumeAt datasource.EntityType
+		want     int
+	}{
+		{"the type is still walked", all, datasource.EntityDeal, 2},
+		{"no cursor starts at the beginning", all, "", 0},
+		{
+			"the type was narrowed away — resume PAST it, never before",
+			[]datasource.EntityType{datasource.EntityPerson, datasource.EntityLead},
+			datasource.EntityDeal, 1,
+		},
+		{
+			"everything past the position was narrowed away — the walk is over",
+			[]datasource.EntityType{datasource.EntityPerson},
+			datasource.EntityLead, 1,
+		},
+	} {
+		t.Run(probe.name, func(t *testing.T) {
+			if at := resumePosition(probe.walk, probe.resumeAt); at != probe.want {
+				t.Errorf("resumePosition = %d, want %d — resuming before the position re-serves rows the "+
+					"caller already holds, and past the next one hides rows they never saw", at, probe.want)
+			}
+		})
+	}
+}
+
+// A type named twice is walked once. The contract's `types` is a plain array
+// with no uniqueness rule, and a stream walked twice serves every record in it
+// twice — a cursor names the type, not which of its appearances.
+func TestASweepWalksEachTypeOnceInMirrorOrder(t *testing.T) {
+	walk, err := searchableTypes([]datasource.EntityType{
+		datasource.EntityDeal, datasource.EntityPerson, datasource.EntityDeal,
+	})
+	if err != nil {
+		t.Fatalf("resolving the walk: %v", err)
+	}
+	want := []datasource.EntityType{datasource.EntityPerson, datasource.EntityDeal}
+	if !slices.Equal(walk, want) {
+		t.Errorf("walk = %v, want %v — each type once, in the mirror's own order", walk, want)
 	}
 }
 

--- a/backend/internal/modules/overlay/provider_test.go
+++ b/backend/internal/modules/overlay/provider_test.go
@@ -5,9 +5,11 @@ package overlay
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
 	"testing"
 
+	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
@@ -241,23 +243,59 @@ func TestExternalIDUUIDBridgeRejectsUnknownActivityClass(t *testing.T) {
 	}
 }
 
-// TestProviderSearchRequiresExactlyOneEntityType proves Search's own
-// branch-1 scope guard: any number of entity types other than exactly
-// one is a clean error, never a silent "search the first one" guess. A
-// zero-value MirrorStore is enough here — the guard runs before Search
-// ever touches p.ms.
-func TestProviderSearchRequiresExactlyOneEntityType(t *testing.T) {
+// TestProviderSearchRefusesATypeTheMirrorCannotHold proves the sweep's own
+// vocabulary guard: the mirror carries five object classes, and a query
+// naming a sixth is refused rather than walked past. Walking past it would
+// answer an empty page about the RECORDS when the truth is about the mode.
+// A zero-value MirrorStore is enough — the guard runs before p.ms is touched.
+func TestProviderSearchRefusesATypeTheMirrorCannotHold(t *testing.T) {
 	p := NewProvider(&MirrorStore{}, nil)
 
-	tests := [][]datasource.EntityType{
-		nil,
-		{datasource.EntityPerson, datasource.EntityDeal},
+	_, err := p.Search(context.Background(), datasource.SearchQuery{
+		EntityTypes: []datasource.EntityType{datasource.EntityPerson, datasource.EntityProject},
+	})
+	var unsupported *datasource.UnsupportedEntityError
+	if !errors.As(err, &unsupported) {
+		t.Fatalf("Search naming an unmirrored type = %v, want an UnsupportedEntityError", err)
 	}
-	for _, types := range tests {
-		_, err := p.Search(context.Background(), datasource.SearchQuery{EntityTypes: types})
-		if err == nil {
-			t.Fatalf("Search with %d entity types: want an error, got nil", len(types))
-		}
+	if unsupported.Type != string(datasource.EntityProject) {
+		t.Errorf("the refusal names %q, want the type the mirror cannot hold", unsupported.Type)
+	}
+}
+
+// TestASweepCursorResumesItsOwnSweepAndRefusesAnother pins the resume token
+// #586 turns on: it round-trips the position, and a cursor minted for a sweep
+// that walked OTHER types is malformed rather than silently reindexed.
+// Reading it as position zero would restart the walk; reading it as some
+// arbitrary index would skip whatever lies between the two scopes.
+func TestASweepCursorResumesItsOwnSweepAndRefusesAnother(t *testing.T) {
+	walked := []datasource.EntityType{datasource.EntityPerson, datasource.EntityOrganization, datasource.EntityDeal}
+
+	from, inner, err := decodeSweepCursor(encodeSweepCursor(datasource.EntityOrganization, "mirror-42"), walked)
+	if err != nil {
+		t.Fatalf("decoding a cursor this sweep minted: %v", err)
+	}
+	if from != 1 || inner != "mirror-42" {
+		t.Errorf("resume position = (%d, %q), want the organization arm at its own mirror cursor", from, inner)
+	}
+
+	// An empty cursor is the start of the walk, not a malformed one.
+	if from, inner, err = decodeSweepCursor("", walked); err != nil || from != 0 || inner != "" {
+		t.Errorf("the empty cursor decoded to (%d, %q, %v), want the beginning", from, inner, err)
+	}
+
+	for _, probe := range []struct{ name, cursor string }{
+		{"minted for a sweep this one does not walk", encodeSweepCursor(datasource.EntityLead, "mirror-7")},
+		{"not base64 at all", "not a cursor!!"},
+		{"base64 of something that is not a position", base64.RawURLEncoding.EncodeToString([]byte("nonsense"))},
+	} {
+		t.Run(probe.name, func(t *testing.T) {
+			_, _, err := decodeSweepCursor(probe.cursor, walked)
+			var malformed *storekit.MalformedCursorError
+			if !errors.As(err, &malformed) {
+				t.Errorf("decoding a cursor %s = %v, want the malformed-cursor answer", probe.name, err)
+			}
+		})
 	}
 }
 

--- a/backend/internal/modules/overlay/search.go
+++ b/backend/internal/modules/overlay/search.go
@@ -10,6 +10,8 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"slices"
 	"strings"
 
@@ -76,24 +78,47 @@ func (p *Provider) Search(ctx context.Context, q datasource.SearchQuery) (dataso
 
 // sweep walks types in order from the cursor's position, filling one page.
 //
-// The invariant it keeps is the one #586 was filed for: HasMore is true if
-// and ONLY if NextCursor names somewhere to resume. A page that reports more
-// and hands back no way to reach it is a page whose remainder does not exist
-// as far as any caller can tell.
+// The invariant it keeps: HasMore is true if and ONLY if NextCursor names
+// somewhere to resume. A page that reports more and hands back no way to
+// reach it is a page whose remainder does not exist as far as any caller can
+// tell.
+//
+// HasMore means the WALK has not reached the end of the mirrored rows — not
+// that another row will match. The mirror pages before the text filter runs,
+// so a page whose rows are all filtered out still reports more and hands back
+// the position to continue from, and a walk's last page can be empty. That is
+// the reading every single-type overlay list already gives (MirrorStore.List
+// answers a cursor whenever a batch filled); the alternative — scanning
+// forward until a match turns up — is a request whose cost is decided by how
+// rare the caller's word is.
 func (p *Provider) sweep(ctx context.Context, types []datasource.EntityType, q datasource.SearchQuery) (datasource.SearchResult, error) {
-	from, inner, err := decodeSweepCursor(q.Cursor, types)
+	resumeAt, inner, err := decodeSweepCursor(q.Cursor)
 	if err != nil {
 		return datasource.SearchResult{}, err
 	}
 	text := strings.ToLower(strings.TrimSpace(q.Text))
-	limit := sweepLimit(q.Limit)
+	// The page is one page whether it comes from one object class or five, so
+	// it is bounded once here rather than per type.
+	limit := clampListLimit(q.Limit)
 	out := datasource.SearchResult{Records: []datasource.Record{}}
 
-	for i := from; i < len(types); i++ {
+	for i := resumePosition(types, resumeAt); i < len(types); i++ {
 		et := types[i]
-		if len(types) > 1 && !p.mayRead(ctx, et) {
+		if len(types) > 1 {
+			admitted, err := p.mayRead(ctx, et)
+			if err != nil {
+				return datasource.SearchResult{}, err
+			}
+			if !admitted {
+				inner = ""
+				continue
+			}
+		}
+		if et != resumeAt {
+			// The stream the cursor was minted in is not this one — it was
+			// narrowed away, or the seat lost it. This type starts at ITS
+			// beginning rather than inheriting a position from another.
 			inner = ""
-			continue
 		}
 		rows, next, err := p.ms.List(ctx, string(et), inner, limit-len(out.Records))
 		if err != nil {
@@ -111,27 +136,47 @@ func (p *Provider) sweep(ctx context.Context, types []datasource.EntityType, q d
 		}
 		// This type still has rows the page did not reach: resume INSIDE it.
 		if next != "" {
-			out.NextCursor, out.HasMore = encodeSweepCursor(et, next), true
-			return out, nil
+			return withResumePosition(out, et, next)
 		}
 		// It is exhausted. If the page is full and any type is left, resume at
 		// the start of the next one; a full page on the LAST type is simply a
 		// complete answer, and claiming more would be the same lie inverted.
 		inner = ""
 		if len(out.Records) >= limit && i+1 < len(types) {
-			out.NextCursor, out.HasMore = encodeSweepCursor(types[i+1], ""), true
-			return out, nil
+			return withResumePosition(out, types[i+1], "")
 		}
 	}
 	return out, nil
 }
 
 // mayRead reports whether the seat may read one entity type, for the sweep's
-// skip-the-denied posture. A failure that is NOT a denial (a malformed
-// principal) also answers false: the sweep omits what it cannot prove the
-// caller may see, and never widens on an error.
-func (p *Provider) mayRead(ctx context.Context, et datasource.EntityType) bool {
-	return auth.Require(ctx, string(et), principal.ActionRead) == nil
+// skip-the-denied posture.
+//
+// A DENIAL and a failure are different answers. Only the first is a fact about
+// the caller's grants; the second — no principal bound, a malformed one — is
+// this server not working, and reading it as "may not see it" would answer a
+// broken request chain with five skipped types and a 200 saying the workspace
+// holds nothing. ListObjects draws the same line for the same reason.
+func (p *Provider) mayRead(ctx context.Context, et datasource.EntityType) (bool, error) {
+	err := auth.Require(ctx, string(et), principal.ActionRead)
+	switch {
+	case err == nil:
+		return true, nil
+	case errors.Is(err, apperrors.ErrPermissionDenied):
+		return false, nil
+	default:
+		return false, err
+	}
+}
+
+// MirroredEntityTypes is the order a sweep walks the mirror's object classes
+// in — fixed, so a capped page is deterministic, and EXPORTED because compose
+// answers "can this mode serve that type?" on the REST door and must answer it
+// from the same list the provider walks. Two lists would drift the moment a
+// sixth class is mirrored, and the shape of that drift is a type MCP serves
+// and REST refuses.
+func MirroredEntityTypes() []datasource.EntityType {
+	return slices.Clone(knownEntityTypes)
 }
 
 // searchableTypes resolves the types one query walks: the ones it named, or
@@ -139,30 +184,54 @@ func (p *Provider) mayRead(ctx context.Context, et datasource.EntityType) bool {
 // means on the tool surface. A type the mirror cannot hold is refused rather
 // than silently walked past, so a caller who names `project` hears that the
 // mirror has none instead of reading an empty page as an empty workspace.
+//
+// The answer is always in MIRROR order and always without repeats, whatever
+// order the caller listed them in and however many times. The contract's
+// `types` is a plain array with no uniqueness rule, and `types=person,person`
+// walked literally would read that stream twice — serving every person again,
+// since a cursor names a type rather than one of its two appearances.
 func searchableTypes(named []datasource.EntityType) ([]datasource.EntityType, error) {
 	if len(named) == 0 {
 		return knownEntityTypes, nil
 	}
+	asked := make(map[datasource.EntityType]bool, len(named))
 	for _, et := range named {
 		if !slices.Contains(knownEntityTypes, et) {
 			return nil, &datasource.UnsupportedEntityError{Type: string(et)}
 		}
+		asked[et] = true
 	}
-	return named, nil
+	walk := make([]datasource.EntityType, 0, len(asked))
+	for _, et := range knownEntityTypes {
+		if asked[et] {
+			walk = append(walk, et)
+		}
+	}
+	return walk, nil
 }
 
-// sweepLimit resolves the page size a sweep fills, through the same bounds
-// MirrorStore.List applies per type — the page is one page whether it comes
-// from one object class or five.
-func sweepLimit(requested int) int {
-	switch {
-	case requested <= 0:
-		return defaultListLimit
-	case requested > maxListLimit:
-		return maxListLimit
-	default:
-		return requested
+// resumePosition is where in this query's walk a cursor's type resumes.
+//
+// The cursor names a position in the MIRROR's fixed type order rather than an
+// index into one request's slice, so the same token still means the same place
+// when the request's own type set is not the one that minted it — a caller who
+// narrowed `types` mid-walk, or a seat that lost a grant between pages. A
+// position this query no longer walks resumes at the next type PAST it: the
+// rows in between belong to a stream this request is not reading, and the
+// contract already says changing a filter mid-walk changes what the remaining
+// pages see. Answering 422 there would call an authorization change a
+// malformed input.
+func resumePosition(walk []datasource.EntityType, resumeAt datasource.EntityType) int {
+	if resumeAt == "" {
+		return 0
 	}
+	at := slices.Index(knownEntityTypes, resumeAt)
+	for i, et := range walk {
+		if slices.Index(knownEntityTypes, et) >= at {
+			return i
+		}
+	}
+	return len(walk)
 }
 
 // sweepCursor is where a sweep stopped: the entity type being walked and that
@@ -176,40 +245,54 @@ type sweepCursor struct {
 
 // encodeSweepCursor renders a resume position opaquely: a caller must never
 // build or edit one, and the shape inside is this package's business.
-func encodeSweepCursor(et datasource.EntityType, inner string) string {
+//
+// It answers an error rather than an empty cursor, because the caller pairs
+// the result with HasMore: a silent "" there would report more with nowhere
+// to go, which is the answer this whole file exists to stop giving.
+func encodeSweepCursor(et datasource.EntityType, inner string) (string, error) {
 	raw, err := json.Marshal(sweepCursor{Type: string(et), Inner: inner})
 	if err != nil {
-		// A two-string struct cannot fail to marshal; encoding it as an empty
-		// cursor rather than panicking keeps the HasMore invariant honest —
-		// see sweep, which reads "" as "nowhere to resume".
-		return ""
+		return "", fmt.Errorf("overlay: encoding the sweep position for %s: %w", et, err)
 	}
-	return base64.RawURLEncoding.EncodeToString(raw)
+	return base64.RawURLEncoding.EncodeToString(raw), nil
 }
 
-// decodeSweepCursor resolves a cursor to the index in types it resumes at and
-// the mirror cursor within that type. An empty cursor starts at the
-// beginning.
+// withResumePosition finishes a page that stopped short of the walk's end:
+// the position to continue from, and the flag that says one exists. They are
+// set together and only together, which is the whole of the invariant.
+func withResumePosition(out datasource.SearchResult, et datasource.EntityType, inner string) (datasource.SearchResult, error) {
+	cursor, err := encodeSweepCursor(et, inner)
+	if err != nil {
+		return datasource.SearchResult{}, err
+	}
+	out.NextCursor, out.HasMore = cursor, true
+	return out, nil
+}
+
+// decodeSweepCursor resolves a cursor to the mirrored type it resumes at and
+// the position within that type's stream. An empty cursor starts at the
+// beginning of the walk.
 //
-// A cursor naming a type this query does not walk is MALFORMED, not
-// ignorable: it was minted for a different sweep, and resuming a narrower
-// query from a wider one's position would silently skip whatever lies between
-// them.
-func decodeSweepCursor(cursor string, types []datasource.EntityType) (from int, inner string, err error) {
+// Malformed is reserved for a token this package could not have minted:
+// something that is not base64, not the position shape, or names an object
+// class the mirror does not hold. Whether the CURRENT request still walks that
+// type is not a question about the token — see resumePosition, which answers
+// it without calling a caller's valid cursor an input error.
+func decodeSweepCursor(cursor string) (resumeAt datasource.EntityType, inner string, err error) {
 	if cursor == "" {
-		return 0, "", nil
+		return "", "", nil
 	}
 	raw, err := base64.RawURLEncoding.DecodeString(cursor)
 	if err != nil {
-		return 0, "", &storekit.MalformedCursorError{}
+		return "", "", &storekit.MalformedCursorError{}
 	}
 	var position sweepCursor
 	if err := json.Unmarshal(raw, &position); err != nil {
-		return 0, "", &storekit.MalformedCursorError{}
+		return "", "", &storekit.MalformedCursorError{}
 	}
-	at := slices.Index(types, datasource.EntityType(position.Type))
-	if at < 0 {
-		return 0, "", &storekit.MalformedCursorError{}
+	at := datasource.EntityType(position.Type)
+	if !slices.Contains(knownEntityTypes, at) {
+		return "", "", &storekit.MalformedCursorError{}
 	}
 	return at, position.Inner, nil
 }

--- a/backend/internal/modules/overlay/search.go
+++ b/backend/internal/modules/overlay/search.go
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package overlay
+
+// The mirror search: one entity type's rows, or a SWEEP across several, and
+// the cursor that makes a walk with no ranking resumable all the same.
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"slices"
+	"strings"
+
+	"github.com/gradionhq/margince/backend/internal/platform/auth"
+	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
+)
+
+// Search pages the mirror rows of one entity type — or SWEEPS several in a
+// fixed order — visibility-joined via MirrorStore.List, applying q.Text as a
+// naive case-insensitive substring filter over each row's string-valued
+// fields (a branch-1 scope limit, not the FTS/RRF hybrid search's own
+// retrieval path).
+//
+// The sweep exists because the tool surface advertises it: search_records
+// says `record_type` may be omitted "to sweep all five", and search over an
+// omitted type is exactly what the native provider answers. A mode that
+// refused it made the same tool behave differently on an overlay workspace,
+// which is the silent break AC-OV-2 forbids.
+//
+// It is walked type by type rather than ranked across them, because the
+// mirror holds opaque incumbent rows and has no score to order them by. What
+// makes that pageable anyway is sweepCursor: the position IS the type plus
+// that type's own mirror cursor, so a caller resumes where the page stopped
+// instead of being told there is more with no way to reach it.
+func (p *Provider) Search(ctx context.Context, q datasource.SearchQuery) (datasource.SearchResult, error) {
+	if p.ms == nil {
+		return datasource.SearchResult{}, errNoMirrorStore()
+	}
+	types, err := searchableTypes(q.EntityTypes)
+	if err != nil {
+		return datasource.SearchResult{}, err
+	}
+	// Object RBAC before any mirror read — the MCP search_records path
+	// reaches the provider directly, so the gate the REST search shadow
+	// applies must also live here (see Read's rationale).
+	//
+	// One NAMED type answers the denial; a sweep omits the types the seat may
+	// not read and answers the rest, which is the posture ListObjects already
+	// takes and the only one that lets a partly-granted seat search at all.
+	if len(types) == 1 {
+		if err := auth.Require(ctx, string(types[0]), principal.ActionRead); err != nil {
+			return datasource.SearchResult{}, err
+		}
+	}
+	// A structured filter the mirror cannot evaluate is REFUSED, never dropped.
+	// The mirror holds the incumbent's rows as opaque fields, so a narrowing by
+	// owner or stage has nothing to bind to — and answering the unnarrowed page
+	// instead would return a superset of what was asked for, in the shape of the
+	// right answer. That is the silent break AC-OV-2 forbids: a tool either
+	// behaves identically across modes or declares it cannot serve this one.
+	//
+	// It lands AFTER the object gate on purpose. A caller with no read grant
+	// must hear the same thing whether or not they attached a filter; refusing
+	// first would let an unauthorized caller learn this workspace's
+	// system-of-record mode by adding one.
+	if len(q.Filters) > 0 {
+		return datasource.SearchResult{}, apperrors.ErrUnsupportedBySoR
+	}
+	return p.sweep(ctx, types, q)
+}
+
+// sweep walks types in order from the cursor's position, filling one page.
+//
+// The invariant it keeps is the one #586 was filed for: HasMore is true if
+// and ONLY if NextCursor names somewhere to resume. A page that reports more
+// and hands back no way to reach it is a page whose remainder does not exist
+// as far as any caller can tell.
+func (p *Provider) sweep(ctx context.Context, types []datasource.EntityType, q datasource.SearchQuery) (datasource.SearchResult, error) {
+	from, inner, err := decodeSweepCursor(q.Cursor, types)
+	if err != nil {
+		return datasource.SearchResult{}, err
+	}
+	text := strings.ToLower(strings.TrimSpace(q.Text))
+	limit := sweepLimit(q.Limit)
+	out := datasource.SearchResult{Records: []datasource.Record{}}
+
+	for i := from; i < len(types); i++ {
+		et := types[i]
+		if len(types) > 1 && !p.mayRead(ctx, et) {
+			inner = ""
+			continue
+		}
+		rows, next, err := p.ms.List(ctx, string(et), inner, limit-len(out.Records))
+		if err != nil {
+			return datasource.SearchResult{}, err
+		}
+		for _, row := range rows {
+			if text != "" && !mirrorRowMatchesText(row, text) {
+				continue
+			}
+			rec, err := recordFromRow(et, row)
+			if err != nil {
+				return datasource.SearchResult{}, err
+			}
+			out.Records = append(out.Records, rec)
+		}
+		// This type still has rows the page did not reach: resume INSIDE it.
+		if next != "" {
+			out.NextCursor, out.HasMore = encodeSweepCursor(et, next), true
+			return out, nil
+		}
+		// It is exhausted. If the page is full and any type is left, resume at
+		// the start of the next one; a full page on the LAST type is simply a
+		// complete answer, and claiming more would be the same lie inverted.
+		inner = ""
+		if len(out.Records) >= limit && i+1 < len(types) {
+			out.NextCursor, out.HasMore = encodeSweepCursor(types[i+1], ""), true
+			return out, nil
+		}
+	}
+	return out, nil
+}
+
+// mayRead reports whether the seat may read one entity type, for the sweep's
+// skip-the-denied posture. A failure that is NOT a denial (a malformed
+// principal) also answers false: the sweep omits what it cannot prove the
+// caller may see, and never widens on an error.
+func (p *Provider) mayRead(ctx context.Context, et datasource.EntityType) bool {
+	return auth.Require(ctx, string(et), principal.ActionRead) == nil
+}
+
+// searchableTypes resolves the types one query walks: the ones it named, or
+// every mirrored type when it named none — which is what "omit to sweep all"
+// means on the tool surface. A type the mirror cannot hold is refused rather
+// than silently walked past, so a caller who names `project` hears that the
+// mirror has none instead of reading an empty page as an empty workspace.
+func searchableTypes(named []datasource.EntityType) ([]datasource.EntityType, error) {
+	if len(named) == 0 {
+		return knownEntityTypes, nil
+	}
+	for _, et := range named {
+		if !slices.Contains(knownEntityTypes, et) {
+			return nil, &datasource.UnsupportedEntityError{Type: string(et)}
+		}
+	}
+	return named, nil
+}
+
+// sweepLimit resolves the page size a sweep fills, through the same bounds
+// MirrorStore.List applies per type — the page is one page whether it comes
+// from one object class or five.
+func sweepLimit(requested int) int {
+	switch {
+	case requested <= 0:
+		return defaultListLimit
+	case requested > maxListLimit:
+		return maxListLimit
+	default:
+		return requested
+	}
+}
+
+// sweepCursor is where a sweep stopped: the entity type being walked and that
+// type's own mirror cursor within it. Both halves are needed — the type alone
+// would restart it, and the mirror cursor alone would not say which object
+// class it indexes into.
+type sweepCursor struct {
+	Type  string `json:"t"`
+	Inner string `json:"c"`
+}
+
+// encodeSweepCursor renders a resume position opaquely: a caller must never
+// build or edit one, and the shape inside is this package's business.
+func encodeSweepCursor(et datasource.EntityType, inner string) string {
+	raw, err := json.Marshal(sweepCursor{Type: string(et), Inner: inner})
+	if err != nil {
+		// A two-string struct cannot fail to marshal; encoding it as an empty
+		// cursor rather than panicking keeps the HasMore invariant honest —
+		// see sweep, which reads "" as "nowhere to resume".
+		return ""
+	}
+	return base64.RawURLEncoding.EncodeToString(raw)
+}
+
+// decodeSweepCursor resolves a cursor to the index in types it resumes at and
+// the mirror cursor within that type. An empty cursor starts at the
+// beginning.
+//
+// A cursor naming a type this query does not walk is MALFORMED, not
+// ignorable: it was minted for a different sweep, and resuming a narrower
+// query from a wider one's position would silently skip whatever lies between
+// them.
+func decodeSweepCursor(cursor string, types []datasource.EntityType) (from int, inner string, err error) {
+	if cursor == "" {
+		return 0, "", nil
+	}
+	raw, err := base64.RawURLEncoding.DecodeString(cursor)
+	if err != nil {
+		return 0, "", &storekit.MalformedCursorError{}
+	}
+	var position sweepCursor
+	if err := json.Unmarshal(raw, &position); err != nil {
+		return 0, "", &storekit.MalformedCursorError{}
+	}
+	at := slices.Index(types, datasource.EntityType(position.Type))
+	if at < 0 {
+		return 0, "", &storekit.MalformedCursorError{}
+	}
+	return at, position.Inner, nil
+}
+
+// mirrorRowMatchesText reports whether any string-valued field of row
+// contains lowerText.
+func mirrorRowMatchesText(row Row, lowerText string) bool {
+	for _, v := range row.Fields {
+		if s, ok := v.(string); ok && strings.Contains(strings.ToLower(s), lowerText) {
+			return true
+		}
+	}
+	return false
+}

--- a/backend/internal/modules/overlay/usermapadmin.go
+++ b/backend/internal/modules/overlay/usermapadmin.go
@@ -162,12 +162,7 @@ func (s *MirrorStore) ListUserMap(ctx context.Context, incumbent, cursor string,
 	if err != nil {
 		return nil, "", err
 	}
-	switch {
-	case limit <= 0:
-		limit = defaultListLimit
-	case limit > maxListLimit:
-		limit = maxListLimit
-	}
+	limit = clampListLimit(limit)
 	var afterID ids.UserID
 	if after != "" {
 		afterID, err = ids.ParseAs[ids.UserKind](after)


### PR DESCRIPTION
Closes #599. Closes #586.

## What was wrong

`search_records` advertises that `record_type` may be omitted **"to sweep all five"**. On an overlay workspace the provider refused any query that did not name exactly one:

```go
if len(q.EntityTypes) != 1 {
    return ..., fmt.Errorf("overlay: search requires exactly one entity type in this branch, got %d", …)
}
```

So an agent doing exactly what the schema told it to was refused — for a rule the schema never stated, and through a bare error rather than the declared unsupported-by-SoR sentinel a caller can branch on.

And the REST `/v1/search` shadow, which **did** walk every type, reported `has_more: true` with no `next_cursor` and refused `cursor` outright. Everything past the first page was unreachable by any means the contract offers (#586).

## The fix, and why it is a cursor rather than a loop

The provider sweeps: the types the query named, or every mirrored one when it named none, walked in a fixed order. A mirror walk has no ranking to interleave types by — the rows are the incumbent's, opaque and unscored — so what makes it pageable is a cursor whose **position is the type plus that type's own mirror cursor**.

The invariant it keeps is the one #586 is about: **`has_more` is true if and only if `next_cursor` names somewhere to resume.** The integration test walks a five-record set one hit at a time and holds every page to it, so the walk is exercised in both cursor shapes — resuming *inside* a type, and starting the next one — and asserts no record is served twice.

A cursor minted for a sweep over other types is **malformed**, not silently reindexed: resuming a narrower query from a wider one's position would skip whatever lies between them.

### Three judgements worth reviewing

| decision | why |
|---|---|
| **Object RBAC splits by shape** — one NAMED type still answers the denial; a sweep omits the types the seat may not read | the MCP path reaches the provider directly, so a named type must not become a probe; and a sweep that 403'd would leave a partly-granted seat unable to search at all. The omit posture is the one `ListObjects` already takes |
| **An unmirrored type is refused, not walked past** | the contract's `types` enum carries six values and the mirror holds five, so answering `project` with an empty page says "this workspace has no projects" when the truth is about the mode |
| **The REST shadow delegates** instead of keeping its own union | the tool and the route now answer one implementation. The shadow resolves the readable types first, which keeps search's own posture (a denied branch is omitted, never a query-wide 403 — `search/store.go`'s `branchScope`) while the seam keeps its |

## Verification

- `make check-backend` — green (exit 0); `craft static --strict` over every changed file: `PASS — 0 blocker, 0 major, 0 minor`.
- The whole `compose/integration/overlay` package passes (31s, 30+ tests), including the three new ones: the paging sweep, the `search_records` tool called **with no `record_type`** in overlay mode (the literal subject of #599), and the unmirrored-type refusal.
- Unit tests cover the cursor codec directly: round-trip, empty-is-the-start, and three malformed shapes — including one minted for a sweep that walked other types.

## Notes

- `provider.go` crossed the 500-line hard ceiling, so the sweep and its cursor moved to `overlay/search.go` — one concept per file.
- **`search_context` is NOT a third instance of this defect**, though the roadmap listed it as one. Its `record_types` makes the same "omit to sweep all" claim, but it rides the **retrieval** seam, and `nativeOnlyRetriever` (`compose/nativeonlytools.go`) already refuses the whole tool in overlay mode with the declared `ErrUnsupportedBySoR` sentinel — a stated refusal, not a claim the surface breaks. Its sweep promise holds natively, which is the only mode it serves. Nothing owed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes overlay search to sweep all mirrored types in a stable order and adds a cross-type cursor that resumes reliably, even if `types` or grants change mid-walk. The `/v1/search` route now delegates to the provider sweep and strictly pairs `has_more` with `next_cursor` (addresses #586, #599).

- **Bug Fixes**
  - The provider sweep de-dupes `types` and walks them in mirror order; the cursor encodes the current type plus that type’s mirror cursor. `has_more` is true only when `next_cursor` is present.
  - An unmirrored type is refused; malformed cursors are only tokens we didn’t mint; resuming after a scope/grant change continues at the next mirrored type.
  - RBAC: a single named type still enforces read denial; a sweep omits unreadable types; non-denial auth failures surface instead of being treated as denials.
  - The overlay `/v1/search` delegates to the sweep, validates `types`, accepts `cursor`, and returns consistent paging; a single denied named type yields an empty page (unmapped users also see empty pages).

- **Refactors**
  - Moved sweep and cursor codec to `backend/internal/modules/overlay/search.go`; exported `overlay.MirroredEntityTypes()` and used it in REST; unified page-size clamping across mirror list and user map.
  - Added/updated integration and unit tests for the sweep, cursor codec, and `search_records` without `record_type`.

<sup>Written for commit 48f62d820451ae303763168ac198283609e5d74f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/832?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



---

## What review changed (second commit)

Three independent reviews — two of them found the same two wire-reachable defects, which is the argument for running more than one:

| finding | why it mattered |
|---|---|
| **A type named twice was walked twice** | `?types=person&types=person` is contract-legal (no uniqueness rule). The cursor names a type, not one of its appearances, so a follow-the-cursor client re-served every person **forever**, `has_more` never settling. The walk is now resolved into mirror order without repeats |
| **A revoked grant mid-walk answered 422 `malformed_cursor`** | the token indexed into one request's type list. It now names a position in the mirror's own order, and a position this request no longer walks resumes at the next type past it — malformed is reserved for a token this package could not have minted |
| **A non-denial authz failure answered an empty page** | `auth.Require` returns more than `ErrPermissionDenied` (no principal bound is a bare error), and both the sweep and the compose scope read anything non-nil as "may not see it" — so a broken request chain answered `200` with nothing. A denial omits the type; anything else surfaces |
| **`encodeSweepCursor` swallowed its error** under a comment describing a guard nothing implemented — the caller paired whatever it returned with `has_more: true` | an empty cursor there would have been exactly the defect this PR removes |
| **Two lists said what the mirror holds** | a sixth mirrored class would have been served by the tool and refused by the route. The module exports the list; compose reads it |

Also: each layer now keeps **one** rule about a denied type instead of both filtering; the package's three copies of the page-size clamp collapse to one; and the sweep test seeds and asserts the `activity` arm it previously only claimed.

**Filed rather than fixed: #839.** `search_records`' schema still says the cursor is "single record_type only" — false as of this PR — and its enum is a *different* five from the mirror's. Editing tool copy moves `prompt_version` and re-arms the paid certification lane, so four words are not a four-word change; it belongs with the next catalog decision, not here.
