### PR TITLE
test(compose): the agent-access suites become their own lane slot

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -561,11 +561,13 @@ follow-up. Each slice also subjects every MOVED line to the full strict linter
 surfaced an unchecked type assertion and a naming violation the un-gated original
 had carried.
 
-**Expect one or two more slices to be worth it, not five.** After #913 the parent
-is ~118s of measured test seconds; `./migrations` (96s, 23 tests — replay, which
-does not split the same way) and `./internal/compose` (92s) are the next poles, so
-a third slice roughly reaches them and a fourth buys nothing until those two are
-addressed.
+**Expect one more slice to be worth it, not five.** #913 was the third (after #859
+and #866), and each took 13–15s of the parent's measured test seconds. `./migrations`
+(96s, 23 tests — replay, which does not split the same way) and `./internal/compose`
+(92s) are the next poles, so a FOURTH slice roughly reaches them and a fifth buys
+nothing until those two are addressed. Re-measure before starting one: the parent's
+own seconds moved in both directions across these three PRs, because `main` kept
+adding tests to it while the slices took them out.
 
 A slice also perturbs what has run by the time each surviving test executes, which
 finds tests that depend on state a neighbour left. #913 turned one red that way
@@ -578,7 +580,13 @@ test-isolation defect before reading it as the slice's fault.
 on `*apptest.AppEnv` goes in `integration/apptest` — `integration`'s ordinary
 files may not import `apptest` (it imports `compose`, whose white-box tests import
 `integration`, so the cycle closes). Anything else two suite packages need goes in
-`integration/suitefixtures.go`. Nothing in a `_test.go` file is reachable from a
+`integration/suitefixtures.go` — **unless `apptest` is itself one of the callers**,
+in which case it goes in `apptest` too, whatever it is keyed on. `apptest` cannot
+import `integration`, so a helper it needs and `suitefixtures.go` holds is a helper
+about to be copied — which is what had happened to the app-DSN read before #913
+collapsed those call sites onto `apptest.AppDSN`. (The sites that read the owner and
+app DSN together are a different shape and still read their own; only the app-only
+readers were the same invariant.) Nothing in a `_test.go` file is reachable from a
 subpackage at all, which is what strands most helpers. And a helper whose other
 caller is an UNTAGGED file cannot be shared in either place: that file belongs to
 the unit lane, so the two callers are on opposite sides of a build tag.

--- a/STATUS.md
+++ b/STATUS.md
@@ -551,7 +551,8 @@ of pre-fan-out is plausibly reducible.
 The cost of a slice is fixture entanglement, not the move itself. #859 took the
 channel suites out (14.8s) and had to leave four neighbours behind, each sharing
 one preflight fixture with suites that were not moving; #866 took the webhook
-suites (13.3s, and the long pole's test seconds fell 183.6s → 170.6s to match).
+suites (13.3s, and the long pole's test seconds fell 183.6s → 170.6s to match);
+#877 took the OAuth + MCP surface (13.25s).
 Two or three shared helpers per slice have to be promoted to importable homes
 first, and each suite package's `doc.go` records where its boundary fell and why.
 Reaching the ~80s floor means repeating that several times — a programme, not a
@@ -559,6 +560,19 @@ follow-up. Each slice also subjects every MOVED line to the full strict linter
 (`new-from-merge-base`), which is a real cost per PR: #866's promotion alone
 surfaced an unchecked type assertion and a naming violation the un-gated original
 had carried.
+
+**Expect one or two more slices to be worth it, not five.** After #877 the parent
+is ~118s of measured test seconds; `./migrations` (96s, 23 tests — replay, which
+does not split the same way) and `./internal/compose` (92s) are the next poles, so
+a third slice roughly reaches them and a fourth buys nothing until those two are
+addressed.
+
+A slice also perturbs what has run by the time each surviving test executes, which
+finds tests that depend on state a neighbour left. #877 turned one red that way
+(#876, fixed on main by #874 while the slice waited): it asserted a field would be
+absent from a change timeline, and passed only because the column that field fills
+was usually already populated. Expect one of these per slice, and read the failure
+as a test-isolation defect before reading it as the slice's fault.
 
 **Where the shared fixtures live, since a slice stalls on this.** A fixture keyed
 on `*apptest.AppEnv` goes in `integration/apptest` — `integration`'s ordinary

--- a/STATUS.md
+++ b/STATUS.md
@@ -552,7 +552,7 @@ The cost of a slice is fixture entanglement, not the move itself. #859 took the
 channel suites out (14.8s) and had to leave four neighbours behind, each sharing
 one preflight fixture with suites that were not moving; #866 took the webhook
 suites (13.3s, and the long pole's test seconds fell 183.6s → 170.6s to match);
-#877 took the OAuth + MCP surface (13.25s).
+#913 took the OAuth + MCP surface (13.25s).
 Two or three shared helpers per slice have to be promoted to importable homes
 first, and each suite package's `doc.go` records where its boundary fell and why.
 Reaching the ~80s floor means repeating that several times — a programme, not a
@@ -561,18 +561,18 @@ follow-up. Each slice also subjects every MOVED line to the full strict linter
 surfaced an unchecked type assertion and a naming violation the un-gated original
 had carried.
 
-**Expect one or two more slices to be worth it, not five.** After #877 the parent
+**Expect one or two more slices to be worth it, not five.** After #913 the parent
 is ~118s of measured test seconds; `./migrations` (96s, 23 tests — replay, which
 does not split the same way) and `./internal/compose` (92s) are the next poles, so
 a third slice roughly reaches them and a fourth buys nothing until those two are
 addressed.
 
 A slice also perturbs what has run by the time each surviving test executes, which
-finds tests that depend on state a neighbour left. #877 turned one red that way
+finds tests that depend on state a neighbour left. #913 turned one red that way
 (#876, fixed on main by #874 while the slice waited): it asserted a field would be
 absent from a change timeline, and passed only because the column that field fills
-was usually already populated. Expect one of these per slice, and read the failure
-as a test-isolation defect before reading it as the slice's fault.
+was usually already populated. Expect these, and read such a failure as a
+test-isolation defect before reading it as the slice's fault.
 
 **Where the shared fixtures live, since a slice stalls on this.** A fixture keyed
 on `*apptest.AppEnv` goes in `integration/apptest` — `integration`'s ordinary

--- a/backend/internal/compose/integration/accountsend_agent_integration_test.go
+++ b/backend/internal/compose/integration/accountsend_agent_integration_test.go
@@ -157,7 +157,7 @@ func TestAnAgentsAccountStartedSendStagesTheCreateAndOnlyLeavesOnceApproved(t *t
 	if n := a.deliveryCount(t); n != 0 {
 		t.Fatalf("%d deliveries staged behind an unapproved agent send, want 0 — nothing may leave", n)
 	}
-	approvalID := extractStagedApprovalID(t, problem.Detail)
+	approvalID := ExtractStagedApprovalID(t, problem.Detail)
 
 	// The staged SHAPE, which is what makes the row decidable at all: the type
 	// the effect will write, and no row for a scope probe to resolve, because

--- a/backend/internal/compose/integration/agent_versionpin_integration_test.go
+++ b/backend/internal/compose/integration/agent_versionpin_integration_test.go
@@ -74,7 +74,7 @@ func TestApprovedOfferArchiveRefusesAfterTheAgentRewritesTheTerms(t *testing.T) 
 		problem.Code != "approval_required" {
 		t.Fatalf("agent archive → %d %q, want 403 approval_required", status, problem.Code)
 	}
-	approvalID := extractStagedApprovalID(t, problem.Detail)
+	approvalID := ExtractStagedApprovalID(t, problem.Detail)
 
 	// The staged row carries a pin the agent never supplied.
 	var pin *int64

--- a/backend/internal/compose/integration/agentaccess/doc.go
+++ b/backend/internal/compose/integration/agentaccess/doc.go
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+// Package agentaccess holds the integration suites for how a non-human caller is
+// admitted and what it may then do: the OAuth surface and its discovery documents,
+// dynamic client registration, consent and its refusals, the grant, refresh,
+// revocation and lending of tokens, the passports those tokens carry, and the MCP
+// transport that presents them — handshake, framing, deadlines and the task
+// surface — plus the query vocabulary the surface publishes.
+//
+// The credentials and the transport are one package on purpose. ADR-0055 governs a
+// passport identically whether it arrives on REST or on /mcp, and the suites
+// reflect that: they share the connector harness and the minted-passport fixture,
+// and splitting them would put a token's issue and its presentation in different
+// binaries.
+//
+// It is a suite package split out of internal/compose/integration so the lane has
+// another scheduling slot: one package is one slot, and the parent is large enough
+// to be the lane's long pole by itself. Its suites ride integration's exported
+// fixtures and integration/apptest's.
+//
+// Where the boundary fell, since the names do not predict it. agentscope and
+// approval_bundle stayed in the parent even though they mint passports — they turn
+// on approvals, not on admission, and the fixture they shared is now
+// apptest.PassportBearer. agenttools_http stayed too: it pins the wire shape of
+// /v1/agent-tools, which mcp_transport only reads two fields of.
+package agentaccess

--- a/backend/internal/compose/integration/agentaccess/doc.go
+++ b/backend/internal/compose/integration/agentaccess/doc.go
@@ -12,7 +12,7 @@
 //
 // The credentials and the transport are one package on purpose. ADR-0055 governs a
 // passport identically whether it arrives on REST or on /mcp, and the suites
-// reflect that: they share the connector harness and the minted-passport fixture,
+// reflect that: they share the connector harness, and each mints passports,
 // and splitting them would put a token's issue and its presentation in different
 // binaries.
 //
@@ -21,9 +21,15 @@
 // to be the lane's long pole by itself. Its suites ride integration's exported
 // fixtures and integration/apptest's.
 //
-// Where the boundary fell, since the names do not predict it. agentscope and
-// approval_bundle stayed in the parent even though they mint passports — they turn
-// on approvals, not on admission, and the fixture they shared is now
-// apptest.PassportBearer. agenttools_http stayed too: it pins the wire shape of
-// /v1/agent-tools, which mcp_transport only reads two fields of.
+// Where the boundary fell, and it is fixture entanglement rather than subject
+// matter. agentscope and approval_bundle mint passports and assert on admission
+// too, so they belong here by charter; they stayed because the assertions they
+// turn on — assertNothingStaged and the approval-inbox queries — live in the
+// parent's _test.go files, which a subpackage cannot reach at all. The fixture
+// they DID share is now apptest.PassportBearer, so what remains behind is those
+// assertions, not the minting.
+//
+// agenttools_http stayed for the cheaper version of the same reason: it pins the
+// full wire shape of /v1/agent-tools, and mcp_transport needs two fields of it,
+// which it declares inline rather than dragging the shape across the boundary.
 package agentaccess

--- a/backend/internal/compose/integration/agentaccess/doc.go
+++ b/backend/internal/compose/integration/agentaccess/doc.go
@@ -21,15 +21,21 @@
 // to be the lane's long pole by itself. Its suites ride integration's exported
 // fixtures and integration/apptest's.
 //
-// Where the boundary fell, and it is fixture entanglement rather than subject
-// matter. agentscope and approval_bundle mint passports and assert on admission
-// too, so they belong here by charter; they stayed because the assertions they
-// turn on — assertNothingStaged and the approval-inbox queries — live in the
-// parent's _test.go files, which a subpackage cannot reach at all. The fixture
-// they DID share is now apptest.PassportBearer, so what remains behind is those
-// assertions, not the minting.
+// Three suites belong here by charter and are not here, for two different
+// reasons — worth stating separately, because only one of them is a constraint.
 //
-// agenttools_http stayed for the cheaper version of the same reason: it pins the
-// full wire shape of /v1/agent-tools, and mcp_transport needs two fields of it,
-// which it declares inline rather than dragging the shape across the boundary.
+// agentscope is pinned. It asserts the passport cap over real HTTP, which is this
+// package's subject exactly, but it arranges through offerFixture and offerBody
+// from offers_integration_test.go — another suite's _test.go file, which a
+// subpackage cannot reach. Moving it means promoting those two first, and the
+// arrange step must keep going through the real endpoints: a hand-inserted offer
+// row would leave the human-only refusal proving nothing about an offer the
+// product would actually have issued.
+//
+// approval_bundle and agenttools_http are NOT pinned — every helper they use is
+// their own. They stayed because this slice was scoped to the admission path and
+// they read as approvals and as the REST tool surface. Nothing prevents a later
+// slice from taking them; mcp_transport already declares inline the two fields it
+// needs of agenttools_http's wire shape, so that shape stays with the suite that
+// owns it either way.
 package agentaccess

--- a/backend/internal/compose/integration/agentaccess/mcp_deadline_integration_test.go
+++ b/backend/internal/compose/integration/agentaccess/mcp_deadline_integration_test.go
@@ -3,7 +3,7 @@
 
 //go:build integration
 
-package integration
+package agentaccess
 
 // A tool call that outlives the response deadline. The api role arms a
 // server-wide WriteTimeout, and a dynamic tool call may legitimately run past

--- a/backend/internal/compose/integration/agentaccess/mcp_handshake_integration_test.go
+++ b/backend/internal/compose/integration/agentaccess/mcp_handshake_integration_test.go
@@ -3,7 +3,7 @@
 
 //go:build integration
 
-package integration
+package agentaccess
 
 // The whole client handshake, walked once, end to end: from a refusal that
 // names where the authorization server is, through dynamic registration and

--- a/backend/internal/compose/integration/agentaccess/mcp_modernframing_integration_test.go
+++ b/backend/internal/compose/integration/agentaccess/mcp_modernframing_integration_test.go
@@ -3,7 +3,7 @@
 
 //go:build integration
 
-package integration
+package agentaccess
 
 // Both framings, end to end on the real origin, against a real database
 // (ADR-0092/A141). The unit suite proves each framing's rules; only this one
@@ -22,6 +22,8 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 )
 
 // The per-request metadata a modern client sends, spelled as the specification
@@ -53,7 +55,7 @@ func modernHeaders(bearer map[string]string, method, name string) map[string]str
 // server, two eras, and a record created through either one.
 func TestBothFramingsConnectAndLandTheSameEffect(t *testing.T) {
 	e := setupConnector(t)
-	bearer := passportBearer(t, e.AppEnv, "dual-era client", "read", "write")
+	bearer := apptest.PassportBearer(t, e.AppEnv, "dual-era client", "read", "write")
 
 	t.Run("a modern client needs no handshake", func(t *testing.T) {
 		discovered := mcpRaw(e.AppEnv, t, http.MethodPost, "/mcp",
@@ -196,7 +198,7 @@ func legacyHeaders(bearer map[string]string, negotiated string) map[string]strin
 // working client back to the handshake.
 func TestAModernRequestWhoseHeaderContradictsItsBodyRunsNothing(t *testing.T) {
 	e := setupConnector(t)
-	bearer := passportBearer(t, e.AppEnv, "mismatching client", "read", "write")
+	bearer := apptest.PassportBearer(t, e.AppEnv, "mismatching client", "read", "write")
 
 	refused := mcpRaw(e.AppEnv, t, http.MethodPost, "/mcp",
 		`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{`+modernMeta+

--- a/backend/internal/compose/integration/agentaccess/mcp_tasks_integration_test.go
+++ b/backend/internal/compose/integration/agentaccess/mcp_tasks_integration_test.go
@@ -3,7 +3,7 @@
 
 //go:build integration
 
-package integration
+package agentaccess
 
 // The io.modelcontextprotocol/tasks extension, end to end on the real origin
 // against a real database.
@@ -36,7 +36,7 @@ const tasksMeta = `"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-2
 // lands exactly once no matter how often the client polls.
 func TestAConfirmFirstCallBecomesATaskAndCompletesOnce(t *testing.T) {
 	e := setupConnector(t)
-	bearer := passportBearer(t, e.AppEnv, "task client", "read", "write")
+	bearer := apptest.PassportBearer(t, e.AppEnv, "task client", "read", "write")
 	leadID := createDisqualifiableLead(t, e.AppEnv)
 
 	// The 🟡 call. A client that declared the extension is handed a handle
@@ -123,8 +123,8 @@ func TestAConfirmFirstCallBecomesATaskAndCompletesOnce(t *testing.T) {
 // exist.
 func TestATaskIsInvisibleToAnyOtherPassport(t *testing.T) {
 	e := setupConnector(t)
-	mine := passportBearer(t, e.AppEnv, "the minting client", "read", "write")
-	theirs := passportBearer(t, e.AppEnv, "another client", "read", "write")
+	mine := apptest.PassportBearer(t, e.AppEnv, "the minting client", "read", "write")
+	theirs := apptest.PassportBearer(t, e.AppEnv, "another client", "read", "write")
 	leadID := createDisqualifiableLead(t, e.AppEnv)
 
 	created := rpcResult(t, mcpRaw(e.AppEnv, t, http.MethodPost, "/mcp",
@@ -162,7 +162,7 @@ func TestATaskIsInvisibleToAnyOtherPassport(t *testing.T) {
 // withdraw.
 func TestCancellingATaskTakesItsProposalOffTheInbox(t *testing.T) {
 	e := setupConnector(t)
-	bearer := passportBearer(t, e.AppEnv, "task client", "read", "write")
+	bearer := apptest.PassportBearer(t, e.AppEnv, "task client", "read", "write")
 	leadID := createDisqualifiableLead(t, e.AppEnv)
 
 	created := rpcResult(t, mcpRaw(e.AppEnv, t, http.MethodPost, "/mcp",
@@ -197,7 +197,7 @@ func TestCancellingATaskTakesItsProposalOffTheInbox(t *testing.T) {
 // client — and the certification band — on byte-identical behaviour.
 func TestANonDeclaringClientStillGetsThePlainRefusal(t *testing.T) {
 	e := setupConnector(t)
-	bearer := passportBearer(t, e.AppEnv, "old client", "read", "write")
+	bearer := apptest.PassportBearer(t, e.AppEnv, "old client", "read", "write")
 	leadID := createDisqualifiableLead(t, e.AppEnv)
 
 	refused := rpcResult(t, mcpRaw(e.AppEnv, t, http.MethodPost, "/mcp",
@@ -224,7 +224,7 @@ func TestANonDeclaringClientStillGetsThePlainRefusal(t *testing.T) {
 // methods refuse a request that did not declare it.
 func TestTheExtensionIsAdvertisedAndItsMethodsRequireIt(t *testing.T) {
 	e := setupConnector(t)
-	bearer := passportBearer(t, e.AppEnv, "task client", "read")
+	bearer := apptest.PassportBearer(t, e.AppEnv, "task client", "read")
 
 	discovered := rpcResult(t, mcpRaw(e.AppEnv, t, http.MethodPost, "/mcp",
 		fmt.Sprintf(`{"jsonrpc":"2.0","id":1,"method":"server/discover","params":{%s}}`, tasksMeta),
@@ -256,7 +256,7 @@ func TestTheExtensionIsAdvertisedAndItsMethodsRequireIt(t *testing.T) {
 // must land one effect.
 func TestTwoSimultaneousPollsRunTheReleasedCallOnce(t *testing.T) {
 	e := setupConnector(t)
-	bearer := passportBearer(t, e.AppEnv, "task client", "read", "write")
+	bearer := apptest.PassportBearer(t, e.AppEnv, "task client", "read", "write")
 	leadID := createDisqualifiableLead(t, e.AppEnv)
 
 	created := rpcResult(t, mcpRaw(e.AppEnv, t, http.MethodPost, "/mcp",
@@ -319,7 +319,7 @@ func TestTwoSimultaneousPollsRunTheReleasedCallOnce(t *testing.T) {
 // act on one human yes, so the task fails and says it does not know.
 func TestATaskWhoseExecutionLeftNoOutcomeFailsRatherThanRunningAgain(t *testing.T) {
 	e := setupConnector(t)
-	bearer := passportBearer(t, e.AppEnv, "task client", "read", "write")
+	bearer := apptest.PassportBearer(t, e.AppEnv, "task client", "read", "write")
 	leadID := createDisqualifiableLead(t, e.AppEnv)
 
 	created := rpcResult(t, mcpRaw(e.AppEnv, t, http.MethodPost, "/mcp",
@@ -361,7 +361,7 @@ func TestATaskWhoseExecutionLeftNoOutcomeFailsRatherThanRunningAgain(t *testing.
 // with the first, which is what the one-task-per-approval index is for.
 func TestRepeatingAStagedCallAnswersItsOwnHandle(t *testing.T) {
 	e := setupConnector(t)
-	bearer := passportBearer(t, e.AppEnv, "task client", "read", "write")
+	bearer := apptest.PassportBearer(t, e.AppEnv, "task client", "read", "write")
 	leadID := createDisqualifiableLead(t, e.AppEnv)
 
 	call := fmt.Sprintf(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{%s,
@@ -388,7 +388,7 @@ func TestRepeatingAStagedCallAnswersItsOwnHandle(t *testing.T) {
 // predicate can show that; the unit fixture has no clock.
 func TestATaskWhoseExecutorDiedCanStillBeCancelled(t *testing.T) {
 	e := setupConnector(t)
-	bearer := passportBearer(t, e.AppEnv, "task client", "read", "write")
+	bearer := apptest.PassportBearer(t, e.AppEnv, "task client", "read", "write")
 	leadID := createDisqualifiableLead(t, e.AppEnv)
 
 	created := rpcResult(t, mcpRaw(e.AppEnv, t, http.MethodPost, "/mcp",

--- a/backend/internal/compose/integration/agentaccess/mcp_transport_integration_test.go
+++ b/backend/internal/compose/integration/agentaccess/mcp_transport_integration_test.go
@@ -3,7 +3,7 @@
 
 //go:build integration
 
-package integration
+package agentaccess
 
 // The remote MCP connector as a third-party client meets it: over the
 // COMPOSED mux, so what is asserted is the route set a real client reaches.
@@ -198,7 +198,16 @@ func TestMCPOnTheAPIServesTheAPIsOwnToolSurface(t *testing.T) {
 		t.Fatalf("issue passport → %d", status)
 	}
 
-	var rest agentToolListWire
+	// Decoded to the two fields this comparison turns on — the tool's name and the
+	// scope it requires. The full wire shape of /v1/agent-tools is pinned by
+	// agenttools_http_integration_test.go, which is the suite that owns it; naming
+	// more fields here would be a second place to update when it changes.
+	var rest struct {
+		Data []struct {
+			Name          string `json:"name"`
+			RequiredScope string `json:"required_scope"`
+		} `json:"data"`
+	}
 	if status := env.Call(t, "GET", "/v1/agent-tools", nil, nil, &rest); status != http.StatusOK {
 		t.Fatalf("GET /v1/agent-tools → %d", status)
 	}

--- a/backend/internal/compose/integration/agentaccess/oauth_accesstoken_ttl_integration_test.go
+++ b/backend/internal/compose/integration/agentaccess/oauth_accesstoken_ttl_integration_test.go
@@ -3,7 +3,7 @@
 
 //go:build integration
 
-package integration
+package agentaccess
 
 // The operator's access-token lifetime (--oauth-access-token-ttl). A connector's
 // access token is a passport, and a passport defaults to 30 days where connector

--- a/backend/internal/compose/integration/agentaccess/oauth_consent_integration_test.go
+++ b/backend/internal/compose/integration/agentaccess/oauth_consent_integration_test.go
@@ -3,7 +3,7 @@
 
 //go:build integration
 
-package integration
+package agentaccess
 
 // The consent screen's read model (GET /oauth/consent-request): which of the
 // signed-in human's passports may be lent to the requesting client. Each

--- a/backend/internal/compose/integration/agentaccess/oauth_consent_refusal_integration_test.go
+++ b/backend/internal/compose/integration/agentaccess/oauth_consent_refusal_integration_test.go
@@ -3,7 +3,7 @@
 
 //go:build integration
 
-package integration
+package agentaccess
 
 // What a HUMAN sees when the consent flow refuses them. The screen is a native
 // form in the SPA, so a JSON refusal replaces it with a body of text on a page

--- a/backend/internal/compose/integration/agentaccess/oauth_grant_integration_test.go
+++ b/backend/internal/compose/integration/agentaccess/oauth_grant_integration_test.go
@@ -3,7 +3,7 @@
 
 //go:build integration
 
-package integration
+package agentaccess
 
 import (
 	"context"

--- a/backend/internal/compose/integration/agentaccess/oauth_integration_test.go
+++ b/backend/internal/compose/integration/agentaccess/oauth_integration_test.go
@@ -3,7 +3,7 @@
 
 //go:build integration
 
-package integration
+package agentaccess
 
 // The A2 handshake end to end (B-EP06.18, B-EP03.14/.15, ADR-0036):
 // discovery → DCR (public clients only) → authorize (PKCE S256

--- a/backend/internal/compose/integration/agentaccess/oauth_lend_integration_test.go
+++ b/backend/internal/compose/integration/agentaccess/oauth_lend_integration_test.go
@@ -3,7 +3,7 @@
 
 //go:build integration
 
-package integration
+package agentaccess
 
 // The consent DECISION (POST /oauth/authorize), as distinct from the screen's
 // read model next door in oauth_consent_integration_test.go: the human lends one
@@ -327,10 +327,9 @@ func TestAPendingConsentDoesNotSurviveItsHumansDeactivation(t *testing.T) {
 	// not be deactivated — the organization would lose user administration with
 	// no way back. A second admin is what the guard is protecting against, so
 	// inviting one is what lets the real endpoint run.
-	var second userWire
 	if status := o.Call(t, "POST", "/v1/users", apptest.AnyMap{
 		"email": "second-admin@fable.test", "display_name": "Second Admin", "role": "admin",
-	}, nil, &second); status != http.StatusCreated {
+	}, nil, nil); status != http.StatusCreated {
 		t.Fatalf("inviting a second admin → %d", status)
 	}
 	granter := o.userIDByEmail(t, "granter@fable.test")

--- a/backend/internal/compose/integration/agentaccess/oauth_refresh_integration_test.go
+++ b/backend/internal/compose/integration/agentaccess/oauth_refresh_integration_test.go
@@ -3,7 +3,7 @@
 
 //go:build integration
 
-package integration
+package agentaccess
 
 // Refresh-token rotation, the two properties a connector's whole lifetime
 // rests on: every presentation of a token is serialized by a row lock, so

--- a/backend/internal/compose/integration/agentaccess/oauth_revocation_integration_test.go
+++ b/backend/internal/compose/integration/agentaccess/oauth_revocation_integration_test.go
@@ -3,7 +3,7 @@
 
 //go:build integration
 
-package integration
+package agentaccess
 
 // Revocation, from the only place it can honestly be observed: the wire a
 // connector calls on. A connection can be cut off four ways — the passport, the

--- a/backend/internal/compose/integration/agentaccess/oauth_surface_integration_test.go
+++ b/backend/internal/compose/integration/agentaccess/oauth_surface_integration_test.go
@@ -3,7 +3,7 @@
 
 //go:build integration
 
-package integration
+package agentaccess
 
 import (
 	"context"
@@ -13,11 +13,11 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"os"
 	"strings"
 	"testing"
 
 	"github.com/gradionhq/margince/backend/internal/compose"
+	"github.com/gradionhq/margince/backend/internal/compose/integration"
 	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 	"github.com/gradionhq/margince/backend/internal/modules/agents"
 	"github.com/gradionhq/margince/backend/internal/modules/approvals"
@@ -53,7 +53,7 @@ func TestApprovalTokenIsASignedEffectBoundJWS(t *testing.T) {
 	if status := o.Call(t, "DELETE", "/v1/people/"+person.ID, nil, agentBearer, &problem); status != http.StatusForbidden {
 		t.Fatalf("agent archive → %d, want staged 403", status)
 	}
-	approvalID := extractStagedApprovalID(t, problem.Detail)
+	approvalID := integration.ExtractStagedApprovalID(t, problem.Detail)
 
 	var approved struct {
 		ApprovalToken *string `json:"approval_token"`
@@ -65,7 +65,7 @@ func TestApprovalTokenIsASignedEffectBoundJWS(t *testing.T) {
 		t.Fatalf("approve response lacks a compact JWS: %+v", approved.ApprovalToken)
 	}
 
-	pool, err := database.NewPool(context.Background(), envDSN(t))
+	pool, err := database.NewPool(context.Background(), integration.AppDSN(t))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -104,7 +104,7 @@ func TestHostedMCPTransportSharesTheGovernedSurface(t *testing.T) {
 	_, body := o.exchange(t, url.Values{"code": {code}})
 	token := body["access_token"].(string)
 
-	pool, err := database.NewPool(context.Background(), envDSN(t))
+	pool, err := database.NewPool(context.Background(), integration.AppDSN(t))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -169,15 +169,6 @@ func TestHostedMCPTransportSharesTheGovernedSurface(t *testing.T) {
 	if resp.StatusCode != http.StatusUnauthorized || !strings.Contains(resp.Header.Get("WWW-Authenticate"), "oauth-protected-resource") {
 		t.Fatalf("revoked bearer → %d %q, want 401 + RFC 9728 pointer", resp.StatusCode, resp.Header.Get("WWW-Authenticate"))
 	}
-}
-
-func envDSN(t *testing.T) string {
-	t.Helper()
-	dsn := os.Getenv("MARGINCE_TEST_APP_DSN")
-	if dsn == "" {
-		t.Fatal("MARGINCE_TEST_APP_DSN not set")
-	}
-	return dsn
 }
 
 func flipLastChar(s string) string {

--- a/backend/internal/compose/integration/agentaccess/oauth_surface_integration_test.go
+++ b/backend/internal/compose/integration/agentaccess/oauth_surface_integration_test.go
@@ -65,7 +65,7 @@ func TestApprovalTokenIsASignedEffectBoundJWS(t *testing.T) {
 		t.Fatalf("approve response lacks a compact JWS: %+v", approved.ApprovalToken)
 	}
 
-	pool, err := database.NewPool(context.Background(), integration.AppDSN(t))
+	pool, err := database.NewPool(context.Background(), apptest.AppDSN(t))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -104,7 +104,7 @@ func TestHostedMCPTransportSharesTheGovernedSurface(t *testing.T) {
 	_, body := o.exchange(t, url.Values{"code": {code}})
 	token := body["access_token"].(string)
 
-	pool, err := database.NewPool(context.Background(), integration.AppDSN(t))
+	pool, err := database.NewPool(context.Background(), apptest.AppDSN(t))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/backend/internal/compose/integration/agentaccess/passports_integration_test.go
+++ b/backend/internal/compose/integration/agentaccess/passports_integration_test.go
@@ -3,7 +3,7 @@
 
 //go:build integration
 
-package integration
+package agentaccess
 
 // The passport list surface (GET /passports, feedback/13): metadata
 // only, own rows for a regular user, workspace-wide for the admin role

--- a/backend/internal/compose/integration/agentaccess/queryvocabulary_integration_test.go
+++ b/backend/internal/compose/integration/agentaccess/queryvocabulary_integration_test.go
@@ -3,7 +3,7 @@
 
 //go:build integration
 
-package integration
+package agentaccess
 
 // The query vocabulary as a client actually reaches it: over the composed
 // /mcp mount, with a real passport, a real workspace and the real custom-field
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/gradionhq/margince/backend/internal/compose"
+	"github.com/gradionhq/margince/backend/internal/compose/integration"
 	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 	"github.com/gradionhq/margince/backend/internal/modules/search"
 )
@@ -100,7 +101,7 @@ func TestACustomFieldReachesThePublishedVocabularyWithoutADeploy(t *testing.T) {
 	// The schema pool is the owner-privileged connection the add-field engine
 	// runs its one ALTER TABLE on; without it the create answers 501 and this
 	// test would be asserting against a surface that is not mounted.
-	env := setupConnectorWith(t, compose.WithSchemaPool(SchemaPool(t)))
+	env := setupConnectorWith(t, compose.WithSchemaPool(integration.SchemaPool(t)))
 	bearer := readPassport(t, env.AppEnv, "custom field reader")
 
 	before := readVocabulary(env.AppEnv, t, bearer)
@@ -108,11 +109,19 @@ func TestACustomFieldReachesThePublishedVocabularyWithoutADeploy(t *testing.T) {
 		t.Fatal("the field under test already exists in the vocabulary")
 	}
 
-	status, created, problem := createCustomField(t, env.AppEnv, apptest.AnyMap{
+	// Created through the real endpoint, decoding only the two fields this suite
+	// reads. The full wire shape and every refusal around it are pinned by the
+	// customfields HTTP suites; what matters here is that a field the engine
+	// accepted turns up in the published vocabulary.
+	var created struct {
+		ID         string `json:"id"`
+		ColumnName string `json:"column_name"`
+	}
+	status := env.Call(t, "POST", "/v1/custom-fields", apptest.AnyMap{
 		"object": "deal", "label": "Renewal risk", "type": "text", "source": "ui",
-	})
+	}, nil, &created)
 	if status != http.StatusCreated {
-		t.Fatalf("adding a custom field → %d %+v", status, problem)
+		t.Fatalf("adding a custom field → %d", status)
 	}
 	if created.ColumnName != "cf_renewal_risk" {
 		t.Fatalf("the engine named the column %q; this test asks the vocabulary for cf_renewal_risk", created.ColumnName)
@@ -123,8 +132,7 @@ func TestACustomFieldReachesThePublishedVocabularyWithoutADeploy(t *testing.T) {
 		t.Fatal("a custom field active in the catalog is not in the published vocabulary")
 	}
 
-	var retired customFieldWire
-	if status := env.Call(t, "POST", "/v1/custom-fields/"+created.ID+"/retire", nil, nil, &retired); status != http.StatusOK {
+	if status := env.Call(t, "POST", "/v1/custom-fields/"+created.ID+"/retire", nil, nil, nil); status != http.StatusOK {
 		t.Fatalf("retiring the custom field → %d", status)
 	}
 	if fieldNamed(dealVocabulary(t, readVocabulary(env.AppEnv, t, bearer)), "cf_renewal_risk") {

--- a/backend/internal/compose/integration/agentaccess/queryvocabulary_integration_test.go
+++ b/backend/internal/compose/integration/agentaccess/queryvocabulary_integration_test.go
@@ -116,12 +116,18 @@ func TestACustomFieldReachesThePublishedVocabularyWithoutADeploy(t *testing.T) {
 	var created struct {
 		ID         string `json:"id"`
 		ColumnName string `json:"column_name"`
+		// The refusal body, kept because a non-201 here is usually the 501 the
+		// comment above names, and its detail is the whole diagnosis. Decoding
+		// the problem into the same target works because a success carries
+		// neither key.
+		Title  string `json:"title"`
+		Detail string `json:"detail"`
 	}
 	status := env.Call(t, "POST", "/v1/custom-fields", apptest.AnyMap{
 		"object": "deal", "label": "Renewal risk", "type": "text", "source": "ui",
 	}, nil, &created)
 	if status != http.StatusCreated {
-		t.Fatalf("adding a custom field → %d", status)
+		t.Fatalf("adding a custom field → %d %s: %s", status, created.Title, created.Detail)
 	}
 	if created.ColumnName != "cf_renewal_risk" {
 		t.Fatalf("the engine named the column %q; this test asks the vocabulary for cf_renewal_risk", created.ColumnName)
@@ -154,9 +160,10 @@ func TestAnUnservedResourceURIIsRefusedOverTheTransport(t *testing.T) {
 }
 
 // readPassport mints a read-scoped passport, which is the credential every
-// exchange in this file presents. It answers the bare token rather than a
-// header map: these exchanges post JSON-RPC bodies, so the header set differs
-// from the REST helper's next to it.
+// exchange in this file presents. It answers the bare token rather than a header
+// map, because these exchanges post JSON-RPC bodies and assemble their own
+// headers — which is why apptest.PassportBearer, whose whole answer is a REST
+// Authorization header, cannot serve them.
 func readPassport(t *testing.T, e *apptest.AppEnv, label string) string {
 	t.Helper()
 	var minted struct {

--- a/backend/internal/compose/integration/agentaccess/queryvocabulary_integration_test.go
+++ b/backend/internal/compose/integration/agentaccess/queryvocabulary_integration_test.go
@@ -109,19 +109,21 @@ func TestACustomFieldReachesThePublishedVocabularyWithoutADeploy(t *testing.T) {
 		t.Fatal("the field under test already exists in the vocabulary")
 	}
 
-	// Created through the real endpoint, decoding only the two fields this suite
-	// reads. The full wire shape and every refusal around it are pinned by the
-	// customfields HTTP suites; what matters here is that a field the engine
-	// accepted turns up in the published vocabulary.
+	// Created through the real endpoint, decoding only what this suite reads. The
+	// full wire shape and every refusal around it are pinned by the customfields
+	// HTTP suites; what matters here is that a field the engine accepted turns up
+	// in the published vocabulary.
+	//
+	// Success and refusal decode into one target because RFC 7807 shares no key
+	// with the custom-field wire: a 201 carries id/column_name and neither
+	// title/detail, so whichever pair is populated says which answer arrived. The
+	// refusal half is message-only, and it is here because the most likely
+	// non-201 is the 501 above, whose detail is the whole diagnosis.
 	var created struct {
 		ID         string `json:"id"`
 		ColumnName string `json:"column_name"`
-		// The refusal body, kept because a non-201 here is usually the 501 the
-		// comment above names, and its detail is the whole diagnosis. Decoding
-		// the problem into the same target works because a success carries
-		// neither key.
-		Title  string `json:"title"`
-		Detail string `json:"detail"`
+		Title      string `json:"title"`
+		Detail     string `json:"detail"`
 	}
 	status := env.Call(t, "POST", "/v1/custom-fields", apptest.AnyMap{
 		"object": "deal", "label": "Renewal risk", "type": "text", "source": "ui",
@@ -169,10 +171,16 @@ func readPassport(t *testing.T, e *apptest.AppEnv, label string) string {
 	var minted struct {
 		Token string `json:"token"`
 	}
-	if status := e.Call(t, "POST", "/v1/passports", apptest.AnyMap{
+	status := e.Call(t, "POST", "/v1/passports", apptest.AnyMap{
 		"label": label, "scopes": []string{"read"},
-	}, nil, &minted); status != http.StatusCreated || minted.Token == "" {
-		t.Fatalf("issue passport → %d", status)
+	}, nil, &minted)
+	if status != http.StatusCreated {
+		t.Fatalf("issue passport %q → %d", label, status)
+	}
+	// Separately, because a 201 carrying no token would otherwise report as
+	// "→ 201" — which reads like the call worked.
+	if minted.Token == "" {
+		t.Fatalf("passport %q minted without a token", label)
 	}
 	return minted.Token
 }

--- a/backend/internal/compose/integration/agentscope_integration_test.go
+++ b/backend/internal/compose/integration/agentscope_integration_test.go
@@ -60,7 +60,7 @@ func TestEnrichRefusesAPassportWithoutTheEnrichCap(t *testing.T) {
 	}
 
 	// The old default: everything a mutating agent did cost `write`.
-	writeOnly := passportBearer(t, e, "write-only agent", "read", "write")
+	writeOnly := apptest.PassportBearer(t, e, "write-only agent", "read", "write")
 
 	var refusal capRefusal
 	status := e.Call(t, "POST", "/v1/organizations/"+org.ID+"/enrich", nil, writeOnly, &refusal)
@@ -81,7 +81,7 @@ func TestEnrichRefusesAPassportWithoutTheEnrichCap(t *testing.T) {
 	// The same principal shape with the cap the contract declares. There is
 	// no route that widens a minted passport's scopes (mint and revoke only),
 	// so the grant is a fresh passport differing in exactly that one cap.
-	withEnrich := passportBearer(t, e, "enriching agent", "read", "write", "enrich")
+	withEnrich := apptest.PassportBearer(t, e, "enriching agent", "read", "write", "enrich")
 
 	// What this proves: auth.Admit checks scope BEFORE tier, so
 	// approval_required is unreachable unless the enrich cap was spent — the
@@ -94,7 +94,7 @@ func TestEnrichRefusesAPassportWithoutTheEnrichCap(t *testing.T) {
 	if status != http.StatusForbidden || staged.Code != "approval_required" {
 		t.Fatalf("enrich with the enrich cap → %d %q, want 403 approval_required (the 🟡 gate)", status, staged.Code)
 	}
-	approvalID := extractStagedApprovalID(t, staged.Detail)
+	approvalID := ExtractStagedApprovalID(t, staged.Detail)
 	var kind string
 	if err := e.Owner.QueryRow(t.Context(),
 		`SELECT kind FROM approval WHERE id = $1`, approvalID).Scan(&kind); err != nil {
@@ -121,7 +121,7 @@ func TestOfferSendRefusesAnyAgentAsHumanOnly(t *testing.T) {
 
 	// The broadest passport short of a human session: even every cap the
 	// contract knows does not reach a human-only verb.
-	bearer := passportBearer(t, e, "drafting agent", "read", "write", "send", "enrich")
+	bearer := apptest.PassportBearer(t, e, "drafting agent", "read", "write", "send", "enrich")
 
 	// Drafting is 🟢 under `write` and still is: send being human-only is
 	// not a blanket tightening of the offer surface.
@@ -156,24 +156,6 @@ func TestOfferSendRefusesAnyAgentAsHumanOnly(t *testing.T) {
 	if status := e.Call(t, "GET", "/v1/offers/"+offer.ID, nil, bearer, &still); status != http.StatusOK || still.Status != "draft" {
 		t.Fatalf("offer after the refused send = %q, want draft", still.Status)
 	}
-}
-
-// passportBearer mints a passport with exactly scopes and returns the
-// Authorization header an agent principal presents.
-func passportBearer(t *testing.T, e *apptest.AppEnv, label string, scopes ...string) map[string]string {
-	t.Helper()
-	var minted struct {
-		Token string `json:"token"`
-	}
-	if status := e.Call(t, "POST", "/v1/passports", apptest.AnyMap{
-		"label": label, "scopes": scopes,
-	}, nil, &minted); status != http.StatusCreated {
-		t.Fatalf("issue passport %q → %d", label, status)
-	}
-	if minted.Token == "" {
-		t.Fatalf("passport %q minted without a token", label)
-	}
-	return map[string]string{"Authorization": "Bearer " + minted.Token}
 }
 
 // assertNothingStaged proves the refusal was a cap refusal and not the 🟡

--- a/backend/internal/compose/integration/approval_bundle_http_integration_test.go
+++ b/backend/internal/compose/integration/approval_bundle_http_integration_test.go
@@ -187,7 +187,7 @@ func TestABundleDecisionRefusesAPassport(t *testing.T) {
 		t.Fatalf("create org → %d", status)
 	}
 	bundle := stageBundleRows(t, e, org.ID, "site_lead")
-	agent := passportBearer(t, e, "bundle agent", "read", "write")
+	agent := apptest.PassportBearer(t, e, "bundle agent", "read", "write")
 
 	status := e.Call(t, "POST", "/v1/approval-bundles/"+bundle.String()+"/approve", nil, agent, nil)
 	if status != http.StatusForbidden && status != http.StatusUnauthorized {

--- a/backend/internal/compose/integration/approval_idless_target_integration_test.go
+++ b/backend/internal/compose/integration/approval_idless_target_integration_test.go
@@ -47,7 +47,7 @@ func TestStagedCreateWithNoTargetIDIsListedAndDecidable(t *testing.T) {
 		problem.Code != "approval_required" {
 		t.Fatalf("agent project create → %d %q, want 403 approval_required", status, problem.Code)
 	}
-	approvalID := extractStagedApprovalID(t, problem.Detail)
+	approvalID := ExtractStagedApprovalID(t, problem.Detail)
 
 	// The shape this test is about: the type the approved call will write, and
 	// no row for a scope probe to resolve.

--- a/backend/internal/compose/integration/approval_targetarms_integration_test.go
+++ b/backend/internal/compose/integration/approval_targetarms_integration_test.go
@@ -117,7 +117,7 @@ func TestAStagedPatchIsRefusedWhenItsTargetMovedBeforeTheApproval(t *testing.T) 
 		problem.Code != "approval_required" {
 		t.Fatalf("agent patch → %d %q, want 403 approval_required", status, problem.Code)
 	}
-	approvalID := extractStagedApprovalID(t, problem.Detail)
+	approvalID := ExtractStagedApprovalID(t, problem.Detail)
 
 	// The admin's own edit, on a different field so the guarded patch really
 	// bumps the version rather than finding nothing to change.
@@ -201,7 +201,7 @@ func releaseStagedCall(t *testing.T, e *apptest.AppEnv, bearer map[string]string
 		problem.Code != "approval_required" {
 		t.Fatalf("agent %s %s → %d %q, want 403 approval_required", method, path, status, problem.Code)
 	}
-	approvalID := extractStagedApprovalID(t, problem.Detail)
+	approvalID := ExtractStagedApprovalID(t, problem.Detail)
 
 	assertDecidableInTheInbox(t, e, approvalID, wantTargetType)
 

--- a/backend/internal/compose/integration/apptest/appdsn.go
+++ b/backend/internal/compose/integration/apptest/appdsn.go
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package apptest
+
+import (
+	"os"
+	"testing"
+)
+
+// AppDSN is the app-role DSN the lane hands each package, for a suite or fixture
+// that opens its own connection rather than riding a pool it was given.
+//
+// Fatal rather than skipped when unset, like every other entry point into this
+// lane: a security suite that skipped because its DSN was missing would look
+// exactly like one that passed.
+//
+// It lives in apptest rather than beside the suites because this is the only home
+// every caller can reach. A fixture in apptest cannot import
+// internal/compose/integration (that closes a cycle through compose), so a copy
+// kept there would leave apptest's own callers with a second spelling of the same
+// invariant — which is how there came to be three.
+func AppDSN(t *testing.T) string {
+	t.Helper()
+	dsn := os.Getenv("MARGINCE_TEST_APP_DSN")
+	if dsn == "" {
+		t.Fatal("MARGINCE_TEST_APP_DSN not set — run `make db-up` (integration tests fail loudly, they never skip)")
+	}
+	return dsn
+}

--- a/backend/internal/compose/integration/apptest/appdsn.go
+++ b/backend/internal/compose/integration/apptest/appdsn.go
@@ -17,11 +17,12 @@ import (
 // lane: a security suite that skipped because its DSN was missing would look
 // exactly like one that passed.
 //
-// It lives in apptest rather than beside the suites because this is the only home
-// every caller can reach. A fixture in apptest cannot import
-// internal/compose/integration (that closes a cycle through compose), so a copy
-// kept there would leave apptest's own callers with a second spelling of the same
-// invariant — which is how there came to be three.
+// It lives in apptest rather than in internal/compose/integration because this is
+// the only home every caller can reach, apptest's own fixtures included. Nothing
+// here may import that package: its suites are `package integration` and import
+// this one, so the edge back would close a cycle in their own test binary. A copy
+// kept over there would therefore leave EarlyPool below with a second spelling of
+// the same invariant.
 func AppDSN(t *testing.T) string {
 	t.Helper()
 	dsn := os.Getenv("MARGINCE_TEST_APP_DSN")

--- a/backend/internal/compose/integration/apptest/doc.go
+++ b/backend/internal/compose/integration/apptest/doc.go
@@ -24,11 +24,18 @@
 // illegal Go, so a helper a suite keeps for itself is a function taking *AppEnv,
 // not a method on it.
 //
-// It also holds the AppEnv-keyed fixtures more than one suite package needs —
-// InWorkspace, EarlyPool, and the seeded-pipeline scenario in pipeline.go. They
-// are here for the same structural reason and not because the package is a
-// dumping ground: a fixture taking *AppEnv cannot live in integration's ordinary
-// files (they may not import this package), and a subpackage cannot reach
-// integration's _test.go files at all, so this is the only place two suite
-// packages can both see it. A fixture only ONE suite uses stays with that suite.
+// It also holds the fixtures more than one suite package needs: InWorkspace,
+// EarlyPool, PassportBearer, AppDSN, and the seeded-pipeline scenario in
+// pipeline.go. They are here for a structural reason and not because the package
+// is a dumping ground — two of them, in fact:
+//
+//   - A fixture taking *AppEnv cannot live in integration's ordinary files, since
+//     those may not import this package, and a subpackage cannot reach
+//     integration's _test.go files at all. So this is the only place two suite
+//     packages can both see it.
+//   - A fixture THIS package also calls belongs here even when it touches no
+//     AppEnv — AppDSN is the case, because EarlyPool needs it and nothing here
+//     can import integration. Kept over there it would simply be copied back.
+//
+// A fixture only ONE suite uses stays with that suite.
 package apptest

--- a/backend/internal/compose/integration/apptest/earlypool.go
+++ b/backend/internal/compose/integration/apptest/earlypool.go
@@ -7,7 +7,6 @@ package apptest
 
 import (
 	"context"
-	"os"
 	"testing"
 
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -25,11 +24,7 @@ import (
 // *testing.T has no reason to sit in either one of them.
 func EarlyPool(t *testing.T) *pgxpool.Pool {
 	t.Helper()
-	appDSN := os.Getenv("MARGINCE_TEST_APP_DSN")
-	if appDSN == "" {
-		t.Fatal("MARGINCE_TEST_APP_DSN not set — run `make db-up` (integration tests fail loudly, they never skip)")
-	}
-	pool, err := database.NewPool(context.Background(), appDSN)
+	pool, err := database.NewPool(context.Background(), AppDSN(t))
 	if err != nil {
 		t.Fatalf("opening the pre-boot pool: %v", err)
 	}

--- a/backend/internal/compose/integration/apptest/passport.go
+++ b/backend/internal/compose/integration/apptest/passport.go
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package apptest
+
+import (
+	"net/http"
+	"testing"
+)
+
+// PassportBearer mints a passport with exactly scopes and returns the
+// Authorization header an agent principal presents.
+//
+// Minted through the real endpoint rather than written into the table, because
+// what most callers are proving is that the granting human's live seat and RBAC
+// still cap the passport — a hand-inserted row would skip the admission that
+// caps it.
+//
+// It lives here because it is keyed on AppEnv and suites on both sides of the
+// integration/agentaccess boundary present passports.
+func PassportBearer(t *testing.T, e *AppEnv, label string, scopes ...string) map[string]string {
+	t.Helper()
+	var minted struct {
+		Token string `json:"token"`
+	}
+	if status := e.Call(t, "POST", "/v1/passports", AnyMap{
+		"label": label, "scopes": scopes,
+	}, nil, &minted); status != http.StatusCreated {
+		t.Fatalf("issue passport %q → %d", label, status)
+	}
+	if minted.Token == "" {
+		t.Fatalf("passport %q minted without a token", label)
+	}
+	return map[string]string{"Authorization": "Bearer " + minted.Token}
+}

--- a/backend/internal/compose/integration/apptest/passport.go
+++ b/backend/internal/compose/integration/apptest/passport.go
@@ -13,13 +13,13 @@ import (
 // PassportBearer mints a passport with exactly scopes and returns the
 // Authorization header an agent principal presents.
 //
-// Minted through the real endpoint rather than written into the table, because
-// what most callers are proving is that the granting human's live seat and RBAC
-// still cap the passport — a hand-inserted row would skip the admission that
-// caps it.
+// Minted through the real endpoint, never written into the table: the granting
+// human's live seat and RBAC cap a passport at the moment of issue, so a
+// hand-inserted row is a credential production would not have issued and proves
+// nothing about one that was.
 //
-// It lives here because it is keyed on AppEnv and suites on both sides of the
-// integration/agentaccess boundary present passports.
+// It lives here because it is keyed on AppEnv and more than one suite package
+// presents passports.
 func PassportBearer(t *testing.T, e *AppEnv, label string, scopes ...string) map[string]string {
 	t.Helper()
 	var minted struct {

--- a/backend/internal/compose/integration/e2e_agent_integration_test.go
+++ b/backend/internal/compose/integration/e2e_agent_integration_test.go
@@ -152,7 +152,7 @@ func TestEndToEnd_agentWritesGovernedOnREST(t *testing.T) {
 	if getStatus := e.Call(t, "GET", "/v1/people/"+created.ID, nil, bearer, nil); getStatus != 200 {
 		t.Fatalf("staged archive must not have executed; GET → %d", getStatus)
 	}
-	approvalID := extractStagedApprovalID(t, problem.Detail)
+	approvalID := ExtractStagedApprovalID(t, problem.Detail)
 
 	// The agent may STAGE but never APPROVE — including its own staging.
 	var denyBody struct {
@@ -180,22 +180,6 @@ func TestEndToEnd_agentWritesGovernedOnREST(t *testing.T) {
 	if e.Call(t, "DELETE", "/v1/people/"+created.ID, nil, withToken, &problem) == 200 {
 		t.Fatal("a consumed approval token authorized a second effect")
 	}
-}
-
-// extractStagedApprovalID pulls the staged approval's id out of the 403
-// approval_required detail — the same reference the human inbox lists.
-func extractStagedApprovalID(t *testing.T, detail string) string {
-	t.Helper()
-	const marker = "staged as approval "
-	i := strings.Index(detail, marker)
-	if i < 0 {
-		t.Fatalf("no staged approval reference in %q", detail)
-	}
-	rest := detail[i+len(marker):]
-	if j := strings.IndexByte(rest, ' '); j > 0 {
-		rest = rest[:j]
-	}
-	return rest
 }
 
 // C2: a read seat is a hard capability ceiling — a read-seat human may read

--- a/backend/internal/compose/integration/fieldhistory_http_integration_test.go
+++ b/backend/internal/compose/integration/fieldhistory_http_integration_test.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
-	"os"
 	"testing"
 	"time"
 
@@ -98,8 +97,7 @@ func fieldHistoryHTTPEnv(t *testing.T, e *apptest.AppEnv) *Env {
 	if err := e.Owner.QueryRow(ctx, `SELECT id FROM workspace WHERE slug = $1`, e.Slug).Scan(&ws); err != nil {
 		t.Fatalf("resolving workspace id for %q: %v", e.Slug, err)
 	}
-	appDSN := os.Getenv("MARGINCE_TEST_APP_DSN")
-	pool, err := database.NewPool(ctx, appDSN)
+	pool, err := database.NewPool(ctx, apptest.AppDSN(t))
 	if err != nil {
 		t.Fatalf("opening app pool: %v", err)
 	}

--- a/backend/internal/compose/integration/humanprecedence_createtime_integration_test.go
+++ b/backend/internal/compose/integration/humanprecedence_createtime_integration_test.go
@@ -88,7 +88,7 @@ func TestAgentCannotSilentlyOverwriteCreateTimeHumanValues(t *testing.T) {
 		t.Fatalf("agent money patch → %d %q, want 403 approval_required — the human typed those values at create",
 			status, problem.Code)
 	}
-	approvalID := extractStagedApprovalID(t, problem.Detail)
+	approvalID := ExtractStagedApprovalID(t, problem.Detail)
 
 	// The staged row names the deal, so it reaches the right inbox.
 	var staged struct {

--- a/backend/internal/compose/integration/humanprecedence_integration_test.go
+++ b/backend/internal/compose/integration/humanprecedence_integration_test.go
@@ -180,7 +180,7 @@ func stagePersonAndAgent(t *testing.T, e *apptest.AppEnv, fullName, label string
 // passport per call, exactly as the stdio/hosted transports do.
 func mcpAgentInvoker(t *testing.T, agentToken string) func(tool, args string) (json.RawMessage, error) {
 	t.Helper()
-	pool, err := database.NewPool(context.Background(), AppDSN(t))
+	pool, err := database.NewPool(context.Background(), apptest.AppDSN(t))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/backend/internal/compose/integration/humanprecedence_integration_test.go
+++ b/backend/internal/compose/integration/humanprecedence_integration_test.go
@@ -77,7 +77,7 @@ func TestEndToEnd_humanEditPrecedenceOnAgentUpdate(t *testing.T) {
 	if status := e.Call(t, "GET", "/v1/people/"+person.ID, nil, bearer, &current); status != 200 || current.FullName != "Greta Human" {
 		t.Fatalf("staged overwrite must not have executed: %d %q", status, current.FullName)
 	}
-	approvalID := extractStagedApprovalID(t, problem.Detail)
+	approvalID := ExtractStagedApprovalID(t, problem.Detail)
 
 	// A human decision releases it; the identical retry lands the patch.
 	if status := e.Call(t, "POST", "/v1/approvals/"+approvalID+"/approve", apptest.AnyMap{}, nil, nil); status != 200 {
@@ -180,7 +180,7 @@ func stagePersonAndAgent(t *testing.T, e *apptest.AppEnv, fullName, label string
 // passport per call, exactly as the stdio/hosted transports do.
 func mcpAgentInvoker(t *testing.T, agentToken string) func(tool, args string) (json.RawMessage, error) {
 	t.Helper()
-	pool, err := database.NewPool(context.Background(), envDSN(t))
+	pool, err := database.NewPool(context.Background(), AppDSN(t))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/backend/internal/compose/integration/offerregenerate_http_integration_test.go
+++ b/backend/internal/compose/integration/offerregenerate_http_integration_test.go
@@ -19,7 +19,6 @@ package integration
 import (
 	"context"
 	"net/http"
-	"os"
 	"testing"
 
 	"github.com/gradionhq/margince/backend/internal/compose"
@@ -43,11 +42,7 @@ import (
 // scripted candidate needs to cite a source_id minted during that seed).
 func setupWithOfferDraft(t *testing.T) (*apptest.AppEnv, *ai.FakeClient) {
 	t.Helper()
-	appDSN := os.Getenv("MARGINCE_TEST_APP_DSN")
-	if appDSN == "" {
-		t.Fatal("MARGINCE_TEST_APP_DSN not set — run `make db-up` (integration tests fail loudly, they never skip)")
-	}
-	pool, err := database.NewPool(context.Background(), appDSN)
+	pool, err := database.NewPool(context.Background(), apptest.AppDSN(t))
 	if err != nil {
 		t.Fatalf("opening the offer-draft retriever's pool: %v", err)
 	}

--- a/backend/internal/compose/integration/relationship_integration_test.go
+++ b/backend/internal/compose/integration/relationship_integration_test.go
@@ -169,7 +169,7 @@ func TestArchivingAnEdgeStagesForAnAgentAndPinsItsVersion(t *testing.T) {
 	if status != http.StatusForbidden || problem.Code != "approval_required" {
 		t.Fatalf("agent archive → %d %q, want 403 approval_required", status, problem.Code)
 	}
-	approvalID := extractStagedApprovalID(t, problem.Detail)
+	approvalID := ExtractStagedApprovalID(t, problem.Detail)
 
 	// The pin the STAGING read produced. Without it the approval would authorize
 	// the archive against whatever the edge had drifted to inside the TTL — and a
@@ -323,7 +323,7 @@ func TestAnApprovalStaysDecidableAfterItsEdgeIsArchived(t *testing.T) {
 		map[string]string{"Authorization": "Bearer " + minted.Token}, &problem); status != http.StatusForbidden {
 		t.Fatalf("agent archive → %d, want 403 approval_required", status)
 	}
-	approvalID := extractStagedApprovalID(t, problem.Detail)
+	approvalID := ExtractStagedApprovalID(t, problem.Detail)
 
 	// The human archives the edge themselves, which is exactly the race the
 	// approval was staged into: the target is gone before anyone decided.

--- a/backend/internal/compose/integration/suitefixtures.go
+++ b/backend/internal/compose/integration/suitefixtures.go
@@ -44,11 +44,16 @@ func ExtractStagedApprovalID(t *testing.T, detail string) string {
 	if i < 0 {
 		t.Fatalf("no staged approval reference in %q", detail)
 	}
-	rest := detail[i+len(marker):]
-	if j := strings.IndexByte(rest, ' '); j > 0 {
-		rest = rest[:j]
+	// Fields rather than a scan to the next space, so a marker with nothing after
+	// it fails HERE. Returning the empty remainder would send the caller to
+	// /v1/approvals/ with no id, and the 404 that came back would be reported as
+	// the approval not existing — which is the one thing the suite is trying to
+	// find out.
+	rest := strings.Fields(detail[i+len(marker):])
+	if len(rest) == 0 {
+		t.Fatalf("the staged-approval reference in %q names no id", detail)
 	}
-	return rest
+	return rest[0]
 }
 
 // GoBDFloorPack is the six-calendar-year correspondence floor the retention

--- a/backend/internal/compose/integration/suitefixtures.go
+++ b/backend/internal/compose/integration/suitefixtures.go
@@ -7,7 +7,6 @@ package integration
 
 import (
 	"context"
-	"os"
 	"strings"
 	"testing"
 
@@ -31,21 +30,6 @@ import (
 // imports compose, and compose's white-box tests import this package, so an
 // ordinary file here that reaches apptest closes an import cycle. A fixture that
 // takes an *apptest.AppEnv therefore belongs in apptest, not here.
-
-// AppDSN is the app-role DSN the lane hands each package, for a suite that opens
-// its own connection rather than riding a fixture's pool.
-//
-// Fatal rather than skipped when unset, like every other entry point into this
-// lane: a security suite that skipped because its DSN was missing would look
-// exactly like one that passed.
-func AppDSN(t *testing.T) string {
-	t.Helper()
-	dsn := os.Getenv("MARGINCE_TEST_APP_DSN")
-	if dsn == "" {
-		t.Fatal("MARGINCE_TEST_APP_DSN not set — run `make db-up` (integration tests fail loudly, they never skip)")
-	}
-	return dsn
-}
 
 // ExtractStagedApprovalID pulls the staged approval's id out of the 403
 // approval_required detail — the same reference the human inbox lists.

--- a/backend/internal/compose/integration/suitefixtures.go
+++ b/backend/internal/compose/integration/suitefixtures.go
@@ -7,6 +7,8 @@ package integration
 
 import (
 	"context"
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/jackc/pgx/v5"
@@ -29,6 +31,41 @@ import (
 // imports compose, and compose's white-box tests import this package, so an
 // ordinary file here that reaches apptest closes an import cycle. A fixture that
 // takes an *apptest.AppEnv therefore belongs in apptest, not here.
+
+// AppDSN is the app-role DSN the lane hands each package, for a suite that opens
+// its own connection rather than riding a fixture's pool.
+//
+// Fatal rather than skipped when unset, like every other entry point into this
+// lane: a security suite that skipped because its DSN was missing would look
+// exactly like one that passed.
+func AppDSN(t *testing.T) string {
+	t.Helper()
+	dsn := os.Getenv("MARGINCE_TEST_APP_DSN")
+	if dsn == "" {
+		t.Fatal("MARGINCE_TEST_APP_DSN not set — run `make db-up` (integration tests fail loudly, they never skip)")
+	}
+	return dsn
+}
+
+// ExtractStagedApprovalID pulls the staged approval's id out of the 403
+// approval_required detail — the same reference the human inbox lists.
+//
+// Reading it out of the message is deliberate: it is the only reference a 🟡
+// caller is given, so a suite that resolved the id any other way would stop
+// proving that the refusal hands back something actionable.
+func ExtractStagedApprovalID(t *testing.T, detail string) string {
+	t.Helper()
+	const marker = "staged as approval "
+	i := strings.Index(detail, marker)
+	if i < 0 {
+		t.Fatalf("no staged approval reference in %q", detail)
+	}
+	rest := detail[i+len(marker):]
+	if j := strings.IndexByte(rest, ' '); j > 0 {
+		rest = rest[:j]
+	}
+	return rest
+}
 
 // GoBDFloorPack is the six-calendar-year correspondence floor the retention
 // suites test against — a stand-in jurisdiction under a reserved code, not the


### PR DESCRIPTION
The third slice off the lane's long pole, after #859 (channels) and #866
(webhooks). `integration/agentaccess` holds how a non-human caller is admitted and
what it may then do: OAuth discovery, DCR, consent and its refusals, grant,
refresh, revocation and lending, the passports those tokens carry, the MCP
transport that presents them — handshake, framing, deadlines, tasks — and the
vocabulary that surface publishes. **16 files, 13.25s of measured test time.**

## Credentials and transport are one package on purpose

ADR-0055 governs a passport identically whether it arrives on REST or on `/mcp`.
The suites already reflected that: they share the connector harness and the
minted-passport fixture, so splitting them would put a token's issue and its
presentation in different binaries.

## Fixtures: three promoted, four avoided

Promoted, each with callers on both sides of the new boundary:

| fixture | home | why there |
|---|---|---|
| `PassportBearer` | `apptest` | keyed on `*AppEnv`; `integration`'s ordinary files cannot import `apptest` without closing a cycle through `compose` |
| `ExtractStagedApprovalID` | `suitefixtures.go` | takes only strings, 8 remaining parent callers |
| `AppDSN` | `suitefixtures.go` | takes only `*testing.T` |

Four other cross-boundary references turned out to be **avoidable rather than
promotable**, which is the cheaper answer: two were decoded into a variable nothing
ever read (so the target became `nil`), and two were wire types where the moved
suite reads two fields of a shape another suite owns (so it decodes those two).
Promoting them would have exported three types to serve one caller each.

## What blocked it, and what unblocked it

This branch sat parked because moving the files turned
`TestEnrichmentWritesProjectAsRealColumnDiffs` red in the parent — filed as #876.
That test asserted a field would be **absent** from a record's change timeline,
and passed only because the column that field fills was usually already populated;
a slice changes what has run beforehand, so it stopped being populated.

I deliberately did not fix it here: the two candidate fixes were "the test is
wrong" and "the field should not be column-backed", the second changes what the
company page's Changes filter shows a reader, and the code is internally
consistent either way — a spec question, not a test adjustment. **#874 fixed it on
`main` independently**, choosing the first: `offer_summary` must appear, with `icp`
added to carry the absence assertion. Rebasing picked that up and this branch went
green unchanged.

STATUS.md now records that a slice reliably finds one such test, and to read the
failure as a test-isolation defect before reading it as the slice's fault.

## Measurement, and what is NOT claimed

No before/after wall clock. `main` gained ~86 tests between this branch point and
the verifying run, and total package seconds rose 45% on a loaded machine (672s →
974s), so the parent's own test seconds went *up* across it. A wall comparison
under those conditions would be noise. The **13.25s** is the per-file measurement
the grouping was chosen from, aggregated from a verbose run.

Also worth setting expectations, now recorded in STATUS.md: after this slice the
parent is ~118s of measured test seconds, and `./migrations` (96s) and
`./internal/compose` (92s) are the next poles — so **one more slice roughly reaches
them and a fourth buys nothing** until those two are addressed.

## Verification

- `make test-it DIR=…/integration/agentaccess` — green, 66 tests, 17.8s.
- `make test-it DIR=…/integration` (parent) — green, 125.45s, 0 failures.
- `make test-integration` (full lane) — green, 37 packages, 2215 tests, 0 skips.
- `make check-backend` — green.
- `go vet` with no build tag — clean, so the unit lane still builds.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split agent-access integration tests into a new package `integration/agentaccess` to open another scheduling slot and cut the long pole by ~13.25s. Clarified boundaries, promoted shared fixtures, consolidated DSN handling, and tightened diagnostics; no behavior changes.

- **Refactors**
  - New `integration/agentaccess` package: OAuth discovery/DCR/consent/refusals/grant/refresh/revoke/lend, passports, MCP handshake/framing/deadlines/tasks, and query vocabulary.
  - Promoted fixtures: `apptest.PassportBearer`, `integration.ExtractStagedApprovalID`, `apptest.AppDSN`; `apptest.EarlyPool` now uses `AppDSN`; updated call sites across suites (removed local `envDSN`).
  - Narrowed decodes to needed fields (e.g., `/v1/agent-tools`, custom field create), dropped duplicated wire types, updated imports to `integration` and `integration/apptest`.
  - Docs: `STATUS.md` credits slice `#913` and clarifies fixture placement rules; `integration/agentaccess/doc.go` records the real pins (agentscope via offers fixtures) and what stayed by choice.

- **Bug Fixes**
  - `integration.ExtractStagedApprovalID` now validates and fails fast when the id is missing (uses `strings.Fields`), preventing misleading 404s.
  - DSN reads now fail loudly via `apptest.AppDSN` (e.g., `offerregenerate_http`, `fieldhistory_http`); custom-field create in `queryvocabulary` decodes RFC 7807 `title/detail`; `readPassport` distinguishes non-201 from 201-without-token.
  - Rebase: `accountsend_agent_integration_test.go` now calls the promoted helper.

<sup>Written for commit 6c56e442ff95530dc30d7f6f6fe871659550e8c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/913?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Reorganized OAuth, MCP, passport, and query integration coverage into focused suites.
  - Added shared test support for application database access, passport authentication, and staged approval handling.
  - Improved diagnostics and response validation for custom-field and authentication scenarios.
  - Updated integration testing guidance, including fixture placement and potential test-order isolation issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->