### PR TITLE
test(approvals): contention probes bounded by time, and able to see what they wait for

### DIFF
--- a/backend/internal/modules/approvals/bundle_integration_test.go
+++ b/backend/internal/modules/approvals/bundle_integration_test.go
@@ -467,24 +467,33 @@ func (e *stagingEnv) competingTx(t *testing.T) pgx.Tx {
 // connection it runs on.
 func waitForRowLockWaiter(t *testing.T, e *stagingEnv, blocker int, done <-chan struct{}) {
 	t.Helper()
-	const maxProbes = 20_000
-	for probe := 0; probe < maxProbes; probe++ {
-		var waiting bool
-		if err := e.owner.QueryRow(context.Background(),
-			`SELECT EXISTS (SELECT 1 FROM pg_stat_activity a
-			  WHERE $1 = ANY (pg_blocking_pids(a.pid)))`, blocker).Scan(&waiting); err != nil {
-			t.Fatal(err)
-		}
-		if waiting {
-			return
-		}
-		select {
-		case <-done:
-			t.Fatal("the bundle decision finished without ever blocking on the contested member — it never reached the row the competing transaction was holding, so this run proved nothing")
-		default:
-		}
-	}
-	t.Fatalf("nothing waited on backend %d within %d probes — the decision never reached the row it should have blocked on", blocker, maxProbes)
+	waitForBlockedBackend(t, done,
+		"the bundle decision finished without ever blocking on the contested member — it never reached the row the competing transaction was holding, so this run proved nothing",
+		fmt.Sprintf("nothing waited on backend %d within %s — the decision never reached the row it should have blocked on", blocker, probeBudget),
+		func(ctx context.Context) (bool, error) {
+			// The competing transaction is open ON THIS CONNECTION, so every
+			// probe below runs inside it — and pg_stat_activity's row set is
+			// materialized once per transaction and cached until that
+			// transaction ends. A decision arriving on a connection the pool
+			// dials after the first look would be missing from every later look,
+			// permanently, and this would report "the decision never reached the
+			// row" about a decision parked squarely on it. Discarding the
+			// snapshot is what keeps each probe a look at the live set.
+			//
+			// Only the row set goes stale; pg_blocking_pids is evaluated per
+			// probe and always reports the live lock manager. That is what makes
+			// the blindness intermittent instead of total: whenever the pool had
+			// a warm connection to hand, the racer pre-dated the first look and
+			// was read correctly.
+			if _, err := e.owner.Exec(ctx, `SELECT pg_stat_clear_snapshot()`); err != nil {
+				return false, err
+			}
+			var waiting bool
+			err := e.owner.QueryRow(ctx,
+				`SELECT EXISTS (SELECT 1 FROM pg_stat_activity a
+				  WHERE $1 = ANY (pg_blocking_pids(a.pid)))`, blocker).Scan(&waiting)
+			return waiting, err
+		})
 }
 
 // backendPID is the server-side backend id of the transaction on tx, which is

--- a/backend/internal/modules/approvals/lockprobe_integration_test.go
+++ b/backend/internal/modules/approvals/lockprobe_integration_test.go
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package approvals
+
+// The one way this package waits for a backend that is provably blocked. Both
+// contention suites here — the bundle decision racing a held row, the staging
+// racing a held identity lock — ask the database the same question in the same
+// shape, and they used to disagree about how to give up on it.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// probeBudget bounds the wait for a backend that never blocks.
+//
+// It is a DURATION, and it used to be a count of 20 000 probes. A count is not a
+// budget: it is a race between how fast probe round trips complete and how fast
+// the racer reaches its lock, and the lane's own concurrency slows BOTH, so a
+// count generous on an idle machine is not generous on a loaded one. A duration
+// means the same thing on every machine.
+//
+// Generous enough that only a genuine miss trips it, short enough that the miss
+// reports itself rather than running into the package timeout, where it would
+// read as a hung suite instead of a stated fact. That ceiling is arithmetic
+// rather than taste: five call sites in this package can each spend this budget,
+// against the lane's 600s per-package timeout (INTEGRATION_TIMEOUT). At 90s a run
+// in which every one of them misses spends 450s and still reports what it found.
+// Raise this number and that sum moves with it.
+const probeBudget = 90 * time.Second
+
+// probeInterval paces the poll, so the observer is not competing for the very
+// resource it is waiting on.
+//
+// Unpaced, these loops issued round trips as fast as the server would answer
+// them, and the pg_stat_activity probe's pg_blocking_pids is documented as
+// needing exclusive access to the lock manager's shared state for a short time —
+// the same state the racer must acquire to register its own lock wait. A watcher
+// holding that thousands of times a second is not a neutral observer of
+// contention; on a loaded runner it is part of it.
+//
+// 25ms is far finer than anything here needs: every block these tests wait for
+// persists until the holding transaction ends, so it cannot be missed between
+// ticks, and a racer that FINISHES is seen at once through done rather than on a
+// tick.
+const probeInterval = 25 * time.Millisecond
+
+// waitForBlockedBackend polls look until it reports the wait the caller needs,
+// the racer finishes without ever blocking, or the budget runs out. Both of the
+// latter are failures, and each caller supplies what they mean in its own terms:
+// a probe that gave up must say what the run failed to prove, never pass having
+// proved nothing.
+func waitForBlockedBackend(
+	t *testing.T,
+	done <-chan struct{},
+	finishedEarly, missed string,
+	look func(context.Context) (bool, error),
+) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), probeBudget)
+	defer cancel()
+	pace := time.NewTicker(probeInterval)
+	defer pace.Stop()
+	for {
+		blocked, err := look(ctx)
+		switch {
+		case err != nil && ctx.Err() != nil:
+			t.Fatal(racerMessage(done, finishedEarly, missed))
+		case err != nil:
+			t.Fatalf("probing for a blocked backend: %v", err)
+		}
+		if blocked {
+			return
+		}
+		// One select for all three answers: the racer finished, the budget ran
+		// out, or it is time to look again.
+		select {
+		case <-done:
+			t.Fatal(finishedEarly)
+		case <-ctx.Done():
+			t.Fatal(racerMessage(done, finishedEarly, missed))
+		case <-pace.C:
+		}
+	}
+}
+
+// racerMessage picks which failure actually happened when the budget expires.
+//
+// When the racer finishes AS the budget runs out, both channels are ready and
+// select picks between them arbitrarily — so the timeout branch can be taken
+// while a finished racer sits unread, and the run would be reported as "nothing
+// ever blocked" when what really happened is that the racer never blocked at
+// all. Those are different diagnoses and the second one is the useful one.
+func racerMessage(done <-chan struct{}, finishedEarly, missed string) string {
+	select {
+	case <-done:
+		return finishedEarly
+	default:
+		return missed
+	}
+}
+
+// The row-lock probe sees a backend that dials AFTER it starts looking.
+//
+// Four bundle contention tests rest on that, and none of them assert it, because
+// on a machine with a warm pool it holds by accident: the racer's connection
+// already exists when the probe takes its first look, so the transaction-scoped
+// statistics snapshot happens to contain it. The competing transaction here is
+// open on the SAME connection the probe uses, so that snapshot is frozen for the
+// whole race — and under the lane's concurrency the pool has no idle connection
+// to hand, dials one mid-race, and a probe trusting that snapshot never sees it.
+//
+// So the ordering is PINNED rather than raced for: the first look is taken while
+// no racer exists, and the racer then arrives on a connection dialled
+// afterwards. That makes this fail on a laptop against the bug it describes,
+// instead of only on a loaded runner.
+func TestTheRowLockProbeSeesABackendThatDialsAfterItsFirstLook(t *testing.T) {
+	e := setupStaging(t)
+	ctx := context.Background()
+	competing := e.competingTx(t)
+	blocker := backendPID(t, competing)
+	// Any lock this connection can hold and another can queue on proves the
+	// probe; an advisory one needs no seeded row to contend over.
+	const contested = 8_712_004
+	if _, err := competing.Exec(ctx, `SELECT pg_advisory_xact_lock($1)`, contested); err != nil {
+		t.Fatalf("taking the contested lock: %v", err)
+	}
+
+	// The look that used to freeze this connection's view of who is connected.
+	var queued bool
+	if err := e.owner.QueryRow(ctx,
+		`SELECT EXISTS (SELECT 1 FROM pg_stat_activity a
+		  WHERE $1 = ANY (pg_blocking_pids(a.pid)))`, blocker).Scan(&queued); err != nil {
+		t.Fatalf("the probe's first look: %v", err)
+	}
+	if queued {
+		t.Fatal("something was already queued on the competing transaction before the racer " +
+			"existed — this run cannot tell a working probe from a blind one")
+	}
+
+	racer := make(chan error, 1)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		racer <- queueOnAdvisoryLockFromAFreshConnection(ctx, contested)
+	}()
+
+	waitForRowLockWaiter(t, e, blocker, done)
+
+	// Let the racer through and account for it. A goroutine still holding a
+	// connection when the test returns outlives the *testing.T it reports
+	// through, and panics whichever package it lands in.
+	if err := competing.Rollback(ctx); err != nil {
+		t.Fatalf("releasing the contested lock: %v", err)
+	}
+	if err := <-racer; err != nil {
+		t.Fatalf("the racer never got the lock the holder released: %v", err)
+	}
+}
+
+// queueOnAdvisoryLockFromAFreshConnection queues for the contested lock from a
+// backend that did not exist when this call began, and returns once it holds it
+// — which is only after the holder lets go. Its own connection is the point: a
+// pooled one may pre-date the probe's first look, and then it proves nothing
+// about a racer that does not.
+func queueOnAdvisoryLockFromAFreshConnection(ctx context.Context, key int) (err error) {
+	conn, err := pgx.Connect(ctx, os.Getenv("MARGINCE_TEST_DSN"))
+	if err != nil {
+		return fmt.Errorf("dialling the racer's own connection: %w", err)
+	}
+	defer func() { err = errors.Join(err, conn.Close(context.Background())) }()
+
+	tx, err := conn.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("opening the racer's transaction: %w", err)
+	}
+	// The lock is held for the transaction, so releasing it IS the rollback.
+	defer func() {
+		if rollback := tx.Rollback(context.Background()); !errors.Is(rollback, pgx.ErrTxClosed) {
+			err = errors.Join(err, rollback)
+		}
+	}()
+	_, err = tx.Exec(ctx, `SELECT pg_advisory_xact_lock($1)`, key)
+	return err
+}

--- a/backend/internal/modules/approvals/stageunlessdeclined_integration_test.go
+++ b/backend/internal/modules/approvals/stageunlessdeclined_integration_test.go
@@ -17,6 +17,7 @@ package approvals
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"testing"
 
@@ -203,28 +204,24 @@ func TestStageUnlessDeclinedWaitsForACompetingPassBeforeReading(t *testing.T) {
 // ordering it claims to exercise and pass having proved nothing.
 func waitForLockWaiter(t *testing.T, e *stagingEnv, done <-chan struct{}) {
 	t.Helper()
-	// Generous enough that a loaded machine cannot trip it, small enough that a
-	// genuine miss reports in seconds rather than minutes.
-	const maxProbes = 20_000
-	for probe := 0; probe < maxProbes; probe++ {
-		var waiting bool
-		if err := e.owner.QueryRow(context.Background(),
-			`SELECT EXISTS (SELECT 1 FROM pg_locks l
-			   JOIN pg_database d ON d.oid = l.database
-			  WHERE l.locktype = 'advisory' AND NOT l.granted
-			    AND d.datname = current_database())`).Scan(&waiting); err != nil {
-			t.Fatal(err)
-		}
-		if waiting {
-			return
-		}
-		select {
-		case <-done:
-			t.Fatal("the staging finished without ever blocking on the identity lock — it read the world before the competing pass wrote to it, which is the defect this test exists to catch")
-		default:
-		}
-	}
-	t.Fatalf("no backend waited on an advisory lock in this database within %d probes — the staging never reached the lock, so this run proved nothing", maxProbes)
+	waitForBlockedBackend(t, done,
+		"the staging finished without ever blocking on the identity lock — it read the world before the competing pass wrote to it, which is the defect this test exists to catch",
+		fmt.Sprintf("no backend waited on an advisory lock in this database within %s — the staging never reached the lock, so this run proved nothing", probeBudget),
+		func(ctx context.Context) (bool, error) {
+			// pg_locks reads the lock manager directly rather than the
+			// statistics snapshot, so it answers live even from inside a
+			// transaction. That is why this probe needs no
+			// pg_stat_clear_snapshot, unlike the pg_stat_activity one the bundle
+			// suite uses — and the competing transaction here is held on the
+			// pool, not on e.owner, so these probes are not inside it either.
+			var waiting bool
+			err := e.owner.QueryRow(ctx,
+				`SELECT EXISTS (SELECT 1 FROM pg_locks l
+				   JOIN pg_database d ON d.oid = l.database
+				  WHERE l.locktype = 'advisory' AND NOT l.granted
+				    AND d.datname = current_database())`).Scan(&waiting)
+			return waiting, err
+		})
 }
 
 // The refusal is narrow: only a REJECTED prior offer stops a staging. Everything


### PR DESCRIPTION
Closes #973.

## The bound

Both probe loops here gave up after a fixed count of 20 000 iterations, with a
comment stating an intent the bound does not deliver:

```go
// Generous enough that a loaded machine cannot trip it, small enough that a
// genuine miss reports in seconds rather than minutes.
const maxProbes = 20_000
```

A count is a race between how fast 20 000 round trips complete and how long the
racer takes to reach its lock, and the lane's concurrency slows **both** — there
is no reason the ratio holds. Both loops are now bounded by a **duration**, paced
at 25ms so the observer stops competing for the very lock-manager state the racer
needs to register its own wait, and share one helper: they asked the database the
same question in the same shape while disagreeing about how to give up on it.

## The part #973 got wrong

I filed #973 saying these two probe outside a transaction and therefore did *not*
have the stale-snapshot blindness fixed in #970. That is true of the staging
probe. It is **false** of `waitForRowLockWaiter`:

- it reads `pg_stat_activity` on `e.owner`, and
- `competingTx` opens its transaction on **that same connection**,

so every probe ran inside that transaction — where the view's row set is
materialized once and cached until the transaction ends. A decision arriving on a
connection the pool dials mid-race was absent from every later look, permanently,
and the probe reported "the decision never reached the row" about a decision
parked squarely on it. Four bundle contention tests rested on this.

Verified rather than argued. With the clear removed, on an idle laptop:

```
lockprobe_integration_test.go:157: nothing waited on backend 66997 within 1m30s —
the decision never reached the row it should have blocked on
--- FAIL: TestTheRowLockProbeSeesABackendThatDialsAfterItsFirstLook (90.04s)
```

With it in place, the same test passes in 0.07s.

The staging probe genuinely needs no clearing, and now says why in-source:
`pg_locks` reads the lock manager directly rather than the statistics snapshot,
and its competing transaction is held on the pool rather than on `e.owner`.

## The regression test

Pins the ordering instead of racing for it — the first look is taken while no
racer exists, and the racer then arrives on a connection dialled afterwards. It
also cleans up after itself rather than leaving a blocked goroutine behind, which
is the failure mode #972 is about.

## Verification

- `make check-backend` — green
- `craft static --strict` on all three files — 0 findings
- full `approvals` integration package — green
- the new test fails with the 90s miss when the clear is reverted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make contention probes in approvals integration tests time-based and paced to avoid interfering with locks. Fix the row-lock probe’s stale-snapshot blindness and add a regression test to ensure we see a backend that dials after the first look.

- **Bug Fixes**
  - Replaced fixed-iteration polling with a shared `waitForBlockedBackend` helper using a 90s budget and 25ms interval.
  - Cleared the `pg_stat_activity` snapshot in `waitForRowLockWaiter` so backends on newly dialed connections are visible.
  - Added `lockprobe_integration_test.go` to pin ordering and verify the probe sees a backend that connects after the first look; staging probe stays snapshot-free via `pg_locks`.

<sup>Written for commit fbf1c91506f90785f40987221ed011ffa92fcce7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/977?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

