### PR TITLE
test(events): the reset subscriber is returned and accounted for, not merely cancelled

### DIFF
--- a/backend/internal/platform/events/control_integration_test.go
+++ b/backend/internal/platform/events/control_integration_test.go
@@ -82,16 +82,39 @@ func TestSubscribeResetSkipsAMalformedPayloadAndKeepsDelivering(t *testing.T) {
 	got := make(chan ids.UUID, 1)
 
 	runCtx, cancel := context.WithCancel(ctx)
-	defer cancel()
 	ready := make(chan struct{})
+	// The result comes back on a channel and cleanup waits for it, exactly as in
+	// the test above. `defer cancel()` alone returns the subscriber but does not
+	// WAIT for it, so its error surfaced from a goroutine racing this test's own
+	// return — and a report that lands after the test completes is not a failure,
+	// it is a panic that takes down whichever package the shard was running.
+	done := make(chan error, 1)
 	go func() {
 		log := slog.New(slog.NewTextHandler(io.Discard, nil))
-		if err := subscribeResetWithReady(runCtx, rdb, log, func(w ids.UUID) { got <- w }, ready); err != nil &&
-			!errors.Is(err, context.Canceled) {
-			t.Errorf("SubscribeReset: %v", err)
-		}
+		done <- subscribeResetWithReady(runCtx, rdb, log, func(w ids.UUID) { got <- w }, ready)
 	}()
-	<-ready
+	// Cleanup is the ONLY reader of done, and it runs on the t.Fatal paths below
+	// too — which is what a `defer` after an early Fatal could not do.
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case err := <-done:
+			if err != nil && !errors.Is(err, context.Canceled) {
+				t.Errorf("SubscribeReset: %v", err)
+			}
+		case <-time.After(5 * time.Second):
+			t.Error("the subscriber goroutine did not return after cancellation")
+		}
+	})
+
+	// Bounded for the same reason as the test above: a subscription that never
+	// confirms would hang here until the suite timeout, reading as a stuck run
+	// rather than a failure.
+	select {
+	case <-ready:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the subscription never became ready")
+	}
 
 	if err := rdb.Publish(ctx, ResetChannel, "not-a-workspace-id").Err(); err != nil {
 		t.Fatalf("publishing the malformed payload: %v", err)


### PR DESCRIPTION
Closes #972.

## What was wrong

`TestSubscribeResetSkipsAMalformedPayloadAndKeepsDelivering` reported its
subscriber's error from **inside the goroutine running it**, with `defer cancel()`
as its only synchronisation:

```go
runCtx, cancel := context.WithCancel(ctx)
defer cancel()
go func() {
    if err := subscribeResetWithReady(...); err != nil && !errors.Is(err, context.Canceled) {
        t.Errorf("SubscribeReset: %v", err)   // races the test's own return
    }
}()
```

Cancel *returns* the subscriber; it does not **wait** for it. So the report raced
the test's return, and a report landing after the test completes is not a failure
— `testing` panics. That panic takes down the **whole test binary**, so it fails
whichever package the shard happened to be running and gets misattributed to
whatever change was in flight. It is also timing-dependent (the goroutine has to
still be alive at exactly the wrong moment), which is why it read as an
unreproducible one-off.

## The fix was already in the file

The test **directly above it** had the answer, comment and all — result on a
channel, cleanup waits for it, bounded so a subscriber that never returns reports
that rather than hanging the suite. Only the sibling was left on the old shape;
this applies the same pattern.

Two details carried over deliberately:

- **`t.Cleanup`, not `defer`** — cleanup runs on the `t.Fatal` paths further down,
  where a `defer` registered after an early Fatal never would.
- **the bounded ready-wait** — a subscription that never confirms now fails as
  itself instead of hanging until the suite timeout.

## Scope

I checked every goroutine in the tree that reports through `*testing.T`:

| site | joined before return? |
|---|---|
| `events/bus_integration_test.go` `consumeUntil` | yes — `<-finished` on both exit paths |
| `agents/apps/hold_test.go` concurrent readers | yes — `readers.Wait()` |
| `events/control_integration_test.go` first test | yes — cleanup waits on `done` |
| `events/control_integration_test.go` malformed-payload test | **no** — this PR |

So this was the only site. No fitness function proposed: `go vet`'s
`testinggoroutine` analyzer already gates `t.Fatal` from a non-test goroutine (and
runs in `make check` for both the tagged and untagged lanes), while detecting
"reports through `t` and is not joined before return" needs dataflow analysis that
a grep-style gate would get wrong in both directions.

## Verification

- `make check-backend` — green
- `craft static --strict` — 0 findings
- full `events` integration package — green (`MARGINCE_TEST_REDIS=localhost:16379`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race in `TestSubscribeResetSkipsAMalformedPayloadAndKeepsDelivering` by joining the subscriber goroutine via a result channel and `t.Cleanup`, preventing post-test panics and flaky failures.

- **Bug Fixes**
  - Report subscriber result on a `done` channel; `t.Cleanup` cancels and waits (with a 5s timeout) to ensure it returns.
  - Replace `defer cancel()` with `t.Cleanup(...)` so failures on `t.Fatal` paths are still synchronized.
  - Add bounded waits for `ready` and subscriber return to fail fast if the subscription never confirms or exits.

<sup>Written for commit ae1d1e51fb0a46b9ae8f4dde12bcc69c6644551b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/978?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

