### PR TITLE
ci: the checks that answer for main, not for a diff

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -88,7 +88,13 @@ jobs:
             echo "status=SKIPPED" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          body="$(curl -fsS -u "$SONAR_TOKEN:" \
+          # Bearer header rather than `-u "$TOKEN:"`. The basic-auth spelling is
+          # what Sonar's own docs show, but it trips gitleaks' curl-auth-user rule
+          # — correctly, in the sense that the rule cannot tell a variable from a
+          # literal. Sonar accepts either, so the header avoids arguing for an
+          # allowlist entry, and an allowlist that grows is how a secret scan
+          # starts reporting "no leaks found" over a tree that has one.
+          body="$(curl -fsS -H "Authorization: Bearer $SONAR_TOKEN" \
             "https://sonarcloud.io/api/qualitygates/project_status?projectKey=$PROJECT_KEY&branch=main")"
           status="$(printf '%s' "$body" | jq -r '.projectStatus.status')"
           echo "quality gate on main: $status"

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -43,6 +43,7 @@ jobs:
   vuln:
     name: govulncheck (main)
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: read
     steps:
@@ -64,6 +65,7 @@ jobs:
   quality-gate:
     name: sonarcloud quality gate (main)
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
     outputs:
@@ -94,7 +96,12 @@ jobs:
           # literal. Sonar accepts either, so the header avoids arguing for an
           # allowlist entry, and an allowlist that grows is how a secret scan
           # starts reporting "no leaks found" over a tree that has one.
-          body="$(curl -fsS -H "Authorization: Bearer $SONAR_TOKEN" \
+          # Timeouts, because a stalled read here is worse than a failed one: the
+          # concurrency group below does not cancel in progress, so a request that
+          # hangs holds the lane and every later scheduled run queues behind it.
+          # A day with no answer is recoverable; a lane that stops answering is not.
+          body="$(curl -fsS --connect-timeout 10 --max-time 60 \
+            -H "Authorization: Bearer $SONAR_TOKEN" \
             "https://sonarcloud.io/api/qualitygates/project_status?projectKey=$PROJECT_KEY&branch=main")"
           status="$(printf '%s' "$body" | jq -r '.projectStatus.status')"
           echo "quality gate on main: $status"
@@ -119,6 +126,7 @@ jobs:
   backend-lane:
     name: backend lane (main)
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     permissions:
       contents: read
     steps:
@@ -164,6 +172,7 @@ jobs:
         || needs.quality-gate.result == 'failure'
         || needs.backend-lane.result == 'failure')
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -1,0 +1,186 @@
+name: scheduled
+
+# The checks whose answer changes when nothing is being merged.
+#
+# Everything in ci.yml answers "is this diff sound?" and runs because a diff
+# exists. These three answer "is main still sound?", which a PR gate structurally
+# cannot: two of them go stale on their own, and the third goes quiet.
+#
+#   govulncheck        — the vulnerability database changes daily. A per-PR scan
+#                        proves the day it merged, not today. This is the only
+#                        thing here that can catch a CVE disclosed after a merge.
+#   sonarcloud gate    — main's quality gate stopped being a required PR check
+#                        (ADR-less product decision: merge speed during heavy
+#                        development, to be re-required once releases exist). A
+#                        gate nobody is blocked by is a gate nobody reads, so
+#                        this reads it and files an issue when it goes red.
+#   backend lane       — main has gone red twice with the breakage MASKED: a
+#                        docs-only commit landing after a breaking one matches no
+#                        classifier scope, so every gate skips and the run reports
+#                        green. main's last-known-green is therefore not evidence
+#                        main is green. This re-runs the lane unconditionally.
+#
+# Findings become ISSUES, not just a red run. A failed scheduled workflow notifies
+# essentially nobody by default, and this whole file exists because "we will check
+# regularly" decays into nobody checking.
+on:
+  schedule:
+    # 08:00 Asia/Ho_Chi_Minh — clear of Renovate's 02:00–06:00 window, and early
+    # enough in the working day that a finding is read the morning it appears.
+    - cron: "0 1 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# A slow lane must not stack up on itself: a run still going when the next fires
+# means the tree is in trouble, and two concurrent copies help nobody diagnose it.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  vuln:
+    name: govulncheck (main)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: backend/go.mod
+          cache-dependency-path: backend/go.sum
+      # Restore-only here: the action saves on `push` to main, and a schedule is
+      # not a push, so this lane never competes with the writers in ci.yml.
+      - name: Restore the Go build cache
+        uses: ./.github/actions/go-build-cache
+        with:
+          flavor: plain
+      - run: make vuln
+
+  quality-gate:
+    name: sonarcloud quality gate (main)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      status: ${{ steps.gate.outputs.status }}
+    env:
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+    defaults:
+      run:
+        working-directory: .
+    steps:
+      # Reads the gate through the API rather than re-running the scanner: the
+      # verdict this asks about is the one the last ci.yml scan already published,
+      # so re-analysing would answer a different question and cost a full lane.
+      - name: Read main's quality gate
+        id: gate
+        env:
+          PROJECT_KEY: gradionhq_margince-poc-v1
+        run: |
+          set -euo pipefail
+          if [ -z "${SONAR_TOKEN:-}" ]; then
+            echo "SONAR_TOKEN not set; nothing to read." >&2
+            echo "status=SKIPPED" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          body="$(curl -fsS -u "$SONAR_TOKEN:" \
+            "https://sonarcloud.io/api/qualitygates/project_status?projectKey=$PROJECT_KEY&branch=main")"
+          status="$(printf '%s' "$body" | jq -r '.projectStatus.status')"
+          echo "quality gate on main: $status"
+          echo "status=$status" >> "$GITHUB_OUTPUT"
+          # NONE is not a pass. It means no analysis is attached to main at all,
+          # which reads identically to green on every dashboard and is exactly the
+          # silence this job exists to break.
+          case "$status" in
+            OK) ;;
+            ERROR | WARN)
+              printf '%s' "$body" | jq -r \
+                '.projectStatus.conditions[]? | select(.status != "OK")
+                 | "  failing: \(.metricKey) \(.comparator) \(.errorThreshold) (actual \(.actualValue))"'
+              exit 1
+              ;;
+            *)
+              echo "no quality gate result for main (status=$status)" >&2
+              exit 1
+              ;;
+          esac
+
+  backend-lane:
+    name: backend lane (main)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          # The RBAC legacy-cohort gates read an early commit as a fixture and
+          # fail rather than degrade on a shallow checkout.
+          fetch-depth: 0
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: backend/go.mod
+          cache-dependency-path: backend/go.sum
+      - name: Restore the Go build cache
+        uses: ./.github/actions/go-build-cache
+        with:
+          flavor: plain
+      - name: Cache the gate binaries
+        id: gate-binaries
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/go/bin
+          key: gate-binaries-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('backend/go.mod', 'backend/Makefile') }}
+      - name: Install the pinned gate binaries
+        if: steps.gate-binaries.outputs.cache-hit != 'true'
+        working-directory: .
+        run: make tools
+      - name: Gate binaries onto PATH
+        run: echo "$HOME/go/bin" >> "$GITHUB_PATH"
+      - name: Backend merge gate (make check-backend)
+        working-directory: .
+        run: make check-backend
+
+  # The one job holding `issues: write`, and it runs no build code — the same
+  # permission isolation sbom.yml's signing job uses. It must RUN when an upstream
+  # fails, so it is guarded on !cancelled() rather than needs alone.
+  report:
+    name: report
+    needs: [vuln, quality-gate, backend-lane]
+    if: >-
+      !cancelled()
+      && (needs.vuln.result == 'failure'
+        || needs.quality-gate.result == 'failure'
+        || needs.backend-lane.result == 'failure')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    defaults:
+      run:
+        working-directory: .
+    steps:
+      # The reporting script lives in the tree, so this job needs the tree — the
+      # only thing it checks out for. persist-credentials: false because the issue
+      # filing authenticates with GH_TOKEN explicitly, not the git credential.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      # One open issue per failing check, keyed on an exact title. Re-filing daily
+      # would bury the original and its discussion; a comment on the existing one
+      # says "still red" without costing anyone a second triage.
+      - name: File or update an issue per failing check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          VULN_RESULT: ${{ needs.vuln.result }}
+          GATE_RESULT: ${{ needs.quality-gate.result }}
+          GATE_STATUS: ${{ needs.quality-gate.outputs.status }}
+          LANE_RESULT: ${{ needs.backend-lane.result }}
+        run: ./scripts/scheduled-report.sh

--- a/infra/ci-pipeline.md
+++ b/infra/ci-pipeline.md
@@ -7,11 +7,17 @@ that decides which jobs run, and how coverage flows into SonarCloud.
 
 `make check` on its own runs only the no-database lane, so the
 tenant-isolation and GDPR-erasure fitness tests (`//go:build integration`,
-they need a real Postgres) never blocked a PR locally. CI runs **both** lanes
-plus the vulnerability scan, the craftsmanship gate, and the frontend + UAT
-lanes as required checks — so a migration that forgets `FORCE RLS`, an
-erasure that misses a PII table, a vulnerable dependency, a swallowed error,
-or a UI regression fails the merge instead of shipping.
+they need a real Postgres) never blocked a PR locally. CI runs **both** lanes,
+plus the craftsmanship gate, the license gate and the frontend lane, as required
+checks — so a migration that forgets `FORCE RLS`, an erasure that misses a PII
+table, a denied dependency license, a swallowed error, or a UI regression fails
+the merge instead of shipping.
+
+Two lanes run but deliberately do **not** block: `vuln` and the SonarCloud scan.
+Both were traded off the required set for merge speed during heavy development,
+and both are re-checked daily on `main` by `scheduled.yml` — see below for why a
+non-blocking gate needs that backstop to stay honest. `uat` and `live-boot` are
+likewise advisory.
 
 ## Triggers
 
@@ -160,7 +166,7 @@ third-party actions it calls, which would otherwise ride in unread.
 | `integration shard (k/12)` | `make test-integration` with `INTEGRATION_SHARD=k/12`: a deterministic per-test round-robin slice of the whole integration lane. Slices are count-based, not duration-based; the heavy e2e tail lands on whichever shard draws it, and `INTEGRATION_JOBS=16` (the tests wait on Postgres, not cores) lets that shard chew through its slice instead of running minutes over its siblings. Boots the dev compose stack (`make db-up`: digest-pinned Postgres 16 (pgvector) + Redis 7 + MinIO + the app role — one stack definition, no hand-mirrored GH services); each shard builds its own migrated `margince_test` template and clones per package. Uploads its slice manifests + binary coverage pods |
 | `integration unit coverage` | The unit `-cover` pass over every package, binary coverage pods only. Needed because the shards run just the integration-tagged packages, and without it SonarCloud would see the unit-only packages at a false ~0% new-code coverage. No services (the test-lanes gate guarantees untagged tests open no real DB) |
 | `integration` | The fan-in — and the required check, under the same name the single-runner lane carried, so branch protection is unchanged. Asserts every shard + the unit pass succeeded (a failed shard must turn this check red, not skipped), then `scripts/test-integration-reconcile.sh` proves the slices add up: every shard present, identical discovery, union complete + disjoint. Merges all coverage pods into `coverage.out`, uploads `go-coverage` |
-| `vuln` | `make vuln` (govulncheck over all packages) |
+| `vuln` | `make vuln` (govulncheck over all packages). **Advisory** — not a required context. It still runs on every backend PR, so a vulnerable dependency a PR *introduces* is reported before merge; what it cannot report is a vulnerability disclosed after one, which is why `scheduled.yml` runs it daily on `main` as well |
 | `license gate` | `make sbom` then `make sbom-check` — the dependency-license policy (`grant`, policy in `.grant.yaml`) over the resolved dependency graph, not the manifests. Lives here rather than in `sbom.yml` because it is a **gate** and that workflow is an artifact producer: `sbom.yml` filters at the workflow level, so on a PR touching no dependency it produces no check run at all, and a required context that never posts blocks the merge forever. Job-level gating makes a path skip report as passing instead. PR-only — on `main` the same gate runs inside `sbom.yml`, where it is the precondition for signing, so each path runs it exactly once |
 | `frontend` | `make frontend-check` (biome + vitest + tsc + Vite build) + a Storybook catalog build (stories must compile & register). Emits `fe-coverage` (lcov) |
 | `uat` | `make frontend-e2e`: the AC-`<screen>`-N screen-acceptance criteria as named Playwright tests + axe WCAG 2.2 AA + the 390px no-horizontal-scroll sweep + the PERF-1 record-open budget. Mocks the API at the network edge, so it is self-contained |
@@ -209,9 +215,26 @@ Wiring details:
 - Every `uses:` and container `image:` is pinned to an immutable SHA (the
   `check-image-pins` gate enforces it).
 
-## The other two workflows
+## The other workflows
 
-`ci.yml` is the merge gate. Two workflows sit beside it, deliberately outside it:
+`ci.yml` is the merge gate. Three workflows sit beside it, deliberately outside it:
+
+- **`scheduled.yml`** — daily on `main`, the checks whose answer changes when
+  nothing is being merged. `ci.yml` asks "is this diff sound?" and runs because a
+  diff exists; these ask "is `main` still sound?", which a PR gate structurally
+  cannot answer. `govulncheck` runs against a vulnerability database that changes
+  daily, so a per-PR scan proves the day it merged and nothing since. The
+  **SonarCloud quality gate** is read through the API (not re-scanned) because it
+  is no longer a required PR check — a gate nobody is blocked by is a gate nobody
+  reads. And the **backend lane** re-runs unconditionally, because `main`'s
+  last-known-green is not evidence `main` is green: a docs-only commit landing
+  after a breaking one matches no classifier scope, so every gate skips and the
+  run reports green over a broken tree. That has happened more than once.
+  Findings become **issues** (`scripts/scheduled-report.sh`), one open issue per
+  check keyed on an exact title, because a red scheduled run notifies nobody and
+  these checks exist precisely for the case where nothing prompts a human to look.
+  The reporting job is the sole holder of `issues: write` and runs no build code —
+  the same permission isolation `sbom.yml` uses for signing.
 
 - **`sbom.yml`** — **no `pull_request` trigger**, so its automatic path is `main`
   (a manual dispatch still runs the `sbom` job on any ref; only `sign` is guarded

--- a/scripts/scheduled-report.sh
+++ b/scripts/scheduled-report.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# scheduled-report.sh — turn a failing scheduled check into a durable issue.
+#
+# Called only when something in .github/workflows/scheduled.yml failed. A red
+# scheduled run notifies essentially nobody by default, which is the whole reason
+# these checks moved off the PR path in the first place: nothing was going to make
+# someone look. An issue is the artifact that survives until it is closed.
+#
+# One OPEN issue per check, keyed on an exact title. A daily re-file would bury
+# the original and whatever discussion it collected, so a repeat comments on the
+# existing issue instead — "still red" costs no second triage.
+set -euo pipefail
+
+: "${GH_TOKEN:?the reporting step needs a token to file issues}"
+: "${REPO:?REPO must name the repository to file against}"
+: "${RUN_URL:?RUN_URL must link the run that produced this verdict}"
+
+# report <title> <label> <body>
+report() {
+  local title="$1" label="$2" body="$3" existing
+  existing="$(gh issue list --repo "$REPO" --state open --limit 100 --json number,title |
+    jq -r --arg t "$title" 'map(select(.title == $t)) | .[0].number // empty')"
+  if [ -n "$existing" ]; then
+    echo "already open as #$existing — commenting"
+    gh issue comment "$existing" --repo "$REPO" \
+      --body "Still failing on the $(date -u +%Y-%m-%d) scheduled run: $RUN_URL"
+    return
+  fi
+  echo "filing: $title"
+  gh issue create --repo "$REPO" --title "$title" --label "$label" --body "$body"
+}
+
+if [ "${VULN_RESULT:-}" = "failure" ]; then
+  report "govulncheck reports a vulnerability reachable from main" security \
+"\`make vuln\` failed on the scheduled run of \`main\`: $RUN_URL
+
+This is the finding a pull-request scan cannot produce. govulncheck answers
+against a vulnerability database that changes daily, so a per-PR run proves the
+tree was clean **the day it merged** — not today. A vulnerability disclosed after
+a merge is only ever found by this lane.
+
+govulncheck reports **reachability**, not mere presence: the affected code is on a
+path this module actually calls. That is a stronger signal than a Dependabot
+alert on the same package, and it is worth acting on rather than deferring.
+
+Reproduce locally with \`make vuln\`."
+fi
+
+if [ "${GATE_RESULT:-}" = "failure" ]; then
+  report "SonarCloud quality gate is not green on main" bug \
+"The quality gate on \`main\` read \`${GATE_STATUS:-unknown}\` on the scheduled
+run: $RUN_URL
+
+\`SonarCloud Code Analysis\` is deliberately **not** a required pull-request check
+— that was traded for merge speed during heavy development, to be re-required
+once there are production releases. The trade only holds while someone still
+reads the gate, so this job reads it and files here when it goes red.
+
+A \`NONE\` status is reported as a failure on purpose: it means no analysis is
+attached to \`main\` at all, which looks identical to green on every dashboard.
+
+The failing conditions are printed in the \`quality-gate\` job log of the run
+above."
+fi
+
+if [ "${LANE_RESULT:-}" = "failure" ]; then
+  report "the backend merge gate is red on main" bug \
+"\`make check-backend\` failed on the scheduled run of \`main\`: $RUN_URL
+
+Worth reading before assuming the last green run means anything. \`main\`'s
+last-known-green is not evidence \`main\` is green: a docs-only commit landing
+after a breaking one matches no classifier scope, so every code gate skips and
+the run reports green over a broken tree. That has happened more than once, which
+is why this lane re-runs the gate unconditionally rather than trusting the last
+push's verdict.
+
+So the breakage may predate the most recent commit. Reproduce locally with
+\`make check-backend\` on \`main\`."
+fi

--- a/scripts/scheduled-report.sh
+++ b/scripts/scheduled-report.sh
@@ -30,6 +30,12 @@ report() {
   gh issue create --repo "$REPO" --title "$title" --label "$label" --body "$body"
 }
 
+# Each report is attempted independently. Under `set -e` a bare call would abort
+# the script, so a single `gh` hiccup on the first finding would silently suppress
+# every later one — and a lane whose job is "say what is broken" must not report
+# one failure and swallow two. Failures accumulate and surface at the end instead.
+unreported=0
+
 if [ "${VULN_RESULT:-}" = "failure" ]; then
   report "govulncheck reports a vulnerability reachable from main" security \
 "\`make vuln\` failed on the scheduled run of \`main\`: $RUN_URL
@@ -43,7 +49,8 @@ govulncheck reports **reachability**, not mere presence: the affected code is on
 path this module actually calls. That is a stronger signal than a Dependabot
 alert on the same package, and it is worth acting on rather than deferring.
 
-Reproduce locally with \`make vuln\`."
+Reproduce locally with \`make vuln\`."\
+    || unreported=1
 fi
 
 if [ "${GATE_RESULT:-}" = "failure" ]; then
@@ -60,7 +67,8 @@ A \`NONE\` status is reported as a failure on purpose: it means no analysis is
 attached to \`main\` at all, which looks identical to green on every dashboard.
 
 The failing conditions are printed in the \`quality-gate\` job log of the run
-above."
+above."\
+    || unreported=1
 fi
 
 if [ "${LANE_RESULT:-}" = "failure" ]; then
@@ -75,5 +83,11 @@ is why this lane re-runs the gate unconditionally rather than trusting the last
 push's verdict.
 
 So the breakage may predate the most recent commit. Reproduce locally with
-\`make check-backend\` on \`main\`."
+\`make check-backend\` on \`main\`."\
+    || unreported=1
+fi
+
+if [ "$unreported" -ne 0 ]; then
+  echo "FAIL: at least one finding could not be filed — the run above names what was broken, but an issue for it does not exist" >&2
+  exit 1
 fi


### PR DESCRIPTION
## Why

Three gates came off the required set for merge speed, and two of them answer a question a pull-request gate **structurally cannot** answer.

- **`govulncheck`** reads a vulnerability database that changes daily. A per-PR run proves the tree was clean *the day it merged* and nothing since. Nothing in the pipeline could report a vulnerability disclosed after a merge.
- **The SonarCloud quality gate** stopped being required. That trade only holds while someone still reads the gate — and nothing made anyone read it.
- **`main`'s last-known-green is not evidence `main` is green.** A docs-only commit landing after a breaking one matches no classifier scope, so every code gate skips and the run reports green over a broken tree. That masked a red `main` **twice in one day**, both times found by hand rather than by CI.

## What

A daily lane on `main` (08:00 ICT — clear of Renovate's 02:00–06:00 window, early enough that a finding is read the same morning):

| Job | What it does |
|---|---|
| `govulncheck (main)` | `make vuln` |
| `sonarcloud quality gate (main)` | Reads the gate through the API rather than re-scanning — the verdict asked about is the one the last `ci.yml` scan published, so re-analysing would answer a different question and cost a full lane |
| `backend lane (main)` | `make check-backend`, unconditionally |

`NONE` from the API is treated as a **failure**, not a pass: it means no analysis is attached to `main` at all, which looks identical to green on every dashboard.

**Findings become issues** (`scripts/scheduled-report.sh`). A red scheduled run notifies essentially nobody, and this lane exists precisely for the case where nothing prompts a human to look. One open issue per check keyed on an exact title, so a repeat **comments** rather than burying the original and its discussion.

## `vuln` stays in `ci.yml`

Deliberately not moved. The two runs catch different things: this one catches disclosure *after* a merge; the PR one catches a vulnerability a PR *introduces*, which Dependabot cannot because it scans only the default branch. It is parallel, unrequired, and off the critical path, so keeping it costs no merge time.

## Two things worth your eye

**`issues: write` is new to this repo.** It is isolated to the `report` job, which runs no build code — the same permission isolation `sbom.yml` uses for signing.

**The schedule cannot be exercised before merge.** `schedule` fires only on the default branch, so its first real run is post-merge. `workflow_dispatch` is wired so it can be triggered manually straight after, which is worth doing: `main`'s current quality-gate status is unknown to us, and this would tell us.

## Verification

- Stubbed `gh` proves both paths: three issues filed with the right titles and labels; a repeat comments on the existing issue instead of duplicating it
- `bash -n` clean, `make check-image-pins` green, `make check-backend` green
- A scripted audit that every job needing the tree checks it out — which caught a real bug: `report` runs the script and had no checkout step. Fixed before pushing.

Also corrects `infra/ci-pipeline.md`, which still described `vuln` and the UAT lane as required checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a daily scheduled workflow on main to catch post-merge risks and silent regressions. It runs govulncheck, reads the SonarCloud quality gate via API, re-runs the backend lane, and files one issue per failing check; the PR `vuln` job remains advisory and CI docs are updated.

- New Features
  - Daily at 08:00 ICT: `govulncheck`, SonarCloud quality gate (API read; Bearer auth; `NONE` = fail), and `make check-backend` on `main`.
  - Concurrency prevents overlaps; per-job and API call timeouts prevent hangs. The reporting script attempts all filings and exits non-zero if any fail.
  - Failures become one persistent issue per check; repeats add a comment. Only the `report` job has `issues: write` and it runs no build code.
  - `vuln` stays in `ci.yml` (advisory) to catch PR-introduced vulns; the schedule covers post-merge disclosures. Docs updated in `infra/ci-pipeline.md`.

- Migration
  - After merging, trigger `scheduled.yml` with `workflow_dispatch` once to seed the first read on `main`.

<sup>Written for commit 5b233bc623a0460fc1738d69e7089f1c0ee45500. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/891?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added daily scheduled validation for security, code quality, and backend checks.
  * Added manual execution support for scheduled validation.
  * Added automatic issue creation or updates when scheduled checks fail.

* **Documentation**
  * Updated CI documentation to clarify required and advisory checks.
  * Documented scheduled validation, failure reporting, and workflow responsibilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->