### PR TITLE
fix(frontend): the composed lane builds the MCP App view documents too

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,7 +24,7 @@
     "gen:events": "openapi-typescript ../backend/api/public-events.yaml --enum-values -o src/api/public-events.ts",
     "gen:composed-types": "openapi-typescript ../build/composition/api/crm.yaml -o ../build/composition-frontend/schema.d.ts",
     "gen:events:composed": "openapi-typescript ../build/composition/api/public-events.yaml --enum-values -o src/api/public-events.ts",
-    "build:composed": "tsc -p tsconfig.composed.json && vite build",
+    "build:composed": "tsc -p tsconfig.composed.json && vite build && node scripts/build-mcp-apps.mjs",
     "e2e": "pnpm build && playwright test",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build -o storybook-static"


### PR DESCRIPTION
## The symptom

The deployed `web` image ships **no MCP App view documents**. Measured on staging today:

```
$ kubectl -n margince-staging exec web-application-… -- ls /usr/share/nginx/html/
50x.html  assets  icon-maskable.svg  icon.svg  index.html  manifest.webmanifest

$ … -- ls /usr/share/nginx/html/mcp-apps/
ls: /usr/share/nginx/html/mcp-apps/: No such file or directory
```

`nginx.conf`'s `location /mcp-apps/` block is in the image, and it answers
`try_files $uri =404` — so every view is a `404`, the api holds zero views, and
no tool is ever tagged as an app:

```
ERROR mcp apps: a view document is not being served
  err: …/mcp-apps/account-brief.html answered status 404 Not Found, want 200
INFO  mcp apps: view documents primed  held=0 catalog=5
WARN  mcp apps: some views are not served; the advertised set is fixed until this api restarts
```

## The cause

The per-view build is wired into the **vanilla** lane only:

```
"build":          "tsc -b && vite build && node scripts/build-mcp-apps.mjs"
"build:composed": "tsc -p tsconfig.composed.json && vite build"      ← no driver
```

`Dockerfile.web` builds the composed lane (`pnpm build:composed`), so
`dist/mcp-apps/` is never emitted into the image. Local `pnpm build`, `pnpm
check` and CI all run the vanilla lane, which is why nothing caught it.

The intent was clearly there: `Dockerfile.web` already declares
`ARG MARGINCE_BUILD_REVISION` and documents it as "written into each MCP App
view document" — the step that would consume it just never joined this lane.

## The change

One line: `build:composed` runs the driver too, so the two lanes cannot drift
again. `Dockerfile.web` is the only consumer of `build:composed`, so nothing
else changes.

Verified the driver standalone in this branch — it needs neither the SPA build
nor the `@composition` alias (`vite.mcp-apps.config.ts` is a separate,
single-input-per-view config):

```
$ node scripts/build-mcp-apps.mjs
mcp-apps: built 5 documents into dist/mcp-apps
$ ls dist/mcp-apps/
account-brief.html  commitments.html  handoff.html  pipeline-review.html  relationship-map.html
```

## Companion change — both are needed

[margince-d13-deploy#11](https://github.com/gradionhq/margince-d13-deploy/pull/11)
fixes the other half: `/mcp-apps/*.html` is currently routed to `api`, not
`web`, because ingress-nginx renders `/mcp` as an unanchored regex that
swallows it. **Neither PR alone produces `held=5`** — without that one the
request never reaches `web`; without this one `web` has nothing to serve. Merge
this, let the `web` image rebuild, apply the ingress, then
`kubectl -n margince-staging rollout restart deploy/api` (the advertised view
set is frozen at boot).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing MCP App view documents in the production `web` image by adding the view build to the composed lane. This ships `/mcp-apps/*.html` in the image and resolves 404s.

- **Bug Fixes**
  - Updated `build:composed` to also run `node scripts/build-mcp-apps.mjs`, ensuring `dist/mcp-apps/` is emitted.

- **Migration**
  - Coordinate with margince-d13-deploy#11 to route `/mcp-apps/*.html` to `web`. Both PRs are required for the API to advertise all views.

<sup>Written for commit e1c73b01dc05d9e35732407c78e6174ed5765878. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/908?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the composed build process to automatically prepare MCP apps after compilation and bundling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->