### PR TITLE
feat(agents): the account-started send becomes a governed agent tool

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -3337,9 +3337,10 @@ paths:
         is confirm-first and stages for approval, a human caller's own action IS the approval
         (ADR-0055). What is staged is a CREATE — this send answers no message, so there is no
         anchor to name and no version to pin — and it is released by a human holding
-        `activity.create`, the grant `send_email` already asks of its approver. The `links` are
-        row-scope probed when the call is staged as well as when it is sent, so an agent naming
-        a record it cannot see is refused before a human is ever asked about it.
+        `activity.create`, the grant `send_email` already asks of its approver. Whichever door
+        the call arrives at, every entry in `links` is row-scope probed before the message is
+        sent; over MCP that probe also runs at staging, so an agent naming a record it cannot
+        see is refused before a human is asked about it at all.
       x-mcp-tool: { verb: send_account_email, record_type: activity, tier: confirmation_required, scope: send }
       parameters:
         - $ref: '#/components/parameters/IdempotencyKey'
@@ -15681,12 +15682,14 @@ components:
         links:
           type: array
           minItems: 1
+          maxItems: 25
           description: |
             The records this conversation is filed under — the company it was started from, and
             optionally the person and deal it concerns. At least one is required: a message
             belonging to no record is one nobody will find again, which is the gap this
             operation exists to close. Each target is row-scope probed, so an id the caller
-            cannot see is refused 404.
+            cannot see is refused 404 — and each probe is its own query, so the list is bounded
+            at 25 (a message about more records than that is about none of them).
           items: { $ref: '#/components/schemas/ActivityLinkInput' }
 
     SendMessageRequest:

--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -3496,7 +3496,11 @@ paths:
                 attendee_emails: { type: array, items: { type: string, format: email } }
                 links:
                   type: array
-                  description: Entities to associate the resulting meeting activity with.
+                  maxItems: 25
+                  description: |
+                    Entities to associate the resulting meeting activity with. Each one is
+                    row-scope probed and written as its own row, so the list is bounded at 25 —
+                    the same bound the `book_meeting` tool applies before it stages.
                   items:
                     type: object
                     required: [entity_type, entity_id]

--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -3333,17 +3333,17 @@ paths:
         - every entry in `links` is row-scope probed, so a record the caller cannot see is
           refused 404 exactly as reading it directly would be.
 
-        HUMAN-ONLY for now, and deliberately so. ADR-0087 §6 gives the agent surface this
-        operation at the same 🟡 tier as the reply, but a 🟡 agent call STAGES for approval, and a
-        staged row is only releasable when its kind maps onto a grantable object in approvals.
-        Registering the verb without that mapping would advertise a tool whose every call clears
-        admission and is then refused at staging — a governed verb no agent can reach and no human
-        can release. The composer surface ships first; the agent tool follows with its
-        decision-grant mapping, tool spec and staging test as one change.
-      x-agent-access: human-only
-      security: [ { cookieAuth: [] } ]   # human session only — rejects agent bearer/Passport
+        Governed identically to the reply, with no new authority (ADR-0087 §6): an agent caller
+        is confirm-first and stages for approval, a human caller's own action IS the approval
+        (ADR-0055). What is staged is a CREATE — this send answers no message, so there is no
+        anchor to name and no version to pin — and it is released by a human holding
+        `activity.create`, the grant `send_email` already asks of its approver. The `links` are
+        row-scope probed when the call is staged as well as when it is sent, so an agent naming
+        a record it cannot see is refused before a human is ever asked about it.
+      x-mcp-tool: { verb: send_account_email, record_type: activity, tier: confirmation_required, scope: send }
       parameters:
         - $ref: '#/components/parameters/IdempotencyKey'
+        - $ref: '#/components/parameters/ApprovalToken'
       requestBody:
         required: true
         content:
@@ -3356,7 +3356,7 @@ paths:
             application/json:
               schema: { $ref: '#/components/schemas/Activity' }
         '403':
-          description: RBAC denied, or an agent principal presented a passport to a human-only operation.
+          description: Approval token missing for a 🟡 send, or RBAC denied.
           content:
             application/problem+json:
               schema: { $ref: '#/components/schemas/Problem' }

--- a/backend/internal/compose/agentpolicy_gen.go
+++ b/backend/internal/compose/agentpolicy_gen.go
@@ -292,7 +292,7 @@ var agentPolicies = map[string]agentPolicy{
 	"POST /v1/deals/{id}/offers":                                         {Op: "createOffer", Access: "tool", Tool: "create_record", RecordType: "offer", Tier: "auto_execute", Scope: "write"},
 	"POST /v1/dedupe/candidates/{id}/disposition":                        {Op: "disposeDedupeCandidate", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"POST /v1/dedupe/candidates/{id}/undo":                               {Op: "undoDedupeDisposition", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
-	"POST /v1/emails":                                                    {Op: "sendAccountEmail", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
+	"POST /v1/emails":                                                    {Op: "sendAccountEmail", Access: "tool", Tool: "send_account_email", RecordType: "activity", Tier: "confirmation_required", Scope: "send"},
 	"POST /v1/embeddings/reindex":                                        {Op: "EmbedReindexStart", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"POST /v1/exports":                                                   {Op: "createFilteredExport", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"POST /v1/fx-rates":                                                  {Op: "setFxRate", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},

--- a/backend/internal/compose/approval_kinds_test.go
+++ b/backend/internal/compose/approval_kinds_test.go
@@ -66,6 +66,10 @@ func (stubComms) SendEmail(context.Context, ids.UUID, agents.SendEmailArgs) (age
 	return agents.SendEmailResult{}, nil
 }
 
+func (stubComms) SendAccountEmail(context.Context, []agents.RecordLink, agents.SendEmailArgs) (agents.SendEmailResult, error) {
+	return agents.SendEmailResult{}, nil
+}
+
 func (stubComms) SendMessage(context.Context, ids.UUID, agents.SendMessageArgs) (agents.SendMessageResult, error) {
 	return agents.SendMessageResult{}, nil
 }

--- a/backend/internal/compose/comms.go
+++ b/backend/internal/compose/comms.go
@@ -78,7 +78,34 @@ func (c commsAdapter) DraftEmail(ctx context.Context, anchor ids.UUID, intent st
 // anyway, and naming a reference here would only make that refusal look like
 // an accident of wiring.
 func (c commsAdapter) SendEmail(ctx context.Context, anchor ids.UUID, in agents.SendEmailArgs) (agents.SendEmailResult, error) {
-	sent, err := c.store.SendEmail(ctx, activities.FromActivity(ids.From[ids.ActivityKind](anchor)), activities.SendEmailInput{
+	return c.send(ctx, activities.FromActivity(ids.From[ids.ActivityKind](anchor)), in)
+}
+
+// SendAccountEmail starts a NEW conversation instead of continuing one
+// (ADR-0087). It differs from the reply above in the origin and in nothing
+// else: the records the message is filed under are named by the caller because
+// there is no anchor to inherit them from, and each is row-scope probed by the
+// store before the send runs.
+func (c commsAdapter) SendAccountEmail(
+	ctx context.Context, links []agents.RecordLink, in agents.SendEmailArgs,
+) (agents.SendEmailResult, error) {
+	filed := make([]activities.ActivityLinkInput, 0, len(links))
+	for _, l := range links {
+		filed = append(filed, activities.ActivityLinkInput{EntityType: l.EntityType, EntityID: l.EntityID})
+	}
+	return c.send(ctx, activities.FromAccount(filed), in)
+}
+
+// send is the mail send both origins share, spelled once so the two tools
+// cannot drift onto different consent gates, different delivery stagers or
+// different readings of who the recipients are. Cc is merged into Recipients
+// because consent is owed to every addressee — the same rule the HTTP
+// transport's sendInputFrom states, and the reason neither is hand-rolled per
+// call site.
+func (c commsAdapter) send(
+	ctx context.Context, origin activities.SendOrigin, in agents.SendEmailArgs,
+) (agents.SendEmailResult, error) {
+	sent, err := c.store.SendEmail(ctx, origin, activities.SendEmailInput{
 		Recipients:     append(append([]string{}, in.To...), in.Cc...),
 		Cc:             append([]string{}, in.Cc...),
 		Subject:        in.Subject,

--- a/backend/internal/compose/integration/accountsend_agent_integration_test.go
+++ b/backend/internal/compose/integration/accountsend_agent_integration_test.go
@@ -1,0 +1,321 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// The account-started send under agent authority, over the real database:
+// ADR-0087 §6's whole claim, which is that this operation is governed exactly
+// like the reply and gains nobody any new authority.
+//
+// Three facts, and none of them is observable without a database:
+//
+//   - a human's own send goes straight out (ADR-0055 — their action IS the
+//     confirmation), which is what makes the agent's refusal below a statement
+//     about the PRINCIPAL rather than about a send path that does not work;
+//   - an agent's identical call stages a real approval row instead, and the
+//     row it stages is the CREATE shape — the type the effect will write, no
+//     target id, because this send answers no message and pins no row;
+//   - a human can then see it, release it, and only then does the message
+//     leave — with the outbound activity filed under the records the call
+//     named, which is the one thing the account-started origin does
+//     differently from the reply.
+//
+// It rides send_preflight's fixture: a consented recipient on file and a
+// mailbox that can actually transmit, so an acceptance here is a real send and
+// not a refusal in disguise.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/gradionhq/margince/backend/internal/compose"
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
+	"github.com/gradionhq/margince/backend/internal/modules/identity"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/workflow"
+)
+
+// accountSendBody is the one call this suite makes, so the human's send and the
+// agent's differ in the CREDENTIAL and in nothing else. The approved retry has
+// to be the identical request — the diff hash binds it — which is a second
+// reason it is built in one place.
+func accountSendBody(org, subject string) apptest.AnyMap {
+	return apptest.AnyMap{
+		"subject": subject, "body": "Good morning — introducing ourselves.",
+		"to": []string{"buyer@preflight.test"}, "consent_purpose": "transactional",
+		"links": []apptest.AnyMap{{"entity_type": "organization", "entity_id": org}},
+	}
+}
+
+// accountSendEnv is the pre-flight fixture plus the record an account-started
+// conversation is filed under.
+type accountSendEnv struct {
+	*preflightEnv
+	org string
+}
+
+func setupAccountSend(t *testing.T) *accountSendEnv {
+	t.Helper()
+	p := setupPreflight(t)
+	// Without the send grant every send below refuses at the pre-flight, and
+	// this suite would pass while proving nothing about authority.
+	p.connect(t, gmailReadonlyScope, gmailSendScope)
+	return &accountSendEnv{preflightEnv: p, org: anchorOrg(t, p.AppEnv, "Northwind")}
+}
+
+// deliveryCount is what a send did or did not do, read from the table both
+// transports write: a refusal that leaves it empty refused on the tool surface
+// too.
+func (a *accountSendEnv) deliveryCount(t *testing.T) int {
+	t.Helper()
+	return a.stagedDeliveries(t)
+}
+
+// linkedActivities counts the outbound activities filed under the organization
+// this suite names — the account-started origin's own effect, since a reply
+// would have inherited its links from an anchor instead.
+func (a *accountSendEnv) linkedActivities(t *testing.T) int {
+	t.Helper()
+	var n int
+	if err := apptest.InWorkspace(a.AppEnv, t, a.Slug, func(tx pgx.Tx) error {
+		return tx.QueryRow(context.Background(), `
+			SELECT count(*) FROM activity a
+			JOIN activity_link l ON l.activity_id = a.id
+			WHERE l.organization_id = $1 AND a.direction = 'outbound'`, a.org).Scan(&n)
+	}); err != nil {
+		t.Fatalf("counting the conversation's activities: %v", err)
+	}
+	return n
+}
+
+func TestAHumansAccountStartedSendLeavesWithoutAnApproval(t *testing.T) {
+	a := setupAccountSend(t)
+
+	var sent struct {
+		ID string `json:"id"`
+	}
+	if status := a.Call(t, "POST", "/v1/emails", accountSendBody(a.org, "Hello from Fable"), nil, &sent); status != http.StatusAccepted {
+		t.Fatalf("human account-started send → %d, want 202 — a human's own action is the approval", status)
+	}
+	if sent.ID == "" {
+		t.Fatal("the accepted send named no activity")
+	}
+	if n := a.deliveryCount(t); n != 1 {
+		t.Fatalf("%d deliveries staged behind an accepted send, want 1", n)
+	}
+	if n := a.linkedActivities(t); n != 1 {
+		t.Fatalf("%d outbound activities filed under the named organization, want 1", n)
+	}
+	if n := a.pendingApprovals(t); n != 0 {
+		t.Fatalf("%d approvals minted for a human's own send, want none", n)
+	}
+}
+
+// pendingApprovals counts what is waiting on a human. Zero is the assertion for
+// a human's own send; one is the assertion for an agent's.
+func (a *accountSendEnv) pendingApprovals(t *testing.T) int {
+	t.Helper()
+	var n int
+	if err := apptest.InWorkspace(a.AppEnv, t, a.Slug, func(tx pgx.Tx) error {
+		return tx.QueryRow(context.Background(),
+			`SELECT count(*) FROM approval WHERE kind = 'send_account_email'`).Scan(&n)
+	}); err != nil {
+		t.Fatalf("counting staged approvals: %v", err)
+	}
+	return n
+}
+
+func TestAnAgentsAccountStartedSendStagesTheCreateAndOnlyLeavesOnceApproved(t *testing.T) {
+	a := setupAccountSend(t)
+	var minted struct {
+		Token string `json:"token"`
+	}
+	if status := a.Call(t, "POST", "/v1/passports", apptest.AnyMap{
+		"label": "outreach agent", "scopes": []string{"read", "send"},
+	}, nil, &minted); status != http.StatusCreated {
+		t.Fatalf("issue passport → %d", status)
+	}
+	bearer := map[string]string{"Authorization": "Bearer " + minted.Token}
+	body := accountSendBody(a.org, "Hello from an agent")
+
+	var problem struct {
+		Code   string `json:"code"`
+		Detail string `json:"detail"`
+	}
+	if status := a.Call(t, "POST", "/v1/emails", body, bearer, &problem); status != http.StatusForbidden ||
+		problem.Code != "approval_required" {
+		t.Fatalf("agent account-started send → %d %q, want 403 approval_required", status, problem.Code)
+	}
+	if n := a.deliveryCount(t); n != 0 {
+		t.Fatalf("%d deliveries staged behind an unapproved agent send, want 0 — nothing may leave", n)
+	}
+	approvalID := extractStagedApprovalID(t, problem.Detail)
+
+	// The staged SHAPE, which is what makes the row decidable at all: the type
+	// the effect will write, and no row for a scope probe to resolve, because
+	// this send answers no message.
+	var targetType, targetID *string
+	if err := a.Owner.QueryRow(t.Context(),
+		`SELECT target_entity_type, target_entity_id FROM approval WHERE id = $1`,
+		approvalID).Scan(&targetType, &targetID); err != nil {
+		t.Fatal(err)
+	}
+	if targetType == nil || *targetType != "activity" || targetID != nil {
+		t.Fatalf("staged target = %v/%v, want activity with no id", targetType, targetID)
+	}
+
+	// A human sees it and releases it. Both halves matter: an approval the
+	// inbox cannot show is one nobody can act on, whatever the decision
+	// endpoint would have accepted.
+	if !a.inboxShows(t, approvalID) {
+		t.Fatal("the staged send is not in the approvals inbox; nobody could ever release it")
+	}
+	if status := a.Call(t, "POST", "/v1/approvals/"+approvalID+"/approve", apptest.AnyMap{}, nil, nil); status != http.StatusOK {
+		t.Fatalf("human approve → %d", status)
+	}
+	if n := a.deliveryCount(t); n != 0 {
+		t.Fatalf("%d deliveries staged by the approval itself, want 0 — approving authorizes, it does not send", n)
+	}
+
+	// The identical request, now carrying the released approval. Identical is
+	// the requirement, not the style: the diff hash binds the approval to this
+	// exact message.
+	redeem := map[string]string{"Authorization": "Bearer " + minted.Token, "X-Approval-Token": approvalID}
+	if status := a.Call(t, "POST", "/v1/emails", body, redeem, nil); status != http.StatusAccepted {
+		t.Fatalf("approved retry → %d, want 202", status)
+	}
+	if n := a.deliveryCount(t); n != 1 {
+		t.Fatalf("%d deliveries after the approved retry, want exactly 1", n)
+	}
+	if n := a.linkedActivities(t); n != 1 {
+		t.Fatalf("%d outbound activities filed under the named organization, want 1 — the links are what "+
+			"an account-started send has instead of an anchor", n)
+	}
+
+	// Single-use: the same approval cannot send a second message.
+	if status := a.Call(t, "POST", "/v1/emails", body, redeem, nil); status == http.StatusAccepted {
+		t.Fatal("a consumed approval sent a second message; redemption must be single-use")
+	}
+	if n := a.deliveryCount(t); n != 1 {
+		t.Fatalf("%d deliveries after replaying a consumed approval, want still 1", n)
+	}
+}
+
+// inboxShows reports whether the acting human's approvals inbox lists the row —
+// the read path targetVisible governs, asked over HTTP rather than in SQL so
+// the answer is the one a person would actually get.
+func (a *accountSendEnv) inboxShows(t *testing.T, approvalID string) bool {
+	t.Helper()
+	var page struct {
+		Data []struct {
+			ID   string `json:"id"`
+			Kind string `json:"kind"`
+		} `json:"data"`
+	}
+	if status := a.Call(t, "GET", "/v1/approvals?status=pending", nil, nil, &page); status != http.StatusOK {
+		t.Fatalf("list approvals → %d", status)
+	}
+	for _, row := range page.Data {
+		if row.ID == approvalID {
+			if row.Kind != "send_account_email" {
+				t.Errorf("inbox row kind = %q, want send_account_email", row.Kind)
+			}
+			return true
+		}
+	}
+	return false
+}
+
+// The MCP door stages through the tool's own StageInfo rather than through the
+// REST gate's route walk, so the two could disagree about what an
+// account-started send targets — and a human would then be deciding a
+// different question depending on which transport the agent used.
+//
+// It drives Registry.Invoke directly, for the reason channelsend_mcp does: the
+// JSON-RPC framing is proven elsewhere, and Invoke is the one call every
+// transport dispatches through.
+func TestTheMCPDoorStagesTheSameShapeAsTheRESTDoor(t *testing.T) {
+	a := setupAccountSend(t)
+	token := a.mintAccountSendPassport(t)
+
+	args, err := json.Marshal(map[string]any{
+		"to": []string{"buyer@preflight.test"}, "subject": "Hello over MCP",
+		"body": "Good morning.", "consent_purpose": "transactional",
+		"links": []map[string]string{{"entity_type": "organization", "entity_id": a.org}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	staged := a.invokeAccountSend(t, token, args)
+
+	var kind string
+	var targetType, targetID *string
+	if err := a.Owner.QueryRow(t.Context(),
+		`SELECT kind, target_entity_type, target_entity_id FROM approval WHERE id = $1`,
+		staged.String()).Scan(&kind, &targetType, &targetID); err != nil {
+		t.Fatal(err)
+	}
+	if kind != "send_account_email" {
+		t.Errorf("staged kind = %q, want send_account_email — the decision grants are looked up by it", kind)
+	}
+	if targetType == nil || *targetType != "activity" || targetID != nil {
+		t.Fatalf("the MCP door staged %v/%v, want the REST door's activity with no id", targetType, targetID)
+	}
+}
+
+// mintAccountSendPassport issues the credential an outreach agent presents.
+func (a *accountSendEnv) mintAccountSendPassport(t *testing.T) string {
+	t.Helper()
+	var minted struct {
+		Token string `json:"token"`
+	}
+	if status := a.Call(t, "POST", "/v1/passports", apptest.AnyMap{
+		"label": "outreach agent", "scopes": []string{"read", "send"},
+	}, nil, &minted); status != http.StatusCreated {
+		t.Fatalf("issue passport → %d", status)
+	}
+	return minted.Token
+}
+
+// invokeAccountSend calls the tool through the governed registry the api role
+// composes, re-authenticating the passport exactly as every transport does, and
+// returns the approval its refusal staged.
+//
+// The SendPath is empty because nothing here is ever redeemed: this test is
+// about what the refusal STAGES, and the send itself is covered end to end by
+// the REST loop above. A delivery machinery wired here would be scenery.
+func (a *accountSendEnv) invokeAccountSend(t *testing.T, token string, args json.RawMessage) ids.ApprovalID {
+	t.Helper()
+	registry := compose.NewRegistry(a.Pool, compose.SendPath{})
+	authSvc := identity.NewService(a.Pool)
+	wsID, err := authSvc.InstallationWorkspace(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := principal.WithWorkspaceID(t.Context(), wsID.UUID)
+	agent, err := authSvc.AuthenticateAgent(ctx, token)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx = principal.WithCorrelationID(principal.WithActor(ctx, agent.Principal()), ids.NewV7())
+
+	_, invokeErr := registry.Invoke(ctx, "send_account_email", args)
+
+	var staged *workflow.StagedApprovalError
+	if !errors.As(invokeErr, &staged) {
+		t.Fatalf("tools/call send_account_email → %v, want it to stage an approval", invokeErr)
+	}
+	if staged.ApprovalID.IsZero() {
+		t.Fatal("the staged refusal carries a zero approval id")
+	}
+	return staged.ApprovalID
+}

--- a/backend/internal/compose/integration/accountsend_agent_integration_test.go
+++ b/backend/internal/compose/integration/accountsend_agent_integration_test.go
@@ -239,6 +239,12 @@ func (a *accountSendEnv) inboxShows(t *testing.T, approvalID string) bool {
 // account-started send targets — and a human would then be deciding a
 // different question depending on which transport the agent used.
 //
+// They agree here because the REST gate takes its target from the route and
+// this route has no {id}, so the id-less create is the only shape both doors
+// can reach. That is a bound on the approver too — read+create on `activity`
+// rather than the row scope of the records the message is filed under — and
+// #928 is where the gate gains the body-derived target that would lift it.
+//
 // It drives Registry.Invoke directly, for the reason channelsend_mcp does: the
 // JSON-RPC framing is proven elsewhere, and Invoke is the one call every
 // transport dispatches through.

--- a/backend/internal/compose/integration/toolschema_conformance_integration_test.go
+++ b/backend/internal/compose/integration/toolschema_conformance_integration_test.go
@@ -208,6 +208,7 @@ func TestToolAnswersReachableWithoutApprovalSatisfyTheirSchemas(t *testing.T) {
 var unreachableInThisLane = gatekit.Waive(map[string]string{
 	"book_meeting":         "needs a live calendar provider",
 	"send_email":           "needs an outbound mail provider",
+	"send_account_email":   "needs an outbound mail provider, and a send-capable mailbox for its pre-flight",
 	"send_message":         "needs an outbound channel provider",
 	"draft_email":          "needs a drafting model path",
 	"draft_follow_ups_for": "needs a drafting model path",

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -16465,7 +16465,8 @@ type SendAccountEmailRequest struct {
 	// optionally the person and deal it concerns. At least one is required: a message
 	// belonging to no record is one nobody will find again, which is the gap this
 	// operation exists to close. Each target is row-scope probed, so an id the caller
-	// cannot see is refused 404.
+	// cannot see is refused 404 — and each probe is its own query, so the list is bounded
+	// at 25 (a message about more records than that is about none of them).
 	Links   []ActivityLinkInput `json:"links"`
 	Subject string              `json:"subject"`
 

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -18680,6 +18680,15 @@ type SendAccountEmailParams struct {
 	// than half-honouring it, so read this contract, not the client, to know which calls are safe
 	// to retry blind.
 	IdempotencyKey *IdempotencyKey `json:"Idempotency-Key,omitempty"`
+
+	// XApprovalToken A signed, single-use approval token (see schema `ApprovalToken`) minted by
+	// POST /approvals/{id}/approve, authorizing exactly one 🟡 confirm-first operation. It is a
+	// compact JWS whose claims **bind** the token to a specific approval, effect, tenant and
+	// principal — it is NOT a bare opaque string (ADR-0036). The server rejects a token that is
+	// expired, already consumed, or whose `diff_hash`/`workspace_id`/`passport_id`/`tool` does not
+	// match the operation being executed (`403 code: approval_token_invalid`). Required when an
+	// AGENT principal invokes a 🟡 operation; a human's direct call is itself the approval.
+	XApprovalToken *ApprovalToken `json:"X-Approval-Token,omitempty"`
 }
 
 // GetFieldHistoryParams defines parameters for GetFieldHistory.
@@ -34996,6 +35005,8 @@ func (siw *ServerInterfaceWrapper) SendAccountEmail(w http.ResponseWriter, r *ht
 
 	ctx := r.Context()
 
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
 	ctx = context.WithValue(ctx, CookieAuthScopes, []string{})
 
 	r = r.WithContext(ctx)
@@ -35021,6 +35032,25 @@ func (siw *ServerInterfaceWrapper) SendAccountEmail(w http.ResponseWriter, r *ht
 		}
 
 		params.IdempotencyKey = &IdempotencyKey
+
+	}
+
+	// ------------- Optional header parameter "X-Approval-Token" -------------
+	if valueList, found := headers[http.CanonicalHeaderKey("X-Approval-Token")]; found {
+		var XApprovalToken ApprovalToken
+		n := len(valueList)
+		if n != 1 {
+			siw.ErrorHandlerFunc(w, r, &TooManyValuesForParamError{ParamName: "X-Approval-Token", Count: n})
+			return
+		}
+
+		err = runtime.BindStyledParameterWithOptions("simple", "X-Approval-Token", valueList[0], &XApprovalToken, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: false, Type: "string", Format: ""})
+		if err != nil {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "X-Approval-Token", Err: err})
+			return
+		}
+
+		params.XApprovalToken = &XApprovalToken
 
 	}
 

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -18166,7 +18166,9 @@ type BookMeetingJSONBody struct {
 	End        time.Time           `json:"end"`
 	HostUserId *openapi_types.UUID `json:"host_user_id,omitempty"`
 
-	// Links Entities to associate the resulting meeting activity with.
+	// Links Entities to associate the resulting meeting activity with. Each one is
+	// row-scope probed and written as its own row, so the list is bounded at 25 —
+	// the same bound the `book_meeting` tool applies before it stages.
 	Links []struct {
 		EntityId   openapi_types.UUID                 `json:"entity_id"`
 		EntityType BookMeetingJSONBodyLinksEntityType `json:"entity_type"`

--- a/backend/internal/modules/activities/activity.go
+++ b/backend/internal/modules/activities/activity.go
@@ -25,6 +25,12 @@ import (
 // payloads (the one spelling of the payload key).
 const fieldKind = "kind"
 
+// fieldLinks is the request field every link refusal attributes itself to, so
+// a caller reading a 422 is told which array to change. One spelling, because
+// three different refusals name it and a fourth that spelled it differently
+// would send the caller looking for a field the request does not have.
+const fieldLinks = "links"
+
 // activityCapturedPayload builds the activity.captured event for the
 // direct-log path (this package's only emit site of the event's two) — it
 // never names a source_system, which is exclusive to the capture
@@ -251,7 +257,7 @@ func (e *InvalidLinkTypeError) Error() string {
 
 // FieldFault refuses a link to an entity type the timeline does not carry.
 func (e *InvalidLinkTypeError) FieldFault() (field, code, message string) {
-	return "links", "invalid_entity_type", e.Error()
+	return fieldLinks, "invalid_entity_type", e.Error()
 }
 
 func (s *Store) GetActivity(ctx context.Context, id ids.ActivityID, archived storekit.ArchivedFilter) (crmcontracts.Activity, error) {

--- a/backend/internal/modules/activities/activity.go
+++ b/backend/internal/modules/activities/activity.go
@@ -6,6 +6,7 @@ package activities
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"time"
 
@@ -206,6 +207,32 @@ func replayedActivity(ctx context.Context, tx pgx.Tx, in LogActivityInput) (*crm
 	return &out, nil
 }
 
+// maxActivityLinks bounds how many records one activity may be filed under.
+//
+// It is a REQUEST BOUND rather than a modelling opinion: every entry costs its
+// own row-scoped probe and its own insert, and the array is chosen freely by
+// the caller. Both request schemas that carry a link list declare the same 25,
+// and the agent surface refuses the count earlier so no approval is minted for
+// a call the store would reject — this is the bound that holds for every
+// transport, a human's own send included. insertActivityLinks applies it at
+// the write itself, which is where a booking meets it.
+const maxActivityLinks = 25
+
+// TooManyLinksError refuses an activity filed under more records than the
+// timeline will carry for one entry.
+type TooManyLinksError struct{ Count int }
+
+func (e *TooManyLinksError) Error() string {
+	return fmt.Sprintf("an activity may be filed under at most %d records; this one names %d",
+		maxActivityLinks, e.Count)
+}
+
+// FieldFault names the field the caller can shorten, so the refusal is a 422
+// against `links` rather than an unattributed rejection.
+func (e *TooManyLinksError) FieldFault() (field, code, message string) {
+	return fieldLinks, "too_many_links", e.Error()
+}
+
 // insertActivityLinks writes the polymorphic link rows and maintains
 // deal.last_activity_at on deal links. The FK alone is not enough: it is
 // checked as the table owner, bypassing RLS, so it would accept a
@@ -218,7 +245,16 @@ func replayedActivity(ctx context.Context, tx pgx.Tx, in LogActivityInput) (*crm
 // and for an agent's approved retry a 500 that consumed the human's one-shot
 // approval on a message that then never left. Deduplicating here rather than in
 // each caller is what makes that true of every transport at once.
+//
+// The count is BOUNDED here for the same reason: the list is the caller's to
+// choose, every entry costs its own row-scope probe and its own insert, and
+// this is the one statement every writer passes through — the timeline's link
+// vocabulary describes what a message or meeting is ABOUT, and a record set
+// larger than this is about nothing.
 func insertActivityLinks(ctx context.Context, tx pgx.Tx, wsID ids.WorkspaceID, activityID ids.ActivityID, links []ActivityLinkInput, occurredAt time.Time) error {
+	if len(links) > maxActivityLinks {
+		return &TooManyLinksError{Count: len(links)}
+	}
 	seen := make(map[ActivityLinkInput]struct{}, len(links))
 	for _, link := range links {
 		if _, duplicate := seen[link]; duplicate {

--- a/backend/internal/modules/activities/activity.go
+++ b/backend/internal/modules/activities/activity.go
@@ -205,8 +205,20 @@ func replayedActivity(ctx context.Context, tx pgx.Tx, in LogActivityInput) (*crm
 // checked as the table owner, bypassing RLS, so it would accept a
 // guessed cross-tenant or out-of-scope UUID as a link target — every
 // target passes the row-scope link check first.
+//
+// A repeated (type, id) is written ONCE. uq_activity_link already says a link
+// is one row per record, so a caller that named the same company twice was
+// answered with a unique violation — a 500 at the end of a send or a booking,
+// and for an agent's approved retry a 500 that consumed the human's one-shot
+// approval on a message that then never left. Deduplicating here rather than in
+// each caller is what makes that true of every transport at once.
 func insertActivityLinks(ctx context.Context, tx pgx.Tx, wsID ids.WorkspaceID, activityID ids.ActivityID, links []ActivityLinkInput, occurredAt time.Time) error {
+	seen := make(map[ActivityLinkInput]struct{}, len(links))
 	for _, link := range links {
+		if _, duplicate := seen[link]; duplicate {
+			continue
+		}
+		seen[link] = struct{}{}
 		column := linkColumn(link.EntityType)
 		if column == "" {
 			return &InvalidLinkTypeError{EntityType: link.EntityType}

--- a/backend/internal/modules/activities/activity.go
+++ b/backend/internal/modules/activities/activity.go
@@ -6,7 +6,6 @@ package activities
 import (
 	"context"
 	"errors"
-	"fmt"
 	"strings"
 	"time"
 
@@ -26,26 +25,12 @@ import (
 // payloads (the one spelling of the payload key).
 const fieldKind = "kind"
 
-// fieldLinks is the request field every link refusal attributes itself to, so
-// a caller reading a 422 is told which array to change. One spelling, because
-// three different refusals name it and a fourth that spelled it differently
-// would send the caller looking for a field the request does not have.
-const fieldLinks = "links"
-
 // activityCapturedPayload builds the activity.captured event for the
 // direct-log path (this package's only emit site of the event's two) — it
 // never names a source_system, which is exclusive to the capture
 // auto-create path (capture/sink.go's own local builder).
 func activityCapturedPayload(kind string) crmcontracts.PublicEventActivityCaptured {
 	return crmcontracts.PublicEventActivityCaptured{Kind: kind}
-}
-
-// ActivityLinkInput ties one activity to a person, organization or deal.
-type ActivityLinkInput struct {
-	EntityType string // person | organization | deal
-	// note: the link target is polymorphic (activity_link is the canonical
-	// (entity_type, entity_id) seam), so the id stays untyped (rule 6).
-	EntityID ids.UUID
 }
 
 type LogActivityInput struct {
@@ -205,95 +190,6 @@ func replayedActivity(ctx context.Context, tx pgx.Tx, in LogActivityInput) (*crm
 		return nil, err
 	}
 	return &out, nil
-}
-
-// maxActivityLinks bounds how many records one activity may be filed under.
-//
-// It is a REQUEST BOUND rather than a modelling opinion: every entry costs its
-// own row-scoped probe and its own insert, and the array is chosen freely by
-// the caller. Both request schemas that carry a link list declare the same 25,
-// and the agent surface refuses the count earlier so no approval is minted for
-// a call the store would reject — this is the bound that holds for every
-// transport, a human's own send included. insertActivityLinks applies it at
-// the write itself, which is where a booking meets it.
-const maxActivityLinks = 25
-
-// TooManyLinksError refuses an activity filed under more records than the
-// timeline will carry for one entry.
-type TooManyLinksError struct{ Count int }
-
-func (e *TooManyLinksError) Error() string {
-	return fmt.Sprintf("an activity may be filed under at most %d records; this one names %d",
-		maxActivityLinks, e.Count)
-}
-
-// FieldFault names the field the caller can shorten, so the refusal is a 422
-// against `links` rather than an unattributed rejection.
-func (e *TooManyLinksError) FieldFault() (field, code, message string) {
-	return fieldLinks, "too_many_links", e.Error()
-}
-
-// insertActivityLinks writes the polymorphic link rows and maintains
-// deal.last_activity_at on deal links. The FK alone is not enough: it is
-// checked as the table owner, bypassing RLS, so it would accept a
-// guessed cross-tenant or out-of-scope UUID as a link target — every
-// target passes the row-scope link check first.
-//
-// A repeated (type, id) is written ONCE. uq_activity_link already says a link
-// is one row per record, so a caller that named the same company twice was
-// answered with a unique violation — a 500 at the end of a send or a booking,
-// and for an agent's approved retry a 500 that consumed the human's one-shot
-// approval on a message that then never left. Deduplicating here rather than in
-// each caller is what makes that true of every transport at once.
-//
-// The count is BOUNDED here for the same reason: the list is the caller's to
-// choose, every entry costs its own row-scope probe and its own insert, and
-// this is the one statement every writer passes through — the timeline's link
-// vocabulary describes what a message or meeting is ABOUT, and a record set
-// larger than this is about nothing.
-func insertActivityLinks(ctx context.Context, tx pgx.Tx, wsID ids.WorkspaceID, activityID ids.ActivityID, links []ActivityLinkInput, occurredAt time.Time) error {
-	if len(links) > maxActivityLinks {
-		return &TooManyLinksError{Count: len(links)}
-	}
-	seen := make(map[ActivityLinkInput]struct{}, len(links))
-	for _, link := range links {
-		if _, duplicate := seen[link]; duplicate {
-			continue
-		}
-		seen[link] = struct{}{}
-		column := linkColumn(link.EntityType)
-		if column == "" {
-			return &InvalidLinkTypeError{EntityType: link.EntityType}
-		}
-		if err := auth.EnsureLinkTarget(ctx, tx, link.EntityType, link.EntityID); err != nil {
-			return err
-		}
-		if _, err := tx.Exec(ctx,
-			sprintf(`INSERT INTO activity_link (workspace_id, activity_id, entity_type, %s) VALUES ($1, $2, $3, $4)`, column),
-			wsID, activityID, link.EntityType, link.EntityID); err != nil {
-			return err
-		}
-		if link.EntityType == "deal" {
-			if _, err := tx.Exec(ctx,
-				`UPDATE deal SET last_activity_at = greatest(coalesce(last_activity_at, $2), $2) WHERE id = $1`,
-				link.EntityID, occurredAt); err != nil {
-				return err
-			}
-		}
-	}
-	return nil
-}
-
-// InvalidLinkTypeError maps to 422.
-type InvalidLinkTypeError struct{ EntityType string }
-
-func (e *InvalidLinkTypeError) Error() string {
-	return "activity link entity_type " + e.EntityType + " is not " + linkVocabulary()
-}
-
-// FieldFault refuses a link to an entity type the timeline does not carry.
-func (e *InvalidLinkTypeError) FieldFault() (field, code, message string) {
-	return fieldLinks, "invalid_entity_type", e.Error()
 }
 
 func (s *Store) GetActivity(ctx context.Context, id ids.ActivityID, archived storekit.ArchivedFilter) (crmcontracts.Activity, error) {

--- a/backend/internal/modules/activities/activitylinks.go
+++ b/backend/internal/modules/activities/activitylinks.go
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package activities
+
+// The timeline's polymorphic link rows: what an activity is filed under, and
+// the rules every writer of one meets — the vocabulary it may name, the bound
+// on how many, and the row-scope check on each. Split from activity.go because
+// a link is its own concept: a send, a booking, a logged note and a captured
+// message all reach this and share little else.
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/gradionhq/margince/backend/internal/platform/auth"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// ActivityLinkInput ties one activity to a person, organization or deal.
+type ActivityLinkInput struct {
+	EntityType string // person | organization | deal
+	// note: the link target is polymorphic (activity_link is the canonical
+	// (entity_type, entity_id) seam), so the id stays untyped (rule 6).
+	EntityID ids.UUID
+}
+
+// fieldLinks is the request field every link refusal attributes itself to, so
+// a caller reading a 422 is told which array to change. One spelling, because
+// three different refusals name it and a fourth that spelled it differently
+// would send the caller looking for a field the request does not have.
+const fieldLinks = "links"
+
+// maxActivityLinks bounds how many records one activity may be filed under.
+//
+// It is a REQUEST BOUND rather than a modelling opinion: every entry costs its
+// own row-scoped probe and its own insert, and the array is chosen freely by
+// the caller. Both request schemas that carry a link list declare the same 25,
+// and the agent surface refuses the count earlier so no approval is minted for
+// a call the store would reject — this is the bound that holds for every
+// transport, a human's own send included. insertActivityLinks applies it at
+// the write itself, which is where a booking meets it.
+const maxActivityLinks = 25
+
+// TooManyLinksError refuses an activity filed under more records than the
+// timeline will carry for one entry.
+type TooManyLinksError struct{ Count int }
+
+func (e *TooManyLinksError) Error() string {
+	return fmt.Sprintf("an activity may be filed under at most %d records; this one names %d",
+		maxActivityLinks, e.Count)
+}
+
+// FieldFault names the field the caller can shorten, so the refusal is a 422
+// against `links` rather than an unattributed rejection.
+func (e *TooManyLinksError) FieldFault() (field, code, message string) {
+	return fieldLinks, "too_many_links", e.Error()
+}
+
+// insertActivityLinks writes the polymorphic link rows and maintains
+// deal.last_activity_at on deal links. The FK alone is not enough: it is
+// checked as the table owner, bypassing RLS, so it would accept a
+// guessed cross-tenant or out-of-scope UUID as a link target — every
+// target passes the row-scope link check first.
+//
+// A repeated (type, id) is written ONCE. uq_activity_link already says a link
+// is one row per record, so a caller that named the same company twice was
+// answered with a unique violation — a 500 at the end of a send or a booking,
+// and for an agent's approved retry a 500 that consumed the human's one-shot
+// approval on a message that then never left. Deduplicating here rather than in
+// each caller is what makes that true of every transport at once.
+//
+// The count is BOUNDED here for the same reason: the list is the caller's to
+// choose, every entry costs its own row-scope probe and its own insert, and
+// this is the one statement every writer passes through — the timeline's link
+// vocabulary describes what a message or meeting is ABOUT, and a record set
+// larger than this is about nothing.
+func insertActivityLinks(ctx context.Context, tx pgx.Tx, wsID ids.WorkspaceID, activityID ids.ActivityID, links []ActivityLinkInput, occurredAt time.Time) error {
+	if len(links) > maxActivityLinks {
+		return &TooManyLinksError{Count: len(links)}
+	}
+	seen := make(map[ActivityLinkInput]struct{}, len(links))
+	for _, link := range links {
+		if _, duplicate := seen[link]; duplicate {
+			continue
+		}
+		seen[link] = struct{}{}
+		column := linkColumn(link.EntityType)
+		if column == "" {
+			return &InvalidLinkTypeError{EntityType: link.EntityType}
+		}
+		if err := auth.EnsureLinkTarget(ctx, tx, link.EntityType, link.EntityID); err != nil {
+			return err
+		}
+		if _, err := tx.Exec(ctx,
+			sprintf(`INSERT INTO activity_link (workspace_id, activity_id, entity_type, %s) VALUES ($1, $2, $3, $4)`, column),
+			wsID, activityID, link.EntityType, link.EntityID); err != nil {
+			return err
+		}
+		if link.EntityType == "deal" {
+			if _, err := tx.Exec(ctx,
+				`UPDATE deal SET last_activity_at = greatest(coalesce(last_activity_at, $2), $2) WHERE id = $1`,
+				link.EntityID, occurredAt); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// InvalidLinkTypeError maps to 422.
+type InvalidLinkTypeError struct{ EntityType string }
+
+func (e *InvalidLinkTypeError) Error() string {
+	return "activity link entity_type " + e.EntityType + " is not " + linkVocabulary()
+}
+
+// FieldFault refuses a link to an entity type the timeline does not carry.
+func (e *InvalidLinkTypeError) FieldFault() (field, code, message string) {
+	return fieldLinks, "invalid_entity_type", e.Error()
+}

--- a/backend/internal/modules/activities/handlers_email.go
+++ b/backend/internal/modules/activities/handlers_email.go
@@ -247,7 +247,7 @@ func (h Handlers) SendAccountEmail(w http.ResponseWriter, r *http.Request, _ crm
 		// A message filed under nothing is one nobody finds again, which is
 		// the gap this operation exists to close. The contract says minItems,
 		// and nothing in this stack validates a request against the schema.
-		writeStoreErr(w, r, &RequiredFieldError{Field: "links"})
+		writeStoreErr(w, r, &RequiredFieldError{Field: fieldLinks})
 		return
 	}
 

--- a/backend/internal/modules/activities/sendorigin.go
+++ b/backend/internal/modules/activities/sendorigin.go
@@ -16,6 +16,7 @@ package activities
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/jackc/pgx/v5"
 
@@ -92,9 +93,36 @@ func (o SendOrigin) resolve(ctx context.Context, s *Store) ([]ActivityLinkInput,
 	return inheritedLinks(anchor), nil
 }
 
+// maxAccountSendLinks bounds how many records one account-started message may
+// be filed under. It is a REQUEST BOUND rather than a modelling opinion: every
+// entry costs its own row-scoped probe below, and the array is chosen freely by
+// the caller. `SendAccountEmailRequest.links` declares the same 25, and the
+// agent surface refuses the same count earlier so no approval is ever minted
+// for a call this would reject — but THIS is the bound that holds for every
+// transport, a human's own send included.
+const maxAccountSendLinks = 25
+
+// TooManyLinksError refuses a message filed under more records than the send
+// path will probe.
+type TooManyLinksError struct{ Count int }
+
+func (e *TooManyLinksError) Error() string {
+	return fmt.Sprintf("a message may be filed under at most %d records; this one names %d",
+		maxAccountSendLinks, e.Count)
+}
+
+// FieldFault names the field the caller can shorten, so the refusal is a 422
+// against `links` rather than an unattributed rejection.
+func (e *TooManyLinksError) FieldFault() (field, code, message string) {
+	return "links", "too_many_links", e.Error()
+}
+
 // probeLinkTargets refuses an account-started send whose named records the
 // caller cannot read, before any later guard can answer about anyone else.
 func (s *Store) probeLinkTargets(ctx context.Context, links []ActivityLinkInput) error {
+	if len(links) > maxAccountSendLinks {
+		return &TooManyLinksError{Count: len(links)}
+	}
 	return s.tx(ctx, func(tx pgx.Tx) error {
 		for _, link := range links {
 			if linkColumn(link.EntityType) == "" {

--- a/backend/internal/modules/activities/sendorigin.go
+++ b/backend/internal/modules/activities/sendorigin.go
@@ -16,7 +16,6 @@ package activities
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/jackc/pgx/v5"
 
@@ -93,34 +92,10 @@ func (o SendOrigin) resolve(ctx context.Context, s *Store) ([]ActivityLinkInput,
 	return inheritedLinks(anchor), nil
 }
 
-// maxAccountSendLinks bounds how many records one account-started message may
-// be filed under. It is a REQUEST BOUND rather than a modelling opinion: every
-// entry costs its own row-scoped probe below, and the array is chosen freely by
-// the caller. `SendAccountEmailRequest.links` declares the same 25, and the
-// agent surface refuses the same count earlier so no approval is ever minted
-// for a call this would reject — but THIS is the bound that holds for every
-// transport, a human's own send included.
-const maxAccountSendLinks = 25
-
-// TooManyLinksError refuses a message filed under more records than the send
-// path will probe.
-type TooManyLinksError struct{ Count int }
-
-func (e *TooManyLinksError) Error() string {
-	return fmt.Sprintf("a message may be filed under at most %d records; this one names %d",
-		maxAccountSendLinks, e.Count)
-}
-
-// FieldFault names the field the caller can shorten, so the refusal is a 422
-// against `links` rather than an unattributed rejection.
-func (e *TooManyLinksError) FieldFault() (field, code, message string) {
-	return fieldLinks, "too_many_links", e.Error()
-}
-
 // probeLinkTargets refuses an account-started send whose named records the
 // caller cannot read, before any later guard can answer about anyone else.
 func (s *Store) probeLinkTargets(ctx context.Context, links []ActivityLinkInput) error {
-	if len(links) > maxAccountSendLinks {
+	if len(links) > maxActivityLinks {
 		return &TooManyLinksError{Count: len(links)}
 	}
 	return s.tx(ctx, func(tx pgx.Tx) error {

--- a/backend/internal/modules/activities/sendorigin.go
+++ b/backend/internal/modules/activities/sendorigin.go
@@ -114,7 +114,7 @@ func (e *TooManyLinksError) Error() string {
 // FieldFault names the field the caller can shorten, so the refusal is a 422
 // against `links` rather than an unattributed rejection.
 func (e *TooManyLinksError) FieldFault() (field, code, message string) {
-	return "links", "too_many_links", e.Error()
+	return fieldLinks, "too_many_links", e.Error()
 }
 
 // probeLinkTargets refuses an account-started send whose named records the

--- a/backend/internal/modules/activities/sendorigin_integration_test.go
+++ b/backend/internal/modules/activities/sendorigin_integration_test.go
@@ -386,7 +386,7 @@ func TestARepeatedLinkIsFiledOnceRatherThanRaisingAUniqueViolation(t *testing.T)
 func TestASendFiledUnderMoreRecordsThanTheBoundIsRefusedBeforeItProbesAnything(t *testing.T) {
 	e := setupSend(t)
 	stager := &recordingStager{}
-	links := make([]ActivityLinkInput, maxAccountSendLinks+1)
+	links := make([]ActivityLinkInput, maxActivityLinks+1)
 	for i := range links {
 		links[i] = ActivityLinkInput{EntityType: "organization", EntityID: ids.NewV7()}
 	}
@@ -403,5 +403,26 @@ func TestASendFiledUnderMoreRecordsThanTheBoundIsRefusedBeforeItProbesAnything(t
 	}
 	if len(stager.staged) != 0 {
 		t.Fatalf("a refused send staged %d deliveries, want none", len(stager.staged))
+	}
+}
+
+// The bound is applied at the WRITE, not only on the send path's probe, so a
+// booking — which reaches the timeline through the same insert and never passes
+// probeLinkTargets — meets it too.
+func TestTheLinkBoundHoldsAtTheWriteItself(t *testing.T) {
+	e := setupSend(t)
+	org := e.seedOrganization(t)
+	links := make([]ActivityLinkInput, maxActivityLinks+1)
+	for i := range links {
+		links[i] = ActivityLinkInput{EntityType: "organization", EntityID: org}
+	}
+
+	_, _, err := e.store(stubUnsubscribeLinker{}).LogActivity(e.as(principal.RowScopeAll), LogActivityInput{
+		Kind: "note", Source: "manual", Links: links,
+	})
+
+	var tooMany *TooManyLinksError
+	if !errors.As(err, &tooMany) {
+		t.Fatalf("logging an activity with %d links = %v, want a TooManyLinksError", len(links), err)
 	}
 }

--- a/backend/internal/modules/activities/sendorigin_integration_test.go
+++ b/backend/internal/modules/activities/sendorigin_integration_test.go
@@ -354,3 +354,54 @@ func (g *countingConsentGate) RequireGrantedForEmails(context.Context, []string,
 	g.calls++
 	return nil
 }
+
+// A record named twice is filed once. uq_activity_link says a link is one row
+// per record, so the repeat used to reach the insert and raise a unique
+// violation — a 500 at the very end of the send, and for an agent's approved
+// retry a 500 that had already consumed the human's one-shot approval.
+func TestARepeatedLinkIsFiledOnceRatherThanRaisingAUniqueViolation(t *testing.T) {
+	e := setupSend(t)
+	org := e.seedOrganization(t)
+	stager := &recordingStager{}
+	repeated := FromAccount([]ActivityLinkInput{
+		{EntityType: "organization", EntityID: org},
+		{EntityType: "organization", EntityID: org},
+	})
+
+	sent, err := e.accountStore().SendEmail(
+		e.as(principal.RowScopeAll), repeated, sendInput("transactional"), stubConsentGate{}, stager)
+	if err != nil {
+		t.Fatalf("send naming the same record twice: %v", err)
+	}
+	if sent.Links == nil || len(*sent.Links) != 1 {
+		t.Fatalf("wrote links %v, want the one record filed once", sent.Links)
+	}
+}
+
+// Every link costs its own row-scoped probe, and the array is the caller's to
+// choose, so the list is bounded before any of those queries runs. The bound is
+// the contract's own `maxItems`, and it holds for a human's send as much as for
+// an agent's — the tool surface refuses the same count earlier so that no
+// approval is minted for a call this would reject.
+func TestASendFiledUnderMoreRecordsThanTheBoundIsRefusedBeforeItProbesAnything(t *testing.T) {
+	e := setupSend(t)
+	stager := &recordingStager{}
+	links := make([]ActivityLinkInput, maxAccountSendLinks+1)
+	for i := range links {
+		links[i] = ActivityLinkInput{EntityType: "organization", EntityID: ids.NewV7()}
+	}
+
+	_, err := e.accountStore().SendEmail(
+		e.as(principal.RowScopeAll), FromAccount(links), sendInput("transactional"), stubConsentGate{}, stager)
+
+	var tooMany *TooManyLinksError
+	if !errors.As(err, &tooMany) {
+		t.Fatalf("send naming %d records = %v, want a TooManyLinksError", len(links), err)
+	}
+	if field, code, _ := tooMany.FieldFault(); field != "links" || code != "too_many_links" {
+		t.Errorf("FieldFault = %s/%s, want links/too_many_links so the caller is told what to shorten", field, code)
+	}
+	if len(stager.staged) != 0 {
+		t.Fatalf("a refused send staged %d deliveries, want none", len(stager.staged))
+	}
+}

--- a/backend/internal/modules/agents/stagingfitness_test.go
+++ b/backend/internal/modules/agents/stagingfitness_test.go
@@ -57,6 +57,12 @@ func TestEveryStageableToolRefusesATargetHeldElsewhere(t *testing.T) {
 		// while proving nothing.
 		"book_meeting": fmt.Sprintf(
 			`{"start":"2026-08-03T09:00:00Z","end":"2026-08-03T09:30:00Z","subject":"s","links":[{"entity_type":"deal","entity_id":%q}]}`, deal),
+		// The account-started send has no anchor either, and for the same
+		// reason: it starts the conversation instead of answering one. Its
+		// links are what carry the refusal here.
+		"send_account_email": fmt.Sprintf(
+			`{"to":["a@example.test"],"subject":"s","body":"b","consent_purpose":"support",`+
+				`"links":[{"entity_type":"organization","entity_id":%q}]}`, ids.NewV7()),
 	}
 
 	registry := NewRegistry(&recordingApprovals{}, nil)

--- a/backend/internal/modules/agents/testdata/outputshapes.json
+++ b/backend/internal/modules/agents/testdata/outputshapes.json
@@ -4226,6 +4226,102 @@
       "warnings"
     ]
   },
+  "send_account_email": {
+    "type": "object",
+    "properties": {
+      "data": {
+        "type": "object",
+        "properties": {
+          "activity_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "status": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "activity_id",
+          "status"
+        ]
+      },
+      "evidence": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "captured_by": {
+              "type": "string"
+            },
+            "record_id": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "record_type": {
+              "type": "string"
+            },
+            "source": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "record_id",
+            "record_type"
+          ]
+        }
+      },
+      "freshness": {
+        "type": "object",
+        "properties": {
+          "authoritative": {
+            "type": "boolean"
+          },
+          "last_synced_at": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "authoritative"
+        ]
+      },
+      "schema_version": {
+        "type": "string"
+      },
+      "trace_id": {
+        "type": "string"
+      },
+      "trust": {
+        "type": "string"
+      },
+      "warnings": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "code": {
+              "type": "string"
+            },
+            "message": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "code",
+            "message"
+          ]
+        }
+      }
+    },
+    "required": [
+      "data",
+      "evidence",
+      "freshness",
+      "schema_version",
+      "trace_id",
+      "trust",
+      "warnings"
+    ]
+  },
   "send_email": {
     "type": "object",
     "properties": {

--- a/backend/internal/modules/agents/toolcopy_comms.go
+++ b/backend/internal/modules/agents/toolcopy_comms.go
@@ -48,6 +48,19 @@ var sendEmailCopy = toolCopy{
 		"approval.",
 }
 
+var sendAccountEmailCopy = toolCopy{
+	Purpose: "Put a mail on the wire to a real recipient, from this workspace, starting a new " +
+		"conversation rather than answering one, and file it on the records it is about.",
+	Limits: "It sends EXACTLY the subject and body it is given and composes nothing. It needs at " +
+		"least one link naming the records the conversation belongs to and is refused without " +
+		"one. Every recipient must have granted the consent purpose the call names, and a person " +
+		"approves the send before it leaves — a message leaving the workspace cannot be recalled.",
+	Instead: "Use send_email when the message answers a conversation already recorded here: that " +
+		"keeps the reply on its own thread, where this starts a separate one beside it.",
+	Retain: "Keep the staged approval id and re-send the identical text and links: the approval " +
+		"is bound to that exact message. The activity_id that comes back is the new conversation.",
+}
+
 var sendMessageCopy = toolCopy{
 	Purpose: "Reply on a captured chat conversation — the channels this workspace has connected " +
 		"— on the thread it was captured from.",

--- a/backend/internal/modules/agents/toollinks.go
+++ b/backend/internal/modules/agents/toollinks.go
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package agents
+
+// The record links a caller NAMES, for the 🟡 verbs that attach to records
+// instead of anchoring on one: a booking says what the meeting is about, an
+// account-started send says which records the new conversation is filed under.
+// Neither has a row handed to it, so both have to answer the same three
+// questions about the list they were given — is it bounded, is it free of
+// repeats, and is every record one the caller may actually reach — and they
+// answer them here, once.
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
+)
+
+// RecordLink is one (record type, id) pair naming a record a staged effect
+// attaches to. Comparable, so it can key the dedupe set below.
+type RecordLink struct {
+	EntityType string   `json:"entity_type"`
+	EntityID   ids.UUID `json:"entity_id"`
+}
+
+// maxRecordLinks bounds how many records one call may attach to.
+//
+// This is a REQUEST BOUND, not a modelling opinion. Each link costs its own
+// row-scoped provider read in its own transaction, and the array is chosen
+// freely by the caller: at the 1 MiB body limit a single tools/call could
+// carry ~15,000 of them, spending tens of thousands of queries against a
+// 16-connection pool inside one request — before any human has approved
+// anything, since staging runs on the refusal path. A meeting, or a message,
+// that genuinely touches more records than this is neither.
+const maxRecordLinks = 25
+
+// uniqueRecordLinks validates and de-duplicates the links a call attaches to.
+// Deduplicating matters as much as the cap: the same id repeated is the
+// cheapest way to turn one call into N reads, and it is also just a caller
+// mistake worth not charging for twice.
+func uniqueRecordLinks(links []RecordLink) ([]RecordLink, error) {
+	if len(links) > maxRecordLinks {
+		return nil, &BadArgsError{Cause: fmt.Errorf(
+			"a call may attach to at most %d records; this one names %d", maxRecordLinks, len(links))}
+	}
+	seen := make(map[RecordLink]struct{}, len(links))
+	unique := make([]RecordLink, 0, len(links))
+	for _, link := range links {
+		if _, dup := seen[link]; dup {
+			continue
+		}
+		seen[link] = struct{}{}
+		unique = append(unique, link)
+	}
+	return unique, nil
+}
+
+// readStageableLinks reads every named link through the record provider and
+// refuses the staging if any one of them cannot carry an approval.
+//
+// EVERY link, not just the one a summary happens to display. Two refusals ride
+// on this read and each would otherwise mint an approval nobody can use: a
+// record outside the caller's row scope answers not-found here rather than
+// after a human has spent the one-shot approval on it, and a record whose
+// authority lives in an external system of record has no row in our tables for
+// redemption's version pin to read — the un-releasable approval
+// refuseStagingElsewhere exists to prevent. A call naming one local record and
+// one mirrored record is exactly the case a first-link-only check waves through.
+//
+// The records come back in the caller's order, so a caller that needs one of
+// them — a booking pins its first link's version — reads it from the result
+// rather than fetching it a second time.
+func readStageableLinks(
+	ctx context.Context, p datasource.SystemOfRecordProvider, links []RecordLink,
+) ([]datasource.Record, error) {
+	records := make([]datasource.Record, 0, len(links))
+	for _, link := range links {
+		rec, err := p.Read(ctx, datasource.EntityRef{
+			Type: datasource.EntityType(link.EntityType), ID: link.EntityID,
+		})
+		if err != nil {
+			return nil, err
+		}
+		if err := refuseStagingElsewhere(rec); err != nil {
+			return nil, err
+		}
+		records = append(records, rec)
+	}
+	return records, nil
+}

--- a/backend/internal/modules/agents/toollinks.go
+++ b/backend/internal/modules/agents/toollinks.go
@@ -13,6 +13,7 @@ package agents
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
@@ -24,6 +25,20 @@ import (
 type RecordLink struct {
 	EntityType string   `json:"entity_type"`
 	EntityID   ids.UUID `json:"entity_id"`
+}
+
+// requireAddressee refuses a mail send that reaches nobody.
+//
+// One spelling for both mail verbs. The store refuses it too, at execution, so
+// the point of raising it at staging is that a human is never asked to approve
+// a send that was already impossible — and two copies of that sentence is how
+// one of the two verbs quietly stops asking.
+func requireAddressee(to []string) error {
+	if len(to) > 0 {
+		return nil
+	}
+	return &BadArgsError{Cause: errors.New(
+		"`to` is empty; a send with no addressee reaches nobody and would be refused after approval")}
 }
 
 // maxRecordLinks bounds how many records one call may attach to.

--- a/backend/internal/modules/agents/tools_account_send.go
+++ b/backend/internal/modules/agents/tools_account_send.go
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package agents
+
+// send_account_email — the account-started twin of send_email (ADR-0087 §6),
+// in its own file because tools_comms.go is at its length ceiling and this is
+// one origin's worth of code, not a second send.
+//
+// 🟡, scope `send`, governed identically to the reply and with no new
+// authority: an agent stages, a human's own action IS the approval (ADR-0055).
+// Everything after the origin — the consent gate, deliverability, identity
+// minting, the single-transaction staging of activity + delivery + job — is the
+// reply path's, reached through the same store method the HTTP transport calls.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/mcp"
+)
+
+// sendAccountEmailTool carries a record reader like its reply twin, but reads
+// something else with it: the twin reads its ANCHOR, and this has none.
+type sendAccountEmailTool struct {
+	comms Comms
+	p     datasource.SystemOfRecordProvider
+}
+
+// SendAccountEmailArgs is one account-started send: the reply's arguments,
+// minus the anchor, plus the records the new conversation is filed under.
+type SendAccountEmailArgs struct {
+	SendEmailArgs
+	Links []RecordLink `json:"links"`
+}
+
+func (t sendAccountEmailTool) Spec() mcp.ToolSpec {
+	return mcp.ToolSpec{
+		Name: "send_account_email", Title: "Start an email conversation from a record", Version: toolVersionV1,
+		Description:   sendAccountEmailCopy.render(),
+		RequiredScope: principal.ScopeSend, Tier: mcp.TierConfirmationRequired, Egress: true,
+		OpenAPIOp: "sendAccountEmail",
+		InputSchema: schema(`{"type":"object","required":["to","subject","body","consent_purpose","links"],"properties":{
+			"to":{"type":"array","items":{"type":"string","format":"email"},"minItems":1},
+			"cc":{"type":"array","items":{"type":"string","format":"email"}},
+			"subject":{"type":"string"},
+			"body":{"type":"string"},
+			"consent_purpose":{"type":"string","description":"Purpose key the recipients must have granted"},
+			"links":{"type":"array","minItems":1,"items":{"type":"object","required":["entity_type","entity_id"],"properties":{
+				"entity_type":{"type":"string","enum":` + activityLinkEntityTypeEnum + `},
+				"entity_id":{"type":"string","format":"uuid"}},"additionalProperties":false},"maxItems":25,
+				"description":"The records this conversation is filed under; at least one. The send is refused without it."},
+			"approval_id":{"type":"string","format":"uuid","description":"Set on retry after a human approved the staged call"}},
+			"additionalProperties":false}`),
+		OutputSchema: schemaFor[SendEmailResult](),
+	}
+}
+
+// StageInfo puts a refused account-started send in the inbox instead of
+// dead-ending it.
+//
+// WHAT IT STAGES IS A CREATE, and the shape says so: the target type is
+// `activity` with no id and no version pin. This send answers no message, so
+// there is no row its effect depends on — approvals.settledByShape reads that
+// shape as decidable on the object-read floor plus the decision grants, which
+// is the same row the REST door stages when the identical call arrives as a
+// bearer request (compose.stageRefusal reads a target id out of the route's
+// {id} parameter and this route has none). One operation, one staged shape,
+// whichever door it came through.
+//
+// It deliberately does NOT pin one of the links the way book_meeting pins its
+// first: a booking is a commitment ON the record it names, so its staleness is
+// the record's; a send's text is not, and pinning a link would refuse an
+// approved message because somebody edited that company's address in between.
+//
+// The links are still read, because that is a question about the STAGER's
+// reach rather than the approver's: the store refuses a link the caller cannot
+// see, at execution — so without the same probe here, an agent naming a company
+// it cannot read mints an approval a human reads, approves, and watches fail
+// with the one-shot authority already spent.
+//
+// What this does not pre-empt, so neither reads as covered: the consent gate's
+// per-purpose verdict, the workspace's mailbox send capability, and whether an
+// address belongs to a person on file. All are refusals a human's yes cannot
+// fix, and all need reads staging does not have.
+func (t sendAccountEmailTool) StageInfo(ctx context.Context, in json.RawMessage) (StageInfo, error) {
+	args, links, err := readAccountSendArgs(in)
+	if err != nil {
+		return StageInfo{}, err
+	}
+	if _, err := readStageableLinks(ctx, t.p, links); err != nil {
+		return StageInfo{}, err
+	}
+	return StageInfo{
+		TargetType: string(datasource.EntityActivity),
+		Summary:    describeAccountSend(args, links),
+	}, nil
+}
+
+// readAccountSendArgs decodes one call and applies the refusals the send path
+// would otherwise raise only after a human had approved it.
+//
+// Both doors go through it, and that is the point: the MCP surface does not
+// validate arguments against an InputSchema — that schema is documentation —
+// so a rule enforced only at staging is one an approved retry never meets.
+func readAccountSendArgs(in json.RawMessage) (SendAccountEmailArgs, []RecordLink, error) {
+	var args SendAccountEmailArgs
+	if err := decodeArgs(in, &args); err != nil {
+		return SendAccountEmailArgs{}, nil, err
+	}
+	if len(args.To) == 0 {
+		return SendAccountEmailArgs{}, nil, &BadArgsError{Cause: errors.New(
+			"`to` is empty; a send with no addressee reaches nobody and would be refused after approval")}
+	}
+	if len(args.Links) == 0 {
+		return SendAccountEmailArgs{}, nil, &BadArgsError{
+			Cause: errors.New("`links` needs at least one entry: a message filed under no record " +
+				"is one nobody finds again, and the store refuses it"),
+			Guidance: "name the company, person or deal this conversation is about",
+		}
+	}
+	links, err := uniqueRecordLinks(args.Links)
+	if err != nil {
+		return SendAccountEmailArgs{}, nil, err
+	}
+	return args, links, nil
+}
+
+// describeAccountSend is the one line the inbox shows for an account-started
+// send: who it reaches, cc included, what it says it is about, and how many
+// records it will land on.
+//
+// Every addressee, for the reason the reply twin's summary states — an unnamed
+// recipient is a recipient nobody agreed to. The links are counted rather than
+// listed: their ids mean nothing to a human reading one line, and the staged
+// row is decidable on the activity floor rather than on those records, so
+// naming them would disclose more than the decision rests on.
+func describeAccountSend(args SendAccountEmailArgs, links []RecordLink) string {
+	summary := fmt.Sprintf("Start an email conversation with %s", strings.Join(args.To, ", "))
+	if len(args.Cc) > 0 {
+		summary += fmt.Sprintf(", cc %s", strings.Join(args.Cc, ", "))
+	}
+	return summary + fmt.Sprintf(", subject %q, filed under %d record(s)", args.Subject, len(links))
+}
+
+func (t sendAccountEmailTool) Handle(ctx context.Context, in json.RawMessage) (json.RawMessage, error) {
+	args, links, err := readAccountSendArgs(in)
+	if err != nil {
+		return nil, err
+	}
+	for _, link := range links {
+		noteEvidence(ctx, datasource.EntityType(link.EntityType), link.EntityID)
+	}
+	return marshalResult(t.comms.SendAccountEmail(ctx, links, args.SendEmailArgs))
+}

--- a/backend/internal/modules/agents/tools_account_send.go
+++ b/backend/internal/modules/agents/tools_account_send.go
@@ -67,16 +67,31 @@ func (t sendAccountEmailTool) Spec() mcp.ToolSpec {
 // WHAT IT STAGES IS A CREATE, and the shape says so: the target type is
 // `activity` with no id and no version pin. This send answers no message, so
 // there is no row its effect depends on — approvals.settledByShape reads that
-// shape as decidable on the object-read floor plus the decision grants, which
+// shape as decidable on the object-read floor plus the decision grants, and it
 // is the same row the REST door stages when the identical call arrives as a
-// bearer request (compose.stageRefusal reads a target id out of the route's
-// {id} parameter and this route has none). One operation, one staged shape,
+// bearer request (compose.stageRefusal takes its target id from the route's
+// {id} parameter, and this route has none). One operation, one staged shape,
 // whichever door it came through.
 //
-// It deliberately does NOT pin one of the links the way book_meeting pins its
-// first: a booking is a commitment ON the record it names, so its staleness is
-// the record's; a send's text is not, and pinning a link would refuse an
-// approved message because somebody edited that company's address in between.
+// NAMING A LINK AS THE TARGET — what book_meeting does with its first — was
+// weighed and is not available here, for two reasons that compound. The REST
+// door cannot follow: it never reads the body, so the two doors would stage one
+// kind two ways and a human would be deciding a different question depending on
+// the transport the agent used. And the pin is taken SERVER-SIDE from the
+// target pair (approvals.resolveTargetVersion), so naming an organization pins
+// its version — which an enrichment run bumps while an overnight proposal waits
+// for someone's morning inbox, cancelling a send the record's own content never
+// invalidated. The waiver that would decline the pin is reserved for kinds
+// whose effect approvals itself applies (TestEveryContextTargetKindIsAKindWeStage),
+// and this effect is performed by the agent's own approved retry.
+//
+// WHAT THAT COSTS, stated rather than left to be discovered: the approver is
+// bounded by read+create on `activity` and NOT by the row scope of the records
+// the message is filed under, where the reply path's approver is bounded by the
+// anchor it targets. A manager whose scope excludes those records can release
+// this send and read its proposed text. Closing it needs the REST staging gate
+// to be able to derive a target from the body, which is a change to a gate this
+// verb shares — issue #928.
 //
 // The links are still read, because that is a question about the STAGER's
 // reach rather than the approver's: the store refuses a link the caller cannot
@@ -113,9 +128,8 @@ func readAccountSendArgs(in json.RawMessage) (SendAccountEmailArgs, []RecordLink
 	if err := decodeArgs(in, &args); err != nil {
 		return SendAccountEmailArgs{}, nil, err
 	}
-	if len(args.To) == 0 {
-		return SendAccountEmailArgs{}, nil, &BadArgsError{Cause: errors.New(
-			"`to` is empty; a send with no addressee reaches nobody and would be refused after approval")}
+	if err := requireAddressee(args.To); err != nil {
+		return SendAccountEmailArgs{}, nil, err
 	}
 	if len(args.Links) == 0 {
 		return SendAccountEmailArgs{}, nil, &BadArgsError{

--- a/backend/internal/modules/agents/tools_account_send.go
+++ b/backend/internal/modules/agents/tools_account_send.go
@@ -3,9 +3,10 @@
 
 package agents
 
-// send_account_email — the account-started twin of send_email (ADR-0087 §6),
-// in its own file because tools_comms.go is at its length ceiling and this is
-// one origin's worth of code, not a second send.
+// send_account_email — the account-started twin of send_email (ADR-0087 §6).
+// Its own file because the ORIGIN is what separates it from the mail verbs next
+// door: this one starts a conversation and names the records it belongs to,
+// where they answer one that already exists.
 //
 // 🟡, scope `send`, governed identically to the reply and with no new
 // authority: an agent stages, a human's own action IS the approval (ADR-0055).
@@ -73,25 +74,23 @@ func (t sendAccountEmailTool) Spec() mcp.ToolSpec {
 // {id} parameter, and this route has none). One operation, one staged shape,
 // whichever door it came through.
 //
-// NAMING A LINK AS THE TARGET — what book_meeting does with its first — was
-// weighed and is not available here, for two reasons that compound. The REST
-// door cannot follow: it never reads the body, so the two doors would stage one
-// kind two ways and a human would be deciding a different question depending on
-// the transport the agent used. And the pin is taken SERVER-SIDE from the
-// target pair (approvals.resolveTargetVersion), so naming an organization pins
-// its version — which an enrichment run bumps while an overnight proposal waits
-// for someone's morning inbox, cancelling a send the record's own content never
-// invalidated. The waiver that would decline the pin is reserved for kinds
-// whose effect approvals itself applies (TestEveryContextTargetKindIsAKindWeStage),
-// and this effect is performed by the agent's own approved retry.
+// A LINK CANNOT BE THE TARGET here, the way book_meeting's first link is.
+// Two constraints close it: the REST door takes its target from the route and
+// never reads the body, so naming one would stage a kind two ways; and the pin
+// is taken SERVER-SIDE from the target pair (approvals.resolveTargetVersion),
+// so an organization target pins a version that an enrichment run bumps while
+// an overnight proposal waits for someone's morning inbox — cancelling a send
+// the record's own content never invalidated. The waiver that declines a pin is
+// reserved for kinds whose effect approvals itself applies
+// (TestEveryContextTargetKindIsAKindWeStage); this effect is performed by the
+// agent's own approved retry.
 //
-// WHAT THAT COSTS, stated rather than left to be discovered: the approver is
-// bounded by read+create on `activity` and NOT by the row scope of the records
-// the message is filed under, where the reply path's approver is bounded by the
-// anchor it targets. A manager whose scope excludes those records can release
-// this send and read its proposed text. Closing it needs the REST staging gate
-// to be able to derive a target from the body, which is a change to a gate this
-// verb shares — issue #928.
+// So the approver is bounded by read+create on `activity` and NOT by the row
+// scope of the records the message is filed under — a manager whose scope
+// excludes them can still release this send and read its proposed text. The
+// reply path binds its approver to the anchor instead. Closing the difference
+// takes a staging gate that can derive a target from the body, which is shared
+// machinery rather than this verb's: issue #928.
 //
 // The links are still read, because that is a question about the STAGER's
 // reach rather than the approver's: the store refuses a link the caller cannot

--- a/backend/internal/modules/agents/tools_account_send_test.go
+++ b/backend/internal/modules/agents/tools_account_send_test.go
@@ -185,6 +185,54 @@ func TestARefusedAccountStartedSendReachesTheInbox(t *testing.T) {
 	}
 }
 
+// unreadableProvider answers every read the way a row outside the caller's
+// scope does — not-found, indistinguishable from absent, which is how this
+// product hides a record's existence.
+type unreadableProvider struct {
+	datasource.SystemOfRecordProvider
+}
+
+func (unreadableProvider) Read(_ context.Context, ref datasource.EntityRef) (datasource.Record, error) {
+	return datasource.Record{}, fmt.Errorf("record %s: %w", ref.ID, apperrors.ErrNotFound)
+}
+
+// A link the caller cannot see is refused at staging, with the row-scope
+// answer and nothing else.
+//
+// The store refuses it too, but only when the approved send runs — by which
+// point a human has read the proposal, said yes, and spent a one-shot
+// authority on a message that was never going to leave. The refusal has to
+// arrive before the question is asked.
+func TestAnAccountStartedSendRefusesALinkTheCallerCannotSee(t *testing.T) {
+	approvals := &recordingApprovals{}
+	registry := NewRegistry(approvals, auth.NewGate(fullSeatAuthority{}))
+	RegisterCommsTools(registry, &recordingComms{}, unreadableProvider{})
+
+	_, err := registry.Invoke(sendCtx(), "send_account_email", accountSendArgs(orgLink(ids.NewV7())))
+
+	if !errors.Is(err, apperrors.ErrNotFound) {
+		t.Fatalf("Invoke err = %v, want the row-scope answer — a record the caller cannot read is not a "+
+			"record they may start a conversation about", err)
+	}
+	if len(approvals.staged) != 0 {
+		t.Errorf("staged %d approvals for an unreachable record, want none", len(approvals.staged))
+	}
+}
+
+// Malformed arguments are refused before anything is staged, at both doors —
+// there is no call here to put in front of a human.
+func TestAnAccountStartedSendRefusesUnreadableArguments(t *testing.T) {
+	tool := sendAccountEmailTool{comms: &recordingComms{}, p: &multiLinkProvider{}}
+	const notAnObject = `["send","this"]`
+
+	if _, err := tool.StageInfo(context.Background(), json.RawMessage(notAnObject)); err == nil {
+		t.Error("StageInfo accepted arguments it cannot read")
+	}
+	if _, err := tool.Handle(withApprovalRedeemed(sendCtx(), 0, false), json.RawMessage(notAnObject)); err == nil {
+		t.Error("Handle accepted arguments it cannot read")
+	}
+}
+
 // Every link is read, not just the first: a send filed under one local record
 // and one mirrored record is exactly what a first-link-only guard waves through
 // into an approval nobody can release.

--- a/backend/internal/modules/agents/tools_account_send_test.go
+++ b/backend/internal/modules/agents/tools_account_send_test.go
@@ -1,0 +1,274 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package agents
+
+// What the account-started send stages, and what it refuses to stage. It is
+// the reply's twin in governance and its opposite in shape: no anchor, so the
+// records it is filed under are the only records it has, and they carry every
+// refusal the anchor carries for send_email.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/platform/auth"
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/mcp"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/workflow"
+)
+
+// accountSendArgs is one well-formed call, so a test that varies ONE thing
+// varies only that thing.
+func accountSendArgs(links string) json.RawMessage {
+	return json.RawMessage(fmt.Sprintf(
+		`{"to":["buyer@example.test"],"subject":"Introductions","body":"b","consent_purpose":"sales","links":[%s]}`,
+		links))
+}
+
+func orgLink(id ids.UUID) string {
+	return fmt.Sprintf(`{"entity_type":"organization","entity_id":%q}`, id)
+}
+
+// ADR-0087 §6: the agent surface gains this operation governed identically to
+// the reply, with no new authority. "Identically" is four properties, and each
+// one is a way the twin could have been governed more loosely by accident.
+func TestTheAccountStartedSendGovernsAsTheReplyDoes(t *testing.T) {
+	spec, reply := sendAccountEmailTool{}.Spec(), sendEmailTool{}.Spec()
+
+	if spec.RequiredScope != reply.RequiredScope {
+		t.Errorf("RequiredScope = %q, want the reply's %q", spec.RequiredScope, reply.RequiredScope)
+	}
+	if spec.RequiredScope != principal.ScopeSend {
+		t.Errorf("RequiredScope = %q, want %q", spec.RequiredScope, principal.ScopeSend)
+	}
+	if spec.Tier != mcp.TierConfirmationRequired {
+		t.Errorf("Tier = %v, want TierConfirmationRequired — an unapproved send would leave the workspace", spec.Tier)
+	}
+	if !spec.Egress {
+		t.Error("Egress = false; the message leaves the workspace")
+	}
+	if spec.OpenAPIOp != "sendAccountEmail" {
+		t.Errorf("OpenAPIOp = %q, want %q", spec.OpenAPIOp, "sendAccountEmail")
+	}
+}
+
+// The staged shape is a CREATE: the type the effect will write, no id, no pin.
+//
+// That is what makes it decidable — approvals settles an id-less shape on the
+// object-read floor plus the decision grants — and it is the SAME row the REST
+// door stages for this operation, whose route carries no {id} for a target to
+// be taken from. One operation staged two ways is a human deciding a different
+// question depending on which transport the agent used.
+func TestTheAccountStartedSendStagesACreate(t *testing.T) {
+	org := ids.NewV7()
+	p := &multiLinkProvider{}
+
+	info, err := sendAccountEmailTool{comms: &recordingComms{}, p: p}.
+		StageInfo(context.Background(), accountSendArgs(orgLink(org)))
+	if err != nil {
+		t.Fatalf("StageInfo: %v", err)
+	}
+	if info.TargetType != string(datasource.EntityActivity) {
+		t.Errorf("TargetType = %q, want %q — the effect writes an activity",
+			info.TargetType, datasource.EntityActivity)
+	}
+	if !info.TargetID.IsZero() {
+		t.Errorf("TargetID = %v, want the zero id: this send answers no message, so it targets no row", info.TargetID)
+	}
+	if info.TargetVersion != nil {
+		t.Errorf("TargetVersion = %v, want none — pinning a linked record's version would refuse an "+
+			"approved message because somebody edited that record in between", *info.TargetVersion)
+	}
+	if len(p.read) != 1 || p.read[0].ID != org {
+		t.Errorf("read %v, want the one named link — the store refuses a link the caller cannot see, "+
+			"and staging must ask that question before a human is asked anything", p.read)
+	}
+}
+
+// The inbox row is the whole of what a human reads before releasing a send, so
+// an addressee missing from it is a recipient nobody agreed to.
+func TestTheAccountStartedSendSummaryNamesEveryArgumentItReleases(t *testing.T) {
+	got := describeAccountSend(SendAccountEmailArgs{SendEmailArgs: SendEmailArgs{
+		To: []string{"buyer@example.test"}, Cc: []string{"rival@example.test"}, Subject: "Q3 pricing",
+	}}, []RecordLink{{EntityType: "organization", EntityID: ids.NewV7()}})
+
+	for _, want := range []string{"buyer@example.test", "rival@example.test", `"Q3 pricing"`, "1 record(s)"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("summary %q does not name %q", got, want)
+		}
+	}
+}
+
+// Two refusals the send path raises anyway, raised here instead — at BOTH
+// doors this verb has, because an InputSchema on the MCP surface is
+// documentation rather than validation and Handle is entered with an approval
+// already redeemed rather than through StageInfo.
+//
+// Raising them late is not a smaller bug than not raising them at all: a human
+// approves a send that was never going to happen, the retry consumes the
+// one-shot authority on it, and the store refuses permanently.
+func TestAnUnsendableAccountStartedCallIsRefusedAtBothDoors(t *testing.T) {
+	for _, tc := range []struct {
+		name, args, names string
+	}{
+		{
+			name:  "no addressee",
+			args:  `{"to":[],"subject":"s","body":"b","consent_purpose":"sales","links":[{"entity_type":"organization","entity_id":"019ff000-0000-7000-8000-000000000001"}]}`,
+			names: "`to`",
+		},
+		{
+			name:  "filed under nothing",
+			args:  `{"to":["buyer@example.test"],"subject":"s","body":"b","consent_purpose":"sales","links":[]}`,
+			names: "`links`",
+		},
+	} {
+		comms := &recordingComms{}
+		tool := sendAccountEmailTool{comms: comms, p: &multiLinkProvider{}}
+		doors := map[string]func(json.RawMessage) error{
+			"staging": func(in json.RawMessage) error {
+				_, err := tool.StageInfo(context.Background(), in)
+				return err
+			},
+			"after an approval was redeemed": func(in json.RawMessage) error {
+				_, err := tool.Handle(withApprovalRedeemed(sendCtx(), 0, false), in)
+				return err
+			},
+		}
+		for door, call := range doors {
+			t.Run(tc.name+"/"+door, func(t *testing.T) {
+				err := call(json.RawMessage(tc.args))
+
+				var badArgs *BadArgsError
+				if !errors.As(err, &badArgs) {
+					t.Fatalf("err = %v, want a BadArgsError naming %s", err, tc.names)
+				}
+				if !strings.Contains(err.Error(), tc.names) {
+					t.Errorf("err = %v, want it to name %s", err, tc.names)
+				}
+				if comms.accountSent != nil {
+					t.Error("an unsendable call reached the comms seam")
+				}
+			})
+		}
+	}
+}
+
+// The refused call reaches the inbox rather than dead-ending: Registry.Invoke
+// stages only a tool that describes its own staging, so a 🟡 verb without one
+// is advertised and unusable. It is the same loop send_email's own pin covers,
+// asked of the twin.
+func TestARefusedAccountStartedSendReachesTheInbox(t *testing.T) {
+	approvals := &recordingApprovals{}
+	comms := &recordingComms{}
+	registry := NewRegistry(approvals, auth.NewGate(fullSeatAuthority{}))
+	RegisterCommsTools(registry, comms, &multiLinkProvider{})
+
+	_, err := registry.Invoke(sendCtx(), "send_account_email", accountSendArgs(orgLink(ids.NewV7())))
+
+	var staged *workflow.StagedApprovalError
+	if !errors.As(err, &staged) {
+		t.Fatalf("Invoke err = %v, want the refusal to have staged an approval", err)
+	}
+	if len(approvals.staged) != 1 {
+		t.Fatalf("staged %d approvals, want exactly one", len(approvals.staged))
+	}
+	if comms.accountSent != nil {
+		t.Error("the unapproved call reached the comms seam")
+	}
+}
+
+// Every link is read, not just the first: a send filed under one local record
+// and one mirrored record is exactly what a first-link-only guard waves through
+// into an approval nobody can release.
+func TestTheAccountStartedSendRefusesAMirroredLinkBehindALocalOne(t *testing.T) {
+	local, mirrored := ids.NewV7(), ids.NewV7()
+	p := &multiLinkProvider{heldElsewhere: map[ids.UUID]bool{mirrored: true}}
+
+	_, err := sendAccountEmailTool{comms: &recordingComms{}, p: p}.StageInfo(context.Background(),
+		accountSendArgs(fmt.Sprintf(`{"entity_type":"deal","entity_id":%q},%s`, local, orgLink(mirrored))))
+
+	if !errors.Is(err, apperrors.ErrUnsupportedBySoR) {
+		t.Fatalf("StageInfo err = %v, want ErrUnsupportedBySoR — the second link was never validated", err)
+	}
+	if len(p.read) != 2 {
+		t.Errorf("read %d links, want both", len(p.read))
+	}
+}
+
+// The link array is chosen freely by the caller and each entry costs its own
+// row-scoped read, on the refusal path, before any human has approved anything.
+// The bound and the dedupe both have to precede the reads they exist to
+// prevent, and this entry point is a second door onto them.
+func TestAnAccountStartedSendIsBoundedAndDeduplicatedBeforeItReadsAnything(t *testing.T) {
+	t.Run("refuses more links than a message could be about", func(t *testing.T) {
+		links := make([]string, maxRecordLinks+1)
+		for i := range links {
+			links[i] = orgLink(ids.NewV7())
+		}
+		p := &multiLinkProvider{}
+
+		_, err := sendAccountEmailTool{comms: &recordingComms{}, p: p}.
+			StageInfo(context.Background(), accountSendArgs(strings.Join(links, ",")))
+
+		var bad *BadArgsError
+		if !errors.As(err, &bad) {
+			t.Fatalf("StageInfo err = %v, want a BadArgsError refusing the oversized link array", err)
+		}
+		if len(p.read) != 0 {
+			t.Errorf("read %d records before refusing — the cap must precede the reads it exists to prevent", len(p.read))
+		}
+	})
+
+	t.Run("reads a repeated link once", func(t *testing.T) {
+		org := ids.NewV7()
+		repeated := make([]string, 10)
+		for i := range repeated {
+			repeated[i] = orgLink(org)
+		}
+		p := &multiLinkProvider{}
+
+		info, err := sendAccountEmailTool{comms: &recordingComms{}, p: p}.
+			StageInfo(context.Background(), accountSendArgs(strings.Join(repeated, ",")))
+		if err != nil {
+			t.Fatalf("StageInfo: %v", err)
+		}
+		if len(p.read) != 1 {
+			t.Errorf("read %d records for one repeated link, want 1", len(p.read))
+		}
+		if !strings.Contains(info.Summary, "1 record(s)") {
+			t.Errorf("summary %q counts the repeats; a human would read a reach the send does not have", info.Summary)
+		}
+	})
+}
+
+// The approved call sends what was staged, through the seam, with the links
+// deduplicated exactly as the staged summary counted them.
+func TestAnApprovedAccountStartedSendReachesTheSeam(t *testing.T) {
+	org := ids.NewV7()
+	comms := &recordingComms{}
+	tool := sendAccountEmailTool{comms: comms, p: &multiLinkProvider{}}
+
+	out, err := tool.Handle(withApprovalRedeemed(sendCtx(), 0, false),
+		accountSendArgs(orgLink(org)+","+orgLink(org)))
+	if err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	if len(comms.accountSent) != 1 || comms.accountSent[0].EntityID != org {
+		t.Fatalf("seam reached with %v, want the one deduplicated link", comms.accountSent)
+	}
+	var result SendEmailResult
+	if err := json.Unmarshal(out, &result); err != nil {
+		t.Fatalf("result is not a SendEmailResult: %v", err)
+	}
+	if result.Status != "accepted" {
+		t.Errorf("Status = %q, want the delivery path's answer", result.Status)
+	}
+}

--- a/backend/internal/modules/agents/tools_comms.go
+++ b/backend/internal/modules/agents/tools_comms.go
@@ -14,7 +14,6 @@ package agents
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -201,9 +200,8 @@ func (t sendEmailTool) StageInfo(ctx context.Context, in json.RawMessage) (Stage
 	// an approval, a human reads a send with no addressee and says yes, the
 	// approved retry consumes that one-shot authority, and only then does the
 	// store refuse — a "yes" spent on something that was never going to happen.
-	if len(args.To) == 0 {
-		return StageInfo{}, &BadArgsError{Cause: errors.New(
-			"`to` is empty; a send with no addressee reaches nobody and would be refused after approval")}
+	if err := requireAddressee(args.To); err != nil {
+		return StageInfo{}, err
 	}
 	rec, err := t.p.Read(ctx, datasource.EntityRef{Type: datasource.EntityActivity, ID: args.ActivityID})
 	if err != nil {

--- a/backend/internal/modules/agents/tools_comms.go
+++ b/backend/internal/modules/agents/tools_comms.go
@@ -30,6 +30,11 @@ import (
 type Comms interface {
 	DraftEmail(ctx context.Context, anchor ids.UUID, intent string) (subject, body string, err error)
 	SendEmail(ctx context.Context, anchor ids.UUID, in SendEmailArgs) (SendEmailResult, error)
+	// SendAccountEmail starts a NEW conversation instead of continuing one
+	// (ADR-0087). It takes no anchor — there is no prior message, and the
+	// product refuses to fabricate a placeholder activity to obtain one — so
+	// the records the message is filed under are named instead of inherited.
+	SendAccountEmail(ctx context.Context, links []RecordLink, in SendEmailArgs) (SendEmailResult, error)
 	// SendMessage replies on a captured channel conversation. It takes no
 	// addressee: the recipient is the person the anchor conversation is with,
 	// resolved server-side, so a reply can only reach the human who opened it.
@@ -61,26 +66,23 @@ type SendMessageArgs struct {
 }
 
 type BookMeetingArgs struct {
-	HostUserID *ids.UUID `json:"host_user_id"`
-	Start      time.Time `json:"start"`
-	End        time.Time `json:"end"`
-	Subject    string    `json:"subject"`
-	Links      []struct {
-		EntityType string   `json:"entity_type"`
-		EntityID   ids.UUID `json:"entity_id"`
-	} `json:"links"`
+	HostUserID *ids.UUID    `json:"host_user_id"`
+	Start      time.Time    `json:"start"`
+	End        time.Time    `json:"end"`
+	Subject    string       `json:"subject"`
+	Links      []RecordLink `json:"links"`
 }
 
-// RegisterCommsTools wires the five verbs over the injected seam. The provider
-// is the record reader the three 🟡 verbs stage against; draft_email and
+// RegisterCommsTools wires the six verbs over the injected seam. The provider
+// is the record reader the four 🟡 verbs stage against; draft_email and
 // check_availability propose nothing durable and never read it.
 //
 // A nil comms seam is a legal composition and registers nothing — the verbs
-// simply are not offered. A nil provider is NOT: the three 🟡 verbs would
+// simply are not offered. A nil provider is NOT: the four 🟡 verbs would
 // register, advertise themselves on tools/list, and then dereference it the
 // first time a human-approvable call was staged. Failing at wiring time is the
 // difference between a boot that does not start and a surface that offers
-// three sends it panics on, so this asserts rather than silently dropping them
+// four sends it panics on, so this asserts rather than silently dropping them
 // — a comms surface missing exactly its outbound verbs is the confusing
 // middle, not a safe default.
 func RegisterCommsTools(r *Registry, comms Comms, p datasource.SystemOfRecordProvider) {
@@ -89,10 +91,11 @@ func RegisterCommsTools(r *Registry, comms Comms, p datasource.SystemOfRecordPro
 	}
 	if p == nil {
 		//craft:ignore panic-in-domain composition-time wiring assertion — fires only while cmd wiring runs, never on a request path
-		panic("crmagents: RegisterCommsTools needs a record provider — send_email, send_message and book_meeting read the row they stage against")
+		panic("crmagents: RegisterCommsTools needs a record provider — the confirm-first sends, the account-started send and book_meeting all read the records they stage against")
 	}
 	r.Register(draftEmailTool{comms: comms})
 	r.Register(sendEmailTool{comms: comms, p: p})
+	r.Register(sendAccountEmailTool{comms: comms, p: p})
 	r.Register(sendMessageTool{comms: comms, p: p})
 	r.Register(checkAvailability{comms: comms})
 	r.Register(bookMeetingTool{comms: comms, p: p})

--- a/backend/internal/modules/agents/tools_comms_test.go
+++ b/backend/internal/modules/agents/tools_comms_test.go
@@ -28,6 +28,9 @@ type recordingComms struct {
 	// booked records that the seam was reached at all, so a test can assert a
 	// refusal stopped SHORT of it rather than merely returning an error.
 	booked *BookMeetingArgs
+	// accountSent is the same evidence for the account-started send: the links
+	// the seam was reached with, nil when the call never got that far.
+	accountSent []RecordLink
 }
 
 func (c *recordingComms) DraftEmail(context.Context, ids.UUID, string) (string, string, error) {
@@ -36,6 +39,11 @@ func (c *recordingComms) DraftEmail(context.Context, ids.UUID, string) (string, 
 
 func (c *recordingComms) SendEmail(context.Context, ids.UUID, SendEmailArgs) (SendEmailResult, error) {
 	return SendEmailResult{}, nil
+}
+
+func (c *recordingComms) SendAccountEmail(_ context.Context, links []RecordLink, _ SendEmailArgs) (SendEmailResult, error) {
+	c.accountSent = links
+	return SendEmailResult{ActivityID: ids.New[ids.ActivityKind]().UUID, Status: "accepted"}, nil
 }
 
 func (c *recordingComms) Availability(context.Context, *ids.UUID, time.Time, time.Time, int) (AvailabilityResult, error) {
@@ -441,7 +449,7 @@ func TestAStagedSummaryNamesEveryArgumentItReleases(t *testing.T) {
 			Start: time.Date(2026, 8, 10, 9, 0, 0, 0, time.UTC),
 			End:   time.Date(2026, 8, 10, 9, 30, 0, 0, time.UTC),
 		}
-		got := describeBooking(args, []bookingLink{
+		got := describeBooking(args, []RecordLink{
 			{EntityType: "deal", EntityID: deal}, {EntityType: "organization", EntityID: org},
 		})
 		for _, want := range []string{host.String(), "2 record(s)", `"Review"`} {

--- a/backend/internal/modules/agents/tools_scheduling.go
+++ b/backend/internal/modules/agents/tools_scheduling.go
@@ -99,19 +99,17 @@ func (t bookMeetingTool) Spec() mcp.ToolSpec {
 // StageInfo puts a refused booking in the inbox instead of dead-ending it.
 //
 // A booking anchors on no existing row, so unlike the two send verbs it has no
-// single target handed to it. What it does have is its links, and those are
-// records: EVERY one is read and refused if its authority lives in another
-// system, because redemption's version pin reads our own tables and a
-// mirror-held link has no row there — the same un-releasable approval
-// refuseStagingElsewhere exists to prevent, reached through a different door.
-// Checking every link rather than the one displayed is deliberate: a booking
-// with a local deal and a mirrored organization is exactly the case a
-// first-link-only check would wave through.
+// single target handed to it. What it does have is its links, and every one of
+// them is read through readStageableLinks — the shared rule for a call that
+// names its own records.
 //
-// The first link becomes the displayed target and supplies the pin. A booking
-// with NO links is refused before any of that: crm.yaml requires them, and a
-// staged approval with no target is a human asked to release a meeting attached
-// to nothing — nothing to show them, and no version to pin it against.
+// The first link becomes the displayed target and supplies the pin, which is
+// what makes a booking's staged row bind to a record rather than float free: a
+// meeting is a commitment ON that record, and the human deciding it is the one
+// whose scope reaches it. A booking with NO links is refused before any of
+// that: crm.yaml requires them, and a staged approval with no target is a human
+// asked to release a meeting attached to nothing — nothing to show them, and no
+// version to pin it against.
 func (t bookMeetingTool) StageInfo(ctx context.Context, in json.RawMessage) (StageInfo, error) {
 	var args BookMeetingArgs
 	if err := decodeArgs(in, &args); err != nil {
@@ -129,24 +127,20 @@ func (t bookMeetingTool) StageInfo(ctx context.Context, in json.RawMessage) (Sta
 	if err := requireBookingLinks(args); err != nil {
 		return StageInfo{}, err
 	}
-	links, err := bookingLinks(args)
+	links, err := uniqueRecordLinks(args.Links)
 	if err != nil {
 		return StageInfo{}, err
 	}
-	info := StageInfo{Summary: describeBooking(args, links)}
-	for i, link := range links {
-		rec, readErr := t.p.Read(ctx, datasource.EntityRef{Type: datasource.EntityType(link.EntityType), ID: link.EntityID})
-		if readErr != nil {
-			return StageInfo{}, readErr
-		}
-		if err := refuseStagingElsewhere(rec); err != nil {
-			return StageInfo{}, err
-		}
-		if i == 0 {
-			info.TargetType, info.TargetID, info.TargetVersion = link.EntityType, link.EntityID, &rec.Version
-		}
+	records, err := readStageableLinks(ctx, t.p, links)
+	if err != nil {
+		return StageInfo{}, err
 	}
-	return info, nil
+	return StageInfo{
+		TargetType:    links[0].EntityType,
+		TargetID:      links[0].EntityID,
+		TargetVersion: &records[0].Version,
+		Summary:       describeBooking(args, links),
+	}, nil
 }
 
 // requireBookingLinks enforces what the schema states: at least one link.
@@ -165,45 +159,6 @@ func requireBookingLinks(args BookMeetingArgs) error {
 			"and one attached to nothing cannot be approved against a record")}
 }
 
-// maxBookingLinks bounds how many records one booking may attach to.
-//
-// This is a REQUEST BOUND, not a modelling opinion. Each link costs its own
-// row-scoped provider read in its own transaction, and the array is chosen
-// freely by the caller: at the 1 MiB body limit a single tools/call could
-// carry ~15,000 of them, spending tens of thousands of queries against a
-// 16-connection pool inside one request — before any human has approved
-// anything, since staging runs on the refusal path. A meeting that genuinely
-// touches more records than this is not a meeting.
-const maxBookingLinks = 25
-
-// bookingLinks validates and de-duplicates the links a booking attaches to.
-// Deduplicating first matters as much as the cap: the same id repeated is the
-// cheapest way to turn one call into N reads, and it is also just a caller
-// mistake worth not charging for twice.
-func bookingLinks(args BookMeetingArgs) ([]bookingLink, error) {
-	if len(args.Links) > maxBookingLinks {
-		return nil, &BadArgsError{Cause: fmt.Errorf(
-			"a booking may attach to at most %d records; this call names %d", maxBookingLinks, len(args.Links))}
-	}
-	seen := make(map[bookingLink]struct{}, len(args.Links))
-	unique := make([]bookingLink, 0, len(args.Links))
-	for _, l := range args.Links {
-		link := bookingLink{EntityType: l.EntityType, EntityID: l.EntityID}
-		if _, dup := seen[link]; dup {
-			continue
-		}
-		seen[link] = struct{}{}
-		unique = append(unique, link)
-	}
-	return unique, nil
-}
-
-// bookingLink is one (type, id) pair, comparable so it can key the dedupe set.
-type bookingLink struct {
-	EntityType string
-	EntityID   ids.UUID
-}
-
 // describeBooking is the one line the inbox shows.
 //
 // It names every argument that changes what gets released — the slot, the
@@ -216,7 +171,7 @@ type bookingLink struct {
 // The subject is the agent's own text, so it is quoted rather than run into
 // the sentence; the approvals engine sanitizes every summary at the single
 // staging path regardless.
-func describeBooking(args BookMeetingArgs, links []bookingLink) string {
+func describeBooking(args BookMeetingArgs, links []RecordLink) string {
 	subject := args.Subject
 	if strings.TrimSpace(subject) == "" {
 		subject = "(no subject)"

--- a/backend/internal/modules/agents/tools_scheduling.go
+++ b/backend/internal/modules/agents/tools_scheduling.go
@@ -194,11 +194,19 @@ func (t bookMeetingTool) Handle(ctx context.Context, in json.RawMessage) (json.R
 	}
 	// Both doors, not just staging. This one is reached with an approval already
 	// redeemed, so a call that skipped StageInfo would otherwise execute a
-	// booking the schema says is impossible.
+	// booking the schema says is impossible — and the cap and the dedupe are
+	// part of that: the human approved "attached to N record(s)" as StageInfo
+	// counted them, and a booking that reaches the seam with the raw list is one
+	// whose approval was read against a different reach than the one it takes.
 	if err := requireBookingLinks(args); err != nil {
 		return nil, err
 	}
-	for _, link := range args.Links {
+	links, err := uniqueRecordLinks(args.Links)
+	if err != nil {
+		return nil, err
+	}
+	args.Links = links
+	for _, link := range links {
 		noteEvidence(ctx, datasource.EntityType(link.EntityType), link.EntityID)
 	}
 	return t.comms.BookMeeting(ctx, args)

--- a/backend/internal/modules/agents/tools_scheduling.go
+++ b/backend/internal/modules/agents/tools_scheduling.go
@@ -115,14 +115,8 @@ func (t bookMeetingTool) StageInfo(ctx context.Context, in json.RawMessage) (Sta
 	if err := decodeArgs(in, &args); err != nil {
 		return StageInfo{}, err
 	}
-	// Refuse here what the store refuses at execution, for the same reason the
-	// mail send does: a human should not be asked to approve a meeting that
-	// ends before it starts, spend the one-shot approval on it, and only then
-	// be told it was never bookable.
-	if !args.End.After(args.Start) {
-		return StageInfo{}, &BadArgsError{Cause: fmt.Errorf(
-			"`end` (%s) does not follow `start` (%s); a booking with no duration would be refused after approval",
-			args.End.Format(time.RFC3339), args.Start.Format(time.RFC3339))}
+	if err := requireBookingWindow(args); err != nil {
+		return StageInfo{}, err
 	}
 	if err := requireBookingLinks(args); err != nil {
 		return StageInfo{}, err
@@ -141,6 +135,21 @@ func (t bookMeetingTool) StageInfo(ctx context.Context, in json.RawMessage) (Sta
 		TargetVersion: &records[0].Version,
 		Summary:       describeBooking(args, links),
 	}, nil
+}
+
+// requireBookingWindow refuses a booking that ends before it starts.
+//
+// The store refuses it too (errBookingEndNotAfterStart), which is why this is
+// not a correctness hole — but reaching THAT refusal costs the human's approval
+// on the way past, since redemption is consumed before the handler runs. So
+// both doors ask first, the same rule the link checks below follow.
+func requireBookingWindow(args BookMeetingArgs) error {
+	if args.End.After(args.Start) {
+		return nil
+	}
+	return &BadArgsError{Cause: fmt.Errorf(
+		"`end` (%s) does not follow `start` (%s); a booking with no duration would be refused after approval",
+		args.End.Format(time.RFC3339), args.Start.Format(time.RFC3339))}
 }
 
 // requireBookingLinks enforces what the schema states: at least one link.
@@ -198,6 +207,9 @@ func (t bookMeetingTool) Handle(ctx context.Context, in json.RawMessage) (json.R
 	// part of that: the human approved "attached to N record(s)" as StageInfo
 	// counted them, and a booking that reaches the seam with the raw list is one
 	// whose approval was read against a different reach than the one it takes.
+	if err := requireBookingWindow(args); err != nil {
+		return nil, err
+	}
 	if err := requireBookingLinks(args); err != nil {
 		return nil, err
 	}

--- a/backend/internal/modules/agents/tools_scheduling_test.go
+++ b/backend/internal/modules/agents/tools_scheduling_test.go
@@ -98,7 +98,7 @@ func TestABookingIsBoundedAndDeduplicatedBeforeItReadsAnything(t *testing.T) {
 	slot := `"start":"2026-08-10T09:00:00Z","end":"2026-08-10T09:30:00Z"`
 
 	t.Run("refuses more links than a meeting could mean", func(t *testing.T) {
-		links := make([]string, maxBookingLinks+1)
+		links := make([]string, maxRecordLinks+1)
 		for i := range links {
 			links[i] = fmt.Sprintf(`{"entity_type":"deal","entity_id":%q}`, ids.NewV7())
 		}

--- a/backend/internal/modules/agents/tools_scheduling_test.go
+++ b/backend/internal/modules/agents/tools_scheduling_test.go
@@ -130,3 +130,34 @@ func TestABookingIsBoundedAndDeduplicatedBeforeItReadsAnything(t *testing.T) {
 		}
 	})
 }
+
+// A booking that ends before it starts is refused at BOTH doors. The store
+// refuses it as well, but reaching that refusal costs the human's approval on
+// the way past: redemption is consumed before the handler runs.
+func TestABookingWithNoDurationIsRefusedAtBothDoors(t *testing.T) {
+	const backwards = `{"start":"2026-08-03T09:30:00Z","end":"2026-08-03T09:00:00Z",` +
+		`"links":[{"entity_type":"deal","entity_id":"019ff000-0000-7000-8000-000000000001"}]}`
+	comms := &recordingComms{}
+	tool := bookMeetingTool{comms: comms, p: &multiLinkProvider{}}
+	doors := map[string]func() error{
+		"staging": func() error {
+			_, err := tool.StageInfo(context.Background(), json.RawMessage(backwards))
+			return err
+		},
+		"after an approval was redeemed": func() error {
+			_, err := tool.Handle(withApprovalRedeemed(sendCtx(), 0, false), json.RawMessage(backwards))
+			return err
+		},
+	}
+	for door, call := range doors {
+		t.Run(door, func(t *testing.T) {
+			var bad *BadArgsError
+			if err := call(); !errors.As(err, &bad) {
+				t.Fatalf("err = %v, want a BadArgsError naming the window", err)
+			}
+			if comms.booked != nil {
+				t.Error("a booking with no duration reached the comms seam")
+			}
+		})
+	}
+}

--- a/backend/internal/modules/approvals/authority.go
+++ b/backend/internal/modules/approvals/authority.go
@@ -86,6 +86,14 @@ var decisionGrants = map[string][]grantRequirement{
 	// time; the approver needs the write grant, the consent gate runs in
 	// the handler regardless of who approved.
 	"send_email": {{objectActivity, principal.ActionCreate}},
+	// send_account_email is the same send from the other origin (ADR-0087 §6):
+	// it starts a conversation instead of continuing one, and the effect it
+	// stages is the identical activity write. The records the message is filed
+	// under are named rather than inherited, and those are row-scope probed at
+	// staging and again at insert — they are a question about the STAGER's
+	// reach, not about the approver's, so they add nothing here. Governed
+	// identically to the reply means exactly this grant and no other.
+	"send_account_email": {{objectActivity, principal.ActionCreate}},
 	// send_message is the same effect on a messaging channel: an activity
 	// write, with the consent gate running in the handler whoever approved it.
 	"send_message": {{objectActivity, principal.ActionCreate}},

--- a/docs/reference/mcp-info.json
+++ b/docs/reference/mcp-info.json
@@ -8,11 +8,11 @@
     "enrich"
   ],
   "totals": {
-    "tools": 37,
+    "tools": 38,
     "resources": 8,
-    "tool_catalog_bytes": 105004,
+    "tool_catalog_bytes": 108218,
     "resource_catalog_bytes": 3108,
-    "approx_wire_tokens_total": 27028,
+    "approx_wire_tokens_total": 27831,
     "largest_tool_bytes": 4151,
     "largest_tool": "run_report"
   },
@@ -5610,6 +5610,189 @@
         "annotations": {
           "openWorldHint": true,
           "readOnlyHint": false,
+          "title": "Start an email conversation from a record"
+        },
+        "description": "Put a mail on the wire to a real recipient, from this workspace, starting a new conversation rather than answering one, and file it on the records it is about. It sends EXACTLY the subject and body it is given and composes nothing. It needs at least one link naming the records the conversation belongs to and is refused without one. Every recipient must have granted the consent purpose the call names, and a person approves the send before it leaves — a message leaving the workspace cannot be recalled. Use send_email when the message answers a conversation already recorded here: that keeps the reply on its own thread, where this starts a separate one beside it. Keep the staged approval id and re-send the identical text and links: the approval is bound to that exact message. The activity_id that comes back is the new conversation. (Governance: a person approves every call before it runs; requires passport scope \"send\".)",
+        "inputSchema": {
+          "additionalProperties": false,
+          "properties": {
+            "approval_id": {
+              "description": "Set on retry after a human approved the staged call",
+              "format": "uuid",
+              "type": "string"
+            },
+            "body": {
+              "type": "string"
+            },
+            "cc": {
+              "items": {
+                "format": "email",
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "consent_purpose": {
+              "description": "Purpose key the recipients must have granted",
+              "type": "string"
+            },
+            "idempotency_key": {
+              "description": "Optional. Repeating a call under the same key returns the first result instead of acting twice; different arguments under one key are refused.",
+              "maxLength": 255,
+              "type": "string"
+            },
+            "links": {
+              "description": "The records this conversation is filed under; at least one. The send is refused without it.",
+              "items": {
+                "additionalProperties": false,
+                "properties": {
+                  "entity_id": {
+                    "format": "uuid",
+                    "type": "string"
+                  },
+                  "entity_type": {
+                    "enum": [
+                      "person",
+                      "organization",
+                      "deal",
+                      "lead"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "entity_type",
+                  "entity_id"
+                ],
+                "type": "object"
+              },
+              "maxItems": 25,
+              "minItems": 1,
+              "type": "array"
+            },
+            "subject": {
+              "type": "string"
+            },
+            "to": {
+              "items": {
+                "format": "email",
+                "type": "string"
+              },
+              "minItems": 1,
+              "type": "array"
+            }
+          },
+          "required": [
+            "to",
+            "subject",
+            "body",
+            "consent_purpose",
+            "links"
+          ],
+          "type": "object"
+        },
+        "name": "send_account_email",
+        "outputSchema": {
+          "properties": {
+            "data": {
+              "properties": {
+                "activity_id": {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                "status": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "activity_id",
+                "status"
+              ],
+              "type": "object"
+            },
+            "evidence": {
+              "items": {
+                "properties": {
+                  "captured_by": {
+                    "type": "string"
+                  },
+                  "record_id": {
+                    "format": "uuid",
+                    "type": "string"
+                  },
+                  "record_type": {
+                    "type": "string"
+                  },
+                  "source": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "record_id",
+                  "record_type"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "freshness": {
+              "properties": {
+                "authoritative": {
+                  "type": "boolean"
+                },
+                "last_synced_at": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "authoritative"
+              ],
+              "type": "object"
+            },
+            "schema_version": {
+              "type": "string"
+            },
+            "trace_id": {
+              "type": "string"
+            },
+            "trust": {
+              "type": "string"
+            },
+            "warnings": {
+              "items": {
+                "properties": {
+                  "code": {
+                    "type": "string"
+                  },
+                  "message": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "code",
+                  "message"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "data",
+            "evidence",
+            "freshness",
+            "schema_version",
+            "trace_id",
+            "trust",
+            "warnings"
+          ],
+          "type": "object"
+        },
+        "title": "Start an email conversation from a record"
+      },
+      {
+        "annotations": {
+          "openWorldHint": true,
+          "readOnlyHint": false,
           "title": "Send an email"
         },
         "description": "Put a mail on the wire to a real recipient, from this workspace, and record it on the thread it belongs to. It sends EXACTLY the subject and body it is given and composes nothing, so it is not the tool to reach for when the message does not exist yet. Every recipient must have granted the consent purpose the call names, and a person approves the send before it leaves — a message leaving the workspace cannot be recalled. Use draft_email first to produce the message and let it be read, and send_message when the conversation is on a chat channel rather than mail. Send the same activity_id, subject and body the draft produced, and keep the staged approval id: the approval is bound to that exact message, so changed text needs a new approval. (Governance: a person approves every call before it runs; requires passport scope \"send\".)",
@@ -6543,7 +6726,7 @@
     "ttlMs": 60000
   },
   "documents": {
-    "margince://capabilities": "{\"version\":\"1\",\"governance\":{\"scopes_held\":[\"draft\",\"enrich\",\"read\",\"send\",\"write\"],\"model\":\"A call either executes under this passport's authority or stages an approval a human decides. An agent can never exceed the human who granted the passport, and every call is re-authorised at the moment it runs, so a revoked grant binds mid-session.\",\"host_confirmation\":\"A confirmation your own client shows the user is NOT one of these approvals. A staged call is decided in Margince and returns its outcome here.\"},\"verbs\":{\"offered\":37,\"execute_directly\":[\"account_coverage\",\"at_risk_relationships\",\"catch_me_up_on\",\"check_availability\",\"create_record\",\"draft_email\",\"draft_follow_ups_for\",\"intro_path_to\",\"list_pipelines\",\"list_records\",\"log_activity\",\"prep_for_meeting\",\"prepare_handoff\",\"qualify_lead\",\"query_workspace\",\"read_brief\",\"read_record\",\"relink_activity\",\"resolve_entities\",\"review_commitments\",\"run_report\",\"search_context\",\"search_records\",\"update_record\",\"whats_slipping_this_week\",\"who_knows\"],\"stage_for_approval\":[\"advance_project_phase\",\"archive_record\",\"book_meeting\",\"disqualify_lead\",\"enrich\",\"merge_records\",\"promote_lead\",\"send_email\",\"send_message\"],\"decided_per_call\":[\"advance_deal\",\"progress_deal\"],\"decided_per_call_reason\":\"The tier depends on the arguments — the same verb can execute or stage depending on what it is asked to do.\"}}",
+    "margince://capabilities": "{\"version\":\"1\",\"governance\":{\"scopes_held\":[\"draft\",\"enrich\",\"read\",\"send\",\"write\"],\"model\":\"A call either executes under this passport's authority or stages an approval a human decides. An agent can never exceed the human who granted the passport, and every call is re-authorised at the moment it runs, so a revoked grant binds mid-session.\",\"host_confirmation\":\"A confirmation your own client shows the user is NOT one of these approvals. A staged call is decided in Margince and returns its outcome here.\"},\"verbs\":{\"offered\":38,\"execute_directly\":[\"account_coverage\",\"at_risk_relationships\",\"catch_me_up_on\",\"check_availability\",\"create_record\",\"draft_email\",\"draft_follow_ups_for\",\"intro_path_to\",\"list_pipelines\",\"list_records\",\"log_activity\",\"prep_for_meeting\",\"prepare_handoff\",\"qualify_lead\",\"query_workspace\",\"read_brief\",\"read_record\",\"relink_activity\",\"resolve_entities\",\"review_commitments\",\"run_report\",\"search_context\",\"search_records\",\"update_record\",\"whats_slipping_this_week\",\"who_knows\"],\"stage_for_approval\":[\"advance_project_phase\",\"archive_record\",\"book_meeting\",\"disqualify_lead\",\"enrich\",\"merge_records\",\"promote_lead\",\"send_account_email\",\"send_email\",\"send_message\"],\"decided_per_call\":[\"advance_deal\",\"progress_deal\"],\"decided_per_call_reason\":\"The tier depends on the arguments — the same verb can execute or stage depending on what it is asked to do.\"}}",
     "margince://schema/query": "{\"version\":\"v1\",\"grammar\":{\"predicates\":\"{\\\"field\\\": \\u003cname below\\u003e, \\\"op\\\": \\u003cop the field admits\\u003e, \\\"value\\\": \\u003coperand\\u003e} — or \\\"values\\\": [...] for \\\"in\\\". Clauses are combined with AND.\",\"semantic_target\":\"\\\"similar_to\\\": \\u003cfree text\\u003e — one similarity clause, ranked by the hybrid retriever.\",\"traversal\":\"\\\"traverse\\\": {\\\"relation\\\": \\u003crelation below\\u003e, \\\"where\\\": [...]} — exactly one hop. A second hop is refused; ask it as its own query.\",\"limit\":\"\\\"limit\\\": 1..200; omit for the default page.\",\"refusal\":\"Anything outside this vocabulary is refused with a typed clarification naming what was not understood. Nothing is coerced, and no plan is narrowed to the part that was recognised.\"},\"targets\":[],\"unavailable\":[{\"op\":\"within_radius\",\"answers\":\"distance_ranking_unavailable\",\"because\":\"records carry no normalized coordinates yet; ask for a city or region as an exact predicate instead.\"}]}",
     "margince://schema/record-fields": "{\"version\":\"1\",\"notation\":\"A key with no `?` is REQUIRED by the contract; `?` marks one the body may omit. A name not listed is not a field: it is refused by name, never stored silently.\",\"create_record\":{\"fields\":{\"activity\":\"{assignee_id?: uuid, body?: string, direction?: \\\"inbound\\\"|\\\"outbound\\\", due_at?: rfc3339, duration_seconds?: integer, kind: \\\"email\\\"|\\\"call\\\"|\\\"meeting\\\"|\\\"note\\\"|\\\"task\\\"|\\\"whatsapp\\\"|\\\"telegram\\\", links?: [{entity_id: uuid, entity_type: \\\"person\\\"|\\\"organization\\\"|\\\"deal\\\"|\\\"lead\\\"}], meeting_status?: \\\"booked\\\"|\\\"held\\\"|\\\"no_show\\\"|\\\"canceled\\\", occurred_at?: rfc3339, raw?: object, remind_at?: rfc3339, source?: string, source_id?: string, source_system?: string, subject?: string}\",\"deal\":\"{amount_minor?: integer, currency?: string, expected_close_date?: YYYY-MM-DD, name: string, organization_id?: uuid, owner_id?: uuid, pipeline_id: uuid, project_id?: uuid, source?: string, stage_id: uuid}\",\"lead\":\"{candidate_org_key?: string, company_name?: string, email?: email, full_name?: string, linkedin_url?: string, owner_id?: uuid, project_id?: uuid, source?: string, source_id?: string, source_system?: string, status?: \\\"new\\\"|\\\"working\\\"|\\\"promoted\\\"|\\\"disqualified\\\", title?: string}\",\"organization\":\"{address?: {city?: string, country?: string, line1?: string, line2?: string, postal_code?: string, region?: string}, description?: string, display_name: string, domains?: [{domain: string, is_primary?: boolean}], industry?: string, legal_name?: string, owner_id?: uuid, parent_org_id?: uuid, size_band?: \\\"1-10\\\"|\\\"11-50\\\"|\\\"51-200\\\"|\\\"201-500\\\"|\\\"501-1000\\\"|\\\"1001-5000\\\"|\\\"5000+\\\", source?: string}\",\"person\":\"{address?: {city?: string, country?: string, line1?: string, line2?: string, postal_code?: string, region?: string}, emails?: [{email: email, email_type?: \\\"work\\\"|\\\"personal\\\"|\\\"other\\\", is_primary?: boolean, position?: integer}], first_name?: string, full_name: string, last_name?: string, owner_id?: uuid, phones?: [{is_primary?: boolean, phone: string, phone_type?: \\\"work\\\"|\\\"mobile\\\"|\\\"home\\\"|\\\"other\\\", position?: integer}], social?: object, source?: string, title?: string}\",\"project\":\"{description?: string, key?: string, name: string, organization_id: uuid, owner_id?: uuid, source?: string, started_at?: YYYY-MM-DD, target_end_date?: YYYY-MM-DD}\",\"relationship\":\"{counterparty_org_id?: uuid, deal_id?: uuid, ended_at?: YYYY-MM-DD, is_current_primary?: boolean, kind: \\\"employment\\\"|\\\"deal_stakeholder\\\"|\\\"project_stakeholder\\\"|\\\"partner_of\\\"|\\\"referred_by\\\"|\\\"co_sell_with\\\", organization_id?: uuid, person_id?: uuid, project_id?: uuid, role?: string, source?: string, started_at?: YYYY-MM-DD}\"},\"notes\":[\"A task is record_type=activity with kind=task.\",\"`source` is accepted but overwritten — this surface stamps its own provenance.\",\"A deal's `pipeline_id` and `stage_id` come from list_pipelines — nothing else on this surface yields them, and neither is defaultable.\",\"A person's employer is a relationship, not a field on the person: record_type=relationship with kind=employment, person_id and organization_id. Each kind REQUIRES its own endpoint pair, and a wrong pair is refused by name — employment: person + organization; deal_stakeholder: deal + person; project_stakeholder: project + person; partner_of, referred_by and co_sell_with: organization + counterparty_org_id. An edge is not searchable, so keep the id a relationship write returns.\",\"An activity is not searchable — search_records does not serve it — so keep the id an activity write returns; read_record answers it by that id.\",\"Extra keys must be named cf_\\u003cslug\\u003e and are read as custom-field values; any other key is REFUSED by name, so an unknown field is never a silent loss. A cf_ key whose custom field is not ACTIVE in this workspace is the one that is: the write reports success and drops the value, so re-read the record if you are unsure a cf_ value landed.\",\"No custom fields on activity or relationship: those types carry no cf_ values at all, so a cf_ key there is refused rather than stored.\"]},\"update_record\":{\"fields\":{\"activity\":\"{assignee_id?: uuid, body?: string, due_at?: rfc3339, is_done?: boolean, occurred_at?: rfc3339, remind_at?: rfc3339, subject?: string}\",\"deal\":\"{amount_minor?: integer, currency?: string, expected_close_date?: YYYY-MM-DD, forecast_category?: \\\"commit\\\"|\\\"best_case\\\"|\\\"pipeline\\\"|\\\"omitted\\\", fx_rate_date?: YYYY-MM-DD, fx_rate_to_base?: string, lost_reason?: string, name?: string, organization_id?: uuid, owner_id?: uuid, partner_org_id?: uuid, project_id?: uuid, status?: \\\"open\\\"|\\\"won\\\"|\\\"lost\\\", wait_until?: YYYY-MM-DD}\",\"lead\":\"{candidate_org_key?: string, company_name?: string, email?: email, full_name?: string, owner_id?: uuid, project_id?: uuid, score?: integer, score_override_reason?: string, status?: \\\"new\\\"|\\\"working\\\", title?: string}\",\"organization\":\"{address?: {city?: string, country?: string, line1?: string, line2?: string, postal_code?: string, region?: string}, description?: string, display_name?: string, domains?: [{domain: string, is_primary?: boolean}], industry?: string, legal_name?: string, lifecycle?: \\\"unknown\\\"|\\\"target\\\"|\\\"prospect\\\"|\\\"opportunity\\\"|\\\"customer\\\"|\\\"former_customer\\\"|\\\"disqualified\\\", linkedin_url?: string, owner_id?: uuid, parent_org_id?: uuid, relationship_types?: [\\\"customer\\\"|\\\"partner\\\"|\\\"supplier\\\"|\\\"investor\\\"|\\\"portfolio_company\\\"|\\\"competitor\\\"|\\\"other\\\"], size_band?: \\\"1-10\\\"|\\\"11-50\\\"|\\\"51-200\\\"|\\\"201-500\\\"|\\\"501-1000\\\"|\\\"1001-5000\\\"|\\\"5000+\\\"}\",\"person\":\"{address?: {city?: string, country?: string, line1?: string, line2?: string, postal_code?: string, region?: string}, first_name?: string, full_name?: string, last_name?: string, owner_id?: uuid, social?: object, title?: string}\",\"project\":\"{description?: string, ended_at?: YYYY-MM-DD, key?: string, name?: string, owner_id?: uuid, started_at?: YYYY-MM-DD, target_end_date?: YYYY-MM-DD}\",\"relationship\":\"{ended_at?: YYYY-MM-DD, is_current_primary?: boolean, role?: string, started_at?: YYYY-MM-DD}\"},\"notes\":[\"A task is record_type=activity with kind=task.\",\"A person's employer is NOT a field here: employment is a relationship, created and archived as record_type=relationship — its endpoints are what it IS, so they cannot be patched.\",\"An activity's links are NOT patchable, here or by any tool on this surface: this write changes what an activity says, never who it is about.\",\"Extra keys must be named cf_\\u003cslug\\u003e and are read as custom-field values; any other key is REFUSED by name, so an unknown field is never a silent loss. A cf_ key whose custom field is not ACTIVE in this workspace is the one that is: the write reports success and drops the value, so re-read the record if you are unsure a cf_ value landed.\",\"No custom fields on activity or relationship: those types carry no cf_ values at all, so a cf_ key there is refused rather than stored.\"]}}",
     "ui://margince/account-brief.html": "(not published here: a ui:// document is fetched from a web origin at boot, so its bytes are a property of the deployment rather than of this build)",

--- a/docs/reference/mcp-info.md
+++ b/docs/reference/mcp-info.md
@@ -11,11 +11,11 @@ receives it. This page is rendered from that file.
 
 | | |
 |---|---:|
-| Tools | 37 |
+| Tools | 38 |
 | Resources | 8 |
-| Tool catalog | 102.5 KB |
+| Tool catalog | 105.7 KB |
 | Resource catalog | 3.0 KB |
-| Approx. wire tokens | 27028 |
+| Approx. wire tokens | 27831 |
 | Largest tool | `run_report` (4.1 KB) |
 | Scopes rendered | `read`, `draft`, `write`, `send`, `enrich` |
 
@@ -37,7 +37,7 @@ budget in `agenttooldescriptions_test.go`.
 - [`ui://margince/handoff.html`](#handoff_view) — Delivery handoff
 - [`ui://margince/pipeline-review.html`](#pipeline_review_view) — Pipeline review
 
-### Tools (37)
+### Tools (38)
 
 | Tool | What it is for | Read-only | View | Size |
 |---|---|:-:|---|---:|
@@ -73,6 +73,7 @@ budget in `agenttooldescriptions_test.go`.
 | [`run_report`](#run_report) | Run a report | yes |  | 4.0 KB |
 | [`search_context`](#search_context) | Search for relevant material | yes |  | 3.0 KB |
 | [`search_records`](#search_records) | Search records | yes |  | 2.5 KB |
+| [`send_account_email`](#send_account_email) | Start an email conversation from a record |  |  | 3.1 KB |
 | [`send_email`](#send_email) | Send an email |  |  | 2.6 KB |
 | [`send_message`](#send_message) | Reply on a channel conversation |  |  | 2.4 KB |
 | [`update_record`](#update_record) | Update a record |  |  | 3.9 KB |
@@ -6035,6 +6036,199 @@ Find people, organizations, deals, leads and projects when you know roughly what
       },
       "required": [
         "records"
+      ],
+      "type": "object"
+    },
+    "evidence": {
+      "items": {
+        "properties": {
+          "captured_by": {
+            "type": "string"
+          },
+          "record_id": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "record_type": {
+            "type": "string"
+          },
+          "source": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "record_id",
+          "record_type"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "freshness": {
+      "properties": {
+        "authoritative": {
+          "type": "boolean"
+        },
+        "last_synced_at": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "authoritative"
+      ],
+      "type": "object"
+    },
+    "schema_version": {
+      "type": "string"
+    },
+    "trace_id": {
+      "type": "string"
+    },
+    "trust": {
+      "type": "string"
+    },
+    "warnings": {
+      "items": {
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    }
+  },
+  "required": [
+    "data",
+    "evidence",
+    "freshness",
+    "schema_version",
+    "trace_id",
+    "trust",
+    "warnings"
+  ],
+  "type": "object"
+}
+```
+
+</details>
+
+### send_account_email
+
+**Start an email conversation from a record**
+
+Put a mail on the wire to a real recipient, from this workspace, starting a new conversation rather than answering one, and file it on the records it is about. It sends EXACTLY the subject and body it is given and composes nothing. It needs at least one link naming the records the conversation belongs to and is refused without one. Every recipient must have granted the consent purpose the call names, and a person approves the send before it leaves — a message leaving the workspace cannot be recalled. Use send_email when the message answers a conversation already recorded here: that keeps the reply on its own thread, where this starts a separate one beside it. Keep the staged approval id and re-send the identical text and links: the approval is bound to that exact message. The activity_id that comes back is the new conversation. (Governance: a person approves every call before it runs; requires passport scope "send".)
+
+<details><summary>Input schema</summary>
+
+```json
+{
+  "additionalProperties": false,
+  "properties": {
+    "approval_id": {
+      "description": "Set on retry after a human approved the staged call",
+      "format": "uuid",
+      "type": "string"
+    },
+    "body": {
+      "type": "string"
+    },
+    "cc": {
+      "items": {
+        "format": "email",
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "consent_purpose": {
+      "description": "Purpose key the recipients must have granted",
+      "type": "string"
+    },
+    "idempotency_key": {
+      "description": "Optional. Repeating a call under the same key returns the first result instead of acting twice; different arguments under one key are refused.",
+      "maxLength": 255,
+      "type": "string"
+    },
+    "links": {
+      "description": "The records this conversation is filed under; at least one. The send is refused without it.",
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "entity_id": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "entity_type": {
+            "enum": [
+              "person",
+              "organization",
+              "deal",
+              "lead"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "entity_type",
+          "entity_id"
+        ],
+        "type": "object"
+      },
+      "maxItems": 25,
+      "minItems": 1,
+      "type": "array"
+    },
+    "subject": {
+      "type": "string"
+    },
+    "to": {
+      "items": {
+        "format": "email",
+        "type": "string"
+      },
+      "minItems": 1,
+      "type": "array"
+    }
+  },
+  "required": [
+    "to",
+    "subject",
+    "body",
+    "consent_purpose",
+    "links"
+  ],
+  "type": "object"
+}
+```
+
+</details>
+
+<details><summary>Output schema</summary>
+
+```json
+{
+  "properties": {
+    "data": {
+      "properties": {
+        "activity_id": {
+          "format": "uuid",
+          "type": "string"
+        },
+        "status": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "activity_id",
+        "status"
       ],
       "type": "object"
     },

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -2169,13 +2169,14 @@ export interface paths {
          *     - every entry in `links` is row-scope probed, so a record the caller cannot see is
          *       refused 404 exactly as reading it directly would be.
          *
-         *     HUMAN-ONLY for now, and deliberately so. ADR-0087 §6 gives the agent surface this
-         *     operation at the same 🟡 tier as the reply, but a 🟡 agent call STAGES for approval, and a
-         *     staged row is only releasable when its kind maps onto a grantable object in approvals.
-         *     Registering the verb without that mapping would advertise a tool whose every call clears
-         *     admission and is then refused at staging — a governed verb no agent can reach and no human
-         *     can release. The composer surface ships first; the agent tool follows with its
-         *     decision-grant mapping, tool spec and staging test as one change.
+         *     Governed identically to the reply, with no new authority (ADR-0087 §6): an agent caller
+         *     is confirm-first and stages for approval, a human caller's own action IS the approval
+         *     (ADR-0055). What is staged is a CREATE — this send answers no message, so there is no
+         *     anchor to name and no version to pin — and it is released by a human holding
+         *     `activity.create`, the grant `send_email` already asks of its approver. Whichever door
+         *     the call arrives at, every entry in `links` is row-scope probed before the message is
+         *     sent; over MCP that probe also runs at staging, so an agent naming a record it cannot
+         *     see is refused before a human is asked about it at all.
          */
         post: operations["sendAccountEmail"];
         delete?: never;
@@ -11060,7 +11061,8 @@ export interface components {
              *     optionally the person and deal it concerns. At least one is required: a message
              *     belonging to no record is one nobody will find again, which is the gap this
              *     operation exists to close. Each target is row-scope probed, so an id the caller
-             *     cannot see is refused 404.
+             *     cannot see is refused 404 — and each probe is its own query, so the list is bounded
+             *     at 25 (a message about more records than that is about none of them).
              */
             links: components["schemas"]["ActivityLinkInput"][];
         };
@@ -18581,6 +18583,16 @@ export interface operations {
                  *     to retry blind.
                  */
                 "Idempotency-Key"?: components["parameters"]["IdempotencyKey"];
+                /**
+                 * @description A signed, single-use approval token (see schema `ApprovalToken`) minted by
+                 *     POST /approvals/{id}/approve, authorizing exactly one 🟡 confirm-first operation. It is a
+                 *     compact JWS whose claims **bind** the token to a specific approval, effect, tenant and
+                 *     principal — it is NOT a bare opaque string (ADR-0036). The server rejects a token that is
+                 *     expired, already consumed, or whose `diff_hash`/`workspace_id`/`passport_id`/`tool` does not
+                 *     match the operation being executed (`403 code: approval_token_invalid`). Required when an
+                 *     AGENT principal invokes a 🟡 operation; a human's direct call is itself the approval.
+                 */
+                "X-Approval-Token"?: components["parameters"]["ApprovalToken"];
             };
             path?: never;
             cookie?: never;
@@ -18600,7 +18612,7 @@ export interface operations {
                     "application/json": components["schemas"]["Activity"];
                 };
             };
-            /** @description RBAC denied, or an agent principal presented a passport to a human-only operation. */
+            /** @description Approval token missing for a 🟡 send, or RBAC denied. */
             403: {
                 headers: {
                     [name: string]: unknown;

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -18805,7 +18805,11 @@ export interface operations {
                     end: string;
                     subject?: string;
                     attendee_emails?: string[];
-                    /** @description Entities to associate the resulting meeting activity with. */
+                    /**
+                     * @description Entities to associate the resulting meeting activity with. Each one is
+                     *     row-scope probed and written as its own row, so the list is bounded at 25 —
+                     *     the same bound the `book_meeting` tool applies before it stages.
+                     */
                     links: {
                         /** @enum {string} */
                         entity_type: "person" | "organization" | "deal" | "lead";


### PR DESCRIPTION
`POST /v1/emails` shipped human-only in #685. ADR-0087 §6 says the agent surface
gains it, at the same 🟡 tier as the reply it mirrors, governed identically and
with no new authority. That half is now built — the 38th tool on the catalog.

Closes #688.

## Why it shipped human-only, and what was actually missing

The issue records the attempt: annotating the operation `x-mcp-tool` failed four
root fitness tests. Re-checked against the tree, exactly ONE of them named a real
substrate gap — `send_account_email` had no `decisionGrants` entry, so every
agent call would have cleared admission and then been refused at staging: a verb
no agent can reach and no human can release. The other three failed because the
contract declared a verb no registered tool answered, which is the tool this PR
writes.

## What it stages, and why that shape

A CREATE: target type `activity`, **no target id, no version pin**. This send
answers no message, so it depends on no row — `approvals.settledByShape` settles
that shape on the object-read floor plus the decision grants, and it is the same
row the REST gate stages for this route, which carries no `{id}`.

Naming a link as the target — what `book_meeting` does with its first — was
weighed and rejected on two grounds that compound:

- **the REST door cannot follow.** `stageRefusal` never reads the body, so the
  two doors would stage one kind two ways and a human would decide a different
  question depending on the transport the agent used;
- **the pin is taken server-side** from the target pair, so naming an
  organization pins its version — which an enrichment run bumps while an
  overnight proposal waits for someone's morning inbox, cancelling a send the
  record's own content never invalidated. The waiver that declines a pin is
  reserved for kinds whose effect approvals itself applies
  (`TestEveryContextTargetKindIsAKindWeStage`), and this effect is performed by
  the agent's own approved retry.

**What that costs is stated in the source rather than left to be discovered:**
the approver is bounded by read+create on `activity`, not by the row scope of the
records the message is filed under. Closing it needs the staging gate to derive a
target from the body — **#928**, filed, with both candidate designs.

The links are still read at staging, because that is a question about the
STAGER's reach: the store refuses a link the caller cannot see at execution, so
without the same probe an agent naming a company it cannot read mints an approval
a human reads, approves, and then watches fail with the one-shot authority spent.

## One spelling of the link rules

`book_meeting` and this verb both name their own records, so the cap, the dedupe
and the per-link read that refuses an externally-held record now live once
(`toollinks.go`). Two copies of that loop is how one of them ends up checking
only the first link.

## What two independent reviews changed

Fable and Codex both reviewed the first commit and converged on the approver-bound
gap above; the second commit is what they found beyond it.

| finding | outcome |
|---|---|
| the new contract text claimed the links are probed at staging — true of MCP, false of REST | reworded door by door |
| a record named twice raised a unique violation on `uq_activity_link` — a 500 at the end of a send or booking, and for an approved retry a 500 with the human's yes already spent | deduplicated at the one write site every transport passes through |
| the link list was unbounded on the REST send path | bounded at the contract's own 25, so the bound holds for a human's send too |
| `book_meeting`'s execute door did not dedupe as its staging door does | fixed — the human approved "attached to N record(s)" as StageInfo counted them |
| the empty-`to` refusal was written twice | one spelling |
| binding `links[0]` without a version was "available" | **not in this tree** — see the pin argument above; the reviews did not have that constraint |
| the external-SoR refusal runs at staging, not at redemption | real, and older than this verb — filed as **#929** |

## Tests

100% statement coverage on both new files. The dedupe fix carries its own defect
test: reverted, `TestARepeatedLinkIsFiledOnceRatherThanRaisingAUniqueViolation`
fails with `duplicate key value violates unique constraint "uq_activity_link"`.

- **unit** — governance parity with the reply (scope, tier, egress, op); the
  staged create's shape; the summary naming every argument it releases; both
  doors refusing an unsendable call; a link the caller cannot see refused before
  anything is staged; a mirrored link behind a local one; cap and dedupe before
  any read.
- **integration, real Postgres** — a human's own send leaves without an approval;
  an agent's identical call stages the create shape (asserted in SQL), is listed
  in the human's inbox over HTTP, is released, and only then leaves — with the
  outbound activity filed under the record the call named — and the approval is
  single-use. Plus the MCP door staging through `StageInfo`.
- **store** — a repeated link filed once; a list over the bound refused before it
  probes anything.

## Live UAT — MCP Inspector + raw protocol against a running stack

Isolated dev stack, a real passport with `read`+`send`, the official Inspector CLI
for discovery and raw `2026-07-28` protocol calls for the loop.

```
$ npx @modelcontextprotocol/inspector --cli --config … --method tools/list
tools offered to a read+send passport: 27
  send_account_email | Start an email conversation from a record

$ POST :18200/mcp   tools/call send_account_email   (agent passport)
"This is a confirm-first (🟡) action: it needs human approval before it runs.
 Nothing was changed. (staged as approval 019ff13c-ecfe-… — once a human approves
 it, repeat this exact call with "approval_id": "019ff13c-ecfe-…")"

$ GET :18200/v1/approvals?status=pending   (as the human)
019ff13c-ecfe-… | send_account_email | target: activity <no id>
summary: Start an email conversation with buyer@northwind.test,
         subject "Introducing Margince", filed under 1 record(s)

$ POST :18200/v1/approvals/019ff13c-…/approve            → 200

$ POST :18200/mcp   the identical call + approval_id
→ redeemed, reaches the store, refused by the send pre-flight:
  "mailbox_not_send_capable: reconnect your mailbox to enable sending"
```

The last step is the dev stack having no Google app configured, not governance —
and the approval **survives** it (`status: approved`, `consumed_at: null`), so the
agent can retry once a mailbox is connected. The send itself completing is
covered by the integration lane, which connects a send-capable mailbox and
asserts the 202 plus the delivery row.

## Catalog cost

38 tools. Re-measured rather than quoted:
`TestTheToolListingLeavesTheRunRoomInTheWindow` is green, and `mcp-info` is
regenerated (105.7 KB, ~27,831 wire tokens). A `read`+`send` passport is offered
27 of the 38, not the all-scope worst case.

## Paid lane

Nothing new is owed. The `agent_loop` records are already one digest behind
(#776, owed by #738, #739, #825, #831) and the gate warns rather than fails; a
38th tool in the all-scope listing joins that debt rather than creating a second.
The corpus is not edited.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `send_account_email` agent tool to start a new email thread from records at the same 🟡 confirm-first tier as replies, with no new authority. Closes #688.

- **New Features**
  - Enable agents for `POST /v1/emails`: tool `send_account_email`, tier `confirmation_required`, scope `send`, with decision grants.
  - Add approval token support to `POST /v1/emails` redemption (`X-Approval-Token`) with a 🟡 403; update API text/docs and regenerate tool catalog (38 tools).

- **Bug Fixes**
  - Enforce the 25-link bound at insert for all activity writers (send and bookings) with write-time dedupe to prevent unique constraint errors; shared link rules live once and probe row scope at staging.
  - Refuse zero-duration bookings at both doors so approvals aren’t consumed on invalid requests.
  - Use one `links` field name in errors; clarify MCP vs REST link probing.

- **Refactors**
  - Move timeline link handling to `activitylinks.go` to centralize vocabulary, bound, refusals, and insert.

<sup>Written for commit 8baff5c502a7390b275a6b080f6d7d2fa1bb12b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/930?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

