### PR TITLE
feat(capture): own domains under admin settings; user-addable consumer-mail domains; searchable shipped baseline

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -6008,12 +6008,15 @@ paths:
       operationId: addConsumerMailDomain
       security: [ { cookieAuth: [] } ]   # human session only (x-agent-access: human-only)
       x-agent-access: human-only
-      summary: Add a consumer-mail domain, or carve one out (admin/ops).
+      summary: Add a consumer-mail domain, or carve one out.
       description: |
-        Admin/ops-only, human session only — an agent never changes a workspace-wide capture
-        posture. `kind: extra` marks a domain the baseline missed as consumer mail; `kind: never`
-        takes one back out and wins over the baseline, which is the only way back in for an
-        operator whose real customers mail from a domain the shipped list claims.
+        Human session only — an agent never changes a workspace-wide capture posture. `kind:
+        extra` marks a domain the baseline missed as consumer mail; any seat holding
+        `capture_settings:create` (every seeded role but read_only) may contribute a NEW one.
+        `kind: never` takes a domain back out of the baseline and wins over it — the only way
+        back in for an operator whose real customers mail from a domain the shipped list claims
+        — and, like overwriting an existing entry's kind, demands `capture_settings:update`
+        (admin/ops).
 
         The domain is normalized to its registrable form (`mail.gmx.net` is stored as `gmx.net`),
         because that is what the matcher keys on. Idempotent on the domain: re-adding returns the
@@ -6052,6 +6055,33 @@ paths:
         already satisfied.
       responses:
         '204': { description: Entry withdrawn (or already absent). }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+
+  /capture/consumer-mail-baseline:
+    get:
+      tags: [Capture]
+      operationId: listConsumerMailBaseline
+      security: [ { cookieAuth: [] } ]
+      x-agent-access: human-only
+      summary: Search the shipped consumer-mail baseline (CAP-PARAM-5).
+      description: |
+        The vendored consumer-domain dataset the installation ships with, as a searchable read.
+        The workspace's own list is only ever a delta against this baseline, so deciding whether
+        a domain needs an `extra` entry — or a `never` carve-out — starts here. Answers the
+        first 50 alphabetical matches plus the counts; every human role may read it, like the
+        rest of the capture posture.
+      parameters:
+        - name: q
+          in: query
+          schema: { type: string }
+          description: 'Case-insensitive substring filter. Absent or empty lists from the top.'
+      responses:
+        '200':
+          description: The matching slice of the shipped baseline.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ConsumerMailBaselineResponse' }
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
 
@@ -11029,6 +11059,16 @@ components:
       required: [data]
       properties:
         data: { type: array, items: { $ref: '#/components/schemas/ConsumerMailDomain' } }
+    ConsumerMailBaselineResponse:
+      type: object
+      required: [data, matched, total]
+      properties:
+        data:
+          type: array
+          items: { type: string }
+          description: The first 50 matching baseline domains, alphabetical.
+        matched: { type: integer, description: How many baseline domains matched the filter in total. }
+        total: { type: integer, description: The size of the whole shipped baseline. }
 
     # ---- capture connectors (per-user OAuth mail/calendar; RC-8, CAP-WIRE-1) ----
     CaptureConnection:

--- a/backend/internal/compose/agentpolicy_gen.go
+++ b/backend/internal/compose/agentpolicy_gen.go
@@ -141,6 +141,7 @@ var agentPolicies = map[string]agentPolicy{
 	"GET /v1/automations/{id}/runs":                                      {Op: "listAutomationRuns", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"GET /v1/availability":                                               {Op: "getAvailability", Access: "tool", Tool: "check_availability", RecordType: "", Tier: "auto_execute", Scope: "read"},
 	"GET /v1/brief":                                                      {Op: "getMorningBrief", Access: "tool", Tool: "read_brief", RecordType: "", Tier: "auto_execute", Scope: "read"},
+	"GET /v1/capture/consumer-mail-baseline":                             {Op: "listConsumerMailBaseline", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"GET /v1/capture/consumer-mail-domains":                              {Op: "listConsumerMailDomains", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"GET /v1/capture/email-domains":                                      {Op: "listWorkspaceEmailDomains", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"GET /v1/channel-connections":                                        {Op: "listChannelConnections", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},

--- a/backend/internal/compose/handlers_consumermaildomains.go
+++ b/backend/internal/compose/handlers_consumermaildomains.go
@@ -5,8 +5,10 @@ package compose
 
 // The workspace's consumer-mail list surface (CAP-PARAM-5): read what the
 // workspace added to and carved out of the shipped baseline (every role),
-// change it (admin/ops, human-only). Thin transport — the capture store owns
-// the RBAC gate, the normalization and the audit-only write.
+// search the baseline itself (every role), and change the list — any seat
+// with capture_settings:create contributes a new `extra` entry, carve-outs
+// and overwrites stay admin/ops. Thin transport — the capture store owns the
+// RBAC gates, the normalization and the audit-only write.
 
 import (
 	"encoding/json"
@@ -40,6 +42,33 @@ func (h consumerMailDomainHandlers) ListConsumerMailDomains(w http.ResponseWrite
 		out = append(out, toContractConsumerMailDomain(e))
 	}
 	httperr.WriteJSON(w, http.StatusOK, crmcontracts.ConsumerMailDomainListResponse{Data: out})
+}
+
+func (h consumerMailDomainHandlers) ListConsumerMailBaseline(w http.ResponseWriter, r *http.Request, params crmcontracts.ListConsumerMailBaselineParams) {
+	// Human-only (x-agent-access): the read is capture posture, and the module
+	// function re-checks the object read grant.
+	if err := auth.RequireHuman(r.Context()); err != nil {
+		httperr.Write(w, r, err)
+		return
+	}
+	var q string
+	if params.Q != nil {
+		q = *params.Q
+	}
+	result, err := capture.SearchBaseline(r.Context(), q)
+	if err != nil {
+		httperr.Write(w, r, err)
+		return
+	}
+	// Empty answers as [], never null — the contract promises an array.
+	if result.Domains == nil {
+		result.Domains = []string{}
+	}
+	httperr.WriteJSON(w, http.StatusOK, crmcontracts.ConsumerMailBaselineResponse{
+		Data:    result.Domains,
+		Matched: result.Matched,
+		Total:   result.Total,
+	})
 }
 
 func (h consumerMailDomainHandlers) AddConsumerMailDomain(w http.ResponseWriter, r *http.Request) {

--- a/backend/internal/compose/integration/consumermaildomain_integration_test.go
+++ b/backend/internal/compose/integration/consumermaildomain_integration_test.go
@@ -11,15 +11,22 @@ package integration
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/jackc/pgx/v5"
 
 	"github.com/gradionhq/margince/backend/internal/modules/capture"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
+
+// adminGrant is the seeded admin/ops posture on capture_settings after 0210:
+// create + read + update. The tests that exercise the surface as its curator
+// bind this, mirroring the real seed.
+var adminGrant = principal.ObjectGrant{Create: true, Read: true, Update: true}
 
 // listAdminCtx binds a human with the capture_settings grant this surface rides
 // — the same grant that gates the auto-enrich toggle, because an admin who may
@@ -41,7 +48,7 @@ func listAdminCtx(ws, user ids.UUID, grant principal.ObjectGrant) context.Contex
 
 func TestWorkspaceConsumerMailListCorrectsTheBaselineBothWays(t *testing.T) {
 	e := Setup(t)
-	ctx := listAdminCtx(e.WS, e.Rep1, principal.ObjectGrant{Read: true, Update: true})
+	ctx := listAdminCtx(e.WS, e.Rep1, adminGrant)
 	store := capture.NewFreemailDomains(e.Pool)
 
 	// A regional provider the shipped dataset missed, and a domain it wrongly
@@ -112,9 +119,40 @@ func TestWorkspaceConsumerMailListCorrectsTheBaselineBothWays(t *testing.T) {
 	}
 }
 
+// The split write posture (0210): a seat holding create contributes a NEW
+// `extra` entry, and nothing else — the `never` carve-out, flipping an
+// existing entry's kind, and removal all rewrite workspace posture and demand
+// update. Each refusal arm exercises the in-transaction demand, so reverting
+// that gate turns this test red.
+func TestConsumerMailCreateGrantAddsButNeverRewrites(t *testing.T) {
+	e := Setup(t)
+	repCtx := listAdminCtx(e.WS, e.Rep1, principal.ObjectGrant{Create: true, Read: true})
+	store := capture.NewFreemailDomains(e.Pool)
+
+	added, err := store.Add(repCtx, "kleinpost.example", capture.FreemailKindExtra)
+	if err != nil {
+		t.Fatalf("a create-only seat adding a missed provider: %v", err)
+	}
+	if _, err := store.Add(repCtx, "realfirm.example", capture.FreemailKindNever); !errors.Is(err, apperrors.ErrPermissionDenied) {
+		t.Errorf("a create-only seat carving a fresh domain out of the baseline = %v, want permission denied", err)
+	}
+	if _, err := store.Add(repCtx, "kleinpost.example", capture.FreemailKindNever); !errors.Is(err, apperrors.ErrPermissionDenied) {
+		t.Errorf("a create-only seat flipping its own existing entry = %v, want permission denied", err)
+	}
+	if err := store.Remove(repCtx, added.ID); !errors.Is(err, apperrors.ErrPermissionDenied) {
+		t.Errorf("a create-only seat removing an entry = %v, want permission denied", err)
+	}
+
+	// The curator path is unchanged: a fresh carve-out admits on update.
+	adminCtx := listAdminCtx(e.WS, e.Rep1, adminGrant)
+	if _, err := store.Add(adminCtx, "realfirm.example", capture.FreemailKindNever); err != nil {
+		t.Fatalf("an admin carving out a fresh domain: %v", err)
+	}
+}
+
 func TestConsumerMailListRefusesWhatTheMatcherCouldNeverRead(t *testing.T) {
 	e := Setup(t)
-	ctx := listAdminCtx(e.WS, e.Rep1, principal.ObjectGrant{Read: true, Update: true})
+	ctx := listAdminCtx(e.WS, e.Rep1, adminGrant)
 	store := capture.NewFreemailDomains(e.Pool)
 
 	if _, err := store.Add(ctx, "localhost", capture.FreemailKindExtra); err == nil {

--- a/backend/internal/compose/integration/harness.go
+++ b/backend/internal/compose/integration/harness.go
@@ -237,11 +237,14 @@ var (
 			// the harness admin fixture can exercise the rate editors.
 			"fx_rate":       {Create: true, Read: true, Update: true, Delete: true},
 			"ai_model_rate": {Create: true, Read: true, Update: true, Delete: true},
-			// capture_settings is admin/ops-only for update and readable by
-			// everyone (the same real seed). It gates the workspace's own-domain
-			// set — including the company-domain change that feeds it, since
-			// that decides whose mail is stored at all.
-			"capture_settings": {Read: true, Update: true},
+			// capture_settings mirrors the real admin seed: create + read +
+			// update (0210 added create — any seat may contribute a consumer
+			// domain, and the admin fixture must hold what the seed holds or
+			// the RBAC assertions stop being evidence about production). It
+			// gates the workspace's own-domain set — including the
+			// company-domain change that feeds it, since that decides whose
+			// mail is stored at all.
+			"capture_settings": {Create: true, Read: true, Update: true},
 			// installation_settings mirrors 0191's real seed: readable by every
 			// system role, updatable by admin/ops. Money readers resolve the
 			// base currency through this gate.

--- a/backend/internal/compose/stubs_gen.go
+++ b/backend/internal/compose/stubs_gen.go
@@ -251,6 +251,10 @@ func (stubs) SnoozeBriefItem(w nethttp.ResponseWriter, r *nethttp.Request, itemI
 	httperr.NotImplemented(w, r, "SnoozeBriefItem")
 }
 
+func (stubs) ListConsumerMailBaseline(w nethttp.ResponseWriter, r *nethttp.Request, params crmcontracts.ListConsumerMailBaselineParams) {
+	httperr.NotImplemented(w, r, "ListConsumerMailBaseline")
+}
+
 func (stubs) ListConsumerMailDomains(w nethttp.ResponseWriter, r *nethttp.Request) {
 	httperr.NotImplemented(w, r, "ListConsumerMailDomains")
 }

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -11308,6 +11308,18 @@ type ConsentRequest struct {
 	Passports []ConsentPassportOption `json:"passports"`
 }
 
+// ConsumerMailBaselineResponse defines model for ConsumerMailBaselineResponse.
+type ConsumerMailBaselineResponse struct {
+	// Data The first 50 matching baseline domains, alphabetical.
+	Data []string `json:"data"`
+
+	// Matched How many baseline domains matched the filter in total.
+	Matched int `json:"matched"`
+
+	// Total The size of the whole shipped baseline.
+	Total int `json:"total"`
+}
+
 // ConsumerMailDomain One entry on the workspace's own consumer-mail list (CAP-PARAM-5). `extra` marks a
 // consumer domain the shipped baseline missed; `never` takes one back out of the baseline
 // that claimed it. Either way the domain is stored in its registrable form, which is what
@@ -18129,6 +18141,12 @@ type BookMeetingParams struct {
 
 // BookMeetingJSONBodyLinksEntityType defines parameters for BookMeeting.
 type BookMeetingJSONBodyLinksEntityType string
+
+// ListConsumerMailBaselineParams defines parameters for ListConsumerMailBaseline.
+type ListConsumerMailBaselineParams struct {
+	// Q Case-insensitive substring filter. Absent or empty lists from the top.
+	Q *string `form:"q,omitempty" json:"q,omitempty"`
+}
 
 // GetCompanyContextParams defines parameters for GetCompanyContext.
 type GetCompanyContextParams struct {
@@ -27173,10 +27191,13 @@ type ServerInterface interface {
 	// Snooze a brief item (A77/AC-home-6) — hidden until `snoozed_until` passes, then it re-surfaces as actionable.
 	// (POST /brief/items/{itemId}/snooze)
 	SnoozeBriefItem(w http.ResponseWriter, r *http.Request, itemId openapi_types.UUID)
+	// Search the shipped consumer-mail baseline (CAP-PARAM-5).
+	// (GET /capture/consumer-mail-baseline)
+	ListConsumerMailBaseline(w http.ResponseWriter, r *http.Request, params ListConsumerMailBaselineParams)
 	// The workspace's own consumer-mail domain list (CAP-PARAM-5).
 	// (GET /capture/consumer-mail-domains)
 	ListConsumerMailDomains(w http.ResponseWriter, r *http.Request)
-	// Add a consumer-mail domain, or carve one out (admin/ops).
+	// Add a consumer-mail domain, or carve one out.
 	// (POST /capture/consumer-mail-domains)
 	AddConsumerMailDomain(w http.ResponseWriter, r *http.Request)
 	// Withdraw a consumer-mail list entry (admin/ops).
@@ -28352,13 +28373,19 @@ func (_ Unimplemented) SnoozeBriefItem(w http.ResponseWriter, r *http.Request, i
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
+// Search the shipped consumer-mail baseline (CAP-PARAM-5).
+// (GET /capture/consumer-mail-baseline)
+func (_ Unimplemented) ListConsumerMailBaseline(w http.ResponseWriter, r *http.Request, params ListConsumerMailBaselineParams) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
 // The workspace's own consumer-mail domain list (CAP-PARAM-5).
 // (GET /capture/consumer-mail-domains)
 func (_ Unimplemented) ListConsumerMailDomains(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
-// Add a consumer-mail domain, or carve one out (admin/ops).
+// Add a consumer-mail domain, or carve one out.
 // (POST /capture/consumer-mail-domains)
 func (_ Unimplemented) AddConsumerMailDomain(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNotImplemented)
@@ -32418,6 +32445,45 @@ func (siw *ServerInterfaceWrapper) SnoozeBriefItem(w http.ResponseWriter, r *htt
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.SnoozeBriefItem(w, r, itemId)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// ListConsumerMailBaseline operation middleware
+func (siw *ServerInterfaceWrapper) ListConsumerMailBaseline(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, CookieAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params ListConsumerMailBaselineParams
+
+	// ------------- Optional query parameter "q" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "q", r.URL.Query(), &params.Q, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "q"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "q", Err: err})
+		}
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ListConsumerMailBaseline(w, r, params)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -45780,6 +45846,9 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 	})
 	r.Group(func(r chi.Router) {
 		r.Post(options.BaseURL+"/brief/items/{itemId}/snooze", wrapper.SnoozeBriefItem)
+	})
+	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/capture/consumer-mail-baseline", wrapper.ListConsumerMailBaseline)
 	})
 	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/capture/consumer-mail-domains", wrapper.ListConsumerMailDomains)

--- a/backend/internal/modules/capture/baselinelist.go
+++ b/backend/internal/modules/capture/baselinelist.go
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package capture
+
+// The shipped consumer-mail baseline as a READ surface (CAP-PARAM-5). The
+// workspace list an operator edits is only ever a delta against the shipped
+// dataset, so judging whether a domain needs an `extra` entry — or a `never`
+// carve-out — starts with seeing what the baseline already says. This answers
+// that without a page-through of 8 700 rows: a count, and a filtered slice.
+
+import (
+	"context"
+	"strings"
+
+	"github.com/gradionhq/margince/backend/internal/platform/auth"
+	"github.com/gradionhq/margince/backend/internal/platform/freemail"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+)
+
+// BaselinePageSize caps how many baseline domains one search answer carries.
+// The count says how many matched; the slice exists to be read, not exported.
+const BaselinePageSize = 50
+
+// BaselineSearch is one answer about the shipped baseline.
+type BaselineSearch struct {
+	// Domains is the first BaselinePageSize matches, alphabetical.
+	Domains []string
+	// Matched is how many baseline domains the filter matched in total.
+	Matched int
+	// Total is the size of the whole shipped baseline.
+	Total int
+}
+
+// SearchBaseline filters the shipped baseline by a case-insensitive substring.
+// An empty filter matches everything, so the first page plus the counts still
+// tell the operator what the list is. Gated on the same read every capture
+// surface uses — the baseline is source data, but WHERE it is consulted is
+// this workspace's capture posture.
+func SearchBaseline(ctx context.Context, q string) (BaselineSearch, error) {
+	if err := auth.Require(ctx, freemailDomainObject, principal.ActionRead); err != nil {
+		return BaselineSearch{}, err
+	}
+	needle := strings.ToLower(strings.TrimSpace(q))
+	all := freemail.Domains()
+	out := BaselineSearch{Total: len(all)}
+	for _, domain := range all {
+		if needle != "" && !strings.Contains(domain, needle) {
+			continue
+		}
+		out.Matched++
+		if len(out.Domains) < BaselinePageSize {
+			out.Domains = append(out.Domains, domain)
+		}
+	}
+	return out, nil
+}

--- a/backend/internal/modules/capture/baselinelist_test.go
+++ b/backend/internal/modules/capture/baselinelist_test.go
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package capture
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+)
+
+func baselineCtx(grant principal.ObjectGrant) context.Context {
+	return principal.WithActor(context.Background(), principal.Principal{
+		Type: principal.PrincipalHuman, ID: "human:baseline-test",
+		Permissions: principal.Permissions{
+			Objects:  map[string]principal.ObjectGrant{"capture_settings": grant},
+			RowScope: principal.RowScopeAll,
+		},
+	})
+}
+
+func TestSearchBaselineFiltersCountsAndCapsThePage(t *testing.T) {
+	ctx := baselineCtx(principal.ObjectGrant{Read: true})
+
+	everything, err := SearchBaseline(ctx, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if everything.Total == 0 || everything.Matched != everything.Total {
+		t.Errorf("no filter: matched %d of total %d, want them equal and non-zero",
+			everything.Matched, everything.Total)
+	}
+	if len(everything.Domains) != BaselinePageSize {
+		t.Errorf("no filter answers %d domains, want the %d-cap", len(everything.Domains), BaselinePageSize)
+	}
+
+	// The filter trims and case-folds, so the operator's paste matches the
+	// lowercased dataset.
+	gmail, err := SearchBaseline(ctx, "  GMAIL.COM ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Contains(gmail.Domains, "gmail.com") {
+		t.Errorf("gmail.com filter answers %v, want it to contain gmail.com", gmail.Domains)
+	}
+	if gmail.Matched == 0 || gmail.Matched >= everything.Total {
+		t.Errorf("gmail.com matched %d of %d, want a real narrowing", gmail.Matched, everything.Total)
+	}
+
+	nothing, err := SearchBaseline(ctx, "no-such-provider.invalid")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if nothing.Matched != 0 || len(nothing.Domains) != 0 {
+		t.Errorf("an unmatched filter answers %d/%v, want zero", nothing.Matched, nothing.Domains)
+	}
+}
+
+func TestSearchBaselineDemandsTheCaptureReadGrant(t *testing.T) {
+	if _, err := SearchBaseline(baselineCtx(principal.ObjectGrant{Create: true}), "gmail"); !errors.Is(err, apperrors.ErrPermissionDenied) {
+		t.Errorf("a seat without capture_settings read = %v, want permission denied", err)
+	}
+}

--- a/backend/internal/modules/capture/freemaildomain.go
+++ b/backend/internal/modules/capture/freemaildomain.go
@@ -175,10 +175,8 @@ func (s *FreemailDomainStore) Add(ctx context.Context, domain, kind string) (Fre
 		// inserting a new `extra` is create; a `never` carve-out overrides the
 		// shipped baseline for the whole workspace, and overwriting an
 		// existing entry rewrites a prior decision, so both are update.
-		required := principal.ActionCreate
-		if before != nil || kind == FreemailKindNever {
-			required = principal.ActionUpdate
-		}
+		// UpsertAction keeps this demand and the audit verb below one word.
+		required := auth.UpsertAction(before != nil || kind == FreemailKindNever)
 		if err := auth.Require(ctx, freemailDomainObject, required); err != nil {
 			return err
 		}
@@ -200,15 +198,14 @@ func (s *FreemailDomainStore) Add(ctx context.Context, domain, kind string) (Fre
 		// map[string]any would store JSON null instead of SQL NULL for a first
 		// classification (see storekit.marshalOrNil).
 		var beforeImage any
-		// The verb mirrors what happened — a first entry is create, a rewrite
-		// is update — so the rendered authorization_rule names the grant that
-		// actually admitted the write (auth.AuthzRule maps verb to grant).
-		verb := "create"
 		if before != nil {
 			beforeImage = map[string]any{auditKeyDomain: base, auditKeyKind: *before}
-			verb = "update"
 		}
-		_, auditErr := storekit.Audit(ctx, tx, verb, freemailDomainObject, out.ID,
+		// The verb IS the demanded action, so the rendered authorization_rule
+		// names the grant that actually admitted the write (auth.AuthzRule
+		// maps verb to grant) — a fresh `never` carve-out audits as the
+		// update it was admitted on, never as a create any rep could make.
+		_, auditErr := storekit.Audit(ctx, tx, string(required), freemailDomainObject, out.ID,
 			beforeImage, map[string]any{auditKeyDomain: base, auditKeyKind: kind})
 		return auditErr
 	})

--- a/backend/internal/modules/capture/freemaildomain.go
+++ b/backend/internal/modules/capture/freemaildomain.go
@@ -12,10 +12,14 @@ package capture
 // operator's real customers mail from. Neither error can wait for a release, and
 // both are answerable by the people reading the mail.
 //
-// Workspace-shared and admin-curated: whether a domain can name a company is a
-// statement about the DOMAIN, not about whoever happens to be reading its mail.
-// Writes are audit-only (EVT-NOEVT-3, the same ruling the capture-settings
-// write holds): the closed event catalog defines no verb for a list entry.
+// Workspace-shared, with a split write posture: ANY seat may contribute a
+// consumer domain the baseline missed (`extra` — everyday judgment about the
+// mail they read, gated on capture_settings:create), while carving a domain
+// back OUT of the baseline (`never`), flipping an entry's kind, and removal
+// change what the whole workspace captures and stay admin/ops
+// (capture_settings:update). Writes are audit-only (EVT-NOEVT-3, the same
+// ruling the capture-settings write holds): the closed event catalog defines
+// no verb for a list entry.
 
 import (
 	"context"
@@ -135,7 +139,13 @@ func (s *FreemailDomainStore) List(ctx context.Context) ([]FreemailDomain, error
 // keys on: an operator typing "mail.gmx.net" means gmx.net, and storing the
 // subdomain would leave an entry that never matches anything.
 func (s *FreemailDomainStore) Add(ctx context.Context, domain, kind string) (FreemailDomain, error) {
-	if err := auth.Require(ctx, freemailDomainObject, principal.ActionUpdate); err != nil {
+	// Which grant this write demands depends on what it turns out to be — a
+	// fresh `extra` contribution is create (every seat), everything else is
+	// update (admin/ops) — and "fresh" is only knowable from the table. So the
+	// upfront gate refuses a principal holding NEITHER before a pool
+	// connection is taken, and the specific demand happens inside the
+	// transaction once the prior state is read.
+	if err := auth.RequireAny(ctx, freemailDomainObject, principal.ActionCreate, principal.ActionUpdate); err != nil {
 		return FreemailDomain{}, err
 	}
 	// The handler validates first and answers 422; these are the store's own
@@ -161,6 +171,17 @@ func (s *FreemailDomainStore) Add(ctx context.Context, domain, kind string) (Fre
 			!errors.Is(err, pgx.ErrNoRows) {
 			return err
 		}
+		// The specific demand, now that the write knows which half it is:
+		// inserting a new `extra` is create; a `never` carve-out overrides the
+		// shipped baseline for the whole workspace, and overwriting an
+		// existing entry rewrites a prior decision, so both are update.
+		required := principal.ActionCreate
+		if before != nil || kind == FreemailKindNever {
+			required = principal.ActionUpdate
+		}
+		if err := auth.Require(ctx, freemailDomainObject, required); err != nil {
+			return err
+		}
 		if err := tx.QueryRow(ctx, `
 			INSERT INTO capture_freemail_domain (workspace_id, domain, kind, created_by)
 			VALUES ($1, $2, $3, $4)
@@ -179,10 +200,15 @@ func (s *FreemailDomainStore) Add(ctx context.Context, domain, kind string) (Fre
 		// map[string]any would store JSON null instead of SQL NULL for a first
 		// classification (see storekit.marshalOrNil).
 		var beforeImage any
+		// The verb mirrors what happened — a first entry is create, a rewrite
+		// is update — so the rendered authorization_rule names the grant that
+		// actually admitted the write (auth.AuthzRule maps verb to grant).
+		verb := "create"
 		if before != nil {
 			beforeImage = map[string]any{auditKeyDomain: base, auditKeyKind: *before}
+			verb = "update"
 		}
-		_, auditErr := storekit.Audit(ctx, tx, "update", freemailDomainObject, out.ID,
+		_, auditErr := storekit.Audit(ctx, tx, verb, freemailDomainObject, out.ID,
 			beforeImage, map[string]any{auditKeyDomain: base, auditKeyKind: kind})
 		return auditErr
 	})

--- a/backend/internal/modules/identity/internal/policy/policy.go
+++ b/backend/internal/modules/identity/internal/policy/policy.go
@@ -113,11 +113,11 @@ var (
 // and migrate-in screens are admin surfaces.
 var defaults = map[string]Document{
 	"admin": {
-		Objects:  objects(crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, readOnly, crud, crud, crud, readUpdate, crud, writeNoDelete, writeNoDelete, readUpdate, crud, crud, crud, readUpdate, crud),
+		Objects:  objects(crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, readOnly, crud, crud, crud, readUpdate, crud, writeNoDelete, writeNoDelete, writeNoDelete, crud, crud, crud, readUpdate, crud),
 		RowScope: principal.RowScopeAll,
 	},
 	"manager": {
-		Objects:  objects(crud, crud, crud, crud, crud, readOnly, crud, crud, crud, crud, readOnly, crud, crud, crud, crud, crud, readOnly, readOnly, readOnly, crud, readOnly, grant{}, readOnly, grant{}, grant{}, readOnly, crud, readOnly, grant{}, readOnly, readOnly),
+		Objects:  objects(crud, crud, crud, crud, crud, readOnly, crud, crud, crud, crud, readOnly, crud, crud, crud, crud, crud, readOnly, readOnly, readOnly, crud, readOnly, grant{}, readOnly, grant{}, grant{}, grant{Create: true, Read: true}, crud, readOnly, grant{}, readOnly, readOnly),
 		RowScope: principal.RowScopeTeam,
 	},
 	"rep": {
@@ -162,8 +162,12 @@ var defaults = map[string]Document{
 			grant{}, // fx_rate — admin/ops-only
 			grant{}, // ai_model_rate — admin/ops-only
 			// capture_settings — everyone reads (a rep sees whether
-			// auto-enrich is on), only admin/ops toggle it.
-			readOnly,
+			// auto-enrich is on), only admin/ops toggle it or carve a
+			// domain back out of the consumer-mail baseline. `create` is
+			// the one write a rep holds: contributing a consumer domain
+			// the shipped baseline missed (CAP-PARAM-5) is everyday
+			// judgment about the mail they read, not workspace config.
+			grant{Create: true, Read: true},
 			// project — the record posture: reps create and work a body
 			// of work, archiving stays manager/admin/ops.
 			grant{Create: true, Read: true, Update: true},
@@ -183,7 +187,7 @@ var defaults = map[string]Document{
 		RowScope: principal.RowScopeAll,
 	},
 	"ops": {
-		Objects:  objects(crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, readOnly, crud, crud, crud, readUpdate, crud, writeNoDelete, writeNoDelete, readUpdate, crud, crud, crud, readUpdate, crud),
+		Objects:  objects(crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, readOnly, crud, crud, crud, readUpdate, crud, writeNoDelete, writeNoDelete, writeNoDelete, crud, crud, crud, readUpdate, crud),
 		RowScope: principal.RowScopeAll,
 	},
 }

--- a/backend/internal/platform/freemail/baseline.go
+++ b/backend/internal/platform/freemail/baseline.go
@@ -11,6 +11,7 @@ package freemail
 
 import (
 	_ "embed"
+	"slices"
 	"strings"
 	"sync"
 )
@@ -51,6 +52,24 @@ var baseline = sync.OnceValue(func() map[string]struct{} {
 	}
 	return set
 })
+
+// sortedBaseline is the same set as one alphabetical list, materialized once —
+// the read surface that shows an operator what the shipped list contains.
+var sortedBaseline = sync.OnceValue(func() []string {
+	set := baseline()
+	out := make([]string, 0, len(set))
+	for domain := range set {
+		out = append(out, domain)
+	}
+	slices.Sort(out)
+	return out
+})
+
+// Domains returns the shipped baseline, alphabetical. The slice is shared and
+// read-only: callers render or filter it, never mutate it.
+func Domains() []string {
+	return sortedBaseline()
+}
 
 // sanitize turns one dataset line into a usable domain, reporting false for a
 // line that cannot be one. The vendored file is byte-identical to upstream, so

--- a/backend/internal/platform/freemail/baseline.go
+++ b/backend/internal/platform/freemail/baseline.go
@@ -65,10 +65,11 @@ var sortedBaseline = sync.OnceValue(func() []string {
 	return out
 })
 
-// Domains returns the shipped baseline, alphabetical. The slice is shared and
-// read-only: callers render or filter it, never mutate it.
+// Domains returns the shipped baseline, alphabetical. The copy is the
+// caller's own — handing out the memoized slice would let one caller's sort
+// or reslice corrupt the process-wide baseline for every workspace.
 func Domains() []string {
-	return sortedBaseline()
+	return slices.Clone(sortedBaseline())
 }
 
 // sanitize turns one dataset line into a usable domain, reporting false for a

--- a/backend/migrations/core/0210_consumer_mail_create_grant.down.sql
+++ b/backend/migrations/core/0210_consumer_mail_create_grant.down.sql
@@ -1,0 +1,15 @@
+-- Mirror of the up: the seeded system roles return to the pre-0210 posture,
+-- where no role held `create` on capture_settings.
+DO $$
+DECLARE ws uuid;
+BEGIN
+  FOR ws IN SELECT id FROM workspace LOOP
+    PERFORM set_config('app.workspace_id', ws::text, true);
+
+    UPDATE role SET permissions = jsonb_set(
+      permissions, '{objects,capture_settings,create}', 'false'::jsonb)
+    WHERE is_system AND key IN ('admin','ops','manager','rep')
+      AND permissions->'objects' ? 'capture_settings'
+      AND role.workspace_id = ws;
+  END LOOP;
+END $$;

--- a/backend/migrations/core/0210_consumer_mail_create_grant.up.sql
+++ b/backend/migrations/core/0210_consumer_mail_create_grant.up.sql
@@ -1,0 +1,19 @@
+-- Every seat may contribute a consumer-mail domain (CAP-PARAM-5): the seeded
+-- system roles admin/ops/manager/rep gain `create` on capture_settings. The
+-- capture store demands `create` for inserting a NEW `extra` entry, while
+-- `never` carve-outs, kind overwrites and removal keep demanding `update`
+-- (admin/ops). read_only stays read-only. Mirrors the policy.go defaults so a
+-- deployed database and a fresh install agree.
+DO $$
+DECLARE ws uuid;
+BEGIN
+  FOR ws IN SELECT id FROM workspace LOOP
+    PERFORM set_config('app.workspace_id', ws::text, true);
+
+    UPDATE role SET permissions = jsonb_set(
+      permissions, '{objects,capture_settings,create}', 'true'::jsonb)
+    WHERE is_system AND key IN ('admin','ops','manager','rep')
+      AND permissions->'objects' ? 'capture_settings'
+      AND role.workspace_id = ws;
+  END LOOP;
+END $$;

--- a/backend/migrations/testdata/rbac_seeded_defaults.json
+++ b/backend/migrations/testdata/rbac_seeded_defaults.json
@@ -20,7 +20,7 @@
         "update": true
       },
       "capture_settings": {
-        "create": false,
+        "create": true,
         "delete": false,
         "read": true,
         "update": true
@@ -211,7 +211,7 @@
         "update": false
       },
       "capture_settings": {
-        "create": false,
+        "create": true,
         "delete": false,
         "read": true,
         "update": false
@@ -402,7 +402,7 @@
         "update": true
       },
       "capture_settings": {
-        "create": false,
+        "create": true,
         "delete": false,
         "read": true,
         "update": true
@@ -784,7 +784,7 @@
         "update": false
       },
       "capture_settings": {
-        "create": false,
+        "create": true,
         "delete": false,
         "read": true,
         "update": false

--- a/docs/reference/rbac-matrix.md
+++ b/docs/reference/rbac-matrix.md
@@ -62,7 +62,7 @@ the workspace but changes none of them.
 | `activity` | CRUD | CRUD | CRU- | -R-- | CRUD |
 | `ai_model_rate` | CRU- | ---- | ---- | ---- | CRU- |
 | `automation` | CRUD | -R-- | -R-- | -R-- | CRUD |
-| `capture_settings` | -RU- | -R-- | -R-- | -R-- | -RU- |
+| `capture_settings` | CRU- | CR-- | CR-- | -R-- | CRU- |
 | `channel_connection` | CRUD | -R-- | -R-- | -R-- | CRUD |
 | `computed_field` | -R-- | -R-- | -R-- | -R-- | -R-- |
 | `custom_field` | CRUD | -R-- | -R-- | -R-- | CRUD |

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -3873,11 +3873,14 @@ export interface paths {
         get: operations["listConsumerMailDomains"];
         put?: never;
         /**
-         * Add a consumer-mail domain, or carve one out (admin/ops).
-         * @description Admin/ops-only, human session only — an agent never changes a workspace-wide capture
-         *     posture. `kind: extra` marks a domain the baseline missed as consumer mail; `kind: never`
-         *     takes one back out and wins over the baseline, which is the only way back in for an
-         *     operator whose real customers mail from a domain the shipped list claims.
+         * Add a consumer-mail domain, or carve one out.
+         * @description Human session only — an agent never changes a workspace-wide capture posture. `kind:
+         *     extra` marks a domain the baseline missed as consumer mail; any seat holding
+         *     `capture_settings:create` (every seeded role but read_only) may contribute a NEW one.
+         *     `kind: never` takes a domain back out of the baseline and wins over it — the only way
+         *     back in for an operator whose real customers mail from a domain the shipped list claims
+         *     — and, like overwriting an existing entry's kind, demands `capture_settings:update`
+         *     (admin/ops).
          *
          *     The domain is normalized to its registrable form (`mail.gmx.net` is stored as `gmx.net`),
          *     because that is what the matcher keys on. Idempotent on the domain: re-adding returns the
@@ -3911,6 +3914,30 @@ export interface paths {
          *     already satisfied.
          */
         delete: operations["removeConsumerMailDomain"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/capture/consumer-mail-baseline": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Search the shipped consumer-mail baseline (CAP-PARAM-5).
+         * @description The vendored consumer-domain dataset the installation ships with, as a searchable read.
+         *     The workspace's own list is only ever a delta against this baseline, so deciding whether
+         *     a domain needs an `extra` entry — or a `never` carve-out — starts here. Answers the
+         *     first 50 alphabetical matches plus the counts; every human role may read it, like the
+         *     rest of the capture posture.
+         */
+        get: operations["listConsumerMailBaseline"];
+        put?: never;
+        post?: never;
+        delete?: never;
         options?: never;
         head?: never;
         patch?: never;
@@ -6890,6 +6917,14 @@ export interface components {
         };
         ConsumerMailDomainListResponse: {
             data: components["schemas"]["ConsumerMailDomain"][];
+        };
+        ConsumerMailBaselineResponse: {
+            /** @description The first 50 matching baseline domains, alphabetical. */
+            data: string[];
+            /** @description How many baseline domains matched the filter in total. */
+            matched: number;
+            /** @description The size of the whole shipped baseline. */
+            total: number;
         };
         /**
          * @description A per-user mail/calendar capture connection + sync state (capture.md CAP-DDL-2). The
@@ -21636,6 +21671,31 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content?: never;
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+        };
+    };
+    listConsumerMailBaseline: {
+        parameters: {
+            query?: {
+                /** @description Case-insensitive substring filter. Absent or empty lists from the top. */
+                q?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The matching slice of the shipped baseline. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ConsumerMailBaselineResponse"];
+                };
             };
             401: components["responses"]["Unauthorized"];
             403: components["responses"]["Forbidden"];

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -2332,6 +2332,16 @@ export const de = {
     "Nichts ergänzt. Die mitgelieferte Liste entscheidet über jede Domain.",
   "consumerMail.adminOnly":
     "Du hast keine Berechtigung, diese Liste zu ändern.",
+  "consumerMail.addOnly":
+    "Du kannst Consumer-Mail-Domains ergänzen. Die mitgelieferte Liste übersteuern und Einträge entfernen kann nur ein Admin.",
+  "consumerMail.baselineTitle": "Mitgelieferte Liste",
+  "consumerMail.baselineCount":
+    "Margince liefert {total} bekannte Consumer-Mail-Domains mit.",
+  "consumerMail.baselineSearchLabel": "Mitgelieferte Liste durchsuchen",
+  "consumerMail.baselinePlaceholder": "gmail.com",
+  "consumerMail.baselineNone": "Keine mitgelieferte Domain passt.",
+  "consumerMail.baselineMore":
+    "Die ersten {shown} von {matched} Treffern.",
 
   "ob.s4.googleVerifying": "Verbindung wird geprüft…",
   "ob.s4.googleDenied": "Du hast die Google-Einwilligung abgelehnt",
@@ -3757,6 +3767,7 @@ export const de = {
     "Das Archivieren entfernt diese Quota aus der Liste und stoppt die Verfolgung der Zielerreichung. Archivierte Quotas können nicht bearbeitet werden.",
 
   "settings.tab.installation": "Installation",
+  "settings.tab.capture": "Erfassung",
   "installationSettings.title": "Installation",
   "installationSettings.sub":
     "Wie diese Installation heißt und in welcher Zeitzone und Währung jede Auswertung berechnet wird.",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -2308,6 +2308,16 @@ export const en = {
   "consumerMail.remove": "Remove",
   "consumerMail.none": "Nothing added. The shipped list decides every domain.",
   "consumerMail.adminOnly": "You do not have permission to change this list.",
+  "consumerMail.addOnly":
+    "You can add consumer-mail domains. Overriding the shipped list and removing entries need an admin.",
+  "consumerMail.baselineTitle": "Shipped list",
+  "consumerMail.baselineCount":
+    "Margince ships with {total} known consumer-mail domains.",
+  "consumerMail.baselineSearchLabel": "Search the shipped list",
+  "consumerMail.baselinePlaceholder": "gmail.com",
+  "consumerMail.baselineNone": "No shipped domain matches.",
+  "consumerMail.baselineMore":
+    "Showing the first {shown} of {matched} matches.",
 
   "ob.s4.googleVerifying": "Verifying the connection…",
   "ob.s4.googleDenied": "You declined the Google consent",
@@ -3737,6 +3747,7 @@ export const en = {
     "Archiving drops this quota from the list and stops tracking its attainment. Archived quotas can't be edited.",
 
   "settings.tab.installation": "Installation",
+  "settings.tab.capture": "Capture",
   "installationSettings.title": "Installation",
   "installationSettings.sub":
     "What this installation is called, and the zone and currency every report is computed in.",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -2322,6 +2322,15 @@ export const vi = {
   "consumerMail.none":
     "Chưa thêm gì. Danh sách có sẵn quyết định mọi tên miền.",
   "consumerMail.adminOnly": "Bạn không có quyền thay đổi danh sách này.",
+  "consumerMail.addOnly":
+    "Bạn có thể thêm tên miền thư cá nhân. Ghi đè danh sách có sẵn và gỡ mục cần quản trị viên.",
+  "consumerMail.baselineTitle": "Danh sách có sẵn",
+  "consumerMail.baselineCount":
+    "Margince có sẵn {total} tên miền thư cá nhân đã biết.",
+  "consumerMail.baselineSearchLabel": "Tìm trong danh sách có sẵn",
+  "consumerMail.baselinePlaceholder": "gmail.com",
+  "consumerMail.baselineNone": "Không có tên miền có sẵn nào khớp.",
+  "consumerMail.baselineMore": "Hiển thị {shown} đầu tiên trong {matched} kết quả.",
 
   "ob.s4.googleVerifying": "Đang xác minh kết nối…",
   "ob.s4.googleDenied": "Bạn đã từ chối chấp thuận của Google",
@@ -3748,6 +3757,7 @@ export const vi = {
     "Lưu trữ sẽ đưa chỉ tiêu này ra khỏi danh sách và ngừng theo dõi mức đạt. Chỉ tiêu đã lưu trữ thì không sửa được.",
 
   "settings.tab.installation": "Cài đặt hệ thống",
+  "settings.tab.capture": "Thu thập",
   "installationSettings.title": "Cài đặt hệ thống",
   "installationSettings.sub":
     "Tên của bản cài đặt này, cùng múi giờ và đơn vị tiền tệ dùng để tính mọi báo cáo.",

--- a/frontend/src/screens/consumer-mail-domains.test.tsx
+++ b/frontend/src/screens/consumer-mail-domains.test.tsx
@@ -7,22 +7,27 @@ import { type GrantSpec, meFixture } from "../app/mefixture";
 import { LocaleProvider } from "../i18n";
 import { ConsumerMailDomainsCard } from "./consumer-mail-domains";
 
-// The workspace's own consumer-mail list. Both add and remove gate on
-// capture_settings:update server-side (freemailDomainObject IS
-// captureSettingsObject, and removal is an update to the capture configuration
-// rather than a delete of a record) — so a fixture granting capture_settings
-// delete, or any grant on a mail-shaped object, must leave the controls inert.
+// The workspace's own consumer-mail list. The server's write split: adding a
+// NEW `extra` entry admits on capture_settings create OR update (the upsert
+// pair), while the `never` carve-out, kind overwrites and removal demand
+// update — so a fixture granting capture_settings delete, or any grant on a
+// mail-shaped object, must leave every control inert.
 const CAPTURE_EDITOR: GrantSpec = { capture_settings: ["read", "update"] };
 
 function backend(allow: GrantSpec) {
   return vi.fn(async (input: RequestInfo | URL) => {
     const url = String(input instanceof Request ? input.url : input);
-    const body = url.endsWith("/v1/me")
-      ? meFixture({ allow })
-      : // id is required by the ConsumerMailDomain contract and is what remove
-        // sends; a fixture without it would let a broken remove path call
-        // mutate(undefined) and still pass.
-        { data: [{ id: "cmd-1", domain: "gmx.test", kind: "extra" }] };
+    let body: unknown;
+    if (url.endsWith("/v1/me")) {
+      body = meFixture({ allow });
+    } else if (url.includes("/consumer-mail-baseline")) {
+      body = { data: [], matched: 0, total: 8758 };
+    } else {
+      // id is required by the ConsumerMailDomain contract and is what remove
+      // sends; a fixture without it would let a broken remove path call
+      // mutate(undefined) and still pass.
+      body = { data: [{ id: "cmd-1", domain: "gmx.test", kind: "extra" }] };
+    }
     return new Response(JSON.stringify(body), {
       headers: { "Content-Type": "application/json" },
     });
@@ -78,6 +83,21 @@ describe("ConsumerMailDomainsCard", () => {
     // Both, not just Add: the two share one grant, so a change that decoupled
     // them would otherwise pass.
     expect(addButton().disabled).toBe(true);
+    expect(removeButton().disabled).toBe(true);
+  });
+
+  // The rep posture: create without update adds a NEW consumer domain, and
+  // nothing else — remove stays inert, mirroring the server's split.
+  it("enables add but not remove on capture_settings:create alone", async () => {
+    vi.stubGlobal("fetch", backend({ capture_settings: ["read", "create"] }));
+    render(
+      <Providers>
+        <ConsumerMailDomainsCard />
+      </Providers>,
+    );
+
+    await waitFor(() => expect(screen.getByText("gmx.test")).toBeTruthy());
+    expect(addButton().disabled).toBe(false);
     expect(removeButton().disabled).toBe(true);
   });
 

--- a/frontend/src/screens/consumer-mail-domains.tsx
+++ b/frontend/src/screens/consumer-mail-domains.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import { api } from "../api/client";
 import { useCanUpsert, useCanWrite } from "../app/capability";
 import { isOption } from "../app/options";
-import { SectionHeader } from "../design-system/atoms";
+import { SectionHeader, TextInput } from "../design-system/atoms";
 import { Select } from "../design-system/select";
 import { useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
@@ -129,7 +129,7 @@ function BaselineSection() {
           {t("consumerMail.baselineCount", { total: result.total })}
         </p>
       )}
-      <input
+      <TextInput
         aria-label={t("consumerMail.baselineSearchLabel")}
         data-testid="consumer-mail-baseline-search"
         placeholder={t("consumerMail.baselinePlaceholder")}

--- a/frontend/src/screens/consumer-mail-domains.tsx
+++ b/frontend/src/screens/consumer-mail-domains.tsx
@@ -2,7 +2,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Mail, Trash2 } from "lucide-react";
 import { useState } from "react";
 import { api } from "../api/client";
-import { useCanWrite } from "../app/capability";
+import { useCanUpsert, useCanWrite } from "../app/capability";
 import { isOption } from "../app/options";
 import { SectionHeader } from "../design-system/atoms";
 import { Select } from "../design-system/select";
@@ -16,10 +16,12 @@ import "./settings.css";
 // shipped baseline is a third-party dataset of some 8 700 domains, right far
 // more often than a hand-typed list and still wrong sometimes in both
 // directions — so this is where an operator adds what it missed and takes back
-// what it wrongly claimed. Every role reads it; only admin/ops may change it,
-// so the controls are disabled rather than hidden — a rep can see that the
-// list exists and what is on it, which is what makes the capture posture
-// legible to the people whose mail it governs.
+// what it wrongly claimed. Every role reads it, and every role may search the
+// shipped baseline itself, so the capture posture stays legible to the people
+// whose mail it governs. The write split mirrors the server's: any seat with
+// capture_settings:create adds a consumer domain the baseline missed (`extra`),
+// while `never` carve-outs and removal stay on capture_settings:update
+// (admin/ops) — those controls disable rather than hide.
 
 // The two things an entry can say, as ONE list: the type is derived from it and
 // the control's options are built from it, so the offered choices, their labels
@@ -31,6 +33,22 @@ const kindLabel: Record<Kind, MessageKey> = {
   extra: "consumerMail.kind.extra",
   never: "consumerMail.kind.never",
 };
+
+function useConsumerMailBaseline(q: string) {
+  return useQuery({
+    queryKey: ["consumer-mail-baseline", q],
+    queryFn: async () => {
+      const { data, error, response } = await api.GET(
+        "/capture/consumer-mail-baseline",
+        { params: { query: q ? { q } : {} } },
+      );
+      if (error || !response.ok) {
+        throwProblem(error);
+      }
+      return data;
+    },
+  });
+}
 
 function useConsumerMailDomains() {
   return useQuery({
@@ -87,12 +105,88 @@ function useRemoveConsumerMailDomain() {
   });
 }
 
+// The shipped baseline, searchable in place: an operator deciding whether a
+// domain needs an entry first sees what the shipped list already says about
+// it. Results render only once a filter is typed — the first 50 of 8 700
+// alphabetical rows answer no question anyone is asking.
+function BaselineSection() {
+  const t = useT();
+  const [q, setQ] = useState("");
+  const needle = q.trim();
+  const query = useConsumerMailBaseline(needle);
+  const result = query.data;
+  return (
+    <div
+      style={{
+        marginTop: "var(--space-3)",
+        paddingTop: "var(--space-3)",
+        borderTop: "1px solid var(--borderSubtle)",
+      }}
+    >
+      <p className="t-label">{t("consumerMail.baselineTitle")}</p>
+      {result && (
+        <p style={{ color: "var(--text-muted)", fontSize: "var(--text-sm)" }}>
+          {t("consumerMail.baselineCount", { total: result.total })}
+        </p>
+      )}
+      <input
+        aria-label={t("consumerMail.baselineSearchLabel")}
+        data-testid="consumer-mail-baseline-search"
+        placeholder={t("consumerMail.baselinePlaceholder")}
+        value={q}
+        onChange={(e) => setQ(e.target.value)}
+        style={{ marginTop: "var(--space-2)" }}
+      />
+      {needle !== "" && result && result.matched === 0 && (
+        <p style={{ color: "var(--text-muted)", fontSize: "var(--text-sm)" }}>
+          {t("consumerMail.baselineNone")}
+        </p>
+      )}
+      {needle !== "" && result && result.matched > 0 && (
+        <>
+          <ul
+            data-testid="consumer-mail-baseline-list"
+            style={{
+              listStyle: "none",
+              margin: "var(--space-2) 0 0",
+              padding: 0,
+              display: "flex",
+              flexWrap: "wrap",
+              gap: "var(--space-1) var(--space-2)",
+            }}
+          >
+            {result.data.map((domain) => (
+              <li key={domain} className="t-mono t-small">
+                {domain}
+              </li>
+            ))}
+          </ul>
+          {result.matched > result.data.length && (
+            <p
+              style={{ color: "var(--text-muted)", fontSize: "var(--text-sm)" }}
+            >
+              {t("consumerMail.baselineMore", {
+                shown: result.data.length,
+                matched: result.matched,
+              })}
+            </p>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
 export function ConsumerMailDomainsCard() {
   const t = useT();
-  // Both add and remove gate on capture_settings:update — there is no
-  // mail-domain object, and removing an entry is an update to the workspace's
-  // capture configuration rather than a delete of a record.
+  // The write split mirrors the server's two demands. `canManage`
+  // (capture_settings:update) covers what rewrites workspace posture: the
+  // `never` carve-out, overwriting an entry, removal. `canAdd` mirrors the
+  // server's upsert admission (create OR update) — a rep holding only create
+  // may still contribute a new `extra` domain, and the server demands the
+  // specific grant once it knows which half the write is.
   const canManage = useCanWrite("capture_settings", "update");
+  const canAdd = useCanUpsert("capture_settings");
   const query = useConsumerMailDomains();
   const add = useAddConsumerMailDomain();
   const remove = useRemoveConsumerMailDomain();
@@ -115,7 +209,7 @@ export function ConsumerMailDomainsCard() {
         }}
         onSubmit={(e) => {
           e.preventDefault();
-          if (!canManage || domain.trim() === "") return;
+          if (!canAdd || domain.trim() === "") return;
           add.mutate(
             { domain: domain.trim(), kind },
             { onSuccess: () => setDomain("") },
@@ -127,9 +221,12 @@ export function ConsumerMailDomainsCard() {
           data-testid="consumer-mail-domain-input"
           placeholder={t("consumerMail.domainPlaceholder")}
           value={domain}
-          disabled={!canManage}
+          disabled={!canAdd}
           onChange={(e) => setDomain(e.target.value)}
         />
+        {/* The kind stays on the update grant: `never` overrides the shipped
+            baseline for the whole workspace, so a create-only seat submits the
+            initial `extra` and never reaches the carve-out. */}
         <Select
           className="consumer-mail-kind"
           aria-label={t("consumerMail.kindLabel")}
@@ -145,7 +242,7 @@ export function ConsumerMailDomainsCard() {
             label: t(kindLabel[value]),
           }))}
         />
-        <button type="submit" disabled={!canManage || add.isPending}>
+        <button type="submit" disabled={!canAdd || add.isPending}>
           {t("consumerMail.add")}
         </button>
         {add.isError && (
@@ -157,9 +254,14 @@ export function ConsumerMailDomainsCard() {
           </span>
         )}
       </form>
-      {!canManage && (
+      {!canAdd && (
         <p style={{ color: "var(--text-muted)", fontSize: "var(--text-sm)" }}>
           {t("consumerMail.adminOnly")}
+        </p>
+      )}
+      {canAdd && !canManage && (
+        <p style={{ color: "var(--text-muted)", fontSize: "var(--text-sm)" }}>
+          {t("consumerMail.addOnly")}
         </p>
       )}
       <QueryGate query={query}>
@@ -220,6 +322,7 @@ export function ConsumerMailDomainsCard() {
           {problemMessageOf(remove.error, t)}
         </span>
       )}
+      <BaselineSection />
     </section>
   );
 }

--- a/frontend/src/screens/settings.tsx
+++ b/frontend/src/screens/settings.tsx
@@ -13,6 +13,7 @@ import {
   Factory,
   Layers,
   type LucideIcon,
+  Mail,
   Mic,
   Package,
   ScrollText,
@@ -114,11 +115,15 @@ import "./settings.css";
 // every seat does for itself. Listing it under Organization put a per-user
 // task beneath an admin heading. The org-owned card on the tab (webhooks)
 // gates itself per-card, exactly as the AI tab's do.
+// `capture` is the org-group counterpart: the own-email-domain list is
+// workspace-shared capture posture an admin curates, so it lives under
+// Organization rather than beside the per-user mailbox connections.
 const SETTINGS_TABS = [
   { id: "account", icon: Building2, group: "you" },
   { id: "voice", icon: Mic, group: "you" },
   { id: "ai", icon: Sparkles, group: "you" },
   { id: "installation", icon: Building, group: "org" },
+  { id: "capture", icon: Mail, group: "org" },
   { id: "company", icon: Factory, group: "org" },
   { id: "users", icon: UsersRound, group: "org" },
   { id: "data", icon: Database, group: "org" },
@@ -144,6 +149,8 @@ function tabContent(id: SettingsTabId): ReactNode {
       return <VoiceDnaCard />;
     case "installation":
       return <InstallationSettingsCard />;
+    case "capture":
+      return <OwnDomainsCard />;
     case "company":
       return <CompanyContextCard />;
     case "users":
@@ -182,7 +189,6 @@ function tabContent(id: SettingsTabId): ReactNode {
         <>
           <ConnectorsCard />
           <CaptureSettingsCard />
-          <OwnDomainsCard />
           <ConsumerMailDomainsCard />
           <LinkedInImportCard />
           {/* No review queue here: a match a human must judge is a proposal,
@@ -249,6 +255,9 @@ function useOrgTabVisibility(): Readonly<Record<OrgTabId, boolean>> {
   // The same call InstallationSettingsCard makes, so the tab and the fields
   // inside it can never disagree about who may edit.
   const canEditInstallation = useCanWrite("installation_settings", "update");
+  // The capture tab carries the own-email-domain list, whose writes gate on
+  // capture_settings:update — the same grant the card's controls ask for.
+  const canEditCapture = useCanWrite("capture_settings", "update");
   const isOrgAdmin = (me.data?.roles ?? []).some(
     (role) => role === "admin" || role === "ops",
   );
@@ -279,6 +288,7 @@ function useOrgTabVisibility(): Readonly<Record<OrgTabId, boolean>> {
     // grant under another role could not reach the surface they may use. The
     // tab exists to change these values, so it follows the write grant.
     installation: canEditInstallation,
+    capture: canEditCapture,
   };
 }
 


### PR DESCRIPTION
The own-email-domain list moves to a new admin-group **Capture** settings tab (it is workspace capture posture, admin-curated — it never belonged under the personal integrations tab).

The consumer-mail list's write posture splits:
- Adding a **new `extra`** entry now admits on `capture_settings:create`, granted to every seeded role but read_only (policy.go defaults + migration 0210 backfill for deployed databases).
- `never` carve-outs, kind overwrites and removal keep demanding `capture_settings:update` (admin/ops). The store demands the specific grant inside the transaction once it knows which half the upsert is; the audit verb mirrors it.

New `GET /capture/consumer-mail-baseline` exposes the shipped ~8.7k consumer-domain dataset as a searchable read (first 50 matches + counts). The card now shows the shipped total and a search box, so an operator sees what Margince already ships before adding a delta.

Verified against the running stack: rep add `extra` → 201; rep `never` and rep overwrite → 403; baseline search → 200; admin add unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved the own email domains list to a new Capture tab under Organization settings, let any seat add new consumer-mail domains, and added a searchable view of the shipped baseline to reduce guesswork. Aligns in-transaction gating and audit logs via `auth.UpsertAction`.

- **New Features**
  - New Capture tab in Org settings; own email domains moved from personal integrations.
  - Split write posture: adding a new `extra` domain admits on `capture_settings:create`; `never` carve-outs, overwrites, and removals still require `capture_settings:update` (enforced in-transaction via `auth.UpsertAction`; audit verb mirrors the admitted grant).
  - New endpoint `GET /capture/consumer-mail-baseline` (human-only): returns first 50 alphabetical matches plus counts; UI shows shipped total, adds search with design-system input, and clarifies add-only vs manage permissions; translations and tests updated.

- **Migration**
  - Seeded roles `admin`, `ops`, `manager`, and `rep` gain `capture_settings:create` via migration `0210_consumer_mail_create_grant` (read_only unchanged). Run migrations; no manual steps required.

<sup>Written for commit 8ca0270b24aa5ade2f2e23a69baa2314f01ceb88. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/872?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

