### PR TITLE
refactor(modules): the last five request-path modules take a bound handle

### DIFF
--- a/backend/cmd/api/modelwiring.go
+++ b/backend/cmd/api/modelwiring.go
@@ -131,7 +131,7 @@ func offerDraftOptions(pool *pgxpool.Pool, modelPath *compose.ModelPath) []compo
 	if modelPath == nil {
 		return nil
 	}
-	retriever := search.NewRetriever(search.NewStore(pool), modelPath.Embedder)
+	retriever := search.NewRetriever(search.NewStore(compose.InstallationDB(pool)), modelPath.Embedder)
 	return []compose.Option{compose.WithOfferDraft(modelPath.OfferDraft, retriever)}
 }
 

--- a/backend/cmd/worker/boot.go
+++ b/backend/cmd/worker/boot.go
@@ -217,7 +217,7 @@ func startRunnerLane(ctx context.Context, cfg workerConfig, pool *pgxpool.Pool, 
 	if modelPath.AgentLoop == nil {
 		return nil
 	}
-	grounding := search.NewRetriever(search.NewStore(pool), modelPath.Embedder)
+	grounding := search.NewRetriever(search.NewStore(compose.InstallationDB(pool)), modelPath.Embedder)
 	// The Surface-B runner's agent tools reach overlay write-back through
 	// the workspace's own vaulted incumbent token; wire the FromEnv
 	// vault-backed resolver so an autonomous run can write back (nil vault
@@ -255,7 +255,7 @@ func startRunnerLane(ctx context.Context, cfg workerConfig, pool *pgxpool.Pool, 
 // projections that need no model at all.
 func startProjectionLanes(ctx context.Context, pool *pgxpool.Pool, rdb *redis.Client, modelPath compose.ModelPath, background *sync.WaitGroup, logger *slog.Logger, stdout io.Writer) {
 	if modelPath.Embedder != nil {
-		gen := search.NewEmbedGen(search.NewStore(pool), modelPath.Embedder)
+		gen := search.NewEmbedGen(search.NewStore(compose.InstallationDB(pool)), modelPath.Embedder)
 		_, _ = fmt.Fprintln(stdout, "worker maintaining retrieval embeddings")
 		background.Go(func() { runSubscriber(ctx, rdb, "cg:context-graph", gen.HandleEvent, logger, 0) })
 	}
@@ -263,14 +263,14 @@ func startProjectionLanes(ctx context.Context, pool *pgxpool.Pool, rdb *redis.Cl
 	// model, so it runs on every worker rather than only where a provider is
 	// configured — a deployment without AI still answers "who on our team knows
 	// this contact", which is a deterministic question about our own mail.
-	edges := search.NewGraphEdgeGen(search.NewStore(pool))
+	edges := search.NewGraphEdgeGen(search.NewStore(compose.InstallationDB(pool)))
 	_, _ = fmt.Fprintln(stdout, "worker maintaining interaction edges")
 	background.Go(func() { runSubscriber(ctx, rdb, "cg:graph-edge", edges.HandleEvent, logger, 0) })
 
 	// The LinkedIn ghost matcher (ADR-0078 §8b): a ghost attaches the moment
 	// its contact exists, whoever created them. Deterministic like the edge
 	// projection above, so it runs on every worker.
-	matcher := compose.NewLinkedInMatchGen(pool, people.NewStore(pool), identity.NewService(pool), logger)
+	matcher := compose.NewLinkedInMatchGen(pool, people.NewStore(compose.InstallationDB(pool)), identity.NewService(pool), logger)
 	_, _ = fmt.Fprintln(stdout, "worker matching LinkedIn connections as contacts appear")
 	background.Go(func() { runSubscriber(ctx, rdb, "cg:linkedin-match", matcher.HandleEvent, logger, 0) })
 

--- a/backend/cmd/worker/personautoenrich.go
+++ b/backend/cmd/worker/personautoenrich.go
@@ -44,7 +44,7 @@ func startPersonAutoEnrich(
 	// provider fills from the employer's own pages and skips discovery,
 	// which is the sovereign posture rather than a degraded one.
 	searchClient, searchConfigured := websearchhttp.FromEnv(time.Now)
-	enricher := compose.NewPersonAutoEnrich(pool, people.NewStore(pool), approvals.NewService(pool), searchClient, logger)
+	enricher := compose.NewPersonAutoEnrich(pool, people.NewStore(compose.InstallationDB(pool)), approvals.NewService(compose.InstallationDB(pool)), searchClient, logger)
 	if searchConfigured {
 		_, _ = fmt.Fprintln(stdout, "worker filling contacts from their employer's pages and public search results")
 	} else {

--- a/backend/internal/compose/brain.go
+++ b/backend/internal/compose/brain.go
@@ -133,10 +133,10 @@ func NewModelPath(cfg ai.RoutingConfig, pool *pgxpool.Pool, capturePayloads bool
 	if err != nil {
 		return ModelPath{}, err
 	}
-	if err := seedEmbedBinding(context.Background(), search.NewStore(pool), router, log); err != nil {
+	if err := seedEmbedBinding(context.Background(), search.NewStore(InstallationDB(pool)), router, log); err != nil {
 		return ModelPath{}, err
 	}
-	return modelPathForRouter(router, newCompanyContextProvider(people.NewStore(pool))), nil
+	return modelPathForRouter(router, newCompanyContextProvider(people.NewStore(InstallationDB(pool)))), nil
 }
 
 // seedEmbedBinding plants search's embed_store_binding marker (Task 9's

--- a/backend/internal/compose/briefseam.go
+++ b/backend/internal/compose/briefseam.go
@@ -29,7 +29,7 @@ import (
 // own user id and requires deal-read, so no scoping is added or re-decided
 // here.
 func briefReader(pool *pgxpool.Pool) agents.BriefReader {
-	engine := briefs.NewBriefEngine(pool, people.NewStore(pool))
+	engine := briefs.NewBriefEngine(pool, people.NewStore(InstallationDB(pool)))
 	return func(ctx context.Context) (agents.ReadBriefResult, error) {
 		// The instant is the read's own, exactly as the HTTP handler passes it:
 		// LatestRun resolves snoozes against it, so a run read now is what the

--- a/backend/internal/compose/capture.go
+++ b/backend/internal/compose/capture.go
@@ -163,7 +163,7 @@ func newCaptureSink(pool *pgxpool.Pool, cfg CaptureConfig) *capture.Sink {
 		// composes a sink gets the same one — the worker runs mail capture and
 		// never sees the api's options.
 		WithFileKeeper(capturedFileKeeper{store: activities.NewStore(pool).WithBlobstore(cfg.Blob)}).
-		WithStager(mergeStager{svc: approvals.NewService(pool)}).
+		WithStager(mergeStager{svc: approvals.NewService(InstallationDB(pool))}).
 		// The ADR-0063 auto-create pipeline: every captured mail ensures
 		// its counterparty exists, through the people module's ONE dedupe
 		// chokepoint — composed here so capture never imports people. The

--- a/backend/internal/compose/captureautoenrich.go
+++ b/backend/internal/compose/captureautoenrich.go
@@ -83,7 +83,7 @@ type captureAutoEnrichSweepWorker struct {
 func newCaptureAutoEnrichSweepWorker(pool *pgxpool.Pool, log *slog.Logger) *captureAutoEnrichSweepWorker {
 	return &captureAutoEnrichSweepWorker{
 		pool:       pool,
-		people:     people.NewStore(pool),
+		people:     people.NewStore(InstallationDB(pool)),
 		settings:   capture.NewSettings(NewSettingsStore(pool)),
 		autoEnrich: capture.NewAutoEnrichStore(pool),
 		dailyCap:   autoEnrichDailyCap,

--- a/backend/internal/compose/capturedbykind_integration_test.go
+++ b/backend/internal/compose/capturedbykind_integration_test.go
@@ -42,7 +42,7 @@ func seatPersonCapturedBy(t *testing.T, e *integration.Env, fullName, capturedBy
 func TestCapturedByKindSelectsWhoCreatedTheRecord(t *testing.T) {
 	e := integration.Setup(t)
 	ctx := e.As(e.Rep1, nil, integration.AdminPerms)
-	store := people.NewStore(e.Pool)
+	store := people.NewStore(e.DB())
 
 	// One of each creator the write paths stamp, plus one whose prefix is in no
 	// enum value at all — the case that decides whether a filter can quietly
@@ -95,7 +95,7 @@ func TestCapturedByKindSelectsWhoCreatedTheRecord(t *testing.T) {
 // values it accepts, and confirm the object exists while doing it.
 func TestCapturedByKindIsRefusedOnlyAfterAuthorization(t *testing.T) {
 	e := integration.Setup(t)
-	store := people.NewStore(e.Pool)
+	store := people.NewStore(e.DB())
 
 	// A rep may read people but NOT organizations, so the organization list is
 	// the natural unauthorized caller here.
@@ -119,7 +119,7 @@ func TestCapturedByKindIsRefusedOnlyAfterAuthorization(t *testing.T) {
 
 func TestCapturedByKindNarrowsRowScopeAndNeverWidensIt(t *testing.T) {
 	e := integration.Setup(t)
-	store := people.NewStore(e.Pool)
+	store := people.NewStore(e.DB())
 
 	// An AI-created person owned by Rep3, who sits in the other team.
 	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
@@ -183,7 +183,7 @@ func agentCtx(e *integration.Env) context.Context {
 func TestAiWrittenFindsRecordsTheConnectorMadeAndTheAiFilled(t *testing.T) {
 	e := integration.Setup(t)
 	adminCtx := e.As(e.Rep1, nil, integration.AdminPerms)
-	store := people.NewStore(e.Pool)
+	store := people.NewStore(e.DB())
 
 	filled := seatConnectorOrg(t, e, "Acme Filled", "domain")
 	industry := "Robotics"
@@ -241,7 +241,7 @@ func TestAiWrittenFindsRecordsTheConnectorMadeAndTheAiFilled(t *testing.T) {
 // nothing about whether the system writes one.
 func TestAiWrittenCatchesAnAgentUpdatingAnOrdinaryColumn(t *testing.T) {
 	e := integration.Setup(t)
-	store := people.NewStore(e.Pool)
+	store := people.NewStore(e.DB())
 	org := seatConnectorOrg(t, e, "Delta Industries", "domain")
 
 	industry := "Robotics"

--- a/backend/internal/compose/capturedomaintriage.go
+++ b/backend/internal/compose/capturedomaintriage.go
@@ -40,7 +40,7 @@ type domainTriageTrigger struct {
 
 func newDomainTriageTrigger(pool *pgxpool.Pool, log *slog.Logger) *domainTriageTrigger {
 	return &domainTriageTrigger{
-		people:     people.NewStore(pool),
+		people:     people.NewStore(InstallationDB(pool)),
 		settings:   capture.NewSettings(NewSettingsStore(pool)),
 		autoEnrich: capture.NewAutoEnrichStore(pool),
 		dailyCap:   autoEnrichDailyCap,

--- a/backend/internal/compose/capturedomaintriage_integration_test.go
+++ b/backend/internal/compose/capturedomaintriage_integration_test.go
@@ -57,7 +57,7 @@ func openQuestion(t *testing.T, e *integration.Env, domain string) {
 // lets the trigger be best-effort.
 func stillDue(t *testing.T, e *integration.Env, domain string) bool {
 	t.Helper()
-	due, err := people.NewStore(e.Pool).ListDueDomains(e.Admin(), 50)
+	due, err := people.NewStore(e.DB()).ListDueDomains(e.Admin(), 50)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/backend/internal/compose/captureenrich.go
+++ b/backend/internal/compose/captureenrich.go
@@ -66,7 +66,7 @@ type CaptureEnricher struct {
 
 // NewCaptureEnricher builds the pass over the pool and one model lane.
 func NewCaptureEnricher(pool *pgxpool.Pool, brain completer, log *slog.Logger) *CaptureEnricher {
-	return &CaptureEnricher{pool: pool, store: people.NewStore(pool), brain: brain, log: log}
+	return &CaptureEnricher{pool: pool, store: people.NewStore(InstallationDB(pool)), brain: brain, log: log}
 }
 
 // RunWorkspace enriches up to enrichPassLimit candidates in the workspace

--- a/backend/internal/compose/captureensurer.go
+++ b/backend/internal/compose/captureensurer.go
@@ -32,7 +32,7 @@ import (
 // of them would silently fall back to the shipped baseline and ignore the
 // workspace's own corrections.
 func newCounterpartyStore(pool *pgxpool.Pool) *people.Store {
-	return people.NewStore(pool).WithConsumerMail(capture.MatcherTx)
+	return people.NewStore(InstallationDB(pool)).WithConsumerMail(capture.MatcherTx)
 }
 
 // peopleEnsurer adapts the people module's auto-create engine onto

--- a/backend/internal/compose/captureverdict.go
+++ b/backend/internal/compose/captureverdict.go
@@ -112,7 +112,7 @@ func NewCounterpartyVerdictEngine(pool *pgxpool.Pool, brain completer, log *slog
 		pending:    capture.NewPendingStore(pool),
 		people:     newCounterpartyStore(pool),
 		activities: activities.NewStore(pool),
-		approvals:  approvals.NewService(pool),
+		approvals:  approvals.NewService(InstallationDB(pool)),
 		brain:      brain,
 		triage:     newDomainTriageTrigger(pool, log),
 		log:        log,

--- a/backend/internal/compose/closedate.go
+++ b/backend/internal/compose/closedate.go
@@ -62,7 +62,7 @@ func (s closeDateStager) StageCorrection(ctx context.Context, dealID ids.UUID, t
 // NewCloseDateCorrector assembles the nightly close-date corrector for
 // the worker process role.
 func NewCloseDateCorrector(pool *pgxpool.Pool, log *slog.Logger) *deals.CloseDateCorrector {
-	return deals.NewCloseDateCorrector(pool, closeDateStager{svc: approvals.NewService(pool)}, log, installseam.Deals())
+	return deals.NewCloseDateCorrector(InstallationDB(pool), closeDateStager{svc: approvals.NewService(InstallationDB(pool))}, log, installseam.Deals())
 }
 
 // closeDateConfirmEffect executes an approved close-date confirmation:

--- a/backend/internal/compose/closedate_integration_test.go
+++ b/backend/internal/compose/closedate_integration_test.go
@@ -67,9 +67,9 @@ func setupCloseDate(t *testing.T) *closeDateEnv {
 		}
 	}
 	quiet := slog.New(slog.NewTextHandler(os.Stderr, nil))
-	e.svc = approvals.NewService(e.Pool)
-	e.svc.WithEffect(deals.CloseDateCorrectionKind, closeDateConfirmEffect(e.svc, deals.NewStore(e.Pool, DealsInstallation())))
-	e.corrector = deals.NewCloseDateCorrector(e.Pool, closeDateStager{svc: e.svc}, quiet, installseam.Deals())
+	e.svc = approvals.NewService(e.DB())
+	e.svc.WithEffect(deals.CloseDateCorrectionKind, closeDateConfirmEffect(e.svc, deals.NewStore(e.DB(), DealsInstallation())))
+	e.corrector = deals.NewCloseDateCorrector(e.DB(), closeDateStager{svc: e.svc}, quiet, installseam.Deals())
 	return e
 }
 

--- a/backend/internal/compose/coldstart_integration_test.go
+++ b/backend/internal/compose/coldstart_integration_test.go
@@ -16,10 +16,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/gradionhq/margince/backend/internal/compose/integration"
-
 	"github.com/jackc/pgx/v5"
 
+	"github.com/gradionhq/margince/backend/internal/compose/integration"
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/modules/ai"
 	"github.com/gradionhq/margince/backend/internal/modules/approvals"
@@ -59,7 +58,7 @@ func TestColdStartStagesOnlyEvidencedFields(t *testing.T) {
 		{"field":"legal_name","value":"Acme GmbH","evidence_snippet":"this text is NOT on the page","confidence":0.9},
 		{"field":"industry","value":"Software","evidence_snippet":"Acme GmbH","confidence":1.7},
 		{"field":"made_up_field","value":"x","evidence_snippet":"Acme GmbH","confidence":0.5}]}`)
-	engine := &coldStartEngine{extract: evidenceExtractor{fetch: acmePage, brain: fakeModelPath(t, fake).ColdStart}, approvals: approvals.NewService(e.Pool)}
+	engine := &coldStartEngine{extract: evidenceExtractor{fetch: acmePage, brain: fakeModelPath(t, fake).ColdStart}, approvals: approvals.NewService(e.DB())}
 
 	ctx := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.SchedulerPerms)
 	proposal, err := engine.Propose(ctx, fromURL("https://acme.example"))
@@ -96,7 +95,7 @@ func TestColdStartStagesOnlyEvidencedFields(t *testing.T) {
 	// Accepting needs organization.update (the effect the proposal
 	// writes on acceptance) — the admin has it; the decision echoes
 	// coldstart.accepted.
-	svc := approvals.NewService(e.Pool)
+	svc := approvals.NewService(e.DB())
 	if _, err := svc.Decide(e.As(e.Rep2, nil, integration.AdminPerms), ids.From[ids.ApprovalKind](ids.UUID(proposal.ProposalId)), true, nil); err != nil {
 		t.Fatalf("accepting the proposal: %v", err)
 	}
@@ -122,7 +121,7 @@ func TestColdStartTextInputGroundsFieldsInThePaste(t *testing.T) {
 		{"field":"value_proposition","value":"Fast onboarding","evidence_snippet":"onboard in minutes","confidence":0.8},
 		{"field":"icp","value":"Scaling B2B SaaS","evidence_snippet":"scaling B2B SaaS companies","confidence":0.7},
 		{"field":"legal_name","value":"Acme GmbH","evidence_snippet":"registered as Acme GmbH in Berlin","confidence":0.9}]}`)
-	engine := &coldStartEngine{extract: evidenceExtractor{brain: fakeModelPath(t, fake).ColdStart}, approvals: approvals.NewService(e.Pool)}
+	engine := &coldStartEngine{extract: evidenceExtractor{brain: fakeModelPath(t, fake).ColdStart}, approvals: approvals.NewService(e.DB())}
 
 	proposal, err := engine.Propose(e.As(e.Rep1, []ids.UUID{e.Team1}, integration.SchedulerPerms), fromPastedText(pasted))
 	if err != nil {
@@ -161,7 +160,7 @@ func TestColdStartSelfDescriptionGroundsOnlyWhatTheStatementSupports(t *testing.
 		{"field":"icp","value":"Seed-stage German startups","evidence_snippet":"seed-stage German startups","confidence":0.8},
 		{"field":"value_proposition","value":"Fractional CFO services","evidence_snippet":"We sell fractional CFO services","confidence":0.9},
 		{"field":"industry","value":"Financial consulting","evidence_snippet":"a leading financial consultancy","confidence":0.9}]}`)
-	engine := &coldStartEngine{extract: evidenceExtractor{brain: fakeModelPath(t, fake).ColdStart}, approvals: approvals.NewService(e.Pool)}
+	engine := &coldStartEngine{extract: evidenceExtractor{brain: fakeModelPath(t, fake).ColdStart}, approvals: approvals.NewService(e.DB())}
 	ctx := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.SchedulerPerms)
 
 	proposal, err := engine.Propose(ctx, fromSelfDescription(statement))
@@ -192,7 +191,7 @@ func TestColdStartSelfDescriptionGroundsOnlyWhatTheStatementSupports(t *testing.
 	// padded (the same honest degradation as an unreadable page).
 	unsupported := ai.NewFakeClient().Script(`{"fields":[
 		{"field":"icp","value":"guessed","evidence_snippet":"enterprise Fortune-500 buyers","confidence":0.9}]}`)
-	empty := &coldStartEngine{extract: evidenceExtractor{brain: fakeModelPath(t, unsupported).ColdStart}, approvals: approvals.NewService(e.Pool)}
+	empty := &coldStartEngine{extract: evidenceExtractor{brain: fakeModelPath(t, unsupported).ColdStart}, approvals: approvals.NewService(e.DB())}
 	var unreadable *unreadableError
 	if _, err := empty.Propose(ctx, fromSelfDescription(statement)); !errors.As(err, &unreadable) {
 		t.Fatalf("unsupported statement → %v, want unreadable (no-guess)", err)
@@ -208,7 +207,7 @@ func TestColdStartPreviewReturnsEvidencedFieldsAndStagesNothing(t *testing.T) {
 		{"field":"value_proposition","value":"Fast onboarding","evidence_snippet":"Onboard your team in minutes, not weeks","confidence":0.9},
 		{"field":"icp","value":"RevOps at SaaS scale-ups","evidence_snippet":"Built for RevOps leaders at scaling SaaS companies","confidence":0.7},
 		{"field":"legal_name","value":"Acme GmbH","evidence_snippet":"a claim the page never makes","confidence":0.9}]}`)
-	engine := &coldStartEngine{extract: evidenceExtractor{fetch: acmePage, brain: fakeModelPath(t, fake).ColdStart}, approvals: approvals.NewService(e.Pool)}
+	engine := &coldStartEngine{extract: evidenceExtractor{fetch: acmePage, brain: fakeModelPath(t, fake).ColdStart}, approvals: approvals.NewService(e.DB())}
 	ctx := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.SchedulerPerms)
 
 	fields, err := engine.Readback(ctx, fromURL("https://acme.example"))
@@ -256,7 +255,7 @@ func TestColdStartPreviewRefusesWhatItCannotQuote(t *testing.T) {
 	e := integration.Setup(t)
 	fake := ai.NewFakeClient().Script(
 		`{"fields":[{"field":"icp","value":"guessed","evidence_snippet":"nowhere on the page","confidence":0.9}]}`)
-	engine := &coldStartEngine{extract: evidenceExtractor{fetch: acmePage, brain: fakeModelPath(t, fake).ColdStart}, approvals: approvals.NewService(e.Pool)}
+	engine := &coldStartEngine{extract: evidenceExtractor{fetch: acmePage, brain: fakeModelPath(t, fake).ColdStart}, approvals: approvals.NewService(e.DB())}
 
 	var unreadable *unreadableError
 	_, err := engine.Readback(e.As(e.Rep1, []ids.UUID{e.Team1}, integration.SchedulerPerms), fromURL("https://acme.example"))
@@ -271,7 +270,7 @@ func TestColdStartRefusesWhenNothingSurvivesTheGate(t *testing.T) {
 		`{"fields":[{"field":"icp","value":"guessed","evidence_snippet":"nowhere on the page","confidence":0.9}]}`,
 		`not even JSON`)
 	brain := fakeModelPath(t, fake).ColdStart
-	engine := &coldStartEngine{extract: evidenceExtractor{fetch: acmePage, brain: brain}, approvals: approvals.NewService(e.Pool)}
+	engine := &coldStartEngine{extract: evidenceExtractor{fetch: acmePage, brain: brain}, approvals: approvals.NewService(e.DB())}
 	ctx := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.SchedulerPerms)
 
 	var unreadable *unreadableError
@@ -290,7 +289,7 @@ func TestColdStartRefusesWhenNothingSurvivesTheGate(t *testing.T) {
 		t.Fatalf("unparseable model output → %v, want it to wrap ai.ErrOutputRejected", err)
 	}
 	// A page below the readable floor never reaches the model.
-	tiny := &coldStartEngine{extract: evidenceExtractor{fetch: fixturePage("hi"), brain: brain}, approvals: approvals.NewService(e.Pool)}
+	tiny := &coldStartEngine{extract: evidenceExtractor{fetch: fixturePage("hi"), brain: brain}, approvals: approvals.NewService(e.DB())}
 	if _, err := tiny.Propose(ctx, fromURL("https://acme.example")); !errors.As(err, &unreadable) {
 		t.Fatalf("tiny page → %v, want unreadable", err)
 	}
@@ -313,8 +312,8 @@ func TestColdStartAcceptWritesProfileOntoOrganization(t *testing.T) {
 	admin := e.Admin()
 	orgID := seedAcmeOrgWithHumanIndustry(t, e, admin)
 
-	svc := approvals.NewService(e.Pool)
-	svc.WithEffect("coldstart", coldstartAcceptEffect(svc, people.NewStore(e.Pool)))
+	svc := approvals.NewService(e.DB())
+	svc.WithEffect("coldstart", coldstartAcceptEffect(svc, people.NewStore(e.DB())))
 	engine := &coldStartEngine{extract: evidenceExtractor{fetch: acmePage, brain: brain}, approvals: svc}
 
 	proposal, err := engine.Propose(e.As(e.Rep1, []ids.UUID{e.Team1}, integration.SchedulerPerms), fromURL("https://www.acme.example/about"))

--- a/backend/internal/compose/coldstartaccept.go
+++ b/backend/internal/compose/coldstartaccept.go
@@ -50,7 +50,7 @@ func approvalsHandlersWithEffects(pool *pgxpool.Pool, quota approvals.QuotaRelea
 // standing up an HTTP surface. Every kind registered here must carry a
 // decision-grant mapping (TestEveryRegisteredEffectKindHasADecisionGrantMapping).
 func approvalsServiceWithEffects(pool *pgxpool.Pool) *approvals.Service {
-	svc := approvals.NewService(pool)
+	svc := approvals.NewService(InstallationDB(pool))
 	store := newCounterpartyStore(pool)
 	svc.WithEffect("coldstart", coldstartAcceptEffect(svc, store))
 	svc.WithEffect(enrichProposalKind, scrapeAcceptEffect(svc, store))
@@ -60,9 +60,9 @@ func approvalsServiceWithEffects(pool *pgxpool.Pool) *approvals.Service {
 	svc.WithEffect(orgNameProposalKind, orgNameAcceptEffect(svc, store))
 	svc.WithEffect(linkedInMatchKind, linkedInMatchAcceptEffect(svc, store))
 	svc.WithEffect(lifecycleProposalKind, lifecycleAcceptEffect(svc, store))
-	svc.WithEffect(deals.CloseDateCorrectionKind, closeDateConfirmEffect(svc, deals.NewStore(pool, DealsInstallation())))
+	svc.WithEffect(deals.CloseDateCorrectionKind, closeDateConfirmEffect(svc, deals.NewStore(InstallationDB(pool), DealsInstallation())))
 	svc.WithEffect(deals.FollowUpReconcileKind, followUpConfirmEffect(svc, activities.NewStore(pool)))
-	svc.WithEffect(fxRateProposalKind, fxRateAcceptEffect(svc, deals.NewStore(pool, DealsInstallation())))
+	svc.WithEffect(fxRateProposalKind, fxRateAcceptEffect(svc, deals.NewStore(InstallationDB(pool), DealsInstallation())))
 	svc.WithEffect(aiModelRateProposalKind, aiModelRateAcceptEffect(svc, ai.NewRateStore(InstallationDB(pool))))
 	return svc
 }

--- a/backend/internal/compose/commercialseams.go
+++ b/backend/internal/compose/commercialseams.go
@@ -105,8 +105,8 @@ func asCommitments(tasks []activities.OpenTask) []agents.OpenCommitment {
 // project outside the caller's scope answers not-found exactly as reading it
 // directly would.
 func handoffReader(pool *pgxpool.Pool) agents.HandoffReader {
-	dealStore := deals.NewStore(pool, DealsInstallation())
-	peopleStore := people.NewStore(pool)
+	dealStore := deals.NewStore(InstallationDB(pool), DealsInstallation())
+	peopleStore := people.NewStore(InstallationDB(pool))
 	taskStore := activities.NewStore(pool)
 	seats := identity.NewService(pool)
 	return func(ctx context.Context, projectID ids.UUID) (agents.HandoffFacts, error) {

--- a/backend/internal/compose/comms_integration_test.go
+++ b/backend/internal/compose/comms_integration_test.go
@@ -21,10 +21,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gradionhq/margince/backend/internal/compose/integration"
-
 	"github.com/jackc/pgx/v5"
 
+	"github.com/gradionhq/margince/backend/internal/compose/integration"
 	"github.com/gradionhq/margince/backend/internal/modules/activities"
 	"github.com/gradionhq/margince/backend/internal/modules/agents"
 	"github.com/gradionhq/margince/backend/internal/modules/consent"
@@ -176,7 +175,7 @@ func assertModelAndFallbackDrafts(ctx context.Context, t *testing.T, adapter com
 func TestIntentToolsReturnTheAssembledPicture(t *testing.T) {
 	e := integration.Setup(t)
 	target := e.SeedPerson(t, "Briefing Target", &e.Rep1)
-	retriever := search.NewRetriever(search.NewStore(e.Pool), nil)
+	retriever := search.NewRetriever(search.NewStore(e.DB()), nil)
 	ctx := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.SchedulerPerms)
 
 	assembled, err := retriever.AssembleContext(ctx,

--- a/backend/internal/compose/company_integration_test.go
+++ b/backend/internal/compose/company_integration_test.go
@@ -30,7 +30,7 @@ func strptr(s string) *string { return &s }
 
 func TestCompanyIsUnsetUntilAHumanSavesIt(t *testing.T) {
 	e := integration.Setup(t)
-	store := people.NewStore(e.Pool)
+	store := people.NewStore(e.DB())
 	ctx := e.As(e.Rep1, nil, integration.AdminPerms)
 
 	// A freshly bootstrapped installation (ADR-0061) has an organization row
@@ -140,7 +140,7 @@ func TestCompanyIsUnsetUntilAHumanSavesIt(t *testing.T) {
 // saw a 200, and kept the old site.
 func TestCompanyWebsiteCanBeChangedAfterTheFirstSave(t *testing.T) {
 	e := integration.Setup(t)
-	store := people.NewStore(e.Pool)
+	store := people.NewStore(e.DB())
 	ctx := e.As(e.Rep1, nil, integration.AdminPerms)
 
 	base := people.SaveCompanyInput{
@@ -200,7 +200,7 @@ func TestCompanyWebsiteCanBeChangedAfterTheFirstSave(t *testing.T) {
 
 func TestCompanySavedByAHumanSurvivesALaterReadBack(t *testing.T) {
 	e := integration.Setup(t)
-	store := people.NewStore(e.Pool)
+	store := people.NewStore(e.DB())
 	human := e.As(e.Rep1, nil, integration.AdminPerms)
 
 	saved, err := store.SaveCompany(human, people.SaveCompanyInput{
@@ -259,7 +259,7 @@ func TestCompanySavedByAHumanSurvivesALaterReadBack(t *testing.T) {
 
 func TestFormResaveDoesNotClobberAHeaderDescriptionEdit(t *testing.T) {
 	e := integration.Setup(t)
-	store := people.NewStore(e.Pool)
+	store := people.NewStore(e.DB())
 	ctx := e.As(e.Rep1, nil, integration.AdminPerms)
 
 	// The first form save fills the empty header line from the summary.
@@ -307,7 +307,7 @@ func TestFormResaveDoesNotClobberAHeaderDescriptionEdit(t *testing.T) {
 
 func TestAcceptedOfferSummaryFillsTheDescriptionColumn(t *testing.T) {
 	e := integration.Setup(t)
-	store := people.NewStore(e.Pool)
+	store := people.NewStore(e.DB())
 	base := principal.WithCorrelationID(principal.WithWorkspaceID(context.Background(), e.WS), ids.NewV7())
 	agent := principal.WithActor(base, principal.Principal{
 		Type: principal.PrincipalSystem, ID: "agent:coldstart",
@@ -371,7 +371,7 @@ func TestAcceptedOfferSummaryFillsTheDescriptionColumn(t *testing.T) {
 
 func TestOverlongOfferSummarySkipsTheColumnButKeepsTheEvidence(t *testing.T) {
 	e := integration.Setup(t)
-	store := people.NewStore(e.Pool)
+	store := people.NewStore(e.DB())
 	base := principal.WithCorrelationID(principal.WithWorkspaceID(context.Background(), e.WS), ids.NewV7())
 	agent := principal.WithActor(base, principal.Principal{
 		Type: principal.PrincipalSystem, ID: "agent:coldstart",
@@ -437,7 +437,7 @@ func TestOverlongOfferSummarySkipsTheColumnButKeepsTheEvidence(t *testing.T) {
 
 func TestColdStartCreateWithoutLegalNameUsesDerivedDomainName(t *testing.T) {
 	e := integration.Setup(t)
-	store := people.NewStore(e.Pool)
+	store := people.NewStore(e.DB())
 	base := principal.WithCorrelationID(principal.WithWorkspaceID(context.Background(), e.WS), ids.NewV7())
 	agent := principal.WithActor(base, principal.Principal{
 		Type: principal.PrincipalSystem, ID: "agent:coldstart",
@@ -473,7 +473,7 @@ func TestColdStartCreateWithoutLegalNameUsesDerivedDomainName(t *testing.T) {
 
 func TestCompanyContextIsScopedProvenanceBearingAndChangesWithTheProfile(t *testing.T) {
 	e := integration.Setup(t)
-	store := people.NewStore(e.Pool)
+	store := people.NewStore(e.DB())
 	ctx := e.As(e.Rep1, nil, integration.AdminPerms)
 
 	saved, err := store.SaveCompany(ctx, people.SaveCompanyInput{

--- a/backend/internal/compose/company_integration_test.go
+++ b/backend/internal/compose/company_integration_test.go
@@ -535,7 +535,12 @@ func TestCompanyContextIsScopedProvenanceBearingAndChangesWithTheProfile(t *test
 	foreignCtx = principal.WithActor(foreignCtx, principal.Principal{
 		Type: principal.PrincipalHuman, ID: "human:foreign", UserID: ids.NewV7(), Permissions: integration.AdminPerms,
 	})
-	foreign, err := store.GetCompanyContext(foreignCtx, []people.CompanyContextScope{people.CompanyContextOffer})
+	// The foreign tenant is read through a store of its own: the workspace a
+	// read is scoped to is the handle's, so asking this tenant's store with the
+	// other tenant's ctx would answer THIS tenant's rows and the isolation arm
+	// below would pass without proving anything.
+	foreignStore := people.NewStore(e.DBFor(foreignWS))
+	foreign, err := foreignStore.GetCompanyContext(foreignCtx, []people.CompanyContextScope{people.CompanyContextOffer})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/backend/internal/compose/datareset.go
+++ b/backend/internal/compose/datareset.go
@@ -286,7 +286,7 @@ func (h dataResetHandlers) sweepAndReseed(ctx context.Context, wsID ids.UUID, co
 			Type: principal.PrincipalSystem, ID: "system",
 		})
 		seedCtx = principal.WithCorrelationID(seedCtx, ids.NewV7())
-		if err := configuredSeed(h.seeds, deals.NewHandlers(h.pool, DealsInstallation()))(seedCtx, tx); err != nil {
+		if err := configuredSeed(h.seeds, deals.NewHandlers(InstallationDB(h.pool), DealsInstallation()))(seedCtx, tx); err != nil {
 			return err
 		}
 

--- a/backend/internal/compose/dbhandle.go
+++ b/backend/internal/compose/dbhandle.go
@@ -4,10 +4,15 @@
 package compose
 
 import (
+	"context"
+	"fmt"
+
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/gradionhq/margince/backend/internal/modules/identity"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
 
 // InstallationDB is the pool bound to the installation's own workspace
@@ -25,4 +30,19 @@ import (
 func InstallationDB(pool *pgxpool.Pool) *database.DB {
 	svc := identity.NewService(pool)
 	return database.Bind(pool, svc.InstallationWorkspace)
+}
+
+// actingWorkspaceDB binds pool to the workspace the CALLER is acting in, for
+// the few paths whose target tenant is not the installation's own.
+//
+// The overlay flip and its reconstruction are the whole list: a rebuild writes
+// an exported estate into the workspace whose operator ordered it, which on a
+// clean instance is a workspace the server never resolved. Everything else on a
+// request path is the installation's one workspace and takes InstallationDB.
+func actingWorkspaceDB(ctx context.Context, pool *pgxpool.Pool) (*database.DB, error) {
+	ws, ok := principal.WorkspaceID(ctx)
+	if !ok {
+		return nil, fmt.Errorf("%w: this call was made outside a workspace", database.ErrNoWorkspace)
+	}
+	return database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), nil
 }

--- a/backend/internal/compose/dealmovepin_integration_test.go
+++ b/backend/internal/compose/dealmovepin_integration_test.go
@@ -93,7 +93,7 @@ func TestAConcurrentCloseSurvivesTheAutoExecutedMoveThatRacedIt(t *testing.T) {
 		SystemOfRecordProvider: native, t: t, as: human, won: won.UUID,
 	}
 	registry := agents.NewRegistry(
-		approvalsAdapter{svc: approvals.NewService(e.Pool)}, auth.NewGate(adminSeat{}))
+		approvalsAdapter{svc: approvals.NewService(e.DB())}, auth.NewGate(adminSeat{}))
 	// The stage resolver reads pipeline configuration and nothing this race
 	// touches, so it goes straight to the real provider — only the RECORD read
 	// carries the interleaving.

--- a/backend/internal/compose/dedupe_budget_integration_test.go
+++ b/backend/internal/compose/dedupe_budget_integration_test.go
@@ -13,10 +13,9 @@ import (
 	"context"
 	"testing"
 
-	"github.com/gradionhq/margince/backend/internal/compose/integration"
-
 	"github.com/jackc/pgx/v5"
 
+	"github.com/gradionhq/margince/backend/internal/compose/integration"
 	"github.com/gradionhq/margince/backend/internal/modules/approvals"
 	"github.com/gradionhq/margince/backend/internal/modules/capture"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
@@ -39,7 +38,7 @@ func connectorCtx(e *integration.Env) context.Context {
 
 func TestCaptureDedupeStagesMergeInsteadOfDuplicating(t *testing.T) {
 	e := integration.Setup(t)
-	sink := capture.NewSink(e.DB()).WithStager(mergeStager{svc: approvals.NewService(e.Pool)})
+	sink := capture.NewSink(e.DB()).WithStager(mergeStager{svc: approvals.NewService(e.DB())})
 	ctx := connectorCtx(e)
 
 	first, err := sink.Upsert(ctx, connector.NormalizedRecord{

--- a/backend/internal/compose/deepread.go
+++ b/backend/internal/compose/deepread.go
@@ -140,13 +140,13 @@ func newSiteDeepReadWorker(pool *pgxpool.Pool, brain, factBrain, triageBrain com
 	caps = caps.withDefaults()
 	return &siteDeepReadWorker{
 		pool:        pool,
-		people:      people.NewStore(pool),
+		people:      people.NewStore(InstallationDB(pool)),
 		crawler:     newSiteCrawler(fetcher, caps),
 		extract:     evidenceExtractor{fetch: fetcher, brain: brain, factBrain: factBrain},
 		triageBrain: triageBrain,
 		fetch:       fetcher,
 		blob:        blob,
-		approvals:   approvals.NewService(pool),
+		approvals:   approvals.NewService(InstallationDB(pool)),
 		authority:   identity.NewService(pool),
 		autoEnrich:  capture.NewAutoEnrichStore(pool),
 		settings:    capture.NewSettings(NewSettingsStore(pool)),

--- a/backend/internal/compose/deepread_integration_test.go
+++ b/backend/internal/compose/deepread_integration_test.go
@@ -85,7 +85,7 @@ func acmeDeepBrain() laneFake {
 // real approvals service, the deepread and site_lead accept effects wired
 // exactly as compose wires them in production.
 func newDeepReadTestWorker(e *integration.Env, site *fakeSite, brain completer) (*siteDeepReadWorker, *approvals.Service) {
-	svc := approvals.NewService(e.Pool)
+	svc := approvals.NewService(e.DB())
 	svc.WithEffect(deepReadProposalKind, deepReadAcceptEffect(svc, e.People))
 	svc.WithEffect(siteLeadProposalKind, siteLeadAcceptEffect(svc, newCaptureSink(e.Pool, CaptureConfig{})))
 	return &siteDeepReadWorker{

--- a/backend/internal/compose/deepreadaccept_integration_test.go
+++ b/backend/internal/compose/deepreadaccept_integration_test.go
@@ -116,7 +116,7 @@ func TestDeepReadOfferingsDedupeOnValueKeyAndAcceptRespectsHumanPrecedence(t *te
 
 func TestAcceptedEmployeeRangeFactFillsSizeBandWhenUnambiguous(t *testing.T) {
 	e := integration.Setup(t)
-	store := people.NewStore(e.Pool)
+	store := people.NewStore(e.DB())
 	ctx := e.As(e.Rep1, nil, integration.AdminPerms)
 	employeeRangeFact := func(value string) []people.DeepReadFact {
 		return []people.DeepReadFact{{

--- a/backend/internal/compose/deepreadtransport.go
+++ b/backend/internal/compose/deepreadtransport.go
@@ -233,7 +233,7 @@ func requestedBy(ctx context.Context) string {
 func WithDeepRead(inserter *jobs.Runner, brain completer) Option {
 	return func(s *Server, pool *pgxpool.Pool) {
 		engine := &deepReadEngine{
-			people: people.NewStore(pool), approvals: approvals.NewService(pool),
+			people: people.NewStore(InstallationDB(pool)), approvals: approvals.NewService(InstallationDB(pool)),
 			runtime: ai.NewRunTransparency(InstallationDB(pool)), brain: brain, enqueue: inserter, log: s.log,
 			// Read here AND written by WithBlobstore, so neither option order
 			// leaves the onboarding confirmation unable to collect the mark its
@@ -243,11 +243,11 @@ func WithDeepRead(inserter *jobs.Runner, brain completer) Option {
 		rollout := s.companyContextRollout
 		s.siteReadHandlers = siteReadHandlers{engine: engine, start: engine.start, report: engine.report, companyContextRollout: rollout}
 		s.assistant = &onboardingCompanyAssistant{
-			state: s.state, people: people.NewStore(pool),
+			state: s.state, people: people.NewStore(InstallationDB(pool)),
 			brain: brain, runtime: ai.NewRunTransparency(InstallationDB(pool)),
 			rollout: &s.companyContextRollout,
 			voice:   ai.NewVoiceStore(pool),
-			company: people.NewStore(pool),
+			company: people.NewStore(InstallationDB(pool)),
 		}
 	}
 }

--- a/backend/internal/compose/deepreadtriage_integration_test.go
+++ b/backend/internal/compose/deepreadtriage_integration_test.go
@@ -43,7 +43,7 @@ func (f *triageBrainFake) Complete(_ context.Context, _ model.Request) (model.Re
 // exactly as compose wires it: the classification never rides the profile
 // lane's brain.
 func newTriageTestWorker(e *integration.Env, site *fakeSite, extractBrain completer, triage completer) *siteDeepReadWorker {
-	svc := approvals.NewService(e.Pool)
+	svc := approvals.NewService(e.DB())
 	svc.WithEffect(siteLeadProposalKind, siteLeadAcceptEffect(svc, newCaptureSink(e.Pool, CaptureConfig{})))
 	return &siteDeepReadWorker{
 		pool:        e.Pool,

--- a/backend/internal/compose/embeddriftsweep.go
+++ b/backend/internal/compose/embeddriftsweep.go
@@ -97,6 +97,6 @@ func addEmbedDriftSweepJob(reg *jobRegistry, pool *pgxpool.Pool, cfg JobRunnerCo
 		return nil
 	}
 	addDeclaredWorker[EmbedDriftSweepArgs](reg, &embedDriftSweepWorker{pool: pool})
-	addDeclaredWorker[EmbedDriftWorkspaceArgs](reg, &embedDriftWorkspaceWorker{store: search.NewStore(pool), embedder: embedder, log: log})
+	addDeclaredWorker[EmbedDriftWorkspaceArgs](reg, &embedDriftWorkspaceWorker{store: search.NewStore(InstallationDB(pool)), embedder: embedder, log: log})
 	return periodicFor(cfg, EmbedDriftSweepArgs{})
 }

--- a/backend/internal/compose/embedreindextransport.go
+++ b/backend/internal/compose/embedreindextransport.go
@@ -478,7 +478,7 @@ func WithEmbedReindex(router *ai.Router, inserter *jobs.Runner) Option {
 		if identity, _ := router.EmbedIdentity(); identity == "" {
 			return
 		}
-		store := search.NewStore(pool)
+		store := search.NewStore(InstallationDB(pool))
 		estimator := costestimate.NewEmbedReindexEstimator(
 			store, ai.NewRateStore(InstallationDB(pool)), router, NewSeatBudget(pool), ai.NewMeter(InstallationDB(pool)), systemClock{},
 		)

--- a/backend/internal/compose/extractionaccept.go
+++ b/backend/internal/compose/extractionaccept.go
@@ -86,7 +86,7 @@ func NewExtractionAccept(pool *pgxpool.Pool, extractor extraction.Extractor) *Ex
 	return &ExtractionAccept{
 		pool:        pool,
 		attachments: activities.NewStore(pool),
-		deals:       deals.NewStore(pool, DealsInstallation()),
+		deals:       deals.NewStore(InstallationDB(pool), DealsInstallation()),
 		extractor:   extractor,
 	}
 }

--- a/backend/internal/compose/flip.go
+++ b/backend/internal/compose/flip.go
@@ -169,7 +169,11 @@ func (f *flipRunner) Preflight(ctx context.Context) (verdictOut crmcontracts.Ove
 func (f *flipRunner) parityPreview(ctx context.Context, incumbent string) ([]crmcontracts.OverlayFlipParityEntry, error) {
 	// The dry-run writes nothing, so it needs neither a run id to
 	// attribute identities to nor an operator to inherit records.
-	writers := newFlipWriters(f.pool, f.ms, incumbent)
+	db, err := actingWorkspaceDB(ctx, f.pool)
+	if err != nil {
+		return nil, err
+	}
+	writers := newFlipWriters(db, f.ms, incumbent)
 	rep, err := migration.NewEngine(f.runs, writers).DryRun(ctx, mirrorFlipSource{ms: f.ms})
 	if err != nil {
 		return nil, fmt.Errorf("flip preflight: parity dry-run: %w", err)
@@ -274,8 +278,12 @@ func (f *flipRunner) importMirrorEstate(ctx context.Context, run migration.Run, 
 	if err != nil {
 		return migration.Report{}, err
 	}
+	db, err := actingWorkspaceDB(ctx, f.pool)
+	if err != nil {
+		return migration.Report{}, err
+	}
 	source := mirrorFlipSource{ms: f.ms}
-	writers := newFlipWriters(f.pool, f.ms, incumbent).forRun(run.ID, operator)
+	writers := newFlipWriters(db, f.ms, incumbent).forRun(run.ID, operator)
 	assocs, err := source.Associations(ctx)
 	if err != nil {
 		return migration.Report{}, err

--- a/backend/internal/compose/flipbundle.go
+++ b/backend/internal/compose/flipbundle.go
@@ -209,7 +209,11 @@ func reconstructFromBundle(ctx context.Context, pool *pgxpool.Pool, bundle []byt
 	// unresolvedOwnerEmails, not nil: this path never resolves an owner
 	// email (owners come from the bundle's own map), and a fail-loud
 	// placeholder beats a nil-interface panic if that stops being true.
-	writers := newFlipWriters(pool, overlay.NewMirrorStore(InstallationDB(pool), unresolvedOwnerEmails{}), contents.incumbent).
+	db, err := actingWorkspaceDB(ctx, pool)
+	if err != nil {
+		return migration.Report{}, err
+	}
+	writers := newFlipWriters(db, overlay.NewMirrorStore(db, unresolvedOwnerEmails{}), contents.incumbent).
 		forRun(run.ID, operator).
 		WithOwnerMap(owners)
 	writers.SetAssociations(assocs)

--- a/backend/internal/compose/flipwriters.go
+++ b/backend/internal/compose/flipwriters.go
@@ -38,6 +38,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/modules/migration"
 	"github.com/gradionhq/margince/backend/internal/modules/overlay"
 	"github.com/gradionhq/margince/backend/internal/modules/people"
+	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/provenance"
 )
@@ -88,11 +89,16 @@ func (w *flipWriters) WithOwnerMap(m map[string]ids.UUID) *flipWriters {
 	return w
 }
 
-func newFlipWriters(pool *pgxpool.Pool, ms *overlay.MirrorStore, incumbent string) *flipWriters {
+// newFlipWriters builds the estate writers for ONE workspace: db is bound to
+// the tenant the estate lands in. That is the caller's, not the installation's
+// — a reconstruction rebuilds into the workspace whose operator ordered it,
+// which on a clean instance is not the one the server resolved at boot.
+func newFlipWriters(db *database.DB, ms *overlay.MirrorStore, incumbent string) *flipWriters {
+	pool := db.Pool()
 	return &flipWriters{
 		pool:       pool,
-		people:     people.NewStore(InstallationDB(pool)),
-		deals:      deals.NewStore(InstallationDB(pool), DealsInstallation()),
+		people:     people.NewStore(db),
+		deals:      deals.NewStore(db, DealsInstallation()),
 		activities: activities.NewStore(pool),
 		ms:         ms,
 		identities: migration.NewRunStore(pool),

--- a/backend/internal/compose/flipwriters.go
+++ b/backend/internal/compose/flipwriters.go
@@ -91,8 +91,8 @@ func (w *flipWriters) WithOwnerMap(m map[string]ids.UUID) *flipWriters {
 func newFlipWriters(pool *pgxpool.Pool, ms *overlay.MirrorStore, incumbent string) *flipWriters {
 	return &flipWriters{
 		pool:       pool,
-		people:     people.NewStore(pool),
-		deals:      deals.NewStore(pool, DealsInstallation()),
+		people:     people.NewStore(InstallationDB(pool)),
+		deals:      deals.NewStore(InstallationDB(pool), DealsInstallation()),
 		activities: activities.NewStore(pool),
 		ms:         ms,
 		identities: migration.NewRunStore(pool),

--- a/backend/internal/compose/fxrefresh.go
+++ b/backend/internal/compose/fxrefresh.go
@@ -302,8 +302,8 @@ func (w *fxRefreshWorker) Work(ctx context.Context, job *river.Job[FxRateRefresh
 
 func newFxRefreshWorker(pool *pgxpool.Pool, brain completer, url string, bootstrapCurrencies []string, log *slog.Logger) *fxRefreshWorker {
 	return &fxRefreshWorker{refresh: fxRefresh{
-		store:               deals.NewStore(pool, DealsInstallation()),
-		svc:                 approvals.NewService(pool),
+		store:               deals.NewStore(InstallationDB(pool), DealsInstallation()),
+		svc:                 approvals.NewService(InstallationDB(pool)),
 		fetcher:             webread.New(),
 		brain:               brain,
 		url:                 url,

--- a/backend/internal/compose/fxrefresh_integration_test.go
+++ b/backend/internal/compose/fxrefresh_integration_test.go
@@ -52,8 +52,8 @@ func (b fixedBrain) Complete(context.Context, model.Request) (model.Response, er
 // that will "extract" the given pairs JSON.
 func fxRefreshWith(e *integration.Env, reply string, bootstrap []string) fxRefresh {
 	return fxRefresh{
-		store:               deals.NewStore(e.Pool, DealsInstallation()),
-		svc:                 approvals.NewService(e.Pool),
+		store:               deals.NewStore(e.DB(), DealsInstallation()),
+		svc:                 approvals.NewService(e.DB()),
 		fetcher:             stubFetcher{},
 		brain:               fixedBrain{json: reply},
 		url:                 "https://rates.test/latest",
@@ -83,7 +83,7 @@ func TestFxRefreshStagesChangedRates(t *testing.T) {
 	adminCtx := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AdminPerms)
 
 	// The workspace tracks USD at 0.92 (base EUR).
-	if _, err := deals.NewStore(e.Pool, DealsInstallation()).SetFxRate(adminCtx,
+	if _, err := deals.NewStore(e.DB(), DealsInstallation()).SetFxRate(adminCtx,
 		deals.SetFxRateInput{FromCurrency: "USD", Rate: "0.92", EffectiveDate: time.Now().UTC()}); err != nil {
 		t.Fatalf("seed USD: %v", err)
 	}
@@ -125,7 +125,7 @@ func seedFx(ctx context.Context, t *testing.T, store *deals.Store, cur, rate str
 func TestFxRefreshDiffsAgainstEffectiveTodayNotSheetHead(t *testing.T) {
 	e := integration.Setup(t)
 	adminCtx := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AdminPerms)
-	store := deals.NewStore(e.Pool, DealsInstallation())
+	store := deals.NewStore(e.DB(), DealsInstallation())
 	tomorrow := time.Now().UTC().Add(24 * time.Hour)
 
 	// USD: today matches the source; a future row differs (must NOT propose).
@@ -158,7 +158,7 @@ func TestFxRefreshDiffsAgainstEffectiveTodayNotSheetHead(t *testing.T) {
 func TestFxRefreshSupersedesStalePendingProposal(t *testing.T) {
 	e := integration.Setup(t)
 	adminCtx := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AdminPerms)
-	store := deals.NewStore(e.Pool, DealsInstallation())
+	store := deals.NewStore(e.DB(), DealsInstallation())
 	seedFx(adminCtx, t, store, "USD", "0.9", time.Time{})
 
 	wctx := rateRefreshWorkerCtx(context.Background(), e.WS, e.Rep1.String())
@@ -246,7 +246,7 @@ func TestFxRefreshEmptySheetNoBootstrapSetIsNoOp(t *testing.T) {
 func TestFxRefreshDropsLowConfidenceAndCrossPairs(t *testing.T) {
 	e := integration.Setup(t)
 	adminCtx := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AdminPerms)
-	seedFx(adminCtx, t, deals.NewStore(e.Pool, DealsInstallation()), "USD", "0.92", time.Now().UTC())
+	seedFx(adminCtx, t, deals.NewStore(e.DB(), DealsInstallation()), "USD", "0.92", time.Now().UTC())
 
 	// USD arrives only via a low-confidence pair and a cross-pair (USD/GBP,
 	// neither side is the base EUR). Both are dropped, so nothing is staged.

--- a/backend/internal/compose/graphconsumer_integration_test.go
+++ b/backend/internal/compose/graphconsumer_integration_test.go
@@ -87,7 +87,7 @@ func TestTheConsumerFoldsAnActivityEventAndIgnoresWhatIsNotItsBusiness(t *testin
 	person := seedGraphPerson(t, e, "Consumed Contact")
 	activityID := seedExchange(t, e, person)
 
-	gen := search.NewGraphEdgeGen(search.NewStore(e.Pool))
+	gen := search.NewGraphEdgeGen(search.NewStore(e.DB()))
 	ctx := context.Background()
 
 	// An event for an entity this projection does not care about must answer
@@ -125,7 +125,7 @@ func TestRetentionAppliedReachesTheConsumer(t *testing.T) {
 	person := seedGraphPerson(t, e, "Retained Contact")
 	activityID := seedExchange(t, e, person)
 
-	gen := search.NewGraphEdgeGen(search.NewStore(e.Pool))
+	gen := search.NewGraphEdgeGen(search.NewStore(e.DB()))
 	ctx := context.Background()
 	if err := gen.HandleEvent(ctx, envelopeFor(e.WS, "activity.captured", "activity", activityID)); err != nil {
 		t.Fatalf("folding: %v", err)

--- a/backend/internal/compose/graphedgereconcile.go
+++ b/backend/internal/compose/graphedgereconcile.go
@@ -51,7 +51,7 @@ type graphEdgeReconcileWorker struct {
 }
 
 func newGraphEdgeReconcileWorker(pool *pgxpool.Pool, log *slog.Logger) *graphEdgeReconcileWorker {
-	return &graphEdgeReconcileWorker{pool: pool, store: search.NewStore(pool), log: log}
+	return &graphEdgeReconcileWorker{pool: pool, store: search.NewStore(InstallationDB(pool)), log: log}
 }
 
 // Work enumerates the fleet and enqueues one rebuild per workspace; it

--- a/backend/internal/compose/installation.go
+++ b/backend/internal/compose/installation.go
@@ -58,7 +58,7 @@ func EnsureInstallation(ctx context.Context, pool *pgxpool.Pool, log *slog.Logge
 		}
 	}
 
-	wsID, created, err := identity.NewService(pool).BootstrapInstallation(ctx, create, configuredSeed(cfg.Seeds, deals.NewHandlers(pool, DealsInstallation())))
+	wsID, created, err := identity.NewService(pool).BootstrapInstallation(ctx, create, configuredSeed(cfg.Seeds, deals.NewHandlers(InstallationDB(pool), DealsInstallation())))
 	if errors.Is(err, identity.ErrNotBootstrapped) {
 		return fmt.Errorf("compose: the database holds no organization and the configuration names no bootstrap_admin — add organization + bootstrap_admin to margince.yaml for first boot: %w", err)
 	}

--- a/backend/internal/compose/integration/agentaccess/oauth_surface_integration_test.go
+++ b/backend/internal/compose/integration/agentaccess/oauth_surface_integration_test.go
@@ -80,7 +80,7 @@ func TestApprovalTokenIsASignedEffectBoundJWS(t *testing.T) {
 	}
 	wsCtx := principal.WithWorkspaceID(context.Background(), wsID)
 
-	svc := approvals.NewService(pool)
+	svc := approvals.NewService(database.BindTo(pool, ids.From[ids.WorkspaceKind](wsID)))
 	claims, err := svc.VerifyApprovalToken(wsCtx, *approved.ApprovalToken)
 	if err != nil {
 		t.Fatalf("verify: %v", err)

--- a/backend/internal/compose/integration/approval_edit_integration_test.go
+++ b/backend/internal/compose/integration/approval_edit_integration_test.go
@@ -29,7 +29,7 @@ func TestModifyThenApproveRebindsTheAuthority(t *testing.T) {
 	e := Setup(t)
 	owner := OwnerConn(t)
 	pipeline, open, _ := DealFixture(t, e)
-	svc := approvals.NewService(e.Pool)
+	svc := approvals.NewService(e.DB())
 
 	var effectPayload json.RawMessage
 	var effectHash string
@@ -137,7 +137,7 @@ func assertEditAuditCarriesBothSides(t *testing.T, owner *pgx.Conn, approvalID i
 func TestModifyThenApproveCannotRetargetTheEffect(t *testing.T) {
 	e := Setup(t)
 	pipeline, open, _ := DealFixture(t, e)
-	svc := approvals.NewService(e.Pool)
+	svc := approvals.NewService(e.DB())
 
 	var effectRan bool
 	svc.WithEffect("advance_deal", func(_ context.Context, _ ids.ApprovalID, _ json.RawMessage, _ string) error {
@@ -197,7 +197,7 @@ func TestModifyThenApproveCannotRetargetTheEffect(t *testing.T) {
 func TestMalformedEditLeavesTheStagingPending(t *testing.T) {
 	e := Setup(t)
 	pipeline, open, _ := DealFixture(t, e)
-	svc := approvals.NewService(e.Pool)
+	svc := approvals.NewService(e.DB())
 
 	deal := e.SeedDeal(t, "Mine", pipeline, open, &e.Rep1)
 	approvalID, _ := stageAdvance(t, svc, e, deal)

--- a/backend/internal/compose/integration/approval_effect_provenance_integration_test.go
+++ b/backend/internal/compose/integration/approval_effect_provenance_integration_test.go
@@ -37,7 +37,7 @@ func TestAgentMintedStagingDoesNotInvokeAServerSideEffect(t *testing.T) {
 
 	const kind = "enrich"
 	var ran int
-	svc := approvals.NewService(e.Pool).WithEffect(kind,
+	svc := approvals.NewService(e.DB()).WithEffect(kind,
 		func(context.Context, ids.ApprovalID, json.RawMessage, string) error {
 			ran++
 			return errors.New("this executor cannot parse an agent REST envelope")
@@ -84,7 +84,7 @@ func TestServerMintedProposalStillInvokesItsEffect(t *testing.T) {
 
 	const kind = "enrich"
 	var ran int
-	svc := approvals.NewService(e.Pool).WithEffect(kind,
+	svc := approvals.NewService(e.DB()).WithEffect(kind,
 		func(context.Context, ids.ApprovalID, json.RawMessage, string) error {
 			ran++
 			return nil

--- a/backend/internal/compose/integration/approval_expiry_integration_test.go
+++ b/backend/internal/compose/integration/approval_expiry_integration_test.go
@@ -46,7 +46,7 @@ func TestApprovalExpiryClosesTheDecisionGate(t *testing.T) {
 	e := Setup(t)
 	owner := OwnerConn(t)
 	pipeline, open, _ := DealFixture(t, e)
-	svc := approvals.NewService(e.Pool)
+	svc := approvals.NewService(e.DB())
 
 	deal := e.SeedDeal(t, "Mine", pipeline, open, &e.Rep1)
 	approvalID, diffHash := stageAdvance(t, svc, e, deal)
@@ -83,7 +83,7 @@ func TestRedemptionWindowExpiresTheDecision(t *testing.T) {
 	e := Setup(t)
 	owner := OwnerConn(t)
 	pipeline, open, _ := DealFixture(t, e)
-	svc := approvals.NewService(e.Pool)
+	svc := approvals.NewService(e.DB())
 
 	deal := e.SeedDeal(t, "Mine", pipeline, open, &e.Rep1)
 	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, RepPerms)

--- a/backend/internal/compose/integration/approval_livetarget_integration_test.go
+++ b/backend/internal/compose/integration/approval_livetarget_integration_test.go
@@ -52,7 +52,7 @@ func everyGrantAllScope(objects ...string) principal.Permissions {
 // instead of waiting for the list to be extended.
 func TestNoStagedApprovalIsDecidableAgainstATargetThatIsNotThere(t *testing.T) {
 	e := Setup(t)
-	svc := approvals.NewService(e.Pool)
+	svc := approvals.NewService(e.DB())
 
 	classified := approvals.ClassifiedTargetTypes()
 	if len(classified) == 0 {
@@ -105,7 +105,7 @@ func TestNoStagedApprovalIsDecidableAgainstATargetThatIsNotThere(t *testing.T) {
 // workflow.
 func TestAStagedApprovalStopsBeingDecidableOnceItsTargetIsArchived(t *testing.T) {
 	e := Setup(t)
-	svc := approvals.NewService(e.Pool)
+	svc := approvals.NewService(e.DB())
 	pipeline, open, _ := DealFixture(t, e)
 
 	deal := e.SeedDeal(t, "Renewal", pipeline, open, &e.Rep1)

--- a/backend/internal/compose/integration/approval_personaltarget_integration_test.go
+++ b/backend/internal/compose/integration/approval_personaltarget_integration_test.go
@@ -34,7 +34,7 @@ import (
 
 func TestAStagedViewArchiveIsDecidableByItsOwnerAlone(t *testing.T) {
 	e := Setup(t)
-	svc := approvals.NewService(e.Pool)
+	svc := approvals.NewService(e.DB())
 	views := collections.NewStore(e.DB())
 
 	owner := e.As(e.Rep1, []ids.UUID{e.Team1}, collectionsPerms())

--- a/backend/internal/compose/integration/approval_targetfilter_integration_test.go
+++ b/backend/internal/compose/integration/approval_targetfilter_integration_test.go
@@ -85,7 +85,7 @@ func listIDs(ctx context.Context, t *testing.T, svc *approvals.Service, in appro
 // actions and gets those, not the workspace's queue.
 func TestApprovalListFilteredToOneTarget(t *testing.T) {
 	e := Setup(t)
-	svc := approvals.NewService(e.Pool)
+	svc := approvals.NewService(e.DB())
 	f := seedSiteReadStagings(t, svc, e)
 	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, siteReadPerms)
 	orgType := "organization"
@@ -134,7 +134,7 @@ func TestApprovalListFilteredToOneTarget(t *testing.T) {
 // the whole surface, not for the target-scoped read alone.
 func TestApprovalListKindFilterNarrowsTheWholeInbox(t *testing.T) {
 	e := Setup(t)
-	svc := approvals.NewService(e.Pool)
+	svc := approvals.NewService(e.DB())
 	f := seedSiteReadStagings(t, svc, e)
 	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, siteReadPerms)
 
@@ -156,7 +156,7 @@ func TestApprovalListKindFilterNarrowsTheWholeInbox(t *testing.T) {
 // own read gives.
 func TestApprovalListFilteredToAnOutOfScopeTargetIsEmpty(t *testing.T) {
 	e := Setup(t)
-	svc := approvals.NewService(e.Pool)
+	svc := approvals.NewService(e.DB())
 
 	theirs := e.SeedOrg(t, "Other Team Account", &e.Rep3)
 	staged := stageFor(t, svc, e, "deepread", "organization", theirs)
@@ -190,7 +190,7 @@ func TestApprovalListFilteredToAnOutOfScopeTargetIsEmpty(t *testing.T) {
 // browse (C3/ADR-0036).
 func TestApprovalListFilteredStillPrunesUndecidableKinds(t *testing.T) {
 	e := Setup(t)
-	svc := approvals.NewService(e.Pool)
+	svc := approvals.NewService(e.DB())
 	f := seedSiteReadStagings(t, svc, e)
 	orgType := "organization"
 
@@ -229,7 +229,7 @@ func TestApprovalListFilteredStillPrunesUndecidableKinds(t *testing.T) {
 // staged contacts and call it the whole list.
 func TestApprovalListFilteredReportsHasMore(t *testing.T) {
 	e := Setup(t)
-	svc := approvals.NewService(e.Pool)
+	svc := approvals.NewService(e.DB())
 	org := e.SeedOrg(t, "Acme", &e.Rep1)
 	for range 5 {
 		stageFor(t, svc, e, "site_lead", "organization", org)
@@ -268,7 +268,7 @@ func TestApprovalListFilteredReportsHasMore(t *testing.T) {
 // server that ignored the cursor would answer the same first page forever.
 func TestApprovalListPagesForwardWithTheCursor(t *testing.T) {
 	e := Setup(t)
-	svc := approvals.NewService(e.Pool)
+	svc := approvals.NewService(e.DB())
 	org := e.SeedOrg(t, "Acme", &e.Rep1)
 	const staged = 5
 	for range staged {
@@ -329,7 +329,7 @@ func TestApprovalListPagesForwardWithTheCursor(t *testing.T) {
 // a panic or a 500.
 func TestApprovalListRefusesAMalformedCursor(t *testing.T) {
 	e := Setup(t)
-	svc := approvals.NewService(e.Pool)
+	svc := approvals.NewService(e.DB())
 	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, siteReadPerms)
 
 	_, _, err := svc.List(rep, approvals.ListInput{Cursor: "not-a-page-token!!"})

--- a/backend/internal/compose/integration/approval_targetreadfloor_integration_test.go
+++ b/backend/internal/compose/integration/approval_targetreadfloor_integration_test.go
@@ -46,7 +46,7 @@ func tagPerms(g principal.ObjectGrant) principal.Permissions {
 
 func TestAStagedTagArchiveNeedsTagReadAndNotOnlyTagDelete(t *testing.T) {
 	e := Setup(t)
-	svc := approvals.NewService(e.Pool)
+	svc := approvals.NewService(e.DB())
 	tags := collections.NewStore(e.DB())
 
 	author := e.As(e.Rep1, []ids.UUID{e.Team1},

--- a/backend/internal/compose/integration/authority_scope_integration_test.go
+++ b/backend/internal/compose/integration/authority_scope_integration_test.go
@@ -109,7 +109,7 @@ func stageFor(t *testing.T, svc *approvals.Service, e *Env, kind string, targetT
 func TestApprovalAuthorityHonorsTargetRowScope(t *testing.T) {
 	e := Setup(t)
 	pipeline, open, _ := DealFixture(t, e)
-	svc := approvals.NewService(e.Pool)
+	svc := approvals.NewService(e.DB())
 
 	theirDeal := e.SeedDeal(t, "Theirs", pipeline, open, &e.Rep3) // team2's
 	approvalID := stageFor(t, svc, e, "advance_deal", "deal", theirDeal)
@@ -159,7 +159,7 @@ func TestApprovalAuthorityHonorsTargetRowScope(t *testing.T) {
 func TestApprovalListPagesPastUndecidableBurst(t *testing.T) {
 	e := Setup(t)
 	pipeline, open, _ := DealFixture(t, e)
-	svc := approvals.NewService(e.Pool)
+	svc := approvals.NewService(e.DB())
 
 	myDeal := e.SeedDeal(t, "Mine", pipeline, open, &e.Rep1)
 	theirDeal := e.SeedDeal(t, "Theirs", pipeline, open, &e.Rep3)

--- a/backend/internal/compose/integration/channels/telegram_identity_integration_test.go
+++ b/backend/internal/compose/integration/channels/telegram_identity_integration_test.go
@@ -107,7 +107,7 @@ func TestAC_TG_6_IdentityPhoneDisagreementIsAConflictNotAMerge(t *testing.T) {
 		t.Fatal("two exact lanes named different people and no conflict was reported — the disagreement would be resolved silently")
 	}
 
-	recorded, err := people.NewStore(c.Pool).EnqueueIdentityConflict(admin, *conflict,
+	recorded, err := people.NewStore(c.DB()).EnqueueIdentityConflict(admin, *conflict,
 		"telegram:"+fmt.Sprintf("%d", telegramBotID)+":"+account+":1", "connector:telegram")
 	if err != nil {
 		t.Fatalf("EnqueueIdentityConflict: %v", err)
@@ -316,7 +316,7 @@ func TestTwoConcurrentFirstMessagesYieldOnePersonAndTwoActivities(t *testing.T) 
 	second := telegramUpdate{updateID: 5702, messageID: 72, senderID: 770701, username: "racer", firstName: "Nadia", text: "second"}
 
 	sink := capture.NewSink(c.DB()).
-		WithChannelEnsurer(channelEnsureForwarder{store: people.NewStore(c.Pool)})
+		WithChannelEnsurer(channelEnsureForwarder{store: people.NewStore(c.DB())})
 	ctx := c.channelConnectorCtx(t)
 
 	start := make(chan struct{})

--- a/backend/internal/compose/integration/channels/telegram_ingress_integration_test.go
+++ b/backend/internal/compose/integration/channels/telegram_ingress_integration_test.go
@@ -172,7 +172,7 @@ func (c *telegramEnv) assertWorkspaceVisible(t *testing.T, personID, ownedPerson
 	reader := c.strangerRepCtx(t, map[string]principal.ObjectGrant{
 		"person": {Read: true}, "activity": {Read: true},
 	})
-	store := people.NewStore(c.Pool)
+	store := people.NewStore(c.DB())
 
 	shared, err := ids.ParseAs[ids.PersonKind](personID)
 	if err != nil {

--- a/backend/internal/compose/integration/customfields_values_deal_integration_test.go
+++ b/backend/internal/compose/integration/customfields_values_deal_integration_test.go
@@ -135,9 +135,14 @@ func TestCustomFieldValues_DealWorkspaceIsolation(t *testing.T) {
 
 	// The deal grants, not the catalog ones: this arm creates a DEAL in tenant B,
 	// so the perms it needs are the ones the write goes through.
-	_, ctxB := SeedSecondWorkspace(t, OwnerConn(t), dealCFVPerms)
-	pipelineB, stageB := seedDealFixtureIn(ctxB, t, f.store)
-	inB, err := f.store.CreateDeal(ctxB, deals.CreateDealInput{
+	wsB, ctxB := SeedSecondWorkspace(t, OwnerConn(t), dealCFVPerms)
+	// Tenant B's own store: a write lands in the workspace its handle names, so
+	// the tenant-A store would stamp B's ids into A's transaction and RLS would
+	// refuse them. The catalog service is shared on purpose — the physical
+	// column is one column, which is what this arm is about.
+	storeB := deals.NewStore(f.e.DBFor(wsB), installseam.Deals()).WithFieldCatalog(f.svc)
+	pipelineB, stageB := seedDealFixtureIn(ctxB, t, storeB)
+	inB, err := storeB.CreateDeal(ctxB, deals.CreateDealInput{
 		Name: "Tenant B Deal", PipelineID: pipelineB, StageID: stageB, Source: "ui",
 		CustomFields: map[string]any{col: "enterprise"},
 	})

--- a/backend/internal/compose/integration/customfields_values_deal_integration_test.go
+++ b/backend/internal/compose/integration/customfields_values_deal_integration_test.go
@@ -59,7 +59,7 @@ func setupDealCFV(t *testing.T) dealCFVFixture {
 	return dealCFVFixture{
 		e:        e,
 		svc:      svc,
-		store:    deals.NewStore(e.Pool, installseam.Deals()).WithFieldCatalog(svc),
+		store:    deals.NewStore(e.DB(), installseam.Deals()).WithFieldCatalog(svc),
 		ctx:      e.As(e.Rep1, nil, dealCFVPerms),
 		pipeline: pipeline,
 		stage:    open,

--- a/backend/internal/compose/integration/customfields_values_integration_test.go
+++ b/backend/internal/compose/integration/customfields_values_integration_test.go
@@ -68,6 +68,14 @@ func setupCFV(t *testing.T) cfvFixture {
 	}
 }
 
+// storeFor is the fixture's people store bound to ANOTHER workspace, for the
+// isolation arms: a write lands in the workspace its handle names, so tenant B
+// needs a store of its own. The field catalog is the same service — the physical
+// column is shared, which is the whole point of the arms below.
+func (f cfvFixture) storeFor(ws ids.UUID) *people.Store {
+	return people.NewStore(f.e.DBFor(ws)).WithFieldCatalog(f.svc)
+}
+
 // defineField creates one active custom field and returns its physical
 // column name.
 func (f cfvFixture) defineField(t *testing.T, spec customfields.FieldSpec) string {
@@ -430,8 +438,8 @@ func TestCustomFieldValues_WorkspaceIsolation(t *testing.T) {
 	}
 	assertCF(t, inA.AdditionalProperties, col, "gold")
 
-	_, ctxB := SeedSecondWorkspace(t, OwnerConn(t), CustomFieldAdminPerms)
-	inB, err := f.store.CreatePerson(ctxB, people.CreatePersonInput{
+	wsB, ctxB := SeedSecondWorkspace(t, OwnerConn(t), CustomFieldAdminPerms)
+	inB, err := f.storeFor(wsB).CreatePerson(ctxB, people.CreatePersonInput{
 		FullName: "Tenant B Person", Source: "ui",
 		CustomFields: map[string]any{col: "gold"},
 	})

--- a/backend/internal/compose/integration/customfields_values_integration_test.go
+++ b/backend/internal/compose/integration/customfields_values_integration_test.go
@@ -63,7 +63,7 @@ func setupCFV(t *testing.T) cfvFixture {
 	return cfvFixture{
 		e:     e,
 		svc:   svc,
-		store: people.NewStore(e.Pool).WithFieldCatalog(svc),
+		store: people.NewStore(e.DB()).WithFieldCatalog(svc),
 		ctx:   e.As(e.Rep1, nil, cfvPerms),
 	}
 }

--- a/backend/internal/compose/integration/customfields_vocab_integration_test.go
+++ b/backend/internal/compose/integration/customfields_vocab_integration_test.go
@@ -278,7 +278,7 @@ func TestCustomFieldVocab_CoreVocabulary(t *testing.T) {
 	f := setupCFV(t)
 	// The deal list shares f's Env (Setup rebuilds the schema, so one
 	// per test) — its store rides the same pool and field catalog.
-	dealStore := deals.NewStore(f.e.Pool, installseam.Deals()).WithFieldCatalog(f.svc)
+	dealStore := deals.NewStore(f.e.DB(), installseam.Deals()).WithFieldCatalog(f.svc)
 	dealCtx := f.e.As(f.e.Rep1, nil, dealCFVPerms)
 
 	resources := coreVocabResources(dealCtx, f, dealStore)

--- a/backend/internal/compose/integration/documents_integration_test.go
+++ b/backend/internal/compose/integration/documents_integration_test.go
@@ -348,7 +348,7 @@ func seedActivityWithDeal(t *testing.T, e *Env, deal ids.UUID) ids.UUID {
 func TestAnOrganizationMergeCarriesTheDocumentsAcross(t *testing.T) {
 	e := Setup(t)
 	files := activities.NewStore(e.Pool)
-	orgs := people.NewStore(e.Pool)
+	orgs := people.NewStore(e.DB())
 	survivor := e.SeedOrg(t, "Acme", &e.Rep1)
 	dissolved := e.SeedOrg(t, "Acme Holdings", &e.Rep1)
 

--- a/backend/internal/compose/integration/embedreindex_integration_test.go
+++ b/backend/internal/compose/integration/embedreindex_integration_test.go
@@ -142,7 +142,7 @@ func setupEmbedReindex(t *testing.T, router *ai.Router) *apptest.AppEnv {
 	e.Slug = "embed-reindex-e2e" // slugify("Embed Reindex E2E")
 
 	identity, _ := router.EmbedIdentity()
-	if err := search.NewStore(e.Pool).SeedBinding(ctx, identity); err != nil {
+	if err := search.NewStore(e.DB()).SeedBinding(ctx, identity); err != nil {
 		t.Fatalf("SeedBinding: %v", err)
 	}
 	return e

--- a/backend/internal/compose/integration/fts_integration_test.go
+++ b/backend/internal/compose/integration/fts_integration_test.go
@@ -31,7 +31,7 @@ func TestSearchFoldsAccentsAndStemsByLanguage(t *testing.T) {
 	}
 
 	// Accent folding: the unaccented spelling must find the umlaut row.
-	searchStore := search.NewStore(e.Pool)
+	searchStore := search.NewStore(e.DB())
 	page, err := searchStore.Search(admin, search.Input{Query: "Muller", Types: []string{"person"}})
 	if err != nil {
 		t.Fatalf("search: %v", err)
@@ -85,7 +85,7 @@ func TestSearchFoldsApostrophesInNames(t *testing.T) {
 
 	// Global search: the collapsed spelling, the apostrophe spelling,
 	// and the bare surname must all find the row.
-	searchStore := search.NewStore(e.Pool)
+	searchStore := search.NewStore(e.DB())
 	for _, q := range []string{"oreilly", "o'reilly", "o’reilly", "reilly"} {
 		page, err := searchStore.Search(admin, search.Input{Query: q, Types: []string{"person"}})
 		if err != nil {

--- a/backend/internal/compose/integration/grants_integration_test.go
+++ b/backend/internal/compose/integration/grants_integration_test.go
@@ -31,7 +31,7 @@ func TestRecordGrantWidensRowScopeAndRevokes(t *testing.T) {
 	foreign := e.Seed(t, `INSERT INTO person (id, workspace_id, full_name, owner_id, source, captured_by) VALUES ($1, $2, 'Shared Secret', $3, 'manual', 'human:x')`, e.Rep3)
 
 	repCtx := e.AsTeamRep(e.Rep1, e.Team1)
-	peopleStore := people.NewStore(e.Pool)
+	peopleStore := people.NewStore(e.DB())
 
 	// Before the grant: team scope hides rep3's record from rep1.
 	if _, err := peopleStore.GetPerson(repCtx, PersonIDOf(foreign), storekit.LiveOnly); err == nil {

--- a/backend/internal/compose/integration/harness.go
+++ b/backend/internal/compose/integration/harness.go
@@ -360,13 +360,16 @@ func (e *Env) SeedOrg(t *testing.T, name string, owner *ids.UUID) ids.UUID {
 	return ids.UUID(org.Id)
 }
 
-// SeedOrgAs creates an ownerless organization under the caller's own
-// context — unlike SeedOrg (always e.Admin(), the harness's one primary
-// workspace), this lets a cross-tenant suite seed a fixture in a SECOND
-// workspace's own context.
-func (e *Env) SeedOrgAs(ctx context.Context, t *testing.T, name string) ids.UUID {
+// SeedOrgAs creates an ownerless organization in a SECOND workspace, under
+// that workspace's own context — unlike SeedOrg, which always writes the
+// harness's primary workspace as e.Admin().
+//
+// It names the workspace as well as the ctx because the row lands wherever the
+// STORE is bound: the harness's own store would stamp the second tenant's ids
+// into the first tenant's transaction, which RLS refuses.
+func (e *Env) SeedOrgAs(ctx context.Context, t *testing.T, ws ids.UUID, name string) ids.UUID {
 	t.Helper()
-	org, err := e.People.CreateOrganization(ctx, people.CreateOrganizationInput{DisplayName: name})
+	org, err := e.PeopleFor(ws).CreateOrganization(ctx, people.CreateOrganizationInput{DisplayName: name})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/backend/internal/compose/integration/harness.go
+++ b/backend/internal/compose/integration/harness.go
@@ -109,8 +109,8 @@ func Setup(t *testing.T) *Env {
 	// last and sees a package that has genuinely stopped.
 	t.Cleanup(func() { testdb.AssertPoolsQuiesced(t) })
 	e.Pool = pool
-	e.People = people.NewStore(pool)
-	e.Deals = deals.NewStore(pool, installseam.Deals())
+	e.People = people.NewStore(harnessDB(pool, e.WS))
+	e.Deals = deals.NewStore(harnessDB(pool, e.WS), installseam.Deals())
 	e.Activities = activities.NewStore(pool)
 	return e
 }

--- a/backend/internal/compose/integration/harnessdb.go
+++ b/backend/internal/compose/integration/harnessdb.go
@@ -8,6 +8,9 @@ package integration
 import (
 	"github.com/jackc/pgx/v5/pgxpool"
 
+	"github.com/gradionhq/margince/backend/internal/compose/installseam"
+	"github.com/gradionhq/margince/backend/internal/modules/deals"
+	"github.com/gradionhq/margince/backend/internal/modules/people"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
@@ -38,4 +41,22 @@ func (e *Env) DBFor(ws ids.UUID) *database.DB {
 // carry it.
 func harnessDB(pool *pgxpool.Pool, ws ids.UUID) *database.DB {
 	return database.BindTo(pool, ids.From[ids.WorkspaceKind](ws))
+}
+
+// DealsFor and PeopleFor are the harness stores of ANOTHER workspace, for the
+// cross-tenant suites that seed a second tenant and then drive it through the
+// real writer.
+//
+// The workspace a store writes is a property of its handle, so seeding tenant B
+// through the harness's own store would stamp B's ids into A's bound
+// transaction and be refused by RLS — the loud version of the silent
+// cross-tenant write these suites exist to deny.
+func (e *Env) DealsFor(ws ids.UUID) *deals.Store {
+	return deals.NewStore(e.DBFor(ws), installseam.Deals())
+}
+
+// PeopleFor is DealsFor for the people module; see its doc for why the second
+// tenant needs a store of its own.
+func (e *Env) PeopleFor(ws ids.UUID) *people.Store {
+	return people.NewStore(e.DBFor(ws))
 }

--- a/backend/internal/compose/integration/harnessdb.go
+++ b/backend/internal/compose/integration/harnessdb.go
@@ -6,6 +6,8 @@
 package integration
 
 import (
+	"github.com/jackc/pgx/v5/pgxpool"
+
 	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
@@ -30,4 +32,10 @@ func (e *Env) DB() *database.DB {
 // a store bound to B must not resolve A's row.
 func (e *Env) DBFor(ws ids.UUID) *database.DB {
 	return database.BindTo(e.Pool, ids.From[ids.WorkspaceKind](ws))
+}
+
+// harnessDB pins a pool to a workspace at Setup time, before the Env exists to
+// carry it.
+func harnessDB(pool *pgxpool.Pool, ws ids.UUID) *database.DB {
+	return database.BindTo(pool, ids.From[ids.WorkspaceKind](ws))
 }

--- a/backend/internal/compose/integration/jobfanout/runner_integration_test.go
+++ b/backend/internal/compose/integration/jobfanout/runner_integration_test.go
@@ -131,7 +131,7 @@ func setupRunner(t *testing.T) *runnerEnv {
 		pool:   pool,
 		svc: compose.NewRunnerService(pool, modelPath.AgentLoop, modelPath.DraftReply, nil, logger, nil,
 			compose.SendPath{}, compose.WithSpecResolver(stagingSpec)),
-		store:      runner.NewStore(pool),
+		store:      runner.NewStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](wsID))),
 		brain:      brain,
 		wsID:       wsID,
 		wsCtx:      principal.WithWorkspaceID(context.Background(), wsID),

--- a/backend/internal/compose/integration/leadlistsort_integration_test.go
+++ b/backend/internal/compose/integration/leadlistsort_integration_test.go
@@ -40,7 +40,7 @@ func TestLeadListSortsByScoreAndPagesUnderIt(t *testing.T) {
 	e.Seed(t, `INSERT INTO lead (id, workspace_id, full_name, status, source, score, captured_by)
 	           VALUES ($1, $2, 'Coldest', 'working', 'inbound', 10, 'human:x')`)
 
-	store := people.NewStore(e.Pool)
+	store := people.NewStore(e.DB())
 	sortField := "-score"
 	one := 1
 
@@ -87,7 +87,7 @@ func TestLeadListNarrowsToTheRequestedMinimumScore(t *testing.T) {
 	e.Seed(t, `INSERT INTO lead (id, workspace_id, full_name, status, source, score, captured_by)
 	           VALUES ($1, $2, 'Coldest', 'working', 'inbound', 10, 'human:x')`)
 
-	store := people.NewStore(e.Pool)
+	store := people.NewStore(e.DB())
 	sortField := "-score"
 	floor := 50
 
@@ -108,7 +108,7 @@ func TestLeadListRefusesAnUnknownSortField(t *testing.T) {
 	e := SetupSearch(t)
 	ctx := e.AsFullUser()
 
-	store := people.NewStore(e.Pool)
+	store := people.NewStore(e.DB())
 	sortField := "not_a_column"
 	if _, _, err := store.ListLeads(ctx, people.ListLeadsInput{Sort: &sortField}); err == nil {
 		t.Fatal("ListLeads sort=not_a_column: want a refusal, got none")

--- a/backend/internal/compose/integration/leadscore_override_integration_test.go
+++ b/backend/internal/compose/integration/leadscore_override_integration_test.go
@@ -61,7 +61,7 @@ func TestLeadScoreOverrideIsSticky(t *testing.T) {
 	e := SetupSearch(t)
 	engine := compose.NewWorkflowEngine(e.DB())
 	ctx := e.AsFullUser()
-	store := people.NewStore(e.Pool)
+	store := people.NewStore(e.DB())
 	activityStore := activities.NewStore(e.Pool)
 
 	// A working lead: decision-maker title (+15) from a high-intent source

--- a/backend/internal/compose/integration/listsortcoverage_integration_test.go
+++ b/backend/internal/compose/integration/listsortcoverage_integration_test.go
@@ -65,7 +65,7 @@ func TestProductListSortsByEveryOfferedColumn(t *testing.T) {
 	e.Seed(t, seedProduct, "Apex", "SKU-A", 9000, false, seedLatest, seedMiddle)
 	e.Seed(t, seedProduct, "Zenith", "SKU-Z", 1000, true, seedEarliest, seedLatest)
 
-	store := deals.NewStore(e.Pool, installseam.Deals())
+	store := deals.NewStore(e.DB(), installseam.Deals())
 	for _, tc := range []struct {
 		sort  string
 		order []string
@@ -103,7 +103,7 @@ func TestOfferTemplateListSortsByEveryOfferedColumn(t *testing.T) {
 	e.Seed(t, seedTemplate, "Apex", "en-GB", false, seedLatest, seedMiddle)
 	e.Seed(t, seedTemplate, "Zenith", "fr-FR", true, seedEarliest, seedLatest)
 
-	store := deals.NewStore(e.Pool, installseam.Deals())
+	store := deals.NewStore(e.DB(), installseam.Deals())
 	for _, tc := range []struct {
 		sort  string
 		order []string

--- a/backend/internal/compose/integration/modelpathbinding_integration_test.go
+++ b/backend/internal/compose/integration/modelpathbinding_integration_test.go
@@ -81,7 +81,7 @@ func TestNewModelPathSeedsBindingMarkerOnEmptyStore(t *testing.T) {
 		t.Fatalf("NewModelPath: %v", err)
 	}
 
-	store := search.NewStore(e.Pool)
+	store := search.NewStore(e.DB())
 	populated, status, _, err := store.PopulatedIdentity(context.Background())
 	if err != nil {
 		t.Fatalf("PopulatedIdentity: %v", err)
@@ -100,7 +100,7 @@ func TestNewModelPathSeedsBindingMarkerOnEmptyStore(t *testing.T) {
 
 func TestNewModelPathLogsLoudlyOnChangedBinding(t *testing.T) {
 	e := Setup(t)
-	store := search.NewStore(e.Pool)
+	store := search.NewStore(e.DB())
 	const priorIdentity = "fake/fake-embed-old@2048"
 	if err := store.SeedBinding(context.Background(), priorIdentity); err != nil {
 		t.Fatalf("seeding the prior binding: %v", err)
@@ -155,7 +155,7 @@ func TestNewModelPathUnboundEmbedLaneSkipsSeed(t *testing.T) {
 		t.Fatalf("NewModelPath must not fail on an unbound embed lane: %v", err)
 	}
 
-	store := search.NewStore(e.Pool)
+	store := search.NewStore(e.DB())
 	// The marker row must be genuinely ABSENT — assert the specific
 	// no-row error, so a schema/permission fault can't masquerade as
 	// "correctly skipped the seed".

--- a/backend/internal/compose/integration/offerregenerate_http_integration_test.go
+++ b/backend/internal/compose/integration/offerregenerate_http_integration_test.go
@@ -47,7 +47,7 @@ func setupWithOfferDraft(t *testing.T) (*apptest.AppEnv, *ai.FakeClient) {
 		t.Fatalf("opening the offer-draft retriever's pool: %v", err)
 	}
 	t.Cleanup(pool.Close)
-	retriever := search.NewRetriever(search.NewStore(pool), nil)
+	retriever := search.NewRetriever(search.NewStore(compose.InstallationDB(pool)), nil)
 	fake := ai.NewFakeClient()
 	// The OfferDraft lane rides the DB-less router (ai.WithFakeClient swaps
 	// in this scripted fake) instead of handing fake straight to

--- a/backend/internal/compose/integration/offerrender_integration_test.go
+++ b/backend/internal/compose/integration/offerrender_integration_test.go
@@ -86,6 +86,14 @@ func (s *spyBlobStore) Put(ctx context.Context, key string, r io.Reader, size in
 // seeded FX rate).
 func renderOneLineOffer(ctx context.Context, t *testing.T, e *Env, dealID ids.UUID, in deals.CreateOfferInput) crmcontracts.Offer {
 	t.Helper()
+	return renderOneLineOfferOn(ctx, t, e.Deals, dealID, in)
+}
+
+// renderOneLineOfferOn is renderOneLineOffer through a store the caller bound.
+// A second tenant's offer has to be written by that tenant's own store, since
+// the workspace a write lands in comes from the handle rather than the ctx.
+func renderOneLineOfferOn(ctx context.Context, t *testing.T, store *deals.Store, dealID ids.UUID, in deals.CreateOfferInput) crmcontracts.Offer {
+	t.Helper()
 	if in.Currency == "" {
 		in.Currency = "EUR"
 	}
@@ -96,7 +104,7 @@ func renderOneLineOffer(ctx context.Context, t *testing.T, e *Env, dealID ids.UU
 		desc, price := "Retainer", int64(50000)
 		in.LineItems = []deals.OfferLineInputRow{{Description: &desc, Quantity: "1", UnitPriceMinor: &price}}
 	}
-	created, err := e.Deals.CreateOffer(ctx, ids.From[ids.DealKind](dealID), in)
+	created, err := store.CreateOffer(ctx, ids.From[ids.DealKind](dealID), in)
 	if err != nil {
 		t.Fatalf("create offer: %v", err)
 	}
@@ -398,10 +406,14 @@ func seedOfferRenderWorkspaceB(t *testing.T, e *Env, owner *pgx.Conn) ids.OfferI
 		},
 	})
 
-	if err := e.Deals.SeedDefaults(ctxB); err != nil {
+	// Tenant B is written through a store bound to tenant B: the workspace is
+	// the handle's, not the ctx's, so the harness's own store would stamp B's
+	// rows inside A's transaction and RLS would refuse them.
+	dealsB := e.DealsFor(ws)
+	if err := dealsB.SeedDefaults(ctxB); err != nil {
 		t.Fatal(err)
 	}
-	p, err := e.Deals.DefaultPipeline(ctxB)
+	p, err := dealsB.DefaultPipeline(ctxB)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -412,13 +424,13 @@ func seedOfferRenderWorkspaceB(t *testing.T, e *Env, owner *pgx.Conn) ids.OfferI
 			break
 		}
 	}
-	deal, err := e.Deals.CreateDeal(ctxB, deals.CreateDealInput{
+	deal, err := dealsB.CreateDeal(ctxB, deals.CreateDealInput{
 		Name: "Tenant B deal", PipelineID: ids.From[ids.PipelineKind](ids.UUID(p.Id)), StageID: openStage,
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	created := renderOneLineOffer(ctxB, t, e, ids.UUID(deal.Id), deals.CreateOfferInput{})
+	created := renderOneLineOfferOn(ctxB, t, dealsB, ids.UUID(deal.Id), deals.CreateOfferInput{})
 	return ids.From[ids.OfferKind](ids.UUID(created.Id))
 }
 

--- a/backend/internal/compose/integration/offerrender_integration_test.go
+++ b/backend/internal/compose/integration/offerrender_integration_test.go
@@ -491,7 +491,7 @@ func TestOfferRenderHandler_ReadOnlyOfferGrantDeniedBeforeAnyBlobWrite(t *testin
 	offerID := ids.From[ids.OfferKind](ids.UUID(created.Id))
 
 	blob := &spyBlobStore{Store: blobstore.NewMemory()}
-	h := deals.NewHandlers(e.Pool, installseam.Deals()).WithBlobstore(blob)
+	h := deals.NewHandlers(e.DB(), installseam.Deals()).WithBlobstore(blob)
 
 	readOnly := e.As(e.Rep2, []ids.UUID{e.Team1}, offerRenderReadOnlyPerms)
 	req := httptest.NewRequest(http.MethodPost, "/v1/offers/"+created.Id.String()+"/render", nil).WithContext(readOnly)

--- a/backend/internal/compose/integration/offertemplate_integration_test.go
+++ b/backend/internal/compose/integration/offertemplate_integration_test.go
@@ -438,17 +438,22 @@ func TestOfferTemplateRLS_TenantIsolation(t *testing.T) {
 		UserID: ids.NewV7(), Permissions: offerTemplateAdminPerms,
 	})
 
+	// Tenant B asks through a store of its own: the workspace a read is scoped
+	// to is the handle's, so driving tenant A's store with tenant B's ctx would
+	// answer tenant A's rows and the isolation claim would be vacuous.
+	dealsB := e.DealsFor(wsB)
+
 	id := ids.From[ids.OfferTemplateKind](ids.UUID(created.Id))
-	if _, err := e.Deals.GetOfferTemplate(ctxB, id, storekit.IncludeArchived); !errors.Is(err, apperrors.ErrNotFound) {
+	if _, err := dealsB.GetOfferTemplate(ctxB, id, storekit.IncludeArchived); !errors.Is(err, apperrors.ErrNotFound) {
 		t.Fatalf("tenant B must not resolve tenant A's template, got %v", err)
 	}
-	listed, _, err := e.Deals.ListOfferTemplates(ctxB, deals.ListOfferTemplatesInput{IncludeArchived: true})
+	listed, _, err := dealsB.ListOfferTemplates(ctxB, deals.ListOfferTemplatesInput{IncludeArchived: true})
 	if err != nil || len(listed) != 0 {
 		t.Fatalf("tenant B's list = %d rows (%v), want empty", len(listed), err)
 	}
 	// Tenant B may still mint its OWN template with the identical name —
 	// offer_template_name_unique is scoped to (workspace_id, name).
-	if _, err := e.Deals.CreateOfferTemplate(ctxB, basicTemplateInput("Tenant A Template")); err != nil {
+	if _, err := dealsB.CreateOfferTemplate(ctxB, basicTemplateInput("Tenant A Template")); err != nil {
 		t.Fatalf("tenant B minting the same name in its own workspace must succeed, got %v", err)
 	}
 	if _, err := e.Deals.GetOfferTemplate(ctxA, id, storekit.LiveOnly); err != nil {

--- a/backend/internal/compose/integration/org360/org360_integration_test.go
+++ b/backend/internal/compose/integration/org360/org360_integration_test.go
@@ -51,7 +51,7 @@ var org360Clock = time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
 // org360Service builds the composite read over the harness pool with the
 // pinned clock.
 func org360Service(e *integration.Env) *org360svc.Service {
-	return org360svc.NewService(e.Pool, people.NewStore(e.Pool), approvals.NewService(e.Pool),
+	return org360svc.NewService(e.Pool, people.NewStore(e.DB()), approvals.NewService(e.DB()),
 		func() time.Time { return org360Clock })
 }
 

--- a/backend/internal/compose/integration/org360/org360_querycount_integration_test.go
+++ b/backend/internal/compose/integration/org360/org360_querycount_integration_test.go
@@ -98,7 +98,7 @@ func TestOrganization360CostDoesNotGrowWithTheAccount(t *testing.T) {
 
 	tracer := &countingTracer{}
 	pool := tracedPool(t, tracer)
-	svc := org360svc.NewService(pool, people.NewStore(pool), approvals.NewService(pool),
+	svc := org360svc.NewService(pool, people.NewStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](e.WS))), approvals.NewService(database.BindTo(pool, ids.From[ids.WorkspaceKind](e.WS))),
 		func() time.Time { return org360Clock })
 	ctx := e.Admin()
 

--- a/backend/internal/compose/integration/org360/org360_visit_integration_test.go
+++ b/backend/internal/compose/integration/org360/org360_visit_integration_test.go
@@ -46,7 +46,7 @@ func TestOrganizationViewAckIsMonotonicAndPerUser(t *testing.T) {
 
 	// A second tab whose clock lags must not rewind the mark: the upsert
 	// keeps the later of the two.
-	lagging := org360svc.NewService(e.Pool, people.NewStore(e.Pool), approvals.NewService(e.Pool),
+	lagging := org360svc.NewService(e.DB().Pool(), people.NewStore(e.DB()), approvals.NewService(e.DB()),
 		func() time.Time { return org360Clock.Add(-time.Hour) })
 	second, err := lagging.Acknowledge(rep1, org)
 	if err != nil {

--- a/backend/internal/compose/integration/organization_computed_integration_test.go
+++ b/backend/internal/compose/integration/organization_computed_integration_test.go
@@ -115,12 +115,12 @@ func assertHonestFloors(t *testing.T, rows []crmcontracts.ComputedField) {
 // second workspace (the cross-tenant suite below) can seed its own
 // default pipeline — DealFixture itself is hard-wired to e.Admin(),
 // which is always bound to the harness's primary workspace.
-func pipelineFixtureFor(ctx context.Context, t *testing.T, e *Env) (pipeline ids.PipelineID, open ids.StageID) {
+func pipelineFixtureFor(ctx context.Context, t *testing.T, store *deals.Store) (pipeline ids.PipelineID, open ids.StageID) {
 	t.Helper()
-	if err := e.Deals.SeedDefaults(ctx); err != nil {
+	if err := store.SeedDefaults(ctx); err != nil {
 		t.Fatal(err)
 	}
-	p, err := e.Deals.DefaultPipeline(ctx)
+	p, err := store.DefaultPipeline(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -173,7 +173,7 @@ var computedFieldWorkspaceBPerms = principal.Permissions{
 func TestOrganizationComputed_GatedVisible_RealValueMatchesDirectViewRead(t *testing.T) {
 	e := Setup(t)
 	owner := OwnerConn(t)
-	pipeline, open := pipelineFixtureFor(e.Admin(), t, e)
+	pipeline, open := pipelineFixtureFor(e.Admin(), t, e.Deals)
 	orgID := e.SeedOrg(t, "Acme Corp", nil)
 
 	d1, err := e.Deals.CreateDeal(e.Admin(), deals.CreateDealInput{
@@ -262,7 +262,7 @@ func TestOrganizationComputed_NoOpenDeals_FloorsToZero(t *testing.T) {
 // genuine-zero no-row case the next test covers.
 func TestOrganizationComputed_OpenDealsWithoutFrozenFX_AwaitingFX(t *testing.T) {
 	e := Setup(t)
-	pipeline, open := pipelineFixtureFor(e.Admin(), t, e)
+	pipeline, open := pipelineFixtureFor(e.Admin(), t, e.Deals)
 	orgID := e.SeedOrg(t, "Unpriced Pipeline LLC", nil)
 
 	for _, amount := range []int64{75000, 125000} {
@@ -374,7 +374,7 @@ func TestOrganizationComputed_SecurityInvokerNeverLeaksAcrossWorkspaces(t *testi
 	e := Setup(t)
 	owner := OwnerConn(t)
 
-	pipelineA, openA := pipelineFixtureFor(e.Admin(), t, e)
+	pipelineA, openA := pipelineFixtureFor(e.Admin(), t, e.Deals)
 	orgA := e.SeedOrg(t, "Acme", nil)
 	dealA, err := e.Deals.CreateDeal(e.Admin(), deals.CreateDealInput{
 		Name: "A deal", AmountMinor: int64Ptr(500000), Currency: strPtr("EUR"),
@@ -385,10 +385,16 @@ func TestOrganizationComputed_SecurityInvokerNeverLeaksAcrossWorkspaces(t *testi
 	}
 	freezeDealFX(t, owner, ids.UUID(dealA.Id))
 
-	_, ctxB := SeedSecondWorkspace(t, owner, computedFieldWorkspaceBPerms)
-	pipelineB, openB := pipelineFixtureFor(ctxB, t, e)
-	orgB := e.SeedOrgAs(ctxB, t, "Acme")
-	dealB, err := e.Deals.CreateDeal(ctxB, deals.CreateDealInput{
+	wsB, ctxB := SeedSecondWorkspace(t, owner, computedFieldWorkspaceBPerms)
+	// Tenant B writes through stores of its own: the workspace a row lands in
+	// is the handle's, so tenant A's stores would stamp B's ids inside A's
+	// transaction and RLS would refuse them. The cross-context PROBES below
+	// stay ctx-driven — they read the view directly, which is where the
+	// isolation claim actually lives.
+	dealsB, peopleB := e.DealsFor(wsB), e.PeopleFor(wsB)
+	pipelineB, openB := pipelineFixtureFor(ctxB, t, dealsB)
+	orgB := e.SeedOrgAs(ctxB, t, wsB, "Acme")
+	dealB, err := dealsB.CreateDeal(ctxB, deals.CreateDealInput{
 		Name: "B deal", AmountMinor: int64Ptr(999000), Currency: strPtr("EUR"),
 		PipelineID: pipelineB, StageID: openB, OrganizationID: orgIDPtr(orgIDOf(orgB)), Source: "manual",
 	})
@@ -410,7 +416,7 @@ func TestOrganizationComputed_SecurityInvokerNeverLeaksAcrossWorkspaces(t *testi
 	if err != nil {
 		t.Fatal(err)
 	}
-	orgBGet, err := e.People.GetOrganization(ctxB, orgIDOf(orgB), storekit.IncludeArchived)
+	orgBGet, err := peopleB.GetOrganization(ctxB, orgIDOf(orgB), storekit.IncludeArchived)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/backend/internal/compose/integration/organizationlogo_integration_test.go
+++ b/backend/internal/compose/integration/organizationlogo_integration_test.go
@@ -74,7 +74,7 @@ func seedLoggedOrg(ctx context.Context, t *testing.T, e *Env, blob blobstore.Sto
 func TestOrganizationLogoStreamsTheStoredMarkUnderNonExecutableHeaders(t *testing.T) {
 	e := Setup(t)
 	blob := blobstore.NewMemory()
-	handlers := people.NewHandlers(e.Pool).WithBlobstore(blob)
+	handlers := people.NewHandlers(e.DB()).WithBlobstore(blob)
 	ctx := e.Admin()
 	want := logoPNG(t)
 	orgID := seedLoggedOrg(ctx, t, e, blob, want)
@@ -128,7 +128,7 @@ func TestOrganizationLogoIs404WithoutOneAnd501WithoutAnObjectStore(t *testing.T)
 	// No logo on file: a 404 the client renders as a monogram.
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/v1/organizations/"+bareID.String()+"/logo", nil).WithContext(ctx)
-	people.NewHandlers(e.Pool).WithBlobstore(blob).GetOrganizationLogo(rec, req, crmcontracts.Id(bareID.UUID))
+	people.NewHandlers(e.DB()).WithBlobstore(blob).GetOrganizationLogo(rec, req, crmcontracts.Id(bareID.UUID))
 	if rec.Code != http.StatusNotFound {
 		t.Fatalf("GET logo of a logo-less org = %d, want 404", rec.Code)
 	}
@@ -138,7 +138,7 @@ func TestOrganizationLogoIs404WithoutOneAnd501WithoutAnObjectStore(t *testing.T)
 	rec = httptest.NewRecorder()
 	missing := ids.NewV7()
 	req = httptest.NewRequest(http.MethodGet, "/v1/organizations/"+missing.String()+"/logo", nil).WithContext(ctx)
-	people.NewHandlers(e.Pool).WithBlobstore(blob).GetOrganizationLogo(rec, req, crmcontracts.Id(missing))
+	people.NewHandlers(e.DB()).WithBlobstore(blob).GetOrganizationLogo(rec, req, crmcontracts.Id(missing))
 	if rec.Code != http.StatusNotFound {
 		t.Fatalf("GET logo of an unknown org = %d, want 404", rec.Code)
 	}
@@ -148,7 +148,7 @@ func TestOrganizationLogoIs404WithoutOneAnd501WithoutAnObjectStore(t *testing.T)
 	orgID := seedLoggedOrg(ctx, t, e, blob, logoPNG(t))
 	rec = httptest.NewRecorder()
 	req = httptest.NewRequest(http.MethodGet, "/v1/organizations/"+orgID.String()+"/logo", nil).WithContext(ctx)
-	people.NewHandlers(e.Pool).GetOrganizationLogo(rec, req, crmcontracts.Id(orgID.UUID))
+	people.NewHandlers(e.DB()).GetOrganizationLogo(rec, req, crmcontracts.Id(orgID.UUID))
 	if rec.Code != http.StatusNotImplemented {
 		t.Fatalf("GET logo with no object store = %d, want 501", rec.Code)
 	}

--- a/backend/internal/compose/integration/orgbrief_integration_test.go
+++ b/backend/internal/compose/integration/orgbrief_integration_test.go
@@ -65,8 +65,8 @@ func (l *countingLane) Complete(context.Context, model.Request) (model.Response,
 }
 
 func briefService(e *Env, lane orgbrief.Completer, routingVersion string) *orgbrief.Service {
-	store := people.NewStore(e.Pool)
-	view := org360.NewService(e.Pool, store, approvals.NewService(e.Pool),
+	store := people.NewStore(e.DB())
+	view := org360.NewService(e.Pool, store, approvals.NewService(e.DB()),
 		func() time.Time { return briefClock })
 	// The same store serves both halves of the brief: the 360 for how the
 	// account stands with us, its profile fields for what the company is.

--- a/backend/internal/compose/integration/overlay/overlay_acceptance_integration_test.go
+++ b/backend/internal/compose/integration/overlay/overlay_acceptance_integration_test.go
@@ -153,7 +153,7 @@ func assertEverySeamVerbIsClassifiedExactlyOnce(t *testing.T) {
 func TestAcceptance_AC_OV_2_BoundedEquivalence_ReadSubset(t *testing.T) {
 	e := integration.Setup(t)
 	personID := e.SeedPerson(t, "Ada Native", nil)
-	native := compose.NewProvider(e.Pool)
+	native := compose.NewProviderFor(e.DB())
 	personRef := datasource.EntityRef{Type: datasource.EntityPerson, ID: personID}
 
 	ctx, overlayProvider, overlayRef := seedMirroredPersonFixture(t, e)

--- a/backend/internal/compose/integration/overlay/overlay_cutover_lifecycle_integration_test.go
+++ b/backend/internal/compose/integration/overlay/overlay_cutover_lifecycle_integration_test.go
@@ -227,7 +227,7 @@ func seedCleanWorkspace(t *testing.T, f flipEstate) context.Context {
 		t.Fatalf("seeding the clean workspace admin: %v", err)
 	}
 	cleanCtx := flipAdminCtx(ws, user.UUID)
-	if err := deals.NewHandlers(f.pool, compose.DealsInstallation()).SeedWorkspaceDefaults(cleanCtx); err != nil {
+	if err := deals.NewHandlers(database.BindTo(f.pool, ids.From[ids.WorkspaceKind](ws)), compose.DealsInstallation()).SeedWorkspaceDefaults(cleanCtx); err != nil {
 		t.Fatalf("seeding the clean workspace's default pipeline: %v", err)
 	}
 	return cleanCtx

--- a/backend/internal/compose/integration/perfbench_integration_test.go
+++ b/backend/internal/compose/integration/perfbench_integration_test.go
@@ -116,7 +116,7 @@ func TestPerfBudgetsHoldOnSeededVolumeTier(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Cleanup(pool.Close)
-	store := search.NewStore(pool)
+	store := search.NewStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)))
 	retriever := search.NewRetriever(store, nil)
 
 	actx := benchAdminCtx(ws)

--- a/backend/internal/compose/integration/personautoenrich_integration_test.go
+++ b/backend/internal/compose/integration/personautoenrich_integration_test.go
@@ -93,7 +93,7 @@ func stageSiteLead(t *testing.T, e *Env, orgID ids.OrganizationID, page sitePage
 		t.Fatalf("marshalling the identity: %v", err)
 	}
 	digest := sha256.Sum256(proposed)
-	id, err := approvals.NewService(e.Pool).Stage(e.Admin(), approvals.StageInput{
+	id, err := approvals.NewService(e.DB()).Stage(e.Admin(), approvals.StageInput{
 		Kind:           "site_lead",
 		ProposedChange: proposed,
 		DiffHash:       hex.EncodeToString(digest[:]),
@@ -115,7 +115,7 @@ func stageSiteLead(t *testing.T, e *Env, orgID ids.OrganizationID, page sitePage
 // what the employer already published.
 func newEnricher(e *Env) *compose.PersonAutoEnrich {
 	quiet := slog.New(slog.NewTextHandler(io.Discard, nil))
-	return compose.NewPersonAutoEnrich(e.Pool, people.NewStore(e.Pool), approvals.NewService(e.Pool), nil, quiet)
+	return compose.NewPersonAutoEnrich(e.Pool, people.NewStore(e.DB()), approvals.NewService(e.DB()), nil, quiet)
 }
 
 // personCreated is the envelope a newly created contact reaches the consumer on.

--- a/backend/internal/compose/integration/project_provider_integration_test.go
+++ b/backend/internal/compose/integration/project_provider_integration_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 func projectProvider(e *Env) *deals.Provider {
-	return deals.NewProvider(e.Pool, installseam.Deals())
+	return deals.NewProvider(e.DB(), installseam.Deals())
 }
 
 // The seam's create-read-update-archive round trip, with the provenance the

--- a/backend/internal/compose/integration/queryplan_integration_test.go
+++ b/backend/internal/compose/integration/queryplan_integration_test.go
@@ -40,7 +40,7 @@ type queryEnv struct {
 func setupQuery(t *testing.T) *queryEnv {
 	t.Helper()
 	e := SetupSearch(t)
-	columns := search.NewColumnCatalog(e.Pool)
+	columns := search.NewColumnCatalog(e.DB())
 	resolver := search.NewVocabularyResolver().WithColumnReader(columns)
 	return &queryEnv{
 		SearchEnv: e,

--- a/backend/internal/compose/integration/searchenv.go
+++ b/backend/internal/compose/integration/searchenv.go
@@ -104,7 +104,7 @@ func SetupSearch(t *testing.T) *SearchEnv {
 	// last and sees a package that has genuinely stopped.
 	t.Cleanup(func() { testdb.AssertPoolsQuiesced(t) })
 	e.Pool = pool
-	e.Store = search.NewStore(pool)
+	e.Store = search.NewStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](e.WS)))
 	return e
 }
 

--- a/backend/internal/compose/integration/signals_integration_test.go
+++ b/backend/internal/compose/integration/signals_integration_test.go
@@ -43,7 +43,7 @@ func (a signalStrengthAdapter) PersonStrength(ctx context.Context, id ids.Person
 }
 
 func signalStore(e *SearchEnv) *signals.Store {
-	return signals.NewStore(e.Pool, signalStrengthAdapter{people: people.NewStore(e.Pool)})
+	return signals.NewStore(e.Pool, signalStrengthAdapter{people: people.NewStore(e.DB())})
 }
 
 // signalActor is a full-scope human over the entities the warm room reads

--- a/backend/internal/compose/integration/strength_integration_test.go
+++ b/backend/internal/compose/integration/strength_integration_test.go
@@ -23,7 +23,7 @@ import (
 func TestRelationshipStrengthOverSeededRows(t *testing.T) {
 	e := Setup(t)
 	owner := OwnerConn(t)
-	store := people.NewStore(e.Pool)
+	store := people.NewStore(e.DB())
 	now := time.Date(2026, 6, 4, 12, 0, 0, 0, time.UTC)
 	ctx := e.As(e.Rep1, []ids.UUID{e.Team1}, AdminPerms)
 

--- a/backend/internal/compose/integration/toolschema_conformance_integration_test.go
+++ b/backend/internal/compose/integration/toolschema_conformance_integration_test.go
@@ -30,8 +30,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jackc/pgx/v5/pgxpool"
-
 	"github.com/gradionhq/margince/backend/internal/compose"
 	"github.com/gradionhq/margince/backend/internal/compose/briefs"
 	"github.com/gradionhq/margince/backend/internal/modules/agents"
@@ -91,7 +89,7 @@ func TestToolAnswersReachableWithoutApprovalSatisfyTheirSchemas(t *testing.T) {
 	// The brief is a persisted read-model, so the lane assembles one for this
 	// rep before reading it: read_brief never ranks, and an unassembled brief
 	// answers not-found rather than an empty queue.
-	snapshotBriefRun(ctx, t, e.Pool)
+	snapshotBriefRun(ctx, t, e)
 
 	calls := []struct{ tool, args string }{
 		{"list_pipelines", `{}`},
@@ -309,9 +307,9 @@ func TestTheConformanceCheckFailsAgainstAMisdeclaredSchema(t *testing.T) {
 // read_brief re-reads a persisted run and never ranks — that is the contract's
 // own rule, not a limitation of this lane — so without a run the sweep would be
 // certifying a not-found instead of an answer.
-func snapshotBriefRun(ctx context.Context, t *testing.T, pool *pgxpool.Pool) {
+func snapshotBriefRun(ctx context.Context, t *testing.T, e *Env) {
 	t.Helper()
-	engine := briefs.NewBriefEngine(pool, people.NewStore(pool))
+	engine := briefs.NewBriefEngine(e.Pool, people.NewStore(e.DB()))
 	// A fixed instant. The run only has to EXIST for read_brief to have
 	// something to re-read, and ranking against the wall clock would make what
 	// this lane certifies depend on the day it ran.

--- a/backend/internal/compose/integration/workflow_approval_staging_integration_test.go
+++ b/backend/internal/compose/integration/workflow_approval_staging_integration_test.go
@@ -100,7 +100,7 @@ func TestConfirmationRequiredActionStagesARealApprovalAndRejectionBlocksTheRun(t
 	pipeline, open, won := DealFixture(t, e)
 	dealID := e.SeedDeal(t, "Confirmation-Required Probe Deal", pipeline, open, nil)
 
-	svc := approvals.NewService(e.Pool)
+	svc := approvals.NewService(e.DB())
 	engine := compose.NewWorkflowEngine(e.DB())
 	engine.RegisterSystemWorkflow(confirmationRequiredStagingProbe{
 		approvals: testApprovalsAdapter{svc: svc},

--- a/backend/internal/compose/introseams.go
+++ b/backend/internal/compose/introseams.go
@@ -225,7 +225,7 @@ const atRiskScanLimit = 25
 // order that list returns them, and the sweep stops at the cap rather than
 // sampling: a deterministic prefix can be explained to a rep, a sample cannot.
 func atRiskLister(pool *pgxpool.Pool) agents.AtRiskLister {
-	store := deals.NewStore(pool, DealsInstallation())
+	store := deals.NewStore(InstallationDB(pool), DealsInstallation())
 	return func(ctx context.Context) (agents.AtRiskReport, error) {
 		var out agents.AtRiskReport
 		openStatus := network.DealStatusOpen

--- a/backend/internal/compose/jobs_embedreindex.go
+++ b/backend/internal/compose/jobs_embedreindex.go
@@ -61,7 +61,7 @@ const embedReindexMaxAttempts = 5
 // set on its last attempt) instead of sitting queued forever behind a job no one
 // can work — the deep-read worker's posture.
 func addEmbedReindexJobs(reg *jobRegistry, pool *pgxpool.Pool, embedder search.Embedder) {
-	store := search.NewStore(pool)
+	store := search.NewStore(InstallationDB(pool))
 	addDeclaredWorker[EmbedReindexArgs](reg, &embedReindexWorker{pool: pool, store: store})
 	addDeclaredWorker[EmbedReindexWorkspaceArgs](reg, &embedReindexWorkspaceWorker{store: store, embedder: embedder})
 }

--- a/backend/internal/compose/jobs_graph.go
+++ b/backend/internal/compose/jobs_graph.go
@@ -36,7 +36,7 @@ func addGraphJobs(reg *jobRegistry, pool *pgxpool.Pool, cfg JobRunnerConfig, log
 	graphEdges := newGraphEdgeReconcileWorker(pool, log)
 	addDeclaredWorker[GraphEdgeReconcileArgs](reg, graphEdges)
 	addDeclaredWorker[GraphEdgeWorkspaceArgs](reg, &graphEdgeWorkspaceWorker{graphEdgeReconcileWorker: graphEdges})
-	rematch := newLinkedInRematchWorker(pool, people.NewStore(pool), identity.NewService(pool), log)
+	rematch := newLinkedInRematchWorker(pool, people.NewStore(InstallationDB(pool)), identity.NewService(pool), log)
 	addDeclaredWorker[LinkedInRematchArgs](reg, rematch)
 	addDeclaredWorker[LinkedInRematchWorkspaceArgs](reg, &linkedInRematchWorkspaceWorker{linkedInRematchWorker: rematch})
 	return slices.Concat(

--- a/backend/internal/compose/lifecycletools.go
+++ b/backend/internal/compose/lifecycletools.go
@@ -118,6 +118,6 @@ func (c companyEnricher) EnrichCompany(
 // lifecycleSeams builds the three adapters over one pool.
 func lifecycleSeams(pool *pgxpool.Pool) (activityRelinker, leadDisqualifier, projectPhaseAdvancer) {
 	return activityRelinker{store: activities.NewStore(pool)},
-		leadDisqualifier{store: people.NewStore(pool)},
-		projectPhaseAdvancer{store: deals.NewStore(pool, DealsInstallation())}
+		leadDisqualifier{store: people.NewStore(InstallationDB(pool))},
+		projectPhaseAdvancer{store: deals.NewStore(InstallationDB(pool), DealsInstallation())}
 }

--- a/backend/internal/compose/linkedinmatchproposal.go
+++ b/backend/internal/compose/linkedinmatchproposal.go
@@ -76,7 +76,7 @@ func withGhostOwnerAsSubject(ctx context.Context) (context.Context, error) {
 // ONCE: the registration list is a dozen effects over a dozen stores, and
 // rebuilding it per upload produces the same service every time.
 func linkedInMatchStager(pool *pgxpool.Pool) func(context.Context) error {
-	svc, store := approvalsServiceWithEffects(pool), people.NewStore(pool)
+	svc, store := approvalsServiceWithEffects(pool), people.NewStore(InstallationDB(pool))
 	return func(ctx context.Context) error {
 		_, err := StageLinkedInMatches(ctx, svc, store)
 		return err

--- a/backend/internal/compose/linkedinmatchproposal_integration_test.go
+++ b/backend/internal/compose/linkedinmatchproposal_integration_test.go
@@ -65,7 +65,7 @@ func TestApprovingAStagedLinkedInMatchLinksTheConnectionAndWritesTheURL(t *testi
 	ctx := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AdminPerms)
 	person := linkedInMatchFixture(ctx, t, e)
 
-	store := people.NewStore(e.Pool)
+	store := people.NewStore(e.DB())
 	if _, err := store.MatchLinkedInConnections(ctx, e.Rep1); err != nil {
 		t.Fatalf("matching: %v", err)
 	}
@@ -116,7 +116,7 @@ func TestARefusedLinkedInMatchIsNeverProposedAgain(t *testing.T) {
 	ctx := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AdminPerms)
 	linkedInMatchFixture(ctx, t, e)
 
-	store := people.NewStore(e.Pool)
+	store := people.NewStore(e.DB())
 	if _, err := store.MatchLinkedInConnections(ctx, e.Rep1); err != nil {
 		t.Fatalf("matching: %v", err)
 	}
@@ -155,7 +155,7 @@ func TestAPersonEventStagesTheLinkedInSuggestionItProduced(t *testing.T) {
 	// nothing is skipped, and the test would prove nothing about this path.
 	grantReadPeopleRole(t, e, e.Rep1, "all")
 
-	matcher := NewLinkedInMatchGen(e.Pool, people.NewStore(e.Pool), identity.NewService(e.Pool),
+	matcher := NewLinkedInMatchGen(e.Pool, people.NewStore(e.DB()), identity.NewService(e.Pool),
 		slog.New(slog.DiscardHandler))
 	if err := matcher.HandleEvent(context.Background(),
 		envelopeFor(e.WS, "person.created", "person", person)); err != nil {
@@ -180,7 +180,7 @@ func TestTheSweepStagesALinkedInSuggestionNobodyWasEverAskedAbout(t *testing.T) 
 
 	// The residue, seeded through the real matcher rather than by hand: match
 	// and do NOT stage, which is exactly the state the old event path left.
-	store := people.NewStore(e.Pool)
+	store := people.NewStore(e.DB())
 	if _, err := store.MatchLinkedInConnections(ctx, e.Rep1); err != nil {
 		t.Fatalf("matching: %v", err)
 	}
@@ -212,7 +212,7 @@ func TestTheSweepNeverReasksALinkedInMatchThatWasRefused(t *testing.T) {
 	linkedInMatchFixture(ctx, t, e)
 	grantReadPeopleRole(t, e, e.Rep1, "all")
 
-	store := people.NewStore(e.Pool)
+	store := people.NewStore(e.DB())
 	if _, err := store.MatchLinkedInConnections(ctx, e.Rep1); err != nil {
 		t.Fatalf("matching: %v", err)
 	}
@@ -250,7 +250,7 @@ func TestAContactEditDoesNotCancelAWaitingLinkedInMatch(t *testing.T) {
 	ctx := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AdminPerms)
 	person := linkedInMatchFixture(ctx, t, e)
 
-	store := people.NewStore(e.Pool)
+	store := people.NewStore(e.DB())
 	if _, err := store.MatchLinkedInConnections(ctx, e.Rep1); err != nil {
 		t.Fatalf("matching: %v", err)
 	}

--- a/backend/internal/compose/mcpedge.go
+++ b/backend/internal/compose/mcpedge.go
@@ -135,7 +135,7 @@ func (s *Server) mcpHandler(pool *pgxpool.Pool, auth *identity.Service, log *slo
 		// per-kind effects belong to the DECIDE path, and a task neither decides
 		// nor triggers one. What it does is read a decision and then take the
 		// ordinary redemption route through Registry.Invoke.
-		agents.WithTaskStore(toolTasks(pool), approvalsAdapter{svc: approvals.NewService(pool)}))
+		agents.WithTaskStore(toolTasks(pool), approvalsAdapter{svc: approvals.NewService(InstallationDB(pool))}))
 }
 
 // mcpAuthenticate binds one request to its agent principal. It runs on EVERY

--- a/backend/internal/compose/modelraterefresh.go
+++ b/backend/internal/compose/modelraterefresh.go
@@ -443,7 +443,7 @@ func (w *aiModelRateRefreshWorker) Work(ctx context.Context, job *river.Job[AiMo
 func newModelCostRefreshWorker(pool *pgxpool.Pool, brain completer, sources []pricingSource, bound map[string]map[string]bool, log *slog.Logger) *aiModelRateRefreshWorker {
 	return &aiModelRateRefreshWorker{refresh: modelCostRefresh{
 		rates:   ai.NewRateStore(InstallationDB(pool)),
-		svc:     approvals.NewService(pool),
+		svc:     approvals.NewService(InstallationDB(pool)),
 		fetcher: webread.New(),
 		brain:   brain,
 		sources: sources,

--- a/backend/internal/compose/modelraterefresh_integration_test.go
+++ b/backend/internal/compose/modelraterefresh_integration_test.go
@@ -60,7 +60,7 @@ func TestModelCostRefreshStagesChangedAndDropsUngrounded(t *testing.T) {
 
 	m := modelCostRefresh{
 		rates:   rates,
-		svc:     approvals.NewService(e.Pool),
+		svc:     approvals.NewService(e.DB()),
 		fetcher: fakeFetcher{text: "some pricing page text"},
 		brain:   fakeBrain{text: extraction},
 		sources: []pricingSource{{Provider: "anthropic", URL: "https://prices.test/pricing"}},
@@ -104,7 +104,7 @@ func runModelRefresh(t *testing.T, e *integration.Env, extraction string) {
 	t.Helper()
 	m := modelCostRefresh{
 		rates:   ai.NewRateStore(e.DB()),
-		svc:     approvals.NewService(e.Pool),
+		svc:     approvals.NewService(e.DB()),
 		fetcher: fakeFetcher{text: "pricing page text"},
 		brain:   fakeBrain{text: extraction},
 		sources: []pricingSource{{Provider: "acme", URL: "https://prices.test/pricing"}},

--- a/backend/internal/compose/offerdraft.go
+++ b/backend/internal/compose/offerdraft.go
@@ -155,7 +155,7 @@ type offerDrafter struct {
 // path, this option only adds the evidence-gated staged lines on top.
 func WithOfferDraft(brain completer, retriever retrieval.Retriever) Option {
 	return func(s *Server, pool *pgxpool.Pool) {
-		store := deals.NewStore(pool, DealsInstallation())
+		store := deals.NewStore(InstallationDB(pool), DealsInstallation())
 		s.offerDrafter = &offerDrafter{brain: brain, deals: store, rateCard: store, context: retriever}
 	}
 }

--- a/backend/internal/compose/offerdraft_integration_test.go
+++ b/backend/internal/compose/offerdraft_integration_test.go
@@ -58,7 +58,7 @@ func newOfferDrafterFixture(t *testing.T, e *integration.Env, brain *ai.FakeClie
 		brain:    fakeModelPath(t, brain).OfferDraft,
 		deals:    e.Deals,
 		rateCard: e.Deals,
-		context:  search.NewRetriever(search.NewStore(e.Pool), nil),
+		context:  search.NewRetriever(search.NewStore(e.DB()), nil),
 	}
 }
 

--- a/backend/internal/compose/onboarding_siteread_integration_test.go
+++ b/backend/internal/compose/onboarding_siteread_integration_test.go
@@ -114,7 +114,7 @@ func TestOnboardingSiteReadTransportStartsPollsAndConfirmsTheDraft(t *testing.T)
 	human := e.As(e.Rep1, nil, integration.AdminPerms)
 	inserter := &fakeInserter{}
 	engine := newDeepReadTestEngine(e, inserter)
-	engine.approvals = approvals.NewService(e.Pool)
+	engine.approvals = approvals.NewService(e.DB())
 
 	start := onboardingPOST(human, t, "/v1/company/site-reads",
 		crmcontracts.StartCompanySiteReadRequest{Url: "  " + seedURL + "  "})
@@ -309,7 +309,7 @@ func TestOnboardingSiteReadConfirmsSelectedDataAndKeepsPeopleSeparate(t *testing
 		t.Fatal("the operational onboarding draft wrote company domain truth before confirmation")
 	}
 
-	engine := &deepReadEngine{people: e.People, approvals: approvals.NewService(e.Pool)}
+	engine := &deepReadEngine{people: e.People, approvals: approvals.NewService(e.DB())}
 	offer, editedICP, website := "Employee onboarding software", "B2B RevOps teams with 50–500 employees", seedURL
 	company, _, err := e.People.ConfirmCompanySiteRead(e.As(e.Rep1, nil, integration.AdminPerms), people.ConfirmCompanySiteReadInput{
 		ReadID: ready.ID, DraftVersion: ready.DraftVersion, ProposalHash: ready.ProposalHash,
@@ -377,7 +377,7 @@ func TestCorrectingAFactAtColdStartStoresItAsTheHumansOwnAssertion(t *testing.T)
 	e := integration.Setup(t)
 	human := e.As(e.Rep1, nil, integration.AdminPerms)
 	ready := onboardingDraft(t, e)
-	engine := &deepReadEngine{people: e.People, approvals: approvals.NewService(e.Pool)}
+	engine := &deepReadEngine{people: e.People, approvals: approvals.NewService(e.DB())}
 
 	accepted, wrong := ready.Facts[0], ready.Facts[1]
 	corrected := "ClickHouse — data platform"
@@ -445,7 +445,7 @@ func TestCompanySiteReadRefreshRequiresConflictDecisionsAndPreservesProvenance(t
 		t.Fatalf("seed human company: %v", err)
 	}
 	ready := onboardingDraft(t, e)
-	engine := &deepReadEngine{people: e.People, approvals: approvals.NewService(e.Pool)}
+	engine := &deepReadEngine{people: e.People, approvals: approvals.NewService(e.DB())}
 
 	_, comparisons, err := e.People.GetCompanySiteRead(human, ready.ID)
 	if err != nil {
@@ -619,7 +619,7 @@ func TestConfirmingAReadThatNamedNobodySucceeds(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	engine := &deepReadEngine{people: e.People, approvals: approvals.NewService(e.Pool)}
+	engine := &deepReadEngine{people: e.People, approvals: approvals.NewService(e.DB())}
 	website := seedURL
 	company, _, err := e.People.ConfirmCompanySiteRead(ctx, people.ConfirmCompanySiteReadInput{
 		ReadID: ready.ID, DraftVersion: ready.DraftVersion, ProposalHash: ready.ProposalHash,

--- a/backend/internal/compose/orgnamepromotion.go
+++ b/backend/internal/compose/orgnamepromotion.go
@@ -130,8 +130,8 @@ type OrgNamePromoter struct {
 func NewOrgNamePromoter(pool *pgxpool.Pool, log *slog.Logger) *OrgNamePromoter {
 	return &OrgNamePromoter{
 		pool:      pool,
-		store:     people.NewStore(pool),
-		approvals: approvals.NewService(pool),
+		store:     people.NewStore(InstallationDB(pool)),
+		approvals: approvals.NewService(InstallationDB(pool)),
 		log:       log,
 	}
 }

--- a/backend/internal/compose/pipelineseams.go
+++ b/backend/internal/compose/pipelineseams.go
@@ -31,7 +31,7 @@ import (
 // pipelineLister answers list_pipelines from the workspace's live pipeline
 // configuration.
 func pipelineLister(pool *pgxpool.Pool) agents.PipelineLister {
-	store := deals.NewStore(pool, DealsInstallation())
+	store := deals.NewStore(InstallationDB(pool), DealsInstallation())
 	return func(ctx context.Context) ([]agents.Pipeline, error) {
 		// Live only: this list is what a tool call picks a target stage
 		// from, and an archived pipeline is not one a deal may be moved to.

--- a/backend/internal/compose/provider.go
+++ b/backend/internal/compose/provider.go
@@ -20,6 +20,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/modules/customfields"
 	"github.com/gradionhq/margince/backend/internal/modules/deals"
 	"github.com/gradionhq/margince/backend/internal/modules/people"
+	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
@@ -38,11 +39,21 @@ type Provider struct {
 }
 
 func NewProvider(pool *pgxpool.Pool) *Provider {
+	return NewProviderFor(InstallationDB(pool))
+}
+
+// NewProviderFor is NewProvider over a handle whose workspace is already
+// decided. A server resolves the installation's singleton, which is what
+// NewProvider does for it; a suite that seeds a second workspace on purpose has
+// no singleton to resolve and names the one it means instead (ADR-0091 §9
+// step 3).
+func NewProviderFor(db *database.DB) *Provider {
+	pool := db.Pool()
 	return &Provider{
 		// The fieldcatalog seam mirrors the HTTP wiring (server.go): the
 		// MCP surface's record verbs carry cf_* values too.
-		people:     people.NewProvider(InstallationDB(pool)).WithFieldCatalog(customfields.NewService(pool, nil)),
-		deals:      deals.NewProvider(InstallationDB(pool), DealsInstallation()).WithFieldCatalog(customfields.NewService(pool, nil)),
+		people:     people.NewProvider(db).WithFieldCatalog(customfields.NewService(pool, nil)),
+		deals:      deals.NewProvider(db, DealsInstallation()).WithFieldCatalog(customfields.NewService(pool, nil)),
 		activities: activities.NewProvider(pool),
 		reports:    newReportEngine(pool),
 	}

--- a/backend/internal/compose/provider.go
+++ b/backend/internal/compose/provider.go
@@ -41,8 +41,8 @@ func NewProvider(pool *pgxpool.Pool) *Provider {
 	return &Provider{
 		// The fieldcatalog seam mirrors the HTTP wiring (server.go): the
 		// MCP surface's record verbs carry cf_* values too.
-		people:     people.NewProvider(pool).WithFieldCatalog(customfields.NewService(pool, nil)),
-		deals:      deals.NewProvider(pool, DealsInstallation()).WithFieldCatalog(customfields.NewService(pool, nil)),
+		people:     people.NewProvider(InstallationDB(pool)).WithFieldCatalog(customfields.NewService(pool, nil)),
+		deals:      deals.NewProvider(InstallationDB(pool), DealsInstallation()).WithFieldCatalog(customfields.NewService(pool, nil)),
 		activities: activities.NewProvider(pool),
 		reports:    newReportEngine(pool),
 	}

--- a/backend/internal/compose/queryseam.go
+++ b/backend/internal/compose/queryseam.go
@@ -32,7 +32,7 @@ import (
 func queryVocabulary(pool *pgxpool.Pool) *search.VocabularyResolver {
 	return search.NewVocabularyResolver().
 		WithFieldCatalog(customfields.NewService(pool, nil)).
-		WithColumnReader(search.NewColumnCatalog(pool))
+		WithColumnReader(search.NewColumnCatalog(InstallationDB(pool)))
 }
 
 // queryRunner joins the three steps a plan takes into the one function the tool
@@ -48,7 +48,7 @@ func queryVocabulary(pool *pgxpool.Pool) *search.VocabularyResolver {
 // which lane ranked it, not why.
 func queryRunner(pool *pgxpool.Pool, embedder search.Embedder) agents.QueryRunner {
 	validator := search.NewPlanValidator(queryVocabulary(pool))
-	executor := search.NewQueryExecutor(search.NewStore(pool), embedder, search.NewColumnCatalog(pool))
+	executor := search.NewQueryExecutor(search.NewStore(InstallationDB(pool)), embedder, search.NewColumnCatalog(InstallationDB(pool)))
 	return func(ctx context.Context, raw json.RawMessage) (agents.QueryAnswer, error) {
 		plan, err := search.DecodePlan(raw)
 		if err != nil {

--- a/backend/internal/compose/rateproposals_integration_test.go
+++ b/backend/internal/compose/rateproposals_integration_test.go
@@ -29,8 +29,8 @@ import (
 )
 
 func rateSvc(e *integration.Env) *approvals.Service {
-	svc := approvals.NewService(e.Pool)
-	svc.WithEffect(fxRateProposalKind, fxRateAcceptEffect(svc, deals.NewStore(e.Pool, DealsInstallation())))
+	svc := approvals.NewService(e.DB())
+	svc.WithEffect(fxRateProposalKind, fxRateAcceptEffect(svc, deals.NewStore(e.DB(), DealsInstallation())))
 	svc.WithEffect(aiModelRateProposalKind, aiModelRateAcceptEffect(svc, ai.NewRateStore(e.DB())))
 	return svc
 }
@@ -130,7 +130,7 @@ func TestFxRateProposalApplyRefusesWhenPriorMoved(t *testing.T) {
 	e := integration.Setup(t)
 	ctx := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AdminPerms)
 	svc := rateSvc(e)
-	store := deals.NewStore(e.Pool, DealsInstallation())
+	store := deals.NewStore(e.DB(), DealsInstallation())
 
 	if _, err := store.SetFxRate(ctx, deals.SetFxRateInput{FromCurrency: "GBP", Rate: "1.0"}); err != nil {
 		t.Fatalf("seed: %v", err)
@@ -165,7 +165,7 @@ func TestFxRateProposalApplyRefusesWhenPriorAppeared(t *testing.T) {
 
 	id := stageProposal(ctx, t, svc, fxRateProposalKind, fxRateTargetType, e.WS,
 		map[string]string{"from_currency": "NOK", "rate": "0.09"}, "NOK")
-	if _, err := deals.NewStore(e.Pool, DealsInstallation()).SetFxRate(ctx, deals.SetFxRateInput{FromCurrency: "NOK", Rate: "0.088"}); err != nil {
+	if _, err := deals.NewStore(e.DB(), DealsInstallation()).SetFxRate(ctx, deals.SetFxRateInput{FromCurrency: "NOK", Rate: "0.088"}); err != nil {
 		t.Fatalf("seed: %v", err)
 	}
 	if _, err := svc.Decide(ctx, id, true, nil); !errors.Is(err, apperrors.ErrVersionSkew) {
@@ -180,7 +180,7 @@ func TestFxRateProposalApplyMatchingPriorApplies(t *testing.T) {
 	ctx := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AdminPerms)
 	svc := rateSvc(e)
 
-	if _, err := deals.NewStore(e.Pool, DealsInstallation()).SetFxRate(ctx, deals.SetFxRateInput{FromCurrency: "DKK", Rate: "0.134"}); err != nil {
+	if _, err := deals.NewStore(e.DB(), DealsInstallation()).SetFxRate(ctx, deals.SetFxRateInput{FromCurrency: "DKK", Rate: "0.134"}); err != nil {
 		t.Fatalf("seed: %v", err)
 	}
 	id := stageProposal(ctx, t, svc, fxRateProposalKind, fxRateTargetType, e.WS,
@@ -290,7 +290,7 @@ func TestModelRateProposalApplyMatchingPriorApplies(t *testing.T) {
 func TestFxRateProposalApplyRefusesAcrossMidnight(t *testing.T) {
 	e := integration.Setup(t)
 	ctx := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AdminPerms)
-	seed := deals.NewStore(e.Pool, DealsInstallation())
+	seed := deals.NewStore(e.DB(), DealsInstallation())
 	tomorrow := time.Now().UTC().Add(24 * time.Hour)
 	seedFx(ctx, t, seed, "SEK", "1.0", time.Time{})
 	seedFx(ctx, t, seed, "SEK", "9.9", tomorrow)
@@ -298,14 +298,14 @@ func TestFxRateProposalApplyRefusesAcrossMidnight(t *testing.T) {
 	// The effect store's clock crosses midnight right after the precondition
 	// read: first sample = today, every later sample = the next day.
 	calls := 0
-	crossing := deals.NewStore(e.Pool, DealsInstallation()).WithClock(func() time.Time {
+	crossing := deals.NewStore(e.DB(), DealsInstallation()).WithClock(func() time.Time {
 		calls++
 		if calls == 1 {
 			return time.Now().UTC()
 		}
 		return time.Now().UTC().Add(24 * time.Hour)
 	})
-	svc := approvals.NewService(e.Pool)
+	svc := approvals.NewService(e.DB())
 	svc.WithEffect(fxRateProposalKind, fxRateAcceptEffect(svc, crossing))
 
 	id := stageProposal(ctx, t, svc, fxRateProposalKind, fxRateTargetType, e.WS,
@@ -338,7 +338,7 @@ func TestModelRateProposalApplyRefusesAcrossMidnight(t *testing.T) {
 		}
 		return time.Now().UTC().Add(24 * time.Hour)
 	})
-	svc := approvals.NewService(e.Pool)
+	svc := approvals.NewService(e.DB())
 	svc.WithEffect(aiModelRateProposalKind, aiModelRateAcceptEffect(svc, crossing))
 
 	id := stageProposal(ctx, t, svc, aiModelRateProposalKind, aiModelRateTargetType, e.WS,

--- a/backend/internal/compose/reconcile.go
+++ b/backend/internal/compose/reconcile.go
@@ -73,7 +73,7 @@ func (s followUpStager) StageFollowUp(ctx context.Context, dealID ids.UUID, summ
 // NewFollowUpReconciler assembles the nightly follow-up reconciler for
 // the worker process role.
 func NewFollowUpReconciler(pool *pgxpool.Pool, log *slog.Logger) *deals.FollowUpReconciler {
-	return deals.NewFollowUpReconciler(pool, followUpStager{svc: approvals.NewService(pool)}, log)
+	return deals.NewFollowUpReconciler(InstallationDB(pool), followUpStager{svc: approvals.NewService(InstallationDB(pool))}, log)
 }
 
 // followUpConfirmEffect executes an approved follow-up: redeem-then-

--- a/backend/internal/compose/reconcile_integration_test.go
+++ b/backend/internal/compose/reconcile_integration_test.go
@@ -21,10 +21,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gradionhq/margince/backend/internal/compose/integration"
-
 	"github.com/jackc/pgx/v5"
 
+	"github.com/gradionhq/margince/backend/internal/compose/integration"
 	"github.com/gradionhq/margince/backend/internal/modules/approvals"
 	"github.com/gradionhq/margince/backend/internal/modules/deals"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
@@ -62,9 +61,9 @@ func setupReconcile(t *testing.T) *reconcileEnv {
 	e := &reconcileEnv{Env: integration.Setup(t), owner: integration.OwnerConn(t)}
 	e.pipeline, e.open, _ = integration.DealFixture(t, e.Env)
 	quiet := slog.New(slog.NewTextHandler(os.Stderr, nil))
-	e.svc = approvals.NewService(e.Pool)
+	e.svc = approvals.NewService(e.DB())
 	e.svc.WithEffect(deals.FollowUpReconcileKind, followUpConfirmEffect(e.svc, e.Activities))
-	e.reconciler = deals.NewFollowUpReconciler(e.Pool, followUpStager{svc: e.svc}, quiet)
+	e.reconciler = deals.NewFollowUpReconciler(e.DB(), followUpStager{svc: e.svc}, quiet)
 	return e
 }
 
@@ -321,7 +320,7 @@ func TestADealEditDoesNotCancelAWaitingFollowUp(t *testing.T) {
 	// Through the real writer, so the row's version moves the way any edit in
 	// the product moves it.
 	renamed := "Renamed while it waited"
-	if _, err := deals.NewStore(e.Pool, DealsInstallation()).UpdateDeal(human, ids.From[ids.DealKind](deal),
+	if _, err := deals.NewStore(e.DB(), DealsInstallation()).UpdateDeal(human, ids.From[ids.DealKind](deal),
 		deals.UpdateDealInput{Name: &renamed}); err != nil {
 		t.Fatalf("editing the deal: %v", err)
 	}

--- a/backend/internal/compose/registry.go
+++ b/backend/internal/compose/registry.go
@@ -92,7 +92,7 @@ func registryWithGate(db *database.DB, gate *auth.Gate, drafter activities.Email
 	// NewOverlayMeter like the REST surface's, sharing the same per-workspace
 	// windows.
 	pool := db.Pool()
-	native := NewProvider(pool)
+	native := NewProviderFor(db)
 	provider := NewDispatcher(native, NewOverlayProviderFor(db, failClosedOverlayMeter(), resolveIncumbent), pool)
 	// Retry safety, wired for EVERY role that composes this surface rather than
 	// arriving as the API server's option the way the read charger does. The

--- a/backend/internal/compose/registry.go
+++ b/backend/internal/compose/registry.go
@@ -112,7 +112,7 @@ func registryWithGate(db *database.DB, gate *auth.Gate, drafter activities.Email
 	// two answers, which is what ADR-0055 exists to prevent.
 	opts = append(opts, withContractTierFloor(),
 		agents.WithIdempotency(toolIdempotency(pool)), agents.WithReplayReader(provider))
-	registry := agents.NewRegistry(approvalsAdapter{svc: approvals.NewService(pool)}, gate, opts...)
+	registry := agents.NewRegistry(approvalsAdapter{svc: approvals.NewService(InstallationDB(pool))}, gate, opts...)
 	// The guards take the Dispatcher as an overlayModeChecker — the interface
 	// whose method IS the uncached read, so no wiring here can hand them the
 	// cached mode. See overlayModeChecker for why that distinction is typed.
@@ -170,7 +170,7 @@ func registryWithGate(db *database.DB, gate *auth.Gate, drafter activities.Email
 		mode: sorMode,
 		inner: riskAwareRetriever{
 			pool:  pool,
-			inner: search.NewRetriever(search.NewStore(pool), embedder),
+			inner: search.NewRetriever(search.NewStore(InstallationDB(pool)), embedder),
 		},
 	}
 	agents.RegisterIntentTools(registry, retriever)

--- a/backend/internal/compose/resolveseam.go
+++ b/backend/internal/compose/resolveseam.go
@@ -26,7 +26,7 @@ import (
 
 // entityResolver adapts the people store's batch resolve to the tool seam.
 func entityResolver(pool *pgxpool.Pool) agents.EntityResolver {
-	store := people.NewStore(pool)
+	store := people.NewStore(InstallationDB(pool))
 	return func(ctx context.Context, in []agents.ResolveCandidate) ([]agents.ResolveOutcome, error) {
 		candidates := make([]people.ResolveCandidate, 0, len(in))
 		for _, c := range in {

--- a/backend/internal/compose/routes.go
+++ b/backend/internal/compose/routes.go
@@ -63,7 +63,7 @@ func contractAPI(srv Server, pool *pgxpool.Pool, identitySvc *identity.Service) 
 	// exactly like the MCP registry's tools do — and the overlay-mode
 	// human read shadows (overlayread.go) ride this same instance.
 	provider := srv.sorDispatch
-	staging := approvalsAdapter{svc: approvals.NewService(pool)}
+	staging := approvalsAdapter{svc: approvals.NewService(InstallationDB(pool))}
 	// Wrap order: the generated router applies the slice left-to-right
 	// around the handler, so the LAST entry is outermost — idempotency
 	// must sit outside the agent gate so a staged-approval refusal is

--- a/backend/internal/compose/runnerservice.go
+++ b/backend/internal/compose/runnerservice.go
@@ -76,7 +76,7 @@ func WithSpecResolver(resolve func(string) (runner.AgentSpec, bool)) RunnerOptio
 // (reads and non-SoR tools are unaffected).
 func NewRunnerService(pool *pgxpool.Pool, brain runner.Brain, draftBrain completer, retriever retrieval.Retriever, log *slog.Logger, resolveIncumbent func(context.Context) (overlay.Incumbent, error), send SendPath, opts ...RunnerOption) *RunnerService {
 	svc := &RunnerService{
-		store:      runner.NewStore(pool),
+		store:      runner.NewStore(InstallationDB(pool)),
 		runner:     runner.New(registryWithDraftBrain(pool, draftBrain, resolveIncumbent, send), brain),
 		identity:   identity.NewService(pool),
 		specByName: runner.SpecByName,

--- a/backend/internal/compose/runnerservice.go
+++ b/backend/internal/compose/runnerservice.go
@@ -20,6 +20,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/modules/agents/runner"
 	"github.com/gradionhq/margince/backend/internal/modules/identity"
 	"github.com/gradionhq/margince/backend/internal/modules/overlay"
+	"github.com/gradionhq/margince/backend/internal/platform/database"
 	kevents "github.com/gradionhq/margince/backend/internal/shared/kernel/events"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
@@ -89,6 +90,21 @@ func NewRunnerService(pool *pgxpool.Pool, brain runner.Brain, draftBrain complet
 	return svc
 }
 
+// forWorkspaceIn is this service with its store bound to the workspace ctx
+// names. The rest of the service — the tool registry, the brain, the identity
+// resolver — is tenant-agnostic and shared; only the store writes rows, and a
+// row lands in the workspace its handle binds.
+func (s *RunnerService) forWorkspaceIn(ctx context.Context) (*RunnerService, error) {
+	ws, ok := principal.WorkspaceID(ctx)
+	if !ok {
+		return nil, fmt.Errorf("%w: this pass was handed no workspace; the fan-out binds one per job row",
+			database.ErrNoWorkspace)
+	}
+	bound := *s
+	bound.store = s.store.ForWorkspace(ids.From[ids.WorkspaceKind](ws))
+	return &bound, nil
+}
+
 // TickWorkspace is ONE tenant's scheduler pass: close the runs abandoned since
 // last time, seed the catalog occurrences due at now, then execute the jobs it
 // can claim. wsCtx must already carry the workspace — the caller binds it, so
@@ -104,6 +120,15 @@ func NewRunnerService(pool *pgxpool.Pool, brain runner.Brain, draftBrain complet
 // schedule must still run when the accounting for last week's crash cannot.
 func (s *RunnerService) TickWorkspace(wsCtx context.Context, now time.Time) error {
 	now = now.UTC()
+	// The fan-out names this pass's tenant in wsCtx, and everything below runs
+	// through a service bound to it. One long-lived RunnerService serves every
+	// tenant's pass, so a pass that used the assembled store directly would
+	// seed, claim and record in whichever workspace the SERVICE was built for —
+	// the whole fleet's rows landing in one tenant.
+	s, err := s.forWorkspaceIn(wsCtx)
+	if err != nil {
+		return err
+	}
 	s.reapAbandonedRuns(wsCtx)
 	for _, spec := range runner.Catalog() {
 		if due := spec.DueAt(now); !now.Before(due) {
@@ -253,6 +278,14 @@ func (s *RunnerService) HandleEvent(ctx context.Context, env kevents.Envelope) e
 	}
 	if err := json.Unmarshal(env.Payload, &payload); err != nil {
 		return fmt.Errorf("runner: approval.decided payload: %w", err)
+	}
+
+	// The envelope names the tenant, and the store is bound to it before any
+	// row is read or written: this consumer, like the scheduler pass, runs on
+	// one shared service.
+	s, err := s.forWorkspaceIn(wsCtx)
+	if err != nil {
+		return err
 	}
 
 	// Claim, don't just look: the bus is at-least-once and a resumed run is

--- a/backend/internal/compose/scrape_integration_test.go
+++ b/backend/internal/compose/scrape_integration_test.go
@@ -16,10 +16,9 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/gradionhq/margince/backend/internal/compose/integration"
-
 	"github.com/jackc/pgx/v5"
 
+	"github.com/gradionhq/margince/backend/internal/compose/integration"
 	"github.com/gradionhq/margince/backend/internal/modules/ai"
 	"github.com/gradionhq/margince/backend/internal/modules/approvals"
 	"github.com/gradionhq/margince/backend/internal/modules/people"
@@ -77,7 +76,7 @@ func TestScrapeStagesEnrichmentBoundToOrg(t *testing.T) {
 	e := integration.Setup(t)
 	orgID := insertOrg(t, e, e.Rep1, "acme.example", "")
 	fake := ai.NewFakeClient().Script(acmeExtraction)
-	engine := &scrapeEngine{extract: evidenceExtractor{fetch: acmePage, brain: fakeModelPath(t, fake).ColdStart}, people: e.People, approvals: approvals.NewService(e.Pool)}
+	engine := &scrapeEngine{extract: evidenceExtractor{fetch: acmePage, brain: fakeModelPath(t, fake).ColdStart}, people: e.People, approvals: approvals.NewService(e.DB())}
 
 	proposal, err := engine.Propose(e.As(e.Rep1, []ids.UUID{e.Team1}, scrapePerms), orgID, "")
 	if err != nil {
@@ -125,7 +124,7 @@ func TestScrapeHidesAnInvisibleOrg(t *testing.T) {
 	// Owned by rep3 (team2) — invisible to rep1 (team1) under team row-scope.
 	hidden := insertOrg(t, e, e.Rep3, "hidden.example", "")
 	fake := ai.NewFakeClient().Script(acmeExtraction)
-	engine := &scrapeEngine{extract: evidenceExtractor{fetch: acmePage, brain: fakeModelPath(t, fake).ColdStart}, people: e.People, approvals: approvals.NewService(e.Pool)}
+	engine := &scrapeEngine{extract: evidenceExtractor{fetch: acmePage, brain: fakeModelPath(t, fake).ColdStart}, people: e.People, approvals: approvals.NewService(e.DB())}
 
 	// Both the domain path and the override path must 404 an org the caller
 	// cannot see — existence-hiding, before any egress on their behalf.
@@ -147,7 +146,7 @@ func TestScrapeDegradesHonestly(t *testing.T) {
 	orgID := insertOrg(t, e, e.Rep1, "acme.example", "")
 	allHallucinated := ai.NewFakeClient().Script(
 		`{"fields":[{"field":"icp","value":"guessed","evidence_snippet":"nowhere on the page","confidence":0.9}]}`)
-	engine := &scrapeEngine{extract: evidenceExtractor{fetch: acmePage, brain: fakeModelPath(t, allHallucinated).ColdStart}, people: e.People, approvals: approvals.NewService(e.Pool)}
+	engine := &scrapeEngine{extract: evidenceExtractor{fetch: acmePage, brain: fakeModelPath(t, allHallucinated).ColdStart}, people: e.People, approvals: approvals.NewService(e.DB())}
 	var unreadable *unreadableError
 	if _, err := engine.Propose(e.As(e.Rep1, []ids.UUID{e.Team1}, scrapePerms), orgID, ""); !errors.As(err, &unreadable) {
 		t.Fatalf("all-hallucinated extraction → %v, want unreadable", err)
@@ -166,7 +165,7 @@ func TestScrapeAcceptFillsOnlyEmptyFields(t *testing.T) {
 	orgID := insertOrg(t, e, e.Rep1, "acme.example", "Handcrafted Industry")
 	fake := ai.NewFakeClient().Script(acmeExtraction, acmeExtraction)
 
-	svc := approvals.NewService(e.Pool)
+	svc := approvals.NewService(e.DB())
 	svc.WithEffect("enrich", scrapeAcceptEffect(svc, e.People))
 	engine := &scrapeEngine{extract: evidenceExtractor{fetch: acmePage, brain: fakeModelPath(t, fake).ColdStart}, people: e.People, approvals: svc}
 

--- a/backend/internal/compose/sendvoiceoutcome_integration_test.go
+++ b/backend/internal/compose/sendvoiceoutcome_integration_test.go
@@ -203,7 +203,7 @@ func (e *voiceSendEnv) draftedSend(ref string) activities.SendEmailInput {
 func composedSendServer(t *testing.T, e *voiceSendEnv, stager DeliveryMachinery) Server {
 	t.Helper()
 	srv := newServer(e.Pool, slog.New(slog.NewTextHandler(io.Discard, nil)),
-		identity.NewHandlers(identity.NewService(e.Pool)), deals.NewHandlers(e.Pool, DealsInstallation()))
+		identity.NewHandlers(identity.NewService(e.Pool)), deals.NewHandlers(e.DB(), DealsInstallation()))
 	for _, opt := range []Option{WithPublicBaseURL(voiceSendBaseURL), WithDelivery(stager)} {
 		opt(&srv, e.Pool)
 	}

--- a/backend/internal/compose/server.go
+++ b/backend/internal/compose/server.go
@@ -325,7 +325,7 @@ var _ crmcontracts.ServerInterface = Server{}
 func New(pool *pgxpool.Pool, log *slog.Logger, opts ...Option) http.Handler {
 	// The fieldcatalog seam for deals (newPeopleHandlers carries the full
 	// note): active cf_* deal columns ride deal payloads on both surfaces.
-	dealsH := deals.NewHandlers(pool, DealsInstallation()).WithFieldCatalog(customfields.NewService(pool, nil))
+	dealsH := deals.NewHandlers(InstallationDB(pool), DealsInstallation()).WithFieldCatalog(customfields.NewService(pool, nil))
 	// Bootstrap happens at boot from deployment configuration
 	// (EnsureInstallation, A107/ADR-0061) — the HTTP surface only ever
 	// serves the already-bound singleton organization.
@@ -361,7 +361,7 @@ func newServer(pool *pgxpool.Pool, log *slog.Logger, authH authHandlers, dealsH 
 		peopleHandlers:     newPeopleHandlers(pool),
 		dealsHandlers:      dealsH,
 		activitiesHandlers: newActivitiesHandlers(pool),
-		searchHandlers:     search.NewHandlers(pool),
+		searchHandlers:     search.NewHandlers(InstallationDB(pool)),
 		// Constructed, not merely embedded: the handler carries no nil-pool
 		// branch, so the zero value would panic on the first authenticated
 		// read rather than answer anything at all.
@@ -374,17 +374,17 @@ func newServer(pool *pgxpool.Pool, log *slog.Logger, authH authHandlers, dealsH 
 		// strength owned by people; injected through the adapter below so
 		// signals never imports its sibling.
 		financeHandlers:    finance.NewHandlers(pool, identity.BaseCurrencyOf),
-		signalsHandlers:    signals.NewHandlers(pool, signalStrength{people: people.NewStore(pool)}),
+		signalsHandlers:    signals.NewHandlers(pool, signalStrength{people: people.NewStore(InstallationDB(pool))}),
 		privacyHandlers:    privacy.NewHandlers(InstallationDB(pool)),
 		automationHandlers: automation.NewHandlers(InstallationDB(pool)),
 		voiceHandlers:      ai.NewHandlers(InstallationDB(pool), NewSeatBudget(pool)),
 		reportHandlers:     reportHandlers{engine: newReportEngine(pool)},
 		// The Morning Brief always serves on the deterministic §10.1 floor;
 		// the L2 re-order is opt-in via WithBrief (the api role's model path).
-		Handlers:          briefs.NewHandlers(briefs.NewBriefEngine(pool, people.NewStore(pool))),
+		Handlers:          briefs.NewHandlers(briefs.NewBriefEngine(pool, people.NewStore(InstallationDB(pool)))),
 		Reads:             network.NewReads(pool),
 		orgRollupHandlers: orgRollupHandlers{pool: pool, now: time.Now},
-		strengthHandlers:  strengthHandlers{people: people.NewStore(pool), now: time.Now},
+		strengthHandlers:  strengthHandlers{people: people.NewStore(InstallationDB(pool)), now: time.Now},
 		// The schema-change pool is boot-optional; nil
 		// here means Create/SetOptions stay their generated 501 until the
 		// api role's WithSchemaPool rebuilds this over the real pool.
@@ -401,7 +401,7 @@ func newServer(pool *pgxpool.Pool, log *slog.Logger, authH authHandlers, dealsH 
 		// the environment). Without it those paths answer an honest 503.
 		webhooksHandlers: newWebhookHandlers(pool, nil, log),
 		log:              log,
-		dealsStore:       deals.NewStore(pool, DealsInstallation()),
+		dealsStore:       deals.NewStore(InstallationDB(pool), DealsInstallation()),
 		// Constructed unconditionally: WithKeyvault rebuilds
 		// overlayHandlers over this SAME instance rather than minting a
 		// second one, and contractAPI's Dispatcher spends force-fresh

--- a/backend/internal/compose/serverassembly.go
+++ b/backend/internal/compose/serverassembly.go
@@ -42,7 +42,7 @@ import (
 // people and a module never imports one: compose is where that edge is
 // made, as it is for every other cross-module dependency.
 func newPeopleHandlers(pool *pgxpool.Pool) peopleHandlers {
-	return people.NewHandlers(pool).
+	return people.NewHandlers(InstallationDB(pool)).
 		WithFieldCatalog(customfields.NewService(pool, nil)).
 		WithMatchStager(linkedInMatchStager(pool))
 }
@@ -55,7 +55,7 @@ func newActivitiesHandlers(pool *pgxpool.Pool) activitiesHandlers {
 		// The public booking capture seams (feedback/14): people is the
 		// idempotent-on-email person path, consent records the
 		// passthrough — both injected here, never sibling imports.
-		WithPublicBooking(people.NewStore(pool), bookingConsentAdapter{store: consent.NewStore(InstallationDB(pool))}).
+		WithPublicBooking(people.NewStore(InstallationDB(pool)), bookingConsentAdapter{store: consent.NewStore(InstallationDB(pool))}).
 		// The RFC 8058 unsubscribe linker (B-E11.32): consent mints the
 		// preference token behind the List-Unsubscribe URL.
 		WithUnsubscribe(preferenceLinkAdapter{store: consent.NewStore(InstallationDB(pool))})
@@ -97,12 +97,12 @@ func (s *Server) wireOnboardingSurface(pool *pgxpool.Pool) {
 	// The installation's own company (the 0083 anchor). Its own store
 	// instance, like every other people-backed shadow here: the company
 	// form's write shape is people's, the transport is compose's.
-	s.companyHandlers = companyHandlers{store: people.NewStore(pool), rollout: companyContextRolloutOnboarding}
+	s.companyHandlers = companyHandlers{store: people.NewStore(InstallationDB(pool)), rollout: companyContextRolloutOnboarding}
 	s.siteReadHandlers = siteReadHandlers{companyContextRollout: companyContextRolloutOnboarding}
 	s.onboardingStateHandlers = onboardingStateHandlers{
-		state: identity.NewOnboardingStore(pool), company: people.NewStore(pool),
+		state: identity.NewOnboardingStore(pool), company: people.NewStore(InstallationDB(pool)),
 		proposal: &onboardingProposalEngine{
-			state: identity.NewOnboardingStore(pool), people: people.NewStore(pool),
+			state: identity.NewOnboardingStore(pool), people: people.NewStore(InstallationDB(pool)),
 			rollout: companyContextRolloutOnboarding,
 		},
 	}
@@ -133,8 +133,8 @@ func (s *Server) wireSystemOfRecordReads(pool *pgxpool.Pool) {
 	// The model lane is nil here: WithAccountBrief binds the api role's
 	// summarize lane, and without it the brief serves its deterministic
 	// floor.
-	s.peopleStore = people.NewStore(pool).WithFieldCatalog(customfields.NewService(pool, nil))
-	s.org360Svc = org360.NewService(pool, s.peopleStore, approvals.NewService(pool), time.Now)
+	s.peopleStore = people.NewStore(InstallationDB(pool)).WithFieldCatalog(customfields.NewService(pool, nil))
+	s.org360Svc = org360.NewService(pool, s.peopleStore, approvals.NewService(InstallationDB(pool)), time.Now)
 	s.orgBriefSvc = orgbrief.NewService(pool, s.org360Svc, s.peopleStore, nil, "", time.Now)
 	s.orgBriefHandlers = orgbrief.NewHandlers(s.orgBriefSvc, s.sorDispatch.isOverlay)
 	// The dossier reads the SAME people store the 360 and the brief read, so

--- a/backend/internal/compose/serveroptions.go
+++ b/backend/internal/compose/serveroptions.go
@@ -442,7 +442,7 @@ func WithColdStart(fetch PageFetcher, brain completer) Option {
 	return func(s *Server, pool *pgxpool.Pool) {
 		s.coldstartHandlers = coldstartHandlers{engine: &coldStartEngine{
 			extract:   evidenceExtractor{fetch: fetch, brain: brain},
-			approvals: approvals.NewService(pool),
+			approvals: approvals.NewService(InstallationDB(pool)),
 		}}
 	}
 }
@@ -455,8 +455,8 @@ func WithScrape(fetch PageFetcher, brain completer) Option {
 	return func(s *Server, pool *pgxpool.Pool) {
 		s.scrapeHandlers = scrapeHandlers{engine: &scrapeEngine{
 			extract:   evidenceExtractor{fetch: fetch, brain: brain},
-			people:    people.NewStore(pool),
-			approvals: approvals.NewService(pool),
+			people:    people.NewStore(InstallationDB(pool)),
+			approvals: approvals.NewService(InstallationDB(pool)),
 		}}
 	}
 }

--- a/backend/internal/compose/sitepersonfields_integration_test.go
+++ b/backend/internal/compose/sitepersonfields_integration_test.go
@@ -67,7 +67,7 @@ func seatedTitle(t *testing.T, e *integration.Env, person ids.UUID) *string {
 
 func TestApplySitePersonFieldsMatchesAnEmployeeByName(t *testing.T) {
 	e := integration.Setup(t)
-	store := people.NewStore(e.Pool)
+	store := people.NewStore(e.DB())
 	org := e.SeedOrg(t, "Acme", nil)
 	person := seatEmployee(t, e, org, "Bob Builder", "")
 
@@ -111,7 +111,7 @@ func TestApplySitePersonFieldsMatchesAnEmployeeByName(t *testing.T) {
 
 func TestApplySitePersonFieldsRefusesToGuess(t *testing.T) {
 	e := integration.Setup(t)
-	store := people.NewStore(e.Pool)
+	store := people.NewStore(e.DB())
 	org := e.SeedOrg(t, "Acme", nil)
 	seatEmployee(t, e, org, "Chris Taylor", "")
 	seatEmployee(t, e, org, "Chris Taylor", "")
@@ -147,7 +147,7 @@ func TestApplySitePersonFieldsRefusesToGuess(t *testing.T) {
 
 func TestApplySitePersonFieldsStaysInsideTheCompany(t *testing.T) {
 	e := integration.Setup(t)
-	store := people.NewStore(e.Pool)
+	store := people.NewStore(e.DB())
 	acme := e.SeedOrg(t, "Acme", nil)
 	other := e.SeedOrg(t, "Other", nil)
 	person := seatEmployee(t, e, other, "Dana Reed", "dana@other.example")
@@ -172,7 +172,7 @@ func TestApplySitePersonFieldsStaysInsideTheCompany(t *testing.T) {
 
 func TestApplySitePersonFieldsNeverTouchesAHumansAnswer(t *testing.T) {
 	e := integration.Setup(t)
-	store := people.NewStore(e.Pool)
+	store := people.NewStore(e.DB())
 	org := e.SeedOrg(t, "Acme", nil)
 	person := seatEmployee(t, e, org, "Erin Vance", "erin@acme.example")
 	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {

--- a/backend/internal/compose/sitereadstore_integration_test.go
+++ b/backend/internal/compose/sitereadstore_integration_test.go
@@ -38,7 +38,7 @@ func siteReadWorkerCtx(e *integration.Env) context.Context {
 
 func TestSiteReadStartCreatesAQueuedDossierAndAReClickJoinsIt(t *testing.T) {
 	e := integration.Setup(t)
-	store := people.NewStore(e.Pool)
+	store := people.NewStore(e.DB())
 	ctx := e.As(e.Rep1, nil, integration.AdminPerms)
 	org := siteReadOrg(e.SeedOrg(t, "Acme", &e.Rep1))
 
@@ -77,7 +77,7 @@ func TestSiteReadStartCreatesAQueuedDossierAndAReClickJoinsIt(t *testing.T) {
 
 func TestSiteReadWorkerAdvancesTheDossierThroughGuardedTransitions(t *testing.T) {
 	e := integration.Setup(t)
-	store := people.NewStore(e.Pool)
+	store := people.NewStore(e.DB())
 	human := e.As(e.Rep1, nil, integration.AdminPerms)
 	worker := siteReadWorkerCtx(e)
 	org := siteReadOrg(e.SeedOrg(t, "Acme", &e.Rep1))
@@ -161,7 +161,7 @@ func TestSiteReadWorkerAdvancesTheDossierThroughGuardedTransitions(t *testing.T)
 
 func TestSiteReadBudgetDeferralKeepsProgressAndJoinsUntilDue(t *testing.T) {
 	e := integration.Setup(t)
-	store := people.NewStore(e.Pool)
+	store := people.NewStore(e.DB())
 	human := e.As(e.Rep1, nil, integration.AdminPerms)
 	worker := siteReadWorkerCtx(e)
 	org := siteReadOrg(e.SeedOrg(t, "Acme", &e.Rep1))
@@ -222,7 +222,7 @@ func TestSiteReadBudgetDeferralKeepsProgressAndJoinsUntilDue(t *testing.T) {
 
 func TestSiteReadWorkerReclaimsAStaleRunningDossier(t *testing.T) {
 	e := integration.Setup(t)
-	store := people.NewStore(e.Pool)
+	store := people.NewStore(e.DB())
 	human := e.As(e.Rep1, nil, integration.AdminPerms)
 	worker := siteReadWorkerCtx(e)
 	org := siteReadOrg(e.SeedOrg(t, "Acme", &e.Rep1))
@@ -261,7 +261,7 @@ func TestSiteReadWorkerReclaimsAStaleRunningDossier(t *testing.T) {
 
 func TestSiteReadIsScopedToTheOrganizationTheCallerCanSee(t *testing.T) {
 	e := integration.Setup(t)
-	store := people.NewStore(e.Pool)
+	store := people.NewStore(e.DB())
 	admin := e.As(e.Rep1, nil, integration.AdminPerms)
 	orgA := siteReadOrg(e.SeedOrg(t, "Org A", &e.Rep1))
 	orgB := siteReadOrg(e.SeedOrg(t, "Org B", &e.Rep1))

--- a/backend/internal/compose/slipping.go
+++ b/backend/internal/compose/slipping.go
@@ -34,7 +34,7 @@ const slippingScanLimit = 50
 // slippingLister serves the formulas-§8 candidate set: stalled open
 // deals plus open deals whose expected close date is already past.
 func slippingLister(pool *pgxpool.Pool) agents.SlippingLister {
-	store := deals.NewStore(pool, DealsInstallation())
+	store := deals.NewStore(InstallationDB(pool), DealsInstallation())
 	return func(ctx context.Context) ([]agents.SlippingDeal, error) {
 		limit := slippingScanLimit
 		stalledOnly := true

--- a/backend/internal/compose/telegramingest.go
+++ b/backend/internal/compose/telegramingest.go
@@ -91,7 +91,7 @@ type telegramIngestWorker struct {
 // seam because this IS the composition layer people.Store already reaches
 // into for that ensurer.
 func newTelegramIngestWorker(pool *pgxpool.Pool, cfg CaptureConfig, log *slog.Logger) *telegramIngestWorker {
-	return &telegramIngestWorker{pool: pool, sink: newCaptureSink(pool, cfg), people: people.NewStore(pool), log: log}
+	return &telegramIngestWorker{pool: pool, sink: newCaptureSink(pool, cfg), people: people.NewStore(InstallationDB(pool)), log: log}
 }
 
 // Work re-establishes the workspace context from job.Args (never inherited

--- a/backend/internal/compose/workflows.go
+++ b/backend/internal/compose/workflows.go
@@ -50,7 +50,7 @@ func workflowEngineWithDrafter(db *database.DB, drafter activities.EmailDrafter)
 	// engine depends only on the port; this is the one place a concrete
 	// identity is injected (ADR-0054 §8), same as platform/auth.NewGate.
 	engine := automation.NewWorkflowEngine(db, identity.NewService(db.Pool()))
-	peopleStore := people.NewStore(db.Pool())
+	peopleStore := people.NewStore(db)
 	// Executors ride the same per-workspace dispatch as every other
 	// datasource consumer: a starter firing for an overlay-mode
 	// workspace reads/writes through the overlay seam, not silently
@@ -60,7 +60,7 @@ func workflowEngineWithDrafter(db *database.DB, drafter activities.EmailDrafter)
 	// fail-closed placeholder (no Redis), never charged.
 	ex := automation.Executors{
 		Provider:  NewDispatcher(NewProvider(db.Pool()), NewOverlayProvider(db.Pool(), failClosedOverlayMeter(), nil), db.Pool()),
-		Approvals: automationApprovalsAdapter{svc: approvals.NewService(db.Pool())},
+		Approvals: automationApprovalsAdapter{svc: approvals.NewService(db)},
 		Lists:     listsAdapter{store: collections.NewStore(db)},
 		// The zero SendPath is the honest one here: a send_email action
 		// stages an approval instead of sending, and automation.Comms

--- a/backend/internal/modules/agents/runner/store.go
+++ b/backend/internal/modules/agents/runner/store.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
@@ -24,19 +23,22 @@ import (
 // happen inside the tools it calls, which carry the full audit+outbox
 // write shape already.
 type Store struct {
-	pool *pgxpool.Pool
-	now  func() time.Time
+	// db binds the workspace this store runs for (ADR-0091 §9 step 3).
+	db  *database.DB
+	now func() time.Time
 }
 
-func NewStore(pool *pgxpool.Pool) *Store {
-	return &Store{pool: pool, now: time.Now}
+// NewStore opens the runner's store on a handle already bound to the
+// workspace it serves.
+func NewStore(db *database.DB) *Store {
+	return &Store{db: db, now: time.Now}
 }
 
 // StartRun records a run for one trigger occurrence. created=false
 // means this occurrence already ran (or is running) — the §6
 // idempotency rule; the caller must not start a second loop.
 func (s *Store) StartRun(ctx context.Context, spec AgentSpec, triggerRef string, passportID ids.PassportID) (runID ids.UUID, created bool, err error) {
-	err = database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err = s.db.Tx(ctx, func(tx pgx.Tx) error {
 		row := tx.QueryRow(ctx, `
 			INSERT INTO agent_run (workspace_id, agent_spec, goal, trigger_ref, passport_id)
 			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, $2, $3, $4)
@@ -85,7 +87,7 @@ func (s *Store) SaveOutcome(ctx context.Context, runID ids.UUID, res Result) err
 	if status == "" {
 		return fmt.Errorf("runner: unknown outcome %q", res.Outcome)
 	}
-	return database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	return s.db.Tx(ctx, func(tx pgx.Tx) error {
 		tag, err := tx.Exec(ctx, `
 			UPDATE agent_run SET
 			  status = $2,
@@ -114,7 +116,7 @@ func (s *Store) SaveOutcome(ctx context.Context, runID ids.UUID, res Result) err
 // MarkFailed closes a run that crashed outside the loop's own degrade
 // path (e.g. the brain adapter failed to construct).
 func (s *Store) MarkFailed(ctx context.Context, runID ids.UUID, reason string) error {
-	return database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	return s.db.Tx(ctx, func(tx pgx.Tx) error {
 		_, err := tx.Exec(ctx, `
 			UPDATE agent_run SET status = 'failed', degrade_reason = $2, updated_at = now(), finished_at = now()
 			WHERE id = $1`, runID, reason)
@@ -150,7 +152,7 @@ func (s *Store) FailStuckRuns(ctx context.Context, grace time.Duration, reason s
 		return nil, fmt.Errorf("runner: stuck-run grace must be at least a microsecond, got %s", grace)
 	}
 	var swept []ids.UUID
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		rows, err := tx.Query(ctx, `
 			UPDATE agent_run
 			   SET status = 'failed', degrade_reason = $2, updated_at = now(), finished_at = now()
@@ -205,7 +207,7 @@ func (s *Store) ClaimSuspendedByApproval(ctx context.Context, approvalID ids.App
 	var run SuspendedRun
 	var pendingJSON []byte
 	found := false
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		row := tx.QueryRow(ctx, `
 			UPDATE agent_run SET status = 'running', updated_at = now()
 			WHERE approval_id = $1 AND status = 'awaiting_approval'
@@ -236,7 +238,7 @@ type QueuedJob struct {
 
 // EnqueueJob seeds one trigger occurrence; re-seeding is a no-op.
 func (s *Store) EnqueueJob(ctx context.Context, specName, triggerRef string, passportID *ids.PassportID, dueAt time.Time) error {
-	return database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	return s.db.Tx(ctx, func(tx pgx.Tx) error {
 		_, err := tx.Exec(ctx, `
 			INSERT INTO runner_job (workspace_id, agent_spec, trigger_ref, passport_id, due_at)
 			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, $2, $3, $4)
@@ -254,7 +256,7 @@ func (s *Store) EnqueueJob(ctx context.Context, specName, triggerRef string, pas
 // double-claiming without serializing on each other.
 func (s *Store) ClaimDueJobs(ctx context.Context, limit int) ([]QueuedJob, error) {
 	var jobs []QueuedJob
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		rows, err := tx.Query(ctx, `
 			UPDATE runner_job SET status = 'running', attempts = attempts + 1
 			WHERE id IN (
@@ -290,7 +292,7 @@ func (s *Store) FinishJob(ctx context.Context, jobID ids.UUID, runID *ids.UUID, 
 	if failReason != "" {
 		status = "failed"
 	}
-	return database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	return s.db.Tx(ctx, func(tx pgx.Tx) error {
 		_, err := tx.Exec(ctx, `
 			UPDATE runner_job SET status = $2, last_error = NULLIF($3, ''), agent_run_id = $4
 			WHERE id = $1`, jobID, status, failReason, runID)

--- a/backend/internal/modules/agents/runner/store.go
+++ b/backend/internal/modules/agents/runner/store.go
@@ -28,6 +28,13 @@ type Store struct {
 	now func() time.Time
 }
 
+// ForWorkspace is this store re-bound to one tenant of the fleet fan-out. The
+// scheduler is one long-lived service ticking every workspace in turn, and the
+// workspace a row lands in is the handle's, not the ctx's.
+func (s *Store) ForWorkspace(ws ids.WorkspaceID) *Store {
+	return &Store{db: s.db.ForWorkspace(ws), now: s.now}
+}
+
 // NewStore opens the runner's store on a handle already bound to the
 // workspace it serves.
 func NewStore(db *database.DB) *Store {

--- a/backend/internal/modules/approvals/bundle.go
+++ b/backend/internal/modules/approvals/bundle.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
@@ -85,7 +84,7 @@ func (s *Service) DecideBundle(ctx context.Context, bundleID ids.UUID, approve b
 	}
 	p, _ := principal.Actor(ctx)
 	var members []BundleMember
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		var err error
 		members, err = s.decideBundleInTx(ctx, tx, p, bundleID, approve, reason)
 		return err

--- a/backend/internal/modules/approvals/decide.go
+++ b/backend/internal/modules/approvals/decide.go
@@ -13,7 +13,6 @@ import (
 	openapi_types "github.com/oapi-codegen/runtime/types"
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/diffhash"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
@@ -72,7 +71,7 @@ func (s *Service) decide(ctx context.Context, id ids.ApprovalID, approve bool, r
 	p, _ := principal.Actor(ctx)
 
 	var a row
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		var err error
 		a, err = s.decideInTx(ctx, tx, p, id, approve, reason, edited)
 		return err

--- a/backend/internal/modules/approvals/inbox.go
+++ b/backend/internal/modules/approvals/inbox.go
@@ -18,7 +18,6 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
@@ -146,7 +145,7 @@ func (s *Service) List(ctx context.Context, in ListInput) ([]row, storekit.Page,
 	}
 	var out []row
 	var page storekit.Page
-	err = database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) (err error) {
+	err = s.db.Tx(ctx, func(tx pgx.Tx) (err error) {
 		if in.targeted() {
 			out, page, err = listForTarget(ctx, tx, p, in, start)
 			return err
@@ -402,7 +401,7 @@ func (s *Service) Get(ctx context.Context, id ids.ApprovalID) (row, error) {
 	}
 	p, _ := principal.Actor(ctx)
 	var a row
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) (err error) {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) (err error) {
 		a, err = get(ctx, tx, id)
 		if err != nil {
 			return err

--- a/backend/internal/modules/approvals/redeem.go
+++ b/backend/internal/modules/approvals/redeem.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
@@ -41,7 +40,7 @@ const RedemptionWindow = redemptionTTL
 // transaction that actually mutates. Callers that can hold one transaction
 // should use RedeemAndApply instead and have no window at all.
 func (s *Service) Redeem(ctx context.Context, id ids.ApprovalID, tool, diffHash string) (version int64, pinned bool, err error) {
-	err = database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err = s.db.Tx(ctx, func(tx pgx.Tx) error {
 		var rerr error
 		version, pinned, rerr = s.RedeemInTx(ctx, tx, id, tool, diffHash)
 		return rerr
@@ -53,7 +52,7 @@ func (s *Service) Redeem(ctx context.Context, id ids.ApprovalID, tool, diffHash 
 // same transaction. Effects that can expose a half-applied state use this
 // path: a failed domain write leaves the approval unconsumed and retryable.
 func (s *Service) RedeemAndApply(ctx context.Context, id ids.ApprovalID, tool, diffHash string, apply func(pgx.Tx) error) error {
-	return database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	return s.db.Tx(ctx, func(tx pgx.Tx) error {
 		if _, _, err := s.RedeemInTx(ctx, tx, id, tool, diffHash); err != nil {
 			return err
 		}

--- a/backend/internal/modules/approvals/service.go
+++ b/backend/internal/modules/approvals/service.go
@@ -22,15 +22,16 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgxpool"
 
+	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/events"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
 
 type Service struct {
-	pool *pgxpool.Pool
+	// db binds the workspace this store runs for (ADR-0091 §9 step 3).
+	db *database.DB
 	// now is the service's clock: both expiry windows (staging TTL,
 	// redemption TTL) are judged against it, so tests can prove the
 	// pending→expired and approved→dead transitions without sleeping.
@@ -63,8 +64,10 @@ const (
 // ApprovedEffect executes what an approved staging of its kind proposed.
 type ApprovedEffect func(ctx context.Context, approvalID ids.ApprovalID, proposedChange json.RawMessage, diffHash string) error
 
-func NewService(pool *pgxpool.Pool) *Service {
-	return &Service{pool: pool, now: time.Now, effects: map[string]ApprovedEffect{}}
+// NewService builds the approvals engine over a workspace-bound handle,
+// with no effects registered until compose wires them.
+func NewService(db *database.DB) *Service {
+	return &Service{db: db, now: time.Now, effects: map[string]ApprovedEffect{}}
 }
 
 // WithEffect registers the follow-on executor for one staging kind.

--- a/backend/internal/modules/approvals/stageunlessdeclined_integration_test.go
+++ b/backend/internal/modules/approvals/stageunlessdeclined_integration_test.go
@@ -71,7 +71,7 @@ func setupStaging(t *testing.T) *stagingEnv {
 		t.Fatal(err)
 	}
 	t.Cleanup(pool.Close)
-	e.pool, e.svc = pool, NewService(pool)
+	e.pool, e.svc = pool, NewService(database.BindTo(pool, ids.From[ids.WorkspaceKind](e.ws)))
 	return e
 }
 

--- a/backend/internal/modules/approvals/staging.go
+++ b/backend/internal/modules/approvals/staging.go
@@ -16,7 +16,6 @@ import (
 	openapi_types "github.com/oapi-codegen/runtime/types"
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/events"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
@@ -81,7 +80,7 @@ func (s *Service) Stage(ctx context.Context, in StageInput) (ids.ApprovalID, err
 		return ids.ApprovalID{}, err
 	}
 	var id ids.ApprovalID
-	err = database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err = s.db.Tx(ctx, func(tx pgx.Tx) error {
 		var err error
 		if in.JoinPending {
 			id, err = s.stageOrJoinPendingInTx(ctx, tx, in)

--- a/backend/internal/modules/approvals/stagingidentity.go
+++ b/backend/internal/modules/approvals/stagingidentity.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
@@ -126,7 +125,7 @@ func lockProposalIdentity(ctx context.Context, tx pgx.Tx, wsID ids.UUID, in Stag
 // identical proposals.
 func (s *Service) HasPendingFor(ctx context.Context, kind string, targetID ids.UUID, diffHash string) (bool, error) {
 	var exists bool
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		return tx.QueryRow(ctx, `
 			SELECT EXISTS (SELECT 1 FROM approval
 			  WHERE kind = $1 AND target_entity_id = $2 AND diff_hash = $3
@@ -143,7 +142,7 @@ func (s *Service) HasPendingFor(ctx context.Context, kind string, targetID ids.U
 // staging on one still awaiting decision.
 func (s *Service) HasPendingKind(ctx context.Context, kind string, targetID ids.UUID) (bool, error) {
 	var exists bool
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		return tx.QueryRow(ctx, `
 			SELECT EXISTS (SELECT 1 FROM approval
 			  WHERE kind = $1 AND target_entity_id = $2
@@ -240,7 +239,7 @@ func declinedProbeSQL(byIdentity bool) string {
 // deciding it wrong.
 func (s *Service) RejectedChangesFor(ctx context.Context, kind string, targetID ids.UUID) ([]json.RawMessage, error) {
 	var out []json.RawMessage
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		var err error
 		out, err = s.RejectedChangesForTx(ctx, tx, kind, targetID)
 		return err
@@ -321,7 +320,7 @@ func (s *Service) StageUnlessDeclined(ctx context.Context, in StageInput) (ids.A
 	}
 	var id ids.ApprovalID
 	staged := false
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		wsID, ok := principal.WorkspaceID(ctx)
 		if !ok {
 			return errors.New("crmapprovals: no workspace bound to context")

--- a/backend/internal/modules/approvals/taskstate.go
+++ b/backend/internal/modules/approvals/taskstate.go
@@ -33,7 +33,6 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
@@ -140,7 +139,7 @@ func (s *Service) Withdraw(ctx context.Context, id ids.ApprovalID, reason string
 	if err != nil {
 		return false, err
 	}
-	err = database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err = s.db.Tx(ctx, func(tx pgx.Tx) error {
 		if _, err := ownProposal(ctx, tx, id, passport); err != nil {
 			return err
 		}
@@ -160,7 +159,7 @@ func (s *Service) readOwnProposal(ctx context.Context, id ids.ApprovalID, read f
 	if err != nil {
 		return err
 	}
-	err = database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err = s.db.Tx(ctx, func(tx pgx.Tx) error {
 		a, err := ownProposal(ctx, tx, id, passport)
 		if err != nil {
 			return err

--- a/backend/internal/modules/approvals/token_jws.go
+++ b/backend/internal/modules/approvals/token_jws.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
@@ -60,7 +59,7 @@ func (s *Service) MintApprovalToken(ctx context.Context, approvalID ids.Approval
 		return "", errors.New("crmapprovals: minting outside workspace context")
 	}
 	var token string
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		a, err := get(ctx, tx, approvalID)
 		if err != nil {
 			return err
@@ -116,7 +115,7 @@ func (s *Service) VerifyApprovalToken(ctx context.Context, token string) (Approv
 	}
 
 	var publicKey []byte
-	err = database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err = s.db.Tx(ctx, func(tx pgx.Tx) error {
 		return tx.QueryRow(ctx,
 			`SELECT public_key FROM workspace_signing_key WHERE kid = $1 AND retired_at IS NULL`,
 			header.Kid).Scan(&publicKey)

--- a/backend/internal/modules/deals/closedatesweep.go
+++ b/backend/internal/modules/deals/closedatesweep.go
@@ -25,7 +25,6 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgxpool"
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
@@ -84,7 +83,8 @@ func UnmarshalCloseDateCorrection(raw json.RawMessage) (CloseDateCorrection, err
 
 // CloseDateCorrector drives the sweep; the worker ticks it nightly.
 type CloseDateCorrector struct {
-	pool   *pgxpool.Pool
+	// db binds the workspace this store runs for (ADR-0091 §9 step 3).
+	db     *database.DB
 	stager CorrectionStager
 	log    *slog.Logger
 	// now is the corrector's clock so the fixed-clock invariant test
@@ -98,11 +98,11 @@ type CloseDateCorrector struct {
 // NewCloseDateCorrector assembles the sweep over the pool it reads through,
 // the stager it raises corrections into, and the seam that answers which zone
 // its dates are computed in.
-func NewCloseDateCorrector(pool *pgxpool.Pool, stager CorrectionStager, log *slog.Logger,
+func NewCloseDateCorrector(db *database.DB, stager CorrectionStager, log *slog.Logger,
 	inst Installation,
 ) *CloseDateCorrector {
 	return &CloseDateCorrector{
-		pool: pool, stager: stager, log: log, now: time.Now, installation: inst.orRefusing(),
+		db: db, stager: stager, log: log, now: time.Now, installation: inst.orRefusing(),
 	}
 }
 
@@ -134,7 +134,7 @@ func (c *CloseDateCorrector) sweepWorkspace(ctx context.Context) error {
 	var tzName string
 	var candidates []closeDateCandidate
 	now := c.now().UTC()
-	err := database.WithWorkspaceTx(ctx, c.pool, func(tx pgx.Tx) error {
+	err := c.db.Tx(ctx, func(tx pgx.Tx) error {
 		var err error
 		if tzName, err = c.installation.Timezone(ctx, tx); err != nil {
 			return fmt.Errorf("read the installation's timezone: %w", err)
@@ -215,7 +215,7 @@ func (c *CloseDateCorrector) sweepWorkspace(ctx context.Context) error {
 func (c *CloseDateCorrector) stageVelocityDays(ctx context.Context, pipelineID ids.PipelineID) (float64, error) {
 	var wonDeals int
 	var medianSeconds *float64
-	err := database.WithWorkspaceTx(ctx, c.pool, func(tx pgx.Tx) error {
+	err := c.db.Tx(ctx, func(tx pgx.Tx) error {
 		return tx.QueryRow(ctx, `
 			WITH stints AS (
 				SELECT d.id AS deal_id,
@@ -351,7 +351,7 @@ func (c *CloseDateCorrector) correct(ctx context.Context, cand closeDateCandidat
 // staging can bind to exactly what the human will see.
 func (c *CloseDateCorrector) apply(ctx context.Context, cand closeDateCandidate, correction string, build func(*storekit.Patch), extra map[string]any) (int64, error) {
 	var version int64
-	err := database.WithWorkspaceTx(ctx, c.pool, func(tx pgx.Tx) error {
+	err := c.db.Tx(ctx, func(tx pgx.Tx) error {
 		// The candidate scan and this write are separate transactions:
 		// a deal closed or archived in between must not be re-dated.
 		lock, err := storekit.LockRow(ctx, tx, "deal", cand.id.UUID, storekit.LiveOnly)
@@ -409,7 +409,7 @@ func (c *CloseDateCorrector) ensureStaged(ctx context.Context, dealID ids.DealID
 	if targetVersion == 0 {
 		// The keep-alive path wrote nothing this pass; bind the staging
 		// to the row's current version so redemption still detects skew.
-		err := database.WithWorkspaceTx(ctx, c.pool, func(tx pgx.Tx) error {
+		err := c.db.Tx(ctx, func(tx pgx.Tx) error {
 			return tx.QueryRow(ctx, `SELECT version FROM deal WHERE id = $1`, dealID).Scan(&targetVersion)
 		})
 		if err != nil {

--- a/backend/internal/modules/deals/handlers.go
+++ b/backend/internal/modules/deals/handlers.go
@@ -16,10 +16,10 @@ import (
 	"net/http"
 
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgxpool"
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/platform/blobstore"
+	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/platform/httperr"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/fieldcatalog"
@@ -37,8 +37,8 @@ type Handlers struct {
 
 // NewHandlers wires the transport over the RLS-bound app pool and the
 // installation's own values.
-func NewHandlers(pool *pgxpool.Pool, inst Installation) Handlers {
-	return Handlers{store: NewStore(pool, inst)}
+func NewHandlers(db *database.DB, inst Installation) Handlers {
+	return Handlers{store: NewStore(db, inst)}
 }
 
 // WithFieldCatalog wires the workspace custom-field catalog into the

--- a/backend/internal/modules/deals/provider.go
+++ b/backend/internal/modules/deals/provider.go
@@ -11,11 +11,10 @@ package deals
 import (
 	"context"
 
-	"github.com/jackc/pgx/v5/pgxpool"
-
 	openapi_types "github.com/oapi-codegen/runtime/types"
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
@@ -29,8 +28,8 @@ type Provider struct {
 
 // NewProvider wires the datasource verbs over the same store the transport
 // uses, installation seam included.
-func NewProvider(pool *pgxpool.Pool, inst Installation) *Provider {
-	return &Provider{store: NewStore(pool, inst)}
+func NewProvider(db *database.DB, inst Installation) *Provider {
+	return &Provider{store: NewStore(db, inst)}
 }
 
 // WithFieldCatalog wires the workspace custom-field catalog into the

--- a/backend/internal/modules/deals/reconcile.go
+++ b/backend/internal/modules/deals/reconcile.go
@@ -34,7 +34,6 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
@@ -110,7 +109,8 @@ type FollowUpStager interface {
 
 // FollowUpReconciler drives the pass; the worker ticks it nightly.
 type FollowUpReconciler struct {
-	pool   *pgxpool.Pool
+	// db binds the workspace this store runs for (ADR-0091 §9 step 3).
+	db     *database.DB
 	stager FollowUpStager
 	log    *slog.Logger
 	// now is the pass's clock so the reconciliation window and the
@@ -118,8 +118,10 @@ type FollowUpReconciler struct {
 	now func() time.Time
 }
 
-func NewFollowUpReconciler(pool *pgxpool.Pool, stager FollowUpStager, log *slog.Logger) *FollowUpReconciler {
-	return &FollowUpReconciler{pool: pool, stager: stager, log: log, now: time.Now}
+// NewFollowUpReconciler builds the follow-up pass over a workspace-bound
+// handle, staging what it proposes through the given stager.
+func NewFollowUpReconciler(db *database.DB, stager FollowUpStager, log *slog.Logger) *FollowUpReconciler {
+	return &FollowUpReconciler{db: db, stager: stager, log: log, now: time.Now}
 }
 
 // ReconcileWorkspace is one follow-up reconciliation pass over the workspace
@@ -143,7 +145,7 @@ type followUpCandidate struct {
 func (r *FollowUpReconciler) reconcileWorkspace(ctx context.Context) error {
 	now := r.now().UTC()
 	var candidates []followUpCandidate
-	err := database.WithWorkspaceTx(ctx, r.pool, func(tx pgx.Tx) error {
+	err := r.db.Tx(ctx, func(tx pgx.Tx) error {
 		// The discrepancy: an open deal whose most recent real interaction
 		// (call/mail/meeting) landed inside the window, and which has NO
 		// open task on its timeline — a touch with no next step planned.

--- a/backend/internal/modules/deals/store.go
+++ b/backend/internal/modules/deals/store.go
@@ -9,8 +9,6 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgxpool"
-
 	openapi_types "github.com/oapi-codegen/runtime/types"
 
 	"github.com/gradionhq/margince/backend/internal/platform/database"
@@ -32,7 +30,8 @@ const liveRowsClause = " AND archived_at IS NULL"
 // Store owns this module's tables (data-seam ownership, ADR-0014 Am.1);
 // every write rides the storekit audit+outbox shape in one transaction.
 type Store struct {
-	pool *pgxpool.Pool
+	// db binds the workspace this store runs for (ADR-0091 §9 step 3).
+	db *database.DB
 	// catalog is the fieldcatalog seam (custom-field columns); nil means
 	// no catalog is wired and every read/write runs core-columns-only.
 	catalog fieldcatalog.Reader
@@ -67,8 +66,8 @@ type Installation struct {
 
 // NewStore binds the store to the pool every tenant query runs through, and
 // to the seam that answers the installation's own values.
-func NewStore(pool *pgxpool.Pool, inst Installation) *Store {
-	return &Store{pool: pool, clock: time.Now, installation: inst.orRefusing()}
+func NewStore(db *database.DB, inst Installation) *Store {
+	return &Store{db: db, clock: time.Now, installation: inst.orRefusing()}
 }
 
 // orRefusing replaces any value the composition left unset with one that
@@ -132,7 +131,7 @@ func (s *Store) activeColumnsFor(ctx context.Context, object string) ([]fieldcat
 }
 
 func (s *Store) tx(ctx context.Context, fn func(pgx.Tx) error) error {
-	return database.WithWorkspaceTx(ctx, s.pool, fn)
+	return s.db.Tx(ctx, fn)
 }
 
 func uuidPtr(id *ids.UUID) *openapi_types.UUID {

--- a/backend/internal/modules/people/anchorguard_integration_test.go
+++ b/backend/internal/modules/people/anchorguard_integration_test.go
@@ -250,7 +250,7 @@ func newAnchorEnv(t *testing.T) *anchorEnv {
 		t.Fatalf("seeding the anchor company: %v", err)
 	}
 	return &anchorEnv{
-		ctx: ctx, pool: base.store.pool, store: base.store,
+		ctx: ctx, pool: base.store.db.Pool(), store: base.store,
 		anchorID: company.OrganizationID,
 	}
 }

--- a/backend/internal/modules/people/captureprivacy_integration_test.go
+++ b/backend/internal/modules/people/captureprivacy_integration_test.go
@@ -102,7 +102,7 @@ func setupCapturePrivacy(t *testing.T) *privacyEnv {
 		t.Fatal(err)
 	}
 	t.Cleanup(pool.Close)
-	e.store = NewStore(pool)
+	e.store = NewStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](e.ws)))
 	return e
 }
 

--- a/backend/internal/modules/people/creatededupe_contention_integration_test.go
+++ b/backend/internal/modules/people/creatededupe_contention_integration_test.go
@@ -35,7 +35,7 @@ import (
 // would hang instead.
 func (e *dedupeEnv) beginHeldPhoneCreate(ctx context.Context, t *testing.T, name, phone string) (pgx.Tx, ids.PersonID, int) {
 	t.Helper()
-	tx, err := e.store.pool.Begin(ctx)
+	tx, err := e.store.db.Pool().Begin(ctx)
 	if err != nil {
 		t.Fatalf("opening the in-flight create's transaction: %v", err)
 	}

--- a/backend/internal/modules/people/dedupe_integration_test.go
+++ b/backend/internal/modules/people/dedupe_integration_test.go
@@ -65,7 +65,7 @@ func setupDedupe(t *testing.T) *dedupeEnv {
 		t.Fatal(err)
 	}
 	t.Cleanup(pool.Close)
-	e.store = NewStore(pool)
+	e.store = NewStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](e.ws)))
 	return e
 }
 

--- a/backend/internal/modules/people/dedupequeue.go
+++ b/backend/internal/modules/people/dedupequeue.go
@@ -23,7 +23,6 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
@@ -202,7 +201,7 @@ func (s *Store) ListDedupeCandidates(ctx context.Context, in DedupeQueueInput) (
 	query += fmt.Sprintf(" ORDER BY confidence DESC, id DESC LIMIT $%d", len(args))
 
 	var rows []DedupeCandidateRow
-	err = database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err = s.db.Tx(ctx, func(tx pgx.Tx) error {
 		res, err := tx.Query(ctx, query, args...)
 		if err != nil {
 			return err
@@ -236,7 +235,7 @@ func (s *Store) ListDedupeCandidates(ctx context.Context, in DedupeQueueInput) (
 // existence-hiding).
 func (s *Store) GetDedupeCandidate(ctx context.Context, id ids.UUID) (DedupeCandidateRow, error) {
 	var row DedupeCandidateRow
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		var err error
 		row, err = readDedupeCandidate(ctx, tx, id)
 		if err != nil {
@@ -352,7 +351,7 @@ func (s *Store) executeDedupeMerge(ctx context.Context, entityType string, loser
 // bus event — the audit ledger is the record (the merge arm's
 // person.merged/organization.merged carries the bus-visible fact).
 func (s *Store) setDedupeDisposition(ctx context.Context, id ids.UUID, disposition string, by ids.UUID) error {
-	return database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	return s.db.Tx(ctx, func(tx pgx.Tx) error {
 		tag, err := tx.Exec(ctx, `
 			UPDATE dedupe_candidate SET disposition = $2, disposed_by = $3, disposed_at = now()
 			WHERE id = $1 AND disposition = 'open'`, id, disposition, by)
@@ -370,7 +369,7 @@ func (s *Store) setDedupeDisposition(ctx context.Context, id ids.UUID, dispositi
 }
 
 func (s *Store) reopenDedupeCandidate(ctx context.Context, id ids.UUID) error {
-	return database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	return s.db.Tx(ctx, func(tx pgx.Tx) error {
 		tag, err := tx.Exec(ctx, `
 			UPDATE dedupe_candidate SET disposition = 'open', disposed_by = NULL, disposed_at = NULL
 			WHERE id = $1 AND disposition <> 'open'`, id)

--- a/backend/internal/modules/people/domaintriage.go
+++ b/backend/internal/modules/people/domaintriage.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
@@ -160,7 +159,7 @@ func recordPendingDispositionTx(ctx context.Context, tx pgx.Tx, domain string, o
 // double-spend the daily budget on a crawl that is already running.
 func (s *Store) ListDueDomains(ctx context.Context, limit int) ([]DueDomain, error) {
 	var out []DueDomain
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		rows, err := tx.Query(ctx, `
 			SELECT d.domain
 			FROM organization_domain_disposition d
@@ -209,7 +208,7 @@ func (s *Store) ListDueDomains(ctx context.Context, limit int) ([]DueDomain, err
 // attempt spent, the next not due until the backoff elapses. A worker that
 // dies without answering therefore costs a delay, never a hot loop.
 func (s *Store) MarkTriageQueued(ctx context.Context, domain string) error {
-	return database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	return s.db.Tx(ctx, func(tx pgx.Tx) error {
 		return MarkTriageQueuedTx(ctx, tx, domain)
 	})
 }
@@ -237,7 +236,7 @@ func MarkTriageQueuedTx(ctx context.Context, tx pgx.Tx, domain string) error {
 // nothing on the row to say why.
 func (s *Store) ExhaustedDomains(ctx context.Context, limit int) ([]DueDomain, error) {
 	var out []DueDomain
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		rows, err := tx.Query(ctx, `
 			SELECT domain FROM organization_domain_disposition
 			WHERE status = 'pending'
@@ -276,7 +275,7 @@ func (s *Store) ExhaustedDomains(ctx context.Context, limit int) ([]DueDomain, e
 // the staleness bound, and only from a live status to `failed`. A read that is
 // merely slow is not touched.
 func (s *Store) RetireStaleTriageRead(ctx context.Context, domain string) error {
-	return database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	return s.db.Tx(ctx, func(tx pgx.Tx) error {
 		if _, err := tx.Exec(ctx, `
 			UPDATE site_read
 			   SET status = 'failed', finished_at = now(), updated_at = now(),

--- a/backend/internal/modules/people/domaintriageresolve.go
+++ b/backend/internal/modules/people/domaintriageresolve.go
@@ -22,7 +22,6 @@ import (
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
@@ -64,7 +63,7 @@ type ResolveDomainTriageResult struct {
 // converges rather than duplicating.
 func (s *Store) ResolveDomainTriage(ctx context.Context, in ResolveDomainTriageInput) (ResolveDomainTriageResult, error) {
 	var res ResolveDomainTriageResult
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		var err error
 		res, err = s.resolveDomainTriageTx(ctx, tx, in)
 		return err
@@ -86,7 +85,7 @@ func (s *Store) ResolveDomainTriage(ctx context.Context, in ResolveDomainTriageI
 // site is down must not lose its record over an outage.
 func (s *Store) ResolveUnreadableDomainTriage(ctx context.Context, in ResolveDomainTriageInput) (ResolveDomainTriageResult, error) {
 	var res ResolveDomainTriageResult
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		persons, err := PersonsOnDomain(ctx, tx, in.Domain)
 		if err != nil {
 			return err

--- a/backend/internal/modules/people/enrichsignature.go
+++ b/backend/internal/modules/people/enrichsignature.go
@@ -19,7 +19,6 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
@@ -56,7 +55,7 @@ func (s *Store) ApplySignatureFields(ctx context.Context, personID ids.PersonID,
 		return res, nil
 	}
 	sourceRef := "activity:" + sourceActivity.String()
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		var appliedFields []string
 		for _, f := range fields {
 			applied, err := s.applySignatureField(ctx, tx, personID, sourceRef, f)
@@ -179,7 +178,7 @@ func revokeSignatureEvidence(ctx context.Context, tx pgx.Tx, personID ids.Person
 // repeated read whose evidence rows are all first-verdict-wins inserts, so the
 // repeat changes nothing.
 func (s *Store) MarkSignatureRead(ctx context.Context, personID ids.PersonID, activityID ids.UUID) error {
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		// occurred_at is read from the activity rather than taken from the
 		// caller: the watermark and the candidate query must compare the same
 		// number, and only one of them can be the row itself.
@@ -240,7 +239,7 @@ type SignatureCandidate struct {
 // archived, and the query would then pay to re-read an OLDER signature.
 func (s *Store) SignatureCandidates(ctx context.Context, limit int) ([]SignatureCandidate, error) {
 	var out []SignatureCandidate
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		rows, err := tx.Query(ctx, `
 			SELECT p.id, p.full_name, coalesce(pe.email, ''), a.id, coalesce(a.body, '')
 			FROM person p

--- a/backend/internal/modules/people/ensure.go
+++ b/backend/internal/modules/people/ensure.go
@@ -24,7 +24,6 @@ import (
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/platform/freemail"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
@@ -111,7 +110,7 @@ func (s *Store) EnsureCounterparty(ctx context.Context, in EnsureCounterpartyInp
 		return EnsureCounterpartyResult{}, errors.New("people: a counterparty needs an email")
 	}
 	var res EnsureCounterpartyResult
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		var err error
 		res, err = s.EnsureCounterpartyTx(ctx, tx, in)
 		return err

--- a/backend/internal/modules/people/ensurechannel.go
+++ b/backend/internal/modules/people/ensurechannel.go
@@ -32,7 +32,6 @@ import (
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
@@ -87,7 +86,7 @@ func (s *Store) EnsureChannelCounterparty(ctx context.Context, in EnsureChannelC
 			errors.New("people: a channel counterparty needs both a provider and a channel user id")
 	}
 	var res EnsureChannelCounterpartyResult
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		var err error
 		res, err = s.ensureChannelCounterpartyTx(ctx, tx, in)
 		return err

--- a/backend/internal/modules/people/ensurechannel_contention_integration_test.go
+++ b/backend/internal/modules/people/ensurechannel_contention_integration_test.go
@@ -112,7 +112,7 @@ func TestTwoConcurrentFirstChannelMessagesConvergeOnOnePerson(t *testing.T) {
 // long as the holder lives, and a call that never takes it never waits at all.
 // The bound is a failure guard, not a race — the holding transaction stays open
 // across the whole call below.
-func lockWaitBoundedStore(t *testing.T) *Store {
+func lockWaitBoundedStore(t *testing.T, ws ids.UUID) *Store {
 	t.Helper()
 	cfg, err := pgxpool.ParseConfig(os.Getenv("MARGINCE_TEST_APP_DSN"))
 	if err != nil {
@@ -128,7 +128,7 @@ func lockWaitBoundedStore(t *testing.T) *Store {
 		t.Fatalf("opening the lock-bounded pool: %v", err)
 	}
 	t.Cleanup(pool.Close)
-	return NewStore(pool)
+	return NewStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)))
 }
 
 // An Art. 17 erasure holds the subject's account lock from its purge until its
@@ -162,9 +162,9 @@ func TestEnsureRefusesToCreateARivalDuringErasure(t *testing.T) {
 	}
 
 	in := e.channelEnsureInput(ctx, t, ci, subjectName)
-	bounded := lockWaitBoundedStore(t)
+	bounded := lockWaitBoundedStore(t, e.ws)
 	var ensureErr error
-	if err := database.WithWorkspaceTx(ctx, e.store.pool, func(tx pgx.Tx) error {
+	if err := database.WithWorkspaceTx(ctx, e.store.db.Pool(), func(tx pgx.Tx) error {
 		if err := storekit.LockChannelIdentities(ctx, tx, []storekit.ChannelIdentityKey{
 			{Provider: ci.Provider, ChannelUserID: ci.ChannelUserID},
 		}); err != nil {
@@ -261,7 +261,7 @@ func (e *dedupeEnv) handleUpdatedEventCount(ctx context.Context, t *testing.T, p
 // guess about timing.
 func (e *dedupeEnv) beginBlockingRefresh(ctx context.Context, t *testing.T, ci connector.ChannelIdentity) (pgx.Tx, int) {
 	t.Helper()
-	tx, err := e.store.pool.Begin(ctx)
+	tx, err := e.store.db.Pool().Begin(ctx)
 	if err != nil {
 		t.Fatalf("opening the blocking transaction: %v", err)
 	}
@@ -647,7 +647,7 @@ func TestAFinishedRacerIsNotReportedAsAMissAtTheBudgetBoundary(t *testing.T) {
 	e := setupDedupe(t)
 	ctx := e.as()
 
-	probe, err := e.store.pool.Begin(ctx)
+	probe, err := e.store.db.Pool().Begin(ctx)
 	if err != nil {
 		t.Fatalf("opening the probe transaction: %v", err)
 	}

--- a/backend/internal/modules/people/handlers.go
+++ b/backend/internal/modules/people/handlers.go
@@ -14,9 +14,8 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/jackc/pgx/v5/pgxpool"
-
 	"github.com/gradionhq/margince/backend/internal/platform/blobstore"
+	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/platform/httperr"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
@@ -35,8 +34,9 @@ type Handlers struct {
 	blob blobstore.Store
 }
 
-func NewHandlers(pool *pgxpool.Pool) Handlers {
-	return Handlers{store: NewStore(pool)}
+// NewHandlers builds the module's HTTP surface over a workspace-bound handle.
+func NewHandlers(db *database.DB) Handlers {
+	return Handlers{store: NewStore(db)}
 }
 
 // WithMatchStager wires the pass that turns this member's suggested LinkedIn

--- a/backend/internal/modules/people/leadlinkedin_integration_test.go
+++ b/backend/internal/modules/people/leadlinkedin_integration_test.go
@@ -73,7 +73,7 @@ func setupLeadLinkedIn(t *testing.T) *linkedinEnv {
 		t.Fatal(err)
 	}
 	t.Cleanup(pool.Close)
-	e.store = NewStore(pool)
+	e.store = NewStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](e.ws)))
 	return e
 }
 

--- a/backend/internal/modules/people/linkedinaccount.go
+++ b/backend/internal/modules/people/linkedinaccount.go
@@ -25,7 +25,6 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
@@ -59,7 +58,7 @@ func (s *Store) MyLinkedInMatchTotals(ctx context.Context) (confirmed, suggested
 	if !ok || actor.UserID == ids.Nil {
 		return 0, 0, apperrors.ErrPermissionDenied
 	}
-	err = database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err = s.db.Tx(ctx, func(tx pgx.Tx) error {
 		return tx.QueryRow(ctx, `
 			SELECT count(*) FILTER (WHERE match_status = 'confirmed'),
 			       count(*) FILTER (WHERE match_status = 'suggested')
@@ -79,7 +78,7 @@ func (s *Store) GetMyLinkedInAccount(ctx context.Context) (LinkedInAccount, erro
 		return LinkedInAccount{}, apperrors.ErrPermissionDenied
 	}
 	var out LinkedInAccount
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		err := tx.QueryRow(ctx, `
 			SELECT a.profile_url, a.connected_at,
 			       (SELECT count(*) FROM linkedin_connection c
@@ -125,7 +124,7 @@ func (s *Store) SaveMyLinkedInAccount(ctx context.Context, in SaveMyLinkedInAcco
 	if err := validateLinkedInProfileURL(trimmed); err != nil {
 		return LinkedInAccount{}, err
 	}
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		before, err := readLinkedInAccountTx(ctx, tx, actor.UserID)
 		if err != nil {
 			return err

--- a/backend/internal/modules/people/linkedinimport.go
+++ b/backend/internal/modules/people/linkedinimport.go
@@ -31,7 +31,6 @@ import (
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
@@ -105,7 +104,7 @@ func (s *Store) ImportLinkedInConnections(ctx context.Context, r io.Reader) (Lin
 	}
 	out := LinkedInImportResult{Rows: len(rows.parsed) + rows.skipped, Skipped: rows.skipped}
 
-	err = database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err = s.db.Tx(ctx, func(tx pgx.Tx) error {
 		// Repair the stored keys BEFORE upserting. normalized_company is a
 		// derived part of the natural key, so rows written under an older
 		// normalizer no longer collide with what this import computes — and

--- a/backend/internal/modules/people/linkedinmatch.go
+++ b/backend/internal/modules/people/linkedinmatch.go
@@ -30,7 +30,6 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
@@ -64,7 +63,7 @@ func (s *Store) MatchLinkedInConnections(ctx context.Context, owner ids.UUID) (L
 		return LinkedInMatchResult{}, err
 	}
 	var out LinkedInMatchResult
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		confirmed, err := matchGhostsByEmail(ctx, tx, owner, ids.Nil)
 		if err != nil {
 			return err
@@ -127,7 +126,7 @@ func (s *Store) MatchLinkedInConnectionsForPerson(ctx context.Context, owner, pe
 		return LinkedInMatchResult{}, err
 	}
 	var out LinkedInMatchResult
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		confirmed, err := matchGhostsByEmail(ctx, tx, owner, person)
 		if err != nil {
 			return err

--- a/backend/internal/modules/people/linkedinmatchapply.go
+++ b/backend/internal/modules/people/linkedinmatchapply.go
@@ -21,7 +21,6 @@ import (
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
@@ -99,7 +98,7 @@ func (s *Store) suggestedMatches(ctx context.Context, forPerson ids.UUID) ([]Pen
 		return nil, err
 	}
 	var out []PendingLinkedInMatch
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		var args []any
 		arg := func(v any) int { args = append(args, v); return len(args) }
 		ownerPos := arg(actor.UserID)
@@ -152,7 +151,7 @@ func (s *Store) ApplyLinkedInMatch(ctx context.Context, connectionID, personID i
 	if err := auth.Require(ctx, "person", principal.ActionUpdate); err != nil {
 		return err
 	}
-	return database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	return s.db.Tx(ctx, func(tx pgx.Tx) error {
 		if err := auth.EnsureVisibleLive(ctx, tx, entityPerson, personID); err != nil {
 			return err
 		}

--- a/backend/internal/modules/people/linkedinreach.go
+++ b/backend/internal/modules/people/linkedinreach.go
@@ -22,7 +22,6 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
@@ -79,7 +78,7 @@ func (s *Store) MyLinkedInReach(ctx context.Context, limit *int) (LinkedInReach,
 	capped := storekit.ClampLimit(limit)
 
 	var out LinkedInReach
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		if err := s.readReachAccounts(ctx, tx, actor.UserID, capped, &out); err != nil {
 			return err
 		}

--- a/backend/internal/modules/people/linkedinrenormalize.go
+++ b/backend/internal/modules/people/linkedinrenormalize.go
@@ -30,7 +30,6 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
@@ -78,7 +77,7 @@ func matchRank(status string) int {
 // a derived column rather than a read of anybody's records.
 func (s *Store) RenormalizeLinkedInCompanyKeys(ctx context.Context) (LinkedInRenormalizeResult, error) {
 	var out LinkedInRenormalizeResult
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		var err error
 		out, err = renormalizeGhostKeysTx(ctx, tx, ids.Nil)
 		return err

--- a/backend/internal/modules/people/orgnamelock_contention_integration_test.go
+++ b/backend/internal/modules/people/orgnamelock_contention_integration_test.go
@@ -34,7 +34,7 @@ import (
 // and the run that meant to fail loudly would hang instead.
 func (e *dedupeEnv) holdOrgNameLock(ctx context.Context, t *testing.T) (pgx.Tx, int) {
 	t.Helper()
-	tx, err := e.store.pool.Begin(ctx)
+	tx, err := e.store.db.Pool().Begin(ctx)
 	if err != nil {
 		t.Fatalf("opening the lock holder's transaction: %v", err)
 	}

--- a/backend/internal/modules/people/orgnamepromotion.go
+++ b/backend/internal/modules/people/orgnamepromotion.go
@@ -37,7 +37,6 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
@@ -243,7 +242,7 @@ func sortedPersonIDs(set map[ids.PersonID]bool) []ids.PersonID {
 // decision, no model call and no network.
 func (s *Store) OrgNameCandidates(ctx context.Context, after ids.OrganizationID, limit int) ([]OrgNameCandidate, error) {
 	var out []OrgNameCandidate
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		var cursor *ids.OrganizationID
 		if !after.IsZero() {
 			cursor = &after
@@ -365,7 +364,7 @@ func loadDossierOrgNames(ctx context.Context, tx pgx.Tx, orgIDs []ids.Organizati
 // organization in its own transaction — the sweep's entry point.
 func (s *Store) PromoteOrgName(ctx context.Context, orgID ids.OrganizationID, name, corroboration string) (bool, error) {
 	var promoted bool
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		var err error
 		promoted, err = s.PromoteOrgNameTx(ctx, tx, orgID, name, corroboration)
 		return err

--- a/backend/internal/modules/people/promoteconsent_integration_test.go
+++ b/backend/internal/modules/people/promoteconsent_integration_test.go
@@ -84,7 +84,7 @@ func setupPromoteConsent(t *testing.T) *promoteConsentEnv {
 		t.Fatal(err)
 	}
 	t.Cleanup(pool.Close)
-	e.store = NewStore(pool)
+	e.store = NewStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](e.ws)))
 
 	opCtx := principal.WithWorkspaceID(context.Background(), e.ws)
 	opCtx = principal.WithCorrelationID(opCtx, ids.NewV7())

--- a/backend/internal/modules/people/provider.go
+++ b/backend/internal/modules/people/provider.go
@@ -12,11 +12,10 @@ package people
 import (
 	"context"
 
-	"github.com/jackc/pgx/v5/pgxpool"
-
 	openapi_types "github.com/oapi-codegen/runtime/types"
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
@@ -28,8 +27,10 @@ type Provider struct {
 	store *Store
 }
 
-func NewProvider(pool *pgxpool.Pool) *Provider {
-	return &Provider{store: NewStore(pool)}
+// NewProvider builds this module's system-of-record provider over a
+// workspace-bound handle.
+func NewProvider(db *database.DB) *Provider {
+	return &Provider{store: NewStore(db)}
 }
 
 // WithFieldCatalog wires the workspace custom-field catalog into the

--- a/backend/internal/modules/people/searchpersonfields.go
+++ b/backend/internal/modules/people/searchpersonfields.go
@@ -25,7 +25,6 @@ import (
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
@@ -70,7 +69,7 @@ func (s *Store) ApplyDiscoveredFields(ctx context.Context, personID ids.PersonID
 		return nil, err
 	}
 	var applied []string
-	err = database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err = s.db.Tx(ctx, func(tx pgx.Tx) error {
 		if err := auth.EnsureVisible(ctx, tx, "person", personID.UUID); err != nil {
 			return err
 		}

--- a/backend/internal/modules/people/store.go
+++ b/backend/internal/modules/people/store.go
@@ -7,8 +7,6 @@ import (
 	"context"
 
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgxpool"
-
 	openapi_types "github.com/oapi-codegen/runtime/types"
 
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
@@ -27,7 +25,8 @@ const ownerIDColumn = "owner_id"
 // Store owns this module's tables (data-seam ownership, ADR-0014 Am.1);
 // every write rides the storekit audit+outbox shape in one transaction.
 type Store struct {
-	pool *pgxpool.Pool
+	// db binds the workspace this store runs for (ADR-0091 §9 step 3).
+	db *database.DB
 	// catalog is the fieldcatalog seam (custom-field columns); nil means
 	// no catalog is wired and every read/write runs core-columns-only.
 	catalog fieldcatalog.Reader
@@ -46,8 +45,10 @@ type Store struct {
 // transaction the caller owns. Compose injects capture's implementation.
 type ConsumerMailReader func(context.Context, pgx.Tx) (*freemail.Matcher, error)
 
-func NewStore(pool *pgxpool.Pool) *Store {
-	return &Store{pool: pool}
+// NewStore opens this module's store on a handle already bound to the
+// workspace it serves.
+func NewStore(db *database.DB) *Store {
+	return &Store{db: db}
 }
 
 // WithConsumerMail wires the reader for the workspace's own consumer-mail
@@ -77,7 +78,7 @@ func (s *Store) WithFieldCatalog(catalog fieldcatalog.Reader) *Store {
 }
 
 func (s *Store) tx(ctx context.Context, fn func(pgx.Tx) error) error {
-	return database.WithWorkspaceTx(ctx, s.pool, fn)
+	return s.db.Tx(ctx, fn)
 }
 
 // scopeAllRows is the row-scope predicate for an actor bounded by nothing.

--- a/backend/internal/modules/people/strength.go
+++ b/backend/internal/modules/people/strength.go
@@ -23,7 +23,6 @@ import (
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
@@ -72,7 +71,7 @@ func (s *Store) PersonStrength(ctx context.Context, personID ids.PersonID, now t
 		return RelationshipStrength{}, err
 	}
 	var out RelationshipStrength
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		if err := auth.EnsureVisible(ctx, tx, "person", personID.UUID); err != nil {
 			return err
 		}
@@ -126,7 +125,7 @@ func (s *Store) OrganizationStrength(ctx context.Context, orgID ids.Organization
 		return AccountStrength{}, err
 	}
 	var out AccountStrength
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		if err := auth.EnsureVisible(ctx, tx, "organization", orgID.UUID); err != nil {
 			return err
 		}

--- a/backend/internal/modules/search/binding.go
+++ b/backend/internal/modules/search/binding.go
@@ -410,7 +410,10 @@ func (s *Store) pendingStats(ctx context.Context, currentIdentity string) (map[i
 		// scope would silently under-report entities the caller cannot see.
 		wsCtx := systemWorkspaceContext(ctx, wsID.UUID)
 
-		count, length, err := s.workspacePending(wsCtx, currentIdentity)
+		// A store bound to THIS tenant: the workspace a read is scoped to is
+		// the handle's, so counting every workspace through the enumerating
+		// store would report the same tenant's total under every id.
+		count, length, err := s.forWorkspace(wsID).workspacePending(wsCtx, currentIdentity)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/backend/internal/modules/search/binding.go
+++ b/backend/internal/modules/search/binding.go
@@ -65,7 +65,7 @@ var pendingSources = map[string]pendingSource{
 // completed reindex.
 func (s *Store) SeedBinding(ctx context.Context, configuredIdentity string) error {
 	// rls-exempt: deployment metadata, no workspace_id (embed_store_binding, migration 0114) — this write must not ride a per-workspace GUC tx.
-	_, err := s.pool.Exec(ctx, `
+	_, err := s.db.Pool().Exec(ctx, `
 		INSERT INTO embed_store_binding (singleton, populated_identity, status)
 		VALUES (true, $1, 'idle')
 		ON CONFLICT (singleton) DO NOTHING`, configuredIdentity)
@@ -86,7 +86,7 @@ func (s *Store) SeedBinding(ctx context.Context, configuredIdentity string) erro
 // status endpoint, not the readiness probe.
 func (s *Store) PopulatedIdentity(ctx context.Context) (identity string, status string, updatedAt time.Time, err error) {
 	// rls-exempt: deployment metadata, no workspace_id
-	err = s.pool.QueryRow(ctx, `SELECT populated_identity, status, updated_at FROM embed_store_binding WHERE singleton`).
+	err = s.db.Pool().QueryRow(ctx, `SELECT populated_identity, status, updated_at FROM embed_store_binding WHERE singleton`).
 		Scan(&identity, &status, &updatedAt)
 	if err != nil {
 		return "", "", time.Time{}, fmt.Errorf("search: reading binding marker: %w", err)
@@ -182,7 +182,7 @@ func (s *Store) ClaimAndEnqueueReembedding(ctx context.Context, claim ReembedCla
 	// job enqueue share one non-tenant transaction so a rolled-back enqueue
 	// always undoes the claim; WithInfraTx is the platform's cross-tenant
 	// tx shape (no GUC to bind, there is no tenant here).
-	return database.WithInfraTx(ctx, s.pool, func(tx pgx.Tx) error {
+	return database.WithInfraTx(ctx, s.db.Pool(), func(tx pgx.Tx) error {
 		tag, err := tx.Exec(ctx, `
 			UPDATE embed_store_binding
 			SET status = 'reembedding', reembedding_run = $1, reembedding_identity = $2,
@@ -229,7 +229,7 @@ func refusedClaimReason(ctx context.Context, tx pgx.Tx) error {
 // ErrReembeddingSuperseded, and the enqueue never happens.
 func (s *Store) SeedReembeddingFleet(ctx context.Context, run ids.UUID, workspaces []ids.WorkspaceID, enqueue func(tx pgx.Tx) error) error {
 	// rls-exempt: deployment metadata, no workspace_id
-	return database.WithInfraTx(ctx, s.pool, func(tx pgx.Tx) error {
+	return database.WithInfraTx(ctx, s.db.Pool(), func(tx pgx.Tx) error {
 		tag, err := tx.Exec(ctx, `
 			UPDATE embed_store_binding SET reembedding_pending = $2, updated_at = now()
 			WHERE reembedding_run = $1 AND cardinality(reembedding_pending) = 0`, run, workspaces)
@@ -262,7 +262,7 @@ func (s *Store) SeedReembeddingFleet(ctx context.Context, run ids.UUID, workspac
 // breaks the steal, not just the straggler.
 func (s *Store) FinishWorkspaceReembedding(ctx context.Context, run ids.UUID, workspace ids.WorkspaceID) error {
 	// rls-exempt: deployment metadata, no workspace_id
-	return database.WithInfraTx(ctx, s.pool, func(tx pgx.Tx) error {
+	return database.WithInfraTx(ctx, s.db.Pool(), func(tx pgx.Tx) error {
 		var remaining int
 		err := tx.QueryRow(ctx, `
 			UPDATE embed_store_binding
@@ -305,7 +305,7 @@ const ReembedProgressStaleness = 5 * time.Minute
 // keep the marker of the run that replaced it looking alive.
 func (s *Store) noteReembedProgress(ctx context.Context, run ids.UUID) error {
 	// rls-exempt: deployment metadata, no workspace_id
-	_, err := s.pool.Exec(ctx, `
+	_, err := s.db.Pool().Exec(ctx, `
 		UPDATE embed_store_binding SET updated_at = now() WHERE reembedding_run = $1`, run)
 	if err != nil {
 		return fmt.Errorf("search: recording reembed progress: %w", err)
@@ -319,7 +319,7 @@ func (s *Store) noteReembedProgress(ctx context.Context, run ids.UUID) error {
 // take the marker away from children that are already working.
 func (s *Store) ReleaseReembedding(ctx context.Context, run ids.UUID) error {
 	// rls-exempt: deployment metadata, no workspace_id
-	return database.WithInfraTx(ctx, s.pool, func(tx pgx.Tx) error {
+	return database.WithInfraTx(ctx, s.db.Pool(), func(tx pgx.Tx) error {
 		return releaseReembeddingTx(ctx, tx, run)
 	})
 }
@@ -441,7 +441,7 @@ func systemWorkspaceContext(ctx context.Context, wsID ids.UUID) context.Context 
 // per-workspace rollup loop from.
 func (s *Store) fleetWorkspaceIDs(ctx context.Context) ([]ids.WorkspaceID, error) {
 	// rls-exempt: fleet enumeration — the workspace table lists every tenant before the per-workspace tx each caller opens next (compose/dispatch.go enumerateWorkspaces is the sanctioned spelling; backend/jobfleetscan_test.go ratifies this site as a read).
-	rows, err := s.pool.Query(ctx, `SELECT id FROM workspace WHERE archived_at IS NULL ORDER BY created_at`)
+	rows, err := s.db.Pool().Query(ctx, `SELECT id FROM workspace WHERE archived_at IS NULL ORDER BY created_at`)
 	if err != nil {
 		return nil, fmt.Errorf("search: enumerating workspaces: %w", err)
 	}
@@ -456,7 +456,7 @@ func (s *Store) fleetWorkspaceIDs(ctx context.Context) ([]ids.WorkspaceID, error
 // summing counts and text lengths across all of them for the workspace
 // bound in ctx.
 func (s *Store) workspacePending(ctx context.Context, currentIdentity string) (count int, length int64, err error) {
-	txErr := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	txErr := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		for entityType, src := range pendingSources {
 			sql := fmt.Sprintf(`
 				SELECT count(*), coalesce(sum(octet_length(btrim(%s))), 0)

--- a/backend/internal/modules/search/driftsweep.go
+++ b/backend/internal/modules/search/driftsweep.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
@@ -79,7 +78,7 @@ func (s *Store) SweepWorkspaceEmbeddingDrift(ctx context.Context, wsID ids.Works
 // call free).
 func (s *Store) healEntity(ctx context.Context, entityType string, id ids.UUID, embedder Embedder) (bool, error) {
 	var text string
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		return tx.QueryRow(ctx, embedText[entityType], id).Scan(&text)
 	})
 	if errors.Is(err, pgx.ErrNoRows) {
@@ -104,7 +103,7 @@ func (s *Store) healEntity(ctx context.Context, entityType string, id ids.UUID, 
 // model calls must not run under a held workspace tx).
 func (s *Store) pendingEntityIDs(ctx context.Context, entityType string, src pendingSource, currentIdentity string) ([]ids.UUID, error) {
 	var pendingIDs []ids.UUID
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		sql := fmt.Sprintf(`
 			SELECT t.id FROM %s t
 			WHERE t.archived_at IS NULL

--- a/backend/internal/modules/search/embedding.go
+++ b/backend/internal/modules/search/embedding.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/model"
 )
@@ -74,7 +73,7 @@ func (s *Store) UpsertEmbedding(ctx context.Context, entityType string, entityID
 	}
 
 	fresh := false
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		var existingHash, existingModel string
 		err := tx.QueryRow(ctx, `
 			SELECT chunk_hash, model FROM embedding
@@ -146,7 +145,7 @@ func (s *Store) SimilarEntities(ctx context.Context, queryVec []float32, identit
 	}
 	limit = clampLimit(limit)
 	var hits []VectorHit
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		var args []any
 		arg := func(v any) int { args = append(args, v); return len(args) }
 		vecPos := arg(vectorLiteral(queryVec))

--- a/backend/internal/modules/search/embedgen.go
+++ b/backend/internal/modules/search/embedgen.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	kevents "github.com/gradionhq/margince/backend/internal/shared/kernel/events"
 )
 
@@ -68,7 +67,7 @@ func (g *EmbedGen) HandleEvent(ctx context.Context, env kevents.Envelope) error 
 	wsCtx := systemWorkspaceContext(ctx, env.WorkspaceID)
 
 	var text string
-	err := database.WithWorkspaceTx(wsCtx, g.store.pool, func(tx pgx.Tx) error {
+	err := g.store.db.Tx(wsCtx, func(tx pgx.Tx) error {
 		return tx.QueryRow(wsCtx, query, env.Entity.ID).Scan(&text)
 	})
 	if errors.Is(err, pgx.ErrNoRows) {

--- a/backend/internal/modules/search/graph.go
+++ b/backend/internal/modules/search/graph.go
@@ -16,7 +16,6 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
@@ -103,7 +102,7 @@ var anchorLinkColumn = map[string]string{
 // and the walk below runs around one of those.
 func (s *Store) assembleGraph(ctx context.Context, anchorType string, anchorID ids.UUID, maxItems int) ([]graphSection, error) {
 	var sections []graphSection
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		var err error
 		if anchorType == string(datasource.EntityActivity) {
 			sections, err = s.assembleActivityWithin(ctx, tx, anchorID, maxItems)

--- a/backend/internal/modules/search/graphedgegen.go
+++ b/backend/internal/modules/search/graphedgegen.go
@@ -35,7 +35,6 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/events"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
@@ -110,7 +109,7 @@ func (g *GraphEdgeGen) onActivity(ctx context.Context, env events.Envelope, acti
 	default:
 		return nil
 	}
-	return database.WithWorkspaceTx(ctx, g.store.pool, func(tx pgx.Tx) error {
+	return g.store.db.Tx(ctx, func(tx pgx.Tx) error {
 		if err := RecomputeEdgesForActivities(ctx, tx, []ids.UUID{activityID}); err != nil {
 			return fmt.Errorf("graph-edge: %s: %w", env.Type, err)
 		}
@@ -120,7 +119,7 @@ func (g *GraphEdgeGen) onActivity(ctx context.Context, env events.Envelope, acti
 
 // onPerson refolds or drops the edges to one contact.
 func (g *GraphEdgeGen) onPerson(ctx context.Context, env events.Envelope, personID ids.UUID) error {
-	return database.WithWorkspaceTx(ctx, g.store.pool, func(tx pgx.Tx) error {
+	return g.store.db.Tx(ctx, func(tx pgx.Tx) error {
 		switch env.Type {
 		case "person.merged":
 			// The source's edges belong to the survivor now. Dropping the

--- a/backend/internal/modules/search/handlers.go
+++ b/backend/internal/modules/search/handlers.go
@@ -6,11 +6,10 @@ package search
 import (
 	"net/http"
 
-	"github.com/jackc/pgx/v5/pgxpool"
-
 	openapi_types "github.com/oapi-codegen/runtime/types"
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/httperr"
 )
 
@@ -21,8 +20,9 @@ type Handlers struct {
 	retriever *Retriever
 }
 
-func NewHandlers(pool *pgxpool.Pool) Handlers {
-	store := NewStore(pool)
+// NewHandlers builds the module's HTTP surface over a workspace-bound handle.
+func NewHandlers(db *database.DB) Handlers {
+	store := NewStore(db)
 	// Embedder is nil, and stays nil: the only thing this retriever serves is
 	// AssembleContext, which walks the context graph and never embeds. The
 	// request-path embed lane compose binds is for the RANKED half, and

--- a/backend/internal/modules/search/queryexec.go
+++ b/backend/internal/modules/search/queryexec.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
@@ -210,7 +209,7 @@ func (e *QueryExecutor) answerRows(ctx context.Context, plan ValidatedPlan, bind
 		return nil, err
 	}
 	var rows []QueryRow
-	err = database.WithWorkspaceTx(ctx, e.store.pool, func(tx pgx.Tx) error {
+	err = e.store.db.Tx(ctx, func(tx pgx.Tx) error {
 		queried, err := tx.Query(ctx, sql, compiler.args...)
 		if err != nil {
 			return fmt.Errorf("search: running the query plan: %w", err)

--- a/backend/internal/modules/search/querystorage.go
+++ b/backend/internal/modules/search/querystorage.go
@@ -35,7 +35,8 @@ import (
 	"strings"
 
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/gradionhq/margince/backend/internal/platform/database"
 )
 
 // StoredColumn is one physical column, as this module needs to see it: its
@@ -59,11 +60,12 @@ type ColumnReader interface {
 
 // ColumnCatalog reads the live schema.
 type ColumnCatalog struct {
-	pool *pgxpool.Pool
+	// db binds the workspace this store runs for (ADR-0091 §9 step 3).
+	db *database.DB
 }
 
 // NewColumnCatalog builds the reader over the pool.
-func NewColumnCatalog(pool *pgxpool.Pool) *ColumnCatalog { return &ColumnCatalog{pool: pool} }
+func NewColumnCatalog(db *database.DB) *ColumnCatalog { return &ColumnCatalog{db: db} }
 
 // Columns answers one table's column names.
 //
@@ -73,7 +75,7 @@ func NewColumnCatalog(pool *pgxpool.Pool) *ColumnCatalog { return &ColumnCatalog
 // process restarted, for a saving of one indexed catalog read per plan.
 func (c *ColumnCatalog) Columns(ctx context.Context, table string) ([]StoredColumn, error) {
 	// rls-exempt: information_schema is the database's own schema catalog; it holds no tenant rows, so there is no workspace to bind
-	rows, err := c.pool.Query(ctx,
+	rows, err := c.db.Pool().Query(ctx,
 		`SELECT column_name, data_type FROM information_schema.columns
 		  WHERE table_schema = current_schema() AND table_name = $1`, table)
 	if err != nil {

--- a/backend/internal/modules/search/reembed.go
+++ b/backend/internal/modules/search/reembed.go
@@ -78,6 +78,10 @@ func (s *Store) ReembedWorkspace(ctx context.Context, pass ReembedPass, wsID ids
 	// workspace, not one caller's row scope — the same posture as
 	// EmbedGen (embedgen.go:51-56) and pendingStats.
 	wsCtx := systemWorkspaceContext(ctx, wsID.UUID)
+	// The pass reads and writes THIS tenant: it is named as an argument, and
+	// the workspace a statement lands in is the handle's, so the enumerating
+	// store would rebuild its own tenant's index under every id it is given.
+	ws := s.forWorkspace(wsID)
 
 	// note says the run is still working, and restarts the pacing from the write
 	// that just landed rather than from when the caller wished it had.
@@ -102,7 +106,7 @@ func (s *Store) ReembedWorkspace(ctx context.Context, pass ReembedPass, wsID ids
 		if err := note(); err != nil {
 			return err
 		}
-		items, err := s.liveEntitiesOf(wsCtx, entityType, src)
+		items, err := ws.liveEntitiesOf(wsCtx, entityType, src)
 		if err != nil {
 			return err
 		}
@@ -110,7 +114,7 @@ func (s *Store) ReembedWorkspace(ctx context.Context, pass ReembedPass, wsID ids
 			return err
 		}
 		for _, item := range items {
-			if _, err := s.UpsertEmbedding(wsCtx, entityType, item.id, item.text, embedder); err != nil {
+			if _, err := ws.UpsertEmbedding(wsCtx, entityType, item.id, item.text, embedder); err != nil {
 				return fmt.Errorf("search: reembedding %s %s: %w", entityType, item.id, err)
 			}
 			// Paced by the clock and not by a count of entities: an entity is not a

--- a/backend/internal/modules/search/reembed.go
+++ b/backend/internal/modules/search/reembed.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
@@ -145,7 +144,7 @@ type liveEntity struct {
 // underneath the whole re-embed pass.
 func (s *Store) liveEntitiesOf(ctx context.Context, entityType string, src pendingSource) ([]liveEntity, error) {
 	var items []liveEntity
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		sql := fmt.Sprintf(`SELECT t.id, %s FROM %s t WHERE t.archived_at IS NULL`, src.text, src.table)
 		rows, err := tx.Query(ctx, sql)
 		if err != nil {

--- a/backend/internal/modules/search/store.go
+++ b/backend/internal/modules/search/store.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
@@ -22,11 +21,14 @@ import (
 )
 
 type Store struct {
-	pool *pgxpool.Pool
+	// db binds the workspace this store runs for (ADR-0091 §9 step 3).
+	db *database.DB
 }
 
-func NewStore(pool *pgxpool.Pool) *Store {
-	return &Store{pool: pool}
+// NewStore opens this module's store on a handle already bound to the
+// workspace it serves.
+func NewStore(db *database.DB) *Store {
+	return &Store{db: db}
 }
 
 // Hit is one ranked result. Score is ts_rank_cd over the entity's
@@ -153,7 +155,7 @@ func (s *Store) Search(ctx context.Context, in Input) (Page, error) {
 	}
 
 	var page Page
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		var args []any
 		arg := func(v any) int { args = append(args, v); return len(args) }
 		qPos := arg(query)

--- a/backend/internal/modules/search/store.go
+++ b/backend/internal/modules/search/store.go
@@ -31,6 +31,13 @@ func NewStore(db *database.DB) *Store {
 	return &Store{db: db}
 }
 
+// forWorkspace is this store re-bound to one tenant of the fleet enumeration.
+// Only the index-maintenance passes that walk every workspace use it; a
+// request-path caller already holds the handle for the tenant it serves.
+func (s *Store) forWorkspace(ws ids.WorkspaceID) *Store {
+	return &Store{db: s.db.ForWorkspace(ws)}
+}
+
 // Hit is one ranked result. Score is ts_rank_cd over the entity's
 // search_tsv — comparable across types because every column uses the
 // same 'simple' configuration.

--- a/backend/internal/platform/database/db.go
+++ b/backend/internal/platform/database/db.go
@@ -93,3 +93,16 @@ func (d *DB) Tx(ctx context.Context, fn func(pgx.Tx) error) error {
 	}
 	return withBoundTx(ctx, d.pool, ws, fn)
 }
+
+// ForWorkspace is this handle re-bound to another workspace, for the fleet
+// passes that enumerate every tenant and must read each one in its own bound
+// transaction.
+//
+// It is deliberately narrow: a pass qualifies only when it is driven by the
+// workspace ENUMERATION itself, never by a request. The single-installation
+// collapse (ADR-0091) retires these — with one workspace there is nothing to
+// enumerate — so a new caller here is a sign the work belongs on the job
+// fan-out, which hands each pass the tenant it runs for.
+func (d *DB) ForWorkspace(ws ids.WorkspaceID) *DB {
+	return BindTo(d.pool, ws)
+}


### PR DESCRIPTION
people, approvals, search, agents and deals now open on a `*database.DB` — a pool that already knows the workspace it serves — instead of taking a raw pool and reading the tenant back out of every request context (ADR-0091 §9 step 3). With these five, every request-path module in the tree is converted.

## Why the call sites still look different

The sweep's finding is that there are exactly three ways a caller knows which tenant it is, and the handle makes that choice visible instead of hiding it inside the store:

- **request paths and bus consumers RESOLVE** the installation's singleton — `compose.InstallationDB(pool)`;
- **fleet passes PIN from their job args** — `workspaceJobDB`; a sweep enumerates every workspace, so a resolver would refuse the second one outright;
- **raw-SQL harnesses pin per tenant** — `Env.DB()` / `Env.DBFor(ws)`; this is what keeps the cross-tenant suites able to seed two workspaces and still prove one cannot read the other.

A cross-tenant suite therefore builds a store per tenant rather than calling one store with a second tenant's ctx. The assertion is unchanged and still RLS's.

## What is not changing

`DB.Tx` is the same `WithWorkspaceTx` spelling, so the GUC contract holds and RLS stays armed. That matters for sequencing: the tenant-isolation suite is the only mechanical proof this collapse was faithful, and ADR-0091 §9 orders step 3 before the schema phase that eventually deletes it.

Every mis-binding this sweep hit surfaced loudly — a refusal, an FK violation, an RLS denial — never as a silent cross-tenant read.

## Verification

- `make check-backend` — green
- `craft static --strict` over all 165 changed Go files — 0 findings
- integration lane runs in CI on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Converted `people`, `approvals`, `search`, `agents`, and `deals` to use a workspace-bound `*database.DB`, and fixed fleet-wide enumeration to rebind per workspace. Also bound the composite provider and overlay flip to the caller’s workspace. This completes the request-path sweep and keeps RLS/transaction behavior unchanged.

- **Refactors**
  - Stores/services and workers now take bound handles; request paths resolve `compose.InstallationDB(pool)`. Added `compose.NewProviderFor(db)` and bound overlay flip writers via `actingWorkspaceDB`; `NewProvider(pool)` now resolves the installation DB.
  - Tests bind per tenant via `Env.DB()`/`DBFor(ws)` and new `DealsFor`/`PeopleFor`; `DB.Tx` (`WithWorkspaceTx`) unchanged, so RLS stays enforced.

- **Bug Fixes**
  - Fleet passes that enumerate workspaces rebind per tenant; search rollups/re-embed and the agent scheduler now operate in the correct workspace.
  - Tool registry/provider and flip paths now honor the caller’s workspace, preventing cross-tenant reads/writes.

<sup>Written for commit 97ede0eecb753815b22dec18e63128a40a85fd1c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/992?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

