### PR TITLE
fix(draftcheck): the reasoning chips are checked too, and an invented introduction is refused in any form

### DIFF
--- a/backend/internal/compose/accountdraft/write.go
+++ b/backend/internal/compose/accountdraft/write.go
@@ -122,7 +122,7 @@ func writeChecked(ctx context.Context, lane Completer, in Input) (Draft, error) 
 		func(ctx context.Context, correction string) (Draft, error) {
 			return writeWithModel(ctx, lane, in, correction)
 		},
-		func(d Draft) string { return d.Body },
+		func(d Draft) (string, []string) { return d.Body, reasonLabels(d.Reasoning) },
 		// No observer: this package holds no logger, and a retry that does not
 		// help still returns a real draft. The reply surface, which has one,
 		// reports it.
@@ -378,3 +378,14 @@ var (
 // gate that asserts every drafting surface writes under the same shared rules.
 // Exported for that assertion alone: the surface itself calls draftSystemFor.
 func SystemPromptFor(fence promptfence.Fence) string { return draftSystemFor(fence) }
+
+// reasonLabels is the provenance a draft shows the rep, for the checks that
+// judge it. The labels alone: an entity id is a citation the filter already
+// grounded, and reading it as prose would flag every uuid.
+func reasonLabels(reasons []Reason) []string {
+	out := make([]string, 0, len(reasons))
+	for _, reason := range reasons {
+		out = append(out, reason.Label)
+	}
+	return out
+}

--- a/backend/internal/compose/draftcheck/draftcheck.go
+++ b/backend/internal/compose/draftcheck/draftcheck.go
@@ -108,6 +108,82 @@ var invention = map[textlang.Lang][]string{
 	},
 }
 
+// directedRelationship are the ways a draft claims who introduced, referred or
+// first contacted whom.
+//
+// The product holds no person-to-person referral record — referred_by is
+// constrained org-to-org — so a directed introduction fact in a draft is
+// necessarily read out of quoted correspondence, which is how the reported
+// defect got the direction backwards. Silence about introductions is the
+// correct behaviour today (DRAFT-AC-E-7), which makes this list a flat refusal
+// rather than a judgement about which direction is right.
+// The NOUN, not the preposition. A first attempt enumerated "introduction by",
+// "introduced by" and the rest; the model wrote "introduction TO" and walked
+// straight through. There is no honest use of these words in a chip while the
+// product holds no referral record, so the word itself is the refusal and the
+// grammar around it does not have to be predicted.
+var directedRelationship = map[textlang.Lang][]string{
+	textlang.English: {
+		// Stems, matched as a word PREFIX, because the word form is not
+		// predictable and enumerating it has failed twice on a live stack:
+		// "introduction by" missed "introduction to", and the noun list missed
+		// "introductory". "introduc" covers introduction/introduced/introducing/
+		// introductory; "refer" covers referral/referred/referring.
+		"introduc", "intro", "refer",
+		"put us in touch", "connected us",
+	},
+	textlang.German: {
+		"vorstell", "vorgestellt", "empfehl", "empfohlen",
+		"vermittl", "vermittelt", "in kontakt gebracht",
+	},
+	textlang.Vietnamese: {
+		"giới thiệu", "được giới thiệu",
+	},
+}
+
+// Reasoning reads the labels a draft shows the rep as its provenance.
+//
+// A chip is the product explaining itself, and a rep reads it less critically
+// than the body they are about to send — so a wrong one is worse there. It gets
+// the same phrase lists as the body, plus the directed-relationship refusal,
+// which caught "Follow-up to previous introduction by Romina Medici" on a
+// thread where the other party made the introduction.
+//
+// Nothing here is gated on the band: a chip is not prose, and "as discussed" in
+// a label is a claim about the record rather than a turn of phrase.
+func Reasoning(labels []string, lang textlang.Lang, band convstate.Band) []Finding {
+	var findings []Finding
+	for _, label := range labels {
+		lowered := strings.ToLower(label)
+		// EVERY language, not just the draft's. A chip is written for the rep
+		// rather than the recipient, and the model reaches for English there
+		// even on a German draft — "shared contact introduction" appeared under
+		// German prose on a live stack, and a German-only list did not see it.
+		for _, phrase := range allDirectedRelationshipPhrases() {
+			if startsWord(lowered, phrase) {
+				findings = append(findings, Finding{
+					Rule:   "invented-relationship",
+					Phrase: phrase,
+					Why: "no referral record exists to support who introduced whom, so a " +
+						"chip asserting one states a fact the product does not hold",
+				})
+			}
+		}
+		findings = append(findings, Body(label, lang, band)...)
+	}
+	return findings
+}
+
+// allDirectedRelationshipPhrases is every language's list at once, for the
+// reasoning channel. A chip's own language is not the draft's.
+func allDirectedRelationshipPhrases() []string {
+	var out []string
+	for _, phrases := range directedRelationship {
+		out = append(out, phrases...)
+	}
+	return out
+}
+
 // Body reads a draft body against the state it was written in.
 //
 // Nothing is checked at band fresh except the pleasantries: a live exchange may
@@ -187,6 +263,33 @@ func contains(text, phrase string) bool {
 		start := offset + i
 		end := start + len(phrase)
 		if boundary(text, start-1) && boundary(text, end) {
+			return true
+		}
+		offset = start + 1
+		if offset >= len(text) {
+			return false
+		}
+	}
+}
+
+// startsWord reports whether text holds phrase beginning at a word boundary,
+// with no requirement about where it ENDS.
+//
+// A stem match: "introduc" has to start a word, so it catches introduction,
+// introduced and introductory alike, and does not fire inside an unrelated word
+// that merely contains those letters.
+//
+// A hyphen counts as a boundary, which German needs: the model wrote
+// "Intro-Thema" and "Folgekontakt nach Intro" on a live stack, and a stem
+// requiring a trailing space saw neither.
+func startsWord(text, phrase string) bool {
+	for offset := 0; ; {
+		i := strings.Index(text[offset:], phrase)
+		if i < 0 {
+			return false
+		}
+		start := offset + i
+		if boundary(text, start-1) {
 			return true
 		}
 		offset = start + 1

--- a/backend/internal/compose/draftcheck/draftcheck_test.go
+++ b/backend/internal/compose/draftcheck/draftcheck_test.go
@@ -130,3 +130,139 @@ func TestAPleasantryIsOnlyFillerAtTheOpening(t *testing.T) {
 		t.Errorf("a pleasantry far into the body is not an opener, got %+v", findings)
 	}
 }
+
+// The chip that reached a real draft on the real Marek thread while the body
+// beside it was correct:
+//
+//	"Follow-up to previous introduction by Romina Medici"
+//
+// Romina did not make that introduction. The product holds no person-to-person
+// referral record at all, so any directed introduction fact in a draft was read
+// out of quoted correspondence — which is how the reported defect got the
+// direction backwards in the first place.
+func TestAnInventedIntroductionInAChipIsCaught(t *testing.T) {
+	labels := []string{"Follow-up to previous introduction by Romina Medici"}
+
+	findings := draftcheck.Reasoning(labels, textlang.English, convstate.BandFresh)
+	if len(findings) == 0 {
+		t.Fatal("the chip that shipped the original defect passed the check")
+	}
+	if findings[0].Rule != "invented-relationship" {
+		t.Errorf("expected an invented-relationship finding, got %q", findings[0].Rule)
+	}
+}
+
+// A chip is the product explaining itself, and the phrase lists that judge the
+// body apply to it too — an invented pitch is an invented pitch wherever it is
+// shown.
+func TestAChipIsJudgedByTheSamePhraseListsAsTheBody(t *testing.T) {
+	labels := []string{"our solution for their dispatch problem"}
+
+	if findings := draftcheck.Reasoning(labels, textlang.English, convstate.BandNone); len(findings) == 0 {
+		t.Error("an invented pitch in a chip should be caught the way one in the body is")
+	}
+}
+
+// An honest chip passes. The check must not fire on ordinary provenance, or
+// every draft retries and the retry buys nothing.
+func TestHonestChipsPassCleanly(t *testing.T) {
+	labels := []string{"pricing concern", "asked about onboarding", "Angebot vom 25. Juli"}
+
+	if findings := draftcheck.Reasoning(labels, textlang.German, convstate.BandWeeks); len(findings) != 0 {
+		t.Errorf("ordinary provenance should pass, got %+v", findings)
+	}
+}
+
+// German and Vietnamese carry their own phrasings, so a German chip is judged
+// against German words rather than translated English ones.
+func TestAnInventedIntroductionIsCaughtInEveryLanguage(t *testing.T) {
+	for lang, label := range map[textlang.Lang]string{
+		textlang.German:     "Nachfassen zur Vorstellung durch Romina Medici",
+		textlang.Vietnamese: "Tiếp theo sau khi được giới thiệu bởi Romina",
+	} {
+		if findings := draftcheck.Reasoning([]string{label}, lang, convstate.BandFresh); len(findings) == 0 {
+			t.Errorf("%s: %q was not caught", lang, label)
+		}
+	}
+}
+
+// The grammar around the noun is not predictable, so the noun is the refusal.
+// A first attempt enumerated "introduction by" and "introduced by"; the model
+// wrote "introduction TO" and walked straight through, twice, on a live stack.
+func TestTheIntroductionNounIsCaughtInAnyGrammar(t *testing.T) {
+	seen := []string{
+		"follow up on introduction to Romina Medici (ERGO)",
+		"follow-up on previous introduction",
+		"Follow-up to previous introduction by Romina Medici",
+		"intro made last month",
+		"referral from a colleague",
+	}
+	for _, label := range seen {
+		if findings := draftcheck.Reasoning([]string{label}, textlang.English, convstate.BandFresh); len(findings) == 0 {
+			t.Errorf("%q was not caught", label)
+		}
+	}
+}
+
+// A chip is written for the rep, not the recipient, and the model reaches for
+// English there even under German prose. "shared contact introduction" appeared
+// on a live stack beside a German body, and a German-only list did not see it.
+func TestAChipIsCheckedAgainstEveryLanguage(t *testing.T) {
+	if findings := draftcheck.Reasoning([]string{"shared contact introduction"},
+		textlang.German, convstate.BandFresh); len(findings) == 0 {
+		t.Error("an English chip on a German draft should still be caught")
+	}
+	if findings := draftcheck.Reasoning([]string{"Vorstellung durch einen Kollegen"},
+		textlang.English, convstate.BandFresh); len(findings) == 0 {
+		t.Error("a German chip on an English draft should still be caught")
+	}
+}
+
+// Every form the model has actually produced on a live stack, plus the ones
+// enumerating word forms kept missing. The stem is what generalizes: matching
+// "introduction by" missed "introduction to", and matching the noun missed
+// "introductory".
+func TestEveryFormOfAnInventedIntroductionIsCaught(t *testing.T) {
+	seen := []string{
+		"Follow-up to previous introduction by Romina Medici",
+		"follow up on introduction to Romina Medici (ERGO)",
+		"follow-up on previous introduction",
+		"introductory connection to Romina Medici",
+		"shared contact introduction",
+		"introducing us to the team",
+		"referral from a colleague",
+		"Vorstellung durch einen Kollegen",
+		"vorgestellt von Marek",
+	}
+	for _, label := range seen {
+		if findings := draftcheck.Reasoning([]string{label}, textlang.English, convstate.BandFresh); len(findings) == 0 {
+			t.Errorf("%q was not caught", label)
+		}
+	}
+}
+
+// The stem must not fire on unrelated words that merely contain those letters.
+func TestTheStemDoesNotFireOnUnrelatedWords(t *testing.T) {
+	honest := []string{
+		"pricing concern", "asked about onboarding", "Angebot vom 25. Juli",
+		"deferred the decision", "preferred delivery window",
+	}
+	if findings := draftcheck.Reasoning(honest, textlang.English, convstate.BandFresh); len(findings) != 0 {
+		t.Errorf("ordinary provenance was flagged: %+v", findings)
+	}
+}
+
+// German compounds the model produced on a live stack. A stem requiring a
+// trailing space saw none of them.
+func TestGermanCompoundsCarryingTheStemAreCaught(t *testing.T) {
+	seen := []string{
+		"Folge-Email nach Intro",
+		"Folgekontakt zum Intro-Thema",
+		"Folgekontakt nach Intro",
+	}
+	for _, label := range seen {
+		if findings := draftcheck.Reasoning([]string{label}, textlang.German, convstate.BandFresh); len(findings) == 0 {
+			t.Errorf("%q was not caught", label)
+		}
+	}
+}

--- a/backend/internal/compose/draftcore/draftcore.go
+++ b/backend/internal/compose/draftcore/draftcore.go
@@ -49,10 +49,18 @@ type Observer interface {
 	RetryDidNotClear(ctx context.Context, rule, phrase string, remaining int)
 }
 
-// BodyOf reads the prose a draft would put in front of a recipient. The check
-// judges the body alone: a subject is one line with its own rules, and a
-// concatenation would let a phrase banned in prose hide in a subject.
-type BodyOf[D any] func(D) string
+// TextOf reads the two channels of a draft a check has to judge.
+//
+// Both, because they fail differently and only one used to be read. The BODY is
+// what the recipient sees. The REASONING labels are what the product tells the
+// rep it wrote from, and a rep reads a chip less critically than the sentence
+// they are about to send — so a wrong chip is the worse of the two. An invented
+// "introduction by Romina Medici" reached one on a real thread while the body
+// beside it was correct.
+//
+// The subject is deliberately absent: it is one line with its own rules, and
+// folding it in would let a phrase banned in prose hide there.
+type TextOf[D any] func(D) (body string, reasoning []string)
 
 // CorrectOnce writes a draft, checks it against the correspondence it was
 // written into, and gives the model exactly one chance to fix what it got wrong.
@@ -71,15 +79,21 @@ type BodyOf[D any] func(D) string
 // only evidence available without asking a model to judge its own output.
 func CorrectOnce[D any](
 	ctx context.Context, lang textlang.Lang, band convstate.Band,
-	write Writer[D], bodyOf BodyOf[D], observe Observer,
+	write Writer[D], textOf TextOf[D], observe Observer,
 ) (D, error) {
+	check := func(draft D) []draftcheck.Finding {
+		body, reasoning := textOf(draft)
+		return append(draftcheck.Body(body, lang, band),
+			draftcheck.Reasoning(reasoning, lang, band)...)
+	}
+
 	draft, err := write(ctx, "")
 	if err != nil {
 		var zero D
 		return zero, err
 	}
 
-	findings := draftcheck.Body(bodyOf(draft), lang, band)
+	findings := check(draft)
 	if len(findings) == 0 {
 		return draft, nil
 	}
@@ -94,7 +108,7 @@ func CorrectOnce[D any](
 		return draft, nil
 	}
 
-	remaining := draftcheck.Body(bodyOf(retried), lang, band)
+	remaining := check(retried)
 	if len(remaining) == 0 {
 		return retried, nil
 	}

--- a/backend/internal/compose/draftcore/draftcore_test.go
+++ b/backend/internal/compose/draftcore/draftcore_test.go
@@ -18,7 +18,7 @@ import (
 // reads its body, which is the point of taking a reader rather than a type.
 type draft struct{ body string }
 
-func bodyOf(d draft) string { return d.body }
+func bodyOf(d draft) (string, []string) { return d.body, nil }
 
 // scripted answers with each body in turn and records the corrections it was
 // given, so a test can assert both what came back and what the model was told.

--- a/backend/internal/compose/persondraft/write.go
+++ b/backend/internal/compose/persondraft/write.go
@@ -127,7 +127,7 @@ func writeChecked(ctx context.Context, lane Completer, in Input) (Draft, error) 
 		func(ctx context.Context, correction string) (Draft, error) {
 			return writeWithModel(ctx, lane, in, correction)
 		},
-		func(d Draft) string { return d.Body },
+		func(d Draft) (string, []string) { return d.Body, reasonLabels(d.Reasoning) },
 		// No observer: this package holds no logger, and a retry that does not
 		// help still returns a real draft. The reply surface, which has one,
 		// reports it.
@@ -305,3 +305,14 @@ var (
 // gate that asserts every drafting surface writes under the same shared rules.
 // Exported for that assertion alone: the surface itself calls draftSystemFor.
 func SystemPromptFor(fence promptfence.Fence) string { return draftSystemFor(fence) }
+
+// reasonLabels is the provenance a draft shows the rep, for the checks that
+// judge it. The labels alone: an entity id is a citation the filter already
+// grounded, and reading it as prose would flag every uuid.
+func reasonLabels(reasons []Reason) []string {
+	out := make([]string, 0, len(reasons))
+	for _, reason := range reasons {
+		out = append(out, reason.Label)
+	}
+	return out
+}

--- a/backend/internal/compose/replydraft.go
+++ b/backend/internal/compose/replydraft.go
@@ -467,7 +467,9 @@ func (d replyDrafter) completeChecked(ctx context.Context, data replyActivityDat
 		func(ctx context.Context, correction string) (replyDraft, error) {
 			return d.completeWith(ctx, data, voiceBlock, correction)
 		},
-		func(draft replyDraft) string { return draft.Body },
+		// The reply site returns no reasoning: its schema is subject and body
+		// alone, so there is no second channel to judge here.
+		func(draft replyDraft) (string, []string) { return draft.Body, nil },
 		draftRetryLog{log: d.logger()},
 	)
 }


### PR DESCRIPTION
Closes #957. **The original defect, found again in a channel nothing checked.**

## What happened

Drafting against the real Marek Janetzke thread on a dev stack with a live model. The **body** was correct — German, correctly addressed, no invented introduction. The **reasoning chip** beside it read:

> Follow-up to previous introduction by Romina Medici

Romina did not make that introduction. Marek did.

`draftcore` was given `func(d Draft) string { return d.Body }` — it read the body and nothing else, so every deterministic gate this program built was blind to the provenance the product shows the rep.

A chip is worse to get wrong than a sentence. The rep reads the body critically because they are about to send it, and reads the chip as the product explaining itself.

## The change

`CorrectOnce` takes both channels now. The reply site yields no reasoning — its schema is subject and body — and both composers yield their labels.

`draftcheck.Reasoning` applies the existing phrase lists plus a directed-relationship refusal. The refusal is flat rather than a judgement about direction, because the product holds **no** person-to-person referral record: `referred_by` is constrained org-to-org, so any directed introduction fact in a draft was read out of quoted correspondence, which is exactly how the reported defect got it backwards.

## Getting the list right took four passes against a live model

The shape of the failures is the useful part:

- `"introduction by"` missed **"introduction to"**
- the noun list missed **"introductory"**
- a German-only list missed **"shared contact introduction"** — a chip is written for the *rep*, and the model reaches for English there even under German prose
- a stem with a trailing space missed **"Intro-Thema"** and **"nach Intro"**

So it is stems, matched at a word boundary, across **every** language regardless of the draft's own. `"introduc"` covers introduction/introduced/introducing/introductory, and a hyphen counts as a boundary.

Every form observed on a live stack is now a test case, and `"deferred"` / `"preferred"` are pinned as words the stem must **not** fire on.

## Verified against the running product

Six consecutive drafts for Marek after the fix — no invented introduction in any chip. Before it, three of five carried one.

## Gate

`make -C backend build`, `go test ./internal/...`, `go test .` all green.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Checks reasoning chips alongside the body and blocks invented introduction/referral claims in any form. Prevents wrong provenance (e.g., “introduction by X”) from reaching reps.

- **Bug Fixes**
  - Added `draftcheck.Reasoning` to scan chip labels using stem-based, word-boundary matching across languages; refuse any directed introduction/referral claims.
  - Improved phrase matching (hyphen-aware) and added safe exclusions for lookalikes (“deferred”, “preferred”).
  - Added tests covering English, German, Vietnamese, and German compounds.

- **Refactors**
  - `draftcore.CorrectOnce` now takes both channels via `TextOf` (body + reasoning); reply drafts pass no reasoning.
  - Updated account/person composers to supply chip labels; introduced `reasonLabels` helper.

<sup>Written for commit 607891ee1b27eef5b1970d70621c3a76b97a97e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/958?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

