### PR TITLE
fix(company): the dossier reads as prose, and the ICP bars say which is which

### DIFF
--- a/frontend/src/screens/company360.css
+++ b/frontend/src/screens/company360.css
@@ -874,3 +874,18 @@
   display: grid;
   gap: var(--space-1);
 }
+
+/* The dimension and its figure share a line above the bar, the figure
+   right-aligned so a column of them reads down. */
+.co-growth-fit-score-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: var(--space-2);
+  font-size: 13px;
+}
+
+.co-growth-fit-score-value {
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}

--- a/frontend/src/screens/companydossier.tsx
+++ b/frontend/src/screens/companydossier.tsx
@@ -114,14 +114,18 @@ export function DossierPanel({
               five fields, and the headings said less than the sentences under
               them. The sections still ORDER the prose — the server decides
               what comes first — they just no longer announce themselves. */}
-          {readable.sections.map((section) => (
-            <SentenceList
-              key={section.kind}
-              sentences={section.sentences}
-              onOpenRecord={onOpenRecord}
-              citations="collected"
-            />
-          ))}
+          {/* ONE list over every section. Per-section lists would each collect
+              their own sources, so a one-sentence section still drew a chip
+              directly under its line — the wall of "fact" relocated rather
+              than removed. The sections still ORDER the prose; the receipts
+              gather once, under all of it. */}
+          <SentenceList
+            sentences={readable.sections.flatMap(
+              (section) => section.sentences,
+            )}
+            onOpenRecord={onOpenRecord}
+            citations="collected"
+          />
           <p className="co-part-foot">
             <WrittenBy by={readable.generated_by} />{" "}
             {readable.needs_refresh && (

--- a/frontend/src/screens/companygrowthfit.tsx
+++ b/frontend/src/screens/companygrowthfit.tsx
@@ -190,6 +190,14 @@ function GrowthFitVerdict({ fit }: Readonly<{ fit: GrowthFit }>) {
         <ul className="co-growth-fit-scores">
           {fit.sub_scores.map((sub) => (
             <li key={sub.dimension} className="co-growth-fit-score">
+              {/* The label and the figure are DRAWN, not only announced:
+                  Meter carries its label to assistive tech as an aria-label
+                  and renders none, so a row of bare bars would say nothing
+                  about which dimension is which. */}
+              <span className="co-growth-fit-score-head">
+                <span>{t(SUB_SCORE_LABELS[sub.dimension])}</span>
+                <span className="co-growth-fit-score-value">{sub.score}</span>
+              </span>
               <Meter
                 value={sub.score}
                 max={100}


### PR DESCRIPTION
Two faults the **screenshots** caught that the tests could not.

## The dossier collected citations per section

So a one-sentence section still drew a chip directly under its line — the wall of `fact` **relocated rather than removed**, which is worse than where it started. #840 fixed the mechanism and missed that each section rendered its own list.

One list over every section collects them once, under all of it. The sections still order the prose; the receipts gather at the end.

## The ICP bars drew no labels

`Meter` carries its label to assistive tech as an `aria-label` and renders none, so four bare bars said nothing about which dimension each one was — a reader could see three scores and not know which was industry fit.

The label and the figure are drawn above each bar now, the figure right-aligned so a column of them reads down:

```
Industry fit                    60
▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓░░░░░░░
The prospect is a creative agency in the professional services
sector, which aligns with our target market…

Company size                    50
▓▓▓▓▓▓▓▓▓▓▓▓░░░░░░░░░░░
```

## Why the tests missed both

Neither is a wrong value — both are the right data in a shape a reader cannot use. The component tests assert what renders; they had no way to say "and it is legible". This is the third time this session that a screenshot found what a green suite did not.

## Verification

`make check-fe` green (2163). Screenshotted settled on a live account — the ICP block above is the real render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the company dossier read as continuous prose with citations collected once at the end, and adds visible labels and scores to ICP sub-score bars for clarity and accessibility.

- **Bug Fixes**
  - Dossier: use one SentenceList across all sections to collect citations once, avoiding per-line chips.
  - ICP bars: draw the dimension label and right-aligned numeric score above each bar; added minimal CSS for layout and tabular numerals.

<sup>Written for commit 3b49a3c7467f651f405d41921130565dd036fbf4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/841?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

