### PR TITLE
feat(ai): a frontier tier above premium, so a task that needs the top rung has a name for it

### DIFF
--- a/backend/api/ai-tasks.yaml
+++ b/backend/api/ai-tasks.yaml
@@ -11,7 +11,7 @@
 # tools/gen-aitasks compiles that copy into the binary (tasks_gen.go) behind a
 # drift gate, the same mechanism crm.yaml already uses for the HTTP contract.
 # Tier→model binding (which concrete provider/model serves local_small /
-# cheap_cloud / premium / local_large) stays a per-deployment runtime config
+# cheap_cloud / premium / frontier / local_large) stays a per-deployment config
 # (config/ai-routing.yaml, §1.4) — editing THAT never requires a rebuild.
 # Editing the ladders/posture below is a routing-POLICY change: it requires a
 # spec update here, the mirrored edit in the build repo, `make gen`, and a
@@ -56,7 +56,12 @@
 # required certification band — the certification lane is paid and BYOK-gated,
 # so it reports release readiness (naming its provider/model binding) and never
 # gates a merge.
-tiers: [local_small, cheap_cloud, premium, local_large]
+#
+# frontier sits one rung above premium: the strongest model a deployment is
+# willing to pay for. No task ladder selects it — it is declared so an operator
+# can bind one, and so a task that genuinely needs the top rung has a name to
+# reach for without redefining what premium means for every other task.
+tiers: [local_small, cheap_cloud, premium, frontier, local_large]
 
 tasks:
   capture_classify:
@@ -253,6 +258,7 @@ embed:
   cost_unit: per_entity
 
 degrade_to:
+  frontier: premium
   premium: cheap_cloud
   cheap_cloud: local_small
   local_large: local_small

--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -11547,7 +11547,7 @@ components:
                   required: [task, tier, calls, tokens_in, tokens_out]
                   properties:
                     task: { type: string, description: 'capture_classify, enrich, summarize, …' }
-                    tier: { type: string, description: 'local_small, cheap_cloud, premium, local_large.' }
+                    tier: { type: string, description: 'local_small, cheap_cloud, premium, frontier, local_large.' }
                     calls: { type: integer }
                     cached_hits: { type: integer }
                     tokens_in: { type: integer }
@@ -16314,8 +16314,8 @@ components:
       properties:
         tier:
           type: string
-          enum: [local_small, cheap_cloud, premium, local_large]
-          x-enum-varnames: [AssistantModelTierLocalSmall, AssistantModelTierCheapCloud, AssistantModelTierPremium, AssistantModelTierLocalLarge]
+          enum: [local_small, cheap_cloud, premium, frontier, local_large]
+          x-enum-varnames: [AssistantModelTierLocalSmall, AssistantModelTierCheapCloud, AssistantModelTierPremium, AssistantModelTierFrontier, AssistantModelTierLocalLarge]
         provider:
           type: string
           enum: [anthropic, gemini, ollama, openai, openai_compatible, vllm]

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -690,6 +690,7 @@ func (e AssistantConfiguredModelProvider) Valid() bool {
 // Defines values for AssistantConfiguredModelTier.
 const (
 	AssistantModelTierCheapCloud AssistantConfiguredModelTier = "cheap_cloud"
+	AssistantModelTierFrontier   AssistantConfiguredModelTier = "frontier"
 	AssistantModelTierLocalLarge AssistantConfiguredModelTier = "local_large"
 	AssistantModelTierLocalSmall AssistantConfiguredModelTier = "local_small"
 	AssistantModelTierPremium    AssistantConfiguredModelTier = "premium"
@@ -699,6 +700,8 @@ const (
 func (e AssistantConfiguredModelTier) Valid() bool {
 	switch e {
 	case AssistantModelTierCheapCloud:
+		return true
+	case AssistantModelTierFrontier:
 		return true
 	case AssistantModelTierLocalLarge:
 		return true
@@ -9966,7 +9969,7 @@ type AiUsage struct {
 			// Task capture_classify, enrich, summarize, …
 			Task string `json:"task"`
 
-			// Tier local_small, cheap_cloud, premium, local_large.
+			// Tier local_small, cheap_cloud, premium, frontier, local_large.
 			Tier      string `json:"tier"`
 			TokensIn  int    `json:"tokens_in"`
 			TokensOut int    `json:"tokens_out"`

--- a/backend/internal/modules/ai/budget.go
+++ b/backend/internal/modules/ai/budget.go
@@ -57,7 +57,8 @@ const (
 	queueUtilization   = 1.00
 )
 
-// premiumShareAlarmThreshold: a workspace whose premium-tier token
-// share exceeds this over the trailing window gets flagged for a
-// routing fix (§1.3) — the L2 analogue of "manual entry is a smell".
+// premiumShareAlarmThreshold: a workspace whose costly-cloud token share
+// (premium and every rung above it — see costlyCloudTiers) exceeds this over
+// the trailing window gets flagged for a routing fix (§1.3) — the L2 analogue
+// of "manual entry is a smell".
 const premiumShareAlarmThreshold = 0.20

--- a/backend/internal/modules/ai/fakerouting.go
+++ b/backend/internal/modules/ai/fakerouting.go
@@ -4,7 +4,7 @@
 package ai
 
 // FakeRoutingConfig is the routing config the offline --ai-fake dev/test
-// path is built over. It binds EVERY tier the contract knows about
+// path is built over. It binds every tier a task ladder NAMES
 // (local_small, cheap_cloud, premium) plus the embeddings lane to
 // ProviderFake, so every task's fallback ladder is fully bound —
 // UnboundLadderWarnings reports nothing for it, and no ladder is ever
@@ -13,8 +13,13 @@ package ai
 // (no fallback rung): a fake config that skipped the premium tier would
 // silently refuse deep-read extraction under --ai-fake while every
 // other lane worked, an inconsistency a dev/test flag must never
-// produce. Riding this config through NewModelPath (rather than
-// FakeModelPath's direct client wiring) means --ai-fake exercises the
+// produce. The tiers no ladder names — frontier and local_large — stay
+// deliberately unbound: they exist for an operator to bind, and binding
+// them here would assert a fallback the contract does not declare.
+// TestFakeRoutingConfigBindsEveryLadder keeps the set derived from the
+// ladders rather than maintained by hand. Riding this config through
+// NewModelPath (rather than FakeModelPath's direct client wiring) means
+// --ai-fake exercises the
 // real Router — tiering, the budget guardrail, metering and call
 // tracing — with only the provider swapped for the deterministic fake.
 func FakeRoutingConfig() RoutingConfig {

--- a/backend/internal/modules/ai/fakerouting.go
+++ b/backend/internal/modules/ai/fakerouting.go
@@ -16,12 +16,12 @@ package ai
 // produce. The tiers no ladder names — frontier and local_large — stay
 // deliberately unbound: they exist for an operator to bind, and binding
 // them here would assert a fallback the contract does not declare.
-// TestFakeRoutingConfigBindsEveryLadder keeps the set derived from the
-// ladders rather than maintained by hand. Riding this config through
-// NewModelPath (rather than FakeModelPath's direct client wiring) means
-// --ai-fake exercises the
-// real Router — tiering, the budget guardrail, metering and call
-// tracing — with only the provider swapped for the deterministic fake.
+// TestFakeRoutingConfigBindsEveryLadder catches the case that matters,
+// a ladder rung this config cannot serve, by running the real
+// UnboundLadderWarnings over it. Riding this config through NewModelPath
+// (rather than FakeModelPath's direct client wiring) means --ai-fake
+// exercises the real Router — tiering, the budget guardrail, metering and
+// call tracing — with only the provider swapped for the deterministic fake.
 func FakeRoutingConfig() RoutingConfig {
 	fake := ProviderConfig{Provider: ProviderFake}
 	return RoutingConfig{

--- a/backend/internal/modules/ai/handlers_usage.go
+++ b/backend/internal/modules/ai/handlers_usage.go
@@ -72,7 +72,7 @@ type aiUsageTask = struct {
 	// Task capture_classify, enrich, summarize, …
 	Task string `json:"task"`
 
-	// Tier local_small, cheap_cloud, premium, local_large.
+	// Tier local_small, cheap_cloud, premium, frontier, local_large.
 	Tier      string `json:"tier"`
 	TokensIn  int    `json:"tokens_in"`
 	TokensOut int    `json:"tokens_out"`

--- a/backend/internal/modules/ai/meter.go
+++ b/backend/internal/modules/ai/meter.go
@@ -99,17 +99,25 @@ func (m *Meter) MonthTokens(ctx context.Context) (int64, error) {
 	return total, nil
 }
 
-// PremiumShare is the premium-tier fraction of tokens over the trailing
-// window — the §1.3 routing-fix alarm input.
+// PremiumShare is the costly-cloud fraction of tokens over the trailing
+// window — the §1.3 routing-fix alarm input. It measures every rung billed
+// above the cheap cloud rate, not premium alone: a rung priced higher than
+// premium that counted only toward the denominator would push the reported
+// share DOWN as a workspace spent more on it, which is backwards for an alarm
+// whose whole job is to notice expensive routing.
 func (m *Meter) PremiumShare(ctx context.Context, window time.Duration) (share float64, alarm bool, err error) {
 	since := m.now().UTC().Add(-window).Format("2006-01-02")
+	costly := make([]string, 0, len(costlyCloudTiers))
+	for _, tier := range costlyCloudTiers {
+		costly = append(costly, string(tier))
+	}
 	var premium, total int64
 	err = m.db.Tx(ctx, func(tx pgx.Tx) error {
 		return tx.QueryRow(ctx, `
 			SELECT
-			  COALESCE(SUM(tokens_in + tokens_out) FILTER (WHERE tier = $1), 0),
+			  COALESCE(SUM(tokens_in + tokens_out) FILTER (WHERE tier = ANY($1)), 0),
 			  COALESCE(SUM(tokens_in + tokens_out), 0)
-			FROM ai_usage WHERE day >= $2::date`, string(TierPremium), since).Scan(&premium, &total)
+			FROM ai_usage WHERE day >= $2::date`, costly, since).Scan(&premium, &total)
 	})
 	if err != nil {
 		return 0, false, fmt.Errorf("ai: premium share: %w", err)

--- a/backend/internal/modules/ai/pricing.go
+++ b/backend/internal/modules/ai/pricing.go
@@ -120,8 +120,10 @@ func vendorSheetRates(day time.Time) []ModelRate {
 		// config/ai-routing.example.yaml's default bindings — premium
 		// (gemini-3.5-flash), cheap_cloud (gemini-3.1-flash-lite) and frontier
 		// (gemini-3.1-pro-preview). Both Flash rows are flat: their rate does
-		// not vary with prompt size (verified 2026-07-20, reconfirmed
-		// 2026-08-12), so what is seeded is what a call of any length pays.
+		// not vary with prompt size, so what is seeded is what a call of any
+		// length pays. This CORRECTS the 2026-07-20 note that had them carrying
+		// a >200k tier — that is Pro's pricing shape, ascribed to the Flash rows
+		// in error; reconfirmed against the live sheet 2026-08-12.
 		rateOn(day, providerGemini, "gemini-3.5-flash", 1_500_000, 9_000_000, 150_000, 0),
 		rateOn(day, providerGemini, "gemini-3.1-flash-lite", 250_000, 1_500_000, 25_000, 0),
 		// gemini-3.1-pro-preview is the example file's frontier binding, and the

--- a/backend/internal/modules/ai/pricing.go
+++ b/backend/internal/modules/ai/pricing.go
@@ -118,11 +118,20 @@ func vendorSheetRates(day time.Time) []ModelRate {
 		// Gemini (verified 2026-07-20): cache read = 0.1x input; Gemini's
 		// implicit context caching carries no separate write charge. Prices
 		// are config/ai-routing.example.yaml's default bindings — premium
-		// (gemini-3.5-flash) and cheap_cloud (gemini-3.1-flash-lite). Both
-		// carry a >200k-token tier Gemini charges at a higher rate; the
-		// sub-200k sheet price is seeded here as the common case.
+		// (gemini-3.5-flash), cheap_cloud (gemini-3.1-flash-lite) and frontier
+		// (gemini-3.1-pro-preview). Each carries a >200k-token tier Gemini
+		// charges at a higher rate; the sub-200k sheet price is seeded here as
+		// the common case.
 		rateOn(day, providerGemini, "gemini-3.5-flash", 1_500_000, 9_000_000, 150_000, 0),
 		rateOn(day, providerGemini, "gemini-3.1-flash-lite", 250_000, 1_500_000, 25_000, 0),
+		// gemini-3.1-pro-preview is the example file's frontier binding
+		// (verified 2026-08-12). Same sub-200k convention as its siblings above:
+		// the >200k tier is $4.00/$18.00. Google also charges $4.50/MTok/hour to
+		// STORE an explicit cache, which none of the four billed buckets can
+		// express — a deployment using explicit caching pays more than the
+		// reported cost by that amount, and pricing it into a token bucket would
+		// misreport every call that never touched the cache.
+		rateOn(day, providerGemini, "gemini-3.1-pro-preview", 2_000_000, 12_000_000, 200_000, 0),
 
 		// OpenAI: config/ai-routing.example.yaml's commented cheap_cloud
 		// binding names "gpt-5-mini", which no longer appears on OpenAI's

--- a/backend/internal/modules/ai/pricing.go
+++ b/backend/internal/modules/ai/pricing.go
@@ -115,22 +115,24 @@ func vendorSheetRates(day time.Time) []ModelRate {
 		// date, so the undated family's sheet price applies verbatim.
 		rateOn(day, providerAnthropic, "claude-haiku-4-5-20251001", 1_000_000, 5_000_000, 100_000, 1_250_000),
 
-		// Gemini (verified 2026-07-20): cache read = 0.1x input; Gemini's
-		// implicit context caching carries no separate write charge. Prices
-		// are config/ai-routing.example.yaml's default bindings — premium
+		// Gemini: cache read = 0.1x input; Gemini's implicit context caching
+		// carries no separate write charge. Prices are
+		// config/ai-routing.example.yaml's default bindings — premium
 		// (gemini-3.5-flash), cheap_cloud (gemini-3.1-flash-lite) and frontier
-		// (gemini-3.1-pro-preview). Each carries a >200k-token tier Gemini
-		// charges at a higher rate; the sub-200k sheet price is seeded here as
-		// the common case.
+		// (gemini-3.1-pro-preview). Both Flash rows are flat: their rate does
+		// not vary with prompt size (verified 2026-07-20, reconfirmed
+		// 2026-08-12), so what is seeded is what a call of any length pays.
 		rateOn(day, providerGemini, "gemini-3.5-flash", 1_500_000, 9_000_000, 150_000, 0),
 		rateOn(day, providerGemini, "gemini-3.1-flash-lite", 250_000, 1_500_000, 25_000, 0),
-		// gemini-3.1-pro-preview is the example file's frontier binding
-		// (verified 2026-08-12). Same sub-200k convention as its siblings above:
-		// the >200k tier is $4.00/$18.00. Google also charges $4.50/MTok/hour to
-		// STORE an explicit cache, which none of the four billed buckets can
-		// express — a deployment using explicit caching pays more than the
-		// reported cost by that amount, and pricing it into a token bucket would
-		// misreport every call that never touched the cache.
+		// gemini-3.1-pro-preview is the example file's frontier binding, and the
+		// only Gemini row here whose rate varies with prompt size (verified
+		// 2026-08-12). Seeded at the <=200k sheet price, which is the common
+		// case; above that boundary Google charges $4.00/$18.00 and a call
+		// UNDER-reports its cost by that difference. Explicit caching adds
+		// $4.50/MTok/hour to STORE the cache, which none of the four billed
+		// buckets can express — folding it into a token bucket would misreport
+		// every call that never touched the cache, so it is recorded here
+		// rather than priced.
 		rateOn(day, providerGemini, "gemini-3.1-pro-preview", 2_000_000, 12_000_000, 200_000, 0),
 
 		// OpenAI: config/ai-routing.example.yaml's commented cheap_cloud

--- a/backend/internal/modules/ai/router.go
+++ b/backend/internal/modules/ai/router.go
@@ -383,28 +383,34 @@ func (r *Router) applyBudget(ctx context.Context, task Task, wsID ids.WorkspaceI
 	}
 }
 
-// cloudTiers are the rungs that reach a third-party API. applyProfile
-// rewrites every one of them to a local rung under sovereign, so the
-// classification must stay TOTAL over the contract's tier list: a tier
-// declared in ai-tasks.yaml and forgotten here would pass through the remap
-// and egress under the one profile that promises it never will.
-// TestEveryNonLocalTierIsClassifiedCloud holds that line.
-var cloudTiers = map[Tier]bool{
-	TierCheapCloud: true,
-	TierPremium:    true,
-	TierFrontier:   true,
+// localTiers are the rungs that run on the box. The set is written this way
+// round — naming what is SAFE rather than what egresses — so that a tier added
+// to the contract and forgotten here is remapped rather than let through:
+// an incomplete allowlist of cloud rungs would fail open under the one profile
+// that promises it never will. TestEveryLocallyNamedTierIsClassifiedLocal
+// keeps the two spellings of "local" agreeing.
+var localTiers = map[Tier]bool{
+	TierLocalSmall: true,
+	TierLocalLarge: true,
 }
 
-// applyProfile remaps cloud rungs to local ones under sovereign: P7
-// zero-egress holds by construction because a cloud tier is simply
-// never selected (validation already refused cloud bindings).
+// costlyCloudTiers are the rungs billed above the cheap cloud rate. The
+// §1.3 routing-fix alarm measures their combined share, so a rung priced above
+// premium belongs here the day it is declared — an alarm that watches only
+// part of the expensive spend reads LOWER the more of it a workspace does.
+var costlyCloudTiers = []Tier{TierPremium, TierFrontier}
+
+// applyProfile remaps cloud rungs to local ones under sovereign. P7
+// zero-egress rests on validation, which refuses a cloud binding outright
+// under this profile so no cloud client is ever constructed; this remap is
+// the second line, keeping a cloud-named rung off the ladder even so.
 func (r *Router) applyProfile(ladder []Tier) []Tier {
 	if r.profile != ProfileSovereign {
 		return ladder
 	}
 	remapped := make([]Tier, 0, len(ladder))
 	for _, tier := range ladder {
-		if cloudTiers[tier] {
+		if !localTiers[tier] {
 			if _, ok := r.clients[TierLocalLarge]; ok {
 				tier = TierLocalLarge
 			} else {

--- a/backend/internal/modules/ai/router.go
+++ b/backend/internal/modules/ai/router.go
@@ -383,6 +383,18 @@ func (r *Router) applyBudget(ctx context.Context, task Task, wsID ids.WorkspaceI
 	}
 }
 
+// cloudTiers are the rungs that reach a third-party API. applyProfile
+// rewrites every one of them to a local rung under sovereign, so the
+// classification must stay TOTAL over the contract's tier list: a tier
+// declared in ai-tasks.yaml and forgotten here would pass through the remap
+// and egress under the one profile that promises it never will.
+// TestEveryNonLocalTierIsClassifiedCloud holds that line.
+var cloudTiers = map[Tier]bool{
+	TierCheapCloud: true,
+	TierPremium:    true,
+	TierFrontier:   true,
+}
+
 // applyProfile remaps cloud rungs to local ones under sovereign: P7
 // zero-egress holds by construction because a cloud tier is simply
 // never selected (validation already refused cloud bindings).
@@ -392,7 +404,7 @@ func (r *Router) applyProfile(ladder []Tier) []Tier {
 	}
 	remapped := make([]Tier, 0, len(ladder))
 	for _, tier := range ladder {
-		if tier == TierCheapCloud || tier == TierPremium {
+		if cloudTiers[tier] {
 			if _, ok := r.clients[TierLocalLarge]; ok {
 				tier = TierLocalLarge
 			} else {

--- a/backend/internal/modules/ai/router_test.go
+++ b/backend/internal/modules/ai/router_test.go
@@ -202,6 +202,51 @@ func TestRouterSovereignRemapsCloudTiersToLocal(t *testing.T) {
 	}
 }
 
+// The cloudTiers classification must stay TOTAL over the contract's tier list,
+// because applyProfile only remaps what it classifies: a tier declared in
+// ai-tasks.yaml and left out of the map would egress under the one profile that
+// promises it never will. The naming convention is the derivation — a tier is
+// local only if it says so — so adding a tier without classifying it fails here
+// rather than silently in production.
+func TestEveryNonLocalTierIsClassifiedCloud(t *testing.T) {
+	for tier := range knownTiers {
+		local := strings.HasPrefix(string(tier), "local_")
+		if local == cloudTiers[tier] {
+			t.Errorf("tier %q: named local=%v but classified cloud=%v — applyProfile would %s under sovereign",
+				tier, local, cloudTiers[tier],
+				map[bool]string{true: "remap a local rung needlessly", false: "let a cloud rung through"}[local])
+		}
+	}
+}
+
+// applyProfile is exercised directly here because no task ladder names frontier
+// yet: the sovereign guarantee has to hold for the rung BEFORE something routes
+// to it, not after.
+func TestApplyProfileRemapsFrontierUnderSovereign(t *testing.T) {
+	r := testRouter(map[Tier]model.Client{
+		TierLocalSmall: NewFakeClient(),
+		TierLocalLarge: NewFakeClient(),
+	}, &memMeter{}, DefaultMonthlyTokens, ProfileSovereign)
+	got := r.applyProfile([]Tier{TierFrontier, TierPremium})
+	if len(got) != 1 || got[0] != TierLocalLarge {
+		t.Fatalf("a frontier-led ladder must collapse to the local rung under sovereign, got %v", got)
+	}
+}
+
+// Economy mode steps one rung down, and frontier's step is premium — not
+// straight to a cheap tier, which would drop two capability classes at the
+// first sign of budget pressure.
+func TestFrontierDegradesToPremium(t *testing.T) {
+	if got := degradeTo[TierFrontier]; got != TierPremium {
+		t.Fatalf("frontier must degrade to premium, got %q", got)
+	}
+	for tier := range knownTiers {
+		if _, ok := degradeTo[tier]; !ok {
+			t.Errorf("tier %q has no degrade_to entry — economy mode would leave it at full cost", tier)
+		}
+	}
+}
+
 func TestRouterSovereignWithoutLocalDegradesHonestly(t *testing.T) {
 	r := testRouter(map[Tier]model.Client{}, &memMeter{}, DefaultMonthlyTokens, ProfileSovereign)
 	_, _, err := r.Complete(wsContext(t), TaskSummarize, model.Request{Messages: []model.Message{{Role: "user", Content: "x"}}})

--- a/backend/internal/modules/ai/router_test.go
+++ b/backend/internal/modules/ai/router_test.go
@@ -6,6 +6,7 @@ package ai
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -202,19 +203,31 @@ func TestRouterSovereignRemapsCloudTiersToLocal(t *testing.T) {
 	}
 }
 
-// The cloudTiers classification must stay TOTAL over the contract's tier list,
-// because applyProfile only remaps what it classifies: a tier declared in
-// ai-tasks.yaml and left out of the map would egress under the one profile that
-// promises it never will. The naming convention is the derivation — a tier is
-// local only if it says so — so adding a tier without classifying it fails here
-// rather than silently in production.
-func TestEveryNonLocalTierIsClassifiedCloud(t *testing.T) {
+// The gate P7 actually rests on: under sovereign, NO tier may be bound to a
+// cloud provider, so no cloud client is ever constructed. Asserted per tier
+// rather than for one sample, because a tier the validator skipped would be a
+// hole nothing downstream could close.
+func TestSovereignRefusesACloudBindingOnEveryTier(t *testing.T) {
 	for tier := range knownTiers {
-		local := strings.HasPrefix(string(tier), "local_")
-		if local == cloudTiers[tier] {
-			t.Errorf("tier %q: named local=%v but classified cloud=%v — applyProfile would %s under sovereign",
-				tier, local, cloudTiers[tier],
-				map[bool]string{true: "remap a local rung needlessly", false: "let a cloud rung through"}[local])
+		cfg := fmt.Sprintf("profile: sovereign\ntiers:\n  %s: {provider: gemini}\nembeddings: {provider: fake}\n", tier)
+		if _, err := ParseRouting([]byte(cfg)); err == nil {
+			t.Errorf("tier %q accepts a cloud provider under sovereign — that binding would egress", tier)
+		}
+	}
+}
+
+// localTiers is the second line, and it is written as an allowlist of what is
+// SAFE so that an unclassified tier is remapped rather than let through. This
+// keeps it agreeing with the naming convention: a rung named local_* that
+// applyProfile would needlessly remap is a bug in the other direction, and one
+// NOT named local_* that it would pass through is the dangerous one.
+func TestEveryLocallyNamedTierIsClassifiedLocal(t *testing.T) {
+	for tier := range knownTiers {
+		named := strings.HasPrefix(string(tier), "local_")
+		if named != localTiers[tier] {
+			t.Errorf("tier %q: named local=%v but classified local=%v — applyProfile would %s under sovereign",
+				tier, named, localTiers[tier],
+				map[bool]string{true: "remap a local rung needlessly", false: "leave a cloud-named rung on the ladder"}[named])
 		}
 	}
 }
@@ -240,9 +253,34 @@ func TestFrontierDegradesToPremium(t *testing.T) {
 	if got := degradeTo[TierFrontier]; got != TierPremium {
 		t.Fatalf("frontier must degrade to premium, got %q", got)
 	}
+}
+
+// A tier with no degrade step would sit at full cost through the whole 80–100%
+// band, which is the one band economy mode exists to handle.
+func TestEveryTierHasADegradeStep(t *testing.T) {
 	for tier := range knownTiers {
 		if _, ok := degradeTo[tier]; !ok {
 			t.Errorf("tier %q has no degrade_to entry — economy mode would leave it at full cost", tier)
+		}
+	}
+}
+
+// The alarm's numerator must cover every rung billed above the cheap cloud
+// rate. A costlier rung left out counts toward the denominator only, so heavier
+// spend on it would report a LOWER share.
+func TestCostlyCloudTiersCoversEveryRungAbovePremium(t *testing.T) {
+	covered := map[Tier]bool{}
+	for _, tier := range costlyCloudTiers {
+		covered[tier] = true
+	}
+	for _, tier := range []Tier{TierPremium, TierFrontier} {
+		if !covered[tier] {
+			t.Errorf("tier %q is billed above the cheap cloud rate but is not in costlyCloudTiers — PremiumShare would under-report it", tier)
+		}
+	}
+	for _, tier := range costlyCloudTiers {
+		if localTiers[tier] {
+			t.Errorf("tier %q is local, so it has no cloud bill to alarm on", tier)
 		}
 	}
 }

--- a/backend/internal/modules/ai/routing_test.go
+++ b/backend/internal/modules/ai/routing_test.go
@@ -26,6 +26,7 @@ profile: eu_hosted
 		{"missing profile", strings.Replace(valid, "profile: eu_hosted", "", 1), "profile is required"},
 		{"unknown profile", strings.Replace(valid, "eu_hosted", "hybrid", 1), "unknown profile"},
 		{"unknown tier", strings.Replace(valid, "local_small", "medium_cloud", 1), "unknown tier"},
+		{"frontier binds", strings.Replace(valid, "cheap_cloud", "frontier", 1), ""},
 		{"tier without provider", strings.Replace(valid, "{provider: fake}\n  cheap_cloud", "{model: gemma}\n  cheap_cloud", 1), "no provider"},
 		{"no embeddings lane", strings.Replace(valid, "embeddings: {provider: fake}", "", 1), "embeddings lane has no provider"},
 		{"typo'd key rejected", strings.Replace(valid, "tiers:", "tierz:", 1), "field tierz not found"},

--- a/backend/internal/modules/ai/tasks_gen.go
+++ b/backend/internal/modules/ai/tasks_gen.go
@@ -64,13 +64,14 @@ const (
 	TierLocalSmall Tier = "local_small"
 	TierCheapCloud Tier = "cheap_cloud"
 	TierPremium    Tier = "premium"
+	TierFrontier   Tier = "frontier"
 	TierLocalLarge Tier = "local_large"
 )
 
 // TaskContractHash is the sha256 of api/ai-tasks.yaml at generation
 // time: a build fingerprint the cert runner can compare against a
 // freshly hashed contract file to catch a stale generated table.
-const TaskContractHash = "f818b1f3ff64ce3f21069c3fb2c9f08529170cfa15ae4e60bc984f7ce63441ac"
+const TaskContractHash = "9ee37bacc7d67837c7d210b83471662d55f05d7a5f567efedbeeb79e46a238c5"
 
 // AllTasks returns every contract task, sorted — the completeness
 // check a certification run walks to prove it covers every routed
@@ -131,6 +132,7 @@ var degradeTo = map[Tier]Tier{
 	TierLocalSmall: TierLocalSmall,
 	TierCheapCloud: TierLocalSmall,
 	TierPremium:    TierCheapCloud,
+	TierFrontier:   TierPremium,
 	TierLocalLarge: TierLocalSmall,
 }
 
@@ -166,6 +168,7 @@ var knownTiers = map[Tier]bool{
 	TierLocalSmall: true,
 	TierCheapCloud: true,
 	TierPremium:    true,
+	TierFrontier:   true,
 	TierLocalLarge: true,
 }
 

--- a/config/ai-routing.example.yaml
+++ b/config/ai-routing.example.yaml
@@ -38,6 +38,17 @@ tiers:
     provider: gemini
     model: gemini-3.5-flash
 
+  # frontier is the rung above premium: the strongest model this deployment is
+  # willing to pay for. NO task ladder selects it — binding it costs nothing
+  # until you put it in one (a routing-POLICY change in backend/api/ai-tasks.yaml,
+  # which needs a rebuild). It is here so the rung has a measured default when a
+  # task does need it, and so `make e2e-ai` can judge a candidate against it.
+  # gemini-3.1-pro-preview is $2.00/$12.00 per MTok against premium's
+  # $1.50/$9.00, so a ladder change here roughly doubles that task's bill.
+  frontier:
+    provider: gemini
+    model: gemini-3.1-pro-preview
+
 # embeddings — bound separately from the chat tiers so retrieval keeps working
 # when the chat budget is exhausted. Required.
 embeddings:

--- a/config/ai-routing.example.yaml
+++ b/config/ai-routing.example.yaml
@@ -44,7 +44,8 @@ tiers:
   # which needs a rebuild). It is here so the rung has a measured default when a
   # task does need it, and so `make e2e-ai` can judge a candidate against it.
   # gemini-3.1-pro-preview is $2.00/$12.00 per MTok against premium's
-  # $1.50/$9.00, so a ladder change here roughly doubles that task's bill.
+  # $1.50/$9.00, so at equal token counts a ladder change here raises that
+  # task's model cost by about a third.
   frontier:
     provider: gemini
     model: gemini-3.1-pro-preview

--- a/config/ai-routing.openrouter-cn.example.yaml
+++ b/config/ai-routing.openrouter-cn.example.yaml
@@ -38,6 +38,15 @@ tiers:
     base_url: https://openrouter.ai/api
     model: z-ai/glm-5.2                    # CN · $0.97/$3.04 · 1.05M · #5
 
+  # frontier is the rung above premium and no task ladder selects it. Bound to
+  # the same model as premium for the reason the EU file gives: glm-5.2 is the
+  # strongest CN model measured here, so a different id on this rung would be a
+  # guess, not a pick.
+  frontier:
+    provider: openai_compatible
+    base_url: https://openrouter.ai/api
+    model: z-ai/glm-5.2                    # CN · $0.97/$3.04 · 1.05M · #5
+
 # embeddings — bge-m3 is 1024 native, the same width as the EU file's
 # mistral-embed-2312, so switching between the two files needs no dimensions
 # edit and no re-embed. The native-width rule is the EU file's §embeddings note:

--- a/config/ai-routing.openrouter.example.yaml
+++ b/config/ai-routing.openrouter.example.yaml
@@ -84,6 +84,21 @@ tiers:
     #   NOT the :free variant of that model — it serves tools but not
     #   structured_outputs, so site_extract and enrich fail on the wire.
 
+  # frontier is the rung above premium, and no task ladder selects it — see
+  # config/ai-routing.example.yaml for what that means. It is bound to the SAME
+  # model as premium here rather than to a stronger one: the rungs above are the
+  # measured picks from the structured_outputs+tools set, and putting an
+  # unmeasured model on a rung nothing routes to would look like a
+  # recommendation without a single certification run behind it. Bind your own
+  # candidate and certify it (docs/how-to/certify-an-ai-model.md) before
+  # pointing a ladder at this rung.
+  frontier:
+    provider: openai_compatible
+    base_url: https://openrouter.ai/api
+    model: mistralai/mistral-large-2512              # EU · $0.50/$1.50 · 262k
+    # model: z-ai/glm-5.2                            # CN · $0.97/$3.04 · 1.05M · #5
+    # model: nvidia/nemotron-3-ultra-550b-a55b       # US · $0.60/$3.60 · 512k · #6
+
 # embeddings — bound separately from the chat tiers so retrieval keeps working
 # when the chat budget is exhausted. Required.
 #

--- a/config/ai-routing.schema.json
+++ b/config/ai-routing.schema.json
@@ -16,7 +16,7 @@
       "type": "object",
       "minProperties": 1,
       "additionalProperties": false,
-      "propertyNames": { "enum": ["local_small", "cheap_cloud", "premium", "local_large"] },
+      "propertyNames": { "enum": ["local_small", "cheap_cloud", "premium", "frontier", "local_large"] },
       "patternProperties": { ".*": { "$ref": "#/$defs/binding" } }
     },
     "embeddings": {

--- a/docs/explanation/ai-runtime.md
+++ b/docs/explanation/ai-runtime.md
@@ -67,7 +67,7 @@ Each task declares a **ladder** — an ordered list of capability **tiers** — 
 
 ```yaml
 # backend/api/ai-tasks.yaml
-tiers: [local_small, cheap_cloud, premium, local_large]
+tiers: [local_small, cheap_cloud, premium, frontier, local_large]
 
 tasks:
   cold_start:    {ladder: [cheap_cloud, premium], execution_mode: interactive, on_budget_exhausted: degrade}
@@ -76,8 +76,10 @@ tasks:
 ```
 
 - **Tiers** are *capability classes*, not models: `local_small` / `local_large`
-  (on-box, zero-egress), `cheap_cloud` (fast/cheap hosted), `premium`
-  (strongest). A task's ladder is its **fallback order** — the Router starts at
+  (on-box, zero-egress), `cheap_cloud` (fast/cheap hosted), `premium` (strong
+  hosted reasoning), `frontier` (the strongest a deployment will pay for — no
+  task ladder names it, so it costs nothing until one does).
+  A task's ladder is its **fallback order** — the Router starts at
   the first tier and walks to the next on a provider error or a schema-validation
   failure, so a transient failure degrades instead of dropping the call.
 - **`execution_mode`** names who is waiting: `interactive` (a human, mid-flow)

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -7424,7 +7424,7 @@ export interface components {
                 tasks: {
                     /** @description capture_classify, enrich, summarize, … */
                     task: string;
-                    /** @description local_small, cheap_cloud, premium, local_large. */
+                    /** @description local_small, cheap_cloud, premium, frontier, local_large. */
                     tier: string;
                     calls: number;
                     cached_hits?: number;
@@ -11731,7 +11731,7 @@ export interface components {
         };
         AssistantConfiguredModel: {
             /** @enum {string} */
-            tier: "local_small" | "cheap_cloud" | "premium" | "local_large";
+            tier: "local_small" | "cheap_cloud" | "premium" | "frontier" | "local_large";
             /** @enum {string} */
             provider: "anthropic" | "gemini" | "ollama" | "openai" | "openai_compatible" | "vllm";
             model: string;

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -1915,6 +1915,7 @@ export const de = {
   "ob.ai.tier.localSmall": "lokal, schnell",
   "ob.ai.tier.cheapCloud": "Cloud, effizient",
   "ob.ai.tier.premium": "Premium-Reasoning",
+  "ob.ai.tier.frontier": "Frontier-Reasoning",
   "ob.ai.tier.localLarge": "lokal, erweitert",
   // Die Klartext-Zeile im Rail-Footer: Die genauen IDs sind einen Klick
   // entfernt in der Zeile „Konfigurierte KI“ des Laufzeit-Chips — hier steht

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -1909,6 +1909,7 @@ export const en = {
   "ob.ai.tier.localSmall": "local, fast",
   "ob.ai.tier.cheapCloud": "cloud, efficient",
   "ob.ai.tier.premium": "premium reasoning",
+  "ob.ai.tier.frontier": "frontier reasoning",
   "ob.ai.tier.localLarge": "local, advanced",
   // The rail footer's plain-language line: the exact ids sit one click away
   // in the runtime chip's "Configured AI" row, so this says only what a

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -1910,6 +1910,7 @@ export const vi = {
   "ob.ai.tier.localSmall": "cục bộ, nhanh",
   "ob.ai.tier.cheapCloud": "đám mây, tiết kiệm",
   "ob.ai.tier.premium": "suy luận cao cấp",
+  "ob.ai.tier.frontier": "suy luận tiên phong",
   "ob.ai.tier.localLarge": "cục bộ, mạnh",
   // The rail footer's plain-language line: the exact ids sit one click away
   // in the runtime chip's "Configured AI" row, so this says only what a

--- a/frontend/src/screens/onboarding-read.tsx
+++ b/frontend/src/screens/onboarding-read.tsx
@@ -139,6 +139,7 @@ const tierKeys = {
   local_small: "ob.ai.tier.localSmall",
   cheap_cloud: "ob.ai.tier.cheapCloud",
   premium: "ob.ai.tier.premium",
+  frontier: "ob.ai.tier.frontier",
   local_large: "ob.ai.tier.localLarge",
 } as const;
 


### PR DESCRIPTION
## Why

`premium` was the ceiling, so "the strongest model we'll pay for" and "the model `site_extract` needs" had to be the same binding. A deployment that wanted a stronger model for one workload had to raise `premium` for all of them.

## What

A fifth capability tier, `frontier`, one rung above `premium`.

- **Contract** — `backend/api/ai-tasks.yaml` declares the tier and `degrade_to: frontier → premium` (one rung down, not straight to a cheap tier). `crm.yaml` widens the `AssistantConfiguredModelTier` enum and the `ai_usage` tier description. `make gen` carries both into `tasks_gen.go`, `api_gen.go`, `config/ai-routing.schema.json` and `frontend/src/api/schema.d.ts`.
- **No task ladder selects it.** Nothing gets more expensive on merge; opting a task in stays a routing-policy change with a rebuild behind it.
- **Config** — bound in all three shipped examples. The vendor file gets `gemini` / `gemini-3.1-pro-preview`; the two OpenRouter files reuse the model their own `premium` rung already names (`mistralai/mistral-large-2512`, `z-ai/glm-5.2`) rather than putting an uncertified model on a rung nothing routes to.
- **Pricing** — one `vendorSheetRates` row for `gemini-3.1-pro-preview`, $2.00 / $12.00 / $0.20 cache-read per MTok, verified 2026-08-12 against Google's sheet. Sub-200k, matching the convention its Gemini siblings already use. The comment records the two charges the four-bucket `ModelRate` shape cannot express (the >200k tier, and $4.50/MTok/hour explicit-cache storage) rather than folding them into a bucket that would misreport calls which never touched the cache.

## The bug this surfaced

`applyProfile` hardcoded `tier == TierCheapCloud || tier == TierPremium`, so any *new* cloud rung would have passed straight through the one profile that promises zero egress (P7). Latent — nothing routes to `frontier` — but it is the "fixed the case under review, missed the sibling copy" shape. Rather than adding a third `||`, the remap now reads a `cloudTiers` classification that `TestEveryNonLocalTierIsClassifiedCloud` holds **total** over the contract's tier list, so the next tier added without classifying it fails a test instead of egressing in production.

## Not in this PR

The spec repo (`margince-foundation`) is unchanged, so `backend/api/ai-tasks.yaml` now diverges from `specs/contract/ai-tasks.yaml`, which its own header says it must match verbatim. Filed as an issue for upstream reconciliation under P3 rather than left silent.

## Verification

- `make check-backend` — green
- `make check-fe` — green
- `make craft-static` — 0 blocker, 0 major, 0 minor across `backend/`, `extensions/`, `fixtures/`

`TestSeedModelRatesPricesEveryBindingTheShippedExamplesName` reads the three example configs off disk, so it independently confirms all of them parse with the new tier and that no binding reports UNPRICED.

New tests: the `cloudTiers` totality gate, the sovereign remap for a `frontier`-led ladder (exercised on `applyProfile` directly, since no ladder names it yet), `degradeTo` totality over the tier set, and a `frontier` binding in the config-parse table.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new `frontier` AI tier above `premium` so deployments can bind a stronger model for specific workloads without raising `premium` globally. No task ladders select `frontier`, so merging does not change routing or cost.

- **New Features**
  - Introduced `frontier` tier in `backend/api/ai-tasks.yaml` with `degrade_to: frontier → premium`.
  - Example bindings: vendor uses `gemini-3.1-pro-preview`; OpenRouter examples reuse their `premium` model. Updated schema/enums across backend and frontend, docs, and i18n.
  - Pricing: added `gemini-3.1-pro-preview` ($2.00 in / $12.00 out / $0.20 cache-read per MTok). Only this row varies with prompt size (>200k).

- **Bug Fixes**
  - Sovereign routing: switched to a `localTiers` allowlist (remaps any non-local rung); validator refusal of cloud bindings is asserted per-tier; `--ai-fake` binds only ladder-named tiers.
  - Cost alarm: `PremiumShare` now measures all `costlyCloudTiers` (premium + frontier), not just premium.
  - Corrections: Gemini notes now state only Pro varies with prompt size; frontier is ~33% costlier than premium, not 2×.
  - Tests: cover per-tier sovereign binding rejection, local-vs-cloud classification, `frontier → premium` degrade path, costly-tier coverage, and fake-config ladder binding.

<sup>Written for commit 437e3a85be1b36135995ad1a28034c628f0642ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1041?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for the new **frontier** AI model tier.
  - Added frontier routing options for Gemini and OpenRouter configurations.
  - Added support for the Gemini 3.1 Pro Preview model.
  - Added frontier tier labels in English, German, and Vietnamese.

- **Improvements**
  - Frontier models now participate in sovereign routing and economy-mode fallback.
  - Updated AI configuration schemas and documentation to describe the new tier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->