### PR TITLE
ci: the license gate becomes a gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,7 @@ jobs:
       frontend: ${{ steps.filter.outputs.frontend }}
       e2e: ${{ steps.filter.outputs.e2e }}
       docker: ${{ steps.filter.outputs.docker }}
+      deps: ${{ steps.filter.outputs.deps }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -116,6 +117,29 @@ jobs:
             docker:
               - 'Dockerfile.*'
               - '.dockerignore'
+            # Everything that can change WHICH packages are in the tree, and
+            # therefore which licenses the gate below judges. `**/pnpm-lock.yaml`
+            # is globbed on purpose: the only lockfile is frontend/pnpm-lock.yaml,
+            # so a bare `pnpm-lock.yaml` matches nothing — and a Renovate
+            # lockfile-only PR, which is precisely where new transitive packages
+            # (and their licenses) enter, would slip past unscanned.
+            deps:
+              - 'go.work'
+              - 'go.work.sum'
+              - '**/go.mod'
+              - '**/go.sum'
+              - '**/package.json'
+              - '**/pnpm-lock.yaml'
+              - '.syft.yaml'
+              - '.grant.yaml'
+              - 'sbom-schemas/**'
+              - 'Makefile'
+              - '.github/workflows/ci.yml'
+              # A composite action is cataloged as a package by the SBOM scan, so
+              # adding one changes what the license gate judges. Omitting this is
+              # how .github/actions/go-build-cache reached main unscanned and left
+              # the gate latently red for the next dependency PR.
+              - '.github/actions/**'
 
   # Every commit in a PR carries a Developer Certificate of Origin sign-off.
   # PR-only: the direct-to-main workflow signs off at push time, and history
@@ -681,6 +705,49 @@ jobs:
         with:
           flavor: plain
       - run: make vuln
+
+  # The dependency-license gate, and the reason it lives HERE rather than in
+  # sbom.yml: it is a GATE, and sbom.yml is an artifact producer. sbom.yml filters
+  # at the WORKFLOW level, so on a PR touching no dependency it produces no check
+  # run at all — and a required context that never posts blocks the merge forever
+  # (the same trap the sonarcloud job below is written to avoid). Gated at the JOB
+  # level like every other lane here, a path skip reports as passing instead.
+  #
+  # PR-only on purpose. On main the identical gate runs inside sbom.yml, where it
+  # is the precondition for signing: a keyless signature lands permanently in a
+  # public transparency log and cannot be retracted, so a policy-failing SBOM must
+  # never reach the sign job. Splitting the two events runs the gate exactly once
+  # per path rather than twice on main.
+  #
+  # `make sbom` first because sbom-check reads the generated document — the gate
+  # judges the resolved dependency graph, not the manifests.
+  license-gate:
+    name: license gate
+    needs: [changes]
+    if: >-
+      github.event_name == 'pull_request'
+      && needs.changes.outputs.deps == 'true'
+      && github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    defaults:
+      run:
+        working-directory: .
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          # SBOM_VERSION is the release tag when HEAD sits exactly on one
+          # (`git describe --tags --exact-match`), else the full revision —
+          # resolving that needs the tags and history.
+          fetch-depth: 0
+      # syft and grant run through digest-pinned Docker images (see the Makefile),
+      # so the runner needs only Docker — pre-installed on ubuntu-latest.
+      - name: Generate the SBOMs
+        run: make sbom
+      - name: License gate
+        run: make sbom-check
 
   # CI-based SonarCloud scan. Unlike Automatic Analysis, the scanner reads the
   # committed sonar-project.properties (exclusions + rule tuning + coverage

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -4,28 +4,38 @@ name: SBOM
 # SBOM pipeline itself (Makefile targets, syft/grant policy, this workflow)
 # changes. syft/grant/cosign run through digest-pinned Docker images (see the
 # Makefile), so the runner needs only Docker — pre-installed on ubuntu-latest.
+# main only. The PR-side license gate moved to ci.yml's `license gate` job, which
+# is gated at the JOB level and so reports a path skip as passing — a required
+# context has to post on every ready PR, and a workflow-level `paths:` filter
+# produces no check run at all when it does not match. What stays here is the
+# artifact work nobody waits on: generation, the gate that guards signing, and
+# signing itself.
+#
+# `**/pnpm-lock.yaml`, not `pnpm-lock.yaml`: the only lockfile in the tree is
+# frontend/pnpm-lock.yaml, so the unglobbed pattern matched nothing and a
+# lockfile-only dependency change — the shape Renovate raises most often, and
+# exactly where new transitive packages and their licenses arrive — never
+# triggered this workflow at all.
 on:
   workflow_dispatch:
-  # Anchored once, reused by both events (YAML alias — DRY).
-  pull_request:
-    # Match ci.yml: ready_for_review joins the defaults so leaving draft triggers
-    # a run, and the job's draft guard skips work while the PR is still a draft.
-    types: [opened, synchronize, reopened, ready_for_review]
-    paths: &dep-paths
+  push:
+    branches: [main]
+    paths:
       - "go.work"
       - "go.work.sum"
       - "**/go.mod"
       - "**/go.sum"
-      - "pnpm-lock.yaml"
+      - "**/pnpm-lock.yaml"
       - "**/package.json"
       - "Makefile"
       - ".syft.yaml"
       - ".grant.yaml"
       - "sbom-schemas/**"
       - ".github/workflows/sbom.yml"
-  push:
-    branches: [main]
-    paths: *dep-paths
+      # Composite actions are cataloged as packages by the scan, so adding one
+      # changes what the license gate judges — and main must be re-scanned when it
+      # does. Its absence is why .github/actions/go-build-cache landed unscanned.
+      - ".github/actions/**"
 
 # contents: read is the floor for every job. The OIDC minting credential
 # (id-token: write) is NOT granted here — only the isolated sign job requests it,
@@ -37,8 +47,6 @@ jobs:
   sbom:
     name: sbom
     runs-on: ubuntu-latest
-    # A draft PR iterating on dependency bumps has no SBOM consumer — skip it.
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -49,6 +57,10 @@ jobs:
           fetch-depth: 0
       - name: Generate SBOMs
         run: make sbom
+      # Kept on this path even though ci.yml gates every PR: it is the
+      # precondition for the sign job below (`needs: sbom`). A keyless signature
+      # lands permanently in a public transparency log and cannot be retracted,
+      # so a policy-failing SBOM must never reach it.
       - name: License gate
         run: make sbom-check
       - name: Publish SBOMs
@@ -57,8 +69,7 @@ jobs:
           name: sboms
           path: sboms/
           if-no-files-found: error
-          # PR artifacts are superseded by the next push; only main's linger.
-          retention-days: ${{ github.event_name == 'pull_request' && 14 || 90 }}
+          retention-days: 90
 
   # Keyless signing is isolated from generation so PR-controlled build code never
   # runs while id-token: write is in scope. Only main's SBOMs are signed: keyless

--- a/.grant.yaml
+++ b/.grant.yaml
@@ -46,6 +46,13 @@ ignore-packages:
   - github.com/gradionhq/margince/* # our own Go modules
   - example.margince.dev/* # committed extension stubs (ADR-0069), first-party
   - SonarSource/sonarqube-scan-action # LGPL-3.0-only CI scanner action, runs in CI only, never shipped
+  # Local composite actions under .github/actions/ — first-party files carrying
+  # the repo's own BUSL-1.1, not a third-party dependency. They cannot be handled
+  # the way the pinned third-party actions are: syft assigns a local action NO
+  # purl at all, and `make sbom-supplement` keys its map on purl, so the map
+  # cannot reach them. Globbed so a future composite action is covered on the day
+  # it is added rather than the day it turns the gate red.
+  - ./.github/actions/* # first-party composite actions (BUSL-1.1, same as the repo)
 
 require-license: true # When true, deny packages with no detected licenses
 require-known-license: true

--- a/docs/reference/supply-chain.md
+++ b/docs/reference/supply-chain.md
@@ -56,9 +56,14 @@ Scan policy lives in [`.syft.yaml`](../../.syft.yaml); the Makefile owns the
   `frontend/src/**`, migrations, config templates) with no checksum at all.
   SHA-1 is kept because SPDX file entries historically key on it; SHA-256 and
   SHA-512 are what a consumer actually verifies.
-- Excluded committed trees — agent/CI/build-tooling/test state, not shipped
-  product: `./.claude/**`, `./.github/**`, `./.githooks/**`, `./.pnpm-store/**`,
-  `./scratchpad/**`, `./cli/craft/**`, `./fixtures/**`.
+- **No `exclude:` list**, on purpose. The constellation dist release gate rejects
+  a release unless the SBOM attests every file the release patch adds or
+  modifies, and that patch is a full committed-tree diff with no excludes — so
+  the SBOM file set must equal the whole committed tree. Excluding any committed
+  tree here (CI workflows, `cli/craft`, `fixtures`, `sbom-schemas`, …) would make
+  a commit touching it fail that gate. Uncommitted host state is already absent
+  because the scan runs on `git archive HEAD`, so there is nothing left to
+  exclude.
 
 ## Versioning
 
@@ -140,9 +145,13 @@ Two categories never reach the allowlist check:
   `github.com/gradionhq/margince/*` (our own Go modules) and
   `example.margince.dev/*` (the committed extension stubs, ADR-0069). They carry
   no third-party license to gate.
-- **CI Actions** are excluded from the **scan** entirely — `.syft.yaml` drops
-  `./.github/**` — so syft never catalogs them as packages and grant never sees
-  them. They are build infrastructure, not shipped product.
+- **Local composite actions** under `.github/actions/` are ignored by coordinate
+  too (`./.github/actions/*`). They are first-party files carrying the repo's own
+  BUSL-1.1, and they cannot be handled the way the pinned third-party actions
+  are: syft assigns a local action **no purl at all**, while
+  `make sbom-supplement` keys its map on purl, so the map cannot reach them. The
+  entry is globbed so the next composite action is covered on the day it is added
+  rather than the day it turns the gate red.
 
 Everything else must still resolve to a known, allowed license.
 
@@ -223,8 +232,10 @@ nor a writable home. So the invocation adds `-u $(id -u):$(id -g)` and
 
 ## CI — `.github/workflows/sbom.yml`
 
-Regenerates the SBOM on **`main`** whenever a dependency set or the pipeline
-itself changes. The runner needs only Docker, which `ubuntu-latest` pre-installs.
+Regenerates the SBOM when a dependency set or the pipeline itself changes. There
+is no `pull_request` trigger, so the automatic path is **`main`** — a manual
+dispatch still runs the `sbom` job on any ref, and only `sign` is guarded to
+`main`. The runner needs only Docker, which `ubuntu-latest` pre-installs.
 
 | Trigger | Condition |
 |---|---|
@@ -233,7 +244,7 @@ itself changes. The runner needs only Docker, which `ubuntu-latest` pre-installs
 
 Path filter: `go.work`, `go.work.sum`, `**/go.mod`, `**/go.sum`,
 `**/pnpm-lock.yaml`, `**/package.json`, `Makefile`, `.syft.yaml`, `.grant.yaml`,
-`sbom-schemas/**`, `.github/workflows/sbom.yml`.
+`sbom-schemas/**`, `.github/workflows/sbom.yml`, `.github/actions/**`.
 
 `**/pnpm-lock.yaml` is globbed deliberately. The only lockfile in the tree is
 `frontend/pnpm-lock.yaml`, so the unglobbed `pnpm-lock.yaml` matched nothing —

--- a/docs/reference/supply-chain.md
+++ b/docs/reference/supply-chain.md
@@ -223,30 +223,41 @@ nor a writable home. So the invocation adds `-u $(id -u):$(id -g)` and
 
 ## CI — `.github/workflows/sbom.yml`
 
-Regenerates the SBOM whenever a dependency set or the pipeline itself changes.
-The runner needs only Docker, which `ubuntu-latest` pre-installs.
+Regenerates the SBOM on **`main`** whenever a dependency set or the pipeline
+itself changes. The runner needs only Docker, which `ubuntu-latest` pre-installs.
 
 | Trigger | Condition |
 |---|---|
 | `workflow_dispatch` | manual, any ref (but see the `sign` job's own guard) |
-| `pull_request` | types `opened`, `synchronize`, `reopened`, `ready_for_review`, filtered to the paths below |
-| `push` | branch `main`, the same paths (anchored once as a YAML alias, reused by both events) |
+| `push` | branch `main`, filtered to the paths below |
 
 Path filter: `go.work`, `go.work.sum`, `**/go.mod`, `**/go.sum`,
-`pnpm-lock.yaml`, `**/package.json`, `Makefile`, `.syft.yaml`, `.grant.yaml`,
-`.github/workflows/sbom.yml`.
+`**/pnpm-lock.yaml`, `**/package.json`, `Makefile`, `.syft.yaml`, `.grant.yaml`,
+`sbom-schemas/**`, `.github/workflows/sbom.yml`.
+
+`**/pnpm-lock.yaml` is globbed deliberately. The only lockfile in the tree is
+`frontend/pnpm-lock.yaml`, so the unglobbed `pnpm-lock.yaml` matched nothing —
+and a lockfile-only dependency change, the shape Renovate raises most often and
+precisely where new transitive packages and their licenses arrive, never
+triggered this workflow at all.
+
+**There is no `pull_request` trigger.** The PR-side license gate is the
+`license gate` job in `ci.yml`, gated at the job level on the `deps` scope. A
+workflow-level `paths:` filter produces no check run when it does not match, and
+a required context that never posts blocks a merge forever — so a gate that must
+be required cannot live behind one. Splitting the two paths also means the policy
+runs exactly once per event rather than twice on `main`. See
+[infra/ci-pipeline.md](../../infra/ci-pipeline.md).
 
 Workflow-level `permissions: contents: read` is the floor for every job. The
 OIDC minting credential is **not** granted there — only the `sign` job requests
-it, so PR-controlled generation code can never mint a signing token.
+it, so branch-controlled generation code can never mint a signing token.
 
-**Job `sbom`** — skipped while a pull request is still a draft (a draft
-iterating on dependency bumps has no SBOM consumer). Checks out with
-`persist-credentials: false` and `fetch-depth: 0` (resolving an exact tag needs
-tags and history), then runs `make sbom`, then `make sbom-check`. Publishes the
-`sboms` artifact from `sboms/` with `if-no-files-found: error` and retention of
-**14 days on a pull request, 90 otherwise** — PR artifacts are superseded by the
-next push, only main's linger.
+**Job `sbom`** — checks out with `persist-credentials: false` and
+`fetch-depth: 0` (resolving an exact tag needs tags and history), then runs
+`make sbom`, then `make sbom-check`. The license gate stays on this path because
+it is the precondition for `sign` below. Publishes the `sboms` artifact from
+`sboms/` with `if-no-files-found: error` and 90-day retention.
 
 **Job `sign`** — `needs: sbom`, and gated to `push` (which the trigger already
 restricts to `main`) or a `workflow_dispatch` on `refs/heads/main`. It adds
@@ -254,16 +265,17 @@ restricts to `main`) or a `workflow_dispatch` on `refs/heads/main`. It adds
 than regenerating it, runs `make sbom-sign`, and publishes `sboms/*.cosign.bundle`
 as the `sbom-signatures` artifact (retention 90 days).
 
-Two reasons it is a separate job and **never runs on a pull request**:
+Two reasons it is a separate job and **never runs off `main`**:
 
 1. **A keyless signature is permanent.** It lands in the public Rekor
-   transparency log and cannot be retracted. A PR preview, or a dispatch from a
-   feature branch, must never produce one.
-2. **Isolation from PR-controlled code.** Generation runs whatever the branch's
-   `Makefile` and `.syft.yaml` say; keeping that out of any job holding
-   `id-token: write` is what stops a pull request from reaching the signing
-   identity. `needs: sbom` also means the license gate has already passed, so a
-   policy-failing SBOM never reaches signing.
+   transparency log and cannot be retracted. A dispatch from a feature branch
+   must never produce one.
+2. **Isolation from branch-controlled code.** Generation runs whatever the
+   branch's `Makefile` and `.syft.yaml` say; keeping that out of any job holding
+   `id-token: write` is what stops branch-controlled code from reaching the
+   signing identity. `needs: sbom` also means the license gate has already
+   passed, so a policy-failing SBOM never reaches signing — which is why that
+   gate stays in this workflow even though `ci.yml` already gates every PR.
 
 ## Targets
 

--- a/infra/ci-pipeline.md
+++ b/infra/ci-pipeline.md
@@ -35,6 +35,7 @@ output. A required job skipped this way still counts as passing.
 | `frontend` | `frontend/**`, `backend/api/**` (the contract drives FE types) | frontend lane, UAT |
 | `e2e` | `backend/**`, `frontend/**`, `infra/**/!(*.md)`, `extensions/**`, `fixtures/**`, `composition/**` | full-stack live-boot |
 | `docker` | root `Dockerfile.*`, `.dockerignore` | the three image builds |
+| `deps` | `go.work[.sum]`, `**/go.mod`, `**/go.sum`, `**/package.json`, `**/pnpm-lock.yaml`, `.syft.yaml`, `.grant.yaml`, `sbom-schemas/**`, `Makefile`, `.github/workflows/ci.yml` | the license gate |
 
 Consequences:
 
@@ -74,6 +75,7 @@ changes ──┬─> deterministic-gates ──> craftsmanship
           ├─> integration-unit-coverage ────┘                          │
           ├─> extension-reference ──────────────────────────────────┐  │
           ├─> vuln                                                  │  │
+          ├─> license gate  (PR-only, `deps` scope)                 │  │
           ├─> frontend ──> uat                                      │  │
           ├─> live-boot                                             │  │
           ├─> docker-image (×3: api, web, worker) ─> docker-images  │  │
@@ -159,6 +161,7 @@ third-party actions it calls, which would otherwise ride in unread.
 | `integration unit coverage` | The unit `-cover` pass over every package, binary coverage pods only. Needed because the shards run just the integration-tagged packages, and without it SonarCloud would see the unit-only packages at a false ~0% new-code coverage. No services (the test-lanes gate guarantees untagged tests open no real DB) |
 | `integration` | The fan-in — and the required check, under the same name the single-runner lane carried, so branch protection is unchanged. Asserts every shard + the unit pass succeeded (a failed shard must turn this check red, not skipped), then `scripts/test-integration-reconcile.sh` proves the slices add up: every shard present, identical discovery, union complete + disjoint. Merges all coverage pods into `coverage.out`, uploads `go-coverage` |
 | `vuln` | `make vuln` (govulncheck over all packages) |
+| `license gate` | `make sbom` then `make sbom-check` — the dependency-license policy (`grant`, policy in `.grant.yaml`) over the resolved dependency graph, not the manifests. Lives here rather than in `sbom.yml` because it is a **gate** and that workflow is an artifact producer: `sbom.yml` filters at the workflow level, so on a PR touching no dependency it produces no check run at all, and a required context that never posts blocks the merge forever. Job-level gating makes a path skip report as passing instead. PR-only — on `main` the same gate runs inside `sbom.yml`, where it is the precondition for signing, so each path runs it exactly once |
 | `frontend` | `make frontend-check` (biome + vitest + tsc + Vite build) + a Storybook catalog build (stories must compile & register). Emits `fe-coverage` (lcov) |
 | `uat` | `make frontend-e2e`: the AC-`<screen>`-N screen-acceptance criteria as named Playwright tests + axe WCAG 2.2 AA + the 390px no-horizontal-scroll sweep + the PERF-1 record-open budget. Mocks the API at the network edge, so it is self-contained |
 | `live-boot` | The README quickstart run literally: compose up → migrate → api → `seed-dev` → `verify-boot`. Keeps the API-driven seed and the boot proof honest — the integration shards never boot the api or run the seed script, so those would rot invisibly without this job |
@@ -210,12 +213,15 @@ Wiring details:
 
 `ci.yml` is the merge gate. Two workflows sit beside it, deliberately outside it:
 
-- **`sbom.yml`** — regenerates and license-gates the source-tree SBOMs whenever a
-  dependency set or the SBOM pipeline itself changes, and signs `main`'s from a
-  separate job that is the sole holder of `id-token: write`. Signing is isolated
-  from all PR-controlled code because a keyless signature lands permanently in a
-  public transparency log and cannot be retracted, so a PR preview must never
-  produce one. Not a required check; the mechanics are in
+- **`sbom.yml`** — **`main` only.** Regenerates the source-tree SBOMs whenever a
+  dependency set or the SBOM pipeline itself changes, license-gates them, and signs
+  them from a separate job that is the sole holder of `id-token: write`. Signing is
+  isolated from all PR-controlled code because a keyless signature lands permanently
+  in a public transparency log and cannot be retracted, so a PR preview must never
+  produce one — and the license gate stays on this path because `sign`'s `needs:
+  sbom` is what keeps a policy-failing SBOM from reaching it. The PR-side gate is
+  the `license gate` job in `ci.yml` (above), so each event path runs the policy
+  exactly once. Not itself a required check; the mechanics are in
   [docs/reference/supply-chain.md](../docs/reference/supply-chain.md).
 - **`patch.yml`** — on every push to `main`, runs the release-management CLI over
   the push's range and uploads the incremental patch as a short-retention

--- a/infra/ci-pipeline.md
+++ b/infra/ci-pipeline.md
@@ -35,7 +35,7 @@ output. A required job skipped this way still counts as passing.
 | `frontend` | `frontend/**`, `backend/api/**` (the contract drives FE types) | frontend lane, UAT |
 | `e2e` | `backend/**`, `frontend/**`, `infra/**/!(*.md)`, `extensions/**`, `fixtures/**`, `composition/**` | full-stack live-boot |
 | `docker` | root `Dockerfile.*`, `.dockerignore` | the three image builds |
-| `deps` | `go.work[.sum]`, `**/go.mod`, `**/go.sum`, `**/package.json`, `**/pnpm-lock.yaml`, `.syft.yaml`, `.grant.yaml`, `sbom-schemas/**`, `Makefile`, `.github/workflows/ci.yml` | the license gate |
+| `deps` | `go.work[.sum]`, `**/go.mod`, `**/go.sum`, `**/package.json`, `**/pnpm-lock.yaml`, `.syft.yaml`, `.grant.yaml`, `sbom-schemas/**`, `Makefile`, `.github/workflows/ci.yml`, `.github/actions/**` | the license gate |
 
 Consequences:
 
@@ -213,7 +213,9 @@ Wiring details:
 
 `ci.yml` is the merge gate. Two workflows sit beside it, deliberately outside it:
 
-- **`sbom.yml`** — **`main` only.** Regenerates the source-tree SBOMs whenever a
+- **`sbom.yml`** — **no `pull_request` trigger**, so its automatic path is `main`
+  (a manual dispatch still runs the `sbom` job on any ref; only `sign` is guarded
+  to `main`). Regenerates the source-tree SBOMs whenever a
   dependency set or the SBOM pipeline itself changes, license-gates them, and signs
   them from a separate job that is the sole holder of `id-token: write`. Signing is
   isolated from all PR-controlled code because a keyless signature lands permanently


### PR DESCRIPTION
## Why

The dependency-license policy catches real denials — a human branch went red at 04:32 and green at 04:40 yesterday — but it **cannot block a merge**. `sbom` is not a required context, and Renovate merges with `platformAutomerge: true`, which waits only on required checks. A dependency PR whose sole failure is a denied license auto-merges into a BUSL-1.1 product.

Making `sbom` required as it stood was not an option: it filters at the **workflow** level, so a PR touching no dependency produces **no check run at all**, and a required context that never posts blocks every such merge forever. (Same trap the `sonarcloud` job is already commented to avoid.)

## What

Split the gate from the artifact production it was bundled with:

| Path | Runs the policy |
|---|---|
| Pull requests | `ci.yml`'s new **`license gate`** job, gated at the job level on a new `deps` scope → a path skip reports as passing, so it can safely be required |
| `main` | `sbom.yml`, where the gate is the precondition for signing |

`sign` needs `sbom` precisely so a policy-failing SBOM never reaches a keyless signature — those land permanently in a public transparency log and cannot be retracted. The new job is `pull_request`-only, so each event path runs the policy **exactly once** rather than twice on `main`.

`sbom.yml` becomes `main` + `workflow_dispatch` only. Its draft guard and conditional artifact retention were PR-only logic and are gone.

## Two defects found while wiring it

Both had already let changes through unscanned.

**1. `pnpm-lock.yaml` matched nothing.** The tree's only lockfile is `frontend/pnpm-lock.yaml`, so the unglobbed pattern never fired. A lockfile-only dependency change — the shape Renovate raises most often, and exactly where new transitive packages and their licenses arrive — did not trigger the scan at all. #518, whose entire purpose was patching vulnerable transitive packages, **was never license-scanned**. Now `**/pnpm-lock.yaml` in both workflows.

**2. The composite action from #860 sits on `main` denied but unreported.** syft catalogs a local action as a package with **no purl**, so `make sbom-supplement` — which keys its map on purl — structurally cannot reach it, and `require-license: true` denies it. Nothing announced this because `.github/actions/**` was in no path filter.

Verified against `main`'s own policy: **exactly one denial, that one.** Nothing else has accumulated.

The fix is at the invariant, not the call site: `.grant.yaml` ignores first-party composite actions **by glob**, and both path filters now carry `.github/actions/**` — so the next composite action is scanned the day it is added rather than the day it turns the gate red.

## Verification

- `make check-backend` — green
- `make sbom` + `make sbom-check` — green, exit 0, `509 allowed, 4 ignored`, no denials (confirmed without pipe masking)
- Against `main`'s policy — `1 denied` (the #860 action), confirming this PR clears the only one present
- `make check-image-pins` — green
- Both workflows parse; `license gate` job and `deps` output confirmed wired

This PR exercises the new job on itself — the diff touches `ci.yml` and `.github/actions/**`, both in the `deps` scope.

## ⚠️ Ordering

**Do not add `license gate` to required contexts until this has merged and posted at least once.** A required context for a job that does not exist blocks every PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split the dependency-license policy into a PR-only license gate in `ci.yml` that can be required to block merges. Kept SBOM generation and signing on `main` in `sbom.yml`, with the gate as the signing precondition.

- **New Features**
  - Added `deps` scope and PR-only `license gate` job in `ci.yml` (runs `make sbom` then `make sbom-check`); job-level gating makes path skips pass and can be required.
  - `sbom.yml` is `main` + `workflow_dispatch` only; artifacts retained 90 days; the gate remains here to guard signing.
  - Expanded path filters to include `sbom-schemas/**`, `.github/workflows/ci.yml`, and `.github/actions/**`; docs corrected to match (no `.syft.yaml` `exclude:` list, PR gate lives in `ci.yml`, `sbom.yml` has no PR trigger).

- **Bug Fixes**
  - Globbing `**/pnpm-lock.yaml` ensures lockfile-only PRs are scanned.
  - `.grant.yaml` now ignores first‑party composite actions under `.github/actions/**`; both workflows watch that path so new composites are scanned when added.

<sup>Written for commit 4677b5535d0882a13503698e0240037194e8e0ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/877?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated dependency and license checks for pull requests involving dependency or supply-chain changes.
  * Added dependency-change detection to CI workflows.
  * Added SBOM generation and signing safeguards for main-branch updates.

* **Documentation**
  * Updated supply-chain and CI documentation to describe trigger conditions, license checks, artifact retention, and signing controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->