### PR TITLE
fix(draftrules): a draft may not greet the person it is written as

### DIFF
--- a/backend/internal/compose/draftrules/draftrules.go
+++ b/backend/internal/compose/draftrules/draftrules.go
@@ -42,6 +42,12 @@ signatures inside quoted text, or from the order messages appear in — a quoted
 thread names the people in a conversation, not the person sending this one.
 If no sender is given, write no sign-off and refer to no name for yourself.
 
+The sender is NOT the recipient. Never greet the person you are writing as —
+that produces a message addressed to its own author. If you were given no
+recipient name, and none is stated in the supplied message you are answering,
+open without a name ("Hallo," / "Hello,") rather than reaching for whatever
+name is nearest.
+
 RELATIONSHIPS
 Never state who introduced whom, who referred whom, or who first made contact,
 unless that exact directed fact is given to you as data. It is not something to

--- a/backend/internal/compose/draftrulesparity_test.go
+++ b/backend/internal/compose/draftrulesparity_test.go
@@ -50,6 +50,7 @@ func TestTheSharedRulesStillSayTheThingsTheyExistToSay(t *testing.T) {
 	promises := map[string]string{
 		"write in the correspondence's language":    "Write the entire draft",
 		"do not read the sender out of quoted text": "Never work out who is who from quoted message headers",
+		"never greet the sender as the recipient":   "The sender is NOT the recipient",
 		"do not invent who introduced whom":         "Never state who introduced whom",
 		"no follow-up on a first touch":             `At state "none" there is no prior contact`,
 		"do not assume memory after a long gap":     "do not assume the recipient remembers",


### PR DESCRIPTION
Found by probing the new certification fixtures against a real model while verifying Wave 1.

## What the probe showed

`stale_months_01` produced a message addressed to its own author:

```
Hi Anna,
...
Best regards,
Anna Krüger
```

The reply payload carries the sender (added by the envelope work) and **no recipient field at all**. When the message being answered has no name in it, the model has exactly one name available and uses it for the greeting.

## What this PR does, and what it does not

It adds the rule: the sender is not the recipient, and a draft with no recipient name opens without one.

**The rule is worth having and it is not the fix.** I re-probed with it in place and got the same greeting — with one name in the payload and a greeting to write, an instruction loses to the data. Same lesson as the prompt-fence work: recognition-based rules lose to structure.

The structural fix is a recipient field on the reply payload, which the person and account composers already carry. `activity.counterparty_email` is the data that would feed it; it is written on capture but is not on the read shape `GetActivity` returns. Filed as **#941**.

## Why it has not been reported

Real inbound mail usually carries a signature block, so the model finds the counterparty's name in the body and greets correctly by accident.

## Gate

`go test ./internal/...` and `go test .` green; the parity test now pins this rule alongside the others.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents drafts from greeting their own sender when the recipient name is missing. Adds a rule: the sender is not the recipient; open with a generic greeting when no recipient name is known.

- **Bug Fixes**
  - Add rule in `backend/internal/compose/draftrules/draftrules.go` to never greet the person you are writing as; use "Hello," when no recipient name is available.
  - Pin the rule in `backend/internal/compose/draftrulesparity_test.go`.
  - Note: the structural fix is adding a recipient field to the reply payload (see #941).

<sup>Written for commit aa06946eaf58358b415c96ac2ad88dfc5b98a3c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/942?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

