### PR TITLE
test(compose): AC-W2's p95 is drawn from enough samples to be a measurement

### DIFF
--- a/backend/internal/compose/integration/workflow_dispatch_perf_integration_test.go
+++ b/backend/internal/compose/integration/workflow_dispatch_perf_integration_test.go
@@ -62,9 +62,26 @@ const workflowDispatchBudget = 200 * time.Millisecond
 // every sampled lead produces exactly one dispatch to measure.
 const leadCreatedEventType = "lead.created"
 
+// The sample size is what makes the p95 above a measurement rather than a
+// coin toss, and it is arithmetic rather than taste.
+//
+// search.MeasureQuery ranks a percentile by index, so p95 IS one sample: at 25
+// it is the second-largest, which means a single stall decides the verdict. On a
+// runner hosting twelve shards against one Postgres, a stall is not a rare
+// event — one CI run measured p50=12ms against p95=379ms and p99=812ms, a
+// median 16x inside the 200ms budget failed by two outliers.
+//
+// At 200 the same rank is the eleventh-largest, so ten samples have to be slow
+// before the gate trips. That is the difference between "this dispatch got
+// unlucky once" and "this dispatch has a tail", and only the second is the
+// regression AC-W2 exists to catch.
+//
+// The budget and the statistic are untouched: AC-W2 still reads p95 < 200ms.
+// This changes only how many samples that p95 is drawn from, which costs about
+// two seconds of dispatch and is the cheapest honest fix available.
 const (
 	dispatchWarmupSamples = 5
-	dispatchSampleSize    = 25
+	dispatchSampleSize    = 200
 )
 
 func TestWorkflowTriggerToDispatchP95HoldsOnTheSeededDataset(t *testing.T) {


### PR DESCRIPTION
Closes #971.

## The number that settles it

The failing CI run logged its own diagnosis:

```
AC-W2 trigger→dispatch: p50=12.344035ms p95=378.677197ms p99=812.017853ms
(budget 200ms, 25 samples)
```

A median **16× inside** the 200ms budget, failed by its tail.

## Why 25 samples cannot hold a p95

`search.MeasureQuery` ranks percentiles by index:

```go
idx := int(float64(len(sorted))*q+0.999999) - 1
```

At n=25 that puts p95 on the **second-largest sample**. The gate's entire verdict
is one value. On a runner hosting twelve shards against one Postgres, one stall —
a co-scheduled heavy query, a checkpoint, CPU steal — is enough, and the p99 of
812ms above shows exactly that shape.

At n=200 the same rank is the **eleventh-largest**, so ten samples have to be slow
before the gate trips. That is the difference between "this dispatch got unlucky
once" and "this dispatch has a tail" — and only the second is the regression AC-W2
exists to catch.

## What is deliberately NOT changed

AC-W2 is a spec acceptance criterion (interfaces.md §5 / PERF-R7 + GATE-CORE-6),
and this repo is contract-first, so the criterion itself is not this PR's to move:

- the budget is still 200ms
- the statistic is still p95
- the measured span is still `engine.HandleEvent` and nothing else
- the warmup discard is unchanged

Only how many samples that p95 is drawn from changes. That makes the same
criterion measurable rather than a coin toss; it does not weaken it. A dispatch
that genuinely regresses past 200ms still fails, and now fails reproducibly.

## Cost

Locally, the whole test still runs in **2.0s** and reports:

```
p50=4.02925ms p95=5.626125ms p99=7.202208ms (budget 200ms, 200 samples)
```

## Verification

- `make check-backend` — green
- `craft static --strict` — 0 findings
- the test itself — green, timings above

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase AC‑W2 workflow-dispatch p95 test sample size from 25 to 200 to make p95 a stable measurement and stop flaky failures. The 200ms budget and metric stay the same.

- **Bug Fixes**
  - Compute p95 over 200 samples so a single stall no longer decides the result (at 25, p95 was the second-largest value).
  - Test runtime remains about 2s locally.

<sup>Written for commit 639f1f546618d7b36673935a876d84597f4d2c5a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/983?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

