### PR TITLE
test(onboarding): the wait for a second poll is derived from the poll

### DIFF
--- a/frontend/src/screens/onboarding-conversation/use-company-read.ts
+++ b/frontend/src/screens/onboarding-conversation/use-company-read.ts
@@ -85,6 +85,15 @@ type UseCompanyReadArgs = Readonly<{
   adoptedRead?: CompanySiteRead | null;
 }>;
 
+/**
+ * How often an in-flight site read is re-fetched while it is still queued or
+ * reading. Exported because a test that waits for the SECOND poll is waiting on
+ * this cadence, and a budget written as a round number cannot be seen to
+ * disagree with it — the disagreement surfaces only as a flake on a loaded
+ * machine.
+ */
+export const READ_POLL_MS = 800;
+
 export function useCompanyRead({
   dispatch,
   machine,
@@ -283,7 +292,7 @@ export function useCompanyRead({
     refetchInterval: (query) => {
       const status = query.state.data?.status;
       if (status === "queued" || status === "reading") {
-        return 800;
+        return READ_POLL_MS;
       }
       return status === "deferred" ? 60_000 : false;
     },

--- a/frontend/src/screens/onboarding.test.tsx
+++ b/frontend/src/screens/onboarding.test.tsx
@@ -428,10 +428,12 @@ describe("the conversational company act", () => {
     await userEvent.type(icp, "Owner-led manufacturers");
 
     // This waits for a COUNT of polls, not for a condition the render reaches,
-    // so it cannot succeed before the cadence has run twice however fast the
-    // machine is. Derived from the cadence for that reason: a round 3000ms left
-    // 1400ms of headroom over two 800ms periods, which a loaded runner spends
-    // on scheduling alone.
+    // so it cannot succeed before the cadence has run EXPECTED_READS times
+    // however fast the machine is. The budget is therefore a multiple of that
+    // floor rather than a number of its own: four cadence periods of headroom
+    // over the two it must outlast, which is what a loaded runner spends on
+    // scheduling. A budget written independently of the cadence cannot be seen
+    // to disagree with it.
     await waitFor(
       () => {
         const reads = calls.filter(

--- a/frontend/src/screens/onboarding.test.tsx
+++ b/frontend/src/screens/onboarding.test.tsx
@@ -13,6 +13,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { components } from "../api/schema";
 import { LocaleProvider } from "../i18n";
 import { OnboardingScreen } from "./onboarding";
+import { READ_POLL_MS } from "./onboarding-conversation/use-company-read";
 
 // The onboarding invariants that survived the conversational flip, driven
 // through the ONE onboarding surface (the conversational shell): honest
@@ -360,6 +361,11 @@ beforeEach(() => {
   vi.stubGlobal("scrollTo", vi.fn());
 });
 
+// The second dossier is the whole point of the case below: the first poll
+// carries the reading snapshot, the second the completed one that must not
+// clobber what the administrator typed.
+const EXPECTED_READS = 2;
+
 describe("the conversational company act", () => {
   it("loads the detailed AI profile after the public login profile was cached", async () => {
     const calls = stubApi();
@@ -421,6 +427,11 @@ describe("the conversational company act", () => {
     await userEvent.clear(icp);
     await userEvent.type(icp, "Owner-led manufacturers");
 
+    // This waits for a COUNT of polls, not for a condition the render reaches,
+    // so it cannot succeed before the cadence has run twice however fast the
+    // machine is. Derived from the cadence for that reason: a round 3000ms left
+    // 1400ms of headroom over two 800ms periods, which a loaded runner spends
+    // on scheduling alone.
     await waitFor(
       () => {
         const reads = calls.filter(
@@ -428,9 +439,9 @@ describe("the conversational company act", () => {
             request.method === "GET" &&
             request.url.includes("/company/site-reads/"),
         );
-        expect(reads.length).toBeGreaterThanOrEqual(2);
+        expect(reads.length).toBeGreaterThanOrEqual(EXPECTED_READS);
       },
-      { timeout: 3_000 },
+      { timeout: READ_POLL_MS * EXPECTED_READS * 5 },
     );
     expect(icp.value).toBe("Owner-led manufacturers");
   });


### PR DESCRIPTION
Found while investigating #998. Fixed on its own merit — see the honesty note at the bottom about what this does **not** claim.

## The defect

`onboarding.test.tsx` › *preserves administrator typing when a newer streamed dossier arrives* waits for a **count of polls**, not for a condition the render reaches:

```ts
expect(reads.length).toBeGreaterThanOrEqual(2);
}, { timeout: 3_000 });
```

That shape cannot succeed before the poll cadence has run twice, however fast the machine is. The cadence is `800`, hard-coded in `use-company-read.ts`:

```ts
if (status === "queued" || status === "reading") {
  return 800;
}
```

So the real headroom is `3000 − (2 × 800) = 1400ms`, and the test spends part of it before the wait even starts — a click, a clear, and 23 keystrokes of `userEvent.type`. Nothing in either file made the relationship visible: `800` lived in the hook, `3000` in the test, and no expression related them.

## The fix

The cadence becomes a named export the hook itself uses, and the test derives its budget from that constant and the number of reads it waits for. The two can no longer drift apart silently, and a reader of either sees which one the other depends on.

## Scope, deliberately

Other onboarding suites carry round budgets too (1000, 2500, 4000, 8000). They are left alone: each waits on a **condition** — an element enabled, a text present — so it completes as soon as the condition holds and a generous round number is merely unprincipled, not structurally racing a cadence. This one is the outlier, and it is the only poll-count wait in the tree.

## What this does not claim

It does **not** claim to fix #998. That report was two suites failing together in one local run, and:

- not reproduced in **9** further full-suite runs under CI's exact command;
- **0** occurrences across 21 `fe-unit`-failing CI runs.

The other test named in #998 (`onboarding-facts.test.tsx`) has no waiters at all — `await user.click(...)` then synchronous assertions — so it can only fail by exceeding vitest's 5s default, which needs a machine far more loaded than CI's. #998 stays open with these measurements recorded.

## Verification

Full suite under CI's exact `fe-unit` command: 187 files, 2281 tests, green. Biome clean over 575 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the onboarding poll interval a shared constant and derive the test timeout from it to prevent flakes when waiting for the second poll. This keeps the hook’s cadence and the test’s wait budget in sync.

- **Bug Fixes**
  - Exported `READ_POLL_MS = 800` from `use-company-read` and used it in `refetchInterval`.
  - Updated `onboarding.test.tsx` to wait for `EXPECTED_READS = 2`, compute timeout as `READ_POLL_MS * EXPECTED_READS * 5`, and clarify the comment to describe the rule.

<sup>Written for commit 4531588a3f75b2028e31dc8d35cd64f3e3113e74. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1000?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the consistency of onboarding site-read polling by using a shared polling interval.
* **Tests**
  * Updated onboarding coverage to validate the expected number of site-read polls and ensure administrator-entered information remains preserved during the process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->