### PR TITLE
refactor(capture): the module's stores read through the bound pool

### DIFF
--- a/backend/internal/compose/backfilltransport_integration_test.go
+++ b/backend/internal/compose/backfilltransport_integration_test.go
@@ -167,7 +167,7 @@ func setupBackfillWire(t *testing.T) *backfillWireEnv {
 	e := integration.Setup(t)
 	integration.ApplyRiverSchema(t)
 	quiet := slog.New(slog.NewTextHandler(io.Discard, nil))
-	registry := capture.NewRegistry(e.Pool, capture.NewSink(e.Pool), backfillAuthority{}, keyvault.NewMemory())
+	registry := capture.NewRegistry(e.DB(), capture.NewSink(e.DB()), backfillAuthority{}, keyvault.NewMemory())
 	gm := &backfillFakeConnector{name: "gmail", messages: 25, pageSize: 10}
 	registry.Register(gm)
 	registry.Register(plainSyncConnector{})

--- a/backend/internal/compose/capture.go
+++ b/backend/internal/compose/capture.go
@@ -130,7 +130,7 @@ func CaptureConfigFromDeploy(c deployconfig.Capture, log *slog.Logger) CaptureCo
 // the deployment's suppression-list additions and the logger; the zero value is
 // the baselines and the default logger.
 func NewCaptureRegistry(pool *pgxpool.Pool, vault keyvault.Vault, cfg CaptureConfig) *capture.Registry {
-	r := capture.NewRegistry(pool, newCaptureSink(pool, cfg), identity.NewService(pool), vault)
+	r := capture.NewRegistry(InstallationDB(pool), newCaptureSink(pool, cfg), identity.NewService(pool), vault)
 	// The standing IMAP connector needs no deployment config — credentials
 	// are per-connection, vault-sealed — so every capture-capable role
 	// carries it.
@@ -157,7 +157,7 @@ func newCaptureSink(pool *pgxpool.Pool, cfg CaptureConfig) *capture.Sink {
 		triage: newDomainTriageTrigger(pool, cfg.logger()),
 		log:    cfg.logger(),
 	}
-	return capture.NewSink(pool).
+	return capture.NewSink(InstallationDB(pool)).
 		// The files a captured message carried, written by the module that owns
 		// the attachment table. Built here, from the store, so every role that
 		// composes a sink gets the same one — the worker runs mail capture and

--- a/backend/internal/compose/capturedfiles_integration_test.go
+++ b/backend/internal/compose/capturedfiles_integration_test.go
@@ -37,7 +37,7 @@ import (
 
 // captureWorkspace seeds a workspace and returns a context bound to it under
 // the per-user mail connector principal the sync loop mints.
-func captureWorkspace(t *testing.T) (context.Context, *pgxpool.Pool, string) {
+func captureWorkspace(t *testing.T) (context.Context, *database.DB, string) {
 	t.Helper()
 	pool := integration.SchemaPool(t)
 	ws := ids.NewV7()
@@ -63,7 +63,7 @@ func captureWorkspace(t *testing.T) (context.Context, *pgxpool.Pool, string) {
 	// The tag makes every source id unique to this run. The test database is
 	// shared and long-lived, so a fixed id would meet rows an earlier run of
 	// this same suite left behind and count them as this run's.
-	return principal.WithCorrelationID(ctx, ids.NewV7()), pool, ws.String()
+	return principal.WithCorrelationID(ctx, ids.NewV7()), database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), ws.String()
 }
 
 // mailRecord is one captured mail record, shaped the way mailmap produces one.
@@ -117,10 +117,10 @@ func onePDF() connector.Part {
 	}
 }
 
-func filesFor(ctx context.Context, t *testing.T, pool *pgxpool.Pool, sourceID string) []capturedFile {
+func filesFor(ctx context.Context, t *testing.T, db *database.DB, sourceID string) []capturedFile {
 	t.Helper()
 	var out []capturedFile
-	if err := database.WithWorkspaceTx(ctx, pool, func(tx pgx.Tx) error {
+	if err := db.Tx(ctx, func(tx pgx.Tx) error {
 		rows, err := tx.Query(ctx, `
 			SELECT filename, content_type, declared_type, category, storage_key,
 			       byte_size, external_part_id, external_source_id, organization_id::text
@@ -147,16 +147,16 @@ func filesFor(ctx context.Context, t *testing.T, pool *pgxpool.Pool, sourceID st
 }
 
 func TestACapturedMessagesFileBecomesAnAttachment(t *testing.T) {
-	ctx, pool, tag := captureWorkspace(t)
+	ctx, db, tag := captureWorkspace(t)
 	blob := blobstore.NewMemory()
-	sink := capture.NewSink(pool).WithFileKeeper(fileKeeper(pool, blob))
+	sink := capture.NewSink(db).WithFileKeeper(fileKeeper(db.Pool(), blob))
 
 	rec := withFiles(mailRecord("msg-with-file-"+tag), onePDF())
 	if _, err := sink.Upsert(ctx, rec); err != nil {
 		t.Fatalf("capture: %v", err)
 	}
 
-	files := filesFor(ctx, t, pool, "msg-with-file-"+tag)
+	files := filesFor(ctx, t, db, "msg-with-file-"+tag)
 	if len(files) != 1 {
 		t.Fatalf("stored %d files, want 1", len(files))
 	}
@@ -193,8 +193,8 @@ func TestACapturedMessagesFileBecomesAnAttachment(t *testing.T) {
 
 // DOC-AC-8: the same provider message pulled twice produces one row per part.
 func TestTheSameMessagePulledTwiceStoresItsFileOnce(t *testing.T) {
-	ctx, pool, tag := captureWorkspace(t)
-	sink := capture.NewSink(pool).WithFileKeeper(fileKeeper(pool, blobstore.NewMemory()))
+	ctx, db, tag := captureWorkspace(t)
+	sink := capture.NewSink(db).WithFileKeeper(fileKeeper(db.Pool(), blobstore.NewMemory()))
 
 	rec := withFiles(mailRecord("msg-pulled-twice-"+tag), onePDF())
 	for pull := 1; pull <= 2; pull++ {
@@ -203,7 +203,7 @@ func TestTheSameMessagePulledTwiceStoresItsFileOnce(t *testing.T) {
 		}
 	}
 
-	if files := filesFor(ctx, t, pool, "msg-pulled-twice-"+tag); len(files) != 1 {
+	if files := filesFor(ctx, t, db, "msg-pulled-twice-"+tag); len(files) != 1 {
 		t.Errorf("stored %d files after two pulls of one message, want 1", len(files))
 	}
 }
@@ -217,27 +217,27 @@ func TestTheSameMessagePulledTwiceStoresItsFileOnce(t *testing.T) {
 // This is what holds when two pulls of one mailbox overlap in time and both
 // reach the insert.
 func TestTheDatabaseRefusesASecondRowForTheSameProviderPart(t *testing.T) {
-	ctx, pool, tag := captureWorkspace(t)
-	sink := capture.NewSink(pool).WithFileKeeper(fileKeeper(pool, blobstore.NewMemory()))
+	ctx, db, tag := captureWorkspace(t)
+	sink := capture.NewSink(db).WithFileKeeper(fileKeeper(db.Pool(), blobstore.NewMemory()))
 
 	rec := withFiles(mailRecord("msg-racing-pulls-"+tag), onePDF())
 	if _, err := sink.Upsert(ctx, rec); err != nil {
 		t.Fatalf("capture: %v", err)
 	}
-	stored := filesFor(ctx, t, pool, "msg-racing-pulls-"+tag)
+	stored := filesFor(ctx, t, db, "msg-racing-pulls-"+tag)
 	if len(stored) != 1 {
 		t.Fatalf("stored %d files, want 1 before the duplicate is attempted", len(stored))
 	}
 
 	// The same (message, part) identity, written as a concurrent pull would.
-	err := database.WithWorkspaceTx(ctx, pool, func(tx pgx.Tx) error {
+	err := db.Tx(ctx, func(tx pgx.Tx) error {
 		_, err := tx.Exec(ctx, `
 			INSERT INTO attachment (
 				workspace_id, entity_type, entity_id, filename, storage_key,
 				source, captured_by, external_source_id, external_part_id)
 			VALUES (current_setting('app.workspace_id')::uuid, 'activity', $1, 'contract.pdf',
 			        'some/other/key', 'imap', 'connector:imap', $2, $3)`,
-			activityOf(ctx, t, pool, "imap:msg-racing-pulls-"+tag),
+			activityOf(ctx, t, db, "imap:msg-racing-pulls-"+tag),
 			"imap:msg-racing-pulls-"+tag, *stored[0].partID)
 		return err
 	})
@@ -245,7 +245,7 @@ func TestTheDatabaseRefusesASecondRowForTheSameProviderPart(t *testing.T) {
 		t.Fatal("a second row for the same provider part was accepted — the part identity is not unique")
 	}
 
-	if files := filesFor(ctx, t, pool, "msg-racing-pulls-"+tag); len(files) != 1 {
+	if files := filesFor(ctx, t, db, "msg-racing-pulls-"+tag); len(files) != 1 {
 		t.Errorf("stored %d files, want the one the refused duplicate did not add", len(files))
 	}
 }
@@ -253,8 +253,8 @@ func TestTheDatabaseRefusesASecondRowForTheSameProviderPart(t *testing.T) {
 // A deployment with no object store keeps the correspondence and no files.
 // Refusing the message would lose a real exchange over an operator's omission.
 func TestWithNoObjectStoreTheMessageLandsAndItsFilesDoNot(t *testing.T) {
-	ctx, pool, tag := captureWorkspace(t)
-	sink := capture.NewSink(pool)
+	ctx, db, tag := captureWorkspace(t)
+	sink := capture.NewSink(db)
 
 	rec := withFiles(mailRecord("msg-no-store-"+tag), onePDF())
 	ref, err := sink.Upsert(ctx, rec)
@@ -264,7 +264,7 @@ func TestWithNoObjectStoreTheMessageLandsAndItsFilesDoNot(t *testing.T) {
 	if ref.ID == (ids.UUID{}) {
 		t.Fatal("the message itself was not captured")
 	}
-	if files := filesFor(ctx, t, pool, "msg-no-store-"+tag); len(files) != 0 {
+	if files := filesFor(ctx, t, db, "msg-no-store-"+tag); len(files) != 0 {
 		t.Errorf("stored %d files with no object store configured, want 0", len(files))
 	}
 }
@@ -272,8 +272,8 @@ func TestWithNoObjectStoreTheMessageLandsAndItsFilesDoNot(t *testing.T) {
 // DOC-AC-12: what the bounds refused is observable, so a message whose files
 // were dropped is not silently identical to one that carried none.
 func TestARefusedFileLeavesAnObservableReason(t *testing.T) {
-	ctx, pool, tag := captureWorkspace(t)
-	sink := capture.NewSink(pool).WithFileKeeper(fileKeeper(pool, blobstore.NewMemory()))
+	ctx, db, tag := captureWorkspace(t)
+	sink := capture.NewSink(db).WithFileKeeper(fileKeeper(db.Pool(), blobstore.NewMemory()))
 
 	rec := mailRecord("msg-dropped-file-" + tag)
 	rec.PartDrops = []connector.PartDrop{{Reason: "part_too_large", Count: 3}}
@@ -282,7 +282,7 @@ func TestARefusedFileLeavesAnObservableReason(t *testing.T) {
 	}
 
 	var logged int
-	if err := database.WithWorkspaceTx(ctx, pool, func(tx pgx.Tx) error {
+	if err := db.Tx(ctx, func(tx pgx.Tx) error {
 		return tx.QueryRow(ctx, `
 			SELECT count(*) FROM system_log
 			 WHERE action = 'capture_parts_dropped'
@@ -312,11 +312,11 @@ func fileKeeper(pool *pgxpool.Pool, blob blobstore.Store) capture.FileKeeper {
 // stays the activity — so a message filed against nobody rolls up to nothing
 // and its file is reachable from the timeline alone.
 func TestACapturedFileRollsUpToTheCompanyItsMessageIsFiledUnder(t *testing.T) {
-	ctx, pool, tag := captureWorkspace(t)
-	sink := capture.NewSink(pool).WithFileKeeper(fileKeeper(pool, blobstore.NewMemory()))
+	ctx, db, tag := captureWorkspace(t)
+	sink := capture.NewSink(db).WithFileKeeper(fileKeeper(db.Pool(), blobstore.NewMemory()))
 
 	orgID := ids.NewV7()
-	if err := database.WithWorkspaceTx(ctx, pool, func(tx pgx.Tx) error {
+	if err := db.Tx(ctx, func(tx pgx.Tx) error {
 		_, err := tx.Exec(ctx, `
 			INSERT INTO organization (id, workspace_id, display_name, source, captured_by)
 			VALUES ($1, current_setting('app.workspace_id')::uuid, 'Voltaq', 'manual', 'human:test')`,
@@ -332,7 +332,7 @@ func TestACapturedFileRollsUpToTheCompanyItsMessageIsFiledUnder(t *testing.T) {
 		t.Fatalf("capture: %v", err)
 	}
 
-	files := filesFor(ctx, t, pool, "msg-filed-"+tag)
+	files := filesFor(ctx, t, db, "msg-filed-"+tag)
 	if len(files) != 1 {
 		t.Fatalf("stored %d files, want 1", len(files))
 	}
@@ -346,14 +346,14 @@ func TestACapturedFileRollsUpToTheCompanyItsMessageIsFiledUnder(t *testing.T) {
 // company. An empty roll-up keeps the file out of every account library; a
 // guessed one puts it in somebody else's.
 func TestACapturedFileFiledAgainstNobodyRollsUpToNothing(t *testing.T) {
-	ctx, pool, tag := captureWorkspace(t)
-	sink := capture.NewSink(pool).WithFileKeeper(fileKeeper(pool, blobstore.NewMemory()))
+	ctx, db, tag := captureWorkspace(t)
+	sink := capture.NewSink(db).WithFileKeeper(fileKeeper(db.Pool(), blobstore.NewMemory()))
 
 	if _, err := sink.Upsert(ctx, withFiles(mailRecord("msg-unfiled-"+tag), onePDF())); err != nil {
 		t.Fatalf("capture: %v", err)
 	}
 
-	files := filesFor(ctx, t, pool, "msg-unfiled-"+tag)
+	files := filesFor(ctx, t, db, "msg-unfiled-"+tag)
 	if len(files) != 1 {
 		t.Fatalf("stored %d files, want 1", len(files))
 	}
@@ -365,10 +365,10 @@ func TestACapturedFileFiledAgainstNobodyRollsUpToNothing(t *testing.T) {
 
 // activityOf reads the activity a captured file hangs off, so a duplicate can
 // be written against the same parent the real one has.
-func activityOf(ctx context.Context, t *testing.T, pool *pgxpool.Pool, sourceKey string) ids.UUID {
+func activityOf(ctx context.Context, t *testing.T, db *database.DB, sourceKey string) ids.UUID {
 	t.Helper()
 	var id ids.UUID
-	if err := database.WithWorkspaceTx(ctx, pool, func(tx pgx.Tx) error {
+	if err := db.Tx(ctx, func(tx pgx.Tx) error {
 		return tx.QueryRow(ctx,
 			`SELECT entity_id FROM attachment WHERE external_source_id = $1 LIMIT 1`,
 			sourceKey).Scan(&id)

--- a/backend/internal/compose/captureparticipant_integration_test.go
+++ b/backend/internal/compose/captureparticipant_integration_test.go
@@ -98,7 +98,7 @@ func readParticipants(t *testing.T, e *integration.Env, activityID ids.UUID) []p
 // connector principal.
 func captureMail(t *testing.T, e *integration.Env, owner ids.UUID, sourceID, direction, counterparty string) ids.UUID {
 	t.Helper()
-	sink := capture.NewSink(e.Pool)
+	sink := capture.NewSink(e.DB())
 	ref, err := sink.Upsert(mailboxOwnerCtx(e, owner), connector.NormalizedRecord{
 		EntityType:   "activity",
 		NaturalKey:   connector.NaturalKey{SourceSystem: "gmail", SourceID: sourceID},

--- a/backend/internal/compose/channelconnect.go
+++ b/backend/internal/compose/channelconnect.go
@@ -30,6 +30,6 @@ import (
 func WithChannelSurface() Option {
 	return func(s *Server, pool *pgxpool.Pool) {
 		s.channelHandlers = capture.NewChannelHandlers(
-			capture.NewChannelStore(pool, nil, telegram.NewAPI(nil, ""), s.log))
+			capture.NewChannelStore(InstallationDB(pool), nil, telegram.NewAPI(nil, ""), s.log))
 	}
 }

--- a/backend/internal/compose/costestimate/estimator_integration_test.go
+++ b/backend/internal/compose/costestimate/estimator_integration_test.go
@@ -92,13 +92,13 @@ func setupEstimator(t *testing.T) *estEnv {
 
 // newEstimatorOverPool wires the estimator over the real stores — the same
 // construction B6 wires in compose.
-func (e *estEnv) newEstimator() *Estimator {
+func (e *estEnv) newEstimator(ws ids.UUID) *Estimator {
 	return NewEstimator(
 		ai.NewCallReadStore(e.pool),
 		ai.NewRateStore(e.pool),
 		e.router,
 		activities.NewStore(e.pool),
-		capture.NewRegistry(e.pool, nil, nil, nil),
+		capture.NewRegistry(database.BindTo(e.pool, ids.From[ids.WorkspaceKind](ws)), nil, nil, nil),
 		clockAt,
 	)
 }
@@ -228,7 +228,7 @@ func TestEstimatorPricesObservedHistory(t *testing.T) {
 		e.insertLabeledActivity(t, ws)
 	}
 
-	got, err := e.newEstimator().EstimateBackfill(wsCtx, "gmail", user, 100)
+	got, err := e.newEstimator(ws).EstimateBackfill(wsCtx, "gmail", user, 100)
 	if err != nil {
 		t.Fatalf("EstimateBackfill: %v", err)
 	}
@@ -282,7 +282,7 @@ func TestEstimatorEnrichFloorsWhenPeopleCreatedZero(t *testing.T) {
 		e.insertLabeledActivity(t, ws)
 	}
 
-	got, err := e.newEstimator().EstimateBackfill(wsCtx, "gmail", user, 100)
+	got, err := e.newEstimator(ws).EstimateBackfill(wsCtx, "gmail", user, 100)
 	if err != nil {
 		t.Fatalf("EstimateBackfill: %v", err)
 	}
@@ -321,7 +321,7 @@ func TestEstimatorExcludesRatelessModelAndFlagsHeuristic(t *testing.T) {
 		e.insertLabeledActivity(t, ws)
 	}
 
-	got, err := e.newEstimator().EstimateBackfill(wsCtx, "gmail", user, 100)
+	got, err := e.newEstimator(ws).EstimateBackfill(wsCtx, "gmail", user, 100)
 	if err != nil {
 		t.Fatalf("EstimateBackfill: %v", err)
 	}
@@ -361,7 +361,7 @@ func TestEstimatorCountsMeteringFailedRows(t *testing.T) {
 	e.insertCall(t, ws, callRow{task: ai.TaskCaptureClassify, tier: ai.TierCheapCloud, provider: ai.ProviderFake, model: "cloud-model", tokensIn: 2_000_000, tokensOut: 0, errorSentinel: "metering_failed"})
 	e.insertLabeledActivity(t, ws)
 
-	got, err := e.newEstimator().EstimateBackfill(wsCtx, "gmail", user, 100)
+	got, err := e.newEstimator(ws).EstimateBackfill(wsCtx, "gmail", user, 100)
 	if err != nil {
 		t.Fatalf("EstimateBackfill: %v", err)
 	}
@@ -402,7 +402,7 @@ func TestEstimatorEnrichMeteringFailedRetryDoesNotInflateDenominator(t *testing.
 	e.insertCall(t, ws, callRow{task: ai.TaskEnrich, tier: ai.TierCheapCloud, provider: ai.ProviderFake, model: "cloud-model", tokensIn: 500_000, tokensOut: 0})
 	e.insertCall(t, ws, callRow{task: ai.TaskEnrich, tier: ai.TierCheapCloud, provider: ai.ProviderFake, model: "cloud-model", tokensIn: 500_000, tokensOut: 0, errorSentinel: "metering_failed"})
 
-	got, err := e.newEstimator().EstimateBackfill(wsCtx, "gmail", user, 100)
+	got, err := e.newEstimator(ws).EstimateBackfill(wsCtx, "gmail", user, 100)
 	if err != nil {
 		t.Fatalf("EstimateBackfill: %v", err)
 	}
@@ -436,7 +436,7 @@ func TestEstimatorRepricesSinceUnboundSlice(t *testing.T) {
 	e.insertCall(t, ws, callRow{task: ai.TaskCaptureClassify, tier: ai.TierCheapCloud, provider: ai.ProviderFake, model: "old-cloud-model", tokensIn: 2_000_000, tokensOut: 0})
 	e.insertLabeledActivity(t, ws)
 
-	got, err := e.newEstimator().EstimateBackfill(wsCtx, "gmail", user, 100)
+	got, err := e.newEstimator(ws).EstimateBackfill(wsCtx, "gmail", user, 100)
 	if err != nil {
 		t.Fatalf("EstimateBackfill: %v", err)
 	}
@@ -461,7 +461,7 @@ func TestEstimatorNoHistoryUsesFloor(t *testing.T) {
 	// Rate the floor's classify head (local-model) so the floor prices honestly.
 	e.insertRate(t, ws, "local-model", 1_000_000, 0)
 
-	got, err := e.newEstimator().EstimateBackfill(wsCtx, "gmail", user, 100)
+	got, err := e.newEstimator(ws).EstimateBackfill(wsCtx, "gmail", user, 100)
 	if err != nil {
 		t.Fatalf("EstimateBackfill: %v", err)
 	}
@@ -487,7 +487,7 @@ func TestEstimatorConnectionScopedYields(t *testing.T) {
 
 	e.insertRate(t, ws, "local-model", 1_000_000, 0)
 
-	est := e.newEstimator()
+	est := e.newEstimator(ws)
 	imap, err := est.EstimateBackfill(wsCtx, "imap", user, 100)
 	if err != nil {
 		t.Fatalf("EstimateBackfill(imap): %v", err)
@@ -522,7 +522,7 @@ func TestEstimatorRLSCrossWorkspaceInvisibility(t *testing.T) {
 
 	// Workspace A (its own context, its own user) sees none of B's history — it
 	// falls to the floor, and its cost never reflects B's expensive slice.
-	got, err := e.newEstimator().EstimateBackfill(ctxA, "gmail", userA, 100)
+	got, err := e.newEstimator(wsA).EstimateBackfill(ctxA, "gmail", userA, 100)
 	if err != nil {
 		t.Fatalf("EstimateBackfill(A): %v", err)
 	}

--- a/backend/internal/compose/dedupe_budget_integration_test.go
+++ b/backend/internal/compose/dedupe_budget_integration_test.go
@@ -39,7 +39,7 @@ func connectorCtx(e *integration.Env) context.Context {
 
 func TestCaptureDedupeStagesMergeInsteadOfDuplicating(t *testing.T) {
 	e := integration.Setup(t)
-	sink := capture.NewSink(e.Pool).WithStager(mergeStager{svc: approvals.NewService(e.Pool)})
+	sink := capture.NewSink(e.DB()).WithStager(mergeStager{svc: approvals.NewService(e.Pool)})
 	ctx := connectorCtx(e)
 
 	first, err := sink.Upsert(ctx, connector.NormalizedRecord{

--- a/backend/internal/compose/handlers_owndomains_integration_test.go
+++ b/backend/internal/compose/handlers_owndomains_integration_test.go
@@ -56,7 +56,7 @@ func ownDomainAdmin(e *integration.Env) context.Context {
 
 func TestOwnDomainHandlersRoundTripTheRegistry(t *testing.T) {
 	e := integration.Setup(t)
-	h := ownDomainHandlers{store: capture.NewOwnDomainStore(e.Pool)}
+	h := ownDomainHandlers{store: capture.NewOwnDomainStore(e.DB())}
 
 	// An empty registry is an empty list, never a null — a client rendering the
 	// screen must not have to tell "none registered" from "no answer".
@@ -106,7 +106,7 @@ func TestOwnDomainHandlersRoundTripTheRegistry(t *testing.T) {
 // The refusals the TRANSPORT owns, each answered before the store is reached.
 func TestOwnDomainHandlersRefuseBadInputAndAgents(t *testing.T) {
 	e := integration.Setup(t)
-	h := ownDomainHandlers{store: capture.NewOwnDomainStore(e.Pool)}
+	h := ownDomainHandlers{store: capture.NewOwnDomainStore(e.DB())}
 	admin := ownDomainAdmin(e)
 	agent := ownDomainCtx(e, principal.PrincipalAgent, principal.ObjectGrant{Read: true, Update: true})
 

--- a/backend/internal/compose/integration/capture/capture_authority_integration_test.go
+++ b/backend/internal/compose/integration/capture/capture_authority_integration_test.go
@@ -31,7 +31,7 @@ func TestConnectRefusesAGrantFromADeactivatedHuman(t *testing.T) {
 	e := integration.SetupSearch(t)
 	// The production resolver, not the always-live harness fake: liveness is
 	// exactly what is under test.
-	registry := capturemod.NewRegistry(e.Pool, capturemod.NewSink(e.Pool), identity.NewService(e.Pool), newTestKeyvault(t, e))
+	registry := capturemod.NewRegistry(e.DB(), capturemod.NewSink(e.DB()), identity.NewService(e.Pool), newTestKeyvault(t, e))
 	registry.Register(&scopeFake{})
 	grantCtx := humanWithScopes(e, e.Rep1, []principal.Scope{principal.ScopeRead})
 

--- a/backend/internal/compose/integration/capture/capture_autocreate_integration_test.go
+++ b/backend/internal/compose/integration/capture/capture_autocreate_integration_test.go
@@ -267,7 +267,7 @@ func TestCaptureRefusesToDeriveARecord(t *testing.T) {
 		// principal: the capture itself must land, the ensure must refuse
 		// honestly (RC-8 — created rows need a human owner), and the fault
 		// must be a system_log line the nightly reconcile can find.
-		sink := capturemod.NewSink(e.Pool).WithEnsurer(recordingEnsurer{}, capturemod.NewTransactionalList(nil, nil))
+		sink := capturemod.NewSink(e.DB()).WithEnsurer(recordingEnsurer{}, capturemod.NewTransactionalList(nil, nil))
 		ownerless := principal.WithCorrelationID(principal.WithActor(
 			principal.WithWorkspaceID(context.Background(), e.WS), principal.Principal{
 				Type: principal.PrincipalConnector, ID: "connector:gmail",

--- a/backend/internal/compose/integration/capture/capture_integration_test.go
+++ b/backend/internal/compose/integration/capture/capture_integration_test.go
@@ -337,5 +337,5 @@ func (fakeAuthority) SeatType(context.Context, ids.UUID, ids.UUID) (principal.Se
 }
 
 func newTestCaptureRegistry(e *integration.SearchEnv, vault keyvault.Vault) *capturemod.Registry {
-	return capturemod.NewRegistry(e.Pool, capturemod.NewSink(e.Pool), fakeAuthority{}, vault)
+	return capturemod.NewRegistry(e.DB(), capturemod.NewSink(e.DB()), fakeAuthority{}, vault)
 }

--- a/backend/internal/compose/integration/capture/capture_provider_scopes_integration_test.go
+++ b/backend/internal/compose/integration/capture/capture_provider_scopes_integration_test.go
@@ -37,7 +37,7 @@ func (f *grantingFake) GrantedScopes(connector.Auth) ([]string, error) { return 
 func TestConnectPersistsTheProviderGrantedScopes(t *testing.T) {
 	e := integration.SetupSearch(t)
 	granted := []string{"offline_access", "User.Read", "Mail.Read"}
-	registry := capturemod.NewRegistry(e.Pool, capturemod.NewSink(e.Pool), fakeAuthority{}, newTestKeyvault(t, e))
+	registry := capturemod.NewRegistry(e.DB(), capturemod.NewSink(e.DB()), fakeAuthority{}, newTestKeyvault(t, e))
 	registry.Register(&grantingFake{granted: granted})
 
 	grantCtx := humanWithScopes(e, e.Rep1, []principal.Scope{principal.ScopeRead})
@@ -76,7 +76,7 @@ func TestConnectPersistsTheProviderGrantedScopes(t *testing.T) {
 
 func TestAConnectorThatCannotReportItsGrantRecordsNoClaim(t *testing.T) {
 	e := integration.SetupSearch(t)
-	registry := capturemod.NewRegistry(e.Pool, capturemod.NewSink(e.Pool), fakeAuthority{}, newTestKeyvault(t, e))
+	registry := capturemod.NewRegistry(e.DB(), capturemod.NewSink(e.DB()), fakeAuthority{}, newTestKeyvault(t, e))
 	registry.Register(&mailFake{})
 
 	grantCtx := humanWithScopes(e, e.Rep1, []principal.Scope{principal.ScopeRead})

--- a/backend/internal/compose/integration/capture/capture_scope_integration_test.go
+++ b/backend/internal/compose/integration/capture/capture_scope_integration_test.go
@@ -73,8 +73,8 @@ func (s *recordingStager) StageMerge(_ context.Context, in capturemod.MergePropo
 func newScopeCaptureRegistry(t *testing.T, e *integration.SearchEnv, fake *scopeFake) (*capturemod.Registry, *recordingStager) {
 	t.Helper()
 	stager := &recordingStager{}
-	sink := capturemod.NewSink(e.Pool).WithStager(stager)
-	registry := capturemod.NewRegistry(e.Pool, sink, fakeAuthority{}, newTestKeyvault(t, e))
+	sink := capturemod.NewSink(e.DB()).WithStager(stager)
+	registry := capturemod.NewRegistry(e.DB(), sink, fakeAuthority{}, newTestKeyvault(t, e))
 	registry.Register(fake)
 	return registry, stager
 }

--- a/backend/internal/compose/integration/channels/telegram_fixture_integration_test.go
+++ b/backend/internal/compose/integration/channels/telegram_fixture_integration_test.go
@@ -308,7 +308,7 @@ func (c *telegramEnv) strangerRepCtx(t *testing.T, objects map[string]principal.
 // to the same vault the server holds so a token sealed here is a token the
 // poller can unseal.
 func (c *telegramEnv) channelStore() *capture.ChannelStore {
-	return capture.NewChannelStore(c.Pool, c.vault, c.api, c.log)
+	return capture.NewChannelStore(c.DB(), c.vault, c.api, c.log)
 }
 
 // connectBot binds the workspace's bot and records the live connection.

--- a/backend/internal/compose/integration/channels/telegram_identity_integration_test.go
+++ b/backend/internal/compose/integration/channels/telegram_identity_integration_test.go
@@ -315,7 +315,7 @@ func TestTwoConcurrentFirstMessagesYieldOnePersonAndTwoActivities(t *testing.T) 
 	first := telegramUpdate{updateID: 5701, messageID: 71, senderID: 770701, username: "racer", firstName: "Nadia", text: "first"}
 	second := telegramUpdate{updateID: 5702, messageID: 72, senderID: 770701, username: "racer", firstName: "Nadia", text: "second"}
 
-	sink := capture.NewSink(c.Pool).
+	sink := capture.NewSink(c.DB()).
 		WithChannelEnsurer(channelEnsureForwarder{store: people.NewStore(c.Pool)})
 	ctx := c.channelConnectorCtx(t)
 

--- a/backend/internal/compose/integration/channels/telegram_roundtrip_integration_test.go
+++ b/backend/internal/compose/integration/channels/telegram_roundtrip_integration_test.go
@@ -48,7 +48,7 @@ import (
 // registry missing the connector reads as "this installation has no Telegram
 // integration" and parks every reply.
 func (c *telegramEnv) sendRegistry() *capture.Registry {
-	registry := capture.NewRegistry(c.Pool, capture.NewSink(c.Pool), identity.NewService(c.Pool), c.vault)
+	registry := capture.NewRegistry(c.DB(), capture.NewSink(c.DB()), identity.NewService(c.Pool), c.vault)
 	registry.Register(telegram.New(c.api))
 	return registry
 }
@@ -357,7 +357,7 @@ func TestAForgedThreadKeyCannotReplyIntoAnotherMediumsConversation(t *testing.T)
 		},
 		ThreadKey: forged,
 	}
-	if _, err := capture.NewSink(c.Pool).Upsert(c.mailConnectorCtx(t), mail); err != nil {
+	if _, err := capture.NewSink(c.DB()).Upsert(c.mailConnectorCtx(t), mail); err != nil {
 		t.Fatalf("capturing the stranger's mail: %v — it must land as an ordinary activity, "+
 			"or this test proves a refusal rather than the thread scan", err)
 	}

--- a/backend/internal/compose/integration/channels/telegram_sinkerasure_integration_test.go
+++ b/backend/internal/compose/integration/channels/telegram_sinkerasure_integration_test.go
@@ -127,7 +127,7 @@ func TestTheSinkRefusesARecordNamingAnErasedChannelAccount(t *testing.T) {
 	}
 
 	const body = "the erased subject's message text"
-	_, err := capture.NewSink(e.Pool).Upsert(sinkConnectorCtx(e), inboundChannelRecord("20301", body))
+	_, err := capture.NewSink(e.DB()).Upsert(sinkConnectorCtx(e), inboundChannelRecord("20301", body))
 	if !errors.Is(err, connector.ErrSkip) {
 		t.Fatalf("Upsert returned %v, want ErrSkip — an erased account's message must not become an activity", err)
 	}
@@ -145,7 +145,7 @@ func TestTheSinkWaitsForAnErasureHoldingTheRecordsAccount(t *testing.T) {
 	person := e.SeedPerson(t, "Live Subject", nil)
 	seedChannelIdentity(t, e, person, "20302", "live")
 
-	sink := capture.NewSink(lockWaitBoundedPool(t))
+	sink := capture.NewSink(database.BindTo(lockWaitBoundedPool(t), ids.From[ids.WorkspaceKind](e.WS)))
 	ctx := sinkConnectorCtx(e)
 
 	var upsertErr error
@@ -178,7 +178,7 @@ func TestTheSinkIsUnaffectedByALockOnAnotherAccount(t *testing.T) {
 	person := e.SeedPerson(t, "Live Subject", nil)
 	seedChannelIdentity(t, e, person, "20303", "live")
 
-	sink := capture.NewSink(lockWaitBoundedPool(t))
+	sink := capture.NewSink(database.BindTo(lockWaitBoundedPool(t), ids.From[ids.WorkspaceKind](e.WS)))
 	ctx := sinkConnectorCtx(e)
 
 	const body = "an unrelated account's message"
@@ -215,7 +215,7 @@ func TestTheSinkRefusesACounterpartyNamedTwice(t *testing.T) {
 	rec := inboundChannelRecord("20304", "named twice")
 	rec.Counterparty.Email = "someone@example.com"
 
-	_, err := capture.NewSink(e.Pool).Upsert(sinkConnectorCtx(e), rec)
+	_, err := capture.NewSink(e.DB()).Upsert(sinkConnectorCtx(e), rec)
 	if !errors.Is(err, capture.ErrCounterpartyNamedTwice) {
 		t.Fatalf("Upsert returned %v, want ErrCounterpartyNamedTwice", err)
 	}
@@ -239,7 +239,7 @@ func TestAnErasureReachesAChannelActivityWithNoPersonLink(t *testing.T) {
 	seedChannelIdentity(t, e, person, "20401", "orphaned")
 
 	const body = "a message no link points at"
-	if _, err := capture.NewSink(e.Pool).Upsert(sinkConnectorCtx(e), inboundChannelRecord("20401", body)); err != nil {
+	if _, err := capture.NewSink(e.DB()).Upsert(sinkConnectorCtx(e), inboundChannelRecord("20401", body)); err != nil {
 		t.Fatalf("Upsert: %v", err)
 	}
 	if n := e.WsCount(t, `SELECT count(*) FROM activity_link WHERE person_id = $1`, person); n != 0 {
@@ -274,7 +274,7 @@ func TestAnErasureLeavesAnotherAccountsChannelActivityUntouched(t *testing.T) {
 	bystander := e.SeedPerson(t, "Bystander", nil)
 	seedChannelIdentity(t, e, bystander, "20502", "bystander")
 
-	sink := capture.NewSink(e.Pool)
+	sink := capture.NewSink(e.DB())
 	ctx := sinkConnectorCtx(e)
 	const bystanderBody = "the bystander's own message"
 	if _, err := sink.Upsert(ctx, inboundChannelRecord("20501", "the erased subject's message")); err != nil {
@@ -316,7 +316,7 @@ func TestARecentChannelMessageIsShieldedFromErasureByTheStatutoryFloor(t *testin
 
 	const body = "a message inside the statutory floor"
 	rec := inboundChannelRecordAt("20601", body, time.Now().UTC())
-	if _, err := capture.NewSink(e.Pool).Upsert(sinkConnectorCtx(e), rec); err != nil {
+	if _, err := capture.NewSink(e.DB()).Upsert(sinkConnectorCtx(e), rec); err != nil {
 		t.Fatalf("Upsert: %v", err)
 	}
 	if err := privacy.NewEraser(e.DB()).ErasePerson(e.Admin(), person, "test"); err != nil {
@@ -337,7 +337,7 @@ func TestTheSinkRefusesHalfAChannelIdentity(t *testing.T) {
 	rec := inboundChannelRecord("20305", "half an identity")
 	rec.Counterparty.ChannelIdentity.Provider = ""
 
-	_, err := capture.NewSink(e.Pool).Upsert(sinkConnectorCtx(e), rec)
+	_, err := capture.NewSink(e.DB()).Upsert(sinkConnectorCtx(e), rec)
 	if !errors.Is(err, capture.ErrChannelIdentityIncomplete) {
 		t.Fatalf("Upsert returned %v, want ErrChannelIdentityIncomplete", err)
 	}

--- a/backend/internal/compose/integration/comms_send_integration_test.go
+++ b/backend/internal/compose/integration/comms_send_integration_test.go
@@ -251,7 +251,7 @@ func TestCapturedCopyOfASentEmailCollapsesOntoTheSameActivity(t *testing.T) {
 			echo.NaturalKey.SourceID, messageID)
 	}
 
-	if _, err := capture.NewSink(p.Pool).Upsert(p.connectorCtx(t), echo); err != nil {
+	if _, err := capture.NewSink(p.DB()).Upsert(p.connectorCtx(t), echo); err != nil {
 		t.Fatalf("capturing the provider's own copy: %v", err)
 	}
 

--- a/backend/internal/compose/integration/consumermaildomain_integration_test.go
+++ b/backend/internal/compose/integration/consumermaildomain_integration_test.go
@@ -49,7 +49,7 @@ func listAdminCtx(ws, user ids.UUID, grant principal.ObjectGrant) context.Contex
 func TestWorkspaceConsumerMailListCorrectsTheBaselineBothWays(t *testing.T) {
 	e := Setup(t)
 	ctx := listAdminCtx(e.WS, e.Rep1, adminGrant)
-	store := capture.NewFreemailDomains(e.Pool)
+	store := capture.NewFreemailDomains(e.DB())
 
 	// A regional provider the shipped dataset missed, and a domain it wrongly
 	// claims — the operator's real customers mail from gmx.de.
@@ -127,7 +127,7 @@ func TestWorkspaceConsumerMailListCorrectsTheBaselineBothWays(t *testing.T) {
 func TestConsumerMailCreateGrantAddsButNeverRewrites(t *testing.T) {
 	e := Setup(t)
 	repCtx := listAdminCtx(e.WS, e.Rep1, principal.ObjectGrant{Create: true, Read: true})
-	store := capture.NewFreemailDomains(e.Pool)
+	store := capture.NewFreemailDomains(e.DB())
 
 	added, err := store.Add(repCtx, "kleinpost.example", capture.FreemailKindExtra)
 	if err != nil {
@@ -161,7 +161,7 @@ func TestConsumerMailCreateGrantAddsButNeverRewrites(t *testing.T) {
 func TestConsumerMailListRefusesWhatTheMatcherCouldNeverRead(t *testing.T) {
 	e := Setup(t)
 	ctx := listAdminCtx(e.WS, e.Rep1, adminGrant)
-	store := capture.NewFreemailDomains(e.Pool)
+	store := capture.NewFreemailDomains(e.DB())
 
 	if _, err := store.Add(ctx, "localhost", capture.FreemailKindExtra); err == nil {
 		t.Error("a label with no dot is not a mail domain and must be refused")

--- a/backend/internal/compose/integration/erasure_integration_test.go
+++ b/backend/internal/compose/integration/erasure_integration_test.go
@@ -186,7 +186,7 @@ func TestErasureRemovesPIIEverywhereAndSticksViaSuppression(t *testing.T) {
 	assertSubjectErased(t, e, personID)
 
 	// Re-capture of the erased address is skipped, not resurrected.
-	sink := capture.NewSink(e.Pool)
+	sink := capture.NewSink(e.DB())
 	connCtx := principal.WithWorkspaceID(context.Background(), e.WS)
 	connCtx = principal.WithCorrelationID(connCtx, ids.NewV7())
 	connCtx = principal.WithActor(connCtx, principal.Principal{

--- a/backend/internal/compose/integration/messageidentity_integration_test.go
+++ b/backend/internal/compose/integration/messageidentity_integration_test.go
@@ -104,7 +104,7 @@ func (p *preflightEnv) captureEcho(t *testing.T, stored []byte) {
 	if err != nil {
 		t.Fatalf("the provider's stored copy does not parse:\n%s\n%v", stored, err)
 	}
-	if _, err := capture.NewSink(p.Pool).Upsert(p.connectorCtx(t),
+	if _, err := capture.NewSink(p.DB()).Upsert(p.connectorCtx(t),
 		msg.AttestSentByOwner(true).ToRecord("gmail", stored)); err != nil {
 		t.Fatalf("capturing the provider's own copy: %v", err)
 	}

--- a/backend/internal/compose/serverassembly.go
+++ b/backend/internal/compose/serverassembly.go
@@ -67,7 +67,7 @@ func (s *Server) wireCaptureSettingsSurface(pool *pgxpool.Pool) {
 	// The workspace capture-settings surface (CAP-WIRE-7, ADR-0072):
 	// read the auto-enrich posture (all roles), toggle it (admin/ops).
 	s.captureSettingsHandlers = captureSettingsHandlers{store: capture.NewSettings(NewSettingsStore(pool))}
-	s.ownDomainHandlers = ownDomainHandlers{store: capture.NewOwnDomainStore(pool)}
+	s.ownDomainHandlers = ownDomainHandlers{store: capture.NewOwnDomainStore(InstallationDB(pool))}
 	// The installation's own identity and reporting basis (ADR-0090/A135):
 	// name, reporting zone, base currency — the last of which locks once a
 	// deal has converted against it (ADR-0085 §7).
@@ -77,7 +77,7 @@ func (s *Server) wireCaptureSettingsSurface(pool *pgxpool.Pool) {
 	// The workspace's own consumer-mail list (CAP-PARAM-5): the surviving
 	// domain control, and the only way an operator corrects a shipped
 	// baseline that is wrong about one of their customers.
-	s.consumerMailDomainHandlers = consumerMailDomainHandlers{store: capture.NewFreemailDomains(pool)}
+	s.consumerMailDomainHandlers = consumerMailDomainHandlers{store: capture.NewFreemailDomains(InstallationDB(pool))}
 }
 
 // wireExportSurface binds the two export transports.

--- a/backend/internal/compose/telegrampollfixture_integration_test.go
+++ b/backend/internal/compose/telegrampollfixture_integration_test.go
@@ -160,7 +160,7 @@ func telegramAdminContext(ws, user ids.UUID) context.Context {
 // writes the real row) so every suite exercises exactly what the poller reads.
 func connectTestTelegramBot(t *testing.T, e *integration.Env, vault keyvault.Vault, api telegram.API, botID int64, username string) capture.ChannelConnection {
 	t.Helper()
-	store := capture.NewChannelStore(e.Pool, vault, api, quietTestLogger())
+	store := capture.NewChannelStore(e.DB(), vault, api, quietTestLogger())
 	conn, err := store.Connect(telegramAdminContext(e.WS, e.Rep1), capture.ConnectRequest{
 		Provider: capture.ProviderTelegram,
 		BotToken: fmt.Sprintf("%d:AAH-fixture-secret-for-%s", botID, username),

--- a/backend/internal/compose/telegramrekey_integration_test.go
+++ b/backend/internal/compose/telegramrekey_integration_test.go
@@ -35,7 +35,7 @@ import (
 func replaceTestTelegramBot(t *testing.T, e *integration.Env, vault keyvault.Vault, connID ids.UUID, botID int64, username string) {
 	t.Helper()
 	api := &telegramPollFakeAPI{bot: telegram.Bot{ID: botID, Username: username}}
-	store := capture.NewChannelStore(e.Pool, vault, api, quietTestLogger())
+	store := capture.NewChannelStore(e.DB(), vault, api, quietTestLogger())
 	err := store.ReplaceToken(telegramAdminContext(e.WS, e.Rep1), connID,
 		fmt.Sprintf("%d:AAH-fixture-secret-for-%s", botID, username))
 	if err != nil {

--- a/backend/internal/modules/capture/backfill.go
+++ b/backend/internal/modules/capture/backfill.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
@@ -88,7 +87,7 @@ func (r *Registry) EstimateBackfill(ctx context.Context, provider string, userID
 	var name string
 	var credentialRef *string
 	var authBytes []byte
-	err = database.WithWorkspaceTx(ctx, r.pool, func(tx pgx.Tx) error {
+	err = r.db.Tx(ctx, func(tx pgx.Tx) error {
 		id, err := r.connectionForUser(ctx, tx, provider, userID)
 		if err != nil {
 			return err
@@ -146,7 +145,7 @@ func (r *Registry) StartBackfill(ctx context.Context, provider string, userID id
 		return BackfillRun{}, errors.New("capture: starting a backfill needs a scheduler — an unpaged run blocks its connection permanently")
 	}
 	var run BackfillRun
-	err := database.WithWorkspaceTx(ctx, r.pool, func(tx pgx.Tx) error {
+	err := r.db.Tx(ctx, func(tx pgx.Tx) error {
 		connID, err := r.connectionForUser(ctx, tx, provider, userID)
 		if err != nil {
 			return err
@@ -203,7 +202,7 @@ func (r *Registry) StartBackfill(ctx context.Context, provider string, userID id
 // contract's state "none".
 func (r *Registry) BackfillStatus(ctx context.Context, provider string, userID ids.UserID) (*BackfillRun, error) {
 	var run *BackfillRun
-	err := database.WithWorkspaceTx(ctx, r.pool, func(tx pgx.Tx) error {
+	err := r.db.Tx(ctx, func(tx pgx.Tx) error {
 		connID, err := r.connectionForUser(ctx, tx, provider, userID)
 		if err != nil {
 			return err
@@ -250,7 +249,7 @@ func latestBackfill(ctx context.Context, tx pgx.Tx, connID ids.UUID) (*BackfillR
 // CancelBackfill stops a live run; captured rows are retained (real
 // history). No live run → apperrors.ErrConflict (409 not_running).
 func (r *Registry) CancelBackfill(ctx context.Context, provider string, userID ids.UserID) (*BackfillRun, error) {
-	err := database.WithWorkspaceTx(ctx, r.pool, func(tx pgx.Tx) error {
+	err := r.db.Tx(ctx, func(tx pgx.Tx) error {
 		connID, err := r.connectionForUser(ctx, tx, provider, userID)
 		if err != nil {
 			return err

--- a/backend/internal/modules/capture/backfillpager.go
+++ b/backend/internal/modules/capture/backfillpager.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/connector"
@@ -57,7 +56,7 @@ func (r *Registry) RunBackfillStep(ctx context.Context, backfillID ids.UUID) (do
 		status        string
 		generation    int
 	)
-	err = database.WithWorkspaceTx(ctx, r.pool, func(tx pgx.Tx) error {
+	err = r.db.Tx(ctx, func(tx pgx.Tx) error {
 		return tx.QueryRow(ctx, `
 			SELECT b.connection_id, b.after_date, b.cursor, b.status, c.provider, c.user_id, c.credential_ref, c.auth, c.generation
 			FROM capture_backfill b JOIN capture_connection c ON c.id = b.connection_id
@@ -176,7 +175,7 @@ func (r *Registry) recordPageFault(ctx context.Context, backfillID ids.UUID, cau
 func (r *Registry) countBackfillFailure(ctx context.Context, backfillID ids.UUID, class errorClass) (failures int, live bool, err error) {
 	countCtx, cancel := detachedWrite(ctx)
 	defer cancel()
-	err = database.WithWorkspaceTx(countCtx, r.pool, func(tx pgx.Tx) error {
+	err = r.db.Tx(countCtx, func(tx pgx.Tx) error {
 		// A run whose FIRST page fails transiently is still a run that started:
 		// leaving it 'queued' would misreport a live import as one never begun.
 		scanErr := tx.QueryRow(countCtx, `
@@ -231,7 +230,7 @@ func backfillRetryDelay(failures int, cause error) time.Duration {
 func (r *Registry) commitBackfillPage(ctx context.Context, backfillID ids.UUID, generation int, res connector.BackfillPageResult) (done, completed bool, err error) {
 	finishing := res.NextToken == ""
 	var rowsAffected int64
-	err = database.WithWorkspaceTx(ctx, r.pool, func(tx pgx.Tx) error {
+	err = r.db.Tx(ctx, func(tx pgx.Tx) error {
 		var cur []byte
 		statusExpr := "CASE WHEN status = 'queued' THEN 'running' ELSE status END"
 		terminal := ""
@@ -301,7 +300,7 @@ func (r *Registry) failBackfill(ctx context.Context, backfillID ids.UUID, cause 
 	class := classifySyncError(cause)
 	failCtx, cancel := detachedWrite(ctx)
 	defer cancel()
-	return database.WithWorkspaceTx(failCtx, r.pool, func(tx pgx.Tx) error {
+	return r.db.Tx(failCtx, func(tx pgx.Tx) error {
 		_, err := tx.Exec(failCtx, `
 			UPDATE capture_backfill SET status = 'error', last_error_class = $2, completed_at = now()`+resetInflightProgress+`
 			WHERE id = $1 AND status IN ('queued','running')`, backfillID, string(class))

--- a/backend/internal/modules/capture/backfillprogress.go
+++ b/backend/internal/modules/capture/backfillprogress.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/connector"
 )
@@ -173,7 +172,7 @@ func (c *pageProgress) counted(ctx context.Context, outcome EnsureOutcome) {
 	}
 	countCtx, cancel := detachedWrite(ctx)
 	defer cancel()
-	err := database.WithWorkspaceTx(countCtx, c.registry.pool, func(tx pgx.Tx) error {
+	err := c.registry.db.Tx(countCtx, func(tx pgx.Tx) error {
 		_, execErr := tx.Exec(countCtx, `
 			UPDATE capture_backfill
 			SET people_created = people_created + $2, organizations_created = organizations_created + $3
@@ -238,7 +237,7 @@ func (c *pageProgress) persist(ctx context.Context, pacing flushPacing) {
 // commit will refuse the same page and cancel the run, and until it does the
 // screen must not show work that is about to be thrown away.
 func (r *Registry) flushBackfillProgress(ctx context.Context, backfillID ids.UUID, generation int, t pageTally) error {
-	return database.WithWorkspaceTx(ctx, r.pool, func(tx pgx.Tx) error {
+	return r.db.Tx(ctx, func(tx pgx.Tx) error {
 		_, err := tx.Exec(ctx, `
 			UPDATE capture_backfill
 			SET inflight_scanned = $2, inflight_captured = $3, inflight_skipped = $4,

--- a/backend/internal/modules/capture/backfillyields.go
+++ b/backend/internal/modules/capture/backfillyields.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
@@ -36,7 +35,7 @@ type BackfillYields struct {
 // RLS-scoped to the current workspace.
 func (r *Registry) BackfillYields(ctx context.Context, provider string, userID ids.UserID) (BackfillYields, error) {
 	var y BackfillYields
-	err := database.WithWorkspaceTx(ctx, r.pool, func(tx pgx.Tx) error {
+	err := r.db.Tx(ctx, func(tx pgx.Tx) error {
 		connID, err := r.connectionForUser(ctx, tx, provider, userID)
 		if err != nil {
 			return err

--- a/backend/internal/modules/capture/channelconn.go
+++ b/backend/internal/modules/capture/channelconn.go
@@ -27,7 +27,6 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/gradionhq/margince/backend/internal/modules/capture/telegram"
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
@@ -138,7 +137,8 @@ var ErrChannelWiringIncomplete = errors.New("capture: no credential custodian is
 // every entry point that needs it refuses by name rather than proceeding
 // half-wired.
 type ChannelStore struct {
-	pool  *pgxpool.Pool
+	// db binds the workspace this store runs for (ADR-0091 §9 step 3).
+	db    *database.DB
 	vault keyvault.Vault
 	api   telegram.API
 	log   *slog.Logger
@@ -148,11 +148,11 @@ type ChannelStore struct {
 // deployment configured none — the mutating paths then refuse with a named,
 // actionable error instead of writing a connection whose token nothing could
 // unseal.
-func NewChannelStore(pool *pgxpool.Pool, vault keyvault.Vault, api telegram.API, log *slog.Logger) *ChannelStore {
+func NewChannelStore(db *database.DB, vault keyvault.Vault, api telegram.API, log *slog.Logger) *ChannelStore {
 	if log == nil {
 		log = slog.Default()
 	}
-	return &ChannelStore{pool: pool, vault: vault, api: api, log: log}
+	return &ChannelStore{db: db, vault: vault, api: api, log: log}
 }
 
 // withVault returns a copy of the store carrying the credential custodian. The
@@ -306,7 +306,7 @@ func (s *ChannelStore) insertConnected(ctx context.Context, bot telegram.Bot, cr
 		return ChannelConnection{}, err
 	}
 	var out ChannelConnection
-	err = database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err = s.db.Tx(ctx, func(tx pgx.Tx) error {
 		out, err = scanChannelConnection(tx.QueryRow(ctx, `
 			INSERT INTO channel_connection
 			  (workspace_id, provider, channel_id, channel_label, credential_ref, status, poll_offset, connected_by)

--- a/backend/internal/modules/capture/channelconnedit.go
+++ b/backend/internal/modules/capture/channelconnedit.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/gradionhq/margince/backend/internal/modules/capture/telegram"
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/platform/keyvault"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
@@ -122,7 +121,7 @@ func (s *ChannelStore) ReplaceToken(ctx context.Context, id ids.UUID, token stri
 // and this one would otherwise destroy the credential that winner is now polling
 // with.
 func (s *ChannelStore) repoint(ctx context.Context, current channelRow, bot telegram.Bot, credentialRef keyvault.Ref) error {
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		if _, err := storekit.LockRow(ctx, tx, "channel_connection", current.ID, storekit.LiveOnly); err != nil {
 			return err
 		}
@@ -194,7 +193,7 @@ func (s *ChannelStore) Disconnect(ctx context.Context, id ids.UUID) error {
 // bot as the one disconnected, and send the caller on to destroy a credential the
 // row no longer names — leaving the winner's with nothing to collect it.
 func (s *ChannelStore) archiveDisconnected(ctx context.Context, current channelRow) error {
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		if _, err := storekit.LockRow(ctx, tx, "channel_connection", current.ID, storekit.LiveOnly); err != nil {
 			return err
 		}
@@ -224,7 +223,7 @@ func (s *ChannelStore) archiveDisconnected(ctx context.Context, current channelR
 func (s *ChannelStore) readChannelRow(ctx context.Context, id ids.UUID) (channelRow, error) {
 	var out channelRow
 	var credentialRef string
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		row := tx.QueryRow(ctx, `SELECT `+channelConnectionColumns+`, credential_ref
 			 FROM channel_connection WHERE id = $1 AND archived_at IS NULL`, id)
 		return row.Scan(&out.ID, &out.WorkspaceID, &out.Provider, &out.ChannelID, &out.ChannelLabel,

--- a/backend/internal/modules/capture/channelconnfixture_test.go
+++ b/backend/internal/modules/capture/channelconnfixture_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/gradionhq/margince/backend/internal/modules/capture"
 	"github.com/gradionhq/margince/backend/internal/modules/capture/telegram"
+	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/keyvault"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
@@ -208,7 +209,7 @@ func newChannelFixture(t *testing.T, api *fakeTelegram) *channelFixture {
 		api = newFakeTelegram()
 	}
 	vault := &countingVault{Vault: keyvault.NewMemory()}
-	store := capture.NewChannelStore(pool, vault, api, nil)
+	store := capture.NewChannelStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](wsUUID)), vault, api, nil)
 
 	return &channelFixture{
 		ctx:      adminChannelContext(ctx, wsUUID, userUUID),
@@ -228,7 +229,7 @@ func newChannelFixture(t *testing.T, api *fakeTelegram) *channelFixture {
 func (f *channelFixture) withoutVault(t *testing.T) {
 	t.Helper()
 	_, pool := setupCaptureDB(t)
-	f.store = capture.NewChannelStore(pool, nil, f.api, nil)
+	f.store = capture.NewChannelStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](f.ws)), nil, f.api, nil)
 	f.handlers = capture.NewChannelHandlers(f.store)
 }
 

--- a/backend/internal/modules/capture/channelconnread.go
+++ b/backend/internal/modules/capture/channelconnread.go
@@ -16,7 +16,6 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
@@ -29,7 +28,7 @@ func (s *ChannelStore) List(ctx context.Context) ([]ChannelConnection, error) {
 		return nil, err
 	}
 	var out []ChannelConnection
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		rows, err := tx.Query(ctx, `SELECT `+channelConnectionColumns+
 			` FROM channel_connection WHERE archived_at IS NULL ORDER BY created_at DESC, id DESC`)
 		if err != nil {

--- a/backend/internal/modules/capture/channelsend.go
+++ b/backend/internal/modules/capture/channelsend.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/connector"
 )
@@ -130,7 +129,7 @@ func (f fencedChannelSender) SendMessage(ctx context.Context, auth connector.Aut
 // never destroy a legitimate message.
 func (r *Registry) requireBindingUnchanged(ctx context.Context, resolved channelBinding) error {
 	var version int64
-	err := database.WithWorkspaceTx(ctx, r.pool, func(tx pgx.Tx) error {
+	err := r.db.Tx(ctx, func(tx pgx.Tx) error {
 		return tx.QueryRow(ctx, `
 			SELECT version FROM channel_connection
 			 WHERE id = $1 AND status = $2 AND archived_at IS NULL`,
@@ -206,7 +205,7 @@ func (r *Registry) liveChannelBinding(ctx context.Context, provider string) (cha
 // copy, so a binding one of them counts is a binding the other does too.
 func (r *Registry) liveChannelBindings(ctx context.Context, provider string) ([]channelBinding, error) {
 	var bindings []channelBinding
-	err := database.WithWorkspaceTx(ctx, r.pool, func(tx pgx.Tx) error {
+	err := r.db.Tx(ctx, func(tx pgx.Tx) error {
 		rows, err := tx.Query(ctx, `
 			SELECT id, version, credential_ref FROM channel_connection
 			 WHERE provider = $1 AND status = $2 AND archived_at IS NULL`,

--- a/backend/internal/modules/capture/channelsend_integration_test.go
+++ b/backend/internal/modules/capture/channelsend_integration_test.go
@@ -19,7 +19,9 @@ import (
 	"testing"
 
 	"github.com/gradionhq/margince/backend/internal/modules/capture"
+	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/connector"
 )
 
@@ -84,7 +86,7 @@ func (captureOnlyChannelConnector) HealthCheck(context.Context, connector.Auth) 
 func channelSendRegistry(t *testing.T, f *channelFixture, c connector.Connector) *capture.Registry {
 	t.Helper()
 	_, pool := setupCaptureDB(t)
-	reg := capture.NewRegistry(pool, nil, fixtureAuthority{}, f.vault)
+	reg := capture.NewRegistry(database.BindTo(pool, ids.From[ids.WorkspaceKind](f.ws)), nil, fixtureAuthority{}, f.vault)
 	if c != nil {
 		reg.Register(c)
 	}

--- a/backend/internal/modules/capture/credentialbackfill.go
+++ b/backend/internal/modules/capture/credentialbackfill.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
@@ -35,7 +34,7 @@ func (r *Registry) BackfillCredentials(ctx context.Context) (int, error) {
 		return 0, errors.New("capture: cannot backfill connector credentials without a keyvault")
 	}
 	// rls-exempt: fleet enumeration — the workspace table is not workspace-scoped; this reads every tenant before entering each workspace's own GUC.
-	rows, err := r.pool.Query(ctx, `SELECT id FROM workspace WHERE archived_at IS NULL ORDER BY created_at`)
+	rows, err := r.db.Pool().Query(ctx, `SELECT id FROM workspace WHERE archived_at IS NULL ORDER BY created_at`)
 	if err != nil {
 		return 0, fmt.Errorf("capture: listing workspaces for credential backfill: %w", err)
 	}
@@ -71,7 +70,7 @@ func (r *Registry) backfillWorkspace(ctx context.Context, ws ids.WorkspaceID) (i
 		auth []byte
 	}
 	var pending []legacyRow
-	err := database.WithWorkspaceTx(ctx, r.pool, func(tx pgx.Tx) error {
+	err := r.db.Tx(ctx, func(tx pgx.Tx) error {
 		rows, err := tx.Query(ctx, `
 			SELECT id, auth FROM capture_connection
 			WHERE credential_ref IS NULL AND auth IS NOT NULL`)
@@ -99,7 +98,7 @@ func (r *Registry) backfillWorkspace(ctx context.Context, ws ids.WorkspaceID) (i
 			return migrated, err
 		}
 		var claimed bool
-		err = database.WithWorkspaceTx(ctx, r.pool, func(tx pgx.Tx) error {
+		err = r.db.Tx(ctx, func(tx pgx.Tx) error {
 			ct, err := tx.Exec(ctx, `
 				UPDATE capture_connection SET credential_ref = $2, auth = NULL
 				WHERE id = $1 AND credential_ref IS NULL`, l.id, string(ref))

--- a/backend/internal/modules/capture/digest.go
+++ b/backend/internal/modules/capture/digest.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
@@ -68,7 +67,7 @@ type DigestConnRow struct {
 func (r *Registry) BuildDigests(ctx context.Context, digestDate time.Time) error {
 	day := digestDate.Format(time.DateOnly)
 	since := digestDate.AddDate(0, 0, -1)
-	return database.WithWorkspaceTx(ctx, r.pool, func(tx pgx.Tx) error {
+	return r.db.Tx(ctx, func(tx pgx.Tx) error {
 		users, err := connectedUsers(ctx, tx)
 		if err != nil {
 			return err
@@ -177,7 +176,7 @@ func (r *Registry) buildDigestPayload(ctx context.Context, tx pgx.Tx, userID ids
 // transport's honest 404.
 func (r *Registry) ReadDigest(ctx context.Context, userID ids.UUID, day *time.Time) (*DigestPayload, error) {
 	var raw []byte
-	err := database.WithWorkspaceTx(ctx, r.pool, func(tx pgx.Tx) error {
+	err := r.db.Tx(ctx, func(tx pgx.Tx) error {
 		var row pgx.Row
 		if day != nil {
 			row = tx.QueryRow(ctx,

--- a/backend/internal/modules/capture/freemaildomain.go
+++ b/backend/internal/modules/capture/freemaildomain.go
@@ -28,7 +28,6 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
@@ -91,12 +90,13 @@ type FreemailDomain struct {
 
 // FreemailDomainStore owns the workspace's consumer-mail list.
 type FreemailDomainStore struct {
-	pool *pgxpool.Pool
+	// db binds the workspace this store runs for (ADR-0091 §9 step 3).
+	db *database.DB
 }
 
 // NewFreemailDomains builds the store over the pool.
-func NewFreemailDomains(pool *pgxpool.Pool) *FreemailDomainStore {
-	return &FreemailDomainStore{pool: pool}
+func NewFreemailDomains(db *database.DB) *FreemailDomainStore {
+	return &FreemailDomainStore{db: db}
 }
 
 // List returns the workspace's entries, additions before carve-outs and
@@ -107,7 +107,7 @@ func (s *FreemailDomainStore) List(ctx context.Context) ([]FreemailDomain, error
 		return nil, err
 	}
 	var out []FreemailDomain
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		rows, err := tx.Query(ctx, `
 			SELECT id, domain, kind, created_at FROM capture_freemail_domain
 			ORDER BY kind, domain`)
@@ -156,7 +156,7 @@ func (s *FreemailDomainStore) Add(ctx context.Context, domain, kind string) (Fre
 	}
 
 	var out FreemailDomain
-	err = database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err = s.db.Tx(ctx, func(tx pgx.Tx) error {
 		// Serialize this domain's decision before reading the prior state. The
 		// read and the upsert are two statements, so two concurrent adds would
 		// otherwise both see "no prior entry" and both record a creation — one
@@ -227,7 +227,7 @@ func (s *FreemailDomainStore) Remove(ctx context.Context, id ids.UUID) error {
 	if err := auth.Require(ctx, freemailDomainObject, principal.ActionUpdate); err != nil {
 		return err
 	}
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		var domain, kind string
 		err := tx.QueryRow(ctx,
 			`DELETE FROM capture_freemail_domain WHERE id = $1 RETURNING domain, kind`, id).Scan(&domain, &kind)

--- a/backend/internal/modules/capture/owndomainstore.go
+++ b/backend/internal/modules/capture/owndomainstore.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgxpool"
 	"golang.org/x/net/idna"
 
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
@@ -43,12 +42,13 @@ type OwnDomain struct {
 
 // OwnDomainStore reads and writes the workspace's own-domain registry.
 type OwnDomainStore struct {
-	pool *pgxpool.Pool
+	// db binds the workspace this store runs for (ADR-0091 §9 step 3).
+	db *database.DB
 }
 
 // NewOwnDomainStore builds the store over the app pool.
-func NewOwnDomainStore(pool *pgxpool.Pool) *OwnDomainStore {
-	return &OwnDomainStore{pool: pool}
+func NewOwnDomainStore(db *database.DB) *OwnDomainStore {
+	return &OwnDomainStore{db: db}
 }
 
 // OwnDomainList is the registry plus what the installation's own company
@@ -67,7 +67,7 @@ func (s *OwnDomainStore) List(ctx context.Context) (OwnDomainList, error) {
 	if err := auth.Require(ctx, captureSettingsObject, principal.ActionRead); err != nil {
 		return OwnDomainList{}, err
 	}
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		rows, err := tx.Query(ctx, `
 			SELECT domain, source, verified, created_at
 			  FROM workspace_email_domain ORDER BY domain`)
@@ -115,7 +115,7 @@ func (s *OwnDomainStore) Add(ctx context.Context, raw string) (OwnDomain, error)
 		return OwnDomain{}, err
 	}
 	var out OwnDomain
-	err = database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err = s.db.Tx(ctx, func(tx pgx.Tx) error {
 		// The prior state, so the trail distinguishes "an admin registered a new
 		// domain" from "an admin confirmed a candidate a mailbox had seen".
 		// `any`, not map[string]any: storekit.marshalOrNil writes SQL NULL only
@@ -171,7 +171,7 @@ func (s *OwnDomainStore) Remove(ctx context.Context, raw string) error {
 	if domain == "" {
 		return nil
 	}
-	return database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	return s.db.Tx(ctx, func(tx pgx.Tx) error {
 		tag, err := tx.Exec(ctx,
 			`DELETE FROM workspace_email_domain WHERE domain = $1`, domain)
 		if err != nil {

--- a/backend/internal/modules/capture/owndomainstore_integration_test.go
+++ b/backend/internal/modules/capture/owndomainstore_integration_test.go
@@ -240,20 +240,28 @@ func TestARepReadsTheDomainsAndCannotChangeThem(t *testing.T) {
 // carries no workspace predicate and relies entirely on RLS, so the isolation
 // is asserted rather than assumed.
 func TestRemovingADomainLeavesAnotherWorkspacesAlone(t *testing.T) {
-	first, db := ownDomainWorkspace(t)
-	second, _ := ownDomainWorkspace(t)
-	store := capture.NewOwnDomainStore(db)
+	// A store per workspace, because the handle carries the tenant now
+	// (ADR-0091 §9 step 3). One store driven by two contexts would run both
+	// halves against the first workspace, and the isolation this asserts would
+	// be asserted against nothing.
+	first, firstDB := ownDomainWorkspace(t)
+	second, secondDB := ownDomainWorkspace(t)
+	firstStore := capture.NewOwnDomainStore(firstDB)
+	secondStore := capture.NewOwnDomainStore(secondDB)
 
-	for _, ctx := range []context.Context{first, second} {
-		if _, err := store.Add(ctx, "shared.example"); err != nil {
+	for _, s := range []struct {
+		ctx   context.Context
+		store *capture.OwnDomainStore
+	}{{first, firstStore}, {second, secondStore}} {
+		if _, err := s.store.Add(s.ctx, "shared.example"); err != nil {
 			t.Fatalf("Add: %v", err)
 		}
 	}
-	if err := store.Remove(first, "shared.example"); err != nil {
+	if err := firstStore.Remove(first, "shared.example"); err != nil {
 		t.Fatalf("Remove: %v", err)
 	}
 
-	list, err := store.List(second)
+	list, err := secondStore.List(second)
 	if err != nil {
 		t.Fatalf("List: %v", err)
 	}

--- a/backend/internal/modules/capture/owndomainstore_integration_test.go
+++ b/backend/internal/modules/capture/owndomainstore_integration_test.go
@@ -15,7 +15,6 @@ import (
 	"testing"
 
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/gradionhq/margince/backend/internal/modules/capture"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
@@ -41,7 +40,9 @@ func adminOwnDomainContext(ctx context.Context, ws ids.UUID) context.Context {
 	return principal.WithCorrelationID(ctx, ids.NewV7())
 }
 
-func ownDomainWorkspace(t *testing.T) (context.Context, *pgxpool.Pool) {
+// Returns the bound handle rather than the pool: the workspace it creates
+// is the one every store in these tests runs as (ADR-0091 §9 step 3).
+func ownDomainWorkspace(t *testing.T) (context.Context, *database.DB) {
 	t.Helper()
 	owner, pool := setupCaptureDB(t)
 	ctx := context.Background()
@@ -51,14 +52,14 @@ func ownDomainWorkspace(t *testing.T) (context.Context, *pgxpool.Pool) {
 		ws, "own-domains-"+ws.String()); err != nil {
 		t.Fatalf("seeding workspace: %v", err)
 	}
-	return adminOwnDomainContext(ctx, ws), pool
+	return adminOwnDomainContext(ctx, ws), database.BindTo(pool, ids.From[ids.WorkspaceKind](ws))
 }
 
 // An administrator adding a domain IS the human vouching for it, so it takes
 // effect without a second confirmation — and it is what makes the drop fire.
 func TestAnAdministratorsDomainIsVerifiedAndSuppressesMail(t *testing.T) {
-	ctx, pool := ownDomainWorkspace(t)
-	store := capture.NewOwnDomainStore(pool)
+	ctx, db := ownDomainWorkspace(t)
+	store := capture.NewOwnDomainStore(db)
 
 	added, err := store.Add(ctx, "Acme.COM")
 	if err != nil {
@@ -75,7 +76,7 @@ func TestAnAdministratorsDomainIsVerifiedAndSuppressesMail(t *testing.T) {
 	// stops being stored.
 	// The sink runs as the connector, never as the human who configured it.
 	ws, _ := principal.WorkspaceID(ctx)
-	sink := capture.NewSink(pool)
+	sink := capture.NewSink(db)
 	if _, err := sink.Upsert(mailSinkContext(context.Background(), ws),
 		mailRecord("admin-dom-1", "boss@acme.com",
 			"boss@acme.com", "rep@acme.com")); !isSkip(err) {
@@ -86,8 +87,8 @@ func TestAnAdministratorsDomainIsVerifiedAndSuppressesMail(t *testing.T) {
 // Adding a domain a mailbox already contributed confirms it rather than failing
 // — that is the whole point of the candidate row.
 func TestAddingACandidateDomainConfirmsIt(t *testing.T) {
-	ctx, pool := ownDomainWorkspace(t)
-	if err := database.WithWorkspaceTx(ctx, pool, func(tx pgx.Tx) error {
+	ctx, db := ownDomainWorkspace(t)
+	if err := db.Tx(ctx, func(tx pgx.Tx) error {
 		_, err := tx.Exec(ctx, `
 			INSERT INTO workspace_email_domain (workspace_id, domain, source, verified)
 			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, 'acme.com', 'mailbox', false)`)
@@ -95,7 +96,7 @@ func TestAddingACandidateDomainConfirmsIt(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("seeding the candidate: %v", err)
 	}
-	store := capture.NewOwnDomainStore(pool)
+	store := capture.NewOwnDomainStore(db)
 
 	added, err := store.Add(ctx, "acme.com")
 	if err != nil {
@@ -115,8 +116,8 @@ func TestAddingACandidateDomainConfirmsIt(t *testing.T) {
 
 // Removing a domain stops the drop from the next message on.
 func TestRemovingADomainLetsItsMailBeCapturedAgain(t *testing.T) {
-	ctx, pool := ownDomainWorkspace(t)
-	store := capture.NewOwnDomainStore(pool)
+	ctx, db := ownDomainWorkspace(t)
+	store := capture.NewOwnDomainStore(db)
 	if _, err := store.Add(ctx, "acme.com"); err != nil {
 		t.Fatalf("Add: %v", err)
 	}
@@ -125,7 +126,7 @@ func TestRemovingADomainLetsItsMailBeCapturedAgain(t *testing.T) {
 	}
 
 	ws, _ := principal.WorkspaceID(ctx)
-	sink := capture.NewSink(pool)
+	sink := capture.NewSink(db)
 	if _, err := sink.Upsert(mailSinkContext(context.Background(), ws),
 		mailRecord("removed-dom-1", "boss@acme.com",
 			"boss@acme.com", "rep@acme.com")); err != nil {
@@ -142,9 +143,9 @@ func TestRemovingADomainLetsItsMailBeCapturedAgain(t *testing.T) {
 // those domains are in force but are changed on the company page, so offering
 // them as removable rows would promise an action this surface cannot perform.
 func TestTheListSeparatesTheCompanysOwnClaimFromTheRegistry(t *testing.T) {
-	ctx, pool := ownDomainWorkspace(t)
+	ctx, db := ownDomainWorkspace(t)
 	ws, _ := principal.WorkspaceID(ctx)
-	if err := database.WithWorkspaceTx(ctx, pool, func(tx pgx.Tx) error {
+	if err := db.Tx(ctx, func(tx pgx.Tx) error {
 		orgID := ids.NewV7()
 		if _, err := tx.Exec(ctx, `
 			INSERT INTO organization (id, workspace_id, display_name, is_anchor, source, captured_by)
@@ -158,7 +159,7 @@ func TestTheListSeparatesTheCompanysOwnClaimFromTheRegistry(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("seeding the anchor company: %v", err)
 	}
-	store := capture.NewOwnDomainStore(pool)
+	store := capture.NewOwnDomainStore(db)
 	if _, err := store.Add(ctx, "acme.com"); err != nil {
 		t.Fatalf("Add: %v", err)
 	}
@@ -179,8 +180,8 @@ func TestTheListSeparatesTheCompanysOwnClaimFromTheRegistry(t *testing.T) {
 // set decides whether mail is stored, so folding a mistyped value into
 // something that silently matches nothing would be the worse failure.
 func TestAValueThatIsNotADomainIsRefused(t *testing.T) {
-	ctx, pool := ownDomainWorkspace(t)
-	store := capture.NewOwnDomainStore(pool)
+	ctx, db := ownDomainWorkspace(t)
+	store := capture.NewOwnDomainStore(db)
 
 	// The public suffixes are the dangerous half: they pass every shape check —
 	// they have a dot and no stray characters — and each would make every
@@ -204,7 +205,7 @@ func TestAValueThatIsNotADomainIsRefused(t *testing.T) {
 // control, so it is asserted against a rep-shaped grant rather than a principal
 // holding nothing at all.
 func TestARepReadsTheDomainsAndCannotChangeThem(t *testing.T) {
-	ctx, pool := ownDomainWorkspace(t)
+	ctx, db := ownDomainWorkspace(t)
 	ws, _ := principal.WorkspaceID(ctx)
 	rep := principal.WithActor(principal.WithWorkspaceID(context.Background(), ws),
 		principal.Principal{
@@ -218,7 +219,7 @@ func TestARepReadsTheDomainsAndCannotChangeThem(t *testing.T) {
 				RowScope: principal.RowScopeOwn,
 			},
 		})
-	store := capture.NewOwnDomainStore(pool)
+	store := capture.NewOwnDomainStore(db)
 
 	if _, err := store.List(rep); err != nil {
 		t.Errorf("a rep must be able to read the set: %v", err)
@@ -239,9 +240,9 @@ func TestARepReadsTheDomainsAndCannotChangeThem(t *testing.T) {
 // carries no workspace predicate and relies entirely on RLS, so the isolation
 // is asserted rather than assumed.
 func TestRemovingADomainLeavesAnotherWorkspacesAlone(t *testing.T) {
-	first, pool := ownDomainWorkspace(t)
+	first, db := ownDomainWorkspace(t)
 	second, _ := ownDomainWorkspace(t)
-	store := capture.NewOwnDomainStore(pool)
+	store := capture.NewOwnDomainStore(db)
 
 	for _, ctx := range []context.Context{first, second} {
 		if _, err := store.Add(ctx, "shared.example"); err != nil {
@@ -272,8 +273,8 @@ func TestRemovingADomainLeavesAnotherWorkspacesAlone(t *testing.T) {
 // and a removal names it in `before` and leaves `after` unset. A predicate that
 // accepted either would pass for a row that recorded the wrong direction.
 func TestBothWritesLeaveAnAuditRowNamingTheDomain(t *testing.T) {
-	ctx, pool := ownDomainWorkspace(t)
-	store := capture.NewOwnDomainStore(pool)
+	ctx, db := ownDomainWorkspace(t)
+	store := capture.NewOwnDomainStore(db)
 
 	if _, err := store.Add(ctx, "acme.com"); err != nil {
 		t.Fatalf("Add: %v", err)
@@ -282,7 +283,7 @@ func TestBothWritesLeaveAnAuditRowNamingTheDomain(t *testing.T) {
 	// other audit row does: SQL NULL. It used to store JSON null instead,
 	// because a nil map handed to an `any` parameter is not an untyped nil —
 	// which made this row invisible to the obvious "before IS NULL" query.
-	assertOwnDomainAudited(ctx, t, pool, ownDomainAuditRow{
+	assertOwnDomainAudited(ctx, t, db, ownDomainAuditRow{
 		action: "update", domain: "acme.com",
 		images: "before IS NULL AND after->>'own_email_domain' = $3",
 	})
@@ -290,7 +291,7 @@ func TestBothWritesLeaveAnAuditRowNamingTheDomain(t *testing.T) {
 	if err := store.Remove(ctx, "acme.com"); err != nil {
 		t.Fatalf("Remove: %v", err)
 	}
-	assertOwnDomainAudited(ctx, t, pool, ownDomainAuditRow{
+	assertOwnDomainAudited(ctx, t, db, ownDomainAuditRow{
 		action: "archive", domain: "acme.com",
 		images: "before->>'own_email_domain' = $3 AND after IS NULL",
 	})
@@ -298,7 +299,7 @@ func TestBothWritesLeaveAnAuditRowNamingTheDomain(t *testing.T) {
 	// Audit-only means exactly that: an event would make workspace configuration
 	// look like a record change to every subscriber.
 	var events int
-	if err := database.WithWorkspaceTx(ctx, pool, func(tx pgx.Tx) error {
+	if err := db.Tx(ctx, func(tx pgx.Tx) error {
 		return tx.QueryRow(ctx,
 			`SELECT count(*) FROM event_outbox
 			  WHERE envelope->>'entity_type' = 'capture_settings'`).Scan(&events)
@@ -321,14 +322,14 @@ type ownDomainAuditRow struct {
 // assertOwnDomainAudited fails unless exactly one audit row records that verb
 // against this workspace, written by this human, with the images the verb is
 // supposed to leave.
-func assertOwnDomainAudited(ctx context.Context, t *testing.T, pool *pgxpool.Pool, want ownDomainAuditRow) {
+func assertOwnDomainAudited(ctx context.Context, t *testing.T, db *database.DB, want ownDomainAuditRow) {
 	t.Helper()
 	actor, ok := principal.Actor(ctx)
 	if !ok {
 		t.Fatal("the test context carries no actor, so this would query for a zero id and pass or fail for the wrong reason")
 	}
 	var rows int
-	if err := database.WithWorkspaceTx(ctx, pool, func(tx pgx.Tx) error {
+	if err := db.Tx(ctx, func(tx pgx.Tx) error {
 		return tx.QueryRow(ctx, `
 			SELECT count(*) FROM audit_log
 			 WHERE entity_type = 'capture_settings' AND action = $1 AND actor_id = $2

--- a/backend/internal/modules/capture/registry.go
+++ b/backend/internal/modules/capture/registry.go
@@ -15,7 +15,6 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/keyvault"
@@ -35,9 +34,10 @@ import (
 type Registry struct {
 	mu         sync.RWMutex
 	connectors map[string]connector.Connector
-	pool       *pgxpool.Pool
-	sink       *Sink
-	authority  authz.Resolver
+	// db binds the workspace this store runs for (ADR-0091 §9 step 3).
+	db        *database.DB
+	sink      *Sink
+	authority authz.Resolver
 	// vault seals and resolves a connection's credential bundle. The row
 	// carries an opaque credential_ref, never the credential bytes; the vault
 	// is the custodian. May be nil for a role composed before WithKeyvault
@@ -64,10 +64,10 @@ const defaultSyncInterval = 2 * time.Minute
 // the live-authority resolver, and the keyvault that seals/resolves each
 // connection's credential. vault may be nil for a role composed before its
 // custodian is wired (WithKeyvault rebuilds the registry once it is).
-func NewRegistry(pool *pgxpool.Pool, sink *Sink, authority authz.Resolver, vault keyvault.Vault) *Registry {
+func NewRegistry(db *database.DB, sink *Sink, authority authz.Resolver, vault keyvault.Vault) *Registry {
 	return &Registry{
 		connectors:     map[string]connector.Connector{},
-		pool:           pool,
+		db:             db,
 		sink:           sink,
 		authority:      authority,
 		vault:          vault,
@@ -142,7 +142,7 @@ func (r *Registry) SyncOnce(ctx context.Context, connectionID ids.UUID) error {
 		cursor        []byte
 		generation    int
 	)
-	err := database.WithWorkspaceTx(ctx, r.pool, func(tx pgx.Tx) error {
+	err := r.db.Tx(ctx, func(tx pgx.Tx) error {
 		// 'error' is syncable by design (ADR-0063): the daily probe of a
 		// degraded connection runs through this same path, and its success
 		// is what flips the row back to connected. Only 'disconnected' and
@@ -231,7 +231,7 @@ func (r *Registry) SyncOnce(ctx context.Context, connectionID ids.UUID) error {
 // matched nothing for that reason — the caller records neither the watermark nor
 // a health verdict, because the cycle belongs to a connection that is gone.
 func (r *Registry) commitSyncCursor(ctx context.Context, connectionID ids.UUID, generation int, next connector.Cursor) (superseded bool, err error) {
-	err = database.WithWorkspaceTx(ctx, r.pool, func(tx pgx.Tx) error {
+	err = r.db.Tx(ctx, func(tx pgx.Tx) error {
 		// sync_cursor is jsonb; the connector's watermark is already JSON. A
 		// connector that yields no cursor writes NULL, never an empty jsonb.
 		var cur []byte
@@ -288,7 +288,7 @@ func (r *Registry) seedOwnDomainFromAccount(ctx context.Context, c connector.Con
 	if strings.TrimSpace(label) == "" {
 		return nil
 	}
-	return database.WithWorkspaceTx(ctx, r.pool, func(tx pgx.Tx) error {
+	return r.db.Tx(ctx, func(tx pgx.Tx) error {
 		return seedDomainOfAddressTx(ctx, tx, label)
 	})
 }

--- a/backend/internal/modules/capture/registry_connections.go
+++ b/backend/internal/modules/capture/registry_connections.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/keyvault"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
@@ -69,7 +68,7 @@ const sendableConnection = `
 // it reports; every other error is a failure to get an answer.
 func (r *Registry) GrantedScopesFor(ctx context.Context, userID ids.UserID, provider string) ([]string, error) {
 	var granted []string
-	err := database.WithWorkspaceTx(ctx, r.pool, func(tx pgx.Tx) error {
+	err := r.db.Tx(ctx, func(tx pgx.Tx) error {
 		return tx.QueryRow(ctx,
 			`SELECT provider_scopes FROM capture_connection`+sendableConnection,
 			userID, provider).Scan(&granted)
@@ -100,7 +99,7 @@ func (r *Registry) SenderFor(ctx context.Context, userID ids.UserID, provider st
 		authBytes     []byte
 		granted       []string
 	)
-	err := database.WithWorkspaceTx(ctx, r.pool, func(tx pgx.Tx) error {
+	err := r.db.Tx(ctx, func(tx pgx.Tx) error {
 		return tx.QueryRow(ctx,
 			`SELECT credential_ref, auth, provider_scopes FROM capture_connection`+sendableConnection,
 			userID, provider).Scan(&credentialRef, &authBytes, &granted)
@@ -176,7 +175,7 @@ func (r *Registry) Connections(ctx context.Context) ([]ConnectionView, error) {
 		return nil, errors.New("capture: only a human lists their connections")
 	}
 	var out []ConnectionView
-	err := database.WithWorkspaceTx(ctx, r.pool, func(tx pgx.Tx) error {
+	err := r.db.Tx(ctx, func(tx pgx.Tx) error {
 		rows, err := tx.Query(ctx, `
 			SELECT c.id, c.provider, c.status, c.sync_cursor, c.watch_expires_at, c.provider_scopes,
 			       c.account_label, s.last_synced_at, s.last_error_class, s.next_sync_at
@@ -278,7 +277,7 @@ func (r *Registry) Disconnect(ctx context.Context, name string) error {
 	// must not leave the row naming a blob that no longer exists.
 	refCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), keyvault.CleanupTimeout)
 	defer cancel()
-	return database.WithWorkspaceTx(refCtx, r.pool, func(tx pgx.Tx) error {
+	return r.db.Tx(refCtx, func(tx pgx.Tx) error {
 		_, err := tx.Exec(refCtx, `
 			UPDATE capture_connection SET credential_ref = NULL
 			 WHERE user_id = $1 AND provider = $2 AND credential_ref = $3`,
@@ -321,7 +320,7 @@ func (r *Registry) Disconnect(ctx context.Context, name string) error {
 // serializes behind this transaction rather than racing it.
 func (r *Registry) withdrawConnection(ctx context.Context, userID ids.UUID, name string) (*string, error) {
 	var ref *string
-	err := database.WithWorkspaceTx(ctx, r.pool, func(tx pgx.Tx) error {
+	err := r.db.Tx(ctx, func(tx pgx.Tx) error {
 		var connID ids.UUID
 		var priorStatus string
 		var priorLabel *string
@@ -406,7 +405,7 @@ func (r *Registry) DueConnections(ctx context.Context, name string) ([]DueConnec
 // failure never starves the rest of the fleet.
 func (r *Registry) collectDue(ctx context.Context, selector func(ctx context.Context, tx pgx.Tx) ([]ids.UUID, error)) ([]DueConnection, error) {
 	// rls-exempt: fleet enumeration — the workspace table is not workspace-scoped; this reads every tenant before entering each workspace's own GUC.
-	rows, err := r.pool.Query(ctx, `SELECT id FROM workspace WHERE archived_at IS NULL ORDER BY created_at`)
+	rows, err := r.db.Pool().Query(ctx, `SELECT id FROM workspace WHERE archived_at IS NULL ORDER BY created_at`)
 	if err != nil {
 		return nil, fmt.Errorf("capture: listing workspaces for the fleet walk: %w", err)
 	}
@@ -419,7 +418,7 @@ func (r *Registry) collectDue(ctx context.Context, selector func(ctx context.Con
 	for _, wsID := range workspaces {
 		wsCtx := principal.WithWorkspaceID(ctx, wsID)
 		ws := ids.From[ids.WorkspaceKind](wsID)
-		err := database.WithWorkspaceTx(wsCtx, r.pool, func(tx pgx.Tx) error {
+		err := r.db.Tx(wsCtx, func(tx pgx.Tx) error {
 			selected, err := selector(wsCtx, tx)
 			if err != nil {
 				return err

--- a/backend/internal/modules/capture/registry_disconnect_integration_test.go
+++ b/backend/internal/modules/capture/registry_disconnect_integration_test.go
@@ -149,7 +149,7 @@ func newCaptureRegistryFixture(t *testing.T) (context.Context, *capture.Registry
 	}
 
 	vault := keyvault.NewMemory()
-	reg := capture.NewRegistry(pool, nil, fixtureAuthority{}, vault)
+	reg := capture.NewRegistry(database.BindTo(pool, ids.From[ids.WorkspaceKind](wsUUID)), nil, fixtureAuthority{}, vault)
 	reg.Register(fixtureConnector{})
 
 	actorCtx := principal.WithWorkspaceID(ctx, wsUUID)
@@ -368,7 +368,7 @@ func TestDisconnectCompletesEvenWhenTheVaultDeleteFails(t *testing.T) {
 	connectFixtureConnection(ctx, t, reg)
 
 	failing := &deleteFailsVault{Vault: vault}
-	reg2 := capture.NewRegistry(poolFromFixture(t), nil, fixtureAuthority{}, failing)
+	reg2 := capture.NewRegistry(database.BindTo(poolFromFixture(t), ws), nil, fixtureAuthority{}, failing)
 	reg2.Register(fixtureConnector{})
 
 	if err := reg2.Disconnect(ctx, "gmail"); err != nil {
@@ -404,7 +404,7 @@ func TestDisconnectPhase3DoesNotClobberAConcurrentReconnect(t *testing.T) {
 	deleteStarted := make(chan struct{})
 	proceed := make(chan struct{})
 	blocking := &blockingDeleteVault{Vault: vault, started: deleteStarted, proceed: proceed}
-	reg2 := capture.NewRegistry(poolFromFixture(t), nil, fixtureAuthority{}, blocking)
+	reg2 := capture.NewRegistry(database.BindTo(poolFromFixture(t), ws), nil, fixtureAuthority{}, blocking)
 	reg2.Register(fixtureConnector{})
 
 	disconnectErr := make(chan error, 1)
@@ -414,7 +414,7 @@ func TestDisconnectPhase3DoesNotClobberAConcurrentReconnect(t *testing.T) {
 
 	// The concurrent reconnect: a fresh Registry sharing the same pool/vault,
 	// exactly like a second request would land on the same process.
-	reg3 := capture.NewRegistry(poolFromFixture(t), nil, fixtureAuthority{}, vault)
+	reg3 := capture.NewRegistry(database.BindTo(poolFromFixture(t), ws), nil, fixtureAuthority{}, vault)
 	reg3.Register(fixtureConnector{})
 	if _, err := reg3.Connect(ctx, "gmail", connector.Auth("fixture-token-reconnect")); err != nil {
 		t.Fatalf("concurrent reconnect: %v", err)

--- a/backend/internal/modules/capture/registry_grant.go
+++ b/backend/internal/modules/capture/registry_grant.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/keyvault"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
@@ -85,7 +84,7 @@ func (r *Registry) Connect(ctx context.Context, name string, auth connector.Auth
 	}
 	var id ids.UUID
 	var priorRef *string
-	if err := database.WithWorkspaceTx(ctx, r.pool, func(tx pgx.Tx) error {
+	if err := r.db.Tx(ctx, func(tx pgx.Tx) error {
 		var err error
 		id, priorRef, err = upsertConnection(ctx, tx, row)
 		return err

--- a/backend/internal/modules/capture/registry_watch.go
+++ b/backend/internal/modules/capture/registry_watch.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/connector"
@@ -72,7 +71,7 @@ func (r *Registry) RenewWatch(ctx context.Context, connectionID ids.UUID, topic 
 		credentialRef *string
 		authBytes     []byte
 	)
-	err := database.WithWorkspaceTx(ctx, r.pool, func(tx pgx.Tx) error {
+	err := r.db.Tx(ctx, func(tx pgx.Tx) error {
 		return tx.QueryRow(ctx, `
 			SELECT provider, user_id, credential_ref, auth FROM capture_connection
 			WHERE id = $1 AND status = 'connected'`, connectionID).
@@ -104,7 +103,7 @@ func (r *Registry) RenewWatch(ctx context.Context, connectionID ids.UUID, topic 
 	if err != nil {
 		return err
 	}
-	return database.WithWorkspaceTx(ctx, r.pool, func(tx pgx.Tx) error {
+	return r.db.Tx(ctx, func(tx pgx.Tx) error {
 		_, err := tx.Exec(ctx, `
 			UPDATE capture_connection SET watch_expires_at = $2
 			WHERE id = $1 AND status = 'connected' AND archived_at IS NULL`,

--- a/backend/internal/modules/capture/sink.go
+++ b/backend/internal/modules/capture/sink.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgxpool"
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
@@ -28,7 +27,8 @@ import (
 // Sink is the one connector.Sink implementation — the chokepoint every
 // captured record passes on its way into the domain.
 type Sink struct {
-	pool           *pgxpool.Pool
+	// db binds the workspace this store runs for (ADR-0091 §9 step 3).
+	db             *database.DB
 	stager         MergeStager
 	ensurer        CounterpartyEnsurer
 	channelEnsurer ChannelCounterpartyEnsurer
@@ -68,8 +68,9 @@ type MergeProposal struct {
 	Summary        string
 }
 
-func NewSink(pool *pgxpool.Pool) *Sink {
-	return &Sink{pool: pool}
+// NewSink binds the capture sink to the pool its writes run through.
+func NewSink(db *database.DB) *Sink {
+	return &Sink{db: db}
 }
 
 // WithFileKeeper returns a copy that keeps the files a captured message
@@ -120,7 +121,7 @@ func (s *Sink) Upsert(ctx context.Context, rec connector.NormalizedRecord) (data
 	// produced no rows, and returning ErrSkip from inside the callback would
 	// roll that proof back along with everything else (ADR-0082 §1).
 	var internalOnly bool
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		// A channel record's account id IS personal data, and THIS transaction is
 		// the one that makes it durable — so the erasure is excluded here, under
 		// the account's own lock, and not only at the ingress edge that admitted

--- a/backend/internal/modules/capture/sinkchannel_integration_test.go
+++ b/backend/internal/modules/capture/sinkchannel_integration_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/gradionhq/margince/backend/internal/modules/capture"
+	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/connector"
@@ -80,7 +81,7 @@ func TestChannelRecordSkipsEveryMailDomainGate(t *testing.T) {
 	}
 
 	ensurer := &recordingChannelEnsurer{}
-	sink := capture.NewSink(pool).
+	sink := capture.NewSink(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws))).
 		WithEnsurer(refusingMailEnsurer{t: t},
 			capture.NewTransactionalList([]string{"sendgrid.net"}, nil)).
 		WithChannelEnsurer(ensurer)

--- a/backend/internal/modules/capture/sinkensure.go
+++ b/backend/internal/modules/capture/sinkensure.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
@@ -457,7 +456,7 @@ func (s *Sink) logEnsureFault(ctx context.Context, rec connector.NormalizedRecor
 	if rec.Counterparty.ChannelIdentity.Provider == "" {
 		detail[fieldSourceID] = rec.NaturalKey.SourceID
 	}
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		_, logErr := storekit.LogSystem(ctx, tx, "capture_ensure_fault", detail)
 		return logErr
 	})

--- a/backend/internal/modules/capture/sinkinternal_integration_test.go
+++ b/backend/internal/modules/capture/sinkinternal_integration_test.go
@@ -32,7 +32,7 @@ import (
 
 // bootstrapInternalMailWorkspace seeds a workspace that has registered acme.com
 // as its own domain, and returns a context bound to it.
-func bootstrapInternalMailWorkspace(t *testing.T, ownDomains ...string) (context.Context, *pgxpool.Pool) {
+func bootstrapInternalMailWorkspace(t *testing.T, ownDomains ...string) (context.Context, *database.DB) {
 	t.Helper()
 	owner, pool := setupCaptureDB(t)
 	ctx := context.Background()
@@ -71,7 +71,7 @@ func bootstrapInternalMailWorkspace(t *testing.T, ownDomains ...string) (context
 			t.Fatalf("seeding the anchor company: %v", err)
 		}
 	}
-	return wsCtx, pool
+	return wsCtx, database.BindTo(pool, ids.From[ids.WorkspaceKind](wsUUID))
 }
 
 // mailSinkContext binds the per-user mail connector principal the sync loop
@@ -185,8 +185,8 @@ func breadcrumbReasons(ctx context.Context, t *testing.T, pool *pgxpool.Pool, so
 // note — so every colleague could open it on the global timeline and find it in
 // search.
 func TestAnAllInternalMessageLeavesNoRowInAnyTable(t *testing.T) {
-	ctx, pool := bootstrapInternalMailWorkspace(t, "acme.com")
-	sink := capture.NewSink(pool)
+	ctx, db := bootstrapInternalMailWorkspace(t, "acme.com")
+	sink := capture.NewSink(db)
 
 	_, err := sink.Upsert(ctx, mailRecord("internal-1", "boss@acme.com",
 		"boss@acme.com", "rep@acme.com", "hr@mail.acme.com"))
@@ -194,7 +194,7 @@ func TestAnAllInternalMessageLeavesNoRowInAnyTable(t *testing.T) {
 		t.Fatalf("Upsert of an all-internal message: got %v, want a skip", err)
 	}
 
-	activities, participants, raws, audits := countsFor(ctx, t, pool, "internal-1")
+	activities, participants, raws, audits := countsFor(ctx, t, db.Pool(), "internal-1")
 	if activities != 0 || participants != 0 || raws != 0 || audits != 0 {
 		t.Errorf("all-internal message left rows behind: activity=%d participant=%d raw_capture=%d audit_log=%d, want 0 in each",
 			activities, participants, raws, audits)
@@ -202,7 +202,7 @@ func TestAnAllInternalMessageLeavesNoRowInAnyTable(t *testing.T) {
 
 	// The drop is provable, not merely asserted: the ledger row is what makes
 	// "colleague mail is never ingested" checkable after the fact.
-	reasons := breadcrumbReasons(ctx, t, pool, "internal-1")
+	reasons := breadcrumbReasons(ctx, t, db.Pool(), "internal-1")
 	if len(reasons) != 1 || reasons[0] != "internal_only" {
 		t.Errorf("ledger reasons = %v, want exactly one internal_only", reasons)
 	}
@@ -216,8 +216,8 @@ func TestAnAllInternalMessageLeavesNoRowInAnyTable(t *testing.T) {
 // the creation ladder is ABOUT is the other half, and needs a wired ensurer —
 // it is asserted in compose's capture_autocreate_integration_test.go.
 func TestAColleaguesMessageCopyingAProspectIsCapturedAndKeepsItsAuthor(t *testing.T) {
-	ctx, pool := bootstrapInternalMailWorkspace(t, "acme.com")
-	sink := capture.NewSink(pool)
+	ctx, db := bootstrapInternalMailWorkspace(t, "acme.com")
+	sink := capture.NewSink(db)
 
 	rec := mailRecord("intro-1", "colleague@acme.com",
 		"colleague@acme.com", "rep@acme.com", "buyer@customer.example")
@@ -225,7 +225,7 @@ func TestAColleaguesMessageCopyingAProspectIsCapturedAndKeepsItsAuthor(t *testin
 		t.Fatalf("an introduction must be captured: %v", err)
 	}
 
-	activities, _, raws, _ := countsFor(ctx, t, pool, "intro-1")
+	activities, _, raws, _ := countsFor(ctx, t, db.Pool(), "intro-1")
 	if activities != 1 {
 		t.Errorf("activity rows = %d, want 1 — one external party makes the message correspondence", activities)
 	}
@@ -236,7 +236,7 @@ func TestAColleaguesMessageCopyingAProspectIsCapturedAndKeepsItsAuthor(t *testin
 	// The stored activity still says the colleague wrote it. Authorship is not
 	// the record-creation question, and conflating them is what fakes replies.
 	var counterparty string
-	if err := database.WithWorkspaceTx(ctx, pool, func(tx pgx.Tx) error {
+	if err := db.Tx(ctx, func(tx pgx.Tx) error {
 		return tx.QueryRow(ctx,
 			`SELECT counterparty_email FROM activity WHERE source_id = 'intro-1'`).Scan(&counterparty)
 	}); err != nil {
@@ -246,7 +246,7 @@ func TestAColleaguesMessageCopyingAProspectIsCapturedAndKeepsItsAuthor(t *testin
 		t.Errorf("counterparty_email = %q, want the colleague who actually wrote it", counterparty)
 	}
 
-	if reasons := breadcrumbReasons(ctx, t, pool, "intro-1"); len(reasons) > 0 {
+	if reasons := breadcrumbReasons(ctx, t, db.Pool(), "intro-1"); len(reasons) > 0 {
 		for _, r := range reasons {
 			if r == "internal_only" {
 				t.Fatal("an introduction was dropped as internal — the copied prospect makes it external")
@@ -259,14 +259,14 @@ func TestAColleaguesMessageCopyingAProspectIsCapturedAndKeepsItsAuthor(t *testin
 // between two colleagues is captured. The installation has made no claim about
 // its own mail, and this gate does not invent one on its behalf.
 func TestWithNoRegisteredDomainEvenColleagueMailIsCaptured(t *testing.T) {
-	ctx, pool := bootstrapInternalMailWorkspace(t)
-	sink := capture.NewSink(pool)
+	ctx, db := bootstrapInternalMailWorkspace(t)
+	sink := capture.NewSink(db)
 
 	if _, err := sink.Upsert(ctx, mailRecord("nodomain-1", "boss@acme.com",
 		"boss@acme.com", "rep@acme.com")); err != nil {
 		t.Fatalf("with an empty own-domain set the message must be captured: %v", err)
 	}
-	if activities, _, _, _ := countsFor(ctx, t, pool, "nodomain-1"); activities != 1 {
+	if activities, _, _, _ := countsFor(ctx, t, db.Pool(), "nodomain-1"); activities != 1 {
 		t.Errorf("activity rows = %d, want 1", activities)
 	}
 }
@@ -275,13 +275,13 @@ func TestWithNoRegisteredDomainEvenColleagueMailIsCaptured(t *testing.T) {
 // says "I could not read the parties", which is not the same claim as "there
 // were none", and the direction to fail in is toward keeping mail.
 func TestAMessageReportingNoAddressesIsCaptured(t *testing.T) {
-	ctx, pool := bootstrapInternalMailWorkspace(t, "acme.com")
-	sink := capture.NewSink(pool)
+	ctx, db := bootstrapInternalMailWorkspace(t, "acme.com")
+	sink := capture.NewSink(db)
 
 	if _, err := sink.Upsert(ctx, mailRecord("unknown-1", "boss@acme.com")); err != nil {
 		t.Fatalf("an unenumerable message must be captured: %v", err)
 	}
-	if activities, _, _, _ := countsFor(ctx, t, pool, "unknown-1"); activities != 1 {
+	if activities, _, _, _ := countsFor(ctx, t, db.Pool(), "unknown-1"); activities != 1 {
 		t.Errorf("activity rows = %d, want 1", activities)
 	}
 }
@@ -289,15 +289,15 @@ func TestAMessageReportingNoAddressesIsCaptured(t *testing.T) {
 // A subdomain of a registered domain is internal. The workspace registered
 // acme.com; mail among people at mail.acme.com is still colleague mail.
 func TestMailAmongSubdomainsOfARegisteredDomainIsInternal(t *testing.T) {
-	ctx, pool := bootstrapInternalMailWorkspace(t, "acme.com")
-	sink := capture.NewSink(pool)
+	ctx, db := bootstrapInternalMailWorkspace(t, "acme.com")
+	sink := capture.NewSink(db)
 
 	_, err := sink.Upsert(ctx, mailRecord("subdomain-1", "boss@mail.acme.com",
 		"boss@mail.acme.com", "rep@eu.acme.com"))
 	if !isSkip(err) {
 		t.Fatalf("subdomain mail: got %v, want a skip", err)
 	}
-	if activities, _, raws, _ := countsFor(ctx, t, pool, "subdomain-1"); activities != 0 || raws != 0 {
+	if activities, _, raws, _ := countsFor(ctx, t, db.Pool(), "subdomain-1"); activities != 0 || raws != 0 {
 		t.Errorf("subdomain mail left rows: activity=%d raw_capture=%d, want 0", activities, raws)
 	}
 }
@@ -316,8 +316,8 @@ func isSkip(err error) bool { return errors.Is(err, connector.ErrSkip) }
 // skipped message. Only the installation's own company, or an administrator,
 // can make a domain count.
 func TestAnUnverifiedOwnDomainSuppressesNothing(t *testing.T) {
-	ctx, pool := bootstrapInternalMailWorkspace(t)
-	if err := database.WithWorkspaceTx(ctx, pool, func(tx pgx.Tx) error {
+	ctx, db := bootstrapInternalMailWorkspace(t)
+	if err := db.Tx(ctx, func(tx pgx.Tx) error {
 		_, err := tx.Exec(ctx, `
 			INSERT INTO workspace_email_domain (workspace_id, domain, source, verified)
 			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, 'acme.com', 'mailbox', false)`)
@@ -325,13 +325,13 @@ func TestAnUnverifiedOwnDomainSuppressesNothing(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("seeding an unverified domain: %v", err)
 	}
-	sink := capture.NewSink(pool)
+	sink := capture.NewSink(db)
 
 	if _, err := sink.Upsert(ctx, mailRecord("unverified-1", "boss@acme.com",
 		"boss@acme.com", "rep@acme.com")); err != nil {
 		t.Fatalf("an unverified domain must not suppress storage: %v", err)
 	}
-	if activities, _, _, _ := countsFor(ctx, t, pool, "unverified-1"); activities != 1 {
+	if activities, _, _, _ := countsFor(ctx, t, db.Pool(), "unverified-1"); activities != 1 {
 		t.Errorf("activity rows = %d, want 1 — only a vouched-for domain governs the drop", activities)
 	}
 }
@@ -343,8 +343,8 @@ func TestAnUnverifiedOwnDomainSuppressesNothing(t *testing.T) {
 // or a company that changed its domain — hiding correspondence with an address
 // nobody claims any more, with nothing in the system able to revoke it.
 func TestADomainTheCompanyNoLongerClaimsStopsSuppressingMail(t *testing.T) {
-	ctx, pool := bootstrapInternalMailWorkspace(t, "acme.com")
-	sink := capture.NewSink(pool)
+	ctx, db := bootstrapInternalMailWorkspace(t, "acme.com")
+	sink := capture.NewSink(db)
 
 	if _, err := sink.Upsert(ctx, mailRecord("revoke-1", "boss@acme.com",
 		"boss@acme.com", "rep@acme.com")); !isSkip(err) {
@@ -352,7 +352,7 @@ func TestADomainTheCompanyNoLongerClaimsStopsSuppressingMail(t *testing.T) {
 	}
 
 	// The company corrects itself: acme.com was never theirs.
-	if err := database.WithWorkspaceTx(ctx, pool, func(tx pgx.Tx) error {
+	if err := db.Tx(ctx, func(tx pgx.Tx) error {
 		_, err := tx.Exec(ctx, `UPDATE organization_domain SET domain = 'acmecorp.com'`)
 		return err
 	}); err != nil {
@@ -363,7 +363,7 @@ func TestADomainTheCompanyNoLongerClaimsStopsSuppressingMail(t *testing.T) {
 		"boss@acme.com", "rep@acme.com")); err != nil {
 		t.Fatalf("once the company no longer claims acme.com the mail must be kept: %v", err)
 	}
-	if activities, _, _, _ := countsFor(ctx, t, pool, "revoke-2"); activities != 1 {
+	if activities, _, _, _ := countsFor(ctx, t, db.Pool(), "revoke-2"); activities != 1 {
 		t.Errorf("activity rows = %d, want 1 — the claim was withdrawn, so the drop must stop", activities)
 	}
 }

--- a/backend/internal/modules/capture/syncstate.go
+++ b/backend/internal/modules/capture/syncstate.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
@@ -106,7 +105,7 @@ func (r *Registry) recordSyncSuccess(ctx context.Context, connectionID ids.UUID)
 	if err != nil {
 		return err
 	}
-	return database.WithWorkspaceTx(ctx, r.pool, func(tx pgx.Tx) error {
+	return r.db.Tx(ctx, func(tx pgx.Tx) error {
 		now := r.now()
 		if _, err := tx.Exec(ctx, `
 			INSERT INTO capture_sync_state (connection_id, workspace_id, next_sync_at,
@@ -145,7 +144,7 @@ func (r *Registry) recordSyncFailure(ctx context.Context, connectionID ids.UUID,
 	if err != nil {
 		return err
 	}
-	return database.WithWorkspaceTx(ctx, r.pool, func(tx pgx.Tx) error {
+	return r.db.Tx(ctx, func(tx pgx.Tx) error {
 		now := r.now()
 
 		var failures int


### PR DESCRIPTION
Sweep continues (ADR-0091 §9 step 3). **7 of 20 modules; 354 `WithWorkspaceTx` sites left** (from 442).

## Where capture divides, and why

Its **request-path stores** take the handle. The two stores reached **only from fleet sweeps** — `AutoEnrichStore` and `PendingStore` — stay on the context-bound helper.

Those sweeps hold their stores as long-lived fields and use them per workspace, so converting the stores without restructuring the sweeps leaves the resolver refusing *inside* a pass — the failure #965 already showed, one layer deeper. Restructuring them is its own change, and the other seven stores don't have to wait for it.

I tried it the other way first and reverted: it spread from `captureautoenrich` into `capturedomaintriage`, `captureverdict` and `deepread`, in paths governing enrichment budget and deep-read spend.

## The fixtures moved further than the sweep did

Several build a workspace by raw SQL and then hand back a **pool**, which makes every test in the file re-derive the tenant. They hand back the **bound handle** now — the same fact stated once, at the point the workspace is created.

Where a helper genuinely takes a pool *as a parameter* — `countsFor`, `breadcrumbReasons`, `activityOf` — it keeps taking one. The caller's handle isn't its business.

## Verification

`make check-backend` and `make craft-static` (0/0/0) green. The tenant-isolation suite is CI's word.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactor capture to execute through a workspace-bound database handle instead of the shared pool. This makes tenancy explicit, tightens RLS boundaries, and leaves behavior unchanged.

- **Refactors**
  - `capture.NewSink`, `capture.NewRegistry`, `capture.NewChannelStore`, `capture.NewOwnDomainStore`, and `capture.NewFreemailDomains` now take `*database.DB` (workspace-bound) instead of `*pgxpool.Pool`.
  - Internals switch from `database.WithWorkspaceTx(ctx, pool, ...)` to `db.Tx(...)`.
  - Compose wiring passes `InstallationDB(pool)` where needed; tests/fixtures use `e.DB()` or `database.BindTo(pool, ws)`. Helpers that truly operate on a pool keep taking one.
  - Fleet-sweep-only stores remain context-bound for now (AutoEnrichStore, PendingStore) to avoid sweep restructuring in this step.

- **Bug Fixes**
  - Own-domain isolation test builds a store per workspace (not one store with two contexts) to correctly assert RLS isolation.

<sup>Written for commit bbf438d6a5bd62ff28d3a6206a65cdec86a6f1d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/968?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

