### PR TITLE
refactor(events): the envelope and the ledger drop the tenant

### DIFF
--- a/backend/internal/compose/datareset_integration_test.go
+++ b/backend/internal/compose/datareset_integration_test.go
@@ -119,16 +119,18 @@ func TestPreserveSetIntegrity(t *testing.T) {
 	}
 }
 
-// TestClearWorkspaceOutboxScopesToWorkspace proves the one sweep target with
-// NO RLS backstop — event_outbox has no workspace_id column, so its tenant
-// boundary rests entirely on the envelope text match — actually scopes to the
-// bound workspace: this workspace's rows go, a foreign workspace's survive.
-func TestClearWorkspaceOutboxScopesToWorkspace(t *testing.T) {
+// TestClearWorkspaceOutboxEmptiesTheStagedEvents is the reset's outbox half: a
+// reset that left staged events behind would ship events naming rows it had
+// just deleted.
+//
+// It used to assert that a foreign workspace's rows SURVIVED, and the delete
+// matched on the envelope's tenant to do it. The envelope carries no tenant now
+// (ADR-0091 §6) and an installation holds one, so there is no other tenant's
+// event to spare — every staged row belongs to the installation being reset.
+func TestClearWorkspaceOutboxEmptiesTheStagedEvents(t *testing.T) {
 	e := integration.Setup(t)
 	ctx := e.Admin()
-	foreign := ids.NewV7()
-	e.WsExec(t, `INSERT INTO event_outbox (stream, envelope) VALUES ('t', jsonb_build_object('workspace_id', $1::text))`, e.WS)
-	e.WsExec(t, `INSERT INTO event_outbox (stream, envelope) VALUES ('t', jsonb_build_object('workspace_id', $1::text))`, foreign)
+	e.WsExec(t, `INSERT INTO event_outbox (stream, envelope) VALUES ('t', jsonb_build_object('type', 'x'))`)
 
 	if err := database.WithWorkspaceTx(ctx, e.Pool, func(tx pgx.Tx) error {
 		return clearWorkspaceOutbox(ctx, tx)
@@ -136,11 +138,8 @@ func TestClearWorkspaceOutboxScopesToWorkspace(t *testing.T) {
 		t.Fatalf("clear: %v", err)
 	}
 
-	if n := e.WsCount(t, `SELECT count(*) FROM event_outbox WHERE envelope->>'workspace_id' = $1`, e.WS.String()); n != 0 {
-		t.Fatalf("this workspace's outbox rows = %d, want 0", n)
-	}
-	if n := e.WsCount(t, `SELECT count(*) FROM event_outbox WHERE envelope->>'workspace_id' = $1`, foreign.String()); n != 1 {
-		t.Fatalf("foreign workspace's outbox rows = %d, want 1 (must survive)", n)
+	if n := e.WsCount(t, `SELECT count(*) FROM event_outbox`); n != 0 {
+		t.Fatalf("staged outbox rows after the reset = %d, want 0", n)
 	}
 }
 

--- a/backend/internal/compose/datasweep.go
+++ b/backend/internal/compose/datasweep.go
@@ -113,12 +113,16 @@ func sweepWorkspaceData(ctx context.Context, tx pgx.Tx, tables []string) error {
 	return nil
 }
 
-// clearWorkspaceOutbox removes this workspace's staged events. event_outbox is
-// infra-owned and has no workspace_id column — tenancy lives in the envelope —
-// so the reset must not leave events that point at rows it just deleted.
+// clearWorkspaceOutbox removes the staged events, so the reset does not leave
+// events pointing at rows it just deleted.
+//
+// event_outbox is infra-owned and has no workspace_id column. Tenancy used to
+// live in the envelope, and the delete matched on it; the envelope carries no
+// tenant now (ADR-0091 §6), and under one installation there is no other
+// tenant's event to spare — every staged row belongs to the installation being
+// reset.
 func clearWorkspaceOutbox(ctx context.Context, tx pgx.Tx) error {
-	_, err := tx.Exec(ctx,
-		`DELETE FROM event_outbox WHERE envelope->>'workspace_id' = current_setting('app.workspace_id')`)
+	_, err := tx.Exec(ctx, `DELETE FROM event_outbox`)
 	return err
 }
 

--- a/backend/internal/compose/graphconsumer_integration_test.go
+++ b/backend/internal/compose/graphconsumer_integration_test.go
@@ -32,13 +32,12 @@ import (
 // envelopeFor builds one bus envelope the way the relay ships it.
 func envelopeFor(ws ids.UUID, eventType, entityType string, entity ids.UUID) kevents.Envelope {
 	return kevents.Envelope{
-		EventID:     ids.NewV7(),
-		Type:        eventType,
-		Version:     1,
-		WorkspaceID: ws,
-		OccurredAt:  time.Now().UTC(),
-		Entity:      kevents.EntityRef{Type: entityType, ID: entity},
-		Trace:       kevents.Trace{CorrelationID: ids.NewV7()},
+		EventID:    ids.NewV7(),
+		Type:       eventType,
+		Version:    1,
+		OccurredAt: time.Now().UTC(),
+		Entity:     kevents.EntityRef{Type: entityType, ID: entity},
+		Trace:      kevents.Trace{CorrelationID: ids.NewV7()},
 	}
 }
 

--- a/backend/internal/compose/integration/embedding_integration_test.go
+++ b/backend/internal/compose/integration/embedding_integration_test.go
@@ -206,10 +206,9 @@ func TestEmbedGenMaintainsRowsFromEvents(t *testing.T) {
 
 	personID := e.Seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Event Driven', 'manual', 'human:x')`)
 	env := kevents.Envelope{
-		EventID:     ids.NewV7(),
-		Type:        "person.created",
-		WorkspaceID: e.WS,
-		Entity:      kevents.EntityRef{Type: "person", ID: personID},
+		EventID: ids.NewV7(),
+		Type:    "person.created",
+		Entity:  kevents.EntityRef{Type: "person", ID: personID},
 	}
 	if err := gen.HandleEvent(context.Background(), env); err != nil {
 		t.Fatal(err)
@@ -230,7 +229,7 @@ func TestEmbedGenMaintainsRowsFromEvents(t *testing.T) {
 	}
 
 	// A non-entity event is not ours.
-	if err := gen.HandleEvent(context.Background(), kevents.Envelope{Type: "approval.decided", WorkspaceID: e.WS, Entity: kevents.EntityRef{Type: "approval", ID: ids.NewV7()}}); err != nil {
+	if err := gen.HandleEvent(context.Background(), kevents.Envelope{Type: "approval.decided", Entity: kevents.EntityRef{Type: "approval", ID: ids.NewV7()}}); err != nil {
 		t.Fatalf("foreign event must be a no-op, got %v", err)
 	}
 }

--- a/backend/internal/compose/integration/jobfanout/privacyretention_integration_test.go
+++ b/backend/internal/compose/integration/jobfanout/privacyretention_integration_test.go
@@ -206,8 +206,8 @@ func TestPrivacyRetentionFansOutOneJobPerWorkspaceAndFailsOnlyTheFailedTenant(t 
 	if err := e.Pool.QueryRow(ctx, `
 		SELECT count(*) FROM event_outbox
 		WHERE envelope->>'type' = 'retention.applied'
-		  AND envelope->>'workspace_id' = $1
-		  AND envelope->'actor'->>'id' = 'system'`, e.WS).Scan(&emitted); err != nil {
+		  AND envelope->'entity'->>'id' = $1
+		  AND envelope->'actor'->>'id' = 'system'`, healthyLead).Scan(&emitted); err != nil {
 		t.Fatalf("reading the staged retention events: %v", err)
 	}
 	if emitted != 1 {

--- a/backend/internal/compose/integration/jobfanout/runner_integration_test.go
+++ b/backend/internal/compose/integration/jobfanout/runner_integration_test.go
@@ -366,11 +366,10 @@ func decidedEnvelope(wsID ids.UUID, approvalID, verdict string) kevents.Envelope
 	id, _ := ids.Parse(approvalID)
 	payload, _ := json.Marshal(map[string]string{"verdict": verdict})
 	return kevents.Envelope{
-		EventID:     ids.NewV7(),
-		Type:        "approval.decided",
-		WorkspaceID: wsID,
-		Entity:      kevents.EntityRef{Type: "approval", ID: id},
-		Payload:     payload,
+		EventID: ids.NewV7(),
+		Type:    "approval.decided",
+		Entity:  kevents.EntityRef{Type: "approval", ID: id},
+		Payload: payload,
 	}
 }
 

--- a/backend/internal/compose/integration/leadrouting_integration_test.go
+++ b/backend/internal/compose/integration/leadrouting_integration_test.go
@@ -55,7 +55,7 @@ func (e *routingEnv) routeNewLead(t *testing.T, source string) (ids.UUID, *ids.U
 		`INSERT INTO lead (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Routed Lead', $3, 'human:x')`,
 		source)
 	if err := e.engine.HandleEvent(context.Background(), kevents.Envelope{
-		EventID: ids.NewV7(), Type: "lead.created", WorkspaceID: e.WS,
+		EventID: ids.NewV7(), Type: "lead.created",
 		OccurredAt: time.Now().UTC(),
 		Entity:     kevents.EntityRef{Type: "lead", ID: leadID},
 	}); err != nil {
@@ -165,7 +165,7 @@ func TestLeadRoutingLeavesHumanAssignmentsAlone(t *testing.T) {
 		`INSERT INTO lead (id, workspace_id, full_name, source, owner_id, captured_by) VALUES ($1, $2, 'Claimed Lead', 'manual', $3, 'human:x')`,
 		e.Rep3)
 	if err := e.engine.HandleEvent(context.Background(), kevents.Envelope{
-		EventID: ids.NewV7(), Type: "lead.created", WorkspaceID: e.WS,
+		EventID: ids.NewV7(), Type: "lead.created",
 		OccurredAt: time.Now().UTC(),
 		Entity:     kevents.EntityRef{Type: "lead", ID: leadID},
 	}); err != nil {

--- a/backend/internal/compose/integration/leadscore_integration_test.go
+++ b/backend/internal/compose/integration/leadscore_integration_test.go
@@ -113,7 +113,7 @@ func TestLeadScoreRecomputesFromLinkedActivities(t *testing.T) {
 func dispatchActivityCaptured(t *testing.T, engine *automation.WorkflowEngine, ws ids.UUID, eventID, activityID ids.UUID) {
 	t.Helper()
 	if err := engine.HandleEvent(context.Background(), kevents.Envelope{
-		EventID: eventID, Type: "activity.captured", WorkspaceID: ws,
+		EventID: eventID, Type: "activity.captured",
 		OccurredAt: time.Now().UTC(),
 		Entity:     kevents.EntityRef{Type: "activity", ID: activityID},
 	}); err != nil {

--- a/backend/internal/compose/integration/overlay/overlay_acceptance_budget_integration_test.go
+++ b/backend/internal/compose/integration/overlay/overlay_acceptance_budget_integration_test.go
@@ -193,8 +193,11 @@ func TestAcceptance_AC_OV_7_ForceFreshDegrades(t *testing.T) {
 	var eventCount int
 	if err := e.Pool.QueryRow(
 		context.Background(),
-		`SELECT count(*) FROM event_outbox WHERE envelope->>'type' = 'mirror.budget_degraded' AND envelope->>'workspace_id' = $1`,
-		ws.String(),
+		// Scoped by SUBJECT: the envelope carries no tenant (ADR-0091 §6).
+		`SELECT count(*) FROM event_outbox
+		  WHERE envelope->>'type' = 'mirror.budget_degraded'
+		    AND envelope->'entity'->>'id' = $1`,
+		ref.ID.String(),
 	).Scan(&eventCount); err != nil {
 		t.Fatalf("querying event_outbox: %v", err)
 	}

--- a/backend/internal/compose/integration/overlay/overlay_acceptance_integration_test.go
+++ b/backend/internal/compose/integration/overlay/overlay_acceptance_integration_test.go
@@ -290,9 +290,8 @@ func countAcceptanceMirrorConflictEvents(ctx context.Context, e *integration.Env
 		ctx,
 		`SELECT count(*) FROM event_outbox
 		 WHERE envelope->>'type' = 'mirror.conflict'
-		   AND envelope->>'workspace_id' = $1
-		   AND envelope->'payload'->>'external_id' = $2`,
-		ws, externalID,
+		   AND envelope->'payload'->>'external_id' = $1`,
+		externalID,
 	).Scan(&count)
 	return count, err
 }

--- a/backend/internal/compose/integration/personautoenrich_integration_test.go
+++ b/backend/internal/compose/integration/personautoenrich_integration_test.go
@@ -125,10 +125,9 @@ func newEnricher(e *Env) *compose.PersonAutoEnrich {
 // the outbox refuses an envelope without one.
 func personCreated(e *Env, personID ids.PersonID) events.Envelope {
 	return events.Envelope{
-		Type:        "person.created",
-		WorkspaceID: e.WS,
-		Entity:      events.EntityRef{Type: "person", ID: personID.UUID},
-		Trace:       events.Trace{CorrelationID: ids.NewV7()},
+		Type:   "person.created",
+		Entity: events.EntityRef{Type: "person", ID: personID.UUID},
+		Trace:  events.Trace{CorrelationID: ids.NewV7()},
 	}
 }
 
@@ -290,11 +289,10 @@ func TestPersonAutoEnrichFollowsAMergeToTheSurvivor(t *testing.T) {
 		t.Fatalf("marshalling the merge payload: %v", err)
 	}
 	if err := newEnricher(e).HandleEvent(context.Background(), events.Envelope{
-		Type:        "person.merged",
-		WorkspaceID: e.WS,
-		Entity:      events.EntityRef{Type: "person", ID: mergedAway.UUID},
-		Trace:       events.Trace{CorrelationID: ids.NewV7()},
-		Payload:     payload,
+		Type:    "person.merged",
+		Entity:  events.EntityRef{Type: "person", ID: mergedAway.UUID},
+		Trace:   events.Trace{CorrelationID: ids.NewV7()},
+		Payload: payload,
 	}); err != nil {
 		t.Fatalf("HandleEvent: %v", err)
 	}

--- a/backend/internal/compose/integration/webhooks/webhooks_integration_test.go
+++ b/backend/internal/compose/integration/webhooks/webhooks_integration_test.go
@@ -187,14 +187,13 @@ func newTestDelivererWithResolver(we *webhookEnv, now *time.Time, client *http.C
 // path is exercised separately by revoking the owner.
 func makeEnvelope(wsID ids.UUID, eventType string) kevents.Envelope {
 	return kevents.Envelope{
-		EventID:     ids.NewV7(),
-		Type:        eventType,
-		Version:     kevents.VersionOf(eventType),
-		WorkspaceID: wsID,
-		OccurredAt:  time.Now().UTC(),
-		Actor:       kevents.Actor{Type: "system", ID: "system"},
-		Entity:      kevents.EntityRef{Type: "deal", ID: ids.NewV7()},
-		Trace:       kevents.Trace{CorrelationID: ids.NewV7(), AuditLogID: ids.NewV7()},
+		EventID:    ids.NewV7(),
+		Type:       eventType,
+		Version:    kevents.VersionOf(eventType),
+		OccurredAt: time.Now().UTC(),
+		Actor:      kevents.Actor{Type: "system", ID: "system"},
+		Entity:     kevents.EntityRef{Type: "deal", ID: ids.NewV7()},
+		Trace:      kevents.Trace{CorrelationID: ids.NewV7(), AuditLogID: ids.NewV7()},
 	}
 }
 

--- a/backend/internal/compose/integration/workflow_action_executors_integration_test.go
+++ b/backend/internal/compose/integration/workflow_action_executors_integration_test.go
@@ -75,7 +75,7 @@ func TestNotifyFiringWithNoTransportLandsAVisibleSkippedRun(t *testing.T) {
 
 	ctx := context.Background()
 	if err := engine.HandleEvent(ctx, kevents.Envelope{
-		EventID: ids.NewV7(), Type: "deal.stage_changed", WorkspaceID: e.WS,
+		EventID: ids.NewV7(), Type: "deal.stage_changed",
 		OccurredAt: time.Now().UTC(),
 		Entity:     kevents.EntityRef{Type: "deal", ID: dealID},
 	}); err != nil {
@@ -174,7 +174,7 @@ func TestAddToListFiringAddsARealListMember(t *testing.T) {
 
 	ctx := context.Background()
 	if err := engine.HandleEvent(ctx, kevents.Envelope{
-		EventID: ids.NewV7(), Type: "deal.stage_changed", WorkspaceID: e.WS,
+		EventID: ids.NewV7(), Type: "deal.stage_changed",
 		OccurredAt: time.Now().UTC(),
 		Entity:     kevents.EntityRef{Type: "deal", ID: dealID},
 	}); err != nil {
@@ -263,7 +263,7 @@ func TestDraftEmailFiringLandsTheComposedDraftOnTheRunRecord(t *testing.T) {
 
 	ctx := context.Background()
 	if err := engine.HandleEvent(ctx, kevents.Envelope{
-		EventID: ids.NewV7(), Type: "deal.stage_changed", WorkspaceID: e.WS,
+		EventID: ids.NewV7(), Type: "deal.stage_changed",
 		OccurredAt: time.Now().UTC(),
 		Entity:     kevents.EntityRef{Type: "deal", ID: dealID},
 	}); err != nil {

--- a/backend/internal/compose/integration/workflow_approval_staging_integration_test.go
+++ b/backend/internal/compose/integration/workflow_approval_staging_integration_test.go
@@ -109,7 +109,7 @@ func TestConfirmationRequiredActionStagesARealApprovalAndRejectionBlocksTheRun(t
 
 	ctx := context.Background()
 	if err := engine.HandleEvent(ctx, kevents.Envelope{
-		EventID: ids.NewV7(), Type: "deal.stage_changed", WorkspaceID: e.WS,
+		EventID: ids.NewV7(), Type: "deal.stage_changed",
 		OccurredAt: time.Now().UTC(),
 		Entity:     kevents.EntityRef{Type: "deal", ID: dealID},
 	}); err != nil {

--- a/backend/internal/compose/integration/workflow_dispatch_perf_integration_test.go
+++ b/backend/internal/compose/integration/workflow_dispatch_perf_integration_test.go
@@ -125,11 +125,10 @@ func TestWorkflowTriggerToDispatchP95HoldsOnTheSeededDataset(t *testing.T) {
 // reused here rather than re-derived.
 func leadCreatedEnvelope(e *Env, leadID ids.UUID) kevents.Envelope {
 	return kevents.Envelope{
-		EventID:     ids.NewV7(),
-		Type:        leadCreatedEventType,
-		WorkspaceID: e.WS,
-		OccurredAt:  time.Now().UTC(),
-		Entity:      kevents.EntityRef{Type: "lead", ID: leadID},
+		EventID:    ids.NewV7(),
+		Type:       leadCreatedEventType,
+		OccurredAt: time.Now().UTC(),
+		Entity:     kevents.EntityRef{Type: "lead", ID: leadID},
 	}
 }
 

--- a/backend/internal/compose/integration/workflow_integration_test.go
+++ b/backend/internal/compose/integration/workflow_integration_test.go
@@ -87,11 +87,10 @@ func TestWorkflowRouteLeadAssignsExactlyOnce(t *testing.T) {
 	engine := compose.NewWorkflowEngine(e.DB())
 
 	env := kevents.Envelope{
-		EventID:     ids.NewV7(),
-		Type:        "lead.created",
-		WorkspaceID: e.WS,
-		OccurredAt:  time.Now().UTC(),
-		Entity:      kevents.EntityRef{Type: "lead", ID: leadID},
+		EventID:    ids.NewV7(),
+		Type:       "lead.created",
+		OccurredAt: time.Now().UTC(),
+		Entity:     kevents.EntityRef{Type: "lead", ID: leadID},
 	}
 	if err := engine.HandleEvent(context.Background(), env); err != nil {
 		t.Fatal(err)
@@ -158,7 +157,7 @@ func TestWorkflowEngineHonorsAutomationInstances(t *testing.T) {
 	dispatch := func(leadID ids.UUID) {
 		t.Helper()
 		if err := engine.HandleEvent(context.Background(), kevents.Envelope{
-			EventID: ids.NewV7(), Type: "lead.created", WorkspaceID: e.WS,
+			EventID: ids.NewV7(), Type: "lead.created",
 			OccurredAt: time.Now().UTC(),
 			Entity:     kevents.EntityRef{Type: "lead", ID: leadID},
 		}); err != nil {
@@ -249,7 +248,7 @@ func TestWorkflowStageChangeMatchGuardsSemantic(t *testing.T) {
 
 	closedPayload, _ := json.Marshal(map[string]string{"to_status": "won"})
 	if err := engine.HandleEvent(context.Background(), kevents.Envelope{
-		EventID: ids.NewV7(), Type: "deal.stage_changed", WorkspaceID: e.WS,
+		EventID: ids.NewV7(), Type: "deal.stage_changed",
 		OccurredAt: time.Now().UTC(),
 		Entity:     kevents.EntityRef{Type: "deal", ID: dealID},
 		Payload:    closedPayload,
@@ -258,7 +257,7 @@ func TestWorkflowStageChangeMatchGuardsSemantic(t *testing.T) {
 	}
 	openPayload, _ := json.Marshal(map[string]string{"to_status": "open"})
 	if err := engine.HandleEvent(context.Background(), kevents.Envelope{
-		EventID: ids.NewV7(), Type: "deal.stage_changed", WorkspaceID: e.WS,
+		EventID: ids.NewV7(), Type: "deal.stage_changed",
 		OccurredAt: time.Now().UTC(),
 		Entity:     kevents.EntityRef{Type: "deal", ID: dealID},
 		Payload:    openPayload,

--- a/backend/internal/compose/linkedinmatchgen.go
+++ b/backend/internal/compose/linkedinmatchgen.go
@@ -92,7 +92,14 @@ func (g *LinkedInMatchGen) HandleEvent(ctx context.Context, env events.Envelope)
 	if env.Entity.ID == ids.Nil {
 		return nil
 	}
-	ctx = g.matchContext(ctx, env)
+	// The workspace is this consumer's own — the envelope carries none
+	// (ADR-0091 §6) — and the two passes below still take it as an argument
+	// because they enumerate owners inside it.
+	ws, err := InstallationDB(g.pool).Workspace(ctx)
+	if err != nil {
+		return err
+	}
+	ctx = g.matchContext(ctx, env, ws.UUID)
 
 	switch env.Entity.Type {
 	case matchEntityPerson:
@@ -103,7 +110,7 @@ func (g *LinkedInMatchGen) HandleEvent(ctx context.Context, env events.Envelope)
 		// both match arms already require archived_at IS NULL, so an archive
 		// needs no reaction, and a merge arrives as an update on the target.
 		case "person.created", "person.updated", "person.merged", "person.restored":
-			return g.matchPerson(ctx, env.WorkspaceID, env.Entity.ID)
+			return g.matchPerson(ctx, ws.UUID, env.Entity.ID)
 		}
 	case matchEntityOrganization:
 		switch env.Type {
@@ -112,7 +119,7 @@ func (g *LinkedInMatchGen) HandleEvent(ctx context.Context, env events.Envelope)
 		// pass is workspace-wide because a new account can unblock ghosts
 		// belonging to any member.
 		case "organization.created", "organization.updated", "organization.merged":
-			return g.matchWorkspace(ctx, env.WorkspaceID)
+			return g.matchWorkspace(ctx, ws.UUID)
 		}
 	}
 	return nil
@@ -185,12 +192,12 @@ func (g *LinkedInMatchGen) matchWorkspace(ctx context.Context, workspace ids.UUI
 		})
 }
 
-// matchContext binds the envelope's workspace and the maintenance principal the
+// matchContext binds the consumer's workspace and the maintenance principal the
 // OWNER enumeration runs under. The per-owner passes replace this actor with
 // the member's own authority before any record is read — this one only reaches
 // linkedin_connection and the roster.
-func (g *LinkedInMatchGen) matchContext(ctx context.Context, env events.Envelope) context.Context {
-	ctx = principal.WithWorkspaceID(ctx, env.WorkspaceID)
+func (g *LinkedInMatchGen) matchContext(ctx context.Context, env events.Envelope, ws ids.UUID) context.Context {
+	ctx = principal.WithWorkspaceID(ctx, ws)
 	ctx = principal.WithCorrelationID(ctx, env.Trace.CorrelationID)
 	return principal.WithActor(ctx, principal.Principal{
 		Type: principal.PrincipalSystem, ID: "system:linkedin_match",

--- a/backend/internal/compose/personautoenrich.go
+++ b/backend/internal/compose/personautoenrich.go
@@ -106,7 +106,12 @@ func (g *PersonAutoEnrich) HandleEvent(ctx context.Context, env events.Envelope)
 	default:
 		return nil
 	}
-	return g.enrich(g.systemContext(ctx, env), ids.From[ids.PersonKind](subject))
+	// The envelope carries no tenant (ADR-0091 §6); the store's handle names it.
+	ws, err := InstallationDB(g.pool).Workspace(ctx)
+	if err != nil {
+		return err
+	}
+	return g.enrich(g.systemContext(ctx, env, ws.UUID), ids.From[ids.PersonKind](subject))
 }
 
 // survivorOf reads the surviving person out of a person.merged payload.
@@ -130,8 +135,8 @@ func survivorOf(env events.Envelope) (ids.UUID, bool) {
 // under. The fill is not a human's edit and must not be recorded as one, and
 // the correlation id carries through so the fill traces back to the event
 // that caused it.
-func (g *PersonAutoEnrich) systemContext(ctx context.Context, env events.Envelope) context.Context {
-	ctx = principal.WithWorkspaceID(ctx, env.WorkspaceID)
+func (g *PersonAutoEnrich) systemContext(ctx context.Context, env events.Envelope, ws ids.UUID) context.Context {
+	ctx = principal.WithWorkspaceID(ctx, ws)
 	ctx = principal.WithCorrelationID(ctx, env.Trace.CorrelationID)
 	return principal.WithActor(ctx, principal.Principal{
 		Type: principal.PrincipalSystem, ID: autoEnrichActor,

--- a/backend/internal/compose/personautoenrich_test.go
+++ b/backend/internal/compose/personautoenrich_test.go
@@ -46,12 +46,11 @@ func TestPersonAutoEnrichWritesAsASystemPrincipal(t *testing.T) {
 	g := &PersonAutoEnrich{}
 	ws := ids.NewV7()
 	env := events.Envelope{
-		Type:        "person.created",
-		Entity:      events.EntityRef{Type: "person", ID: ids.NewV7()},
-		WorkspaceID: ws,
+		Type:   "person.created",
+		Entity: events.EntityRef{Type: "person", ID: ids.NewV7()},
 	}
 
-	ctx := g.systemContext(context.Background(), env)
+	ctx := g.systemContext(context.Background(), env, ws)
 	actor, ok := principal.Actor(ctx)
 	if !ok {
 		t.Fatal("the pass writes with no principal at all")

--- a/backend/internal/compose/runnerservice.go
+++ b/backend/internal/compose/runnerservice.go
@@ -265,7 +265,13 @@ func (s *RunnerService) HandleEvent(ctx context.Context, env kevents.Envelope) e
 		return nil
 	}
 	approvalID := ids.From[ids.ApprovalKind](env.Entity.ID)
-	wsCtx := principal.WithWorkspaceID(ctx, env.WorkspaceID)
+	// The envelope carries no tenant (ADR-0091 §6): this consumer resolves the
+	// installation, exactly as the request paths beside it do.
+	ws, err := s.identity.InstallationWorkspace(ctx)
+	if err != nil {
+		return err
+	}
+	wsCtx := principal.WithWorkspaceID(ctx, ws.UUID)
 
 	// The payload is read BEFORE the run is claimed: claiming is one-way, so
 	// every step after it must end in a terminal status rather than in a
@@ -280,10 +286,9 @@ func (s *RunnerService) HandleEvent(ctx context.Context, env kevents.Envelope) e
 		return fmt.Errorf("runner: approval.decided payload: %w", err)
 	}
 
-	// The envelope names the tenant, and the store is bound to it before any
-	// row is read or written: this consumer, like the scheduler pass, runs on
-	// one shared service.
-	s, err := s.forWorkspaceIn(wsCtx)
+	// The store is bound before any row is read or written: this consumer,
+	// like the scheduler pass, runs on one shared service.
+	s, err = s.forWorkspaceIn(wsCtx)
 	if err != nil {
 		return err
 	}

--- a/backend/internal/compose/webhooks.go
+++ b/backend/internal/compose/webhooks.go
@@ -14,7 +14,6 @@ import (
 	"github.com/gradionhq/margince/backend/internal/modules/webhooks"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
 	kevents "github.com/gradionhq/margince/backend/internal/shared/kernel/events"
-	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
 // newWebhookHandlers builds the outbound-webhook transport (E10/S-E10.6,
@@ -89,13 +88,15 @@ func WithWebhookKey(key string) (Option, error) {
 }
 
 // WebhookEventHandler adapts the per-workspace deliverer factory to the bus
-// consumer's one-function shape: each envelope names the workspace it belongs
-// to, so the deliverer that handles it binds THAT one. A single deliverer
-// shared across the lane would carry one tenant's handle into every other
-// tenant's event (ADR-0091 §9 step 3).
+// consumer's one-function shape. The envelope no longer names a tenant
+// (ADR-0091 §6), so the handle is the installation's — the same one every
+// other request-path and bus consumer resolves. The factory shape is kept
+// because the RETRY fan-out still pins per tenant from its job args, and both
+// callers must build their deliverer the same way.
 func WebhookEventHandler(pool *pgxpool.Pool, deliverer func(*database.DB) *webhooks.Deliverer,
 ) func(context.Context, kevents.Envelope) error {
+	handler := deliverer(InstallationDB(pool))
 	return func(ctx context.Context, env kevents.Envelope) error {
-		return deliverer(database.BindTo(pool, ids.From[ids.WorkspaceKind](env.WorkspaceID))).HandleEvent(ctx, env)
+		return handler.HandleEvent(ctx, env)
 	}
 }

--- a/backend/internal/modules/approvals/bundle_integration_test.go
+++ b/backend/internal/modules/approvals/bundle_integration_test.go
@@ -160,10 +160,15 @@ func TestABundleIsDecidedOnceAndRecordedPerMember(t *testing.T) {
 		WHERE workspace_id = $1 AND entity_type = 'approval' AND action = 'approve'`, e.ws); n != 3 {
 		t.Errorf("approve audit rows = %d, want one per member", n)
 	}
-	if n := e.count(t, `SELECT count(*) FROM event_outbox
-		WHERE envelope->>'type' = 'approval.decided'
-		  AND envelope->'workspace_id' IS NOT NULL AND envelope->>'workspace_id' = $1`, e.ws.String()); n != 3 {
-		t.Errorf("approval.decided events = %d, want one per member", n)
+	// Scoped by SUBJECT: the envelope carries no tenant (ADR-0091 §6), and this
+	// package's tests share one database, so counting the type alone would
+	// count every other bundle's decisions too.
+	for _, id := range []ids.ApprovalID{facts, first, second} {
+		if n := e.count(t, `SELECT count(*) FROM event_outbox
+			WHERE envelope->>'type' = 'approval.decided'
+			  AND envelope->'entity'->>'id' = $1`, id.String()); n != 1 {
+			t.Errorf("approval.decided events for member %s = %d, want exactly one", id, n)
+		}
 	}
 }
 

--- a/backend/internal/modules/approvals/service.go
+++ b/backend/internal/modules/approvals/service.go
@@ -133,18 +133,16 @@ func (s *Service) audit(ctx context.Context, tx pgx.Tx, p principal.Principal, a
 // wrong payload for an event type without failing to compile, the same
 // guarantee storekit.EmitEvent gives every other module.
 func (s *Service) emit(ctx context.Context, tx pgx.Tx, p principal.Principal, auditID ids.UUID, entityID ids.UUID, payload events.Payload) error {
-	wsID, _ := principal.WorkspaceID(ctx)
 	correlationID, ok := principal.CorrelationID(ctx)
 	if !ok {
 		return errors.New("crmapprovals: no correlation id bound to context")
 	}
 	eventType := payload.EventType()
 	env := events.Envelope{
-		EventID:     ids.NewV7(),
-		Type:        eventType,
-		Version:     events.VersionOf(eventType),
-		WorkspaceID: wsID,
-		OccurredAt:  s.now().UTC(),
+		EventID:    ids.NewV7(),
+		Type:       eventType,
+		Version:    events.VersionOf(eventType),
+		OccurredAt: s.now().UTC(),
 		Actor: events.Actor{
 			Type: string(p.Type), ID: p.ID,
 			PassportID: nullUUID(p.PassportID), OnBehalfOf: nullUUID(p.OnBehalfOf),

--- a/backend/internal/modules/automation/automationrecording_integration_test.go
+++ b/backend/internal/modules/automation/automationrecording_integration_test.go
@@ -48,11 +48,10 @@ func TestFiringPathRecordsEveryTerminalOutcomeWithItsReason(t *testing.T) {
 	}
 
 	env := kevents.Envelope{
-		EventID:     ids.NewV7(),
-		Type:        scriptedTrigger,
-		WorkspaceID: fx.ws,
-		OccurredAt:  time.Date(2026, 7, 1, 9, 0, 0, 0, time.UTC),
-		Entity:      kevents.EntityRef{Type: "deal", ID: ids.NewV7()},
+		EventID:    ids.NewV7(),
+		Type:       scriptedTrigger,
+		OccurredAt: time.Date(2026, 7, 1, 9, 0, 0, 0, time.UTC),
+		Entity:     kevents.EntityRef{Type: "deal", ID: ids.NewV7()},
 	}
 	if err := engine.HandleEvent(context.Background(), env); err == nil {
 		t.Fatal("HandleEvent swallowed the handler failures — the dispatcher must still surface them")
@@ -94,11 +93,10 @@ func TestFailedRunReasonNeverLeaksRawProviderErrorInternals(t *testing.T) {
 	engine.RegisterWorkflow(h)
 
 	env := kevents.Envelope{
-		EventID:     ids.NewV7(),
-		Type:        scriptedTrigger,
-		WorkspaceID: fx.ws,
-		OccurredAt:  time.Date(2026, 7, 1, 9, 0, 0, 0, time.UTC),
-		Entity:      kevents.EntityRef{Type: "deal", ID: ids.NewV7()},
+		EventID:    ids.NewV7(),
+		Type:       scriptedTrigger,
+		OccurredAt: time.Date(2026, 7, 1, 9, 0, 0, 0, time.UTC),
+		Entity:     kevents.EntityRef{Type: "deal", ID: ids.NewV7()},
 	}
 	if err := engine.HandleEvent(context.Background(), env); err == nil {
 		t.Fatal("HandleEvent swallowed the apply failure")
@@ -196,11 +194,10 @@ func assertRejectionBlocksParkedRun(t *testing.T, fx *autoFixture, engine *Workf
 			t.Fatal(err)
 		}
 		return kevents.Envelope{
-			EventID:     ids.NewV7(),
-			Type:        "approval.decided",
-			WorkspaceID: fx.ws,
-			Entity:      kevents.EntityRef{Type: "approval", ID: stagedApproval.UUID},
-			Payload:     payload,
+			EventID: ids.NewV7(),
+			Type:    "approval.decided",
+			Entity:  kevents.EntityRef{Type: "approval", ID: stagedApproval.UUID},
+			Payload: payload,
 		}
 	}
 	if err := engine.HandleApprovalDecided(context.Background(), decided("approved")); err != nil {

--- a/backend/internal/modules/automation/engine.go
+++ b/backend/internal/modules/automation/engine.go
@@ -127,17 +127,24 @@ func (e *WorkflowEngine) HandleEvent(ctx context.Context, env kevents.Envelope) 
 	system := append([]workflow.Handler(nil), e.system...)
 	e.mu.RUnlock()
 
+	// The workspace is this engine's, not the envelope's: the bus carries no
+	// tenant (ADR-0091 §6) and the engine is wired for one installation. The
+	// gate still needs the value to ask the authz seam about an owner.
+	ws, err := e.db.Workspace(ctx)
+	if err != nil {
+		return err
+	}
 	ev := workflow.Event{
 		ID:          env.EventID,
 		Type:        env.Type,
-		WorkspaceID: env.WorkspaceID,
+		WorkspaceID: ws.UUID,
 		OccurredAt:  env.OccurredAt,
 		Entity:      datasource.EntityRef{Type: datasource.EntityType(env.Entity.Type), ID: env.Entity.ID},
 		Payload:     env.Payload,
 	}
 	// Workflows are deterministic system automations; their writes are
 	// attributed to the system actor and grouped per trigger event.
-	runCtx := principal.WithWorkspaceID(ctx, env.WorkspaceID)
+	runCtx := principal.WithWorkspaceID(ctx, ws.UUID)
 	runCtx = principal.WithActor(runCtx, principal.Principal{Type: principal.PrincipalSystem, ID: "system"})
 	runCtx = principal.WithCorrelationID(runCtx, ids.NewV7())
 	runCtx = principal.WithCausationEvent(runCtx, env.EventID)

--- a/backend/internal/modules/automation/engine_blocked.go
+++ b/backend/internal/modules/automation/engine_blocked.go
@@ -47,7 +47,12 @@ func (e *WorkflowEngine) HandleApprovalDecided(ctx context.Context, env kevents.
 		return nil
 	}
 	approvalID := ids.From[ids.ApprovalKind](env.Entity.ID)
-	wsCtx := principal.WithWorkspaceID(ctx, env.WorkspaceID)
+	// This consumer's workspace is its handle's; the envelope carries none.
+	ws, err := e.db.Workspace(ctx)
+	if err != nil {
+		return err
+	}
+	wsCtx := principal.WithWorkspaceID(ctx, ws.UUID)
 	return e.MarkRunBlocked(wsCtx, approvalID,
 		"approval "+approvalID.String()+" was rejected by the deciding human")
 }

--- a/backend/internal/modules/automation/gate_integration_test.go
+++ b/backend/internal/modules/automation/gate_integration_test.go
@@ -55,11 +55,10 @@ var _ authz.Resolver = fixtureResolver{}
 // this suite's resolvers are built to grant or withhold.
 func gateTestEnvelope(ws ids.UUID) kevents.Envelope {
 	return kevents.Envelope{
-		EventID:     ids.NewV7(),
-		Type:        scriptedTrigger,
-		WorkspaceID: ws,
-		OccurredAt:  time.Date(2026, 7, 16, 9, 0, 0, 0, time.UTC),
-		Entity:      kevents.EntityRef{Type: "deal", ID: ids.NewV7()},
+		EventID:    ids.NewV7(),
+		Type:       scriptedTrigger,
+		OccurredAt: time.Date(2026, 7, 16, 9, 0, 0, 0, time.UTC),
+		Entity:     kevents.EntityRef{Type: "deal", ID: ids.NewV7()},
 	}
 }
 

--- a/backend/internal/modules/identity/revocation_integration_test.go
+++ b/backend/internal/modules/identity/revocation_integration_test.go
@@ -153,9 +153,13 @@ func (e *revocationEnv) wsCtx(id Identity) context.Context {
 	return principal.WithCorrelationID(ctx, ids.NewV7())
 }
 
-// identityEvents returns the identity-stream envelopes of one type,
-// oldest first — the §5.6a cascade facts the outbox staged.
-func (e *revocationEnv) identityEvents(t *testing.T, eventType string) []events.Envelope {
+// identityEvents returns the identity-stream envelopes of one type ABOUT one
+// entity, oldest first — the §5.6a cascade facts the outbox staged.
+//
+// Scoped by the subject rather than by a tenant: the envelope carries no
+// workspace any more (ADR-0091 §6) and this package's tests share one database,
+// so a type-only read counts every other test's events of the same kind.
+func (e *revocationEnv) identityEvents(t *testing.T, eventType string, entity ids.UUID) []events.Envelope {
 	t.Helper()
 	rows, err := e.owner.Query(context.Background(),
 		`SELECT envelope FROM event_outbox WHERE stream = 'gw:events:crm:identity' ORDER BY created_at, id`)
@@ -172,7 +176,7 @@ func (e *revocationEnv) identityEvents(t *testing.T, eventType string) []events.
 		if err := json.Unmarshal(raw, &env); err != nil {
 			t.Fatalf("outbox envelope does not parse: %v", err)
 		}
-		if env.Type == eventType && env.WorkspaceID == e.admin.WorkspaceID.UUID {
+		if env.Type == eventType && env.Entity.ID == entity {
 			out = append(out, env)
 		}
 	}
@@ -221,7 +225,7 @@ func TestDeactivateUserRevokesSessionsAndPassportsAndEmits(t *testing.T) {
 		t.Errorf("deactivation left %d live sessions, %d live passports; want 0, 0", liveSessions, livePassports)
 	}
 
-	envs := e.identityEvents(t, "user.deactivated")
+	envs := e.identityEvents(t, "user.deactivated", e.member.UserID.UUID)
 	if len(envs) != 1 {
 		t.Fatalf("user.deactivated staged %d times, want exactly once", len(envs))
 	}
@@ -244,7 +248,7 @@ func TestDeactivateUserRevokesSessionsAndPassportsAndEmits(t *testing.T) {
 	if err := e.svc.DeactivateUser(e.wsCtx(e.admin), e.admin, DeactivateUserInput{UserID: e.member.UserID}); err != nil {
 		t.Fatalf("repeat deactivate: %v", err)
 	}
-	if again := e.identityEvents(t, "user.deactivated"); len(again) != 1 {
+	if again := e.identityEvents(t, "user.deactivated", e.member.UserID.UUID); len(again) != 1 {
 		t.Errorf("repeat deactivation staged a duplicate event (%d total)", len(again))
 	}
 
@@ -281,7 +285,7 @@ func TestRevokedPassportRefusedOnNextCall(t *testing.T) {
 		t.Errorf("revoked passport resolves by id on the next call: err = %v, want not-found", err)
 	}
 
-	envs := e.identityEvents(t, "passport.revoked")
+	envs := e.identityEvents(t, "passport.revoked", issued.ID.UUID)
 	if len(envs) != 1 {
 		t.Fatalf("passport.revoked staged %d times, want exactly once", len(envs))
 	}
@@ -327,7 +331,7 @@ func TestChangeUserRoleReplacesAssignmentAndEmits(t *testing.T) {
 		t.Errorf("role assignments after change = %v, want exactly [manager]", keys)
 	}
 
-	envs := e.identityEvents(t, "role.changed")
+	envs := e.identityEvents(t, "role.changed", e.member.UserID.UUID)
 	if len(envs) != 2 {
 		t.Fatalf("role.changed staged %d times, want one per effective change", len(envs))
 	}

--- a/backend/internal/modules/identity/userpasswordlink_integration_test.go
+++ b/backend/internal/modules/identity/userpasswordlink_integration_test.go
@@ -95,7 +95,7 @@ func TestIssuePasswordLinkWritesAnAuditRowAndAnEventCarryingNoToken(t *testing.T
 		t.Error("the audit image carries the raw token — it must never be written to a ledger")
 	}
 
-	envs := e.identityEvents(t, "user.password_link_issued")
+	envs := e.identityEvents(t, "user.password_link_issued", member.UUID)
 	if len(envs) != 1 {
 		t.Fatalf("user.password_link_issued staged %d times, want once", len(envs))
 	}

--- a/backend/internal/modules/identity/users_admin_integration_test.go
+++ b/backend/internal/modules/identity/users_admin_integration_test.go
@@ -166,7 +166,7 @@ func TestInviteUserCreatesActiveMemberWithRoleTokenAndEvent(t *testing.T) {
 		t.Errorf("invite minted %d live set-password tokens, want exactly 1", liveTokens)
 	}
 
-	envs := e.identityEvents(t, "user.invited")
+	envs := e.identityEvents(t, "user.invited", userID.UUID)
 	if len(envs) != 1 {
 		t.Fatalf("user.invited staged %d times, want once", len(envs))
 	}
@@ -252,7 +252,7 @@ func TestReactivateUserRestoresActiveAndEmits(t *testing.T) {
 		t.Errorf("reactivated member status = %q, want active", member.Status)
 	}
 
-	envs := e.identityEvents(t, "user.reactivated")
+	envs := e.identityEvents(t, "user.reactivated", e.member.UserID.UUID)
 	if len(envs) != 1 {
 		t.Fatalf("user.reactivated staged %d times, want once", len(envs))
 	}
@@ -261,7 +261,7 @@ func TestReactivateUserRestoresActiveAndEmits(t *testing.T) {
 	if err := e.svc.ReactivateUser(e.wsCtx(e.admin), e.admin, e.member.UserID); err != nil {
 		t.Fatalf("repeat reactivate: %v", err)
 	}
-	if again := e.identityEvents(t, "user.reactivated"); len(again) != 1 {
+	if again := e.identityEvents(t, "user.reactivated", e.member.UserID.UUID); len(again) != 1 {
 		t.Errorf("repeat reactivation staged a duplicate event (%d total)", len(again))
 	}
 

--- a/backend/internal/modules/overlay/deletion_integration_test.go
+++ b/backend/internal/modules/overlay/deletion_integration_test.go
@@ -125,7 +125,7 @@ func TestReconcileDeletionsPurgesMirroredRecordAndEmits(t *testing.T) {
 	if n := countRowsTouching(ctx, t, pool, objectClass, externalID); n != 0 {
 		t.Fatalf("association/visibility rows survived the deletion sweep: %d remain", n)
 	}
-	n, err := countMirrorDeletedEvents(ctx, pool, ws.String(), objectClass, externalID)
+	n, err := countMirrorDeletedEvents(ctx, pool, objectClass, externalID)
 	if err != nil {
 		t.Fatalf("querying event_outbox: %v", err)
 	}
@@ -181,7 +181,7 @@ func TestReconcileDeletionsForUnmirroredRecordIsANoOp(t *testing.T) {
 	if err := ReconcileDeletions(ctx, inc, ms, meter, objectClass); err != nil {
 		t.Fatalf("ReconcileDeletions: %v", err)
 	}
-	n, err := countMirrorDeletedEvents(ctx, pool, ws.String(), objectClass, externalID)
+	n, err := countMirrorDeletedEvents(ctx, pool, objectClass, externalID)
 	if err != nil {
 		t.Fatalf("querying event_outbox: %v", err)
 	}
@@ -196,16 +196,15 @@ func TestReconcileDeletionsForUnmirroredRecordIsANoOp(t *testing.T) {
 // documents), so the workspace filter lives in the query, not a GUC. The
 // object_class is part of the match so the count can't be satisfied by an
 // unrelated mirror.deleted row that happens to share the external id.
-func countMirrorDeletedEvents(ctx context.Context, pool *pgxpool.Pool, ws, objectClass, externalID string) (int, error) {
+func countMirrorDeletedEvents(ctx context.Context, pool *pgxpool.Pool, objectClass, externalID string) (int, error) {
 	var count int
 	err := pool.QueryRow(
 		ctx,
 		`SELECT count(*) FROM event_outbox
 		 WHERE envelope->>'type' = 'mirror.deleted'
-		   AND envelope->>'workspace_id' = $1
-		   AND envelope->'payload'->>'object_class' = $2
-		   AND envelope->'payload'->>'external_id' = $3`,
-		ws, objectClass, externalID,
+		   AND envelope->'payload'->>'object_class' = $1
+		   AND envelope->'payload'->>'external_id' = $2`,
+		objectClass, externalID,
 	).Scan(&count)
 	return count, err
 }

--- a/backend/internal/modules/overlay/freshness_integration_test.go
+++ b/backend/internal/modules/overlay/freshness_integration_test.go
@@ -311,8 +311,12 @@ func TestFreshnessReaderNoIncumbentClassMappingDegradesHonestly(t *testing.T) {
 	var eventCount int
 	if err := pool.QueryRow(
 		context.Background(),
-		`SELECT count(*) FROM event_outbox WHERE envelope->>'workspace_id' = $1 AND envelope->>'type' = 'mirror.budget_degraded'`,
-		ws.String(),
+		// Scoped by SUBJECT, not by tenant: the envelope carries no workspace
+		// (ADR-0091 §6) and this package's tests share one database.
+		`SELECT count(*) FROM event_outbox
+		  WHERE envelope->>'type' = 'mirror.budget_degraded'
+		    AND envelope->'entity'->>'id' = $1`,
+		id.String(),
 	).Scan(&eventCount); err != nil {
 		t.Fatalf("querying event_outbox: %v", err)
 	}
@@ -385,9 +389,8 @@ func TestFreshnessReaderShedDegradesToMirrorAndEmitsBudgetDegraded(t *testing.T)
 		context.Background(),
 		`SELECT count(*) FROM event_outbox
 		 WHERE envelope->>'type' = 'mirror.budget_degraded'
-		   AND envelope->>'workspace_id' = $1
-		   AND envelope->'entity'->>'id' = $2`,
-		ws.String(), id.String(),
+		   AND envelope->'entity'->>'id' = $1`,
+		id.String(),
 	).Scan(&eventCount); err != nil {
 		t.Fatalf("querying event_outbox: %v", err)
 	}

--- a/backend/internal/modules/overlay/reconcile_integration_test.go
+++ b/backend/internal/modules/overlay/reconcile_integration_test.go
@@ -120,15 +120,14 @@ func (e *fixtureMethodError) Error() string {
 // TestFreshnessReaderShedDegradesToMirrorAndEmitsBudgetDegraded's own
 // query documents), so no workspace GUC is needed to read it, only to
 // filter by workspace in the query itself.
-func countMirrorConflictEvents(ctx context.Context, pool *pgxpool.Pool, ws, externalID string) (int, error) {
+func countMirrorConflictEvents(ctx context.Context, pool *pgxpool.Pool, externalID string) (int, error) {
 	var count int
 	err := pool.QueryRow(
 		ctx,
 		`SELECT count(*) FROM event_outbox
 		 WHERE envelope->>'type' = 'mirror.conflict'
-		   AND envelope->>'workspace_id' = $1
-		   AND envelope->'payload'->>'external_id' = $2`,
-		ws, externalID,
+		   AND envelope->'payload'->>'external_id' = $1`,
+		externalID,
 	).Scan(&count)
 	return count, err
 }
@@ -201,7 +200,7 @@ func TestReconcileOverwritesDivergedNonDirtyRowAndEmitsConflict(t *testing.T) {
 		t.Fatalf("mirror row baseline = %v, want %v", row.UpdatedAtBaseline, newBaseline)
 	}
 
-	eventCount, err := countMirrorConflictEvents(ctx, pool, ws.String(), externalID)
+	eventCount, err := countMirrorConflictEvents(ctx, pool, externalID)
 	if err != nil {
 		t.Fatalf("querying event_outbox: %v", err)
 	}
@@ -250,7 +249,7 @@ func TestEmitMirrorConflictIsFencedAgainstADisconnectedConnection(t *testing.T) 
 		t.Fatalf("emitMirrorConflict after disconnect = %v, want ErrConnectionGone", err)
 	}
 
-	eventCount, err := countMirrorConflictEvents(ctx, pool, ws.String(), externalID)
+	eventCount, err := countMirrorConflictEvents(ctx, pool, externalID)
 	if err != nil {
 		t.Fatalf("querying event_outbox: %v", err)
 	}
@@ -315,7 +314,7 @@ func TestReconcileNeverClobbersADirtyRow(t *testing.T) {
 		t.Fatalf("sync_state = %q, want %q (unchanged)", row.SyncState, syncStatePendingSync)
 	}
 
-	eventCount, err := countMirrorConflictEvents(ctx, pool, ws.String(), externalID)
+	eventCount, err := countMirrorConflictEvents(ctx, pool, externalID)
 	if err != nil {
 		t.Fatalf("querying event_outbox: %v", err)
 	}

--- a/backend/internal/modules/people/ensurechannel_contention_integration_test.go
+++ b/backend/internal/modules/people/ensurechannel_contention_integration_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/connector"
 )
 
@@ -241,17 +242,17 @@ func TestAnInboundMessageConcurrentWithAMergeLinksTheSurvivor(t *testing.T) {
 }
 
 // handleUpdatedEventCount counts the person.updated envelopes a handle refresh
-// staged. event_outbox is a global infra table outside RLS, so the count scopes
-// itself on the envelope's own workspace and subject.
+// staged. event_outbox is a global infra table outside RLS, and the envelope no
+// longer names a tenant (ADR-0091 §6), so the count scopes itself on the
+// subject — which is what the assertion is about anyway.
 func (e *dedupeEnv) handleUpdatedEventCount(ctx context.Context, t *testing.T, personID ids.PersonID) int {
 	t.Helper()
 	return e.countInWorkspace(ctx, t, `
 		SELECT count(*) FROM event_outbox
 		 WHERE envelope->>'type' = 'person.updated'
-		   AND envelope->>'workspace_id' = $1::text
-		   AND envelope->'entity'->>'id' = $2::text
+		   AND envelope->'entity'->>'id' = $1::text
 		   AND envelope->'payload'->'changed_fields'->'channel_username' IS NOT NULL`,
-		e.ws, personID)
+		personID)
 }
 
 // beginBlockingRefresh runs one whole handle refresh in a transaction the test
@@ -549,6 +550,17 @@ func takeOrgNameLockOnAFreshConnection(ctx context.Context) (err error) {
 			err = errors.Join(err, rollback)
 		}
 	}()
+	// Bind the workspace, as every real writer's transaction does: the advisory
+	// key is built from the TRANSACTION's binding, so a racer that skipped it
+	// would take a different key and contend with nobody — the test would then
+	// report a working lock as broken.
+	ws, ok := principal.WorkspaceID(ctx)
+	if !ok {
+		return errors.New("the racer's context carries no workspace")
+	}
+	if _, err := tx.Exec(ctx, `SELECT set_config('app.workspace_id', $1, true)`, ws.String()); err != nil {
+		return fmt.Errorf("binding the racer's workspace: %w", err)
+	}
 	return lockOrgNameWrites(ctx, tx)
 }
 

--- a/backend/internal/modules/search/embedgen.go
+++ b/backend/internal/modules/search/embedgen.go
@@ -64,10 +64,17 @@ func (g *EmbedGen) HandleEvent(ctx context.Context, env kevents.Envelope) error 
 	// the whole workspace, filtered per caller at QUERY time — an
 	// index built through one user's row scope would silently hide
 	// records from everyone else's retrieval.
-	wsCtx := systemWorkspaceContext(ctx, env.WorkspaceID)
+	// The workspace is the STORE's, not the envelope's: this consumer is
+	// wired for one installation and its handle already names it (ADR-0091 §6
+	// — the envelope carries no tenant).
+	ws, err := g.store.db.Workspace(ctx)
+	if err != nil {
+		return err
+	}
+	wsCtx := systemWorkspaceContext(ctx, ws.UUID)
 
 	var text string
-	err := g.store.db.Tx(wsCtx, func(tx pgx.Tx) error {
+	err = g.store.db.Tx(wsCtx, func(tx pgx.Tx) error {
 		return tx.QueryRow(wsCtx, query, env.Entity.ID).Scan(&text)
 	})
 	if errors.Is(err, pgx.ErrNoRows) {

--- a/backend/internal/modules/search/graphedgegen.go
+++ b/backend/internal/modules/search/graphedgegen.go
@@ -58,7 +58,10 @@ func (g *GraphEdgeGen) HandleEvent(ctx context.Context, env events.Envelope) err
 	if entity == ids.Nil {
 		return nil
 	}
-	ctx = g.projectionContext(ctx, env)
+	ctx, err := g.projectionContext(ctx, env)
+	if err != nil {
+		return err
+	}
 
 	switch env.Entity.Type {
 	case entityActivity:
@@ -70,18 +73,24 @@ func (g *GraphEdgeGen) HandleEvent(ctx context.Context, env events.Envelope) err
 	}
 }
 
-// projectionContext binds the envelope's workspace and a system principal.
+// projectionContext binds the STORE's workspace and a system principal. The
+// workspace is the handle's rather than the envelope's: this consumer is wired
+// for one installation, and the envelope carries no tenant (ADR-0091 §6).
 // The projection is maintenance, not a user action: it must fold EVERY
 // interaction the base tables hold, including ones the human who happened to
 // trigger the event could not read, or the edge counts would differ depending
 // on who last touched the record.
-func (g *GraphEdgeGen) projectionContext(ctx context.Context, env events.Envelope) context.Context {
-	ctx = principal.WithWorkspaceID(ctx, env.WorkspaceID)
+func (g *GraphEdgeGen) projectionContext(ctx context.Context, env events.Envelope) (context.Context, error) {
+	ws, err := g.store.db.Workspace(ctx)
+	if err != nil {
+		return nil, err
+	}
+	ctx = principal.WithWorkspaceID(ctx, ws.UUID)
 	ctx = principal.WithCorrelationID(ctx, env.Trace.CorrelationID)
 	return principal.WithActor(ctx, principal.Principal{
 		Type: principal.PrincipalSystem, ID: "system:graph_edge",
 		Permissions: principal.Permissions{RowScope: principal.RowScopeAll},
-	})
+	}), nil
 }
 
 // onActivity refolds the pairs one activity touches.

--- a/backend/internal/modules/webhooks/delivery.go
+++ b/backend/internal/modules/webhooks/delivery.go
@@ -94,7 +94,13 @@ func (d *Deliverer) HandleEvent(ctx context.Context, env kevents.Envelope) error
 	if err != nil {
 		return fmt.Errorf("webhooks: marshaling envelope %s: %w", env.EventID, err)
 	}
-	wsCtx := d.systemContext(ctx, env.WorkspaceID)
+	// The tenant is this deliverer's own: the fan-out builds one per workspace
+	// it sweeps, and the envelope carries none (ADR-0091 §6).
+	ws, err := d.store.db.Workspace(ctx)
+	if err != nil {
+		return err
+	}
+	wsCtx := d.systemContext(ctx, ws.UUID)
 	cands, err := d.store.matchingSubscriptions(wsCtx, env.Type)
 	if err != nil {
 		return fmt.Errorf("webhooks: matching subscriptions for %s: %w", env.Type, err)
@@ -154,7 +160,11 @@ func (d *Deliverer) ownerCanSee(ctx context.Context, env kevents.Envelope, owner
 	if d.resolver == nil {
 		return false, errors.New("webhooks: no principal resolver configured for owner-scoped fan-out")
 	}
-	rbac, err := d.resolver.EffectiveRBAC(ctx, env.WorkspaceID, ownerID)
+	ws, err := d.store.db.Workspace(ctx)
+	if err != nil {
+		return false, err
+	}
+	rbac, err := d.resolver.EffectiveRBAC(ctx, ws.UUID, ownerID)
 	if errors.Is(err, apperrors.ErrNotFound) {
 		return false, nil
 	}

--- a/backend/internal/modules/webhooks/unit_test.go
+++ b/backend/internal/modules/webhooks/unit_test.go
@@ -228,14 +228,14 @@ func TestOwnerCanSeeEarlyReturns(t *testing.T) {
 	d := NewDeliverer(NewStore(nil, nil), nil, nil, nil, log) // nil resolver
 
 	// An entity-less envelope names no subject to scope by → not visible.
-	entityless := kevents.Envelope{WorkspaceID: ids.NewV7()}
+	entityless := kevents.Envelope{}
 	if ok, err := d.ownerCanSee(context.Background(), entityless, ids.NewV7()); ok || err != nil {
 		t.Fatalf("entity-less ownerCanSee = (%v, %v), want (false, nil)", ok, err)
 	}
 
 	// An entity present but no resolver configured → a loud error, never a
 	// silent allow.
-	withEntity := kevents.Envelope{WorkspaceID: ids.NewV7(), Entity: kevents.EntityRef{Type: "deal", ID: ids.NewV7()}}
+	withEntity := kevents.Envelope{Entity: kevents.EntityRef{Type: "deal", ID: ids.NewV7()}}
 	if ok, err := d.ownerCanSee(context.Background(), withEntity, ids.NewV7()); ok || err == nil {
 		t.Fatalf("nil-resolver ownerCanSee = (%v, %v), want (false, err)", ok, err)
 	}

--- a/backend/internal/modules/webhooks/wireenvelope_test.go
+++ b/backend/internal/modules/webhooks/wireenvelope_test.go
@@ -28,11 +28,10 @@ func fullInternalEnvelope(t *testing.T) kevents.Envelope {
 	onBehalfOf := ids.NewV7()
 	causationID := ids.NewV7()
 	return kevents.Envelope{
-		EventID:     ids.NewV7(),
-		Type:        "deal.created",
-		Version:     1,
-		WorkspaceID: ids.NewV7(),
-		OccurredAt:  time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC),
+		EventID:    ids.NewV7(),
+		Type:       "deal.created",
+		Version:    1,
+		OccurredAt: time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC),
 		Actor: kevents.Actor{
 			Type:       "human",
 			ID:         "human:abc",

--- a/backend/internal/platform/database/storekit/storekit.go
+++ b/backend/internal/platform/database/storekit/storekit.go
@@ -69,7 +69,6 @@ func AuditWithEvidence(ctx context.Context, tx pgx.Tx, action, entityType string
 	if err != nil {
 		return ids.Nil, err
 	}
-	wsID, _ := principal.WorkspaceID(ctx)
 
 	beforeJSON, err := marshalOrNil(before)
 	if err != nil {
@@ -89,9 +88,13 @@ func AuditWithEvidence(ctx context.Context, tx pgx.Tx, action, entityType string
 
 	id := ids.NewV7()
 	_, err = tx.Exec(ctx,
+		// The tenant comes from the TRANSACTION's binding, not from the caller:
+		// the ledger row must name the workspace its domain row landed in, and
+		// the GUC is the one thing that decides both. Read from ctx they could
+		// disagree, and the disagreement would be invisible.
 		`INSERT INTO audit_log (id, workspace_id, actor_type, actor_id, passport_id, on_behalf_of, action, entity_type, entity_id, before, after, evidence, authorization_rule)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)`,
-		id, wsID, string(p.Type), p.ID, UUIDOrNil(p.PassportID), UUIDOrNil(p.OnBehalfOf),
+		 VALUES ($1, NULLIF(current_setting('app.workspace_id', true), '')::uuid, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)`,
+		id, string(p.Type), p.ID, UUIDOrNil(p.PassportID), UUIDOrNil(p.OnBehalfOf),
 		action, entityType, entityID, beforeJSON, afterJSON, evidenceJSON,
 		auth.AuthzRule(p, entityType, action))
 	return id, err
@@ -112,16 +115,12 @@ func LogSystem(ctx context.Context, tx pgx.Tx, action string, detail map[string]
 	if err != nil {
 		return ids.Nil, err
 	}
-	// MustWorkspace is safe here: LogSystem only runs inside WithWorkspaceTx,
-	// which already failed if no workspace was bound, and the system_log RLS
-	// WITH CHECK rejects a mismatched workspace_id as a final backstop.
-	wsID := MustWorkspace(ctx)
-
 	id := ids.NewV7()
 	_, err = tx.Exec(ctx,
+		// The tenant is the transaction's, like every other ledger row here.
 		`INSERT INTO system_log (id, workspace_id, actor_type, actor_id, passport_id, on_behalf_of, action, detail)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
-		id, wsID, string(p.Type), p.ID, UUIDOrNil(p.PassportID), UUIDOrNil(p.OnBehalfOf),
+		 VALUES ($1, NULLIF(current_setting('app.workspace_id', true), '')::uuid, $2, $3, $4, $5, $6, $7)`,
+		id, string(p.Type), p.ID, UUIDOrNil(p.PassportID), UUIDOrNil(p.OnBehalfOf),
 		action, JSONArg(detail))
 	return id, err
 }
@@ -138,7 +137,6 @@ func Emit(ctx context.Context, tx pgx.Tx, auditID ids.UUID, eventType, entityTyp
 	if err != nil {
 		return err
 	}
-	wsID, _ := principal.WorkspaceID(ctx)
 	correlationID, ok := principal.CorrelationID(ctx)
 	if !ok {
 		// Every write path opens an operation scope (the HTTP middleware,
@@ -148,11 +146,10 @@ func Emit(ctx context.Context, tx pgx.Tx, auditID ids.UUID, eventType, entityTyp
 	}
 
 	env := events.Envelope{
-		EventID:     ids.NewV7(),
-		Type:        eventType,
-		Version:     events.VersionOf(eventType),
-		WorkspaceID: wsID,
-		OccurredAt:  time.Now().UTC(),
+		EventID:    ids.NewV7(),
+		Type:       eventType,
+		Version:    events.VersionOf(eventType),
+		OccurredAt: time.Now().UTC(),
 		Actor: events.Actor{
 			Type:       string(p.Type),
 			ID:         p.ID,
@@ -258,8 +255,13 @@ func UUIDOrNil(id ids.UUID) *ids.UUID {
 	return &id
 }
 
-// MustWorkspace is safe inside a workspace-bound transaction:
-// WithWorkspaceTx already failed if no workspace was bound.
+// MustWorkspace is the workspace the caller's context names, for the domain
+// INSERTs that still stamp a `workspace_id` column of their own.
+//
+// The ledger writes above no longer use it: they take the tenant from the
+// TRANSACTION's binding, which is the only thing that can agree with the
+// domain row by construction. These callers follow when the column itself
+// goes (ADR-0091 §8 phase D).
 func MustWorkspace(ctx context.Context) ids.UUID {
 	wsID, _ := principal.WorkspaceID(ctx)
 	return wsID
@@ -273,9 +275,12 @@ func MustWorkspace(ctx context.Context) ids.UUID {
 // is reentrant within one transaction, so a caller that locked at its
 // precondition read may write through the same store path without deadlock.
 func LockWriteIdentity(ctx context.Context, tx pgx.Tx, entityType, identity string) error {
+	// The workspace in the key is the TRANSACTION's, read where the lock is
+	// taken: a key built from a ctx that disagreed with the binding would put
+	// two writers of one record on different locks and serialize neither.
 	if _, err := tx.Exec(ctx, `SELECT pg_advisory_xact_lock(hashtextextended(
-		$1 || ':' || $2::text || ':' || $3, 0))`,
-		entityType+"_write", MustWorkspace(ctx), identity); err != nil {
+		$1 || ':' || coalesce(current_setting('app.workspace_id', true), '') || ':' || $2, 0))`,
+		entityType+"_write", identity); err != nil {
 		return fmt.Errorf("lock %s write identity: %w", entityType, err)
 	}
 	return nil

--- a/backend/internal/platform/events/bus_integration_test.go
+++ b/backend/internal/platform/events/bus_integration_test.go
@@ -107,14 +107,13 @@ func testLogger() *slog.Logger {
 func (e *busEnv) stage(t *testing.T, eventType string, entityID ids.UUID) kevents.Envelope {
 	t.Helper()
 	env := kevents.Envelope{
-		EventID:     ids.NewV7(),
-		Type:        eventType,
-		Version:     1,
-		WorkspaceID: e.ws,
-		OccurredAt:  time.Now().UTC(),
-		Actor:       kevents.Actor{Type: "human", ID: "human:" + ids.NewV7().String()},
-		Entity:      kevents.EntityRef{Type: "person", ID: entityID},
-		Trace:       kevents.Trace{CorrelationID: ids.NewV7(), AuditLogID: ids.NewV7()},
+		EventID:    ids.NewV7(),
+		Type:       eventType,
+		Version:    1,
+		OccurredAt: time.Now().UTC(),
+		Actor:      kevents.Actor{Type: "human", ID: "human:" + ids.NewV7().String()},
+		Entity:     kevents.EntityRef{Type: "person", ID: entityID},
+		Trace:      kevents.Trace{CorrelationID: ids.NewV7(), AuditLogID: ids.NewV7()},
 	}
 	if err := env.Validate(); err != nil {
 		t.Fatalf("fixture envelope: %v", err)
@@ -291,42 +290,30 @@ func consumeUntil(t *testing.T, s *Subscriber, deadline time.Duration, done func
 	}
 }
 
-func TestSubscriberDeliversAcksAndFiltersWorkspaces(t *testing.T) {
+func TestSubscriberDeliversEveryEntryAndAcksIt(t *testing.T) {
 	e := setup(t)
-	mine := e.stage(t, "person.created", ids.NewV7())
-
-	// A second tenant's event on the same stream (workspace is a field,
-	// not a stream — events.md §4.1).
-	otherWS := ids.NewV7()
-	foreign := mine
-	foreign.EventID = ids.NewV7()
-	foreign.WorkspaceID = otherWS
-	raw, _ := json.Marshal(foreign)
-	if _, err := e.pool.Exec(t.Context(),
-		`INSERT INTO event_outbox (stream, envelope) VALUES ('gw:events:crm:person', $1)`, raw); err != nil {
-		t.Fatal(err)
+	e.stage(t, "person.created", ids.NewV7())
+	// A second entry on the same stream. This used to be another tenant's, and
+	// the assertion used to be that a workspace-scoped handler never saw it —
+	// the bus carries no tenant any more (ADR-0091 §6), so what is left to hold
+	// is the property that outlived it: every entry reaches the handler exactly
+	// once, and every entry is acked.
+	second := e.stage(t, "person.created", ids.NewV7())
+	if second.EventID.IsZero() {
+		t.Fatal("the second staged envelope has no event id")
 	}
 	if _, err := e.relay(t).relayBatch(t.Context()); err != nil {
 		t.Fatal(err)
 	}
 
 	var seen atomic.Int32
-	var sawForeign atomic.Bool
 	group := kevents.Group{Name: "cg:read-model", Streams: []string{"gw:events:crm:person"}}
-	s := NewSubscriber(e.rdb, group, ForWorkspace(e.ws, func(_ context.Context, env kevents.Envelope) error {
-		if env.WorkspaceID != e.ws {
-			sawForeign.Store(true)
-		}
+	s := NewSubscriber(e.rdb, group, func(_ context.Context, _ kevents.Envelope) error {
 		seen.Add(1)
 		return nil
-	}), testLogger())
+	}, testLogger())
 	s.block = 100 * time.Millisecond
 
-	// Wait for what this test actually asserts: BOTH entries acked. Waiting on
-	// `seen >= 1` instead waits for the OWN event's handler, which says nothing
-	// about the foreign one — that is filtered and acked on its own schedule,
-	// so the pending read could land before it happened and fail a subscriber
-	// that was working correctly.
 	pendingCount := func(t *testing.T) int64 {
 		t.Helper()
 		pending, err := e.rdb.XPending(t.Context(), "gw:events:crm:person", group.Name).Result()
@@ -338,17 +325,13 @@ func TestSubscriberDeliversAcksAndFiltersWorkspaces(t *testing.T) {
 		}
 		return pending.Count
 	}
-	consumeUntil(t, s, 5*time.Second, func() bool { return seen.Load() >= 1 && pendingCount(t) == 0 })
+	consumeUntil(t, s, 5*time.Second, func() bool { return seen.Load() >= 2 && pendingCount(t) == 0 })
 
-	if sawForeign.Load() {
-		t.Fatal("a handler scoped to workspace A saw workspace B's event")
+	if got := seen.Load(); got != 2 {
+		t.Fatalf("handler ran %d times, want 2 — one per staged entry", got)
 	}
-	if seen.Load() != 1 {
-		t.Fatalf("handler ran %d times, want 1 (own event only)", seen.Load())
-	}
-	// Both entries must be acked — the foreign one is filtered, not stuck.
 	if n := pendingCount(t); n != 0 {
-		t.Fatalf("%d entries still pending; filtering must ack, not strand", n)
+		t.Fatalf("%d entries still pending; a delivered entry must be acked, not stranded", n)
 	}
 }
 

--- a/backend/internal/platform/events/subscriber.go
+++ b/backend/internal/platform/events/subscriber.go
@@ -16,7 +16,6 @@ import (
 	"github.com/redis/go-redis/v9"
 
 	kevents "github.com/gradionhq/margince/backend/internal/shared/kernel/events"
-	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
 // envelopeField is the single stream-entry field holding the envelope
@@ -258,24 +257,4 @@ func isBusyGroup(err error) bool {
 // longer exists.
 func isNoGroup(err error) bool {
 	return err != nil && strings.HasPrefix(err.Error(), "NOGROUP")
-}
-
-// ForWorkspace scopes a handler to one tenant: events for any other
-// workspace are acked without invoking it. This is the in-process
-// analogue of RLS on the bus (events.md §4.1 — workspace is a field, not
-// a stream, so the filter is the consumer's responsibility).
-//
-// Group-topology rule: a consumer GROUP must own ONE
-// handler. Redis partitions a group's entries across its consumers, so
-// two ForWorkspace handlers sharing a group would each ack away the
-// other tenant's events — silently dropping them. Scope per workspace
-// either by dispatching inside one group-wide handler or by giving each
-// workspace its own group, never by filtered consumers in a shared group.
-func ForWorkspace(workspaceID ids.UUID, next Handler) Handler {
-	return func(ctx context.Context, env kevents.Envelope) error {
-		if env.WorkspaceID != workspaceID {
-			return nil
-		}
-		return next(ctx, env)
-	}
 }

--- a/backend/internal/platform/events/subscriberrecovery_integration_test.go
+++ b/backend/internal/platform/events/subscriberrecovery_integration_test.go
@@ -79,14 +79,13 @@ func publishProbe(ctx context.Context, t *testing.T, rdb *redis.Client, stream s
 	t.Helper()
 	const probeType = "activity.captured"
 	env := kevents.Envelope{
-		EventID:     ids.NewV7(),
-		Type:        probeType,
-		Version:     kevents.VersionOf(probeType),
-		WorkspaceID: ids.NewV7(),
-		OccurredAt:  time.Now().UTC(),
-		Actor:       kevents.Actor{Type: "system", ID: "system"},
-		Entity:      kevents.EntityRef{Type: "activity", ID: ids.NewV7()},
-		Trace:       kevents.Trace{CorrelationID: ids.NewV7(), AuditLogID: ids.NewV7()},
+		EventID:    ids.NewV7(),
+		Type:       probeType,
+		Version:    kevents.VersionOf(probeType),
+		OccurredAt: time.Now().UTC(),
+		Actor:      kevents.Actor{Type: "system", ID: "system"},
+		Entity:     kevents.EntityRef{Type: "activity", ID: ids.NewV7()},
+		Trace:      kevents.Trace{CorrelationID: ids.NewV7(), AuditLogID: ids.NewV7()},
 	}
 	if err := env.Validate(); err != nil {
 		t.Fatalf("probe envelope: %v", err)

--- a/backend/internal/shared/kernel/events/envelope.go
+++ b/backend/internal/shared/kernel/events/envelope.go
@@ -25,15 +25,14 @@ import (
 type Envelope struct {
 	// EventID is minted as UUIDv7 so it is time-ordered; it is the
 	// consumer-side idempotency key (§3 — dedupe on event_id).
-	EventID     ids.UUID        `json:"event_id"`
-	Type        string          `json:"type"`
-	Version     int             `json:"version"`
-	WorkspaceID ids.UUID        `json:"workspace_id"`
-	OccurredAt  time.Time       `json:"occurred_at"`
-	Actor       Actor           `json:"actor"`
-	Entity      EntityRef       `json:"entity"`
-	Payload     json.RawMessage `json:"payload,omitempty"`
-	Trace       Trace           `json:"trace"`
+	EventID    ids.UUID        `json:"event_id"`
+	Type       string          `json:"type"`
+	Version    int             `json:"version"`
+	OccurredAt time.Time       `json:"occurred_at"`
+	Actor      Actor           `json:"actor"`
+	Entity     EntityRef       `json:"entity"`
+	Payload    json.RawMessage `json:"payload,omitempty"`
+	Trace      Trace           `json:"trace"`
 }
 
 // Actor answers "who did this, under whose authority" from the event
@@ -87,9 +86,6 @@ func (e Envelope) Validate() error {
 	}
 	if v := VersionOf(e.Type); e.Version != v {
 		return fmt.Errorf("events: %s is at version %d, envelope says %d", e.Type, v, e.Version)
-	}
-	if e.WorkspaceID.IsZero() {
-		return fmt.Errorf("events: %s envelope has no workspace_id (the bus analogue of RLS)", e.Type)
 	}
 	if e.OccurredAt.IsZero() {
 		return fmt.Errorf("events: %s envelope has no occurred_at", e.Type)

--- a/backend/internal/shared/kernel/events/envelope_test.go
+++ b/backend/internal/shared/kernel/events/envelope_test.go
@@ -15,14 +15,13 @@ import (
 func validEnvelope(t *testing.T, eventType string) Envelope {
 	t.Helper()
 	return Envelope{
-		EventID:     ids.NewV7(),
-		Type:        eventType,
-		Version:     VersionOf(eventType),
-		WorkspaceID: ids.NewV7(),
-		OccurredAt:  time.Date(2026, 7, 16, 9, 38, 0, 0, time.UTC),
-		Actor:       Actor{Type: "connector", ID: "connector:gmail"},
-		Entity:      EntityRef{Type: "activity", ID: ids.NewV7()},
-		Trace:       Trace{CorrelationID: ids.NewV7(), AuditLogID: ids.NewV7()},
+		EventID:    ids.NewV7(),
+		Type:       eventType,
+		Version:    VersionOf(eventType),
+		OccurredAt: time.Date(2026, 7, 16, 9, 38, 0, 0, time.UTC),
+		Actor:      Actor{Type: "connector", ID: "connector:gmail"},
+		Entity:     EntityRef{Type: "activity", ID: ids.NewV7()},
+		Trace:      Trace{CorrelationID: ids.NewV7(), AuditLogID: ids.NewV7()},
 	}
 }
 

--- a/backend/internal/shared/kernel/events/events_test.go
+++ b/backend/internal/shared/kernel/events/events_test.go
@@ -157,11 +157,10 @@ func TestGroupStreamSetsMatchSpecTable(t *testing.T) {
 func TestEnvelopeRoundTripPreservesEveryField(t *testing.T) {
 	passport := ids.NewV7()
 	env := Envelope{
-		EventID:     ids.NewV7(),
-		Type:        "deal.stage_changed",
-		Version:     1,
-		WorkspaceID: ids.NewV7(),
-		OccurredAt:  time.Date(2026, 7, 3, 10, 15, 30, 123e6, time.UTC),
+		EventID:    ids.NewV7(),
+		Type:       "deal.stage_changed",
+		Version:    1,
+		OccurredAt: time.Date(2026, 7, 3, 10, 15, 30, 123e6, time.UTC),
 		Actor: Actor{
 			Type:       "agent",
 			ID:         "agent:overnight",
@@ -207,14 +206,13 @@ func TestEventIDsAreTimeOrdered(t *testing.T) {
 func TestValidateRejectsTheDishonestEnvelopes(t *testing.T) {
 	valid := func() Envelope {
 		return Envelope{
-			EventID:     ids.NewV7(),
-			Type:        "person.created",
-			Version:     1,
-			WorkspaceID: ids.NewV7(),
-			OccurredAt:  time.Now().UTC(),
-			Actor:       Actor{Type: "human", ID: "human:x"},
-			Entity:      EntityRef{Type: "person", ID: ids.NewV7()},
-			Trace:       Trace{CorrelationID: ids.NewV7(), AuditLogID: ids.NewV7()},
+			EventID:    ids.NewV7(),
+			Type:       "person.created",
+			Version:    1,
+			OccurredAt: time.Now().UTC(),
+			Actor:      Actor{Type: "human", ID: "human:x"},
+			Entity:     EntityRef{Type: "person", ID: ids.NewV7()},
+			Trace:      Trace{CorrelationID: ids.NewV7(), AuditLogID: ids.NewV7()},
 		}
 	}
 
@@ -222,7 +220,6 @@ func TestValidateRejectsTheDishonestEnvelopes(t *testing.T) {
 		"zero event_id":       func(e *Envelope) { e.EventID = ids.Nil },
 		"uncataloged type":    func(e *Envelope) { e.Type = "person.exploded" },
 		"wrong version":       func(e *Envelope) { e.Version = 2 },
-		"missing workspace":   func(e *Envelope) { e.WorkspaceID = ids.Nil },
 		"missing occurred_at": func(e *Envelope) { e.OccurredAt = time.Time{} },
 		"missing actor":       func(e *Envelope) { e.Actor = Actor{} },
 		"missing entity":      func(e *Envelope) { e.Entity = EntityRef{} },


### PR DESCRIPTION
ADR-0091 §6, first half — the start of §9 **step 4**. `workspace_id` leaves the `shared/kernel/events` envelope, and with it `events.ForWorkspace`, the bus filter whose whole premise was that the workspace is a field on the bus.

## Consumers take the tenant from their binding

Every consumer that read the tenant off the envelope now takes it from what it was *built with* — the store's handle, or the installation resolver where the consumer holds no store. Same rule step 3 established: which tenant a component serves is a property of its construction, not of the message it is handed.

## The ledger goes further: the tenant is the transaction's

`audit_log` and `system_log` now stamp `current_setting('app.workspace_id')` in SQL, and `LockWriteIdentity` builds its advisory key from it too. Read from ctx, two things could go wrong invisibly: a ledger row could name a different workspace than the domain row it records, and two writers of one record could take different lock keys and serialize neither. Both are now impossible by construction.

`storekit.MustWorkspace` stays for the domain INSERTs that still stamp a `workspace_id` column of their own — they follow when the column goes (§8 phase D).

## One genuine finding in the test surface

The suites that counted staged events by tenant now scope by **subject**, which is what each assertion was about anyway. One of them was a real defect: the lock-contention racer opened a transaction without binding its workspace, so under a transaction-derived key it contended with nobody — a test supplying its own version of production (README rule 6). It binds now, as every real writer does.

The data-reset outbox purge also changed shape and says so: it matched on the envelope's tenant, and with one installation there is no other tenant's staged event to spare.

## Verification

- `make check-backend` — green
- `craft static --strict` over all 46 changed Go files — 0 findings
- `make test-integration` — `OK: integration passed with 0 skips (38 packages, parallel)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed tenant from event envelopes and made tenancy a property of the running component and its transaction. Consumers resolve the workspace from their bound handle/installation, and ledger writes read it from the SQL GUC to prevent mismatches and locking gaps.

- **Refactors**
  - Dropped `workspace_id` from `shared/kernel/events.Envelope`; removed `events.ForWorkspace`.
  - Consumers (workflow engine, webhooks deliverer, runner, search embed/edges, LinkedIn matcher, auto-enrich) now resolve the workspace from their store/installation and bind it to context.
  - Ledger writes to `audit_log` and `system_log` now stamp `current_setting('app.workspace_id')`; `storekit.LockWriteIdentity` builds its key from the transaction GUC.
  - Workspace reset now deletes all `event_outbox` rows for the installation.
  - Tests that counted staged events by tenant now scope by subject (entity id/payload).
  - Fixed a contention test by binding the workspace inside the transaction so writers contend on the same advisory key.

- **Migration**
  - Remove uses of `Envelope.WorkspaceID` and update envelope construction/validation.
  - Replace envelope-tenant filters with installation-bound handles or subject scoping; remove `events.ForWorkspace`.
  - Ensure code that writes ledger rows or calls `storekit.LockWriteIdentity` runs inside a workspace-bound transaction (sets `app.workspace_id`).

<sup>Written for commit 945fe6ff5bd58fc75853a56a4124bec047fc343f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1036?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Event processing now derives workspace context from the connected installation, improving consistency across automation, enrichment, search, webhooks, and workflow actions.
  * Event records no longer depend on workspace metadata embedded in each event.
  * Event delivery processes all entries on a stream while preserving acknowledgement behavior.
  * Staged events are fully cleared during data resets.
  * Audit, identity, overlay, and approval event lookups now target specific affected entities for more accurate results.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->