### PR TITLE
fix(frontend): a mutation takes its value, it does not close over it

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -3586,8 +3586,6 @@ export const de = {
   "settings.companyViewSource": "Quelle ansehen",
   "settings.companySave": "Firmenkontext speichern",
   "settings.companySaved": "Gespeichert",
-  "settings.companyRefreshUnavailable":
-    "Diese Website-Aktualisierung ist nicht mehr verfügbar.",
   "settings.companyRefreshUnreadable":
     "Wir haben den Stand dieses Website-Lesevorgangs verloren. Starte die Aktualisierung erneut.",
   "settings.companyRefreshStale":

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -3575,8 +3575,6 @@ export const en = {
   "settings.companyViewSource": "View source",
   "settings.companySave": "Save company context",
   "settings.companySaved": "Saved",
-  "settings.companyRefreshUnavailable":
-    "This website refresh is no longer available.",
   "settings.companyRefreshUnreadable":
     "We lost track of this website read. Start the refresh again.",
   "settings.companyRefreshStale":

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -3578,8 +3578,6 @@ export const vi = {
   "settings.companyViewSource": "Xem nguồn",
   "settings.companySave": "Lưu bối cảnh công ty",
   "settings.companySaved": "Đã lưu",
-  "settings.companyRefreshUnavailable":
-    "Lần làm mới từ website này không còn nữa.",
   "settings.companyRefreshUnreadable":
     "Chúng tôi đã mất dấu lượt đọc website này. Hãy bắt đầu làm mới lại.",
   "settings.companyRefreshStale":

--- a/frontend/src/screens/company-context.test.tsx
+++ b/frontend/src/screens/company-context.test.tsx
@@ -152,12 +152,12 @@ afterEach(() => {
 const SETTLE_MS = 10_000;
 
 // The budget for a test that drives `renderReview`, and it must cover EVERY
-// waiter in there: three run in sequence, each bounded by SETTLE_MS. A test whose
+// waiter in there: four run in sequence, each bounded by SETTLE_MS. A test whose
 // own limit is smaller than the sum lets vitest fire while a waiter still has
 // budget, and what surfaces then is an opaque timeout rather than the assertion
 // the test was written to make. Vitest's per-test default is 5s, which is less
 // than one of these waiters alone.
-const TEST_MS = SETTLE_MS * 3;
+const TEST_MS = SETTLE_MS * 4;
 
 // The fixture's two selectable changes — the `new` and `machine_change` rows.
 // The human_conflict row is decided by radio and the unchanged row offers
@@ -176,6 +176,17 @@ async function renderReview() {
   const refresh = await screen.findByRole(
     "button",
     { name: "Refresh from website" },
+    { timeout: SETTLE_MS },
+  );
+  // The same wait `clickRefresh` below makes, and for the same reason: the
+  // button appears as soon as the profile lands, while the website the start
+  // sends comes from the form state seeded beside it. Clicking on the button's
+  // arrival alone races that seeding.
+  await waitFor(
+    () =>
+      expect(
+        screen.getByLabelText<HTMLInputElement>("Public company website").value,
+      ).toBe(COMPANY.website),
     { timeout: SETTLE_MS },
   );
   fireEvent.click(refresh);

--- a/frontend/src/screens/company-context.tsx
+++ b/frontend/src/screens/company-context.tsx
@@ -36,6 +36,14 @@ type SiteRead = components["schemas"]["CompanySiteRead"];
 type Comparison = components["schemas"]["CompanySiteReadComparison"];
 type Resolution = components["schemas"]["CompanySiteReadResolution"];
 
+/** What the reviewer had on screen at the moment they applied the refresh. */
+type RefreshChoice = Readonly<{
+  current: CompanyInput;
+  read: SiteRead;
+  selected: Set<string>;
+  resolutions: Record<string, Resolution>;
+}>;
+
 const EMPTY_COMPANY_INPUT: CompanyInput = {
   display_name: "",
   website: "",
@@ -354,22 +362,28 @@ export function CompanyContextCard() {
     );
   }, [siteRead.data?.comparisons]);
 
+  // Everything the confirm sends arrives as the mutation's VARIABLE, for the
+  // reason spelled out on startRefresh above: react-query re-arms a mutation's
+  // options in a passive effect, so a click landing between commit and that
+  // effect runs the previous render's closure. Read through one, `form` and the
+  // read are null and the reviewer is told their refresh is unavailable while
+  // it is on the screen in front of them; `selected` and `resolutions` are
+  // worse, because a stale pair sends a set of choices nobody made. The click
+  // handler belongs to the committed render, so what it passes is what the
+  // reviewer sees.
   const confirm = useMutation({
-    mutationFn: async () => {
-      if (!siteRead.data || !form) {
-        throwProblem({ title: t("settings.companyRefreshUnavailable") });
-      }
+    mutationFn: async (choice: RefreshChoice) => {
       const body = refreshConfirmation(
-        form,
-        siteRead.data,
-        selected,
-        resolutions,
+        choice.current,
+        choice.read,
+        choice.selected,
+        choice.resolutions,
       );
       const { data, error, response } = await api.POST(
         "/company/site-reads/{readId}/confirm",
         {
           params: {
-            path: { readId: siteRead.data.id },
+            path: { readId: choice.read.id },
             header: { "Idempotency-Key": crypto.randomUUID() },
           },
           body,
@@ -392,6 +406,10 @@ export function CompanyContextCard() {
   });
 
   const refreshFailure = refreshProblem(startRefresh, siteRead, t);
+  // Bound to a const so the narrowing below survives into the confirm handler:
+  // TypeScript discards a narrowed PROPERTY access inside a closure, and the
+  // whole point of that handler is to carry the read rather than re-read it.
+  const read = siteRead.data;
 
   if (capabilities.data && !capabilities.data.read_enabled) {
     return null;
@@ -483,9 +501,9 @@ export function CompanyContextCard() {
               {refreshFailure !== null && (
                 <p className="company-context-error">{refreshFailure}</p>
               )}
-              {siteRead.data && (
+              {read && (
                 <RefreshReview
-                  read={siteRead.data}
+                  read={read}
                   selected={selected}
                   resolutions={resolutions}
                   onToggle={(key) => setSelected(toggleSet(selected, key))}
@@ -495,7 +513,14 @@ export function CompanyContextCard() {
                       [resolution.key]: resolution,
                     })
                   }
-                  onConfirm={() => confirm.mutate()}
+                  onConfirm={() =>
+                    confirm.mutate({
+                      current: form,
+                      read,
+                      selected,
+                      resolutions,
+                    })
+                  }
                   confirming={confirm.isPending}
                   error={
                     confirm.error

--- a/frontend/src/screens/compose.tsx
+++ b/frontend/src/screens/compose.tsx
@@ -107,12 +107,16 @@ export function RelinkModal({
   const [target, setTarget] = useState<RecordPickerCandidate | null>(null);
   const [replace, setReplace] = useState(false);
 
+  // The picked target arrives as the mutation's variable: read through this
+  // closure it would be the one from the render before the confirm was
+  // enabled, because react-query re-arms a mutation's options in a passive
+  // effect. The remaining guard is a real path and stays — `kindOf` answers
+  // from the search results, and a target whose remembered kind was lost must
+  // be surfaced rather than relinked to nothing.
   const mutation = useMutation({
-    mutationFn: async () => {
-      const kind = target ? kindOf(target.id) : null;
-      if (!target || !kind) {
-        // The confirm is disabled without a target, so this only fires if the
-        // remembered kind was lost — surface it, never send an empty relink.
+    mutationFn: async (target: RecordPickerCandidate) => {
+      const kind = kindOf(target.id);
+      if (!kind) {
         throwProblem({ title: t("compose.relinkTarget") });
       }
       const { data, error } = await api.POST("/activities/{id}/relink", {
@@ -144,7 +148,7 @@ export function RelinkModal({
       title={t("compose.relinkTitle")}
       confirmLabel={t("compose.relinkConfirm")}
       confirmDisabled={!target}
-      onConfirm={() => mutation.mutate()}
+      onConfirm={() => target && mutation.mutate(target)}
       pending={mutation.isPending}
       error={mutation.isError ? problemMessageOf(mutation.error, t) : null}
     >

--- a/frontend/src/screens/mutation-variable-coverage.test.ts
+++ b/frontend/src/screens/mutation-variable-coverage.test.ts
@@ -162,14 +162,33 @@ function findingsIn(file: string): string[] {
   return findings;
 }
 
+// Vitest's 5s per-test default is sized for an async UI test, not for a
+// synchronous parse of every file that defines a mutation. The work below is
+// bounded and deterministic — only the machine's speed varies — so it states a
+// budget a loaded runner cannot exhaust rather than living on one the default
+// happens to cover on a quiet one. The first version of this gate had no such
+// budget and timed out in CI while passing locally.
+const PARSE_MS = 60_000;
+
 describe("mutation variables", () => {
   it("never refuses on state a mutationFn only closed over", () => {
     const files = sourceFiles(srcRoot);
-    // An empty sweep would pass while checking nothing — the way a source-wide
-    // gate is most likely to fail.
+    // A file with no `mutationFn` in its text cannot hold a finding, and
+    // parsing it anyway is what this gate would otherwise cost: a whole-tree
+    // parse on every run, growing with the SPA rather than with the number of
+    // mutations. The first version did exactly that and timed out on a loaded
+    // CI runner — a source check whose verdict depends on how busy the machine
+    // is, which is the failure this whole change is about.
+    const candidates = files.filter((file) =>
+      readFileSync(file, "utf8").includes("mutationFn"),
+    );
+    // Both counts, because either one reaching zero passes this gate while
+    // comparing nothing — a swept tree that finds no files and a prefilter that
+    // admits none look identical from the outside, and both look like success.
     expect(files.length).toBeGreaterThan(0);
+    expect(candidates.length).toBeGreaterThan(0);
 
-    const findings = files.flatMap(findingsIn);
+    const findings = candidates.flatMap(findingsIn);
     expect(findings, `\n${findings.join("\n")}\n`).toEqual([]);
-  });
+  }, PARSE_MS);
 });

--- a/frontend/src/screens/mutation-variable-coverage.test.ts
+++ b/frontend/src/screens/mutation-variable-coverage.test.ts
@@ -171,24 +171,28 @@ function findingsIn(file: string): string[] {
 const PARSE_MS = 60_000;
 
 describe("mutation variables", () => {
-  it("never refuses on state a mutationFn only closed over", () => {
-    const files = sourceFiles(srcRoot);
-    // A file with no `mutationFn` in its text cannot hold a finding, and
-    // parsing it anyway is what this gate would otherwise cost: a whole-tree
-    // parse on every run, growing with the SPA rather than with the number of
-    // mutations. The first version did exactly that and timed out on a loaded
-    // CI runner — a source check whose verdict depends on how busy the machine
-    // is, which is the failure this whole change is about.
-    const candidates = files.filter((file) =>
-      readFileSync(file, "utf8").includes("mutationFn"),
-    );
-    // Both counts, because either one reaching zero passes this gate while
-    // comparing nothing — a swept tree that finds no files and a prefilter that
-    // admits none look identical from the outside, and both look like success.
-    expect(files.length).toBeGreaterThan(0);
-    expect(candidates.length).toBeGreaterThan(0);
+  it(
+    "never refuses on state a mutationFn only closed over",
+    () => {
+      const files = sourceFiles(srcRoot);
+      // A file with no `mutationFn` in its text cannot hold a finding, and
+      // parsing it anyway is what this gate would otherwise cost: a whole-tree
+      // parse on every run, growing with the SPA rather than with the number of
+      // mutations. The first version did exactly that and timed out on a loaded
+      // CI runner — a source check whose verdict depends on how busy the machine
+      // is, which is the failure this whole change is about.
+      const candidates = files.filter((file) =>
+        readFileSync(file, "utf8").includes("mutationFn"),
+      );
+      // Both counts, because either one reaching zero passes this gate while
+      // comparing nothing — a swept tree that finds no files and a prefilter that
+      // admits none look identical from the outside, and both look like success.
+      expect(files.length).toBeGreaterThan(0);
+      expect(candidates.length).toBeGreaterThan(0);
 
-    const findings = candidates.flatMap(findingsIn);
-    expect(findings, `\n${findings.join("\n")}\n`).toEqual([]);
-  }, PARSE_MS);
+      const findings = candidates.flatMap(findingsIn);
+      expect(findings, `\n${findings.join("\n")}\n`).toEqual([]);
+    },
+    PARSE_MS,
+  );
 });

--- a/frontend/src/screens/mutation-variable-coverage.test.ts
+++ b/frontend/src/screens/mutation-variable-coverage.test.ts
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+import ts from "typescript";
+import { describe, expect, it } from "vitest";
+
+// Fitness function for the one way a mutation can refuse work the screen was
+// plainly offering: a `mutationFn` that reads the value it needs out of its
+// CLOSURE instead of taking it as the mutation's variable.
+//
+// `useMutation` re-arms its options in a PASSIVE effect
+// (@tanstack/react-query's useMutation.js: `useEffect(() =>
+// observer.setOptions(options))`). Between the commit that first renders a
+// control with loaded state and the effect that hands the observer that
+// render's closure, the observer still holds the PREVIOUS render's closure —
+// the one where the state was null. A click landing in that window runs the
+// older function, reads nothing, and refuses. React yields between commit and
+// passive effects, so the window is real in a browser and merely wider on a
+// loaded machine.
+//
+// The tell is a zero-parameter `mutationFn` that throws on a falsy check of a
+// value it closed over. Such a guard cannot fire on a real path — the control
+// that triggers it only renders once the value exists — so the only state it
+// can ever report is the stale-closure window, and what it reports there is
+// false: it tells a reader with a filled form that there is nothing to submit.
+// A variable cannot be older than the control that carries it, so the fix is
+// always the same shape: pass the value to `mutate()` and let the parameter
+// replace the guard.
+//
+// WHAT THIS CATCHES: the guarded form, which is the one that produces a false
+// refusal a user can see and report.
+//
+// WHAT THIS DOES NOT CATCH, deliberately: an unguarded closure read. Deciding
+// which free identifier is component state and which is a stable prop needs
+// the type checker and a rule about what counts, and a gate whose rules are
+// fiddly is a gate that gets worked around rather than fixed. The guard is the
+// author's own admission that the value can be absent, which is the honest
+// place to draw the line.
+
+const screensDir = dirname(fileURLToPath(import.meta.url));
+const srcRoot = join(screensDir, "..");
+
+function sourceFiles(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      return sourceFiles(path);
+    }
+    return /\.tsx?$/.test(entry.name) ? [path] : [];
+  });
+}
+
+/** Every name bound inside the function body, so a local cannot read as free. */
+function localNames(body: ts.Node): Set<string> {
+  const names = new Set<string>();
+  const visit = (node: ts.Node) => {
+    // A destructured `const { data, error } = await …` binds through a
+    // BindingElement rather than a plain identifier; missing those reads every
+    // destructured local as free and reports the awaited value as closed over.
+    if (
+      (ts.isVariableDeclaration(node) ||
+        ts.isParameter(node) ||
+        ts.isBindingElement(node)) &&
+      ts.isIdentifier(node.name)
+    ) {
+      names.add(node.name.text);
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(body);
+  return names;
+}
+
+/** The root identifier of `!x` / `!x.y.z`, for every negation in the test. */
+function negatedRoots(expression: ts.Node): string[] {
+  const roots: string[] = [];
+  const visit = (node: ts.Node) => {
+    if (
+      ts.isPrefixUnaryExpression(node) &&
+      node.operator === ts.SyntaxKind.ExclamationToken
+    ) {
+      let operand: ts.Node = node.operand;
+      while (ts.isPropertyAccessExpression(operand)) {
+        operand = operand.expression;
+      }
+      if (ts.isIdentifier(operand)) {
+        roots.push(operand.text);
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(expression);
+  return roots;
+}
+
+function refuses(statement: ts.Node): boolean {
+  let found = false;
+  const visit = (node: ts.Node) => {
+    if (ts.isThrowStatement(node)) {
+      found = true;
+    }
+    if (
+      ts.isCallExpression(node) &&
+      ts.isIdentifier(node.expression) &&
+      node.expression.text === "throwProblem"
+    ) {
+      found = true;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(statement);
+  return found;
+}
+
+function findingsIn(file: string): string[] {
+  const text = readFileSync(file, "utf8");
+  const source = ts.createSourceFile(
+    file,
+    text,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TSX,
+  );
+  const findings: string[] = [];
+
+  const visit = (node: ts.Node) => {
+    if (
+      ts.isPropertyAssignment(node) &&
+      ts.isIdentifier(node.name) &&
+      node.name.text === "mutationFn" &&
+      (ts.isArrowFunction(node.initializer) ||
+        ts.isFunctionExpression(node.initializer)) &&
+      node.initializer.parameters.length === 0 &&
+      node.initializer.body
+    ) {
+      const body = node.initializer.body;
+      const locals = localNames(body);
+      const guards = (inner: ts.Node) => {
+        if (ts.isIfStatement(inner) && refuses(inner.thenStatement)) {
+          const free = negatedRoots(inner.expression).filter(
+            (name) => !locals.has(name),
+          );
+          if (free.length > 0) {
+            const { line } = source.getLineAndCharacterOfPosition(
+              inner.getStart(source),
+            );
+            findings.push(
+              `${relative(srcRoot, file)}:${line + 1} — mutationFn takes no variable and refuses on closed-over ${free.map((n) => `\`${n}\``).join(", ")}; pass it to mutate() instead`,
+            );
+          }
+        }
+        ts.forEachChild(inner, guards);
+      };
+      guards(body);
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(source);
+  return findings;
+}
+
+describe("mutation variables", () => {
+  it("never refuses on state a mutationFn only closed over", () => {
+    const files = sourceFiles(srcRoot);
+    // An empty sweep would pass while checking nothing — the way a source-wide
+    // gate is most likely to fail.
+    expect(files.length).toBeGreaterThan(0);
+
+    const findings = files.flatMap(findingsIn);
+    expect(findings, `\n${findings.join("\n")}\n`).toEqual([]);
+  });
+});

--- a/frontend/src/screens/preferences.tsx
+++ b/frontend/src/screens/preferences.tsx
@@ -137,17 +137,18 @@ function PreferenceCenterBody({ token }: Readonly<{ token: string }>) {
     }
   }, [center.data]);
 
+  // The draft arrives as the mutation's variable rather than through this
+  // closure. react-query re-arms a mutation's options in a passive effect, so a
+  // click landing between the commit that renders Save and that effect runs the
+  // previous render's function — where the draft was still null. The guard that
+  // used to stand here could only ever fire in that window, and what it
+  // reported was false: the subject's choices were on the screen.
   const save = useMutation({
-    mutationFn: async () => {
-      if (!draft) {
-        // The Save button only renders once the draft is seeded — this
-        // guard only protects a stale closure, never a real path.
-        throw new Error("preferences not loaded yet");
-      }
+    mutationFn: async (choices: Draft) => {
       const { data, error } = await api.PUT("/public/preferences/{token}", {
         params: { path: { token } },
         body: {
-          choices: toChoices(purposes, draft, (key) => wordingByKey[key]),
+          choices: toChoices(purposes, choices, (key) => wordingByKey[key]),
         },
       });
       if (error) {
@@ -380,7 +381,7 @@ function PreferenceCenterBody({ token }: Readonly<{ token: string }>) {
               <Button
                 variant="primary"
                 disabled={writePending}
-                onClick={() => save.mutate()}
+                onClick={() => draft && save.mutate(draft)}
               >
                 {t("prefs.save")}
               </Button>

--- a/frontend/src/screens/privacy.tsx
+++ b/frontend/src/screens/privacy.tsx
@@ -693,23 +693,27 @@ function FulfilErasureModal({
   const queryClient = useQueryClient();
   const [typed, setTyped] = useState("");
 
+  // Both the staged request and the operator's resolution arrive as the
+  // mutation's variable rather than through this closure. react-query re-arms
+  // a mutation's options in a passive effect, so a confirm landing between the
+  // commit that stages a request and that effect runs the previous render's
+  // function. On the most destructive action in the product that matters twice
+  // over: read through a stale closure, `dsr` is null and the erasure refuses,
+  // and `resolution` is whatever the operator had typed one render ago.
   const patch = useMutation({
-    mutationFn: async () => {
-      if (!dsr) {
-        // The confirm button only exists while a request is staged in
-        // `dsr` — this guard only protects a stale closure, never a real path.
-        throw new Error("no request selected");
-      }
+    mutationFn: async (
+      fulfilment: Readonly<{ request: DataSubjectRequest; resolution: string }>,
+    ) => {
       const body: UpdateDataSubjectRequest = { status: "fulfilled" };
       // Same omit-if-blank rule as the row's own plain PATCH above: a blank
       // resolution key would still be a value the server writes over
       // whatever it already had stored, so it only rides along when there is
       // something to write.
-      if (resolution.trim()) {
-        body.resolution = resolution.trim();
+      if (fulfilment.resolution.trim()) {
+        body.resolution = fulfilment.resolution.trim();
       }
       const { data, error } = await api.PATCH("/data-subject-requests/{id}", {
-        params: { path: { id: dsr.id } },
+        params: { path: { id: fulfilment.request.id } },
         body,
       });
       if (error) {
@@ -769,7 +773,7 @@ function FulfilErasureModal({
       confirmDisabled={
         typed.trim().toUpperCase() !== "ERASE" || held || movedOn
       }
-      onConfirm={() => dsr && patch.mutate()}
+      onConfirm={() => dsr && patch.mutate({ request: dsr, resolution })}
       pending={patch.isPending}
       error={errorMessage}
     >

--- a/frontend/src/screens/relationships.tsx
+++ b/frontend/src/screens/relationships.tsx
@@ -307,13 +307,12 @@ function AddRelationshipAction({
     };
   }, [open, term, entity]);
 
+  // The picked target arrives as the mutation's variable, not through this
+  // closure: react-query re-arms a mutation's options in a passive effect, so a
+  // submit landing between the commit that enables the button and that effect
+  // runs the previous render's function — where nothing had been picked yet.
   const mutation = useMutation({
-    mutationFn: async () => {
-      if (!target) {
-        // The submit button is disabled until a target is picked — this
-        // guard only protects against a stale closure, never a real path.
-        throw new Error("no target selected");
-      }
+    mutationFn: async (target: Candidate) => {
       const body: CreateRelationshipRequest = {
         kind,
         role: role.trim() || undefined,
@@ -457,7 +456,7 @@ function AddRelationshipAction({
               small
               variant="primary"
               disabled={!target || mutation.isPending}
-              onClick={() => mutation.mutate()}
+              onClick={() => target && mutation.mutate(target)}
               data-testid="add-relationship-submit"
             >
               {t("create.save")}

--- a/frontend/src/screens/share.tsx
+++ b/frontend/src/screens/share.tsx
@@ -365,13 +365,12 @@ function ShareScreenBody({
     setReason("");
   }
 
+  // The picked subject arrives as the mutation's variable, not through this
+  // closure: react-query re-arms a mutation's options in a passive effect, so a
+  // submit landing between the commit that enables the button and that effect
+  // runs the previous render's function — where nothing had been picked yet.
   const grant = useMutation({
-    mutationFn: async () => {
-      if (!subject) {
-        // The submit button is disabled until a subject is picked — this
-        // guard only protects a stale closure, never a real path.
-        throw new Error("no subject selected");
-      }
+    mutationFn: async (subject: RosterSubject) => {
       const body: CreateRecordGrantRequest = {
         record_type: recordType,
         record_id: recordId,
@@ -568,7 +567,7 @@ function ShareScreenBody({
           <Button
             variant="primary"
             disabled={!subject || grant.isPending}
-            onClick={() => grant.mutate()}
+            onClick={() => subject && grant.mutate(subject)}
             data-testid="share-grant-submit"
           >
             {t("share.grant")}


### PR DESCRIPTION
Consolidates the company-context flake family (#545, #652, #782, #981) and fixes what it turned out to be hiding.

## The family was one bug, and it was already fixed

All three original reports share one signature: a 10-second waiter expiring, which #652's investigator correctly read as *"not merely late — never settled."* #545 caught it in the act, with the DOM dump showing `Add a company website before refreshing.` The click landed and the mutation refused it.

Why, confirmed at the library level in the installed `@tanstack/react-query` 5.101.2 (`useMutation.js:20-22`):

```js
React.useEffect(() => {
  observer.setOptions(options);
}, [observer, options]);
```

That is a **passive** effect. Between the commit that renders an enabled button and that effect, the observer holds the previous render's closure — where `form` was `null`.

`10c5103a` (#878, 2026-08-11) fixed it for `startRefresh` by passing the website as the mutation's variable. Evidence it holds: 6/6 local full-suite runs under CI's exact command, and **23 post-fix CI runs that executed `fe-unit` — 18 of which failed for other reasons, with company-context passing in all 18.** Pre-fix the rate was ~17% (#782: 2 in ~12).

#981's stated mechanism — "under parallel load the review render takes longer than that budget" — is refuted by measurement: the file takes **271ms inside the full suite** against 192ms isolated. 1.4×, not the 40× needed to exhaust a 10s waiter.

## What that investigation actually found

`10c5103a` fixed one mutation and left six. Five carry a copy-pasted comment recording the gap instead of closing it:

| Site | Guard | Comment |
|---|---|---|
| `company-context.tsx:359` | `if (!siteRead.data \|\| !form)` | *none* |
| `preferences.tsx:142` | `if (!draft)` | "only protects a stale closure, never a real path" |
| `relationships.tsx:312` | `if (!target)` | "…never a real path" |
| `share.tsx:370` | `if (!subject)` | "…never a real path" |
| `privacy.tsx:698` | `if (!dsr)` | "…never a real path" |
| `compose.tsx:113` | `if (!target \|\| !kind)` | "the confirm is disabled without a target…" |

The comments have it backwards. The guard does not *protect* against the stale closure — it is what **fires** when one happens, and what it does is tell a user with a filled form that there is nothing to submit. `company-context`'s confirm proves it: `RefreshReview` renders only when `siteRead.data` is truthy (`:486`), nested inside `form &&` (`:414`), so at the render where Apply exists both values are non-null and the guard is unreachable except through the window.

Two sites are worse than a refusal. `company-context`'s confirm also reads `selected` and `resolutions` through the closure, and `privacy`'s fulfil reads `resolution` — where a stale value is not a refusal but a payload of choices nobody made, on the most destructive action in the product.

`compose.tsx` is the one partial case: its guard has a second, genuine cause (`kindOf` can legitimately return null for a lost remembered kind), so only the `target` half is the closure defect. That guard stays, narrowed.

`auth.tsx:594` matches the grep but is **not** in the class — its `if (!result)` follows a `.catch(() => null)` and is a real network-failure path.

## The fix

Each site takes what it needs as the mutation's variable, passed by a click handler that belongs to the committed render — a variable cannot be older than the control that carries it. The guards go with them, and so does `settings.companyRefreshUnavailable` (all three catalogs), whose last caller was one of them. A refusal string with no reachable path is the proof the state cannot arise.

`renderReview` in the company-context suite now makes the same wait its sibling `clickRefresh` already made four lines down, and `TEST_MS` grows to cover the fourth waiter — the file's own comment requires the budget to cover every waiter in sequence.

## The gate, and that it fails on the defect

`mutation-variable-coverage.test.ts` walks the TSX with the TypeScript compiler API for a zero-parameter `mutationFn` that refuses on a falsy check of a value it closed over. Written before the fixes and run against the unfixed tree:

```
screens/company-context.tsx:359 — mutationFn takes no variable and refuses on closed-over `siteRead`, `form`
screens/compose.tsx:113        — … `target`
screens/preferences.tsx:142    — … `draft`
screens/privacy.tsx:698        — … `dsr`
screens/relationships.tsx:312  — … `target`
screens/share.tsx:370          — … `subject`
```

It also flagged `compose.tsx:1211`, which was a **false positive in the gate** — `response` is destructured from an `await`, and the local-name walker only recorded plain-identifier declarations, not binding patterns. Fixed before relying on it; that site is correctly silent now. The first version had also found `company-context.tsx:359` before the grep behind this change did.

Its header states what it deliberately does not catch — an *unguarded* closure read, which needs the type checker to separate component state from a stable prop — following the precedent in `check-ci-doc-parity.sh`, because a gate whose rules are fiddly is one that gets worked around rather than fixed.

## Verification

- Gate: 6 findings before, 0 after.
- Every touched screen's suite: 132 tests pass.
- `make check-fe` green (frontend-check + fe-test-ext).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale-closure bugs by passing current values as mutation variables instead of reading from closures, preventing false “nothing to submit” errors and stale payloads. Hardens the mutation gate to only scan mutation files and sets an explicit time budget so it doesn’t race CI.

- **Bug Fixes**
  - Mutations now take variables in: `company-context` confirm, `compose` relink (target only), `preferences` save, `privacy` erasure fulfil, `relationships` add, `share` grant. Removed stale guards and the unreachable `settings.companyRefreshUnavailable` string.
  - `company-context` test: added an explicit wait for the website field and increased `TEST_MS` to cover four sequential waits.

- **New Features**
  - Added `mutation-variable-coverage.test.ts`: scans `.tsx` for zero-parameter `mutationFn` that throws based on closed-over state to prevent regressions with `@tanstack/react-query` mutations. Now prefilters to files containing `mutationFn`, asserts non-empty sweeps, and uses a stated parse budget to avoid CI timeouts.

<sup>Written for commit 40d23e58eb47a160d0cef04b541a076f90eb5999. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/995?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

