### PR TITLE
fix(company): the form's summary fills the header line only while empty

### DIFF
--- a/backend/internal/compose/company_integration_test.go
+++ b/backend/internal/compose/company_integration_test.go
@@ -257,6 +257,54 @@ func TestCompanySavedByAHumanSurvivesALaterReadBack(t *testing.T) {
 	}
 }
 
+func TestFormResaveDoesNotClobberAHeaderDescriptionEdit(t *testing.T) {
+	e := integration.Setup(t)
+	store := people.NewStore(e.Pool)
+	ctx := e.As(e.Rep1, nil, integration.AdminPerms)
+
+	// The first form save fills the empty header line from the summary.
+	saved, err := store.SaveCompany(ctx, people.SaveCompanyInput{
+		DisplayName: "Acme GmbH",
+		Website:     strptr("https://acme.example"),
+		Fields:      map[string]*string{"offer_summary": strptr("Revenue operations software")},
+	})
+	if err != nil {
+		t.Fatalf("SaveCompany: %v", err)
+	}
+	readDescription := func() *string {
+		var description *string
+		if err := database.WithWorkspaceTx(ctx, e.Pool, func(tx pgx.Tx) error {
+			return tx.QueryRow(context.Background(),
+				`SELECT description FROM organization WHERE id = $1`, saved.OrganizationID).Scan(&description)
+		}); err != nil {
+			t.Fatalf("reading description: %v", err)
+		}
+		return description
+	}
+	if got := readDescription(); got == nil || *got != "Revenue operations software" {
+		t.Fatalf("description after the first form save = %v, want the typed summary", got)
+	}
+
+	// The header's inline edit is the one editor of a standing value.
+	if _, err := store.UpdateOrganization(ctx, saved.OrganizationID, people.UpdateOrganizationInput{
+		Description: strptr("The RevOps platform for manufacturers"),
+	}); err != nil {
+		t.Fatalf("UpdateOrganization: %v", err)
+	}
+
+	// A later form save re-sends the unchanged summary; the newer header line
+	// must survive it.
+	if _, err := store.SaveCompany(ctx, people.SaveCompanyInput{
+		DisplayName: "Acme GmbH",
+		Fields:      map[string]*string{"offer_summary": strptr("Revenue operations software")},
+	}); err != nil {
+		t.Fatalf("second SaveCompany: %v", err)
+	}
+	if got := readDescription(); got == nil || *got != "The RevOps platform for manufacturers" {
+		t.Fatalf("description after a form resave = %v, want the header edit kept", got)
+	}
+}
+
 func TestAcceptedOfferSummaryFillsTheDescriptionColumn(t *testing.T) {
 	e := integration.Setup(t)
 	store := people.NewStore(e.Pool)

--- a/backend/internal/modules/people/company.go
+++ b/backend/internal/modules/people/company.go
@@ -84,12 +84,15 @@ type companyField struct {
 // reads the way the form does.
 var companyFields = []companyField{
 	{name: fieldDisplayName},
-	// offer_summary is column-backed like the read-back's apply (description is
-	// the header's one-line answer); the length guard mirrors
-	// organization_description_length (0203) so an overlong summary keeps its
-	// profile-field row without aborting the save.
+	// offer_summary fills description (the header's one-line answer) only while
+	// the column is empty — the same semantics as the read-back's apply. The
+	// form re-sends an unchanged summary on every save, so an overwrite here
+	// would clobber a newer description typed into the header's inline edit
+	// (UpdateOrganization), which stays the one editor of a standing value.
+	// The length guard mirrors organization_description_length (0203) so an
+	// overlong summary keeps its profile-field row without aborting the save.
 	{name: fieldOfferSummary, update: `UPDATE organization SET description = $2 WHERE id = $1
-		AND description IS DISTINCT FROM $2 AND ($2::text IS NULL OR length($2) <= 500)`},
+		AND description IS NULL AND $2::text IS NOT NULL AND length($2) <= 500`},
 	{name: fieldLegalName, update: `UPDATE organization SET legal_name = $2 WHERE id = $1 AND legal_name IS DISTINCT FROM $2`},
 	{name: fieldRegisteredAddress, update: `UPDATE organization SET address_line1 = $2 WHERE id = $1 AND address_line1 IS DISTINCT FROM $2`},
 	{name: fieldRegisterVat},


### PR DESCRIPTION
Follow-up to #869, from its stop-time review: the company form re-sends an unchanged `offer_summary` on every save, so the `IS DISTINCT FROM` write could overwrite a newer `description` a human typed into the header's inline edit (e.g. edit the header line, then change only the ICP in the form — the old summary clobbers the new line).

The form's write becomes fill-only (`description IS NULL`), the same semantics as the read-back's apply; `UpdateOrganization` (the header inline edit) stays the one editor of a standing value. `TestFormResaveDoesNotClobberAHeaderDescriptionEdit` pins the scenario end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the company form from overwriting a manually edited header description. The form now fills `organization.description` from `offer_summary` only when empty, matching read-back behavior.

- **Bug Fixes**
  - Changed `offer_summary` update to fill-only (`description IS NULL` and summary non-null, <=500 chars) in `people.SaveCompany`, so header edits via `UpdateOrganization` are not clobbered.
  - Added `TestFormResaveDoesNotClobberAHeaderDescriptionEdit` to verify a form re-save preserves a newer header description.

<sup>Written for commit d773a1b2052702d8ae2a219ae6b1c05c191c69bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/871?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

