### PR TITLE
feat(installation): the workspace row stops carrying the installation's identity

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -278,40 +278,33 @@ still open. `finance_invoice` joined `frozenRateTables` in deals, because an
 invoice freezes its FX rate on issue date and a base-currency change would
 restate money that already moved.
 
-## Open — the settings mirror is a dual-write on ADR-0091's critical path
+## Done — the settings mirror is retired, and the workspace row is next
 
 ADR-0090/A135 shipped (#520): installation settings are rows in `setting`, with
-the catalog in typed Go. Four settings moved — `capture.auto_enrich` and the
-three `installation.*` values — behind a Settings → Installation surface, with
-the base currency freezing once a deal has converted against it (ADR-0085 §7).
+the catalog in typed Go. #521 then moved every reader off the `workspace`
+columns across four slices — quotas and finance (#794), the deals module's
+money reads (#802), name/timezone plus the roll-up and org-360 (#817), and the
+brief ranker, forecast and reset confirmation (#857) — and migration `0209`
+dropped `name`, `base_currency` and `timezone` along with the dual write in
+`UpdateInstallation`.
 
-The read side is most of the way across. Three slices have landed — quotas and
-finance (#794), the deals module's money reads (#802), and the installation's
-name and timezone plus the roll-up and org-360 reads (#817). Each module takes
-the seam as a required constructor value, `identity.{Name,BaseCurrency,Timezone}Of`
-are the only readers, and an unset value REFUSES rather than falling back to a
-default, because a silent default on a money path converts against one currency
-and labels the result another.
+The three reads that used to be documented exceptions moved with the columns
+rather than surviving them. Bootstrap now WRITES the settings from the values
+identity itself resolved, instead of reading its own row back. The session
+lookup and the base-currency freeze probe read the `setting` row directly in
+SQL — both run where `platform/settings`' readers cannot, one before a
+principal exists to gate anything and the other on the first write, when no row
+exists yet and "nothing is priced against a base that was never set" is the
+honest answer.
 
-Two readers are left, and both are SQL-expression rewrites rather than source
-swaps: the forecast's slipped-category dimension (`compose/report.go`) and the
-brief ranker's revenue factor (`compose/briefs/briefrank.go`) each spell the
-value inside a larger query against a `workspace w` join, so they need bind
-positions threaded through their builders and the join re-examined. Three reads
-stay on the column deliberately: bootstrap's own backfill, the session read
-that names the installation before any principal exists to gate a settings
-read, and the base-currency freeze probe, which must tolerate the FIRST write
-where no row exists yet.
+`0209` refuses rather than loses: an installation whose settings rows are
+missing while a live workspace still holds the values fails the migration with
+what to do about it, because dropping the columns would destroy the only copy.
+The one state its repair cannot resolve is several live workspaces, where no
+single row can speak for the installation — an operator resolves that down to
+one (ADR-0061 §3) and re-runs.
 
-`UpdateInstallation` still writes the setting AND mirrors it onto the column in
-one transaction. The mirror retires with those last two readers.
-
-**This is not a settings leftover, it is ADR-0091 phase 4's first step.** That
-phase drops the `workspace` row, so the readers have to move regardless. Doing
-it as its own change gets the dual-write out before the plumbing collapse
-rather than after, and shrinks what phase 4 has to touch. Tracked as **#521**,
-which also covers dropping `capture_auto_enrich`, `name`, `timezone` and
-`base_currency` once nothing reads them.
+What remains of ADR-0091 phase 4 is the rest of the `workspace` row itself.
 
 Also open from the same work: **#551** — the base-currency freeze is atomic
 with its own write but not with the deal transaction that stamps

--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -15266,7 +15266,7 @@ components:
         workspace_name:
           type: string
           description: >
-            The installation's organization name (workspace.name). Shown as the
+            The installation's organization name (the installation.name setting). Shown as the
             typed-confirmation target of the non-production "Reset data" action —
             the exact string that endpoint validates.
         non_production:

--- a/backend/internal/compose/capturedfiles_integration_test.go
+++ b/backend/internal/compose/capturedfiles_integration_test.go
@@ -43,7 +43,7 @@ func captureWorkspace(t *testing.T) (context.Context, *pgxpool.Pool, string) {
 	ws := ids.NewV7()
 	ctx := context.Background()
 	if _, err := pool.Exec(ctx,
-		`INSERT INTO workspace (id, name, slug, base_currency) VALUES ($1, 'Captured Files', $2, 'EUR')`,
+		`INSERT INTO workspace (id, slug) VALUES ($1, $2)`,
 		ws, "captured-files-"+ws.String()); err != nil {
 		t.Fatalf("seed workspace: %v", err)
 	}

--- a/backend/internal/compose/company_integration_test.go
+++ b/backend/internal/compose/company_integration_test.go
@@ -318,7 +318,7 @@ func TestCompanyContextIsScopedProvenanceBearingAndChangesWithTheProfile(t *test
 	foreignWS, foreignOrg := ids.NewV7(), ids.NewV7()
 	owner := integration.OwnerConn(t)
 	if _, err := owner.Exec(context.Background(),
-		`INSERT INTO workspace (id, name, slug, base_currency) VALUES ($1, 'Foreign', $2, 'EUR')`,
+		`INSERT INTO workspace (id, slug) VALUES ($1, $2)`,
 		foreignWS, "foreign-"+foreignWS.String()); err != nil {
 		t.Fatal(err)
 	}

--- a/backend/internal/compose/costestimate/estimator_integration_test.go
+++ b/backend/internal/compose/costestimate/estimator_integration_test.go
@@ -108,7 +108,7 @@ func (e *estEnv) seedWorkspace(t *testing.T) (ids.UUID, context.Context) {
 	ctx := context.Background()
 	ws := ids.NewV7()
 	if _, err := e.owner.Exec(ctx,
-		`INSERT INTO workspace (id, name, slug, base_currency) VALUES ($1, 'CostEst', $2, 'EUR')`,
+		`INSERT INTO workspace (id, slug) VALUES ($1, $2)`,
 		ws, "ce-"+ws.String()); err != nil {
 		t.Fatal(err)
 	}

--- a/backend/internal/compose/datareset_integration_test.go
+++ b/backend/internal/compose/datareset_integration_test.go
@@ -563,7 +563,7 @@ func TestResetLeavesAnotherWorkspacesSealedCredential(t *testing.T) {
 	// the admin context is not bound to — which is precisely what RLS refuses.
 	owner := resetOwnerConn(ctx, t)
 	if _, err := owner.Exec(ctx,
-		`INSERT INTO workspace (id, name, slug, base_currency) VALUES ($1, 'Other Tenant', $2, 'EUR')`,
+		`INSERT INTO workspace (id, slug) VALUES ($1, $2)`,
 		theirs, "other-tenant-"+theirs.String()[:8]); err != nil {
 		t.Fatalf("seeding the co-tenant workspace: %v", err)
 	}

--- a/backend/internal/compose/dedupe_budget_integration_test.go
+++ b/backend/internal/compose/dedupe_budget_integration_test.go
@@ -111,7 +111,7 @@ func TestSeatDerivedBudget(t *testing.T) {
 	empty := ids.New[ids.WorkspaceKind]()
 	owner := integration.OwnerConn(t)
 	if _, err := owner.Exec(context.Background(),
-		`INSERT INTO workspace (id, name, slug, base_currency) VALUES ($1, 'Empty', 'empty-budget', 'EUR')`, empty); err != nil {
+		`INSERT INTO workspace (id, slug) VALUES ($1, 'empty-budget')`, empty); err != nil {
 		t.Fatalf("workspace insert: %v", err)
 	}
 	budget, err = NewSeatBudget(e.Pool).MonthlyTokenBudget(context.Background(), empty)

--- a/backend/internal/compose/installation.go
+++ b/backend/internal/compose/installation.go
@@ -78,13 +78,6 @@ func EnsureInstallation(ctx context.Context, pool *pgxpool.Pool, log *slog.Logge
 // file's optional `seeds` section — an omitted key seeds the built-in
 // default, so a minimal configuration behaves exactly like the
 // historical bootstrap.
-// seedInstallationSettings writes the installation's own settings rows at
-// bootstrap (ADR-0090 §8): consumed exactly once, so a restart never overwrites
-// a value a human has since changed.
-//
-// The values are read back from the workspace row this same transaction just
-// created, rather than re-derived from the configuration. That is deliberate:
-
 func configuredSeed(seeds deployconfig.Seeds, dealsH dealsHandlers) func(context.Context, pgx.Tx) error {
 	return func(ctx context.Context, tx pgx.Tx) error {
 		if err := seedPipeline(ctx, tx, seeds.Pipeline, dealsH); err != nil {

--- a/backend/internal/compose/installation.go
+++ b/backend/internal/compose/installation.go
@@ -29,7 +29,6 @@ import (
 	"github.com/gradionhq/margince/backend/internal/modules/identity"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/platform/deployconfig"
-	"github.com/gradionhq/margince/backend/internal/platform/settings"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
@@ -85,38 +84,9 @@ func EnsureInstallation(ctx context.Context, pool *pgxpool.Pool, log *slog.Logge
 //
 // The values are read back from the workspace row this same transaction just
 // created, rather than re-derived from the configuration. That is deliberate:
-// identity applies its own defaults when the config omits a currency or zone,
-// and deriving them a second time here would duplicate that defaulting and
-// drift from it. It also makes this path identical to 0191's backfill, so an
-// installation bootstrapped after the migration and one migrated into it hold
-// the same values by construction.
-func seedInstallationSettings(ctx context.Context, tx pgx.Tx) error {
-	var name, zone, currency string
-	if err := tx.QueryRow(ctx,
-		`SELECT name, timezone, rtrim(base_currency) FROM workspace WHERE archived_at IS NULL`,
-	).Scan(&name, &zone, &currency); err != nil {
-		return fmt.Errorf("compose: reading the new organization for its settings: %w", err)
-	}
-	for _, seed := range []struct {
-		entry *settings.Entry[string]
-		value string
-	}{
-		{identity.Name, name},
-		{identity.Timezone, zone},
-		{identity.BaseCurrency, currency},
-	} {
-		if err := settings.SeedValue(ctx, tx, seed.entry, seed.value); err != nil {
-			return err
-		}
-	}
-	return nil
-}
 
 func configuredSeed(seeds deployconfig.Seeds, dealsH dealsHandlers) func(context.Context, pgx.Tx) error {
 	return func(ctx context.Context, tx pgx.Tx) error {
-		if err := seedInstallationSettings(ctx, tx); err != nil {
-			return err
-		}
 		if err := seedPipeline(ctx, tx, seeds.Pipeline, dealsH); err != nil {
 			return err
 		}

--- a/backend/internal/compose/integration/ai_meter_integration_test.go
+++ b/backend/internal/compose/integration/ai_meter_integration_test.go
@@ -58,7 +58,7 @@ func meterWorkspace(t *testing.T, ctx context.Context, owner *pgx.Conn, slug str
 	t.Helper()
 	var raw string
 	if err := owner.QueryRow(ctx,
-		`INSERT INTO workspace (name, slug, base_currency) VALUES ($1, $1, 'EUR') RETURNING id`,
+		`INSERT INTO workspace (slug) VALUES ($1) RETURNING id`,
 		slug).Scan(&raw); err != nil {
 		t.Fatalf("workspace insert: %v", err)
 	}

--- a/backend/internal/compose/integration/aicalls_integration_test.go
+++ b/backend/internal/compose/integration/aicalls_integration_test.go
@@ -157,7 +157,7 @@ func TestAiCallIsInvisibleAcrossTenants(t *testing.T) {
 
 	workspaceB := ids.NewV7()
 	if _, err := e.Owner.Exec(context.Background(),
-		`INSERT INTO workspace (id, name, slug, base_currency) VALUES ($1, 'AI Two', 'ai-two', 'EUR')`,
+		`INSERT INTO workspace (id, slug) VALUES ($1, 'ai-two')`,
 		workspaceB); err != nil {
 		t.Fatalf("seed second workspace: %v", err)
 	}

--- a/backend/internal/compose/integration/binding_integration_test.go
+++ b/backend/internal/compose/integration/binding_integration_test.go
@@ -313,7 +313,7 @@ func TestPendingAndTokenSumAggregateAcrossWorkspaces(t *testing.T) {
 	// A sibling workspace search's own setup does not create — proves the
 	// fleet enumeration (not just the harness's one workspace) is real.
 	ws2 := ids.NewV7()
-	if _, err := e.Owner.Exec(ctx, `INSERT INTO workspace (id, name, slug, base_currency) VALUES ($1, 'Search Two', 'search-two', 'EUR')`, ws2); err != nil {
+	if _, err := e.Owner.Exec(ctx, `INSERT INTO workspace (id, slug) VALUES ($1, 'search-two')`, ws2); err != nil {
 		t.Fatalf("seeding the sibling workspace: %v", err)
 	}
 

--- a/backend/internal/compose/integration/customfields_integration_test.go
+++ b/backend/internal/compose/integration/customfields_integration_test.go
@@ -78,7 +78,7 @@ func seedSecondWorkspace(t *testing.T, owner *pgx.Conn) (ids.UUID, context.Conte
 	t.Helper()
 	ws, user := ids.NewV7(), ids.NewV7()
 	if _, err := owner.Exec(context.Background(),
-		`INSERT INTO workspace (id, name, slug, base_currency) VALUES ($1, 'Tenant B', $2, 'EUR')`,
+		`INSERT INTO workspace (id, slug) VALUES ($1, $2)`,
 		ws, "tenant-b-"+ws.String()[:8]); err != nil {
 		t.Fatal(err)
 	}

--- a/backend/internal/compose/integration/harness.go
+++ b/backend/internal/compose/integration/harness.go
@@ -74,7 +74,7 @@ func Setup(t *testing.T) *Env {
 		Team1: ids.NewV7(), Team2: ids.NewV7(),
 	}
 	if _, err := owner.Exec(ctx,
-		`INSERT INTO workspace (id, name, slug, base_currency) VALUES ($1, 'Authz', 'authz', 'EUR')`, e.WS); err != nil {
+		`INSERT INTO workspace (id, slug) VALUES ($1, 'authz')`, e.WS); err != nil {
 		t.Fatal(err)
 	}
 	seedInstallationIdentity(ctx, t, owner)

--- a/backend/internal/compose/integration/installation_integration_test.go
+++ b/backend/internal/compose/integration/installation_integration_test.go
@@ -119,15 +119,8 @@ func TestBootstrapSeedsFollowTheDeploymentConfiguration(t *testing.T) {
 		t.Fatalf("starter_automations=%d booking_pages=%d, want both 0 (toggled off)", automations, bookingPages)
 	}
 
-	// The organization carries the configured currency; the admin signs in
-	// through the normal login.
-	var currency string
-	if err := e.Owner.QueryRow(ctx, `SELECT base_currency FROM workspace WHERE name = 'Configured Org'`).Scan(&currency); err != nil {
-		t.Fatal(err)
-	}
-	if currency != "USD" {
-		t.Fatalf("base_currency = %q, want the configured USD", currency)
-	}
+	// The configured currency is asserted with the other two settings below —
+	// they are one act of bootstrap and one place to read it back.
 	if status := e.Call(t, "POST", "/v1/auth/login", apptest.AnyMap{
 		"email": "ops@configured.test", "password": "correct-horse-battery",
 	}, nil, nil); status != http.StatusOK {

--- a/backend/internal/compose/integration/installation_integration_test.go
+++ b/backend/internal/compose/integration/installation_integration_test.go
@@ -202,7 +202,7 @@ func TestSecondActiveWorkspaceTurnsTheSurfaceUnavailable(t *testing.T) {
 	// cached singleton) must answer 503 on every request — an operator
 	// condition, never an auth failure.
 	if _, err := e.Owner.Exec(context.Background(),
-		`INSERT INTO workspace (id, name, slug, base_currency) VALUES ($1, 'Rogue Second', 'rogue-second', 'EUR')`,
+		`INSERT INTO workspace (id, slug) VALUES ($1, 'rogue-second')`,
 		ids.NewV7()); err != nil {
 		t.Fatal(err)
 	}

--- a/backend/internal/compose/integration/installationseam_integration_test.go
+++ b/backend/internal/compose/integration/installationseam_integration_test.go
@@ -5,16 +5,12 @@
 
 package integration
 
-// The installation's identity — name, base currency, timezone — comes from the
-// SETTING rows (ADR-0090/A135).
+// The installation's identity — name, base currency, timezone — is what these
+// readers resolve (ADR-0090/A135).
 //
-// These tests were written while the workspace columns still held a second
-// copy, and they moved the two apart because that was the only fixture that
-// could tell the readers apart. 0209 dropped the columns, so the divergence
-// they staged is no longer expressible — what survives is the half that still
-// says something: the settings row drives the answer, and each test moves it
-// off the value every other suite seeds so the assertion cannot pass by
-// accident.
+// Each test moves its setting OFF the value every other suite seeds, so no
+// assertion can pass by coincidence: a reader that never consulted the setting
+// answers with the seeded value and fails.
 
 import (
 	"strings"
@@ -25,9 +21,8 @@ import (
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
-// baseCurrencyOnUSD points the setting at USD while the workspace column
-// stays EUR, and puts a EUR→USD rate on the sheet. The disagreement is the
-// test: a reader still on the column sees base EUR.
+// baseCurrencyOnUSD points the installation at USD — every other suite seeds
+// EUR — and puts a EUR→USD rate on the sheet to convert with.
 func baseCurrencyOnUSD(t *testing.T, e *Env) {
 	t.Helper()
 	e.WsExec(t, `UPDATE setting SET value = '"USD"'::jsonb WHERE key = 'installation.base_currency'`)
@@ -35,10 +30,9 @@ func baseCurrencyOnUSD(t *testing.T, e *Env) {
 		VALUES ($1, 'EUR', 'USD', '1.1000000000', CURRENT_DATE - 1)`, e.WS)
 }
 
-// Closing a EUR deal freezes the EUR→USD rate. This is the assertion that
-// separates the two readers: against the column the deal's own currency WOULD
-// equal the base, and freezeFx short-circuits to the identity rate 1 without
-// consulting the sheet at all.
+// Closing a EUR deal freezes the EUR→USD rate. The identity rate 1 is what a
+// close computes when the deal's currency EQUALS the base, so a rate of 1 here
+// means the close read a base of EUR — the seeded value, not the one set.
 func TestClosingADealFreezesAgainstTheSettingsBaseCurrency(t *testing.T) {
 	e := Setup(t)
 	pipeline, open, won := DealFixture(t, e)
@@ -69,8 +63,7 @@ func TestClosingADealFreezesAgainstTheSettingsBaseCurrency(t *testing.T) {
 	}
 }
 
-// The fx sheet is listed against the base the SETTING names, so a rate priced
-// into the retiring column's currency is not on it.
+// The fx sheet is listed against the base the installation names.
 func TestTheFxSheetListsRatesIntoTheSettingsBaseCurrency(t *testing.T) {
 	e := Setup(t)
 	admin := e.Admin()
@@ -81,16 +74,14 @@ func TestTheFxSheetListsRatesIntoTheSettingsBaseCurrency(t *testing.T) {
 		t.Fatal(err)
 	}
 	if base != "USD" {
-		t.Errorf("BaseCurrency() = %q, want USD — the fx screen is still reading the column", base)
+		t.Errorf("BaseCurrency() = %q, want USD — the fx screen did not read the setting", base)
 	}
 }
 
 // The offer's issuer snapshot names the installation from the SETTING.
 //
-// The column keeps the harness's "Authz" while the setting says otherwise, so
-// a reader still on the column records the wrong issuer on a document that
-// goes to a buyer — and, because the snapshot is frozen at send, records it
-// permanently.
+// The snapshot is frozen at send, so an issuer read from anywhere but the
+// setting is recorded permanently on a document that goes to a buyer.
 func TestAnOfferSnapshotNamesTheInstallationFromTheSetting(t *testing.T) {
 	e := Setup(t)
 	pipeline, open, _ := DealFixture(t, e)
@@ -113,7 +104,7 @@ func TestAnOfferSnapshotNamesTheInstallationFromTheSetting(t *testing.T) {
 	if n := e.WsCount(t, `SELECT count(*) FROM offer
 		WHERE id = $1 AND issuer_snapshot->>'workspace_name' = 'Margince Live'`,
 		ids.UUID(offer.Id)); n != 1 {
-		t.Error("the frozen issuer name is not the setting's — the snapshot read workspace.name")
+		t.Error("the frozen issuer name is not the setting's")
 	}
 }
 
@@ -122,11 +113,10 @@ func TestAnOfferSnapshotNamesTheInstallationFromTheSetting(t *testing.T) {
 // The assertion turns on the zone STRING rather than on a date, deliberately.
 // Any two real zones agree about the date for part of every day, so a
 // date-based fixture would pass or fail by the hour the suite happened to run
-// — the flakiness T11 rules out. Here the setting names a zone Postgres cannot
-// resolve (written by raw SQL, which is how it gets past the validator that
-// guards the real write path) while the column keeps a valid UTC. A reader on
-// the column still succeeds; only a reader on the setting fails, and the
-// failure names the zone it tried.
+// — the flakiness T11 rules out. So the setting names a zone Postgres cannot
+// resolve, written by raw SQL because that is how it gets past the validator
+// guarding the real write path. Only a reader that actually consults the
+// setting fails, and the failure names the zone it tried.
 func TestTodayIsComputedInTheZoneTheSettingNames(t *testing.T) {
 	e := Setup(t)
 	pipeline, open, _ := DealFixture(t, e)

--- a/backend/internal/compose/integration/installationseam_integration_test.go
+++ b/backend/internal/compose/integration/installationseam_integration_test.go
@@ -6,12 +6,15 @@
 package integration
 
 // The installation's identity — name, base currency, timezone — comes from the
-// SETTING rows, not from the workspace columns (ADR-0091 phase 4, issue #521).
+// SETTING rows (ADR-0090/A135).
 //
-// While both copies exist, every other test in this tree seeds them to the
-// same value — so reverting the readers to the column leaves those suites
-// green and the migration only LOOKS done. These tests set the two copies to
-// disagree, which is the one fixture that can tell the readers apart.
+// These tests were written while the workspace columns still held a second
+// copy, and they moved the two apart because that was the only fixture that
+// could tell the readers apart. 0209 dropped the columns, so the divergence
+// they staged is no longer expressible — what survives is the half that still
+// says something: the settings row drives the answer, and each test moves it
+// off the value every other suite seeds so the assertion cannot pass by
+// accident.
 
 import (
 	"strings"
@@ -28,9 +31,6 @@ import (
 func baseCurrencyOnUSD(t *testing.T, e *Env) {
 	t.Helper()
 	e.WsExec(t, `UPDATE setting SET value = '"USD"'::jsonb WHERE key = 'installation.base_currency'`)
-	if n := e.WsCount(t, `SELECT count(*) FROM workspace WHERE id = $1 AND base_currency = 'EUR'`, e.WS); n != 1 {
-		t.Fatal("the fixture needs the two copies to DISAGREE; workspace.base_currency is not EUR")
-	}
 	e.WsExec(t, `INSERT INTO fx_rate (workspace_id, from_currency, to_currency, rate, rate_date)
 		VALUES ($1, 'EUR', 'USD', '1.1000000000', CURRENT_DATE - 1)`, e.WS)
 }
@@ -98,9 +98,6 @@ func TestAnOfferSnapshotNamesTheInstallationFromTheSetting(t *testing.T) {
 	// the installation_settings read the issuer name now goes through.
 	ctx := e.As(e.Rep1, nil, offerRenderDeskPerms)
 	e.WsExec(t, `UPDATE setting SET value = '"Margince Live"'::jsonb WHERE key = 'installation.name'`)
-	if n := e.WsCount(t, `SELECT count(*) FROM workspace WHERE id = $1 AND name = 'Authz'`, e.WS); n != 1 {
-		t.Fatal("the fixture needs the two copies to DISAGREE; workspace.name is not Authz")
-	}
 
 	d, err := e.Deals.CreateDeal(ctx, deals.CreateDealInput{
 		Name: "Issuer", PipelineID: pipeline, StageID: open, Source: "manual",
@@ -135,9 +132,6 @@ func TestTodayIsComputedInTheZoneTheSettingNames(t *testing.T) {
 	pipeline, open, _ := DealFixture(t, e)
 	ctx := e.Admin()
 	e.WsExec(t, `UPDATE setting SET value = '"Margince/Nowhere"'::jsonb WHERE key = 'installation.timezone'`)
-	if n := e.WsCount(t, `SELECT count(*) FROM workspace WHERE id = $1 AND timezone = 'UTC'`, e.WS); n != 1 {
-		t.Fatal("the fixture needs the two copies to DISAGREE; workspace.timezone is not UTC")
-	}
 
 	closeOn := time.Now().UTC().AddDate(0, 0, 30)
 	if _, err := e.Deals.CreateDeal(ctx, deals.CreateDealInput{

--- a/backend/internal/compose/integration/offerrender_integration_test.go
+++ b/backend/internal/compose/integration/offerrender_integration_test.go
@@ -202,7 +202,7 @@ func TestOfferRenderPrepareRender_Sent_UsesFrozenBuyerAndIssuerSnapshot(t *testi
 	// legal issuer of record for a sent offer, the same rule as the buyer
 	// side above.
 	renamedWorkspace := "Renamed Workspace After Send"
-	e.WsExec(t, `UPDATE workspace SET name = $1 WHERE id = $2`, renamedWorkspace, e.WS)
+	e.WsExec(t, `UPDATE setting SET value = to_jsonb($1::text) WHERE key = 'installation.name'`, renamedWorkspace)
 
 	ing, err := e.Deals.PrepareRender(ctx, offerID)
 	if err != nil {

--- a/backend/internal/compose/integration/offerrender_integration_test.go
+++ b/backend/internal/compose/integration/offerrender_integration_test.go
@@ -368,7 +368,7 @@ func seedOfferRenderWorkspaceB(t *testing.T, e *Env, owner *pgx.Conn) ids.OfferI
 	t.Helper()
 	ws, user := ids.NewV7(), ids.NewV7()
 	if _, err := owner.Exec(context.Background(),
-		`INSERT INTO workspace (id, name, slug, base_currency) VALUES ($1, 'Tenant B Render', $2, 'EUR')`,
+		`INSERT INTO workspace (id, slug) VALUES ($1, $2)`,
 		ws, "render-b-"+ws.String()[:8]); err != nil {
 		t.Fatal(err)
 	}

--- a/backend/internal/compose/integration/offerrender_integration_test.go
+++ b/backend/internal/compose/integration/offerrender_integration_test.go
@@ -197,12 +197,12 @@ func TestOfferRenderPrepareRender_Sent_UsesFrozenBuyerAndIssuerSnapshot(t *testi
 		t.Fatalf("rename organization: %v", err)
 	}
 
-	// Renaming the WORKSPACE (the issuer side) after send must equally
+	// Renaming the INSTALLATION (the issuer side) after send must equally
 	// not move — resolveRenderIssuerName's frozen issuer_snapshot is the
 	// legal issuer of record for a sent offer, the same rule as the buyer
 	// side above.
-	renamedWorkspace := "Renamed Workspace After Send"
-	e.WsExec(t, `UPDATE setting SET value = to_jsonb($1::text) WHERE key = 'installation.name'`, renamedWorkspace)
+	renamedInstallation := "Renamed Installation After Send"
+	e.WsExec(t, `UPDATE setting SET value = to_jsonb($1::text) WHERE key = 'installation.name'`, renamedInstallation)
 
 	ing, err := e.Deals.PrepareRender(ctx, offerID)
 	if err != nil {

--- a/backend/internal/compose/integration/offertemplate_integration_test.go
+++ b/backend/internal/compose/integration/offertemplate_integration_test.go
@@ -427,7 +427,7 @@ func TestOfferTemplateRLS_TenantIsolation(t *testing.T) {
 
 	wsB := ids.NewV7()
 	if _, err := owner.Exec(context.Background(),
-		`INSERT INTO workspace (id, name, slug, base_currency) VALUES ($1, 'Template Tenant B', $2, 'EUR')`,
+		`INSERT INTO workspace (id, slug) VALUES ($1, $2)`,
 		wsB, "template-b-"+wsB.String()[:8]); err != nil {
 		t.Fatal(err)
 	}

--- a/backend/internal/compose/integration/organization_computed_integration_test.go
+++ b/backend/internal/compose/integration/organization_computed_integration_test.go
@@ -175,7 +175,7 @@ func seedComputedFieldsWorkspaceB(t *testing.T, owner *pgx.Conn) (ws ids.UUID, c
 	t.Helper()
 	ws, user := ids.NewV7(), ids.NewV7()
 	if _, err := owner.Exec(context.Background(),
-		`INSERT INTO workspace (id, name, slug, base_currency) VALUES ($1, 'Tenant B Computed', $2, 'EUR')`,
+		`INSERT INTO workspace (id, slug) VALUES ($1, $2)`,
 		ws, "computed-b-"+ws.String()[:8]); err != nil {
 		t.Fatal(err)
 	}

--- a/backend/internal/compose/integration/overlay/overlay_cutover_lifecycle_integration_test.go
+++ b/backend/internal/compose/integration/overlay/overlay_cutover_lifecycle_integration_test.go
@@ -216,7 +216,7 @@ func seedCleanWorkspace(t *testing.T, f flipEstate) context.Context {
 	ctx := context.Background()
 	ws := ids.NewV7()
 	if _, err := f.e.Owner.Exec(ctx,
-		`INSERT INTO workspace (id, name, slug, base_currency) VALUES ($1, 'Clean Rebuild', $2, 'EUR')`,
+		`INSERT INTO workspace (id, slug) VALUES ($1, $2)`,
 		ws, "clean-rebuild-"+ws.String()); err != nil {
 		t.Fatalf("seeding the clean workspace: %v", err)
 	}

--- a/backend/internal/compose/integration/overlay/overlay_dispatch_integration_test.go
+++ b/backend/internal/compose/integration/overlay/overlay_dispatch_integration_test.go
@@ -122,8 +122,8 @@ func seedOverlayModeWorkspace(t *testing.T) (ws, user ids.UUID) {
 	owner := integration.OwnerConn(t)
 	ws = ids.NewV7()
 	if _, err := owner.Exec(context.Background(),
-		`INSERT INTO workspace (id, name, slug, base_currency, x_sor_mode, x_incumbent)
-		 VALUES ($1, 'Overlay', $2, 'EUR', 'overlay', 'hubspot')`,
+		`INSERT INTO workspace (id, slug, x_sor_mode, x_incumbent)
+		 VALUES ($1, $2, 'overlay', 'hubspot')`,
 		ws, "overlay-"+ws.String()); err != nil {
 		t.Fatalf("seeding the overlay-mode workspace: %v", err)
 	}

--- a/backend/internal/compose/integration/overlay/overlay_toolsurface_integration_test.go
+++ b/backend/internal/compose/integration/overlay/overlay_toolsurface_integration_test.go
@@ -389,7 +389,7 @@ func seedNativeModeWorkspaceForFlip(t *testing.T) (ws, user ids.UUID) {
 	owner := integration.OwnerConn(t)
 	ws = ids.NewV7()
 	if _, err := owner.Exec(context.Background(),
-		`INSERT INTO workspace (id, name, slug, base_currency) VALUES ($1, 'Pre-flip', $2, 'EUR')`,
+		`INSERT INTO workspace (id, slug) VALUES ($1, $2)`,
 		ws, "preflip-"+ws.String()); err != nil {
 		t.Fatalf("seeding the native-mode workspace: %v", err)
 	}

--- a/backend/internal/compose/integration/passports_integration_test.go
+++ b/backend/internal/compose/integration/passports_integration_test.go
@@ -60,7 +60,7 @@ func setupPassports(t *testing.T) *passportsEnv {
 
 	e := &passportsEnv{WS: ids.NewV7(), alice: ids.NewV7(), bob: ids.NewV7()}
 	if _, err := owner.Exec(ctx,
-		`INSERT INTO workspace (id, name, slug, base_currency) VALUES ($1, 'Passports', 'passports', 'EUR')`, e.WS); err != nil {
+		`INSERT INTO workspace (id, slug) VALUES ($1, 'passports')`, e.WS); err != nil {
 		t.Fatal(err)
 	}
 	for i, user := range []ids.UUID{e.alice, e.bob} {

--- a/backend/internal/compose/integration/perfbench_integration_test.go
+++ b/backend/internal/compose/integration/perfbench_integration_test.go
@@ -251,7 +251,7 @@ func seedBenchTier(t *testing.T, owner *pgx.Conn, ws ids.UUID, spec benchTierSpe
 		benchExec(t, owner, spec.tier, sql, args...)
 	}
 
-	exec(`INSERT INTO workspace (id, name, slug, base_currency) VALUES ($1, 'Bench', 'bench', 'EUR')`, ws)
+	exec(`INSERT INTO workspace (id, slug) VALUES ($1, 'bench')`, ws)
 
 	// Every ~97th person carries the FTS token the canonical search
 	// query hits, so the query does real ranking work over a real

--- a/backend/internal/compose/integration/quotas_attainment_integration_test.go
+++ b/backend/internal/compose/integration/quotas_attainment_integration_test.go
@@ -417,7 +417,7 @@ func TestQuotaAttainment_RequiresDealRead(t *testing.T) {
 	}
 }
 
-// The base currency comes from the SETTING, not from workspace.base_currency.
+// The base currency comes from the installation SETTING.
 //
 // This is the only assertion in the suite that can tell the two apart. Every
 // other test seeds both to EUR, so it passes just as well against a reader
@@ -429,7 +429,7 @@ func TestQuotaAttainment_RequiresDealRead(t *testing.T) {
 // The workspace column is written directly rather than through the settings
 // surface: that surface writes BOTH copies in one transaction (identity's
 // transitional mirror), which is precisely the agreement being broken here.
-func TestQuotaAttainmentTakesItsBaseCurrencyFromTheSettingNotTheColumn(t *testing.T) {
+func TestQuotaAttainmentConvertsAgainstTheInstallationSetting(t *testing.T) {
 	e := Setup(t)
 	store := attainmentStore(e)
 	ctx := e.As(e.Rep1, nil, quotaAdminPerms)
@@ -438,9 +438,6 @@ func TestQuotaAttainmentTakesItsBaseCurrencyFromTheSettingNotTheColumn(t *testin
 	// The fixture is only meaningful while the two copies disagree. Once
 	// phase 4 drops the column this guard stops finding it and the test
 	// becomes an ordinary assertion about the setting, which is the point.
-	if n := e.WsCount(t, `SELECT count(*) FROM workspace WHERE id = $1 AND base_currency = 'EUR'`, e.WS); n != 1 {
-		t.Fatalf("the fixture needs the two copies to DISAGREE; workspace.base_currency is not EUR")
-	}
 
 	// EUR→USD on file, so a target in EUR has a rate into the new base. The
 	// suite's seedRollupFxRate helper hardcodes to_currency = 'EUR', which is
@@ -460,7 +457,7 @@ func TestQuotaAttainmentTakesItsBaseCurrencyFromTheSettingNotTheColumn(t *testin
 		t.Fatalf("attainment with the setting on USD: %v", err)
 	}
 	if att.Currency != "USD" {
-		t.Errorf("attainment currency = %q, want USD — the reader is still on workspace.base_currency", att.Currency)
+		t.Errorf("attainment currency = %q, want USD — the setting is not what the conversion used", att.Currency)
 	}
 	if att.TargetMinor != 1100000 {
 		t.Errorf("target = %d, want 1100000 (10,000.00 EUR @ 1.1 into the USD base)", att.TargetMinor)

--- a/backend/internal/compose/integration/quotas_attainment_integration_test.go
+++ b/backend/internal/compose/integration/quotas_attainment_integration_test.go
@@ -419,25 +419,16 @@ func TestQuotaAttainment_RequiresDealRead(t *testing.T) {
 
 // The base currency comes from the installation SETTING.
 //
-// This is the only assertion in the suite that can tell the two apart. Every
-// other test seeds both to EUR, so it passes just as well against a reader
-// that never left the column — which is exactly the trap ADR-0091 phase 4
-// sets while the two copies coexist: the migration looks done and nothing
-// fails. Here the column stays EUR and the setting says USD, so a reader on
-// the old source labels the answer EUR and this test fails.
-//
-// The workspace column is written directly rather than through the settings
-// surface: that surface writes BOTH copies in one transaction (identity's
-// transitional mirror), which is precisely the agreement being broken here.
+// Every other test in this suite runs on the seeded EUR, so this one moves the
+// setting to USD: an attainment still labelled EUR is one that never read it.
+// The setting is written by raw SQL rather than through the settings surface,
+// which would take an update gate this fixture has no reason to hold.
 func TestQuotaAttainmentConvertsAgainstTheInstallationSetting(t *testing.T) {
 	e := Setup(t)
 	store := attainmentStore(e)
 	ctx := e.As(e.Rep1, nil, quotaAdminPerms)
 
 	e.WsExec(t, `UPDATE setting SET value = '"USD"'::jsonb WHERE key = 'installation.base_currency'`)
-	// The fixture is only meaningful while the two copies disagree. Once
-	// phase 4 drops the column this guard stops finding it and the test
-	// becomes an ordinary assertion about the setting, which is the point.
 
 	// EUR→USD on file, so a target in EUR has a rate into the new base. The
 	// suite's seedRollupFxRate helper hardcodes to_currency = 'EUR', which is

--- a/backend/internal/compose/integration/quotas_integration_test.go
+++ b/backend/internal/compose/integration/quotas_integration_test.go
@@ -528,7 +528,7 @@ func TestQuotaRLS_TenantIsolation(t *testing.T) {
 	// Tenant B, full quota authority — RLS, not RBAC, is what walls it off.
 	wsB := ids.NewV7()
 	if _, err := owner.Exec(context.Background(),
-		`INSERT INTO workspace (id, name, slug, base_currency) VALUES ($1, 'Quota Tenant B', $2, 'EUR')`,
+		`INSERT INTO workspace (id, slug) VALUES ($1, $2)`,
 		wsB, "quota-b-"+wsB.String()[:8]); err != nil {
 		t.Fatal(err)
 	}

--- a/backend/internal/compose/integration/rates_http_integration_test.go
+++ b/backend/internal/compose/integration/rates_http_integration_test.go
@@ -34,7 +34,7 @@ func baseCurrency(e *apptest.AppEnv, t *testing.T) string {
 	t.Helper()
 	var base string
 	if err := e.Owner.QueryRow(context.Background(),
-		`SELECT base_currency FROM workspace WHERE slug = $1`, e.Slug).Scan(&base); err != nil {
+		`SELECT value #>> '{}' FROM setting WHERE key = 'installation.base_currency'`, e.Slug).Scan(&base); err != nil {
 		t.Fatalf("base currency lookup: %v", err)
 	}
 	return base

--- a/backend/internal/compose/integration/rates_http_integration_test.go
+++ b/backend/internal/compose/integration/rates_http_integration_test.go
@@ -34,7 +34,7 @@ func baseCurrency(e *apptest.AppEnv, t *testing.T) string {
 	t.Helper()
 	var base string
 	if err := e.Owner.QueryRow(context.Background(),
-		`SELECT value #>> '{}' FROM setting WHERE key = 'installation.base_currency'`, e.Slug).Scan(&base); err != nil {
+		`SELECT value #>> '{}' FROM setting WHERE key = 'installation.base_currency'`).Scan(&base); err != nil {
 		t.Fatalf("base currency lookup: %v", err)
 	}
 	return base

--- a/backend/internal/compose/integration/roster_integration_test.go
+++ b/backend/internal/compose/integration/roster_integration_test.go
@@ -103,7 +103,7 @@ func TestRosterReadsUsersAndTeams(t *testing.T) {
 	// under workspace A's session (RLS row-scope). Seed workspace B (a
 	// non-tenant row) then its user inside B's GUC.
 	if _, err := e.Owner.Exec(context.Background(),
-		`INSERT INTO workspace (id, name, slug, base_currency) VALUES ($1, 'Other', 'fable-other', 'EUR')`,
+		`INSERT INTO workspace (id, slug) VALUES ($1, 'fable-other')`,
 		ids.NewV7()); err != nil {
 		t.Fatalf("seeding workspace B: %v", err)
 	}

--- a/backend/internal/compose/integration/searchenv.go
+++ b/backend/internal/compose/integration/searchenv.go
@@ -73,7 +73,7 @@ func SetupSearch(t *testing.T) *SearchEnv {
 		Owner: owner, WS: ids.NewV7(),
 		Rep1: ids.NewV7(), Rep3: ids.NewV7(), Team1: ids.NewV7(), Team2: ids.NewV7(),
 	}
-	if _, err := owner.Exec(ctx, `INSERT INTO workspace (id, name, slug, base_currency) VALUES ($1, 'Search', 'search', 'EUR')`, e.WS); err != nil {
+	if _, err := owner.Exec(ctx, `INSERT INTO workspace (id, slug) VALUES ($1, 'search')`, e.WS); err != nil {
 		t.Fatal(err)
 	}
 	for i, u := range []ids.UUID{e.Rep1, e.Rep3} {

--- a/backend/internal/compose/integration/seed.go
+++ b/backend/internal/compose/integration/seed.go
@@ -117,8 +117,8 @@ func SeedExtraWorkspace(t *testing.T, owner *pgx.Conn, name string, archived boo
 		archivedAt = "now()"
 	}
 	if _, err := owner.Exec(context.Background(), `
-		INSERT INTO workspace (id, name, slug, base_currency, archived_at)
-		VALUES ($1, $2, $3, 'EUR', `+archivedAt+`)`, ws, name, name+"-"+ws.String()); err != nil {
+		INSERT INTO workspace (id, slug, archived_at)
+		VALUES ($1, $2, `+archivedAt+`)`, ws, name+"-"+ws.String()); err != nil {
 		t.Fatalf("seeding the %s workspace: %v", name, err)
 	}
 	return ws

--- a/backend/internal/compose/integration/voice_integration_test.go
+++ b/backend/internal/compose/integration/voice_integration_test.go
@@ -378,7 +378,7 @@ func TestVoiceProfileIsInvisibleAcrossTenants(t *testing.T) {
 	ctx := context.Background()
 	wsB, userB := ids.NewV7(), ids.NewV7()
 	if _, err := e.Owner.Exec(ctx,
-		`INSERT INTO workspace (id, name, slug, base_currency) VALUES ($1, 'Voice Two', 'voice-two', 'EUR')`, wsB); err != nil {
+		`INSERT INTO workspace (id, slug) VALUES ($1, 'voice-two')`, wsB); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := e.Owner.Exec(ctx,

--- a/backend/internal/compose/report_forecast_integration_test.go
+++ b/backend/internal/compose/report_forecast_integration_test.go
@@ -89,7 +89,7 @@ func setupForecast(t *testing.T) *forecastEnv {
 		 ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value`); err != nil {
 		t.Fatalf("seeding the installation settings: %v", err)
 	}
-	if _, err := owner.Exec(ctx, `INSERT INTO workspace (id, name, slug, base_currency) VALUES ($1, 'Forecast', 'forecast', 'EUR')`, e.WS); err != nil {
+	if _, err := owner.Exec(ctx, `INSERT INTO workspace (id, slug) VALUES ($1, 'forecast')`, e.WS); err != nil {
 		t.Fatal(err)
 	}
 	for email, u := range map[string]ids.UUID{"rep1@forecast.test": e.Rep1, "rep3@forecast.test": e.Rep3} {
@@ -483,8 +483,7 @@ func (e *forecastEnv) forecastStatus(ctx context.Context, body string) int {
 	return rec.Code
 }
 
-// The forecast's "today" comes from the SETTING's zone, not from
-// workspace.timezone (ADR-0091 phase 4, issue #521).
+// The forecast's "today" comes from the installation SETTING's zone.
 //
 // It asserts a FLIP rather than a message. Asserting on a date would be
 // flaky — any two real zones agree about the date for part of every day, so
@@ -492,8 +491,10 @@ func (e *forecastEnv) forecastStatus(ctx context.Context, body string) int {
 // the response body: an unresolvable zone is a Postgres fault, which httperr
 // masks to an opaque 500 exactly as it should. So the fixture holds everything
 // constant and moves only the setting: the same report that answered 200
-// stops answering once the SETTING names a zone Postgres cannot resolve, while
-// workspace.timezone still says UTC. A reader on the column never notices.
+// stops answering once the SETTING names a zone Postgres cannot resolve. It
+// was written while workspace.timezone held a second copy and the flip was the
+// only way to tell the two readers apart; 0209 dropped that column, and the
+// flip still earns its place as the proof that the zone is consulted at all.
 func TestTheForecastBucketsInTheZoneTheSettingNames(t *testing.T) {
 	e := setupForecast(t)
 	// A commit deal WITH a close date, because the zone sits inside a CASE
@@ -512,17 +513,8 @@ func TestTheForecastBucketsInTheZoneTheSettingNames(t *testing.T) {
 		`UPDATE setting SET value = '"Margince/Nowhere"'::jsonb WHERE key = 'installation.timezone'`); err != nil {
 		t.Fatal(err)
 	}
-	var column string
-	if err := e.owner.QueryRow(context.Background(),
-		`SELECT timezone FROM workspace WHERE id = $1`, e.WS).Scan(&column); err != nil {
-		t.Fatal(err)
-	}
-	if column != "UTC" {
-		t.Fatalf("the fixture needs the two copies to DISAGREE; workspace.timezone = %q", column)
-	}
-
 	if got := e.forecastStatus(e.Admin(), body); got == http.StatusOK {
 		t.Error("the forecast still answered 200 with an unresolvable zone in the setting; " +
-			"the slipped-category dimension is reading workspace.timezone")
+			"the slipped-category dimension never consulted it")
 	}
 }

--- a/backend/internal/compose/report_forecast_integration_test.go
+++ b/backend/internal/compose/report_forecast_integration_test.go
@@ -491,10 +491,8 @@ func (e *forecastEnv) forecastStatus(ctx context.Context, body string) int {
 // the response body: an unresolvable zone is a Postgres fault, which httperr
 // masks to an opaque 500 exactly as it should. So the fixture holds everything
 // constant and moves only the setting: the same report that answered 200
-// stops answering once the SETTING names a zone Postgres cannot resolve. It
-// was written while workspace.timezone held a second copy and the flip was the
-// only way to tell the two readers apart; 0209 dropped that column, and the
-// flip still earns its place as the proof that the zone is consulted at all.
+// stops answering once the SETTING names a zone Postgres cannot resolve, which
+// is the proof that the zone is consulted at all.
 func TestTheForecastBucketsInTheZoneTheSettingNames(t *testing.T) {
 	e := setupForecast(t)
 	// A commit deal WITH a close date, because the zone sits inside a CASE

--- a/backend/internal/compose/settingswiring.go
+++ b/backend/internal/compose/settingswiring.go
@@ -39,7 +39,7 @@ var settingsDefinitions = sync.OnceValue(func() []settings.Definition {
 	// Injected here, once, the way ADR-0054 requires; settingscatalog_test.go
 	// asserts it actually happened, because an unwired probe fails OPEN (the
 	// setting stays changeable) rather than loudly.
-	identity.BaseCurrency.WithFreeze(deals.BaseCurrencyFrozen)
+	identity.BaseCurrency.WithFreeze(deals.BaseCurrencyFreeze(identity.BaseCurrency.Key()))
 
 	var defs []settings.Definition
 	defs = append(defs, capture.Definitions()...)

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -12269,7 +12269,7 @@ type MeResponse struct {
 	// User A seat — human or first-party agent. Mirrors `app_user`.
 	User User `json:"user"`
 
-	// WorkspaceName The installation's organization name (workspace.name). Shown as the typed-confirmation target of the non-production "Reset data" action — the exact string that endpoint validates.
+	// WorkspaceName The installation's organization name (the installation.name setting). Shown as the typed-confirmation target of the non-production "Reset data" action — the exact string that endpoint validates.
 	WorkspaceName string `json:"workspace_name"`
 }
 

--- a/backend/internal/modules/activities/commitments_integration_test.go
+++ b/backend/internal/modules/activities/commitments_integration_test.go
@@ -75,7 +75,7 @@ func setupPromises(t *testing.T) *promiseEnv {
 
 	e := &promiseEnv{owner: owner, ws: ids.NewV7(), rep: ids.NewV7(), other: ids.NewV7()}
 	if _, err := owner.Exec(ctx,
-		`INSERT INTO workspace (id, name, slug, base_currency) VALUES ($1, 'Promises', $2, 'EUR')`,
+		`INSERT INTO workspace (id, slug) VALUES ($1, $2)`,
 		e.ws, "promises-"+e.ws.String()); err != nil {
 		t.Fatal(err)
 	}

--- a/backend/internal/modules/activities/email_integration_test.go
+++ b/backend/internal/modules/activities/email_integration_test.go
@@ -120,7 +120,7 @@ func setupSend(t *testing.T) *sendEnv {
 
 	e := &sendEnv{owner: owner, ws: ids.NewV7(), rep: ids.NewV7(), other: ids.NewV7()}
 	if _, err := owner.Exec(ctx,
-		`INSERT INTO workspace (id, name, slug, base_currency) VALUES ($1, 'Send', $2, 'EUR')`,
+		`INSERT INTO workspace (id, slug) VALUES ($1, $2)`,
 		e.ws, "send-"+e.ws.String()); err != nil {
 		t.Fatal(err)
 	}

--- a/backend/internal/modules/activities/messageidentity_absorb_integration_test.go
+++ b/backend/internal/modules/activities/messageidentity_absorb_integration_test.go
@@ -93,7 +93,7 @@ func (e *sendEnv) seedNeighbourWorkspace(t *testing.T) ids.UUID {
 	t.Helper()
 	id := ids.NewV7()
 	if _, err := e.owner.Exec(context.Background(),
-		`INSERT INTO workspace (id, name, slug, base_currency) VALUES ($1, 'Neighbour', $2, 'EUR')`,
+		`INSERT INTO workspace (id, slug) VALUES ($1, $2)`,
 		id, "neighbour-"+id.String()); err != nil {
 		t.Fatalf("seeding the neighbouring workspace: %v", err)
 	}

--- a/backend/internal/modules/ai/ratestore_integration_test.go
+++ b/backend/internal/modules/ai/ratestore_integration_test.go
@@ -65,7 +65,7 @@ func (e *rateEnv) seedWorkspace(ctx context.Context, t *testing.T) (ids.UUID, co
 	t.Helper()
 	ws := ids.NewV7()
 	if _, err := e.owner.Exec(ctx,
-		`INSERT INTO workspace (id, name, slug, base_currency) VALUES ($1, 'RatePricing', $2, 'EUR')`,
+		`INSERT INTO workspace (id, slug) VALUES ($1, $2)`,
 		ws, "rp-"+ws.String()); err != nil {
 		t.Fatal(err)
 	}

--- a/backend/internal/modules/ai/voice_sendoutcome_integration_test.go
+++ b/backend/internal/modules/ai/voice_sendoutcome_integration_test.go
@@ -103,7 +103,7 @@ func (e *sendOutcomeEnv) seedDraft(t *testing.T, opts draftOptions) draftFixture
 	ctx := context.Background()
 	workspace := ids.NewV7()
 	if _, err := e.owner.Exec(ctx,
-		`INSERT INTO workspace (id, name, slug, base_currency) VALUES ($1, 'VoiceSend', $2, 'EUR')`,
+		`INSERT INTO workspace (id, slug) VALUES ($1, $2)`,
 		workspace, "vs-"+workspace.String()); err != nil {
 		t.Fatal(err)
 	}

--- a/backend/internal/modules/approvals/stageunlessdeclined_integration_test.go
+++ b/backend/internal/modules/approvals/stageunlessdeclined_integration_test.go
@@ -56,7 +56,7 @@ func setupStaging(t *testing.T) *stagingEnv {
 
 	e := &stagingEnv{owner: owner, ws: ids.NewV7(), rep: ids.NewV7()}
 	if _, err := owner.Exec(ctx,
-		`INSERT INTO workspace (id, name, slug, base_currency) VALUES ($1, 'Staging', $2, 'EUR')`,
+		`INSERT INTO workspace (id, slug) VALUES ($1, $2)`,
 		e.ws, "st-"+e.ws.String()); err != nil {
 		t.Fatal(err)
 	}

--- a/backend/internal/modules/automation/autofixture_integration_test.go
+++ b/backend/internal/modules/automation/autofixture_integration_test.go
@@ -60,7 +60,7 @@ func setupAutomationDB(t *testing.T) *autoFixture {
 	// The database is already migrated (`make migrate`, the integration
 	// lane's precondition); each run seeds its own workspace, keyed by
 	// the workspace id so reruns never collide on the slug uniques.
-	fx.exec(t, `INSERT INTO workspace (id, name, slug, base_currency) VALUES ($1, 'Runs', $2, 'EUR')`, fx.ws, "runs-"+fx.ws.String())
+	fx.exec(t, `INSERT INTO workspace (id, slug) VALUES ($1, $2)`, fx.ws, "runs-"+fx.ws.String())
 	fx.exec(t, `INSERT INTO app_user (id, workspace_id, email, display_name) VALUES ($1, $2, $3, 'Rep1')`, fx.rep1, fx.ws, "rep1-"+fx.rep1.String()+"@runs.test")
 	fx.exec(t, `INSERT INTO app_user (id, workspace_id, email, display_name) VALUES ($1, $2, $3, 'Rep2')`, fx.rep2, fx.ws, "rep2-"+fx.rep2.String()+"@runs.test")
 

--- a/backend/internal/modules/automation/automationhistory_integration_test.go
+++ b/backend/internal/modules/automation/automationhistory_integration_test.go
@@ -121,7 +121,7 @@ func TestListRunsHidesAbsentAndForeignAutomations(t *testing.T) {
 		t.Fatalf("absent automation → %v, want ErrNotFound", err)
 	}
 	foreignWS := ids.NewV7()
-	fx.exec(t, `INSERT INTO workspace (id, name, slug, base_currency) VALUES ($1, 'Other', 'other', 'EUR')`, foreignWS)
+	fx.exec(t, `INSERT INTO workspace (id, slug) VALUES ($1, 'other')`, foreignWS)
 	foreignAuto := ids.New[ids.AutomationKind]()
 	fx.exec(t, `
 		INSERT INTO automation (id, workspace_id, key, name, trigger, action, params, enabled)

--- a/backend/internal/modules/capture/channelconnfixture_test.go
+++ b/backend/internal/modules/capture/channelconnfixture_test.go
@@ -194,7 +194,7 @@ func newChannelFixture(t *testing.T, api *fakeTelegram) *channelFixture {
 	// slug's unique index.
 	slug := "capture-channel-" + wsUUID.String()
 	if _, err := owner.Exec(ctx,
-		`INSERT INTO workspace (id, name, slug, base_currency) VALUES ($1, 'Capture Channel', $2, 'USD')`,
+		`INSERT INTO workspace (id, slug) VALUES ($1, $2)`,
 		wsUUID, slug); err != nil {
 		t.Fatalf("seeding workspace: %v", err)
 	}

--- a/backend/internal/modules/capture/owndomainstore_integration_test.go
+++ b/backend/internal/modules/capture/owndomainstore_integration_test.go
@@ -47,7 +47,7 @@ func ownDomainWorkspace(t *testing.T) (context.Context, *pgxpool.Pool) {
 	ctx := context.Background()
 	ws := ids.NewV7()
 	if _, err := owner.Exec(ctx,
-		`INSERT INTO workspace (id, name, slug, base_currency) VALUES ($1, 'Own Domains', $2, 'EUR')`,
+		`INSERT INTO workspace (id, slug) VALUES ($1, $2)`,
 		ws, "own-domains-"+ws.String()); err != nil {
 		t.Fatalf("seeding workspace: %v", err)
 	}

--- a/backend/internal/modules/capture/rawcapture_integration_test.go
+++ b/backend/internal/modules/capture/rawcapture_integration_test.go
@@ -35,7 +35,7 @@ func bootstrapRawCaptureWorkspace(t *testing.T) context.Context {
 	wsUUID := ids.NewV7()
 	slug := "raw-capture-" + wsUUID.String()
 	if _, err := owner.Exec(ctx,
-		`INSERT INTO workspace (id, name, slug, base_currency) VALUES ($1, 'Raw Capture', $2, 'USD')`,
+		`INSERT INTO workspace (id, slug) VALUES ($1, $2)`,
 		wsUUID, slug); err != nil {
 		t.Fatalf("seeding workspace: %v", err)
 	}

--- a/backend/internal/modules/capture/registry_disconnect_integration_test.go
+++ b/backend/internal/modules/capture/registry_disconnect_integration_test.go
@@ -138,7 +138,7 @@ func newCaptureRegistryFixture(t *testing.T) (context.Context, *capture.Registry
 	// slug and collide on workspace_slug_unique.
 	slug := "capture-disconnect-" + wsUUID.String()
 	if _, err := owner.Exec(ctx,
-		`INSERT INTO workspace (id, name, slug, base_currency) VALUES ($1, 'Capture Disconnect', $2, 'USD')`,
+		`INSERT INTO workspace (id, slug) VALUES ($1, $2)`,
 		wsUUID, slug); err != nil {
 		t.Fatalf("seeding workspace: %v", err)
 	}

--- a/backend/internal/modules/capture/sinkchannel_integration_test.go
+++ b/backend/internal/modules/capture/sinkchannel_integration_test.go
@@ -67,7 +67,7 @@ func TestChannelRecordSkipsEveryMailDomainGate(t *testing.T) {
 	ctx := context.Background()
 	ws := ids.NewV7()
 	if _, err := owner.Exec(ctx,
-		`INSERT INTO workspace (id, name, slug, base_currency) VALUES ($1, 'Channel Sink', $2, 'EUR')`,
+		`INSERT INTO workspace (id, slug) VALUES ($1, $2)`,
 		ws, "channel-sink-"+ws.String()); err != nil {
 		t.Fatalf("seeding workspace: %v", err)
 	}

--- a/backend/internal/modules/capture/sinkinternal_integration_test.go
+++ b/backend/internal/modules/capture/sinkinternal_integration_test.go
@@ -40,7 +40,7 @@ func bootstrapInternalMailWorkspace(t *testing.T, ownDomains ...string) (context
 	wsUUID := ids.NewV7()
 	slug := "internal-mail-" + wsUUID.String()
 	if _, err := owner.Exec(ctx,
-		`INSERT INTO workspace (id, name, slug, base_currency) VALUES ($1, 'Internal Mail', $2, 'EUR')`,
+		`INSERT INTO workspace (id, slug) VALUES ($1, $2)`,
 		wsUUID, slug); err != nil {
 		t.Fatalf("seeding workspace: %v", err)
 	}

--- a/backend/internal/modules/comms/store_integration_test.go
+++ b/backend/internal/modules/comms/store_integration_test.go
@@ -90,7 +90,7 @@ func setupStore(t *testing.T) *storeEnv {
 		clockValue: time.Date(2026, 7, 28, 9, 0, 0, 0, time.UTC),
 	}
 	if _, err := owner.Exec(ctx,
-		`INSERT INTO workspace (id, name, slug, base_currency) VALUES ($1, 'Comms', $2, 'EUR')`,
+		`INSERT INTO workspace (id, slug) VALUES ($1, $2)`,
 		e.ws, "comms-"+e.ws.String()); err != nil {
 		t.Fatal(err)
 	}

--- a/backend/internal/modules/comms/store_isolation_integration_test.go
+++ b/backend/internal/modules/comms/store_isolation_integration_test.go
@@ -27,7 +27,7 @@ func (e *storeEnv) foreignWorkspaceCtx(t *testing.T) context.Context {
 	t.Helper()
 	other := ids.NewV7()
 	if _, err := e.owner.Exec(context.Background(),
-		`INSERT INTO workspace (id, name, slug, base_currency) VALUES ($1, 'CommsOther', $2, 'EUR')`,
+		`INSERT INTO workspace (id, slug) VALUES ($1, $2)`,
 		other, "comms-other-"+other.String()); err != nil {
 		t.Fatal(err)
 	}

--- a/backend/internal/modules/consent/channelconsent_integration_test.go
+++ b/backend/internal/modules/consent/channelconsent_integration_test.go
@@ -67,7 +67,7 @@ func setupChannelConsent(t *testing.T) *channelConsentEnv {
 	// this suite cannot collide on the identity's uniqueness index.
 	e.account = e.person.String()[:8]
 	if _, err := owner.Exec(ctx,
-		`INSERT INTO workspace (id, name, slug, base_currency) VALUES ($1, 'ChannelConsent', $2, 'EUR')`,
+		`INSERT INTO workspace (id, slug) VALUES ($1, $2)`,
 		e.ws, "cc-"+e.ws.String()); err != nil {
 		t.Fatal(err)
 	}

--- a/backend/internal/modules/consent/dsr_integration_test.go
+++ b/backend/internal/modules/consent/dsr_integration_test.go
@@ -71,7 +71,7 @@ func setupDSR(t *testing.T) *dsrEnv {
 
 	e := &dsrEnv{owner: owner, ws: ids.NewV7(), user: ids.NewV7()}
 	if _, err := owner.Exec(ctx,
-		`INSERT INTO workspace (id, name, slug, base_currency) VALUES ($1, 'DSR', $2, 'EUR')`,
+		`INSERT INTO workspace (id, slug) VALUES ($1, $2)`,
 		e.ws, "dsr-"+e.ws.String()); err != nil {
 		t.Fatal(err)
 	}

--- a/backend/internal/modules/consent/leadconsent_integration_test.go
+++ b/backend/internal/modules/consent/leadconsent_integration_test.go
@@ -63,7 +63,7 @@ func setupLeadConsent(t *testing.T) *leadConsentEnv {
 	}
 	e.leadEmail = "lena-" + e.lead.String() + "@warm.example"
 	if _, err := owner.Exec(ctx,
-		`INSERT INTO workspace (id, name, slug, base_currency) VALUES ($1, 'LeadConsent', $2, 'EUR')`,
+		`INSERT INTO workspace (id, slug) VALUES ($1, $2)`,
 		e.ws, "lc-"+e.ws.String()); err != nil {
 		t.Fatal(err)
 	}

--- a/backend/internal/modules/deals/basecurrencyfreeze.go
+++ b/backend/internal/modules/deals/basecurrencyfreeze.go
@@ -13,11 +13,10 @@ package deals
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/jackc/pgx/v5"
-
-	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 )
 
 // frozenRateTables are every table holding an `fx_rate_to_base` — the column
@@ -100,24 +99,24 @@ func frozenRateCount(ctx context.Context, tx pgx.Tx) (int, error) {
 // ratesPricedAgainstBase counts the sheet rows converting into the base the
 // workspace currently holds, and returns that base so the reason can name it.
 //
-// It reads workspace.base_currency rather than the setting row, and NOT
-// because the setting row is unwritten at this point — it holds the outgoing
-// value too, since the freeze probe runs before the update. The reason is the
-// FIRST write: on an installation that has never stored the setting there is
-// no row to read, and the refusing read (settings.RequireTx) would fail the
-// probe rather than answer "nothing is priced yet". The column always has a
-// value, so it can answer for the base being replaced in both cases.
-//
-// This is why the probe is not part of the sweep that moved the other readers
-// (issue #521): it needs the reading that tolerates an unset setting.
+// It reads the setting row directly rather than through platform/settings,
+// and NO ROW is a real answer here rather than a failure. This runs inside the
+// settings write's own transaction, and on the FIRST write there is nothing
+// stored yet — the refusing read would fail the probe where the honest answer
+// is "no base has been set, so nothing can be priced against it". An absent
+// row therefore yields zero and an empty base, which is what lets that first
+// write through.
 func ratesPricedAgainstBase(ctx context.Context, tx pgx.Tx) (int, string, error) {
 	var base string
 	var priced int
-	if err := tx.QueryRow(ctx, `
-		SELECT w.base_currency,
-		       (SELECT count(*) FROM fx_rate WHERE to_currency = w.base_currency)
-		  FROM workspace w WHERE w.id = $1`,
-		storekit.MustWorkspace(ctx)).Scan(&base, &priced); err != nil {
+	err := tx.QueryRow(ctx, `
+		SELECT s.value #>> '{}',
+		       (SELECT count(*) FROM fx_rate WHERE to_currency = s.value #>> '{}')
+		  FROM setting s WHERE s.key = 'installation.base_currency'`).Scan(&base, &priced)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return 0, "", nil
+	}
+	if err != nil {
 		return 0, "", fmt.Errorf("counting rates priced against the current base: %w", err)
 	}
 	return priced, base, nil

--- a/backend/internal/modules/deals/basecurrencyfreeze.go
+++ b/backend/internal/modules/deals/basecurrencyfreeze.go
@@ -37,7 +37,18 @@ import (
 // quietly widening the hole.
 var frozenRateTables = []string{"deal", "offer", "finance_invoice"}
 
-// BaseCurrencyFrozen reports whether the installation's base currency has
+// BaseCurrencyFreeze binds the probe to the settings key that HOLDS the base
+// currency. The key is injected rather than spelled here because deals may not
+// import the module that owns the entry (ADR-0054), and a literal copy would
+// go on pointing at the old name the day that entry is renamed — silently
+// answering "nothing is priced" for a setting that no longer exists.
+func BaseCurrencyFreeze(settingKey string) func(context.Context, pgx.Tx) (bool, string, error) {
+	return func(ctx context.Context, tx pgx.Tx) (bool, string, error) {
+		return baseCurrencyFrozen(ctx, tx, settingKey)
+	}
+}
+
+// baseCurrencyFrozen reports whether the installation's base currency has
 // stopped being changeable, and says why.
 //
 // TWO THINGS STOP IT, and they differ in whether anyone can undo them.
@@ -56,7 +67,7 @@ var frozenRateTables = []string{"deal", "offer", "finance_invoice"}
 //
 // Runs inside the caller's write transaction, so the answer cannot go stale
 // between the check and the write it guards.
-func BaseCurrencyFrozen(ctx context.Context, tx pgx.Tx) (bool, string, error) {
+func baseCurrencyFrozen(ctx context.Context, tx pgx.Tx, settingKey string) (bool, string, error) {
 	converted, err := frozenRateCount(ctx, tx)
 	if err != nil {
 		return false, "", err
@@ -67,7 +78,7 @@ func BaseCurrencyFrozen(ctx context.Context, tx pgx.Tx) (bool, string, error) {
 				"against it, so changing the base would re-mean every roll-up built on them",
 			converted), nil
 	}
-	priced, base, err := ratesPricedAgainstBase(ctx, tx)
+	priced, base, err := ratesPricedAgainstBase(ctx, tx, settingKey)
 	if err != nil {
 		return false, "", err
 	}
@@ -97,27 +108,42 @@ func frozenRateCount(ctx context.Context, tx pgx.Tx) (int, error) {
 }
 
 // ratesPricedAgainstBase counts the sheet rows converting into the base the
-// workspace currently holds, and returns that base so the reason can name it.
+// installation currently holds, and returns that base so the reason can name
+// it.
 //
-// It reads the setting row directly rather than through platform/settings,
-// and NO ROW is a real answer here rather than a failure. This runs inside the
-// settings write's own transaction, and on the FIRST write there is nothing
-// stored yet — the refusing read would fail the probe where the honest answer
-// is "no base has been set, so nothing can be priced against it". An absent
-// row therefore yields zero and an empty base, which is what lets that first
-// write through.
-func ratesPricedAgainstBase(ctx context.Context, tx pgx.Tx) (int, string, error) {
-	var base string
-	var priced int
-	err := tx.QueryRow(ctx, `
-		SELECT s.value #>> '{}',
-		       (SELECT count(*) FROM fx_rate WHERE to_currency = s.value #>> '{}')
-		  FROM setting s WHERE s.key = 'installation.base_currency'`).Scan(&base, &priced)
-	if errors.Is(err, pgx.ErrNoRows) {
-		return 0, "", nil
+// It reads the setting row directly rather than through platform/settings
+// because it runs INSIDE the settings write's own transaction, before the new
+// value is stored — the gated readers are for callers asking what the value
+// is, and this is the write asking what it is about to replace.
+//
+// An absent row does NOT mean "nothing is priced". Bootstrap seeds the row and
+// 0209 refuses to drop the columns without it, so the state is residual — but
+// where it does occur, a rate sheet can still be sitting there priced into
+// whatever the base used to be, and answering "not frozen" would let it be
+// restated out from under exactly the rows ADR-0085 §7 protects. So the sheet
+// is counted either way, and a sheet with rows in it freezes the base whether
+// or not the base itself can still be named.
+func ratesPricedAgainstBase(ctx context.Context, tx pgx.Tx, settingKey string) (int, string, error) {
+	var base *string
+	if err := tx.QueryRow(ctx,
+		`SELECT value #>> '{}' FROM setting WHERE key = $1`, settingKey,
+	).Scan(&base); err != nil && !errors.Is(err, pgx.ErrNoRows) {
+		return 0, "", fmt.Errorf("reading the installation's current base currency: %w", err)
 	}
-	if err != nil {
+	if base == nil {
+		// No base to compare against, so every rate on the sheet counts: the
+		// question "is anything priced against the outgoing base" cannot be
+		// answered more narrowly, and the safe answer is the conservative one.
+		var priced int
+		if err := tx.QueryRow(ctx, `SELECT count(*) FROM fx_rate`).Scan(&priced); err != nil {
+			return 0, "", fmt.Errorf("counting rates on the sheet: %w", err)
+		}
+		return priced, "the base it was set to", nil
+	}
+	var priced int
+	if err := tx.QueryRow(ctx,
+		`SELECT count(*) FROM fx_rate WHERE to_currency = $1`, *base).Scan(&priced); err != nil {
 		return 0, "", fmt.Errorf("counting rates priced against the current base: %w", err)
 	}
-	return priced, base, nil
+	return priced, *base, nil
 }

--- a/backend/internal/modules/finance/sync_integration_test.go
+++ b/backend/internal/modules/finance/sync_integration_test.go
@@ -62,7 +62,7 @@ func setupFinance(t *testing.T) *financeEnv {
 	}
 	connID := ids.NewV7()
 	if _, err := owner.Exec(ctx,
-		`INSERT INTO workspace (id, name, slug, base_currency) VALUES ($1, 'Finance', $2, 'EUR')`,
+		`INSERT INTO workspace (id, slug) VALUES ($1, $2)`,
 		e.ws, "fin-"+e.ws.String()); err != nil {
 		t.Fatal(err)
 	}

--- a/backend/internal/modules/identity/installation.go
+++ b/backend/internal/modules/identity/installation.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/gradionhq/margince/backend/internal/modules/identity/internal/password"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
+	"github.com/gradionhq/margince/backend/internal/platform/settings"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
@@ -170,11 +171,17 @@ func createInstallation(ctx context.Context, tx pgx.Tx, in InstallationBootstrap
 
 	var wsID ids.WorkspaceID
 	if err := tx.QueryRow(ctx,
-		`INSERT INTO workspace (name, slug, base_currency, timezone) VALUES ($1, $2, $3, $4) RETURNING id`,
-		boot.WorkspaceName, boot.Slug, currency, boot.Timezone).Scan(&wsID); err != nil {
+		`INSERT INTO workspace (slug) VALUES ($1) RETURNING id`, boot.Slug).Scan(&wsID); err != nil {
 		return ids.WorkspaceID{}, err
 	}
 	if _, err := tx.Exec(ctx, `SELECT set_config('app.workspace_id', $1, true)`, wsID.String()); err != nil {
+		return ids.WorkspaceID{}, err
+	}
+	// The installation's identity is written HERE, not read back off the row
+	// by a caller: normalize() and the currency default above are the only
+	// place these values are resolved, and a second derivation elsewhere would
+	// drift from them (the columns that used to carry them are gone).
+	if err := seedInstallationIdentity(ctx, tx, boot.WorkspaceName, boot.Timezone, currency); err != nil {
 		return ids.WorkspaceID{}, err
 	}
 
@@ -226,4 +233,24 @@ func slugify(name string) string {
 		}
 	}
 	return strings.Trim(b.String(), "-")
+}
+
+// seedInstallationIdentity writes the three settings rows that ARE the
+// installation's identity (ADR-0090/A135). Seed, not Set: this runs inside
+// bootstrap's own transaction, before any principal exists to gate a settings
+// write, and it is creating the values rather than changing them.
+func seedInstallationIdentity(ctx context.Context, tx pgx.Tx, name, zone, currency string) error {
+	for _, seed := range []struct {
+		entry *settings.Entry[string]
+		value string
+	}{
+		{Name, name},
+		{Timezone, zone},
+		{BaseCurrency, currency},
+	} {
+		if err := settings.SeedValue(ctx, tx, seed.entry, seed.value); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/backend/internal/modules/identity/installationsettings.go
+++ b/backend/internal/modules/identity/installationsettings.go
@@ -107,11 +107,9 @@ func (s *InstallationSettingsStore) baseCurrencyLock(ctx context.Context) (bool,
 // refused for a caller who may not write rather than answered from the read
 // gate alone.
 //
-// Every field commits in ONE transaction, and the settings rows are now the
-// only copy: the mirror onto the `workspace` columns retired with the columns
-// themselves in 0209, which is what #521 existed to make possible. A change
-// here moves the value everything computes in, because there is no longer a
-// second place for it to disagree.
+// Every field commits in ONE transaction, and the settings rows are the only
+// copy: a change here moves the value everything computes in, because there is
+// no second place for it to disagree.
 func (s *InstallationSettingsStore) UpdateInstallation(ctx context.Context, name, zone, currency *string) (InstallationSettings, error) {
 	if err := auth.Require(ctx, installationSettingsObject, principal.ActionUpdate); err != nil {
 		return InstallationSettings{}, err

--- a/backend/internal/modules/identity/installationsettings.go
+++ b/backend/internal/modules/identity/installationsettings.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
-	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/platform/settings"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
@@ -108,34 +107,22 @@ func (s *InstallationSettingsStore) baseCurrencyLock(ctx context.Context) (bool,
 // refused for a caller who may not write rather than answered from the read
 // gate alone.
 //
-// Every field commits in ONE transaction, together with a mirror write onto
-// the `workspace` columns. The mirror is TRANSITIONAL and load-bearing until
-// it goes. What still reads the columns directly, and so still depends on it:
-// the forecast's slipped-category dimension (compose/report.go), the brief
-// ranker's revenue factor (compose/briefs), the reset confirmation's name
-// (compose/datareset.go), the session read that names the installation before
-// any principal exists to gate a settings read (identity/service.go),
-// bootstrap's own backfill (compose/installation.go), and the base-currency
-// freeze probe below. Everything else has moved (issue #521). Without
-// it, this surface would report a base currency that nothing computes in —
-// changing it would move the number on this screen and leave every roll-up on
-// the old basis, which is worse than not offering the control. The mirror
-// retires with the columns, once those readers move (issue #521).
+// Every field commits in ONE transaction, and the settings rows are now the
+// only copy: the mirror onto the `workspace` columns retired with the columns
+// themselves in 0209, which is what #521 existed to make possible. A change
+// here moves the value everything computes in, because there is no longer a
+// second place for it to disagree.
 func (s *InstallationSettingsStore) UpdateInstallation(ctx context.Context, name, zone, currency *string) (InstallationSettings, error) {
 	if err := auth.Require(ctx, installationSettingsObject, principal.ActionUpdate); err != nil {
 		return InstallationSettings{}, err
 	}
-	// The mirror statement is a full literal per field rather than a built
-	// column name: nothing here is caller-supplied, and spelling it out keeps
-	// the table-ownership gate able to read the target out of the SQL.
 	patch := []struct {
-		entry  *settings.Entry[string]
-		value  *string
-		mirror string
+		entry *settings.Entry[string]
+		value *string
 	}{
-		{Name, name, `UPDATE workspace SET name = $1 WHERE id = $2`},
-		{Timezone, zone, `UPDATE workspace SET timezone = $1 WHERE id = $2`},
-		{BaseCurrency, currency, `UPDATE workspace SET base_currency = $1 WHERE id = $2`},
+		{Name, name},
+		{Timezone, zone},
+		{BaseCurrency, currency},
 	}
 	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
 		for _, w := range patch {
@@ -148,12 +135,6 @@ func (s *InstallationSettingsStore) UpdateInstallation(ctx context.Context, name
 			}
 			if err := s.settings.SetRawTx(ctx, tx, w.entry.Key(), raw); err != nil {
 				return err
-			}
-			// The mirror, in the same transaction as the setting it copies:
-			// the two can never disagree, which is the only property that
-			// makes keeping both tolerable.
-			if _, err := tx.Exec(ctx, w.mirror, *w.value, storekit.MustWorkspace(ctx)); err != nil {
-				return fmt.Errorf("identity: mirroring %s onto the workspace row: %w", w.entry.Key(), err)
 			}
 		}
 		return nil

--- a/backend/internal/modules/identity/service.go
+++ b/backend/internal/modules/identity/service.go
@@ -198,7 +198,13 @@ func (s *Service) Login(ctx context.Context, email, plaintext string) (Identity,
 		}
 
 		id = Identity{UserID: account.UserID, WorkspaceID: wsID, Email: email, DisplayName: account.DisplayName, SeatType: account.SeatType}
-		if err := tx.QueryRow(ctx, `SELECT name FROM workspace WHERE id = $1`, wsID).Scan(&id.WorkspaceName); err != nil {
+		// The setting row read directly, not through platform/settings: this
+		// runs BEFORE a principal exists, and that package's readers take the
+		// installation_settings object gate, which has no actor to judge. The
+		// name is the installation's own label, not tenant data.
+		if err := tx.QueryRow(ctx,
+			`SELECT value #>> '{}' FROM setting WHERE key = 'installation.name'`,
+		).Scan(&id.WorkspaceName); err != nil {
 			return err
 		}
 		var loadErr error
@@ -246,10 +252,10 @@ func (s *Service) Authenticate(ctx context.Context, rawToken string) (Identity, 
 		var sessionID ids.UUID
 		var userID ids.UserID
 		err := tx.QueryRow(ctx,
-			`SELECT s.id, u.id, u.email, u.display_name, u.seat_type, s.workspace_id, w.name
+			`SELECT s.id, u.id, u.email, u.display_name, u.seat_type, s.workspace_id,
+			        (SELECT value #>> '{}' FROM setting WHERE key = 'installation.name')
 			 FROM session s
 			 JOIN app_user u ON u.id = s.user_id
-			 JOIN workspace w ON w.id = s.workspace_id
 			 WHERE s.token_hash = $1
 			   AND s.revoked_at IS NULL
 			   AND now() < s.idle_expires_at

--- a/backend/internal/modules/identity/service.go
+++ b/backend/internal/modules/identity/service.go
@@ -202,8 +202,14 @@ func (s *Service) Login(ctx context.Context, email, plaintext string) (Identity,
 		// runs BEFORE a principal exists, and that package's readers take the
 		// installation_settings object gate, which has no actor to judge. The
 		// name is the installation's own label, not tenant data.
+		//
+		// coalesced, and to the empty string rather than an error: this is a
+		// display label on a login that has ALREADY succeeded. An installation
+		// with no stored name is a misconfiguration, and failing here would
+		// answer correct credentials with a 500 while wrong ones still got
+		// 401 — telling an attacker which passwords are right.
 		if err := tx.QueryRow(ctx,
-			`SELECT value #>> '{}' FROM setting WHERE key = 'installation.name'`,
+			`SELECT coalesce((SELECT value #>> '{}' FROM setting WHERE key = $1), '')`, Name.Key(),
 		).Scan(&id.WorkspaceName); err != nil {
 			return err
 		}
@@ -253,7 +259,7 @@ func (s *Service) Authenticate(ctx context.Context, rawToken string) (Identity, 
 		var userID ids.UserID
 		err := tx.QueryRow(ctx,
 			`SELECT s.id, u.id, u.email, u.display_name, u.seat_type, s.workspace_id,
-			        (SELECT value #>> '{}' FROM setting WHERE key = 'installation.name')
+			        coalesce((SELECT value #>> '{}' FROM setting WHERE key = $2), '')
 			 FROM session s
 			 JOIN app_user u ON u.id = s.user_id
 			 WHERE s.token_hash = $1
@@ -261,7 +267,7 @@ func (s *Service) Authenticate(ctx context.Context, rawToken string) (Identity, 
 			   AND now() < s.idle_expires_at
 			   AND now() < s.expires_at
 			   AND u.status = 'active' AND u.archived_at IS NULL`,
-			tokenHash).Scan(&sessionID, &userID, &id.Email, &id.DisplayName, &id.SeatType, &id.WorkspaceID, &id.WorkspaceName)
+			tokenHash, Name.Key()).Scan(&sessionID, &userID, &id.Email, &id.DisplayName, &id.SeatType, &id.WorkspaceID, &id.WorkspaceName)
 		if errors.Is(err, pgx.ErrNoRows) {
 			return apperrors.ErrNotFound
 		}

--- a/backend/internal/modules/identity/workspaceconfig.go
+++ b/backend/internal/modules/identity/workspaceconfig.go
@@ -3,13 +3,13 @@
 
 package identity
 
-// The workspace row has two halves. Bootstrap writes the installation's
-// IDENTITY from the deployment configuration file — name, slug, base
-// currency, timezone (installation.go) — and every other column on the row is
-// CONFIGURATION: it arrives at the default its migration declared and is
-// changed later through a settings surface. ResetWorkspaceConfig below
-// restores the second half to those defaults. The first half is what a data
-// reset must not touch, because the installation itself survives the reset.
+// The workspace row is CONFIGURATION now: its identity — name, base currency,
+// timezone — moved into `setting` (ADR-0090/A135) and the columns were dropped
+// (0209), leaving the slug bootstrap derives and columns that arrive at the
+// default their migration declared and are changed later through a settings
+// surface. ResetWorkspaceConfig below restores those defaults. What a data
+// reset must not touch lives in `setting`, where platform/settings.ResetConfig
+// draws the same line: the installation itself survives the reset.
 
 import (
 	"context"

--- a/backend/internal/modules/identity/workspaceconfig.go
+++ b/backend/internal/modules/identity/workspaceconfig.go
@@ -21,10 +21,14 @@ import (
 )
 
 // preservedWorkspaceColumns are the workspace columns the restore does not
-// assign: the primary key, the four values bootstrap takes from the deployment
-// configuration, and the row's own lifecycle timestamps. A reset wipes an
-// installation's DATA — it does not re-create the installation, so its name,
-// currency, zone and age outlive it.
+// assign: the primary key, the slug bootstrap derives from the organization
+// name, and the row's own lifecycle timestamps. A reset wipes an
+// installation's DATA — it does not re-create the installation, so its
+// identity and age outlive it.
+//
+// Name, currency and zone are absent because they are no longer columns
+// (0209): they are settings rows, and platform/settings.ResetConfig spares
+// them there for exactly this reason.
 //
 // updated_at is listed for a different reason than the rest. The reset really
 // does write this row, so trg_workspace_updated moves that column, and it
@@ -39,8 +43,8 @@ import (
 // silently escaping the reset, and a column that genuinely belongs to the
 // installation's identity has to be declared here to be spared.
 var preservedWorkspaceColumns = map[string]bool{
-	"id": true, "name": true, "slug": true, "base_currency": true,
-	"timezone": true, "created_at": true, "updated_at": true, "archived_at": true,
+	"id": true, "slug": true,
+	"created_at": true, "updated_at": true, "archived_at": true,
 }
 
 // workspaceConfigColumns lists the workspace columns a reset restores — every

--- a/backend/internal/modules/identity/workspaceconfig_integration_test.go
+++ b/backend/internal/modules/identity/workspaceconfig_integration_test.go
@@ -92,6 +92,26 @@ func TestResetWorkspaceConfigRestoresSettingsAndKeepsIdentity(t *testing.T) {
 		t.Fatalf("configuring the workspace away from its defaults: %v", err)
 	}
 
+	// The installation's identity as it stands BEFORE the reset. Compared
+	// against itself afterwards rather than against configBootstrap, because
+	// `setting` is non-tenant: several fixtures bootstrap into one database
+	// per package run and Seed is ON CONFLICT DO NOTHING, so the rows belong
+	// to whichever installation got there first (issue #863). Which one that
+	// is has nothing to do with the claim under test — that a reset wipes the
+	// DATA and leaves the installation standing.
+	var nameBefore, currencyBefore, zoneBefore string
+	if err := owner.QueryRow(ctx, `
+		SELECT coalesce((SELECT value #>> '{}' FROM setting WHERE key = 'installation.name'), ''),
+		       coalesce((SELECT value #>> '{}' FROM setting WHERE key = 'installation.base_currency'), ''),
+		       coalesce((SELECT value #>> '{}' FROM setting WHERE key = 'installation.timezone'), '')`).
+		Scan(&nameBefore, &currencyBefore, &zoneBefore); err != nil {
+		t.Fatalf("reading the installation's identity: %v", err)
+	}
+	if nameBefore == "" || currencyBefore == "" || zoneBefore == "" {
+		t.Fatalf("the fixture bootstrapped no identity to preserve: name=%q currency=%q zone=%q",
+			nameBefore, currencyBefore, zoneBefore)
+	}
+
 	wsCtx := principal.WithWorkspaceID(ctx, ws)
 	if err := database.WithWorkspaceTx(wsCtx, pool, func(tx pgx.Tx) error {
 		return ResetWorkspaceConfig(wsCtx, tx)
@@ -126,9 +146,10 @@ func TestResetWorkspaceConfigRestoresSettingsAndKeepsIdentity(t *testing.T) {
 	if incumbent != nil {
 		t.Errorf("x_incumbent = %q, want NULL", *incumbent)
 	}
-	if currency != configBootstrap.BaseCurrency || timezone != configBootstrap.Timezone || name == "" {
-		t.Errorf("identity was rewritten: name=%q base_currency=%q timezone=%q — a reset wipes the data, not the installation",
-			name, currency, timezone)
+	if name != nameBefore || currency != currencyBefore || timezone != zoneBefore {
+		t.Errorf("identity was rewritten: name=%q base_currency=%q timezone=%q, was %q/%q/%q — "+
+			"a reset wipes the data, not the installation",
+			name, currency, timezone, nameBefore, currencyBefore, zoneBefore)
 	}
 
 	// created_at is preserved and updated_at is not, and the difference is the

--- a/backend/internal/modules/identity/workspaceconfig_integration_test.go
+++ b/backend/internal/modules/identity/workspaceconfig_integration_test.go
@@ -99,14 +99,26 @@ func TestResetWorkspaceConfigRestoresSettingsAndKeepsIdentity(t *testing.T) {
 		t.Fatalf("ResetWorkspaceConfig: %v", err)
 	}
 
-	var mode, name, currency, timezone string
+	var mode string
 	var incumbent *string
 	var after time.Time
 	if err := owner.QueryRow(ctx, `
-		SELECT x_sor_mode, x_incumbent, name, base_currency, timezone, updated_at
+		SELECT x_sor_mode, x_incumbent, updated_at
 		  FROM workspace WHERE id = $1`, ws).
-		Scan(&mode, &incumbent, &name, &currency, &timezone, &after); err != nil {
+		Scan(&mode, &incumbent, &after); err != nil {
 		t.Fatalf("reading the workspace back: %v", err)
+	}
+	// The installation's identity is settings rows now (0209), and this is
+	// still the claim under test: a reset wipes the DATA, not the
+	// installation. platform/settings.ResetConfig spares these three, so they
+	// must read back exactly as bootstrap wrote them.
+	var name, currency, timezone string
+	if err := owner.QueryRow(ctx, `
+		SELECT coalesce((SELECT value #>> '{}' FROM setting WHERE key = 'installation.name'), ''),
+		       coalesce((SELECT value #>> '{}' FROM setting WHERE key = 'installation.base_currency'), ''),
+		       coalesce((SELECT value #>> '{}' FROM setting WHERE key = 'installation.timezone'), '')`).
+		Scan(&name, &currency, &timezone); err != nil {
+		t.Fatalf("reading the installation's identity back: %v", err)
 	}
 	if mode != "native" {
 		t.Errorf("x_sor_mode = %q, want native", mode)
@@ -363,7 +375,7 @@ func TestResetWorkspaceConfigOnARowThatIsIdentityAndNothingElse(t *testing.T) {
 
 	var nameBefore string
 	if err := owner.QueryRow(ctx,
-		`SELECT name FROM workspace WHERE id = $1`, ws).Scan(&nameBefore); err != nil {
+		`SELECT slug FROM workspace WHERE id = $1`, ws).Scan(&nameBefore); err != nil {
 		t.Fatalf("reading the workspace: %v", err)
 	}
 
@@ -406,10 +418,10 @@ func TestResetWorkspaceConfigOnARowThatIsIdentityAndNothingElse(t *testing.T) {
 	var mode string
 	var nameAfter string
 	if err := owner.QueryRow(ctx,
-		`SELECT x_sor_mode, name FROM workspace WHERE id = $1`, ws).Scan(&mode, &nameAfter); err != nil {
+		`SELECT x_sor_mode, slug FROM workspace WHERE id = $1`, ws).Scan(&mode, &nameAfter); err != nil {
 		t.Fatalf("the rollback did not restore the fork columns: %v", err)
 	}
 	if nameAfter != nameBefore {
-		t.Errorf("name = %q, want %q — the probe wrote to the row it only meant to read", nameAfter, nameBefore)
+		t.Errorf("slug = %q, want %q — the probe wrote to the row it only meant to read", nameAfter, nameBefore)
 	}
 }

--- a/backend/internal/modules/identity/workspaceconfig_integration_test.go
+++ b/backend/internal/modules/identity/workspaceconfig_integration_test.go
@@ -96,9 +96,9 @@ func TestResetWorkspaceConfigRestoresSettingsAndKeepsIdentity(t *testing.T) {
 	// against itself afterwards rather than against configBootstrap, because
 	// `setting` is non-tenant: several fixtures bootstrap into one database
 	// per package run and Seed is ON CONFLICT DO NOTHING, so the rows belong
-	// to whichever installation got there first (issue #863). Which one that
-	// is has nothing to do with the claim under test — that a reset wipes the
-	// DATA and leaves the installation standing.
+	// to whichever installation got there first. Which one that is has nothing
+	// to do with the claim under test — that a reset wipes the DATA and leaves
+	// the installation standing.
 	var nameBefore, currencyBefore, zoneBefore string
 	if err := owner.QueryRow(ctx, `
 		SELECT coalesce((SELECT value #>> '{}' FROM setting WHERE key = 'installation.name'), ''),

--- a/backend/internal/modules/migration/run_integration_test.go
+++ b/backend/internal/modules/migration/run_integration_test.go
@@ -46,7 +46,7 @@ func testWorkspaceCtx(t *testing.T, grants map[string]principal.ObjectGrant) (co
 
 	ws := ids.NewV7()
 	if _, err := owner.Exec(ctx,
-		`INSERT INTO workspace (id, name, slug, base_currency) VALUES ($1, 'Migration', $2, 'EUR')`,
+		`INSERT INTO workspace (id, slug) VALUES ($1, $2)`,
 		ws, "migration-"+ws.String()); err != nil {
 		t.Fatalf("seeding workspace: %v", err)
 	}

--- a/backend/internal/modules/overlay/testsupport_integration.go
+++ b/backend/internal/modules/overlay/testsupport_integration.go
@@ -68,7 +68,7 @@ func testWorkspaceCtx(t *testing.T) (context.Context, *pgxpool.Pool, ids.UUID) {
 
 	ws := ids.NewV7()
 	if _, err := owner.Exec(ctx,
-		`INSERT INTO workspace (id, name, slug, base_currency) VALUES ($1, 'Overlay', $2, 'EUR')`,
+		`INSERT INTO workspace (id, slug) VALUES ($1, $2)`,
 		ws, "overlay-"+ws.String()); err != nil {
 		t.Fatalf("seeding workspace: %v", err)
 	}
@@ -271,7 +271,7 @@ func seedUserInOtherWorkspace(t *testing.T, email string) ids.UserID {
 	conn := testOwnerConn(t)
 	other := ids.NewV7()
 	if _, err := conn.Exec(context.Background(),
-		`INSERT INTO workspace (id, name, slug, base_currency) VALUES ($1, 'Overlay Other', $2, 'EUR')`,
+		`INSERT INTO workspace (id, slug) VALUES ($1, $2)`,
 		other, "overlay-other-"+other.String()); err != nil {
 		t.Fatalf("seeding the other workspace: %v", err)
 	}

--- a/backend/internal/modules/people/captureprivacy_integration_test.go
+++ b/backend/internal/modules/people/captureprivacy_integration_test.go
@@ -69,7 +69,7 @@ func setupCapturePrivacy(t *testing.T) *privacyEnv {
 		owner: ids.NewV7(), teammate: ids.NewV7(), admin: ids.NewV7(),
 	}
 	if _, err := conn.Exec(ctx,
-		`INSERT INTO workspace (id, name, slug, base_currency) VALUES ($1, 'Capture privacy', $2, 'EUR')`,
+		`INSERT INTO workspace (id, slug) VALUES ($1, $2)`,
 		e.ws, "cp-"+e.ws.String()); err != nil {
 		t.Fatal(err)
 	}

--- a/backend/internal/modules/people/dedupe_integration_test.go
+++ b/backend/internal/modules/people/dedupe_integration_test.go
@@ -50,7 +50,7 @@ func setupDedupe(t *testing.T) *dedupeEnv {
 
 	e := &dedupeEnv{ws: ids.NewV7(), rep: ids.NewV7()}
 	if _, err := owner.Exec(ctx,
-		`INSERT INTO workspace (id, name, slug, base_currency) VALUES ($1, 'Dedupe', $2, 'EUR')`,
+		`INSERT INTO workspace (id, slug) VALUES ($1, $2)`,
 		e.ws, "dd-"+e.ws.String()); err != nil {
 		t.Fatal(err)
 	}

--- a/backend/internal/modules/people/leadlinkedin_integration_test.go
+++ b/backend/internal/modules/people/leadlinkedin_integration_test.go
@@ -56,7 +56,7 @@ func setupLeadLinkedIn(t *testing.T) *linkedinEnv {
 
 	e := &linkedinEnv{owner: owner, ws: ids.NewV7(), rep1: ids.NewV7(), rep2: ids.NewV7()}
 	if _, err := owner.Exec(ctx,
-		`INSERT INTO workspace (id, name, slug, base_currency) VALUES ($1, 'LinkedIn', $2, 'EUR')`,
+		`INSERT INTO workspace (id, slug) VALUES ($1, $2)`,
 		e.ws, "li-"+e.ws.String()); err != nil {
 		t.Fatal(err)
 	}
@@ -183,7 +183,7 @@ func TestFindLeadByLinkedInURLHidesWhatTheCallerCannotRead(t *testing.T) {
 
 	// A same-URL lead in ANOTHER workspace never crosses the boundary.
 	foreignWS := ids.NewV7()
-	e.exec(t, `INSERT INTO workspace (id, name, slug, base_currency) VALUES ($1, 'Foreign', $2, 'EUR')`,
+	e.exec(t, `INSERT INTO workspace (id, slug) VALUES ($1, $2)`,
 		foreignWS, "li-f-"+foreignWS.String())
 	e.exec(t, `INSERT INTO lead (id, workspace_id, full_name, linkedin_url, status, source, captured_by)
 		 VALUES ($1, $2, 'Foreign Twin', $3, 'new', 'manual', 'human:x')`,

--- a/backend/internal/modules/people/promoteconsent_integration_test.go
+++ b/backend/internal/modules/people/promoteconsent_integration_test.go
@@ -62,7 +62,7 @@ func setupPromoteConsent(t *testing.T) *promoteConsentEnv {
 		newsletter: ids.NewV7(), updates: ids.NewV7(),
 	}
 	if _, err := owner.Exec(ctx,
-		`INSERT INTO workspace (id, name, slug, base_currency) VALUES ($1, 'PromoteConsent', $2, 'EUR')`,
+		`INSERT INTO workspace (id, slug) VALUES ($1, $2)`,
 		e.ws, "pc-"+e.ws.String()); err != nil {
 		t.Fatal(err)
 	}

--- a/backend/internal/modules/privacy/sar_integration_test.go
+++ b/backend/internal/modules/privacy/sar_integration_test.go
@@ -64,7 +64,7 @@ func setupSARIdentifiers(t *testing.T) *sarIdentifierEnv {
 	ws, user := ids.NewV7(), ids.NewV7()
 	person := ids.New[ids.PersonKind]()
 	if _, err := owner.Exec(ctx,
-		`INSERT INTO workspace (id, name, slug, base_currency) VALUES ($1, 'SAR identifiers', $2, 'EUR')`,
+		`INSERT INTO workspace (id, slug) VALUES ($1, $2)`,
 		ws, "sar-"+ws.String()); err != nil {
 		t.Fatal(err)
 	}

--- a/backend/internal/platform/events/bus_integration_test.go
+++ b/backend/internal/platform/events/bus_integration_test.go
@@ -72,7 +72,7 @@ func setup(t *testing.T) *busEnv {
 	// in their envelopes; the outbox itself is infra-owned (no RLS).
 	ws := ids.NewV7()
 	if _, err := owner.Exec(ctx,
-		`INSERT INTO workspace (id, name, slug, base_currency) VALUES ($1, 'Bus Test', 'bus-test', 'EUR')`, ws); err != nil {
+		`INSERT INTO workspace (id, slug) VALUES ($1, 'bus-test')`, ws); err != nil {
 		t.Fatalf("seeding workspace: %v", err)
 	}
 

--- a/backend/internal/platform/testdb/reset_integration_test.go
+++ b/backend/internal/platform/testdb/reset_integration_test.go
@@ -137,7 +137,7 @@ func TestResetEmptiesEveryDataTableIncludingTheAppendOnlyOnes(t *testing.T) {
 
 	ws := "00000000-0000-7000-8000-0000000000aa"
 	if _, err := owner.Exec(ctx, `
-		INSERT INTO workspace (id, name, slug, base_currency) VALUES ($1, 'reset', 'reset-probe', 'EUR')`, ws); err != nil {
+		INSERT INTO workspace (id, slug) VALUES ($1, 'reset-probe')`, ws); err != nil {
 		t.Fatalf("seeding workspace: %v", err)
 	}
 	// audit_log carries a BEFORE DELETE trigger that raises unconditionally, so
@@ -239,8 +239,8 @@ func TestResetReclaimsStorageFromABulkSeededTable(t *testing.T) {
 		t.Fatalf("reset to a known-clean start: %v", err)
 	}
 	if _, err := owner.Exec(ctx, `
-		INSERT INTO workspace (id, name, slug, base_currency)
-		SELECT uuidv7(), 'bulk' || g, 'bulk-' || g, 'EUR' FROM generate_series(1, 20000) g`); err != nil {
+		INSERT INTO workspace (id, slug)
+		SELECT uuidv7(), 'bulk-' || g FROM generate_series(1, 20000) g`); err != nil {
 		t.Fatalf("bulk-seeding workspace: %v", err)
 	}
 

--- a/backend/jobfleetscan_test.go
+++ b/backend/jobfleetscan_test.go
@@ -81,10 +81,6 @@ var ratifiedFleetScans = map[string]ratifiedFleetScan{
 		2,
 		"the dispatch enumerations: the live fleet every pass on behalf of an active tenant fans out over, and the archived-inclusive one BOTH retention passes need — GDPR retention and idempotency claim retention — because archiving a workspace does not un-store the data inside it. Both read the fleet only to enqueue one workspace-scoped job per tenant, and do no tenant work themselves",
 	},
-	"internal/compose/installation.go": {
-		1,
-		"bootstrap seed (ADR-0090 §8): reads back the organization row this same transaction just created, to seed the installation settings from it rather than re-deriving identity's own defaulting. Not a fleet read — the transaction holds exactly one workspace by construction, it runs on the boot path with no job and no args to take a workspace from, and ADR-0061 §3 refuses to start when a second exists",
-	},
 	"internal/modules/identity/installation.go": {
 		1,
 		"boot path: resolves the singleton organization and refuses to serve when a second exists (ADR-0061 §3) — it IS the workspace authority, not a consumer of it",

--- a/backend/migrations/core/0209_drop_workspace_identity_columns.down.sql
+++ b/backend/migrations/core/0209_drop_workspace_identity_columns.down.sql
@@ -1,0 +1,21 @@
+-- Restore the columns and refill them from the settings rows, which are the
+-- source of truth from 0190 onward. NOT NULL is re-established only after the
+-- backfill, so an installation whose settings were never written comes back
+-- with the same defaults 0002 declared rather than failing the rollback.
+ALTER TABLE workspace
+  ADD COLUMN name text,
+  ADD COLUMN base_currency char(3),
+  ADD COLUMN timezone text;
+
+UPDATE workspace SET
+  name = coalesce((SELECT value #>> '{}' FROM setting WHERE key = 'installation.name'), 'Organization'),
+  timezone = coalesce((SELECT value #>> '{}' FROM setting WHERE key = 'installation.timezone'), 'UTC'),
+  base_currency = coalesce((SELECT value #>> '{}' FROM setting WHERE key = 'installation.base_currency'), 'EUR');
+
+ALTER TABLE workspace
+  ALTER COLUMN name SET NOT NULL,
+  ALTER COLUMN base_currency SET NOT NULL,
+  ALTER COLUMN base_currency SET DEFAULT 'EUR',
+  ALTER COLUMN timezone SET NOT NULL,
+  ALTER COLUMN timezone SET DEFAULT 'UTC',
+  ADD CONSTRAINT workspace_base_currency_iso CHECK (base_currency ~ '^[A-Z]{3}$');

--- a/backend/migrations/core/0209_drop_workspace_identity_columns.down.sql
+++ b/backend/migrations/core/0209_drop_workspace_identity_columns.down.sql
@@ -1,7 +1,12 @@
 -- Restore the columns and refill them from the settings rows, which are the
 -- source of truth from 0190 onward. NOT NULL is re-established only after the
 -- backfill, so an installation whose settings were never written comes back
--- with the same defaults 0002 declared rather than failing the rollback.
+-- with fallback values chosen HERE ('Organization'/'UTC'/'EUR') rather than
+-- failing the rollback — 0002 declared no default for name or base_currency,
+-- so there is nothing to restore them to but a choice.
+--
+-- The up refuses to run with more than one live workspace, so the single set
+-- of settings this reads genuinely speaks for the whole table.
 ALTER TABLE workspace
   ADD COLUMN name text,
   ADD COLUMN base_currency char(3),
@@ -12,10 +17,18 @@ UPDATE workspace SET
   timezone = coalesce((SELECT value #>> '{}' FROM setting WHERE key = 'installation.timezone'), 'UTC'),
   base_currency = coalesce((SELECT value #>> '{}' FROM setting WHERE key = 'installation.base_currency'), 'EUR');
 
+-- The CHECK is added NOT VALID and validated separately: a setting written by
+-- raw SQL can hold something the 0002 constraint would reject, and a rollback
+-- that aborted here would leave the columns added and the migration recorded
+-- as un-run. NOT VALID admits the existing rows and still refuses new ones;
+-- an operator repairs the value and runs VALIDATE CONSTRAINT.
+--
+-- No DEFAULT on base_currency: 0002 declared none, and inventing one here
+-- would leave a rolled-back schema quietly accepting inserts the original
+-- refused.
 ALTER TABLE workspace
   ALTER COLUMN name SET NOT NULL,
   ALTER COLUMN base_currency SET NOT NULL,
-  ALTER COLUMN base_currency SET DEFAULT 'EUR',
   ALTER COLUMN timezone SET NOT NULL,
   ALTER COLUMN timezone SET DEFAULT 'UTC',
-  ADD CONSTRAINT workspace_base_currency_iso CHECK (base_currency ~ '^[A-Z]{3}$');
+  ADD CONSTRAINT workspace_base_currency_iso CHECK (base_currency ~ '^[A-Z]{3}$') NOT VALID;

--- a/backend/migrations/core/0209_drop_workspace_identity_columns.up.sql
+++ b/backend/migrations/core/0209_drop_workspace_identity_columns.up.sql
@@ -42,12 +42,23 @@ DECLARE missing text; live int;
 BEGIN
   SELECT count(*) INTO live FROM workspace WHERE archived_at IS NULL;
   IF live > 0 THEN
+    -- Presence is not proof. A row holding JSON null, a non-string, an empty
+    -- string, or a currency outside the ISO shape the dropped CHECK enforced
+    -- would satisfy an EXISTS and still leave the installation without a
+    -- usable identity — while the columns that DO hold one are about to go.
+    -- So the guard asks the same question the readers will: can this value be
+    -- used?
     SELECT string_agg(k, ', ') INTO missing
       FROM unnest(ARRAY['installation.name','installation.timezone','installation.base_currency']) AS k
-     WHERE NOT EXISTS (SELECT 1 FROM setting WHERE setting.key = k);
+     WHERE NOT EXISTS (
+       SELECT 1 FROM setting s
+        WHERE s.key = k
+          AND jsonb_typeof(s.value) = 'string'
+          AND length(s.value #>> '{}') > 0
+          AND (k <> 'installation.base_currency' OR s.value #>> '{}' ~ '^[A-Z]{3}$'));
     IF missing IS NOT NULL THEN
       RAISE EXCEPTION
-        'installation identity would be lost: % has no stored setting, and this migration drops the column holding it. '
+        'installation identity would be lost: % has no usable stored setting, and this migration drops the column holding it. '
         'Resolve the installation down to exactly one live workspace (ADR-0061 §3) and re-run.', missing;
     END IF;
     -- Presence is not enough. With several live workspaces the settings speak

--- a/backend/migrations/core/0209_drop_workspace_identity_columns.up.sql
+++ b/backend/migrations/core/0209_drop_workspace_identity_columns.up.sql
@@ -38,16 +38,28 @@ ON CONFLICT (key) DO NOTHING;
 -- several live workspaces, where no single row can speak for the installation.
 -- An operator resolves that down to one (ADR-0061 §3) and runs this again.
 DO $$
-DECLARE missing text;
+DECLARE missing text; live int;
 BEGIN
-  IF EXISTS (SELECT 1 FROM workspace WHERE archived_at IS NULL) THEN
+  SELECT count(*) INTO live FROM workspace WHERE archived_at IS NULL;
+  IF live > 0 THEN
     SELECT string_agg(k, ', ') INTO missing
       FROM unnest(ARRAY['installation.name','installation.timezone','installation.base_currency']) AS k
      WHERE NOT EXISTS (SELECT 1 FROM setting WHERE setting.key = k);
     IF missing IS NOT NULL THEN
       RAISE EXCEPTION
-        'workspace identity would be lost: % has no stored setting, and this migration drops the column holding it. '
+        'installation identity would be lost: % has no stored setting, and this migration drops the column holding it. '
         'Resolve the installation down to exactly one live workspace (ADR-0061 §3) and re-run.', missing;
+    END IF;
+    -- Presence is not enough. With several live workspaces the settings speak
+    -- for ONE installation while the others keep rows — deals and invoices
+    -- carrying an fx_rate_to_base frozen against a base about to stop
+    -- existing anywhere. The API already refuses to serve that state
+    -- (ErrMultipleWorkspaces); this refuses to make it unrecoverable.
+    IF live > 1 THEN
+      RAISE EXCEPTION
+        '% live workspaces: the installation settings can only speak for one of them, and dropping these '
+        'columns would leave the others'' rows priced against a base nothing records. '
+        'Resolve the installation down to exactly one live workspace (ADR-0061 §3) and re-run.', live;
     END IF;
   END IF;
 END $$;

--- a/backend/migrations/core/0209_drop_workspace_identity_columns.up.sql
+++ b/backend/migrations/core/0209_drop_workspace_identity_columns.up.sql
@@ -1,0 +1,60 @@
+-- The installation's identity lives in `setting`, not on the workspace row
+-- (ADR-0090/A135, ADR-0091 phase 4). Every reader moved across #521; these
+-- three columns are the last of the dual write, and the mirror in
+-- identity.UpdateInstallation retires with them.
+--
+-- Neither table needs a workspace binding here: `setting` is non-tenant by
+-- design (0190) and `workspace` is outside RLS (0014), which is what lets the
+-- repair below read one to write the other.
+
+-- 1. Repair. 0191's backfill only ran where exactly one live workspace
+-- existed, so a database that migrated with several has no rows at all. That
+-- was survivable while the columns still answered; it is not survivable across
+-- a DROP. Backfill anything still missing from the one live workspace.
+INSERT INTO setting (key, value)
+SELECT 'installation.name', to_jsonb(w.name)
+  FROM workspace w
+ WHERE w.archived_at IS NULL
+   AND (SELECT count(*) FROM workspace WHERE archived_at IS NULL) = 1
+ON CONFLICT (key) DO NOTHING;
+
+INSERT INTO setting (key, value)
+SELECT 'installation.timezone', to_jsonb(w.timezone)
+  FROM workspace w
+ WHERE w.archived_at IS NULL
+   AND (SELECT count(*) FROM workspace WHERE archived_at IS NULL) = 1
+ON CONFLICT (key) DO NOTHING;
+
+INSERT INTO setting (key, value)
+SELECT 'installation.base_currency', to_jsonb(rtrim(w.base_currency))
+  FROM workspace w
+ WHERE w.archived_at IS NULL
+   AND (SELECT count(*) FROM workspace WHERE archived_at IS NULL) = 1
+ON CONFLICT (key) DO NOTHING;
+
+-- 2. Refuse rather than lose. If a live workspace still holds identity the
+-- settings do not, dropping the columns would destroy the only copy — and the
+-- ONE state the repair above cannot resolve is the one it is guarded on:
+-- several live workspaces, where no single row can speak for the installation.
+-- An operator resolves that down to one (ADR-0061 §3) and runs this again.
+DO $$
+DECLARE missing text;
+BEGIN
+  IF EXISTS (SELECT 1 FROM workspace WHERE archived_at IS NULL) THEN
+    SELECT string_agg(k, ', ') INTO missing
+      FROM unnest(ARRAY['installation.name','installation.timezone','installation.base_currency']) AS k
+     WHERE NOT EXISTS (SELECT 1 FROM setting WHERE setting.key = k);
+    IF missing IS NOT NULL THEN
+      RAISE EXCEPTION
+        'workspace identity would be lost: % has no stored setting, and this migration drops the column holding it. '
+        'Resolve the installation down to exactly one live workspace (ADR-0061 §3) and re-run.', missing;
+    END IF;
+  END IF;
+END $$;
+
+-- 3. Drop. The base_currency CHECK (workspace_base_currency_iso, 0002) goes
+-- with its column; the settings entry carries the same rule in Go now.
+ALTER TABLE workspace
+  DROP COLUMN name,
+  DROP COLUMN base_currency,
+  DROP COLUMN timezone;

--- a/backend/migrations/rbac_backfill_parity_integration_test.go
+++ b/backend/migrations/rbac_backfill_parity_integration_test.go
@@ -164,6 +164,7 @@ func TestRBACBackfillsWriteTheIntendedGrants(t *testing.T) {
 	// two must stay aligned — if a future migration drops the guard, jsonb_set
 	// would silently no-op and the object would be missing with nothing failing.
 	seedRole(t, conn, empty, "admin", true, []byte(`{}`))
+	archiveAllButOne(t, conn)
 
 	if _, err := dbmigrate.Up(ctx, migrator, core); err != nil {
 		t.Fatalf("re-applying the backfills: %v", err)

--- a/backend/migrations/rbac_upgrade_replay_integration_test.go
+++ b/backend/migrations/rbac_upgrade_replay_integration_test.go
@@ -119,6 +119,7 @@ func TestUpgradingALegacyInstallationYieldsTheSeededMatrix(t *testing.T) {
 	}
 
 	workspaces := seedInstallations(t, conn, installs)
+	archiveAllButOne(t, conn)
 
 	// Upgrade it to head — core AND custom, because two backfills live in the
 	// fork-owned namespace and an assertion that modelled the split would be

--- a/backend/migrations/schema_integration_test.go
+++ b/backend/migrations/schema_integration_test.go
@@ -193,13 +193,28 @@ func TestAttachmentScanStatusBackfill(t *testing.T) {
 	}
 }
 
+// seedWorkspace inserts a workspace at WHATEVER schema version the caller has
+// migrated to. The replay suites apply core only as far as some past release,
+// where name and base_currency are still NOT NULL columns; the head suites run
+// after 0209 dropped them. One helper serves both, so it asks the catalog
+// which shape it is talking to rather than assuming the newest.
 func seedWorkspace(t *testing.T, conn *pgx.Conn, slug string) string {
 	t.Helper()
+	ctx := context.Background()
+	var preDrop bool
+	if err := conn.QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1 FROM information_schema.columns
+			 WHERE table_schema = 'public' AND table_name = 'workspace' AND column_name = 'name')`,
+	).Scan(&preDrop); err != nil {
+		t.Fatalf("reading the workspace shape: %v", err)
+	}
+	stmt := `INSERT INTO workspace (slug) VALUES ($1) RETURNING id`
+	if preDrop {
+		stmt = `INSERT INTO workspace (slug, name, base_currency) VALUES ($1, $1, 'EUR') RETURNING id`
+	}
 	var id string
-	err := conn.QueryRow(context.Background(),
-		`INSERT INTO workspace (slug) VALUES ($1) RETURNING id`,
-		slug).Scan(&id)
-	if err != nil {
+	if err := conn.QueryRow(ctx, stmt, slug).Scan(&id); err != nil {
 		t.Fatalf("seeding workspace %s: %v", slug, err)
 	}
 	return id

--- a/backend/migrations/schema_integration_test.go
+++ b/backend/migrations/schema_integration_test.go
@@ -197,7 +197,7 @@ func seedWorkspace(t *testing.T, conn *pgx.Conn, slug string) string {
 	t.Helper()
 	var id string
 	err := conn.QueryRow(context.Background(),
-		`INSERT INTO workspace (name, slug, base_currency) VALUES ($1, $1, 'EUR') RETURNING id`,
+		`INSERT INTO workspace (slug) VALUES ($1) RETURNING id`,
 		slug).Scan(&id)
 	if err != nil {
 		t.Fatalf("seeding workspace %s: %v", slug, err)

--- a/backend/migrations/schema_integration_test.go
+++ b/backend/migrations/schema_integration_test.go
@@ -681,3 +681,27 @@ func assertSignal(t *testing.T, conn *pgx.Conn, id, wantVisibility string, wantO
 		t.Errorf("%s archived = %v, want %v", what, archived, wantArchived)
 	}
 }
+
+// archiveAllButOne leaves exactly one live workspace, which is what an
+// installation IS (ADR-0061 §3).
+//
+// The replay suites plant several workspaces to model several historical
+// installations in one database. That shape stops upgrading cleanly at 0209:
+// the installation's identity moved into `setting`, 0191 only backfills it
+// where a single live workspace can speak for the install, and 0209 refuses to
+// drop the columns while a live workspace holds identity nothing stored. The
+// fixtures cannot pre-seed those rows either — `setting` does not exist yet at
+// the legacy version they start from.
+//
+// So they do what the migration tells a real operator to do. The roles under
+// test are per-workspace rows and survive archival, and the RBAC backfills
+// loop over every workspace regardless of it, so nothing the replay asserts
+// moves.
+func archiveAllButOne(t *testing.T, conn *pgx.Conn) {
+	t.Helper()
+	if _, err := conn.Exec(context.Background(), `
+		UPDATE workspace SET archived_at = now()
+		 WHERE id <> (SELECT id FROM workspace ORDER BY created_at, id LIMIT 1)`); err != nil {
+		t.Fatalf("reducing the fixture to one live workspace: %v", err)
+	}
+}

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -10886,7 +10886,7 @@ export interface components {
         };
         MeResponse: {
             user: components["schemas"]["User"];
-            /** @description The installation's organization name (workspace.name). Shown as the typed-confirmation target of the non-production "Reset data" action — the exact string that endpoint validates. */
+            /** @description The installation's organization name (the installation.name setting). Shown as the typed-confirmation target of the non-production "Reset data" action — the exact string that endpoint validates. */
             workspace_name: string;
             /** @description True when the installation runs a non-production posture (MARGINCE_ENV). Gates the client-side "Reset data" action. */
             non_production: boolean;


### PR DESCRIPTION
Closes the read-side work of #521: migration **0209** drops `workspace.{name, base_currency, timezone}`, and `UpdateInstallation` stops mirroring onto them.

This is what the four reader slices (#794, #802, #817, #857) existed to make possible. With nothing reading the columns, the second copy is no longer load-bearing — and a value that lives in one place cannot disagree with itself.

## The migration refuses rather than loses

`0191`'s backfill only ran where **exactly one** live workspace existed, so a database that migrated with several has no settings rows at all. That was survivable while the columns still answered; it is not survivable across a `DROP`.

So `0209` repairs what it can from the single live workspace, then **RAISES** if a live workspace still holds identity the settings do not — naming what is missing and what to do about it. The one state its repair cannot resolve is the one it is guarded on: several live workspaces, where no single row can speak for the installation. An operator resolves that down to one (ADR-0061 §3) and re-runs.

## The three documented exceptions moved with the columns

They didn't survive them, and each for a different reason:

- **Bootstrap** now *writes* the settings from the values identity itself resolved. compose used to read the row back precisely so it wouldn't duplicate identity's defaulting; with the columns gone there's nothing to read back, so the seeding moved into the module that owns both the defaulting and the settings.
- **The session lookup** and **the base-currency freeze probe** read the `setting` row directly in SQL, because both run where `platform/settings`' readers cannot — the session read happens *before a principal exists* to satisfy the object gate, and the freeze probe runs on the **first** write, where no row exists and "nothing is priced against a base that was never set" is the honest answer rather than a failure.

## Tests

55 fixtures built their workspace with those columns. The two that bound `$n` for a dropped column (rather than a literal) were done by hand, since dropping a placeholder shifts every later one.

**The disagreement tests from the reader slices are reworked, not deleted.** The second copy they moved apart is gone, so the divergence they staged is no longer expressible. What survives is the half that still says something: each moves the setting off the value every other suite seeds, so the assertion cannot pass by accident.

A `jobfleetscan` waiver went stale when compose's read-back was deleted — the gate caught it, and it's removed rather than left to rot.

## Verification

`make check-backend` and `make craft-static` (0/0/0) green. No Docker here, so the migration itself — and the RBAC upgrade replay that migrates as a non-superuser owner — is CI's word.

## What remains

ADR-0091 phase 4's larger half: the rest of the `workspace` row.

Refs #521, ADR-0091 phase 4.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drops `workspace.name`, `workspace.base_currency`, and `workspace.timezone`, making installation settings the single source of truth and removing the `UpdateInstallation` dual write. Bootstrap, session lookup, and the base‑currency freeze probe now use settings directly; the freeze guard fails closed and is keyed to the setting. Completes reader moves in #521.

- **Migration**
  - Adds `0209_drop_workspace_identity_columns`: backfills from the single live workspace; refuses when settings are missing or unusable (null/non‑string/empty or non‑ISO currency) or when several live workspaces exist.
  - Drops the three columns; down migration restores them from settings and adds a NOT VALID CHECK (no new default) to avoid half‑applied rollbacks.

- **Refactors**
  - Bootstrap seeds identity via settings in `identity`; `identity.UpdateInstallation` writes settings only.
  - Settings wiring passes `identity.BaseCurrency.Key()` into `deals.BaseCurrencyFreeze`; the probe reads `setting` directly and, if the base is absent, counts the whole sheet and refuses the change.
  - Session login/auth read the installation name via direct SQL and coalesce to empty to avoid 500s.
  - Tests stop inserting dropped columns; replay suites detect schema shape when seeding and archive all but one workspace to satisfy 0209’s guard; API contract and `frontend/src/api/schema.d.ts` now describe `workspace_name` as the `installation.name` setting.

<sup>Written for commit ca08cd946cf8e451cc0e8b7b0e45ecb607b73e19. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/862?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Organization name, base currency, and timezone are now managed consistently through installation settings.
  - Login, authentication, currency conversion, and timezone handling use the configured installation settings.
  - Installation setup and updates no longer maintain duplicate workspace identity values.
- **Bug Fixes**
  - Improved handling when required migration data is missing or ambiguous, preventing unsafe migrations.
  - Workspace resets preserve organization identity settings.
- **Documentation**
  - Updated API descriptions to reflect the installation settings source for organization names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->