### PR TITLE
docs(mcp): the published tool-catalog sizes match what a client is served

### DIFF
--- a/docs/reference/mcp-info.json
+++ b/docs/reference/mcp-info.json
@@ -16,10 +16,10 @@
     "largest_tool_bytes": 4151,
     "largest_tool": "run_report",
     "tool_catalog_composition": {
-      "description_bytes": 28224,
-      "input_schema_bytes": 23668,
-      "output_schema_bytes": 45049,
-      "description_plus_input_schema_bytes": 51892
+      "description_bytes": 29156,
+      "input_schema_bytes": 24804,
+      "output_schema_bytes": 45953,
+      "description_plus_input_schema_bytes": 53960
     }
   },
   "tools": {

--- a/docs/reference/mcp-info.md
+++ b/docs/reference/mcp-info.md
@@ -28,11 +28,11 @@ budget in `agenttooldescriptions_test.go`.
 
 | Part | Bytes | Share | In a run's prompt? |
 |---|---:|---:|---|
-| Output schemas | 44.0 KB | 42% | **No** — a result's shape, never listed to a model |
-| Descriptions (incl. governance clause) | 27.6 KB | 26% | Yes, every step |
-| Input schemas | 23.1 KB | 22% | Yes, every step |
-| _Names, annotations, punctuation_ | 7.9 KB | 7% | Partly |
-| **Description + input schema** | **50.7 KB** | **49%** | **the recurring cost** |
+| Output schemas | 44.9 KB | 42% | **No** — a result's shape, never listed to a model |
+| Descriptions (incl. governance clause) | 28.5 KB | 26% | Yes, every step |
+| Input schemas | 24.2 KB | 22% | Yes, every step |
+| _Names, annotations, punctuation_ | 8.1 KB | 7% | Partly |
+| **Description + input schema** | **52.7 KB** | **49%** | **the recurring cost** |
 
 So the headline total is dominated by the part a model is never charged for, and
 descriptions are a minority of it. Trimming the copy to shrink the total trades a


### PR DESCRIPTION
`TestPublishedMCPSurfaceMatchesWhatAClientIsServed` is **red on main**. The committed `docs/reference/mcp-info.{json,md}` still carry the catalog sizes from before the account-started send became a governed tool (#930):

```
first difference at line 31:
  committed: | Output schemas | 44.0 KB | 42% | ...
  served:    | Output schemas | 44.9 KB | 42% | ...
```

Verified on plain `origin/main` (not just on a branch), so this is not rebase fallout.

Regenerated with the command the test itself names — `go test ./internal/compose/ -run TestPublishedMCPSurface -update-mcp-info` — so **only the size figures move**. The prose #933 added about what the catalog is made of is untouched, and the surface itself does not change: this is the generated half catching up with the tool that landed.

The gate compares committed bytes against a live render, so any change that adds or reshapes a tool has to regenerate these two files in the same PR, or main goes red between them. Noted in the commit message for whoever adds the next one.

Found while trying to land #913, which cannot merge past a red required check. That PR is unrelated to the MCP surface.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Regenerated MCP tool-catalog size figures in `docs/reference/mcp-info.{json,md}` to match what clients are served, fixing the red `TestPublishedMCPSurfaceMatchesWhatAClientIsServed` on main. Only numeric size values changed; the catalog surface and prose are unchanged.

- **Bug Fixes**
  - Updated sizes to reflect the governed tool added in #930, aligning committed bytes with the live render.
  - Regenerated via `go test ./internal/compose/ -run TestPublishedMCPSurface -update-mcp-info`.

<sup>Written for commit a58dd291405532f2fb3a465166da7676bee1d17d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/946?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated MCP tool-catalog size metrics to reflect the latest descriptions, input schemas, output schemas, names, annotations, and punctuation totals.
  * Revised the combined description-and-input schema total in the reference documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->