### PR TITLE
docs(status): the lane section says what the runner measures, and what narrowing the classifier cost

### DIFF
--- a/STATUS-ARCHIVE.md
+++ b/STATUS-ARCHIVE.md
@@ -21,6 +21,70 @@
 > [CHANGELOG.md](CHANGELOG.md) and [README.md → *What works
 > today*](README.md#what-works-today).
 
+## 2026-08-11 — the lane says where its own time goes, 222s → 207s (PRs #854, #859, #861)
+
+Three changes, and the first is the one that matters after the other two are
+forgotten: **the runner prints its own wall-clock breakdown every run.** The
+per-package cost report priced tests and said so, which left everything around
+them unattributed — and unattributed turned out to be 42s of a 221s run. Every
+number in this entry came out of that report; before it existed, three of the four
+components were guesses and two of the guesses were wrong. Clone churn looked like
+the residue and is ~3s of it (eight concurrent `CREATE DATABASE` from one template
+measure 1.06s, not eight times 0.38s — they do not serialize), while pre-fan-out
+discovery looked negligible and is 15–20s.
+
+Measured back to back on one machine, same sitting:
+
+```
+222s  before        long pole waited 12s
+212s  + #859 split  long pole waited 12s
+207s  + #861 order  long pole waited  0s
+```
+
+**The split (#859) bought 10s and cost 4s of total CPU** — an extra binary, clone
+and compile — which is the trade a split is supposed to make. **The ordering
+(#861) bought 11s**, and its mechanism is the load-independent part: slot-wait 16s
+→ 0s. That win is understated, because total package seconds ROSE 1.4% between
+those two runs and the long pole's own occupancy rose with it (183s → 191s), so
+the faster run was the busier one.
+
+**What the numbers corrected.** An earlier edition of the STATUS.md lane section
+said splitting was spent and the wall was no longer bound by the longest package.
+It is: `compose/integration` is 191s of 207s. What is actually spent is
+scheduling — the long pole now starts at t=0 and no ordering can beat that. This
+is worth remembering as a shape: the claim was plausible, held for a while, and
+was only falsifiable once the runner reported the breakdown.
+
+**The entanglement that sized the split.** Grouping was done from measured
+seconds (927 tests aggregated onto the file declaring each), not from names, and
+the boundary still had to be walked back three times — four neighbours that read
+as if they belonged with the channel suites share one preflight fixture with
+suites that were not moving, and `channelsend_mcp` asserts through a sealed
+envelope five types deep in the parent's `_test.go` files. Two helpers with
+callers on both sides were promoted rather than copied: `InWorkspace` to
+`apptest` (it takes an `AppEnv`, and an ordinary file in the parent cannot import
+`apptest` without closing a cycle through `compose`), and the retention seeder to
+`integration/suitefixtures.go`.
+
+**Two traps, both of which produce a passing test that proves nothing.** A suite
+that moves out of a package leaves behind whatever an `init()` armed, with no
+compile error — here the jurisdiction floor, whose absence makes the erasure the
+suite expects to be REFUSED succeed, so the assertion reports a missing floor as
+a missing shield. The registration travels with the suite now, and a guard asserts
+it by pack code and span. And the file holding that guard was first called
+`jurisdiction_arm_test.go`: Go reads the segment before `_test.go` as an implicit
+build constraint, **`arm` is a GOARCH**, and the file was silently dropped on every
+arm64 machine — so the fix appeared not to work, and the guard reported success
+while printing `no tests to run`.
+
+Every review finding across the three PRs was the same shape: instrumentation
+allowed to lie or to break what it measures. A failed timing write would have
+failed the whole lane (last command in `run_one`, under `xargs -P`, `set -e`); a
+package with no recorded duration had its entire slot reported as provisioning; a
+half-written ordering hint would have inverted the ordering, since a heavy package
+truncated mid-line sorts LAST. The hint is published by rename now, and the
+report says the split is unavailable rather than inventing one.
+
 ## 2026-08-11 — the cheapest integration run is the one that never starts (PR #816)
 
 The entry above spends itself on making the lane faster. This one is about not

--- a/STATUS-ARCHIVE.md
+++ b/STATUS-ARCHIVE.md
@@ -21,6 +21,39 @@
 > [CHANGELOG.md](CHANGELOG.md) and [README.md → *What works
 > today*](README.md#what-works-today).
 
+## 2026-08-11 — the cheapest integration run is the one that never starts (PR #816)
+
+The entry above spends itself on making the lane faster. This one is about not
+running it. Editing `infra/ci-pipeline.md` — the file that *documents* the change
+classifier — booted twelve Postgres shards, because the `backend` scope matched
+`infra/**` and `.github/workflows/**` whole. A gate input earns its place by being
+able to change what a gate **does**; prose that merely describes one does not. So
+both scopes now name `infra/**/!(*.md)`, and the workflow glob names
+`.github/workflows/ci.yml` rather than every workflow.
+
+**The negation footgun, since the obvious spelling is wrong.** paths-filter ORs
+its patterns, so a `!infra/**/*.md` list entry matches every path *outside*
+`infra/` and fires the filter on everything — the opposite of the intent, failing
+open. Each cut is therefore one positive extglob. The behaviour was checked
+against picomatch (the matcher the action uses) before pushing, and the merged
+run confirmed it on live CI: two changed files, `ci.yml` matched, the `.md` did
+not.
+
+**What the narrowing nearly broke.** `make check-image-pins` reads the whole
+workflow directory but reached CI only through `make check-backend`, inside the
+`backend`-gated job. Narrowed, it would have skipped on exactly the PR that
+unpins an action in `sbom.yml` or `patch.yml` — and Renovate, which bumps `uses:`
+across all three workflows, auto-merges on green. It moved to `secret-scan`,
+which runs on every non-draft change for the same reason its two existing gates
+do: supply-chain surface is not a scope. No new check name, so branch protection
+was untouched. This is the same shape as the `docker images` fan-in, and worth
+remembering as a class: **narrowing a scope silently disarms every whole-tree
+gate that was riding inside it.** Grep for what a job actually reads before
+cutting what triggers it.
+
+A PR that edits `ci.yml` still runs the full backend lane, by design — a change
+to the merge gate that the merge gate never exercised is not a saving.
+
 ## 2026-08-10 — the MCP App views move to `frontend/` (#742, PR #793)
 
 The two `ui://` views left `go:embed` and became a frontend build target. The api

--- a/STATUS.md
+++ b/STATUS.md
@@ -420,17 +420,44 @@ their refusal probe checks for, under production RLS).
 
 ## Open — the integration lane, what is left
 
-The lane is ~2060 tests over 30 packages, ~192s wall. It was ~300s when this was
-first profiled on 2026-08-06. #524, #539 and #482 are closed; the narrative for
-each is in [STATUS-ARCHIVE.md](STATUS-ARCHIVE.md), and the entry for #539 is
-worth reading before optimizing further because it is mostly a record of things
-that did not work.
+The lane is ~2126 tests over 32 packages, **207s wall** — measured 2026-08-11,
+back to back with the 222s it was that morning. It was ~300s when first profiled
+on 2026-08-06. #524, #539 and #482 are closed; the narrative for each is in
+[STATUS-ARCHIVE.md](STATUS-ARCHIVE.md), and the entry for #539 is worth reading
+before optimizing further because it is mostly a record of things that did not
+work.
 
-**Do not expect much more from splitting packages.** It was the obvious lever and
-it is spent: the lane's wall clock is no longer bound by its longest package, so
-the last split bought ~9% and the next would buy less. What is left sits in the
-~35s between the longest package and the lane's wall time, and in the suites
-below.
+**Stop guessing where the time goes — the runner says.** Every full run now
+prints its own wall-clock breakdown (#854), so a claim about this lane is
+checkable rather than argued. The current one:
+
+```
+207s total
+  15s   before any package could start (template, constraint scan, enumeration)
+   0s   then ./internal/compose/integration waited for a slot
+ 191s   it occupied a slot, of which 183.6s was its tests
+ 7.4s   provisioning that slot (clone, compile, process start)
+```
+
+**Splitting packages is the only lever left, and it is not spent** — an earlier
+edition of this section said the opposite, before the numbers above existed.
+`compose/integration` is **191s of the 207s wall, 92% of it**, and seven cores
+idle while it finishes. The balanced floor is ~80s (sum of packages ÷ 8 slots),
+so essentially the whole gap between 80s and 207s is that one package.
+
+What IS spent is scheduling. #861 dispatches longest-first, which took the long
+pole's slot-wait from 12–16s to **0s** — it now starts at t=0, and no ordering
+change can do better than that. The remaining residue is ~22s, and only the 15s
+of pre-fan-out is plausibly reducible.
+
+The cost of the next slice is fixture entanglement, not the move itself. #859
+took the channel suites out (14.8s) and had to leave four neighbours behind, each
+sharing one preflight fixture with suites that were not moving; two shared helpers
+had to be promoted to importable homes first, and `integration/channels/doc.go`
+records where the boundary fell and why. Reaching the ~80s floor means repeating
+that several times — a programme, not a follow-up. Each slice also subjects every
+MOVED line to the full strict linter (`new-from-merge-base`), which is a real cost
+per PR.
 
 The other lever is not running the lane at all. PR #816 narrowed the change
 classifier so a docs edit under `infra/` and a change to a workflow other than
@@ -449,9 +476,14 @@ narrowing nearly disarmed, is in
   Postgres per case (~44s), which also hides that the property under test is pure.
 - **#536** — a few tests assert pure logic through a booted app; `check-test-lanes.sh`
   forbids the mirror case (a unit test opening real infra) but cannot see this one.
-- **#639** — two packages hand-roll the process pool `testdb.Pool` now owns.
+- **#639** — two packages hand-roll the process pool `testdb.Pool` now owns. One
+  of them moved rather than shrank: the pre-boot pool the vault suites need is
+  now `integration/apptest.EarlyPool`, which still calls `database.NewPool`
+  itself. It is one place instead of one per caller, which is where #639 can
+  reach it.
 - **#770** — the telegram-ingress suite leaves a connection checked out past its
-  own cleanup under lane load.
+  own cleanup under lane load. It lives in `integration/channels` since #859, not
+  the parent package.
 
 Three measurement notes, each of which cost a wrong number before it was written
 down. **Restart Postgres between runs** — a fresh container is worth ~25% on its

--- a/STATUS.md
+++ b/STATUS.md
@@ -432,6 +432,12 @@ the last split bought ~9% and the next would buy less. What is left sits in the
 ~35s between the longest package and the lane's wall time, and in the suites
 below.
 
+The other lever is not running the lane at all. PR #816 narrowed the change
+classifier so a docs edit under `infra/` and a change to a workflow other than
+`ci.yml` no longer trigger it; the narrative, including the whole-tree gate that
+narrowing nearly disarmed, is in
+[STATUS-ARCHIVE.md](STATUS-ARCHIVE.md).
+
 - **#779** — the periodic-dispatch suites wait ~28s in 12 tests on River's real
   clock, the largest single concentration of real waiting. River can stub the
   clock; the issue says why that is not a one-liner and which suite must stay on


### PR DESCRIPTION
Follows #816. Session narrative to `STATUS-ARCHIVE.md`, per the rule that
`STATUS.md` stays a snapshot of open work.

The part worth carrying forward is not the two path globs — it is the two things
that were nearly got wrong:

- **paths-filter ORs its patterns**, so the obvious `!infra/**/*.md` spelling
  matches every path *outside* `infra/` and fires the filter on everything. It
  fails **open**, which is the direction that does not announce itself. Each cut
  is one positive extglob instead.
- **Narrowing a scope silently disarms every whole-tree gate riding inside it.**
  `make check-image-pins` reads the whole workflow directory but reached CI only
  through `make check-backend`. Narrowed, it would have skipped on exactly the PR
  that unpins an action — with Renovate auto-merging on green. Same shape as the
  `docker images` fan-in, so it is recorded as a class, not an anecdote.

`STATUS.md` gains a four-line pointer in *Open — the integration lane, what is
left*: that section is where someone goes to make the lane cheaper, and #816
removed a class of runs rather than speeding any up.

Docs only — matches no classifier scope, so every code gate skips. Which is
itself #816 working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated `STATUS.md` with the runner’s measured breakdown (207s wall; `compose/integration` is the long pole; it now starts at t=0) and added a pointer to the change-classifier narrowing. Archived PR #816’s lessons in `STATUS-ARCHIVE.md`: `paths-filter` ORs patterns (use positive extglobs) and narrowing can silently disarm whole-tree gates, so image-pin checks run in always-on `secret-scan`.

<sup>Written for commit bbf7f9d6db4693a7bfa500a92d98c036a447cae5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/855?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

