### PR TITLE
perf(ci): seventeen Go jobs stop compiling the module from scratch

### DIFF
--- a/.github/actions/go-build-cache/action.yml
+++ b/.github/actions/go-build-cache/action.yml
@@ -1,0 +1,66 @@
+name: go-build-cache
+description: >-
+  Restore the shared Go build cache for one build flavor, and hand back the key
+  a main-branch job uses to refresh it.
+
+# Why this exists: actions/setup-go caches ~/.cache/go-build under a key that
+# hashes only go.sum, so the entry is written ONCE and then every later run logs
+# "Cache hit occurred on the primary key ... not saving cache" and restores that
+# first, near-empty snapshot forever. A warm build cache for this repo measures
+# ~550 MB; the blob setup-go restores is ~25 MB. The result was that every Go
+# job in the pipeline — the twelve integration shards, the merge gate, the
+# composed-build lane, the coverage pass, live-boot, govulncheck — compiled the
+# module from scratch on every run. setup-go keeps caching the MODULE cache
+# (that part works); this action owns the build cache it cannot.
+#
+# The key ends in the commit SHA so a refresh always writes a new entry, and
+# restore-keys walks back to the newest prior entry. Go's build cache is
+# content-addressed, so a partially stale restore is never WRONG — it simply
+# misses the entries whose inputs changed and recompiles those. That is why the
+# last fallback drops the dependency hash entirely: after a dependency bump a
+# mostly-warm cache still beats a cold one, and the stale entries age out under
+# Go's own trimming rather than being served in error.
+
+inputs:
+  flavor:
+    description: >-
+      Which set of compiled artifacts this job produces, and therefore which
+      cache it shares. `plain` is the untagged build/vet/lint/unit compile;
+      `integration` is the `-tags=integration -cover -coverpkg=./...` compile
+      the shards do. They are separate keys because a build tag and coverage
+      instrumentation both change the package builds themselves — only the
+      dependency builds underneath are common to both, and those come along in
+      whichever entry is restored.
+    required: true
+
+outputs:
+  key:
+    description: >-
+      The primary key this restore attempted. A job that refreshes the cache
+      passes it straight to actions/cache/save, so the key is spelled in one
+      place and a save can never write an entry no restore looks for.
+    value: ${{ steps.key.outputs.key }}
+
+runs:
+  using: composite
+  steps:
+    - name: Compute the cache key for this flavor
+      id: key
+      shell: bash
+      run: |
+        prefix="go-build-${{ inputs.flavor }}-${{ runner.os }}-${{ runner.arch }}"
+        deps="${{ hashFiles('backend/go.mod', 'backend/go.sum', 'go.work', 'go.work.sum') }}"
+        {
+          echo "key=$prefix-$deps-${{ github.sha }}"
+          echo "restore-keys<<RESTORE_KEYS"
+          echo "$prefix-$deps-"
+          echo "$prefix-"
+          echo "RESTORE_KEYS"
+        } >> "$GITHUB_OUTPUT"
+
+    - name: Restore the Go build cache
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ~/.cache/go-build
+        key: ${{ steps.key.outputs.key }}
+        restore-keys: ${{ steps.key.outputs.restore-keys }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,10 @@ jobs:
               # backend gate, so editing one cannot invalidate a gate result —
               # and each proves itself when it runs.
               - '.github/workflows/ci.yml'
+              # The composite actions ci.yml calls. go-build-cache decides what
+              # every Go job restores, so an edit to it changes what the gates
+              # compile — the same claim on this scope that ci.yml itself has.
+              - '.github/actions/**'
               - 'AGENTS.md'
               - 'sonar-project.properties'
             frontend:
@@ -158,6 +162,15 @@ jobs:
         with:
           go-version-file: backend/go.mod
           cache-dependency-path: backend/go.sum
+      # The shared Go build cache (see .github/actions/go-build-cache): this job
+      # compiles the untagged tree twice over — `go build ./...` plus the unit
+      # test binaries — and is the natural writer of the `plain` flavour every
+      # other untagged Go job reads.
+      - name: Restore the Go build cache
+        id: go-cache
+        uses: ./.github/actions/go-build-cache
+        with:
+          flavor: plain
       # Cache the compiled gate binaries. `make tools` compiles golangci-lint,
       # go-arch-lint, govulncheck, and oasdiff from source into ~/go/bin — ~75s
       # that setup-go's module/build cache does not cover (it caches ~/go/pkg/mod
@@ -221,6 +234,20 @@ jobs:
           # In CI a missing base ref is a broken checkout, never a skip.
           CONTRACT_BREAKING_REQUIRE_BASE: "1"
         run: make check-backend
+      # Refresh the shared cache from main only. On a PR this step does not run,
+      # so the twelve shards and this job never race to write the same key and a
+      # PR can never poison what the next PR restores. `!cancelled()` rather than
+      # success(): a red lint or a failed test still compiled the tree, and those
+      # artifacts are exactly as reusable as a green run's.
+      - name: Refresh the shared build cache
+        if: >-
+          !cancelled()
+          && github.event_name == 'push'
+          && github.ref == 'refs/heads/main'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/go-build
+          key: ${{ steps.go-cache.outputs.key }}
 
   # The composed-build lane (ADR-0069): materialize the walking-skeleton
   # reference extension into extensions/, compose, and run the backend
@@ -252,6 +279,13 @@ jobs:
         with:
           go-version-file: backend/go.mod
           cache-dependency-path: backend/go.sum
+      # Reads the `plain` flavour: this lane builds the untagged tree twice (once
+      # with extensions/ emptied, once composed), so it is the biggest single
+      # beneficiary after the shards.
+      - name: Restore the Go build cache
+        uses: ./.github/actions/go-build-cache
+        with:
+          flavor: plain
       # working-directory: . on the root-level steps — the workflow default
       # (backend) would resolve fixtures/ and extensions/ under backend/.
       #
@@ -413,6 +447,17 @@ jobs:
         with:
           go-version-file: backend/go.mod
           cache-dependency-path: backend/go.sum
+      # The `integration` flavour: a shard compiles ~26 of the 31 tagged packages
+      # with `-tags=integration -cover -coverpkg=./...`, and because the slice is
+      # per-TEST rather than per-package, EVERY shard compiles nearly the whole
+      # lane. Sharding therefore divides the test execution twelve ways and
+      # multiplies the compile by twelve — which is affordable off a warm cache
+      # and was the dominant cost of this job off a cold one.
+      - name: Restore the Go build cache
+        id: go-cache
+        uses: ./.github/actions/go-build-cache
+        with:
+          flavor: integration
       # The same compose stack dev machines use (infra/docker-compose.dev.yml:
       # Postgres + Redis + MinIO, digest-pinned there) plus scripts/db-init.sql
       # for the cluster-level margince_app role — migration 0015 GRANTs to it,
@@ -440,6 +485,20 @@ jobs:
           path: ${{ runner.temp }}/shard-out
           if-no-files-found: error
           retention-days: 1
+      # ONE shard refreshes the `integration` flavour, and only from main. Every
+      # shard compiles substantially the same set, so a second writer would add
+      # nothing but a race for the same key — and twelve runners each uploading a
+      # ~550 MB cache would evict the entry they were meant to seed.
+      - name: Refresh the shared build cache
+        if: >-
+          !cancelled()
+          && matrix.shard == 1
+          && github.event_name == 'push'
+          && github.ref == 'refs/heads/main'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/go-build
+          key: ${{ steps.go-cache.outputs.key }}
 
   # Unit coverage for SonarCloud. The shards run only the integration-tagged
   # packages, but the unit-only packages need a `-cover` pass of their own —
@@ -470,6 +529,13 @@ jobs:
         with:
           go-version-file: backend/go.mod
           cache-dependency-path: backend/go.sum
+      # The `plain` flavour, not `integration`: this pass is untagged. Coverage
+      # instrumentation means its own package builds miss, but the dependency
+      # builds underneath — the bulk of a cold compile — hit.
+      - name: Restore the Go build cache
+        uses: ./.github/actions/go-build-cache
+        with:
+          flavor: plain
       - name: Unit tests with binary coverage
         run: |
           mkdir -p "$RUNNER_TEMP/covdata-unit"
@@ -608,6 +674,12 @@ jobs:
         with:
           go-version-file: backend/go.mod
           cache-dependency-path: backend/go.sum
+      # govulncheck type-checks and builds every package to trace reachability,
+      # so it pays the same cold compile the merge gate does.
+      - name: Restore the Go build cache
+        uses: ./.github/actions/go-build-cache
+        with:
+          flavor: plain
       - run: make vuln
 
   # CI-based SonarCloud scan. Unlike Automatic Analysis, the scanner reads the
@@ -728,6 +800,11 @@ jobs:
           node-version: 24
           cache: pnpm
           cache-dependency-path: frontend/pnpm-lock.yaml
+      # This lane compiles the composition generator and then `go run`s cmd/api.
+      - name: Restore the Go build cache
+        uses: ./.github/actions/go-build-cache
+        with:
+          flavor: plain
       - name: Boot the dev stack and migrate
         run: make db-up && make migrate
       # The deployment configuration (A107/ADR-0061): the api bootstraps the

--- a/infra/ci-pipeline.md
+++ b/infra/ci-pipeline.md
@@ -31,7 +31,7 @@ output. A required job skipped this way still counts as passing.
 
 | Scope | Paths | Gates |
 |---|---|---|
-| `backend` | `backend/**`, `infra/**/!(*.md)`, `go.work[.sum]`, `Makefile`, `scripts/**`, `extensions/**`, `fixtures/**`, `composition/**`, `.github/workflows/ci.yml`, `AGENTS.md`, `sonar-project.properties`, `frontend/src/mcp-apps/forbidden.json` | Go build/gate, extension reference, craftsmanship, integration, vuln |
+| `backend` | `backend/**`, `infra/**/!(*.md)`, `go.work[.sum]`, `Makefile`, `scripts/**`, `extensions/**`, `fixtures/**`, `composition/**`, `.github/workflows/ci.yml`, `.github/actions/**`, `AGENTS.md`, `sonar-project.properties`, `frontend/src/mcp-apps/forbidden.json` | Go build/gate, extension reference, craftsmanship, integration, vuln |
 | `frontend` | `frontend/**`, `backend/api/**` (the contract drives FE types) | frontend lane, UAT |
 | `e2e` | `backend/**`, `frontend/**`, `infra/**/!(*.md)`, `extensions/**`, `fixtures/**`, `composition/**` | full-stack live-boot |
 | `docker` | root `Dockerfile.*`, `.dockerignore` | the three image builds |
@@ -94,6 +94,55 @@ build is still caught by `deterministic-gates` itself. And the lane is
 (package-level splitting would floor at the heaviest package,
 `compose/integration`), and the `integration` fan-in reassembles them into the
 one required check.
+
+## The shared Go build cache
+
+Every Go job restores
+[`.github/actions/go-build-cache`](../.github/actions/go-build-cache/action.yml)
+before it compiles.
+
+It exists because `actions/setup-go` cannot do this job. Its cache key hashes
+only `go.sum`, so the entry is written once and never refreshed — every later
+run logs *"Cache hit occurred on the primary key … not saving cache"* and
+restores that first snapshot forever. Measured on this repo, that blob is
+**~25 MB** while a warm Go build cache is **~550 MB**: the module cache was
+being restored, the build cache effectively was not. Seventeen Go jobs per
+backend run — the twelve shards, the merge gate, the composed-build lane, the
+coverage pass, `live-boot`, `govulncheck` — each compiled the module from
+scratch, every run. setup-go still owns the module cache; this action owns the
+build cache beside it.
+
+Two flavours, because a build tag and coverage instrumentation change the
+package builds themselves and only the dependency builds underneath are common:
+
+| Flavour | Written by | Read by |
+|---|---|---|
+| `plain` | `deterministic-gates` | `deterministic-gates`, `extension-reference`, `integration unit coverage`, `live-boot`, `vuln` |
+| `integration` | `integration shard (1/12)` | all twelve shards |
+
+Three properties worth keeping:
+
+- **Only `main` writes.** Both refresh steps are gated on
+  `github.event_name == 'push' && github.ref == 'refs/heads/main'`, so a PR
+  restores and never saves. That is what stops twelve shards racing to upload
+  the same ~550 MB key, and what stops one PR's cache from reaching the next.
+- **Exactly one writer per flavour.** Every shard compiles substantially the
+  same set, so a second writer would add nothing but contention — hence the
+  `matrix.shard == 1` guard.
+- **The key falls back twice.** `…-<deps-hash>-<sha>` → `…-<deps-hash>-` →
+  `…-`. Dropping the dependency hash on the last hop is deliberate: Go's build
+  cache is content-addressed, so a stale restore is never *wrong*, it only
+  misses the entries whose inputs changed. After a dependency bump a
+  mostly-warm cache still beats a cold one.
+
+The refresh steps use `!cancelled()` rather than `success()`: a red lint or a
+failed test still compiled the tree, and those artifacts are exactly as
+reusable as a green run's.
+
+`scripts/check-image-pins.sh` scans `.github/actions/` alongside the workflows.
+The `./path` allowance waves a local action through on the grounds that the
+repo versions its own code — true of the action's own ref, but not of the
+third-party actions it calls, which would otherwise ride in unread.
 
 ## The jobs
 

--- a/scripts/check-image-pins.sh
+++ b/scripts/check-image-pins.sh
@@ -14,12 +14,21 @@ set -euo pipefail
 
 fail=0
 workflow_dir=".github/workflows"
+actions_dir=".github/actions"
 compose_files="infra/docker-compose.dev.yml"
 
 if [ ! -d "$workflow_dir" ]; then
   echo "No $workflow_dir directory found — skipping image-pin check"
   exit 0
 fi
+
+# Scan the local composite actions alongside the workflows. The `./path` case
+# below waves a local action through on the grounds that the repo versions its
+# own code — which is only true of the action's OWN ref, not of the third-party
+# actions it calls. A composite action pulls those into CI exactly as a workflow
+# does, so an unpinned `uses:` one level down would otherwise ride in unread.
+scan_dirs=("$workflow_dir")
+[ -d "$actions_dir" ] && scan_dirs+=("$actions_dir")
 
 # --- Workflow `uses:` actions: pinned to a commit SHA or digest ---
 while IFS= read -r line; do
@@ -37,7 +46,8 @@ while IFS= read -r line; do
 # marker, then the key — never a bare substring. Anchoring this way keeps the
 # `statuses:` permission (`stat[uses:]`), a `uses:` inside a comment, and a
 # `uses:` in a scalar value from being flagged as an unpinned action.
-done < <(grep -rnE '^[[:space:]]*(-[[:space:]]+)?uses:' "$workflow_dir"/*.yml "$workflow_dir"/*.yaml 2>/dev/null || true)
+done < <(grep -rnE --include='*.yml' --include='*.yaml' \
+  '^[[:space:]]*(-[[:space:]]+)?uses:' "${scan_dirs[@]}" 2>/dev/null || true)
 
 # --- Container images (workflow services + compose): pinned by digest ---
 # A tag pin is not enough for images: tags are mutable, only @sha256: binds
@@ -55,7 +65,8 @@ while IFS= read -r line; do
     fail=1
   fi
 # `image:` as a YAML key too (same key-anchoring as `uses:` above).
-done < <(grep -rnE '^[[:space:]]*(-[[:space:]]+)?image:' "$workflow_dir"/*.yml "$workflow_dir"/*.yaml $compose_files 2>/dev/null || true)
+done < <(grep -rnE --include='*.yml' --include='*.yaml' \
+  '^[[:space:]]*(-[[:space:]]+)?image:' "${scan_dirs[@]}" $compose_files 2>/dev/null || true)
 
 if [ "$fail" -eq 0 ]; then
   echo "image pins OK"


### PR DESCRIPTION
## What

`actions/setup-go` keys its cache on `go.sum` alone, so the entry is written **once** and never refreshed — every later run logs `Cache hit occurred on the primary key ... not saving cache` and restores that first snapshot forever.

Measured on this repo: that blob is **~25 MB**, a warm Go build cache is **~550 MB**. The module cache was being restored; the build cache effectively was not. Every Go job in the pipeline compiled the module cold, on every run.

Evidence from run [31451571134](https://github.com/gradionhq/margince-poc-v1/actions/runs/31451571134) — integration shard 1 spent **249s** in its test step, of which the summed `go test` package time was **98.67s** across 26 packages at 16-way concurrency. The gap is compile.

## How

A composite action owns the build cache setup-go cannot, called from the six jobs that compile.

| Flavour | Written by | Read by |
|---|---|---|
| `plain` | `deterministic-gates` | + `extension-reference`, `integration unit coverage`, `live-boot`, `vuln` |
| `integration` | `integration shard (1/12)` | all twelve shards |

Two flavours because a build tag and coverage instrumentation change the package builds themselves — only the dependency builds underneath are common.

Three guards:
- **Only `main` writes.** A PR restores and never saves, so twelve shards never race for the same key and no PR poisons what the next one restores.
- **One writer per flavour.** Every shard compiles substantially the same set; a second writer adds only contention.
- **The key falls back twice**, dropping the dependency hash on the last hop. Go's cache is content-addressed, so a stale restore is never *wrong* — it misses and recompiles. After a dependency bump a mostly-warm cache still beats a cold one.

Refreshes use `!cancelled()` rather than `success()`: a red lint still compiled the tree, and those artifacts are as reusable as a green run's.

## Two invariants this would otherwise have broken

- **The classifier gains `.github/actions/**`.** The cache action decides what every Go job compiles, so it has the same claim on the `backend` scope that `ci.yml` itself has. Without it, an edit to the action would skip the lanes it changes.
- **`check-image-pins` now reads `.github/actions/`.** Its `./path` rule waves a local action through because the repo versions its own code — true of that action's own ref, but not of the third-party actions it calls. Mutation-tested: planting `uses: actions/checkout@v4` in the composite action fails the gate with `UNPINNED REF`.

## What to expect

**This PR's own CI will not be faster, and neither will the first PR after it merges.** Only `main` writes, so both entries are seeded by the next merge to `main`; the run after that is the first to benefit.

Separately: the repo's Actions cache is at **10.72 GB against a 10 GB cap** across 533 entries, dominated by CodeQL storing ~211 MB per PR ref. Until that is reined in, a fresh ~550 MB entry is a prime LRU eviction target — retiring CodeQL is the gating dependency for this actually paying off.

## Verification

- `make check-backend` — green
- `make check-image-pins` — green, and mutation-tested as above
- Both YAML files parse; all six call sites and both save steps confirmed wired

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a composite CI action to restore and refresh the Go build cache so 17 Go jobs stop compiling from scratch. Only `main` writes the cache, with `plain` and `integration` flavors, to cut cold builds and reduce CI time.

- **New Features - New features added**
  - Added `./.github/actions/go-build-cache` to manage the Go build cache with fallback keys; complements `actions/setup-go` which keys only on `go.sum`.
  - Wired into the merge gate, composed-build, unit coverage, `live-boot`, `vuln`, and all 12 integration shards.
  - Two flavors: `plain` (untagged) and `integration` (`-tags=integration -cover`); PRs restore only, and exactly one writer on `main` refreshes each flavor using `actions/cache/save` with `!cancelled()`.
  - Updated path classification to include `.github/actions/**` so backend gates rerun when the action changes.
  - Extended `scripts/check-image-pins.sh` to scan `.github/actions/` and enforce pinned third‑party actions.

<sup>Written for commit ae588b8a25ed677b90786c6cee3723e95edbe299. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/860?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

