### PR TITLE
perf(ci): the build caches nothing can restore stop evicting the ones lanes need

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -20,6 +20,12 @@ name: scheduled
 #                        green. main's last-known-green is therefore not evidence
 #                        main is green. This re-runs the lane unconditionally.
 #
+# A fourth job earns its place here for the same reason rather than the same
+# question. reap-caches is maintenance, not a verdict on main — but the state it
+# maintains only ever drifts BETWEEN merges, and its failure mode is silence:
+# caches evict each other and lanes get slower with nothing to point at. A thing
+# that decays on the calendar belongs on the calendar.
+#
 # Findings become ISSUES, not just a red run. A failed scheduled workflow notifies
 # essentially nobody by default, and this whole file exists because "we will check
 # regularly" decays into nobody checking.
@@ -160,17 +166,53 @@ jobs:
         working-directory: .
         run: make check-backend
 
+  # Delete the build caches nothing can restore. The go-build key ends in the
+  # commit sha and falls back through restore-keys to the newest entry sharing
+  # its deps hash, so within one deps hash only the newest is ever read — and one
+  # push to main writes ~5 GB across the two flavours against a 10 GB quota. Left
+  # alone, GitHub evicts least-recently-used, which reaches node-cache,
+  # gate-binaries and setup-go first: the cheap caches are evicted by the
+  # expensive ones and several lanes get slower with nothing to point at.
+  #
+  # The only job holding `actions: write`, and it runs no build code — the same
+  # permission isolation the report job below uses for `issues: write`. The test
+  # runs FIRST, beside the tool it tests, exactly as test-secret-scan.sh runs
+  # beside the scan: this one deletes, so "it succeeded" is not evidence it kept
+  # the right entry.
+  reap-caches:
+    name: reap superseded build caches
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      actions: write
+    defaults:
+      run:
+        working-directory: .
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: The reaper keeps the reachable entry (stubbed, deletes nothing)
+        run: ./scripts/test-reap-build-caches.sh
+      - name: Reap
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: ./scripts/reap-build-caches.sh
+
   # The one job holding `issues: write`, and it runs no build code — the same
   # permission isolation sbom.yml's signing job uses. It must RUN when an upstream
   # fails, so it is guarded on !cancelled() rather than needs alone.
   report:
     name: report
-    needs: [vuln, quality-gate, backend-lane]
+    needs: [vuln, quality-gate, backend-lane, reap-caches]
     if: >-
       !cancelled()
       && (needs.vuln.result == 'failure'
         || needs.quality-gate.result == 'failure'
-        || needs.backend-lane.result == 'failure')
+        || needs.backend-lane.result == 'failure'
+        || needs.reap-caches.result == 'failure')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -198,4 +240,5 @@ jobs:
           GATE_RESULT: ${{ needs.quality-gate.result }}
           GATE_STATUS: ${{ needs.quality-gate.outputs.status }}
           LANE_RESULT: ${{ needs.backend-lane.result }}
+          CACHE_RESULT: ${{ needs.reap-caches.result }}
         run: ./scripts/scheduled-report.sh

--- a/scripts/reap-build-caches.sh
+++ b/scripts/reap-build-caches.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# reap-build-caches.sh — delete the Go build caches that nothing can restore.
+#
+# `.github/actions/go-build-cache` keys every entry
+# `go-build-<flavor>-<os>-<arch>-<deps-hash>-<commit-sha>` and falls back through
+# `restore-keys` to the newest entry sharing the deps hash. So within one deps
+# hash only the NEWEST entry is ever read: every older one is unreachable by
+# construction, and the only thing it can still do is take up room.
+#
+# Room is the problem. A repository gets 10 GB of Actions cache, and one push to
+# main writes about 5 GB of Go build cache across the two flavours. Two
+# generations fill the quota on their own, and GitHub then evicts by
+# least-recently-used — which reaches the small entries first, because
+# node-cache, gate-binaries and setup-go are read once per run each while a 3 GB
+# build cache is read by every Go job. The cheap caches are evicted by the
+# expensive ones, and the lanes that depended on them quietly get slower.
+#
+# So this deletes the superseded generations rather than waiting for eviction to
+# choose worse victims. It is deliberately narrow: only `go-build-` keys, only
+# entries that are not the newest of their deps hash. Everything else — including
+# an older deps hash, which restore-keys CAN still fall back to after a go.sum
+# bump — is left alone.
+#
+# DRY_RUN=1 prints the plan and deletes nothing.
+set -euo pipefail
+
+repo="${REPO:-$(gh repo view --json nameWithOwner --jq .nameWithOwner)}"
+dry_run="${DRY_RUN:-0}"
+
+# Creation time first, then sorted here rather than by the API. The ordering IS
+# the correctness argument — "keep the first of each group" only means "keep the
+# newest" while the list is newest-first — and this deletes things, so it does
+# not rest on a query parameter a server is free to ignore. RFC 3339 timestamps
+# sort lexicographically, so a plain reverse sort is the right one.
+caches="$(gh api "repos/$repo/actions/caches?per_page=100" \
+	--paginate --jq '.actions_caches[] | [.created_at, .id, .key, .size_in_bytes] | @tsv' |
+	sort -r)"
+
+# An empty listing is ambiguous — a repository with no caches looks exactly like
+# a token that cannot read them, and the second one must not pass for a clean
+# sweep. There is always at least one cache on a repository whose CI has run.
+if [ -z "$caches" ]; then
+	echo "reap-build-caches: $repo listed no caches at all — refusing to report a clean sweep over a read that returned nothing" >&2
+	exit 1
+fi
+
+seen_groups=""
+deleted=0
+freed=0
+kept=0
+
+while IFS=$'\t' read -r created id key size; do
+	[ -n "$id" ] || continue
+	case "$key" in
+	go-build-*) ;;
+	*) continue ;;
+	esac
+
+	# The group is the key without its trailing commit sha: everything
+	# restore-keys uses to find a hit. Entries sharing it are interchangeable
+	# candidates, and only the newest is reachable.
+	group="${key%-*}"
+	# Checked as a commit sha, not merely as "something after a dash": every
+	# segment of the key is dash-separated, so a truncated key still splits
+	# cleanly and would silently group two flavours together — and grouping is
+	# what decides which entry gets deleted.
+	if ! [[ "${key##*-}" =~ ^[0-9a-f]{40}$ ]]; then
+		echo "reap-build-caches: cache key $key does not end in a commit sha; the key shape changed and this script would group it wrongly" >&2
+		exit 1
+	fi
+
+	case " $seen_groups " in
+	*" $group "*)
+		printf 'delete  %6s MB  %s  (superseded)\n' "$((size / 1048576))" "$key"
+		if [ "$dry_run" != "1" ]; then
+			gh api -X DELETE "repos/$repo/actions/caches/$id" --silent
+		fi
+		deleted=$((deleted + 1))
+		freed=$((freed + size))
+		;;
+	*)
+		printf 'keep    %6s MB  %s  (newest, %s)\n' "$((size / 1048576))" "$key" "$created"
+		seen_groups="$seen_groups $group"
+		kept=$((kept + 1))
+		;;
+	esac
+done <<<"$caches"
+
+if [ "$kept" -eq 0 ]; then
+	echo "reap-build-caches: no go-build-* cache found — the key prefix changed, so this ran over nothing" >&2
+	exit 1
+fi
+
+verb="freed"
+[ "$dry_run" = "1" ] && verb="would free"
+echo "reap-build-caches: kept $kept, deleted $deleted, $verb $((freed / 1048576)) MB"

--- a/scripts/scheduled-report.sh
+++ b/scripts/scheduled-report.sh
@@ -87,6 +87,28 @@ So the breakage may predate the most recent commit. Reproduce locally with
     || unreported=1
 fi
 
+if [ "${CACHE_RESULT:-}" = "failure" ]; then
+  report "the Actions build-cache reaper is failing" bug \
+"\`scripts/reap-build-caches.sh\` failed on the scheduled run: $RUN_URL
+
+This one degrades quietly, which is why it is filed rather than left as a red
+run. A repository gets 10 GB of Actions cache and one push to \`main\` writes
+about 5 GB of Go build cache, so without the reaper the quota fills and GitHub
+evicts least-recently-used — which reaches \`node-cache\`, \`gate-binaries\` and
+\`setup-go\` first, because each is read once per run while a build cache is read
+by every Go job. Nothing breaks; the cheap caches are evicted by the expensive
+ones and several lanes just get slower, with no failure to point at.
+
+The reaper is written to refuse rather than guess, so the likely cause is a
+deliberate change it cannot interpret: the cache key shape moved. If
+\`.github/actions/go-build-cache\` no longer ends its key with a commit sha, or
+the \`go-build-\` prefix changed, teach the script the new shape —
+\`scripts/test-reap-build-caches.sh\` covers both refusals.
+
+Inspect without deleting anything: \`DRY_RUN=1 scripts/reap-build-caches.sh\`."\
+    || unreported=1
+fi
+
 if [ "$unreported" -ne 0 ]; then
   echo "FAIL: at least one finding could not be filed — the run above names what was broken, but an issue for it does not exist" >&2
   exit 1

--- a/scripts/test-reap-build-caches.sh
+++ b/scripts/test-reap-build-caches.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# test-reap-build-caches.sh — prove reap-build-caches.sh keeps the right entry
+# and refuses the cases where it cannot know.
+#
+# The script under test DELETES, so the failure that matters is not "it deleted
+# nothing" but "it deleted the entry restore-keys was about to use", and the
+# quiet one is a read that returns nothing being reported as a clean sweep. Both
+# are covered here. It runs beside the reaper in the scheduled lane for the same
+# reason `test-secret-scan.sh` runs beside the scan: a destructive tool that can
+# only be observed succeeding is a tool nobody has checked.
+#
+# `gh` is stubbed on PATH, so no case reaches the network or a real cache.
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+stub_dir="$(mktemp -d)"
+trap 'rm -rf "$stub_dir"' EXIT
+failures=0
+
+# The stub answers the list call from CACHES_TSV and records deletions, so a case
+# can assert on exactly which ids the script chose to remove.
+cat >"$stub_dir/gh" <<'STUB'
+#!/usr/bin/env bash
+case "$*" in
+*"-X DELETE"*)
+	for arg in "$@"; do
+		case "$arg" in */actions/caches/*) echo "${arg##*/}" >>"$DELETED_LOG" ;; esac
+	done
+	;;
+*actions/caches*) printf '%s' "$CACHES_TSV" ;;
+*) echo "unexpected gh call: $*" >&2; exit 1 ;;
+esac
+STUB
+chmod +x "$stub_dir/gh"
+export PATH="$stub_dir:$PATH"
+
+# expect <name> <expected-exit> <expected-deleted-ids> <tsv>
+expect() {
+	local name="$1" want_exit="$2" want_deleted="$3" tsv="$4"
+	local out status deleted
+	export DELETED_LOG="$stub_dir/deleted"
+	: >"$DELETED_LOG"
+	set +e
+	out="$(CACHES_TSV="$tsv" REPO=owner/repo "$root/scripts/reap-build-caches.sh" 2>&1)"
+	status=$?
+	set -e
+	deleted="$(paste -sd, - <"$DELETED_LOG")"
+
+	if [ "$status" -ne "$want_exit" ] || [ "$deleted" != "$want_deleted" ]; then
+		echo "FAIL: $name"
+		echo "  exit    want $want_exit got $status"
+		echo "  deleted want '$want_deleted' got '$deleted'"
+		printf '  output: %s\n' "$out" | head -5
+		failures=$((failures + 1))
+	else
+		echo "ok: $name"
+	fi
+}
+
+plain_new=$'2026-08-12T04:00:00Z\t101\tgo-build-plain-Linux-X64-deadbeef-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\t3000000000'
+plain_old=$'2026-08-12T03:00:00Z\t102\tgo-build-plain-Linux-X64-deadbeef-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\t3000000000'
+plain_older=$'2026-08-12T02:00:00Z\t103\tgo-build-plain-Linux-X64-deadbeef-cccccccccccccccccccccccccccccccccccccccc\t3000000000'
+integ=$'2026-08-12T03:30:00Z\t201\tgo-build-integration-Linux-X64-deadbeef-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\t2000000000'
+other_deps=$'2026-08-12T01:00:00Z\t301\tgo-build-plain-Linux-X64-cafe1234-dddddddddddddddddddddddddddddddddddddddd\t3000000000'
+unrelated=$'2026-08-12T03:00:00Z\t401\tnode-cache-Linux-x64-pnpm-abc123\t70000000'
+
+# The newest of a deps-hash group survives; the rest go. Fed oldest-first on
+# purpose — the script must not depend on the order the API happened to use.
+expect "keeps the newest, deletes the superseded" 0 "102,103" \
+	"$plain_older"$'\n'"$plain_old"$'\n'"$plain_new"
+
+# Flavours are separate groups: one entry each means nothing to reap.
+expect "flavours do not shadow each other" 0 "" "$plain_new"$'\n'"$integ"
+
+# A different deps hash is a different group and restore-keys can still fall
+# back to it after a go.sum bump, so it is not superseded.
+expect "an older deps hash is left alone" 0 "" "$plain_new"$'\n'"$other_deps"
+
+# Everything that is not a build cache is out of scope entirely.
+expect "non-build caches are never touched" 0 "" "$unrelated"$'\n'"$plain_new"
+
+# A read that returned nothing must not pass for a clean sweep.
+expect "an empty listing fails loudly" 1 "" ""
+
+# If the key stops carrying a -<sha> suffix, grouping would silently merge
+# unrelated entries — refuse rather than guess.
+expect "a key shape change fails loudly" 1 "" $'2026-08-12T04:00:00Z\t101\tgo-build-plain\t3000000000'
+
+# A listing with caches but no build caches means the prefix moved.
+expect "a missing build-cache prefix fails loudly" 1 "" "$unrelated"
+
+if [ "$failures" -ne 0 ]; then
+	echo "FAIL: $failures case(s)" >&2
+	exit 1
+fi
+echo "OK: reap-build-caches keeps the reachable entry and refuses what it cannot judge"


### PR DESCRIPTION
## The problem, measured

A repository gets **10 GB** of Actions cache. One push to `main` writes ~5 GB of Go build cache across the two flavours, and `.github/actions/go-build-cache` keys each entry `go-build-<flavor>-<os>-<arch>-<deps-hash>-<commit-sha>`. Two merges fill the quota on their own.

Current state of this repository:

```
3013 MB  go-build-plain-Linux-X64-ff4120f0…-1c1d7b00   ← newest
2172 MB  go-build-integration-Linux-X64-ff4120f0…-b3a609b5  ← newest
2170 MB  go-build-integration-Linux-X64-ff4120f0…-1c1d7b00  ← unreachable
2170 MB  go-build-integration-Linux-X64-ff4120f0…-a2638f24  ← unreachable
  73 MB  node-cache · 68 MB gate-binaries · 55 MB golangci-analysis · 25 MB setup-go
```

**10.3 GB held, 4.3 GB of it unreachable.** GitHub evicts least-recently-used, which reaches `node-cache`, `gate-binaries` and `setup-go` first — each is read once per run, while a build cache is read by every Go job. The cheap caches were being evicted by the expensive ones. Nothing breaks; some lanes just get slower with no failure to point at.

Correcting an earlier claim of mine: `golangci-analysis` is **55 MB across 3 entries**, not 4.37 GB across 377. That number was stale — LRU had already reaped it. The pressure is the build cache added in #860, i.e. mine.

## What it deletes

"Unreachable" is exact, not a heuristic. `restore-keys` falls back to the newest entry sharing a deps hash, so within one deps hash **every older entry is already impossible to restore**. Those are what goes, daily, in the scheduled lane.

An **older deps hash is left alone** — `restore-keys` can still fall back to it after a `go.sum` bump, so it is stale, not dead. Non-`go-build-` caches are out of scope entirely.

Steady state becomes ~5.5 GB, with real headroom.

## Because it deletes

Three deliberate choices:

- **An empty listing fails loudly.** A token that cannot read caches looks exactly like a repository that has none, and the second must not pass for a clean sweep.
- **A key not ending in a commit sha fails loudly.** Every segment is dash-separated, so a changed key shape still splits cleanly and would silently group two flavours together — and grouping decides what gets deleted. (My first attempt at this guard only caught a key with *no* dash at all; the test caught that.)
- **It sorts by creation time itself**, rather than passing `sort=created_at&direction=desc` to the API. The ordering is the entire argument for which entry survives, so it does not rest on a query parameter a server is free to ignore.

## Verification

`scripts/test-reap-build-caches.sh` stubs `gh` — no network, no real cache — and asserts the exact ids deleted:

```
ok: keeps the newest, deletes the superseded
ok: flavours do not shadow each other
ok: an older deps hash is left alone
ok: non-build caches are never touched
ok: an empty listing fails loudly
ok: a key shape change fails loudly
ok: a missing build-cache prefix fails loudly
```

It runs in the same job immediately **before** the reaper, as `test-secret-scan.sh` runs beside the scan: a destructive tool observed only succeeding is a tool nobody has checked. The first case feeds entries oldest-first on purpose, so the script cannot pass by inheriting the API's ordering.

Also run: `DRY_RUN=1` against the real repository (output above), `make check-backend` ✓, `make secret-scan` ✓.

## Wiring

- `reap-caches` holds the only `actions: write` in the file and runs no build code — the same permission isolation the `report` job uses for `issues: write`.
- A failure **files an issue** rather than only reddening the run. This decays in silence, and that lane's own premise is that a red scheduled run notifies nobody.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a scheduled job to reap superseded Go build caches so we stay under the 10 GB Actions cache and stop LRU from evicting small per‑run caches. This keeps lanes fast without changing build behavior.

- **New Features**
  - Adds `reap-caches` to `.github/workflows/scheduled.yml` as the only job with `actions: write`; runs a test first, then the reaper.
  - New `scripts/reap-build-caches.sh`: keeps the newest `go-build-*` per deps-hash group and deletes older ones; leaves other deps hashes and non-build caches; sorts by `created_at` locally; fails on empty listings or keys not ending with a commit SHA; supports `DRY_RUN=1`.
  - New `scripts/test-reap-build-caches.sh`: stubs `gh` and verifies seven cases; runs before the reaper in CI.
  - Updates `scripts/scheduled-report.sh` to open an issue when the reaper fails, with quick troubleshooting notes.
  - Outcome: steady footprint ~5.5 GB; prevents LRU eviction of `node-cache`, `gate-binaries`, and `setup-go`, improving lane performance.

<sup>Written for commit 03035f780398c581fa45b6a24628819fd1f011fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/980?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

