### PR TITLE
feat(draftfloor): every no-model draft is written in the correspondence's language

### DIFF
--- a/backend/internal/compose/accountdraft/deterministic.go
+++ b/backend/internal/compose/accountdraft/deterministic.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/draftfloor"
 )
 
 // Draft is the written message plus what it was written from, before the wire
@@ -50,48 +51,55 @@ func Deterministic(in Input) Draft {
 	}
 }
 
+// The subject, from the best topic the account has, in the correspondence's own
+// language. Nothing here is a thread subject - this drafter opens a NEW
+// conversation - so none of it earns a reply prefix.
 func deterministicSubject(in Input) string {
+	lang, band := in.Envelope.Lang(), in.Envelope.Band()
 	if in.Deal != nil {
-		return in.Deal.Name
+		return draftfloor.Subject(lang, band, in.Deal.Name, false)
 	}
 	if in.Commitment != nil {
-		return in.Commitment.Name
+		return draftfloor.Subject(lang, band, in.Commitment.Name, false)
 	}
-	return "Following up · " + in.Company
+	return draftfloor.Subject(lang, band, in.Company, false)
 }
 
-// The body: a greeting, the one thing there is to say, a question, a sign-off.
-// Each part is skipped rather than padded when the summary has nothing for it.
+// The body: a greeting, where the conversation stands, the one thing there is
+// to say, a question. Each part is skipped rather than padded when the summary
+// has nothing for it.
 func deterministicBody(in Input) string {
+	phrases := draftfloor.For(in.Envelope.Lang(), in.Envelope.Band())
+
 	lines := []string{greeting(in), ""}
+	if phrases.Opener != "" {
+		lines = append(lines, phrases.Opener, "")
+	}
 	if subject := deterministicOpener(in); subject != "" {
 		lines = append(lines, subject, "")
 	}
 	// No sign-off: the composer knows who is signed in and adds their name,
 	// and a server that guessed would sometimes sign with the wrong one.
-	lines = append(lines, "Would a short call this week suit you?")
-	return strings.Join(lines, "\n")
+	return strings.Join(append(lines, phrases.Ask), "\n")
 }
 
 func greeting(in Input) string {
-	if in.Recipient.FirstName == "" {
-		return "Hello,"
-	}
-	return "Hi " + in.Recipient.FirstName + ","
+	return draftfloor.Greeting(in.Envelope.Lang(), in.Envelope.Band(), in.Recipient.FirstName)
 }
 
 // The one sentence of substance, from the highest-ranked input that has
 // something to say. The order is A132's: a commitment we made outranks the
 // deal it belongs to, which outranks the account in general.
 func deterministicOpener(in Input) string {
+	lines := draftfloor.SubstanceFor(in.Envelope.Lang())
 	if in.Commitment != nil {
-		return "I wanted to come back to you on " + in.Commitment.Name + "."
+		return draftfloor.Fill(lines.Commitment, in.Commitment.Name)
 	}
 	if in.Deal != nil {
-		return "I wanted to pick up where we left off on " + in.Deal.Name + "."
+		return draftfloor.Fill(lines.Deal, in.Deal.Name)
 	}
 	if len(in.Recent) > 0 && in.Recent[0].Subject != "" {
-		return "I wanted to follow up on " + in.Recent[0].Subject + "."
+		return draftfloor.Fill(lines.Thread, in.Recent[0].Subject)
 	}
 	return ""
 }

--- a/backend/internal/compose/accountdraft/input.go
+++ b/backend/internal/compose/accountdraft/input.go
@@ -15,8 +15,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/convstate"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/draftfloor"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/values"
 )
@@ -29,10 +31,9 @@ type Input struct {
 	// one field they typed, and the one field not fenced.
 	Intent string `json:"intent,omitempty"`
 
-	// Envelope is the correspondence this draft opens: its language, the
-	// current time and who is signing it. The conversation state is always the
-	// first-touch band here - that is what an account-started draft IS - so
-	// nothing in the body may imply an earlier exchange (DRAFT-AC-E-3).
+	// Envelope is the correspondence this draft is written into: its language,
+	// how long it has been silent, the current time and who is signing it.
+	// Server-derived, never read out of the counterparty's own text.
 	Envelope draftfloor.Envelope `json:"envelope"`
 
 	Company  string `json:"company"`
@@ -216,6 +217,25 @@ func foldCommitment(view crmcontracts.Organization360) *TaskIn {
 		out.Due = step.DueAt.UTC().Format(rfc3339)
 	}
 	return &out
+}
+
+// ConversationState reads where this account's correspondence stands off the
+// view's own last-message stamps.
+//
+// Both are absent when the caller holds no activity grant, which reads as a
+// first touch. That is the conservative end of the axis and the right answer
+// here: a caller who cannot see the history has no basis for a draft that
+// refers to it.
+func ConversationState(view crmcontracts.Organization360, now time.Time) convstate.State {
+	return convstate.Classify(now, instant(view.LastInboundAt), instant(view.LastOutboundAt))
+}
+
+// instant reads one optional stamp, treating an absent one as never.
+func instant(at *time.Time) time.Time {
+	if at == nil {
+		return time.Time{}
+	}
+	return *at
 }
 
 // CorrespondenceText is what this account has been written to and from,

--- a/backend/internal/compose/accountdraft/input.go
+++ b/backend/internal/compose/accountdraft/input.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/draftfloor"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/values"
 )
 
@@ -27,6 +28,12 @@ type Input struct {
 	// Intent is the caller's own steering ("shorter", "ask for Tuesday"). The
 	// one field they typed, and the one field not fenced.
 	Intent string `json:"intent,omitempty"`
+
+	// Envelope is the correspondence this draft opens: its language, the
+	// current time and who is signing it. The conversation state is always the
+	// first-touch band here - that is what an account-started draft IS - so
+	// nothing in the body may imply an earlier exchange (DRAFT-AC-E-3).
+	Envelope draftfloor.Envelope `json:"envelope"`
 
 	Company  string `json:"company"`
 	Industry string `json:"industry,omitempty"`
@@ -142,6 +149,7 @@ func FromView(
 	}
 	in := Input{
 		Intent:     strings.TrimSpace(req.Intent),
+		Envelope:   req.Envelope,
 		Company:    view.Organization.DisplayName,
 		Recipient:  recipientOf(contact),
 		Recent:     foldRecent(view),
@@ -208,6 +216,33 @@ func foldCommitment(view crmcontracts.Organization360) *TaskIn {
 		out.Due = step.DueAt.UTC().Format(rfc3339)
 	}
 	return &out
+}
+
+// CorrespondenceText is what this account has been written to and from,
+// newest first, for detecting the language its correspondence runs in.
+//
+// Subjects and bodies both, because a subject line rarely carries enough words
+// to clear the detector's floor on its own. This drafter opens a new
+// conversation, so the text is evidence about the ACCOUNT's language rather
+// than about a thread being answered — a German account gets a German first
+// touch even though nothing is being replied to.
+func CorrespondenceText(view crmcontracts.Organization360) string {
+	if view.Activities == nil {
+		return ""
+	}
+	var text strings.Builder
+	for i, act := range view.Activities.Data {
+		if i == draftInputActivities {
+			break
+		}
+		if act.Subject != nil {
+			text.WriteString(*act.Subject + "\n")
+		}
+		if act.Body != nil {
+			text.WriteString(*act.Body + "\n\n")
+		}
+	}
+	return text.String()
 }
 
 func foldRecent(view crmcontracts.Organization360) []ActIn {

--- a/backend/internal/compose/accountdraft/service.go
+++ b/backend/internal/compose/accountdraft/service.go
@@ -18,7 +18,6 @@ import (
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
 	"github.com/gradionhq/margince/backend/internal/platform/httperr"
-	"github.com/gradionhq/margince/backend/internal/shared/kernel/convstate"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/draftfloor"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
@@ -66,16 +65,15 @@ func (s *Service) WithEnvelope(resolver *draftfloor.Resolver) *Service {
 
 // envelopeFor resolves the correspondence this draft opens.
 //
-// The band is always BandNone, and that is the definition of this surface
-// rather than a default: an account-started draft opens a NEW conversation, so
-// there is no prior exchange for it to refer to however much history the
-// account itself has (DRAFT-AC-E-3). The language still comes from whatever the
-// account has been written in, so a German account gets a German first touch.
+// The band comes from the account's own history rather than being forced to
+// BandNone. "Account-started" describes where the draft was requested from —
+// a company page with no anchoring activity — not a claim that nobody at the
+// company has ever been written to. Forcing the first-touch band would tell an
+// account we have corresponded with for a year that we are writing for the
+// first time, which is as false as the "just following up" this program set out
+// to remove, only in the other direction.
 func (s *Service) envelopeFor(ctx context.Context, view crmcontracts.Organization360) draftfloor.Envelope {
-	return s.envelope.Resolve(ctx, CorrespondenceText(view), convstate.State{
-		Band:          convstate.BandNone,
-		LastDirection: convstate.DirectionNone,
-	})
+	return s.envelope.Resolve(ctx, CorrespondenceText(view), ConversationState(view, s.envelope.Now()))
 }
 
 // NewService binds the draft to the composite read it is grounded in and the

--- a/backend/internal/compose/accountdraft/service.go
+++ b/backend/internal/compose/accountdraft/service.go
@@ -18,6 +18,8 @@ import (
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
 	"github.com/gradionhq/margince/backend/internal/platform/httperr"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/convstate"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/draftfloor"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
@@ -33,24 +35,54 @@ type Request struct {
 	PersonID string
 	DealID   string
 	Intent   string
-	// Sender is deliberately NOT here and not resolved server-side. The draft
-	// carries no sign-off: the composer knows who is signed in and puts their
-	// name on it, and a server that guessed would sometimes sign a message
-	// with the wrong person's name — the one error a rep notices last and
-	// cares about most.
+	// Envelope is the correspondence this draft opens: the language it must be
+	// written in, the current time, and who is writing it. Resolved by the
+	// service, never by the model.
+	//
+	// The sender identity is what tells the model who "I" is. It is NOT a
+	// sign-off: the draft still carries none, because the composer knows who is
+	// signed in and a server that guessed would sometimes sign a message with
+	// the wrong person's name.
+	Envelope draftfloor.Envelope
 }
 
 // Service writes one draft per call.
 type Service struct {
-	view Assembler
-	lane Completer
+	view     Assembler
+	lane     Completer
+	envelope *draftfloor.Resolver
+}
+
+// WithEnvelope replaces the resolver that answers what language to write in,
+// what time it is and who is signing. Compose binds one carrying the real
+// identity lookup; the default resolves a language and a time but no sender,
+// so drafts are unsigned rather than failing (DRAFT-AC-E-6).
+func (s *Service) WithEnvelope(resolver *draftfloor.Resolver) *Service {
+	if resolver != nil {
+		s.envelope = resolver
+	}
+	return s
+}
+
+// envelopeFor resolves the correspondence this draft opens.
+//
+// The band is always BandNone, and that is the definition of this surface
+// rather than a default: an account-started draft opens a NEW conversation, so
+// there is no prior exchange for it to refer to however much history the
+// account itself has (DRAFT-AC-E-3). The language still comes from whatever the
+// account has been written in, so a German account gets a German first touch.
+func (s *Service) envelopeFor(ctx context.Context, view crmcontracts.Organization360) draftfloor.Envelope {
+	return s.envelope.Resolve(ctx, CorrespondenceText(view), convstate.State{
+		Band:          convstate.BandNone,
+		LastDirection: convstate.DirectionNone,
+	})
 }
 
 // NewService binds the draft to the composite read it is grounded in and the
 // model lane that writes it. lane may be nil: that is a deployment running no
 // model, and the deterministic floor is the answer.
 func NewService(view Assembler, lane Completer) *Service {
-	return &Service{view: view, lane: lane}
+	return &Service{view: view, lane: lane, envelope: draftfloor.NewResolver()}
 }
 
 // Draft writes one email. It performs no write of any kind.
@@ -69,6 +101,7 @@ func (s *Service) Draft(
 	if err != nil {
 		return crmcontracts.AccountEmailDraft{}, err
 	}
+	req.Envelope = s.envelopeFor(ctx, view)
 	in, err := FromView(view, req)
 	if err != nil {
 		return crmcontracts.AccountEmailDraft{}, err

--- a/backend/internal/compose/comms.go
+++ b/backend/internal/compose/comms.go
@@ -58,7 +58,10 @@ func (c commsAdapter) DraftEmail(ctx context.Context, anchor ids.UUID, intent st
 	if err != nil {
 		return "", "", err
 	}
-	answering := activities.DraftContext{Band: convstate.BandFresh, Threaded: true}
+	answering := activities.DraftContext{
+		Band:     convstate.BandFresh,
+		Threaded: activities.IsMailThread(activity.Kind, activity.Direction),
+	}
 	if activity.Subject != nil {
 		answering.Topic = *activity.Subject
 	}

--- a/backend/internal/compose/comms.go
+++ b/backend/internal/compose/comms.go
@@ -17,6 +17,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/modules/agents"
 	"github.com/gradionhq/margince/backend/internal/modules/automation"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/convstate"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
@@ -57,11 +58,14 @@ func (c commsAdapter) DraftEmail(ctx context.Context, anchor ids.UUID, intent st
 	if err != nil {
 		return "", "", err
 	}
-	topic := ""
+	answering := activities.DraftContext{Band: convstate.BandFresh, Threaded: true}
 	if activity.Subject != nil {
-		topic = *activity.Subject
+		answering.Topic = *activity.Subject
 	}
-	subject, body := activities.DeterministicEmailDraft(topic, intent)
+	if activity.Body != nil {
+		answering.Body = *activity.Body
+	}
+	subject, body := activities.DeterministicEmailDraft(answering, intent)
 	return subject, body, nil
 }
 

--- a/backend/internal/compose/persondraft/deterministic.go
+++ b/backend/internal/compose/persondraft/deterministic.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/draftfloor"
 )
 
 // Draft is the written message plus what it was written from, before the wire
@@ -51,51 +52,57 @@ func Deterministic(in Input) Draft {
 	}
 }
 
+// The subject, from the best topic the input has, in the correspondence's own
+// language. Only a real thread subject earns a reply prefix: a deal name or an
+// employer is a topic this side chose, and "Re:" on one claims a thread that
+// does not exist.
 func deterministicSubject(in Input) string {
+	lang, band := in.Envelope.Lang(), in.Envelope.Band()
 	if in.Deal != nil {
-		return in.Deal.Name
+		return draftfloor.Subject(lang, band, in.Deal.Name, false)
 	}
 	if len(in.Recent) > 0 && in.Recent[0].Subject != "" {
-		return "Re: " + in.Recent[0].Subject
+		return draftfloor.Subject(lang, band, in.Recent[0].Subject, true)
 	}
-	if in.Recipient.Employer != "" {
-		return "Following up · " + in.Recipient.Employer
-	}
-	return "Following up"
+	return draftfloor.Subject(lang, band, in.Recipient.Employer, false)
 }
 
-// The body: a greeting, the one thing there is to say, a question. Each part is
-// skipped rather than padded when the input has nothing for it.
+// The body: a greeting, where the conversation stands, the one thing there is
+// to say, a question. Each part is skipped rather than padded when the input
+// has nothing for it.
 //
 // No sign-off: the composer knows who is signed in and adds their name, and a
 // server that guessed would sometimes sign with the wrong one.
 func deterministicBody(in Input) string {
+	phrases := draftfloor.For(in.Envelope.Lang(), in.Envelope.Band())
+
 	lines := []string{greeting(in), ""}
+	if phrases.Opener != "" {
+		lines = append(lines, phrases.Opener, "")
+	}
 	if opener := deterministicOpener(in); opener != "" {
 		lines = append(lines, opener, "")
 	}
-	return strings.Join(append(lines, "Would a short call this week suit you?"), "\n")
+	return strings.Join(append(lines, phrases.Ask), "\n")
 }
 
 func greeting(in Input) string {
-	if in.Recipient.FirstName == "" {
-		return "Hello,"
-	}
-	return "Hi " + in.Recipient.FirstName + ","
+	return draftfloor.Greeting(in.Envelope.Lang(), in.Envelope.Band(), in.Recipient.FirstName)
 }
 
 // The one sentence of substance, from the highest-ranked input that has
 // something to say: what this person SAID outranks the deal it was said about,
 // which outranks the last message anyone happened to send.
 func deterministicOpener(in Input) string {
+	lines := draftfloor.SubstanceFor(in.Envelope.Lang())
 	if claim, ok := leadClaim(in); ok {
-		return claimOpener(claim)
+		return claimOpener(claim, lines)
 	}
 	if in.Deal != nil {
-		return "I wanted to pick up where we left off on " + dealLine(in.Deal) + "."
+		return draftfloor.Fill(lines.Deal, dealLine(in.Deal))
 	}
 	if len(in.Recent) > 0 && in.Recent[0].Subject != "" {
-		return "I wanted to follow up on " + in.Recent[0].Subject + "."
+		return draftfloor.Fill(lines.Thread, in.Recent[0].Subject)
 	}
 	return ""
 }
@@ -124,14 +131,14 @@ func leadClaim(in Input) (ClaimIn, bool) {
 // An objection is something we owe them an answer on; a question is something
 // they asked; a priority is something they said matters. Rendering all three
 // the same way would put "you objected to" in a message about a preference.
-func claimOpener(claim ClaimIn) string {
+func claimOpener(claim ClaimIn, lines draftfloor.Substance) string {
 	switch claim.Kind {
 	case "open_question":
-		return "I wanted to come back to you on " + claim.Body + "."
+		return draftfloor.Fill(lines.OpenQuestion, claim.Body)
 	case "objection":
-		return "I still owe you an answer on " + claim.Body + "."
+		return draftfloor.Fill(lines.Objection, claim.Body)
 	default:
-		return "I know " + claim.Body + " matters to you, and I wanted to come back to it."
+		return draftfloor.Fill(lines.Priority, claim.Body)
 	}
 }
 

--- a/backend/internal/compose/persondraft/deterministic.go
+++ b/backend/internal/compose/persondraft/deterministic.go
@@ -61,8 +61,10 @@ func deterministicSubject(in Input) string {
 	if in.Deal != nil {
 		return draftfloor.Subject(lang, band, in.Deal.Name, false)
 	}
+	// Only a message THEY sent us is a thread to reply to. Our own last
+	// outbound carries a subject too, and "Re:" on it replies to ourselves.
 	if len(in.Recent) > 0 && in.Recent[0].Subject != "" {
-		return draftfloor.Subject(lang, band, in.Recent[0].Subject, true)
+		return draftfloor.Subject(lang, band, in.Recent[0].Subject, in.Recent[0].Inbound)
 	}
 	return draftfloor.Subject(lang, band, in.Recipient.Employer, false)
 }

--- a/backend/internal/compose/persondraft/deterministic_test.go
+++ b/backend/internal/compose/persondraft/deterministic_test.go
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package persondraft_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/compose/persondraft"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/convstate"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/draftfloor"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/textlang"
+)
+
+// envelopeFor builds the envelope a resolved correspondence would produce,
+// without going through the service - these cases are about what the FLOOR
+// writes, given facts already resolved.
+func envelopeFor(lang textlang.Lang, band convstate.Band) draftfloor.Envelope {
+	return draftfloor.Envelope{
+		Language:          string(lang),
+		ConversationState: string(band),
+		Now:               "2026-08-11T09:00:00Z",
+	}
+}
+
+// The reported defect, at the floor: a German correspondence produced an
+// English draft, because nothing in the drafter knew what language it was
+// writing in.
+func TestAGermanCorrespondenceGetsAGermanFloorDraft(t *testing.T) {
+	draft := persondraft.Deterministic(persondraft.Input{
+		Envelope: envelopeFor(textlang.German, convstate.BandFresh),
+		Recipient: persondraft.RecipientIn{
+			ID: "p1", Name: "Marek Janetzke", FirstName: "Marek", Employer: "Beispiel GmbH",
+		},
+	})
+
+	if !strings.HasPrefix(draft.Body, "Hallo Marek,") {
+		t.Errorf("body opens %q, want a German greeting", firstLine(draft.Body))
+	}
+	for _, english := range []string{"Would a short call", "Hi Marek", "Hello,"} {
+		if strings.Contains(draft.Body, english) {
+			t.Errorf("body contains English %q in a German draft:\n%s", english, draft.Body)
+		}
+	}
+}
+
+// The other half of the reported defect: a first message to somebody with no
+// history opened by following up on nothing (DRAFT-AC-E-3).
+func TestAFirstTouchNeitherFollowsUpNorRepliesToAThread(t *testing.T) {
+	for _, lang := range []textlang.Lang{textlang.English, textlang.German, textlang.Vietnamese} {
+		draft := persondraft.Deterministic(persondraft.Input{
+			Envelope: envelopeFor(lang, convstate.BandNone),
+			Recipient: persondraft.RecipientIn{
+				ID: "p1", Name: "Marek Janetzke", FirstName: "Marek", Employer: "Beispiel GmbH",
+			},
+		})
+
+		if strings.HasPrefix(draft.Subject, "Re:") {
+			t.Errorf("%s: subject %q replies to a thread that does not exist", lang, draft.Subject)
+		}
+		for _, invented := range []string{"Following up", "Nachfassen", "Tiếp theo"} {
+			if strings.Contains(draft.Subject, invented) {
+				t.Errorf("%s: subject %q claims a history with somebody never written to",
+					lang, draft.Subject)
+			}
+		}
+	}
+}
+
+// A long silence is acknowledged rather than written straight through
+// (DRAFT-AC-E-4). The floor cannot know WHAT changed, but it can decline to
+// assume nothing did.
+func TestALongSilenceIsAcknowledged(t *testing.T) {
+	fresh := persondraft.Deterministic(persondraft.Input{
+		Envelope:  envelopeFor(textlang.German, convstate.BandFresh),
+		Recipient: persondraft.RecipientIn{ID: "p1", FirstName: "Marek"},
+	})
+	stale := persondraft.Deterministic(persondraft.Input{
+		Envelope:  envelopeFor(textlang.German, convstate.BandMonths),
+		Recipient: persondraft.RecipientIn{ID: "p1", FirstName: "Marek"},
+	})
+
+	if len(strings.TrimSpace(stale.Body)) <= len(strings.TrimSpace(fresh.Body)) {
+		t.Errorf("a months-old correspondence should say more than a live one, "+
+			"not the same:\nfresh:\n%s\n\nstale:\n%s", fresh.Body, stale.Body)
+	}
+	if !strings.Contains(stale.Body, "lange zurück") {
+		t.Errorf("a months-old German draft should acknowledge the gap:\n%s", stale.Body)
+	}
+}
+
+// Only a real thread subject earns the reply prefix. A deal name is a topic
+// this side chose, and "Re:" on one claims somebody wrote to us about it.
+func TestOnlyARealThreadSubjectEarnsTheReplyPrefix(t *testing.T) {
+	withDeal := persondraft.Deterministic(persondraft.Input{
+		Envelope:  envelopeFor(textlang.English, convstate.BandFresh),
+		Recipient: persondraft.RecipientIn{ID: "p1", FirstName: "Marek"},
+		Deal:      &persondraft.DealIn{ID: "d1", Name: "Platform rollout"},
+	})
+	if strings.HasPrefix(withDeal.Subject, "Re:") {
+		t.Errorf("a deal name is not a thread: subject %q", withDeal.Subject)
+	}
+
+	withThread := persondraft.Deterministic(persondraft.Input{
+		Envelope:  envelopeFor(textlang.English, convstate.BandFresh),
+		Recipient: persondraft.RecipientIn{ID: "p1", FirstName: "Marek"},
+		Recent: []persondraft.ActIn{
+			{ID: "a1", Kind: "email", Subject: "Pricing question", At: "2026-08-10T09:00:00Z"},
+		},
+	})
+	if !strings.HasPrefix(withThread.Subject, "Re:") {
+		t.Errorf("an inbound thread subject should be replied to: subject %q", withThread.Subject)
+	}
+}
+
+// The floor says its one thing of substance in the correspondence's language
+// too, not only its skeleton. A German draft with an English sentence in the
+// middle is not a German draft.
+func TestTheSubstanceSentenceIsInTheSameLanguageAsTheSkeleton(t *testing.T) {
+	draft := persondraft.Deterministic(persondraft.Input{
+		Envelope:  envelopeFor(textlang.German, convstate.BandFresh),
+		Recipient: persondraft.RecipientIn{ID: "p1", FirstName: "Marek"},
+		Claims: []persondraft.ClaimIn{
+			{ID: "c1", Kind: "objection", Body: "den Preis", SourceID: "a1"},
+		},
+	})
+
+	if !strings.Contains(draft.Body, "noch eine Antwort") {
+		t.Errorf("the substance sentence should be German:\n%s", draft.Body)
+	}
+	if strings.Contains(draft.Body, "I still owe you") {
+		t.Errorf("the substance sentence is still English:\n%s", draft.Body)
+	}
+}
+
+func firstLine(body string) string {
+	line, _, _ := strings.Cut(body, "\n")
+	return line
+}

--- a/backend/internal/compose/persondraft/deterministic_test.go
+++ b/backend/internal/compose/persondraft/deterministic_test.go
@@ -102,15 +102,28 @@ func TestOnlyARealThreadSubjectEarnsTheReplyPrefix(t *testing.T) {
 		t.Errorf("a deal name is not a thread: subject %q", withDeal.Subject)
 	}
 
-	withThread := persondraft.Deterministic(persondraft.Input{
+	inbound := persondraft.Deterministic(persondraft.Input{
+		Envelope:  envelopeFor(textlang.English, convstate.BandFresh),
+		Recipient: persondraft.RecipientIn{ID: "p1", FirstName: "Marek"},
+		Recent: []persondraft.ActIn{
+			{ID: "a1", Kind: "email", Subject: "Pricing question", At: "2026-08-10T09:00:00Z", Inbound: true},
+		},
+	})
+	if !strings.HasPrefix(inbound.Subject, "Re:") {
+		t.Errorf("a message THEY sent should be replied to: subject %q", inbound.Subject)
+	}
+
+	// Our own last outbound carries a subject too, and replying to it replies
+	// to ourselves.
+	outbound := persondraft.Deterministic(persondraft.Input{
 		Envelope:  envelopeFor(textlang.English, convstate.BandFresh),
 		Recipient: persondraft.RecipientIn{ID: "p1", FirstName: "Marek"},
 		Recent: []persondraft.ActIn{
 			{ID: "a1", Kind: "email", Subject: "Pricing question", At: "2026-08-10T09:00:00Z"},
 		},
 	})
-	if !strings.HasPrefix(withThread.Subject, "Re:") {
-		t.Errorf("an inbound thread subject should be replied to: subject %q", withThread.Subject)
+	if strings.HasPrefix(outbound.Subject, "Re:") {
+		t.Errorf("our own outbound is not a thread to reply to: subject %q", outbound.Subject)
 	}
 }
 

--- a/backend/internal/compose/persondraft/input.go
+++ b/backend/internal/compose/persondraft/input.go
@@ -22,6 +22,8 @@ import (
 	"time"
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/convstate"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/draftfloor"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/values"
 )
 
@@ -42,6 +44,11 @@ type Input struct {
 	// Intent is the caller's own steering ("shorter", "ask for Tuesday"). The
 	// one field they typed, and the one field not fenced.
 	Intent string `json:"intent,omitempty"`
+
+	// Envelope is the correspondence this draft is written into: its language,
+	// how long it has been silent, the current time and who is signing it.
+	// Server-derived, never read out of the counterparty's own text.
+	Envelope draftfloor.Envelope `json:"envelope"`
 
 	Recipient RecipientIn `json:"recipient"`
 	// Deal is the open opportunity this person sits on, when the caller can see
@@ -141,6 +148,7 @@ type ActIn struct {
 func FromView(view crmcontracts.Person360, req Request) Input {
 	in := Input{
 		Intent:          strings.TrimSpace(req.Intent),
+		Envelope:        req.Envelope,
 		Recipient:       recipientOf(view),
 		SectionsOmitted: omittedNames(view.SectionsOmitted),
 	}
@@ -148,6 +156,50 @@ func FromView(view crmcontracts.Person360, req Request) Input {
 	foldClaims(&in, view)
 	foldRecent(&in, view)
 	return in
+}
+
+// ConversationState reads where this correspondence stands off the view's own
+// last-message stamps.
+//
+// It lives here rather than in the service because the two stamps it reads are
+// already folded onto the recipient, so the classification and the fields it is
+// derived from cannot drift apart. An unparseable stamp counts as absent, which
+// at worst reads a correspondence as a first touch — the conservative end, and
+// the one that assumes no history rather than inventing some.
+func ConversationState(view crmcontracts.Person360, now time.Time) convstate.State {
+	return convstate.Classify(now, instant(view.LastInboundAt), instant(view.LastOutboundAt))
+}
+
+// instant parses one optional stamp, treating anything unreadable as absent.
+func instant(at *time.Time) time.Time {
+	if at == nil {
+		return time.Time{}
+	}
+	return *at
+}
+
+// CorrespondenceText is the counterparty's own writing this draft answers,
+// newest first, for detecting what language the correspondence is in.
+//
+// Subjects and bodies both, because a subject line rarely carries enough words
+// to clear the detector's floor on its own.
+func CorrespondenceText(view crmcontracts.Person360) string {
+	if view.Activities == nil {
+		return ""
+	}
+	var text strings.Builder
+	for i, activity := range view.Activities.Data {
+		if i == draftInputActivities {
+			break
+		}
+		if activity.Subject != nil {
+			text.WriteString(*activity.Subject + "\n")
+		}
+		if activity.Body != nil {
+			text.WriteString(*activity.Body + "\n\n")
+		}
+	}
+	return text.String()
 }
 
 func recipientOf(view crmcontracts.Person360) RecipientIn {

--- a/backend/internal/compose/persondraft/service.go
+++ b/backend/internal/compose/persondraft/service.go
@@ -17,6 +17,7 @@ import (
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/draftfloor"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
@@ -30,24 +31,43 @@ type Assembler interface {
 // Request is the transport's body, narrowed to what the writer needs.
 type Request struct {
 	Intent string
+	// Envelope is the correspondence this draft is written into: the language
+	// it must be in, where the conversation stands, the current time, and who
+	// is writing it. Resolved by the caller, never by the model.
+	//
+	// The sender identity in it is what the model needs to know who "I" is —
+	// it is NOT a sign-off. The draft still carries none, because the composer
+	// knows who is signed in and a server that guessed would sometimes sign
+	// with the wrong person's name.
+	//
 	// The recipient is not here: the person in the path IS the recipient, which
-	// is what separates this from the account drafter. Sender is deliberately
-	// absent too, and not resolved server-side — the draft carries no sign-off,
-	// because the composer knows who is signed in and a server that guessed
-	// would sometimes sign with the wrong person's name.
+	// is what separates this from the account drafter.
+	Envelope draftfloor.Envelope
 }
 
 // Service writes one draft per call.
 type Service struct {
-	view Assembler
-	lane Completer
+	view     Assembler
+	lane     Completer
+	envelope *draftfloor.Resolver
 }
 
 // NewService binds the draft to the composite read it is grounded in and the
 // model lane that writes it. lane may be nil: that is a deployment running no
 // model, and the deterministic floor is the answer.
 func NewService(view Assembler, lane Completer) *Service {
-	return &Service{view: view, lane: lane}
+	return &Service{view: view, lane: lane, envelope: draftfloor.NewResolver()}
+}
+
+// WithEnvelope replaces the resolver that answers what language to write in,
+// what time it is and who is signing. Compose binds one carrying the real
+// identity lookup; the default resolves a language and a time but no sender,
+// so drafts are unsigned rather than failing (DRAFT-AC-E-6).
+func (s *Service) WithEnvelope(resolver *draftfloor.Resolver) *Service {
+	if resolver != nil {
+		s.envelope = resolver
+	}
+	return s
 }
 
 // Draft writes one email. It performs no write of any kind.
@@ -66,6 +86,8 @@ func (s *Service) Draft(
 	if err != nil {
 		return crmcontracts.AccountEmailDraft{}, err
 	}
+	req.Envelope = s.envelope.Resolve(ctx, CorrespondenceText(view),
+		ConversationState(view, s.envelope.Now()))
 	draft, by, err := Write(ctx, s.lane, FromView(view, req))
 	if err != nil {
 		return crmcontracts.AccountEmailDraft{}, err

--- a/backend/internal/compose/replydraft.go
+++ b/backend/internal/compose/replydraft.go
@@ -114,7 +114,7 @@ func (d replyDrafter) DraftEmailWithProvenance(ctx context.Context, anchor ids.U
 		Topic:    topic,
 		Body:     stringValue(activity.Body),
 		Band:     convstate.BandFresh,
-		Threaded: true,
+		Threaded: activities.IsMailThread(activity.Kind, activity.Direction),
 	}, intent)
 	data := replyActivityData{
 		Subject: boundedRunes(topic, replyActivityMaxRunes),

--- a/backend/internal/compose/replydraft.go
+++ b/backend/internal/compose/replydraft.go
@@ -22,6 +22,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/modules/ai"
 	"github.com/gradionhq/margince/backend/internal/modules/signals"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/convstate"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/promptfence"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/model"
@@ -106,7 +107,15 @@ func (d replyDrafter) DraftEmailWithProvenance(ctx context.Context, anchor ids.U
 		return activities.DraftResult{}, err
 	}
 	topic := stringValue(activity.Subject)
-	fallbackSubject, fallbackBody := activities.DeterministicEmailDraft(topic, intent)
+	// A reply drafter is answering an activity that exists, so the floor it
+	// degrades to is answering one too: band fresh, and the body it read is
+	// what tells the floor which language to write in.
+	fallbackSubject, fallbackBody := activities.DeterministicEmailDraft(activities.DraftContext{
+		Topic:    topic,
+		Body:     stringValue(activity.Body),
+		Band:     convstate.BandFresh,
+		Threaded: true,
+	}, intent)
 	data := replyActivityData{
 		Subject: boundedRunes(topic, replyActivityMaxRunes),
 		Body:    boundedRunes(stringValue(activity.Body), replyActivityMaxRunes),

--- a/backend/internal/compose/slipping.go
+++ b/backend/internal/compose/slipping.go
@@ -21,6 +21,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/modules/activities"
 	"github.com/gradionhq/margince/backend/internal/modules/agents"
 	"github.com/gradionhq/margince/backend/internal/modules/deals"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/convstate"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
 )
@@ -90,7 +91,14 @@ func slippingCandidate(d crmcontracts.Deal, today time.Time) agents.SlippingDeal
 // the deterministic draft voice with draft_email.
 func followUpDrafter(provider datasource.SystemOfRecordProvider) agents.FollowUpDrafter {
 	return func(ctx context.Context, deal agents.SlippingDeal) (ids.UUID, string, error) {
-		subject, body := activities.DeterministicEmailDraft(deal.Name, "")
+		// A slipping deal is by definition one nobody has touched lately, so
+		// the floor writes at the weeks band: it acknowledges the gap instead
+		// of opening as if the conversation were still live. The deal name is
+		// the topic, not a thread subject, so it earns no reply prefix.
+		subject, body := activities.DeterministicEmailDraft(activities.DraftContext{
+			Topic: deal.Name,
+			Band:  convstate.BandWeeks,
+		}, "")
 		fields, err := json.Marshal(map[string]any{
 			"kind":    "note",
 			"subject": "Draft follow-up: " + subject,

--- a/backend/internal/modules/activities/handlers_email.go
+++ b/backend/internal/modules/activities/handlers_email.go
@@ -139,7 +139,10 @@ func (h Handlers) prepareEmailDraft(ctx context.Context, anchor ids.UUID, intent
 	if err != nil {
 		return DraftResult{}, err
 	}
-	answering := DraftContext{Band: convstate.BandFresh, Threaded: true}
+	answering := DraftContext{
+		Band:     convstate.BandFresh,
+		Threaded: IsMailThread(activity.Kind, activity.Direction),
+	}
 	if activity.Subject != nil {
 		answering.Topic = *activity.Subject
 	}
@@ -171,6 +174,11 @@ func DeterministicEmailDraft(answering DraftContext, intent string) (subject, bo
 	if phrases.Opener != "" {
 		lines = append(lines, phrases.Opener, "")
 	}
+	// The topic is the only substance this floor has, and dropping it would
+	// leave a draft that says nothing about what it is answering.
+	if topic != "" {
+		lines = append(lines, draftfloor.Fill(draftfloor.SubstanceFor(lang).Thread, topic), "")
+	}
 	if intent := strings.TrimSpace(intent); intent != "" {
 		lines = append(lines, intent, "")
 	}
@@ -185,15 +193,27 @@ type DraftContext struct {
 	// Topic is what the message is about: the subject of the thread being
 	// answered, or a deal name the caller chose. Empty when nothing is known.
 	Topic string
-	// Threaded says the topic is a real inbound thread subject rather than a
-	// name the caller picked. Only that earns the reply prefix - "Re:" on a
-	// deal name is a claim that somebody wrote to us about it.
+	// Threaded says the topic is the subject of a real INBOUND MAIL thread
+	// rather than a name the caller picked. Only that earns the reply prefix:
+	// "Re:" on a deal name, or on a meeting somebody titled "Quarterly
+	// review", claims a message that was never written to us.
 	Threaded bool
 	// Body is the text of the message being answered, used to detect the
 	// language of the correspondence. Empty falls back to the topic.
 	Body string
 	// Band is where the correspondence stands. The zero value is BandNone.
 	Band convstate.Band
+}
+
+// IsMailThread reports whether an activity is an inbound mail thread, which is
+// the only thing a reply prefix may be built on.
+//
+// Spelled once rather than at each call site: three callers derive the same
+// flag, and a fourth that guessed would put "Re:" on a meeting title. Kind and
+// direction both, because an email WE sent is not a message to reply to either.
+func IsMailThread(kind crmcontracts.ActivityKind, direction *crmcontracts.ActivityDirection) bool {
+	return kind == crmcontracts.ActivityKindEmail &&
+		direction != nil && *direction == crmcontracts.ActivityDirectionInbound
 }
 
 // language resolves the correspondence language from whatever text there is,

--- a/backend/internal/modules/activities/handlers_email.go
+++ b/backend/internal/modules/activities/handlers_email.go
@@ -5,7 +5,6 @@ package activities
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"strings"
 
@@ -14,7 +13,10 @@ import (
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/platform/httperr"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/convstate"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/draftfloor"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/textlang"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/connector"
 )
 
@@ -137,35 +139,74 @@ func (h Handlers) prepareEmailDraft(ctx context.Context, anchor ids.UUID, intent
 	if err != nil {
 		return DraftResult{}, err
 	}
-	topic := ""
+	answering := DraftContext{Band: convstate.BandFresh, Threaded: true}
 	if activity.Subject != nil {
-		topic = *activity.Subject
+		answering.Topic = *activity.Subject
 	}
-	subject, body := DeterministicEmailDraft(topic, intent)
+	if activity.Body != nil {
+		answering.Body = *activity.Body
+	}
+	subject, body := DeterministicEmailDraft(answering, intent)
 	return DraftResult{Subject: subject, Body: body}, nil
 }
 
 // DeterministicEmailDraft is the shared no-model floor for every drafting
 // transport. Compose calls it when the model lane is absent or unavailable,
 // so HTTP, MCP, and automation cannot drift into different fallback text.
-func DeterministicEmailDraft(topic, intent string) (subject, body string) {
-	subject = "Re: follow-up"
-	if topic != "" {
-		subject = "Re: " + topic
+//
+// The prose skeleton comes from the shared floor table rather than from string
+// literals here, so this path writes the same German a model-backed draft would
+// (DRAFT-AC-E-1). answering is the correspondence the draft replies into: its
+// text decides the language, and its shape decides whether there is a thread to
+// reply to at all.
+func DeterministicEmailDraft(answering DraftContext, intent string) (subject, body string) {
+	lang := answering.language()
+	band := answering.Band
+
+	topic := strings.TrimSpace(answering.Topic)
+	subject = draftfloor.Subject(lang, band, topic, answering.Threaded)
+
+	phrases := draftfloor.For(lang, band)
+	lines := []string{phrases.GreetingAnonymous, ""}
+	if phrases.Opener != "" {
+		lines = append(lines, phrases.Opener, "")
 	}
-	var b strings.Builder
-	b.WriteString("Hi,\n\nfollowing up on ")
-	if topic != "" {
-		fmt.Fprintf(&b, "%q", topic)
-	} else {
-		b.WriteString("our last conversation")
+	if intent := strings.TrimSpace(intent); intent != "" {
+		lines = append(lines, intent, "")
 	}
-	b.WriteString(".")
-	if strings.TrimSpace(intent) != "" {
-		b.WriteString("\n\n" + strings.TrimSpace(intent))
+	return subject, strings.Join(append(lines, phrases.Ask), "\n")
+}
+
+// DraftContext is what the floor knows about the correspondence it is writing
+// into. Everything is optional: the zero value describes a first message to
+// somebody with no history, which is the honest reading of "we were told
+// nothing".
+type DraftContext struct {
+	// Topic is what the message is about: the subject of the thread being
+	// answered, or a deal name the caller chose. Empty when nothing is known.
+	Topic string
+	// Threaded says the topic is a real inbound thread subject rather than a
+	// name the caller picked. Only that earns the reply prefix - "Re:" on a
+	// deal name is a claim that somebody wrote to us about it.
+	Threaded bool
+	// Body is the text of the message being answered, used to detect the
+	// language of the correspondence. Empty falls back to the topic.
+	Body string
+	// Band is where the correspondence stands. The zero value is BandNone.
+	Band convstate.Band
+}
+
+// language resolves the correspondence language from whatever text there is,
+// preferring the body because a subject line rarely carries enough words to
+// clear the detector's floor.
+func (c DraftContext) language() textlang.Lang {
+	if lang := textlang.Detect(c.Body); lang != textlang.Unknown {
+		return lang
 	}
-	b.WriteString("\n\nBest regards")
-	return subject, b.String()
+	if lang := textlang.Detect(c.Topic); lang != textlang.Unknown {
+		return lang
+	}
+	return draftfloor.DefaultLang
 }
 
 // SendAccountEmail starts a NEW conversation from a record rather than

--- a/backend/internal/modules/signals/intropath.go
+++ b/backend/internal/modules/signals/intropath.go
@@ -88,8 +88,13 @@ func (s *Store) IntroPath(ctx context.Context, signalID ids.SignalID, now time.T
 		kind = crmcontracts.SignalIntroPathNextMoveKind("intro_request")
 	}
 	out.NextMove.Kind = kind
-	out.NextMove.DraftSubject, out.NextMove.DraftBody = renderIntroDraft(kind, route, orgName, sig.Summary)
-	out.NextMove.AiDisclosure = Art50Disclosure
+	var disclosure string
+	out.NextMove.DraftSubject, out.NextMove.DraftBody, disclosure =
+		renderIntroDraft(kind, route, orgName, sig.Summary)
+	// The machine-readable field carries the SAME sentence the body does, in
+	// the same language. Two spellings of one disclosure is a reader being told
+	// one thing and an auditor another.
+	out.NextMove.AiDisclosure = disclosure
 	return out, nil
 }
 
@@ -106,6 +111,14 @@ type introPhrases struct {
 	IntroBody     string
 	DirectSubject string
 	DirectBody    string
+	// Disclosure is the Art. 50 line in this language. Translated rather than
+	// shared, because a legally required sentence a reader cannot read has not
+	// disclosed anything - and an English footer under German prose is the
+	// clearest possible tell that the message was machine-made.
+	Disclosure string
+	// Relationships names each relationship kind in prose. Without it the raw
+	// enum ("deal_stakeholder") lands mid-sentence in a message a rep sends.
+	Relationships map[crmcontracts.SignalWarmContactRelationshipKind]string
 }
 
 // The two moves in each language. The German is Sie throughout to a
@@ -115,26 +128,41 @@ var introTable = map[textlang.Lang]introPhrases{
 	textlang.English: {
 		IntroSubject: "Could you introduce us at %s?",
 		IntroBody: "Hi %s,\n\nSomething came up on our side about %s: %s. You know the " +
-			"right people there (%s) - would you be open to making an intro?\n\n%s",
+			"right people there - would you be open to making an intro?\n\n%s",
 		DirectSubject: "Getting in touch about %s",
 		DirectBody: "Hi %s,\n\nI am writing because of something we picked up about %s: %s. " +
-			"Given our %s relationship, this felt worth raising with you directly.\n\n%s",
+			"Given that we %s, this felt worth raising with you directly.\n\n%s",
+		Disclosure: Art50Disclosure,
+		Relationships: map[crmcontracts.SignalWarmContactRelationshipKind]string{
+			crmcontracts.SignalWarmContactRelationshipKindDealStakeholder: "are working together on a deal",
+			crmcontracts.SignalWarmContactRelationshipKindEmployment:      "know each other through your company",
+		},
 	},
 	textlang.German: {
 		IntroSubject: "Können Sie uns bei %s vorstellen?",
 		IntroBody: "Hallo %s,\n\nbei uns ist etwas zu %s aufgekommen: %s. Sie kennen dort " +
-			"die richtigen Ansprechpartner (%s) - wären Sie bereit, uns vorzustellen?\n\n%s",
+			"die richtigen Ansprechpartner - wären Sie bereit, uns vorzustellen?\n\n%s",
 		DirectSubject: "Kurze Anfrage zu %s",
 		DirectBody: "Hallo %s,\n\nich melde mich, weil wir etwas zu %s aufgenommen haben: %s. " +
-			"Aufgrund unserer %s-Beziehung wollte ich das direkt mit Ihnen besprechen.\n\n%s",
+			"Da wir %s, wollte ich das direkt mit Ihnen besprechen.\n\n%s",
+		Disclosure: "Diese Nachricht wurde mit KI-Unterstützung verfasst (Offenlegung nach Art. 50 EU-KI-Verordnung).",
+		Relationships: map[crmcontracts.SignalWarmContactRelationshipKind]string{
+			crmcontracts.SignalWarmContactRelationshipKindDealStakeholder: "gemeinsam an einem Vorgang arbeiten",
+			crmcontracts.SignalWarmContactRelationshipKindEmployment:      "über Ihr Unternehmen in Kontakt stehen",
+		},
 	},
 	textlang.Vietnamese: {
 		IntroSubject: "Anh/chị có thể giới thiệu chúng tôi tại %s không?",
 		IntroBody: "Chào %s,\n\nchúng tôi vừa ghi nhận một việc liên quan đến %s: %s. " +
-			"Anh/chị quen những người phù hợp ở đó (%s) - anh/chị có thể giới thiệu giúp không?\n\n%s",
+			"Anh/chị quen những người phù hợp ở đó - anh/chị có thể giới thiệu giúp không?\n\n%s",
 		DirectSubject: "Xin được liên hệ về %s",
 		DirectBody: "Chào %s,\n\ntôi liên hệ vì chúng tôi ghi nhận một việc liên quan đến %s: %s. " +
-			"Với quan hệ %s giữa hai bên, tôi muốn trao đổi trực tiếp với anh/chị.\n\n%s",
+			"Vì hai bên %s, tôi muốn trao đổi trực tiếp với anh/chị.\n\n%s",
+		Disclosure: "Thư này được soạn với sự hỗ trợ của AI (công bố theo Điều 50 Đạo luật AI của EU).",
+		Relationships: map[crmcontracts.SignalWarmContactRelationshipKind]string{
+			crmcontracts.SignalWarmContactRelationshipKindDealStakeholder: "đang cùng làm việc trong một cơ hội",
+			crmcontracts.SignalWarmContactRelationshipKindEmployment:      "có liên hệ qua công ty của anh/chị",
+		},
 	},
 }
 
@@ -148,7 +176,7 @@ var introTable = map[textlang.Lang]introPhrases{
 // resolution ladder (DRAFT-AC-E-2). Neither subject may be a follow-up line:
 // both moves are a first approach on this topic, and "Following up with X" to
 // somebody who has heard nothing is the invented history DRAFT-AC-E-3 forbids.
-func renderIntroDraft(kind crmcontracts.SignalIntroPathNextMoveKind, route crmcontracts.SignalWarmContact, orgName, signalSummary string) (subject, body string) {
+func renderIntroDraft(kind crmcontracts.SignalIntroPathNextMoveKind, route crmcontracts.SignalWarmContact, orgName, signalSummary string) (subject, body, disclosure string) {
 	lang := textlang.Detect(signalSummary)
 	phrases, ok := introTable[lang]
 	if !ok {
@@ -159,17 +187,27 @@ func renderIntroDraft(kind crmcontracts.SignalIntroPathNextMoveKind, route crmco
 	if route.FullName != nil && *route.FullName != "" {
 		name = *route.FullName
 	}
-	relationship := string(route.RelationshipKind)
-	if route.RelationshipRole != nil && *route.RelationshipRole != "" {
-		relationship += " (" + *route.RelationshipRole + ")"
-	}
 
 	if kind == "intro_request" {
 		return fmt.Sprintf(phrases.IntroSubject, orgName),
-			fmt.Sprintf(phrases.IntroBody, name, orgName, signalSummary, relationship, Art50Disclosure)
+			fmt.Sprintf(phrases.IntroBody, name, orgName, signalSummary, phrases.Disclosure),
+			phrases.Disclosure
 	}
 	return fmt.Sprintf(phrases.DirectSubject, orgName),
-		fmt.Sprintf(phrases.DirectBody, name, orgName, signalSummary, relationship, Art50Disclosure)
+		fmt.Sprintf(phrases.DirectBody, name, orgName, signalSummary,
+			phrases.relationship(route.RelationshipKind), phrases.Disclosure),
+		phrases.Disclosure
+}
+
+// relationship names a relationship kind in prose, or says nothing specific
+// about it. An unrecognized kind is a new enum member this table has not
+// learned yet, and a vague clause is better in a rep's outbound message than
+// the raw identifier.
+func (p introPhrases) relationship(kind crmcontracts.SignalWarmContactRelationshipKind) string {
+	if named, ok := p.Relationships[kind]; ok {
+		return named
+	}
+	return p.Relationships[crmcontracts.SignalWarmContactRelationshipKindEmployment]
 }
 
 // anonymousGreetingName is what to call somebody whose name is not on file.

--- a/backend/internal/modules/signals/intropath.go
+++ b/backend/internal/modules/signals/intropath.go
@@ -24,7 +24,9 @@ import (
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/draftfloor"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/textlang"
 )
 
 // Art50Disclosure is the Art. 50 AI-assisted disclosure every proposed
@@ -91,12 +93,69 @@ func (s *Store) IntroPath(ctx context.Context, signalID ids.SignalID, now time.T
 	return out, nil
 }
 
+// introPhrases is the wording of one warm-intro draft in one language.
+//
+// This path does not use the shared floor table's phrases, and the reason is
+// worth stating: the table writes correspondence WITH a counterparty, while
+// these two messages are an ask TO a colleague ("would you introduce us") and a
+// first approach to a stranger. The shared vocabulary they do use is the
+// language the message is written in and the band-none rule that a first
+// approach may not open by following up on nothing.
+type introPhrases struct {
+	IntroSubject  string
+	IntroBody     string
+	DirectSubject string
+	DirectBody    string
+}
+
+// The two moves in each language. The German is Sie throughout to a
+// counterparty and du to nobody, since the route contact is a business
+// relationship rather than a colleague in the seat sense.
+var introTable = map[textlang.Lang]introPhrases{
+	textlang.English: {
+		IntroSubject: "Could you introduce us at %s?",
+		IntroBody: "Hi %s,\n\nSomething came up on our side about %s: %s. You know the " +
+			"right people there (%s) - would you be open to making an intro?\n\n%s",
+		DirectSubject: "Getting in touch about %s",
+		DirectBody: "Hi %s,\n\nI am writing because of something we picked up about %s: %s. " +
+			"Given our %s relationship, this felt worth raising with you directly.\n\n%s",
+	},
+	textlang.German: {
+		IntroSubject: "Können Sie uns bei %s vorstellen?",
+		IntroBody: "Hallo %s,\n\nbei uns ist etwas zu %s aufgekommen: %s. Sie kennen dort " +
+			"die richtigen Ansprechpartner (%s) - wären Sie bereit, uns vorzustellen?\n\n%s",
+		DirectSubject: "Kurze Anfrage zu %s",
+		DirectBody: "Hallo %s,\n\nich melde mich, weil wir etwas zu %s aufgenommen haben: %s. " +
+			"Aufgrund unserer %s-Beziehung wollte ich das direkt mit Ihnen besprechen.\n\n%s",
+	},
+	textlang.Vietnamese: {
+		IntroSubject: "Anh/chị có thể giới thiệu chúng tôi tại %s không?",
+		IntroBody: "Chào %s,\n\nchúng tôi vừa ghi nhận một việc liên quan đến %s: %s. " +
+			"Anh/chị quen những người phù hợp ở đó (%s) - anh/chị có thể giới thiệu giúp không?\n\n%s",
+		DirectSubject: "Xin được liên hệ về %s",
+		DirectBody: "Chào %s,\n\ntôi liên hệ vì chúng tôi ghi nhận một việc liên quan đến %s: %s. " +
+			"Với quan hệ %s giữa hai bên, tôi muốn trao đổi trực tiếp với anh/chị.\n\n%s",
+	},
+}
+
 // renderIntroDraft is the deterministic V1 draft: it names the contact,
 // the relationship, and the signal it derives from, and always ends with
 // the Art. 50 disclosure. (The Voice-DNA styled draft is the E07 seam —
 // it replaces the wording, never the disclosure or the evidence.)
+//
+// The language comes from the signal's own summary, which is the only text
+// this path holds. An unresolvable one writes English, the last rung of the
+// resolution ladder (DRAFT-AC-E-2). Neither subject may be a follow-up line:
+// both moves are a first approach on this topic, and "Following up with X" to
+// somebody who has heard nothing is the invented history DRAFT-AC-E-3 forbids.
 func renderIntroDraft(kind crmcontracts.SignalIntroPathNextMoveKind, route crmcontracts.SignalWarmContact, orgName, signalSummary string) (subject, body string) {
-	name := "there"
+	lang := textlang.Detect(signalSummary)
+	phrases, ok := introTable[lang]
+	if !ok {
+		phrases = introTable[draftfloor.DefaultLang]
+	}
+
+	name := anonymousGreetingName(lang)
 	if route.FullName != nil && *route.FullName != "" {
 		name = *route.FullName
 	}
@@ -104,17 +163,23 @@ func renderIntroDraft(kind crmcontracts.SignalIntroPathNextMoveKind, route crmco
 	if route.RelationshipRole != nil && *route.RelationshipRole != "" {
 		relationship += " (" + *route.RelationshipRole + ")"
 	}
-	switch kind {
-	case "intro_request":
-		subject = "Could you introduce us at " + orgName + "?"
-		body = fmt.Sprintf(
-			"Hi %s,\n\nSomething came up on our side about %s: %s. You know the right people there (%s) — would you be open to making an intro?\n\n%s",
-			name, orgName, signalSummary, relationship, Art50Disclosure)
-	default:
-		subject = "Following up with " + orgName
-		body = fmt.Sprintf(
-			"Hi %s,\n\nReaching out because of a recent signal on %s: %s. Given our %s relationship, this felt worth a direct conversation.\n\n%s",
-			name, orgName, signalSummary, relationship, Art50Disclosure)
+
+	if kind == "intro_request" {
+		return fmt.Sprintf(phrases.IntroSubject, orgName),
+			fmt.Sprintf(phrases.IntroBody, name, orgName, signalSummary, relationship, Art50Disclosure)
 	}
-	return subject, body
+	return fmt.Sprintf(phrases.DirectSubject, orgName),
+		fmt.Sprintf(phrases.DirectBody, name, orgName, signalSummary, relationship, Art50Disclosure)
+}
+
+// anonymousGreetingName is what to call somebody whose name is not on file.
+func anonymousGreetingName(lang textlang.Lang) string {
+	switch lang {
+	case textlang.German:
+		return "zusammen"
+	case textlang.Vietnamese:
+		return "anh/chị"
+	default:
+		return "there"
+	}
 }

--- a/backend/internal/shared/kernel/draftfloor/draftfloor.go
+++ b/backend/internal/shared/kernel/draftfloor/draftfloor.go
@@ -1,0 +1,229 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+// Package draftfloor holds the prose skeleton of a draft written without a
+// model, in the language of the correspondence and honest about how long it
+// has been silent.
+//
+// Four places in the product write an email with no model available: the person
+// composer, the account composer, the timeline's own fallback, and the
+// warm-intro path in signals. All four spelled their skeleton in hardcoded
+// English, and all four opened a first message to a stranger with "Following
+// up" — an invented history, which is exactly what DRAFT-AC-E-3 forbids. Four
+// copies also means a fix to one is a fix to one.
+//
+// So the skeleton is one table here, indexed by band and language, and each
+// caller keeps its own wire shape, its own reasoning assembly, and its own
+// ranking of what to say. This package supplies only the words around them.
+//
+// It is in the shared tier because two of the four callers are modules
+// (activities, signals) that sit below composition and may not import a
+// sibling (specs/subsystems/drafting.md, "Where it lives"). Stdlib-only, so it
+// stays a Tier-0 leaf.
+package draftfloor
+
+import (
+	"strings"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/convstate"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/textlang"
+)
+
+// DefaultLang is what an unresolved language falls back to. English, as the
+// last rung of the resolution ladder (DRAFT-AC-E-2) — a floor draft in a
+// language nobody asked for is still a draft the rep can edit, where no draft
+// at all is a broken screen.
+const DefaultLang = textlang.English
+
+// Phrases is the prose skeleton for one band in one language.
+//
+// Every field is a whole clause rather than a fragment to be assembled, because
+// the three languages do not agree on where the pieces go and a template that
+// concatenates them produces German that reads translated.
+type Phrases struct {
+	// SubjectNoContext is the subject when nothing better is known. At band
+	// none it names a reason to write; it is never a follow-up line, because
+	// there is nothing to follow up on.
+	SubjectNoContext string
+	// SubjectAbout builds a subject around a topic that IS known - a deal
+	// name, an employer. The verb "%s" is the topic.
+	SubjectAbout string
+	// GreetingNamed and GreetingAnonymous open the message. Named takes the
+	// recipient's first name.
+	GreetingNamed     string
+	GreetingAnonymous string
+	// Opener acknowledges where the conversation stands, before the message
+	// says anything of its own. Empty at band fresh, where a live exchange
+	// needs no preamble and one reads as padding.
+	Opener string
+	// Ask closes the message with the one request it makes.
+	Ask string
+}
+
+// The table. Twelve cells: four bands in three languages.
+//
+// The German is written as German rather than translated from the English, and
+// uses Sie throughout — the register a drafter should default to when nothing
+// tells it otherwise. The Vietnamese likewise uses the neutral business
+// register.
+var table = map[textlang.Lang]map[convstate.Band]Phrases{
+	textlang.English: {
+		convstate.BandNone: {
+			SubjectNoContext:  "Getting in touch",
+			SubjectAbout:      "About %s",
+			GreetingNamed:     "Hi %s,",
+			GreetingAnonymous: "Hello,",
+			Opener:            "I am writing to you for the first time, so I will keep this short.",
+			Ask:               "Would a short call in the next week or two be useful?",
+		},
+		convstate.BandFresh: {
+			SubjectNoContext:  "Following up",
+			SubjectAbout:      "Re: %s",
+			GreetingNamed:     "Hi %s,",
+			GreetingAnonymous: "Hello,",
+			Opener:            "",
+			Ask:               "Would a short call this week suit you?",
+		},
+		convstate.BandWeeks: {
+			SubjectNoContext:  "Picking this back up",
+			SubjectAbout:      "Re: %s",
+			GreetingNamed:     "Hi %s,",
+			GreetingAnonymous: "Hello,",
+			Opener:            "It has been a few weeks since we last spoke, so here is where things stand.",
+			Ask:               "Would a short call in the next week or two be useful?",
+		},
+		convstate.BandMonths: {
+			SubjectNoContext:  "Picking this back up",
+			SubjectAbout:      "Re: %s",
+			GreetingNamed:     "Hi %s,",
+			GreetingAnonymous: "Hello,",
+			Opener:            "It has been a long time since we were last in touch, so I will not assume any of this is still current.",
+			Ask:               "Is this still worth a conversation on your side?",
+		},
+	},
+	textlang.German: {
+		convstate.BandNone: {
+			SubjectNoContext:  "Kurze Anfrage",
+			SubjectAbout:      "Anfrage zu %s",
+			GreetingNamed:     "Hallo %s,",
+			GreetingAnonymous: "Guten Tag,",
+			Opener:            "ich melde mich zum ersten Mal bei Ihnen und fasse mich deshalb kurz.",
+			Ask:               "Wäre ein kurzes Gespräch in den nächsten zwei Wochen sinnvoll?",
+		},
+		convstate.BandFresh: {
+			SubjectNoContext:  "Nachfassen",
+			SubjectAbout:      "Re: %s",
+			GreetingNamed:     "Hallo %s,",
+			GreetingAnonymous: "Guten Tag,",
+			Opener:            "",
+			Ask:               "Passt Ihnen ein kurzes Gespräch in dieser Woche?",
+		},
+		convstate.BandWeeks: {
+			SubjectNoContext:  "Wir nehmen das Thema wieder auf",
+			SubjectAbout:      "Re: %s",
+			GreetingNamed:     "Hallo %s,",
+			GreetingAnonymous: "Guten Tag,",
+			Opener:            "seit unserem letzten Austausch sind einige Wochen vergangen, deshalb hier der aktuelle Stand.",
+			Ask:               "Wäre ein kurzes Gespräch in den nächsten zwei Wochen sinnvoll?",
+		},
+		convstate.BandMonths: {
+			SubjectNoContext:  "Wir nehmen das Thema wieder auf",
+			SubjectAbout:      "Re: %s",
+			GreetingNamed:     "Hallo %s,",
+			GreetingAnonymous: "Guten Tag,",
+			Opener:            "unser letzter Kontakt liegt lange zurück, deshalb setze ich nichts davon als noch aktuell voraus.",
+			Ask:               "Ist das Thema auf Ihrer Seite noch relevant?",
+		},
+	},
+	textlang.Vietnamese: {
+		convstate.BandNone: {
+			SubjectNoContext:  "Xin được liên hệ",
+			SubjectAbout:      "Về %s",
+			GreetingNamed:     "Chào %s,",
+			GreetingAnonymous: "Xin chào,",
+			Opener:            "Đây là lần đầu tôi liên hệ với anh/chị nên tôi xin trình bày ngắn gọn.",
+			Ask:               "Anh/chị có thể dành một cuộc trao đổi ngắn trong hai tuần tới không?",
+		},
+		convstate.BandFresh: {
+			SubjectNoContext:  "Tiếp theo trao đổi",
+			SubjectAbout:      "Re: %s",
+			GreetingNamed:     "Chào %s,",
+			GreetingAnonymous: "Xin chào,",
+			Opener:            "",
+			Ask:               "Anh/chị có thể dành một cuộc trao đổi ngắn trong tuần này không?",
+		},
+		convstate.BandWeeks: {
+			SubjectNoContext:  "Xin phép trao đổi lại",
+			SubjectAbout:      "Re: %s",
+			GreetingNamed:     "Chào %s,",
+			GreetingAnonymous: "Xin chào,",
+			Opener:            "Đã vài tuần kể từ lần trao đổi trước, tôi xin cập nhật tình hình hiện tại.",
+			Ask:               "Anh/chị có thể dành một cuộc trao đổi ngắn trong hai tuần tới không?",
+		},
+		convstate.BandMonths: {
+			SubjectNoContext:  "Xin phép trao đổi lại",
+			SubjectAbout:      "Re: %s",
+			GreetingNamed:     "Chào %s,",
+			GreetingAnonymous: "Xin chào,",
+			Opener:            "Đã lâu chúng ta chưa liên hệ nên tôi không mặc định rằng mọi việc vẫn như trước.",
+			Ask:               "Việc này còn phù hợp với anh/chị không?",
+		},
+	},
+}
+
+// For returns the skeleton for a band in a language.
+//
+// An unknown language falls back to DefaultLang rather than returning an error:
+// the caller is already on the no-model path, and a floor draft that refuses to
+// render leaves the screen with nothing. An unrecognized band falls back to
+// BandNone, which is the conservative end of the axis — it assumes no history,
+// and assuming none where some exists costs a sentence of context, while
+// assuming some where none exists is the fabrication this package removes.
+func For(lang textlang.Lang, band convstate.Band) Phrases {
+	byBand, ok := table[lang]
+	if !ok {
+		byBand = table[DefaultLang]
+	}
+	phrases, ok := byBand[band]
+	if !ok {
+		phrases = byBand[convstate.BandNone]
+	}
+	return phrases
+}
+
+// Subject renders the subject line for a draft.
+//
+// topic is what the message is about — a deal name, an employer, the subject of
+// the thread being answered — or empty when nothing is known. threaded says
+// whether topic came from a real inbound thread subject, which is the only
+// thing that earns a reply prefix: "Re:" on a message nobody replied to is a
+// claim that a thread exists, and at band none it is always false
+// (DRAFT-AC-E-3).
+func Subject(lang textlang.Lang, band convstate.Band, topic string, threaded bool) string {
+	phrases := For(lang, band)
+	topic = strings.TrimSpace(topic)
+	if topic == "" {
+		return phrases.SubjectNoContext
+	}
+	if !threaded || band == convstate.BandNone {
+		return fill(For(lang, convstate.BandNone).SubjectAbout, topic)
+	}
+	return fill(phrases.SubjectAbout, topic)
+}
+
+// Greeting renders the opening line, by name when one is known.
+func Greeting(lang textlang.Lang, band convstate.Band, firstName string) string {
+	phrases := For(lang, band)
+	firstName = strings.TrimSpace(firstName)
+	if firstName == "" {
+		return phrases.GreetingAnonymous
+	}
+	return fill(phrases.GreetingNamed, firstName)
+}
+
+// fill substitutes the single "%s" in a template without going through the
+// formatting verbs, so a topic or a name containing a percent sign renders as
+// itself rather than as a format directive.
+func fill(template, value string) string {
+	return strings.Replace(template, "%s", value, 1)
+}

--- a/backend/internal/shared/kernel/draftfloor/draftfloor_test.go
+++ b/backend/internal/shared/kernel/draftfloor/draftfloor_test.go
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package draftfloor_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/convstate"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/draftfloor"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/textlang"
+)
+
+// Every language the detector can return, and every band the axis can produce.
+// Derived from the two vocabularies rather than listed, so a new band or a new
+// language fails this file until the table covers it.
+var (
+	langs = []textlang.Lang{textlang.English, textlang.German, textlang.Vietnamese}
+	bands = []convstate.Band{
+		convstate.BandNone, convstate.BandFresh, convstate.BandWeeks, convstate.BandMonths,
+	}
+)
+
+// Every cell is filled. A missing phrase renders as an empty line in a real
+// draft, which reads as a bug in the product rather than a gap in a table.
+func TestEveryBandInEveryLanguageHasItsPhrases(t *testing.T) {
+	for _, lang := range langs {
+		for _, band := range bands {
+			phrases := draftfloor.For(lang, band)
+			required := map[string]string{
+				"SubjectNoContext":  phrases.SubjectNoContext,
+				"SubjectAbout":      phrases.SubjectAbout,
+				"GreetingNamed":     phrases.GreetingNamed,
+				"GreetingAnonymous": phrases.GreetingAnonymous,
+				"Ask":               phrases.Ask,
+			}
+			for name, value := range required {
+				if strings.TrimSpace(value) == "" {
+					t.Errorf("%s/%s: %s is empty", lang, band, name)
+				}
+			}
+			// Opener is deliberately empty at fresh and required elsewhere:
+			// a live exchange needs no preamble, and a gap needs acknowledging.
+			opener := strings.TrimSpace(phrases.Opener)
+			if band == convstate.BandFresh && opener != "" {
+				t.Errorf("%s/fresh: Opener should be empty, got %q", lang, opener)
+			}
+			if band != convstate.BandFresh && opener == "" {
+				t.Errorf("%s/%s: Opener is empty, but this band has a gap to acknowledge",
+					lang, band)
+			}
+		}
+	}
+}
+
+// Templates take exactly one substitution. Two would silently drop a value and
+// none would render the placeholder to the recipient.
+func TestEveryTemplateTakesExactlyOneSubstitution(t *testing.T) {
+	for _, lang := range langs {
+		for _, band := range bands {
+			phrases := draftfloor.For(lang, band)
+			for name, template := range map[string]string{
+				"SubjectAbout":  phrases.SubjectAbout,
+				"GreetingNamed": phrases.GreetingNamed,
+			} {
+				if got := strings.Count(template, "%s"); got != 1 {
+					t.Errorf("%s/%s: %s has %d placeholders, want 1: %q",
+						lang, band, name, got, template)
+				}
+			}
+		}
+	}
+}
+
+// The bug this table exists to kill. A first message to somebody the product
+// has never written to must not open by following up on nothing, in any
+// language (DRAFT-AC-E-3).
+func TestAFirstTouchNeverClaimsAHistory(t *testing.T) {
+	inventedHistory := []string{
+		"following up", "checking in", "circling back",
+		"nachfassen", "wie besprochen", "erneut",
+		"tiếp theo", "nhắc lại",
+	}
+	for _, lang := range langs {
+		phrases := draftfloor.For(lang, convstate.BandNone)
+		for _, field := range []string{phrases.SubjectNoContext, phrases.Opener, phrases.Ask} {
+			lowered := strings.ToLower(field)
+			for _, phrase := range inventedHistory {
+				if strings.Contains(lowered, phrase) {
+					t.Errorf("%s/none: %q implies a prior exchange that does not exist",
+						lang, field)
+				}
+			}
+		}
+	}
+}
+
+// A reply prefix is a claim that a thread exists. It is earned only by a real
+// inbound thread subject, and never at band none.
+func TestTheReplyPrefixIsOnlyUsedOnARealThread(t *testing.T) {
+	cases := []struct {
+		name       string
+		band       convstate.Band
+		topic      string
+		threaded   bool
+		wantPrefix bool
+	}{
+		{name: "answering a real thread", band: convstate.BandFresh, topic: "Angebot", threaded: true, wantPrefix: true},
+		{name: "a topic we chose ourselves", band: convstate.BandFresh, topic: "Angebot", threaded: false, wantPrefix: false},
+		{name: "first touch, even with a topic", band: convstate.BandNone, topic: "Angebot", threaded: true, wantPrefix: false},
+		{name: "picking up an old thread", band: convstate.BandMonths, topic: "Angebot", threaded: true, wantPrefix: true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := draftfloor.Subject(textlang.German, c.band, c.topic, c.threaded)
+			if hasPrefix := strings.HasPrefix(got, "Re:"); hasPrefix != c.wantPrefix {
+				t.Fatalf("Subject = %q, want reply prefix = %v", got, c.wantPrefix)
+			}
+		})
+	}
+}
+
+// With nothing known about the topic, the subject is the band's own line.
+func TestSubjectFallsBackToTheBandLineWithNoTopic(t *testing.T) {
+	got := draftfloor.Subject(textlang.German, convstate.BandNone, "   ", true)
+	want := draftfloor.For(textlang.German, convstate.BandNone).SubjectNoContext
+
+	if got != want {
+		t.Fatalf("Subject(no topic) = %q, want %q", got, want)
+	}
+}
+
+func TestGreetingUsesTheNameWhenThereIsOne(t *testing.T) {
+	if got := draftfloor.Greeting(textlang.German, convstate.BandFresh, "Marek"); got != "Hallo Marek," {
+		t.Errorf("Greeting(named) = %q, want %q", got, "Hallo Marek,")
+	}
+	if got := draftfloor.Greeting(textlang.German, convstate.BandFresh, "  "); got != "Guten Tag," {
+		t.Errorf("Greeting(anonymous) = %q, want %q", got, "Guten Tag,")
+	}
+}
+
+// A name or a topic carrying a percent sign is text, not a format directive.
+func TestAPercentSignInTheInputIsRenderedAsItself(t *testing.T) {
+	got := draftfloor.Subject(textlang.English, convstate.BandNone, "100%d discount", false)
+
+	if !strings.Contains(got, "100%d discount") {
+		t.Fatalf("Subject = %q, want the topic rendered verbatim", got)
+	}
+}
+
+// The caller is already on the no-model path, so an unresolved language or an
+// unrecognized band degrades to a renderable draft rather than to nothing.
+func TestUnresolvedInputDegradesToARenderableDraft(t *testing.T) {
+	unknownLang := draftfloor.For(textlang.Unknown, convstate.BandFresh)
+	if unknownLang != draftfloor.For(draftfloor.DefaultLang, convstate.BandFresh) {
+		t.Error("an unresolved language should fall back to the default language")
+	}
+
+	unknownBand := draftfloor.For(textlang.German, convstate.Band("something-else"))
+	if unknownBand != draftfloor.For(textlang.German, convstate.BandNone) {
+		t.Error("an unrecognized band should fall back to the band that assumes no history")
+	}
+}

--- a/backend/internal/shared/kernel/draftfloor/envelope.go
+++ b/backend/internal/shared/kernel/draftfloor/envelope.go
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package draftfloor
+
+import (
+	"strconv"
+	"time"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/convstate"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/textlang"
+)
+
+// Envelope is what every drafting surface is told about the correspondence it
+// is writing into, as opposed to what it is writing about.
+//
+// The fields are pinned by ai-operational-spec.md §2.4 and they are all flat
+// strings, which is a constraint rather than a style: the certification harness
+// decodes a prompt payload as a string map to bound every field it carries, so
+// a nested value here would refuse every draft case at preparation time. It is
+// also the reason SilenceDays is a string — the field is rendered into a
+// prompt, never arithmetic.
+//
+// Every field is server-derived. None of it comes from the counterparty's own
+// text, which is what keeps an instruction in an inbound message from changing
+// who a draft says it is from.
+type Envelope struct {
+	// Language the draft must be written in (DRAFT-AC-E-1).
+	Language string `json:"output_language"`
+	// ConversationState is the convstate band (DRAFT-AC-E-3, E-4).
+	ConversationState string `json:"conversation_state"`
+	// SilenceDays is whole days since the last message either way, empty at
+	// band none where there is no last message to count from.
+	SilenceDays string `json:"silence_days,omitempty"`
+	// Now is the current time, RFC 3339. Without it a model cannot tell two
+	// days from eight months apart, which is every time-truthful sentence in a
+	// draft (DRAFT-AC-E-5).
+	Now string `json:"now"`
+	// SenderName and SenderEmail are the acting human's, so the draft is not
+	// written as whoever appears in a quoted header. Both empty for a system
+	// principal with no human authority behind it, where drafting degrades to
+	// an unsigned draft rather than failing (DRAFT-AC-E-6).
+	SenderName  string `json:"sender_name,omitempty"`
+	SenderEmail string `json:"sender_email,omitempty"`
+}
+
+// NewEnvelope assembles the envelope from the resolved facts.
+func NewEnvelope(lang textlang.Lang, state convstate.State, now time.Time, senderName, senderEmail string) Envelope {
+	envelope := Envelope{
+		Language:          string(langOrDefault(lang)),
+		ConversationState: string(state.Band),
+		Now:               now.UTC().Format(time.RFC3339),
+		SenderName:        senderName,
+		SenderEmail:       senderEmail,
+	}
+	if state.Band != convstate.BandNone {
+		envelope.SilenceDays = strconv.Itoa(state.SilenceDays)
+	}
+	return envelope
+}
+
+// Lang reads the envelope's language back as a typed value, so a caller
+// rendering the floor does not have to re-parse the string it just wrote.
+func (e Envelope) Lang() textlang.Lang { return langOrDefault(textlang.Lang(e.Language)) }
+
+// Band reads the envelope's conversation state back as a typed value.
+func (e Envelope) Band() convstate.Band { return convstate.Band(e.ConversationState) }
+
+// langOrDefault resolves an unknown or unrecognized language to the default.
+// One spelling, so the envelope, the floor table and the prompt cannot disagree
+// about what an unresolved language means.
+func langOrDefault(lang textlang.Lang) textlang.Lang {
+	if _, ok := table[lang]; ok {
+		return lang
+	}
+	return DefaultLang
+}

--- a/backend/internal/shared/kernel/draftfloor/resolve.go
+++ b/backend/internal/shared/kernel/draftfloor/resolve.go
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package draftfloor
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/convstate"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/textlang"
+)
+
+// Sender answers who is writing. It is a READ of the acting principal's own
+// identity and writes nothing, which is what lets a drafting service that
+// guarantees zero writes depend on it.
+//
+// A principal with no human behind it — the system, a connector acting on
+// nobody's authority — answers with two empty strings and no error. That is not
+// a failure: DRAFT-AC-E-6 makes an unsigned draft the specified answer there.
+type Sender interface {
+	ActorIdentity(ctx context.Context) (name, email string, err error)
+}
+
+// Clock is the current time, injected rather than read, per the house pattern.
+type Clock func() time.Time
+
+// Resolver assembles the envelope every drafting surface is handed.
+//
+// It is one type rather than a method on each service because the fallbacks are
+// the interesting part and they must not differ by surface: a language that
+// will not resolve becomes the default, and a sender that will not resolve
+// becomes nobody. Two copies of that would eventually disagree about which
+// failure is fatal, and the drafting screen would break on one surface only.
+type Resolver struct {
+	sender Sender
+	now    Clock
+	logger *slog.Logger
+}
+
+// NewResolver builds a resolver on the real clock, with no sender bound.
+func NewResolver() *Resolver { return &Resolver{now: time.Now} }
+
+// WithSender binds the identity lookup. Without one, every draft is unsigned.
+func (r *Resolver) WithSender(sender Sender) *Resolver {
+	r.sender = sender
+	return r
+}
+
+// WithClock replaces the clock, so a test states the date its case is about.
+func (r *Resolver) WithClock(now Clock) *Resolver {
+	if now != nil {
+		r.now = now
+	}
+	return r
+}
+
+// WithLogger binds the logger the degrade paths report through.
+func (r *Resolver) WithLogger(logger *slog.Logger) *Resolver {
+	r.logger = logger
+	return r
+}
+
+// Now is the resolver's clock, for a caller that needs the same instant the
+// envelope was stamped with.
+func (r *Resolver) Now() time.Time {
+	if r == nil || r.now == nil {
+		return time.Now()
+	}
+	return r.now()
+}
+
+// Resolve assembles the envelope from the correspondence's own text and where
+// it stands.
+//
+// Neither half can fail the draft. An unresolvable language falls back to the
+// default (DRAFT-AC-E-2), and an unresolvable sender leaves the draft unsigned
+// (DRAFT-AC-E-6) — a drafting screen that errors because it could not work out
+// a greeting is worse than a draft the rep edits.
+func (r *Resolver) Resolve(ctx context.Context, correspondence string, state convstate.State) Envelope {
+	now := r.Now()
+	name, email := r.actor(ctx)
+	return NewEnvelope(textlang.Detect(correspondence), state, now, name, email)
+}
+
+// actor names the acting human, or nobody.
+//
+// A lookup failure is reported and then degraded past, not swallowed: the
+// caller gets an unsigned draft, and the reason it happened is in the log
+// rather than only in the shape of the output.
+func (r *Resolver) actor(ctx context.Context) (name, email string) {
+	if r == nil || r.sender == nil {
+		return "", ""
+	}
+	name, email, err := r.sender.ActorIdentity(ctx)
+	if err != nil {
+		r.log().WarnContext(ctx, "draft sender identity unavailable; drafting unsigned", "err", err)
+		return "", ""
+	}
+	return name, email
+}
+
+// log is the resolver's logger, defaulting rather than being required at
+// construction so a caller that only wants a draft is not made to supply one.
+func (r *Resolver) log() *slog.Logger {
+	if r == nil || r.logger == nil {
+		return slog.Default()
+	}
+	return r.logger
+}

--- a/backend/internal/shared/kernel/draftfloor/substance.go
+++ b/backend/internal/shared/kernel/draftfloor/substance.go
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package draftfloor
+
+import (
+	"strings"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/textlang"
+)
+
+// Substance is the one sentence of substance a floor draft opens on, in one
+// language.
+//
+// Separate from Phrases because these say something SPECIFIC — about a claim,
+// a deal, a commitment, a thread — while Phrases is the skeleton around them.
+// Which of these a caller reaches for is the caller's own ranking, and the
+// person and account composers deliberately rank them differently: what a
+// person SAID outranks the deal it was said about, while on an account a
+// commitment we made outranks the deal it belongs to.
+//
+// The "%s" in each takes the thing being named.
+type Substance struct {
+	// OpenQuestion: they asked us something and are waiting.
+	OpenQuestion string
+	// Objection: we owe them an answer.
+	Objection string
+	// Priority: they told us this matters to them.
+	Priority string
+	// Commitment: we said we would do something.
+	Commitment string
+	// Deal: picking up an opportunity already in motion.
+	Deal string
+	// Thread: following up on an exchange that happened.
+	Thread string
+}
+
+var substance = map[textlang.Lang]Substance{
+	textlang.English: {
+		OpenQuestion: "I wanted to come back to you on %s.",
+		Objection:    "I still owe you an answer on %s.",
+		Priority:     "I know %s matters to you, and I wanted to come back to it.",
+		Commitment:   "I wanted to come back to you on %s.",
+		Deal:         "I wanted to pick up where we left off on %s.",
+		Thread:       "I wanted to follow up on %s.",
+	},
+	textlang.German: {
+		OpenQuestion: "ich wollte auf %s zurückkommen.",
+		Objection:    "ich bin Ihnen noch eine Antwort zu %s schuldig.",
+		Priority:     "ich weiß, dass Ihnen %s wichtig ist, und wollte das Thema wieder aufgreifen.",
+		Commitment:   "ich wollte auf %s zurückkommen.",
+		Deal:         "ich wollte da anknüpfen, wo wir bei %s aufgehört haben.",
+		Thread:       "ich wollte zu %s nachfassen.",
+	},
+	textlang.Vietnamese: {
+		OpenQuestion: "tôi xin phép trao đổi lại về %s.",
+		Objection:    "tôi còn nợ anh/chị câu trả lời về %s.",
+		Priority:     "tôi biết %s là điều quan trọng với anh/chị nên xin phép trao đổi lại.",
+		Commitment:   "tôi xin phép trao đổi lại về %s.",
+		Deal:         "tôi muốn tiếp tục phần chúng ta đang trao đổi về %s.",
+		Thread:       "tôi xin phép trao đổi tiếp về %s.",
+	},
+}
+
+// SubstanceFor resolves the substance lines for a language, falling back the
+// same way the skeleton does so one unresolved language never produces two
+// languages inside one message.
+func SubstanceFor(lang textlang.Lang) Substance {
+	lines, ok := substance[langOrDefault(lang)]
+	if !ok {
+		return substance[DefaultLang]
+	}
+	return lines
+}
+
+// Fill substitutes the single placeholder in a template without going through
+// the formatting verbs, so a deal name or subject line containing a percent
+// sign renders as itself rather than as a format directive.
+func Fill(template, value string) string {
+	return strings.Replace(template, "%s", value, 1)
+}


### PR DESCRIPTION
Second build PR of the "Make eMail meaningful" program. Builds on #916 (`textlang` + `convstate`).

## The bug

Four places in the product write an email when no model is available: the person composer, the account composer, the timeline's own fallback, and the warm-intro path in signals. All four spelled their prose in hardcoded English, so a German thread produced an English draft. All four also opened a first message to a stranger with **"Following up"** — an invented history, and what `DRAFT-AC-E-3` forbids. Four copies also means a fix to one is a fix to one.

## The shape

`shared/kernel/draftfloor` is now the one skeleton, indexed by conversation band and language: twelve cells of subject, greeting, gap-opener and ask, plus the substance sentences the composers choose between. Each caller keeps its own wire shape, its own reasoning assembly and its own ranking of what to say; the package supplies the words around them. It is in `shared` because the timeline and signals modules sit below composition and may not import a sibling.

`draftfloor.Envelope` is the six flat strings `ai-operational-spec.md` §2.4 pins. Flat because the certification harness decodes a prompt payload as a string map to bound every field, so a nested value would refuse every draft case at preparation time.

`draftfloor.Resolver` assembles it, and is shared for one specific reason: **the fallbacks must not differ by surface.** An unresolvable language becomes the default (`DRAFT-AC-E-2`), an unresolvable sender leaves the draft unsigned (`DRAFT-AC-E-6`). Two copies of that would eventually disagree about which failure is fatal, and the drafting screen would break on one surface only.

No sender is bound yet — `identity.ActorIdentity` is the next change — so drafts resolve language and time today and gain a signature next.

## Per surface

- **Person composer**: detects the language from the activity bodies the `Person360` already carried and previously threw away, and classifies the band off its own last-inbound/last-outbound stamps.
- **Account composer**: the band comes from the account's own history. "Account-started" describes where the draft was requested from, not a claim that nobody there has ever been written to.
- **Timeline floor**: takes a `DraftContext` naming the thread it answers, with `Threaded` explicit.
- **Signals intro path**: keeps its own two messages — an ask to a colleague is not correspondence with a counterparty — but takes the language and the first-touch rule. Its "Following up with X" subject is gone, and its Art. 50 disclosure is now translated.

## Review

Codex reviewed the branch and found eight defects. Six are fixed in the second commit:

- the account drafter was forced to the first-touch band, so an established account was told "I am writing to you for the first time"
- the timeline floor stopped naming the topic in the body, so the draft said nothing about what it was answering
- the warm-intro path put the English disclosure under German prose, and interpolated the raw relationship enum (`deal_stakeholder`) mid-sentence
- the `AiDisclosure` payload field disagreed with the body's own disclosure

Two were pre-existing and are now tightened rather than merely preserved: a reply prefix was earned by any activity carrying a subject, so a captured meeting titled "Quarterly review" produced `Re: Quarterly review`, and our own last outbound produced a reply to ourselves. `activities.IsMailThread` answers it in one place now — inbound **and** email.

## Gate

`make -C backend build`, `go test ./internal/...`, and `go test .` (root fitness suite) all green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes every no-model email draft use the conversation’s language and removes invented history on first touch. Adds a shared `draftfloor` used by person/account composers, timeline fallback, and signals warm-intro.

- **New Features**
  - Introduced `shared/kernel/draftfloor` with language- and band-aware phrases, plus `Substance` lines and helpers (`Subject`, `Greeting`, `Fill`).
  - Added `draftfloor.Envelope` and `draftfloor.Resolver` to resolve output language, conversation band, clock time, and sender (unsigned when unavailable).
  - Person and account composers now detect language from recent correspondence and classify band from last inbound/outbound; rendering comes from `draftfloor`.
  - Activities fallback now uses `DraftContext` and `activities.IsMailThread`; subjects/bodies are built via `draftfloor` and respect intent.
  - Signals intro path localized both messages and the Art. 50 disclosure (EN/DE/VI), with readable relationship names.

- **Bug Fixes**
  - First-touch drafts no longer open with “Following up”; subjects/opener match band none.
  - Reply prefix is only added for real inbound email threads; no replies to meetings or our own outbound.
  - Timeline fallback includes the topic in the body and writes in the detected language.
  - Account drafts use history-derived band instead of forcing first touch.
  - Signals: disclosure text matches the body and is localized; raw relationship enums are no longer surfaced.

<sup>Written for commit e26f6ef84895407e22a87f57a610141f4b78da2d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/918?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

