### PR TITLE
refactor(automation): the workflow engine binds per fleet pass

### DIFF
--- a/backend/cmd/worker/boot.go
+++ b/backend/cmd/worker/boot.go
@@ -164,7 +164,7 @@ func startEventLanes(ctx context.Context, cfg workerConfig, pool *pgxpool.Pool, 
 // startWorkflowLane starts the cg:workflows dispatcher. It needs nothing the job
 // runner builds, so it belongs with the other event lanes rather than after it.
 func startWorkflowLane(ctx context.Context, pool *pgxpool.Pool, rdb *redis.Client, modelPath compose.ModelPath, background *sync.WaitGroup, logger *slog.Logger, stdout io.Writer) {
-	workflows := compose.NewWorkflowEngineWithReplyDraft(pool, modelPath.DraftReply)
+	workflows := compose.NewWorkflowEngineWithReplyDraft(compose.InstallationDB(pool), modelPath.DraftReply)
 	_, _ = fmt.Fprintln(stdout, "worker dispatching workflows (cg:workflows)")
 	background.Go(func() { runSubscriber(ctx, rdb, "cg:workflows", workflows.HandleEvent, logger, 0) })
 }

--- a/backend/internal/compose/integration/leadrouting_integration_test.go
+++ b/backend/internal/compose/integration/leadrouting_integration_test.go
@@ -44,7 +44,7 @@ func setupRouting(t *testing.T) *routingEnv {
 		rep2, e.WS); err != nil {
 		t.Fatal(err)
 	}
-	return &routingEnv{SearchEnv: e, Rep2: rep2, engine: compose.NewWorkflowEngine(e.Pool)}
+	return &routingEnv{SearchEnv: e, Rep2: rep2, engine: compose.NewWorkflowEngine(e.DB())}
 }
 
 // routeNewLead seeds one unowned lead and dispatches its lead.created

--- a/backend/internal/compose/integration/leadscore_integration_test.go
+++ b/backend/internal/compose/integration/leadscore_integration_test.go
@@ -28,7 +28,7 @@ import (
 
 func TestLeadScoreRecomputesFromLinkedActivities(t *testing.T) {
 	e := SetupSearch(t)
-	engine := compose.NewWorkflowEngine(e.Pool)
+	engine := compose.NewWorkflowEngine(e.DB())
 	ctx := e.AsFullUser()
 
 	// A working lead with a decision-maker title from a high-intent

--- a/backend/internal/compose/integration/leadscore_override_integration_test.go
+++ b/backend/internal/compose/integration/leadscore_override_integration_test.go
@@ -59,7 +59,7 @@ func TestLeadScoreOverrideColumnsAndRLS(t *testing.T) {
 
 func TestLeadScoreOverrideIsSticky(t *testing.T) {
 	e := SetupSearch(t)
-	engine := compose.NewWorkflowEngine(e.Pool)
+	engine := compose.NewWorkflowEngine(e.DB())
 	ctx := e.AsFullUser()
 	store := people.NewStore(e.Pool)
 	activityStore := activities.NewStore(e.Pool)

--- a/backend/internal/compose/integration/no_activity_eligibility_integration_test.go
+++ b/backend/internal/compose/integration/no_activity_eligibility_integration_test.go
@@ -243,7 +243,7 @@ func TestCleanupMigrationArchivesGeneratedRemindersOnly(t *testing.T) {
 func runEligibilityScan(t *testing.T, e *Env) {
 	t.Helper()
 	quiet := slog.New(slog.NewTextHandler(io.Discard, nil))
-	scanner := compose.NewTimeScannerWithClock(e.Pool, func() time.Time { return eligibilityScanNow }, quiet)
+	scanner := compose.NewTimeScannerWithClock(e.DB(), func() time.Time { return eligibilityScanNow }, quiet)
 	if err := scanner.ScanWorkspace(principal.WithWorkspaceID(context.Background(), e.WS), e.WS); err != nil {
 		t.Fatalf("time-scan pass: %v", err)
 	}

--- a/backend/internal/compose/integration/searchenv.go
+++ b/backend/internal/compose/integration/searchenv.go
@@ -15,6 +15,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/gradionhq/margince/backend/internal/modules/search"
+	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/testdb"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
@@ -183,4 +184,14 @@ func (e *SearchEnv) AsFullUser() context.Context {
 		Type: principal.PrincipalHuman, ID: "human:" + ids.NewV7().String(), UserID: ids.NewV7(),
 		Permissions: principal.Permissions{Objects: grants, RowScope: principal.RowScopeAll},
 	})
+}
+
+// DB is this env's pool, pinned to the workspace it created.
+//
+// Pinned rather than resolved for the reason every raw-SQL harness is: this
+// env builds its workspace directly, so there is no installation for the
+// resolver to find, and the suites that seed a second one need the tenant to
+// be a property of the handle (ADR-0091 §9 step 3).
+func (e *SearchEnv) DB() *database.DB {
+	return database.BindTo(e.Pool, ids.From[ids.WorkspaceKind](e.WS))
 }

--- a/backend/internal/compose/integration/timescan_integration_test.go
+++ b/backend/internal/compose/integration/timescan_integration_test.go
@@ -71,7 +71,7 @@ func TestTimeScannerFiresOnceThenTheOccurrenceKeySuppressesTheRefire(t *testing.
 	seedNoActivityReminder(t, owner, e.WS)
 
 	quiet := slog.New(slog.NewTextHandler(io.Discard, nil))
-	scanner := compose.NewTimeScannerWithClock(e.Pool, now, quiet)
+	scanner := compose.NewTimeScannerWithClock(e.DB(), now, quiet)
 
 	// Pass 1: the deal is stale, so the reminder fires exactly once.
 	if err := scanner.ScanWorkspace(principal.WithWorkspaceID(context.Background(), e.WS), e.WS); err != nil {

--- a/backend/internal/compose/integration/workflow_action_executors_integration_test.go
+++ b/backend/internal/compose/integration/workflow_action_executors_integration_test.go
@@ -70,7 +70,7 @@ func TestNotifyFiringWithNoTransportLandsAVisibleSkippedRun(t *testing.T) {
 	pipeline, open, _ := DealFixture(t, e)
 	dealID := e.SeedDeal(t, "Notify Probe Deal", pipeline, open, nil)
 
-	engine := compose.NewWorkflowEngine(e.Pool)
+	engine := compose.NewWorkflowEngine(e.DB())
 	engine.RegisterSystemWorkflow(notifyNoTransportProbe{})
 
 	ctx := context.Background()
@@ -169,7 +169,7 @@ func TestAddToListFiringAddsARealListMember(t *testing.T) {
 		t.Fatalf("seeding the probe list: %v", err)
 	}
 
-	engine := compose.NewWorkflowEngine(e.Pool)
+	engine := compose.NewWorkflowEngine(e.DB())
 	engine.RegisterSystemWorkflow(addToListProbe{listID: list.ID, lists: testListsAdapter{store: listsStore}})
 
 	ctx := context.Background()
@@ -258,7 +258,7 @@ func TestDraftEmailFiringLandsTheComposedDraftOnTheRunRecord(t *testing.T) {
 	pipeline, open, _ := DealFixture(t, e)
 	dealID := e.SeedDeal(t, "Draft Email Probe Deal", pipeline, open, nil)
 
-	engine := compose.NewWorkflowEngine(e.Pool)
+	engine := compose.NewWorkflowEngine(e.DB())
 	engine.RegisterSystemWorkflow(draftEmailProbe{comms: draftingComms{subject: "Re: next step", body: "Following up on our last conversation."}})
 
 	ctx := context.Background()

--- a/backend/internal/compose/integration/workflow_approval_staging_integration_test.go
+++ b/backend/internal/compose/integration/workflow_approval_staging_integration_test.go
@@ -101,7 +101,7 @@ func TestConfirmationRequiredActionStagesARealApprovalAndRejectionBlocksTheRun(t
 	dealID := e.SeedDeal(t, "Confirmation-Required Probe Deal", pipeline, open, nil)
 
 	svc := approvals.NewService(e.Pool)
-	engine := compose.NewWorkflowEngine(e.Pool)
+	engine := compose.NewWorkflowEngine(e.DB())
 	engine.RegisterSystemWorkflow(confirmationRequiredStagingProbe{
 		approvals: testApprovalsAdapter{svc: svc},
 		toStage:   won.UUID,

--- a/backend/internal/compose/integration/workflow_dispatch_perf_integration_test.go
+++ b/backend/internal/compose/integration/workflow_dispatch_perf_integration_test.go
@@ -70,7 +70,7 @@ const (
 func TestWorkflowTriggerToDispatchP95HoldsOnTheSeededDataset(t *testing.T) {
 	e := Setup(t)
 	seedAllStarterAutomations(t, e)
-	engine := compose.NewWorkflowEngine(e.Pool)
+	engine := compose.NewWorkflowEngine(e.DB())
 
 	// Warmup: discarded, per the file doc comment's fixed-cost note.
 	for _, leadID := range seedTriggerLeads(t, e, dispatchWarmupSamples) {

--- a/backend/internal/compose/integration/workflow_integration_test.go
+++ b/backend/internal/compose/integration/workflow_integration_test.go
@@ -84,7 +84,7 @@ func TestWorkflowRouteLeadAssignsExactlyOnce(t *testing.T) {
 	e := SetupSearch(t)
 	enableLeadRouting(t, e, map[string]any{"owners": []string{e.Rep1.String()}})
 	leadID := e.Seed(t, `INSERT INTO lead (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Fresh Lead', 'manual', 'human:x')`)
-	engine := compose.NewWorkflowEngine(e.Pool)
+	engine := compose.NewWorkflowEngine(e.DB())
 
 	env := kevents.Envelope{
 		EventID:     ids.NewV7(),
@@ -153,7 +153,7 @@ func TestWorkflowRouteLeadAssignsExactlyOnce(t *testing.T) {
 // on the very next event (no cache) with its params applied.
 func TestWorkflowEngineHonorsAutomationInstances(t *testing.T) {
 	e := SetupSearch(t)
-	engine := compose.NewWorkflowEngine(e.Pool)
+	engine := compose.NewWorkflowEngine(e.DB())
 
 	dispatch := func(leadID ids.UUID) {
 		t.Helper()
@@ -245,7 +245,7 @@ func TestWorkflowStageChangeMatchGuardsSemantic(t *testing.T) {
 	if err := e.Owner.QueryRow(context.Background(), `SELECT id FROM deal LIMIT 1`).Scan(&dealID); err != nil {
 		t.Fatal(err)
 	}
-	engine := compose.NewWorkflowEngine(e.Pool)
+	engine := compose.NewWorkflowEngine(e.DB())
 
 	closedPayload, _ := json.Marshal(map[string]string{"to_status": "won"})
 	if err := engine.HandleEvent(context.Background(), kevents.Envelope{

--- a/backend/internal/compose/integration/workflow_replay_integration_test.go
+++ b/backend/internal/compose/integration/workflow_replay_integration_test.go
@@ -94,7 +94,7 @@ func TestWorkflowRunReplaysFromItsPersistedTrace(t *testing.T) {
 	// Dispatch: engine.HandleEvent is the synchronous cg:workflows
 	// consumer call — see the file doc comment for why no bus rides
 	// under this test.
-	engine := compose.NewWorkflowEngine(e.Pool)
+	engine := compose.NewWorkflowEngine(e.DB())
 	if err := engine.HandleEvent(context.Background(), trigger); err != nil {
 		t.Fatalf("dispatching the trigger lead's lead.created: %v", err)
 	}

--- a/backend/internal/compose/jobs.go
+++ b/backend/internal/compose/jobs.go
@@ -374,7 +374,7 @@ func addDatabaseOnlySweepJobs(reg *jobRegistry, pool *pgxpool.Pool, log *slog.Lo
 	addDeclaredWorker[FollowUpReconcileArgs](reg, &followUpReconcileWorker{pool: pool})
 	addDeclaredWorker[FollowUpWorkspaceArgs](reg, &followUpWorkspaceWorker{reconciler: NewFollowUpReconciler(pool, log)})
 	addDeclaredWorker[TimeScanArgs](reg, &timeScanWorker{pool: pool})
-	addDeclaredWorker[TimeScanWorkspaceArgs](reg, &timeScanWorkspaceWorker{scanner: NewTimeScanner(pool, log)})
+	addDeclaredWorker[TimeScanWorkspaceArgs](reg, &timeScanWorkspaceWorker{pool: pool, log: log})
 	addDeclaredWorker[IdempotencyRetentionArgs](reg, &idempotencyRetentionWorker{pool: pool})
 	addDeclaredWorker[IdempotencyRetentionWorkspaceArgs](reg, &idempotencyRetentionWorkspaceWorker{sweeper: NewIdempotencyRetentionSweeper(pool, log)})
 	addDeclaredWorker[AgentTaskRetentionArgs](reg, &agentTaskRetentionWorker{pool: pool})

--- a/backend/internal/compose/jobs_automation.go
+++ b/backend/internal/compose/jobs_automation.go
@@ -10,11 +10,11 @@ package compose
 
 import (
 	"context"
+	"log/slog"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/riverqueue/river"
 
-	"github.com/gradionhq/margince/backend/internal/modules/automation"
 	"github.com/gradionhq/margince/backend/internal/platform/jobs"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
@@ -59,7 +59,8 @@ func (a TimeScanWorkspaceArgs) WorkspaceID() ids.UUID { return a.Workspace }
 // module's TimeScanner — River-agnostic by construction (this file's own doc:
 // the adapters are the only code that knows about River).
 type timeScanWorkspaceWorker struct {
-	scanner *automation.TimeScanner
+	pool *pgxpool.Pool
+	log  *slog.Logger
 }
 
 func (w *timeScanWorkspaceWorker) Work(ctx context.Context, job *river.Job[TimeScanWorkspaceArgs]) error {
@@ -67,5 +68,13 @@ func (w *timeScanWorkspaceWorker) Work(ctx context.Context, job *river.Job[TimeS
 	if err != nil {
 		return jobs.FaultContext(ctx, err)
 	}
-	return jobs.FaultContext(ctx, w.scanner.ScanWorkspace(wsCtx, job.Args.Workspace))
+	// Built per job: this is a fleet pass, so the scanner's engine binds the
+	// workspace THIS job names rather than whatever an installation resolver
+	// would answer (ADR-0091 §9 step 3).
+	db, err := workspaceJobDB(w.pool, job.Args)
+	if err != nil {
+		return jobs.FaultContext(ctx, err)
+	}
+	scanner := NewTimeScanner(db, w.log)
+	return jobs.FaultContext(ctx, scanner.ScanWorkspace(wsCtx, job.Args.Workspace))
 }

--- a/backend/internal/compose/server.go
+++ b/backend/internal/compose/server.go
@@ -376,7 +376,7 @@ func newServer(pool *pgxpool.Pool, log *slog.Logger, authH authHandlers, dealsH 
 		financeHandlers:    finance.NewHandlers(pool, identity.BaseCurrencyOf),
 		signalsHandlers:    signals.NewHandlers(pool, signalStrength{people: people.NewStore(pool)}),
 		privacyHandlers:    privacy.NewHandlers(InstallationDB(pool)),
-		automationHandlers: automation.NewHandlers(pool),
+		automationHandlers: automation.NewHandlers(InstallationDB(pool)),
 		voiceHandlers:      ai.NewHandlers(pool, NewSeatBudget(pool)),
 		reportHandlers:     reportHandlers{engine: newReportEngine(pool)},
 		// The Morning Brief always serves on the deterministic §10.1 floor;

--- a/backend/internal/compose/timescan.go
+++ b/backend/internal/compose/timescan.go
@@ -13,10 +13,9 @@ import (
 	"log/slog"
 	"time"
 
-	"github.com/jackc/pgx/v5/pgxpool"
-
 	"github.com/gradionhq/margince/backend/internal/modules/activities"
 	"github.com/gradionhq/margince/backend/internal/modules/automation"
+	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
 )
 
@@ -51,14 +50,14 @@ func (a activityScanAdapter) LastTouchBefore(ctx context.Context, cutoff time.Ti
 // NewWorkflowEngine builds (so no_activity_reminder's Apply drives
 // through the identical Executors every other starter uses), over the
 // activities-sourced ActivityScan seam.
-func NewTimeScanner(pool *pgxpool.Pool, log *slog.Logger) *automation.TimeScanner {
-	return NewTimeScannerWithClock(pool, time.Now, log)
+func NewTimeScanner(db *database.DB, log *slog.Logger) *automation.TimeScanner {
+	return NewTimeScannerWithClock(db, time.Now, log)
 }
 
 // NewTimeScannerWithClock is NewTimeScanner with an explicit clock — the
 // integration proof pins it so a scan pass evaluates "no activity for N
 // days" against seeded timestamps, never the wall clock.
-func NewTimeScannerWithClock(pool *pgxpool.Pool, now func() time.Time, log *slog.Logger) *automation.TimeScanner {
-	engine := NewWorkflowEngine(pool)
-	return automation.NewTimeScannerWithClock(engine, activityScanAdapter{store: activities.NewStore(pool)}, now, log)
+func NewTimeScannerWithClock(db *database.DB, now func() time.Time, log *slog.Logger) *automation.TimeScanner {
+	engine := NewWorkflowEngine(db)
+	return automation.NewTimeScannerWithClock(engine, activityScanAdapter{store: activities.NewStore(db.Pool())}, now, log)
 }

--- a/backend/internal/compose/workflows.go
+++ b/backend/internal/compose/workflows.go
@@ -10,14 +10,13 @@ package compose
 import (
 	"context"
 
-	"github.com/jackc/pgx/v5/pgxpool"
-
 	"github.com/gradionhq/margince/backend/internal/modules/activities"
 	"github.com/gradionhq/margince/backend/internal/modules/approvals"
 	"github.com/gradionhq/margince/backend/internal/modules/automation"
 	"github.com/gradionhq/margince/backend/internal/modules/collections"
 	"github.com/gradionhq/margince/backend/internal/modules/identity"
 	"github.com/gradionhq/margince/backend/internal/modules/people"
+	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
@@ -31,27 +30,27 @@ import (
 // creates a task) — while the lead-score recompute is a formula
 // obligation (formulas-and-rules §3 — "recomputed on each captured
 // signal") and fires always.
-func NewWorkflowEngine(pool *pgxpool.Pool) *automation.WorkflowEngine {
-	return workflowEngineWithDrafter(pool, nil)
+func NewWorkflowEngine(db *database.DB) *automation.WorkflowEngine {
+	return workflowEngineWithDrafter(db, nil)
 }
 
 // NewWorkflowEngineWithReplyDraft adds the routed reply lane to draft_email
 // actions while preserving NewWorkflowEngine's deterministic default.
-func NewWorkflowEngineWithReplyDraft(pool *pgxpool.Pool, brain completer) *automation.WorkflowEngine {
+func NewWorkflowEngineWithReplyDraft(db *database.DB, brain completer) *automation.WorkflowEngine {
 	if brain == nil {
-		return NewWorkflowEngine(pool)
+		return NewWorkflowEngine(db)
 	}
-	drafter := newReplyDrafter(pool, brain, nil)
-	return workflowEngineWithDrafter(pool, drafter)
+	drafter := newReplyDrafter(db.Pool(), brain, nil)
+	return workflowEngineWithDrafter(db, drafter)
 }
 
-func workflowEngineWithDrafter(pool *pgxpool.Pool, drafter activities.EmailDrafter) *automation.WorkflowEngine {
+func workflowEngineWithDrafter(db *database.DB, drafter activities.EmailDrafter) *automation.WorkflowEngine {
 	// identity.Service implements shared/ports/authz.Resolver — the
 	// match-time owner-permission gate's (gate.go) authority source. The
 	// engine depends only on the port; this is the one place a concrete
 	// identity is injected (ADR-0054 §8), same as platform/auth.NewGate.
-	engine := automation.NewWorkflowEngine(pool, identity.NewService(pool))
-	peopleStore := people.NewStore(pool)
+	engine := automation.NewWorkflowEngine(db, identity.NewService(db.Pool()))
+	peopleStore := people.NewStore(db.Pool())
 	// Executors ride the same per-workspace dispatch as every other
 	// datasource consumer: a starter firing for an overlay-mode
 	// workspace reads/writes through the overlay seam, not silently
@@ -60,14 +59,14 @@ func workflowEngineWithDrafter(pool *pgxpool.Pool, drafter activities.EmailDraft
 	// a starter never triggers a force-fresh spend; its OVB meter is a
 	// fail-closed placeholder (no Redis), never charged.
 	ex := automation.Executors{
-		Provider:  NewDispatcher(NewProvider(pool), NewOverlayProvider(pool, failClosedOverlayMeter(), nil), pool),
-		Approvals: automationApprovalsAdapter{svc: approvals.NewService(pool)},
-		Lists:     listsAdapter{store: collections.NewStore(InstallationDB(pool))},
+		Provider:  NewDispatcher(NewProvider(db.Pool()), NewOverlayProvider(db.Pool(), failClosedOverlayMeter(), nil), db.Pool()),
+		Approvals: automationApprovalsAdapter{svc: approvals.NewService(db.Pool())},
+		Lists:     listsAdapter{store: collections.NewStore(db)},
 		// The zero SendPath is the honest one here: a send_email action
 		// stages an approval instead of sending, and automation.Comms
 		// declares DraftEmail alone, so no send is reachable from this
 		// surface to configure.
-		Comms: newCommsAdapter(pool, drafter, SendPath{}),
+		Comms: newCommsAdapter(db.Pool(), drafter, SendPath{}),
 		// Notifier stays nil: this repo wires no notification transport
 		// (no notification table, the inbox is approvals-only) — a
 		// notify firing surfaces as a visible 'skipped' run instead

--- a/backend/internal/modules/automation/automationhistory_integration_test.go
+++ b/backend/internal/modules/automation/automationhistory_integration_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
@@ -57,7 +58,7 @@ func seedRunHistory(t *testing.T, fx *autoFixture, autoID ids.AutomationID) int 
 
 func TestListRunsPagesNewestFirstScopedToTheInstance(t *testing.T) {
 	fx := setupAutomationDB(t)
-	store := NewAutomationStore(fx.pool)
+	store := NewAutomationStore(database.BindTo(fx.pool, ids.From[ids.WorkspaceKind](fx.ws)))
 	ctx := fx.humanCtx(fx.rep1, principal.RowScopeAll)
 	autoID := fx.seedAutomation(t, "stage_change_create_task")
 	seeded := seedRunHistory(t, fx, autoID)
@@ -91,7 +92,7 @@ func TestListRunsPagesNewestFirstScopedToTheInstance(t *testing.T) {
 
 func TestListRunsOutcomeFilterSpeaksTheWireVocabulary(t *testing.T) {
 	fx := setupAutomationDB(t)
-	store := NewAutomationStore(fx.pool)
+	store := NewAutomationStore(database.BindTo(fx.pool, ids.From[ids.WorkspaceKind](fx.ws)))
 	ctx := fx.humanCtx(fx.rep1, principal.RowScopeAll)
 	autoID := fx.seedAutomation(t, "stage_change_create_task")
 	seedRunHistory(t, fx, autoID)
@@ -114,7 +115,7 @@ func TestListRunsOutcomeFilterSpeaksTheWireVocabulary(t *testing.T) {
 
 func TestListRunsHidesAbsentAndForeignAutomations(t *testing.T) {
 	fx := setupAutomationDB(t)
-	store := NewAutomationStore(fx.pool)
+	store := NewAutomationStore(database.BindTo(fx.pool, ids.From[ids.WorkspaceKind](fx.ws)))
 	ctx := fx.humanCtx(fx.rep1, principal.RowScopeAll)
 
 	if _, err := store.ListRuns(ctx, ids.New[ids.AutomationKind](), nil, nil, nil); !errors.Is(err, apperrors.ErrNotFound) {

--- a/backend/internal/modules/automation/automationpreview_integration_test.go
+++ b/backend/internal/modules/automation/automationpreview_integration_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
@@ -65,7 +66,7 @@ func seedDealBoard(t *testing.T, fx *autoFixture) dealFixture {
 
 func TestPreviewMatchesCurrentRecordsWithoutApplying(t *testing.T) {
 	fx := setupAutomationDB(t)
-	store := NewAutomationStore(fx.pool)
+	store := NewAutomationStore(database.BindTo(fx.pool, ids.From[ids.WorkspaceKind](fx.ws)))
 	autoID := fx.seedAutomation(t, "stage_change_create_task")
 	board := seedDealBoard(t, fx)
 
@@ -124,7 +125,7 @@ func TestPreviewMatchesCurrentRecordsWithoutApplying(t *testing.T) {
 
 func TestPreviewDraftOverrideAndValidation(t *testing.T) {
 	fx := setupAutomationDB(t)
-	store := NewAutomationStore(fx.pool)
+	store := NewAutomationStore(database.BindTo(fx.pool, ids.From[ids.WorkspaceKind](fx.ws)))
 	autoID := fx.seedAutomation(t, "stage_change_create_task")
 	ctx := fx.humanCtx(fx.rep1, principal.RowScopeOwn)
 

--- a/backend/internal/modules/automation/automationrecording_integration_test.go
+++ b/backend/internal/modules/automation/automationrecording_integration_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gradionhq/margince/backend/internal/platform/database"
 	kevents "github.com/gradionhq/margince/backend/internal/shared/kernel/events"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/workflow"
@@ -40,7 +41,7 @@ func TestFiringPathRecordsEveryTerminalOutcomeWithItsReason(t *testing.T) {
 			return workflow.RunResult{}, &workflow.StagedApprovalError{ApprovalID: stagedApproval}
 		}},
 	}
-	engine := NewWorkflowEngine(fx.pool, nil) // nil resolver: these fixtures carry no owner_id, so the match-time gate skips before ever touching it
+	engine := NewWorkflowEngine(database.BindTo(fx.pool, ids.From[ids.WorkspaceKind](fx.ws)), nil) // nil resolver: these fixtures carry no owner_id, so the match-time gate skips before ever touching it
 	for _, h := range handlers {
 		fx.seedAutomation(t, h.name)
 		engine.RegisterWorkflow(h)
@@ -89,7 +90,7 @@ func TestFailedRunReasonNeverLeaksRawProviderErrorInternals(t *testing.T) {
 		},
 	}
 	fx.seedAutomation(t, h.name)
-	engine := NewWorkflowEngine(fx.pool, nil) // nil resolver: this fixture carries no owner_id, so the match-time gate skips before ever touching it
+	engine := NewWorkflowEngine(database.BindTo(fx.pool, ids.From[ids.WorkspaceKind](fx.ws)), nil) // nil resolver: this fixture carries no owner_id, so the match-time gate skips before ever touching it
 	engine.RegisterWorkflow(h)
 
 	env := kevents.Envelope{

--- a/backend/internal/modules/automation/automations.go
+++ b/backend/internal/modules/automation/automations.go
@@ -18,7 +18,6 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
@@ -31,12 +30,14 @@ import (
 // AutomationStore owns the automation table (tableownership: this
 // module) and the catalog lookups the transport needs.
 type AutomationStore struct {
-	pool *pgxpool.Pool
-	now  func() time.Time
+	// db binds the workspace this pass runs for (ADR-0091 §9 step 3).
+	db  *database.DB
+	now func() time.Time
 }
 
-func NewAutomationStore(pool *pgxpool.Pool) *AutomationStore {
-	return &AutomationStore{pool: pool, now: time.Now}
+// NewAutomationStore binds the automation tables to the pool it is given.
+func NewAutomationStore(db *database.DB) *AutomationStore {
+	return &AutomationStore{db: db, now: time.Now}
 }
 
 // Automation is one configured instance.
@@ -99,7 +100,7 @@ func (s *AutomationStore) List(ctx context.Context, cursor *string, limit *int) 
 		args = append(args, c.CreatedAt, c.ID)
 	}
 	var page AutomationPage
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		rows, err := tx.Query(ctx, storekit.SQLf(
 			`SELECT %s FROM automation WHERE %s ORDER BY created_at DESC, id DESC LIMIT %d`,
 			automationColumns, where, n+1), args...)
@@ -135,7 +136,7 @@ func (s *AutomationStore) Get(ctx context.Context, id ids.AutomationID) (Automat
 		return Automation{}, err
 	}
 	var a Automation
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		var err error
 		a, err = scanAutomation(tx.QueryRow(ctx, storekit.SQLf(
 			`SELECT %s FROM automation WHERE id = $1 AND archived_at IS NULL`, automationColumns), id))
@@ -183,7 +184,7 @@ func (s *AutomationStore) Create(ctx context.Context, in CreateAutomationInput) 
 	}
 
 	var a Automation
-	err = database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err = s.db.Tx(ctx, func(tx pgx.Tx) error {
 		var err error
 		a, err = scanAutomation(tx.QueryRow(ctx, storekit.SQLf(`
 			INSERT INTO automation (workspace_id, key, name, origin, trigger, action, params, owner_id, enabled, tier)
@@ -212,7 +213,7 @@ func (s *AutomationStore) Update(ctx context.Context, id ids.AutomationID, in Up
 		return Automation{}, err
 	}
 	var a Automation
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		// The row lock makes the state read and the update below one
 		// race-free unit.
 		if _, err := storekit.LockRow(ctx, tx, "automation", id.UUID, storekit.LiveOnly); err != nil {
@@ -280,7 +281,7 @@ func (s *AutomationStore) Archive(ctx context.Context, id ids.AutomationID) erro
 	if err := auth.Require(ctx, "automation", principal.ActionDelete); err != nil {
 		return err
 	}
-	return database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	return s.db.Tx(ctx, func(tx pgx.Tx) error {
 		before, err := scanAutomation(tx.QueryRow(ctx, storekit.SQLf(
 			`SELECT %s FROM automation WHERE id = $1 AND archived_at IS NULL`, automationColumns), id))
 		if errors.Is(err, pgx.ErrNoRows) {

--- a/backend/internal/modules/automation/automations_preview.go
+++ b/backend/internal/modules/automation/automations_preview.go
@@ -20,7 +20,6 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
@@ -262,7 +261,7 @@ func (s *AutomationStore) Preview(ctx context.Context, id ids.AutomationID, in A
 
 	since := s.now().UTC().AddDate(0, 0, -window)
 	res := AutomationPreviewResult{WindowDays: window}
-	err = database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err = s.db.Tx(ctx, func(tx pgx.Tx) error {
 		return def.measure(ctx, tx, since, &res)
 	})
 	if err != nil {

--- a/backend/internal/modules/automation/automations_runs.go
+++ b/backend/internal/modules/automation/automations_runs.go
@@ -18,7 +18,6 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
@@ -91,7 +90,7 @@ func (s *AutomationStore) ListRuns(ctx context.Context, id ids.AutomationID, cur
 	n := storekit.ClampLimit(limit)
 
 	var page AutomationRunPage
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		var key, tier string
 		err := tx.QueryRow(ctx,
 			`SELECT key, tier FROM automation WHERE id = $1 AND archived_at IS NULL`, id).Scan(&key, &tier)

--- a/backend/internal/modules/automation/engine.go
+++ b/backend/internal/modules/automation/engine.go
@@ -19,7 +19,6 @@ import (
 	"sync"
 
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/diffhash"
@@ -42,7 +41,8 @@ type WorkflowEngine struct {
 	// automations, so the catalog and the paused/enabled surface do not
 	// apply to them.
 	system []workflow.Handler
-	pool   *pgxpool.Pool
+	// db binds the workspace this pass runs for (ADR-0091 §9 step 3).
+	db *database.DB
 	// resolver backs the match-time owner-permission gate (gate.go,
 	// AUTO-T06): the ratified authz.Resolver seam, never modules/identity
 	// directly (a module never imports a sibling) — the composition root
@@ -54,8 +54,8 @@ type WorkflowEngine struct {
 // the match-time owner gate re-checks each human-authored firing against
 // (gate.go). compose injects the real resolver; a nil one fails firings
 // closed rather than waving them through.
-func NewWorkflowEngine(pool *pgxpool.Pool, resolver authz.Resolver) *WorkflowEngine {
-	return &WorkflowEngine{pool: pool, resolver: resolver}
+func NewWorkflowEngine(db *database.DB, resolver authz.Resolver) *WorkflowEngine {
+	return &WorkflowEngine{db: db, resolver: resolver}
 }
 
 // RegisterWorkflow adds one handler at composition time.
@@ -204,7 +204,7 @@ type automationInstance struct {
 // binds on the very next dispatch, no cache to invalidate.
 func (e *WorkflowEngine) liveInstances(ctx context.Context) (map[string][]automationInstance, error) {
 	out := map[string][]automationInstance{}
-	err := database.WithWorkspaceTx(ctx, e.pool, func(tx pgx.Tx) error {
+	err := e.db.Tx(ctx, func(tx pgx.Tx) error {
 		rows, err := tx.Query(ctx,
 			`SELECT id, key, params, owner_id FROM automation WHERE enabled AND archived_at IS NULL ORDER BY created_at, id`)
 		if err != nil {

--- a/backend/internal/modules/automation/engine_blocked.go
+++ b/backend/internal/modules/automation/engine_blocked.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	kevents "github.com/gradionhq/margince/backend/internal/shared/kernel/events"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
@@ -67,7 +66,7 @@ func (e *WorkflowEngine) MarkRunBlocked(ctx context.Context, approvalID ids.Appr
 	if err != nil {
 		return fmt.Errorf("automation: encoding the blocked reason: %w", err)
 	}
-	return database.WithWorkspaceTx(ctx, e.pool, func(tx pgx.Tx) error {
+	return e.db.Tx(ctx, func(tx pgx.Tx) error {
 		_, err := tx.Exec(ctx, `
 			UPDATE workflow_run SET status = 'blocked', detail = $2
 			WHERE status = 'requires_approval' AND detail->>'approval_id' = $1`,

--- a/backend/internal/modules/automation/engine_run.go
+++ b/backend/internal/modules/automation/engine_run.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/workflow"
@@ -141,7 +140,7 @@ func (e *WorkflowEngine) runOne(ctx context.Context, h workflow.Handler, ev work
 // Split out of runOne so the dispatch flow above stays readable as the
 // outcome vocabulary grows.
 func (e *WorkflowEngine) recordApplyOutcome(ctx context.Context, h workflow.Handler, ev workflow.Event, result workflow.RunResult, applyErr error) error {
-	return database.WithWorkspaceTx(ctx, e.pool, func(tx pgx.Tx) error {
+	return e.db.Tx(ctx, func(tx pgx.Tx) error {
 		var staged *workflow.StagedApprovalError
 		switch {
 		case errors.As(applyErr, &staged):
@@ -207,7 +206,7 @@ func (e *WorkflowEngine) recordApplyOutcome(ctx context.Context, h workflow.Hand
 // column guards against).
 func (e *WorkflowEngine) claimRun(ctx context.Context, h workflow.Handler, ev workflow.Event, planned []byte, status string, detail []byte) (bool, error) {
 	claimed := false
-	err := database.WithWorkspaceTx(ctx, e.pool, func(tx pgx.Tx) error {
+	err := e.db.Tx(ctx, func(tx pgx.Tx) error {
 		tag, err := tx.Exec(ctx, `
 			INSERT INTO workflow_run (workspace_id, handler, idempotency_key, trigger_event, planned, status, detail)
 			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, $2, $3, $4, $5, $6)

--- a/backend/internal/modules/automation/gate_integration_test.go
+++ b/backend/internal/modules/automation/gate_integration_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gradionhq/margince/backend/internal/platform/database"
 	kevents "github.com/gradionhq/margince/backend/internal/shared/kernel/events"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
@@ -81,7 +82,7 @@ func TestMatchTimeGateBlocksAFiringWhoseOwnerLostThePermission(t *testing.T) {
 	resolver := fixtureResolver{rbac: authz.RBAC{Permissions: principal.Permissions{
 		Objects: map[string]principal.ObjectGrant{}, // the owner's RBAC no longer grants anything
 	}}}
-	engine := NewWorkflowEngine(fx.pool, resolver)
+	engine := NewWorkflowEngine(database.BindTo(fx.pool, ids.From[ids.WorkspaceKind](fx.ws)), resolver)
 	engine.RegisterWorkflow(handler)
 
 	if err := engine.HandleEvent(context.Background(), gateTestEnvelope(fx.ws)); err != nil {
@@ -127,7 +128,7 @@ func TestMatchTimeGateAllowsAFiringWhoseOwnerStillHasThePermission(t *testing.T)
 	resolver := fixtureResolver{rbac: authz.RBAC{Permissions: principal.Permissions{
 		Objects: map[string]principal.ObjectGrant{"activity": {Create: true}},
 	}}}
-	engine := NewWorkflowEngine(fx.pool, resolver)
+	engine := NewWorkflowEngine(database.BindTo(fx.pool, ids.From[ids.WorkspaceKind](fx.ws)), resolver)
 	engine.RegisterWorkflow(handler)
 
 	if err := engine.HandleEvent(context.Background(), gateTestEnvelope(fx.ws)); err != nil {
@@ -164,7 +165,7 @@ func TestMatchTimeGateSkipsASeededAutomationWithNoOwner(t *testing.T) {
 	fx.seedAutomation(t, handler.name) // no owner_id: the system-seed shape
 
 	resolver := fixtureResolver{err: errors.New("must never be called for a NULL-owner automation")}
-	engine := NewWorkflowEngine(fx.pool, resolver)
+	engine := NewWorkflowEngine(database.BindTo(fx.pool, ids.From[ids.WorkspaceKind](fx.ws)), resolver)
 	engine.RegisterWorkflow(handler)
 
 	if err := engine.HandleEvent(context.Background(), gateTestEnvelope(fx.ws)); err != nil {

--- a/backend/internal/modules/automation/handlers_automations.go
+++ b/backend/internal/modules/automation/handlers_automations.go
@@ -12,10 +12,10 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/jackc/pgx/v5/pgxpool"
 	openapi_types "github.com/oapi-codegen/runtime/types"
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/httperr"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/workflow"
@@ -33,8 +33,9 @@ type Handlers struct {
 	automations *AutomationStore
 }
 
-func NewHandlers(pool *pgxpool.Pool) Handlers {
-	return Handlers{automations: NewAutomationStore(pool)}
+// NewHandlers wires the transport over the installation-bound pool.
+func NewHandlers(db *database.DB) Handlers {
+	return Handlers{automations: NewAutomationStore(db)}
 }
 
 // ListAutomationCatalog implements (GET /automations/catalog).

--- a/backend/internal/modules/automation/handlers_clock_integration_test.go
+++ b/backend/internal/modules/automation/handlers_clock_integration_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
@@ -124,7 +125,7 @@ func checkInClockEvent(t *testing.T, ws ids.UUID, automationID ids.AutomationID,
 func TestCheckInCadenceFiresOncePerQuietSpell(t *testing.T) {
 	fx := setupAutomationDB(t)
 	provider := &fakeCreateTaskProvider{}
-	engine := NewWorkflowEngine(fx.pool, nil) // nil resolver: this fixture's instance carries no owner_id, so the match-time gate skips before ever touching it
+	engine := NewWorkflowEngine(database.BindTo(fx.pool, ids.From[ids.WorkspaceKind](fx.ws)), nil) // nil resolver: this fixture's instance carries no owner_id, so the match-time gate skips before ever touching it
 	h := checkInCadence{ex: Executors{Provider: provider}}
 	instanceID := fx.seedAutomation(t, checkInCadenceName)
 	entity := datasource.EntityRef{Type: datasource.EntityDeal, ID: ids.NewV7()}
@@ -186,7 +187,7 @@ func TestCheckInCadenceFiresOncePerQuietSpell(t *testing.T) {
 // never a fabricated firing.
 func TestRenewalReminderScanIsANoOpWhenUnconfigured(t *testing.T) {
 	fx := setupAutomationDB(t)
-	engine := NewWorkflowEngine(fx.pool, nil)
+	engine := NewWorkflowEngine(database.BindTo(fx.pool, ids.From[ids.WorkspaceKind](fx.ws)), nil)
 	engine.RegisterWorkflow(renewalReminder{ex: Executors{}}) // Apply is never reached: Match never runs for an un-enumerated handler
 	fx.seedAutomation(t, renewalReminderName)
 

--- a/backend/internal/modules/automation/occurrence_integration_test.go
+++ b/backend/internal/modules/automation/occurrence_integration_test.go
@@ -27,6 +27,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
@@ -98,7 +99,7 @@ func clockPass(ws ids.UUID, automationID ids.AutomationID, entity datasource.Ent
 // firing actually happened.
 func TestClockTriggerFiresAfterEarlierNonMatchingPasses(t *testing.T) {
 	fx := setupAutomationDB(t)
-	engine := NewWorkflowEngine(fx.pool, nil) // nil resolver: these fixtures carry no owner_id, so the match-time gate skips before ever touching it
+	engine := NewWorkflowEngine(database.BindTo(fx.pool, ids.From[ids.WorkspaceKind](fx.ws)), nil) // nil resolver: these fixtures carry no owner_id, so the match-time gate skips before ever touching it
 	instanceID := fx.seedAutomation(t, "clock_first_firing")
 	entity := datasource.EntityRef{Type: datasource.EntityDeal, ID: ids.NewV7()}
 	runCtx := principal.WithWorkspaceID(context.Background(), fx.ws)
@@ -142,7 +143,7 @@ func TestClockTriggerFiresAfterEarlierNonMatchingPasses(t *testing.T) {
 // last_activity_at, say) would have re-armed it.
 func TestClockTriggerAtMostOnceOnAnUnchangedAnchor(t *testing.T) {
 	fx := setupAutomationDB(t)
-	engine := NewWorkflowEngine(fx.pool, nil) // nil resolver: these fixtures carry no owner_id, so the match-time gate skips before ever touching it
+	engine := NewWorkflowEngine(database.BindTo(fx.pool, ids.From[ids.WorkspaceKind](fx.ws)), nil) // nil resolver: these fixtures carry no owner_id, so the match-time gate skips before ever touching it
 	instanceID := fx.seedAutomation(t, "clock_at_most_once")
 	entity := datasource.EntityRef{Type: datasource.EntityDeal, ID: ids.NewV7()}
 	runCtx := principal.WithWorkspaceID(context.Background(), fx.ws)
@@ -177,7 +178,7 @@ func TestClockTriggerAtMostOnceOnAnUnchangedAnchor(t *testing.T) {
 // again after a fresh burst of inactivity) must fire again.
 func TestClockTriggerRearmsWhenTheAnchorMoves(t *testing.T) {
 	fx := setupAutomationDB(t)
-	engine := NewWorkflowEngine(fx.pool, nil) // nil resolver: these fixtures carry no owner_id, so the match-time gate skips before ever touching it
+	engine := NewWorkflowEngine(database.BindTo(fx.pool, ids.From[ids.WorkspaceKind](fx.ws)), nil) // nil resolver: these fixtures carry no owner_id, so the match-time gate skips before ever touching it
 	instanceID := fx.seedAutomation(t, "clock_rearm")
 	entity := datasource.EntityRef{Type: datasource.EntityDeal, ID: ids.NewV7()}
 	runCtx := principal.WithWorkspaceID(context.Background(), fx.ws)


### PR DESCRIPTION
`automation` comes back (it was pulled from #917), with the fleet path done deliberately rather than substituted.

**6 of 20 modules on the handle; 398 `WithWorkspaceTx` sites left.**

## The engine is built per fleet pass

The time-scan pass runs one job per workspace, and its scanner carries a workflow engine. Built once and shared, that engine answers every workspace's scan with whatever the installation resolver says — a **refusal** while more than one workspace exists, and a **right-by-accident** answer when one does. Neither is what the job means.

It is built per job now, from the workspace the job names, through the `workspaceJobDB` seam retention established in #917.

The engine's other two callers keep resolving, because they are not fleet paths: the HTTP surface, and the `cg:workflows` subscriber, which handles one event at a time for the installation it serves.

## The three binding kinds are now stable

| caller | binding |
|---|---|
| request paths, bus consumers | **resolve** |
| fleet jobs | **pin from job args** (`workspaceJobDB`) |
| raw-SQL harnesses | **pin per tenant** (`e.DB()` / `e.DBFor(ws)`) |

`SearchEnv` is the third env to need a pinned handle, which is what makes this feel like a settled shape rather than three coincidences.

## webhooks stays out, deliberately

Its `Deliverer` is shared across **three** per-workspace paths — the bus consumer, the retry sweep, and HTTP replay — so making it fleet-safe means making it per-workspace throughout. The failure mode there is delivering one tenant's data to another tenant's endpoint, so it gets its own change rather than a corner of this one.

## Verification

`make check-backend` and `make craft-static` (0/0/0) green. The tenant-isolation suite is CI's word, and on this branch it is the check that matters: the engine now decides tenancy by handle, and any fixture still switching tenants by context will fail loudly rather than quietly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bind the workflow engine to the specific workspace for fleet passes (time-scan) using a workspace-pinned DB handle. This removes installation-based ambiguity and enforces tenant-accurate scans.

- **Refactors**
  - `compose.NewWorkflowEngine` and `NewTimeScanner` now accept `*database.DB` instead of `*pgxpool.Pool`.
  - Fleet job `timeScanWorkspaceWorker` builds the scanner per job via `workspaceJobDB`; tenancy is set by the job’s workspace.
  - HTTP and `cg:workflows` keep installation-scoped resolution via `InstallationDB(pool)`.
  - Raw-SQL harnesses pin per tenant; added `SearchEnv.DB()`. Tests use `compose.NewWorkflowEngine(e.DB())` and `NewTimeScanner(e.DB(), ...)`.
  - `AutomationStore` is constructed with `*database.DB`; `automation.NewHandlers` now receives `InstallationDB(pool)`.
  - Webhooks unchanged; handled in a dedicated follow-up to avoid cross-tenant delivery risks.

- **Migration**
  - Replace `compose.NewWorkflowEngine(pool)` with `compose.NewWorkflowEngine(db)`.
  - Use `database.BindTo(pool, workspaceID)` for fleet/tenant-pinned paths, or `compose.InstallationDB(pool)` for installation-scoped paths.
  - Replace `NewTimeScanner(pool, ...)` with `NewTimeScanner(db, ...)`.
  - Construct automation pieces with `automation.NewAutomationStore(db)` and `automation.NewHandlers(db)`.

<sup>Written for commit ffe84ef10a68e569ebc92985014f9c299c3699f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/965?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

