### PR TITLE
docs(status): step 3 is done except identity, and what the handle meant

### DIFF
--- a/STATUS-ARCHIVE.md
+++ b/STATUS-ARCHIVE.md
@@ -21,6 +21,61 @@
 > [CHANGELOG.md](CHANGELOG.md) and [README.md → *What works
 > today*](README.md#what-works-today).
 
+## 2026-08-12 — every module but identity opens on a pool that knows its workspace (PRs #976, #984, #992, #999, #1002)
+
+ADR-0091 §9 **step 3** is done except `identity`. `platform/database.DB` — a pool
+plus the workspace it binds — replaced `WithWorkspaceTx(ctx, pool, …)` across
+twenty modules, and `DB.Tx` is the SAME GUC spelling, so RLS stayed armed the
+whole way and the tenant-isolation suite stayed the mechanical proof that an
+edit of this size was faithful. That is the point of doing the Go plumbing
+before the schema: the phase that deletes the proof comes after.
+
+**What the sweep actually found** is that there are exactly three ways a caller
+knows which tenant it is, and that they had been indistinguishable while the
+answer came from the ctx. They are now an argument at the call site: request
+paths and bus consumers RESOLVE the installation's singleton
+(`compose.InstallationDB`), fleet passes PIN from their job args
+(`workspaceJobDB`, or `DB.ForWorkspace` inside a store that walks the fleet
+itself), and raw-SQL harnesses PIN per tenant (`Env.DB()` / `Env.DBFor(ws)`).
+
+**Four fleet passes were reading the tenant off the ctx while their store
+carried it on its handle**, and each therefore swept ONE workspace repeatedly
+while reporting the fan-out as working: the webhook retry deliverer, the agent
+scheduler, search's pending rollup and its re-embed. None of them was found by
+reading — every one surfaced as a loud failure in a cross-tenant suite
+(a refusal, an FK violation, an RLS denial). Not once did a mis-binding show up
+as a silent cross-tenant READ, which is the property the whole shape rests on.
+
+**A composed surface now says which workspace it was built for.**
+`NewRegistryFor`, `NewProviderFor` and `NewOverlayProviderFor` are the pinned
+siblings of the resolving constructors: a server resolves the singleton, a suite
+that seeds a second workspace on purpose has no singleton to resolve and names
+the one it means. The same distinction fixed a test that had been passing
+vacuously — an existence-hiding arm asserts not-found, so a provider bound to
+the wrong workspace passed it without ever reaching the rows whose hiding it
+exists to prove.
+
+**The flip and its reconstruction bind the workspace the OPERATOR is acting in**,
+not the installation's. That is not a test concession: a rebuild lands where the
+human ordered it, which on a clean instance is a workspace the server never
+resolved at boot.
+
+**identity is the one module left.** A self-bound handle is legal —
+`InstallationWorkspace` reads no tenant table, so a service holding a handle
+that resolves through it is not circular at runtime — and it compiles and passes
+the unit lane. It does not pass identity's own integration suites, nor the CIMD
+and agent-seat lanes, which drive several tenants through one service on
+purpose. That is a slice with real fixture work, not a rename.
+
+One process note, paid for twice: a PR here cannot merge with an unresolved
+review thread (`required_review_thread_resolution`), and CodeRabbit had learned
+a rule that does not exist in this repo — "`backend/**/*.go`: Never edit" — and
+was applying it to every changed file. What CLAUDE.md actually forbids is the
+short DO NOT TOUCH list (generated files, shipped core migrations, the RLS/GUC
+contract, the apperrors registry). The learning was corrected in a reply on
+#999; if it resurfaces, correct it again rather than resolving twenty threads by
+hand.
+
 ## 2026-08-11 — the lane says where its own time goes, 222s → 207s (PRs #854, #859, #861)
 
 Three changes, and the first is the one that matters after the other two are

--- a/STATUS.md
+++ b/STATUS.md
@@ -455,6 +455,42 @@ collapses while RLS is still armed, because the tenant-isolation suite staying
 green is the only mechanical proof that an edit of that size stayed faithful,
 and the schema phase deletes that suite. Do not reorder it.
 
+### Step 3 is done except identity — what the handle turned out to mean
+
+`platform/database.DB` is the seam that landed: a pool that knows its
+workspace, with `Tx` spelling the same `WithWorkspaceTx` GUC contract, so RLS
+stayed armed and the isolation suite stayed the proof. Every module but
+`identity` now opens on one.
+
+The sweep's real finding is that there are exactly **three** ways a caller knows
+which tenant it is, and the handle makes the choice visible at the call site
+instead of burying it in a store:
+
+- **resolve** — request paths and bus consumers: `compose.InstallationDB(pool)`;
+- **pin from job args** — fleet passes: `workspaceJobDB`, and inside a store
+  that walks the fleet itself, `DB.ForWorkspace` per tenant;
+- **pin per tenant** — raw-SQL harnesses: `Env.DB()` / `Env.DBFor(ws)`.
+
+Two rules fell out of it and are worth knowing before the next slice:
+
+- **A long-lived service shared by every tenant's pass must re-bind per pass.**
+  The webhook deliverer, the agent scheduler, search's pending rollup and its
+  re-embed all read the tenant off the ctx while their store carried it on its
+  handle — so each swept ONE workspace repeatedly while reporting the fan-out as
+  working. Every one of them was caught by a cross-tenant suite, loudly.
+- **A composed surface says which workspace it was built for.** `NewRegistryFor`,
+  `NewProviderFor` and `NewOverlayProviderFor` are the pinned siblings of the
+  resolving constructors; a suite that seeds a second workspace has no singleton
+  to resolve and names the one it means.
+
+**identity is the one module left**, and it is not a mechanical rename. A
+self-bound handle is legal — `InstallationWorkspace` reads no tenant table, so
+`svc.db = database.Bind(pool, svc.InstallationWorkspace)` is not circular at
+runtime, and it compiles and passes the unit lane. What it does not pass is
+identity's own integration suites plus the CIMD and agent-seat lanes: they drive
+several tenants through ONE service on purpose. Converting it means reworking
+those fixtures tenant by tenant, which is its own slice.
+
 Phase 2 spans roughly nine hundred `WithWorkspaceTx` occurrences, a bit over
 four hundred of them outside tests, across a couple of hundred non-test files.
 Deliberately not a precise count: it moved by eleven while this note was being


### PR DESCRIPTION
The ADR-0091 pick-up section said "one loop per PR" and left the shape open. With PRs #976, #984, #992, #999 and #1002 on main, §9 step 3 is done except `identity` — so STATUS.md now records what the sweep established rather than what it planned, and the session narrative goes to STATUS-ARCHIVE.md where CLAUDE.md wants it.

The three things worth carrying forward:

- **Three binding kinds, visible at the call site** — resolve (request paths), pin from job args (fleet passes), pin per tenant (raw-SQL harnesses).
- **A long-lived service shared by every tenant's pass must re-bind per pass.** Four passes read the tenant off the ctx while their store carried it on its handle, so each swept one workspace repeatedly while reporting the fan-out as working. All four surfaced loudly in cross-tenant suites, never as a silent cross-tenant read.
- **A composed surface says which workspace it was built for** — `NewRegistryFor` / `NewProviderFor` / `NewOverlayProviderFor` beside the resolving constructors.

`identity` is named as the one module left, with the reason it is a slice rather than a rename: a self-bound handle is legal and passes the unit lane, but its own integration suites plus the CIMD and agent-seat lanes drive several tenants through one service on purpose.

Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update STATUS.md to mark ADR-0091 §9 step 3 as complete (except `identity`) and clarify the `platform/database.DB` handle; move the prior session narrative to STATUS-ARCHIVE.md. Documents the three binding kinds, that long-lived services must re-bind per pass, and that composed surfaces declare their target workspace.

<sup>Written for commit 0be75998ab99acf0b641cf81a32f46b314611593. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1003?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

