### PR TITLE
test(extensions): a unit's SQL names the unit's own tables

### DIFF
--- a/backend/extensionsqlscope_test.go
+++ b/backend/extensionsqlscope_test.go
@@ -42,6 +42,13 @@ package backendarch
 // the fold could read does not stand in for one it could not. Under both rules
 // the statement reads as computed — a finding — rather than as allowed.
 //
+// A CTE is the one name that is not a table, and the exemption for it is bounded
+// twice: to the tokens AFTER the body that declares it (inside its own body the
+// same name still reads the real table, unless the WITH is RECURSIVE), and to
+// the positions a statement READS from. PostgreSQL has no such thing as writing
+// a CTE — the target of an UPDATE, DELETE, INSERT or TRUNCATE always resolves to
+// the real relation — so a write position takes no exemption at all.
+//
 // The allowlist is the unit's namespace, not a list of core tables: a table is
 // the unit's own when it is `ext.<namespace>_…` — derived through the same
 // extension.Name(…).Namespace() the migration gate and the unit's database role
@@ -347,8 +354,7 @@ func sqlStrings(file *ast.File, consts map[string]string) []foldedSQL {
 		// Stripped BEFORE the shape test, not after: a statement that opens with
 		// its own `-- why` comment is still a statement, and testing the raw text
 		// would read that comment as the first word and skip the query.
-		cleaned := sqlNoise.ReplaceAllString(text, " ")
-		if looksLikeSQL(cleaned) {
+		if cleaned := stripNoise(text); looksLikeSQL(cleaned) {
 			out = append(out, foldedSQL{text: cleaned, pos: expr.Pos()})
 		}
 		return false
@@ -417,6 +423,16 @@ var sqlStatementShapes = []struct{ opener, companion string }{
 	// refuses anyway (the runtime role is granted SELECT, INSERT, UPDATE and
 	// DELETE, never TRUNCATE, on core tables and on a unit's own alike).
 	{"truncate", " table "},
+	// A DO block's body is SQL that happens to be delimited, and its
+	// companion is the delimiter rather than a word: `do` alone opens too many
+	// English sentences to be a statement on its own.
+	{"do", "$$"},
+	{"do", "'"},
+	// COPY … TO STDOUT reads a whole table out on nothing but SELECT, which the
+	// shared runtime role holds on every core table. The direction word is the
+	// companion because it is what a statement has and a sentence does not.
+	{"copy", " to "},
+	{"copy", " from "},
 }
 
 func looksLikeSQL(text string) bool {
@@ -432,6 +448,27 @@ func looksLikeSQL(text string) bool {
 	return false
 }
 
+// stripNoise removes what a keyword can falsely appear in, so the shape test and
+// the token scan both read the statement rather than its contents.
+//
+// The exception is what a DO block is FOR. Everywhere else a quoted body is a
+// value — `SELECT $$FROM person$$ AS example` names one table, not two — but a
+// DO block's body IS the statement, and stripping it would delete the only
+// place its DML is written. So a DO keeps its body and loses only its comments,
+// which is the difference between reading `DO $$ BEGIN DELETE FROM person; END
+// $$` and reading `DO`.
+func stripNoise(text string) string {
+	if opensDoBlock(text) {
+		return sqlComments.ReplaceAllString(text, " ")
+	}
+	return sqlNoise.ReplaceAllString(text, " ")
+}
+
+func opensDoBlock(text string) bool {
+	fields := strings.Fields(text)
+	return len(fields) > 0 && strings.EqualFold(fields[0], "do")
+}
+
 // tableRef is one table position in a statement: the name it holds, or the fact
 // that the name could not be read.
 type tableRef struct {
@@ -440,12 +477,15 @@ type tableRef struct {
 }
 
 var (
-	// sqlNoise is what a keyword can falsely appear in and a table name cannot
-	// hide in: comments, single-quoted literals ('' escaping included), and
-	// dollar-quoted bodies. The dollar-quote pattern cannot pair a tag with its
-	// own closing tag (RE2 has no backreference), so it matches the nearest
-	// closing delimiter of the same SHAPE — which over-strips only a statement
-	// carrying two differently-tagged bodies, and under-strips nothing.
+	// sqlComments carry no SQL in any statement.
+	sqlComments = regexp.MustCompile(`--[^\n]*|(?s)/\*.*?\*/`)
+
+	// sqlNoise adds what carries no TABLE outside a DO block (see stripNoise):
+	// single-quoted literals ('' escaping included) and dollar-quoted bodies.
+	// The dollar-quote pattern cannot pair a tag with its own closing tag (RE2
+	// has no backreference), so it matches the nearest closing delimiter of the
+	// same SHAPE, which over-strips only a statement carrying two
+	// differently-tagged bodies.
 	sqlNoise = regexp.MustCompile(`--[^\n]*|(?s)/\*.*?\*/|'(?:[^']|'')*'|(?s)\$[A-Za-z0-9_]*\$.*?\$[A-Za-z0-9_]*\$`)
 
 	// sqlToken splits a statement into names (a dotted chain of bare or quoted
@@ -479,6 +519,7 @@ func tableRefs(sql string) []tableRef {
 		if !opensTablePosition(tokens, i, callStack) {
 			continue
 		}
+		readPosition := readsRatherThanWrites(tokens, i)
 		for _, at := range tableTargets(tokens, i) {
 			// One index is judged once. `TRUNCATE TABLE t` reaches t twice —
 			// once past the qualifier TRUNCATE steps over, once from TABLE
@@ -489,13 +530,39 @@ func tableRefs(sql string) []tableRef {
 			}
 			judged[at] = true
 			ref := refAt(tokens, at)
-			if ref.readable && withinCTEScope(ctes, ref.name, at) {
+			if ref.readable && readPosition && withinCTEScope(ctes, ref.name, at) {
 				continue
 			}
 			refs = append(refs, ref)
 		}
 	}
 	return refs
+}
+
+// readsRatherThanWrites reports whether the keyword at i introduces a table the
+// statement READS. It is what bounds the CTE exemption, and the bound is
+// PostgreSQL's own: a WITH name can stand wherever a relation is read, and
+// nowhere a statement writes. `WITH person AS (…) UPDATE person SET …` does not
+// rewrite the CTE — there is no such thing — it rewrites the table, and a gate
+// that exempted the name there would hand a unit a two-token way past itself
+// while its own table, read inside the CTE body, kept the reference count
+// honest.
+//
+// DELETE is why this reads the previous token rather than switching on the
+// keyword alone: FROM is a read position in every statement except the one
+// whose target it names.
+func readsRatherThanWrites(tokens []string, i int) bool {
+	previous := ""
+	if i > 0 {
+		previous = strings.ToLower(tokens[i-1])
+	}
+	switch strings.ToLower(tokens[i]) {
+	case "from":
+		return previous != "delete"
+	case "join", "using", "copy":
+		return true
+	}
+	return false
 }
 
 // argumentSeparators are the functions whose FROM separates arguments rather
@@ -516,7 +583,7 @@ var clauseWords = []string{
 // listKeywords introduce a comma-separated list of tables rather than one:
 // `FROM ext.ext_notes_note n, person p` is a join with no JOIN in it, and
 // `TRUNCATE TABLE a, b` and `DROP TABLE a, b` name two each.
-var listKeywords = []string{"from", "table", "truncate"}
+var listKeywords = []string{"from", "using", "table", "truncate"}
 
 // tableQualifiers stand between a keyword and the name it introduces —
 // `DELETE FROM ONLY t`, `JOIN LATERAL …`, `TRUNCATE TABLE t`,
@@ -539,7 +606,7 @@ func opensTablePosition(tokens []string, i int, callStack []string) bool {
 	switch strings.ToLower(tokens[i]) {
 	case "from":
 		return len(callStack) == 0 || !slices.Contains(argumentSeparators, callStack[len(callStack)-1])
-	case "join", "into", "table", "truncate", "using":
+	case "join", "into", "table", "truncate", "using", "copy":
 		// USING carries two meanings and both are handled here: the table of a
 		// `DELETE … USING t` / `MERGE … USING t`, and the column list of a
 		// `JOIN … USING (a, b)`, which tableTargets drops on the opening paren.
@@ -566,10 +633,15 @@ func tableTargets(tokens []string, i int) []int {
 		if at >= len(tokens) {
 			return append(targets, at)
 		}
-		if !namesATable(tokens, at, keyword) {
+		// An entry that is not a table — a subquery, a set-returning function —
+		// ends a single position and is STEPPED OVER in a list. Returning here
+		// instead would let one such entry shield every table behind it:
+		// `FROM generate_series(1,1) g, person p` names a core table second.
+		if namesATable(tokens, at, keyword) {
+			targets = append(targets, at)
+		} else if !list {
 			return targets
 		}
-		targets = append(targets, at)
 		if !list {
 			return targets
 		}
@@ -591,11 +663,24 @@ func namesATable(tokens []string, i int, keyword string) bool {
 	if tokens[i] == "(" {
 		return false
 	}
-	if keyword != "from" && keyword != "join" {
+	if slices.Contains(copyEndpoints, strings.ToLower(tokens[i])) {
+		return false // COPY t FROM STDIN — the endpoint, not a relation
+	}
+	if !slices.Contains(functionPositions, keyword) {
 		return true
 	}
 	return !isName(tokens[i]) || i+1 >= len(tokens) || tokens[i+1] != "("
 }
+
+// functionPositions are the keywords a set-returning function may stand after,
+// so a name applied to an argument list there is a call rather than a table:
+// `FROM unnest($1)`, `JOIN unnest($1)`, and the `DELETE … USING unnest($1)` that
+// is the ordinary bulk-delete idiom against a unit's own table. INTO, UPDATE and
+// TABLE are absent — `INSERT INTO t (cols)` names a table and its columns.
+var functionPositions = []string{"from", "join", "using"}
+
+// copyEndpoints are what COPY names on the side that is not a table.
+var copyEndpoints = []string{"stdin", "stdout", "program"}
 
 // refAt classifies the token at i as the table reference it holds.
 func refAt(tokens []string, i int) tableRef {
@@ -605,18 +690,23 @@ func refAt(tokens []string, i int) tableRef {
 	return tableRef{name: tokens[i], readable: true}
 }
 
-// skipAlias steps over the alias a table may carry — `t x`, `t AS x`, and the
-// column list either spelling may take — and returns where the entry ends. A
-// clause word is never an alias: it is what the list stops at.
+// skipAlias steps over everything between one list entry and the comma that
+// ends it: an alias with or without AS, a column list, and the argument list of
+// a set-returning function — in whatever order the entry spells them, since
+// `generate_series(1,2) g` and `t AS x (id)` both stand where a table can.
+// A clause word is never part of an entry: it is what the list stops at.
 func skipAlias(tokens []string, i int) int {
-	if i < len(tokens) && strings.EqualFold(tokens[i], "as") {
-		i++
-	}
-	if i < len(tokens) && isName(tokens[i]) && !slices.Contains(clauseWords, strings.ToLower(tokens[i])) {
-		i++
-	}
-	if i < len(tokens) && tokens[i] == "(" {
-		i = matchingParen(tokens, i) + 1
+	for i < len(tokens) {
+		switch {
+		case tokens[i] == "(":
+			i = matchingParen(tokens, i) + 1
+		case strings.EqualFold(tokens[i], "as"):
+			i++
+		case isName(tokens[i]) && !slices.Contains(clauseWords, strings.ToLower(tokens[i])):
+			i++
+		default:
+			return i
+		}
 	}
 	return i
 }
@@ -635,6 +725,10 @@ type cteScope struct {
 // inner name still reads the core table, and exempting it everywhere would hand
 // a unit a one-line way past this gate. A RECURSIVE WITH is the exception —
 // there the body legitimately names the CTE itself.
+//
+// Scope is half the bound; readsRatherThanWrites is the other half. A CTE can
+// stand where a statement reads and nowhere it writes, so these spans decide
+// nothing about the target of an UPDATE, DELETE, INSERT or TRUNCATE.
 func cteScopes(tokens []string) map[string]cteScope {
 	recursive := false
 	for i, raw := range tokens {

--- a/backend/extensionsqlscope_test.go
+++ b/backend/extensionsqlscope_test.go
@@ -409,7 +409,14 @@ var sqlStatementShapes = []struct{ opener, companion string }{
 	{"create", " table "},
 	{"alter", " table "},
 	{"drop", " table "},
-	{"truncate", ""},
+	// TRUNCATE's companion is the optional TABLE word, which makes the bare
+	// `TRUNCATE person` spelling unread. That is the deliberate half of a trade:
+	// with no companion, every sentence opening with the word is a statement,
+	// and "truncate the note body before sending" refuses a table called `the`
+	// — a false failure with no waiver to answer it, on a statement PostgreSQL
+	// refuses anyway (the runtime role is granted SELECT, INSERT, UPDATE and
+	// DELETE, never TRUNCATE, on core tables and on a unit's own alike).
+	{"truncate", " table "},
 }
 
 func looksLikeSQL(text string) bool {
@@ -506,6 +513,11 @@ var clauseWords = []string{
 	"natural", "lateral", "select", "insert", "update", "delete", "with", "into",
 }
 
+// listKeywords introduce a comma-separated list of tables rather than one:
+// `FROM ext.ext_notes_note n, person p` is a join with no JOIN in it, and
+// `TRUNCATE TABLE a, b` and `DROP TABLE a, b` name two each.
+var listKeywords = []string{"from", "table", "truncate"}
+
 // tableQualifiers stand between a keyword and the name it introduces —
 // `DELETE FROM ONLY t`, `JOIN LATERAL …`, `TRUNCATE TABLE t`,
 // `CREATE TABLE IF NOT EXISTS t`.
@@ -539,13 +551,12 @@ func opensTablePosition(tokens []string, i int, callStack []string) bool {
 }
 
 // tableTargets returns the token indices the keyword at i introduces as table
-// names: one for most keywords, and after FROM every entry of a comma-separated
-// list, because `FROM ext.ext_notes_note n, person p` is a join with no JOIN in
-// it. An index at or past the end means the statement stopped on the keyword and
-// the name is somewhere this gate cannot see.
+// names: one for most keywords, and every entry of the list for the ones that
+// introduce a list. An index at or past the end means the statement stopped on
+// the keyword and the name is somewhere this gate cannot see.
 func tableTargets(tokens []string, i int) []int {
 	keyword := strings.ToLower(tokens[i])
-	fromList := keyword == "from"
+	list := slices.Contains(listKeywords, keyword)
 	var targets []int
 	at := i + 1
 	for {
@@ -559,7 +570,7 @@ func tableTargets(tokens []string, i int) []int {
 			return targets
 		}
 		targets = append(targets, at)
-		if !fromList {
+		if !list {
 			return targets
 		}
 		next := skipAlias(tokens, at+1)

--- a/backend/extensionsqlscope_test.go
+++ b/backend/extensionsqlscope_test.go
@@ -34,6 +34,14 @@ package backendarch
 // computed is not judged at all, and a table name that is computed IS a finding
 // (name it with a string constant, and the gate can read it).
 //
+// The fold has no scopes, and the rules that make that safe are the two the
+// gate would otherwise be wrong under. A name resolves only when every binding
+// of it in the unit folds to the SAME text, so one function's `table :=
+// "person"` is never answered by another function's `table := "ext.…"`; and a
+// name bound even once to something unreadable resolves to nothing, so a value
+// the fold could read does not stand in for one it could not. Under both rules
+// the statement reads as computed — a finding — rather than as allowed.
+//
 // The allowlist is the unit's namespace, not a list of core tables: a table is
 // the unit's own when it is `ext.<namespace>_…` — derived through the same
 // extension.Name(…).Namespace() the migration gate and the unit's database role
@@ -41,6 +49,12 @@ package backendarch
 // and for the reason notes' own constant gives: the ext schema is on no
 // search_path the app connects with, so `ext_notes_note` unqualified is a public
 // table the unit does not own.
+//
+// WHAT IT CANNOT SEE, so that nobody reads more into a green run than it says: a
+// statement built by anything other than `+` over constants (a Sprintf whose
+// verb is the table, a strings.Builder, a query assembled in a loop) is read as
+// far as its literals go and no further. That is the same bound as the header's
+// first paragraph and the reason the wall is #628's, not this file's.
 
 import (
 	"fmt"
@@ -78,8 +92,11 @@ func TestExtensionSQLNamesOnlyTheUnitsOwnTables(t *testing.T) {
 		t.Fatal("no extension tree was found: this gate judges extensions/* and fixtures/extensions/*, and a run that enrols none certifies nothing")
 	}
 	judged := 0
-	for dir, unit := range trees {
-		scan := scanUnitSQL(t, unit, goSources(t, dir))
+	// Sorted, because two units each holding a finding must report in the same
+	// order twice: a merge gate whose output shuffles between runs is one a
+	// reader cannot diff.
+	for _, dir := range slices.Sorted(maps.Keys(trees)) {
+		scan := scanUnitSQL(t, trees[dir], goSources(t, dir))
 		judged += scan.tables
 		for _, finding := range scan.findings {
 			t.Error(finding)
@@ -113,9 +130,8 @@ func scanUnitSQL(t testing.TB, unit string, sources map[string]string) extSQLSca
 	prefix := namespace + "_"
 
 	fset := token.NewFileSet()
-	paths := slices.Sorted(maps.Keys(sources))
-	files := make([]*ast.File, 0, len(paths))
-	for _, path := range paths {
+	files := make([]*ast.File, 0, len(sources))
+	for _, path := range slices.Sorted(maps.Keys(sources)) {
 		file, parseErr := parser.ParseFile(fset, path, sources[path], 0)
 		if parseErr != nil {
 			t.Fatalf("%s does not parse, and a source this gate cannot read may hold the SQL it exists to judge: %v", path, parseErr)
@@ -144,13 +160,9 @@ func scanUnitSQL(t testing.TB, unit string, sources map[string]string) extSQLSca
 // declared them.
 func judgeTable(ref tableRef, unit, prefix string) string {
 	if !ref.readable {
-		return fmt.Sprintf("a statement names its table through something this gate cannot read (a call, a format verb, a runtime value): spell the table with a string constant, so the SQL the unit %s issues says which table it touches", unit)
+		return fmt.Sprintf("a statement names its table through something this gate cannot read (a call, a format verb, a name bound more than one way): spell the table with a string constant, so the SQL the unit %s issues says which table it touches", unit)
 	}
-	name := strings.ToLower(strings.Trim(ref.name, `"`))
-	schema, relation, qualified := strings.Cut(name, ".")
-	if !qualified {
-		schema, relation = "", name
-	}
+	schema, relation := splitQualified(ref.name)
 	switch {
 	case schema == "information_schema" || schema == "pg_catalog":
 		return "" // reading the catalog says nothing about another owner's rows
@@ -159,9 +171,42 @@ func judgeTable(ref tableRef, unit, prefix string) string {
 	case schema == extSchema && strings.HasPrefix(relation, prefix):
 		return ""
 	case schema == "" && strings.HasPrefix(relation, prefix):
-		return fmt.Sprintf("SQL names %q unqualified: the %s schema is on no search_path the app connects with, so this resolves to a public table the unit %s does not own — qualify it as %s.%s", name, extSchema, unit, extSchema, relation)
+		return fmt.Sprintf("SQL names %q unqualified: the %s schema is on no search_path the app connects with, so this resolves to a public table the unit %s does not own — qualify it as %s.%s", ref.name, extSchema, unit, extSchema, relation)
 	}
-	return fmt.Sprintf("SQL names %q: the unit %s addresses %s.%s… and nothing else, so this table is not its to read or write", name, unit, extSchema, prefix)
+	return fmt.Sprintf("SQL names %q: the unit %s addresses %s.%s… and nothing else, so this table is not its to read or write", ref.name, unit, extSchema, prefix)
+}
+
+// splitQualified reads a possibly-qualified name as (schema, relation), taking
+// the LAST two parts so that a database-qualified `db.public.person` is judged
+// on `public.person`. Quoting is stripped per part, because PostgreSQL quotes
+// each identifier separately — `"ext"."ext_notes_note"` is one reference — and
+// the result is lower-cased, which is what an unquoted identifier folds to.
+func splitQualified(name string) (schema, relation string) {
+	parts := identParts(name)
+	if len(parts) == 1 {
+		return "", parts[0]
+	}
+	return parts[len(parts)-2], parts[len(parts)-1]
+}
+
+// identParts splits a qualified name on the dots OUTSIDE quotes, so a quoted
+// identifier holding one ("a.b") stays whole.
+func identParts(name string) []string {
+	var parts []string
+	current := strings.Builder{}
+	quoted := false
+	for _, r := range name {
+		switch {
+		case r == '"':
+			quoted = !quoted
+		case r == '.' && !quoted:
+			parts = append(parts, strings.ToLower(current.String()))
+			current.Reset()
+		default:
+			current.WriteRune(r)
+		}
+	}
+	return append(parts, strings.ToLower(current.String()))
 }
 
 // goSources reads every .go file under dir, keyed by its slash-normalised path.
@@ -185,32 +230,70 @@ func goSources(t testing.TB, dir string) map[string]string {
 	return out
 }
 
+// stringBinding is one place a unit binds a name to a value — a const, a var,
+// or an assignment.
+type stringBinding struct {
+	name string
+	expr ast.Expr
+}
+
+// maxConstantPasses bounds the fold's fixed point. Each pass resolves one more
+// link of a constant built from constants, so the bound is the longest chain
+// this reader follows; past it the map is used as it stands, which can only
+// leave a name unresolved (and its SQL unread), never wrongly resolved.
+const maxConstantPasses = 8
+
 // stringConstants maps every name a unit binds to a constant string — package
 // consts, vars, and `:=` — so a statement spelled through them can be folded.
 //
-// Two passes, over the files in a fixed order, so a constant built from another
-// resolves whichever file declares it first. A name bound twice is read as its
-// last binding: a unit that spells one table two ways under one name is not a
-// shape this tree has, and reading the later one keeps the pass deterministic.
+// A name resolves only when EVERY binding of it in the unit folds to the same
+// text. Bind it twice to different strings, or once to something the fold
+// cannot read (a function call, another package's value), and the name resolves
+// to nothing at all: the SQL spelled through it then reads as computed, which is
+// a finding rather than a silent pass. That rule is what keeps one function's
+// `table := "person"` from being answered by another function's `table :=
+// "ext.ext_notes_note"` — the fold is name-keyed across the whole unit and has
+// no scopes of its own.
 func stringConstants(files []*ast.File) map[string]string {
+	all := make([]stringBinding, 0, 16)
+	for _, file := range files {
+		all = append(all, stringBindings(file)...)
+	}
 	consts := map[string]string{}
-	for range 2 {
-		for _, file := range files {
-			collectStringBindings(file, consts)
+	for range maxConstantPasses {
+		next := map[string]string{}
+		unreadable := map[string]bool{}
+		for _, binding := range all {
+			text, folded := foldString(binding.expr, consts)
+			prior, bound := next[binding.name]
+			switch {
+			case !folded, bound && prior != text:
+				unreadable[binding.name] = true
+			default:
+				next[binding.name] = text
+			}
 		}
+		for name := range unreadable {
+			delete(next, name)
+		}
+		if maps.Equal(next, consts) {
+			break
+		}
+		consts = next
 	}
 	return consts
 }
 
-func collectStringBindings(file *ast.File, consts map[string]string) {
+// stringBindings walks one file and reports every name it binds, in source
+// order. The blank identifier is skipped: it binds nothing a statement can name.
+func stringBindings(file *ast.File) []stringBinding {
+	var out []stringBinding
 	ast.Inspect(file, func(node ast.Node) bool {
 		switch decl := node.(type) {
 		case *ast.ValueSpec:
 			for i, name := range decl.Names {
-				if i < len(decl.Values) {
-					if text, ok := foldString(decl.Values[i], consts); ok {
-						consts[name.Name] = text
-					}
+				if i < len(decl.Values) && name.Name != "_" {
+					out = append(out, stringBinding{name: name.Name, expr: decl.Values[i]})
 				}
 			}
 		case *ast.AssignStmt:
@@ -218,20 +301,18 @@ func collectStringBindings(file *ast.File, consts map[string]string) {
 				return true
 			}
 			for i, target := range decl.Lhs {
-				name, ok := target.(*ast.Ident)
-				if !ok {
-					continue
-				}
-				if text, folded := foldString(decl.Rhs[i], consts); folded {
-					consts[name.Name] = text
+				if name, ok := target.(*ast.Ident); ok && name.Name != "_" {
+					out = append(out, stringBinding{name: name.Name, expr: decl.Rhs[i]})
 				}
 			}
 		}
 		return true
 	})
+	return out
 }
 
-// foldedSQL is one folded string the gate reads as a statement.
+// foldedSQL is one folded string the gate reads as a statement, already
+// stripped of the comments and literals a keyword can hide in.
 type foldedSQL struct {
 	text string
 	pos  token.Pos
@@ -248,12 +329,27 @@ func sqlStrings(file *ast.File, consts map[string]string) []foldedSQL {
 		if !isExpr {
 			return true
 		}
+		switch expr.(type) {
+		case *ast.BasicLit, *ast.BinaryExpr, *ast.ParenExpr:
+		default:
+			// A bare name is not a statement even when it resolves to one. The
+			// fold answers for a name so a concatenation can be read through it;
+			// judging the name on its own would report the statement again at
+			// its declaration, at every call that passes it, and at every
+			// comparison against it — three reports of one mistake, none of them
+			// where the SQL is written.
+			return true
+		}
 		text, folded := foldString(expr, consts)
 		if !folded {
 			return true
 		}
-		if looksLikeSQL(text) {
-			out = append(out, foldedSQL{text: text, pos: expr.Pos()})
+		// Stripped BEFORE the shape test, not after: a statement that opens with
+		// its own `-- why` comment is still a statement, and testing the raw text
+		// would read that comment as the first word and skip the query.
+		cleaned := sqlNoise.ReplaceAllString(text, " ")
+		if looksLikeSQL(cleaned) {
+			out = append(out, foldedSQL{text: cleaned, pos: expr.Pos()})
 		}
 		return false
 	})
@@ -337,25 +433,29 @@ type tableRef struct {
 }
 
 var (
-	// sqlNoise is what a table name cannot hide in and a keyword can falsely
-	// appear in: comments, and single-quoted literals ('' escaping included).
-	sqlNoise = regexp.MustCompile(`--[^\n]*|(?s)/\*.*?\*/|'(?:[^']|'')*'`)
+	// sqlNoise is what a keyword can falsely appear in and a table name cannot
+	// hide in: comments, single-quoted literals ('' escaping included), and
+	// dollar-quoted bodies. The dollar-quote pattern cannot pair a tag with its
+	// own closing tag (RE2 has no backreference), so it matches the nearest
+	// closing delimiter of the same SHAPE — which over-strips only a statement
+	// carrying two differently-tagged bodies, and under-strips nothing.
+	sqlNoise = regexp.MustCompile(`--[^\n]*|(?s)/\*.*?\*/|'(?:[^']|'')*'|(?s)\$[A-Za-z0-9_]*\$.*?\$[A-Za-z0-9_]*\$`)
 
-	// sqlToken splits a statement into quoted identifiers, bare identifiers
-	// (schema-qualified names held together by the dot), placeholders, and
-	// single characters for everything else.
-	sqlToken = regexp.MustCompile(`"[^"]*"|[A-Za-z_][A-Za-z0-9_$.]*|\$[0-9]+|\S`)
+	// sqlToken splits a statement into names (a dotted chain of bare or quoted
+	// identifiers, held together so `"ext"."ext_notes_note"` is one token),
+	// placeholders, and single characters for everything else.
+	sqlToken = regexp.MustCompile(`(?:"[^"]*"|[A-Za-z_][A-Za-z0-9_$]*)(?:\.(?:"[^"]*"|[A-Za-z_][A-Za-z0-9_$]*))*|\$[0-9]+|\S`)
 )
 
 // tableRefs returns every table the statement names.
 func tableRefs(sql string) []tableRef {
-	tokens := sqlToken.FindAllString(sqlNoise.ReplaceAllString(sql, " "), -1)
-	ctes := cteNames(tokens)
+	tokens := sqlToken.FindAllString(sql, -1)
+	ctes := cteScopes(tokens)
 	var refs []tableRef
 	var callStack []string
+	judged := map[int]bool{}
 	for i, raw := range tokens {
-		keyword := strings.ToLower(raw)
-		switch keyword {
+		switch raw {
 		case "(":
 			enclosing := ""
 			if i > 0 && isBareIdentifier(tokens[i-1]) {
@@ -372,11 +472,21 @@ func tableRefs(sql string) []tableRef {
 		if !opensTablePosition(tokens, i, callStack) {
 			continue
 		}
-		ref, judgeable := tableAfter(tokens, i+1, keyword)
-		if !judgeable || (ref.readable && ctes[strings.ToLower(ref.name)]) {
-			continue
+		for _, at := range tableTargets(tokens, i) {
+			// One index is judged once. `TRUNCATE TABLE t` reaches t twice —
+			// once past the qualifier TRUNCATE steps over, once from TABLE
+			// itself — and the same table counted twice would read as two
+			// findings for one mistake.
+			if judged[at] {
+				continue
+			}
+			judged[at] = true
+			ref := refAt(tokens, at)
+			if ref.readable && withinCTEScope(ctes, ref.name, at) {
+				continue
+			}
+			refs = append(refs, ref)
 		}
-		refs = append(refs, ref)
 	}
 	return refs
 }
@@ -386,9 +496,26 @@ func tableRefs(sql string) []tableRef {
 // SUBSTRING(s FROM 2), OVERLAY(s PLACING x FROM 2).
 var argumentSeparators = []string{"extract", "trim", "substring", "overlay"}
 
+// clauseWords end a table list. They are what tells `FROM a, b WHERE c` from
+// `FROM a, b` — an alias is any other word, so the list has to know where it
+// stops.
+var clauseWords = []string{
+	"where", "group", "having", "window", "order", "limit", "offset", "fetch",
+	"for", "union", "intersect", "except", "returning", "set", "values", "on",
+	"using", "join", "left", "right", "inner", "outer", "full", "cross",
+	"natural", "lateral", "select", "insert", "update", "delete", "with", "into",
+}
+
 // tableQualifiers stand between a keyword and the name it introduces —
-// `DELETE FROM ONLY t`, `JOIN LATERAL …`, `CREATE TABLE IF NOT EXISTS t`.
-var tableQualifiers = []string{"only", "lateral", "if", "not", "exists"}
+// `DELETE FROM ONLY t`, `JOIN LATERAL …`, `TRUNCATE TABLE t`,
+// `CREATE TABLE IF NOT EXISTS t`.
+var tableQualifiers = []string{"only", "lateral", "table", "if", "not", "exists"}
+
+// nonTableUpdatePrefixes are the words a clause's UPDATE follows: `FOR UPDATE`,
+// `FOR NO KEY UPDATE`, `ON CONFLICT … DO UPDATE`. Every other UPDATE names the
+// table it is about to rewrite — including the one in `WITH x AS (…) UPDATE t`,
+// which is why this is a denylist and not a list of positions UPDATE may open in.
+var nonTableUpdatePrefixes = []string{"for", "do", "key"}
 
 // opensTablePosition reports whether the token at i is a keyword the next token
 // names a table for.
@@ -400,66 +527,177 @@ func opensTablePosition(tokens []string, i int, callStack []string) bool {
 	switch strings.ToLower(tokens[i]) {
 	case "from":
 		return len(callStack) == 0 || !slices.Contains(argumentSeparators, callStack[len(callStack)-1])
-	case "join", "into", "table", "using":
+	case "join", "into", "table", "truncate", "using":
 		// USING carries two meanings and both are handled here: the table of a
 		// `DELETE … USING t` / `MERGE … USING t`, and the column list of a
-		// `JOIN … USING (a, b)`, which tableAfter drops on the opening paren.
+		// `JOIN … USING (a, b)`, which tableTargets drops on the opening paren.
 		return true
 	case "update":
-		// Only a statement's own opening UPDATE names a table. Every other
-		// spelling — `FOR UPDATE`, `FOR NO KEY UPDATE`, `ON CONFLICT DO UPDATE` —
-		// is a clause, and the words before it are not a table's.
-		return previous == "" || previous == ";" || previous == "("
+		return !slices.Contains(nonTableUpdatePrefixes, previous)
 	}
 	return false
 }
 
-// tableAfter reads the table a keyword introduces. It reports false when the
-// position holds something that is not a table at all (a subquery, a column
-// list, a set-returning function) and true when there is a reference to judge —
-// including one whose name it could not read.
-func tableAfter(tokens []string, i int, keyword string) (tableRef, bool) {
-	for i < len(tokens) && slices.Contains(tableQualifiers, strings.ToLower(tokens[i])) {
-		i++
+// tableTargets returns the token indices the keyword at i introduces as table
+// names: one for most keywords, and after FROM every entry of a comma-separated
+// list, because `FROM ext.ext_notes_note n, person p` is a join with no JOIN in
+// it. An index at or past the end means the statement stopped on the keyword and
+// the name is somewhere this gate cannot see.
+func tableTargets(tokens []string, i int) []int {
+	keyword := strings.ToLower(tokens[i])
+	fromList := keyword == "from"
+	var targets []int
+	at := i + 1
+	for {
+		for at < len(tokens) && slices.Contains(tableQualifiers, strings.ToLower(tokens[at])) {
+			at++
+		}
+		if at >= len(tokens) {
+			return append(targets, at)
+		}
+		if !namesATable(tokens, at, keyword) {
+			return targets
+		}
+		targets = append(targets, at)
+		if !fromList {
+			return targets
+		}
+		next := skipAlias(tokens, at+1)
+		if next >= len(tokens) || tokens[next] != "," {
+			return targets
+		}
+		at = next + 1
 	}
-	if i >= len(tokens) {
-		// A statement that ends on the keyword introducing its table: the name is
-		// somewhere this gate cannot see.
-		return tableRef{}, true
-	}
-	name := tokens[i]
-	if name == "(" {
-		return tableRef{}, false // a subquery, or the column list of a JOIN … USING (a, b)
-	}
-	if !isBareIdentifier(name) && !strings.HasPrefix(name, `"`) {
-		return tableRef{readable: false}, true
-	}
-	// A name applied to an argument list is a set-returning function, not a
-	// table — but only where one can stand: `INSERT INTO t (cols)` names a table
-	// and a column list, and `UPDATE t (…)` is not a spelling at all.
-	if (keyword == "from" || keyword == "join") && i+1 < len(tokens) && tokens[i+1] == "(" {
-		return tableRef{}, false
-	}
-	return tableRef{name: name, readable: true}, true
 }
 
-// cteNames collects the names a statement declares for itself: `WITH x AS (…)`,
-// including the MATERIALIZED spellings. A reference to one names no table.
-func cteNames(tokens []string) map[string]bool {
-	names := map[string]bool{}
+// namesATable reports whether the token at i can be a table name at all. A `(`
+// opens a subquery or a column list. A name applied to an argument list is a
+// set-returning function — but only where one can stand: `INSERT INTO t (cols)`
+// names a table and its columns, and `CREATE TABLE t (…)` a table and its
+// definition. A token that is neither a paren nor a name IS judged, as a
+// reference whose name could not be read.
+func namesATable(tokens []string, i int, keyword string) bool {
+	if tokens[i] == "(" {
+		return false
+	}
+	if keyword != "from" && keyword != "join" {
+		return true
+	}
+	return !isName(tokens[i]) || i+1 >= len(tokens) || tokens[i+1] != "("
+}
+
+// refAt classifies the token at i as the table reference it holds.
+func refAt(tokens []string, i int) tableRef {
+	if i >= len(tokens) || !isName(tokens[i]) {
+		return tableRef{}
+	}
+	return tableRef{name: tokens[i], readable: true}
+}
+
+// skipAlias steps over the alias a table may carry — `t x`, `t AS x`, and the
+// column list either spelling may take — and returns where the entry ends. A
+// clause word is never an alias: it is what the list stops at.
+func skipAlias(tokens []string, i int) int {
+	if i < len(tokens) && strings.EqualFold(tokens[i], "as") {
+		i++
+	}
+	if i < len(tokens) && isName(tokens[i]) && !slices.Contains(clauseWords, strings.ToLower(tokens[i])) {
+		i++
+	}
+	if i < len(tokens) && tokens[i] == "(" {
+		i = matchingParen(tokens, i) + 1
+	}
+	return i
+}
+
+// cteScope is the token span of one WITH-declared name's body.
+type cteScope struct {
+	start, end int
+	recursive  bool
+}
+
+// cteScopes collects the names a statement declares for itself: `WITH x AS (…)`,
+// including the MATERIALIZED spellings and a column list (`WITH x(id) AS (…)`).
+//
+// The BODY is recorded, not just the name, because a CTE shadows a real table
+// only where it is in scope: in `WITH person AS (SELECT id FROM person)` the
+// inner name still reads the core table, and exempting it everywhere would hand
+// a unit a one-line way past this gate. A RECURSIVE WITH is the exception —
+// there the body legitimately names the CTE itself.
+func cteScopes(tokens []string) map[string]cteScope {
+	recursive := false
 	for i, raw := range tokens {
-		if !strings.EqualFold(raw, "as") || i == 0 || !isBareIdentifier(tokens[i-1]) {
-			continue
-		}
-		next := i + 1
-		for next < len(tokens) && (strings.EqualFold(tokens[next], "materialized") || strings.EqualFold(tokens[next], "not")) {
-			next++
-		}
-		if next < len(tokens) && tokens[next] == "(" {
-			names[strings.ToLower(tokens[i-1])] = true
+		if strings.EqualFold(raw, "with") && i+1 < len(tokens) && strings.EqualFold(tokens[i+1], "recursive") {
+			recursive = true
 		}
 	}
-	return names
+	scopes := map[string]cteScope{}
+	for i, raw := range tokens {
+		if !strings.EqualFold(raw, "as") || i == 0 {
+			continue
+		}
+		name := i - 1
+		if tokens[name] == ")" {
+			name = matchingOpen(tokens, name) - 1 // a column list: WITH x(id) AS (…)
+		}
+		if name < 0 || !isBareIdentifier(tokens[name]) {
+			continue
+		}
+		body := i + 1
+		for body < len(tokens) && (strings.EqualFold(tokens[body], "materialized") || strings.EqualFold(tokens[body], "not")) {
+			body++
+		}
+		if body < len(tokens) && tokens[body] == "(" {
+			scopes[strings.ToLower(tokens[name])] = cteScope{start: body, end: matchingParen(tokens, body), recursive: recursive}
+		}
+	}
+	return scopes
+}
+
+// withinCTEScope reports whether the reference at index at reads a CTE rather
+// than a table: anywhere for a recursive WITH, and after the body otherwise.
+func withinCTEScope(scopes map[string]cteScope, name string, at int) bool {
+	scope, declared := scopes[strings.ToLower(strings.Trim(name, `"`))]
+	return declared && (scope.recursive || at > scope.end)
+}
+
+// matchingParen returns the index of the ")" closing the "(" at open, or the
+// last token when the statement never closes it.
+func matchingParen(tokens []string, open int) int {
+	depth := 0
+	for i := open; i < len(tokens); i++ {
+		switch tokens[i] {
+		case "(":
+			depth++
+		case ")":
+			if depth--; depth == 0 {
+				return i
+			}
+		}
+	}
+	return len(tokens) - 1
+}
+
+// matchingOpen is matchingParen read backwards, from a ")" to its "(".
+func matchingOpen(tokens []string, closing int) int {
+	depth := 0
+	for i := closing; i >= 0; i-- {
+		switch tokens[i] {
+		case ")":
+			depth++
+		case "(":
+			if depth--; depth == 0 {
+				return i
+			}
+		}
+	}
+	return 0
+}
+
+// isName reports whether the token can be an identifier — bare, quoted, or a
+// dotted chain of either.
+func isName(token string) bool {
+	return isBareIdentifier(token) || strings.HasPrefix(token, `"`)
 }
 
 func isBareIdentifier(token string) bool {
@@ -468,164 +706,4 @@ func isBareIdentifier(token string) bool {
 	}
 	first := token[0]
 	return first == '_' || (first >= 'a' && first <= 'z') || (first >= 'A' && first <= 'Z')
-}
-
-// probeUnit is the synthetic unit the gate's own test is written against. Its
-// namespace is ext_probe, so ext.ext_probe_note is its table and everything else
-// in the cases below is somebody's else's.
-const probeUnit = "probe"
-
-// extSQLGateCase is one source the gate must judge a particular way. want is the
-// text the refusal has to carry, or "" when the source must be accepted.
-type extSQLGateCase struct {
-	name   string
-	body   string
-	want   string
-	tables int // table references the gate is expected to have read
-}
-
-// extSQLGateCases exercise the gate against a unit it can refuse. The real tree
-// is supposed to pass, so a gate proven only by "extensions/ is currently clean"
-// is one that keeps passing after it stops working — and this one has a second
-// way to read green that a clean tree hides completely: seeing no SQL at all.
-// Every accepted case therefore also pins how many table references were READ.
-var extSQLGateCases = []extSQLGateCase{
-	{
-		name:   "a core table named inline",
-		body:   `tx.Exec(ctx, "SELECT id FROM person WHERE id = $1")`,
-		want:   `"person": the unit probe addresses ext.ext_probe_…`,
-		tables: 1,
-	},
-	{
-		name:   "a core table named through the public schema",
-		body:   `tx.Exec(ctx, "DELETE FROM public.person WHERE id = $1")`,
-		want:   `"public.person"`,
-		tables: 1,
-	},
-	{
-		name: "a core table reached through a constant",
-		body: `tx.Exec(ctx, "SELECT id FROM "+subject+" WHERE id = $1")`,
-		// The spelling the one unit shipping SQL uses for its OWN table. A gate
-		// blind to the concatenation reads the whole tier green.
-		want:   `"person"`,
-		tables: 1,
-	},
-	{
-		name:   "another unit's table",
-		body:   `tx.Exec(ctx, "SELECT body FROM ext.ext_notes_note LIMIT 1")`,
-		want:   `"ext.ext_notes_note": the unit probe addresses`,
-		tables: 1,
-	},
-	{
-		name:   "a core table joined onto the unit's own",
-		body:   `tx.Exec(ctx, "SELECT n.id FROM ext.ext_probe_note n JOIN person p ON p.id = n.subject_id")`,
-		want:   `"person"`,
-		tables: 2,
-	},
-	{
-		name:   "a core table reached around a DELETE … USING",
-		body:   `tx.Exec(ctx, "DELETE FROM ext.ext_probe_note USING person WHERE person.id = ext_probe_note.subject_id")`,
-		want:   `"person"`,
-		tables: 2,
-	},
-	{
-		name:   "a core table written by an INSERT",
-		body:   `tx.Exec(ctx, "INSERT INTO activity (kind, subject_id) VALUES ($1, $2)")`,
-		want:   `"activity"`,
-		tables: 1,
-	},
-	{
-		name:   "a core table rewritten by an UPDATE",
-		body:   `tx.Exec(ctx, "UPDATE person SET full_name = $1 WHERE id = $2")`,
-		want:   `"person"`,
-		tables: 1,
-	},
-	{
-		name:   "the unit's own table left unqualified",
-		body:   `tx.Exec(ctx, "SELECT id FROM ext_probe_note LIMIT 1")`,
-		want:   "the ext schema is on no search_path",
-		tables: 1,
-	},
-	{
-		name:   "a scratch table created over a core name",
-		body:   `tx.Exec(ctx, "CREATE TABLE IF NOT EXISTS person (id uuid)")`,
-		want:   `"person"`,
-		tables: 1,
-	},
-	{
-		name:   "a table name assembled at runtime",
-		body:   `tx.Exec(ctx, fmt.Sprintf("SELECT id FROM %s LIMIT 1", subject))`,
-		want:   "this gate cannot read",
-		tables: 1,
-	},
-	{
-		name:   "the unit's own table, schema-qualified through a constant",
-		body:   `tx.Exec(ctx, "SELECT id FROM "+noteTable+" ORDER BY id LIMIT 1")`,
-		tables: 1,
-	},
-	{
-		name:   "a CTE the same statement declares",
-		body:   `tx.Exec(ctx, "WITH stale AS (SELECT id FROM "+noteTable+" ORDER BY id DESC OFFSET 50) DELETE FROM "+noteTable+" WHERE id IN (SELECT id FROM stale)")`,
-		tables: 2,
-	},
-	{
-		name:   "a catalog read",
-		body:   `tx.Exec(ctx, "SELECT column_name FROM information_schema.columns WHERE table_name = $1")`,
-		tables: 1,
-	},
-	{
-		name:   "EXTRACT's argument separator",
-		body:   `tx.Exec(ctx, "SELECT extract(epoch FROM created_at) FROM "+noteTable)`,
-		tables: 1,
-	},
-	{
-		name:   "a row lock and an upsert clause",
-		body:   `tx.Exec(ctx, "INSERT INTO "+noteTable+" (id) VALUES ($1) ON CONFLICT (id) DO UPDATE SET body = $2 RETURNING (SELECT body FROM "+noteTable+" WHERE id = $1 FOR UPDATE)")`,
-		tables: 2,
-	},
-	{
-		name:   "a set-returning function and a USING column list",
-		body:   `tx.Exec(ctx, "SELECT n.id FROM "+noteTable+" n JOIN unnest($1::uuid[]) AS wanted(id) USING (id)")`,
-		tables: 1,
-	},
-	{
-		name:   "prose that merely reads like SQL",
-		body:   `_ = "hello from the demo extension"; _ = "update the note, then select the row"`,
-		tables: 0,
-	},
-}
-
-// TestExtensionSQLScopeRefusesWhatItMust drives the gate with sources the real
-// tree does not contain.
-func TestExtensionSQLScopeRefusesWhatItMust(t *testing.T) {
-	for _, probe := range extSQLGateCases {
-		t.Run(probe.name, func(t *testing.T) {
-			scan := scanUnitSQL(t, probeUnit, map[string]string{"probe.go": probeSource(probe.body)})
-			if probe.tables != scan.tables {
-				t.Errorf("the gate read %d table reference(s), want %d — a case whose SQL the reader never saw proves nothing about the verdict below", scan.tables, probe.tables)
-			}
-			switch {
-			case probe.want == "" && len(scan.findings) > 0:
-				t.Errorf("the gate refused what it must accept: %s", strings.Join(scan.findings, "; "))
-			case probe.want == "":
-			case len(scan.findings) != 1:
-				t.Errorf("the gate returned %d finding(s), want the one refusing %q: %s", len(scan.findings), probe.want, strings.Join(scan.findings, "; "))
-			case !strings.Contains(scan.findings[0], probe.want):
-				t.Errorf("the gate refused the source but the reason does not mention %q: %s", probe.want, scan.findings[0])
-			}
-		})
-	}
-}
-
-// probeSource wraps a case body in a compilable unit whose constants are the
-// two a real unit declares: its own table, and — for the cases that reach past
-// it — a core one.
-func probeSource(body string) string {
-	return `package probe
-
-const noteTable = "ext.ext_probe_note"
-const subject = "person"
-
-func run(ctx context.Context, tx Tx) { ` + body + ` }
-`
 }

--- a/backend/extensionsqlscope_test.go
+++ b/backend/extensionsqlscope_test.go
@@ -1,0 +1,631 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package backendarch
+
+// A unit's SQL addresses the unit's own tables.
+//
+// The extension runtime hands a unit a workspace-pinned transaction on the
+// SHARED application role, so its SQL can name any table that role can reach.
+// pkg/extension/runtime.go says so in the open, under "WHAT IS NOT WALLED AT
+// ALL": core's tables, another unit's tables, extension_secret. The fix for the
+// wall itself is a per-unit database role (#628), and this is not it.
+//
+// WHAT THIS IS: defence against mistakes, and nothing else. It reads the SQL a
+// unit's source spells out and refuses a table that is not the unit's own,
+// which is worth doing BEFORE a unit grows the habit — no shipped unit names a
+// core table today, so the narrowing costs nothing now and costs a rewrite
+// later. A unit is trusted in-process code either way, and a table name the
+// source does not spell out defeats a static reader by construction. Read it as
+// a lint; the boundary is #628's.
+//
+// WHAT IT READS. Every .go file a unit ships, tests included: a unit's test that
+// seeds a core table is the same mistake as its handler doing so, and it is
+// where the habit would start. String CONSTANTS are folded first, because the
+// one unit shipping SQL today spells every table through one — `"SELECT " +
+// noteColumns + " FROM " + noteTable` is what a real statement looks like here,
+// and a gate that cannot see through the concatenation would read green over
+// the only SQL in the tree.
+//
+// A folded string is judged when it OPENS as a statement (`SELECT … FROM …`,
+// `INSERT … INTO …`), so that prose which merely contains a keyword — "hello
+// from the demo extension" — is not read as a query. Two consequences worth
+// stating rather than discovering: a statement whose opening fragment is itself
+// computed is not judged at all, and a table name that is computed IS a finding
+// (name it with a string constant, and the gate can read it).
+//
+// The allowlist is the unit's namespace, not a list of core tables: a table is
+// the unit's own when it is `ext.<namespace>_…` — derived through the same
+// extension.Name(…).Namespace() the migration gate and the unit's database role
+// come from, so the three cannot drift. A bare, unqualified name is refused too,
+// and for the reason notes' own constant gives: the ext schema is on no
+// search_path the app connects with, so `ext_notes_note` unqualified is a public
+// table the unit does not own.
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"maps"
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/pkg/extension"
+)
+
+// extSchema is the one schema an extension's tables live in (ADR-0069 §9); the
+// migration gate refuses a unit relation anywhere else.
+const extSchema = "ext"
+
+// computedFragment stands in for a fragment the fold cannot read — a function
+// call, a parameter, a `%s`. It is deliberately not identifier-shaped, so it
+// tokenises on its own and a name it is glued to (`"public." + t`) still reads
+// as the schema-qualified reference it is.
+const computedFragment = "?"
+
+// TestExtensionSQLNamesOnlyTheUnitsOwnTables reads every unit's SQL and refuses
+// a table outside the unit's namespace.
+func TestExtensionSQLNamesOnlyTheUnitsOwnTables(t *testing.T) {
+	trees := extensionTrees(t)
+	if len(trees) == 0 {
+		t.Fatal("no extension tree was found: this gate judges extensions/* and fixtures/extensions/*, and a run that enrols none certifies nothing")
+	}
+	judged := 0
+	for dir, unit := range trees {
+		scan := scanUnitSQL(t, unit, goSources(t, dir))
+		judged += scan.tables
+		for _, finding := range scan.findings {
+			t.Error(finding)
+		}
+	}
+	// The anti-vacuity check. Every refusal above is a statement about SQL the
+	// gate read; if it read none, the run says nothing at all and says it in the
+	// same green.
+	if judged == 0 {
+		t.Error("the gate judged no table reference in any unit: either the tier stopped issuing SQL (in which case this gate is vacuous and should be retired with the runtime seam) or the reader stopped seeing it")
+	}
+}
+
+// extSQLScan is one unit's result: how many table references were read, and
+// what was refused. The count is what separates a clean unit from an unread one.
+type extSQLScan struct {
+	tables   int
+	findings []string
+}
+
+// scanUnitSQL parses one unit's sources (path → source text) and judges every
+// table its SQL names. Sources are passed in rather than read here so the gate's
+// own test can drive it with a synthetic unit — a fixture tree that named a core
+// table would have to fail this very gate to prove anything.
+func scanUnitSQL(t testing.TB, unit string, sources map[string]string) extSQLScan {
+	t.Helper()
+	namespace, err := extension.Name(unit).Namespace()
+	if err != nil {
+		t.Fatalf("unit %q has no SQL namespace, so nothing can be judged against it: %v", unit, err)
+	}
+	prefix := namespace + "_"
+
+	fset := token.NewFileSet()
+	paths := slices.Sorted(maps.Keys(sources))
+	files := make([]*ast.File, 0, len(paths))
+	for _, path := range paths {
+		file, parseErr := parser.ParseFile(fset, path, sources[path], 0)
+		if parseErr != nil {
+			t.Fatalf("%s does not parse, and a source this gate cannot read may hold the SQL it exists to judge: %v", path, parseErr)
+		}
+		files = append(files, file)
+	}
+
+	consts := stringConstants(files)
+	scan := extSQLScan{}
+	for _, file := range files {
+		for _, stmt := range sqlStrings(file, consts) {
+			for _, ref := range tableRefs(stmt.text) {
+				scan.tables++
+				if refused := judgeTable(ref, unit, prefix); refused != "" {
+					scan.findings = append(scan.findings, fmt.Sprintf("%s: %s", fset.Position(stmt.pos), refused))
+				}
+			}
+		}
+	}
+	return scan
+}
+
+// judgeTable returns the refusal a reference earns, or "" when the name is the
+// unit's own — schema-qualified under its namespace — or a catalog read. A CTE
+// never reaches here: tableRefs resolves those against the statement that
+// declared them.
+func judgeTable(ref tableRef, unit, prefix string) string {
+	if !ref.readable {
+		return fmt.Sprintf("a statement names its table through something this gate cannot read (a call, a format verb, a runtime value): spell the table with a string constant, so the SQL the unit %s issues says which table it touches", unit)
+	}
+	name := strings.ToLower(strings.Trim(ref.name, `"`))
+	schema, relation, qualified := strings.Cut(name, ".")
+	if !qualified {
+		schema, relation = "", name
+	}
+	switch {
+	case schema == "information_schema" || schema == "pg_catalog":
+		return "" // reading the catalog says nothing about another owner's rows
+	case schema == "" && strings.HasPrefix(relation, "pg_"):
+		return ""
+	case schema == extSchema && strings.HasPrefix(relation, prefix):
+		return ""
+	case schema == "" && strings.HasPrefix(relation, prefix):
+		return fmt.Sprintf("SQL names %q unqualified: the %s schema is on no search_path the app connects with, so this resolves to a public table the unit %s does not own — qualify it as %s.%s", name, extSchema, unit, extSchema, relation)
+	}
+	return fmt.Sprintf("SQL names %q: the unit %s addresses %s.%s… and nothing else, so this table is not its to read or write", name, unit, extSchema, prefix)
+}
+
+// goSources reads every .go file under dir, keyed by its slash-normalised path.
+func goSources(t testing.TB, dir string) map[string]string {
+	t.Helper()
+	out := map[string]string{}
+	err := filepath.WalkDir(dir, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil || entry.IsDir() || !strings.HasSuffix(path, ".go") {
+			return walkErr
+		}
+		src, readErr := os.ReadFile(path) // #nosec G304 -- path from walking the trusted source tree
+		if readErr != nil {
+			return readErr
+		}
+		out[filepath.ToSlash(path)] = string(src)
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return out
+}
+
+// stringConstants maps every name a unit binds to a constant string — package
+// consts, vars, and `:=` — so a statement spelled through them can be folded.
+//
+// Two passes, over the files in a fixed order, so a constant built from another
+// resolves whichever file declares it first. A name bound twice is read as its
+// last binding: a unit that spells one table two ways under one name is not a
+// shape this tree has, and reading the later one keeps the pass deterministic.
+func stringConstants(files []*ast.File) map[string]string {
+	consts := map[string]string{}
+	for range 2 {
+		for _, file := range files {
+			collectStringBindings(file, consts)
+		}
+	}
+	return consts
+}
+
+func collectStringBindings(file *ast.File, consts map[string]string) {
+	ast.Inspect(file, func(node ast.Node) bool {
+		switch decl := node.(type) {
+		case *ast.ValueSpec:
+			for i, name := range decl.Names {
+				if i < len(decl.Values) {
+					if text, ok := foldString(decl.Values[i], consts); ok {
+						consts[name.Name] = text
+					}
+				}
+			}
+		case *ast.AssignStmt:
+			if len(decl.Lhs) != len(decl.Rhs) {
+				return true
+			}
+			for i, target := range decl.Lhs {
+				name, ok := target.(*ast.Ident)
+				if !ok {
+					continue
+				}
+				if text, folded := foldString(decl.Rhs[i], consts); folded {
+					consts[name.Name] = text
+				}
+			}
+		}
+		return true
+	})
+}
+
+// foldedSQL is one folded string the gate reads as a statement.
+type foldedSQL struct {
+	text string
+	pos  token.Pos
+}
+
+// sqlStrings folds every string expression in the file and keeps the ones that
+// open as a statement. A folded expression is consumed whole — the walk does not
+// descend into it — so a concatenation is judged once rather than fragment by
+// fragment.
+func sqlStrings(file *ast.File, consts map[string]string) []foldedSQL {
+	var out []foldedSQL
+	ast.Inspect(file, func(node ast.Node) bool {
+		expr, isExpr := node.(ast.Expr)
+		if !isExpr {
+			return true
+		}
+		text, folded := foldString(expr, consts)
+		if !folded {
+			return true
+		}
+		if looksLikeSQL(text) {
+			out = append(out, foldedSQL{text: text, pos: expr.Pos()})
+		}
+		return false
+	})
+	return out
+}
+
+// foldString reads a string expression as the text it produces, standing
+// computedFragment in for every part it cannot resolve. It reports false when
+// the expression is not a string at all, which is what keeps the walk descending
+// into a call's arguments.
+func foldString(expr ast.Expr, consts map[string]string) (string, bool) {
+	switch node := expr.(type) {
+	case *ast.BasicLit:
+		if node.Kind != token.STRING {
+			return "", false
+		}
+		text, err := strconv.Unquote(node.Value)
+		if err != nil {
+			// A STRING literal the parser accepted and strconv cannot decode is
+			// not a shape Go admits; treating it as unreadable keeps the fold
+			// total without inventing text for it.
+			return computedFragment, true
+		}
+		return text, true
+	case *ast.ParenExpr:
+		return foldString(node.X, consts)
+	case *ast.Ident:
+		if text, known := consts[node.Name]; known {
+			return text, true
+		}
+		return computedFragment, false
+	case *ast.BinaryExpr:
+		if node.Op != token.ADD {
+			return "", false
+		}
+		left, leftIsString := foldString(node.X, consts)
+		right, rightIsString := foldString(node.Y, consts)
+		if !leftIsString && !rightIsString {
+			return "", false
+		}
+		return left + right, true
+	}
+	return computedFragment, false
+}
+
+// sqlStatementShapes are the openings a folded string must have to be read as
+// SQL, each with the word that separates a statement from a sentence that
+// happens to start the same way. "update the note" is prose; `UPDATE … SET …`
+// is not.
+var sqlStatementShapes = []struct{ opener, companion string }{
+	{"select", " from "},
+	{"insert", " into "},
+	{"update", " set "},
+	{"delete", " from "},
+	{"with", " as "},
+	{"merge", " into "},
+	{"create", " table "},
+	{"alter", " table "},
+	{"drop", " table "},
+	{"truncate", ""},
+}
+
+func looksLikeSQL(text string) bool {
+	normalised := " " + strings.ToLower(strings.Join(strings.Fields(text), " ")) + " "
+	for _, shape := range sqlStatementShapes {
+		if !strings.HasPrefix(normalised, " "+shape.opener+" ") {
+			continue
+		}
+		if shape.companion == "" || strings.Contains(normalised, shape.companion) {
+			return true
+		}
+	}
+	return false
+}
+
+// tableRef is one table position in a statement: the name it holds, or the fact
+// that the name could not be read.
+type tableRef struct {
+	name     string
+	readable bool
+}
+
+var (
+	// sqlNoise is what a table name cannot hide in and a keyword can falsely
+	// appear in: comments, and single-quoted literals ('' escaping included).
+	sqlNoise = regexp.MustCompile(`--[^\n]*|(?s)/\*.*?\*/|'(?:[^']|'')*'`)
+
+	// sqlToken splits a statement into quoted identifiers, bare identifiers
+	// (schema-qualified names held together by the dot), placeholders, and
+	// single characters for everything else.
+	sqlToken = regexp.MustCompile(`"[^"]*"|[A-Za-z_][A-Za-z0-9_$.]*|\$[0-9]+|\S`)
+)
+
+// tableRefs returns every table the statement names.
+func tableRefs(sql string) []tableRef {
+	tokens := sqlToken.FindAllString(sqlNoise.ReplaceAllString(sql, " "), -1)
+	ctes := cteNames(tokens)
+	var refs []tableRef
+	var callStack []string
+	for i, raw := range tokens {
+		keyword := strings.ToLower(raw)
+		switch keyword {
+		case "(":
+			enclosing := ""
+			if i > 0 && isBareIdentifier(tokens[i-1]) {
+				enclosing = strings.ToLower(tokens[i-1])
+			}
+			callStack = append(callStack, enclosing)
+			continue
+		case ")":
+			if len(callStack) > 0 {
+				callStack = callStack[:len(callStack)-1]
+			}
+			continue
+		}
+		if !opensTablePosition(tokens, i, callStack) {
+			continue
+		}
+		ref, judgeable := tableAfter(tokens, i+1, keyword)
+		if !judgeable || (ref.readable && ctes[strings.ToLower(ref.name)]) {
+			continue
+		}
+		refs = append(refs, ref)
+	}
+	return refs
+}
+
+// argumentSeparators are the functions whose FROM separates arguments rather
+// than naming a table: EXTRACT(epoch FROM ts), TRIM(both FROM s),
+// SUBSTRING(s FROM 2), OVERLAY(s PLACING x FROM 2).
+var argumentSeparators = []string{"extract", "trim", "substring", "overlay"}
+
+// tableQualifiers stand between a keyword and the name it introduces —
+// `DELETE FROM ONLY t`, `JOIN LATERAL …`, `CREATE TABLE IF NOT EXISTS t`.
+var tableQualifiers = []string{"only", "lateral", "if", "not", "exists"}
+
+// opensTablePosition reports whether the token at i is a keyword the next token
+// names a table for.
+func opensTablePosition(tokens []string, i int, callStack []string) bool {
+	previous := ""
+	if i > 0 {
+		previous = strings.ToLower(tokens[i-1])
+	}
+	switch strings.ToLower(tokens[i]) {
+	case "from":
+		return len(callStack) == 0 || !slices.Contains(argumentSeparators, callStack[len(callStack)-1])
+	case "join", "into", "table", "using":
+		// USING carries two meanings and both are handled here: the table of a
+		// `DELETE … USING t` / `MERGE … USING t`, and the column list of a
+		// `JOIN … USING (a, b)`, which tableAfter drops on the opening paren.
+		return true
+	case "update":
+		// Only a statement's own opening UPDATE names a table. Every other
+		// spelling — `FOR UPDATE`, `FOR NO KEY UPDATE`, `ON CONFLICT DO UPDATE` —
+		// is a clause, and the words before it are not a table's.
+		return previous == "" || previous == ";" || previous == "("
+	}
+	return false
+}
+
+// tableAfter reads the table a keyword introduces. It reports false when the
+// position holds something that is not a table at all (a subquery, a column
+// list, a set-returning function) and true when there is a reference to judge —
+// including one whose name it could not read.
+func tableAfter(tokens []string, i int, keyword string) (tableRef, bool) {
+	for i < len(tokens) && slices.Contains(tableQualifiers, strings.ToLower(tokens[i])) {
+		i++
+	}
+	if i >= len(tokens) {
+		// A statement that ends on the keyword introducing its table: the name is
+		// somewhere this gate cannot see.
+		return tableRef{}, true
+	}
+	name := tokens[i]
+	if name == "(" {
+		return tableRef{}, false // a subquery, or the column list of a JOIN … USING (a, b)
+	}
+	if !isBareIdentifier(name) && !strings.HasPrefix(name, `"`) {
+		return tableRef{readable: false}, true
+	}
+	// A name applied to an argument list is a set-returning function, not a
+	// table — but only where one can stand: `INSERT INTO t (cols)` names a table
+	// and a column list, and `UPDATE t (…)` is not a spelling at all.
+	if (keyword == "from" || keyword == "join") && i+1 < len(tokens) && tokens[i+1] == "(" {
+		return tableRef{}, false
+	}
+	return tableRef{name: name, readable: true}, true
+}
+
+// cteNames collects the names a statement declares for itself: `WITH x AS (…)`,
+// including the MATERIALIZED spellings. A reference to one names no table.
+func cteNames(tokens []string) map[string]bool {
+	names := map[string]bool{}
+	for i, raw := range tokens {
+		if !strings.EqualFold(raw, "as") || i == 0 || !isBareIdentifier(tokens[i-1]) {
+			continue
+		}
+		next := i + 1
+		for next < len(tokens) && (strings.EqualFold(tokens[next], "materialized") || strings.EqualFold(tokens[next], "not")) {
+			next++
+		}
+		if next < len(tokens) && tokens[next] == "(" {
+			names[strings.ToLower(tokens[i-1])] = true
+		}
+	}
+	return names
+}
+
+func isBareIdentifier(token string) bool {
+	if token == "" {
+		return false
+	}
+	first := token[0]
+	return first == '_' || (first >= 'a' && first <= 'z') || (first >= 'A' && first <= 'Z')
+}
+
+// probeUnit is the synthetic unit the gate's own test is written against. Its
+// namespace is ext_probe, so ext.ext_probe_note is its table and everything else
+// in the cases below is somebody's else's.
+const probeUnit = "probe"
+
+// extSQLGateCase is one source the gate must judge a particular way. want is the
+// text the refusal has to carry, or "" when the source must be accepted.
+type extSQLGateCase struct {
+	name   string
+	body   string
+	want   string
+	tables int // table references the gate is expected to have read
+}
+
+// extSQLGateCases exercise the gate against a unit it can refuse. The real tree
+// is supposed to pass, so a gate proven only by "extensions/ is currently clean"
+// is one that keeps passing after it stops working — and this one has a second
+// way to read green that a clean tree hides completely: seeing no SQL at all.
+// Every accepted case therefore also pins how many table references were READ.
+var extSQLGateCases = []extSQLGateCase{
+	{
+		name:   "a core table named inline",
+		body:   `tx.Exec(ctx, "SELECT id FROM person WHERE id = $1")`,
+		want:   `"person": the unit probe addresses ext.ext_probe_…`,
+		tables: 1,
+	},
+	{
+		name:   "a core table named through the public schema",
+		body:   `tx.Exec(ctx, "DELETE FROM public.person WHERE id = $1")`,
+		want:   `"public.person"`,
+		tables: 1,
+	},
+	{
+		name: "a core table reached through a constant",
+		body: `tx.Exec(ctx, "SELECT id FROM "+subject+" WHERE id = $1")`,
+		// The spelling the one unit shipping SQL uses for its OWN table. A gate
+		// blind to the concatenation reads the whole tier green.
+		want:   `"person"`,
+		tables: 1,
+	},
+	{
+		name:   "another unit's table",
+		body:   `tx.Exec(ctx, "SELECT body FROM ext.ext_notes_note LIMIT 1")`,
+		want:   `"ext.ext_notes_note": the unit probe addresses`,
+		tables: 1,
+	},
+	{
+		name:   "a core table joined onto the unit's own",
+		body:   `tx.Exec(ctx, "SELECT n.id FROM ext.ext_probe_note n JOIN person p ON p.id = n.subject_id")`,
+		want:   `"person"`,
+		tables: 2,
+	},
+	{
+		name:   "a core table reached around a DELETE … USING",
+		body:   `tx.Exec(ctx, "DELETE FROM ext.ext_probe_note USING person WHERE person.id = ext_probe_note.subject_id")`,
+		want:   `"person"`,
+		tables: 2,
+	},
+	{
+		name:   "a core table written by an INSERT",
+		body:   `tx.Exec(ctx, "INSERT INTO activity (kind, subject_id) VALUES ($1, $2)")`,
+		want:   `"activity"`,
+		tables: 1,
+	},
+	{
+		name:   "a core table rewritten by an UPDATE",
+		body:   `tx.Exec(ctx, "UPDATE person SET full_name = $1 WHERE id = $2")`,
+		want:   `"person"`,
+		tables: 1,
+	},
+	{
+		name:   "the unit's own table left unqualified",
+		body:   `tx.Exec(ctx, "SELECT id FROM ext_probe_note LIMIT 1")`,
+		want:   "the ext schema is on no search_path",
+		tables: 1,
+	},
+	{
+		name:   "a scratch table created over a core name",
+		body:   `tx.Exec(ctx, "CREATE TABLE IF NOT EXISTS person (id uuid)")`,
+		want:   `"person"`,
+		tables: 1,
+	},
+	{
+		name:   "a table name assembled at runtime",
+		body:   `tx.Exec(ctx, fmt.Sprintf("SELECT id FROM %s LIMIT 1", subject))`,
+		want:   "this gate cannot read",
+		tables: 1,
+	},
+	{
+		name:   "the unit's own table, schema-qualified through a constant",
+		body:   `tx.Exec(ctx, "SELECT id FROM "+noteTable+" ORDER BY id LIMIT 1")`,
+		tables: 1,
+	},
+	{
+		name:   "a CTE the same statement declares",
+		body:   `tx.Exec(ctx, "WITH stale AS (SELECT id FROM "+noteTable+" ORDER BY id DESC OFFSET 50) DELETE FROM "+noteTable+" WHERE id IN (SELECT id FROM stale)")`,
+		tables: 2,
+	},
+	{
+		name:   "a catalog read",
+		body:   `tx.Exec(ctx, "SELECT column_name FROM information_schema.columns WHERE table_name = $1")`,
+		tables: 1,
+	},
+	{
+		name:   "EXTRACT's argument separator",
+		body:   `tx.Exec(ctx, "SELECT extract(epoch FROM created_at) FROM "+noteTable)`,
+		tables: 1,
+	},
+	{
+		name:   "a row lock and an upsert clause",
+		body:   `tx.Exec(ctx, "INSERT INTO "+noteTable+" (id) VALUES ($1) ON CONFLICT (id) DO UPDATE SET body = $2 RETURNING (SELECT body FROM "+noteTable+" WHERE id = $1 FOR UPDATE)")`,
+		tables: 2,
+	},
+	{
+		name:   "a set-returning function and a USING column list",
+		body:   `tx.Exec(ctx, "SELECT n.id FROM "+noteTable+" n JOIN unnest($1::uuid[]) AS wanted(id) USING (id)")`,
+		tables: 1,
+	},
+	{
+		name:   "prose that merely reads like SQL",
+		body:   `_ = "hello from the demo extension"; _ = "update the note, then select the row"`,
+		tables: 0,
+	},
+}
+
+// TestExtensionSQLScopeRefusesWhatItMust drives the gate with sources the real
+// tree does not contain.
+func TestExtensionSQLScopeRefusesWhatItMust(t *testing.T) {
+	for _, probe := range extSQLGateCases {
+		t.Run(probe.name, func(t *testing.T) {
+			scan := scanUnitSQL(t, probeUnit, map[string]string{"probe.go": probeSource(probe.body)})
+			if probe.tables != scan.tables {
+				t.Errorf("the gate read %d table reference(s), want %d — a case whose SQL the reader never saw proves nothing about the verdict below", scan.tables, probe.tables)
+			}
+			switch {
+			case probe.want == "" && len(scan.findings) > 0:
+				t.Errorf("the gate refused what it must accept: %s", strings.Join(scan.findings, "; "))
+			case probe.want == "":
+			case len(scan.findings) != 1:
+				t.Errorf("the gate returned %d finding(s), want the one refusing %q: %s", len(scan.findings), probe.want, strings.Join(scan.findings, "; "))
+			case !strings.Contains(scan.findings[0], probe.want):
+				t.Errorf("the gate refused the source but the reason does not mention %q: %s", probe.want, scan.findings[0])
+			}
+		})
+	}
+}
+
+// probeSource wraps a case body in a compilable unit whose constants are the
+// two a real unit declares: its own table, and — for the cases that reach past
+// it — a core one.
+func probeSource(body string) string {
+	return `package probe
+
+const noteTable = "ext.ext_probe_note"
+const subject = "person"
+
+func run(ctx context.Context, tx Tx) { ` + body + ` }
+`
+}

--- a/backend/extensionsqlscopecases_test.go
+++ b/backend/extensionsqlscopecases_test.go
@@ -154,6 +154,73 @@ var extSQLGateCases = []extSQLGateCase{
 		tables: 2,
 	},
 	{
+		name: "a core table REWRITTEN behind a CTE of its own name",
+		// PostgreSQL has no such thing as writing a CTE: the target of an
+		// UPDATE, DELETE, INSERT or TRUNCATE always resolves to the real table,
+		// however the WITH list names itself. Exempting the name in a write
+		// position is a two-token way past the whole gate — and the unit's own
+		// table, read inside the CTE body, keeps the reference count looking
+		// honest while it happens.
+		body:   `tx.Exec(ctx, "WITH person AS (SELECT id FROM "+noteTable+") UPDATE person SET full_name = $1")`,
+		want:   `"person"`,
+		tables: 2,
+	},
+	{
+		name:   "a core table DELETED behind a CTE of its own name",
+		body:   `tx.Exec(ctx, "WITH person AS (SELECT id FROM "+noteTable+") DELETE FROM person WHERE id = $1")`,
+		want:   `"person"`,
+		tables: 2,
+	},
+	{
+		name: "a core table inside a DO block",
+		// The one statement whose quoted body IS the statement. Everywhere else
+		// a dollar-quoted body is a value and gets stripped; here stripping it
+		// would delete the only place the DML is written.
+		body:   "tx.Exec(ctx, `DO $$ BEGIN DELETE FROM person; END $$`)",
+		want:   `"person"`,
+		tables: 1,
+	},
+	{
+		name:   "a core table inside a quoted DO body",
+		body:   `tx.Exec(ctx, "DO 'DELETE FROM person'")`,
+		want:   `"person"`,
+		tables: 1,
+	},
+	{
+		name: "a core table read out by COPY",
+		// COPY … TO STDOUT needs only SELECT, which the shared runtime role
+		// holds on every core table, so this is a read of the whole table.
+		body:   `tx.Exec(ctx, "COPY person TO STDOUT")`,
+		want:   `"person"`,
+		tables: 1,
+	},
+	{
+		name: "a core table behind a set-returning function in a FROM list",
+		// One non-table entry must not shield the rest of the list.
+		body:   `tx.Exec(ctx, "SELECT * FROM generate_series(1,1) g, person p, "+noteTable+" n WHERE true")`,
+		want:   `"person"`,
+		tables: 2,
+	},
+	{
+		name:   "a core table second in a DELETE … USING list",
+		body:   `tx.Exec(ctx, "DELETE FROM "+noteTable+" USING "+noteTable+" x, person WHERE true")`,
+		want:   `"person"`,
+		tables: 3,
+	},
+	{
+		name: "the bulk-delete idiom against the unit's own table",
+		// `DELETE FROM own USING unnest($1)` is how a unit deletes a batch, and
+		// a gate that reads `unnest` as a table refuses it in the merge gate
+		// with a message about a table nobody named.
+		body:   `tx.Exec(ctx, "DELETE FROM "+noteTable+" USING unnest($1::uuid[]) AS wanted(id) WHERE "+noteTable+".id = wanted.id")`,
+		tables: 1,
+	},
+	{
+		name:   "COPY naming its endpoint rather than a second table",
+		body:   `tx.Exec(ctx, "COPY "+noteTable+" FROM STDIN")`,
+		tables: 1,
+	},
+	{
 		name: "a bare TRUNCATE, which is read as prose",
 		// The stated half of the trade the shape list makes: reading this
 		// spelling means reading every sentence that opens with the word. The
@@ -241,7 +308,7 @@ const source = "FROM person LIMIT 1"`,
 	},
 	{
 		name:   "prose that merely reads like SQL",
-		body:   `_ = "hello from the demo extension"; _ = "update the note, then select the row"; _ = "truncate the note body before sending"`,
+		body:   `_ = "hello from the demo extension"; _ = "update the note, then select the row"; _ = "truncate the note body before sending"; _ = "do the work, then copy the note"`,
 		tables: 0,
 	},
 }

--- a/backend/extensionsqlscopecases_test.go
+++ b/backend/extensionsqlscopecases_test.go
@@ -154,18 +154,21 @@ var extSQLGateCases = []extSQLGateCase{
 		tables: 2,
 	},
 	{
-		name:   "a core table truncated without the TABLE word",
+		name: "a bare TRUNCATE, which is read as prose",
+		// The stated half of the trade the shape list makes: reading this
+		// spelling means reading every sentence that opens with the word. The
+		// prose case below is its other half, and both move together.
 		body:   `tx.Exec(ctx, "TRUNCATE person")`,
-		want:   `"person"`,
-		tables: 1,
+		tables: 0,
 	},
 	{
-		name: "a core table truncated with the TABLE word",
-		// TRUNCATE reaches the name past the qualifier, and TABLE reaches it as
-		// a keyword of its own: one mistake, and it must be reported once.
-		body:   `tx.Exec(ctx, "TRUNCATE TABLE person")`,
+		name: "a core table truncated beside the unit's own",
+		// TRUNCATE reaches the first name past the qualifier, and TABLE reaches
+		// it as a keyword of its own: one mistake, and it must be reported once.
+		// The list is what carries the second name.
+		body:   `tx.Exec(ctx, "TRUNCATE TABLE "+noteTable+", person")`,
 		want:   `"person"`,
-		tables: 1,
+		tables: 2,
 	},
 	{
 		name:   "a core table behind the statement's own comment",
@@ -238,7 +241,7 @@ const source = "FROM person LIMIT 1"`,
 	},
 	{
 		name:   "prose that merely reads like SQL",
-		body:   `_ = "hello from the demo extension"; _ = "update the note, then select the row"`,
+		body:   `_ = "hello from the demo extension"; _ = "update the note, then select the row"; _ = "truncate the note body before sending"`,
 		tables: 0,
 	},
 }

--- a/backend/extensionsqlscopecases_test.go
+++ b/backend/extensionsqlscopecases_test.go
@@ -1,0 +1,282 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package backendarch
+
+// The SQL-scope gate's own test, driven with SYNTHETIC unit sources rather than
+// the tree — the real units are supposed to pass, so a gate proven only by
+// "extensions/ is currently clean" is one that keeps passing after it stops
+// working. A fixture unit could not carry these either: a fixture naming a core
+// table would have to fail the gate to prove anything.
+//
+// The gate has a second way to read green that a clean tree hides completely:
+// seeing no SQL at all. Every case therefore pins how many table references were
+// READ alongside the verdict, and each rule below was checked by breaking it —
+// the case is here because the gate without that rule fails it.
+
+import (
+	"strings"
+	"testing"
+)
+
+// probeUnit is the synthetic unit the gate's own test is written against. Its
+// namespace is ext_probe, so ext.ext_probe_note is its table and everything else
+// in the cases below is somebody's else's.
+const probeUnit = "probe"
+
+// extSQLGateCase is one source the gate must judge a particular way. want is the
+// text the refusal has to carry, or "" when the source must be accepted.
+type extSQLGateCase struct {
+	name string
+	body string
+	// decls is package-level source this case needs beside the shared ones. It
+	// is per case rather than shared because a declaration holding SQL is read
+	// by every case that can see it.
+	decls  string
+	want   string
+	tables int // table references the gate is expected to have read
+}
+
+// extSQLGateCases exercise the gate against a unit it can refuse. The real tree
+// is supposed to pass, so a gate proven only by "extensions/ is currently clean"
+// is one that keeps passing after it stops working — and this one has a second
+// way to read green that a clean tree hides completely: seeing no SQL at all.
+// Every accepted case therefore also pins how many table references were READ.
+var extSQLGateCases = []extSQLGateCase{
+	{
+		name:   "a core table named inline",
+		body:   `tx.Exec(ctx, "SELECT id FROM person WHERE id = $1")`,
+		want:   `"person": the unit probe addresses ext.ext_probe_…`,
+		tables: 1,
+	},
+	{
+		name:   "a core table named through the public schema",
+		body:   `tx.Exec(ctx, "DELETE FROM public.person WHERE id = $1")`,
+		want:   `"public.person"`,
+		tables: 1,
+	},
+	{
+		name: "a core table reached through a constant",
+		body: `tx.Exec(ctx, "SELECT id FROM "+subject+" WHERE id = $1")`,
+		// The spelling the one unit shipping SQL uses for its OWN table. A gate
+		// blind to the concatenation reads the whole tier green.
+		want:   `"person"`,
+		tables: 1,
+	},
+	{
+		name:   "another unit's table",
+		body:   `tx.Exec(ctx, "SELECT body FROM ext.ext_notes_note LIMIT 1")`,
+		want:   `"ext.ext_notes_note": the unit probe addresses`,
+		tables: 1,
+	},
+	{
+		name:   "a core table joined onto the unit's own",
+		body:   `tx.Exec(ctx, "SELECT n.id FROM ext.ext_probe_note n JOIN person p ON p.id = n.subject_id")`,
+		want:   `"person"`,
+		tables: 2,
+	},
+	{
+		name:   "a core table reached around a DELETE … USING",
+		body:   `tx.Exec(ctx, "DELETE FROM ext.ext_probe_note USING person WHERE person.id = ext_probe_note.subject_id")`,
+		want:   `"person"`,
+		tables: 2,
+	},
+	{
+		name:   "a core table written by an INSERT",
+		body:   `tx.Exec(ctx, "INSERT INTO activity (kind, subject_id) VALUES ($1, $2)")`,
+		want:   `"activity"`,
+		tables: 1,
+	},
+	{
+		name:   "a core table rewritten by an UPDATE",
+		body:   `tx.Exec(ctx, "UPDATE person SET full_name = $1 WHERE id = $2")`,
+		want:   `"person"`,
+		tables: 1,
+	},
+	{
+		name:   "the unit's own table left unqualified",
+		body:   `tx.Exec(ctx, "SELECT id FROM ext_probe_note LIMIT 1")`,
+		want:   "the ext schema is on no search_path",
+		tables: 1,
+	},
+	{
+		name:   "a scratch table created over a core name",
+		body:   `tx.Exec(ctx, "CREATE TABLE IF NOT EXISTS person (id uuid)")`,
+		want:   `"person"`,
+		tables: 1,
+	},
+	{
+		name:   "a table name assembled at runtime",
+		body:   `tx.Exec(ctx, fmt.Sprintf("SELECT id FROM %s LIMIT 1", subject))`,
+		want:   "this gate cannot read",
+		tables: 1,
+	},
+	{
+		name:   "the unit's own table, schema-qualified through a constant",
+		body:   `tx.Exec(ctx, "SELECT id FROM "+noteTable+" ORDER BY id LIMIT 1")`,
+		tables: 1,
+	},
+	{
+		name:   "a CTE the same statement declares",
+		body:   `tx.Exec(ctx, "WITH stale AS (SELECT id FROM "+noteTable+" ORDER BY id DESC OFFSET 50) DELETE FROM "+noteTable+" WHERE id IN (SELECT id FROM stale)")`,
+		tables: 2,
+	},
+	{
+		name:   "a catalog read",
+		body:   `tx.Exec(ctx, "SELECT column_name FROM information_schema.columns WHERE table_name = $1")`,
+		tables: 1,
+	},
+	{
+		name:   "EXTRACT's argument separator",
+		body:   `tx.Exec(ctx, "SELECT extract(epoch FROM created_at) FROM "+noteTable)`,
+		tables: 1,
+	},
+	{
+		name:   "a row lock and an upsert clause",
+		body:   `tx.Exec(ctx, "INSERT INTO "+noteTable+" (id) VALUES ($1) ON CONFLICT (id) DO UPDATE SET body = $2 RETURNING (SELECT body FROM "+noteTable+" WHERE id = $1 FOR UPDATE)")`,
+		tables: 2,
+	},
+	{
+		name:   "a set-returning function and a USING column list",
+		body:   `tx.Exec(ctx, "SELECT n.id FROM "+noteTable+" n JOIN unnest($1::uuid[]) AS wanted(id) USING (id)")`,
+		tables: 1,
+	},
+	{
+		name:   "a core table updated from a WITH clause",
+		body:   `tx.Exec(ctx, "WITH chosen AS (SELECT id FROM "+noteTable+") UPDATE person SET full_name = $1 WHERE id IN (SELECT id FROM chosen)")`,
+		want:   `"person"`,
+		tables: 2,
+	},
+	{
+		name:   "a core table in an old-style comma join",
+		body:   `tx.Exec(ctx, "SELECT n.id FROM "+noteTable+" n, person p WHERE p.id = n.subject_id")`,
+		want:   `"person"`,
+		tables: 2,
+	},
+	{
+		name:   "a core table truncated without the TABLE word",
+		body:   `tx.Exec(ctx, "TRUNCATE person")`,
+		want:   `"person"`,
+		tables: 1,
+	},
+	{
+		name: "a core table truncated with the TABLE word",
+		// TRUNCATE reaches the name past the qualifier, and TABLE reaches it as
+		// a keyword of its own: one mistake, and it must be reported once.
+		body:   `tx.Exec(ctx, "TRUNCATE TABLE person")`,
+		want:   `"person"`,
+		tables: 1,
+	},
+	{
+		name:   "a core table behind the statement's own comment",
+		body:   "tx.Exec(ctx, `-- the stale rows\nDELETE FROM person WHERE id = $1`)",
+		want:   `"person"`,
+		tables: 1,
+	},
+	{
+		name: "a core table shadowed by a CTE of the same name",
+		// The CTE's own body still reads the core table; only what follows the
+		// body is the CTE. Exempting the name everywhere is a one-line evasion.
+		body:   `tx.Exec(ctx, "WITH person AS (SELECT id FROM person) SELECT id FROM person")`,
+		want:   `"person"`,
+		tables: 1,
+	},
+	{
+		name: "a core table under a name bound two ways",
+		// Two functions, one unit-wide fold: the second binding must not answer
+		// for the first.
+		body:   `tx.Exec(ctx, "SELECT id FROM "+where+" LIMIT 1"); _ = func() { where := noteTable; _ = where }`,
+		want:   "this gate cannot read",
+		tables: 1,
+	},
+	{
+		name: "a core table under a name a call also binds",
+		// The readable binding comes SECOND here, which is the order the
+		// disagreement rule above does not cover on its own: the fold would
+		// otherwise take the one value it could read and answer with it, for a
+		// name whose value at the statement is whatever pick() returned.
+		body:   `chosen := pick(); chosen = noteTable; tx.Exec(ctx, "SELECT id FROM "+chosen)`,
+		want:   "this gate cannot read",
+		tables: 1,
+	},
+	{
+		name:   "the unit's own table, quoted the way PostgreSQL qualifies one",
+		body:   "tx.Exec(ctx, `SELECT id FROM \"ext\".\"ext_probe_note\" LIMIT 1`)",
+		tables: 1,
+	},
+	{
+		name:   "a CTE that declares its column list",
+		body:   `tx.Exec(ctx, "WITH stale(id) AS (SELECT id FROM "+noteTable+") DELETE FROM "+noteTable+" WHERE id IN (SELECT id FROM stale)")`,
+		tables: 2,
+	},
+	{
+		name:   "a recursive CTE naming itself",
+		body:   `tx.Exec(ctx, "WITH RECURSIVE walk AS (SELECT id, parent_id FROM "+noteTable+" UNION ALL SELECT n.id, n.parent_id FROM "+noteTable+" n JOIN walk w ON w.parent_id = n.id) SELECT id FROM walk")`,
+		tables: 2,
+	},
+	{
+		name:   "a dollar-quoted body that reads like a statement",
+		body:   `tx.Exec(ctx, "SELECT $$FROM person$$ AS example FROM "+noteTable)`,
+		tables: 1,
+	},
+	{
+		name: "a statement assembled through a chain of constants",
+		body: `tx.Exec(ctx, statement)`,
+		// Four links deep, declared out of order: the fold resolves one link a
+		// pass and must run to a fixed point, not a fixed number of passes.
+		decls: `const statement = opener + body
+const opener = verb + " "
+const verb = keyword
+const keyword = upper + lower
+const upper = "SE"
+const lower = "LECT"
+const body = columns + source
+const columns = "id "
+const source = "FROM person LIMIT 1"`,
+		want:   `"person"`,
+		tables: 1,
+	},
+	{
+		name:   "prose that merely reads like SQL",
+		body:   `_ = "hello from the demo extension"; _ = "update the note, then select the row"`,
+		tables: 0,
+	},
+}
+
+// TestExtensionSQLScopeRefusesWhatItMust drives the gate with sources the real
+// tree does not contain.
+func TestExtensionSQLScopeRefusesWhatItMust(t *testing.T) {
+	for _, probe := range extSQLGateCases {
+		t.Run(probe.name, func(t *testing.T) {
+			scan := scanUnitSQL(t, probeUnit, map[string]string{"probe.go": probeSource(probe.body, probe.decls)})
+			if probe.tables != scan.tables {
+				t.Errorf("the gate read %d table reference(s), want %d — a case whose SQL the reader never saw proves nothing about the verdict below", scan.tables, probe.tables)
+			}
+			switch {
+			case probe.want == "" && len(scan.findings) > 0:
+				t.Errorf("the gate refused what it must accept: %s", strings.Join(scan.findings, "; "))
+			case probe.want == "":
+			case len(scan.findings) != 1:
+				t.Errorf("the gate returned %d finding(s), want the one refusing %q: %s", len(scan.findings), probe.want, strings.Join(scan.findings, "; "))
+			case !strings.Contains(scan.findings[0], probe.want):
+				t.Errorf("the gate refused the source but the reason does not mention %q: %s", probe.want, scan.findings[0])
+			}
+		})
+	}
+}
+
+// probeSource wraps a case body in a compilable unit whose constants are the
+// two a real unit declares: its own table, and — for the cases that reach past
+// it — a core one.
+func probeSource(body, decls string) string {
+	return `package probe
+
+const noteTable = "ext.ext_probe_note"
+const subject = "person"
+const where = "person"
+
+func pick() string { return subject }
+
+func run(ctx context.Context, tx Tx) { ` + body + ` }
+` + decls + "\n"
+}

--- a/backend/pkg/extension/runtime.go
+++ b/backend/pkg/extension/runtime.go
@@ -196,7 +196,11 @@ type Caller struct {
 //     property of polite units, not of this transaction.
 //
 // All four are the same missing thing (#628) and all four are inside the
-// trusted-unit threat model above.
+// trusted-unit threat model above. A static gate does refuse the first two
+// where it can SEE them — backend/extensionsqlscope_test.go reads the SQL a
+// unit's source spells out and holds it to that unit's own ext_<name>_* tables
+// — but a scanner is defence against mistakes by construction: it reads text,
+// and this seam takes whatever string a unit assembles.
 //
 // args is ...any because SQL arguments are genuinely heterogeneous — a
 // statement's parameters are whatever its placeholders are — and every

--- a/docs/explanation/extensibility.md
+++ b/docs/explanation/extensibility.md
@@ -320,6 +320,7 @@ The tier is defended by fitness tests and scripts, so the guarantees can't rot i
 | The core stays jurisdiction-neutral | `scripts/check-no-jurisdiction.sh` |
 | Every unit table carries FORCE RLS and a workspace-bound policy, and touches nothing in `public` | `make check-ext-migrations` (applies each unit's migrations as a minted restricted role) |
 | Every unit table grants the runtime role exactly `SELECT, INSERT, UPDATE, DELETE` — a table granting *nothing* satisfied the old one-sided allowlist and then answered `permission denied` at the first call | `make check-ext-migrations` |
+| A unit's SQL names only that unit's own `ext.ext_<name>_…` tables — the mistake-defence half of the shared-role reach described above, reading through the string constants a table name is spelled with | `backend/extensionsqlscope_test.go` |
 | A unit's shipped `migrations/` is actually embedded and applied — the directory and the field are two facts, and the gates read different ones | `backend/tools/gen-composition` (the `Migrations` field must name a var whose `//go:embed` covers the layer) |
 | The runtime pool is not the migration owner: no superuser, no BYPASSRLS, and no ownership of the `ext` schema *or* anything in it | `compose.AssertRuntimeRole`, at boot and on `/readyz` |
 | A declaration the composer cannot honour is refused rather than discarded — an unknown job role, governance declared on the wrong half of a pair, a `$ref` in an advertised schema, a multi-document base contract | `backend/tools/gen-composition` |

--- a/docs/how-to/add-an-extension.md
+++ b/docs/how-to/add-an-extension.md
@@ -271,6 +271,16 @@ restricted role against a throwaway database and re-reads the catalog):
   else, because a foreign key onto a core table takes a lock on core writes and can refuse a core
   delete forever after.
 
+**And what your migrations may CREATE is what your handlers' SQL may NAME.** `rt.Tx()` runs on the
+shared `margince_app` role, so a statement naming `person` would work — which is why
+`TestExtensionSQLNamesOnlyTheUnitsOwnTables` (`backend/extensionsqlscope_test.go`) reads every unit's
+Go source, folds the string constants a table name is usually spelled through, and refuses a table
+outside `ext.ext_<name>_…`. Qualify the schema — `ext` is on no `search_path` the app connects with,
+so a bare `ext_notes_note` names a *public* table you do not own — and keep the name in a constant: a
+name assembled at run time is a finding too, because a reader that cannot see the table cannot vouch
+for it. This is defence against mistakes, not a wall; see "what the tier does NOT protect against" in
+[extensibility.md](../explanation/extensibility.md).
+
 **A new migration is a new file — including for an index.** `dbmigrate` keys on the version, so a line
 added to an already-applied `0001` runs on exactly the installations that did not need it (a fresh one)
 and never on the ones that do. `extensions/notes/migrations/0003_note_workspace_index.up.sql` is the

--- a/docs/how-to/add-an-extension.md
+++ b/docs/how-to/add-an-extension.md
@@ -271,11 +271,12 @@ restricted role against a throwaway database and re-reads the catalog):
   else, because a foreign key onto a core table takes a lock on core writes and can refuse a core
   delete forever after.
 
-**And what your migrations may CREATE is what your handlers' SQL may NAME.** `rt.Tx()` runs on the
-shared `margince_app` role, so a statement naming `person` would work — which is why
-`TestExtensionSQLNamesOnlyTheUnitsOwnTables` (`backend/extensionsqlscope_test.go`) reads every unit's
-Go source, folds the string constants a table name is usually spelled through, and refuses a table
-outside `ext.ext_<name>_…`. Qualify the schema — `ext` is on no `search_path` the app connects with,
+**And what your migrations may CREATE is what your SQL may NAME — in your tests too.** `rt.Tx()` runs
+on the shared `margince_app` role, so a statement naming `person` would work, which is why
+`TestExtensionSQLNamesOnlyTheUnitsOwnTables` (`backend/extensionsqlscope_test.go`) reads **every `.go`
+file your unit ships**, folds the string constants a table name is usually spelled through, and refuses
+a table outside `ext.ext_<name>_…`. A unit test that seeds a core table fails it exactly as a handler
+would, and that is deliberate: a test is where the habit starts. Qualify the schema — `ext` is on no `search_path` the app connects with,
 so a bare `ext_notes_note` names a *public* table you do not own — and keep the name in a constant: a
 name assembled at run time is a finding too, because a reader that cannot see the table cannot vouch
 for it. This is defence against mistakes, not a wall; see "what the tier does NOT protect against" in


### PR DESCRIPTION
## What

A fitness test — `backend/extensionsqlscope_test.go` — that reads the SQL an extension unit's Go source spells out and refuses any table outside that unit's own `ext.ext_<name>_…` namespace. Its own test lives beside it in `backend/extensionsqlscopecases_test.go`.

This is **step 12** of the extension-tier core write port (SP1 §3.8). It is the one remaining step with no dependency on the port itself, and it closes the gap `pkg/extension/runtime.go` already lists under *"WHAT IS NOT WALLED AT ALL"*.

## Why now

It costs nothing now and a rewrite later. No shipped unit names a core table: `notes` touches only `ext.ext_notes_note`, `de` and `yogi` issue no SQL. Landing the rule before any unit depends on wider reach is the whole point of the timing.

## Why a Go fitness test and not the grep the plan sketched

Every table in this tree is spelled through a string constant:

```go
`SELECT ` + noteColumns + ` FROM ` + noteTable + ` ORDER BY created_at DESC LIMIT $1`
```

A line-oriented scanner sees `FROM ` and nothing after it, so it would have read green over the only SQL the tier ships. The test parses with `go/ast`, folds string constants to a fixed point, then judges the statement. Ownership is derived through the same `extension.Name(…).Namespace()` the migration gate and the unit's database role come from, so the three cannot drift.

## What it is not

Defence against mistakes, and the header says so in those words. A unit is trusted in-process code either way: a table name assembled at run time defeats a static reader by construction. The boundary is a per-unit database role, #628. A name the reader *cannot* resolve is itself a finding, with the fix in the message: spell the table with a constant.

## Evidence

Both halves are proven against code, not against a clean tree.

- **31 cases.** Refused: a core table inline, through a constant, joined, comma-joined, reached around `DELETE … USING`, updated from behind a `WITH`, hidden behind the statement's own `--` comment, shadowed by a CTE of the same name, under a name two bindings disagree about, under a name a call also binds, in `INSERT`/`UPDATE`/`CREATE TABLE`/`TRUNCATE TABLE`, assembled at run time, and another unit's table. Accepted: own table via constant, quoted qualification, CTE with and without a column list, a recursive CTE, catalog read, `EXTRACT(epoch FROM …)`, `FOR UPDATE`, `ON CONFLICT DO UPDATE SET`, a set-returning function, `JOIN … USING (col)`, a dollar-quoted body that reads like a statement, and prose that merely contains a keyword.
- **Every accept case also pins how many table references were READ.** A reader that stopped seeing SQL reads exactly like a clean tier; the count is what separates them. The whole-tree test carries the same anti-vacuity check (it reads 8 references today).
- **Mutation-verified, one rule at a time.** 22 mutations, each caught by the case that names it. Planting `FROM person` in `extensions/notes/note.go` fails the tree test at the right line; disabling the constant fold fails 8 real statements plus 5 cases.

## Review rounds folded in

- **Codex** found twelve spellings the first commit missed — `WITH … UPDATE`, comma joins, `TRUNCATE`, a leading SQL comment, CTE self-shadowing, two name-binding holes, constant chains deeper than two links, plus three false positives (quoted qualification, CTE column lists, dollar-quoted bodies) and nondeterministic report order. All twelve are closed in 708a88b, each with a case.
- **CodeRabbit** independently found four, three of them the same, and one that mattered on its own: admitting `truncate` with no companion word makes "truncate the note body before sending" refuse a table called `the`. Reproduced, then fixed in 1b10f56b by reading only the `TRUNCATE TABLE t` spelling — the bare one names a statement the runtime role has no grant for anyway. Both halves of that trade are cases.

## Gates

`make check-backend` green (build, vet, golangci base **and** strict, arch-lint, unit tests, drift, composition), `make craft-static` green on all three trees. No runtime behaviour changes, so the integration lane has nothing new to exercise.

## Also in the diff

- `docs/how-to/add-an-extension.md` — what your SQL may name, next to what your migrations may create, and that the gate reads your tests too.
- `docs/explanation/extensibility.md` — one row in the guardrail table.
- `pkg/extension/runtime.go` — a sentence at the seam pointing at the gate, and restating that a scanner is mistake-defence by construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)