### PR TITLE
refactor(collections,consent): two more modules read through the bound pool

### DIFF
--- a/backend/internal/compose/comms_integration_test.go
+++ b/backend/internal/compose/comms_integration_test.go
@@ -79,7 +79,7 @@ func TestCommsAdapterSharesTheGovernedPaths(t *testing.T) {
 	stager := &recordingStager{}
 	adapter := commsAdapter{
 		store:  activities.NewStore(e.Pool),
-		gate:   consent.NewGate(consent.NewStore(e.Pool)),
+		gate:   consent.NewGate(consent.NewStore(InstallationDB(e.Pool))),
 		stager: stager,
 	}
 	ctx := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.SchedulerPerms)

--- a/backend/internal/compose/commsjobs.go
+++ b/backend/internal/compose/commsjobs.go
@@ -438,7 +438,7 @@ func newSendWorker(pool *pgxpool.Pool, registry *capture.Registry, pacing SendPa
 		commsResolver{registry: registry, channels: registry},
 		NewSendSeatAuthority(pool),
 		NewSendAttachmentAuthority(pool),
-		consent.NewGate(consent.NewStore(pool)),
+		consent.NewGate(consent.NewStore(InstallationDB(pool))),
 		[]comms.SendPolicy{comms.NewMailboxRatePolicy(p.Limit, p.Window, time.Now)},
 		time.Now,
 		p.MaxAge,

--- a/backend/internal/compose/handlersets.go
+++ b/backend/internal/compose/handlersets.go
@@ -75,7 +75,7 @@ type (
 // same overlay refusal. Its own function so the composition root reads as a
 // list of what is wired rather than how each piece is built.
 func (srv *Server) wirePerson360(pool *pgxpool.Pool) {
-	srv.person360Svc = person360.NewService(pool, srv.peopleStore, consent.NewStore(pool), ai.NewFeedbackStore(pool), time.Now)
+	srv.person360Svc = person360.NewService(pool, srv.peopleStore, consent.NewStore(InstallationDB(pool)), ai.NewFeedbackStore(pool), time.Now)
 	srv.person360Handlers = person360.NewHandlers(srv.person360Svc, srv.sorDispatch.isOverlay)
 	// The relationship brief is assembled from the SAME composite read the page
 	// serves, so the two cannot disagree about what this caller may see. No

--- a/backend/internal/compose/integration/approval_personaltarget_integration_test.go
+++ b/backend/internal/compose/integration/approval_personaltarget_integration_test.go
@@ -35,7 +35,7 @@ import (
 func TestAStagedViewArchiveIsDecidableByItsOwnerAlone(t *testing.T) {
 	e := Setup(t)
 	svc := approvals.NewService(e.Pool)
-	views := collections.NewStore(e.Pool)
+	views := collections.NewStore(e.DB())
 
 	owner := e.As(e.Rep1, []ids.UUID{e.Team1}, collectionsPerms())
 	view, err := views.CreateSavedView(owner, collections.CreateSavedViewInput{

--- a/backend/internal/compose/integration/approval_targetreadfloor_integration_test.go
+++ b/backend/internal/compose/integration/approval_targetreadfloor_integration_test.go
@@ -47,7 +47,7 @@ func tagPerms(g principal.ObjectGrant) principal.Permissions {
 func TestAStagedTagArchiveNeedsTagReadAndNotOnlyTagDelete(t *testing.T) {
 	e := Setup(t)
 	svc := approvals.NewService(e.Pool)
-	tags := collections.NewStore(e.Pool)
+	tags := collections.NewStore(e.DB())
 
 	author := e.As(e.Rep1, []ids.UUID{e.Team1},
 		tagPerms(principal.ObjectGrant{Create: true, Read: true, Delete: true}))

--- a/backend/internal/compose/integration/comms_send_integration_test.go
+++ b/backend/internal/compose/integration/comms_send_integration_test.go
@@ -183,7 +183,7 @@ func (p *preflightEnv) dispatchOnce(t *testing.T, deliveryID ids.UUID, stampAs s
 		stubMailbox{sender: gmailConnector, auth: auth},
 		compose.NewSendSeatAuthority(p.Pool),
 		compose.NewSendAttachmentAuthority(p.Pool),
-		consent.NewGate(consent.NewStore(p.Pool)),
+		consent.NewGate(consent.NewStore(compose.InstallationDB(p.Pool))),
 		nil, time.Now, 24*time.Hour, 10,
 	)
 	// A job carries no session. The scope comes from the composition rather

--- a/backend/internal/compose/integration/declaredfilters_integration_test.go
+++ b/backend/internal/compose/integration/declaredfilters_integration_test.go
@@ -49,7 +49,7 @@ func TestThePersonListNarrowsByTagName(t *testing.T) {
 	tagged := e.SeedPerson(t, "Tagged Person", nil)
 	e.SeedPerson(t, "Untagged Person", nil)
 
-	tags := collections.NewStore(e.Pool)
+	tags := collections.NewStore(e.DB())
 	curator := tagCurator(e)
 	vip, err := tags.CreateTag(curator, "VIP", nil)
 	if err != nil {

--- a/backend/internal/compose/integration/dsr_erasure_fulfil_integration_test.go
+++ b/backend/internal/compose/integration/dsr_erasure_fulfil_integration_test.go
@@ -39,14 +39,14 @@ import (
 // the store an assertion can read the request back through.
 func setupErasureDSR(t *testing.T, e *Env, subjectRef string) (consent.Handlers, *consent.Store, ids.UUID) {
 	t.Helper()
-	store := consent.NewStore(e.Pool)
+	store := consent.NewStore(e.DB())
 	created, err := store.CreateDSR(e.Admin(), consent.CreateDSRInput{
 		Kind: "erasure", SubjectRef: subjectRef, DueAt: time.Date(2026, 8, 31, 0, 0, 0, 0, time.UTC),
 	})
 	if err != nil {
 		t.Fatalf("creating erasure DSR: %v", err)
 	}
-	h := consent.NewHandlers(e.Pool).WithEraser(privacy.NewEraser(e.Pool))
+	h := consent.NewHandlers(e.DB()).WithEraser(privacy.NewEraser(e.Pool))
 	return h, store, created.ID
 }
 
@@ -204,7 +204,7 @@ func TestFulfillErasureHoldsTheRequestLockedAcrossTheErase(t *testing.T) {
 	e := Setup(t)
 	personID := e.SeedPerson(t, "Locked Subject", nil)
 
-	store := consent.NewStore(e.Pool)
+	store := consent.NewStore(e.DB())
 	created, err := store.CreateDSR(e.Admin(), consent.CreateDSRInput{
 		Kind: "erasure", SubjectRef: personID.String(), DueAt: time.Date(2026, 8, 31, 0, 0, 0, 0, time.UTC),
 	})
@@ -216,7 +216,7 @@ func TestFulfillErasureHoldsTheRequestLockedAcrossTheErase(t *testing.T) {
 		entered: make(chan struct{}),
 		release: make(chan struct{}),
 	}
-	h := consent.NewHandlers(e.Pool).WithEraser(gate)
+	h := consent.NewHandlers(e.DB()).WithEraser(gate)
 
 	done := make(chan *httptest.ResponseRecorder, 1)
 	go func() {

--- a/backend/internal/compose/integration/erasure_integration_test.go
+++ b/backend/internal/compose/integration/erasure_integration_test.go
@@ -232,7 +232,7 @@ func TestErasureRetiresTheSubjectsPreferenceToken(t *testing.T) {
 	e := Setup(t)
 	personID := seedSubject(t, e)
 	token := seededPreferenceToken(personID)
-	store := consent.NewStore(e.Pool)
+	store := consent.NewStore(e.DB())
 
 	// The fixture is live first, so the assertion below measures the erasure
 	// and not a token that never worked.

--- a/backend/internal/compose/integration/erasure_killswitch_integration_test.go
+++ b/backend/internal/compose/integration/erasure_killswitch_integration_test.go
@@ -85,7 +85,7 @@ func TestErasingASubjectNeutralizesTheirQueuedSend(t *testing.T) {
 		// nothing here and would hide a regression that let the send get far
 		// enough to ask about attachments at all.
 		nil,
-		consent.NewGate(consent.NewStore(e.Pool)),
+		consent.NewGate(consent.NewStore(e.DB())),
 		nil, time.Now, 24*time.Hour, 10,
 	)
 	// The dispatch runs under the scope compose assembles, which is the half of

--- a/backend/internal/compose/integration/meetingbrief_integration_test.go
+++ b/backend/internal/compose/integration/meetingbrief_integration_test.go
@@ -31,7 +31,7 @@ import (
 )
 
 func meetingBriefService(e *Env) *meetingbrief.Service {
-	view := person360.NewService(e.Pool, e.People, consent.NewStore(e.Pool),
+	view := person360.NewService(e.Pool, e.People, consent.NewStore(e.DB()),
 		ai.NewFeedbackStore(e.Pool), func() time.Time { return roomFixedNow })
 	return meetingbrief.NewService(e.Pool, view, e.People, func() time.Time { return roomFixedNow })
 }

--- a/backend/internal/compose/integration/person360_http_integration_test.go
+++ b/backend/internal/compose/integration/person360_http_integration_test.go
@@ -33,7 +33,7 @@ func nativeWorkspace(context.Context) (bool, error) { return false, nil }
 
 func personHandlers(e *Env) person360.Handlers {
 	return person360.NewHandlers(
-		person360.NewService(e.Pool, e.People, consent.NewStore(e.Pool),
+		person360.NewService(e.Pool, e.People, consent.NewStore(e.DB()),
 			ai.NewFeedbackStore(e.Pool), func() time.Time { return roomFixedNow }),
 		nativeWorkspace,
 	)

--- a/backend/internal/compose/integration/person_relationship_room_integration_test.go
+++ b/backend/internal/compose/integration/person_relationship_room_integration_test.go
@@ -54,7 +54,7 @@ var roomPerms = principal.Permissions{
 }
 
 func personRoomService(e *Env) *person360.Service {
-	return person360.NewService(e.Pool, e.People, consent.NewStore(e.Pool),
+	return person360.NewService(e.Pool, e.People, consent.NewStore(e.DB()),
 		ai.NewFeedbackStore(e.Pool), func() time.Time { return roomFixedNow })
 }
 

--- a/backend/internal/compose/integration/preference_token_integration_test.go
+++ b/backend/internal/compose/integration/preference_token_integration_test.go
@@ -56,7 +56,7 @@ func livePreferenceTokens(t *testing.T, e *Env) int {
 // marketing mail with no working List-Unsubscribe URL.
 func TestPreferenceTokenMintRefusesAnInvisibleRecipient(t *testing.T) {
 	e := Setup(t)
-	store := consent.NewStore(e.Pool)
+	store := consent.NewStore(e.DB())
 
 	seedRecipient(t, e, "Foreign Recipient", "foreign@recipient.test", &e.Rep2)
 	seedRecipient(t, e, "Own Recipient", "own@recipient.test", &e.Rep1)
@@ -120,7 +120,7 @@ func preferenceTokenRevoked(t *testing.T, e *Env, token string) bool {
 // and the next send rotates rather than reviving it.
 func TestPreferenceTokenExpiresAndTheNextSendRotatesIt(t *testing.T) {
 	e := Setup(t)
-	store := consent.NewStore(e.Pool)
+	store := consent.NewStore(e.DB())
 	seedRecipient(t, e, "Bulk Recipient", "bulk@recipient.test", &e.Rep1)
 	admin := e.Admin()
 
@@ -164,7 +164,7 @@ func TestPreferenceTokenExpiresAndTheNextSendRotatesIt(t *testing.T) {
 // even though the refreshed window is still open.
 func TestPreferenceTokenRotatesPastItsAgeCeiling(t *testing.T) {
 	e := Setup(t)
-	store := consent.NewStore(e.Pool)
+	store := consent.NewStore(e.DB())
 	seedRecipient(t, e, "Long Subscriber", "subscriber@recipient.test", &e.Rep1)
 	admin := e.Admin()
 
@@ -198,7 +198,7 @@ func TestPreferenceTokenRotatesPastItsAgeCeiling(t *testing.T) {
 // a refusal, or the send path becomes an in-CRM/not-in-CRM oracle.
 func TestPreferenceTokenMintIsSilentForAnUnknownAddress(t *testing.T) {
 	e := Setup(t)
-	store := consent.NewStore(e.Pool)
+	store := consent.NewStore(e.DB())
 
 	token, found, err := store.PreferenceTokenForEmail(e.Admin(), "stranger@nowhere.test")
 	if err != nil || found || token != "" {

--- a/backend/internal/compose/integration/smartlist_integration_test.go
+++ b/backend/internal/compose/integration/smartlist_integration_test.go
@@ -59,7 +59,7 @@ func (e *Env) adminCollectionsCtx() context.Context {
 
 func TestDynamicList_membershipIsRowScopedToTheCaller(t *testing.T) {
 	e := Setup(t)
-	store := collections.NewStore(e.Pool)
+	store := collections.NewStore(e.DB())
 
 	mine := e.SeedPerson(t, "Mine Renewal", &e.Rep1)
 	foreign := e.SeedPerson(t, "Foreign Renewal", &e.Rep3)
@@ -108,7 +108,7 @@ func TestDynamicList_membershipIsRowScopedToTheCaller(t *testing.T) {
 
 func TestDynamicList_reEvaluatesLiveAsRecordsChange(t *testing.T) {
 	e := Setup(t)
-	store := collections.NewStore(e.Pool)
+	store := collections.NewStore(e.DB())
 	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, collectionsPerms())
 
 	created, err := store.CreateList(rep, collections.CreateListInput{
@@ -158,7 +158,7 @@ func TestDynamicList_reEvaluatesLiveAsRecordsChange(t *testing.T) {
 
 func TestDynamicList_rejectsInvalidDefinition(t *testing.T) {
 	e := Setup(t)
-	store := collections.NewStore(e.Pool)
+	store := collections.NewStore(e.DB())
 	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, collectionsPerms())
 
 	assertCode := func(name string, def map[string]any, wantCode string) {
@@ -190,7 +190,7 @@ func TestDynamicList_rejectsInvalidDefinition(t *testing.T) {
 
 func TestSavedView_roundTripsAndIsPerUser(t *testing.T) {
 	e := Setup(t)
-	store := collections.NewStore(e.Pool)
+	store := collections.NewStore(e.DB())
 	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, collectionsPerms())
 
 	query := map[string]any{

--- a/backend/internal/compose/integration/workflow_action_executors_integration_test.go
+++ b/backend/internal/compose/integration/workflow_action_executors_integration_test.go
@@ -154,7 +154,7 @@ func TestAddToListFiringAddsARealListMember(t *testing.T) {
 	pipeline, open, _ := DealFixture(t, e)
 	dealID := e.SeedDeal(t, "Add To List Probe Deal", pipeline, open, nil)
 
-	listsStore := collections.NewStore(e.Pool)
+	listsStore := collections.NewStore(e.DB())
 	// The harness AdminPerms grants the core record objects but not `list`,
 	// so seed the probe list as a seeded user carrying an explicit list
 	// grant — the automation firing below is what the test exercises, not

--- a/backend/internal/compose/preference_agent_integration_test.go
+++ b/backend/internal/compose/preference_agent_integration_test.go
@@ -31,7 +31,7 @@ import (
 
 func TestPreferenceCenterOptOutBlocksAgentSend(t *testing.T) {
 	e := integration.Setup(t)
-	consentStore := consent.NewStore(e.Pool)
+	consentStore := consent.NewStore(InstallationDB(e.Pool))
 	stager := &recordingStager{}
 	// Built through the composition root, not by hand: a marketing send is
 	// exactly the case whose derivation depends on the unsubscribe linker and

--- a/backend/internal/compose/routes.go
+++ b/backend/internal/compose/routes.go
@@ -147,7 +147,7 @@ func operationalMux(srv Server, pool *pgxpool.Pool, log *slog.Logger, identitySv
 	// workspace-scoped call like any other /v1 route, and mounting it on the
 	// operational mux instead would win the longest-pattern match against
 	// "/v1/" and serve without a session. See extensionEdge.
-	publicEdge := publicPreferences(consent.NewStore(pool), newPublicPreferenceLimiters())(
+	publicEdge := publicPreferences(consent.NewStore(InstallationDB(pool)), newPublicPreferenceLimiters())(
 		publicBooking(activities.NewStore(pool), newPublicBookingLimiters())(
 			extensionEdge(srv, log)(api),
 		),

--- a/backend/internal/compose/senddeliverability_integration_test.go
+++ b/backend/internal/compose/senddeliverability_integration_test.go
@@ -30,7 +30,7 @@ const toolSurfaceBaseURL = "https://mail.example.test"
 
 func TestToolSurfaceSendCarriesTheUnsubscribeSurface(t *testing.T) {
 	e := integration.Setup(t)
-	consentStore := consent.NewStore(e.Pool)
+	consentStore := consent.NewStore(InstallationDB(e.Pool))
 	admin := e.Admin()
 
 	person := e.SeedPerson(t, "Newsletter Reader", &e.Rep1)

--- a/backend/internal/compose/sendpath.go
+++ b/backend/internal/compose/sendpath.go
@@ -123,7 +123,7 @@ func (s *Server) applySendPath(pool *pgxpool.Pool) {
 func sendStore(pool *pgxpool.Pool, send SendPath) *activities.Store {
 	send = send.withPoolDefaults(pool)
 	return activities.NewStore(pool).
-		WithUnsubscribe(preferenceLinkAdapter{store: consent.NewStore(pool)}).
+		WithUnsubscribe(preferenceLinkAdapter{store: consent.NewStore(InstallationDB(pool))}).
 		WithPublicBaseURL(send.PublicBaseURL).
 		WithSendAuthority(send.SendAuthority).
 		WithChannelReachability(send.ChannelRecipients).
@@ -142,7 +142,7 @@ func sendStore(pool *pgxpool.Pool, send SendPath) *activities.Store {
 func newCommsAdapter(pool *pgxpool.Pool, drafter activities.EmailDrafter, send SendPath) commsAdapter {
 	return commsAdapter{
 		store:         sendStore(pool, send),
-		gate:          consent.NewGate(consent.NewStore(pool)),
+		gate:          consent.NewGate(consent.NewStore(InstallationDB(pool))),
 		draft:         drafter,
 		stager:        send.Delivery,
 		channelStager: send.Delivery,

--- a/backend/internal/compose/sendvoiceoutcome_integration_test.go
+++ b/backend/internal/compose/sendvoiceoutcome_integration_test.go
@@ -170,7 +170,7 @@ func setupVoiceSend(t *testing.T) *voiceSendEnv {
 	person := e.SeedPerson(t, "Draft Reader", &e.Rep1)
 	addPersonEmail(t, e, person, recipient)
 	admin := e.Admin()
-	store := consent.NewStore(e.Pool)
+	store := consent.NewStore(InstallationDB(e.Pool))
 	purpose, err := store.CreatePurpose(admin, "transactional", "Transactional", false)
 	if err != nil {
 		t.Fatalf("create purpose: %v", err)
@@ -220,7 +220,7 @@ func TestBothSendTransportsCarryTheDraftOutcomeRecorder(t *testing.T) {
 		store := sendStore(e.Pool, SendPath{PublicBaseURL: voiceSendBaseURL, Delivery: stager})
 
 		if _, err := store.SendEmail(e.ctx, activities.FromActivity(ids.From[ids.ActivityKind](e.anchor)),
-			e.draftedSend(draft.ref), consent.NewGate(consent.NewStore(e.Pool)), stager); err != nil {
+			e.draftedSend(draft.ref), consent.NewGate(consent.NewStore(InstallationDB(e.Pool))), stager); err != nil {
 			t.Fatalf("send through the tool surface's store: %v", err)
 		}
 		assertStaged(t, stager, 1, "the send through the tool surface's store")
@@ -357,7 +357,7 @@ func TestConcurrentSendsSharingADraftReferenceLeaveOneOutcomeAndBothTransmit(t *
 		PublicBaseURL: voiceSendBaseURL, Delivery: loserStager, DraftOutcome: loser,
 	})
 
-	gate := consent.NewGate(consent.NewStore(e.Pool))
+	gate := consent.NewGate(consent.NewStore(InstallationDB(e.Pool)))
 	anchor := ids.From[ids.ActivityKind](e.anchor)
 	var wg sync.WaitGroup
 	var winnerErr, loserErr error

--- a/backend/internal/compose/server.go
+++ b/backend/internal/compose/server.go
@@ -368,8 +368,8 @@ func newServer(pool *pgxpool.Pool, log *slog.Logger, authH authHandlers, dealsH 
 		jobHealthHandlers: jobHealthHandlers{pool: pool},
 		// DSR fulfillment executes privacy's erase path — injected here so
 		// consent never imports its sibling.
-		consentHandlers:     consent.NewHandlers(pool).WithEraser(privacy.NewEraser(pool)),
-		collectionsHandlers: collections.NewHandlers(pool),
+		consentHandlers:     consent.NewHandlers(InstallationDB(pool)).WithEraser(privacy.NewEraser(pool)),
+		collectionsHandlers: collections.NewHandlers(InstallationDB(pool)),
 		// The warm room ranks its contact edges by the §4 relationship
 		// strength owned by people; injected through the adapter below so
 		// signals never imports its sibling.

--- a/backend/internal/compose/serverassembly.go
+++ b/backend/internal/compose/serverassembly.go
@@ -51,14 +51,14 @@ func newPeopleHandlers(pool *pgxpool.Pool) peopleHandlers {
 // modules its inbound and outbound edges need.
 func newActivitiesHandlers(pool *pgxpool.Pool) activitiesHandlers {
 	return activities.NewHandlers(pool).
-		WithConsent(consent.NewGate(consent.NewStore(pool))).
+		WithConsent(consent.NewGate(consent.NewStore(InstallationDB(pool)))).
 		// The public booking capture seams (feedback/14): people is the
 		// idempotent-on-email person path, consent records the
 		// passthrough — both injected here, never sibling imports.
-		WithPublicBooking(people.NewStore(pool), bookingConsentAdapter{store: consent.NewStore(pool)}).
+		WithPublicBooking(people.NewStore(pool), bookingConsentAdapter{store: consent.NewStore(InstallationDB(pool))}).
 		// The RFC 8058 unsubscribe linker (B-E11.32): consent mints the
 		// preference token behind the List-Unsubscribe URL.
-		WithUnsubscribe(preferenceLinkAdapter{store: consent.NewStore(pool)})
+		WithUnsubscribe(preferenceLinkAdapter{store: consent.NewStore(InstallationDB(pool))})
 }
 
 // wireCaptureSettingsSurface binds the workspace's own capture posture
@@ -86,7 +86,7 @@ func (s *Server) wireExportSurface(pool *pgxpool.Pool, log *slog.Logger) {
 	// predicate engine + the bundle writer's open-format rendering; the
 	// collections store resolves a saved view / dynamic list source
 	// behind its own visibility gate.
-	s.filteredExportHandlers = filteredExportHandlers{writer: NewFilteredExportWriter(pool), collections: collections.NewStore(pool)}
+	s.filteredExportHandlers = filteredExportHandlers{writer: NewFilteredExportWriter(pool), collections: collections.NewStore(InstallationDB(pool))}
 	s.overlayExportHandlers = newOverlayExportHandlers(pool, log)
 }
 

--- a/backend/internal/compose/workflows.go
+++ b/backend/internal/compose/workflows.go
@@ -62,7 +62,7 @@ func workflowEngineWithDrafter(pool *pgxpool.Pool, drafter activities.EmailDraft
 	ex := automation.Executors{
 		Provider:  NewDispatcher(NewProvider(pool), NewOverlayProvider(pool, failClosedOverlayMeter(), nil), pool),
 		Approvals: automationApprovalsAdapter{svc: approvals.NewService(pool)},
-		Lists:     listsAdapter{store: collections.NewStore(pool)},
+		Lists:     listsAdapter{store: collections.NewStore(InstallationDB(pool))},
 		// The zero SendPath is the honest one here: a send_email action
 		// stages an approval instead of sending, and automation.Comms
 		// declares DraftEmail alone, so no send is reachable from this

--- a/backend/internal/modules/collections/handlers.go
+++ b/backend/internal/modules/collections/handlers.go
@@ -7,10 +7,10 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/jackc/pgx/v5/pgxpool"
 	openapi_types "github.com/oapi-codegen/runtime/types"
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/platform/httperr"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
@@ -39,8 +39,9 @@ type Handlers struct {
 	store *Store
 }
 
-func NewHandlers(pool *pgxpool.Pool) Handlers {
-	return Handlers{store: NewStore(pool)}
+// NewHandlers wires the transport over the installation-bound pool.
+func NewHandlers(db *database.DB) Handlers {
+	return Handlers{store: NewStore(db)}
 }
 
 func (h Handlers) ListLists(w http.ResponseWriter, r *http.Request, params crmcontracts.ListListsParams) {

--- a/backend/internal/modules/collections/lists.go
+++ b/backend/internal/modules/collections/lists.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgxpool"
 	openapi_types "github.com/oapi-codegen/runtime/types"
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
@@ -26,11 +25,13 @@ import (
 )
 
 type Store struct {
-	pool *pgxpool.Pool
+	// db binds the installation's workspace itself (ADR-0091 §9 step 3).
+	db *database.DB
 }
 
-func NewStore(pool *pgxpool.Pool) *Store {
-	return &Store{pool: pool}
+// NewStore binds the store to the pool every read and write runs through.
+func NewStore(db *database.DB) *Store {
+	return &Store{db: db}
 }
 
 // memberEntityTables is the closed polymorphic target set — the table
@@ -105,7 +106,7 @@ func (s *Store) ListLists(ctx context.Context, entityType *string, archived stor
 	}
 	var out []listRow
 	truncated := false
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		var args []any
 		arg := func(v any) int { args = append(args, v); return len(args) }
 		where := []string{"true"}
@@ -186,7 +187,7 @@ func (s *Store) CreateList(ctx context.Context, in CreateListInput) (listRow, er
 		}
 	}
 	var out listRow
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		row := tx.QueryRow(ctx, `
 			INSERT INTO list (workspace_id, name, entity_type, list_type, definition, owner_id, team_id)
 			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, $2, $3, $4, $5, $6)
@@ -209,7 +210,7 @@ func (s *Store) GetList(ctx context.Context, id ids.ListID) (listRow, error) {
 		return listRow{}, err
 	}
 	var out listRow
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		if err := ensureListVisible(ctx, tx, id); err != nil {
 			return err
 		}
@@ -228,7 +229,7 @@ func (s *Store) ArchiveList(ctx context.Context, id ids.ListID) (listRow, error)
 		return listRow{}, err
 	}
 	var out listRow
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		if err := ensureListVisible(ctx, tx, id); err != nil {
 			return err
 		}

--- a/backend/internal/modules/collections/members.go
+++ b/backend/internal/modules/collections/members.go
@@ -14,7 +14,6 @@ import (
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/platform/httperr"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
@@ -45,7 +44,7 @@ func (s *Store) ListMembers(ctx context.Context, listID ids.ListID, limit int, c
 	}
 	var out []memberRow
 	var page storekit.Page
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		if err := ensureListVisible(ctx, tx, listID); err != nil {
 			return err
 		}
@@ -139,7 +138,7 @@ func (s *Store) AddMember(ctx context.Context, listID ids.ListID, entityType str
 	}
 	actor, _ := principal.Actor(ctx)
 	var out memberRow
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		if err := ensureListVisible(ctx, tx, listID); err != nil {
 			return err
 		}

--- a/backend/internal/modules/collections/savedviews.go
+++ b/backend/internal/modules/collections/savedviews.go
@@ -15,7 +15,6 @@ import (
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
@@ -107,7 +106,7 @@ func (s *Store) ListSavedViews(ctx context.Context, resource *string, archived s
 	}
 	var out []savedViewRow
 	truncated := false
-	err = database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err = s.db.Tx(ctx, func(tx pgx.Tx) error {
 		var args []any
 		arg := func(v any) int { args = append(args, v); return len(args) }
 		where := []string{fmt.Sprintf("owner_id = $%d", arg(owner))}
@@ -164,7 +163,7 @@ func (s *Store) CreateSavedView(ctx context.Context, in CreateSavedViewInput) (s
 		return savedViewRow{}, &BadInputError{Field: "query", Reason: "must not be null"}
 	}
 	var out savedViewRow
-	err = database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err = s.db.Tx(ctx, func(tx pgx.Tx) error {
 		row := tx.QueryRow(ctx, `
 			INSERT INTO saved_view (workspace_id, owner_id, shared_scope, resource, name, query)
 			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, 'private', $2, $3, $4)
@@ -191,7 +190,7 @@ func (s *Store) GetSavedView(ctx context.Context, id ids.SavedViewID) (savedView
 		return savedViewRow{}, err
 	}
 	var out savedViewRow
-	err = database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err = s.db.Tx(ctx, func(tx pgx.Tx) error {
 		var err error
 		out, err = scanSavedView(tx.QueryRow(ctx,
 			selectSavedView+"id = $1 AND owner_id = $2", id, owner))
@@ -219,7 +218,7 @@ func (s *Store) UpdateSavedView(ctx context.Context, id ids.SavedViewID, in Upda
 		return savedViewRow{}, err
 	}
 	var out savedViewRow
-	err = database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err = s.db.Tx(ctx, func(tx pgx.Tx) error {
 		current, err := scanSavedView(tx.QueryRow(ctx,
 			selectSavedView+"id = $1 AND owner_id = $2 AND archived_at IS NULL", id, owner))
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -261,7 +260,7 @@ func (s *Store) ArchiveSavedView(ctx context.Context, id ids.SavedViewID) (saved
 		return savedViewRow{}, err
 	}
 	var out savedViewRow
-	err = database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err = s.db.Tx(ctx, func(tx pgx.Tx) error {
 		row := tx.QueryRow(ctx,
 			"UPDATE saved_view SET archived_at = now() WHERE id = $1 AND owner_id = $2 AND archived_at IS NULL RETURNING "+savedViewColumns,
 			id, owner)

--- a/backend/internal/modules/collections/tags.go
+++ b/backend/internal/modules/collections/tags.go
@@ -15,7 +15,6 @@ import (
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/platform/httperr"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
@@ -51,7 +50,7 @@ func (s *Store) ListTags(ctx context.Context, archived storekit.ArchivedFilter) 
 	}
 	var out []tagRow
 	truncated := false
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		sql := "SELECT " + tagColumns + " FROM tag"
 		if archived != storekit.IncludeArchived {
 			sql += " WHERE archived_at IS NULL"
@@ -88,7 +87,7 @@ func (s *Store) CreateTag(ctx context.Context, name string, color *string) (tagR
 		return tagRow{}, &BadInputError{Field: "name", Reason: "required"}
 	}
 	var out tagRow
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		row := tx.QueryRow(ctx, `
 			INSERT INTO tag (workspace_id, name, color)
 			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, $2)
@@ -111,7 +110,7 @@ func (s *Store) ArchiveTag(ctx context.Context, id ids.TagID) (tagRow, error) {
 		return tagRow{}, err
 	}
 	var out tagRow
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		row := tx.QueryRow(ctx,
 			"UPDATE tag SET archived_at = now() WHERE id = $1 AND archived_at IS NULL RETURNING "+tagColumns, id)
 		var err error
@@ -151,7 +150,7 @@ func (s *Store) ApplyTag(ctx context.Context, tagID ids.TagID, entityType string
 		return taggableRow{}, &BadInputError{Field: entityTypeField, Reason: "must be " + memberEntityVocabulary}
 	}
 	var out taggableRow
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		var archived *time.Time
 		err := tx.QueryRow(ctx, `SELECT archived_at FROM tag WHERE id = $1`, tagID).Scan(&archived)
 		if errors.Is(err, pgx.ErrNoRows) || (err == nil && archived != nil) {

--- a/backend/internal/modules/consent/channelconsent_integration_test.go
+++ b/backend/internal/modules/consent/channelconsent_integration_test.go
@@ -103,7 +103,7 @@ func setupChannelConsent(t *testing.T) *channelConsentEnv {
 		t.Fatal(err)
 	}
 	t.Cleanup(pool.Close)
-	e.store = NewStore(pool)
+	e.store = NewStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](e.ws)))
 
 	opCtx := principal.WithWorkspaceID(context.Background(), e.ws)
 	opCtx = principal.WithCorrelationID(opCtx, ids.NewV7())

--- a/backend/internal/modules/consent/doi.go
+++ b/backend/internal/modules/consent/doi.go
@@ -16,7 +16,6 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/platform/httperr"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
@@ -65,7 +64,7 @@ func (s *Store) IssueDoubleOptIn(ctx context.Context, personID ids.PersonID, pur
 		return IssuedDOI{}, err
 	}
 	var out IssuedDOI
-	err = database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err = s.db.Tx(ctx, func(tx pgx.Tx) error {
 		if err := auth.EnsureVisible(ctx, tx, "person", personID.UUID); err != nil {
 			return err
 		}

--- a/backend/internal/modules/consent/dsr.go
+++ b/backend/internal/modules/consent/dsr.go
@@ -21,7 +21,6 @@ import (
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
@@ -149,7 +148,7 @@ func (s *Store) ListDSRs(ctx context.Context, limit *int, cursor string, status 
 	bounded := storekit.ClampLimit(limit)
 	var out []dsrRow
 	var page storekit.Page
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		sql, args, err := dsrListQuery(cursor, status, bounded)
 		if err != nil {
 			return err
@@ -187,7 +186,7 @@ func (s *Store) CreateDSR(ctx context.Context, in CreateDSRInput) (dsrRow, error
 		return dsrRow{}, &ValidationError{Field: fieldSubjectRef, Reason: "required"}
 	}
 	var out dsrRow
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		row := tx.QueryRow(ctx, `
 			INSERT INTO data_subject_request (workspace_id, kind, subject_ref, assignee_id, due_at)
 			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, $2, $3, $4)
@@ -212,7 +211,7 @@ func (s *Store) GetDSR(ctx context.Context, id ids.UUID) (dsrRow, error) {
 		return dsrRow{}, err
 	}
 	var out dsrRow
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		var err error
 		out, err = scanDSR(tx.QueryRow(ctx,
 			dsrSelectByID, id))
@@ -263,7 +262,7 @@ func (s *Store) UpdateDSR(ctx context.Context, id ids.UUID, in UpdateDSRInput) (
 		return dsrRow{}, err
 	}
 	var out dsrRow
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		current, err := scanDSR(tx.QueryRow(ctx,
 			dsrSelectByID, id))
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -343,7 +342,7 @@ func (s *Store) FulfilErasure(ctx context.Context, id ids.UUID, in UpdateDSRInpu
 		Reason: "an erasure request must name a person id before it can be fulfilled",
 	}
 	var out dsrRow
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		current, err := scanDSR(tx.QueryRow(ctx, dsrSelectForUpdate, id))
 		if errors.Is(err, pgx.ErrNoRows) {
 			return apperrors.ErrNotFound

--- a/backend/internal/modules/consent/dsr_integration_test.go
+++ b/backend/internal/modules/consent/dsr_integration_test.go
@@ -87,7 +87,7 @@ func setupDSR(t *testing.T) *dsrEnv {
 	}
 	t.Cleanup(pool.Close)
 	e.pool = pool
-	e.store = NewStore(pool)
+	e.store = NewStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](e.ws)))
 
 	opCtx := principal.WithWorkspaceID(context.Background(), e.ws)
 	opCtx = principal.WithCorrelationID(opCtx, ids.NewV7())
@@ -133,7 +133,7 @@ func TestListDSRsNarrowsByStatus(t *testing.T) {
 		t.Fatalf("closing the second request: %v", err)
 	}
 
-	h := NewHandlers(e.pool)
+	h := NewHandlers(database.BindTo(e.pool, ids.From[ids.WorkspaceKind](e.ws)))
 	r := httptest.NewRequest(http.MethodGet, "/v1/data-subject-requests", nil).WithContext(e.ctx)
 
 	openStatus := crmcontracts.ListDataSubjectRequestsParamsStatusOpen
@@ -159,7 +159,7 @@ func TestListDSRsNarrowsByStatus(t *testing.T) {
 // error, not a filter that happens to match nothing.
 func TestListDataSubjectRequestsRejectsAnUnknownStatus(t *testing.T) {
 	e := setupDSR(t)
-	h := NewHandlers(e.pool)
+	h := NewHandlers(database.BindTo(e.pool, ids.From[ids.WorkspaceKind](e.ws)))
 	r := httptest.NewRequest(http.MethodGet, "/v1/data-subject-requests", nil).WithContext(e.ctx)
 	bogus := crmcontracts.ListDataSubjectRequestsParamsStatus("bogus")
 	w := httptest.NewRecorder()
@@ -225,7 +225,7 @@ func TestFulfillErasureHTTPRefusesAnUnresolvableSubject(t *testing.T) {
 	// NewHandlers builds its own store from the pool; WithEraser wires the
 	// erase seam compose injects in production.
 	eraser := &recordingEraser{}
-	h := NewHandlers(e.pool).WithEraser(eraser)
+	h := NewHandlers(database.BindTo(e.pool, ids.From[ids.WorkspaceKind](e.ws))).WithEraser(eraser)
 	body := `{"status":"fulfilled","resolution":"verified by phone"}`
 	r := httptest.NewRequest(http.MethodPatch, "/v1/data-subject-requests/"+req.ID.String(),
 		strings.NewReader(body)).WithContext(e.ctx)
@@ -264,7 +264,7 @@ func TestFulfillErasureHTTPRefusesAMissingResolution(t *testing.T) {
 	req := e.mustCreate(t, "erasure", ids.NewV7().String())
 
 	eraser := &recordingEraser{}
-	h := NewHandlers(e.pool).WithEraser(eraser)
+	h := NewHandlers(database.BindTo(e.pool, ids.From[ids.WorkspaceKind](e.ws))).WithEraser(eraser)
 	body := `{"status":"fulfilled"}`
 	r := httptest.NewRequest(http.MethodPatch, "/v1/data-subject-requests/"+req.ID.String(),
 		strings.NewReader(body)).WithContext(e.ctx)
@@ -304,7 +304,7 @@ func TestFulfillErasureHTTPRefusesAnAlreadyRejectedRequest(t *testing.T) {
 	}
 
 	eraser := &recordingEraser{}
-	h := NewHandlers(e.pool).WithEraser(eraser)
+	h := NewHandlers(database.BindTo(e.pool, ids.From[ids.WorkspaceKind](e.ws))).WithEraser(eraser)
 	body := `{"status":"fulfilled","resolution":"verified by phone"}`
 	r := httptest.NewRequest(http.MethodPatch, "/v1/data-subject-requests/"+req.ID.String(),
 		strings.NewReader(body)).WithContext(e.ctx)

--- a/backend/internal/modules/consent/gate.go
+++ b/backend/internal/modules/consent/gate.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/connector"
@@ -61,7 +60,7 @@ func (g *Gate) RequireGrantedForRecipients(ctx context.Context, recipients []con
 		}
 	}
 	purposeKey = strings.TrimSpace(strings.ToLower(purposeKey))
-	return database.WithWorkspaceTx(ctx, g.store.pool, func(tx pgx.Tx) error {
+	return g.store.db.Tx(ctx, func(tx pgx.Tx) error {
 		var purpose PurposeRow
 		err := tx.QueryRow(ctx,
 			`SELECT id, key, label, class, requires_double_opt_in

--- a/backend/internal/modules/consent/guard.go
+++ b/backend/internal/modules/consent/guard.go
@@ -27,7 +27,6 @@ import (
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/httperr"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
@@ -58,7 +57,7 @@ func (s *Store) PersonConsentGuard(ctx context.Context, personID ids.PersonID) (
 		PersonId: openapi_types.UUID(personID.UUID),
 		Entries:  []crmcontracts.PersonConsentGuardEntry{},
 	}
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		// Anything that names a record is gated: answering about a person the
 		// caller cannot read would confirm that person exists.
 		if err := auth.EnsureVisibleLive(ctx, tx, "person", personID.UUID); err != nil {

--- a/backend/internal/modules/consent/handlers.go
+++ b/backend/internal/modules/consent/handlers.go
@@ -9,10 +9,10 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/jackc/pgx/v5/pgxpool"
 	openapi_types "github.com/oapi-codegen/runtime/types"
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/httperr"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
@@ -31,8 +31,9 @@ type Eraser interface {
 	ErasePerson(ctx context.Context, personID ids.UUID, reason string) error
 }
 
-func NewHandlers(pool *pgxpool.Pool) Handlers {
-	return Handlers{store: NewStore(pool)}
+// NewHandlers wires the transport over the installation-bound pool.
+func NewHandlers(db *database.DB) Handlers {
+	return Handlers{store: NewStore(db)}
 }
 
 // WithEraser returns a copy wired to the erase path.

--- a/backend/internal/modules/consent/leadconsent_integration_test.go
+++ b/backend/internal/modules/consent/leadconsent_integration_test.go
@@ -90,7 +90,7 @@ func setupLeadConsent(t *testing.T) *leadConsentEnv {
 		t.Fatal(err)
 	}
 	t.Cleanup(pool.Close)
-	e.store = NewStore(pool)
+	e.store = NewStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](e.ws)))
 
 	opCtx := principal.WithWorkspaceID(context.Background(), e.ws)
 	opCtx = principal.WithCorrelationID(opCtx, ids.NewV7())

--- a/backend/internal/modules/consent/preference.go
+++ b/backend/internal/modules/consent/preference.go
@@ -86,7 +86,7 @@ const preferenceTokenMaxAgeDays = 180
 // an oracle for which of the three it was.
 func (s *Store) ResolvePreferenceToken(ctx context.Context, token string) (PreferenceRef, error) {
 	var ref PreferenceRef
-	err := database.WithInfraTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := database.WithInfraTx(ctx, s.db.Pool(), func(tx pgx.Tx) error {
 		err := tx.QueryRow(ctx, `
 			SELECT workspace_id, person_id FROM preference_token
 			 WHERE token = $1 AND revoked_at IS NULL AND expires_at > now()`,
@@ -113,7 +113,7 @@ func (s *Store) PreferenceTokenForEmail(ctx context.Context, email string) (toke
 		return "", false, err
 	}
 	email = strings.ToLower(strings.TrimSpace(email))
-	err = database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err = s.db.Tx(ctx, func(tx pgx.Tx) error {
 		var personID ids.PersonID
 		lookup := tx.QueryRow(ctx, `
 			SELECT pe.person_id
@@ -244,7 +244,7 @@ func (s *Store) PublicPurposeStates(ctx context.Context, personID ids.PersonID) 
 		return nil, err
 	}
 	var out []PurposeChoice
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		if err := auth.EnsureVisible(ctx, tx, "person", personID.UUID); err != nil {
 			return err
 		}
@@ -301,7 +301,7 @@ func (s *Store) PublicSetConsent(ctx context.Context, personID ids.PersonID, pur
 // workspace; an unknown key is a client fault, not a 500.
 func (s *Store) purposeByKey(ctx context.Context, key string) (ids.PurposeID, error) {
 	var id ids.PurposeID
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		err := tx.QueryRow(ctx,
 			`SELECT id FROM consent_purpose WHERE key = $1 AND archived_at IS NULL`, key).Scan(&id)
 		if errors.Is(err, pgx.ErrNoRows) {

--- a/backend/internal/modules/consent/store.go
+++ b/backend/internal/modules/consent/store.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgxpool"
 	openapi_types "github.com/oapi-codegen/runtime/types"
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
@@ -25,12 +24,14 @@ import (
 )
 
 type Store struct {
-	pool *pgxpool.Pool
-	now  func() time.Time
+	// db binds the installation's workspace itself (ADR-0091 §9 step 3).
+	db  *database.DB
+	now func() time.Time
 }
 
-func NewStore(pool *pgxpool.Pool) *Store {
-	return &Store{pool: pool, now: time.Now}
+// NewStore binds the store to the pool every read and write runs through.
+func NewStore(db *database.DB) *Store {
+	return &Store{db: db, now: time.Now}
 }
 
 type Purpose struct {
@@ -72,7 +73,7 @@ func (s *Store) ListPurposes(ctx context.Context) ([]Purpose, error) {
 		return nil, err
 	}
 	var out []Purpose
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		rows, err := tx.Query(ctx, `
 			SELECT id, workspace_id, key, label, requires_double_opt_in, created_at
 			FROM consent_purpose WHERE archived_at IS NULL ORDER BY key`)
@@ -104,7 +105,7 @@ func (s *Store) CreatePurpose(ctx context.Context, key, label string, requiresDO
 		return Purpose{}, &ValidationError{Field: "key", Reason: "key and label are required"}
 	}
 	var p Purpose
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		err := tx.QueryRow(ctx, `
 			INSERT INTO consent_purpose (workspace_id, key, label, requires_double_opt_in)
 			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, $2, $3)
@@ -140,7 +141,7 @@ func (s *Store) subjectConsent(ctx context.Context, sub subject) ([]State, []Pro
 	}
 	var states []State
 	var events []ProofEvent
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) (err error) {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) (err error) {
 		states, events, err = subjectConsentInTx(ctx, tx, sub)
 		return err
 	})
@@ -307,7 +308,7 @@ func (s *Store) Record(ctx context.Context, in RecordInput) (State, error) {
 	actor, _ := principal.Actor(ctx)
 
 	var out State
-	err = database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err = s.db.Tx(ctx, func(tx pgx.Tx) error {
 		if err := auth.EnsureVisible(ctx, tx, sub.entityType, sub.id); err != nil {
 			return err
 		}


### PR DESCRIPTION
Sweep continues from #903 (ADR-0091 §9 step 3). `collections` and `consent` take `database.DB` instead of a pool, so their transactions bind the installation's workspace themselves rather than reading it off whatever context reached them.

**3 of 20 modules through; 419 `WithWorkspaceTx` call sites left.**

## Mechanical except where it wasn't

Two things in `consent` needed a decision rather than a substitution:

- **The gate reached through `g.store.pool`** — a second path to the same pool from outside the store.
- **The preference path runs an INFRA transaction**, deliberately un-bound, for the token lookup that happens before any workspace is known. It takes `db.Pool()` and stays exactly what it was.

That second one is worth calling out, because it is the point of this step: **a transaction that must not bind is now visibly different from one that simply forgot to.** Under `WithWorkspaceTx` the two are the same call with a different helper name; under the handle, one asks for the pool explicitly.

## Fixtures

The module-level integration suites bind to their own workspace with `BindTo` — the same translation the cross-tenant suites needed in #903. These envs create a workspace by raw SQL and act as it, so the handle is where that fact lives now.

## Verification

`make check-backend` and `make craft-static` (0/0/0) green. The tenant-isolation suite is CI's word, as always here — and it is the check that matters for this step: it caught a real cross-tenant read in #903 the moment the binding moved.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors `collections` and `consent` to use an installation‑bound `database.DB` for all workspace-scoped transactions instead of raw pools. This makes binding explicit, reduces cross-tenant risk, and keeps the infra-only token lookup clearly unbound.

- **Refactors**
  - `collections`/`consent` `NewStore` and handlers now take `*database.DB`; transactions use `db.Tx(...)`.
  - Composition, workers, and tests build stores with `InstallationDB(pool)` or `database.BindTo(...)` (e.g., `e.DB()`).
  - `consent.Gate` transacts via the store handle, not a direct pool.
  - Preference token lookup stays an INFRA transaction before a workspace is known, using `database.WithInfraTx(..., db.Pool(), ...)`.

- **Migration**
  - Replace `collections.NewStore(pool)` and `consent.NewStore(pool)` with `collections.NewStore(InstallationDB(pool))` or `collections.NewStore(database.BindTo(pool, workspaceID))` (same for `consent`).
  - Replace `NewHandlers(pool)` with `NewHandlers(db)`.
  - Use `db.Tx(...)` inside these modules instead of `WithWorkspaceTx(...)`.

<sup>Written for commit e151d7748f77cb51de38bd90896f8e6578cfef7e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/914?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

