### PR TITLE
feat(company): an accepted employee_range fact fills the size chip when it maps cleanly

### DIFF
--- a/backend/internal/compose/deepread_integration_test.go
+++ b/backend/internal/compose/deepread_integration_test.go
@@ -620,6 +620,78 @@ func TestDeepReadOfferingsDedupeOnValueKeyAndAcceptRespectsHumanPrecedence(t *te
 	}
 }
 
+func TestAcceptedEmployeeRangeFactFillsSizeBandWhenUnambiguous(t *testing.T) {
+	e := integration.Setup(t)
+	store := people.NewStore(e.Pool)
+	ctx := e.As(e.Rep1, nil, integration.AdminPerms)
+	employeeRangeFact := func(value string) []people.DeepReadFact {
+		return []people.DeepReadFact{{
+			Category: "company", Field: "employee_range", Value: value,
+			EvidenceSnippet: "our team of " + value, SourceURL: "https://acme.example/about", Confidence: 0.9,
+		}}
+	}
+	readSizeBand := func(org ids.UUID) *string {
+		var sizeBand *string
+		if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+			return tx.QueryRow(context.Background(),
+				`SELECT size_band FROM organization WHERE id = $1`, org).Scan(&sizeBand)
+		}); err != nil {
+			t.Fatalf("reading size_band: %v", err)
+		}
+		return sizeBand
+	}
+
+	// A cleanly-phrased range fills the chip's column on accept.
+	org := insertOrg(t, e, e.Rep1, "acme.example", "")
+	if err := store.ApplyDeepRead(ctx, people.DeepReadProposal{
+		OrganizationID: ids.From[ids.OrganizationKind](org),
+		SourceURL:      "https://acme.example",
+		Facts:          employeeRangeFact("25 to 50"),
+	}); err != nil {
+		t.Fatalf("ApplyDeepRead: %v", err)
+	}
+	if got := readSizeBand(org); got == nil || *got != "11-50" {
+		t.Fatalf("size_band after accept = %v, want 11-50", got)
+	}
+
+	// A later read never overwrites the standing value — fill-once.
+	if err := store.ApplyDeepRead(ctx, people.DeepReadProposal{
+		OrganizationID: ids.From[ids.OrganizationKind](org),
+		SourceURL:      "https://acme.example",
+		Facts:          employeeRangeFact("about 300 people"),
+	}); err != nil {
+		t.Fatalf("second ApplyDeepRead: %v", err)
+	}
+	if got := readSizeBand(org); got == nil || *got != "11-50" {
+		t.Fatalf("size_band after re-accept = %v, want the first fill kept", got)
+	}
+
+	// A range spanning two bands abstains: the fact lands as evidence, the
+	// column stays empty rather than holding a guess.
+	vague := insertOrg(t, e, e.Rep1, "vague.example", "")
+	if err := store.ApplyDeepRead(ctx, people.DeepReadProposal{
+		OrganizationID: ids.From[ids.OrganizationKind](vague),
+		SourceURL:      "https://vague.example",
+		Facts:          employeeRangeFact("50-200 employees"),
+	}); err != nil {
+		t.Fatalf("ambiguous ApplyDeepRead: %v", err)
+	}
+	if got := readSizeBand(vague); got != nil {
+		t.Fatalf("an ambiguous range filled size_band = %q, want NULL", *got)
+	}
+	var factValue string
+	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		return tx.QueryRow(context.Background(),
+			`SELECT value FROM organization_fact
+			  WHERE organization_id = $1 AND field = 'employee_range'`, vague).Scan(&factValue)
+	}); err != nil {
+		t.Fatalf("reading the fact row: %v", err)
+	}
+	if factValue != "50-200 employees" {
+		t.Fatalf("fact row = %q, want the raw stated range kept as evidence", factValue)
+	}
+}
+
 func TestDeepReadRejectionLandsNothing(t *testing.T) {
 	e := integration.Setup(t)
 	org := insertOrg(t, e, e.Rep1, "acme.example", "")

--- a/backend/internal/compose/deepread_integration_test.go
+++ b/backend/internal/compose/deepread_integration_test.go
@@ -690,6 +690,33 @@ func TestAcceptedEmployeeRangeFactFillsSizeBandWhenUnambiguous(t *testing.T) {
 	if factValue != "50-200 employees" {
 		t.Fatalf("fact row = %q, want the raw stated range kept as evidence", factValue)
 	}
+
+	// A human-claimed employee_range fact blocks the whole promotion: the
+	// upsert refuses the agent's fact, so the column must not contradict the
+	// human's standing statement either.
+	claimed := insertOrg(t, e, e.Rep1, "claimed.example", "")
+	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		_, err := tx.Exec(context.Background(), `
+			INSERT INTO organization_fact
+			  (workspace_id, organization_id, category, field, value, value_key,
+			   evidence_snippet, source_url, confidence, source, captured_by)
+			VALUES ($1, $2, 'company', 'employee_range', '11-50', '',
+			        'set by hand', '', 1, 'human', $3)`,
+			e.WS, claimed, "human:"+e.Rep1.String())
+		return err
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.ApplyDeepRead(ctx, people.DeepReadProposal{
+		OrganizationID: ids.From[ids.OrganizationKind](claimed),
+		SourceURL:      "https://claimed.example",
+		Facts:          employeeRangeFact("about 300 people"),
+	}); err != nil {
+		t.Fatalf("ApplyDeepRead against a human-claimed fact: %v", err)
+	}
+	if got := readSizeBand(claimed); got != nil {
+		t.Fatalf("a refused fact still promoted size_band = %q, want NULL", *got)
+	}
 }
 
 func TestDeepReadRejectionLandsNothing(t *testing.T) {

--- a/backend/internal/modules/people/organizationfact.go
+++ b/backend/internal/modules/people/organizationfact.go
@@ -270,7 +270,7 @@ func (s *Store) ApplyDeepReadTx(ctx context.Context, tx pgx.Tx, in DeepReadPropo
 	// An accepted employee_range fact is also the size chip's answer when its
 	// phrasing maps cleanly onto the size_band enum — promoted here, inside
 	// the same accept, so the column change lands in this audit's images.
-	if err := fillSizeBandFromFacts(ctx, tx, in, by); err != nil {
+	if err := fillSizeBandFromFacts(ctx, tx, in, by, appliedFacts); err != nil {
 		return err
 	}
 	after, err := readColdStartColumnImages(ctx, tx, in.OrganizationID)

--- a/backend/internal/modules/people/organizationfact.go
+++ b/backend/internal/modules/people/organizationfact.go
@@ -267,6 +267,12 @@ func (s *Store) ApplyDeepReadTx(ctx context.Context, tx pgx.Tx, in DeepReadPropo
 	if err != nil {
 		return err
 	}
+	// An accepted employee_range fact is also the size chip's answer when its
+	// phrasing maps cleanly onto the size_band enum — promoted here, inside
+	// the same accept, so the column change lands in this audit's images.
+	if err := fillSizeBandFromFacts(ctx, tx, in, by); err != nil {
+		return err
+	}
 	after, err := readColdStartColumnImages(ctx, tx, in.OrganizationID)
 	if err != nil {
 		return err

--- a/backend/internal/modules/people/orgcolumnimages.go
+++ b/backend/internal/modules/people/orgcolumnimages.go
@@ -26,7 +26,7 @@ import (
 // audit row gives it nothing to diff.
 func readColdStartColumnImages(ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID) (map[string]any, error) {
 	var displayName string
-	var legalName, industry, addressLine1, description *string
+	var legalName, industry, addressLine1, description, sizeBand *string
 	// FOR UPDATE, and it is the audit that needs it: the before image and the
 	// apply that follows must describe ONE transaction's work. Read unlocked,
 	// a concurrent update landing between them lands inside this diff, and
@@ -37,9 +37,9 @@ func readColdStartColumnImages(ctx context.Context, tx pgx.Tx, orgID ids.Organiz
 	// the row lock second (see its own doc); a caller that reaches this row
 	// lock without it inverts the pair and deadlocks against a human rename.
 	if err := tx.QueryRow(ctx,
-		`SELECT display_name, legal_name, industry, address_line1, description
+		`SELECT display_name, legal_name, industry, address_line1, description, size_band
 		   FROM organization WHERE id = $1 FOR UPDATE`,
-		orgID).Scan(&displayName, &legalName, &industry, &addressLine1, &description); err != nil {
+		orgID).Scan(&displayName, &legalName, &industry, &addressLine1, &description, &sizeBand); err != nil {
 		return nil, fmt.Errorf("read organization column images: %w", err)
 	}
 	// Keyed by FIELD, not by column: field history projects per field, and
@@ -47,9 +47,12 @@ func readColdStartColumnImages(ctx context.Context, tx pgx.Tx, orgID ids.Organiz
 	// column name, the account's registered address showed up in history as a
 	// field the profile surface does not have.
 	out := map[string]any{fieldDisplayName: displayName}
+	// size_band has no profile-field twin: the column IS the surface, so its
+	// own name is the field-history key.
 	for column, value := range map[string]*string{
 		fieldLegalName: legalName, fieldIndustry: industry,
 		fieldRegisteredAddress: addressLine1, fieldOfferSummary: description,
+		"size_band": sizeBand,
 	} {
 		if value == nil {
 			// An empty column reads as an explicit null in the image, never as
@@ -73,6 +76,7 @@ func emptyColdStartColumnImages() map[string]any {
 		fieldIndustry:          nil,
 		fieldRegisteredAddress: nil,
 		fieldOfferSummary:      nil,
+		"size_band":            nil,
 	}
 }
 

--- a/backend/internal/modules/people/sizeband.go
+++ b/backend/internal/modules/people/sizeband.go
@@ -38,13 +38,21 @@ var sizeBands = []struct {
 }
 
 var (
-	// A magnitude word next to a digit ("10k", "2 thousand") means the
-	// digits alone are NOT the headcount — always a refusal, never a parse.
-	employeeRangeMagnitude = regexp.MustCompile(`(?i)\d\s*(k\b|thousand|tausend|million|mio\b)`)
-	employeeRangeNumber    = regexp.MustCompile(`\d[\d,.]*`)
-	// Thousands separators are the one punctuation a headcount may carry;
-	// "2.5" is a decimal, and a decimal headcount is nobody's clean answer.
-	thousandsShaped = regexp.MustCompile(`^\d{1,3}([,.]\d{3})*$|^\d+$`)
+	// A magnitude word next to a digit ("10k", "2 thousand", "2-million")
+	// means the digits alone are NOT the headcount — always a refusal,
+	// never a parse.
+	employeeRangeMagnitude = regexp.MustCompile(`(?i)\d\s*[-–.]?\s*(k|m|thousand|tausend|tsd|million|mio|mrd|billion)($|[^\p{L}])`)
+	// A comparison marker (">500", "over 500", "up to 50") states a bound,
+	// not a range this mapping can place in one band.
+	employeeRangeComparison = regexp.MustCompile(`(?i)[<>≤≥]|(^|[^\p{L}])(over|under|more than|less than|fewer than|at least|up to|mehr als|über|unter|weniger als|bis zu|mindestens|höchstens)([^\p{L}]|$)`)
+	// A company-register marker means the digits are an identifier, not a
+	// headcount ("HRB 9001").
+	employeeRangeRegister = regexp.MustCompile(`(?i)(^|[^\p{L}])(hrb|hra|vr|vat|ust)([^\p{L}\d]|\d|$)`)
+	employeeRangeNumber   = regexp.MustCompile(`\d[\d,.]*`)
+	// Thousands separators are the one punctuation a headcount may carry,
+	// and only one KIND of them per number; "2.5" is a decimal and
+	// "1,234.567" is mixed — neither is anybody's clean headcount.
+	thousandsShaped = regexp.MustCompile(`^\d{1,3}(,\d{3})*$|^\d{1,3}(\.\d{3})*$|^\d+$`)
 )
 
 // sizeBandFromEmployeeRange maps a stated headcount phrase onto the
@@ -57,7 +65,11 @@ func sizeBandFromEmployeeRange(text string) (string, bool) {
 			return band.label, true
 		}
 	}
-	if employeeRangeMagnitude.MatchString(trimmed) {
+	// A leading minus is a parse artifact ("-5"), not a headcount.
+	if strings.HasPrefix(trimmed, "-") ||
+		employeeRangeMagnitude.MatchString(trimmed) ||
+		employeeRangeComparison.MatchString(trimmed) ||
+		employeeRangeRegister.MatchString(trimmed) {
 		return "", false
 	}
 	numbers, ok := employeeRangeNumbers(trimmed)
@@ -118,7 +130,18 @@ func bandContaining(n int) (string, bool) {
 // import's) standing value is never overwritten, and only when the phrasing
 // maps cleanly. On abstention the fact row stays the evidence and the column
 // stays fillable by a later, cleaner read.
-func fillSizeBandFromFacts(ctx context.Context, tx pgx.Tx, in DeepReadProposal, by string) error {
+//
+// appliedFacts is upsertOrganizationFacts' report of what actually landed: a
+// proposal whose employee_range the human-precedence guard refused must not
+// promote either, or the column would contradict the standing human fact.
+func fillSizeBandFromFacts(ctx context.Context, tx pgx.Tx, in DeepReadProposal, by string, appliedFacts []map[string]any) error {
+	landed := false
+	for _, applied := range appliedFacts {
+		landed = landed || applied["field"] == FactEmployeeRange
+	}
+	if !landed {
+		return nil
+	}
 	for _, f := range in.Facts {
 		if f.Category != factCategoryCompany || f.Field != FactEmployeeRange {
 			continue

--- a/backend/internal/modules/people/sizeband.go
+++ b/backend/internal/modules/people/sizeband.go
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package people
+
+// The size_band column is a closed enum; employee_range is the page's own
+// phrasing ("25 to 50", "about 120 people", "51-200"). The mapping between
+// them REFUSES rather than guesses (PO-AC-N-7's spirit for a derived
+// canonical value): a phrase lands in a band only when every headcount it
+// could honestly mean falls inside that one band.
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
+)
+
+// sizeBands mirrors the organization.size_band CHECK (0005) in ascending
+// order; the top band is open-ended.
+var sizeBands = []struct {
+	label  string
+	lo, hi int
+}{
+	{"1-10", 1, 10},
+	{"11-50", 11, 50},
+	{"51-200", 51, 200},
+	{"201-500", 201, 500},
+	{"501-1000", 501, 1000},
+	{"1001-5000", 1001, 5000},
+	{"5000+", 5001, math.MaxInt},
+}
+
+var (
+	// A magnitude word next to a digit ("10k", "2 thousand") means the
+	// digits alone are NOT the headcount — always a refusal, never a parse.
+	employeeRangeMagnitude = regexp.MustCompile(`(?i)\d\s*(k\b|thousand|tausend|million|mio\b)`)
+	employeeRangeNumber    = regexp.MustCompile(`\d[\d,.]*`)
+	// Thousands separators are the one punctuation a headcount may carry;
+	// "2.5" is a decimal, and a decimal headcount is nobody's clean answer.
+	thousandsShaped = regexp.MustCompile(`^\d{1,3}([,.]\d{3})*$|^\d+$`)
+)
+
+// sizeBandFromEmployeeRange maps a stated headcount phrase onto the
+// size_band enum, reporting false whenever the phrasing does not land
+// cleanly in exactly one band.
+func sizeBandFromEmployeeRange(text string) (string, bool) {
+	trimmed := strings.TrimSpace(text)
+	for _, band := range sizeBands {
+		if trimmed == band.label {
+			return band.label, true
+		}
+	}
+	if employeeRangeMagnitude.MatchString(trimmed) {
+		return "", false
+	}
+	numbers, ok := employeeRangeNumbers(trimmed)
+	if !ok {
+		return "", false
+	}
+	// "200+" states a floor with no ceiling: only the open top band can
+	// contain all of it.
+	if strings.Contains(trimmed, "+") {
+		if len(numbers) == 1 && numbers[0] > 5000 {
+			return "5000+", true
+		}
+		return "", false
+	}
+	switch len(numbers) {
+	case 1:
+		return bandContaining(numbers[0])
+	case 2:
+		lowBand, okLow := bandContaining(numbers[0])
+		highBand, okHigh := bandContaining(numbers[1])
+		if okLow && okHigh && numbers[0] <= numbers[1] && lowBand == highBand {
+			return lowBand, true
+		}
+	}
+	return "", false
+}
+
+// employeeRangeNumbers extracts the headcounts a phrase states, refusing
+// any token whose punctuation is not thousands-shaped.
+func employeeRangeNumbers(text string) ([]int, bool) {
+	tokens := employeeRangeNumber.FindAllString(text, -1)
+	numbers := make([]int, 0, len(tokens))
+	for _, token := range tokens {
+		token = strings.TrimRight(token, ",.")
+		if !thousandsShaped.MatchString(token) {
+			return nil, false
+		}
+		n, err := strconv.Atoi(strings.NewReplacer(",", "", ".", "").Replace(token))
+		if err != nil {
+			return nil, false
+		}
+		numbers = append(numbers, n)
+	}
+	return numbers, len(numbers) > 0
+}
+
+func bandContaining(n int) (string, bool) {
+	for _, band := range sizeBands {
+		if n >= band.lo && n <= band.hi {
+			return band.label, true
+		}
+	}
+	return "", false
+}
+
+// fillSizeBandFromFacts promotes an accepted employee_range fact onto the
+// size_band column — only while the column is empty, so a human's (or an
+// import's) standing value is never overwritten, and only when the phrasing
+// maps cleanly. On abstention the fact row stays the evidence and the column
+// stays fillable by a later, cleaner read.
+func fillSizeBandFromFacts(ctx context.Context, tx pgx.Tx, in DeepReadProposal, by string) error {
+	for _, f := range in.Facts {
+		if f.Category != factCategoryCompany || f.Field != FactEmployeeRange {
+			continue
+		}
+		band, ok := sizeBandFromEmployeeRange(f.Value)
+		if !ok {
+			return nil
+		}
+		tag, err := tx.Exec(ctx,
+			`UPDATE organization SET size_band = $2 WHERE id = $1 AND size_band IS NULL`,
+			in.OrganizationID, band)
+		if err != nil {
+			return fmt.Errorf("fill size_band: %w", err)
+		}
+		if tag.RowsAffected() == 1 {
+			confidence := f.Confidence
+			stamp := storekit.FieldStamp{Field: "size_band", Confidence: &confidence}
+			if f.SourceURL != "" {
+				stamp.EvidenceRef = &f.SourceURL
+			}
+			if err := storekit.StampFields(ctx, tx, "organization", in.OrganizationID.UUID,
+				companySourceSiteRead, by, []storekit.FieldStamp{stamp}); err != nil {
+				return err
+			}
+		}
+		// employee_range is single-value: there is at most one such fact.
+		return nil
+	}
+	return nil
+}

--- a/backend/internal/modules/people/sizeband_test.go
+++ b/backend/internal/modules/people/sizeband_test.go
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package people
+
+import "testing"
+
+func TestSizeBandFromEmployeeRangeMapsOnlyUnambiguousPhrasings(t *testing.T) {
+	cases := []struct {
+		text string
+		band string
+		ok   bool
+	}{
+		// Enum-shaped values pass through as themselves.
+		{"51-200", "51-200", true},
+		{"5000+", "5000+", true},
+		// A stated range maps when both ends share one band.
+		{"25 to 50", "11-50", true},
+		{"11-50", "11-50", true},
+		{"60–180", "51-200", true},
+		// A single stated headcount maps to its containing band.
+		{"about 120 people", "51-200", true},
+		{"ca. 40 Mitarbeiter", "11-50", true},
+		{"7", "1-10", true},
+		{"1,200 employees", "1001-5000", true},
+		{"1.200 Mitarbeitende", "1001-5000", true},
+		// A floor with no ceiling fits only the open top band.
+		{"6000+", "5000+", true},
+		{"200+", "", false},
+		{"50+ employees", "", false},
+		// A range spanning two bands is nobody's clean answer.
+		{"50-200", "", false},
+		{"10 to 500", "", false},
+		// An inverted range is a parse artifact, not a statement.
+		{"200 to 50", "", false},
+		// Magnitude words mean the digits are not the headcount.
+		{"10k employees", "", false},
+		{"2 thousand", "", false},
+		{"about 1 million users", "", false},
+		// Decimals, zeros, and numberless prose all abstain.
+		{"2.5", "", false},
+		{"0 employees", "", false},
+		{"a growing team", "", false},
+		{"", "", false},
+		// Three numbers state no single range.
+		{"between 10, 50 and 200", "", false},
+	}
+	for _, c := range cases {
+		band, ok := sizeBandFromEmployeeRange(c.text)
+		if band != c.band || ok != c.ok {
+			t.Errorf("sizeBandFromEmployeeRange(%q) = (%q, %v), want (%q, %v)", c.text, band, ok, c.band, c.ok)
+		}
+	}
+}

--- a/backend/internal/modules/people/sizeband_test.go
+++ b/backend/internal/modules/people/sizeband_test.go
@@ -44,6 +44,28 @@ func TestSizeBandFromEmployeeRangeMapsOnlyUnambiguousPhrasings(t *testing.T) {
 		{"", "", false},
 		// Three numbers state no single range.
 		{"between 10, 50 and 200", "", false},
+		// A comparison states a bound, not a placeable range.
+		{">500 employees", "", false},
+		{"over 500", "", false},
+		{"up to 50", "", false},
+		{"mehr als 1000", "", false},
+		{"über 200 Mitarbeiter", "", false},
+		// Magnitude shorthand in any spelling refuses.
+		{"2m employees", "", false},
+		{"10-k", "", false},
+		{"2 Tsd. Mitarbeiter", "", false},
+		// Register identifiers and negatives are not headcounts.
+		{"HRB 9001", "", false},
+		{"-5 employees", "", false},
+		// Mixed separators are no unambiguous integer.
+		{"1,234.567", "", false},
+		// The band edges, both sides.
+		{"10", "1-10", true},
+		{"11", "11-50", true},
+		{"200", "51-200", true},
+		{"201", "201-500", true},
+		{"5000", "1001-5000", true},
+		{"5001", "5000+", true},
 	}
 	for _, c := range cases {
 		band, ok := sizeBandFromEmployeeRange(c.text)


### PR DESCRIPTION
The remaining half of #847. The site read already extracts `employee_range` ("25 to 50", "about 120 people", "51-200") into `organization_fact`, but nothing promoted it to the `size_band` column the header chip renders — 0 of 220 dev-book companies had a value.

The accepted deep read now maps the fact onto the closed enum and fills the column, with the same rules as the description fill from #869: only while the column is empty (a human's or an import's standing value is never overwritten), inside the same accept transaction so the change lands in the audit images, and with field provenance stamped.

The mapping refuses rather than guesses, per the issue's constraint: exact enum spellings, single stated headcounts, and ranges that fit inside one band map; ranges spanning two bands ("50-200"), floors ("200+"), magnitude words ("10k", "2 thousand"), decimals and zero all abstain — the fact row stays the evidence and the column stays fillable by a later cleaner read. Governance unchanged: the write happens on a human-accepted staged proposal (PO-AC-N-7).

Covered by a table-driven unit test of the mapper (24 phrasings) and `TestAcceptedEmployeeRangeFactFillsSizeBandWhenUnambiguous` (fills, never overwrites, abstains while keeping the evidence).

Closes #847.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accepted `employee_range` facts now auto-fill the size chip by mapping to the `size_band` enum when the phrasing is unambiguous, and only if the fact actually landed. Completes #847 by promoting clean ranges into a displayable size without manual input.

- **New Features**
  - Maps only exact enum labels, single headcounts, or ranges within one band; floors map only to the open band (e.g., "6000+" -> `5000+`).
  - Fill-once: writes only when `size_band` is NULL; runs in the accept transaction, stamps provenance, and includes `size_band` in audit images.
  - Added unit and integration tests.

- **Bug Fixes**
  - Honors the human-precedence guard and tightens parsing: promotes only landed facts and now rejects comparison bounds (>500, over, up to), register IDs (e.g., "HRB 9001"), leading minus, and mixed thousands separators.

<sup>Written for commit d679671e5e783feb014382dadec22e3fda70fbcf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/875?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Organization size bands can now be automatically populated from accepted employee-range information when the range maps clearly to a supported band.
  * Source information and field history are preserved for traceability.

* **Bug Fixes**
  * Existing size-band values are no longer overwritten.
  * Ambiguous, invalid, or unsupported employee ranges remain unset instead of producing potentially incorrect classifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->