### PR TITLE
fix(agents): a tier the contract tightens binds every door that can reach it

### DIFF
--- a/backend/internal/compose/agenttierfloor.go
+++ b/backend/internal/compose/agenttierfloor.go
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The contract's per-record-type tier declarations, handed to the tool door.
+//
+// `operationSpec` applies the tighten-only floor (A34/ADR-0026) to a REST call,
+// because a REST call names its operation. A tools/call names a VERB, and a verb
+// serving seven record types has one tier for all of them — so `createProject`
+// being confirm-first while `createPerson` is not was a decision only one of the
+// two doors could act on, and the write a route staged for a human ran unattended
+// through the tool that performs it (#982).
+//
+// This is the same table, read the other way: keyed by (verb, record_type) instead
+// of by route, so both doors resolve one contract declaration. DERIVED from
+// agentPolicies rather than listed, so an annotation added to crm.yaml binds the
+// tool door by regeneration and not by anyone remembering.
+
+import (
+	"strings"
+
+	"github.com/gradionhq/margince/backend/internal/modules/agents"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/mcp"
+)
+
+// toolRecordType is one (verb, record type) pair — the key a tool call can be
+// resolved by, where a route key cannot reach it.
+type toolRecordType struct{ tool, recordType string }
+
+// contractTierFloors is the tier the contract declares for the operation each verb
+// ACTUALLY PERFORMS, per record type.
+//
+// NOT the strictest tier across every route sharing the pair, which is the shape
+// this started as and was wrong in the direction that matters: `updateOrganization`
+// is auto-execute, while `updateOrganizationFact` — a different effect, writing a
+// sidecar row `update_record` cannot reach — is confirm-first. Collapsing them made
+// every ordinary organization patch confirm-first on the tool door while REST kept
+// it automatic: the same one-credential-two-answers divergence this file exists to
+// close, pointing the other way.
+//
+// So a pair takes the tier of its CANONICAL route: the collection route the
+// generic verb's own effect corresponds to. A route carrying anything further — a
+// second path parameter, a trailing action segment — is a different operation
+// that merely borrows this verb's tier annotation, and its tightening is not this
+// verb's to inherit.
+//
+// The OTHER half of that question — can this verb carry out its effect for this
+// record type at all — is answered by the tool, inside Registry.tightened, where
+// the tool is in hand. A floor entry for a type the verb cannot serve is inert
+// there rather than wrong here, and it is the tool that knows.
+var contractTierFloors = func() map[toolRecordType]mcp.RiskTier {
+	floors := map[toolRecordType]mcp.RiskTier{}
+	for route, pol := range agentPolicies {
+		if pol.Access != accessTool || pol.RecordType == "" || pol.Tier != tierConfirmationRequired {
+			continue
+		}
+		if !isCanonicalRecordRoute(route) {
+			continue
+		}
+		floors[toolRecordType{tool: pol.Tool, recordType: string(pol.RecordType)}] = mcp.TierConfirmationRequired
+	}
+	return floors
+}()
+
+// isCanonicalRecordRoute reports whether a route is a whole-record write on the
+// record's own collection — `/v1/<collection>` or `/v1/<collection>/{id}` — which
+// is the only shape a generic record verb performs.
+//
+// Read off the route pattern rather than listed, so a sidecar route added later is
+// excluded by being what it is. The deeper shapes this rejects are real and
+// current: `/v1/organizations/{id}/facts/{factKey}` writes a fact row,
+// `/v1/projects/{id}/stakeholders/{person_id}` a membership, and
+// `/v1/custom-fields/{id}/retire` performs an action — none of them a field patch
+// of the routed record, and none of them reachable through `update_record`.
+func isCanonicalRecordRoute(route string) bool {
+	_, path, found := strings.Cut(route, " ")
+	if !found {
+		return false
+	}
+	segments := strings.Split(strings.TrimPrefix(path, "/v1/"), "/")
+	switch len(segments) {
+	case 1:
+		return segments[0] != ""
+	case 2:
+		return segments[1] == "{id}"
+	default:
+		return false
+	}
+}
+
+// tierFloor answers the tier the contract declares for this verb against this
+// record type. It is agents.TierFloor, injected where the registry is built.
+func tierFloor(tool, recordType string) (mcp.RiskTier, bool) {
+	floor, declared := contractTierFloors[toolRecordType{tool: tool, recordType: recordType}]
+	return floor, declared
+}
+
+// withContractTierFloor carries the contract's declarations into a registry. The
+// composed api surface passes it; the integration lane is what proves that, since
+// a comment cannot.
+func withContractTierFloor() agents.RegistryOption { return agents.WithTierFloor(tierFloor) }

--- a/backend/internal/compose/agenttierfloor_integration_test.go
+++ b/backend/internal/compose/agenttierfloor_integration_test.go
@@ -1,0 +1,249 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package compose
+
+// The bypass itself, against real Postgres (#982).
+//
+// The contract declares `createProject` and `updateProject` confirm-first for an
+// agent — a tier tightened for ONE record type, where creating a person or a
+// deal is not tightened at all. The REST door honours it, because its tier comes
+// from the operation. The MCP door resolves a tier from the VERB, and the verb
+// that performs the same write is `create_record`, which is auto-execute for
+// every type it admits.
+//
+// So the refusal is one tool call away from being irrelevant, and the only way
+// to prove that is to let the call reach the write and then look at the
+// database. A unit test asserting a resolved tier would prove what the gate
+// decided; it would not prove that a project now exists which no human agreed
+// to.
+//
+// The registry is built through registryWithGate — the same function the api role
+// composes — so what is proved is that the floor is WIRED and applied before
+// admission, not merely that the option works. The missing wiring WAS the defect,
+// and a registry a test assembled itself would prove only the option.
+//
+// One seam is stubbed: the authority resolver (adminSeat, from
+// dealmovepin_integration_test.go). The harness seeds users with no role
+// assignment, so the live resolver denies every grant, and a refusal for a
+// missing grant looks exactly like the refusal these tests want. Stubbing the
+// question that is NOT under test is what lets the tier be the only thing that
+// can answer.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/gradionhq/margince/backend/internal/compose/integration"
+	"github.com/gradionhq/margince/backend/internal/modules/agents"
+	"github.com/gradionhq/margince/backend/internal/platform/auth"
+	"github.com/gradionhq/margince/backend/internal/platform/database"
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
+)
+
+func TestATierTheContractTightensForOneRecordTypeBindsTheToolDoorToo(t *testing.T) {
+	e := integration.Setup(t)
+	human := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AdminPerms)
+	native := NewProvider(e.Pool)
+
+	registry := composedRegistry(e)
+
+	org := seedOrgForTierFloor(human, t, native)
+
+	// The identical effect POST /v1/projects performs, asked for through the
+	// verb whose tier the contract never tightened.
+	_, err := registry.Invoke(tierFloorAgent(t, e), "create_record",
+		json.RawMessage(`{"record_type":"project","fields":{"name":"Unapproved",`+
+			`"organization_id":"`+org.String()+`"}}`))
+
+	// Three assertions, answering three different questions, because any two of
+	// them pass for the wrong reason.
+	//
+	// The sentinel alone proves least: workflow.StagedApprovalError unwraps to
+	// ErrRequiresApproval, and so does the bare refusal a tool with no StageInfo
+	// returns — so a fix that tightened the tier and left the call dead-ending
+	// would satisfy it exactly. The staged ROW is what separates "put to a human"
+	// from "refused with nowhere to land", which is the whole point of the two new
+	// StageInfo implementations. The row count says no effect happened, which a
+	// call refused for a missing grant would also satisfy — hence a full seat.
+	if !errors.Is(err, apperrors.ErrRequiresApproval) {
+		t.Errorf("create_record{project} answered %v, want the confirm-first refusal the "+
+			"contract declares for createProject — a tier tightened for one record type is a "+
+			"decision the tool door cannot see", err)
+	}
+	if n := liveProjectsNamed(human, t, e, "Unapproved"); n != 0 {
+		t.Errorf("%d project(s) named Unapproved exist; the agent performed unattended the write "+
+			"POST /v1/projects would have staged for a human", n)
+	}
+	assertStagedApprovalRow(human, t, e, stagedRow{kind: "create_record", targetType: "project", hasTargetID: false})
+}
+
+// The update half of the same bypass. It is a separate call rather than a table
+// case because it stages a different SHAPE — a target id and a pin, where the
+// create has neither — and because a fix that tightened creates and missed
+// updates would otherwise leave every gate in this package green.
+func TestATightenedUpdateAlsoStagesOnTheToolDoor(t *testing.T) {
+	e := integration.Setup(t)
+	human := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AdminPerms)
+	native := NewProvider(e.Pool)
+	registry := composedRegistry(e)
+
+	org := seedOrgForTierFloor(human, t, native)
+	project := seedProjectForTierFloor(human, t, native, org)
+
+	_, err := registry.Invoke(tierFloorAgent(t, e), "update_record",
+		json.RawMessage(`{"record_type":"project","id":"`+project.String()+
+			`","fields":{"name":"Renamed without asking"}}`))
+
+	if !errors.Is(err, apperrors.ErrRequiresApproval) {
+		t.Errorf("update_record{project} answered %v, want the confirm-first refusal "+
+			"PATCH /v1/projects/{id} declares", err)
+	}
+	if n := liveProjectsNamed(human, t, e, "Renamed without asking"); n != 0 {
+		t.Error("the project was renamed unattended; the REST twin stages that patch for a human")
+	}
+	assertStagedApprovalRow(human, t, e, stagedRow{kind: "update_record", targetType: "project", hasTargetID: true})
+}
+
+// An ordinary organization patch must NOT stage. `updateOrganization` is
+// auto-execute, and the confirm-first routes that share (update_record,
+// organization) — the fact and profile-field corrections — write a sidecar row
+// this verb cannot reach. A floor that collapsed them tightened every org patch
+// on the tool door while REST kept it automatic: #982 in reverse, which is what
+// this test exists to catch and what the first draft of the fix did.
+func TestAnOrdinaryOrganizationPatchStillRunsUnattended(t *testing.T) {
+	e := integration.Setup(t)
+	human := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AdminPerms)
+	native := NewProvider(e.Pool)
+	registry := composedRegistry(e)
+
+	org := seedOrgForTierFloor(human, t, native)
+
+	if _, err := registry.Invoke(tierFloorAgent(t, e), "update_record",
+		json.RawMessage(`{"record_type":"organization","id":"`+org.String()+
+			`","fields":{"industry":"Logistics"}}`)); err != nil {
+		t.Fatalf("an ordinary organization patch answered %v, want it to run — the contract "+
+			"declares updateOrganization auto-execute, and tightening it here would make the tool "+
+			"door stage what the REST door performs", err)
+	}
+}
+
+// composedRegistry is the api role's own composition, with the authority seam
+// stubbed for the reason stated at the top of this file. It goes through
+// registryWithGate rather than NewRegistry so the tier floor arrives the way
+// production supplies it.
+func composedRegistry(e *integration.Env) *agents.Registry {
+	return registryWithGate(e.Pool, auth.NewGate(adminSeat{}), nil, nil,
+		SendPath{}, companyEnricher{}, nil)
+}
+
+// stagedRow is what a staged approval must look like for the operation that
+// produced it — the shape, not just the fact that something was written.
+type stagedRow struct {
+	kind, targetType string
+	hasTargetID      bool
+}
+
+// assertStagedApprovalRow reads the approval the refusal claims to have minted. Without it
+// this suite could not tell a staged call from one refused with nowhere to land:
+// both answer ErrRequiresApproval, and only one of them puts a question in front
+// of a human.
+func assertStagedApprovalRow(as context.Context, t *testing.T, e *integration.Env, want stagedRow) {
+	t.Helper()
+	var kind, targetType string
+	var targetID *ids.UUID
+	if err := database.WithWorkspaceTx(as, e.Pool, func(tx pgx.Tx) error {
+		return tx.QueryRow(as, `
+			SELECT kind, coalesce(target_entity_type, ''), target_entity_id
+			  FROM approval
+			 WHERE kind = $1 AND status = 'pending'`, want.kind).Scan(&kind, &targetType, &targetID)
+	}); err != nil {
+		t.Fatalf("no pending %s approval was staged (%v) — the call was refused with nowhere to "+
+			"land, which is not the confirm-first promise the contract makes", want.kind, err)
+	}
+	if targetType != want.targetType {
+		t.Errorf("staged target type %q, want %q — the approvals surface scopes an inbox row by "+
+			"probing its target's own visibility, and it cannot probe a type it was not told",
+			targetType, want.targetType)
+	}
+	if got := targetID != nil; got != want.hasTargetID {
+		t.Errorf("staged with a target id = %v, want %v", got, want.hasTargetID)
+	}
+}
+
+// seedProjectForTierFloor creates one project through the real writer, so the
+// update case patches a row the store actually wrote.
+func seedProjectForTierFloor(as context.Context, t *testing.T, p *Provider, org ids.UUID) ids.UUID {
+	t.Helper()
+	ref, err := p.Create(as, datasource.CreateInput{
+		EntityType: datasource.EntityProject,
+		Fields:     json.RawMessage(`{"name":"Tier floor project","organization_id":"` + org.String() + `"}`),
+		Source:     "test",
+	})
+	if err != nil {
+		t.Fatalf("seeding the project: %v", err)
+	}
+	return ref.ID
+}
+
+// seedOrgForTierFloor creates the anchor company a project requires, through the
+// real writer.
+func seedOrgForTierFloor(as context.Context, t *testing.T, p *Provider) ids.UUID {
+	t.Helper()
+	ref, err := p.Create(as, datasource.CreateInput{
+		EntityType: datasource.EntityOrganization,
+		Fields:     json.RawMessage(`{"display_name":"Tier floor anchor"}`),
+		Source:     "test",
+	})
+	if err != nil {
+		t.Fatalf("seeding the anchor company: %v", err)
+	}
+	return ref.ID
+}
+
+// liveProjectsNamed counts the projects the call did or did not create.
+//
+// Bound through WithWorkspaceTx, not read off the pool directly. Env.Pool is the
+// RLS-bound app role, so an unbound `SELECT count(*) FROM project` resolves the
+// policy expression against a NULL workspace and answers zero for every row that
+// exists — an absence-assertion that passes whether or not the write happened,
+// which is the one thing this test may not do.
+func liveProjectsNamed(as context.Context, t *testing.T, e *integration.Env, name string) int {
+	t.Helper()
+	var n int
+	if err := database.WithWorkspaceTx(as, e.Pool, func(tx pgx.Tx) error {
+		return tx.QueryRow(as, `SELECT count(*) FROM project WHERE name = $1`, name).Scan(&n)
+	}); err != nil {
+		t.Fatalf("counting the projects: %v", err)
+	}
+	return n
+}
+
+// tierFloorAgent is a passport holding every scope and grant a project create
+// needs, so the only thing left that can refuse it is the tier.
+//
+// The passport is SEEDED rather than invented: a staged approval records the
+// passport it was minted by under a real foreign key, so a synthetic id fails in
+// the database and the test would report a schema complaint where it means to
+// report a governance decision.
+func tierFloorAgent(t *testing.T, e *integration.Env) context.Context {
+	t.Helper()
+	ctx := principal.WithWorkspaceID(context.Background(), e.WS)
+	ctx = principal.WithCorrelationID(ctx, ids.NewV7())
+	return principal.WithActor(ctx, principal.Principal{
+		Type: principal.PrincipalAgent, ID: "agent:tier-floor", SeatType: principal.SeatFull,
+		OnBehalfOf: e.Rep1, UserID: e.Rep1,
+		PassportID:  e.SeedPassport(t, integration.OwnerConn(t), "tier floor probe"),
+		Scopes:      principal.NewScopeSet(principal.ScopeRead, principal.ScopeWrite),
+		Permissions: integration.AdminPerms,
+	})
+}

--- a/backend/internal/compose/agenttierfloor_test.go
+++ b/backend/internal/compose/agenttierfloor_test.go
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// A tier the contract declares binds every door that can reach the effect.
+//
+// #982 was not a missing line; it was a vocabulary mismatch nothing could see.
+// The contract tightens per OPERATION, a tool declares per VERB, and where one
+// verb serves seven record types the tightening had nowhere to live on the tool
+// door — so `createProject` was confirm-first on one door and auto-execute on the
+// other, and no test failed.
+//
+// These gates are derived from the generated policy table rather than from a list
+// of today's affected pairs. A new `x-mcp-tool` annotation that tightens a record
+// type a generic verb already performs regenerates that table and fails here until
+// the floor and the staging behind it exist.
+//
+// What they do NOT prove is that the floor is WIRED into the served registry, or
+// that it runs before admission. No unit test in this package can: the floor is a
+// function the composition passes and the tier is decided inside Admit. The
+// integration lane proves both, for a create and for an update — see
+// agenttierfloor_integration_test.go.
+
+import (
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/ports/mcp"
+)
+
+// tightenedPairs are the (verb, record type) pairs whose tier the contract
+// tightens BEYOND what the verb itself declares, for an effect that verb actually
+// performs. That is the whole subject of #982 and the set these gates walk.
+//
+// Both filters matter. A pair whose verb is already confirm-first needs no floor.
+// A route that is not the record's own collection route — a fact write, a
+// stakeholder membership, a retire action — is a different operation borrowing
+// this verb's annotation, and inheriting its tightening would stage every ordinary
+// patch of that record type. A record type the verb cannot serve is not a tightening
+// at all: the call is refused at the provider, and staging it first would spend a
+// human's yes on a call that was never going to run.
+func tightenedPairs(t *testing.T) map[toolRecordType]string {
+	t.Helper()
+	registry := NewRegistry(nil, SendPath{})
+	pairs := map[toolRecordType]string{}
+	for route, pol := range agentPolicies {
+		if pol.Access != accessTool || pol.RecordType == "" || pol.Tier != tierConfirmationRequired {
+			continue
+		}
+		spec, registered := registry.Spec(pol.Tool)
+		if !registered || spec.Tier == mcp.TierConfirmationRequired {
+			continue
+		}
+		if !isCanonicalRecordRoute(route) || !registry.Performs(pol.Tool, string(pol.RecordType)) {
+			continue
+		}
+		pairs[toolRecordType{tool: pol.Tool, recordType: string(pol.RecordType)}] = route
+	}
+	return pairs
+}
+
+func TestEveryTierTheContractTightensReachesTheToolDoor(t *testing.T) {
+	pairs := tightenedPairs(t)
+	if len(pairs) == 0 {
+		t.Fatal("no tightened pair found — this gate walks the set #982 is about, and an empty " +
+			"set means the derivation stopped seeing it, not that the contract stopped declaring it")
+	}
+	for pair, route := range pairs {
+		if _, declared := tierFloor(pair.tool, pair.recordType); !declared {
+			t.Errorf("%s tightens %s to confirm-first for record type %q, and the tool door's floor "+
+				"does not know it — an agent refused on that route performs the same write by calling "+
+				"the verb instead", route, pair.tool, pair.recordType)
+		}
+	}
+}
+
+// A floor with nowhere to land is a refusal wearing an approval's clothes: the
+// gate answers "this needs a human" and no inbox row is ever minted, so the
+// action is not confirm-first at all — it is impossible, which is a different
+// promise from the one the contract made.
+func TestEveryVerbTheFloorTightensCanStage(t *testing.T) {
+	registry := NewRegistry(nil, SendPath{})
+	for pair, route := range tightenedPairs(t) {
+		if !registry.Stageable(pair.tool) {
+			t.Errorf("%s tightens %s to confirm-first for %q, but %s cannot stage — the refusal "+
+				"would have nowhere to land, so the call is refused outright rather than put to a human",
+				route, pair.tool, pair.recordType, pair.tool)
+		}
+	}
+}
+
+// The floor is only reachable through a tool that can say which record type a
+// call names. A verb the contract tightens per record type whose tool cannot
+// answer that question would take the floor for no call at all — every other gate
+// green, and the bypass still open.
+func TestEveryVerbTheFloorTightensNamesItsRecordType(t *testing.T) {
+	registry := NewRegistry(nil, SendPath{})
+	for pair, route := range tightenedPairs(t) {
+		if !registry.NamesRecordType(pair.tool) {
+			t.Errorf("%s tightens %s for record type %q, but %s does not report the record type of "+
+				"a call, so the floor is never consulted for it", route, pair.tool, pair.recordType, pair.tool)
+		}
+	}
+}
+
+// The floor must not reach an operation the verb does not perform. This is the
+// regression that shipped in this change's first draft: every confirm-first route
+// riding `update_record` for an organization was collapsed onto the pair, so an
+// ordinary organization patch — auto-execute on REST, by `updateOrganization` —
+// became confirm-first on the tool door. That is #982 pointing the other way, and
+// it is invisible to every gate above, all of which only ask whether the floor
+// knows ENOUGH.
+func TestTheFloorTightensNothingTheContractLeavesAutomatic(t *testing.T) {
+	for route, pol := range agentPolicies {
+		if pol.Access != accessTool || pol.RecordType == "" || pol.Tier != tierAutoExecute {
+			continue
+		}
+		if !isCanonicalRecordRoute(route) {
+			continue
+		}
+		if _, declared := tierFloor(pol.Tool, string(pol.RecordType)); declared {
+			t.Errorf("%s is auto-execute — it IS the operation %s performs for %q — and the floor "+
+				"tightens that pair anyway, so the tool door stages what the REST door runs unattended",
+				route, pol.Tool, pol.RecordType)
+		}
+	}
+}

--- a/backend/internal/compose/registry.go
+++ b/backend/internal/compose/registry.go
@@ -93,7 +93,13 @@ func registryWithGate(pool *pgxpool.Pool, gate *auth.Gate, drafter activities.Em
 	// The replay reader is the composite provider this registry is already
 	// composed over, so a recorded result's records are re-checked through the
 	// same door — mirror included — that a live read of them would take.
-	opts = append(opts, agents.WithIdempotency(toolIdempotency(pool)), agents.WithReplayReader(provider))
+	// The contract's per-record-type tier floor, on EVERY role that composes this
+	// surface. A verb's own tier cannot express "confirm-first for a project and
+	// auto-execute for a person", so without this the tool door admits at a tier
+	// the contract tightened and the REST door refuses (#982) — one credential,
+	// two answers, which is what ADR-0055 exists to prevent.
+	opts = append(opts, withContractTierFloor(),
+		agents.WithIdempotency(toolIdempotency(pool)), agents.WithReplayReader(provider))
 	registry := agents.NewRegistry(approvalsAdapter{svc: approvals.NewService(pool)}, gate, opts...)
 	// The guards take the Dispatcher as an overlayModeChecker — the interface
 	// whose method IS the uncached read, so no wiring here can hand them the

--- a/backend/internal/modules/agents/registry.go
+++ b/backend/internal/modules/agents/registry.go
@@ -63,6 +63,9 @@ type Registry struct {
 	// granting human's authority live per call. A nil gate fails closed
 	// for agent principals (Gate.Admit owns that rule).
 	gate *auth.Gate
+	// tierFloor carries the contract's per-record-type tier declarations, which
+	// a verb's own tier cannot express (tierfloor.go, #982).
+	tierFloor TierFloor
 	// quota is the MCP-SESS-* meter this surface CHARGES. The gate holds the
 	// same meter and does the refusing; the split is deliberate — a bound is
 	// enforced where admission is decided and paid where records and effects
@@ -141,6 +144,11 @@ func (r *Registry) InvokeServing(ctx context.Context, name string, in json.RawMe
 		return nil, 0, err
 	}
 	args := res.Args
+
+	// The contract may tighten this verb's tier for the record type this call
+	// names, and only the call can say which type that is (tierfloor.go).
+	// Applied before Admit, because the tier is what Admit decides on.
+	spec = r.tightened(t, spec, args)
 
 	admitted, err := r.gate.Admit(ctx, spec, r.tierResolverFor(ctx, t, name, args))
 	// Static-tier tools, whose resolver Admit never runs. After authority and
@@ -341,6 +349,51 @@ func (r *Registry) stageRefusedCall(ctx context.Context, t mcp.Tool, tool string
 		return err
 	}
 	return &workflow.StagedApprovalError{ApprovalID: id}
+}
+
+// Stageable reports whether a refused 🟡 call on this verb has somewhere to
+// land. Exported for the composition root's gate: a tier the contract tightens
+// onto a verb that cannot stage turns an approval question into a dead end, so
+// the gate has to be able to ask this rather than assume it.
+func (r *Registry) Stageable(name string) bool {
+	r.mu.RLock()
+	t, ok := r.tools[name]
+	r.mu.RUnlock()
+	if !ok {
+		return false
+	}
+	_, stageable := t.(stageableTool)
+	return stageable
+}
+
+// NamesRecordType reports whether this verb can say which record type a given
+// call acts on, which is the only way the contract's per-record-type floor is
+// ever consulted for it (tierfloor.go). Exported for the same gate as Stageable:
+// a floor declared for a verb that cannot answer binds nothing, and reads green.
+func (r *Registry) NamesRecordType(name string) bool {
+	r.mu.RLock()
+	t, ok := r.tools[name]
+	r.mu.RUnlock()
+	if !ok {
+		return false
+	}
+	_, typed := t.(recordTypedTool)
+	return typed
+}
+
+// Performs reports whether this verb can carry out its effect for this record
+// type. The composition root derives the tier floor from it: tightening a pair
+// the verb cannot serve would turn an instant refusal into an approval a human
+// spends on a call that dies at the provider.
+func (r *Registry) Performs(name, recordType string) bool {
+	r.mu.RLock()
+	t, ok := r.tools[name]
+	r.mu.RUnlock()
+	if !ok {
+		return false
+	}
+	typed, isTyped := t.(recordTypedTool)
+	return isTyped && typed.ServesRecordType(recordType)
 }
 
 // Spec returns the registered spec for name — the REST admission path

--- a/backend/internal/modules/agents/stagingfitness_test.go
+++ b/backend/internal/modules/agents/stagingfitness_test.go
@@ -11,10 +11,21 @@ package agents
 // lives elsewhere — one with no args entry fails here, and one that forgets the
 // guard fails here too.
 //
-// Two boundaries this walk does NOT cover, stated so neither reads as covered:
-//   - update_record stages through stageConflicts, not StageInfo, so it is
-//     invisible here; TestUpdateRecordRefusesStagingForATargetHeldElsewhere is
-//     its pin, and that test fails if its guard is removed.
+// Two tools answer a DIFFERENT question here, and both are walked rather than
+// excused:
+//   - update_record stages twice over. Its per-field residue goes through
+//     stageConflicts, which this walk cannot see —
+//     TestUpdateRecordRefusesStagingForATargetHeldElsewhere is that path's pin.
+//     Its StageInfo is the whole-call staging the contract's per-record-type
+//     tier floor produces (#982), and that one IS walked here, because it reads
+//     the record it patches exactly as its 🟡 siblings do.
+//   - create_record stages a CREATE, which names no existing record, so there is
+//     no target whose system of record could be elsewhere and nothing for
+//     refuseStagingElsewhere to be called about. It is held to the invariant it
+//     does have — stagesACreate below — rather than dropped from the count, so a
+//     create that began inventing a target still fails something.
+//
+// One boundary this walk does NOT cover, stated so it does not read as covered:
 //   - the walk builds only RegisterCoreTools and RegisterCommsTools. Every
 //     stageable tool lives in one of the two today; one registered by a third
 //     family would escape, which is what the count assertion below is for — it
@@ -63,6 +74,16 @@ func TestEveryStageableToolRefusesATargetHeldElsewhere(t *testing.T) {
 		"send_account_email": fmt.Sprintf(
 			`{"to":["a@example.test"],"subject":"s","body":"b","consent_purpose":"support",`+
 				`"links":[{"entity_type":"organization","entity_id":%q}]}`, ids.NewV7()),
+		// The whole-call staging the tier floor produces (#982). It patches an
+		// existing row, so it carries the same obligation as its siblings.
+		"update_record": fmt.Sprintf(`{"record_type":"person","id":%q,"fields":{"full_name":"X"}}`, person),
+	}
+	// A create names no existing record, so it has no target to probe. What it
+	// owes instead is to stage the shape it claims: the record TYPE, and no id —
+	// an id here would be a target the approvals surface probes for row scope and
+	// pins a version against, neither of which exists yet.
+	stagesACreate := map[string]string{
+		"create_record": `{"record_type":"person","fields":{"full_name":"Fresh"}}`,
 	}
 
 	registry := NewRegistry(&recordingApprovals{}, nil)
@@ -81,6 +102,18 @@ func TestEveryStageableToolRefusesATargetHeldElsewhere(t *testing.T) {
 			continue
 		}
 		walked++
+		if in, creates := stagesACreate[name]; creates {
+			info, err := stageable.StageInfo(context.Background(), json.RawMessage(in))
+			if err != nil {
+				t.Errorf("%s.StageInfo err = %v, want a staged create — a create reads no record, "+
+					"so nothing here should refuse it", name, err)
+			}
+			if !info.TargetID.IsZero() {
+				t.Errorf("%s staged target id %s; a create has no row yet, and naming one makes the "+
+					"approvals surface probe and pin a record that does not exist", name, info.TargetID)
+			}
+			continue
+		}
 		in, known := args[name]
 		if !known {
 			t.Errorf("%s can stage an approval but this pin carries no arguments for it — "+
@@ -92,9 +125,9 @@ func TestEveryStageableToolRefusesATargetHeldElsewhere(t *testing.T) {
 				"no human can release, because redemption re-reads a row this record does not have", name, err)
 		}
 	}
-	if walked != len(args) {
+	if pinned := len(args) + len(stagesACreate); walked != pinned {
 		t.Errorf("walked %d stageable core tools, pinned %d — the core set changed, so a staging site "+
-			"may now be unexercised", walked, len(args))
+			"may now be unexercised", walked, pinned)
 	}
 }
 

--- a/backend/internal/modules/agents/tierfloor.go
+++ b/backend/internal/modules/agents/tierfloor.go
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package agents
+
+// A tier the CONTRACT tightens for ONE record type, made visible to the tool door.
+//
+// ADR-0026's tighten-only floor is declared per contract OPERATION — `createProject`
+// is confirm-first where `createPerson` is not — while a tool's tier is declared per
+// VERB. The REST door resolves the operation and sees the tightening; this door
+// resolves `create_record` and could not, so the write a route staged for a human
+// ran unattended through the verb that performs it (#982).
+//
+// The floor asks the question the contract already answers: for THIS call's
+// (verb, record_type), what is the tightest tier any operation declares? The answer
+// is derived from the generated policy table at the composition root, so the
+// contract stays the one source and a new annotation cannot bind one door only.
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/gradionhq/margince/backend/internal/shared/ports/mcp"
+)
+
+// TierFloor answers the tier the contract declares for this verb against this
+// record type, and whether it declares one at all.
+type TierFloor func(tool, recordType string) (mcp.RiskTier, bool)
+
+// WithTierFloor injects the contract's per-record-type tier declarations. A
+// registry composed without one admits every call at its verb's declared tier,
+// which is the pre-#982 behaviour; the composed api surface always passes one,
+// and the integration lane is what proves that wiring rather than this comment.
+func WithTierFloor(floor TierFloor) RegistryOption {
+	return func(r *Registry) { r.tierFloor = floor }
+}
+
+// recordTypedTool is a tool whose arguments NAME the record type it acts on, so a
+// tier tightened for one type can be resolved for a CALL rather than for a verb.
+// A tool that names no record type has nothing to key on and keeps its declared
+// tier — which is correct, because a tool serving one record type declares that
+// type's tier already.
+//
+// RecordTypeOf answers a bare string rather than a string and an error: an
+// unreadable argument object is not this seam's to report. Returning "" leaves the
+// declared tier in place and lets requireDeclaredArgs and the handler's own strict
+// decode produce the message that names the field, rather than two surfaces
+// answering for one mistake.
+//
+// ServesRecordType is the other half, and it is what keeps the floor from making
+// things worse: a verb that cannot carry out the effect for a record type must not
+// be tightened for it, because tightening converts an immediate refusal into a
+// staged approval a human releases onto a call that was never going to run.
+type recordTypedTool interface {
+	RecordTypeOf(args json.RawMessage) string
+	ServesRecordType(recordType string) bool
+}
+
+// recordTypeArg reads the `record_type` argument the generic verbs share.
+func recordTypeArg(args json.RawMessage) string {
+	var a struct {
+		RecordType string `json:"record_type"`
+	}
+	if err := json.Unmarshal(args, &a); err != nil {
+		return ""
+	}
+	return a.RecordType
+}
+
+// tightened applies the contract's floor to the spec this call is admitted
+// against.
+//
+// It can only TIGHTEN, never loosen — the same one-way rule compose.operationSpec
+// applies on the REST door (A34/ADR-0026), so a verb declared confirm-first stays
+// confirm-first whatever an operation says, and a floor that is not confirm-first
+// changes nothing. Clearing TierResolver with the tier is deliberate and matches
+// the REST door: a resolver that could answer 🟢 must not survive a decision to
+// stage.
+func (r *Registry) tightened(t mcp.Tool, spec mcp.ToolSpec, args json.RawMessage) mcp.ToolSpec {
+	if r.tierFloor == nil {
+		return spec
+	}
+	typed, ok := t.(recordTypedTool)
+	if !ok {
+		return spec
+	}
+	recordType := typed.RecordTypeOf(args)
+	if recordType == "" {
+		return spec
+	}
+	// A type this verb cannot carry out is left at its declared tier, so the call
+	// meets the provider's refusal directly. Tightening it would stage an approval
+	// a human releases onto a call that then dies at the provider with the
+	// one-shot authority already spent — strictly worse than refusing now.
+	if !typed.ServesRecordType(recordType) {
+		return spec
+	}
+	floor, declared := r.tierFloor(spec.Name, recordType)
+	if !declared || floor != mcp.TierConfirmationRequired {
+		return spec
+	}
+	spec.Tier, spec.TierResolver = mcp.TierConfirmationRequired, nil
+	return spec
+}
+
+// summaryFieldLimit bounds how many field names a staged generic write
+// enumerates, so one very wide patch cannot fill an inbox line.
+const summaryFieldLimit = 8
+
+// describeGenericWrite is the one line the inbox shows for a create or an update
+// staged through a generic verb — the act, the record type, and which fields the
+// call sets, sorted so two renderings of one call read alike.
+//
+// It names the fields rather than their values. The sibling 🟡 tools render
+// values because their arguments ARE the effect a human weighs — who a mail
+// reaches, when a meeting lands. A record patch's values are the record, and the
+// staged row carries the whole of them in proposed_change, which the inbox shows
+// beside this line; repeating them here would truncate exactly the long text a
+// reader would then have to open proposed_change to see anyway.
+func describeGenericWrite(act, recordType string, fields json.RawMessage) string {
+	head := fmt.Sprintf("%s a %s", act, recordType)
+	var patch map[string]json.RawMessage
+	if json.Unmarshal(fields, &patch) != nil || len(patch) == 0 {
+		return head
+	}
+	names := make([]string, 0, len(patch))
+	for name := range patch {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	if len(names) > summaryFieldLimit {
+		names = append(names[:summaryFieldLimit],
+			fmt.Sprintf("+%d more", len(names)-summaryFieldLimit))
+	}
+	return head + ", setting " + strings.Join(names, ", ")
+}

--- a/backend/internal/modules/agents/tierfloor_test.go
+++ b/backend/internal/modules/agents/tierfloor_test.go
@@ -1,0 +1,209 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package agents
+
+// What the floor does with each answer it can get, and what the two generic
+// verbs stage once it has tightened them.
+//
+// The composition root's gates prove the floor KNOWS every pair the contract
+// tightens, and the integration lane proves the wiring reaches a real call.
+// Neither reaches the branches here: a tool that names no record type, a floor
+// that declares nothing for the pair, an argument object that will not decode.
+// Each of those silently returns the declared tier, so a mistake in one is a
+// bypass that looks exactly like a correct pass.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/mcp"
+)
+
+// confirmFirstForCreating answers a floor that tightens create_record for
+// exactly one record type, so a test can say which call it means to be about.
+// The verb is fixed because the floor's whole subject is the record type: a
+// tightening keyed on the verb alone is what a ToolSpec.Tier already expresses.
+func confirmFirstForCreating(recordType string) TierFloor {
+	return func(gotTool, gotType string) (mcp.RiskTier, bool) {
+		if gotTool == "create_record" && gotType == recordType {
+			return mcp.TierConfirmationRequired, true
+		}
+		return mcp.TierAutoExecute, false
+	}
+}
+
+func TestTheFloorTightensOnlyTheRecordTypeItNames(t *testing.T) {
+	r := NewRegistry(nil, nil, WithTierFloor(confirmFirstForCreating("project")))
+	tool := createRecord{}
+	green := tool.Spec()
+
+	tightened := r.tightened(tool, green, json.RawMessage(`{"record_type":"project","fields":{}}`))
+	if tightened.Tier != mcp.TierConfirmationRequired {
+		t.Errorf("a project create admitted at tier %v, want confirm-first — the floor named this "+
+			"very pair", tightened.Tier)
+	}
+	if tightened.TierResolver != nil {
+		t.Error("the tightened spec kept a tier resolver, which could still answer auto-execute " +
+			"for a call the contract says a human must see")
+	}
+
+	untouched := r.tightened(tool, green, json.RawMessage(`{"record_type":"person","fields":{}}`))
+	if untouched.Tier != green.Tier {
+		t.Errorf("a person create admitted at tier %v, want the verb's own %v — tightening a pair "+
+			"the contract never declared would stage work nobody asked to review",
+			untouched.Tier, green.Tier)
+	}
+}
+
+// The three answers that all look like "no change" and are not the same thing.
+// A regression in any of them reopens #982 while every other test stays green.
+func TestTheFloorLeavesTheDeclaredTierWhenItCannotAnswer(t *testing.T) {
+	green := createRecord{}.Spec()
+	project := json.RawMessage(`{"record_type":"project","fields":{}}`)
+
+	cases := map[string]struct {
+		registry *Registry
+		tool     mcp.Tool
+		args     json.RawMessage
+	}{
+		"no floor composed": {
+			registry: NewRegistry(nil, nil), tool: createRecord{}, args: project,
+		},
+		"a tool that names no record type": {
+			registry: NewRegistry(nil, nil, WithTierFloor(confirmFirstForCreating("project"))),
+			tool:     logActivity{}, args: project,
+		},
+		"an argument object that will not decode": {
+			registry: NewRegistry(nil, nil, WithTierFloor(confirmFirstForCreating("project"))),
+			tool:     createRecord{}, args: json.RawMessage(`not json`),
+		},
+		"a pair the contract declares nothing for": {
+			registry: NewRegistry(nil, nil, WithTierFloor(confirmFirstForCreating("deal"))),
+			tool:     createRecord{}, args: project,
+		},
+		// The contract tightens createCustomField, and this verb cannot create a
+		// custom field. Tightening anyway would turn the provider's immediate
+		// refusal into an approval a human releases onto a call that then dies.
+		"a record type the verb does not serve": {
+			registry: NewRegistry(nil, nil, WithTierFloor(confirmFirstForCreating("custom_field"))),
+			tool:     createRecord{}, args: json.RawMessage(`{"record_type":"custom_field","fields":{}}`),
+		},
+	}
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			if got := c.registry.tightened(c.tool, green, c.args).Tier; got != green.Tier {
+				t.Errorf("tier = %v, want the declared %v", got, green.Tier)
+			}
+		})
+	}
+}
+
+// A verb the floor could tighten must be able to say which record a call names,
+// or the floor is consulted for nothing. The two generic verbs are the whole
+// set today; the composition root's gate holds that claim against the contract.
+func TestBothGenericVerbsNameTheRecordTypeOfACall(t *testing.T) {
+	args := json.RawMessage(`{"record_type":"project","id":"` + ids.NewV7().String() + `","fields":{}}`)
+	if got := (createRecord{}).RecordTypeOf(args); got != "project" {
+		t.Errorf("create_record read record type %q, want project", got)
+	}
+	if got := (updateRecord{}).RecordTypeOf(args); got != "project" {
+		t.Errorf("update_record read record type %q, want project", got)
+	}
+	if got := (updateRecord{}).RecordTypeOf(json.RawMessage(`{`)); got != "" {
+		t.Errorf("an unreadable argument object named record type %q, want none — a guess here "+
+			"would tighten or loosen a call nobody could read", got)
+	}
+}
+
+// A staged create must be refusable for the same reasons Handle refuses it,
+// because the approved retry re-enters through Handle: a rule enforced only
+// there is one a human's yes is spent discovering.
+func TestAStagedCreateRefusesWhatItsHandlerWouldRefuse(t *testing.T) {
+	tool := createRecord{}
+	if _, err := tool.StageInfo(context.Background(),
+		json.RawMessage(`{"record_type":"person","fields":{"not_a_field":"x"}}`)); err == nil {
+		t.Error("a create naming a field the contract does not declare staged cleanly; a human " +
+			"would approve it and the retry would then be refused with the approval already spent")
+	}
+	if _, err := tool.StageInfo(context.Background(), json.RawMessage(`{`)); err == nil {
+		t.Error("an unreadable create staged cleanly")
+	}
+	// rejectUnknownFields deliberately passes a record type it does not know —
+	// naming the served vocabulary is the provider's refusal to make. That is
+	// right for a call about to reach the provider and wrong for one about to
+	// reach a human, so the verb's own served set is checked first.
+	if _, err := tool.StageInfo(context.Background(),
+		json.RawMessage(`{"record_type":"custom_field","fields":{}}`)); err == nil {
+		t.Error("a create of a record type this verb cannot create staged cleanly; the approved " +
+			"retry would die at the provider with the human's one-shot approval already spent")
+	}
+}
+
+// The summary is the whole of what a triaging human reads on the inbox row.
+func TestAGenericWriteSaysWhatItWouldSet(t *testing.T) {
+	line := describeGenericWrite("Create", "project", json.RawMessage(`{"name":"N","organization_id":"o"}`))
+	if !strings.Contains(line, "project") || !strings.Contains(line, "name") ||
+		!strings.Contains(line, "organization_id") {
+		t.Errorf("summary %q names neither the record type nor the fields the call sets", line)
+	}
+
+	if got := describeGenericWrite("Update", "deal", json.RawMessage(`{}`)); got != "Update a deal" {
+		t.Errorf("an empty patch rendered %q, want the act alone rather than a dangling list", got)
+	}
+	if got := describeGenericWrite("Update", "deal", json.RawMessage(`not json`)); got != "Update a deal" {
+		t.Errorf("an unreadable patch rendered %q; the summary may not invent fields", got)
+	}
+
+	wide := map[string]int{}
+	for i := range summaryFieldLimit + 4 {
+		wide["f"+string(rune('a'+i))] = i
+	}
+	raw, err := json.Marshal(wide)
+	if err != nil {
+		t.Fatalf("building the wide patch: %v", err)
+	}
+	if line := describeGenericWrite("Update", "person", raw); !strings.Contains(line, "more") {
+		t.Errorf("a %d-field patch rendered %q with no overflow marker, so the inbox line silently "+
+			"drops fields the call would set", len(wide), line)
+	}
+}
+
+// Stageable and NamesRecordType are read by the composition root's gates, and a
+// gate that answers for a verb nobody registered would certify an empty surface.
+func TestTheRegistryAnswersNothingForAnUnregisteredVerb(t *testing.T) {
+	r := NewRegistry(nil, nil)
+	if r.Stageable("summon_demon") {
+		t.Error("an unregistered verb reported as stageable")
+	}
+	if r.NamesRecordType("summon_demon") {
+		t.Error("an unregistered verb reported as naming a record type")
+	}
+}
+
+// A staged update reads the row it patches, so a record the caller cannot see is
+// refused before a human is asked about it rather than after.
+func TestAStagedUpdateRefusesARecordItCannotRead(t *testing.T) {
+	tool := updateRecord{p: unreadableProvider{}}
+	_, err := tool.StageInfo(context.Background(), json.RawMessage(
+		`{"record_type":"person","id":"`+ids.NewV7().String()+`","fields":{"full_name":"X"}}`))
+	if !errors.Is(err, apperrors.ErrNotFound) {
+		t.Errorf("staging a patch against an unreadable record answered %v, want not-found — "+
+			"otherwise the inbox shows a change against a row the approver cannot see", err)
+	}
+	if _, err := tool.StageInfo(context.Background(), json.RawMessage(`{`)); err == nil {
+		t.Error("an unreadable patch staged cleanly")
+	}
+	// The field check runs before the read, so a patch naming a field the
+	// contract does not declare is refused whether or not its record exists.
+	if _, err := tool.StageInfo(context.Background(), json.RawMessage(
+		`{"record_type":"person","id":"`+ids.NewV7().String()+`","fields":{"not_a_field":"x"}}`)); err == nil {
+		t.Error("a patch naming an undeclared field staged cleanly; a human would approve it and " +
+			"the retry would then be refused with the approval already spent")
+	}
+}

--- a/backend/internal/modules/agents/tools.go
+++ b/backend/internal/modules/agents/tools.go
@@ -241,6 +241,61 @@ func (t createRecord) Handle(ctx context.Context, in json.RawMessage) (json.RawM
 	return readBack(ctx, t.p, ref)
 }
 
+// RecordTypeOf lets the contract's per-record-type tier floor see which record
+// this call creates (tierfloor.go).
+func (createRecord) RecordTypeOf(args json.RawMessage) string { return recordTypeArg(args) }
+
+// ServesRecordType reports the record types this verb can actually create — the
+// contract's own create bodies, which is the same vocabulary the schema
+// advertises. The floor reads it so a type this verb cannot create is never
+// tightened into an approval that could only ever fail.
+func (createRecord) ServesRecordType(recordType string) bool {
+	_, served := createShapes[datasource.EntityType(recordType)]
+	return served
+}
+
+// StageInfo puts a create the contract tightened to confirm-first in the inbox
+// instead of dead-ending it (#982).
+//
+// WHAT IT STAGES IS A CREATE, and the shape says so: the record type with no id
+// and no version pin, because the record does not exist yet and there is no row
+// an approval could bind to. That is the shape the REST door stages for the same
+// operation, whose route carries no `{id}` — one operation, one staged shape,
+// whichever door the agent came through.
+//
+// The checks run HERE as well as in Handle, and that is the point: the approved
+// retry re-enters through Handle, so a rule enforced only there is one a human's
+// yes is spent discovering.
+//
+// The record type is checked FIRST and by this verb's own served set, not by
+// rejectUnknownFields — which answers nil for a type it does not know, on the
+// deliberate ground that naming the served vocabulary is the provider's refusal
+// to make. That is right for a call about to reach the provider and wrong for one
+// about to reach a human: `create_record{record_type:"custom_field"}` would
+// otherwise stage cleanly, because the surface does not enforce schema enums, and
+// the approved retry would then die at the provider with the approval spent.
+func (t createRecord) StageInfo(_ context.Context, in json.RawMessage) (StageInfo, error) {
+	var args struct {
+		RecordType string          `json:"record_type"`
+		Fields     json.RawMessage `json:"fields"`
+	}
+	if err := decodeArgs(in, &args); err != nil {
+		return StageInfo{}, err
+	}
+	if !t.ServesRecordType(args.RecordType) {
+		return StageInfo{}, &BadArgsError{Cause: fmt.Errorf(
+			"this verb does not create %q records, so no approval of it could ever be carried out",
+			args.RecordType)}
+	}
+	if err := rejectUnknownFields(createShapes, args.RecordType, args.Fields); err != nil {
+		return StageInfo{}, err
+	}
+	return StageInfo{
+		TargetType: args.RecordType,
+		Summary:    describeGenericWrite("Create", args.RecordType, args.Fields),
+	}, nil
+}
+
 // --- log_activity (🟢 write) ---
 
 type logActivity struct {

--- a/backend/internal/modules/agents/tools_update.go
+++ b/backend/internal/modules/agents/tools_update.go
@@ -71,6 +71,58 @@ type stagedApprovalNote struct {
 	Message    string          `json:"message"`
 }
 
+// RecordTypeOf lets the contract's per-record-type tier floor see which record
+// this call patches (tierfloor.go).
+func (updateRecord) RecordTypeOf(args json.RawMessage) string { return recordTypeArg(args) }
+
+// ServesRecordType reports the record types this verb can actually patch — the
+// contract's own update bodies. The floor reads it so a type this verb cannot
+// patch is never tightened into an approval that could only ever fail.
+func (updateRecord) ServesRecordType(recordType string) bool {
+	_, served := updateShapes[datasource.EntityType(recordType)]
+	return served
+}
+
+// StageInfo puts a patch the contract tightened to confirm-first in the inbox
+// instead of dead-ending it (#982).
+//
+// It stages the WHOLE call, not the per-field residue Handle's precedence split
+// stages. The two answer different questions and both are real: the split asks
+// "may a machine overwrite what a person typed", and applies everything else
+// meanwhile; the floor says this operation is confirm-first whatever the fields
+// hold, so nothing may apply until a human releases it. The floor is resolved
+// before admission, so a call that reaches here has already been judged the
+// second way, and an approved retry carries the ApprovalRedeemed marker that
+// sends Handle straight to the full apply.
+//
+// The record is READ, for the reasons its 🟡 siblings read theirs: a patch
+// naming a record the caller cannot see must be refused now rather than after a
+// human has spent a one-shot approval on it, and a record whose authority lives
+// in another system of record can never have that approval released at all.
+func (t updateRecord) StageInfo(ctx context.Context, in json.RawMessage) (StageInfo, error) {
+	var args updateRecordArgs
+	if err := decodeArgs(in, &args); err != nil {
+		return StageInfo{}, err
+	}
+	if err := rejectUnknownFields(updateShapes, args.RecordType, args.Fields); err != nil {
+		return StageInfo{}, err
+	}
+	rec, err := t.p.Read(ctx, datasource.EntityRef{
+		Type: datasource.EntityType(args.RecordType), ID: args.ID,
+	})
+	if err != nil {
+		return StageInfo{}, err
+	}
+	if err := refuseStagingElsewhere(rec); err != nil {
+		return StageInfo{}, err
+	}
+	return StageInfo{
+		TargetType: args.RecordType,
+		TargetID:   args.ID,
+		Summary:    describeGenericWrite("Update", args.RecordType, args.Fields),
+	}, nil
+}
+
 // Handle is the per-field human-edit-precedence split (interfaces.md
 // §2.1): fields a human last wrote are staged 🟡 for approval, the rest
 // of the patch applies 🟢 in the same call — a machine does not silently


### PR DESCRIPTION
## What

`crm.yaml` declares `createProject` and `updateProject` confirm-first for an agent — a tier
tightened for ONE record type, where creating a person or a deal is not. `operationSpec`
applies that on the REST door, because a REST call names its operation. A `tools/call` names
a VERB, and `create_record` is auto-execute for every type it admits, so the refusal was one
tool call away from being irrelevant:

| door | call | outcome |
|---|---|---|
| REST | `POST /v1/projects` | 🟡 staged for a human |
| MCP | `create_record {"record_type":"project", …}` | 🟢 executed |

Both land on the same `t.p.Create(EntityProject, …)`. The seat ceiling and object RBAC still
applied, so this was never privilege escalation — it was an **autonomy-tier** bypass, the
control ADR-0026 and ADR-0055 exist to hold. Reproduced live before anything was written:
the call answered `nil` and the project existed.

Closes #982.

## How

The floor is **derived** from the generated policy table, keyed by (verb, record_type)
instead of by route, so one contract declaration reaches both doors and a new annotation
binds the tool door by regeneration rather than by anyone remembering.

Two filters decide whether a tightening is this verb's to inherit, and both are load-bearing:

- **the canonical route** — `/v1/<collection>` or `/v1/<collection>/{id}`. `updateOrganizationFact`
  writes a sidecar row `update_record` cannot reach; inheriting its tightening would make every
  ordinary organization patch confirm-first on the tool door while REST kept it automatic. That
  is #982 pointing the other way, and the first draft of this branch shipped it — see below.
- **what the verb serves** — asked of the tool, in `tightened`, where the tool is in hand.
  The contract tightens `createCustomField`, and `create_record` cannot create a custom field;
  tightening anyway converts an immediate provider refusal into an approval a human releases
  onto a call that then dies with the one-shot authority spent.

A floor with nowhere to land would be a refusal wearing an approval's clothes, so `create_record`
and `update_record` gain the `StageInfo` they never had. The create stages the shape it is —
record type, no id, no pin, which is what the REST door already stages for the same operation.
The update stages the WHOLE call, distinct from the per-field precedence residue `stageConflicts`
stages, and reads its target for the reasons its 🟡 siblings do.

## Gates

Derived from the generated table, so a new annotation cannot ship past them. Each was **shown
red against its own mutation** before being trusted:

1. every pair the contract tightens is known to the floor;
2. every such verb can stage;
3. every such verb can name the record type a call carries — without which the floor is never
   consulted and gates 1–2 read green over an open bypass;
4. the floor tightens **nothing** the contract leaves automatic.

Integration lane, through `registryWithGate` — the api role's own composition, so the wiring and
its ordering are what is proved, not the option: a tightened create stages, a tightened update
stages, and an ordinary organization patch still runs unattended. Each asserts the **staged
approval row** and not only the sentinel, because `StagedApprovalError` unwraps to
`ErrRequiresApproval` and so does a refusal with nowhere to land — the two are only
distinguishable by the row.

New code is 85.7–100% covered per function.

## Review

Reviewed by two independent adversarial passes before push. They agreed on two defects, both
fixed here rather than filed:

- the first derivation collapsed every confirm-first route sharing a (verb, record_type) and
  took the strictest, which tightened ordinary organization patches on MCP only;
- staging a record type the verb cannot serve minted approvals that could never execute.

Also from review: the integration test's original single assertion could not tell staging from a
dead end, one gate was vacuous (it re-read the single constant it audited), and two comments
asserted invariants nothing enforced. All corrected.

## Left open, deliberately

`update_record`'s approved retry is still conditioned on the caller's `if_version` rather than the
released pin — the asymmetry `agents/approvals.go` already documents and #813 already tracks.
This branch makes that filed gap newly reachable for whole-call project updates; it is not
widened silently, and closing it belongs with #813.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes an autonomy-tier bypass where project creates/updates were confirm-first on REST but auto-executed via MCP tools. Adds a derived per-record-type tier floor so both doors enforce confirm-first when the contract requires it (fixes #982).

- **Bug Fixes**
  - Apply a contract-derived, per-record-type tier floor to tools: keyed by `(verb, record_type)`, canonical routes only, tighten-only.
  - Wire the floor into the composed registry via `withContractTierFloor()` so `create_record`/`update_record` inherit confirm-first for `project`; ordinary organization patches stay auto-execute.
  - Add staging for generic verbs: `create_record` stages a create (type only, no id); `update_record` stages the whole call and reads the target; refuse unsupported types and unknown fields.
  - Expose gates on the registry (`Stageable`, `NamesRecordType`, `Performs`) and add unit/integration tests to prove wiring and behavior.

<sup>Written for commit 6a2cb8114fa386c8b19be0a5e25f0d9661b0e333. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/991?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

