### PR TITLE
test(people,identity): a contention probe that can see the backend it waits for

### DIFF
--- a/backend/internal/modules/identity/oauth_lend_lock_integration_test.go
+++ b/backend/internal/modules/identity/oauth_lend_lock_integration_test.go
@@ -114,11 +114,25 @@ func (e *lendEnv) revokeAndHold(t *testing.T, passportID ids.PassportID, fn func
 // live answer, and the deadline is a failure guard, not a race — the consent
 // either queues behind this transaction within it or the property under test is
 // simply false.
+//
+// Each round trip discards the statistics snapshot first, and without that the
+// round trips would not return a live answer at all. pg_stat_activity's row set
+// is materialized once per transaction and cached until it ends; this probe runs
+// INSIDE the revocation's own long-lived transaction, so a consent that arrives
+// on a connection dialled after the first look would be absent from every later
+// look no matter how long the loop ran. On an idle machine the pool has a warm
+// connection and the bug is invisible; under the lane's concurrency it is not,
+// and it reports itself as "the consent never contended" — a true-looking
+// failure about a consent queued squarely behind this transaction.
 func waitUntilBlockingSomebody(t *testing.T, tx pgx.Tx) {
 	t.Helper()
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	for ctx.Err() == nil {
+		if _, err := tx.Exec(ctx, `SELECT pg_stat_clear_snapshot()`); err != nil &&
+			!errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("discarding the statistics snapshot before looking again: %v", err)
+		}
 		var blocked bool
 		err := tx.QueryRow(ctx, `
 			SELECT EXISTS (

--- a/backend/internal/modules/people/ensurechannel_contention_integration_test.go
+++ b/backend/internal/modules/people/ensurechannel_contention_integration_test.go
@@ -19,6 +19,7 @@ package people
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"sync"
 	"testing"
@@ -319,14 +320,14 @@ func (e *dedupeEnv) refreshInBackground(ctx context.Context, ci connector.Channe
 // failure this comment exists to prevent. Raise this number and that sum moves
 // with it.
 //
-// 60s was not enough under a twelve-shard lane — two tests on this helper
-// reddened two unrelated PRs in one day, each burning the full budget while the
-// writer never reached its lock (#898). The pacing below is the change that
-// addresses WHY; this is the headroom that covers a merely slow runner.
+// This number covers a merely slow runner and nothing else. It is deliberately
+// NOT the answer to the runs that burned a whole budget while the writer never
+// reached its lock: those were not slow, they were blind, and no budget reaches
+// blindness — see probeForWaiter, which is where that was actually fixed.
 const probeBudget = 90 * time.Second
 
-// probeInterval paces the poll, and it is the half of #898 that is about cause
-// rather than headroom.
+// probeInterval paces the poll. It is about the COST of watching, not about
+// whether the watching works — that is probeForWaiter's job.
 //
 // The probe calls pg_blocking_pids, which Postgres documents as needing
 // exclusive access to the lock manager's shared state for a short time and
@@ -368,21 +369,25 @@ func waitUntilBlocked[T any](t *testing.T, probe pgx.Tx, pid int, done <-chan T)
 func waitUntilBlockedIn[T any](ctx context.Context, t *testing.T, probe pgx.Tx, pid int, done <-chan T) (T, bool) {
 	t.Helper()
 	var zero T
+	// The budget REPORTED is the one SUPPLIED. This function takes its deadline
+	// from the caller precisely so a caller can hand it a shorter one, and a
+	// message naming the probeBudget constant would misreport every caller that
+	// does.
+	budget := probeBudget
+	if deadline, ok := ctx.Deadline(); ok {
+		budget = time.Until(deadline).Round(time.Second)
+	}
 	pace := time.NewTicker(probeInterval)
 	defer pace.Stop()
 	for probes := 1; ; probes++ {
-		var blocked bool
-		switch err := probe.QueryRow(ctx, `
-			SELECT EXISTS (
-			  SELECT 1 FROM pg_stat_activity a
-			   WHERE a.datname = current_database() AND $1 = ANY (pg_blocking_pids(a.pid)))`,
-			pid).Scan(&blocked); {
+		blocked, err := probeForWaiter(ctx, probe, pid)
+		switch {
 		case err != nil && ctx.Err() != nil:
 			if result, finished := racerFinished(done); finished {
 				return result, true
 			}
 			t.Fatalf("no backend waited on the held row within %s (%d probes): the writer neither "+
-				"reached the lock nor returned, so this run proved nothing", probeBudget, probes)
+				"reached the lock nor returned, so this run proved nothing", budget, probes)
 		case err != nil:
 			t.Fatalf("probing for a waiting backend: %v", err)
 		}
@@ -403,10 +408,46 @@ func waitUntilBlockedIn[T any](ctx context.Context, t *testing.T, probe pgx.Tx, 
 				return result, true
 			}
 			t.Fatalf("no backend waited on the held row within %s (%d probes): the writer neither "+
-				"reached the lock nor returned, so this run proved nothing", probeBudget, probes)
+				"reached the lock nor returned, so this run proved nothing", budget, probes)
 		case <-pace.C:
 		}
 	}
+}
+
+// probeForWaiter asks once whether any backend is waiting on a lock pid holds.
+//
+// It discards the statistics snapshot first, and THAT is why this is a function
+// rather than a query inlined in the loop above. pg_stat_activity's row set is
+// materialized once per transaction and then cached until that transaction
+// ends: a backend that connects after the probing transaction's first look is
+// missing from every later look, permanently. The probe runs on the lock
+// HOLDER's transaction, which stays open for the whole race, while the racer
+// arrives on a pooled connection the pool may only dial once the race is under
+// way — so the observer could be structurally blind to the one backend it
+// exists to see, and would then report "the writer never reached the lock"
+// about a writer parked squarely on it.
+//
+// That is the failure this helper kept producing on CI and never on an idle
+// machine, where the pool always had a warm connection to hand (#548). It is
+// not slowness, so neither of the two budget increases it outlived could have
+// helped. pg_stat_clear_snapshot drops the cache, which is what makes every
+// probe a look at the live set rather than a re-reading of the first one.
+//
+// Only the row set goes stale. pg_blocking_pids is a function call evaluated
+// per probe and always reports the live lock manager, which is exactly why the
+// bug hid: whenever the racer's connection happened to pre-date the first look,
+// its blocking state was reported correctly and the test passed.
+func probeForWaiter(ctx context.Context, probe pgx.Tx, pid int) (bool, error) {
+	if _, err := probe.Exec(ctx, `SELECT pg_stat_clear_snapshot()`); err != nil {
+		return false, err
+	}
+	var blocked bool
+	err := probe.QueryRow(ctx, `
+		SELECT EXISTS (
+		  SELECT 1 FROM pg_stat_activity a
+		   WHERE a.datname = current_database() AND $1 = ANY (pg_blocking_pids(a.pid)))`,
+		pid).Scan(&blocked)
+	return blocked, err
 }
 
 // racerFinished asks once more whether the racer has an answer waiting.
@@ -442,6 +483,73 @@ func mustBlockOn(t *testing.T, probe pgx.Tx, pid int, done <-chan error) {
 		t.Fatalf("the second writer finished (%v) without ever waiting on the first — "+
 			"it never reached the binding, so this run exercises no ordering at all", err)
 	}
+}
+
+// The probe sees a backend that dials AFTER it has started looking.
+//
+// Every contention test in this package rests on that, and none of them assert
+// it, because on a machine with a warm pool it holds by accident: the racer's
+// connection already exists when the probing transaction takes its first look,
+// so the transaction-scoped statistics snapshot happens to contain it. Under
+// the lane's concurrency the pool has no idle connection to hand, the racer
+// dials one mid-race, and a probe that trusts that snapshot cannot ever see it.
+//
+// So the ordering is PINNED here rather than raced for: the first look is taken
+// deliberately while no racer exists, and the racer then arrives on a connection
+// dialled afterwards. That makes this test fail on a laptop against the bug it
+// describes, instead of only on a loaded runner.
+func TestTheProbeSeesABackendThatDialsAfterItsFirstLook(t *testing.T) {
+	e := setupDedupe(t)
+	ctx := e.as()
+	holder, pid := e.holdOrgNameLock(ctx, t)
+
+	// The look that used to freeze this transaction's view of who is connected.
+	switch waiting, err := probeForWaiter(ctx, holder, pid); {
+	case err != nil:
+		t.Fatalf("the probe's first look: %v", err)
+	case waiting:
+		t.Fatal("something was already queued on the holder before the racer existed — " +
+			"this run cannot tell a working probe from a blind one")
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- takeOrgNameLockOnAFreshConnection(ctx) }()
+
+	// A budget of its own, and a short one. This racer dials and blocks in
+	// milliseconds, so a longer wait only delays the report — and it keeps this
+	// test out of probeBudget's arithmetic, which is sized for the five call
+	// sites that genuinely need the long one.
+	probing, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	if err, finished := waitUntilBlockedIn(probing, t, holder, pid, done); finished {
+		t.Fatalf("the racer finished (%v) without ever waiting on a lock it cannot hold — "+
+			"the holder still owns it, so the only way to finish is not to have reached it", err)
+	}
+}
+
+// takeOrgNameLockOnAFreshConnection contends for the workspace's
+// organization-name write identity from a backend that did not exist when this
+// call began, and returns once it holds it — which is only after the holder
+// lets go. Its own connection is the point: a pooled one may pre-date the
+// probe's first look, and then it proves nothing about a racer that does not.
+func takeOrgNameLockOnAFreshConnection(ctx context.Context) (err error) {
+	conn, err := pgx.Connect(ctx, os.Getenv("MARGINCE_TEST_APP_DSN"))
+	if err != nil {
+		return fmt.Errorf("dialling the racer's own connection: %w", err)
+	}
+	defer func() { err = errors.Join(err, conn.Close(context.Background())) }()
+
+	tx, err := conn.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("opening the racer's transaction: %w", err)
+	}
+	// The lock is held for the transaction, so releasing it IS the rollback.
+	defer func() {
+		if rollback := tx.Rollback(context.Background()); !errors.Is(rollback, pgx.ErrTxClosed) {
+			err = errors.Join(err, rollback)
+		}
+	}()
+	return lockOrgNameWrites(ctx, tx)
 }
 
 // The trail has to name the handle a refresh actually displaced. Two messages


### PR DESCRIPTION
Closes the residual half of #548.

## What was wrong

The contention probes read `pg_stat_activity` from inside the lock **holder's**
transaction, which stays open for the whole race. That view's row set is
materialized once per transaction and cached until it ends, so **a backend that
connects after the probe's first look is absent from every later look,
permanently**. The racer arrives on a pooled connection that pgxpool may only
dial once the race is under way — so the observer could be structurally blind to
the one backend it exists to see, and reported that as "the writer never reached
the lock".

Only the row set goes stale. `pg_blocking_pids` is a function call evaluated per
probe and always reports the live lock manager. That is why the bug hid:
whenever the pool had a warm connection to hand, the racer pre-dated the first
look and its blocking state was read correctly. An idle machine always has one;
a twelve-shard lane does not.

## Evidence

Measured against this repo's PG16, inside one transaction:

| step | result |
|---|---|
| first read | 1 backend |
| a new backend connects, 5s pass | still **1** — invisible |
| after `pg_stat_clear_snapshot()` | 2 |
| a backend that *pre-dated* the first read, then blocks | seen correctly |

Reproduced locally by denying the racer a warm connection (`pool_min_conns=0`)
and changing nothing else:

```
orgnamelock_contention_integration_test.go:108: no backend waited on the held row
within 1m30s (3601 probes): the writer neither reached the lock nor returned, so
this run proved nothing
--- FAIL: TestAnEvidenceApplyClearingANameWaitsOnTheNameLock (90.06s)
```

Same message, same line, same duration as run 31553267692 (3455 probes).

This accounts for every data point in #548: budget-independent (20 000 probes →
60s → 90s all failed identically), load-correlated (pgxpool fills `MinConns` in a
background goroutine, which lags under the lane's concurrency), green on re-run,
and the ~38 probes/s figure that showed the pacing fix was already doing its job.
**The writer was blocked on the lock the whole time — the test could not see it.**

## The change

- `probeForWaiter` discards the statistics snapshot before each look, so a probe
  reads the live set rather than re-reading the first one. Five call sites in
  `people` go through it.
- `identity`'s `waitUntilBlockingSomebody` had the same defect, where it would
  misreport as "the consent never contended". Fixed the same way.
- A regression test **pins** the ordering instead of racing for it: the first
  look is taken while no racer exists, and the racer then arrives on a connection
  dialled afterwards. It fails on an idle laptop with the message CI has been
  producing, rather than only on a loaded runner — confirmed by removing the fix.
- `waitUntilBlockedIn` now reports the budget it was **supplied**. It takes its
  deadline from the caller precisely so a caller can hand it a shorter one, and a
  message naming the package constant misreports every caller that does.
- The `probeBudget` / `probeInterval` comments claimed the pacing addressed the
  *why*. It did not, and a comment asserting a false invariant is worse than none.

`probeBudget` is unchanged at 90s, and its arithmetic against the package
timeout still holds: the new test carries its own 15s budget precisely so it
stays out of that sum.

## Verification

- `make check-backend` — green
- `craft static --strict` on both changed files — 0 findings
- `scripts/check-go-file-length.sh`, `gofumpt`, `go vet -tags integration` — green
- full `people` and `identity` integration packages — green
- the new test fails with the exact CI message when the fix is reverted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix contention probes in `people` and `identity` to read live `pg_stat_activity` by clearing the stats snapshot before each check. This lets probes see backends that connect mid-race and stops false “writer never reached the lock” failures (refs #548).

- **Bug Fixes**
  - Added `probeForWaiter` that calls `pg_stat_clear_snapshot()` before each probe; all `people` call sites and `identity`’s `waitUntilBlockingSomebody` use it.
  - Added a regression test that pins the ordering and uses a fresh connection so the bug reproduces on idle machines, and passes with the fix.
  - `waitUntilBlockedIn` now reports the caller-supplied budget instead of the package constant.

<sup>Written for commit f922dbea3ca16cac69f4ce62b04baeaf5adb77fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/970?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lock-wait detection so newly arriving blockers are reliably recognized during repeated checks.
  * Corrected probe timeout diagnostics to report the actual context time budget.

* **Tests**
  * Added integration coverage for lock contenders that connect after the initial check.
  * Added scenarios covering wrapped connection, transaction, and cleanup errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->