### PR TITLE
fix(agents): the scope-filtered catalog refuses to be stored (#644); feat(deals): a forecast that moves without a stage change leaves a trace (#823)

### DIFF
--- a/backend/internal/compose/integration/dealforecasthistory_integration_test.go
+++ b/backend/internal/compose/integration/dealforecasthistory_integration_test.go
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// A forecast moves for two reasons that leave no stage transition behind: an
+// amount revised in place, and a close date slipped. deal_stage_history is
+// written on creation and on a move and nowhere else, so a forecast
+// reconstructed from it reconciles over stage movement and silently omits the
+// rest — while presenting itself as the whole answer.
+//
+// The last assertion here is the one that pins a design decision rather than a
+// behaviour: these rows go to their own table BECAUSE five readers hold
+// deal_stage_history to its stated meaning, counting rows as movements and
+// taking max(changed_at) as "when did this deal last move". If a future change
+// folds this write back into that table, stalled-deal detection and every
+// automation preview start lying, and nothing else in the suite would notice.
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/gradionhq/margince/backend/internal/modules/deals"
+	"github.com/gradionhq/margince/backend/internal/platform/database"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+func TestAForecastMovedWithoutAStageChangeIsRecorded(t *testing.T) {
+	e := Setup(t)
+	pipeline, open, _ := DealFixture(t, e)
+	admin := e.Admin()
+	deal := ids.From[ids.DealKind](e.SeedDeal(t, "Forecast probe", pipeline, open, &e.Rep1))
+
+	stageRows := func(t *testing.T) int {
+		t.Helper()
+		return countRows(admin, t, e, `SELECT count(*) FROM deal_stage_history WHERE deal_id = $1`, deal.UUID)
+	}
+	forecastRows := func(t *testing.T) int {
+		t.Helper()
+		return countRows(admin, t, e, `SELECT count(*) FROM deal_forecast_history WHERE deal_id = $1`, deal.UUID)
+	}
+
+	stageAtStart := stageRows(t)
+
+	// A field a forecast never reads must leave no trace here, or the table
+	// answers "the forecast moved" for every edit anyone makes to a deal.
+	renamed := "Forecast probe, renamed"
+	if _, err := e.Deals.UpdateDeal(admin, deal, deals.UpdateDealInput{Name: &renamed}); err != nil {
+		t.Fatalf("renaming the deal: %v", err)
+	}
+	if got := forecastRows(t); got != 0 {
+		t.Fatalf("a rename wrote %d forecast rows, want 0 — a name is not a forecast field", got)
+	}
+
+	// amount_minor and currency move together or not at all — a bare number is
+	// not money, and the store refuses one without the other.
+	amount, currency := int64(250_000), "EUR"
+	if _, err := e.Deals.UpdateDeal(admin, deal,
+		deals.UpdateDealInput{AmountMinor: &amount, Currency: &currency}); err != nil {
+		t.Fatalf("revising the amount: %v", err)
+	}
+	if got := forecastRows(t); got != 1 {
+		t.Fatalf("an amount revision wrote %d forecast rows, want 1", got)
+	}
+
+	// The value recorded is the state the deal is IN after the change, which is
+	// what a reconstruction asking "what was the forecast as of date T" reads
+	// off the latest row at or before T. Recorded the other way round, every
+	// answer would be one edit stale.
+	recorded := recordedForecastAmount(admin, t, e, deal.UUID)
+	if recorded == nil || *recorded != amount {
+		t.Fatalf("recorded amount = %v, want %d — the row must carry the amount the deal now has", recorded, amount)
+	}
+
+	// A close date set for the first time is a slip like any other: NULL and a
+	// date are different forecasts, and the move from one to the other is
+	// exactly what a reconstruction needs to see.
+	slipped := time.Now().UTC().AddDate(0, 1, 0)
+	if _, err := e.Deals.UpdateDeal(admin, deal, deals.UpdateDealInput{ExpectedClose: &slipped}); err != nil {
+		t.Fatalf("slipping the close date: %v", err)
+	}
+	if got := forecastRows(t); got != 2 {
+		t.Fatalf("a close-date change wrote %d forecast rows in total, want 2", got)
+	}
+
+	// And the reason this is a separate table at all.
+	if got := stageRows(t); got != stageAtStart {
+		t.Fatalf("deal_stage_history grew from %d to %d rows without a stage change — health.go reads "+
+			"max(changed_at) there as 'when did this deal last move' and the automation previews count "+
+			"those rows as movements, so both now answer wrongly", stageAtStart, got)
+	}
+}
+
+func countRows(ctx context.Context, t *testing.T, e *Env, query string, deal ids.UUID) int {
+	t.Helper()
+	var n int
+	if err := database.WithWorkspaceTx(ctx, e.Pool, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx, query, deal).Scan(&n)
+	}); err != nil {
+		t.Fatalf("counting rows for %q: %v", query, err)
+	}
+	return n
+}
+
+// recordedForecastAmount reads back the one column whose VALUE this suite
+// asserts, so the read has the column's own type rather than an any the caller
+// has to get right.
+func recordedForecastAmount(ctx context.Context, t *testing.T, e *Env, deal ids.UUID) *int64 {
+	t.Helper()
+	var amount *int64
+	if err := database.WithWorkspaceTx(ctx, e.Pool, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx,
+			`SELECT amount_minor_at_change FROM deal_forecast_history WHERE deal_id = $1`, deal).Scan(&amount)
+	}); err != nil {
+		t.Fatalf("reading the recorded forecast amount: %v", err)
+	}
+	return amount
+}

--- a/backend/internal/modules/agents/httpmcp.go
+++ b/backend/internal/modules/agents/httpmcp.go
@@ -85,6 +85,23 @@ func writeRPCResponse(w http.ResponseWriter, r *http.Request, resp rpcResponse, 
 		})
 		return
 	}
+	// BYO-WIRE-1: a scope-filtered catalog caches `private`. Every answer on
+	// this path is derived from the presenting passport — tools/list is cut to
+	// the scopes it holds, and each call is re-authorized against live
+	// authority — so a stored copy is two wrong things at once: one
+	// principal's surface served to another, and an authority claim that went
+	// stale the moment a passport was revoked mid-session. Neither request
+	// reaches the server to be audited, which is what makes this a disclosure
+	// rather than a staleness bug.
+	//
+	// no-store rather than a bare private for the second reason: private
+	// permits a browser's own cache to keep it, and this answer may not
+	// outlive the authority it was computed under.
+	//
+	// Set above the framing branch because it is a property of the ANSWER
+	// rather than of how the client asked for it — the event-stream frame
+	// carries the same scope-filtered body.
+	w.Header().Set("Cache-Control", "private, no-store")
 	if strings.Contains(r.Header.Get("Accept"), "text/event-stream") {
 		w.Header().Set("Content-Type", "text/event-stream")
 		w.WriteHeader(status)

--- a/backend/internal/modules/agents/httpmcp_test.go
+++ b/backend/internal/modules/agents/httpmcp_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/mcp"
 )
 
 // discardLog is the logger for the cases that assert something other than what
@@ -426,5 +427,98 @@ func TestPostWithEventStreamAcceptFramesASingleDataFrame(t *testing.T) {
 	}
 	if frame.Error != nil {
 		t.Errorf("ping returned an error: %+v", frame.Error)
+	}
+}
+
+// BYO-WIRE-1: the catalog this transport serves is cut to the presenting
+// passport's scopes, so a shared cache holding one answer and replaying it to
+// another credential discloses a surface that principal was never admitted to
+// — and the replayed request never reaches the server, so nothing is audited.
+//
+// Both halves are asserted, and the first is why this is not a header test.
+// Checking only the directive would pass just as well against a transport that
+// had stopped filtering by scope altogether — the very state that makes the
+// directive necessary. So the two answers must differ FIRST, and then both must
+// refuse to be stored.
+func TestTheScopeFilteredCatalogRefusesToBeStored(t *testing.T) {
+	listing := func(t *testing.T, scopes ...principal.Scope) (tools []string, cacheControl string) {
+		t.Helper()
+		authenticate := func(*http.Request) (context.Context, error) {
+			ctx := principal.WithWorkspaceID(context.Background(), ids.NewV7())
+			return principal.WithActor(ctx, principal.Principal{
+				Type: principal.PrincipalAgent, ID: "agent:catalog", OnBehalfOf: ids.NewV7(),
+				Scopes: principal.NewScopeSet(scopes...),
+			}), nil
+		}
+		registry := NewRegistry(nil, nil)
+		for name, scope := range map[string]principal.Scope{
+			"read_tool":  principal.ScopeRead,
+			"write_tool": principal.ScopeWrite,
+		} {
+			registry.Register(&fakeTool{spec: mcp.ToolSpec{
+				Name: name, Title: name, Version: testToolVersion,
+				Description:   name + " is offered to whoever holds its scope.",
+				RequiredScope: scope, Tier: mcp.TierAutoExecute,
+				InputSchema: json.RawMessage(`{"type":"object"}`),
+			}})
+		}
+		h := NewHTTPHandler(registry, authenticate,
+			func(*http.Request) string { return "" }, "margince-crm", "test", discardLog())
+		// A real listener rather than a recorder: dispatch extends the write
+		// deadline through http.ResponseController, which the recorder does
+		// not implement.
+		server := httptest.NewServer(h)
+		t.Cleanup(server.Close)
+
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, server.URL,
+			strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"tools/list"}`))
+		if err != nil {
+			t.Fatalf("building the tools/list request: %v", err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := server.Client().Do(req)
+		if err != nil {
+			t.Fatalf("tools/list: %v", err)
+		}
+		defer func() {
+			if err := resp.Body.Close(); err != nil {
+				t.Errorf("closing the response body: %v", err)
+			}
+		}()
+		var decoded struct {
+			Result struct {
+				Tools []struct {
+					Name string `json:"name"`
+				} `json:"tools"`
+			} `json:"result"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&decoded); err != nil {
+			t.Fatalf("decoding the catalog: %v", err)
+		}
+		for _, tool := range decoded.Result.Tools {
+			tools = append(tools, tool.Name)
+		}
+		return tools, resp.Header.Get("Cache-Control")
+	}
+
+	readOnly, readOnlyCache := listing(t, principal.ScopeRead)
+	writing, writingCache := listing(t, principal.ScopeRead, principal.ScopeWrite)
+
+	if len(readOnly) == 0 || len(writing) == 0 {
+		t.Fatalf("a passport was served no tools at all (read %d, write %d) — this proves nothing about caching",
+			len(readOnly), len(writing))
+	}
+	if slices.Equal(readOnly, writing) {
+		t.Fatalf("both passports were served the same %d tools, so this response does not vary by scope — "+
+			"either the filter is gone or this test no longer exercises it", len(readOnly))
+	}
+	for _, tc := range []struct {
+		passport, got string
+	}{{"read-only", readOnlyCache}, {"read+write", writingCache}} {
+		if tc.got != "private, no-store" {
+			t.Errorf("the %s passport's catalog was served with Cache-Control %q, want %q — a shared cache "+
+				"may store it and answer another credential from it, and that request never reaches the server to be audited",
+				tc.passport, tc.got, "private, no-store")
+		}
 	}
 }

--- a/backend/internal/modules/deals/deal.go
+++ b/backend/internal/modules/deals/deal.go
@@ -197,6 +197,9 @@ func recordDealUpdate(ctx context.Context, tx pgx.Tx, id ids.DealID, current crm
 			return fmt.Errorf("emit deal.owner_changed: %w", err)
 		}
 	}
+	if err := recordForecastMovement(ctx, tx, id, current, in, after); err != nil {
+		return err
+	}
 	rest := make(map[string]any, len(after))
 	for field, v := range after {
 		if ownerChanged && field == "owner_id" {
@@ -392,6 +395,9 @@ const currencyField = "currency"
 
 // amountField is the other half of a money value.
 const amountField = "amount_minor"
+
+// closeDateField names the column a slipped forecast moves.
+const closeDateField = "expected_close_date"
 
 // missingMoneyHalf names whichever half of the pair was left out.
 func missingMoneyHalf(amountMissing bool) string {

--- a/backend/internal/modules/deals/doc.go
+++ b/backend/internal/modules/deals/doc.go
@@ -9,9 +9,15 @@
 // composition root — as store + contract mapping + transport handlers +
 // the deals slice of the datasource provider, flat per ADR-0054 §3.
 //
-// Tables owned: deal, deal_stage_history, pipeline, stage, fx_rate,
+// Tables owned: deal, deal_stage_history, deal_forecast_history, pipeline,
+// stage, fx_rate,
 // product, offer, offer_line_item (the E03.16-.20 offer engine: rate-card
 // products, versioned deal-bound offers with derived money totals).
+//
+// The two histories are separate on purpose. deal_stage_history answers what a
+// deal looked like when it entered a stage, and readers outside this module
+// count its rows as movements; deal_forecast_history records an amount or close
+// date that moved WITHOUT a stage change (see forecasthistory.go).
 //
 // Imports shared + platform + the generated contract only; never a
 // sibling module. Every write rides storekit's audit+outbox shape and

--- a/backend/internal/modules/deals/forecasthistory.go
+++ b/backend/internal/modules/deals/forecasthistory.go
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package deals
+
+// The forecast's own history: what a deal's amount and close date were, when
+// they moved, and who moved them. It lives beside the stage history rather than
+// inside it — see recordForecastMovement and the 0215 migration for why the two
+// tables stay apart.
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// forecastColumns are the fields a forecast reconstruction reads. A move in any
+// of them is what deal_forecast_history exists to record.
+var forecastColumns = []string{amountField, currencyField, closeDateField}
+
+// recordForecastMovement snapshots the forecast fields when an update moves one
+// of them without moving the stage.
+//
+// deal_stage_history answers "what did this deal look like when it entered this
+// stage", and it is written on creation and on a move — nowhere else. So an
+// amount revised in place and a close date slipped leave no trace at all, and
+// the second of those is the single most common reason a real forecast moves. A
+// reconstruction built from stage history alone reconciles over stage movement
+// and omits the rest while presenting itself as the whole answer: a partial sum
+// wearing the label of a total, which is what finance/formulas.go already
+// refuses by hand elsewhere.
+//
+// It writes to its own table rather than adding an arm to deal_stage_history
+// because five readers hold that table to its stated meaning — health.go reads
+// max(changed_at) as "when did this deal last move", the automation previews
+// COUNT rows as movements — and a row that is not a transition would make every
+// edited deal look freshly moved. See the migration for the full argument.
+//
+// The values are the deal's state AFTER the change, which is what a
+// reconstruction asking "what was the forecast as of date T" needs from the
+// latest row at or before T. The patch decides WHETHER to write; it already
+// compared old against new, so a close date cleared or set for the first time
+// counts as movement exactly as a revision does.
+func recordForecastMovement(ctx context.Context, tx pgx.Tx, id ids.DealID,
+	current crmcontracts.Deal, in UpdateDealInput, after map[string]any,
+) error {
+	moved := false
+	for _, column := range forecastColumns {
+		if _, ok := after[column]; ok {
+			moved = true
+			break
+		}
+	}
+	if !moved {
+		return nil
+	}
+	by, err := storekit.CapturedBy(ctx)
+	if err != nil {
+		return err
+	}
+	amount, currency := current.AmountMinor, current.Currency
+	if in.AmountMinor != nil {
+		amount = in.AmountMinor
+	}
+	if in.Currency != nil {
+		currency = in.Currency
+	}
+	// Carried as *time.Time rather than the contract's Date wrapper: this is
+	// the value the driver encodes into a `date` column, and a wrapper it has
+	// to be taught about is a second place the column's type is decided.
+	var closeDate *time.Time
+	if current.ExpectedCloseDate != nil {
+		closeDate = &current.ExpectedCloseDate.Time
+	}
+	if in.ExpectedClose != nil {
+		closeDate = in.ExpectedClose
+	}
+	if _, err := tx.Exec(ctx,
+		`INSERT INTO deal_forecast_history
+		   (workspace_id, deal_id, changed_by, amount_minor_at_change, currency_at_change, close_date_at_change)
+		 VALUES ($1, $2, $3, $4, $5, $6)`,
+		storekit.MustWorkspace(ctx), id, by, amount, currency, closeDate); err != nil {
+		return fmt.Errorf("record forecast history: %w", err)
+	}
+	return nil
+}

--- a/backend/migrations/core/0215_deal_forecast_history.down.sql
+++ b/backend/migrations/core/0215_deal_forecast_history.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS deal_forecast_history;

--- a/backend/migrations/core/0215_deal_forecast_history.up.sql
+++ b/backend/migrations/core/0215_deal_forecast_history.up.sql
@@ -1,0 +1,55 @@
+-- Append-only snapshot of the forecast fields a deal carries, written when one
+-- of them moves WITHOUT a stage change: an amount revised in place, or a close
+-- date slipped. Those two are invisible today — deal_stage_history is written
+-- only on creation and on a move — so a forecast reconstructed from history
+-- reconciles over stage movement and silently omits the rest, while presenting
+-- itself as the whole answer.
+--
+-- WHY A SECOND TABLE, rather than an arm on deal_stage_history. That table's
+-- own comment is "append-only stage-change snapshot", and five readers hold it
+-- to that: deals/health.go takes max(changed_at) as "when did this deal last
+-- move", automation previews COUNT rows as stage movements, and org360's
+-- baseline and the close-date sweep read it the same way. A row that is not a
+-- transition would make every edited deal look freshly moved and inflate every
+-- movement count — a silent corruption of stalled-deal detection, which is
+-- exactly the kind of answer nobody re-derives once it looks plausible. Two
+-- tables keep both meanings intact by construction rather than by every present
+-- and future reader remembering to filter.
+--
+-- SNAPSHOT, not diff, mirroring the sibling: each row freezes what the deal
+-- read at that instant, and a reconstruction diffs consecutive rows. Amount and
+-- currency are frozen for the reason deal_stage_history freezes them — a deal's
+-- current amount cannot answer what the forecast SAID last month.
+--
+-- No birth row here: every deal already gets one in deal_stage_history at
+-- creation, carrying amount and currency, so the baseline exists and a
+-- reconstruction unions the two tables in time order.
+CREATE TABLE deal_forecast_history (
+  id           uuid PRIMARY KEY DEFAULT uuidv7(),
+  workspace_id uuid NOT NULL REFERENCES workspace(id) ON DELETE RESTRICT,
+  deal_id      uuid NOT NULL,
+  changed_by   text NOT NULL,                 -- principal string (human:/agent:)
+  changed_at   timestamptz NOT NULL DEFAULT now(),
+  amount_minor_at_change bigint NULL,
+  currency_at_change     char(3) NULL,
+  -- Nullable because the column it snapshots is: a deal with no close date and
+  -- a deal whose close date was just cleared are different states, and the
+  -- clearing is itself a forecast movement worth a row.
+  close_date_at_change   date NULL,
+  -- Composite so the database itself refuses a deal from another workspace,
+  -- matching what 0019 did for deal_stage_history.
+  CONSTRAINT deal_forecast_history_deal_id_fkey
+    FOREIGN KEY (workspace_id, deal_id) REFERENCES deal (workspace_id, id) ON DELETE CASCADE
+);
+
+-- The read this table exists for: one deal's forecast movements in time order.
+CREATE INDEX idx_deal_forecast_history_deal
+  ON deal_forecast_history (workspace_id, deal_id, changed_at);
+
+-- Tenant table ⇒ RLS with the deny-on-unset policy every other one carries
+-- (the coverage fitness test refuses a workspace_id table without it).
+ALTER TABLE deal_forecast_history ENABLE ROW LEVEL SECURITY;
+ALTER TABLE deal_forecast_history FORCE ROW LEVEL SECURITY;
+CREATE POLICY deal_forecast_history_tenant_isolation ON deal_forecast_history
+  USING (workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid)
+  WITH CHECK (workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid);

--- a/backend/migrations/schema_fitness_integration_test.go
+++ b/backend/migrations/schema_fitness_integration_test.go
@@ -314,6 +314,7 @@ var rowScopedFKDecisions = gatekit.Waive(map[string]string{
 	"organization.merged_into_id":      "server-derived: stamped by MergeOrganization",
 	"person.converted_from_lead_id":    "server-derived: stamped by PromoteLead",
 	"deal_stage_history.deal_id":       "server-derived: appended by CreateDeal/AdvanceDeal",
+	"deal_forecast_history.deal_id":    "server-derived: appended by UpdateDeal for the deal it has just written, and only after auth.EnsureVisible admitted that deal at the top of the same transaction — the id never comes from a request body",
 	"project_phase_history.project_id": "server-derived: appended by CreateProject/AdvanceProjectPhase from the project row they just wrote or advanced, never from a request body",
 	"brief_item.deal_id":               "server-derived: written only by the brief ranker from its own row-scoped candidate query, never from a request body",
 	// The capture disposition ledger (CAP-DDL-8): capture writes the row in

--- a/backend/tableownership_test.go
+++ b/backend/tableownership_test.go
@@ -108,6 +108,9 @@ var tableOwners = map[string]string{
 	"pipeline":           "internal/modules/deals",
 	"stage":              "internal/modules/deals",
 	"deal_stage_history": "internal/modules/deals",
+	// Kept apart from deal_stage_history rather than folded into it: readers
+	// outside this module count that table's rows as stage movements.
+	"deal_forecast_history": "internal/modules/deals",
 	// The project lives in the deals bounded context (ADR-0073): it is the
 	// body of work the deals hang off, not a context of its own.
 	"project":               "internal/modules/deals",


### PR DESCRIPTION
Closes #644. Closes #823.

Two unrelated fixes in one branch at the author's request; they share no files and are separate commits.

## #644 — the scope-filtered catalog refuses to be stored

`tools/list` became scope-filtered in #636, so the body varies by the presenting passport, and the transport set `Content-Type`, `WWW-Authenticate` and `Mcp-Session-Id` and **no cache directive at all**. BYO-WIRE-1 states it directly: a scope-filtered catalog caches `private`, because a shared entry on a scope-filtered response is a disclosure that never reaches the server to be audited.

`private, no-store`, matching the three `identity` handlers that already answer this for their own principal-varying reads. `no-store` rather than a bare `private` for a reason those reads do not have: **every call here is re-authorized against live authority**, so revocation binds mid-session and a stored catalog is an outdated *authority* claim as well as another principal's surface.

Set above the framing branch, because it is a property of the answer rather than of how the client asked for it — the event-stream frame carries the same scope-filtered body.

**The test asserts the filtering first and the directive second, and that order is the point.** A test that checked only the header would pass just as well against a transport that had stopped filtering by scope altogether — the very state that makes the header necessary. Verified both ways:

| mutation | what failed |
|---|---|
| remove the header | `Cache-Control ""`, want `private, no-store` |
| give both tools the same required scope | `both passports were served the same 2 tools, so this response does not vary by scope` |

**Mitigating factor, recorded so it is not rediscovered as a reason this was unnecessary:** `/mcp` requires a bearer, and RFC 9111 §3.5 already stops a *compliant* shared cache from storing it. That lowers the severity and does not settle it — A2 is operator-hosted (ADR-0027), and "every intermediary is compliant" is not an invariant this codebase gets to assume about someone else's deployment.

## #823 — a forecast that moves without a stage change leaves a trace

`deal_stage_history` is written on creation and on a move, and nowhere else, so **an amount revised in place and a close date slipped leave no history at all** — and the second is the single most common reason a real forecast moves. Anything reconstructing a forecast from that table reconciles over stage movement and omits the rest while presenting itself as the whole answer.

### The design decision, and the constraint that drove it

A **second table**, not an arm on the existing one. `deal_stage_history`'s own comment is "append-only stage-change snapshot", and **five readers hold it to that**:

| reader | what it assumes |
|---|---|
| `deals/health.go:294` | `max(changed_at)` is "when did this deal last move" — stalled-deal detection |
| `automations_preview.go:181,199` | `count(*)` of rows is a count of stage movements |
| `org360/suggestionreads.go:236`, `viewbaseline.go:199` | same, for the account baseline |
| `deals/closedatesweep.go:213` | same |

A row that is not a transition would make every edited deal look freshly moved and inflate every movement count — silently, in stalled-deal detection, which nobody re-derives once it looks plausible. Two tables keep both meanings **by construction** rather than by every present and future reader remembering to filter.

### The rest of the shape

- **Snapshot, not diff**, mirroring the sibling, so a reconstruction unions the two tables in time order and learns one idiom instead of two.
- **The values are the state the deal is IN after the change** — what "the forecast as of date T" reads off the latest row at or before T. Recorded the other way round, every answer would be one edit stale.
- **No birth row needed**: every deal already gets one in `deal_stage_history` carrying amount and currency.
- **The patch decides whether to write.** It has already compared old against new, so a close date cleared or set for the first time counts as movement exactly as a revision does, and a rename writes nothing.

### Verified against a live database, four mutations

| mutation | what failed |
|---|---|
| never record | `an amount revision wrote 0 forecast rows, want 1` |
| record the pre-change value | `recorded amount = <nil>, want 250000` |
| record on any update | `a rename wrote 1 forecast rows, want 0` |
| write into `deal_stage_history` instead | the suite fails — this is the decision above, pinned |

**Scope**: this is the substrate #823 names. The tool that reads it (`explain_forecast_change`) does not exist anywhere in the tree, so there is no answer text to narrow and nothing here to gate — which is also why the issue's option 3 ("ship it scoped and say so in the answer") was not available.

## Gates

`make check-backend` green, `make craft-static` clean across backend/extensions/fixtures, and the new integration test run against a real Postgres. The migration is numbered `0215` against `origin/main` at push time — re-check before merging if main moves, since a duplicate version is a failure no branch-local gate can see.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sets correct caching for the scope-filtered MCP tools catalog and adds forecast history so deal amount/close-date changes are tracked without a stage move. Fixes #644 and delivers the data needed for #823.

- **Bug Fixes**
  - `tools/list` now sends Cache-Control: "private, no-store" for both JSON and event-stream responses to prevent shared-cache leaks across principals.
  - Test asserts scope-based filtering first, then the header, to catch any regression in filtering.

- **New Features**
  - Added `deal_forecast_history` with a write path that snapshots post-change amount, currency, and expected close date when they change without a stage transition.
  - Keeps `deal_stage_history` semantics intact; no rows on non-forecast edits (e.g., rename).
  - Includes integration test, migration `0215` (RLS + index), and schema fitness FK decision for `deal_forecast_history.deal_id`.

<sup>Written for commit 7162cd019a0e3360326dfc62cf8c1806f5f87cd8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/896?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

