### PR TITLE
fix(frontend): a unit's screen names its own page, and the shell yields to it

### DIFF
--- a/docs/how-to/add-an-extension.md
+++ b/docs/how-to/add-an-extension.md
@@ -337,6 +337,12 @@ so `frontend/scripts/check-ext-imports.sh` is the boundary. It refuses a relativ
 unit, an unpublished subpath, and any bare specifier your own `package.json` does not declare —
 `devDependencies` count for test files only, so a screen cannot pull a test runner into the bundle.
 
+**Name your page in a level-1 header, exactly once.** The app shell mints the page's `h1` for a core
+screen, but it *yields* to a composed unit — your surface is yours to name, and the shell has no title
+key for a route the NAV rail deliberately does not carry. So your screen's top
+`<SectionHeader …  level={1} />` IS the page's heading, and every header under it stays at the default
+`2`. Leave the top one at the default and your page ships with no heading for a reader to jump to.
+
 The four design-system gates (`ds-purity`, `icon-lint`, `ds-spacing`, `native-controls`) sweep your
 unit exactly as they sweep core.
 

--- a/extensions/notes/frontend/screen.test.tsx
+++ b/extensions/notes/frontend/screen.test.tsx
@@ -114,6 +114,24 @@ afterEach(() => {
 });
 
 describe("the Demo Notepad screen", () => {
+  // The app shell yields the page's name to a composed unit, so this screen's
+  // own top header is the page's ONE h1 — and every card header under it stays
+  // at level 2. A unit that leaves its top header at the default ships a surface
+  // with no page-level heading for a reader to jump to, which is what the shell
+  // used to paper over by printing "Not found" there instead.
+  it("names the page in the one level-1 heading a unit screen owns", async () => {
+    const { fetchStub } = stubTransport(FULL_GRANT, {
+      "/ext/notes/list": () => ({ notes: [] }),
+      "/ext/notes/signing-key/status": () => ({ stored: false }),
+    });
+    vi.stubGlobal("fetch", vi.fn(fetchStub));
+
+    renderScreen();
+    const h1 = await screen.findByRole("heading", { level: 1 });
+    expect(h1.textContent).toBe("Demo Notepad");
+    expect(screen.getAllByRole("heading", { level: 1 })).toHaveLength(1);
+  });
+
   it("lists the workspace's notes, heartbeat rows included", async () => {
     const { fetchStub } = stubTransport(FULL_GRANT, {
       "/ext/notes/list": () => ({

--- a/extensions/notes/frontend/screen.tsx
+++ b/extensions/notes/frontend/screen.tsx
@@ -79,7 +79,15 @@ export default function NotesScreen() {
   const t = useT();
   return (
     <div className="wrap narrow">
-      <SectionHeader title={t("extNotes.title")} sub={t("extNotes.sub")} />
+      {/* level 1, and this is the rule for a unit screen rather than a choice
+          this one made: the app shell yields the page's name to a composed unit,
+          so the screen's own top header IS the page's h1. Every other header
+          under it stays at the default 2. */}
+      <SectionHeader
+        title={t("extNotes.title")}
+        sub={t("extNotes.sub")}
+        level={1}
+      />
       <SigningCard />
       <NotesCard />
     </div>

--- a/frontend/src/App.extscreen.test.tsx
+++ b/frontend/src/App.extscreen.test.tsx
@@ -93,6 +93,25 @@ describe("extension routes (composed screen registry)", () => {
     expect(screen.queryByText("Published operations")).toBeNull();
   });
 
+  // The unit owns its surface, so it owns the page's name. The shell mints an
+  // h1 from the NAV rail entry or the off-rail title map, and a unit route is
+  // deliberately in neither — so the head fell through to `shell.unknownPage`
+  // and printed "Not found" at heading level, above a screen the installation
+  // plainly answers. The head has to yield here for the same reason it yields
+  // to a record: two page titles for one page, and the wrong one is the h1.
+  it("gives the page's one h1 to the unit's own screen", async () => {
+    window.location.hash = "#/ext/notes";
+    renderApp();
+    expect(
+      await screen.findByRole("heading", { level: 1, name: "Demo Notepad" }),
+    ).toBeTruthy();
+    // The COUNT is the assertion that bites: the shell's own h1 renders empty in
+    // this harness (the catalogue loads a tick later), so asserting on the
+    // "Not found" text here would pass without the head yielding at all. That
+    // half of the rule is pinned in shell.test.tsx, where the copy is settled.
+    expect(screen.getAllByRole("heading", { level: 1 })).toHaveLength(1);
+  });
+
   // The registry lookup must answer for the unit's OWN entries only. Read off a
   // plain object, `extensionScreens["constructor"]` is Object itself — truthy,
   // and a function, so the dispatch mounts it and the route dies where it
@@ -102,6 +121,19 @@ describe("extension routes (composed screen registry)", () => {
     renderApp();
     expect(await screen.findByText("Published operations")).toBeTruthy();
     expect(await screen.findByText(/Ping/)).toBeTruthy();
+  });
+
+  // A unit with no screen still owns the page: once the head yields to the unit,
+  // the descriptor card is the only thing left that can name it, so its header
+  // is the h1. Otherwise this route has no page-level heading at all — a worse
+  // outcome than the wrong one, because there is nothing for a reader to jump to.
+  it("gives the h1 to the descriptor card when the unit ships no screen", async () => {
+    window.location.hash = "#/ext/constructor";
+    renderApp();
+    expect(
+      await screen.findByRole("heading", { level: 1, name: "constructor" }),
+    ).toBeTruthy();
+    expect(screen.getAllByRole("heading", { level: 1 })).toHaveLength(1);
   });
 
   it("does not render a screen for a unit the installation did not compose", async () => {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -165,7 +165,10 @@ function ExtensionRoute({ name }: Readonly<{ name?: string }>) {
   }
   return (
     <div className="wrap narrow">
-      <SectionHeader title={unit.name} sub={t("ext.operations")} />
+      {/* level 1: the head yields to a composed unit, so this card is the only
+          thing left that can name the page. A unit with no screen would
+          otherwise have no page-level heading at all. */}
+      <SectionHeader title={unit.name} sub={t("ext.operations")} level={1} />
       <Card>
         <ul>
           {unit.verbs.map((verb) => (

--- a/frontend/src/app/shell.test.tsx
+++ b/frontend/src/app/shell.test.tsx
@@ -389,6 +389,20 @@ describe("PageHead", () => {
     expect(document.body.textContent).not.toContain("nope");
   });
 
+  // An extension route the installation does NOT answer keeps the unknown-page
+  // heading, and that is the deliberate half of the head's yield to a unit: the
+  // yield is conditioned on the descriptor resolving, so a hand-typed
+  // `#/ext/<anything>` is an unknown page here exactly as it is under the head,
+  // where the screen says so in words. This is the vanilla registry, where EVERY
+  // unit route is unknown — the composed half is pinned in App.extscreen.test.tsx.
+  it("names an extension route this installation did not compose", () => {
+    render(<PageHead route={{ screen: "ext", id: "notes" }} />);
+    expect(
+      screen.getByRole("heading", { level: 1, name: "Not found" }),
+    ).toBeTruthy();
+    expect(document.body.textContent).not.toContain("notes");
+  });
+
   // A record names itself: its surface prints the identity block, and that is
   // the page's one h1. The head yields — it prints the trail that leads here
   // and nothing at heading level, or the document would offer two page titles

--- a/frontend/src/app/shell.tsx
+++ b/frontend/src/app/shell.tsx
@@ -18,6 +18,7 @@ import { AgentDock } from "./agentdock";
 import { EconomyBanner } from "./economybanner";
 import { EmbedReindexBanner } from "./embedreindexbanner";
 import { type EntityKind, SCREEN_ENTITY } from "./entity";
+import { EXTENSION_SCREEN, findExtension } from "./extensions";
 import {
   BADGE_SCREENS,
   MOBILE_PRIMARY,
@@ -491,6 +492,24 @@ export function PageHead({
   // screen. Printing that slug as the page's name gave Settings an h1 reading
   // "privacy".
   const recordKind = route.id ? SCREEN_ENTITY[route.screen] : undefined;
+  // A composed unit names its own page, so the head yields to it exactly as it
+  // yields to a record — and for the same reason: the unit's screen prints its
+  // name, and a second one at heading level would leave a screen reader picking
+  // between two page titles.
+  //
+  // Conditioned on the DESCRIPTOR resolving, not on the screen slug alone. A
+  // unit route is deliberately absent from both the NAV rail and
+  // OFF_RAIL_TITLE_KEYS, so resolveTitle fell through to shell.unknownPage and
+  // printed "Not found" over every unit surface an installation answers. But a
+  // unit this installation did not compose is genuinely an unknown page, and the
+  // screen under it says so in words — so that case keeps the heading rather
+  // than yielding to a surface that will not name itself either.
+  //
+  // No crumb, unlike a record: a record's trail leads back to its list, and
+  // there is no `#/ext` index to lead back to. Task 13/14 owns a unit's place in
+  // the rail; when it lands, this is where a trail would go.
+  const unitNamesPage =
+    route.screen === EXTENSION_SCREEN && findExtension(route.id) !== null;
 
   return (
     <header className="pagehead">
@@ -502,7 +521,7 @@ export function PageHead({
             head yields and shows the trail that leads here instead. Printing
             the name twice, once at heading level and once beside the avatar,
             would leave a screen reader picking between two page titles. */}
-        {recordKind && route.id ? (
+        {unitNamesPage ? null : recordKind && route.id ? (
           <p className="pagecrumb">
             <a className="pageback" href={routeHash({ screen: route.screen })}>
               {navItem && (


### PR DESCRIPTION
Every extension route printed **"Not found"** as its page heading, above a screen the installation plainly answers. `#/ext/notes` rendered the Demo Notepad — signing card, notes list, working Add and Remove — under an `h1` saying the page did not exist.

**Found by opening a browser, not by a suite.** Every lane was green while the heading was wrong, because nothing asserted what the shell mints for a route that no title map names. Worth stating plainly, because it is the gap this PR closes as much as the heading is.

## Why it happened

The shell mints the page's one `h1` from the NAV rail entry, falling back to `OFF_RAIL_TITLE_KEYS`, then to `shell.unknownPage`. A unit route is deliberately in **neither** map: `NAV_GROUPS` is the canonical ten-item list whose order `shell.test.tsx` pins, and a unit's place in the rail is a later task's decision (`app/extensions.ts` says so, and flags `RAIL_LESS_SCREENS` for review at the same time). So `resolveTitle` fell all the way through, and the fallback that exists for "an address nobody in this app answers" answered for an address the product does answer.

**Not a regression from #878.** `main` had the same wrong heading over the generic descriptor card before that PR — this branch touches neither `shell.tsx` nor `nav.ts` history. #878 only made it conspicuous by putting a real screen under it.

## The fix

The head now **yields** to a composed unit exactly as it yields to a record, and for the same reason: the unit's screen prints its own name, so a second name at heading level would leave a screen reader picking between two page titles.

```
const unitNamesPage =
  route.screen === EXTENSION_SCREEN && findExtension(route.id) !== null;
```

Three things about that condition:

- **It gates on the DESCRIPTOR, not the screen slug.** A unit this installation did not compose is genuinely an unknown page — the screen under it says so in words — so `#/ext/anything-else` keeps the unknown-page heading. This is the same gate `App.tsx`'s dispatch already uses: the descriptor decides, and a registry entry is not a route.
- **No crumb, unlike a record.** A record's trail leads back to its list; there is no `#/ext` index to lead back to. Where a trail would go is marked for the task that owns a unit's place in the rail.
- **Two surfaces must now supply the `h1`**, or the yield trades a wrong heading for no heading:
  - `extensions/notes/frontend/screen.tsx` — its top `SectionHeader` is `level={1}`, and that is the **rule for a unit screen** rather than this one's choice. Card headers under it stay at `2`.
  - `App.tsx`'s descriptor card — a unit that ships no screen still owns its page, and once the head yields the card is the only thing left that can name it.

`docs/how-to/add-an-extension.md` gains that rule, because it is now a contract every future unit author is subject to and it was written down nowhere: leave your top header at the default and your page ships with no heading for a reader to jump to.

## Tests — four cases, each verified failing first

| Where | What it pins |
|---|---|
| `App.extscreen.test.tsx` | a composed unit's page has exactly **one** `h1` and it is the unit's |
| `App.extscreen.test.tsx` | a **screenless** unit's descriptor card carries the `h1` |
| `shell.test.tsx` | an extension route this installation did **not** compose still names itself "Not found" |
| `extensions/notes/frontend/screen.test.tsx` | the real unit screen owns the one `h1` |

Two notes on how those are written, because both bit me:

- In `App.extscreen.test.tsx` the **count** is the load-bearing assertion. The shell's `h1` renders *empty* in that harness (the catalogue lands a tick later), so asserting on the "Not found" text there would have passed without the head yielding at all. I removed that assertion rather than leave one that proves nothing, and pinned the text half in `shell.test.tsx` where the copy is settled.
- The `notes` screen case was written after its production change, so I confirmed it bites by removing `level={1}` and watching it fail (`Unable to find role="heading"`), then restoring.

## Verification

| | |
|---|---|
| `make check-fe` | **exit 0** — 186/186 files, **2278** tests (+3), unit lane **8/8** |
| `make ci-doc-parity` | OK — 41 paths from `ci.yml`, 12 from `sbom.yml` |
| `check-ext-imports.sh` | PASS on the changed `screen.tsx` |

Diff is three lines of logic plus `level={1}` twice; the rest is tests and the how-to paragraph.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes extension pages that showed "Not found" as the page heading. The shell now yields the single page title to composed units; screens own the h1, and only unknown extension routes show "Not found".

- **Bug Fixes**
  - Yield the `h1` to a composed unit when its descriptor resolves; avoids duplicate titles and no crumb is shown.
  - Set the Demo Notepad screen’s top `SectionHeader` to `level={1}`; subheaders remain level 2.
  - For units without a screen, the descriptor card in `App.tsx` now owns the `h1`.
  - Keep "Not found" for uncomposed extension routes; tests cover all cases and docs note the rule.

<sup>Written for commit ff77488c8326f9c6f803c2528d5b7190873064b9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/904?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

