### PR TITLE
fix(agents): the native sweep answers the page it was asked for, and can be resumed (#843)

### DIFF
--- a/backend/internal/compose/integration/nativesweep_integration_test.go
+++ b/backend/internal/compose/integration/nativesweep_integration_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/gradionhq/margince/backend/internal/compose"
+	"github.com/gradionhq/margince/backend/internal/modules/people"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
@@ -33,26 +34,32 @@ import (
 // seedSweepable puts two records of each searchable type in the workspace,
 // each carrying the same word, so a sweep has more of every type than any
 // small page can hold.
-func seedSweepable(t *testing.T, e *SearchEnv) {
+//
+// Through the module writers rather than INSERTs: the rows a sweep pages over
+// have to be the rows production makes, and a fixture that writes its own
+// would prove the walk against a shape no writer produces.
+func seedSweepable(t *testing.T, e *Env) {
 	t.Helper()
 	for _, name := range []string{"Sweepable One", "Sweepable Two"} {
-		e.Seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by)
-		           VALUES ($1, $2, $3, 'manual', 'human:x')`, name)
-		e.Seed(t, `INSERT INTO organization (id, workspace_id, display_name, source, captured_by)
-		           VALUES ($1, $2, $3, 'manual', 'human:x')`, name)
-		e.Seed(t, `INSERT INTO lead (id, workspace_id, full_name, status, source, score, captured_by)
-		           VALUES ($1, $2, $3, 'working', 'inbound', 10, 'human:x')`, name)
+		e.SeedPerson(t, name, nil)
+		e.SeedOrg(t, name, nil)
+		lead := name
+		if _, _, err := e.People.CreateLead(e.Admin(), people.CreateLeadInput{
+			FullName: &lead, Status: "working", Source: "manual",
+		}); err != nil {
+			t.Fatalf("seeding lead %q: %v", name, err)
+		}
 	}
 }
 
 // sweepingProvider is the composite provider over this fixture's pool — the
 // one `search_records` reaches.
-func sweepingProvider(e *SearchEnv) *compose.Provider {
+func sweepingProvider(e *Env) *compose.Provider {
 	return compose.NewProvider(e.Pool)
 }
 
 func TestTheNativeSweepAnswersAtMostTheLimitItWasAskedFor(t *testing.T) {
-	e := SetupSearch(t)
+	e := Setup(t)
 	seedSweepable(t, e)
 	ctx := e.Admin()
 
@@ -73,7 +80,7 @@ func TestTheNativeSweepAnswersAtMostTheLimitItWasAskedFor(t *testing.T) {
 }
 
 func TestTheNativeSweepPagesThroughEveryTypeWithoutRepeating(t *testing.T) {
-	e := SetupSearch(t)
+	e := Setup(t)
 	seedSweepable(t, e)
 	ctx := e.Admin()
 	provider := sweepingProvider(e)
@@ -120,7 +127,7 @@ func TestTheNativeSweepPagesThroughEveryTypeWithoutRepeating(t *testing.T) {
 }
 
 func TestTheNativeSweepAnswersTheTypesASeatMayReadRatherThanRefusingAll(t *testing.T) {
-	e := SetupSearch(t)
+	e := Setup(t)
 	seedSweepable(t, e)
 
 	// A seat with organization read and nothing else. The sweep it asks for
@@ -169,7 +176,7 @@ func TestTheNativeSweepAnswersTheTypesASeatMayReadRatherThanRefusingAll(t *testi
 // otherwise resume "past" a position this provider cannot place and answer a
 // complete empty page to a caller holding a real token.
 func TestTheNativeSweepRefusesACursorFromAStreamItDoesNotSearch(t *testing.T) {
-	e := SetupSearch(t)
+	e := Setup(t)
 	seedSweepable(t, e)
 
 	foreign, err := storekit.EncodeSweepCursor(storekit.SweepCursor{

--- a/backend/internal/compose/integration/nativesweep_integration_test.go
+++ b/backend/internal/compose/integration/nativesweep_integration_test.go
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// The native seam's multi-type sweep — what `search_records` answers when a
+// caller names no record type.
+//
+// Three claims, each of which a caller reads off the published schema and acts
+// on: the page is at most the limit it asked for, a page that says there is
+// more hands back somewhere to resume, and a seat that may read four of the
+// five object classes is answered about those four rather than refused.
+//
+// The first is the one that costs. The schema declares `limit` with a maximum
+// of 50, and charging each type the full limit answers up to five times that —
+// on the surface where the records land in a paid context window.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/compose"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
+)
+
+// seedSweepable puts two records of each searchable type in the workspace,
+// each carrying the same word, so a sweep has more of every type than any
+// small page can hold.
+func seedSweepable(t *testing.T, e *SearchEnv) {
+	t.Helper()
+	for _, name := range []string{"Sweepable One", "Sweepable Two"} {
+		e.Seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by)
+		           VALUES ($1, $2, $3, 'manual', 'human:x')`, name)
+		e.Seed(t, `INSERT INTO organization (id, workspace_id, display_name, source, captured_by)
+		           VALUES ($1, $2, $3, 'manual', 'human:x')`, name)
+		e.Seed(t, `INSERT INTO lead (id, workspace_id, full_name, status, source, score, captured_by)
+		           VALUES ($1, $2, $3, 'working', 'inbound', 10, 'human:x')`, name)
+	}
+}
+
+// sweepingProvider is the composite provider over this fixture's pool — the
+// one `search_records` reaches.
+func sweepingProvider(e *SearchEnv) *compose.Provider {
+	return compose.NewProvider(e.Pool)
+}
+
+func TestTheNativeSweepAnswersAtMostTheLimitItWasAskedFor(t *testing.T) {
+	e := SetupSearch(t)
+	seedSweepable(t, e)
+	ctx := e.Admin()
+
+	// Three types hold two matching records each. A page of three that charged
+	// every type its own limit would answer nine.
+	res, err := sweepingProvider(e).Search(ctx, datasource.SearchQuery{Text: "Sweepable", Limit: 3})
+	if err != nil {
+		t.Fatalf("sweeping with no record type: %v", err)
+	}
+	if len(res.Records) != 3 {
+		t.Fatalf("a sweep with limit=3 answered %d records — the limit bounds the PAGE, not each type, "+
+			"and a caller reads the declared maximum as what it is about to be handed", len(res.Records))
+	}
+	if !res.HasMore || res.NextCursor == "" {
+		t.Fatalf("the capped page reported has_more=%v next_cursor=%q — a page that stopped short of the "+
+			"walk's end says so and hands back where to resume", res.HasMore, res.NextCursor)
+	}
+}
+
+func TestTheNativeSweepPagesThroughEveryTypeWithoutRepeating(t *testing.T) {
+	e := SetupSearch(t)
+	seedSweepable(t, e)
+	ctx := e.Admin()
+	provider := sweepingProvider(e)
+
+	seen := map[ids.UUID]datasource.EntityType{}
+	query := datasource.SearchQuery{Text: "Sweepable", Limit: 1}
+	for pages := 0; ; pages++ {
+		if pages > 12 {
+			t.Fatalf("the sweep did not terminate after %d pages, holding %d records", pages, len(seen))
+		}
+		res, err := provider.Search(ctx, query)
+		if err != nil {
+			t.Fatalf("page %d: %v", pages, err)
+		}
+		for _, rec := range res.Records {
+			if _, repeated := seen[rec.Ref.ID]; repeated {
+				t.Fatalf("the sweep served %s twice — a resumed walk must not re-serve what it handed over", rec.Ref.ID)
+			}
+			seen[rec.Ref.ID] = rec.Ref.Type
+		}
+		if res.HasMore != (res.NextCursor != "") {
+			t.Fatalf("has_more=%v with next_cursor=%q — a page claiming a remainder it cannot hand back leaves "+
+				"those records unreachable, and one claiming completeness it has not established stops the "+
+				"caller looking", res.HasMore, res.NextCursor)
+		}
+		if !res.HasMore {
+			break
+		}
+		query.Cursor = res.NextCursor
+	}
+
+	if len(seen) != 6 {
+		t.Fatalf("the sweep reached %d of the 6 seeded records: %v", len(seen), seen)
+	}
+	for _, want := range []datasource.EntityType{datasource.EntityPerson, datasource.EntityOrganization, datasource.EntityLead} {
+		found := false
+		for _, got := range seen {
+			found = found || got == want
+		}
+		if !found {
+			t.Errorf("the sweep never reached a %s — it walks every searchable type or it is not a sweep", want)
+		}
+	}
+}
+
+func TestTheNativeSweepAnswersTheTypesASeatMayReadRatherThanRefusingAll(t *testing.T) {
+	e := SetupSearch(t)
+	seedSweepable(t, e)
+
+	// A seat with organization read and nothing else. The sweep it asks for
+	// covers five types; four of them it may not see.
+	ctx := principal.WithWorkspaceID(context.Background(), e.WS)
+	orgOnly := principal.WithActor(ctx, principal.Principal{
+		Type: principal.PrincipalHuman, ID: "human:" + e.Rep1.String(), UserID: e.Rep1,
+		Permissions: principal.Permissions{
+			Objects:  map[string]principal.ObjectGrant{"organization": {Read: true}},
+			RowScope: principal.RowScopeAll,
+		},
+	})
+	provider := sweepingProvider(e)
+
+	res, err := provider.Search(orgOnly, datasource.SearchQuery{Text: "Sweepable", Limit: 50})
+	if err != nil {
+		t.Fatalf("sweeping as a seat that may read one type: %v — a sweep answers what the seat can see, "+
+			"and refusing the whole walk for one missing grant makes the advertised all-types search "+
+			"unusable for any seat that is not universal", err)
+	}
+	if len(res.Records) != 2 {
+		t.Fatalf("the sweep answered %d records, want the 2 organizations this seat may read", len(res.Records))
+	}
+	for _, rec := range res.Records {
+		if rec.Ref.Type != datasource.EntityOrganization {
+			t.Errorf("the sweep answered a %s to a seat granted only organizations", rec.Ref.Type)
+		}
+	}
+
+	// A caller who NAMES one type still hears the denial: they asked about
+	// that type, and an empty page would say it holds nothing.
+	if _, err := provider.Search(orgOnly, datasource.SearchQuery{
+		Text: "Sweepable", EntityTypes: []datasource.EntityType{datasource.EntityPerson},
+	}); err == nil {
+		t.Error("naming a single denied type answered a page — a caller who asked about people must not be " +
+			"told there are none")
+	}
+}

--- a/backend/internal/compose/integration/nativesweep_integration_test.go
+++ b/backend/internal/compose/integration/nativesweep_integration_test.go
@@ -19,9 +19,12 @@ package integration
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/gradionhq/margince/backend/internal/compose"
+	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
@@ -148,11 +151,38 @@ func TestTheNativeSweepAnswersTheTypesASeatMayReadRatherThanRefusingAll(t *testi
 	}
 
 	// A caller who NAMES one type still hears the denial: they asked about
-	// that type, and an empty page would say it holds nothing.
-	if _, err := provider.Search(orgOnly, datasource.SearchQuery{
+	// that type, and an empty page would say it holds nothing. The DENIAL
+	// specifically — any-error would also accept a pool failure or a missing
+	// fixture, which would prove nothing about the path under test.
+	_, err = provider.Search(orgOnly, datasource.SearchQuery{
 		Text: "Sweepable", EntityTypes: []datasource.EntityType{datasource.EntityPerson},
-	}); err == nil {
-		t.Error("naming a single denied type answered a page — a caller who asked about people must not be " +
-			"told there are none")
+	})
+	if !errors.Is(err, apperrors.ErrPermissionDenied) {
+		t.Errorf("naming a single denied type answered %v, want the denial — a caller who asked about people "+
+			"must not be told there are none", err)
+	}
+}
+
+// A cursor naming a stream this seam does not search is a fault, not a
+// finished walk. The mirror sweeps `activity` and this one does not, so a
+// token minted over there and presented here — after a cutover, say — would
+// otherwise resume "past" a position this provider cannot place and answer a
+// complete empty page to a caller holding a real token.
+func TestTheNativeSweepRefusesACursorFromAStreamItDoesNotSearch(t *testing.T) {
+	e := SetupSearch(t)
+	seedSweepable(t, e)
+
+	foreign, err := storekit.EncodeSweepCursor(storekit.SweepCursor{
+		Stream: string(datasource.EntityActivity), Inner: "whatever-the-mirror-minted",
+	})
+	if err != nil {
+		t.Fatalf("minting the foreign position: %v", err)
+	}
+	res, err := sweepingProvider(e).Search(e.Admin(), datasource.SearchQuery{Text: "Sweepable", Cursor: foreign})
+	var malformed *storekit.MalformedCursorError
+	if !errors.As(err, &malformed) {
+		t.Fatalf("a cursor from a stream this seam does not search answered %d records / %v, want the "+
+			"malformed-cursor fault — a complete empty page tells a caller mid-walk that there is nothing "+
+			"left, which is the answer they cannot check", len(res.Records), err)
 	}
 }

--- a/backend/internal/compose/overlaysearch.go
+++ b/backend/internal/compose/overlaysearch.go
@@ -45,11 +45,11 @@ var overlayMirroredTypes = func() map[string]bool {
 }()
 
 // overlaySearchDefaultLimit sizes an overlay search page when the request
-// names no limit — the shared Limit parameter's own default (crm.yaml's
-// components.parameters.Limit: default 50), which /search refs like every
-// other paged op. Overlay pages the same way native does or the two modes
-// answer different pages for one query.
-const overlaySearchDefaultLimit = 50
+// names no limit. It is defaultSearchPageSize — the shared Limit parameter's
+// declared default — rather than a second copy of the number: overlay pages
+// the same way native does, or the two modes answer different pages for one
+// query.
+const overlaySearchDefaultLimit = defaultSearchPageSize
 
 // overlaySearchMaxLimit is that same shared parameter's ceiling (maximum
 // 200). A bound integer that slips past request validation (a negative or

--- a/backend/internal/compose/provider.go
+++ b/backend/internal/compose/provider.go
@@ -54,9 +54,17 @@ var _ datasource.SystemOfRecordProvider = (*Provider)(nil)
 // searchable is the entity set Search sweeps when the query names none.
 // Activities are deliberately absent: the timeline is reached through
 // read_record/list on a named entity, not blind full-text sweep.
-// defaultSearchPageSize is the page a caller that named no limit gets — the
-// size this seam has always answered when asked for none.
-const defaultSearchPageSize = 20
+// defaultSearchPageSize is the page a caller who named no limit gets: the
+// shared Limit parameter's own declared default (crm.yaml
+// components.parameters.Limit, `default: 50`), which /search refs like every
+// other paged operation.
+//
+// It is ONE number for both seams. This one answered 20 while the overlay
+// route answered the declared 50, so a query with no limit came back a
+// different size depending on which system of record served it — the same
+// divergence this file's sweep exists to close, in the parameter rather than
+// the page.
+const defaultSearchPageSize = 50
 
 var searchable = []datasource.EntityType{datasource.EntityPerson, datasource.EntityOrganization, datasource.EntityDeal, datasource.EntityLead, datasource.EntityProject}
 
@@ -114,7 +122,7 @@ func (p *Provider) Search(ctx context.Context, q datasource.SearchQuery) (dataso
 	if err != nil {
 		return datasource.SearchResult{}, err
 	}
-	position, err := storekit.DecodeSweepCursor(q.Cursor)
+	position, err := resumeStream(q.Cursor)
 	if err != nil {
 		return datasource.SearchResult{}, err
 	}
@@ -216,12 +224,35 @@ func sweepOrder(named []datasource.EntityType) ([]datasource.EntityType, error) 
 	return walk, nil
 }
 
+// resumeStream reads the position a cursor names, refusing one this seam could
+// not have minted: a token whose stream is not a type this provider searches
+// at all — an overlay mirror's `activity` position presented here after a
+// cutover, say. Resuming "past" a stream this provider does not know would
+// answer a complete empty page to a caller holding a real token, which is the
+// confident-wrong-answer shape a resumable walk exists to remove.
+//
+// Whether THIS request still walks a stream it does know is a different
+// question with a different answer — see resumeIndex.
+func resumeStream(cursor string) (storekit.SweepCursor, error) {
+	position, err := storekit.DecodeSweepCursor(cursor)
+	if err != nil {
+		return storekit.SweepCursor{}, err
+	}
+	if position.Stream == "" {
+		return position, nil
+	}
+	if !slices.Contains(searchable, datasource.EntityType(position.Stream)) {
+		return storekit.SweepCursor{}, &storekit.MalformedCursorError{}
+	}
+	return position, nil
+}
+
 // resumeIndex is where in this walk the cursor's stream resumes.
 //
 // The token names a stream, not an index into one request's slice, so it still
 // means the same place when the request presenting it is not the one that
 // minted it — a narrowed type list, or a grant lost between pages. A stream
-// this walk no longer covers resumes at the next type PAST it: the records
+// this request no longer walks resumes at the next type PAST it: the records
 // between belong to a stream this request is not reading, and the contract
 // already says changing a filter mid-walk changes what the remaining pages
 // see.
@@ -230,9 +261,6 @@ func resumeIndex(walk []datasource.EntityType, stream string) int {
 		return 0
 	}
 	at := slices.Index(searchable, datasource.EntityType(stream))
-	if at < 0 {
-		return len(walk)
-	}
 	for i, et := range walk {
 		if slices.Index(searchable, et) >= at {
 			return i

--- a/backend/internal/compose/provider.go
+++ b/backend/internal/compose/provider.go
@@ -11,6 +11,7 @@ package compose
 import (
 	"context"
 	"errors"
+	"slices"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -20,6 +21,8 @@ import (
 	"github.com/gradionhq/margince/backend/internal/modules/deals"
 	"github.com/gradionhq/margince/backend/internal/modules/identity"
 	"github.com/gradionhq/margince/backend/internal/modules/people"
+	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
 )
@@ -51,6 +54,10 @@ var _ datasource.SystemOfRecordProvider = (*Provider)(nil)
 // searchable is the entity set Search sweeps when the query names none.
 // Activities are deliberately absent: the timeline is reached through
 // read_record/list on a named entity, not blind full-text sweep.
+// defaultSearchPageSize is the page a caller that named no limit gets — the
+// size this seam has always answered when asked for none.
+const defaultSearchPageSize = 20
+
 var searchable = []datasource.EntityType{datasource.EntityPerson, datasource.EntityOrganization, datasource.EntityDeal, datasource.EntityLead, datasource.EntityProject}
 
 func (p *Provider) Read(ctx context.Context, ref datasource.EntityRef) (datasource.Record, error) {
@@ -86,54 +93,163 @@ func (p *Provider) ListFilters(t datasource.EntityType) []string {
 	}
 }
 
+// Search answers one page of records: one entity type's, or a SWEEP across
+// several — which is what the tool surface advertises when a caller names no
+// record type, and what this provider must therefore be able to page.
+//
+// The page is bounded ONCE, across the whole walk. Charging each type the full
+// limit and concatenating would answer five times the ceiling the caller
+// named, on the surface where that context is paid for and displaces the run's
+// own observations.
+//
+// It is walked type by type rather than ranked across them, because the types
+// have no common score to interleave by. What makes that pageable is the
+// composite cursor: the position is the type plus that type's own keyset, so a
+// caller resumes where the page stopped. HasMore is true if and only if there
+// is such a position — a page that reports a remainder it cannot hand back
+// leaves those records unreachable, and one that reports completeness it has
+// not established stops the caller looking.
 func (p *Provider) Search(ctx context.Context, q datasource.SearchQuery) (datasource.SearchResult, error) {
-	types := q.EntityTypes
-	if len(types) == 0 {
-		types = searchable
+	types, err := sweepOrder(q.EntityTypes)
+	if err != nil {
+		return datasource.SearchResult{}, err
 	}
-	limit := q.Limit
-	if limit <= 0 {
-		limit = 20
+	position, err := storekit.DecodeSweepCursor(q.Cursor)
+	if err != nil {
+		return datasource.SearchResult{}, err
 	}
 	text := &q.Text
 	if q.Text == "" {
 		text = nil
 	}
-	// Keyset cursors are per-entity streams; a cross-type cursor would
-	// have to interleave four of them. Honest bound: cursor pagination
-	// needs exactly one entity type, multi-type queries get page one.
-	var cursor *string
-	if q.Cursor != "" {
-		if len(types) != 1 {
-			return datasource.SearchResult{}, errors.New("compose: search cursor requires exactly one entity_type")
-		}
-		cursor = &q.Cursor
+	limit := q.Limit
+	if limit <= 0 {
+		limit = defaultSearchPageSize
 	}
 
 	out := datasource.SearchResult{Records: []datasource.Record{}}
-	for _, t := range types {
-		var (
-			records []datasource.Record
-			next    string
-			more    bool
-			err     error
-		)
-		switch t {
-		case datasource.EntityPerson, datasource.EntityOrganization, datasource.EntityLead:
-			records, next, more, err = p.people.SearchEntity(ctx, t, text, limit, cursor, q.Filters)
-		case datasource.EntityDeal, datasource.EntityProject:
-			records, next, more, err = p.deals.SearchEntity(ctx, t, text, limit, cursor, q.Filters)
-		default:
-			return datasource.SearchResult{}, &datasource.UnsupportedEntityError{Type: string(t)}
+	inner := position.Inner
+	for i := resumeIndex(types, position.Stream); i < len(types); i++ {
+		et := types[i]
+		if string(et) != position.Stream {
+			// The stream the cursor was minted in is not this one, so this
+			// type starts at ITS beginning rather than inheriting a keyset
+			// from another.
+			inner = ""
 		}
+		records, next, err := p.searchOneType(ctx, et, text, limit-len(out.Records), inner, q.Filters, len(types) > 1)
 		if err != nil {
 			return datasource.SearchResult{}, err
 		}
 		out.Records = append(out.Records, records...)
-		if len(types) == 1 {
-			out.NextCursor, out.HasMore = next, more
+		if next != "" {
+			return sweepResumesAt(out, et, next)
+		}
+		inner = ""
+		if len(out.Records) >= limit && i+1 < len(types) {
+			return sweepResumesAt(out, types[i+1], "")
 		}
 	}
+	return out, nil
+}
+
+// searchOneType pages one entity type through the module that owns it.
+//
+// In a SWEEP a denied type is omitted; a caller who NAMED one type hears the
+// denial. Search shows a seat the object classes it can read and says nothing
+// about the rest — the posture ListObjects and the native /v1/search branches
+// already take — and refusing the whole walk for one missing grant would make
+// the advertised all-types sweep unusable for any seat that is not universal.
+func (p *Provider) searchOneType(ctx context.Context, t datasource.EntityType, text *string, limit int,
+	cursor string, filters map[string]string, sweeping bool,
+) ([]datasource.Record, string, error) {
+	var inner *string
+	if cursor != "" {
+		inner = &cursor
+	}
+	var (
+		records []datasource.Record
+		next    string
+		err     error
+	)
+	switch t {
+	case datasource.EntityPerson, datasource.EntityOrganization, datasource.EntityLead:
+		records, next, _, err = p.people.SearchEntity(ctx, t, text, limit, inner, filters)
+	case datasource.EntityDeal, datasource.EntityProject:
+		records, next, _, err = p.deals.SearchEntity(ctx, t, text, limit, inner, filters)
+	default:
+		return nil, "", &datasource.UnsupportedEntityError{Type: string(t)}
+	}
+	if err != nil {
+		if sweeping && errors.Is(err, apperrors.ErrPermissionDenied) {
+			return nil, "", nil
+		}
+		return nil, "", err
+	}
+	return records, next, nil
+}
+
+// sweepOrder resolves the types one query walks: the ones it named, or every
+// searchable type when it named none.
+//
+// Always in one fixed order and always without repeats, whatever order the
+// caller listed them in and however many times — a stream walked twice serves
+// its records twice, and a cursor names the type rather than one of its
+// appearances, so a resumed walk would re-serve them forever.
+func sweepOrder(named []datasource.EntityType) ([]datasource.EntityType, error) {
+	if len(named) == 0 {
+		return searchable, nil
+	}
+	asked := make(map[datasource.EntityType]bool, len(named))
+	for _, et := range named {
+		if !slices.Contains(searchable, et) {
+			return nil, &datasource.UnsupportedEntityError{Type: string(et)}
+		}
+		asked[et] = true
+	}
+	walk := make([]datasource.EntityType, 0, len(asked))
+	for _, et := range searchable {
+		if asked[et] {
+			walk = append(walk, et)
+		}
+	}
+	return walk, nil
+}
+
+// resumeIndex is where in this walk the cursor's stream resumes.
+//
+// The token names a stream, not an index into one request's slice, so it still
+// means the same place when the request presenting it is not the one that
+// minted it — a narrowed type list, or a grant lost between pages. A stream
+// this walk no longer covers resumes at the next type PAST it: the records
+// between belong to a stream this request is not reading, and the contract
+// already says changing a filter mid-walk changes what the remaining pages
+// see.
+func resumeIndex(walk []datasource.EntityType, stream string) int {
+	if stream == "" {
+		return 0
+	}
+	at := slices.Index(searchable, datasource.EntityType(stream))
+	if at < 0 {
+		return len(walk)
+	}
+	for i, et := range walk {
+		if slices.Index(searchable, et) >= at {
+			return i
+		}
+	}
+	return len(walk)
+}
+
+// sweepResumesAt finishes a page that stopped short of the walk's end: the
+// position to continue from, and the flag that says one exists. They are set
+// together and only together.
+func sweepResumesAt(out datasource.SearchResult, et datasource.EntityType, inner string) (datasource.SearchResult, error) {
+	cursor, err := storekit.EncodeSweepCursor(storekit.SweepCursor{Stream: string(et), Inner: inner})
+	if err != nil {
+		return datasource.SearchResult{}, err
+	}
+	out.NextCursor, out.HasMore = cursor, true
 	return out, nil
 }
 

--- a/backend/internal/modules/overlay/provider_test.go
+++ b/backend/internal/modules/overlay/provider_test.go
@@ -269,11 +269,11 @@ func TestProviderSearchRefusesATypeTheMirrorCannotHold(t *testing.T) {
 // token has to mean the same place when the request presenting it is not the
 // one that minted it.
 func TestASweepCursorNamesAPositionInTheMirrorRatherThanInOneRequest(t *testing.T) {
-	minted, err := encodeSweepCursor(datasource.EntityOrganization, "mirror-42")
+	minted, err := storekit.EncodeSweepCursor(storekit.SweepCursor{Stream: string(datasource.EntityOrganization), Inner: "mirror-42"})
 	if err != nil {
 		t.Fatalf("encoding a sweep position: %v", err)
 	}
-	resumeAt, inner, err := decodeSweepCursor(minted)
+	resumeAt, inner, err := resumeStream(minted)
 	if err != nil {
 		t.Fatalf("decoding a cursor the sweep minted: %v", err)
 	}
@@ -282,7 +282,7 @@ func TestASweepCursorNamesAPositionInTheMirrorRatherThanInOneRequest(t *testing.
 	}
 
 	// An empty cursor is the start of the walk, not a malformed one.
-	if resumeAt, inner, err = decodeSweepCursor(""); err != nil || resumeAt != "" || inner != "" {
+	if resumeAt, inner, err = resumeStream(""); err != nil || resumeAt != "" || inner != "" {
 		t.Errorf("the empty cursor decoded to (%q, %q, %v), want the beginning", resumeAt, inner, err)
 	}
 
@@ -293,7 +293,7 @@ func TestASweepCursorNamesAPositionInTheMirrorRatherThanInOneRequest(t *testing.
 		{"naming an object class the mirror cannot hold", mustEncodeSweepCursor(t, datasource.EntityProject)},
 	} {
 		t.Run(probe.name, func(t *testing.T) {
-			_, _, err := decodeSweepCursor(probe.cursor)
+			_, _, err := resumeStream(probe.cursor)
 			var malformed *storekit.MalformedCursorError
 			if !errors.As(err, &malformed) {
 				t.Errorf("decoding a cursor %s = %v, want the malformed-cursor answer", probe.name, err)
@@ -306,7 +306,7 @@ func TestASweepCursorNamesAPositionInTheMirrorRatherThanInOneRequest(t *testing.
 // than swallowing an encoding error into an empty cursor.
 func mustEncodeSweepCursor(t *testing.T, et datasource.EntityType) string {
 	t.Helper()
-	cursor, err := encodeSweepCursor(et, "mirror-7")
+	cursor, err := storekit.EncodeSweepCursor(storekit.SweepCursor{Stream: string(et), Inner: "mirror-7"})
 	if err != nil {
 		t.Fatalf("encoding a sweep position for %s: %v", et, err)
 	}

--- a/backend/internal/modules/overlay/search.go
+++ b/backend/internal/modules/overlay/search.go
@@ -8,10 +8,7 @@ package overlay
 
 import (
 	"context"
-	"encoding/base64"
-	"encoding/json"
 	"errors"
-	"fmt"
 	"slices"
 	"strings"
 
@@ -92,7 +89,7 @@ func (p *Provider) Search(ctx context.Context, q datasource.SearchQuery) (dataso
 // forward until a match turns up — is a request whose cost is decided by how
 // rare the caller's word is.
 func (p *Provider) sweep(ctx context.Context, types []datasource.EntityType, q datasource.SearchQuery) (datasource.SearchResult, error) {
-	resumeAt, inner, err := decodeSweepCursor(q.Cursor)
+	resumeAt, inner, err := resumeStream(q.Cursor)
 	if err != nil {
 		return datasource.SearchResult{}, err
 	}
@@ -234,34 +231,11 @@ func resumePosition(walk []datasource.EntityType, resumeAt datasource.EntityType
 	return len(walk)
 }
 
-// sweepCursor is where a sweep stopped: the entity type being walked and that
-// type's own mirror cursor within it. Both halves are needed — the type alone
-// would restart it, and the mirror cursor alone would not say which object
-// class it indexes into.
-type sweepCursor struct {
-	Type  string `json:"t"`
-	Inner string `json:"c"`
-}
-
-// encodeSweepCursor renders a resume position opaquely: a caller must never
-// build or edit one, and the shape inside is this package's business.
-//
-// It answers an error rather than an empty cursor, because the caller pairs
-// the result with HasMore: a silent "" there would report more with nowhere
-// to go, which is the answer this whole file exists to stop giving.
-func encodeSweepCursor(et datasource.EntityType, inner string) (string, error) {
-	raw, err := json.Marshal(sweepCursor{Type: string(et), Inner: inner})
-	if err != nil {
-		return "", fmt.Errorf("overlay: encoding the sweep position for %s: %w", et, err)
-	}
-	return base64.RawURLEncoding.EncodeToString(raw), nil
-}
-
 // withResumePosition finishes a page that stopped short of the walk's end:
 // the position to continue from, and the flag that says one exists. They are
 // set together and only together, which is the whole of the invariant.
 func withResumePosition(out datasource.SearchResult, et datasource.EntityType, inner string) (datasource.SearchResult, error) {
-	cursor, err := encodeSweepCursor(et, inner)
+	cursor, err := storekit.EncodeSweepCursor(storekit.SweepCursor{Stream: string(et), Inner: inner})
 	if err != nil {
 		return datasource.SearchResult{}, err
 	}
@@ -269,28 +243,19 @@ func withResumePosition(out datasource.SearchResult, et datasource.EntityType, i
 	return out, nil
 }
 
-// decodeSweepCursor resolves a cursor to the mirrored type it resumes at and
-// the position within that type's stream. An empty cursor starts at the
-// beginning of the walk.
-//
-// Malformed is reserved for a token this package could not have minted:
-// something that is not base64, not the position shape, or names an object
-// class the mirror does not hold. Whether the CURRENT request still walks that
-// type is not a question about the token — see resumePosition, which answers
-// it without calling a caller's valid cursor an input error.
-func decodeSweepCursor(cursor string) (resumeAt datasource.EntityType, inner string, err error) {
-	if cursor == "" {
+// resumeStream reads the position a cursor names, refusing one this package
+// could not have minted: a token whose stream is an object class the mirror
+// does not hold. Whether THIS request still walks that stream is
+// resumePosition's question, not a fault in the token.
+func resumeStream(cursor string) (datasource.EntityType, string, error) {
+	position, err := storekit.DecodeSweepCursor(cursor)
+	if err != nil {
+		return "", "", err
+	}
+	if position.Stream == "" {
 		return "", "", nil
 	}
-	raw, err := base64.RawURLEncoding.DecodeString(cursor)
-	if err != nil {
-		return "", "", &storekit.MalformedCursorError{}
-	}
-	var position sweepCursor
-	if err := json.Unmarshal(raw, &position); err != nil {
-		return "", "", &storekit.MalformedCursorError{}
-	}
-	at := datasource.EntityType(position.Type)
+	at := datasource.EntityType(position.Stream)
 	if !slices.Contains(knownEntityTypes, at) {
 		return "", "", &storekit.MalformedCursorError{}
 	}

--- a/backend/internal/platform/database/storekit/pagination.go
+++ b/backend/internal/platform/database/storekit/pagination.go
@@ -42,6 +42,66 @@ func mintCursorToken(c Cursor) string {
 	return base64.RawURLEncoding.EncodeToString(raw)
 }
 
+// SweepCursor is a position in a walk across SEVERAL streams: which stream the
+// page stopped in, and where inside that stream it stopped.
+//
+// A walk with no ordering to interleave its streams by — a search across
+// record types, whose rows carry no common rank — can still be resumed if the
+// token says both. The stream alone would restart it; the inner position alone
+// would not say what it indexes into.
+//
+// Both providers that sweep mint this ONE token, rather than a shape each:
+// what a caller pages with must not depend on which system of record answered
+// them, and two codecs for one wire value drift the first time either changes.
+// The inner half stays opaque here — a keyset token on one side, an incumbent
+// mirror's own cursor on the other — because this type carries a position, not
+// a meaning.
+type SweepCursor struct {
+	Stream string `json:"s"`
+	Inner  string `json:"c"`
+}
+
+// EncodeSweepCursor renders a resume position opaquely: a caller never builds
+// or edits one.
+//
+// It answers an error rather than an empty token because the caller pairs the
+// result with "there is more" — a silent empty cursor there would report a
+// remainder with no way to reach it, which is the defect a resumable sweep
+// exists to remove.
+func EncodeSweepCursor(position SweepCursor) (string, error) {
+	raw, err := json.Marshal(position)
+	if err != nil {
+		return "", fmt.Errorf("store: encoding the sweep position in %s: %w", position.Stream, err)
+	}
+	return base64.RawURLEncoding.EncodeToString(raw), nil
+}
+
+// DecodeSweepCursor reads a resume position back. An empty token is the start
+// of the walk, not a fault.
+//
+// It answers MalformedCursorError for anything this package could not have
+// minted. Whether the CALLER still walks the stream named is a different
+// question with a different answer — a narrowed request, or a grant lost
+// between pages, is not the caller mistyping a token — so it is left to the
+// provider, which knows its own vocabulary.
+func DecodeSweepCursor(token string) (SweepCursor, error) {
+	if token == "" {
+		return SweepCursor{}, nil
+	}
+	raw, err := base64.RawURLEncoding.DecodeString(token)
+	if err != nil {
+		return SweepCursor{}, &MalformedCursorError{}
+	}
+	var position SweepCursor
+	if err := json.Unmarshal(raw, &position); err != nil {
+		return SweepCursor{}, &MalformedCursorError{}
+	}
+	if position.Stream == "" {
+		return SweepCursor{}, &MalformedCursorError{}
+	}
+	return position, nil
+}
+
 // MalformedCursorError is a client fault: the opaque keyset token is
 // client-supplied input, so failing to decode it — or a decoded sort key
 // that does not parse as the sort column's kind — maps to a 4xx at the


### PR DESCRIPTION
Closes #843.

Found by reviewing the served tool surface in `docs/reference/mcp-info.json` against the handlers behind it — the declared-*input* class is clean there; the declared **bounds** were not.

## What was wrong

`search_records` declares `"limit": {"minimum":1,"maximum":50}` and `record_type` as "omit to sweep all five". On a native workspace the seam kept neither claim — and since #832 the mirror keeps both, so **one tool answered two different ways depending on the workspace's system of record**, which is the divergence AC-OV-2 exists to forbid.

| defect | what a caller got |
|---|---|
| the page was **per type**, not per page | `limit=50` with no `record_type` returned up to **250** records — into a paid context window, displacing the run's own observations |
| **`has_more` always false** on a sweep | the assignment sat behind a single-type guard, so a capped walk reported completeness it had not established |
| a cursor on a sweep answered a **bare error** | unmapped by any sentinel, so a 500 rather than something a caller can branch on |
| **one missing grant refused the whole walk** | a seat that may read four of the five object classes was denied the sweep entirely |

The last one is worth its own line: the tests below fail on `main` with `project.read: permission denied` **before** they can even measure the page size. The five seeded system roles all carry `project` read so the standard seats are unaffected, but any narrower set — a custom role, a passport capped below its granting seat — turns the advertised sweep into a denial.

## What it does now

One page bounded across the whole walk; types walked in a fixed order without repeats; a composite cursor naming where it stopped (the type plus that type's own keyset); `has_more` true **iff** that cursor exists; a sweep omits what the seat cannot read while a **named** single type still answers the denial — the split the overlay side already draws, and the posture `ListObjects` and `search/store.go`'s `branchScope` already take.

**The two providers now mint one cursor.** `storekit.SweepCursor` replaces the overlay's private codec. What a caller pages with must not depend on which system of record answered them, and two codecs for one wire value drift the first time either changes — the same argument that made compose read the mirrored-type list from the module rather than keeping a copy.

## On the red `main` this was cut from

`overlayread.go` had reached **503 lines** against a 500 cap. **#844 fixed it first** — the same split, into `overlaysearch.go` — so this branch was rebased onto it and carries none of that; the file is byte-identical to `main`'s.

Worth knowing anyway, because neither PR could have seen it coming: #832 and #826 each added lines to that file, each passed the whole-tree size gate against a `main` that did not yet carry the other, and the sum crossed the cap only once both had merged. **A whole-tree size gate is not merge-order safe** — two green PRs can produce a red `main`, and nothing in either one's CI can see it.

## Verification

- `make check-backend` green (exit 0); `craft static --strict` over every changed file: `PASS — 0 blocker, 0 major, 0 minor`.
- Three new integration tests against real Postgres, each **verified to fail on `main`**: the page is at most the limit asked for; the walk pages every type without repeating and terminates with `has_more` matching `next_cursor` on every page; a seat granted one object class is answered about that class rather than refused.
- The whole `compose/integration/overlay` package (39 tests) and the search suites stay green — the overlay sweep now rides the shared codec.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes native multi-type search so one page respects the requested limit, resumes across types with a shared `storekit.SweepCursor`, and both native and overlay use the same 50-item default. Cursors from streams the native seam doesn’t search now return a client error instead of a silent empty page.

- **Bug Fixes**
  - Page limit applies to the whole sweep; no duplicates; `has_more` only when `next_cursor` exists.
  - Resumable cross-type pagination via `storekit.SweepCursor`; foreign-stream cursors return a client error.
  - Sweep skips types without read grants; a named single denied type still returns permission denied.
  - New native integration tests cover page size, pagination, permission behavior, and foreign-cursor handling.

- **Refactors**
  - Unified cursor encoding/decoding under `storekit.SweepCursor`; removed the overlay’s private codec.
  - One shared page-size default (`defaultSearchPageSize` = 50) used by native and overlay.
  - `compose.Provider` walks types in a fixed order without repeats.

<sup>Written for commit 4bf6f2d4a48f710314f788f3cd655efc61b15460. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/845?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added multi-entity search across supported record types, including people, organizations, and leads.
  - Search results now support consistent page limits and resumable pagination across entity types.
  - Searches automatically exclude record types the caller cannot access.
  - Overlay searches now provide validated, paginated results across mirrored record types.

- **Bug Fixes**
  - Improved handling of unauthorized, unavailable, and invalid search requests.
  - Enhanced pagination reliability so records appear once across multi-type searches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
