### PR TITLE
test(comms): the draft anchor is a mail somebody actually wrote to us

### DIFF
--- a/backend/internal/compose/comms_integration_test.go
+++ b/backend/internal/compose/comms_integration_test.go
@@ -85,11 +85,16 @@ func TestCommsAdapterSharesTheGovernedPaths(t *testing.T) {
 	ctx := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.SchedulerPerms)
 
 	anchorID := ids.NewV7()
+	// INBOUND, and that is load-bearing rather than fixture decoration: only a
+	// mail thread somebody actually wrote to us earns a reply prefix
+	// (activities.IsMailThread), so an anchor carrying no direction is a topic
+	// WE picked and is drafted as "About …". This test answers a customer's
+	// mail, so the row has to be one.
 	err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 		_, err := tx.Exec(context.Background(), `
-			INSERT INTO activity (id, workspace_id, kind, subject, occurred_at, source, captured_by)
+			INSERT INTO activity (id, workspace_id, kind, direction, subject, occurred_at, source, captured_by)
 			VALUES ($1, NULLIF(current_setting('app.workspace_id', true), '')::uuid,
-			        'email', 'Pricing question', now(), 'manual', 'human:x')`, anchorID)
+			        'email', 'inbound', 'Pricing question', now(), 'manual', 'human:x')`, anchorID)
 		return err
 	})
 	if err != nil {


### PR DESCRIPTION
Closes #923. **The integration lane has been red on `main` since #918** — every PR opened against it fails a required check, whatever it touches.

## Which half was wrong

I filed #923 without knowing, and offered bands as the likely mechanism. That was wrong, and the real one is simpler.

#918 stopped the no-model drafter inventing a history. Before it:

```go
subject = "Re: " + topic     // any topic at all
```

after it, `draftfloor.Subject(...)` only prefixes when the anchor is a real inbound mail thread (`activities.IsMailThread(kind, direction)`). The band never enters it — `threaded=false` short-circuits first, which is why looking at band classification would have found nothing.

This fixture inserts an email with **no direction**, so under the new rule it is a topic *we* picked, and it drafts as `"About Pricing question"`. The test asserts `"Re: Pricing question"` — which is precisely the output of the behaviour #918 removed.

So the code is right and the test is stale. Three things agree:

- `DraftContext.Threaded` documents the rule and the failure it prevents: *"'Re:' on a deal name, or on a meeting somebody titled 'Quarterly review', claims a message that was never written to us."*
- DRAFT-AC-E-3 requires it.
- `draftfloor_test.go` covers `threaded: false → no prefix` as a named case, so the unthreaded path is deliberate and independently pinned.

## The repair

The anchor becomes what the test always meant it to be: a customer's mail. It is titled "Pricing question" and drafted as a reply, so the row now carries `direction = 'inbound'` and says so.

That restores what this leg was written to exercise — drafting a reply through the MCP seam — rather than freezing whatever a directionless row happens to emit today. The unthreaded case keeps its own coverage in `draftfloor_test.go`, where it belongs.

The same stale expectation sits in the fallback-draft helper on the same anchor (`comms_integration_test.go:166`); it would have failed on the next line once the first stopped fataling, and the fixture fixes both.

## Gates

`make test-integration` ✅ `OK: integration passed with 0 skips (36 packages)` — the lane is green again · `make check-backend` ✅ · `make craft-static` ✅ (0/0/0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the comms integration test by making the draft anchor a real inbound email thread so the drafter correctly applies the "Re:" prefix. This removes the stale expectation and restores the green integration lane.

- **Bug Fixes**
  - Set `direction = 'inbound'` on the inserted `activity` row used as the draft anchor.
  - Updated the fallback-draft helper on the same anchor to match.

<sup>Written for commit 8b33d1d7331e8c435458b7f5c7fc4a617c3e3b61. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/927?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

