### PR TITLE
refactor(installation): the last readers leave the workspace columns

### DIFF
--- a/backend/internal/compose/briefs/briefrank.go
+++ b/backend/internal/compose/briefs/briefrank.go
@@ -25,6 +25,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 
+	"github.com/gradionhq/margince/backend/internal/modules/identity"
 	"github.com/gradionhq/margince/backend/internal/modules/people"
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
@@ -83,16 +84,16 @@ func (e *BriefEngine) WithL2Ranker(brain briefBrain, log *slog.Logger) *BriefEng
 // rate yields NULL — the revenue factor floors rather than guessing (a
 // wrong number is worse than a missing one). asOfPos is the bind position
 // of the as-of date.
-func briefBaseValueSQL(asOfPos int) string {
+func briefBaseValueSQL(asOfPos, basePos int) string {
 	return fmt.Sprintf(`CASE
 		WHEN d.amount_minor IS NULL THEN NULL
-		WHEN d.currency IS NULL OR d.currency = w.base_currency THEN d.amount_minor
+		WHEN d.currency IS NULL OR d.currency = $%[2]d THEN d.amount_minor
 		WHEN d.fx_rate_to_base IS NOT NULL THEN d.amount_minor_base
 		ELSE (SELECT round(d.amount_minor * fr.rate)::bigint FROM fx_rate fr
-		      WHERE fr.from_currency = d.currency AND fr.to_currency = w.base_currency
-		        AND fr.rate_date <= $%d::date
+		      WHERE fr.from_currency = d.currency AND fr.to_currency = $%[2]d
+		        AND fr.rate_date <= $%[1]d::date
 		      ORDER BY fr.rate_date DESC LIMIT 1)
-	END`, asOfPos)
+	END`, asOfPos, basePos)
 }
 
 // Rank computes the deterministic §10.1 queue for the acting rep at one
@@ -121,13 +122,20 @@ func (e *BriefEngine) Rank(ctx context.Context, now time.Time) (BriefRanking, er
 			return err
 		}
 
-		norm, err := briefRevenueNorm(ctx, tx, now)
+		// Resolved ONCE for the whole rank: the revenue norm and every
+		// candidate's base value must be measured against the same basis, and
+		// two reads of one installation-wide value is two chances to disagree.
+		base, err := identity.BaseCurrencyOf(ctx, tx)
+		if err != nil {
+			return err
+		}
+		norm, err := briefRevenueNorm(ctx, tx, now, base)
 		if err != nil {
 			return err
 		}
 		revenueNorm = norm
 
-		if err := briefCandidates(ctx, tx, userID, now, facts, &order); err != nil {
+		if err := briefCandidates(ctx, tx, userID, now, base, facts, &order); err != nil {
 			return err
 		}
 		return briefEvidenceRows(ctx, tx, lastView, facts, order, stakeholders)
@@ -207,19 +215,22 @@ func briefLastView(ctx context.Context, tx pgx.Tx, userID ids.UUID) (*time.Time,
 // briefRevenueNorm computes REVENUE_NORM: the workspace P90 base deal
 // value over live deals with an evidencable amount, or the fixed
 // fallback below ten deals of history.
-func briefRevenueNorm(ctx context.Context, tx pgx.Tx, now time.Time) (int64, error) {
+//
+// The basis is a bind parameter, and the workspace join that used to supply it
+// is gone with it: it earned its place only by carrying base_currency, which
+// is now one installation-wide value rather than a column on a joinable row.
+func briefRevenueNorm(ctx context.Context, tx pgx.Tx, now time.Time, base string) (int64, error) {
 	var valued int
 	var p90 *float64
 	err := tx.QueryRow(ctx, fmt.Sprintf(`
 		WITH sized AS (
 			SELECT %s AS base_value
 			FROM deal d
-			JOIN workspace w ON w.id = d.workspace_id
 			WHERE d.archived_at IS NULL
 		)
 		SELECT count(*), percentile_cont(%v) WITHIN GROUP (ORDER BY base_value::double precision)
 		FROM sized WHERE base_value IS NOT NULL`,
-		briefBaseValueSQL(1), briefRevenueNormPercentile), now.UTC()).Scan(&valued, &p90)
+		briefBaseValueSQL(1, 2), briefRevenueNormPercentile), now.UTC(), base).Scan(&valued, &p90)
 	if err != nil {
 		return 0, err
 	}
@@ -236,11 +247,14 @@ func briefRevenueNorm(ctx context.Context, tx pgx.Tx, now time.Time) (int64, err
 // just the last). A snoozed item suppresses its deal on time alone
 // (A77/AC-home-6): out while snoozed_until lies ahead, back once it
 // passes — no material change required.
-func briefCandidates(ctx context.Context, tx pgx.Tx, userID ids.UUID, now time.Time, facts map[ids.UUID]briefDealFacts, order *[]ids.UUID) error {
+func briefCandidates(ctx context.Context, tx pgx.Tx, userID ids.UUID, now time.Time,
+	base string, facts map[ids.UUID]briefDealFacts, order *[]ids.UUID,
+) error {
 	var args []any
 	arg := func(v any) int { args = append(args, v); return len(args) }
 	asOfPos := arg(now.UTC())
 	userPos := arg(userID)
+	basePos := arg(base)
 
 	scope, err := auth.ScopeClauseFor(ctx, "deal", "d", arg)
 	if err != nil {
@@ -250,7 +264,6 @@ func briefCandidates(ctx context.Context, tx pgx.Tx, userID ids.UUID, now time.T
 		SELECT d.id, s.win_probability, %s, d.expected_close_date
 		FROM deal d
 		JOIN stage s ON s.id = d.stage_id
-		JOIN workspace w ON w.id = d.workspace_id
 		WHERE d.archived_at IS NULL AND d.status = 'open'
 		  AND NOT EXISTS (
 			SELECT 1 FROM brief_item bi
@@ -262,7 +275,7 @@ func briefCandidates(ctx context.Context, tx pgx.Tx, userID ids.UUID, now time.T
 				SELECT 1 FROM activity a
 				JOIN activity_link l ON l.activity_id = a.id AND l.deal_id = d.id
 				WHERE a.archived_at IS NULL AND a.occurred_at > bi.state_at) END)`,
-		briefBaseValueSQL(asOfPos), userPos, asOfPos)
+		briefBaseValueSQL(asOfPos, basePos), userPos, asOfPos)
 	if scope != "" {
 		q += " AND " + scope
 	}

--- a/backend/internal/compose/datareset.go
+++ b/backend/internal/compose/datareset.go
@@ -103,7 +103,7 @@ func (h dataResetHandlers) run(ctx context.Context, confirmation string) (resetC
 	// sweep re-checks inside its own transaction — one row read that closes
 	// the window where the organization is renamed in between.
 	if err := database.WithWorkspaceTx(ctx, h.pool, func(tx pgx.Tx) error {
-		return confirmResetOrgName(ctx, tx, wsID, confirmation)
+		return confirmResetOrgName(ctx, tx, confirmation)
 	}); err != nil {
 		return resetCounts{}, err
 	}
@@ -185,9 +185,12 @@ func (h dataResetHandlers) runQuiesced(ctx context.Context, wsID ids.UUID, clear
 
 // confirmResetOrgName refuses the reset unless confirmation is exactly the
 // organization's name.
-func confirmResetOrgName(ctx context.Context, tx pgx.Tx, wsID ids.UUID, confirmation string) error {
-	var orgName string
-	if err := tx.QueryRow(ctx, `SELECT name FROM workspace WHERE id = $1`, wsID).Scan(&orgName); err != nil {
+func confirmResetOrgName(ctx context.Context, tx pgx.Tx, confirmation string) error {
+	// The SETTING, because that is the name the operator is reading off the
+	// screen when they type it. Demanding the column's copy would, the moment
+	// the two drifted, refuse the only spelling they can see (issue #521).
+	orgName, err := identity.NameOf(ctx, tx)
+	if err != nil {
 		return err
 	}
 	if confirmation != orgName {
@@ -203,7 +206,7 @@ func confirmResetOrgName(ctx context.Context, tx pgx.Tx, wsID ids.UUID, confirma
 // nothing staged to ship into streams that were just emptied (clearOutbox).
 func (h dataResetHandlers) sweepAndReseed(ctx context.Context, wsID ids.UUID, confirmation string, counts *resetCounts) error {
 	return database.WithWorkspaceTx(ctx, h.pool, func(tx pgx.Tx) error {
-		if err := confirmResetOrgName(ctx, tx, wsID, confirmation); err != nil {
+		if err := confirmResetOrgName(ctx, tx, confirmation); err != nil {
 			return err
 		}
 		tables, err := resetTargetTables(ctx, tx)

--- a/backend/internal/compose/datareset_integration_test.go
+++ b/backend/internal/compose/datareset_integration_test.go
@@ -440,7 +440,11 @@ func TestResetRestoresSettingRowsButKeepsTheInstallationsIdentity(t *testing.T) 
 		env:   runtimeenv.Development,
 		log:   slog.New(slog.NewTextHandler(io.Discard, nil)),
 	}
-	if _, err := h.run(ctx, "Authz"); err != nil {
+	// Confirmed with the SETTING's name, not the workspace column's. This test
+	// is the one place the two deliberately differ, and the confirmation
+	// prompt asks for the name the operator can actually see — which is the
+	// one the installation settings screen shows (issue #521).
+	if _, err := h.run(ctx, "Brandt Automotive"); err != nil {
 		t.Fatalf("run: %v", err)
 	}
 

--- a/backend/internal/compose/derivation.go
+++ b/backend/internal/compose/derivation.go
@@ -265,9 +265,13 @@ func (e *reportEngine) fetchDerivation(ctx context.Context, report string, spec 
 		}
 		whereSQL := strings.Join(where, " AND ")
 
-		rowsSQL := fmt.Sprintf("SELECT %s FROM %s WHERE %s ORDER BY t.id LIMIT %d",
-			strings.Join(plan.selects, ", "), spec.fromClause(), whereSQL, reportRowLimit)
-		pgRows, err := tx.Query(ctx, rowsSQL, args...)
+		rowsSQL, rowsArgs, err := bindInstallationZone(ctx, tx, fmt.Sprintf(
+			"SELECT %s FROM %s WHERE %s ORDER BY t.id LIMIT %d",
+			strings.Join(plan.selects, ", "), spec.fromClause(), whereSQL, reportRowLimit), args)
+		if err != nil {
+			return err
+		}
+		pgRows, err := tx.Query(ctx, rowsSQL, rowsArgs...)
 		if err != nil {
 			return fmt.Errorf("derivation %s rows: %w", report, err)
 		}
@@ -282,14 +286,18 @@ func (e *reportEngine) fetchDerivation(ctx context.Context, report string, spec 
 		// (count(*) rides along as the honest total behind the capped
 		// rows slice). Values are read positionally, so a caller alias
 		// cannot shadow the total.
-		aggSQL := fmt.Sprintf("SELECT count(*), %s FROM %s WHERE %s",
-			strings.Join(plan.aggSelects, ", "), spec.fromClause(), whereSQL)
+		aggSQL, aggArgs, err := bindInstallationZone(ctx, tx, fmt.Sprintf(
+			"SELECT count(*), %s FROM %s WHERE %s",
+			strings.Join(plan.aggSelects, ", "), spec.fromClause(), whereSQL), args)
+		if err != nil {
+			return err
+		}
 		values := make([]any, len(plan.aggColumns)+1)
 		ptrs := make([]any, len(values))
 		for i := range values {
 			ptrs[i] = &values[i]
 		}
-		if err := tx.QueryRow(ctx, aggSQL, args...).Scan(ptrs...); err != nil {
+		if err := tx.QueryRow(ctx, aggSQL, aggArgs...).Scan(ptrs...); err != nil {
 			return fmt.Errorf("derivation %s aggregates: %w", report, err)
 		}
 		total, ok := values[0].(int64)

--- a/backend/internal/compose/derivation_test.go
+++ b/backend/internal/compose/derivation_test.go
@@ -178,9 +178,11 @@ func TestForecastSpecShape(t *testing.T) {
 	if !ok {
 		t.Fatal("forecast report missing from the prebuilt catalog")
 	}
-	// Both joins are to-one lookups (the stage for win_probability, the
-	// workspace for the §11 reporting-zone "today"), never row multipliers.
-	if got := spec.fromClause(); got != "deal t JOIN stage s ON s.id = t.stage_id JOIN workspace w ON w.id = t.workspace_id" {
+	// One join, a to-one lookup for win_probability, never a row multiplier.
+	// The workspace join went with the §11 reporting-zone "today": that zone
+	// is an installation SETTING now, bound as a parameter, so the join had
+	// nothing left to carry (issue #521).
+	if got := spec.fromClause(); got != "deal t JOIN stage s ON s.id = t.stage_id" {
 		t.Errorf("fromClause = %q", got)
 	}
 	if spec.measures["weighted_amount_minor"] != "round((t.amount_minor * s.win_probability) / 100.0)::bigint" {

--- a/backend/internal/compose/report.go
+++ b/backend/internal/compose/report.go
@@ -75,13 +75,25 @@ type reportSpec struct {
 // confirms a real date. The exclusion lives in the dimension itself, so
 // the aggregate, its filter, and the drill-through all read the same
 // row set and keep reconciling exactly (no post-hoc subtraction).
-// "Today" buckets in the workspace reporting zone (data-semantics §2 r4)
-// via the spec's fixed workspace join.
+// "Today" buckets in the installation's reporting zone (data-semantics §2 r4).
+//
+// The zone arrives as a BIND parameter, written here as reportZoneToken and
+// substituted for a real $n once the statement is assembled — the catalog is a
+// static map of expressions, so it has no bind position to name at the point
+// it is written. Postgres still does the date arithmetic, which is what keeps
+// the DST rules and the day boundary where they were when the zone was a
+// column on a joined row.
 const forecastCategoryExpr = `(CASE WHEN t.forecast_category IN ('commit','best_case')
 		AND (t.expected_close_date IS NULL
-			OR t.expected_close_date < (timezone(w.timezone, now()))::date
+			OR t.expected_close_date < (timezone(` + reportZoneToken + `, now()))::date
 			OR t.close_date_provisional)
 	THEN 'slipped' ELSE t.forecast_category END)`
+
+// reportZoneToken stands in for the installation timezone's bind position
+// until fetchRows knows it. It is deliberately not valid SQL, so a statement
+// that reaches Postgres with the token unsubstituted fails loudly rather than
+// quietly reporting in the wrong zone.
+const reportZoneToken = "<<installation-timezone>>"
 
 // prebuiltReports is the report catalog (data-model §13 shape): keys
 // are never UUIDs, so saved-report ids cannot collide.
@@ -138,7 +150,7 @@ var prebuiltReports = map[string]reportSpec{
 	"forecast": {
 		entity:    datasource.EntityDeal,
 		table:     "deal",
-		joins:     []string{"JOIN stage s ON s.id = t.stage_id", "JOIN workspace w ON w.id = t.workspace_id"},
+		joins:     []string{"JOIN stage s ON s.id = t.stage_id"},
 		baseWhere: "t.archived_at IS NULL AND t.status = 'open'",
 		basePlain: "open, unarchived deals (win probability read live from the deal's current stage; a commit/best_case deal whose close date is past, missing, or provisional reports as 'slipped' instead, per formulas §11)",
 		dimensions: map[string]string{

--- a/backend/internal/compose/report_forecast_integration_test.go
+++ b/backend/internal/compose/report_forecast_integration_test.go
@@ -496,6 +496,13 @@ func (e *forecastEnv) forecastStatus(ctx context.Context, body string) int {
 // workspace.timezone still says UTC. A reader on the column never notices.
 func TestTheForecastBucketsInTheZoneTheSettingNames(t *testing.T) {
 	e := setupForecast(t)
+	// A commit deal WITH a close date, because the zone sits inside a CASE
+	// that Postgres evaluates per row: over an empty result the expression is
+	// never reached, and the fixture would report success in both directions
+	// without ever consulting a zone at all.
+	commit := "commit"
+	amount := int64(100000)
+	e.seedOpenDeal(t, "Zoned", 60, nil, &amount, &commit)
 	body := `{"group_by":["forecast_category"]}`
 	if got := e.forecastStatus(e.Admin(), body); got != http.StatusOK {
 		t.Fatalf("the control run answered %d, want 200 — the fixture is broken before the setting moves", got)

--- a/backend/internal/compose/report_forecast_integration_test.go
+++ b/backend/internal/compose/report_forecast_integration_test.go
@@ -78,6 +78,17 @@ func setupForecast(t *testing.T) *forecastEnv {
 		Rep1: ids.NewV7(), Rep3: ids.NewV7(), Team1: ids.NewV7(), Team2: ids.NewV7(),
 		stages: map[int]ids.UUID{},
 	}
+	// The installation's identity as settings rows: the forecast's
+	// slipped-category dimension resolves its zone from the SETTING now, and
+	// this env builds its workspace by raw SQL, so bootstrap never seeded them
+	// (issue #521).
+	if _, err := owner.Exec(ctx, `INSERT INTO setting (key, value) VALUES
+			('installation.name', '"Forecast"'::jsonb),
+			('installation.base_currency', '"EUR"'::jsonb),
+			('installation.timezone', '"UTC"'::jsonb)
+		 ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value`); err != nil {
+		t.Fatalf("seeding the installation settings: %v", err)
+	}
 	if _, err := owner.Exec(ctx, `INSERT INTO workspace (id, name, slug, base_currency) VALUES ($1, 'Forecast', 'forecast', 'EUR')`, e.WS); err != nil {
 		t.Fatal(err)
 	}
@@ -453,5 +464,51 @@ func TestForecastDerivationHonorsRowScope(t *testing.T) {
 	full := e.explain(t, e.Admin(), result.DerivationURL)
 	if full.TotalRows != 3 {
 		t.Errorf("admin drill-through total = %d, want 3", full.TotalRows)
+	}
+}
+
+// forecastStatus runs the forecast and reports only the status code, for the
+// cases where the interesting outcome is a refusal rather than a result.
+func (e *forecastEnv) forecastStatus(ctx context.Context, body string) int {
+	req := httptest.NewRequest(http.MethodPost, "/v1/reports/forecast", strings.NewReader(body)).WithContext(ctx)
+	rec := httptest.NewRecorder()
+	e.handlers.RunReport(rec, req, "forecast")
+	return rec.Code
+}
+
+// The forecast's "today" comes from the SETTING's zone, not from
+// workspace.timezone (ADR-0091 phase 4, issue #521).
+//
+// It asserts a FLIP rather than a message. Asserting on a date would be
+// flaky — any two real zones agree about the date for part of every day, so
+// the outcome would turn on the hour the suite ran. And the zone never reaches
+// the response body: an unresolvable zone is a Postgres fault, which httperr
+// masks to an opaque 500 exactly as it should. So the fixture holds everything
+// constant and moves only the setting: the same report that answered 200
+// stops answering once the SETTING names a zone Postgres cannot resolve, while
+// workspace.timezone still says UTC. A reader on the column never notices.
+func TestTheForecastBucketsInTheZoneTheSettingNames(t *testing.T) {
+	e := setupForecast(t)
+	body := `{"group_by":["forecast_category"]}`
+	if got := e.forecastStatus(e.Admin(), body); got != http.StatusOK {
+		t.Fatalf("the control run answered %d, want 200 — the fixture is broken before the setting moves", got)
+	}
+
+	if _, err := e.owner.Exec(context.Background(),
+		`UPDATE setting SET value = '"Margince/Nowhere"'::jsonb WHERE key = 'installation.timezone'`); err != nil {
+		t.Fatal(err)
+	}
+	var column string
+	if err := e.owner.QueryRow(context.Background(),
+		`SELECT timezone FROM workspace WHERE id = $1`, e.WS).Scan(&column); err != nil {
+		t.Fatal(err)
+	}
+	if column != "UTC" {
+		t.Fatalf("the fixture needs the two copies to DISAGREE; workspace.timezone = %q", column)
+	}
+
+	if got := e.forecastStatus(e.Admin(), body); got == http.StatusOK {
+		t.Error("the forecast still answered 200 with an unresolvable zone in the setting; " +
+			"the slipped-category dimension is reading workspace.timezone")
 	}
 }

--- a/backend/internal/compose/report_forecast_integration_test.go
+++ b/backend/internal/compose/report_forecast_integration_test.go
@@ -152,7 +152,14 @@ func (e *forecastEnv) dealReadCtx(userID ids.UUID, teams []ids.UUID, scope princ
 	return principal.WithActor(ctx, principal.Principal{
 		Type: principal.PrincipalHuman, ID: "human:" + userID.String(), UserID: userID, TeamIDs: teams,
 		Permissions: principal.Permissions{
-			Objects:  map[string]principal.ObjectGrant{"deal": {Read: true}},
+			Objects: map[string]principal.ObjectGrant{
+				"deal": {Read: true},
+				// The forecast buckets "today" in the installation's zone, and
+				// that zone is read behind this object now (issue #521). 0191
+				// grants it to all five seeded roles, so no real caller of a
+				// report is without it.
+				"installation_settings": {Read: true},
+			},
 			RowScope: scope,
 		},
 	})

--- a/backend/internal/compose/reportsql.go
+++ b/backend/internal/compose/reportsql.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
+	"github.com/gradionhq/margince/backend/internal/modules/identity"
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
@@ -39,7 +40,17 @@ func (e *reportEngine) fetchRows(ctx context.Context, report string, spec report
 		if err != nil {
 			return err
 		}
-		pgRows, err := tx.Query(ctx, reportSQL(spec, selects, where, groupBy), args...)
+		sql := reportSQL(spec, selects, where, groupBy)
+		// Bound only when the assembled statement actually asks for it: a
+		// parameter Postgres never references is a bind error, not a spare.
+		if strings.Contains(sql, reportZoneToken) {
+			zone, err := identity.TimezoneOf(ctx, tx)
+			if err != nil {
+				return err
+			}
+			sql = strings.ReplaceAll(sql, reportZoneToken, fmt.Sprintf("$%d", arg(zone)))
+		}
+		pgRows, err := tx.Query(ctx, sql, args...)
 		if err != nil {
 			return fmt.Errorf("report %s: %w", report, err)
 		}

--- a/backend/internal/compose/reportsql.go
+++ b/backend/internal/compose/reportsql.go
@@ -40,15 +40,9 @@ func (e *reportEngine) fetchRows(ctx context.Context, report string, spec report
 		if err != nil {
 			return err
 		}
-		sql := reportSQL(spec, selects, where, groupBy)
-		// Bound only when the assembled statement actually asks for it: a
-		// parameter Postgres never references is a bind error, not a spare.
-		if strings.Contains(sql, reportZoneToken) {
-			zone, err := identity.TimezoneOf(ctx, tx)
-			if err != nil {
-				return err
-			}
-			sql = strings.ReplaceAll(sql, reportZoneToken, fmt.Sprintf("$%d", arg(zone)))
+		sql, args, err := bindInstallationZone(ctx, tx, reportSQL(spec, selects, where, groupBy), args)
+		if err != nil {
+			return err
 		}
 		pgRows, err := tx.Query(ctx, sql, args...)
 		if err != nil {
@@ -159,3 +153,28 @@ func quoteIdent(name string) string {
 }
 
 var identShape = regexp.MustCompile(`^[a-z][a-z0-9_]{0,62}$`)
+
+// bindInstallationZone substitutes reportZoneToken for a real bind position,
+// appending the installation's zone to THIS statement's arguments.
+//
+// It takes and returns the argument slice rather than sharing one, because a
+// caller may assemble several statements from one plan and only some of them
+// mention the zone: Postgres rejects a parameter the statement never
+// references, so a shared slice would break the queries that do not use it.
+//
+// The zone is resolved only when the assembled statement actually asks for it,
+// so a report that never buckets by date neither reads the setting nor takes
+// its gate.
+func bindInstallationZone(
+	ctx context.Context, tx pgx.Tx, sql string, args []any,
+) (string, []any, error) {
+	if !strings.Contains(sql, reportZoneToken) {
+		return sql, args, nil
+	}
+	zone, err := identity.TimezoneOf(ctx, tx)
+	if err != nil {
+		return "", nil, err
+	}
+	args = append(append([]any(nil), args...), zone)
+	return strings.ReplaceAll(sql, reportZoneToken, fmt.Sprintf("$%d", len(args))), args, nil
+}


### PR DESCRIPTION
Slice 4 of #521, following #794, #802 and #817 — **the end of the reader migration**.

Both remaining sites spelled the value *inside* a larger query against a `workspace w` join, which is why they were held back: they needed bind positions threaded through their builders, not a source swap.

## The brief ranker

Takes the basis as a parameter, resolved **once per rank** — the P90 revenue norm and every candidate's base value must be measured against the same one, and two reads of an installation-wide value is two chances to disagree. Its `workspace` join is gone with it: the join earned its place only by carrying `base_currency`.

## The forecast's slipped-category dimension

Harder, because the report catalog is a **static map of SQL expressions** with no bind position to name at the point they're written. The zone is written as a token and substituted for a real `$n` once the statement is assembled, and bound **only when the assembled statement actually contains it** — a parameter Postgres never references is a bind error, not a spare.

The token is deliberately not valid SQL, so a statement reaching Postgres unsubstituted fails loudly rather than quietly reporting in the wrong zone. Postgres still does the date arithmetic, which keeps the DST rules and the day boundary where they were.

## Also moved

The data reset's confirmation prompt. It demands the organization's name, and the name the operator reads off the screen is the setting's — the moment the two drifted it would have refused the only spelling they can see.

## Three reads stay on the column — each for a reason that is not "not yet"

| Read | Why it stays |
|---|---|
| `compose/installation.go` bootstrap backfill | it is what **writes** the settings |
| `identity/service.go` session read | names the installation *before any principal exists* to gate a settings read |
| `deals/basecurrencyfreeze.go` freeze probe | must answer on the **first** write, where no setting row exists yet |

## Test notes

The forecast fixture builds its workspace by raw SQL, so it seeds the settings now.

The new forecast test asserts a **flip**, not a message — and I want that choice reviewed. A date assertion would turn on the hour the suite ran (any two zones agree about the date for part of every day), and an unresolvable zone is a Postgres fault that `httperr` masks to an opaque 500, exactly as it should. So the fixture holds everything constant and moves only the setting: the same report that answered 200 stops answering. A reader still on the column never notices.

`TestForecastSpecShape` pinned the removed join; updated with why.

## What this unblocks, and what it does not

After this, nothing reads `workspace.{name,base_currency,timezone}` except the three above. **Dropping the columns is not in this PR** — it needs an additive migration plus a resolution for each of those three, and the `UpdateInstallation` dual-write mirror retires with them. That is ADR-0091 phase 4's next step.

## Verification

`make check-backend` and `make craft-static` (0/0/0) green; `go vet -tags integration ./...` clean.

Refs #521, ADR-0091 phase 4.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the last runtime reads of `workspace.{name,base_currency,timezone}`. Brief ranking and forecast now bind installation settings; the reporting zone binds on both report and derivation statements, and data reset confirms against the setting name. Refs #521 (ADR-0091 phase 4).

- **Refactors**
  - Brief ranker: fetch base currency once via `identity`, pass as a bind, remove the workspace join.
  - Forecast slipped-category: write the zone as `<<installation-timezone>>`, substitute a bind at assembly on both report and derivation statements; bind only when used; keep Postgres date arithmetic.
  - Data reset: confirmation matches `installation.name` instead of `workspace.name`.
  - Tests: seed settings in the forecast fixture; grant `installation_settings:read`; seed a commit deal with a close date to force the CASE to evaluate; add a flip-to-500 test when the setting names an unresolvable zone; update the reset test to confirm with the setting’s name.
  - Note: three readers intentionally remain on the column (bootstrap backfill, pre-principal session naming, first-write base-currency freeze); column drops are out of scope here.

<sup>Written for commit 86e7b937b92e05c599775831bac6a1cff483cbc7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/857?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

