### PR TITLE
feat(persondraft): an overdue promise is the reason to write, so it leads the draft

### DIFF
--- a/backend/internal/compose/persondraft/commitment_test.go
+++ b/backend/internal/compose/persondraft/commitment_test.go
@@ -6,77 +6,149 @@ package persondraft
 import (
 	"strings"
 	"testing"
+	"time"
 
+	openapi_types "github.com/oapi-codegen/runtime/types"
+
+	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/convstate"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/draftfloor"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/textlang"
 )
 
-func envelope(lang textlang.Lang, band convstate.Band) draftfloor.Envelope {
+var draftedAt = time.Date(2026, 8, 11, 9, 0, 0, 0, time.UTC)
+
+func envelopeAt(lang textlang.Lang, band convstate.Band) draftfloor.Envelope {
 	return draftfloor.Envelope{
 		Language:          string(lang),
 		ConversationState: string(band),
-		Now:               "2026-08-11T09:00:00Z",
+		Now:               draftedAt.Format(time.RFC3339),
 	}
 }
 
-// An overdue promise is the reason to write today, so it leads — over a
-// question they asked, which is the kind that led before.
+// claim builds a contract claim, which is the shape the fold really reads.
 //
-// This is the archetype the grounding work is for: the email a rep knows they
-// should send and does not.
-func TestAnOverduePromiseLeadsTheDraft(t *testing.T) {
-	draft := Deterministic(Input{
-		Envelope:  envelope(textlang.English, convstate.BandWeeks),
-		Recipient: RecipientIn{ID: "p1", FirstName: "Priya"},
-		Claims: []ClaimIn{
-			{ID: "c1", Kind: "open_question", Body: "the API rate limits", SourceID: "a1"},
-			{ID: "c2", Kind: "commitment", Body: "the integration scope document",
-				SourceID: "a2", Due: "2026-07-25T00:00:00Z", Overdue: true},
-		},
-	})
-
-	if !strings.Contains(draft.Body, "integration scope document") {
-		t.Errorf("the overdue promise should lead:\n%s", draft.Body)
-	}
-	if strings.Contains(draft.Body, "API rate limits") {
-		t.Errorf("a question should not lead while a promise is outstanding:\n%s", draft.Body)
+// Every case here goes through foldClaims rather than hand-building ClaimIn,
+// and that is the lesson this file was rewritten for: the first version of
+// these tests fabricated a claim kind ("commitment") the contract never emits,
+// so they passed against a branch that could not fire on a single real record.
+func claim(kind crmcontracts.ConversationClaimKind, body string,
+	status crmcontracts.ConversationClaimStatus, due *time.Time,
+) crmcontracts.ConversationClaim {
+	return crmcontracts.ConversationClaim{
+		Id:               openapi_types.UUID(ids.NewV7()),
+		SourceActivityId: openapi_types.UUID(ids.NewV7()),
+		Kind:             kind,
+		Body:             body,
+		Status:           status,
+		DueAt:            due,
 	}
 }
 
-// A promise NOT yet due is not a reason to write today. Leading on it invents
-// an urgency nobody agreed to.
-func TestAPromiseStillWithinItsDateDoesNotLead(t *testing.T) {
-	draft := Deterministic(Input{
-		Envelope:  envelope(textlang.English, convstate.BandWeeks),
-		Recipient: RecipientIn{ID: "p1", FirstName: "Priya"},
-		Claims: []ClaimIn{
-			{ID: "c1", Kind: "open_question", Body: "the API rate limits", SourceID: "a1"},
-			{ID: "c2", Kind: "commitment", Body: "the integration scope document",
-				SourceID: "a2", Due: "2026-09-30T00:00:00Z"},
-		},
-	})
+func at(day int) *time.Time {
+	t := time.Date(2026, 7, day, 0, 0, 0, 0, time.UTC)
+	return &t
+}
 
-	if !strings.Contains(draft.Body, "API rate limits") {
-		t.Errorf("with nothing overdue, the question they asked should lead:\n%s", draft.Body)
+// foldedFrom runs the real fold, so a case describes a Person360 the product
+// could actually assemble.
+func foldedFrom(claims ...crmcontracts.ConversationClaim) Input {
+	view := crmcontracts.Person360{Claims: &claims}
+	in := Input{
+		Envelope:  envelopeAt(textlang.English, convstate.BandWeeks),
+		Recipient: RecipientIn{ID: "p1", FirstName: "Priya"},
+	}
+	foldClaims(&in, view, draftedAt)
+	return in
+}
+
+// An overdue promise of OURS is the reason to write today, so it leads — over a
+// question they asked, which is the kind that led before.
+func TestAnOverduePromiseOfOursLeadsTheDraft(t *testing.T) {
+	in := foldedFrom(
+		claim(crmcontracts.OpenQuestion, "the API rate limits", crmcontracts.ConversationClaimStatusOpen, nil),
+		claim(crmcontracts.CommitmentOurs, "the integration scope document",
+			crmcontracts.ConversationClaimStatusOpen, at(25)),
+	)
+
+	body := Deterministic(in).Body
+	if !strings.Contains(body, "integration scope document") {
+		t.Errorf("the overdue promise should lead:\n%s", body)
+	}
+	if strings.Contains(body, "API rate limits") {
+		t.Errorf("a question should not lead while a promise is outstanding:\n%s", body)
 	}
 }
 
-// A commitment with no date at all never leads. "We said we would look into it"
-// is not a promise with a deadline, and treating it as one manufactures a
-// reason to write.
-func TestAPromiseWithNoDateNeverLeads(t *testing.T) {
-	draft := Deterministic(Input{
-		Envelope:  envelope(textlang.English, convstate.BandWeeks),
-		Recipient: RecipientIn{ID: "p1", FirstName: "Priya"},
-		Claims: []ClaimIn{
-			{ID: "c1", Kind: "objection", Body: "the price", SourceID: "a1"},
-			{ID: "c2", Kind: "commitment", Body: "looking into the integration", SourceID: "a2"},
-		},
-	})
+// The cases that must NOT lead. Each is a different sentence, and treating any
+// of them as an overdue promise of ours puts a false claim in front of a
+// customer.
+func TestOnlyAnOpenOverduePromiseOfOursLeads(t *testing.T) {
+	question := claim(crmcontracts.OpenQuestion, "the API rate limits",
+		crmcontracts.ConversationClaimStatusOpen, nil)
 
-	if !strings.Contains(draft.Body, "the price") {
-		t.Errorf("an undated commitment should not displace a real objection:\n%s", draft.Body)
+	cases := []struct {
+		name  string
+		claim crmcontracts.ConversationClaim
+	}{
+		{
+			name: "a promise THEY made, past its date",
+			claim: claim(crmcontracts.CommitmentTheirs, "the signed order form",
+				crmcontracts.ConversationClaimStatusOpen, at(25)),
+		},
+		{
+			name: "a promise of ours already kept",
+			claim: claim(crmcontracts.CommitmentOurs, "the integration scope document",
+				crmcontracts.ConversationClaimStatusDone, at(25)),
+		},
+		{
+			name: "a promise of ours still within its date",
+			claim: func() crmcontracts.ConversationClaim {
+				later := time.Date(2026, 9, 30, 0, 0, 0, 0, time.UTC)
+				return claim(crmcontracts.CommitmentOurs, "the integration scope document",
+					crmcontracts.ConversationClaimStatusOpen, &later)
+			}(),
+		},
+		{
+			name: "a promise of ours with no date at all",
+			claim: claim(crmcontracts.CommitmentOurs, "looking into the integration",
+				crmcontracts.ConversationClaimStatusOpen, nil),
+		},
+		{
+			name: "a promise due at this very instant is not yet late",
+			claim: claim(crmcontracts.CommitmentOurs, "the integration scope document",
+				crmcontracts.ConversationClaimStatusOpen, &draftedAt),
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			body := Deterministic(foldedFrom(question, c.claim)).Body
+			if !strings.Contains(body, "API rate limits") {
+				t.Errorf("this should not have displaced the open question:\n%s", body)
+			}
+		})
+	}
+}
+
+// The claims arrive newest-first and the fold keeps only a handful, so on a
+// busy record the longest-overdue promise — the one that most needs saying —
+// would fall outside the window. It is hoisted before the cap, not ranked
+// after it.
+func TestTheLongestOverduePromiseSurvivesABusyRecord(t *testing.T) {
+	var claims []crmcontracts.ConversationClaim
+	for i := range draftInputClaims + 3 {
+		claims = append(claims, claim(crmcontracts.OpenQuestion,
+			"a question about topic "+string(rune('A'+i)),
+			crmcontracts.ConversationClaimStatusOpen, nil))
+	}
+	// Oldest, so newest-first ordering puts it last of all.
+	claims = append(claims, claim(crmcontracts.CommitmentOurs, "the integration scope document",
+		crmcontracts.ConversationClaimStatusOpen, at(2)))
+
+	body := Deterministic(foldedFrom(claims...)).Body
+	if !strings.Contains(body, "integration scope document") {
+		t.Errorf("the overdue promise fell outside the claim window:\n%s", body)
 	}
 }
 
@@ -84,34 +156,28 @@ func TestAPromiseWithNoDateNeverLeads(t *testing.T) {
 // the recipient as a raw timestamp. A person writes "last month", not
 // "2026-07-25T00:00:00Z".
 func TestTheDueDateNeverReachesTheBodyAsATimestamp(t *testing.T) {
-	draft := Deterministic(Input{
-		Envelope:  envelope(textlang.German, convstate.BandWeeks),
-		Recipient: RecipientIn{ID: "p1", FirstName: "Marek"},
-		Claims: []ClaimIn{
-			{ID: "c1", Kind: "commitment", Body: "das Angebot",
-				SourceID: "a1", Due: "2026-07-25T00:00:00Z", Overdue: true},
-		},
-	})
+	in := foldedFrom(claim(crmcontracts.CommitmentOurs, "das Angebot",
+		crmcontracts.ConversationClaimStatusOpen, at(25)))
+	in.Envelope = envelopeAt(textlang.German, convstate.BandWeeks)
 
-	for _, leaked := range []string{"2026-07-25", "T00:00:00Z", "RFC3339"} {
-		if strings.Contains(draft.Body, leaked) {
-			t.Errorf("the body leaked the raw date %q:\n%s", leaked, draft.Body)
+	body := Deterministic(in).Body
+	for _, leaked := range []string{"2026-07-25", "T00:00:00Z"} {
+		if strings.Contains(body, leaked) {
+			t.Errorf("the body leaked the raw date %q:\n%s", leaked, body)
 		}
 	}
 }
 
-// The overdue reading is the ENVELOPE's clock, not a fresh one. A draft stamped
+// The overdue reading is the ENVELOPE's clock, not a fresh one: a draft stamped
 // at one instant and judging dates at another can call the same promise overdue
 // on one line and pending on the next.
 func TestOverdueIsReadFromTheEnvelopesOwnClock(t *testing.T) {
-	stamped := envelope(textlang.English, convstate.BandWeeks)
-	if got := stamped.At().Format("2006-01-02"); got != "2026-08-11" {
-		t.Fatalf("the envelope's clock reads %s, want 2026-08-11", got)
+	if got := envelopeAt(textlang.English, convstate.BandWeeks).At(); !got.Equal(draftedAt) {
+		t.Fatalf("the envelope's clock reads %s, want %s", got, draftedAt)
 	}
 
-	// An envelope with no readable stamp answers the zero time, and every
-	// comparison against it treats a due date as "not yet" rather than
-	// declaring everything overdue.
+	// An unstamped envelope answers the zero time, and every comparison against
+	// it treats a due date as "not yet" rather than declaring everything overdue.
 	unstamped := draftfloor.Envelope{}
 	if !unstamped.At().IsZero() {
 		t.Error("an unstamped envelope should answer the zero time")

--- a/backend/internal/compose/persondraft/commitment_test.go
+++ b/backend/internal/compose/persondraft/commitment_test.go
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package persondraft
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/convstate"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/draftfloor"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/textlang"
+)
+
+func envelope(lang textlang.Lang, band convstate.Band) draftfloor.Envelope {
+	return draftfloor.Envelope{
+		Language:          string(lang),
+		ConversationState: string(band),
+		Now:               "2026-08-11T09:00:00Z",
+	}
+}
+
+// An overdue promise is the reason to write today, so it leads — over a
+// question they asked, which is the kind that led before.
+//
+// This is the archetype the grounding work is for: the email a rep knows they
+// should send and does not.
+func TestAnOverduePromiseLeadsTheDraft(t *testing.T) {
+	draft := Deterministic(Input{
+		Envelope:  envelope(textlang.English, convstate.BandWeeks),
+		Recipient: RecipientIn{ID: "p1", FirstName: "Priya"},
+		Claims: []ClaimIn{
+			{ID: "c1", Kind: "open_question", Body: "the API rate limits", SourceID: "a1"},
+			{ID: "c2", Kind: "commitment", Body: "the integration scope document",
+				SourceID: "a2", Due: "2026-07-25T00:00:00Z", Overdue: true},
+		},
+	})
+
+	if !strings.Contains(draft.Body, "integration scope document") {
+		t.Errorf("the overdue promise should lead:\n%s", draft.Body)
+	}
+	if strings.Contains(draft.Body, "API rate limits") {
+		t.Errorf("a question should not lead while a promise is outstanding:\n%s", draft.Body)
+	}
+}
+
+// A promise NOT yet due is not a reason to write today. Leading on it invents
+// an urgency nobody agreed to.
+func TestAPromiseStillWithinItsDateDoesNotLead(t *testing.T) {
+	draft := Deterministic(Input{
+		Envelope:  envelope(textlang.English, convstate.BandWeeks),
+		Recipient: RecipientIn{ID: "p1", FirstName: "Priya"},
+		Claims: []ClaimIn{
+			{ID: "c1", Kind: "open_question", Body: "the API rate limits", SourceID: "a1"},
+			{ID: "c2", Kind: "commitment", Body: "the integration scope document",
+				SourceID: "a2", Due: "2026-09-30T00:00:00Z"},
+		},
+	})
+
+	if !strings.Contains(draft.Body, "API rate limits") {
+		t.Errorf("with nothing overdue, the question they asked should lead:\n%s", draft.Body)
+	}
+}
+
+// A commitment with no date at all never leads. "We said we would look into it"
+// is not a promise with a deadline, and treating it as one manufactures a
+// reason to write.
+func TestAPromiseWithNoDateNeverLeads(t *testing.T) {
+	draft := Deterministic(Input{
+		Envelope:  envelope(textlang.English, convstate.BandWeeks),
+		Recipient: RecipientIn{ID: "p1", FirstName: "Priya"},
+		Claims: []ClaimIn{
+			{ID: "c1", Kind: "objection", Body: "the price", SourceID: "a1"},
+			{ID: "c2", Kind: "commitment", Body: "looking into the integration", SourceID: "a2"},
+		},
+	})
+
+	if !strings.Contains(draft.Body, "the price") {
+		t.Errorf("an undated commitment should not displace a real objection:\n%s", draft.Body)
+	}
+}
+
+// The negative gate: the DATE is grounding for the writer and must not reach
+// the recipient as a raw timestamp. A person writes "last month", not
+// "2026-07-25T00:00:00Z".
+func TestTheDueDateNeverReachesTheBodyAsATimestamp(t *testing.T) {
+	draft := Deterministic(Input{
+		Envelope:  envelope(textlang.German, convstate.BandWeeks),
+		Recipient: RecipientIn{ID: "p1", FirstName: "Marek"},
+		Claims: []ClaimIn{
+			{ID: "c1", Kind: "commitment", Body: "das Angebot",
+				SourceID: "a1", Due: "2026-07-25T00:00:00Z", Overdue: true},
+		},
+	})
+
+	for _, leaked := range []string{"2026-07-25", "T00:00:00Z", "RFC3339"} {
+		if strings.Contains(draft.Body, leaked) {
+			t.Errorf("the body leaked the raw date %q:\n%s", leaked, draft.Body)
+		}
+	}
+}
+
+// The overdue reading is the ENVELOPE's clock, not a fresh one. A draft stamped
+// at one instant and judging dates at another can call the same promise overdue
+// on one line and pending on the next.
+func TestOverdueIsReadFromTheEnvelopesOwnClock(t *testing.T) {
+	stamped := envelope(textlang.English, convstate.BandWeeks)
+	if got := stamped.At().Format("2006-01-02"); got != "2026-08-11" {
+		t.Fatalf("the envelope's clock reads %s, want 2026-08-11", got)
+	}
+
+	// An envelope with no readable stamp answers the zero time, and every
+	// comparison against it treats a due date as "not yet" rather than
+	// declaring everything overdue.
+	unstamped := draftfloor.Envelope{}
+	if !unstamped.At().IsZero() {
+		t.Error("an unstamped envelope should answer the zero time")
+	}
+}

--- a/backend/internal/compose/persondraft/deterministic.go
+++ b/backend/internal/compose/persondraft/deterministic.go
@@ -127,10 +127,18 @@ func deterministicOpener(in Input) string {
 // matters.
 var openingClaimKinds = []string{"open_question", "objection", "priority"}
 
-// commitmentKind is the claim kind that records something one side said they
-// would do. Only OUR overdue ones open a draft; the rest of the ranking is
-// about what THEY said.
-const commitmentKind = "commitment"
+// ourCommitment is the claim kind recording something WE said we would do.
+//
+// Derived from the contract enum rather than spelled as a literal, which is not
+// a style point here: this rule first shipped keyed on "commitment", a kind the
+// contract never emits, so the branch could not fire on any real record and the
+// test that "proved" it fabricated the same missing kind.
+//
+// Their commitments are deliberately excluded. "You said you would send the
+// signed order" is a real fact and a different message from "we owe you the
+// scope document" - chasing them is not what this rule is for, and the prompt
+// beside it says the overdue item is ours.
+var ourCommitment = string(crmcontracts.CommitmentOurs)
 
 // leadClaim picks the claim the opener refers to: the first one of the
 // highest-ranked kind present. The 360 hands claims over newest-first, so
@@ -139,7 +147,7 @@ func leadClaim(in Input) (ClaimIn, bool) {
 	// An overdue promise outranks every kind below: it is the only one the
 	// recipient is owed, and the newest is the one most likely to still matter.
 	for _, claim := range in.Claims {
-		if claim.Kind == commitmentKind && claim.Overdue {
+		if claim.Kind == ourCommitment && claim.Overdue {
 			return claim, true
 		}
 	}
@@ -159,7 +167,7 @@ func leadClaim(in Input) (ClaimIn, bool) {
 // the same way would put "you objected to" in a message about a preference.
 func claimOpener(claim ClaimIn, lines draftfloor.Substance) string {
 	switch claim.Kind {
-	case commitmentKind:
+	case ourCommitment:
 		return draftfloor.Fill(lines.Commitment, claim.Body)
 	case "open_question":
 		return draftfloor.Fill(lines.OpenQuestion, claim.Body)

--- a/backend/internal/compose/persondraft/deterministic.go
+++ b/backend/internal/compose/persondraft/deterministic.go
@@ -109,16 +109,40 @@ func deterministicOpener(in Input) string {
 	return ""
 }
 
-// The claim kinds a first message can honestly open on, most actionable first.
-// An open question and an objection are both things the reader is waiting on us
-// for; a priority is what they told us matters. The other kinds — our own
-// commitments, decisions already taken — are not openers for a message TO them.
+// The claim kinds a message can honestly open on, most actionable first.
+//
+// An OVERDUE commitment leads, and it leads for a reason worth stating: it is
+// the one thing on this list the recipient is owed rather than merely
+// interested in. We said we would do something by a date, the date has passed,
+// and a message that opens on anything else while that is outstanding reads as
+// having forgotten. It is also the archetype the whole grounding effort is for
+// — the email a rep knows they should send and does not.
+//
+// A commitment with no due date, or one not yet due, stays out. "We said we
+// would look into it" is not a reason to write today, and leading on it invents
+// an urgency nobody agreed to.
+//
+// Below it the order is unchanged: an open question and an objection are both
+// things the reader is waiting on US for, and a priority is what they told us
+// matters.
 var openingClaimKinds = []string{"open_question", "objection", "priority"}
+
+// commitmentKind is the claim kind that records something one side said they
+// would do. Only OUR overdue ones open a draft; the rest of the ranking is
+// about what THEY said.
+const commitmentKind = "commitment"
 
 // leadClaim picks the claim the opener refers to: the first one of the
 // highest-ranked kind present. The 360 hands claims over newest-first, so
 // within a kind the first is the most recent.
 func leadClaim(in Input) (ClaimIn, bool) {
+	// An overdue promise outranks every kind below: it is the only one the
+	// recipient is owed, and the newest is the one most likely to still matter.
+	for _, claim := range in.Claims {
+		if claim.Kind == commitmentKind && claim.Overdue {
+			return claim, true
+		}
+	}
 	for _, kind := range openingClaimKinds {
 		for _, claim := range in.Claims {
 			if claim.Kind == kind {
@@ -135,6 +159,8 @@ func leadClaim(in Input) (ClaimIn, bool) {
 // the same way would put "you objected to" in a message about a preference.
 func claimOpener(claim ClaimIn, lines draftfloor.Substance) string {
 	switch claim.Kind {
+	case commitmentKind:
+		return draftfloor.Fill(lines.Commitment, claim.Body)
 	case "open_question":
 		return draftfloor.Fill(lines.OpenQuestion, claim.Body)
 	case "objection":

--- a/backend/internal/compose/persondraft/input.go
+++ b/backend/internal/compose/persondraft/input.go
@@ -313,7 +313,12 @@ func foldClaims(in *Input, view crmcontracts.Person360, now time.Time) {
 	if view.Claims == nil {
 		return
 	}
-	for _, claim := range *view.Claims {
+	// An overdue promise of ours is why this message is being written, and the
+	// claims arrive newest-first — so on a busy record the longest-overdue one,
+	// which is the one that most needs saying, falls outside the window. It is
+	// hoisted BEFORE the cap rather than ranked after it.
+	claims := hoistOverdueOurs(*view.Claims, now)
+	for _, claim := range claims {
 		if len(in.Claims) == draftInputClaims {
 			break
 		}
@@ -328,10 +333,55 @@ func foldClaims(in *Input, view crmcontracts.Person360, now time.Time) {
 		}
 		if claim.DueAt != nil {
 			folded.Due = claim.DueAt.UTC().Format(time.RFC3339)
-			folded.Overdue = claim.DueAt.Before(now)
+			folded.Overdue = isOverdueOurs(claim, now)
 		}
 		in.Claims = append(in.Claims, folded)
 	}
+}
+
+// isOverdueOurs reports whether this claim is a promise WE made, still open,
+// and past its date.
+//
+// All three conditions, because each alone is a different sentence. A
+// commitment of THEIRS past its date is a fact about them and a different
+// message from one we owe; a DONE commitment past its date was kept, and
+// resurrecting it in front of the customer is worse than not mentioning it at
+// all; and a promise still within its date is not a reason to write today.
+//
+// A due date exactly equal to now is not yet overdue. The boundary favours the
+// side that says less.
+func isOverdueOurs(claim crmcontracts.ConversationClaim, now time.Time) bool {
+	if claim.Kind != crmcontracts.CommitmentOurs {
+		return false
+	}
+	if claim.Status != crmcontracts.ConversationClaimStatusOpen {
+		return false
+	}
+	return claim.DueAt != nil && claim.DueAt.Before(now)
+}
+
+// hoistOverdueOurs moves our overdue promises to the front, keeping every other
+// claim in the order the store returned them.
+//
+// Stable, so the newest-first ordering the rest of the ranking depends on
+// survives underneath. Only the hoist is a reordering; nothing is dropped, and
+// a record with no overdue promise of ours comes back exactly as it went in.
+func hoistOverdueOurs(claims []crmcontracts.ConversationClaim, now time.Time) []crmcontracts.ConversationClaim {
+	out := make([]crmcontracts.ConversationClaim, 0, len(claims))
+	for _, claim := range claims {
+		if isOverdueOurs(claim, now) {
+			out = append(out, claim)
+		}
+	}
+	if len(out) == 0 {
+		return claims
+	}
+	for _, claim := range claims {
+		if !isOverdueOurs(claim, now) {
+			out = append(out, claim)
+		}
+	}
+	return out
 }
 
 func foldRecent(in *Input, view crmcontracts.Person360) {

--- a/backend/internal/compose/persondraft/input.go
+++ b/backend/internal/compose/persondraft/input.go
@@ -126,6 +126,16 @@ type ClaimIn struct {
 	ID   string `json:"id"`
 	Kind string `json:"kind"`
 	Body string `json:"body"`
+	// Due is when this was promised for, RFC3339, empty when nothing was
+	// promised by a date. It is the difference between "we said we would send
+	// the scope" and "we said we would send the scope by the 25th, and it is
+	// the 11th of August" — one is a note, the other is a reason to write
+	// today, and the drafter cannot tell them apart without the date.
+	Due string `json:"due,omitempty"`
+	// Overdue says the due date has passed. Derived here rather than left to
+	// the model, which has "now" and a date and would still have to do the
+	// arithmetic in prose.
+	Overdue bool `json:"overdue,omitempty"`
 	// SourceID is the activity the claim was read from — carried so a reason
 	// about a claim cites the conversation the reader can open rather than the
 	// derived row, which has no page.
@@ -153,7 +163,7 @@ func FromView(view crmcontracts.Person360, req Request) Input {
 		SectionsOmitted: omittedNames(view.SectionsOmitted),
 	}
 	foldCommercial(&in, view)
-	foldClaims(&in, view)
+	foldClaims(&in, view, req.Envelope.At())
 	foldRecent(&in, view)
 	return in
 }
@@ -299,7 +309,7 @@ func foldCommercial(in *Input, view crmcontracts.Person360) {
 // foldClaims keeps the claims a message can honestly refer to. A dismissed
 // claim is one a human said was never true, and writing an email from it would
 // resurrect it in front of the customer.
-func foldClaims(in *Input, view crmcontracts.Person360) {
+func foldClaims(in *Input, view crmcontracts.Person360, now time.Time) {
 	if view.Claims == nil {
 		return
 	}
@@ -310,12 +320,17 @@ func foldClaims(in *Input, view crmcontracts.Person360) {
 		if claim.Status == crmcontracts.ConversationClaimStatusDismissed {
 			continue
 		}
-		in.Claims = append(in.Claims, ClaimIn{
+		folded := ClaimIn{
 			ID:       claim.Id.String(),
 			Kind:     string(claim.Kind),
 			Body:     claim.Body,
 			SourceID: claim.SourceActivityId.String(),
-		})
+		}
+		if claim.DueAt != nil {
+			folded.Due = claim.DueAt.UTC().Format(time.RFC3339)
+			folded.Overdue = claim.DueAt.Before(now)
+		}
+		in.Claims = append(in.Claims, folded)
 	}
 }
 

--- a/backend/internal/compose/persondraft/write.go
+++ b/backend/internal/compose/persondraft/write.go
@@ -42,6 +42,7 @@ Open by name using the recipient's first name exactly as given; never invent or 
 Do NOT write a sign-off or a sender name. The composer adds the sender's own; a name you guessed would go out over the wrong signature.
 Say one thing and ask for one thing. Three short paragraphs at most.
 The claims are things this contact said. Answer one of them if it helps; never quote it back at them as something they are on record as saying.
+A claim marked "overdue" is something WE said we would do by a date that has passed. If there is one, it is the reason this message is being written: lead with it, say what is happening with it, and do not open on anything else while it is outstanding. Do not apologise at length and do not promise a new date the summary did not give you.
 Where the shared rules let you either write around a missing detail or ask for it, prefer writing around it here: this message opens with an ask of its own, and a second question dilutes it.
 The reasoning array is where an explanation of the draft goes. It is the ONLY place; the body carries none.
 Each reasoning entry names ONE input you actually used, in the reader's words, short enough to read as a chip ("pricing concern", "asked about onboarding"). Give entity_type and entity_id when the input was a record the summary identified; omit both when it was the caller's own intent.

--- a/backend/internal/compose/persondraft/write.go
+++ b/backend/internal/compose/persondraft/write.go
@@ -43,6 +43,7 @@ Do NOT write a sign-off or a sender name. The composer adds the sender's own; a 
 Say one thing and ask for one thing. Three short paragraphs at most.
 The claims are things this contact said. Answer one of them if it helps; never quote it back at them as something they are on record as saying.
 A claim marked "overdue" is something WE said we would do by a date that has passed. If there is one, it is the reason this message is being written: lead with it, say what is happening with it, and do not open on anything else while it is outstanding. Do not apologise at length and do not promise a new date the summary did not give you.
+The "due" field is a machine timestamp for you to read, never text to copy. Never write a date in that form to the recipient; if the timing is worth saying at all, say it the way a person would.
 Where the shared rules let you either write around a missing detail or ask for it, prefer writing around it here: this message opens with an ask of its own, and a second question dilutes it.
 The reasoning array is where an explanation of the draft goes. It is the ONLY place; the body carries none.
 Each reasoning entry names ONE input you actually used, in the reader's words, short enough to read as a chip ("pricing concern", "asked about onboarding"). Give entity_type and entity_id when the input was a record the summary identified; omit both when it was the caller's own intent.

--- a/backend/internal/shared/kernel/draftfloor/envelope.go
+++ b/backend/internal/shared/kernel/draftfloor/envelope.go
@@ -85,6 +85,18 @@ func boundedRunes(value string, maxRunes int) string {
 // rendering the floor does not have to re-parse the string it just wrote.
 func (e Envelope) Lang() textlang.Lang { return langOrDefault(textlang.Lang(e.Language)) }
 
+// At reads the envelope's "now" back as a time, so a caller that needs to
+// compare a date against it does not re-read a clock and get a different
+// instant than the draft was stamped with. An unparseable or absent value
+// answers the zero time, which every comparison treats as "not yet".
+func (e Envelope) At() time.Time {
+	at, err := time.Parse(time.RFC3339, e.Now)
+	if err != nil {
+		return time.Time{}
+	}
+	return at
+}
+
 // Band reads the envelope's conversation state back as a typed value.
 func (e Envelope) Band() convstate.Band { return convstate.Band(e.ConversationState) }
 


### PR DESCRIPTION
Wave 3's first grounding field, and the archetype the whole effort is for: **the email a rep knows they should send and does not.**

We said we would do something by a date, the date has passed, and nothing in the drafter knew. Claims reached it with their body and kind, and the fold dropped the due date entirely — so "we promised the scope by the 25th" and "we mentioned the scope" arrived identical.

## What changed

`ClaimIn` carries `Due` and `Overdue`. `Overdue` is derived server-side rather than left to the model, which has "now" and a date and would still have to do the arithmetic in prose. It reads the **envelope's** stamped clock rather than a fresh one, so a draft cannot call the same promise overdue on one line and pending on the next.

An overdue promise of ours outranks every other claim kind. It is the only one the recipient is *owed* rather than merely interested in, and a message that opens on something else while it is outstanding reads as having forgotten. The prompt says the same thing, so the model path and the deterministic floor agree.

## Review found a BLOCKER, and it was the important kind

I keyed the rule on the claim kind `"commitment"`. The contract emits `commitment_ours` and `commitment_theirs` — **never** `commitment`. The branch could not fire on a single real record.

The tests passed because they fabricated the same missing kind. That is a test supplying its own version of production and proving nothing about production, which is a trap this repo names explicitly and I walked into anyway.

The kind is now derived from the contract enum, so a rename upstream fails to compile here rather than silently unhooking the feature again. The tests are rewritten to run through the **real fold** from contract claims.

Two more from the same review:

- **`Overdue` ignored status.** A commitment already *done* was resurrected in front of the customer past its date — worse than never mentioning it.
- **The claim window capped at six before ranking**, while claims arrive newest-first. On a busy record the longest-overdue promise — the one that most needs saying — fell outside the window. Overdue ones are now hoisted before the cap, stably, so the newest-first order survives underneath.

## The three gates

**It is used**: an overdue promise displaces the open question that led before.

**It does not fire when it should not**: five cases pin what must not lead — their promise, one already kept, one still within its date, one with no date, and one due at this very instant. Both the kind and the status guard are mutation-checked, and both mutations are caught.

**It does not leak**: the raw timestamp never reaches the body, because a person writes "last month" and not `2026-07-25T00:00:00Z`. The prompt also now states that the due field is a machine timestamp to read and never text to copy — the one leak path a deterministic test cannot cover.

## Certification

No fixture regressed. Two varied between runs, and **a baseline run on unchanged main varies the same way**, so that is model variance rather than this change.

## Gate

`make -C backend build`, `go test ./internal/...`, `go test .` all green.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes overdue promises we made lead the draft. We compute “overdue” server‑side from the envelope’s clock, hoist those claims before the cap, and prevent raw date leaks.

- New Features
  - Add `ClaimIn.Due` (RFC3339) and `ClaimIn.Overdue`; derive `Overdue` from `Envelope.At()` instead of the model.
  - Update opener logic: our overdue commitments outrank all other claim kinds; undated or not‑yet‑due commitments stay out.
  - Hoist our overdue commitments before the claim window cap; preserve stable newest‑first order underneath.
  - Prompt updated to lead with overdue items and to treat `due` as machine data, never echoed to the recipient.

- Bug Fixes
  - Match the correct kind from the contract enum (`commitment_ours`), exclude `commitment_theirs`.
  - Consider status: only OPEN commitments can be overdue; DONE items no longer surface.
  - Use the envelope’s stamped time to avoid inconsistent “now”.
  - Rewrite tests to fold from real contract claims and assert no ISO timestamp leaks.

<sup>Written for commit 522926c6cdc79295100f5e7850253f895b7cfb42. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/954?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

