### PR TITLE
refactor(overlay): the mirror store binds the workspace its pass reconciles

### DIFF
--- a/backend/internal/compose/agenttierfloor_integration_test.go
+++ b/backend/internal/compose/agenttierfloor_integration_test.go
@@ -142,7 +142,7 @@ func TestAnOrdinaryOrganizationPatchStillRunsUnattended(t *testing.T) {
 // registryWithGate rather than NewRegistry so the tier floor arrives the way
 // production supplies it.
 func composedRegistry(e *integration.Env) *agents.Registry {
-	return registryWithGate(e.Pool, auth.NewGate(adminSeat{}), nil, nil,
+	return registryWithGate(e.DB(), auth.NewGate(adminSeat{}), nil, nil,
 		SendPath{}, companyEnricher{}, nil)
 }
 

--- a/backend/internal/compose/flipbundle.go
+++ b/backend/internal/compose/flipbundle.go
@@ -209,7 +209,7 @@ func reconstructFromBundle(ctx context.Context, pool *pgxpool.Pool, bundle []byt
 	// unresolvedOwnerEmails, not nil: this path never resolves an owner
 	// email (owners come from the bundle's own map), and a fail-loud
 	// placeholder beats a nil-interface panic if that stops being true.
-	writers := newFlipWriters(pool, overlay.NewMirrorStore(pool, unresolvedOwnerEmails{}), contents.incumbent).
+	writers := newFlipWriters(pool, overlay.NewMirrorStore(InstallationDB(pool), unresolvedOwnerEmails{}), contents.incumbent).
 		forRun(run.ID, operator).
 		WithOwnerMap(owners)
 	writers.SetAssociations(assocs)

--- a/backend/internal/compose/integration/overlay/overlay_acceptance_budget_integration_test.go
+++ b/backend/internal/compose/integration/overlay/overlay_acceptance_budget_integration_test.go
@@ -72,7 +72,7 @@ func TestAcceptance_AC_OV_3_MirrorReadMeetsBudget(t *testing.T) {
 	ws, actorID := seedOverlayModeWorkspace(t)
 	ctx := overlayActorCtx(ws, actorID)
 
-	mirror := overlaymod.NewMirrorStore(e.Pool, stubOwnerEmails{})
+	mirror := overlaymod.NewMirrorStore(e.DB(), stubOwnerEmails{})
 	if err := mirror.UpsertUserMap(ctx, ids.From[ids.UserKind](actorID), "hubspot", "owner-1", "manual"); err != nil {
 		t.Fatalf("mapping the acting user to owner-1: %v", err)
 	}
@@ -138,7 +138,7 @@ func TestAcceptance_AC_OV_7_ForceFreshDegrades(t *testing.T) {
 	ws, actorID := seedOverlayModeWorkspace(t)
 	ctx := overlayActorCtx(ws, actorID)
 
-	mirror := overlaymod.NewMirrorStore(e.Pool, stubOwnerEmails{})
+	mirror := overlaymod.NewMirrorStore(e.DB(), stubOwnerEmails{})
 	if err := mirror.UpsertUserMap(ctx, ids.From[ids.UserKind](actorID), "hubspot", "owner-1", "manual"); err != nil {
 		t.Fatalf("mapping the acting user to owner-1: %v", err)
 	}

--- a/backend/internal/compose/integration/overlay/overlay_acceptance_budget_integration_test.go
+++ b/backend/internal/compose/integration/overlay/overlay_acceptance_budget_integration_test.go
@@ -72,7 +72,7 @@ func TestAcceptance_AC_OV_3_MirrorReadMeetsBudget(t *testing.T) {
 	ws, actorID := seedOverlayModeWorkspace(t)
 	ctx := overlayActorCtx(ws, actorID)
 
-	mirror := overlaymod.NewMirrorStore(e.DB(), stubOwnerEmails{})
+	mirror := overlaymod.NewMirrorStore(e.DBFor(ws), stubOwnerEmails{})
 	if err := mirror.UpsertUserMap(ctx, ids.From[ids.UserKind](actorID), "hubspot", "owner-1", "manual"); err != nil {
 		t.Fatalf("mapping the acting user to owner-1: %v", err)
 	}
@@ -138,7 +138,7 @@ func TestAcceptance_AC_OV_7_ForceFreshDegrades(t *testing.T) {
 	ws, actorID := seedOverlayModeWorkspace(t)
 	ctx := overlayActorCtx(ws, actorID)
 
-	mirror := overlaymod.NewMirrorStore(e.DB(), stubOwnerEmails{})
+	mirror := overlaymod.NewMirrorStore(e.DBFor(ws), stubOwnerEmails{})
 	if err := mirror.UpsertUserMap(ctx, ids.From[ids.UserKind](actorID), "hubspot", "owner-1", "manual"); err != nil {
 		t.Fatalf("mapping the acting user to owner-1: %v", err)
 	}

--- a/backend/internal/compose/integration/overlay/overlay_acceptance_integration_test.go
+++ b/backend/internal/compose/integration/overlay/overlay_acceptance_integration_test.go
@@ -483,7 +483,11 @@ func TestAcceptance_AC_OV_11_FailClosedVisibility_ReadSubset(t *testing.T) {
 
 	t.Run("an unmapped user sees zero rows through the composed dispatcher (existence-hiding)", func(t *testing.T) {
 		unmappedCtx := overlayActorCtx(ws, seedUnmappedAppUser(t, ws))
-		d := compose.NewDispatcher(compose.NewProvider(e.Pool), compose.NewOverlayProviderFor(e.DB(), overlaybudget.New(nil, nil), nil), e.Pool)
+		// Bound to ws, the workspace the mirror fixture above wrote: a provider
+		// bound to any other one answers not-found for every id, and this arm
+		// asserts not-found — it would pass without ever reaching the rows whose
+		// hiding it exists to prove.
+		d := compose.NewDispatcher(compose.NewProvider(e.Pool), compose.NewOverlayProviderFor(e.DBFor(ws), overlaybudget.New(nil, nil), nil), e.Pool)
 		if _, err := d.Search(unmappedCtx, datasource.SearchQuery{EntityTypes: []datasource.EntityType{datasource.EntityPerson}, Limit: 10}); !errors.Is(err, apperrors.ErrNotFound) {
 			t.Fatalf("dispatched Search for an unmapped user = %v, want apperrors.ErrNotFound (existence-hiding, zero rows)", err)
 		}

--- a/backend/internal/compose/integration/overlay/overlay_acceptance_integration_test.go
+++ b/backend/internal/compose/integration/overlay/overlay_acceptance_integration_test.go
@@ -483,7 +483,7 @@ func TestAcceptance_AC_OV_11_FailClosedVisibility_ReadSubset(t *testing.T) {
 
 	t.Run("an unmapped user sees zero rows through the composed dispatcher (existence-hiding)", func(t *testing.T) {
 		unmappedCtx := overlayActorCtx(ws, seedUnmappedAppUser(t, ws))
-		d := compose.NewDispatcher(compose.NewProvider(e.Pool), compose.NewOverlayProvider(e.Pool, overlaybudget.New(nil, nil), nil), e.Pool)
+		d := compose.NewDispatcher(compose.NewProvider(e.Pool), compose.NewOverlayProviderFor(e.DB(), overlaybudget.New(nil, nil), nil), e.Pool)
 		if _, err := d.Search(unmappedCtx, datasource.SearchQuery{EntityTypes: []datasource.EntityType{datasource.EntityPerson}, Limit: 10}); !errors.Is(err, apperrors.ErrNotFound) {
 			t.Fatalf("dispatched Search for an unmapped user = %v, want apperrors.ErrNotFound (existence-hiding, zero rows)", err)
 		}

--- a/backend/internal/compose/integration/overlay/overlay_acceptance_integration_test.go
+++ b/backend/internal/compose/integration/overlay/overlay_acceptance_integration_test.go
@@ -48,6 +48,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 	overlaymod "github.com/gradionhq/margince/backend/internal/modules/overlay"
 	"github.com/gradionhq/margince/backend/internal/modules/overlay/fake"
+	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/keyvault"
 	"github.com/gradionhq/margince/backend/internal/platform/overlaybudget"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
@@ -69,7 +70,7 @@ func seedMirroredPersonFixture(t *testing.T, e *integration.Env) (context.Contex
 	t.Helper()
 	overlayWS, actorID := seedOverlayModeWorkspace(t)
 	ctx := overlayActorCtx(overlayWS, actorID)
-	mirror := overlaymod.NewMirrorStore(e.Pool, stubOwnerEmails{})
+	mirror := overlaymod.NewMirrorStore(e.DB(), stubOwnerEmails{})
 	if err := mirror.UpsertUserMap(ctx, ids.From[ids.UserKind](actorID), "hubspot", "owner-1", "manual"); err != nil {
 		t.Fatalf("mapping the acting user to owner-1: %v", err)
 	}
@@ -312,7 +313,7 @@ func TestAcceptance_AC_OV_8_IncumbentWinsConflict(t *testing.T) {
 	e := integration.Setup(t)
 	ws, actorID := seedOverlayModeWorkspace(t)
 	ctx := overlayActorCtx(ws, actorID)
-	mirror := overlaymod.NewMirrorStore(e.Pool, stubOwnerEmails{})
+	mirror := overlaymod.NewMirrorStore(e.DB(), stubOwnerEmails{})
 	if err := mirror.UpsertUserMap(ctx, ids.From[ids.UserKind](actorID), "hubspot", "owner-1", "manual"); err != nil {
 		t.Fatalf("mapping the acting user to owner-1: %v", err)
 	}
@@ -429,7 +430,7 @@ func TestAcceptance_AC_OV_11_FailClosedVisibility_ReadSubset(t *testing.T) {
 	e := integration.Setup(t)
 	ws, actorID := seedOverlayModeWorkspace(t)
 	ctx := overlayActorCtx(ws, actorID)
-	mirror := overlaymod.NewMirrorStore(e.Pool, stubOwnerEmails{})
+	mirror := overlaymod.NewMirrorStore(e.DB(), stubOwnerEmails{})
 	if err := mirror.UpsertUserMap(ctx, ids.From[ids.UserKind](actorID), "hubspot", "owner-1", "manual"); err != nil {
 		t.Fatalf("mapping the acting user to owner-1: %v", err)
 	}
@@ -545,7 +546,7 @@ func TestAcceptance_OVA_AC_1_TeardownPurges(t *testing.T) {
 	}
 
 	pool := openAppPool(t)
-	mirror := overlaymod.NewMirrorStore(pool, stubOwnerEmails{})
+	mirror := overlaymod.NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](wsID)), stubOwnerEmails{})
 	adminCtx := overlayActorCtx(wsID, adminID)
 	if err := mirror.UpsertUserMap(adminCtx, ids.From[ids.UserKind](adminID), "hubspot", "owner-1", "manual"); err != nil {
 		t.Fatalf("mapping the admin to the fake incumbent owner: %v", err)

--- a/backend/internal/compose/integration/overlay/overlay_acceptance_integration_test.go
+++ b/backend/internal/compose/integration/overlay/overlay_acceptance_integration_test.go
@@ -70,7 +70,7 @@ func seedMirroredPersonFixture(t *testing.T, e *integration.Env) (context.Contex
 	t.Helper()
 	overlayWS, actorID := seedOverlayModeWorkspace(t)
 	ctx := overlayActorCtx(overlayWS, actorID)
-	mirror := overlaymod.NewMirrorStore(e.DB(), stubOwnerEmails{})
+	mirror := overlaymod.NewMirrorStore(e.DBFor(overlayWS), stubOwnerEmails{})
 	if err := mirror.UpsertUserMap(ctx, ids.From[ids.UserKind](actorID), "hubspot", "owner-1", "manual"); err != nil {
 		t.Fatalf("mapping the acting user to owner-1: %v", err)
 	}
@@ -313,7 +313,7 @@ func TestAcceptance_AC_OV_8_IncumbentWinsConflict(t *testing.T) {
 	e := integration.Setup(t)
 	ws, actorID := seedOverlayModeWorkspace(t)
 	ctx := overlayActorCtx(ws, actorID)
-	mirror := overlaymod.NewMirrorStore(e.DB(), stubOwnerEmails{})
+	mirror := overlaymod.NewMirrorStore(e.DBFor(ws), stubOwnerEmails{})
 	if err := mirror.UpsertUserMap(ctx, ids.From[ids.UserKind](actorID), "hubspot", "owner-1", "manual"); err != nil {
 		t.Fatalf("mapping the acting user to owner-1: %v", err)
 	}
@@ -430,7 +430,7 @@ func TestAcceptance_AC_OV_11_FailClosedVisibility_ReadSubset(t *testing.T) {
 	e := integration.Setup(t)
 	ws, actorID := seedOverlayModeWorkspace(t)
 	ctx := overlayActorCtx(ws, actorID)
-	mirror := overlaymod.NewMirrorStore(e.DB(), stubOwnerEmails{})
+	mirror := overlaymod.NewMirrorStore(e.DBFor(ws), stubOwnerEmails{})
 	if err := mirror.UpsertUserMap(ctx, ids.From[ids.UserKind](actorID), "hubspot", "owner-1", "manual"); err != nil {
 		t.Fatalf("mapping the acting user to owner-1: %v", err)
 	}

--- a/backend/internal/compose/integration/overlay/overlay_dispatch_integration_test.go
+++ b/backend/internal/compose/integration/overlay/overlay_dispatch_integration_test.go
@@ -39,7 +39,7 @@ func TestDispatcherRoutesNativeWorkspaceReadsToTheNativeProvider(t *testing.T) {
 	e := integration.Setup(t)
 	personID := e.SeedPerson(t, "Ada Native", nil)
 
-	d := compose.NewDispatcher(compose.NewProvider(e.Pool), compose.NewOverlayProvider(e.Pool, overlaybudget.New(nil, nil), nil), e.Pool)
+	d := compose.NewDispatcher(compose.NewProvider(e.Pool), compose.NewOverlayProviderFor(e.DB(), overlaybudget.New(nil, nil), nil), e.Pool)
 
 	rec, err := d.Read(e.Admin(), datasource.EntityRef{Type: datasource.EntityPerson, ID: personID})
 	if err != nil {
@@ -75,7 +75,7 @@ func TestDispatcherRoutesOverlayWorkspaceReadsToTheOverlayProvider(t *testing.T)
 		t.Fatalf("ingesting the overlay fixture record: %v", err)
 	}
 
-	d := compose.NewDispatcher(compose.NewProvider(e.Pool), compose.NewOverlayProvider(e.Pool, overlaybudget.New(nil, nil), nil), e.Pool)
+	d := compose.NewDispatcher(compose.NewProvider(e.Pool), compose.NewOverlayProviderFor(e.DBFor(overlayWS), overlaybudget.New(nil, nil), nil), e.Pool)
 
 	searchRes, err := d.Search(ctx, datasource.SearchQuery{
 		EntityTypes: []datasource.EntityType{datasource.EntityPerson},

--- a/backend/internal/compose/integration/overlay/overlay_dispatch_integration_test.go
+++ b/backend/internal/compose/integration/overlay/overlay_dispatch_integration_test.go
@@ -61,7 +61,7 @@ func TestDispatcherRoutesOverlayWorkspaceReadsToTheOverlayProvider(t *testing.T)
 	overlayWS, actorID := seedOverlayModeWorkspace(t)
 	ctx := overlayActorCtx(overlayWS, actorID)
 
-	mirror := overlaymod.NewMirrorStore(e.Pool, stubOwnerEmails{})
+	mirror := overlaymod.NewMirrorStore(e.DB(), stubOwnerEmails{})
 	if err := mirror.UpsertUserMap(ctx, ids.From[ids.UserKind](actorID), "hubspot", "owner-1", "manual"); err != nil {
 		t.Fatalf("mapping the acting user to owner-1: %v", err)
 	}

--- a/backend/internal/compose/integration/overlay/overlay_dispatch_integration_test.go
+++ b/backend/internal/compose/integration/overlay/overlay_dispatch_integration_test.go
@@ -61,7 +61,7 @@ func TestDispatcherRoutesOverlayWorkspaceReadsToTheOverlayProvider(t *testing.T)
 	overlayWS, actorID := seedOverlayModeWorkspace(t)
 	ctx := overlayActorCtx(overlayWS, actorID)
 
-	mirror := overlaymod.NewMirrorStore(e.DB(), stubOwnerEmails{})
+	mirror := overlaymod.NewMirrorStore(e.DBFor(overlayWS), stubOwnerEmails{})
 	if err := mirror.UpsertUserMap(ctx, ids.From[ids.UserKind](actorID), "hubspot", "owner-1", "manual"); err != nil {
 		t.Fatalf("mapping the acting user to owner-1: %v", err)
 	}

--- a/backend/internal/compose/integration/overlay/overlay_e2e_integration_test.go
+++ b/backend/internal/compose/integration/overlay/overlay_e2e_integration_test.go
@@ -196,7 +196,7 @@ func connectOverlayToTheFakeIncumbent(t *testing.T, e *apptest.AppEnv) (adminID,
 // admin's, the actor every mirror-backed read below runs as.
 func backfillOneMirroredContact(t *testing.T, pool *pgxpool.Pool, wsID, adminID ids.UUID) context.Context {
 	t.Helper()
-	mirror := overlaymod.NewMirrorStore(pool, stubOwnerEmails{})
+	mirror := overlaymod.NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](wsID)), stubOwnerEmails{})
 	adminCtx := overlayActorCtx(wsID, adminID)
 	if err := mirror.UpsertUserMap(adminCtx, ids.From[ids.UserKind](adminID), "hubspot", "owner-1", "manual"); err != nil {
 		t.Fatalf("mapping the admin to the fake incumbent owner: %v", err)

--- a/backend/internal/compose/integration/overlay/overlay_flip_integration_test.go
+++ b/backend/internal/compose/integration/overlay/overlay_flip_integration_test.go
@@ -172,7 +172,7 @@ func setupFlipEstate(t *testing.T) flipEstate {
 	}
 
 	pool := openAppPool(t)
-	mirror := overlaymod.NewMirrorStore(pool, stubOwnerEmails{})
+	mirror := overlaymod.NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](wsID)), stubOwnerEmails{})
 	adminCtx := flipAdminCtx(wsID, adminID)
 
 	if err := mirror.UpsertUserMap(adminCtx, ids.From[ids.UserKind](adminID), "hubspot", "owner-1", "manual"); err != nil {

--- a/backend/internal/compose/integration/overlay/overlay_search_sweep_integration_test.go
+++ b/backend/internal/compose/integration/overlay/overlay_search_sweep_integration_test.go
@@ -108,7 +108,7 @@ func TestTheSearchRecordsToolSweepsWithoutARecordTypeInOverlayMode(t *testing.T)
 	ws, actorID := seedOverlayModeWorkspace(t)
 	ctx := overlayActorCtxWith(ws, actorID, nativeToolReaderPerms())
 
-	mirror := overlaymod.NewMirrorStore(e.Pool, stubOwnerEmails{})
+	mirror := overlaymod.NewMirrorStore(e.DB(), stubOwnerEmails{})
 	if err := mirror.UpsertUserMap(ctx, ids.From[ids.UserKind](actorID), "hubspot", "owner-1", "manual"); err != nil {
 		t.Fatalf("mapping the acting user to the incumbent owner: %v", err)
 	}

--- a/backend/internal/compose/integration/overlay/overlay_search_sweep_integration_test.go
+++ b/backend/internal/compose/integration/overlay/overlay_search_sweep_integration_test.go
@@ -108,7 +108,7 @@ func TestTheSearchRecordsToolSweepsWithoutARecordTypeInOverlayMode(t *testing.T)
 	ws, actorID := seedOverlayModeWorkspace(t)
 	ctx := overlayActorCtxWith(ws, actorID, nativeToolReaderPerms())
 
-	mirror := overlaymod.NewMirrorStore(e.DB(), stubOwnerEmails{})
+	mirror := overlaymod.NewMirrorStore(e.DBFor(ws), stubOwnerEmails{})
 	if err := mirror.UpsertUserMap(ctx, ids.From[ids.UserKind](actorID), "hubspot", "owner-1", "manual"); err != nil {
 		t.Fatalf("mapping the acting user to the incumbent owner: %v", err)
 	}

--- a/backend/internal/compose/integration/overlay/overlay_search_sweep_integration_test.go
+++ b/backend/internal/compose/integration/overlay/overlay_search_sweep_integration_test.go
@@ -119,7 +119,7 @@ func TestTheSearchRecordsToolSweepsWithoutARecordTypeInOverlayMode(t *testing.T)
 		t.Fatalf("seeding the mirrored person: %v", err)
 	}
 
-	out, err := compose.NewRegistry(e.Pool, compose.SendPath{}).
+	out, err := compose.NewRegistryFor(e.DBFor(ws), compose.SendPath{}).
 		Invoke(ctx, "search_records", json.RawMessage(`{"q":"Unrestricted"}`))
 	if err != nil {
 		t.Fatalf("search_records with no record_type in overlay mode: %v — the schema says omitting it sweeps "+

--- a/backend/internal/compose/integration/overlay/overlay_toolsurface_integration_test.go
+++ b/backend/internal/compose/integration/overlay/overlay_toolsurface_integration_test.go
@@ -157,7 +157,7 @@ func nativeToolReaderPerms() principal.Permissions {
 func TestOverlayAgentToolsRefuseRatherThanAnswerFromNativeTables(t *testing.T) {
 	e := integration.Setup(t)
 	ws, user := seedOverlayModeWorkspace(t)
-	registry := compose.NewRegistry(e.Pool, compose.SendPath{})
+	registry := compose.NewRegistryFor(e.DBFor(ws), compose.SendPath{})
 	// Every object grant a guarded read could need, so an unwired guard fails
 	// with the native-table answer this suite exists to forbid rather than with
 	// "permission denied" — which would pass the assertion for a reason that has
@@ -208,7 +208,7 @@ func TestOverlayUpdateRecordRefusesAnAgentRatherThanWritingBack(t *testing.T) {
 
 	// The tool addresses the record by the id its own reads hand out, so
 	// resolve it the way an agent would rather than minting one.
-	d := compose.NewDispatcher(compose.NewProvider(e.Pool), compose.NewOverlayProvider(e.Pool, overlaybudget.New(nil, nil), nil), e.Pool)
+	d := compose.NewDispatcher(compose.NewProvider(e.Pool), compose.NewOverlayProviderFor(e.DBFor(overlayWS), overlaybudget.New(nil, nil), nil), e.Pool)
 	found, err := d.Search(ctx, datasource.SearchQuery{
 		EntityTypes: []datasource.EntityType{datasource.EntityPerson},
 		Limit:       10,
@@ -218,7 +218,7 @@ func TestOverlayUpdateRecordRefusesAnAgentRatherThanWritingBack(t *testing.T) {
 	}
 	target := found.Records[0].Ref.ID
 
-	registry := compose.NewRegistry(e.Pool, compose.SendPath{})
+	registry := compose.NewRegistryFor(e.DBFor(overlayWS), compose.SendPath{})
 	args := fmt.Sprintf(`{"record_type":"person","id":%q,"fields":{"title":"Principal Analyst"}}`, target)
 
 	_, err = registry.Invoke(agentActorCtx(overlayWS, actorID), "update_record", json.RawMessage(args))
@@ -274,7 +274,7 @@ func TestOverlayWritesRefuseAnUnreleasedAgentAtTheSeam(t *testing.T) {
 		t.Fatalf("ingesting the overlay fixture record: %v", err)
 	}
 
-	d := compose.NewDispatcher(compose.NewProvider(e.Pool), compose.NewOverlayProvider(e.Pool, overlaybudget.New(nil, nil), nil), e.Pool)
+	d := compose.NewDispatcher(compose.NewProvider(e.Pool), compose.NewOverlayProviderFor(e.DBFor(ws), overlaybudget.New(nil, nil), nil), e.Pool)
 	found, err := d.Search(ctx, datasource.SearchQuery{
 		EntityTypes: []datasource.EntityType{datasource.EntityPerson}, Limit: 10,
 	})
@@ -332,7 +332,7 @@ func TestOverlayUpdateRecordEgressGateIgnoresAStaleNativeModeCache(t *testing.T)
 	e := integration.Setup(t)
 	ws, actorID := seedNativeModeWorkspaceForFlip(t)
 	ctx := overlayActorCtx(ws, actorID)
-	registry := compose.NewRegistry(e.Pool, compose.SendPath{})
+	registry := compose.NewRegistryFor(e.DBFor(ws), compose.SendPath{})
 
 	// Warm this process's mode cache while the workspace is still native, by
 	// making the same read an ordinary request would.
@@ -362,7 +362,7 @@ func TestOverlayUpdateRecordEgressGateIgnoresAStaleNativeModeCache(t *testing.T)
 		t.Fatalf("ingesting the overlay fixture record: %v", err)
 	}
 
-	d := compose.NewDispatcher(compose.NewProvider(e.Pool), compose.NewOverlayProvider(e.Pool, overlaybudget.New(nil, nil), nil), e.Pool)
+	d := compose.NewDispatcher(compose.NewProvider(e.Pool), compose.NewOverlayProviderFor(e.DBFor(ws), overlaybudget.New(nil, nil), nil), e.Pool)
 	found, err := d.Search(ctx, datasource.SearchQuery{
 		EntityTypes: []datasource.EntityType{datasource.EntityPerson},
 		Limit:       10,
@@ -419,7 +419,7 @@ func mergedFixtures(sets ...map[string]string) map[string]string {
 
 func TestNativeAgentToolsAreNotRefusedByTheSoRModeGuard(t *testing.T) {
 	e := integration.Setup(t)
-	registry := compose.NewRegistry(e.Pool, compose.SendPath{})
+	registry := compose.NewRegistryFor(e.DB(), compose.SendPath{})
 	ctx := e.As(e.Rep1, nil, nativeToolReaderPerms())
 
 	// The tools whose NOT-FOUND is itself a served answer — the answer only a
@@ -472,7 +472,7 @@ func TestNativeAgentToolsAreNotRefusedByTheSoRModeGuard(t *testing.T) {
 func TestOverlayListRecordsRefusesAFilterAndServesAnEnumeration(t *testing.T) {
 	e := integration.Setup(t)
 	ws, user := seedOverlayModeWorkspace(t)
-	registry := compose.NewRegistry(e.Pool, compose.SendPath{})
+	registry := compose.NewRegistryFor(e.DBFor(ws), compose.SendPath{})
 	ctx := overlayActorCtxWith(ws, user, nativeToolReaderPerms())
 
 	_, err := registry.Invoke(ctx, "list_records",

--- a/backend/internal/compose/integration/overlay/overlay_toolsurface_integration_test.go
+++ b/backend/internal/compose/integration/overlay/overlay_toolsurface_integration_test.go
@@ -192,7 +192,7 @@ func TestOverlayUpdateRecordRefusesAnAgentRatherThanWritingBack(t *testing.T) {
 	overlayWS, actorID := seedOverlayModeWorkspace(t)
 	ctx := overlayActorCtx(overlayWS, actorID)
 
-	mirror := overlaymod.NewMirrorStore(e.DB(), stubOwnerEmails{})
+	mirror := overlaymod.NewMirrorStore(e.DBFor(overlayWS), stubOwnerEmails{})
 	if err := mirror.UpsertUserMap(ctx, ids.From[ids.UserKind](actorID), "hubspot", "owner-1", "manual"); err != nil {
 		t.Fatalf("mapping the acting user to owner-1: %v", err)
 	}
@@ -262,7 +262,7 @@ func TestOverlayWritesRefuseAnUnreleasedAgentAtTheSeam(t *testing.T) {
 	ws, actorID := seedOverlayModeWorkspace(t)
 	ctx := overlayActorCtx(ws, actorID)
 
-	mirror := overlaymod.NewMirrorStore(e.DB(), stubOwnerEmails{})
+	mirror := overlaymod.NewMirrorStore(e.DBFor(ws), stubOwnerEmails{})
 	if err := mirror.UpsertUserMap(ctx, ids.From[ids.UserKind](actorID), "hubspot", "owner-1", "manual"); err != nil {
 		t.Fatalf("mapping the acting user to owner-1: %v", err)
 	}
@@ -484,7 +484,7 @@ func TestOverlayListRecordsRefusesAFilterAndServesAnEnumeration(t *testing.T) {
 
 	// The served arm needs a row to serve: the mirror's visibility join is
 	// fail-closed, so an unmapped rep reads as not-found rather than as empty.
-	mirror := overlaymod.NewMirrorStore(e.DB(), stubOwnerEmails{})
+	mirror := overlaymod.NewMirrorStore(e.DBFor(ws), stubOwnerEmails{})
 	if err := mirror.UpsertUserMap(ctx, ids.From[ids.UserKind](user), "hubspot", "owner-1", "manual"); err != nil {
 		t.Fatalf("mapping the acting user to owner-1: %v", err)
 	}

--- a/backend/internal/compose/integration/overlay/overlay_toolsurface_integration_test.go
+++ b/backend/internal/compose/integration/overlay/overlay_toolsurface_integration_test.go
@@ -348,7 +348,7 @@ func TestOverlayUpdateRecordEgressGateIgnoresAStaleNativeModeCache(t *testing.T)
 		t.Fatalf("flipping the workspace to overlay mode: %v", err)
 	}
 
-	mirror := overlaymod.NewMirrorStore(e.DB(), stubOwnerEmails{})
+	mirror := overlaymod.NewMirrorStore(e.DBFor(ws), stubOwnerEmails{})
 	if err := mirror.UpsertUserMap(ctx, ids.From[ids.UserKind](actorID), "hubspot", "owner-1", "manual"); err != nil {
 		t.Fatalf("mapping the acting user to owner-1: %v", err)
 	}

--- a/backend/internal/compose/integration/overlay/overlay_toolsurface_integration_test.go
+++ b/backend/internal/compose/integration/overlay/overlay_toolsurface_integration_test.go
@@ -192,7 +192,7 @@ func TestOverlayUpdateRecordRefusesAnAgentRatherThanWritingBack(t *testing.T) {
 	overlayWS, actorID := seedOverlayModeWorkspace(t)
 	ctx := overlayActorCtx(overlayWS, actorID)
 
-	mirror := overlaymod.NewMirrorStore(e.Pool, stubOwnerEmails{})
+	mirror := overlaymod.NewMirrorStore(e.DB(), stubOwnerEmails{})
 	if err := mirror.UpsertUserMap(ctx, ids.From[ids.UserKind](actorID), "hubspot", "owner-1", "manual"); err != nil {
 		t.Fatalf("mapping the acting user to owner-1: %v", err)
 	}
@@ -262,7 +262,7 @@ func TestOverlayWritesRefuseAnUnreleasedAgentAtTheSeam(t *testing.T) {
 	ws, actorID := seedOverlayModeWorkspace(t)
 	ctx := overlayActorCtx(ws, actorID)
 
-	mirror := overlaymod.NewMirrorStore(e.Pool, stubOwnerEmails{})
+	mirror := overlaymod.NewMirrorStore(e.DB(), stubOwnerEmails{})
 	if err := mirror.UpsertUserMap(ctx, ids.From[ids.UserKind](actorID), "hubspot", "owner-1", "manual"); err != nil {
 		t.Fatalf("mapping the acting user to owner-1: %v", err)
 	}
@@ -348,7 +348,7 @@ func TestOverlayUpdateRecordEgressGateIgnoresAStaleNativeModeCache(t *testing.T)
 		t.Fatalf("flipping the workspace to overlay mode: %v", err)
 	}
 
-	mirror := overlaymod.NewMirrorStore(e.Pool, stubOwnerEmails{})
+	mirror := overlaymod.NewMirrorStore(e.DB(), stubOwnerEmails{})
 	if err := mirror.UpsertUserMap(ctx, ids.From[ids.UserKind](actorID), "hubspot", "owner-1", "manual"); err != nil {
 		t.Fatalf("mapping the acting user to owner-1: %v", err)
 	}
@@ -484,7 +484,7 @@ func TestOverlayListRecordsRefusesAFilterAndServesAnEnumeration(t *testing.T) {
 
 	// The served arm needs a row to serve: the mirror's visibility join is
 	// fail-closed, so an unmapped rep reads as not-found rather than as empty.
-	mirror := overlaymod.NewMirrorStore(e.Pool, stubOwnerEmails{})
+	mirror := overlaymod.NewMirrorStore(e.DB(), stubOwnerEmails{})
 	if err := mirror.UpsertUserMap(ctx, ids.From[ids.UserKind](user), "hubspot", "owner-1", "manual"); err != nil {
 		t.Fatalf("mapping the acting user to owner-1: %v", err)
 	}

--- a/backend/internal/compose/integration/overlay/overlay_usermap_http_integration_test.go
+++ b/backend/internal/compose/integration/overlay/overlay_usermap_http_integration_test.go
@@ -141,8 +141,8 @@ func TestAnUnmappedAdminMapsThemselvesAndTheRecordsAppear(t *testing.T) {
 	fakeInc := fake.New()
 	fakeInc.SeedOwner(recordOwner, unmatchedOwnerEmail)
 
-	store := overlaymod.NewMirrorStore(e.DB(), fakeInc)
-	svc := overlaymod.NewService(e.DB(), keyvault.NewMemory(), store).
+	store := overlaymod.NewMirrorStore(e.DBFor(ws), fakeInc)
+	svc := overlaymod.NewService(e.DBFor(ws), keyvault.NewMemory(), store).
 		WithIncumbentFactory(func(string, string) overlaymod.Incumbent { return fakeInc })
 
 	// The connection is what makes the owners directory readable, and the

--- a/backend/internal/compose/integration/overlay/overlay_usermap_http_integration_test.go
+++ b/backend/internal/compose/integration/overlay/overlay_usermap_http_integration_test.go
@@ -141,8 +141,8 @@ func TestAnUnmappedAdminMapsThemselvesAndTheRecordsAppear(t *testing.T) {
 	fakeInc := fake.New()
 	fakeInc.SeedOwner(recordOwner, unmatchedOwnerEmail)
 
-	store := overlaymod.NewMirrorStore(e.Pool, fakeInc)
-	svc := overlaymod.NewService(e.Pool, keyvault.NewMemory(), store).
+	store := overlaymod.NewMirrorStore(e.DB(), fakeInc)
+	svc := overlaymod.NewService(e.DB(), keyvault.NewMemory(), store).
 		WithIncumbentFactory(func(string, string) overlaymod.Incumbent { return fakeInc })
 
 	// The connection is what makes the owners directory readable, and the

--- a/backend/internal/compose/integration/overlay/overlay_write_shadow_integration_test.go
+++ b/backend/internal/compose/integration/overlay/overlay_write_shadow_integration_test.go
@@ -90,7 +90,7 @@ func setupOverlayWrite(t *testing.T) overlayWriteEnv {
 		t.Fatalf("parsing workspace id: %v", err)
 	}
 
-	mirror := overlaymod.NewMirrorStore(e.Pool, stubOwnerEmails{})
+	mirror := overlaymod.NewMirrorStore(e.DB(), stubOwnerEmails{})
 	actorCtx := overlayActorCtx(wsID, adminID)
 	if err := mirror.UpsertUserMap(actorCtx, ids.From[ids.UserKind](adminID), "hubspot", "owner-1", "manual"); err != nil {
 		t.Fatalf("mapping the admin to the fake incumbent owner: %v", err)

--- a/backend/internal/compose/jobs_overlay.go
+++ b/backend/internal/compose/jobs_overlay.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/gradionhq/margince/backend/internal/modules/overlay"
 	"github.com/gradionhq/margince/backend/internal/modules/overlay/hubspot"
+	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/jobs"
 	"github.com/gradionhq/margince/backend/internal/platform/keyvault"
 	"github.com/gradionhq/margince/backend/internal/platform/overlaybudget"
@@ -37,7 +38,6 @@ func addOverlayJobs(reg *jobRegistry, pool *pgxpool.Pool, cfg JobRunnerConfig, l
 	if cfg.OverlayVault == nil {
 		return
 	}
-	ms := overlay.NewMirrorStore(pool, unresolvedOwnerEmails{})
 	// cmd/worker built the meter over the shared Redis (so the poller's spend
 	// and the api's force-fresh spend land on ONE count); fall back to a
 	// fail-closed meter if a role wired the poller without one.
@@ -47,7 +47,7 @@ func addOverlayJobs(reg *jobRegistry, pool *pgxpool.Pool, cfg JobRunnerConfig, l
 	}
 	addDeclaredWorker[OverlayReconcileArgs](reg, &overlayReconcileWorker{pool: pool, log: log})
 	addDeclaredWorker[OverlayReconcileWorkspaceArgs](reg, &overlayReconcileWorkspaceWorker{
-		pool: pool, vault: cfg.OverlayVault, ms: ms, meter: meter, log: log,
+		pool: pool, vault: cfg.OverlayVault, meter: meter, log: log,
 		newIncumbent: overlayIncumbentFactory(cfg.OverlayBackfillLimit),
 	})
 	// The webhook-as-signal re-fetch worker (OVA-WIRE-10): consumes the
@@ -56,7 +56,7 @@ func addOverlayJobs(reg *jobRegistry, pool *pgxpool.Pool, cfg JobRunnerConfig, l
 	// vault is present (the receiver only enqueues when the api role has the
 	// app secret wired).
 	addDeclaredWorker[OverlayRefetchArgs](reg, &overlayRefetchWorker{
-		pool: pool, vault: cfg.OverlayVault, ms: ms, meter: meter, log: log,
+		pool: pool, vault: cfg.OverlayVault, meter: meter, log: log,
 		newIncumbent: overlayIncumbentFactory(cfg.OverlayBackfillLimit),
 	})
 }
@@ -156,7 +156,6 @@ func (a OverlayReconcileWorkspaceArgs) WorkspaceID() ids.UUID { return a.Workspa
 type overlayReconcileWorkspaceWorker struct {
 	pool         *pgxpool.Pool
 	vault        keyvault.Vault
-	ms           *overlay.MirrorStore
 	meter        *overlaybudget.Meter
 	newIncumbent func(region, token string) overlay.Incumbent
 	log          *slog.Logger
@@ -187,8 +186,12 @@ func (w *overlayReconcileWorkspaceWorker) Work(ctx context.Context, job *river.J
 	// abort with ErrConnectionGone instead. A rate-limit/auth failure leaves
 	// the connection row 'active' (only Disconnect revokes it), so the
 	// legitimate backoff paths still record.
-	recMS := w.ms.WithFenceIdentity(d.ConnectedAt)
-	sweepErr := reconcileConnection(wsCtx, w.pool, w.vault, w.ms, w.meter, w.log, d, w.newIncumbent)
+	// Built for the workspace THIS pass reconciles: the mirror store writes
+	// tenant rows, and a fleet pass cannot share one across the workspaces it
+	// sweeps (ADR-0091 §9 step 3).
+	ms := overlay.NewMirrorStore(database.BindTo(w.pool, d.Workspace), unresolvedOwnerEmails{})
+	recMS := ms.WithFenceIdentity(d.ConnectedAt)
+	sweepErr := reconcileConnection(wsCtx, w.pool, w.vault, ms, w.meter, w.log, d, w.newIncumbent)
 	if errors.Is(sweepErr, overlay.ErrConnectionGone) {
 		// The connection was disconnected, or disconnected AND reconnected,
 		// mid-sweep: every fenced write aborted, so nothing was resurrected
@@ -293,7 +296,7 @@ func reconcileConnection(ctx context.Context, pool *pgxpool.Pool, vault keyvault
 	// growth and does not retain a value_canonical past the window. Best-effort
 	// — correctness never depends on it (Classify already filters by the open
 	// window), so a failure never aborts the record sweep.
-	if _, err := overlay.NewWriteLedger(pool).PruneExpired(ctx); err != nil {
+	if _, err := overlay.NewWriteLedger(database.BindTo(pool, d.Workspace)).PruneExpired(ctx); err != nil {
 		log.WarnContext(ctx, "overlay reconcile: pruning expired write-ledger entries failed",
 			"workspace", d.Workspace.String(), "err", err)
 	}

--- a/backend/internal/compose/jobs_overlay_disconnectfence_integration_test.go
+++ b/backend/internal/compose/jobs_overlay_disconnectfence_integration_test.go
@@ -43,9 +43,9 @@ import (
 func TestReconcileConnectionStopsCleanlyWhenDisconnectedMidSweep(t *testing.T) {
 	e := integration.Setup(t)
 	vault := keyvault.NewMemory()
-	ms := overlay.NewMirrorStore(e.Pool, unresolvedOwnerEmails{})
+	ms := overlay.NewMirrorStore(e.DB(), unresolvedOwnerEmails{})
 
-	if _, err := overlay.NewService(e.Pool, vault, ms).
+	if _, err := overlay.NewService(e.DB(), vault, ms).
 		Connect(overlayAdminCtx(e.WS, e.Rep1), overlay.ConnectInput{Incumbent: "hubspot", Region: "eu1", Token: "tok"}); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
@@ -124,9 +124,9 @@ func TestReconcileConnectionStopsCleanlyWhenDisconnectedMidSweep(t *testing.T) {
 func TestReconcileConnectionStopsCleanlyWhenReconnectedMidSweep(t *testing.T) {
 	e := integration.Setup(t)
 	vault := keyvault.NewMemory()
-	ms := overlay.NewMirrorStore(e.Pool, unresolvedOwnerEmails{})
+	ms := overlay.NewMirrorStore(e.DB(), unresolvedOwnerEmails{})
 
-	if _, err := overlay.NewService(e.Pool, vault, ms).
+	if _, err := overlay.NewService(e.DB(), vault, ms).
 		Connect(overlayAdminCtx(e.WS, e.Rep1), overlay.ConnectInput{Incumbent: "hubspot", Region: "eu1", Token: "tok"}); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
@@ -239,8 +239,8 @@ func (r *revokeOnOwnersIncumbent) Owners(ctx context.Context) ([]overlay.OwnerRe
 func TestWorkerCleanStopsOnMidSweepDisconnect(t *testing.T) {
 	e := integration.Setup(t)
 	vault := keyvault.NewMemory()
-	ms := overlay.NewMirrorStore(e.Pool, unresolvedOwnerEmails{})
-	if _, err := overlay.NewService(e.Pool, vault, ms).
+	ms := overlay.NewMirrorStore(e.DB(), unresolvedOwnerEmails{})
+	if _, err := overlay.NewService(e.DB(), vault, ms).
 		Connect(overlayAdminCtx(e.WS, e.Rep1), overlay.ConnectInput{Incumbent: "hubspot", Region: "eu1", Token: "tok"}); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
@@ -248,9 +248,8 @@ func TestWorkerCleanStopsOnMidSweepDisconnect(t *testing.T) {
 	fakeInc.SeedOwner("owner-1", "a@authz.test") // matches Rep1, so SeedUserMap reaches a fenced UpsertUserMap
 
 	w := &overlayReconcileWorkspaceWorker{
-		pool: e.Pool, vault: vault, ms: ms,
-		meter: workerBudgetMeter(t),
-		log:   slog.New(slog.DiscardHandler),
+		pool: e.Pool, vault: vault, meter: workerBudgetMeter(t),
+		log: slog.New(slog.DiscardHandler),
 		newIncumbent: func(_, _ string) overlay.Incumbent {
 			return &revokeOnOwnersIncumbent{Incumbent: fakeInc, pool: e.Pool}
 		},
@@ -304,8 +303,8 @@ func TestWorkerCleanStopsOnMidSweepDisconnect(t *testing.T) {
 func TestOnDemandReconcileRacingDisconnectAnswersModeNotOverlay(t *testing.T) {
 	e := integration.Setup(t)
 	vault := keyvault.NewMemory()
-	ms := overlay.NewMirrorStore(e.Pool, unresolvedOwnerEmails{})
-	svc := overlay.NewService(e.Pool, vault, ms)
+	ms := overlay.NewMirrorStore(e.DB(), unresolvedOwnerEmails{})
+	svc := overlay.NewService(e.DB(), vault, ms)
 	adminCtx := overlayAdminCtx(e.WS, e.Rep1)
 
 	if _, err := svc.Connect(adminCtx, overlay.ConnectInput{Incumbent: "hubspot", Region: "eu1", Token: "tok"}); err != nil {

--- a/backend/internal/compose/jobs_overlay_refetch.go
+++ b/backend/internal/compose/jobs_overlay_refetch.go
@@ -19,6 +19,7 @@ import (
 	"github.com/riverqueue/river"
 
 	"github.com/gradionhq/margince/backend/internal/modules/overlay"
+	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/jobs"
 	"github.com/gradionhq/margince/backend/internal/platform/keyvault"
 	"github.com/gradionhq/margince/backend/internal/platform/overlaybudget"
@@ -113,7 +114,7 @@ func (w *overlayRefetchWorker) resolveRefetchTarget(ctx context.Context, job *ri
 	if conn.Incumbent != incumbentHubSpot {
 		return nil, overlay.DueOverlayConnection{}, false, nil
 	}
-	if halted, err := overlay.NewWriteLedger(w.pool).Halted(wsCtx); err != nil {
+	if halted, err := overlay.NewWriteLedger(database.BindTo(w.pool, ids.From[ids.WorkspaceKind](job.Args.Workspace))).Halted(wsCtx); err != nil {
 		return nil, overlay.DueOverlayConnection{}, false, fmt.Errorf("overlay refetch: reading the mirror-halt flag: %w", err)
 	} else if halted {
 		w.log.WarnContext(wsCtx, "overlay refetch: mirror is halted (ledger collision), skipping",

--- a/backend/internal/compose/jobs_overlay_refetch_failures_integration_test.go
+++ b/backend/internal/compose/jobs_overlay_refetch_failures_integration_test.go
@@ -49,9 +49,9 @@ func newRefetchFixture(t *testing.T) refetchFixture {
 	t.Helper()
 	e := integration.Setup(t)
 	vault := keyvault.NewMemory()
-	ms := overlay.NewMirrorStore(e.Pool, unresolvedOwnerEmails{})
+	ms := overlay.NewMirrorStore(e.DB(), unresolvedOwnerEmails{})
 	adminCtx := overlayAdminCtx(e.WS, e.Rep1)
-	if _, err := overlay.NewService(e.Pool, vault, ms).
+	if _, err := overlay.NewService(e.DB(), vault, ms).
 		Connect(adminCtx, overlay.ConnectInput{Incumbent: "hubspot", Region: "eu1", Token: "tok"}); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
@@ -119,7 +119,7 @@ func seededPortal() *fake.Adapter {
 // report a failure River would retry.
 func TestOverlayRefetchWorkerStopsCleanlyWhenTheWorkspaceDisconnected(t *testing.T) {
 	f := newRefetchFixture(t)
-	if err := overlay.NewService(f.e.Pool, f.vault, f.ms).
+	if err := overlay.NewService(f.e.DB(), f.vault, f.ms).
 		Disconnect(overlayAdminCtx(f.e.WS, f.e.Rep1)); err != nil {
 		t.Fatalf("Disconnect: %v", err)
 	}

--- a/backend/internal/compose/jobs_overlay_sweep_failures_integration_test.go
+++ b/backend/internal/compose/jobs_overlay_sweep_failures_integration_test.go
@@ -152,9 +152,9 @@ func TestReconcileConnectionPerPhaseFailurePolicy(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			e := integration.Setup(t)
 			vault := keyvault.NewMemory()
-			ms := overlay.NewMirrorStore(e.Pool, unresolvedOwnerEmails{})
+			ms := overlay.NewMirrorStore(e.DB(), unresolvedOwnerEmails{})
 			adminCtx := overlayAdminCtx(e.WS, e.Rep1)
-			if _, err := overlay.NewService(e.Pool, vault, ms).
+			if _, err := overlay.NewService(e.DB(), vault, ms).
 				Connect(adminCtx, overlay.ConnectInput{Incumbent: "hubspot", Region: "eu1", Token: "tok"}); err != nil {
 				t.Fatalf("Connect: %v", err)
 			}

--- a/backend/internal/compose/jobs_overlay_worker_integration_test.go
+++ b/backend/internal/compose/jobs_overlay_worker_integration_test.go
@@ -122,8 +122,8 @@ func TestResolveOverlayIncumbentBuildsALiveAdapterFromTheVault(t *testing.T) {
 	}
 
 	// Connect a HubSpot overlay; now resolve builds a live adapter.
-	ms := overlay.NewMirrorStore(e.Pool, unresolvedOwnerEmails{})
-	if _, err := overlay.NewService(e.Pool, vault, ms).
+	ms := overlay.NewMirrorStore(e.DB(), unresolvedOwnerEmails{})
+	if _, err := overlay.NewService(e.DB(), vault, ms).
 		Connect(adminCtx, overlay.ConnectInput{Incumbent: "hubspot", Region: "eu1", Token: "tok"}); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
@@ -155,15 +155,14 @@ func (authFailingIncumbent) Owners(context.Context) ([]overlay.OwnerRef, error) 
 func TestWorkerBacksOffAConnectionLevelFailure(t *testing.T) {
 	e := integration.Setup(t)
 	vault := keyvault.NewMemory()
-	ms := overlay.NewMirrorStore(e.Pool, unresolvedOwnerEmails{})
-	if _, err := overlay.NewService(e.Pool, vault, ms).
+	ms := overlay.NewMirrorStore(e.DB(), unresolvedOwnerEmails{})
+	if _, err := overlay.NewService(e.DB(), vault, ms).
 		Connect(overlayAdminCtx(e.WS, e.Rep1), overlay.ConnectInput{Incumbent: "hubspot", Region: "eu1", Token: "tok"}); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 
 	w := &overlayReconcileWorkspaceWorker{
-		pool: e.Pool, vault: vault, ms: ms,
-		meter:        workerBudgetMeter(t),
+		pool: e.Pool, vault: vault, meter: workerBudgetMeter(t),
 		log:          slog.New(slog.DiscardHandler),
 		newIncumbent: func(_, _ string) overlay.Incumbent { return authFailingIncumbent{Adapter: fake.New()} },
 	}
@@ -202,12 +201,12 @@ func TestWorkerBacksOffAConnectionLevelFailure(t *testing.T) {
 func TestReconcileConnectionBackfillsAndSeedsViaFakeIncumbent(t *testing.T) {
 	e := integration.Setup(t)
 	vault := keyvault.NewMemory()
-	ms := overlay.NewMirrorStore(e.Pool, unresolvedOwnerEmails{})
+	ms := overlay.NewMirrorStore(e.DB(), unresolvedOwnerEmails{})
 
 	// Connect an overlay for the workspace. No connect-time incumbent
 	// factory is wired on this Service, so NOTHING is seeded or backfilled
 	// until the sweep runs — exactly the behavior under test.
-	if _, err := overlay.NewService(e.Pool, vault, ms).
+	if _, err := overlay.NewService(e.DB(), vault, ms).
 		Connect(overlayAdminCtx(e.WS, e.Rep1), overlay.ConnectInput{Incumbent: "hubspot", Region: "eu1", Token: "tok"}); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
@@ -288,9 +287,9 @@ func countMirrorRows(ctx context.Context, t *testing.T, pool *pgxpool.Pool, obje
 func TestCappedBackfillIsNotUndoneByTheFirstModifiedSweep(t *testing.T) {
 	e := integration.Setup(t)
 	vault := keyvault.NewMemory()
-	ms := overlay.NewMirrorStore(e.Pool, unresolvedOwnerEmails{})
+	ms := overlay.NewMirrorStore(e.DB(), unresolvedOwnerEmails{})
 
-	if _, err := overlay.NewService(e.Pool, vault, ms).
+	if _, err := overlay.NewService(e.DB(), vault, ms).
 		Connect(overlayAdminCtx(e.WS, e.Rep1), overlay.ConnectInput{Incumbent: "hubspot", Region: "eu1", Token: "tok"}); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
@@ -344,7 +343,7 @@ func TestCappedBackfillIsNotUndoneByTheFirstModifiedSweep(t *testing.T) {
 	// — re-listing under the same cap would relearn nothing). Reporting
 	// complete here would be the same silent-truncation-as-success lie this
 	// whole fix exists to close, just for the cap instead of the watermark.
-	svc := overlay.NewService(e.Pool, vault, ms).WithIncumbentClassesTranslator(hubspot.IncumbentClassesFor)
+	svc := overlay.NewService(e.DB(), vault, ms).WithIncumbentClassesTranslator(hubspot.IncumbentClassesFor)
 	status, err := svc.SyncStatus(overlayAdminCtx(e.WS, e.Rep1))
 	if err != nil {
 		t.Fatalf("SyncStatus: %v", err)
@@ -375,9 +374,9 @@ func TestCappedBackfillIsNotUndoneByTheFirstModifiedSweep(t *testing.T) {
 func TestSweepStillIngestsRecordsEditedAfterTheConnect(t *testing.T) {
 	e := integration.Setup(t)
 	vault := keyvault.NewMemory()
-	ms := overlay.NewMirrorStore(e.Pool, unresolvedOwnerEmails{})
+	ms := overlay.NewMirrorStore(e.DB(), unresolvedOwnerEmails{})
 
-	if _, err := overlay.NewService(e.Pool, vault, ms).
+	if _, err := overlay.NewService(e.DB(), vault, ms).
 		Connect(overlayAdminCtx(e.WS, e.Rep1), overlay.ConnectInput{Incumbent: "hubspot", Region: "eu1", Token: "tok"}); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
@@ -433,9 +432,9 @@ func TestSweepStillIngestsRecordsEditedAfterTheConnect(t *testing.T) {
 func TestReconcileConnectionPurgesIncumbentDeletedRecord(t *testing.T) {
 	e := integration.Setup(t)
 	vault := keyvault.NewMemory()
-	ms := overlay.NewMirrorStore(e.Pool, unresolvedOwnerEmails{})
+	ms := overlay.NewMirrorStore(e.DB(), unresolvedOwnerEmails{})
 
-	if _, err := overlay.NewService(e.Pool, vault, ms).
+	if _, err := overlay.NewService(e.DB(), vault, ms).
 		Connect(overlayAdminCtx(e.WS, e.Rep1), overlay.ConnectInput{Incumbent: "hubspot", Region: "eu1", Token: "tok"}); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
@@ -496,11 +495,11 @@ func TestReconcileConnectionPurgesIncumbentDeletedRecord(t *testing.T) {
 func TestReconcileConnectionBackfillsTheWebhookPortalBinding(t *testing.T) {
 	e := integration.Setup(t)
 	vault := keyvault.NewMemory()
-	ms := overlay.NewMirrorStore(e.Pool, unresolvedOwnerEmails{})
+	ms := overlay.NewMirrorStore(e.DB(), unresolvedOwnerEmails{})
 
 	// Connect with NO incumbent factory: fetchPortalID is skipped, so the
 	// binding starts NULL — the exact state the backfill exists to heal.
-	if _, err := overlay.NewService(e.Pool, vault, ms).
+	if _, err := overlay.NewService(e.DB(), vault, ms).
 		Connect(overlayAdminCtx(e.WS, e.Rep1), overlay.ConnectInput{Incumbent: "hubspot", Region: "eu1", Token: "tok"}); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
@@ -553,10 +552,10 @@ func TestReconcileConnectionBackfillsTheWebhookPortalBinding(t *testing.T) {
 func TestOverlayRefetchWorkerFreshensTheMirrorRecord(t *testing.T) {
 	e := integration.Setup(t)
 	vault := keyvault.NewMemory()
-	ms := overlay.NewMirrorStore(e.Pool, unresolvedOwnerEmails{})
+	ms := overlay.NewMirrorStore(e.DB(), unresolvedOwnerEmails{})
 
 	adminCtx := overlayAdminCtx(e.WS, e.Rep1)
-	if _, err := overlay.NewService(e.Pool, vault, ms).
+	if _, err := overlay.NewService(e.DB(), vault, ms).
 		Connect(adminCtx, overlay.ConnectInput{Incumbent: "hubspot", Region: "eu1", Token: "tok"}); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
@@ -644,10 +643,10 @@ func TestOverlayRefetchWorkerFreshensTheMirrorRecord(t *testing.T) {
 func TestOverlayRefetchWorkerShedsWhenBudgetExhausted(t *testing.T) {
 	e := integration.Setup(t)
 	vault := keyvault.NewMemory()
-	ms := overlay.NewMirrorStore(e.Pool, unresolvedOwnerEmails{})
+	ms := overlay.NewMirrorStore(e.DB(), unresolvedOwnerEmails{})
 
 	adminCtx := overlayAdminCtx(e.WS, e.Rep1)
-	if _, err := overlay.NewService(e.Pool, vault, ms).
+	if _, err := overlay.NewService(e.DB(), vault, ms).
 		Connect(adminCtx, overlay.ConnectInput{Incumbent: "hubspot", Region: "eu1", Token: "tok"}); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}

--- a/backend/internal/compose/overlay.go
+++ b/backend/internal/compose/overlay.go
@@ -85,9 +85,9 @@ func OverlayBudgetConfig(cfg deployconfig.OverlayBudget) overlaybudget.Config {
 // (jobs_overlay.go's overlayReconcileWorker), which builds its own
 // incumbent adapter from the same overlayIncumbentFactory.
 func NewOverlayHandlers(pool *pgxpool.Pool, vault keyvault.Vault, meter *overlaybudget.Meter, log *slog.Logger, backfillLimit int, onModeFlip func(workspaceID ids.UUID)) overlay.Handlers {
-	ms := overlay.NewMirrorStore(pool, unresolvedOwnerEmails{})
+	ms := overlay.NewMirrorStore(InstallationDB(pool), unresolvedOwnerEmails{})
 	incumbent := overlayIncumbentFactory(backfillLimit)
-	svc := overlay.NewService(pool, vault, ms).
+	svc := overlay.NewService(InstallationDB(pool), vault, ms).
 		WithBudgetMeter(meter).
 		WithIncumbentClassesTranslator(hubspot.IncumbentClassesFor).
 		WithIncumbentFactory(incumbent).
@@ -126,7 +126,7 @@ func hubspotIncumbentFactory(region, token string) overlay.Incumbent {
 // force-fresh to the mirror honestly (freshness.go's own doc) — never a
 // faked authority claim.
 func NewOverlayProvider(pool *pgxpool.Pool, meter *overlaybudget.Meter, resolveIncumbent func(context.Context) (overlay.Incumbent, error)) *overlay.Provider {
-	ms := overlay.NewMirrorStore(pool, unresolvedOwnerEmails{})
+	ms := overlay.NewMirrorStore(InstallationDB(pool), unresolvedOwnerEmails{})
 	ff := overlay.NewFreshnessReader(resolveIncumbent, ms, meter, hubspot.IncumbentClassesFor)
 	p := overlay.NewProvider(ms, ff)
 	// Wire the write-back path's incumbent resolver too — NewProvider stores
@@ -137,7 +137,7 @@ func NewOverlayProvider(pool *pgxpool.Pool, meter *overlaybudget.Meter, resolveI
 	p.SetFreshnessIncumbentResolver(resolveIncumbent)
 	// Wire the echo-suppression ledger's producer half (OVA-DDL-6): each
 	// write-back opens ledger entries so the webhook receiver can drop its echo.
-	p.SetWriteLedger(overlay.NewWriteLedger(pool), slog.Default())
+	p.SetWriteLedger(overlay.NewWriteLedger(InstallationDB(pool)), slog.Default())
 	return p
 }
 

--- a/backend/internal/compose/overlay.go
+++ b/backend/internal/compose/overlay.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/gradionhq/margince/backend/internal/modules/overlay"
 	"github.com/gradionhq/margince/backend/internal/modules/overlay/hubspot"
+	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/deployconfig"
 	"github.com/gradionhq/margince/backend/internal/platform/httpserver"
 	"github.com/gradionhq/margince/backend/internal/platform/keyvault"
@@ -126,7 +127,15 @@ func hubspotIncumbentFactory(region, token string) overlay.Incumbent {
 // force-fresh to the mirror honestly (freshness.go's own doc) — never a
 // faked authority claim.
 func NewOverlayProvider(pool *pgxpool.Pool, meter *overlaybudget.Meter, resolveIncumbent func(context.Context) (overlay.Incumbent, error)) *overlay.Provider {
-	ms := overlay.NewMirrorStore(InstallationDB(pool), unresolvedOwnerEmails{})
+	return NewOverlayProviderFor(InstallationDB(pool), meter, resolveIncumbent)
+}
+
+// NewOverlayProviderFor is NewOverlayProvider over a handle whose workspace is
+// already decided — the harness half of the same wiring. A server resolves the
+// installation's singleton; a suite that seeds a second workspace to prove one
+// tenant cannot read another names the one it means (ADR-0091 §9 step 3).
+func NewOverlayProviderFor(db *database.DB, meter *overlaybudget.Meter, resolveIncumbent func(context.Context) (overlay.Incumbent, error)) *overlay.Provider {
+	ms := overlay.NewMirrorStore(db, unresolvedOwnerEmails{})
 	ff := overlay.NewFreshnessReader(resolveIncumbent, ms, meter, hubspot.IncumbentClassesFor)
 	p := overlay.NewProvider(ms, ff)
 	// Wire the write-back path's incumbent resolver too — NewProvider stores
@@ -137,7 +146,7 @@ func NewOverlayProvider(pool *pgxpool.Pool, meter *overlaybudget.Meter, resolveI
 	p.SetFreshnessIncumbentResolver(resolveIncumbent)
 	// Wire the echo-suppression ledger's producer half (OVA-DDL-6): each
 	// write-back opens ledger entries so the webhook receiver can drop its echo.
-	p.SetWriteLedger(overlay.NewWriteLedger(InstallationDB(pool)), slog.Default())
+	p.SetWriteLedger(overlay.NewWriteLedger(db), slog.Default())
 	return p
 }
 

--- a/backend/internal/compose/overlaywebhook.go
+++ b/backend/internal/compose/overlaywebhook.go
@@ -96,7 +96,7 @@ func WithOverlayWebhook(inserter *jobs.Runner, clientSecret string) Option {
 		if clientSecret == "" || inserter == nil {
 			return
 		}
-		ledger := overlay.NewWriteLedger(pool)
+		ledger := overlay.NewWriteLedger(InstallationDB(pool))
 		s.overlayWebhook = &hubspotWebhookHandler{
 			bind: func(ctx context.Context, incumbent, portalID string) (ids.WorkspaceID, error) {
 				return overlay.WorkspaceForPortal(ctx, pool, incumbent, portalID)

--- a/backend/internal/compose/registry.go
+++ b/backend/internal/compose/registry.go
@@ -23,6 +23,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/modules/overlay"
 	"github.com/gradionhq/margince/backend/internal/modules/search"
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
+	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/httperr"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/diffhash"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
@@ -33,7 +34,17 @@ import (
 // seam, which identity implements — injected here so platform/auth never
 // imports a module (ADR-0054 §5).
 func NewRegistry(pool *pgxpool.Pool, send SendPath) *agents.Registry {
-	return registryWithGate(pool, auth.NewGate(identity.NewService(pool)), nil, nil, send, companyEnricher{}, nil)
+	return NewRegistryFor(InstallationDB(pool), send)
+}
+
+// NewRegistryFor is NewRegistry over a handle whose workspace is already
+// decided. A server resolves the installation's singleton, which is what
+// NewRegistry does for it; a harness that seeds a second workspace on purpose
+// has no singleton to resolve and names the one it means instead. Same wiring,
+// same gate — only where the tenant comes from differs (ADR-0091 §9 step 3).
+func NewRegistryFor(db *database.DB, send SendPath) *agents.Registry {
+	pool := db.Pool()
+	return registryWithGate(db, auth.NewGate(identity.NewService(pool)), nil, nil, send, companyEnricher{}, nil)
 }
 
 // NewRegistryWithIncumbent is NewRegistry plus the per-workspace live-incumbent
@@ -41,14 +52,14 @@ func NewRegistry(pool *pgxpool.Pool, send SendPath) *agents.Registry {
 // through — the wiring a role with a vault (the api server) installs so the MCP
 // tool surface can actually write back, not just answer errNoWriteIncumbent.
 func NewRegistryWithIncumbent(pool *pgxpool.Pool, resolveIncumbent func(context.Context) (overlay.Incumbent, error), send SendPath) *agents.Registry {
-	return registryWithGate(pool, auth.NewGate(identity.NewService(pool)), nil, resolveIncumbent, send, companyEnricher{}, nil)
+	return registryWithGate(InstallationDB(pool), auth.NewGate(identity.NewService(pool)), nil, resolveIncumbent, send, companyEnricher{}, nil)
 }
 
 func registryWithDraftBrain(pool *pgxpool.Pool, brain completer, resolveIncumbent func(context.Context) (overlay.Incumbent, error), send SendPath) *agents.Registry {
 	if brain == nil {
-		return registryWithGate(pool, auth.NewGate(identity.NewService(pool)), nil, resolveIncumbent, send, companyEnricher{}, nil)
+		return registryWithGate(InstallationDB(pool), auth.NewGate(identity.NewService(pool)), nil, resolveIncumbent, send, companyEnricher{}, nil)
 	}
-	return registryWithGate(pool, auth.NewGate(identity.NewService(pool)), newReplyDrafter(pool, brain, nil), resolveIncumbent, send, companyEnricher{}, nil)
+	return registryWithGate(InstallationDB(pool), auth.NewGate(identity.NewService(pool)), newReplyDrafter(pool, brain, nil), resolveIncumbent, send, companyEnricher{}, nil)
 }
 
 // registryWithGate composes the tool surface. The quota charger arrives as
@@ -65,7 +76,7 @@ func registryWithDraftBrain(pool *pgxpool.Pool, brain completer, resolveIncumben
 // model path has none, and the offline fake binds no embeddings model — and
 // every path that can lose the vector lane says so on the wire rather than
 // serving a lexically-ranked page under a semantic label.
-func registryWithGate(pool *pgxpool.Pool, gate *auth.Gate, drafter activities.EmailDrafter, resolveIncumbent func(context.Context) (overlay.Incumbent, error), send SendPath, enricher agents.CompanyEnricher, embedder search.Embedder, opts ...agents.RegistryOption) *agents.Registry {
+func registryWithGate(db *database.DB, gate *auth.Gate, drafter activities.EmailDrafter, resolveIncumbent func(context.Context) (overlay.Incumbent, error), send SendPath, enricher agents.CompanyEnricher, embedder search.Embedder, opts ...agents.RegistryOption) *agents.Registry {
 	// The Dispatcher is the datasource seam every core/slipping tool
 	// rides: a native-mode workspace lands on the composite SoR
 	// Provider exactly as before, an overlay-mode workspace's reads land
@@ -80,8 +91,9 @@ func registryWithGate(pool *pgxpool.Pool, gate *auth.Gate, drafter activities.Em
 	// metered force-fresh path lands for a tool, this becomes a Redis-backed
 	// NewOverlayMeter like the REST surface's, sharing the same per-workspace
 	// windows.
+	pool := db.Pool()
 	native := NewProvider(pool)
-	provider := NewDispatcher(native, NewOverlayProvider(pool, failClosedOverlayMeter(), resolveIncumbent), pool)
+	provider := NewDispatcher(native, NewOverlayProviderFor(db, failClosedOverlayMeter(), resolveIncumbent), pool)
 	// Retry safety, wired for EVERY role that composes this surface rather than
 	// arriving as the API server's option the way the read charger does. The
 	// difference is who the promise is made to: the read bound governs agent

--- a/backend/internal/compose/routes.go
+++ b/backend/internal/compose/routes.go
@@ -56,7 +56,7 @@ func contractAPI(srv Server, pool *pgxpool.Pool, identitySvc *identity.Service) 
 	// this registry, so a registry built without one would refuse REST calls on
 	// a counter it then never paid — the exact half-a-control this change exists
 	// to remove.
-	registry := registryWithGate(pool, gate, srv.replyDrafter, srv.resolveOverlayIncumbent(pool), srv.send,
+	registry := registryWithGate(InstallationDB(pool), gate, srv.replyDrafter, srv.resolveOverlayIncumbent(pool), srv.send,
 		companyEnricher{}, srv.retrievalEmbedder, agents.WithQuotaCharger(srv.quotaMeter))
 	// The ADR-0055 admission layer and the MCP tool surface share one
 	// provider seam: agentGate's StageResolver dispatches per workspace

--- a/backend/internal/compose/server.go
+++ b/backend/internal/compose/server.go
@@ -451,7 +451,7 @@ func (s *Server) rebuildToolRegistry(pool *pgxpool.Pool) {
 	// The gate and the registry take the SAME meter pointer: one refuses on the
 	// bound, the other pays into it, and a surface where those were two
 	// counters would step an agent up against a number nothing was charging.
-	s.toolRegistry = registryWithGate(pool,
+	s.toolRegistry = registryWithGate(InstallationDB(pool),
 		auth.NewGate(identity.NewService(pool), auth.WithQuota(s.quotaMeter)),
 		s.replyDrafter, s.resolveOverlayIncumbent(pool), s.send, companyEnricher{srv: s},
 		s.retrievalEmbedder,

--- a/backend/internal/modules/overlay/backfill_integration_test.go
+++ b/backend/internal/modules/overlay/backfill_integration_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/gradionhq/margince/backend/internal/platform/database"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
 // pagingCompanies is a minimal in-memory overlay.Incumbent used only by
@@ -133,8 +134,8 @@ func countMirrorRows(ctx context.Context, pool *pgxpool.Pool, objectClass string
 // converges in overlay_mirror itself, with no duplicate rows, after a
 // mid-page crash.
 func TestBackfillCursorPersistsAcrossRestartInPostgres(t *testing.T) {
-	ctx, pool, _ := testWorkspaceCtx(t)
-	store := NewMirrorStore(pool, noOwnerEmails{})
+	ctx, pool, ws := testWorkspaceCtx(t)
+	store := NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), noOwnerEmails{})
 
 	const n = 250
 	records := make([]Record, n)

--- a/backend/internal/modules/overlay/connection.go
+++ b/backend/internal/modules/overlay/connection.go
@@ -28,7 +28,6 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgxpool"
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
@@ -128,7 +127,8 @@ type ConnectInput struct {
 // imports THIS package, so the reverse import would cycle). It is plural
 // because "activity" is backed by all five engagement classes at once.
 type Service struct {
-	pool               *pgxpool.Pool
+	// db binds the workspace this store runs for (ADR-0091 §9 step 3).
+	db                 *database.DB
 	vault              keyvault.Vault
 	ms                 *MirrorStore
 	meter              *overlaybudget.Meter
@@ -150,8 +150,8 @@ type Service struct {
 
 // NewService constructs a Service over pool, vault (the credential
 // custodian), and ms (the mirror store teardown purges).
-func NewService(pool *pgxpool.Pool, vault keyvault.Vault, ms *MirrorStore) *Service {
-	return &Service{pool: pool, vault: vault, ms: ms, log: slog.Default()}
+func NewService(db *database.DB, vault keyvault.Vault, ms *MirrorStore) *Service {
+	return &Service{db: db, vault: vault, ms: ms, log: slog.Default()}
 }
 
 // WithModeFlipObserver wires the committed-mode-flip observer (the
@@ -390,7 +390,7 @@ func incumbentConnectedPayload(incumbent, region string, scopes []string, status
 // the audit action is "create" and before is nil.
 func (s *Service) insertConnection(ctx context.Context, in ConnectInput, ref keyvault.Ref, accountID string) (Connection, error) {
 	var out Connection
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		var id ids.UUID
 		var connectedAt time.Time
 		// NULLIF($5,'') stores a blank account id (the portal fetch failed or the
@@ -465,7 +465,7 @@ func (s *Service) Get(ctx context.Context) (Connection, error) {
 	}
 	var out Connection
 	var connectedAt time.Time
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		return tx.QueryRow(ctx, `
 			SELECT incumbent, region, status, connected_at, scopes
 			FROM incumbent_connection

--- a/backend/internal/modules/overlay/connection_integration_test.go
+++ b/backend/internal/modules/overlay/connection_integration_test.go
@@ -49,7 +49,7 @@ func queryRowWS(ctx context.Context, t *testing.T, pool *pgxpool.Pool, sql strin
 func TestActiveConnectionReadsThisWorkspacesConnection(t *testing.T) {
 	ctx, pool, ws := testWorkspaceCtx(t)
 	vault := keyvault.NewMemory()
-	svc := NewService(pool, vault, NewMirrorStore(pool, noOwnerEmails{}))
+	svc := NewService(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), vault, NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), noOwnerEmails{}))
 
 	if _, err := ActiveConnection(ctx, pool); !errors.Is(err, apperrors.ErrNotFound) {
 		t.Fatalf("ActiveConnection with no connection = %v, want ErrNotFound", err)
@@ -77,7 +77,7 @@ func TestActiveConnectionReadsThisWorkspacesConnection(t *testing.T) {
 func TestConnectSealsTheTokenAndFlipsTheWorkspaceToOverlay(t *testing.T) {
 	ctx, pool, ws := testWorkspaceCtx(t)
 	vault := keyvault.NewMemory()
-	svc := NewService(pool, vault, NewMirrorStore(pool, noOwnerEmails{}))
+	svc := NewService(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), vault, NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), noOwnerEmails{}))
 
 	const token = "pat-super-secret-hubspot-token"
 	conn, err := svc.Connect(ctx, ConnectInput{Incumbent: "hubspot", Region: "eu1", Token: token})
@@ -143,9 +143,9 @@ func TestConnectSealsTheTokenAndFlipsTheWorkspaceToOverlay(t *testing.T) {
 }
 
 func TestConnectTwiceAnswersAlreadyConnected(t *testing.T) {
-	ctx, pool, _ := testWorkspaceCtx(t)
+	ctx, pool, ws := testWorkspaceCtx(t)
 	vault := keyvault.NewMemory()
-	svc := NewService(pool, vault, NewMirrorStore(pool, noOwnerEmails{}))
+	svc := NewService(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), vault, NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), noOwnerEmails{}))
 
 	if _, err := svc.Connect(ctx, ConnectInput{Incumbent: "hubspot", Region: "us1", Token: "first-token"}); err != nil {
 		t.Fatalf("first Connect: %v", err)
@@ -160,9 +160,9 @@ func TestConnectTwiceAnswersAlreadyConnected(t *testing.T) {
 }
 
 func TestGetAnswersNotFoundBeforeConnectAndTheConnectionAfter(t *testing.T) {
-	ctx, pool, _ := testWorkspaceCtx(t)
+	ctx, pool, ws := testWorkspaceCtx(t)
 	vault := keyvault.NewMemory()
-	svc := NewService(pool, vault, NewMirrorStore(pool, noOwnerEmails{}))
+	svc := NewService(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), vault, NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), noOwnerEmails{}))
 
 	if _, err := svc.Get(ctx); !errors.Is(err, apperrors.ErrNotFound) {
 		t.Errorf("Get before Connect = %v, want apperrors.ErrNotFound", err)
@@ -193,7 +193,7 @@ func TestConnectionLifecycleObjectRBACDeniesMemberAllowsAdmin(t *testing.T) {
 	_, memberUserID := testWorkspaceCtxAsUser(t, ws, "member@overlay.test")
 	memberCtx := testMemberCtx(ws, memberUserID)
 	vault := keyvault.NewMemory()
-	svc := NewService(pool, vault, NewMirrorStore(pool, noOwnerEmails{}))
+	svc := NewService(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), vault, NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), noOwnerEmails{}))
 
 	// A member (read-only on overlay_connection) is denied Connect...
 	if _, err := svc.Connect(memberCtx, ConnectInput{Incumbent: "hubspot", Region: "eu1", Token: "member-attempt"}); !errors.Is(err, apperrors.ErrPermissionDenied) {
@@ -234,9 +234,9 @@ func TestConnectionLifecycleObjectRBACDeniesMemberAllowsAdmin(t *testing.T) {
 // place, the teardown tombstones that would suppress re-mirroring are gone,
 // and the workspace is back in overlay mode.
 func TestConnectAfterDisconnectRevivesTheConnection(t *testing.T) {
-	ctx, pool, _ := testWorkspaceCtx(t)
+	ctx, pool, ws := testWorkspaceCtx(t)
 	vault := keyvault.NewMemory()
-	svc := NewService(pool, vault, NewMirrorStore(pool, noOwnerEmails{}))
+	svc := NewService(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), vault, NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), noOwnerEmails{}))
 
 	first, err := svc.Connect(ctx, ConnectInput{Incumbent: "hubspot", Region: "eu1", Token: "pat-first"})
 	if err != nil {
@@ -300,7 +300,7 @@ func TestConnectAfterDisconnectRevivesTheConnection(t *testing.T) {
 func TestReconnectAuditsThePreviousRegion(t *testing.T) {
 	ctx, pool, ws := testWorkspaceCtx(t)
 	vault := keyvault.NewMemory()
-	svc := NewService(pool, vault, NewMirrorStore(pool, noOwnerEmails{}))
+	svc := NewService(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), vault, NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), noOwnerEmails{}))
 
 	if _, err := svc.Connect(ctx, ConnectInput{Incumbent: "hubspot", Region: "eu1", Token: "pat-first"}); err != nil {
 		t.Fatalf("first Connect: %v", err)
@@ -327,9 +327,9 @@ func TestReconnectAuditsThePreviousRegion(t *testing.T) {
 
 // An ACTIVE connection still refuses a second connect — only a revoked one reconnects.
 func TestConnectRefusesASecondActiveConnection(t *testing.T) {
-	ctx, pool, _ := testWorkspaceCtx(t)
+	ctx, pool, ws := testWorkspaceCtx(t)
 	vault := keyvault.NewMemory()
-	svc := NewService(pool, vault, NewMirrorStore(pool, noOwnerEmails{}))
+	svc := NewService(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), vault, NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), noOwnerEmails{}))
 
 	if _, err := svc.Connect(ctx, ConnectInput{Incumbent: "hubspot", Region: "eu1", Token: "pat-first"}); err != nil {
 		t.Fatalf("first Connect: %v", err)

--- a/backend/internal/modules/overlay/deletion_integration_test.go
+++ b/backend/internal/modules/overlay/deletion_integration_test.go
@@ -28,8 +28,8 @@ import (
 // It also pins idempotency: purging an already-absent record is a no-op
 // that reports existed=false, never an error (the sweep re-runs freely).
 func TestPurgeRecordRemovesMirrorAssociationAndVisibility(t *testing.T) {
-	ctx, pool, _ := testWorkspaceCtx(t)
-	store := NewMirrorStore(pool, noOwnerEmails{})
+	ctx, pool, ws := testWorkspaceCtx(t)
+	store := NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), noOwnerEmails{})
 	const objectClass = "person"
 	const externalID = "555001"
 
@@ -90,7 +90,7 @@ func TestPurgeRecordRemovesMirrorAssociationAndVisibility(t *testing.T) {
 // poller-lane spend.
 func TestReconcileDeletionsPurgesMirroredRecordAndEmits(t *testing.T) {
 	ctx, pool, ws := testWorkspaceCtx(t)
-	ms := NewMirrorStore(pool, noOwnerEmails{})
+	ms := NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), noOwnerEmails{})
 	const objectClass = "person"
 	const externalID = "777001"
 	deletedAt := time.Date(2026, 7, 2, 8, 0, 0, 0, time.UTC)
@@ -151,8 +151,8 @@ func TestReconcileDeletionsPurgesMirroredRecordAndEmits(t *testing.T) {
 // BEFORE any row is deleted — never a partial purge with the event silently
 // dropped.
 func TestPurgeRecordRejectsANonNumericExternalID(t *testing.T) {
-	ctx, pool, _ := testWorkspaceCtx(t)
-	store := NewMirrorStore(pool, noOwnerEmails{})
+	ctx, pool, ws := testWorkspaceCtx(t)
+	store := NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), noOwnerEmails{})
 
 	if _, err := store.PurgeRecord(ctx, Deletion{
 		ObjectClass: "person", ExternalID: "not-a-number",
@@ -168,7 +168,7 @@ func TestPurgeRecordRejectsANonNumericExternalID(t *testing.T) {
 // and returns no error — so the full-scan deletion feed is safe to re-run.
 func TestReconcileDeletionsForUnmirroredRecordIsANoOp(t *testing.T) {
 	ctx, pool, ws := testWorkspaceCtx(t)
-	ms := NewMirrorStore(pool, noOwnerEmails{})
+	ms := NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), noOwnerEmails{})
 	const objectClass = "person"
 	const externalID = "777404"
 	deletedAt := time.Date(2026, 7, 2, 8, 0, 0, 0, time.UTC)

--- a/backend/internal/modules/overlay/emailrevalidate.go
+++ b/backend/internal/modules/overlay/emailrevalidate.go
@@ -14,8 +14,6 @@ import (
 	"fmt"
 
 	"github.com/jackc/pgx/v5"
-
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 )
 
 // revalidateEmailMapping re-verifies every email-sourced mirror_user_map
@@ -134,7 +132,7 @@ func (s *MirrorStore) RevalidateEmailMappings(ctx context.Context, emails OwnerE
 // bounded population RevalidateEmailMappings re-checks each pass.
 func (s *MirrorStore) listEmailSourcedOwners(ctx context.Context) ([]string, error) {
 	var owners []string
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		rows, err := tx.Query(ctx, distinctEmailSourcedOwnersSQL)
 		if err != nil {
 			return fmt.Errorf("overlay: listing email-sourced owners to revalidate: %w", err)
@@ -157,7 +155,7 @@ func (s *MirrorStore) listEmailSourcedOwners(ctx context.Context) ([]string, err
 // fenced visibility mutator takes) then revalidateEmailMapping's own
 // delete-if-stale-then-recompute.
 func (s *MirrorStore) revalidateOneOwner(ctx context.Context, emails OwnerEmailResolver, owner string) error {
-	return database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	return s.db.Tx(ctx, func(tx pgx.Tx) error {
 		if err := s.assertFence(ctx, tx); err != nil {
 			return err
 		}

--- a/backend/internal/modules/overlay/flipreads.go
+++ b/backend/internal/modules/overlay/flipreads.go
@@ -20,7 +20,6 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
@@ -32,7 +31,7 @@ func (s *MirrorStore) FlipCounts(ctx context.Context) (map[string]int, error) {
 		return nil, err
 	}
 	counts := map[string]int{}
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		rows, err := tx.Query(ctx, `SELECT object_class, count(*) FROM overlay_mirror GROUP BY object_class`)
 		if err != nil {
 			return fmt.Errorf("overlay: counting the mirror estate for the flip: %w", err)
@@ -62,7 +61,7 @@ func (s *MirrorStore) FlipRows(ctx context.Context, objectClass string, offset, 
 		return nil, err
 	}
 	var out []Row
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		rows, err := tx.Query(ctx, `
 			SELECT object_class, external_id, fields, updated_at_baseline,
 			       coalesce(owner_external_id, ''), sync_state, last_synced_at
@@ -97,7 +96,7 @@ func (s *MirrorStore) FlipAssociations(ctx context.Context) ([]Assoc, error) {
 		return nil, err
 	}
 	var out []Assoc
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		rows, err := tx.Query(ctx, `
 			SELECT from_type, from_id, to_type, to_id, type_id, category, coalesce(label, ''), direction
 			FROM overlay_association
@@ -135,7 +134,7 @@ func (s *MirrorStore) ResolveMirrorOwner(ctx context.Context, incumbentUserID st
 	}
 	var id ids.UUID
 	found := false
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		err := tx.QueryRow(ctx,
 			`SELECT app_user_id FROM mirror_user_map WHERE incumbent_user_id = $1`, incumbentUserID,
 		).Scan(&id)

--- a/backend/internal/modules/overlay/flipstate.go
+++ b/backend/internal/modules/overlay/flipstate.go
@@ -32,7 +32,6 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
@@ -92,7 +91,7 @@ func (s *Service) FlipChecks(ctx context.Context) (FlipChecks, error) {
 		return FlipChecks{}, err
 	}
 	checks := FlipChecks{Incumbent: incumbent}
-	err = database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err = s.db.Tx(ctx, func(tx pgx.Tx) error {
 		if err := tx.QueryRow(ctx, `SELECT status FROM incumbent_connection`).Scan(&checks.ConnectionStatus); err != nil {
 			if errors.Is(err, pgx.ErrNoRows) {
 				// Overlay mode with no connection row cannot arise through
@@ -186,7 +185,7 @@ func (s *Service) SealFlipSnapshot(ctx context.Context) (FlipSnapshot, error) {
 	// resume path keys a checkpoint on it — a stale checkpoint matched
 	// against a DIFFERENT freeze would skip rows it never imported.
 	candidate := "snap-" + time.Now().UTC().Format("2006-01-02T15:04:05Z") + "-" + ids.NewV7().String()
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		if err := tx.QueryRow(ctx, `
 			INSERT INTO overlay_sync_state (workspace_id, next_sweep_at, flip_snapshot_id, mirror_frozen_at, updated_at)
 			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, now(), $1, now(), now())
@@ -247,7 +246,7 @@ func (s *Service) UnsealFlipSnapshot(ctx context.Context) error {
 	if err := s.requireOverlayMode(ctx); err != nil {
 		return err
 	}
-	return database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	return s.db.Tx(ctx, func(tx pgx.Tx) error {
 		// RETURNING the OLD values: the SET list has already replaced
 		// them in the returned row, so the prior state is read from the
 		// pre-update snapshot the CTE holds.
@@ -286,7 +285,7 @@ func (s *Service) FlipSnapshot(ctx context.Context) (FlipSnapshot, error) {
 		return FlipSnapshot{}, err
 	}
 	var snap FlipSnapshot
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		var id *string
 		var frozenAt *time.Time
 		err := tx.QueryRow(ctx, `SELECT flip_snapshot_id, mirror_frozen_at FROM overlay_sync_state`).Scan(&id, &frozenAt)
@@ -327,7 +326,7 @@ func (s *Service) CompleteFlip(ctx context.Context, runID ids.UUID, mode string)
 	if !ok {
 		return errors.New("overlay: flip completion called outside a workspace context")
 	}
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		tag, err := tx.Exec(ctx, `
 			UPDATE workspace SET x_sor_mode = 'native', x_incumbent = NULL
 			WHERE id = NULLIF(current_setting('app.workspace_id', true), '')::uuid

--- a/backend/internal/modules/overlay/flipstate_integration_test.go
+++ b/backend/internal/modules/overlay/flipstate_integration_test.go
@@ -103,8 +103,8 @@ func markBackfillDone(ctx context.Context, t *testing.T, pool *pgxpool.Pool, inc
 
 // flipService builds the Service under test with the hubspot
 // canonical→incumbent translation the backfill-completeness check needs.
-func flipService(pool *pgxpool.Pool) *Service {
-	svc := NewService(pool, nil, NewMirrorStore(pool, nil))
+func flipService(db *database.DB) *Service {
+	svc := NewService(db, nil, NewMirrorStore(db, nil))
 	return svc.WithIncumbentClassesTranslator(func(canonical string) ([]string, bool) {
 		switch canonical {
 		case "person":
@@ -118,9 +118,9 @@ func flipService(pool *pgxpool.Pool) *Service {
 }
 
 func TestFlipChecksReportUnreachableStaleAndPending(t *testing.T) {
-	ctx, pool, _ := testWorkspaceCtx(t)
+	ctx, pool, ws := testWorkspaceCtx(t)
 	seedOverlayWorkspace(ctx, t, pool)
-	svc := flipService(pool)
+	svc := flipService(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)))
 
 	// Fresh overlay, one converged person row.
 	seedMirrorPerson(ctx, t, pool, "p-1", "fresh")
@@ -161,9 +161,9 @@ func TestFlipChecksReportUnreachableStaleAndPending(t *testing.T) {
 }
 
 func TestFlipChecksRequireBackfillConvergence(t *testing.T) {
-	ctx, pool, _ := testWorkspaceCtx(t)
+	ctx, pool, ws := testWorkspaceCtx(t)
 	seedOverlayWorkspace(ctx, t, pool)
-	svc := flipService(pool)
+	svc := flipService(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)))
 
 	seedMirrorPerson(ctx, t, pool, "p-1", "fresh")
 	recordSweepSuccess(ctx, t, pool)
@@ -178,10 +178,10 @@ func TestFlipChecksRequireBackfillConvergence(t *testing.T) {
 }
 
 func TestSealUnsealLifecycleAndFreezeFence(t *testing.T) {
-	ctx, pool, _ := testWorkspaceCtx(t)
+	ctx, pool, ws := testWorkspaceCtx(t)
 	seedOverlayWorkspace(ctx, t, pool)
-	svc := flipService(pool)
-	ms := NewMirrorStore(pool, nil)
+	svc := flipService(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)))
+	ms := NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), nil)
 
 	snap, err := svc.SealFlipSnapshot(ctx)
 	if err != nil {
@@ -235,7 +235,7 @@ func TestSealUnsealLifecycleAndFreezeFence(t *testing.T) {
 func TestCompleteFlipFlipsModeOnceAndKeepsConnection(t *testing.T) {
 	ctx, pool, ws := testWorkspaceCtx(t)
 	seedOverlayWorkspace(ctx, t, pool)
-	svc := flipService(pool)
+	svc := flipService(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)))
 	var flipped []ids.UUID
 	svc = svc.WithModeFlipObserver(func(id ids.UUID) { flipped = append(flipped, id) })
 
@@ -288,9 +288,9 @@ func TestCompleteFlipFlipsModeOnceAndKeepsConnection(t *testing.T) {
 }
 
 func TestDisconnectRefusesARunningImportButNeverALatchedFreeze(t *testing.T) {
-	ctx, pool, _ := testWorkspaceCtx(t)
+	ctx, pool, ws := testWorkspaceCtx(t)
 	seedOverlayWorkspace(ctx, t, pool)
-	svc := flipService(pool)
+	svc := flipService(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)))
 
 	// A RUNNING flip import is the one thing disconnect refuses: tearing
 	// the mirror down mid-import would migrate a vanishing estate.

--- a/backend/internal/modules/overlay/freshness.go
+++ b/backend/internal/modules/overlay/freshness.go
@@ -11,7 +11,6 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/platform/overlaybudget"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
@@ -270,7 +269,7 @@ func (f *FreshnessReader) degradeForShed(ctx context.Context, ref datasource.Ent
 // row it traces to is a system_log row rather than an audit_log row,
 // because no domain row was mutated to audit.
 func (f *FreshnessReader) emitBudgetDegraded(ctx context.Context, ref datasource.EntityRef) error {
-	return database.WithWorkspaceTx(ctx, f.ms.pool, func(tx pgx.Tx) error {
+	return f.ms.db.Tx(ctx, func(tx pgx.Tx) error {
 		logID, err := storekit.LogSystem(ctx, tx, "mirror.budget_degraded", map[string]any{
 			"entity_type": string(ref.Type),
 			"entity_id":   ref.ID.String(),

--- a/backend/internal/modules/overlay/freshness_integration_test.go
+++ b/backend/internal/modules/overlay/freshness_integration_test.go
@@ -180,8 +180,8 @@ func seedMirrorAndLiveFixture(ctx context.Context, t *testing.T, ms *MirrorStore
 // ModifiedAt — the one path this port ever answers Authoritative:true
 // on for an overlay-mode workspace.
 func TestFreshnessReaderUnderThresholdReadsLiveAndSpends(t *testing.T) {
-	ctx, pool, _ := testWorkspaceCtx(t)
-	ms := NewMirrorStore(pool, noOwnerEmails{})
+	ctx, pool, ws := testWorkspaceCtx(t)
+	ms := NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), noOwnerEmails{})
 
 	const externalID = "100214862042"
 	mirrorTime := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
@@ -229,8 +229,8 @@ func TestFreshnessReaderUnderThresholdReadsLiveAndSpends(t *testing.T) {
 // than erroring. Charging only on success would let an unbounded run of
 // failing force-fresh reads hammer HubSpot without the meter ever shedding.
 func TestFreshnessReaderFailedLiveReadStillSpendsAndDegrades(t *testing.T) {
-	ctx, pool, _ := testWorkspaceCtx(t)
-	ms := NewMirrorStore(pool, noOwnerEmails{})
+	ctx, pool, ws := testWorkspaceCtx(t)
+	ms := NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), noOwnerEmails{})
 
 	const externalID = "100214862042"
 	mirrorTime := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
@@ -271,7 +271,7 @@ func TestFreshnessReaderFailedLiveReadStillSpendsAndDegrades(t *testing.T) {
 // NOT emit mirror.budget_degraded.
 func TestFreshnessReaderNoIncumbentClassMappingDegradesHonestly(t *testing.T) {
 	ctx, pool, ws := testWorkspaceCtx(t)
-	ms := NewMirrorStore(pool, noOwnerEmails{})
+	ms := NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), noOwnerEmails{})
 
 	const externalID = "100214862077"
 	mirrorTime := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
@@ -330,7 +330,7 @@ func TestFreshnessReaderNoIncumbentClassMappingDegradesHonestly(t *testing.T) {
 // silent quality drop would not leave behind.
 func TestFreshnessReaderShedDegradesToMirrorAndEmitsBudgetDegraded(t *testing.T) {
 	ctx, pool, ws := testWorkspaceCtx(t)
-	ms := NewMirrorStore(pool, noOwnerEmails{})
+	ms := NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), noOwnerEmails{})
 
 	const externalID = "100214862099"
 	mirrorTime := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)

--- a/backend/internal/modules/overlay/handlers_usermap_integration_test.go
+++ b/backend/internal/modules/overlay/handlers_usermap_integration_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/keyvault"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
@@ -45,7 +46,7 @@ func decodeJSON(t *testing.T, rec *httptest.ResponseRecorder, want int, out any)
 // directory, pin a user to an owner from it, read the page back, then unmap.
 func TestUserMapHandlersServeTheAdminRoundTrip(t *testing.T) {
 	ctx, pool, ws := testWorkspaceCtx(t)
-	svc := connectedUserMapService(ctx, t, pool, &directoryIncumbent{
+	svc := connectedUserMapService(ctx, t, database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), &directoryIncumbent{
 		owners: []OwnerRef{{ExternalID: "owner-1", Email: "ada@acme.test", Name: "Ada Lovelace"}},
 	})
 	h := NewHandlers(svc)
@@ -119,8 +120,9 @@ func TestUserMapHandlersServeTheAdminRoundTrip(t *testing.T) {
 // mode_not_overlay 404 rather than an empty page a card would render as
 // "nobody to map".
 func TestListOverlayUserMapIs404InNativeMode(t *testing.T) {
-	ctx, pool, _ := testWorkspaceCtx(t)
-	h := NewHandlers(NewService(pool, keyvault.NewMemory(), NewMirrorStore(pool, noOwnerEmails{})))
+	ctx, pool, ws := testWorkspaceCtx(t)
+	db := database.BindTo(pool, ids.From[ids.WorkspaceKind](ws))
+	h := NewHandlers(NewService(db, keyvault.NewMemory(), NewMirrorStore(db, noOwnerEmails{})))
 
 	rec := httptest.NewRecorder()
 	h.ListOverlayUserMap(rec,
@@ -141,8 +143,8 @@ func TestListOverlayUserMapIs404InNativeMode(t *testing.T) {
 // fix exists to correct, so it is pinned at the transport, not just at the
 // decoder.
 func TestListOverlayUserMapAnswers422ForAMalformedCursor(t *testing.T) {
-	ctx, pool, _ := testWorkspaceCtx(t)
-	h := NewHandlers(connectedUserMapService(ctx, t, pool, &directoryIncumbent{}))
+	ctx, pool, ws := testWorkspaceCtx(t)
+	h := NewHandlers(connectedUserMapService(ctx, t, database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), &directoryIncumbent{}))
 	garbage := "not valid base64!!"
 
 	rec := httptest.NewRecorder()

--- a/backend/internal/modules/overlay/metrics_integration_test.go
+++ b/backend/internal/modules/overlay/metrics_integration_test.go
@@ -20,13 +20,14 @@ import (
 
 	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/keyvault"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
 func TestSourceLagByClassReportsTheOldestWatermarkPerClass(t *testing.T) {
-	ctx, pool, _ := testWorkspaceCtx(t)
+	ctx, pool, ws := testWorkspaceCtx(t)
 	vault := keyvault.NewMemory()
-	ms := NewMirrorStore(pool, noOwnerEmails{})
-	svc := NewService(pool, vault, ms)
+	ms := NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), noOwnerEmails{})
+	svc := NewService(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), vault, ms)
 
 	// Flip this workspace into overlay mode — SourceLagByClass's own
 	// fleet query filters on x_sor_mode='overlay', the same condition
@@ -95,8 +96,8 @@ func TestSourceLagByClassReportsTheOldestWatermarkPerClass(t *testing.T) {
 // mode-related — the mode boundary here is SourceLagByClass's own
 // workspace enumeration, not Ingest).
 func TestSourceLagByClassIgnoresNativeModeWorkspaces(t *testing.T) {
-	ctx, pool, _ := testWorkspaceCtx(t) // testWorkspaceCtx's own fixture never flips to overlay mode
-	ms := NewMirrorStore(pool, noOwnerEmails{})
+	ctx, pool, ws := testWorkspaceCtx(t) // testWorkspaceCtx's own fixture never flips to overlay mode
+	ms := NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), noOwnerEmails{})
 	if err := ms.Ingest(ctx, Record{
 		ObjectClass: "native_probe", ExternalID: "99", Fields: map[string]any{}, ModifiedAt: time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC),
 	}); err != nil {

--- a/backend/internal/modules/overlay/mirrorcheckpoints.go
+++ b/backend/internal/modules/overlay/mirrorcheckpoints.go
@@ -25,8 +25,6 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
-
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 )
 
 // upsertBackfillCursorSQL checkpoints the backfill cursor design.md §4.4
@@ -76,7 +74,7 @@ type BackfillProgress struct {
 // must still be the ACTIVE connection's identity (assertOwnConnection), not
 // just an active row.
 func (s *MirrorStore) SaveBackfillCursor(ctx context.Context, objectClass, cursor string, progress BackfillProgress, connectedAt time.Time) error {
-	return database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	return s.db.Tx(ctx, func(tx pgx.Tx) error {
 		if s.fenced {
 			if err := assertOwnConnection(ctx, tx, connectedAt); err != nil {
 				return err
@@ -95,7 +93,7 @@ func (s *MirrorStore) SaveBackfillCursor(ctx context.Context, objectClass, curso
 func (s *MirrorStore) LoadBackfillCursor(ctx context.Context, objectClass string) (string, bool, error) {
 	var cursor string
 	var done bool
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		scanErr := tx.QueryRow(
 			ctx,
 			`SELECT cursor, done FROM overlay_backfill_cursor WHERE object_class = $1`,
@@ -140,7 +138,7 @@ ON CONFLICT (workspace_id, object_class) DO UPDATE
 // just an active row — see SaveBackfillCursor's doc for why this checkpoint
 // specifically needs identity, not just status.
 func (s *MirrorStore) SaveReconcileWatermark(ctx context.Context, objectClass string, watermark, connectedAt time.Time) error {
-	return database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	return s.db.Tx(ctx, func(tx pgx.Tx) error {
 		if s.fenced {
 			if err := assertOwnConnection(ctx, tx, connectedAt); err != nil {
 				return err
@@ -160,7 +158,7 @@ func (s *MirrorStore) SaveReconcileWatermark(ctx context.Context, objectClass st
 // time to the incumbent seam.
 func (s *MirrorStore) LoadReconcileWatermark(ctx context.Context, objectClass string) (time.Time, error) {
 	var watermark time.Time
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		scanErr := tx.QueryRow(
 			ctx,
 			`SELECT watermark FROM overlay_reconcile_watermark WHERE object_class = $1`,

--- a/backend/internal/modules/overlay/mirrorcheckpoints_integration_test.go
+++ b/backend/internal/modules/overlay/mirrorcheckpoints_integration_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/keyvault"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
 // TestSaveReconcileWatermarkOnlyAdvances proves the watermark never moves
@@ -22,8 +23,8 @@ import (
 // which would re-sweep the window between and risk re-ingesting records the
 // newer pass already saw.
 func TestSaveReconcileWatermarkOnlyAdvances(t *testing.T) {
-	ctx, pool, _ := testWorkspaceCtx(t)
-	store := NewMirrorStore(pool, noOwnerEmails{})
+	ctx, pool, ws := testWorkspaceCtx(t)
+	store := NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), noOwnerEmails{})
 
 	newer := time.Date(2026, 7, 2, 0, 0, 0, 0, time.UTC)
 	older := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
@@ -63,8 +64,8 @@ func TestSaveReconcileWatermarkOnlyAdvances(t *testing.T) {
 // done=false (a slower concurrent pass) must not re-open it, which would
 // re-list the whole incumbent.
 func TestSaveBackfillCursorDoneIsSticky(t *testing.T) {
-	ctx, pool, _ := testWorkspaceCtx(t)
-	store := NewMirrorStore(pool, noOwnerEmails{})
+	ctx, pool, ws := testWorkspaceCtx(t)
+	store := NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), noOwnerEmails{})
 	connectedAt := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 
 	if err := store.SaveBackfillCursor(ctx, "contacts", "", BackfillProgress{Done: true}, connectedAt); err != nil {
@@ -93,10 +94,10 @@ func TestSaveBackfillCursorDoneIsSticky(t *testing.T) {
 // writes (Ingest, UpsertAssoc, ...) must still reject a checkpoint write
 // carrying a stale connection identity.
 func TestSaveBackfillCursorEnforcesIdentityEvenOnAPlainFenceStore(t *testing.T) {
-	ctx, pool, _ := testWorkspaceCtx(t)
+	ctx, pool, ws := testWorkspaceCtx(t)
 	vault := keyvault.NewMemory()
-	store := NewMirrorStore(pool, noOwnerEmails{})
-	svc := NewService(pool, vault, store)
+	store := NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), noOwnerEmails{})
+	svc := NewService(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), vault, store)
 
 	conn, err := svc.Connect(ctx, ConnectInput{Incumbent: "hubspot", Region: "eu1", Token: "pat-identity-secret"})
 	if err != nil {

--- a/backend/internal/modules/overlay/mirrordeletion.go
+++ b/backend/internal/modules/overlay/mirrordeletion.go
@@ -19,7 +19,6 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 )
 
@@ -54,7 +53,7 @@ func mirrorDeletedPayload(objectClass, externalID string, deletedAt time.Time) c
 // which owns its own suppression path.
 func (s *MirrorStore) PurgeRecord(ctx context.Context, del Deletion) (bool, error) {
 	var existed bool
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		var err error
 		existed, err = s.purgeRecordTx(ctx, tx, del)
 		return err

--- a/backend/internal/modules/overlay/mirrorstore.go
+++ b/backend/internal/modules/overlay/mirrorstore.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
@@ -53,7 +52,8 @@ type Row struct {
 // concern, not an audit-log concern; only genuine domain events
 // (mirror.conflict, mirror.budget_degraded) go through storekit.Emit.
 type MirrorStore struct {
-	pool   *pgxpool.Pool
+	// db binds the workspace this store runs for (ADR-0091 §9 step 3).
+	db     *database.DB
 	emails OwnerEmailResolver
 	// fenced opts this store into the disconnect-race fence
 	// (disconnectfence.go): every mutation that could resurrect
@@ -84,8 +84,8 @@ type MirrorStore struct {
 // UpsertUserMap's and Ingest's owner-email-change re-validation
 // (visibility.go, design.md §4.6 rules 3/5) verify a mirror_user_map row
 // against.
-func NewMirrorStore(pool *pgxpool.Pool, emails OwnerEmailResolver) *MirrorStore {
-	return &MirrorStore{pool: pool, emails: emails}
+func NewMirrorStore(db *database.DB, emails OwnerEmailResolver) *MirrorStore {
+	return &MirrorStore{db: db, emails: emails}
 }
 
 // WithResolver returns a MirrorStore identical to s but resolving owner
@@ -169,7 +169,7 @@ func (s *MirrorStore) Ingest(ctx context.Context, rec Record) error {
 // what the mirror held, and only a landed row can have.
 func (s *MirrorStore) ingestReporting(ctx context.Context, rec Record) (bool, error) {
 	var landed bool
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		var err error
 		landed, err = s.ingestTx(ctx, tx, rec)
 		return err
@@ -304,7 +304,7 @@ func (s *MirrorStore) UpsertAssoc(ctx context.Context, a Assoc) error {
 	if a.Label != "" {
 		label = a.Label
 	}
-	return database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	return s.db.Tx(ctx, func(tx pgx.Tx) error {
 		if err := s.assertFence(ctx, tx); err != nil {
 			return err
 		}
@@ -340,7 +340,7 @@ WHERE object_class = $1 AND external_id = $2`
 
 func (s *MirrorStore) getRaw(ctx context.Context, objectClass, externalID string) (Row, error) {
 	var row Row
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		return tx.QueryRow(ctx, selectRawMirrorRowSQL, objectClass, externalID).Scan(
 			&row.ObjectClass, &row.ExternalID, &row.Fields, &row.UpdatedAtBaseline,
 			&row.OwnerExternalID, &row.SyncState, &row.LastSyncedAt,
@@ -369,7 +369,7 @@ WHERE m.object_class = $2 AND m.external_id = $3`
 // before the query ever runs — zero rows, existence-hiding, never a 403.
 func (s *MirrorStore) Get(ctx context.Context, objectClass, externalID string) (Row, error) {
 	var row Row
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		mirrorUserID, err := resolveActingMirrorUserID(ctx, tx)
 		if err != nil {
 			return err
@@ -434,7 +434,7 @@ func (s *MirrorStore) List(ctx context.Context, objectClass, cursor string, limi
 	limit = clampListLimit(limit)
 
 	var rows []Row
-	err = database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err = s.db.Tx(ctx, func(tx pgx.Tx) error {
 		mirrorUserID, err := resolveActingMirrorUserID(ctx, tx)
 		if err != nil {
 			return err

--- a/backend/internal/modules/overlay/mirrorstore_integration_test.go
+++ b/backend/internal/modules/overlay/mirrorstore_integration_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/gradionhq/margince/backend/internal/platform/database"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
 // getRaw itself (and its backing SQL) now lives in mirrorstore.go: it has
@@ -31,8 +32,8 @@ import (
 // visibility rows, so a visibility-joined read would find nothing for
 // reasons unrelated to what this test is proving.
 func TestIngestHonorsStalenessAndTombstone(t *testing.T) {
-	ctx, pool, _ := testWorkspaceCtx(t)
-	store := NewMirrorStore(pool, noOwnerEmails{})
+	ctx, pool, ws := testWorkspaceCtx(t)
+	store := NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), noOwnerEmails{})
 	const objectClass = "contact"
 	const externalID = "100214862042"
 

--- a/backend/internal/modules/overlay/provider_integration_test.go
+++ b/backend/internal/modules/overlay/provider_integration_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
@@ -24,8 +25,8 @@ import (
 // gated behind //go:build integration like the rest of this package's
 // mirror-backed tests.
 func TestProviderReadServesFromTheMirror(t *testing.T) {
-	ctx, pool, _ := testWorkspaceCtx(t)
-	store := NewMirrorStore(pool, noOwnerEmails{})
+	ctx, pool, ws := testWorkspaceCtx(t)
+	store := NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), noOwnerEmails{})
 	p := NewProvider(store, nil)
 
 	actor, ok := principal.Actor(ctx)

--- a/backend/internal/modules/overlay/provider_writeback_integration_test.go
+++ b/backend/internal/modules/overlay/provider_writeback_integration_test.go
@@ -160,8 +160,8 @@ func mapActorToOwner(ctx context.Context, t *testing.T, ms *MirrorStore) {
 // auto-execute tool — an unattended loop retrying a create that appears to
 // fail would mint a new invisible record every attempt.
 func TestProviderCreateIsRefusedBeforeReachingTheIncumbent(t *testing.T) {
-	ctx, pool, _ := testWorkspaceCtx(t)
-	ms := NewMirrorStore(pool, noOwnerEmails{})
+	ctx, pool, ws := testWorkspaceCtx(t)
+	ms := NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), noOwnerEmails{})
 	mapActorToOwner(ctx, t, ms)
 	seedActiveConnection(ctx, t, pool)
 
@@ -191,8 +191,8 @@ func TestProviderCreateIsRefusedBeforeReachingTheIncumbent(t *testing.T) {
 // exactly as the echo webhook will present it — so the entry the receiver later
 // classifies against actually exists. Proves the producer half end to end.
 func TestProviderWriteOpensEchoLedgerEntries(t *testing.T) {
-	ctx, pool, _ := testWorkspaceCtx(t)
-	ms := NewMirrorStore(pool, noOwnerEmails{})
+	ctx, pool, ws := testWorkspaceCtx(t)
+	ms := NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), noOwnerEmails{})
 	mapActorToOwner(ctx, t, ms)
 	seedActiveConnection(ctx, t, pool)
 
@@ -218,7 +218,7 @@ func TestProviderWriteOpensEchoLedgerEntries(t *testing.T) {
 		updateProps: map[string]string{"firstname": "Ada"},
 		incClass:    "contacts",
 	}
-	ledger := NewWriteLedger(pool)
+	ledger := NewWriteLedger(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)))
 	p := providerFor(ms, inc)
 	p.SetWriteLedger(ledger, slog.New(slog.DiscardHandler))
 
@@ -245,8 +245,8 @@ func TestProviderWriteOpensEchoLedgerEntries(t *testing.T) {
 // surfaces it to the caller AND leaves the mirror row exactly as it was —
 // the mirror is never advanced ahead of an incumbent ack.
 func TestProviderUpdateRejectsIncumbentSkewLeavingMirrorUntouched(t *testing.T) {
-	ctx, pool, _ := testWorkspaceCtx(t)
-	ms := NewMirrorStore(pool, noOwnerEmails{})
+	ctx, pool, ws := testWorkspaceCtx(t)
+	ms := NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), noOwnerEmails{})
 	mapActorToOwner(ctx, t, ms)
 	seedActiveConnection(ctx, t, pool)
 
@@ -293,8 +293,8 @@ func TestProviderUpdateRejectsIncumbentSkewLeavingMirrorUntouched(t *testing.T) 
 // TestProviderUpdateMirrorsResultOnAck: a successful incumbent update is
 // re-mirrored, so the mirror reflects the acked state.
 func TestProviderUpdateMirrorsResultOnAck(t *testing.T) {
-	ctx, pool, _ := testWorkspaceCtx(t)
-	ms := NewMirrorStore(pool, noOwnerEmails{})
+	ctx, pool, ws := testWorkspaceCtx(t)
+	ms := NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), noOwnerEmails{})
 	mapActorToOwner(ctx, t, ms)
 	seedActiveConnection(ctx, t, pool)
 
@@ -331,8 +331,8 @@ func TestProviderUpdateMirrorsResultOnAck(t *testing.T) {
 // TestProviderArchivePurgesMirror: Archive removes the mirror row after the
 // incumbent archive so it stops being readable.
 func TestProviderArchivePurgesMirror(t *testing.T) {
-	ctx, pool, _ := testWorkspaceCtx(t)
-	ms := NewMirrorStore(pool, noOwnerEmails{})
+	ctx, pool, ws := testWorkspaceCtx(t)
+	ms := NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), noOwnerEmails{})
 	mapActorToOwner(ctx, t, ms)
 	seedActiveConnection(ctx, t, pool)
 

--- a/backend/internal/modules/overlay/reconcile.go
+++ b/backend/internal/modules/overlay/reconcile.go
@@ -22,7 +22,6 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/platform/overlaybudget"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
@@ -294,7 +293,7 @@ func emitMirrorConflict(ctx context.Context, ms *MirrorStore, rec Record, prior 
 		"prior_updated_at":     prior.UpdatedAtBaseline,
 		"incumbent_updated_at": rec.ModifiedAt,
 	}
-	err = database.WithWorkspaceTx(ctx, ms.pool, func(tx pgx.Tx) error {
+	err = ms.db.Tx(ctx, func(tx pgx.Tx) error {
 		// Fenced the same way every other sweep write is: a disconnect (or
 		// disconnect+reconnect) landing between reconcileOne's ingest commit
 		// and this call must not let a stray system_log/event_outbox row

--- a/backend/internal/modules/overlay/reconcile_integration_test.go
+++ b/backend/internal/modules/overlay/reconcile_integration_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/keyvault"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
 // sweptRecords is a minimal in-memory Incumbent exercising ONLY Modified
@@ -155,7 +156,7 @@ func setSyncState(ctx context.Context, pool *pgxpool.Pool, objectClass, external
 // watermark advances to the swept record's ModifiedAt.
 func TestReconcileOverwritesDivergedNonDirtyRowAndEmitsConflict(t *testing.T) {
 	ctx, pool, ws := testWorkspaceCtx(t)
-	ms := NewMirrorStore(pool, noOwnerEmails{})
+	ms := NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), noOwnerEmails{})
 
 	const objectClass = "organization"
 	const externalID = "61655665850"
@@ -227,8 +228,8 @@ func TestReconcileOverwritesDivergedNonDirtyRowAndEmitsConflict(t *testing.T) {
 func TestEmitMirrorConflictIsFencedAgainstADisconnectedConnection(t *testing.T) {
 	ctx, pool, ws := testWorkspaceCtx(t)
 	vault := keyvault.NewMemory()
-	store := NewMirrorStore(pool, noOwnerEmails{})
-	svc := NewService(pool, vault, store)
+	store := NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), noOwnerEmails{})
+	svc := NewService(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), vault, store)
 	conn, err := svc.Connect(ctx, ConnectInput{Incumbent: "hubspot", Region: "eu1", Token: "pat-conflict-fence-secret"})
 	if err != nil {
 		t.Fatalf("Connect: %v", err)
@@ -274,7 +275,7 @@ func TestEmitMirrorConflictIsFencedAgainstADisconnectedConnection(t *testing.T) 
 // row the sweep never actually changed.
 func TestReconcileNeverClobbersADirtyRow(t *testing.T) {
 	ctx, pool, ws := testWorkspaceCtx(t)
-	ms := NewMirrorStore(pool, noOwnerEmails{})
+	ms := NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), noOwnerEmails{})
 
 	const objectClass = "organization"
 	const externalID = "61655665851"

--- a/backend/internal/modules/overlay/reconnect.go
+++ b/backend/internal/modules/overlay/reconnect.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/keyvault"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
@@ -43,7 +42,7 @@ import (
 func (s *Service) reconnectConnection(ctx context.Context, in ConnectInput, ref keyvault.Ref, accountID string) (Connection, error) {
 	var out Connection
 	var supersededRef string
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		var id ids.UUID
 		var previousIncumbent, previousRegion string
 		// The pre-read is FOR UPDATE so a concurrent reconnect serializes behind
@@ -125,7 +124,7 @@ func (s *Service) deleteSupersededRef(ctx context.Context, ref keyvault.Ref) {
 // Disconnect leaves so a stray in-flight sweep cannot resurrect a purged row —
 // is what a reconnect revives.
 func (s *Service) existingConnectionStatus(ctx context.Context) (status string, found bool, err error) {
-	err = database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err = s.db.Tx(ctx, func(tx pgx.Tx) error {
 		scanErr := tx.QueryRow(ctx, `
 			SELECT status FROM incumbent_connection
 			WHERE workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid`).Scan(&status)

--- a/backend/internal/modules/overlay/syncbackoff.go
+++ b/backend/internal/modules/overlay/syncbackoff.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 )
@@ -84,7 +83,7 @@ func sweepBackoffDelay(consecutiveFailures int) time.Duration {
 // sweep is due immediately and the failure ladder is cleared. One clean
 // sweep heals a backed-off connection.
 func (s *MirrorStore) RecordSweepSuccess(ctx context.Context, now time.Time) error {
-	return database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	return s.db.Tx(ctx, func(tx pgx.Tx) error {
 		if err := s.assertFence(ctx, tx); err != nil {
 			return err
 		}
@@ -109,7 +108,7 @@ func (s *MirrorStore) RecordSweepSuccess(ctx context.Context, now time.Time) err
 // only the worker role holds. Clearing the ladder is deliberate — an operator
 // asking for a sweep is overriding the backoff the last failure imposed.
 func (s *MirrorStore) RequestSweep(ctx context.Context) error {
-	return database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	return s.db.Tx(ctx, func(tx pgx.Tx) error {
 		if err := s.assertFence(ctx, tx); err != nil {
 			return err
 		}
@@ -134,7 +133,7 @@ func (s *MirrorStore) RequestSweep(ctx context.Context) error {
 // detail is logged to system_log; the sidecar row carries only the class.
 func (s *MirrorStore) RecordSweepFailure(ctx context.Context, sweepErr error, now time.Time) error {
 	class := classifySweepError(sweepErr)
-	return database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	return s.db.Tx(ctx, func(tx pgx.Tx) error {
 		if err := s.assertFence(ctx, tx); err != nil {
 			return err
 		}

--- a/backend/internal/modules/overlay/syncbackoff_integration_test.go
+++ b/backend/internal/modules/overlay/syncbackoff_integration_test.go
@@ -50,8 +50,8 @@ func isDue(ctx context.Context, t *testing.T, pool *pgxpool.Pool, ws ids.UUID) b
 func TestSweepBackoffGatesDueOverlayConnections(t *testing.T) {
 	ctx, pool, ws := testWorkspaceCtx(t)
 	vault := keyvault.NewMemory()
-	store := NewMirrorStore(pool, noOwnerEmails{})
-	if _, err := NewService(pool, vault, store).
+	store := NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), noOwnerEmails{})
+	if _, err := NewService(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), vault, store).
 		Connect(ctx, ConnectInput{Incumbent: "hubspot", Region: "eu1", Token: "tok"}); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
@@ -82,8 +82,8 @@ func TestSweepBackoffGatesDueOverlayConnections(t *testing.T) {
 func TestRequestSweepMakesTheWorkspaceDueNow(t *testing.T) {
 	ctx, pool, ws := testWorkspaceCtx(t)
 	vault := keyvault.NewMemory()
-	store := NewMirrorStore(pool, noOwnerEmails{})
-	if _, err := NewService(pool, vault, store).
+	store := NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), noOwnerEmails{})
+	if _, err := NewService(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), vault, store).
 		Connect(ctx, ConnectInput{Incumbent: "hubspot", Region: "eu1", Token: "tok"}); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
@@ -106,10 +106,10 @@ func TestRequestSweepMakesTheWorkspaceDueNow(t *testing.T) {
 // A disconnected workspace's sync state stays a never-connected one's: a
 // request racing a teardown must not repopulate what the purge removed.
 func TestRequestSweepIsRefusedAfterDisconnect(t *testing.T) {
-	ctx, pool, _ := testWorkspaceCtx(t)
+	ctx, pool, ws := testWorkspaceCtx(t)
 	vault := keyvault.NewMemory()
-	store := NewMirrorStore(pool, noOwnerEmails{})
-	svc := NewService(pool, vault, store)
+	store := NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), noOwnerEmails{})
+	svc := NewService(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), vault, store)
 	if _, err := svc.Connect(ctx, ConnectInput{Incumbent: "hubspot", Region: "eu1", Token: "tok"}); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
@@ -150,7 +150,7 @@ func TestRequestSweepObjectRBACDeniesReadOnlyAllowsAdmin(t *testing.T) {
 	_, memberUserID := testWorkspaceCtxAsUser(t, ws, "sweep-member@overlay.test")
 	memberCtx := testMemberCtx(ws, memberUserID)
 	vault := keyvault.NewMemory()
-	svc := NewService(pool, vault, NewMirrorStore(pool, noOwnerEmails{}))
+	svc := NewService(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), vault, NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), noOwnerEmails{}))
 
 	if _, err := svc.Connect(adminCtx, ConnectInput{Incumbent: "hubspot", Region: "eu1", Token: "tok"}); err != nil {
 		t.Fatalf("Connect: %v", err)

--- a/backend/internal/modules/overlay/syncstatus.go
+++ b/backend/internal/modules/overlay/syncstatus.go
@@ -81,7 +81,7 @@ func (s *Service) resolveOverlayMode(ctx context.Context) (incumbent string, err
 		return "", errors.New("overlay: sync-status/budget/reconcile called outside a workspace context")
 	}
 	var mode string
-	err = database.WithInfraTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err = database.WithInfraTx(ctx, s.db.Pool(), func(tx pgx.Tx) error {
 		return tx.QueryRow(ctx,
 			`SELECT x_sor_mode, coalesce(x_incumbent, '') FROM workspace WHERE id = $1`, wsID,
 		).Scan(&mode, &incumbent)
@@ -127,7 +127,7 @@ func (s *Service) SyncStatus(ctx context.Context) ([]ObjectSyncStatus, error) {
 	}
 
 	var out []ObjectSyncStatus
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		// Drain the aggregate query FULLY before running any further query
 		// on this same tx — pgx ties the connection up while a Rows result
 		// is still open, so calling backfillCompleteFor's own tx.QueryRow

--- a/backend/internal/modules/overlay/syncstatus_integration_test.go
+++ b/backend/internal/modules/overlay/syncstatus_integration_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/platform/keyvault"
 	"github.com/gradionhq/margince/backend/internal/platform/overlaybudget"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
 // TestBackfillCompleteForRequiresEveryEngagementClass proves the plural
@@ -30,9 +31,9 @@ import (
 // engagement classes, so its backfill is complete ONLY when every one of the
 // five cursors has converged — a single lagging class keeps it incomplete.
 func TestBackfillCompleteForRequiresEveryEngagementClass(t *testing.T) {
-	ctx, pool, _ := testWorkspaceCtx(t)
-	store := NewMirrorStore(pool, noOwnerEmails{})
-	svc := NewService(pool, keyvault.NewMemory(), store).
+	ctx, pool, ws := testWorkspaceCtx(t)
+	store := NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), noOwnerEmails{})
+	svc := NewService(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), keyvault.NewMemory(), store).
 		WithIncumbentClassesTranslator(func(canonical string) ([]string, bool) {
 			if canonical == "activity" {
 				return []string{"calls", "meetings", "emails", "notes", "tasks"}, true
@@ -78,8 +79,8 @@ func TestBackfillCompleteForRequiresEveryEngagementClass(t *testing.T) {
 }
 
 func TestSyncStatusAndBudgetRefuseANativeModeWorkspace(t *testing.T) {
-	ctx, pool, _ := testWorkspaceCtx(t) // never flips to overlay mode
-	svc := NewService(pool, keyvault.NewMemory(), NewMirrorStore(pool, noOwnerEmails{})).
+	ctx, pool, ws := testWorkspaceCtx(t) // never flips to overlay mode
+	svc := NewService(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), keyvault.NewMemory(), NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), noOwnerEmails{})).
 		WithBudgetMeter(overlaybudget.New(nil, nil))
 
 	if _, err := svc.SyncStatus(ctx); !errors.Is(err, apperrors.ErrModeNotOverlay) {
@@ -91,8 +92,8 @@ func TestSyncStatusAndBudgetRefuseANativeModeWorkspace(t *testing.T) {
 }
 
 func TestBudgetAnswersAWiringErrorWithNoMeterConfigured(t *testing.T) {
-	ctx, pool, _ := testWorkspaceCtx(t)
-	svc := NewService(pool, keyvault.NewMemory(), NewMirrorStore(pool, noOwnerEmails{})) // no WithBudgetMeter
+	ctx, pool, ws := testWorkspaceCtx(t)
+	svc := NewService(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), keyvault.NewMemory(), NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), noOwnerEmails{})) // no WithBudgetMeter
 
 	if _, err := svc.Connect(ctx, ConnectInput{Incumbent: "hubspot", Region: "eu1", Token: "pat-token"}); err != nil {
 		t.Fatalf("Connect: %v", err)

--- a/backend/internal/modules/overlay/teardown.go
+++ b/backend/internal/modules/overlay/teardown.go
@@ -39,7 +39,6 @@ import (
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/platform/keyvault"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
@@ -70,7 +69,7 @@ func (s *Service) Disconnect(ctx context.Context) error {
 	}
 
 	var ref string
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		// A flip RUN in flight is the one thing disconnect must not race:
 		// tearing the mirror down mid-import would migrate a vanishing
 		// estate. A merely SEALED snapshot is NOT enough to refuse on —

--- a/backend/internal/modules/overlay/teardown_integration_test.go
+++ b/backend/internal/modules/overlay/teardown_integration_test.go
@@ -34,8 +34,8 @@ import (
 func TestDisconnectPurgesTheMirrorTombstonesAndRetainsTheConnectionAudit(t *testing.T) {
 	ctx, pool, ws := testWorkspaceCtx(t)
 	vault := keyvault.NewMemory()
-	store := NewMirrorStore(pool, noOwnerEmails{})
-	svc := NewService(pool, vault, store)
+	store := NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), noOwnerEmails{})
+	svc := NewService(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), vault, store)
 
 	const token = "pat-teardown-secret"
 	if _, err := svc.Connect(ctx, ConnectInput{Incumbent: "hubspot", Region: "eu1", Token: token}); err != nil {
@@ -304,8 +304,8 @@ func assertAuditTrailRetained(ctx context.Context, t *testing.T, pool *pgxpool.P
 func TestFencedSyncWritesAbortOnceTheConnectionIsRevoked(t *testing.T) {
 	ctx, pool, ws := testWorkspaceCtx(t)
 	vault := keyvault.NewMemory()
-	store := NewMirrorStore(pool, noOwnerEmails{})
-	svc := NewService(pool, vault, store)
+	store := NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), noOwnerEmails{})
+	svc := NewService(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), vault, store)
 	conn, err := svc.Connect(ctx, ConnectInput{Incumbent: "hubspot", Region: "eu1", Token: "pat-fence-secret"})
 	if err != nil {
 		t.Fatalf("Connect: %v", err)
@@ -460,10 +460,10 @@ func TestFencedSyncWritesAbortOnceTheConnectionIsRevoked(t *testing.T) {
 // misconfigured store re-sweep hot forever instead of pacing off on a real,
 // loud failure.
 func TestIdentityFenceFailsClosedOnZeroConnectedAt(t *testing.T) {
-	ctx, pool, _ := testWorkspaceCtx(t)
+	ctx, pool, ws := testWorkspaceCtx(t)
 	vault := keyvault.NewMemory()
-	store := NewMirrorStore(pool, noOwnerEmails{})
-	svc := NewService(pool, vault, store)
+	store := NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), noOwnerEmails{})
+	svc := NewService(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), vault, store)
 	if _, err := svc.Connect(ctx, ConnectInput{Incumbent: "hubspot", Region: "eu1", Token: "pat-misconfig-secret"}); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
@@ -503,13 +503,13 @@ func (v deleteFailingVault) Delete(context.Context, ids.WorkspaceID, keyvault.Re
 func TestDisconnectCommitsEvenWhenVaultDeleteFails(t *testing.T) {
 	ctx, pool, ws := testWorkspaceCtx(t)
 	vault := deleteFailingVault{Vault: keyvault.NewMemory(), err: errors.New("vault unreachable")}
-	store := NewMirrorStore(pool, noOwnerEmails{})
+	store := NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), noOwnerEmails{})
 	// Capture ERROR logs: the cleanup ERROR is the ONLY recovery signal for
 	// the orphaned blob while a durable retry is deferred, so the test must
 	// verify it fires with the attributes ops needs (level ERROR filters out
 	// Connect's best-effort WARN seeding, leaving just the cleanup record).
 	var logbuf bytes.Buffer
-	svc := NewService(pool, vault, store).
+	svc := NewService(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), vault, store).
 		WithLogger(slog.New(slog.NewTextHandler(&logbuf, &slog.HandlerOptions{Level: slog.LevelError})))
 
 	if _, err := svc.Connect(ctx, ConnectInput{Incumbent: "hubspot", Region: "eu1", Token: "pat-a5b"}); err != nil {
@@ -553,9 +553,9 @@ func TestDisconnectCommitsEvenWhenVaultDeleteFails(t *testing.T) {
 }
 
 func TestDisconnectWithNoActiveConnectionAnswersNotFound(t *testing.T) {
-	ctx, pool, _ := testWorkspaceCtx(t)
+	ctx, pool, ws := testWorkspaceCtx(t)
 	vault := keyvault.NewMemory()
-	svc := NewService(pool, vault, NewMirrorStore(pool, noOwnerEmails{}))
+	svc := NewService(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), vault, NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), noOwnerEmails{}))
 
 	if err := svc.Disconnect(ctx); !errors.Is(err, apperrors.ErrNotFound) {
 		t.Errorf("Disconnect with no connection = %v, want apperrors.ErrNotFound", err)
@@ -616,8 +616,8 @@ func (c *countingIncumbent) Backfill(ctx context.Context, objectClass, cursor st
 func TestDisconnectResetsSyncCheckpointsSoAFreshBackfillRelistsFromTheStart(t *testing.T) {
 	ctx, pool, ws := testWorkspaceCtx(t)
 	vault := keyvault.NewMemory()
-	store := NewMirrorStore(pool, noOwnerEmails{})
-	svc := NewService(pool, vault, store)
+	store := NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), noOwnerEmails{})
+	svc := NewService(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), vault, store)
 
 	if _, err := svc.Connect(ctx, ConnectInput{Incumbent: "hubspot", Region: "eu1", Token: "pat-reset-secret"}); err != nil {
 		t.Fatalf("Connect: %v", err)
@@ -703,8 +703,8 @@ func TestDisconnectResetsSyncCheckpointsSoAFreshBackfillRelistsFromTheStart(t *t
 func TestDisconnectPurgesTheAutomapBlocks(t *testing.T) {
 	ctx, pool, ws := testWorkspaceCtx(t)
 	vault := keyvault.NewMemory()
-	store := NewMirrorStore(pool, noOwnerEmails{})
-	svc := NewService(pool, vault, store)
+	store := NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), noOwnerEmails{})
+	svc := NewService(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), vault, store)
 
 	if _, err := svc.Connect(ctx, ConnectInput{Incumbent: "hubspot", Region: "eu1", Token: "pat-automap-block-secret"}); err != nil {
 		t.Fatalf("Connect: %v", err)

--- a/backend/internal/modules/overlay/usermapadmin.go
+++ b/backend/internal/modules/overlay/usermapadmin.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
@@ -175,7 +174,7 @@ func (s *MirrorStore) ListUserMap(ctx context.Context, incumbent, cursor string,
 	}
 
 	var entries []UserMapEntry
-	err = database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err = s.db.Tx(ctx, func(tx pgx.Tx) error {
 		rows, err := tx.Query(ctx, listUserMapSQL, incumbent, afterID, limit)
 		if err != nil {
 			return fmt.Errorf("overlay: listing the user map for %s: %w", incumbent, err)
@@ -263,7 +262,7 @@ func automapTargetIsGrantable(ctx context.Context, tx pgx.Tx, appUser ids.UserID
 // in the SAME transaction as the write (upsertUserMapTx), so the seat cannot
 // change state between the decision and the row it authorizes.
 func (s *MirrorStore) SetManualUserMap(ctx context.Context, appUser ids.UserID, incumbent, incumbentUserID string) error {
-	return database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	return s.db.Tx(ctx, func(tx pgx.Tx) error {
 		grantable, err := resolveUserMapTarget(ctx, tx, appUser)
 		if err != nil {
 			return err
@@ -300,7 +299,7 @@ func (s *MirrorStore) BlockAutoMap(ctx context.Context, appUser ids.UserID, incu
 	if !ok {
 		return errors.New("overlay: no principal bound to context")
 	}
-	return database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	return s.db.Tx(ctx, func(tx pgx.Tx) error {
 		// Fence before the visibility lock — the order every other visibility
 		// mutator takes (UpsertUserMap, ingestTx, RecomputeForOwner), so no two
 		// fenced writers can deadlock by acquiring the two in opposite orders

--- a/backend/internal/modules/overlay/usermapadmin_integration_test.go
+++ b/backend/internal/modules/overlay/usermapadmin_integration_test.go
@@ -28,7 +28,7 @@ import (
 // the upsert statement itself, which is what this test pins.
 func TestBlockCommittedAfterCandidateSelectionStillStopsTheMapping(t *testing.T) {
 	ctx, pool, ws := testWorkspaceCtx(t)
-	store := NewMirrorStore(pool, stubOwnerEmails{"owner-1": "rep@acme.test"})
+	store := NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), stubOwnerEmails{"owner-1": "rep@acme.test"})
 	_, repRaw := testWorkspaceCtxAsUser(t, ws, "rep@acme.test")
 	rep := ids.From[ids.UserKind](repRaw)
 
@@ -69,7 +69,7 @@ func TestBlockCommittedAfterCandidateSelectionStillStopsTheMapping(t *testing.T)
 // and blocked at once.
 func TestManualMapClearsTheBlockAndWrites(t *testing.T) {
 	ctx, pool, ws := testWorkspaceCtx(t)
-	store := NewMirrorStore(pool, stubOwnerEmails{"owner-1": "rep@acme.test"})
+	store := NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), stubOwnerEmails{"owner-1": "rep@acme.test"})
 	_, repRaw := testWorkspaceCtxAsUser(t, ws, "rep@acme.test")
 	rep := ids.From[ids.UserKind](repRaw)
 
@@ -103,7 +103,7 @@ func TestManualMapClearsTheBlockAndWrites(t *testing.T) {
 // to run through recomputeForOwnerTx.
 func TestBlockAutoMapRevokesTheVisibilityGrants(t *testing.T) {
 	ctx, pool, ws := testWorkspaceCtx(t)
-	store := NewMirrorStore(pool, stubOwnerEmails{"owner-1": "rep@acme.test"})
+	store := NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), stubOwnerEmails{"owner-1": "rep@acme.test"})
 	repCtx, repRaw := testWorkspaceCtxAsUser(t, ws, "rep@acme.test")
 	rep := ids.From[ids.UserKind](repRaw)
 
@@ -139,7 +139,7 @@ func TestBlockAutoMapRevokesTheVisibilityGrants(t *testing.T) {
 // admin's decision, so a retry or a double-click is not an error.
 func TestBlockAutoMapOnAnUnmappedUserIsIdempotent(t *testing.T) {
 	ctx, pool, ws := testWorkspaceCtx(t)
-	store := NewMirrorStore(pool, stubOwnerEmails{"owner-1": "rep@acme.test"})
+	store := NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), stubOwnerEmails{"owner-1": "rep@acme.test"})
 	_, repRaw := testWorkspaceCtxAsUser(t, ws, "rep@acme.test")
 	rep := ids.From[ids.UserKind](repRaw)
 
@@ -164,7 +164,7 @@ func TestBlockAutoMapOnAnUnmappedUserIsIdempotent(t *testing.T) {
 // mapping (they are the ones an admin has to act on) and mark blocked ones.
 func TestListUserMapIncludesUnmappedAndBlockedUsers(t *testing.T) {
 	ctx, pool, ws := testWorkspaceCtx(t)
-	store := NewMirrorStore(pool, stubOwnerEmails{"owner-1": "mapped@acme.test"})
+	store := NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), stubOwnerEmails{"owner-1": "mapped@acme.test"})
 	_, mappedRaw := testWorkspaceCtxAsUser(t, ws, "mapped@acme.test")
 	mapped := ids.From[ids.UserKind](mappedRaw)
 	_, unmappedRaw := testWorkspaceCtxAsUser(t, ws, "unmapped@acme.test")
@@ -206,7 +206,7 @@ func TestListUserMapIncludesUnmappedAndBlockedUsers(t *testing.T) {
 // grant mirror visibility to something that should not have it.
 func TestListUserMapExcludesAgentAndArchivedUsers(t *testing.T) {
 	ctx, pool, ws := testWorkspaceCtx(t)
-	store := NewMirrorStore(pool, noOwnerEmails{})
+	store := NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), noOwnerEmails{})
 	_, humanRaw := testWorkspaceCtxAsUser(t, ws, "human@acme.test")
 	human := ids.From[ids.UserKind](humanRaw)
 	agent := seedAgentUser(t, ws, "agent@acme.test")
@@ -234,8 +234,8 @@ func TestListUserMapExcludesAgentAndArchivedUsers(t *testing.T) {
 // The composite FK, not RLS, is what must reject this: RLS would merely hide
 // the other workspace's user, leaving a block row that references nothing.
 func TestBlockAutoMapCannotTargetAnotherWorkspacesUser(t *testing.T) {
-	ctx, pool, _ := testWorkspaceCtx(t)
-	store := NewMirrorStore(pool, noOwnerEmails{})
+	ctx, pool, ws := testWorkspaceCtx(t)
+	store := NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), noOwnerEmails{})
 	foreign := seedUserInOtherWorkspace(t, "elsewhere@other.test")
 
 	if err := store.BlockAutoMap(ctx, foreign, "hubspot"); !errors.Is(err, apperrors.ErrNotFound) {
@@ -247,8 +247,8 @@ func TestBlockAutoMapCannotTargetAnotherWorkspacesUser(t *testing.T) {
 // row-scope miss on the GRANT path too — 404, not the 500 an unhandled
 // foreign-key violation would produce.
 func TestSetManualUserMapCannotTargetAnotherWorkspacesUser(t *testing.T) {
-	ctx, pool, _ := testWorkspaceCtx(t)
-	store := NewMirrorStore(pool, noOwnerEmails{})
+	ctx, pool, ws := testWorkspaceCtx(t)
+	store := NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), noOwnerEmails{})
 	foreign := seedUserInOtherWorkspace(t, "elsewhere-manual@other.test")
 
 	if err := store.SetManualUserMap(ctx, foreign, "hubspot", "owner-1"); !errors.Is(err, apperrors.ErrNotFound) {
@@ -261,7 +261,7 @@ func TestSetManualUserMapCannotTargetAnotherWorkspacesUser(t *testing.T) {
 // exactly the identities the list refuses to offer.
 func TestSetManualUserMapRefusesAgentAndArchivedUsers(t *testing.T) {
 	ctx, pool, ws := testWorkspaceCtx(t)
-	store := NewMirrorStore(pool, noOwnerEmails{})
+	store := NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), noOwnerEmails{})
 	agent := seedAgentUser(t, ws, "agent@acme.test")
 	archived := seedArchivedUser(t, ws, "gone@acme.test")
 
@@ -289,7 +289,7 @@ func TestSetManualUserMapRefusesAgentAndArchivedUsers(t *testing.T) {
 // not be turned away.
 func TestBlockAutoMapStillUnmapsAnArchivedUser(t *testing.T) {
 	ctx, pool, ws := testWorkspaceCtx(t)
-	store := NewMirrorStore(pool, stubOwnerEmails{"owner-1": "rep@acme.test"})
+	store := NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), stubOwnerEmails{"owner-1": "rep@acme.test"})
 	_, repRaw := testWorkspaceCtxAsUser(t, ws, "rep@acme.test")
 	rep := ids.From[ids.UserKind](repRaw)
 
@@ -323,7 +323,7 @@ func TestBlockAutoMapStillUnmapsAnArchivedUser(t *testing.T) {
 // one seat that stopped being grantable must not abort the rest of the sweep.
 func TestEmailSourcedMappingSkipsASeatArchivedAfterTheCandidateRead(t *testing.T) {
 	ctx, pool, ws := testWorkspaceCtx(t)
-	store := NewMirrorStore(pool, stubOwnerEmails{"owner-1": "rep@acme.test"})
+	store := NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), stubOwnerEmails{"owner-1": "rep@acme.test"})
 	_, repRaw := testWorkspaceCtxAsUser(t, ws, "rep@acme.test")
 	rep := ids.From[ids.UserKind](repRaw)
 
@@ -344,8 +344,8 @@ func TestEmailSourcedMappingSkipsASeatArchivedAfterTheCandidateRead(t *testing.T
 // there is nothing to map, and that is a row to pass over rather than a fault
 // that ends the pass.
 func TestEmailSourcedMappingSkipsACandidateTheWorkspaceNoLongerHas(t *testing.T) {
-	ctx, pool, _ := testWorkspaceCtx(t)
-	store := NewMirrorStore(pool, stubOwnerEmails{"owner-1": "gone@other.test"})
+	ctx, pool, ws := testWorkspaceCtx(t)
+	store := NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), stubOwnerEmails{"owner-1": "gone@other.test"})
 	foreign := seedUserInOtherWorkspace(t, "gone@other.test")
 
 	if err := store.UpsertUserMap(ctx, foreign, "hubspot", "owner-1", "email"); err != nil {

--- a/backend/internal/modules/overlay/usermapaudit_integration_test.go
+++ b/backend/internal/modules/overlay/usermapaudit_integration_test.go
@@ -50,7 +50,7 @@ func countAutoMapBlockAudits(ctx context.Context, t *testing.T, pool *pgxpool.Po
 // has no answer at all once a disconnect purges the block's own blocked_by.
 func TestBlockingAnAlreadyUnmappedUserIsAudited(t *testing.T) {
 	ctx, pool, ws := testWorkspaceCtx(t)
-	store := NewMirrorStore(pool, noOwnerEmails{})
+	store := NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), noOwnerEmails{})
 	_, repRaw := testWorkspaceCtxAsUser(t, ws, "rep@acme.test")
 	rep := ids.From[ids.UserKind](repRaw)
 
@@ -72,7 +72,7 @@ func TestBlockingAnAlreadyUnmappedUserIsAudited(t *testing.T) {
 // would record a decision the admin took once as one they took twice.
 func TestRepeatingTheBlockWritesNoSecondAudit(t *testing.T) {
 	ctx, pool, ws := testWorkspaceCtx(t)
-	store := NewMirrorStore(pool, noOwnerEmails{})
+	store := NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), noOwnerEmails{})
 	_, repRaw := testWorkspaceCtxAsUser(t, ws, "rep@acme.test")
 	rep := ids.From[ids.UserKind](repRaw)
 
@@ -92,7 +92,7 @@ func TestRepeatingTheBlockWritesNoSecondAudit(t *testing.T) {
 // never be mapped again.
 func TestUnmappingAMappedUserAuditsBothTheRemovalAndTheBlock(t *testing.T) {
 	ctx, pool, ws := testWorkspaceCtx(t)
-	store := NewMirrorStore(pool, stubOwnerEmails{"owner-1": "rep@acme.test"})
+	store := NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), stubOwnerEmails{"owner-1": "rep@acme.test"})
 	_, repRaw := testWorkspaceCtxAsUser(t, ws, "rep@acme.test")
 	rep := ids.From[ids.UserKind](repRaw)
 
@@ -113,7 +113,7 @@ func TestUnmappingAMappedUserAuditsBothTheRemovalAndTheBlock(t *testing.T) {
 
 func TestFirstMappingWritesACreateAudit(t *testing.T) {
 	ctx, pool, ws := testWorkspaceCtx(t)
-	store := NewMirrorStore(pool, stubOwnerEmails{"owner-1": "rep@acme.test"})
+	store := NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), stubOwnerEmails{"owner-1": "rep@acme.test"})
 	_, repRaw := testWorkspaceCtxAsUser(t, ws, "rep@acme.test")
 	rep := ids.From[ids.UserKind](repRaw)
 
@@ -130,7 +130,7 @@ func TestFirstMappingWritesACreateAudit(t *testing.T) {
 // readable evidence.
 func TestIdempotentReseedWritesNoAudit(t *testing.T) {
 	ctx, pool, ws := testWorkspaceCtx(t)
-	store := NewMirrorStore(pool, stubOwnerEmails{"owner-1": "rep@acme.test"})
+	store := NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), stubOwnerEmails{"owner-1": "rep@acme.test"})
 	_, repRaw := testWorkspaceCtxAsUser(t, ws, "rep@acme.test")
 	rep := ids.From[ids.UserKind](repRaw)
 
@@ -152,7 +152,7 @@ func TestIdempotentReseedWritesNoAudit(t *testing.T) {
 // change predicate that compares only the owner id would silently miss it.
 func TestMatchSourceFlipAloneWritesAnUpdateAudit(t *testing.T) {
 	ctx, pool, ws := testWorkspaceCtx(t)
-	store := NewMirrorStore(pool, stubOwnerEmails{"owner-1": "rep@acme.test"})
+	store := NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), stubOwnerEmails{"owner-1": "rep@acme.test"})
 	_, repRaw := testWorkspaceCtxAsUser(t, ws, "rep@acme.test")
 	rep := ids.From[ids.UserKind](repRaw)
 
@@ -173,7 +173,7 @@ func TestMatchSourceFlipAloneWritesAnUpdateAudit(t *testing.T) {
 func TestRevalidationRevokeIsAudited(t *testing.T) {
 	ctx, pool, ws := testWorkspaceCtx(t)
 	emails := stubOwnerEmails{"owner-1": "rep@acme.test"}
-	store := NewMirrorStore(pool, emails)
+	store := NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), emails)
 	_, repRaw := testWorkspaceCtxAsUser(t, ws, "rep@acme.test")
 	rep := ids.From[ids.UserKind](repRaw)
 
@@ -197,7 +197,7 @@ func TestRevalidationRevokeIsAudited(t *testing.T) {
 // That revoke is audited for the same reason.
 func TestAmbiguityRevokeIsAudited(t *testing.T) {
 	ctx, pool, ws := testWorkspaceCtx(t)
-	store := NewMirrorStore(pool, stubOwnerEmails{"owner-1": "rep@acme.test"})
+	store := NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), stubOwnerEmails{"owner-1": "rep@acme.test"})
 	_, repRaw := testWorkspaceCtxAsUser(t, ws, "rep@acme.test")
 	rep := ids.From[ids.UserKind](repRaw)
 

--- a/backend/internal/modules/overlay/usermapseed.go
+++ b/backend/internal/modules/overlay/usermapseed.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
@@ -158,7 +157,7 @@ func ambiguousOwnerIDs(ownersByEmail ownerIDsByEmail) []string {
 // one.
 func (s *MirrorStore) revokeEmailMappingsForOwners(ctx context.Context, incumbent string, ownerIDs []string) error {
 	seen := make(map[string]bool, len(ownerIDs))
-	return database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	return s.db.Tx(ctx, func(tx pgx.Tx) error {
 		// Fence BEFORE the visibility lock — the same order every other
 		// fenced visibility mutator takes (UpsertUserMap, ingestTx), so a
 		// doomed transaction (the connection is already gone) never holds
@@ -231,7 +230,7 @@ func (s *MirrorStore) revokeEmailMappingsForOwners(ctx context.Context, incumben
 // read better apart, so a change to either belongs in both.
 func (s *MirrorStore) usersMatchingEmail(ctx context.Context, email, incumbent string) ([]ids.UserID, error) {
 	var users []ids.UserID
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		rows, err := tx.Query(ctx, `
 			SELECT u.id FROM app_user u
 			WHERE lower(trim(u.email)) = lower(trim($1))

--- a/backend/internal/modules/overlay/usermapseed_integration_test.go
+++ b/backend/internal/modules/overlay/usermapseed_integration_test.go
@@ -95,8 +95,8 @@ func (seedIncumbent) Archive(context.Context, string, string, time.Time) error {
 func TestConnectSeedsUserMapFromTheOwnersDirectory(t *testing.T) {
 	ctx, pool, ws := testWorkspaceCtx(t)
 	vault := keyvault.NewMemory()
-	store := NewMirrorStore(pool, noOwnerEmails{})
-	svc := NewService(pool, vault, store).
+	store := NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), noOwnerEmails{})
+	svc := NewService(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), vault, store).
 		WithIncumbentFactory(func(_, _ string) Incumbent {
 			return seedIncumbent{owners: map[string]string{"owner-alice": "alice@example.com"}}
 		})
@@ -141,7 +141,7 @@ func TestSeedUserMapMatchesOwnersToUsersByEmail(t *testing.T) {
 	// The store's resolver mirrors the directory it will be seeded from:
 	// UpsertUserMap re-verifies each proposed pairing against the
 	// incumbent's current owner email, so the two must agree.
-	store := NewMirrorStore(pool, stubOwnerEmails{
+	store := NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), stubOwnerEmails{
 		"owner-alice": "alice@example.com",
 		"owner-carol": "carol@example.com",
 	})
@@ -200,7 +200,7 @@ func TestSeedUserMapMatchesOwnersToUsersByEmail(t *testing.T) {
 // (which would revoke owner-X's records the escape hatch exists to grant).
 func TestSeedUserMapNeverOverwritesAManualMapping(t *testing.T) {
 	ctx, pool, ws := testWorkspaceCtx(t)
-	store := NewMirrorStore(pool, stubOwnerEmails{
+	store := NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), stubOwnerEmails{
 		"owner-x": "someone-else@example.com",
 		"owner-y": "alice@example.com",
 	})
@@ -247,7 +247,7 @@ func TestSeedUserMapNeverOverwritesAManualMapping(t *testing.T) {
 // re-seed is not enough; the pre-existing row must be revoked.
 func TestSeedUserMapRevokesAMappingThatBecameAmbiguous(t *testing.T) {
 	ctx, pool, ws := testWorkspaceCtx(t)
-	store := NewMirrorStore(pool, stubOwnerEmails{"owner-p": "bob@example.com"})
+	store := NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), stubOwnerEmails{"owner-p": "bob@example.com"})
 	ctxBob, _ := testWorkspaceCtxAsUser(t, ws, "bob@example.com")
 
 	const objectClass, external = "contact", "ext-owned-by-p"
@@ -286,7 +286,7 @@ func TestSeedUserMapRevokesAMappingThatBecameAmbiguous(t *testing.T) {
 // misread as two owners sharing the email and revoked/withheld.
 func TestSeedUserMapTreatsADuplicateOwnerListingAsOneOwner(t *testing.T) {
 	ctx, pool, ws := testWorkspaceCtx(t)
-	store := NewMirrorStore(pool, stubOwnerEmails{"owner-p": "bob@example.com"})
+	store := NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), stubOwnerEmails{"owner-p": "bob@example.com"})
 	ctxBob, _ := testWorkspaceCtxAsUser(t, ws, "bob@example.com")
 
 	const objectClass, external = "contact", "ext-owned-by-p"
@@ -315,7 +315,7 @@ func TestSeedUserMapTreatsADuplicateOwnerListingAsOneOwner(t *testing.T) {
 // rather than a nondeterministic remap to whichever owner listed last.
 func TestSeedUserMapSkipsAmbiguousEmail(t *testing.T) {
 	ctx, pool, ws := testWorkspaceCtx(t)
-	store := NewMirrorStore(pool, stubOwnerEmails{
+	store := NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), stubOwnerEmails{
 		"owner-p": "bob@example.com",
 		"owner-q": "bob@example.com",
 	})
@@ -352,7 +352,7 @@ func TestSeedUserMapSkipsAmbiguousEmail(t *testing.T) {
 // address, so the fixture gives each its own matching owner.
 func TestSeedUserMapSkipsAgentAndArchivedUsers(t *testing.T) {
 	ctx, pool, ws := testWorkspaceCtx(t)
-	store := NewMirrorStore(pool, stubOwnerEmails{
+	store := NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), stubOwnerEmails{
 		"owner-human":    "human@acme.test",
 		"owner-agent":    "agent@acme.test",
 		"owner-archived": "gone@acme.test",

--- a/backend/internal/modules/overlay/usermapservice.go
+++ b/backend/internal/modules/overlay/usermapservice.go
@@ -238,7 +238,7 @@ func (s *Service) ownerDirectory(ctx context.Context, incumbent string) (OwnerDi
 	if s.incumbent == nil || s.vault == nil {
 		return OwnerDirectory{}, fmt.Errorf("overlay: no incumbent adapter is wired for this role; the %s owners directory cannot be read", incumbent)
 	}
-	conn, err := ActiveConnection(ctx, s.pool)
+	conn, err := ActiveConnection(ctx, s.db.Pool())
 	if err != nil {
 		if errors.Is(err, apperrors.ErrNotFound) {
 			// The mode gate passed and the connection is already gone: a

--- a/backend/internal/modules/overlay/usermapservice_integration_test.go
+++ b/backend/internal/modules/overlay/usermapservice_integration_test.go
@@ -50,9 +50,9 @@ func (d *directoryIncumbent) Owners(context.Context) ([]OwnerRef, error) {
 // and connects it to inc — the state every user-map operation requires, since
 // all four are refused outright in native mode. The vault round-trip the
 // connect sets up is the path ownerDirectory actually takes to reach inc.
-func connectedUserMapService(ctx context.Context, t *testing.T, pool *pgxpool.Pool, inc *directoryIncumbent) *Service {
+func connectedUserMapService(ctx context.Context, t *testing.T, db *database.DB, inc *directoryIncumbent) *Service {
 	t.Helper()
-	svc := NewService(pool, keyvault.NewMemory(), NewMirrorStore(pool, noOwnerEmails{})).
+	svc := NewService(db, keyvault.NewMemory(), NewMirrorStore(db, noOwnerEmails{})).
 		WithIncumbentFactory(func(string, string) Incumbent { return inc })
 	if _, err := svc.Connect(ctx, ConnectInput{Incumbent: "hubspot", Region: "eu1", Token: "pat-user-map"}); err != nil {
 		t.Fatalf("connecting the fixture incumbent: %v", err)
@@ -64,8 +64,9 @@ func connectedUserMapService(ctx context.Context, t *testing.T, pool *pgxpool.Po
 // /overlay cluster's own convention is a mode_not_overlay 404, never an
 // empty page that would read as "this workspace has no users to map".
 func TestUserMapSurfaceIs404InNativeMode(t *testing.T) {
-	ctx, pool, _ := testWorkspaceCtx(t)
-	svc := NewService(pool, keyvault.NewMemory(), NewMirrorStore(pool, noOwnerEmails{})).
+	ctx, pool, ws := testWorkspaceCtx(t)
+	db := database.BindTo(pool, ids.From[ids.WorkspaceKind](ws))
+	svc := NewService(db, keyvault.NewMemory(), NewMirrorStore(db, noOwnerEmails{})).
 		WithIncumbentFactory(func(string, string) Incumbent { return &directoryIncumbent{} })
 	someUser := ids.New[ids.UserKind]()
 
@@ -113,7 +114,7 @@ func disconnectUnderARequestHoldingAStaleMode(ctx context.Context, t *testing.T,
 // and revoked its connection.
 func TestSetUserMapRacingADisconnectIsRefused(t *testing.T) {
 	ctx, pool, ws := testWorkspaceCtx(t)
-	svc := connectedUserMapService(ctx, t, pool, &directoryIncumbent{
+	svc := connectedUserMapService(ctx, t, database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), &directoryIncumbent{
 		owners: []OwnerRef{{ExternalID: "owner-1", Email: "rep@acme.test"}},
 	})
 	_, repRaw := testWorkspaceCtxAsUser(t, ws, "rep@acme.test")
@@ -134,7 +135,7 @@ func TestSetUserMapRacingADisconnectIsRefused(t *testing.T) {
 // auto-map block nobody in that connection's lifetime ever set.
 func TestUnmapUserRacingADisconnectIsRefused(t *testing.T) {
 	ctx, pool, ws := testWorkspaceCtx(t)
-	svc := connectedUserMapService(ctx, t, pool, &directoryIncumbent{
+	svc := connectedUserMapService(ctx, t, database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), &directoryIncumbent{
 		owners: []OwnerRef{{ExternalID: "owner-1", Email: "rep@acme.test"}},
 	})
 	_, repRaw := testWorkspaceCtxAsUser(t, ws, "rep@acme.test")
@@ -162,7 +163,7 @@ func TestUnmapUserRacingADisconnectIsRefused(t *testing.T) {
 // closes, not a replacement for it.
 func TestUserMapSurfaceIs404AfterDisconnect(t *testing.T) {
 	ctx, pool, ws := testWorkspaceCtx(t)
-	svc := connectedUserMapService(ctx, t, pool, &directoryIncumbent{})
+	svc := connectedUserMapService(ctx, t, database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), &directoryIncumbent{})
 	_, repRaw := testWorkspaceCtxAsUser(t, ws, "rep@acme.test")
 	rep := ids.From[ids.UserKind](repRaw)
 
@@ -183,7 +184,7 @@ func TestUserMapSurfaceIs404AfterDisconnect(t *testing.T) {
 // directory — the two halves the settings card is built on.
 func TestSetUserMapPinsAManualOverrideThePageReadsBack(t *testing.T) {
 	ctx, pool, ws := testWorkspaceCtx(t)
-	svc := connectedUserMapService(ctx, t, pool, &directoryIncumbent{
+	svc := connectedUserMapService(ctx, t, database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), &directoryIncumbent{
 		owners: []OwnerRef{{ExternalID: "owner-1", Email: "ada@acme.test", Name: "Ada Lovelace"}},
 	})
 	_, repRaw := testWorkspaceCtxAsUser(t, ws, "rep@acme.test")
@@ -221,7 +222,7 @@ func TestSetUserMapPinsAManualOverrideThePageReadsBack(t *testing.T) {
 // for every other caller.
 func TestSetUserMapRefusesABlankIncumbentUserIDAndWritesNothing(t *testing.T) {
 	ctx, pool, ws := testWorkspaceCtx(t)
-	svc := connectedUserMapService(ctx, t, pool, &directoryIncumbent{})
+	svc := connectedUserMapService(ctx, t, database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), &directoryIncumbent{})
 	_, repRaw := testWorkspaceCtxAsUser(t, ws, "rep@acme.test")
 	rep := ids.From[ids.UserKind](repRaw)
 
@@ -238,7 +239,7 @@ func TestSetUserMapRefusesABlankIncumbentUserIDAndWritesNothing(t *testing.T) {
 // a fabricated diagnosis from a directory it could not read.
 func TestUserMapDegradesHonestlyWhenTheDirectoryCannotBeRead(t *testing.T) {
 	ctx, pool, ws := testWorkspaceCtx(t)
-	svc := connectedUserMapService(ctx, t, pool, &directoryIncumbent{
+	svc := connectedUserMapService(ctx, t, database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), &directoryIncumbent{
 		err: fmt.Errorf("test: the owners directory is unreachable"),
 	})
 	_, repRaw := testWorkspaceCtxAsUser(t, ws, "rep@acme.test")
@@ -285,7 +286,7 @@ func TestUserMapDegradesHonestlyWhenTheDirectoryCannotBeRead(t *testing.T) {
 // this installation no longer mirrors.
 func TestUserMapAnswers404WhenTheConnectionVanishesBeforeTheDirectoryRead(t *testing.T) {
 	ctx, pool, ws := testWorkspaceCtx(t)
-	svc := connectedUserMapService(ctx, t, pool, &directoryIncumbent{
+	svc := connectedUserMapService(ctx, t, database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), &directoryIncumbent{
 		owners: []OwnerRef{{ExternalID: "owner-1", Email: "rep@acme.test"}},
 	})
 	testWorkspaceCtxAsUser(t, ws, "rep@acme.test")
@@ -310,7 +311,7 @@ func TestUserMapDerivesNoAbsenceBasedReasonFromATruncatedDirectory(t *testing.T)
 			Email:      fmt.Sprintf("owner-%d@acme.test", i),
 		})
 	}
-	svc := connectedUserMapService(ctx, t, pool, &directoryIncumbent{owners: oversized})
+	svc := connectedUserMapService(ctx, t, database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), &directoryIncumbent{owners: oversized})
 	_, unmatchedRaw := testWorkspaceCtxAsUser(t, ws, "unmatched@acme.test")
 	unmatched := ids.From[ids.UserKind](unmatchedRaw)
 	_, pinnedRaw := testWorkspaceCtxAsUser(t, ws, "pinned@acme.test")
@@ -362,7 +363,7 @@ func TestUserMapDerivesNoAbsenceBasedReasonFromATruncatedDirectory(t *testing.T)
 // the response — and a capped list that did not say so would read as the
 // incumbent's complete directory.
 func TestOwnersCapsTheDirectoryAndReportsTheTruncation(t *testing.T) {
-	ctx, pool, _ := testWorkspaceCtx(t)
+	ctx, pool, ws := testWorkspaceCtx(t)
 	oversized := make([]OwnerRef, 0, ownerDirectoryCap+1)
 	for i := range ownerDirectoryCap + 1 {
 		oversized = append(oversized, OwnerRef{
@@ -370,7 +371,7 @@ func TestOwnersCapsTheDirectoryAndReportsTheTruncation(t *testing.T) {
 			Email:      fmt.Sprintf("owner-%d@acme.test", i),
 		})
 	}
-	svc := connectedUserMapService(ctx, t, pool, &directoryIncumbent{owners: oversized})
+	svc := connectedUserMapService(ctx, t, database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), &directoryIncumbent{owners: oversized})
 
 	dir, err := svc.Owners(ctx)
 	if err != nil {
@@ -396,7 +397,7 @@ func TestOwnersCapsTheDirectoryAndReportsTheTruncation(t *testing.T) {
 // it would keep passing against a fixture that had drifted from the policy.
 func TestUserMapRefusesAMemberAgainstTheRealWorkspace(t *testing.T) {
 	ctx, pool, ws := testWorkspaceCtx(t)
-	svc := connectedUserMapService(ctx, t, pool, &directoryIncumbent{})
+	svc := connectedUserMapService(ctx, t, database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), &directoryIncumbent{})
 	_, repRaw := testWorkspaceCtxAsUser(t, ws, "rep@acme.test")
 	memberCtx := testMemberCtx(ws, repRaw)
 

--- a/backend/internal/modules/overlay/visibility.go
+++ b/backend/internal/modules/overlay/visibility.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
@@ -196,7 +195,7 @@ func recomputeForOwnerTx(ctx context.Context, tx pgx.Tx, incumbentUserID string)
 // gets the same protection theirs already do, rather than a silent gap
 // waiting for the next straddling sweep to find.
 func (s *MirrorStore) RecomputeForOwner(ctx context.Context, incumbentUserID string) error {
-	return database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	return s.db.Tx(ctx, func(tx pgx.Tx) error {
 		if err := s.assertFence(ctx, tx); err != nil {
 			return err
 		}
@@ -229,7 +228,7 @@ func lockWorkspaceVisibility(ctx context.Context, tx pgx.Tx) error {
 	// STRICT, so a NULL workspace id would turn this into a no-op SELECT
 	// that acquires NO lock — silently bypassing the serialization every
 	// caller relies on. Failing closed on an unset GUC (this is only ever
-	// called inside database.WithWorkspaceTx, which sets it) matches how the
+	// called inside the store's bound transaction, which sets it) matches how the
 	// RLS policies fail closed on the same condition.
 	if _, err := tx.Exec(ctx,
 		`SELECT pg_advisory_xact_lock(hashtext('margince:overlay-visibility:' || current_setting('app.workspace_id'))::bigint)`); err != nil {
@@ -290,7 +289,7 @@ WHERE app_user_id = $1 AND incumbent = $2`
 // owner's records keep whatever stale can_see=true row the prior mapping
 // left behind, so a remapped user silently retains access to records they
 // should no longer see. Doing both recomputes inside ONE
-// database.WithWorkspaceTx alongside the upsert makes the whole
+// the store's bound transaction alongside the upsert makes the whole
 // remap — write + revoke-old + grant-new — atomic: a crash or error
 // partway through can never leave the mapping row and the visibility
 // projections disagreeing about who currently has access.
@@ -304,7 +303,7 @@ WHERE app_user_id = $1 AND incumbent = $2`
 // bypasses the email check entirely, because a human already vouched for
 // the mapping.
 func (s *MirrorStore) UpsertUserMap(ctx context.Context, appUser ids.UserID, incumbent, incumbentUserID, source string) error {
-	return database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	return s.db.Tx(ctx, func(tx pgx.Tx) error {
 		return s.upsertUserMapTx(ctx, tx, appUser, incumbent, incumbentUserID, source)
 	})
 }

--- a/backend/internal/modules/overlay/visibility_concurrency_integration_test.go
+++ b/backend/internal/modules/overlay/visibility_concurrency_integration_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
@@ -33,7 +34,7 @@ func TestConcurrentRemapsLeaveExactlyOneOwnerVisible(t *testing.T) {
 	ctx, pool, ws := testWorkspaceCtx(t)
 	// Both owners resolve to Bob's email, so either remap passes the
 	// UpsertUserMap email check — the honest concurrency scenario.
-	store := NewMirrorStore(pool, stubOwnerEmails{
+	store := NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), stubOwnerEmails{
 		"owner-a": "bob@example.com",
 		"owner-b": "bob@example.com",
 	})

--- a/backend/internal/modules/overlay/visibility_integration_test.go
+++ b/backend/internal/modules/overlay/visibility_integration_test.go
@@ -42,7 +42,7 @@ import (
 
 func TestVisibilityDenyJoinFourCases(t *testing.T) {
 	ctx, pool, ws := testWorkspaceCtx(t)
-	store := NewMirrorStore(pool, noOwnerEmails{})
+	store := NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), noOwnerEmails{})
 
 	actorA, ok := principal.Actor(ctx)
 	if !ok {
@@ -123,7 +123,7 @@ func TestVisibilityDenyJoinFourCases(t *testing.T) {
 // un-gated-read window ADR-0044 forbids on whichever one was skipped.
 func TestListAppliesTheSameDenyJoinAsGet(t *testing.T) {
 	ctx, pool, ws := testWorkspaceCtx(t)
-	store := NewMirrorStore(pool, noOwnerEmails{})
+	store := NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), noOwnerEmails{})
 
 	actor, _ := principal.Actor(ctx)
 	userA := ids.From[ids.UserKind](actor.UserID)
@@ -168,8 +168,8 @@ func TestListAppliesTheSameDenyJoinAsGet(t *testing.T) {
 // a record ingested before its owner is mapped stays hidden forever, with
 // no branch-1 remedy short of a full bulk refresh.
 func TestRecomputeForOwnerUnhidesAlreadyIngestedRecords(t *testing.T) {
-	ctx, pool, _ := testWorkspaceCtx(t)
-	store := NewMirrorStore(pool, noOwnerEmails{})
+	ctx, pool, ws := testWorkspaceCtx(t)
+	store := NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), noOwnerEmails{})
 
 	actor, _ := principal.Actor(ctx)
 	userA := ids.From[ids.UserKind](actor.UserID)
@@ -205,7 +205,7 @@ func TestRecomputeForOwnerUnhidesAlreadyIngestedRecords(t *testing.T) {
 // match).
 func TestUpsertUserMapAppliesThePinnedEmailRule(t *testing.T) {
 	ctx, pool, ws := testWorkspaceCtx(t)
-	store := NewMirrorStore(pool, stubOwnerEmails{"owner-alice": "alice@example.com"})
+	store := NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), stubOwnerEmails{"owner-alice": "alice@example.com"})
 
 	ctxAlice, aliceRaw := testWorkspaceCtxAsUser(t, ws, "  Alice@Example.com  ")
 	alice := ids.From[ids.UserKind](aliceRaw)
@@ -256,7 +256,7 @@ func TestUpsertUserMapAppliesThePinnedEmailRule(t *testing.T) {
 // user's email-sourced mapping is still correct.
 func TestIngestRevalidatesEmailSourcedMapOnOwnerChange(t *testing.T) {
 	ctx, pool, ws := testWorkspaceCtx(t)
-	store := NewMirrorStore(pool, stubOwnerEmails{"owner-new": "carol@example.com"})
+	store := NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), stubOwnerEmails{"owner-new": "carol@example.com"})
 
 	ctxDave, daveRaw := testWorkspaceCtxAsUser(t, ws, "dave@example.test")
 	dave := ids.From[ids.UserKind](daveRaw)
@@ -302,8 +302,8 @@ func TestIngestRevalidatesEmailSourcedMapOnOwnerChange(t *testing.T) {
 // mirrored record) since a fix that only re-clears the FIRST record found
 // would still leak.
 func TestUpsertUserMapRemapRevokesTheOldOwnersRecords(t *testing.T) {
-	ctx, pool, _ := testWorkspaceCtx(t)
-	store := NewMirrorStore(pool, noOwnerEmails{})
+	ctx, pool, ws := testWorkspaceCtx(t)
+	store := NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), noOwnerEmails{})
 
 	actor, _ := principal.Actor(ctx)
 	userA := ids.From[ids.UserKind](actor.UserID)
@@ -374,7 +374,7 @@ func TestUpsertUserMapRemapRevokesTheOldOwnersRecords(t *testing.T) {
 func TestRevalidateEmailMappingDeleteRevokesVisibility(t *testing.T) {
 	ctx, pool, ws := testWorkspaceCtx(t)
 	emails := stubOwnerEmails{"owner-z": "dana@example.com"}
-	store := NewMirrorStore(pool, emails)
+	store := NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), emails)
 
 	ctxDana, danaRaw := testWorkspaceCtxAsUser(t, ws, "dana@example.com")
 	dana := ids.From[ids.UserKind](danaRaw)
@@ -421,7 +421,7 @@ func TestRevalidateEmailMappingDeleteRevokesVisibility(t *testing.T) {
 func TestRevalidateEmailMappingsPeriodicSweepCatchesEmailChangeAlone(t *testing.T) {
 	ctx, pool, ws := testWorkspaceCtx(t)
 	emails := stubOwnerEmails{"owner-w": "erin@example.com"}
-	store := NewMirrorStore(pool, emails)
+	store := NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), emails)
 
 	ctxErin, erinRaw := testWorkspaceCtxAsUser(t, ws, "erin@example.com")
 	erin := ids.From[ids.UserKind](erinRaw)

--- a/backend/internal/modules/overlay/webhook_binding_integration_test.go
+++ b/backend/internal/modules/overlay/webhook_binding_integration_test.go
@@ -18,8 +18,10 @@ import (
 
 	"github.com/jackc/pgx/v5/pgxpool"
 
+	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/keyvault"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
 // TestWorkspaceForPortalBindsAndFailsClosed connects a workspace with a portal
@@ -27,8 +29,8 @@ import (
 // resolves to nothing (fail-closed).
 func TestWorkspaceForPortalBindsAndFailsClosed(t *testing.T) {
 	ctx, pool, ws := testWorkspaceCtx(t)
-	store := NewMirrorStore(pool, noOwnerEmails{})
-	svc := NewService(pool, keyvault.NewMemory(), store).
+	store := NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), noOwnerEmails{})
+	svc := NewService(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), keyvault.NewMemory(), store).
 		WithIncumbentFactory(func(_, _ string) Incumbent {
 			return seedIncumbent{portalID: "portal-A"}
 		})
@@ -65,8 +67,8 @@ func TestWorkspaceForPortalBindsAndFailsClosed(t *testing.T) {
 func TestWorkspaceForPortalIsFailClosedUnderAmbiguity(t *testing.T) {
 	const shared = "portal-ambiguity-test"
 	connect := func() *pgxpool.Pool {
-		ctx, pool, _ := testWorkspaceCtx(t)
-		svc := NewService(pool, keyvault.NewMemory(), NewMirrorStore(pool, noOwnerEmails{})).
+		ctx, pool, ws := testWorkspaceCtx(t)
+		svc := NewService(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), keyvault.NewMemory(), NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), noOwnerEmails{})).
 			WithIncumbentFactory(func(_, _ string) Incumbent { return seedIncumbent{portalID: shared} })
 		if _, err := svc.Connect(ctx, ConnectInput{Incumbent: "hubspot", Region: "eu1", Token: "tok"}); err != nil {
 			t.Fatalf("Connect: %v", err)

--- a/backend/internal/modules/overlay/writeaudit.go
+++ b/backend/internal/modules/overlay/writeaudit.go
@@ -37,7 +37,6 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
@@ -243,7 +242,7 @@ func (p *Provider) commitUpdateWriteBack(ctx context.Context, inc Incumbent, rec
 	}
 	ms := p.ms.WithResolver(inc).WithFence()
 	var landed bool
-	err := database.WithWorkspaceTx(ctx, ms.pool, func(tx pgx.Tx) error {
+	err := ms.db.Tx(ctx, func(tx pgx.Tx) error {
 		var ingestErr error
 		if landed, ingestErr = ms.ingestTx(ctx, tx, rec); ingestErr != nil {
 			return ingestErr
@@ -268,7 +267,7 @@ func (p *Provider) commitArchiveWriteBack(ctx context.Context, del Deletion, ref
 	}
 	ms := p.ms.WithFence()
 	var existed bool
-	err := database.WithWorkspaceTx(ctx, ms.pool, func(tx pgx.Tx) error {
+	err := ms.db.Tx(ctx, func(tx pgx.Tx) error {
 		var purgeErr error
 		if existed, purgeErr = ms.purgeRecordTx(ctx, tx, del); purgeErr != nil {
 			return purgeErr

--- a/backend/internal/modules/overlay/writeledger.go
+++ b/backend/internal/modules/overlay/writeledger.go
@@ -30,7 +30,6 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/gradionhq/margince/backend/internal/platform/database"
 )
@@ -59,15 +58,16 @@ const (
 // production) hash-collision path deterministically without a real collision;
 // the open/expiry clock itself is always the database's, never a wall clock.
 type WriteLedger struct {
-	pool   *pgxpool.Pool
+	// db binds the workspace this store runs for (ADR-0091 §9 step 3).
+	db     *database.DB
 	window time.Duration
 	hash   func(string) string
 }
 
 // NewWriteLedger builds the production ledger: SHA-256 value hashing and the
 // default 24h open window.
-func NewWriteLedger(pool *pgxpool.Pool) *WriteLedger {
-	return &WriteLedger{pool: pool, window: DefaultLedgerWindow, hash: sha256Hex}
+func NewWriteLedger(db *database.DB) *WriteLedger {
+	return &WriteLedger{db: db, window: DefaultLedgerWindow, hash: sha256Hex}
 }
 
 // sha256Hex is OVA-PARAM-4's pinned value hash: SHA-256 over the canonicalized
@@ -92,7 +92,7 @@ func (l *WriteLedger) OpenEntries(ctx context.Context, objectClass, externalID s
 	if len(props) == 0 {
 		return nil
 	}
-	return database.WithWorkspaceTx(ctx, l.pool, func(tx pgx.Tx) error {
+	return l.db.Tx(ctx, func(tx pgx.Tx) error {
 		if err := assertActiveConnection(ctx, tx); err != nil {
 			return err
 		}
@@ -125,7 +125,7 @@ func (l *WriteLedger) OpenEntries(ctx context.Context, objectClass, externalID s
 func (l *WriteLedger) Classify(ctx context.Context, objectClass, externalID, property, value string) (Classification, error) {
 	incomingHash := l.hash(value)
 	var result Classification
-	err := database.WithWorkspaceTx(ctx, l.pool, func(tx pgx.Tx) error {
+	err := l.db.Tx(ctx, func(tx pgx.Tx) error {
 		var storedValue string
 		scanErr := tx.QueryRow(ctx, `
 			SELECT value_canonical FROM overlay_write_ledger
@@ -170,7 +170,7 @@ func (l *WriteLedger) Classify(ctx context.Context, objectClass, externalID, pro
 // only reclaims space. Returns the number of rows removed.
 func (l *WriteLedger) PruneExpired(ctx context.Context) (int64, error) {
 	var removed int64
-	err := database.WithWorkspaceTx(ctx, l.pool, func(tx pgx.Tx) error {
+	err := l.db.Tx(ctx, func(tx pgx.Tx) error {
 		// pgx returns a usable (zero) CommandTag alongside an error, so reading
 		// RowsAffected before returning execErr is safe — on failure removed
 		// stays 0 and the outer guard discards it.
@@ -224,7 +224,7 @@ func haltedTx(ctx context.Context, tx pgx.Tx) (bool, error) {
 // trigger is a SHA-256 value-hash collision, which does not occur in practice.
 func (l *WriteLedger) Halted(ctx context.Context) (bool, error) {
 	var halted bool
-	err := database.WithWorkspaceTx(ctx, l.pool, func(tx pgx.Tx) error {
+	err := l.db.Tx(ctx, func(tx pgx.Tx) error {
 		var err error
 		halted, err = haltedTx(ctx, tx)
 		return err

--- a/backend/internal/modules/overlay/writeledger_integration_test.go
+++ b/backend/internal/modules/overlay/writeledger_integration_test.go
@@ -17,14 +17,17 @@ package overlay
 
 import (
 	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/platform/database"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
 // TestWriteLedgerClassifiesEchoGenuineAndWindow drives the echo, non-echo, and
 // window-boundary arms with the production SHA-256 hash.
 func TestWriteLedgerClassifiesEchoGenuineAndWindow(t *testing.T) {
-	ctx, pool, _ := testWorkspaceCtx(t)
+	ctx, pool, ws := testWorkspaceCtx(t)
 	seedActiveConnection(ctx, t, pool) // OpenEntries is disconnect-fenced
-	l := NewWriteLedger(pool)
+	l := NewWriteLedger(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)))
 
 	// The producer opened an entry for contacts/42.firstname = "Ada".
 	if err := l.OpenEntries(ctx, "contacts", "42", map[string]string{"firstname": "Ada"}); err != nil {
@@ -43,7 +46,7 @@ func TestWriteLedgerClassifiesEchoGenuineAndWindow(t *testing.T) {
 	// Window boundary (OVA-PARAM-3): a zero window means the entry — opened an
 	// instant ago against the DB clock — is already outside the strict
 	// opened_at > now()-window comparison, so the SAME value is now genuine.
-	expired := &WriteLedger{pool: pool, window: 0, hash: sha256Hex}
+	expired := &WriteLedger{db: database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), window: 0, hash: sha256Hex}
 	if err := expired.OpenEntries(ctx, "contacts", "77", map[string]string{"firstname": "Grace"}); err != nil {
 		t.Fatalf("OpenEntries (expired case): %v", err)
 	}
@@ -57,9 +60,9 @@ func TestWriteLedgerClassifiesEchoGenuineAndWindow(t *testing.T) {
 // value must not be mis-suppressed — observing the genuine change invalidates
 // our now-superseded entry.
 func TestWriteLedgerGenuineChangeInvalidatesStaleEntry(t *testing.T) {
-	ctx, pool, _ := testWorkspaceCtx(t)
+	ctx, pool, ws := testWorkspaceCtx(t)
 	seedActiveConnection(ctx, t, pool)
-	l := NewWriteLedger(pool)
+	l := NewWriteLedger(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)))
 
 	// We wrote firstname="Ada".
 	if err := l.OpenEntries(ctx, "contacts", "42", map[string]string{"firstname": "Ada"}); err != nil {
@@ -80,9 +83,9 @@ func TestWriteLedgerGenuineChangeInvalidatesStaleEntry(t *testing.T) {
 // write-back keeps BOTH entries open, so A's (delayed) echo is still recognized
 // rather than clobbered by B's entry.
 func TestWriteLedgerKeepsDistinctValuesPerProperty(t *testing.T) {
-	ctx, pool, _ := testWorkspaceCtx(t)
+	ctx, pool, ws := testWorkspaceCtx(t)
 	seedActiveConnection(ctx, t, pool)
-	l := NewWriteLedger(pool)
+	l := NewWriteLedger(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)))
 
 	if err := l.OpenEntries(ctx, "contacts", "42", map[string]string{"firstname": "Ada"}); err != nil {
 		t.Fatalf("OpenEntries A: %v", err)
@@ -103,10 +106,10 @@ func TestWriteLedgerKeepsDistinctValuesPerProperty(t *testing.T) {
 // prune at its own window, while a zero-window prune (everything expired)
 // removes it — after which the same value is a genuine change, not an echo.
 func TestWriteLedgerPruneExpired(t *testing.T) {
-	ctx, pool, _ := testWorkspaceCtx(t)
+	ctx, pool, ws := testWorkspaceCtx(t)
 	seedActiveConnection(ctx, t, pool)
 
-	l := NewWriteLedger(pool)
+	l := NewWriteLedger(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)))
 	if err := l.OpenEntries(ctx, "contacts", "42", map[string]string{"firstname": "Ada"}); err != nil {
 		t.Fatalf("OpenEntries: %v", err)
 	}
@@ -119,7 +122,7 @@ func TestWriteLedgerPruneExpired(t *testing.T) {
 	}
 
 	// A zero-window prune treats every entry as expired and reclaims it.
-	expiring := &WriteLedger{pool: pool, window: 0, hash: sha256Hex}
+	expiring := &WriteLedger{db: database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), window: 0, hash: sha256Hex}
 	if n, err := expiring.PruneExpired(ctx); err != nil || n != 1 {
 		t.Errorf("zero-window prune removed %d (err %v), want 1", n, err)
 	}
@@ -133,9 +136,9 @@ func TestWriteLedgerPruneExpired(t *testing.T) {
 // flagged and halted. A forced colliding hasher stands in for the
 // astronomically improbable real SHA-256 collision (production keeps sha256Hex).
 func TestWriteLedgerCollisionHaltsTheMirror(t *testing.T) {
-	ctx, pool, _ := testWorkspaceCtx(t)
+	ctx, pool, ws := testWorkspaceCtx(t)
 	seedActiveConnection(ctx, t, pool)
-	l := &WriteLedger{pool: pool, window: DefaultLedgerWindow, hash: func(string) string { return "COLLIDE" }}
+	l := &WriteLedger{db: database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), window: DefaultLedgerWindow, hash: func(string) string { return "COLLIDE" }}
 
 	if err := l.OpenEntries(ctx, "contacts", "42", map[string]string{"firstname": "Ada"}); err != nil {
 		t.Fatalf("OpenEntries: %v", err)


### PR DESCRIPTION
Sweep continues (ADR-0091 §9 step 3). **8 of 20 modules; 309 `WithWorkspaceTx` sites left** (from 442).

## The sharpest version of this step's hazard

The overlay reconcile is a fleet pass that held **one mirror store across every workspace it swept**. That store *writes tenant rows* — so a shared one isn't a refusal like the retention and time-scan cases were. It's a write landing in whichever workspace the handle happened to name.

It's built per pass now, from the connection's own workspace, and the fence identity rides that store rather than a shared one.

The write ledger was already constructed at its use site inside each pass, so it only needed the workspace it was already standing in.

## Fixtures

Same discovery as capture, repeated: several overlay suites take a **pool** as a parameter and re-derive the tenant per call. Where the helper builds the service under test — `flipService`, `connectedUserMapService` — it takes the **handle** now, so a suite cannot accidentally exercise two tenants through one store.

## Verification

`make check-backend` and `make craft-static` (0/0/0) green. The tenant-isolation suite is CI's word — and given what a shared mirror store could do, it is the check that matters most on this branch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bind the overlay mirror and write ledger to workspace-scoped DB handles across services, workers, webhooks, and composed surfaces to prevent cross-tenant writes. Adds `NewRegistryFor`/`NewOverlayProviderFor`; pool-based constructors delegate via `InstallationDB`.

- **Refactors**
  - `overlay.NewMirrorStore` and `overlay.NewService` now take `*database.DB`; reconcile builds a per-connection store and the fence identity rides that bound handle.
  - `overlay.NewWriteLedger` now takes `*database.DB`; refetch worker/webhook/jobs bind the workspace via `database.BindTo`/`InstallationDB` before use.
  - Composed surfaces: `compose.NewRegistryFor` and `compose.NewOverlayProviderFor` accept a pre-bound handle; pool-based `NewRegistry`/`NewOverlayProvider` delegate through `InstallationDB`. Server/routes/tool registry and webhooks now construct with `InstallationDB`.
  - Jobs/handlers stop sharing a mirror store; they construct per-workspace components.
  - Tests bind the workspace they act as (`e.DBFor(ws)`/`database.BindTo`); helpers like `flipService`/`connectedUserMapService` take a bound handle; tool-surface suite binds the workspace it flips; the existence-hiding visibility suite binds the workspace it hid rows in to avoid false not-found.
  - Reduced `WithWorkspaceTx` call sites (309 remaining).

<sup>Written for commit 3b5f531b248707169a34841066b458f0e7f33343. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/976?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace-level data isolation and transaction handling across overlay operations.
  * Increased reliability for reconciliation, synchronization, write-back, user mapping, visibility, and teardown workflows.
  * Reduced the risk of cross-workspace data access during background processing and recovery scenarios.

* **Tests**
  * Expanded integration coverage for workspace-scoped behavior across overlay features, backfills, ledgers, and service operations.
  * Validated isolation and recovery scenarios without changing expected user-facing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->