### PR TITLE
docs(status): step 4's surfaces are done; the rest of principal waits on step 5

### DIFF
--- a/STATUS-ARCHIVE.md
+++ b/STATUS-ARCHIVE.md
@@ -21,6 +21,46 @@
 > [CHANGELOG.md](CHANGELOG.md) and [README.md → *What works
 > today*](README.md#what-works-today).
 
+## 2026-08-12 (later still) — the tenant leaves the bus and the wire (PRs #1036, #1049, foundation#1284)
+
+ADR-0091 §9 **step 4**, the parts that do not wait on the schema. The envelope
+carries no `workspace_id`, and neither do thirty contract response schemas —
+the spec's own `crm.yaml` landed first, which is what contract-first means when
+the change is yours to write.
+
+The consumers are the interesting half. Every one that read the tenant off the
+envelope now takes it from what it was BUILT with — its store's handle, or the
+installation resolver where it holds no store. That is step 3's rule arriving at
+the bus: which tenant a component serves is a property of its construction, not
+of the message it is handed.
+
+Three ledger writes went further and take the tenant from the TRANSACTION —
+`audit_log`, `system_log`, and the advisory key in `LockWriteIdentity`, all
+reading `current_setting('app.workspace_id')` in SQL. Read from ctx, two things
+could disagree invisibly: a ledger row and the domain row it records, and two
+writers of one record taking different lock keys. The domain INSERTs deliberately
+did NOT follow — their binds vanish with the column in §8 phase D.
+
+That change surfaced a genuine test defect: the lock-contention racer opened a
+transaction without binding its workspace, so under a transaction-derived key it
+contended with nobody and would have reported a working lock as broken. A test
+supplying its own version of production, exactly as the review-loop rule warns.
+
+On the wire, two shapes collapsed rather than losing a field, because a per-tenant
+breakdown of a single tenant is the total repeated: embed-reindex status dropped
+`per_workspace`, and its preview keeps one `utilization_impact` instead of an
+array of one.
+
+The breaking-change gate was satisfied through its ratified-resync allowlist —
+the mechanism's intended use, keyed on the exact (base blob, new blob) pair so
+any later contract edit restores the stable gate.
+
+Filed, not fixed: **#1048** — the data reset drains the outbox in a transaction
+of its own and sweeps domain rows in another, so an event staged between them
+survives the sweep. Pre-existing since #513; closing it means a reset lock on
+every outbox writer, which is a change to the shared write shape rather than a
+line in the sweep.
+
 ## 2026-08-12 (later) — identity too: step 3 is complete (PR #1010)
 
 The entry below called identity a slice with real fixture work, and it was —

--- a/STATUS.md
+++ b/STATUS.md
@@ -501,6 +501,37 @@ different one — an ungoverned-agent refusal answered `ErrMultipleWorkspaces`
 instead of the refusal it exists to assert. **A component that carries a handle
 must pass THAT handle to everything it constructs.**
 
+### Step 4: the surfaces are done, the last of `principal` waits on step 5
+
+Landed: the **envelope** drops `workspace_id` (#1036, taking `events.ForWorkspace`
+with it — a bus filter whose premise was that the workspace is a field on the
+bus), and the **contract, generated types and SPA** drop it from thirty response
+schemas (#1049, after the spec's own `crm.yaml` landed it first —
+margince-foundation#1284, which is what P3 requires).
+
+Two things from that pair are worth carrying forward:
+
+- **The ledger now takes its tenant from the TRANSACTION.** `audit_log`,
+  `system_log` and `LockWriteIdentity`'s advisory key read
+  `current_setting('app.workspace_id')` in SQL instead of ctx. Read from ctx,
+  a ledger row could name a different workspace than the domain row it records,
+  and two writers of one record could take different lock keys and serialize
+  neither — both invisible. This is why the ledger moved early while the domain
+  INSERTs did not: their `workspace_id` binds vanish with the column in §8 phase
+  D, so converting them now is churn that phase deletes.
+- **A per-tenant breakdown of a single tenant is the total repeated.** Two wire
+  shapes collapsed rather than losing a field (embed-reindex status and
+  preview), and the same reasoning retires any other per-workspace fan-out on
+  the wire.
+
+**What is left of step 4 is `principal.WorkspaceID`, and it is entangled with
+step 5.** Sixty-six non-test readers remain, and they are not one shape: bound
+checks, meter keys, blob path segments, cache keys. The big consumer is
+`storekit.MustWorkspace` (53 sites stamping a `workspace_id` column) and
+`WithWorkspaceTx` itself (~580 uses), and §5 retires the latter as part of the
+SCHEMA phase. So the honest order is: do §8's phases, and let `principal` fall
+out where its referents go, rather than churning 600 call sites twice.
+
 Phase 2 spans roughly nine hundred `WithWorkspaceTx` occurrences, a bit over
 four hundred of them outside tests, across a couple of hundred non-test files.
 Deliberately not a precise count: it moved by eleven while this note was being


### PR DESCRIPTION
With #1036 and #1049 on main (and margince-foundation#1284 upstream), ADR-0091 §9 **step 4's named surfaces are done** — envelope, ledger, contract, frontend. STATUS.md now records what they established rather than what they planned.

Two findings worth carrying into the schema phase:

- **The ledger takes its tenant from the TRANSACTION**, not from ctx. A ledger row and the domain row it records could otherwise name different workspaces, and two writers of one record could take different advisory keys and serialize neither — both invisible. The domain INSERTs deliberately did *not* follow: their `workspace_id` binds vanish with the column in §8 phase D, so converting them now is churn that phase deletes.
- **A per-tenant breakdown of a single tenant is the total repeated** — two wire shapes collapsed rather than losing a field, and the same reasoning retires any other per-workspace fan-out on the wire.

And the honest order for what remains: `principal.WorkspaceID` has 66 non-test readers of four different shapes, and its big consumers are `storekit.MustWorkspace` (53 sites) and `WithWorkspaceTx` (~580), which §5 retires as part of the schema phase. Doing §8's phases first lets `principal` fall out where its referents go, instead of churning 600 call sites twice.

The archive gets its own entry, per its append-at-top rule.

Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update STATUS docs to record that step 4 surfaces are complete—envelope and contract responses drop `workspace_id`—and note that remaining `principal.WorkspaceID` cleanup is deferred to step 5 (schema).
Also document that the ledger now derives tenant from the transaction and that per-tenant wire shapes collapsed to totals; added an archive entry; docs only, no code changes.

<sup>Written for commit 52aa96501407c26c2546dd4660033b3f5e3b7b34. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1051?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

