### PR TITLE
ci: every backend target `make help` advertises resolves from the repo root

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@
 # one target here that invokes the compiler directly instead of delegating.
 GO ?= go
 
-.PHONY: help install ai-routing-local dev-fresh check check-backend check-q check-go check-gates check-fe build test test-v test-cover test-integration e2e-ai e2e-ai-report ai-probe test-db-up test-it test-integration-serial bench-perf lint arch-lint vet gen gen-types gen-types-check drift composition check-composition test-extensions db-up db-init db-wait migrate migrate-up migrate-down run psql redis-cli tidy dev dev-stop dev-logs clean tools tools-go infra-up infra-down infra-logs infra-reset seed-dev seed-dev-db seed-reset verify-boot frontend-check frontend-e2e e2e-company fe-install fe-typecheck fe-typecheck-composed fe-lint fe-build fe-preview fe-format fe-test fe-test-ext fe-ds-gates fe-drift fe-unit fe-quality fe-bundle fe-storybook ds-purity font-lock icon-lint ds-spacing space-tokens native-controls ext-imports fitness-jurisdiction storybook fe-uat craft-static craft-residue check-craft-doc secret-scan test-secret-scan check-image-pins check-host-ports ci-doc-parity check-ext-migrations contract-breaking-check test-lanes go-file-length rls-store-path no-jurisdiction pkg-freeze hooks sbom sbom-normalize sbom-supplement sbom-parity sbom-validate sbom-sign sbom-check
+.PHONY: help install ai-routing-local dev-fresh check check-backend check-q check-go check-gates check-fe build test test-v test-cover test-integration e2e-siteread e2e-ai e2e-ai-report ai-probe test-db-up test-it test-integration-serial bench-perf lint arch-lint vet gen gen-workflow mcp-apps-vocab gen-types gen-types-check drift composition check-composition test-extensions db-up db-init db-wait migrate migrate-up migrate-down run psql redis-cli tidy dev dev-stop dev-logs clean vuln tools tools-go infra-up infra-down infra-logs infra-reset seed-dev seed-dev-db seed-reset verify-boot frontend-check frontend-e2e e2e-company fe-install fe-typecheck fe-typecheck-composed fe-lint fe-build fe-preview fe-format fe-test fe-test-ext fe-ds-gates fe-drift fe-unit fe-quality fe-bundle fe-storybook ds-purity font-lock icon-lint ds-spacing space-tokens native-controls ext-imports fitness-jurisdiction storybook fe-uat craft-static craft-residue check-craft-doc secret-scan test-secret-scan check-image-pins check-host-ports ci-doc-parity make-target-parity check-ext-migrations contract-breaking-check test-lanes go-file-length rls-store-path no-jurisdiction pkg-freeze hooks sbom sbom-normalize sbom-supplement sbom-parity sbom-validate sbom-sign sbom-check
 
 # Bare `make` lists every command instead of running the first target.
 .DEFAULT_GOAL := help
@@ -47,7 +47,7 @@ ai-routing-local:
 ## gates plus the backend gate (build, vet, lint, arch-lint, unit + fitness
 ## tests, contract drift). No frontend toolchain needed — this is what the CI
 ## deterministic-gates job runs.
-check-backend: check-craft-doc check-image-pins check-host-ports ci-doc-parity contract-breaking-check test-lanes go-file-length rls-store-path no-jurisdiction pkg-freeze
+check-backend: check-craft-doc check-image-pins check-host-ports ci-doc-parity make-target-parity contract-breaking-check test-lanes go-file-length rls-store-path no-jurisdiction pkg-freeze
 	$(MAKE) -C backend check
 
 ## check — the full merge gate: backend + frontend
@@ -129,7 +129,7 @@ dev-stop:
 dev-logs:
 	@bash scripts/dev-logs.sh
 
-build test test-v test-cover test-integration e2e-ai e2e-ai-report ai-probe test-db-up test-it test-integration-serial bench-perf lint arch-lint vet gen drift composition check-composition test-extensions db-up db-init db-wait seed-reset seed-dev-db migrate migrate-up migrate-down run psql redis-cli tidy clean tools tools-go infra-logs infra-reset:
+build test test-v test-cover test-integration e2e-siteread e2e-ai e2e-ai-report ai-probe test-db-up test-it test-integration-serial bench-perf lint arch-lint vet gen gen-workflow mcp-apps-vocab drift composition check-composition test-extensions db-up db-init db-wait seed-reset seed-dev-db migrate migrate-up migrate-down run psql redis-cli tidy clean vuln tools tools-go infra-logs infra-reset:
 	$(MAKE) -C backend $@
 
 ## check-fe — the frontend half of the gate (part of `make check`). Fails loudly
@@ -443,6 +443,14 @@ check-host-ports:
 ## not catch the reverse — see the script for why that trade is deliberate.
 ci-doc-parity:
 	@./scripts/check-ci-doc-parity.sh
+
+## make-target-parity — every backend target `make help` advertises resolves
+## from the repo root, which is what the help text tells a reader (and a CI
+## step) it does. The root delegation list is hand-maintained, so a new backend
+## target is one edit away from being advertised and unreachable at once — how
+## the scheduled govulncheck lane came to report red daily without ever running.
+make-target-parity:
+	@./scripts/check-make-target-parity.sh
 
 ## contract-breaking-check — oasdiff severity gate on backend/api/crm.yaml vs
 ## origin/main: a breaking change (removed op, narrowed type…) fails; additive

--- a/docs/reference/make-targets.md
+++ b/docs/reference/make-targets.md
@@ -67,6 +67,7 @@ root gates (each is a small script; all merge-blocking):
 |---|---|
 | `check-image-pins` | Every workflow `uses:` and container `image:` is pinned to an immutable ref |
 | `check-host-ports` | Every host port published by `infra/docker-compose.dev.yml` is below the ephemeral floor (32768), so `db-up` cannot lose a bind to a transient client port |
+| `make-target-parity` | Every backend target `make help` advertises resolves from the repo root, as the help text promises. The root delegation list is hand-maintained, so a new backend target can be advertised and unreachable at once — and a CI step that calls it then fails at `No rule to make target` without ever running what it was gating |
 | `contract-breaking-check` | oasdiff severity gate on `api/crm.yaml` vs `origin/main` (breaking change fails; additive passes) |
 | `test-lanes` | Hermetic-unit-lane check: no untagged test opens a real Postgres/Redis |
 | `go-file-length` | Hard 500-LOC cap on hand-written **product** Go, ratcheted via `scripts/go-file-length-waivers.txt`. Test and generated files are exempt here — `*_test.go` is bounded at 1000 lines by the craft gate instead |
@@ -78,7 +79,7 @@ root gates (each is a small script; all merge-blocking):
 
 | Target | What it does |
 |---|---|
-| `vuln` | govulncheck over all packages (not yet part of `check`; CI wiring comes later) |
+| `vuln` | govulncheck over all packages. Not part of `check` — it answers against a database that changes daily, so it runs per-PR in `ci.yml` and again daily against `main` in `scheduled.yml`, which is the only lane that can find a vulnerability disclosed after a merge |
 | `hooks` (root) | Point git at `.githooks/` (`core.hooksPath`), arming the diff-scoped pre-push craft gate and the RLS/jurisdiction script gates. Run once after cloning; `make install` does it for you. The backend's own `make -C backend hooks` is a **different** target that installs `scripts/pre-commit` (gofmt + license header) — it does **not** set `core.hooksPath`, so it alone leaves the strict pre-push gate disarmed |
 | `check-gates` | The meta-gate lane: the waiver census, the obligations derived from the migrations and the contract, and the walk-scope proofs. A dev-loop convenience — deliberately **not** a `check-backend` prerequisite, since `make -C backend check` already runs these tests uncached |
 | `tools` / `tools-go` | Install every gate binary at its pinned version (fresh-machine bootstrap) |

--- a/scripts/check-make-target-parity.sh
+++ b/scripts/check-make-target-parity.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# check-make-target-parity.sh — every backend target `make help` advertises is
+# invocable from the repo root, as the help text promises it is.
+#
+# The root Makefile delegates to backend/ through a hand-maintained list of
+# target names, and `make help` prints the backend targets underneath the line
+# "each also runnable as `make <name>` from the repo root". A target added to
+# backend/Makefile and left out of that list breaks the promise silently: the
+# help still advertises it, and `make <name>` from the root answers
+#
+#   make: *** No rule to make target 'vuln'.  Stop.
+#
+# which is indistinguishable from a typo. That is not hypothetical. The
+# scheduled govulncheck lane ran `make vuln` from the repo root, where the
+# target did not exist, and the run failed at the step that was supposed to
+# scan — so the lane reported red every day without ever scanning main, and the
+# red read as the vulnerability it was meant to find.
+#
+# WHAT THIS CATCHES: a backend target advertised by `make help` that the root
+# Makefile cannot resolve. That is the direction with teeth — it turns a
+# documented command into an error, and a caller that is a CI step turns it
+# into a gate that never runs.
+#
+# WHAT THIS DOES NOT CATCH, deliberately: whether a given caller invokes make
+# from the right directory. Resolving that means teaching this script how
+# GitHub Actions layers workflow, job and step `working-directory`, and a gate
+# whose rules are fiddly is a gate that gets worked around rather than fixed.
+# Making every advertised target resolve from the root removes the question for
+# the direction that has actually failed.
+#
+# Root targets come from make's own database (`make -qpRr`) rather than a regex
+# over the Makefile, so a target reachable by any route counts as reachable.
+set -euo pipefail
+
+root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+backend_makefile="$root_dir/backend/Makefile"
+
+if [ ! -f "$backend_makefile" ]; then
+  echo "check-make-target-parity: $backend_makefile not found" >&2
+  exit 1
+fi
+
+# The backend's advertised surface, spelled the way `make -C backend help`
+# spells it: a target whose rule line carries a `## ` description.
+advertised="$(grep -hE '^[a-zA-Z][a-zA-Z0-9_-]*:.*## ' "$backend_makefile" | cut -d: -f1 | sort -u)"
+
+# Question mode prints the rule database without running a recipe. It exits
+# non-zero whenever the default goal is out of date, which says nothing about
+# the dump, so the status is discarded and the emptiness check below is what
+# decides whether the dump is usable.
+root_targets="$(cd "$root_dir" && make -qpRr --no-print-directory 2>/dev/null || true)"
+root_targets="$(printf '%s\n' "$root_targets" |
+  grep -E '^[a-zA-Z][a-zA-Z0-9_.-]*:([^=]|$)' | cut -d: -f1 | sort -u)"
+
+# Either list coming back empty would pass this gate while comparing nothing —
+# the failure a parity check is most likely to fail by.
+for pair in "advertised backend targets:$advertised" "root targets:$root_targets"; do
+  if [ -z "${pair#*:}" ]; then
+    echo "check-make-target-parity: extracted no ${pair%%:*} — the Makefile changed shape, so this gate was about to pass without comparing anything" >&2
+    exit 1
+  fi
+done
+
+missing="$(comm -23 <(printf '%s\n' "$advertised") <(printf '%s\n' "$root_targets"))"
+
+if [ -n "$missing" ]; then
+  while IFS= read -r target; do
+    echo "UNREACHABLE FROM ROOT: \`make $target\` is advertised by \`make help\` but the root Makefile has no such target — add it to the delegation list in Makefile" >&2
+  done <<<"$missing"
+  exit 1
+fi
+
+echo "make target parity OK ($(printf '%s\n' "$advertised" | grep -c .) backend targets, all reachable from the repo root)"


### PR DESCRIPTION
Closes #974.

## What was broken

The scheduled lane's `govulncheck (main)` job did not find a vulnerability. It never ran:

```
govulncheck (main)  Run make vuln   make: *** No rule to make target 'vuln'.  Stop.
```

`.github/workflows/scheduled.yml:63` runs `make vuln` with no `working-directory`, so it resolves at the repo root — and the root Makefile delegates to `backend/` through a hand-maintained list of target names (`Makefile:133`) that never included `vuln`. `ci.yml` is unaffected: it sets a workflow-level `defaults.run.working-directory: backend` (`ci.yml:30-32`), so its `govulncheck` job passes, which is why the gap survived.

The lane landed 2026-08-11 in fa43d67f (#891) and has run twice — both failures, at that step. **govulncheck has never scanned `main`.** The daily report then filed and bumped #974 as a *reachable* vulnerability, the one reading the failure cannot support, and the false alarm hid the absence of the scan. The issue's own "Reproduce locally with `make vuln`" fails at the repo root for the same reason.

## What this changes

Fixing the caller would leave the promise `make help` prints — that each backend target is "also runnable as `make <name>` from the repo root" (`Makefile:28`) — false for four targets, so the delegation list gains all four: `e2e-siteread`, `gen-workflow`, `mcp-apps-vocab`, `vuln`. No workflow change is needed; the scheduled job's invocation now resolves.

`scripts/check-make-target-parity.sh` then derives that promise instead of asking anyone to maintain it. The advertised set comes from the same `## ` rule descriptions `make -C backend help` reads; the root set comes from make's own rule database (`make -qpRr`) rather than a regex over the source, so a target reachable by any route counts. It fails loudly if either extraction comes back empty — a parity check that silently compares nothing is the way this kind of gate fails. Wired into `check-backend`, so it is merge-blocking and runs in CI's deterministic-gates job.

The script's header states what it does **not** cover — whether a given caller invokes make from the right directory — and why, following the precedent in `check-ci-doc-parity.sh`.

## Evidence

The gate was written first and run against the unfixed tree; it named the defect before the delegation list was touched:

```
$ ./scripts/check-make-target-parity.sh
UNREACHABLE FROM ROOT: `make e2e-siteread` is advertised by `make help` but the root Makefile has no such target — add it to the delegation list in Makefile
UNREACHABLE FROM ROOT: `make gen-workflow` ...
UNREACHABLE FROM ROOT: `make mcp-apps-vocab` ...
UNREACHABLE FROM ROOT: `make vuln` ...
EXIT=1
```

After the fix:

```
$ ./scripts/check-make-target-parity.sh
make target parity OK (45 backend targets, all reachable from the repo root)

$ make vuln          # from the repo root
make -C backend vuln
govulncheck ./...
No vulnerabilities found.
Your code is affected by 0 vulnerabilities.
```

That last line is the answer #974 was reporting the opposite of: the tree has **no reachable vulnerability**. govulncheck does see one vulnerability in an imported package and one in a required module — the open Dependabot high — but reports neither as called, which is exactly the distinction the scheduled lane exists to draw and has never been able to.

`make check-backend` green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the broken scheduled `govulncheck` by making every backend target advertised by `make help` runnable from the repo root. Adds an automated parity gate and updates root delegations so `make vuln` (and others) resolve correctly.

- **Bug Fixes**
  - Scheduled `govulncheck (main)` now runs: root `Makefile` delegates added for `e2e-siteread`, `gen-workflow`, `mcp-apps-vocab`, and `vuln`.

- **New Features**
  - Added `scripts/check-make-target-parity.sh` and `make make-target-parity`; verifies advertised backend targets are reachable from root; wired into `check-backend`.
  - Docs: updated `docs/reference/make-targets.md`; clarified `vuln` behavior and documented the new gate.

<sup>Written for commit 603f8568526b9e3f9974bade56a4731a7c841794. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/988?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

