### PR TITLE
docs: a session here may author and commit spec changes upstream

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,14 @@ the spec disagree, the spec wins). Its tree is `specs/` — `specs/subsystems/` 
 the per-module chapters, `specs/contract/` the normative contract, `specs/adr/` the
 decisions; delivery tracking lives at that repo's root in `tooling/`. See
 [CLAUDE.md](CLAUDE.md#where-the-spec-is-read-before-building) for the full map.
-Don't edit the spec from here — raise discrepancies for upstream reconciliation.
+A session here MAY author and commit spec changes in `margince-foundation` — and
+should when a build need requires a spec change first, since contract-first means
+the spec change lands first, not that somebody else writes it. Ship it through
+that repo's own loop (branch off its `origin/main`, own PR, own gates), and treat
+it as the shared tree it is: branch from `origin/main` rather than whatever is
+checked out, stage by explicit path (never `git add -A` — `DECISIONS.md` is
+routinely mid-edit elsewhere), and take ADR/A-numbers from `origin/main`. A change
+that contradicts a ratified ADR is a discrepancy to raise, not an edit to make.
 
 **Start at [STATUS.md](STATUS.md)** — open work and the session-pickup point.
 Read its *Open work, in one screen* index first and open only the sections that

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,8 +62,23 @@ rule 3 those resolve in **git history**, not the working tree — the content ha
 **Contract-first (principle P3): when this code and the spec disagree, the spec wins.**
 Product name **Margince** is locked; older docs say "Gradion CRM" — same product.
 The spec is under active cleanup by another session: some docs still show the old
-`crm-*` layout. Don't edit the spec from here — raise discrepancies for
-upstream reconciliation.
+`crm-*` layout.
+
+**A session working here MAY author and commit spec changes in
+`margince-foundation`**, and should when a build need requires a spec change first
+— contract-first means the spec change LANDS first, not that somebody else writes
+it. It ships through that repo's own loop: branch off its `origin/main`, its own
+PR, its own gates. Four rules make that safe, because it is a second working tree
+that parallel sessions also use:
+
+- **Branch from `origin/main`, never from whatever is checked out.** The local
+  branch is often another session's work in progress.
+- **Stage by explicit path; never `git add -A`.** Shared files — `DECISIONS.md`
+  above all — are routinely mid-edit in another session.
+- **Take ADR and A-numbers from `origin/main`**, which is the only place the real
+  highest number is visible; the checked-out branch lags and collides.
+- **A spec change that contradicts a ratified ADR is a discrepancy, not an edit.**
+  Raise it for reconciliation rather than quietly overwriting a decision.
 
 **Start at [STATUS.md](STATUS.md)** — open work and the session-pickup point.
 Read its *Open work, in one screen* index first and open only the sections that


### PR DESCRIPTION
## What changed

`CLAUDE.md` and `AGENTS.md` both said *"Don't edit the spec from here — raise discrepancies for upstream reconciliation."* That rule is now reversed: a session working in this repo **may** author and commit spec changes in `margince-foundation`, and should when a build need requires a spec change first.

## Why

Contract-first (P3) specifies an **order** — the spec change lands first — not a division of labour. Nothing in it requires a different session to write the spec. The detour added a round trip to every change that needed one, which is most non-trivial features.

## What did NOT change

Four constraints stay, and each maps to a defect that has already happened in that tree:

- **Branch from its `origin/main`**, not from whatever is checked out — the local branch is usually a parallel session's work in progress.
- **Stage by explicit path, never `git add -A`** — `DECISIONS.md` is routinely mid-edit in another session.
- **Take ADR and A-numbers from `origin/main`** — a checked-out branch lags and collides.
- **A change that contradicts a ratified ADR is a discrepancy to raise**, not an edit to make.

## Gates

Both files carry the rule in full, since each is read in isolation. `TestSharedRulebookSectionsAreIdenticalInBothDocs` governs only the three named byte-identical sections (*The write shape*, *License headers*, *Rules learned from the review loop*), none of which this touches. `go test .` in `backend/` and `make check-craft-doc` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow sessions in this repo to author and commit spec changes upstream in `margince-foundation`. This aligns with contract-first so spec changes land first and removes the round trip for non-trivial builds.

- **Rules**
  - Branch from `origin/main`, not the current checkout.
  - Stage by explicit path; never `git add -A` (e.g., `DECISIONS.md` may be mid-edit).
  - Take ADR and A-numbers from `origin/main`.
  - If a change contradicts a ratified ADR, raise a discrepancy instead of editing.

- **Gates**
  - Shared rulebook sections remain untouched; the new rule is added to both docs.
  - `go test .` in `backend/` and `make check-craft-doc` pass.

<sup>Written for commit 7c04745d1054f7d732bc370bcb44d71dbfac15b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/899?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contribution guidance to allow required specification changes in the designated specification repository.
  * Added instructions for branch management, explicit staging, and sourcing identifiers from the main branch.
  * Clarified that conflicts with ratified decisions should be reported as discrepancies rather than modified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->