### PR TITLE
fix(rail): thread the composite read's loading flag into Health and People

### DIFF
--- a/frontend/src/screens/companyrail.test.tsx
+++ b/frontend/src/screens/companyrail.test.tsx
@@ -115,14 +115,14 @@ function stub(overrides: Record<string, (req: Request) => Response> = {}) {
 describe("CompanyRail", () => {
   it("renders nothing while the composer holds the column", () => {
     stub();
-    render(<CompanyRail orgId="o-1" view={view()} withPeople composerOpen />);
+    render(<CompanyRail orgId="o-1" view={view()} withPeople loading={false} composerOpen />);
     expect(screen.queryByText("Details")).not.toBeInTheDocument();
   });
 
   it("draws the details grid from the fields the record actually carries", async () => {
     stub();
     render(
-      <CompanyRail orgId="o-1" view={view()} withPeople composerOpen={false} />,
+      <CompanyRail orgId="o-1" view={view()} withPeople loading={false} composerOpen={false} />,
     );
     expect(screen.getByText("Brandt Automotive GmbH")).toBeInTheDocument();
     expect(screen.getByText("Automotive")).toBeInTheDocument();
@@ -152,6 +152,7 @@ describe("CompanyRail", () => {
       <CompanyRail
         orgId="o-1"
         view={view({ organization: bare })}
+        loading={false}
         withPeople
         composerOpen={false}
       />,
@@ -183,6 +184,7 @@ describe("CompanyRail", () => {
             relationship: { rating: "good", reason: "Replying steadily." },
           },
         })}
+        loading={false}
         withPeople
         composerOpen={false}
       />,
@@ -198,6 +200,7 @@ describe("CompanyRail", () => {
       <CompanyRail
         orgId="o-1"
         view={view({ sections_omitted: ["health", "people"] })}
+        loading={false}
         withPeople
         composerOpen={false}
       />,
@@ -248,6 +251,7 @@ describe("CompanyRail", () => {
             page: emptyPage,
           },
         })}
+        loading={false}
         withPeople
         composerOpen={false}
       />,
@@ -285,7 +289,7 @@ describe("CompanyRail", () => {
         }),
     });
     render(
-      <CompanyRail orgId="o-1" view={view()} withPeople composerOpen={false} />,
+      <CompanyRail orgId="o-1" view={view()} withPeople loading={false} composerOpen={false} />,
     );
     await waitFor(() =>
       expect(screen.getByText("No reply in three weeks.")).toBeInTheDocument(),
@@ -309,6 +313,7 @@ describe("CompanyRail", () => {
             },
           ],
         })}
+        loading={false}
         withPeople
         composerOpen={false}
       />,
@@ -320,7 +325,7 @@ describe("CompanyRail", () => {
   it("offers the add-tag and add-to-list verbs once each half has answered, on a writable record", async () => {
     stub();
     render(
-      <CompanyRail orgId="o-1" view={view()} withPeople composerOpen={false} />,
+      <CompanyRail orgId="o-1" view={view()} withPeople loading={false} composerOpen={false} />,
     );
     // Both halves answered `empty` (view()'s tags/list_memberships default to
     // []), so both verbs render beside the half they act on.
@@ -340,6 +345,7 @@ describe("CompanyRail", () => {
         view={view({
           organization: { ...org, archived_at: "2026-06-02T00:00:00Z" },
         })}
+        loading={false}
         withPeople
         composerOpen={false}
       />,
@@ -354,5 +360,51 @@ describe("CompanyRail", () => {
         screen.queryByRole("button", { name: /add tag/i }),
       ).not.toBeInTheDocument();
     });
+  });
+
+  // sectionState (company360.tsx) reads an undefined `view` as "loading" only
+  // when told the composite read is still running — otherwise it reads the
+  // exact same undefined `view` as "unavailable", the words a real outage
+  // shows. Before `loading` was threaded through, every ordinary page open
+  // flashed "could not be loaded" on Health/People/Tags for as long as the
+  // read was in flight. Pinned here as two DIFFERENT renders rather than one
+  // happy-path check, because a fix that only makes the loading case not
+  // crash is not the fix — it has to render DIFFERENTLY from the failed case.
+  it("reads an in-flight composite read as loading, not unavailable", () => {
+    stub();
+    render(
+      <CompanyRail
+        orgId="o-1"
+        view={undefined}
+        loading={true}
+        withPeople
+        composerOpen={false}
+      />,
+    );
+    // The skeleton placeholder, not the "could not be loaded" sentence.
+    expect(
+      screen.queryByText("Could not be loaded — this may not be the whole picture"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("reads a failed composite read (view undefined, not loading) as unavailable", () => {
+    stub();
+    render(
+      <CompanyRail
+        orgId="o-1"
+        view={undefined}
+        loading={false}
+        withPeople
+        composerOpen={false}
+      />,
+    );
+    // The SAME undefined `view` as the loading test above, but with
+    // `loading={false}` — the honest "could not be loaded" sentence, not a
+    // skeleton pretending a read is still running.
+    expect(
+      screen.getAllByText(
+        "Could not be loaded — this may not be the whole picture",
+      ).length,
+    ).toBeGreaterThan(0);
   });
 });

--- a/frontend/src/screens/companyrail.test.tsx
+++ b/frontend/src/screens/companyrail.test.tsx
@@ -115,14 +115,28 @@ function stub(overrides: Record<string, (req: Request) => Response> = {}) {
 describe("CompanyRail", () => {
   it("renders nothing while the composer holds the column", () => {
     stub();
-    render(<CompanyRail orgId="o-1" view={view()} withPeople loading={false} composerOpen />);
+    render(
+      <CompanyRail
+        orgId="o-1"
+        view={view()}
+        withPeople
+        loading={false}
+        composerOpen
+      />,
+    );
     expect(screen.queryByText("Details")).not.toBeInTheDocument();
   });
 
   it("draws the details grid from the fields the record actually carries", async () => {
     stub();
     render(
-      <CompanyRail orgId="o-1" view={view()} withPeople loading={false} composerOpen={false} />,
+      <CompanyRail
+        orgId="o-1"
+        view={view()}
+        withPeople
+        loading={false}
+        composerOpen={false}
+      />,
     );
     expect(screen.getByText("Brandt Automotive GmbH")).toBeInTheDocument();
     expect(screen.getByText("Automotive")).toBeInTheDocument();
@@ -289,7 +303,13 @@ describe("CompanyRail", () => {
         }),
     });
     render(
-      <CompanyRail orgId="o-1" view={view()} withPeople loading={false} composerOpen={false} />,
+      <CompanyRail
+        orgId="o-1"
+        view={view()}
+        withPeople
+        loading={false}
+        composerOpen={false}
+      />,
     );
     await waitFor(() =>
       expect(screen.getByText("No reply in three weeks.")).toBeInTheDocument(),
@@ -325,7 +345,13 @@ describe("CompanyRail", () => {
   it("offers the add-tag and add-to-list verbs once each half has answered, on a writable record", async () => {
     stub();
     render(
-      <CompanyRail orgId="o-1" view={view()} withPeople loading={false} composerOpen={false} />,
+      <CompanyRail
+        orgId="o-1"
+        view={view()}
+        withPeople
+        loading={false}
+        composerOpen={false}
+      />,
     );
     // Both halves answered `empty` (view()'s tags/list_memberships default to
     // []), so both verbs render beside the half they act on.
@@ -383,7 +409,9 @@ describe("CompanyRail", () => {
     );
     // The skeleton placeholder, not the "could not be loaded" sentence.
     expect(
-      screen.queryByText("Could not be loaded — this may not be the whole picture"),
+      screen.queryByText(
+        "Could not be loaded — this may not be the whole picture",
+      ),
     ).not.toBeInTheDocument();
   });
 

--- a/frontend/src/screens/companyrail.tsx
+++ b/frontend/src/screens/companyrail.tsx
@@ -56,11 +56,19 @@ type Signal = components["schemas"]["Signal"];
 export function CompanyRail({
   orgId,
   view,
+  loading,
   withPeople,
   composerOpen,
 }: Readonly<{
   orgId: string;
   view?: Organization360;
+  // The composite read `view` comes off is still in flight. Threaded to the
+  // sections that read `view` straight (Health, People, Tags) so their
+  // `sectionState` calls can tell "still loading" apart from "the read
+  // failed" — both hand a section an undefined `view`, and without this flag
+  // every one of them reads the failed state for as long as the read runs,
+  // flashing "could not be loaded" on every ordinary page open.
+  loading: boolean;
   // False where the page's own body is already the roster in full.
   withPeople: boolean;
   // A composer drawer is open in this column. The rail stands down entirely
@@ -81,10 +89,10 @@ export function CompanyRail({
         <PanelBody>
           <DetailsGrid organization={view?.organization} />
         </PanelBody>
-        <HealthSection view={view} orgId={orgId} />
-        {withPeople && <PeopleSection view={view} />}
+        <HealthSection view={view} orgId={orgId} loading={loading} />
+        {withPeople && <PeopleSection view={view} loading={loading} />}
         <SignalsSection orgId={orgId} />
-        <TagsSection view={view} orgId={orgId} />
+        <TagsSection view={view} orgId={orgId} loading={loading} />
       </Panel>
     </div>
   );
@@ -113,7 +121,8 @@ const HEALTH_BADGE_TONE: Record<HealthRating, "danger" | "warn" | "success"> = {
 function HealthSection({
   view,
   orgId,
-}: Readonly<{ view?: Organization360; orgId?: string }>) {
+  loading,
+}: Readonly<{ view?: Organization360; orgId?: string; loading: boolean }>) {
   const t = useT();
   const health = view?.health;
   const payment = usePaymentHealth(orgId);
@@ -150,6 +159,7 @@ function HealthSection({
     "health",
     Boolean(health),
     lines.length + rated,
+    loading,
   );
   const dimensions = [
     ["relationship", health?.relationship],
@@ -218,7 +228,10 @@ function HealthSection({
  * contact with them. The set-role and route-in verbs stay on the People tab's
  * own roster rather than being rebuilt here a second time.
  */
-function PeopleSection({ view }: Readonly<{ view?: Organization360 }>) {
+function PeopleSection({
+  view,
+  loading,
+}: Readonly<{ view?: Organization360; loading: boolean }>) {
   const t = useT();
   const contacts = [...(view?.people?.data ?? [])].sort(byReach);
   const state = sectionState(
@@ -226,6 +239,7 @@ function PeopleSection({ view }: Readonly<{ view?: Organization360 }>) {
     "people",
     Boolean(view?.people),
     contacts.length,
+    loading,
   );
   return (
     <Disclosure

--- a/frontend/src/screens/companyrailtags.tsx
+++ b/frontend/src/screens/companyrailtags.tsx
@@ -34,7 +34,8 @@ type Organization = components["schemas"]["Organization"];
 export function TagsSection({
   view,
   orgId,
-}: Readonly<{ view?: Organization360; orgId: string }>) {
+  loading,
+}: Readonly<{ view?: Organization360; orgId: string; loading: boolean }>) {
   const t = useT();
   const tags = view?.tags ?? [];
   const lists = view?.list_memberships ?? [];
@@ -43,8 +44,15 @@ export function TagsSection({
     "list_memberships",
     Boolean(view?.list_memberships),
     lists.length,
+    loading,
   );
-  const tagState = sectionState(view, "tags", Boolean(view?.tags), tags.length);
+  const tagState = sectionState(
+    view,
+    "tags",
+    Boolean(view?.tags),
+    tags.length,
+    loading,
+  );
   const listsAnswered = sectionAnswered(listState);
   const tagsAnswered = sectionAnswered(tagState);
   // Absent, not zero, until at least one half has actually answered: two

--- a/frontend/src/screens/organizations.tsx
+++ b/frontend/src/screens/organizations.tsx
@@ -2026,6 +2026,11 @@ function CompanyPage({
     <CompanyRail
       orgId={org.id}
       view={view}
+      // The composite read still in flight vs. it having failed: without
+      // this the rail's own sections cannot tell the two apart from an
+      // undefined `view` alone, and both drawing the loading skeleton is not
+      // the same defect as both drawing "could not be loaded".
+      loading={loading}
       // The People tab IS the roster in full, so the rail's summary of it
       // stands down rather than repeating it beside itself.
       withPeople={tab !== "people"}


### PR DESCRIPTION
## Summary
- The rail's Health and People sections read the account's composite view directly, and while that read was still in flight they showed the same "could not be loaded" copy a real outage draws.
- Both now take the composite read's own pending flag (threaded from CompanyPage, same shape `fix/section-loading-vs-unavailable` already applies elsewhere) and pass it into `sectionState`, so they render the waiting shape while the read runs and the failure sentence only once it has actually failed.

## Test plan
- [x] `pnpm tsc -b` — clean
- [x] `pnpm vitest run src/screens/companyrail.test.tsx` — 12/12, including two tests pinning the distinction (pending → skeleton, not unavailable copy; failed/undefined+not-loading → unavailable copy), verified non-vacuous by stashing the source fix and confirming both fail
- [x] `make check-fe` from repo root — exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the rail so Health, People, and Tags show a loading skeleton while the composite view is fetching, and only show “could not be loaded” if the read actually fails. This removes the failure flash on page open.

- **Bug Fixes**
  - Thread `loading` from `CompanyPage` to `CompanyRail`, then into `HealthSection`, `PeopleSection`, and `TagsSection` via `sectionState`.
  - Distinguish “loading” vs “unavailable” for sections that read directly from the composite view.
  - Expanded tests to pin both cases (loading ⇒ skeleton; failed ⇒ unavailable).

<sup>Written for commit 8db791f72959e603a1dee372ba39e3f2fb2ec19c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1018?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

