### PR TITLE
fix(migrations): the repair coverage reads the verb-grant shape

### DIFF
--- a/backend/migrations/rbacrepair_test.go
+++ b/backend/migrations/rbacrepair_test.go
@@ -50,6 +50,19 @@ var guardedBackfillPattern = regexp.MustCompile(
 		`WHERE \(is_system AND key (?:IN \(([^)]*)\)|= ('\w+'))\s*` +
 		`AND NOT permissions->'objects' \? '(\w+)'\)`)
 
+// The second legitimate shape: grant ONE verb on an object entry the role
+// ALREADY has, guarded on the object's presence. The pattern above cannot
+// express it and must not be stretched to — it seeds `{objects,<object>}` whole
+// and guards on that object's ABSENCE, so forcing this write into it would
+// either overwrite the verbs already there or, with the absence guard, match
+// nothing at all. Two shapes, because there are two operations.
+var guardedVerbGrantPattern = regexp.MustCompile(
+	`UPDATE role SET permissions = jsonb_set\(\s*` +
+		`permissions,\s*'\{objects,(\w+),(\w+)\}',\s*` +
+		`'([^']*)'::jsonb\)\s*` +
+		`WHERE is_system AND key (?:IN \(([^)]*)\)|= ('\w+'))\s*` +
+		`AND permissions->'objects' \? '(\w+)'`)
+
 // Every write to role.permissions, however it is spelled. This has to be
 // STRICTLY BROADER than guardedBackfillPattern, not a prefix of it: a canary
 // sharing the pattern's literal head would miss exactly the deviations that
@@ -96,6 +109,7 @@ func TestTheRepairsCoverEveryGuardedRBACBackfill(t *testing.T) {
 			}
 
 			assertNoUnnamedRepairAboveTheCeiling(t, namespace, newestRepair, backfills)
+			assertNoVerbGrantBelowTheCeiling(t, namespace, newestRepair)
 		})
 	}
 }
@@ -128,6 +142,35 @@ func assertNoUnnamedRepairAboveTheCeiling(
 					namespace.Name, migration.Version, migration.Name, grant.role, above[grant],
 					grant.object, ceiling)
 			}
+		}
+	}
+}
+
+// assertNoVerbGrantBelowTheCeiling refuses to be silently blind about the one
+// write shape the coverage derivation does not model.
+//
+// A verb grant reaches into an object entry the role already has, so the
+// (object, role) key the comparison speaks in cannot hold it: two migrations
+// granting different verbs on one object would collide on a single key and one
+// would replace the other, unnoticed. Above the ceiling that costs nothing — a
+// migration up there never shipped unbound and needs no repair, which is why the
+// verb grant that exists today is fine where it sits. At or below the ceiling the
+// comparison would quietly skip a backfill, the exact outcome this file exists to
+// prevent, so it fails instead and whoever writes that migration extends the
+// derivation on purpose rather than by accident.
+func assertNoVerbGrantBelowTheCeiling(t *testing.T, namespace dbmigrate.Namespace, ceiling string) {
+	t.Helper()
+	for _, migration := range namespace.Migrations {
+		if migration.Version > ceiling {
+			continue
+		}
+		for _, match := range guardedVerbGrantPattern.FindAllStringSubmatch(migration.UpSQL, -1) {
+			t.Errorf("%s: %s_%s grants %q the %s verb on %s, and it sits at or below %s where a repair "+
+				"must re-apply it. The coverage comparison keys on (object, role) and cannot carry a "+
+				"verb, so it would pass over this write instead of demanding the repair. Teach the "+
+				"derivation the verb dimension before landing a verb grant this low.",
+				namespace.Name, migration.Version, migration.Name, match[4]+match[5], match[2],
+				match[1], ceiling)
 		}
 	}
 }
@@ -172,15 +215,27 @@ func backfillGrants(t *testing.T, namespace dbmigrate.Namespace, ceiling string)
 }
 
 // collectGrants adds one migration's guarded backfill blocks to grants, and
-// fails if the migration writes role permissions in a shape the pattern misses.
+// fails if the migration writes role permissions in a shape neither pattern
+// reads. Verb grants are reconciled here but NOT collected: they carry a verb the
+// (object, role) key cannot hold, and assertNoVerbGrantBelowTheCeiling is what
+// keeps that omission from ever reaching the coverage comparison.
 func collectGrants(t *testing.T, migration dbmigrate.Migration, grants map[rbacGrant]string) {
 	t.Helper()
 	matches := guardedBackfillPattern.FindAllStringSubmatch(migration.UpSQL, -1)
-	if written := len(anyRolePermissionWrite.FindAllString(migration.UpSQL, -1)); written != len(matches) {
-		t.Fatalf("%s_%s writes role permissions %d times but only %d are in the guarded shape this test "+
+	verbGrants := guardedVerbGrantPattern.FindAllStringSubmatch(migration.UpSQL, -1)
+	read := len(matches) + len(verbGrants)
+	if written := len(anyRolePermissionWrite.FindAllString(migration.UpSQL, -1)); written != read {
+		t.Fatalf("%s_%s writes role permissions %d times but only %d are in a guarded shape this test "+
 			"reads. The unread ones are invisible to the coverage check above, which would then report "+
 			"a repair complete while a backfill it cannot see goes unrepaired.",
-			migration.Version, migration.Name, written, len(matches))
+			migration.Version, migration.Name, written, read)
+	}
+	for _, match := range verbGrants {
+		if object, guardedObject := match[1], match[6]; object != guardedObject {
+			t.Fatalf("%s_%s sets '{objects,%s,%s}' but guards on presence of %q. One of the two is a "+
+				"typo, and whichever it is, the block writes into or skips the wrong object.",
+				migration.Version, migration.Name, object, match[2], guardedObject)
+		}
 	}
 	for _, match := range matches {
 		object, payload, roleList, singleRole, guardedObject := match[1], match[2], match[3], match[4], match[5]


### PR DESCRIPTION
## main is red

`b443a0da` (#875 is on top of it, so `main` has been red since) fails three tests in `backend/migrations`:

```
FAIL: TestTheRepairsCoverEveryGuardedRBACBackfill/core
  0210_consumer_mail_create_grant writes role permissions 1 times but only 0 are
  in the guarded shape this test reads. The unread ones are invisible to the
  coverage check above, which would then report a repair complete while a
  backfill it cannot see goes unrepaired.
```

Reproduced on plain `origin/main` in a clean worktree. `97a80be9` sits between the breaking commit and now — it is docs-only, so its gates skipped and it reported green, which is why `main` looked healthy.

The test is right to fail. Its sibling assertions spell out the stakes: a backfill no repair re-applies leaves every installation that upgraded past it *"403ing on every route, permanently."*

## The migration is not at fault, and is not edited here

An applied core migration is immutable — additive-only. Correcting one in place changes what a **fresh** installation gets while every database that already applied it keeps the old behaviour, and the two diverge silently with nothing to reveal it. That holds without production: dev and CI databases have applied `0210`.

What `0210` does is legitimately a **second operation**:

| | `guardedBackfillPattern` | `0210` |
|---|---|---|
| Writes | `{objects,<object>}` whole | one verb *inside* an existing entry |
| Guarded on | that object's **absence** | that object's **presence** |

Forcing the second into the first would either overwrite the verbs already present or, under the absence guard, match nothing at all. Two shapes, because there are two operations — so this adds a pattern rather than stretching one past its meaning.

## Verb grants are reconciled, deliberately not collected

The coverage comparison keys on `(object, role)` and cannot carry a verb: two migrations granting different verbs on one object would collide on a single key and one would replace the other, unnoticed.

Rather than model a dimension nothing needs yet, `assertNoVerbGrantBelowTheCeiling` refuses the case that would matter:

- **Above the ceiling** — never shipped unbound, needs no repair. That is where the one verb grant that exists sits.
- **At or below it** — the comparison would silently skip a backfill, the exact outcome this file exists to prevent. It fails, and says what to extend.

A deliberate scope boundary, stated in the source rather than left implicit. If the verb dimension should be modelled properly instead, that is a contained follow-up to `rbacGrant` plus the sort and messages.

## Both directions mutation-proven

Neither gate passes vacuously:

- **Check every migration** instead of only those below the ceiling → the new assertion fires on `0210` by name, with the verb, object, roles and ceiling `0192`
- **Blind the verb pattern** → the reconciliation canary catches the write it can no longer read (`1 write, 0 in a guarded shape`)

## Verification

- `go test ./migrations/` — green, uncached
- The three previously failing tests — all pass
- `make check-backend` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Teach the RBAC repair coverage to read verb-level grants, fixing three failing migration tests and unblocking `main`. Adds a guarded verb-grant pattern and a check to prevent unread backfills.

- **Bug Fixes**
  - Added a `guardedVerbGrantPattern` to match verb-level updates guarded on object presence.
  - Updated coverage logic to count both guarded shapes and validate object/guard alignment, while not collecting verbs to avoid (object, role) collisions.
  - Introduced `assertNoVerbGrantBelowTheCeiling` to block verb grants at or below the ceiling, ensuring repairs can’t be skipped.

<sup>Written for commit bd295252707ace0674ebf7edb36787f3a5b55fb5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/883?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

