### PR TITLE
ci: drop the docker-images no-op now that its context is not required

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -690,25 +690,6 @@ jobs:
           fi
           make check-ext-migrations
 
-  # The three role images are built, pushed and digest-pinned by release.yml
-  # on every push to main; no PR-side job builds them anymore. Branch
-  # protection still requires the "docker images (api + web + worker)"
-  # context, so this no-op posts it — remove the job together with the
-  # required-context entry in the protection settings.
-  docker-images:
-    name: docker images (api + web + worker)
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    defaults:
-      run:
-        # The workflow default is backend/, which exists only after a checkout
-        # this job doesn't need.
-        working-directory: .
-    steps:
-      - name: No-op — the release build is the image gate
-        run: echo "image builds run in release.yml"
 
   vuln:
     name: govulncheck

--- a/infra/ci-pipeline.md
+++ b/infra/ci-pipeline.md
@@ -55,9 +55,10 @@ Consequences:
   `docker-bake.hcl`) also matches no scope. The role images are built, pushed
   and digest-pinned into the release by `release.yml` on every push to `main`
   — that build is the gate now, so an image break surfaces in the release run
-  rather than the merge gate. Branch protection still requires the
-  `docker images (api + web + worker)` context, so `ci.yml` posts it from a
-  no-op job; drop the job and the required-context entry together.
+  rather than the merge gate. Stated plainly because it is a real trade: a
+  Dockerfile change merges without any image being built, and the first thing
+  to notice is the release. `ci.yml` no longer carries a job for it, and the
+  `docker images (api + web + worker)` context is no longer required.
 - A **backend-only PR** skips the frontend + UAT lanes; a **frontend-only PR**
   skips the Go build/gate + the integration lane — except for
   `frontend/src/mcp-apps/forbidden.json`, which is authored under `frontend/`


### PR DESCRIPTION
## Why

`release.yml` builds, pushes and digest-pins the three role images on every push to `main` via `docker-bake.hcl`, so no PR-side job builds them any more.

What remained in `ci.yml` was a job whose entire body was `echo "image builds run in release.yml"`. It existed only to post the `docker images (api + web + worker)` context that branch protection required — and its own comment said so:

> *"Branch protection still requires the `docker images (api + web + worker)` context, so this no-op posts it — remove the job together with the required-context entry in the protection settings."*

The required-context entry has now been removed, so the job goes with it.

## The doc states the trade rather than the mechanism

`infra/ci-pipeline.md` described a job that will not exist. It now says the thing worth knowing:

> A Dockerfile change merges without any image being built, and the release run is the first thing to notice.

That is a real consequence of moving image builds to the release flow, and it deserves to be written down rather than discovered.

## Verification

- `make ci-doc-parity` — green, 39 + 12 paths
- `make check-image-pins` — green
- No `docker` job or classifier scope remains in `ci.yml` (asserted by parsing the workflow, not by grep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the no-op `docker images (api + web + worker)` job from `ci.yml` now that image builds run in `release.yml` on pushes to `main` and the branch-protection context is no longer required. Updated `infra/ci-pipeline.md` to state the trade: Dockerfile changes can merge without a PR image build; the release run is the first gate.

<sup>Written for commit f14512abe239dc286f3595c45fae4b09e1ab067b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/963?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

