### PR TITLE
fix(dbmigrate): the ledger notices when a version was applied under another name

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -364,7 +364,7 @@ ADR-0090/A135 shipped (#520): installation settings are rows in `setting`, with
 the catalog in typed Go. #521 then moved every reader off the `workspace`
 columns across four slices — quotas and finance (#794), the deals module's
 money reads (#802), name/timezone plus the roll-up and org-360 (#817), and the
-brief ranker, forecast and reset confirmation (#857) — and migration `0209`
+brief ranker, forecast and reset confirmation (#857) — and migration `0211`
 dropped `name`, `base_currency` and `timezone` along with the dual write in
 `UpdateInstallation`.
 
@@ -377,7 +377,7 @@ principal exists to gate anything and the other on the first write, when no row
 exists yet and "nothing is priced against a base that was never set" is the
 honest answer.
 
-`0209` refuses rather than loses: an installation whose settings rows are
+`0211` refuses rather than loses: an installation whose settings rows are
 missing while a live workspace still holds the values fails the migration with
 what to do about it, because dropping the columns would destroy the only copy.
 The one state its repair cannot resolve is several live workspaces, where no

--- a/backend/internal/platform/dbmigrate/dbmigrate.go
+++ b/backend/internal/platform/dbmigrate/dbmigrate.go
@@ -129,7 +129,10 @@ func Up(ctx context.Context, conn *pgx.Conn, namespaces ...Namespace) (applied i
 		}
 
 		for _, m := range ns.Migrations {
-			if done[m.Version] {
+			if err := assertLedgerMatches(ns.Name, done, m); err != nil {
+				return applied, err
+			}
+			if _, isDone := done[m.Version]; isDone {
 				continue
 			}
 			if err := inTx(ctx, conn, func(tx pgx.Tx) error {
@@ -168,7 +171,14 @@ func Down(ctx context.Context, conn *pgx.Conn, ns Namespace, n int) (reverted in
 
 	for i := len(ns.Migrations) - 1; i >= 0 && reverted < n; i-- {
 		m := ns.Migrations[i]
-		if !done[m.Version] {
+		// Checked on the way down too, and for a sharper reason: reverting a
+		// version whose ledger row names a different migration would run THIS
+		// migration's down against a schema the other one built, then delete
+		// the row that was the only record either had been applied.
+		if err := assertLedgerMatches(ns.Name, done, m); err != nil {
+			return reverted, err
+		}
+		if _, isDone := done[m.Version]; !isDone {
 			continue
 		}
 		if err := inTx(ctx, conn, func(tx pgx.Tx) error {
@@ -234,22 +244,51 @@ func trackingTable(ctx context.Context, conn *pgx.Conn, namespace string) (strin
 	return table, nil
 }
 
-func appliedVersions(ctx context.Context, conn *pgx.Conn, table string) (map[string]bool, error) {
-	rows, err := conn.Query(ctx, fmt.Sprintf(`SELECT version FROM %s`, table))
+// appliedVersions returns version → the NAME it was applied under.
+//
+// The name is read, not just the version, because the ledger is the only place
+// a renumber is visible. A version recorded under a different name is a
+// database that applied some other migration in that slot — and matching on
+// the version alone makes the two indistinguishable, so the migration actually
+// sitting there is skipped silently and forever.
+func appliedVersions(ctx context.Context, conn *pgx.Conn, table string) (map[string]string, error) {
+	rows, err := conn.Query(ctx, fmt.Sprintf(`SELECT version, name FROM %s`, table))
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
 
-	done := map[string]bool{}
+	done := map[string]string{}
 	for rows.Next() {
-		var v string
-		if err := rows.Scan(&v); err != nil {
+		var version, name string
+		if err := rows.Scan(&version, &name); err != nil {
 			return nil, err
 		}
-		done[v] = true
+		done[version] = name
 	}
 	return done, rows.Err()
+}
+
+// assertLedgerMatches refuses when a version was applied under a different
+// name than the source carries.
+//
+// It is a stop, not a warning, because every continuation from here is wrong
+// in a way nothing later reports. The migration recorded in that slot is not
+// the one on disk, so this run would skip the on-disk one as done; the obvious
+// manual repair — inserting the new version's row — leaves the database
+// permanently missing whatever the skipped migration created, with no failure
+// to point at it. A renumbered migration cannot be reconciled forward: the
+// database has to be rebuilt (make dev-fresh).
+func assertLedgerMatches(namespace string, done map[string]string, m Migration) error {
+	recorded, ok := done[m.Version]
+	if !ok || recorded == m.Name {
+		return nil
+	}
+	return fmt.Errorf(
+		"pgmigrate: %s %s: applied as %q, but the source at that version is %q — this database "+
+			"applied a migration that has since been renumbered, so %q would be skipped as done. "+
+			"It cannot be repaired forward; rebuild the database (make dev-fresh)",
+		namespace, m.Version, recorded, m.Name, m.Name)
 }
 
 func inTx(ctx context.Context, conn *pgx.Conn, fn func(pgx.Tx) error) error {

--- a/backend/internal/platform/dbmigrate/dbmigrate_test.go
+++ b/backend/internal/platform/dbmigrate/dbmigrate_test.go
@@ -131,3 +131,41 @@ func TestTrackingTableRefusesUnspellableNamespaces(t *testing.T) {
 		}
 	}
 }
+
+// A version applied under a different name is a renumber, and it must stop the
+// run rather than read as done.
+//
+// The failure it prevents is silent: the database recorded 0209 against a
+// migration that has since become 0211, so the 0209 now on disk — an unrelated
+// migration — would be skipped as already applied and never create anything it
+// declares. Nothing later reports that; the first symptom is a missing
+// relation at runtime, long after the deploy that caused it.
+func TestALedgerRowNamingADifferentMigrationStopsTheRun(t *testing.T) {
+	t.Parallel()
+	applied := map[string]string{"0209": "drop_workspace_identity_columns"}
+
+	err := assertLedgerMatches("core", applied, Migration{Version: "0209", Name: "person_record_page_v2"})
+	if err == nil {
+		t.Fatal("a version applied under another name read as a match; the migration on disk would be skipped as done")
+	}
+	for _, want := range []string{"drop_workspace_identity_columns", "person_record_page_v2", "dev-fresh"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("the refusal must name both migrations and the repair; %q is missing from %q", want, err)
+		}
+	}
+}
+
+// The same version under the same name is an ordinary already-applied
+// migration, and an unrecorded version is ordinary work to do. Neither may
+// trip the guard, or every run would refuse.
+func TestALedgerRowMatchingItsMigrationIsNotARenumber(t *testing.T) {
+	t.Parallel()
+	applied := map[string]string{"0209": "person_record_page_v2"}
+
+	if err := assertLedgerMatches("core", applied, Migration{Version: "0209", Name: "person_record_page_v2"}); err != nil {
+		t.Errorf("an exact match refused: %v", err)
+	}
+	if err := assertLedgerMatches("core", applied, Migration{Version: "0210", Name: "consumer_mail_create_grant"}); err != nil {
+		t.Errorf("an unapplied version refused: %v", err)
+	}
+}


### PR DESCRIPTION
Two migrations took `0209` last night, `main` stopped loading its core namespace, and the drop was renumbered to `0211`. **That fix is already on `main`** (not this PR). This is the gap it exposed.

## The defect

`Up` writes `(version, name)` but `appliedVersions` reads back `version` alone — so a version recorded under a **different name** is indistinguishable from a correct application.

On any database that applied the drop as `0209` (this tree is shared with parallel sessions that switch branches under each other, and CI ran the branch repeatedly):

1. `0209_person_record_page_v2` → `done["0209"]` is true → **skipped, silently, forever.** None of its tables or columns are ever created.
2. `0210` applies normally.
3. `0211` runs and dies loudly on `column w.name does not exist`.

Step 3 is loud and harmless — the tx rolls back. **The damage is step 1, and step 3 masks it.** The obvious repair for a stuck deploy is to insert the missing ledger row, which leaves the database permanently missing everything the skipped migration declares, with no failure left pointing at it. First symptom is `relation "…" does not exist` from a handler, long after the deploy that caused it.

`Down` is the sharper half: it would run *this* migration's down against the schema the *other* one built, succeed having reverted nothing, and then delete the row that was the only record either had been applied.

## The fix

Read the name, compare it, and stop in both directions — naming both migrations and the repair.

A **stop, not a warning**, because every continuation is wrong in a way nothing later reports, and a renumbered migration cannot be reconciled forward: the database has to be rebuilt (`make dev-fresh`).

## Also

`STATUS.md` still cited `0209` for the identity drop, which now names an unrelated migration.

## Provenance

Both review agents found this independently while reviewing my (now closed, no-op) renumber PR #895 — they also caught that `main` had already been fixed. Worth recording: `required_status_checks.strict` is not enforcing up-to-date branches on `main`, which is how two PRs each claimed `0209` while each was green alone. That is a settings change, not a code one, so it is not in this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `dbmigrate` detect when a migration version was applied under a different name and halt both Up and Down to prevent silent skips and bad rollbacks. Also fix `STATUS.md` to reference `0211` for the identity column drop.

- **Bug Fixes**
  - Read `(version, name)` from the ledger; `appliedVersions` now returns `map[string]string`.
  - Add `assertLedgerMatches` in Up/Down; stop with a clear error that names both migrations and instructs a rebuild (`make dev-fresh`) on mismatch.
  - Add tests for mismatch and match cases.
  - Update `STATUS.md` from `0209` to `0211`.

<sup>Written for commit aaa7f674e45a13a846d764348e3530ffa50db86e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/897?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

