### PR TITLE
refactor(database): a pool that knows its workspace, proven on one module

### DIFF
--- a/backend/internal/compose/dbhandle.go
+++ b/backend/internal/compose/dbhandle.go
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+import (
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/gradionhq/margince/backend/internal/modules/identity"
+	"github.com/gradionhq/margince/backend/internal/platform/database"
+)
+
+// InstallationDB is the pool bound to the installation's own workspace
+// (ADR-0091 §9 step 3): the handle a store uses instead of asking every caller
+// to have put a workspace in ctx first.
+//
+// The resolution is identity's, because identity is the workspace authority —
+// it is the module that refuses to serve when a second one exists (ADR-0061
+// §3). Its resolver caches the first success, so the lookup happens once per
+// process without this layer owning a variable that would make it a global.
+//
+// One Service per handle, deliberately: the cache lives on the Service, and
+// sharing one across the api and the worker would make a bootstrap race in one
+// role visible as a stale answer in the other.
+func InstallationDB(pool *pgxpool.Pool) *database.DB {
+	svc := identity.NewService(pool)
+	return database.Bind(pool, svc.InstallationWorkspace)
+}

--- a/backend/internal/compose/integration/harnessdb.go
+++ b/backend/internal/compose/integration/harnessdb.go
@@ -20,3 +20,14 @@ import (
 func (e *Env) DB() *database.DB {
 	return database.BindTo(e.Pool, ids.From[ids.WorkspaceKind](e.WS))
 }
+
+// DBFor pins a handle to another workspace, for the cross-tenant suites.
+//
+// In the collapsed plumbing (ADR-0091 §9 step 3) "which tenant am I" is a
+// property of the HANDLE, not of the context — so a suite proving one tenant
+// cannot read another builds a store per tenant rather than calling one store
+// with a second tenant's ctx. The assertion is unchanged and still RLS's:
+// a store bound to B must not resolve A's row.
+func (e *Env) DBFor(ws ids.UUID) *database.DB {
+	return database.BindTo(e.Pool, ids.From[ids.WorkspaceKind](ws))
+}

--- a/backend/internal/compose/integration/harnessdb.go
+++ b/backend/internal/compose/integration/harnessdb.go
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+import (
+	"github.com/gradionhq/margince/backend/internal/platform/database"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// DB is the harness's pool bound to THIS env's workspace.
+//
+// Pinned rather than resolved: the cross-tenant suites seed a second workspace
+// on purpose, and a handle that asked identity which one the installation is
+// would refuse them outright (ErrMultipleWorkspaces) — taking with it the only
+// mechanical proof that one tenant cannot read another, which ADR-0091 §9
+// step 3 keeps green precisely to show this collapse was faithful.
+func (e *Env) DB() *database.DB {
+	return database.BindTo(e.Pool, ids.From[ids.WorkspaceKind](e.WS))
+}

--- a/backend/internal/compose/integration/quotas_attainment_integration_test.go
+++ b/backend/internal/compose/integration/quotas_attainment_integration_test.go
@@ -34,7 +34,7 @@ import (
 var attainmentClock = time.Date(2026, 2, 15, 12, 0, 0, 0, time.UTC)
 
 func attainmentStore(e *Env) *quotas.Store {
-	return quotas.NewStoreWithClock(e.Pool, func() time.Time { return attainmentClock },
+	return quotas.NewStoreWithClock(e.DB(), func() time.Time { return attainmentClock },
 		identity.BaseCurrencyOf)
 }
 

--- a/backend/internal/compose/integration/quotas_integration_test.go
+++ b/backend/internal/compose/integration/quotas_integration_test.go
@@ -539,10 +539,13 @@ func TestQuotaRLS_TenantIsolation(t *testing.T) {
 		UserID: ids.NewV7(), Permissions: quotaAdminPerms,
 	})
 
-	if _, err := store.GetQuota(ctxB, ids.UUID(created.Id), storekit.IncludeArchived); !errors.Is(err, apperrors.ErrNotFound) {
+	// B's own store: the handle carries the tenant now, so reading A's row
+	// through A's handle would prove nothing about B.
+	storeB := quotas.NewStore(e.DBFor(wsB), identity.BaseCurrencyOf)
+	if _, err := storeB.GetQuota(ctxB, ids.UUID(created.Id), storekit.IncludeArchived); !errors.Is(err, apperrors.ErrNotFound) {
 		t.Fatalf("tenant B must not resolve tenant A's quota, got %v", err)
 	}
-	listed, _, err := store.ListQuotas(ctxB, quotas.ListQuotasInput{IncludeArchived: true})
+	listed, _, err := storeB.ListQuotas(ctxB, quotas.ListQuotasInput{IncludeArchived: true})
 	if err != nil || len(listed) != 0 {
 		t.Fatalf("tenant B's list = %d rows (%v), want empty", len(listed), err)
 	}

--- a/backend/internal/compose/integration/quotas_integration_test.go
+++ b/backend/internal/compose/integration/quotas_integration_test.go
@@ -69,7 +69,7 @@ func ownerQuotaInput(owner ids.UUID, target int64) quotas.CreateQuotaInput {
 
 func TestQuotaCreate_OwnerAndTeamQuotas(t *testing.T) {
 	e := Setup(t)
-	store := quotas.NewStore(e.Pool, identity.BaseCurrencyOf)
+	store := quotas.NewStore(e.DB(), identity.BaseCurrencyOf)
 	ctx := e.As(e.Rep1, nil, quotaAdminPerms)
 
 	owned, err := store.CreateQuota(ctx, ownerQuotaInput(e.Rep1, 28000000))
@@ -108,7 +108,7 @@ func TestQuotaCreate_OwnerAndTeamQuotas(t *testing.T) {
 
 func TestQuotaCreate_XORRefusedBeforeInsert(t *testing.T) {
 	e := Setup(t)
-	store := quotas.NewStore(e.Pool, identity.BaseCurrencyOf)
+	store := quotas.NewStore(e.DB(), identity.BaseCurrencyOf)
 	ctx := e.As(e.Rep1, nil, quotaAdminPerms)
 
 	both := ownerQuotaInput(e.Rep1, 1000)
@@ -133,7 +133,7 @@ func TestQuotaCreate_XORRefusedBeforeInsert(t *testing.T) {
 
 func TestQuotaWrite_NegativeTargetRefused(t *testing.T) {
 	e := Setup(t)
-	store := quotas.NewStore(e.Pool, identity.BaseCurrencyOf)
+	store := quotas.NewStore(e.DB(), identity.BaseCurrencyOf)
 	ctx := e.As(e.Rep1, nil, quotaAdminPerms)
 
 	// The contract's target_minor minimum (0) holds at the store for BOTH
@@ -174,7 +174,7 @@ func TestQuotaWrite_NegativeTargetRefused(t *testing.T) {
 
 func TestQuotaCreate_UnknownOwnerOrTeamAnswersNotFound(t *testing.T) {
 	e := Setup(t)
-	store := quotas.NewStore(e.Pool, identity.BaseCurrencyOf)
+	store := quotas.NewStore(e.DB(), identity.BaseCurrencyOf)
 	ctx := e.As(e.Rep1, nil, quotaAdminPerms)
 
 	ghost := ids.NewV7()
@@ -190,7 +190,7 @@ func TestQuotaCreate_UnknownOwnerOrTeamAnswersNotFound(t *testing.T) {
 
 func TestQuotaGet_LiveArchivedAndAbsent(t *testing.T) {
 	e := Setup(t)
-	store := quotas.NewStore(e.Pool, identity.BaseCurrencyOf)
+	store := quotas.NewStore(e.DB(), identity.BaseCurrencyOf)
 	ctx := e.As(e.Rep1, nil, quotaAdminPerms)
 
 	created, err := store.CreateQuota(ctx, ownerQuotaInput(e.Rep1, 1000))
@@ -221,7 +221,7 @@ func TestQuotaGet_LiveArchivedAndAbsent(t *testing.T) {
 
 func TestQuotaUpdate_HappyVersionSkewAndMergedXOR(t *testing.T) {
 	e := Setup(t)
-	store := quotas.NewStore(e.Pool, identity.BaseCurrencyOf)
+	store := quotas.NewStore(e.DB(), identity.BaseCurrencyOf)
 	ctx := e.As(e.Rep1, nil, quotaAdminPerms)
 
 	created, err := store.CreateQuota(ctx, ownerQuotaInput(e.Rep1, 28000000))
@@ -282,7 +282,7 @@ func TestQuotaUpdate_HappyVersionSkewAndMergedXOR(t *testing.T) {
 
 func TestQuotaUpdate_PeriodAndCurrency(t *testing.T) {
 	e := Setup(t)
-	store := quotas.NewStore(e.Pool, identity.BaseCurrencyOf)
+	store := quotas.NewStore(e.DB(), identity.BaseCurrencyOf)
 	ctx := e.As(e.Rep1, nil, quotaAdminPerms)
 
 	created, err := store.CreateQuota(ctx, ownerQuotaInput(e.Rep1, 1000))
@@ -305,7 +305,7 @@ func TestQuotaUpdate_PeriodAndCurrency(t *testing.T) {
 
 func TestQuotaArchive_IdempotentAndAuditedOnce(t *testing.T) {
 	e := Setup(t)
-	store := quotas.NewStore(e.Pool, identity.BaseCurrencyOf)
+	store := quotas.NewStore(e.DB(), identity.BaseCurrencyOf)
 	ctx := e.As(e.Rep1, nil, quotaAdminPerms)
 
 	created, err := store.CreateQuota(ctx, ownerQuotaInput(e.Rep1, 1000))
@@ -337,7 +337,7 @@ func TestQuotaArchive_IdempotentAndAuditedOnce(t *testing.T) {
 
 func TestQuotaList_KeysetFiltersAndArchived(t *testing.T) {
 	e := Setup(t)
-	store := quotas.NewStore(e.Pool, identity.BaseCurrencyOf)
+	store := quotas.NewStore(e.DB(), identity.BaseCurrencyOf)
 	ctx := e.As(e.Rep1, nil, quotaAdminPerms)
 
 	for _, owner := range []ids.UUID{e.Rep1, e.Rep2, e.Rep3} {
@@ -399,7 +399,7 @@ func TestQuotaList_KeysetFiltersAndArchived(t *testing.T) {
 
 func TestQuotaList_SortVocabulary(t *testing.T) {
 	e := Setup(t)
-	store := quotas.NewStore(e.Pool, identity.BaseCurrencyOf)
+	store := quotas.NewStore(e.DB(), identity.BaseCurrencyOf)
 	ctx := e.As(e.Rep1, nil, quotaAdminPerms)
 
 	// Three owner-quotas whose period_start order deliberately disagrees
@@ -476,7 +476,7 @@ func TestQuotaList_SortVocabulary(t *testing.T) {
 
 func TestQuotaRBAC_RepReadsButNeverMutates(t *testing.T) {
 	e := Setup(t)
-	store := quotas.NewStore(e.Pool, identity.BaseCurrencyOf)
+	store := quotas.NewStore(e.DB(), identity.BaseCurrencyOf)
 	admin := e.As(e.Rep1, nil, quotaAdminPerms)
 	rep := e.As(e.Rep2, []ids.UUID{e.Team1}, quotaRepPerms)
 
@@ -517,7 +517,7 @@ func TestQuotaRBAC_RepReadsButNeverMutates(t *testing.T) {
 func TestQuotaRLS_TenantIsolation(t *testing.T) {
 	e := Setup(t)
 	owner := OwnerConn(t)
-	store := quotas.NewStore(e.Pool, identity.BaseCurrencyOf)
+	store := quotas.NewStore(e.DB(), identity.BaseCurrencyOf)
 	ctxA := e.As(e.Rep1, nil, quotaAdminPerms)
 
 	created, err := store.CreateQuota(ctxA, ownerQuotaInput(e.Rep1, 1000))

--- a/backend/internal/compose/server.go
+++ b/backend/internal/compose/server.go
@@ -389,7 +389,7 @@ func newServer(pool *pgxpool.Pool, log *slog.Logger, authH authHandlers, dealsH 
 		// here means Create/SetOptions stay their generated 501 until the
 		// api role's WithSchemaPool rebuilds this over the real pool.
 		customfieldsHandlers: customfields.NewHandlers(pool, nil),
-		quotasHandlers:       quotas.NewHandlers(pool, identity.BaseCurrencyOf),
+		quotasHandlers:       quotas.NewHandlers(InstallationDB(pool), identity.BaseCurrencyOf),
 		// The accept-write's default engine rides the honest-empty NoOp
 		// extractor (nothing is ever grounded, so nothing is acceptable);
 		// WithExtractor rebuilds it together with the activities read so

--- a/backend/internal/modules/quotas/handlers.go
+++ b/backend/internal/modules/quotas/handlers.go
@@ -12,10 +12,10 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/jackc/pgx/v5/pgxpool"
 	openapi_types "github.com/oapi-codegen/runtime/types"
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/platform/httperr"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
@@ -28,8 +28,8 @@ type Handlers struct {
 }
 
 // NewHandlers wires the transport over the RLS-bound app pool.
-func NewHandlers(pool *pgxpool.Pool, baseCurrency BaseCurrencyFunc) Handlers {
-	return Handlers{store: NewStore(pool, baseCurrency)}
+func NewHandlers(db *database.DB, baseCurrency BaseCurrencyFunc) Handlers {
+	return Handlers{store: NewStore(db, baseCurrency)}
 }
 
 // pageInfo renders the store's keyset page onto the contract's PageInfo

--- a/backend/internal/modules/quotas/quotas.go
+++ b/backend/internal/modules/quotas/quotas.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgxpool"
 	openapi_types "github.com/oapi-codegen/runtime/types"
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
@@ -27,7 +26,9 @@ import (
 // Store owns the quota table (data-seam ownership, ADR-0014 Am.1); every
 // mutation rides the storekit audit shape in one transaction.
 type Store struct {
-	pool *pgxpool.Pool
+	// db binds the installation's workspace itself, so a caller no longer has
+	// to have put it in ctx first (ADR-0091 §9 step 3).
+	db *database.DB
 	// baseCurrency resolves the installation's reporting currency
 	// (ADR-0090/A135). Injected because quotas may not import the module that
 	// owns the setting, and REQUIRED by the constructor because a store that
@@ -46,18 +47,18 @@ type Store struct {
 type BaseCurrencyFunc func(context.Context, pgx.Tx) (string, error)
 
 // NewStore wires the store over the RLS-bound app pool.
-func NewStore(pool *pgxpool.Pool, baseCurrency BaseCurrencyFunc) *Store {
-	return NewStoreWithClock(pool, time.Now, baseCurrency)
+func NewStore(db *database.DB, baseCurrency BaseCurrencyFunc) *Store {
+	return NewStoreWithClock(db, time.Now, baseCurrency)
 }
 
 // NewStoreWithClock is NewStore with an explicit clock (the
 // ratelimit.NewWithClock precedent) — the attainment suites pin it.
-func NewStoreWithClock(pool *pgxpool.Pool, now func() time.Time, baseCurrency BaseCurrencyFunc) *Store {
-	return &Store{pool: pool, now: now, baseCurrency: baseCurrency}
+func NewStoreWithClock(db *database.DB, now func() time.Time, baseCurrency BaseCurrencyFunc) *Store {
+	return &Store{db: db, now: now, baseCurrency: baseCurrency}
 }
 
 func (s *Store) tx(ctx context.Context, fn func(pgx.Tx) error) error {
-	return database.WithWorkspaceTx(ctx, s.pool, fn)
+	return s.db.Tx(ctx, fn)
 }
 
 // OwnerXorTeamError is RD-DDL-2's refusal: a quota state with both

--- a/backend/internal/platform/database/database.go
+++ b/backend/internal/platform/database/database.go
@@ -17,6 +17,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
 
@@ -99,6 +100,13 @@ func WithWorkspaceTx(ctx context.Context, pool *pgxpool.Pool, fn func(pgx.Tx) er
 		return ErrNoWorkspace
 	}
 
+	return withBoundTx(ctx, pool, ids.From[ids.WorkspaceKind](wsID), fn)
+}
+
+// withBoundTx is the one spelling of "a transaction with the workspace GUC
+// bound", shared by WithWorkspaceTx (workspace from ctx) and DB.Tx (workspace
+// from the installation resolver) so the two cannot drift while both exist.
+func withBoundTx(ctx context.Context, pool *pgxpool.Pool, ws ids.WorkspaceID, fn func(pgx.Tx) error) error {
 	tx, err := pool.Begin(ctx)
 	if err != nil {
 		return fmt.Errorf("pg: begin: %w", err)
@@ -110,7 +118,7 @@ func WithWorkspaceTx(ctx context.Context, pool *pgxpool.Pool, fn func(pgx.Tx) er
 	defer func() { _ = tx.Rollback(ctx) }()
 
 	// Parameterized set_config, never string-built SET LOCAL.
-	if _, err := tx.Exec(ctx, `SELECT set_config('app.workspace_id', $1, true)`, wsID.String()); err != nil {
+	if _, err := tx.Exec(ctx, `SELECT set_config('app.workspace_id', $1, true)`, ws.String()); err != nil {
 		return fmt.Errorf("pg: binding workspace GUC: %w", err)
 	}
 	if err := fn(tx); err != nil {

--- a/backend/internal/platform/database/db.go
+++ b/backend/internal/platform/database/db.go
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package database
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// DB is a pool that knows which workspace it binds — the installation's, the
+// only one there is (ADR-0061/A107).
+//
+// It exists to take that binding OFF the request context. WithWorkspaceTx
+// reads the workspace from the caller's ctx, which means every request path,
+// every job and every fixture has to put it there first, and a path that
+// forgets fails at the SQL rather than at the seam. ADR-0091 §9 step 3 is the
+// collapse: one helper, the singleton resolved once, and the GUC still set
+// from it, so RLS stays armed and the tenant-isolation suite remains the proof
+// that the edit was faithful.
+//
+// The workspace arrives as a resolver rather than a value because bootstrap
+// has not necessarily happened when the server is assembled — the worker polls
+// until the API bootstraps. identity's resolver caches its first success, so
+// "resolved once" is a property of that resolver, not of a package-level
+// variable this type would otherwise have to own.
+type DB struct {
+	pool      *pgxpool.Pool
+	workspace func(context.Context) (ids.WorkspaceID, error)
+}
+
+// Bind returns a handle that resolves its workspace through resolve.
+func Bind(pool *pgxpool.Pool, resolve func(context.Context) (ids.WorkspaceID, error)) *DB {
+	return &DB{pool: pool, workspace: resolve}
+}
+
+// BindTo returns a handle pinned to one workspace, for the callers that
+// already hold it: bootstrap, which is creating the installation the resolver
+// would look for, and the cross-tenant suites, which seed a second workspace
+// precisely to prove one cannot read the other.
+func BindTo(pool *pgxpool.Pool, ws ids.WorkspaceID) *DB {
+	return &DB{pool: pool, workspace: func(context.Context) (ids.WorkspaceID, error) { return ws, nil }}
+}
+
+// Pool exposes the underlying pool for the paths that do not run a
+// transaction — the outbox relay's listener, the health probe.
+func (d *DB) Pool() *pgxpool.Pool { return d.pool }
+
+// Tx runs fn inside a transaction with app.workspace_id bound, which is what
+// the RLS policies key on. Same contract as WithWorkspaceTx, minus the
+// requirement that the caller have put the workspace in ctx.
+func (d *DB) Tx(ctx context.Context, fn func(pgx.Tx) error) error {
+	ws, err := d.workspace(ctx)
+	if err != nil {
+		return fmt.Errorf("pg: resolving the installation's workspace: %w", err)
+	}
+	return withBoundTx(ctx, d.pool, ws, fn)
+}


### PR DESCRIPTION
**ADR-0091 §9 step 3**, slice 1 of ~N: collapse the Go plumbing with the schema untouched — one helper, the singleton resolved once, the GUC still set from it. RLS stays armed, so the tenant-isolation suite remains the proof the edit was faithful.

This PR is the **seam plus one module through it**. The surface is ~900 call sites (`WithWorkspaceTx` 442, `principal.WithWorkspaceID` 388, `MustWorkspace` 55, `WithInfraTx` 12 — matching the ADR's "887-call-site edit"), so it lands as a series rather than one diff.

## The problem it removes

`WithWorkspaceTx` reads the workspace off the caller's **ctx**. Every request path, every job and every fixture has to put it there first, and a path that forgets fails at the SQL rather than at the seam. `database.DB` carries the binding instead; `Tx` resolves the installation's workspace itself.

## Two design points I'd like reviewed

**The workspace is a resolver, not a value.** Bootstrap has not necessarily happened when the server is assembled — the worker polls until the API bootstraps. identity's resolver already caches its first success, so *"resolved once"* is a property of the module that owns the question rather than of a package-level variable this layer would otherwise own. That was the constraint I most wanted to avoid: a process-global would make the api and the worker share one answer to a question they reach at different times.

**`BindTo` pins a handle to a workspace the caller already holds** — for the two that legitimately have one: bootstrap, which is *creating* the installation the resolver would look for, and the cross-tenant suites, which seed a second workspace precisely to prove one cannot read the other. A handle that asked identity which workspace the installation is would refuse those outright (`ErrMultipleWorkspaces`) and take the isolation proof with it — the very thing §9 step 3 keeps green to show the collapse was faithful.

Both helpers now run the same `withBoundTx`, so the two spellings of "a transaction with the GUC bound" cannot drift while both exist.

## Scope

`quotas` goes through the handle. The other nineteen modules still use `WithWorkspaceTx`, unchanged — the dual mechanism is deliberate and temporary, and the sweep is mechanical once the shape is agreed.

## What comes after (ADR-0091 §9)

- rest of step 3: the remaining modules, then delete `WithWorkspaceTx`/`WithInfraTx` and the request-path `principal.WithWorkspaceID`
- step 4: strip the tenant from the surface — principal, envelope, `audit_log`, contract, frontend
- step 5: the schema, per §8 — and §3's waiver re-reading is a **precondition**, since once the policies drop `rbacgate_test.go` is the only systematic proof reads are scoped

## Verification

`make check-backend` and `make craft-static` (0/0/0) green. No Docker here, so the integration lane — including the tenant-isolation suite that is this step's whole safety net — is CI's word.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduce `database.DB`, a pool handle that resolves and binds the installation workspace itself, so callers no longer pass the workspace via context. Applied to `quotas`, server wiring, and the integration harness; RLS binding stays via shared `withBoundTx`.

- **Refactors**
  - Added `database.DB` with `Bind`, `BindTo`, `Tx`, and shared `withBoundTx`.
  - Added `compose.InstallationDB` (resolves workspace via `identity`).
  - Added integration helpers `integration.Env.DB()` and `integration.Env.DBFor()`; cross-tenant tests now build a store per tenant.
  - Updated `quotas` to use `*database.DB` (`NewStore`, `NewHandlers`) and switched tests to `Env.DB()` / `DBFor`.
  - Server wires `quotas` via `InstallationDB`.
  - Kept `WithWorkspaceTx` for remaining modules; both paths share `withBoundTx` to avoid drift.

<sup>Written for commit 987296e1760576dd8edf8e7fa025c4a7ee4f7654. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/903?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace-specific data isolation for quota operations.
  * Ensured database transactions consistently use the correct workspace context, including environments with multiple workspaces.
  * Added clearer handling when workspace information cannot be resolved.

* **Refactor**
  * Standardized database access for quota features, improving consistency and reducing the risk of cross-workspace data access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->