### PR TITLE
refactor(modules): the fleet-held stores take a bound handle too

### DIFF
--- a/backend/internal/compose/captureautoenrich.go
+++ b/backend/internal/compose/captureautoenrich.go
@@ -85,7 +85,7 @@ func newCaptureAutoEnrichSweepWorker(pool *pgxpool.Pool, log *slog.Logger) *capt
 		pool:       pool,
 		people:     people.NewStore(InstallationDB(pool)),
 		settings:   capture.NewSettings(NewSettingsStore(pool)),
-		autoEnrich: capture.NewAutoEnrichStore(pool),
+		autoEnrich: capture.NewAutoEnrichStore(InstallationDB(pool)),
 		dailyCap:   autoEnrichDailyCap,
 		log:        log,
 	}

--- a/backend/internal/compose/captureautoenrich_integration_test.go
+++ b/backend/internal/compose/captureautoenrich_integration_test.go
@@ -28,7 +28,7 @@ import (
 func TestAutoEnrichLaneAppliesDirectlyInsteadOfStaging(t *testing.T) {
 	e := integration.Setup(t)
 	org := insertOrg(t, e, e.Rep1, "acme.example", "")
-	store := capture.NewAutoEnrichStore(e.Pool)
+	store := capture.NewAutoEnrichStore(e.DB())
 	worker, _ := newDeepReadTestWorker(e, acmeDeepSite(), acmeDeepBrain())
 
 	// The dossier is created system-requested (as the sweep does), and its
@@ -100,7 +100,7 @@ func insertDomainOrg(t *testing.T, e *integration.Env, domain string) ids.Organi
 
 func TestAutoEnrichStoreEligibilityAndCap(t *testing.T) {
 	e := integration.Setup(t)
-	store := capture.NewAutoEnrichStore(e.Pool)
+	store := capture.NewAutoEnrichStore(e.DB())
 	ctx := e.As(e.Rep1, nil, integration.AdminPerms)
 
 	// Two captured domain-named orgs are due; a human-named org (from insertOrg,
@@ -162,7 +162,7 @@ func TestTheInstallationsOwnCompanyIsNeverSwept(t *testing.T) {
 	// from a swept company in exactly the thing the sweep selects on, and the
 	// exclusion is the point rather than an oversight.
 	e := integration.Setup(t)
-	store := capture.NewAutoEnrichStore(e.Pool)
+	store := capture.NewAutoEnrichStore(e.DB())
 	ctx := e.As(e.Rep1, nil, integration.AdminPerms)
 
 	website := "https://anchor.example"
@@ -188,7 +188,7 @@ func TestACancelledReadDoesNotRetireAnOrgForever(t *testing.T) {
 	// reach that company, or the sweep's self-healing stops at exactly the orgs
 	// the setting stopped.
 	e := integration.Setup(t)
-	store := capture.NewAutoEnrichStore(e.Pool)
+	store := capture.NewAutoEnrichStore(e.DB())
 	ctx := e.As(e.Rep1, nil, integration.AdminPerms)
 
 	cancelled := insertDomainOrg(t, e, "offagain.example")
@@ -207,7 +207,7 @@ func TestACancelledReadDoesNotRetireAnOrgForever(t *testing.T) {
 
 func TestAutoEnrichExpireExhausted(t *testing.T) {
 	e := integration.Setup(t)
-	store := capture.NewAutoEnrichStore(e.Pool)
+	store := capture.NewAutoEnrichStore(e.DB())
 	ctx := e.As(e.Rep1, nil, integration.AdminPerms)
 	org := insertDomainOrg(t, e, "fail.example")
 

--- a/backend/internal/compose/capturedomaintriage.go
+++ b/backend/internal/compose/capturedomaintriage.go
@@ -42,7 +42,7 @@ func newDomainTriageTrigger(pool *pgxpool.Pool, log *slog.Logger) *domainTriageT
 	return &domainTriageTrigger{
 		people:     people.NewStore(InstallationDB(pool)),
 		settings:   capture.NewSettings(NewSettingsStore(pool)),
-		autoEnrich: capture.NewAutoEnrichStore(pool),
+		autoEnrich: capture.NewAutoEnrichStore(InstallationDB(pool)),
 		dailyCap:   autoEnrichDailyCap,
 		log:        log,
 	}

--- a/backend/internal/compose/capturedomaintriage_integration_test.go
+++ b/backend/internal/compose/capturedomaintriage_integration_test.go
@@ -120,7 +120,7 @@ func TestTriageOnCaptureLeavesTheOrgToTheSweepAtTheDailyCap(t *testing.T) {
 	// round trips to demonstrate a bound that behaves identically at three, and
 	// the number under test is "the cap", not its value.
 	const testCap = 3
-	store := capture.NewAutoEnrichStore(e.Pool)
+	store := capture.NewAutoEnrichStore(e.DB())
 	for i := 0; i < testCap; i++ {
 		slot, err := store.ReserveBudget(e.Admin(), testCap)
 		if err != nil {
@@ -188,7 +188,7 @@ func TestTriageOnCaptureIgnoresAnEmptyDomain(t *testing.T) {
 // exactly the concurrency the cap is meant to be indifferent to.
 func TestAutoEnrichBudgetSlotIsReturnedWhenItBoughtNothing(t *testing.T) {
 	e := integration.Setup(t)
-	store := capture.NewAutoEnrichStore(e.Pool)
+	store := capture.NewAutoEnrichStore(e.DB())
 
 	const testCap = 3
 	var last capture.BudgetSlot
@@ -226,7 +226,7 @@ func TestAutoEnrichBudgetSlotIsReturnedWhenItBoughtNothing(t *testing.T) {
 // failure the cap exists to prevent.
 func TestAutoEnrichBudgetReleaseNeverGoesBelowZero(t *testing.T) {
 	e := integration.Setup(t)
-	store := capture.NewAutoEnrichStore(e.Pool)
+	store := capture.NewAutoEnrichStore(e.DB())
 
 	const testCap = 3
 	// The day comes from a real reservation rather than Go's clock: the counter
@@ -265,7 +265,7 @@ func TestAutoEnrichBudgetReleaseNeverGoesBelowZero(t *testing.T) {
 // cap.
 func TestAutoEnrichBudgetRefundNamesTheDayItWasReservedOn(t *testing.T) {
 	e := integration.Setup(t)
-	store := capture.NewAutoEnrichStore(e.Pool)
+	store := capture.NewAutoEnrichStore(e.DB())
 
 	// Yesterday relative to the DATABASE's day, taken from a real reservation —
 	// the counter is keyed on that day, not on the test process's clock.
@@ -305,7 +305,7 @@ func TestAutoEnrichBudgetRefundNamesTheDayItWasReservedOn(t *testing.T) {
 // leaking the slot in precisely the case it was written to handle.
 func TestAutoEnrichRefundSurvivesACancelledCaptureContext(t *testing.T) {
 	e := integration.Setup(t)
-	store := capture.NewAutoEnrichStore(e.Pool)
+	store := capture.NewAutoEnrichStore(e.DB())
 	slot, err := store.ReserveBudget(e.Admin(), 3)
 	if err != nil {
 		t.Fatal(err)

--- a/backend/internal/compose/captureverdict.go
+++ b/backend/internal/compose/captureverdict.go
@@ -109,7 +109,7 @@ type CounterpartyVerdictEngine struct {
 func NewCounterpartyVerdictEngine(pool *pgxpool.Pool, brain completer, log *slog.Logger) *CounterpartyVerdictEngine {
 	return &CounterpartyVerdictEngine{
 		pool:       pool,
-		pending:    capture.NewPendingStore(pool),
+		pending:    capture.NewPendingStore(InstallationDB(pool)),
 		people:     newCounterpartyStore(pool),
 		activities: activities.NewStore(InstallationDB(pool)),
 		approvals:  approvals.NewService(InstallationDB(pool)),

--- a/backend/internal/compose/coldstartaccept.go
+++ b/backend/internal/compose/coldstartaccept.go
@@ -56,7 +56,7 @@ func approvalsServiceWithEffects(pool *pgxpool.Pool) *approvals.Service {
 	svc.WithEffect(enrichProposalKind, scrapeAcceptEffect(svc, store))
 	svc.WithEffect(deepReadProposalKind, deepReadAcceptEffect(svc, store))
 	svc.WithEffect(siteLeadProposalKind, siteLeadAcceptEffect(svc, newCaptureSink(pool, CaptureConfig{})))
-	svc.WithEffect(counterpartyProposalKind, counterpartyAcceptEffect(svc, store, activities.NewStore(InstallationDB(pool)), capture.NewPendingStore(pool), newDomainTriageTrigger(pool, slog.Default())))
+	svc.WithEffect(counterpartyProposalKind, counterpartyAcceptEffect(svc, store, activities.NewStore(InstallationDB(pool)), capture.NewPendingStore(InstallationDB(pool)), newDomainTriageTrigger(pool, slog.Default())))
 	svc.WithEffect(orgNameProposalKind, orgNameAcceptEffect(svc, store))
 	svc.WithEffect(linkedInMatchKind, linkedInMatchAcceptEffect(svc, store))
 	svc.WithEffect(lifecycleProposalKind, lifecycleAcceptEffect(svc, store))

--- a/backend/internal/compose/deepread.go
+++ b/backend/internal/compose/deepread.go
@@ -148,7 +148,7 @@ func newSiteDeepReadWorker(pool *pgxpool.Pool, brain, factBrain, triageBrain com
 		blob:        blob,
 		approvals:   approvals.NewService(InstallationDB(pool)),
 		authority:   identity.NewService(pool),
-		autoEnrich:  capture.NewAutoEnrichStore(pool),
+		autoEnrich:  capture.NewAutoEnrichStore(InstallationDB(pool)),
 		settings:    capture.NewSettings(NewSettingsStore(pool)),
 		log:         log,
 		caps:        caps,

--- a/backend/internal/compose/deepread_integration_test.go
+++ b/backend/internal/compose/deepread_integration_test.go
@@ -98,7 +98,7 @@ func newDeepReadTestWorker(e *integration.Env, site *fakeSite, brain completer) 
 		// the REQUESTER's live grants, and a stub would let the tests pass
 		// while production asked the question with the wrong authority.
 		authority:  identity.NewService(e.Pool),
-		autoEnrich: capture.NewAutoEnrichStore(e.Pool),
+		autoEnrich: capture.NewAutoEnrichStore(e.DB()),
 		settings:   capture.NewSettings(NewSettingsStore(e.Pool)),
 		log:        slog.New(slog.NewTextHandler(io.Discard, nil)),
 	}, svc

--- a/backend/internal/compose/deepreadtransport.go
+++ b/backend/internal/compose/deepreadtransport.go
@@ -246,7 +246,7 @@ func WithDeepRead(inserter *jobs.Runner, brain completer) Option {
 			state: s.state, people: people.NewStore(InstallationDB(pool)),
 			brain: brain, runtime: ai.NewRunTransparency(InstallationDB(pool)),
 			rollout: &s.companyContextRollout,
-			voice:   ai.NewVoiceStore(pool),
+			voice:   ai.NewVoiceStore(InstallationDB(pool)),
 			company: people.NewStore(InstallationDB(pool)),
 		}
 	}

--- a/backend/internal/compose/deepreadtriage_integration_test.go
+++ b/backend/internal/compose/deepreadtriage_integration_test.go
@@ -53,7 +53,7 @@ func newTriageTestWorker(e *integration.Env, site *fakeSite, extractBrain comple
 		triageBrain: triage,
 		approvals:   svc,
 		authority:   identity.NewService(e.Pool),
-		autoEnrich:  capture.NewAutoEnrichStore(e.Pool),
+		autoEnrich:  capture.NewAutoEnrichStore(e.DB()),
 		settings:    capture.NewSettings(NewSettingsStore(e.Pool)),
 		log:         slog.New(slog.NewTextHandler(io.Discard, nil)),
 	}

--- a/backend/internal/compose/flip.go
+++ b/backend/internal/compose/flip.go
@@ -68,7 +68,7 @@ type flipRunner struct {
 var _ overlay.FlipRunner = (*flipRunner)(nil)
 
 func newFlipRunner(pool *pgxpool.Pool, svc *overlay.Service, ms *overlay.MirrorStore, log *slog.Logger) *flipRunner {
-	return &flipRunner{pool: pool, svc: svc, ms: ms, runs: migration.NewRunStore(pool), log: log}
+	return &flipRunner{pool: pool, svc: svc, ms: ms, runs: migration.NewRunStore(InstallationDB(pool)), log: log}
 }
 
 // Preflight is OVA-WIRE-7: {ready, blocking[], unresolved_conflicts[]}

--- a/backend/internal/compose/flipbundle.go
+++ b/backend/internal/compose/flipbundle.go
@@ -172,7 +172,11 @@ func reconstructFromBundle(ctx context.Context, pool *pgxpool.Pool, bundle []byt
 	if err != nil {
 		return migration.Report{}, err
 	}
-	runs := migration.NewRunStore(pool)
+	db, err := actingWorkspaceDB(ctx, pool)
+	if err != nil {
+		return migration.Report{}, err
+	}
+	runs := migration.NewRunStore(db)
 	// Everything that can still fail happens BEFORE the run row exists.
 	// Only the engine needs a run id, so an early return here cannot
 	// strand a row at `running` with an empty error column — a state
@@ -209,10 +213,6 @@ func reconstructFromBundle(ctx context.Context, pool *pgxpool.Pool, bundle []byt
 	// unresolvedOwnerEmails, not nil: this path never resolves an owner
 	// email (owners come from the bundle's own map), and a fail-loud
 	// placeholder beats a nil-interface panic if that stops being true.
-	db, err := actingWorkspaceDB(ctx, pool)
-	if err != nil {
-		return migration.Report{}, err
-	}
 	writers := newFlipWriters(db, overlay.NewMirrorStore(db, unresolvedOwnerEmails{}), contents.incumbent).
 		forRun(run.ID, operator).
 		WithOwnerMap(owners)

--- a/backend/internal/compose/flipwriters.go
+++ b/backend/internal/compose/flipwriters.go
@@ -101,7 +101,7 @@ func newFlipWriters(db *database.DB, ms *overlay.MirrorStore, incumbent string) 
 		deals:      deals.NewStore(db, DealsInstallation()),
 		activities: activities.NewStore(db),
 		ms:         ms,
-		identities: migration.NewRunStore(pool),
+		identities: migration.NewRunStore(db),
 		incumbent:  incumbent,
 		nativeIDs:  map[string]ids.UUID{},
 	}

--- a/backend/internal/compose/integration/capture/capture_ledger_integration_test.go
+++ b/backend/internal/compose/integration/capture/capture_ledger_integration_test.go
@@ -83,7 +83,7 @@ func TestCaptureLedgerStopsDeferringAtTheWorkspaceCeiling(t *testing.T) {
 func TestCaptureLedgerRefusesAVerdictFromAnExpiredClaim(t *testing.T) {
 	env := newCaptureEnv(t)
 	e, sync := env.e, env.sync
-	store := capturemod.NewPendingStore(e.Pool)
+	store := capturemod.NewPendingStore(e.DB())
 	wsCtx := principal.WithWorkspaceID(context.Background(), e.WS)
 
 	sync(t, email("contested@stranger.example", "Contested", captureOwner, "led3@stranger.example", ""))

--- a/backend/internal/compose/integration/overlay/overlay_flipclaim_integration_test.go
+++ b/backend/internal/compose/integration/overlay/overlay_flipclaim_integration_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/gradionhq/margince/backend/internal/compose"
 	"github.com/gradionhq/margince/backend/internal/modules/migration"
+	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
@@ -56,7 +57,7 @@ func (f flipEstate) flipLiveness(t *testing.T) bool {
 // the probe that survives a crash.
 func (f flipEstate) startMirrorRun(t *testing.T, snapshot string) {
 	t.Helper()
-	if _, err := migration.NewRunStore(f.pool).Create(f.adminCtx, migration.CreateRunInput{
+	if _, err := migration.NewRunStore(database.BindTo(f.pool, ids.From[ids.WorkspaceKind](f.wsID))).Create(f.adminCtx, migration.CreateRunInput{
 		Connector: migration.ConnectorMirror, SourceRef: snapshot, Source: "overlay:flip",
 	}); err != nil {
 		t.Fatalf("creating the mirror run: %v", err)

--- a/backend/internal/compose/integration/voice_integration_test.go
+++ b/backend/internal/compose/integration/voice_integration_test.go
@@ -396,7 +396,10 @@ func TestVoiceProfileIsInvisibleAcrossTenants(t *testing.T) {
 		},
 	})
 
-	store := ai.NewVoiceStore(e.Pool)
+	// Tenant B asks through a store of its own: the workspace a read is scoped
+	// to is the handle's, so this tenant's store would answer this tenant's
+	// rows and the existence-hiding claim would be vacuous.
+	store := ai.NewVoiceStore(e.DBFor(wsB))
 	profileID, err := ids.Parse(created.ID)
 	if err != nil {
 		t.Fatalf("created profile id: %v", err)

--- a/backend/internal/compose/integration/voicestore_integration_test.go
+++ b/backend/internal/compose/integration/voicestore_integration_test.go
@@ -70,7 +70,7 @@ func seedVoiceCandidate(t *testing.T, pool *pgxpool.Pool, workspaceID, profileID
 
 func TestVoiceProfileAndCorpusAreOwnerPrivate(t *testing.T) {
 	e := Setup(t)
-	voice := ai.NewVoiceStore(e.Pool)
+	voice := ai.NewVoiceStore(e.DB())
 
 	owner := e.As(e.Rep1, []ids.UUID{e.Team1}, voiceRepPerms)
 	created, err := voice.CreateProfile(owner, ai.CreateVoiceProfileInput{})
@@ -190,7 +190,7 @@ Kurz: das Angebot steht, Freitag entscheiden wir.
 
 func TestVoiceDerivedRebuildVersionsArtifactAndPreservesIdentity(t *testing.T) {
 	e := Setup(t)
-	voice := ai.NewVoiceStore(e.Pool)
+	voice := ai.NewVoiceStore(e.DB())
 	owner := e.As(e.Rep1, []ids.UUID{e.Team1}, voiceRepPerms)
 
 	created, err := voice.CreateProfile(owner, ai.CreateVoiceProfileInput{
@@ -350,7 +350,7 @@ func TestVoiceDerivedRebuildVersionsArtifactAndPreservesIdentity(t *testing.T) {
 func TestVoiceCandidateTransitionsUseCandidateConcurrencyAndForwardRollback(t *testing.T) {
 	e := Setup(t)
 	ownerDB := SchemaPool(t)
-	voice := ai.NewVoiceStore(e.Pool)
+	voice := ai.NewVoiceStore(e.DB())
 	owner := e.As(e.Rep1, []ids.UUID{e.Team1}, voiceRepPerms)
 	profile, err := voice.CreateProfile(owner, ai.CreateVoiceProfileInput{})
 	if err != nil {
@@ -410,7 +410,7 @@ func TestVoiceCandidateTransitionsUseCandidateConcurrencyAndForwardRollback(t *t
 func TestVoiceConcurrentBuildRequestsConvergeOnOneDurableRow(t *testing.T) {
 	e := Setup(t)
 	ownerDB := SchemaPool(t)
-	voice := ai.NewVoiceStore(e.Pool)
+	voice := ai.NewVoiceStore(e.DB())
 	owner := e.As(e.Rep1, []ids.UUID{e.Team1}, voiceRepPerms)
 	profile, err := voice.CreateProfile(owner, ai.CreateVoiceProfileInput{})
 	if err != nil {
@@ -468,7 +468,7 @@ func TestVoiceConcurrentBuildRequestsConvergeOnOneDurableRow(t *testing.T) {
 func TestVoiceDraftRejectionIsIdempotentAndTerminalSafe(t *testing.T) {
 	e := Setup(t)
 	ownerDB := SchemaPool(t)
-	voice := ai.NewVoiceStore(e.Pool)
+	voice := ai.NewVoiceStore(e.DB())
 	owner := e.As(e.Rep1, []ids.UUID{e.Team1}, voiceRepPerms)
 	profile, err := voice.CreateProfile(owner, ai.CreateVoiceProfileInput{})
 	if err != nil {
@@ -538,7 +538,7 @@ func TestVoiceDraftRejectionIsIdempotentAndTerminalSafe(t *testing.T) {
 func TestVoiceClearCorpusScrubsQualifyingLearningSignal(t *testing.T) {
 	e := Setup(t)
 	ownerDB := SchemaPool(t)
-	voice := ai.NewVoiceStore(e.Pool)
+	voice := ai.NewVoiceStore(e.DB())
 	owner := e.As(e.Rep1, []ids.UUID{e.Team1}, voiceRepPerms)
 	profile, err := voice.CreateProfile(owner, ai.CreateVoiceProfileInput{})
 	if err != nil {

--- a/backend/internal/compose/jobs.go
+++ b/backend/internal/compose/jobs.go
@@ -346,7 +346,7 @@ func addModelLaneJobs(reg *jobRegistry, pool *pgxpool.Pool, cfg JobRunnerConfig,
 		newSiteDeepReadWorker(pool, cfg.DeepReadBrain, cfg.DeepReadFactBrain, cfg.DeepReadTriageBrain, log, cfg.DeepReadCaps, cfg.Blobstore),
 		deepReadTimeout(cfg.DeepReadCaps))
 	addDeclaredWorker[VoiceBuildArgs](reg, newVoiceBuildWorker(pool, cfg.VoiceBrain, log))
-	addDeclaredWorker[VoiceBuildRetryArgs](reg, &voiceBuildRetryWorker{store: ai.NewVoiceStore(pool), log: log})
+	addDeclaredWorker[VoiceBuildRetryArgs](reg, &voiceBuildRetryWorker{store: ai.NewVoiceStore(InstallationDB(pool)), log: log})
 	// The reindex is a dispatcher plus a workspace worker, and neither is
 	// ticked: the api enqueues the dispatcher once per confirmed reindex
 	// (jobs_embedreindex.go).

--- a/backend/internal/compose/replydraft.go
+++ b/backend/internal/compose/replydraft.go
@@ -78,7 +78,7 @@ func newReplyDrafter(pool *pgxpool.Pool, brain completer, log *slog.Logger) repl
 		brain:    brain,
 		envelope: draftEnvelope(pool, log),
 		store:    activities.NewStore(InstallationDB(pool)),
-		voice:    ai.NewVoiceStore(pool),
+		voice:    ai.NewVoiceStore(InstallationDB(pool)),
 		log:      log,
 	}
 }

--- a/backend/internal/compose/sendpath.go
+++ b/backend/internal/compose/sendpath.go
@@ -77,7 +77,7 @@ type SendPath struct {
 // learning loop exists.
 func (p SendPath) withPoolDefaults(pool *pgxpool.Pool) SendPath {
 	if p.DraftOutcome == nil {
-		p.DraftOutcome = ai.NewVoiceStore(pool)
+		p.DraftOutcome = ai.NewVoiceStore(InstallationDB(pool))
 	}
 	if p.ChannelRecipients == nil {
 		p.ChannelRecipients = channelReachability{}

--- a/backend/internal/compose/sendvoiceoutcome_integration_test.go
+++ b/backend/internal/compose/sendvoiceoutcome_integration_test.go
@@ -346,9 +346,9 @@ func TestConcurrentSendsSharingADraftReferenceLeaveOneOutcomeAndBothTransmit(t *
 	draft := e.openDraft(t)
 
 	winner := gatedDraftOutcome{
-		inner: ai.NewVoiceStore(e.Pool), locked: make(chan int32), release: make(chan struct{}),
+		inner: ai.NewVoiceStore(e.DB()), locked: make(chan int32), release: make(chan struct{}),
 	}
-	loser := &witnessDraftOutcome{inner: ai.NewVoiceStore(e.Pool)}
+	loser := &witnessDraftOutcome{inner: ai.NewVoiceStore(e.DB())}
 	winnerStager, loserStager := &recordingStager{}, &recordingStager{}
 	winnerStore := sendStore(e.Pool, SendPath{
 		PublicBaseURL: voiceSendBaseURL, Delivery: winnerStager, DraftOutcome: winner,

--- a/backend/internal/compose/voicebuild.go
+++ b/backend/internal/compose/voicebuild.go
@@ -111,7 +111,7 @@ type voiceBuildWorker struct {
 }
 
 func newVoiceBuildWorker(pool *pgxpool.Pool, brain completer, log *slog.Logger) *voiceBuildWorker {
-	return &voiceBuildWorker{store: ai.NewVoiceStore(pool), brain: brain, log: log, now: time.Now}
+	return &voiceBuildWorker{store: ai.NewVoiceStore(InstallationDB(pool)), brain: brain, log: log, now: time.Now}
 }
 
 // reclaimAfter leaves a grace beyond the work timeout before a replacement

--- a/backend/internal/compose/voicebuild_integration_test.go
+++ b/backend/internal/compose/voicebuild_integration_test.go
@@ -162,7 +162,7 @@ type voiceBuildEnv struct {
 func seedVoiceBuild(t *testing.T, quote string, sourceCount int) (*voiceBuildEnv, ai.VoiceBuild) {
 	t.Helper()
 	e := integration.Setup(t)
-	store := ai.NewVoiceStore(e.Pool)
+	store := ai.NewVoiceStore(e.DB())
 	owner := e.As(e.Rep1, []ids.UUID{e.Team1}, voiceBuildPerms)
 	profile, err := store.CreateProfile(owner, ai.CreateVoiceProfileInput{})
 	if err != nil {

--- a/backend/internal/modules/ai/handlers_voice.go
+++ b/backend/internal/modules/ai/handlers_voice.go
@@ -52,7 +52,7 @@ type Handlers struct {
 // every other tenant read.
 func NewHandlers(db *database.DB, budget BudgetPolicy) Handlers {
 	return Handlers{
-		voice: NewVoiceStore(db.Pool()), meter: NewMeter(db), budget: budget,
+		voice: NewVoiceStore(db), meter: NewMeter(db), budget: budget,
 		calls: NewCallReadStore(db), rates: NewRateStore(db),
 		feedback:      NewFeedbackStore(db),
 		publicProfile: NewPublicProfile("unconfigured", RoutingConfig{}),

--- a/backend/internal/modules/ai/voice.go
+++ b/backend/internal/modules/ai/voice.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgxpool"
 	openapi_types "github.com/oapi-codegen/runtime/types"
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
@@ -38,16 +37,19 @@ import (
 // (tableownership: this module). The profile half lives here; the
 // corpus-source half (ingest, manifest, meter) is voicesources.go.
 type VoiceStore struct {
-	pool *pgxpool.Pool
-	now  func() time.Time
+	// db binds the workspace this store runs for (ADR-0091 §9 step 3).
+	db  *database.DB
+	now func() time.Time
 	// enqueueBuild queues a freshly created build's job inside the creating
 	// transaction; nil when no job runner is configured (the row then stays
 	// honestly queued). Wired by WithBuildEnqueue.
 	enqueueBuild VoiceBuildEnqueue
 }
 
-func NewVoiceStore(pool *pgxpool.Pool) *VoiceStore {
-	return &VoiceStore{pool: pool, now: time.Now}
+// NewVoiceStore opens the voice store on a handle already bound to the
+// workspace it serves.
+func NewVoiceStore(db *database.DB) *VoiceStore {
+	return &VoiceStore{db: db, now: time.Now}
 }
 
 // VoiceProfile is the §B0.2 artifact pair: derived voice_profile_md
@@ -127,7 +129,7 @@ func (s *VoiceStore) ListProfiles(ctx context.Context, cursor *string, limit *in
 		where += fmt.Sprintf(" AND (created_at, id) < ($%d, $%d)", arg(c.CreatedAt), arg(c.ID))
 	}
 	var page VoiceProfilePage
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		rows, err := tx.Query(ctx, storekit.SQLf(
 			`SELECT %s FROM voice_profile WHERE %s ORDER BY created_at DESC, id DESC LIMIT %d`,
 			voiceProfileColumns, where, n+1,
@@ -164,7 +166,7 @@ func (s *VoiceStore) GetProfile(ctx context.Context, id ids.UUID) (VoiceProfile,
 		return VoiceProfile{}, err
 	}
 	var p VoiceProfile
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		var err error
 		p, err = s.visibleProfile(ctx, tx, id)
 		return err
@@ -224,7 +226,7 @@ func (s *VoiceStore) CreateProfile(ctx context.Context, in CreateVoiceProfileInp
 		return VoiceProfile{}, apperrors.ErrPermissionDenied
 	}
 	var p VoiceProfile
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		var err error
 		p, err = scanVoiceProfile(tx.QueryRow(ctx, storekit.SQLf(`
 			INSERT INTO voice_profile
@@ -265,7 +267,7 @@ func (s *VoiceStore) UpdateProfile(ctx context.Context, id ids.UUID, in UpdateVo
 		return VoiceProfile{}, err
 	}
 	var p VoiceProfile
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		var err error
 		p, err = s.updateVoiceProfile(ctx, tx, id, in)
 		return err
@@ -388,7 +390,7 @@ func (s *VoiceStore) ArchiveProfile(ctx context.Context, id ids.UUID, ifVersion 
 		return VoiceProfile{}, err
 	}
 	var archived VoiceProfile
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		if _, err := storekit.LockRow(ctx, tx, "voice_profile", id, storekit.LiveOnly); err != nil {
 			return err
 		}

--- a/backend/internal/modules/ai/voice_build_complete.go
+++ b/backend/internal/modules/ai/voice_build_complete.go
@@ -18,7 +18,6 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
@@ -68,7 +67,7 @@ func (s *VoiceStore) CompleteBuild(ctx context.Context, buildID ids.UUID, claime
 		return VoiceProfileVersion{}, apperrors.ErrPermissionDenied
 	}
 	var result VoiceProfileVersion
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		// Lock order is profile THEN build — the same order every corpus
 		// mutation takes, so a concurrent corpus write cannot deadlock a
 		// completing build.
@@ -265,7 +264,7 @@ func (s *VoiceStore) ActiveVersion(ctx context.Context, profileID ids.UUID) (Voi
 	}
 	var version VoiceProfileVersion
 	found := false
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		if _, err := s.visibleProfile(ctx, tx, profileID); err != nil {
 			return err
 		}
@@ -306,7 +305,7 @@ const staleQueuedAge = 10 * time.Minute
 // workspace-by-workspace RLS walk.
 func (s *VoiceStore) DueDeferredBuilds(ctx context.Context) ([]VoiceBuildRef, error) {
 	// rls-exempt: fleet enumeration — the workspace table is not workspace-scoped; this reads every tenant before entering each workspace's own GUC.
-	rows, err := s.pool.Query(ctx, `SELECT id FROM workspace WHERE archived_at IS NULL ORDER BY created_at`)
+	rows, err := s.db.Pool().Query(ctx, `SELECT id FROM workspace WHERE archived_at IS NULL ORDER BY created_at`)
 	if err != nil {
 		return nil, fmt.Errorf("voice: listing workspaces for the deferred-build walk: %w", err)
 	}
@@ -318,7 +317,7 @@ func (s *VoiceStore) DueDeferredBuilds(ctx context.Context) ([]VoiceBuildRef, er
 	var errs error
 	for _, wsID := range workspaces {
 		wsCtx := principal.WithWorkspaceID(ctx, wsID)
-		err := database.WithWorkspaceTx(wsCtx, s.pool, func(tx pgx.Tx) error {
+		err := s.db.Tx(wsCtx, func(tx pgx.Tx) error {
 			now := s.now().UTC()
 			wsRows, err := tx.Query(ctx, `
 				SELECT id, voice_profile_id, requested_by FROM voice_build

--- a/backend/internal/modules/ai/voice_build_run.go
+++ b/backend/internal/modules/ai/voice_build_run.go
@@ -17,7 +17,6 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
@@ -78,7 +77,7 @@ func (s *VoiceStore) ClaimBuild(ctx context.Context, profileID, buildID ids.UUID
 	}
 	var input VoiceBuildInput
 	claimed := false
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		now := s.now().UTC()
 		// Lock order is profile THEN build — the same order CompleteBuild
 		// and every corpus mutation take, so a concurrent claim and
@@ -175,7 +174,7 @@ func (s *VoiceStore) SetBuildStage(ctx context.Context, buildID ids.UUID, stage 
 	if err := auth.Require(ctx, "voice_profile", principal.ActionUpdate); err != nil {
 		return err
 	}
-	return database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	return s.db.Tx(ctx, func(tx pgx.Tx) error {
 		_, err := tx.Exec(ctx, `
 			UPDATE voice_build SET stage = $2, version = version + 1, updated_at = $3
 			WHERE id = $1 AND status = 'running' AND archived_at IS NULL`, buildID, stage, s.now().UTC())
@@ -191,7 +190,7 @@ func (s *VoiceStore) DeferBuild(ctx context.Context, buildID ids.UUID, claimedAt
 	if err := auth.Require(ctx, "voice_profile", principal.ActionUpdate); err != nil {
 		return err
 	}
-	return database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	return s.db.Tx(ctx, func(tx pgx.Tx) error {
 		build, err := scanVoiceBuild(tx.QueryRow(ctx, storekit.SQLf(`
 			UPDATE voice_build
 			SET status = 'deferred', status_code = 'budget_deferred', status_detail = $2,
@@ -221,7 +220,7 @@ func (s *VoiceStore) FailBuild(ctx context.Context, buildID ids.UUID, claimedAt 
 	if err := auth.Require(ctx, "voice_profile", principal.ActionUpdate); err != nil {
 		return err
 	}
-	return database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	return s.db.Tx(ctx, func(tx pgx.Tx) error {
 		build, err := scanVoiceBuild(tx.QueryRow(ctx, storekit.SQLf(`
 			SELECT %s FROM voice_build
 			WHERE id = $1 AND status = 'running' AND started_at = $2 AND archived_at IS NULL

--- a/backend/internal/modules/ai/voice_corpus_summary.go
+++ b/backend/internal/modules/ai/voice_corpus_summary.go
@@ -11,7 +11,6 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
@@ -85,7 +84,7 @@ func (s *VoiceStore) ProfilePresentation(ctx context.Context, profileID ids.UUID
 		summary          CorpusSummary
 		candidateVersion *int
 	)
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		var exists bool
 		if err := tx.QueryRow(ctx, `
 			SELECT EXISTS (

--- a/backend/internal/modules/ai/voice_draftread.go
+++ b/backend/internal/modules/ai/voice_draftread.go
@@ -17,7 +17,6 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
@@ -45,7 +44,7 @@ func (s *VoiceStore) ActiveVoiceForActor(ctx context.Context) (VoiceProfile, Voi
 		version VoiceProfileVersion
 		found   bool
 	)
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		p, err := scanVoiceProfile(tx.QueryRow(ctx, storekit.SQLf(`
 			SELECT %s FROM voice_profile
 			WHERE archived_at IS NULL AND scope = 'user' AND owner_id = $1 AND status = 'ready'
@@ -88,7 +87,7 @@ func (s *VoiceStore) RecordDraftedSignal(ctx context.Context, profileID ids.UUID
 		return &CorpusIngestError{Field: voiceKeyDraftRef, Reason: voiceValidationNotEmpty}
 	}
 	hash := sha256.Sum256([]byte(draftRef))
-	return database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	return s.db.Tx(ctx, func(tx pgx.Tx) error {
 		if _, err := s.visibleProfile(ctx, tx, profileID); err != nil {
 			return err
 		}

--- a/backend/internal/modules/ai/voice_history.go
+++ b/backend/internal/modules/ai/voice_history.go
@@ -16,7 +16,6 @@ import (
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
@@ -103,7 +102,7 @@ func (s *VoiceStore) ListDeltas(ctx context.Context, profileID ids.UUID, cursor 
 		where += " AND (created_at, id) < ($2, $3)"
 	}
 	var page VoiceProfileDeltaPage
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		if _, err := s.visibleProfile(ctx, tx, profileID); err != nil {
 			return err
 		}
@@ -161,7 +160,7 @@ func (s *VoiceStore) LearningSummary(ctx context.Context, profileID ids.UUID) (V
 		return VoiceLearningSummary{}, err
 	}
 	var summary VoiceLearningSummary
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		if _, err := s.visibleProfile(ctx, tx, profileID); err != nil {
 			return err
 		}
@@ -222,7 +221,7 @@ func (s *VoiceStore) RejectDraft(ctx context.Context, profileID ids.UUID, draftR
 		return VoiceLearningSummary{}, &CorpusIngestError{Field: voiceKeyDraftRef, Reason: voiceValidationNotEmpty}
 	}
 	hash := sha256.Sum256([]byte(draftRef))
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		if _, err := s.visibleProfile(ctx, tx, profileID); err != nil {
 			return err
 		}

--- a/backend/internal/modules/ai/voice_lifecycle.go
+++ b/backend/internal/modules/ai/voice_lifecycle.go
@@ -17,7 +17,6 @@ import (
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
@@ -88,7 +87,7 @@ func (s *VoiceStore) CreateBuild(ctx context.Context, profileID ids.UUID, in Cre
 		return VoiceBuild{}, apperrors.ErrPermissionDenied
 	}
 	var build VoiceBuild
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		if _, err := storekit.LockRow(ctx, tx, "voice_profile", profileID, storekit.LiveOnly); err != nil {
 			return err
 		}
@@ -158,7 +157,7 @@ func (s *VoiceStore) GetBuild(ctx context.Context, profileID, buildID ids.UUID) 
 		return VoiceBuild{}, err
 	}
 	var build VoiceBuild
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		if _, err := s.visibleProfile(ctx, tx, profileID); err != nil {
 			return err
 		}

--- a/backend/internal/modules/ai/voice_profile_artifact.go
+++ b/backend/internal/modules/ai/voice_profile_artifact.go
@@ -11,7 +11,6 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
@@ -32,7 +31,7 @@ func (s *VoiceStore) SetDerivedProfile(ctx context.Context, id ids.UUID, voicePr
 		return VoiceProfile{}, &CorpusIngestError{Field: "voice_profile_md", Reason: "a rebuild must produce a non-empty derived artifact"}
 	}
 	var p VoiceProfile
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		var err error
 		p, err = s.rebuildDerivedProfileTx(ctx, tx, id, voiceProfileMD, modelRef)
 		return err

--- a/backend/internal/modules/ai/voice_sendoutcome_integration_test.go
+++ b/backend/internal/modules/ai/voice_sendoutcome_integration_test.go
@@ -38,7 +38,15 @@ var draftRetentionUntil = sendOutcomeClock.Add(voiceLearningSignalRetention)
 type sendOutcomeEnv struct {
 	owner *pgx.Conn
 	pool  *pgxpool.Pool
-	store *VoiceStore
+}
+
+// storeIn is the voice store bound to ONE of this suite's workspaces. Each
+// seedDraft mints its own tenant, so there is no single workspace the fixture
+// could bind at setup — and the workspace a store runs in is its handle's.
+func (e *sendOutcomeEnv) storeIn(ws ids.UUID) *VoiceStore {
+	s := NewVoiceStore(database.BindTo(e.pool, ids.From[ids.WorkspaceKind](ws)))
+	s.now = func() time.Time { return sendOutcomeClock }
+	return s
 }
 
 func setupSendOutcomeStore(t *testing.T) *sendOutcomeEnv {
@@ -65,9 +73,7 @@ func setupSendOutcomeStore(t *testing.T) *sendOutcomeEnv {
 	}
 	t.Cleanup(pool.Close)
 
-	store := NewVoiceStore(pool)
-	store.now = func() time.Time { return sendOutcomeClock }
-	return &sendOutcomeEnv{owner: owner, pool: pool, store: store}
+	return &sendOutcomeEnv{owner: owner, pool: pool}
 }
 
 // draftOptions varies the seeded signal for the refusal under test. The
@@ -196,14 +202,26 @@ func (e *sendOutcomeEnv) seedUser(t *testing.T, workspace ids.UUID, label string
 	return id
 }
 
+// workspaceOf names the tenant a fixture ctx is acting in, which is the one its
+// store has to bind.
+func workspaceOf(ctx context.Context, t *testing.T) ids.UUID {
+	t.Helper()
+	ws, ok := principal.WorkspaceID(ctx)
+	if !ok {
+		t.Fatal("the fixture context carries no workspace")
+	}
+	return ws
+}
+
 // record runs the method the way task 3's send path will: inside a
 // workspace transaction the CALLER owns, never one the store opens.
 func (e *sendOutcomeEnv) record(ctx context.Context, t *testing.T, draftRef, finalBody string) bool {
 	t.Helper()
+	store := e.storeIn(workspaceOf(ctx, t))
 	var recorded bool
 	if err := database.WithWorkspaceTx(ctx, e.pool, func(tx pgx.Tx) error {
 		var err error
-		recorded, err = e.store.RecordSendOutcomeTx(ctx, tx, draftRef, finalBody)
+		recorded, err = store.RecordSendOutcomeTx(ctx, tx, draftRef, finalBody)
 		return err
 	}); err != nil {
 		t.Fatalf("RecordSendOutcomeTx: %v", err)
@@ -520,13 +538,14 @@ func (e *sendOutcomeEnv) holdSignalLock(t *testing.T, signal ids.UUID) {
 // call that does take one surfaces as an error instead of a hang.
 func (e *sendOutcomeEnv) recordUnderLockTimeout(ctx context.Context, t *testing.T, draftRef, finalBody string) (bool, error) {
 	t.Helper()
+	store := e.storeIn(workspaceOf(ctx, t))
 	var recorded bool
 	err := database.WithWorkspaceTx(ctx, e.pool, func(tx pgx.Tx) error {
 		if _, err := tx.Exec(ctx, `SET LOCAL lock_timeout = '2s'`); err != nil {
 			return err
 		}
 		var err error
-		recorded, err = e.store.RecordSendOutcomeTx(ctx, tx, draftRef, finalBody)
+		recorded, err = store.RecordSendOutcomeTx(ctx, tx, draftRef, finalBody)
 		return err
 	})
 	return recorded, err

--- a/backend/internal/modules/ai/voice_source_mutations.go
+++ b/backend/internal/modules/ai/voice_source_mutations.go
@@ -12,7 +12,6 @@ import (
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
@@ -55,7 +54,7 @@ func (s *VoiceStore) UpdateSource(ctx context.Context, profileID, sourceID ids.U
 		source  VoiceCorpusSource
 		summary CorpusSummary
 	)
-	err = database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err = s.db.Tx(ctx, func(tx pgx.Tx) error {
 		var err error
 		source, summary, err = s.updateVoiceSource(ctx, tx, profileID, sourceID, in, excluded)
 		return err
@@ -171,7 +170,7 @@ func (s *VoiceStore) DeleteSource(ctx context.Context, profileID, sourceID ids.U
 		return VoiceCorpusSource{}, err
 	}
 	var removed VoiceCorpusSource
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		profile, err := s.visibleProfile(ctx, tx, profileID)
 		if err != nil {
 			return err
@@ -234,7 +233,7 @@ func (s *VoiceStore) ClearCorpus(ctx context.Context, profileID ids.UUID, ifVers
 		return VoiceProfile{}, err
 	}
 	var cleared VoiceProfile
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		if _, err := storekit.LockRow(ctx, tx, "voice_profile", profileID, storekit.LiveOnly); err != nil {
 			return err
 		}

--- a/backend/internal/modules/ai/voice_source_store.go
+++ b/backend/internal/modules/ai/voice_source_store.go
@@ -10,7 +10,6 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
@@ -34,7 +33,7 @@ func (s *VoiceStore) IngestSource(ctx context.Context, profileID ids.UUID, in In
 		source  VoiceCorpusSource
 		summary CorpusSummary
 	)
-	err = database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err = s.db.Tx(ctx, func(tx pgx.Tx) error {
 		var err error
 		source, summary, err = s.ingestPreparedSource(ctx, tx, profileID, prepared)
 		return err
@@ -51,7 +50,7 @@ func (s *VoiceStore) PreviewSource(ctx context.Context, profileID ids.UUID, form
 	if err := auth.Require(ctx, "voice_profile", principal.ActionUpdate); err != nil {
 		return CorpusPreview{}, err
 	}
-	if err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	if err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		_, err := s.visibleProfile(ctx, tx, profileID)
 		return err
 	}); err != nil {
@@ -203,7 +202,7 @@ func (s *VoiceStore) ListSources(ctx context.Context, profileID ids.UUID) ([]Voi
 		sources []VoiceCorpusSource
 		summary CorpusSummary
 	)
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		p, err := s.visibleProfile(ctx, tx, profileID)
 		if err != nil {
 			return err

--- a/backend/internal/modules/ai/voice_versions.go
+++ b/backend/internal/modules/ai/voice_versions.go
@@ -19,7 +19,6 @@ import (
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
@@ -106,7 +105,7 @@ func (s *VoiceStore) ListVersions(ctx context.Context, profileID ids.UUID, curso
 		where += " AND (created_at, id) < ($2, $3)"
 	}
 	var page VoiceProfileVersionPage
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		if _, err := s.visibleProfile(ctx, tx, profileID); err != nil {
 			return err
 		}
@@ -153,7 +152,7 @@ func (s *VoiceStore) transitionVersion(ctx context.Context, profileID ids.UUID, 
 		return VoiceProfileVersion{}, err
 	}
 	var result VoiceProfileVersion
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		var err error
 		result, err = s.transitionVoiceVersion(ctx, tx, profileID, profileVersion, ifVersion, target)
 		return err
@@ -265,7 +264,7 @@ func (s *VoiceStore) RollbackVersion(ctx context.Context, profileID ids.UUID, so
 		return VoiceProfileVersion{}, apperrors.ErrPermissionDenied
 	}
 	var result VoiceProfileVersion
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		if _, err := storekit.LockRow(ctx, tx, "voice_profile", profileID, storekit.LiveOnly); err != nil {
 			return err
 		}

--- a/backend/internal/modules/capture/autoenrich.go
+++ b/backend/internal/modules/capture/autoenrich.go
@@ -19,7 +19,6 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
@@ -40,11 +39,13 @@ type DueOrg struct {
 
 // AutoEnrichStore owns the sweep's scheduling state and daily-cap reservation.
 type AutoEnrichStore struct {
-	pool *pgxpool.Pool
+	// db binds the workspace this store runs for (ADR-0091 §9 step 3).
+	db *database.DB
 }
 
-// NewAutoEnrichStore builds the store over the pool.
-func NewAutoEnrichStore(pool *pgxpool.Pool) *AutoEnrichStore { return &AutoEnrichStore{pool: pool} }
+// NewAutoEnrichStore builds the store on a handle already bound to the
+// workspace it serves.
+func NewAutoEnrichStore(db *database.DB) *AutoEnrichStore { return &AutoEnrichStore{db: db} }
 
 // ListDueOrgs returns up to limit captured organizations that need a dossier,
 // newest first (ADR-0072): with a live primary domain, no dossier, and either
@@ -71,7 +72,7 @@ func NewAutoEnrichStore(pool *pgxpool.Pool) *AutoEnrichStore { return &AutoEnric
 // opposite of the self-healing this sweep is for.
 func (s *AutoEnrichStore) ListDueOrgs(ctx context.Context, limit int) ([]DueOrg, error) {
 	var out []DueOrg
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		rows, err := tx.Query(ctx, `
 			SELECT o.id, d.domain
 			FROM organization o
@@ -116,7 +117,7 @@ func (s *AutoEnrichStore) ListDueOrgs(ctx context.Context, limit int) ([]DueOrg,
 // names. Called once per sweep pass, before ListDueOrgs. A resolved org already
 // has a NULL next_attempt_at, so the NOT-NULL guard leaves it untouched.
 func (s *AutoEnrichStore) ExpireExhausted(ctx context.Context) error {
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		_, err := tx.Exec(ctx, `
 			UPDATE capture_auto_enrich_state SET
 			  last_outcome = 'exhausted', next_attempt_at = NULL, updated_at = now()
@@ -144,7 +145,7 @@ type BudgetSlot struct {
 // sweeps (replicas) can never both slip past the cap.
 func (s *AutoEnrichStore) ReserveBudget(ctx context.Context, dailyCap int) (BudgetSlot, error) {
 	var slot BudgetSlot
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		var enqueued int
 		var day time.Time
 		// INSERT the day's first slot, or increment only while under the cap;
@@ -197,7 +198,7 @@ func (s *AutoEnrichStore) ReleaseBudget(ctx context.Context, slot BudgetSlot) er
 	if !slot.Reserved {
 		return nil
 	}
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		_, err := tx.Exec(ctx, `
 			UPDATE capture_auto_enrich_budget
 			   SET enqueued = enqueued - 1
@@ -221,7 +222,7 @@ func (s *AutoEnrichStore) ReleaseBudget(ctx context.Context, slot BudgetSlot) er
 // process instead makes that a cross-clock comparison, and the two clocks are
 // only ever coincidentally equal.
 func (s *AutoEnrichStore) MarkQueued(ctx context.Context, orgID ids.OrganizationID, backoff time.Duration) error {
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		_, err := tx.Exec(ctx, `
 			INSERT INTO capture_auto_enrich_state
 			  (organization_id, workspace_id, attempts, last_attempt_at, next_attempt_at, last_outcome)
@@ -247,7 +248,7 @@ func (s *AutoEnrichStore) MarkQueued(ctx context.Context, orgID ids.Organization
 // due sweep retries it (until the attempt bound). A cursor row is expected
 // (MarkQueued wrote it); a missing row is a no-op, never an error.
 func (s *AutoEnrichStore) MarkResolved(ctx context.Context, orgID ids.OrganizationID, outcome string) error {
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		_, err := tx.Exec(ctx, `
 			UPDATE capture_auto_enrich_state SET
 			  last_outcome = $2,

--- a/backend/internal/modules/capture/pending.go
+++ b/backend/internal/modules/capture/pending.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
@@ -218,10 +217,13 @@ type dispositionRow struct {
 
 // PendingStore reads and resolves the ledger. It is the verdict engine's seam
 // into capture's own table; compose injects it.
-type PendingStore struct{ pool *pgxpool.Pool }
+// PendingStore's db binds the workspace this store runs for (ADR-0091 §9
+// step 3).
+type PendingStore struct{ db *database.DB }
 
-// NewPendingStore builds the ledger store over the capture pool.
-func NewPendingStore(pool *pgxpool.Pool) *PendingStore { return &PendingStore{pool: pool} }
+// NewPendingStore builds the ledger store on a handle already bound to the
+// workspace it serves.
+func NewPendingStore(db *database.DB) *PendingStore { return &PendingStore{db: db} }
 
 // ClaimDue atomically leases up to limit due rows for this workspace. FOR UPDATE
 // SKIP LOCKED lets several replicas drain the ledger without double-judging a
@@ -234,7 +236,7 @@ func NewPendingStore(pool *pgxpool.Pool) *PendingStore { return &PendingStore{po
 func (s *PendingStore) ClaimDue(ctx context.Context, limit int) ([]PendingCounterparty, error) {
 	claim := ids.NewV7()
 	var out []PendingCounterparty
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		rows, err := tx.Query(ctx, `
 			UPDATE capture_pending_counterparty p
 			   SET attempts = p.attempts + 1,
@@ -336,7 +338,7 @@ func (s *PendingStore) CorrectResolution(ctx context.Context, tx pgx.Tx, id ids.
 // Guarded by the same claim as Resolve, for the same reason: a stalled worker
 // releasing "its" row would otherwise cut short a lease someone else now holds.
 func (s *PendingStore) Defer(ctx context.Context, p PendingCounterparty, backoff time.Duration, reason string, refundAttempt bool) error {
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		// Whether the attempt is given back is the difference between a row the
 		// SYSTEM failed and a row that fails on its own content.
 		//
@@ -371,7 +373,7 @@ func (s *PendingStore) Defer(ctx context.Context, p PendingCounterparty, backoff
 // it stopped, so an operator reading the row sees why it ended rather than
 // having to infer it from a counter that says something else.
 func (s *PendingStore) Retire(ctx context.Context, p PendingCounterparty, reason string) error {
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		_, err := tx.Exec(ctx, `
 			UPDATE capture_pending_counterparty
 			   SET status = 'unsure', disposition_reason = NULLIF($2, ''),

--- a/backend/internal/modules/capture/pendingreview.go
+++ b/backend/internal/modules/capture/pendingreview.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
@@ -32,7 +31,7 @@ import (
 // Guarded on the row still being `unsure`: one a human has already decided must
 // never have a fresh proposal attached to it.
 func (s *PendingStore) LinkProposal(ctx context.Context, id, proposalID ids.UUID) error {
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		_, err := tx.Exec(ctx, `
 			UPDATE capture_pending_counterparty
 			   SET proposal_id = $2, updated_at = now()
@@ -62,7 +61,7 @@ func (s *PendingStore) LinkProposal(ctx context.Context, id, proposalID ids.UUID
 // Expired means unanswered; decided means answered, whichever way.
 func (s *PendingStore) AwaitingReview(ctx context.Context, limit int) ([]PendingCounterparty, error) {
 	var out []PendingCounterparty
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		rows, err := tx.Query(ctx, `
 			SELECT p.id, p.email, coalesce(p.domain, ''), coalesce(left(p.display_name, $2), ''),
 			       p.activity_id, p.owner_id

--- a/backend/internal/modules/capture/pendingsweeps.go
+++ b/backend/internal/modules/capture/pendingsweeps.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
@@ -45,7 +44,7 @@ import (
 // cannot be.
 func (s *PendingStore) RetireExhausted(ctx context.Context, reason string) (int, error) {
 	var retired int
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		tag, err := tx.Exec(ctx, `
 			UPDATE capture_pending_counterparty
 			   SET status = 'unsure', disposition_reason = NULLIF($1, ''),
@@ -77,7 +76,7 @@ func (s *PendingStore) RetireExhausted(ctx context.Context, reason string) (int,
 // simply stops asking a question that has been answered.
 func (s *PendingStore) ReconcileDeclined(ctx context.Context) (int, error) {
 	var closed int
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		tag, err := tx.Exec(ctx, `
 			UPDATE capture_pending_counterparty p
 			   SET status = 'rejected',
@@ -122,7 +121,7 @@ type StaleReview struct {
 // would keep resetting its own deadline and never age out at all.
 func (s *PendingStore) StaleReviews(ctx context.Context, window time.Duration, limit int) ([]StaleReview, error) {
 	var out []StaleReview
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		rows, err := tx.Query(ctx, `
 			SELECT id, proposal_id
 			  FROM capture_pending_counterparty
@@ -396,7 +395,7 @@ func (s *PendingStore) PurgeRawCaptureTx(ctx context.Context, tx pgx.Tx, activit
 // noiseMail runs the shared join with one extra predicate.
 func (s *PendingStore) noiseMail(ctx context.Context, extra string, limit int) ([]ids.UUID, error) {
 	var out []ids.UUID
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		rows, err := tx.Query(ctx, `
 			SELECT DISTINCT a.id, a.occurred_at
 			  FROM activity a

--- a/backend/internal/modules/migration/run.go
+++ b/backend/internal/modules/migration/run.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
@@ -56,16 +55,18 @@ type Run struct {
 // RunStore owns the import_run table; every status transition rides the
 // storekit audit shape.
 type RunStore struct {
-	pool *pgxpool.Pool
+	// db binds the workspace this store runs for (ADR-0091 §9 step 3).
+	db *database.DB
 }
 
-// NewRunStore wires the store over the RLS-bound app pool.
-func NewRunStore(pool *pgxpool.Pool) *RunStore {
-	return &RunStore{pool: pool}
+// NewRunStore opens the run store on a handle already bound to the workspace
+// it serves.
+func NewRunStore(db *database.DB) *RunStore {
+	return &RunStore{db: db}
 }
 
 func (s *RunStore) tx(ctx context.Context, fn func(pgx.Tx) error) error {
-	return database.WithWorkspaceTx(ctx, s.pool, fn)
+	return s.db.Tx(ctx, fn)
 }
 
 // CreateRunInput starts a run record. Source is the provenance stamp

--- a/backend/internal/modules/migration/run_integration_test.go
+++ b/backend/internal/modules/migration/run_integration_test.go
@@ -13,7 +13,6 @@ import (
 	"testing"
 
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
@@ -26,7 +25,7 @@ import (
 // needs (the overlay module's testsupport_integration.go pattern). It
 // fails loudly rather than skipping — a silently skipped gate looks
 // exactly like a passing one.
-func testWorkspaceCtx(t *testing.T, grants map[string]principal.ObjectGrant) (context.Context, *pgxpool.Pool) {
+func testWorkspaceCtx(t *testing.T, grants map[string]principal.ObjectGrant) (context.Context, *database.DB) {
 	t.Helper()
 	ownerDSN := os.Getenv("MARGINCE_TEST_DSN")
 	appDSN := os.Getenv("MARGINCE_TEST_APP_DSN")
@@ -74,7 +73,9 @@ func testWorkspaceCtx(t *testing.T, grants map[string]principal.ObjectGrant) (co
 			RowScope: principal.RowScopeAll,
 		},
 	})
-	return opCtx, pool
+	// The handle as well as the ctx: a store writes the workspace its handle
+	// binds, so a second tenant needs one of its own.
+	return opCtx, database.BindTo(pool, ids.From[ids.WorkspaceKind](ws))
 }
 
 func adminImportRunGrant() map[string]principal.ObjectGrant {
@@ -84,8 +85,8 @@ func adminImportRunGrant() map[string]principal.ObjectGrant {
 }
 
 func TestRunStoreLifecycleWithAuditAndResume(t *testing.T) {
-	ctx, pool := testWorkspaceCtx(t, adminImportRunGrant())
-	s := NewRunStore(pool)
+	ctx, db := testWorkspaceCtx(t, adminImportRunGrant())
+	s := NewRunStore(db)
 
 	run, err := s.Create(ctx, CreateRunInput{Connector: ConnectorMirror, SourceRef: "snap-test", Source: "overlay:flip"})
 	if err != nil {
@@ -149,7 +150,7 @@ func TestRunStoreLifecycleWithAuditAndResume(t *testing.T) {
 
 	// Every gate audited: create + fail + resume + complete.
 	var audits int
-	err = database.WithWorkspaceTx(ctx, pool, func(tx pgx.Tx) error {
+	err = db.Tx(ctx, func(tx pgx.Tx) error {
 		return tx.QueryRow(ctx,
 			`SELECT count(*) FROM audit_log WHERE entity_type = 'import_run' AND entity_id = $1`,
 			run.ID).Scan(&audits)
@@ -163,8 +164,8 @@ func TestRunStoreLifecycleWithAuditAndResume(t *testing.T) {
 }
 
 func TestIdentityMapIsIdempotentAndTenantFenced(t *testing.T) {
-	ctxA, pool := testWorkspaceCtx(t, adminImportRunGrant())
-	s := NewRunStore(pool)
+	ctxA, dbA := testWorkspaceCtx(t, adminImportRunGrant())
+	s := NewRunStore(dbA)
 	run, err := s.Create(ctxA, CreateRunInput{Connector: ConnectorMirror, SourceRef: "snap-a", Source: "overlay:flip"})
 	if err != nil {
 		t.Fatalf("Create: %v", err)
@@ -191,14 +192,18 @@ func TestIdentityMapIsIdempotentAndTenantFenced(t *testing.T) {
 	// Another workspace neither sees that identity nor may reference the
 	// run: the composite FK rejects a cross-workspace run at the
 	// database, not merely through RLS visibility.
-	ctxB, _ := testWorkspaceCtx(t, adminImportRunGrant())
-	if _, found, err := s.LookupIdentity(ctxB, "hubspot", "person", "p-1"); err != nil || found {
+	// Workspace B asks through a store of its own: the workspace a statement
+	// runs in is the handle's, so driving A's store with B's ctx would answer
+	// A's rows and this fence would prove nothing.
+	ctxB, dbB := testWorkspaceCtx(t, adminImportRunGrant())
+	sB := NewRunStore(dbB)
+	if _, found, err := sB.LookupIdentity(ctxB, "hubspot", "person", "p-1"); err != nil || found {
 		t.Fatalf("workspace B resolved workspace A's identity (found=%v, err=%v)", found, err)
 	}
 	// Rejected AND existence-hiding: a bare constraint error would tell
 	// workspace B that A's run id is real, which is the thing row scope
 	// is supposed to withhold.
-	err = s.RecordIdentity(ctxB, run.ID, "hubspot", "person", "p-9", ids.NewV7())
+	err = sB.RecordIdentity(ctxB, run.ID, "hubspot", "person", "p-9", ids.NewV7())
 	if err == nil {
 		t.Fatal("recording an identity against ANOTHER workspace's run must be rejected by the database")
 	}
@@ -211,15 +216,15 @@ func TestIdentityMapIsIdempotentAndTenantFenced(t *testing.T) {
 }
 
 func TestRunStoreForeignWorkspaceReadsNotFound(t *testing.T) {
-	ctxA, pool := testWorkspaceCtx(t, adminImportRunGrant())
-	s := NewRunStore(pool)
+	ctxA, dbA := testWorkspaceCtx(t, adminImportRunGrant())
+	s := NewRunStore(dbA)
 	run, err := s.Create(ctxA, CreateRunInput{Connector: ConnectorMirror, SourceRef: "x", Source: "t"})
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
 
-	ctxB, _ := testWorkspaceCtx(t, adminImportRunGrant())
-	if _, err := NewRunStore(pool).Get(ctxB, run.ID); !errors.Is(err, apperrors.ErrNotFound) {
+	ctxB, dbB := testWorkspaceCtx(t, adminImportRunGrant())
+	if _, err := NewRunStore(dbB).Get(ctxB, run.ID); !errors.Is(err, apperrors.ErrNotFound) {
 		t.Fatalf("foreign-workspace Get err = %v, want ErrNotFound (existence-hiding)", err)
 	}
 }


### PR DESCRIPTION
capture's auto-enrich and pending-review stores, ai's voice store and migration's run store were the ones left on a raw pool, because each is held by a worker that walks the fleet rather than serving a request (ADR-0091 §9 step 3).

## The walk is what re-binds

`database.DB.ForWorkspace` gives each tenant its own handle *inside* the enumeration, so the loop reads and writes the workspace it is on rather than the one its holder was built for. That seam is deliberately narrow — a pass qualifies only when the workspace enumeration drives it, never a request — and the single-installation collapse retires it: with one workspace there is nothing to enumerate.

The reconstruction path binds the workspace the **operator** is acting in for its run store and identity map as well. That is not a test concession: a rebuild lands where the human ordered it, which on a clean instance is not the workspace the server resolved at boot.

## identity stays on the pool, deliberately

Not only because the handle would resolve through itself (that part is solvable — `InstallationWorkspace` reads no tenant table, so a self-bound handle is not circular at runtime). Its suites drive several tenants through one service on purpose — login, the agent seat, the CIMD client cache — so binding it is a slice with real test surface rather than a mechanical rename. It is the last module left.

## Verification

- `make check-backend` — green
- `craft static --strict` over all 70 changed Go files — 0 findings
- `make test-integration` — `OK: integration passed with 0 skips (38 packages, parallel)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bind fleet-held stores to workspace-bound `database.DB` handles to enforce RLS and correct tenant scoping during fleet walks and operator-initiated rebuilds. Compose, jobs, and tests now pass bound handles; the identity module remains on the raw pool by design.

- **Refactors**
  - capture: `AutoEnrichStore` and `PendingStore` now take `*database.DB`; compose paths (auto-enrich sweep, domain triage trigger, counterparty verdict, coldstart approvals) pass `InstallationDB(pool)`; tests use `e.DB()`.
  - ai: `VoiceStore` now takes `*database.DB` and uses `db.Tx`; workers (voice build/retry), reply drafter, send path, and deep read transport use `InstallationDB(pool)`; API handlers wire `NewVoiceStore(db)`; integration tests bind per-workspace stores (`e.DB()`, `e.DBFor(...)`, `database.BindTo(...)`).
  - migration: `RunStore` now takes `*database.DB`; flip runner and reconstruction bind the operator’s workspace (`actingWorkspaceDB`/`database.BindTo`) before creating the store and flip writers; integration tests bind per-tenant handles and verify cross-tenant fences.

<sup>Written for commit 46ea8b3aaebb4d127dbd9e93738931e4975a9f1a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1002?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

