### PR TITLE
refactor(identity): the last module opens on a bound handle

### DIFF
--- a/backend/internal/compose/integration/installation_settings_integration_test.go
+++ b/backend/internal/compose/integration/installation_settings_integration_test.go
@@ -66,7 +66,7 @@ func installationAuditCount(t *testing.T, e *SearchEnv) int {
 
 func TestInstallationSettingsReadWriteAndGate(t *testing.T) {
 	e := SetupSearch(t)
-	store := identity.NewInstallationSettings(e.Pool, compose.NewSettingsStore(e.Pool))
+	store := identity.NewInstallationSettings(e.DB(), compose.NewSettingsStore(e.Pool))
 
 	admin := e.installationSettingsCtx(principal.ObjectGrant{Read: true, Update: true})
 	rep := e.installationSettingsCtx(principal.ObjectGrant{Read: true})
@@ -135,7 +135,7 @@ func TestInstallationSettingsReadWriteAndGate(t *testing.T) {
 
 func TestInstallationSettingsRefuseValuesTheOwningModuleRejects(t *testing.T) {
 	e := SetupSearch(t)
-	store := identity.NewInstallationSettings(e.Pool, compose.NewSettingsStore(e.Pool))
+	store := identity.NewInstallationSettings(e.DB(), compose.NewSettingsStore(e.Pool))
 	admin := e.installationSettingsCtx(principal.ObjectGrant{Read: true, Update: true})
 
 	blank := "   "
@@ -174,7 +174,7 @@ func TestInstallationSettingsRefuseValuesTheOwningModuleRejects(t *testing.T) {
 // working guard from an absent one.
 func TestBaseCurrencyFreezesOnceADealHasConvertedAgainstIt(t *testing.T) {
 	e := SetupSearch(t)
-	store := identity.NewInstallationSettings(e.Pool, compose.NewSettingsStore(e.Pool))
+	store := identity.NewInstallationSettings(e.DB(), compose.NewSettingsStore(e.Pool))
 	admin := e.installationSettingsCtx(principal.ObjectGrant{Read: true, Update: true})
 
 	// Changeable first — this is the case ADR-0085 §7 exists to serve: an
@@ -263,7 +263,7 @@ func TestBaseCurrencyFreezesOnceADealHasConvertedAgainstIt(t *testing.T) {
 // one of them — the freeze looked correct and was half-blind.
 func TestBaseCurrencyFreezesOnASentOfferWithNoClosedDeal(t *testing.T) {
 	e := SetupSearch(t)
-	store := identity.NewInstallationSettings(e.Pool, compose.NewSettingsStore(e.Pool))
+	store := identity.NewInstallationSettings(e.DB(), compose.NewSettingsStore(e.Pool))
 	admin := e.installationSettingsCtx(principal.ObjectGrant{Read: true, Update: true})
 
 	// An OPEN deal — it carries no frozen rate itself, so anything the probe
@@ -315,7 +315,7 @@ func TestBaseCurrencyFreezesOnASentOfferWithNoClosedDeal(t *testing.T) {
 // Unlike a frozen rate this is repairable, and the reason has to say so.
 func TestBaseCurrencyWillNotMoveOutFromUnderAPricedRateSheet(t *testing.T) {
 	e := SetupSearch(t)
-	store := identity.NewInstallationSettings(e.Pool, compose.NewSettingsStore(e.Pool))
+	store := identity.NewInstallationSettings(e.DB(), compose.NewSettingsStore(e.Pool))
 	admin := e.installationSettingsCtx(principal.ObjectGrant{Read: true, Update: true})
 
 	base, err := store.GetInstallation(admin)

--- a/backend/internal/compose/registry.go
+++ b/backend/internal/compose/registry.go
@@ -43,8 +43,10 @@ func NewRegistry(pool *pgxpool.Pool, send SendPath) *agents.Registry {
 // has no singleton to resolve and names the one it means instead. Same wiring,
 // same gate — only where the tenant comes from differs (ADR-0091 §9 step 3).
 func NewRegistryFor(db *database.DB, send SendPath) *agents.Registry {
-	pool := db.Pool()
-	return registryWithGate(db, auth.NewGate(identity.NewService(pool)), nil, nil, send, companyEnricher{}, nil)
+	// The gate resolves seats through identity, and identity binds the same
+	// handle: a registry built for a named workspace must not admit through a
+	// service that resolves a different one.
+	return registryWithGate(db, auth.NewGate(identity.NewServiceFor(db)), nil, nil, send, companyEnricher{}, nil)
 }
 
 // NewRegistryWithIncumbent is NewRegistry plus the per-workspace live-incumbent

--- a/backend/internal/compose/serverassembly.go
+++ b/backend/internal/compose/serverassembly.go
@@ -72,7 +72,7 @@ func (s *Server) wireCaptureSettingsSurface(pool *pgxpool.Pool) {
 	// name, reporting zone, base currency — the last of which locks once a
 	// deal has converted against it (ADR-0085 §7).
 	s.installationSettingsHandlers = installationSettingsHandlers{
-		store: identity.NewInstallationSettings(pool, NewSettingsStore(pool)),
+		store: identity.NewInstallationSettings(InstallationDB(pool), NewSettingsStore(pool)),
 	}
 	// The workspace's own consumer-mail list (CAP-PARAM-5): the surviving
 	// domain control, and the only way an operator corrects a shipped
@@ -100,9 +100,9 @@ func (s *Server) wireOnboardingSurface(pool *pgxpool.Pool) {
 	s.companyHandlers = companyHandlers{store: people.NewStore(InstallationDB(pool)), rollout: companyContextRolloutOnboarding}
 	s.siteReadHandlers = siteReadHandlers{companyContextRollout: companyContextRolloutOnboarding}
 	s.onboardingStateHandlers = onboardingStateHandlers{
-		state: identity.NewOnboardingStore(pool), company: people.NewStore(InstallationDB(pool)),
+		state: identity.NewOnboardingStore(InstallationDB(pool)), company: people.NewStore(InstallationDB(pool)),
 		proposal: &onboardingProposalEngine{
-			state: identity.NewOnboardingStore(pool), people: people.NewStore(InstallationDB(pool)),
+			state: identity.NewOnboardingStore(InstallationDB(pool)), people: people.NewStore(InstallationDB(pool)),
 			rollout: companyContextRolloutOnboarding,
 		},
 	}

--- a/backend/internal/modules/identity/actoridentity.go
+++ b/backend/internal/modules/identity/actoridentity.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
@@ -51,7 +50,7 @@ func (s *Service) ActorIdentity(ctx context.Context) (name, email string, err er
 		return "", "", nil
 	}
 
-	err = database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err = s.db.Tx(ctx, func(tx pgx.Tx) error {
 		return tx.QueryRow(ctx,
 			`SELECT display_name, email FROM app_user WHERE id = $1 AND archived_at IS NULL`,
 			human).Scan(&name, &email)

--- a/backend/internal/modules/identity/agentseat_integration_test.go
+++ b/backend/internal/modules/identity/agentseat_integration_test.go
@@ -151,8 +151,10 @@ func TestBootstrapMintsAnAgentSeatThatCarriesNoAuthorityOfItsOwn(t *testing.T) {
 // identity could come to hold a password.
 func TestNoSetPasswordLinkCanBeIssuedForTheAgentSeat(t *testing.T) {
 	owner, pool := setupIdentityDB(t)
-	svc := NewService(pool)
 	wsID, slug := bootstrapForAgentSeat(t, pool)
+	// Bound to the workspace this test just bootstrapped: the suite seeds one
+	// per test, so there is no installation singleton to resolve.
+	svc := NewServiceFor(database.BindTo(pool, wsID))
 	// Workspace AND correlation id, as the HTTP middleware binds both. Without
 	// the correlation id the write shape refuses at the audit row, so a missing
 	// guard would fail this test on the wrong error and the assertions below

--- a/backend/internal/modules/identity/authority.go
+++ b/backend/internal/modules/identity/authority.go
@@ -17,7 +17,6 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/gradionhq/margince/backend/internal/modules/identity/internal/policy"
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
@@ -80,7 +79,7 @@ func (s *Service) liveUserTx(ctx context.Context, workspaceID, humanID ids.UUID,
 	if !ok || ctxWs != workspaceID {
 		return fmt.Errorf("crmauth: authority resolution outside the bound workspace")
 	}
-	return database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	return s.db.Tx(ctx, func(tx pgx.Tx) error {
 		var seatType string
 		err := tx.QueryRow(ctx,
 			`SELECT seat_type FROM app_user

--- a/backend/internal/modules/identity/grants.go
+++ b/backend/internal/modules/identity/grants.go
@@ -19,7 +19,6 @@ import (
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/platform/httperr"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
@@ -62,7 +61,7 @@ type ListGrantsInput struct {
 
 func (s *Service) ListRecordGrants(ctx context.Context, in ListGrantsInput) ([]grantRow, error) {
 	var out []grantRow
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		var args []any
 		arg := func(v any) int { args = append(args, v); return len(args) }
 		where := "(expires_at IS NULL OR expires_at > now())"
@@ -155,7 +154,7 @@ func (s *Service) CreateRecordGrant(ctx context.Context, in CreateGrantInput) (g
 		return grantRow{}, errors.New("crmauth: only a human shares records directly; agents stage through the approval gate")
 	}
 	var out grantRow
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		// Scope-intersection: you can only share what you can see (H1
 		// probe on the client-supplied record reference).
 		if err := auth.EnsureLinkTarget(ctx, tx, in.RecordType, in.RecordID); err != nil {
@@ -202,7 +201,7 @@ func (s *Service) RevokeRecordGrant(ctx context.Context, id ids.UUID) error {
 	if !ok || actor.Type != principal.PrincipalHuman {
 		return errors.New("crmauth: only a human revokes shares directly; agents stage through the approval gate")
 	}
-	return database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	return s.db.Tx(ctx, func(tx pgx.Tx) error {
 		grant, err := scanGrant(tx.QueryRow(ctx,
 			"SELECT "+grantColumns+" FROM record_grant WHERE id = $1", id))
 		if errors.Is(err, pgx.ErrNoRows) {

--- a/backend/internal/modules/identity/installation.go
+++ b/backend/internal/modules/identity/installation.go
@@ -66,7 +66,7 @@ type InstallationBootstrap struct {
 // bootstrap values never reconcile into an existing organization
 // (restart never resets a password, role, or seed).
 func (s *Service) BootstrapInstallation(ctx context.Context, create *InstallationBootstrap, seed func(ctx context.Context, tx pgx.Tx) error) (wsID ids.WorkspaceID, created bool, err error) {
-	err = database.WithInfraTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err = database.WithInfraTx(ctx, s.db.Pool(), func(tx pgx.Tx) error {
 		if _, err := tx.Exec(ctx, `SELECT pg_advisory_xact_lock($1)`, installationLockKey); err != nil {
 			return fmt.Errorf("identity: taking the bootstrap advisory lock: %w", err)
 		}
@@ -104,7 +104,7 @@ func (s *Service) InstallationWorkspace(ctx context.Context) (ids.WorkspaceID, e
 		return *cached, nil
 	}
 	var wsID ids.WorkspaceID
-	err := database.WithInfraTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := database.WithInfraTx(ctx, s.db.Pool(), func(tx pgx.Tx) error {
 		existing, err := activeWorkspaces(ctx, tx)
 		if err != nil {
 			return err

--- a/backend/internal/modules/identity/installationsettings.go
+++ b/backend/internal/modules/identity/installationsettings.go
@@ -14,7 +14,6 @@ import (
 	"fmt"
 
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
@@ -37,15 +36,17 @@ type InstallationSettings struct {
 
 // InstallationSettingsStore reads and patches the installation settings.
 type InstallationSettingsStore struct {
-	pool     *pgxpool.Pool
+	// db binds the workspace this store runs for (ADR-0091 §9 step 3); it is
+	// held for the lock probe, which asks a question no setting read can
+	// answer: whether the currency has become immutable.
+	db       *database.DB
 	settings *settings.Store
 }
 
-// NewInstallationSettings builds the store over the settings mechanism. The
-// pool is held for the lock probe, which asks a question no setting read can
-// answer: whether the currency has become immutable.
-func NewInstallationSettings(pool *pgxpool.Pool, s *settings.Store) *InstallationSettingsStore {
-	return &InstallationSettingsStore{pool: pool, settings: s}
+// NewInstallationSettings builds the store over the settings mechanism, on a
+// handle already bound to the workspace it serves.
+func NewInstallationSettings(db *database.DB, s *settings.Store) *InstallationSettingsStore {
+	return &InstallationSettingsStore{db: db, settings: s}
 }
 
 // GetInstallation reads the three settings and the base currency's lock state.
@@ -88,7 +89,7 @@ func (s *InstallationSettingsStore) GetInstallation(ctx context.Context) (Instal
 func (s *InstallationSettingsStore) baseCurrencyLock(ctx context.Context) (bool, string, error) {
 	var locked bool
 	var why string
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		var probeErr error
 		locked, why, probeErr = BaseCurrency.Frozen(ctx, tx)
 		return probeErr
@@ -122,7 +123,7 @@ func (s *InstallationSettingsStore) UpdateInstallation(ctx context.Context, name
 		{Timezone, zone},
 		{BaseCurrency, currency},
 	}
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		for _, w := range patch {
 			if w.value == nil {
 				continue

--- a/backend/internal/modules/identity/lockout.go
+++ b/backend/internal/modules/identity/lockout.go
@@ -16,7 +16,6 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/gradionhq/margince/backend/internal/modules/identity/internal/password"
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
@@ -149,7 +148,7 @@ func (s *Service) checkCredentials(ctx context.Context, tx pgx.Tx, email, plaint
 // An unknown or non-active email still lands the audit row — an
 // invisible brute-force is exactly what the trail exists to catch.
 func (s *Service) recordFailedLogin(ctx context.Context, wsID ids.WorkspaceID, email string) error {
-	return database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	return s.db.Tx(ctx, func(tx pgx.Tx) error {
 		outcome := "failed"
 		var userID ids.UserID
 		var state lockoutState

--- a/backend/internal/modules/identity/oauth.go
+++ b/backend/internal/modules/identity/oauth.go
@@ -89,8 +89,9 @@ func (h Handlers) oauthRegister(w http.ResponseWriter, r *http.Request) {
 		httperr.Write(w, r, err)
 		return
 	}
-	err = database.WithWorkspaceTx(r.Context(), h.svc.pool, func(tx pgx.Tx) error {
-		_, err := tx.Exec(r.Context(), `
+	ctx := r.Context()
+	err = h.svc.db.Tx(ctx, func(tx pgx.Tx) error {
+		_, err := tx.Exec(ctx, `
 			INSERT INTO oauth_client (workspace_id, client_id, client_name, redirect_uris)
 			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, $2, $3)`,
 			clientID, req.ClientName, req.RedirectURIs)
@@ -185,13 +186,14 @@ func (h Handlers) validateAuthorize(r *http.Request, q url.Values) (authorizeReq
 	if err := h.svc.resolveCIMDClient(r.Context(), req.ClientID); err != nil && !errors.Is(err, errNotCIMD) {
 		return authorizeRequest{}, "invalid_client", "unknown client_id"
 	}
-	err = database.WithWorkspaceTx(r.Context(), h.svc.pool, func(tx pgx.Tx) error {
+	ctx := r.Context()
+	err = h.svc.db.Tx(ctx, func(tx pgx.Tx) error {
 		var uris []string
 		// A disabled or deleted client reads as UNKNOWN, deliberately: the same
 		// answer an unregistered client_id gets, so the refusal tells an
 		// attacker nothing about whether a client exists and has been switched
 		// off.
-		err := tx.QueryRow(r.Context(),
+		err := tx.QueryRow(ctx,
 			`SELECT c.client_name, c.redirect_uris FROM oauth_client c
 			  WHERE c.client_id = $1 AND `+liveClientPredicate,
 			req.ClientID).Scan(&req.ClientName, &uris)

--- a/backend/internal/modules/identity/oauth_cimd.go
+++ b/backend/internal/modules/identity/oauth_cimd.go
@@ -38,7 +38,6 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/netguard"
 )
 
@@ -144,7 +143,7 @@ func (s *Service) resolveCIMDClient(ctx context.Context, clientID string) error 
 // admin switched off keep this server making outbound requests on its behalf.
 func (s *Service) cimdCacheIsFresh(ctx context.Context, clientID string) (bool, error) {
 	var fresh bool
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		return tx.QueryRow(ctx, `
 			SELECT (metadata_expires_at IS NOT NULL AND metadata_expires_at > now())
 			       OR disabled_at IS NOT NULL OR deleted_at IS NOT NULL
@@ -168,7 +167,7 @@ func (s *Service) cimdCacheIsFresh(ctx context.Context, clientID string) (bool, 
 // list. The conflict target is the row this document may own or nothing.
 func (s *Service) upsertCIMDClient(ctx context.Context, doc cimdDocument, ttl time.Duration) error {
 	expires := time.Now().Add(ttl)
-	return database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	return s.db.Tx(ctx, func(tx pgx.Tx) error {
 		_, err := tx.Exec(ctx, `
 			INSERT INTO oauth_client (workspace_id, client_id, client_name, redirect_uris, created_via, metadata_expires_at)
 			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, $2, $3, 'cimd', $4)

--- a/backend/internal/modules/identity/oauth_cimd_integration_test.go
+++ b/backend/internal/modules/identity/oauth_cimd_integration_test.go
@@ -52,7 +52,6 @@ func setupCIMD(t *testing.T, slug string) *cimdEnv {
 	t.Helper()
 	owner, pool := setupIdentityDB(t)
 	_ = owner
-	svc := NewService(pool)
 	slug += "-" + ids.NewV7().String()[24:]
 
 	var wsID ids.WorkspaceID
@@ -70,6 +69,9 @@ func setupCIMD(t *testing.T, slug string) *cimdEnv {
 		t.Fatalf("creating the installation: %v", err)
 	}
 
+	// Bound to the workspace this fixture just created: the suite seeds one per
+	// test, so there is no installation singleton to resolve.
+	svc := NewServiceFor(database.BindTo(pool, wsID))
 	e := &cimdEnv{
 		svc: svc,
 		ctx: principal.WithWorkspaceID(context.Background(), wsID.UUID),
@@ -95,7 +97,7 @@ func setupCIMD(t *testing.T, slug string) *cimdEnv {
 // client reads back the one row a document produced.
 func (e *cimdEnv) client(t *testing.T, clientID string) (name, via string, redirects []string, expires *time.Time) {
 	t.Helper()
-	err := database.WithWorkspaceTx(e.ctx, e.svc.pool, func(tx pgx.Tx) error {
+	err := database.WithWorkspaceTx(e.ctx, e.svc.db.Pool(), func(tx pgx.Tx) error {
 		return tx.QueryRow(e.ctx,
 			`SELECT client_name, created_via, redirect_uris, metadata_expires_at
 			   FROM oauth_client WHERE client_id = $1`, clientID).
@@ -187,7 +189,7 @@ func TestAStaleDocumentIsRefetchedAndItsNewContentWins(t *testing.T) {
 // expire backdates the cache so the next resolve has to fetch.
 func (e *cimdEnv) expire(t *testing.T, clientID string) {
 	t.Helper()
-	err := database.WithWorkspaceTx(e.ctx, e.svc.pool, func(tx pgx.Tx) error {
+	err := database.WithWorkspaceTx(e.ctx, e.svc.db.Pool(), func(tx pgx.Tx) error {
 		_, err := tx.Exec(e.ctx,
 			`UPDATE oauth_client SET metadata_expires_at = now() - interval '1 hour' WHERE client_id = $1`, clientID)
 		return err
@@ -207,7 +209,7 @@ func TestADisabledClientIsNotFetchedAgain(t *testing.T) {
 		t.Fatal(err)
 	}
 	e.expire(t, clientID)
-	err := database.WithWorkspaceTx(e.ctx, e.svc.pool, func(tx pgx.Tx) error {
+	err := database.WithWorkspaceTx(e.ctx, e.svc.db.Pool(), func(tx pgx.Tx) error {
 		_, err := tx.Exec(e.ctx, `UPDATE oauth_client SET disabled_at = now() WHERE client_id = $1`, clientID)
 		return err
 	})
@@ -233,7 +235,7 @@ func TestADisabledClientIsNotFetchedAgain(t *testing.T) {
 func TestADocumentCannotTakeOverARegisteredClient(t *testing.T) {
 	e := setupCIMD(t, "cimd-takeover")
 	clientID := e.docs.URL + "/client.json"
-	err := database.WithWorkspaceTx(e.ctx, e.svc.pool, func(tx pgx.Tx) error {
+	err := database.WithWorkspaceTx(e.ctx, e.svc.db.Pool(), func(tx pgx.Tx) error {
 		_, err := tx.Exec(e.ctx, `
 			INSERT INTO oauth_client (workspace_id, client_id, client_name, redirect_uris, created_via)
 			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, 'Registered', $2, 'dcr')`,
@@ -286,7 +288,7 @@ func TestARefusedDocumentLeavesNoRow(t *testing.T) {
 	}
 
 	var rows int
-	if err := database.WithWorkspaceTx(e.ctx, e.svc.pool, func(tx pgx.Tx) error {
+	if err := database.WithWorkspaceTx(e.ctx, e.svc.db.Pool(), func(tx pgx.Tx) error {
 		return tx.QueryRow(e.ctx, `SELECT count(*) FROM oauth_client WHERE client_id = $1`, clientID).Scan(&rows)
 	}); err != nil {
 		t.Fatal(err)

--- a/backend/internal/modules/identity/oauth_consent.go
+++ b/backend/internal/modules/identity/oauth_consent.go
@@ -22,7 +22,6 @@ import (
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/httperr"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
@@ -76,7 +75,7 @@ func (s *Service) SelectablePassports(ctx context.Context, id Identity) ([]Conse
 		return nil, err
 	}
 	var out []ConsentOption
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		rows, err := tx.Query(ctx, `
 			SELECT id, label, scopes, expires_at
 			FROM passport
@@ -188,7 +187,7 @@ func lockLentPassport(
 // database problem is never mistaken for a client that does not exist.
 func (s *Service) liveClient(ctx context.Context, clientID string) (string, error) {
 	var name string
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		return tx.QueryRow(ctx,
 			`SELECT c.client_name FROM oauth_client c WHERE c.client_id = $1 AND `+liveClientPredicate,
 			clientID).Scan(&name)

--- a/backend/internal/modules/identity/oauth_grant.go
+++ b/backend/internal/modules/identity/oauth_grant.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
@@ -393,7 +392,7 @@ const clientRevokeReason = "revoked via RFC 7009 /oauth/revoke"
 // forbids this endpoint from ever becoming an oracle for whether a token
 // string is real.
 func (s *Service) revokeToken(ctx context.Context, in revokeTokenInput) error {
-	return database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	return s.db.Tx(ctx, func(tx pgx.Tx) error {
 		grantID, err := resolveGrantID(ctx, tx, in)
 		if err != nil {
 			return err

--- a/backend/internal/modules/identity/oauth_lend.go
+++ b/backend/internal/modules/identity/oauth_lend.go
@@ -18,7 +18,6 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
@@ -79,7 +78,7 @@ func (s *Service) mintLentAuthorizationCode(
 	if err != nil {
 		return "", false, err
 	}
-	err = database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err = s.db.Tx(ctx, func(tx pgx.Tx) error {
 		if err := lockConsentingUser(ctx, tx, id); err != nil {
 			return err
 		}

--- a/backend/internal/modules/identity/oauth_lend_lock_integration_test.go
+++ b/backend/internal/modules/identity/oauth_lend_lock_integration_test.go
@@ -93,7 +93,7 @@ func (e *lendEnv) lend(svc *Service, rawPassportID string) (code string, lendabl
 func (e *lendEnv) revokeAndHold(t *testing.T, passportID ids.PassportID, fn func(tx pgx.Tx) error) {
 	t.Helper()
 	ctx := e.wsCtx(e.admin)
-	if err := database.WithWorkspaceTx(ctx, e.svc.pool, func(tx pgx.Tx) error {
+	if err := e.svc.db.Tx(ctx, func(tx pgx.Tx) error {
 		if err := e.svc.revokePassportTx(ctx, tx, e.admin, passportID); err != nil {
 			return err
 		}
@@ -184,14 +184,14 @@ func (e *lendEnv) codesAndLendAudits(t *testing.T) (codes, audits int) {
 //
 // The bound is a test instrument, not this endpoint's production behaviour: a
 // real consent waits, which the blocking case below is about.
-func lockWaitBoundedService(t *testing.T) *Service {
+func lockWaitBoundedService(t *testing.T, ws ids.WorkspaceID) *Service {
 	t.Helper()
 	pool, err := database.NewPool(context.Background(), lockBoundedDSN(t, 250*time.Millisecond))
 	if err != nil {
 		t.Fatalf("opening the lock-bounded pool: %v", err)
 	}
 	t.Cleanup(pool.Close)
-	return NewService(pool)
+	return NewServiceFor(database.BindTo(pool, ws))
 }
 
 // lockBoundedDSN adds lock_timeout to the test DSN through the URL's query, not
@@ -225,7 +225,7 @@ func lockBoundedDSN(t *testing.T, bound time.Duration) string {
 // Whatever the consent answered, nothing durable may exist afterwards.
 func TestAConsentRacingARevocationOfTheLentPassportWritesNoCode(t *testing.T) {
 	e := setupLendEnv(t, "lend-race-revoke")
-	bounded := lockWaitBoundedService(t)
+	bounded := lockWaitBoundedService(t, e.ws)
 
 	var (
 		code       string
@@ -299,7 +299,7 @@ func TestAConsentBlockedByARevocationRefusesInsteadOfMintingACode(t *testing.T) 
 // narrower request, and the courier itself is stored only as a hash.
 func TestAnUncontendedLendCommitsTheCodeAndItsAudit(t *testing.T) {
 	e := setupLendEnv(t, "lend-uncontended")
-	bounded := lockWaitBoundedService(t)
+	bounded := lockWaitBoundedService(t, e.ws)
 
 	code, lendable, err := e.lend(bounded, e.passport.String())
 	if err != nil {
@@ -331,7 +331,7 @@ func TestAnUncontendedLendCommitsTheCodeAndItsAudit(t *testing.T) {
 // any revocation.
 func TestALendIsUnaffectedByARevocationOfAnotherPassport(t *testing.T) {
 	e := setupLendEnv(t, "lend-other-passport")
-	bounded := lockWaitBoundedService(t)
+	bounded := lockWaitBoundedService(t, e.ws)
 	other := e.mintLendable(t, e.admin, []string{"read"})
 
 	var (

--- a/backend/internal/modules/identity/oauth_lockorder_integration_test.go
+++ b/backend/internal/modules/identity/oauth_lockorder_integration_test.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
@@ -71,7 +70,7 @@ func (e *revocationEnv) connectOAuthLent(
 	var out connectFixture
 	out.clientID = clientID
 	ctx := e.wsCtx(consenter)
-	if err := database.WithWorkspaceTx(ctx, e.svc.pool, func(tx pgx.Tx) error {
+	if err := e.svc.db.Tx(ctx, func(tx pgx.Tx) error {
 		var err error
 		out.grantID, out.refresh, err = issueGrant(ctx, tx, issueGrantInput{
 			WorkspaceID: consenter.WorkspaceID, UserID: consenter.UserID, ClientID: clientID,
@@ -119,7 +118,7 @@ func TestARevokeRacingARotationNeverDeadlocksOrLeavesACredentialLive(t *testing.
 		}()
 		go func() {
 			defer wg.Done()
-			revokeErr = database.WithWorkspaceTx(revokeCtx, e.svc.pool, func(tx pgx.Tx) error {
+			revokeErr = e.svc.db.Tx(revokeCtx, func(tx pgx.Tx) error {
 				return revokeGrantTx(revokeCtx, tx, fixture.grantID, "the human ended the connection")
 			})
 		}()
@@ -224,7 +223,7 @@ func (e *revocationEnv) mintUnderGrantFor(t *testing.T, grantID ids.UUID, consen
 	t.Helper()
 	ctx := e.wsCtx(consenter)
 	var issued IssuedPassport
-	if err := database.WithWorkspaceTx(ctx, e.svc.pool, func(tx pgx.Tx) error {
+	if err := e.svc.db.Tx(ctx, func(tx pgx.Tx) error {
 		label := oauthPassportLabel("lock order")
 		var err error
 		issued, err = mintPassport(ctx, tx, consenter,

--- a/backend/internal/modules/identity/oauth_refresh.go
+++ b/backend/internal/modules/identity/oauth_refresh.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
@@ -115,7 +114,7 @@ func (s *Service) rotateRefreshToken(ctx context.Context, in refreshRequest) (Is
 		refresh string
 		reused  bool
 	)
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		var err error
 		issued, refresh, reused, err = s.rotateRefreshTokenTx(ctx, tx, in)
 		return err

--- a/backend/internal/modules/identity/oauth_token.go
+++ b/backend/internal/modules/identity/oauth_token.go
@@ -148,7 +148,8 @@ func writeTokenResponse(w http.ResponseWriter, issued IssuedPassport, refresh st
 //
 // refresh is empty unless the authorization carried offline_access.
 func (h Handlers) exchangeAuthCode(r *http.Request, code, verifier string) (issued IssuedPassport, refresh string, err error) {
-	err = database.WithWorkspaceTx(r.Context(), h.svc.pool, func(tx pgx.Tx) error {
+	ctx := r.Context()
+	err = h.svc.db.Tx(ctx, func(tx pgx.Tx) error {
 		redeemed, err := h.consumeAuthCode(r, tx, code, verifier)
 		if err != nil {
 			return err
@@ -168,7 +169,7 @@ func (h Handlers) exchangeAuthCode(r *http.Request, code, verifier string) (issu
 			})
 		}
 
-		grantID, refreshToken, err := issueGrant(r.Context(), tx, issueGrantInput{
+		grantID, refreshToken, err := issueGrant(ctx, tx, issueGrantInput{
 			WorkspaceID:    redeemed.WorkspaceID,
 			UserID:         redeemed.UserID,
 			ClientID:       redeemed.ClientID,
@@ -185,7 +186,7 @@ func (h Handlers) exchangeAuthCode(r *http.Request, code, verifier string) (issu
 		// The label names the client the consent was for; the grant is what
 		// actually binds the passport to it.
 		label := oauthPassportLabel(redeemed.ClientID)
-		issued, err = mintPassport(r.Context(), tx,
+		issued, err = mintPassport(ctx, tx,
 			Identity{UserID: redeemed.UserID, WorkspaceID: redeemed.WorkspaceID},
 			IssuePassportInput{Label: &label, Scopes: passportScopes, TTL: h.accessTokenTTL()}, &grantID)
 		return err

--- a/backend/internal/modules/identity/onboarding.go
+++ b/backend/internal/modules/identity/onboarding.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgxpool"
 	openapi_types "github.com/oapi-codegen/runtime/types"
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
@@ -142,11 +141,14 @@ func invalidOnboarding(field, reason string) error {
 }
 
 // OnboardingStore owns per-human resumable wizard checkpoints.
-type OnboardingStore struct{ pool *pgxpool.Pool }
+// OnboardingStore's db binds the workspace this store runs for (ADR-0091 §9
+// step 3).
+type OnboardingStore struct{ db *database.DB }
 
-// NewOnboardingStore builds the workspace-scoped checkpoint store.
-func NewOnboardingStore(pool *pgxpool.Pool) *OnboardingStore {
-	return &OnboardingStore{pool: pool}
+// NewOnboardingStore opens the workspace-scoped checkpoint store on a handle
+// already bound to the workspace it serves.
+func NewOnboardingStore(db *database.DB) *OnboardingStore {
+	return &OnboardingStore{db: db}
 }
 
 func onboardingActor(ctx context.Context, mutate bool) (principal.Principal, error) {
@@ -167,7 +169,7 @@ func (s *OnboardingStore) Get(ctx context.Context) (OnboardingState, error) {
 		return OnboardingState{}, err
 	}
 	var state OnboardingState
-	err = database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err = s.db.Tx(ctx, func(tx pgx.Tx) error {
 		var draft []byte
 		row := tx.QueryRow(ctx, `SELECT id, path, step, source_mode, website_url, site_read_id,
 			company_draft, selected_fact_keys, voice_skipped, connect_skipped, version,
@@ -200,7 +202,7 @@ func (s *OnboardingStore) Put(
 	}
 
 	var state OnboardingState
-	err = database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err = s.db.Tx(ctx, func(tx pgx.Tx) error {
 		companyExists, companyComplete, err := readCompanyState(ctx, tx)
 		if err != nil {
 			return err

--- a/backend/internal/modules/identity/passport.go
+++ b/backend/internal/modules/identity/passport.go
@@ -22,7 +22,6 @@ import (
 	openapi_types "github.com/oapi-codegen/runtime/types"
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
@@ -114,7 +113,7 @@ func (e *InvalidScopeError) Error() string {
 // A1/local path, where the passport answers to no OAuth grant.
 func (s *Service) IssuePassport(ctx context.Context, id Identity, in IssuePassportInput) (IssuedPassport, error) {
 	var out IssuedPassport
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		var err error
 		out, err = mintPassport(ctx, tx, id, in, nil)
 		return err
@@ -195,7 +194,7 @@ func mintPassport(ctx context.Context, tx pgx.Tx, id Identity, in IssuePassportI
 // function must not invert.
 func (s *Service) RevokePassport(ctx context.Context, id Identity, passportID ids.PassportID) error {
 	ctx = actorCtx(ctx, id)
-	return database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	return s.db.Tx(ctx, func(tx pgx.Tx) error {
 		return s.revokePassportTx(ctx, tx, id, passportID)
 	})
 }
@@ -407,7 +406,7 @@ func (s *Service) authenticateAgentWhere(ctx context.Context, tx pgx.Tx, predica
 // when enqueued.
 func (s *Service) AuthenticateAgentByID(ctx context.Context, passportID ids.PassportID) (AgentIdentity, error) {
 	var a AgentIdentity
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		var err error
 		a, err = s.authenticateAgentWhere(ctx, tx, agentByIDPredicate, passportID)
 		return err
@@ -428,7 +427,7 @@ func (s *Service) AuthenticateAgent(ctx context.Context, rawToken string) (Agent
 	}
 
 	var a AgentIdentity
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		var err error
 		a, err = s.authenticateAgentWhere(ctx, tx, agentByHashPredicate, hashToken(rawToken))
 		return err

--- a/backend/internal/modules/identity/passport_list.go
+++ b/backend/internal/modules/identity/passport_list.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
@@ -114,7 +113,7 @@ func (s *Service) ListPassports(ctx context.Context, id Identity) ([]PassportRow
 	}
 	query := fmt.Sprintf(listPassportsSQL, scope)
 	var out []PassportRow
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		rows, err := tx.Query(ctx, query, args...)
 		if err != nil {
 			return err

--- a/backend/internal/modules/identity/reset.go
+++ b/backend/internal/modules/identity/reset.go
@@ -34,7 +34,6 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/gradionhq/margince/backend/internal/modules/identity/internal/password"
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/httperr"
 	"github.com/gradionhq/margince/backend/internal/platform/httpserver"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
@@ -202,7 +201,7 @@ func (s *Service) CreatePasswordReset(ctx context.Context, email string) (string
 	}
 
 	minted := false
-	err = database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err = s.db.Tx(ctx, func(tx pgx.Tx) error {
 		var userID ids.UserID
 		lookupErr := tx.QueryRow(ctx,
 			`SELECT id FROM app_user
@@ -257,7 +256,7 @@ func (s *Service) RedeemPasswordReset(ctx context.Context, rawToken, newPassword
 	if err != nil {
 		return err
 	}
-	return database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	return s.db.Tx(ctx, func(tx pgx.Tx) error {
 		var tokenID ids.UUID
 		var userID ids.UserID
 		lookupErr := tx.QueryRow(ctx,

--- a/backend/internal/modules/identity/revocation_integration_test.go
+++ b/backend/internal/modules/identity/revocation_integration_test.go
@@ -72,8 +72,12 @@ func setupIdentityDB(t *testing.T) (*pgx.Conn, *pgxpool.Pool) {
 // revocationEnv is one bootstrapped workspace: an admin (with session)
 // plus a plain second user with a known password.
 type revocationEnv struct {
-	owner  *pgx.Conn
-	svc    *Service
+	owner *pgx.Conn
+	svc   *Service
+	// ws is the workspace this env bootstrapped, for the fixtures that build a
+	// second service of their own — a pinned handle is what they need, since
+	// the suite seeds one workspace per env and there is no singleton.
+	ws     ids.WorkspaceID
 	admin  Identity
 	member Identity
 }
@@ -83,7 +87,6 @@ const memberPassword = "correct horse battery staple"
 func setupRevocationEnv(t *testing.T, slug string) *revocationEnv {
 	t.Helper()
 	owner, pool := setupIdentityDB(t)
-	svc := NewService(pool)
 	ctx := context.Background()
 	// The database persists across binary runs; key the slug (and the
 	// emails derived from it) uniquely so reruns never collide. The suffix is
@@ -111,6 +114,9 @@ func setupRevocationEnv(t *testing.T, slug string) *revocationEnv {
 	if err != nil {
 		t.Fatalf("bootstrap: %v", err)
 	}
+	// Bound to the workspace just created: this suite seeds one per env, so
+	// there is no installation singleton to resolve.
+	svc := NewServiceFor(database.BindTo(pool, wsID))
 	// Login resolves the admin's full Identity (roles, permissions) the
 	// way the HTTP surface would.
 	admin, _, err := svc.Login(principal.WithWorkspaceID(ctx, wsID.UUID), adminEmail, "a bootstrap password!")
@@ -132,7 +138,7 @@ func setupRevocationEnv(t *testing.T, slug string) *revocationEnv {
 	}
 
 	return &revocationEnv{
-		owner: owner, svc: svc, admin: admin,
+		owner: owner, svc: svc, ws: wsID, admin: admin,
 		member: Identity{UserID: memberID, WorkspaceID: admin.WorkspaceID, Email: memberEmail},
 	}
 }

--- a/backend/internal/modules/identity/roles.go
+++ b/backend/internal/modules/identity/roles.go
@@ -30,7 +30,6 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/gradionhq/margince/backend/internal/modules/identity/internal/policy"
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
@@ -96,7 +95,7 @@ func (s *Service) ListRoles(ctx context.Context, actor Identity) ([]roleRow, err
 	}
 	ctx = actorCtx(ctx, actor)
 	var out []roleRow
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		rows, err := tx.Query(ctx,
 			`SELECT key, name, is_system, version, permissions
 			   FROM role WHERE archived_at IS NULL ORDER BY key`)
@@ -146,7 +145,7 @@ func (s *Service) SetRoleObjectGrant(ctx context.Context, actor Identity, roleKe
 	}
 	ctx = actorCtx(ctx, actor)
 	var updated roleRow
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		var err error
 		updated, err = applyRoleObjectGrant(ctx, tx, roleKey, object, grant, ifVersion)
 		return err

--- a/backend/internal/modules/identity/roster.go
+++ b/backend/internal/modules/identity/roster.go
@@ -17,7 +17,6 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
@@ -150,7 +149,7 @@ func (s *Service) ListUsers(ctx context.Context, in ListUsersInput) ([]userRow, 
 	if in.IncludeInactive {
 		plain, filtered = listUsersAllQuery, listUsersAllFilteredQuery
 	}
-	return listRosterPage(ctx, s.db.Pool(), in.Q, in.Cursor, in.Limit, rosterQuery[userRow]{
+	return listRosterPage(ctx, s.db, in.Q, in.Cursor, in.Limit, rosterQuery[userRow]{
 		plain:     plain,
 		filtered:  filtered,
 		leadArgs:  []any{in.WithRoles},
@@ -211,7 +210,7 @@ func scanTeam(r pgx.Row) (teamRow, error) {
 // teams (row-scoped by RLS) with each team's active-membership count,
 // optionally filtered by in.Q.
 func (s *Service) ListTeams(ctx context.Context, in ListTeamsInput) ([]teamRow, storekit.Page, error) {
-	return listRosterPage(ctx, s.db.Pool(), in.Q, in.Cursor, in.Limit, rosterQuery[teamRow]{
+	return listRosterPage(ctx, s.db, in.Q, in.Cursor, in.Limit, rosterQuery[teamRow]{
 		plain:     listTeamsQuery,
 		filtered:  listTeamsFilteredQuery,
 		scan:      scanTeam,
@@ -263,7 +262,7 @@ type rosterQuery[T userRow | teamRow] struct {
 // a page + continuation cursor. Generic over the row type so ListUsers and
 // ListTeams share this instead of carrying two copies of the same plumbing.
 func listRosterPage[T userRow | teamRow](
-	ctx context.Context, pool *pgxpool.Pool,
+	ctx context.Context, db *database.DB,
 	q, cursor *string, limitIn *int,
 	spec rosterQuery[T],
 ) ([]T, storekit.Page, error) {
@@ -274,7 +273,7 @@ func listRosterPage[T userRow | teamRow](
 	}
 
 	var pageRows []T
-	err = database.WithWorkspaceTx(ctx, pool, func(tx pgx.Tx) error {
+	err = db.Tx(ctx, func(tx pgx.Tx) error {
 		var rows pgx.Rows
 		var err error
 		if q != nil && *q != "" {

--- a/backend/internal/modules/identity/roster.go
+++ b/backend/internal/modules/identity/roster.go
@@ -129,7 +129,7 @@ const getUserQuery = `SELECT ` + userColumns + ` FROM app_user WHERE id = $2 AND
 // it always asks for the role keys. ErrNotFound when absent or archived.
 func (s *Service) GetUser(ctx context.Context, userID ids.UserID) (userRow, error) {
 	var u userRow
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		row, scanErr := scanUser(tx.QueryRow(ctx, getUserQuery, true, userID))
 		if errors.Is(scanErr, pgx.ErrNoRows) {
 			return apperrors.ErrNotFound
@@ -150,7 +150,7 @@ func (s *Service) ListUsers(ctx context.Context, in ListUsersInput) ([]userRow, 
 	if in.IncludeInactive {
 		plain, filtered = listUsersAllQuery, listUsersAllFilteredQuery
 	}
-	return listRosterPage(ctx, s.pool, in.Q, in.Cursor, in.Limit, rosterQuery[userRow]{
+	return listRosterPage(ctx, s.db.Pool(), in.Q, in.Cursor, in.Limit, rosterQuery[userRow]{
 		plain:     plain,
 		filtered:  filtered,
 		leadArgs:  []any{in.WithRoles},
@@ -211,7 +211,7 @@ func scanTeam(r pgx.Row) (teamRow, error) {
 // teams (row-scoped by RLS) with each team's active-membership count,
 // optionally filtered by in.Q.
 func (s *Service) ListTeams(ctx context.Context, in ListTeamsInput) ([]teamRow, storekit.Page, error) {
-	return listRosterPage(ctx, s.pool, in.Q, in.Cursor, in.Limit, rosterQuery[teamRow]{
+	return listRosterPage(ctx, s.db.Pool(), in.Q, in.Cursor, in.Limit, rosterQuery[teamRow]{
 		plain:     listTeamsQuery,
 		filtered:  listTeamsFilteredQuery,
 		scan:      scanTeam,

--- a/backend/internal/modules/identity/seatnames.go
+++ b/backend/internal/modules/identity/seatnames.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
@@ -37,7 +36,7 @@ func (s *Service) SeatNames(ctx context.Context, seats []ids.UserID) (map[ids.UU
 	if len(seats) == 0 {
 		return names, nil
 	}
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		rows, err := tx.Query(ctx,
 			`SELECT id, display_name FROM app_user WHERE id = ANY($1) AND archived_at IS NULL`, seats)
 		if err != nil {

--- a/backend/internal/modules/identity/service.go
+++ b/backend/internal/modules/identity/service.go
@@ -37,7 +37,11 @@ const (
 // Service owns identity: the singleton organization, users, opaque
 // server-side sessions.
 type Service struct {
-	pool *pgxpool.Pool
+	// db binds the installation's workspace, resolved through this service's
+	// own InstallationWorkspace — which reads no tenant table, so a service
+	// holding a handle that resolves through it is not circular at runtime
+	// (ADR-0091 §9 step 3).
+	db *database.DB
 	// now is the service's clock: the §27 lockout window and duration are
 	// judged against it, so tests prove the lock/expiry transitions
 	// without sleeping. Session/passport expiries stay on the database's
@@ -50,7 +54,19 @@ type Service struct {
 }
 
 func NewService(pool *pgxpool.Pool) *Service {
-	return &Service{pool: pool, now: time.Now}
+	svc := &Service{now: time.Now}
+	svc.db = database.Bind(pool, svc.InstallationWorkspace)
+	return svc
+}
+
+// NewServiceFor is NewService over a handle whose workspace is already decided.
+//
+// A server resolves the installation's singleton, which is what NewService does
+// for it. A suite that seeds a workspace per test has no singleton to resolve —
+// identity is the module that refuses when a second one exists — so it names the
+// one it means instead (ADR-0091 §9 step 3).
+func NewServiceFor(db *database.DB) *Service {
+	return &Service{db: db, now: time.Now}
 }
 
 // Identity is the authenticated principal's resolved state — what /me
@@ -185,7 +201,7 @@ func (s *Service) Login(ctx context.Context, email, plaintext string) (Identity,
 	}
 
 	var id Identity
-	err = database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err = s.db.Tx(ctx, func(tx pgx.Tx) error {
 		account, err := s.checkCredentials(ctx, tx, email, plaintext)
 		if err != nil {
 			return err
@@ -252,7 +268,7 @@ func (s *Service) Authenticate(ctx context.Context, rawToken string) (Identity, 
 	tokenHash := hashToken(rawToken)
 
 	var id Identity
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		// note: a session is keyed by its opaque token, not exposed as a
 		// first-class entity id — its row id has no kind and stays ids.UUID.
 		var sessionID ids.UUID
@@ -300,7 +316,7 @@ func (s *Service) Logout(ctx context.Context, rawToken string) error {
 		// revoke, same no-op as an unknown token.
 		return nil
 	}
-	return database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	return s.db.Tx(ctx, func(tx pgx.Tx) error {
 		_, err := tx.Exec(ctx,
 			`UPDATE session SET revoked_at = now() WHERE token_hash = $1 AND revoked_at IS NULL`,
 			hashToken(rawToken))

--- a/backend/internal/modules/identity/userpasswordlink.go
+++ b/backend/internal/modules/identity/userpasswordlink.go
@@ -27,7 +27,6 @@ import (
 	openapi_types "github.com/oapi-codegen/runtime/types"
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
@@ -96,7 +95,7 @@ func (s *Service) IssuePasswordLink(ctx context.Context, actor Identity, userID 
 	}
 	ctx = actorCtx(ctx, actor)
 	var expiresAt time.Time
-	err = database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err = s.db.Tx(ctx, func(tx pgx.Tx) error {
 		superseded, err := supersedeSetPasswordTokens(ctx, tx, userID)
 		if err != nil {
 			return err

--- a/backend/internal/modules/identity/users.go
+++ b/backend/internal/modules/identity/users.go
@@ -20,7 +20,6 @@ import (
 	openapi_types "github.com/oapi-codegen/runtime/types"
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
@@ -87,7 +86,7 @@ func (s *Service) InviteUser(ctx context.Context, actor Identity, in InviteUserI
 	}
 	ctx = actorCtx(ctx, actor)
 	var newUserID ids.UserID
-	err = database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	err = s.db.Tx(ctx, func(tx pgx.Tx) error {
 		var roleID ids.UUID
 		roleErr := tx.QueryRow(ctx, `SELECT id FROM role WHERE key = $1`, in.Role).Scan(&roleID)
 		if errors.Is(roleErr, pgx.ErrNoRows) {
@@ -149,7 +148,7 @@ func (s *Service) ReactivateUser(ctx context.Context, actor Identity, userID ids
 		return apperrors.ErrPermissionDenied
 	}
 	ctx = actorCtx(ctx, actor)
-	return database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	return s.db.Tx(ctx, func(tx pgx.Tx) error {
 		var status string
 		err := tx.QueryRow(ctx,
 			`SELECT status FROM app_user WHERE id = $1 AND archived_at IS NULL FOR UPDATE`,
@@ -237,7 +236,7 @@ func (s *Service) DeactivateUser(ctx context.Context, actor Identity, in Deactiv
 		return apperrors.ErrPermissionDenied
 	}
 	ctx = actorCtx(ctx, actor)
-	return database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	return s.db.Tx(ctx, func(tx pgx.Tx) error {
 		var status string
 		err := tx.QueryRow(ctx,
 			`SELECT status FROM app_user WHERE id = $1 AND archived_at IS NULL FOR UPDATE`,
@@ -372,7 +371,7 @@ func (s *Service) ChangeUserRole(ctx context.Context, actor Identity, userID ids
 		return apperrors.ErrPermissionDenied
 	}
 	ctx = actorCtx(ctx, actor)
-	return database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+	return s.db.Tx(ctx, func(tx pgx.Tx) error {
 		// The target is read rather than merely proved to exist, because what it
 		// IS decides the answer: an agent seat holds no role at all.
 		var isAgent bool


### PR DESCRIPTION
`identity` was the one module left on a raw pool, and the stated reason was that its handle would have to resolve through identity itself. It can: `InstallationWorkspace` reads no tenant table — it runs on an infra transaction — so a service holding a handle bound through its own resolver is not circular at runtime.

## Why identity needed the pinned sibling most

`NewServiceFor` is the same shape every other module already has. Identity needs it more than they do: its suites bootstrap an installation *per test*, so the module that **refuses when a second workspace exists** is exactly the one whose fixtures cannot resolve a singleton. Each now names the workspace it just created.

## One real defect this surfaced

The tool registry's admission gate resolves seats through identity, and it was building a service of its own. A registry built for a named workspace must not admit through a service resolving a different one — which is what left an ungoverned-agent refusal answering `ErrMultipleWorkspaces` instead of the `ErrUnsupportedBySoR` it exists to assert. The gate now takes the registry's own handle.

## Step 3 is complete

Every module opens on a pool that knows its workspace, and `DB.Tx` is still the `WithWorkspaceTx` GUC spelling — so RLS stays armed and the tenant-isolation suite stays the mechanical proof that this collapse was faithful. That ordering is ADR-0091 §9's, and it is what makes the schema phase safe to start.

## Verification

- `make check-backend` — green
- `craft static --strict` over all 31 changed Go files — 0 findings
- `make test-integration` — `OK: integration passed with 0 skips (38 packages, parallel)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored the `identity` module to use a workspace‑bound `database.DB` and added `NewServiceFor` for explicit workspace wiring. This completes ADR‑0091 §9 step 3, keeps RLS enforced, and fixes both the registry admission path and roster paging to always use the bound workspace.

- **Refactors**
  - `identity.Service` now holds `db *database.DB` and uses `s.db.Tx` for transactions.
  - Added `NewServiceFor(db)`; `NewService(pool)` now binds via `InstallationWorkspace`.
  - `InstallationSettingsStore` and `OnboardingStore` now take a bound `db`; server wiring uses `InstallationDB(pool)`.
  - `compose.NewRegistryFor` builds the gate with `identity.NewServiceFor(db)`.
  - Tests bind services to the workspace they create.

- **Bug Fixes**
  - Registry admission gate now resolves through the same bound handle, returning `ErrUnsupportedBySoR` instead of `ErrMultipleWorkspaces` when appropriate.
  - Roster paging now uses the bound handle (`s.db`), so workspace‑pinned services aren’t bypassed.

<sup>Written for commit dfb3c202f0871f551d0b99474b054f0211ecf9f2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1010?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved workspace-scoped database handling across identity, OAuth, onboarding, installation settings, user, role, passport, and access-management operations.
  * Standardized transaction execution to use the active workspace context, helping ensure data access remains correctly isolated.
  * Updated service setup and configuration flows to use workspace-bound database connections.
* **Tests**
  * Updated integration tests and fixtures to reflect workspace-scoped database behavior, with existing assertions preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->