### PR TITLE
chore(compose): the operator's mailer is named for the transport, not for one consumer

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -18,6 +18,7 @@
 Every section in this file, in order. Read this list first and jump; nobody
 needs the whole file to start a session.
 
+- Shipped 2026-08-11 (batman): "Make eMail meaningful" Wave 1 — a draft is now written in the language of the correspondence, knows what time it is, knows who is sending it, and stops inventing a history. Two spec PRs land first (margince-foundation #1272 the correspondence envelope + DRAFT-AC-E-1..7, #1273 the shared-core layering + E-8/E-9 + AIEVAL-32/33), then five code PRs: `shared/kernel/textlang` + `convstate` (#916), `draftfloor` with all four no-model producers ported onto one band×language table (#918), `identity.ActorIdentity` + its ratified RBAC waiver (#919), `compose/draftrules` — the shared prompt block that fixes the reported "Romina introduced me to Marek" defect, since there is no referral data to ground on and forbidding the inference is the cure (#922), and the person/account certification sites ADR-0074 requires now that both prompts changed (#926). Filed as fast-track-debt: #915 (an English signature footer can still outvote a short German reply), #921 (the recorded cert outputs need a paid re-record; the staleness gate warns rather than fails), #934 (the person page's "Ask for context" button renders enabled and is inert), #935 (the composer never calls the person draft endpoint), #936 (the warm-intro drafter has no UI). Waves 2 and 3 — the shared `draftcore` engine, the one Person360 fold, voice on the composers, and widened grounding — are not started.
 - Shipped 2026-08-11: bootstrap writes the installation's Agent Runner seat (`is_agent`, no password, no role assignment) and core `0216` backfills the installations that predate it, so a scheduled extension job has an initiator and actually runs on a fresh install (#656). The seat is an identity and not an authority: the one path that could have handed it a credential — the admin-issued set-password link — now refuses it. Left out deliberately: the admin members screen lists the seat with a role selector and a set-password button the API now refuses; its presentation is filed as a follow-up.
 - Shipped 2026-08-11 (batman, follow-up): a same-kind consumer-mail re-add stays on the create grant, so a rep retrying a lost response gets the existing entry instead of a 403 (PR #888, found by the Codex review of #872). Open upstream: spec capture.md CAP-PARAM-5 predates the workspace consumer-mail surface entirely (still says baseline + margince.yaml, no UI) — reconcile in the spec repo.
 - Shipped 2026-08-11 (batman): own-email-domains card moved to a new admin-group Capture settings tab; any seat (not just admin/ops) may add a consumer-mail `extra` domain — `capture_settings` gained `create` for rep/manager/admin/ops (policy.go + migration 0210) while `never` carve-outs/overwrites/removal stay on `update`; new `GET /capture/consumer-mail-baseline` makes the shipped ~8.7k-domain list searchable in the card (PR #872). No fast-track-debt issues filed — all review findings were fixed in the PR.
@@ -81,10 +82,12 @@ arm exists, computed at send time from the timeline. `inquiry`, `in_person` and
 flag. The behaviour under-allows rather than over-allows, so it is safe and
 incomplete.
 
-**No model lane is wired to any of it.** The person brief, the person draft and
-the meeting brief all render their deterministic floor and say so in
-`generated_by`. `WithPersonDraft` exists for the api role; the other two need
-the same treatment.
+**The person brief and the meeting brief have no model lane wired.** Both render
+their deterministic floor and say so in `generated_by`. The person DRAFT does
+have one — `cmd/api/modelwiring.go` binds `WithPersonDraft(modelPath.DraftReply)`
+— so a person-page draft is model-written wherever a model is configured. The
+distinction matters: a stale reading of this line has already led a reviewer to
+assess the drafting work as lower-risk than it was.
 
 **No research provider is registered**, which is the supported configuration
 (ADR-0096 D4): the drawer answers "no data provider yet connected" and writes

--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -319,10 +319,10 @@ func passwordResetOptions(deployCfg deployconfig.Config, publicBaseURL string, s
 		Password:    smtpPassword,
 		FromAddress: deployCfg.Email.FromAddress,
 	}
-	_, _ = fmt.Fprintln(stdout, "api password reset enabled (outbound email configured)")
+	_, _ = fmt.Fprintln(stdout, "api operator mail enabled (password reset, invites)")
 	// The link base rides compose.WithPublicBaseURL, assembled with the base
 	// options — this option carries the transport alone.
-	return []compose.Option{compose.WithPasswordReset(m)}, nil
+	return []compose.Option{compose.WithOperatorMail(m)}, nil
 }
 
 // blobstoreOptions wires the attachment endpoints (and their /readyz probe +

--- a/backend/internal/compose/serveroptions.go
+++ b/backend/internal/compose/serveroptions.go
@@ -37,14 +37,22 @@ import (
 // optioned keeps its safe default.
 type Option func(*Server, *pgxpool.Pool)
 
-// WithPasswordReset wires the A74 forgot-password flow's transport onto
-// the identity surface: the operator's transactional mailer. Without it
-// forgot-password answers its explicit 501 and the capabilities probe
-// reports password_reset=false (A107 — the login UI renders only what
-// works). The link base is NOT wired here; it arrives through
-// WithPublicBaseURL, because an installation with no mailer still builds
-// set-password links (ADR-0061 Amendment 1).
-func WithPasswordReset(m mailer.Mailer) Option {
+// WithOperatorMail wires the operator's own transactional mailer — the
+// ADR-0056 transport the INSTALLATION sends through, as distinct from a
+// rep's mailbox, which is what correspondence goes out on.
+//
+// It is named for the transport rather than for one consumer because it
+// has more than one. Password reset is the consumer that exists today, and
+// the invite mail rides the same door; the emailed daily digest
+// (UC-NOTIFY-03) is the next one, and it would otherwise have had to be
+// wired through an option whose name says password reset.
+//
+// Without it, forgot-password answers its explicit 501 and the
+// capabilities probe reports password_reset=false (A107 — the login UI
+// renders only what works). The link base is NOT wired here; it arrives
+// through WithPublicBaseURL, because an installation with no mailer still
+// builds set-password links (ADR-0061 Amendment 1).
+func WithOperatorMail(m mailer.Mailer) Option {
 	return func(s *Server, _ *pgxpool.Pool) {
 		s.authHandlers = s.WithPasswordReset(m)
 	}


### PR DESCRIPTION
Close-out of "Make eMail meaningful" Wave 1. A rename, a corrected STATUS line, and the program's record.

## The rename

`compose.WithPasswordReset` becomes `compose.WithOperatorMail`. It is the ADR-0056 door onto the transport the **installation** sends through, as distinct from a rep's mailbox, which is what correspondence goes out on.

Password reset is the consumer that exists today, and the invite mail already rides the same door. The emailed daily digest (UC-NOTIFY-03) is the next one, and it would otherwise have had to be wired through an option whose name says password reset.

The identity handler method keeps its name — that one really is about password reset. The startup line stops naming one consumer too.

## The STATUS correction

STATUS.md said the person brief, the person draft and the meeting brief all render their deterministic floor with no model lane wired. **Half of that is wrong**: `cmd/api/modelwiring.go` binds `WithPersonDraft(modelPath.DraftReply)`, so a person-page draft is model-written wherever a model is configured — which is how the reported "Romina introduced me to Marek" defect was produced in the first place. The brief and meeting-brief halves were correct and stay.

This is not cosmetic: a stale reading of that line already led a reviewer to assess this program's risk as lower than it was, so the corrected text says so.

## The Wave 1 record

One line in the open-work index covering the two spec PRs and five code PRs, and naming the five `fast-track-debt` issues left behind (#915, #921, #934, #935, #936) plus what Waves 2 and 3 still owe.

## Gate

`make -C backend build`, `go test ./internal/...`, and `go test .` all green. No separate review round: this is a rename with one caller plus documentation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed `compose.WithPasswordReset` to `compose.WithOperatorMail` to reflect the operator mail transport used by multiple consumers (password reset, invites, future digest), and updated the startup message. Corrected STATUS to note person drafts are model-wired and recorded Wave 1 in the open-work index.

- **Refactors**
  - Replaced `compose.WithPasswordReset` with `compose.WithOperatorMail`; transport wiring unchanged.
  - Updated stdout to "api operator mail enabled (password reset, invites)".

- **Migration**
  - Replace `compose.WithPasswordReset(...)` with `compose.WithOperatorMail(...)` in call sites.

<sup>Written for commit 795fba5a83c16e21451c81864615f9c6a9fa72f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/937?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

