### PR TITLE
refactor(personcontext): the readings three prose surfaces share are read once

### DIFF
--- a/backend/internal/compose/meetingbrief/input.go
+++ b/backend/internal/compose/meetingbrief/input.go
@@ -13,6 +13,7 @@ package meetingbrief
 import (
 	"time"
 
+	"github.com/gradionhq/margince/backend/internal/compose/personcontext"
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
@@ -213,16 +214,7 @@ func dealFromView(view crmcontracts.Person360) *DealIn {
 
 // currentEmployer names where the counterpart works now. The 360 sorts the
 // current-primary employment to index zero, so the first row is the answer.
-func currentEmployer(view crmcontracts.Person360) string {
-	if view.Employments == nil || len(view.Employments.Data) == 0 {
-		return ""
-	}
-	first := view.Employments.Data[0]
-	if !first.IsCurrentPrimary || first.OrganizationName == nil {
-		return ""
-	}
-	return *first.OrganizationName
-}
+func currentEmployer(view crmcontracts.Person360) string { return personcontext.CurrentEmployer(view) }
 
 // latest keeps the newer of two optional instants, treating nil as "nothing
 // captured" rather than as the zero time — the zero time would win every

--- a/backend/internal/compose/personbrief/input.go
+++ b/backend/internal/compose/personbrief/input.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/gradionhq/margince/backend/internal/compose/personcontext"
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/values"
 )
@@ -143,28 +144,12 @@ func FromView(view crmcontracts.Person360) Input {
 // fingerprint hashes and the writer reads. The contract types them as an enum;
 // the brief only needs to know which names are in the list.
 func omittedNames(omitted []crmcontracts.Person360SectionsOmitted) []string {
-	if len(omitted) == 0 {
-		return nil
-	}
-	out := make([]string, 0, len(omitted))
-	for _, section := range omitted {
-		out = append(out, string(section))
-	}
-	return out
+	return personcontext.OmittedNames(omitted)
 }
 
 // currentEmployer names where this person works now. The 360 sorts the
 // current-primary employment to index zero, so the first row is the answer.
-func currentEmployer(view crmcontracts.Person360) string {
-	if view.Employments == nil || len(view.Employments.Data) == 0 {
-		return ""
-	}
-	first := view.Employments.Data[0]
-	if !first.IsCurrentPrimary || first.OrganizationName == nil {
-		return ""
-	}
-	return *first.OrganizationName
-}
+func currentEmployer(view crmcontracts.Person360) string { return personcontext.CurrentEmployer(view) }
 
 func foldCommercial(in *Input, view crmcontracts.Person360) {
 	if view.Commercial == nil {
@@ -241,12 +226,7 @@ func foldRecent(in *Input, view crmcontracts.Person360) {
 // stamp renders an optional instant in one fixed format, so two timestamps
 // compare as strings the way the instants they name compare — and so the
 // fingerprint does not churn on a formatting difference.
-func stamp(at *time.Time) string {
-	if at == nil {
-		return ""
-	}
-	return at.UTC().Format(time.RFC3339)
-}
+func stamp(at *time.Time) string { return personcontext.Stamp(at) }
 
 // Fingerprint keys the cache on everything that could change the text: the
 // assembled input, the prompt version, and the model routing version.

--- a/backend/internal/compose/personcontext/personcontext.go
+++ b/backend/internal/compose/personcontext/personcontext.go
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+// Package personcontext holds the readings of a Person360 that more than one
+// prose surface takes.
+//
+// Three packages fold the same 360 into their own input — the person draft, the
+// relationship brief, the pre-meeting brief — and three of the readings were
+// byte-identical copies of each other. That is the shape that has already cost
+// this program four defects: one list knows something, its copy does not, and
+// the two answers diverge without anything failing.
+//
+// What this package is NOT is a canonical Person360 fold. The three consumers
+// genuinely disagree about what they need — the draft models a deal's direction
+// as a bool and takes amount and currency only as a pair, the brief allows them
+// independently and carries relationship strength — and a shared shape would
+// have to be the union of those disagreements, which is a worse thing than
+// three honest projections. So only the readings that are the SAME move here,
+// and each consumer keeps its own input struct.
+package personcontext
+
+import (
+	"time"
+
+	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+)
+
+// CurrentEmployer names where this person works now, or nothing.
+//
+// The 360 orders employments with the current primary first, so the first row
+// is the only one that can be it. A row that is not current, or one carrying no
+// organization name, answers empty rather than the next-best guess: "used to
+// work at" is a different sentence from "works at", and a draft that gets it
+// wrong tells somebody about a job they have left.
+func CurrentEmployer(view crmcontracts.Person360) string {
+	if view.Employments == nil || len(view.Employments.Data) == 0 {
+		return ""
+	}
+	first := view.Employments.Data[0]
+	if !first.IsCurrentPrimary || first.OrganizationName == nil {
+		return ""
+	}
+	return *first.OrganizationName
+}
+
+// OmittedNames is what the caller could NOT see, as plain strings.
+//
+// Every prose surface carries this to the model for the same reason: a section
+// missing because the reader lacks the grant is different from a section that
+// is empty, and a writer told the difference stays silent about the subject
+// instead of inferring around the gap.
+func OmittedNames(omitted []crmcontracts.Person360SectionsOmitted) []string {
+	if len(omitted) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(omitted))
+	for _, section := range omitted {
+		out = append(out, string(section))
+	}
+	return out
+}
+
+// Stamp renders an optional time as RFC3339 UTC, or empty.
+//
+// Empty means the thing never happened, which is a fact the prose surfaces
+// state honestly — "we have never written to them" rather than a zero date that
+// reads as 1 January year one.
+func Stamp(at *time.Time) string {
+	if at == nil {
+		return ""
+	}
+	return at.UTC().Format(time.RFC3339)
+}

--- a/backend/internal/compose/personcontext/personcontext_test.go
+++ b/backend/internal/compose/personcontext/personcontext_test.go
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package personcontext_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gradionhq/margince/backend/internal/compose/personcontext"
+	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+)
+
+// The employer reading, including the two cases that make it a refusal rather
+// than a lookup: a row that is not the current primary, and one with no
+// organization name. "Used to work at" is a different sentence from "works at",
+// and a draft that gets it wrong tells somebody about a job they have left.
+func TestCurrentEmployerRefusesAnythingButTheCurrentPrimary(t *testing.T) {
+	name := "Beispiel Maschinenbau GmbH"
+
+	cases := []struct {
+		name string
+		rows []crmcontracts.Person360Employment
+		want string
+	}{
+		{name: "no employments at all", rows: nil, want: ""},
+		{
+			name: "the current primary",
+			rows: []crmcontracts.Person360Employment{{IsCurrentPrimary: true, OrganizationName: &name}},
+			want: name,
+		},
+		{
+			name: "a past role is not where they work now",
+			rows: []crmcontracts.Person360Employment{{IsCurrentPrimary: false, OrganizationName: &name}},
+			want: "",
+		},
+		{
+			name: "a current row with no organization name",
+			rows: []crmcontracts.Person360Employment{{IsCurrentPrimary: true}},
+			want: "",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			view := crmcontracts.Person360{}
+			if c.rows != nil {
+				view.Employments = &struct {
+					Data []crmcontracts.Person360Employment `json:"data"`
+					Page crmcontracts.PageInfo              `json:"page"`
+				}{Data: c.rows}
+			}
+			if got := personcontext.CurrentEmployer(view); got != c.want {
+				t.Errorf("CurrentEmployer = %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+// A section missing because the reader lacks the grant is different from one
+// that is empty, and every prose surface carries the distinction so a writer
+// stays silent about the subject rather than inferring around the gap.
+func TestOmittedNamesCarriesTheSectionsTheReaderCouldNotSee(t *testing.T) {
+	if got := personcontext.OmittedNames(nil); got != nil {
+		t.Errorf("nothing omitted should answer nil, got %+v", got)
+	}
+	got := personcontext.OmittedNames([]crmcontracts.Person360SectionsOmitted{
+		crmcontracts.Person360SectionsOmittedNextMeeting,
+	})
+	if len(got) != 1 || got[0] != "next_meeting" {
+		t.Errorf("OmittedNames = %+v, want [next_meeting]", got)
+	}
+}
+
+// Empty means the thing never happened, which the prose surfaces state honestly
+// — "we have never written to them" rather than a zero date reading as year one.
+func TestStampAnswersEmptyForSomethingThatNeverHappened(t *testing.T) {
+	if got := personcontext.Stamp(nil); got != "" {
+		t.Errorf("Stamp(nil) = %q, want empty", got)
+	}
+	at := time.Date(2026, 8, 12, 9, 0, 0, 0, time.UTC)
+	if got := personcontext.Stamp(&at); got != "2026-08-12T09:00:00Z" {
+		t.Errorf("Stamp = %q", got)
+	}
+}

--- a/backend/internal/compose/persondraft/fold.go
+++ b/backend/internal/compose/persondraft/fold.go
@@ -13,6 +13,7 @@ import (
 
 	openapi_types "github.com/oapi-codegen/runtime/types"
 
+	"github.com/gradionhq/margince/backend/internal/compose/personcontext"
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/convstate"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/textlang"
@@ -133,16 +134,7 @@ func primaryEmail(person crmcontracts.Person) string {
 
 // currentEmployer names where this person works now. The 360 sorts the
 // current-primary employment to index zero, so the first row is the answer.
-func currentEmployer(view crmcontracts.Person360) string {
-	if view.Employments == nil || len(view.Employments.Data) == 0 {
-		return ""
-	}
-	first := view.Employments.Data[0]
-	if !first.IsCurrentPrimary || first.OrganizationName == nil {
-		return ""
-	}
-	return *first.OrganizationName
-}
+func currentEmployer(view crmcontracts.Person360) string { return personcontext.CurrentEmployer(view) }
 
 func foldCommercial(in *Input, view crmcontracts.Person360) {
 	if view.Commercial == nil {
@@ -350,24 +342,12 @@ func foldRecent(in *Input, view crmcontracts.Person360) {
 // omittedNames renders the withheld sections as plain strings for the writer.
 // The contract types them as an enum; the draft only needs the names.
 func omittedNames(omitted []crmcontracts.Person360SectionsOmitted) []string {
-	if len(omitted) == 0 {
-		return nil
-	}
-	out := make([]string, 0, len(omitted))
-	for _, section := range omitted {
-		out = append(out, string(section))
-	}
-	return out
+	return personcontext.OmittedNames(omitted)
 }
 
 // stamp renders an optional instant in one fixed format, so two timestamps
 // compare as strings the way the instants they name compare.
-func stamp(at *time.Time) string {
-	if at == nil {
-		return ""
-	}
-	return at.UTC().Format(time.RFC3339)
-}
+func stamp(at *time.Time) string { return personcontext.Stamp(at) }
 
 // Threaded reports whether a real inbound message earns this draft a reply
 // prefix. Only a message THEY sent counts: our own last outbound carries a


### PR DESCRIPTION
Wave 2b, scoped by what the code actually shows rather than by the plan's guess.

## What the duplication really is

Three packages fold the same `Person360` — the person draft, the relationship brief, the pre-meeting brief. I hashed their helpers before touching anything:

| helper | identical in |
|---|---|
| `currentEmployer` | **all three** |
| `omittedNames` | two |
| `stamp` | two |

That is copy-paste, and it is the shape that has already cost this program four defects — one list knows something, its copy does not, and the two answers diverge without anything failing.

Those three move to `compose/personcontext`. Each package keeps a one-line wrapper under its own name, so no call site churns and the diff stays readable.

## What did NOT move

The canonical `Person360` shape the plan sketched. The three consumers **genuinely disagree** about what they need: the draft models a deal's direction as a bool and takes amount and currency only as a pair, while the brief allows them independently and carries relationship strength.

A shared shape would have to be the union of those disagreements, which is a worse thing than three honest projections. The plan itself flagged this item as the first to cut — cutting the *shape* and keeping the *helpers* is the version worth having.

## Behaviour

Unchanged by construction. The extracted bodies are the ones that were there, confirmed identical by hash before the move, and every compose test passes untouched.

Seven tests on the shared package, including the two cases that make `CurrentEmployer` a refusal rather than a lookup: a row that is not the current primary, and one with no organization name. \"Used to work at\" is a different sentence from \"works at\", and a draft that gets it wrong tells somebody about a job they have left.

## Gate

`make -C backend build`, `go test ./internal/...`, `go test .` all green.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicated shared Person360 helpers by moving `currentEmployer`, `omittedNames`, and `stamp` into a new `compose/personcontext` package with one-line wrappers in `persondraft`, `personbrief`, and `meetingbrief`. Behavior is unchanged and unit tests cover key edge cases.

- **Refactors**
  - Added `compose/personcontext` with `CurrentEmployer`, `OmittedNames`, `Stamp`.
  - Replaced duplicated helpers in `compose/persondraft`, `compose/personbrief`, and `compose/meetingbrief` with wrappers calling the shared functions.
  - Kept consumer-specific input shapes; only truly shared readings moved.
  - Added tests for employer selection, omitted sections, and timestamp formatting.

<sup>Written for commit 09d153a298585f6b64cfca075762682cdf9ce32f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1043?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

