### PR TITLE
chore(renovate): the lockfile refresh is the security lever, so it runs daily

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,9 +12,9 @@
   "minimumReleaseAge": "7 days",
   "internalChecksFilter": "strict",
   "lockFileMaintenance": {
-    "description": "Refreshes transitive packages, which have no manifest range for Renovate to raise. The repo-wide minimumReleaseAge does NOT apply here — Renovate delegates resolution to pnpm. The age floor is enforced instead by pnpm 11's supply-chain policy at install time, which fails CI on a too-fresh entry and so blocks automerge.",
+    "description": "Refreshes transitive packages, which have no manifest range for Renovate to raise. The repo-wide minimumReleaseAge does NOT apply here — Renovate delegates resolution to pnpm. The age floor is enforced instead by pnpm 11's supply-chain policy at install time, which fails CI on a too-fresh entry and so blocks automerge. DAILY, not weekly, because this is the ONLY mechanism that adopts a fix for a lockfile-only transitive advisory: vulnerabilityAlerts cannot raise a package that has no manifest range, and Renovate removed the option that once bridged that gap. On a weekly cadence such a fix waited on the calendar rather than on the advisory — GHSA-5p4m-2wfm-xmqj (js-yaml, high) was fixed upstream twenty hours after a Monday run and would have sat unadopted for six more days. The cost is a lockfile PR whenever something in range moves, which automerges on green like any other.",
     "enabled": true,
-    "schedule": ["after 2am and before 6am on monday"]
+    "schedule": ["after 2am and before 6am"]
   },
   "packageRules": [
     {
@@ -29,6 +29,7 @@
     }
   ],
   "vulnerabilityAlerts": {
+    "description": "Advisory-driven PRs, unscheduled so they are not held to the nightly window. This reaches only packages with a manifest range of their own: an advisory naming a LOCKFILE-ONLY transitive package has nothing here for Renovate to raise, and no option restores that — `transitiveRemediation` was removed from Renovate and is stripped by config migration. lockFileMaintenance above is the only mechanism that adopts those, which is why its cadence is the security lever rather than anything in this block.",
     "labels": ["security", "dependencies"],
     "schedule": ["at any time"]
   }


### PR DESCRIPTION
## The gap, and why it is structural

Dependabot reports advisories Renovate cannot act on. Not a misconfiguration — a missing capability.

An advisory naming a **lockfile-only transitive** package gives `vulnerabilityAlerts` nothing to raise: the package has no manifest range of its own. The open `js-yaml` alert is the worked example:

```
GHSA-5p4m-2wfm-xmqj  (high, CVE-2026-59870, development scope)
  js-yaml 4.3.0  ←  @redocly/openapi-core@1.34.18  ←  openapi-typescript  ←  us
```

`@redocly/openapi-core@1.34.18` pins js-yaml **exactly** `4.3.0`, so the fix is not a js-yaml bump at all — it is **redocly 1.34.19**, an ancestor, which pins `4.3.1` and satisfies openapi-typescript's `^1.34.6`.

Renovate once bridged this with `transitiveRemediation`. **That option is gone.** It survives only in the config-migration table, which strips it — the validator reports `Config migration necessary` and removes it. So no setting restores the capability, and `lockFileMaintenance` is the only mechanism left that adopts such a fix.

## What changes

`lockFileMaintenance` weekly → **daily**. One line.

Weekly meant waiting on the calendar rather than on the advisory. redocly 1.34.19 was published roughly **twenty hours after** a Monday run, so the fix for an open high-severity alert would have sat unadopted until the following Monday — six more days.

The cost is a lockfile PR whenever something in range moves, which automerges on green like any other. The pnpm install-time age floor still refuses a too-fresh entry, so this does **not** shorten the supply-chain quarantine — it only stops a fix waiting for a weekday once that quarantine has passed.

## What I deliberately did not change

**The repo-wide `minimumReleaseAge: 7 days` is not overridden for vulnerability alerts.** Zeroing it would adopt CVE fixes faster, but it would trade away a real control — the quarantine guarding against a compromised fresh publish, which is the dominant npm attack pattern. That trade belongs to whoever owns the supply-chain posture. Flagging it as a decision rather than making it.

**`osvVulnerabilityAlerts`** is a real current option but adds alert *sources*, not remediation power. Dependabot alerts already work here — they are what found this one — so it would not have closed this gap.

**No `pnpm.overrides`.** I tried the direct route first and it is the wrong shape: forcing js-yaml past an exact upstream pin diverges from the declared tree and lingers after upstream fixes it. An ancestor bump is available, so no override is warranted. (#518 set the house pattern as a lockfile refresh, not overrides, and this keeps to it.)

**The lockfile is untouched.** I attempted the bump locally and reverted it: `pnpm update` did not move redocly, and produced 59 lines of unrelated `supports-color` peer-dependency churn because my pnpm major differs from CI's. Hand-editing a lockfile with mismatched tooling is not worth it when the daily refresh will do it correctly.

## Follow-up worth taking separately

`dependabot_security_updates` is **disabled** on the repository. It is a free fallback for exactly this class, and enabling it costs nothing.

## Verification

- `renovate-config-validator` — validates cleanly, and the `Config migration necessary` warning is gone, confirming no dead options remain
- The advisory chain above traced against the published registry metadata, not inferred

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run Renovate `lockFileMaintenance` daily (2–6am) so fixes for lockfile-only transitive advisories are adopted as soon as they’re available. `minimumReleaseAge` stays at 7 days; `pnpm` still enforces the age gate, so remediation is faster without shortening the supply‑chain quarantine.

<sup>Written for commit e3c19a24e90eb4faf16ea2af77ef12b2d1d358ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/893?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

