### PR TITLE
feat(company): an accepted offer_summary fills the header's description

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -18,6 +18,7 @@
 Every section in this file, in order. Read this list first and jump; nobody
 needs the whole file to start a session.
 
+- Shipped 2026-08-11 (batman): an accepted `offer_summary` and the company form now fill `organization.description`, the header's one-line answer (PR #869, the description half of #847); the silent skip of a 501–2000-char summary is filed as #870 (fast-track-debt).
 - [Open — the person record page V2, and what it still owes (2026-08-11)](#open--the-person-record-page-v2-and-what-it-still-owes-2026-08-11)
 - [Open — the finance offline ledger drifts out of its timeliness window (#798, 2026-08-10)](#open--the-finance-offline-ledger-drifts-out-of-its-timeliness-window-798-2026-08-10)
 - [Open — two follow-ups left by the activity anchor (#686, 2026-08-09)](#open--two-follow-ups-left-by-the-activity-anchor-686-2026-08-09)

--- a/backend/internal/compose/company_integration_test.go
+++ b/backend/internal/compose/company_integration_test.go
@@ -308,6 +308,17 @@ func TestAcceptedOfferSummaryFillsTheDescriptionColumn(t *testing.T) {
 	if got := readDescription(); got == nil || *got != "Revenue operations software for mid-market manufacturers" {
 		t.Fatalf("description after re-accept = %v, want the first fill kept", got)
 	}
+	var evidenceValue string
+	if err := database.WithWorkspaceTx(e.As(e.Rep1, nil, integration.AdminPerms), e.Pool, func(tx pgx.Tx) error {
+		return tx.QueryRow(context.Background(),
+			`SELECT value FROM organization_profile_field
+			  WHERE organization_id = $1 AND field = 'offer_summary'`, orgID).Scan(&evidenceValue)
+	}); err != nil {
+		t.Fatalf("reading the evidence row: %v", err)
+	}
+	if evidenceValue != "A different sentence entirely" {
+		t.Fatalf("evidence row after re-accept = %q, want the refreshed value", evidenceValue)
+	}
 }
 
 func TestOverlongOfferSummarySkipsTheColumnButKeepsTheEvidence(t *testing.T) {
@@ -319,9 +330,11 @@ func TestOverlongOfferSummarySkipsTheColumnButKeepsTheEvidence(t *testing.T) {
 		UserID: e.Rep1, OnBehalfOf: e.Rep1, Permissions: integration.AdminPerms,
 	})
 
-	// organization_description_length caps the column at 500 (0203). A longer
-	// accepted summary must skip the fill, not abort the whole apply.
-	long := strings.Repeat("Revenue operations software. ", 20)
+	// organization_description_length caps the column at 500 CHARACTERS (0203).
+	// The pair below is the exact boundary: 501 must skip the fill (not abort
+	// the apply), and 500 must land — spelled in multibyte characters so a
+	// future byte-counting guard (octet_length) fails this test.
+	long := strings.Repeat("ü", 501)
 	orgID, err := store.ApplyColdStartProfile(agent, people.ApplyColdStartProfileInput{
 		SourceURL: "https://longwinded.example",
 		Fields: []people.ColdStartFieldInput{{
@@ -333,23 +346,44 @@ func TestOverlongOfferSummarySkipsTheColumnButKeepsTheEvidence(t *testing.T) {
 		t.Fatalf("ApplyColdStartProfile with an overlong summary: %v", err)
 	}
 
-	var description, evidenceValue *string
-	if err := database.WithWorkspaceTx(e.As(e.Rep1, nil, integration.AdminPerms), e.Pool, func(tx pgx.Tx) error {
-		if err := tx.QueryRow(context.Background(),
-			`SELECT description FROM organization WHERE id = $1`, orgID).Scan(&description); err != nil {
-			return err
+	readState := func() (*string, string) {
+		var description *string
+		var evidenceValue string
+		if err := database.WithWorkspaceTx(e.As(e.Rep1, nil, integration.AdminPerms), e.Pool, func(tx pgx.Tx) error {
+			if err := tx.QueryRow(context.Background(),
+				`SELECT description FROM organization WHERE id = $1`, orgID).Scan(&description); err != nil {
+				return err
+			}
+			return tx.QueryRow(context.Background(),
+				`SELECT value FROM organization_profile_field
+				  WHERE organization_id = $1 AND field = 'offer_summary'`, orgID).Scan(&evidenceValue)
+		}); err != nil {
+			t.Fatalf("reading the apply's result: %v", err)
 		}
-		return tx.QueryRow(context.Background(),
-			`SELECT value FROM organization_profile_field
-			  WHERE organization_id = $1 AND field = 'offer_summary'`, orgID).Scan(&evidenceValue)
-	}); err != nil {
-		t.Fatalf("reading the apply's result: %v", err)
+		return description, evidenceValue
 	}
+	description, evidenceValue := readState()
 	if description != nil {
-		t.Fatalf("an overlong summary filled description = %q, want NULL", *description)
+		t.Fatalf("a 501-character summary filled description = %q, want NULL", *description)
 	}
-	if evidenceValue == nil || *evidenceValue != long {
+	if evidenceValue != long {
 		t.Fatal("the evidence row should still carry the full accepted summary")
+	}
+
+	// The skipped fill left the column NULL, so a later in-bounds read still
+	// fills it: exactly 500 characters (1000 bytes) passes the guard.
+	atCap := strings.Repeat("ü", 500)
+	if _, err := store.ApplyColdStartProfile(agent, people.ApplyColdStartProfileInput{
+		SourceURL: "https://longwinded.example",
+		Fields: []people.ColdStartFieldInput{{
+			Field: "offer_summary", Value: atCap,
+			EvidenceSnippet: "We build RevOps software", SourceURL: "https://longwinded.example", Confidence: 0.9,
+		}},
+	}); err != nil {
+		t.Fatalf("ApplyColdStartProfile at the cap: %v", err)
+	}
+	if description, _ := readState(); description == nil || *description != atCap {
+		t.Fatal("a summary of exactly 500 characters should fill description")
 	}
 }
 

--- a/backend/internal/compose/company_integration_test.go
+++ b/backend/internal/compose/company_integration_test.go
@@ -13,6 +13,7 @@ package compose
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/jackc/pgx/v5"
@@ -253,6 +254,102 @@ func TestCompanySavedByAHumanSurvivesALaterReadBack(t *testing.T) {
 	}
 	if got.Fields["icp"] != "What the human says we sell to" {
 		t.Fatalf("an agent read-back overwrote the human's own value: %q", got.Fields["icp"])
+	}
+}
+
+func TestAcceptedOfferSummaryFillsTheDescriptionColumn(t *testing.T) {
+	e := integration.Setup(t)
+	store := people.NewStore(e.Pool)
+	base := principal.WithCorrelationID(principal.WithWorkspaceID(context.Background(), e.WS), ids.NewV7())
+	agent := principal.WithActor(base, principal.Principal{
+		Type: principal.PrincipalSystem, ID: "agent:coldstart",
+		UserID: e.Rep1, OnBehalfOf: e.Rep1, Permissions: integration.AdminPerms,
+	})
+
+	// The header renders organization.description; an accepted offer_summary is
+	// the one-sentence answer, so the apply fills the column (only while empty).
+	orgID, err := store.ApplyColdStartProfile(agent, people.ApplyColdStartProfileInput{
+		SourceURL: "https://summarized.example",
+		Fields: []people.ColdStartFieldInput{{
+			Field: "offer_summary", Value: "Revenue operations software for mid-market manufacturers",
+			EvidenceSnippet: "We build RevOps software", SourceURL: "https://summarized.example", Confidence: 0.9,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("ApplyColdStartProfile: %v", err)
+	}
+
+	readDescription := func() *string {
+		var description *string
+		if err := database.WithWorkspaceTx(e.As(e.Rep1, nil, integration.AdminPerms), e.Pool, func(tx pgx.Tx) error {
+			return tx.QueryRow(context.Background(),
+				`SELECT description FROM organization WHERE id = $1`, orgID).Scan(&description)
+		}); err != nil {
+			t.Fatalf("reading description: %v", err)
+		}
+		return description
+	}
+	got := readDescription()
+	if got == nil || *got != "Revenue operations software for mid-market manufacturers" {
+		t.Fatalf("description after accept = %v, want the accepted offer_summary", got)
+	}
+
+	// A later accept refreshes the evidence row but leaves the standing column
+	// alone — acceptance covers the staged diff, not an overwrite.
+	if _, err := store.ApplyColdStartProfile(agent, people.ApplyColdStartProfileInput{
+		SourceURL: "https://summarized.example",
+		Fields: []people.ColdStartFieldInput{{
+			Field: "offer_summary", Value: "A different sentence entirely",
+			EvidenceSnippet: "New copy", SourceURL: "https://summarized.example", Confidence: 0.9,
+		}},
+	}); err != nil {
+		t.Fatalf("second ApplyColdStartProfile: %v", err)
+	}
+	if got := readDescription(); got == nil || *got != "Revenue operations software for mid-market manufacturers" {
+		t.Fatalf("description after re-accept = %v, want the first fill kept", got)
+	}
+}
+
+func TestOverlongOfferSummarySkipsTheColumnButKeepsTheEvidence(t *testing.T) {
+	e := integration.Setup(t)
+	store := people.NewStore(e.Pool)
+	base := principal.WithCorrelationID(principal.WithWorkspaceID(context.Background(), e.WS), ids.NewV7())
+	agent := principal.WithActor(base, principal.Principal{
+		Type: principal.PrincipalSystem, ID: "agent:coldstart",
+		UserID: e.Rep1, OnBehalfOf: e.Rep1, Permissions: integration.AdminPerms,
+	})
+
+	// organization_description_length caps the column at 500 (0203). A longer
+	// accepted summary must skip the fill, not abort the whole apply.
+	long := strings.Repeat("Revenue operations software. ", 20)
+	orgID, err := store.ApplyColdStartProfile(agent, people.ApplyColdStartProfileInput{
+		SourceURL: "https://longwinded.example",
+		Fields: []people.ColdStartFieldInput{{
+			Field: "offer_summary", Value: long,
+			EvidenceSnippet: "We build RevOps software", SourceURL: "https://longwinded.example", Confidence: 0.9,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("ApplyColdStartProfile with an overlong summary: %v", err)
+	}
+
+	var description, evidenceValue *string
+	if err := database.WithWorkspaceTx(e.As(e.Rep1, nil, integration.AdminPerms), e.Pool, func(tx pgx.Tx) error {
+		if err := tx.QueryRow(context.Background(),
+			`SELECT description FROM organization WHERE id = $1`, orgID).Scan(&description); err != nil {
+			return err
+		}
+		return tx.QueryRow(context.Background(),
+			`SELECT value FROM organization_profile_field
+			  WHERE organization_id = $1 AND field = 'offer_summary'`, orgID).Scan(&evidenceValue)
+	}); err != nil {
+		t.Fatalf("reading the apply's result: %v", err)
+	}
+	if description != nil {
+		t.Fatalf("an overlong summary filled description = %q, want NULL", *description)
+	}
+	if evidenceValue == nil || *evidenceValue != long {
+		t.Fatal("the evidence row should still carry the full accepted summary")
 	}
 }
 

--- a/backend/internal/modules/people/coldstartprofile.go
+++ b/backend/internal/modules/people/coldstartprofile.go
@@ -61,6 +61,7 @@ var columnBackedColdStartFields = map[string]string{
 	fieldLegalName:       columnLegalName,
 	"industry":           "industry",
 	"registered_address": "address",
+	fieldOfferSummary:    "description",
 }
 
 // ApplyColdStartProfile executes an ACCEPTED coldstart proposal. A
@@ -265,6 +266,12 @@ var coldStartColumns = map[string]string{
 	// fills line1 only when no structured address exists yet.
 	"address": `UPDATE organization SET address_line1 = $2 WHERE id = $1 AND address_line1 IS NULL
 	            AND address_city IS NULL AND address_postal_code IS NULL`,
+	// The length guard mirrors organization_description_length (0203): a
+	// summary the CHECK would reject skips the fill instead of aborting the
+	// whole apply — the evidence row still lands, and the column stays
+	// fillable by a shorter later read.
+	"description": `UPDATE organization SET description = $2
+	            WHERE id = $1 AND description IS NULL AND length($2) <= 500`,
 }
 
 // applyEvidenceFields fills the column-backed fields (only when empty) and
@@ -368,6 +375,9 @@ func writeOrgColumn(ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID, co
 			WHERE id = $1 AND industry IS DISTINCT FROM $2`,
 		"address": `UPDATE organization SET address_line1 = $2, updated_at = now()
 			WHERE id = $1 AND address_line1 IS DISTINCT FROM $2`,
+		"description": `UPDATE organization SET description = $2, updated_at = now()
+			WHERE id = $1 AND description IS DISTINCT FROM $2
+			AND ($2::text IS NULL OR length($2) <= 500)`,
 	}
 	query, ok := queries[column]
 	if !ok {

--- a/backend/internal/modules/people/company.go
+++ b/backend/internal/modules/people/company.go
@@ -84,7 +84,12 @@ type companyField struct {
 // reads the way the form does.
 var companyFields = []companyField{
 	{name: fieldDisplayName},
-	{name: fieldOfferSummary},
+	// offer_summary is column-backed like the read-back's apply (description is
+	// the header's one-line answer); the length guard mirrors
+	// organization_description_length (0203) so an overlong summary keeps its
+	// profile-field row without aborting the save.
+	{name: fieldOfferSummary, update: `UPDATE organization SET description = $2 WHERE id = $1
+		AND description IS DISTINCT FROM $2 AND ($2::text IS NULL OR length($2) <= 500)`},
 	{name: fieldLegalName, update: `UPDATE organization SET legal_name = $2 WHERE id = $1 AND legal_name IS DISTINCT FROM $2`},
 	{name: fieldRegisteredAddress, update: `UPDATE organization SET address_line1 = $2 WHERE id = $1 AND address_line1 IS DISTINCT FROM $2`},
 	{name: fieldRegisterVat},

--- a/backend/internal/modules/people/orgcolumnimages.go
+++ b/backend/internal/modules/people/orgcolumnimages.go
@@ -26,7 +26,7 @@ import (
 // audit row gives it nothing to diff.
 func readColdStartColumnImages(ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID) (map[string]any, error) {
 	var displayName string
-	var legalName, industry, addressLine1 *string
+	var legalName, industry, addressLine1, description *string
 	// FOR UPDATE, and it is the audit that needs it: the before image and the
 	// apply that follows must describe ONE transaction's work. Read unlocked,
 	// a concurrent update landing between them lands inside this diff, and
@@ -37,9 +37,9 @@ func readColdStartColumnImages(ctx context.Context, tx pgx.Tx, orgID ids.Organiz
 	// the row lock second (see its own doc); a caller that reaches this row
 	// lock without it inverts the pair and deadlocks against a human rename.
 	if err := tx.QueryRow(ctx,
-		`SELECT display_name, legal_name, industry, address_line1
+		`SELECT display_name, legal_name, industry, address_line1, description
 		   FROM organization WHERE id = $1 FOR UPDATE`,
-		orgID).Scan(&displayName, &legalName, &industry, &addressLine1); err != nil {
+		orgID).Scan(&displayName, &legalName, &industry, &addressLine1, &description); err != nil {
 		return nil, fmt.Errorf("read organization column images: %w", err)
 	}
 	// Keyed by FIELD, not by column: field history projects per field, and
@@ -48,7 +48,8 @@ func readColdStartColumnImages(ctx context.Context, tx pgx.Tx, orgID ids.Organiz
 	// field the profile surface does not have.
 	out := map[string]any{fieldDisplayName: displayName}
 	for column, value := range map[string]*string{
-		fieldLegalName: legalName, fieldIndustry: industry, fieldRegisteredAddress: addressLine1,
+		fieldLegalName: legalName, fieldIndustry: industry,
+		fieldRegisteredAddress: addressLine1, fieldOfferSummary: description,
 	} {
 		if value == nil {
 			// An empty column reads as an explicit null in the image, never as
@@ -71,6 +72,7 @@ func emptyColdStartColumnImages() map[string]any {
 		fieldLegalName:         nil,
 		fieldIndustry:          nil,
 		fieldRegisteredAddress: nil,
+		fieldOfferSummary:      nil,
 	}
 }
 


### PR DESCRIPTION
The company header renders `organization.description`, but no ingest path ever wrote it — only the human inline edit, create, and merge-fill wrote that column. The cold-start read-back and the deep read's profile lane already extract `offer_summary` ("what the company sells or delivers"), so this maps it into the coldstart column whitelist: an accepted `offer_summary` fills `description` the same way `legal_name`, `industry` and `registered_address` already fill their columns — only while the column is empty, evidence row and field stamp landing either way. Governance is unchanged: the value still arrives through a staged proposal a human accepts (PO-AC-N-7).

A summary longer than the 500-char CHECK (migration 0203) skips the fill instead of aborting the whole apply; the evidence row still carries the full value and the column stays fillable by a shorter later read.

Covered by two new integration tests: `TestAcceptedOfferSummaryFillsTheDescriptionColumn` (fills once, never overwrites a standing value) and `TestOverlongOfferSummarySkipsTheColumnButKeepsTheEvidence`.

Addresses the description half of #847; the size_band half stays open there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accepted `offer_summary` now backfills the company header’s `organization.description`, and the company form writes it too, so profiles don’t render empty descriptions. Addresses the description half of #847.

- **New Features**
  - Map accepted `offer_summary` to `organization.description` during cold start apply.
  - Update the company form to write `description` from `offer_summary` with the same 500-char guard.
  - Fill only when empty; never overwrite.
  - If >500 chars, skip the fill; still write the evidence row.
  - Include `description` in cold-start column images.

<sup>Written for commit 3a7b7ac6fffd13d16167e217baa1959bb6d83f4c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/869?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

