### PR TITLE
refactor(webhooks): a deliverer per workspace, because three paths bind three

### DIFF
--- a/backend/cmd/api/relay.go
+++ b/backend/cmd/api/relay.go
@@ -95,7 +95,7 @@ func startInlineWebhookDelivery(ctx context.Context, relay *sync.WaitGroup, rdb 
 		}
 	}
 	relay.Go(func() {
-		sub := events.NewSubscriber(rdb, group, events.Dedupe(rdb, group.Name, deliverer.HandleEvent), logger)
+		sub := events.NewSubscriber(rdb, group, events.Dedupe(rdb, group.Name, compose.WebhookEventHandler(pool, deliverer)), logger)
 		if err := sub.Run(ctx); err != nil && !errors.Is(err, context.Canceled) {
 			logger.Error("subscriber cg:webhooks", "err", err)
 		}

--- a/backend/cmd/worker/boot.go
+++ b/backend/cmd/worker/boot.go
@@ -24,6 +24,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/modules/search"
 	"github.com/gradionhq/margince/backend/internal/modules/webhooks"
 	"github.com/gradionhq/margince/backend/internal/platform/blobstore"
+	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/deployconfig"
 	"github.com/gradionhq/margince/backend/internal/platform/events"
 	"github.com/gradionhq/margince/backend/internal/platform/jobs"
@@ -98,7 +99,7 @@ func resetFlush(path compose.ModelPath) func(ids.UUID) {
 
 // workerLanes is what the event lanes leave behind for the job runner, which
 // schedules against the SAME instances those lanes consume into: one governed
-// registry and one brain per role, ONE deliverer across both outbound-webhook
+// registry and one brain per role, ONE deliverer FACTORY across both outbound-webhook
 // lanes (E10/S-E10.6) — never two that could drift apart — plus the object
 // store the deep-read logo write and the retention purge share.
 type workerLanes struct {
@@ -111,7 +112,7 @@ type workerLanes struct {
 	// only thing that should call either, so the lanes have one shutdown.
 	stop      context.CancelFunc
 	runner    *compose.RunnerService
-	deliverer *webhooks.Deliverer
+	deliverer func(*database.DB) *webhooks.Deliverer
 	blob      blobstore.Store
 }
 
@@ -294,7 +295,9 @@ func startWebhookLane(ctx context.Context, cfg workerConfig, pool *pgxpool.Pool,
 	}
 	_, _ = fmt.Fprintln(stdout, "worker delivering outbound webhooks (cg:webhooks)")
 	lanes.deliverer = deliverer
-	lanes.background.Go(func() { runSubscriber(ctx, rdb, "cg:webhooks", deliverer.HandleEvent, logger, 0) })
+	lanes.background.Go(func() {
+		runSubscriber(ctx, rdb, "cg:webhooks", compose.WebhookEventHandler(pool, deliverer), logger, 0)
+	})
 	return nil
 }
 

--- a/backend/internal/compose/integration/webhooks/webhookretry_fanout_integration_test.go
+++ b/backend/internal/compose/integration/webhooks/webhookretry_fanout_integration_test.go
@@ -152,12 +152,17 @@ func parkDueDeliveryIn(t *testing.T, we *webhookEnv, owner *pgx.Conn, ws ids.UUI
 func TestWebhookRetryReportsTheWorkspaceWhoseDueScanFailed(t *testing.T) {
 	we := setupWebhooks(t)
 	owner := integration.OwnerConn(t)
-	healthy := integration.SeedExtraWorkspace(t, owner, "healthy", false)
 
 	rcv := newReceiver(t, http.StatusInternalServerError) // endpoint is down
 	now := time.Now().UTC()
 	deliverer := newTestDeliverer(we, &now, rcv.server.Client())
 	parkOneDelivery(t, we, deliverer, rcv)
+	// The second tenant arrives only AFTER the harness has used the HTTP
+	// surface, and that order is load-bearing: a request path resolves the
+	// installation's one workspace (ADR-0061/A107) and refuses outright once
+	// there are two. A sweep is the opposite kind of caller — it is handed the
+	// tenant it runs for — so the fan-out this suite is about still reads both.
+	healthy := integration.SeedExtraWorkspace(t, owner, "healthy", false)
 	// The healthy tenant gets real due work of its own, so its sweep below
 	// actually scans and re-attempts. Without a row it would read nothing, and
 	// an assertion about a scan that never ran proves nothing about isolation.
@@ -189,7 +194,12 @@ func TestWebhookRetryReportsTheWorkspaceWhoseDueScanFailed(t *testing.T) {
 	// with the policy still armed, the healthy tenant scans its own due row and
 	// re-attempts it. The receiver hit is the load-bearing half — a pass that
 	// returned nil without delivering would have scanned nothing.
-	if err := deliverer.SweepOnce(webhookSweepCtx(healthy)); err != nil {
+	// A deliverer of the healthy tenant's own: the workspace a sweep runs for
+	// is a property of the handle it was built on, not of the ctx it is called
+	// with, so reusing the victim's deliverer here would sweep the victim again
+	// and read as the fault leaking across tenants.
+	if err := newTestDelivererOn(we, we.DBFor(healthy), &now, rcv.server.Client()).
+		SweepOnce(webhookSweepCtx(healthy)); err != nil {
 		t.Fatalf("the healthy tenant's sweep, while the victim's is faulted: %v", err)
 	}
 	if got := rcv.count.Load(); got != 3 {
@@ -205,13 +215,16 @@ func TestWebhookRetryReportsTheWorkspaceWhoseDueScanFailed(t *testing.T) {
 func TestWebhookRetryFansOutOneJobPerLiveWorkspaceAndFailsOnlyTheFailedTenant(t *testing.T) {
 	we := setupWebhooks(t)
 	owner := integration.OwnerConn(t)
-	healthy := integration.SeedExtraWorkspace(t, owner, "healthy", false)
-	archived := integration.SeedExtraWorkspace(t, owner, "archived", true)
 
 	rcv := newReceiver(t, http.StatusInternalServerError)
 	now := time.Now().UTC()
 	deliverer := newTestDeliverer(we, &now, rcv.server.Client())
 	parkOneDelivery(t, we, deliverer, rcv)
+	// Seeded after the HTTP subscription above, and for the same reason: the
+	// request path resolves the installation's one workspace and refuses when a
+	// second exists, while the fan-out under test is handed its tenant.
+	healthy := integration.SeedExtraWorkspace(t, owner, "healthy", false)
+	archived := integration.SeedExtraWorkspace(t, owner, "archived", true)
 	// Past the parked delivery's backoff, so the victim's sweep has something
 	// due to scan for: a tenant with nothing due never reads a row and so never
 	// meets the fault.
@@ -227,10 +240,14 @@ func TestWebhookRetryFansOutOneJobPerLiveWorkspaceAndFailsOnlyTheFailedTenant(t 
 		TimeScanInterval:  time.Hour,
 		WebhookRetry: compose.WebhookRetryConfig{
 			Interval: time.Hour,
-			// The fan-out builds one deliverer per workspace it sweeps; this
-			// fixture drives a single tenant, so the factory answers with the
-			// deliverer it already built for that one.
-			Deliverer: func(*database.DB) *webhooks.Deliverer { return deliverer },
+			// The fan-out builds one deliverer per workspace it sweeps, and the
+			// factory honours that: each tenant's worker gets a deliverer over
+			// the handle it was given. A factory that answered with one shared
+			// deliverer would sweep a single tenant twice and report the fan-out
+			// as working.
+			Deliverer: func(db *database.DB) *webhooks.Deliverer {
+				return newTestDelivererOn(we, db, &now, rcv.server.Client())
+			},
 		},
 	})
 	waitCtx, cancel := context.WithTimeout(context.Background(), 60*time.Second)

--- a/backend/internal/compose/integration/webhooks/webhookretry_fanout_integration_test.go
+++ b/backend/internal/compose/integration/webhooks/webhookretry_fanout_integration_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/compose/integration"
 	"github.com/gradionhq/margince/backend/internal/compose/integration/jobtest"
 	"github.com/gradionhq/margince/backend/internal/modules/webhooks"
+	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
@@ -225,7 +226,11 @@ func TestWebhookRetryFansOutOneJobPerLiveWorkspaceAndFailsOnlyTheFailedTenant(t 
 		ReconcileInterval: time.Hour,
 		TimeScanInterval:  time.Hour,
 		WebhookRetry: compose.WebhookRetryConfig{
-			Interval: time.Hour, Deliverer: deliverer,
+			Interval: time.Hour,
+			// The fan-out builds one deliverer per workspace it sweeps; this
+			// fixture drives a single tenant, so the factory answers with the
+			// deliverer it already built for that one.
+			Deliverer: func(*database.DB) *webhooks.Deliverer { return deliverer },
 		},
 	})
 	waitCtx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
@@ -276,7 +281,7 @@ func TestWebhookRetryDispatchRepeatsOnItsConfiguredInterval(t *testing.T) {
 		ReconcileInterval: time.Hour,
 		TimeScanInterval:  time.Hour,
 		WebhookRetry: compose.WebhookRetryConfig{
-			Interval: jobtest.DispatchInterval, Deliverer: newTestDeliverer(we, &now, rcv.server.Client()),
+			Interval: jobtest.DispatchInterval, Deliverer: func(*database.DB) *webhooks.Deliverer { return newTestDeliverer(we, &now, rcv.server.Client()) },
 		},
 	})
 	// Generous compared with the gap bound: a run this slow is a sick machine,
@@ -308,7 +313,7 @@ func TestWebhookRetryWithoutAnIntervalSchedulesNothingButStillWorksAQueuedRow(t 
 		CloseDateInterval: time.Hour,
 		ReconcileInterval: time.Hour,
 		TimeScanInterval:  time.Hour,
-		WebhookRetry:      compose.WebhookRetryConfig{Interval: 0, Deliverer: deliverer},
+		WebhookRetry:      compose.WebhookRetryConfig{Interval: 0, Deliverer: func(*database.DB) *webhooks.Deliverer { return deliverer }},
 	})
 	if err := runner.Enqueue(context.Background(),
 		compose.WebhookRetryWorkspaceArgs{Workspace: we.wsID}, nil); err != nil {

--- a/backend/internal/compose/integration/webhooks/webhooks_integration_test.go
+++ b/backend/internal/compose/integration/webhooks/webhooks_integration_test.go
@@ -45,6 +45,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 	"github.com/gradionhq/margince/backend/internal/modules/identity"
 	"github.com/gradionhq/margince/backend/internal/modules/webhooks"
+	"github.com/gradionhq/margince/backend/internal/platform/database"
 	kevents "github.com/gradionhq/margince/backend/internal/shared/kernel/events"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
@@ -163,7 +164,7 @@ func newTestDeliverer(we *webhookEnv, now *time.Time, client *http.Client) *webh
 }
 
 func newTestDelivererWithResolver(we *webhookEnv, now *time.Time, client *http.Client, resolver authz.Resolver) *webhooks.Deliverer {
-	store := webhooks.NewStore(we.pool, we.cipher)
+	store := webhooks.NewStore(database.BindTo(we.pool, ids.From[ids.WorkspaceKind](we.wsID)), we.cipher)
 	clock := func() time.Time { return *now }
 	return webhooks.NewDeliverer(store, client, clock, resolver,
 		slog.New(slog.NewTextHandler(os.Stderr, nil)))
@@ -227,7 +228,7 @@ func TestNewWebhookDelivererBuildsFromKey(t *testing.T) {
 	valid := base64.StdEncoding.EncodeToString(make([]byte, webhooks.WebhookKeyBytes))
 	d, err := compose.NewWebhookDeliverer(we.pool, valid, log)
 	if err != nil || d == nil {
-		t.Fatalf("NewWebhookDeliverer(valid) d=%v err=%v", d, err)
+		t.Fatalf("NewWebhookDeliverer(valid) returned a nil factory: err=%v", err)
 	}
 	if _, err := compose.NewWebhookDeliverer(we.pool, "not base64!!!", log); err == nil {
 		t.Fatal("NewWebhookDeliverer must reject a non-base64 key")

--- a/backend/internal/compose/integration/webhooks/webhooks_integration_test.go
+++ b/backend/internal/compose/integration/webhooks/webhooks_integration_test.go
@@ -163,6 +163,17 @@ func newTestDeliverer(we *webhookEnv, now *time.Time, client *http.Client) *webh
 	return newTestDelivererWithResolver(we, now, client, identity.NewService(we.pool))
 }
 
+// newTestDelivererOn builds a deliverer over a handle the CALLER bound. The
+// retry fan-out hands its worker one handle per workspace it sweeps, so a
+// fixture that reuses a single deliverer across tenants would sweep the first
+// one twice — and read as the fan-out working.
+func newTestDelivererOn(we *webhookEnv, db *database.DB, now *time.Time, client *http.Client) *webhooks.Deliverer {
+	store := webhooks.NewStore(db, we.cipher)
+	clock := func() time.Time { return *now }
+	return webhooks.NewDeliverer(store, client, clock, identity.NewService(we.pool),
+		slog.New(slog.NewTextHandler(os.Stderr, nil)))
+}
+
 func newTestDelivererWithResolver(we *webhookEnv, now *time.Time, client *http.Client, resolver authz.Resolver) *webhooks.Deliverer {
 	store := webhooks.NewStore(database.BindTo(we.pool, ids.From[ids.WorkspaceKind](we.wsID)), we.cipher)
 	clock := func() time.Time { return *now }

--- a/backend/internal/compose/jobcensusconfig.go
+++ b/backend/internal/compose/jobcensusconfig.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/gradionhq/margince/backend/internal/modules/capture"
 	"github.com/gradionhq/margince/backend/internal/modules/webhooks"
+	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/jobs"
 	"github.com/gradionhq/margince/backend/internal/platform/keyvault"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/model"
@@ -82,7 +83,7 @@ func censusJobConfig() JobRunnerConfig {
 		VoiceBrain:        seam,
 		Embedder:          seam,
 		AgentScheduler:    AgentSchedulerConfig{Interval: censusInterval, Service: &RunnerService{}},
-		WebhookRetry:      WebhookRetryConfig{Interval: censusInterval, Deliverer: &webhooks.Deliverer{}},
+		WebhookRetry:      WebhookRetryConfig{Interval: censusInterval, Deliverer: func(*database.DB) *webhooks.Deliverer { return &webhooks.Deliverer{} }},
 		PrivacyRetention:  PrivacyRetentionConfig{Interval: censusInterval},
 		CloseDateInterval: censusInterval,
 		ReconcileInterval: censusInterval,

--- a/backend/internal/compose/jobs_webhookretry.go
+++ b/backend/internal/compose/jobs_webhookretry.go
@@ -17,6 +17,7 @@ import (
 	"github.com/riverqueue/river"
 
 	"github.com/gradionhq/margince/backend/internal/modules/webhooks"
+	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/jobs"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
@@ -71,7 +72,7 @@ type WebhookRetryConfig struct {
 	//
 	// Nil is a role with no signing key, and there is then no way to sign a
 	// re-attempt: absent by omission, the posture JobRunnerConfig states.
-	Deliverer *webhooks.Deliverer
+	Deliverer func(*database.DB) *webhooks.Deliverer
 }
 
 // addWebhookRetryJobs registers the retry workers and returns the dispatcher's
@@ -83,7 +84,7 @@ func addWebhookRetryJobs(reg *jobRegistry, pool *pgxpool.Pool, cfg JobRunnerConf
 		return nil
 	}
 	addDeclaredWorker[WebhookRetryArgs](reg, &webhookRetryWorker{pool: pool})
-	addDeclaredWorker[WebhookRetryWorkspaceArgs](reg, &webhookRetryWorkspaceWorker{deliverer: cfg.WebhookRetry.Deliverer})
+	addDeclaredWorker[WebhookRetryWorkspaceArgs](reg, &webhookRetryWorkspaceWorker{pool: pool, deliverer: cfg.WebhookRetry.Deliverer})
 	return periodicFor(cfg, WebhookRetryArgs{})
 }
 
@@ -127,7 +128,8 @@ func (a WebhookRetryWorkspaceArgs) WorkspaceID() ids.UUID { return a.Workspace }
 
 // webhookRetryWorkspaceWorker sweeps one workspace.
 type webhookRetryWorkspaceWorker struct {
-	deliverer *webhooks.Deliverer
+	pool      *pgxpool.Pool
+	deliverer func(*database.DB) *webhooks.Deliverer
 }
 
 // Work binds the tenant and nothing else: the sweep re-sends deliveries that
@@ -138,5 +140,12 @@ func (w *webhookRetryWorkspaceWorker) Work(ctx context.Context, job *river.Job[W
 	if err != nil {
 		return jobs.FaultContext(ctx, err)
 	}
-	return jobs.FaultContext(ctx, w.deliverer.SweepOnce(wsCtx))
+	// Built for the workspace THIS pass sweeps: the deliverer's store writes
+	// delivery rows, and a fleet pass cannot share one across the workspaces it
+	// re-attempts (ADR-0091 §9 step 3).
+	db, err := workspaceJobDB(w.pool, job.Args)
+	if err != nil {
+		return jobs.FaultContext(ctx, err)
+	}
+	return jobs.FaultContext(ctx, w.deliverer(db).SweepOnce(wsCtx))
 }

--- a/backend/internal/compose/webhooks.go
+++ b/backend/internal/compose/webhooks.go
@@ -4,6 +4,7 @@
 package compose
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 
@@ -11,6 +12,9 @@ import (
 
 	"github.com/gradionhq/margince/backend/internal/modules/identity"
 	"github.com/gradionhq/margince/backend/internal/modules/webhooks"
+	"github.com/gradionhq/margince/backend/internal/platform/database"
+	kevents "github.com/gradionhq/margince/backend/internal/shared/kernel/events"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
 // newWebhookHandlers builds the outbound-webhook transport (E10/S-E10.6,
@@ -20,7 +24,7 @@ import (
 // shipping an unsigned or guessable delivery. The api role supplies the
 // deployment key via WithWebhookSigningKey.
 func newWebhookHandlers(pool *pgxpool.Pool, cipher *webhooks.Cipher, log *slog.Logger) webhooks.Handlers {
-	store := webhooks.NewStore(pool, cipher)
+	store := webhooks.NewStore(InstallationDB(pool), cipher)
 	// The HTTP-transport deliverer serves replay only (re-sending an
 	// already-authorized delivery), so it needs no principal resolver — the
 	// owner-scoped fan-out lives on the bus-consumer deliverer wired in the
@@ -35,7 +39,14 @@ func newWebhookHandlers(pool *pgxpool.Pool, cipher *webhooks.Cipher, log *slog.L
 // identity-backed principal resolver (authz.Resolver): a webhook only ever
 // delivers an event its owner may see (BYO-EVT-4). key is the base64
 // 32-byte signing-secret sealing key.
-func NewWebhookDeliverer(pool *pgxpool.Pool, key string, log *slog.Logger) (*webhooks.Deliverer, error) {
+// The deliverer is returned as a FACTORY rather than a value: it is used by
+// three per-workspace paths — the bus consumer (one event at a time, for the
+// workspace the envelope names), the retry sweep (one pass per workspace), and
+// HTTP replay (the installation's own). Each binds a different workspace, so a
+// single shared deliverer would carry one tenant's handle into all three
+// (ADR-0091 §9 step 3). The cipher and the resolver are built once and closed
+// over; only the store's binding varies.
+func NewWebhookDeliverer(pool *pgxpool.Pool, key string, log *slog.Logger) (func(*database.DB) *webhooks.Deliverer, error) {
 	raw, err := webhooks.DecodeKey(key)
 	if err != nil {
 		return nil, fmt.Errorf("webhook signing key: %w", err)
@@ -44,8 +55,11 @@ func NewWebhookDeliverer(pool *pgxpool.Pool, key string, log *slog.Logger) (*web
 	if err != nil {
 		return nil, fmt.Errorf("webhook cipher: %w", err)
 	}
-	store := webhooks.NewStore(pool, cipher)
-	return webhooks.NewDeliverer(store, webhooks.NewGuardedClient(), nil, identity.NewService(pool), log), nil
+	resolver := identity.NewService(pool)
+	return func(db *database.DB) *webhooks.Deliverer {
+		return webhooks.NewDeliverer(webhooks.NewStore(db, cipher),
+			webhooks.NewGuardedClient(), nil, resolver, log)
+	}, nil
 }
 
 // WithWebhookSigningKey enables the mutating outbound-webhook surface: the
@@ -72,4 +86,16 @@ func WithWebhookKey(key string) (Option, error) {
 		return nil, fmt.Errorf("webhook cipher: %w", err)
 	}
 	return WithWebhookSigningKey(cipher), nil
+}
+
+// WebhookEventHandler adapts the per-workspace deliverer factory to the bus
+// consumer's one-function shape: each envelope names the workspace it belongs
+// to, so the deliverer that handles it binds THAT one. A single deliverer
+// shared across the lane would carry one tenant's handle into every other
+// tenant's event (ADR-0091 §9 step 3).
+func WebhookEventHandler(pool *pgxpool.Pool, deliverer func(*database.DB) *webhooks.Deliverer,
+) func(context.Context, kevents.Envelope) error {
+	return func(ctx context.Context, env kevents.Envelope) error {
+		return deliverer(database.BindTo(pool, ids.From[ids.WorkspaceKind](env.WorkspaceID))).HandleEvent(ctx, env)
+	}
 }

--- a/backend/internal/modules/webhooks/approvalvisibility.go
+++ b/backend/internal/modules/webhooks/approvalvisibility.go
@@ -25,7 +25,6 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
@@ -58,7 +57,7 @@ func (s *Store) approvalVisibleTo(ctx context.Context, approvalID ids.UUID) (boo
 		targetID   *ids.UUID
 		stagedFor  *ids.UUID
 	)
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		return tx.QueryRow(ctx,
 			`SELECT target_entity_type, target_entity_id, on_behalf_of FROM approval WHERE id = $1`,
 			approvalID).Scan(&targetType, &targetID, &stagedFor)

--- a/backend/internal/modules/webhooks/deliverystore.go
+++ b/backend/internal/modules/webhooks/deliverystore.go
@@ -11,7 +11,6 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
@@ -66,7 +65,7 @@ func (s *Store) ListDeliveries(ctx context.Context, subID ids.UUID, limit int) (
 		limit = 50
 	}
 	var out []Delivery
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		// Fetch one past the page so a full page is distinguishable from a
 		// truncated one without a second count query.
 		rows, err := tx.Query(ctx, "SELECT "+deliveryColumns+
@@ -98,7 +97,7 @@ func (s *Store) ListDeliveries(ctx context.Context, subID ids.UUID, limit int) (
 // getDelivery reads one delivery by id in the caller's workspace.
 func (s *Store) getDelivery(ctx context.Context, deliveryID ids.UUID) (Delivery, error) {
 	var out Delivery
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		var err error
 		out, err = scanDelivery(tx.QueryRow(ctx,
 			"SELECT "+deliveryColumns+" FROM webhook_delivery WHERE id = $1", deliveryID))
@@ -121,7 +120,7 @@ func (s *Store) requireReplay(ctx context.Context, subID, deliveryID ids.UUID) e
 	if _, err := s.GetSubscription(ctx, subID); err != nil {
 		return err
 	}
-	return database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	return s.db.Tx(ctx, func(tx pgx.Tx) error {
 		var belongs bool
 		err := tx.QueryRow(ctx,
 			"SELECT EXISTS (SELECT 1 FROM webhook_delivery WHERE id = $1 AND subscription_id = $2)",
@@ -164,7 +163,7 @@ type subCandidate struct {
 // the envelope's workspace under the tenant GUC.
 func (s *Store) matchingSubscriptions(ctx context.Context, eventType string) ([]subCandidate, error) {
 	var out []subCandidate
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		rows, err := tx.Query(ctx, `
 			SELECT id, owner_id FROM webhook_subscription
 			WHERE state = 'active' AND archived_at IS NULL
@@ -196,7 +195,7 @@ func (s *Store) enqueueForSubscriptions(ctx context.Context, subIDs []ids.UUID, 
 		return nil, nil
 	}
 	var targets []attemptTarget
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		rows, err := tx.Query(ctx, `
 			WITH matched AS (
 				SELECT id, target_url, signing_secret_ref
@@ -235,7 +234,7 @@ func (s *Store) enqueueForSubscriptions(ctx context.Context, subIDs []ids.UUID, 
 // subscription's retries wait until it resumes). Runs under the tenant GUC.
 func (s *Store) dueRetries(ctx context.Context, now time.Time, limit int) ([]ids.UUID, error) {
 	var out []ids.UUID
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		rows, err := tx.Query(ctx, `
 			SELECT d.id
 			FROM webhook_delivery d
@@ -265,7 +264,7 @@ func (s *Store) dueRetries(ctx context.Context, now time.Time, limit int) ([]ids
 // secret (so a rotation between attempts takes effect). Runs in-workspace.
 func (s *Store) loadTarget(ctx context.Context, deliveryID ids.UUID) (attemptTarget, error) {
 	var t attemptTarget
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		return tx.QueryRow(ctx, `
 			SELECT d.id, d.subscription_id, s.target_url, s.signing_secret_ref,
 			       d.event_type, d.event_id, d.payload, d.attempts
@@ -299,7 +298,7 @@ func (s *Store) recordOutcome(ctx context.Context, t attemptTarget, res outcome,
 	if res.statusCode != 0 {
 		statusCode = &res.statusCode
 	}
-	return database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	return s.db.Tx(ctx, func(tx pgx.Tx) error {
 		if res.failure == "" {
 			_, err := tx.Exec(ctx, `
 				UPDATE webhook_delivery
@@ -330,7 +329,7 @@ func (s *Store) recordOutcome(ctx context.Context, t attemptTarget, res outcome,
 // re-attempted. Returns ErrNotFound if the delivery is absent in the
 // caller's workspace (existence-hiding).
 func (s *Store) resetForReplay(ctx context.Context, deliveryID ids.UUID) error {
-	return database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	return s.db.Tx(ctx, func(tx pgx.Tx) error {
 		tag, err := tx.Exec(ctx, `
 			UPDATE webhook_delivery
 			SET status = 'pending', next_retry_at = NULL, dead_lettered_at = NULL, last_error = NULL

--- a/backend/internal/modules/webhooks/deliveryvisibility.go
+++ b/backend/internal/modules/webhooks/deliveryvisibility.go
@@ -10,7 +10,6 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
@@ -226,7 +225,7 @@ func objectReadable(ctx context.Context, object string) (bool, error) {
 // and maps its outcome to (visible, err): nil → visible, ErrNotFound → not
 // visible (out of scope), anything else → a real error the caller surfaces.
 func (s *Store) probeVisible(ctx context.Context, probe func(context.Context, pgx.Tx) error) (bool, error) {
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error { return probe(ctx, tx) })
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error { return probe(ctx, tx) })
 	switch {
 	case err == nil:
 		return true, nil
@@ -255,7 +254,7 @@ func (s *Store) offerVisibleTo(ctx context.Context, offerID ids.UUID) (bool, err
 // not-visible.
 func (s *Store) offerDealVisible(ctx context.Context, offerID ids.UUID) (bool, error) {
 	var dealID ids.UUID
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		return tx.QueryRow(ctx, `SELECT deal_id FROM offer WHERE id = $1`, offerID).Scan(&dealID)
 	})
 	if errors.Is(err, pgx.ErrNoRows) {
@@ -273,7 +272,7 @@ func (s *Store) offerDealVisible(ctx context.Context, offerID ids.UUID) (bool, e
 // the workspace-shared-config floor the approval-target gate shares.
 func (s *Store) rowExists(ctx context.Context, query string, id ids.UUID) (bool, error) {
 	var exists bool
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		return tx.QueryRow(ctx, query, id).Scan(&exists)
 	})
 	if err != nil {

--- a/backend/internal/modules/webhooks/store.go
+++ b/backend/internal/modules/webhooks/store.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
@@ -48,14 +47,15 @@ const fieldEventTypes = "event_types"
 // open a secret returns ErrNotConfigured rather than shipping an
 // unsigned or guessable delivery.
 type Store struct {
-	pool   *pgxpool.Pool
+	// db binds the workspace this store runs for (ADR-0091 §9 step 3).
+	db     *database.DB
 	cipher *Cipher
 }
 
 // NewStore wires the webhook tables over a pool; cipher may be nil when no
 // deployment signing key is configured (read paths work, secret paths 503).
-func NewStore(pool *pgxpool.Pool, cipher *Cipher) *Store {
-	return &Store{pool: pool, cipher: cipher}
+func NewStore(db *database.DB, cipher *Cipher) *Store {
+	return &Store{db: db, cipher: cipher}
 }
 
 // DeliveryEnabled reports whether this deployment has a signing key — i.e.
@@ -178,7 +178,7 @@ func (s *Store) CreateSubscription(ctx context.Context, in CreateSubscriptionInp
 	}
 
 	var out Subscription
-	err = database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err = s.db.Tx(ctx, func(tx pgx.Tx) error {
 		row := tx.QueryRow(ctx, `
 			INSERT INTO webhook_subscription
 			  (workspace_id, owner_id, target_url, event_types, signing_secret_ref, state)
@@ -207,7 +207,7 @@ func (s *Store) ListSubscriptions(ctx context.Context, archived storekit.Archive
 		return nil, err
 	}
 	var out []Subscription
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		where := ""
 		if archived != storekit.IncludeArchived {
 			where = " WHERE archived_at IS NULL"
@@ -237,7 +237,7 @@ func (s *Store) GetSubscription(ctx context.Context, id ids.UUID) (Subscription,
 		return Subscription{}, err
 	}
 	var out Subscription
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		var err error
 		out, err = scanSubscription(tx.QueryRow(ctx,
 			"SELECT "+subscriptionColumns+" FROM webhook_subscription WHERE id = $1 AND archived_at IS NULL", id))
@@ -285,7 +285,7 @@ func (s *Store) UpdateSubscription(ctx context.Context, id ids.UUID, in UpdateSu
 		return Subscription{}, err
 	}
 	var out Subscription
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		current, err := scanSubscription(tx.QueryRow(ctx,
 			"SELECT "+subscriptionColumns+" FROM webhook_subscription WHERE id = $1 AND archived_at IS NULL", id))
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -337,7 +337,7 @@ func (s *Store) RotateSecret(ctx context.Context, id ids.UUID) (Subscription, st
 		return Subscription{}, "", err
 	}
 	var out Subscription
-	err = database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err = s.db.Tx(ctx, func(tx pgx.Tx) error {
 		tag, err := tx.Exec(ctx,
 			"UPDATE webhook_subscription SET signing_secret_ref = $2 WHERE id = $1 AND archived_at IS NULL",
 			id, sealed)
@@ -369,7 +369,7 @@ func (s *Store) ArchiveSubscription(ctx context.Context, id ids.UUID) (Subscript
 		return Subscription{}, err
 	}
 	var out Subscription
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		row := tx.QueryRow(ctx,
 			"UPDATE webhook_subscription SET archived_at = now() WHERE id = $1 AND archived_at IS NULL RETURNING "+subscriptionColumns,
 			id)


### PR DESCRIPTION
**10 of 20 modules.** This is the module I pulled out of #917 and #965, and it needed its own change for a specific reason.

## Three paths, three tenants

The `Deliverer` is reached by three per-workspace paths that each learn the tenant somewhere different:

| path | learns the tenant from |
|---|---|
| bus consumer | the **envelope** (`env.WorkspaceID`), one event at a time |
| retry sweep | **job args**, one pass per workspace |
| HTTP replay | the **installation** |

One shared deliverer carries whichever handle it was built with into all three. So it is a **factory** now: the cipher and the resolver are built once and closed over — only the store's binding varies — and each caller supplies the workspace it actually knows.

## Why this one was worth doing carefully rather than quickly

A webhook is an outbound HTTP request carrying record data to a **customer-controlled endpoint**. A mis-bound store here does not surface as a refused read, the way every other failure in this sweep has. It surfaces as one tenant's data arriving at another tenant's URL.

That is why I took it out of two earlier batches rather than converting it alongside modules where the failure mode is a loud refusal.

## Verification

`make check-backend` and `make craft-static` (0/0/0) green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored outbound-webhook delivery to use a per-workspace deliverer factory so the bus consumer, retry sweep, and HTTP replay each bind the correct tenant, preventing cross-tenant deliveries.

- **Refactors**
  - `compose.NewWebhookDeliverer` now returns `func(*database.DB) *webhooks.Deliverer` (cipher/resolver shared; store is workspace-bound).
  - Added `compose.WebhookEventHandler(pool, deliverer)` and wired it into subscribers in `api` and `worker`.
  - Retry worker builds a deliverer per workspace; `WebhookRetryConfig.Deliverer` is now a factory.
  - `webhooks.Store` now takes a bound `*database.DB` and uses `s.db.Tx`; all store methods updated.
  - HTTP handlers bind via `compose.InstallationDB(pool)`; tests updated to bind a workspace DB and to expect a deliverer factory.

- **Migration**
  - Keep and pass the deliverer factory from `compose.NewWebhookDeliverer`, then call it with a bound `*database.DB` (e.g., `database.BindTo(pool, workspaceID)` or `compose.InstallationDB(pool)`).
  - Replace `deliverer.HandleEvent` with `compose.WebhookEventHandler(pool, deliverer)` in subscribers.
  - Update `WebhookRetryConfig.Deliverer` to `func(*database.DB) *webhooks.Deliverer`.
  - When creating `webhooks.NewStore`, pass a bound `*database.DB` instead of a pool.

<sup>Written for commit 7eadfd148815596cee77c810369a6e821253ee22. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/984?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

