### PR TITLE
docs(make-targets): the intro no longer calls `vuln` backend-only

### DIFF
--- a/docs/reference/make-targets.md
+++ b/docs/reference/make-targets.md
@@ -1,9 +1,10 @@
 # Make targets
 
 The real Makefile is `backend/Makefile`; the root Makefile delegates the
-common backend targets and adds the frontend lane. In `backend/`, `make`
-(or `make help`) lists targets with descriptions; `vuln` is backend-only
-(`make -C backend vuln` from the root).
+backend targets and adds the frontend lane. In `backend/`, `make` (or `make
+help`) lists targets with descriptions. Every target that listing advertises
+also runs as `make <name>` from the repo root, which `make-target-parity`
+enforces — so a command copied out of here works from either directory.
 
 ## Everyday
 


### PR DESCRIPTION
Follow-up to #988, which missed a sibling copy in the file it edited.

That PR made every advertised backend target resolve from the repo root and added `make-target-parity` to enforce it. Four lines above the gate table it landed in, the intro still read:

> `vuln` is backend-only (`make -C backend vuln` from the root).

Which is now the one thing the new gate exists to prevent. The intro states the invariant instead, and names the gate that holds it — so a command copied out of this page works from either directory.

Docs only. `make ci-doc-parity` and `make make-target-parity` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update Make targets docs to reflect that all listed backend targets run from the repo root, removing the outdated note that `vuln` is backend-only. Notes the `make-target-parity` gate that enforces this, so commands work from either `backend/` or the root.

<sup>Written for commit 6fb75b2e8c18fac41c7ef4ee044b7ba26ecc2c6e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/989?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

