### PR TITLE
fix(textlang): a forwarded mail is read, not cut down to its address lines

### DIFF
--- a/backend/internal/compose/persondraft/fold.go
+++ b/backend/internal/compose/persondraft/fold.go
@@ -13,6 +13,7 @@ import (
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/convstate"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/textlang"
 )
 
 // FromView folds the caller's 360 into the draft's input.
@@ -254,15 +255,12 @@ func stripMailHeaders(body string) string {
 	return body
 }
 
-// isMailHeaderLine reports whether a line is one of the envelope headers the
-// capture path stores above a body.
+// isMailHeaderLine defers to the shared vocabulary rather than keeping a second
+// list. Two lists is how this drifted: the language detector knew two headers
+// and this knew six, and neither knew what the other knew — which is how a
+// German thread kept drafting in English.
 func isMailHeaderLine(line string) bool {
-	for _, header := range []string{"From: ", "To: ", "Cc: ", "Bcc: ", "Von: ", "An: "} {
-		if strings.HasPrefix(line, header) {
-			return true
-		}
-	}
-	return false
+	return textlang.IsMailHeader(line)
 }
 
 // isOverdueOurs reports whether this claim is a promise WE made, still open,

--- a/backend/internal/shared/kernel/textlang/mailtext.go
+++ b/backend/internal/shared/kernel/textlang/mailtext.go
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package textlang
+
+// What in a stored mail body is somebody writing, and what is plumbing.
+//
+// This is one question with one answer, and it had been answered in two places
+// with different lists: the language detector knew about "From:" and "Von:",
+// the draft's snippet knew about six headers, and neither knew what the other
+// knew. Four separate defects came out of that seam, all with the same shape —
+// a German thread drafting in English because the words never reached the
+// detector.
+//
+// So the vocabulary lives here, once, beside the detector that needs it most.
+
+import (
+	"strings"
+	"unicode"
+)
+
+// mailHeaders are the envelope lines the capture path stores above a body.
+// Both languages, because a German mail client writes German headers.
+var mailHeaders = []string{
+	"From: ", "To: ", "Cc: ", "Bcc: ", "Subject: ", "Date: ", "Sent: ",
+	"Von: ", "An: ", "Kopie: ", "Betreff: ", "Gesendet: ", "Datum: ",
+}
+
+// IsMailHeader reports whether a line is one of those envelope lines.
+//
+// Exported because the drafting surfaces strip the same block before showing a
+// message to a model, and a second list there is how the two answers drifted
+// apart in the first place.
+func IsMailHeader(line string) bool {
+	trimmed := strings.TrimLeftFunc(line, unicode.IsSpace)
+	for _, header := range mailHeaders {
+		if strings.HasPrefix(trimmed, header) {
+			return true
+		}
+	}
+	return false
+}
+
+// WordsWritten counts the words in text that somebody actually wrote, ignoring
+// envelope headers and quoted lines.
+//
+// It answers the question every caller here really has: is there a message in
+// this, or only the machinery around one? A forwarded mail is stored as its
+// headers and then the original with every line quoted — plenty of characters,
+// no words of its own — and treating that as a reply is what left a 1180-rune
+// German mail with 53 runes of addresses and an English draft.
+func WordsWritten(text string) int {
+	words := 0
+	for _, line := range strings.FieldsFunc(text, func(r rune) bool {
+		return r == '\n' || r == '\r'
+	}) {
+		if IsMailHeader(line) || startsQuote([]rune(strings.TrimLeftFunc(line, unicode.IsSpace))) {
+			continue
+		}
+		inWord := false
+		for _, r := range line {
+			if isWordRune(r) {
+				if !inWord {
+					words++
+					inWord = true
+				}
+				continue
+			}
+			inWord = false
+		}
+	}
+	return words
+}

--- a/backend/internal/shared/kernel/textlang/textlang.go
+++ b/backend/internal/shared/kernel/textlang/textlang.go
@@ -253,11 +253,24 @@ const ownHeaderRunes = 400
 // all the evidence there is and refusing to read it would answer Unknown for a
 // forward whose language is perfectly clear.
 func replyText(runes []rune) (text []rune, lead int) {
-	if cut := quoteStart(runes); cut > 0 {
+	if cut := quoteStart(runes); cut > 0 && WordsWritten(string(runes[:cut])) >= minReplyWords {
 		runes = runes[:cut]
 	}
 	return runes, min(len(runes), LeadRunes)
 }
+
+// minReplyWords is how much text has to sit above a quote before that text is
+// treated as the reply.
+//
+// A forwarded message is stored as its envelope headers and then the whole
+// original, every line quoted. Cutting at the quote leaves the address lines
+// and nothing else - 53 runes of a 1180-rune German mail, no words to read, and
+// the language resolves to Unknown so the draft comes out in English. That is a
+// real defect a user reported twice.
+//
+// Three words, because a header pair carries two names and a real reply above a
+// quote is a sentence.
+const minReplyWords = 3
 
 // quoteStart finds where the quoted thread begins, as a rune offset, or -1
 // when no line announces itself as quoted.
@@ -291,8 +304,7 @@ func isOwnHeader(line []rune, offset int) bool {
 	if offset >= ownHeaderRunes {
 		return false
 	}
-	text := string(line)
-	return strings.HasPrefix(text, "From: ") || strings.HasPrefix(text, "Von: ")
+	return IsMailHeader(string(line))
 }
 
 // lineAt returns the rest of the line beginning at offset.

--- a/backend/internal/shared/kernel/textlang/textlang_test.go
+++ b/backend/internal/shared/kernel/textlang/textlang_test.go
@@ -301,3 +301,36 @@ func TestVietnameseIsDecidedByAccentDensityNotStopwords(t *testing.T) {
 			"vietnamese diacritics", got)
 	}
 }
+
+// A forwarded mail is stored as its envelope headers and then the whole
+// original with EVERY line quoted. Cutting at the quote leaves the address
+// lines and nothing else — 53 runes of a 1180-rune German mail on the record
+// this reproduces — so the language resolved to Unknown and the draft came out
+// in English. Reported twice, on two different contacts.
+func TestAForwardedMailIsReadRatherThanCutToItsHeaders(t *testing.T) {
+	forwarded := "From: lars@gradion.com\nTo: frank.miller@straight.de\n\n" +
+		"> Moin moin Frank,\n> \n" +
+		"> hier wie versprochen ein kurzer Stand zu Margince. Wir sind tief in der\n" +
+		"> Entwicklung und arbeiten mit Hochdruck an einer ersten Version. Viele Dinge,\n" +
+		"> die Margince automatisch machen soll, wurden so noch nie umgesetzt.\n"
+
+	if got := textlang.Detect(forwarded); got != textlang.German {
+		t.Fatalf("Detect(forwarded german mail) = %q, want German: cutting at the quote "+
+			"leaves only the addresses, and the message is what somebody wrote", got)
+	}
+}
+
+// The cut still happens when there IS a reply above the quote — that is the
+// case it exists for, and it is what keeps a long English chain from outvoting
+// a short German reply.
+func TestAQuoteIsStillCutWhenSomethingWasWrittenAboveIt(t *testing.T) {
+	reply := "From: lars@gradion.com\nTo: marek@example.de\n\n" +
+		"Hallo Marek,\n\ndas passt gut, ich melde mich bei Ihnen mit einer Antwort " +
+		"und schicke die Unterlagen mit.\n\n"
+	quoted := strings.Repeat("> The team has reviewed this and would like to move "+
+		"forward with the proposal as it stands.\n", 12)
+
+	if got := textlang.Detect(reply + quoted); got != textlang.German {
+		t.Fatalf("Detect(german reply over english quote) = %q, want German", got)
+	}
+}


### PR DESCRIPTION
Reported on **Frank Miller** after the same defect was reported on Marek Janetzke: a German thread drafting in English, five times out of six.

## The cause

A forwarded message is stored as its envelope headers and then the whole original **with every line quoted**. `replyText` cut at the first quote marker whenever one appeared — so 1180 runes of German mail became 53 runes of two addresses, with no words at all. `Detect` answered Unknown and the draft fell back to English.

The cut now happens only when at least three real words sit above the quote. Below that there is no reply there, and the quoted text *is* the message.

## The deeper cause was two lists

"What is mail plumbing versus what somebody wrote" was answered in the detector (which knew `From:` and `Von:`) and again in the draft's snippet (which knew six headers), and neither knew what the other knew. **Four defects have come out of that seam**, all with the same shape.

The vocabulary now lives once in `textlang.IsMailHeader`, with `textlang.WordsWritten` beside it, and `persondraft` defers to it rather than keeping a second copy.

## Verified

On the real record: 1180 runes read, 56 German hits against 2 English, `detect=de`.

Live drafts for Frank went from **one German in six to two in three**. Better, and not yet good enough — the remaining English draft and the du/Sie inconsistency visible across the same samples are a separate conversation about model tier and context, which I'm raising with Lars rather than patching further here.

Two regression tests: the forwarded shape that reproduces this, and the reply-above-quote case that must still cut (which is what keeps a long English chain from outvoting a short German reply).

## Gate

`make -C backend build`, `go test ./internal/...`, `go test .` all green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes language detection for forwarded emails by reading the actual message instead of cutting at the first quote, so German threads stop drafting in English. We only cut when there are at least three real words above the quote, and header detection is unified across EN/DE labels.

- **Bug Fixes**
  - Cut before a quoted block only if there are >= 3 real words above it, preventing forwarded mails from being reduced to address headers.
  - Added regression tests for forwarded-only messages and reply-above-quote cases.

- **Refactors**
  - Unified and expanded mail header vocabulary (EN/DE) in `textlang.IsMailHeader`; `persondraft` now defers to it.
  - Added `textlang.WordsWritten` to count words excluding headers and quoted lines; used by the detector.

<sup>Written for commit cd9e4e6b15d7362171afb82b43774ffb26f62fbc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1009?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

