### PR TITLE
test(compose): the channel suites become their own lane slot

### DIFF
--- a/backend/internal/compose/integration/apptest/earlypool.go
+++ b/backend/internal/compose/integration/apptest/earlypool.go
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package apptest
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/gradionhq/margince/backend/internal/platform/database"
+)
+
+// EarlyPool opens a pool onto the app database BEFORE the harness boots, for the
+// one thing that has to exist first: a suite that needs a row in the vault (a
+// stored Google credential, say) must write it before SetupAppWithOptions builds
+// the composition that reads it.
+//
+// It lives here because both this package's callers and the suite packages split
+// out of internal/compose/integration need it, and a fixture keyed on nothing but
+// *testing.T has no reason to sit in either one of them.
+func EarlyPool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	appDSN := os.Getenv("MARGINCE_TEST_APP_DSN")
+	if appDSN == "" {
+		t.Fatal("MARGINCE_TEST_APP_DSN not set — run `make db-up` (integration tests fail loudly, they never skip)")
+	}
+	pool, err := database.NewPool(context.Background(), appDSN)
+	if err != nil {
+		t.Fatalf("opening the pre-boot pool: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	return pool
+}

--- a/backend/internal/compose/integration/apptest/inworkspace.go
+++ b/backend/internal/compose/integration/apptest/inworkspace.go
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package apptest
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// InWorkspace runs fn on the owner connection under the bootstrapped workspace's
+// GUC. FORCE RLS applies to the owner too, so a tenant table is unreachable
+// without it.
+//
+// It lives in apptest rather than beside the suites that call it because it takes
+// an AppEnv: the parent integration package's ordinary files cannot import
+// apptest without closing an import cycle through compose, so a fixture keyed on
+// this type has exactly one home that every suite package can reach.
+func InWorkspace(e *AppEnv, t *testing.T, slug string, fn func(pgx.Tx) error) error {
+	t.Helper()
+	ctx := context.Background()
+	tx, err := e.Owner.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	//craft:ignore swallowed-errors error-path safety net only — the Commit below is asserted, after which this rollback is a designed no-op
+	defer func() { _ = tx.Rollback(ctx) }()
+	var wsID string
+	if err := tx.QueryRow(ctx, `SELECT id FROM workspace WHERE slug = $1`, slug).Scan(&wsID); err != nil {
+		return err
+	}
+	if _, err := tx.Exec(ctx, `SELECT set_config('app.workspace_id', $1, true)`, wsID); err != nil {
+		return err
+	}
+	if err := fn(tx); err != nil {
+		return err
+	}
+	return tx.Commit(ctx)
+}

--- a/backend/internal/compose/integration/authz_integration_test.go
+++ b/backend/internal/compose/integration/authz_integration_test.go
@@ -32,21 +32,21 @@ func TestObjectLevelRBACDeniesUngrantedActions(t *testing.T) {
 	if _, err := e.People.CreatePerson(reader, people.CreatePersonInput{FullName: "X", Source: "manual"}); !errors.Is(err, apperrors.ErrPermissionDenied) {
 		t.Errorf("read_only create → %v, want ErrPermissionDenied", err)
 	}
-	if _, err := e.People.UpdatePerson(reader, personIDOf(target), people.UpdatePersonInput{Title: strPtr("CEO")}); !errors.Is(err, apperrors.ErrPermissionDenied) {
+	if _, err := e.People.UpdatePerson(reader, PersonIDOf(target), people.UpdatePersonInput{Title: strPtr("CEO")}); !errors.Is(err, apperrors.ErrPermissionDenied) {
 		t.Errorf("read_only update → %v, want ErrPermissionDenied", err)
 	}
-	if _, err := e.People.ArchivePerson(reader, personIDOf(target)); !errors.Is(err, apperrors.ErrPermissionDenied) {
+	if _, err := e.People.ArchivePerson(reader, PersonIDOf(target)); !errors.Is(err, apperrors.ErrPermissionDenied) {
 		t.Errorf("read_only archive → %v, want ErrPermissionDenied", err)
 	}
 	// …but reading is granted, and row_scope=all sees the foreign-owned row.
-	if _, err := e.People.GetPerson(reader, personIDOf(target), storekit.LiveOnly); err != nil {
+	if _, err := e.People.GetPerson(reader, PersonIDOf(target), storekit.LiveOnly); err != nil {
 		t.Errorf("read_only get → %v, want success", err)
 	}
 
 	// A rep (no delete grant on person) cannot archive even an OWN record:
 	// object-level denial precedes row scope.
 	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, RepPerms)
-	if _, err := e.People.ArchivePerson(rep, personIDOf(target)); !errors.Is(err, apperrors.ErrPermissionDenied) {
+	if _, err := e.People.ArchivePerson(rep, PersonIDOf(target)); !errors.Is(err, apperrors.ErrPermissionDenied) {
 		t.Errorf("rep archive own → %v, want ErrPermissionDenied", err)
 	}
 }
@@ -76,11 +76,11 @@ func TestRowScopeTeamNeverShowsAnotherTeamsRecord(t *testing.T) {
 
 	// Single fetch: the foreign row answers 404 — never the row, and
 	// never a 403 that would disclose its existence.
-	if _, err := e.People.GetPerson(rep, personIDOf(foreign), storekit.LiveOnly); !errors.Is(err, apperrors.ErrNotFound) {
+	if _, err := e.People.GetPerson(rep, PersonIDOf(foreign), storekit.LiveOnly); !errors.Is(err, apperrors.ErrNotFound) {
 		t.Errorf("get another team's record → %v, want ErrNotFound", err)
 	}
 	// Nor can it be mutated blind by id.
-	if _, err := e.People.UpdatePerson(rep, personIDOf(foreign), people.UpdatePersonInput{Title: strPtr("Pwned")}); !errors.Is(err, apperrors.ErrNotFound) {
+	if _, err := e.People.UpdatePerson(rep, PersonIDOf(foreign), people.UpdatePersonInput{Title: strPtr("Pwned")}); !errors.Is(err, apperrors.ErrNotFound) {
 		t.Errorf("update another team's record → %v, want ErrNotFound", err)
 	}
 

--- a/backend/internal/compose/integration/channels/channelidentity_erasurelock_integration_test.go
+++ b/backend/internal/compose/integration/channels/channelidentity_erasurelock_integration_test.go
@@ -3,7 +3,7 @@
 
 //go:build integration
 
-package integration
+package channels
 
 // The mutex between an Art. 17 erasure and an inbound message from the very
 // account being erased. Both sides must take the same per-account lock or the
@@ -33,6 +33,7 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 
+	"github.com/gradionhq/margince/backend/internal/compose/integration"
 	"github.com/gradionhq/margince/backend/internal/modules/privacy"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
@@ -69,7 +70,7 @@ func lockWaitBoundedPool(t *testing.T) *pgxpool.Pool {
 // that holds one account's identity lock, and reports what the erasure did.
 // The holder is the caller's own transaction, so the lock is provably held for
 // the entire erasure — no goroutine, no clock, no ordering to get lucky with.
-func eraseWhileAccountIsLocked(t *testing.T, e *Env, person ids.UUID, lockedAccount string) error {
+func eraseWhileAccountIsLocked(t *testing.T, e *integration.Env, person ids.UUID, lockedAccount string) error {
 	t.Helper()
 	eraser := privacy.NewEraser(lockWaitBoundedPool(t))
 	admin := e.Admin()
@@ -100,7 +101,7 @@ func eraseWhileAccountIsLocked(t *testing.T, e *Env, person ids.UUID, lockedAcco
 // transaction, so the overlap is a window of seconds, not microseconds, for a
 // subject who keeps messaging while their own erasure runs.
 func TestErasureWaitsForAnInFlightDeliveryOfTheSubjectsAccount(t *testing.T) {
-	e := Setup(t)
+	e := integration.Setup(t)
 	person := e.SeedPerson(t, "Locked Subject", nil)
 	seedChannelIdentity(t, e, person, "10108", "locked")
 
@@ -121,7 +122,7 @@ func TestErasureWaitsForAnInFlightDeliveryOfTheSubjectsAccount(t *testing.T) {
 // per ACCOUNT, so a delivery for someone else never delays an erasure — and the
 // failure above is the lock, not the bounded pool.
 func TestErasureIsUnaffectedByALockOnAnotherAccount(t *testing.T) {
-	e := Setup(t)
+	e := integration.Setup(t)
 	person := e.SeedPerson(t, "Unrelated Subject", nil)
 	seedChannelIdentity(t, e, person, "10109", "unrelated")
 
@@ -138,7 +139,7 @@ func TestErasureIsUnaffectedByALockOnAnotherAccount(t *testing.T) {
 
 // liveIdentityExists asks whether one provider account is still bound to
 // anybody at all — the state an erasure must leave empty.
-func liveIdentityExists(t *testing.T, e *Env, channelUserID string) bool {
+func liveIdentityExists(t *testing.T, e *integration.Env, channelUserID string) bool {
 	t.Helper()
 	return e.WsCount(t,
 		`SELECT count(*) FROM person_channel_identity WHERE provider = $1 AND channel_user_id = $2`,

--- a/backend/internal/compose/integration/channels/channelidentity_lifecycle_integration_test.go
+++ b/backend/internal/compose/integration/channels/channelidentity_lifecycle_integration_test.go
@@ -3,7 +3,7 @@
 
 //go:build integration
 
-package integration
+package channels
 
 // person_channel_identity is a person satellite, so it owes every lifecycle
 // path its siblings ride: Art. 17 erasure (plus the suppression row that makes
@@ -26,6 +26,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
+	"github.com/gradionhq/margince/backend/internal/compose/integration"
 	"github.com/gradionhq/margince/backend/internal/modules/privacy"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
@@ -41,7 +42,7 @@ const telegramProvider = "telegram"
 // must be unique per test: the live unique index spans (provider,
 // channel_user_id) without person_id, deliberately, because one account is one
 // human across the whole installation.
-func seedChannelIdentity(t *testing.T, e *Env, person ids.UUID, channelUserID, username string) {
+func seedChannelIdentity(t *testing.T, e *integration.Env, person ids.UUID, channelUserID, username string) {
 	t.Helper()
 	e.WsExec(t, `
 		INSERT INTO person_channel_identity
@@ -52,7 +53,7 @@ func seedChannelIdentity(t *testing.T, e *Env, person ids.UUID, channelUserID, u
 }
 
 // liveIdentities counts the person's un-archived channel identities.
-func liveIdentities(t *testing.T, e *Env, person ids.UUID) int {
+func liveIdentities(t *testing.T, e *integration.Env, person ids.UUID) int {
 	t.Helper()
 	return e.WsCount(t,
 		`SELECT count(*) FROM person_channel_identity WHERE person_id = $1 AND archived_at IS NULL`, person)
@@ -60,7 +61,7 @@ func liveIdentities(t *testing.T, e *Env, person ids.UUID) int {
 
 // suppressed asks the same probe the ingest paths ask: is this account an
 // erased subject's?
-func suppressed(t *testing.T, e *Env, channelUserID string) bool {
+func suppressed(t *testing.T, e *integration.Env, channelUserID string) bool {
 	t.Helper()
 	ctx := principal.WithWorkspaceID(context.Background(), e.WS)
 	var answer bool
@@ -75,7 +76,7 @@ func suppressed(t *testing.T, e *Env, channelUserID string) bool {
 }
 
 func TestErasurePurgesTheChannelIdentityAndSuppressesTheAccount(t *testing.T) {
-	e := Setup(t)
+	e := integration.Setup(t)
 	admin := e.Admin()
 	person := e.SeedPerson(t, "Tomas Telegram", nil)
 	seedChannelIdentity(t, e, person, "10101", "tomas")
@@ -83,7 +84,7 @@ func TestErasurePurgesTheChannelIdentityAndSuppressesTheAccount(t *testing.T) {
 	// Art. 15 hands the binding back while it is held — asserted BEFORE the
 	// erasure, so the emptiness afterwards measures the erasure and not a
 	// section that never worked.
-	pkg, err := privacy.AssembleSAR(admin, e.Pool, personIDOf(person))
+	pkg, err := privacy.AssembleSAR(admin, e.Pool, integration.PersonIDOf(person))
 	if err != nil {
 		t.Fatalf("AssembleSAR: %v", err)
 	}
@@ -142,8 +143,8 @@ func TestErasurePurgesTheChannelIdentityAndSuppressesTheAccount(t *testing.T) {
 // suppression list stays empty — suppressing here would silently bar a person
 // the workspace is free to re-capture.
 func TestRetentionAnonymizeDropsTheChannelIdentityWithoutSuppressingIt(t *testing.T) {
-	e := Setup(t)
-	seedRetentionPolicies(t, e)
+	e := integration.Setup(t)
+	integration.SeedRetentionPolicies(t, e)
 	person := e.SeedPerson(t, "Otto Overage", nil)
 	seedChannelIdentity(t, e, person, "30303", "otto")
 	// Past the seeded person/no_consent_no_deal window (730 days), with no
@@ -151,7 +152,7 @@ func TestRetentionAnonymizeDropsTheChannelIdentityWithoutSuppressingIt(t *testin
 	e.WsExec(t, `UPDATE person SET created_at = now() - interval '800 days' WHERE id = $1`, person)
 
 	svc := privacy.NewRetentionService(e.Pool, nil, slog.New(slog.NewTextHandler(io.Discard, nil)))
-	if err := svc.EvaluateWorkspace(RetentionPassCtx(e.WS)); err != nil {
+	if err := svc.EvaluateWorkspace(integration.RetentionPassCtx(e.WS)); err != nil {
 		t.Fatalf("retention pass: %v", err)
 	}
 
@@ -165,16 +166,16 @@ func TestRetentionAnonymizeDropsTheChannelIdentityWithoutSuppressingIt(t *testin
 }
 
 func TestMergeRelinksTheChannelIdentityOntoTheSurvivor(t *testing.T) {
-	e := Setup(t)
+	e := integration.Setup(t)
 	source := e.SeedPerson(t, "Ada Source", nil)
 	target := e.SeedPerson(t, "Ada Target", nil)
 	seedChannelIdentity(t, e, source, "40404", "ada")
 
-	survivor, err := e.People.MergePerson(e.Admin(), personIDOf(source), personIDOf(target))
+	survivor, err := e.People.MergePerson(e.Admin(), integration.PersonIDOf(source), integration.PersonIDOf(target))
 	if err != nil {
 		t.Fatalf("MergePerson: %v", err)
 	}
-	if personIDOf(ids.UUID(survivor.Id)) != personIDOf(target) {
+	if integration.PersonIDOf(ids.UUID(survivor.Id)) != integration.PersonIDOf(target) {
 		t.Fatalf("survivor = %s, want the target %s", survivor.Id, target)
 	}
 
@@ -187,11 +188,11 @@ func TestMergeRelinksTheChannelIdentityOntoTheSurvivor(t *testing.T) {
 }
 
 func TestArchivingAPersonArchivesTheChannelIdentity(t *testing.T) {
-	e := Setup(t)
+	e := integration.Setup(t)
 	person := e.SeedPerson(t, "Vera Vanished", nil)
 	seedChannelIdentity(t, e, person, "50505", "vera")
 
-	if _, err := e.People.ArchivePerson(e.Admin(), personIDOf(person)); err != nil {
+	if _, err := e.People.ArchivePerson(e.Admin(), integration.PersonIDOf(person)); err != nil {
 		t.Fatalf("ArchivePerson: %v", err)
 	}
 
@@ -213,7 +214,7 @@ func TestArchivingAPersonArchivesTheChannelIdentity(t *testing.T) {
 // update_id — irrelevant to the fixture, but it is itself a second place a
 // digit run can appear in the payload, which is exactly what the
 // over-deletion guard test below needs.
-func seedTelegramMessageRaw(t *testing.T, e *Env, sourceID string, messageID int64, senderID, text string) {
+func seedTelegramMessageRaw(t *testing.T, e *integration.Env, sourceID string, messageID int64, senderID, text string) {
 	t.Helper()
 	e.WsExec(t, `
 		INSERT INTO raw_capture (workspace_id, source_system, source_id, payload)
@@ -240,7 +241,7 @@ func seedTelegramMessageRaw(t *testing.T, e *Env, sourceID string, messageID int
 // their user id. A fixture that instead put the customer in new_chat_member.user
 // would agree with a matcher reading that path and prove nothing about
 // production, where such a matcher purges and exports nothing at all.
-func seedTelegramMembershipRaw(t *testing.T, e *Env, sourceID string, updateID int64, senderID, status string) {
+func seedTelegramMembershipRaw(t *testing.T, e *integration.Env, sourceID string, updateID int64, senderID, status string) {
 	t.Helper()
 	e.WsExec(t, `
 		INSERT INTO raw_capture (workspace_id, source_system, source_id, payload)
@@ -257,7 +258,7 @@ func seedTelegramMembershipRaw(t *testing.T, e *Env, sourceID string, updateID i
 // rawCaptureSurvives reports whether exactly one raw_capture row still holds
 // the given source_id — the harness's WsCount wrapped for readability at the
 // call sites below.
-func rawCaptureSurvives(t *testing.T, e *Env, sourceID string) bool {
+func rawCaptureSurvives(t *testing.T, e *integration.Env, sourceID string) bool {
 	t.Helper()
 	return e.WsCount(t,
 		`SELECT count(*) FROM raw_capture WHERE source_system = 'telegram' AND source_id = $1`, sourceID) == 1
@@ -276,7 +277,7 @@ func rawCaptureSurvives(t *testing.T, e *Env, sourceID string) bool {
 // evidence gone — would be the catastrophic failure mode here, worse than the
 // under-deleting one this task fixes.
 func TestErasureOfAChannelOnlySubjectPurgesRawCaptureWithoutOverreaching(t *testing.T) {
-	e := Setup(t)
+	e := integration.Setup(t)
 	admin := e.Admin()
 
 	subject := e.SeedPerson(t, "Ilya Channel-Only", nil)
@@ -328,7 +329,7 @@ func TestErasureOfAChannelOnlySubjectPurgesRawCaptureWithoutOverreaching(t *test
 // history — an Art. 15 failure as real as erasure's, and just as silent,
 // because nothing about assembling an incomplete package errors or logs.
 func TestSARIncludesAChannelOnlySubjectsRawCapture(t *testing.T) {
-	e := Setup(t)
+	e := integration.Setup(t)
 	subject := e.SeedPerson(t, "Nadia Channel-Only", nil)
 	seedChannelIdentity(t, e, subject, "40404", "nadia")
 	seedTelegramMessageRaw(t, e, "sar-message", 5, "40404", "hi from telegram")
@@ -339,7 +340,7 @@ func TestSARIncludesAChannelOnlySubjectsRawCapture(t *testing.T) {
 	seedChannelIdentity(t, e, unrelated, "50506", "boris")
 	seedTelegramMessageRaw(t, e, "sar-unrelated-message", 7, "50506", "not the subject")
 
-	pkg, err := privacy.AssembleSAR(e.Admin(), e.Pool, personIDOf(subject))
+	pkg, err := privacy.AssembleSAR(e.Admin(), e.Pool, integration.PersonIDOf(subject))
 	if err != nil {
 		t.Fatalf("AssembleSAR: %v", err)
 	}
@@ -362,7 +363,7 @@ func TestSARIncludesAChannelOnlySubjectsRawCapture(t *testing.T) {
 // seedPersonEmail binds one address to a person. person_email's dedupe index
 // is partial on archived_at IS NULL exactly like the channel one's, which is
 // what makes the two halves of the guard below the SAME defect.
-func seedPersonEmail(t *testing.T, e *Env, person ids.UUID, email string) {
+func seedPersonEmail(t *testing.T, e *integration.Env, person ids.UUID, email string) {
 	t.Helper()
 	e.WsExec(t, `
 		INSERT INTO person_email (workspace_id, person_id, email, source, captured_by)
@@ -376,11 +377,11 @@ func seedPersonEmail(t *testing.T, e *Env, person ids.UUID, email string) {
 // archived row, and a SECOND Person is created holding a live binding for the
 // same account. uq_person_channel_identity admits it — it is partial on
 // archived_at IS NULL. Returns both records.
-func archiveAndRebindTheAccount(t *testing.T, e *Env, account, handle string) (archived, live ids.UUID) {
+func archiveAndRebindTheAccount(t *testing.T, e *integration.Env, account, handle string) (archived, live ids.UUID) {
 	t.Helper()
 	archived = e.SeedPerson(t, "Ada Archived", nil)
 	seedChannelIdentity(t, e, archived, account, handle)
-	if _, err := e.People.ArchivePerson(e.Admin(), personIDOf(archived)); err != nil {
+	if _, err := e.People.ArchivePerson(e.Admin(), integration.PersonIDOf(archived)); err != nil {
 		t.Fatalf("ArchivePerson: %v", err)
 	}
 	live = e.SeedPerson(t, "Ada Writes Again", nil)
@@ -402,7 +403,7 @@ func archiveAndRebindTheAccount(t *testing.T, e *Env, account, handle string) (a
 // duplicates, then erase the survivor — and it leaves the installation
 // untouched, which the assertions below insist on.
 func TestErasureRefusesWhenAnotherLivePersonHoldsTheSameChannelAccount(t *testing.T) {
-	e := Setup(t)
+	e := integration.Setup(t)
 	archived, live := archiveAndRebindTheAccount(t, e, "60601", "ada")
 	seedTelegramMessageRaw(t, e, "rival-account-message", 11, "60601", "written to the surviving record")
 
@@ -429,10 +430,10 @@ func TestErasureRefusesWhenAnotherLivePersonHoldsTheSameChannelAccount(t *testin
 // covering both satellites (erasure_rivals.go) rather than a fix applied to
 // whichever one was reported.
 func TestErasureRefusesWhenAnotherLivePersonHoldsTheSameEmail(t *testing.T) {
-	e := Setup(t)
+	e := integration.Setup(t)
 	archived := e.SeedPerson(t, "Bruno Archived", nil)
 	seedPersonEmail(t, e, archived, "bruno@rival.test")
-	if _, err := e.People.ArchivePerson(e.Admin(), personIDOf(archived)); err != nil {
+	if _, err := e.People.ArchivePerson(e.Admin(), integration.PersonIDOf(archived)); err != nil {
 		t.Fatalf("ArchivePerson: %v", err)
 	}
 	live := e.SeedPerson(t, "Bruno Captured Again", nil)
@@ -455,7 +456,7 @@ func TestErasureRefusesWhenAnotherLivePersonHoldsTheSameEmail(t *testing.T) {
 // row that would otherwise go on holding the erased human's account id and
 // handle after the erasure certified them gone.
 func TestErasingTheLiveRecordAlsoClearsAnArchivedDuplicatesBinding(t *testing.T) {
-	e := Setup(t)
+	e := integration.Setup(t)
 	_, live := archiveAndRebindTheAccount(t, e, "60701", "beatrix")
 
 	if n := e.WsCount(t,

--- a/backend/internal/compose/integration/channels/doc.go
+++ b/backend/internal/compose/integration/channels/doc.go
@@ -11,9 +11,9 @@
 //
 // It is a suite package split out of internal/compose/integration so the lane
 // has another scheduling slot: one package is one slot, and the parent is large
-// enough to be the lane's long pole by itself. Measured, these suites are 14.8s
-// of the parent's 160s. It rides the parent's exported fixtures and apptest's,
-// and owns its own connector stubs, seeding and assertions.
+// enough to be the lane's long pole by itself. It rides the parent's exported
+// fixtures and apptest's, and owns its own connector stubs, seeding and
+// assertions.
 //
 // The boundary is where the fixtures fall, not where the names suggest. Three
 // neighbours that read as if they belong here stay in the parent, each for the

--- a/backend/internal/compose/integration/channels/doc.go
+++ b/backend/internal/compose/integration/channels/doc.go
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+// Package channels holds the messaging-channel integration suites: Telegram
+// ingress end to end (the webhook, the normalized sink and its idempotency, the
+// round trip back out, and erasure reaching the raw capture), and the channel
+// identity a handle resolves to — its lifecycle, suppression, rebinding onto a
+// new account, and the lock that erasure must respect.
+//
+// It is a suite package split out of internal/compose/integration so the lane
+// has another scheduling slot: one package is one slot, and the parent is large
+// enough to be the lane's long pole by itself. Measured, these suites are 14.8s
+// of the parent's 160s. It rides the parent's exported fixtures and apptest's,
+// and owns its own connector stubs, seeding and assertions.
+//
+// The boundary is where the fixtures fall, not where the names suggest. Three
+// neighbours that read as if they belong here stay in the parent, each for the
+// same reason — a fixture they share with suites that are not moving:
+//
+//   - channelsend and send_preflight share the preflight environment and the
+//     Google scope constants with each other and with comms_send.
+//   - comms_send and messageidentity build on that same preflight environment.
+//   - channelsend_mcp asserts through the sealed tool envelope, whose helpers are
+//     five types deep in the parent's _test.go files and reachable from nowhere
+//     else.
+//
+// Moving any of them would mean promoting those fixtures to importable files for
+// one caller, which trades a clear boundary for a wider one.
+package channels

--- a/backend/internal/compose/integration/channels/statutoryfloor_test.go
+++ b/backend/internal/compose/integration/channels/statutoryfloor_test.go
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package channels
+
+import (
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/compose/integration"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/jurisdiction"
+)
+
+// The statutory retention floor, armed for THIS binary. The jurisdiction registry
+// is process-global and one package is one binary, so the parent package's own
+// arming does not reach here: this file is the registration travelling with the
+// erasure suite that moved out of internal/compose/integration.
+//
+// Do not rename this file to anything ending in a GOOS or GOARCH word. Go reads
+// the segment before _test.go as an implicit build constraint, so a plausible
+// name like jurisdiction_arm_test.go is silently dropped on every machine whose
+// GOARCH is not literally arm — the registration then never happens, and the
+// suite below reports the missing floor as a missing shield.
+func init() {
+	integration.RegisterGoBDFloorPack()
+}
+
+// TestTheStatutoryFloorIsArmedForThisBinary is the guard the erasure suites
+// cannot be: an absent floor makes the destructive path succeed, so a suite that
+// asserts the shield would go green for the opposite of the intended reason.
+// This asserts the registration itself, where a failure names its own cause.
+func TestTheStatutoryFloorIsArmedForThisBinary(t *testing.T) {
+	for _, pack := range jurisdiction.Applicable() {
+		retention := pack.Retention()
+		if retention == nil {
+			continue
+		}
+		for _, class := range retention.Classes() {
+			if class.Name == jurisdiction.CommercialCorrespondence {
+				return
+			}
+		}
+	}
+	t.Fatal("no pack in this binary declares a commercial-correspondence floor — the erasure suites here would pass by proving nothing")
+}

--- a/backend/internal/compose/integration/channels/statutoryfloor_test.go
+++ b/backend/internal/compose/integration/channels/statutoryfloor_test.go
@@ -30,17 +30,32 @@ func init() {
 // cannot be: an absent floor makes the destructive path succeed, so a suite that
 // asserts the shield would go green for the opposite of the intended reason.
 // This asserts the registration itself, where a failure names its own cause.
+//
+// It asserts THIS pack and the span the suites were written against, not merely
+// that some pack declares a correspondence class. A different pack satisfying the
+// weaker check would let this pass while the floor the erasure assertions depend
+// on is absent or shortened — the same false green by another route.
 func TestTheStatutoryFloorIsArmedForThisBinary(t *testing.T) {
+	want := integration.GoBDFloorPack{}
 	for _, pack := range jurisdiction.Applicable() {
-		retention := pack.Retention()
-		if retention == nil {
+		if pack.Code() != want.Code() {
 			continue
 		}
-		for _, class := range retention.Classes() {
-			if class.Name == jurisdiction.CommercialCorrespondence {
-				return
-			}
+		retention := pack.Retention()
+		if retention == nil {
+			t.Fatalf("pack %q is registered but declares no retention", pack.Code())
 		}
+		for _, class := range retention.Classes() {
+			if class.Name != jurisdiction.CommercialCorrespondence {
+				continue
+			}
+			if class.Keep.Years != 6 || class.Anchor != jurisdiction.AnchorCalendarYearEnd {
+				t.Fatalf("the correspondence floor is %+v, want six years anchored to calendar-year end — the erasure suites here are written against that span",
+					class)
+			}
+			return
+		}
+		t.Fatalf("pack %q declares no commercial-correspondence class", pack.Code())
 	}
-	t.Fatal("no pack in this binary declares a commercial-correspondence floor — the erasure suites here would pass by proving nothing")
+	t.Fatalf("pack %q is not registered in this binary — the erasure suites here would pass by proving nothing", want.Code())
 }

--- a/backend/internal/compose/integration/channels/telegram_fixture_integration_test.go
+++ b/backend/internal/compose/integration/channels/telegram_fixture_integration_test.go
@@ -3,7 +3,7 @@
 
 //go:build integration
 
-package integration
+package channels
 
 // The shared fixture the Telegram acceptance suite rides: the composed api
 // role with the channel surface live, the ONE faked boundary (the Telegram
@@ -34,6 +34,7 @@ import (
 	"github.com/riverqueue/river"
 
 	"github.com/gradionhq/margince/backend/internal/compose"
+	"github.com/gradionhq/margince/backend/internal/compose/integration"
 	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 	"github.com/gradionhq/margince/backend/internal/modules/capture"
 	"github.com/gradionhq/margince/backend/internal/modules/capture/telegram"
@@ -207,7 +208,7 @@ func setupTelegram(t *testing.T) *telegramEnv {
 	// The vault and the job inserter both need a pool before apptest.SetupAppWithOptions
 	// has opened the harness's own — the separate-connection precedent
 	// setupPreflight uses for exactly this reason.
-	pool := preflightAppPool(t)
+	pool := apptest.EarlyPool(t)
 	key := make([]byte, 32)
 	if _, err := rand.Read(key); err != nil {
 		t.Fatalf("generating a test root key: %v", err)
@@ -242,7 +243,7 @@ func setupTelegram(t *testing.T) *telegramEnv {
 // carries a real composite foreign key.
 func (c *telegramEnv) resolveActors(t *testing.T) {
 	t.Helper()
-	if err := inWorkspace(c.AppEnv, t, c.Slug, func(tx pgx.Tx) error {
+	if err := apptest.InWorkspace(c.AppEnv, t, c.Slug, func(tx pgx.Tx) error {
 		return tx.QueryRow(context.Background(),
 			`SELECT workspace_id, id FROM app_user WHERE email = $1`, telegramAdminEmail).Scan(&c.ws, &c.admin)
 	}); err != nil {
@@ -436,7 +437,7 @@ func (c *telegramEnv) pollNow(t *testing.T, sub <-chan *river.Event, wantOffset 
 func (c *telegramEnv) pollCursor(t *testing.T) int64 {
 	t.Helper()
 	var offset int64
-	if err := inWorkspace(c.AppEnv, t, c.Slug, func(tx pgx.Tx) error {
+	if err := apptest.InWorkspace(c.AppEnv, t, c.Slug, func(tx pgx.Tx) error {
 		return tx.QueryRow(context.Background(),
 			`SELECT poll_offset FROM channel_connection WHERE id = $1`, c.conn.ID).Scan(&offset)
 	}); err != nil {
@@ -450,7 +451,7 @@ func (c *telegramEnv) pollCursor(t *testing.T) int64 {
 // the batch was never acknowledged, so the next poll asks for it again.
 func (c *telegramEnv) rewindPollCursor(t *testing.T, offset int64) {
 	t.Helper()
-	if err := inWorkspace(c.AppEnv, t, c.Slug, func(tx pgx.Tx) error {
+	if err := apptest.InWorkspace(c.AppEnv, t, c.Slug, func(tx pgx.Tx) error {
 		_, err := tx.Exec(context.Background(),
 			`UPDATE channel_connection SET poll_offset = $2 WHERE id = $1`, c.conn.ID, offset)
 		return err
@@ -466,7 +467,7 @@ func (c *telegramEnv) rewindPollCursor(t *testing.T, offset int64) {
 func (c *telegramEnv) count(t *testing.T, query string, args ...any) int {
 	t.Helper()
 	var n int
-	if err := inWorkspace(c.AppEnv, t, c.Slug, func(tx pgx.Tx) error {
+	if err := apptest.InWorkspace(c.AppEnv, t, c.Slug, func(tx pgx.Tx) error {
 		return tx.QueryRow(context.Background(), query, args...).Scan(&n)
 	}); err != nil {
 		t.Fatalf("counting (%s): %v", query, err)
@@ -508,7 +509,7 @@ func (c *telegramEnv) ingestJobs(t *testing.T) int {
 // client and this suite would reach api.telegram.org.
 func newTelegramWorker(t *testing.T, c *telegramEnv, cfg compose.JobRunnerConfig) (*jobs.Runner, <-chan *river.Event) {
 	t.Helper()
-	ApplyRiverSchema(t)
+	integration.ApplyRiverSchema(t)
 	cfg.CloseDateInterval, cfg.ReconcileInterval, cfg.TimeScanInterval = time.Hour, time.Hour, time.Hour
 	cfg.ChannelVault, cfg.ChannelAPI = c.vault, c.api
 	runner, err := compose.NewJobRunner(c.Pool, c.log, cfg)
@@ -545,5 +546,5 @@ func awaitJobKind(t *testing.T, sub <-chan *river.Event, kind string) {
 	t.Helper()
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
-	AwaitKindCompleted(ctx, t, sub, kind)
+	integration.AwaitKindCompleted(ctx, t, sub, kind)
 }

--- a/backend/internal/compose/integration/channels/telegram_identity_integration_test.go
+++ b/backend/internal/compose/integration/channels/telegram_identity_integration_test.go
@@ -3,7 +3,7 @@
 
 //go:build integration
 
-package integration
+package channels
 
 // The identity and lifecycle half of the Telegram acceptance suite
 // (telegram-oa design §7, §10): what happens when two exact lanes disagree,
@@ -28,6 +28,7 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/gradionhq/margince/backend/internal/compose"
+	"github.com/gradionhq/margince/backend/internal/compose/integration"
 	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 	"github.com/gradionhq/margince/backend/internal/modules/capture"
 	"github.com/gradionhq/margince/backend/internal/modules/people"
@@ -53,7 +54,7 @@ func (c *telegramEnv) adminStoreCtx(t *testing.T) context.Context {
 	ctx := principal.WithWorkspaceID(context.Background(), c.workspaceID(t))
 	ctx = principal.WithActor(ctx, principal.Principal{
 		Type: principal.PrincipalHuman, ID: "human:" + c.admin, UserID: user,
-		SeatType: principal.SeatFull, Permissions: AdminPerms,
+		SeatType: principal.SeatFull, Permissions: integration.AdminPerms,
 	})
 	return principal.WithCorrelationID(ctx, ids.NewV7())
 }
@@ -221,7 +222,7 @@ func (c *telegramEnv) seedPerson(t *testing.T, name string, phone *string) strin
 // there (which AC-TG-3 already proves).
 func (c *telegramEnv) bindChannelIdentity(t *testing.T, person string, identity connector.ChannelIdentity) {
 	t.Helper()
-	if err := inWorkspace(c.AppEnv, t, c.Slug, func(tx pgx.Tx) error {
+	if err := apptest.InWorkspace(c.AppEnv, t, c.Slug, func(tx pgx.Tx) error {
 		_, err := tx.Exec(context.Background(), `
 			INSERT INTO person_channel_identity
 			  (workspace_id, person_id, provider, channel_user_id, username, source, captured_by)
@@ -355,7 +356,7 @@ func TestTwoConcurrentFirstMessagesYieldOnePersonAndTwoActivities(t *testing.T) 
 	// across two people is the failure this convergence exists to prevent.
 	var links int
 	var linkedPeople int
-	if err := inWorkspace(c.AppEnv, t, c.Slug, func(tx pgx.Tx) error {
+	if err := apptest.InWorkspace(c.AppEnv, t, c.Slug, func(tx pgx.Tx) error {
 		return tx.QueryRow(context.Background(), `
 			SELECT count(*), count(DISTINCT l.person_id)
 			  FROM activity_link l JOIN activity a ON a.id = l.activity_id

--- a/backend/internal/compose/integration/channels/telegram_ingress_integration_test.go
+++ b/backend/internal/compose/integration/channels/telegram_ingress_integration_test.go
@@ -3,7 +3,7 @@
 
 //go:build integration
 
-package integration
+package channels
 
 // The ingress half of the Telegram acceptance suite (telegram-oa design v2 §3):
 // what an inbound message leaves behind once the real poll has collected it and
@@ -51,7 +51,7 @@ const captureLatencyBudget = 60 * time.Second
 // marker, not a captured conversation.
 func (c *telegramEnv) capturedMessage(t *testing.T, u telegramUpdate) (activityID, personID string) {
 	t.Helper()
-	if err := inWorkspace(c.AppEnv, t, c.Slug, func(tx pgx.Tx) error {
+	if err := apptest.InWorkspace(c.AppEnv, t, c.Slug, func(tx pgx.Tx) error {
 		return tx.QueryRow(context.Background(), `
 			SELECT a.id::text, l.person_id::text
 			  FROM activity a
@@ -119,7 +119,7 @@ func TestAC_TG_3_UnknownSenderBecomesOwnerlessWorkspaceVisiblePerson(t *testing.
 
 	var ownerID *string
 	var fullName string
-	if err := inWorkspace(c.AppEnv, t, c.Slug, func(tx pgx.Tx) error {
+	if err := apptest.InWorkspace(c.AppEnv, t, c.Slug, func(tx pgx.Tx) error {
 		return tx.QueryRow(context.Background(),
 			`SELECT owner_id::text, full_name FROM person WHERE id = $1`, personID).
 			Scan(&ownerID, &fullName)
@@ -142,7 +142,7 @@ func TestAC_TG_3_UnknownSenderBecomesOwnerlessWorkspaceVisiblePerson(t *testing.
 		t.Errorf("%d email rows beside the channel identity, want 0", n)
 	}
 	var boundUsername, identitySource, identityCapturedBy string
-	if err := inWorkspace(c.AppEnv, t, c.Slug, func(tx pgx.Tx) error {
+	if err := apptest.InWorkspace(c.AppEnv, t, c.Slug, func(tx pgx.Tx) error {
 		return tx.QueryRow(context.Background(), `
 			SELECT username, source, captured_by FROM person_channel_identity
 			 WHERE provider = 'telegram' AND channel_user_id = $1`, u.account()).
@@ -280,7 +280,7 @@ func TestAC_TG_5_MailGatesAreNoOpsForAChannelRecord(t *testing.T) {
 	c := setupTelegramConnected(t)
 	// The workspace's own mail domain, so the colleagues gate has something to
 	// find if anything asks it about a record with no domain.
-	if err := inWorkspace(c.AppEnv, t, c.Slug, func(tx pgx.Tx) error {
+	if err := apptest.InWorkspace(c.AppEnv, t, c.Slug, func(tx pgx.Tx) error {
 		_, err := tx.Exec(context.Background(),
 			`INSERT INTO workspace_email_domain (workspace_id, domain) VALUES ($1, 'own-house.test')`, c.ws)
 		return err
@@ -353,7 +353,7 @@ func TestCaptureLatencyIsMeasuredOnTheAsyncPathNotThePollCommit(t *testing.T) {
 	}
 
 	injectedReceipt := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
-	if err := inWorkspace(c.AppEnv, t, c.Slug, func(tx pgx.Tx) error {
+	if err := apptest.InWorkspace(c.AppEnv, t, c.Slug, func(tx pgx.Tx) error {
 		_, err := tx.Exec(context.Background(),
 			`UPDATE raw_capture SET received_at = $2
 			  WHERE source_system = 'telegram' AND payload->>'update_id' = $1`,
@@ -364,7 +364,7 @@ func TestCaptureLatencyIsMeasuredOnTheAsyncPathNotThePollCommit(t *testing.T) {
 	}
 
 	var receivedAt, createdAt, occurredAt time.Time
-	if err := inWorkspace(c.AppEnv, t, c.Slug, func(tx pgx.Tx) error {
+	if err := apptest.InWorkspace(c.AppEnv, t, c.Slug, func(tx pgx.Tx) error {
 		ctx := context.Background()
 		if err := tx.QueryRow(ctx,
 			`SELECT received_at FROM raw_capture

--- a/backend/internal/compose/integration/channels/telegram_integration_test.go
+++ b/backend/internal/compose/integration/channels/telegram_integration_test.go
@@ -3,7 +3,7 @@
 
 //go:build integration
 
-package integration
+package channels
 
 // The Telegram channel acceptance suite (telegram-oa design §12, TG-CR-3's
 // AC-TG-1…6). It is the last gate before a real bot is pointed at this code:
@@ -26,6 +26,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 	"github.com/gradionhq/margince/backend/internal/platform/keyvault"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
@@ -76,7 +77,7 @@ func TestAC_TG_1_ConnectValidatesSealsAndRecordsAuditOnly(t *testing.T) {
 func (c *telegramEnv) assertTokenSealed(t *testing.T) {
 	t.Helper()
 	var credentialRef string
-	if err := inWorkspace(c.AppEnv, t, c.Slug, func(tx pgx.Tx) error {
+	if err := apptest.InWorkspace(c.AppEnv, t, c.Slug, func(tx pgx.Tx) error {
 		return tx.QueryRow(context.Background(),
 			`SELECT credential_ref FROM channel_connection WHERE id = $1`, c.conn.ID).Scan(&credentialRef)
 	}); err != nil {

--- a/backend/internal/compose/integration/channels/telegram_roundtrip_integration_test.go
+++ b/backend/internal/compose/integration/channels/telegram_roundtrip_integration_test.go
@@ -3,7 +3,7 @@
 
 //go:build integration
 
-package integration
+package channels
 
 // The full Telegram round trip (telegram-oa design §1, §8, §12): a stranger's
 // message arrives at the mounted webhook, becomes a conversation against a
@@ -199,7 +199,7 @@ func TestCustomerReplyNamesTheChannelItArrivedOn(t *testing.T) {
 		t.Fatalf("%d engagement.reply events, want exactly 1 — the formula emits once per inbound message", n)
 	}
 	var channel, contactID string
-	if err := inWorkspace(c.AppEnv, t, c.Slug, func(tx pgx.Tx) error {
+	if err := apptest.InWorkspace(c.AppEnv, t, c.Slug, func(tx pgx.Tx) error {
 		return tx.QueryRow(context.Background(), `
 			SELECT envelope->'payload'->>'channel',
 			       coalesce(envelope->'payload'->>'contact_id', '')
@@ -259,7 +259,7 @@ func TestAnArchivedOutboundIsNotAConversationToReplyInto(t *testing.T) {
 
 	// The rep takes their message back off the timeline, leaving the thread with
 	// no LIVE outbound in it.
-	if err := inWorkspace(c.AppEnv, t, c.Slug, func(tx pgx.Tx) error {
+	if err := apptest.InWorkspace(c.AppEnv, t, c.Slug, func(tx pgx.Tx) error {
 		_, err := tx.Exec(context.Background(),
 			`UPDATE activity SET archived_at = now() WHERE id = $1`, sent.ID)
 		return err
@@ -331,7 +331,7 @@ func TestAForgedThreadKeyCannotReplyIntoAnotherMediumsConversation(t *testing.T)
 	// The thread key that outbound is filed under is what an attacker would
 	// forge, so the test reads the real one rather than reconstructing it.
 	var forged string
-	if err := inWorkspace(c.AppEnv, t, c.Slug, func(tx pgx.Tx) error {
+	if err := apptest.InWorkspace(c.AppEnv, t, c.Slug, func(tx pgx.Tx) error {
 		return tx.QueryRow(context.Background(),
 			`SELECT thread_key FROM activity WHERE id = $1`, activityID).Scan(&forged)
 	}); err != nil {
@@ -441,7 +441,7 @@ func (c *telegramEnv) assertDeliveryRecorded(t *testing.T, sentActivityID string
 	var recipient, status, deliveryActivity string
 	var providerMessageID *string
 	var subject, messageID *string
-	if err := inWorkspace(c.AppEnv, t, c.Slug, func(tx pgx.Tx) error {
+	if err := apptest.InWorkspace(c.AppEnv, t, c.Slug, func(tx pgx.Tx) error {
 		return tx.QueryRow(context.Background(), `
 			SELECT channel_user_id, status, activity_id::text, provider_message_id, subject, message_id
 			  FROM comms_outbound WHERE channel_user_id IS NOT NULL`).
@@ -471,7 +471,7 @@ func (c *telegramEnv) assertDeliveryRecorded(t *testing.T, sentActivityID string
 	// Capture joins inbound messages against outbound activities on thread_key,
 	// so a reply filed anywhere else reads as a message out of nowhere.
 	var threadKey, linkedPerson string
-	if err := inWorkspace(c.AppEnv, t, c.Slug, func(tx pgx.Tx) error {
+	if err := apptest.InWorkspace(c.AppEnv, t, c.Slug, func(tx pgx.Tx) error {
 		ctx := context.Background()
 		if err := tx.QueryRow(ctx,
 			`SELECT coalesce(thread_key, '') FROM activity WHERE id = $1`, sentActivityID).Scan(&threadKey); err != nil {

--- a/backend/internal/compose/integration/channels/telegram_sinkerasure_integration_test.go
+++ b/backend/internal/compose/integration/channels/telegram_sinkerasure_integration_test.go
@@ -3,7 +3,7 @@
 
 //go:build integration
 
-package integration
+package channels
 
 // The mutex between an Art. 17 erasure and the transaction that makes a channel
 // record DURABLE — the activity write, not the ingress edge that admitted it.
@@ -36,6 +36,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 
+	"github.com/gradionhq/margince/backend/internal/compose/integration"
 	"github.com/gradionhq/margince/backend/internal/modules/capture"
 	"github.com/gradionhq/margince/backend/internal/modules/privacy"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
@@ -49,7 +50,7 @@ import (
 // sinkConnectorCtx is the principal the ingest worker acts as: a connector
 // acting for no human, permitted to create the activity it captures and the
 // person that activity names.
-func sinkConnectorCtx(e *Env) context.Context {
+func sinkConnectorCtx(e *integration.Env) context.Context {
 	ctx := principal.WithWorkspaceID(context.Background(), e.WS)
 	ctx = principal.WithActor(ctx, principal.Principal{
 		Type: principal.PrincipalConnector, ID: "connector:telegram",
@@ -107,7 +108,7 @@ func inboundChannelRecordAt(account, body string, at time.Time) connector.Normal
 // activityBodyCount counts activities holding this exact text, whatever they are
 // linked to. It deliberately does NOT join person or activity_link: the whole
 // point of the defect is that the surviving row is joined to nothing.
-func activityBodyCount(t *testing.T, e *Env, body string) int {
+func activityBodyCount(t *testing.T, e *integration.Env, body string) int {
 	t.Helper()
 	return e.WsCount(t, `SELECT count(*) FROM activity WHERE body = $1`, body)
 }
@@ -116,7 +117,7 @@ func activityBodyCount(t *testing.T, e *Env, body string) int {
 // be able to commit the activity after it: the row would outlive the erasure
 // that certified it gone, permanently beyond every lane that could remove it.
 func TestTheSinkRefusesARecordNamingAnErasedChannelAccount(t *testing.T) {
-	e := Setup(t)
+	e := integration.Setup(t)
 	person := e.SeedPerson(t, "Erased Subject", nil)
 	seedChannelIdentity(t, e, person, "20301", "erased")
 
@@ -140,7 +141,7 @@ func TestTheSinkRefusesARecordNamingAnErasedChannelAccount(t *testing.T) {
 // probe and its write, and the activity lands anyway. Holding the lock for the
 // whole call proves Upsert waits for it.
 func TestTheSinkWaitsForAnErasureHoldingTheRecordsAccount(t *testing.T) {
-	e := Setup(t)
+	e := integration.Setup(t)
 	person := e.SeedPerson(t, "Live Subject", nil)
 	seedChannelIdentity(t, e, person, "20302", "live")
 
@@ -173,7 +174,7 @@ func TestTheSinkWaitsForAnErasureHoldingTheRecordsAccount(t *testing.T) {
 // ACCOUNT, so an erasure of somebody else never delays this capture — and the
 // failure above is the lock, not the bounded pool.
 func TestTheSinkIsUnaffectedByALockOnAnotherAccount(t *testing.T) {
-	e := Setup(t)
+	e := integration.Setup(t)
 	person := e.SeedPerson(t, "Live Subject", nil)
 	seedChannelIdentity(t, e, person, "20303", "live")
 
@@ -209,7 +210,7 @@ func TestTheSinkIsUnaffectedByALockOnAnotherAccount(t *testing.T) {
 // "some error occurred" would keep passing if the gate were deleted and an
 // unrelated fault took its place.
 func TestTheSinkRefusesACounterpartyNamedTwice(t *testing.T) {
-	e := Setup(t)
+	e := integration.Setup(t)
 
 	rec := inboundChannelRecord("20304", "named twice")
 	rec.Counterparty.Email = "someone@example.com"
@@ -233,7 +234,7 @@ func TestTheSinkRefusesACounterpartyNamedTwice(t *testing.T) {
 // This test builds exactly that state: a Sink with no channel ensurer wired
 // never writes the link at all, which is the same row the race produces.
 func TestAnErasureReachesAChannelActivityWithNoPersonLink(t *testing.T) {
-	e := Setup(t)
+	e := integration.Setup(t)
 	person := e.SeedPerson(t, "Orphaned Subject", nil)
 	seedChannelIdentity(t, e, person, "20401", "orphaned")
 
@@ -267,7 +268,7 @@ func TestAnErasureReachesAChannelActivityWithNoPersonLink(t *testing.T) {
 // row — would redact other people's timelines. This pins that erasing one
 // subject touches only their own account's rows.
 func TestAnErasureLeavesAnotherAccountsChannelActivityUntouched(t *testing.T) {
-	e := Setup(t)
+	e := integration.Setup(t)
 	erased := e.SeedPerson(t, "Erased Subject", nil)
 	seedChannelIdentity(t, e, erased, "20501", "erased")
 	bystander := e.SeedPerson(t, "Bystander", nil)
@@ -309,7 +310,7 @@ func TestAnErasureLeavesAnotherAccountsChannelActivityUntouched(t *testing.T) {
 // under a commercial-correspondence floor is wrong, that is a product and legal
 // question for the spec, not a change to make here.
 func TestARecentChannelMessageIsShieldedFromErasureByTheStatutoryFloor(t *testing.T) {
-	e := Setup(t)
+	e := integration.Setup(t)
 	person := e.SeedPerson(t, "Recent Subject", nil)
 	seedChannelIdentity(t, e, person, "20601", "recent")
 
@@ -331,7 +332,7 @@ func TestARecentChannelMessageIsShieldedFromErasureByTheStatutoryFloor(t *testin
 // a provider-less identity would lock and probe a key space the eraser never
 // touches — the erasure gate would pass while an erasure was mid-purge.
 func TestTheSinkRefusesHalfAChannelIdentity(t *testing.T) {
-	e := Setup(t)
+	e := integration.Setup(t)
 
 	rec := inboundChannelRecord("20305", "half an identity")
 	rec.Counterparty.ChannelIdentity.Provider = ""

--- a/backend/internal/compose/integration/channelsend_integration_test.go
+++ b/backend/internal/compose/integration/channelsend_integration_test.go
@@ -59,7 +59,7 @@ func setupChannelSend(t *testing.T) *channelSendEnv {
 	if _, err := rand.Read(key); err != nil {
 		t.Fatalf("generating a test root key: %v", err)
 	}
-	vault, err := keyvault.New(keyvault.Config{RootKey: key, Pool: preflightAppPool(t)})
+	vault, err := keyvault.New(keyvault.Config{RootKey: key, Pool: apptest.EarlyPool(t)})
 	if err != nil {
 		t.Fatalf("building the local vault: %v", err)
 	}
@@ -82,7 +82,7 @@ func setupChannelSend(t *testing.T) *channelSendEnv {
 		t.Fatalf("create person → %d", status)
 	}
 	c.personID = person.ID
-	if err := inWorkspace(e, t, e.Slug, func(tx pgx.Tx) error {
+	if err := apptest.InWorkspace(e, t, e.Slug, func(tx pgx.Tx) error {
 		return tx.QueryRow(context.Background(),
 			`SELECT workspace_id, id FROM app_user WHERE email = $1`, "rep@fable.test").Scan(&c.ws, &c.user)
 	}); err != nil {
@@ -100,7 +100,7 @@ func setupChannelSend(t *testing.T) *channelSendEnv {
 // reads out of it, not how ingress puts it there.
 func (c *channelSendEnv) bindIdentity(t *testing.T) {
 	t.Helper()
-	if err := inWorkspace(c.AppEnv, t, c.Slug, func(tx pgx.Tx) error {
+	if err := apptest.InWorkspace(c.AppEnv, t, c.Slug, func(tx pgx.Tx) error {
 		_, err := tx.Exec(context.Background(), `
 			INSERT INTO person_channel_identity
 				(workspace_id, person_id, provider, channel_user_id, username, source, captured_by)
@@ -117,7 +117,7 @@ func (c *channelSendEnv) bindIdentity(t *testing.T) {
 // the shape capture leaves behind.
 func (c *channelSendEnv) seedInboundMessage(t *testing.T) {
 	t.Helper()
-	if err := inWorkspace(c.AppEnv, t, c.Slug, func(tx pgx.Tx) error {
+	if err := apptest.InWorkspace(c.AppEnv, t, c.Slug, func(tx pgx.Tx) error {
 		ctx := context.Background()
 		if err := tx.QueryRow(ctx, `
 			INSERT INTO activity (workspace_id, kind, body, occurred_at, direction,
@@ -171,7 +171,7 @@ func (c *channelSendEnv) grantConsent(t *testing.T, key string) {
 // vault — so its value is deliberately opaque here.
 func (c *channelSendEnv) connectBot(t *testing.T) {
 	t.Helper()
-	if err := inWorkspace(c.AppEnv, t, c.Slug, func(tx pgx.Tx) error {
+	if err := apptest.InWorkspace(c.AppEnv, t, c.Slug, func(tx pgx.Tx) error {
 		_, err := tx.Exec(context.Background(), `
 			INSERT INTO channel_connection
 				(workspace_id, provider, channel_id, channel_label, credential_ref, status, connected_by)
@@ -232,7 +232,7 @@ func (c *channelSendEnv) sendReplyAs(t *testing.T, scopes []string, purpose stri
 func (c *channelSendEnv) stagedChannelDeliveries(t *testing.T) int {
 	t.Helper()
 	var n int
-	if err := inWorkspace(c.AppEnv, t, c.Slug, func(tx pgx.Tx) error {
+	if err := apptest.InWorkspace(c.AppEnv, t, c.Slug, func(tx pgx.Tx) error {
 		return tx.QueryRow(context.Background(),
 			`SELECT count(*) FROM comms_outbound WHERE channel_user_id IS NOT NULL`).Scan(&n)
 	}); err != nil {
@@ -246,7 +246,7 @@ func (c *channelSendEnv) stagedChannelDeliveries(t *testing.T) int {
 func (c *channelSendEnv) outboundActivities(t *testing.T) int {
 	t.Helper()
 	var n int
-	if err := inWorkspace(c.AppEnv, t, c.Slug, func(tx pgx.Tx) error {
+	if err := apptest.InWorkspace(c.AppEnv, t, c.Slug, func(tx pgx.Tx) error {
 		return tx.QueryRow(context.Background(),
 			`SELECT count(*) FROM activity WHERE direction = 'outbound'`).Scan(&n)
 	}); err != nil {
@@ -321,7 +321,7 @@ func TestSendMessageAcceptsAHumanCallerWithoutAToken(t *testing.T) {
 	// caller.
 	var recipient, body, provider string
 	var subject, messageID *string
-	if err := inWorkspace(c.AppEnv, t, c.Slug, func(tx pgx.Tx) error {
+	if err := apptest.InWorkspace(c.AppEnv, t, c.Slug, func(tx pgx.Tx) error {
 		return tx.QueryRow(context.Background(),
 			`SELECT channel_user_id, body, provider, subject, message_id
 			   FROM comms_outbound WHERE channel_user_id IS NOT NULL`).
@@ -346,7 +346,7 @@ func TestSendMessageAcceptsAHumanCallerWithoutAToken(t *testing.T) {
 // park where the rep never looks.
 func TestSendMessageRefusesWhenNoBotIsBoundForTheChannel(t *testing.T) {
 	c := setupChannelSend(t)
-	if err := inWorkspace(c.AppEnv, t, c.Slug, func(tx pgx.Tx) error {
+	if err := apptest.InWorkspace(c.AppEnv, t, c.Slug, func(tx pgx.Tx) error {
 		_, err := tx.Exec(context.Background(), `UPDATE channel_connection SET status = 'disconnected'`)
 		return err
 	}); err != nil {
@@ -411,7 +411,7 @@ func TestSendMessageRefusesWithoutConsentForThePurpose(t *testing.T) {
 // reply must be refused on reachability rather than accepted and parked.
 func TestSendMessageRefusesAnUnreachablePerson(t *testing.T) {
 	c := setupChannelSend(t)
-	if err := inWorkspace(c.AppEnv, t, c.Slug, func(tx pgx.Tx) error {
+	if err := apptest.InWorkspace(c.AppEnv, t, c.Slug, func(tx pgx.Tx) error {
 		_, err := tx.Exec(context.Background(),
 			`UPDATE person_channel_identity SET blocked_at = now() WHERE channel_user_id = $1`, channelSendAccountID)
 		return err
@@ -453,7 +453,7 @@ func TestSentMessageLandsAsAnOutboundActivity(t *testing.T) {
 
 	var threadKey, linkedPerson string
 	var deliveryActivity string
-	if err := inWorkspace(c.AppEnv, t, c.Slug, func(tx pgx.Tx) error {
+	if err := apptest.InWorkspace(c.AppEnv, t, c.Slug, func(tx pgx.Tx) error {
 		ctx := context.Background()
 		if err := tx.QueryRow(ctx,
 			`SELECT coalesce(thread_key, '') FROM activity WHERE id = $1`, sent.ID).Scan(&threadKey); err != nil {

--- a/backend/internal/compose/integration/channelsend_mcp_integration_test.go
+++ b/backend/internal/compose/integration/channelsend_mcp_integration_test.go
@@ -129,7 +129,7 @@ func TestSendMessageMCPLoopStagesApprovesAndRedeemsAgainstRealPostgres(t *testin
 	// delivery anchors on — otherwise the response could name any activity while
 	// the delivery transmits a different one.
 	var deliveryActivity string
-	if err := inWorkspace(c.AppEnv, t, c.Slug, func(tx pgx.Tx) error {
+	if err := apptest.InWorkspace(c.AppEnv, t, c.Slug, func(tx pgx.Tx) error {
 		return tx.QueryRow(context.Background(),
 			`SELECT activity_id::text FROM comms_outbound WHERE channel_user_id IS NOT NULL`).Scan(&deliveryActivity)
 	}); err != nil {

--- a/backend/internal/compose/integration/channelsend_no_gmail_integration_test.go
+++ b/backend/internal/compose/integration/channelsend_no_gmail_integration_test.go
@@ -48,7 +48,7 @@ func setupChannelSendNoGmail(t *testing.T) *channelSendEnv {
 	if _, err := rand.Read(key); err != nil {
 		t.Fatalf("generating a test root key: %v", err)
 	}
-	vault, err := keyvault.New(keyvault.Config{RootKey: key, Pool: preflightAppPool(t)})
+	vault, err := keyvault.New(keyvault.Config{RootKey: key, Pool: apptest.EarlyPool(t)})
 	if err != nil {
 		t.Fatalf("building the local vault: %v", err)
 	}
@@ -64,7 +64,7 @@ func setupChannelSendNoGmail(t *testing.T) *channelSendEnv {
 		t.Fatalf("create person → %d", status)
 	}
 	c.personID = person.ID
-	if err := inWorkspace(e, t, e.Slug, func(tx pgx.Tx) error {
+	if err := apptest.InWorkspace(e, t, e.Slug, func(tx pgx.Tx) error {
 		return tx.QueryRow(context.Background(),
 			`SELECT workspace_id, id FROM app_user WHERE email = $1`, "rep@fable.test").Scan(&c.ws, &c.user)
 	}); err != nil {

--- a/backend/internal/compose/integration/comms_send_integration_test.go
+++ b/backend/internal/compose/integration/comms_send_integration_test.go
@@ -115,7 +115,7 @@ func (p *preflightEnv) deliveryFor(t *testing.T, activityID ids.UUID) (ids.UUID,
 	t.Helper()
 	var id ids.UUID
 	var messageID string
-	if err := inWorkspace(p.AppEnv, t, p.Slug, func(tx pgx.Tx) error {
+	if err := apptest.InWorkspace(p.AppEnv, t, p.Slug, func(tx pgx.Tx) error {
 		return tx.QueryRow(context.Background(),
 			`SELECT id, message_id FROM comms_outbound WHERE activity_id = $1`, activityID).Scan(&id, &messageID)
 	}); err != nil {
@@ -256,7 +256,7 @@ func TestCapturedCopyOfASentEmailCollapsesOntoTheSameActivity(t *testing.T) {
 	}
 
 	var rows int
-	if err := inWorkspace(p.AppEnv, t, p.Slug, func(tx pgx.Tx) error {
+	if err := apptest.InWorkspace(p.AppEnv, t, p.Slug, func(tx pgx.Tx) error {
 		return tx.QueryRow(context.Background(),
 			`SELECT count(*) FROM activity WHERE source_system = $1 AND source_id = $2`,
 			sourceSystem, messageID).Scan(&rows)
@@ -272,7 +272,7 @@ func TestCapturedCopyOfASentEmailCollapsesOntoTheSameActivity(t *testing.T) {
 	// has to be stamped at send or the conversation has no identity.
 	var id ids.UUID
 	var threadKey *string
-	if err := inWorkspace(p.AppEnv, t, p.Slug, func(tx pgx.Tx) error {
+	if err := apptest.InWorkspace(p.AppEnv, t, p.Slug, func(tx pgx.Tx) error {
 		return tx.QueryRow(context.Background(),
 			`SELECT id, thread_key FROM activity WHERE source_system = $1 AND source_id = $2`,
 			sourceSystem, messageID).Scan(&id, &threadKey)
@@ -412,7 +412,7 @@ func TestASenderDowngradedToAReadSeatParksAStagedDelivery(t *testing.T) {
 // path reads out of the row, not how the admin endpoint puts it there.
 func (p *preflightEnv) deactivateSender(t *testing.T) {
 	t.Helper()
-	if err := inWorkspace(p.AppEnv, t, p.Slug, func(tx pgx.Tx) error {
+	if err := apptest.InWorkspace(p.AppEnv, t, p.Slug, func(tx pgx.Tx) error {
 		_, err := tx.Exec(context.Background(),
 			`UPDATE app_user SET status = 'deactivated' WHERE id = $1`, p.user)
 		return err
@@ -427,7 +427,7 @@ func (p *preflightEnv) deactivateSender(t *testing.T) {
 // from.
 func (p *preflightEnv) downgradeSenderToReadSeat(t *testing.T) {
 	t.Helper()
-	if err := inWorkspace(p.AppEnv, t, p.Slug, func(tx pgx.Tx) error {
+	if err := apptest.InWorkspace(p.AppEnv, t, p.Slug, func(tx pgx.Tx) error {
 		_, err := tx.Exec(context.Background(),
 			`UPDATE app_user SET seat_type = 'read' WHERE id = $1`, p.user)
 		return err
@@ -440,7 +440,7 @@ func (p *preflightEnv) downgradeSenderToReadSeat(t *testing.T) {
 func (p *preflightEnv) deliveryReason(t *testing.T, deliveryID ids.UUID) string {
 	t.Helper()
 	var reason *string
-	if err := inWorkspace(p.AppEnv, t, p.Slug, func(tx pgx.Tx) error {
+	if err := apptest.InWorkspace(p.AppEnv, t, p.Slug, func(tx pgx.Tx) error {
 		return tx.QueryRow(context.Background(),
 			`SELECT reason FROM comms_outbound WHERE id = $1`, deliveryID).Scan(&reason)
 	}); err != nil {

--- a/backend/internal/compose/integration/concurrency_integration_test.go
+++ b/backend/internal/compose/integration/concurrency_integration_test.go
@@ -83,7 +83,7 @@ func TestConcurrentMergesNeverStrandChildrenOnADeadRecord(t *testing.T) {
 		if err != nil {
 			t.Fatalf("create %s: %v", name, err)
 		}
-		return personIDOf(ids.UUID(p.Id))
+		return PersonIDOf(ids.UUID(p.Id))
 	}
 	a := mkPerson("Person A", "a@merge-race.test")
 	b := mkPerson("Person B", "b@merge-race.test")
@@ -139,7 +139,7 @@ func TestMergeWithdrawalCarriesAConsentProofEvent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create target: %v", err)
 	}
-	srcID, tgtID := personIDOf(ids.UUID(src.Id)), personIDOf(ids.UUID(tgt.Id))
+	srcID, tgtID := PersonIDOf(ids.UUID(src.Id)), PersonIDOf(ids.UUID(tgt.Id))
 
 	purpose := ids.NewV7()
 	e.WsExec(t, `INSERT INTO consent_purpose (id, workspace_id, key, label) VALUES ($1, $2, 'marketing_email', 'Marketing')`, purpose, e.WS)

--- a/backend/internal/compose/integration/customfields_values_deal_integration_test.go
+++ b/backend/internal/compose/integration/customfields_values_deal_integration_test.go
@@ -202,5 +202,5 @@ func seedDealFixtureIn(ctx context.Context, t *testing.T, store *deals.Store) (i
 	return ids.PipelineID{}, ids.StageID{}
 }
 
-// dealIDOf mirrors personIDOf/orgIDOf for the deal suites.
+// dealIDOf mirrors PersonIDOf/orgIDOf for the deal suites.
 func dealIDOf(u ids.UUID) ids.DealID { return ids.From[ids.DealKind](u) }

--- a/backend/internal/compose/integration/customfields_values_integration_test.go
+++ b/backend/internal/compose/integration/customfields_values_integration_test.go
@@ -112,13 +112,13 @@ func TestCustomFieldValues_PersonRoundTrip(t *testing.T) {
 	}
 	assertCF(t, created.AdditionalProperties, col, "gold")
 
-	got, err := f.store.GetPerson(f.ctx, personIDOf(ids.UUID(created.Id)), storekit.LiveOnly)
+	got, err := f.store.GetPerson(f.ctx, PersonIDOf(ids.UUID(created.Id)), storekit.LiveOnly)
 	if err != nil {
 		t.Fatalf("GetPerson: %v", err)
 	}
 	assertCF(t, got.AdditionalProperties, col, "gold")
 
-	updated, err := f.store.UpdatePerson(f.ctx, personIDOf(ids.UUID(created.Id)), people.UpdatePersonInput{
+	updated, err := f.store.UpdatePerson(f.ctx, PersonIDOf(ids.UUID(created.Id)), people.UpdatePersonInput{
 		CustomFields: map[string]any{col: "silver"},
 	})
 	if err != nil {
@@ -207,7 +207,7 @@ func TestCustomFieldValues_AllSixTypesRoundTrip(t *testing.T) {
 		t.Fatalf("CreatePerson: %v", err)
 	}
 
-	got, err := f.store.GetPerson(f.ctx, personIDOf(ids.UUID(created.Id)), storekit.LiveOnly)
+	got, err := f.store.GetPerson(f.ctx, PersonIDOf(ids.UUID(created.Id)), storekit.LiveOnly)
 	if err != nil {
 		t.Fatalf("GetPerson: %v", err)
 	}
@@ -236,17 +236,17 @@ func TestCustomFieldValues_WrongShapeDropped(t *testing.T) {
 	}
 	assertNoCF(t, created.AdditionalProperties, col)
 
-	if _, err := f.store.UpdatePerson(f.ctx, personIDOf(ids.UUID(created.Id)), people.UpdatePersonInput{
+	if _, err := f.store.UpdatePerson(f.ctx, PersonIDOf(ids.UUID(created.Id)), people.UpdatePersonInput{
 		CustomFields: map[string]any{col: float64(7)},
 	}); err != nil {
 		t.Fatalf("UpdatePerson (valid shape): %v", err)
 	}
-	if _, err := f.store.UpdatePerson(f.ctx, personIDOf(ids.UUID(created.Id)), people.UpdatePersonInput{
+	if _, err := f.store.UpdatePerson(f.ctx, PersonIDOf(ids.UUID(created.Id)), people.UpdatePersonInput{
 		CustomFields: map[string]any{col: "not-a-number"},
 	}); err != nil {
 		t.Fatalf("UpdatePerson with mismatched value shape: %v", err)
 	}
-	got, err := f.store.GetPerson(f.ctx, personIDOf(ids.UUID(created.Id)), storekit.LiveOnly)
+	got, err := f.store.GetPerson(f.ctx, PersonIDOf(ids.UUID(created.Id)), storekit.LiveOnly)
 	if err != nil {
 		t.Fatalf("GetPerson: %v", err)
 	}
@@ -385,14 +385,14 @@ func TestCustomFieldValues_RetiredFieldHiddenButPreserved(t *testing.T) {
 		t.Fatalf("Retire: %v", err)
 	}
 
-	got, err := f.store.GetPerson(f.ctx, personIDOf(ids.UUID(created.Id)), storekit.LiveOnly)
+	got, err := f.store.GetPerson(f.ctx, PersonIDOf(ids.UUID(created.Id)), storekit.LiveOnly)
 	if err != nil {
 		t.Fatalf("GetPerson after retire: %v", err)
 	}
 	assertNoCF(t, got.AdditionalProperties, col)
 
 	// A write against the retired key is dropped like any unknown key.
-	if _, err := f.store.UpdatePerson(f.ctx, personIDOf(ids.UUID(created.Id)), people.UpdatePersonInput{
+	if _, err := f.store.UpdatePerson(f.ctx, PersonIDOf(ids.UUID(created.Id)), people.UpdatePersonInput{
 		CustomFields: map[string]any{col: "silver"},
 	}); err != nil {
 		t.Fatalf("UpdatePerson against retired key: %v", err)
@@ -453,7 +453,7 @@ func TestCustomFieldValues_WorkspaceIsolation(t *testing.T) {
 	}
 
 	// Tenant A still reads its value.
-	gotA, err := f.store.GetPerson(f.ctx, personIDOf(ids.UUID(inA.Id)), storekit.LiveOnly)
+	gotA, err := f.store.GetPerson(f.ctx, PersonIDOf(ids.UUID(inA.Id)), storekit.LiveOnly)
 	if err != nil {
 		t.Fatalf("GetPerson (tenant A): %v", err)
 	}
@@ -474,7 +474,7 @@ func TestCustomFieldValues_UpdateAuditCarriesDiff(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreatePerson: %v", err)
 	}
-	if _, err := f.store.UpdatePerson(f.ctx, personIDOf(ids.UUID(created.Id)), people.UpdatePersonInput{
+	if _, err := f.store.UpdatePerson(f.ctx, PersonIDOf(ids.UUID(created.Id)), people.UpdatePersonInput{
 		CustomFields: map[string]any{col: "silver"},
 	}); err != nil {
 		t.Fatalf("UpdatePerson: %v", err)

--- a/backend/internal/compose/integration/fieldhistory_integration_test.go
+++ b/backend/internal/compose/integration/fieldhistory_integration_test.go
@@ -458,7 +458,7 @@ func TestFieldHistoryProjectsOnlyFieldImageVerbs(t *testing.T) {
 // happened on the record.
 func TestFieldHistoryExcludesRetentionArchiveMeta(t *testing.T) {
 	e := Setup(t)
-	seedRetentionPolicies(t, e)
+	SeedRetentionPolicies(t, e)
 	_, _, staleDeal, _ := seedOverAgeRecords(t, e)
 
 	svc := privacy.NewRetentionService(e.Pool, nil, slog.New(slog.NewTextHandler(os.Stderr, nil)))

--- a/backend/internal/compose/integration/grants_integration_test.go
+++ b/backend/internal/compose/integration/grants_integration_test.go
@@ -34,7 +34,7 @@ func TestRecordGrantWidensRowScopeAndRevokes(t *testing.T) {
 	peopleStore := people.NewStore(e.Pool)
 
 	// Before the grant: team scope hides rep3's record from rep1.
-	if _, err := peopleStore.GetPerson(repCtx, personIDOf(foreign), storekit.LiveOnly); err == nil {
+	if _, err := peopleStore.GetPerson(repCtx, PersonIDOf(foreign), storekit.LiveOnly); err == nil {
 		t.Fatal("foreign person visible before any grant")
 	}
 	// A search misses it too.
@@ -48,7 +48,7 @@ func TestRecordGrantWidensRowScopeAndRevokes(t *testing.T) {
 
 	// After: the direct read, the search branch, and the link probe all
 	// see the record through the SAME widened predicate.
-	if _, err := peopleStore.GetPerson(repCtx, personIDOf(foreign), storekit.LiveOnly); err != nil {
+	if _, err := peopleStore.GetPerson(repCtx, PersonIDOf(foreign), storekit.LiveOnly); err != nil {
 		t.Fatalf("granted person still hidden: %v", err)
 	}
 	page, err = e.Store.Search(repCtx, search.Input{Query: "Shared Secret"})
@@ -63,7 +63,7 @@ func TestRecordGrantWidensRowScopeAndRevokes(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := peopleStore.GetPerson(repCtx, personIDOf(foreign), storekit.LiveOnly); err == nil {
+	if _, err := peopleStore.GetPerson(repCtx, PersonIDOf(foreign), storekit.LiveOnly); err == nil {
 		t.Fatal("revoked grant still widens visibility")
 	}
 }

--- a/backend/internal/compose/integration/harness.go
+++ b/backend/internal/compose/integration/harness.go
@@ -306,11 +306,11 @@ func (e *Env) AgentCtxWithPassport(passportID ids.UUID) context.Context {
 	})
 }
 
-// personIDOf / orgIDOf / leadIDOf assert a harness-seeded untyped id as
+// PersonIDOf / orgIDOf / leadIDOf assert a harness-seeded untyped id as
 // the entity a people-store call targets — the suites' spelling of the
 // contracts-edge ids.From widening (the harness keeps its fixture ids
 // untyped so every module's suite can share them).
-func personIDOf(u ids.UUID) ids.PersonID    { return ids.From[ids.PersonKind](u) }
+func PersonIDOf(u ids.UUID) ids.PersonID    { return ids.From[ids.PersonKind](u) }
 func orgIDOf(u ids.UUID) ids.OrganizationID { return ids.From[ids.OrganizationKind](u) }
 func leadIDOf(u ids.UUID) ids.LeadID        { return ids.From[ids.LeadKind](u) }
 func projectIDOf(u ids.UUID) ids.ProjectID  { return ids.From[ids.ProjectKind](u) }

--- a/backend/internal/compose/integration/merge_integration_test.go
+++ b/backend/internal/compose/integration/merge_integration_test.go
@@ -45,13 +45,13 @@ func TestMergePerson_relinkSurvivorshipAndReferentialIntegrity(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create target: %v", err)
 	}
-	src, tgt := personIDOf(ids.UUID(source.Id)), personIDOf(ids.UUID(target.Id))
+	src, tgt := PersonIDOf(ids.UUID(source.Id)), PersonIDOf(ids.UUID(target.Id))
 
 	survivor, err := e.People.MergePerson(admin, src, tgt)
 	if err != nil {
 		t.Fatalf("merge: %v", err)
 	}
-	if personIDOf(ids.UUID(survivor.Id)) != tgt {
+	if PersonIDOf(ids.UUID(survivor.Id)) != tgt {
 		t.Fatalf("survivor = %s, want the target %s", survivor.Id, tgt)
 	}
 
@@ -86,7 +86,7 @@ func TestMergePerson_relinkSurvivorshipAndReferentialIntegrity(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read archived source: %v", err)
 	}
-	if archived.MergedIntoId == nil || personIDOf(ids.UUID(*archived.MergedIntoId)) != tgt {
+	if archived.MergedIntoId == nil || PersonIDOf(ids.UUID(*archived.MergedIntoId)) != tgt {
 		t.Errorf("source merged_into_id = %v, want the target %s", archived.MergedIntoId, tgt)
 	}
 }
@@ -107,7 +107,7 @@ func TestMergePerson_consentMergesRestrictively(t *testing.T) {
 	e.WsExec(t, `INSERT INTO person_consent (workspace_id, person_id, purpose_id, state) VALUES ($1, $2, $3, 'withdrawn')`, e.WS, source, purpose)
 	e.WsExec(t, `INSERT INTO person_consent (workspace_id, person_id, purpose_id, state) VALUES ($1, $2, $3, 'granted')`, e.WS, target, purpose)
 
-	if _, err := e.People.MergePerson(admin, personIDOf(source), personIDOf(target)); err != nil {
+	if _, err := e.People.MergePerson(admin, PersonIDOf(source), PersonIDOf(target)); err != nil {
 		t.Fatalf("merge: %v", err)
 	}
 
@@ -221,17 +221,17 @@ func TestMerge_errorPaths(t *testing.T) {
 
 	// Self-merge.
 	var selfErr *people.MergeSelfError
-	if _, err := e.People.MergePerson(admin, personIDOf(a), personIDOf(a)); !errors.As(err, &selfErr) {
+	if _, err := e.People.MergePerson(admin, PersonIDOf(a), PersonIDOf(a)); !errors.As(err, &selfErr) {
 		t.Fatalf("self-merge → %v, want people.MergeSelfError", err)
 	}
 
 	// First merge succeeds; a second merge OF the same source answers
 	// AlreadyMerged with the redirect pointer.
-	if _, err := e.People.MergePerson(admin, personIDOf(a), personIDOf(b)); err != nil {
+	if _, err := e.People.MergePerson(admin, PersonIDOf(a), PersonIDOf(b)); err != nil {
 		t.Fatalf("first merge: %v", err)
 	}
 	var already *people.AlreadyMergedError
-	if _, err := e.People.MergePerson(admin, personIDOf(a), personIDOf(c)); !errors.As(err, &already) {
+	if _, err := e.People.MergePerson(admin, PersonIDOf(a), PersonIDOf(c)); !errors.As(err, &already) {
 		t.Fatalf("re-merge of a merged-away source → %v, want people.AlreadyMergedError", err)
 	} else if already.IntoID != b {
 		t.Errorf("AlreadyMerged points at %s, want the first survivor %s", already.IntoID, b)
@@ -239,7 +239,7 @@ func TestMerge_errorPaths(t *testing.T) {
 
 	// Merging INTO a merged-away (archived) target is refused.
 	var deadTarget *people.MergedTargetError
-	if _, err := e.People.MergePerson(admin, personIDOf(c), personIDOf(a)); !errors.As(err, &deadTarget) {
+	if _, err := e.People.MergePerson(admin, PersonIDOf(c), PersonIDOf(a)); !errors.As(err, &deadTarget) {
 		t.Fatalf("merge into a dead target → %v, want people.MergedTargetError", err)
 	}
 }

--- a/backend/internal/compose/integration/messageidentity_integration_test.go
+++ b/backend/internal/compose/integration/messageidentity_integration_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 	"github.com/gradionhq/margince/backend/internal/modules/capture"
 	"github.com/gradionhq/margince/backend/internal/modules/capture/mailmap"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
@@ -57,7 +58,7 @@ func replyFrom(quoting string) []byte {
 func (p *preflightEnv) activityOnTheStampedIdentity(t *testing.T) ids.UUID {
 	t.Helper()
 	var found []ids.UUID
-	if err := inWorkspace(p.AppEnv, t, p.Slug, func(tx pgx.Tx) error {
+	if err := apptest.InWorkspace(p.AppEnv, t, p.Slug, func(tx pgx.Tx) error {
 		rows, err := tx.Query(context.Background(),
 			`SELECT id FROM activity WHERE source_system = 'gmail' AND source_id = $1`, gmailStamped)
 		if err != nil {
@@ -87,7 +88,7 @@ func (p *preflightEnv) activityOnTheStampedIdentity(t *testing.T) ids.UUID {
 func (p *preflightEnv) countActivities(t *testing.T, where string, args ...any) int {
 	t.Helper()
 	var n int
-	if err := inWorkspace(p.AppEnv, t, p.Slug, func(tx pgx.Tx) error {
+	if err := apptest.InWorkspace(p.AppEnv, t, p.Slug, func(tx pgx.Tx) error {
 		return tx.QueryRow(context.Background(), `SELECT count(*) FROM activity WHERE `+where, args...).Scan(&n)
 	}); err != nil {
 		t.Fatalf("counting the activities matching %q: %v", where, err)
@@ -162,7 +163,7 @@ func TestAnEchoCapturedBeforeTransmitIsAbsorbedByTheReceiptItself(t *testing.T) 
 	// may destroy.
 	var archived bool
 	var released bool
-	if err := inWorkspace(p.AppEnv, t, p.Slug, func(tx pgx.Tx) error {
+	if err := apptest.InWorkspace(p.AppEnv, t, p.Slug, func(tx pgx.Tx) error {
 		return tx.QueryRow(context.Background(),
 			`SELECT archived_at IS NOT NULL, source_id IS NULL FROM activity WHERE id = $1`, echo).
 			Scan(&archived, &released)
@@ -178,7 +179,7 @@ func TestAnEchoCapturedBeforeTransmitIsAbsorbedByTheReceiptItself(t *testing.T) 
 	// Zero breadcrumbs is what distinguishes an absorb that worked from a
 	// reconcile that silently degraded to "receipt recorded, one duplicate".
 	var faults int
-	if err := inWorkspace(p.AppEnv, t, p.Slug, func(tx pgx.Tx) error {
+	if err := apptest.InWorkspace(p.AppEnv, t, p.Slug, func(tx pgx.Tx) error {
 		return tx.QueryRow(context.Background(),
 			`SELECT count(*) FROM system_log WHERE action = 'comms_identity_reconcile_failed'`).Scan(&faults)
 	}); err != nil {
@@ -209,7 +210,7 @@ func TestAGmailRewrittenIdentityStillYieldsOneActivityAndOneReplyTarget(t *testi
 		t.Fatalf("the stamped identity resolves to %s, want the send's own activity %s", id, sentActivity)
 	}
 	var deliveryMessageID string
-	if err := inWorkspace(p.AppEnv, t, p.Slug, func(tx pgx.Tx) error {
+	if err := apptest.InWorkspace(p.AppEnv, t, p.Slug, func(tx pgx.Tx) error {
 		return tx.QueryRow(context.Background(),
 			`SELECT message_id FROM comms_outbound WHERE id = $1`, deliveryID).Scan(&deliveryMessageID)
 	}); err != nil {
@@ -237,7 +238,7 @@ func TestAGmailRewrittenIdentityStillYieldsOneActivityAndOneReplyTarget(t *testi
 	// and must land on the send.
 	p.captureEcho(t, replyFrom(gmailStamped))
 	var matched ids.UUID
-	if err := inWorkspace(p.AppEnv, t, p.Slug, func(tx pgx.Tx) error {
+	if err := apptest.InWorkspace(p.AppEnv, t, p.Slug, func(tx pgx.Tx) error {
 		return tx.QueryRow(context.Background(), `
 			SELECT (envelope->'payload'->>'matched_outbound_activity_id')::uuid
 			  FROM event_outbox

--- a/backend/internal/compose/integration/promote_integration_test.go
+++ b/backend/internal/compose/integration/promote_integration_test.go
@@ -114,7 +114,7 @@ func TestPromoteCreatesAPersonCarryingProvenance(t *testing.T) {
 	if !errors.As(err, &already) {
 		t.Fatalf("re-promote → %v, want people.AlreadyPromotedError", err)
 	}
-	if already.PersonID != personIDOf(ids.UUID(person.Id)) {
+	if already.PersonID != PersonIDOf(ids.UUID(person.Id)) {
 		t.Error("409 lost the promoted_person_id pointer")
 	}
 }

--- a/backend/internal/compose/integration/retention_integration_test.go
+++ b/backend/internal/compose/integration/retention_integration_test.go
@@ -24,28 +24,6 @@ import (
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
-// seedRetentionPolicies plants the same rows the workspace bootstrap
-// seeds (the HTTP-path exactness is asserted in the consent e2e suite).
-func seedRetentionPolicies(t *testing.T, e *Env) {
-	t.Helper()
-	err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
-		_, err := tx.Exec(context.Background(), `
-			INSERT INTO retention_policy (workspace_id, object_type, category, retain_days, action)
-			SELECT NULLIF(current_setting('app.workspace_id', true), '')::uuid, v.o, v.c, v.d, v.a
-			FROM (VALUES
-			  ('lead', 'unconverted', 365, 'anonymize'),
-			  ('activity', NULL, 1095, 'archive'),
-			  ('activity', 'transcript', 365, 'erase'),
-			  ('person', 'no_consent_no_deal', 730, 'anonymize'),
-			  ('deal', 'lost', 1825, 'archive')
-			) AS v(o, c, d, a)`)
-		return err
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-}
-
 // seedOverAgeRecords plants one record per policy branch the engine must
 // act on — a stale unconverted lead, its legal-held twin, an aged
 // transcript activity, and a long-lost deal (with the pipeline/stage
@@ -114,7 +92,7 @@ func seedOverAgeRecords(t *testing.T, e *Env) (staleLead, heldLead, staleDeal, t
 
 func TestRetentionActsOnOverAgeRecordsAndHonorsLegalHold(t *testing.T) {
 	e := Setup(t)
-	seedRetentionPolicies(t, e)
+	SeedRetentionPolicies(t, e)
 	staleLead, heldLead, staleDeal, transcript := seedOverAgeRecords(t, e)
 
 	svc := privacy.NewRetentionService(e.Pool, nil, slog.New(slog.NewTextHandler(os.Stderr, nil)))

--- a/backend/internal/compose/integration/retention_jurisdiction_integration_test.go
+++ b/backend/internal/compose/integration/retention_jurisdiction_integration_test.go
@@ -23,28 +23,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/modules/privacy"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
-	"github.com/gradionhq/margince/backend/internal/shared/ports/jurisdiction"
 )
-
-// gobdFloorPack is the test's own six-calendar-year correspondence
-// floor — the same span the de extension declares. The engine is what
-// this suite proves; the de unit's statutory CONTENT is pinned by its
-// own test lane (extensions/de), and the backend never imports an
-// extension module (TestCompositionWiredOnlyFromCmd), so the floor is
-// registered here the way the boot reconciliation would.
-type gobdFloorPack struct{}
-
-func (gobdFloorPack) Code() jurisdiction.Code { return "zq" }
-
-func (gobdFloorPack) Retention() jurisdiction.Retention { return gobdFloorClasses{} }
-
-type gobdFloorClasses struct{}
-
-func (gobdFloorClasses) Classes() []jurisdiction.RetentionClass {
-	return []jurisdiction.RetentionClass{
-		{Name: jurisdiction.CommercialCorrespondence, Keep: jurisdiction.Period{Years: 6}, Anchor: jurisdiction.AnchorCalendarYearEnd},
-	}
-}
 
 // init mirrors the arming the composed boot performs: the registry is
 // process-global, so registering once arms the floor for THIS BINARY — and one
@@ -53,7 +32,7 @@ func (gobdFloorClasses) Classes() []jurisdiction.RetentionClass {
 // a destructive pass over correspondence would go green precisely because the
 // floor that shields it is absent. A suite that moves out takes this with it.
 func init() {
-	jurisdiction.Register(gobdFloorPack{})
+	RegisterGoBDFloorPack()
 }
 
 func TestStatutoryFloorShieldsCorrespondenceFromDestruction(t *testing.T) {

--- a/backend/internal/compose/integration/send_preflight_integration_test.go
+++ b/backend/internal/compose/integration/send_preflight_integration_test.go
@@ -23,16 +23,13 @@ import (
 	"context"
 	"crypto/rand"
 	"net/http"
-	"os"
 	"strings"
 	"testing"
 
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/gradionhq/margince/backend/internal/compose"
 	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/keyvault"
 )
 
@@ -51,48 +48,6 @@ type preflightEnv struct {
 	activityID string
 	personID   string
 	ws, user   string
-}
-
-// inWorkspace runs fn on the owner connection under the bootstrapped
-// workspace's GUC. FORCE RLS applies to the owner too, so a tenant table is
-// unreachable without it.
-func inWorkspace(e *apptest.AppEnv, t *testing.T, slug string, fn func(pgx.Tx) error) error {
-	t.Helper()
-	ctx := context.Background()
-	tx, err := e.Owner.Begin(ctx)
-	if err != nil {
-		return err
-	}
-	//craft:ignore swallowed-errors error-path safety net only — the Commit below is asserted, after which this rollback is a designed no-op
-	defer func() { _ = tx.Rollback(ctx) }()
-	var wsID string
-	if err := tx.QueryRow(ctx, `SELECT id FROM workspace WHERE slug = $1`, slug).Scan(&wsID); err != nil {
-		return err
-	}
-	if _, err := tx.Exec(ctx, `SELECT set_config('app.workspace_id', $1, true)`, wsID); err != nil {
-		return err
-	}
-	if err := fn(tx); err != nil {
-		return err
-	}
-	return tx.Commit(ctx)
-}
-
-// preflightAppPool opens a second pool onto the same database, because the
-// vault WithGmailCapture needs must exist before apptest.SetupAppWithOptions opens the
-// harness's own (the separate-connection precedent setupEmbedReindex uses).
-func preflightAppPool(t *testing.T) *pgxpool.Pool {
-	t.Helper()
-	appDSN := os.Getenv("MARGINCE_TEST_APP_DSN")
-	if appDSN == "" {
-		t.Fatal("MARGINCE_TEST_APP_DSN not set — run `make db-up` (integration tests fail loudly, they never skip)")
-	}
-	pool, err := database.NewPool(context.Background(), appDSN)
-	if err != nil {
-		t.Fatalf("opening the vault's pool: %v", err)
-	}
-	t.Cleanup(pool.Close)
-	return pool
 }
 
 // setupPreflight boots the api composition WITH the Google app configured, so
@@ -128,7 +83,7 @@ func setupPreflightIn(t *testing.T, extra ...compose.Option) *preflightEnv {
 	if _, err := rand.Read(key); err != nil {
 		t.Fatalf("generating a test root key: %v", err)
 	}
-	vaultPool := preflightAppPool(t)
+	vaultPool := apptest.EarlyPool(t)
 	vault, err := keyvault.New(keyvault.Config{RootKey: key, Pool: vaultPool})
 	if err != nil {
 		t.Fatalf("building the local vault: %v", err)
@@ -188,7 +143,7 @@ func setupPreflightIn(t *testing.T, extra ...compose.Option) *preflightEnv {
 	}
 
 	var ws, user string
-	if err := inWorkspace(e, t, e.Slug, func(tx pgx.Tx) error {
+	if err := apptest.InWorkspace(e, t, e.Slug, func(tx pgx.Tx) error {
 		return tx.QueryRow(context.Background(),
 			`SELECT workspace_id, id FROM app_user WHERE email = $1`, "sender@fable.test").Scan(&ws, &user)
 	}); err != nil {
@@ -233,7 +188,7 @@ func (p *preflightEnv) send(t *testing.T) (status int, code, message string) {
 func (p *preflightEnv) stagedDeliveries(t *testing.T) int {
 	t.Helper()
 	var n int
-	if err := inWorkspace(p.AppEnv, t, p.Slug, func(tx pgx.Tx) error {
+	if err := apptest.InWorkspace(p.AppEnv, t, p.Slug, func(tx pgx.Tx) error {
 		return tx.QueryRow(context.Background(), `SELECT count(*) FROM comms_outbound`).Scan(&n)
 	}); err != nil {
 		t.Fatalf("counting staged deliveries: %v", err)
@@ -246,7 +201,7 @@ func (p *preflightEnv) stagedDeliveries(t *testing.T) int {
 // reads out of the row, not how the OAuth callback puts it there.
 func (p *preflightEnv) connect(t *testing.T, providerScopes ...string) {
 	t.Helper()
-	if err := inWorkspace(p.AppEnv, t, p.Slug, func(tx pgx.Tx) error {
+	if err := apptest.InWorkspace(p.AppEnv, t, p.Slug, func(tx pgx.Tx) error {
 		_, err := tx.Exec(context.Background(), `
 			INSERT INTO capture_connection (workspace_id, provider, user_id, scopes, status, auth, provider_scopes)
 			VALUES ($1, 'gmail', $2, '{}', 'connected', $3, $4)

--- a/backend/internal/compose/integration/smartlist_integration_test.go
+++ b/backend/internal/compose/integration/smartlist_integration_test.go
@@ -145,7 +145,7 @@ func TestDynamicList_reEvaluatesLiveAsRecordsChange(t *testing.T) {
 
 	// Reassign p1 so it no longer matches the filter (rep2 is on the same
 	// team, so p1 stays VISIBLE — it leaves by the filter, not the scope).
-	if _, err := e.People.UpdatePerson(e.Admin(), personIDOf(p1), people.UpdatePersonInput{OwnerID: userIDPtr(&e.Rep2)}); err != nil {
+	if _, err := e.People.UpdatePerson(e.Admin(), PersonIDOf(p1), people.UpdatePersonInput{OwnerID: userIDPtr(&e.Rep2)}); err != nil {
 		t.Fatalf("reassign p1: %v", err)
 	}
 	if has(p1) {

--- a/backend/internal/compose/integration/strength_integration_test.go
+++ b/backend/internal/compose/integration/strength_integration_test.go
@@ -64,7 +64,7 @@ func TestRelationshipStrengthOverSeededRows(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got, err := store.PersonStrength(ctx, personIDOf(person), now)
+	got, err := store.PersonStrength(ctx, PersonIDOf(person), now)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -84,7 +84,7 @@ func TestRelationshipStrengthOverSeededRows(t *testing.T) {
 	}
 
 	// Determinism: the same seed + clock reproduces the same value.
-	again, err := store.PersonStrength(ctx, personIDOf(person), now)
+	again, err := store.PersonStrength(ctx, PersonIDOf(person), now)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/backend/internal/compose/integration/suitefixtures.go
+++ b/backend/internal/compose/integration/suitefixtures.go
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/gradionhq/margince/backend/internal/platform/database"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/jurisdiction"
+)
+
+// Fixtures shared between this package's suites and the suite packages split out
+// of it. They live in a NON-test file on purpose: a subpackage can import
+// identifiers from this package's ordinary files, and nothing at all from its
+// _test.go files, so a helper two suite packages need has to sit here or be
+// copied into each — and a copied seeder drifts from the one it was copied from.
+//
+// The bar for moving a helper here is a caller on BOTH sides of a package
+// boundary. A helper only one suite uses belongs in that suite, next to the test
+// that reads it.
+//
+// This file must not import internal/compose/integration/apptest: apptest
+// imports compose, and compose's white-box tests import this package, so an
+// ordinary file here that reaches apptest closes an import cycle. A fixture that
+// takes an *apptest.AppEnv therefore belongs in apptest, not here.
+
+// GoBDFloorPack is the six-calendar-year correspondence floor the retention
+// suites test against — a stand-in jurisdiction under a reserved code, not the
+// shipped de pack, so a suite asserts the seam rather than one country's law.
+type GoBDFloorPack struct{}
+
+// Code is a reserved two-letter code, so this pack can never collide with a
+// shipped jurisdiction or be mistaken for one in a failure message.
+func (GoBDFloorPack) Code() jurisdiction.Code { return "zq" }
+
+// Retention declares the one class these suites turn on — the commercial
+// correspondence floor.
+//
+//nolint:ireturn // jurisdiction.Pack declares this method returning the interface; a concrete return type would not satisfy it.
+func (GoBDFloorPack) Retention() jurisdiction.Retention { return goBDFloorClasses{} }
+
+type goBDFloorClasses struct{}
+
+func (goBDFloorClasses) Classes() []jurisdiction.RetentionClass {
+	return []jurisdiction.RetentionClass{
+		{Name: jurisdiction.CommercialCorrespondence, Keep: jurisdiction.Period{Years: 6}, Anchor: jurisdiction.AnchorCalendarYearEnd},
+	}
+}
+
+// RegisterGoBDFloorPack arms the floor the way the composed boot does. The
+// registry is process-global and one package is one binary, so every suite
+// package whose tests depend on the floor must call this from its own init —
+// leaving it behind does not fail to compile, it makes a destructive pass over
+// correspondence go green precisely because the floor that shields it is absent.
+func RegisterGoBDFloorPack() {
+	jurisdiction.Register(GoBDFloorPack{})
+}
+
+// SeedRetentionPolicies installs the policy set the retention engine acts on:
+// one row per branch the sweep must take, so a suite asserting an outcome does
+// not also have to state the policy that produced it.
+func SeedRetentionPolicies(t *testing.T, e *Env) {
+	t.Helper()
+	err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		_, err := tx.Exec(context.Background(), `
+			INSERT INTO retention_policy (workspace_id, object_type, category, retain_days, action)
+			SELECT NULLIF(current_setting('app.workspace_id', true), '')::uuid, v.o, v.c, v.d, v.a
+			FROM (VALUES
+			  ('lead', 'unconverted', 365, 'anonymize'),
+			  ('activity', NULL, 1095, 'archive'),
+			  ('activity', 'transcript', 365, 'erase'),
+			  ('person', 'no_consent_no_deal', 730, 'anonymize'),
+			  ('deal', 'lost', 1825, 'archive')
+			) AS v(o, c, d, a)`)
+		return err
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/backend/internal/compose/integration/voice_sendoutcome_integration_test.go
+++ b/backend/internal/compose/integration/voice_sendoutcome_integration_test.go
@@ -180,7 +180,7 @@ func (e *voiceSendEnv) send(t *testing.T, ref, body string) ids.UUID {
 func (e *voiceSendEnv) transmittedBody(t *testing.T, activityID ids.UUID) string {
 	t.Helper()
 	var body string
-	if err := inWorkspace(e.AppEnv, t, e.Slug, func(tx pgx.Tx) error {
+	if err := apptest.InWorkspace(e.AppEnv, t, e.Slug, func(tx pgx.Tx) error {
 		return tx.QueryRow(context.Background(),
 			`SELECT body FROM comms_outbound WHERE activity_id = $1`, activityID).Scan(&body)
 	}); err != nil {


### PR DESCRIPTION
`internal/compose/integration` is the integration lane's long pole — measured,
927 tests and 160s of a 221s wall clock, with seven cores idle while it finishes.
One package is one scheduling slot, so the only thing that shortens the lane is
taking suites out of it. This takes the messaging-channel ones into
`compose/integration/channels`: Telegram ingress end to end, and the channel
identity a handle resolves to.

## The win, sized honestly

The moved suites are **14.8s** of the parent's 160s, and the parent still
measures **155s** afterwards on a loaded machine. The lane's wall clock is set by
the parent either way, so this is a few percent — not a step change.

I over-projected this earlier: four groups looked separable and totalled 46s, but
only one of them is cleanly separable. The rest share one preflight fixture with
suites that must stay, and the boundary here was walked back three times as the
compiler proved it. Reaching the lane's balanced floor (~66s) means moving about
half the package, which is a programme of fixture untangling, not a follow-up.

It is worth landing as the first slice and for the two seams it settles below.

## The boundary is where the fixtures fall, not where the names suggest

Four neighbours that read as if they belong here stay behind, each sharing a
fixture with suites that are not moving: `channelsend`, `send_preflight`,
`comms_send` and `messageidentity` all build on one preflight environment, and
`channelsend_mcp` asserts through the sealed tool envelope, five types deep in the
parent's `_test.go` files. `channels/doc.go` records each exception with its
reason.

Two helpers had callers on both sides and were promoted rather than copied:

- **`InWorkspace` → `apptest`**, not to a shared file in the parent. It takes an
  `*apptest.AppEnv`, and an ordinary file in `integration` cannot import `apptest`
  without closing an import cycle through `compose` — which compose's white-box
  tests complete. `suitefixtures.go` carries that constraint as a comment.
- **The retention-policy seeder and the correspondence-floor pack →
  `suitefixtures.go`**, an ordinary file, because a subpackage can import those
  and nothing at all from a `_test.go` file.

## The floor pack, and a filename that silently disabled it

`jurisdiction` registration is process-global and one package is one binary, so a
suite that moves out leaves the arming behind — with no compile error, and
inverted: the erasure it expects to be REFUSED succeeds, and the assertion reports
the missing floor as a missing shield. The registration travels in
`statutoryfloor_test.go`, and a guard there asserts it directly so the failure
names its own cause.

That file's name is load-bearing. It was first written as
`jurisdiction_arm_test.go`, and Go reads the segment before `_test.go` as an
implicit build constraint: **`arm` is a GOARCH**, so the file was dropped on every
arm64 machine and the registration never happened. The comment says so, because
the obvious name is the broken one.

## Verification

- `make test-it DIR=backend/internal/compose/integration/channels` — green, 32
  tests.
- `make test-it DIR=backend/internal/compose/integration` — green, 155.06s.
- `make test-integration` (full lane) — green, 32 packages, 2126 tests, 0 skips.
- `make check-backend` — green.

No before/after wall-clock number is claimed: this machine degraded badly over the
session (the same package measured 191s and 264s hours apart), and a few percent
cannot be told from that noise. The per-suite seconds above are the measurement
this change rests on.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split the messaging-channel integration suites into `internal/compose/integration/channels` to add a parallel test slot and shave a few percent off the integration lane’s wall time. Shared test helpers and statutory-retention wiring were promoted to keep the boundary clean and reliable.

- **Refactors**
  - Moved Telegram ingress and channel identity suites to `internal/compose/integration/channels` (≈14.8s of the parent; parent still ≈155s).
  - Added `apptest.EarlyPool` for pre-boot vault writes and `apptest.InWorkspace` for workspace-scoped owner queries.
  - Introduced `integration/suitefixtures.go` with `SeedRetentionPolicies` and `RegisterGoBDFloorPack`; retention suites now call the shared registrar.
  - Strengthened `channels/statutoryfloor_test.go` to assert the specific `integration.GoBDFloorPack` and its six-year, calendar-year-end span; also fixes the prior implicit GOARCH filename trap.
  - Updated tests to import `integration`/`apptest` and renamed `personIDOf` to `PersonIDOf`.

<sup>Written for commit 4d2746ef294ed8f373d15d388ab6ed9922759032. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/859?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added shared integration-test fixtures for early database setup, workspace-scoped transactions, retention-policy seeding, and statutory retention validation.
  * Expanded channel and messaging integration coverage across Telegram workflows, identity handling, lifecycle events, erasure, retention, delivery, and authorization.
  * Consolidated test setup and helpers, improving consistency across integration suites.
* **Documentation**
  * Added documentation for channel integration-test coverage and fixture ownership.
* **Refactor**
  * Standardized shared helper usage and package organization without changing existing test assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->