### PR TITLE
feat(draftcheck): the subject line is checked too, because its worst failure is a claim

### DIFF
--- a/backend/internal/compose/accountdraft/input.go
+++ b/backend/internal/compose/accountdraft/input.go
@@ -341,3 +341,8 @@ func (in Input) String() string {
 	return fmt.Sprintf("accountdraft{company:%q to:%q deal:%v}",
 		in.Company, in.Recipient.Name, in.Deal != nil)
 }
+
+// Threaded is always false here, and that is what this surface IS: it opens a
+// new conversation, so no subject it writes can be a reply to anything. The
+// method exists so the shared check reads the same shape from every surface.
+func (Input) Threaded() bool { return false }

--- a/backend/internal/compose/accountdraft/write.go
+++ b/backend/internal/compose/accountdraft/write.go
@@ -123,6 +123,7 @@ func writeChecked(ctx context.Context, lane Completer, in Input) (Draft, error) 
 			return writeWithModel(ctx, lane, in, correction)
 		},
 		func(d Draft) (string, []string) { return d.Body, reasonLabels(d.Reasoning) },
+		func(d Draft) (string, bool) { return d.Subject, in.Threaded() },
 		// No observer: this package holds no logger, and a retry that does not
 		// help still returns a real draft. The reply surface, which has one,
 		// reports it.

--- a/backend/internal/compose/aicert/corpus/draft_reply/basic_01.yaml
+++ b/backend/internal/compose/aicert/corpus/draft_reply/basic_01.yaml
@@ -16,6 +16,7 @@ fixture:
     now: 2026-08-11T09:00:00Z
     sender_name: Anna Krüger
     sender_email: anna.krueger@example.com
+    thread: inbound_mail
     recipient: Marek
     subject: quick question
     body: |

--- a/backend/internal/compose/aicert/corpus/draft_reply/german_intro_01.yaml
+++ b/backend/internal/compose/aicert/corpus/draft_reply/german_intro_01.yaml
@@ -16,6 +16,7 @@ fixture:
     now: 2026-08-11T09:00:00Z
     sender_name: Anna Krüger
     sender_email: anna.krueger@example.com
+    thread: inbound_mail
     recipient: Marek
     subject: Kurze Rückfrage zum Angebot
     body: |

--- a/backend/internal/compose/aicert/corpus/draft_reply/rich_thread_01.yaml
+++ b/backend/internal/compose/aicert/corpus/draft_reply/rich_thread_01.yaml
@@ -11,6 +11,7 @@ fixture:
     now: '2026-08-12T09:00:00Z'
     sender_name: Anna Krüger
     sender_email: anna.krueger@example.com
+    thread: inbound_mail
     recipient: Priya
     register: du
     subject: Corvia CRM - erstes Feedback

--- a/backend/internal/compose/aicert/corpus/draft_reply/stale_months_01.yaml
+++ b/backend/internal/compose/aicert/corpus/draft_reply/stale_months_01.yaml
@@ -15,6 +15,7 @@ fixture:
     now: 2026-08-11T09:00:00Z
     sender_name: Anna Krüger
     sender_email: anna.krueger@example.com
+    thread: inbound_mail
     recipient: Priya
     subject: Integration timeline
     body: |

--- a/backend/internal/compose/certcase_replydraft_test.go
+++ b/backend/internal/compose/certcase_replydraft_test.go
@@ -51,7 +51,7 @@ const (
 // for a reply — the variant that can issue all three calls.
 func replyDraftVoicedFixture() replyDraftFixture {
 	return replyDraftFixture{
-		Activity: replyActivityData{
+		Activity: replyActivityData{Thread: "inbound_mail",
 			Subject: "Heat recovery commissioning",
 			Body:    "We need commissioning in September. Can you confirm the window?",
 			Intent:  "Confirm the delivery window",

--- a/backend/internal/compose/draftcheck/draftcheck.go
+++ b/backend/internal/compose/draftcheck/draftcheck.go
@@ -379,6 +379,90 @@ func boundary(text string, i int) bool {
 	return !unicode.IsLetter(r) && !unicode.IsDigit(r) && r != '\''
 }
 
+// SubjectMaxRunes is where a subject line stops being read.
+//
+// Mail clients truncate around here, and a subject that needs more than this
+// is a first sentence rather than a label. The number is the conventional one
+// rather than any client's exact cut, because every client's differs and the
+// point is to stay short of all of them.
+const SubjectMaxRunes = 70
+
+// replyPrefixes are the ways a client marks a subject as a reply, in the
+// languages this product writes.
+var replyPrefixes = []string{"re:", "aw:", "fwd:", "wg:", "antw:"}
+
+// Subject reads a draft's subject line against the correspondence it belongs to.
+//
+// Separate from Body because a subject fails differently: it is one line, it is
+// read before anything else, and its worst failure is a claim rather than a
+// phrase. "Re:" says a thread exists. A follow-up subject says there was a
+// previous message. Both are checkable facts the envelope already holds, which
+// is why they are refused here rather than explained in a prompt.
+func Subject(subject string, lang textlang.Lang, band convstate.Band, threaded bool) []Finding {
+	trimmed := strings.TrimSpace(subject)
+	lowered := strings.ToLower(trimmed)
+	var findings []Finding
+
+	if trimmed == "" {
+		return []Finding{{
+			Rule:   "empty-subject",
+			Phrase: "",
+			Why:    "a message with no subject line arrives looking like spam",
+		}}
+	}
+
+	for _, prefix := range replyPrefixes {
+		if !strings.HasPrefix(lowered, prefix) {
+			continue
+		}
+		if !threaded {
+			findings = append(findings, Finding{
+				Rule:   "unearned-reply-prefix",
+				Phrase: strings.TrimSuffix(prefix, ":"),
+				Why: "there is no inbound thread with this subject, so the prefix claims " +
+					"a message that was never received",
+			})
+		}
+		break
+	}
+
+	// A follow-up subject at band none says there was something before this.
+	// There was not: this is the first message.
+	if band == convstate.BandNone {
+		for _, phrase := range append(append([]string{},
+			assumedMemory[lang]...), firstTouchSubjects[lang]...) {
+			if contains(lowered, phrase) {
+				findings = append(findings, Finding{
+					Rule:   "invented-history-subject",
+					Phrase: phrase,
+					Why:    "this is a first message, so the subject cannot refer back to anything",
+				})
+				break
+			}
+		}
+	}
+
+	if n := len([]rune(trimmed)); n > SubjectMaxRunes {
+		findings = append(findings, Finding{
+			Rule:   "long-subject",
+			Phrase: trimmed[:40] + "…",
+			Why: "a subject this long is truncated by the client that shows it, so the " +
+				"part that carries the meaning may never be read",
+		})
+	}
+	return findings
+}
+
+// firstTouchSubjects are the subject-line formulas that imply a previous
+// message. They overlap the body's assumed-memory list and are not the same:
+// a subject is a label, so "Follow-up" alone is a claim there where it needs a
+// sentence around it to be one in prose.
+var firstTouchSubjects = map[textlang.Lang][]string{
+	textlang.English:    {"follow-up", "follow up", "checking in", "touching base", "reminder"},
+	textlang.German:     {"nachfassen", "nachfrage", "erinnerung", "wiedervorlage"},
+	textlang.Vietnamese: {"nhắc lại", "tiếp theo"},
+}
+
 // Feedback turns findings into the correction a regeneration prompt carries.
 // One line per finding, naming the phrase and why it is wrong here, because a
 // model told only "try again" produces the same draft with different adjectives.

--- a/backend/internal/compose/draftcheck/draftcheck_test.go
+++ b/backend/internal/compose/draftcheck/draftcheck_test.go
@@ -361,3 +361,53 @@ func TestTheStaleThreadPhrasingsAreCaught(t *testing.T) {
 		}
 	}
 }
+
+// A subject fails differently from a body: it is one line, it is read before
+// anything else, and its worst failure is a CLAIM rather than a phrase.
+func TestASubjectMayNotClaimAThreadThatDoesNotExist(t *testing.T) {
+	for _, subject := range []string{"Re: Angebot", "AW: Angebot", "Fwd: Angebot", "WG: Angebot"} {
+		if f := draftcheck.Subject(subject, textlang.German, convstate.BandFresh, false); len(f) == 0 {
+			t.Errorf("%q claims an inbound thread that was never received", subject)
+		}
+		if f := draftcheck.Subject(subject, textlang.German, convstate.BandFresh, true); len(f) != 0 {
+			t.Errorf("%q is correct when a real thread stands behind it, got %+v", subject, f)
+		}
+	}
+}
+
+// At band none there is nothing to follow up ON, so a subject saying so is a
+// claim about a message that does not exist.
+func TestAFirstTouchSubjectMayNotReferBack(t *testing.T) {
+	for lang, subject := range map[textlang.Lang]string{
+		textlang.English: "Follow-up on our conversation",
+		textlang.German:  "Nachfassen zum Angebot",
+	} {
+		if f := draftcheck.Subject(subject, lang, convstate.BandNone, false); len(f) == 0 {
+			t.Errorf("%s: %q refers back on a first message", lang, subject)
+		}
+		// The same words are honest once there IS something behind them.
+		if f := draftcheck.Subject(subject, lang, convstate.BandWeeks, false); len(f) != 0 {
+			t.Errorf("%s: %q is fine when a history exists, got %+v", lang, subject, f)
+		}
+	}
+}
+
+// A subject the client truncates loses the part that carried the meaning.
+func TestAnOverlongSubjectIsCaught(t *testing.T) {
+	long := "Unser Angebot zur Schnittstelle, zum Zeitplan, zur Abnahme und zu den " +
+		"weiteren Schritten im Projekt"
+
+	if f := draftcheck.Subject(long, textlang.German, convstate.BandFresh, false); len(f) == 0 {
+		t.Errorf("a %d-rune subject should be caught at %d", len([]rune(long)), draftcheck.SubjectMaxRunes)
+	}
+	if f := draftcheck.Subject("Angebot Schnittstelle", textlang.German, convstate.BandFresh, false); len(f) != 0 {
+		t.Errorf("a short subject should pass, got %+v", f)
+	}
+}
+
+// An empty subject arrives looking like spam.
+func TestAnEmptySubjectIsCaught(t *testing.T) {
+	if f := draftcheck.Subject("   ", textlang.German, convstate.BandFresh, false); len(f) != 1 {
+		t.Errorf("an empty subject should be caught exactly once, got %+v", f)
+	}
+}

--- a/backend/internal/compose/draftcore/draftcore.go
+++ b/backend/internal/compose/draftcore/draftcore.go
@@ -62,6 +62,12 @@ type Observer interface {
 // folding it in would let a phrase banned in prose hide there.
 type TextOf[D any] func(D) (body string, reasoning []string)
 
+// SubjectOf reads a draft's subject line and whether a real inbound thread
+// earns it a reply prefix. Separate from TextOf because a subject fails
+// differently — its worst failure is a CLAIM ("Re:" says a thread exists)
+// rather than a phrase — and because a surface with no subject supplies none.
+type SubjectOf[D any] func(D) (subject string, threaded bool)
+
 // CorrectOnce writes a draft, checks it against the correspondence it was
 // written into, and gives the model exactly one chance to fix what it got wrong.
 //
@@ -79,12 +85,17 @@ type TextOf[D any] func(D) (body string, reasoning []string)
 // only evidence available without asking a model to judge its own output.
 func CorrectOnce[D any](
 	ctx context.Context, lang textlang.Lang, band convstate.Band,
-	write Writer[D], textOf TextOf[D], observe Observer,
+	write Writer[D], textOf TextOf[D], subjectOf SubjectOf[D], observe Observer,
 ) (D, error) {
 	check := func(draft D) []draftcheck.Finding {
 		body, reasoning := textOf(draft)
-		return append(draftcheck.Body(body, lang, band),
+		findings := append(draftcheck.Body(body, lang, band),
 			draftcheck.Reasoning(reasoning, lang, band)...)
+		if subjectOf != nil {
+			subject, threaded := subjectOf(draft)
+			findings = append(findings, draftcheck.Subject(subject, lang, band, threaded)...)
+		}
+		return findings
 	}
 
 	draft, err := write(ctx, "")

--- a/backend/internal/compose/draftcore/draftcore_test.go
+++ b/backend/internal/compose/draftcore/draftcore_test.go
@@ -46,7 +46,7 @@ func TestACleanDraftIsNotRetried(t *testing.T) {
 	lane := &scripted{bodies: []string{"Hallo Marek,\n\nder Vertrag ist unterschrieben."}}
 
 	got, err := draftcore.CorrectOnce(context.Background(),
-		textlang.German, convstate.BandMonths, lane.write, bodyOf, nil)
+		textlang.German, convstate.BandMonths, lane.write, bodyOf, nil, nil)
 	if err != nil {
 		t.Fatalf("CorrectOnce errored on a clean draft: %v", err)
 	}
@@ -67,7 +67,7 @@ func TestARejectedPhraseEarnsOneRetryThatNamesIt(t *testing.T) {
 	}}
 
 	got, err := draftcore.CorrectOnce(context.Background(),
-		textlang.English, convstate.BandMonths, lane.write, bodyOf, nil)
+		textlang.English, convstate.BandMonths, lane.write, bodyOf, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -92,7 +92,7 @@ func TestTheModelIsNeverAskedMoreThanTwice(t *testing.T) {
 	lane := &scripted{bodies: []string{stubborn, stubborn}}
 
 	if _, err := draftcore.CorrectOnce(context.Background(),
-		textlang.English, convstate.BandMonths, lane.write, bodyOf, nil); err != nil {
+		textlang.English, convstate.BandMonths, lane.write, bodyOf, nil, nil); err != nil {
 		t.Fatal(err)
 	}
 	if len(lane.corrections) != 2 {
@@ -111,7 +111,7 @@ func TestOnlyAStrictlyWorseRetryIsDiscarded(t *testing.T) {
 		"Hi Priya, just checking in on this.",
 	}}
 	got, err := draftcore.CorrectOnce(context.Background(),
-		textlang.English, convstate.BandMonths, tied.write, bodyOf, nil)
+		textlang.English, convstate.BandMonths, tied.write, bodyOf, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -125,7 +125,7 @@ func TestOnlyAStrictlyWorseRetryIsDiscarded(t *testing.T) {
 	}}
 
 	worse, err := draftcore.CorrectOnce(context.Background(),
-		textlang.English, convstate.BandMonths, lane.write, bodyOf, nil)
+		textlang.English, convstate.BandMonths, lane.write, bodyOf, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -141,7 +141,7 @@ func TestAFailedRetryLeavesTheFirstDraftStanding(t *testing.T) {
 	lane := &failOnRetry{first: first}
 
 	got, err := draftcore.CorrectOnce(context.Background(),
-		textlang.English, convstate.BandMonths, lane.write, bodyOf, nil)
+		textlang.English, convstate.BandMonths, lane.write, bodyOf, nil, nil)
 	if err != nil {
 		t.Fatalf("a failed retry must not fail the draft: %v", err)
 	}
@@ -156,7 +156,7 @@ func TestAFailedFirstAttemptIsReturnedAsAnError(t *testing.T) {
 	lane := &scripted{bodies: []string{"unused"}, err: errors.New("model unavailable")}
 
 	if _, err := draftcore.CorrectOnce(context.Background(),
-		textlang.English, convstate.BandFresh, lane.write, bodyOf, nil); err == nil {
+		textlang.English, convstate.BandFresh, lane.write, bodyOf, nil, nil); err == nil {
 		t.Fatal("a failed first attempt should return its error")
 	}
 }
@@ -195,7 +195,7 @@ func TestTheLoopReportsARetryThatDidNotHelp(t *testing.T) {
 	lane := &scripted{bodies: []string{stubborn, stubborn}}
 
 	if _, err := draftcore.CorrectOnce(context.Background(),
-		textlang.English, convstate.BandMonths, lane.write, bodyOf, seen); err != nil {
+		textlang.English, convstate.BandMonths, lane.write, bodyOf, nil, seen); err != nil {
 		t.Fatal(err)
 	}
 	if len(seen.notCleared) != 1 {
@@ -207,7 +207,7 @@ func TestTheLoopReportsARetryThatDidNotHelp(t *testing.T) {
 
 	broken := &recorder{}
 	if _, err := draftcore.CorrectOnce(context.Background(), textlang.English,
-		convstate.BandMonths, (&failOnRetry{first: stubborn}).write, bodyOf, broken); err != nil {
+		convstate.BandMonths, (&failOnRetry{first: stubborn}).write, bodyOf, nil, broken); err != nil {
 		t.Fatal(err)
 	}
 	if broken.failed != 1 {
@@ -217,7 +217,7 @@ func TestTheLoopReportsARetryThatDidNotHelp(t *testing.T) {
 	quiet := &recorder{}
 	clean := &scripted{bodies: []string{stubborn, "Hi Priya, the scope is ready."}}
 	if _, err := draftcore.CorrectOnce(context.Background(),
-		textlang.English, convstate.BandMonths, clean.write, bodyOf, quiet); err != nil {
+		textlang.English, convstate.BandMonths, clean.write, bodyOf, nil, quiet); err != nil {
 		t.Fatal(err)
 	}
 	if quiet.failed != 0 || len(quiet.notCleared) != 0 {

--- a/backend/internal/compose/persondraft/fold.go
+++ b/backend/internal/compose/persondraft/fold.go
@@ -365,3 +365,10 @@ func stamp(at *time.Time) string {
 	}
 	return at.UTC().Format(time.RFC3339)
 }
+
+// Threaded reports whether a real inbound message earns this draft a reply
+// prefix. Only a message THEY sent counts: our own last outbound carries a
+// subject too, and "Re:" on it replies to ourselves.
+func (in Input) Threaded() bool {
+	return len(in.Recent) > 0 && in.Recent[0].Inbound && in.Recent[0].Subject != ""
+}

--- a/backend/internal/compose/persondraft/write.go
+++ b/backend/internal/compose/persondraft/write.go
@@ -128,6 +128,7 @@ func writeChecked(ctx context.Context, lane Completer, in Input) (Draft, error) 
 			return writeWithModel(ctx, lane, in, correction)
 		},
 		func(d Draft) (string, []string) { return d.Body, reasonLabels(d.Reasoning) },
+		func(d Draft) (string, bool) { return d.Subject, in.Threaded() },
 		// No observer: this package holds no logger, and a retry that does not
 		// help still returns a real draft. The reply surface, which has one,
 		// reports it.

--- a/backend/internal/compose/replydraft.go
+++ b/backend/internal/compose/replydraft.go
@@ -52,7 +52,16 @@ type replyActivityData struct {
 	Subject string `json:"subject,omitempty"`
 	Body    string `json:"body,omitempty"`
 	Intent  string `json:"intent,omitempty"`
+	// Thread carries whether a real INBOUND mail thread stands behind this
+	// subject, as a string because the whole payload decodes as a flat string
+	// map for the certification bound check. Only that earns a reply prefix:
+	// "Re:" on a meeting title, or on our own last outbound, claims a message
+	// nobody sent us.
+	Thread string `json:"thread,omitempty"`
 }
+
+// Threaded reads the flag back as the bool the checks want.
+func (d replyActivityData) Threaded() bool { return d.Thread == "inbound_mail" }
 
 type replyDrafter struct {
 	brain completer
@@ -135,6 +144,7 @@ func (d replyDrafter) DraftEmailWithProvenance(ctx context.Context, anchor ids.U
 		// the only ones that come from a text column rather than being
 		// server-derived and fixed-shape.
 		Envelope:  envelope,
+		Thread:    threadFlag(threaded),
 		Recipient: boundedRunes(recipient, recipientMaxRunes),
 		Subject:   boundedRunes(topic, replyActivityMaxRunes),
 		Body:      boundedRunes(body, replyActivityMaxRunes),
@@ -219,4 +229,14 @@ func (d replyDrafter) conversationState(activity crmcontracts.Activity) convstat
 		return convstate.Classify(d.envelope.Now(), occurred, time.Time{})
 	}
 	return convstate.Classify(d.envelope.Now(), time.Time{}, occurred)
+}
+
+// threadFlag spells the thread state for the flat payload. A named value rather
+// than "true"/"false": the prompt reads this field, and "inbound_mail" says what
+// it means where a bare true does not.
+func threadFlag(threaded bool) string {
+	if threaded {
+		return "inbound_mail"
+	}
+	return ""
 }

--- a/backend/internal/compose/replydraft_test.go
+++ b/backend/internal/compose/replydraft_test.go
@@ -127,7 +127,7 @@ func TestVoicedDraftInjectsTheProfileAndStampsTheVersion(t *testing.T) {
 	drafter := replyDrafter{brain: brain}
 
 	draft, version, _, err := drafter.completeVoiced(context.Background(), ids.NewV7(),
-		replyActivityData{Subject: "plan"}, testVoiceContext())
+		replyActivityData{Subject: "plan", Thread: "inbound_mail"}, testVoiceContext())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -171,7 +171,7 @@ func TestVoicedDraftRetriesOnceOnAntiAIViolations(t *testing.T) {
 	drafter := replyDrafter{brain: brain}
 
 	draft, version, _, err := drafter.completeVoiced(context.Background(), ids.NewV7(),
-		replyActivityData{Subject: "plan"}, testVoiceContext())
+		replyActivityData{Subject: "plan", Thread: "inbound_mail"}, testVoiceContext())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -196,7 +196,7 @@ func TestVoicedDraftFallsBackToPlainWhenViolationsSurvive(t *testing.T) {
 	drafter := replyDrafter{brain: brain}
 
 	draft, version, _, err := drafter.completeVoiced(context.Background(), ids.NewV7(),
-		replyActivityData{Subject: "plan"}, testVoiceContext())
+		replyActivityData{Subject: "plan", Thread: "inbound_mail"}, testVoiceContext())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -220,7 +220,7 @@ func TestVoicedDraftWithoutAProfileIsThePlainPath(t *testing.T) {
 	}}
 	drafter := replyDrafter{brain: brain}
 	_, version, _, err := drafter.completeVoiced(context.Background(), ids.NewV7(),
-		replyActivityData{Subject: "plan"}, voiceContext{})
+		replyActivityData{Subject: "plan", Thread: "inbound_mail"}, voiceContext{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/backend/internal/compose/replydraftmodel.go
+++ b/backend/internal/compose/replydraftmodel.go
@@ -132,6 +132,7 @@ func (d replyDrafter) completeChecked(ctx context.Context, data replyActivityDat
 		// The reply site returns no reasoning: its schema is subject and body
 		// alone, so there is no second channel to judge here.
 		func(draft replyDraft) (string, []string) { return draft.Body, nil },
+		func(draft replyDraft) (string, bool) { return draft.Subject, data.Threaded() },
 		draftRetryLog{log: d.logger()},
 	)
 }


### PR DESCRIPTION
A subject fails differently from a body. It is one line, it is read before anything else, and what it gets wrong is a **claim** rather than a phrase: `Re:` says a thread exists, and a follow-up subject says there was a message before this one.

Both are facts the envelope already holds, so they are refused deterministically rather than explained in a prompt for the fourth time.

## Four rules

- **A reply prefix** (`Re:`/`AW:`/`Fwd:`/`WG:`) needs a real inbound mail thread behind it. Our own last outbound carries a subject too, and replying to it replies to ourselves.
- **A follow-up subject at band none** refers to a message that does not exist.
- **Past 70 runes** the client truncates it, so the part carrying the meaning may never be read.
- **An empty subject** arrives looking like spam.

## How each surface answers "is this threaded?"

The reply payload carries the thread state as a named string (`inbound_mail`) — the whole payload decodes as a flat string map for the certification bound check, and a named value says what it means where a bare `true` does not.

The composers answer it **structurally**: the account site opens conversations, so nothing it writes can be a reply; the person site is threaded only when *their* newest message carries a subject.

Every reply fixture now states its thread explicitly, which is what it always was implicitly — a reply fixture answers an activity.

## Gate

GOWORK=/Users/lars/develop/margince-poc-v1/build/composition/go.work go build ./..., FAIL	./internal/compose/... [setup failed]
FAIL, FAIL	. [setup failed]
FAIL all green. Four new subject tests, each checking both the failing and the passing side.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add subject-line validation to catch false claims and unreadable subjects. Thread state is now passed through composers so subjects are checked deterministically.

- **New Features**
  - Validate subjects with language-aware rules in `draftcheck.Subject`.
  - Reject reply prefixes (`Re:` `AW:` `Fwd:` `WG:` `Antw:`) unless a real inbound thread exists.
  - On `BandNone`, flag follow-up subjects (e.g., English: "follow-up", German: "nachfassen").
  - Flag overlong subjects (>70 runes) and empty subjects.

- **Migration**
  - `draftcore.CorrectOnce` now takes a `SubjectOf` callback: `CorrectOnce(ctx, lang, band, write, textOf, subjectOf, observe)`. Pass `nil` to skip subject checks.
  - Surfaces expose threading via `Threaded()`: account drafts return `false`; person drafts return `true` only if the newest message is inbound and has a subject.
  - Reply payload carries `thread: "inbound_mail"`; use `replyActivityData.Threaded()` to feed `SubjectOf`. Fixtures updated to include `thread` where replies are real.

<sup>Written for commit de23c537c996775ff3551549305dba218fb47056. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1033?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

