### PR TITLE
refactor(ai): the rate, meter and call stores read through the bound pool

### DIFF
--- a/backend/internal/compose/backfilltransport.go
+++ b/backend/internal/compose/backfilltransport.go
@@ -88,8 +88,8 @@ func WithBackfillEstimator(router *ai.Router) Option {
 			return
 		}
 		s.estimator = costestimate.NewEstimator(
-			ai.NewCallReadStore(pool),
-			ai.NewRateStore(pool),
+			ai.NewCallReadStore(InstallationDB(pool)),
+			ai.NewRateStore(InstallationDB(pool)),
 			router,
 			activities.NewStore(pool),
 			s.backfillHandlers.registry,

--- a/backend/internal/compose/backfilltransport_integration_test.go
+++ b/backend/internal/compose/backfilltransport_integration_test.go
@@ -210,7 +210,7 @@ func setupBackfillWire(t *testing.T) *backfillWireEnv {
 		t.Fatalf("NewLocalRouter: %v", err)
 	}
 	estimator := costestimate.NewEstimator(
-		ai.NewCallReadStore(e.Pool), ai.NewRateStore(e.Pool), router,
+		ai.NewCallReadStore(e.DB()), ai.NewRateStore(e.DB()), router,
 		activities.NewStore(e.Pool), registry, backfillFixedClock{},
 	)
 	return &backfillWireEnv{

--- a/backend/internal/compose/brain.go
+++ b/backend/internal/compose/brain.go
@@ -129,7 +129,7 @@ func (m ModelPath) WithAgentTokenSpend(spend ai.AgentTokenSpender) ModelPath {
 // router's ai_call tracing (ai.NewRouter) — the deployment's
 // AI.CapturePayloads posture and the process logger, never a stand-in.
 func NewModelPath(cfg ai.RoutingConfig, pool *pgxpool.Pool, capturePayloads bool, log *slog.Logger) (ModelPath, error) {
-	router, err := ai.NewRouter(cfg, ai.NewMeter(pool), NewSeatBudget(pool), ai.NewCallMeter(pool), capturePayloads, log)
+	router, err := ai.NewRouter(cfg, ai.NewMeter(InstallationDB(pool)), NewSeatBudget(pool), ai.NewCallMeter(InstallationDB(pool)), capturePayloads, log)
 	if err != nil {
 		return ModelPath{}, err
 	}

--- a/backend/internal/compose/coldstartaccept.go
+++ b/backend/internal/compose/coldstartaccept.go
@@ -63,7 +63,7 @@ func approvalsServiceWithEffects(pool *pgxpool.Pool) *approvals.Service {
 	svc.WithEffect(deals.CloseDateCorrectionKind, closeDateConfirmEffect(svc, deals.NewStore(pool, DealsInstallation())))
 	svc.WithEffect(deals.FollowUpReconcileKind, followUpConfirmEffect(svc, activities.NewStore(pool)))
 	svc.WithEffect(fxRateProposalKind, fxRateAcceptEffect(svc, deals.NewStore(pool, DealsInstallation())))
-	svc.WithEffect(aiModelRateProposalKind, aiModelRateAcceptEffect(svc, ai.NewRateStore(pool)))
+	svc.WithEffect(aiModelRateProposalKind, aiModelRateAcceptEffect(svc, ai.NewRateStore(InstallationDB(pool))))
 	return svc
 }
 

--- a/backend/internal/compose/costestimate/estimator_integration_test.go
+++ b/backend/internal/compose/costestimate/estimator_integration_test.go
@@ -94,8 +94,8 @@ func setupEstimator(t *testing.T) *estEnv {
 // construction B6 wires in compose.
 func (e *estEnv) newEstimator(ws ids.UUID) *Estimator {
 	return NewEstimator(
-		ai.NewCallReadStore(e.pool),
-		ai.NewRateStore(e.pool),
+		ai.NewCallReadStore(database.BindTo(e.pool, ids.From[ids.WorkspaceKind](ws))),
+		ai.NewRateStore(database.BindTo(e.pool, ids.From[ids.WorkspaceKind](ws))),
 		e.router,
 		activities.NewStore(e.pool),
 		capture.NewRegistry(database.BindTo(e.pool, ids.From[ids.WorkspaceKind](ws)), nil, nil, nil),

--- a/backend/internal/compose/deepreadtransport.go
+++ b/backend/internal/compose/deepreadtransport.go
@@ -234,7 +234,7 @@ func WithDeepRead(inserter *jobs.Runner, brain completer) Option {
 	return func(s *Server, pool *pgxpool.Pool) {
 		engine := &deepReadEngine{
 			people: people.NewStore(pool), approvals: approvals.NewService(pool),
-			runtime: ai.NewRunTransparency(pool), brain: brain, enqueue: inserter, log: s.log,
+			runtime: ai.NewRunTransparency(InstallationDB(pool)), brain: brain, enqueue: inserter, log: s.log,
 			// Read here AND written by WithBlobstore, so neither option order
 			// leaves the onboarding confirmation unable to collect the mark its
 			// anchor declined — the two-way wiring WithDataReset carries too.
@@ -244,7 +244,7 @@ func WithDeepRead(inserter *jobs.Runner, brain completer) Option {
 		s.siteReadHandlers = siteReadHandlers{engine: engine, start: engine.start, report: engine.report, companyContextRollout: rollout}
 		s.assistant = &onboardingCompanyAssistant{
 			state: s.state, people: people.NewStore(pool),
-			brain: brain, runtime: ai.NewRunTransparency(pool),
+			brain: brain, runtime: ai.NewRunTransparency(InstallationDB(pool)),
 			rollout: &s.companyContextRollout,
 			voice:   ai.NewVoiceStore(pool),
 			company: people.NewStore(pool),

--- a/backend/internal/compose/embedreindextransport.go
+++ b/backend/internal/compose/embedreindextransport.go
@@ -480,7 +480,7 @@ func WithEmbedReindex(router *ai.Router, inserter *jobs.Runner) Option {
 		}
 		store := search.NewStore(pool)
 		estimator := costestimate.NewEmbedReindexEstimator(
-			store, ai.NewRateStore(pool), router, NewSeatBudget(pool), ai.NewMeter(pool), systemClock{},
+			store, ai.NewRateStore(InstallationDB(pool)), router, NewSeatBudget(pool), ai.NewMeter(InstallationDB(pool)), systemClock{},
 		)
 		s.embedReindexHandlers = embedReindexHandlers{engine: &embedReindexEngine{
 			store:     store,

--- a/backend/internal/compose/handlersets.go
+++ b/backend/internal/compose/handlersets.go
@@ -75,7 +75,7 @@ type (
 // same overlay refusal. Its own function so the composition root reads as a
 // list of what is wired rather than how each piece is built.
 func (srv *Server) wirePerson360(pool *pgxpool.Pool) {
-	srv.person360Svc = person360.NewService(pool, srv.peopleStore, consent.NewStore(InstallationDB(pool)), ai.NewFeedbackStore(pool), time.Now)
+	srv.person360Svc = person360.NewService(pool, srv.peopleStore, consent.NewStore(InstallationDB(pool)), ai.NewFeedbackStore(InstallationDB(pool)), time.Now)
 	srv.person360Handlers = person360.NewHandlers(srv.person360Svc, srv.sorDispatch.isOverlay)
 	// The relationship brief is assembled from the SAME composite read the page
 	// serves, so the two cannot disagree about what this caller may see. No

--- a/backend/internal/compose/integration/ai_call_integration_test.go
+++ b/backend/internal/compose/integration/ai_call_integration_test.go
@@ -36,7 +36,7 @@ import (
 func TestCallMeterWritesTraceAndOptInPayload(t *testing.T) {
 	e := Setup(t)
 	ctx := principal.WithWorkspaceID(context.Background(), e.WS)
-	meter := ai.NewCallMeter(e.Pool)
+	meter := ai.NewCallMeter(e.DB())
 
 	corr := ids.NewV7()
 	logical := ids.NewV7()
@@ -129,7 +129,7 @@ func TestCallMeterWritesTraceAndOptInPayload(t *testing.T) {
 func TestRecordWritesEveryAttemptOfOneLogicalCallInOneTransaction(t *testing.T) {
 	e := Setup(t)
 	ctx := principal.WithWorkspaceID(context.Background(), e.WS)
-	meter := ai.NewCallMeter(e.Pool)
+	meter := ai.NewCallMeter(e.DB())
 
 	logical := ids.NewV7()
 	terminalPayload := &ai.Payload{Request: json.RawMessage(`{"messages":[]}`), Response: json.RawMessage(`{"text":"ok"}`)}
@@ -206,7 +206,7 @@ func TestRecordWritesEveryAttemptOfOneLogicalCallInOneTransaction(t *testing.T) 
 func TestEnsureConfigIsIdempotentAndFKsFromAICall(t *testing.T) {
 	e := Setup(t)
 	ctx := principal.WithWorkspaceID(context.Background(), e.WS)
-	meter := ai.NewCallMeter(e.Pool)
+	meter := ai.NewCallMeter(e.DB())
 
 	snap := ai.ConfigSnapshot{
 		Hash: "test-config-hash", TaskContractHash: "task-hash",

--- a/backend/internal/compose/integration/ai_meter_integration_test.go
+++ b/backend/internal/compose/integration/ai_meter_integration_test.go
@@ -81,7 +81,13 @@ func TestMeterAccumulatesUnderRLS(t *testing.T) {
 	}
 	t.Cleanup(pool.Close)
 
-	meter := ai.NewMeter(pool)
+	// A meter per workspace: the handle carries the tenant now (ADR-0091 §9
+	// step 3), so one meter driven by two contexts would fold both tenants'
+	// usage into whichever workspace it was bound to — and the RLS isolation
+	// this asserts would be asserted against nothing.
+	meterA := ai.NewMeter(database.BindTo(pool, ids.From[ids.WorkspaceKind](wsA)))
+	meterB := ai.NewMeter(database.BindTo(pool, ids.From[ids.WorkspaceKind](wsB)))
+	unbound := ai.NewMeter(database.BindTo(pool, ids.WorkspaceID{}))
 	ctxA := principal.WithWorkspaceID(ctx, wsA)
 	ctxB := principal.WithWorkspaceID(ctx, wsB)
 
@@ -91,12 +97,12 @@ func TestMeterAccumulatesUnderRLS(t *testing.T) {
 		{Task: ai.TaskSummarize, Tier: ai.TierCheapCloud, TokensIn: 50, TokensOut: 10, Cached: true},
 		{Task: ai.TaskBriefRanking, Tier: ai.TierPremium, TokensIn: 500, TokensOut: 300},
 	} {
-		if err := meter.Record(ctxA, usage); err != nil {
+		if err := meterA.Record(ctxA, usage); err != nil {
 			t.Fatalf("record: %v", err)
 		}
 	}
 
-	total, err := meter.MonthTokens(ctxA)
+	total, err := meterA.MonthTokens(ctxA)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -104,7 +110,7 @@ func TestMeterAccumulatesUnderRLS(t *testing.T) {
 		t.Fatalf("month tokens = %d, want 1000", total)
 	}
 
-	share, alarm, err := meter.PremiumShare(ctxA, 30*24*time.Hour)
+	share, alarm, err := meterA.PremiumShare(ctxA, 30*24*time.Hour)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -113,7 +119,7 @@ func TestMeterAccumulatesUnderRLS(t *testing.T) {
 	}
 
 	// Tenant isolation: workspace B sees none of A's spend.
-	totalB, err := meter.MonthTokens(ctxB)
+	totalB, err := meterB.MonthTokens(ctxB)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -122,7 +128,7 @@ func TestMeterAccumulatesUnderRLS(t *testing.T) {
 	}
 
 	// A workspace-less call is a programming error, not an empty result.
-	if err := meter.Record(ctx, ai.Usage{Task: ai.TaskSummarize, Tier: ai.TierCheapCloud}); err == nil {
+	if err := unbound.Record(ctx, ai.Usage{Task: ai.TaskSummarize, Tier: ai.TierCheapCloud}); err == nil {
 		t.Fatal("metering outside workspace context must fail")
 	}
 

--- a/backend/internal/compose/integration/aicalls_integration_test.go
+++ b/backend/internal/compose/integration/aicalls_integration_test.go
@@ -175,7 +175,7 @@ func TestAiCallIsInvisibleAcrossTenants(t *testing.T) {
 			RowScope: principal.RowScopeAll,
 		},
 	})
-	if _, err := ai.NewCallReadStore(e.Pool).GetCall(ctx, seeded.newest); !errors.Is(err, apperrors.ErrNotFound) {
+	if _, err := ai.NewCallReadStore(e.DB()).GetCall(ctx, seeded.newest); !errors.Is(err, apperrors.ErrNotFound) {
 		t.Fatalf("cross-tenant detail err = %v, want ErrNotFound", err)
 	}
 }

--- a/backend/internal/compose/integration/aicalls_integration_test.go
+++ b/backend/internal/compose/integration/aicalls_integration_test.go
@@ -175,7 +175,7 @@ func TestAiCallIsInvisibleAcrossTenants(t *testing.T) {
 			RowScope: principal.RowScopeAll,
 		},
 	})
-	if _, err := ai.NewCallReadStore(e.DB()).GetCall(ctx, seeded.newest); !errors.Is(err, apperrors.ErrNotFound) {
+	if _, err := ai.NewCallReadStore(e.DBFor(workspaceB)).GetCall(ctx, seeded.newest); !errors.Is(err, apperrors.ErrNotFound) {
 		t.Fatalf("cross-tenant detail err = %v, want ErrNotFound", err)
 	}
 }

--- a/backend/internal/compose/integration/apptest/appenv.go
+++ b/backend/internal/compose/integration/apptest/appenv.go
@@ -27,6 +27,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/platform/deployconfig"
 	"github.com/gradionhq/margince/backend/internal/platform/jobs"
 	"github.com/gradionhq/margince/backend/internal/platform/testdb"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
 // AppEnv is the heaviest of the three exported fixtures: a real compose handler
@@ -311,4 +312,14 @@ func applyRiverSchema(t *testing.T) {
 // honest about the path under test.
 func (e *AppEnv) DB() *database.DB {
 	return compose.InstallationDB(e.Pool)
+}
+
+// DBFor pins a handle to another workspace, for the suites that seed a second
+// one to prove it cannot be read from the first.
+//
+// The resolving DB above is right for everything the app itself does; it is
+// wrong the moment a test creates a workspace the installation does not know
+// about, because then there is no single installation to resolve.
+func (e *AppEnv) DBFor(ws ids.UUID) *database.DB {
+	return database.BindTo(e.Pool, ids.From[ids.WorkspaceKind](ws))
 }

--- a/backend/internal/compose/integration/meetingbrief_integration_test.go
+++ b/backend/internal/compose/integration/meetingbrief_integration_test.go
@@ -32,7 +32,7 @@ import (
 
 func meetingBriefService(e *Env) *meetingbrief.Service {
 	view := person360.NewService(e.Pool, e.People, consent.NewStore(e.DB()),
-		ai.NewFeedbackStore(e.Pool), func() time.Time { return roomFixedNow })
+		ai.NewFeedbackStore(e.DB()), func() time.Time { return roomFixedNow })
 	return meetingbrief.NewService(e.Pool, view, e.People, func() time.Time { return roomFixedNow })
 }
 

--- a/backend/internal/compose/integration/modelrate_integration_test.go
+++ b/backend/internal/compose/integration/modelrate_integration_test.go
@@ -35,7 +35,7 @@ func modelRateOf(rows []ai.ModelRateRow, provider, model string) (ai.ModelRateRo
 
 func TestModelRateAppendForwardAndConversion(t *testing.T) {
 	e := Setup(t)
-	store := ai.NewRateStore(e.Pool)
+	store := ai.NewRateStore(e.DB())
 	ctx := e.Admin()
 	today := time.Now().UTC().Truncate(24 * time.Hour)
 
@@ -88,7 +88,7 @@ func TestModelRateAppendForwardAndConversion(t *testing.T) {
 
 func TestModelRateRejects(t *testing.T) {
 	e := Setup(t)
-	store := ai.NewRateStore(e.Pool)
+	store := ai.NewRateStore(e.DB())
 	ctx := e.Admin()
 	today := time.Now().UTC().Truncate(24 * time.Hour)
 	base := ai.SetModelRateInput{Provider: "anthropic", ModelID: "m", InputUsd: "1", OutputUsd: "1", CacheReadUsd: "0", CacheWriteUsd: "0", EffectiveDate: today}
@@ -114,7 +114,7 @@ func TestModelRateRejects(t *testing.T) {
 
 func TestModelRateWriteDeniedForNonAdmin(t *testing.T) {
 	e := Setup(t)
-	store := ai.NewRateStore(e.Pool)
+	store := ai.NewRateStore(e.DB())
 	repCtx := e.As(e.Rep1, []ids.UUID{e.Team1}, RepPerms)
 	_, err := store.SetModelRate(repCtx, ai.SetModelRateInput{Provider: "anthropic", ModelID: "m", InputUsd: "1", OutputUsd: "1", CacheReadUsd: "0", CacheWriteUsd: "0", EffectiveDate: time.Now().UTC()})
 	if !errors.Is(err, apperrors.ErrPermissionDenied) {
@@ -124,7 +124,7 @@ func TestModelRateWriteDeniedForNonAdmin(t *testing.T) {
 
 func TestModelRateReadDeniedForNonAdmin(t *testing.T) {
 	e := Setup(t)
-	store := ai.NewRateStore(e.Pool)
+	store := ai.NewRateStore(e.DB())
 	roCtx := e.As(e.Rep1, []ids.UUID{e.Team1}, ReadOnlyPerms)
 	if _, err := store.ListLatestModelRates(roCtx); !errors.Is(err, apperrors.ErrPermissionDenied) {
 		t.Fatalf("read_only list err = %v, want ErrPermissionDenied", err)
@@ -133,7 +133,7 @@ func TestModelRateReadDeniedForNonAdmin(t *testing.T) {
 
 func TestModelRateWritesAuditRow(t *testing.T) {
 	e := Setup(t)
-	store := ai.NewRateStore(e.Pool)
+	store := ai.NewRateStore(e.DB())
 	if _, err := store.SetModelRate(e.Admin(), ai.SetModelRateInput{Provider: "anthropic", ModelID: "m", InputUsd: "1", OutputUsd: "1", CacheReadUsd: "0", CacheWriteUsd: "0", EffectiveDate: time.Now().UTC()}); err != nil {
 		t.Fatalf("set: %v", err)
 	}
@@ -144,7 +144,7 @@ func TestModelRateWritesAuditRow(t *testing.T) {
 
 func TestModelRateCrossWorkspaceIsolation(t *testing.T) {
 	e := Setup(t)
-	store := ai.NewRateStore(e.Pool)
+	store := ai.NewRateStore(e.DB())
 	if _, err := store.SetModelRate(e.Admin(), ai.SetModelRateInput{Provider: "anthropic", ModelID: "m", InputUsd: "1", OutputUsd: "1", CacheReadUsd: "0", CacheWriteUsd: "0", EffectiveDate: time.Now().UTC()}); err != nil {
 		t.Fatalf("set in workspace A: %v", err)
 	}
@@ -183,7 +183,7 @@ func TestModelRateCreateAndUpdateGrantsGateSeparately(t *testing.T) {
 	// OWN clock inside the transaction, so a real clock crossing UTC midnight
 	// between the two would refuse this write as past-dated.
 	today := pinnedRateDay()
-	store := ai.NewRateStore(e.Pool).WithClock(func() time.Time { return today })
+	store := ai.NewRateStore(e.DB()).WithClock(func() time.Time { return today })
 	setOn := func(ctx context.Context, input string, day time.Time) error {
 		_, err := store.SetModelRate(ctx, ai.SetModelRateInput{
 			Provider: "anthropic", ModelID: "m",
@@ -238,7 +238,7 @@ func TestModelRateOverwriteAuditsAsUpdate(t *testing.T) {
 	// Pinned so both writes land on the SAME day: a real clock crossing UTC
 	// midnight between them would create two rows and audit two creates.
 	today := pinnedRateDay()
-	store := ai.NewRateStore(e.Pool).WithClock(func() time.Time { return today })
+	store := ai.NewRateStore(e.DB()).WithClock(func() time.Time { return today })
 	ctx := e.Admin()
 	for _, price := range []string{"1", "2"} {
 		if _, err := store.SetModelRate(ctx, ai.SetModelRateInput{

--- a/backend/internal/compose/integration/person360_http_integration_test.go
+++ b/backend/internal/compose/integration/person360_http_integration_test.go
@@ -34,7 +34,7 @@ func nativeWorkspace(context.Context) (bool, error) { return false, nil }
 func personHandlers(e *Env) person360.Handlers {
 	return person360.NewHandlers(
 		person360.NewService(e.Pool, e.People, consent.NewStore(e.DB()),
-			ai.NewFeedbackStore(e.Pool), func() time.Time { return roomFixedNow }),
+			ai.NewFeedbackStore(e.DB()), func() time.Time { return roomFixedNow }),
 		nativeWorkspace,
 	)
 }

--- a/backend/internal/compose/integration/person_relationship_room_integration_test.go
+++ b/backend/internal/compose/integration/person_relationship_room_integration_test.go
@@ -55,7 +55,7 @@ var roomPerms = principal.Permissions{
 
 func personRoomService(e *Env) *person360.Service {
 	return person360.NewService(e.Pool, e.People, consent.NewStore(e.DB()),
-		ai.NewFeedbackStore(e.Pool), func() time.Time { return roomFixedNow })
+		ai.NewFeedbackStore(e.DB()), func() time.Time { return roomFixedNow })
 }
 
 // A contact outside the caller's row scope must be a NOT FOUND, never an empty
@@ -139,7 +139,7 @@ func TestCorrectionLedgerSurvivesRederivation(t *testing.T) {
 	}
 
 	corrected := "Head of Business Development"
-	if err := ai.NewFeedbackStore(e.Pool).Record(rep, ai.RecordInput{
+	if err := ai.NewFeedbackStore(e.DB()).Record(rep, ai.RecordInput{
 		SubjectType: "person", SubjectID: mine, ClaimKind: ai.ClaimProfileField,
 		ClaimPath: *before[0].ClaimKey, Verdict: ai.VerdictCorrected, CorrectedValue: &corrected,
 	}); err != nil {
@@ -178,7 +178,7 @@ func TestCorrectionLedgerRefusesAWriteWithoutTheSubjectsUpdateGrant(t *testing.T
 	readOnly.Objects = map[string]principal.ObjectGrant{"person": {Read: true}}
 	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, readOnly)
 
-	err := ai.NewFeedbackStore(e.Pool).Record(rep, ai.RecordInput{
+	err := ai.NewFeedbackStore(e.DB()).Record(rep, ai.RecordInput{
 		SubjectType: "person", SubjectID: mine, ClaimKind: ai.ClaimProfileField,
 		ClaimPath: "profile_field:title", Verdict: ai.VerdictSuppressed,
 	})
@@ -194,7 +194,7 @@ func TestCorrectionLedgerRefusesASubjectOutsideRowScope(t *testing.T) {
 	theirs := e.SeedPerson(t, "Their Contact", &e.Rep3)
 	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, roomPerms)
 
-	err := ai.NewFeedbackStore(e.Pool).Record(rep, ai.RecordInput{
+	err := ai.NewFeedbackStore(e.DB()).Record(rep, ai.RecordInput{
 		SubjectType: "person", SubjectID: theirs, ClaimKind: ai.ClaimProfileField,
 		ClaimPath: "profile_field:title", Verdict: ai.VerdictSuppressed,
 	})
@@ -209,7 +209,7 @@ func TestCorrectionLedgerKeepsOneVerdictPerClaim(t *testing.T) {
 	e := Setup(t)
 	mine := e.SeedPerson(t, "Anna Weber", &e.Rep1)
 	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, roomPerms)
-	store := ai.NewFeedbackStore(e.Pool)
+	store := ai.NewFeedbackStore(e.DB())
 
 	first := "Head of Sales"
 	if err := store.Record(rep, ai.RecordInput{
@@ -268,7 +268,7 @@ func TestErasureReachesTheEnrichmentSidecarAndTheLedger(t *testing.T) {
 		        'Anna Weber — Head of Procurement at ScaleCommerce', 'site_read:https://example.test/team', 'site_read', 'agent:enrich')`, e.WS)
 
 	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, roomPerms)
-	if err := ai.NewFeedbackStore(e.Pool).Record(rep, ai.RecordInput{
+	if err := ai.NewFeedbackStore(e.DB()).Record(rep, ai.RecordInput{
 		SubjectType: "person", SubjectID: mine, ClaimKind: ai.ClaimProfileField,
 		ClaimPath: "profile_field:title", Verdict: ai.VerdictSuppressed,
 	}); err != nil {

--- a/backend/internal/compose/modelraterefresh.go
+++ b/backend/internal/compose/modelraterefresh.go
@@ -442,7 +442,7 @@ func (w *aiModelRateRefreshWorker) Work(ctx context.Context, job *river.Job[AiMo
 
 func newModelCostRefreshWorker(pool *pgxpool.Pool, brain completer, sources []pricingSource, bound map[string]map[string]bool, log *slog.Logger) *aiModelRateRefreshWorker {
 	return &aiModelRateRefreshWorker{refresh: modelCostRefresh{
-		rates:   ai.NewRateStore(pool),
+		rates:   ai.NewRateStore(InstallationDB(pool)),
 		svc:     approvals.NewService(pool),
 		fetcher: webread.New(),
 		brain:   brain,

--- a/backend/internal/compose/modelraterefresh_integration_test.go
+++ b/backend/internal/compose/modelraterefresh_integration_test.go
@@ -38,7 +38,7 @@ func (f fakeFetcher) Fetch(_ context.Context, _ string) (webread.Doc, error) {
 func TestModelCostRefreshStagesChangedAndDropsUngrounded(t *testing.T) {
 	e := integration.Setup(t)
 	adminCtx := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AdminPerms)
-	rates := ai.NewRateStore(e.Pool)
+	rates := ai.NewRateStore(e.DB())
 
 	// The sheet currently prices opus input at 5.
 	if _, err := rates.SetModelRate(adminCtx, ai.SetModelRateInput{
@@ -103,7 +103,7 @@ func extractionFixture(provider, modelID, inputUsd string) string {
 func runModelRefresh(t *testing.T, e *integration.Env, extraction string) {
 	t.Helper()
 	m := modelCostRefresh{
-		rates:   ai.NewRateStore(e.Pool),
+		rates:   ai.NewRateStore(e.DB()),
 		svc:     approvals.NewService(e.Pool),
 		fetcher: fakeFetcher{text: "pricing page text"},
 		brain:   fakeBrain{text: extraction},
@@ -122,7 +122,7 @@ func runModelRefresh(t *testing.T, e *integration.Env, extraction string) {
 func TestModelRefreshDiffsAgainstEffectiveTodayAndSupersedes(t *testing.T) {
 	e := integration.Setup(t)
 	adminCtx := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AdminPerms)
-	rates := ai.NewRateStore(e.Pool)
+	rates := ai.NewRateStore(e.DB())
 	tomorrow := time.Now().UTC().Add(24 * time.Hour)
 
 	// Today the model costs input=5; tomorrow a scheduled row already says 6.

--- a/backend/internal/compose/onboardingsitereadmessage_integration_test.go
+++ b/backend/internal/compose/onboardingsitereadmessage_integration_test.go
@@ -43,7 +43,7 @@ func TestCompanySiteReadMessageUsesTheStoredDossierAndReturnsRuntime(t *testing.
 		"message":"I found the company name on the home page.",
 		"proposed_changes":[{"field":"display_name","value":"Acme","reason":"The page states it.","source_ids":["S1"]}],
 		"source_ids":["S1"]}`}}
-	engine := &deepReadEngine{people: env.People, brain: brain, runtime: ai.NewRunTransparency(env.Pool)}
+	engine := &deepReadEngine{people: env.People, brain: brain, runtime: ai.NewRunTransparency(env.DB())}
 
 	request := companyReadMessageRequest(human, t, read.ID.String(), "Please update the display name to Acme from the website.")
 	recorder := httptest.NewRecorder()

--- a/backend/internal/compose/rateproposals_integration_test.go
+++ b/backend/internal/compose/rateproposals_integration_test.go
@@ -31,7 +31,7 @@ import (
 func rateSvc(e *integration.Env) *approvals.Service {
 	svc := approvals.NewService(e.Pool)
 	svc.WithEffect(fxRateProposalKind, fxRateAcceptEffect(svc, deals.NewStore(e.Pool, DealsInstallation())))
-	svc.WithEffect(aiModelRateProposalKind, aiModelRateAcceptEffect(svc, ai.NewRateStore(e.Pool)))
+	svc.WithEffect(aiModelRateProposalKind, aiModelRateAcceptEffect(svc, ai.NewRateStore(e.DB())))
 	return svc
 }
 
@@ -200,7 +200,7 @@ func TestModelRateProposalApplyRefusesWhenPriorMoved(t *testing.T) {
 	e := integration.Setup(t)
 	ctx := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AdminPerms)
 	svc := rateSvc(e)
-	rates := ai.NewRateStore(e.Pool)
+	rates := ai.NewRateStore(e.DB())
 
 	if _, err := rates.SetModelRate(ctx, ai.SetModelRateInput{
 		Provider: "acme", ModelID: "m", InputUsd: "5", OutputUsd: "25", CacheReadUsd: "0", CacheWriteUsd: "0",
@@ -245,7 +245,7 @@ func TestModelRateProposalApplyRefusesWhenPriorAppeared(t *testing.T) {
 			"provider": "acme", "model_id": "new",
 			"input_per_mtok": "3", "output_per_mtok": "15", "cache_read_per_mtok": "0", "cache_write_per_mtok": "0",
 		}, "acme/new")
-	if _, err := ai.NewRateStore(e.Pool).SetModelRate(ctx, ai.SetModelRateInput{
+	if _, err := ai.NewRateStore(e.DB()).SetModelRate(ctx, ai.SetModelRateInput{
 		Provider: "acme", ModelID: "new", InputUsd: "2", OutputUsd: "10", CacheReadUsd: "0", CacheWriteUsd: "0",
 	}); err != nil {
 		t.Fatalf("seed: %v", err)
@@ -262,7 +262,7 @@ func TestModelRateProposalApplyMatchingPriorApplies(t *testing.T) {
 	ctx := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AdminPerms)
 	svc := rateSvc(e)
 
-	if _, err := ai.NewRateStore(e.Pool).SetModelRate(ctx, ai.SetModelRateInput{
+	if _, err := ai.NewRateStore(e.DB()).SetModelRate(ctx, ai.SetModelRateInput{
 		Provider: "acme", ModelID: "m2", InputUsd: "5", OutputUsd: "25", CacheReadUsd: "0", CacheWriteUsd: "0",
 	}); err != nil {
 		t.Fatalf("seed: %v", err)
@@ -325,13 +325,13 @@ func TestFxRateProposalApplyRefusesAcrossMidnight(t *testing.T) {
 func TestModelRateProposalApplyRefusesAcrossMidnight(t *testing.T) {
 	e := integration.Setup(t)
 	ctx := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AdminPerms)
-	seed := ai.NewRateStore(e.Pool)
+	seed := ai.NewRateStore(e.DB())
 	tomorrow := time.Now().UTC().Add(24 * time.Hour)
 	seedModelRate(ctx, t, seed, "mx", "5", time.Time{})
 	seedModelRate(ctx, t, seed, "mx", "9", tomorrow)
 
 	calls := 0
-	crossing := ai.NewRateStore(e.Pool).WithClock(func() time.Time {
+	crossing := ai.NewRateStore(e.DB()).WithClock(func() time.Time {
 		calls++
 		if calls == 1 {
 			return time.Now().UTC()

--- a/backend/internal/compose/server.go
+++ b/backend/internal/compose/server.go
@@ -377,7 +377,7 @@ func newServer(pool *pgxpool.Pool, log *slog.Logger, authH authHandlers, dealsH 
 		signalsHandlers:    signals.NewHandlers(pool, signalStrength{people: people.NewStore(pool)}),
 		privacyHandlers:    privacy.NewHandlers(InstallationDB(pool)),
 		automationHandlers: automation.NewHandlers(InstallationDB(pool)),
-		voiceHandlers:      ai.NewHandlers(pool, NewSeatBudget(pool)),
+		voiceHandlers:      ai.NewHandlers(InstallationDB(pool), NewSeatBudget(pool)),
 		reportHandlers:     reportHandlers{engine: newReportEngine(pool)},
 		// The Morning Brief always serves on the deterministic §10.1 floor;
 		// the L2 re-order is opt-in via WithBrief (the api role's model path).

--- a/backend/internal/modules/ai/callread.go
+++ b/backend/internal/modules/ai/callread.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
@@ -22,10 +21,10 @@ import (
 
 // CallReadStore serves the admin-only AI trace without loading payload
 // content into list responses.
-type CallReadStore struct{ pool *pgxpool.Pool }
+type CallReadStore struct{ db *database.DB }
 
 // NewCallReadStore constructs the RLS-bound AI trace read store.
-func NewCallReadStore(pool *pgxpool.Pool) *CallReadStore { return &CallReadStore{pool: pool} }
+func NewCallReadStore(db *database.DB) *CallReadStore { return &CallReadStore{db: db} }
 
 // CallSummary is one terminal attempt in the newest-first trace list.
 type CallSummary struct {
@@ -153,7 +152,7 @@ func (s *CallReadStore) ListCalls(
 
 	items := make([]CallSummary, 0, n+1)
 	tasks := []string{}
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		rows, err := tx.Query(ctx, storekit.SQLf(
 			`SELECT %s FROM ai_call c WHERE %s ORDER BY c.occurred_at DESC, c.id DESC LIMIT %d`,
 			callSummaryColumns, where, n+1,
@@ -217,7 +216,7 @@ func (s *CallReadStore) GetCall(ctx context.Context, id ids.UUID) (CallDetail, e
 		return CallDetail{}, err
 	}
 	var detail CallDetail
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		row := tx.QueryRow(ctx, storekit.SQLf(
 			`SELECT %s, c.correlation_id, c.agent_run_id, c.served_identity_source,
 				c.config_hash, c.context_scopes, c.context_fingerprint, c.logical_call_id,

--- a/backend/internal/modules/ai/callstats.go
+++ b/backend/internal/modules/ai/callstats.go
@@ -9,8 +9,6 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
-
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 )
 
 // ServedTaskTotal is one (task, tier, provider, model) slice of served
@@ -75,7 +73,7 @@ func (s *CallReadStore) ServedTaskTotals(ctx context.Context, tasks []Task, sinc
 	}
 
 	var totals []ServedTaskTotal
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		rows, err := tx.Query(ctx, q, since, taskStrings)
 		if err != nil {
 			return err

--- a/backend/internal/modules/ai/callstore.go
+++ b/backend/internal/modules/ai/callstore.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
@@ -153,12 +152,13 @@ type callStore = CallRecorder
 // CallMeter writes ai_call (+ ai_call_payload when capture is on). It rides
 // the workspace GUC transaction like every tenant write.
 type CallMeter struct {
-	pool *pgxpool.Pool
+	// db binds the workspace this store runs for (ADR-0091 §9 step 3).
+	db *database.DB
 }
 
 // NewCallMeter constructs the CallMeter that writes ai_call trace rows
 // (and, when payload capture is on, the linked ai_call_payload row).
-func NewCallMeter(pool *pgxpool.Pool) *CallMeter { return &CallMeter{pool: pool} }
+func NewCallMeter(db *database.DB) *CallMeter { return &CallMeter{db: db} }
 
 // Record writes every attempt's ai_call row — and, for whichever attempt
 // carries a Payload (only ever the terminal one), the ai_call_payload
@@ -168,7 +168,7 @@ func (m *CallMeter) Record(ctx context.Context, attempts []Call) error {
 	if len(attempts) == 0 {
 		return nil
 	}
-	return database.WithWorkspaceTx(ctx, m.pool, func(tx pgx.Tx) error {
+	return m.db.Tx(ctx, func(tx pgx.Tx) error {
 		for _, c := range attempts {
 			// kind and served_identity_source carry a CHECK constraint, not
 			// just a SQL DEFAULT — the columns are always listed explicitly
@@ -233,7 +233,7 @@ func (m *CallMeter) Record(ctx context.Context, attempts []Call) error {
 // exist.
 func (m *CallMeter) EnsureConfig(ctx context.Context, snap ConfigSnapshot) error {
 	// rls-exempt: ai_call_config is a global config-snapshot dimension (spec §4) — no workspace_id, no RLS policy, so this write must not ride the per-workspace GUC transaction.
-	_, err := m.pool.Exec(ctx, `
+	_, err := m.db.Pool().Exec(ctx, `
 		INSERT INTO ai_call_config (hash, task_contract_hash, routing_config_hash, prompt_version, provider_params)
 		VALUES ($1, $2, $3, $4, $5)
 		ON CONFLICT (hash) DO NOTHING`,

--- a/backend/internal/modules/ai/feedback.go
+++ b/backend/internal/modules/ai/feedback.go
@@ -28,7 +28,6 @@ import (
 	"strings"
 
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
@@ -74,13 +73,14 @@ var feedbackSubjects = map[string]bool{
 
 // FeedbackStore owns the ledger.
 type FeedbackStore struct {
-	pool *pgxpool.Pool
+	// db binds the workspace this store runs for (ADR-0091 §9 step 3).
+	db *database.DB
 }
 
 // NewFeedbackStore binds the ledger to the pool. It holds no other
 // dependency: consulting a verdict is a read of one table, and recording one
 // is a decision a human has already made.
-func NewFeedbackStore(pool *pgxpool.Pool) *FeedbackStore { return &FeedbackStore{pool: pool} }
+func NewFeedbackStore(db *database.DB) *FeedbackStore { return &FeedbackStore{db: db} }
 
 // ClaimKey is the stable identity of a logical claim within a subject and
 // kind: a hash of the claim's normalized PATH, never its value.
@@ -137,7 +137,7 @@ func (s *FeedbackStore) Record(ctx context.Context, in RecordInput) error {
 	}
 	key := ClaimKey(in.ClaimPath)
 
-	return database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	return s.db.Tx(ctx, func(tx pgx.Tx) error {
 		// Live, not merely visible: an unbounded caller skips the plain
 		// probe's query entirely, so an archived or erased subject would keep
 		// accruing verdicts — and a corrected_value is human-typed text about

--- a/backend/internal/modules/ai/handlers_voice.go
+++ b/backend/internal/modules/ai/handlers_voice.go
@@ -14,10 +14,10 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/jackc/pgx/v5/pgxpool"
 	openapi_types "github.com/oapi-codegen/runtime/types"
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/httperr"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
@@ -50,11 +50,11 @@ type Handlers struct {
 // rates is the ADR-0067 price sheet the usage read prices ai_call
 // against at read time (price-on-read) — the same pool, RLS scoped like
 // every other tenant read.
-func NewHandlers(pool *pgxpool.Pool, budget BudgetPolicy) Handlers {
+func NewHandlers(db *database.DB, budget BudgetPolicy) Handlers {
 	return Handlers{
-		voice: NewVoiceStore(pool), meter: NewMeter(pool), budget: budget,
-		calls: NewCallReadStore(pool), rates: NewRateStore(pool),
-		feedback:      NewFeedbackStore(pool),
+		voice: NewVoiceStore(db.Pool()), meter: NewMeter(db), budget: budget,
+		calls: NewCallReadStore(db), rates: NewRateStore(db),
+		feedback:      NewFeedbackStore(db),
 		publicProfile: NewPublicProfile("unconfigured", RoutingConfig{}),
 	}
 }

--- a/backend/internal/modules/ai/meter.go
+++ b/backend/internal/modules/ai/meter.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/gradionhq/margince/backend/internal/platform/database"
 )
@@ -47,13 +46,15 @@ type usageStore interface {
 // It rides the workspace GUC transaction like every tenant write; a
 // call outside workspace context is a programming error and fails.
 type Meter struct {
-	pool *pgxpool.Pool
+	// db binds the workspace this store runs for (ADR-0091 §9 step 3).
+	db *database.DB
 	// now is injectable so tests pin the day/month boundaries.
 	now func() time.Time
 }
 
-func NewMeter(pool *pgxpool.Pool) *Meter {
-	return &Meter{pool: pool, now: time.Now}
+// NewMeter binds the AI usage meter to the pool its counters are folded in.
+func NewMeter(db *database.DB) *Meter {
+	return &Meter{db: db, now: time.Now}
 }
 
 func (m *Meter) Record(ctx context.Context, u Usage) error {
@@ -62,7 +63,7 @@ func (m *Meter) Record(ctx context.Context, u Usage) error {
 	if u.Cached {
 		cachedHit = 1
 	}
-	return database.WithWorkspaceTx(ctx, m.pool, func(tx pgx.Tx) error {
+	return m.db.Tx(ctx, func(tx pgx.Tx) error {
 		_, err := tx.Exec(ctx, `
 			INSERT INTO ai_usage (workspace_id, day, task, tier, calls, cached_hits, tokens_in, tokens_out, reasoning_tokens, cached_tokens, cache_write_tokens)
 			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, $2, $3, 1, $4, $5, $6, $7, $8, $9)
@@ -87,7 +88,7 @@ func (m *Meter) Record(ctx context.Context, u Usage) error {
 func (m *Meter) MonthTokens(ctx context.Context) (int64, error) {
 	monthStart := m.now().UTC().Format("2006-01") + "-01"
 	var total int64
-	err := database.WithWorkspaceTx(ctx, m.pool, func(tx pgx.Tx) error {
+	err := m.db.Tx(ctx, func(tx pgx.Tx) error {
 		return tx.QueryRow(ctx, `
 			SELECT COALESCE(SUM(tokens_in + tokens_out), 0)
 			FROM ai_usage WHERE day >= $1::date`, monthStart).Scan(&total)
@@ -103,7 +104,7 @@ func (m *Meter) MonthTokens(ctx context.Context) (int64, error) {
 func (m *Meter) PremiumShare(ctx context.Context, window time.Duration) (share float64, alarm bool, err error) {
 	since := m.now().UTC().Add(-window).Format("2006-01-02")
 	var premium, total int64
-	err = database.WithWorkspaceTx(ctx, m.pool, func(tx pgx.Tx) error {
+	err = m.db.Tx(ctx, func(tx pgx.Tx) error {
 		return tx.QueryRow(ctx, `
 			SELECT
 			  COALESCE(SUM(tokens_in + tokens_out) FILTER (WHERE tier = $1), 0),

--- a/backend/internal/modules/ai/ratestore.go
+++ b/backend/internal/modules/ai/ratestore.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
@@ -24,15 +23,16 @@ import (
 // like every tenant read: RLS alone decides which workspace's rates a
 // caller can see, the same as fx_rate.
 type RateStore struct {
-	pool *pgxpool.Pool
+	// db binds the workspace this store runs for (ADR-0091 §9 step 3).
+	db *database.DB
 	// clock is the "today" source for effective-dated writes; injected so
 	// append-forward date validation is deterministic in tests.
 	clock func() time.Time
 }
 
 // NewRateStore constructs the RateStore over pool.
-func NewRateStore(pool *pgxpool.Pool) *RateStore {
-	return &RateStore{pool: pool, clock: time.Now}
+func NewRateStore(db *database.DB) *RateStore {
+	return &RateStore{db: db, clock: time.Now}
 }
 
 // WithClock overrides the "today" source (tests only). Returns the store
@@ -50,7 +50,7 @@ func (s *RateStore) WithClock(clock func() time.Time) *RateStore {
 // caller gets (nil, nil) and decides what "unpriced" means to it.
 func (s *RateStore) RateFor(ctx context.Context, provider, modelID string, day time.Time) (*ModelRate, error) {
 	var rate *ModelRate
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		var e error
 		rate, e = rateForInTx(ctx, tx, provider, modelID, day)
 		return e
@@ -132,7 +132,7 @@ func rateForInTx(ctx context.Context, tx pgx.Tx, provider, modelID string, day t
 // transparency, never a gate).
 func (s *RateStore) CostReport(ctx context.Context, from, to time.Time) ([]DayCost, error) {
 	var report []DayCost
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		rows, err := tx.Query(ctx, `
 			SELECT
 			  ac.occurred_at::date AS day,

--- a/backend/internal/modules/ai/ratestore_integration_test.go
+++ b/backend/internal/modules/ai/ratestore_integration_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
@@ -28,7 +29,7 @@ import (
 
 type rateEnv struct {
 	owner *pgx.Conn
-	store *RateStore
+	pool  *pgxpool.Pool
 }
 
 func setupRateStore(t *testing.T) *rateEnv {
@@ -55,7 +56,7 @@ func setupRateStore(t *testing.T) *rateEnv {
 	}
 	t.Cleanup(pool.Close)
 
-	return &rateEnv{owner: owner, store: NewRateStore(pool)}
+	return &rateEnv{owner: owner, pool: pool}
 }
 
 // seedWorkspace inserts one throwaway workspace and returns a context
@@ -120,6 +121,7 @@ func TestRateForResolvesEffectiveDateAcrossARateChange(t *testing.T) {
 	e := setupRateStore(t)
 	ctx := context.Background()
 	ws, wsCtx := e.seedWorkspace(ctx, t)
+	store := e.storeFor(ws)
 
 	jan1 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 	jun1 := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
@@ -133,7 +135,7 @@ func TestRateForResolvesEffectiveDateAcrossARateChange(t *testing.T) {
 	})
 
 	t.Run("before either rate exists → unpriced", func(t *testing.T) {
-		got, err := e.store.RateFor(wsCtx, providerAnthropic, "claude-test-model", time.Date(2025, 12, 31, 0, 0, 0, 0, time.UTC))
+		got, err := store.RateFor(wsCtx, providerAnthropic, "claude-test-model", time.Date(2025, 12, 31, 0, 0, 0, 0, time.UTC))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -143,7 +145,7 @@ func TestRateForResolvesEffectiveDateAcrossARateChange(t *testing.T) {
 	})
 
 	t.Run("between the two rates → the first one still applies", func(t *testing.T) {
-		got, err := e.store.RateFor(wsCtx, providerAnthropic, "claude-test-model", time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC))
+		got, err := store.RateFor(wsCtx, providerAnthropic, "claude-test-model", time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -153,7 +155,7 @@ func TestRateForResolvesEffectiveDateAcrossARateChange(t *testing.T) {
 	})
 
 	t.Run("on or after the rate change → the new rate applies", func(t *testing.T) {
-		got, err := e.store.RateFor(wsCtx, providerAnthropic, "claude-test-model", time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC))
+		got, err := store.RateFor(wsCtx, providerAnthropic, "claude-test-model", time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -163,7 +165,7 @@ func TestRateForResolvesEffectiveDateAcrossARateChange(t *testing.T) {
 	})
 
 	t.Run("unknown model → unpriced, never an error", func(t *testing.T) {
-		got, err := e.store.RateFor(wsCtx, providerAnthropic, "no-such-model", jun1)
+		got, err := store.RateFor(wsCtx, providerAnthropic, "no-such-model", jun1)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -238,6 +240,7 @@ func TestCostReportPricesTheWindowAndCountsUnpriced(t *testing.T) {
 	e := setupRateStore(t)
 	ctx := context.Background()
 	ws, wsCtx := e.seedWorkspace(ctx, t)
+	store := e.storeFor(ws)
 
 	f := buildCostReportFixture()
 	e.insertRate(ctx, t, ws, f.rate)
@@ -245,7 +248,7 @@ func TestCostReportPricesTheWindowAndCountsUnpriced(t *testing.T) {
 		e.insertCall(ctx, t, ws, c)
 	}
 
-	report, err := e.store.CostReport(wsCtx, f.from, f.to)
+	report, err := store.CostReport(wsCtx, f.from, f.to)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -302,6 +305,7 @@ func TestCostReportGroupsByCalendarDay(t *testing.T) {
 	e := setupRateStore(t)
 	ctx := context.Background()
 	ws, wsCtx := e.seedWorkspace(ctx, t)
+	store := e.storeFor(ws)
 
 	rate := ModelRate{
 		Provider: providerAnthropic, ModelID: "claude-test-model",
@@ -321,7 +325,7 @@ func TestCostReportGroupsByCalendarDay(t *testing.T) {
 		tokensIn: 300, tokensOut: 30, occurredAt: day2,
 	})
 
-	report, err := e.store.CostReport(wsCtx, time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC), time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC))
+	report, err := store.CostReport(wsCtx, time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC), time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -352,6 +356,7 @@ func TestCostReportGroupsByTierNotJustTask(t *testing.T) {
 	e := setupRateStore(t)
 	ctx := context.Background()
 	ws, wsCtx := e.seedWorkspace(ctx, t)
+	store := e.storeFor(ws)
 
 	rate := ModelRate{
 		Provider: providerAnthropic, ModelID: "claude-test-model",
@@ -372,7 +377,7 @@ func TestCostReportGroupsByTierNotJustTask(t *testing.T) {
 	e.insertCall(ctx, t, ws, cheapCall)
 	e.insertCall(ctx, t, ws, premiumCall)
 
-	report, err := e.store.CostReport(wsCtx, time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC), time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC))
+	report, err := store.CostReport(wsCtx, time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC), time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -429,6 +434,7 @@ func TestCostReportPricesEmbeddingCallsHonestly(t *testing.T) {
 	e := setupRateStore(t)
 	ctx := context.Background()
 	ws, wsCtx := e.seedWorkspace(ctx, t)
+	store := e.storeFor(ws)
 
 	effective := time.Date(2026, 7, 20, 0, 0, 0, 0, time.UTC)
 	for _, r := range SeedModelRates(effective) {
@@ -458,7 +464,7 @@ func TestCostReportPricesEmbeddingCallsHonestly(t *testing.T) {
 		tokensIn: 10_000, occurredAt: day.Add(2 * time.Hour),
 	})
 
-	report, err := e.store.CostReport(wsCtx, from, to)
+	report, err := store.CostReport(wsCtx, from, to)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -485,7 +491,7 @@ func TestCostReportPricesEmbeddingCallsHonestly(t *testing.T) {
 func TestRateAndCallVisibilityIsScopedByWorkspaceRLS(t *testing.T) {
 	e := setupRateStore(t)
 	ctx := context.Background()
-	_, ctxA := e.seedWorkspace(ctx, t)
+	wsA, ctxA := e.seedWorkspace(ctx, t)
 	wsB, ctxB := e.seedWorkspace(ctx, t)
 
 	day := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
@@ -500,7 +506,7 @@ func TestRateAndCallVisibilityIsScopedByWorkspaceRLS(t *testing.T) {
 
 	// Workspace A's context must never see workspace B's rate row — same
 	// provider/model, RLS is the only thing standing between them.
-	got, err := e.store.RateFor(ctxA, providerAnthropic, "shared-model-name", day.Add(24*time.Hour))
+	got, err := e.storeFor(wsA).RateFor(ctxA, providerAnthropic, "shared-model-name", day.Add(24*time.Hour))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -510,7 +516,7 @@ func TestRateAndCallVisibilityIsScopedByWorkspaceRLS(t *testing.T) {
 
 	// And workspace A's CostReport over the same window must not pick up
 	// workspace B's call.
-	report, err := e.store.CostReport(ctxA, day, day.Add(48*time.Hour))
+	report, err := e.storeFor(wsA).CostReport(ctxA, day, day.Add(48*time.Hour))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -522,14 +528,14 @@ func TestRateAndCallVisibilityIsScopedByWorkspaceRLS(t *testing.T) {
 
 	// Sanity: workspace B's own context DOES see it (proves the isolation
 	// above is RLS working, not a fixture that silently inserted nothing).
-	gotB, err := e.store.RateFor(ctxB, providerAnthropic, "shared-model-name", day.Add(24*time.Hour))
+	gotB, err := e.storeFor(wsB).RateFor(ctxB, providerAnthropic, "shared-model-name", day.Add(24*time.Hour))
 	if err != nil {
 		t.Fatal(err)
 	}
 	if gotB == nil {
 		t.Fatal("workspace B could not see its own rate row")
 	}
-	reportB, err := e.store.CostReport(ctxB, day, day.Add(48*time.Hour))
+	reportB, err := e.storeFor(wsB).CostReport(ctxB, day, day.Add(48*time.Hour))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -542,4 +548,18 @@ func TestRateAndCallVisibilityIsScopedByWorkspaceRLS(t *testing.T) {
 	if !found {
 		t.Fatal("workspace B's own cost report did not see its own call")
 	}
+}
+
+// storeFor binds a rate store to the workspace a test just seeded. One store
+// per workspace, because the handle carries the tenant now (ADR-0091 §9
+// step 3) — a shared one would run every test against whichever workspace
+// happened to be created first.
+func (e *rateEnv) storeFor(ws ids.UUID) *RateStore {
+	return NewRateStore(database.BindTo(e.pool, ids.From[ids.WorkspaceKind](ws)))
+}
+
+// dbFor is storeFor's handle, for the tests that build a different store over
+// the same workspace.
+func (e *rateEnv) dbFor(ws ids.UUID) *database.DB {
+	return database.BindTo(e.pool, ids.From[ids.WorkspaceKind](ws))
 }

--- a/backend/internal/modules/ai/ratewrite.go
+++ b/backend/internal/modules/ai/ratewrite.go
@@ -13,7 +13,6 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
@@ -89,7 +88,7 @@ func (s *RateStore) SetModelRate(ctx context.Context, in SetModelRateInput) (Mod
 		return ModelRateRow{}, err
 	}
 	var out ModelRateRow
-	err = database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err = s.db.Tx(ctx, func(tx pgx.Tx) error {
 		var e error
 		out, e = s.writeModelRate(ctx, tx, p, in.EffectiveDate)
 		return e
@@ -278,7 +277,7 @@ func (s *RateStore) ListLatestModelRates(ctx context.Context) ([]ModelRateRow, e
 		return nil, err
 	}
 	var rows []ModelRateRow
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		r, err := tx.Query(ctx, `
 			SELECT DISTINCT ON (provider, model_id)
 			       provider, model_id, input_per_mtok_microusd, output_per_mtok_microusd,
@@ -306,7 +305,7 @@ func (s *RateStore) ListEffectiveModelRates(ctx context.Context) ([]ModelRateRow
 		return nil, err
 	}
 	var rows []ModelRateRow
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		// Sample "today" inside the transaction: a wait for a pooled
 		// connection across UTC midnight must not list yesterday's cutoff.
 		r, err := tx.Query(ctx, `
@@ -332,7 +331,7 @@ func (s *RateStore) ModelRateHistory(ctx context.Context, provider, modelID stri
 		return nil, err
 	}
 	var rows []ModelRateRow
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		r, err := tx.Query(ctx, `
 			SELECT provider, model_id, input_per_mtok_microusd, output_per_mtok_microusd,
 			       cache_read_per_mtok_microusd, cache_write_per_mtok_microusd, effective_date

--- a/backend/internal/modules/ai/runtransparency.go
+++ b/backend/internal/modules/ai/runtransparency.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
@@ -56,11 +55,11 @@ type runCall struct {
 // It intentionally grants the same create fallback as the unbound onboarding
 // dossier itself: before an anchor company exists, its installer may still
 // inspect the model calls that their own setup action caused.
-type RunTransparency struct{ pool *pgxpool.Pool }
+type RunTransparency struct{ db *database.DB }
 
 // NewRunTransparency constructs the RLS-bound correlated-run reader.
-func NewRunTransparency(pool *pgxpool.Pool) *RunTransparency {
-	return &RunTransparency{pool: pool}
+func NewRunTransparency(db *database.DB) *RunTransparency {
+	return &RunTransparency{db: db}
 }
 
 // Get returns the complete attempt and cost account for one correlation id.
@@ -71,7 +70,7 @@ func (s *RunTransparency) Get(ctx context.Context, correlationID ids.UUID) (RunS
 		}
 	}
 	calls := []runCall{}
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		rows, err := tx.Query(ctx, `
 			SELECT c.task, c.tier, c.provider, c.model_id, c.served_model,
 				c.served_identity_source,

--- a/backend/internal/modules/ai/runtransparency_integration_test.go
+++ b/backend/internal/modules/ai/runtransparency_integration_test.go
@@ -44,7 +44,7 @@ func TestRunTransparencyReadsAndPricesOneCorrelatedProductRun(t *testing.T) {
 			Objects: map[string]principal.ObjectGrant{"organization": {Read: true}},
 		},
 	})
-	summary, err := NewRunTransparency(env.store.pool).Get(readCtx, correlationID)
+	summary, err := NewRunTransparency(env.dbFor(workspaceID)).Get(readCtx, correlationID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -65,10 +65,10 @@ func TestRunTransparencyReadsAndPricesOneCorrelatedProductRun(t *testing.T) {
 			Objects: map[string]principal.ObjectGrant{"organization": {Create: true}},
 		},
 	})
-	if _, err := NewRunTransparency(env.store.pool).Get(createCtx, correlationID); err != nil {
+	if _, err := NewRunTransparency(env.dbFor(workspaceID)).Get(createCtx, correlationID); err != nil {
 		t.Fatalf("installer create fallback: %v", err)
 	}
-	if _, err := NewRunTransparency(env.store.pool).Get(workspaceCtx, correlationID); err == nil {
+	if _, err := NewRunTransparency(env.dbFor(workspaceID)).Get(workspaceCtx, correlationID); err == nil {
 		t.Fatal("an unauthenticated caller read correlated model telemetry")
 	}
 }

--- a/backend/internal/modules/ai/usage.go
+++ b/backend/internal/modules/ai/usage.go
@@ -16,7 +16,6 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
@@ -131,7 +130,7 @@ func (m *Meter) UsageReport(ctx context.Context, budget BudgetPolicy, rates *Rat
 // aggregates, grouped day → task lines in query order.
 func (m *Meter) usageDays(ctx context.Context, from, to time.Time) ([]DayUsage, error) {
 	var days []DayUsage
-	err := database.WithWorkspaceTx(ctx, m.pool, func(tx pgx.Tx) error {
+	err := m.db.Tx(ctx, func(tx pgx.Tx) error {
 		rows, err := tx.Query(ctx, `
 			SELECT day, task, tier, calls, cached_hits, tokens_in, tokens_out
 			FROM ai_usage

--- a/backend/internal/platform/database/db.go
+++ b/backend/internal/platform/database/db.go
@@ -56,7 +56,18 @@ func (d *DB) Workspace(ctx context.Context) (ids.WorkspaceID, error) {
 
 // Pool exposes the underlying pool for the paths that do not run a
 // transaction — the outbox relay's listener, the health probe.
-func (d *DB) Pool() *pgxpool.Pool { return d.pool }
+//
+// Nil-safe on a nil handle, because construction reaches it: a store built
+// from an un-injected handle would otherwise panic where it is WIRED rather
+// than where it is used, and the unit tests that build a handler with no
+// database at all — to assert a gate that answers before any query — are
+// exactly the callers that would crash.
+func (d *DB) Pool() *pgxpool.Pool {
+	if d == nil {
+		return nil
+	}
+	return d.pool
+}
 
 // Tx runs fn inside a transaction with app.workspace_id bound, which is what
 // the RLS policies key on. Same contract as WithWorkspaceTx, minus the


### PR DESCRIPTION
Sweep continues (ADR-0091 §9 step 3). **9 of 20 modules.**

## What stays behind, and why

The **voice store** stays on the context-bound helper — the same call capture's two fleet-only stores got. Two fleet workers hold it (the build worker per job, the retry worker across the whole fleet), and its `DueDeferredBuilds` **enumerates every workspace**. A handle bound to one is the wrong answer to a question that spans them, and converting it means restructuring both workers rather than swapping a type.

## `DB.Pool` is nil-safe now

Worth stating because it is a behaviour change at the seam: a store built from an un-injected handle would otherwise panic where it is **wired** rather than where it is **used** — and the unit tests that build a handler with no database at all, to assert a gate that answers before any query, are exactly the callers that crash. `Tx` already refused rather than panicking; `Pool` now matches it.

## Fixtures

Two more instances of the pattern these slices keep finding:

- The **rate suite** built ONE store before any workspace existed, then seeded a workspace per test — so every test ran against whichever was created first. A store per workspace now.
- The **meter suite** drove one meter with two contexts to assert RLS isolation. With the handle deciding, that folds both tenants into one and asserts nothing.

## Verification

`make check-backend` and `make craft-static` (0/0/0) green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored AI rate, meter, call read/write, feedback, and run-transparency stores to use a workspace-bound `database.DB` instead of a raw `pgxpool.Pool`, improving tenant scoping and simplifying transactions. Also made `DB.Pool()` nil-safe to avoid panics when a DB handle is not injected.

- **Refactors**
  - Switched `CallReadStore`, `CallMeter`, `Meter`, `RateStore`, `FeedbackStore`, and `RunTransparency` to accept `*database.DB` and run `db.Tx(...)`.
  - Updated wiring to pass `InstallationDB(pool)` (e.g., `ai.NewMeter(InstallationDB(pool))`, `ai.NewRateStore(InstallationDB(pool))`, `ai.NewCallMeter(InstallationDB(pool))`, `ai.NewRunTransparency(InstallationDB(pool))`, `ai.NewFeedbackStore(InstallationDB(pool))`; also applied to estimators and embed reindex).
  - Changed `ai.NewHandlers` to accept `*database.DB`; the voice store remains on the context-bound helper and is built via `db.Pool()` due to fleet-wide use.
  - Tests now bind per-workspace handles using `e.DB()` or `e.DBFor(ws)`, and create one store per workspace to preserve RLS isolation.

- **Bug Fixes**
  - `DB.Pool()` is now nil-safe, preventing panics during handler construction when no DB is injected (matches `Tx` refusal behavior).

<sup>Written for commit afe788bb2f5c4d0fdb39e351fc8be46b91205d5b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/979?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

