### PR TITLE
test(identity): the agent-seat refusal is asserted where a client meets it

### DIFF
--- a/backend/internal/modules/identity/userpasswordlink_integration_test.go
+++ b/backend/internal/modules/identity/userpasswordlink_integration_test.go
@@ -8,7 +8,7 @@ package identity
 // The admin-issued set-password link over a real migrated Postgres: one live
 // token at a time, an audit row and an event that carry no credential, a
 // redemption that actually works on the email-less installation the link exists
-// for, and refusals for a non-admin and a non-active target.
+// for, and refusals for a non-admin, a non-active target, and the agent seat.
 
 import (
 	"context"
@@ -290,5 +290,42 @@ func TestPasswordLinkHandlerRefusesANonActiveMember(t *testing.T) {
 	// admin is told to reactivate rather than to go and change the deployment.
 	if !strings.Contains(rec.Body.String(), "member_not_active") {
 		t.Errorf("refusal body = %s, want the member_not_active code", rec.Body)
+	}
+}
+
+// The agent seat over the wire. That the service refuses it is asserted where
+// the rule lives; this is the half a client meets — a 409 carrying a code it can
+// branch on, rather than the bare "conflict" an unmapped sentinel falls through
+// to. Untested, the status and the code are whatever the mapping happens to say,
+// and an admin who tries to issue a link for the workspace's agent identity is
+// told nothing about why it can never have one.
+func TestPasswordLinkHandlerRefusesTheAgentSeat(t *testing.T) {
+	e := setupRevocationEnv(t, "link-http-agent")
+	h := NewHandlers(e.svc).WithPasswordLinkBase("https://crm.example.test")
+
+	// The seat bootstrap wrote for this workspace, read back rather than
+	// inserted: a hand-made row would prove only that the handler refuses a row
+	// this test invented, which is not the row an admin can reach.
+	var seat ids.UserID
+	if err := e.owner.QueryRow(context.Background(),
+		`SELECT id FROM app_user WHERE workspace_id = $1 AND is_agent`,
+		e.admin.WorkspaceID).Scan(&seat); err != nil {
+		t.Fatalf("reading the workspace's agent seat: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/users/"+seat.String()+"/password-link", nil)
+	h.IssueUserPasswordLink(rec, req.WithContext(withIdentity(e.wsCtx(e.admin), e.admin)),
+		crmcontracts.Id(seat.UUID))
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("agent-seat target = %d, want 409: %s", rec.Code, rec.Body)
+	}
+	if !strings.Contains(rec.Body.String(), "agent_seat_has_no_password") {
+		t.Errorf("refusal body = %s, want the agent_seat_has_no_password code — a client that has to "+
+			"tell this apart from an inactive member would otherwise be matching sentences", rec.Body)
+	}
+	if live := liveTokenCount(t, e, seat); live != 0 {
+		t.Errorf("the refused request left %d live token(s) for the agent seat; a refusal that still "+
+			"mints the credential refuses nothing", live)
 	}
 }


### PR DESCRIPTION
Follow-up to #909, which SonarCloud flagged at 65.2% new-code coverage (threshold 80). The uncovered lines were not incidental — they were the 409 mapping for the agent-seat refusal, in `handlers_users.go`.

#909 refuses a set-password link for the workspace's agent seat at the service (redeeming one would give an identity with no person behind it a working credential) and maps the sentinel to a `409 agent_seat_has_no_password`. Only the service half was covered. The status, and the code a client uses to tell this apart from an inactive member, were whatever the handler happened to say — nothing would have failed if it said something else. That is the same shape as the `httperr` field-code mismatch this repo has been bitten by before: the refusal is right and the wire contract for it is unasserted.

The test drives `IssueUserPasswordLink` over `httptest` against the real service, copying the shape of the neighbouring `TestPasswordLinkHandlerRefusesANonActiveMember`, and asserts three things: the 409, the code, and that no token was minted on the way to the refusal.

The seat is **read back** from the workspace `setupRevocationEnv` bootstraps rather than inserted — a hand-made row would prove the handler refuses a row the test invented, which is not the row an admin can reach.

Leaves 2 uncovered new lines from #909: the error wrap in `seedAgentSeat`, reachable only on a database fault inside bootstrap's transaction. Covering that would need injected failure with more artifice than value; new-code coverage clears the gate without it.

## Gates

`make check-backend` ✅ · `make craft-static` ✅ (0/0/0) · `make test-integration` ✅ `OK: integration passed with 0 skips (36 packages)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an integration test that asserts the agent seat is refused when issuing a set‑password link over HTTP. It verifies `IssueUserPasswordLink` returns 409 with `agent_seat_has_no_password` and that no token is minted, reading the agent seat created by bootstrap rather than inserting a test row.

<sup>Written for commit 1f15d597b696fbc8729a39c2777457547b7c7757. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/911?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

