### PR TITLE
docs(status): the account-started send's agent half shipped, and what it left

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -19,6 +19,7 @@ Every section in this file, in order. Read this list first and jump; nobody
 needs the whole file to start a session.
 
 - Shipped 2026-08-11 (batman): "Make eMail meaningful" Wave 1 — a draft is now written in the language of the correspondence, knows what time it is, knows who is sending it, and stops inventing a history. Two spec PRs land first (margince-foundation #1272 the correspondence envelope + DRAFT-AC-E-1..7, #1273 the shared-core layering + E-8/E-9 + AIEVAL-32/33), then five code PRs: `shared/kernel/textlang` + `convstate` (#916), `draftfloor` with all four no-model producers ported onto one band×language table (#918), `identity.ActorIdentity` + its ratified RBAC waiver (#919), `compose/draftrules` — the shared prompt block that fixes the reported "Romina introduced me to Marek" defect, since there is no referral data to ground on and forbidding the inference is the cure (#922), and the person/account certification sites ADR-0074 requires now that both prompts changed (#926). Filed as fast-track-debt: #915 (an English signature footer can still outvote a short German reply), #921 (the recorded cert outputs need a paid re-record; the staleness gate warns rather than fails), #934 (the person page's "Ask for context" button renders enabled and is inert), #935 (the composer never calls the person draft endpoint), #936 (the warm-intro drafter has no UI). Waves 2 and 3 — the shared `draftcore` engine, the one Person360 fold, voice on the composers, and widened grounding — are not started.
+- Shipped 2026-08-11: the account-started send gains its agent tool — `send_account_email`, the 38th on the catalog, 🟡 and governed identically to the reply (ADR-0087 §6, PR #930). The gap #688 named was one `decisionGrants` entry. Left open: **#928** (the REST staging gate stages before it can read the body, so the approver is not bounded by the records the effect concerns — the same shape `book_meeting` already had) and **#929** (the external-SoR refusal runs at staging, not at redemption). Both reviews proposed binding a link as the staged target; the server-side pin makes that unavailable — see the section below before repeating it.
 - Shipped 2026-08-11: bootstrap writes the installation's Agent Runner seat (`is_agent`, no password, no role assignment) and core `0216` backfills the installations that predate it, so a scheduled extension job has an initiator and actually runs on a fresh install (#656). The seat is an identity and not an authority: the one path that could have handed it a credential — the admin-issued set-password link — now refuses it. Left out deliberately: the admin members screen lists the seat with a role selector and a set-password button the API now refuses; its presentation is filed as a follow-up.
 - Shipped 2026-08-11 (batman, follow-up): a same-kind consumer-mail re-add stays on the create grant, so a rep retrying a lost response gets the existing entry instead of a 403 (PR #888, found by the Codex review of #872). Open upstream: spec capture.md CAP-PARAM-5 predates the workspace consumer-mail surface entirely (still says baseline + margince.yaml, no UI) — reconcile in the spec repo.
 - Shipped 2026-08-11 (batman): own-email-domains card moved to a new admin-group Capture settings tab; any seat (not just admin/ops) may add a consumer-mail `extra` domain — `capture_settings` gained `create` for rep/manager/admin/ops (policy.go + migration 0210) while `never` carve-outs/overwrites/removal stay on `update`; new `GET /capture/consumer-mail-baseline` makes the shipped ~8.7k-domain list searchable in the card (PR #872). No fast-track-debt issues filed — all review findings were fixed in the PR.
@@ -349,11 +350,27 @@ There is still exactly one send. `POST /v1/emails` carries the account-started
 surface; an address belonging to no person the sender can read refuses 422
 `recipient_not_on_file` and names the address.
 
-Left open: the operation is **human-only**. ADR-0087 §6's agent tool needs a
-decision-grant mapping before the verb can honestly be advertised — issue #688
-carries the four fitness tests that are its acceptance criteria. The
-account-started DRAFT (§3: grounded, fenced, auto-starting, writing nothing) is
-not built.
+**The agent tool shipped 2026-08-11 (PR #930, `88c7f07b`)**, so the operation is
+no longer human-only: `send_account_email` is the 38th tool, 🟡, governed
+identically to the reply. What #688 called four failing fitness tests was one
+map entry — the missing `decisionGrants` mapping; the other three failed only
+because the contract declared a verb no registered tool answered.
+
+Left open, and worth reading before touching any staged 🟡 verb:
+
+- **#928 — the REST staging gate stages before it can read the body.** It takes
+  its target from the route, so an operation whose subject lives in the body
+  (this one, `book_meeting`) stages an id-less create: the approver is bounded
+  by read+create on the record TYPE, not by the row scope of the records the
+  effect concerns. A manager whose scope excludes them can release the send and
+  read its proposed text. It cannot be closed from the verb — the version pin is
+  taken server-side from the target pair, and the waiver that declines a pin is
+  reserved for kinds approvals applies itself. Two independent code reviews
+  proposed that unavailable fix; check the constraint before proposing it again.
+- **#929 — the external-system-of-record refusal runs at staging, not at
+  redemption**, for all four staging verbs.
+- The account-started DRAFT (§3: grounded, fenced, auto-starting, writing
+  nothing) is still not built.
 
 **Finance mirror (ADR-0083) — PR #689.** The five tables only:
 `finance_connection`, `finance_external_customer`, `finance_customer_link`,


### PR DESCRIPTION
Session-close update for [#930](https://github.com/gradionhq/margince-poc-v1/pull/930) (`88c7f07b`), which closed #688.

The *Open — account-started outbound* section said the operation was human-only and that #688 carried four fitness tests as acceptance criteria. Both are now out of date: the tool shipped, and the four tests turned out to be one missing `decisionGrants` entry plus three consequences of the contract declaring a verb no registered tool answered.

What the section carries instead is the part a future session needs: **the approver of a staged account-started send is bounded by read+create on `activity`, not by the row scope of the records the message is filed under** — tracked as #928, and not closable from the verb, because the version pin is taken server-side and the waiver that declines one is reserved for kinds approvals applies itself. Two independent code reviews proposed exactly that unavailable fix, which is why the constraint is written down rather than left to be rediscovered.

Docs only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update STATUS.md to record that the account-started send now has an agent tool, `send_account_email`, shipped 2026-08-11. This closes #688 and documents remaining gaps: approver scope is limited by read+create on activity due to REST staging behavior (#928), external SoR refusal runs at staging (#929), and the account-started DRAFT is still not built.

<sup>Written for commit 6489d611f2613426b5c0c5f131fe8907d9be1190. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/944?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

