### PR TITLE
feat(kernel): the correspondence language and the conversation-state axis

### DIFF
--- a/backend/internal/shared/kernel/convstate/convstate.go
+++ b/backend/internal/shared/kernel/convstate/convstate.go
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+// Package convstate answers where a correspondence stands, on one axis, at a
+// stated moment.
+//
+// A drafter is handed message timestamps and nothing else, which is not enough
+// to write a truthful sentence about time: two days and eight months look the
+// same to a model reading two dates, and the difference decides whether "as
+// discussed" is a courtesy or a fabrication. This package turns the raw
+// timestamps into the one fact a draft actually needs — how long the silence
+// has run, and therefore what may be assumed about shared memory.
+//
+// It lives in the shared tier because the surfaces that need it sit in
+// different places: the timeline module renders a floor draft with no model
+// available, the signals module renders a warm-intro draft, and the
+// composition layer runs the model drafters. A module may not import a
+// sibling, so shared is the only tier all three can reach
+// (specs/subsystems/drafting.md, "Where it lives").
+//
+// The bands are pinned by DRAFT-AC-E-3 and DRAFT-AC-E-4: at BandNone a draft
+// may imply no earlier contact, and at BandWeeks or BandMonths it may not
+// assume the other party remembers an earlier exchange.
+package convstate
+
+import "time"
+
+// Band is where a correspondence stands. Closed, because each value is a
+// distinct set of sentences a draft may write, and an unrecognized band would
+// have to fall back to one of these anyway — silently, and probably to the
+// wrong one.
+type Band string
+
+const (
+	// BandNone: no prior correspondence with this person at all. A first
+	// touch. The band that most needs naming, because every "just following
+	// up" a drafter reaches for by reflex is false here.
+	BandNone Band = "none"
+	// BandFresh: the exchange is live. Shared memory can be assumed and the
+	// gap needs no acknowledgement.
+	BandFresh Band = "fresh"
+	// BandWeeks: long enough that the other party has been doing other things,
+	// short enough that the thread is still recognizable to them.
+	BandWeeks Band = "weeks"
+	// BandMonths: long enough that assuming they remember the exchange is a
+	// claim about them rather than a fact.
+	BandMonths Band = "months"
+)
+
+// The boundaries between the bands, in days of silence. Product decisions, so
+// they sit here beside the band they define rather than in a caller.
+const (
+	// FreshMaxDays: within a working rhythm - a reply this week is a turn in
+	// an ongoing conversation.
+	FreshMaxDays = 7
+	// WeeksMaxDays: roughly a quarter of a year. Past this, an unacknowledged
+	// gap reads as not having noticed one.
+	WeeksMaxDays = 90
+)
+
+// Direction is who spoke last. It changes what a draft owes: after an inbound
+// message the draft is an answer, after an outbound one it is a second
+// approach into silence, which is a different thing to write.
+type Direction string
+
+const (
+	// DirectionNone: nothing has been exchanged.
+	DirectionNone Direction = "none"
+	// DirectionInbound: they wrote last.
+	DirectionInbound Direction = "inbound"
+	// DirectionOutbound: we wrote last, and have not been answered.
+	DirectionOutbound Direction = "outbound"
+)
+
+// State is the whole axis: the band, the silence that produced it, and who
+// spoke last.
+type State struct {
+	Band Band
+	// SilenceDays is whole days since the last message in either direction.
+	// Zero at BandNone, where there is no last message to count from.
+	SilenceDays int
+	// LastDirection is who sent that last message.
+	LastDirection Direction
+}
+
+// Classify folds the two timestamps into the axis.
+//
+// lastIn and lastOut are the most recent inbound and outbound messages, each
+// zero when there is none. The clock is passed rather than read so callers
+// inject their own; this package holds no clock of its own by design (the
+// house pattern - see compose.Dispatcher).
+//
+// A timestamp in the future is treated as now rather than as negative silence.
+// Clock skew between a mail host and this one is ordinary, and the honest
+// reading of "the last message is dated tomorrow" is that it just arrived.
+func Classify(now, lastIn, lastOut time.Time) State {
+	last := lastIn
+	direction := DirectionInbound
+	if last.IsZero() || (!lastOut.IsZero() && lastOut.After(last)) {
+		last = lastOut
+		direction = DirectionOutbound
+	}
+	if last.IsZero() {
+		return State{Band: BandNone, SilenceDays: 0, LastDirection: DirectionNone}
+	}
+
+	days := wholeDaysBetween(last, now)
+	return State{Band: bandForDays(days), SilenceDays: days, LastDirection: direction}
+}
+
+// bandForDays maps a silence to its band. Separate from Classify so the
+// boundary arithmetic is testable without constructing timestamps around it.
+func bandForDays(days int) Band {
+	switch {
+	case days <= FreshMaxDays:
+		return BandFresh
+	case days <= WeeksMaxDays:
+		return BandWeeks
+	default:
+		return BandMonths
+	}
+}
+
+// wholeDaysBetween counts elapsed days, floored, and never returns a negative.
+func wholeDaysBetween(from, to time.Time) int {
+	if !to.After(from) {
+		return 0
+	}
+	return int(to.Sub(from).Hours() / 24)
+}
+
+// AssumesSharedMemory reports whether a draft in this state may write as if
+// the other party remembers the earlier exchange. False at BandNone because
+// there is no exchange, and false at BandWeeks and BandMonths because enough
+// has happened to them since (DRAFT-AC-E-4).
+func (s State) AssumesSharedMemory() bool {
+	return s.Band == BandFresh
+}
+
+// ImpliesPriorContact reports whether a draft may refer to any earlier contact
+// with this person at all. False only at BandNone, which is exactly where a
+// follow-up subject or a reply prefix would be a fabrication (DRAFT-AC-E-3).
+func (s State) ImpliesPriorContact() bool {
+	return s.Band != BandNone
+}

--- a/backend/internal/shared/kernel/convstate/convstate_test.go
+++ b/backend/internal/shared/kernel/convstate/convstate_test.go
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package convstate_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/convstate"
+)
+
+// A fixed instant, so every case reads as a date rather than as arithmetic
+// against whatever today happens to be.
+var now = time.Date(2026, time.August, 11, 9, 0, 0, 0, time.UTC)
+
+func daysAgo(n int) time.Time { return now.AddDate(0, 0, -n) }
+
+func TestClassifyPlacesACorrespondenceOnTheAxis(t *testing.T) {
+	cases := []struct {
+		name          string
+		lastIn        time.Time
+		lastOut       time.Time
+		wantBand      convstate.Band
+		wantDays      int
+		wantDirection convstate.Direction
+	}{
+		{
+			name:          "nothing exchanged is a first touch",
+			wantBand:      convstate.BandNone,
+			wantDays:      0,
+			wantDirection: convstate.DirectionNone,
+		},
+		{
+			name:          "they wrote yesterday",
+			lastIn:        daysAgo(1),
+			wantBand:      convstate.BandFresh,
+			wantDays:      1,
+			wantDirection: convstate.DirectionInbound,
+		},
+		{
+			name:          "we wrote three weeks ago and got no answer",
+			lastOut:       daysAgo(21),
+			wantBand:      convstate.BandWeeks,
+			wantDays:      21,
+			wantDirection: convstate.DirectionOutbound,
+		},
+		{
+			name:          "they wrote eight months ago",
+			lastIn:        daysAgo(240),
+			wantBand:      convstate.BandMonths,
+			wantDays:      240,
+			wantDirection: convstate.DirectionInbound,
+		},
+		{
+			name:          "the later of the two messages decides the direction",
+			lastIn:        daysAgo(30),
+			lastOut:       daysAgo(4),
+			wantBand:      convstate.BandFresh,
+			wantDays:      4,
+			wantDirection: convstate.DirectionOutbound,
+		},
+		{
+			name:          "an inbound after our own reply reads as inbound",
+			lastIn:        daysAgo(2),
+			lastOut:       daysAgo(9),
+			wantBand:      convstate.BandFresh,
+			wantDays:      2,
+			wantDirection: convstate.DirectionInbound,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := convstate.Classify(now, c.lastIn, c.lastOut)
+			if got.Band != c.wantBand {
+				t.Errorf("Band = %q, want %q", got.Band, c.wantBand)
+			}
+			if got.SilenceDays != c.wantDays {
+				t.Errorf("SilenceDays = %d, want %d", got.SilenceDays, c.wantDays)
+			}
+			if got.LastDirection != c.wantDirection {
+				t.Errorf("LastDirection = %q, want %q", got.LastDirection, c.wantDirection)
+			}
+		})
+	}
+}
+
+// Mutation check on the two boundaries: each is pinned from both sides, so
+// moving either constant flips an answer here.
+func TestTheBandBoundariesAreExactlyWhereTheyAreWritten(t *testing.T) {
+	cases := []struct {
+		days int
+		want convstate.Band
+	}{
+		{days: convstate.FreshMaxDays, want: convstate.BandFresh},
+		{days: convstate.FreshMaxDays + 1, want: convstate.BandWeeks},
+		{days: convstate.WeeksMaxDays, want: convstate.BandWeeks},
+		{days: convstate.WeeksMaxDays + 1, want: convstate.BandMonths},
+	}
+	for _, c := range cases {
+		got := convstate.Classify(now, daysAgo(c.days), time.Time{})
+		if got.Band != c.want {
+			t.Errorf("at %d days of silence Band = %q, want %q", c.days, got.Band, c.want)
+		}
+	}
+}
+
+// Clock skew between a mail host and this one is ordinary. A message dated in
+// the future just arrived; it is not negative silence.
+func TestAMessageDatedInTheFutureIsTreatedAsJustArrived(t *testing.T) {
+	got := convstate.Classify(now, now.AddDate(0, 0, 2), time.Time{})
+
+	if got.SilenceDays != 0 {
+		t.Errorf("SilenceDays = %d, want 0", got.SilenceDays)
+	}
+	if got.Band != convstate.BandFresh {
+		t.Errorf("Band = %q, want %q", got.Band, convstate.BandFresh)
+	}
+}
+
+// The two questions a drafter actually asks the axis. These are what
+// DRAFT-AC-E-3 and DRAFT-AC-E-4 turn into code: at BandNone a draft may not
+// imply any earlier contact, and outside BandFresh it may not assume the other
+// party remembers the exchange.
+func TestTheAxisAnswersWhatADraftMayAssume(t *testing.T) {
+	cases := []struct {
+		band             convstate.Band
+		wantPriorContact bool
+		wantSharedMemory bool
+	}{
+		{band: convstate.BandNone, wantPriorContact: false, wantSharedMemory: false},
+		{band: convstate.BandFresh, wantPriorContact: true, wantSharedMemory: true},
+		{band: convstate.BandWeeks, wantPriorContact: true, wantSharedMemory: false},
+		{band: convstate.BandMonths, wantPriorContact: true, wantSharedMemory: false},
+	}
+	for _, c := range cases {
+		state := convstate.State{Band: c.band}
+		if got := state.ImpliesPriorContact(); got != c.wantPriorContact {
+			t.Errorf("%q: ImpliesPriorContact() = %v, want %v", c.band, got, c.wantPriorContact)
+		}
+		if got := state.AssumesSharedMemory(); got != c.wantSharedMemory {
+			t.Errorf("%q: AssumesSharedMemory() = %v, want %v", c.band, got, c.wantSharedMemory)
+		}
+	}
+}

--- a/backend/internal/shared/kernel/textlang/textlang.go
+++ b/backend/internal/shared/kernel/textlang/textlang.go
@@ -1,0 +1,299 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+// Package textlang guesses what language a piece of correspondence is written
+// in, and says so honestly when it cannot tell.
+//
+// A draft has to be written in the language of the correspondence rather than
+// the language of the interface asking for it (DRAFT-AC-E-1): a German thread
+// gets a German reply even when the rep's UI is English. Nothing in the
+// product knew that, so drafts came out in English on German threads.
+//
+// The detector is deliberately small and stdlib-only, because it runs in the
+// shared tier where the timeline and signals modules can reach it, and because
+// the alternative — a model call to find out which language to write in — pays
+// for a whole inference to answer a question stopwords answer.
+//
+// It is biased toward Unknown. This market code-switches constantly: German
+// professionals write English mail to German colleagues, quote English threads
+// in German replies, and sign off in either. Guessing German on an English
+// thread produces a draft the rep cannot send, which is worse than the bug it
+// replaces; answering Unknown lets the caller fall back down its own ladder to
+// evidence it trusts more. So the winner needs both an absolute floor of hits
+// and a clear margin over the runner-up, and gets neither from one greeting.
+package textlang
+
+import (
+	"strings"
+	"unicode"
+)
+
+// Lang is a detected correspondence language. Three plus Unknown, because
+// these are the languages the product has correspondence in and an
+// unrecognized one is more useful named than guessed.
+type Lang string
+
+const (
+	// Unknown: the evidence did not clear the bar. Never a failure - it is the
+	// honest answer for a two-word message, and the caller has other tiers.
+	Unknown Lang = ""
+	// German.
+	German Lang = "de"
+	// English.
+	English Lang = "en"
+	// Vietnamese.
+	Vietnamese Lang = "vi"
+)
+
+// The bar a winner clears.
+const (
+	// MinHits is how many stopwords a language needs before its lead means
+	// anything. Below this, one shared word ("in", "die" as a Vietnamese
+	// syllable) decides the answer.
+	MinHits = 3
+	// MinMargin is how far ahead of the runner-up the winner must be. A German
+	// sentence quoting an English one scores both; only a clear lead is a
+	// language rather than a mixture.
+	MinMargin = 1.5
+	// LeadRunes is how much of the text carries the extra weight when the
+	// quoted part does not announce itself. A reply is written above the
+	// thread it quotes, so the top of the message is the language being
+	// WRITTEN and everything below it is the language being answered; a
+	// drafter needs the former.
+	LeadRunes = 800
+	// LeadWeight is what a hit in that lead is worth against the margin. It
+	// only has to overcome an unmarked continuation, since a marked quote is
+	// cut off entirely rather than weighted down.
+	LeadWeight = 3
+	// bodyWeight is what a hit below the lead is worth.
+	bodyWeight = 1
+)
+
+// germanStopwords and englishStopwords are the discriminating function words
+// of each language: articles, pronouns, prepositions, auxiliaries. Words that
+// occur in both (in, so, was, hat as a name) are deliberately absent - a
+// feature only helps when it separates.
+var germanStopwords = map[string]bool{
+	"der": true, "die": true, "das": true, "den": true, "dem": true, "des": true,
+	"ein": true, "eine": true, "einen": true, "einem": true, "einer": true,
+	"und": true, "oder": true, "aber": true, "auch": true, "noch": true,
+	"nicht": true, "kein": true, "keine": true, "sehr": true, "schon": true,
+	"ich": true, "sie": true, "wir": true, "ihr": true, "mich": true, "mir": true,
+	"uns": true, "ihnen": true, "ihre": true, "unser": true, "unsere": true,
+	"ist": true, "sind": true, "war": true, "waren": true, "wird": true,
+	"werden": true, "haben": true, "hatte": true, "kann": true, "koennen": true,
+	"muss": true, "soll": true, "wuerde": true, "gerne": true, "bitte": true,
+	"mit": true, "auf": true, "fuer": true, "von": true, "bei": true, "nach": true,
+	"aus": true, "ueber": true, "durch": true, "zum": true, "zur": true,
+	"dass": true, "wenn": true, "weil": true, "damit": true, "diese": true,
+	"dieser": true, "welche": true, "hier": true, "dann": true, "immer": true,
+}
+
+var englishStopwords = map[string]bool{
+	"the": true, "a": true, "an": true, "and": true, "or": true, "but": true,
+	"not": true, "no": true, "very": true, "already": true, "also": true,
+	"i": true, "you": true, "we": true, "they": true, "he": true, "she": true,
+	"me": true, "us": true, "them": true, "our": true, "your": true, "their": true,
+	"is": true, "are": true, "was": true, "were": true, "will": true, "would": true,
+	"have": true, "has": true, "had": true, "can": true, "could": true,
+	"should": true, "must": true, "please": true, "thanks": true,
+	"with": true, "for": true, "from": true, "about": true, "into": true,
+	"that": true, "this": true, "these": true, "those": true, "which": true,
+	"when": true, "because": true, "there": true, "then": true, "always": true,
+	"just": true, "here": true, "what": true, "how": true,
+}
+
+// germanRunes are the letters no English or Vietnamese word carries. One of
+// them is worth a stopword hit: they are rarer but far more decisive.
+const germanRunes = "äöüßÄÖÜ"
+
+// vietnameseMarkRatio is the share of letters carrying a diacritic above which
+// text is Vietnamese. Vietnamese marks a majority of its syllables; German
+// umlauts and the odd French loanword in English never approach this.
+const vietnameseMarkRatio = 0.12
+
+// Detect reports the language the text is written in, or Unknown when the
+// evidence does not clear the bar.
+//
+// Vietnamese is decided first and separately, by diacritic density rather than
+// by stopwords: its function words are short unaccented syllables that collide
+// with everything, while its accent pattern is unmistakable.
+func Detect(text string) Lang {
+	if text == "" {
+		return Unknown
+	}
+	if vietnameseByDiacritics(text) {
+		return Vietnamese
+	}
+
+	return winner(scoreStopwords(text))
+}
+
+// score is one language's evidence, counted two ways because the two bars ask
+// different questions. Hits asks "is there enough evidence to speak at all",
+// so every hit counts once wherever it sits. Weighted asks "which language is
+// this written in", where a hit in the lead counts for much more than one in
+// the quoted chain below it.
+type score struct {
+	hits     int
+	weighted int
+}
+
+// winner applies the two-part bar: an absolute floor on raw hits, then a
+// margin on the weighted score. Split out so the thresholds can be exercised
+// directly.
+func winner(de, en score) Lang {
+	high, low, lang := de, en, German
+	if en.weighted > de.weighted {
+		high, low, lang = en, de, English
+	}
+	if high.hits < MinHits {
+		return Unknown
+	}
+	if float64(high.weighted) < float64(low.weighted)*MinMargin {
+		return Unknown
+	}
+	return lang
+}
+
+// scoreStopwords walks the text once, counting each language's hits and
+// weighting those in the lead. A German-only rune counts as a German hit.
+func scoreStopwords(text string) (de, en score) {
+	runes, lead := replyText([]rune(text))
+	for start := 0; start < len(runes); {
+		end := start
+		for end < len(runes) && isWordRune(runes[end]) {
+			end++
+		}
+		if end == start {
+			if strings.ContainsRune(germanRunes, runes[start]) {
+				de.add(weightAt(start, lead))
+			}
+			start++
+			continue
+		}
+
+		word := strings.ToLower(string(runes[start:end]))
+		weight := weightAt(start, lead)
+		switch {
+		case strings.ContainsAny(word, germanRunes):
+			de.add(weight)
+		case germanStopwords[word]:
+			de.add(weight)
+		case englishStopwords[word]:
+			en.add(weight)
+		}
+		start = end
+	}
+	return de, en
+}
+
+// add records one hit worth the given weight.
+func (s *score) add(weight int) {
+	s.hits++
+	s.weighted += weight
+}
+
+// weightAt is what a hit is worth at this offset into the text.
+func weightAt(runeOffset, leadEnd int) int {
+	if runeOffset < leadEnd {
+		return LeadWeight
+	}
+	return bodyWeight
+}
+
+// quoteMarkers are the ways a mail client announces that what follows is the
+// thread being replied to rather than the reply. Ordinary German and English
+// correspondence does not produce these lines by accident.
+var quoteMarkers = []string{
+	">",
+	"-----Original Message",
+	"-----Ursprüngliche Nachricht",
+	"________________________________",
+	"Von: ",
+	"From: ",
+	"Am ", // "Am 3. Juni 2026 schrieb ..." - the German On-wrote line.
+	"On ", // "On 3 June 2026, ... wrote:"
+}
+
+// replyText narrows the text to the message actually being written, and says
+// how much of what remains is the lead.
+//
+// Where a quote marker announces the thread below, everything from there down
+// is dropped: it is a different message, in whatever language its author chose,
+// and counting it as diluted evidence still lets a long English chain outvote
+// the short German reply on top of it. A reply with no marker keeps its whole
+// text and leans on the LeadRunes window instead.
+//
+// A message that is ONLY quoted text keeps the quote, because then the quote is
+// all the evidence there is and refusing to read it would answer Unknown for a
+// forward whose language is perfectly clear.
+func replyText(runes []rune) (text []rune, lead int) {
+	if cut := quoteStart(runes); cut > 0 {
+		runes = runes[:cut]
+	}
+	return runes, min(len(runes), LeadRunes)
+}
+
+// quoteStart finds where the quoted thread begins, as a rune offset, or -1
+// when no line announces itself as quoted.
+func quoteStart(runes []rune) int {
+	for offset, atLineStart := 0, true; offset < len(runes); offset++ {
+		if atLineStart && startsQuote(runes[offset:]) {
+			return offset
+		}
+		atLineStart = runes[offset] == '\n'
+	}
+	return -1
+}
+
+// startsQuote reports whether a line beginning here announces quoted text.
+func startsQuote(line []rune) bool {
+	for _, marker := range quoteMarkers {
+		if len(line) >= len([]rune(marker)) &&
+			strings.HasPrefix(string(line[:len([]rune(marker))]), marker) {
+			return true
+		}
+	}
+	return false
+}
+
+// isWordRune reports whether a rune is part of a word. Letters only: digits and
+// punctuation end a word, and an apostrophe inside one ("don't") splits it into
+// two harmless fragments rather than a miss.
+func isWordRune(r rune) bool {
+	return unicode.IsLetter(r)
+}
+
+// vietnameseByDiacritics reports whether enough of the text's letters carry a
+// diacritic for Vietnamese to be the only explanation.
+func vietnameseByDiacritics(text string) bool {
+	letters, marked := 0, 0
+	for _, r := range text {
+		if !unicode.IsLetter(r) {
+			continue
+		}
+		letters++
+		if isVietnameseMarked(r) {
+			marked++
+		}
+	}
+	if letters < MinHits {
+		return false
+	}
+	return float64(marked)/float64(letters) >= vietnameseMarkRatio
+}
+
+// isVietnameseMarked reports whether a rune is an accented Latin letter of the
+// kind Vietnamese uses. German's own accented letters are excluded, so a German
+// text scores zero here however many umlauts it carries.
+func isVietnameseMarked(r rune) bool {
+	if strings.ContainsRune(germanRunes, r) {
+		return false
+	}
+	lower := unicode.ToLower(r)
+	if lower >= 'a' && lower <= 'z' {
+		return false
+	}
+	return unicode.IsLetter(r)
+}

--- a/backend/internal/shared/kernel/textlang/textlang.go
+++ b/backend/internal/shared/kernel/textlang/textlang.go
@@ -122,11 +122,12 @@ func Detect(text string) Lang {
 	if text == "" {
 		return Unknown
 	}
-	if vietnameseByDiacritics(text) {
+	reply, lead := replyText([]rune(text))
+	if vietnameseByDiacritics(reply) {
 		return Vietnamese
 	}
 
-	return winner(scoreStopwords(text))
+	return winner(scoreStopwords(reply, lead))
 }
 
 // score is one language's evidence, counted two ways because the two bars ask
@@ -158,8 +159,7 @@ func winner(de, en score) Lang {
 
 // scoreStopwords walks the text once, counting each language's hits and
 // weighting those in the lead. A German-only rune counts as a German hit.
-func scoreStopwords(text string) (de, en score) {
-	runes, lead := replyText([]rune(text))
+func scoreStopwords(runes []rune, lead int) (de, en score) {
 	for start := 0; start < len(runes); {
 		end := start
 		for end < len(runes) && isWordRune(runes[end]) {
@@ -203,8 +203,8 @@ func weightAt(runeOffset, leadEnd int) int {
 }
 
 // quoteMarkers are the ways a mail client announces that what follows is the
-// thread being replied to rather than the reply. Ordinary German and English
-// correspondence does not produce these lines by accident.
+// thread being replied to rather than the reply. Ordinary correspondence does
+// not produce these lines by accident.
 var quoteMarkers = []string{
 	">",
 	"-----Original Message",
@@ -212,9 +212,22 @@ var quoteMarkers = []string{
 	"________________________________",
 	"Von: ",
 	"From: ",
-	"Am ", // "Am 3. Juni 2026 schrieb ..." - the German On-wrote line.
-	"On ", // "On 3 June 2026, ... wrote:"
 }
+
+// attributionOpeners begin the "On <date>, <name> wrote:" line that clients
+// put above a quoted thread. They are ordinary words as well — "On balance",
+// "Am Montag besprechen wir" — so an opener alone is not a marker; the line
+// must also carry the verb that makes it an attribution.
+var attributionOpeners = []string{"On ", "Am "}
+
+// attributionVerbs are how such a line says somebody wrote something. One of
+// these must appear on the same line as the opener for it to be a quote header.
+var attributionVerbs = []string{"wrote:", "schrieb:", "schrieb ", " wrote "}
+
+// attributionMaxRunes bounds how far along a line the verb is looked for. An
+// attribution line is one date and one name long; a paragraph that happens to
+// open with "On" and mention writing much later is prose.
+const attributionMaxRunes = 200
 
 // replyText narrows the text to the message actually being written, and says
 // how much of what remains is the lead.
@@ -237,21 +250,65 @@ func replyText(runes []rune) (text []rune, lead int) {
 
 // quoteStart finds where the quoted thread begins, as a rune offset, or -1
 // when no line announces itself as quoted.
+//
+// A line starts after any of the three line endings in the wild, and its
+// leading whitespace is skipped: "  > quoted" is a quote however the client
+// indented it.
 func quoteStart(runes []rune) int {
 	for offset, atLineStart := 0, true; offset < len(runes); offset++ {
-		if atLineStart && startsQuote(runes[offset:]) {
-			return offset
+		if atLineStart && !unicode.IsSpace(runes[offset]) {
+			if startsQuote(lineAt(runes, offset)) {
+				return offset
+			}
+			atLineStart = false
+			continue
 		}
-		atLineStart = runes[offset] == '\n'
+		atLineStart = atLineStart || runes[offset] == '\n' || runes[offset] == '\r'
 	}
 	return -1
 }
 
-// startsQuote reports whether a line beginning here announces quoted text.
+// lineAt returns the rest of the line beginning at offset.
+func lineAt(runes []rune, offset int) []rune {
+	for end := offset; end < len(runes); end++ {
+		if runes[end] == '\n' || runes[end] == '\r' {
+			return runes[offset:end]
+		}
+	}
+	return runes[offset:]
+}
+
+// startsQuote reports whether this line announces quoted text.
 func startsQuote(line []rune) bool {
+	text := string(line)
 	for _, marker := range quoteMarkers {
-		if len(line) >= len([]rune(marker)) &&
-			strings.HasPrefix(string(line[:len([]rune(marker))]), marker) {
+		if strings.HasPrefix(text, marker) {
+			return true
+		}
+	}
+	return isAttributionLine(text)
+}
+
+// isAttributionLine reports whether the line is a client's "On <date>, <name>
+// wrote:" header rather than a sentence that happens to begin the same way.
+func isAttributionLine(line string) bool {
+	opens := false
+	for _, opener := range attributionOpeners {
+		if strings.HasPrefix(line, opener) {
+			opens = true
+			break
+		}
+	}
+	if !opens {
+		return false
+	}
+
+	head := line
+	if runes := []rune(line); len(runes) > attributionMaxRunes {
+		head = string(runes[:attributionMaxRunes])
+	}
+	for _, verb := range attributionVerbs {
+		if strings.Contains(head, verb) {
 			return true
 		}
 	}
@@ -267,7 +324,7 @@ func isWordRune(r rune) bool {
 
 // vietnameseByDiacritics reports whether enough of the text's letters carry a
 // diacritic for Vietnamese to be the only explanation.
-func vietnameseByDiacritics(text string) bool {
+func vietnameseByDiacritics(text []rune) bool {
 	letters, marked := 0, 0
 	for _, r := range text {
 		if !unicode.IsLetter(r) {
@@ -284,16 +341,31 @@ func vietnameseByDiacritics(text string) bool {
 	return float64(marked)/float64(letters) >= vietnameseMarkRatio
 }
 
-// isVietnameseMarked reports whether a rune is an accented Latin letter of the
-// kind Vietnamese uses. German's own accented letters are excluded, so a German
-// text scores zero here however many umlauts it carries.
+// vietnameseMarked is the set of accented letters Vietnamese writes, lowercase
+// — the six vowels in their five tones, plus đ and the horned/breved forms.
+//
+// It is an explicit set rather than "any letter that is not plain ASCII",
+// because that predicate calls a French loanword Vietnamese: "José's résumé"
+// carries three accented letters in twenty-one, which clears the density
+// threshold, and so does any Cyrillic or Greek text.
+const vietnameseMarked = "àáảãạăằắẳẵặâầấẩẫậ" +
+	"èéẻẽẹêềếểễệ" +
+	"ìíỉĩị" +
+	"òóỏõọôồốổỗộơờớởỡợ" +
+	"ùúủũụưừứửữự" +
+	"ỳýỷỹỵ" +
+	"đ"
+
+// isVietnameseMarked reports whether a rune is one of the accented letters
+// Vietnamese writes. Case-folded, so the set above lists each letter once.
+//
+// Only precomposed (NFC) forms count. Decomposed text spells the same letter
+// as a plain ASCII base plus a combining mark, which is a Unicode mark rather
+// than a letter and so is never counted — decomposed Vietnamese therefore
+// scores zero and falls through to Unknown. That is the honest failure: the
+// callers of this package read text out of mail bodies and database columns,
+// which arrive precomposed, and normalizing here would pull in a dependency
+// this tier does not have.
 func isVietnameseMarked(r rune) bool {
-	if strings.ContainsRune(germanRunes, r) {
-		return false
-	}
-	lower := unicode.ToLower(r)
-	if lower >= 'a' && lower <= 'z' {
-		return false
-	}
-	return unicode.IsLetter(r)
+	return strings.ContainsRune(vietnameseMarked, unicode.ToLower(r))
 }

--- a/backend/internal/shared/kernel/textlang/textlang_test.go
+++ b/backend/internal/shared/kernel/textlang/textlang_test.go
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package textlang_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/textlang"
+)
+
+// The bug this package exists to fix: a German thread produced an English
+// draft, because nothing anywhere asked what language the correspondence was
+// in. Real correspondence, not sentences built to be detected.
+func TestDetectsTheLanguageOfRealCorrespondence(t *testing.T) {
+	cases := []struct {
+		name string
+		text string
+		want textlang.Lang
+	}{
+		{
+			name: "german business mail",
+			text: "Hallo Herr Janetzke,\n\nvielen Dank für die Einführung. Ich würde mich gerne " +
+				"kurz mit Ihnen austauschen, wenn Sie diese Woche noch Zeit haben. Bitte sagen " +
+				"Sie mir, welcher Termin für Sie passt.\n\nViele Grüße",
+			want: textlang.German,
+		},
+		{
+			name: "english business mail",
+			text: "Hi Marek,\n\nthanks for the introduction. I would like to have a short call " +
+				"with you this week if you have the time. Please let me know which slot works " +
+				"for you.\n\nBest regards",
+			want: textlang.English,
+		},
+		{
+			name: "vietnamese business mail",
+			text: "Chào anh Minh,\n\ncảm ơn anh đã giới thiệu. Tôi muốn trao đổi ngắn với anh " +
+				"trong tuần này nếu anh có thời gian. Anh cho tôi biết khung giờ nào phù hợp.\n\n" +
+				"Trân trọng",
+			want: textlang.Vietnamese,
+		},
+		{
+			name: "german without any umlaut still resolves",
+			text: "Hallo,\n\nwir haben das Angebot intern besprochen und wollen es so machen. " +
+				"Ich melde mich bei Ihnen, sobald wir eine Entscheidung haben. Bitte geben Sie " +
+				"mir noch Bescheid, ob das so passt.",
+			want: textlang.German,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := textlang.Detect(c.text); got != c.want {
+				t.Fatalf("Detect(%s) = %q, want %q", c.name, got, c.want)
+			}
+		})
+	}
+}
+
+// The reply-above-quote shape is the common one and the one a naive counter
+// gets wrong: a short German reply sits on top of a long English thread, and
+// the language being WRITTEN is the German at the top.
+func TestAGermanReplyAboveAQuotedEnglishThreadIsGerman(t *testing.T) {
+	reply := "Hallo Marek,\n\ndas passt gut. Ich würde vorschlagen, dass wir uns " +
+		"nächste Woche kurz austauschen. Bitte sagen Sie mir, welcher Tag für Sie " +
+		"funktioniert, dann schicke ich eine Einladung.\n\nViele Grüße\n\n"
+	quoted := strings.Repeat(
+		"> The team has reviewed the proposal and we would like to move forward with "+
+			"it. Could you let us know what the next steps are on your side?\n", 12)
+
+	if got := textlang.Detect(reply + quoted); got != textlang.German {
+		t.Fatalf("Detect(german reply over english quote) = %q, want %q", got, textlang.German)
+	}
+}
+
+// A message that is nothing but forwarded text still has a clear language, and
+// refusing to read the quote would answer Unknown for it. The quote is dropped
+// only when there is a reply above it to read instead.
+func TestAForwardWithNoReplyAboveItIsReadFromTheQuote(t *testing.T) {
+	forward := "> Hallo,\n> \n> wir haben die Unterlagen geprüft und würden gerne " +
+		"weitermachen. Bitte sagen Sie uns, welche Schritte als nächstes bei Ihnen " +
+		"anstehen und wann wir mit einer Antwort rechnen können.\n"
+
+	if got := textlang.Detect(forward); got != textlang.German {
+		t.Fatalf("Detect(quoted-only german) = %q, want German: with no reply above it "+
+			"the quote is the only evidence there is", got)
+	}
+}
+
+// The honest answer for thin or genuinely mixed evidence. This bias is the
+// design: a false German draft on an English thread is worse than the bug it
+// replaces, and the caller has other tiers to fall back to.
+func TestReportsUnknownRatherThanGuessing(t *testing.T) {
+	cases := []struct {
+		name string
+		text string
+	}{
+		{name: "empty", text: ""},
+		{name: "one greeting", text: "Hallo"},
+		{name: "too few hits to clear the floor", text: "Danke!"},
+		{name: "no function words at all", text: "Roadmap Q3 2026 Kickoff Workshop Berlin"},
+		{
+			name: "genuinely mixed, neither language clearly ahead",
+			text: "Hi, das ist the plan for uns: we haben a call and dann wir see.",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := textlang.Detect(c.text); got != textlang.Unknown {
+				t.Fatalf("Detect(%s) = %q, want Unknown", c.name, got)
+			}
+		})
+	}
+}
+
+// Mutation check on MinHits: the floor is what stops a single shared word from
+// deciding a language. Text that clears the floor by exactly one hit must
+// resolve, and text one hit short of it must not - so lowering the constant
+// changes an answer this test pins.
+func TestTheHitFloorIsWhatSeparatesEvidenceFromNoise(t *testing.T) {
+	belowFloor := "Der die."
+	if got := textlang.Detect(belowFloor); got != textlang.Unknown {
+		t.Fatalf("Detect(two german stopwords) = %q, want Unknown: below the %d-hit floor "+
+			"nothing should resolve", got, textlang.MinHits)
+	}
+
+	atFloor := "Der die das und."
+	if got := textlang.Detect(atFloor); got != textlang.German {
+		t.Fatalf("Detect(four german stopwords) = %q, want German: clearing the %d-hit floor "+
+			"with no english present should resolve", got, textlang.MinHits)
+	}
+}
+
+// Mutation check on MinMargin: a clear lead is a language, a narrow one is a
+// mixture. Both sides of the boundary are pinned, so widening or removing the
+// margin flips one of them.
+func TestALeadOnlyCountsWhenItIsClear(t *testing.T) {
+	narrow := "Der die das und the a an and."
+	if got := textlang.Detect(narrow); got != textlang.Unknown {
+		t.Fatalf("Detect(four german, four english) = %q, want Unknown: neither side leads "+
+			"by the %.1fx margin", got, textlang.MinMargin)
+	}
+
+	clear := "Der die das und nicht auch immer bitte the a."
+	if got := textlang.Detect(clear); got != textlang.German {
+		t.Fatalf("Detect(eight german, two english) = %q, want German: that is well past "+
+			"the %.1fx margin", got, textlang.MinMargin)
+	}
+}
+
+// German-only runes are worth a stopword hit because they are decisive on
+// their own: no English or Vietnamese word carries them.
+func TestUmlautsCountAsGermanEvidence(t *testing.T) {
+	if got := textlang.Detect("Größe, Prüfung, Änderung."); got != textlang.German {
+		t.Fatalf("Detect(three umlaut words) = %q, want German", got)
+	}
+}
+
+// Vietnamese is decided by diacritic density, before stopwords are counted at
+// all. The separation matters because its function words are short unaccented
+// syllables that collide with both other languages.
+func TestVietnameseIsDecidedByAccentDensityNotStopwords(t *testing.T) {
+	if got := textlang.Detect("Tôi sẽ gửi cho anh bản đề xuất vào ngày mai."); got != textlang.Vietnamese {
+		t.Fatalf("Detect(accented vietnamese) = %q, want Vietnamese", got)
+	}
+
+	// A German text carries umlauts, and must never cross the Vietnamese
+	// threshold on them - the two accent sets are disjoint by construction.
+	german := "Über die Prüfung der Größe möchte ich mit Ihnen sprechen, und zwar bald."
+	if got := textlang.Detect(german); got != textlang.German {
+		t.Fatalf("Detect(umlaut-heavy german) = %q, want German: umlauts are not "+
+			"vietnamese diacritics", got)
+	}
+}

--- a/backend/internal/shared/kernel/textlang/textlang_test.go
+++ b/backend/internal/shared/kernel/textlang/textlang_test.go
@@ -87,6 +87,103 @@ func TestAForwardWithNoReplyAboveItIsReadFromTheQuote(t *testing.T) {
 	}
 }
 
+// Quote removal has to happen before the Vietnamese check, not after it. A
+// quoted Vietnamese chain under an English reply raises the diacritic density
+// of the whole input well past the threshold.
+func TestQuotedTextIsRemovedBeforeVietnameseIsConsidered(t *testing.T) {
+	reply := "Hi Minh,\n\nthat works for us. I will send the contract over tomorrow " +
+		"and we can go from there.\n\n"
+	quoted := strings.Repeat("> Tôi sẽ gửi đề xuất vào ngày mai và chờ phản hồi.\n", 10)
+
+	if got := textlang.Detect(reply + quoted); got != textlang.English {
+		t.Fatalf("Detect(english reply over vietnamese quote) = %q, want English", got)
+	}
+}
+
+// The Vietnamese test is an explicit character set, not "any letter that is
+// not plain ASCII". The loose predicate calls a French loanword Vietnamese.
+func TestAccentedLoanwordsAreNotVietnamese(t *testing.T) {
+	cases := []struct {
+		name string
+		text string
+		want textlang.Lang
+	}{
+		{
+			name: "french loanwords in english",
+			text: "Please send José's résumé and the café invoice when you have a moment.",
+			want: textlang.English,
+		},
+		{
+			name: "a language this package does not know is Unknown, not Vietnamese",
+			text: "Пожалуйста, отправьте документы на следующей неделе.",
+			want: textlang.Unknown,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := textlang.Detect(c.text); got != c.want {
+				t.Fatalf("Detect(%s) = %q, want %q", c.name, got, c.want)
+			}
+		})
+	}
+}
+
+// "On" and "Am" open ordinary sentences as well as attribution lines, so an
+// opener alone must not cut the message off at its second line.
+func TestASentenceOpeningLikeAnAttributionLineIsNotAQuoteHeader(t *testing.T) {
+	cases := []struct {
+		name string
+		text string
+		want textlang.Lang
+	}{
+		{
+			name: "english prose beginning On",
+			text: "Hi team,\nOn balance we should review the proposal, because the terms " +
+				"are clear and we have the time for it this week.",
+			want: textlang.English,
+		},
+		{
+			name: "german prose beginning Am",
+			text: "Hallo,\nAm Montag besprechen wir das Angebot mit dem Team, und ich " +
+				"melde mich danach bei Ihnen mit einer Antwort.",
+			want: textlang.German,
+		},
+		{
+			name: "a real attribution line does cut",
+			text: "Hallo Marek,\n\ndas passt gut, ich melde mich bei Ihnen. Viele Grüße\n\n" +
+				"On 3 June 2026, Marek wrote:\n" +
+				strings.Repeat("The team has reviewed this and we would like to move "+
+					"forward with the proposal as it stands.\n", 12),
+			want: textlang.German,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := textlang.Detect(c.text); got != c.want {
+				t.Fatalf("Detect(%s) = %q, want %q", c.name, got, c.want)
+			}
+		})
+	}
+}
+
+// Clients indent quoted lines and end lines in three different ways. A quote
+// that announces itself must be found however it is laid out.
+func TestQuotedLinesAreFoundWhateverTheIndentAndLineEnding(t *testing.T) {
+	reply := "Hallo Marek,\n\ndas passt gut, ich melde mich bei Ihnen mit einer " +
+		"Antwort. Viele Grüße\n\n"
+	quote := strings.Repeat("   > The team has reviewed this and we would like to "+
+		"move forward with the proposal.\n", 12)
+
+	if got := textlang.Detect(reply + quote); got != textlang.German {
+		t.Errorf("Detect(indented quote) = %q, want German", got)
+	}
+
+	crOnly := strings.ReplaceAll(reply+quote, "\n", "\r")
+	if got := textlang.Detect(crOnly); got != textlang.German {
+		t.Errorf("Detect(CR line endings) = %q, want German", got)
+	}
+}
+
 // The honest answer for thin or genuinely mixed evidence. This bias is the
 // design: a false German draft on an English thread is worse than the bug it
 // replaces, and the caller has other tiers to fall back to.


### PR DESCRIPTION
First build PR of the "Make eMail meaningful" program. Gated by the two merged spec PRs (margince-foundation #1272, #1273). Two stdlib-only kernel packages with no callers yet — this is the vocabulary the drafting surfaces need before any of them can be fixed.

## Why they are in `shared/kernel`

Three tiers need them: the timeline module renders a floor draft when no model is available, the signals module renders a warm-intro draft, and the composition drafters run the model path. A module may not import a sibling, so shared is the only tier all three can reach — which is what `specs/subsystems/drafting.md` "Where it lives" now says.

## `textlang`

Answers what language a message is written in, or `Unknown`. German against English by discriminating stopwords plus umlauts; Vietnamese by the density of the accented letters it actually writes, decided first because its function words are short unaccented syllables that collide with both.

Two bars that measure different things: an absolute floor on raw hits decides whether there is enough evidence to speak at all, and a margin on the weighted score decides which language won. Both are mutation-checked from each side.

**A reply is written above the thread it quotes**, so a quote marker cuts the text rather than merely down-weighting it. Diluting is not enough — a twelve-turn English chain outvotes a three-line German reply on volume alone, which is the exact shape of the reported bug. A message that is only quoted text keeps its quote, because then the quote is all the evidence there is.

Biased toward `Unknown` on purpose. This market code-switches, and a false German draft on an English thread is worse than the bug it replaces; `Unknown` lets the caller fall back down its own resolution ladder.

## `convstate`

Places a correspondence on one axis — `none`, `fresh`, `weeks`, `months` — with the elapsed silence and who spoke last. Pure function, clock injected at the call site per the house pattern. A timestamp in the future is treated as just-arrived rather than as negative silence, because skew between a mail host and this one is ordinary.

Two predicates carry the new acceptance criteria: `ImpliesPriorContact` is false only at band `none` (DRAFT-AC-E-3, which is what makes "just following up" on a first touch a fabrication), and `AssumesSharedMemory` is true only at `fresh` (DRAFT-AC-E-4).

## Review

Codex reviewed the branch and found seven defects in `textlang`; six are fixed in the second commit, each with a test:

- quote removal ran after the Vietnamese check, so a quoted Vietnamese chain under an English reply was called Vietnamese
- `isVietnameseMarked` accepted any non-ASCII letter, so "José's résumé" was Vietnamese and so was Cyrillic
- `On ` / `Am ` counted as quote headers alone, so "On balance we should review the proposal" truncated the message
- indented `  > quoted` was missed, and CR-only line endings hid the quote

The seventh — an English legal footer under a short German reply still gets full lead weight — is filed as #915, because fixing it means detecting where a signature starts, which is a different problem from detecting where a quote starts.

`convstate` came back clean.

## Gate

`make -C backend build` and `go test .` (root fitness suite: license headers, table ownership, migration RLS scoping, RBAC vocabulary) both green, plus the two packages' own tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds two stdlib-only kernel packages in `shared/kernel` to tell drafters what language a message is in and where a correspondence sits on the silence axis, so replies use the right language and tone.

- **New Features**
  - `textlang`: Detects `de`, `en`, `vi`, or `Unknown`. Cuts quoted threads before judging, gives extra weight to the reply lead, uses German stopwords+umlauts and Vietnamese diacritic density, and returns `Unknown` unless both a hit floor and margin are met.
  - `convstate`: Folds last inbound/outbound timestamps into `none`/`fresh`/`weeks`/`months`, with silence days and last direction. `AssumesSharedMemory` only at `fresh`; `ImpliesPriorContact` except at `none`. Future timestamps read as “just arrived.”

- **Bug Fixes**
  - Fixed detector edge cases: remove quotes before language check; Vietnamese uses an explicit rune set (not “non‑ASCII”); attribution lines require a verb; handle indented `> ` quotes and CR-only line endings. Known follow-up: signatures/legal footers under short replies still get full lead weight (see #915).

<sup>Written for commit 2aaf468e6f4ebe4083d0b77e10aba8d915c5afcb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/916?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added conversation-state classification based on message timing, direction, silence duration, shared context, and prior contact.
  * Added correspondence language detection for German, English, Vietnamese, and unknown text.
  * Improved analysis of replies and forwarded messages by distinguishing current content from quoted email threads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->