### PR TITLE
docs(status): G1's commercial reads, and the three passes it took to prove they render

### DIFF
--- a/STATUS-ARCHIVE.md
+++ b/STATUS-ARCHIVE.md
@@ -21,6 +21,90 @@
 > [CHANGELOG.md](CHANGELOG.md) and [README.md → *What works
 > today*](README.md#what-works-today).
 
+## G1 — the commercial reads, and three passes at proving they render (2026-08-10)
+
+**Merged as `086b08ad` (#825).** Two tools — `review_commitments` and
+`prepare_handoff` — plus three MCP App views. `render_pipeline_review` is a
+VIEW on the existing `whats_slipping_this_week` and registers nothing; every
+`render_*` name on this surface is a document hung off a tool that already
+answers, and reading PLAN.md's four names as four tools would have cost a
+listing slot and an admission surface to display an answer the caller already
+holds. It hangs off that tool ALONE and not also off `run_report`, which the
+product concept names beside it: a view reads one payload shape, and run_report
+answers a different `{columns, rows}` per report and per plan.
+
+`explain_forecast_change` was deliberately not built — `deal_stage_history` is
+written in two places, both stage transitions, so an amount revised in place or
+a close date slipped leaves no trace and a forecast rebuilt from it reconciles
+over stage movement while presenting itself as whole. That is **#823**, still
+open.
+
+**One derivation, two callers.** Open promises are read once, by a new gated
+store path in `modules/activities` whose predicate and order are exactly what
+core 0008's `idx_activity_tasks` was built for and nothing had asked. The clock
+lives on the compose side of the seam, so both tools are pure functions of (due
+date, an instant) and every state is reproducible in a test with no clock in it.
+There is no "due today": a calendar day needs a timezone this build does not
+store.
+
+### What the reviews found
+
+Fable and Codex independently found the same worst defect: `prepare_handoff`
+read at most fifty deals and then judged the whole project from them, so a
+project with fifty-one whose only won one sorted off the page was told "no won
+deal is rolled up to this project" — a gap firing about a field that is present.
+The two gaps that are claims of ABSENCE are withheld when a read was bounded
+now; the counts of what WAS read still stand.
+
+Fable also found that deleting the row-scope clause from the "about" projection
+left every test in the branch green while a colleague's deal name appeared in an
+answer. Both that guard and the narrowing gate Codex prompted now have
+real-Postgres tests, each verified by breaking the guard and watching it go red.
+
+### What three UAT passes found, and the pattern under it
+
+**Pass 1** — protocol, two independent clients: `resources/list` served the
+`ui://` documents to clients that cannot render them (#830, fixed here), and
+`prepare_handoff` answered "who to call at the client" as a UUID.
+
+**Pass 2** — the real Inspector: **no view on this surface had ever rendered in
+a spec-compliant host.** `ui/initialize` sent `clientInfo` and `capabilities` —
+the CORE protocol's names — where the App extension wants `appInfo` and
+`appCapabilities`. A host refuses the wrong pair, after which the document
+loads, sandboxes and sits blank forever, because a refused initialise produces
+no error anywhere the document can show. Two views had shipped that way.
+
+**Pass 3** — against that fix: the theme-following written DURING pass 2's fix
+was wrong twice. It read `params.hostContext` where the notification carries the
+context as `params`, and it treated "no theme stated" in a partial update as
+"delegated to the platform" — so the `containerDimensions`-only notification the
+Inspector sends after every open clobbered the theme the handshake had just
+resolved, and dark became unreachable. It was WORSE than not having been added.
+
+**The pattern is one thing, three times: the test asserted the assumption rather
+than the protocol.** The handshake test checked the method, the target and the
+version and never the member NAMES. The theme test used the shape I had guessed
+rather than the shape the Inspector sends. Both passed against the defect they
+were written to prevent. D3b's fallback harness accepted whatever the bridge
+sent, which is how the handshake bug survived two shipped views.
+
+Worth carrying: when a wire contract is involved, assert the member names, and
+get the shape from a capture rather than from the code you just wrote.
+
+### Smaller things worth keeping
+
+- Three sweeps stopped being hand-written view lists and derive from the catalog
+  (`apps.DeclaredViews`). Each would have gone on passing over a deployment
+  serving two views of five.
+- The Inspector's per-server **Protocol Era defaults to Legacy**, and this server
+  serves the App extension only in the modern per-request era. A default-
+  configured connection gets no Apps tab and nothing says why.
+- `@modelcontextprotocol/inspector` 2.0.0 and 2.1.0 both ship a tarball missing
+  `clients/web/static/sandbox_proxy.html`. Upstream defect; patch the npx cache.
+- The video CAN be attached programmatically after all — the file input on the
+  comment box accepts an upload and GitHub mints the `user-attachments` URL. The
+  roadmap's note that this is drag-and-drop only is stale.
+
 ## 2026-08-10 — the MCP App views move to `frontend/` (#742, PR #793)
 
 The two `ui://` views left `go:embed` and became a frontend build target. The api

--- a/STATUS.md
+++ b/STATUS.md
@@ -18,6 +18,7 @@
 Every section in this file, in order. Read this list first and jump; nobody
 needs the whole file to start a session.
 
+- [Open — the agent_loop records are stale, and one paid pass clears four things (2026-08-11)](#open--the-agent_loop-records-are-stale-and-one-paid-pass-clears-four-things-2026-08-11)
 - [Open — the finance offline ledger drifts out of its timeliness window (#798, 2026-08-10)](#open--the-finance-offline-ledger-drifts-out-of-its-timeliness-window-798-2026-08-10)
 - [Open — two follow-ups left by the activity anchor (#686, 2026-08-09)](#open--two-follow-ups-left-by-the-activity-anchor-686-2026-08-09)
 - [Company record page V2 — the contract changed so the mockups are buildable, 2026-08-10](#company-record-page-v2--the-contract-changed-so-the-mockups-are-buildable-2026-08-10)
@@ -49,6 +50,30 @@ needs the whole file to start a session.
 - [Upstream spec raises owed from 2026-07-31](#upstream-spec-raises-owed-from-2026-07-31)
 - [Upstream spec reconciliation](#upstream-spec-reconciliation)
 - [Decisions owed](#decisions-owed)
+
+## Open — the agent_loop records are stale, and one paid pass clears four things (2026-08-11)
+
+**Owed, not blocking.** `make check-backend` is green with stale records and
+always has been; this is debt with a price tag, and the price is one paid lane
+run.
+
+Nineteen of the 21 `agent_loop` corpus scenarios set `tools: "catalog"`, which
+resolves to the REAL registered surface — deliberately, so a tool added or
+renamed reaches those scenarios the same commit it reaches the surface.
+`PromptVersion` digests the scenarios AND the first request each site builds,
+and the agent-loop request contains the rendered tool listing. So **G1's two new
+tools moved the stamp** (#825, `086b08ad`), on top of the three records already
+stale from #776.
+
+**One pass clears #738, #739, #776 and G1 together.** Running it earlier would
+have paid for a stamp G1 immediately invalidated, which is why it was held.
+
+Nothing else is owed: no migration, no contract change, and the tool COPY of
+every previously-certified tool is untouched — the only description edits were
+to the two new tools' own entries and to `prepare_handoff`'s, which is new.
+
+**Ask before spending it.** Confirm with `make -C backend e2e-ai-report` that the
+records are stale in the way described rather than in some other way.
 
 ## Open — the finance offline ledger drifts out of its timeliness window (#798, 2026-08-10)
 


### PR DESCRIPTION
The session record for #825, split out of it because the PR was already large and this is prose.

**STATUS-ARCHIVE.md** gets the G1 narrative. It is mostly about a pattern rather than a feature: three UAT passes each found a defect the previous one had not, and all three were the same mistake — **the test asserted the assumption rather than the protocol.**

- The handshake test checked the method, the target and the protocol version, and never the member *names*. So `ui/initialize` sent the core protocol's `clientInfo`/`capabilities` where the App extension wants `appInfo`/`appCapabilities`, a host refused it, and **no view on this surface had ever rendered in a spec-compliant host** — through two previously shipped views.
- The theme test used the wire shape I had guessed rather than the one the Inspector actually sends, so a fix written *during* the UAT made dark unreachable and was worse than not having been added.

Worth carrying: when a wire contract is involved, assert the member names, and take the shape from a capture rather than from the code you just wrote.

**STATUS.md** gets one open item — the paid `agent_loop` pass. G1's two new tools moved the prompt stamp (19 of 21 corpus scenarios resolve `tools: "catalog"` against the real registered surface, and `PromptVersion` digests the rendered listing), so the records are stale on top of the three already stale from #776. One pass clears #738, #739, #776 and G1 together, which is why it was held rather than run earlier. **Not blocking** — `make check-backend` is green with stale records — and it needs a human's go-ahead before it is spent.

Also recorded because the roadmap says the opposite: a video **can** be attached to a PR programmatically. The comment box's file input accepts an upload and GitHub mints the `user-attachments` URL; drag-and-drop is not the only path.

Docs only — no code, no gates affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the G1 session narrative to `STATUS-ARCHIVE.md` and an open item in `STATUS.md` for the paid `agent_loop` refresh. Documents the UAT pattern that blocked spec-compliant rendering (tests asserted assumptions instead of the protocol) and notes that G1’s two new tools moved the prompt stamp, so one paid run will refresh the stale agent-loop records.

<sup>Written for commit b52d6bbbb3a4f93a57b2fcf67deca7d6bc29c663. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/848?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

