### PR TITLE
docs(mcp): say what the tool catalog is made of, so the wire total stops being read as the cost

### DIFF
--- a/backend/internal/compose/mcpinfo_test.go
+++ b/backend/internal/compose/mcpinfo_test.go
@@ -100,13 +100,43 @@ type mcpInfo struct {
 // prevent. The ~4-bytes rule is the same one the window estimates with, so the
 // figure is an estimate of the same KIND, not of the same thing.
 type mcpInfoTotals struct {
-	Tools          int    `json:"tools"`
-	Resources      int    `json:"resources"`
-	ToolBytes      int    `json:"tool_catalog_bytes"`
-	ResourceBytes  int    `json:"resource_catalog_bytes"`
-	ApproxTokens   int    `json:"approx_wire_tokens_total"`
-	LargestToolB   int    `json:"largest_tool_bytes"`
-	LargestToolNam string `json:"largest_tool"`
+	Tools          int                `json:"tools"`
+	Resources      int                `json:"resources"`
+	ToolBytes      int                `json:"tool_catalog_bytes"`
+	ResourceBytes  int                `json:"resource_catalog_bytes"`
+	ApproxTokens   int                `json:"approx_wire_tokens_total"`
+	LargestToolB   int                `json:"largest_tool_bytes"`
+	LargestToolNam string             `json:"largest_tool"`
+	Composition    mcpInfoComposition `json:"tool_catalog_composition"`
+}
+
+// mcpInfoComposition splits the tool catalog into its parts, because the total
+// above is prose-warned and still misread: the comment on mcpInfoTotals says
+// the wire figure is not the per-step one, and a reader looking at a TABLE of
+// bytes reaches for the biggest number in it anyway.
+//
+// The split is published so the arithmetic argues for itself. Output schemas
+// are the largest single component and appear in NO run's prompt — the runner's
+// listing renders name, description and input schema alone — so a reader who
+// shortens descriptions to bring the headline down is paying with the one
+// component measured to move tool selection (agenttooldescriptions_test.go
+// records the copy taking gemini 0.80 -> 0.87) to save bytes nothing was ever
+// charged for.
+//
+// DescriptionBytes counts decoded text and the schema fields count served JSON,
+// so these are the reviewable magnitudes of each part rather than addends of
+// ToolBytes: names, annotations and per-entry punctuation are outside them and
+// the sum is deliberately short of the total.
+//
+// Neither is the runner's number. DescAndInputBytes is the pair that survives
+// into a listing, NOT a prediction of what ToolListing renders — that has its
+// own format and its own budget, and restating it here would recreate the exact
+// conflation this type exists to break.
+type mcpInfoComposition struct {
+	DescriptionBytes  int `json:"description_bytes"`
+	InputSchemaBytes  int `json:"input_schema_bytes"`
+	OutputSchemaBytes int `json:"output_schema_bytes"`
+	DescAndInputBytes int `json:"description_plus_input_schema_bytes"`
 }
 
 func TestPublishedMCPSurfaceMatchesWhatAClientIsServed(t *testing.T) {
@@ -148,6 +178,7 @@ func mcpInfoDocument(t *testing.T, tools, resources json.RawMessage) mcpInfo {
 			ApproxTokens:   (len(tools) + len(resources)) / 4,
 			LargestToolB:   size,
 			LargestToolNam: name,
+			Composition:    toolCatalogComposition(t, tools),
 		},
 		Tools:     tools,
 		Resources: resources,
@@ -358,9 +389,39 @@ func countMembers(t *testing.T, result json.RawMessage, member string) int {
 	return len(entries)
 }
 
+// toolCatalogComposition sizes each part of the served tool catalog.
+//
+// It walks the SERVED payload rather than the registry, for the same reason the
+// page is rendered from the published document: a walk of the specs would size
+// what this package believes is advertised, and the whole question here is what
+// a client is actually charged for.
+//
+// It decodes into mcpToolEntry rather than a shape of its own. A second
+// spelling of the same three members would carry its own camelCase exemptions
+// and could drift from what the page reads, which is the drift this whole
+// artifact exists to prevent.
+func toolCatalogComposition(t *testing.T, result json.RawMessage) mcpInfoComposition {
+	t.Helper()
+	var decoded struct {
+		Tools []mcpToolEntry `json:"tools"`
+	}
+	if err := json.Unmarshal(result, &decoded); err != nil {
+		t.Fatalf("sizing the parts of the tool catalog: %v", err)
+	}
+	var split mcpInfoComposition
+	for _, tool := range decoded.Tools {
+		split.DescriptionBytes += len(tool.Description)
+		split.InputSchemaBytes += len(tool.InputSchema)
+		split.OutputSchemaBytes += len(tool.OutputSchema)
+	}
+	split.DescAndInputBytes = split.DescriptionBytes + split.InputSchemaBytes
+	return split
+}
+
 // largestTool names the entry a reader should look at first when the catalog
 // grows. One tool carrying a per-type vocabulary is how this surface reached
 // its budget once already, and a total alone does not say which one.
+
 func largestTool(t *testing.T, result json.RawMessage) (string, int) {
 	t.Helper()
 	var decoded struct {

--- a/backend/internal/compose/mcpinfomarkdown_test.go
+++ b/backend/internal/compose/mcpinfomarkdown_test.go
@@ -111,6 +111,44 @@ func writeMCPInfoHead(page *strings.Builder, doc mcpInfo) {
 	page.WriteString("clause the transport appends. The Surface-B listing a run re-sends every step is\n")
 	page.WriteString("smaller — name, description and input schema only — and is held against its own\n")
 	page.WriteString("budget in `agenttooldescriptions_test.go`.\n\n")
+	writeMCPInfoComposition(page, doc.Totals)
+}
+
+// writeMCPInfoComposition prints what the wire total is made of, because the
+// paragraph above has warned in prose since this page existed and the number in
+// the table is still the one people act on.
+//
+// The last column is the point: the largest component is the one no prompt
+// carries, so "shorten the descriptions" attacks a quarter of the bytes and
+// spends the only part with a measured effect on tool selection.
+func writeMCPInfoComposition(page *strings.Builder, totals mcpInfoTotals) {
+	split := totals.Composition
+	page.WriteString("### What the tool catalog is made of\n\n")
+	page.WriteString("| Part | Bytes | Share | In a run's prompt? |\n|---|---:|---:|---|\n")
+	for _, row := range []struct {
+		part   string
+		bytes  int
+		prompt string
+	}{
+		{"Output schemas", split.OutputSchemaBytes, "**No** — a result's shape, never listed to a model"},
+		{"Descriptions (incl. governance clause)", split.DescriptionBytes, "Yes, every step"},
+		{"Input schemas", split.InputSchemaBytes, "Yes, every step"},
+	} {
+		fmt.Fprintf(page, "| %s | %s | %d%% | %s |\n",
+			row.part, humanBytes(row.bytes), row.bytes*100/totals.ToolBytes, row.prompt)
+	}
+	fmt.Fprintf(page, "| _Names, annotations, punctuation_ | %s | %d%% | Partly |\n",
+		humanBytes(totals.ToolBytes-split.OutputSchemaBytes-split.DescAndInputBytes),
+		(totals.ToolBytes-split.OutputSchemaBytes-split.DescAndInputBytes)*100/totals.ToolBytes)
+	fmt.Fprintf(page, "| **Description + input schema** | **%s** | **%d%%** | **the recurring cost** |\n\n",
+		humanBytes(split.DescAndInputBytes), split.DescAndInputBytes*100/totals.ToolBytes)
+	page.WriteString("So the headline total is dominated by the part a model is never charged for, and\n")
+	page.WriteString("descriptions are a minority of it. Trimming the copy to shrink the total trades a\n")
+	page.WriteString("MEASURED gain — the same copy took gemini's tool selection from 0.80 to 0.87, and\n")
+	page.WriteString("one restraint scenario from 0/3 to 3/3 on a single sentence — for bytes that were\n")
+	page.WriteString("not the cost. `agenttooldescriptions_test.go` records that argument and the\n")
+	page.WriteString("budget decision it produced; the room is bought by publishing a vocabulary as a\n")
+	page.WriteString("resource, the way `margince://schema/record-fields` did, not by writing less.\n\n")
 }
 
 func writeMCPInfoIndex(page *strings.Builder, tools []mcpToolEntry, resources []mcpResourceEntry) {

--- a/docs/reference/mcp-info.json
+++ b/docs/reference/mcp-info.json
@@ -14,7 +14,13 @@
     "resource_catalog_bytes": 3108,
     "approx_wire_tokens_total": 27028,
     "largest_tool_bytes": 4151,
-    "largest_tool": "run_report"
+    "largest_tool": "run_report",
+    "tool_catalog_composition": {
+      "description_bytes": 28224,
+      "input_schema_bytes": 23668,
+      "output_schema_bytes": 45049,
+      "description_plus_input_schema_bytes": 51892
+    }
   },
   "tools": {
     "_meta": {

--- a/docs/reference/mcp-info.md
+++ b/docs/reference/mcp-info.md
@@ -24,6 +24,24 @@ clause the transport appends. The Surface-B listing a run re-sends every step is
 smaller — name, description and input schema only — and is held against its own
 budget in `agenttooldescriptions_test.go`.
 
+### What the tool catalog is made of
+
+| Part | Bytes | Share | In a run's prompt? |
+|---|---:|---:|---|
+| Output schemas | 44.0 KB | 42% | **No** — a result's shape, never listed to a model |
+| Descriptions (incl. governance clause) | 27.6 KB | 26% | Yes, every step |
+| Input schemas | 23.1 KB | 22% | Yes, every step |
+| _Names, annotations, punctuation_ | 7.9 KB | 7% | Partly |
+| **Description + input schema** | **50.7 KB** | **49%** | **the recurring cost** |
+
+So the headline total is dominated by the part a model is never charged for, and
+descriptions are a minority of it. Trimming the copy to shrink the total trades a
+MEASURED gain — the same copy took gemini's tool selection from 0.80 to 0.87, and
+one restraint scenario from 0/3 to 3/3 on a single sentence — for bytes that were
+not the cost. `agenttooldescriptions_test.go` records that argument and the
+budget decision it produced; the room is bought by publishing a vocabulary as a
+resource, the way `margince://schema/record-fields` did, not by writing less.
+
 ## Index
 
 ### Resources (8)


### PR DESCRIPTION
## What

`mcp-info.json` and `mcp-info.md` now publish what the tool catalog is **made of**, not just how big it is:

| Part | Bytes | Share | In a run's prompt? |
|---|---:|---:|---|
| Output schemas | 44.0 KB | 42% | **No** — a result's shape, never listed to a model |
| Descriptions (incl. governance clause) | 27.6 KB | 26% | Yes, every step |
| Input schemas | 23.1 KB | 22% | Yes, every step |

No tool copy, schema, or budget constant is touched. **The served surface is byte-identical** — this is the artifact explaining itself.

## Why

`mcpInfoTotals` has carried a comment since the page existed saying the wire figure is not the per-step one, and that *"reading either number as the other is the mistake this comment exists to prevent."*

The warning did not hold. A review of the surface opened on "the tool descriptions are too long, can we shorten them to save preload cost" — reasoning from `Approx. wire tokens | 27028` at the top of the page. The prose warning is below the table; the misleading number is *in* it.

The two facts that stop that conclusion have to sit next to each other:

- **Output schemas are 42% of the wire bytes and appear in no run's prompt.**
- **Descriptions are 26%, and they are the one component with a measured effect on tool selection** — `agenttooldescriptions_test.go` records the copy taking gemini from 0.80 to 0.87, and one restraint scenario from 0/3 to 3/3 on a single sentence.

Trimming the copy to shrink the headline trades the second to save the first. The room is bought by publishing a vocabulary as a resource, the way `margince://schema/record-fields` did (#831) — not by writing less.

Full analysis, and the re-measure it produced, in #737.

## How

- `mcpInfoComposition` on `mcpInfoTotals` → `tool_catalog_composition` in the JSON.
- `toolCatalogComposition()` walks the **served payload** rather than the registry — the same reason the page is rendered from the published document: a walk of the specs would size what this package *believes* is advertised.
- `writeMCPInfoComposition()` renders the table with the "In a run's prompt?" column.
- Both artifacts regenerated by their own test, not hand-edited.

### One deliberate omission

`DescAndInputBytes` does **not** restate `runner.ToolListing`'s figure. That has its own renderer and its own budget gate, and repeating it here would rebuild the exact conflation this change exists to break. The type comment says so, and says the field is not an addend of `ToolBytes` either — names, annotations and punctuation sit outside it, so the parts deliberately do not sum to the total.

## Verification

- `go test ./internal/compose/` — green (full package).
- `gofmt` clean, `go vet ./internal/compose/` clean.
- Regeneration is idempotent: `-update-mcp-info` then a plain run passes the byte-for-byte comparison.

## Reviewer note

The 0.80 → 0.87 figure quoted in the page copy and commit message is a **citation of this repo's own record** in `agenttooldescriptions_test.go`, not a fresh measurement. Per #737's certification-debt item, the committed `agent_loop` records currently describe a prompt `main` no longer sends (#831 and #825 both changed it). The figure is the basis on which the budget decision was originally made and is quoted as such; if the re-cert moves it, this copy should move with it.

---

Closes nothing. Supports #737.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publishes the tool catalog’s composition in `mcp-info.json` and `mcp-info.md` so the wire total isn’t mistaken for per-step prompt cost. No behavior change; docs are generated from the served payload.

- **New Features**
  - Added `tool_catalog_composition` to `mcp-info.json` with `description_bytes`, `input_schema_bytes`, `output_schema_bytes`, and `description_plus_input_schema_bytes`.
  - Rendered a composition table in `mcp-info.md` with an “In a run’s prompt?” column, making clear output schemas aren’t sent per step.
  - Computed composition by walking the served payload via `toolCatalogComposition()`; rendered markdown via `writeMCPInfoComposition()`.
  - Artifacts regenerated via tests; served payload remains byte-identical. Supports #737.

<sup>Written for commit 787e56f3465f64b9cf018ebcabadf14789e034f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/933?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tool catalog composition metrics to MCP information, including description, input schema, output schema, and combined byte totals.
  * Added a breakdown showing how catalog content contributes to overall size and recurring prompt costs.

* **Documentation**
  * Updated MCP reference documentation with the new composition metrics and guidance on catalog size, prompt inclusion, and optimization considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->