### PR TITLE
feat(company): a suggestion says what to do, and when it went quiet

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -12804,6 +12804,30 @@ components:
             filed under: a `contract_ended` signal stands while the record still reads as a live
             customer or an open opportunity. The page states the conflict rather than resolving
             it, because which of the two is wrong is a judgment only the reader can make.
+        title:
+          type: [string, 'null']
+          description: |
+            What to do, in the RULE's own words — "Follow up: no reply in 24 days" (PO-AC-N-13).
+
+            Never an invented task. The mockups draw rows like "Prep expansion workshop", which
+            the system has no basis for and no way to complete; a title here says only what the
+            rule that fired already knows.
+
+            It is NOT part of the fingerprint (PO-AC-N-14). Folding it in would resurrect every
+            suggestion every reader has ever dismissed the moment the wording changed.
+        due_at:
+          type: [string, 'null']
+          format: date-time
+          description: |
+            The date the EVIDENCE carries — when the thread went quiet, when the deal last moved.
+
+            Never a deadline the system chose for a rep. A suggestion is a reading, and inventing
+            a due date would turn it into an obligation nobody agreed to. Null where the rule
+            fired on something with no date of its own.
+
+            Excluded from the fingerprint for the same reason as the title, and more sharply: a
+            date moves on its own, so a dismissal keyed on one would expire without anything
+            about the account changing.
         fingerprint:
           type: string
           description: |

--- a/backend/internal/compose/org360/suggestions.go
+++ b/backend/internal/compose/org360/suggestions.go
@@ -273,6 +273,10 @@ func staleThread(
 		Fingerprint: fingerprint(string(suggestNoReply), orgID.String(), evidence),
 		Evidence:    evidence,
 	}
+	// The rule's own words, and the date the EVIDENCE carries — when the thread
+	// went quiet. Neither reaches the fingerprint above (PO-AC-N-14).
+	out.Title = ptrString(fmt.Sprintf("Follow up: no reply in %d days", int(waited.Hours()/24)))
+	out.DueAt = ptrTime(newest.At)
 	setDraftReply(out, newest.ID)
 	return out
 }
@@ -300,7 +304,11 @@ func stalledDealSuggestions(stalled []stalledDeal) []crmcontracts.Organization36
 			SubjectType: &subjectType,
 			SubjectId:   &subjectID,
 			Evidence:    evidence,
+			Title:       ptrString(fmt.Sprintf("Move %q — stalled", deal.Name)),
 		})
+		if !deal.IdleSince.IsZero() {
+			out[len(out)-1].DueAt = ptrTime(deal.IdleSince)
+		}
 		setOpenDeal(&out[len(out)-1], deal.ID)
 	}
 	return out
@@ -333,7 +341,10 @@ func noNextStepSuggestion(
 		Reason:      fmt.Sprintf("%d open deal(s) here and no task saying what happens next.", open.OpenCount),
 		Fingerprint: fingerprint(string(suggestNoNextStep), open.OpenDigest, evidence),
 		Evidence:    evidence,
+		Title:       ptrString("Set the next step"),
 	}
+	// No date: this rule fires on the ABSENCE of a task, and an absence has no
+	// date of its own. Inventing one would make a reading into a deadline.
 	// No deal named: the account has several open, and picking one for the
 	// reader would be a guess dressed as advice.
 	out.Action = newSuggestionAction(crmcontracts.Organization360SuggestionActionKindAddTask)
@@ -371,6 +382,9 @@ func lifecycleConflict(
 		// that has since been fixed.
 		Fingerprint: fingerprint(string(suggestConflict), in.lifecycle, evidence),
 		Evidence:    evidence,
+		// The conflict is named, not resolved — which of the two is wrong is the
+		// reader's judgment, so the title asks rather than instructs.
+		Title: ptrString("Check the stage against what they wrote"),
 	}
 }
 
@@ -378,6 +392,13 @@ func lifecycleConflict(
 // that already reads as over — former_customer, disqualified — is not in
 // conflict with the mail that says so; it is the mail's conclusion.
 var liveLifecycles = map[string]bool{"prospect": true, "opportunity": true, "customer": true}
+
+// A title and a date are OPTIONAL on the wire, so both are pointers. Spelled
+// once here rather than inline, because a suggestion that carried a zero time
+// would render as "due 1 January year one" — a date is either the evidence's or
+// it is absent.
+func ptrString(v string) *string     { return &v }
+func ptrTime(v time.Time) *time.Time { return &v }
 
 // fingerprint identifies a suggestion by what it fired ON, not by what kind
 // it is.

--- a/backend/internal/compose/org360/suggestiontitles_test.go
+++ b/backend/internal/compose/org360/suggestiontitles_test.go
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package org360
+
+import (
+	"testing"
+	"time"
+
+	openapi_types "github.com/oapi-codegen/runtime/types"
+
+	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// A suggestion's title and date are for the READER; its fingerprint is for the
+// dismissal (PO-AC-N-13..14, ADR-0095/A146).
+//
+// The two must never meet. A dismissal is matched by fingerprint, so folding a
+// title or a date into it would resurrect every suggestion every reader has
+// ever dismissed — silently, and for everyone at once. That is the constraint
+// that makes this change safe, and it is the one worth a test of its own.
+
+func TestTheFingerprintIgnoresTheTitleAndTheDate(t *testing.T) {
+	evidence := []crmcontracts.OrganizationBriefEvidence{{
+		EntityType: crmcontracts.OrganizationBriefEvidenceEntityTypeActivity,
+		EntityId:   openapi_types.UUID(ids.NewV7()),
+	}}
+	// The fingerprint's whole input, spelled here so a change to its signature
+	// has to be reckoned with rather than absorbed.
+	before := fingerprint("no_reply", "org-1", evidence)
+
+	// Whatever a title or a date says, the situation is the same situation.
+	after := fingerprint("no_reply", "org-1", evidence)
+	if before != after {
+		t.Fatalf("the fingerprint is not stable over identical inputs: %q vs %q", before, after)
+	}
+
+	// And the rule that builds one carries a title and a date WITHOUT them
+	// reaching it: the same account, dismissed yesterday, stays dismissed.
+	now := time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC)
+	orgID := ids.OrganizationID{UUID: ids.NewV7()}
+	msg := lastMessage{
+		ID:        ids.NewV7(),
+		At:        now.Add(-30 * 24 * time.Hour),
+		Direction: string(crmcontracts.ActivityDirectionOutbound),
+	}
+
+	first := staleThread(orgID, now, msg)
+	if first == nil || first.Title == nil || first.DueAt == nil {
+		t.Fatalf("the no-reply rule produced no title or date: %+v", first)
+	}
+	// A day later the SENTENCE changes (31 days, not 30) and the date is the
+	// same evidence's. The fingerprint must not move: nothing about the account
+	// changed, so a dismissal must still hold.
+	later := staleThread(orgID, now.Add(24*time.Hour), msg)
+	if later == nil {
+		t.Fatal("the rule stopped firing on a thread that is quieter than before")
+	}
+	if *first.Title == *later.Title {
+		t.Fatal("the title did not change with the wait — it is not reading the evidence")
+	}
+	if first.Fingerprint != later.Fingerprint {
+		t.Fatalf("the fingerprint MOVED when only the title's wording did:\n  %s\n  %s\nEvery dismissal on this account would resurrect.",
+			first.Fingerprint, later.Fingerprint)
+	}
+}
+
+// A title says what the RULE knows. The mockups draw rows like "Prep expansion
+// workshop" — a task the system has no basis for and no way to complete.
+func TestATitleSaysWhatTheRuleKnows(t *testing.T) {
+	now := time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC)
+	orgID := ids.OrganizationID{UUID: ids.NewV7()}
+	out := staleThread(orgID, now, lastMessage{
+		ID:        ids.NewV7(),
+		At:        now.Add(-24 * 24 * time.Hour),
+		Direction: string(crmcontracts.ActivityDirectionOutbound),
+	})
+	if out == nil || out.Title == nil {
+		t.Fatal("no suggestion or no title")
+	}
+	if want := "Follow up: no reply in 24 days"; *out.Title != want {
+		t.Fatalf("title = %q, want %q", *out.Title, want)
+	}
+	// The date is the evidence's own — when the thread went quiet — never a
+	// deadline the system chose for a rep.
+	if out.DueAt == nil || !out.DueAt.Equal(now.Add(-24*24*time.Hour)) {
+		t.Fatalf("due_at = %v, want the message's own instant", out.DueAt)
+	}
+}
+
+// The no-next-step rule fires on an ABSENCE, and an absence has no date.
+// Inventing one would turn a reading into an obligation nobody agreed to.
+func TestARuleThatFiresOnAnAbsenceCarriesNoDate(t *testing.T) {
+	orgID := ids.OrganizationID{UUID: ids.NewV7()}
+	out := noNextStepSuggestion(orgID, suggestionInputs{
+		open: pipeline{OpenCount: 2, OpenDigest: "digest"},
+	})
+	if out == nil || out.Title == nil {
+		t.Fatal("no suggestion or no title")
+	}
+	if out.DueAt != nil {
+		t.Fatalf("due_at = %v, want none — there is no task, so there is no date", out.DueAt)
+	}
+}

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -13274,6 +13274,17 @@ type Organization360Suggestion struct {
 		Kind Organization360SuggestionActionKind `json:"kind"`
 	} `json:"action,omitempty"`
 
+	// DueAt The date the EVIDENCE carries — when the thread went quiet, when the deal last moved.
+	//
+	// Never a deadline the system chose for a rep. A suggestion is a reading, and inventing
+	// a due date would turn it into an obligation nobody agreed to. Null where the rule
+	// fired on something with no date of its own.
+	//
+	// Excluded from the fingerprint for the same reason as the title, and more sharply: a
+	// date moves on its own, so a dismissal keyed on one would expire without anything
+	// about the account changing.
+	DueAt *time.Time `json:"due_at,omitempty"`
+
 	// Evidence The records the rule fired on — always ones this reader can open.
 	Evidence []OrganizationBriefEvidence `json:"evidence"`
 
@@ -13299,6 +13310,16 @@ type Organization360Suggestion struct {
 	Reason      string                                `json:"reason"`
 	SubjectId   *openapi_types.UUID                   `json:"subject_id,omitempty"`
 	SubjectType *Organization360SuggestionSubjectType `json:"subject_type,omitempty"`
+
+	// Title What to do, in the RULE's own words — "Follow up: no reply in 24 days" (PO-AC-N-13).
+	//
+	// Never an invented task. The mockups draw rows like "Prep expansion workshop", which
+	// the system has no basis for and no way to complete; a title here says only what the
+	// rule that fired already knows.
+	//
+	// It is NOT part of the fingerprint (PO-AC-N-14). Folding it in would resurrect every
+	// suggestion every reader has ever dismissed the moment the wording changed.
+	Title *string `json:"title,omitempty"`
 }
 
 // Organization360SuggestionActionKind `draft_reply` — open the composer on the message that went unanswered.

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -8465,6 +8465,30 @@ export interface components {
              */
             kind: "no_reply" | "stalled_deal" | "no_next_step" | "lifecycle_conflict";
             /**
+             * @description What to do, in the RULE's own words — "Follow up: no reply in 24 days" (PO-AC-N-13).
+             *
+             *     Never an invented task. The mockups draw rows like "Prep expansion workshop", which
+             *     the system has no basis for and no way to complete; a title here says only what the
+             *     rule that fired already knows.
+             *
+             *     It is NOT part of the fingerprint (PO-AC-N-14). Folding it in would resurrect every
+             *     suggestion every reader has ever dismissed the moment the wording changed.
+             */
+            title?: string | null;
+            /**
+             * Format: date-time
+             * @description The date the EVIDENCE carries — when the thread went quiet, when the deal last moved.
+             *
+             *     Never a deadline the system chose for a rep. A suggestion is a reading, and inventing
+             *     a due date would turn it into an obligation nobody agreed to. Null where the rule
+             *     fired on something with no date of its own.
+             *
+             *     Excluded from the fingerprint for the same reason as the title, and more sharply: a
+             *     date moves on its own, so a dismissal keyed on one would expire without anything
+             *     about the account changing.
+             */
+            due_at?: string | null;
+            /**
              * @description Identifies this suggestion by its EVIDENCE, not by its kind: a hash over the
              *     kind, the subject and the records it fired on. Dismissing a suggestion stores
              *     this, so the same advice stays gone — and re-arms by itself when the evidence

--- a/frontend/src/screens/company360.tsx
+++ b/frontend/src/screens/company360.tsx
@@ -2784,6 +2784,7 @@ export function SuggestionsSection({
   // the deal and the task form all live above it.
   onPerform?: (action: SuggestionAction) => void;
 }>) {
+  const { locale } = useLocale();
   const t = useT();
   const client = useQueryClient();
   const dismiss = useMutation({
@@ -2825,13 +2826,24 @@ export function SuggestionsSection({
         {suggestions.map((suggestion) => (
           <li key={suggestion.fingerprint} className="co-row">
             <span>
+              {/* The title leads where the rule gave one: it says what to DO,
+                  where the kind says which rule fired. Absent on a rule that
+                  named none, and the kind carries the row alone. */}
               <span className="co-suggest-kind">
-                {t(`co.suggest.kind.${suggestion.kind}`)}
+                {suggestion.title ?? t(`co.suggest.kind.${suggestion.kind}`)}
               </span>
               {/* The reason is the suggestion. Everything else is chrome. */}
               <span className="co-suggest-reason">{suggestion.reason}</span>
             </span>
             <span className="co-row-meta">
+              {/* The date the EVIDENCE carries — when the thread went quiet,
+                  when the deal last moved. Never a deadline the system chose,
+                  which is why a rule firing on an absence shows none. */}
+              {suggestion.due_at && (
+                <span>
+                  {formatDate(suggestion.due_at, locale, RECORD_ZONE)}
+                </span>
+              )}
               <Citations
                 evidence={suggestion.evidence}
                 onOpenRecord={onOpenRecord}


### PR DESCRIPTION
"Next best actions" showed a rule name and a reason sentence, so the card read as **diagnostics rather than as work** (PO-AC-N-13, ADR-0095/A146).

On a real account it now reads:

```
FOLLOW UP: NO REPLY IN 24 DAYS
You reached out 24 days ago and nobody has come back.
17/07/2026                              [activity] [Not now]
```

## The title is the rule's own words

Never the mockups' invented tasks — "Prep expansion workshop" is something the system has no basis for and no way to complete. Each rule says what it already knows:

| Rule | Title |
|---|---|
| `no_reply` | Follow up: no reply in N days |
| `stalled_deal` | Move "<deal>" — stalled |
| `no_next_step` | Set the next step |
| `lifecycle_conflict` | Check the stage against what they wrote |

The conflict rule **asks rather than instructs** — which of the two facts is wrong is the reader's judgment, and the card has always refused to resolve it.

## The date is the evidence's

When the thread went quiet, when the deal last moved. **Never a deadline the system chose for a rep** — a suggestion is a reading, and inventing a due date would turn it into an obligation nobody agreed to.

The `no_next_step` rule fires on an *absence*, and an absence has no date, so it carries none.

## The fingerprint does not change — this is the whole safety of the diff

A dismissal is matched by fingerprint. Folding in a title would **resurrect every suggestion every reader has ever dismissed** — silently, and for everyone at once. A date would be worse: it moves on its own, so a dismissal keyed on one would expire without anything about the account changing.

The test does not assert the fingerprint's contents. It asserts that a title which **changes** between two reads of the same unchanged account leaves the fingerprint identical — which is the property that actually matters.

Mutation-checked by leaking the title into the hash: the test fails with the resurrection named in the message.

## Verification

`make check-fe` green (2163), `go test .` green including the producer gate, org360 suite green. Screenshotted on a live account — the block above is the real render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make suggestions actionable by adding clear titles and showing when the thread/deal went quiet. Keeps dismissals stable by leaving fingerprints unchanged.

- **New Features**
  - API: added `title` and `due_at` to `Organization360Suggestion` (optional; typed in contracts and `frontend/src/api/schema.d.ts`).
  - Rule titles:
    - `no_reply`: "Follow up: no reply in N days"; `due_at` = last outbound message time.
    - `stalled_deal`: `Move "<deal>" — stalled`; `due_at` = `idleSince` when present.
    - `no_next_step`: "Set the next step"; no `due_at`.
    - `lifecycle_conflict`: "Check the stage against what they wrote".
  - Fingerprint excludes `title` and `due_at`. Added tests to pin stability across wording/date changes.
  - UI: shows `title` when present (falls back to kind). Renders `due_at` using locale if provided.

<sup>Written for commit 5a6db956c38c8e5d9e304f3603de20bbfc84278a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/838?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

