### PR TITLE
docs(status): step 3 is complete — identity landed too

### DIFF
--- a/STATUS-ARCHIVE.md
+++ b/STATUS-ARCHIVE.md
@@ -21,6 +21,32 @@
 > [CHANGELOG.md](CHANGELOG.md) and [README.md → *What works
 > today*](README.md#what-works-today).
 
+## 2026-08-12 (later) — identity too: step 3 is complete (PR #1010)
+
+The entry below called identity a slice with real fixture work, and it was —
+just a smaller one than it looked. The self-reference is a non-issue:
+`InstallationWorkspace` reads no tenant table, so
+`svc.db = database.Bind(pool, svc.InstallationWorkspace)` resolves fine at
+runtime. What actually needed doing was the fixtures, and the reason is the
+module's own invariant turned on itself: identity REFUSES when a second
+workspace exists, and its suites bootstrap an installation per test — so the
+one module that defines the singleton is the one whose tests can never resolve
+one. `NewServiceFor` is what they use; each names the workspace it just created.
+
+One real defect fell out of it, and it is the shape to watch for in step 4: the
+tool registry's admission gate built an identity service of its own rather than
+taking the registry's handle, so a registry pinned to a named workspace admitted
+through a service resolving a different one. An ungoverned-agent refusal answered
+`ErrMultipleWorkspaces` instead of the refusal it exists to assert. **A component
+that carries a handle must pass THAT handle to everything it constructs** — the
+gate now does.
+
+CodeRabbit caught the other one, correctly: the mechanical rewrite had turned
+`s.pool` into `s.db.Pool()` in identity's roster pager, which kept the old
+ctx-derived binding and silently bypassed a pinned service. Worth knowing that
+the rewrite has exactly this failure mode wherever a helper takes a pool and
+opens its own workspace transaction; roster was the only one left in the tree.
+
 ## 2026-08-12 — every module but identity opens on a pool that knows its workspace (PRs #976, #984, #992, #999, #1002)
 
 ADR-0091 §9 **step 3** is done except `identity`. `platform/database.DB` — a pool

--- a/STATUS.md
+++ b/STATUS.md
@@ -455,12 +455,13 @@ collapses while RLS is still armed, because the tenant-isolation suite staying
 green is the only mechanical proof that an edit of that size stayed faithful,
 and the schema phase deletes that suite. Do not reorder it.
 
-### Step 3 is done except identity — what the handle turned out to mean
+### Step 3 is DONE — what the handle turned out to mean
 
 `platform/database.DB` is the seam that landed: a pool that knows its
 workspace, with `Tx` spelling the same `WithWorkspaceTx` GUC contract, so RLS
-stayed armed and the isolation suite stayed the proof. Every module but
-`identity` now opens on one.
+stayed armed and the isolation suite stayed the proof. Every module now opens on
+one, `identity` included (#1010) — **step 4 (principal/envelope/audit_log/
+contract/frontend) is the next slice, and the schema phase after it.**
 
 The sweep's real finding is that there are exactly **three** ways a caller knows
 which tenant it is, and the handle makes the choice visible at the call site
@@ -483,13 +484,21 @@ Two rules fell out of it and are worth knowing before the next slice:
   resolving constructors; a suite that seeds a second workspace has no singleton
   to resolve and names the one it means.
 
-**identity is the one module left**, and it is not a mechanical rename. A
-self-bound handle is legal — `InstallationWorkspace` reads no tenant table, so
+**identity went last**, and the reason is worth keeping: the module that REFUSES
+when a second workspace exists is the one whose own suites bootstrap an
+installation per test, so its fixtures cannot resolve a singleton. They name the
+workspace they just created, through `NewServiceFor`. The self-reference is fine
+— `InstallationWorkspace` reads no tenant table, so
 `svc.db = database.Bind(pool, svc.InstallationWorkspace)` is not circular at
-runtime, and it compiles and passes the unit lane. What it does not pass is
-identity's own integration suites plus the CIMD and agent-seat lanes: they drive
-several tenants through ONE service on purpose. Converting it means reworking
-those fixtures tenant by tenant, which is its own slice.
+runtime. `identity.NewService(pool)` therefore still takes a pool: it is the one
+constructor that builds its own handle.
+
+One defect that slice surfaced, and the shape to watch for in step 4: the tool
+registry's admission gate was building an identity service of its own, so a
+registry pinned to a named workspace admitted through a service resolving a
+different one — an ungoverned-agent refusal answered `ErrMultipleWorkspaces`
+instead of the refusal it exists to assert. **A component that carries a handle
+must pass THAT handle to everything it constructs.**
 
 Phase 2 spans roughly nine hundred `WithWorkspaceTx` occurrences, a bit over
 four hundred of them outside tests, across a couple of hundred non-test files.


### PR DESCRIPTION
With #1010 on main every module opens on a bound handle, so the STATUS.md section that said "done except identity" is stale.

It now records **why identity went last** — the module that refuses when a second workspace exists is the one whose own suites bootstrap an installation per test, so its fixtures can never resolve a singleton; they name the workspace they just created, through `NewServiceFor` — and the one rule the slice taught:

> **A component that carries a handle must pass THAT handle to everything it constructs.**

The tool registry's admission gate did not: it built an identity service of its own, so a registry pinned to a named workspace admitted through a service resolving a different tenant, and an ungoverned-agent refusal answered `ErrMultipleWorkspaces` instead of the refusal it exists to assert. That is the shape to watch for in step 4.

The archive gets a short follow-up entry rather than an edit to yesterday's, per its own append-at-top rule.

Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mark step 3 as DONE and note that `identity` now opens on a bound handle, including why it went last. Record the handle-passing rule and the registry admission gate and roster pager gotchas; docs only, no code changes.

<sup>Written for commit d0daced3c53e1d56ee377e60945fb2ca47516648. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1020?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

