### PR TITLE
fix(textlang): a captured mail's own headers are not a quoted thread

### DIFF
--- a/backend/internal/shared/kernel/textlang/textlang.go
+++ b/backend/internal/shared/kernel/textlang/textlang.go
@@ -229,6 +229,17 @@ var attributionVerbs = []string{"wrote:", "schrieb:", "schrieb ", " wrote "}
 // open with "On" and mention writing much later is prose.
 const attributionMaxRunes = 200
 
+// ownHeaderRunes is how far into the text a "From:"/"Von:" line may sit and
+// still belong to THIS message rather than to a quoted one.
+//
+// A captured email body often begins with its own envelope headers — the
+// capture path stores "From: …\nTo: …\n\n" above the text somebody wrote. Those
+// same words further down the message introduce the thread being quoted. The
+// difference is position: a header block is at the top, and a quoted-message
+// header comes after the reply. Generous enough for a few header lines with
+// long addresses, far short of any real reply.
+const ownHeaderRunes = 400
+
 // replyText narrows the text to the message actually being written, and says
 // how much of what remains is the lead.
 //
@@ -257,7 +268,8 @@ func replyText(runes []rune) (text []rune, lead int) {
 func quoteStart(runes []rune) int {
 	for offset, atLineStart := 0, true; offset < len(runes); offset++ {
 		if atLineStart && !unicode.IsSpace(runes[offset]) {
-			if startsQuote(lineAt(runes, offset)) {
+			line := lineAt(runes, offset)
+			if startsQuote(line) && !isOwnHeader(line, offset) {
 				return offset
 			}
 			atLineStart = false
@@ -266,6 +278,21 @@ func quoteStart(runes []rune) int {
 		atLineStart = atLineStart || runes[offset] == '\n' || runes[offset] == '\r'
 	}
 	return -1
+}
+
+// isOwnHeader reports whether an address header at this offset belongs to the
+// message itself rather than announcing a quoted one.
+//
+// Without this a captured email is cut to nothing: the capture path stores the
+// envelope headers above the body, so the text starts "From: …", the whole
+// message reads as quoted, and the language of a German thread resolves to
+// Unknown — which is exactly how a German thread produced an English draft.
+func isOwnHeader(line []rune, offset int) bool {
+	if offset >= ownHeaderRunes {
+		return false
+	}
+	text := string(line)
+	return strings.HasPrefix(text, "From: ") || strings.HasPrefix(text, "Von: ")
 }
 
 // lineAt returns the rest of the line beginning at offset.

--- a/backend/internal/shared/kernel/textlang/textlang_test.go
+++ b/backend/internal/shared/kernel/textlang/textlang_test.go
@@ -73,6 +73,38 @@ func TestAGermanReplyAboveAQuotedEnglishThreadIsGerman(t *testing.T) {
 	}
 }
 
+// A captured email body carries its own envelope headers above the text
+// somebody wrote. Those must not read as a quote marker, or the message is cut
+// to nothing and its language resolves to Unknown.
+//
+// This is the shape that shipped the defect: a German thread whose stored body
+// began "From: …" detected as Unknown, so the draft fell back to English.
+func TestAMessagesOwnHeadersAreNotAQuote(t *testing.T) {
+	stored := "From: marek.janetzke@lucidlabs.de\nTo: lars@gradion.com\n\n" +
+		"Hallo zusammen,\n\nwie besprochen verbinde ich euch hiermit gerne direkt. " +
+		"Romina, ich hatte dir Gradion für euren Case empfohlen und wollte fragen, " +
+		"ob wir dazu kurz sprechen können.\n"
+
+	if got := textlang.Detect(stored); got != textlang.German {
+		t.Fatalf("Detect(captured german mail) = %q, want German: the envelope headers "+
+			"the capture path stores are the message's own, not a quoted thread", got)
+	}
+}
+
+// The same words further down DO introduce a quoted message, and there the cut
+// is correct. Position is what separates the two.
+func TestAnAddressHeaderBelowTheReplyStillCutsTheQuote(t *testing.T) {
+	reply := "Hallo Marek,\n\ndas passt gut, ich melde mich bei Ihnen mit einer Antwort " +
+		"und schicke die Unterlagen mit. Viele Grüße\n\n" +
+		strings.Repeat("Ein weiterer Satz auf Deutsch, damit die Antwort lang genug ist.\n", 6)
+	quoted := "From: marek.janetzke@lucidlabs.de\n\n" +
+		strings.Repeat("The team has reviewed this and would like to move forward with it.\n", 12)
+
+	if got := textlang.Detect(reply + quoted); got != textlang.German {
+		t.Fatalf("Detect(german reply over a From:-quoted english thread) = %q, want German", got)
+	}
+}
+
 // A message that is nothing but forwarded text still has a clear language, and
 // refusing to read the quote would answer Unknown for it. The quote is dropped
 // only when there is a reply above it to read instead.


### PR DESCRIPTION
**The reported bug, still live in the product.** Marek's page drafted in English on a German thread — the exact defect this program set out to fix.

## The cause

A captured email body carries its own envelope headers above the text somebody wrote. The stored body starts:

```
From: marek.janetzke@lucidlabs.de
To: lars@gradion.com

Hallo zusammen,
...
```

`From: ` is one of the markers that says *a quoted thread starts here*. So `quoteStart` cut the text at position **zero**, nothing was left to read, `Detect` answered `Unknown`, and the deterministic floor fell back to English.

Every layer above was working correctly: the 360 carries the bodies, the fold reads them, the service resolves the envelope, the floor renders whatever language it is given. The detector was handed an empty string.

## The fix

Position separates the two cases. A header block at the top of a message belongs to that message; the same words below a reply introduce the thread being quoted. An address header inside the first 400 runes is now read as the message's own — generous for a few header lines with long addresses, far short of any real reply — and one below that still cuts the quote as before.

Both directions are pinned: the regression test uses the shape that shipped the defect, and a second test proves a `From:` header below a German reply still cuts the English thread under it.

## How it was found, and why the tests missed it

By running the real thread from the dev database through the drafter, not by reading code. Every unit test passed because they all built the message body **by hand** — without the headers the capture path really stores. That is the "a test that supplies its own version of production proves nothing about production" rule, and I walked into it.

## Gate

`go test ./internal/...` and `go test .` green, plus the two new detector tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes language detection for captured emails by not treating top-of-body envelope headers as quoted threads. Prevents empty input to `textlang.Detect` that made German threads fall back to English.

- **Bug Fixes**
  - Treat "From:"/"Von:" within the first 400 runes as the message’s own headers; only headers below that start a quote.
  - Update quote detection to skip these lines in `quoteStart` via `isOwnHeader`.
  - Add tests for captured headers at the top and for a header below a reply still cutting the quote.

<sup>Written for commit 0b10fe1c149b528e7f99c37ff7cef81d8ba03bc8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/945?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

