### PR TITLE
perf(test): the lane starts its long pole first

### DIFF
--- a/scripts/test-integration-parallel.sh
+++ b/scripts/test-integration-parallel.sh
@@ -322,6 +322,34 @@ awk -F'|' '
 REGEX_DIR="$(mktemp -d)"
 export REGEX_DIR
 : > "$WORK"
+# Longest package first, from what the last run measured.
+#
+# Wall clock is set by when the LONGEST package finishes, so it should start at
+# t=0. Dispatched in discovery order it does not: measured, this lane's long pole
+# waited 16s of a 252s run for a slot while shorter packages held all eight. That
+# is the classic longest-processing-time-first result, and the durations to order
+# by are the ones the run below is about to print anyway.
+#
+# A package with no recorded time sorts FIRST, not last. The unknown is usually a
+# new small package, where the cost of guessing wrong is one slot occupied early;
+# guessing wrong the other way puts a new heavy package last and pays its whole
+# duration after everything else has finished. On the first run the cache is
+# absent and the order is discovery's, unchanged.
+#
+# Ordered HERE, before slots are numbered, so each package's -run slice, clone,
+# bucket and Redis db follow it rather than being handed to whoever inherits its
+# slot number.
+ORDER_HINT="$ROOT/.tmp/integration-lane-timing.txt"
+if [[ -s "$ORDER_HINT" ]]; then
+  # Only fields 1 and 2 are read; $0 is reprinted whole, because field 3 is a
+  # -run regex that contains its own pipes.
+  awk -F'|' -v hint="$ORDER_HINT" '
+    BEGIN { while ((getline l < hint) > 0) { split(l, f, "|"); secs[f[1]] = f[2] + 0 } }
+    { printf "%012.3f|%s\n", ($2 in secs ? secs[$2] : 999999), $0 }
+  ' "$GROUPED" | LC_ALL=C sort -t'|' -k1 -rn | cut -d'|' -f2- > "${GROUPED}.ordered"
+  mv "${GROUPED}.ordered" "$GROUPED"
+fi
+
 slot=0
 while IFS= read -r line; do
   slot=$((slot + 1))
@@ -525,6 +553,14 @@ if [[ -s "$WALLCLOCK" ]] && [[ -s "$TIMING" ]]; then
         printf "  %ds  %s occupied a slot; it recorded no test duration, so the tests/provisioning split is unavailable\n", ended - began, last
       }
     }'
+fi
+
+# Leave the durations behind for the next run to dispatch by. Full runs only: a
+# shard measures its own slice, and saving that would order the next full run by
+# a twelfth of each package.
+if [[ -s "$TIMING" ]] && (( SHARD_TOTAL == 0 )); then
+  mkdir -p "$(dirname "$ORDER_HINT")"
+  cut -d'|' -f1,2 "$TIMING" > "$ORDER_HINT" || true
 fi
 
 # Reconcile against discovery: a green run must have executed every package we

--- a/scripts/test-integration-parallel.sh
+++ b/scripts/test-integration-parallel.sh
@@ -558,9 +558,23 @@ fi
 # Leave the durations behind for the next run to dispatch by. Full runs only: a
 # shard measures its own slice, and saving that would order the next full run by
 # a twelfth of each package.
+#
+# Published by rename, never written in place. The next run treats a non-empty
+# hint as authoritative, so a HALF-written one is worse than none: truncate a
+# heavy package's duration mid-line and it sorts LAST, which is precisely the
+# schedule this ordering exists to avoid. The temporary file is created beside the
+# destination so the rename stays within one filesystem and is atomic.
+#
+# Every step is non-fatal, and on any failure the previous hint survives
+# untouched. A scheduling hint that could fail a green lane would be a worse
+# trade than dispatching in discovery order forever.
 if [[ -s "$TIMING" ]] && (( SHARD_TOTAL == 0 )); then
-  mkdir -p "$(dirname "$ORDER_HINT")"
-  cut -d'|' -f1,2 "$TIMING" > "$ORDER_HINT" || true
+  hint_dir="$(dirname "$ORDER_HINT")"
+  if mkdir -p "$hint_dir" 2>/dev/null && hint_tmp="$(mktemp "$hint_dir/.integration-lane-timing.XXXXXX" 2>/dev/null)"; then
+    cut -d'|' -f1,2 "$TIMING" > "$hint_tmp" 2>/dev/null \
+      && mv -f "$hint_tmp" "$ORDER_HINT" 2>/dev/null \
+      || rm -f "$hint_tmp"
+  fi
 fi
 
 # Reconcile against discovery: a green run must have executed every package we


### PR DESCRIPTION
Wall clock is set by when the LONGEST package finishes, so it should start at
t=0. Dispatched in discovery order it does not — the accounting from #854 measured
this lane's long pole waiting 12–16s for a slot while shorter packages held all
eight. This orders dispatch longest-first, using the durations the run already
prints, left in `.tmp` for the next run to read.

## Measured

Three consecutive full runs on one machine, back to back:

```
218s  discovery order, long pole waited 16s   (sum of packages 633s)
207s  longest-first,   long pole waited  0s   (sum of packages 642s)
```

**The slot-wait going to zero is the mechanism**, and it is the part that does not
depend on how loaded the machine is. The 11s of wall clock is the payoff, and it is
understated: total package seconds *rose* 1.4% between those two runs, and the long
pole's own slot occupancy rose with it (183s → 191s), so the faster run was the
busier one. Starting at t=0 more than paid for that.

This is why the change sat unmerged for a while — it was written from the argument
and only landed once there was a measurement to go with it, on a machine that had
stopped degrading.

## Design notes

A package with no recorded time sorts **first**, not last. The unknown is usually a
new small package, where guessing wrong costs one slot occupied early; guessing
wrong the other way puts a new heavy package last and pays its whole duration after
everything else has finished.

On the first run the hint is absent and the order is discovery's, unchanged — that
is the 218s run above. Only full runs write the hint, since a shard measures a
twelfth of each package and ordering the next full run by that would be worse than
not ordering at all.

Ordering happens before slots are numbered, so each package's `-run` slice, clone,
bucket and Redis db follow it rather than being handed to whoever inherits its
number.

## Verification

- Three full lane runs above, all green, 0 skips.
- `INTEGRATION_SHARD=1/12 make test-integration` on the rebased branch — green,
  178 tests, 26 packages, 0 skips.
- `make test-lanes` — green. `bash -n` on the runner.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run integration test packages longest-first using durations from the previous full run so the longest package starts at t=0 and reduces wall-clock time (~218s → ~207s). The ordering hint is written via atomic rename and never blocks the lane.

- **New Features - New features added**
  - Save per-package durations to `.tmp/integration-lane-timing.txt` on full runs; write to a temp file then atomically rename. Failures are non-fatal and keep the previous hint; shards don’t write.
  - Read the hint to dispatch packages longest-first; packages without a record run first.
  - Order before slot numbering so each package’s `-run` slice, clone, bucket, and Redis DB stay aligned.

<sup>Written for commit 47743e54e319376a461033059fa3163377483d6b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/861?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Test Improvements**
  * Integration test packages are now scheduled based on previous test durations, helping faster packages run earlier.
  * Packages without timing history are prioritized for initial runs.
  * Timing data is updated after successful full test runs to improve future scheduling.
  * Sharded test runs do not alter full-run timing history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->