### PR TITLE
fix(capture): a same-kind consumer-mail re-add stays on the create grant

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -5989,8 +5989,9 @@ paths:
       description: |
         The workspace's additions to and carve-outs from the shipped consumer-mail baseline.
         Mail from a consumer domain still creates the person; what it never creates is a
-        company. Every human role may read the list; only admin/ops may change it. Governed by
-        the `capture_settings` RBAC object.
+        company. Every human role may read the list; any seat holding `capture_settings:create`
+        adds a new `extra` entry, while carve-outs, kind changes and removal demand
+        `capture_settings:update` (admin/ops). Governed by the `capture_settings` RBAC object.
 
         Human-only, like the personal-mail exclusion list it replaces: the list names the domains
         this installation corresponds with and which of them it treats as consumer mail, which is

--- a/backend/internal/compose/integration/consumermaildomain_integration_test.go
+++ b/backend/internal/compose/integration/consumermaildomain_integration_test.go
@@ -133,6 +133,14 @@ func TestConsumerMailCreateGrantAddsButNeverRewrites(t *testing.T) {
 	if err != nil {
 		t.Fatalf("a create-only seat adding a missed provider: %v", err)
 	}
+	// The contract promises an idempotent re-add answers the existing entry —
+	// a create-only seat retrying a lost response must get it back, not a 403
+	// for "updating" a row it just created.
+	if again, err := store.Add(repCtx, "kleinpost.example", capture.FreemailKindExtra); err != nil {
+		t.Fatalf("a create-only seat re-adding the same entry: %v", err)
+	} else if again.ID != added.ID {
+		t.Errorf("re-add answered entry %s, want the existing %s", again.ID, added.ID)
+	}
 	if _, err := store.Add(repCtx, "realfirm.example", capture.FreemailKindNever); !errors.Is(err, apperrors.ErrPermissionDenied) {
 		t.Errorf("a create-only seat carving a fresh domain out of the baseline = %v, want permission denied", err)
 	}

--- a/backend/internal/modules/capture/freemaildomain.go
+++ b/backend/internal/modules/capture/freemaildomain.go
@@ -172,11 +172,16 @@ func (s *FreemailDomainStore) Add(ctx context.Context, domain, kind string) (Fre
 			return err
 		}
 		// The specific demand, now that the write knows which half it is:
-		// inserting a new `extra` is create; a `never` carve-out overrides the
-		// shipped baseline for the whole workspace, and overwriting an
-		// existing entry rewrites a prior decision, so both are update.
+		// inserting a new `extra` is create; a fresh `never` carve-out
+		// overrides the shipped baseline for the whole workspace, and flipping
+		// an existing entry's kind rewrites a prior decision, so both are
+		// update. A same-kind re-add changes NOTHING and stays on create —
+		// the contract promises an idempotent re-add answers the existing
+		// entry, so a create-only seat retrying a lost response must not 403.
 		// UpsertAction keeps this demand and the audit verb below one word.
-		required := auth.UpsertAction(before != nil || kind == FreemailKindNever)
+		rewriting := before != nil && *before != kind
+		freshCarveOut := before == nil && kind == FreemailKindNever
+		required := auth.UpsertAction(rewriting || freshCarveOut)
 		if err := auth.Require(ctx, freemailDomainObject, required); err != nil {
 			return err
 		}


### PR DESCRIPTION
Codex review follow-up to #872, two findings fixed:

- **Idempotent retry**: `FreemailDomainStore.Add` demanded `update` for ANY existing row, so a create-only seat (rep) retrying its own lost `extra` add got 403 — against the contract's idempotent re-add promise. `update` is now demanded only when the write rewrites (kind flip, or a fresh `never` carve-out). New integration case covers the retry.
- **Contract text**: the list operation's description still said only admin/ops may change the list; it now states the create/update split from #872.

Codex's remaining finding — spec CAP-PARAM-5 (capture.md) doesn't know the workspace consumer-mail surface at all (it still describes baseline + margince.yaml with no admin UI) — is upstream spec reconciliation, tracked outside this repo per contract-first rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix idempotent re-adds for consumer-mail domains to prevent 403s on retried adds by create-only seats. Re-adding the same domain/kind stays a create and returns the existing entry; docs now reflect the create vs update RBAC split.

- **Bug Fixes**
  - Updated `FreemailDomainStore.Add`: require `update` only for kind flips or fresh `never` carve-outs; same-kind re-add stays `create` and returns the existing entry.
  - Added integration coverage for idempotent re-adds.
  - Clarified API text in `backend/api/crm.yaml`: `capture_settings:create` adds `extra`; carve-outs, kind changes, and removal require `capture_settings:update`.

<sup>Written for commit 380939edceb71532905905602db5c6e8b46062f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/888?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated consumer-mail exclusion list permissions: human roles can view entries, create permissions allow adding entries, and update permissions cover carve-outs, type changes, and removals.
  - Re-adding an unchanged entry is now supported with create access and does not require update permissions.

- **Bug Fixes**
  - Prevented unchanged consumer-mail entries from being incorrectly treated as updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->