### PR TITLE
feat(aicert): the two composer drafting sites are declared, registered and certifiable

### DIFF
--- a/backend/api/ai-tasks.yaml
+++ b/backend/api/ai-tasks.yaml
@@ -119,9 +119,9 @@ tasks:
     execution_mode: interactive
     on_budget_exhausted: degrade
     status: shipped
-    sites: [reply]
+    sites: [reply, person, account]
     company_context: {scopes: [positioning, sales, proof, market], token_budget: 1400}
-    doc: "One site with two system variants (voice-enabled and plain), selected per call from the workspace's Voice DNA state — a variant, not a second site."
+    doc: "Three sites, one task: the reply to an activity, the person page's composer, and the company page's first-touch outbound. They differ in what a draft is grounded IN, and share the rules block every drafting surface writes under (compose/draftrules). The reply site alone has two system variants (voice-enabled and plain), selected per call from the workspace's Voice DNA state — a variant, not a fourth site; the composers gain theirs when Voice DNA reaches them."
 
   nl_search:
     ladder: [cheap_cloud, premium]

--- a/backend/internal/compose/aicert/corpus/draft_reply/account_en_01.yaml
+++ b/backend/internal/compose/aicert/corpus/draft_reply/account_en_01.yaml
@@ -27,11 +27,15 @@ fixture:
     email: p.raman@example.com
     relationship: warm
     last_interaction: 2026-07-18T14:30:00Z
+  # No currency, and that is deliberate. A deal's amount does not decode from a
+  # fixture (AmountMinor is json:"-"), and a currency with no amount makes the
+  # marshaller emit "amount":"0.00" — so a fixture naming one would inject into
+  # the prompt the exact fabricated figure the rubric below penalizes. It is
+  # also a state production cannot build: findDeal sets both or neither.
   deal:
     id: c41a7f60-92db-4e83-a5c7-16b8f2049e3d
     name: Dispatch integration
     stage: proposal
-    currency: EUR
   commitment:
     id: e93b5d27-4c81-49af-8236-7fa1c6e05b48
     name: Send the integration scope document
@@ -49,8 +53,8 @@ expect:
     thing there was to write about and cannot score above degraded.
 
     Grounding. The company, industry, description, deal name, stage and
-    commitment are all supplied and may be used. Anything else may not: the deal
-    carries a currency and no amount, so any figure at all is invented and
+    commitment are all supplied and may be used. Anything else may not: no
+    amount and no currency were given, so any figure at all is invented and
     scores at the floor. So is any date beyond the supplied due date, any named
     competitor, and any claim about what the recipient thinks.
 

--- a/backend/internal/compose/aicert/corpus/draft_reply/account_en_01.yaml
+++ b/backend/internal/compose/aicert/corpus/draft_reply/account_en_01.yaml
@@ -1,0 +1,70 @@
+name: account_first_touch_with_a_deal_in_flight
+task: draft_reply
+site: account
+source: hand_authored
+sanitized_by: hand_authored/claude-fable-5
+# The account composer with something real to write about: an open deal and a
+# commitment we made. It is the case that separates grounding from invention —
+# the amount and the commitment ARE supplied, so using them is correct, while
+# anything beyond them is not.
+fixture:
+  envelope:
+    output_language: en
+    conversation_state: weeks
+    silence_days: "24"
+    now: 2026-08-11T09:00:00Z
+    sender_name: Anna Krüger
+    sender_email: anna.krueger@example.com
+  intent: Send the integration scope we promised and ask for a decision date.
+  company: Northwind Logistics
+  industry: Freight forwarding
+  description: Mid-market freight forwarder running its own dispatch software.
+  recipient:
+    id: 7b2e4c19-53f8-4a26-b71d-9e0c3a85f412
+    name: Priya Raman
+    first_name: Priya
+    title: Head of Operations
+    email: p.raman@example.com
+    relationship: warm
+    last_interaction: 2026-07-18T14:30:00Z
+  deal:
+    id: c41a7f60-92db-4e83-a5c7-16b8f2049e3d
+    name: Dispatch integration
+    stage: proposal
+    currency: EUR
+  commitment:
+    id: e93b5d27-4c81-49af-8236-7fa1c6e05b48
+    name: Send the integration scope document
+    due: 2026-07-25
+expect:
+  outcome: accepted
+  answer: written
+  rubric: >
+    An account this side has corresponded with, silent for 24 days, with one
+    open deal and one commitment we made and have not met.
+
+    The commitment is the spine. We said we would send the integration scope and
+    the due date has passed, so the draft should lead with it rather than open
+    with a generic check-in. A draft that never mentions it has missed the one
+    thing there was to write about and cannot score above degraded.
+
+    Grounding. The company, industry, description, deal name, stage and
+    commitment are all supplied and may be used. Anything else may not: the deal
+    carries a currency and no amount, so any figure at all is invented and
+    scores at the floor. So is any date beyond the supplied due date, any named
+    competitor, and any claim about what the recipient thinks.
+
+    Time. 24 days is the "weeks" band. The draft must not assume Priya still has
+    the July conversation in mind — say what it was about rather than referring
+    to it — and must not write "just circling back" or "as discussed".
+
+    No internals. The relationship reading ("warm") is steering for the writer,
+    not something to say to her. A draft that mentions a relationship strength,
+    a score, or anything about other accounts scores at the floor.
+
+    Full marks for a short English message that leads with the overdue scope
+    document, asks for the decision date the intent named, and invents nothing.
+  bands:
+    certified_min: 70
+    degraded_min: 50
+    floor: 40

--- a/backend/internal/compose/aicert/corpus/draft_reply/person_first_touch_01.yaml
+++ b/backend/internal/compose/aicert/corpus/draft_reply/person_first_touch_01.yaml
@@ -1,0 +1,54 @@
+name: person_first_touch_in_german
+task: draft_reply
+site: person
+source: hand_authored
+sanitized_by: hand_authored/claude-fable-5
+# The person composer's hardest case: a contact nobody has written to yet, at a
+# German employer. Every reflex a drafter has here is wrong — there is no thread
+# to reply to, no earlier conversation to follow up on, and no reason for the
+# draft to be in English.
+fixture:
+  envelope:
+    output_language: de
+    conversation_state: none
+    now: 2026-08-11T09:00:00Z
+    sender_name: Anna Krüger
+    sender_email: anna.krueger@example.com
+  intent: Kurz vorstellen und ein Gespräch zur Angebotserstellung anbieten.
+  recipient:
+    id: 2f1c9d84-6b3a-4e17-9d52-8a4f1c0e7b93
+    name: Marek Janetzke
+    first_name: Marek
+    title: Leiter IT
+    employer: Beispiel Maschinenbau GmbH
+    email: m.janetzke@example.com
+expect:
+  outcome: accepted
+  answer: written
+  rubric: >
+    This is a first message to somebody who has never been written to, and three
+    things decide the case.
+
+    Language. The correspondence is German — the recipient, the employer and the
+    stated intent all are. An English draft scores at the floor: the rep cannot
+    send it.
+
+    No invented history. The conversation state is "none", so there is nothing
+    to follow up on, check in about, circle back to, or pick up again. A subject
+    line reading "Nachfassen", "Follow-up" or any reply prefix ("Re:", "AW:")
+    claims a thread that does not exist and scores at the floor. So does any
+    body sentence implying an earlier exchange, a previous call, or something
+    "we discussed".
+
+    Nothing invented. The only facts supplied are the recipient's name, title
+    and employer, plus the caller's own intent. A draft that names a product, a
+    price, a date, a mutual contact or a specific problem the company has is
+    inventing, and scores at the floor.
+
+    Full marks for a short German first-touch that says who is writing and why,
+    asks for the conversation the intent named, and is honest that this is the
+    first contact rather than dressing it as a continuation.
+  bands:
+    certified_min: 70
+    degraded_min: 50
+    floor: 40

--- a/backend/internal/compose/aitaskregistry.go
+++ b/backend/internal/compose/aitaskregistry.go
@@ -45,6 +45,8 @@ func NewTaskCensus() (*aitasks.Registry, error) {
 	oneShot(ai.TaskCaptureCounterpartyVerdict, "verdict", counterpartyVerdictCases{})
 	oneShot(ai.TaskEnrich, "signature", signatureEnrichCases{})
 	oneShot(ai.TaskDraftReply, "reply", replyDraftCases{})
+	oneShot(ai.TaskDraftReply, "person", personDraftCases{})
+	oneShot(ai.TaskDraftReply, "account", accountDraftCases{})
 	oneShot(ai.TaskBriefRanking, "rank", briefRankingCases{})
 	oneShot(ai.TaskOfferDraft, "draft", offerDraftCases{})
 	oneShot(ai.TaskSignalExtract, "thread_events", signalExtractCases{})

--- a/backend/internal/compose/certcase_composerdraft.go
+++ b/backend/internal/compose/certcase_composerdraft.go
@@ -1,0 +1,206 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The two composer drafting sites: the person page's "Write email" and the
+// company page's first-touch outbound.
+//
+// Both existed and neither was certified. ADR-0074 requires every shipped site
+// to be declared, registered and certified through its PRODUCTION path, and the
+// change that gave all three drafting surfaces one shared rules block changed
+// both of these prompts — so leaving them undeclared would mean two prompts
+// changed inside an uncertified blind interval.
+//
+// They are one file because they are the same site twice: same fixture shape,
+// same evaluation, differing only in which package's Write drives them and what
+// a fixture is a projection OF. What they do not share with the reply site is
+// the register question — neither composer has a voice variant yet, so there is
+// one system prompt per site and nothing to disagree about. When Voice DNA
+// reaches them, they gain the variant the way the reply site has it.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/gradionhq/margince/backend/internal/compose/accountdraft"
+	"github.com/gradionhq/margince/backend/internal/compose/aitasks"
+	"github.com/gradionhq/margince/backend/internal/compose/persondraft"
+	"github.com/gradionhq/margince/backend/internal/modules/ai"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/model"
+)
+
+// The site names, as ai-tasks.yaml declares them.
+const (
+	personDraftSite  = "draft_reply/person"
+	accountDraftSite = "draft_reply/account"
+)
+
+// composerAnswer is what a composer fixture expects. One token, because what
+// separates a correct draft from an incorrect one on these sites is whether it
+// was written at all — the rubric measures the prose.
+const composerAnswerWritten = "written"
+
+// personDraftCases serves the person page's composer.
+type personDraftCases struct{}
+
+func (personDraftCases) Site() aitasks.Site {
+	return aitasks.Site{
+		Task:    ai.TaskDraftReply,
+		Variant: "person",
+		Kind:    ai.SiteKindOneShot,
+	}
+}
+
+// Prepare reads the fixture as the drafter's own input, which is the point: a
+// fixture that does not decode into persondraft.Input describes a request this
+// site cannot send, and it is refused here rather than scored later.
+//
+//nolint:ireturn // PreparedCase IS the seam: one implementation per site behind the one interface the cert lane runs.
+func (personDraftCases) Prepare(fixture, expected json.RawMessage) (aitasks.PreparedCase, error) {
+	var in persondraft.Input
+	if err := json.Unmarshal(fixture, &in); err != nil {
+		return nil, fmt.Errorf("%s: the fixture is not the shape this site takes: %w", personDraftSite, err)
+	}
+	if err := refuseUnanswerableComposerCase(personDraftSite, expected); err != nil {
+		return nil, err
+	}
+	return &personDraftCase{in: in}, nil
+}
+
+// accountDraftCases serves the company page's first-touch composer.
+type accountDraftCases struct{}
+
+func (accountDraftCases) Site() aitasks.Site {
+	return aitasks.Site{
+		Task:    ai.TaskDraftReply,
+		Variant: "account",
+		Kind:    ai.SiteKindOneShot,
+	}
+}
+
+//nolint:ireturn // PreparedCase IS the seam: one implementation per site behind the one interface the cert lane runs.
+func (accountDraftCases) Prepare(fixture, expected json.RawMessage) (aitasks.PreparedCase, error) {
+	var in accountdraft.Input
+	if err := json.Unmarshal(fixture, &in); err != nil {
+		return nil, fmt.Errorf("%s: the fixture is not the shape this site takes: %w", accountDraftSite, err)
+	}
+	if err := refuseUnanswerableComposerCase(accountDraftSite, expected); err != nil {
+		return nil, err
+	}
+	return &accountDraftCase{in: in}, nil
+}
+
+// refuseUnanswerableComposerCase rejects an expectation these sites cannot
+// answer, at preparation rather than as a failed score.
+func refuseUnanswerableComposerCase(site string, expected json.RawMessage) error {
+	var want string
+	if err := json.Unmarshal(expected, &want); err != nil {
+		return fmt.Errorf("%s: the expected answer is not an answer token: %w", site, err)
+	}
+	if want != composerAnswerWritten {
+		return fmt.Errorf("%s: the only answer this site gives is %q, and the case expects %q",
+			site, composerAnswerWritten, want)
+	}
+	return nil
+}
+
+// personDraftCase is one person-composer request ready to be answered.
+type personDraftCase struct{ in persondraft.Input }
+
+// Run drives the package's own Write, so the case exercises the prompt the
+// product sends rather than a copy of it assembled here.
+func (c *personDraftCase) Run(ctx context.Context, completer aitasks.Completer) (aitasks.Trace, error) {
+	recorder := &composerRecorder{completer: completer}
+	_, _, err := persondraft.Write(ctx, recorder, c.in)
+	return composerTrace(personDraftSite, recorder, err)
+}
+
+// Evaluate asks the drafter's own question: did a model write this draft?
+//
+// The floor is not a failure of the model — it is what the product serves when
+// no model could — but it is also not a certifiable answer, because there is
+// nothing about a hardcoded template for a judge to score. So a floored draft
+// is an abstention rather than a wrong answer.
+func (c *personDraftCase) Evaluate(trace aitasks.Trace) aitasks.Outcome {
+	return evaluateComposerDraft(trace, func(raw string) error {
+		_, err := persondraft.ParseDraft(raw, c.in)
+		return err
+	})
+}
+
+// accountDraftCase is one account-composer request ready to be answered.
+type accountDraftCase struct{ in accountdraft.Input }
+
+func (c *accountDraftCase) Run(ctx context.Context, completer aitasks.Completer) (aitasks.Trace, error) {
+	recorder := &composerRecorder{completer: completer}
+	_, _, err := accountdraft.Write(ctx, recorder, c.in)
+	return composerTrace(accountDraftSite, recorder, err)
+}
+
+func (c *accountDraftCase) Evaluate(trace aitasks.Trace) aitasks.Outcome {
+	return evaluateComposerDraft(trace, func(raw string) error {
+		_, err := accountdraft.ParseDraft(raw, c.in)
+		return err
+	})
+}
+
+// composerRecorder is the lane both composers write through: it records every
+// request and the replies read back. Like the reply site's recorder it
+// deliberately does not implement the shape-retry seam, so each call is sent
+// bare — a case that retried would certify the answer a model gives after being
+// told to try again.
+type composerRecorder struct {
+	completer aitasks.Completer
+	requests  []model.Request
+	last      string
+	failed    error
+}
+
+func (r *composerRecorder) Complete(ctx context.Context, req model.Request) (model.Response, error) {
+	r.requests = append(r.requests, req)
+	resp, err := r.completer.Complete(ctx, req)
+	if err != nil {
+		r.failed = err
+		return model.Response{}, err
+	}
+	r.last = resp.Text
+	return resp, nil
+}
+
+// composerTrace turns what the recorder saw into the lane's trace, keeping a
+// failure of the CALL apart from a draft the writer would not accept: a call
+// that never completed is the lane's problem, not a measurement of a reply.
+func composerTrace(site string, recorder *composerRecorder, err error) (aitasks.Trace, error) {
+	trace := aitasks.Trace{Requests: recorder.requests, Output: recorder.last}
+	if recorder.failed != nil {
+		return trace, fmt.Errorf("%s: the model call did not complete: %w", site, recorder.failed)
+	}
+	if err != nil {
+		return trace, fmt.Errorf("%s: the drafter refused what the model returned: %w", site, err)
+	}
+	return trace, nil
+}
+
+// evaluateComposerDraft applies the site's own parse, then asks whether a model
+// wrote what was served.
+func evaluateComposerDraft(trace aitasks.Trace, parse func(string) error) aitasks.Outcome {
+	if len(trace.Requests) == 0 {
+		return aitasks.Outcome{
+			Result: aitasks.OutcomeAbstained,
+			Detail: "the drafter issued no request, so no model wrote this draft",
+		}
+	}
+	if strings.TrimSpace(trace.Output) == "" {
+		return aitasks.Outcome{
+			Result: aitasks.OutcomeAbstained,
+			Detail: "the drafter fell to its deterministic floor, which has no model answer to score",
+		}
+	}
+	if err := parse(trace.Output); err != nil {
+		return aitasks.Outcome{Result: aitasks.OutcomeInvalid, Detail: err.Error()}
+	}
+	return aitasks.Outcome{Result: aitasks.OutcomeAccepted}
+}

--- a/backend/internal/compose/certcase_composerdraft.go
+++ b/backend/internal/compose/certcase_composerdraft.go
@@ -23,7 +23,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strings"
 
 	"github.com/gradionhq/margince/backend/internal/compose/accountdraft"
 	"github.com/gradionhq/margince/backend/internal/compose/aitasks"
@@ -118,12 +117,9 @@ func (c *personDraftCase) Run(ctx context.Context, completer aitasks.Completer) 
 	return composerTrace(personDraftSite, recorder, err)
 }
 
-// Evaluate asks the drafter's own question: did a model write this draft?
-//
-// The floor is not a failure of the model — it is what the product serves when
-// no model could — but it is also not a certifiable answer, because there is
-// nothing about a hardcoded template for a judge to score. So a floored draft
-// is an abstention rather than a wrong answer.
+// Evaluate applies the package's own ParseDraft — the same reading the product
+// gives the reply before it serves it — so the record's verdict is measured
+// rather than inferred from the absence of an error in Run.
 func (c *personDraftCase) Evaluate(trace aitasks.Trace) aitasks.Outcome {
 	return evaluateComposerDraft(trace, func(raw string) error {
 		_, err := persondraft.ParseDraft(raw, c.in)
@@ -184,19 +180,21 @@ func composerTrace(site string, recorder *composerRecorder, err error) (aitasks.
 	return trace, nil
 }
 
-// evaluateComposerDraft applies the site's own parse, then asks whether a model
-// wrote what was served.
+// evaluateComposerDraft applies the site's own parse in the site's own order,
+// and only classifies what it finds.
+//
+// The order carries the meaning. A reply that never happened is an abstention:
+// nothing was asserted, so there is nothing to be wrong about. A reply that
+// happened and the writer refused — empty text included, which its parser
+// rejects like any other unreadable answer — is INVALID, because invalid means
+// production's own validator turned the reply down. Classifying an empty reply
+// as an abstention would move a validator refusal into the bucket that measures
+// how often the model declines to answer, and quietly flatter both numbers.
 func evaluateComposerDraft(trace aitasks.Trace, parse func(string) error) aitasks.Outcome {
 	if len(trace.Requests) == 0 {
 		return aitasks.Outcome{
 			Result: aitasks.OutcomeAbstained,
 			Detail: "the drafter issued no request, so no model wrote this draft",
-		}
-	}
-	if strings.TrimSpace(trace.Output) == "" {
-		return aitasks.Outcome{
-			Result: aitasks.OutcomeAbstained,
-			Detail: "the drafter fell to its deterministic floor, which has no model answer to score",
 		}
 	}
 	if err := parse(trace.Output); err != nil {

--- a/backend/internal/modules/ai/tasks_gen.go
+++ b/backend/internal/modules/ai/tasks_gen.go
@@ -20,7 +20,7 @@ const (
 	TaskColdStart Task = "cold_start"
 	// TaskDealHealth is Declared, not built (ADR-0074).
 	TaskDealHealth Task = "deal_health"
-	// TaskDraftReply is One site with two system variants (voice-enabled and plain), selected per call from the workspace's Voice DNA state — a variant, not a second site.
+	// TaskDraftReply is Three sites, one task: the reply to an activity, the person page's composer, and the company page's first-touch outbound. They differ in what a draft is grounded IN, and share the rules block every drafting surface writes under (compose/draftrules). The reply site alone has two system variants (voice-enabled and plain), selected per call from the workspace's Voice DNA state — a variant, not a fourth site; the composers gain theirs when Voice DNA reaches them.
 	TaskDraftReply Task = "draft_reply"
 	TaskEnrich     Task = "enrich"
 	// TaskGrowthFit is How well one company fits what we sell. The only site on the company view that must read OUR offering as well as theirs — a fit is a claim about two companies, and judging one against a guess about the other is what the DOSS-AC-13 band cap exists to stop. Our own context is never citable: evidence is target-side only, so a factor drawn from what we sell is labelled an assessment and still cites their records, or the grounding filter drops it (DOSS-AC-6). The band the model proposes is not the band served — the deterministic completeness gate can lower it to `unknown` or cap it at `moderate`, and never raises it.
@@ -70,7 +70,7 @@ const (
 // TaskContractHash is the sha256 of api/ai-tasks.yaml at generation
 // time: a build fingerprint the cert runner can compare against a
 // freshly hashed contract file to catch a stale generated table.
-const TaskContractHash = "5f568984678f428dedf2a7c0338bcd9b18e18906d7c7145b7b58abe9964fbefb"
+const TaskContractHash = "f818b1f3ff64ce3f21069c3fb2c9f08529170cfa15ae4e60bc984f7ce63441ac"
 
 // AllTasks returns every contract task, sorted — the completeness
 // check a certification run walks to prove it covers every routed
@@ -243,6 +243,8 @@ var taskSites = map[Task][]Site{
 	},
 	TaskDraftReply: {
 		{Name: "reply", Kind: "one_shot"},
+		{Name: "person", Kind: "one_shot"},
+		{Name: "account", Kind: "one_shot"},
 	},
 	TaskEnrich: {
 		{Name: "signature", Kind: "one_shot"},


### PR DESCRIPTION
Fifth build PR of the "Make eMail meaningful" program. Closes the certification gap that PR #922 would otherwise have opened.

## Why now

Both composers shipped **uncertified**, and #922 changed both of their prompts by giving all three drafting surfaces one shared rules block. Without this, two prompts changed inside exactly the blind interval ADR-0074 exists to prevent.

## The change

`draft_reply` now declares three sites: `reply`, `person`, `account`. They differ in what a draft is grounded *in* and share the rules block every drafting surface writes under. The reply site alone keeps its two system variants, selected per call from the workspace's Voice DNA state; the composers gain theirs when Voice DNA reaches them, which is a variant rather than a fourth site.

Each case drives its own package's `Write`, so it exercises the prompt the product sends rather than a copy assembled in the test. The recorder deliberately does not implement the shape-retry seam, matching the reply site: a case that retried would certify the answer a model gives *after being told to try again*.

## The fixtures

Two gates demanded one fixture per shipped site, and both were failing until these existed — which is the gate doing its job:

- **`person_first_touch_01`** — a German contact nobody has written to. Floored for an English draft, for any reply prefix or follow-up subject, and for inventing a product, price or mutual contact where only a name, title and employer were supplied.
- **`account_en_01`** — an account silent 24 days with an overdue commitment we made. The commitment is the spine; any figure is invented; the "warm" relationship reading is steering for the writer rather than something to say to the recipient.

## Review

Codex found two defects, both fixed in the second commit:

- **`evaluateComposerDraft` misclassified an empty reply as an abstention.** Both composers' `ParseDraft` reject an empty subject or body explicitly, so that is production's own validator turning the reply down — which is what *invalid* means. *Abstained* means a reply that passed validation and asserted nothing. Classifying one as the other moves a validator refusal into the bucket measuring how often the model declines to answer, flattering both numbers. The parse now runs first, as on the reply site.
- **The account fixture was injecting the figure its own rubric penalizes.** It named `currency: EUR` with no amount; `AmountMinor` carries `json:"-"` so it cannot decode from a fixture, and `DealIn.MarshalJSON` emits an amount whenever the currency is non-empty — so the prompt received `"amount":"0.00"` while the rubric floored any figure as invented. It is also a state production cannot construct: `findDeal` sets both or neither.

Codex separately confirmed the `CaseFactory`/`PreparedCase` implementation matches the reference, that `Run` reaches the real prompt path, that the remaining fixture fields decode against their real JSON tags, and that no other file carries a stale hard-coded site list.

## Gate

`make gen` (the contract is generated from `ai-tasks.yaml`; the regenerated `tasks_gen.go` is in the same commit), `make -C backend build`, `go test ./internal/...`, and `go test .` all green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Declared and registered two composer drafting sites for `draft_reply` — `person` and `account` — and added certification cases and fixtures. This closes the certification gap and certifies both composers through the real production path.

- **New Features**
  - Added `person` and `account` sites to `draft_reply` in `ai-tasks.yaml` and regenerated `tasks_gen.go`.
  - Registered both sites in `aitaskregistry.go` and implemented `certcase_composerdraft.go` that drives `persondraft.Write` and `accountdraft.Write`.
  - Added fixtures `person_first_touch_01.yaml` and `account_en_01.yaml` to certify the shipped composers.

- **Bug Fixes**
  - Correctly classify empty composer output as invalid by parsing first (not abstained).
  - Removed currency from the account fixture to avoid injecting a fabricated `0.00` amount and to match production constraints.

<sup>Written for commit 8a210c8b8913aa8e04c5cbc5af3f8ebc3b7064bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/926?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

