### PR TITLE
fix(identity): the agent seat is not a colleague, and the roster stops treating it as one

### DIFF
--- a/backend/internal/modules/identity/handlers_users.go
+++ b/backend/internal/modules/identity/handlers_users.go
@@ -90,6 +90,9 @@ func (h Handlers) ChangeUserRole(w http.ResponseWriter, r *http.Request, id crmc
 		err = conflictIf(err, errLastActiveAdmin, "last_active_admin",
 			"this member is the organization's only active administrator; give another "+
 				"member the admin role first, then change this one's")
+		err = conflictIf(err, errAgentSeatHoldsNoRole, "agent_seat_holds_no_role",
+			"this is the workspace's agent identity; what an agent may do comes from the "+
+				"passport granting it and the person that passport names, never from a role of its own")
 		httperr.Write(w, r, unknownRoleRefusal(err))
 		return
 	}

--- a/backend/internal/modules/identity/lastadmin.go
+++ b/backend/internal/modules/identity/lastadmin.go
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package identity
+
+// The one invariant user administration cannot be allowed to break: an
+// organization always keeps at least one administrator who can actually
+// administer it. Every path that could remove the last one — deactivating an
+// admin, demoting an admin — asks here first.
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// lastActiveAdmin reports whether userID is an active admin and the ONLY one —
+// deactivating them would leave the organization with no administrator and no
+// in-app way to recover. Runs inside the caller's row-locked transaction.
+func lastActiveAdmin(ctx context.Context, tx pgx.Tx, userID ids.UserID) (bool, error) {
+	// Serialize the admin-count check+act across the whole workspace: without
+	// this, two transactions each deactivating a DIFFERENT admin would both see
+	// the other still active (their target-row FOR UPDATE lock doesn't cover the
+	// other admin's row) and both commit, leaving zero admins. A transaction
+	// advisory lock keyed on the workspace makes admin-management serial, so the
+	// second transaction re-reads the first's committed change and refuses.
+	if _, err := tx.Exec(ctx,
+		`SELECT pg_advisory_xact_lock(hashtext('margince:admin-guard:' || current_setting('app.workspace_id', true))::bigint)`); err != nil {
+		return false, err
+	}
+	var targetIsAdmin bool
+	if err := tx.QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1 FROM role_assignment ra JOIN role r ON r.id = ra.role_id
+			WHERE ra.user_id = $1 AND r.key = 'admin')`, userID).Scan(&targetIsAdmin); err != nil {
+		return false, err
+	}
+	if !targetIsAdmin {
+		return false, nil
+	}
+	// NOT is_agent, because the question this count answers is "would anyone
+	// still be able to administer users afterwards" — and the agent seat could
+	// not, whatever its role assignments say. It carries no password by
+	// construction, so it signs in nowhere and reaches no admin screen.
+	//
+	// Nothing should be able to give it the admin role (ChangeUserRole refuses an
+	// agent target), so this is the second lock on the same door rather than the
+	// only one. It earns its place because a grant through that door is not the
+	// only way the row could come to hold one: an installation that hand-inserted
+	// its agent seat while the product created none may have granted it anything,
+	// and this count is what turns such a row into a lockout — the last human
+	// administrator is deactivated on the strength of a "colleague" who can never
+	// sign in, and there is no way back in.
+	var otherAdmins int
+	if err := tx.QueryRow(ctx, `
+		SELECT count(*) FROM app_user u
+		JOIN role_assignment ra ON ra.user_id = u.id
+		JOIN role r ON r.id = ra.role_id
+		WHERE r.key = 'admin' AND u.status = 'active' AND u.archived_at IS NULL
+		  AND NOT u.is_agent
+		  AND u.id <> $1`, userID).Scan(&otherAdmins); err != nil {
+		return false, err
+	}
+	return otherAdmins == 0, nil
+}

--- a/backend/internal/modules/identity/refusal_test.go
+++ b/backend/internal/modules/identity/refusal_test.go
@@ -27,6 +27,7 @@ func TestRefusalsRenderTheirOwnCauseOnly(t *testing.T) {
 		{"duplicate email", errEmailTaken, "email_taken", http.StatusConflict},
 		{"last active admin", errLastActiveAdmin, "last_active_admin", http.StatusConflict},
 		{"suspended, not deactivated", errNotDeactivated, "not_deactivated", http.StatusConflict},
+		{"agent seat holds no role", errAgentSeatHoldsNoRole, "agent_seat_holds_no_role", http.StatusConflict},
 	} {
 		got := conflictIf(c.err, c.err, c.want, "actionable prose")
 		var refusal *httperr.DetailedError

--- a/backend/internal/modules/identity/users.go
+++ b/backend/internal/modules/identity/users.go
@@ -36,7 +36,7 @@ const (
 	roleAdmin             = "admin"
 )
 
-// The three distinct refusals this surface can answer with. Each WRAPS
+// The distinct refusals this surface can answer with. Each WRAPS
 // apperrors.ErrConflict, so every caller that only asks "was this a conflict?"
 // is unaffected, while a handler can tell them apart and say which one it was:
 // the bare sentinel reaches the operator as the single word "conflict", which
@@ -47,6 +47,13 @@ var (
 	errEmailTaken      = fmt.Errorf("%w: a member with this email already exists", apperrors.ErrConflict)
 	errNotDeactivated  = fmt.Errorf("%w: the member is not deactivated", apperrors.ErrConflict)
 	errLastActiveAdmin = fmt.Errorf("%w: the member is the only active administrator", apperrors.ErrConflict)
+	// The agent seat holds no role, ever. Its authority is the passport granting
+	// it intersected with the human that passport names, so a role on its own
+	// row grants nothing today and is a standing grant nothing bounds tomorrow —
+	// and while it held `admin` it would count toward the last-active-admin
+	// guard below, letting an operator deactivate the final human administrator
+	// on the strength of an identity that can never sign in.
+	errAgentSeatHoldsNoRole = fmt.Errorf("%w: the agent seat holds no role", apperrors.ErrConflict)
 	// A role key nobody defines is a 404 like a missing member, but it is a
 	// DIFFERENT 404: the admin mistyped a role, not a person. Wrapping keeps
 	// the status while letting the handler say which of the two happened.
@@ -182,42 +189,6 @@ func userReactivatedPayload(userID ids.UserID, by ids.UserID) crmcontracts.Publi
 		UserId: openapi_types.UUID(userID.UUID),
 		By:     openapi_types.UUID(by.UUID),
 	}
-}
-
-// lastActiveAdmin reports whether userID is an active admin and the ONLY one —
-// deactivating them would leave the organization with no administrator and no
-// in-app way to recover. Runs inside the caller's row-locked transaction.
-func lastActiveAdmin(ctx context.Context, tx pgx.Tx, userID ids.UserID) (bool, error) {
-	// Serialize the admin-count check+act across the whole workspace: without
-	// this, two transactions each deactivating a DIFFERENT admin would both see
-	// the other still active (their target-row FOR UPDATE lock doesn't cover the
-	// other admin's row) and both commit, leaving zero admins. A transaction
-	// advisory lock keyed on the workspace makes admin-management serial, so the
-	// second transaction re-reads the first's committed change and refuses.
-	if _, err := tx.Exec(ctx,
-		`SELECT pg_advisory_xact_lock(hashtext('margince:admin-guard:' || current_setting('app.workspace_id', true))::bigint)`); err != nil {
-		return false, err
-	}
-	var targetIsAdmin bool
-	if err := tx.QueryRow(ctx, `
-		SELECT EXISTS (
-			SELECT 1 FROM role_assignment ra JOIN role r ON r.id = ra.role_id
-			WHERE ra.user_id = $1 AND r.key = 'admin')`, userID).Scan(&targetIsAdmin); err != nil {
-		return false, err
-	}
-	if !targetIsAdmin {
-		return false, nil
-	}
-	var otherAdmins int
-	if err := tx.QueryRow(ctx, `
-		SELECT count(*) FROM app_user u
-		JOIN role_assignment ra ON ra.user_id = u.id
-		JOIN role r ON r.id = ra.role_id
-		WHERE r.key = 'admin' AND u.status = 'active' AND u.archived_at IS NULL
-		  AND u.id <> $1`, userID).Scan(&otherAdmins); err != nil {
-		return false, err
-	}
-	return otherAdmins == 0, nil
 }
 
 // hasRole is the identity module's own admin gate for the operations
@@ -402,14 +373,20 @@ func (s *Service) ChangeUserRole(ctx context.Context, actor Identity, userID ids
 	}
 	ctx = actorCtx(ctx, actor)
 	return database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
-		var exists bool
-		if err := tx.QueryRow(ctx,
-			`SELECT EXISTS (SELECT 1 FROM app_user WHERE id = $1 AND archived_at IS NULL)`,
-			userID).Scan(&exists); err != nil {
-			return err
-		}
-		if !exists {
+		// The target is read rather than merely proved to exist, because what it
+		// IS decides the answer: an agent seat holds no role at all.
+		var isAgent bool
+		targetErr := tx.QueryRow(ctx,
+			`SELECT is_agent FROM app_user WHERE id = $1 AND archived_at IS NULL`,
+			userID).Scan(&isAgent)
+		if errors.Is(targetErr, pgx.ErrNoRows) {
 			return apperrors.ErrNotFound
+		}
+		if targetErr != nil {
+			return targetErr
+		}
+		if isAgent {
+			return errAgentSeatHoldsNoRole
 		}
 		var roleID ids.UUID
 		err := tx.QueryRow(ctx, `SELECT id FROM role WHERE key = $1`, toRole).Scan(&roleID)

--- a/backend/internal/modules/identity/users_admin_integration_test.go
+++ b/backend/internal/modules/identity/users_admin_integration_test.go
@@ -312,3 +312,60 @@ func TestConcurrentLastAdminDeactivationsKeepOneAdmin(t *testing.T) {
 		t.Fatalf("concurrent double-admin deactivation refused %d times, want exactly 1 — the race would zero out admins", conflicts)
 	}
 }
+
+// agentSeatOf answers the workspace's agent seat, the one bootstrap wrote.
+func agentSeatOf(t *testing.T, e *revocationEnv) ids.UserID {
+	t.Helper()
+	var seat ids.UserID
+	if err := e.owner.QueryRow(context.Background(),
+		`SELECT id FROM app_user WHERE workspace_id = $1 AND is_agent`,
+		e.admin.WorkspaceID).Scan(&seat); err != nil {
+		t.Fatalf("reading the workspace's agent seat: %v", err)
+	}
+	return seat
+}
+
+func TestTheAgentSeatCannotBeGivenARole(t *testing.T) {
+	e := setupRevocationEnv(t, "agent-role")
+	seat := agentSeatOf(t, e)
+
+	err := e.svc.ChangeUserRole(e.wsCtx(e.admin), e.admin, seat, "admin")
+	if !errors.Is(err, errAgentSeatHoldsNoRole) {
+		t.Fatalf("granting the agent seat a role returned %v, want the agent-seat refusal. What an "+
+			"agent may do is the passport granting it intersected with the human that passport names, "+
+			"so a role on its own row is authority nothing bounds", err)
+	}
+	var grants int
+	if err := e.owner.QueryRow(context.Background(),
+		`SELECT count(*) FROM role_assignment WHERE user_id = $1`, seat).Scan(&grants); err != nil {
+		t.Fatalf("counting the seat's role assignments: %v", err)
+	}
+	if grants != 0 {
+		t.Errorf("the refused grant left %d role assignment(s) on the agent seat", grants)
+	}
+}
+
+// The lockout the seat could otherwise cause, and the reason the admin count
+// carries an exclusion of its own rather than resting on the refusal above.
+//
+// The role assignment here is written directly, because the product refuses to
+// create it — which is the point. An installation that hand-inserted its agent
+// seat while no product path existed can hold exactly this row already, and a
+// refusal added afterwards reaches no grant that has already happened.
+func TestTheAgentSeatIsNotTheOtherAdminWhoCouldRecoverTheOrganization(t *testing.T) {
+	e := setupRevocationEnv(t, "agent-lockout")
+	seat := agentSeatOf(t, e)
+	if _, err := e.owner.Exec(context.Background(),
+		`INSERT INTO role_assignment (workspace_id, role_id, user_id)
+		 SELECT $1, r.id, $2 FROM role r WHERE r.workspace_id = $1 AND r.key = 'admin'`,
+		e.admin.WorkspaceID, seat); err != nil {
+		t.Fatalf("granting the agent seat the admin role directly: %v", err)
+	}
+
+	err := e.svc.DeactivateUser(e.wsCtx(e.admin), e.admin, DeactivateUserInput{UserID: e.admin.UserID})
+	if !errors.Is(err, errLastActiveAdmin) {
+		t.Fatalf("deactivating the only human administrator returned %v, want the last-admin refusal. "+
+			"The agent seat administers nothing — it carries no password and signs in nowhere — so "+
+			"counting it leaves the organization with no way back into user administration at all", err)
+	}
+}

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -3533,6 +3533,10 @@ export const de = {
   "users.deactivateConfirmTitle": "{name} deaktivieren?",
   "users.deactivateConfirmBody":
     "Die Person wird überall abgemeldet und ihre Agent-Pässe werden sofort widerrufen. Du kannst sie später reaktivieren, aber sie muss sich dann neu anmelden.",
+  "users.deactivateAgentConfirmBody":
+    "Das ist die Agent-Identität dieses Arbeitsbereichs. Wird sie deaktiviert, laufen alle Jobs ohne Person dahinter nicht mehr — Erweiterungen eingeschlossen — bis du sie reaktivierst. Kein Mensch verliert Zugriff: Sie meldet sich nirgends an.",
+  "users.agentSeat": "Agent",
+  "users.agentSeatRole": "Handelt mit einem Pass, nicht mit einer Rolle",
   "users.roleLabel": "Rolle für das neue Mitglied",
   "users.invite": "Einladen",
   "users.setRole": "Rolle setzen…",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -3522,6 +3522,10 @@ export const en = {
   "users.deactivateConfirmTitle": "Deactivate {name}?",
   "users.deactivateConfirmBody":
     "They'll be signed out everywhere and their agent passports revoked immediately. You can reactivate them later, but they'll need to sign in again.",
+  "users.deactivateAgentConfirmBody":
+    "This is the workspace's agent identity. Deactivating it stops every job that runs with nobody behind it, extensions included, until you reactivate it. No person loses access — it signs in nowhere.",
+  "users.agentSeat": "Agent",
+  "users.agentSeatRole": "Acts under a passport, not a role",
   "users.roleLabel": "Role for the new member",
   "users.invite": "Invite",
   "users.setRole": "Set role…",

--- a/frontend/src/i18n/i18n.test.ts
+++ b/frontend/src/i18n/i18n.test.ts
@@ -137,6 +137,7 @@ const KEPT_IN_ENGLISH = new Set<string>([
   "trust.agentTag",
   "consent.actorAgent",
   "consent.actorConnector",
+  "users.agentSeat",
 
   // Other cases verified individually against the source.
   "shell.logoAria",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -3524,6 +3524,10 @@ export const vi = {
   "users.deactivateConfirmTitle": "Vô hiệu hoá {name}?",
   "users.deactivateConfirmBody":
     "Người đó sẽ bị đăng xuất ở mọi nơi và mọi passport Agent của họ bị thu hồi ngay. Bạn có thể kích hoạt lại sau, nhưng họ sẽ phải đăng nhập lại.",
+  "users.deactivateAgentConfirmBody":
+    "Đây là danh tính Agent của không gian làm việc. Vô hiệu hoá nó sẽ dừng mọi tác vụ chạy mà không có người đứng sau, kể cả tiện ích mở rộng, cho đến khi bạn kích hoạt lại. Không ai mất quyền truy cập — nó không đăng nhập ở đâu cả.",
+  "users.agentSeat": "Agent",
+  "users.agentSeatRole": "Hành động theo passport, không theo vai trò",
   "users.roleLabel": "Vai trò cho thành viên mới",
   "users.invite": "Mời",
   "users.setRole": "Đặt vai trò…",

--- a/frontend/src/screens/users-admin.test.tsx
+++ b/frontend/src/screens/users-admin.test.tsx
@@ -57,6 +57,18 @@ const ROSTER = {
       is_agent: false,
       roles: [],
     },
+    // The workspace's agent identity, which bootstrap writes into every
+    // installation — so every case in this suite renders the roster a real
+    // admin sees, rather than a people-only one that no longer exists.
+    {
+      id: "u-agent",
+      workspace_id: "ws-1",
+      email: "agent@acme.gradion.local",
+      display_name: "Gradion Agent",
+      status: "active",
+      is_agent: true,
+      roles: [],
+    },
   ],
   page: { next_cursor: null, has_more: false },
 };
@@ -171,6 +183,55 @@ describe("UsersAdminCard", () => {
     const off = screen.getByText("Otto Off").closest("li") as HTMLElement;
     expect(within(active).getByText("Deactivate")).toBeTruthy();
     expect(within(off).getByText("Reactivate")).toBeTruthy();
+  });
+
+  // The agent seat is listed — a client resolving the owner of a record it owns
+  // has to find it — but it is not a colleague, and the row has to say so. Each
+  // absence below is a control the server refuses anyway, so offering it could
+  // only produce a 409 an admin cannot act on.
+  it("marks the agent seat and offers it no control meant for a person", async () => {
+    vi.stubGlobal("fetch", backend([]));
+    render(<UsersAdminCard />);
+    await waitFor(() => expect(screen.getByText("Gradion Agent")).toBeTruthy());
+
+    const agent = rowFor("Gradion Agent");
+    expect(within(agent).getByText("Agent")).toBeTruthy();
+    // No role control at all, not a disabled one: the seat's authority comes
+    // from a passport and the person it names, never from a role of its own.
+    expect(
+      within(agent).queryByRole("combobox", { name: /set role for/i }),
+    ).toBeNull();
+    expect(within(agent).getByText(/acts under a passport/i)).toBeTruthy();
+    // No set-password link: the seat holds no password by construction, which
+    // is what makes it a thing that signs in nowhere.
+    expect(
+      within(agent).queryByRole("button", { name: /set-password link/i }),
+    ).toBeNull();
+
+    // A person's row is untouched by any of that.
+    const person = rowFor("Nora None");
+    expect(roleSelect(person, "Nora None")).toBeTruthy();
+    expect(within(person).queryByText("Agent")).toBeNull();
+  });
+
+  // Deactivating the seat stays offered — an operator is entitled to that — but
+  // what it stops is invisible from this screen, and the body written for a
+  // person describes sessions and sign-ins that the seat has none of.
+  it("warns what stops before deactivating the agent seat", async () => {
+    vi.stubGlobal("fetch", backend([]));
+    render(<UsersAdminCard />);
+    await waitFor(() => expect(screen.getByText("Gradion Agent")).toBeTruthy());
+
+    await userEvent.click(
+      within(rowFor("Gradion Agent")).getByRole("button", {
+        name: /deactivate/i,
+      }),
+    );
+    const dialog = await screen.findByRole("dialog");
+    expect(
+      within(dialog).getByText(/every job that runs with nobody/i),
+    ).toBeTruthy();
+    expect(within(dialog).queryByText(/signed out everywhere/i)).toBeNull();
   });
 
   it("invites a member with the entered email, name, and role", async () => {

--- a/frontend/src/screens/users-admin.test.tsx
+++ b/frontend/src/screens/users-admin.test.tsx
@@ -113,6 +113,11 @@ function backend(calls: { method: string; url: string; body?: unknown }[]) {
         user: { email: "admin@acme.test" },
         roles: ["admin"],
         teams: [],
+        // The installation CAN mint set-password links. Without this the card
+        // withholds that action from every row, and any assertion that one
+        // particular row lacks it passes without the row having anything to do
+        // with it.
+        admin_password_link: true,
       });
     }
     if (req.url.includes("/users") && req.method === "GET") {
@@ -125,6 +130,19 @@ function backend(calls: { method: string; url: string; body?: unknown }[]) {
       body = undefined;
     }
     calls.push({ method: req.method, url: req.url, body });
+    // The link mint answers its own shape. With admin_password_link on, the
+    // invite flow opens the link dialog itself, and a generic user row handed
+    // to it renders an expiry from `undefined` — an unhandled error rather
+    // than a failed assertion, which fails the run without naming a test.
+    if (req.url.includes("/password-link")) {
+      return jsonResponse(
+        {
+          set_password_url: "https://crm.example.test/set-password?t=fixture",
+          expires_at: "2026-08-18T09:00:00Z",
+        },
+        201,
+      );
+    }
     return jsonResponse({ ...ROSTER.data[0], id: "u-new" }, 201);
   });
 }
@@ -208,10 +226,15 @@ describe("UsersAdminCard", () => {
       within(agent).queryByRole("button", { name: /set-password link/i }),
     ).toBeNull();
 
-    // A person's row is untouched by any of that.
+    // A person's row is untouched by any of that — and the link's absence above
+    // has to be about the AGENT rather than about an installation that mints no
+    // links at all, so the same control is asserted PRESENT here.
     const person = rowFor("Nora None");
     expect(roleSelect(person, "Nora None")).toBeTruthy();
     expect(within(person).queryByText("Agent")).toBeNull();
+    expect(
+      within(person).getByRole("button", { name: /set-password link/i }),
+    ).toBeTruthy();
   });
 
   // Deactivating the seat stays offered — an operator is entitled to that — but

--- a/frontend/src/screens/users-admin.tsx
+++ b/frontend/src/screens/users-admin.tsx
@@ -208,6 +208,62 @@ function InviteForm({ canIssueLink }: Readonly<{ canIssueLink: boolean }>) {
   );
 }
 
+// The role cell: what a member's role reads as, and the control that changes it.
+//
+// An agent seat has neither, and gets the reason in their place. Its authority
+// is the passport granting it intersected with the person that passport names,
+// so a role on its own row grants nothing — the server refuses to write one, and
+// a control here would promise otherwise. A line rather than a disabled select
+// or a gap: the absence is a rule about what the seat IS, not a permission this
+// admin happens to lack.
+function RoleCell({
+  member,
+  pending,
+  inFlight,
+  onPick,
+}: Readonly<{
+  member: User;
+  pending: boolean;
+  inFlight?: Role;
+  onPick: (role: Role) => void;
+}>) {
+  const t = useT();
+  if (member.is_agent) {
+    return <span className="t-small">{t("users.agentSeatRole")}</span>;
+  }
+  // `roles` arrives only for an admin caller — which this card always is — and
+  // normally holds exactly one key. No key (an unassigned seat) and several keys
+  // both leave the select on its placeholder, because neither has one current
+  // role to show.
+  const heldRoles = member.roles ?? [];
+  const currentRole =
+    heldRoles.length === 1 && isOption(heldRoles[0], ROLES) ? heldRoles[0] : "";
+  // A member holding SEVERAL roles is the case worth naming: any choice here
+  // replaces the whole set, so a neutral "Set role…" would let an admin strip
+  // privileges they never saw. The placeholder says what is held instead.
+  const placeholder =
+    heldRoles.length > 1
+      ? t("users.rolesHeld", { roles: heldRoles.map(roleLabel(t)).join(", ") })
+      : t("users.setRole");
+  return (
+    // The unset state is the select's PLACEHOLDER, not an option: picking it
+    // back would set no role, so it belongs on the closed face and nowhere in
+    // the list. It is only ever seen when there is no single role to show.
+    <Select
+      aria-label={t("users.setRoleFor", { name: member.display_name })}
+      value={inFlight ?? currentRole}
+      placeholder={placeholder}
+      disabled={pending}
+      onChange={(value) => {
+        if (isOption(value, ROLES)) {
+          onPick(value);
+        }
+      }}
+      options={roleOptions(t)}
+    />
+  );
+}
+
 function MemberRow({
   member,
   canIssueLink,
@@ -279,27 +335,6 @@ function MemberRow({
   const pending =
     setRole.isPending || deactivate.isPending || reactivate.isPending;
 
-  // The role the select reads back. `roles` arrives only for an admin caller —
-  // which this card always is — and normally holds exactly one key. No key (an
-  // unassigned seat) and several keys both leave the select on its placeholder,
-  // because neither has one current role to show.
-  const heldRoles = member.roles ?? [];
-  const currentRole =
-    heldRoles.length === 1 && isOption(heldRoles[0], ROLES) ? heldRoles[0] : "";
-  // A member holding SEVERAL roles is the case worth naming: any choice here
-  // replaces the whole set, so a neutral "Set role…" would let an admin strip
-  // privileges they never saw. The placeholder says what is held instead.
-  const placeholder =
-    heldRoles.length > 1
-      ? t("users.rolesHeld", { roles: heldRoles.map(roleLabel(t)).join(", ") })
-      : t("users.setRole");
-  // While a change is in flight the select shows the role being applied — and
-  // it stays in flight until the refreshed roster lands (see refresh), so the
-  // row never renders the replaced role. A FAILED change leaves the select on
-  // the role still held, which is what keeps a retry live: re-picking the same
-  // target still fires onChange.
-  const inFlightRole = setRole.isPending ? setRole.variables : undefined;
-
   return (
     <li className="users-row">
       <span className="users-who">
@@ -309,25 +344,28 @@ function MemberRow({
       <Badge tone={member.status === "active" ? "success" : "warn"}>
         {t(`users.status.${member.status}`)}
       </Badge>
-      {/* The unset state is the select's PLACEHOLDER, not an option: picking it
-          back would set no role, so it belongs on the closed face and nowhere in
-          the list. It is only ever seen when there is no single role to show. */}
-      <Select
-        aria-label={t("users.setRoleFor", { name: member.display_name })}
-        value={inFlightRole ?? currentRole}
-        placeholder={placeholder}
-        disabled={pending}
-        onChange={(value) => {
-          if (isOption(value, ROLES)) {
-            setRole.mutate(value);
-          }
-        }}
-        options={roleOptions(t)}
+      {/* The workspace's agent identity sits in this roster because it OWNS
+          records — a client resolving an owner has to find it — so the row says
+          what it is rather than passing for a colleague. */}
+      {member.is_agent && <Badge tone="ai">{t("users.agentSeat")}</Badge>}
+      <RoleCell
+        member={member}
+        pending={pending}
+        // While a change is in flight the cell shows the role being applied —
+        // and it stays in flight until the refreshed roster lands (see refresh),
+        // so the row never renders the replaced role. A FAILED change leaves it
+        // on the role still held, which is what keeps a retry live: re-picking
+        // the same target still fires onChange.
+        inFlight={setRole.isPending ? setRole.variables : undefined}
+        onPick={(role) => setRole.mutate(role)}
       />
       {/* Only an ACTIVE member can redeem a link — redemption updates an active
           account and refuses otherwise — so offering one on a deactivated row
-          would hand the admin a link that is dead on arrival. */}
-      {canIssueLink && member.status === "active" && (
+          would hand the admin a link that is dead on arrival. The agent seat is
+          excluded for a different reason: it holds no password by construction,
+          which is what makes it a thing that signs in nowhere, and the server
+          refuses to mint it one. */}
+      {canIssueLink && !member.is_agent && member.status === "active" && (
         <Button small disabled={pending} onClick={openLink}>
           {t("users.link.action")}
         </Button>
@@ -357,7 +395,17 @@ function MemberRow({
         error={deactivate.error ? problemMessageOf(deactivate.error, t) : null}
         onConfirm={() => deactivate.mutate()}
       >
-        <p className="t-small">{t("users.deactivateConfirmBody")}</p>
+        {/* Deactivating the agent seat is a posture an operator is entitled to
+            take, so it stays offered — but what stops when they take it is
+            invisible from this screen, and the generic body (signed out, sessions
+            revoked) describes a person rather than what actually happens. */}
+        <p className="t-small">
+          {t(
+            member.is_agent
+              ? "users.deactivateAgentConfirmBody"
+              : "users.deactivateConfirmBody",
+          )}
+        </p>
       </ConfirmModal>
       {linkOpen && (
         <PasswordLinkModal


### PR DESCRIPTION
Closes #910.

## The presentation, and the lockout hiding behind it

#909 gave every installation an agent identity, and it is listed in `GET /v1/users` deliberately — a client resolving the owner of a record it owns has to find it, and `is_agent` on `User` is what tells a picker of humans to leave it out. But the members screen rendered it like a person, and two of the controls it offered reached writes nothing refused.

**A role on the seat defeats the last-admin guard.** Grant it `admin` — which the product allowed — and `lastActiveAdmin` counts it as another administrator, so deactivating the last human one is permitted. The organization is then left with nobody who can administer users, and an "administrator" that holds no password and signs in nowhere. There is no in-app recovery. Probed by deleting the fix: the deactivation returns `nil`.

Two guards, because they close different doors:

- `ChangeUserRole` refuses an agent target (`409 agent_seat_holds_no_role`). What an agent may do is the passport granting it intersected with the person that passport names; a role on its own row grants nothing today and is a standing grant nothing bounds tomorrow.
- The admin count excludes `is_agent` **independently**. The refusal cannot reach a grant that already happened, and an installation that hand-inserted its agent seat while no product path created one may hold exactly that row. The test writes the assignment directly for that reason.

I checked the sibling sites rather than only this one: `lastActiveAdmin` is the tree's only admin count, and passports are minted `on_behalf_of` the authenticated caller — which the seat can never be, since it has no password to sign in with. So those two need nothing.

## The screen

| | before | after |
|---|---|---|
| identity | indistinguishable from a colleague | an `Agent` badge |
| role | a working selector | "Acts under a passport, not a role" — a line, not a disabled control: the absence is a rule about what the seat *is*, not a permission this admin lacks |
| set-password link | offered, refused by the API since #909 | not offered |
| deactivate | offered, body describing sessions and sign-ins the seat has none of | offered (an operator is entitled to it, and the seatless gauge exists for it) with a body naming what stops: every job that runs with nobody behind it, extensions included |

Strings land in all three catalogs; `users.agentSeat` joins `KEPT_IN_ENGLISH` beside `trust.agentTag` and `consent.actorAgent`, which vi already carries as a loanword.

## Structure

Two ceilings tripped as the branches landed, and both were fair:

- `MemberRow` hit cognitive complexity 17/15 → the role cell is its own component, which also gives the agent/person split one place to live.
- `users.go` hit 508/500 lines → `lastActiveAdmin` moved to `lastadmin.go`, where the invariant it protects reads in one screen.

## Tests

Every one was probed against the bug it describes: removing the admin-count exclusion, the role guard, each UI branch, and the confirm body each produced the named failure.

## Gates

`make check-backend` ✅ · `make check-fe` ✅ (2280 tests) · `make craft-static` ✅ (0/0/0).

`make test-integration` fails on **`TestCommsAdapterSharesTheGovernedPaths`**, which is **pre-existing on `origin/main`** — reproduced at `803b23bc` in a throwaway worktree with none of this branch applied. Filed as **#923**: #918 made the no-model draft phrases band-aware, `BandNone` carries `"About %s"` where the test expects `"Re: %s"`, and which half is wrong is a judgement for that change's author. The identity package's own integration tests pass in full. CI will show that same red until #923 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops treating the workspace agent like a normal member. Blocks role grants to the agent seat and updates the members screen to label it and hide person-only controls, closing a path to last‑admin lockouts.

- **Bug Fixes**
  - Backend: `ChangeUserRole` now rejects agent targets with conflict `agent_seat_holds_no_role`; `lastActiveAdmin` excludes `is_agent` so the seat never counts toward admin quorum; handler returns a clear refusal; integration tests cover both.
  - Frontend: Adds an "Agent" badge; replaces the role select with “Acts under a passport, not a role”; hides the set‑password link; keeps Deactivate with agent-specific confirm copy; updates `en`, `de`, `vi` and keeps `users.agentSeat` in English.
  - Frontend tests: Make the missing set‑password link selective by enabling `/me.admin_password_link` and stubbing the `/password-link` mint; also assert the link is present for a person.

- **Refactors**
  - Extracted `RoleCell` to reduce `MemberRow` complexity.
  - Moved the admin guard to `lastadmin.go` for readability.

<sup>Written for commit 115e24d81ac65792e87738906f5a8cc6f041105e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/925?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent seats are clearly labeled and explain that permissions come through passports rather than roles.
  * Agent seats no longer display role or password-management controls.
  * Deactivation confirmations now provide agent-specific guidance in English, German, and Vietnamese.

* **Bug Fixes**
  * Prevented assigning roles to agent seats.
  * Protected workspaces from being left without a usable administrator when changing administrator access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->