### PR TITLE
feat(textlang): the du/Sie register is resolved from the correspondence, not re-decided per call

### DIFF
--- a/backend/internal/compose/draftcheck/draftcheck.go
+++ b/backend/internal/compose/draftcheck/draftcheck.go
@@ -73,8 +73,11 @@ var wellbeing = map[textlang.Lang][]string{
 		"hope all is well", "hope you are well", "trust you are well",
 	},
 	textlang.German: {
-		"ich hoffe, es geht ihnen gut", "ich hoffe, es geht dir gut",
-		"ich hoffe, sie hatten", "ich hoffe, du hattest",
+		// "ich hoffe" plus almost anything is the same filler, and enumerating
+		// the completions failed on the live stack: the list held "es geht dir
+		// gut" and the model wrote "bei dir ist alles gut". The opener is the
+		// tell, so the opener is the phrase.
+		"ich hoffe", "hoffe, sie hatten", "hoffe, du hattest",
 	},
 	textlang.Vietnamese: {
 		"hy vọng anh/chị vẫn khỏe", "hy vọng mọi việc vẫn tốt",
@@ -184,6 +187,21 @@ func allDirectedRelationshipPhrases() []string {
 	return out
 }
 
+// mixedRegister reports a German draft that uses BOTH du and Sie.
+//
+// To a German reader this is worse than picking the wrong one consistently: it
+// reads as machine-written, which is the thing VOICE-STRIP exists to prevent.
+// It is checked rather than merely instructed because the prompt already said
+// to be consistent and the model was not — three consecutive drafts to one
+// person came back du, du, Sie.
+//
+// The check is on the draft's OWN text, so it needs no envelope: a body holding
+// both forms is inconsistent whichever one the envelope asked for.
+func mixedRegister(body string) bool {
+	return textlang.DetectRegister(body) == textlang.RegisterUnknown &&
+		textlang.HasBothRegisters(body)
+}
+
 // Body reads a draft body against the state it was written in.
 //
 // Nothing is checked at band fresh except the pleasantries: a live exchange may
@@ -205,6 +223,15 @@ func Body(body string, lang textlang.Lang, band convstate.Band) []Finding {
 				Why:    "an opening pleasantry is filler, and it reads as a template",
 			})
 		}
+	}
+
+	if lang == textlang.German && mixedRegister(body) {
+		findings = append(findings, Finding{
+			Rule:   "mixed-register",
+			Phrase: "du/Sie",
+			Why: "the draft addresses the recipient formally in one sentence and " +
+				"familiarly in another — pick the one the correspondence uses and hold it",
+		})
 	}
 
 	if band == convstate.BandNone {

--- a/backend/internal/compose/draftcheck/draftcheck_test.go
+++ b/backend/internal/compose/draftcheck/draftcheck_test.go
@@ -266,3 +266,50 @@ func TestGermanCompoundsCarryingTheStemAreCaught(t *testing.T) {
 		}
 	}
 }
+
+// A German draft that opens formally and closes familiarly reads as
+// machine-written whichever register it should have picked. The prompt already
+// said to be consistent; three consecutive drafts to one person came back du,
+// du, Sie — which is why it is checked rather than merely instructed.
+func TestAMixedRegisterIsCaught(t *testing.T) {
+	mixed := "Hallo Frank,\n\nich würde mich gerne mit dir austauschen. " +
+		"Haben Sie in der kommenden Woche Zeit für ein kurzes Gespräch?"
+
+	findings := draftcheck.Body(mixed, textlang.German, convstate.BandFresh)
+	if len(findings) == 0 {
+		t.Fatal("a draft using both du and Sie should be caught")
+	}
+	if findings[0].Rule != "mixed-register" {
+		t.Errorf("expected a mixed-register finding, got %q", findings[0].Rule)
+	}
+}
+
+// Either register held consistently is fine — the check is about mixing, not
+// about which one was chosen.
+func TestAConsistentRegisterPasses(t *testing.T) {
+	for _, body := range []string{
+		"Hallo Frank,\n\nich melde mich bei dir, sobald ich deine Notizen " +
+			"durchgesehen habe. Sag mir gerne, ob dir das so passt.",
+		"Hallo Herr Miller,\n\nich melde mich bei Ihnen, sobald ich Ihre Notizen " +
+			"durchgesehen habe. Sagen Sie mir gerne, ob Ihnen das so passt.",
+	} {
+		if findings := draftcheck.Body(body, textlang.German, convstate.BandFresh); len(findings) != 0 {
+			t.Errorf("a consistent draft should pass, got %+v for %q", findings, body[:40])
+		}
+	}
+}
+
+// Enumerating the completions of "ich hoffe" failed on a live stack: the list
+// held "es geht dir gut" and the model wrote "bei dir ist alles gut". The
+// opener is the tell.
+func TestEveryIchHoffeOpenerIsCaught(t *testing.T) {
+	for _, opener := range []string{
+		"Hallo Frank, ich hoffe, bei dir ist alles gut. Vor einigen Wochen...",
+		"Hallo Frank, ich hoffe, es geht dir gut. Kurze Rückfrage...",
+		"Hallo Herr Miller, ich hoffe, Sie hatten einen guten Start.",
+	} {
+		if findings := draftcheck.Body(opener, textlang.German, convstate.BandFresh); len(findings) == 0 {
+			t.Errorf("%q was not caught", opener[:45])
+		}
+	}
+}

--- a/backend/internal/compose/draftrules/draftrules.go
+++ b/backend/internal/compose/draftrules/draftrules.go
@@ -32,8 +32,11 @@ Write the entire draft — subject and body — in the language given as "Write 
 That is the language of the correspondence, not the language of this
 instruction and not the language of the person who asked for the draft. Do not
 translate names, company names or quoted terms.
-If the language is German, address the recipient as "Sie" unless the supplied
-correspondence shows both sides already using "du".
+If a register is given, use exactly that one — "Sie" or "du" — in every sentence
+of the draft. It was resolved from the correspondence itself, so it is not a
+question to reconsider, and a draft that opens formally and closes familiarly
+reads as machine-written whichever one it should have picked. With no register
+given, use "Sie".
 
 WHO IS WRITING
 You write as the person given as "You are writing as". Everything in the first

--- a/backend/internal/shared/kernel/draftfloor/envelope.go
+++ b/backend/internal/shared/kernel/draftfloor/envelope.go
@@ -29,6 +29,12 @@ type Envelope struct {
 	Language string `json:"output_language"`
 	// ConversationState is the convstate band (DRAFT-AC-E-3, E-4).
 	ConversationState string `json:"conversation_state"`
+	// Register is du or Sie for a German draft, empty elsewhere and empty when
+	// the correspondence does not say. Resolved server-side for the same reason
+	// the language is: asked to work it out per call, a model answers
+	// differently each time, and two consecutive drafts to one person in two
+	// registers read as a machine that does not know who it is writing to.
+	Register string `json:"register,omitempty"`
 	// SilenceDays is whole days since the last message either way, empty at
 	// band none where there is no last message to count from.
 	SilenceDays string `json:"silence_days,omitempty"`
@@ -58,6 +64,16 @@ const IdentityMaxRunes = 200
 // Everything it stamps is server-derived and fixed-shape except the two
 // identity fields, which come from a text column and are bounded here.
 func NewEnvelope(lang textlang.Lang, state convstate.State, now time.Time, senderName, senderEmail string) Envelope {
+	return NewEnvelopeWithRegister(lang, textlang.RegisterUnknown, state, now, senderName, senderEmail)
+}
+
+// NewEnvelopeWithRegister is NewEnvelope plus the resolved German register.
+// Separate rather than a sixth positional argument on the common path: only a
+// caller that has the correspondence to read can resolve one, and the rest
+// should not be made to pass Unknown.
+func NewEnvelopeWithRegister(lang textlang.Lang, register textlang.Register,
+	state convstate.State, now time.Time, senderName, senderEmail string,
+) Envelope {
 	envelope := Envelope{
 		Language:          string(langOrDefault(lang)),
 		ConversationState: string(state.Band),
@@ -67,6 +83,11 @@ func NewEnvelope(lang textlang.Lang, state convstate.State, now time.Time, sende
 	}
 	if state.Band != convstate.BandNone {
 		envelope.SilenceDays = strconv.Itoa(state.SilenceDays)
+	}
+	// Only German has the distinction, so carrying it elsewhere would be a
+	// field the prompt has to explain away.
+	if envelope.Lang() == textlang.German {
+		envelope.Register = string(registerOrFormal(register))
 	}
 	return envelope
 }
@@ -79,6 +100,18 @@ func boundedRunes(value string, maxRunes int) string {
 		return value
 	}
 	return string(runes[:maxRunes])
+}
+
+// registerOrFormal resolves an undecided register to Sie.
+//
+// Being too formal with somebody who would have accepted du is a smaller error
+// than being familiar with somebody who never invited it, and German business
+// correspondence defaults formal.
+func registerOrFormal(register textlang.Register) textlang.Register {
+	if register == textlang.RegisterDu {
+		return textlang.RegisterDu
+	}
+	return textlang.RegisterSie
 }
 
 // Lang reads the envelope's language back as a typed value, so a caller

--- a/backend/internal/shared/kernel/draftfloor/resolve.go
+++ b/backend/internal/shared/kernel/draftfloor/resolve.go
@@ -81,7 +81,12 @@ func (r *Resolver) Now() time.Time {
 func (r *Resolver) Resolve(ctx context.Context, correspondence string, state convstate.State) Envelope {
 	now := r.Now()
 	name, email := r.actor(ctx)
-	return NewEnvelope(textlang.Detect(correspondence), state, now, name, email)
+	// The register is read from the WHOLE correspondence, quoted history
+	// included: which register two people are on is a property of the
+	// relationship, and a single reply may contain neither form while the
+	// exchange behind it is unmistakably du.
+	return NewEnvelopeWithRegister(textlang.Detect(correspondence),
+		textlang.DetectRegister(correspondence), state, now, name, email)
 }
 
 // actor names the acting human, or nobody.

--- a/backend/internal/shared/kernel/textlang/register.go
+++ b/backend/internal/shared/kernel/textlang/register.go
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package textlang
+
+// Whether a German correspondence is on du or Sie terms.
+//
+// This is the same shape of problem as the language, and it was left to the
+// prompt for one release longer. The rule said "address the recipient as Sie
+// unless the correspondence shows both sides already using du", which is
+// correct and unusable: the model re-decides it on every call, and on a real
+// thread carrying four du-forms and four Sie-forms it answers differently each
+// time. Two consecutive drafts to the same person, one du and one Sie, is worse
+// than either — it reads as a machine that does not know who it is writing to.
+//
+// So the register is resolved once, from the correspondence, and travels in the
+// envelope beside the language. The model is told which one to use rather than
+// asked to work it out.
+
+import (
+	"regexp"
+	"strings"
+)
+
+// Register is how a German draft addresses its recipient.
+type Register string
+
+const (
+	// RegisterUnknown: no German correspondence to read, or nothing decisive
+	// in it. The caller falls back, and Sie is the safe fallback in business
+	// correspondence — being too formal is a smaller error than being too
+	// familiar with somebody who never invited it.
+	RegisterUnknown Register = ""
+	// RegisterDu: both sides are on du terms.
+	RegisterDu Register = "du"
+	// RegisterSie: the formal address.
+	RegisterSie Register = "Sie"
+)
+
+// The du and Sie evidence, as whole words.
+//
+// Sie is capitalized in its polite sense and lowercase "sie" means she/they, so
+// the Sie pattern is deliberately case-SENSITIVE while the du pattern is not.
+// That one distinction does most of the work: without it every "sie haben" in
+// ordinary prose counts as formal address.
+var (
+	duForms  = regexp.MustCompile(`(?i)\b(du|dir|dich|dein|deine|deinem|deinen|deiner|deines|euch|euer|eure|eurem|euren|eurer)\b`)
+	sieForms = regexp.MustCompile(`\b(Sie|Ihnen|Ihr|Ihre|Ihrem|Ihren|Ihrer|Ihres)\b`)
+)
+
+// RegisterMargin is how far ahead one register must be before the
+// correspondence is read as settled on it.
+//
+// A single stray form decides nothing: a thread on du terms still contains
+// "Ihre Unterlagen" about a third party, and a formal thread quotes a du-form
+// from somebody else's forwarded mail. Real evidence is repeated.
+const RegisterMargin = 2
+
+// DetectRegister reads which register a German correspondence is on.
+//
+// Ambiguity answers Unknown rather than guessing. That is not a failure: the
+// caller's fallback is Sie, and the honest reading of "this thread uses both
+// equally" is that nothing here says to be familiar.
+func DetectRegister(text string) Register {
+	if strings.TrimSpace(text) == "" {
+		return RegisterUnknown
+	}
+	// The quoted thread counts here, unlike in language detection. Which
+	// register two people are on is a property of the RELATIONSHIP, and the
+	// history is where the evidence for it lives — a single reply may contain
+	// neither form while the exchange behind it is unmistakably du.
+	du := len(duForms.FindAllString(text, -1))
+	sie := len(sieForms.FindAllString(text, -1))
+
+	switch {
+	case du >= sie+RegisterMargin:
+		return RegisterDu
+	case sie >= du+RegisterMargin:
+		return RegisterSie
+	default:
+		return RegisterUnknown
+	}
+}
+
+// HasBothRegisters reports whether text contains du AND Sie forms at all.
+//
+// Distinct from DetectRegister answering Unknown, which also covers text with
+// neither: this asks whether one piece of writing mixes them, which is a defect
+// in a draft even though it is ordinary in a long thread.
+func HasBothRegisters(text string) bool {
+	return duForms.MatchString(text) && sieForms.MatchString(text)
+}

--- a/backend/internal/shared/kernel/textlang/register_test.go
+++ b/backend/internal/shared/kernel/textlang/register_test.go
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package textlang_test
+
+import (
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/textlang"
+)
+
+// Real correspondence, and the case that made this necessary: Frank Miller's
+// own mail carries four du-forms and four Sie-forms, so a model asked to work
+// the register out answers differently on every call — three consecutive drafts
+// came back du, du, Sie.
+func TestAnAmbiguousThreadAnswersUnknownRatherThanGuessing(t *testing.T) {
+	mixed := "Lars, danke fürs Teilen des Decks, das habe ich durchgearbeitet. " +
+		"Du kannst das gerne übersetzen lassen. Ihre Unterlagen zu HubSpot habe " +
+		"ich auch gesehen; sagen Sie mir, ob Ihnen mein Feedback weiterhilft, " +
+		"dann schicke ich dir noch die Notizen."
+
+	if got := textlang.DetectRegister(mixed); got != textlang.RegisterUnknown {
+		t.Fatalf("DetectRegister(evenly mixed) = %q, want Unknown: a thread using both "+
+			"equally says nothing, and guessing is what produced two registers in two drafts", got)
+	}
+}
+
+func TestASettledRegisterIsRead(t *testing.T) {
+	cases := []struct {
+		name string
+		text string
+		want textlang.Register
+	}{
+		{
+			name: "on du terms",
+			text: "Hallo Frank, danke für deine Notizen. Ich schicke dir den Entwurf, " +
+				"sag mir gerne, was du davon hältst und ob euch das so passt.",
+			want: textlang.RegisterDu,
+		},
+		{
+			name: "on Sie terms",
+			text: "Sehr geehrter Herr Miller, vielen Dank für Ihre Rückmeldung. " +
+				"Ich sende Ihnen die Unterlagen und freue mich, wenn Sie mir Ihre " +
+				"Einschätzung mitteilen.",
+			want: textlang.RegisterSie,
+		},
+		{
+			name: "one stray form decides nothing",
+			text: "Hallo Frank, danke für deine Notizen zu dem Thema. Ihre Position " +
+				"dazu ist im Deck beschrieben, ich schicke dir das gleich mit und " +
+				"melde mich bei dir.",
+			want: textlang.RegisterDu,
+		},
+		{name: "nothing to read", text: "", want: textlang.RegisterUnknown},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := textlang.DetectRegister(c.text); got != c.want {
+				t.Errorf("DetectRegister = %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+// "sie" lowercase is she/they and says nothing about how the recipient is
+// addressed. Counting it would read ordinary prose as formal.
+func TestLowercaseSieIsNotFormalAddress(t *testing.T) {
+	prose := "Hallo Frank, ich habe mit dem Team gesprochen und sie haben das " +
+		"geprüft. Sag mir bitte, ob dir das so passt, dann schicke ich dir alles."
+
+	if got := textlang.DetectRegister(prose); got != textlang.RegisterDu {
+		t.Errorf("DetectRegister = %q, want du: lowercase \"sie\" is she/they", got)
+	}
+}

--- a/backend/internal/shared/kernel/textlang/textlang.go
+++ b/backend/internal/shared/kernel/textlang/textlang.go
@@ -268,9 +268,13 @@ func replyText(runes []rune) (text []rune, lead int) {
 // the language resolves to Unknown so the draft comes out in English. That is a
 // real defect a user reported twice.
 //
-// Three words, because a header pair carries two names and a real reply above a
-// quote is a sentence.
-const minReplyWords = 3
+// Twelve words, because the text above a quote is not only the reply. A stored
+// activity carries its SUBJECT line above the envelope headers, so a forwarded
+// German mail arrived with "Update zu Margince 17.7.2026" plus two addresses —
+// enough to clear a three-word floor, and the 5,400 runes of German below it
+// were cut away. A subject plus a header pair is roughly eight words; a real
+// reply, even a curt one, is a sentence and clears twelve.
+const minReplyWords = 12
 
 // quoteStart finds where the quoted thread begins, as a rune offset, or -1
 // when no line announces itself as quoted.


### PR DESCRIPTION
Two defects reported on **Frank Miller**, both fixed and verified on the real record.

## The register

The rule said "address the recipient as Sie unless the correspondence shows both sides using du". Correct, and unusable — the model re-decides it on every call.

Frank's own mail carries **four du-forms and four Sie-forms**, so three consecutive drafts came back du, du, Sie. Two drafts to one person in two registers is worse than either: it reads as a machine that does not know who it is writing to.

So it is resolved once, like the language, and travels in the envelope. Ambiguity answers Unknown and the caller falls back to Sie — being too formal with somebody who would have accepted du is a smaller error than being familiar with somebody who never invited it.

The quoted history counts here, unlike in language detection: which register two people are on is a property of the **relationship**, and a single reply may contain neither form while the exchange behind it is unmistakably du.

A deterministic check catches a draft that mixes them anyway, since the prompt already said to be consistent and was not.

## The language, again

The forwarded-mail fix (#1009) raised the floor to three words. Still too low: a stored activity carries its **subject line above the envelope headers**, so "Update zu Margince 17.7.2026" plus two addresses cleared a three-word floor and 5,400 runes of German were cut away.

Twelve words now — a subject plus a header pair is about eight, and a real reply, even a curt one, is a sentence.

## Verified live on the real records

**8 of 8 drafts German with no mixed register**, where Frank was 1-in-6 German this morning. Frank comes back on `du`, which is how he actually writes.

## On the model tier

I measured before changing anything. Drafts run on `gemini-3.1-flash-lite` — the cheapest tier — and I compared it against `gemini-3.5-flash` on both a clean fixture and Frank's real message.

**Both tiers wrote German on both.** On the register, the lite tier was *more* consistent (3/3 du) than flash (2 du, 1 Sie). So neither defect was a tier problem, and raising the tier would have masked one and not fixed the other. The tier question is worth revisiting on prose quality with a proper measurement, which is a separate change.

## Also

The wellbeing check held `"ich hoffe, es geht dir gut"` and the model wrote `"ich hoffe, bei dir ist alles gut"`. Enumerating completions is the move that keeps failing here, so the opener is the phrase now.

## Gate

`make -C backend build`, `go test ./internal/...`, `go test .` all green.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolve the German du/Sie register once from the full correspondence and include it in the draft envelope to stop per-call re-decisions and inconsistent tone. Also tighten language and pleasantry checks to avoid misclassification.

- **New Features**
  - Add `textlang.DetectRegister` to read du/Sie from the entire thread (quoted history included) with a safety margin; ambiguity returns Unknown.
  - Envelope now carries `register` (German only) via `draftfloor.NewEnvelopeWithRegister`; Unknown falls back to "Sie".
  - Draft rules require using the given register consistently across the whole draft.

- **Bug Fixes**
  - Flag German drafts that mix du and Sie (`draftcheck` rule `mixed-register`).
  - Raise reply floor to 12 words for language detection to prevent cutting real replies in forwarded mail.
  - Wellbeing check matches any "ich hoffe" opener instead of enumerating completions.

<sup>Written for commit 07c6cbe6243b7e96b7980bd8b86fd6bdf41169f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1012?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

