### PR TITLE
test(company): the 360's query budget counts the last-meeting read

### DIFF
--- a/backend/internal/compose/integration/org360/org360_querycount_integration_test.go
+++ b/backend/internal/compose/integration/org360/org360_querycount_integration_test.go
@@ -140,7 +140,19 @@ func TestOrganization360CostDoesNotGrowWithTheAccount(t *testing.T) {
 	// composite that costs the same on every account and one that costs most on
 	// the accounts with the most contacts. It rides the person grant the
 	// contacts section already checked, so it costs no second admission.
-	const budget = 29
+	//
+	// Raised 29 → 30 for last_meeting_at: ONE query, the most recent meeting
+	// that has already happened. It is the opposite question from the
+	// next-meeting section — backwards rather than forwards — so it cannot be
+	// read off that section's row, and it carries the activity scope clause
+	// itself rather than trusting a read that asked something else. It reuses
+	// the activity grant the timeline already checked, so it costs no second
+	// admission, and it stays flat in the size of the account like every
+	// other section here.
+	//
+	// It landed without this line, so the assembly issued 30 against a budget
+	// of 29 and every branch cut afterwards inherited a red gate.
+	const budget = 30
 	if smallCost > budget {
 		t.Errorf("one 360 issued %d queries, budget is %d", smallCost, budget)
 	}


### PR DESCRIPTION
**`main` is red.** `TestOrganization360CostDoesNotGrowWithTheAccount` has been failing since #829 merged:

```
org360_querycount_integration_test.go:145: one 360 issued 30 queries, budget is 29
```

Bisected locally against a throwaway clone: `a531ec20` passes, `6c0607f4` (#829, which added `last_meeting_at`) fails, and so does everything after it. Every branch cut since inherits a red integration shard it did not cause — including the two I have open, which is how I found it.

## What changed here

One line, and the sentence that earns it. The `last_meeting_at` read is a legitimate query and the ceiling is what moves:

- it asks the **opposite** question from the next-meeting section — the most recent meeting that has already happened, not the next one — so it cannot be read off that section's row;
- it carries the activity scope clause itself rather than trusting a read that asked something else;
- it reuses the activity grant the timeline already checked, so it costs no second admission;
- it is flat in the size of the account, like every other section the budget covers.

The test's own comment block asks for exactly this ("If this ever needs raising, the reason belongs in the commit that raises it"), so the raise goes in with its reason beside the four before it.

## Verification

`make test-it DIR=backend/internal/compose/integration/org360` — the whole package green, including the shape assertion (`largeCost == smallCost`) that the budget line sits next to. That assertion is untouched: this changes the ceiling, not the claim that the cost does not grow with the account.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raised the Organization 360 query budget from 29 to 30 to account for the `last_meeting_at` read, fixing `TestOrganization360CostDoesNotGrowWithTheAccount` and restoring green tests. The query is legitimate and flat in cost; only the ceiling moves, with the reason documented inline.

<sup>Written for commit 2783a25600a3da3b72d91650bc3baf00644d452e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/834?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

