### PR TITLE
style(scripts): the parity gate uses bash's own conditional

### DIFF
--- a/scripts/check-make-target-parity.sh
+++ b/scripts/check-make-target-parity.sh
@@ -35,7 +35,7 @@ set -euo pipefail
 root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 backend_makefile="$root_dir/backend/Makefile"
 
-if [ ! -f "$backend_makefile" ]; then
+if [[ ! -f "$backend_makefile" ]]; then
   echo "check-make-target-parity: $backend_makefile not found" >&2
   exit 1
 fi
@@ -55,7 +55,7 @@ root_targets="$(printf '%s\n' "$root_targets" |
 # Either list coming back empty would pass this gate while comparing nothing —
 # the failure a parity check is most likely to fail by.
 for pair in "advertised backend targets:$advertised" "root targets:$root_targets"; do
-  if [ -z "${pair#*:}" ]; then
+  if [[ -z "${pair#*:}" ]]; then
     echo "check-make-target-parity: extracted no ${pair%%:*} — the Makefile changed shape, so this gate was about to pass without comparing anything" >&2
     exit 1
   fi
@@ -63,7 +63,7 @@ done
 
 missing="$(comm -23 <(printf '%s\n' "$advertised") <(printf '%s\n' "$root_targets"))"
 
-if [ -n "$missing" ]; then
+if [[ -n "$missing" ]]; then
   while IFS= read -r target; do
     echo "UNREACHABLE FROM ROOT: \`make $target\` is advertised by \`make help\` but the root Makefile has no such target — add it to the delegation list in Makefile" >&2
   done <<<"$missing"


### PR DESCRIPTION
Clears the three SonarCloud findings against the script #988 added.

## The findings

```
MAJOR  shelldre:S7688  scripts/check-make-target-parity.sh:38
MAJOR  shelldre:S7688  scripts/check-make-target-parity.sh:58
MAJOR  shelldre:S7688  scripts/check-make-target-parity.sh:66
       "Use '[[' instead of '[' for conditional tests."
```

#988's quality gate passed — the rating conditions were met — so these landed on `main` as open MAJOR smells rather than blocking the merge. Worth clearing rather than leaving: the scheduled lane exists to keep someone reading that gate (#975), and a gate accumulating unaddressed MAJORs is one people stop reading.

The rule is right on the merits here. The file is `#!/usr/bin/env bash`, so the portable single-bracket form bought nothing, while `[[` does no word splitting or pathname expansion on its operands.

## Scope

Only this script. Its siblings (`check-host-ports.sh`, `check-ci-doc-parity.sh`, …) use `[` throughout and sit outside the new-code window Sonar judges. Converting them too would be a five-file style sweep that buries the one change with a reason behind it — and a diff nobody can scan is how a real finding gets waved through.

## Verification

`bash -n` clean, and the gate still answers correctly:

```
$ ./scripts/check-make-target-parity.sh
make target parity OK (45 backend targets, all reachable from the repo root)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switched `[` to `[[` in `scripts/check-make-target-parity.sh` to use bash-safe conditionals and clear three SonarCloud S7688 findings. No behavior change; the gate still validates parity and passes `bash -n`.

<sup>Written for commit 958c222575aa6b0fbd61b6c317ba58b1307306d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1005?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

