### PR TITLE
feat(agents): one governed call, whichever door it arrived at

### DIFF
--- a/backend/fieldnames_test.go
+++ b/backend/fieldnames_test.go
@@ -352,6 +352,9 @@ var validationFieldsOutsideTheContract = gatekit.Waive(map[string]string{
 	"arguments": "compose/registry.go's MCP tools/call handler names params.arguments, which is " +
 		"the JSON-RPC request shape rather than a REST contract property — correct for that " +
 		"wire, and absent from api_gen.go's tags because no REST body carries it",
+	"lineItemId": "crm.yaml's own PATH parameter name on /offers/{id}/line-items/{lineItemId} — " +
+		"correct for that wire, and absent from api_gen.go's tags because no request body carries " +
+		"a line item's own id as a JSON property (agentcommandnested.go's lineItemID)",
 })
 
 // A field name published through the transport helper has to BE a field name.

--- a/backend/gatecensus_test.go
+++ b/backend/gatecensus_test.go
@@ -50,7 +50,7 @@ const (
 	// Permitting the marker without counting it would let it spread quietly and
 	// reopen the class these rules close; pinned, every new one moves a number a
 	// reviewer sees.
-	wantFixtureAnnotations = 12
+	wantFixtureAnnotations = 14
 )
 
 // censusDecl is one package-level declaration this census governs — a map from

--- a/backend/internal/compose/agentcommand.go
+++ b/backend/internal/compose/agentcommand.go
@@ -8,9 +8,11 @@ package compose
 //
 // The door decodes; it does not interpret. What the approval binds to, and what
 // would be refused anyway, come back from the resolver the command is bound to
-// — the same resolver the tool door reaches for the same operation. The rest of
-// the gate's questions are still answered elsewhere: the tier by the generated
-// policy and dynamicTierInputs, the inbox line by restSummary.
+// — the same resolver the tool door reaches for the same operation. Where the
+// contract states a tier outright, the generated policy answers it; where the
+// tier turns on the record's own state, the command answers that too
+// (agents.DynamicTierInput). Only the inbox line is still this door's own
+// (restSummary), and stagedTarget says why.
 
 import (
 	"encoding/json"
@@ -28,9 +30,10 @@ import (
 // family added would re-sign this map type and every entry already in it — the
 // churn a table of twelve identical signatures is least able to absorb.
 //
-// It is not tierDeps, which answers a different question (what tier is this
-// call) and is consulted before admission rather than at staging; the two
-// happen to share a provider today and have no reason to share a shape.
+// One struct serves BOTH moments a decoder runs at — resolving a dynamic tier
+// before admission, and naming a staged target after a refusal — because it is
+// the same decode either way. The tier used to be fed from a struct of its own,
+// which is one of the two spellings this seam removed.
 type restCommandDeps struct {
 	records datasource.SystemOfRecordProvider
 	// stages resolves a pipeline stage's configured SEMANTIC, which is what

--- a/backend/internal/compose/agentcommand.go
+++ b/backend/internal/compose/agentcommand.go
@@ -49,10 +49,12 @@ type restCommandDeps struct {
 // request into the operation's typed command, bound to the resolver that
 // speaks it.
 //
-// The table covers one operation family, not the surface: an operation with no
-// entry resolves its staged target by walking the route
-// (stagedTargetByRoute) instead, which is the guess this seam replaces family
-// by family (gradionhq/margince-poc-v1#928).
+// The table covers the WHOLE agent-reachable mutating surface — all sixty-nine
+// routes, one entry per operation, with nothing left to answer from the route's
+// own shape (gradionhq/margince-poc-v1#928).
+// TestEveryAgentReachableMutatingRouteDecodesIntoACommand derives both
+// directions of that from the policy table, so a route the contract adds fails
+// there rather than reaching a door that has no answer for it.
 //
 // Every create and every whole-record patch route is registered, all
 // twenty-six — thirteen creates and thirteen whole-record writes. Twelve of
@@ -132,9 +134,10 @@ var restCommands = map[string]func(pol agentPolicy, deps restCommandDeps, r *htt
 	// The seven bespoke auto-execute commands (agentcommandnested.go). Six of
 	// the seven — every one but upsertPartner — are nested creates or
 	// child/membership actions that are 🟢 today and have NEVER staged:
-	// registered anyway, because the route walk's guess (stagedTargetByRoute)
-	// is the one this table replaces family by family, and for createOffer
-	// that guess is provably wrong today (gradionhq/margince-poc-v1#1046).
+	// registered anyway, because a tier floor tightening one would otherwise
+	// leave this door with only the route's own shape to name a target from,
+	// and for createOffer that shape is provably wrong: the routed id is the
+	// parent deal (gradionhq/margince-poc-v1#1046).
 	// upsertPartner is the one exception: it stages TODAY, through BOTH
 	// splitOrRedeemUpdate branches a human-owned conflict can take —
 	// stageRefusal when every touched field is human-owned, and

--- a/backend/internal/compose/agentcommand.go
+++ b/backend/internal/compose/agentcommand.go
@@ -53,6 +53,8 @@ var restCommands = map[string]func(pol agentPolicy, records datasource.SystemOfR
 // here a second time: the entry is generated from the contract's x-mcp-tool
 // annotation, so a type spelled again in this file could disagree with the one
 // the gate admitted against.
+//
+//nolint:ireturn // a decoder's whole product is the erased command-and-resolver pair the table above is typed by
 func archiveCommand(pol agentPolicy, records datasource.SystemOfRecordProvider, r *http.Request) (agents.GovernedCall, error) {
 	id, err := ids.Parse(chi.URLParam(r, "id"))
 	if err != nil {

--- a/backend/internal/compose/agentcommand.go
+++ b/backend/internal/compose/agentcommand.go
@@ -102,6 +102,21 @@ var restCommands = map[string]func(pol agentPolicy, deps restCommandDeps, r *htt
 	"updateRelationship":        patchCommand,
 	"updateSavedView":           patchCommand,
 	"updateWebhookSubscription": patchCommand,
+
+	// The eight bespoke confirm-first commands (agentcommandoperand.go): none
+	// of them is a whole-record patch, so none belongs above — each targets
+	// the routed record but carries a SECOND operand (a path segment or, for
+	// removeProjectStakeholder, a second path parameter) that a projection
+	// onto update_record's own {record_type, id, fields} arguments cannot
+	// express (gradionhq/margince-poc-v1#928 task 5).
+	"confirmOrganizationFact":         confirmFactCommand,
+	"updateOrganizationFact":          updateFactCommand,
+	"confirmOrganizationProfileField": confirmProfileFieldCommand,
+	"updateOrganizationProfileField":  updateProfileFieldCommand,
+	"retireCustomField":               retireCustomFieldCommand,
+	"updateCustomFieldOptions":        updateCustomFieldOptionsCommand,
+	"setProjectStakeholder":           setStakeholderCommand,
+	"removeProjectStakeholder":        removeStakeholderCommand,
 }
 
 // archiveCommand decodes one DELETE /v1/<collection>/{id} into the archive

--- a/backend/internal/compose/agentcommand.go
+++ b/backend/internal/compose/agentcommand.go
@@ -33,6 +33,16 @@ import (
 // happen to share a provider today and have no reason to share a shape.
 type restCommandDeps struct {
 	records datasource.SystemOfRecordProvider
+	// stages resolves a pipeline stage's configured SEMANTIC, which is what
+	// makes a deal move a close, a reopen or a routine step — three opposite
+	// decisions wearing one shape, so the summary a human reads cannot be
+	// written without it (modules/agents/commandlifecycle.go).
+	stages agents.StageResolver
+	// channels answers whether an activity kind is a messaging-channel
+	// conversation. The tool door holds the whole Comms seam and asks it
+	// there; this door holds the question alone, because a REST send_message
+	// needs to refuse a non-channel anchor without being able to send anything.
+	channels agents.ChannelKinds
 }
 
 // restCommands maps a crm.yaml operationId to the decoder that turns an HTTP
@@ -142,6 +152,39 @@ var restCommands = map[string]func(pol agentPolicy, deps restCommandDeps, r *htt
 	opRemoveOfferLineItem: removeOfferLineItemCommand,
 	"createOffer":         createOfferCommand,
 	opUpsertPartner:       upsertPartnerCommand,
+
+	// The fourteen single-purpose commands over sixteen routes
+	// (agentcommandsend.go, agentcommandlifecycle.go, agentcommandrecord.go,
+	// agentcommandauto.go), and the first family where EVERY entry has a real
+	// tool-door twin resolving the same command. Until here the seam only
+	// promised that both doors COULD agree; these are where they actually do,
+	// because every one of these operations is reachable as a tool call too.
+	//
+	// Two commands serve two operations each, and neither pair is a duplicate:
+	// merge_records is the person and organization halves of one verb, and
+	// enrich is one verb at its two DEPTHS — a page read and a whole-site
+	// crawl, told apart by which decoder was reached rather than by anything on
+	// the wire (agentcommandrecord.go says why that has to be structural).
+	//
+	// Four of the fourteen are 🟢 today and stage nothing, so their entries are
+	// unreached until a tier floor tightens them; agentcommandauto.go's own doc
+	// says why they are registered anyway.
+	"sendEmail":           sendEmailCommand,
+	"sendMessage":         sendMessageCommand,
+	"sendAccountEmail":    sendAccountEmailCommand,
+	"bookMeeting":         bookMeetingCommand,
+	"promoteLead":         promoteLeadCommand,
+	"disqualifyLead":      disqualifyLeadCommand,
+	"advanceProjectPhase": advanceProjectPhaseCommand,
+	"advanceDeal":         advanceDealCommand,
+	"mergePerson":         mergeCommand,
+	"mergeOrganization":   mergeCommand,
+	"scrapeCompany":       scrapeCompanyCommand,
+	"deepReadCompany":     deepReadCompanyCommand,
+	"logActivity":         logActivityCommand,
+	"draftEmail":          draftEmailCommand,
+	"relinkActivity":      relinkActivityCommand,
+	"runReport":           runReportCommand,
 }
 
 // archiveCommand decodes one DELETE /v1/<collection>/{id} into the archive

--- a/backend/internal/compose/agentcommand.go
+++ b/backend/internal/compose/agentcommand.go
@@ -16,11 +16,7 @@ import (
 	"encoding/json"
 	"net/http"
 
-	chi "github.com/go-chi/chi/v5"
-
 	"github.com/gradionhq/margince/backend/internal/modules/agents"
-	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
-	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
 )
 
@@ -129,12 +125,9 @@ var restCommands = map[string]func(pol agentPolicy, deps restCommandDeps, r *htt
 //
 //nolint:ireturn // a decoder's whole product is the erased command-and-resolver pair the table above is typed by
 func archiveCommand(pol agentPolicy, deps restCommandDeps, r *http.Request, _ []byte) (agents.GovernedCall, error) {
-	id, err := ids.Parse(chi.URLParam(r, "id"))
+	id, err := routedID(r)
 	if err != nil {
-		// Existence-hiding, and the answer this door already gave: "that is not
-		// a uuid" and "there is no such row" must read alike, or the shape of a
-		// caller's id tells them which rows exist.
-		return nil, apperrors.ErrNotFound
+		return nil, err
 	}
 	return agents.NewArchiveCall(deps.records, agents.ArchiveCommand{
 		RecordType: string(pol.RecordType),
@@ -165,9 +158,9 @@ func createCommand(pol agentPolicy, _ restCommandDeps, _ *http.Request, body []b
 //
 //nolint:ireturn // a decoder's whole product is the erased command-and-resolver pair the table above is typed by
 func patchCommand(pol agentPolicy, deps restCommandDeps, r *http.Request, body []byte) (agents.GovernedCall, error) {
-	id, err := ids.Parse(chi.URLParam(r, "id"))
+	id, err := routedID(r)
 	if err != nil {
-		return nil, apperrors.ErrNotFound
+		return nil, err
 	}
 	return agents.NewPatchCall(deps.records, agents.PatchCommand{
 		RecordType: string(pol.RecordType),

--- a/backend/internal/compose/agentcommand.go
+++ b/backend/internal/compose/agentcommand.go
@@ -13,6 +13,7 @@ package compose
 // policy and dynamicTierInputs, the inbox line by restSummary.
 
 import (
+	"encoding/json"
 	"net/http"
 
 	chi "github.com/go-chi/chi/v5"
@@ -46,7 +47,18 @@ type restCommandDeps struct {
 // entry resolves its staged target by walking the route
 // (stagedTargetByRoute) instead, which is the guess this seam replaces family
 // by family (gradionhq/margince-poc-v1#928).
-var restCommands = map[string]func(pol agentPolicy, deps restCommandDeps, r *http.Request) (agents.GovernedCall, error){
+//
+// Six of the thirteen create routes are deliberately ABSENT even though
+// create_record is their governing tool: custom_field, list, offer_template,
+// product, saved_view and tag create through their own module's handler, never
+// through create_record's own datasource-provider write path, so
+// createResolver.Guards' "does this verb serve this record type" refusal
+// (command.go) does not describe them — it would hard-refuse a create that
+// works fine, where stagedTargetByRoute already stages the correct shape
+// (their type, and no id, since none of these routes carries one). Patch has
+// no equivalent gap: patchResolver.Guards has no such refusal, so every
+// update_record patch is registered.
+var restCommands = map[string]func(pol agentPolicy, deps restCommandDeps, r *http.Request, body []byte) (agents.GovernedCall, error){
 	"archiveActivity":      archiveCommand,
 	"archiveDeal":          archiveCommand,
 	"archiveList":          archiveCommand,
@@ -59,6 +71,26 @@ var restCommands = map[string]func(pol agentPolicy, deps restCommandDeps, r *htt
 	"archiveRelationship":  archiveCommand,
 	"archiveSavedView":     archiveCommand,
 	"archiveTag":           archiveCommand,
+
+	"createDeal":         createCommand,
+	"createLead":         createCommand,
+	"createOrganization": createCommand,
+	"createPerson":       createCommand,
+	"createProject":      createCommand,
+	"createRelationship": createCommand,
+
+	opRenameCustomField:         patchCommand,
+	"updateActivity":            patchCommand,
+	"updateDeal":                patchCommand,
+	"updateLead":                patchCommand,
+	"updateOffer":               patchCommand,
+	"updateOrganization":        patchCommand,
+	"updatePerson":              patchCommand,
+	"updateProduct":             patchCommand,
+	"updateProject":             patchCommand,
+	"updateRelationship":        patchCommand,
+	"updateSavedView":           patchCommand,
+	"updateWebhookSubscription": patchCommand,
 }
 
 // archiveCommand decodes one DELETE /v1/<collection>/{id} into the archive
@@ -70,7 +102,7 @@ var restCommands = map[string]func(pol agentPolicy, deps restCommandDeps, r *htt
 // the gate admitted against.
 //
 //nolint:ireturn // a decoder's whole product is the erased command-and-resolver pair the table above is typed by
-func archiveCommand(pol agentPolicy, deps restCommandDeps, r *http.Request) (agents.GovernedCall, error) {
+func archiveCommand(pol agentPolicy, deps restCommandDeps, r *http.Request, _ []byte) (agents.GovernedCall, error) {
 	id, err := ids.Parse(chi.URLParam(r, "id"))
 	if err != nil {
 		// Existence-hiding, and the answer this door already gave: "that is not
@@ -81,5 +113,39 @@ func archiveCommand(pol agentPolicy, deps restCommandDeps, r *http.Request) (age
 	return agents.NewArchiveCall(deps.records, agents.ArchiveCommand{
 		RecordType: string(pol.RecordType),
 		ID:         id,
+	}), nil
+}
+
+// createCommand decodes one POST /v1/<collection> into the create command.
+// The REST body IS the record's fields — unlike create_record's own tool
+// arguments, there is no {record_type, fields} envelope to unwrap, because
+// the route already names the type.
+//
+// body is the buffered copy stageRefusal already hashed into
+// canonicalRESTCall (agentgatestaging.go), not a second read of r.Body: a
+// stream has one honest reading, and the gate already took it.
+//
+//nolint:ireturn,unparam // ireturn: a decoder's whole product is the erased command-and-resolver pair the table above is typed by. unparam: the error is always nil TODAY (a create has no id to fail parsing), but every restCommands entry shares this signature, and archiveCommand/patchCommand both use theirs
+func createCommand(pol agentPolicy, _ restCommandDeps, _ *http.Request, body []byte) (agents.GovernedCall, error) {
+	return agents.NewCreateCall(agents.CreateCommand{
+		RecordType: string(pol.RecordType),
+		Fields:     json.RawMessage(body),
+	}), nil
+}
+
+// patchCommand decodes one PATCH /v1/<collection>/{id} into the patch
+// command, the same existence-hiding answer to a malformed id as
+// archiveCommand, and the same buffered body as createCommand.
+//
+//nolint:ireturn // a decoder's whole product is the erased command-and-resolver pair the table above is typed by
+func patchCommand(pol agentPolicy, deps restCommandDeps, r *http.Request, body []byte) (agents.GovernedCall, error) {
+	id, err := ids.Parse(chi.URLParam(r, "id"))
+	if err != nil {
+		return nil, apperrors.ErrNotFound
+	}
+	return agents.NewPatchCall(deps.records, agents.PatchCommand{
+		RecordType: string(pol.RecordType),
+		ID:         id,
+		Fields:     json.RawMessage(body),
 	}), nil
 }

--- a/backend/internal/compose/agentcommand.go
+++ b/backend/internal/compose/agentcommand.go
@@ -114,15 +114,23 @@ var restCommands = map[string]func(pol agentPolicy, deps restCommandDeps, r *htt
 	"setProjectStakeholder":           setStakeholderCommand,
 	"removeProjectStakeholder":        removeStakeholderCommand,
 
-	// The seven bespoke auto-execute commands (agentcommandnested.go): nested
-	// creates and child/membership actions that are 🟢 today, so none of
-	// these has ever staged — registered anyway, because the route walk's
-	// guess (stagedTargetByRoute) is the one this table replaces family by
-	// family, and for createOffer that guess is provably wrong today
-	// (gradionhq/margince-poc-v1#1046). Six of the seven share their
-	// operationId constant with agentsplit.go's actionShapedUpdateOps
-	// (opAddListMember's own comment says why); createOffer has no such
-	// twin, since create_record never reaches the split.
+	// The seven bespoke auto-execute commands (agentcommandnested.go). Six of
+	// the seven — every one but upsertPartner — are nested creates or
+	// child/membership actions that are 🟢 today and have NEVER staged:
+	// registered anyway, because the route walk's guess (stagedTargetByRoute)
+	// is the one this table replaces family by family, and for createOffer
+	// that guess is provably wrong today (gradionhq/margince-poc-v1#1046).
+	// upsertPartner is the one exception: it stages TODAY, whenever
+	// splitOrRedeemUpdate's per-field probe finds a human-owned conflict
+	// (agentsplit.go's actionShapedUpdateOps — upsertPartner is deliberately
+	// NOT a member — explains why), so this entry is already load-bearing,
+	// not merely future-proofing. Five of the seven share their operationId
+	// constant with agentsplit.go's own (opAddListMember's own comment says
+	// why); upsertPartner shares the CONSTANT with agentsplit.go too (its
+	// restCommands entry and its exclusion from actionShapedUpdateOps must
+	// name the identical operationId), though it is not a MEMBER of that
+	// map; createOffer has no such twin at all, since create_record never
+	// reaches the split.
 	opAddListMember:       addListMemberCommand,
 	opApplyTag:            applyTagCommand,
 	opAddOfferLineItem:    addOfferLineItemCommand,

--- a/backend/internal/compose/agentcommand.go
+++ b/backend/internal/compose/agentcommand.go
@@ -113,6 +113,23 @@ var restCommands = map[string]func(pol agentPolicy, deps restCommandDeps, r *htt
 	"updateCustomFieldOptions":        updateCustomFieldOptionsCommand,
 	"setProjectStakeholder":           setStakeholderCommand,
 	"removeProjectStakeholder":        removeStakeholderCommand,
+
+	// The seven bespoke auto-execute commands (agentcommandnested.go): nested
+	// creates and child/membership actions that are 🟢 today, so none of
+	// these has ever staged — registered anyway, because the route walk's
+	// guess (stagedTargetByRoute) is the one this table replaces family by
+	// family, and for createOffer that guess is provably wrong today
+	// (gradionhq/margince-poc-v1#1046). Six of the seven share their
+	// operationId constant with agentsplit.go's actionShapedUpdateOps
+	// (opAddListMember's own comment says why); createOffer has no such
+	// twin, since create_record never reaches the split.
+	opAddListMember:       addListMemberCommand,
+	opApplyTag:            applyTagCommand,
+	opAddOfferLineItem:    addOfferLineItemCommand,
+	opUpdateOfferLineItem: updateOfferLineItemCommand,
+	opRemoveOfferLineItem: removeOfferLineItemCommand,
+	"createOffer":         createOfferCommand,
+	opUpsertPartner:       upsertPartnerCommand,
 }
 
 // archiveCommand decodes one DELETE /v1/<collection>/{id} into the archive

--- a/backend/internal/compose/agentcommand.go
+++ b/backend/internal/compose/agentcommand.go
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The REST door's half of the governance seam (modules/agents/command.go):
+// what turns an HTTP request into the operation's typed command.
+//
+// The door decodes; it does not interpret. Everything the gate must know about
+// the call it decoded — what the approval binds to, what would be refused
+// anyway — comes back from the resolver the command is bound to, which is the
+// same resolver the tool door reaches for the same operation.
+
+import (
+	"net/http"
+
+	chi "github.com/go-chi/chi/v5"
+
+	"github.com/gradionhq/margince/backend/internal/modules/agents"
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
+)
+
+// restCommands maps a crm.yaml operationId to the decoder that turns an HTTP
+// request into the operation's typed command, bound to the resolver that
+// speaks it.
+//
+// The table is deliberately incomplete: an operation with no entry still
+// resolves its staged target by walking the route (stagedTargetByRoute), which
+// is the guess this seam replaces one operation family at a time. The walk is
+// what goes away as the entries arrive, and the fail-closed refusal
+// dynamicTierInputs already takes for the tier question is what replaces it.
+var restCommands = map[string]func(pol agentPolicy, records datasource.SystemOfRecordProvider, r *http.Request) (agents.GovernedCall, error){
+	"archiveActivity":      archiveCommand,
+	"archiveDeal":          archiveCommand,
+	"archiveList":          archiveCommand,
+	"archiveOffer":         archiveCommand,
+	"archiveOfferTemplate": archiveCommand,
+	"archiveOrganization":  archiveCommand,
+	"archivePerson":        archiveCommand,
+	"archiveProduct":       archiveCommand,
+	"archiveProject":       archiveCommand,
+	"archiveRelationship":  archiveCommand,
+	"archiveSavedView":     archiveCommand,
+	"archiveTag":           archiveCommand,
+}
+
+// archiveCommand decodes one DELETE /v1/<collection>/{id} into the archive
+// command.
+//
+// The record type is read off the route's own policy entry rather than written
+// here a second time: the entry is generated from the contract's x-mcp-tool
+// annotation, so a type spelled again in this file could disagree with the one
+// the gate admitted against.
+func archiveCommand(pol agentPolicy, records datasource.SystemOfRecordProvider, r *http.Request) (agents.GovernedCall, error) {
+	id, err := ids.Parse(chi.URLParam(r, "id"))
+	if err != nil {
+		// Existence-hiding, and the answer this door already gave: "that is not
+		// a uuid" and "there is no such row" must read alike, or the shape of a
+		// caller's id tells them which rows exist.
+		return nil, apperrors.ErrNotFound
+	}
+	return agents.Bind(agents.NewArchiveResolver(records), agents.ArchiveCommand{
+		RecordType: string(pol.RecordType),
+		ID:         id,
+	}), nil
+}

--- a/backend/internal/compose/agentcommand.go
+++ b/backend/internal/compose/agentcommand.go
@@ -23,6 +23,21 @@ import (
 	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
 )
 
+// restCommandDeps is what a decoder needs to build its command's resolver.
+//
+// A struct rather than a positional argument because the dependency is per
+// FAMILY: the archive reads the record seam, an update_record command will want
+// the field-ownership probe, a send the comms seam. Passed positionally, each
+// family added would re-sign this map type and every entry already in it — the
+// churn a table of twelve identical signatures is least able to absorb.
+//
+// It is not tierDeps, which answers a different question (what tier is this
+// call) and is consulted before admission rather than at staging; the two
+// happen to share a provider today and have no reason to share a shape.
+type restCommandDeps struct {
+	records datasource.SystemOfRecordProvider
+}
+
 // restCommands maps a crm.yaml operationId to the decoder that turns an HTTP
 // request into the operation's typed command, bound to the resolver that
 // speaks it.
@@ -31,7 +46,7 @@ import (
 // entry resolves its staged target by walking the route
 // (stagedTargetByRoute) instead, which is the guess this seam replaces family
 // by family (gradionhq/margince-poc-v1#928).
-var restCommands = map[string]func(pol agentPolicy, records datasource.SystemOfRecordProvider, r *http.Request) (agents.GovernedCall, error){
+var restCommands = map[string]func(pol agentPolicy, deps restCommandDeps, r *http.Request) (agents.GovernedCall, error){
 	"archiveActivity":      archiveCommand,
 	"archiveDeal":          archiveCommand,
 	"archiveList":          archiveCommand,
@@ -55,7 +70,7 @@ var restCommands = map[string]func(pol agentPolicy, records datasource.SystemOfR
 // the gate admitted against.
 //
 //nolint:ireturn // a decoder's whole product is the erased command-and-resolver pair the table above is typed by
-func archiveCommand(pol agentPolicy, records datasource.SystemOfRecordProvider, r *http.Request) (agents.GovernedCall, error) {
+func archiveCommand(pol agentPolicy, deps restCommandDeps, r *http.Request) (agents.GovernedCall, error) {
 	id, err := ids.Parse(chi.URLParam(r, "id"))
 	if err != nil {
 		// Existence-hiding, and the answer this door already gave: "that is not
@@ -63,7 +78,7 @@ func archiveCommand(pol agentPolicy, records datasource.SystemOfRecordProvider, 
 		// caller's id tells them which rows exist.
 		return nil, apperrors.ErrNotFound
 	}
-	return agents.Bind(agents.NewArchiveResolver(records), agents.ArchiveCommand{
+	return agents.NewArchiveCall(deps.records, agents.ArchiveCommand{
 		RecordType: string(pol.RecordType),
 		ID:         id,
 	}), nil

--- a/backend/internal/compose/agentcommand.go
+++ b/backend/internal/compose/agentcommand.go
@@ -6,10 +6,11 @@ package compose
 // The REST door's half of the governance seam (modules/agents/command.go):
 // what turns an HTTP request into the operation's typed command.
 //
-// The door decodes; it does not interpret. Everything the gate must know about
-// the call it decoded — what the approval binds to, what would be refused
-// anyway — comes back from the resolver the command is bound to, which is the
-// same resolver the tool door reaches for the same operation.
+// The door decodes; it does not interpret. What the approval binds to, and what
+// would be refused anyway, come back from the resolver the command is bound to
+// — the same resolver the tool door reaches for the same operation. The rest of
+// the gate's questions are still answered elsewhere: the tier by the generated
+// policy and dynamicTierInputs, the inbox line by restSummary.
 
 import (
 	"net/http"
@@ -26,11 +27,10 @@ import (
 // request into the operation's typed command, bound to the resolver that
 // speaks it.
 //
-// The table is deliberately incomplete: an operation with no entry still
-// resolves its staged target by walking the route (stagedTargetByRoute), which
-// is the guess this seam replaces one operation family at a time. The walk is
-// what goes away as the entries arrive, and the fail-closed refusal
-// dynamicTierInputs already takes for the tier question is what replaces it.
+// The table covers one operation family, not the surface: an operation with no
+// entry resolves its staged target by walking the route
+// (stagedTargetByRoute) instead, which is the guess this seam replaces family
+// by family (gradionhq/margince-poc-v1#928).
 var restCommands = map[string]func(pol agentPolicy, records datasource.SystemOfRecordProvider, r *http.Request) (agents.GovernedCall, error){
 	"archiveActivity":      archiveCommand,
 	"archiveDeal":          archiveCommand,

--- a/backend/internal/compose/agentcommand.go
+++ b/backend/internal/compose/agentcommand.go
@@ -55,7 +55,11 @@ type restCommandDeps struct {
 // by family (gradionhq/margince-poc-v1#928).
 //
 // Every create and every whole-record patch route is registered, all
-// twenty-five. Six of the thirteen create record types (custom_field, list,
+// twenty-six — thirteen creates and thirteen whole-record writes. Twelve of
+// those thirteen route as PATCH; updateOfferTemplate is a PUT, a full replace
+// rather than a field patch, and is the same shape for everything this table
+// answers: one routed {id} naming the record the write lands on, and a body
+// that is that record's fields. Six of the thirteen create record types (custom_field, list,
 // offer_template, product, saved_view, tag) create through their own
 // module's handler, never through create_record's own datasource-provider
 // write path — but that asymmetry is not this table's to answer for.
@@ -98,6 +102,7 @@ var restCommands = map[string]func(pol agentPolicy, deps restCommandDeps, r *htt
 
 	opRenameCustomField:         patchCommand,
 	"updateActivity":            patchCommand,
+	"updateOfferTemplate":       patchCommand,
 	"updateDeal":                patchCommand,
 	"updateLead":                patchCommand,
 	"updateOffer":               patchCommand,

--- a/backend/internal/compose/agentcommand.go
+++ b/backend/internal/compose/agentcommand.go
@@ -142,7 +142,7 @@ var restCommands = map[string]func(pol agentPolicy, deps restCommandDeps, r *htt
 	// and for createOffer that shape is provably wrong: the routed id is the
 	// parent deal (gradionhq/margince-poc-v1#1046).
 	// upsertPartner is the one exception: it stages TODAY, through BOTH
-	// splitOrRedeemUpdate branches a human-owned conflict can take —
+	// splitHumanOwnedUpdate branches a human-owned conflict can take —
 	// stageRefusal when every touched field is human-owned, and
 	// applyAutoExecuteAndStageResidue's residue when only some are
 	// (agentsplit.go) — since both resolve their staged target through this

--- a/backend/internal/compose/agentcommand.go
+++ b/backend/internal/compose/agentcommand.go
@@ -120,17 +120,21 @@ var restCommands = map[string]func(pol agentPolicy, deps restCommandDeps, r *htt
 	// registered anyway, because the route walk's guess (stagedTargetByRoute)
 	// is the one this table replaces family by family, and for createOffer
 	// that guess is provably wrong today (gradionhq/margince-poc-v1#1046).
-	// upsertPartner is the one exception: it stages TODAY, whenever
-	// splitOrRedeemUpdate's per-field probe finds a human-owned conflict
-	// (agentsplit.go's actionShapedUpdateOps — upsertPartner is deliberately
-	// NOT a member — explains why), so this entry is already load-bearing,
-	// not merely future-proofing. Five of the seven share their operationId
-	// constant with agentsplit.go's own (opAddListMember's own comment says
-	// why); upsertPartner shares the CONSTANT with agentsplit.go too (its
-	// restCommands entry and its exclusion from actionShapedUpdateOps must
-	// name the identical operationId), though it is not a MEMBER of that
-	// map; createOffer has no such twin at all, since create_record never
-	// reaches the split.
+	// upsertPartner is the one exception: it stages TODAY, through BOTH
+	// splitOrRedeemUpdate branches a human-owned conflict can take —
+	// stageRefusal when every touched field is human-owned, and
+	// applyAutoExecuteAndStageResidue's residue when only some are
+	// (agentsplit.go) — since both resolve their staged target through this
+	// same table rather than off pol.RecordType directly (agentsplit.go's
+	// actionShapedUpdateOps — upsertPartner is deliberately NOT a member —
+	// explains why "partner" is the wrong target type). So this entry is
+	// already load-bearing on two call sites, not merely future-proofing.
+	// Five of the seven share their operationId constant with agentsplit.go's
+	// own (opAddListMember's own comment says why); upsertPartner shares the
+	// CONSTANT with agentsplit.go too (its restCommands entry and its
+	// exclusion from actionShapedUpdateOps must name the identical
+	// operationId), though it is not a MEMBER of that map; createOffer has no
+	// such twin at all, since create_record never reaches the split.
 	opAddListMember:       addListMemberCommand,
 	opApplyTag:            applyTagCommand,
 	opAddOfferLineItem:    addOfferLineItemCommand,

--- a/backend/internal/compose/agentcommand.go
+++ b/backend/internal/compose/agentcommand.go
@@ -48,16 +48,20 @@ type restCommandDeps struct {
 // (stagedTargetByRoute) instead, which is the guess this seam replaces family
 // by family (gradionhq/margince-poc-v1#928).
 //
-// Six of the thirteen create routes are deliberately ABSENT even though
-// create_record is their governing tool: custom_field, list, offer_template,
-// product, saved_view and tag create through their own module's handler, never
-// through create_record's own datasource-provider write path, so
-// createResolver.Guards' "does this verb serve this record type" refusal
-// (command.go) does not describe them — it would hard-refuse a create that
-// works fine, where stagedTargetByRoute already stages the correct shape
-// (their type, and no id, since none of these routes carries one). Patch has
-// no equivalent gap: patchResolver.Guards has no such refusal, so every
-// update_record patch is registered.
+// Every create and every whole-record patch route is registered, all
+// twenty-five. Six of the thirteen create record types (custom_field, list,
+// offer_template, product, saved_view, tag) create through their own
+// module's handler, never through create_record's own datasource-provider
+// write path — but that asymmetry is not this table's to answer for.
+// createResolver.Guards (command.go) deliberately asks nothing about whether
+// create_record itself "serves" a record type: that question has a
+// door-dependent answer (create_record's own Handle cannot express these six
+// types; the REST operation that creates one performs it fine through its
+// own handler), so it is asked once, at createRecord.StageInfo (tools.go),
+// on the one door where it is a fact about the executor rather than about
+// the operation. Every whole-record patch route is registered for the same
+// reason patch never had that question at all — see patchResolver.Guards'
+// own comment.
 var restCommands = map[string]func(pol agentPolicy, deps restCommandDeps, r *http.Request, body []byte) (agents.GovernedCall, error){
 	"archiveActivity":      archiveCommand,
 	"archiveDeal":          archiveCommand,
@@ -72,12 +76,19 @@ var restCommands = map[string]func(pol agentPolicy, deps restCommandDeps, r *htt
 	"archiveSavedView":     archiveCommand,
 	"archiveTag":           archiveCommand,
 
-	"createDeal":         createCommand,
-	"createLead":         createCommand,
-	"createOrganization": createCommand,
-	"createPerson":       createCommand,
-	"createProject":      createCommand,
-	"createRelationship": createCommand,
+	"createCustomField":         createCommand,
+	"createDeal":                createCommand,
+	"createLead":                createCommand,
+	"createList":                createCommand,
+	"createOfferTemplate":       createCommand,
+	"createOrganization":        createCommand,
+	"createPerson":              createCommand,
+	"createProduct":             createCommand,
+	"createProject":             createCommand,
+	"createRelationship":        createCommand,
+	"createSavedView":           createCommand,
+	"createTag":                 createCommand,
+	"createWebhookSubscription": createCommand,
 
 	opRenameCustomField:         patchCommand,
 	"updateActivity":            patchCommand,

--- a/backend/internal/compose/agentcommand_createpatch_test.go
+++ b/backend/internal/compose/agentcommand_createpatch_test.go
@@ -1,0 +1,244 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The create and patch families' half of the governance seam
+// (modules/agents/command.go), the same shape agentcommand_test.go proves for
+// archive: createCommand and patchCommand, registered in restCommands
+// alongside archiveCommand, resolving through agents.NewCreateCall /
+// agents.NewPatchCall.
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
+)
+
+// createRequest is a POST against one of the create routes, carrying body as
+// the request payload — the shape createCommand decodes. Unlike an archive or
+// a patch, a create route carries no {id} for the router to have bound.
+func createRequest(path string, body []byte) *http.Request {
+	return httptest.NewRequest(http.MethodPost, path, bytes.NewReader(body))
+}
+
+// patchRequest is a PATCH against one of the patch routes, carrying the {id}
+// the chi router would have bound plus the request body.
+func patchRequest(path string, id ids.UUID, body []byte) *http.Request {
+	req := httptest.NewRequest(http.MethodPatch, path+"/"+id.String(), bytes.NewReader(body))
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", id.String())
+	return req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+}
+
+// Every create operation the record seam actually serves must decode into a
+// command. Derived from the generated policy table rather than a remembered
+// list of six: create_record's own tool tag covers thirteen routes, not all
+// of which belong here. createOffer (POST /v1/deals/{id}/offers) nests under
+// a parent resource, excluded by route shape (a bare collection path carries
+// no `{`). The other six — custom_field, list, offer_template, product,
+// saved_view, tag — create through their OWN module's handler rather than
+// create_record's datasource-provider write path, so createResolver.Guards'
+// "verb does not serve this type" refusal does not describe them; wiring them
+// here would hard-refuse a create that works fine (agentcommand.go's own
+// comment states the bound). datasource.EntityTypes() is that same served
+// vocabulary (createShapes, command.go), read off the seam's own port rather
+// than re-hardcoded.
+func TestEveryAgentReachableCreateOperationDecodesIntoACommand(t *testing.T) {
+	checked := 0
+	for route, pol := range agentPolicies {
+		if pol.Access != accessTool || pol.Tool != "create_record" || strings.Contains(route, "{") {
+			continue
+		}
+		if !slices.Contains(datasource.EntityTypes(), datasource.EntityType(pol.RecordType)) {
+			continue
+		}
+		checked++
+		if _, described := restCommands[pol.Op]; !described {
+			t.Errorf("%s (%s) creates a record the seam serves but decodes into no command, so its staged "+
+				"target is still guessed from the route while the tool door reads it from the call", route, pol.Op)
+		}
+	}
+	if checked != 6 {
+		t.Errorf("the policy table carries %d agent-reachable seam-served create operations, want 6 — if the "+
+			"contract gained or lost one, this seam's coverage moved with it", checked)
+	}
+}
+
+// Every patch operation the contract lets an agent reach must decode into a
+// command. update_record's own tool tag covers far more than a whole-record
+// field patch — child-resource and membership mutations like
+// updateOfferLineItem or applyTag carry a second path segment or a second
+// path parameter after {id}, and agentsplit.go's actionShapedUpdateOps
+// already draws that line for the auto-execute side. The filter here draws
+// the same line independently, by route shape: a field-patch twin routes as
+// PATCH .../{id} and nothing after it — one path parameter, named id, at the
+// very end. Unlike create, EVERY one of these twelve belongs here: patch has
+// no equivalent "verb does not serve" refusal to trip over (see
+// patchResolver.Guards' own comment in command.go).
+func TestEveryAgentReachablePatchOperationDecodesIntoACommand(t *testing.T) {
+	checked := 0
+	for route, pol := range agentPolicies {
+		if pol.Access != accessTool || pol.Tool != "update_record" || !strings.HasPrefix(route, "PATCH ") {
+			continue
+		}
+		if !strings.HasSuffix(route, "/{id}") || strings.Count(route, "{") != 1 {
+			continue
+		}
+		checked++
+		if _, described := restCommands[pol.Op]; !described {
+			t.Errorf("%s (%s) patches a record but decodes into no command, so its staged target is still "+
+				"guessed from the route while the tool door reads it from the call", route, pol.Op)
+		}
+	}
+	if checked != 12 {
+		t.Errorf("the policy table carries %d agent-reachable whole-record patch operations, want 12 — if the "+
+			"contract gained or lost one, this seam's coverage moved with it", checked)
+	}
+}
+
+// A served create type stages the record TYPE with no id: the row does not
+// exist yet, so there is nothing for the approvals surface to probe or pin.
+func TestACreateStagesItsRecordTypeWithNoTargetID(t *testing.T) {
+	staging := &capturingApprovals{}
+	pol := agentPolicy{Op: "createProject", Access: accessTool, Tool: "create_record", RecordType: recordTypeProject}
+	body := []byte(`{"name":"New Project","organization_id":"018f2a10-0000-7000-8000-000000000001"}`)
+
+	stageRefusal(httptest.NewRecorder(), createRequest("/v1/projects", body), staging, restCommandDeps{}, pol, body)
+
+	if staging.last.TargetType != "project" {
+		t.Fatalf("staged target_type = %q, want \"project\"", staging.last.TargetType)
+	}
+	if !staging.last.TargetID.IsZero() {
+		t.Errorf("staged target_id = %s, want zero — a create names no row an approval could pin",
+			staging.last.TargetID)
+	}
+}
+
+// A create OUTSIDE create_record's own served vocabulary still stages, by the
+// route walk (stagedTargetByRoute) rather than through createResolver — the
+// same shape TestAnArchiveOutsideTheToolSchemaStagesTheRowItNames proves for
+// archive. custom_field is one of the six create routes restCommands
+// deliberately leaves unregistered (see its own doc comment); proving it
+// stages successfully is what makes that omission a choice rather than an
+// untested gap.
+func TestACreateOutsideTheToolSchemaStagesItsRecordTypeWithNoTargetID(t *testing.T) {
+	staging := &capturingApprovals{}
+	pol := agentPolicy{Op: "createCustomField", Access: accessTool, Tool: "create_record", RecordType: recordTypeCustomField}
+	body := []byte(`{"name":"Champion Score","field_type":"text"}`)
+
+	stageRefusal(httptest.NewRecorder(), createRequest("/v1/custom-fields", body), staging, restCommandDeps{}, pol, body)
+
+	if staging.last.TargetType != "custom_field" {
+		t.Fatalf("staged target_type = %q, want \"custom_field\"", staging.last.TargetType)
+	}
+	if !staging.last.TargetID.IsZero() {
+		t.Errorf("staged target_id = %s, want zero", staging.last.TargetID)
+	}
+}
+
+// A served patch type stages the record TYPE and the id the route named — the
+// row a human's decision reads and the redemption pins.
+func TestAPatchStagesItsRecordAndID(t *testing.T) {
+	staging := &capturingApprovals{}
+	pol := agentPolicy{Op: "updateProject", Access: accessTool, Tool: "update_record", RecordType: recordTypeProject}
+	projectID := ids.NewV7()
+	body := []byte(`{"name":"Renamed"}`)
+
+	stageRefusal(httptest.NewRecorder(), patchRequest("/v1/projects", projectID, body), staging,
+		restCommandDeps{records: seamRecord{}}, pol, body)
+
+	if staging.last.TargetType != "project" || staging.last.TargetID != projectID {
+		t.Fatalf("staged target = (%s,%s), want (project,%s)", staging.last.TargetType, staging.last.TargetID, projectID)
+	}
+}
+
+// A malformed id is a miss, not a parse failure, for a patch exactly as it is
+// for an archive: "that is not a uuid" and "there is no such row" must read
+// alike.
+func TestAMalformedPatchIDAnswersNotFound(t *testing.T) {
+	staging := &capturingApprovals{}
+	pol := agentPolicy{Op: "updateProject", Access: accessTool, Tool: "update_record", RecordType: recordTypeProject}
+	body := []byte(`{"name":"Renamed"}`)
+
+	req := httptest.NewRequest(http.MethodPatch, "/v1/projects/not-a-uuid", bytes.NewReader(body))
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", "not-a-uuid")
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+
+	rec := httptest.NewRecorder()
+	stageRefusal(rec, req, staging, restCommandDeps{records: seamRecord{}}, pol, body)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("a malformed patch id answered %d, want 404", rec.Code)
+	}
+	if staging.last.Tool != "" {
+		t.Errorf("an approval was staged for %q against an id that names no row", staging.last.Tool)
+	}
+}
+
+// A patch record type the record seam does not serve still stages, with its
+// own type and id — the servedByTheRecordSeam short-circuit
+// (modules/agents/command.go) standing down rather than faulting on a read
+// the seam cannot answer. Staged against a provider that fails EVERY read, so
+// a resolver that consulted the seam anyway fails here rather than passing on
+// a lenient stub — the same proof shape as
+// TestAnArchiveOutsideTheToolSchemaStagesTheRowItNames.
+func TestAPatchOutsideTheToolSchemaStagesTheRowItNames(t *testing.T) {
+	staging := &capturingApprovals{}
+	pol := agentPolicy{
+		Op: "updateWebhookSubscription", Access: accessTool, Tool: "update_record",
+		RecordType: recordTypeWebhookSubscription,
+	}
+	subID := ids.NewV7()
+	body := []byte(`{"state":"paused"}`)
+
+	stageRefusal(httptest.NewRecorder(), patchRequest("/v1/webhook-subscriptions", subID, body), staging,
+		restCommandDeps{records: hiddenRecord{}}, pol, body)
+
+	if staging.last.TargetType != "webhook_subscription" || staging.last.TargetID != subID {
+		t.Fatalf("staged target = (%s,%s), want (webhook_subscription,%s) — a webhook subscription is patched "+
+			"over REST whether or not the record seam has ever heard of one",
+			staging.last.TargetType, staging.last.TargetID, subID)
+	}
+}
+
+// An unknown field over REST answers 422 validation_error, not an opaque 500.
+// rejectUnknownFields (modules/agents/recordfields.go) returns a
+// *agents.BadArgsError, an MCP-tool-door type httperr.Classify has no
+// built-in notion of — this is the first REST path to reach one, and without
+// BadArgsError.MessageFault (badargs.go) this would answer as an unhandled
+// server fault instead of the caller mistake it is.
+func TestAPatchWithAnUnknownFieldAnswers422NotAn500(t *testing.T) {
+	staging := &capturingApprovals{}
+	pol := agentPolicy{Op: "updateProject", Access: accessTool, Tool: "update_record", RecordType: recordTypeProject}
+	projectID := ids.NewV7()
+	body := []byte(`{"nickname":"typo"}`)
+
+	rec := httptest.NewRecorder()
+	stageRefusal(rec, patchRequest("/v1/projects", projectID, body), staging,
+		restCommandDeps{records: seamRecord{}}, pol, body)
+
+	var problem struct {
+		Code string `json:"code"`
+	}
+	if decErr := json.NewDecoder(rec.Body).Decode(&problem); decErr != nil {
+		t.Fatalf("decoding the problem body: %v", decErr)
+	}
+	if rec.Code != http.StatusUnprocessableEntity || problem.Code != "validation_error" {
+		t.Errorf("an unknown field answered %d %q, want %d validation_error", rec.Code, problem.Code, http.StatusUnprocessableEntity)
+	}
+	if staging.last.Tool != "" {
+		t.Errorf("an approval was staged for %q against a payload that was never a valid patch", staging.last.Tool)
+	}
+}

--- a/backend/internal/compose/agentcommand_createpatch_test.go
+++ b/backend/internal/compose/agentcommand_createpatch_test.go
@@ -15,7 +15,6 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
 
 	"github.com/go-chi/chi/v5"
@@ -37,80 +36,6 @@ func patchRequest(path string, id ids.UUID, body []byte) *http.Request {
 	rctx := chi.NewRouteContext()
 	rctx.URLParams.Add("id", id.String())
 	return req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
-}
-
-// Every create operation the contract lets an agent reach must decode into a
-// command. Derived from the generated policy table rather than a remembered
-// list of thirteen: create_record's own tool tag also covers createOffer
-// (POST /v1/deals/{id}/offers), which nests under a parent resource and is
-// out of this family's scope — so the filter is the route shape a top-level
-// collection create actually has, a bare collection path with no `{`, which
-// is what tells the two apart without hand-naming either.
-//
-// Every one of the thirteen belongs here, including the six whose record
-// type (custom_field, list, offer_template, product, saved_view, tag)
-// create_record's own Handle cannot write: createResolver.Guards
-// (command.go) asks nothing about whether the verb "serves" a type, so
-// registering them costs nothing, and the door-dependent question that
-// mattered is answered once, at createRecord.StageInfo, on the door where it
-// is true.
-func TestEveryAgentReachableCreateOperationDecodesIntoACommand(t *testing.T) {
-	checked := 0
-	for route, pol := range agentPolicies {
-		if pol.Access != accessTool || pol.Tool != "create_record" || strings.Contains(route, "{") {
-			continue
-		}
-		checked++
-		if _, described := restCommands[pol.Op]; !described {
-			t.Errorf("%s (%s) creates a record but decodes into no command, so its staged target is still "+
-				"guessed from the route while the tool door reads it from the call", route, pol.Op)
-		}
-	}
-	if checked != 13 {
-		t.Errorf("the policy table carries %d agent-reachable top-level create operations, want 13 — if the "+
-			"contract gained or lost one, this seam's coverage moved with it", checked)
-	}
-}
-
-// Every whole-record write operation the contract lets an agent reach must
-// decode into a command. update_record's own tool tag covers far more than a
-// whole-record write — child-resource and membership mutations like
-// updateOfferLineItem or applyTag carry a second path segment or a second
-// path parameter after {id}, and agentsplit.go's actionShapedUpdateOps
-// already draws that line for the auto-execute side. The filter here draws
-// the same line independently, by ROUTE SHAPE alone: one path parameter,
-// named id, at the very end, and nothing after it.
-//
-// The shape, not the method. Twelve of these route as PATCH and one — the
-// offer template's — as PUT, a full replace rather than a field patch, and
-// the difference changes nothing this seam answers: both name the record in
-// {id} and carry that record's fields in the body. A method-keyed filter is
-// how the PUT came to be invisible to every gate on this surface at once,
-// including canonicalCollectionRoute (agentcommandnested_test.go), which
-// excused it as covered HERE.
-//
-// Unlike create, this family never had a "verb does not serve" refusal to
-// worry about (see patchResolver.Guards' own comment in command.go), so
-// every one of these thirteen belongs here.
-func TestEveryAgentReachableWholeRecordWriteOperationDecodesIntoACommand(t *testing.T) {
-	checked := 0
-	for route, pol := range agentPolicies {
-		if pol.Access != accessTool || pol.Tool != "update_record" {
-			continue
-		}
-		if !strings.HasSuffix(route, "/{id}") || strings.Count(route, "{") != 1 {
-			continue
-		}
-		checked++
-		if _, described := restCommands[pol.Op]; !described {
-			t.Errorf("%s (%s) writes a whole record but decodes into no command, so its staged target is "+
-				"still guessed from the route while the tool door reads it from the call", route, pol.Op)
-		}
-	}
-	if checked != 13 {
-		t.Errorf("the policy table carries %d agent-reachable whole-record write operations, want 13 — if the "+
-			"contract gained or lost one, this seam's coverage moved with it", checked)
-	}
 }
 
 // A served create type stages the record TYPE with no id: the row does not

--- a/backend/internal/compose/agentcommand_createpatch_test.go
+++ b/backend/internal/compose/agentcommand_createpatch_test.go
@@ -72,21 +72,30 @@ func TestEveryAgentReachableCreateOperationDecodesIntoACommand(t *testing.T) {
 	}
 }
 
-// Every patch operation the contract lets an agent reach must decode into a
-// command. update_record's own tool tag covers far more than a whole-record
-// field patch — child-resource and membership mutations like
+// Every whole-record write operation the contract lets an agent reach must
+// decode into a command. update_record's own tool tag covers far more than a
+// whole-record write — child-resource and membership mutations like
 // updateOfferLineItem or applyTag carry a second path segment or a second
 // path parameter after {id}, and agentsplit.go's actionShapedUpdateOps
 // already draws that line for the auto-execute side. The filter here draws
-// the same line independently, by route shape: a field-patch twin routes as
-// PATCH .../{id} and nothing after it — one path parameter, named id, at the
-// very end. Unlike create, patch never had a "verb does not serve" refusal
-// to worry about (see patchResolver.Guards' own comment in command.go), so
-// every one of these twelve belongs here.
-func TestEveryAgentReachablePatchOperationDecodesIntoACommand(t *testing.T) {
+// the same line independently, by ROUTE SHAPE alone: one path parameter,
+// named id, at the very end, and nothing after it.
+//
+// The shape, not the method. Twelve of these route as PATCH and one — the
+// offer template's — as PUT, a full replace rather than a field patch, and
+// the difference changes nothing this seam answers: both name the record in
+// {id} and carry that record's fields in the body. A method-keyed filter is
+// how the PUT came to be invisible to every gate on this surface at once,
+// including canonicalCollectionRoute (agentcommandnested_test.go), which
+// excused it as covered HERE.
+//
+// Unlike create, this family never had a "verb does not serve" refusal to
+// worry about (see patchResolver.Guards' own comment in command.go), so
+// every one of these thirteen belongs here.
+func TestEveryAgentReachableWholeRecordWriteOperationDecodesIntoACommand(t *testing.T) {
 	checked := 0
 	for route, pol := range agentPolicies {
-		if pol.Access != accessTool || pol.Tool != "update_record" || !strings.HasPrefix(route, "PATCH ") {
+		if pol.Access != accessTool || pol.Tool != "update_record" {
 			continue
 		}
 		if !strings.HasSuffix(route, "/{id}") || strings.Count(route, "{") != 1 {
@@ -94,12 +103,12 @@ func TestEveryAgentReachablePatchOperationDecodesIntoACommand(t *testing.T) {
 		}
 		checked++
 		if _, described := restCommands[pol.Op]; !described {
-			t.Errorf("%s (%s) patches a record but decodes into no command, so its staged target is still "+
-				"guessed from the route while the tool door reads it from the call", route, pol.Op)
+			t.Errorf("%s (%s) writes a whole record but decodes into no command, so its staged target is "+
+				"still guessed from the route while the tool door reads it from the call", route, pol.Op)
 		}
 	}
-	if checked != 12 {
-		t.Errorf("the policy table carries %d agent-reachable whole-record patch operations, want 12 — if the "+
+	if checked != 13 {
+		t.Errorf("the policy table carries %d agent-reachable whole-record write operations, want 13 — if the "+
 			"contract gained or lost one, this seam's coverage moved with it", checked)
 	}
 }

--- a/backend/internal/compose/agentcommand_createpatch_test.go
+++ b/backend/internal/compose/agentcommand_createpatch_test.go
@@ -15,14 +15,12 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"slices"
 	"strings"
 	"testing"
 
 	"github.com/go-chi/chi/v5"
 
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
-	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
 )
 
 // createRequest is a POST against one of the create routes, carrying body as
@@ -41,36 +39,35 @@ func patchRequest(path string, id ids.UUID, body []byte) *http.Request {
 	return req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
 }
 
-// Every create operation the record seam actually serves must decode into a
+// Every create operation the contract lets an agent reach must decode into a
 // command. Derived from the generated policy table rather than a remembered
-// list of six: create_record's own tool tag covers thirteen routes, not all
-// of which belong here. createOffer (POST /v1/deals/{id}/offers) nests under
-// a parent resource, excluded by route shape (a bare collection path carries
-// no `{`). The other six — custom_field, list, offer_template, product,
-// saved_view, tag — create through their OWN module's handler rather than
-// create_record's datasource-provider write path, so createResolver.Guards'
-// "verb does not serve this type" refusal does not describe them; wiring them
-// here would hard-refuse a create that works fine (agentcommand.go's own
-// comment states the bound). datasource.EntityTypes() is that same served
-// vocabulary (createShapes, command.go), read off the seam's own port rather
-// than re-hardcoded.
+// list of thirteen: create_record's own tool tag also covers createOffer
+// (POST /v1/deals/{id}/offers), which nests under a parent resource and is
+// out of this family's scope — so the filter is the route shape a top-level
+// collection create actually has, a bare collection path with no `{`, which
+// is what tells the two apart without hand-naming either.
+//
+// Every one of the thirteen belongs here, including the six whose record
+// type (custom_field, list, offer_template, product, saved_view, tag)
+// create_record's own Handle cannot write: createResolver.Guards
+// (command.go) asks nothing about whether the verb "serves" a type, so
+// registering them costs nothing, and the door-dependent question that
+// mattered is answered once, at createRecord.StageInfo, on the door where it
+// is true.
 func TestEveryAgentReachableCreateOperationDecodesIntoACommand(t *testing.T) {
 	checked := 0
 	for route, pol := range agentPolicies {
 		if pol.Access != accessTool || pol.Tool != "create_record" || strings.Contains(route, "{") {
 			continue
 		}
-		if !slices.Contains(datasource.EntityTypes(), datasource.EntityType(pol.RecordType)) {
-			continue
-		}
 		checked++
 		if _, described := restCommands[pol.Op]; !described {
-			t.Errorf("%s (%s) creates a record the seam serves but decodes into no command, so its staged "+
-				"target is still guessed from the route while the tool door reads it from the call", route, pol.Op)
+			t.Errorf("%s (%s) creates a record but decodes into no command, so its staged target is still "+
+				"guessed from the route while the tool door reads it from the call", route, pol.Op)
 		}
 	}
-	if checked != 6 {
-		t.Errorf("the policy table carries %d agent-reachable seam-served create operations, want 6 — if the "+
+	if checked != 13 {
+		t.Errorf("the policy table carries %d agent-reachable top-level create operations, want 13 — if the "+
 			"contract gained or lost one, this seam's coverage moved with it", checked)
 	}
 }
@@ -83,9 +80,9 @@ func TestEveryAgentReachableCreateOperationDecodesIntoACommand(t *testing.T) {
 // already draws that line for the auto-execute side. The filter here draws
 // the same line independently, by route shape: a field-patch twin routes as
 // PATCH .../{id} and nothing after it — one path parameter, named id, at the
-// very end. Unlike create, EVERY one of these twelve belongs here: patch has
-// no equivalent "verb does not serve" refusal to trip over (see
-// patchResolver.Guards' own comment in command.go).
+// very end. Unlike create, patch never had a "verb does not serve" refusal
+// to worry about (see patchResolver.Guards' own comment in command.go), so
+// every one of these twelve belongs here.
 func TestEveryAgentReachablePatchOperationDecodesIntoACommand(t *testing.T) {
 	checked := 0
 	for route, pol := range agentPolicies {
@@ -125,13 +122,13 @@ func TestACreateStagesItsRecordTypeWithNoTargetID(t *testing.T) {
 	}
 }
 
-// A create OUTSIDE create_record's own served vocabulary still stages, by the
-// route walk (stagedTargetByRoute) rather than through createResolver — the
-// same shape TestAnArchiveOutsideTheToolSchemaStagesTheRowItNames proves for
-// archive. custom_field is one of the six create routes restCommands
-// deliberately leaves unregistered (see its own doc comment); proving it
-// stages successfully is what makes that omission a choice rather than an
-// untested gap.
+// A create OUTSIDE create_record's own served vocabulary still stages,
+// through createResolver like every other registered create — the same shape
+// TestAnArchiveOutsideTheToolSchemaStagesTheRowItNames proves for archive.
+// custom_field is one of the six create routes whose record type
+// create_record's own Handle cannot write, and createResolver.Guards has no
+// opinion on that (command.go); proving it stages successfully through the
+// resolver is what makes that indifference correct rather than assumed.
 func TestACreateOutsideTheToolSchemaStagesItsRecordTypeWithNoTargetID(t *testing.T) {
 	staging := &capturingApprovals{}
 	pol := agentPolicy{Op: "createCustomField", Access: accessTool, Tool: "create_record", RecordType: recordTypeCustomField}

--- a/backend/internal/compose/agentcommand_integration_test.go
+++ b/backend/internal/compose/agentcommand_integration_test.go
@@ -57,6 +57,10 @@ func TestTheRecordProviderServesExactlyTheSeamVocabulary(t *testing.T) {
 	as := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AdminPerms)
 	native := NewProvider(e.Pool)
 
+	if len(datasource.EntityTypes()) == 0 {
+		t.Fatal("the seam declares no entity type at all — the half of this gate that covers the served " +
+			"types is asserting nothing")
+	}
 	for _, entity := range datasource.EntityTypes() {
 		// A random id: the answer under test is whether this provider ROUTES
 		// the type, and a miss says routed-and-absent as clearly as a hit says

--- a/backend/internal/compose/agentcommand_integration_test.go
+++ b/backend/internal/compose/agentcommand_integration_test.go
@@ -1,0 +1,207 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package compose
+
+// The two claims the archive resolver makes about the world outside its own
+// package, against a real database.
+//
+// The first is a PREDICTION across a DAG boundary: agents.servedByTheRecordSeam
+// decides from datasource.EntityTypes() which archives the seam can be asked
+// about, and the thing that actually answers is Provider.Read's switch, one
+// layer up where the module lives. A type added to the vocabulary with no arm
+// in that switch would make every archive of it fault at staging, with no unit
+// test anywhere able to see it — the two halves are in packages that cannot
+// import each other.
+//
+// The second is the refusal this seam added to the REST door. The unit tests
+// prove the door asks the resolver; they cannot prove that a row the caller
+// may not see comes back as not-found, because they supply the answer they are
+// checking for. Only RLS and the store's row-scope clauses can say that.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/gradionhq/margince/backend/internal/compose/integration"
+	"github.com/gradionhq/margince/backend/internal/modules/approvals"
+	"github.com/gradionhq/margince/backend/internal/platform/database"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
+)
+
+// Provider.Read serves the seam's vocabulary and nothing outside it.
+//
+// Both directions matter and neither is decidable from one side. A declared
+// entity type with no arm in the switch answers "not served here" for a record
+// that exists, so the resolver would refuse an archive it is meant to guard. A
+// type the switch grew quietly without joining the vocabulary would be guarded
+// by nothing, because the resolver would never ask about it.
+//
+// The subject set is DERIVED: the vocabulary from datasource.EntityTypes(), the
+// outside set from the record types the generated agent policy actually names.
+// A contract that adds an archivable type is covered here without anybody
+// extending a list.
+func TestTheRecordProviderServesExactlyTheSeamVocabulary(t *testing.T) {
+	e := integration.Setup(t)
+	as := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AdminPerms)
+	native := NewProvider(e.Pool)
+
+	for _, entity := range datasource.EntityTypes() {
+		// A random id: the answer under test is whether this provider ROUTES
+		// the type, and a miss says routed-and-absent as clearly as a hit says
+		// routed-and-present.
+		_, err := native.Read(as, datasource.EntityRef{Type: entity, ID: ids.NewV7()})
+		var unsupported *datasource.UnsupportedEntityError
+		if errors.As(err, &unsupported) {
+			t.Errorf("the provider does not serve %q, which the seam's own vocabulary declares — every "+
+				"governed archive of one faults at staging, and agents.servedByTheRecordSeam cannot see it "+
+				"from the other side of the DAG", entity)
+		}
+	}
+
+	outside := 0
+	for _, recordType := range archivableRecordTypes() {
+		if isSeamEntity(recordType) {
+			continue
+		}
+		outside++
+		_, err := native.Read(as, datasource.EntityRef{Type: datasource.EntityType(recordType), ID: ids.NewV7()})
+		var unsupported *datasource.UnsupportedEntityError
+		if !errors.As(err, &unsupported) {
+			t.Errorf("the provider serves %q, which is outside the seam's vocabulary — the resolver stands "+
+				"its guards down for that type, so a record the seam CAN reach would be staged unguarded",
+				recordType)
+		}
+	}
+	if outside == 0 {
+		t.Fatal("no archivable record type sits outside the seam vocabulary — the half of this gate that " +
+			"covers the stood-down types is asserting nothing")
+	}
+}
+
+// archivableRecordTypes is every record type an agent-reachable archive names,
+// taken from the generated policy rather than from a list.
+func archivableRecordTypes() []string {
+	types := make([]string, 0, len(agentPolicies))
+	for _, pol := range agentPolicies {
+		if pol.Access == accessTool && pol.Tool == "archive_record" && pol.RecordType != "" {
+			types = append(types, string(pol.RecordType))
+		}
+	}
+	return types
+}
+
+// isSeamEntity mirrors the question agents.servedByTheRecordSeam answers, from
+// the same source: the seam's own declared vocabulary.
+func isSeamEntity(recordType string) bool {
+	for _, entity := range datasource.EntityTypes() {
+		if string(entity) == recordType {
+			return true
+		}
+	}
+	return false
+}
+
+// An archive of a row the agent's own row scope hides is refused before
+// anything is staged, and nothing is staged.
+//
+// Through the REAL provider and the REAL approvals engine: the refusal under
+// test is the store's row-scope clause answering not-found, and a stub that
+// returns ErrNotFound proves only that the door forwards whatever it is handed.
+// The person is seeded by the real writer under a rep whose team the agent's
+// granting human is not in, so nothing about the fixture is hand-made.
+func TestAnArchiveOfARowOutsideTheAgentsScopeStagesNothing(t *testing.T) {
+	e := integration.Setup(t)
+	native := NewProvider(e.Pool)
+	staging := approvalsAdapter{svc: approvals.NewService(e.Pool)}
+
+	// Rep3 sits in Team2; the agent below acts for Rep1, in Team1. The person is
+	// OWNED by Rep3 — an ownerless row is workspace-shared and visible at every
+	// tier (auth.ScopeClause), so a fixture without an owner would be seen by
+	// the agent and this test would prove nothing about row scope.
+	elsewhere := e.As(e.Rep3, []ids.UUID{e.Team2}, integration.AdminPerms)
+	hidden, err := native.Create(elsewhere, datasource.CreateInput{
+		EntityType: datasource.EntityPerson,
+		Fields:     json.RawMessage(`{"full_name":"Out Of Scope","owner_id":"` + e.Rep3.String() + `"}`),
+		Source:     "test",
+	})
+	if err != nil {
+		t.Fatalf("seeding the out-of-scope person: %v", err)
+	}
+	// The fixture is only evidence if the agent's own seat really cannot reach
+	// it, and the row scope is what must do the hiding — not a missing grant.
+	if _, err := native.Read(e.As(e.Rep3, []ids.UUID{e.Team2}, integration.RepPerms), datasource.EntityRef{
+		Type: datasource.EntityPerson, ID: hidden.ID,
+	}); err != nil {
+		t.Fatalf("the owning rep cannot read the seeded person either (%v) — the refusal below would then "+
+			"say nothing about the AGENT's scope", err)
+	}
+
+	// Through the door, with a staging engine that WOULD have written: "zero
+	// approvals" then means the gate declined to stage, not that there was
+	// nothing present to stage with.
+	agent := scopedArchiveAgent(t, e)
+	req := httptest.NewRequest(http.MethodDelete, "/v1/people/"+hidden.ID.String(), nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", hidden.ID.String())
+	req = req.WithContext(context.WithValue(agent, chi.RouteCtxKey, rctx))
+	rec := httptest.NewRecorder()
+
+	stageRefusal(rec, req, staging, restCommandDeps{records: native},
+		agentPolicy{Op: "archivePerson", Access: accessTool, Tool: "archive_record", RecordType: recordTypePerson}, nil)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("archiving a row outside the agent's scope answered %d, want 404 — the archive itself "+
+			"answers that once released, and a human's yes must not be spent on it", rec.Code)
+	}
+	if n := pendingApprovals(agent, t, e); n != 0 {
+		t.Errorf("%d approval(s) were staged against a record the agent cannot see", n)
+	}
+}
+
+// scopedArchiveAgent is an agent acting for Rep1 with Rep1's team scope — the
+// authority a real passport carries, which is the granting human's.
+//
+// The passport is SEEDED because a staged approval records the passport it was
+// minted by under a real foreign key: an invented id would fail in the database
+// and report a schema complaint where this test means to report a refusal.
+func scopedArchiveAgent(t *testing.T, e *integration.Env) context.Context {
+	t.Helper()
+	ctx := principal.WithWorkspaceID(context.Background(), e.WS)
+	ctx = principal.WithCorrelationID(ctx, ids.NewV7())
+	return principal.WithActor(ctx, principal.Principal{
+		Type: principal.PrincipalAgent, ID: "agent:scoped-archive", SeatType: principal.SeatFull,
+		OnBehalfOf: e.Rep1, UserID: e.Rep1, TeamIDs: []ids.UUID{e.Team1},
+		PassportID:  e.SeedPassport(t, integration.OwnerConn(t), "scoped archive probe"),
+		Scopes:      principal.NewScopeSet(principal.ScopeRead, principal.ScopeWrite),
+		Permissions: integration.RepPerms,
+	})
+}
+
+// pendingApprovals counts the staged rows.
+//
+// Bound through WithWorkspaceTx: Env.Pool is the RLS-bound app role, so an
+// unbound count resolves the policy against a NULL workspace and answers zero
+// for every row that exists — an absence-assertion that passes whether or not
+// anything was staged, which is the one thing this test may not do.
+func pendingApprovals(as context.Context, t *testing.T, e *integration.Env) int {
+	t.Helper()
+	var n int
+	if err := database.WithWorkspaceTx(as, e.Pool, func(tx pgx.Tx) error {
+		return tx.QueryRow(as, `SELECT count(*) FROM approval WHERE status = 'pending'`).Scan(&n)
+	}); err != nil {
+		t.Fatalf("counting the staged approvals: %v", err)
+	}
+	return n
+}

--- a/backend/internal/compose/agentcommand_integration_test.go
+++ b/backend/internal/compose/agentcommand_integration_test.go
@@ -124,7 +124,7 @@ func isSeamEntity(recordType string) bool {
 func TestAnArchiveOfARowOutsideTheAgentsScopeStagesNothing(t *testing.T) {
 	e := integration.Setup(t)
 	native := NewProvider(e.Pool)
-	staging := approvalsAdapter{svc: approvals.NewService(e.Pool)}
+	staging := approvalsAdapter{svc: approvals.NewService(e.DB())}
 
 	// Rep3 sits in Team2; the agent below acts for Rep1, in Team1. The person is
 	// OWNED by Rep3 — an ownerless row is workspace-shared and visible at every

--- a/backend/internal/compose/agentcommand_test.go
+++ b/backend/internal/compose/agentcommand_test.go
@@ -67,47 +67,6 @@ func archiveRequest(path string, id ids.UUID) *http.Request {
 	return req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
 }
 
-// Every archive operation the contract lets an agent reach must decode into a
-// command, or the two doors are back to describing the same operation
-// differently — which is the drift this seam exists to end. Derived from the
-// generated policy table rather than from a list of the twelve someone
-// remembered, so an archive route added upstream fails here.
-func TestEveryAgentReachableArchiveOperationDecodesIntoACommand(t *testing.T) {
-	checked := 0
-	for route, pol := range agentPolicies {
-		if pol.Access != accessTool || pol.Tool != "archive_record" {
-			continue
-		}
-		checked++
-		if _, described := restCommands[pol.Op]; !described {
-			t.Errorf("%s (%s) archives a record but decodes into no command, so its staged target is still "+
-				"guessed from the route while the tool door reads it from the call", route, pol.Op)
-		}
-	}
-	if checked != 12 {
-		t.Errorf("the policy table carries %d agent-reachable archive operations, want 12 — if the contract "+
-			"gained or lost one, this seam's coverage moved with it", checked)
-	}
-}
-
-// The other direction, which no single family's walk above can see on its
-// own now that restCommands holds three of them: a decoder left behind for an
-// operation the contract retired would sit in the table answering for a route
-// nothing routes. Checked once, across every family, rather than each
-// family's own test re-deriving "restCommands holds exactly what I counted" —
-// which stopped being true the moment a second family shared the map.
-func TestEveryRegisteredCommandDecodesAnOperationTheContractStillDeclares(t *testing.T) {
-	known := make(map[string]bool, len(agentPolicies))
-	for _, pol := range agentPolicies {
-		known[pol.Op] = true
-	}
-	for op := range restCommands {
-		if !known[op] {
-			t.Errorf("restCommands[%q] decodes an operation the policy table no longer declares", op)
-		}
-	}
-}
-
 // A record type the seam does not serve still stages, with its own type and
 // its own id. Six of the twelve archivable types are archived by their own
 // module, and the tool's narrow schema is not the operation's vocabulary.

--- a/backend/internal/compose/agentcommand_test.go
+++ b/backend/internal/compose/agentcommand_test.go
@@ -88,12 +88,23 @@ func TestEveryAgentReachableArchiveOperationDecodesIntoACommand(t *testing.T) {
 		t.Errorf("the policy table carries %d agent-reachable archive operations, want 12 — if the contract "+
 			"gained or lost one, this seam's coverage moved with it", checked)
 	}
-	// The other direction, which the walk above cannot see: a decoder left
-	// behind for an operation the contract retired would sit in the table
-	// answering for a route nothing routes.
-	if len(restCommands) != checked {
-		t.Errorf("restCommands holds %d decoders for %d agent-reachable operations — one of them decodes an "+
-			"operation the contract no longer serves", len(restCommands), checked)
+}
+
+// The other direction, which no single family's walk above can see on its
+// own now that restCommands holds three of them: a decoder left behind for an
+// operation the contract retired would sit in the table answering for a route
+// nothing routes. Checked once, across every family, rather than each
+// family's own test re-deriving "restCommands holds exactly what I counted" —
+// which stopped being true the moment a second family shared the map.
+func TestEveryRegisteredCommandDecodesAnOperationTheContractStillDeclares(t *testing.T) {
+	known := make(map[string]bool, len(agentPolicies))
+	for _, pol := range agentPolicies {
+		known[pol.Op] = true
+	}
+	for op := range restCommands {
+		if !known[op] {
+			t.Errorf("restCommands[%q] decodes an operation the policy table no longer declares", op)
+		}
 	}
 }
 
@@ -194,7 +205,7 @@ func TestArchiveCommandRefusesAMalformedIDAsAMiss(t *testing.T) {
 	rctx.URLParams.Add("id", "not-a-uuid")
 	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
 
-	_, err := archiveCommand(agentPolicy{Op: "archiveTag", RecordType: recordTypeTag}, restCommandDeps{records: seamRecord{}}, req)
+	_, err := archiveCommand(agentPolicy{Op: "archiveTag", RecordType: recordTypeTag}, restCommandDeps{records: seamRecord{}}, req, nil)
 	if !errors.Is(err, apperrors.ErrNotFound) {
 		t.Errorf("decoding a malformed id answered %v, want the not-found sentinel", err)
 	}

--- a/backend/internal/compose/agentcommand_test.go
+++ b/backend/internal/compose/agentcommand_test.go
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// What the REST door stages once it decodes the call into a command: the
+// target the resolver names, the refusals the resolver raises, and the
+// existence-hiding answer to an id that is not one.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
+)
+
+// seamRecord is a record the caller may see, held in OUR system of record —
+// the one shape an archive may be staged against.
+type seamRecord struct {
+	datasource.SystemOfRecordProvider
+}
+
+func (seamRecord) Read(_ context.Context, ref datasource.EntityRef) (datasource.Record, error) {
+	return datasource.Record{
+		Ref:       ref,
+		Fields:    json.RawMessage(`{"name":"Acme"}`),
+		Version:   4,
+		Freshness: datasource.FreshnessInfo{Authoritative: true},
+	}, nil
+}
+
+// hiddenRecord answers every read the way a row outside the caller's scope
+// does: not-found, indistinguishable from absent.
+type hiddenRecord struct {
+	datasource.SystemOfRecordProvider
+}
+
+func (hiddenRecord) Read(_ context.Context, ref datasource.EntityRef) (datasource.Record, error) {
+	return datasource.Record{}, fmt.Errorf("record %s: %w", ref.ID, apperrors.ErrNotFound)
+}
+
+// mirroredRecord is a record the caller can see whose authority lives in
+// another system of record — readable, and unstageable.
+type mirroredRecord struct {
+	datasource.SystemOfRecordProvider
+}
+
+func (mirroredRecord) Read(_ context.Context, ref datasource.EntityRef) (datasource.Record, error) {
+	return datasource.Record{Ref: ref, Fields: json.RawMessage(`{"name":"Mirrored"}`)}, nil
+}
+
+// archiveRequest is a DELETE against one of the archive routes, carrying the
+// {id} the chi router would have bound.
+func archiveRequest(path string, id ids.UUID) *http.Request {
+	req := httptest.NewRequest(http.MethodDelete, path+"/"+id.String(), nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", id.String())
+	return req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+}
+
+// Every archive operation the contract lets an agent reach must decode into a
+// command, or the two doors are back to describing the same operation
+// differently — which is the drift this seam exists to end. Derived from the
+// generated policy table rather than from a list of the twelve someone
+// remembered, so an archive route added upstream fails here.
+func TestEveryAgentReachableArchiveOperationDecodesIntoACommand(t *testing.T) {
+	checked := 0
+	for route, pol := range agentPolicies {
+		if pol.Access != accessTool || pol.Tool != "archive_record" {
+			continue
+		}
+		checked++
+		if _, described := restCommands[pol.Op]; !described {
+			t.Errorf("%s (%s) archives a record but decodes into no command, so its staged target is still "+
+				"guessed from the route while the tool door reads it from the call", route, pol.Op)
+		}
+	}
+	if checked != 12 {
+		t.Errorf("the policy table carries %d agent-reachable archive operations, want 12 — if the contract "+
+			"gained or lost one, this seam's coverage moved with it", checked)
+	}
+}
+
+// A record type the seam does not serve still stages, with its own type and
+// its own id. Six of the twelve archivable types are archived by their own
+// module, and the tool's narrow schema is not the operation's vocabulary.
+//
+// Staged against a provider that fails EVERY read, so a resolver that
+// consulted the seam for a tag fails here rather than passing on a lenient stub.
+func TestAnArchiveOutsideTheToolSchemaStagesItsOwnTypeAndID(t *testing.T) {
+	tagID := ids.NewV7()
+	staging := &capturingApprovals{}
+	pol := agentPolicy{Op: "archiveTag", Access: accessTool, Tool: "archive_record", RecordType: recordTypeTag}
+
+	stageRefusal(httptest.NewRecorder(), archiveRequest("/v1/tags", tagID), staging, hiddenRecord{}, pol, nil)
+
+	if staging.last.TargetType != "tag" || staging.last.TargetID != tagID {
+		t.Fatalf("staged target = (%s,%s), want (tag,%s) — a tag is archived over REST whether or not the "+
+			"record seam has ever heard of one", staging.last.TargetType, staging.last.TargetID, tagID)
+	}
+}
+
+// A target the caller cannot see stages NOTHING. The archive would answer the
+// same not-found once released, by which point a human has spent a one-shot
+// authority on a call that was never going to run.
+func TestAnArchiveOfAnUnseeableRecordStagesNothing(t *testing.T) {
+	staging := &capturingApprovals{}
+	pol := agentPolicy{Op: "archivePerson", Access: accessTool, Tool: "archive_record", RecordType: recordTypePerson}
+	rec := httptest.NewRecorder()
+
+	stageRefusal(rec, archiveRequest("/v1/people", ids.NewV7()), staging, hiddenRecord{}, pol, nil)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("archiving a record the caller cannot see answered %d, want 404 — the refusal must not "+
+			"tell a caller that a row they may not see exists", rec.Code)
+	}
+	if staging.last.Tool != "" {
+		t.Errorf("an approval was staged for %q against a record nobody can decide about", staging.last.Tool)
+	}
+}
+
+// The REST door runs the resolver's GUARDS, not only its subject.
+//
+// An externally-held target is the one refusal only Guards makes — Subject
+// reads the same row and is happy to describe it — so this is what proves the
+// door asks both questions rather than the one it needs an answer from. The
+// approval could never be released: the decidability probe and the version pin
+// both read tables this record has no row in.
+func TestAnArchiveOfAnExternallyHeldRecordStagesNothing(t *testing.T) {
+	staging := &capturingApprovals{}
+	pol := agentPolicy{Op: "archivePerson", Access: accessTool, Tool: "archive_record", RecordType: recordTypePerson}
+	rec := httptest.NewRecorder()
+
+	stageRefusal(rec, archiveRequest("/v1/people", ids.NewV7()), staging, mirroredRecord{}, pol, nil)
+
+	if staging.last.Tool != "" {
+		t.Errorf("an approval was staged for %q against a record whose authority lives elsewhere — nobody "+
+			"could ever release it", staging.last.Tool)
+	}
+	if rec.Code == http.StatusOK {
+		t.Error("the refusal was not written; a staged call that cannot be released must answer as one")
+	}
+}
+
+// A malformed id is a miss, not a parse failure: "that is not a uuid" and
+// "there is no such row" must read alike, or the shape of an id tells a caller
+// which rows exist.
+func TestAMalformedArchiveIDAnswersNotFound(t *testing.T) {
+	staging := &capturingApprovals{}
+	pol := agentPolicy{Op: "archiveTag", Access: accessTool, Tool: "archive_record", RecordType: recordTypeTag}
+
+	req := httptest.NewRequest(http.MethodDelete, "/v1/tags/not-a-uuid", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", "not-a-uuid")
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+
+	rec := httptest.NewRecorder()
+	stageRefusal(rec, req, staging, seamRecord{}, pol, nil)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("a malformed archive id answered %d, want 404", rec.Code)
+	}
+	if staging.last.Tool != "" {
+		t.Errorf("an approval was staged for %q against an id that names no row", staging.last.Tool)
+	}
+}
+
+// The decoder itself, on the same fault: the command layer answers the
+// not-found sentinel, so every door that decodes through it hides existence
+// the same way rather than each mapping the parse failure for itself.
+func TestArchiveCommandRefusesAMalformedIDAsAMiss(t *testing.T) {
+	req := httptest.NewRequest(http.MethodDelete, "/v1/tags/not-a-uuid", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", "not-a-uuid")
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+
+	_, err := archiveCommand(agentPolicy{Op: "archiveTag", RecordType: recordTypeTag}, seamRecord{}, req)
+	if !errors.Is(err, apperrors.ErrNotFound) {
+		t.Errorf("decoding a malformed id answered %v, want the not-found sentinel", err)
+	}
+}

--- a/backend/internal/compose/agentcommand_test.go
+++ b/backend/internal/compose/agentcommand_test.go
@@ -88,6 +88,13 @@ func TestEveryAgentReachableArchiveOperationDecodesIntoACommand(t *testing.T) {
 		t.Errorf("the policy table carries %d agent-reachable archive operations, want 12 — if the contract "+
 			"gained or lost one, this seam's coverage moved with it", checked)
 	}
+	// The other direction, which the walk above cannot see: a decoder left
+	// behind for an operation the contract retired would sit in the table
+	// answering for a route nothing routes.
+	if len(restCommands) != checked {
+		t.Errorf("restCommands holds %d decoders for %d agent-reachable operations — one of them decodes an "+
+			"operation the contract no longer serves", len(restCommands), checked)
+	}
 }
 
 // A record type the seam does not serve still stages, with its own type and
@@ -146,8 +153,12 @@ func TestAnArchiveOfAnExternallyHeldRecordStagesNothing(t *testing.T) {
 		t.Errorf("an approval was staged for %q against a record whose authority lives elsewhere — nobody "+
 			"could ever release it", staging.last.Tool)
 	}
-	if rec.Code == http.StatusOK {
-		t.Error("the refusal was not written; a staged call that cannot be released must answer as one")
+	// The concrete status, not merely "something other than 200": httperr maps
+	// an unclassified error to 500, so an unrelated fault would satisfy a
+	// not-200 assertion while this test reported the guard as proven.
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Errorf("an externally-held target answered %d, want %d (unsupported_by_sor) — the refusal a caller "+
+			"gets must name why the archive cannot be governed here", rec.Code, http.StatusUnprocessableEntity)
 	}
 }
 
@@ -186,5 +197,31 @@ func TestArchiveCommandRefusesAMalformedIDAsAMiss(t *testing.T) {
 	_, err := archiveCommand(agentPolicy{Op: "archiveTag", RecordType: recordTypeTag}, seamRecord{}, req)
 	if !errors.Is(err, apperrors.ErrNotFound) {
 		t.Errorf("decoding a malformed id answered %v, want the not-found sentinel", err)
+	}
+}
+
+// The fail-closed refusal covers the resolver branch too.
+//
+// A concrete target with no record type is a row the approvals surface cannot
+// scope: it probes a target's own/team visibility by type, so an untyped row
+// would show its summary and proposed change to everyone holding the object
+// grant. The check used to sit inside the route walk, which is the one path a
+// resolved target never takes — so it is applied to the answer, whichever
+// branch produced it.
+func TestAResolvedTargetWithNoRecordTypeIsRefused(t *testing.T) {
+	staging := &capturingApprovals{}
+	// The operation decodes into a command, and declares no record type — the
+	// shape a decoder wired to an untyped operation would produce.
+	pol := agentPolicy{Op: "archiveTag", Access: accessTool, Tool: "archive_record", RecordType: ""}
+	rec := httptest.NewRecorder()
+
+	stageRefusal(rec, archiveRequest("/v1/tags", ids.NewV7()), staging, seamRecord{}, pol, nil)
+
+	if staging.last.Tool != "" {
+		t.Errorf("an approval was staged for %q with a concrete target and no type — no inbox can scope it, "+
+			"and everyone holding the object grant could decide it", staging.last.Tool)
+	}
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("an untyped concrete target answered %d, want 403", rec.Code)
 	}
 }

--- a/backend/internal/compose/agentcommand_test.go
+++ b/backend/internal/compose/agentcommand_test.go
@@ -108,7 +108,7 @@ func TestAnArchiveOutsideTheToolSchemaStagesItsOwnTypeAndID(t *testing.T) {
 	staging := &capturingApprovals{}
 	pol := agentPolicy{Op: "archiveTag", Access: accessTool, Tool: "archive_record", RecordType: recordTypeTag}
 
-	stageRefusal(httptest.NewRecorder(), archiveRequest("/v1/tags", tagID), staging, hiddenRecord{}, pol, nil)
+	stageRefusal(httptest.NewRecorder(), archiveRequest("/v1/tags", tagID), staging, restCommandDeps{records: hiddenRecord{}}, pol, nil)
 
 	if staging.last.TargetType != "tag" || staging.last.TargetID != tagID {
 		t.Fatalf("staged target = (%s,%s), want (tag,%s) — a tag is archived over REST whether or not the "+
@@ -124,7 +124,7 @@ func TestAnArchiveOfAnUnseeableRecordStagesNothing(t *testing.T) {
 	pol := agentPolicy{Op: "archivePerson", Access: accessTool, Tool: "archive_record", RecordType: recordTypePerson}
 	rec := httptest.NewRecorder()
 
-	stageRefusal(rec, archiveRequest("/v1/people", ids.NewV7()), staging, hiddenRecord{}, pol, nil)
+	stageRefusal(rec, archiveRequest("/v1/people", ids.NewV7()), staging, restCommandDeps{records: hiddenRecord{}}, pol, nil)
 
 	if rec.Code != http.StatusNotFound {
 		t.Errorf("archiving a record the caller cannot see answered %d, want 404 — the refusal must not "+
@@ -147,7 +147,7 @@ func TestAnArchiveOfAnExternallyHeldRecordStagesNothing(t *testing.T) {
 	pol := agentPolicy{Op: "archivePerson", Access: accessTool, Tool: "archive_record", RecordType: recordTypePerson}
 	rec := httptest.NewRecorder()
 
-	stageRefusal(rec, archiveRequest("/v1/people", ids.NewV7()), staging, mirroredRecord{}, pol, nil)
+	stageRefusal(rec, archiveRequest("/v1/people", ids.NewV7()), staging, restCommandDeps{records: mirroredRecord{}}, pol, nil)
 
 	if staging.last.Tool != "" {
 		t.Errorf("an approval was staged for %q against a record whose authority lives elsewhere — nobody "+
@@ -175,7 +175,7 @@ func TestAMalformedArchiveIDAnswersNotFound(t *testing.T) {
 	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
 
 	rec := httptest.NewRecorder()
-	stageRefusal(rec, req, staging, seamRecord{}, pol, nil)
+	stageRefusal(rec, req, staging, restCommandDeps{records: seamRecord{}}, pol, nil)
 
 	if rec.Code != http.StatusNotFound {
 		t.Errorf("a malformed archive id answered %d, want 404", rec.Code)
@@ -194,7 +194,7 @@ func TestArchiveCommandRefusesAMalformedIDAsAMiss(t *testing.T) {
 	rctx.URLParams.Add("id", "not-a-uuid")
 	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
 
-	_, err := archiveCommand(agentPolicy{Op: "archiveTag", RecordType: recordTypeTag}, seamRecord{}, req)
+	_, err := archiveCommand(agentPolicy{Op: "archiveTag", RecordType: recordTypeTag}, restCommandDeps{records: seamRecord{}}, req)
 	if !errors.Is(err, apperrors.ErrNotFound) {
 		t.Errorf("decoding a malformed id answered %v, want the not-found sentinel", err)
 	}
@@ -215,7 +215,7 @@ func TestAResolvedTargetWithNoRecordTypeIsRefused(t *testing.T) {
 	pol := agentPolicy{Op: "archiveTag", Access: accessTool, Tool: "archive_record", RecordType: ""}
 	rec := httptest.NewRecorder()
 
-	stageRefusal(rec, archiveRequest("/v1/tags", ids.NewV7()), staging, seamRecord{}, pol, nil)
+	stageRefusal(rec, archiveRequest("/v1/tags", ids.NewV7()), staging, restCommandDeps{records: seamRecord{}}, pol, nil)
 
 	if staging.last.Tool != "" {
 		t.Errorf("an approval was staged for %q with a concrete target and no type — no inbox can scope it, "+

--- a/backend/internal/compose/agentcommandauto.go
+++ b/backend/internal/compose/agentcommandauto.go
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The REST door's half of the four auto-execute commands
+// (gradionhq/margince-poc-v1#928 task 7): logging an activity, drafting a
+// reply, re-associating an activity, and running a report. All four are 🟢
+// today and none of them stages, so these decoders are reached only if a tier
+// floor (#982) tightens one — registered anyway, for the reason
+// agentcommandnested.go's seven are: the route walk's guess is what this table
+// replaces, and a guess is only ever as good as the route's shape.
+//
+// runReport is the clearest case. Its route is POST /v1/reports/{report}:
+// there is no {id} for the walk to read and no record type on its policy
+// entry, so the walk can only answer an empty target with no name attached to
+// it, where the command at least says which report.
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/gradionhq/margince/backend/internal/modules/agents"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// logActivityCommand decodes POST /v1/activities. The body IS the activity's
+// fields — the route names no record, because the activity does not exist yet
+// — so this is the same shape createCommand takes for every other create.
+//
+//nolint:ireturn,unparam // ireturn: a decoder's whole product is the erased command-and-resolver pair restCommands is typed by. unparam: the error is always nil TODAY (a create has no id to fail parsing), but every restCommands entry shares this signature
+func logActivityCommand(_ agentPolicy, _ restCommandDeps, _ *http.Request, body []byte) (agents.GovernedCall, error) {
+	return agents.NewLogActivityCall(agents.LogActivityCommand{Fields: json.RawMessage(body)}), nil
+}
+
+// draftEmailCommand decodes POST /v1/activities/{id}/draft-email. The optional
+// `intent` body is not read: nothing the resolver answers depends on it.
+//
+//nolint:ireturn // a decoder's whole product is the erased command-and-resolver pair restCommands is typed by
+func draftEmailCommand(_ agentPolicy, deps restCommandDeps, r *http.Request, _ []byte) (agents.GovernedCall, error) {
+	id, err := routedID(r)
+	if err != nil {
+		return nil, err
+	}
+	return agents.NewDraftEmailCall(deps.records, agents.DraftEmailCommand{ActivityID: id}), nil
+}
+
+// relinkActivityCommand decodes POST /v1/activities/{id}/relink. The
+// destination travels because both of the resolver's questions read it: one
+// refuses a type that is not a link target, and the other names where the
+// activity is going.
+//
+//nolint:ireturn // a decoder's whole product is the erased command-and-resolver pair restCommands is typed by
+func relinkActivityCommand(_ agentPolicy, deps restCommandDeps, r *http.Request, body []byte) (agents.GovernedCall, error) {
+	id, err := routedID(r)
+	if err != nil {
+		return nil, err
+	}
+	in, err := commandBody[struct {
+		EntityType string   `json:"entity_type"`
+		EntityID   ids.UUID `json:"entity_id"`
+	}](body)
+	if err != nil {
+		return nil, err
+	}
+	return agents.NewRelinkActivityCall(deps.records, agents.RelinkActivityCommand{
+		ActivityID: id,
+		EntityType: in.EntityType,
+		EntityID:   in.EntityID,
+	}), nil
+}
+
+// runReportCommand decodes POST /v1/reports/{report}. The report key is a PATH
+// parameter, and not the route's own {id} — so it goes through pathOperand
+// (agentcommandoperand.go), which answers 422 naming the parameter rather than
+// routedID's existence-hiding 404: a report key names no row whose existence
+// this door could be hiding.
+//
+//nolint:ireturn // a decoder's whole product is the erased command-and-resolver pair restCommands is typed by
+func runReportCommand(_ agentPolicy, _ restCommandDeps, r *http.Request, _ []byte) (agents.GovernedCall, error) {
+	report, err := pathOperand(r, "report")
+	if err != nil {
+		return nil, err
+	}
+	return agents.NewRunReportCall(agents.RunReportCommand{Report: report}), nil
+}

--- a/backend/internal/compose/agentcommandbothdoors_test.go
+++ b/backend/internal/compose/agentcommandbothdoors_test.go
@@ -441,8 +441,8 @@ var dynamicTierVerbs = gatekit.Waive(map[string]string{
 	"advance_deal": "a deal move's tier is decided by reading both endpoints, so an open→open call executes " +
 		"where a close stages, and this lane's fixture would compare a staged row that only some workspace " +
 		"states produce — what the two doors do share is the command itself, both decoding into " +
-		"AdvanceDealCommand{DealID, ToStageID} (agentcommandlifecycle.go and tools_lifecycle.go), which no " +
-		"test compares door-to-door today",
+		"AdvanceDealCommand{DealID, ToStageID} (advanceDealCommand in agentcommandlifecycle.go, " +
+		"advanceDeal.StageInfo in tools.go), which no test compares door-to-door today",
 })
 
 // assertVerbResolvesItsTierPerCall holds an unwritten fixture to the one

--- a/backend/internal/compose/agentcommandbothdoors_test.go
+++ b/backend/internal/compose/agentcommandbothdoors_test.go
@@ -1,0 +1,389 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// One operation, two doors, one command.
+//
+// For an operation a client can reach BOTH ways — the REST route and the tool
+// verb its `x-mcp-tool` names — the two doors must resolve to the same governed
+// call: the same record, the same version to pin, the same sentence a human
+// reads. That is the whole claim of the command seam (modules/agents/command.go)
+// and the only claim no single-door test can make, because each door is
+// perfectly self-consistent while describing a different act.
+//
+// The fixtures are written PER DOOR, from each door's own published contract:
+// the REST request from the route and requestBody crm.yaml declares, the tool
+// arguments from the verb's own InputSchema. Deriving one from the other — call
+// a decoder, feed its output to the twin — would compare a decoder with itself
+// and pass for any pair of doors that agreed on nothing.
+//
+// The enrich verb is why the summary is compared and not only the target. Its
+// two operations are one verb at two DEPTHS against one organization, so a
+// swapped depth stages an identical target under a sentence describing the
+// other act: a human releasing a whole-site crawl on a line written for a
+// single page read.
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	chi "github.com/go-chi/chi/v5"
+
+	"github.com/gradionhq/margince/backend/internal/modules/agents"
+	"github.com/gradionhq/margince/backend/internal/platform/auth"
+	"github.com/gradionhq/margince/backend/internal/shared/gatekit"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/mcp"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/workflow"
+)
+
+// bothDoorsFixture is one intended act, written twice — once as the request the
+// REST route carries, once as the arguments the tool schema declares. Both
+// builders take the same two ids so the two spellings name the same records
+// without either being derived from the other: primary is the record the route
+// names, secondary the second record an operation that has one (a merge's
+// survivor) names in its body.
+type bothDoorsFixture struct {
+	rest func(primary, secondary ids.UUID) (*http.Request, []byte)
+	args func(primary, secondary ids.UUID) string
+}
+
+// doorRequest builds what the chi router would hand the gate: the concrete
+// path, the routed {id} bound the way the router binds it, and the body the
+// gate buffered.
+func doorRequest(method, path string, routed ids.UUID, body string) (*http.Request, []byte) {
+	payload := []byte(body)
+	var reader io.Reader = http.NoBody
+	if body != "" {
+		reader = bytes.NewReader(payload)
+	}
+	req := httptest.NewRequest(method, path, reader)
+	if routed.IsZero() {
+		return req, payload
+	}
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", routed.String())
+	return req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx)), payload
+}
+
+// archiveDoors, createDoors, updateDoors and mergeDoors write the four generic
+// families once each. The families are generic on BOTH doors — one route shape,
+// one tool verb, the record type as an argument — so a per-operation literal
+// would be the same four lines twenty times, and a divergence would hide in the
+// repetition rather than stand out.
+func archiveDoors(collection, recordType string) bothDoorsFixture {
+	return bothDoorsFixture{
+		rest: func(primary, _ ids.UUID) (*http.Request, []byte) {
+			return doorRequest(http.MethodDelete, "/v1/"+collection+"/"+primary.String(), primary, "")
+		},
+		args: func(primary, _ ids.UUID) string {
+			return `{"record_type":"` + recordType + `","id":"` + primary.String() + `"}`
+		},
+	}
+}
+
+func createDoors(collection, recordType, fields string) bothDoorsFixture {
+	return bothDoorsFixture{
+		rest: func(_, _ ids.UUID) (*http.Request, []byte) {
+			return doorRequest(http.MethodPost, "/v1/"+collection, ids.UUID{}, fields)
+		},
+		args: func(_, _ ids.UUID) string {
+			return `{"record_type":"` + recordType + `","fields":` + fields + `}`
+		},
+	}
+}
+
+func updateDoors(collection, recordType, fields string) bothDoorsFixture {
+	return bothDoorsFixture{
+		rest: func(primary, _ ids.UUID) (*http.Request, []byte) {
+			return doorRequest(http.MethodPatch, "/v1/"+collection+"/"+primary.String(), primary, fields)
+		},
+		args: func(primary, _ ids.UUID) string {
+			return `{"record_type":"` + recordType + `","id":"` + primary.String() + `","fields":` + fields + `}`
+		},
+	}
+}
+
+// mergeDoors is the one family where the two doors name the two records
+// differently on purpose: the route names the record merged AWAY and the body
+// the survivor, while the tool names both as arguments. An approval binds to
+// the survivor either way, which is exactly what a per-door fixture can prove
+// and a derived one cannot.
+func mergeDoors(collection, recordType string) bothDoorsFixture {
+	return bothDoorsFixture{
+		rest: func(primary, secondary ids.UUID) (*http.Request, []byte) {
+			return doorRequest(http.MethodPost, "/v1/"+collection+"/"+primary.String()+"/merge", primary,
+				`{"target_id":"`+secondary.String()+`"}`)
+		},
+		args: func(primary, secondary ids.UUID) string {
+			return `{"record_type":"` + recordType + `","source_id":"` + primary.String() +
+				`","target_id":"` + secondary.String() + `"}`
+		},
+	}
+}
+
+// enrichDoors is the pair the gate exists for. The REST door has no depth
+// argument at all — its two ROUTES are the two depths — so the depth is
+// structural on one door and a word on the other, which is the one shape where
+// two doors can agree on every field and still mean different acts.
+func enrichDoors(path string, depth agents.EnrichDepth) bothDoorsFixture {
+	return bothDoorsFixture{
+		rest: func(primary, _ ids.UUID) (*http.Request, []byte) {
+			return doorRequest(http.MethodPost, "/v1/organizations/"+primary.String()+"/"+path, primary, "")
+		},
+		args: func(primary, _ ids.UUID) string {
+			return `{"organization_id":"` + primary.String() + `","depth":"` + string(depth) + `"}`
+		},
+	}
+}
+
+// bothDoorsFixtures is the act each twinned operation performs, per door.
+//
+// The `fields` payloads name only members the record type's own contract shape
+// declares (agents.createRecordShapes / updateRecordShapes): the resolvers
+// refuse an unknown key before staging anything, so a typo here would be
+// answered as a refusal on both doors and the comparison would hold vacuously.
+var bothDoorsFixtures = map[string]bothDoorsFixture{
+	"archivePerson":       archiveDoors("people", "person"),
+	"archiveOrganization": archiveDoors("organizations", "organization"),
+	"archiveDeal":         archiveDoors("deals", "deal"),
+	"archiveProject":      archiveDoors("projects", "project"),
+	"archiveRelationship": archiveDoors("relationships", "relationship"),
+
+	"createPerson":       createDoors("people", "person", `{"full_name":"Ada Lovelace"}`),
+	"createOrganization": createDoors("organizations", "organization", `{"display_name":"Acme"}`),
+	"createDeal": createDoors("deals", "deal", `{"name":"Acme renewal",`+
+		`"pipeline_id":"019ff000-0000-7000-8000-000000000011","stage_id":"019ff000-0000-7000-8000-000000000012"}`),
+	"createLead": createDoors("leads", "lead", `{"full_name":"Grace Hopper","company_name":"Acme"}`),
+	"createProject": createDoors("projects", "project",
+		`{"name":"Acme rollout","organization_id":"019ff000-0000-7000-8000-000000000013"}`),
+	"createRelationship": createDoors("relationships", "relationship",
+		`{"kind":"employment","person_id":"019ff000-0000-7000-8000-000000000014"}`),
+
+	"updatePerson":       updateDoors("people", "person", `{"title":"CTO"}`),
+	"updateOrganization": updateDoors("organizations", "organization", `{"industry":"payments"}`),
+	"updateDeal":         updateDoors("deals", "deal", `{"forecast_category":"commit"}`),
+	"updateLead":         updateDoors("leads", "lead", `{"status":"working"}`),
+	"updateActivity":     updateDoors("activities", "activity", `{"subject":"Renewal call"}`),
+	"updateProject":      updateDoors("projects", "project", `{"description":"Rollout"}`),
+	"updateRelationship": updateDoors("relationships", "relationship", `{"role":"champion"}`),
+
+	"mergePerson":       mergeDoors("people", "person"),
+	"mergeOrganization": mergeDoors("organizations", "organization"),
+
+	"scrapeCompany":   enrichDoors("enrich", agents.EnrichDepthPage),
+	"deepReadCompany": enrichDoors("deep-read", agents.EnrichDepthSite),
+
+	"promoteLead": {
+		rest: func(primary, _ ids.UUID) (*http.Request, []byte) {
+			return doorRequest(http.MethodPost, "/v1/leads/"+primary.String()+"/promote", primary,
+				`{"trigger":"inbound_reply"}`)
+		},
+		args: func(primary, _ ids.UUID) string {
+			return `{"lead_id":"` + primary.String() + `","trigger":"inbound_reply"}`
+		},
+	},
+	"disqualifyLead": {
+		rest: func(primary, _ ids.UUID) (*http.Request, []byte) {
+			return doorRequest(http.MethodDelete, "/v1/leads/"+primary.String(), primary, "")
+		},
+		args: func(primary, _ ids.UUID) string { return `{"lead_id":"` + primary.String() + `"}` },
+	},
+	"advanceProjectPhase": {
+		rest: func(primary, _ ids.UUID) (*http.Request, []byte) {
+			return doorRequest(http.MethodPost, "/v1/projects/"+primary.String()+"/advance", primary,
+				`{"to_phase":"pursuing"}`)
+		},
+		args: func(primary, _ ids.UUID) string {
+			return `{"project_id":"` + primary.String() + `","to_phase":"pursuing"}`
+		},
+	},
+}
+
+// twinnedOperations is the subject set, derived: an operation whose declared
+// verb is a REGISTERED tool that can stage, and whose own operationId that
+// tool's spec names as one of the operations it twins (ToolSpec.OpenAPIOp, the
+// `/`-separated list a verb serving several operations carries).
+//
+// The OpenAPIOp reading is what keeps this set honest in both directions. Most
+// of the surface shares a verb with operations the verb cannot express —
+// confirmOrganizationFact is an `update_record` operation no update_record call
+// can spell — and a set built from the verb alone would demand a tool fixture
+// for an act the tool door has no way to ask for. A composed entry (`getPerson
+// + listActivities`) matches no operationId and drops out on its own.
+func twinnedOperations(served *agents.Registry) map[string]string {
+	twins := map[string]string{}
+	for op, route := range agentReachableMutations() {
+		pol := agentPolicies[route]
+		spec, registered := served.Spec(pol.Tool)
+		if !registered || !served.Stageable(pol.Tool) {
+			continue
+		}
+		for _, named := range strings.Split(spec.OpenAPIOp, "/") {
+			if named == op {
+				twins[op] = pol.Tool
+			}
+		}
+	}
+	return twins
+}
+
+// bothDoorsRegistry is the tool door under test: the production registrations,
+// over the record seam every one of these resolvers reads through and nothing
+// else. The executor seams are nil on purpose — a call that EXECUTED instead of
+// staging would fault here rather than quietly pass.
+//
+// The floor tightens every (verb, record type) it is asked about, which is how
+// a 🟢 verb comes to stage at all. It is the contract's own mechanism (#982),
+// injected with a test's answer rather than the generated table's: the question
+// this gate asks — do the two doors resolve one command — has the same answer
+// at either tier, and keying the subject set on today's floor would quietly
+// drop an operation the day the contract loosened one.
+func bothDoorsRegistry(staging agents.Approvals) *agents.Registry {
+	reg := agents.NewRegistry(staging, auth.NewGate(fullSeat{}),
+		agents.WithTierFloor(func(string, string) (mcp.RiskTier, bool) {
+			return mcp.TierConfirmationRequired, true
+		}))
+	agents.RegisterCoreTools(reg, seamRecord{}, nil, nil, nil)
+	agents.RegisterEnrichTool(reg, seamRecord{}, nil)
+	agents.RegisterLifecycleTools(reg, seamRecord{}, nil, nil, nil)
+	return reg
+}
+
+// agentDoorCtx is a passport principal holding every cap, so admission turns on
+// the call's tier alone — which is the only thing this gate wants it to turn on.
+func agentDoorCtx() context.Context {
+	ctx := principal.WithWorkspaceID(context.Background(), ids.NewV7())
+	return principal.WithActor(ctx, principal.Principal{
+		Type: principal.PrincipalAgent, ID: "agent:both-doors", SeatType: principal.SeatFull,
+		OnBehalfOf: ids.NewV7(),
+		Scopes: principal.NewScopeSet(principal.ScopeRead, principal.ScopeWrite,
+			principal.ScopeSend, principal.ScopeEnrich, principal.ScopeDraft),
+	})
+}
+
+// outOfLaneVerbs are the twinned verbs whose tool cannot be built without a
+// live comms or scheduling seam — both of which need a pool, which is a
+// database, which is not this lane. The claim is CHECKED rather than trusted:
+// the walk asserts each is registered on the production surface and absent from
+// the one built here, so a verb that becomes buildable stops being excused.
+//
+// Their two doors are compared where a database exists:
+// TestBothDoorsStageOneRowForOneOperation (agentcommandstagedrow_integration_test.go)
+// takes the send through the real registry and the real approvals engine.
+var outOfLaneVerbs = gatekit.Waive(map[string]string{
+	"send_email": "a reply send is built over the comms seam, which needs a pool — so this lane compares " +
+		"nothing about the two doors of POST /v1/activities/{id}/send-email",
+	"send_message": "a channel reply is built over the comms seam, which needs a pool — so this lane " +
+		"compares nothing about the two doors of POST /v1/activities/{id}/send-message",
+	"send_account_email": "an account-started send is built over the comms seam, which needs a pool — so " +
+		"this lane compares nothing about the two doors of POST /v1/emails",
+	"book_meeting": "a booking is built over the scheduling seam, which needs a pool — so this lane " +
+		"compares nothing about the two doors of POST /v1/bookings",
+})
+
+func TestBothDoorsResolveOneOperationToOneCommand(t *testing.T) {
+	defer outOfLaneVerbs.AssertAllMatched(t)
+	served := NewRegistry(nil, SendPath{})
+	twins := twinnedOperations(served)
+	if len(twins) == 0 {
+		t.Fatal("no operation has a stageable tool twin — this gate compared nothing")
+	}
+	for op, tool := range twins {
+		fixture, written := bothDoorsFixtures[op]
+		if !written {
+			assertVerbIsOutOfLane(t, served, op, tool)
+			continue
+		}
+		t.Run(op, func(t *testing.T) {
+			compareDoors(t, op, tool, fixture)
+		})
+	}
+	for op := range bothDoorsFixtures {
+		if _, twinned := twins[op]; !twinned {
+			t.Errorf("%s has a two-door fixture and no stageable tool twin — the fixture describes a call the "+
+				"tool door cannot be asked to make, and the comparison below never runs for it", op)
+		}
+	}
+}
+
+// assertVerbIsOutOfLane holds an unwritten fixture to its stated reason. A
+// dynamic-tier verb resolves its tier by READING the record, so whether it
+// stages at all is a fact about workspace state rather than about the call, and
+// there is no staged row for a fixture to compare; anything else must be a verb
+// this lane cannot build a tool for.
+func assertVerbIsOutOfLane(t *testing.T, served *agents.Registry, op, tool string) {
+	t.Helper()
+	if spec, _ := served.Spec(tool); spec.Tier == mcp.TierDynamic {
+		return
+	}
+	if !outOfLaneVerbs.Waived(t, tool) {
+		t.Errorf("%s is twinned by the stageable verb %s and has no two-door fixture, so nothing checks that "+
+			"the route and the tool call resolve to one command", op, tool)
+		return
+	}
+	if _, buildable := bothDoorsRegistry(&capturingApprovals{}).Spec(tool); buildable {
+		t.Errorf("%s is excused as unbuildable in this lane, and this lane registers it after all — write "+
+			"%s's fixture instead", tool, op)
+	}
+}
+
+// compareDoors resolves one operation through each door and holds the two
+// answers to being the same one.
+//
+// The REST side is compared at the COMMAND, not at the staged row: this door
+// writes its own inbox line (restSummary names the concrete method and path a
+// REST diff hash binds), so the resolver's sentence never reaches the approval
+// it stages. The sentence is still the only handle either door has on what the
+// erased command carries — the enrich depth lives nowhere else — so it is the
+// resolved StageInfo that is held against the tool door's staged row.
+func compareDoors(t *testing.T, op, tool string, fixture bothDoorsFixture) {
+	t.Helper()
+	primary, secondary := ids.NewV7(), ids.NewV7()
+	pol := agentPolicies[agentReachableMutations()[op]]
+
+	req, body := fixture.rest(primary, secondary)
+	call, err := restCommands[op](pol, restCommandDeps{records: seamRecord{}}, req, body)
+	if err != nil {
+		t.Fatalf("the REST door refused the request its own route declares: %v", err)
+	}
+	rest, err := agents.StageSubject(req.Context(), call)
+	if err != nil {
+		t.Fatalf("the REST door's command refused to name a subject: %v", err)
+	}
+
+	staging := &capturingApprovals{}
+	_, err = bothDoorsRegistry(staging).Invoke(agentDoorCtx(), tool,
+		json.RawMessage(fixture.args(primary, secondary)))
+	var staged *workflow.StagedApprovalError
+	if !errors.As(err, &staged) {
+		t.Fatalf("the tool door answered %v rather than staging the call its own schema declares", err)
+	}
+
+	if staging.last.TargetType != rest.TargetType || staging.last.TargetID != rest.TargetID {
+		t.Errorf("the doors bind one operation to two records: REST (%s,%s), tool (%s,%s) — one of them asks "+
+			"a human about a row the other would not have written",
+			rest.TargetType, rest.TargetID, staging.last.TargetType, staging.last.TargetID)
+	}
+	if staging.last.Summary != rest.Summary {
+		t.Errorf("the doors describe one operation two ways:\n  REST: %q\n  tool: %q\nA human releasing one "+
+			"reads the other's act", rest.Summary, staging.last.Summary)
+	}
+	if (staging.last.TargetVersion == nil) != (rest.TargetVersion == nil) {
+		t.Errorf("one door pins a version the other does not (REST %v, tool %v) — the same call would be held "+
+			"to a record's version through one door and not through the other",
+			rest.TargetVersion, staging.last.TargetVersion)
+	}
+	if staging.last.Tool != tool {
+		t.Errorf("the tool door staged kind %q for verb %s", staging.last.Tool, tool)
+	}
+}

--- a/backend/internal/compose/agentcommandbothdoors_test.go
+++ b/backend/internal/compose/agentcommandbothdoors_test.go
@@ -18,11 +18,14 @@ package compose
 // a decoder, feed its output to the twin — would compare a decoder with itself
 // and pass for any pair of doors that agreed on nothing.
 //
-// The enrich verb is why the summary is compared and not only the target. Its
-// two operations are one verb at two DEPTHS against one organization, so a
-// swapped depth stages an identical target under a sentence describing the
-// other act: a human releasing a whole-site crawl on a line written for a
-// single page read.
+// The enrich verb is why the SUMMARY is compared and not only the target. Its
+// two operations are one verb at two depths against one organization, so a
+// swapped depth is invisible in every field a door writes: the target is the
+// same organization either way, and the line this door stages is its own
+// path-derived one (restSummary), which still names the route the caller took.
+// The resolver's sentence is the only place the erased command's depth surfaces
+// at all — so comparing it is how a page read that will execute as a whole-site
+// crawl is caught, and there is nothing else on this door to catch it with.
 
 import (
 	"bytes"
@@ -293,6 +296,7 @@ var outOfLaneVerbs = gatekit.Waive(map[string]string{
 
 func TestBothDoorsResolveOneOperationToOneCommand(t *testing.T) {
 	defer outOfLaneVerbs.AssertAllMatched(t)
+	defer dynamicTierVerbs.AssertAllMatched(t)
 	served := NewRegistry(nil, SendPath{})
 	twins := twinnedOperations(served)
 	if len(twins) == 0 {
@@ -316,14 +320,27 @@ func TestBothDoorsResolveOneOperationToOneCommand(t *testing.T) {
 	}
 }
 
-// assertVerbIsOutOfLane holds an unwritten fixture to its stated reason. A
-// dynamic-tier verb resolves its tier by READING the record, so whether it
-// stages at all is a fact about workspace state rather than about the call, and
-// there is no staged row for a fixture to compare; anything else must be a verb
-// this lane cannot build a tool for.
+// dynamicTierVerbs are the twinned verbs whose tier is resolved by READING the
+// record, so whether a given call stages at all is a fact about workspace state
+// rather than about the call — there is no staged row for a fixture to compare
+// against. Ratified rather than waved through in a bare branch: a second verb
+// turning dynamic would otherwise drop out of this gate in silence, and a verb
+// that stops being dynamic is reported stale.
+var dynamicTierVerbs = gatekit.Waive(map[string]string{
+	"advance_deal": "a deal move's tier is decided by reading both endpoints, so an open→open call executes " +
+		"where a close stages — its two doors' agreement is held by agentgatepin_test.go and " +
+		"dealmovepin_integration_test.go instead, which compare the version pin rather than the staged subject",
+})
+
+// assertVerbIsOutOfLane holds an unwritten fixture to a ratified reason: either
+// the verb's tier is resolved per call, or the lane cannot build its tool.
 func assertVerbIsOutOfLane(t *testing.T, served *agents.Registry, op, tool string) {
 	t.Helper()
 	if spec, _ := served.Spec(tool); spec.Tier == mcp.TierDynamic {
+		if !dynamicTierVerbs.Waived(t, tool) {
+			t.Errorf("%s is twinned by %s, whose tier is resolved per call, and no entry says where that "+
+				"operation's two doors are compared instead", op, tool)
+		}
 		return
 	}
 	if !outOfLaneVerbs.Waived(t, tool) {
@@ -375,8 +392,9 @@ func compareDoors(t *testing.T, op, tool string, fixture bothDoorsFixture) {
 			rest.TargetType, rest.TargetID, staging.last.TargetType, staging.last.TargetID)
 	}
 	if staging.last.Summary != rest.Summary {
-		t.Errorf("the doors describe one operation two ways:\n  REST: %q\n  tool: %q\nA human releasing one "+
-			"reads the other's act", rest.Summary, staging.last.Summary)
+		t.Errorf("the doors resolve one operation to two commands:\n  REST: %q\n  tool: %q\nThe sentence is "+
+			"the only place an erased command's own arguments show, so the two doors would perform different "+
+			"acts for one call", rest.Summary, staging.last.Summary)
 	}
 	if (staging.last.TargetVersion == nil) != (rest.TargetVersion == nil) {
 		t.Errorf("one door pins a version the other does not (REST %v, tool %v) — the same call would be held "+

--- a/backend/internal/compose/agentcommandbothdoors_test.go
+++ b/backend/internal/compose/agentcommandbothdoors_test.go
@@ -37,6 +37,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	chi "github.com/go-chi/chi/v5"
 
@@ -45,6 +46,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/shared/gatekit"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/mcp"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/workflow"
 )
@@ -210,6 +212,63 @@ var bothDoorsFixtures = map[string]bothDoorsFixture{
 			return `{"project_id":"` + primary.String() + `","to_phase":"pursuing"}`
 		},
 	},
+
+	// The four outbound verbs. They are the pairs with the most to lose from a
+	// door-to-door disagreement — an approval bound to the wrong record, or a
+	// sentence naming recipients the other door would not have reached — and
+	// the two mail sends carry a `cc` for that reason: the addressee list is
+	// the operand a human reads and the one both summaries have to spell the
+	// same way.
+	//
+	// The account-started send and the booking name their records in the BODY
+	// on both doors, which is why the route carries no id for either: they are
+	// the two operations whose staged target cannot be read off the path at all.
+	"sendEmail": {
+		rest: func(primary, _ ids.UUID) (*http.Request, []byte) {
+			return doorRequest(http.MethodPost, "/v1/activities/"+primary.String()+"/send-email", primary,
+				`{"to":["buyer@example.test"],"cc":["cfo@example.test"],"subject":"Q3 renewal",`+
+					`"body":"hi","consent_purpose":"sales"}`)
+		},
+		args: func(primary, _ ids.UUID) string {
+			return `{"activity_id":"` + primary.String() + `","to":["buyer@example.test"],` +
+				`"cc":["cfo@example.test"],"subject":"Q3 renewal","body":"hi","consent_purpose":"sales"}`
+		},
+	},
+	"sendMessage": {
+		rest: func(primary, _ ids.UUID) (*http.Request, []byte) {
+			return doorRequest(http.MethodPost, "/v1/activities/"+primary.String()+"/send-message", primary,
+				`{"body":"Sending the deck now","consent_purpose":"support"}`)
+		},
+		args: func(primary, _ ids.UUID) string {
+			return `{"activity_id":"` + primary.String() + `","body":"Sending the deck now",` +
+				`"consent_purpose":"support"}`
+		},
+	},
+	"sendAccountEmail": {
+		rest: func(primary, _ ids.UUID) (*http.Request, []byte) {
+			return doorRequest(http.MethodPost, "/v1/emails", ids.UUID{},
+				`{"to":["buyer@example.test"],"cc":["cfo@example.test"],"subject":"Introduction",`+
+					`"body":"hi","consent_purpose":"sales","links":[{"entity_type":"organization",`+
+					`"entity_id":"`+primary.String()+`"}]}`)
+		},
+		args: func(primary, _ ids.UUID) string {
+			return `{"to":["buyer@example.test"],"cc":["cfo@example.test"],"subject":"Introduction",` +
+				`"body":"hi","consent_purpose":"sales","links":[{"entity_type":"organization",` +
+				`"entity_id":"` + primary.String() + `"}]}`
+		},
+	},
+	"bookMeeting": {
+		rest: func(primary, _ ids.UUID) (*http.Request, []byte) {
+			return doorRequest(http.MethodPost, "/v1/bookings", ids.UUID{},
+				`{"start":"2026-08-10T09:00:00Z","end":"2026-08-10T09:30:00Z","subject":"Renewal review",`+
+					`"links":[{"entity_type":"deal","entity_id":"`+primary.String()+`"}]}`)
+		},
+		args: func(primary, _ ids.UUID) string {
+			return `{"start":"2026-08-10T09:00:00Z","end":"2026-08-10T09:30:00Z",` +
+				`"subject":"Renewal review","links":[{"entity_type":"deal","entity_id":"` +
+				primary.String() + `"}]}`
+		},
+	},
 }
 
 // twinnedOperations is the subject set, derived: an operation whose declared
@@ -242,8 +301,15 @@ func twinnedOperations(served *agents.Registry) map[string]string {
 
 // bothDoorsRegistry is the tool door under test: the production registrations,
 // over the record seam every one of these resolvers reads through and nothing
-// else. The executor seams are nil on purpose — a call that EXECUTED instead of
-// staging would fault here rather than quietly pass.
+// else. The executor seams are nil or refusing on purpose — a call that
+// EXECUTED instead of staging would fault here rather than quietly pass.
+//
+// The comms and scheduling verbs register over a refusing seam rather than
+// being left out, and that is the whole difference between this lane covering
+// the four sends and excusing them: their resolvers read RECORDS (and, for a
+// channel reply, the kind test), never the send machinery, and Invoke stages a
+// refused 🟡 call before Handle is reached at all. A seam that needed a pool to
+// be CONSTRUCTED was what previously kept them out; nothing about staging did.
 //
 // The floor tightens every (verb, record type) it is asked about, which is how
 // a 🟢 verb comes to stage at all. It is the contract's own mechanism (#982),
@@ -256,10 +322,71 @@ func bothDoorsRegistry(staging agents.Approvals) *agents.Registry {
 		agents.WithTierFloor(func(string, string) (mcp.RiskTier, bool) {
 			return mcp.TierConfirmationRequired, true
 		}))
-	agents.RegisterCoreTools(reg, seamRecord{}, nil, nil, nil)
-	agents.RegisterEnrichTool(reg, seamRecord{}, nil)
-	agents.RegisterLifecycleTools(reg, seamRecord{}, nil, nil, nil)
+	agents.RegisterCoreTools(reg, channelAnchor{}, nil, nil, nil)
+	agents.RegisterEnrichTool(reg, channelAnchor{}, nil)
+	agents.RegisterLifecycleTools(reg, channelAnchor{}, nil, nil, nil)
+	agents.RegisterCommsTools(reg, bothDoorsComms{}, channelAnchor{})
 	return reg
+}
+
+// channelAnchor is seamRecord's answer plus the one field a channel reply's
+// guard reads: an activity whose kind IS a messaging conversation, so a
+// send_message names a subject on both doors instead of being refused before
+// either names one.
+//
+// A second fixture rather than a `kind` added to seamRecord, because the other
+// one's silence is load-bearing: TestAChannelReplyOnANonChannelAnchorStagesNothing
+// reaches its refusal precisely because seamRecord carries no kind at all.
+// `telegram` is the one kind activities.IsChannelKind admits today; if that
+// stops being true, the REST door refuses here and the comparison reports it
+// rather than passing on a reply neither door would make.
+type channelAnchor struct{ seamRecord }
+
+func (channelAnchor) Read(_ context.Context, ref datasource.EntityRef) (datasource.Record, error) {
+	return datasource.Record{
+		Ref:       ref,
+		Fields:    json.RawMessage(`{"name":"Acme","kind":"telegram"}`),
+		Version:   4,
+		Freshness: datasource.FreshnessInfo{Authoritative: true},
+	}, nil
+}
+
+// errBothDoorsExecuted is what every executor method of the seam below answers.
+// Staging reaches none of them, so reaching one means the tool door ran the
+// send instead of staging it — reported as this lane's own failure rather than
+// as a nil-seam panic somewhere inside a handler.
+var errBothDoorsExecuted = errors.New(
+	"the comms seam executed in a lane that only compares what the two doors stage")
+
+// bothDoorsComms is the comms and scheduling seam with no send machinery behind
+// it. Every EXECUTOR method refuses; the one method that is not an executor —
+// the channel-kind test both doors' guards ask — is answered by production's own
+// reading of it (channelKinds, comms.go), so the two doors cannot come to
+// disagree about a kind because a test double had an opinion.
+type bothDoorsComms struct{ channelKinds }
+
+func (bothDoorsComms) DraftEmail(context.Context, ids.UUID, string) (string, string, error) {
+	return "", "", errBothDoorsExecuted
+}
+
+func (bothDoorsComms) SendEmail(context.Context, ids.UUID, agents.SendEmailArgs) (agents.SendEmailResult, error) {
+	return agents.SendEmailResult{}, errBothDoorsExecuted
+}
+
+func (bothDoorsComms) SendAccountEmail(context.Context, []agents.RecordLink, agents.SendEmailArgs) (agents.SendEmailResult, error) {
+	return agents.SendEmailResult{}, errBothDoorsExecuted
+}
+
+func (bothDoorsComms) SendMessage(context.Context, ids.UUID, agents.SendMessageArgs) (agents.SendMessageResult, error) {
+	return agents.SendMessageResult{}, errBothDoorsExecuted
+}
+
+func (bothDoorsComms) Availability(context.Context, *ids.UUID, time.Time, time.Time, int) (agents.AvailabilityResult, error) {
+	return agents.AvailabilityResult{}, errBothDoorsExecuted
+}
+
+func (bothDoorsComms) BookMeeting(context.Context, agents.BookMeetingArgs) (json.RawMessage, error) {
+	return nil, errBothDoorsExecuted
 }
 
 // agentDoorCtx is a passport principal holding every cap, so admission turns on
@@ -274,28 +401,7 @@ func agentDoorCtx() context.Context {
 	})
 }
 
-// outOfLaneVerbs are the twinned verbs whose tool cannot be built without a
-// live comms or scheduling seam — both of which need a pool, which is a
-// database, which is not this lane. The claim is CHECKED rather than trusted:
-// the walk asserts each is registered on the production surface and absent from
-// the one built here, so a verb that becomes buildable stops being excused.
-//
-// Their two doors are compared where a database exists:
-// TestBothDoorsStageOneRowForOneOperation (agentcommandstagedrow_integration_test.go)
-// takes the send through the real registry and the real approvals engine.
-var outOfLaneVerbs = gatekit.Waive(map[string]string{
-	"send_email": "a reply send is built over the comms seam, which needs a pool — so this lane compares " +
-		"nothing about the two doors of POST /v1/activities/{id}/send-email",
-	"send_message": "a channel reply is built over the comms seam, which needs a pool — so this lane " +
-		"compares nothing about the two doors of POST /v1/activities/{id}/send-message",
-	"send_account_email": "an account-started send is built over the comms seam, which needs a pool — so " +
-		"this lane compares nothing about the two doors of POST /v1/emails",
-	"book_meeting": "a booking is built over the scheduling seam, which needs a pool — so this lane " +
-		"compares nothing about the two doors of POST /v1/bookings",
-})
-
 func TestBothDoorsResolveOneOperationToOneCommand(t *testing.T) {
-	defer outOfLaneVerbs.AssertAllMatched(t)
 	defer dynamicTierVerbs.AssertAllMatched(t)
 	served := NewRegistry(nil, SendPath{})
 	twins := twinnedOperations(served)
@@ -305,7 +411,7 @@ func TestBothDoorsResolveOneOperationToOneCommand(t *testing.T) {
 	for op, tool := range twins {
 		fixture, written := bothDoorsFixtures[op]
 		if !written {
-			assertVerbIsOutOfLane(t, served, op, tool)
+			assertVerbResolvesItsTierPerCall(t, served, op, tool)
 			continue
 		}
 		t.Run(op, func(t *testing.T) {
@@ -326,31 +432,32 @@ func TestBothDoorsResolveOneOperationToOneCommand(t *testing.T) {
 // against. Ratified rather than waved through in a bare branch: a second verb
 // turning dynamic would otherwise drop out of this gate in silence, and a verb
 // that stops being dynamic is reported stale.
+//
+// It is the ONLY reason a twinned verb may skip a fixture. A verb whose seam
+// this lane cannot build is not one of them — a resolver reads records, never
+// executors, which is what lets the four outbound verbs above be compared here
+// over a seam that refuses every send.
 var dynamicTierVerbs = gatekit.Waive(map[string]string{
 	"advance_deal": "a deal move's tier is decided by reading both endpoints, so an open→open call executes " +
-		"where a close stages — its two doors' agreement is held by agentgatepin_test.go and " +
-		"dealmovepin_integration_test.go instead, which compare the version pin rather than the staged subject",
+		"where a close stages, and this lane's fixture would compare a staged row that only some workspace " +
+		"states produce — what the two doors do share is the command itself, both decoding into " +
+		"AdvanceDealCommand{DealID, ToStageID} (agentcommandlifecycle.go and tools_lifecycle.go), which no " +
+		"test compares door-to-door today",
 })
 
-// assertVerbIsOutOfLane holds an unwritten fixture to a ratified reason: either
-// the verb's tier is resolved per call, or the lane cannot build its tool.
-func assertVerbIsOutOfLane(t *testing.T, served *agents.Registry, op, tool string) {
+// assertVerbResolvesItsTierPerCall holds an unwritten fixture to the one
+// ratified reason for having none: the verb decides its own tier by reading the
+// record, so this lane has no staged row to compare it by.
+func assertVerbResolvesItsTierPerCall(t *testing.T, served *agents.Registry, op, tool string) {
 	t.Helper()
-	if spec, _ := served.Spec(tool); spec.Tier == mcp.TierDynamic {
-		if !dynamicTierVerbs.Waived(t, tool) {
-			t.Errorf("%s is twinned by %s, whose tier is resolved per call, and no entry says where that "+
-				"operation's two doors are compared instead", op, tool)
-		}
-		return
-	}
-	if !outOfLaneVerbs.Waived(t, tool) {
+	if spec, _ := served.Spec(tool); spec.Tier != mcp.TierDynamic {
 		t.Errorf("%s is twinned by the stageable verb %s and has no two-door fixture, so nothing checks that "+
 			"the route and the tool call resolve to one command", op, tool)
 		return
 	}
-	if _, buildable := bothDoorsRegistry(&capturingApprovals{}).Spec(tool); buildable {
-		t.Errorf("%s is excused as unbuildable in this lane, and this lane registers it after all — write "+
-			"%s's fixture instead", tool, op)
+	if !dynamicTierVerbs.Waived(t, tool) {
+		t.Errorf("%s is twinned by %s, whose tier is resolved per call, and no entry says where that "+
+			"operation's two doors are compared instead", op, tool)
 	}
 }
 
@@ -369,7 +476,8 @@ func compareDoors(t *testing.T, op, tool string, fixture bothDoorsFixture) {
 	pol := agentPolicies[agentReachableMutations()[op]]
 
 	req, body := fixture.rest(primary, secondary)
-	call, err := restCommands[op](pol, restCommandDeps{records: seamRecord{}}, req, body)
+	call, err := restCommands[op](pol,
+		restCommandDeps{records: channelAnchor{}, channels: channelKinds{}}, req, body)
 	if err != nil {
 		t.Fatalf("the REST door refused the request its own route declares: %v", err)
 	}

--- a/backend/internal/compose/agentcommandcoverage_test.go
+++ b/backend/internal/compose/agentcommandcoverage_test.go
@@ -23,8 +23,15 @@ package compose
 // target — and each says so where it stands.
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
+
+	chi "github.com/go-chi/chi/v5"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
 // agentReachableMutations is the subject set, derived: every route an agent
@@ -79,5 +86,48 @@ func TestEveryAgentReachableMutatingRouteDecodesIntoACommand(t *testing.T) {
 				"retired operationId or a route the contract no longer annotates for agents, and it will go "+
 				"on reading as coverage for as long as it sits there", op)
 		}
+	}
+}
+
+// The other half of the gate above: what the door does with an operation that
+// slipped past it anyway.
+//
+// The walk makes the branch statically unreachable for every route the contract
+// declares today, which is the defence that matters — but "unreachable" is a
+// claim about the table, and the behaviour behind it is what a future table
+// makes true or false. The old answer was a GUESS assembled from the route: the
+// {id} the router bound, paired with the policy's declared record type. It
+// staged for anything, which is precisely why a missing entry could go unnoticed
+// for two tasks.
+//
+// The request here carries a well-formed routed id on purpose. That is the input
+// the guess read, so a door that resolved targets that way would stage happily
+// and pass everything except this.
+func TestAnOperationWithNoCommandIsRefusedRatherThanGuessedAt(t *testing.T) {
+	person := ids.NewV7()
+	pol := agentPolicy{
+		Op: "archiveSomethingNoCommandDescribes", Access: accessTool, Tool: "archive_record",
+		RecordType: recordTypePerson, Tier: tierConfirmationRequired,
+	}
+	if _, described := restCommands[pol.Op]; described {
+		t.Fatalf("%s has a command after all, so this test proves nothing about the door's answer without one", pol.Op)
+	}
+
+	req := httptest.NewRequest(http.MethodDelete, "/v1/people/"+person.String(), nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", person.String())
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+	staging := &capturingApprovals{}
+	rec := httptest.NewRecorder()
+
+	stageRefusal(rec, req, staging, restCommandDeps{records: seamRecord{}}, pol, nil)
+
+	if staging.last.Tool != "" {
+		t.Errorf("an approval was staged for an operation nothing can describe, binding %s %s — a target read "+
+			"off the route is a guess, and a human deciding from it is deciding about whatever the route "+
+			"happened to name", staging.last.TargetType, staging.last.TargetID)
+	}
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("an operation with no governed call answered %d, want 403", rec.Code)
 	}
 }

--- a/backend/internal/compose/agentcommandcoverage_test.go
+++ b/backend/internal/compose/agentcommandcoverage_test.go
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The completeness gate for the governance seam: every operation an agent can
+// MUTATE anything through decodes into a typed command, and nothing else does.
+//
+// It replaces four family-shaped walks — one per operation family, each with
+// its own filter (a route shape, a tier, a tool verb) and its own remembered
+// count. Between them they happened to cover the whole surface, but a set of
+// partial gates that unions to completeness is not a completeness gate: the
+// filters were written independently, and a route none of them selected was
+// covered by none of them. updateOfferTemplate spent two tasks in exactly that
+// position, because one walk filtered on the method PATCH and its route is a
+// PUT, while the walk that would otherwise have caught it stood down on the
+// grounds that the first one had it.
+//
+// So there is one subject set here and no filter inside it: Access "tool" and
+// a mutating method, which is precisely what the gate admits an agent to and
+// therefore precisely what may reach staging. The per-family tests that remain
+// assert something this one does not — decoding a real body, staging the right
+// target — and each says so where it stands.
+
+import (
+	"strings"
+	"testing"
+)
+
+// agentReachableMutations is the subject set, derived: every route an agent
+// principal can reach with a mutating method, keyed by operationId.
+//
+// Keyed by OP rather than by route because that is the key restCommands is
+// keyed by, and the gate below compares the two sets directly. The route comes
+// along as the value so a failure names the place a reader has to go.
+func agentReachableMutations() map[string]string {
+	routes := make(map[string]string, len(agentPolicies))
+	for route, pol := range agentPolicies {
+		method, _, _ := strings.Cut(route, " ")
+		if pol.Access != accessTool || !mutatingMethod(method) {
+			continue
+		}
+		routes[pol.Op] = route
+	}
+	return routes
+}
+
+// The seam's whole claim, in one assertion: what an agent can mutate and what
+// this door can describe are the same set.
+//
+// Both directions, because either alone is satisfied by a table that is wrong
+// in the other. A missing entry is an operation whose staged approval nothing
+// can say what it binds to — the refusal a human is asked to release names a
+// target the door never resolved. A surplus entry is a decoder answering for an
+// operation no agent reaches, which reads as coverage and is not: the same
+// entry would go on looking correct after the contract retired the route it
+// belongs to.
+//
+// The count is derived on both sides rather than written down. A remembered
+// literal is a second source of truth about the contract, and it goes stale in
+// the direction that reads as success: a route the contract adds fails a count
+// of 69 with a message about arithmetic, where what actually happened is that
+// an operation arrived with no governed call.
+func TestEveryAgentReachableMutatingRouteDecodesIntoACommand(t *testing.T) {
+	reachable := agentReachableMutations()
+	if len(reachable) == 0 {
+		t.Fatal("the policy table declares no agent-reachable mutating route at all — this gate checked nothing")
+	}
+	for op, route := range reachable {
+		if _, described := restCommands[op]; !described {
+			t.Errorf("%s (%s) is a mutating operation an agent can reach, and it decodes into no command — "+
+				"nothing can say what an approval of it would bind to, so the call is refused at staging "+
+				"rather than staged. Register it in restCommands (agentcommand.go).", route, op)
+		}
+	}
+	for op := range restCommands {
+		if _, reaches := reachable[op]; !reaches {
+			t.Errorf("restCommands[%q] decodes an operation no agent can mutate through — it is either a "+
+				"retired operationId or a route the contract no longer annotates for agents, and it will go "+
+				"on reading as coverage for as long as it sits there", op)
+		}
+	}
+}

--- a/backend/internal/compose/agentcommandlifecycle.go
+++ b/backend/internal/compose/agentcommandlifecycle.go
@@ -11,9 +11,11 @@ package compose
 // (modules/agents/commandlifecycle.go).
 
 import (
+	"encoding/json"
 	"net/http"
 
 	"github.com/gradionhq/margince/backend/internal/modules/agents"
+	"github.com/gradionhq/margince/backend/internal/platform/httperr"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
@@ -75,25 +77,51 @@ func advanceProjectPhaseCommand(_ agentPolicy, deps restCommandDeps, r *http.Req
 	}), nil
 }
 
-// advanceDealCommand decodes POST /v1/deals/{id}/advance.
+// advanceDealCommand decodes POST /v1/deals/{id}/advance — the ONE parse of this
+// request. The tier gate reads its answer off the call this produces
+// (agents.DynamicTierInput, reached from agentgate.go's tierInput), so the
+// endpoints a move's 🟢/🟡 is judged from and the move a human is later asked
+// about cannot be read differently.
 //
-// It reads the same two ids advanceDealTierInput (agentgate.go) reads, and
-// that overlap is deliberate for now: the tier question is answered BEFORE
-// admission and the staged subject only on the refusal path, so the two run at
-// different moments and each takes the reading its own moment needs. Folding
-// them into one reading is task 9's, and doing it here would mean this decoder
-// answering a tier question it is never asked.
+// It does not share commandBody, because this is the one decoder whose faults
+// the caller must be able to tell apart. THREE of them, three answers, and the
+// order matters because each later check presumes the earlier one passed:
+// json.Unmarshal alone cannot separate the first two — it fails identically for
+// a body that is not JSON and for a body that is perfectly good JSON carrying a
+// to_stage_id the UUID decoder refuses. Answering "not readable JSON" to the
+// second sends the caller hunting a syntax error that is not there, while the
+// real fault — a value they can see and fix — goes unnamed.
 //
 //nolint:ireturn // a decoder's whole product is the erased command-and-resolver pair restCommands is typed by
 func advanceDealCommand(_ agentPolicy, deps restCommandDeps, r *http.Request, body []byte) (agents.GovernedCall, error) {
+	// The deal is named by the ROUTE — /deals/{id}/advance — and a path segment
+	// that is not an id gets the existence-hiding answer every other decoder here
+	// gives, rather than a validation message about a record nobody proved exists.
 	id, err := routedID(r)
 	if err != nil {
 		return nil, err
 	}
-	in, err := commandBody[struct {
+	if !json.Valid(body) {
+		// malformed_json, the code httperr.Decode answers on the session half of
+		// this same route — one mistake must not carry two machine codes keyed on
+		// which credential the caller presented.
+		return nil, httperr.Validation("body", "malformed_json", "the request body is not readable JSON")
+	}
+	var in struct {
 		ToStageID ids.UUID `json:"to_stage_id"`
-	}](body)
-	if err != nil {
+	}
+	if err := json.Unmarshal(body, &in); err != nil {
+		// Valid JSON the shape refuses: a non-object, or a to_stage_id that is not
+		// a UUID string. Naming the field is right for both — the fix is to send an
+		// object carrying a canonical UUID there.
+		return nil, httperr.Validation("to_stage_id", "invalid",
+			"to_stage_id must be a canonical UUID string on a JSON object body")
+	}
+	// The omission goes through the one implementation, so a passport reaching
+	// this gate and a session reaching advanceDealInput read the SAME sentence.
+	// The gate resolves the tier before the handler runs, so without this the rule
+	// had two spellings on the one field U3 unified.
+	if err := httperr.RequireBodyID("to_stage_id", in.ToStageID); err != nil {
 		return nil, err
 	}
 	return agents.NewAdvanceDealCall(deps.records, deps.stages, agents.AdvanceDealCommand{

--- a/backend/internal/compose/agentcommandlifecycle.go
+++ b/backend/internal/compose/agentcommandlifecycle.go
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The REST door's half of the four record-lifecycle commands
+// (gradionhq/margince-poc-v1#928 task 7): graduating a lead, retiring one,
+// stepping a project along its phase ladder, and moving a deal between stages.
+// Each names its record in the route and its operands in the body, and each
+// has a tool-door twin resolving the identical command
+// (modules/agents/commandlifecycle.go).
+
+import (
+	"net/http"
+
+	"github.com/gradionhq/margince/backend/internal/modules/agents"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// promoteLeadCommand decodes POST /v1/leads/{id}/promote. The trigger is read
+// off crm.yaml's PromoteLeadRequest; the evidence sub-object is not, because
+// nothing the resolver answers reads it.
+//
+//nolint:ireturn // a decoder's whole product is the erased command-and-resolver pair restCommands is typed by
+func promoteLeadCommand(_ agentPolicy, deps restCommandDeps, r *http.Request, body []byte) (agents.GovernedCall, error) {
+	id, err := routedID(r)
+	if err != nil {
+		return nil, err
+	}
+	in, err := commandBody[struct {
+		Trigger string `json:"trigger"`
+	}](body)
+	if err != nil {
+		return nil, err
+	}
+	return agents.NewPromoteLeadCall(deps.records, agents.PromoteLeadCommand{
+		LeadID:  id,
+		Trigger: in.Trigger,
+	}), nil
+}
+
+// disqualifyLeadCommand decodes DELETE /v1/leads/{id}, which carries no body
+// at all — the routed lead is the whole of the call.
+//
+//nolint:ireturn // a decoder's whole product is the erased command-and-resolver pair restCommands is typed by
+func disqualifyLeadCommand(_ agentPolicy, deps restCommandDeps, r *http.Request, _ []byte) (agents.GovernedCall, error) {
+	id, err := routedID(r)
+	if err != nil {
+		return nil, err
+	}
+	return agents.NewDisqualifyLeadCall(deps.records, agents.DisqualifyLeadCommand{LeadID: id}), nil
+}
+
+// advanceProjectPhaseCommand decodes POST /v1/projects/{id}/advance. Both body
+// fields travel: the resolver refuses a phase the ladder does not have, and a
+// close with no reason, before a human is asked about either.
+//
+//nolint:ireturn // a decoder's whole product is the erased command-and-resolver pair restCommands is typed by
+func advanceProjectPhaseCommand(_ agentPolicy, deps restCommandDeps, r *http.Request, body []byte) (agents.GovernedCall, error) {
+	id, err := routedID(r)
+	if err != nil {
+		return nil, err
+	}
+	in, err := commandBody[struct {
+		ToPhase string  `json:"to_phase"`
+		Reason  *string `json:"reason"`
+	}](body)
+	if err != nil {
+		return nil, err
+	}
+	return agents.NewAdvanceProjectPhaseCall(deps.records, agents.AdvanceProjectPhaseCommand{
+		ProjectID: id,
+		ToPhase:   in.ToPhase,
+		Reason:    in.Reason,
+	}), nil
+}
+
+// advanceDealCommand decodes POST /v1/deals/{id}/advance.
+//
+// It reads the same two ids advanceDealTierInput (agentgate.go) reads, and
+// that overlap is deliberate for now: the tier question is answered BEFORE
+// admission and the staged subject only on the refusal path, so the two run at
+// different moments and each takes the reading its own moment needs. Folding
+// them into one reading is task 9's, and doing it here would mean this decoder
+// answering a tier question it is never asked.
+//
+//nolint:ireturn // a decoder's whole product is the erased command-and-resolver pair restCommands is typed by
+func advanceDealCommand(_ agentPolicy, deps restCommandDeps, r *http.Request, body []byte) (agents.GovernedCall, error) {
+	id, err := routedID(r)
+	if err != nil {
+		return nil, err
+	}
+	in, err := commandBody[struct {
+		ToStageID ids.UUID `json:"to_stage_id"`
+	}](body)
+	if err != nil {
+		return nil, err
+	}
+	return agents.NewAdvanceDealCall(deps.records, deps.stages, agents.AdvanceDealCommand{
+		DealID:    id,
+		ToStageID: in.ToStageID,
+	}), nil
+}

--- a/backend/internal/compose/agentcommandlifecycle.go
+++ b/backend/internal/compose/agentcommandlifecycle.go
@@ -97,6 +97,14 @@ func advanceDealCommand(_ agentPolicy, deps restCommandDeps, r *http.Request, bo
 	// The deal is named by the ROUTE — /deals/{id}/advance — and a path segment
 	// that is not an id gets the existence-hiding answer every other decoder here
 	// gives, rather than a validation message about a record nobody proved exists.
+	//
+	// That does put the two credentials at odds on this one input — a session gets
+	// the handler's own 422 on the path parameter, a passport gets 404 — where the
+	// omission rule below deliberately unifies them. The difference is what each
+	// answer is ABOUT: a body field is the caller's own input either way, while a
+	// routed id names a RECORD, and an agent must not learn from a validation
+	// message that an id it guessed is well-formed but invisible to it.
+	// Existence-hiding wins where the two principles meet.
 	id, err := routedID(r)
 	if err != nil {
 		return nil, err

--- a/backend/internal/compose/agentcommandnested.go
+++ b/backend/internal/compose/agentcommandnested.go
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The REST door's half of the seven bespoke auto-execute commands
+// (gradionhq/margince-poc-v1#928 task 6): a list member, a tag apply, an
+// offer line item add/update/remove, an offer created under a parent deal,
+// and a partner upsert. Unlike agentcommandoperand.go's confirm-first
+// family, none of these carries body-derived VALUES into its command — the
+// body is the executor's own concern, never something Subject or Guards
+// reads (modules/agents/commandnested.go's own doc says why per command) —
+// so decoding is routedID, plus the offer line items' own {lineItemId},
+// handed straight to the resolver.
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/gradionhq/margince/backend/internal/modules/agents"
+	"github.com/gradionhq/margince/backend/internal/platform/httperr"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+//nolint:ireturn // a decoder's whole product is the erased command-and-resolver pair restCommands is typed by
+func addListMemberCommand(_ agentPolicy, deps restCommandDeps, r *http.Request, _ []byte) (agents.GovernedCall, error) {
+	id, err := routedID(r)
+	if err != nil {
+		return nil, err
+	}
+	return agents.NewAddListMemberCall(deps.records, agents.AddListMemberCommand{ID: id}), nil
+}
+
+//nolint:ireturn // a decoder's whole product is the erased command-and-resolver pair restCommands is typed by
+func applyTagCommand(_ agentPolicy, deps restCommandDeps, r *http.Request, _ []byte) (agents.GovernedCall, error) {
+	id, err := routedID(r)
+	if err != nil {
+		return nil, err
+	}
+	return agents.NewApplyTagCall(deps.records, agents.ApplyTagCommand{ID: id}), nil
+}
+
+//nolint:ireturn // a decoder's whole product is the erased command-and-resolver pair restCommands is typed by
+func addOfferLineItemCommand(_ agentPolicy, deps restCommandDeps, r *http.Request, _ []byte) (agents.GovernedCall, error) {
+	id, err := routedID(r)
+	if err != nil {
+		return nil, err
+	}
+	return agents.NewAddOfferLineItemCall(deps.records, agents.AddOfferLineItemCommand{ID: id}), nil
+}
+
+// lineItemID reads the offer line item's {lineItemId} path parameter — the
+// route's SECOND parameter, beyond the offer's own {id} — through the same
+// pathOperand + ids.Parse composition removeStakeholderCommand uses for
+// person_id (agentcommandoperand.go): a missing segment answers 422
+// "missing", a non-empty malformed one answers 422 "invalid". Neither is
+// routedID's existence-hiding 404 — a line item's shape being wrong is the
+// caller's mistake, not a fact about whether the offer exists.
+func lineItemID(r *http.Request) (ids.UUID, error) {
+	raw, err := pathOperand(r, "lineItemId")
+	if err != nil {
+		return ids.UUID{}, err
+	}
+	id, perr := ids.Parse(raw)
+	if perr != nil {
+		return ids.UUID{}, httperr.Validation("lineItemId", "invalid", "lineItemId must be a uuid")
+	}
+	return id, nil
+}
+
+//nolint:ireturn // a decoder's whole product is the erased command-and-resolver pair restCommands is typed by
+func updateOfferLineItemCommand(_ agentPolicy, deps restCommandDeps, r *http.Request, _ []byte) (agents.GovernedCall, error) {
+	id, err := routedID(r)
+	if err != nil {
+		return nil, err
+	}
+	itemID, err := lineItemID(r)
+	if err != nil {
+		return nil, err
+	}
+	return agents.NewUpdateOfferLineItemCall(deps.records, agents.UpdateOfferLineItemCommand{ID: id, LineItemID: itemID}), nil
+}
+
+//nolint:ireturn // a decoder's whole product is the erased command-and-resolver pair restCommands is typed by
+func removeOfferLineItemCommand(_ agentPolicy, deps restCommandDeps, r *http.Request, _ []byte) (agents.GovernedCall, error) {
+	id, err := routedID(r)
+	if err != nil {
+		return nil, err
+	}
+	itemID, err := lineItemID(r)
+	if err != nil {
+		return nil, err
+	}
+	return agents.NewRemoveOfferLineItemCall(deps.records, agents.RemoveOfferLineItemCommand{ID: id, LineItemID: itemID}), nil
+}
+
+// createOfferCommand decodes POST /v1/deals/{id}/offers. The route's own
+// {id} is the DEAL the offer nests under (gradionhq/margince-poc-v1#1046),
+// not an offer id — there is no offer id to decode, since the offer does
+// not exist yet. body is the same buffered copy every other create/patch
+// decoder reuses (createCommand's own comment says why).
+//
+//nolint:ireturn // a decoder's whole product is the erased command-and-resolver pair restCommands is typed by
+func createOfferCommand(_ agentPolicy, deps restCommandDeps, r *http.Request, body []byte) (agents.GovernedCall, error) {
+	dealID, err := routedID(r)
+	if err != nil {
+		return nil, err
+	}
+	return agents.NewCreateOfferCall(deps.records, agents.CreateOfferCommand{
+		DealID: dealID,
+		Fields: json.RawMessage(body),
+	}), nil
+}
+
+//nolint:ireturn // a decoder's whole product is the erased command-and-resolver pair restCommands is typed by
+func upsertPartnerCommand(_ agentPolicy, deps restCommandDeps, r *http.Request, _ []byte) (agents.GovernedCall, error) {
+	id, err := routedID(r)
+	if err != nil {
+		return nil, err
+	}
+	return agents.NewUpsertPartnerCall(deps.records, agents.UpsertPartnerCommand{ID: id}), nil
+}

--- a/backend/internal/compose/agentcommandnested_test.go
+++ b/backend/internal/compose/agentcommandnested_test.go
@@ -1,0 +1,295 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The REST door's half of the seven bespoke auto-execute commands
+// (agentcommandnested.go): the routed {id}'s existence-hiding 404, the
+// offer line items' own {lineItemId} 422, the staged target each decoder
+// resolves to, and the derived coverage gate that pins all seven off the
+// route walk — task 6's sibling of agentcommandoperand_test.go's proof
+// shape for task 5's eight.
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/modules/agents"
+	"github.com/gradionhq/margince/backend/internal/platform/httperr"
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// A malformed routed {id} answers 404 for every one of the seven, the same
+// existence-hiding answer archiveCommand/patchCommand and task 5's eight
+// already give.
+func TestANestedCommandMalformedRouteIDAnswersNotFound(t *testing.T) {
+	cases := []struct {
+		name   string
+		decode func(pol agentPolicy, deps restCommandDeps, r *http.Request, body []byte) (agents.GovernedCall, error)
+		req    *http.Request
+	}{
+		{"addListMember", addListMemberCommand, operandRequest(http.MethodPost, "/v1/lists", "not-a-uuid", "", "", nil)},
+		{"applyTag", applyTagCommand, operandRequest(http.MethodPost, "/v1/tags", "not-a-uuid", "", "", nil)},
+		{
+			"addOfferLineItem", addOfferLineItemCommand,
+			operandRequest(http.MethodPost, "/v1/offers", "not-a-uuid", "", "", []byte(`{}`)),
+		},
+		{
+			"updateOfferLineItem", updateOfferLineItemCommand,
+			operandRequest(http.MethodPatch, "/v1/offers", "not-a-uuid", "lineItemId", ids.NewV7().String(), []byte(`{}`)),
+		},
+		{
+			"removeOfferLineItem", removeOfferLineItemCommand,
+			operandRequest(http.MethodDelete, "/v1/offers", "not-a-uuid", "lineItemId", ids.NewV7().String(), nil),
+		},
+		{
+			"createOffer", createOfferCommand,
+			operandRequest(http.MethodPost, "/v1/deals", "not-a-uuid", "", "", []byte(`{}`)),
+		},
+		{
+			"upsertPartner", upsertPartnerCommand,
+			operandRequest(http.MethodPut, "/v1/organizations", "not-a-uuid", "", "", []byte(`{}`)),
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if _, err := c.decode(agentPolicy{Op: c.name}, restCommandDeps{records: seamRecord{}}, c.req, nil); !errors.Is(err, apperrors.ErrNotFound) {
+				t.Errorf("decoding a malformed id answered %v, want the not-found sentinel", err)
+			}
+		})
+	}
+}
+
+// A missing {lineItemId} answers 422 naming it, not a panic on an empty
+// UUID downstream — the same shape removeProjectStakeholder's person_id
+// gets in task 5's own table.
+func TestAMissingLineItemIDAnswers422(t *testing.T) {
+	offerID := ids.NewV7().String()
+	cases := []struct {
+		name   string
+		decode func(pol agentPolicy, deps restCommandDeps, r *http.Request, body []byte) (agents.GovernedCall, error)
+	}{
+		{"updateOfferLineItem", updateOfferLineItemCommand},
+		{"removeOfferLineItem", removeOfferLineItemCommand},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			// extraParam left empty: the route matched (a valid offer {id}), but
+			// the {lineItemId} segment the router would bind was never set.
+			req := operandRequest(http.MethodPatch, "/v1/offers", offerID, "", "", []byte(`{}`))
+			_, err := c.decode(agentPolicy{Op: c.name}, restCommandDeps{records: seamRecord{}}, req, []byte(`{}`))
+			var detailed *httperr.DetailedError
+			if !errors.As(err, &detailed) || detailed.Status != http.StatusUnprocessableEntity {
+				t.Fatalf("a missing lineItemId answered %v, want a 422 naming it", err)
+			}
+			if len(detailed.Fields) != 1 || detailed.Fields[0].Field != "lineItemId" || detailed.Fields[0].Code != "missing" {
+				t.Errorf("the 422 named %+v, want field \"lineItemId\" code \"missing\"", detailed.Fields)
+			}
+		})
+	}
+}
+
+// A malformed (non-empty) lineItemId is also a 422, code "invalid" rather
+// than "missing" — the other half of the pathOperand + ids.Parse
+// composition, the same shape TestARemoveStakeholderMalformedPersonIDAnswers422
+// proves for person_id.
+func TestAMalformedLineItemIDAnswers422(t *testing.T) {
+	req := operandRequest(http.MethodDelete, "/v1/offers", ids.NewV7().String(), "lineItemId", "not-a-uuid", nil)
+	_, err := removeOfferLineItemCommand(agentPolicy{Op: "removeOfferLineItem"}, restCommandDeps{records: seamRecord{}}, req, nil)
+	var detailed *httperr.DetailedError
+	if !errors.As(err, &detailed) || detailed.Status != http.StatusUnprocessableEntity {
+		t.Fatalf("a malformed lineItemId answered %v, want a 422", err)
+	}
+	if len(detailed.Fields) != 1 || detailed.Fields[0].Field != "lineItemId" || detailed.Fields[0].Code != "invalid" {
+		t.Errorf("the 422 named %+v, want field \"lineItemId\" code \"invalid\"", detailed.Fields)
+	}
+}
+
+// Each of the seven stages against the routed record it names — proven
+// through stageRefusal end to end, the same shape
+// TestEachOperandCommandStagesTheRoutedRecord proves for task 5's eight.
+// createOffer is the one exception: it stages the record TYPE with no id
+// (gradionhq/margince-poc-v1#1046), asserted separately below.
+func TestEachNestedCommandStagesTheRoutedRecord(t *testing.T) {
+	listID, tagID, offerID, orgID := ids.NewV7(), ids.NewV7(), ids.NewV7(), ids.NewV7()
+	lineItemID := ids.NewV7()
+	cases := []struct {
+		name           string
+		pol            agentPolicy
+		req            *http.Request
+		body           []byte
+		wantTargetType string
+		wantTargetID   ids.UUID
+	}{
+		{
+			"addListMember",
+			agentPolicy{Op: "addListMember", Access: accessTool, Tool: "update_record", RecordType: recordTypeList},
+			operandRequest(http.MethodPost, "/v1/lists", listID.String(), "", "", []byte(`{}`)), []byte(`{}`),
+			"list", listID,
+		},
+		{
+			"applyTag",
+			agentPolicy{Op: "applyTag", Access: accessTool, Tool: "update_record", RecordType: recordTypeTag},
+			operandRequest(http.MethodPost, "/v1/tags", tagID.String(), "", "", []byte(`{}`)), []byte(`{}`),
+			"tag", tagID,
+		},
+		{
+			"addOfferLineItem",
+			agentPolicy{Op: "addOfferLineItem", Access: accessTool, Tool: "update_record", RecordType: recordTypeOffer},
+			operandRequest(http.MethodPost, "/v1/offers", offerID.String(), "", "", []byte(`{}`)), []byte(`{}`),
+			"offer", offerID,
+		},
+		{
+			"updateOfferLineItem",
+			agentPolicy{Op: "updateOfferLineItem", Access: accessTool, Tool: "update_record", RecordType: recordTypeOffer},
+			operandRequest(http.MethodPatch, "/v1/offers", offerID.String(), "lineItemId", lineItemID.String(), []byte(`{}`)),
+			[]byte(`{}`), "offer", offerID,
+		},
+		{
+			"removeOfferLineItem",
+			agentPolicy{Op: "removeOfferLineItem", Access: accessTool, Tool: "update_record", RecordType: recordTypeOffer},
+			operandRequest(http.MethodDelete, "/v1/offers", offerID.String(), "lineItemId", lineItemID.String(), nil), nil,
+			"offer", offerID,
+		},
+		{
+			"upsertPartner",
+			agentPolicy{Op: "upsertPartner", Access: accessTool, Tool: "update_record", RecordType: recordTypePartner},
+			operandRequest(http.MethodPut, "/v1/organizations", orgID.String(), "", "", []byte(`{}`)), []byte(`{}`),
+			"organization", orgID,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			staging := &capturingApprovals{}
+			stageRefusal(httptest.NewRecorder(), c.req, staging, restCommandDeps{records: seamRecord{}}, c.pol, c.body)
+
+			if staging.last.TargetType != c.wantTargetType || staging.last.TargetID != c.wantTargetID {
+				t.Fatalf("staged target = (%s,%s), want (%s,%s)",
+					staging.last.TargetType, staging.last.TargetID, c.wantTargetType, c.wantTargetID)
+			}
+		})
+	}
+}
+
+// gradionhq/margince-poc-v1#1046: createOffer stages the record TYPE with
+// NO id, end to end through stageRefusal — the routed {id} on
+// POST /v1/deals/{id}/offers is the DEAL, not an offer, so the only honest
+// staged target is the one every other create stages.
+func TestCreateOfferStagesNoIDThroughStageRefusal(t *testing.T) {
+	dealID := ids.NewV7()
+	staging := &capturingApprovals{}
+	pol := agentPolicy{Op: "createOffer", Access: accessTool, Tool: "create_record", RecordType: recordTypeOffer}
+	body := []byte(`{"currency":"EUR"}`)
+	req := operandRequest(http.MethodPost, "/v1/deals", dealID.String(), "", "", body)
+
+	stageRefusal(httptest.NewRecorder(), req, staging, restCommandDeps{records: seamRecord{}}, pol, body)
+
+	if staging.last.TargetType != "offer" {
+		t.Fatalf("staged target_type = %q, want \"offer\"", staging.last.TargetType)
+	}
+	if !staging.last.TargetID.IsZero() {
+		t.Errorf("staged target_id = %s, want zero — the routed id names the deal, not an offer", staging.last.TargetID)
+	}
+	if !strings.Contains(staging.last.Summary, dealID.String()) {
+		t.Errorf("summary %q does not name the parent deal", staging.last.Summary)
+	}
+}
+
+// The behaviour change registering these seven in restCommands buys over
+// the route-walk fallback: Guards now runs, for the two families the
+// record seam actually serves. createOffer refuses a DEAL the caller
+// cannot see; upsertPartner refuses an ORGANIZATION the caller cannot see.
+// The other five (list, tag, offer) have no such proof — the seam has
+// never served those types, so there is no read for Guards to skip, the
+// same bound task 5's custom_field commands stand on.
+func TestANestedCommandOfAnUnseeableParentStagesNothing(t *testing.T) {
+	cases := []struct {
+		name string
+		pol  agentPolicy
+		req  *http.Request
+		body []byte
+	}{
+		{
+			"createOffer",
+			agentPolicy{Op: "createOffer", Access: accessTool, Tool: "create_record", RecordType: recordTypeOffer},
+			operandRequest(http.MethodPost, "/v1/deals", ids.NewV7().String(), "", "", []byte(`{}`)), []byte(`{}`),
+		},
+		{
+			"upsertPartner",
+			agentPolicy{Op: "upsertPartner", Access: accessTool, Tool: "update_record", RecordType: recordTypePartner},
+			operandRequest(http.MethodPut, "/v1/organizations", ids.NewV7().String(), "", "", []byte(`{}`)), []byte(`{}`),
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			staging := &capturingApprovals{}
+			rec := httptest.NewRecorder()
+
+			stageRefusal(rec, c.req, staging, restCommandDeps{records: hiddenRecord{}}, c.pol, c.body)
+
+			if rec.Code != http.StatusNotFound {
+				t.Errorf("staging against an unseeable parent answered %d, want 404 — the refusal must not "+
+					"tell a caller that a row they may not see exists", rec.Code)
+			}
+			if staging.last.Tool != "" {
+				t.Errorf("an approval was staged for %q against a parent nobody can decide about", staging.last.Tool)
+			}
+		})
+	}
+}
+
+// canonicalCollectionRoute reports the two route shapes
+// TestEveryAgentReachableCreateOperationDecodesIntoACommand and
+// TestEveryAgentReachablePatchOperationDecodesIntoACommand already cover in
+// full: a bare collection path with no path parameter at all (a top-level
+// create), or a path ending in exactly one {id} (a whole-record patch,
+// PATCH or PUT alike — updateOfferTemplate's PUT is canonical by this
+// shape even though that other test's own filter is PATCH-only). Anything
+// else nests under a parent or reaches a child/membership action, which is
+// this file's seven.
+func canonicalCollectionRoute(route string) bool {
+	if !strings.Contains(route, "{") {
+		return true
+	}
+	return strings.HasSuffix(route, "/{id}") && strings.Count(route, "{") == 1
+}
+
+// TestEveryAutoExecuteNestedOrActionRouteDecodesIntoACommand is task 6's
+// sibling of TestEveryConfirmFirstOperandRouteDecodesIntoTheRightCommand
+// (agentcommandoperand_test.go): the same derived-coverage shape, for the
+// AUTO-EXECUTE side of create_record/update_record — every such operation
+// whose route is not the canonical collection shape must decode into a
+// command, or its staged target is still guessed from the route the moment
+// a tier floor (#982) promotes it to confirm-first.
+//
+// Derived from agentPolicies rather than the seven names in the brief's own
+// table, so a route the contract adds to this shape fails here rather than
+// silently falling back to the guess.
+func TestEveryAutoExecuteNestedOrActionRouteDecodesIntoACommand(t *testing.T) {
+	checked := 0
+	for route, pol := range agentPolicies {
+		if pol.Access != accessTool || pol.Tier != tierAutoExecute {
+			continue
+		}
+		if pol.Tool != "create_record" && pol.Tool != "update_record" {
+			continue
+		}
+		if canonicalCollectionRoute(route) {
+			continue
+		}
+		checked++
+		if _, described := restCommands[pol.Op]; !described {
+			t.Errorf("%s (%s) is an auto-execute create/update operation whose route is not the canonical "+
+				"collection shape, but decodes into no command — its staged target is still guessed from "+
+				"the route the moment a tier floor promotes it", route, pol.Op)
+		}
+	}
+	if checked != 7 {
+		t.Errorf("the policy table carries %d auto-execute nested/action create-or-update operations, want "+
+			"7 — if the contract gained or lost one, this seam's coverage moved with it", checked)
+	}
+}

--- a/backend/internal/compose/agentcommandnested_test.go
+++ b/backend/internal/compose/agentcommandnested_test.go
@@ -244,13 +244,17 @@ func TestANestedCommandOfAnUnseeableParentStagesNothing(t *testing.T) {
 
 // canonicalCollectionRoute reports the two route shapes
 // TestEveryAgentReachableCreateOperationDecodesIntoACommand and
-// TestEveryAgentReachablePatchOperationDecodesIntoACommand already cover in
-// full: a bare collection path with no path parameter at all (a top-level
-// create), or a path ending in exactly one {id} (a whole-record patch,
-// PATCH or PUT alike — updateOfferTemplate's PUT is canonical by this
-// shape even though that other test's own filter is PATCH-only). Anything
-// else nests under a parent or reaches a child/membership action, which is
-// this file's seven.
+// TestEveryAgentReachableWholeRecordWriteOperationDecodesIntoACommand
+// already cover in full: a bare collection path with no path parameter at
+// all (a top-level create), or a path ending in exactly one {id} (a
+// whole-record write, PATCH or PUT alike). Anything else nests under a
+// parent or reaches a child/membership action, which is this file's seven.
+//
+// "In full" is now literally true. It was not: the write walk used to filter
+// on PATCH, so updateOfferTemplate's PUT was canonical by THIS shape and
+// invisible to the test excused for covering it — a hole every gate on the
+// surface pointed at each other about. That filter is keyed on shape alone
+// now, which is the only reason this function may go on standing down.
 func canonicalCollectionRoute(route string) bool {
 	if !strings.Contains(route, "{") {
 		return true

--- a/backend/internal/compose/agentcommandnested_test.go
+++ b/backend/internal/compose/agentcommandnested_test.go
@@ -5,10 +5,16 @@ package compose
 
 // The REST door's half of the seven bespoke auto-execute commands
 // (agentcommandnested.go): the routed {id}'s existence-hiding 404, the
-// offer line items' own {lineItemId} 422, the staged target each decoder
-// resolves to, and the derived coverage gate that pins all seven off the
-// route walk — task 6's sibling of agentcommandoperand_test.go's proof
-// shape for task 5's eight.
+// offer line items' own {lineItemId} 422, and the staged target each decoder
+// resolves to — the sibling of agentcommandoperand_test.go's proof shape for
+// the confirm-first eight.
+//
+// That every one of the seven is REGISTERED is not asserted here:
+// TestEveryAgentReachableMutatingRouteDecodesIntoACommand
+// (agentcommandcoverage_test.go) derives that for the whole surface. What this
+// file adds is what a registration alone does not say — that the decoder bound
+// to each route reads the operands its own route carries, and stages the
+// record they name.
 
 import (
 	"errors"
@@ -239,61 +245,5 @@ func TestANestedCommandOfAnUnseeableParentStagesNothing(t *testing.T) {
 				t.Errorf("an approval was staged for %q against a parent nobody can decide about", staging.last.Tool)
 			}
 		})
-	}
-}
-
-// canonicalCollectionRoute reports the two route shapes
-// TestEveryAgentReachableCreateOperationDecodesIntoACommand and
-// TestEveryAgentReachableWholeRecordWriteOperationDecodesIntoACommand
-// already cover in full: a bare collection path with no path parameter at
-// all (a top-level create), or a path ending in exactly one {id} (a
-// whole-record write, PATCH or PUT alike). Anything else nests under a
-// parent or reaches a child/membership action, which is this file's seven.
-//
-// "In full" is now literally true. It was not: the write walk used to filter
-// on PATCH, so updateOfferTemplate's PUT was canonical by THIS shape and
-// invisible to the test excused for covering it — a hole every gate on the
-// surface pointed at each other about. That filter is keyed on shape alone
-// now, which is the only reason this function may go on standing down.
-func canonicalCollectionRoute(route string) bool {
-	if !strings.Contains(route, "{") {
-		return true
-	}
-	return strings.HasSuffix(route, "/{id}") && strings.Count(route, "{") == 1
-}
-
-// TestEveryAutoExecuteNestedOrActionRouteDecodesIntoACommand is task 6's
-// sibling of TestEveryConfirmFirstOperandRouteDecodesIntoTheRightCommand
-// (agentcommandoperand_test.go): the same derived-coverage shape, for the
-// AUTO-EXECUTE side of create_record/update_record — every such operation
-// whose route is not the canonical collection shape must decode into a
-// command, or its staged target is still guessed from the route the moment
-// a tier floor (#982) promotes it to confirm-first.
-//
-// Derived from agentPolicies rather than the seven names in the brief's own
-// table, so a route the contract adds to this shape fails here rather than
-// silently falling back to the guess.
-func TestEveryAutoExecuteNestedOrActionRouteDecodesIntoACommand(t *testing.T) {
-	checked := 0
-	for route, pol := range agentPolicies {
-		if pol.Access != accessTool || pol.Tier != tierAutoExecute {
-			continue
-		}
-		if pol.Tool != "create_record" && pol.Tool != "update_record" {
-			continue
-		}
-		if canonicalCollectionRoute(route) {
-			continue
-		}
-		checked++
-		if _, described := restCommands[pol.Op]; !described {
-			t.Errorf("%s (%s) is an auto-execute create/update operation whose route is not the canonical "+
-				"collection shape, but decodes into no command — its staged target is still guessed from "+
-				"the route the moment a tier floor promotes it", route, pol.Op)
-		}
-	}
-	if checked != 7 {
-		t.Errorf("the policy table carries %d auto-execute nested/action create-or-update operations, want "+
-			"7 — if the contract gained or lost one, this seam's coverage moved with it", checked)
 	}
 }

--- a/backend/internal/compose/agentcommandoperand.go
+++ b/backend/internal/compose/agentcommandoperand.go
@@ -14,6 +14,7 @@ package compose
 // because the family carries a SECOND path operand those two never had to.
 
 import (
+	"encoding/json"
 	"net/http"
 
 	chi "github.com/go-chi/chi/v5"
@@ -119,13 +120,48 @@ func updateCustomFieldOptionsCommand(_ agentPolicy, deps restCommandDeps, r *htt
 	return agents.NewUpdateCustomFieldOptionsCall(deps.records, agents.UpdateCustomFieldOptionsCommand{ID: id}), nil
 }
 
+// setStakeholderCommand decodes PUT /v1/projects/{id}/stakeholders, whose
+// person_id arrives in the BODY where its DELETE twin carries it in the path.
+//
+// The shape check is the same one removeStakeholderCommand makes for its own
+// operand, and for the same reason: the request the approval stages IS the
+// request its redemption replays, so a person_id that names no person is a call
+// the handler refuses AFTER a human's one-shot approval has been consumed. 422
+// rather than the routed id's 404 — like the path operand, person_id says WHICH
+// edge, not whether the project exists.
+//
+// It is checked here rather than in the resolver because there is nothing for
+// the command to carry it as: neither Guards nor Subject reads the attached
+// person (setStakeholderResolver's own doc says why), and a field with no
+// reader documents no obligation.
+//
 //nolint:ireturn // a decoder's whole product is the erased command-and-resolver pair restCommands is typed by
-func setStakeholderCommand(_ agentPolicy, deps restCommandDeps, r *http.Request, _ []byte) (agents.GovernedCall, error) {
+func setStakeholderCommand(_ agentPolicy, deps restCommandDeps, r *http.Request, body []byte) (agents.GovernedCall, error) {
 	id, err := routedID(r)
 	if err != nil {
 		return nil, err
 	}
+	if err := requireStakeholderPerson(body); err != nil {
+		return nil, err
+	}
 	return agents.NewSetStakeholderCall(deps.records, agents.SetStakeholderCommand{ID: id}), nil
+}
+
+// requireStakeholderPerson holds the body to the one member the attach cannot
+// run without. crm.yaml's SetProjectStakeholderRequest requires person_id as a
+// uuid; a body that is not even an object is answered as the same missing
+// person_id, since neither carries one.
+func requireStakeholderPerson(body []byte) error {
+	var payload struct {
+		PersonID string `json:"person_id"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil || payload.PersonID == "" {
+		return httperr.Validation("person_id", "missing", "person_id is required")
+	}
+	if _, err := ids.Parse(payload.PersonID); err != nil {
+		return httperr.Validation("person_id", "invalid", "person_id must be a uuid")
+	}
+	return nil
 }
 
 // removeStakeholderCommand decodes DELETE /v1/projects/{id}/stakeholders/{person_id}.

--- a/backend/internal/compose/agentcommandoperand.go
+++ b/backend/internal/compose/agentcommandoperand.go
@@ -8,13 +8,12 @@ package compose
 // (gradionhq/margince-poc-v1#928 task 5): an organization fact or profile
 // field, a custom field's retire/options actions, and a project stakeholder.
 // The decoding shape is the same one archiveCommand/patchCommand set in
-// agentcommand.go — parse {id} as the existence-hiding 404, decode the rest,
-// hand the typed command to its resolver (modules/agents/commandsidecar.go,
-// commandaction.go) — split out here because the family carries a SECOND
-// path operand those two never had to.
+// agentcommand.go — parse {id} as the existence-hiding 404 (routedID, shared
+// with them), decode the rest, hand the typed command to its resolver
+// (modules/agents/commandsidecar.go, commandaction.go) — split out here
+// because the family carries a SECOND path operand those two never had to.
 
 import (
-	"encoding/json"
 	"net/http"
 
 	chi "github.com/go-chi/chi/v5"
@@ -38,9 +37,10 @@ func pathOperand(r *http.Request, name string) (string, error) {
 	return v, nil
 }
 
-// routedID parses the route's own {id}, the existence-hiding answer
-// archiveCommand/patchCommand already give a malformed one: "that is not a
-// uuid" and "there is no such row" must read alike.
+// routedID parses the route's own {id}, the existence-hiding answer every
+// restCommands decoder gives a malformed one: "that is not a uuid" and
+// "there is no such row" must read alike, or the shape of a caller's id
+// tells them which rows exist.
 func routedID(r *http.Request) (ids.UUID, error) {
 	id, err := ids.Parse(chi.URLParam(r, "id"))
 	if err != nil {
@@ -63,7 +63,7 @@ func confirmFactCommand(_ agentPolicy, deps restCommandDeps, r *http.Request, _ 
 }
 
 //nolint:ireturn // a decoder's whole product is the erased command-and-resolver pair restCommands is typed by
-func updateFactCommand(_ agentPolicy, deps restCommandDeps, r *http.Request, body []byte) (agents.GovernedCall, error) {
+func updateFactCommand(_ agentPolicy, deps restCommandDeps, r *http.Request, _ []byte) (agents.GovernedCall, error) {
 	id, err := routedID(r)
 	if err != nil {
 		return nil, err
@@ -72,9 +72,7 @@ func updateFactCommand(_ agentPolicy, deps restCommandDeps, r *http.Request, bod
 	if err != nil {
 		return nil, err
 	}
-	return agents.NewUpdateFactCall(deps.records, agents.UpdateFactCommand{
-		ID: id, FactKey: factKey, Fields: json.RawMessage(body),
-	}), nil
+	return agents.NewUpdateFactCall(deps.records, agents.UpdateFactCommand{ID: id, FactKey: factKey}), nil
 }
 
 //nolint:ireturn // a decoder's whole product is the erased command-and-resolver pair restCommands is typed by
@@ -91,7 +89,7 @@ func confirmProfileFieldCommand(_ agentPolicy, deps restCommandDeps, r *http.Req
 }
 
 //nolint:ireturn // a decoder's whole product is the erased command-and-resolver pair restCommands is typed by
-func updateProfileFieldCommand(_ agentPolicy, deps restCommandDeps, r *http.Request, body []byte) (agents.GovernedCall, error) {
+func updateProfileFieldCommand(_ agentPolicy, deps restCommandDeps, r *http.Request, _ []byte) (agents.GovernedCall, error) {
 	id, err := routedID(r)
 	if err != nil {
 		return nil, err
@@ -100,9 +98,7 @@ func updateProfileFieldCommand(_ agentPolicy, deps restCommandDeps, r *http.Requ
 	if err != nil {
 		return nil, err
 	}
-	return agents.NewUpdateProfileFieldCall(deps.records, agents.UpdateProfileFieldCommand{
-		ID: id, Field: field, Fields: json.RawMessage(body),
-	}), nil
+	return agents.NewUpdateProfileFieldCall(deps.records, agents.UpdateProfileFieldCommand{ID: id, Field: field}), nil
 }
 
 //nolint:ireturn // a decoder's whole product is the erased command-and-resolver pair restCommands is typed by
@@ -115,31 +111,31 @@ func retireCustomFieldCommand(_ agentPolicy, deps restCommandDeps, r *http.Reque
 }
 
 //nolint:ireturn // a decoder's whole product is the erased command-and-resolver pair restCommands is typed by
-func updateCustomFieldOptionsCommand(_ agentPolicy, deps restCommandDeps, r *http.Request, body []byte) (agents.GovernedCall, error) {
+func updateCustomFieldOptionsCommand(_ agentPolicy, deps restCommandDeps, r *http.Request, _ []byte) (agents.GovernedCall, error) {
 	id, err := routedID(r)
 	if err != nil {
 		return nil, err
 	}
-	return agents.NewUpdateCustomFieldOptionsCall(deps.records, agents.UpdateCustomFieldOptionsCommand{
-		ID: id, Fields: json.RawMessage(body),
-	}), nil
+	return agents.NewUpdateCustomFieldOptionsCall(deps.records, agents.UpdateCustomFieldOptionsCommand{ID: id}), nil
 }
 
 //nolint:ireturn // a decoder's whole product is the erased command-and-resolver pair restCommands is typed by
-func setStakeholderCommand(_ agentPolicy, deps restCommandDeps, r *http.Request, body []byte) (agents.GovernedCall, error) {
+func setStakeholderCommand(_ agentPolicy, deps restCommandDeps, r *http.Request, _ []byte) (agents.GovernedCall, error) {
 	id, err := routedID(r)
 	if err != nil {
 		return nil, err
 	}
-	return agents.NewSetStakeholderCall(deps.records, agents.SetStakeholderCommand{
-		ID: id, Fields: json.RawMessage(body),
-	}), nil
+	return agents.NewSetStakeholderCall(deps.records, agents.SetStakeholderCommand{ID: id}), nil
 }
 
 // removeStakeholderCommand decodes DELETE /v1/projects/{id}/stakeholders/{person_id}.
-// person_id fails as 422, not 404: unlike the routed {id}, a malformed
-// person_id names no row this door hides the existence of — it names which
-// edge the caller meant, a shape the caller simply got wrong.
+// person_id fails as 422, not 404: unlike the routed {id}, a malformed or
+// missing person_id names no row this door hides the existence of — it
+// names which edge the caller meant, a shape the caller simply got wrong.
+// Composed from the same pathOperand every other second-operand decoder
+// uses (a missing segment answers "missing") plus ids.Parse for the shape
+// check the others don't need (a non-empty but malformed one answers
+// "invalid") — one spelling of "required", not a second copy of it.
 //
 //nolint:ireturn // a decoder's whole product is the erased command-and-resolver pair restCommands is typed by
 func removeStakeholderCommand(_ agentPolicy, deps restCommandDeps, r *http.Request, _ []byte) (agents.GovernedCall, error) {
@@ -147,7 +143,11 @@ func removeStakeholderCommand(_ agentPolicy, deps restCommandDeps, r *http.Reque
 	if err != nil {
 		return nil, err
 	}
-	personID, perr := ids.Parse(chi.URLParam(r, "person_id"))
+	raw, err := pathOperand(r, "person_id")
+	if err != nil {
+		return nil, err
+	}
+	personID, perr := ids.Parse(raw)
 	if perr != nil {
 		return nil, httperr.Validation("person_id", "invalid", "person_id must be a uuid")
 	}

--- a/backend/internal/compose/agentcommandoperand.go
+++ b/backend/internal/compose/agentcommandoperand.go
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The REST door's half of the eight commands whose operand is a SECOND path
+// parameter or a second path segment, not the route's own {id}
+// (gradionhq/margince-poc-v1#928 task 5): an organization fact or profile
+// field, a custom field's retire/options actions, and a project stakeholder.
+// The decoding shape is the same one archiveCommand/patchCommand set in
+// agentcommand.go — parse {id} as the existence-hiding 404, decode the rest,
+// hand the typed command to its resolver (modules/agents/commandsidecar.go,
+// commandaction.go) — split out here because the family carries a SECOND
+// path operand those two never had to.
+
+import (
+	"encoding/json"
+	"net/http"
+
+	chi "github.com/go-chi/chi/v5"
+
+	"github.com/gradionhq/margince/backend/internal/modules/agents"
+	"github.com/gradionhq/margince/backend/internal/platform/httperr"
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// pathOperand reads a required path parameter beyond the route's own {id}.
+// chi has already matched the route by the time a handler runs, so an empty
+// value means the parameter was never bound — a request built by hand
+// (tests) or a future route missing the segment — and answers 422 naming the
+// parameter, not a panic on an empty FactKey/Field later.
+func pathOperand(r *http.Request, name string) (string, error) {
+	v := chi.URLParam(r, name)
+	if v == "" {
+		return "", httperr.Validation(name, "missing", name+" is required")
+	}
+	return v, nil
+}
+
+// routedID parses the route's own {id}, the existence-hiding answer
+// archiveCommand/patchCommand already give a malformed one: "that is not a
+// uuid" and "there is no such row" must read alike.
+func routedID(r *http.Request) (ids.UUID, error) {
+	id, err := ids.Parse(chi.URLParam(r, "id"))
+	if err != nil {
+		return ids.UUID{}, apperrors.ErrNotFound
+	}
+	return id, nil
+}
+
+//nolint:ireturn // a decoder's whole product is the erased command-and-resolver pair restCommands is typed by
+func confirmFactCommand(_ agentPolicy, deps restCommandDeps, r *http.Request, _ []byte) (agents.GovernedCall, error) {
+	id, err := routedID(r)
+	if err != nil {
+		return nil, err
+	}
+	factKey, err := pathOperand(r, "factKey")
+	if err != nil {
+		return nil, err
+	}
+	return agents.NewConfirmFactCall(deps.records, agents.ConfirmFactCommand{ID: id, FactKey: factKey}), nil
+}
+
+//nolint:ireturn // a decoder's whole product is the erased command-and-resolver pair restCommands is typed by
+func updateFactCommand(_ agentPolicy, deps restCommandDeps, r *http.Request, body []byte) (agents.GovernedCall, error) {
+	id, err := routedID(r)
+	if err != nil {
+		return nil, err
+	}
+	factKey, err := pathOperand(r, "factKey")
+	if err != nil {
+		return nil, err
+	}
+	return agents.NewUpdateFactCall(deps.records, agents.UpdateFactCommand{
+		ID: id, FactKey: factKey, Fields: json.RawMessage(body),
+	}), nil
+}
+
+//nolint:ireturn // a decoder's whole product is the erased command-and-resolver pair restCommands is typed by
+func confirmProfileFieldCommand(_ agentPolicy, deps restCommandDeps, r *http.Request, _ []byte) (agents.GovernedCall, error) {
+	id, err := routedID(r)
+	if err != nil {
+		return nil, err
+	}
+	field, err := pathOperand(r, "field")
+	if err != nil {
+		return nil, err
+	}
+	return agents.NewConfirmProfileFieldCall(deps.records, agents.ConfirmProfileFieldCommand{ID: id, Field: field}), nil
+}
+
+//nolint:ireturn // a decoder's whole product is the erased command-and-resolver pair restCommands is typed by
+func updateProfileFieldCommand(_ agentPolicy, deps restCommandDeps, r *http.Request, body []byte) (agents.GovernedCall, error) {
+	id, err := routedID(r)
+	if err != nil {
+		return nil, err
+	}
+	field, err := pathOperand(r, "field")
+	if err != nil {
+		return nil, err
+	}
+	return agents.NewUpdateProfileFieldCall(deps.records, agents.UpdateProfileFieldCommand{
+		ID: id, Field: field, Fields: json.RawMessage(body),
+	}), nil
+}
+
+//nolint:ireturn // a decoder's whole product is the erased command-and-resolver pair restCommands is typed by
+func retireCustomFieldCommand(_ agentPolicy, deps restCommandDeps, r *http.Request, _ []byte) (agents.GovernedCall, error) {
+	id, err := routedID(r)
+	if err != nil {
+		return nil, err
+	}
+	return agents.NewRetireCustomFieldCall(deps.records, agents.RetireCustomFieldCommand{ID: id}), nil
+}
+
+//nolint:ireturn // a decoder's whole product is the erased command-and-resolver pair restCommands is typed by
+func updateCustomFieldOptionsCommand(_ agentPolicy, deps restCommandDeps, r *http.Request, body []byte) (agents.GovernedCall, error) {
+	id, err := routedID(r)
+	if err != nil {
+		return nil, err
+	}
+	return agents.NewUpdateCustomFieldOptionsCall(deps.records, agents.UpdateCustomFieldOptionsCommand{
+		ID: id, Fields: json.RawMessage(body),
+	}), nil
+}
+
+//nolint:ireturn // a decoder's whole product is the erased command-and-resolver pair restCommands is typed by
+func setStakeholderCommand(_ agentPolicy, deps restCommandDeps, r *http.Request, body []byte) (agents.GovernedCall, error) {
+	id, err := routedID(r)
+	if err != nil {
+		return nil, err
+	}
+	return agents.NewSetStakeholderCall(deps.records, agents.SetStakeholderCommand{
+		ID: id, Fields: json.RawMessage(body),
+	}), nil
+}
+
+// removeStakeholderCommand decodes DELETE /v1/projects/{id}/stakeholders/{person_id}.
+// person_id fails as 422, not 404: unlike the routed {id}, a malformed
+// person_id names no row this door hides the existence of — it names which
+// edge the caller meant, a shape the caller simply got wrong.
+//
+//nolint:ireturn // a decoder's whole product is the erased command-and-resolver pair restCommands is typed by
+func removeStakeholderCommand(_ agentPolicy, deps restCommandDeps, r *http.Request, _ []byte) (agents.GovernedCall, error) {
+	id, err := routedID(r)
+	if err != nil {
+		return nil, err
+	}
+	personID, perr := ids.Parse(chi.URLParam(r, "person_id"))
+	if perr != nil {
+		return nil, httperr.Validation("person_id", "invalid", "person_id must be a uuid")
+	}
+	return agents.NewRemoveStakeholderCall(deps.records, agents.RemoveStakeholderCommand{ID: id, PersonID: personID}), nil
+}

--- a/backend/internal/compose/agentcommandoperand_test.go
+++ b/backend/internal/compose/agentcommandoperand_test.go
@@ -202,8 +202,8 @@ func TestEachOperandCommandStagesTheRoutedRecord(t *testing.T) {
 	}
 }
 
-// This is the actual behavior change registering these eight in restCommands
-// buys over the route-walk fallback (stagedTargetByRoute): Guards now runs.
+// What resolving these eight through their own commands buys, and it is a
+// refusal rather than a label: Guards runs before anything stages.
 // An organization or project the caller cannot see stages NOTHING — the same
 // proof shape TestAnArchiveOfAnUnseeableRecordStagesNothing gives archive —
 // for one op from each seam-served family (organization, project). The two
@@ -284,28 +284,37 @@ func syntheticOperandRequest(route string, id ids.UUID) *http.Request {
 	return req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
 }
 
-// Every confirm-first update_record operation whose route carries more than
-// the routed {id} — a second path segment or a second path parameter — must
-// decode into a command, or its staged target is still guessed from the
-// route (stagedTargetByRoute) rather than answered by the resolver that
-// speaks for the operation; and the command it decodes into must be the
-// RIGHT one, staging the policy table's own declared record type and the
-// routed id rather than some other operation's.
+// What a registration does not say: that the decoder bound to an operation is
+// the RIGHT one. TestEveryAgentReachableMutatingRouteDecodesIntoACommand
+// (agentcommandcoverage_test.go) proves every one of these routes HAS an entry;
+// a mis-wired entry satisfies it completely, because a swapped decoder still
+// stages something — often something that looks right, since most of this
+// family stages the routed record.
 //
-// Derived from agentPolicies rather than a hand-listed set of eight op
-// names: TestEachOperandCommandStagesTheRoutedRecord above hand-picks its
-// eight and would not notice a NINTH such operation the contract grows, nor
-// would it notice one of the eight silently bound to the wrong decoder in
-// the restCommands table (a swapped entry still "stages something", and
-// stagedTargetByRoute's fallback answers the identical target for any
-// operation this test skips) — this walk catches both, because it actually
-// invokes the bound decoder and checks what it staged against what the
-// policy table declared, rather than assuming the binding is the one its
-// key implies.
+// So this walk invokes the bound decoder against a synthetic request for the
+// route the policy table names, and checks what it staged against what that
+// same table declared: the record type, and the routed id rather than one of
+// the route's OTHER path parameters.
 //
-// The whole-record patch shape (route ends exactly at /{id}) is excluded:
-// that coverage is TestEveryAgentReachablePatchOperationDecodesIntoACommand's,
-// derived the same way for its own twelve.
+// Derived from agentPolicies rather than a hand-listed set of eight op names:
+// TestEachOperandCommandStagesTheRoutedRecord above hand-picks its eight and
+// would not notice a NINTH such operation the contract grows.
+//
+// The whole-record patch shape (route ends exactly at /{id}) is excluded
+// because a synthetic request cannot exercise it: those decoders read a BODY,
+// and a body is per-operation where a path parameter is not. Their equivalent
+// proof is TestAPatchStagesItsRecordAndID and its siblings above.
+// operandBodies carries a minimal contract body for the one route in this
+// family whose operand is not in the path at all: setProjectStakeholder names
+// its person in the BODY, and its decoder refuses a request that names none
+// (agentcommandoperand.go). Every other route here is decodable from the path
+// alone, which is what lets the walk be synthetic.
+//
+// gatekit:fixture the minimal contract body the one body-carrying route in this family declares — expected input, not a waived cost
+var operandBodies = map[string]string{
+	"setProjectStakeholder": `{"person_id":"019ff000-0000-7000-8000-000000000031","role":"champion"}`,
+}
+
 func TestEveryConfirmFirstOperandRouteDecodesIntoTheRightCommand(t *testing.T) {
 	checked := 0
 	for route, pol := range agentPolicies {
@@ -319,15 +328,15 @@ func TestEveryConfirmFirstOperandRouteDecodesIntoTheRightCommand(t *testing.T) {
 
 		decode, described := restCommands[pol.Op]
 		if !described {
-			t.Errorf("%s (%s) is a confirm-first update_record operation whose route carries more than the "+
-				"routed {id}, but decodes into no command — its staged target is still guessed from the route",
-				route, pol.Op)
+			// The completeness gate reports this route by name; here it would
+			// only be a nil decoder to dereference.
 			continue
 		}
 
 		id := ids.NewV7()
 		req := syntheticOperandRequest(route, id)
-		call, err := decode(pol, restCommandDeps{records: seamRecord{}}, req, nil)
+		body := []byte(operandBodies[pol.Op])
+		call, err := decode(pol, restCommandDeps{records: seamRecord{}}, req, body)
 		if err != nil {
 			t.Errorf("%s (%s): decoding a well-formed request answered %v", route, pol.Op, err)
 			continue
@@ -346,8 +355,12 @@ func TestEveryConfirmFirstOperandRouteDecodesIntoTheRightCommand(t *testing.T) {
 				"WRONG decoder, or the decoder read the wrong path parameter as {id}", route, pol.Op, info.TargetID, id)
 		}
 	}
-	if checked != 8 {
-		t.Errorf("the policy table carries %d confirm-first update_record operand operations, want 8 — if the "+
-			"contract gained or lost one, this seam's coverage moved with it", checked)
+	// No literal count: how many such routes exist is the contract's business,
+	// and the completeness gate is what notices one arriving. What this walk
+	// owes is that it ran at all — a filter that selected nothing would report
+	// every decoder correctly wired without invoking one.
+	if checked == 0 {
+		t.Fatal("no confirm-first update_record route carries more than the routed {id} — this walk invoked " +
+			"no decoder, and would pass against every mis-wiring it exists to catch")
 	}
 }

--- a/backend/internal/compose/agentcommandoperand_test.go
+++ b/backend/internal/compose/agentcommandoperand_test.go
@@ -187,3 +187,90 @@ func TestEachOperandCommandStagesTheRoutedRecord(t *testing.T) {
 		})
 	}
 }
+
+// This is the actual behavior change registering these eight in restCommands
+// buys over the route-walk fallback (stagedTargetByRoute): Guards now runs.
+// An organization or project the caller cannot see stages NOTHING — the same
+// proof shape TestAnArchiveOfAnUnseeableRecordStagesNothing gives archive —
+// for one op from each seam-served family (organization, project); the two
+// custom_field ops have no such proof because the seam has never served that
+// type (TestEachOperandCommandStagesTheRoutedRecord above already stages
+// them against `seamRecord{}` without incident, which is what proves Guards
+// does not even attempt a read for them).
+func TestAnOperandCommandOfAnUnseeableRecordStagesNothing(t *testing.T) {
+	staging := &capturingApprovals{}
+	pol := agentPolicy{Op: "confirmOrganizationFact", Access: accessTool, Tool: "update_record", RecordType: recordTypeOrganization}
+	req := operandRequest(http.MethodPost, "/v1/organizations", ids.NewV7().String(), "factKey", "named_customer:acme-inc", nil)
+	rec := httptest.NewRecorder()
+
+	stageRefusal(rec, req, staging, restCommandDeps{records: hiddenRecord{}}, pol, nil)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("confirming a fact on an organization the caller cannot see answered %d, want 404 — the "+
+			"refusal must not tell a caller that a row they may not see exists", rec.Code)
+	}
+	if staging.last.Tool != "" {
+		t.Errorf("an approval was staged for %q against an organization nobody can decide about", staging.last.Tool)
+	}
+}
+
+// The other refusal Guards makes: an organization/project the caller CAN see
+// but whose authority lives in another system of record — readable, and
+// still unstageable, the same shape TestAnArchiveOfAnExternallyHeldRecordStagesNothing
+// gives archive.
+func TestAnOperandCommandOfARecordHeldElsewhereStagesNothing(t *testing.T) {
+	staging := &capturingApprovals{}
+	body := []byte(`{"person_id":"018f2a10-0000-7000-8000-000000000001","role":"champion"}`)
+	pol := agentPolicy{Op: "setProjectStakeholder", Access: accessTool, Tool: "update_record", RecordType: recordTypeProject}
+	req := operandRequest(http.MethodPut, "/v1/projects", ids.NewV7().String(), "", "", body)
+	rec := httptest.NewRecorder()
+
+	stageRefusal(rec, req, staging, restCommandDeps{records: mirroredRecord{}}, pol, body)
+
+	if staging.last.Tool != "" {
+		t.Errorf("an approval was staged for %q against a project whose authority lives elsewhere — nobody "+
+			"could ever release it", staging.last.Tool)
+	}
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Errorf("an externally-held target answered %d, want %d (unsupported_by_sor)", rec.Code, http.StatusUnprocessableEntity)
+	}
+}
+
+// The record type each of these eight resolvers is hardcoded against
+// (organizationSidecarRecordType, customFieldRecordType, projectRecordType
+// — commandsidecar.go, commandaction.go) must agree with the generated
+// policy table, or a contract change could silently point the gate at one
+// record type while the resolver's Guards reads another. Nothing else pins
+// that agreement: the decoders all discard `pol` (its RecordType is not
+// threaded through, unlike archiveCommand/patchCommand's), so this is a
+// fitness function over agentPolicies rather than a point assertion.
+func TestOperandCommandRecordTypesAgreeWithThePolicyTable(t *testing.T) {
+	want := map[string]string{
+		"confirmOrganizationFact":         "organization",
+		"updateOrganizationFact":          "organization",
+		"confirmOrganizationProfileField": "organization",
+		"updateOrganizationProfileField":  "organization",
+		"retireCustomField":               "custom_field",
+		"updateCustomFieldOptions":        "custom_field",
+		"setProjectStakeholder":           "project",
+		"removeProjectStakeholder":        "project",
+	}
+	found := make(map[string]bool, len(want))
+	for _, pol := range agentPolicies {
+		wantType, tracked := want[pol.Op]
+		if !tracked {
+			continue
+		}
+		found[pol.Op] = true
+		if string(pol.RecordType) != wantType {
+			t.Errorf("%s declares RecordType %q in the generated policy table, want %q — its resolver's "+
+				"hardcoded record type would silently disagree with a contract change",
+				pol.Op, pol.RecordType, wantType)
+		}
+	}
+	for op := range want {
+		if !found[op] {
+			t.Errorf("%s no longer appears in the generated policy table", op)
+		}
+	}
+}

--- a/backend/internal/compose/agentcommandoperand_test.go
+++ b/backend/internal/compose/agentcommandoperand_test.go
@@ -15,6 +15,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/go-chi/chi/v5"
@@ -69,47 +70,60 @@ func TestAMalformedOperandRouteIDAnswersNotFound(t *testing.T) {
 
 // A missing second path operand — a request built without the segment the
 // router would otherwise have bound — answers 422 naming it, not a panic on
-// an empty FactKey/Field downstream.
+// an empty FactKey/Field downstream. removeProjectStakeholder's person_id is
+// the one operand composed from pathOperand + ids.Parse (agentcommandoperand.go)
+// rather than pathOperand alone, so it is included here too: a missing one
+// must still answer "missing" through that composition, not fall through to
+// ids.Parse("") and answer the malformed-shape code instead.
 func TestAMissingSecondPathOperandAnswers422(t *testing.T) {
 	id := ids.NewV7().String()
 	cases := []struct {
 		name      string
+		method    string
+		path      string
 		decode    func(pol agentPolicy, deps restCommandDeps, r *http.Request, body []byte) (agents.GovernedCall, error)
 		body      []byte
 		wantField string
 	}{
-		{"confirmOrganizationFact", confirmFactCommand, nil, "factKey"},
-		{"updateOrganizationFact", updateFactCommand, []byte(`{"value":"v"}`), "factKey"},
-		{"confirmOrganizationProfileField", confirmProfileFieldCommand, nil, "field"},
-		{"updateOrganizationProfileField", updateProfileFieldCommand, []byte(`{"value":"v"}`), "field"},
+		{"confirmOrganizationFact", http.MethodPost, "/v1/organizations", confirmFactCommand, nil, "factKey"},
+		{"updateOrganizationFact", http.MethodPatch, "/v1/organizations", updateFactCommand, nil, "factKey"},
+		{"confirmOrganizationProfileField", http.MethodPost, "/v1/organizations", confirmProfileFieldCommand, nil, "field"},
+		{"updateOrganizationProfileField", http.MethodPatch, "/v1/organizations", updateProfileFieldCommand, nil, "field"},
+		{"removeProjectStakeholder", http.MethodDelete, "/v1/projects", removeStakeholderCommand, nil, "person_id"},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			// extraParam left empty: the route matched (a valid {id}), but the
 			// second segment the router would bind was never set — the shape a
 			// routing bug, not a malformed request, would produce.
-			req := operandRequest(http.MethodPost, "/v1/organizations", id, "", "", c.body)
+			req := operandRequest(c.method, c.path, id, "", "", c.body)
 			_, err := c.decode(agentPolicy{Op: c.name}, restCommandDeps{records: seamRecord{}}, req, c.body)
 			var detailed *httperr.DetailedError
 			if !errors.As(err, &detailed) || detailed.Status != http.StatusUnprocessableEntity {
 				t.Fatalf("a missing %s answered %v, want a 422 naming it", c.wantField, err)
 			}
-			if len(detailed.Fields) != 1 || detailed.Fields[0].Field != c.wantField {
-				t.Errorf("the 422 named field %+v, want %q", detailed.Fields, c.wantField)
+			if len(detailed.Fields) != 1 || detailed.Fields[0].Field != c.wantField || detailed.Fields[0].Code != "missing" {
+				t.Errorf("the 422 named %+v, want field %q code \"missing\"", detailed.Fields, c.wantField)
 			}
 		})
 	}
 }
 
-// A malformed person_id on removeProjectStakeholder is a 422, not the 404
-// the routed {id} gets: it names WHICH edge, not whether the project exists,
-// so its shape being wrong is the caller's mistake, never an existence leak.
+// A malformed (non-empty) person_id on removeProjectStakeholder is also a
+// 422, code "invalid" rather than "missing" — the other half of the
+// pathOperand + ids.Parse composition the test above proves the missing
+// case for. Neither is the 404 the routed {id} gets: person_id names WHICH
+// edge, not whether the project exists, so its shape being wrong is the
+// caller's mistake, never an existence leak.
 func TestARemoveStakeholderMalformedPersonIDAnswers422(t *testing.T) {
 	req := operandRequest(http.MethodDelete, "/v1/projects", ids.NewV7().String(), "person_id", "not-a-uuid", nil)
 	_, err := removeStakeholderCommand(agentPolicy{Op: "removeProjectStakeholder"}, restCommandDeps{records: seamRecord{}}, req, nil)
 	var detailed *httperr.DetailedError
 	if !errors.As(err, &detailed) || detailed.Status != http.StatusUnprocessableEntity {
 		t.Fatalf("a malformed person_id answered %v, want a 422", err)
+	}
+	if len(detailed.Fields) != 1 || detailed.Fields[0].Field != "person_id" || detailed.Fields[0].Code != "invalid" {
+		t.Errorf("the 422 named %+v, want field \"person_id\" code \"invalid\"", detailed.Fields)
 	}
 }
 
@@ -192,11 +206,15 @@ func TestEachOperandCommandStagesTheRoutedRecord(t *testing.T) {
 // buys over the route-walk fallback (stagedTargetByRoute): Guards now runs.
 // An organization or project the caller cannot see stages NOTHING — the same
 // proof shape TestAnArchiveOfAnUnseeableRecordStagesNothing gives archive —
-// for one op from each seam-served family (organization, project); the two
-// custom_field ops have no such proof because the seam has never served that
-// type (TestEachOperandCommandStagesTheRoutedRecord above already stages
-// them against `seamRecord{}` without incident, which is what proves Guards
-// does not even attempt a read for them).
+// for one op from each seam-served family (organization, project). The two
+// custom_field ops have no such proof: the seam has never served that type,
+// so there is no read for Guards to skip. That they never attempt one is
+// TestCustomFieldCommandsStageAndAdmitOutsideTheRecordSeam's own claim
+// (modules/agents/commandaction_test.go), proven there against
+// unreadableProvider{} — a provider that fails every read, so a resolver
+// that consulted it anyway would fail that test rather than pass here:
+// TestEachOperandCommandStagesTheRoutedRecord's use of `seamRecord{}` (every
+// read succeeds) cannot tell "never read" apart from "read and got lucky".
 func TestAnOperandCommandOfAnUnseeableRecordStagesNothing(t *testing.T) {
 	staging := &capturingApprovals{}
 	pol := agentPolicy{Op: "confirmOrganizationFact", Access: accessTool, Tool: "update_record", RecordType: recordTypeOrganization}
@@ -236,41 +254,100 @@ func TestAnOperandCommandOfARecordHeldElsewhereStagesNothing(t *testing.T) {
 	}
 }
 
-// The record type each of these eight resolvers is hardcoded against
-// (organizationSidecarRecordType, customFieldRecordType, projectRecordType
-// — commandsidecar.go, commandaction.go) must agree with the generated
-// policy table, or a contract change could silently point the gate at one
-// record type while the resolver's Guards reads another. Nothing else pins
-// that agreement: the decoders all discard `pol` (its RecordType is not
-// threaded through, unlike archiveCommand/patchCommand's), so this is a
-// fitness function over agentPolicies rather than a point assertion.
-func TestOperandCommandRecordTypesAgreeWithThePolicyTable(t *testing.T) {
-	want := map[string]string{
-		"confirmOrganizationFact":         "organization",
-		"updateOrganizationFact":          "organization",
-		"confirmOrganizationProfileField": "organization",
-		"updateOrganizationProfileField":  "organization",
-		"retireCustomField":               "custom_field",
-		"updateCustomFieldOptions":        "custom_field",
-		"setProjectStakeholder":           "project",
-		"removeProjectStakeholder":        "project",
-	}
-	found := make(map[string]bool, len(want))
-	for _, pol := range agentPolicies {
-		wantType, tracked := want[pol.Op]
-		if !tracked {
+// syntheticOperandRequest builds a well-formed request for route (an
+// agentPolicies key, "METHOD /path/{param}/…"), binding {id} to id and every
+// OTHER path parameter to a fresh, distinct uuid — enough for any of this
+// family's decoders to succeed without this test needing to know which
+// parameter names a given route carries (factKey and field accept any
+// non-empty string; a uuid satisfies that as well as anything, and is what
+// person_id's own ids.Parse requires).
+func syntheticOperandRequest(route string, id ids.UUID) *http.Request {
+	method, template, _ := strings.Cut(route, " ")
+	segments := strings.Split(strings.TrimPrefix(template, "/"), "/")
+	rctx := chi.NewRouteContext()
+	built := make([]string, 0, len(segments))
+	for _, seg := range segments {
+		name, isParam := strings.CutPrefix(seg, "{")
+		if !isParam {
+			built = append(built, seg)
 			continue
 		}
-		found[pol.Op] = true
-		if string(pol.RecordType) != wantType {
-			t.Errorf("%s declares RecordType %q in the generated policy table, want %q — its resolver's "+
-				"hardcoded record type would silently disagree with a contract change",
-				pol.Op, pol.RecordType, wantType)
+		name = strings.TrimSuffix(name, "}")
+		val := ids.NewV7().String()
+		if name == "id" {
+			val = id.String()
+		}
+		rctx.URLParams.Add(name, val)
+		built = append(built, val)
+	}
+	req := httptest.NewRequest(method, "/"+strings.Join(built, "/"), nil)
+	return req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+}
+
+// Every confirm-first update_record operation whose route carries more than
+// the routed {id} — a second path segment or a second path parameter — must
+// decode into a command, or its staged target is still guessed from the
+// route (stagedTargetByRoute) rather than answered by the resolver that
+// speaks for the operation; and the command it decodes into must be the
+// RIGHT one, staging the policy table's own declared record type and the
+// routed id rather than some other operation's.
+//
+// Derived from agentPolicies rather than a hand-listed set of eight op
+// names: TestEachOperandCommandStagesTheRoutedRecord above hand-picks its
+// eight and would not notice a NINTH such operation the contract grows, nor
+// would it notice one of the eight silently bound to the wrong decoder in
+// the restCommands table (a swapped entry still "stages something", and
+// stagedTargetByRoute's fallback answers the identical target for any
+// operation this test skips) — this walk catches both, because it actually
+// invokes the bound decoder and checks what it staged against what the
+// policy table declared, rather than assuming the binding is the one its
+// key implies.
+//
+// The whole-record patch shape (route ends exactly at /{id}) is excluded:
+// that coverage is TestEveryAgentReachablePatchOperationDecodesIntoACommand's,
+// derived the same way for its own twelve.
+func TestEveryConfirmFirstOperandRouteDecodesIntoTheRightCommand(t *testing.T) {
+	checked := 0
+	for route, pol := range agentPolicies {
+		if pol.Access != accessTool || pol.Tool != "update_record" || pol.Tier != tierConfirmationRequired {
+			continue
+		}
+		if strings.HasSuffix(route, "/{id}") {
+			continue
+		}
+		checked++
+
+		decode, described := restCommands[pol.Op]
+		if !described {
+			t.Errorf("%s (%s) is a confirm-first update_record operation whose route carries more than the "+
+				"routed {id}, but decodes into no command — its staged target is still guessed from the route",
+				route, pol.Op)
+			continue
+		}
+
+		id := ids.NewV7()
+		req := syntheticOperandRequest(route, id)
+		call, err := decode(pol, restCommandDeps{records: seamRecord{}}, req, nil)
+		if err != nil {
+			t.Errorf("%s (%s): decoding a well-formed request answered %v", route, pol.Op, err)
+			continue
+		}
+		info, err := call.Subject(context.Background())
+		if err != nil {
+			t.Errorf("%s (%s): naming the subject answered %v", route, pol.Op, err)
+			continue
+		}
+		if info.TargetType != string(pol.RecordType) {
+			t.Errorf("%s (%s) stages target type %q, want %q — the policy table's own declared record type",
+				route, pol.Op, info.TargetType, pol.RecordType)
+		}
+		if info.TargetID != id {
+			t.Errorf("%s (%s) stages target id %s, want %s — restCommands binds this operationId to the "+
+				"WRONG decoder, or the decoder read the wrong path parameter as {id}", route, pol.Op, info.TargetID, id)
 		}
 	}
-	for op := range want {
-		if !found[op] {
-			t.Errorf("%s no longer appears in the generated policy table", op)
-		}
+	if checked != 8 {
+		t.Errorf("the policy table carries %d confirm-first update_record operand operations, want 8 — if the "+
+			"contract gained or lost one, this seam's coverage moved with it", checked)
 	}
 }

--- a/backend/internal/compose/agentcommandoperand_test.go
+++ b/backend/internal/compose/agentcommandoperand_test.go
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The REST door's half of the eight bespoke commands (agentcommandoperand.go):
+// the routed {id}'s existence-hiding 404, the second path operand's 422, and
+// the staged target each decoder resolves to — the same proof shape
+// agentcommand_test.go gives archive/patch, for a family whose operand lives
+// in a SECOND path parameter rather than in the body.
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/gradionhq/margince/backend/internal/modules/agents"
+	"github.com/gradionhq/margince/backend/internal/platform/httperr"
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// operandRequest builds a request for a route carrying the router's own {id}
+// (as the raw path segment routeID — a malformed one is what proves the 404)
+// plus an optional second path parameter the chi router would have bound —
+// factKey, field, or person_id.
+func operandRequest(method, path, routeID, extraParam, extraValue string, body []byte) *http.Request {
+	req := httptest.NewRequest(method, path+"/"+routeID, bytes.NewReader(body))
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", routeID)
+	if extraParam != "" {
+		rctx.URLParams.Add(extraParam, extraValue)
+	}
+	return req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+}
+
+// A malformed routed {id} answers 404 for every one of the eight, the same
+// existence-hiding answer archiveCommand/patchCommand already give — proven
+// once per decoder rather than assuming the shared routedID helper carries
+// the property for free.
+func TestAMalformedOperandRouteIDAnswersNotFound(t *testing.T) {
+	cases := []struct {
+		name   string
+		decode func(pol agentPolicy, deps restCommandDeps, r *http.Request, body []byte) (agents.GovernedCall, error)
+		req    *http.Request
+	}{
+		{"confirmOrganizationFact", confirmFactCommand, operandRequest(http.MethodPost, "/v1/organizations", "not-a-uuid", "factKey", "k", nil)},
+		{"updateOrganizationFact", updateFactCommand, operandRequest(http.MethodPatch, "/v1/organizations", "not-a-uuid", "factKey", "k", []byte(`{"value":"v"}`))},
+		{"confirmOrganizationProfileField", confirmProfileFieldCommand, operandRequest(http.MethodPost, "/v1/organizations", "not-a-uuid", "field", "icp", nil)},
+		{"updateOrganizationProfileField", updateProfileFieldCommand, operandRequest(http.MethodPatch, "/v1/organizations", "not-a-uuid", "field", "icp", []byte(`{"value":"v"}`))},
+		{"retireCustomField", retireCustomFieldCommand, operandRequest(http.MethodPost, "/v1/custom-fields", "not-a-uuid", "", "", nil)},
+		{"updateCustomFieldOptions", updateCustomFieldOptionsCommand, operandRequest(http.MethodPatch, "/v1/custom-fields", "not-a-uuid", "", "", []byte(`{"options":["a"]}`))},
+		{"setProjectStakeholder", setStakeholderCommand, operandRequest(http.MethodPut, "/v1/projects", "not-a-uuid", "", "", []byte(`{"person_id":"018f2a10-0000-7000-8000-000000000001","role":"champion"}`))},
+		{"removeProjectStakeholder", removeStakeholderCommand, operandRequest(http.MethodDelete, "/v1/projects", "not-a-uuid", "person_id", ids.NewV7().String(), nil)},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if _, err := c.decode(agentPolicy{Op: c.name}, restCommandDeps{records: seamRecord{}}, c.req, nil); !errors.Is(err, apperrors.ErrNotFound) {
+				t.Errorf("decoding a malformed id answered %v, want the not-found sentinel", err)
+			}
+		})
+	}
+}
+
+// A missing second path operand — a request built without the segment the
+// router would otherwise have bound — answers 422 naming it, not a panic on
+// an empty FactKey/Field downstream.
+func TestAMissingSecondPathOperandAnswers422(t *testing.T) {
+	id := ids.NewV7().String()
+	cases := []struct {
+		name      string
+		decode    func(pol agentPolicy, deps restCommandDeps, r *http.Request, body []byte) (agents.GovernedCall, error)
+		body      []byte
+		wantField string
+	}{
+		{"confirmOrganizationFact", confirmFactCommand, nil, "factKey"},
+		{"updateOrganizationFact", updateFactCommand, []byte(`{"value":"v"}`), "factKey"},
+		{"confirmOrganizationProfileField", confirmProfileFieldCommand, nil, "field"},
+		{"updateOrganizationProfileField", updateProfileFieldCommand, []byte(`{"value":"v"}`), "field"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			// extraParam left empty: the route matched (a valid {id}), but the
+			// second segment the router would bind was never set — the shape a
+			// routing bug, not a malformed request, would produce.
+			req := operandRequest(http.MethodPost, "/v1/organizations", id, "", "", c.body)
+			_, err := c.decode(agentPolicy{Op: c.name}, restCommandDeps{records: seamRecord{}}, req, c.body)
+			var detailed *httperr.DetailedError
+			if !errors.As(err, &detailed) || detailed.Status != http.StatusUnprocessableEntity {
+				t.Fatalf("a missing %s answered %v, want a 422 naming it", c.wantField, err)
+			}
+			if len(detailed.Fields) != 1 || detailed.Fields[0].Field != c.wantField {
+				t.Errorf("the 422 named field %+v, want %q", detailed.Fields, c.wantField)
+			}
+		})
+	}
+}
+
+// A malformed person_id on removeProjectStakeholder is a 422, not the 404
+// the routed {id} gets: it names WHICH edge, not whether the project exists,
+// so its shape being wrong is the caller's mistake, never an existence leak.
+func TestARemoveStakeholderMalformedPersonIDAnswers422(t *testing.T) {
+	req := operandRequest(http.MethodDelete, "/v1/projects", ids.NewV7().String(), "person_id", "not-a-uuid", nil)
+	_, err := removeStakeholderCommand(agentPolicy{Op: "removeProjectStakeholder"}, restCommandDeps{records: seamRecord{}}, req, nil)
+	var detailed *httperr.DetailedError
+	if !errors.As(err, &detailed) || detailed.Status != http.StatusUnprocessableEntity {
+		t.Fatalf("a malformed person_id answered %v, want a 422", err)
+	}
+}
+
+// Each of the eight stages against the routed record it names — proven
+// through stageRefusal end to end, the same shape TestAPatchStagesItsRecordAndID
+// proves for a whole-record patch.
+func TestEachOperandCommandStagesTheRoutedRecord(t *testing.T) {
+	orgID, projectID, cfID := ids.NewV7(), ids.NewV7(), ids.NewV7()
+	cases := []struct {
+		name           string
+		pol            agentPolicy
+		req            *http.Request
+		body           []byte
+		wantTargetType string
+		wantTargetID   ids.UUID
+	}{
+		{
+			"confirmOrganizationFact",
+			agentPolicy{Op: "confirmOrganizationFact", Access: accessTool, Tool: "update_record", RecordType: recordTypeOrganization},
+			operandRequest(http.MethodPost, "/v1/organizations", orgID.String(), "factKey", "named_customer:acme-inc", nil), nil,
+			"organization", orgID,
+		},
+		{
+			"updateOrganizationFact",
+			agentPolicy{Op: "updateOrganizationFact", Access: accessTool, Tool: "update_record", RecordType: recordTypeOrganization},
+			operandRequest(http.MethodPatch, "/v1/organizations", orgID.String(), "factKey", "named_customer:acme-inc", []byte(`{"value":"Acme Inc"}`)),
+			[]byte(`{"value":"Acme Inc"}`), "organization", orgID,
+		},
+		{
+			"confirmOrganizationProfileField",
+			agentPolicy{Op: "confirmOrganizationProfileField", Access: accessTool, Tool: "update_record", RecordType: recordTypeOrganization},
+			operandRequest(http.MethodPost, "/v1/organizations", orgID.String(), "field", "icp", nil), nil,
+			"organization", orgID,
+		},
+		{
+			"updateOrganizationProfileField",
+			agentPolicy{Op: "updateOrganizationProfileField", Access: accessTool, Tool: "update_record", RecordType: recordTypeOrganization},
+			operandRequest(http.MethodPatch, "/v1/organizations", orgID.String(), "field", "icp", []byte(`{"value":"Payments infra"}`)),
+			[]byte(`{"value":"Payments infra"}`), "organization", orgID,
+		},
+		{
+			"retireCustomField",
+			agentPolicy{Op: "retireCustomField", Access: accessTool, Tool: "update_record", RecordType: recordTypeCustomField},
+			operandRequest(http.MethodPost, "/v1/custom-fields", cfID.String(), "", "", nil), nil,
+			"custom_field", cfID,
+		},
+		{
+			"updateCustomFieldOptions",
+			agentPolicy{Op: "updateCustomFieldOptions", Access: accessTool, Tool: "update_record", RecordType: recordTypeCustomField},
+			operandRequest(http.MethodPatch, "/v1/custom-fields", cfID.String(), "", "", []byte(`{"options":["a","b"]}`)),
+			[]byte(`{"options":["a","b"]}`), "custom_field", cfID,
+		},
+		{
+			"setProjectStakeholder",
+			agentPolicy{Op: "setProjectStakeholder", Access: accessTool, Tool: "update_record", RecordType: recordTypeProject},
+			operandRequest(http.MethodPut, "/v1/projects", projectID.String(), "", "", []byte(`{"person_id":"018f2a10-0000-7000-8000-000000000001","role":"champion"}`)),
+			[]byte(`{"person_id":"018f2a10-0000-7000-8000-000000000001","role":"champion"}`), "project", projectID,
+		},
+		{
+			"removeProjectStakeholder",
+			agentPolicy{Op: "removeProjectStakeholder", Access: accessTool, Tool: "update_record", RecordType: recordTypeProject},
+			operandRequest(http.MethodDelete, "/v1/projects", projectID.String(), "person_id", ids.NewV7().String(), nil), nil,
+			"project", projectID,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			staging := &capturingApprovals{}
+			stageRefusal(httptest.NewRecorder(), c.req, staging, restCommandDeps{records: seamRecord{}}, c.pol, c.body)
+
+			if staging.last.TargetType != c.wantTargetType || staging.last.TargetID != c.wantTargetID {
+				t.Fatalf("staged target = (%s,%s), want (%s,%s)",
+					staging.last.TargetType, staging.last.TargetID, c.wantTargetType, c.wantTargetID)
+			}
+		})
+	}
+}

--- a/backend/internal/compose/agentcommandrecord.go
+++ b/backend/internal/compose/agentcommandrecord.go
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The REST door's half of the two commands one tool serves through TWO
+// contract operations (gradionhq/margince-poc-v1#928 task 7): merge_records is
+// mergePerson and mergeOrganization, and enrich is scrapeCompany and
+// deepReadCompany.
+//
+// Both are where this door was previously answering the WRONG question, and in
+// two different ways. A merge's route walk read the routed {id} as the staged
+// target, but that id is the record merged FROM — the one about to be archived
+// — while the approval belongs on the survivor the body names. And the two
+// enrich routes are one verb at two depths, distinguishable by nothing on the
+// wire except which path was taken, so a target derived from the route could
+// never say which of the two a human was releasing.
+
+import (
+	"net/http"
+
+	"github.com/gradionhq/margince/backend/internal/modules/agents"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// mergeCommand decodes POST /v1/people/{id}/merge and
+// POST /v1/organizations/{id}/merge.
+//
+// The routed {id} is the SOURCE and the body's `target_id` is the survivor:
+// crm.yaml says so ("The surviving person (B). This row (A) is archived") and
+// the handler does the same (people.Handlers.MergePerson passes the path id as
+// the source). So this is where the two doors stop disagreeing: the tool door
+// has always pinned the survivor, and this door pinned whichever row the route
+// happened to name.
+//
+// The record type comes off the route's own policy entry rather than being
+// written here a second time — the entry is generated from the contract's
+// x-mcp-tool annotation, so a type spelled again in this file could disagree
+// with the one the gate admitted against.
+//
+//nolint:ireturn // a decoder's whole product is the erased command-and-resolver pair restCommands is typed by
+func mergeCommand(pol agentPolicy, deps restCommandDeps, r *http.Request, body []byte) (agents.GovernedCall, error) {
+	sourceID, err := routedID(r)
+	if err != nil {
+		return nil, err
+	}
+	in, err := commandBody[struct {
+		TargetID ids.UUID `json:"target_id"`
+	}](body)
+	if err != nil {
+		return nil, err
+	}
+	return agents.NewMergeCall(deps.records, agents.MergeCommand{
+		RecordType: string(pol.RecordType),
+		SourceID:   sourceID,
+		TargetID:   in.TargetID,
+	}), nil
+}
+
+// scrapeCompanyCommand decodes POST /v1/organizations/{id}/enrich — the
+// one-page read.
+//
+//nolint:ireturn // a decoder's whole product is the erased command-and-resolver pair restCommands is typed by
+func scrapeCompanyCommand(_ agentPolicy, deps restCommandDeps, r *http.Request, body []byte) (agents.GovernedCall, error) {
+	return enrichCall(deps, r, body, agents.EnrichDepthPage)
+}
+
+// deepReadCompanyCommand decodes POST /v1/organizations/{id}/deep-read — the
+// whole-site crawl.
+//
+//nolint:ireturn // a decoder's whole product is the erased command-and-resolver pair restCommands is typed by
+func deepReadCompanyCommand(_ agentPolicy, deps restCommandDeps, r *http.Request, body []byte) (agents.GovernedCall, error) {
+	return enrichCall(deps, r, body, agents.EnrichDepthSite)
+}
+
+// enrichCall builds one enrich command at the depth its CALLER names.
+//
+// The depth is a parameter of this function, supplied by the two decoders
+// above as a typed constant. It is never read from the request: there is no
+// `depth` on either route's wire form to read it from, and a decoder that
+// synthesized the string would be free to synthesize the wrong one — a
+// scrapeCompany described to an approving human as a whole-site crawl, which
+// no schema check could catch because "site" is a perfectly valid value.
+// Passing the value structurally is what makes that unreachable rather than
+// merely unlikely.
+//
+// The body is optional on both routes (crm.yaml's EnrichCompanyRequest: "With
+// no body the org's own domain is read"), which commandBody answers with an
+// empty override rather than a refusal.
+//
+//nolint:ireturn // a decoder's whole product is the erased command-and-resolver pair restCommands is typed by
+func enrichCall(deps restCommandDeps, r *http.Request, body []byte, depth agents.EnrichDepth) (agents.GovernedCall, error) {
+	id, err := routedID(r)
+	if err != nil {
+		return nil, err
+	}
+	in, err := commandBody[struct {
+		URL string `json:"url"`
+	}](body)
+	if err != nil {
+		return nil, err
+	}
+	return agents.NewEnrichCall(deps.records, agents.EnrichCommand{
+		OrganizationID: id,
+		URL:            in.URL,
+		Depth:          depth,
+	}), nil
+}

--- a/backend/internal/compose/agentcommandsend.go
+++ b/backend/internal/compose/agentcommandsend.go
@@ -33,15 +33,24 @@ import (
 //
 // An ABSENT body answers the zero value rather than an error. The two enrich
 // routes declare their body optional in crm.yaml ("With no body the org's own
-// domain is read") and are the pair that actually reaches this branch; for
-// every other route a missing required field is the HANDLER's 422 to write.
-// This decoder's job is to say what an approval would bind to, and a governance
-// layer that refused the request first would answer one mistake with two
-// different machine codes depending on which credential the caller presented.
+// domain is read") and are the pair that reaches this branch legitimately;
+// everywhere else it hands the resolver a command with empty operands and lets
+// the resolver decide.
 //
-// Unreadable JSON is different, and is refused with the code httperr.Decode
-// answers on the session half of the same route — the rule
-// advanceDealTierInput (agentgate.go) already follows for the same reason.
+// That division is the point, and it is not "the gate never refuses a bad
+// request" — several resolvers here refuse an absent operand outright, an
+// empty `to` among them. It is that a DECODER has no standing to. Guards
+// refuses what the EXECUTOR would refuse anyway, deliberately and with the
+// executor's own sentence, so that a human's one-shot approval is not spent
+// discovering it. A decoder erroring on a missing field would instead invent a
+// refusal nobody else makes, for a field no resolver asked about, on the agent
+// door only — and the same mistake would then carry one machine code for a
+// passport and the handler's own for a session.
+//
+// Unreadable JSON is different: no resolver can be handed operands that were
+// never legible. It is refused with the code httperr.Decode answers on the
+// session half of the same route — the rule advanceDealTierInput
+// (agentgate.go) already follows for the same reason.
 func commandBody[T any](body []byte) (T, error) {
 	var into T
 	if len(bytes.TrimSpace(body)) == 0 {

--- a/backend/internal/compose/agentcommandsend.go
+++ b/backend/internal/compose/agentcommandsend.go
@@ -49,8 +49,8 @@ import (
 //
 // Unreadable JSON is different: no resolver can be handed operands that were
 // never legible. It is refused with the code httperr.Decode answers on the
-// session half of the same route — the rule advanceDealTierInput
-// (agentgate.go) already follows for the same reason.
+// session half of the same route — the rule advanceDealCommand
+// (agentcommandlifecycle.go) already follows for the same reason.
 func commandBody[T any](body []byte) (T, error) {
 	var into T
 	if len(bytes.TrimSpace(body)) == 0 {

--- a/backend/internal/compose/agentcommandsend.go
+++ b/backend/internal/compose/agentcommandsend.go
@@ -31,12 +31,13 @@ import (
 
 // commandBody decodes the buffered body into one decoder's view of it.
 //
-// An ABSENT body answers the zero value rather than an error. Three of this
-// task's routes declare their body optional in crm.yaml, and for the rest a
-// missing required field is the HANDLER's 422 to write: this decoder's job is
-// to say what an approval would bind to, and a governance layer that refused
-// the request first would answer one mistake with two different machine codes
-// depending on which credential the caller presented.
+// An ABSENT body answers the zero value rather than an error. The two enrich
+// routes declare their body optional in crm.yaml ("With no body the org's own
+// domain is read") and are the pair that actually reaches this branch; for
+// every other route a missing required field is the HANDLER's 422 to write.
+// This decoder's job is to say what an approval would bind to, and a governance
+// layer that refused the request first would answer one mistake with two
+// different machine codes depending on which credential the caller presented.
 //
 // Unreadable JSON is different, and is refused with the code httperr.Decode
 // answers on the session half of the same route — the rule

--- a/backend/internal/compose/agentcommandsend.go
+++ b/backend/internal/compose/agentcommandsend.go
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The REST door's half of the four outbound commands
+// (gradionhq/margince-poc-v1#928 task 7): a mail reply, a channel reply, an
+// account-started send and a booking. Unlike every family before them, each of
+// these has a real tool-door twin resolving the SAME command — so a refusal
+// the tool made and this door skipped (an empty `to`, an empty `links`, a link
+// over the cap, a link held in another system of record, a booking whose end
+// precedes its start, an anchor that is not a channel conversation) is now one
+// refusal both doors reach.
+//
+// These are also the first decoders that read the request BODY for operands
+// rather than only for a create's fields: a send names its addressees there,
+// and a booking names its slot and its records. body is the same buffered copy
+// stageRefusal already hashed into canonicalRESTCall — a stream has one honest
+// reading, and the gate has already taken it.
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/gradionhq/margince/backend/internal/modules/agents"
+	"github.com/gradionhq/margince/backend/internal/platform/httperr"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// commandBody decodes the buffered body into one decoder's view of it.
+//
+// An ABSENT body answers the zero value rather than an error. Three of this
+// task's routes declare their body optional in crm.yaml, and for the rest a
+// missing required field is the HANDLER's 422 to write: this decoder's job is
+// to say what an approval would bind to, and a governance layer that refused
+// the request first would answer one mistake with two different machine codes
+// depending on which credential the caller presented.
+//
+// Unreadable JSON is different, and is refused with the code httperr.Decode
+// answers on the session half of the same route — the rule
+// advanceDealTierInput (agentgate.go) already follows for the same reason.
+func commandBody[T any](body []byte) (T, error) {
+	var into T
+	if len(bytes.TrimSpace(body)) == 0 {
+		return into, nil
+	}
+	if err := json.Unmarshal(body, &into); err != nil {
+		return into, httperr.Validation("body", "malformed_json", "the request body is not readable JSON")
+	}
+	return into, nil
+}
+
+// sendEmailCommand decodes POST /v1/activities/{id}/send-email. The routed
+// {id} is the ANCHOR — the thread being replied to — and the addressees come
+// from the body, which is where crm.yaml's SendEmailRequest puts them.
+//
+//nolint:ireturn // a decoder's whole product is the erased command-and-resolver pair restCommands is typed by
+func sendEmailCommand(_ agentPolicy, deps restCommandDeps, r *http.Request, body []byte) (agents.GovernedCall, error) {
+	id, err := routedID(r)
+	if err != nil {
+		return nil, err
+	}
+	in, err := commandBody[struct {
+		To      []string `json:"to"`
+		Cc      []string `json:"cc"`
+		Subject string   `json:"subject"`
+	}](body)
+	if err != nil {
+		return nil, err
+	}
+	return agents.NewSendEmailCall(deps.records, agents.SendEmailCommand{
+		ActivityID: id,
+		To:         in.To,
+		Cc:         in.Cc,
+		Subject:    in.Subject,
+	}), nil
+}
+
+// sendMessageCommand decodes POST /v1/activities/{id}/send-message. The body
+// carries the message text and nothing else the resolver reads: a channel
+// reply names no addressee, because the conversation does.
+//
+//nolint:ireturn // a decoder's whole product is the erased command-and-resolver pair restCommands is typed by
+func sendMessageCommand(_ agentPolicy, deps restCommandDeps, r *http.Request, body []byte) (agents.GovernedCall, error) {
+	id, err := routedID(r)
+	if err != nil {
+		return nil, err
+	}
+	in, err := commandBody[struct {
+		Body string `json:"body"`
+	}](body)
+	if err != nil {
+		return nil, err
+	}
+	return agents.NewSendMessageCall(deps.records, deps.channels, agents.SendMessageCommand{
+		ActivityID: id,
+		Body:       in.Body,
+	}), nil
+}
+
+// sendAccountEmailCommand decodes POST /v1/emails. There is no routed id to
+// read: this send starts a conversation rather than answering one, so the
+// records it belongs to are NAMED in the body — which is exactly why the route
+// walk this replaces could offer no target for it at all.
+//
+//nolint:ireturn // a decoder's whole product is the erased command-and-resolver pair restCommands is typed by
+func sendAccountEmailCommand(_ agentPolicy, deps restCommandDeps, _ *http.Request, body []byte) (agents.GovernedCall, error) {
+	in, err := commandBody[struct {
+		To      []string            `json:"to"`
+		Cc      []string            `json:"cc"`
+		Subject string              `json:"subject"`
+		Links   []agents.RecordLink `json:"links"`
+	}](body)
+	if err != nil {
+		return nil, err
+	}
+	return agents.NewSendAccountEmailCall(deps.records, agents.SendAccountEmailCommand{
+		To:      in.To,
+		Cc:      in.Cc,
+		Subject: in.Subject,
+		Links:   in.Links,
+	}), nil
+}
+
+// bookMeetingCommand decodes POST /v1/bookings. It has no routed id either —
+// a booking anchors on no existing row — and every operand the resolver reads
+// is in the body.
+//
+//nolint:ireturn // a decoder's whole product is the erased command-and-resolver pair restCommands is typed by
+func bookMeetingCommand(_ agentPolicy, deps restCommandDeps, _ *http.Request, body []byte) (agents.GovernedCall, error) {
+	in, err := commandBody[struct {
+		HostUserID *ids.UUID           `json:"host_user_id"`
+		Start      time.Time           `json:"start"`
+		End        time.Time           `json:"end"`
+		Subject    string              `json:"subject"`
+		Links      []agents.RecordLink `json:"links"`
+	}](body)
+	if err != nil {
+		return nil, err
+	}
+	return agents.NewBookMeetingCall(deps.records, agents.BookMeetingCommand{
+		HostUserID: in.HostUserID,
+		Start:      in.Start,
+		End:        in.End,
+		Subject:    in.Subject,
+		Links:      in.Links,
+	}), nil
+}

--- a/backend/internal/compose/agentcommandsingle_test.go
+++ b/backend/internal/compose/agentcommandsingle_test.go
@@ -68,15 +68,18 @@ var contractBodies = map[string]string{
 	"relinkActivity":      `{"entity_type":"deal","entity_id":"019ff000-0000-7000-8000-000000000006"}`,
 }
 
-// Every route these fourteen verbs reach must decode into a command, and the
-// decoder bound to it must accept the body its own route declares — a decoder
-// that errored on the shape crm.yaml specifies would answer the whole
-// operation as a refusal the moment a tier floor tightened it.
+// What a registration does not say: that the decoder bound to a route can
+// actually READ the request that route produces. The completeness gate
+// (agentcommandcoverage_test.go) proves every one of these operations has an
+// entry; an entry whose decoder rejects the body crm.yaml declares satisfies it
+// completely, and answers the whole operation as a refusal the moment a tier
+// floor tightens it.
 //
-// Derived from agentPolicies rather than from a list of sixteen operationIds
-// someone remembered, so a route added upstream for any of these verbs fails
-// here rather than quietly falling back to the route walk.
-func TestEverySinglePurposeToolRouteDecodesIntoACommand(t *testing.T) {
+// So this walk hands each decoder its own route's minimal contract body and
+// requires a call back. Derived from agentPolicies rather than from a list of
+// operationIds someone remembered, so a route added upstream for any of these
+// verbs is decoded here too.
+func TestEverySinglePurposeToolRouteDecodesTheBodyItsContractDeclares(t *testing.T) {
 	verbs := make(map[string]bool, len(singlePurposeTools))
 	for _, tool := range singlePurposeTools {
 		verbs[tool] = true
@@ -90,8 +93,13 @@ func TestEverySinglePurposeToolRouteDecodesIntoACommand(t *testing.T) {
 		checked++
 		decode, described := restCommands[pol.Op]
 		if !described {
-			t.Errorf("%s (%s) is a %s operation that decodes into no command, so its staged target is still "+
-				"guessed from the route while the tool door reads it from the call", route, pol.Op, pol.Tool)
+			// The completeness gate reports this route by name; here it would
+			// only be a nil decoder to dereference.
+			continue
+		}
+		if _, declared := contractBodies[pol.Op]; !declared && !bodilessRoutes[pol.Op] {
+			t.Errorf("%s (%s) has no contract body here and is not one of the routes declared bodiless, so "+
+				"the decode below proves only that commandBody short-circuits an empty payload", route, pol.Op)
 			continue
 		}
 		body := []byte(contractBodies[pol.Op])
@@ -105,16 +113,24 @@ func TestEverySinglePurposeToolRouteDecodesIntoACommand(t *testing.T) {
 			t.Errorf("%s (%s): decoded into no call at all", route, pol.Op)
 		}
 	}
-	if checked != 16 {
-		t.Errorf("the policy table carries %d mutating routes for these fourteen verbs, want 16 — if the "+
-			"contract gained or lost one, this seam's coverage moved with it", checked)
+	if checked == 0 {
+		t.Fatal("none of these fourteen verbs reached a mutating route — this walk decoded nothing")
 	}
-	if len(contractBodies) != checked-2 {
-		t.Errorf("contractBodies carries %d bodies for %d routes; the two without one are disqualifyLead "+
-			"and runReport, so any other gap means a route is being decoded from nothing",
-			len(contractBodies), checked)
+	for op := range contractBodies {
+		if bodilessRoutes[op] {
+			t.Errorf("%s is declared bodiless and carries a contract body; one of the two is wrong about the "+
+				"operation, and the walk above trusts whichever it reads first", op)
+		}
 	}
 }
+
+// bodilessRoutes are the two routes of the fourteen that declare no request
+// body at all, named rather than counted: disqualifyLead is a bare DELETE, and
+// runReport's plan arguments are optional and read by nothing this walk
+// asserts. A route that quietly lost its body would otherwise be decoded from
+// nothing and pass — which is what a bare "sixteen routes, fourteen bodies"
+// subtraction could not tell apart from a body someone forgot to write.
+var bodilessRoutes = map[string]bool{"disqualifyLead": true, "runReport": true}
 
 // mergeRequest is a POST against a merge route, carrying the {id} chi would
 // have bound plus the body naming the survivor. body is the caller's own copy

--- a/backend/internal/compose/agentcommandsingle_test.go
+++ b/backend/internal/compose/agentcommandsingle_test.go
@@ -6,10 +6,10 @@ package compose
 // The REST door's half of the fourteen single-purpose commands
 // (agentcommandsend.go, agentcommandlifecycle.go, agentcommandrecord.go,
 // agentcommandauto.go): the derived coverage gate that pins all sixteen routes
-// off the route walk, and the three places where this door's answer actually
+// off the route walk, and the four places where this door's answer actually
 // CHANGES — a merge that used to stage the wrong half, two enrich routes that
-// could not be told apart, and a send that used to stage a refusal no human
-// could act on.
+// could not be told apart, a booking whose approval bound to no record at all,
+// and two sends that used to stage refusals no human could act on.
 
 import (
 	"bytes"
@@ -23,6 +23,7 @@ import (
 
 	"github.com/gradionhq/margince/backend/internal/modules/agents"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
 )
 
 // singlePurposeTools are the fourteen verbs whose every contract operation
@@ -167,6 +168,31 @@ func TestTheTwoEnrichRoutesStageTheDepthTheirOwnRouteMeans(t *testing.T) {
 	}
 	if !strings.Contains(staged["deepReadCompany"], string(agents.EnrichDepthSite)) {
 		t.Errorf("deepReadCompany staged %q, which does not say it reads the whole site", staged["deepReadCompany"])
+	}
+}
+
+// A booking's route carries no {id}, so the walk could only stage the policy
+// table's declared record type against the ZERO id — an approval floating free
+// of any record, which the approvals surface can scope to nobody in particular.
+// The command binds it to the first record the booking attaches to: the row a
+// meeting is a commitment ON, and whose scope the deciding human must reach.
+func TestABookingStagesTheRecordItAttachesTo(t *testing.T) {
+	deal := ids.NewV7()
+	staging := &capturingApprovals{}
+	pol := agentPolicy{Op: "bookMeeting", Access: accessTool, Tool: "book_meeting", RecordType: recordTypeActivity}
+	body := []byte(`{"start":"2026-08-10T09:00:00Z","end":"2026-08-10T09:30:00Z","subject":"Review",` +
+		`"links":[{"entity_type":"deal","entity_id":"` + deal.String() + `"}]}`)
+	req := httptest.NewRequest(http.MethodPost, "/v1/bookings", bytes.NewReader(body))
+
+	stageRefusal(httptest.NewRecorder(), req, staging, restCommandDeps{records: seamRecord{}}, pol, body)
+
+	if staging.last.TargetID != deal {
+		t.Errorf("staged target %s, want the deal %s the booking attaches to — an approval bound to no row "+
+			"is one the approvals surface cannot scope to anybody", staging.last.TargetID, deal)
+	}
+	if staging.last.TargetType != string(datasource.EntityDeal) {
+		t.Errorf("staged target type %q, want %q — the type comes from the link the booking names, not from "+
+			"the route's own declared record type", staging.last.TargetType, datasource.EntityDeal)
 	}
 }
 

--- a/backend/internal/compose/agentcommandsingle_test.go
+++ b/backend/internal/compose/agentcommandsingle_test.go
@@ -39,10 +39,39 @@ var singlePurposeTools = []string{
 	"log_activity", "draft_email", "relink_activity", "run_report",
 }
 
+// contractBodies is each of the sixteen routes' own minimal request body, as
+// crm.yaml declares it — every required member present and nothing else.
+//
+// They are real bodies rather than nil because the walk below asserts that a
+// decoder ACCEPTS the shape its route produces, and commandBody short-circuits
+// an empty body before it decodes anything at all: passing nil would exercise
+// that short-circuit sixteen times and prove nothing about the sixteen structs
+// underneath it. An operation absent from this map declares no body at all
+// (disqualifyLead is a bare DELETE; runReport's plan arguments are optional and
+// nothing here reads them).
+//
+// gatekit:fixture the request body crm.yaml declares for each route — expected input the walk decodes, not a waived cost
+var contractBodies = map[string]string{
+	"sendEmail":           `{"to":["buyer@example.test"],"subject":"Q3","body":"hi","consent_purpose":"sales"}`,
+	"sendMessage":         `{"body":"hi","consent_purpose":"support"}`,
+	"sendAccountEmail":    `{"to":["buyer@example.test"],"subject":"Q3","body":"hi","consent_purpose":"sales","links":[{"entity_type":"organization","entity_id":"019ff000-0000-7000-8000-000000000001"}]}`,
+	"bookMeeting":         `{"start":"2026-08-10T09:00:00Z","end":"2026-08-10T09:30:00Z","links":[{"entity_type":"deal","entity_id":"019ff000-0000-7000-8000-000000000002"}]}`,
+	"promoteLead":         `{"trigger":"inbound_reply"}`,
+	"advanceProjectPhase": `{"to_phase":"pursuing"}`,
+	"advanceDeal":         `{"to_stage_id":"019ff000-0000-7000-8000-000000000003"}`,
+	"mergePerson":         `{"target_id":"019ff000-0000-7000-8000-000000000004"}`,
+	"mergeOrganization":   `{"target_id":"019ff000-0000-7000-8000-000000000005"}`,
+	"scrapeCompany":       `{"url":"https://acme.test/about"}`,
+	"deepReadCompany":     `{"url":"https://acme.test"}`,
+	"logActivity":         `{"kind":"note","body":"hi"}`,
+	"draftEmail":          `{"intent":"polite follow-up"}`,
+	"relinkActivity":      `{"entity_type":"deal","entity_id":"019ff000-0000-7000-8000-000000000006"}`,
+}
+
 // Every route these fourteen verbs reach must decode into a command, and the
-// decoder bound to it must accept a well-formed request — a decoder that
-// errors on the shape its own route produces would answer the whole operation
-// as a refusal the moment a tier floor tightened it.
+// decoder bound to it must accept the body its own route declares — a decoder
+// that errored on the shape crm.yaml specifies would answer the whole
+// operation as a refusal the moment a tier floor tightened it.
 //
 // Derived from agentPolicies rather than from a list of sixteen operationIds
 // someone remembered, so a route added upstream for any of these verbs fails
@@ -65,9 +94,11 @@ func TestEverySinglePurposeToolRouteDecodesIntoACommand(t *testing.T) {
 				"guessed from the route while the tool door reads it from the call", route, pol.Op, pol.Tool)
 			continue
 		}
-		call, err := decode(pol, restCommandDeps{records: seamRecord{}, channels: channelKinds{}}, syntheticOperandRequest(route, ids.NewV7()), nil)
+		body := []byte(contractBodies[pol.Op])
+		call, err := decode(pol, restCommandDeps{records: seamRecord{}, channels: channelKinds{}},
+			syntheticOperandRequest(route, ids.NewV7()), body)
 		if err != nil {
-			t.Errorf("%s (%s): decoding a well-formed request answered %v", route, pol.Op, err)
+			t.Errorf("%s (%s): decoding the body crm.yaml declares answered %v", route, pol.Op, err)
 			continue
 		}
 		if call == nil {
@@ -77,6 +108,11 @@ func TestEverySinglePurposeToolRouteDecodesIntoACommand(t *testing.T) {
 	if checked != 16 {
 		t.Errorf("the policy table carries %d mutating routes for these fourteen verbs, want 16 — if the "+
 			"contract gained or lost one, this seam's coverage moved with it", checked)
+	}
+	if len(contractBodies) != checked-2 {
+		t.Errorf("contractBodies carries %d bodies for %d routes; the two without one are disqualifyLead "+
+			"and runReport, so any other gap means a route is being decoded from nothing",
+			len(contractBodies), checked)
 	}
 }
 

--- a/backend/internal/compose/agentcommandsingle_test.go
+++ b/backend/internal/compose/agentcommandsingle_test.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/getkin/kin-openapi/openapi3"
 	chi "github.com/go-chi/chi/v5"
 
 	"github.com/gradionhq/margince/backend/internal/modules/agents"
@@ -39,16 +40,16 @@ var singlePurposeTools = []string{
 	"log_activity", "draft_email", "relink_activity", "run_report",
 }
 
-// contractBodies is each of the sixteen routes' own minimal request body, as
-// crm.yaml declares it — every required member present and nothing else.
+// contractBodies is each route's own minimal request body, as crm.yaml declares
+// it — every required member present and nothing else.
 //
 // They are real bodies rather than nil because the walk below asserts that a
 // decoder ACCEPTS the shape its route produces, and commandBody short-circuits
 // an empty body before it decodes anything at all: passing nil would exercise
-// that short-circuit sixteen times and prove nothing about the sixteen structs
-// underneath it. An operation absent from this map declares no body at all
-// (disqualifyLead is a bare DELETE; runReport's plan arguments are optional and
-// nothing here reads them).
+// that short-circuit for every route and prove nothing about the structs
+// underneath it. Which routes need an entry is read off the contract rather than
+// stated here — a route that declares a requestBody must have one, and one that
+// declares none must not.
 //
 // gatekit:fixture the request body crm.yaml declares for each route — expected input the walk decodes, not a waived cost
 var contractBodies = map[string]string{
@@ -66,6 +67,12 @@ var contractBodies = map[string]string{
 	"logActivity":         `{"kind":"note","body":"hi"}`,
 	"draftEmail":          `{"intent":"polite follow-up"}`,
 	"relinkActivity":      `{"entity_type":"deal","entity_id":"019ff000-0000-7000-8000-000000000006"}`,
+	// Optional in the contract, and supplied all the same: `required: false`
+	// describes what a CALLER may omit, not what the decoder is entitled to be
+	// unproven against. runReportCommand reads the report key out of the path
+	// and nothing out of the body, which is exactly the claim a real plan
+	// travelling through it makes checkable.
+	"runReport": `{"filters":{"period":"last_quarter"},"group_by":["source"]}`,
 }
 
 // What a registration does not say: that the decoder bound to a route can
@@ -84,6 +91,7 @@ func TestEverySinglePurposeToolRouteDecodesTheBodyItsContractDeclares(t *testing
 	for _, tool := range singlePurposeTools {
 		verbs[tool] = true
 	}
+	declared := operationsDeclaringARequestBody(t)
 	checked := 0
 	for route, pol := range agentPolicies {
 		method, _, _ := strings.Cut(route, " ")
@@ -97,14 +105,19 @@ func TestEverySinglePurposeToolRouteDecodesTheBodyItsContractDeclares(t *testing
 			// only be a nil decoder to dereference.
 			continue
 		}
-		if _, declared := contractBodies[pol.Op]; !declared && !bodilessRoutes[pol.Op] {
-			t.Errorf("%s (%s) has no contract body here and is not one of the routes declared bodiless, so "+
-				"the decode below proves only that commandBody short-circuits an empty payload", route, pol.Op)
+		body, written := contractBodies[pol.Op]
+		if declaresBody := declared[pol.Op]; declaresBody != written {
+			if declaresBody {
+				t.Errorf("%s (%s) declares a requestBody in crm.yaml and carries none here, so the decode "+
+					"below proves only that commandBody short-circuits an empty payload", route, pol.Op)
+			} else {
+				t.Errorf("%s (%s) declares no requestBody in crm.yaml and carries one here, so the walk "+
+					"decodes a shape the route cannot produce", route, pol.Op)
+			}
 			continue
 		}
-		body := []byte(contractBodies[pol.Op])
 		call, err := decode(pol, restCommandDeps{records: seamRecord{}, channels: channelKinds{}},
-			syntheticOperandRequest(route, ids.NewV7()), body)
+			syntheticOperandRequest(route, ids.NewV7()), []byte(body))
 		if err != nil {
 			t.Errorf("%s (%s): decoding the body crm.yaml declares answered %v", route, pol.Op, err)
 			continue
@@ -116,21 +129,34 @@ func TestEverySinglePurposeToolRouteDecodesTheBodyItsContractDeclares(t *testing
 	if checked == 0 {
 		t.Fatal("none of these fourteen verbs reached a mutating route — this walk decoded nothing")
 	}
-	for op := range contractBodies {
-		if bodilessRoutes[op] {
-			t.Errorf("%s is declared bodiless and carries a contract body; one of the two is wrong about the "+
-				"operation, and the walk above trusts whichever it reads first", op)
-		}
-	}
 }
 
-// bodilessRoutes are the two routes of the fourteen that declare no request
-// body at all, named rather than counted: disqualifyLead is a bare DELETE, and
-// runReport's plan arguments are optional and read by nothing this walk
-// asserts. A route that quietly lost its body would otherwise be decoded from
-// nothing and pass — which is what a bare "sixteen routes, fourteen bodies"
-// subtraction could not tell apart from a body someone forgot to write.
-var bodilessRoutes = map[string]bool{"disqualifyLead": true, "runReport": true}
+// operationsDeclaringARequestBody reads, from crm.yaml itself, which operations
+// carry a request body — including the ones that declare it `required: false`,
+// since an optional body is still a shape a caller may send and a decoder must
+// therefore be proved against.
+//
+// Read from the contract rather than listed here: a hand-kept list of the
+// exceptions is a second statement about the contract, and it goes stale in the
+// direction that reads as success — a route that gains a body stays excused, and
+// its decoder goes on being proved against an empty payload alone.
+func operationsDeclaringARequestBody(t *testing.T) map[string]bool {
+	t.Helper()
+	doc, err := openapi3.NewLoader().LoadFromFile("../../api/crm.yaml")
+	if err != nil {
+		t.Fatalf("loading the contract: %v", err)
+	}
+	declaring := map[string]bool{}
+	for _, item := range doc.Paths.Map() {
+		for _, op := range item.Operations() {
+			declaring[op.OperationID] = op.RequestBody != nil
+		}
+	}
+	if len(declaring) == 0 {
+		t.Fatal("the contract declares no operations — every membership question below would answer false")
+	}
+	return declaring
+}
 
 // mergeRequest is a POST against a merge route, carrying the {id} chi would
 // have bound plus the body naming the survivor. body is the caller's own copy

--- a/backend/internal/compose/agentcommandsingle_test.go
+++ b/backend/internal/compose/agentcommandsingle_test.go
@@ -1,0 +1,227 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The REST door's half of the fourteen single-purpose commands
+// (agentcommandsend.go, agentcommandlifecycle.go, agentcommandrecord.go,
+// agentcommandauto.go): the derived coverage gate that pins all sixteen routes
+// off the route walk, and the three places where this door's answer actually
+// CHANGES — a merge that used to stage the wrong half, two enrich routes that
+// could not be told apart, and a send that used to stage a refusal no human
+// could act on.
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	chi "github.com/go-chi/chi/v5"
+
+	"github.com/gradionhq/margince/backend/internal/modules/agents"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// singlePurposeTools are the fourteen verbs whose every contract operation
+// this task put on the seam. Named as VERBS rather than as operationIds
+// because the mapping is the point: two of them serve two operations each
+// (merge_records is the person and organization halves, enrich is the two
+// depths), so a walk keyed on tool names finds sixteen routes and would find a
+// seventeenth the contract grew for any of them.
+var singlePurposeTools = []string{
+	"send_email", "send_message", "send_account_email", "book_meeting",
+	"promote_lead", "disqualify_lead", "advance_project_phase", "advance_deal",
+	"merge_records", "enrich",
+	"log_activity", "draft_email", "relink_activity", "run_report",
+}
+
+// Every route these fourteen verbs reach must decode into a command, and the
+// decoder bound to it must accept a well-formed request — a decoder that
+// errors on the shape its own route produces would answer the whole operation
+// as a refusal the moment a tier floor tightened it.
+//
+// Derived from agentPolicies rather than from a list of sixteen operationIds
+// someone remembered, so a route added upstream for any of these verbs fails
+// here rather than quietly falling back to the route walk.
+func TestEverySinglePurposeToolRouteDecodesIntoACommand(t *testing.T) {
+	verbs := make(map[string]bool, len(singlePurposeTools))
+	for _, tool := range singlePurposeTools {
+		verbs[tool] = true
+	}
+	checked := 0
+	for route, pol := range agentPolicies {
+		method, _, _ := strings.Cut(route, " ")
+		if pol.Access != accessTool || !verbs[pol.Tool] || !mutatingMethod(method) {
+			continue
+		}
+		checked++
+		decode, described := restCommands[pol.Op]
+		if !described {
+			t.Errorf("%s (%s) is a %s operation that decodes into no command, so its staged target is still "+
+				"guessed from the route while the tool door reads it from the call", route, pol.Op, pol.Tool)
+			continue
+		}
+		call, err := decode(pol, restCommandDeps{records: seamRecord{}, channels: channelKinds{}}, syntheticOperandRequest(route, ids.NewV7()), nil)
+		if err != nil {
+			t.Errorf("%s (%s): decoding a well-formed request answered %v", route, pol.Op, err)
+			continue
+		}
+		if call == nil {
+			t.Errorf("%s (%s): decoded into no call at all", route, pol.Op)
+		}
+	}
+	if checked != 16 {
+		t.Errorf("the policy table carries %d mutating routes for these fourteen verbs, want 16 — if the "+
+			"contract gained or lost one, this seam's coverage moved with it", checked)
+	}
+}
+
+// mergeRequest is a POST against a merge route, carrying the {id} chi would
+// have bound plus the body naming the survivor.
+func mergeRequest(collection string, routed, target ids.UUID) *http.Request {
+	body := []byte(`{"target_id":"` + target.String() + `"}`)
+	req := httptest.NewRequest(http.MethodPost, collection+"/"+routed.String()+"/merge", bytes.NewReader(body))
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", routed.String())
+	return req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+}
+
+// The behaviour change a merge's command buys, and it is a correction rather
+// than an addition.
+//
+// POST /v1/people/{id}/merge merges the ROUTED person INTO the body's
+// target_id: the routed row is the one archived. The route walk read that
+// routed id as the staged target, so the approval bound to — and the pin was
+// taken from — the record about to be retired, while the tool door had always
+// bound it to the survivor. One operation, two doors, two different rows.
+func TestAMergeStagesTheSurvivorTheBodyNamesRatherThanTheRoutedRecord(t *testing.T) {
+	for _, c := range []struct {
+		op, collection string
+		recordType     agentRecordType
+	}{
+		{"mergePerson", "/v1/people", recordTypePerson},
+		{"mergeOrganization", "/v1/organizations", recordTypeOrganization},
+	} {
+		t.Run(c.op, func(t *testing.T) {
+			source, survivor := ids.NewV7(), ids.NewV7()
+			staging := &capturingApprovals{}
+			pol := agentPolicy{Op: c.op, Access: accessTool, Tool: "merge_records", RecordType: c.recordType}
+			body := []byte(`{"target_id":"` + survivor.String() + `"}`)
+
+			stageRefusal(httptest.NewRecorder(), mergeRequest(c.collection, source, survivor), staging,
+				restCommandDeps{records: seamRecord{}}, pol, body)
+
+			if staging.last.TargetID != survivor {
+				t.Errorf("staged target %s, want the survivor %s the body names — the routed id is the record "+
+					"being archived, and an approval bound to it pins a row the merge retires",
+					staging.last.TargetID, survivor)
+			}
+			if staging.last.TargetType != string(c.recordType) {
+				t.Errorf("staged target type %q, want %q", staging.last.TargetType, c.recordType)
+			}
+		})
+	}
+}
+
+// The two enrich routes are ONE verb at two depths, and nothing on the wire
+// tells them apart — no `depth` field, no differing body, only which path was
+// taken. So the decoders set it structurally, and the line a human approves
+// says which read it is. A site crawl described as a page read is an approval
+// given for something else entirely.
+func TestTheTwoEnrichRoutesStageTheDepthTheirOwnRouteMeans(t *testing.T) {
+	staged := map[string]string{}
+	for _, c := range []struct{ op, path string }{
+		{"scrapeCompany", "/v1/organizations/%s/enrich"},
+		{"deepReadCompany", "/v1/organizations/%s/deep-read"},
+	} {
+		org := ids.NewV7()
+		pol := agentPolicy{Op: c.op, Access: accessTool, Tool: "enrich", RecordType: recordTypeOrganization}
+		req := httptest.NewRequest(http.MethodPost, strings.Replace(c.path, "%s", org.String(), 1), nil)
+		rctx := chi.NewRouteContext()
+		rctx.URLParams.Add("id", org.String())
+		req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+
+		decode := restCommands[c.op]
+		call, err := decode(pol, restCommandDeps{records: seamRecord{}}, req, nil)
+		if err != nil {
+			t.Fatalf("%s: decoding answered %v", c.op, err)
+		}
+		info, err := agents.StageSubject(req.Context(), call)
+		if err != nil {
+			t.Fatalf("%s: staging answered %v", c.op, err)
+		}
+		staged[c.op] = info.Summary
+	}
+
+	if staged["scrapeCompany"] == staged["deepReadCompany"] {
+		t.Fatalf("both enrich routes stage the sentence %q — a human releasing a whole-site crawl would "+
+			"read the line written for a single page", staged["scrapeCompany"])
+	}
+	if !strings.Contains(staged["scrapeCompany"], string(agents.EnrichDepthPage)) {
+		t.Errorf("scrapeCompany staged %q, which does not say it reads one page", staged["scrapeCompany"])
+	}
+	if !strings.Contains(staged["deepReadCompany"], string(agents.EnrichDepthSite)) {
+		t.Errorf("deepReadCompany staged %q, which does not say it reads the whole site", staged["deepReadCompany"])
+	}
+}
+
+// The behaviour change the outbound commands buy: a refusal the tool door has
+// always made, now made by this door too.
+//
+// A send with an empty `to` reaches nobody and the store refuses it. Without
+// the command, this door staged it anyway — a human read a send addressed to
+// no one, approved it, and the approved retry spent the one-shot authority
+// discovering what could have been said first.
+func TestASendWithNoAddresseeStagesNothing(t *testing.T) {
+	anchor := ids.NewV7()
+	staging := &capturingApprovals{}
+	pol := agentPolicy{Op: "sendEmail", Access: accessTool, Tool: "send_email", RecordType: recordTypeActivity}
+	body := []byte(`{"to":[],"subject":"Q3","body":"hi","consent_purpose":"sales"}`)
+	req := httptest.NewRequest(http.MethodPost, "/v1/activities/"+anchor.String()+"/send-email", bytes.NewReader(body))
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", anchor.String())
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+	rec := httptest.NewRecorder()
+
+	stageRefusal(rec, req, staging, restCommandDeps{records: seamRecord{}}, pol, body)
+
+	if staging.last.Tool != "" {
+		t.Errorf("an approval was staged for %q against a send that reaches nobody", staging.last.Tool)
+	}
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Errorf("a send with no addressee answered %d, want %d — the caller is told what to fix instead of "+
+			"being handed an approval nobody can act on", rec.Code, http.StatusUnprocessableEntity)
+	}
+}
+
+// The channel guard is the one refusal this door could not previously make at
+// all: it needs the ANCHOR's kind, which the route does not carry. The command
+// carries the question instead (restCommandDeps.channels), so a reply proposed
+// on an email thread is refused before a human is asked to release it.
+func TestAChannelReplyOnANonChannelAnchorStagesNothing(t *testing.T) {
+	anchor := ids.NewV7()
+	staging := &capturingApprovals{}
+	pol := agentPolicy{Op: "sendMessage", Access: accessTool, Tool: "send_message", RecordType: recordTypeActivity}
+	body := []byte(`{"body":"hello","consent_purpose":"support"}`)
+	req := httptest.NewRequest(http.MethodPost, "/v1/activities/"+anchor.String()+"/send-message", bytes.NewReader(body))
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", anchor.String())
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+	rec := httptest.NewRecorder()
+
+	// seamRecord answers every read with an activity whose fields carry no
+	// `kind` at all, which is not a channel kind — the same answer an email
+	// anchor gives, reached without a second fixture.
+	stageRefusal(rec, req, staging, restCommandDeps{records: seamRecord{}, channels: channelKinds{}}, pol, body)
+
+	if staging.last.Tool != "" {
+		t.Errorf("an approval was staged for %q against an anchor no channel reply can transmit through",
+			staging.last.Tool)
+	}
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Errorf("a reply on a non-channel anchor answered %d, want %d", rec.Code, http.StatusUnprocessableEntity)
+	}
+}

--- a/backend/internal/compose/agentcommandsingle_test.go
+++ b/backend/internal/compose/agentcommandsingle_test.go
@@ -80,9 +80,11 @@ func TestEverySinglePurposeToolRouteDecodesIntoACommand(t *testing.T) {
 }
 
 // mergeRequest is a POST against a merge route, carrying the {id} chi would
-// have bound plus the body naming the survivor.
-func mergeRequest(collection string, routed, target ids.UUID) *http.Request {
-	body := []byte(`{"target_id":"` + target.String() + `"}`)
+// have bound plus the body naming the survivor. body is the caller's own copy
+// — the gate buffers it once and hands the same bytes to the decoder, so a
+// request built with different bytes than the test passes on would prove
+// nothing about the pair that actually travels together.
+func mergeRequest(collection string, routed ids.UUID, body []byte) *http.Request {
 	req := httptest.NewRequest(http.MethodPost, collection+"/"+routed.String()+"/merge", bytes.NewReader(body))
 	rctx := chi.NewRouteContext()
 	rctx.URLParams.Add("id", routed.String())
@@ -111,7 +113,7 @@ func TestAMergeStagesTheSurvivorTheBodyNamesRatherThanTheRoutedRecord(t *testing
 			pol := agentPolicy{Op: c.op, Access: accessTool, Tool: "merge_records", RecordType: c.recordType}
 			body := []byte(`{"target_id":"` + survivor.String() + `"}`)
 
-			stageRefusal(httptest.NewRecorder(), mergeRequest(c.collection, source, survivor), staging,
+			stageRefusal(httptest.NewRecorder(), mergeRequest(c.collection, source, body), staging,
 				restCommandDeps{records: seamRecord{}}, pol, body)
 
 			if staging.last.TargetID != survivor {

--- a/backend/internal/compose/agentcommandsingle_test.go
+++ b/backend/internal/compose/agentcommandsingle_test.go
@@ -131,9 +131,16 @@ func TestAMergeStagesTheSurvivorTheBodyNamesRatherThanTheRoutedRecord(t *testing
 
 // The two enrich routes are ONE verb at two depths, and nothing on the wire
 // tells them apart — no `depth` field, no differing body, only which path was
-// taken. So the decoders set it structurally, and the line a human approves
-// says which read it is. A site crawl described as a page read is an approval
-// given for something else entirely.
+// taken. So the decoders set it structurally, and the resolver's own summary is
+// where that shows: a site crawl a resolver describes as a page read is an
+// approval given for something else entirely.
+//
+// The SUMMARY rather than the inbox line, and the difference is worth stating.
+// stagedTarget (agentgatestaging.go) takes only the TARGET from the resolver
+// and writes restSummary as the line an approver reads on this door — that line
+// names the concrete path, so a human here does see which read they are
+// releasing. What the summary proves is that the erased command underneath
+// carries the right depth at all, which is the only handle this door has on it.
 func TestTheTwoEnrichRoutesStageTheDepthTheirOwnRouteMeans(t *testing.T) {
 	staged := map[string]string{}
 	for _, c := range []struct{ op, path string }{

--- a/backend/internal/compose/agentcommandstagedrow_integration_test.go
+++ b/backend/internal/compose/agentcommandstagedrow_integration_test.go
@@ -49,6 +49,7 @@ import (
 // it.
 type stagedApproval struct {
 	kind           string
+	status         string
 	targetType     string
 	targetID       string
 	pinned         bool
@@ -74,6 +75,14 @@ func TestBothDoorsStageOneRowForOneOperation(t *testing.T) {
 	rest := readStagedApproval(agent, t, e, restID)
 	tool := readStagedApproval(agent, t, e, toolID)
 
+	// Both doors stage for the same operation against the same target inside one
+	// test, and staging force-expires a stale pending approval that shares a
+	// proposal identity (approvals/staging.go). Every comparison below is about
+	// a row a human can decide from, so a superseded row must not pass as one.
+	if rest.status != "pending" || tool.status != "pending" {
+		t.Fatalf("the staged rows are %q (REST) and %q (tool), want both pending — an expired row is not "+
+			"one a human can decide from", rest.status, tool.status)
+	}
 	if rest.kind != tool.kind {
 		t.Errorf("the doors staged kinds %q and %q — an approval's kind is what the decision grants are "+
 			"mapped by, so one of the two is decidable by a different set of people", rest.kind, tool.kind)
@@ -271,10 +280,11 @@ func readStagedApproval(as context.Context, t *testing.T, e *integration.Env, id
 	var row stagedApproval
 	if err := database.WithWorkspaceTx(as, e.Pool, func(tx pgx.Tx) error {
 		return tx.QueryRow(as, `
-			SELECT kind, coalesce(target_entity_type, ''), coalesce(target_entity_id::text, ''),
+			SELECT kind, status, coalesce(target_entity_type, ''), coalesce(target_entity_id::text, ''),
 			       target_version IS NOT NULL, proposed_change::text, diff_hash
 			FROM approval WHERE id = $1`, id).Scan(
-			&row.kind, &row.targetType, &row.targetID, &row.pinned, &row.proposedChange, &row.diffHash)
+			&row.kind, &row.status, &row.targetType, &row.targetID, &row.pinned, &row.proposedChange,
+			&row.diffHash)
 	}); err != nil {
 		t.Fatalf("reading staged approval %s: %v", id, err)
 	}

--- a/backend/internal/compose/agentcommandstagedrow_integration_test.go
+++ b/backend/internal/compose/agentcommandstagedrow_integration_test.go
@@ -1,0 +1,282 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package compose
+
+// The two doors, staged for real: one operation, one record, two approval rows
+// that a human could not tell apart on anything the decision depends on.
+//
+// The unit twin (agentcommandbothdoors_test.go) compares what each door
+// RESOLVES. This compares what each door WROTE, and it has to run here for one
+// reason: the version an approval pins is taken server-side inside the staging
+// transaction (approvals.StageInTx), so no fake approvals engine can say
+// anything about pin shape — a stub would answer whatever it was written to
+// answer, for both doors, identically and meaninglessly.
+//
+// Two of the columns are DELIBERATELY different, and asserting the difference
+// is as much the point as asserting the agreement: proposed_change and
+// diff_hash are each door's own replay. A REST approval is redeemed by
+// repeating the HTTP request, an MCP approval by repeating the tool call, and a
+// row that carried the other door's payload would be a decision nobody could
+// act on from where they made it.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/gradionhq/margince/backend/internal/compose/integration"
+	"github.com/gradionhq/margince/backend/internal/modules/agents"
+	"github.com/gradionhq/margince/backend/internal/modules/approvals"
+	"github.com/gradionhq/margince/backend/internal/platform/auth"
+	"github.com/gradionhq/margince/backend/internal/platform/database"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/authz"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/workflow"
+)
+
+// stagedApproval is the row a human decides from, as the approvals table holds
+// it.
+type stagedApproval struct {
+	kind           string
+	targetType     string
+	targetID       string
+	pinned         bool
+	proposedChange string
+	diffHash       string
+}
+
+// archivePersonPolicy is the operation both doors are asked to perform.
+var archivePersonPolicy = agentPolicy{
+	Op: "archivePerson", Access: accessTool, Tool: "archive_record",
+	RecordType: recordTypePerson, Tier: tierConfirmationRequired, Scope: scopeWrite,
+}
+
+func TestBothDoorsStageOneRowForOneOperation(t *testing.T) {
+	e := integration.Setup(t)
+	native := NewProvider(e.Pool)
+	agent := scopedArchiveAgent(t, e)
+	person := seedVisiblePerson(t, e, native, "Ada Lovelace")
+
+	restID := stageArchiveOverREST(agent, t, e, native, person)
+	toolID := stageArchiveOverTheToolDoor(agent, t, e, person)
+
+	rest := readStagedApproval(agent, t, e, restID)
+	tool := readStagedApproval(agent, t, e, toolID)
+
+	if rest.kind != tool.kind {
+		t.Errorf("the doors staged kinds %q and %q — an approval's kind is what the decision grants are "+
+			"mapped by, so one of the two is decidable by a different set of people", rest.kind, tool.kind)
+	}
+	if rest.targetType != tool.targetType || rest.targetID != tool.targetID {
+		t.Errorf("the doors bound one archive to two records: REST (%s,%s), tool (%s,%s) — the approvals "+
+			"surface scopes and probes an inbox row by exactly this pair",
+			rest.targetType, rest.targetID, tool.targetType, tool.targetID)
+	}
+	if rest.targetID != person.String() {
+		t.Errorf("the staged target is %s, want the person %s both doors were asked about", rest.targetID, person)
+	}
+	if rest.pinned != tool.pinned {
+		t.Errorf("one door pinned a version and the other did not (REST %v, tool %v) — the same approved "+
+			"call would be re-checked against the record's version through one door and not the other",
+			rest.pinned, tool.pinned)
+	}
+	if !rest.pinned {
+		t.Error("neither door pinned a version for a person, which has one — an approval released against " +
+			"an unpinned target is spent on whatever the record has become since")
+	}
+
+	// The deliberate difference. Each door's payload is the replay ITS OWN retry
+	// must present: the REST row carries the request, the tool row the tool
+	// call, and the diff hash each redemption checks is taken over its own.
+	if rest.proposedChange == tool.proposedChange {
+		t.Errorf("both doors staged the identical proposed_change %s — one of the two retries cannot "+
+			"present the call it describes", rest.proposedChange)
+	}
+	if rest.diffHash == tool.diffHash {
+		t.Error("both doors staged the identical diff_hash, so one door's approval would redeem the other " +
+			"door's call — the hash binds an approval to the request that was actually made")
+	}
+}
+
+// A record the agent's own row scope hides is refused by BOTH doors, and
+// neither stages anything: the guards each door runs are the same guards,
+// reached through the same resolver.
+func TestBothDoorsRefuseOneRecordNeitherCallerCanSee(t *testing.T) {
+	e := integration.Setup(t)
+	native := NewProvider(e.Pool)
+	agent := scopedArchiveAgent(t, e)
+
+	// Owned by a rep in another team: the row-scope clause hides it from the
+	// human this agent acts for, and an ownerless row would be workspace-shared
+	// and visible to everyone, proving nothing.
+	elsewhere := e.As(e.Rep3, []ids.UUID{e.Team2}, integration.AdminPerms)
+	hidden, err := native.Create(elsewhere, datasource.CreateInput{
+		EntityType: datasource.EntityPerson,
+		Fields:     json.RawMessage(`{"full_name":"Out Of Scope","owner_id":"` + e.Rep3.String() + `"}`),
+		Source:     "test",
+	})
+	if err != nil {
+		t.Fatalf("seeding the out-of-scope person: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	stageRefusal(rec, archiveRequestFor(agent, hidden.ID), approvalsAdapter{svc: approvals.NewService(e.Pool)},
+		restCommandDeps{records: native}, archivePersonPolicy, nil)
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("the REST door answered %d for a row outside the agent's scope, want 404", rec.Code)
+	}
+
+	_, invokeErr := archiveRegistry(e).Invoke(agent, "archive_record",
+		json.RawMessage(`{"record_type":"person","id":"`+hidden.ID.String()+`"}`))
+	var staged *workflow.StagedApprovalError
+	if errors.As(invokeErr, &staged) {
+		t.Errorf("the tool door staged approval %s for a row outside the agent's scope, where the REST door "+
+			"refused — one credential, two answers", staged.ApprovalID)
+	}
+
+	if n := pendingApprovals(agent, t, e); n != 0 {
+		t.Errorf("%d approval(s) were staged against a record neither door's caller can see", n)
+	}
+}
+
+// seedVisiblePerson writes one person through the real provider, owned by the
+// human the agent acts for, so both doors can read it.
+func seedVisiblePerson(t *testing.T, e *integration.Env, native *Provider, name string) ids.UUID {
+	t.Helper()
+	ref, err := native.Create(e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AdminPerms), datasource.CreateInput{
+		EntityType: datasource.EntityPerson,
+		Fields:     json.RawMessage(`{"full_name":"` + name + `","owner_id":"` + e.Rep1.String() + `"}`),
+		Source:     "test",
+	})
+	if err != nil {
+		t.Fatalf("seeding the person both doors archive: %v", err)
+	}
+	return ref.ID
+}
+
+// archiveRequestFor is the request the router would hand the gate for
+// DELETE /v1/people/{id}, carrying the agent's own context.
+func archiveRequestFor(as context.Context, person ids.UUID) *http.Request {
+	req := httptest.NewRequest(http.MethodDelete, "/v1/people/"+person.String(), nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", person.String())
+	return req.WithContext(context.WithValue(as, chi.RouteCtxKey, rctx))
+}
+
+// repSeat re-derives, for the tool door's admission gate, exactly the authority
+// the REST door's own request context carries: a full seat with a rep's
+// permissions and the rep's team. Both doors must be governed by ONE authority
+// or the comparison below is about seats rather than about doors — and a gate
+// handed admin permissions would read rows the REST side's row scope hides,
+// which is a difference in the fixture, not in the surface.
+//
+// The harness stamps a rep's authority onto its contexts rather than seeding
+// role grants, so the live identity resolver has nothing to answer with here;
+// this stands in for it, with the same two answers.
+type repSeat struct{ e *integration.Env }
+
+func (s repSeat) EffectiveRBAC(context.Context, ids.UUID, ids.UUID) (authz.RBAC, error) {
+	return authz.RBAC{Permissions: integration.RepPerms, TeamIDs: []ids.UUID{s.e.Team1}}, nil
+}
+
+func (repSeat) SeatType(context.Context, ids.UUID, ids.UUID) (principal.SeatType, error) {
+	return principal.SeatFull, nil
+}
+
+// archiveRegistry is the tool door over the real provider and the real
+// approvals engine — the same adapter the composed api server injects, so the
+// row this door writes is written by production's own stager.
+func archiveRegistry(e *integration.Env) *agents.Registry {
+	native := NewProvider(e.Pool)
+	reg := agents.NewRegistry(approvalsAdapter{svc: approvals.NewService(e.Pool)}, auth.NewGate(repSeat{e}))
+	agents.RegisterCoreTools(reg, native, native, nil, fieldOwnership{pool: e.Pool})
+	return reg
+}
+
+// stageArchiveOverREST stages through the REST door and answers the id of the
+// row it wrote — read back rather than parsed out of the refusal text, since
+// the row is what this test is about.
+func stageArchiveOverREST(agent context.Context, t *testing.T, e *integration.Env, native *Provider,
+	person ids.UUID,
+) ids.ApprovalID {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	stageRefusal(rec, archiveRequestFor(agent, person), approvalsAdapter{svc: approvals.NewService(e.Pool)},
+		restCommandDeps{records: native}, archivePersonPolicy, nil)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("the REST archive answered %d, want 403 with the redemption instructions", rec.Code)
+	}
+	ids := pendingApprovalIDs(agent, t, e)
+	if len(ids) != 1 {
+		t.Fatalf("%d approvals are pending after one REST archive, want exactly 1", len(ids))
+	}
+	return ids[0]
+}
+
+// stageArchiveOverTheToolDoor invokes the same archive as a tool call and
+// answers the id the staging refusal carries.
+func stageArchiveOverTheToolDoor(agent context.Context, t *testing.T, e *integration.Env,
+	person ids.UUID,
+) ids.ApprovalID {
+	t.Helper()
+	_, err := archiveRegistry(e).Invoke(agent, "archive_record",
+		json.RawMessage(`{"record_type":"person","id":"`+person.String()+`"}`))
+	var staged *workflow.StagedApprovalError
+	if !errors.As(err, &staged) {
+		t.Fatalf("the tool door answered %v rather than staging the archive", err)
+	}
+	return staged.ApprovalID
+}
+
+// pendingApprovalIDs lists what is waiting on a human, bound through
+// WithWorkspaceTx: Env.Pool is the RLS-bound app role, and an unbound read
+// resolves the policy against a NULL workspace and answers nothing for every
+// row that exists.
+func pendingApprovalIDs(as context.Context, t *testing.T, e *integration.Env) []ids.ApprovalID {
+	t.Helper()
+	var found []ids.ApprovalID
+	if err := database.WithWorkspaceTx(as, e.Pool, func(tx pgx.Tx) error {
+		rows, err := tx.Query(as, `SELECT id FROM approval WHERE status = 'pending' ORDER BY id`)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var id ids.ApprovalID
+			if err := rows.Scan(&id); err != nil {
+				return err
+			}
+			found = append(found, id)
+		}
+		return rows.Err()
+	}); err != nil {
+		t.Fatalf("listing the staged approvals: %v", err)
+	}
+	return found
+}
+
+func readStagedApproval(as context.Context, t *testing.T, e *integration.Env, id ids.ApprovalID) stagedApproval {
+	t.Helper()
+	var row stagedApproval
+	if err := database.WithWorkspaceTx(as, e.Pool, func(tx pgx.Tx) error {
+		return tx.QueryRow(as, `
+			SELECT kind, coalesce(target_entity_type, ''), coalesce(target_entity_id::text, ''),
+			       target_version IS NOT NULL, proposed_change::text, diff_hash
+			FROM approval WHERE id = $1`, id).Scan(
+			&row.kind, &row.targetType, &row.targetID, &row.pinned, &row.proposedChange, &row.diffHash)
+	}); err != nil {
+		t.Fatalf("reading staged approval %s: %v", id, err)
+	}
+	return row
+}

--- a/backend/internal/compose/agentcommandstagedrow_integration_test.go
+++ b/backend/internal/compose/agentcommandstagedrow_integration_test.go
@@ -131,7 +131,7 @@ func TestBothDoorsRefuseOneRecordNeitherCallerCanSee(t *testing.T) {
 	}
 
 	rec := httptest.NewRecorder()
-	stageRefusal(rec, archiveRequestFor(agent, hidden.ID), approvalsAdapter{svc: approvals.NewService(e.Pool)},
+	stageRefusal(rec, archiveRequestFor(agent, hidden.ID), approvalsAdapter{svc: approvals.NewService(e.DB())},
 		restCommandDeps{records: native}, archivePersonPolicy, nil)
 	if rec.Code != http.StatusNotFound {
 		t.Errorf("the REST door answered %d for a row outside the agent's scope, want 404", rec.Code)
@@ -199,7 +199,7 @@ func (repSeat) SeatType(context.Context, ids.UUID, ids.UUID) (principal.SeatType
 // row this door writes is written by production's own stager.
 func archiveRegistry(e *integration.Env) *agents.Registry {
 	native := NewProvider(e.Pool)
-	reg := agents.NewRegistry(approvalsAdapter{svc: approvals.NewService(e.Pool)}, auth.NewGate(repSeat{e}))
+	reg := agents.NewRegistry(approvalsAdapter{svc: approvals.NewService(e.DB())}, auth.NewGate(repSeat{e}))
 	agents.RegisterCoreTools(reg, native, native, nil, fieldOwnership{pool: e.Pool})
 	return reg
 }
@@ -212,7 +212,7 @@ func stageArchiveOverREST(agent context.Context, t *testing.T, e *integration.En
 ) ids.ApprovalID {
 	t.Helper()
 	rec := httptest.NewRecorder()
-	stageRefusal(rec, archiveRequestFor(agent, person), approvalsAdapter{svc: approvals.NewService(e.Pool)},
+	stageRefusal(rec, archiveRequestFor(agent, person), approvalsAdapter{svc: approvals.NewService(e.DB())},
 		restCommandDeps{records: native}, archivePersonPolicy, nil)
 	if rec.Code != http.StatusForbidden {
 		t.Fatalf("the REST archive answered %d, want 403 with the redemption instructions", rec.Code)

--- a/backend/internal/compose/agentcommandunrunnable_test.go
+++ b/backend/internal/compose/agentcommandunrunnable_test.go
@@ -20,6 +20,7 @@ package compose
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -31,12 +32,66 @@ import (
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
-// unrunnableCall is one call an operation's executor would refuse, and the
-// reason it would — stated so a reader can tell a fixture that exercises the
-// refusal from one that merely happens to fail.
+// unrunnableCall is one call an operation's executor would refuse, together with
+// the refusal the door owes for it.
+//
+// The refusal is a SHAPE rather than a sentence, and that is the difference
+// between a gate and a caption. stageRefusal has refusal points upstream of the
+// decoder — the canonical-call hash, the decision-grant check — so "some 4xx,
+// nothing staged" is satisfied by a fixture that has stopped exercising the
+// reason its own comment names, while the failure message goes on quoting that
+// reason. Naming the answer the reason implies is what makes the two disagree
+// loudly.
 type unrunnableCall struct {
-	refusedFor string
-	build      func() (*http.Request, []byte)
+	refusal refusal
+	build   func() (*http.Request, []byte)
+}
+
+// refusal is the problem body a call must be answered with: the status, the
+// contract's own problem code, and — for the two shapes that name what was
+// wrong — either the `details.errors` entry or the argument the detail must
+// name.
+//
+// why is the reason in prose, and it is not decoration: it is what a failure
+// reports, and every field beside it is that same reason made checkable.
+type refusal struct {
+	why    string
+	status int
+	code   string
+	// field and fieldCode are the details.errors entry a validation refusal
+	// renders (httperr.Validation). Empty when the refusal names no member.
+	field, fieldCode string
+	// names is a substring the problem detail must carry, for a refusal that
+	// answers with a message rather than a field list — an agents.BadArgsError
+	// classifies as validation_error and carries its reason in prose only, so
+	// the argument it names is the only checkable part of it.
+	names string
+}
+
+// hiddenRow is the existence-hiding answer a routed id gets: "that is not a
+// uuid" and "there is no such row" must read alike, or the shape of an id tells
+// a caller which rows exist.
+func hiddenRow(why string) refusal {
+	return refusal{why: why, status: http.StatusNotFound, code: "not_found"}
+}
+
+// namedMember is the 422 that names the member the caller got wrong, and the
+// contract's code for how — the shape a caller can act on without guessing.
+func namedMember(field, fieldCode, why string) refusal {
+	return refusal{
+		why: why, status: http.StatusUnprocessableEntity, code: "validation_error",
+		field: field, fieldCode: fieldCode,
+	}
+}
+
+// refusedArgument is the 422 whose reason travels as prose: the resolver
+// answered an agents.BadArgsError, which classifies as validation_error and
+// renders no field list. The argument it names is asserted instead, so a
+// fixture that starts failing for some other reason stops passing.
+func refusedArgument(names, why string) refusal {
+	return refusal{
+		why: why, status: http.StatusUnprocessableEntity, code: "validation_error", names: names,
+	}
 }
 
 // malformedRoutedID is the refusal every routed operation shares: the id in the
@@ -46,7 +101,7 @@ type unrunnableCall struct {
 // answers the same not-found for it.
 func malformedRoutedID(method, collection string) unrunnableCall {
 	return unrunnableCall{
-		refusedFor: "the routed id is not a uuid, so it names no record the handler could act on",
+		refusal: hiddenRow("the routed id is not a uuid, so it names no record the handler could act on"),
 		build: func() (*http.Request, []byte) {
 			return routedFixture(method, "/v1"+collection+"/not-a-uuid", "not-a-uuid", "")
 		},
@@ -66,9 +121,9 @@ func routedFixture(method, path, routedID, body string) (*http.Request, []byte) 
 
 // bodyFixture builds a request for a route that carries no {id}: the body is
 // the whole of what can be wrong.
-func bodyFixture(path, body string) unrunnableCall {
+func bodyFixture(path, body, member string) unrunnableCall {
 	return unrunnableCall{
-		refusedFor: "the body names a member the record type does not accept",
+		refusal: refusedArgument(member, "the body names a member the record type does not accept"),
 		build: func() (*http.Request, []byte) {
 			payload := []byte(body)
 			return httptest.NewRequest(http.MethodPost, path, bytes.NewReader(payload)), payload
@@ -108,30 +163,32 @@ var unrunnableCalls = map[string]unrunnableCall{
 	"mergeOrganization":         malformedRoutedID(http.MethodPost, "/organizations"),
 
 	"updateProject": {
-		refusedFor: "the patch names a member a project has no field for",
+		refusal: refusedArgument("nickname", "the patch names a member a project has no field for"),
 		build: func() (*http.Request, []byte) {
 			return routedFixture(http.MethodPatch, "/v1/projects/"+ids.NewV7().String(),
 				ids.NewV7().String(), `{"nickname":"typo"}`)
 		},
 	},
-	"createProject": bodyFixture("/v1/projects", `{"nickname":"typo"}`),
+	"createProject": bodyFixture("/v1/projects", `{"nickname":"typo"}`, "nickname"),
 
 	"advanceProjectPhase": {
-		refusedFor: "the phase named is outside the contract's ladder",
+		refusal: refusedArgument("vibing", "the phase named is outside the contract's ladder"),
 		build: func() (*http.Request, []byte) {
 			id := ids.NewV7().String()
 			return routedFixture(http.MethodPost, "/v1/projects/"+id+"/advance", id, `{"to_phase":"vibing"}`)
 		},
 	},
 	"promoteLead": {
-		refusedFor: "the trigger named is outside the contract's enum, so no engagement justifies the promotion",
+		refusal: refusedArgument("trigger",
+			"the trigger named is outside the contract's enum, so no engagement justifies the promotion"),
 		build: func() (*http.Request, []byte) {
 			id := ids.NewV7().String()
 			return routedFixture(http.MethodPost, "/v1/leads/"+id+"/promote", id, `{"trigger":"a hunch"}`)
 		},
 	},
 	"bookMeeting": {
-		refusedFor: "the meeting ends before it starts, which the store refuses after the approval is spent",
+		refusal: refusedArgument("end",
+			"the meeting ends before it starts, which the store refuses after the approval is spent"),
 		build: func() (*http.Request, []byte) {
 			body := []byte(`{"start":"2026-08-10T10:00:00Z","end":"2026-08-10T09:00:00Z",` +
 				`"links":[{"entity_type":"deal","entity_id":"019ff000-0000-7000-8000-000000000021"}]}`)
@@ -139,7 +196,7 @@ var unrunnableCalls = map[string]unrunnableCall{
 		},
 	},
 	"sendEmail": {
-		refusedFor: "the send reaches nobody",
+		refusal: refusedArgument("to", "the send reaches nobody"),
 		build: func() (*http.Request, []byte) {
 			id := ids.NewV7().String()
 			return routedFixture(http.MethodPost, "/v1/activities/"+id+"/send-email", id,
@@ -147,7 +204,7 @@ var unrunnableCalls = map[string]unrunnableCall{
 		},
 	},
 	"sendAccountEmail": {
-		refusedFor: "the send reaches nobody",
+		refusal: refusedArgument("to", "the send reaches nobody"),
 		build: func() (*http.Request, []byte) {
 			body := []byte(`{"to":[],"subject":"Q3","body":"hi","consent_purpose":"sales",` +
 				`"links":[{"entity_type":"organization","entity_id":"019ff000-0000-7000-8000-000000000022"}]}`)
@@ -155,7 +212,8 @@ var unrunnableCalls = map[string]unrunnableCall{
 		},
 	},
 	"sendMessage": {
-		refusedFor: "the anchor is not a channel conversation, so no reply can be transmitted through it",
+		refusal: refusedArgument("channel",
+			"the anchor is not a channel conversation, so no reply can be transmitted through it"),
 		build: func() (*http.Request, []byte) {
 			id := ids.NewV7().String()
 			return routedFixture(http.MethodPost, "/v1/activities/"+id+"/send-message", id,
@@ -166,14 +224,15 @@ var unrunnableCalls = map[string]unrunnableCall{
 	// The operand family: the second path segment the router would have bound
 	// is absent, which is the shape a routing defect produces and the one thing
 	// these operations cannot run without.
-	"confirmOrganizationFact":         missingOperand(http.MethodPost, "/v1/organizations/%s/facts//confirm"),
-	"updateOrganizationFact":          missingOperand(http.MethodPatch, "/v1/organizations/%s/facts/"),
-	"confirmOrganizationProfileField": missingOperand(http.MethodPost, "/v1/organizations/%s/profile-fields//confirm"),
-	"updateOrganizationProfileField":  missingOperand(http.MethodPatch, "/v1/organizations/%s/profile-fields/"),
-	"removeProjectStakeholder":        missingOperand(http.MethodDelete, "/v1/projects/%s/stakeholders/"),
+	"confirmOrganizationFact":         missingOperand(http.MethodPost, "/v1/organizations/%s/facts//confirm", "factKey"),
+	"updateOrganizationFact":          missingOperand(http.MethodPatch, "/v1/organizations/%s/facts/", "factKey"),
+	"confirmOrganizationProfileField": missingOperand(http.MethodPost, "/v1/organizations/%s/profile-fields//confirm", "field"),
+	"updateOrganizationProfileField":  missingOperand(http.MethodPatch, "/v1/organizations/%s/profile-fields/", "field"),
+	"removeProjectStakeholder":        missingOperand(http.MethodDelete, "/v1/projects/%s/stakeholders/", "person_id"),
 
 	"setProjectStakeholder": {
-		refusedFor: "the person_id in the body is not a uuid, so the edge names no person",
+		refusal: namedMember("person_id", "invalid",
+			"the person_id in the body is not a uuid, so the edge names no person"),
 		build: func() (*http.Request, []byte) {
 			id := ids.NewV7().String()
 			return routedFixture(http.MethodPut, "/v1/projects/"+id+"/stakeholders", id,
@@ -184,9 +243,10 @@ var unrunnableCalls = map[string]unrunnableCall{
 
 // missingOperand builds a request whose routed {id} is well formed and whose
 // SECOND path parameter was never bound.
-func missingOperand(method, path string) unrunnableCall {
+func missingOperand(method, path, operand string) unrunnableCall {
 	return unrunnableCall{
-		refusedFor: "the operand the route carries is absent, and the operation has nothing to act on without it",
+		refusal: namedMember(operand, "missing",
+			"the operand the route carries is absent, and the operation has nothing to act on without it"),
 		build: func() (*http.Request, []byte) {
 			id := ids.NewV7().String()
 			return routedFixture(method, strings.Replace(path, "%s", id, 1), id, "")
@@ -263,10 +323,57 @@ func assertRefusedBeforeStaging(t *testing.T, op string, fixture unrunnableCall)
 
 	if staging.last.Tool != "" {
 		t.Errorf("an approval was staged for a call refused because %s — the human's yes is spent reaching a "+
-			"refusal this door could have made first", fixture.refusedFor)
+			"refusal this door could have made first", fixture.refusal.why)
 	}
-	if rec.Code < http.StatusBadRequest || rec.Code >= http.StatusInternalServerError {
-		t.Errorf("a call refused because %s answered %d; the caller is owed a 4xx naming what to fix, not a "+
-			"server fault", fixture.refusedFor, rec.Code)
+	assertAnsweredAs(t, rec, fixture.refusal)
+}
+
+// assertAnsweredAs holds the answer to the refusal the fixture's reason implies.
+//
+// The status alone is not enough: stageRefusal refuses upstream of the decoder
+// too (a canonical call it cannot hash, a kind with no decision grants), and
+// both of those are 4xx with nothing staged. A fixture that stopped reaching its
+// own reason would pass on either of them while the message above still quoted
+// the reason.
+func assertAnsweredAs(t *testing.T, rec *httptest.ResponseRecorder, want refusal) {
+	t.Helper()
+	var problem struct {
+		Code    string `json:"code"`
+		Detail  string `json:"detail"`
+		Details struct {
+			Errors []struct {
+				Field string `json:"field"`
+				Code  string `json:"code"`
+			} `json:"errors"`
+		} `json:"details"`
 	}
+	if err := json.NewDecoder(rec.Body).Decode(&problem); err != nil {
+		t.Fatalf("the refusal for %s carried no problem body: %v", want.why, err)
+	}
+	if rec.Code != want.status || problem.Code != want.code {
+		t.Fatalf("a call refused because %s answered %d %q, want %d %q — the caller is owed the answer this "+
+			"refusal implies, not merely some refusal", want.why, rec.Code, problem.Code, want.status, want.code)
+	}
+	if want.field != "" && !namesMember(problem.Details.Errors, want.field, want.fieldCode) {
+		t.Errorf("a call refused because %s answered %+v, want the member %q with code %q — a 422 that names "+
+			"no member leaves the caller to guess which argument to fix",
+			want.why, problem.Details.Errors, want.field, want.fieldCode)
+	}
+	if want.names != "" && !strings.Contains(problem.Detail, want.names) {
+		t.Errorf("a call refused because %s answered %q, which does not name %q — the refusal a caller acts "+
+			"on is the one that says which argument was wrong", want.why, problem.Detail, want.names)
+	}
+}
+
+func namesMember(errs []struct {
+	Field string `json:"field"`
+	Code  string `json:"code"`
+}, field, code string,
+) bool {
+	for _, e := range errs {
+		if e.Field == field && e.Code == code {
+			return true
+		}
+	}
+	return false
 }

--- a/backend/internal/compose/agentcommandunrunnable_test.go
+++ b/backend/internal/compose/agentcommandunrunnable_test.go
@@ -165,8 +165,8 @@ var unrunnableCalls = map[string]unrunnableCall{
 	"updateProject": {
 		refusal: refusedArgument("nickname", "the patch names a member a project has no field for"),
 		build: func() (*http.Request, []byte) {
-			return routedFixture(http.MethodPatch, "/v1/projects/"+ids.NewV7().String(),
-				ids.NewV7().String(), `{"nickname":"typo"}`)
+			id := ids.NewV7().String()
+			return routedFixture(http.MethodPatch, "/v1/projects/"+id, id, `{"nickname":"typo"}`)
 		},
 	},
 	"createProject": bodyFixture("/v1/projects", `{"nickname":"typo"}`, "nickname"),

--- a/backend/internal/compose/agentcommandunrunnable_test.go
+++ b/backend/internal/compose/agentcommandunrunnable_test.go
@@ -1,0 +1,272 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// No confirm-first operation stages a call its own executor would refuse.
+//
+// A staged approval spends a human's attention and then their one-shot
+// authority: the redemption is consumed BEFORE the handler runs, so a call the
+// handler was always going to reject on its arguments costs the approval on the
+// way to the refusal, and the agent has to ask again. #982 closed this for the
+// generic verbs one at a time; this is the same obligation, derived over every
+// confirm-first operation the contract declares, so a family that grows one
+// answers here rather than being remembered.
+//
+// Each fixture is a call that is wrong on ARGUMENT grounds alone — nothing
+// about who is asking, nothing about workspace state. The refusal must arrive
+// as a 4xx with nothing staged.
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	chi "github.com/go-chi/chi/v5"
+
+	"github.com/gradionhq/margince/backend/internal/shared/gatekit"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// unrunnableCall is one call an operation's executor would refuse, and the
+// reason it would — stated so a reader can tell a fixture that exercises the
+// refusal from one that merely happens to fail.
+type unrunnableCall struct {
+	refusedFor string
+	build      func() (*http.Request, []byte)
+}
+
+// malformedRoutedID is the refusal every routed operation shares: the id in the
+// path is not one. It is the weakest of the fixtures here and the most widely
+// applicable — an operation whose only argument is the record it names has no
+// other way to be wrong — and it is a real executor refusal, since the handler
+// answers the same not-found for it.
+func malformedRoutedID(method, collection string) unrunnableCall {
+	return unrunnableCall{
+		refusedFor: "the routed id is not a uuid, so it names no record the handler could act on",
+		build: func() (*http.Request, []byte) {
+			return routedFixture(method, "/v1"+collection+"/not-a-uuid", "not-a-uuid", "")
+		},
+	}
+}
+
+// routedFixture builds the request with the router's {id} bound, and nothing
+// else bound: every fixture here that needs a SECOND path parameter is a
+// fixture about that parameter being absent.
+func routedFixture(method, path, routedID, body string) (*http.Request, []byte) {
+	payload := []byte(body)
+	req := httptest.NewRequest(method, path, bytes.NewReader(payload))
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", routedID)
+	return req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx)), payload
+}
+
+// bodyFixture builds a request for a route that carries no {id}: the body is
+// the whole of what can be wrong.
+func bodyFixture(path, body string) unrunnableCall {
+	return unrunnableCall{
+		refusedFor: "the body names a member the record type does not accept",
+		build: func() (*http.Request, []byte) {
+			payload := []byte(body)
+			return httptest.NewRequest(http.MethodPost, path, bytes.NewReader(payload)), payload
+		},
+	}
+}
+
+// unrunnableCalls is one such call per confirm-first operation.
+//
+// Where a family has a SEMANTIC argument refusal — a phase outside the ladder,
+// a booking with no duration, a send addressed to nobody, a patch naming a
+// field the record type has no member for — that is the fixture, because it is
+// the refusal #982 was about: an argument the handler validates and the staging
+// used not to. Where an operation's only argument is the record it names, the
+// id shape is the whole of what can be wrong and the fixture says so.
+var unrunnableCalls = map[string]unrunnableCall{
+	"archiveActivity":      malformedRoutedID(http.MethodDelete, "/activities"),
+	"archiveDeal":          malformedRoutedID(http.MethodDelete, "/deals"),
+	"archiveList":          malformedRoutedID(http.MethodDelete, "/lists"),
+	"archiveOffer":         malformedRoutedID(http.MethodDelete, "/offers"),
+	"archiveOfferTemplate": malformedRoutedID(http.MethodDelete, "/offer-templates"),
+	"archiveOrganization":  malformedRoutedID(http.MethodDelete, "/organizations"),
+	"archivePerson":        malformedRoutedID(http.MethodDelete, "/people"),
+	"archiveProduct":       malformedRoutedID(http.MethodDelete, "/products"),
+	"archiveProject":       malformedRoutedID(http.MethodDelete, "/projects"),
+	"archiveRelationship":  malformedRoutedID(http.MethodDelete, "/relationships"),
+	"archiveSavedView":     malformedRoutedID(http.MethodDelete, "/views"),
+	"archiveTag":           malformedRoutedID(http.MethodDelete, "/tags"),
+
+	"disqualifyLead":            malformedRoutedID(http.MethodDelete, "/leads"),
+	"retireCustomField":         malformedRoutedID(http.MethodPost, "/custom-fields"),
+	"updateCustomFieldOptions":  malformedRoutedID(http.MethodPatch, "/custom-fields"),
+	"updateWebhookSubscription": malformedRoutedID(http.MethodPatch, "/webhook-subscriptions"),
+	"scrapeCompany":             malformedRoutedID(http.MethodPost, "/organizations"),
+	"deepReadCompany":           malformedRoutedID(http.MethodPost, "/organizations"),
+	"mergePerson":               malformedRoutedID(http.MethodPost, "/people"),
+	"mergeOrganization":         malformedRoutedID(http.MethodPost, "/organizations"),
+
+	"updateProject": {
+		refusedFor: "the patch names a member a project has no field for",
+		build: func() (*http.Request, []byte) {
+			return routedFixture(http.MethodPatch, "/v1/projects/"+ids.NewV7().String(),
+				ids.NewV7().String(), `{"nickname":"typo"}`)
+		},
+	},
+	"createProject": bodyFixture("/v1/projects", `{"nickname":"typo"}`),
+
+	"advanceProjectPhase": {
+		refusedFor: "the phase named is outside the contract's ladder",
+		build: func() (*http.Request, []byte) {
+			id := ids.NewV7().String()
+			return routedFixture(http.MethodPost, "/v1/projects/"+id+"/advance", id, `{"to_phase":"vibing"}`)
+		},
+	},
+	"promoteLead": {
+		refusedFor: "the trigger named is outside the contract's enum, so no engagement justifies the promotion",
+		build: func() (*http.Request, []byte) {
+			id := ids.NewV7().String()
+			return routedFixture(http.MethodPost, "/v1/leads/"+id+"/promote", id, `{"trigger":"a hunch"}`)
+		},
+	},
+	"bookMeeting": {
+		refusedFor: "the meeting ends before it starts, which the store refuses after the approval is spent",
+		build: func() (*http.Request, []byte) {
+			body := []byte(`{"start":"2026-08-10T10:00:00Z","end":"2026-08-10T09:00:00Z",` +
+				`"links":[{"entity_type":"deal","entity_id":"019ff000-0000-7000-8000-000000000021"}]}`)
+			return httptest.NewRequest(http.MethodPost, "/v1/bookings", bytes.NewReader(body)), body
+		},
+	},
+	"sendEmail": {
+		refusedFor: "the send reaches nobody",
+		build: func() (*http.Request, []byte) {
+			id := ids.NewV7().String()
+			return routedFixture(http.MethodPost, "/v1/activities/"+id+"/send-email", id,
+				`{"to":[],"subject":"Q3","body":"hi","consent_purpose":"sales"}`)
+		},
+	},
+	"sendAccountEmail": {
+		refusedFor: "the send reaches nobody",
+		build: func() (*http.Request, []byte) {
+			body := []byte(`{"to":[],"subject":"Q3","body":"hi","consent_purpose":"sales",` +
+				`"links":[{"entity_type":"organization","entity_id":"019ff000-0000-7000-8000-000000000022"}]}`)
+			return httptest.NewRequest(http.MethodPost, "/v1/emails", bytes.NewReader(body)), body
+		},
+	},
+	"sendMessage": {
+		refusedFor: "the anchor is not a channel conversation, so no reply can be transmitted through it",
+		build: func() (*http.Request, []byte) {
+			id := ids.NewV7().String()
+			return routedFixture(http.MethodPost, "/v1/activities/"+id+"/send-message", id,
+				`{"body":"hello","consent_purpose":"support"}`)
+		},
+	},
+
+	// The operand family: the second path segment the router would have bound
+	// is absent, which is the shape a routing defect produces and the one thing
+	// these operations cannot run without.
+	"confirmOrganizationFact":         missingOperand(http.MethodPost, "/v1/organizations/%s/facts//confirm"),
+	"updateOrganizationFact":          missingOperand(http.MethodPatch, "/v1/organizations/%s/facts/"),
+	"confirmOrganizationProfileField": missingOperand(http.MethodPost, "/v1/organizations/%s/profile-fields//confirm"),
+	"updateOrganizationProfileField":  missingOperand(http.MethodPatch, "/v1/organizations/%s/profile-fields/"),
+	"removeProjectStakeholder":        missingOperand(http.MethodDelete, "/v1/projects/%s/stakeholders/"),
+
+	"setProjectStakeholder": {
+		refusedFor: "the person_id in the body is not a uuid, so the edge names no person",
+		build: func() (*http.Request, []byte) {
+			id := ids.NewV7().String()
+			return routedFixture(http.MethodPut, "/v1/projects/"+id+"/stakeholders", id,
+				`{"person_id":"not-a-uuid","role":"champion"}`)
+		},
+	},
+}
+
+// missingOperand builds a request whose routed {id} is well formed and whose
+// SECOND path parameter was never bound.
+func missingOperand(method, path string) unrunnableCall {
+	return unrunnableCall{
+		refusedFor: "the operand the route carries is absent, and the operation has nothing to act on without it",
+		build: func() (*http.Request, []byte) {
+			id := ids.NewV7().String()
+			return routedFixture(method, strings.Replace(path, "%s", id, 1), id, "")
+		},
+	}
+}
+
+// noUnrunnableCall names the confirm-first operations with no cheap call an
+// executor would refuse on arguments alone, and why — stated here rather than
+// skipped silently, so the shape of what is NOT covered is readable.
+//
+// Both are creates of a record type whose body the governance seam holds to no
+// shape: agents.createRecordShapes carries the types create_record itself
+// writes, and a create outside it is performed by its own module's handler,
+// which is where its body is validated. The seam has no shape to refuse against
+// (gradionhq/margince-poc-v1#1021 is where those types get one), so any body
+// this test could send would stage — which is a gap to record, not a fixture to
+// fake.
+var noUnrunnableCall = gatekit.Waive(map[string]string{
+	"createCustomField": "the governance seam holds a custom_field body to no declared shape, so every " +
+		"body this gate could send would stage and the refusal it looks for happens in the module's own handler",
+	"createWebhookSubscription": "the governance seam holds a webhook_subscription body to no declared " +
+		"shape, so every body this gate could send would stage and the refusal it looks for happens in the " +
+		"module's own handler",
+})
+
+func TestNoConfirmFirstOperationStagesACallItsExecutorWouldRefuse(t *testing.T) {
+	defer noUnrunnableCall.AssertAllMatched(t)
+	subject := map[string]bool{}
+	for op, route := range agentReachableMutations() {
+		if agentPolicies[route].Tier != tierConfirmationRequired {
+			continue
+		}
+		subject[op] = true
+	}
+	if len(subject) == 0 {
+		t.Fatal("the policy table declares no confirm-first agent-reachable mutation — this gate checked nothing")
+	}
+	for op := range subject {
+		fixture, written := unrunnableCalls[op]
+		if !written {
+			if !noUnrunnableCall.Waived(t, op) {
+				t.Errorf("%s is confirm-first and has neither a call its executor would refuse nor a stated "+
+					"reason there is none — a human's one-shot approval can be spent reaching a refusal the "+
+					"staging could have made first", op)
+			}
+			continue
+		}
+		t.Run(op, func(t *testing.T) {
+			assertRefusedBeforeStaging(t, op, fixture)
+		})
+	}
+	for op := range unrunnableCalls {
+		if !subject[op] {
+			t.Errorf("unrunnableCalls[%q] describes an operation that is not confirm-first, so nothing it "+
+				"asserts is about a staged approval", op)
+		}
+	}
+	for _, op := range noUnrunnableCall.Subjects() {
+		if _, both := unrunnableCalls[op]; both {
+			t.Errorf("%s is both excused and covered by a fixture; the excuse describes a gap that is closed", op)
+		}
+	}
+}
+
+func assertRefusedBeforeStaging(t *testing.T, op string, fixture unrunnableCall) {
+	t.Helper()
+	req, body := fixture.build()
+	staging := &capturingApprovals{}
+	rec := httptest.NewRecorder()
+	pol := agentPolicies[agentReachableMutations()[op]]
+
+	stageRefusal(rec, req, staging, restCommandDeps{records: seamRecord{}, channels: channelKinds{}}, pol, body)
+
+	if staging.last.Tool != "" {
+		t.Errorf("an approval was staged for a call refused because %s — the human's yes is spent reaching a "+
+			"refusal this door could have made first", fixture.refusedFor)
+	}
+	if rec.Code < http.StatusBadRequest || rec.Code >= http.StatusInternalServerError {
+		t.Errorf("a call refused because %s answered %d; the caller is owed a 4xx naming what to fix, not a "+
+			"server fault", fixture.refusedFor, rec.Code)
+	}
+}

--- a/backend/internal/compose/agentgate.go
+++ b/backend/internal/compose/agentgate.go
@@ -87,7 +87,7 @@ func agentGate(reg *agents.Registry, staging agents.Approvals, stages agents.Sta
 				}
 			}
 			admitAgentCall(w, r, next, admissionOutcome{
-				staging: staging, ownership: ownership, records: records, pol: pol, body: body,
+				staging: staging, ownership: ownership, commands: restCommandDeps{records: records}, pol: pol, body: body,
 				err: err, spec: spec, registry: reg,
 			})
 		})
@@ -209,13 +209,13 @@ func prepareAgentGate(w http.ResponseWriter, r *http.Request, reg *agents.Regist
 type admissionOutcome struct {
 	staging   agents.Approvals
 	ownership agents.FieldOwnership
-	// records is the seam a staged call's resolver reads its own target
-	// through, so the target the REST door stages is the one the tool door
-	// would have staged for the same operation.
-	records datasource.SystemOfRecordProvider
-	pol     agentPolicy
-	body    []byte
-	err     error
+	// commands carries what a staged call's own resolver needs to answer for
+	// itself, so the target the REST door stages is the one the tool door would
+	// have staged for the same operation.
+	commands restCommandDeps
+	pol      agentPolicy
+	body     []byte
+	err      error
 	// spec and registry are what the effect below is charged against — the
 	// tool twin this call admitted as, and the surface that owns the counters.
 	spec     mcp.ToolSpec
@@ -246,7 +246,7 @@ func admitAgentCall(w http.ResponseWriter, r *http.Request, next http.Handler, o
 		performed := &effectRecorder{ResponseWriter: w}
 		metered := &servedMeter{ResponseWriter: performed, r: r, reg: outcome.registry, mayRefuse: theEffectAlreadyLanded}
 		if outcome.pol.Tool == "update_record" && !actionShapedUpdateOps[outcome.pol.Op] {
-			splitOrRedeemUpdate(metered, r, next, outcome.staging, outcome.records, outcome.ownership, outcome.pol, outcome.body)
+			splitOrRedeemUpdate(metered, r, next, outcome.staging, outcome.commands, outcome.ownership, outcome.pol, outcome.body)
 		} else {
 			next.ServeHTTP(metered, r)
 		}
@@ -261,7 +261,7 @@ func admitAgentCall(w http.ResponseWriter, r *http.Request, next http.Handler, o
 		// where redeemIfPresented actually forwarded.
 		performed := &effectRecorder{ResponseWriter: w}
 		metered := &servedMeter{ResponseWriter: performed, r: r, reg: outcome.registry, mayRefuse: theEffectAlreadyLanded}
-		ran := stageOrRedeem(metered, r, next, outcome.staging, outcome.records, outcome.pol, outcome.body)
+		ran := stageOrRedeem(metered, r, next, outcome.staging, outcome.commands, outcome.pol, outcome.body)
 		if !ran {
 			return
 		}

--- a/backend/internal/compose/agentgate.go
+++ b/backend/internal/compose/agentgate.go
@@ -21,8 +21,6 @@ package compose
 import (
 	"bytes"
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -458,25 +456,6 @@ func tierInput(ctx context.Context, spec mcp.ToolSpec, pol agentPolicy, deps tie
 	return func() (mcp.TierResolverInput, error) {
 		return resolve(ctx, deps, pol, r, body)
 	}, true
-}
-
-// canonicalRESTCall canonicalizes the request into the bytes both staging
-// and redemption hash: decoding into maps and re-marshaling sorts keys at
-// every depth, so "identical call" is a property of content, not of the
-// client's serialization habits.
-func canonicalRESTCall(op, path string, body []byte) (json.RawMessage, string, error) {
-	var payload any
-	if len(bytes.TrimSpace(body)) > 0 {
-		if err := json.Unmarshal(body, &payload); err != nil {
-			return nil, "", httperr.Validation("body", "invalid_json", "request body must be valid JSON")
-		}
-	}
-	canonical, err := json.Marshal(map[string]any{"operation": op, "path": path, "body": payload})
-	if err != nil {
-		return nil, "", err
-	}
-	sum := sha256.Sum256(canonical)
-	return canonical, hex.EncodeToString(sum[:]), nil
 }
 
 func mutatingMethod(method string) bool {

--- a/backend/internal/compose/agentgate.go
+++ b/backend/internal/compose/agentgate.go
@@ -21,7 +21,6 @@ package compose
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -34,7 +33,6 @@ import (
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
 	"github.com/gradionhq/margince/backend/internal/platform/httperr"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
-	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/mcp"
@@ -47,7 +45,10 @@ const approvalTokenHeader = "X-Approval-Token"
 const maxGatedBody = 1 << 20
 
 func agentGate(reg *agents.Registry, staging agents.Approvals, stages agents.StageResolver, records datasource.SystemOfRecordProvider, ownership agents.FieldOwnership, gate *auth.Gate) func(http.Handler) http.Handler {
-	deps := tierDeps{stages: stages, records: records, ownership: ownership}
+	// ONE set of read-side dependencies for both questions this door asks of a
+	// command: what tier it runs at, and what an approval of it would bind to.
+	// They were two structs while the tier had its own table to feed.
+	deps := restCommandDeps{records: records, stages: stages, channels: channelKinds{}}
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			ctx := r.Context()
@@ -88,8 +89,7 @@ func agentGate(reg *agents.Registry, staging agents.Approvals, stages agents.Sta
 			}
 			admitAgentCall(w, r, next, admissionOutcome{
 				staging: staging, ownership: ownership, pol: pol, body: body,
-				commands: restCommandDeps{records: records, stages: stages, channels: channelKinds{}},
-				err:      err, spec: spec, registry: reg,
+				commands: deps, err: err, spec: spec, registry: reg,
 			})
 		})
 	}
@@ -157,7 +157,7 @@ func refusedAsHumanOnly(w http.ResponseWriter, r *http.Request) bool {
 // onto the request for the downstream handler), and the lazy tier-resolver
 // input. It writes the refusal and reports ok=false when the route is
 // unknown, human-only, unresolvable, or over the body cap (fail-closed).
-func prepareAgentGate(w http.ResponseWriter, r *http.Request, reg *agents.Registry, deps tierDeps) (mcp.ToolSpec, func() (mcp.TierResolverInput, error), agentPolicy, []byte, bool) {
+func prepareAgentGate(w http.ResponseWriter, r *http.Request, reg *agents.Registry, deps restCommandDeps) (mcp.ToolSpec, func() (mcp.TierResolverInput, error), agentPolicy, []byte, bool) {
 	ctx := r.Context()
 	// The generated table is keyed by the chi route pattern the contract
 	// router registered; a mutating route it doesn't know is refused, never
@@ -196,13 +196,7 @@ func prepareAgentGate(w http.ResponseWriter, r *http.Request, reg *agents.Regist
 		return mcp.ToolSpec{}, nil, agentPolicy{}, nil, false
 	}
 	r.Body = io.NopCloser(bytes.NewReader(body))
-	resolve, ok := tierInput(ctx, spec, pol, deps, r, body)
-	if !ok {
-		httperr.Write(w, r, fmt.Errorf(
-			"agent gate: %s: no REST tier resolver for dynamic tool %s: %w", pol.Op, pol.Tool, apperrors.ErrPermissionDenied))
-		return mcp.ToolSpec{}, nil, agentPolicy{}, nil, false
-	}
-	return spec, resolve, pol, body, true
+	return spec, tierInput(ctx, spec, pol, deps, r, body), pol, body, true
 }
 
 // admissionOutcome carries the result of the autonomy gate's Admit call
@@ -378,89 +372,38 @@ func operationSpec(pol agentPolicy, reg *agents.Registry) (spec mcp.ToolSpec, re
 	return spec, true, true
 }
 
-// tierDeps carries the read-side dependencies the dynamic REST tier
-// resolvers consult.
-type tierDeps struct {
-	stages agents.StageResolver
-	// records reads the deal a move is about, so the tier gate can see the stage
-	// it is moving FROM. Without it this door could only judge the destination,
-	// which is how a reopen came to be auto-execute.
-	records   datasource.SystemOfRecordProvider
-	ownership agents.FieldOwnership
-}
-
-// dynamicTierInputs maps each dynamic tool onto the resolver that reads
-// its tier decision out of the tool's REST body shape. The invariant: a
-// dynamic tool without an entry here has no REST twin the gate knows how
-// to interpret — its tier question cannot be answered, so tierInput
-// reports a miss and the caller refuses the request (fail-closed).
-var dynamicTierInputs = map[string]func(ctx context.Context, deps tierDeps, pol agentPolicy, r *http.Request, body []byte) (mcp.TierResolverInput, error){
-	"advance_deal": advanceDealTierInput,
-}
-
-// advanceDealTierInput: 🟢/🟡 turns on whether EITHER endpoint of the move is a
-// closing stage, so the resolver needs both the destination's semantic and the
-// one the deal is currently in.
-func advanceDealTierInput(ctx context.Context, deps tierDeps, _ agentPolicy, r *http.Request, body []byte) (mcp.TierResolverInput, error) {
-	var args struct {
-		ToStageID ids.UUID `json:"to_stage_id"`
-	}
-	// THREE faults, three answers, and the order matters because each later check
-	// presumes the earlier one passed.
-	//
-	// json.Unmarshal alone cannot tell them apart: it fails identically for a body
-	// that is not JSON and for a body that is perfectly good JSON carrying a
-	// to_stage_id the UUID decoder refuses. Answering "not readable JSON" to the
-	// second sends the caller hunting a syntax error that is not there, while the
-	// real fault — a value they can see and fix — goes unnamed.
-	if !json.Valid(body) {
-		// malformed_json, the code httperr.Decode answers on the session half of
-		// this same route — one mistake must not carry two machine codes keyed on
-		// which credential the caller presented.
-		return mcp.TierResolverInput{}, httperr.Validation("body", "malformed_json",
-			"the request body is not readable JSON")
-	}
-	if err := json.Unmarshal(body, &args); err != nil {
-		// Valid JSON the shape refuses: a non-object, or a to_stage_id that is not
-		// a UUID string. Naming the field is right for both — the fix is to send an
-		// object carrying a canonical UUID there.
-		return mcp.TierResolverInput{}, httperr.Validation("to_stage_id", "invalid",
-			"to_stage_id must be a canonical UUID string on a JSON object body")
-	}
-	// The omission goes through the one implementation, so a passport reaching
-	// this gate and a session reaching advanceDealInput read the SAME sentence.
-	// The gate resolves the tier before the handler runs, so without this the
-	// rule had two spellings on the one field U3 unified.
-	if err := httperr.RequireBodyID("to_stage_id", args.ToStageID); err != nil {
-		return mcp.TierResolverInput{}, err
-	}
-	// The deal is named by the ROUTE, not the body — /deals/{id}/advance — so it
-	// is read from there before the shared builder can resolve both endpoints.
-	dealID, err := ids.Parse(chi.URLParam(r, "id"))
-	if err != nil {
-		return mcp.TierResolverInput{}, httperr.Validation("id", "invalid",
-			"the deal id in the path must be a canonical UUID string")
-	}
-	// The SAME builder the MCP registry calls. Two spellings of "what the tier
-	// gate is shown" is how one door came to judge a deal move by its
-	// destination alone while the other judged both ends.
-	return agents.DealMoveTierInput(ctx, deps.records, deps.stages, dealID, args.ToStageID, body)
-}
-
-// tierInput supplies the lazy TierResolverInput for the admitted spec:
-// static tiers pass the body through; dynamic tiers dispatch through
-// dynamicTierInputs and report a miss for the caller to refuse.
-func tierInput(ctx context.Context, spec mcp.ToolSpec, pol agentPolicy, deps tierDeps, r *http.Request, body []byte) (func() (mcp.TierResolverInput, error), bool) {
+// tierInput supplies the lazy TierResolverInput for the admitted spec.
+//
+// A STATIC tier passes the body through: nothing is read to decide it, so there
+// is no record for the input to describe. A DYNAMIC tier is answered by the
+// operation's own command — the decode restCommands already performs is the one
+// parse of this request, and the call it produces answers what the tier gate is
+// shown (agents.DynamicTierInput). A second table keyed by the same operations
+// used to answer this, and two tables free to disagree is how one door came to
+// judge a deal move by its destination alone while the other judged both ends.
+//
+// Both faults the dynamic path can meet are answered by the CLOSURE rather than
+// by a miss the caller reports: an operation with no decoder and a command that
+// answers no tier are equally "this door cannot tell whether the call needs a
+// human", and the gate refuses on the error rather than admitting at a tier
+// nobody resolved.
+func tierInput(ctx context.Context, spec mcp.ToolSpec, pol agentPolicy, deps restCommandDeps, r *http.Request, body []byte) func() (mcp.TierResolverInput, error) {
 	if spec.Tier != mcp.TierDynamic {
-		return func() (mcp.TierResolverInput, error) { return mcp.TierResolverInput{Args: body}, nil }, true
-	}
-	resolve, known := dynamicTierInputs[pol.Tool]
-	if !known {
-		return nil, false
+		return func() (mcp.TierResolverInput, error) { return mcp.TierResolverInput{Args: body}, nil }
 	}
 	return func() (mcp.TierResolverInput, error) {
-		return resolve(ctx, deps, pol, r, body)
-	}, true
+		decode, described := restCommands[pol.Op]
+		if !described {
+			return mcp.TierResolverInput{}, fmt.Errorf(
+				"agent gate: %s decodes into no governed call, so nothing can say whether it needs a human: %w",
+				pol.Op, apperrors.ErrPermissionDenied)
+		}
+		call, err := decode(pol, deps, r, body)
+		if err != nil {
+			return mcp.TierResolverInput{}, err
+		}
+		return agents.DynamicTierInput(ctx, call, body)
+	}
 }
 
 func mutatingMethod(method string) bool {

--- a/backend/internal/compose/agentgate.go
+++ b/backend/internal/compose/agentgate.go
@@ -218,36 +218,17 @@ type admissionOutcome struct {
 }
 
 // admitAgentCall dispatches a mutating agent call on the admission outcome:
-// admitted 🟢 work runs (a field-shaped update_record edit routes through
-// the per-field owner check first); a 🟡 refusal stages or redeems the
+// admitted 🟢 work runs (runAutoExecuted); a 🟡 refusal stages or redeems the
 // approval; any other admission error is surfaced as-is.
+//
+// BOTH admitted arms redeem an X-Approval-Token the call presents, and each
+// charges its own call ceiling once — the arms differ only in where that charge
+// falls, because only one of them has a human's approval already committed
+// behind it.
 func admitAgentCall(w http.ResponseWriter, r *http.Request, next http.Handler, outcome admissionOutcome) {
 	switch {
 	case outcome.err == nil:
-		if !pinAdmittedWrite(w, r) {
-			return
-		}
-		// The effect is charged on BOTH arms — the field split forwards to the
-		// same handler through its own path — and on NEITHER when the handler
-		// refused. A quota counts what an agent did, so a rejected mutation that
-		// spent a write would let a caller exhaust its own allowance on requests
-		// that changed nothing, which is a bound nobody wrote.
-		// The meter sits OUTSIDE the recorder, so the handler's WriteJSON finds
-		// it by a plain assertion while the recorder still sees every status.
-		// A mutation that answers with the row it changed handed over a record,
-		// and the MCP door charges that record at chargeAnswer whatever the tool
-		// kind — a read-back free on one door and charged on the other is the
-		// same asymmetry this gate exists to close.
-		performed := &effectRecorder{ResponseWriter: w}
-		metered := &servedMeter{ResponseWriter: performed, r: r, reg: outcome.registry, mayRefuse: theEffectAlreadyLanded}
-		if outcome.pol.Tool == "update_record" && !actionShapedUpdateOps[outcome.pol.Op] {
-			splitOrRedeemUpdate(metered, r, next, outcome.staging, outcome.commands, outcome.ownership, outcome.pol, outcome.body)
-		} else {
-			next.ServeHTTP(metered, r)
-		}
-		if performed.done() {
-			outcome.registry.ChargeEffect(r.Context(), outcome.spec)
-		}
+		runAutoExecuted(w, r, next, outcome)
 	case !errors.Is(outcome.err, apperrors.ErrRequiresApproval) || outcome.staging == nil:
 		httperr.Write(w, r, outcome.err)
 	default:
@@ -269,30 +250,105 @@ func admitAgentCall(w http.ResponseWriter, r *http.Request, next http.Handler, o
 	}
 }
 
-// pinAdmittedWrite conditions an auto-executed agent write on the record state
-// its tier was decided from, by forwarding the gate's pin as the request's own
-// If-Match.
+// runAutoExecuted dispatches a call the gate admitted at the auto-execute tier.
 //
-// This is redeemIfPresented's forward (agentgatestaging.go) one tier down, and
-// for the same reason: the gate resolved a dynamic tier by READING the record,
-// that read commits before the handler's transaction opens, and the agent
-// controls both sides of the window — its own 🟢 call can close a deal between
-// the two. Moving the compare inside the transaction that mutates is what makes
-// a record that changed lose to the version check instead of to timing.
+// An X-Approval-Token on such a call is CONSUMED, whatever tool it names. A
+// staged 🟡 call can resolve 🟢 on its retry — the record moved, or the
+// per-field split staged an otherwise auto-execute patch — and the asserted
+// authority is then still an assertion: left unread, the approval stays pending
+// in a human's inbox for work that already happened, and an invalid or replayed
+// token is accepted by being ignored. The MCP door has always redeemed on this
+// arm (registry.go, runClaimed); this door redeemed for update_record alone
+// (gradionhq/margince-poc-v1#812).
 //
-// A caller that sent its own If-Match keeps it — but only if it names the
-// version the gate read, and that is CHECKED. The caller controls the header,
-// so a version the gate never saw is a version nothing proved: a caller naming
-// the version the racing close will PRODUCE walks straight through, because the
-// store's compare then passes on precisely the record the tier decision does not
-// describe. Preferring the caller unchecked would turn a coin-toss race into an
-// armable one. A disagreement is answered as skew, which is also what a caller
-// holding a genuinely stale version already gets, one layer down.
+// A REDEEMED call goes straight to the handler: it carries exactly the change a
+// human released, whose identity the diff_hash already bound, so re-running the
+// per-field ownership split over it would stage a second approval for the
+// overwrite that was just approved.
+func runAutoExecuted(w http.ResponseWriter, r *http.Request, next http.Handler, outcome admissionOutcome) {
+	redemption, redeemed, ok := consumePresentedToken(w, r, outcome.staging, outcome.pol, outcome.body)
+	if redeemed && !ok {
+		return
+	}
+	if !pinAutoExecutedWrite(w, r, redemption) {
+		return
+	}
+	if redeemed {
+		// WithContext shares the header map the pin was just set on, so the
+		// released marker and the precondition travel together.
+		r = r.WithContext(redemption.released) //nolint:contextcheck // released is derived from r.Context() inside consumePresentedToken
+	}
+	// The effect is charged on BOTH arms — the field split forwards to the
+	// same handler through its own path — and on NEITHER when the handler
+	// refused. A quota counts what an agent did, so a rejected mutation that
+	// spent a write would let a caller exhaust its own allowance on requests
+	// that changed nothing, which is a bound nobody wrote.
+	// The meter sits OUTSIDE the recorder, so the handler's WriteJSON finds
+	// it by a plain assertion while the recorder still sees every status.
+	// A mutation that answers with the row it changed handed over a record,
+	// and the MCP door charges that record at chargeAnswer whatever the tool
+	// kind — a read-back free on one door and charged on the other is the
+	// same asymmetry this gate exists to close.
+	//
+	// The CALL itself is charged once, before this arm is reached
+	// (ChargeAdmittedCall in agentGate), and a redemption here adds nothing on
+	// top: one call, one charge, whichever arm it took — which is the rule the
+	// MCP door keeps by skipping its own pre-dispatch charge exactly when an
+	// approval_id is presented and charging at the redemption instead.
+	performed := &effectRecorder{ResponseWriter: w}
+	metered := &servedMeter{ResponseWriter: performed, r: r, reg: outcome.registry, mayRefuse: theEffectAlreadyLanded}
+	if !redeemed && outcome.pol.Tool == toolUpdateRecord && !actionShapedUpdateOps[outcome.pol.Op] {
+		splitHumanOwnedUpdate(metered, r, next, outcome.staging, outcome.commands, outcome.ownership, outcome.pol, outcome.body)
+	} else {
+		next.ServeHTTP(metered, r)
+	}
+	if performed.done() {
+		outcome.registry.ChargeEffect(r.Context(), outcome.spec)
+	}
+}
+
+// pinAutoExecutedWrite conditions an auto-executed agent write on the version
+// the decision it runs under was taken at, by forwarding that version as the
+// request's own If-Match.
+//
+// Three places establish a version, and this is the order of who established it
+// — the same precedence agents.pinForWrite applies on the MCP door.
+//
+// The CALLER's pin wins when it supplied one, and only when it names the version
+// this gate proved something about, which is CHECKED. The caller controls the
+// header, so a version nothing here read is a version nothing proved: a caller
+// naming the version the racing close will PRODUCE walks straight through,
+// because the store's compare then passes on precisely the record the decision
+// does not describe. Preferring the caller unchecked would turn a coin-toss race
+// into an armable one.
+//
+// The RELEASED pin comes next, and the ADMITTED pin last, for the same reason
+// each exists: both readings commit before the handler's own transaction opens,
+// and the agent controls both sides of that window — its own 🟢 call can close a
+// deal between the two. Moving the compare inside the transaction that mutates
+// is what makes a record that changed lose to the version check instead of to
+// timing.
+//
+// Where the two DISAGREE the answer is skew rather than a choice between them.
+// The disagreement means the row moved between the human's approval and this
+// call, so neither version is the one they judged, and silently preferring
+// either would run the write against a state nothing authorized.
 //
 // It reports whether the request may proceed; a refusal has already been
 // written.
-func pinAdmittedWrite(w http.ResponseWriter, r *http.Request) bool {
-	version, pinned := auth.AutoExecutePin(r.Context())
+func pinAutoExecutedWrite(w http.ResponseWriter, r *http.Request, redemption tokenRedemption) bool {
+	admitted, gateRead := auth.AutoExecutePin(r.Context())
+	if redemption.pinned && gateRead && redemption.pin != admitted {
+		httperr.Write(w, r, fmt.Errorf(
+			"the approval released this record at version %d and the tier gate read it at %d — it moved "+
+				"between the two, so neither is the version that was judged; re-read it and retry: %w",
+			redemption.pin, admitted, apperrors.ErrVersionSkew))
+		return false
+	}
+	version, pinned := admitted, gateRead
+	if redemption.pinned {
+		version, pinned = redemption.pin, true
+	}
 	if !pinned {
 		return true
 	}
@@ -306,7 +362,7 @@ func pinAdmittedWrite(w http.ResponseWriter, r *http.Request) bool {
 			return true
 		}
 		httperr.Write(w, r, fmt.Errorf(
-			"If-Match %s is not the version this record was read at (%d) — re-read it and retry: %w",
+			"If-Match %s is not the version this call was authorized against (%d) — re-read it and retry: %w",
 			caller, version, apperrors.ErrVersionSkew))
 		return false
 	}

--- a/backend/internal/compose/agentgate.go
+++ b/backend/internal/compose/agentgate.go
@@ -87,8 +87,9 @@ func agentGate(reg *agents.Registry, staging agents.Approvals, stages agents.Sta
 				}
 			}
 			admitAgentCall(w, r, next, admissionOutcome{
-				staging: staging, ownership: ownership, commands: restCommandDeps{records: records}, pol: pol, body: body,
-				err: err, spec: spec, registry: reg,
+				staging: staging, ownership: ownership, pol: pol, body: body,
+				commands: restCommandDeps{records: records, stages: stages, channels: channelKinds{}},
+				err:      err, spec: spec, registry: reg,
 			})
 		})
 	}

--- a/backend/internal/compose/agentgate.go
+++ b/backend/internal/compose/agentgate.go
@@ -87,7 +87,7 @@ func agentGate(reg *agents.Registry, staging agents.Approvals, stages agents.Sta
 				}
 			}
 			admitAgentCall(w, r, next, admissionOutcome{
-				staging: staging, ownership: ownership, pol: pol, body: body,
+				staging: staging, ownership: ownership, records: records, pol: pol, body: body,
 				err: err, spec: spec, registry: reg,
 			})
 		})
@@ -209,9 +209,13 @@ func prepareAgentGate(w http.ResponseWriter, r *http.Request, reg *agents.Regist
 type admissionOutcome struct {
 	staging   agents.Approvals
 	ownership agents.FieldOwnership
-	pol       agentPolicy
-	body      []byte
-	err       error
+	// records is the seam a staged call's resolver reads its own target
+	// through, so the target the REST door stages is the one the tool door
+	// would have staged for the same operation.
+	records datasource.SystemOfRecordProvider
+	pol     agentPolicy
+	body    []byte
+	err     error
 	// spec and registry are what the effect below is charged against — the
 	// tool twin this call admitted as, and the surface that owns the counters.
 	spec     mcp.ToolSpec
@@ -242,7 +246,7 @@ func admitAgentCall(w http.ResponseWriter, r *http.Request, next http.Handler, o
 		performed := &effectRecorder{ResponseWriter: w}
 		metered := &servedMeter{ResponseWriter: performed, r: r, reg: outcome.registry, mayRefuse: theEffectAlreadyLanded}
 		if outcome.pol.Tool == "update_record" && !actionShapedUpdateOps[outcome.pol.Op] {
-			splitOrRedeemUpdate(metered, r, next, outcome.staging, outcome.ownership, outcome.pol, outcome.body)
+			splitOrRedeemUpdate(metered, r, next, outcome.staging, outcome.records, outcome.ownership, outcome.pol, outcome.body)
 		} else {
 			next.ServeHTTP(metered, r)
 		}
@@ -257,7 +261,7 @@ func admitAgentCall(w http.ResponseWriter, r *http.Request, next http.Handler, o
 		// where redeemIfPresented actually forwarded.
 		performed := &effectRecorder{ResponseWriter: w}
 		metered := &servedMeter{ResponseWriter: performed, r: r, reg: outcome.registry, mayRefuse: theEffectAlreadyLanded}
-		ran := stageOrRedeem(metered, r, next, outcome.staging, outcome.pol, outcome.body)
+		ran := stageOrRedeem(metered, r, next, outcome.staging, outcome.records, outcome.pol, outcome.body)
 		if !ran {
 			return
 		}

--- a/backend/internal/compose/agentgate.go
+++ b/backend/internal/compose/agentgate.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strconv"
 
 	"github.com/go-chi/chi/v5"
 
@@ -75,13 +74,20 @@ func agentGate(reg *agents.Registry, staging agents.Approvals, stages agents.Sta
 			//
 			// Charged where the MCP door charges: the ceiling before anything
 			// happens (and refusing what it cannot count), the act after it has.
-			// Charged where the call is known to RUN. A plainly-admitted call is
-			// charged here, before anything happens, and may still be refused if
-			// it cannot be counted. A 🟡 retry is charged after its token is
-			// redeemed (stageOrRedeem) — counting it here would let a caller
-			// suspend its own Passport with malformed or replayed tokens that
-			// open nothing.
-			if err == nil {
+			// Charged where the call is known to RUN, which is why the condition
+			// below is the one the MCP door applies (registry.go: `err == nil &&
+			// res.ApprovalID.IsZero()`) spelled for this transport.
+			//
+			// A call asserting an approval is NOT charged here, at EITHER tier.
+			// Its token may be malformed, replayed or expired, and such a call
+			// runs nothing — counting it would let a caller suspend its own
+			// Passport by looping a token that opens nothing, since exhausting
+			// MCP-SESS-CALLS is what suspends it for the window. Both arms charge
+			// after the redemption succeeds instead (ChargeRedeemedCall, in
+			// runAutoExecuted and in admitAgentCall's 🟡 default), where the
+			// charge is absorbed rather than refused because the human's approval
+			// has committed by then.
+			if err == nil && presentedApprovalToken(r) == "" {
 				if chargeErr := reg.ChargeAdmittedCall(ctx, spec); chargeErr != nil {
 					httperr.Write(w, r, chargeErr)
 					return
@@ -248,126 +254,6 @@ func admitAgentCall(w http.ResponseWriter, r *http.Request, next http.Handler, o
 			outcome.registry.ChargeEffect(r.Context(), outcome.spec)
 		}
 	}
-}
-
-// runAutoExecuted dispatches a call the gate admitted at the auto-execute tier.
-//
-// An X-Approval-Token on such a call is CONSUMED, whatever tool it names. A
-// staged 🟡 call can resolve 🟢 on its retry — the record moved, or the
-// per-field split staged an otherwise auto-execute patch — and the asserted
-// authority is then still an assertion: left unread, the approval stays pending
-// in a human's inbox for work that already happened, and an invalid or replayed
-// token is accepted by being ignored. The MCP door has always redeemed on this
-// arm (registry.go, runClaimed); this door redeemed for update_record alone
-// (gradionhq/margince-poc-v1#812).
-//
-// A REDEEMED call goes straight to the handler: it carries exactly the change a
-// human released, whose identity the diff_hash already bound, so re-running the
-// per-field ownership split over it would stage a second approval for the
-// overwrite that was just approved.
-func runAutoExecuted(w http.ResponseWriter, r *http.Request, next http.Handler, outcome admissionOutcome) {
-	redemption, redeemed, ok := consumePresentedToken(w, r, outcome.staging, outcome.pol, outcome.body)
-	if redeemed && !ok {
-		return
-	}
-	if !pinAutoExecutedWrite(w, r, redemption) {
-		return
-	}
-	if redeemed {
-		// WithContext shares the header map the pin was just set on, so the
-		// released marker and the precondition travel together.
-		r = r.WithContext(redemption.released) //nolint:contextcheck // released is derived from r.Context() inside consumePresentedToken
-	}
-	// The effect is charged on BOTH arms — the field split forwards to the
-	// same handler through its own path — and on NEITHER when the handler
-	// refused. A quota counts what an agent did, so a rejected mutation that
-	// spent a write would let a caller exhaust its own allowance on requests
-	// that changed nothing, which is a bound nobody wrote.
-	// The meter sits OUTSIDE the recorder, so the handler's WriteJSON finds
-	// it by a plain assertion while the recorder still sees every status.
-	// A mutation that answers with the row it changed handed over a record,
-	// and the MCP door charges that record at chargeAnswer whatever the tool
-	// kind — a read-back free on one door and charged on the other is the
-	// same asymmetry this gate exists to close.
-	//
-	// The CALL itself is charged once, before this arm is reached
-	// (ChargeAdmittedCall in agentGate), and a redemption here adds nothing on
-	// top: one call, one charge, whichever arm it took — which is the rule the
-	// MCP door keeps by skipping its own pre-dispatch charge exactly when an
-	// approval_id is presented and charging at the redemption instead.
-	performed := &effectRecorder{ResponseWriter: w}
-	metered := &servedMeter{ResponseWriter: performed, r: r, reg: outcome.registry, mayRefuse: theEffectAlreadyLanded}
-	if !redeemed && outcome.pol.Tool == toolUpdateRecord && !actionShapedUpdateOps[outcome.pol.Op] {
-		splitHumanOwnedUpdate(metered, r, next, outcome.staging, outcome.commands, outcome.ownership, outcome.pol, outcome.body)
-	} else {
-		next.ServeHTTP(metered, r)
-	}
-	if performed.done() {
-		outcome.registry.ChargeEffect(r.Context(), outcome.spec)
-	}
-}
-
-// pinAutoExecutedWrite conditions an auto-executed agent write on the version
-// the decision it runs under was taken at, by forwarding that version as the
-// request's own If-Match.
-//
-// Three places establish a version, and this is the order of who established it
-// — the same precedence agents.pinForWrite applies on the MCP door.
-//
-// The CALLER's pin wins when it supplied one, and only when it names the version
-// this gate proved something about, which is CHECKED. The caller controls the
-// header, so a version nothing here read is a version nothing proved: a caller
-// naming the version the racing close will PRODUCE walks straight through,
-// because the store's compare then passes on precisely the record the decision
-// does not describe. Preferring the caller unchecked would turn a coin-toss race
-// into an armable one.
-//
-// The RELEASED pin comes next, and the ADMITTED pin last, for the same reason
-// each exists: both readings commit before the handler's own transaction opens,
-// and the agent controls both sides of that window — its own 🟢 call can close a
-// deal between the two. Moving the compare inside the transaction that mutates
-// is what makes a record that changed lose to the version check instead of to
-// timing.
-//
-// Where the two DISAGREE the answer is skew rather than a choice between them.
-// The disagreement means the row moved between the human's approval and this
-// call, so neither version is the one they judged, and silently preferring
-// either would run the write against a state nothing authorized.
-//
-// It reports whether the request may proceed; a refusal has already been
-// written.
-func pinAutoExecutedWrite(w http.ResponseWriter, r *http.Request, redemption tokenRedemption) bool {
-	admitted, gateRead := auth.AutoExecutePin(r.Context())
-	if redemption.pinned && gateRead && redemption.pin != admitted {
-		httperr.Write(w, r, fmt.Errorf(
-			"the approval released this record at version %d and the tier gate read it at %d — it moved "+
-				"between the two, so neither is the version that was judged; re-read it and retry: %w",
-			redemption.pin, admitted, apperrors.ErrVersionSkew))
-		return false
-	}
-	version, pinned := admitted, gateRead
-	if redemption.pinned {
-		version, pinned = redemption.pin, true
-	}
-	if !pinned {
-		return true
-	}
-	if caller := r.Header.Get("If-Match"); caller != "" {
-		// Compared as the numbers they are: the contract's If-Match is a bare
-		// integer version, and two spellings of one number must not read as
-		// disagreement. A caller header this parser refuses is left for the
-		// handler's own IfMatchVersion to answer, which is where that message
-		// already lives.
-		if got, err := strconv.ParseInt(caller, 10, 64); err != nil || got == version {
-			return true
-		}
-		httperr.Write(w, r, fmt.Errorf(
-			"If-Match %s is not the version this call was authorized against (%d) — re-read it and retry: %w",
-			caller, version, apperrors.ErrVersionSkew))
-		return false
-	}
-	r.Header.Set("If-Match", strconv.FormatInt(version, 10))
-	return true
 }
 
 // effectRecorder answers whether the handler behind this door actually

--- a/backend/internal/compose/agentgate_dealreopen_test.go
+++ b/backend/internal/compose/agentgate_dealreopen_test.go
@@ -17,25 +17,40 @@ package compose
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/go-chi/chi/v5"
 
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/mcp"
 )
+
+// advanceTierInput resolves the tier input the REST door actually builds for a
+// deal move: through tierInput, against the real advance_deal policy and the
+// real registry spec, so what these assert is what the middleware produces
+// rather than what a hand-picked resolver would.
+func advanceTierInput(t *testing.T, deps restCommandDeps, r *http.Request, body []byte) (mcp.TierResolverInput, error) {
+	t.Helper()
+	_, spec := advanceSpec(t, deps)
+	if spec.Tier != mcp.TierDynamic {
+		t.Fatalf("advance_deal resolved a %v spec — the dynamic path these assert about is not the one this door takes", spec.Tier)
+	}
+	return tierInput(r.Context(), spec, agentPolicies["POST /v1/deals/{id}/advance"], deps, r, body)()
+}
 
 func TestTheRESTDoorResolvesTheTierFromBothEndpointsToo(t *testing.T) {
 	deal, current, target := ids.NewV7(), ids.NewV7(), ids.NewV7()
-	deps := tierDeps{
+	deps := restCommandDeps{
 		stages:  reopenStages{semantics: map[ids.UUID]string{current: "won", target: "open"}},
 		records: reopenRecords{stageID: current},
 	}
 
-	in, err := advanceDealTierInput(context.Background(), deps, agentPolicy{},
-		requestForDeal(t, deal), []byte(`{"to_stage_id":"`+target.String()+`"}`))
+	in, err := advanceTierInput(t, deps, requestForDeal(t, deal), []byte(`{"to_stage_id":"`+target.String()+`"}`))
 	if err != nil {
 		t.Fatalf("resolving the tier input: %v", err)
 	}
@@ -52,10 +67,46 @@ func TestTheRESTDoorResolvesTheTierFromBothEndpointsToo(t *testing.T) {
 // something that is not an id is refused as the caller's mistake rather than
 // resolved against the zero deal.
 func TestTheRESTDoorRefusesAPathThatNamesNoDeal(t *testing.T) {
-	deps := tierDeps{stages: reopenStages{}, records: reopenRecords{}}
-	if _, err := advanceDealTierInput(context.Background(), deps, agentPolicy{},
-		requestForDealRaw(t, "not-a-uuid"), []byte(`{"to_stage_id":"`+ids.NewV7().String()+`"}`)); err == nil {
-		t.Error("a path naming no deal was resolved rather than refused")
+	deps := restCommandDeps{stages: reopenStages{}, records: reopenRecords{}}
+	_, err := advanceTierInput(t, deps, requestForDealRaw(t, "not-a-uuid"),
+		[]byte(`{"to_stage_id":"`+ids.NewV7().String()+`"}`))
+	if !errors.Is(err, apperrors.ErrNotFound) {
+		t.Errorf("a path naming no deal resolved to %v, want the existence-hiding refusal every other "+
+			"decoder on this door gives a routed id it cannot read", err)
+	}
+}
+
+// A dynamic tier the command seam cannot answer is REFUSED, never admitted at
+// some default. The pairing here is the runtime disagreement the refusal exists
+// for: advance_deal's dynamic spec against an operation whose command decodes
+// perfectly well and resolves no invocation-time tier.
+func TestADynamicSpecWhoseCommandAnswersNoTierIsRefused(t *testing.T) {
+	deps := restCommandDeps{stages: reopenStages{}, records: reopenRecords{}}
+	_, spec := advanceSpec(t, deps)
+	lead := agentPolicies["POST /v1/leads/{id}/promote"]
+	if _, described := restCommands[lead.Op]; !described {
+		t.Fatalf("%s decodes into no command at all, so this proves nothing about a command that answers no tier", lead.Op)
+	}
+
+	r := requestForDeal(t, ids.NewV7())
+	resolve := tierInput(r.Context(), spec, lead, deps, r, []byte(`{"trigger":"reply"}`))
+	if _, err := resolve(); !errors.Is(err, apperrors.ErrPermissionDenied) {
+		t.Errorf("an unanswerable dynamic tier resolved to %v, want a refusal — a gate that cannot tell "+
+			"whether a call needs a human must not decide that it does not", err)
+	}
+}
+
+// The other half of the same fail-closed rule: an operation with no decoder has
+// nothing to ask, and is refused rather than admitted ungated.
+func TestADynamicSpecWithNoDecoderIsRefused(t *testing.T) {
+	deps := restCommandDeps{stages: reopenStages{}, records: reopenRecords{}}
+	_, spec := advanceSpec(t, deps)
+	unknown := agentPolicy{Op: "anOperationNoDecoderKnows", Access: accessTool, Tool: "advance_deal", Tier: tierDynamic}
+
+	r := requestForDeal(t, ids.NewV7())
+	resolve := tierInput(r.Context(), spec, unknown, deps, r, []byte(`{}`))
+	if _, err := resolve(); !errors.Is(err, apperrors.ErrPermissionDenied) {
+		t.Errorf("an undecodable dynamic operation resolved to %v, want a refusal", err)
 	}
 }
 

--- a/backend/internal/compose/agentgate_dealreopen_test.go
+++ b/backend/internal/compose/agentgate_dealreopen_test.go
@@ -24,6 +24,9 @@ import (
 
 	"github.com/go-chi/chi/v5"
 
+	"github.com/gradionhq/margince/backend/internal/modules/agents"
+	"github.com/gradionhq/margince/backend/internal/platform/auth"
+	"github.com/gradionhq/margince/backend/internal/platform/httperr"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
@@ -107,6 +110,99 @@ func TestADynamicSpecWithNoDecoderIsRefused(t *testing.T) {
 	resolve := tierInput(r.Context(), spec, unknown, deps, r, []byte(`{}`))
 	if _, err := resolve(); !errors.Is(err, apperrors.ErrPermissionDenied) {
 		t.Errorf("an undecodable dynamic operation resolved to %v, want a refusal", err)
+	}
+}
+
+// The three faults advanceDealCommand tells apart keep three ANSWERS, and the
+// answer a client acts on is the machine code — the whole reason this decoder
+// does not share commandBody's single malformed_json. Eleven lines of comment
+// explain why they differ; this is what makes the explanation checkable.
+//
+// Two bodies reach the middle answer, because "valid JSON the shape refuses" is
+// one fault with two spellings: a to_stage_id that is not a UUID, and a body
+// that is not an object at all. Both are fixed by sending an object carrying a
+// canonical UUID there, which is why both name that field rather than the body.
+func TestTheDealAdvanceDecoderAnswersEachFaultOnItsOwnField(t *testing.T) {
+	deps := restCommandDeps{stages: reopenStages{}, records: reopenRecords{}}
+	pol := agentPolicies["POST /v1/deals/{id}/advance"]
+
+	for name, tc := range map[string]struct{ body, field, code string }{
+		"a body that is not JSON":          {body: `{"to_stage_id":`, field: "body", code: "malformed_json"},
+		"a to_stage_id that is not a UUID": {body: `{"to_stage_id":"not-a-uuid"}`, field: "to_stage_id", code: "invalid"},
+		"valid JSON that is not an object": {body: `[1,2]`, field: "to_stage_id", code: "invalid"},
+		"an object omitting to_stage_id":   {body: `{}`, field: "to_stage_id", code: "required"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := advanceDealCommand(pol, deps, requestForDeal(t, ids.NewV7()), []byte(tc.body))
+
+			var detailed *httperr.DetailedError
+			if !errors.As(err, &detailed) {
+				t.Fatalf("the decoder answered %v, which carries no field or code for a client to act on", err)
+			}
+			if len(detailed.Fields) != 1 {
+				t.Fatalf("the decoder named %d fields, want exactly the one at fault", len(detailed.Fields))
+			}
+			if got := detailed.Fields[0]; got.Field != tc.field || got.Code != tc.code {
+				t.Errorf("answered %s/%s, want %s/%s — a client branches on the code, so one fault wearing "+
+					"another's is a fix the caller cannot find", got.Field, got.Code, tc.field, tc.code)
+			}
+		})
+	}
+}
+
+// wellFormedDynamicCalls is one valid request per dynamic-tier operation. It is
+// the half the walk below CANNOT derive — a well-formed body is the operation's
+// own vocabulary — and the walk fails on a dynamic route missing from it, so the
+// half that actually goes stale (which routes are dynamic) is the derived one.
+var wellFormedDynamicCalls = map[string]func(t *testing.T, stage ids.UUID) (*http.Request, []byte){
+	"advanceDeal": func(t *testing.T, stage ids.UUID) (*http.Request, []byte) {
+		t.Helper()
+		return requestForDeal(t, ids.NewV7()), []byte(`{"to_stage_id":"` + stage.String() + `"}`)
+	},
+}
+
+// Every dynamic-tier route must have a command that can ANSWER its tier
+// question. A route without one is refused, for every caller and forever — and
+// that refusal is indistinguishable from a route an agent was never allowed to
+// reach, which is what makes it worth deriving rather than noticing.
+//
+// This is the derived twin of the two synthetic pairings above: those prove the
+// fail-closed refusal fires, this proves it fires only where it should, over the
+// routes the real router can actually produce.
+func TestEveryDynamicTierRouteHasACommandThatAnswersItsTier(t *testing.T) {
+	stage := ids.NewV7()
+	deps := restCommandDeps{
+		stages:  reopenStages{semantics: map[ids.UUID]string{stage: "open"}},
+		records: versionedDeal{stageID: stage, version: 3},
+	}
+	reg := agents.NewRegistry(nil, auth.NewGate(fullSeat{}))
+	agents.RegisterCoreTools(reg, deps.records, deps.stages, nil, nil)
+
+	checked := 0
+	for route, pol := range agentPolicies {
+		if pol.Access != accessTool || pol.Tier != tierDynamic {
+			continue
+		}
+		checked++
+		build, described := wellFormedDynamicCalls[pol.Op]
+		if !described {
+			t.Errorf("%s (%s) declares a dynamic tier and this walk has no well-formed call for it — add "+
+				"one, so the route's own tier answer is proved rather than assumed", route, pol.Op)
+			continue
+		}
+		spec, _, ok := operationSpec(pol, reg)
+		if !ok {
+			t.Errorf("%s (%s): the gate resolves no spec for it", route, pol.Op)
+			continue
+		}
+		r, body := build(t, stage)
+		if _, err := tierInput(r.Context(), spec, pol, deps, r, body)(); err != nil {
+			t.Errorf("%s (%s) cannot answer its own tier question: %v — a dynamic route whose command "+
+				"resolves no tier is refused for every caller", route, pol.Op, err)
+		}
+	}
+	if checked == 0 {
+		t.Fatal("no dynamic-tier route in the generated policy — this walk asserted nothing")
 	}
 }
 

--- a/backend/internal/compose/agentgate_pin_test.go
+++ b/backend/internal/compose/agentgate_pin_test.go
@@ -61,7 +61,7 @@ func TestStageRefusalNamesTheTargetAndSuppliesNoClientPin(t *testing.T) {
 			rctx.URLParams.Add("id", dealID.String())
 			req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
 
-			stageRefusal(httptest.NewRecorder(), req, staging, pol, nil)
+			stageRefusal(httptest.NewRecorder(), req, staging, seamRecord{}, pol, nil)
 
 			if staging.last.TargetType != "deal" || staging.last.TargetID != dealID {
 				t.Fatalf("staged target = (%s,%s), want (deal,%s) — the engine cannot pin a target it was not given",

--- a/backend/internal/compose/agentgate_pin_test.go
+++ b/backend/internal/compose/agentgate_pin_test.go
@@ -61,7 +61,7 @@ func TestStageRefusalNamesTheTargetAndSuppliesNoClientPin(t *testing.T) {
 			rctx.URLParams.Add("id", dealID.String())
 			req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
 
-			stageRefusal(httptest.NewRecorder(), req, staging, seamRecord{}, pol, nil)
+			stageRefusal(httptest.NewRecorder(), req, staging, restCommandDeps{records: seamRecord{}}, pol, nil)
 
 			if staging.last.TargetType != "deal" || staging.last.TargetID != dealID {
 				t.Fatalf("staged target = (%s,%s), want (deal,%s) — the engine cannot pin a target it was not given",

--- a/backend/internal/compose/agentgate_test.go
+++ b/backend/internal/compose/agentgate_test.go
@@ -147,23 +147,23 @@ func TestOperationSpecTightenOnly(t *testing.T) {
 // The redemption key is content, not serialization: key order and
 // whitespace hash equal; a changed value, path, or operation does not.
 func TestCanonicalRESTCallHashesContent(t *testing.T) {
-	_, h1, err := canonicalRESTCall("updatePerson", "/v1/people/x", http.Header{}, []byte(`{"b":2,"a":1}`))
+	_, h1, err := canonicalRESTCall("updatePerson", "/v1/people/x", http.Header{}, []byte(`{"b":2,"a":1}`), keyBindsTheRetry)
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, h2, _ := canonicalRESTCall("updatePerson", "/v1/people/x", http.Header{}, []byte(` {"a": 1, "b": 2} `))
+	_, h2, _ := canonicalRESTCall("updatePerson", "/v1/people/x", http.Header{}, []byte(` {"a": 1, "b": 2} `), keyBindsTheRetry)
 	if h1 != h2 {
 		t.Fatal("equivalent bodies must hash equal — redemption would refuse the identical call")
 	}
-	_, h3, _ := canonicalRESTCall("updatePerson", "/v1/people/x", http.Header{}, []byte(`{"a":1,"b":3}`))
-	_, h4, _ := canonicalRESTCall("updatePerson", "/v1/people/y", http.Header{}, []byte(`{"a":1,"b":2}`))
+	_, h3, _ := canonicalRESTCall("updatePerson", "/v1/people/x", http.Header{}, []byte(`{"a":1,"b":3}`), keyBindsTheRetry)
+	_, h4, _ := canonicalRESTCall("updatePerson", "/v1/people/y", http.Header{}, []byte(`{"a":1,"b":2}`), keyBindsTheRetry)
 	if h1 == h3 || h1 == h4 {
 		t.Fatal("a different body or target must not ride the staged approval")
 	}
-	if _, _, err := canonicalRESTCall("op", "/p", http.Header{}, []byte(`{broken`)); err == nil {
+	if _, _, err := canonicalRESTCall("op", "/p", http.Header{}, []byte(`{broken`), keyBindsTheRetry); err == nil {
 		t.Fatal("malformed JSON must be refused, not hashed")
 	}
-	_, hEmpty, err := canonicalRESTCall("archivePerson", "/v1/people/x", http.Header{}, nil)
+	_, hEmpty, err := canonicalRESTCall("archivePerson", "/v1/people/x", http.Header{}, nil, keyBindsTheRetry)
 	if err != nil || hEmpty == "" {
 		t.Fatalf("bodyless mutations (DELETE) must canonicalize: %v", err)
 	}
@@ -183,11 +183,11 @@ func TestTheCanonicalCallBindsIdempotencyKey(t *testing.T) {
 	body := []byte(`{"to_stage_id":"a"}`)
 	withKey := http.Header{}
 	withKey.Set("Idempotency-Key", "k")
-	base, _, err := canonicalRESTCall("advanceDeal", "/v1/deals/d/advance", http.Header{}, body)
+	base, _, err := canonicalRESTCall("advanceDeal", "/v1/deals/d/advance", http.Header{}, body, keyBindsTheRetry)
 	if err != nil {
 		t.Fatal(err)
 	}
-	other, _, err := canonicalRESTCall("advanceDeal", "/v1/deals/d/advance", withKey, body)
+	other, _, err := canonicalRESTCall("advanceDeal", "/v1/deals/d/advance", withKey, body, keyBindsTheRetry)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -204,7 +204,7 @@ func TestTheCanonicalCallBindsIdempotencyKey(t *testing.T) {
 // header creeping into the digest by sitting next to one that belongs there.
 func TestTheCanonicalCallIgnoresHeadersThatDoNotChangeExecution(t *testing.T) {
 	body := []byte(`{"to_stage_id":"a"}`)
-	base, _, err := canonicalRESTCall("advanceDeal", "/v1/deals/d/advance", http.Header{}, body)
+	base, _, err := canonicalRESTCall("advanceDeal", "/v1/deals/d/advance", http.Header{}, body, keyBindsTheRetry)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -212,7 +212,7 @@ func TestTheCanonicalCallIgnoresHeadersThatDoNotChangeExecution(t *testing.T) {
 		{"Authorization": []string{"Bearer secret"}},
 		{"User-Agent": []string{"some-agent/1.0"}},
 	} {
-		other, _, err := canonicalRESTCall("advanceDeal", "/v1/deals/d/advance", h, body)
+		other, _, err := canonicalRESTCall("advanceDeal", "/v1/deals/d/advance", h, body, keyBindsTheRetry)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -231,7 +231,7 @@ func TestTheCanonicalCallIgnoresHeadersThatDoNotChangeExecution(t *testing.T) {
 func TestTheCanonicalCallIsByteCompatibleWithoutAHashedHeader(t *testing.T) {
 	const wantCanonical = `{"body":{"a":1,"b":2},"operation":"updatePerson","path":"/v1/people/x"}`
 	const wantHash = "8924889e55733baa0964dc3aa1929f9af6f315b49ed82d4c11e8c2c1190bba84"
-	canonical, hash, err := canonicalRESTCall("updatePerson", "/v1/people/x", http.Header{}, []byte(`{"a":1,"b":2}`))
+	canonical, hash, err := canonicalRESTCall("updatePerson", "/v1/people/x", http.Header{}, []byte(`{"a":1,"b":2}`), keyBindsTheRetry)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -247,7 +247,7 @@ func TestTheCanonicalCallIsByteCompatibleWithoutAHashedHeader(t *testing.T) {
 // one string and would redeem each other's approval. The tool door rejects this before
 // decoding (reserved.go); this door did not.
 func TestTheCanonicalCallRefusesInvalidUTF8(t *testing.T) {
-	if _, _, err := canonicalRESTCall("x", "/v1/x", http.Header{}, []byte("{\"a\":\"\xff\"}")); err == nil {
+	if _, _, err := canonicalRESTCall("x", "/v1/x", http.Header{}, []byte("{\"a\":\"\xff\"}"), keyBindsTheRetry); err == nil {
 		t.Error("a body carrying invalid UTF-8 canonicalized cleanly")
 	}
 }
@@ -255,7 +255,7 @@ func TestTheCanonicalCallRefusesInvalidUTF8(t *testing.T) {
 // An escaped unpaired surrogate is valid UTF-8 on the wire and still decodes to U+FFFD,
 // so the byte check above cannot see it. reserved.go checks both halves; so must this.
 func TestTheCanonicalCallRefusesAnEscapedUnpairedSurrogate(t *testing.T) {
-	if _, _, err := canonicalRESTCall("x", "/v1/x", http.Header{}, []byte(`{"a":"\udcff"}`)); err == nil {
+	if _, _, err := canonicalRESTCall("x", "/v1/x", http.Header{}, []byte(`{"a":"\udcff"}`), keyBindsTheRetry); err == nil {
 		t.Error("an escaped unpaired surrogate canonicalized cleanly")
 	}
 }
@@ -268,7 +268,7 @@ func TestTheCanonicalCallRefusesAnEscapedUnpairedSurrogate(t *testing.T) {
 // and modules/agents/badargs.go draw elsewhere in this tree.
 func TestTheCanonicalCallRefusesTrailingContentAfterTheJSONValue(t *testing.T) {
 	for _, body := range []string{`{"a":1} garbage`, `{"a":1}{"b":2}`} {
-		if _, _, err := canonicalRESTCall("x", "/v1/x", http.Header{}, []byte(body)); err == nil {
+		if _, _, err := canonicalRESTCall("x", "/v1/x", http.Header{}, []byte(body), keyBindsTheRetry); err == nil {
 			t.Errorf("body %q canonicalized cleanly despite trailing content after the JSON value", body)
 		}
 	}

--- a/backend/internal/compose/agentgate_test.go
+++ b/backend/internal/compose/agentgate_test.go
@@ -151,12 +151,24 @@ func TestCanonicalRESTCallHashesContent(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, h2, _ := canonicalRESTCall("updatePerson", "/v1/people/x", http.Header{}, []byte(` {"a": 1, "b": 2} `), keyBindsTheRetry)
+	_, h2, err := canonicalRESTCall("updatePerson", "/v1/people/x", http.Header{}, []byte(` {"a": 1, "b": 2} `), keyBindsTheRetry)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if h1 != h2 {
 		t.Fatal("equivalent bodies must hash equal — redemption would refuse the identical call")
 	}
-	_, h3, _ := canonicalRESTCall("updatePerson", "/v1/people/x", http.Header{}, []byte(`{"a":1,"b":3}`), keyBindsTheRetry)
-	_, h4, _ := canonicalRESTCall("updatePerson", "/v1/people/y", http.Header{}, []byte(`{"a":1,"b":2}`), keyBindsTheRetry)
+	// Both errors are asserted, not dropped: a refused input hashes to "", and an
+	// empty hash satisfies the inequality below while proving nothing about a
+	// different body or a different path.
+	_, h3, err := canonicalRESTCall("updatePerson", "/v1/people/x", http.Header{}, []byte(`{"a":1,"b":3}`), keyBindsTheRetry)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, h4, err := canonicalRESTCall("updatePerson", "/v1/people/y", http.Header{}, []byte(`{"a":1,"b":2}`), keyBindsTheRetry)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if h1 == h3 || h1 == h4 {
 		t.Fatal("a different body or target must not ride the staged approval")
 	}

--- a/backend/internal/compose/agentgate_test.go
+++ b/backend/internal/compose/agentgate_test.go
@@ -4,6 +4,8 @@
 package compose
 
 import (
+	"bytes"
+	"net/http"
 	"strings"
 	"testing"
 
@@ -145,25 +147,80 @@ func TestOperationSpecTightenOnly(t *testing.T) {
 // The redemption key is content, not serialization: key order and
 // whitespace hash equal; a changed value, path, or operation does not.
 func TestCanonicalRESTCallHashesContent(t *testing.T) {
-	_, h1, err := canonicalRESTCall("updatePerson", "/v1/people/x", []byte(`{"b":2,"a":1}`))
+	_, h1, err := canonicalRESTCall("updatePerson", "/v1/people/x", http.Header{}, []byte(`{"b":2,"a":1}`))
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, h2, _ := canonicalRESTCall("updatePerson", "/v1/people/x", []byte(` {"a": 1, "b": 2} `))
+	_, h2, _ := canonicalRESTCall("updatePerson", "/v1/people/x", http.Header{}, []byte(` {"a": 1, "b": 2} `))
 	if h1 != h2 {
 		t.Fatal("equivalent bodies must hash equal — redemption would refuse the identical call")
 	}
-	_, h3, _ := canonicalRESTCall("updatePerson", "/v1/people/x", []byte(`{"a":1,"b":3}`))
-	_, h4, _ := canonicalRESTCall("updatePerson", "/v1/people/y", []byte(`{"a":1,"b":2}`))
+	_, h3, _ := canonicalRESTCall("updatePerson", "/v1/people/x", http.Header{}, []byte(`{"a":1,"b":3}`))
+	_, h4, _ := canonicalRESTCall("updatePerson", "/v1/people/y", http.Header{}, []byte(`{"a":1,"b":2}`))
 	if h1 == h3 || h1 == h4 {
 		t.Fatal("a different body or target must not ride the staged approval")
 	}
-	if _, _, err := canonicalRESTCall("op", "/p", []byte(`{broken`)); err == nil {
+	if _, _, err := canonicalRESTCall("op", "/p", http.Header{}, []byte(`{broken`)); err == nil {
 		t.Fatal("malformed JSON must be refused, not hashed")
 	}
-	_, hEmpty, err := canonicalRESTCall("archivePerson", "/v1/people/x", nil)
+	_, hEmpty, err := canonicalRESTCall("archivePerson", "/v1/people/x", http.Header{}, nil)
 	if err != nil || hEmpty == "" {
 		t.Fatalf("bodyless mutations (DELETE) must canonicalize: %v", err)
+	}
+}
+
+// Two calls differing only in a header that changes what executes must not hash alike.
+// If-Match decides whether the write happens at all; Idempotency-Key decides whether it
+// is a fresh effect, a replay or a conflict. Both reach the handler; neither was hashed.
+func TestTheCanonicalCallBindsTheHeadersThatChangeWhatExecutes(t *testing.T) {
+	body := []byte(`{"to_stage_id":"a"}`)
+	with := func(k, v string) http.Header { h := http.Header{}; h.Set(k, v); return h }
+	base, _, err := canonicalRESTCall("advanceDeal", "/v1/deals/d/advance", http.Header{}, body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, h := range []http.Header{with("If-Match", "7"), with("Idempotency-Key", "k")} {
+		other, _, err := canonicalRESTCall("advanceDeal", "/v1/deals/d/advance", h, body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if bytes.Equal(base, other) {
+			t.Errorf("a call carrying %v canonicalized identically to one without it", h)
+		}
+	}
+}
+
+// encoding/json replaces invalid bytes with U+FFFD, so two distinct wire calls arrive as
+// one string and would redeem each other's approval. The tool door rejects this before
+// decoding (reserved.go); this door did not.
+func TestTheCanonicalCallRefusesInvalidUTF8(t *testing.T) {
+	if _, _, err := canonicalRESTCall("x", "/v1/x", http.Header{}, []byte("{\"a\":\"\xff\"}")); err == nil {
+		t.Error("a body carrying invalid UTF-8 canonicalized cleanly")
+	}
+}
+
+// An escaped unpaired surrogate is valid UTF-8 on the wire and still decodes to U+FFFD,
+// so the byte check above cannot see it. reserved.go checks both halves; so must this.
+func TestTheCanonicalCallRefusesAnEscapedUnpairedSurrogate(t *testing.T) {
+	if _, _, err := canonicalRESTCall("x", "/v1/x", http.Header{}, []byte(`{"a":"\udcff"}`)); err == nil {
+		t.Error("an escaped unpaired surrogate canonicalized cleanly")
+	}
+}
+
+// Decoding through `any` turns every JSON number into a float64, so two distinct integers
+// beyond 2^53 canonicalize to one — and the handler decodes the original bytes into an
+// int64, which is a second reading of one value.
+func TestTheCanonicalCallKeepsLargeIntegersDistinct(t *testing.T) {
+	a, _, err := canonicalRESTCall("x", "/v1/x", http.Header{}, []byte(`{"v":9007199254740993}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, _, err := canonicalRESTCall("x", "/v1/x", http.Header{}, []byte(`{"v":9007199254740992}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Equal(a, b) {
+		t.Error("two distinct integers canonicalized identically")
 	}
 }
 

--- a/backend/internal/compose/agentgate_test.go
+++ b/backend/internal/compose/agentgate_test.go
@@ -169,24 +169,77 @@ func TestCanonicalRESTCallHashesContent(t *testing.T) {
 	}
 }
 
-// Two calls differing only in a header that changes what executes must not hash alike.
-// If-Match decides whether the write happens at all; Idempotency-Key decides whether it
-// is a fresh effect, a replay or a conflict. Both reach the handler; neither was hashed.
-func TestTheCanonicalCallBindsTheHeadersThatChangeWhatExecutes(t *testing.T) {
+// A call carrying Idempotency-Key must not hash the same as one without it:
+// the header decides whether a retry is a fresh effect, a replay or a
+// conflict, and it reaches the handler untouched.
+//
+// If-Match is deliberately NOT exercised here the same way: the gate itself
+// overwrites it with the server-side version pin on redemption
+// (agentgatestaging.go), so the caller's own If-Match never reaches the
+// handler unchanged, and hashing it would make the split-update residue
+// (agentsplit.go) unredeemable by the very version the agent just read.
+// canonicalHeaders' own doc comment carries the full reasoning.
+func TestTheCanonicalCallBindsIdempotencyKey(t *testing.T) {
 	body := []byte(`{"to_stage_id":"a"}`)
-	with := func(k, v string) http.Header { h := http.Header{}; h.Set(k, v); return h }
+	withKey := http.Header{}
+	withKey.Set("Idempotency-Key", "k")
 	base, _, err := canonicalRESTCall("advanceDeal", "/v1/deals/d/advance", http.Header{}, body)
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, h := range []http.Header{with("If-Match", "7"), with("Idempotency-Key", "k")} {
+	other, _, err := canonicalRESTCall("advanceDeal", "/v1/deals/d/advance", withKey, body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Equal(base, other) {
+		t.Error("a call carrying Idempotency-Key canonicalized identically to one without it")
+	}
+}
+
+// A header that never changes what a handler does — Authorization names WHO
+// is calling, User-Agent names WHAT is calling, neither decides WHAT RUNS —
+// must leave the hash untouched. This is the half TestTheCanonicalCallBindsIdempotencyKey
+// cannot prove on its own: that test shows a hashed header changes the hash,
+// this one shows an unhashed header does not, which is what stops a future
+// header creeping into the digest by sitting next to one that belongs there.
+func TestTheCanonicalCallIgnoresHeadersThatDoNotChangeExecution(t *testing.T) {
+	body := []byte(`{"to_stage_id":"a"}`)
+	base, _, err := canonicalRESTCall("advanceDeal", "/v1/deals/d/advance", http.Header{}, body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, h := range []http.Header{
+		{"Authorization": []string{"Bearer secret"}},
+		{"User-Agent": []string{"some-agent/1.0"}},
+	} {
 		other, _, err := canonicalRESTCall("advanceDeal", "/v1/deals/d/advance", h, body)
 		if err != nil {
 			t.Fatal(err)
 		}
-		if bytes.Equal(base, other) {
-			t.Errorf("a call carrying %v canonicalized identically to one without it", h)
+		if !bytes.Equal(base, other) {
+			t.Errorf("a call carrying %v canonicalized differently from one without it", h)
 		}
+	}
+}
+
+// A call carrying no hashed header must canonicalize BYTE-FOR-BYTE as it did
+// before the `headers` member existed, or every pending REST-agent approval
+// and every issued redemption token minted before this task ships becomes
+// unredeemable. Pinned against literal golden bytes and a literal golden
+// hash — not two in-process hashes compared to each other, which cannot see
+// a canonical-form change that moves both sides of the comparison together.
+func TestTheCanonicalCallIsByteCompatibleWithoutAHashedHeader(t *testing.T) {
+	const wantCanonical = `{"body":{"a":1,"b":2},"operation":"updatePerson","path":"/v1/people/x"}`
+	const wantHash = "8924889e55733baa0964dc3aa1929f9af6f315b49ed82d4c11e8c2c1190bba84"
+	canonical, hash, err := canonicalRESTCall("updatePerson", "/v1/people/x", http.Header{}, []byte(`{"a":1,"b":2}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(canonical) != wantCanonical {
+		t.Errorf("canonical = %s, want %s", canonical, wantCanonical)
+	}
+	if hash != wantHash {
+		t.Errorf("hash = %s, want %s", hash, wantHash)
 	}
 }
 
@@ -207,20 +260,17 @@ func TestTheCanonicalCallRefusesAnEscapedUnpairedSurrogate(t *testing.T) {
 	}
 }
 
-// Decoding through `any` turns every JSON number into a float64, so two distinct integers
-// beyond 2^53 canonicalize to one — and the handler decodes the original bytes into an
-// int64, which is a second reading of one value.
-func TestTheCanonicalCallKeepsLargeIntegersDistinct(t *testing.T) {
-	a, _, err := canonicalRESTCall("x", "/v1/x", http.Header{}, []byte(`{"v":9007199254740993}`))
-	if err != nil {
-		t.Fatal(err)
-	}
-	b, _, err := canonicalRESTCall("x", "/v1/x", http.Header{}, []byte(`{"v":9007199254740992}`))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if bytes.Equal(a, b) {
-		t.Error("two distinct integers canonicalized identically")
+// json.Unmarshal into `any` refuses a body that is not exactly one JSON value —
+// unlike json.Decoder.Decode, which stops after the first value and leaves the
+// rest unread. Without this, `{"a":1} garbage` and `{"a":1}{"b":2}` would both
+// canonicalize to `{"a":1}` and hash identically to it, letting a distinct wire
+// body redeem another call's approval. The same one-value boundary httperr.Decode
+// and modules/agents/badargs.go draw elsewhere in this tree.
+func TestTheCanonicalCallRefusesTrailingContentAfterTheJSONValue(t *testing.T) {
+	for _, body := range []string{`{"a":1} garbage`, `{"a":1}{"b":2}`} {
+		if _, _, err := canonicalRESTCall("x", "/v1/x", http.Header{}, []byte(body)); err == nil {
+			t.Errorf("body %q canonicalized cleanly despite trailing content after the JSON value", body)
+		}
 	}
 }
 

--- a/backend/internal/compose/agentgateauto.go
+++ b/backend/internal/compose/agentgateauto.go
@@ -25,6 +25,8 @@ import (
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 )
 
+const ifMatchHeader = "If-Match"
+
 // runAutoExecuted dispatches a call the gate admitted at the auto-execute tier.
 //
 // An X-Approval-Token on such a call is CONSUMED, whatever tool it names. A
@@ -79,7 +81,9 @@ func runAutoExecuted(w http.ResponseWriter, r *http.Request, next http.Handler, 
 	performed := &effectRecorder{ResponseWriter: w}
 	metered := &servedMeter{ResponseWriter: performed, r: r, reg: outcome.registry, mayRefuse: theEffectAlreadyLanded}
 	if !redeemed && outcome.pol.Tool == toolUpdateRecord && !actionShapedUpdateOps[outcome.pol.Op] {
-		splitHumanOwnedUpdate(metered, r, next, outcome.staging, outcome.commands, outcome.ownership, outcome.pol, outcome.body)
+		splitHumanOwnedUpdate(metered, r, next,
+			splitUpdateDeps{staging: outcome.staging, commands: outcome.commands, ownership: outcome.ownership},
+			outcome.pol, outcome.body)
 	} else {
 		next.ServeHTTP(metered, r)
 	}
@@ -145,7 +149,7 @@ func pinAutoExecutedWrite(w http.ResponseWriter, r *http.Request, redemption tok
 				redemption.pin, admitted, apperrors.ErrVersionSkew))
 			return false
 		}
-		r.Header.Set("If-Match", strconv.FormatInt(redemption.pin, 10))
+		r.Header.Set(ifMatchHeader, strconv.FormatInt(redemption.pin, 10))
 		return true
 	}
 	if !gateRead {
@@ -159,10 +163,10 @@ func pinAutoExecutedWrite(w http.ResponseWriter, r *http.Request, redemption tok
 		// read is then the only proved version, and it overrides the caller's
 		// header for the same reason the released pin does above: the approval is
 		// already spent, so a refusal here would destroy it.
-		r.Header.Set("If-Match", strconv.FormatInt(admitted, 10))
+		r.Header.Set(ifMatchHeader, strconv.FormatInt(admitted, 10))
 		return true
 	}
-	if caller := r.Header.Get("If-Match"); caller != "" {
+	if caller := r.Header.Get(ifMatchHeader); caller != "" {
 		// Compared as the numbers they are: the contract's If-Match is a bare
 		// integer version, and two spellings of one number must not read as
 		// disagreement. A caller header this parser refuses is left for the
@@ -183,6 +187,6 @@ func pinAutoExecutedWrite(w http.ResponseWriter, r *http.Request, redemption tok
 			caller, admitted, apperrors.ErrVersionSkew))
 		return false
 	}
-	r.Header.Set("If-Match", strconv.FormatInt(admitted, 10))
+	r.Header.Set(ifMatchHeader, strconv.FormatInt(admitted, 10))
 	return true
 }

--- a/backend/internal/compose/agentgateauto.go
+++ b/backend/internal/compose/agentgateauto.go
@@ -167,7 +167,14 @@ func pinAutoExecutedWrite(w http.ResponseWriter, r *http.Request, redemption tok
 		// integer version, and two spellings of one number must not read as
 		// disagreement. A caller header this parser refuses is left for the
 		// handler's own IfMatchVersion to answer, which is where that message
-		// already lives.
+		// already lives — and the handler behind THIS branch has one, because
+		// gateRead is true only for an operation whose tier was decided by
+		// reading a record (auth.Admit pins nothing for a static tier), which is
+		// the dynamic-tier set, and a dynamic tier is resolved from a version the
+		// operation's own handler is conditioned on. A handler that read no
+		// If-Match at all would not be pinned by the well-formed header this
+		// function sets either, so a malformed one is not what would leave it
+		// unpinned.
 		if got, err := strconv.ParseInt(caller, 10, 64); err != nil || got == admitted {
 			return true
 		}

--- a/backend/internal/compose/agentgateauto.go
+++ b/backend/internal/compose/agentgateauto.go
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The 🟢 arm on the REST door: how a call the gate admitted at the auto-execute
+// tier is dispatched, and what its write is conditioned on.
+//
+// Split from agentgate.go on the 500-line cap, along the boundary that file
+// already draws for the other answer: agentgate.go decides whether a call is
+// ADMITTED, agentgatestaging.go is what happens to a 🟡, and this is what
+// happens to a 🟢. The two arms are deliberately readable side by side — both
+// redeem a presented X-Approval-Token through the same consumePresentedToken,
+// both charge their call ceiling once, and where they DIFFER (which version
+// conditions the write, and at which moment the charge falls) each says why
+// against the other.
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/gradionhq/margince/backend/internal/platform/auth"
+	"github.com/gradionhq/margince/backend/internal/platform/httperr"
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+)
+
+// runAutoExecuted dispatches a call the gate admitted at the auto-execute tier.
+//
+// An X-Approval-Token on such a call is CONSUMED, whatever tool it names. A
+// staged 🟡 call can resolve 🟢 on its retry — the record moved, or the
+// per-field split staged an otherwise auto-execute patch — and the asserted
+// authority is then still an assertion: left unread, the approval stays pending
+// in a human's inbox for work that already happened, and an invalid or replayed
+// token is accepted by being ignored. The MCP door has always redeemed on this
+// arm (registry.go, runClaimed); this door redeemed for update_record alone
+// (gradionhq/margince-poc-v1#812).
+//
+// A REDEEMED call goes straight to the handler: it carries exactly the change a
+// human released, whose identity the diff_hash already bound, so re-running the
+// per-field ownership split over it would stage a second approval for the
+// overwrite that was just approved.
+func runAutoExecuted(w http.ResponseWriter, r *http.Request, next http.Handler, outcome admissionOutcome) {
+	redemption, redeemed, ok := consumePresentedToken(w, r, outcome.staging, outcome.pol, outcome.body)
+	if redeemed && !ok {
+		return
+	}
+	if redeemed {
+		// Charged HERE and not at the door's own charge point, for the reason
+		// that point states: a token that opens nothing runs nothing, and
+		// counting it would let a caller suspend its own Passport with replays.
+		// Absorbed rather than refused, because the approval has already
+		// committed — the same asymmetry the MCP door takes at redeemPresented.
+		outcome.registry.ChargeRedeemedCall(r.Context(), outcome.spec)
+	}
+	if !pinAutoExecutedWrite(w, r, redemption, redeemed) {
+		return
+	}
+	if redeemed {
+		// WithContext shares the header map the pin was just set on, so the
+		// released marker and the precondition travel together.
+		r = r.WithContext(redemption.released) //nolint:contextcheck // released is derived from r.Context() inside consumePresentedToken
+	}
+	// The effect is charged on BOTH arms — the field split forwards to the
+	// same handler through its own path — and on NEITHER when the handler
+	// refused. A quota counts what an agent did, so a rejected mutation that
+	// spent a write would let a caller exhaust its own allowance on requests
+	// that changed nothing, which is a bound nobody wrote.
+	// The meter sits OUTSIDE the recorder, so the handler's WriteJSON finds
+	// it by a plain assertion while the recorder still sees every status.
+	// A mutation that answers with the row it changed handed over a record,
+	// and the MCP door charges that record at chargeAnswer whatever the tool
+	// kind — a read-back free on one door and charged on the other is the
+	// same asymmetry this gate exists to close.
+	//
+	// The CALL itself has been charged exactly once by the time this runs — at
+	// the door for a plain admission, at the redemption above for a call that
+	// asserted one — so nothing charges it here.
+	performed := &effectRecorder{ResponseWriter: w}
+	metered := &servedMeter{ResponseWriter: performed, r: r, reg: outcome.registry, mayRefuse: theEffectAlreadyLanded}
+	if !redeemed && outcome.pol.Tool == toolUpdateRecord && !actionShapedUpdateOps[outcome.pol.Op] {
+		splitHumanOwnedUpdate(metered, r, next, outcome.staging, outcome.commands, outcome.ownership, outcome.pol, outcome.body)
+	} else {
+		next.ServeHTTP(metered, r)
+	}
+	if performed.done() {
+		outcome.registry.ChargeEffect(r.Context(), outcome.spec)
+	}
+}
+
+// pinAutoExecutedWrite conditions an auto-executed agent write on the version
+// its authority was taken at, by forwarding that version as the request's own
+// If-Match. It reports whether the request may proceed; a refusal has already
+// been written.
+//
+// The two calls this arm carries are pinned by DIFFERENT rules, because only one
+// of them has something irreversible behind it.
+//
+// A REDEEMED call takes the server's version and takes it over anything the
+// caller sent — the approval's own pin where it carried one, the version the
+// tier gate read otherwise. That is redeemIfPresented's rule
+// (agentgatestaging.go) on the other arm, adopted here for the reason that arm
+// gives: this door hashes no If-Match into the identity a human's decision bound
+// (canonicalHeaders, agentgatecanon.go), so a caller header is a version nothing
+// proved while the server's pin names the state that was judged. Refusing the
+// disagreement instead would be strictly worse and was, briefly, what this
+// function did — consumePresentedToken has already SPENT the approval by the
+// time this runs, so a refusal here destroys a human's one-shot yes on a call
+// that never ran and can never be redeemed again. Forwarding is no weaker: the
+// store re-checks the pin inside the transaction that mutates and refuses there
+// unless the row is at the version the approval was granted against.
+//
+// An UNREDEEMED call is the ordinary 🟢 write, and there the CALLER's own
+// If-Match is honoured — but only when it names the version this gate read, and
+// that is CHECKED. The caller controls the header, so a version the gate never
+// saw is a version nothing proved: a caller naming the version the racing close
+// will PRODUCE walks straight through, because the store's compare then passes
+// on precisely the record the tier decision does not describe. Preferring the
+// caller unchecked would turn a coin-toss race into an armable one, and nothing
+// has been consumed at that point, so refusing costs the caller only a retry.
+//
+// The precedence — caller, then released, then admitted — is agents.pinForWrite's
+// (approvals.go), with ONE difference, named here because the two doors are
+// meant to be comparable: pinForWrite silently prefers the released pin where it
+// disagrees with the admitted one, and the branch below refuses instead. That
+// branch is a defensive assertion rather than a case either door meets. Through
+// the real stager a disagreement is unreachable — approvals pins server-side
+// only for a concrete, version-checkable target, versions are monotonic, and the
+// gate's read precedes the redemption's, so admitted ≤ current = released, and a
+// row that really moved fails validateRedemptionTarget inside the redemption
+// first. Whether refusing is even the right answer for a disagreement BOTH doors
+// could only discover after the approval is consumed is
+// gradionhq/margince-poc-v1#1069; until that is settled, neither door's
+// behaviour here is load-bearing.
+// redeemed is passed rather than read back off the redemption, so this function
+// and its caller cannot come to different answers about whether an approval was
+// spent — the one fact both the charge above and the rule below turn on.
+func pinAutoExecutedWrite(w http.ResponseWriter, r *http.Request, redemption tokenRedemption, redeemed bool) bool {
+	admitted, gateRead := auth.AutoExecutePin(r.Context())
+	if redemption.pinned {
+		if gateRead && redemption.pin != admitted {
+			httperr.Write(w, r, fmt.Errorf(
+				"the approval released this record at version %d and the tier gate read it at %d — it moved "+
+					"between the two, so neither is the version that was judged; re-read it and retry: %w",
+				redemption.pin, admitted, apperrors.ErrVersionSkew))
+			return false
+		}
+		r.Header.Set("If-Match", strconv.FormatInt(redemption.pin, 10))
+		return true
+	}
+	if !gateRead {
+		// Nothing read a version: a static tier, and an approval that carried no
+		// pin. A header invented here would refuse writes for a reason nobody can
+		// act on, and a caller's own is left for the store to adjudicate.
+		return true
+	}
+	if redeemed {
+		// Redeemed against an approval that carried no pin of its own. The gate's
+		// read is then the only proved version, and it overrides the caller's
+		// header for the same reason the released pin does above: the approval is
+		// already spent, so a refusal here would destroy it.
+		r.Header.Set("If-Match", strconv.FormatInt(admitted, 10))
+		return true
+	}
+	if caller := r.Header.Get("If-Match"); caller != "" {
+		// Compared as the numbers they are: the contract's If-Match is a bare
+		// integer version, and two spellings of one number must not read as
+		// disagreement. A caller header this parser refuses is left for the
+		// handler's own IfMatchVersion to answer, which is where that message
+		// already lives.
+		if got, err := strconv.ParseInt(caller, 10, 64); err != nil || got == admitted {
+			return true
+		}
+		httperr.Write(w, r, fmt.Errorf(
+			"If-Match %s is not the version this record was read at (%d) — re-read it and retry: %w",
+			caller, admitted, apperrors.ErrVersionSkew))
+		return false
+	}
+	r.Header.Set("If-Match", strconv.FormatInt(admitted, 10))
+	return true
+}

--- a/backend/internal/compose/agentgatecanon.go
+++ b/backend/internal/compose/agentgatecanon.go
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The canonicalization the REST agent gate hashes for staging and redemption.
+//
+// Split from agentgate.go on the 500-line cap, along a boundary already
+// implicit in the file: agentgate.go decides admission, and this is the one
+// thing both stageOrRedeem (agentgatestaging.go) and splitOrRedeemUpdate
+// (agentsplit.go) hash a call through — kept together because a caller that
+// diverges on operation, path, headers or body diverges on the identity a
+// staged approval binds to.
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"unicode/utf8"
+
+	"github.com/gradionhq/margince/backend/internal/platform/httperr"
+)
+
+// canonicalHeaders is the two REQUEST headers that change what a staged
+// call executes, sorted (a Go map marshals its keys in sorted order, so
+// the type carries the ordering rather than a caller having to remember
+// it). If-Match decides whether the write happens at all; Idempotency-Key
+// decides whether it is a fresh effect, a replay, or a conflict — both
+// reach the handler, so both are part of what "the identical call" means.
+// Every other header (Authorization, User-Agent, tracing headers, …) does
+// not change execution and is deliberately excluded: hashing one would
+// make an approval unredeemable from a different client, which is a worse
+// bug than the one this guards against.
+func canonicalHeaders(h http.Header) map[string]string {
+	out := map[string]string{}
+	for _, name := range []string{"If-Match", idempotencyKeyHeader} {
+		if v := h.Get(name); v != "" {
+			out[name] = v
+		}
+	}
+	return out
+}
+
+// canonicalRESTCall canonicalizes the request into the bytes both staging
+// and redemption hash: decoding into maps and re-marshaling sorts keys at
+// every depth, so "identical call" is a property of content, not of the
+// client's serialization habits.
+//
+// Numbers survive as json.Number (UseNumber): decoding through a bare
+// `any` renders every JSON number as float64, which loses precision past
+// 2^53 while the handler that later decodes the same bytes reads an exact
+// int64 — two distinct integers would canonicalize alike and a hash
+// collision would let one redeem the other's approval.
+//
+// UTF-8 is checked on both sides of the decode, matching the tool door's
+// two-halved check (modules/agents/reserved.go): utf8.Valid on the raw
+// bytes catches malformed encoding BEFORE the decode destroys the
+// evidence (encoding/json replaces an invalid byte with U+FFFD, so two
+// different wire bodies would arrive as one string); the replacement-rune
+// scan on the canonical form catches an escaped unpaired surrogate
+// (`"\udcff"`), which is valid UTF-8 on the wire and still decodes to
+// U+FFFD, so the byte check cannot see it.
+func canonicalRESTCall(op, path string, headers http.Header, body []byte) (json.RawMessage, string, error) {
+	if !utf8.Valid(body) {
+		return nil, "", httperr.Validation("body", "invalid_utf8", "request body must be valid UTF-8")
+	}
+	var payload any
+	if len(bytes.TrimSpace(body)) > 0 {
+		dec := json.NewDecoder(bytes.NewReader(body))
+		dec.UseNumber()
+		if err := dec.Decode(&payload); err != nil {
+			return nil, "", httperr.Validation("body", "invalid_json", "request body must be valid JSON")
+		}
+	}
+	canonical, err := json.Marshal(map[string]any{
+		"operation": op,
+		"path":      path,
+		"headers":   canonicalHeaders(headers),
+		"body":      payload,
+	})
+	if err != nil {
+		return nil, "", err
+	}
+	if bytes.ContainsRune(canonical, utf8.RuneError) {
+		return nil, "", httperr.Validation("body", "invalid_utf8",
+			"request body contains the Unicode replacement character, which makes two different calls indistinguishable")
+	}
+	sum := sha256.Sum256(canonical)
+	return canonical, hex.EncodeToString(sum[:]), nil
+}

--- a/backend/internal/compose/agentgatecanon.go
+++ b/backend/internal/compose/agentgatecanon.go
@@ -7,7 +7,7 @@ package compose
 //
 // Split from agentgate.go on the 500-line cap, along a boundary already
 // implicit in the file: agentgate.go decides admission, and this is the one
-// thing both stageOrRedeem (agentgatestaging.go) and splitOrRedeemUpdate
+// thing both stageOrRedeem (agentgatestaging.go) and splitHumanOwnedUpdate
 // (agentsplit.go) hash a call through — kept together because a caller that
 // diverges on operation, path, headers or body diverges on the identity a
 // staged approval binds to.

--- a/backend/internal/compose/agentgatecanon.go
+++ b/backend/internal/compose/agentgatecanon.go
@@ -23,63 +23,73 @@ import (
 	"github.com/gradionhq/margince/backend/internal/platform/httperr"
 )
 
-// canonicalHeaders is the two REQUEST headers that change what a staged
-// call executes, sorted (a Go map marshals its keys in sorted order, so
-// the type carries the ordering rather than a caller having to remember
-// it). If-Match decides whether the write happens at all; Idempotency-Key
-// decides whether it is a fresh effect, a replay, or a conflict — both
-// reach the handler, so both are part of what "the identical call" means.
-// Every other header (Authorization, User-Agent, tracing headers, …) does
-// not change execution and is deliberately excluded: hashing one would
-// make an approval unredeemable from a different client, which is a worse
-// bug than the one this guards against.
+// canonicalHeaders is the one REQUEST header that changes what a staged call
+// executes without the gate itself already deciding it: Idempotency-Key says
+// whether a retry is a fresh effect, a replay or a conflict, and it reaches
+// the handler exactly as the caller sent it.
+//
+// If-Match is deliberately NOT here, though it is also execution-relevant.
+// On the redemption path the gate OVERWRITES the caller's If-Match with the
+// server-side version pin taken at staging time (agentgatestaging.go,
+// redeemIfPresented) before the handler ever reads it, and on the
+// field-ownership split path (agentsplit.go) the auto-execute half can
+// advance the record's version between staging and redemption while the
+// staged residue's hash must still match on retry — hashing If-Match would
+// make that retry unredeemable by the version the agent just saw, without
+// protecting anything the server-side pin does not already protect.
+//
+// Every other header (Authorization, User-Agent, tracing headers, …) is
+// excluded for the same reason it always was: hashing one would make an
+// approval unredeemable from a different client, which is a worse bug than
+// the one this guards against.
 func canonicalHeaders(h http.Header) map[string]string {
 	out := map[string]string{}
-	for _, name := range []string{"If-Match", idempotencyKeyHeader} {
-		if v := h.Get(name); v != "" {
-			out[name] = v
-		}
+	if v := h.Get(idempotencyKeyHeader); v != "" {
+		out[idempotencyKeyHeader] = v
 	}
 	return out
 }
 
 // canonicalRESTCall canonicalizes the request into the bytes both staging
 // and redemption hash: decoding into maps and re-marshaling sorts keys at
-// every depth, so "identical call" is a property of content, not of the
-// client's serialization habits.
+// every depth and folds equivalent number spellings ("1" vs "1.0" vs "1e0")
+// to the same value, so "identical call" is a property of content, not of
+// the client's serialization habits. The decode into `any` also draws the
+// one-value boundary this tree already draws elsewhere (httperr.Decode,
+// modules/agents/badargs.go): a body carrying trailing content after the
+// JSON value — `{"a":1} garbage`, `{"a":1}{"b":2}` — is refused rather than
+// silently truncated to its first value.
 //
-// Numbers survive as json.Number (UseNumber): decoding through a bare
-// `any` renders every JSON number as float64, which loses precision past
-// 2^53 while the handler that later decodes the same bytes reads an exact
-// int64 — two distinct integers would canonicalize alike and a hash
-// collision would let one redeem the other's approval.
+// The `headers` member is present only when canonicalHeaders found
+// something to carry: a call presenting no hashed header canonicalizes
+// byte-for-byte as it did before this member existed, so a REST-agent
+// approval or redemption token minted before headers joined the hash stays
+// redeemable. Adding the empty member unconditionally would have changed
+// the hash of every call, headered or not.
 //
 // UTF-8 is checked on both sides of the decode, matching the tool door's
 // two-halved check (modules/agents/reserved.go): utf8.Valid on the raw
-// bytes catches malformed encoding BEFORE the decode destroys the
-// evidence (encoding/json replaces an invalid byte with U+FFFD, so two
-// different wire bodies would arrive as one string); the replacement-rune
-// scan on the canonical form catches an escaped unpaired surrogate
-// (`"\udcff"`), which is valid UTF-8 on the wire and still decodes to
-// U+FFFD, so the byte check cannot see it.
+// bytes catches malformed encoding BEFORE the decode destroys the evidence
+// (encoding/json replaces an invalid byte with U+FFFD, so two different
+// wire bodies would arrive as one string); the replacement-rune scan on the
+// canonical form catches an escaped unpaired surrogate (`"\udcff"`), which
+// is valid UTF-8 on the wire and still decodes to U+FFFD, so the byte check
+// cannot see it.
 func canonicalRESTCall(op, path string, headers http.Header, body []byte) (json.RawMessage, string, error) {
 	if !utf8.Valid(body) {
 		return nil, "", httperr.Validation("body", "invalid_utf8", "request body must be valid UTF-8")
 	}
 	var payload any
 	if len(bytes.TrimSpace(body)) > 0 {
-		dec := json.NewDecoder(bytes.NewReader(body))
-		dec.UseNumber()
-		if err := dec.Decode(&payload); err != nil {
+		if err := json.Unmarshal(body, &payload); err != nil {
 			return nil, "", httperr.Validation("body", "invalid_json", "request body must be valid JSON")
 		}
 	}
-	canonical, err := json.Marshal(map[string]any{
-		"operation": op,
-		"path":      path,
-		"headers":   canonicalHeaders(headers),
-		"body":      payload,
-	})
+	fields := map[string]any{"operation": op, "path": path, "body": payload}
+	if hdrs := canonicalHeaders(headers); len(hdrs) > 0 {
+		fields["headers"] = hdrs
+	}
+	canonical, err := json.Marshal(fields)
 	if err != nil {
 		return nil, "", err
 	}

--- a/backend/internal/compose/agentgatecanon.go
+++ b/backend/internal/compose/agentgatecanon.go
@@ -23,10 +23,49 @@ import (
 	"github.com/gradionhq/margince/backend/internal/platform/httperr"
 )
 
+// idempotencyKeyBinding says whether the caller's Idempotency-Key joins the
+// identity of the call being staged.
+//
+// It is a PARAMETER rather than a second canonicalization function because
+// two spellings of "the identity a staged approval binds to" is the disease
+// this seam exists to remove: staging and redemption hash through one code
+// path or they are free to drift, and a narrow fix that forked the path
+// would reintroduce exactly that. What varies is one member; the answer to
+// why it varies is below.
+type idempotencyKeyBinding bool
+
+const (
+	// keyBindsTheRetry is every ordinary staging (stageRefusal,
+	// agentgatestaging.go). The whole request is the staged change, so the
+	// approved retry IS this exact request again — key included. The refused
+	// attempt performed nothing, and only a 2xx settles a claim
+	// (idempotency.go), so the key is still the caller's to present.
+	keyBindsTheRetry idempotencyKeyBinding = true
+
+	// keySettledByThisCall is the field-ownership split's residue
+	// (applyAutoExecuteAndStageResidue, agentsplit.go), and the name is the
+	// reason: the auto-execute half of this same request ALREADY answered
+	// 2xx under the caller's key, which settles that claim for good.
+	//
+	// The approved retry therefore cannot present the key again. Re-using it
+	// never reaches the gate at all — the idempotency middleware sits
+	// outside it (routes.go) and answers the retry's residue body as a
+	// digest mismatch, 409. Presenting no key, which is what the staging
+	// note instructs, is then the only retry that can arrive; hashing a key
+	// it cannot carry would make the human's approval permanently
+	// unredeemable and the withheld field permanently unwritable.
+	//
+	// This is the same judgment canonicalHeaders already makes for If-Match
+	// below — a member that makes the retry impossible protects nothing —
+	// applied to the one path where it is the key that becomes impossible.
+	keySettledByThisCall idempotencyKeyBinding = false
+)
+
 // canonicalHeaders is the one REQUEST header that changes what a staged call
 // executes without the gate itself already deciding it: Idempotency-Key says
 // whether a retry is a fresh effect, a replay or a conflict, and it reaches
-// the handler exactly as the caller sent it.
+// the handler exactly as the caller sent it — on every path where the retry
+// can still present it (idempotencyKeyBinding, above).
 //
 // If-Match is deliberately NOT here, though it is also execution-relevant.
 // On the redemption path the gate OVERWRITES the caller's If-Match with the
@@ -42,9 +81,9 @@ import (
 // excluded for the same reason it always was: hashing one would make an
 // approval unredeemable from a different client, which is a worse bug than
 // the one this guards against.
-func canonicalHeaders(h http.Header) map[string]string {
+func canonicalHeaders(h http.Header, keys idempotencyKeyBinding) map[string]string {
 	out := map[string]string{}
-	if v := h.Get(idempotencyKeyHeader); v != "" {
+	if v := h.Get(idempotencyKeyHeader); v != "" && keys == keyBindsTheRetry {
 		out[idempotencyKeyHeader] = v
 	}
 	return out
@@ -67,6 +106,16 @@ func canonicalHeaders(h http.Header) map[string]string {
 // redeemable. Adding the empty member unconditionally would have changed
 // the hash of every call, headered or not.
 //
+// That same absence is what lets ONE function serve both bindings.
+// Redemption cannot know which kind of approval it is about to redeem — it
+// computes a hash before it has read the row — so it always canonicalizes
+// with keyBindsTheRetry. A residue retry arrives carrying no key (its own
+// binding's doc says why it can carry no other), canonicalizes with no
+// `headers` member, and matches the residue staged without one; a
+// full-request retry arrives carrying the key it always could and matches
+// the staging that hashed it. The two agree without redemption having to
+// ask which it is looking at.
+//
 // UTF-8 is checked on both sides of the decode, matching the tool door's
 // two-halved check (modules/agents/reserved.go): utf8.Valid on the raw
 // bytes catches malformed encoding BEFORE the decode destroys the evidence
@@ -75,7 +124,7 @@ func canonicalHeaders(h http.Header) map[string]string {
 // canonical form catches an escaped unpaired surrogate (`"\udcff"`), which
 // is valid UTF-8 on the wire and still decodes to U+FFFD, so the byte check
 // cannot see it.
-func canonicalRESTCall(op, path string, headers http.Header, body []byte) (json.RawMessage, string, error) {
+func canonicalRESTCall(op, path string, headers http.Header, body []byte, keys idempotencyKeyBinding) (json.RawMessage, string, error) {
 	if !utf8.Valid(body) {
 		return nil, "", httperr.Validation("body", "invalid_utf8", "request body must be valid UTF-8")
 	}
@@ -86,7 +135,7 @@ func canonicalRESTCall(op, path string, headers http.Header, body []byte) (json.
 		}
 	}
 	fields := map[string]any{"operation": op, "path": path, "body": payload}
-	if hdrs := canonicalHeaders(headers); len(hdrs) > 0 {
+	if hdrs := canonicalHeaders(headers, keys); len(hdrs) > 0 {
 		fields["headers"] = hdrs
 	}
 	canonical, err := json.Marshal(fields)

--- a/backend/internal/compose/agentgatepin_test.go
+++ b/backend/internal/compose/agentgatepin_test.go
@@ -51,7 +51,7 @@ func (p versionedDeal) Read(context.Context, datasource.EntityRef) (datasource.R
 // resolves it: through the generated policy table's op→tool mapping. The
 // registry comes back with it because the dispatch this door performs charges
 // its counters against that same surface.
-func advanceSpec(t *testing.T, deps tierDeps) (*agents.Registry, mcp.ToolSpec) {
+func advanceSpec(t *testing.T, deps restCommandDeps) (*agents.Registry, mcp.ToolSpec) {
 	t.Helper()
 	reg := agents.NewRegistry(nil, auth.NewGate(fullSeat{}))
 	agents.RegisterCoreTools(reg, deps.records, deps.stages, nil, nil)
@@ -71,7 +71,7 @@ func advanceSpec(t *testing.T, deps tierDeps) (*agents.Registry, mcp.ToolSpec) {
 func admitOpenMove(t *testing.T, callerIfMatch string) (seen string, status int) {
 	t.Helper()
 	deal, stage := ids.NewV7(), ids.NewV7()
-	deps := tierDeps{
+	deps := restCommandDeps{
 		stages:  reopenStages{semantics: map[ids.UUID]string{stage: "open"}},
 		records: versionedDeal{stageID: stage, version: 12},
 	}
@@ -83,9 +83,8 @@ func admitOpenMove(t *testing.T, callerIfMatch string) (seen string, status int)
 	r = r.WithContext(agentRequestCtx(r.Context()))
 
 	reg, spec := advanceSpec(t, deps)
-	ctx, err := auth.NewGate(fullSeat{}).Admit(r.Context(), spec, func() (mcp.TierResolverInput, error) {
-		return advanceDealTierInput(r.Context(), deps, agentPolicy{}, r, body)
-	})
+	pol := agentPolicies["POST /v1/deals/{id}/advance"]
+	ctx, err := auth.NewGate(fullSeat{}).Admit(r.Context(), spec, tierInput(r.Context(), spec, pol, deps, r, body))
 	if err != nil {
 		t.Fatalf("the open→open move was refused: %v", err)
 	}
@@ -95,9 +94,7 @@ func admitOpenMove(t *testing.T, callerIfMatch string) (seen string, status int)
 		seen = got.Header.Get("If-Match")
 	})
 	recorder := httptest.NewRecorder()
-	admitAgentCall(recorder, r, next, admissionOutcome{
-		pol: agentPolicies["POST /v1/deals/{id}/advance"], spec: spec, registry: reg,
-	})
+	admitAgentCall(recorder, r, next, admissionOutcome{pol: pol, spec: spec, registry: reg})
 	return seen, recorder.Code
 }
 
@@ -158,7 +155,7 @@ func TestACallerIfMatchTheGateDidNotReadIsRefused(t *testing.T) {
 // passing if pin forwarding regressed for every static call on the surface.
 func TestAWriteWithNoAdmittedPinIsForwardedUnconditioned(t *testing.T) {
 	stage := ids.NewV7()
-	deps := tierDeps{
+	deps := restCommandDeps{
 		stages:  reopenStages{semantics: map[ids.UUID]string{stage: "open"}},
 		records: versionedDeal{stageID: stage, version: 12},
 	}
@@ -178,11 +175,7 @@ func TestAWriteWithNoAdmittedPinIsForwardedUnconditioned(t *testing.T) {
 	body := []byte(`{"display_name":"Ada"}`)
 	r := httptest.NewRequest(http.MethodPost, "/v1/people", bytes.NewReader(body))
 	r = r.WithContext(agentRequestCtx(r.Context()))
-	resolve, known := tierInput(r.Context(), spec, pol, deps, r, body)
-	if !known {
-		t.Fatal("the gate has no tier input for a static-tier create")
-	}
-	ctx, err := auth.NewGate(fullSeat{}).Admit(r.Context(), spec, resolve)
+	ctx, err := auth.NewGate(fullSeat{}).Admit(r.Context(), spec, tierInput(r.Context(), spec, pol, deps, r, body))
 	if err != nil {
 		t.Fatalf("the create was refused: %v", err)
 	}

--- a/backend/internal/compose/agentgateredeem_test.go
+++ b/backend/internal/compose/agentgateredeem_test.go
@@ -88,9 +88,10 @@ func (p *probeCounter) HumanOwnedConflicts(context.Context, string, ids.UUID, js
 }
 
 // autoExecutedMove runs one open→open deal move — a move the tier gate admits
-// 🟢 — carrying the token given, and answers what the handler saw plus the
-// status the door replied with.
-func autoExecutedMove(t *testing.T, staging agents.Approvals, token string) (sawRequest, int) {
+// 🟢, reading the deal at version 12 — carrying the token and the caller
+// If-Match given, and answers what the handler saw plus the status the door
+// replied with.
+func autoExecutedMove(t *testing.T, staging agents.Approvals, token, callerIfMatch string) (sawRequest, int) {
 	t.Helper()
 	deal, stage := ids.NewV7(), ids.NewV7()
 	deps := restCommandDeps{
@@ -101,6 +102,9 @@ func autoExecutedMove(t *testing.T, staging agents.Approvals, token string) (saw
 	r := requestForDeal(t, deal)
 	if token != "" {
 		r.Header.Set(approvalTokenHeader, token)
+	}
+	if callerIfMatch != "" {
+		r.Header.Set("If-Match", callerIfMatch)
 	}
 	r = r.WithContext(agentRequestCtx(r.Context()))
 
@@ -129,7 +133,7 @@ func autoExecutedMove(t *testing.T, staging agents.Approvals, token string) (saw
 func TestAnAutoExecutedCallConsumesThePresentedToken(t *testing.T) {
 	staging := &countingRedeemer{pin: 12, pinned: true}
 
-	saw, status := autoExecutedMove(t, staging, ids.New[ids.ApprovalKind]().String())
+	saw, status := autoExecutedMove(t, staging, ids.New[ids.ApprovalKind]().String(), "")
 
 	if staging.redeemed != 1 {
 		t.Fatalf("the token was redeemed %d times, want exactly once — an unread token leaves the "+
@@ -162,7 +166,7 @@ func TestAnAutoExecutedCallRefusesATokenThatDoesNotHold(t *testing.T) {
 		"a surface with no approvals engine": {staging: nil, token: ids.New[ids.ApprovalKind]().String()},
 	} {
 		t.Run(name, func(t *testing.T) {
-			saw, status := autoExecutedMove(t, tc.staging, tc.token)
+			saw, status := autoExecutedMove(t, tc.staging, tc.token, "")
 
 			if status != http.StatusForbidden {
 				t.Errorf("status = %d, want 403 — an assertion of authority that does not hold must be "+
@@ -176,14 +180,47 @@ func TestAnAutoExecutedCallRefusesATokenThatDoesNotHold(t *testing.T) {
 	}
 }
 
-// The released pin and the pin the tier gate read must AGREE. A disagreement
-// means the row moved between the human's approval and this call, so neither
-// version is the one they judged and neither may condition the write.
-func TestAReleasedPinThatDisagreesWithTheAdmittedPinIsSkew(t *testing.T) {
+// A redeemed call takes the SERVER's pin over anything the caller sent, and is
+// never refused for the disagreement.
+//
+// The refusal this replaced looked right and was not: consumePresentedToken has
+// already spent the approval by the time the pin is decided, so a 409 here
+// destroys a human's one-shot yes on a call that never ran and can never be
+// redeemed again — while the 🟡 arm accepts the identical call. Forwarding
+// concedes nothing, because the store re-checks the pin inside the transaction
+// that mutates and refuses there unless the row is at the approved version.
+func TestAReleasedRetryTakesTheServersPinOverTheCallersIfMatch(t *testing.T) {
+	staging := &countingRedeemer{pin: 12, pinned: true}
+
+	saw, status := autoExecutedMove(t, staging, ids.New[ids.ApprovalKind]().String(), "4")
+
+	if status != http.StatusOK || !saw.ran {
+		t.Fatalf("the released retry answered %d and ran=%v — refusing it burns the approval it just "+
+			"consumed on a call that never happened", status, saw.ran)
+	}
+	if saw.ifMatch != "12" {
+		t.Errorf("forwarded If-Match = %q, want \"12\" — the caller's header is a version nothing proved, "+
+			"and this door hashes none into what the human approved", saw.ifMatch)
+	}
+}
+
+// The released pin and the pin the tier gate read disagreeing is a DEFENSIVE
+// assertion, not a case this door meets.
+//
+// Through the real stager it is unreachable: approvals pins server-side only for
+// a concrete, version-checkable target, versions are monotonic, and the gate's
+// read precedes the redemption's — so admitted ≤ current = released, and a row
+// that really moved fails validateRedemptionTarget inside the redemption first.
+// This reaches the branch only because countingRedeemer answers a pin without
+// the target re-check production performs. Whether refusing is even the right
+// answer for a disagreement both doors could only discover after the approval is
+// consumed is gradionhq/margince-poc-v1#1069; what this pins meanwhile is that
+// the branch is live and fails closed rather than picking a version.
+func TestADisagreementBetweenTheTwoServerPinsFailsClosed(t *testing.T) {
 	// versionedDeal reports 12 to the tier gate; the approval was granted at 9.
 	staging := &countingRedeemer{pin: 9, pinned: true}
 
-	saw, status := autoExecutedMove(t, staging, ids.New[ids.ApprovalKind]().String())
+	saw, status := autoExecutedMove(t, staging, ids.New[ids.ApprovalKind]().String(), "")
 
 	if status != http.StatusConflict {
 		t.Errorf("status = %d, want 409 — picking either version would run the write against a state "+
@@ -277,7 +314,7 @@ func (p stagedDeal) Read(_ context.Context, ref datasource.EntityRef) (datasourc
 // sourceSemantic decides the arm: an open source is the 🟢 move, a won one is
 // the 🟡 refusal, and the tool, the route and the policy are identical either
 // way. That is the point: the claim is one charge per CALL, not one per arm.
-func gateCallCharges(t *testing.T, sourceSemantic, token string) (int, int) {
+func gateCallCharges(t *testing.T, sourceSemantic, token string, redeemErr error) (int, int) {
 	t.Helper()
 	deal, current, target := ids.NewV7(), ids.NewV7(), ids.NewV7()
 	stages := reopenStages{semantics: map[ids.UUID]string{current: sourceSemantic, target: "open"}}
@@ -297,7 +334,7 @@ func gateCallCharges(t *testing.T, sourceSemantic, token string) (int, int) {
 	routeCtx.URLParams.Add("id", deal.String())
 	r = r.WithContext(context.WithValue(agentRequestCtx(r.Context()), chi.RouteCtxKey, routeCtx))
 
-	staging := &countingRedeemer{pin: 12, pinned: true}
+	staging := &countingRedeemer{pin: 12, pinned: true, err: redeemErr}
 	recorder := httptest.NewRecorder()
 	gate := agentGate(reg, staging, stages, records, nil, auth.NewGate(fullSeat{}))
 	gate(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -307,13 +344,20 @@ func gateCallCharges(t *testing.T, sourceSemantic, token string) (int, int) {
 	return charger.spent[agentquota.Calls], recorder.Code
 }
 
-// The call ceiling counts CALLS, so a call that ran spends exactly one of it
-// whichever arm carried it, and a call that ran nothing spends none. Charging
+// The call ceiling counts CALLS THAT RAN: one apiece whichever arm carried them,
+// and none at all for a call that ran nothing.
+//
+// The last row is the one that costs something to get wrong. Exhausting
+// MCP-SESS-CALLS suspends the Passport for the window, so charging a call whose
+// token opened nothing lets an agent looping one consumed token spend its own
+// credential's whole day — on REST only, since the MCP door refuses to count
+// exactly that (registry.go: "a replayed token that opens nothing"). Charging
 // the redemption on top of the admission would bill a 🟢 retry twice for one
 // act; leaving the 🟡 redemption uncharged would leave the arm that redeems free.
 func TestOneRestCallSpendsOneOfTheCallCeiling(t *testing.T) {
 	for name, tc := range map[string]struct {
 		source, token string
+		redeemErr     error
 		wantCalls     int
 		wantStatus    int
 	}{
@@ -325,9 +369,17 @@ func TestOneRestCallSpendsOneOfTheCallCeiling(t *testing.T) {
 			source: "won", token: ids.New[ids.ApprovalKind]().String(), wantCalls: 1, wantStatus: http.StatusOK,
 		},
 		"confirm-first, staged and never run": {source: "won", wantCalls: 0, wantStatus: http.StatusForbidden},
+		"auto-executed, presenting a token that opens nothing": {
+			source: "open", token: ids.New[ids.ApprovalKind]().String(),
+			redeemErr: apperrors.ErrApprovalTokenInvalid, wantCalls: 0, wantStatus: http.StatusForbidden,
+		},
+		"confirm-first, presenting a token that opens nothing": {
+			source: "won", token: ids.New[ids.ApprovalKind]().String(),
+			redeemErr: apperrors.ErrApprovalTokenInvalid, wantCalls: 0, wantStatus: http.StatusForbidden,
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			calls, status := gateCallCharges(t, tc.source, tc.token)
+			calls, status := gateCallCharges(t, tc.source, tc.token, tc.redeemErr)
 			if status != tc.wantStatus {
 				t.Fatalf("status = %d, want %d — this case is not the arm it names", status, tc.wantStatus)
 			}

--- a/backend/internal/compose/agentgateredeem_test.go
+++ b/backend/internal/compose/agentgateredeem_test.go
@@ -1,0 +1,339 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The auto-executed arm's half of the approval loop
+// (gradionhq/margince/backend — gradionhq/margince-poc-v1#812).
+//
+// A staged 🟡 call can resolve 🟢 on its retry: the record moved, or the
+// per-field split staged an otherwise auto-execute patch. The token that retry
+// presents is an assertion of authority, and this door used to read it for
+// update_record alone — so for every other tool the approval stayed pending in a
+// human's inbox for work that had already happened, and an invalid or replayed
+// token was accepted by being ignored.
+//
+// Admission runs through the real gate and the real tier input, so what these
+// assert is what the middleware produces rather than what a hand-set context
+// claims.
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/gradionhq/margince/backend/internal/modules/agents"
+	"github.com/gradionhq/margince/backend/internal/platform/agentquota"
+	"github.com/gradionhq/margince/backend/internal/platform/auth"
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
+)
+
+// countingRedeemer is the approvals engine as this door uses it: it records what
+// each redemption was asked about, so a test can say the token was validated
+// against THIS call rather than merely consumed.
+type countingRedeemer struct {
+	pin      int64
+	pinned   bool
+	err      error
+	redeemed int
+	tools    []string
+	hashes   []string
+}
+
+// StageQuotaRelease satisfies the seam; a step-up never reaches these tests.
+func (*countingRedeemer) StageQuotaRelease(context.Context, agents.QuotaReleaseRequest) (ids.ApprovalID, bool, error) {
+	return ids.ApprovalID{}, false, nil
+}
+
+func (*countingRedeemer) Stage(context.Context, agents.StageRequest) (ids.ApprovalID, error) {
+	return ids.New[ids.ApprovalKind](), nil
+}
+
+func (c *countingRedeemer) Redeem(_ context.Context, _ ids.ApprovalID, tool, diffHash string) (int64, bool, error) {
+	c.redeemed++
+	c.tools = append(c.tools, tool)
+	c.hashes = append(c.hashes, diffHash)
+	if c.err != nil {
+		return 0, false, c.err
+	}
+	return c.pin, c.pinned, nil
+}
+
+// sawRequest is what the handler behind the door was handed, or that it was
+// never reached at all. The released marker is read through the seam's own
+// exported probe — the same answer the egress backstop asks for — so a pin
+// forwarded without the marker, or the reverse, is visible here.
+type sawRequest struct {
+	ran      bool
+	ifMatch  string
+	released bool
+}
+
+// probeCounter records whether the per-field ownership split ran. A redeemed
+// retry must not be re-split: it carries exactly the sub-patch a human released,
+// and probing it again would stage a second approval for the overwrite that was
+// just approved.
+type probeCounter struct{ probes int }
+
+func (p *probeCounter) HumanOwnedConflicts(context.Context, string, ids.UUID, json.RawMessage) ([]string, error) {
+	p.probes++
+	return nil, nil
+}
+
+// autoExecutedMove runs one open→open deal move — a move the tier gate admits
+// 🟢 — carrying the token given, and answers what the handler saw plus the
+// status the door replied with.
+func autoExecutedMove(t *testing.T, staging agents.Approvals, token string) (sawRequest, int) {
+	t.Helper()
+	deal, stage := ids.NewV7(), ids.NewV7()
+	deps := restCommandDeps{
+		stages:  reopenStages{semantics: map[ids.UUID]string{stage: "open"}},
+		records: versionedDeal{stageID: stage, version: 12},
+	}
+	body := []byte(`{"to_stage_id":"` + stage.String() + `"}`)
+	r := requestForDeal(t, deal)
+	if token != "" {
+		r.Header.Set(approvalTokenHeader, token)
+	}
+	r = r.WithContext(agentRequestCtx(r.Context()))
+
+	reg, spec := advanceSpec(t, deps)
+	pol := agentPolicies["POST /v1/deals/{id}/advance"]
+	ctx, err := auth.NewGate(fullSeat{}).Admit(r.Context(), spec, tierInput(r.Context(), spec, pol, deps, r, body))
+	if err != nil {
+		t.Fatalf("the open→open move was refused before its token was ever read: %v", err)
+	}
+	r = r.WithContext(ctx)
+
+	var saw sawRequest
+	next := http.HandlerFunc(func(_ http.ResponseWriter, got *http.Request) {
+		saw = sawRequest{ran: true, ifMatch: got.Header.Get("If-Match"), released: agents.ApprovalRedeemed(got.Context())}
+	})
+	recorder := httptest.NewRecorder()
+	admitAgentCall(recorder, r, next, admissionOutcome{
+		staging: staging, pol: pol, body: body, commands: deps, spec: spec, registry: reg,
+	})
+	return saw, recorder.Code
+}
+
+// A valid token on an auto-executed call is CONSUMED, and consumed against this
+// exact call: the approval it names stops being a pending question in a human's
+// inbox about work that has already happened.
+func TestAnAutoExecutedCallConsumesThePresentedToken(t *testing.T) {
+	staging := &countingRedeemer{pin: 12, pinned: true}
+
+	saw, status := autoExecutedMove(t, staging, ids.New[ids.ApprovalKind]().String())
+
+	if staging.redeemed != 1 {
+		t.Fatalf("the token was redeemed %d times, want exactly once — an unread token leaves the "+
+			"approval pending for work that already happened", staging.redeemed)
+	}
+	if staging.tools[0] != "advance_deal" || staging.hashes[0] == "" {
+		t.Errorf("redeemed against tool %q and hash %q — a token must be validated against the call "+
+			"presenting it, not merely spent", staging.tools[0], staging.hashes[0])
+	}
+	if !saw.ran || status != http.StatusOK {
+		t.Fatalf("the released call ran=%v at status %d, want it through at 200", saw.ran, status)
+	}
+	if !saw.released {
+		t.Error("the handler ran without the released marker — the seam's egress backstop reads exactly that")
+	}
+}
+
+// An asserted authority that does not hold is REFUSED, never ignored. All three
+// failures are one answer: nothing ran, and the caller is told why.
+func TestAnAutoExecutedCallRefusesATokenThatDoesNotHold(t *testing.T) {
+	for name, tc := range map[string]struct {
+		staging agents.Approvals
+		token   string
+	}{
+		"a token that is not an approval id": {staging: &countingRedeemer{}, token: "not-an-approval-id"},
+		"a replayed or expired approval": {
+			staging: &countingRedeemer{err: apperrors.ErrApprovalTokenInvalid},
+			token:   ids.New[ids.ApprovalKind]().String(),
+		},
+		"a surface with no approvals engine": {staging: nil, token: ids.New[ids.ApprovalKind]().String()},
+	} {
+		t.Run(name, func(t *testing.T) {
+			saw, status := autoExecutedMove(t, tc.staging, tc.token)
+
+			if status != http.StatusForbidden {
+				t.Errorf("status = %d, want 403 — an assertion of authority that does not hold must be "+
+					"answered, not stepped over", status)
+			}
+			if saw.ran {
+				t.Error("the handler ran anyway, which is the call being admitted with its own asserted " +
+					"authority left unread")
+			}
+		})
+	}
+}
+
+// The released pin and the pin the tier gate read must AGREE. A disagreement
+// means the row moved between the human's approval and this call, so neither
+// version is the one they judged and neither may condition the write.
+func TestAReleasedPinThatDisagreesWithTheAdmittedPinIsSkew(t *testing.T) {
+	// versionedDeal reports 12 to the tier gate; the approval was granted at 9.
+	staging := &countingRedeemer{pin: 9, pinned: true}
+
+	saw, status := autoExecutedMove(t, staging, ids.New[ids.ApprovalKind]().String())
+
+	if status != http.StatusConflict {
+		t.Errorf("status = %d, want 409 — picking either version would run the write against a state "+
+			"nothing authorized", status)
+	}
+	if saw.ran {
+		t.Errorf("the handler ran with If-Match %q despite the two pins naming different records", saw.ifMatch)
+	}
+}
+
+// Where the gate read no record — a static auto-execute tier — the approval's
+// own pin is what conditions the write, and the redeemed retry goes straight to
+// the handler: it carries exactly the sub-patch a human released, so re-running
+// the ownership split over it would stage a second approval for the overwrite
+// just approved.
+func TestAReleasedRetryOnAStaticTierIsPinnedAndNotResplit(t *testing.T) {
+	person := ids.NewV7()
+	pol := agentPolicies["PATCH /v1/people/{id}"]
+	if pol.Tier != tierAutoExecute || pol.Tool != "update_record" {
+		t.Fatalf("PATCH /v1/people/{id} is %q on %s — this case is about a redeemed retry of the split", pol.Tier, pol.Tool)
+	}
+	body := []byte(`{"display_name":"Ada"}`)
+	r := httptest.NewRequest(http.MethodPatch, "/v1/people/"+person.String(), http.NoBody)
+	r.Header.Set(approvalTokenHeader, ids.New[ids.ApprovalKind]().String())
+	routeCtx := chi.NewRouteContext()
+	routeCtx.URLParams.Add("id", person.String())
+	r = r.WithContext(context.WithValue(agentRequestCtx(r.Context()), chi.RouteCtxKey, routeCtx))
+
+	var saw sawRequest
+	next := http.HandlerFunc(func(_ http.ResponseWriter, got *http.Request) {
+		saw = sawRequest{ran: true, ifMatch: got.Header.Get("If-Match"), released: agents.ApprovalRedeemed(got.Context())}
+	})
+	ownership := &probeCounter{}
+	reg := agents.NewRegistry(nil, auth.NewGate(fullSeat{}))
+	agents.RegisterCoreTools(reg, seamRecord{}, nil, nil, nil)
+	spec, _, ok := operationSpec(pol, reg)
+	if !ok {
+		t.Fatal("the registry serves no update_record spec for the REST twin to admit against")
+	}
+	admitAgentCall(httptest.NewRecorder(), r, next, admissionOutcome{
+		staging: &countingRedeemer{pin: 7, pinned: true}, ownership: ownership,
+		pol: pol, body: body, commands: restCommandDeps{records: seamRecord{}},
+		spec: spec, registry: reg,
+	})
+
+	if !saw.ran || !saw.released {
+		t.Fatalf("the released patch ran=%v with the marker=%v, want both", saw.ran, saw.released)
+	}
+	if saw.ifMatch != "7" {
+		t.Errorf("forwarded If-Match = %q, want \"7\" — with no version read at admission the approval's "+
+			"own pin is the only one anything proved", saw.ifMatch)
+	}
+	if ownership.probes != 0 {
+		t.Errorf("the ownership split ran %d times on a redeemed retry — it would stage a second approval "+
+			"for the overwrite a human just approved", ownership.probes)
+	}
+}
+
+// countingCharges is the quota meter as the REST door uses it: it only ever
+// receives charges, and keeps them per counter.
+type countingCharges struct{ spent map[agentquota.Counter]int }
+
+func (c *countingCharges) Consume(_ context.Context, counter agentquota.Counter, n int) error {
+	c.spent[counter] += n
+	return nil
+}
+
+// stagedDeal is a deal the record seam serves as its OWN — authoritative, at a
+// known version, sitting in a known stage. Authority is stamped because
+// refuseStagingElsewhere reads exactly that flag: an unstamped fixture would be
+// refused before the 🟡 arm this exercises was ever reached.
+type stagedDeal struct {
+	datasource.SystemOfRecordProvider
+	stageID ids.UUID
+	version int64
+}
+
+func (p stagedDeal) Read(_ context.Context, ref datasource.EntityRef) (datasource.Record, error) {
+	return datasource.Record{
+		Ref:       ref,
+		Fields:    json.RawMessage(`{"stage_id":"` + p.stageID.String() + `","name":"Acme"}`),
+		Version:   p.version,
+		Freshness: datasource.FreshnessInfo{Authoritative: true},
+	}, nil
+}
+
+// gateCallCharges runs ONE request through the whole middleware — the only place
+// both call-charge points are reachable — and answers what it spent against the
+// call ceiling, plus the status.
+//
+// sourceSemantic decides the arm: an open source is the 🟢 move, a won one is
+// the 🟡 refusal, and the tool, the route and the policy are identical either
+// way. That is the point: the claim is one charge per CALL, not one per arm.
+func gateCallCharges(t *testing.T, sourceSemantic, token string) (int, int) {
+	t.Helper()
+	deal, current, target := ids.NewV7(), ids.NewV7(), ids.NewV7()
+	stages := reopenStages{semantics: map[ids.UUID]string{current: sourceSemantic, target: "open"}}
+	var records datasource.SystemOfRecordProvider = stagedDeal{stageID: current, version: 12}
+	charger := &countingCharges{spent: map[agentquota.Counter]int{}}
+
+	reg := agents.NewRegistry(nil, auth.NewGate(fullSeat{}), agents.WithQuotaCharger(charger))
+	agents.RegisterCoreTools(reg, records, stages, nil, nil)
+
+	r := httptest.NewRequest(http.MethodPost, "/v1/deals/"+deal.String()+"/advance",
+		strings.NewReader(`{"to_stage_id":"`+target.String()+`"}`))
+	if token != "" {
+		r.Header.Set(approvalTokenHeader, token)
+	}
+	routeCtx := chi.NewRouteContext()
+	routeCtx.RoutePatterns = []string{"/v1/deals/{id}/advance"}
+	routeCtx.URLParams.Add("id", deal.String())
+	r = r.WithContext(context.WithValue(agentRequestCtx(r.Context()), chi.RouteCtxKey, routeCtx))
+
+	staging := &countingRedeemer{pin: 12, pinned: true}
+	recorder := httptest.NewRecorder()
+	gate := agentGate(reg, staging, stages, records, nil, auth.NewGate(fullSeat{}))
+	gate(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})).ServeHTTP(recorder, r)
+
+	return charger.spent[agentquota.Calls], recorder.Code
+}
+
+// The call ceiling counts CALLS, so a call that ran spends exactly one of it
+// whichever arm carried it, and a call that ran nothing spends none. Charging
+// the redemption on top of the admission would bill a 🟢 retry twice for one
+// act; leaving the 🟡 redemption uncharged would leave the arm that redeems free.
+func TestOneRestCallSpendsOneOfTheCallCeiling(t *testing.T) {
+	for name, tc := range map[string]struct {
+		source, token string
+		wantCalls     int
+		wantStatus    int
+	}{
+		"auto-executed, no token": {source: "open", wantCalls: 1, wantStatus: http.StatusOK},
+		"auto-executed, redeeming a token": {
+			source: "open", token: ids.New[ids.ApprovalKind]().String(), wantCalls: 1, wantStatus: http.StatusOK,
+		},
+		"confirm-first, redeeming a token": {
+			source: "won", token: ids.New[ids.ApprovalKind]().String(), wantCalls: 1, wantStatus: http.StatusOK,
+		},
+		"confirm-first, staged and never run": {source: "won", wantCalls: 0, wantStatus: http.StatusForbidden},
+	} {
+		t.Run(name, func(t *testing.T) {
+			calls, status := gateCallCharges(t, tc.source, tc.token)
+			if status != tc.wantStatus {
+				t.Fatalf("status = %d, want %d — this case is not the arm it names", status, tc.wantStatus)
+			}
+			if calls != tc.wantCalls {
+				t.Errorf("the call ceiling was charged %d, want %d", calls, tc.wantCalls)
+			}
+		})
+	}
+}

--- a/backend/internal/compose/agentgatestaging.go
+++ b/backend/internal/compose/agentgatestaging.go
@@ -10,8 +10,11 @@ package compose
 // already there: agentgate.go decides whether a call is ADMITTED, and this is
 // what happens to the one answer that is neither yes nor no. The MCP door's
 // twin of this file is modules/agents/approvals.go, and the two must agree on
-// what "the identical call" means — which is why both hash through
-// shared/kernel/diffhash rather than each spelling it.
+// what "the identical call" means even though each hashes it through its own
+// spelling — the MCP door through shared/kernel/diffhash
+// (modules/agents/reserved.go), this door through its own canonicalRESTCall
+// (agentgatecanon.go), because a REST call carries a method, a concrete path
+// and headers that a tool call's arguments object has no place for.
 
 import (
 	"fmt"

--- a/backend/internal/compose/agentgatestaging.go
+++ b/backend/internal/compose/agentgatestaging.go
@@ -17,6 +17,7 @@ package compose
 // and headers that a tool call's arguments object has no place for.
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -47,37 +48,46 @@ func stageOrRedeem(w http.ResponseWriter, r *http.Request, next http.Handler, st
 	return false
 }
 
-// redeemIfPresented consumes an X-Approval-Token when the request carries
-// one: a valid token bound to this exact call lets it through to the
-// handler; an invalid one is answered with the failure — asserted
-// authority is validated, never ignored.
+// tokenRedemption is what consuming a presented X-Approval-Token yielded: the
+// context marked as released — the marker the seam's egress backstop reads, and
+// the only proof a human released THIS call — plus the version the approval was
+// granted against.
+type tokenRedemption struct {
+	released context.Context
+	pin      int64
+	pinned   bool
+}
+
+// consumePresentedToken validates and consumes the X-Approval-Token on this
+// request: a valid token bound to this exact call is spent, and an invalid one
+// is answered with the failure — asserted authority is validated, never ignored.
 //
-// It answers TWO things, because they are two different facts and a caller
-// needs both: `handled` says the request has been answered and the caller
-// should stop, `ran` says a handler actually executed. They differ on every
-// refusal path here — a malformed token is handled and ran nothing — and the
-// difference is what decides whether an effect is charged. Reading one off the
-// other (by inspecting the status already written, say) would be a second
-// reading of one value, which is how these two come to disagree.
-func redeemIfPresented(w http.ResponseWriter, r *http.Request, next http.Handler, staging agents.Approvals, pol agentPolicy, body []byte) (handled, ran bool) {
+// It answers THREE things, because they are three different facts and both arms
+// of the gate need all of them: `presented` says the request asserted an
+// authority at all, `ok` says that assertion held, and the redemption carries
+// what the release proved. Nothing here forwards to a handler — what a released
+// call is then conditioned on differs between the two arms (agentgate.go's
+// pinAutoExecutedWrite and redeemIfPresented below), and folding the dispatch in
+// here is what left one arm redeeming and the other ignoring the same header.
+func consumePresentedToken(w http.ResponseWriter, r *http.Request, staging agents.Approvals, pol agentPolicy, body []byte) (redemption tokenRedemption, presented, ok bool) {
 	token := r.Header.Get(approvalTokenHeader)
 	if token == "" {
-		return false, false
+		return tokenRedemption{}, false, false
 	}
 	approvalID, pErr := ids.ParseAs[ids.ApprovalKind](token)
 	if pErr != nil {
 		httperr.Write(w, r, fmt.Errorf("agent gate: malformed %s: %w", approvalTokenHeader, apperrors.ErrApprovalTokenInvalid))
-		return true, false
+		return tokenRedemption{}, true, false
 	}
 	_, diffHash, cErr := canonicalRESTCall(pol.Op, r.URL.Path, r.Header, body, keyBindsTheRetry)
 	if cErr != nil {
 		httperr.Write(w, r, cErr)
-		return true, false
+		return tokenRedemption{}, true, false
 	}
 	if staging == nil {
 		httperr.Write(w, r, fmt.Errorf("agent gate: %s presented but this surface has no approvals engine: %w",
 			approvalTokenHeader, apperrors.ErrApprovalTokenInvalid))
-		return true, false
+		return tokenRedemption{}, true, false
 	}
 	// Redeeming and marking are one step (agents.RedeemAndMark), so this
 	// transport cannot forward an approved call without the released marker the
@@ -85,6 +95,36 @@ func redeemIfPresented(w http.ResponseWriter, r *http.Request, next http.Handler
 	released, pin, pinned, rErr := agents.RedeemAndMark(r.Context(), staging, approvalID, pol.Tool, diffHash)
 	if rErr != nil {
 		httperr.Write(w, r, rErr)
+		return tokenRedemption{}, true, false
+	}
+	return tokenRedemption{released: released, pin: pin, pinned: pinned}, true, true
+}
+
+// redeemIfPresented is the 🟡 arm's use of the redemption above: a released call
+// goes through to the handler, carrying the approval's pin as its own If-Match.
+//
+// It answers TWO things, because they are two different facts and a caller
+// needs both: `handled` says the request has been answered and the caller
+// should stop, `ran` says a handler actually executed. They differ on every
+// refusal path — a malformed token is handled and ran nothing — and the
+// difference is what decides whether an effect is charged. Reading one off the
+// other (by inspecting the status already written, say) would be a second
+// reading of one value, which is how these two come to disagree.
+//
+// The released pin OVERRIDES a caller's own If-Match here, where the 🟢 arm
+// checks the two against each other instead (pinAutoExecutedWrite). The two
+// arms differ because the caller's header has been proved against something on
+// one and against nothing on the other: a 🟢 admission read the record itself
+// and pinAdmittedWrite already refused an If-Match naming a version it did not
+// read, while a 🟡 call was admitted by a human's decision and this door hashes
+// no If-Match into the identity that decision bound (agentgatecanon.go says
+// why). The approval's own pin is then the only version anything proved.
+func redeemIfPresented(w http.ResponseWriter, r *http.Request, next http.Handler, staging agents.Approvals, pol agentPolicy, body []byte) (handled, ran bool) {
+	redemption, presented, ok := consumePresentedToken(w, r, staging, pol, body)
+	if !presented {
+		return false, false
+	}
+	if !ok {
 		return true, false
 	}
 	// Redemption commits its OWN transaction, and the handler below opens a
@@ -96,12 +136,12 @@ func redeemIfPresented(w http.ResponseWriter, r *http.Request, next http.Handler
 	// forward as the request's own If-Match makes the store re-check it
 	// inside the transaction that actually mutates, where a concurrent write
 	// loses to the version compare instead of to timing.
-	if pinned {
-		r.Header.Set("If-Match", strconv.FormatInt(pin, 10))
+	if redemption.pinned {
+		r.Header.Set("If-Match", strconv.FormatInt(redemption.pin, 10))
 	}
 	// WithContext shares the header map set just above, so the pin travels with
 	// the released request.
-	next.ServeHTTP(w, r.WithContext(released))
+	next.ServeHTTP(w, r.WithContext(redemption.released))
 	return true, true
 }
 

--- a/backend/internal/compose/agentgatestaging.go
+++ b/backend/internal/compose/agentgatestaging.go
@@ -28,6 +28,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/platform/httperr"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
 )
 
 // stageOrRedeem handles the 🟡 outcome. The identical call is the
@@ -40,12 +41,12 @@ import (
 // whether an effect was performed and so whether one is charged. A redemption
 // that forwarded reports true; a refused token and a fresh staging both report
 // false, because neither ran anything.
-func stageOrRedeem(w http.ResponseWriter, r *http.Request, next http.Handler, staging agents.Approvals, pol agentPolicy, body []byte) bool {
+func stageOrRedeem(w http.ResponseWriter, r *http.Request, next http.Handler, staging agents.Approvals, records datasource.SystemOfRecordProvider, pol agentPolicy, body []byte) bool {
 	handled, ran := redeemIfPresented(w, r, next, staging, pol, body)
 	if handled {
 		return ran
 	}
-	stageRefusal(w, r, staging, pol, body)
+	stageRefusal(w, r, staging, records, pol, body)
 	return false
 }
 
@@ -110,7 +111,7 @@ func redeemIfPresented(w http.ResponseWriter, r *http.Request, next http.Handler
 // stageRefusal stages the refused call as a pending approval and answers
 // with the redemption instructions — the whole request, unapplied, is the
 // staged change, so the approved retry is this exact request again.
-func stageRefusal(w http.ResponseWriter, r *http.Request, staging agents.Approvals, pol agentPolicy, body []byte) {
+func stageRefusal(w http.ResponseWriter, r *http.Request, staging agents.Approvals, records datasource.SystemOfRecordProvider, pol agentPolicy, body []byte) {
 	ctx := r.Context()
 	canonical, diffHash, cErr := canonicalRESTCall(pol.Op, r.URL.Path, r.Header, body)
 	if cErr != nil {
@@ -125,25 +126,8 @@ func stageRefusal(w http.ResponseWriter, r *http.Request, staging agents.Approva
 			"agent gate: %s (%s) has no approval decision mapping: %w", pol.Op, pol.Tool, apperrors.ErrPermissionDenied))
 		return
 	}
-	var targetID ids.UUID
-	if raw := chi.URLParam(r, "id"); raw != "" {
-		var err error
-		if targetID, err = ids.Parse(raw); err != nil {
-			httperr.Write(w, r, apperrors.ErrNotFound)
-			return
-		}
-	}
-	// A concrete target with no record type is unstageable authority: the
-	// approvals surface scopes an inbox row by probing its target's own/team
-	// visibility, and it cannot probe a type it was not told. Such a row
-	// would show a record's summary and proposed change to everyone holding
-	// the object grant, and let any of them decide a write against a row
-	// their own scope hides. Refuse it here, the same fail-closed shape as
-	// an undecidable kind, rather than mint an unscopable authority object.
-	if targetID != (ids.UUID{}) && pol.RecordType == "" {
-		httperr.Write(w, r, fmt.Errorf(
-			"agent gate: %s stages against a concrete record but declares no record type: %w",
-			pol.Op, apperrors.ErrPermissionDenied))
+	target, ok := stagedTarget(w, r, records, pol)
+	if !ok {
 		return
 	}
 	// The version a human approves is pinned SERVER-SIDE, inside the staging
@@ -159,8 +143,8 @@ func stageRefusal(w http.ResponseWriter, r *http.Request, staging agents.Approva
 		Tool:           pol.Tool,
 		ProposedChange: canonical,
 		DiffHash:       diffHash,
-		TargetType:     string(pol.RecordType),
-		TargetID:       targetID,
+		TargetType:     target.TargetType,
+		TargetID:       target.TargetID,
 		Summary:        restSummary(pol.Op, r.Method, r.URL.Path, body),
 	})
 	if sErr != nil {
@@ -169,5 +153,69 @@ func stageRefusal(w http.ResponseWriter, r *http.Request, staging agents.Approva
 	}
 	httperr.Write(w, r, fmt.Errorf(
 		"staged as approval %s — once a human approves it, repeat this exact request with the %s: %s header: %w",
-		approvalID, approvalTokenHeader, approvalID, apperrors.ErrRequiresApproval))
+		approvalID, approvalTokenHeader, approvalID, apperrors.ErrRequiresApproval,
+	))
+}
+
+// stagedTarget answers what the approval binds to: the record type and the id
+// the human's decision will be scoped and pinned by.
+//
+// An operation this door can decode into a typed command (agentcommand.go) is
+// answered by the SAME resolver the tool door asks, so the two cannot describe
+// one operation differently — and the resolver's guards run here too, refusing
+// a target the caller cannot see before a human is asked about it. Everything
+// else still walks the route below.
+//
+// Only the target is taken from the resolver. The line the human reads stays
+// this door's own (restSummary), because a REST summary names the concrete
+// method, path and body fields that this door's diff_hash actually binds.
+//
+// It writes the refusal itself and reports ok=false, so a caller that cannot
+// name a target stages nothing.
+func stagedTarget(w http.ResponseWriter, r *http.Request, records datasource.SystemOfRecordProvider, pol agentPolicy) (agents.StageInfo, bool) {
+	decode, described := restCommands[pol.Op]
+	if !described {
+		return stagedTargetByRoute(w, r, pol)
+	}
+	call, err := decode(pol, records, r)
+	if err != nil {
+		httperr.Write(w, r, err)
+		return agents.StageInfo{}, false
+	}
+	info, err := agents.StageSubject(r.Context(), call)
+	if err != nil {
+		httperr.Write(w, r, err)
+		return agents.StageInfo{}, false
+	}
+	return info, true
+}
+
+// stagedTargetByRoute is the guess the seam above is replacing: the target id
+// read out of the route's {id} parameter and paired with the record type the
+// generated policy declares. It stands for every operation with no command
+// entry yet, and goes away with the last of them.
+func stagedTargetByRoute(w http.ResponseWriter, r *http.Request, pol agentPolicy) (agents.StageInfo, bool) {
+	var targetID ids.UUID
+	if raw := chi.URLParam(r, "id"); raw != "" {
+		var err error
+		if targetID, err = ids.Parse(raw); err != nil {
+			httperr.Write(w, r, apperrors.ErrNotFound)
+			return agents.StageInfo{}, false
+		}
+	}
+	// A concrete target with no record type is unstageable authority: the
+	// approvals surface scopes an inbox row by probing its target's own/team
+	// visibility, and it cannot probe a type it was not told. Such a row
+	// would show a record's summary and proposed change to everyone holding
+	// the object grant, and let any of them decide a write against a row
+	// their own scope hides. Refuse it here, the same fail-closed shape as
+	// an undecidable kind, rather than mint an unscopable authority object.
+	if targetID != (ids.UUID{}) && pol.RecordType == "" {
+		httperr.Write(w, r, fmt.Errorf(
+			"agent gate: %s stages against a concrete record but declares no record type: %w",
+			pol.Op, apperrors.ErrPermissionDenied,
+		))
+		return agents.StageInfo{}, false
+	}
+	return agents.StageInfo{TargetType: string(pol.RecordType), TargetID: targetID}, true
 }

--- a/backend/internal/compose/agentgatestaging.go
+++ b/backend/internal/compose/agentgatestaging.go
@@ -153,8 +153,7 @@ func stageRefusal(w http.ResponseWriter, r *http.Request, staging agents.Approva
 	}
 	httperr.Write(w, r, fmt.Errorf(
 		"staged as approval %s — once a human approves it, repeat this exact request with the %s: %s header: %w",
-		approvalID, approvalTokenHeader, approvalID, apperrors.ErrRequiresApproval,
-	))
+		approvalID, approvalTokenHeader, approvalID, apperrors.ErrRequiresApproval))
 }
 
 // stagedTarget answers what the approval binds to: the record type and the id
@@ -213,8 +212,7 @@ func stagedTargetByRoute(w http.ResponseWriter, r *http.Request, pol agentPolicy
 	if targetID != (ids.UUID{}) && pol.RecordType == "" {
 		httperr.Write(w, r, fmt.Errorf(
 			"agent gate: %s stages against a concrete record but declares no record type: %w",
-			pol.Op, apperrors.ErrPermissionDenied,
-		))
+			pol.Op, apperrors.ErrPermissionDenied))
 		return agents.StageInfo{}, false
 	}
 	return agents.StageInfo{TargetType: string(pol.RecordType), TargetID: targetID}, true

--- a/backend/internal/compose/agentgatestaging.go
+++ b/backend/internal/compose/agentgatestaging.go
@@ -78,7 +78,7 @@ func presentedApprovalToken(r *http.Request) string {
 // of the gate need all of them: `presented` says the request asserted an
 // authority at all, `ok` says that assertion held, and the redemption carries
 // what the release proved. Nothing here forwards to a handler — what a released
-// call is then conditioned on differs between the two arms (agentgate.go's
+// call is then conditioned on differs between the two arms (agentgateauto.go's
 // pinAutoExecutedWrite and redeemIfPresented below), and folding the dispatch in
 // here is what left one arm redeeming and the other ignoring the same header.
 func consumePresentedToken(w http.ResponseWriter, r *http.Request, staging agents.Approvals, pol agentPolicy, body []byte) (redemption tokenRedemption, presented, ok bool) {

--- a/backend/internal/compose/agentgatestaging.go
+++ b/backend/internal/compose/agentgatestaging.go
@@ -125,7 +125,7 @@ func stageRefusal(w http.ResponseWriter, r *http.Request, staging agents.Approva
 			"agent gate: %s (%s) has no approval decision mapping: %w", pol.Op, pol.Tool, apperrors.ErrPermissionDenied))
 		return
 	}
-	target, ok := stagedTarget(w, r, commands, pol)
+	target, ok := stagedTarget(w, r, commands, pol, body)
 	if !ok {
 		return
 	}
@@ -175,8 +175,8 @@ func stageRefusal(w http.ResponseWriter, r *http.Request, staging agents.Approva
 //
 // It writes the refusal itself and reports ok=false, so a caller that cannot
 // name a target stages nothing.
-func stagedTarget(w http.ResponseWriter, r *http.Request, commands restCommandDeps, pol agentPolicy) (agents.StageInfo, bool) {
-	info, ok := resolveOrWalk(w, r, commands, pol)
+func stagedTarget(w http.ResponseWriter, r *http.Request, commands restCommandDeps, pol agentPolicy, body []byte) (agents.StageInfo, bool) {
+	info, ok := resolveOrWalk(w, r, commands, pol, body)
 	if !ok {
 		return agents.StageInfo{}, false
 	}
@@ -202,12 +202,18 @@ func stagedTarget(w http.ResponseWriter, r *http.Request, commands restCommandDe
 
 // resolveOrWalk answers the staged target from the operation's own resolver
 // where it has one, and from the route where it does not.
-func resolveOrWalk(w http.ResponseWriter, r *http.Request, commands restCommandDeps, pol agentPolicy) (agents.StageInfo, bool) {
+//
+// body is the same buffered copy stageRefusal already hashed into
+// canonicalRESTCall — passed through rather than re-read off r.Body, so a
+// decoder that needs the request payload (create, patch) is a pure function
+// of values the gate already proved readable, with no second reader of a
+// stream nothing guarantees stays replayable.
+func resolveOrWalk(w http.ResponseWriter, r *http.Request, commands restCommandDeps, pol agentPolicy, body []byte) (agents.StageInfo, bool) {
 	decode, described := restCommands[pol.Op]
 	if !described {
 		return stagedTargetByRoute(w, r, pol)
 	}
-	call, err := decode(pol, commands, r)
+	call, err := decode(pol, commands, r, body)
 	if err != nil {
 		httperr.Write(w, r, err)
 		return agents.StageInfo{}, false

--- a/backend/internal/compose/agentgatestaging.go
+++ b/backend/internal/compose/agentgatestaging.go
@@ -127,8 +127,8 @@ func consumePresentedToken(w http.ResponseWriter, r *http.Request, staging agent
 // checks the two against each other instead (pinAutoExecutedWrite). The two
 // arms differ because the caller's header has been proved against something on
 // one and against nothing on the other: a 🟢 admission read the record itself
-// and pinAdmittedWrite already refused an If-Match naming a version it did not
-// read, while a 🟡 call was admitted by a human's decision and this door hashes
+// and pinAutoExecutedWrite already refused an If-Match naming a version it did
+// not read, while a 🟡 call was admitted by a human's decision and this door hashes
 // no If-Match into the identity that decision bound (agentgatecanon.go says
 // why). The approval's own pin is then the only version anything proved.
 func redeemIfPresented(w http.ResponseWriter, r *http.Request, next http.Handler, staging agents.Approvals, pol agentPolicy, body []byte) (handled, ran bool) {

--- a/backend/internal/compose/agentgatestaging.go
+++ b/backend/internal/compose/agentgatestaging.go
@@ -71,7 +71,7 @@ func redeemIfPresented(w http.ResponseWriter, r *http.Request, next http.Handler
 		httperr.Write(w, r, fmt.Errorf("agent gate: malformed %s: %w", approvalTokenHeader, apperrors.ErrApprovalTokenInvalid))
 		return true, false
 	}
-	_, diffHash, cErr := canonicalRESTCall(pol.Op, r.URL.Path, r.Header, body)
+	_, diffHash, cErr := canonicalRESTCall(pol.Op, r.URL.Path, r.Header, body, keyBindsTheRetry)
 	if cErr != nil {
 		httperr.Write(w, r, cErr)
 		return true, false
@@ -112,7 +112,7 @@ func redeemIfPresented(w http.ResponseWriter, r *http.Request, next http.Handler
 // staged change, so the approved retry is this exact request again.
 func stageRefusal(w http.ResponseWriter, r *http.Request, staging agents.Approvals, commands restCommandDeps, pol agentPolicy, body []byte) {
 	ctx := r.Context()
-	canonical, diffHash, cErr := canonicalRESTCall(pol.Op, r.URL.Path, r.Header, body)
+	canonical, diffHash, cErr := canonicalRESTCall(pol.Op, r.URL.Path, r.Header, body, keyBindsTheRetry)
 	if cErr != nil {
 		httperr.Write(w, r, cErr)
 		return

--- a/backend/internal/compose/agentgatestaging.go
+++ b/backend/internal/compose/agentgatestaging.go
@@ -58,6 +58,18 @@ type tokenRedemption struct {
 	pinned   bool
 }
 
+// presentedApprovalToken answers the X-Approval-Token this request asserts, or
+// "" when it asserts none.
+//
+// One accessor, because two parts of the gate must agree about whether a call is
+// a redemption and they are far apart: the charge point skips its pre-dispatch
+// charge for one (agentGate, agentgate.go), and this file spends it. Two
+// readings of one header is how the door comes to charge a call it then refuses
+// to run.
+func presentedApprovalToken(r *http.Request) string {
+	return r.Header.Get(approvalTokenHeader)
+}
+
 // consumePresentedToken validates and consumes the X-Approval-Token on this
 // request: a valid token bound to this exact call is spent, and an invalid one
 // is answered with the failure — asserted authority is validated, never ignored.
@@ -70,7 +82,7 @@ type tokenRedemption struct {
 // pinAutoExecutedWrite and redeemIfPresented below), and folding the dispatch in
 // here is what left one arm redeeming and the other ignoring the same header.
 func consumePresentedToken(w http.ResponseWriter, r *http.Request, staging agents.Approvals, pol agentPolicy, body []byte) (redemption tokenRedemption, presented, ok bool) {
-	token := r.Header.Get(approvalTokenHeader)
+	token := presentedApprovalToken(r)
 	if token == "" {
 		return tokenRedemption{}, false, false
 	}

--- a/backend/internal/compose/agentgatestaging.go
+++ b/backend/internal/compose/agentgatestaging.go
@@ -21,8 +21,6 @@ import (
 	"net/http"
 	"strconv"
 
-	chi "github.com/go-chi/chi/v5"
-
 	"github.com/gradionhq/margince/backend/internal/modules/agents"
 	"github.com/gradionhq/margince/backend/internal/modules/approvals"
 	"github.com/gradionhq/margince/backend/internal/platform/httperr"
@@ -158,11 +156,11 @@ func stageRefusal(w http.ResponseWriter, r *http.Request, staging agents.Approva
 // stagedTarget answers what the approval binds to: the record type and the id
 // the human's decision will be scoped and pinned by.
 //
-// An operation this door can decode into a typed command (agentcommand.go) is
-// answered by the SAME resolver the tool door asks, so the two cannot describe
-// one operation differently — and the resolver's guards run here too, refusing
-// a target the caller cannot see before a human is asked about it. Everything
-// else still walks the route below.
+// Every operation this door can stage decodes into a typed command
+// (agentcommand.go) and is answered by the SAME resolver the tool door asks, so
+// the two cannot describe one operation differently — and the resolver's guards
+// run here too, refusing a target the caller cannot see before a human is asked
+// about it.
 //
 // Only the target is taken from the resolver. The line the human reads stays
 // this door's own (restSummary), because a REST summary names the concrete
@@ -176,7 +174,7 @@ func stageRefusal(w http.ResponseWriter, r *http.Request, staging agents.Approva
 // It writes the refusal itself and reports ok=false, so a caller that cannot
 // name a target stages nothing.
 func stagedTarget(w http.ResponseWriter, r *http.Request, commands restCommandDeps, pol agentPolicy, body []byte) (agents.StageInfo, bool) {
-	info, ok := resolveOrWalk(w, r, commands, pol, body)
+	info, ok := resolveStagedTarget(w, r, commands, pol, body)
 	if !ok {
 		return agents.StageInfo{}, false
 	}
@@ -200,18 +198,31 @@ func stagedTarget(w http.ResponseWriter, r *http.Request, commands restCommandDe
 	return info, true
 }
 
-// resolveOrWalk answers the staged target from the operation's own resolver
-// where it has one, and from the route where it does not.
+// resolveStagedTarget answers the staged target from the operation's own
+// resolver, which every agent-reachable mutating operation now has
+// (TestEveryAgentReachableMutatingRouteDecodesIntoACommand derives that from
+// the policy table, so a route the contract adds fails there rather than
+// arriving here undescribed).
+//
+// An operation with no entry is a defect this door refuses rather than guesses
+// around. The guess it used to fall back to — the route's own {id} paired with
+// the policy's declared record type — is what this seam replaced: it read the
+// merge's routed id as the survivor, gave createOffer the deal's id as an
+// offer's, and could not tell the two enrich depths apart, all while looking
+// exactly as green as a real answer.
 //
 // body is the same buffered copy stageRefusal already hashed into
 // canonicalRESTCall — passed through rather than re-read off r.Body, so a
 // decoder that needs the request payload (create, patch) is a pure function
 // of values the gate already proved readable, with no second reader of a
 // stream nothing guarantees stays replayable.
-func resolveOrWalk(w http.ResponseWriter, r *http.Request, commands restCommandDeps, pol agentPolicy, body []byte) (agents.StageInfo, bool) {
+func resolveStagedTarget(w http.ResponseWriter, r *http.Request, commands restCommandDeps, pol agentPolicy, body []byte) (agents.StageInfo, bool) {
 	decode, described := restCommands[pol.Op]
 	if !described {
-		return stagedTargetByRoute(w, r, pol)
+		httperr.Write(w, r, fmt.Errorf(
+			"agent gate: %s decodes into no governed call, so nothing can say what an approval of it would "+
+				"bind to: %w", pol.Op, apperrors.ErrPermissionDenied))
+		return agents.StageInfo{}, false
 	}
 	call, err := decode(pol, commands, r, body)
 	if err != nil {
@@ -224,20 +235,4 @@ func resolveOrWalk(w http.ResponseWriter, r *http.Request, commands restCommandD
 		return agents.StageInfo{}, false
 	}
 	return info, true
-}
-
-// stagedTargetByRoute is the guess the seam above replaces one operation family
-// at a time: the target id read out of the route's {id} parameter, paired with
-// the record type the generated policy declares. It answers for every operation
-// with no command of its own.
-func stagedTargetByRoute(w http.ResponseWriter, r *http.Request, pol agentPolicy) (agents.StageInfo, bool) {
-	var targetID ids.UUID
-	if raw := chi.URLParam(r, "id"); raw != "" {
-		var err error
-		if targetID, err = ids.Parse(raw); err != nil {
-			httperr.Write(w, r, apperrors.ErrNotFound)
-			return agents.StageInfo{}, false
-		}
-	}
-	return agents.StageInfo{TargetType: string(pol.RecordType), TargetID: targetID}, true
 }

--- a/backend/internal/compose/agentgatestaging.go
+++ b/backend/internal/compose/agentgatestaging.go
@@ -28,7 +28,6 @@ import (
 	"github.com/gradionhq/margince/backend/internal/platform/httperr"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
-	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
 )
 
 // stageOrRedeem handles the 🟡 outcome. The identical call is the
@@ -41,12 +40,12 @@ import (
 // whether an effect was performed and so whether one is charged. A redemption
 // that forwarded reports true; a refused token and a fresh staging both report
 // false, because neither ran anything.
-func stageOrRedeem(w http.ResponseWriter, r *http.Request, next http.Handler, staging agents.Approvals, records datasource.SystemOfRecordProvider, pol agentPolicy, body []byte) bool {
+func stageOrRedeem(w http.ResponseWriter, r *http.Request, next http.Handler, staging agents.Approvals, commands restCommandDeps, pol agentPolicy, body []byte) bool {
 	handled, ran := redeemIfPresented(w, r, next, staging, pol, body)
 	if handled {
 		return ran
 	}
-	stageRefusal(w, r, staging, records, pol, body)
+	stageRefusal(w, r, staging, commands, pol, body)
 	return false
 }
 
@@ -111,7 +110,7 @@ func redeemIfPresented(w http.ResponseWriter, r *http.Request, next http.Handler
 // stageRefusal stages the refused call as a pending approval and answers
 // with the redemption instructions — the whole request, unapplied, is the
 // staged change, so the approved retry is this exact request again.
-func stageRefusal(w http.ResponseWriter, r *http.Request, staging agents.Approvals, records datasource.SystemOfRecordProvider, pol agentPolicy, body []byte) {
+func stageRefusal(w http.ResponseWriter, r *http.Request, staging agents.Approvals, commands restCommandDeps, pol agentPolicy, body []byte) {
 	ctx := r.Context()
 	canonical, diffHash, cErr := canonicalRESTCall(pol.Op, r.URL.Path, r.Header, body)
 	if cErr != nil {
@@ -126,7 +125,7 @@ func stageRefusal(w http.ResponseWriter, r *http.Request, staging agents.Approva
 			"agent gate: %s (%s) has no approval decision mapping: %w", pol.Op, pol.Tool, apperrors.ErrPermissionDenied))
 		return
 	}
-	target, ok := stagedTarget(w, r, records, pol)
+	target, ok := stagedTarget(w, r, commands, pol)
 	if !ok {
 		return
 	}
@@ -168,11 +167,16 @@ func stageRefusal(w http.ResponseWriter, r *http.Request, staging agents.Approva
 // Only the target is taken from the resolver. The line the human reads stays
 // this door's own (restSummary), because a REST summary names the concrete
 // method, path and body fields that this door's diff_hash actually binds.
+// Adopting the resolver's line on this door as well is blocked on the six types
+// the record seam does not serve: it can label those by id alone, so the change
+// would put "Archive tag 0195c3…" in front of an approver where the operation
+// and path stand today (gradionhq/margince-poc-v1#1021 is where those types get
+// a name).
 //
 // It writes the refusal itself and reports ok=false, so a caller that cannot
 // name a target stages nothing.
-func stagedTarget(w http.ResponseWriter, r *http.Request, records datasource.SystemOfRecordProvider, pol agentPolicy) (agents.StageInfo, bool) {
-	info, ok := resolveOrWalk(w, r, records, pol)
+func stagedTarget(w http.ResponseWriter, r *http.Request, commands restCommandDeps, pol agentPolicy) (agents.StageInfo, bool) {
+	info, ok := resolveOrWalk(w, r, commands, pol)
 	if !ok {
 		return agents.StageInfo{}, false
 	}
@@ -198,12 +202,12 @@ func stagedTarget(w http.ResponseWriter, r *http.Request, records datasource.Sys
 
 // resolveOrWalk answers the staged target from the operation's own resolver
 // where it has one, and from the route where it does not.
-func resolveOrWalk(w http.ResponseWriter, r *http.Request, records datasource.SystemOfRecordProvider, pol agentPolicy) (agents.StageInfo, bool) {
+func resolveOrWalk(w http.ResponseWriter, r *http.Request, commands restCommandDeps, pol agentPolicy) (agents.StageInfo, bool) {
 	decode, described := restCommands[pol.Op]
 	if !described {
 		return stagedTargetByRoute(w, r, pol)
 	}
-	call, err := decode(pol, records, r)
+	call, err := decode(pol, commands, r)
 	if err != nil {
 		httperr.Write(w, r, err)
 		return agents.StageInfo{}, false

--- a/backend/internal/compose/agentgatestaging.go
+++ b/backend/internal/compose/agentgatestaging.go
@@ -149,7 +149,7 @@ func redeemIfPresented(w http.ResponseWriter, r *http.Request, next http.Handler
 	// inside the transaction that actually mutates, where a concurrent write
 	// loses to the version compare instead of to timing.
 	if redemption.pinned {
-		r.Header.Set("If-Match", strconv.FormatInt(redemption.pin, 10))
+		r.Header.Set(ifMatchHeader, strconv.FormatInt(redemption.pin, 10))
 	}
 	// WithContext shares the header map set just above, so the pin travels with
 	// the released request.

--- a/backend/internal/compose/agentgatestaging.go
+++ b/backend/internal/compose/agentgatestaging.go
@@ -68,7 +68,7 @@ func redeemIfPresented(w http.ResponseWriter, r *http.Request, next http.Handler
 		httperr.Write(w, r, fmt.Errorf("agent gate: malformed %s: %w", approvalTokenHeader, apperrors.ErrApprovalTokenInvalid))
 		return true, false
 	}
-	_, diffHash, cErr := canonicalRESTCall(pol.Op, r.URL.Path, body)
+	_, diffHash, cErr := canonicalRESTCall(pol.Op, r.URL.Path, r.Header, body)
 	if cErr != nil {
 		httperr.Write(w, r, cErr)
 		return true, false
@@ -109,7 +109,7 @@ func redeemIfPresented(w http.ResponseWriter, r *http.Request, next http.Handler
 // staged change, so the approved retry is this exact request again.
 func stageRefusal(w http.ResponseWriter, r *http.Request, staging agents.Approvals, pol agentPolicy, body []byte) {
 	ctx := r.Context()
-	canonical, diffHash, cErr := canonicalRESTCall(pol.Op, r.URL.Path, body)
+	canonical, diffHash, cErr := canonicalRESTCall(pol.Op, r.URL.Path, r.Header, body)
 	if cErr != nil {
 		httperr.Write(w, r, cErr)
 		return

--- a/backend/internal/compose/agentgatestaging.go
+++ b/backend/internal/compose/agentgatestaging.go
@@ -172,6 +172,33 @@ func stageRefusal(w http.ResponseWriter, r *http.Request, staging agents.Approva
 // It writes the refusal itself and reports ok=false, so a caller that cannot
 // name a target stages nothing.
 func stagedTarget(w http.ResponseWriter, r *http.Request, records datasource.SystemOfRecordProvider, pol agentPolicy) (agents.StageInfo, bool) {
+	info, ok := resolveOrWalk(w, r, records, pol)
+	if !ok {
+		return agents.StageInfo{}, false
+	}
+	// A concrete target with no record type is unstageable authority: the
+	// approvals surface scopes an inbox row by probing its target's own/team
+	// visibility, and it cannot probe a type it was not told. Such a row
+	// would show a record's summary and proposed change to everyone holding
+	// the object grant, and let any of them decide a write against a row
+	// their own scope hides. Refuse it here, the same fail-closed shape as
+	// an undecidable kind, rather than mint an unscopable authority object.
+	//
+	// Applied to EVERY answer rather than inside one branch: a resolver names
+	// its own target, so a decoder wired to an operation that declares no
+	// record type would otherwise walk straight past the check that catches it.
+	if !info.TargetID.IsZero() && info.TargetType == "" {
+		httperr.Write(w, r, fmt.Errorf(
+			"agent gate: %s stages against a concrete record but declares no record type: %w",
+			pol.Op, apperrors.ErrPermissionDenied))
+		return agents.StageInfo{}, false
+	}
+	return info, true
+}
+
+// resolveOrWalk answers the staged target from the operation's own resolver
+// where it has one, and from the route where it does not.
+func resolveOrWalk(w http.ResponseWriter, r *http.Request, records datasource.SystemOfRecordProvider, pol agentPolicy) (agents.StageInfo, bool) {
 	decode, described := restCommands[pol.Op]
 	if !described {
 		return stagedTargetByRoute(w, r, pol)
@@ -189,10 +216,10 @@ func stagedTarget(w http.ResponseWriter, r *http.Request, records datasource.Sys
 	return info, true
 }
 
-// stagedTargetByRoute is the guess the seam above is replacing: the target id
-// read out of the route's {id} parameter and paired with the record type the
-// generated policy declares. It stands for every operation with no command
-// entry yet, and goes away with the last of them.
+// stagedTargetByRoute is the guess the seam above replaces one operation family
+// at a time: the target id read out of the route's {id} parameter, paired with
+// the record type the generated policy declares. It answers for every operation
+// with no command of its own.
 func stagedTargetByRoute(w http.ResponseWriter, r *http.Request, pol agentPolicy) (agents.StageInfo, bool) {
 	var targetID ids.UUID
 	if raw := chi.URLParam(r, "id"); raw != "" {
@@ -201,19 +228,6 @@ func stagedTargetByRoute(w http.ResponseWriter, r *http.Request, pol agentPolicy
 			httperr.Write(w, r, apperrors.ErrNotFound)
 			return agents.StageInfo{}, false
 		}
-	}
-	// A concrete target with no record type is unstageable authority: the
-	// approvals surface scopes an inbox row by probing its target's own/team
-	// visibility, and it cannot probe a type it was not told. Such a row
-	// would show a record's summary and proposed change to everyone holding
-	// the object grant, and let any of them decide a write against a row
-	// their own scope hides. Refuse it here, the same fail-closed shape as
-	// an undecidable kind, rather than mint an unscopable authority object.
-	if targetID != (ids.UUID{}) && pol.RecordType == "" {
-		httperr.Write(w, r, fmt.Errorf(
-			"agent gate: %s stages against a concrete record but declares no record type: %w",
-			pol.Op, apperrors.ErrPermissionDenied))
-		return agents.StageInfo{}, false
 	}
 	return agents.StageInfo{TargetType: string(pol.RecordType), TargetID: targetID}, true
 }

--- a/backend/internal/compose/agentsplit.go
+++ b/backend/internal/compose/agentsplit.go
@@ -23,7 +23,6 @@ import (
 	"github.com/gradionhq/margince/backend/internal/platform/httperr"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
-	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
 )
 
 // actionShapedUpdateOps are the update_record twins whose body is a
@@ -58,7 +57,7 @@ var actionShapedUpdateOps = map[string]bool{
 // so transport never changes what a human decision protects. An
 // X-Approval-Token redeems a prior staging: the approved retry carries
 // exactly the staged sub-patch, whose hash the staging was bound to.
-func splitOrRedeemUpdate(w http.ResponseWriter, r *http.Request, next http.Handler, staging agents.Approvals, records datasource.SystemOfRecordProvider, ownership agents.FieldOwnership, pol agentPolicy, body []byte) {
+func splitOrRedeemUpdate(w http.ResponseWriter, r *http.Request, next http.Handler, staging agents.Approvals, commands restCommandDeps, ownership agents.FieldOwnership, pol agentPolicy, body []byte) {
 	ctx := r.Context()
 	if handled, _ := redeemIfPresented(w, r, next, staging, pol, body); handled {
 		return
@@ -96,7 +95,7 @@ func splitOrRedeemUpdate(w http.ResponseWriter, r *http.Request, next http.Handl
 		// Every touched field is human-owned: nothing applies, the whole
 		// request is the staged change — the approved retry is this exact
 		// request again.
-		stageRefusal(w, r, staging, records, pol, body)
+		stageRefusal(w, r, staging, commands, pol, body)
 		return
 	}
 	applyAutoExecuteAndStageResidue(w, r, next, staging, pol, targetID, split)

--- a/backend/internal/compose/agentsplit.go
+++ b/backend/internal/compose/agentsplit.go
@@ -92,7 +92,7 @@ var actionShapedUpdateOps = map[string]bool{
 //
 // A retry presenting an X-Approval-Token never arrives here: the auto-execute
 // arm consumes the token and forwards the released call straight to the handler
-// (runAutoExecuted, agentgate.go), because that retry carries exactly the staged
+// (runAutoExecuted, agentgateauto.go), because that retry carries exactly the staged
 // sub-patch whose hash the approval was bound to and re-splitting it would stage
 // a second approval for the overwrite just approved. This function used to
 // redeem the token itself, which is how every OTHER tool's 🟢 arm came to ignore
@@ -216,20 +216,21 @@ func applyAutoExecuteAndStageResidue(w http.ResponseWriter, r *http.Request, nex
 		// second return shape for stagedTarget's callers to carry.
 		return
 	}
+	// No version pin travels from here, and the residue is still staged against
+	// the state the approving human will actually judge (ADR-0036 §2). What
+	// makes that true is WHEN the pin is read, not who supplies it: the
+	// approvals engine resolves target_version itself, inside the staging
+	// transaction (approvals.insertProposalInTx), which this call reaches only
+	// after the auto-execute half above committed — so the version it takes is
+	// the post-write one, and this call's own successful half cannot invalidate
+	// its own staged half. A pin named here would not survive the trip anyway:
+	// approvalsAdapter.Stage (registry.go) forwards none, deliberately.
 	approvalID, sErr := staging.Stage(r.Context(), agents.StageRequest{
 		Tool:           pol.Tool,
 		ProposedChange: canonical,
 		DiffHash:       diffHash,
 		TargetType:     info.TargetType,
 		TargetID:       info.TargetID,
-		// TargetVersion overrides the resolver's own answer (always nil —
-		// Subject supplies no version pin, command.go's own doc says why)
-		// with the version the AUTO-EXECUTE half just wrote, not whatever
-		// the row held before this request: this residue is staged
-		// against the state the approving human will actually judge
-		// (ADR-0036 §2), so this call's own successful half cannot
-		// invalidate its own staged half.
-		TargetVersion: recordVersion(record),
 		// The staged sub-patch is what the approval binds to, so the summary
 		// names the values it would write, not only the field names it would
 		// write them to: "overwrite human-edited amount_minor" told an
@@ -251,23 +252,6 @@ func applyAutoExecuteAndStageResidue(w http.ResponseWriter, r *http.Request, nex
 			strings.Join(split.Conflicts, ", "), approvalID, approvalTokenHeader, approvalID),
 	}
 	buffered.flushJSON(w, r, record)
-}
-
-// recordVersion pins the staged residue to the record version the auto-execute
-// half of the split produced. Contract record bodies carry the read-only
-// `version` (RowVersion, ADR-0036 §3); a response without one yields no
-// pin rather than a wrong one. The body is decoded with UseNumber, so the
-// value arrives as json.Number and is read losslessly.
-func recordVersion(record map[string]any) *int64 {
-	number, ok := record["version"].(json.Number)
-	if !ok {
-		return nil
-	}
-	version, err := number.Int64()
-	if err != nil {
-		return nil
-	}
-	return &version
 }
 
 // bufferedResponse holds a handler's answer so the gate can decide

--- a/backend/internal/compose/agentsplit.go
+++ b/backend/internal/compose/agentsplit.go
@@ -134,7 +134,7 @@ func applyAutoExecuteAndStageResidue(w http.ResponseWriter, r *http.Request, nex
 			pol.Op, strings.Join(split.Conflicts, ", "), uErr))
 		return
 	}
-	canonical, diffHash, cErr := canonicalRESTCall(pol.Op, r.URL.Path, split.Staged)
+	canonical, diffHash, cErr := canonicalRESTCall(pol.Op, r.URL.Path, r.Header, split.Staged)
 	if cErr != nil {
 		httperr.Write(w, r, cErr)
 		return

--- a/backend/internal/compose/agentsplit.go
+++ b/backend/internal/compose/agentsplit.go
@@ -185,8 +185,8 @@ func applyAutoExecuteAndStageResidue(w http.ResponseWriter, r *http.Request, nex
 		return
 	}
 	// The staged target is resolved through the SAME seam stageRefusal uses
-	// (stagedTarget, which is resolveOrWalk plus the untyped-target check),
-	// not read off pol.RecordType directly the way this line used to:
+	// (stagedTarget, which is resolveStagedTarget plus the untyped-target
+	// check), not read off pol.RecordType directly:
 	// upsertPartner's declared record_type is "partner", but its resolver
 	// (modules/agents/commandnested.go) stages "organization" — the row a
 	// human's decision and the approvals surface's own visibility probe

--- a/backend/internal/compose/agentsplit.go
+++ b/backend/internal/compose/agentsplit.go
@@ -143,7 +143,7 @@ func splitOrRedeemUpdate(w http.ResponseWriter, r *http.Request, next http.Handl
 		stageRefusal(w, r, staging, commands, pol, body)
 		return
 	}
-	applyAutoExecuteAndStageResidue(w, r, next, staging, pol, targetID, split)
+	applyAutoExecuteAndStageResidue(w, r, next, staging, commands, pol, split)
 }
 
 // applyAutoExecuteAndStageResidue handles the mixed patch: the auto-execute remainder
@@ -152,7 +152,7 @@ func splitOrRedeemUpdate(w http.ResponseWriter, r *http.Request, next http.Handl
 // judge, so this call's own auto-execute half cannot invalidate its staged half
 // (ADR-0036 §2). The staging note is spliced into the handler's own 2xx
 // record body, making the split legible in a single response.
-func applyAutoExecuteAndStageResidue(w http.ResponseWriter, r *http.Request, next http.Handler, staging agents.Approvals, pol agentPolicy, targetID ids.UUID, split agents.PatchSplit) {
+func applyAutoExecuteAndStageResidue(w http.ResponseWriter, r *http.Request, next http.Handler, staging agents.Approvals, commands restCommandDeps, pol agentPolicy, split agents.PatchSplit) {
 	r.Body = io.NopCloser(bytes.NewReader(split.AutoExecute))
 	r.ContentLength = int64(len(split.AutoExecute))
 	buffered := newBufferedResponse()
@@ -184,13 +184,49 @@ func applyAutoExecuteAndStageResidue(w http.ResponseWriter, r *http.Request, nex
 		httperr.Write(w, r, cErr)
 		return
 	}
+	// The staged target is resolved through the SAME seam stageRefusal uses
+	// (stagedTarget, which is resolveOrWalk plus the untyped-target check),
+	// not read off pol.RecordType directly the way this line used to:
+	// upsertPartner's declared record_type is "partner", but its resolver
+	// (modules/agents/commandnested.go) stages "organization" — the row a
+	// human's decision and the approvals surface's own visibility probe
+	// actually depend on. Staging target_entity_type="partner" here would
+	// have named a pair neither targetProbes nor existenceProbes
+	// (approvals/targetvisibility.go) has a rule for, so the approval fails
+	// closed as invisible and undecidable — the zombie authority object
+	// this whole seam exists to prevent, for the one write this branch is
+	// supposed to protect. body is split.Staged, the sub-patch this
+	// approval actually binds to (canonicalRESTCall's own argument, above),
+	// not the full original request half of which already ran.
+	info, ok := stagedTarget(w, r, commands, pol, split.Staged)
+	if !ok {
+		// stagedTarget already wrote the refusal. It does not know the
+		// auto-execute half already landed — a target this door cannot
+		// resolve or is not allowed to stage is refused the same way
+		// whether or not a sibling write preceded it — but a caller
+		// reading only this response is told the change was refused, not
+		// that part of it already applied. sErr below carries that
+		// nuance for the one failure this branch CAN distinguish (the
+		// staging call itself); this one is rare enough (a Guards
+		// refusal produced by state that changed between the two writes)
+		// that duplicating the framing here was judged not worth a
+		// second return shape for stagedTarget's callers to carry.
+		return
+	}
 	approvalID, sErr := staging.Stage(r.Context(), agents.StageRequest{
 		Tool:           pol.Tool,
 		ProposedChange: canonical,
 		DiffHash:       diffHash,
-		TargetType:     string(pol.RecordType),
-		TargetID:       targetID,
-		TargetVersion:  recordVersion(record),
+		TargetType:     info.TargetType,
+		TargetID:       info.TargetID,
+		// TargetVersion overrides the resolver's own answer (always nil —
+		// Subject supplies no version pin, command.go's own doc says why)
+		// with the version the AUTO-EXECUTE half just wrote, not whatever
+		// the row held before this request: this residue is staged
+		// against the state the approving human will actually judge
+		// (ADR-0036 §2), so this call's own successful half cannot
+		// invalidate its own staged half.
+		TargetVersion: recordVersion(record),
 		// The staged sub-patch is what the approval binds to, so the summary
 		// names the values it would write, not only the field names it would
 		// write them to: "overwrite human-edited amount_minor" told an

--- a/backend/internal/compose/agentsplit.go
+++ b/backend/internal/compose/agentsplit.go
@@ -32,9 +32,13 @@ import (
 // operationId spelled the same way.
 const opRenameCustomField = "renameCustomField"
 
-// The remaining six action-shaped ops named below are ALSO both this file's
-// and agentcommand.go's restCommands table's (agentcommandnested.go): named
-// once here so the two do not spell an operationId twice each.
+// The remaining five action-shaped ops named below are ALSO both this
+// file's and agentcommand.go's restCommands table's
+// (agentcommandnested.go): named once here so the two do not spell an
+// operationId twice each. opUpsertPartner is named alongside them for the
+// same reason — agentcommand.go's restCommands entry needs the identical
+// spelling — even though (its own comment below says why) upsertPartner is
+// NOT a member of the map these five populate.
 const (
 	opAddListMember       = "addListMember"
 	opApplyTag            = "applyTag"
@@ -46,12 +50,23 @@ const (
 
 // actionShapedUpdateOps are the update_record twins whose body is a
 // membership/apply request naming ANOTHER record, or a mutation of a
-// CHILD record (an offer's line items), not a field patch on the routed
+// CHILD record (an offer's line items), NOT a field patch on the routed
 // record itself — there is no human-typed field of the routed record the
-// call could overwrite, so the ownership probe has nothing to ask and the
-// call runs 🟢 by design (an op absent here gets the full split; the
-// deliberate inclusion is upsertPartner, which the resolver maps
-// partner→organization so its patch IS a field patch on that org).
+// call could overwrite, so the ownership probe has nothing to ask, and the
+// call runs 🟢 by design. Membership is earned by that one test; an op
+// absent here gets the full split instead.
+//
+// upsertPartner LOOKS like it belongs — PUT .../partner, a body naming
+// partner fields — but is deliberately ABSENT: the resolver
+// (commandnested.go) maps partner→organization, so this patch really IS a
+// field patch on the routed record (the organization), which is exactly
+// the case this map exists to exclude. An agent overwriting a human-typed
+// partner field (cert_status, margin_tier, …) has to stage, the same §2.1
+// precedence protection every ordinary organization field patch gets —
+// adding upsertPartner here would silently disable that protection for
+// this one operation. TestUpsertPartnerStagesAHumanOwnedPartnerField pins
+// the split running for it.
+//
 // renameCustomField is here for a different reason: its target is a
 // catalog CONFIG row, not record data — §2.1 human-edit precedence
 // protects human-typed record values from agent overwrite, while a
@@ -65,7 +80,6 @@ var actionShapedUpdateOps = map[string]bool{
 	opUpdateOfferLineItem: true,
 	opRemoveOfferLineItem: true,
 	opRenameCustomField:   true,
-	opUpsertPartner:       true,
 }
 
 // splitOrRedeemUpdate is the per-field human-edit-precedence split

--- a/backend/internal/compose/agentsplit.go
+++ b/backend/internal/compose/agentsplit.go
@@ -32,6 +32,18 @@ import (
 // operationId spelled the same way.
 const opRenameCustomField = "renameCustomField"
 
+// The remaining six action-shaped ops named below are ALSO both this file's
+// and agentcommand.go's restCommands table's (agentcommandnested.go): named
+// once here so the two do not spell an operationId twice each.
+const (
+	opAddListMember       = "addListMember"
+	opApplyTag            = "applyTag"
+	opAddOfferLineItem    = "addOfferLineItem"
+	opUpdateOfferLineItem = "updateOfferLineItem"
+	opRemoveOfferLineItem = "removeOfferLineItem"
+	opUpsertPartner       = "upsertPartner"
+)
+
 // actionShapedUpdateOps are the update_record twins whose body is a
 // membership/apply request naming ANOTHER record, or a mutation of a
 // CHILD record (an offer's line items), not a field patch on the routed
@@ -47,12 +59,13 @@ const opRenameCustomField = "renameCustomField"
 // left to the split, the creating admin's audit trail would mark `label`
 // human-owned and silently convert every agent rename into a 🟡 staging.
 var actionShapedUpdateOps = map[string]bool{
-	"applyTag":            true,
-	"addListMember":       true,
-	"addOfferLineItem":    true,
-	"updateOfferLineItem": true,
-	"removeOfferLineItem": true,
+	opApplyTag:            true,
+	opAddListMember:       true,
+	opAddOfferLineItem:    true,
+	opUpdateOfferLineItem: true,
+	opRemoveOfferLineItem: true,
 	opRenameCustomField:   true,
+	opUpsertPartner:       true,
 }
 
 // splitOrRedeemUpdate is the per-field human-edit-precedence split

--- a/backend/internal/compose/agentsplit.go
+++ b/backend/internal/compose/agentsplit.go
@@ -82,6 +82,18 @@ var actionShapedUpdateOps = map[string]bool{
 	opRenameCustomField:   true,
 }
 
+// splitUpdateDeps is what splitHumanOwnedUpdate needs to decide and stage a
+// conflict, bundled for the same reason restCommandDeps is: the three are
+// fixed at composition (admissionOutcome.staging/commands/ownership, set once
+// per gate from agentGate's own parameters, not per request), so threading
+// them as positional arguments churns the signature every time one more join
+// is needed rather than describing what this REST split actually depends on.
+type splitUpdateDeps struct {
+	staging   agents.Approvals
+	commands  restCommandDeps
+	ownership agents.FieldOwnership
+}
+
 // splitHumanOwnedUpdate is the per-field human-edit-precedence split
 // (interfaces.md §2.1) on the REST twin of the 🟢 update_record verb. The
 // body IS the field patch; the route's record_type annotation and {id}
@@ -97,7 +109,7 @@ var actionShapedUpdateOps = map[string]bool{
 // a second approval for the overwrite just approved. This function used to
 // redeem the token itself, which is how every OTHER tool's 🟢 arm came to ignore
 // one (gradionhq/margince-poc-v1#812).
-func splitHumanOwnedUpdate(w http.ResponseWriter, r *http.Request, next http.Handler, staging agents.Approvals, commands restCommandDeps, ownership agents.FieldOwnership, pol agentPolicy, body []byte) {
+func splitHumanOwnedUpdate(w http.ResponseWriter, r *http.Request, next http.Handler, deps splitUpdateDeps, pol agentPolicy, body []byte) {
 	ctx := r.Context()
 	raw := chi.URLParam(r, "id")
 	if raw == "" {
@@ -114,7 +126,7 @@ func splitHumanOwnedUpdate(w http.ResponseWriter, r *http.Request, next http.Han
 		httperr.Write(w, r, apperrors.ErrNotFound)
 		return
 	}
-	split, err := agents.SplitHumanOwned(ctx, ownership, string(pol.RecordType), targetID, body)
+	split, err := agents.SplitHumanOwned(ctx, deps.ownership, string(pol.RecordType), targetID, body)
 	if err != nil {
 		httperr.Write(w, r, err)
 		return
@@ -123,7 +135,7 @@ func splitHumanOwnedUpdate(w http.ResponseWriter, r *http.Request, next http.Han
 		next.ServeHTTP(w, r)
 		return
 	}
-	if staging == nil {
+	if deps.staging == nil {
 		httperr.Write(w, r, fmt.Errorf("fields %s were last edited by a human, and this surface has no approvals engine to stage the overwrite: %w",
 			strings.Join(split.Conflicts, ", "), apperrors.ErrRequiresApproval))
 		return
@@ -143,10 +155,10 @@ func splitHumanOwnedUpdate(w http.ResponseWriter, r *http.Request, next http.Han
 		// (Authoritative:false) record could never be redeemed anyway, since
 		// redemption's version pin reads our own tables, so refusing now
 		// beats spending a human's yes on a call that cannot be released.
-		stageRefusal(w, r, staging, commands, pol, body)
+		stageRefusal(w, r, deps.staging, deps.commands, pol, body)
 		return
 	}
-	applyAutoExecuteAndStageResidue(w, r, next, staging, commands, pol, split)
+	applyAutoExecuteAndStageResidue(w, r, next, deps.staging, deps.commands, pol, split)
 }
 
 // applyAutoExecuteAndStageResidue handles the mixed patch: everything that can

--- a/backend/internal/compose/agentsplit.go
+++ b/backend/internal/compose/agentsplit.go
@@ -102,6 +102,17 @@ func splitOrRedeemUpdate(w http.ResponseWriter, r *http.Request, next http.Handl
 		// Every touched field is human-owned: nothing applies, the whole
 		// request is the staged change — the approved retry is this exact
 		// request again.
+		//
+		// stageRefusal resolves through the SAME command seam every other
+		// registered patch op does (agentcommand.go's patchCommand, now that
+		// all twelve whole-record patch routes are registered), which means
+		// this branch carries patchResolver.Guards too: a records.Read plus
+		// refuseStagingElsewhere the split path never ran on its own before
+		// that registration. That is deliberate, not a side effect nobody
+		// noticed — an approval staged here for a mirror-held
+		// (Authoritative:false) record could never be redeemed anyway, since
+		// redemption's version pin reads our own tables, so refusing now
+		// beats spending a human's yes on a call that cannot be released.
 		stageRefusal(w, r, staging, commands, pol, body)
 		return
 	}

--- a/backend/internal/compose/agentsplit.go
+++ b/backend/internal/compose/agentsplit.go
@@ -135,7 +135,7 @@ func splitHumanOwnedUpdate(w http.ResponseWriter, r *http.Request, next http.Han
 		//
 		// stageRefusal resolves through the SAME command seam every other
 		// registered patch op does (agentcommand.go's patchCommand, now that
-		// all twelve whole-record patch routes are registered), which means
+		// all thirteen whole-record patch routes are registered), which means
 		// this branch carries patchResolver.Guards too: a records.Read plus
 		// refuseStagingElsewhere the split path never ran on its own before
 		// that registration. That is deliberate, not a side effect nobody
@@ -149,13 +149,55 @@ func splitHumanOwnedUpdate(w http.ResponseWriter, r *http.Request, next http.Han
 	applyAutoExecuteAndStageResidue(w, r, next, staging, commands, pol, split)
 }
 
-// applyAutoExecuteAndStageResidue handles the mixed patch: the auto-execute remainder
-// runs through the real handler first, then the residue is staged against
-// the post-write version — the state the approving human will actually
-// judge, so this call's own auto-execute half cannot invalidate its staged half
-// (ADR-0036 §2). The staging note is spliced into the handler's own 2xx
-// record body, making the split legible in a single response.
+// applyAutoExecuteAndStageResidue handles the mixed patch: everything that can
+// refuse the residue is settled first, then the auto-execute remainder runs
+// through the real handler, and only then is the residue staged — against the
+// post-write version, the state the approving human will actually judge, so this
+// call's own auto-execute half cannot invalidate its staged half (ADR-0036 §2).
+// The staging note is spliced into the handler's own 2xx record body, making the
+// split legible in a single response.
 func applyAutoExecuteAndStageResidue(w http.ResponseWriter, r *http.Request, next http.Handler, staging agents.Approvals, commands restCommandDeps, pol agentPolicy, split agents.PatchSplit) {
+	// Everything this function can REFUSE on is settled before the auto-execute
+	// half runs, because none of it depends on that write: the canonical form and
+	// the staged target are functions of pol, the request's own path and headers,
+	// and split.Staged, all of which exist before the handler is dispatched. Asked
+	// afterwards — which is where they used to be — a resolver or Guards refusal
+	// answered a refusal status for a request whose first half had already
+	// committed, and the buffered 2xx was dropped: the agent was told the change
+	// was refused and could retry the whole patch against a record that had
+	// already moved (gradionhq/margince-poc-v1#1073). Asked here, a refusal costs
+	// the caller only a retry, which is the rule pinAutoExecutedWrite already
+	// applies to the unconsumed case.
+	//
+	// This does NOT move the pin: approvals resolves target_version itself, inside
+	// the staging transaction (the comment on the Stage call below), which still
+	// runs after the write — so the residue is still staged against the post-write
+	// state the approving human judges (ADR-0036 §2).
+	canonical, diffHash, cErr := canonicalRESTCall(pol.Op, r.URL.Path, r.Header, split.Staged, keySettledByThisCall)
+	if cErr != nil {
+		httperr.Write(w, r, cErr)
+		return
+	}
+	// The staged target is resolved through the SAME seam stageRefusal uses
+	// (stagedTarget, which is resolveStagedTarget plus the untyped-target
+	// check), not read off pol.RecordType directly:
+	// upsertPartner's declared record_type is "partner", but its resolver
+	// (modules/agents/commandnested.go) stages "organization" — the row a
+	// human's decision and the approvals surface's own visibility probe
+	// actually depend on. Staging target_entity_type="partner" here would
+	// have named a pair neither targetProbes nor existenceProbes
+	// (approvals/targetvisibility.go) has a rule for, so the approval fails
+	// closed as invisible and undecidable — the zombie authority object
+	// this whole seam exists to prevent, for the one write this branch is
+	// supposed to protect. body is split.Staged, the sub-patch this
+	// approval actually binds to (canonicalRESTCall's own argument, above),
+	// not the full original request half of which already ran.
+	info, ok := stagedTarget(w, r, commands, pol, split.Staged)
+	if !ok {
+		// stagedTarget already wrote the refusal, and nothing has been
+		// written to the record yet, so it is the whole answer.
+		return
+	}
 	r.Body = io.NopCloser(bytes.NewReader(split.AutoExecute))
 	r.ContentLength = int64(len(split.AutoExecute))
 	buffered := newBufferedResponse()
@@ -180,40 +222,6 @@ func applyAutoExecuteAndStageResidue(w http.ResponseWriter, r *http.Request, nex
 		httperr.Write(w, r, fmt.Errorf(
 			"agent gate: %s applied the permitted fields, but its response cannot carry the staging note for the withheld human-edited fields (%s): %w",
 			pol.Op, strings.Join(split.Conflicts, ", "), uErr))
-		return
-	}
-	canonical, diffHash, cErr := canonicalRESTCall(pol.Op, r.URL.Path, r.Header, split.Staged, keySettledByThisCall)
-	if cErr != nil {
-		httperr.Write(w, r, cErr)
-		return
-	}
-	// The staged target is resolved through the SAME seam stageRefusal uses
-	// (stagedTarget, which is resolveStagedTarget plus the untyped-target
-	// check), not read off pol.RecordType directly:
-	// upsertPartner's declared record_type is "partner", but its resolver
-	// (modules/agents/commandnested.go) stages "organization" — the row a
-	// human's decision and the approvals surface's own visibility probe
-	// actually depend on. Staging target_entity_type="partner" here would
-	// have named a pair neither targetProbes nor existenceProbes
-	// (approvals/targetvisibility.go) has a rule for, so the approval fails
-	// closed as invisible and undecidable — the zombie authority object
-	// this whole seam exists to prevent, for the one write this branch is
-	// supposed to protect. body is split.Staged, the sub-patch this
-	// approval actually binds to (canonicalRESTCall's own argument, above),
-	// not the full original request half of which already ran.
-	info, ok := stagedTarget(w, r, commands, pol, split.Staged)
-	if !ok {
-		// stagedTarget already wrote the refusal. It does not know the
-		// auto-execute half already landed — a target this door cannot
-		// resolve or is not allowed to stage is refused the same way
-		// whether or not a sibling write preceded it — but a caller
-		// reading only this response is told the change was refused, not
-		// that part of it already applied. sErr below carries that
-		// nuance for the one failure this branch CAN distinguish (the
-		// staging call itself); this one is rare enough (a Guards
-		// refusal produced by state that changed between the two writes)
-		// that duplicating the framing here was judged not worth a
-		// second return shape for stagedTarget's callers to carry.
 		return
 	}
 	// No version pin travels from here, and the residue is still staged against

--- a/backend/internal/compose/agentsplit.go
+++ b/backend/internal/compose/agentsplit.go
@@ -25,6 +25,13 @@ import (
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
+// opRenameCustomField is the one patch operation both this file and
+// agentcommand.go's restCommands table name: the sole action-shaped op
+// (comment below) that is ALSO a whole-record field patch the governance seam
+// stages, so it is the one place those two lists have to agree on the same
+// operationId spelled the same way.
+const opRenameCustomField = "renameCustomField"
+
 // actionShapedUpdateOps are the update_record twins whose body is a
 // membership/apply request naming ANOTHER record, or a mutation of a
 // CHILD record (an offer's line items), not a field patch on the routed
@@ -45,7 +52,7 @@ var actionShapedUpdateOps = map[string]bool{
 	"addOfferLineItem":    true,
 	"updateOfferLineItem": true,
 	"removeOfferLineItem": true,
-	"renameCustomField":   true,
+	opRenameCustomField:   true,
 }
 
 // splitOrRedeemUpdate is the per-field human-edit-precedence split

--- a/backend/internal/compose/agentsplit.go
+++ b/backend/internal/compose/agentsplit.go
@@ -23,6 +23,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/platform/httperr"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
 )
 
 // actionShapedUpdateOps are the update_record twins whose body is a
@@ -57,7 +58,7 @@ var actionShapedUpdateOps = map[string]bool{
 // so transport never changes what a human decision protects. An
 // X-Approval-Token redeems a prior staging: the approved retry carries
 // exactly the staged sub-patch, whose hash the staging was bound to.
-func splitOrRedeemUpdate(w http.ResponseWriter, r *http.Request, next http.Handler, staging agents.Approvals, ownership agents.FieldOwnership, pol agentPolicy, body []byte) {
+func splitOrRedeemUpdate(w http.ResponseWriter, r *http.Request, next http.Handler, staging agents.Approvals, records datasource.SystemOfRecordProvider, ownership agents.FieldOwnership, pol agentPolicy, body []byte) {
 	ctx := r.Context()
 	if handled, _ := redeemIfPresented(w, r, next, staging, pol, body); handled {
 		return
@@ -95,7 +96,7 @@ func splitOrRedeemUpdate(w http.ResponseWriter, r *http.Request, next http.Handl
 		// Every touched field is human-owned: nothing applies, the whole
 		// request is the staged change — the approved retry is this exact
 		// request again.
-		stageRefusal(w, r, staging, pol, body)
+		stageRefusal(w, r, staging, records, pol, body)
 		return
 	}
 	applyAutoExecuteAndStageResidue(w, r, next, staging, pol, targetID, split)

--- a/backend/internal/compose/agentsplit.go
+++ b/backend/internal/compose/agentsplit.go
@@ -179,7 +179,7 @@ func applyAutoExecuteAndStageResidue(w http.ResponseWriter, r *http.Request, nex
 			pol.Op, strings.Join(split.Conflicts, ", "), uErr))
 		return
 	}
-	canonical, diffHash, cErr := canonicalRESTCall(pol.Op, r.URL.Path, r.Header, split.Staged)
+	canonical, diffHash, cErr := canonicalRESTCall(pol.Op, r.URL.Path, r.Header, split.Staged, keySettledByThisCall)
 	if cErr != nil {
 		httperr.Write(w, r, cErr)
 		return

--- a/backend/internal/compose/agentsplit.go
+++ b/backend/internal/compose/agentsplit.go
@@ -82,20 +82,23 @@ var actionShapedUpdateOps = map[string]bool{
 	opRenameCustomField:   true,
 }
 
-// splitOrRedeemUpdate is the per-field human-edit-precedence split
+// splitHumanOwnedUpdate is the per-field human-edit-precedence split
 // (interfaces.md §2.1) on the REST twin of the 🟢 update_record verb. The
 // body IS the field patch; the route's record_type annotation and {id}
 // name the audited record. Fields whose current value a human last wrote
 // are withheld and staged as a 🟡 approval while the rest of the patch
 // proceeds to the handler in the same request — mirroring the MCP tool,
-// so transport never changes what a human decision protects. An
-// X-Approval-Token redeems a prior staging: the approved retry carries
-// exactly the staged sub-patch, whose hash the staging was bound to.
-func splitOrRedeemUpdate(w http.ResponseWriter, r *http.Request, next http.Handler, staging agents.Approvals, commands restCommandDeps, ownership agents.FieldOwnership, pol agentPolicy, body []byte) {
+// so transport never changes what a human decision protects.
+//
+// A retry presenting an X-Approval-Token never arrives here: the auto-execute
+// arm consumes the token and forwards the released call straight to the handler
+// (runAutoExecuted, agentgate.go), because that retry carries exactly the staged
+// sub-patch whose hash the approval was bound to and re-splitting it would stage
+// a second approval for the overwrite just approved. This function used to
+// redeem the token itself, which is how every OTHER tool's 🟢 arm came to ignore
+// one (gradionhq/margince-poc-v1#812).
+func splitHumanOwnedUpdate(w http.ResponseWriter, r *http.Request, next http.Handler, staging agents.Approvals, commands restCommandDeps, ownership agents.FieldOwnership, pol agentPolicy, body []byte) {
 	ctx := r.Context()
-	if handled, _ := redeemIfPresented(w, r, next, staging, pol, body); handled {
-		return
-	}
 	raw := chi.URLParam(r, "id")
 	if raw == "" {
 		// Every field-patch twin routes with {id} today; a future route

--- a/backend/internal/compose/agentsplit_test.go
+++ b/backend/internal/compose/agentsplit_test.go
@@ -263,3 +263,61 @@ func TestUpsertPartnerResidueStagesTheOrganizationNotPartner(t *testing.T) {
 			"directly", staging.last.TargetType, staging.last.TargetID, orgID)
 	}
 }
+
+// A residue staged under an Idempotency-Key must be redeemable by the retry
+// the staging note actually instructs.
+//
+// This is the whole of the defect. The auto-execute half of a mixed patch
+// answers 2xx under the caller's key, and only a 2xx settles an idempotency
+// claim — so that key is spent, permanently. The retry the note asks for
+// ("repeat this request with ONLY those fields and the X-Approval-Token
+// header") therefore cannot present it: re-using it never even reaches the
+// gate, because the idempotency middleware sits outside it and answers the
+// residue body as a digest mismatch. Hashing the key into the residue's
+// identity made the only retry that CAN arrive unable to match, so the human's
+// approval was void and the withheld field could never be written.
+//
+// Asserted as the redemption side computes it, not as a property of the
+// canonicalization alone: redeemIfPresented hashes the retry with
+// keyBindsTheRetry — it cannot know which kind of approval it is about to
+// redeem — so what has to agree is the STAGED hash and the hash of a keyless
+// retry carrying the same residue.
+func TestAResidueStagedUnderAnIdempotencyKeyIsRedeemableByItsRetry(t *testing.T) {
+	orgID := ids.NewV7()
+	staging := &capturingApprovals{}
+	pol := agentPolicy{Op: "upsertPartner", Access: accessTool, Tool: "update_record", RecordType: recordTypePartner}
+	body := []byte(`{"cert_status":"certified","margin_tier":"tier1_15"}`)
+	req := operandRequest(http.MethodPut, "/v1/organizations", orgID.String(), "", "", body)
+	req.Header.Set(idempotencyKeyHeader, "01J0-agent-retry-key")
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"organization_id":"` + orgID.String() + `","margin_tier":"tier1_15","version":3}`))
+	})
+
+	admitAgentCall(httptest.NewRecorder(), req, next, admissionOutcome{
+		staging: staging, ownership: mixedHumanOwned{conflict: "cert_status"},
+		commands: restCommandDeps{records: seamRecord{}}, pol: pol, body: body,
+		registry: agents.NewRegistry(nil, auth.NewGate(fullSeat{})),
+	})
+	if staging.last.DiffHash == "" {
+		t.Fatal("nothing was staged, so there is no residue identity to redeem")
+	}
+
+	// The retry the staging note instructs: the withheld fields alone, the
+	// approval token, and NO idempotency key — the original is settled and a
+	// fresh one would be a different call.
+	retry := operandRequest(http.MethodPut, "/v1/organizations", orgID.String(), "", "",
+		[]byte(staging.last.ProposedChange))
+	_, retryHash, err := canonicalRESTCall(pol.Op, retry.URL.Path, retry.Header,
+		[]byte(`{"cert_status":"certified"}`), keyBindsTheRetry)
+	if err != nil {
+		t.Fatalf("canonicalizing the retry answered %v", err)
+	}
+
+	if retryHash != staging.last.DiffHash {
+		t.Errorf("the approved retry hashes to %s but the residue was staged as %s — the human's approval "+
+			"is unredeemable and the withheld field can never be written",
+			retryHash, staging.last.DiffHash)
+	}
+}

--- a/backend/internal/compose/agentsplit_test.go
+++ b/backend/internal/compose/agentsplit_test.go
@@ -9,11 +9,14 @@ package compose
 // a client that cannot read its own error.
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
 // bufferedFor builds a buffered response already holding a status and headers,
@@ -103,4 +106,54 @@ func itoa(n int) string {
 		n /= 10
 	}
 	return string(digits)
+}
+
+// allHumanOwned answers the ownership probe by naming every field the patch
+// touches — the shape that leaves SplitHumanOwned's AutoExecute half empty,
+// so splitOrRedeemUpdate's terminal branch (agentsplit.go: "every touched
+// field is human-owned") is the one under test rather than the mixed one.
+type allHumanOwned struct{}
+
+func (allHumanOwned) HumanOwnedConflicts(_ context.Context, _ string, _ ids.UUID, patch json.RawMessage) ([]string, error) {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(patch, &fields); err != nil {
+		return nil, err
+	}
+	names := make([]string, 0, len(fields))
+	for name := range fields {
+		names = append(names, name)
+	}
+	return names, nil
+}
+
+// The split's all-human-owned branch resolves through the SAME command seam
+// every other registered patch does (agentsplit.go's own comment on this
+// branch states why), so it owes the record the same refusal
+// refuseStagingElsewhere gives every other stager: an approval against a
+// target whose authority lives elsewhere could never be redeemed, since
+// redemption's version pin reads our own tables. Before that registration
+// this branch ran no such check at all — an agent patching a mirrored deal
+// with every field human-owned got a staged approval instead.
+func TestSplitAllHumanOwnedRefusesAnExternallyHeldRecord(t *testing.T) {
+	staging := &capturingApprovals{}
+	pol := agentPolicy{Op: "updatePerson", Access: accessTool, Tool: "update_record", RecordType: recordTypePerson}
+	personID := ids.NewV7()
+	body := []byte(`{"full_name":"Overwritten"}`)
+
+	req := patchRequest("/v1/people", personID, body)
+	rec := httptest.NewRecorder()
+	next := http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		t.Fatal("the handler ran — every field was human-owned, so nothing should have auto-executed")
+	})
+
+	splitOrRedeemUpdate(rec, req, next, staging, restCommandDeps{records: mirroredRecord{}}, allHumanOwned{}, pol, body)
+
+	if staging.last.Tool != "" {
+		t.Errorf("an approval was staged for %q against a record whose authority lives elsewhere — "+
+			"nobody could ever release it", staging.last.Tool)
+	}
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Errorf("an externally-held target answered %d, want %d (unsupported_by_sor) — the refusal a "+
+			"caller gets must name why the patch cannot be governed here", rec.Code, http.StatusUnprocessableEntity)
+	}
 }

--- a/backend/internal/compose/agentsplit_test.go
+++ b/backend/internal/compose/agentsplit_test.go
@@ -157,3 +157,46 @@ func TestSplitAllHumanOwnedRefusesAnExternallyHeldRecord(t *testing.T) {
 			"caller gets must name why the patch cannot be governed here", rec.Code, http.StatusUnprocessableEntity)
 	}
 }
+
+// TestUpsertPartnerStagesAHumanOwnedPartnerField pins actionShapedUpdateOps'
+// own claim about upsertPartner (its comment, above the map): the resolver
+// maps partner→organization, so this patch IS a field patch on the routed
+// organization, and an agent overwriting a human-typed partner field
+// (cert_status here) has to STAGE, the same §2.1 precedence protection
+// every ordinary organization field patch gets — not silently apply, which
+// is what would happen if upsertPartner were ever added to the map.
+//
+// Run through admitAgentCall — the layer that actually reads
+// actionShapedUpdateOps to decide between splitOrRedeemUpdate and a bare
+// next.ServeHTTP (agentgate.go) — rather than splitOrRedeemUpdate directly,
+// so this test is sensitive to the membership question itself, not only to
+// splitOrRedeemUpdate's own internals. Verified by hand: adding
+// `opUpsertPartner: true` back into actionShapedUpdateOps and rerunning
+// this test fails it — the call takes the bare next.ServeHTTP branch
+// instead, the handler runs, and nothing stages.
+func TestUpsertPartnerStagesAHumanOwnedPartnerField(t *testing.T) {
+	orgID := ids.NewV7()
+	staging := &capturingApprovals{}
+	pol := agentPolicy{Op: "upsertPartner", Access: accessTool, Tool: "update_record", RecordType: recordTypePartner}
+	body := []byte(`{"cert_status":"certified"}`)
+	req := operandRequest(http.MethodPut, "/v1/organizations", orgID.String(), "", "", body)
+	rec := httptest.NewRecorder()
+	next := http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		t.Fatal("the handler ran — cert_status is human-owned, so the write must stage, not apply")
+	})
+
+	admitAgentCall(rec, req, next, admissionOutcome{
+		staging: staging, ownership: allHumanOwned{},
+		commands: restCommandDeps{records: seamRecord{}}, pol: pol, body: body,
+	})
+
+	if staging.last.TargetType != "organization" || staging.last.TargetID != orgID {
+		t.Fatalf("staged target = (%s,%s), want (organization,%s) — the resolver maps partner→organization, "+
+			"so the approval binds to the org whose field this patch actually sets",
+			staging.last.TargetType, staging.last.TargetID, orgID)
+	}
+	if rec.Code == http.StatusOK {
+		t.Errorf("status = %d, want a refusal naming the staged approval — a human-owned field applied "+
+			"silently is the §2.1 precedence protection this test exists to hold", rec.Code)
+	}
+}

--- a/backend/internal/compose/agentsplit_test.go
+++ b/backend/internal/compose/agentsplit_test.go
@@ -197,9 +197,10 @@ func TestUpsertPartnerStagesAHumanOwnedPartnerField(t *testing.T) {
 			"so the approval binds to the org whose field this patch actually sets",
 			staging.last.TargetType, staging.last.TargetID, orgID)
 	}
-	if rec.Code == http.StatusOK {
-		t.Errorf("status = %d, want a refusal naming the staged approval — a human-owned field applied "+
-			"silently is the §2.1 precedence protection this test exists to hold", rec.Code)
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want %d (approval_required) — a human-owned field applied silently is the "+
+			"§2.1 precedence protection this test exists to hold, and an unclassified 500 must not read "+
+			"as that refusal", rec.Code, http.StatusForbidden)
 	}
 }
 
@@ -260,6 +261,45 @@ func TestUpsertPartnerResidueStagesTheOrganizationNotPartner(t *testing.T) {
 		t.Fatalf("residue staged target = (%s,%s), want (organization,%s) — the residue path must "+
 			"resolve through the same seam the all-human-owned branch does, not off pol.RecordType "+
 			"directly", staging.last.TargetType, staging.last.TargetID, orgID)
+	}
+}
+
+// A refusal describes a request that changed nothing
+// (gradionhq/margince-poc-v1#1073). The residue path's own refusals — the
+// resolver's Guards among them — are settled BEFORE the auto-execute half is
+// dispatched, so a target this door will not stage against costs the caller a
+// retry rather than leaving half a patch committed under a 4xx that says the
+// change was refused.
+//
+// Driven with the mirrored record the all-human-owned branch uses
+// (TestSplitAllHumanOwnedRefusesAnExternallyHeldRecord) and the MIXED ownership
+// that reaches the residue path: before the ordering fix the handler ran first,
+// so this same call answered 422 with the agent-owned half already written.
+func TestTheResiduePathRefusesAnExternallyHeldRecordBeforeAnythingIsWritten(t *testing.T) {
+	orgID := ids.NewV7()
+	staging := &capturingApprovals{}
+	pol := agentPolicy{Op: "upsertPartner", Access: accessTool, Tool: "update_record", RecordType: recordTypePartner}
+	body := []byte(`{"cert_status":"certified","margin_tier":"tier1_15"}`)
+	req := operandRequest(http.MethodPut, "/v1/organizations", orgID.String(), "", "", body)
+	rec := httptest.NewRecorder()
+	next := http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		t.Error("the handler ran — the agent-owned half was written for a call this door then refused, " +
+			"which is the partial write a refusal must never describe")
+	})
+
+	admitAgentCall(rec, req, next, admissionOutcome{
+		staging: staging, ownership: mixedHumanOwned{conflict: "cert_status"},
+		commands: restCommandDeps{records: mirroredRecord{}}, pol: pol, body: body,
+		registry: agents.NewRegistry(nil, auth.NewGate(fullSeat{})),
+	})
+
+	if staging.last.Tool != "" {
+		t.Errorf("an approval was staged for %q against a record whose authority lives elsewhere — "+
+			"nobody could ever release it", staging.last.Tool)
+	}
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Errorf("an externally-held target answered %d, want %d (unsupported_by_sor)", rec.Code,
+			http.StatusUnprocessableEntity)
 	}
 }
 

--- a/backend/internal/compose/agentsplit_test.go
+++ b/backend/internal/compose/agentsplit_test.go
@@ -148,7 +148,9 @@ func TestSplitAllHumanOwnedRefusesAnExternallyHeldRecord(t *testing.T) {
 		t.Fatal("the handler ran — every field was human-owned, so nothing should have auto-executed")
 	})
 
-	splitHumanOwnedUpdate(rec, req, next, staging, restCommandDeps{records: mirroredRecord{}}, allHumanOwned{}, pol, body)
+	splitHumanOwnedUpdate(rec, req, next,
+		splitUpdateDeps{staging: staging, commands: restCommandDeps{records: mirroredRecord{}}, ownership: allHumanOwned{}},
+		pol, body)
 
 	if staging.last.Tool != "" {
 		t.Errorf("an approval was staged for %q against a record whose authority lives elsewhere — "+

--- a/backend/internal/compose/agentsplit_test.go
+++ b/backend/internal/compose/agentsplit_test.go
@@ -112,7 +112,7 @@ func itoa(n int) string {
 
 // allHumanOwned answers the ownership probe by naming every field the patch
 // touches — the shape that leaves SplitHumanOwned's AutoExecute half empty,
-// so splitOrRedeemUpdate's terminal branch (agentsplit.go: "every touched
+// so splitHumanOwnedUpdate's terminal branch (agentsplit.go: "every touched
 // field is human-owned") is the one under test rather than the mixed one.
 type allHumanOwned struct{}
 
@@ -148,7 +148,7 @@ func TestSplitAllHumanOwnedRefusesAnExternallyHeldRecord(t *testing.T) {
 		t.Fatal("the handler ran — every field was human-owned, so nothing should have auto-executed")
 	})
 
-	splitOrRedeemUpdate(rec, req, next, staging, restCommandDeps{records: mirroredRecord{}}, allHumanOwned{}, pol, body)
+	splitHumanOwnedUpdate(rec, req, next, staging, restCommandDeps{records: mirroredRecord{}}, allHumanOwned{}, pol, body)
 
 	if staging.last.Tool != "" {
 		t.Errorf("an approval was staged for %q against a record whose authority lives elsewhere — "+
@@ -169,10 +169,10 @@ func TestSplitAllHumanOwnedRefusesAnExternallyHeldRecord(t *testing.T) {
 // is what would happen if upsertPartner were ever added to the map.
 //
 // Run through admitAgentCall — the layer that actually reads
-// actionShapedUpdateOps to decide between splitOrRedeemUpdate and a bare
-// next.ServeHTTP (agentgate.go) — rather than splitOrRedeemUpdate directly,
+// actionShapedUpdateOps to decide between splitHumanOwnedUpdate and a bare
+// next.ServeHTTP (agentgate.go) — rather than splitHumanOwnedUpdate directly,
 // so this test is sensitive to the membership question itself, not only to
-// splitOrRedeemUpdate's own internals. Verified by hand: adding
+// splitHumanOwnedUpdate's own internals. Verified by hand: adding
 // `opUpsertPartner: true` back into actionShapedUpdateOps and rerunning
 // this test fails it — the call takes the bare next.ServeHTTP branch
 // instead, the handler runs, and nothing stages.
@@ -205,7 +205,7 @@ func TestUpsertPartnerStagesAHumanOwnedPartnerField(t *testing.T) {
 
 // mixedHumanOwned answers the ownership probe by naming only ONE field as
 // human-owned, leaving any other touched field to auto-execute — the shape
-// that sends splitOrRedeemUpdate down applyAutoExecuteAndStageResidue's
+// that sends splitHumanOwnedUpdate down applyAutoExecuteAndStageResidue's
 // residue path (split.AutoExecute != nil) rather than allHumanOwned's
 // all-refused terminal branch.
 type mixedHumanOwned struct{ conflict string }

--- a/backend/internal/compose/agentsplit_test.go
+++ b/backend/internal/compose/agentsplit_test.go
@@ -16,6 +16,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gradionhq/margince/backend/internal/modules/agents"
+	"github.com/gradionhq/margince/backend/internal/platform/auth"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
@@ -198,5 +200,66 @@ func TestUpsertPartnerStagesAHumanOwnedPartnerField(t *testing.T) {
 	if rec.Code == http.StatusOK {
 		t.Errorf("status = %d, want a refusal naming the staged approval — a human-owned field applied "+
 			"silently is the §2.1 precedence protection this test exists to hold", rec.Code)
+	}
+}
+
+// mixedHumanOwned answers the ownership probe by naming only ONE field as
+// human-owned, leaving any other touched field to auto-execute — the shape
+// that sends splitOrRedeemUpdate down applyAutoExecuteAndStageResidue's
+// residue path (split.AutoExecute != nil) rather than allHumanOwned's
+// all-refused terminal branch.
+type mixedHumanOwned struct{ conflict string }
+
+func (m mixedHumanOwned) HumanOwnedConflicts(context.Context, string, ids.UUID, json.RawMessage) ([]string, error) {
+	return []string{m.conflict}, nil
+}
+
+// TestUpsertPartnerResidueStagesTheOrganizationNotPartner pins the THIRD
+// staging call site a review round found still guessing after
+// TestUpsertPartnerStagesAHumanOwnedPartnerField fixed the first two
+// (stageRefusal and, transitively, resolveOrWalk/stagedTargetByRoute):
+// applyAutoExecuteAndStageResidue used to build its StageRequest straight
+// off pol.RecordType ("partner" for this op) and the routed id, bypassing
+// the resolver seam entirely. "partner" has no rule in either
+// targetProbes or existenceProbes (approvals/targetvisibility.go), so a
+// row staged under it fails closed — invisible in the inbox, undecidable
+// at the decision — the zombie authority object this whole seam exists to
+// prevent, for the exact write §2.1 is supposed to protect.
+//
+// A MIXED patch (one human-owned field, one agent-owned) is what reaches
+// the residue path rather than the all-human-owned terminal branch, so
+// this drives one through admitAgentCall — the same layer
+// TestUpsertPartnerStagesAHumanOwnedPartnerField uses — with an
+// auto-execute handler that answers the shape a real 200 record has.
+// Verified to fail against the pre-fix residue path: it staged
+// target_type "partner" instead of "organization".
+func TestUpsertPartnerResidueStagesTheOrganizationNotPartner(t *testing.T) {
+	orgID := ids.NewV7()
+	staging := &capturingApprovals{}
+	pol := agentPolicy{Op: "upsertPartner", Access: accessTool, Tool: "update_record", RecordType: recordTypePartner}
+	body := []byte(`{"cert_status":"certified","margin_tier":"tier1_15"}`)
+	req := operandRequest(http.MethodPut, "/v1/organizations", orgID.String(), "", "", body)
+	rec := httptest.NewRecorder()
+	// The stand-in for the real UpsertPartner handler: applies the
+	// agent-owned half and answers 200 with a record body, the shape
+	// applyAutoExecuteAndStageResidue decodes to read the post-write
+	// version and splice the staging note into.
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"organization_id":"` + orgID.String() + `","margin_tier":"tier1_15","version":3}`))
+	})
+	reg := agents.NewRegistry(nil, auth.NewGate(fullSeat{}))
+
+	admitAgentCall(rec, req, next, admissionOutcome{
+		staging: staging, ownership: mixedHumanOwned{conflict: "cert_status"},
+		commands: restCommandDeps{records: seamRecord{}}, pol: pol, body: body,
+		registry: reg,
+	})
+
+	if staging.last.TargetType != "organization" || staging.last.TargetID != orgID {
+		t.Fatalf("residue staged target = (%s,%s), want (organization,%s) — the residue path must "+
+			"resolve through the same seam the all-human-owned branch does, not off pol.RecordType "+
+			"directly", staging.last.TargetType, staging.last.TargetID, orgID)
 	}
 }

--- a/backend/internal/compose/agentsplit_test.go
+++ b/backend/internal/compose/agentsplit_test.go
@@ -214,13 +214,12 @@ func (m mixedHumanOwned) HumanOwnedConflicts(context.Context, string, ids.UUID, 
 	return []string{m.conflict}, nil
 }
 
-// TestUpsertPartnerResidueStagesTheOrganizationNotPartner pins the THIRD
-// staging call site a review round found still guessing after
-// TestUpsertPartnerStagesAHumanOwnedPartnerField fixed the first two
-// (stageRefusal and, transitively, resolveOrWalk/stagedTargetByRoute):
-// applyAutoExecuteAndStageResidue used to build its StageRequest straight
-// off pol.RecordType ("partner" for this op) and the routed id, bypassing
-// the resolver seam entirely. "partner" has no rule in either
+// TestUpsertPartnerResidueStagesTheOrganizationNotPartner pins the third
+// staging call site: applyAutoExecuteAndStageResidue builds its StageRequest
+// through the resolver seam (stagedTarget) rather than straight off
+// pol.RecordType ("partner" for this op) and the routed id, which is what the
+// two call sites TestUpsertPartnerStagesAHumanOwnedPartnerField covers already
+// do. "partner" has no rule in either
 // targetProbes or existenceProbes (approvals/targetvisibility.go), so a
 // row staged under it fails closed — invisible in the inbox, undecidable
 // at the decision — the zombie authority object this whole seam exists to

--- a/backend/internal/compose/comms.go
+++ b/backend/internal/compose/comms.go
@@ -134,9 +134,24 @@ func (c commsAdapter) SendMessage(ctx context.Context, anchor ids.UUID, in agent
 }
 
 // IsChannelKind delegates to activities.IsChannelKind — the same test the
-// store's own SendMessage refuses on — so StageInfo's pre-check and Handle's
+// store's own SendMessage refuses on — so the staging pre-check and Handle's
 // eventual refusal can never drift onto two different answers for the same kind.
 func (c commsAdapter) IsChannelKind(kind string) bool { return activities.IsChannelKind(kind) }
+
+// channelKinds is that same question WITHOUT the send machinery around it, for
+// the REST admission gate: its send_message resolver must refuse a non-channel
+// anchor before a human is asked about the reply, and it has no reason to hold
+// a seam that can also send mail, book meetings and read calendars in order to
+// ask (restCommandDeps, agentcommand.go).
+//
+// It reaches activities.IsChannelKind exactly as the adapter above does, so the
+// two are one answer arrived at from two places rather than two answers — there
+// is no state here for a second opinion to accumulate in.
+type channelKinds struct{}
+
+func (channelKinds) IsChannelKind(kind string) bool { return activities.IsChannelKind(kind) }
+
+var _ agents.ChannelKinds = channelKinds{}
 
 func (c commsAdapter) Availability(ctx context.Context, host *ids.UUID, from, to time.Time, durationMinutes int) (agents.AvailabilityResult, error) {
 	hostID, err := defaultHost(ctx, host)

--- a/backend/internal/compose/integration/agentcommandoperand_integration_test.go
+++ b/backend/internal/compose/integration/agentcommandoperand_integration_test.go
@@ -11,13 +11,12 @@ package integration
 // approval ROW.
 //
 // TestAConfirmFirstFactCallAgainstAnUnseeableOrganizationStagesNothing below
-// is this task's actual proof: registering these eight in restCommands
-// makes Guards run before anything stages, where the route-walk fallback
-// (stagedTargetByRoute) ran none. TestTwoFactKeysOnOneOrganizationStageDistinguishableApprovals
+// is the proof that matters: their restCommands entries make Guards run before
+// anything stages. TestTwoFactKeysOnOneOrganizationStageDistinguishableApprovals
 // does NOT prove that — diff_hash and summary are both derived from the
 // concrete request path upstream of the resolver (canonicalRESTCall,
-// restSummary), so it would pass unchanged against the pre-task route walk
-// too. It stays because it is the one place production's chi parameter
+// restSummary), so it holds whether or not a resolver was consulted at all.
+// It stays because it is the one place production's chi parameter
 // names (factKey, field, person_id) are exercised through the REAL router
 // rather than hand-bound in a unit test's route context.
 
@@ -33,10 +32,10 @@ import (
 // this task's actual behavioral proof: an agent acting for a human whose row
 // scope hides an organization (team-scoped, no shared team with the
 // organization's owner) gets the existence-hiding 404 GetOrganization itself
-// would give, and stages NO approval. Without this task's restCommands entry,
-// stagedTargetByRoute answers the target from the route alone — no read, no
-// refusal — and stages one regardless; that is the entire delta this test
-// exercises through the REAL row-scope predicate (internal/platform/auth),
+// would give, and stages NO approval. A target answered from the route alone
+// asks for no read and so makes no such refusal — it stages one regardless;
+// that is the delta this test exercises through the REAL row-scope predicate
+// (internal/platform/auth),
 // which TestAnOperandCommandOfAnUnseeableRecordStagesNothing (agentcommandoperand_test.go)
 // can only fake.
 func TestAConfirmFirstFactCallAgainstAnUnseeableOrganizationStagesNothing(t *testing.T) {

--- a/backend/internal/compose/integration/agentcommandoperand_integration_test.go
+++ b/backend/internal/compose/integration/agentcommandoperand_integration_test.go
@@ -10,20 +10,87 @@ package integration
 // agentcommandtarget_integration_test.go proves it for archive: the staged
 // approval ROW.
 //
-// The defect this task exists to prevent: every fact on one organization
-// rides the identical update_record verb, so a design that projected the
-// call onto that verb's own arguments would let one approval redeem any of
-// them. The proof has to be two DIFFERENT fact keys on the SAME organization
-// staging two DISTINGUISHABLE approvals — different diff_hash, different
-// summary — asserted on the rows, not on the ErrRequiresApproval sentinel a
-// refusal with nowhere to land would answer just as readily.
+// TestAConfirmFirstFactCallAgainstAnUnseeableOrganizationStagesNothing below
+// is this task's actual proof: registering these eight in restCommands
+// makes Guards run before anything stages, where the route-walk fallback
+// (stagedTargetByRoute) ran none. TestTwoFactKeysOnOneOrganizationStageDistinguishableApprovals
+// does NOT prove that — diff_hash and summary are both derived from the
+// concrete request path upstream of the resolver (canonicalRESTCall,
+// restSummary), so it would pass unchanged against the pre-task route walk
+// too. It stays because it is the one place production's chi parameter
+// names (factKey, field, person_id) are exercised through the REAL router
+// rather than hand-bound in a unit test's route context.
 
 import (
 	"net/http"
 	"testing"
 
 	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
+
+// TestAConfirmFirstFactCallAgainstAnUnseeableOrganizationStagesNothing is
+// this task's actual behavioral proof: an agent acting for a human whose row
+// scope hides an organization (team-scoped, no shared team with the
+// organization's owner) gets the existence-hiding 404 GetOrganization itself
+// would give, and stages NO approval. Without this task's restCommands entry,
+// stagedTargetByRoute answers the target from the route alone — no read, no
+// refusal — and stages one regardless; that is the entire delta this test
+// exercises through the REAL row-scope predicate (internal/platform/auth),
+// which TestAnOperandCommandOfAnUnseeableRecordStagesNothing (agentcommandoperand_test.go)
+// can only fake.
+func TestAConfirmFirstFactCallAgainstAnUnseeableOrganizationStagesNothing(t *testing.T) {
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
+
+	var adminID string
+	if err := e.Owner.QueryRow(t.Context(), `SELECT id FROM app_user WHERE email = 'ada@example.com'`).Scan(&adminID); err != nil {
+		t.Fatalf("resolving admin id: %v", err)
+	}
+
+	// Owned by the admin: owner_id IS NULL is visible to everyone regardless
+	// of row scope, so an explicit owner the rep below shares no team with is
+	// what makes the miss genuine rather than incidental.
+	orgID := createdID(t, e, "/v1/organizations", apptest.AnyMap{
+		"display_name": "Row-Scope Hidden Inc", "owner_id": adminID,
+	})
+
+	wsA := wsID(t, e, e.Slug)
+	rep := ids.NewV7()
+	seedInWorkspace(t, e, wsA,
+		stmt(`INSERT INTO app_user (id, workspace_id, email, display_name) VALUES ($1, $2, 'rep@example.com', 'Rep One')`, rep, wsA),
+		// Borrow the bootstrap admin's hash so the rep can actually sign in —
+		// the same reason TestRosterWithholdsRoleKeysFromANonAdmin does.
+		stmt(`UPDATE app_user SET password_hash = (SELECT password_hash FROM app_user WHERE email = 'ada@example.com') WHERE id = $1`, rep),
+		// 'rep' is RowScopeTeam with no team_membership row seeded — an empty
+		// team set, so the predicate's team arm matches nothing and only
+		// owner_id = rep's own id could pass it, which it does not.
+		stmt(`INSERT INTO role_assignment (workspace_id, role_id, user_id) SELECT $2, r.id, $1 FROM role r WHERE r.key = 'rep'`, rep, wsA),
+	)
+	if status := e.Call(t, "POST", "/v1/auth/login", apptest.AnyMap{
+		"email": "rep@example.com", "password": "correct-horse-battery",
+	}, nil, nil); status != http.StatusOK {
+		t.Fatalf("rep login → %d, want 200", status)
+	}
+	bearer := agentBearer(t, e, "row-scope-miss agent")
+
+	var problem struct {
+		Code string `json:"code"`
+	}
+	status := e.Call(t, "POST", "/v1/organizations/"+orgID+"/facts/named_customer:acme-inc/confirm", nil, bearer, &problem)
+	if status != http.StatusNotFound {
+		t.Fatalf("confirming a fact on an organization the acting human cannot see answered %d %q, want 404 — "+
+			"the refusal must not tell a caller that a row they may not see exists", status, problem.Code)
+	}
+
+	var n int
+	if err := e.Owner.QueryRow(t.Context(), `SELECT count(*) FROM approval WHERE target_entity_id = $1`, orgID).Scan(&n); err != nil {
+		t.Fatalf("counting approvals: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("staged %d approvals against an organization nobody could ever decide about, want 0", n)
+	}
+}
 
 func TestTwoFactKeysOnOneOrganizationStageDistinguishableApprovals(t *testing.T) {
 	e := apptest.SetupApp(t)

--- a/backend/internal/compose/integration/agentcommandoperand_integration_test.go
+++ b/backend/internal/compose/integration/agentcommandoperand_integration_test.go
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// The eight bespoke commands' half of the governance seam
+// (modules/agents/commandsidecar.go, commandaction.go), proved the same way
+// agentcommandtarget_integration_test.go proves it for archive: the staged
+// approval ROW.
+//
+// The defect this task exists to prevent: every fact on one organization
+// rides the identical update_record verb, so a design that projected the
+// call onto that verb's own arguments would let one approval redeem any of
+// them. The proof has to be two DIFFERENT fact keys on the SAME organization
+// staging two DISTINGUISHABLE approvals — different diff_hash, different
+// summary — asserted on the rows, not on the ErrRequiresApproval sentinel a
+// refusal with nowhere to land would answer just as readily.
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
+)
+
+func TestTwoFactKeysOnOneOrganizationStageDistinguishableApprovals(t *testing.T) {
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
+	bearer := agentBearer(t, e, "fact-confirm agent")
+
+	orgID := createdID(t, e, "/v1/organizations", apptest.AnyMap{"display_name": "Distinguishable Facts Inc"})
+
+	approvalA := stageFactConfirm(t, e, bearer, orgID, "named_customer:acme-inc")
+	approvalB := stageFactConfirm(t, e, bearer, orgID, "annual_revenue:2026")
+
+	typeA, idA, hashA, summaryA := readApproval(t, e, approvalA)
+	typeB, idB, hashB, summaryB := readApproval(t, e, approvalB)
+
+	if typeA != "organization" || typeB != "organization" {
+		t.Errorf("staged target types = (%q,%q), want both \"organization\"", typeA, typeB)
+	}
+	if idA == nil || idB == nil {
+		t.Fatal("a staged approval names no target id — a decision about which organization was never captured")
+	}
+	if *idA != orgID || *idB != orgID {
+		t.Fatalf("staged target ids = (%s,%s), want both %s — both facts belong to the SAME organization, so a "+
+			"target id alone cannot be what tells the two apart", *idA, *idB, orgID)
+	}
+	if hashA == hashB {
+		t.Error("two different fact keys on the same organization staged the SAME diff_hash — one approval " +
+			"could redeem either")
+	}
+	if summaryA == summaryB {
+		t.Error("two different fact keys on the same organization staged the SAME summary — a human triaging " +
+			"the inbox cannot tell which fact they are confirming")
+	}
+}
+
+// stageFactConfirm provokes a refused agent fact confirmation and returns
+// the approval id it staged.
+func stageFactConfirm(t *testing.T, e *apptest.AppEnv, bearer map[string]string, orgID, factKey string) string {
+	t.Helper()
+	var problem struct {
+		Code   string `json:"code"`
+		Detail string `json:"detail"`
+	}
+	path := "/v1/organizations/" + orgID + "/facts/" + factKey + "/confirm"
+	if status := e.Call(t, "POST", path, nil, bearer, &problem); status != http.StatusForbidden ||
+		problem.Code != "approval_required" {
+		t.Fatalf("agent fact confirm %q → %d %q, want 403 approval_required", factKey, status, problem.Code)
+	}
+	return ExtractStagedApprovalID(t, problem.Detail)
+}
+
+// readApproval reads the staged row's target and the two fields that must
+// distinguish it from a sibling staging: diff_hash and summary.
+func readApproval(t *testing.T, e *apptest.AppEnv, approvalID string) (targetType string, targetID *string, diffHash, summary string) {
+	t.Helper()
+	if err := e.Owner.QueryRow(t.Context(),
+		`SELECT coalesce(target_entity_type, ''), target_entity_id, diff_hash, coalesce(summary, '') FROM approval WHERE id = $1`,
+		approvalID).Scan(&targetType, &targetID, &diffHash, &summary); err != nil {
+		t.Fatalf("reading approval %s: %v", approvalID, err)
+	}
+	return targetType, targetID, diffHash, summary
+}

--- a/backend/internal/compose/integration/agentcommandtarget_createpatch_integration_test.go
+++ b/backend/internal/compose/integration/agentcommandtarget_createpatch_integration_test.go
@@ -123,6 +123,18 @@ func TestARestPatchOutsideTheToolSchemaStagesTheRowWithID(t *testing.T) {
 	if *targetID != created.Subscription.ID {
 		t.Errorf("staged target_entity_id = %s, want %s", *targetID, created.Subscription.ID)
 	}
+
+	// The staged row is only half the proof: a door that staged the approval AND
+	// applied the patch answers everything above unchanged.
+	var state string
+	if err := e.Owner.QueryRow(t.Context(),
+		`SELECT state FROM webhook_subscription WHERE id = $1`, created.Subscription.ID).Scan(&state); err != nil {
+		t.Fatalf("reading the subscription back: %v", err)
+	}
+	if state != "active" {
+		t.Errorf("the subscription is %q — the agent performed unattended the write this confirm-first "+
+			"tier should have staged", state)
+	}
 }
 
 // The regression this rules out: createCustomField creates a record type
@@ -163,6 +175,16 @@ func TestARestCreateCustomFieldStagesRatherThanRefuses(t *testing.T) {
 	if targetID != nil {
 		t.Errorf("staged target_entity_id = %v, want NULL — a create names no existing row", *targetID)
 	}
+
+	var n int
+	if err := e.Owner.QueryRow(t.Context(),
+		`SELECT count(*) FROM custom_field WHERE label = 'Champion Score'`).Scan(&n); err != nil {
+		t.Fatalf("counting custom fields: %v", err)
+	}
+	if n != 0 {
+		t.Error("a custom field labelled Champion Score exists — the agent performed unattended the write " +
+			"this confirm-first tier should have staged")
+	}
 }
 
 // The same regression, on createWebhookSubscription — the other create
@@ -200,5 +222,17 @@ func TestARestCreateWebhookSubscriptionStagesRatherThanRefuses(t *testing.T) {
 	}
 	if targetID != nil {
 		t.Errorf("staged target_entity_id = %v, want NULL — a create names no existing row", *targetID)
+	}
+
+	// Nothing else in this test creates a subscription, so the staged create is
+	// the only one that could have written a row.
+	var n int
+	if err := e.Owner.QueryRow(t.Context(),
+		`SELECT count(*) FROM webhook_subscription`).Scan(&n); err != nil {
+		t.Fatalf("counting webhook subscriptions: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("%d webhook subscriptions exist — the agent performed unattended the write this "+
+			"confirm-first tier should have staged", n)
 	}
 }

--- a/backend/internal/compose/integration/agentcommandtarget_createpatch_integration_test.go
+++ b/backend/internal/compose/integration/agentcommandtarget_createpatch_integration_test.go
@@ -124,3 +124,81 @@ func TestARestPatchOutsideTheToolSchemaStagesTheRowWithID(t *testing.T) {
 		t.Errorf("staged target_entity_id = %s, want %s", *targetID, created.Subscription.ID)
 	}
 }
+
+// The regression this rules out: createCustomField creates a record type
+// (custom_field) createResolver.Guards has no opinion on — create_record's
+// own Handle cannot write it, but this operation's own module (customfields)
+// does, entirely independent of that verb. An earlier version of this seam
+// had createResolver.Guards refuse it outright over REST (the "does
+// create_record itself serve this type" question, correct for the TOOL door,
+// wrongly asked of every door); this proves it now STAGES like any other
+// confirm-first create, not that it merely fails to 500.
+func TestARestCreateCustomFieldStagesRatherThanRefuses(t *testing.T) {
+	e := apptest.SetupAppWithOptions(t, compose.WithSchemaPool(SchemaPool(t)))
+	e.BootstrapWorkspace(t)
+	bearer := agentBearer(t, e, "custom-field-create agent")
+
+	var problem struct {
+		Code   string `json:"code"`
+		Detail string `json:"detail"`
+	}
+	if status := e.Call(t, "POST", "/v1/custom-fields", apptest.AnyMap{
+		"object": "deal", "label": "Champion Score", "type": "text", "source": "ui",
+	}, bearer, &problem); status != http.StatusForbidden || problem.Code != "approval_required" {
+		t.Fatalf("agent custom field create → %d %q, want 403 approval_required — a hard refusal here is "+
+			"the exact regression this test rules out", status, problem.Code)
+	}
+	approvalID := ExtractStagedApprovalID(t, problem.Detail)
+
+	var targetType string
+	var targetID *string
+	if err := e.Owner.QueryRow(t.Context(),
+		`SELECT coalesce(target_entity_type, ''), target_entity_id FROM approval WHERE id = $1`,
+		approvalID).Scan(&targetType, &targetID); err != nil {
+		t.Fatalf("reading the staged approval: %v", err)
+	}
+	if targetType != "custom_field" {
+		t.Errorf("staged target_entity_type = %q, want \"custom_field\"", targetType)
+	}
+	if targetID != nil {
+		t.Errorf("staged target_entity_id = %v, want NULL — a create names no existing row", *targetID)
+	}
+}
+
+// The same regression, on createWebhookSubscription — the other create
+// route outside createResolver's served vocabulary.
+func TestARestCreateWebhookSubscriptionStagesRatherThanRefuses(t *testing.T) {
+	cipher, err := webhooks.NewCipher(bytes.Repeat([]byte{0x5a}, webhooks.WebhookKeyBytes))
+	if err != nil {
+		t.Fatalf("cipher: %v", err)
+	}
+	e := apptest.SetupAppWithOptions(t, compose.WithWebhookSigningKey(cipher))
+	e.BootstrapWorkspace(t)
+	bearer := agentBearer(t, e, "webhook-subscription-create agent")
+
+	var problem struct {
+		Code   string `json:"code"`
+		Detail string `json:"detail"`
+	}
+	if status := e.Call(t, "POST", "/v1/webhook-subscriptions", apptest.AnyMap{
+		"target_url": "https://ok.example/hook", "event_types": []string{"deal.created"},
+	}, bearer, &problem); status != http.StatusForbidden || problem.Code != "approval_required" {
+		t.Fatalf("agent webhook subscription create → %d %q, want 403 approval_required — a hard refusal "+
+			"here is the exact regression this test rules out", status, problem.Code)
+	}
+	approvalID := ExtractStagedApprovalID(t, problem.Detail)
+
+	var targetType string
+	var targetID *string
+	if err := e.Owner.QueryRow(t.Context(),
+		`SELECT coalesce(target_entity_type, ''), target_entity_id FROM approval WHERE id = $1`,
+		approvalID).Scan(&targetType, &targetID); err != nil {
+		t.Fatalf("reading the staged approval: %v", err)
+	}
+	if targetType != "webhook_subscription" {
+		t.Errorf("staged target_entity_type = %q, want \"webhook_subscription\"", targetType)
+	}
+	if targetID != nil {
+		t.Errorf("staged target_entity_id = %v, want NULL — a create names no existing row", *targetID)
+	}
+}

--- a/backend/internal/compose/integration/agentcommandtarget_createpatch_integration_test.go
+++ b/backend/internal/compose/integration/agentcommandtarget_createpatch_integration_test.go
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// The create and patch families' half of the governance seam
+// (modules/agents/command.go), proved the same way
+// agentcommandtarget_integration_test.go proves it for archive: the staged
+// approval ROW, not merely the ErrRequiresApproval sentinel a refusal with
+// nowhere to land answers just as readily.
+
+import (
+	"bytes"
+	"net/http"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/compose"
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
+	"github.com/gradionhq/margince/backend/internal/modules/webhooks"
+)
+
+// A confirm-first CREATE stages the record TYPE with NO target id — the row
+// does not exist yet, so there is nothing for an approval to pin. createProject
+// is the contract's per-record-type floor (#982) tightening a verb that is
+// auto-execute for every other type it serves.
+func TestARestCreateStagesItsRecordTypeWithNoTargetID(t *testing.T) {
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
+	bearer := agentBearer(t, e, "create-staging agent")
+
+	orgID := createdID(t, e, "/v1/organizations", apptest.AnyMap{"display_name": "Tier floor anchor"})
+
+	var problem struct {
+		Code   string `json:"code"`
+		Detail string `json:"detail"`
+	}
+	if status := e.Call(t, "POST", "/v1/projects", apptest.AnyMap{
+		"name": "Unapproved", "organization_id": orgID,
+	}, bearer, &problem); status != http.StatusForbidden || problem.Code != "approval_required" {
+		t.Fatalf("agent project create → %d %q, want 403 approval_required", status, problem.Code)
+	}
+	approvalID := ExtractStagedApprovalID(t, problem.Detail)
+
+	var targetType string
+	var targetID *string
+	if err := e.Owner.QueryRow(t.Context(),
+		`SELECT coalesce(target_entity_type, ''), target_entity_id FROM approval WHERE id = $1`,
+		approvalID).Scan(&targetType, &targetID); err != nil {
+		t.Fatalf("reading the staged approval: %v", err)
+	}
+	if targetType != "project" {
+		t.Errorf("staged target_entity_type = %q, want \"project\"", targetType)
+	}
+	if targetID != nil {
+		t.Errorf("staged target_entity_id = %v, want NULL — a create names no existing row an approval "+
+			"could pin", *targetID)
+	}
+
+	var n int
+	if err := e.Owner.QueryRow(t.Context(),
+		`SELECT count(*) FROM project WHERE name = 'Unapproved'`).Scan(&n); err != nil {
+		t.Fatalf("counting projects: %v", err)
+	}
+	if n != 0 {
+		t.Error("a project named Unapproved exists — the agent performed unattended the write this " +
+			"confirm-first tier should have staged")
+	}
+}
+
+// A confirm-first PATCH stages the record TYPE and the ID the route named —
+// the row a human's decision reads and the redemption pins. webhook_subscription
+// is outside create_record/update_record's own tool schema and outside the
+// record seam (datasource.EntityTypes()), so this also proves
+// patchResolver.Guards' servedByTheRecordSeam short-circuit stands down
+// gracefully over the full stack rather than faulting on a read the seam
+// cannot answer.
+func TestARestPatchOutsideTheToolSchemaStagesTheRowWithID(t *testing.T) {
+	cipher, err := webhooks.NewCipher(bytes.Repeat([]byte{0x5a}, webhooks.WebhookKeyBytes))
+	if err != nil {
+		t.Fatalf("cipher: %v", err)
+	}
+	e := apptest.SetupAppWithOptions(t, compose.WithWebhookSigningKey(cipher))
+	e.BootstrapWorkspace(t)
+	bearer := agentBearer(t, e, "patch-staging agent")
+
+	var created struct {
+		Subscription struct {
+			ID string `json:"id"`
+		} `json:"subscription"`
+	}
+	if status := e.Call(t, "POST", "/v1/webhook-subscriptions", apptest.AnyMap{
+		"target_url": "https://ok.example/hook", "event_types": []string{"deal.created"},
+	}, nil, &created); status != http.StatusCreated {
+		t.Fatalf("create subscription → %d", status)
+	}
+
+	var problem struct {
+		Code   string `json:"code"`
+		Detail string `json:"detail"`
+	}
+	if status := e.Call(t, "PATCH", "/v1/webhook-subscriptions/"+created.Subscription.ID,
+		apptest.AnyMap{"state": "paused"}, bearer, &problem); status != http.StatusForbidden ||
+		problem.Code != "approval_required" {
+		t.Fatalf("agent subscription patch → %d %q, want 403 approval_required", status, problem.Code)
+	}
+	approvalID := ExtractStagedApprovalID(t, problem.Detail)
+
+	var targetType string
+	var targetID *string
+	if err := e.Owner.QueryRow(t.Context(),
+		`SELECT coalesce(target_entity_type, ''), target_entity_id FROM approval WHERE id = $1`,
+		approvalID).Scan(&targetType, &targetID); err != nil {
+		t.Fatalf("reading the staged approval: %v", err)
+	}
+	if targetType != "webhook_subscription" {
+		t.Errorf("staged target_entity_type = %q, want \"webhook_subscription\"", targetType)
+	}
+	if targetID == nil {
+		t.Fatal("the staged approval names no target id — a decision about which subscription was never captured")
+	}
+	if *targetID != created.Subscription.ID {
+		t.Errorf("staged target_entity_id = %s, want %s", *targetID, created.Subscription.ID)
+	}
+}

--- a/backend/internal/compose/integration/agentcommandtarget_integration_test.go
+++ b/backend/internal/compose/integration/agentcommandtarget_integration_test.go
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// A REST archive of a record type the archive_record TOOL cannot even express
+// still stages against the row it names.
+//
+// `tag` is outside that tool's declared enum, and outside the record seam's
+// vocabulary too — nothing the tool door can reach describes it. The REST door
+// archives it all the same, so it is the operation, not the tool's schema, that
+// decides what a governed call is about. The proof has to be the approval ROW:
+// ErrRequiresApproval comes back from a refusal with nowhere to land as
+// readily as from a staged one, and a target_entity_id that is merely a
+// well-formed uuid is not the record anybody will decide about.
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
+)
+
+func TestARestArchiveOutsideTheToolSchemaStagesTheRowItNames(t *testing.T) {
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
+	bearer := agentBearer(t, e, "outside-the-tool-schema agent")
+
+	tagID := createdID(t, e, "/v1/tags", apptest.AnyMap{"name": "Champion"})
+
+	var problem struct {
+		Code   string `json:"code"`
+		Detail string `json:"detail"`
+	}
+	if status := e.Call(t, "DELETE", "/v1/tags/"+tagID, nil, bearer, &problem); status != http.StatusForbidden ||
+		problem.Code != "approval_required" {
+		t.Fatalf("agent tag archive → %d %q, want 403 approval_required", status, problem.Code)
+	}
+	approvalID := ExtractStagedApprovalID(t, problem.Detail)
+
+	var targetType string
+	var targetID *string
+	if err := e.Owner.QueryRow(t.Context(),
+		`SELECT coalesce(target_entity_type, ''), target_entity_id FROM approval WHERE id = $1`,
+		approvalID).Scan(&targetType, &targetID); err != nil {
+		t.Fatalf("reading the staged approval: %v", err)
+	}
+	if targetType != "tag" {
+		t.Errorf("staged target_entity_type = %q, want \"tag\" — the approvals surface scopes an inbox row "+
+			"by probing its target's visibility, and it cannot probe a type it was not told", targetType)
+	}
+	if targetID == nil {
+		t.Fatal("the staged approval names no target id — a decision about which tag was never captured")
+	}
+
+	// The id is the tag the agent asked to archive, not merely a uuid: the
+	// staged row is what a human decides from, and a target that resolves to
+	// nothing is a decision about nothing.
+	var name string
+	if err := e.Owner.QueryRow(t.Context(),
+		`SELECT name FROM tag WHERE id = $1 AND archived_at IS NULL`, *targetID).Scan(&name); err != nil {
+		t.Fatalf("the staged target id %s resolves to no live tag (%v)", *targetID, err)
+	}
+	if name != "Champion" {
+		t.Errorf("the staged target is the tag named %q, want \"Champion\"", name)
+	}
+	if *targetID != tagID {
+		t.Errorf("staged target_entity_id = %s, want %s", *targetID, tagID)
+	}
+}

--- a/backend/internal/compose/lifecycletools.go
+++ b/backend/internal/compose/lifecycletools.go
@@ -85,13 +85,14 @@ func (p projectPhaseAdvancer) AdvanceProjectPhase(
 type companyEnricher struct{ srv *Server }
 
 func (c companyEnricher) EnrichCompany(
-	ctx context.Context, orgID ids.UUID, overrideURL, depth string,
+	ctx context.Context, orgID ids.UUID, overrideURL string, depth agents.EnrichDepth,
 ) (json.RawMessage, error) {
 	// Routed on the seam's own constants, and an unknown depth is REFUSED
-	// rather than falling through to the cheaper read: the tool admits the
-	// vocabulary before it gets here, so a value arriving unrecognised means
-	// the two halves disagree, and answering a one-page scrape to a site read
-	// would be a wrong answer rather than an error.
+	// rather than falling through to the cheaper read: both doors resolve the
+	// vocabulary before it gets here — the tool by admitting its `depth`
+	// argument, the REST door by which of its two routes was taken — so a value
+	// arriving unrecognised means the halves disagree, and answering a one-page
+	// scrape to a site read would be a wrong answer rather than an error.
 	switch depth {
 	case agents.EnrichDepthSite:
 		if c.srv == nil || c.srv.siteReadHandlers.engine == nil {

--- a/backend/internal/compose/lifecycletools_test.go
+++ b/backend/internal/compose/lifecycletools_test.go
@@ -22,11 +22,11 @@ func TestCompanyEnricherRoutesOnDepthAndNamesWhatIsMissing(t *testing.T) {
 	// so an operator reads which flag was not declared rather than a generic
 	// failure. This is the tool's half of the REST route's explicit 501.
 	unwired := companyEnricher{}
-	for depth, want := range map[string]string{
+	for depth, want := range map[agents.EnrichDepth]string{
 		agents.EnrichDepthSite: "crawl runner",
 		agents.EnrichDepthPage: "model path",
 	} {
-		t.Run(depth, func(t *testing.T) {
+		t.Run(string(depth), func(t *testing.T) {
 			_, err := unwired.EnrichCompany(context.Background(), ids.NewV7(), "", depth)
 			if err == nil {
 				t.Fatalf("depth %q answered without an engine — a silent empty result where the "+
@@ -46,7 +46,7 @@ func TestCompanyEnricherRoutesOnDepthAndNamesWhatIsMissing(t *testing.T) {
 	if err == nil {
 		t.Fatal("an unknown depth was served")
 	}
-	if !strings.Contains(err.Error(), agents.EnrichDepthPage) || !strings.Contains(err.Error(), agents.EnrichDepthSite) {
+	if !strings.Contains(err.Error(), string(agents.EnrichDepthPage)) || !strings.Contains(err.Error(), string(agents.EnrichDepthSite)) {
 		t.Errorf("err = %v, want the two depths this seam serves named", err)
 	}
 }

--- a/backend/internal/modules/agents/approvals.go
+++ b/backend/internal/modules/agents/approvals.go
@@ -59,6 +59,14 @@ type StageRequest struct {
 // StageInfo is what a 🟡-capable tool contributes to its own staging: the
 // row the effect targets (for the version re-check) and the one-liner the
 // inbox displays.
+//
+// TargetVersion reaches no staged row in production, on either door. It travels
+// as far as StageRequest and stops there: the approvals engine resolves the pin
+// itself, inside the staging transaction, discarding whatever a caller offered
+// (approvals.insertProposalInTx). So a resolver's answer here documents the
+// version its own read saw, and is not the pin an approval is later redeemed
+// against — a difference worth stating, since a field named TargetVersion on
+// the staging seam reads like the thing that binds the redemption.
 type StageInfo struct {
 	TargetType    string
 	TargetID      ids.UUID

--- a/backend/internal/modules/agents/badargs.go
+++ b/backend/internal/modules/agents/badargs.go
@@ -22,8 +22,14 @@ import (
 	"unicode/utf8"
 
 	"github.com/gradionhq/margince/backend/internal/platform/httperr"
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
 )
+
+// var-checked here rather than left implicit: a signature typo on the method
+// below would otherwise compile clean and simply never match in
+// httperr.Classify, which is a silent 500 nobody would connect to this file.
+var _ apperrors.MessageFault = (*BadArgsError)(nil)
 
 // decodeArgs is the surface's input validation: strict JSON — unknown argument
 // names are errors rather than silent drops, and the arguments are exactly ONE
@@ -115,6 +121,30 @@ func (e *BadArgsError) Error() string {
 	return msg + "; " + e.Guidance
 }
 func (e *BadArgsError) Unwrap() error { return e.Cause }
+
+// MessageFault lets a BadArgsError classify correctly when it reaches the REST
+// surface — which the create/patch resolvers' shared Guards are the first
+// callers to do, since every earlier BadArgsError site answered the MCP tool
+// door alone. httperr.Classify has no notion of this package's own error type,
+// and moduleDeclaredFault (its comment: "a module opts in by implementing a
+// method") is the seam built for exactly that; without it the REST door would
+// answer a caller's own mistake with an opaque 500, which is the one thing
+// clientInputValidation's own doc says must never happen.
+//
+// The code REUSES validation_error rather than minting one: crm.yaml already
+// declares it for exactly this class of caller mistake (httperr.Validation's
+// own code), and inventing a second would put an undocumented code in front
+// of a client that branches on the documented one (P3 — the contract wins).
+// A code this package needs of its own belongs in an upstream contract
+// change, the same rule compose's EmptyReportPlanError.MessageFault states
+// for its own reused code.
+//
+// The MCP tool door is untouched by this: Dispatcher.explain matches
+// *BadArgsError by type BEFORE it ever consults httperr.Classify, so this
+// method is never read on that path.
+func (e *BadArgsError) MessageFault() (code, message string) {
+	return "validation_error", e.Error()
+}
 
 // boundDetail caps a message at n bytes, cutting on a rune boundary so the
 // result stays valid UTF-8 rather than ending mid-sequence.

--- a/backend/internal/modules/agents/command.go
+++ b/backend/internal/modules/agents/command.go
@@ -379,3 +379,58 @@ func (t routedRecordTarget) refuse(ctx context.Context, id ids.UUID) error {
 	}
 	return refuseStagingElsewhere(rec)
 }
+
+// anchoredRecord answers, for a resolver whose Subject needs the ROW and not
+// only the id, the one read both of its questions rest on.
+//
+// It is routedRecordTarget's sibling, and the difference is which of the two
+// questions reads. That family's Subject names an operand and reads nothing, so
+// Guards is the only reader and a memo would protect against nothing (its own
+// doc says so). The families in commandcomms.go, commandlifecycle.go and
+// commandrecord.go are the other case: their Subject pins the row's VERSION and
+// names the row's LABEL, so both questions want the same row — and a row read
+// twice can change between the readings, leaving the authority judgment and the
+// human's sentence describing two different states of one record.
+//
+// entityType is a datasource.EntityType rather than a plain string, which is
+// what makes servedByTheRecordSeam's stand-down unnecessary here rather than
+// merely omitted: a type outside the seam's vocabulary cannot be spelled into
+// this field at all, so there is no unserved case for a branch to answer.
+//
+// The zero value is not usable: every constructor sets both fields, and a
+// resolver holding this is reached only through its family's New…Call.
+type anchoredRecord struct {
+	records    datasource.SystemOfRecordProvider
+	entityType datasource.EntityType
+	// seen is the id rec was read for, so a resolver asked about a second row
+	// reads that row rather than answering about the first.
+	seen ids.UUID
+	rec  datasource.Record
+	read bool
+}
+
+// row reads the record the id names, once.
+func (a *anchoredRecord) row(ctx context.Context, id ids.UUID) (datasource.Record, error) {
+	if a.read && a.seen == id {
+		return a.rec, nil
+	}
+	rec, err := a.records.Read(ctx, datasource.EntityRef{Type: a.entityType, ID: id})
+	if err != nil {
+		return datasource.Record{}, err
+	}
+	a.seen, a.rec, a.read = id, rec, true
+	return rec, nil
+}
+
+// refuse reads the row and refuses the two stagings patchResolver.Guards
+// refuses for its own target: one whose row the caller cannot see (the read
+// answers the row-scope miss as not-found, the existence-hiding answer the
+// executor would give), and one whose authority lives in another system of
+// record.
+func (a *anchoredRecord) refuse(ctx context.Context, id ids.UUID) error {
+	rec, err := a.row(ctx, id)
+	if err != nil {
+		return err
+	}
+	return refuseStagingElsewhere(rec)
+}

--- a/backend/internal/modules/agents/command.go
+++ b/backend/internal/modules/agents/command.go
@@ -342,3 +342,39 @@ func (p patchResolver) Guards(ctx context.Context, cmd PatchCommand) error {
 func servedByTheRecordSeam(recordType string) bool {
 	return slices.Contains(datasource.EntityTypes(), datasource.EntityType(recordType))
 }
+
+// routedRecordTarget memoizes the one read a resolver whose approval binds to
+// a FIXED record type needs to answer both Guards and Subject — the record
+// the routed id names, read once and shared by both questions. The same
+// belt-and-braces shape archiveResolver's own target (above) gives a
+// resolver whose record type instead VARIES per command; here recordType is
+// set once at construction by the family's NewXCall constructors
+// (command_sidecar.go, command_action.go), which is what lets fetch stay a
+// plain memo keyed on the id alone.
+type routedRecordTarget struct {
+	records    datasource.SystemOfRecordProvider
+	recordType string
+	seen       ids.UUID
+	rec        datasource.Record
+	read       bool
+}
+
+// fetch answers served=false, with no read, for a record type the seam has
+// never heard of — reusing servedByTheRecordSeam rather than a resolver-local
+// opinion about which of this family's types are governed here, so the two
+// cannot drift the way a second, hand-restated list would
+// (gradionhq/margince-poc-v1#1021).
+func (t *routedRecordTarget) fetch(ctx context.Context, id ids.UUID) (rec datasource.Record, served bool, err error) {
+	if !servedByTheRecordSeam(t.recordType) {
+		return datasource.Record{}, false, nil
+	}
+	if t.read && t.seen == id {
+		return t.rec, true, nil
+	}
+	rec, err = t.records.Read(ctx, datasource.EntityRef{Type: datasource.EntityType(t.recordType), ID: id})
+	if err != nil {
+		return datasource.Record{}, false, err
+	}
+	t.seen, t.rec, t.read = id, rec, true
+	return rec, true, nil
+}

--- a/backend/internal/modules/agents/command.go
+++ b/backend/internal/modules/agents/command.go
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package agents
+
+// One governed call, whichever door asked for it.
+//
+// The two doors used to decide independently what a call was about: the tool
+// door asked the tool, and the REST door GUESSED — the route's {id} parameter
+// paired with the operation's declared record type. A guess and a fact cannot
+// be held in agreement by review, and these two drifted repeatedly.
+//
+// What the doors share here is not the tool's arguments: half the REST
+// operations have no expressible tool call, and hashing a projection of a
+// request while executing the raw request lets an operand drift between them.
+// It is a typed COMMAND — the operation's own vocabulary, where a path operand
+// is a field like any other — and one resolver over it.
+
+import (
+	"context"
+	"fmt"
+	"slices"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
+)
+
+// GovernanceResolver answers, for one typed command, everything the gate must
+// know before it admits or stages the call it describes.
+//
+// Both doors resolve through the SAME resolver: the tool decodes its arguments
+// into the command, the REST descriptor decodes the request into the command,
+// and neither door constructs the other's wire form. That is what makes an
+// obligation added here impossible to add to one door and forget on the other.
+type GovernanceResolver[T any] interface {
+	// Subject names the record the approval binds to, the line the human reads,
+	// and (where the target has one) the version to pin.
+	Subject(ctx context.Context, cmd T) (StageInfo, error)
+	// Guards refuses, BEFORE anything is staged, what the executor would refuse
+	// afterwards — so a human's one-shot approval is never spent on a call that
+	// was never going to run.
+	Guards(ctx context.Context, cmd T) error
+}
+
+// GovernedCall is a command already bound to the resolver that speaks it.
+//
+// A door decodes a command where its concrete type is known and hands THIS to
+// everything downstream. Without the binding, a door holding a decoded command
+// would need a type switch of its own to find the resolver again — a second
+// table, keyed by the same operations as the first, free to disagree with it.
+// That disagreement is the fault this seam exists to remove, so the seam does
+// not reintroduce it one layer down.
+type GovernedCall interface {
+	Subject(ctx context.Context) (StageInfo, error)
+	Guards(ctx context.Context) error
+}
+
+// Bind pairs one command with the resolver that speaks its language.
+func Bind[T any](resolver GovernanceResolver[T], cmd T) GovernedCall {
+	return boundCommand[T]{resolver: resolver, cmd: cmd}
+}
+
+type boundCommand[T any] struct {
+	resolver GovernanceResolver[T]
+	cmd      T
+}
+
+func (b boundCommand[T]) Subject(ctx context.Context) (StageInfo, error) {
+	return b.resolver.Subject(ctx, b.cmd)
+}
+
+func (b boundCommand[T]) Guards(ctx context.Context) error {
+	return b.resolver.Guards(ctx, b.cmd)
+}
+
+// StageSubject asks a bound call both questions in the order that makes them
+// mean anything: the refusals first, so a call that was never going to run is
+// never described to a human, and the subject after. Every door stages through
+// here, which is what keeps that order from being something each door has to
+// remember.
+func StageSubject(ctx context.Context, call GovernedCall) (StageInfo, error) {
+	if err := call.Guards(ctx); err != nil {
+		return StageInfo{}, err
+	}
+	return call.Subject(ctx)
+}
+
+// ArchiveCommand is one archive, whichever door asked for it.
+type ArchiveCommand struct {
+	RecordType string
+	ID         ids.UUID
+}
+
+// NewArchiveResolver answers both governance questions for an archive, reading
+// through the record seam the archive itself writes through.
+func NewArchiveResolver(records datasource.SystemOfRecordProvider) GovernanceResolver[ArchiveCommand] {
+	return archiveResolver{records: records}
+}
+
+type archiveResolver struct{ records datasource.SystemOfRecordProvider }
+
+// Subject names the row the approval binds to.
+//
+// It supplies NO version pin. approvals.resolveTargetVersion takes the pin
+// server-side inside the staging transaction — the one place every stager
+// passes through — and discards whatever a caller passed, so a version
+// computed here would be a number nothing reads.
+func (a archiveResolver) Subject(ctx context.Context, cmd ArchiveCommand) (StageInfo, error) {
+	info := StageInfo{
+		TargetType: cmd.RecordType,
+		TargetID:   cmd.ID,
+		Summary:    fmt.Sprintf("Archive %s %s", cmd.RecordType, cmd.ID),
+	}
+	if !servedByTheRecordSeam(cmd.RecordType) {
+		return info, nil
+	}
+	// The label is worth its own read: "Archive person 0195c3…" tells the
+	// approver nothing about who disappears, and the approvals surface hands
+	// the inbox no other human-readable name for the target.
+	rec, err := a.records.Read(ctx, datasource.EntityRef{Type: datasource.EntityType(cmd.RecordType), ID: cmd.ID})
+	if err != nil {
+		return StageInfo{}, err
+	}
+	info.Summary = fmt.Sprintf("Archive %s %s", cmd.RecordType, recordLabel(rec))
+	return info, nil
+}
+
+// Guards refuses, before anything is staged, the two archives that were never
+// going to run: one whose target the caller cannot see (the read answers the
+// row-scope miss as not-found, which is the existence-hiding answer the caller
+// would get from the archive itself), and one whose authority lives in another
+// system of record.
+func (a archiveResolver) Guards(ctx context.Context, cmd ArchiveCommand) error {
+	if !servedByTheRecordSeam(cmd.RecordType) {
+		return nil
+	}
+	rec, err := a.records.Read(ctx, datasource.EntityRef{Type: datasource.EntityType(cmd.RecordType), ID: cmd.ID})
+	if err != nil {
+		return err
+	}
+	return refuseStagingElsewhere(rec)
+}
+
+// servedByTheRecordSeam reports whether the record seam speaks this type at all.
+//
+// Half of the twelve types the REST door can archive — lists, offers, offer
+// templates, products, tags and saved views — have no row on the seam, and are
+// archived by their own module's handler instead. The seam therefore has
+// nothing to say about who may see them or where their authority lives, and
+// asking it would answer "not served here" and turn an ordinary archive into a
+// refusal. It is the archive_record TOOL's schema that is narrow, not the
+// operation, so the vocabulary is read from the seam that defines it rather
+// than restated here.
+func servedByTheRecordSeam(recordType string) bool {
+	return slices.Contains(datasource.EntityTypes(), datasource.EntityType(recordType))
+}

--- a/backend/internal/modules/agents/command.go
+++ b/backend/internal/modules/agents/command.go
@@ -346,9 +346,10 @@ func (patchResolver) Subject(_ context.Context, cmd PatchCommand) (StageInfo, er
 // keyed on the same vocabulary the seam is keyed on would make the
 // servedByTheRecordSeam stand-down below unreachable: a type outside it would
 // already have been refused. The seam stands down instead, exactly as
-// archive's does, for the same reason: five of the twelve patchable types
-// (custom_field, offer, product, saved_view, webhook_subscription) are
-// patched by their own module rather than through this seam.
+// archive's does, for the same reason: six of the thirteen patchable types
+// (custom_field, offer, offer_template, product, saved_view,
+// webhook_subscription) are patched by their own module rather than through
+// this seam.
 func (p patchResolver) Guards(ctx context.Context, cmd PatchCommand) error {
 	if err := rejectUnknownFields(updateShapes, cmd.RecordType, cmd.Fields); err != nil {
 		return err

--- a/backend/internal/modules/agents/command.go
+++ b/backend/internal/modules/agents/command.go
@@ -95,12 +95,47 @@ type ArchiveCommand struct {
 
 // NewArchiveResolver answers both governance questions for an archive, reading
 // through the record seam the archive itself writes through.
+//
+// One resolver per call. It remembers the row it read so both questions are
+// answered about the SAME record, which is only true while the resolver is as
+// short-lived as the call it was built for.
 func NewArchiveResolver(records datasource.SystemOfRecordProvider) GovernanceResolver[ArchiveCommand] {
-	return archiveResolver{records: records}
+	return &archiveResolver{records: records}
 }
 
 type archiveResolver struct {
 	records datasource.SystemOfRecordProvider
+	// seen is the command rec was read for, so a resolver asked about a second
+	// target reads that target rather than answering about the first.
+	seen ArchiveCommand
+	rec  datasource.Record
+	read bool
+}
+
+// target reads the row the command names, once.
+//
+// Both questions below are answered from it, for two reasons. A row read twice
+// can change between the readings, and the answers would then describe
+// different records — an authority judgment about one, a summary about
+// another. And the read is not cheap: the seam resolves the installation's
+// mode before it reaches the record, so asking twice doubles the round trips a
+// staging spends on one row.
+//
+// served is false for a record type the seam does not speak: there is no row
+// then, and nothing to say about one.
+func (a *archiveResolver) target(ctx context.Context, cmd ArchiveCommand) (rec datasource.Record, served bool, err error) {
+	if !servedByTheRecordSeam(cmd.RecordType) {
+		return datasource.Record{}, false, nil
+	}
+	if a.read && a.seen == cmd {
+		return a.rec, true, nil
+	}
+	rec, err = a.records.Read(ctx, datasource.EntityRef{Type: datasource.EntityType(cmd.RecordType), ID: cmd.ID})
+	if err != nil {
+		return datasource.Record{}, false, err
+	}
+	a.seen, a.rec, a.read = cmd, rec, true
+	return rec, true, nil
 }
 
 // Subject names the row the approval binds to.
@@ -109,22 +144,23 @@ type archiveResolver struct {
 // server-side inside the staging transaction — the one place every stager
 // passes through — and discards whatever a caller passed, so a version
 // computed here would be a number nothing reads.
-func (a archiveResolver) Subject(ctx context.Context, cmd ArchiveCommand) (StageInfo, error) {
+func (a *archiveResolver) Subject(ctx context.Context, cmd ArchiveCommand) (StageInfo, error) {
 	info := StageInfo{
 		TargetType: cmd.RecordType,
 		TargetID:   cmd.ID,
 		Summary:    fmt.Sprintf("Archive %s %s", cmd.RecordType, cmd.ID),
 	}
-	if !servedByTheRecordSeam(cmd.RecordType) {
-		return info, nil
-	}
-	// The label is worth its own read: "Archive person 0195c3…" tells the
-	// approver nothing about who disappears, and the approvals surface hands
-	// the inbox no other human-readable name for the target.
-	rec, err := a.records.Read(ctx, datasource.EntityRef{Type: datasource.EntityType(cmd.RecordType), ID: cmd.ID})
+	rec, served, err := a.target(ctx, cmd)
 	if err != nil {
 		return StageInfo{}, err
 	}
+	if !served {
+		// The id is the only name this type has here.
+		return info, nil
+	}
+	// "Archive person 0195c3…" tells the approver nothing about who
+	// disappears, and the approvals surface hands the inbox no other
+	// human-readable name for the target.
 	info.Summary = fmt.Sprintf("Archive %s %s", cmd.RecordType, recordLabel(rec))
 	return info, nil
 }
@@ -134,13 +170,13 @@ func (a archiveResolver) Subject(ctx context.Context, cmd ArchiveCommand) (Stage
 // row-scope miss as not-found, which is the existence-hiding answer the caller
 // would get from the archive itself), and one whose authority lives in another
 // system of record.
-func (a archiveResolver) Guards(ctx context.Context, cmd ArchiveCommand) error {
-	if !servedByTheRecordSeam(cmd.RecordType) {
-		return nil
-	}
-	rec, err := a.records.Read(ctx, datasource.EntityRef{Type: datasource.EntityType(cmd.RecordType), ID: cmd.ID})
+func (a *archiveResolver) Guards(ctx context.Context, cmd ArchiveCommand) error {
+	rec, served, err := a.target(ctx, cmd)
 	if err != nil {
 		return err
+	}
+	if !served {
+		return nil
 	}
 	return refuseStagingElsewhere(rec)
 }

--- a/backend/internal/modules/agents/command.go
+++ b/backend/internal/modules/agents/command.go
@@ -343,38 +343,39 @@ func servedByTheRecordSeam(recordType string) bool {
 	return slices.Contains(datasource.EntityTypes(), datasource.EntityType(recordType))
 }
 
-// routedRecordTarget memoizes the one read a resolver whose approval binds to
-// a FIXED record type needs to answer both Guards and Subject — the record
-// the routed id names, read once and shared by both questions. The same
-// belt-and-braces shape archiveResolver's own target (above) gives a
-// resolver whose record type instead VARIES per command; here recordType is
-// set once at construction by the family's NewXCall constructors
-// (command_sidecar.go, command_action.go), which is what lets fetch stay a
-// plain memo keyed on the id alone.
+// routedRecordTarget answers, for a resolver whose approval binds to a FIXED
+// record type (recordType is set once at construction by the family's
+// NewXCall constructors — commandsidecar.go, commandaction.go), the one
+// question that family's Guards needs: is the routed id a target this
+// approval can actually be released against.
+//
+// Unlike archiveResolver's own target (above), there is no memo here: none
+// of this family's Subject implementations reads the record — their summary
+// names the OPERAND (a fact key, a profile field, a person id), the same way
+// patchResolver's names the fields a patch sets rather than reading the
+// record for a value nothing downstream renders (patchResolver's own doc,
+// below) — so refuse is Guards' only caller and there is no second reading
+// for a memo to protect against.
 type routedRecordTarget struct {
 	records    datasource.SystemOfRecordProvider
 	recordType string
-	seen       ids.UUID
-	rec        datasource.Record
-	read       bool
 }
 
-// fetch answers served=false, with no read, for a record type the seam has
-// never heard of — reusing servedByTheRecordSeam rather than a resolver-local
+// refuse reads the routed record where the seam serves this resolver's
+// record type and refuses it the same two ways patchResolver.Guards refuses
+// its own target: unreadable (the row-scope miss) or held in another system
+// of record. It stands down — no read, no refusal — for a type the seam has
+// never heard of, reusing servedByTheRecordSeam rather than a resolver-local
 // opinion about which of this family's types are governed here, so the two
 // cannot drift the way a second, hand-restated list would
 // (gradionhq/margince-poc-v1#1021).
-func (t *routedRecordTarget) fetch(ctx context.Context, id ids.UUID) (rec datasource.Record, served bool, err error) {
+func (t routedRecordTarget) refuse(ctx context.Context, id ids.UUID) error {
 	if !servedByTheRecordSeam(t.recordType) {
-		return datasource.Record{}, false, nil
+		return nil
 	}
-	if t.read && t.seen == id {
-		return t.rec, true, nil
-	}
-	rec, err = t.records.Read(ctx, datasource.EntityRef{Type: datasource.EntityType(t.recordType), ID: id})
+	rec, err := t.records.Read(ctx, datasource.EntityRef{Type: datasource.EntityType(t.recordType), ID: id})
 	if err != nil {
-		return datasource.Record{}, false, err
+		return err
 	}
-	t.seen, t.rec, t.read = id, rec, true
-	return rec, true, nil
+	return refuseStagingElsewhere(rec)
 }

--- a/backend/internal/modules/agents/command.go
+++ b/backend/internal/modules/agents/command.go
@@ -247,17 +247,18 @@ func (createResolver) Guards(_ context.Context, cmd CreateCommand) error {
 }
 
 // PatchCommand is one whole-record field patch, whichever door asked for it.
+//
+// It carries no IfVersion: the tool door's own if_version argument has no
+// reader here to give it to. The pin an approval binds to is taken
+// server-side inside the staging transaction (Subject's own comment below),
+// so a caller-supplied version has nothing this command's Guards/Subject
+// would do with it — a field with no reader is exactly what a command
+// documents ITS OWN OBLIGATIONS by carrying, and this one has none to
+// document.
 type PatchCommand struct {
 	RecordType string
 	ID         ids.UUID
 	Fields     json.RawMessage
-	// IfVersion is the caller's own optimistic-concurrency guard. Neither
-	// Guards nor Subject below reads it — the version an approval pins is
-	// taken server-side inside the staging transaction (Subject's own
-	// comment) — it is part of the command because it is part of what the
-	// call ASKED for, the same reason a canonicalized REST body carries it
-	// into the diff_hash the redemption checks.
-	IfVersion *int64
 }
 
 // NewPatchCall binds one patch to the resolver that answers for it, reading

--- a/backend/internal/modules/agents/command.go
+++ b/backend/internal/modules/agents/command.go
@@ -18,6 +18,7 @@ package agents
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"slices"
 
@@ -187,6 +188,142 @@ func (a *archiveResolver) Guards(ctx context.Context, cmd ArchiveCommand) error 
 	}
 	if !served {
 		return nil
+	}
+	return refuseStagingElsewhere(rec)
+}
+
+// CreateCommand is one record creation, whichever door asked for it.
+type CreateCommand struct {
+	RecordType string
+	Fields     json.RawMessage
+}
+
+// NewCreateCall binds one create to the resolver that answers for it.
+//
+// Unlike archive's, this resolver holds no dependency and no memo: a create
+// names no ROW — the record does not exist yet — so there is nothing for
+// Guards to read and nothing for Subject to describe beyond the command's own
+// fields. What Guards refuses is settled entirely from createShapes, the same
+// vocabulary createRecord.ServesRecordType already answers from, so this calls
+// that method rather than restating its membership test.
+//
+//nolint:ireturn // the call IS the product: a resolver named concretely here is exactly the thing that must not leave this package
+func NewCreateCall(cmd CreateCommand) GovernedCall {
+	return bind[CreateCommand](createResolver{}, cmd)
+}
+
+type createResolver struct{}
+
+// Subject names the record TYPE the approval binds to — with no id and no
+// pin, because there is no row yet for either to describe. This is the shape
+// a staged create already had before this seam existed (#982); the REST door
+// now stages the identical shape for the same operation.
+func (createResolver) Subject(_ context.Context, cmd CreateCommand) (StageInfo, error) {
+	return StageInfo{
+		TargetType: cmd.RecordType,
+		Summary:    describeGenericWrite("Create", cmd.RecordType, cmd.Fields),
+	}, nil
+}
+
+// Guards refuses, before anything is staged, the two creates that were never
+// going to run: a record type this verb's own write path cannot make at all,
+// and a `fields` payload naming a key that type does not accept.
+//
+// The record type is checked FIRST and by createRecord's own served set, not
+// by rejectUnknownFields — which answers nil for a type it does not know, on
+// the deliberate ground that naming the served vocabulary is the provider's
+// refusal to make. That is right for a call about to reach the provider and
+// wrong for one about to reach a human: create_record{record_type:"custom_field"}
+// would otherwise stage cleanly, because the surface does not enforce schema
+// enums, and the approved retry would then die at the provider with the
+// approval spent.
+//
+// This is right for BOTH doors only because compose's restCommands
+// (agentcommand.go) registers this resolver for a create operation only when
+// its record type is one createRecord actually serves — a type outside that
+// set is created through its own module's handler, never through this verb's
+// write path, so the refusal below would describe a door it was never asked
+// about. That boundary is the REST wiring's to keep, not this resolver's: it
+// has no way to tell which door a given cmd.RecordType arrived from.
+func (createResolver) Guards(_ context.Context, cmd CreateCommand) error {
+	if !(createRecord{}).ServesRecordType(cmd.RecordType) {
+		return &BadArgsError{Cause: fmt.Errorf(
+			"this verb does not create %q records, so no approval of it could ever be carried out", cmd.RecordType)}
+	}
+	return rejectUnknownFields(createShapes, cmd.RecordType, cmd.Fields)
+}
+
+// PatchCommand is one whole-record field patch, whichever door asked for it.
+type PatchCommand struct {
+	RecordType string
+	ID         ids.UUID
+	Fields     json.RawMessage
+	// IfVersion is the caller's own optimistic-concurrency guard. Neither
+	// Guards nor Subject below reads it — the version an approval pins is
+	// taken server-side inside the staging transaction (Subject's own
+	// comment) — it is part of the command because it is part of what the
+	// call ASKED for, the same reason a canonicalized REST body carries it
+	// into the diff_hash the redemption checks.
+	IfVersion *int64
+}
+
+// NewPatchCall binds one patch to the resolver that answers for it, reading
+// through the record seam the patch itself writes through.
+//
+// No memo here, unlike archive's: Subject below reads nothing — its summary
+// names the FIELDS the patch sets, not the record, so there is only ONE
+// caller of a target read (Guards) and nothing for a second reading to race
+// against. A memo earns its keep with a second caller; adding one here ahead
+// of that caller would be exactly the abstraction T3/T8 forbid.
+//
+//nolint:ireturn // the call IS the product: a resolver named concretely here is exactly the thing that must not leave this package
+func NewPatchCall(records datasource.SystemOfRecordProvider, cmd PatchCommand) GovernedCall {
+	return bind[PatchCommand](patchResolver{records: records}, cmd)
+}
+
+type patchResolver struct {
+	records datasource.SystemOfRecordProvider
+}
+
+// Subject names the record TYPE and ID the approval binds to, with no pin:
+// approvals.resolveTargetVersion takes the pin server-side inside the staging
+// transaction, the one place every stager passes through, so a version
+// computed here would be a number nothing reads. The summary names the
+// FIELDS the patch sets rather than the record, matching the shape a staged
+// patch already had before this seam existed (#982) — a record's values are
+// the record, and the staged row carries all of them in proposed_change,
+// which the inbox shows beside this line.
+func (patchResolver) Subject(_ context.Context, cmd PatchCommand) (StageInfo, error) {
+	return StageInfo{
+		TargetType: cmd.RecordType,
+		TargetID:   cmd.ID,
+		Summary:    describeGenericWrite("Update", cmd.RecordType, cmd.Fields),
+	}, nil
+}
+
+// Guards refuses, before anything is staged: a `fields` payload naming a key
+// the record type does not accept, a target the caller cannot see (the read
+// answers the row-scope miss as not-found), and a target whose authority
+// lives in another system of record.
+//
+// Unlike create's, there is no standalone "verb does not serve this type"
+// refusal here — update_record's pre-#982 body never had one, and adding one
+// keyed on the same vocabulary the seam is keyed on would make the
+// servedByTheRecordSeam stand-down below unreachable: a type outside it would
+// already have been refused. The seam stands down instead, exactly as
+// archive's does, for the same reason: five of the twelve patchable types
+// (custom_field, offer, product, saved_view, webhook_subscription) are
+// patched by their own module rather than through this seam.
+func (p patchResolver) Guards(ctx context.Context, cmd PatchCommand) error {
+	if err := rejectUnknownFields(updateShapes, cmd.RecordType, cmd.Fields); err != nil {
+		return err
+	}
+	if !servedByTheRecordSeam(cmd.RecordType) {
+		return nil
+	}
+	rec, err := p.records.Read(ctx, datasource.EntityRef{Type: datasource.EntityType(cmd.RecordType), ID: cmd.ID})
+	if err != nil {
+		return err
 	}
 	return refuseStagingElsewhere(rec)
 }

--- a/backend/internal/modules/agents/command.go
+++ b/backend/internal/modules/agents/command.go
@@ -55,10 +55,14 @@ type GovernedCall interface {
 	Guards(ctx context.Context) error
 }
 
-// Bind pairs one command with the resolver that speaks its language.
+// bind pairs one command with the resolver that speaks its language.
+//
+// Unexported, and reached only through a family's own New…Call constructor
+// below: what leaves this package is a call, never a resolver, so a resolver
+// cannot be built once and reused for a second command.
 //
 //nolint:ireturn // the erasure IS the return type: the bound pair cannot be named without the type parameter the caller has just spent, which is the whole reason a door can carry it
-func Bind[T any](resolver GovernanceResolver[T], cmd T) GovernedCall {
+func bind[T any](resolver GovernanceResolver[T], cmd T) GovernedCall {
 	return boundCommand[T]{resolver: resolver, cmd: cmd}
 }
 
@@ -93,14 +97,20 @@ type ArchiveCommand struct {
 	ID         ids.UUID
 }
 
-// NewArchiveResolver answers both governance questions for an archive, reading
+// NewArchiveCall binds one archive to the resolver that answers for it, reading
 // through the record seam the archive itself writes through.
 //
-// One resolver per call. It remembers the row it read so both questions are
-// answered about the SAME record, which is only true while the resolver is as
-// short-lived as the call it was built for.
-func NewArchiveResolver(records datasource.SystemOfRecordProvider) GovernanceResolver[ArchiveCommand] {
-	return &archiveResolver{records: records}
+// A CALL is what leaves this package, not a resolver, and that is what keeps
+// the memo below safe. The remembered row was read under the calling
+// principal's row scope, and the memo is keyed on the command rather than on
+// who asked — so a resolver hoisted out of one call and reused in another would
+// hand the second caller the first caller's read and skip the visibility check
+// the second was owed. Binding at construction makes that unreachable rather
+// than discouraged.
+//
+//nolint:ireturn // the call IS the product: a resolver named concretely here is exactly the thing that must not leave this package
+func NewArchiveCall(records datasource.SystemOfRecordProvider, cmd ArchiveCommand) GovernedCall {
+	return bind[ArchiveCommand](&archiveResolver{records: records}, cmd)
 }
 
 type archiveResolver struct {
@@ -184,13 +194,20 @@ func (a *archiveResolver) Guards(ctx context.Context, cmd ArchiveCommand) error 
 // servedByTheRecordSeam reports whether the record seam speaks this type at all.
 //
 // Half of the twelve types the REST door can archive — lists, offers, offer
-// templates, products, tags and saved views — have no row on the seam, and are
-// archived by their own module's handler instead. The seam therefore has
-// nothing to say about who may see them or where their authority lives, and
-// asking it would answer "not served here" and turn an ordinary archive into a
-// refusal. It is the archive_record TOOL's schema that is narrow, not the
-// operation, so the vocabulary is read from the seam that defines it rather
-// than restated here.
+// templates, products, tags and saved views — have no row on the seam; they are
+// archived by their own module's handler. Asking the seam about one answers
+// "not served here", which would refuse an ordinary archive, so the guards above
+// stand down for them. It is the archive_record TOOL's schema that is narrow,
+// not the operation, so the vocabulary is read from the seam that defines it
+// rather than restated here.
+//
+// Standing down is a BOUND, not a discharge, and the bound is uneven: three of
+// those six — list, offer and saved_view — carry real row scope in
+// approvals.targetProbes. An agent can still stage an archive of one it cannot
+// see, and the human's yes is then spent on a call the handler answers 404.
+// Closing it needs a visibility question this seam cannot ask through the
+// record provider, which is why it is filed rather than patched here:
+// gradionhq/margince-poc-v1#1021.
 func servedByTheRecordSeam(recordType string) bool {
 	return slices.Contains(datasource.EntityTypes(), datasource.EntityType(recordType))
 }

--- a/backend/internal/modules/agents/command.go
+++ b/backend/internal/modules/agents/command.go
@@ -22,8 +22,10 @@ import (
 	"fmt"
 	"slices"
 
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/mcp"
 )
 
 // GovernanceResolver answers, for one typed command, everything the gate must
@@ -78,6 +80,45 @@ func (b boundCommand[T]) Subject(ctx context.Context) (StageInfo, error) {
 
 func (b boundCommand[T]) Guards(ctx context.Context) error {
 	return b.resolver.Guards(ctx, b.cmd)
+}
+
+// dynamicTierCall is the extra question a call whose tier is decided at
+// INVOCATION must answer: what the tier gate is shown for it.
+//
+// It is deliberately NOT a member of GovernedCall, and not a method boundCommand
+// answers for every T. Sixty-nine operations carry a tier the contract states
+// once; one — the deal move — carries a tier that turns on the record's own
+// state, and a call that cannot answer this must be refused rather than handed
+// an empty input a resolver would read as an answer. Put on the shared bound
+// command, the assertion below would succeed for every call and prove nothing,
+// which is a guard the caller supplies to itself.
+type dynamicTierCall interface {
+	tierInput(ctx context.Context, args json.RawMessage) (mcp.TierResolverInput, error)
+}
+
+// DynamicTierInput asks a bound call what the tier gate should be shown for it.
+//
+// It is how a door with a dynamic-tier operation gets its tier question answered
+// from the SAME command the staging path resolves. The alternative — a second
+// per-operation table mapping a request onto a tier resolver's input — is what
+// this seam exists to remove: two tables keyed by the same operations are free
+// to disagree, and the disagreement that actually happened was a deal move
+// judged by its destination alone on one door and by both endpoints on the
+// other.
+//
+// A call that answers no invocation-time tier is REFUSED here rather than
+// admitted at some default. A caller reaches this only for a spec that declares
+// its tier resolvable at invocation, so a call with no answer means the registry
+// and the command seam disagree at runtime, and there is no honest tier to fall
+// back to.
+func DynamicTierInput(ctx context.Context, call GovernedCall, args json.RawMessage) (mcp.TierResolverInput, error) {
+	dynamic, ok := call.(dynamicTierCall)
+	if !ok {
+		return mcp.TierResolverInput{}, fmt.Errorf(
+			"crmagents: this call resolves no invocation-time tier, so nothing can say whether it needs a "+
+				"human: %w", apperrors.ErrPermissionDenied)
+	}
+	return dynamic.tierInput(ctx, args)
 }
 
 // StageSubject asks a bound call both questions in the order that makes them

--- a/backend/internal/modules/agents/command.go
+++ b/backend/internal/modules/agents/command.go
@@ -56,6 +56,8 @@ type GovernedCall interface {
 }
 
 // Bind pairs one command with the resolver that speaks its language.
+//
+//nolint:ireturn // the erasure IS the return type: the bound pair cannot be named without the type parameter the caller has just spent, which is the whole reason a door can carry it
 func Bind[T any](resolver GovernanceResolver[T], cmd T) GovernedCall {
 	return boundCommand[T]{resolver: resolver, cmd: cmd}
 }
@@ -97,7 +99,9 @@ func NewArchiveResolver(records datasource.SystemOfRecordProvider) GovernanceRes
 	return archiveResolver{records: records}
 }
 
-type archiveResolver struct{ records datasource.SystemOfRecordProvider }
+type archiveResolver struct {
+	records datasource.SystemOfRecordProvider
+}
 
 // Subject names the row the approval binds to.
 //

--- a/backend/internal/modules/agents/command.go
+++ b/backend/internal/modules/agents/command.go
@@ -203,9 +203,7 @@ type CreateCommand struct {
 // Unlike archive's, this resolver holds no dependency and no memo: a create
 // names no ROW — the record does not exist yet — so there is nothing for
 // Guards to read and nothing for Subject to describe beyond the command's own
-// fields. What Guards refuses is settled entirely from createShapes, the same
-// vocabulary createRecord.ServesRecordType already answers from, so this calls
-// that method rather than restating its membership test.
+// fields.
 //
 //nolint:ireturn // the call IS the product: a resolver named concretely here is exactly the thing that must not leave this package
 func NewCreateCall(cmd CreateCommand) GovernedCall {
@@ -225,31 +223,26 @@ func (createResolver) Subject(_ context.Context, cmd CreateCommand) (StageInfo, 
 	}, nil
 }
 
-// Guards refuses, before anything is staged, the two creates that were never
-// going to run: a record type this verb's own write path cannot make at all,
-// and a `fields` payload naming a key that type does not accept.
+// Guards refuses, before anything is staged, a `fields` payload naming a key
+// the record type does not accept. rejectUnknownFields answers nil for a
+// record type it does not know (createShapes), which is deliberately a
+// stand-down and not this resolver's business to override: a type outside
+// createShapes is still a real, working create over REST — its OWN module's
+// handler performs it, entirely independent of create_record's write path —
+// so there is nothing here for a door-agnostic Guards to refuse it FOR.
 //
-// The record type is checked FIRST and by createRecord's own served set, not
-// by rejectUnknownFields — which answers nil for a type it does not know, on
-// the deliberate ground that naming the served vocabulary is the provider's
-// refusal to make. That is right for a call about to reach the provider and
-// wrong for one about to reach a human: create_record{record_type:"custom_field"}
-// would otherwise stage cleanly, because the surface does not enforce schema
-// enums, and the approved retry would then die at the provider with the
-// approval spent.
-//
-// This is right for BOTH doors only because compose's restCommands
-// (agentcommand.go) registers this resolver for a create operation only when
-// its record type is one createRecord actually serves — a type outside that
-// set is created through its own module's handler, never through this verb's
-// write path, so the refusal below would describe a door it was never asked
-// about. That boundary is the REST wiring's to keep, not this resolver's: it
-// has no way to tell which door a given cmd.RecordType arrived from.
+// createRecord.StageInfo (tools.go) refuses such a type BEFORE it ever
+// reaches here, and that is deliberate placement, not an oversight: #982's
+// guarantee — no approval staged for a create that could only ever die at
+// the provider — is true of create_record's OWN Handle, which writes
+// exclusively through datasource.SystemOfRecordProvider.Create and cannot
+// express a type outside createShapes at all. That is a fact about the TOOL
+// door's executor, not about the record type, so it has to be asked at the
+// tool door and cannot be asked here: the same command reaching this
+// resolver from REST names an operation whose OWN handler creates the type
+// fine, and a resolver that cannot tell which door asked has no way to
+// answer "does the executor support this" correctly for both.
 func (createResolver) Guards(_ context.Context, cmd CreateCommand) error {
-	if !(createRecord{}).ServesRecordType(cmd.RecordType) {
-		return &BadArgsError{Cause: fmt.Errorf(
-			"this verb does not create %q records, so no approval of it could ever be carried out", cmd.RecordType)}
-	}
 	return rejectUnknownFields(createShapes, cmd.RecordType, cmd.Fields)
 }
 

--- a/backend/internal/modules/agents/command_createpatch_test.go
+++ b/backend/internal/modules/agents/command_createpatch_test.go
@@ -21,17 +21,49 @@ import (
 	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
 )
 
-// A record type create_record's own write path cannot make at all is refused
-// before anything stages: the approved retry would otherwise die at the
-// provider with the approval spent.
-func TestCreateGuardsRefuseARecordTypeThisVerbDoesNotServe(t *testing.T) {
-	call := NewCreateCall(CreateCommand{RecordType: "custom_field", Fields: json.RawMessage(`{}`)})
+// A record type create_record's own write path cannot make at all still
+// stages through createResolver — unlike patch, create has no target to
+// read, so there is no seam to stand down on, but the same door-agnostic
+// principle holds: whether this VERB can make a custom_field is a fact about
+// create_record's own Handle, not about the operation, and the resolver has
+// no way to tell whether a REST create (whose own module's handler performs
+// it fine) or a raw tool call (which cannot) supplied this command. That
+// question is asked at the door that owns the answer —
+// TestCreateRecordStageInfoRefusesARecordTypeItCannotWrite below, on
+// createRecord.StageInfo itself, before the command is ever built.
+func TestCreateStagesARecordTypeTheResolverHasNoOpinionOn(t *testing.T) {
+	call := NewCreateCall(CreateCommand{RecordType: "custom_field", Fields: json.RawMessage(`{"name":"x"}`)})
 
-	err := call.Guards(context.Background())
+	info, err := StageSubject(context.Background(), call)
+	if err != nil {
+		t.Fatalf("staging a custom_field create through the resolver answered %v, want it staged — "+
+			"createResolver.Guards has no opinion on whether create_record itself can write this type", err)
+	}
+	if info.TargetType != "custom_field" {
+		t.Errorf("staged target_type = %q, want \"custom_field\"", info.TargetType)
+	}
+	if !info.TargetID.IsZero() {
+		t.Errorf("staged target_id = %s, want zero", info.TargetID)
+	}
+}
+
+// createRecord.StageInfo (tools.go) is the ONE door where "does this verb
+// serve this record type" is a real question: create_record's own Handle
+// writes exclusively through datasource.SystemOfRecordProvider.Create, which
+// cannot express a type outside createShapes, so staging one here would mint
+// an approval whose approved retry dies at the provider with the authority
+// already spent. Checked at the door, before the command is even built —
+// createResolver.Guards itself has no such refusal (proved above), because
+// the identical command reaching it from REST names an operation whose own
+// module's handler performs the create fine.
+func TestCreateRecordStageInfoRefusesARecordTypeItCannotWrite(t *testing.T) {
+	tool := createRecord{}
+
+	_, err := tool.StageInfo(context.Background(), json.RawMessage(`{"record_type":"custom_field","fields":{}}`))
 	var badArgs *BadArgsError
 	if !errors.As(err, &badArgs) {
-		t.Fatalf("guarding a record type create_record does not serve answered %v, want a BadArgsError — "+
-			"an approval for it could never be carried out", err)
+		t.Fatalf("staging a create_record call naming a type this verb cannot create answered %v, want a "+
+			"BadArgsError — an approval for it could never be carried out", err)
 	}
 }
 

--- a/backend/internal/modules/agents/command_createpatch_test.go
+++ b/backend/internal/modules/agents/command_createpatch_test.go
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package agents
+
+// The create and patch resolvers are the seam both doors ask, exactly as
+// command_test.go pins the archive resolver's answers. This file pins
+// createResolver's and patchResolver's own: what each refuses, what each
+// stages, and — for patch — what happens when the record seam has never
+// heard of the type.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
+)
+
+// A record type create_record's own write path cannot make at all is refused
+// before anything stages: the approved retry would otherwise die at the
+// provider with the approval spent.
+func TestCreateGuardsRefuseARecordTypeThisVerbDoesNotServe(t *testing.T) {
+	call := NewCreateCall(CreateCommand{RecordType: "custom_field", Fields: json.RawMessage(`{}`)})
+
+	err := call.Guards(context.Background())
+	var badArgs *BadArgsError
+	if !errors.As(err, &badArgs) {
+		t.Fatalf("guarding a record type create_record does not serve answered %v, want a BadArgsError — "+
+			"an approval for it could never be carried out", err)
+	}
+}
+
+// A `fields` key the record type does not accept is refused by name, not
+// silently dropped.
+func TestCreateGuardsRefuseAnUnknownField(t *testing.T) {
+	call := NewCreateCall(CreateCommand{RecordType: "person", Fields: json.RawMessage(`{"nickname":"Bob"}`)})
+
+	err := call.Guards(context.Background())
+	var badArgs *BadArgsError
+	if !errors.As(err, &badArgs) {
+		t.Fatalf("guarding an unknown field answered %v, want a BadArgsError naming it", err)
+	}
+	if !strings.Contains(err.Error(), "nickname") {
+		t.Errorf("refusal %q does not name the offending field", err.Error())
+	}
+}
+
+// A served create stages the record TYPE with no id and no pin: the row does
+// not exist yet, so there is nothing for either to describe.
+func TestCreateStagesAServedTypeWithNoTargetID(t *testing.T) {
+	call := NewCreateCall(CreateCommand{RecordType: "person", Fields: json.RawMessage(`{"full_name":"Ada"}`)})
+
+	info, err := StageSubject(context.Background(), call)
+	if err != nil {
+		t.Fatalf("staging a served create answered %v, want it staged", err)
+	}
+	if info.TargetType != "person" {
+		t.Errorf("staged target_type = %q, want \"person\"", info.TargetType)
+	}
+	if !info.TargetID.IsZero() {
+		t.Errorf("staged target_id = %s, want zero — a create names no existing row an approval could pin",
+			info.TargetID)
+	}
+	if info.TargetVersion != nil {
+		t.Errorf("the resolver supplied target_version %d for a record that does not exist yet", *info.TargetVersion)
+	}
+}
+
+// A `fields` key the record type does not accept is refused before the
+// target is ever read — the same order updateRecord.StageInfo always used.
+func TestPatchGuardsRefuseAnUnknownField(t *testing.T) {
+	call := NewPatchCall(unreadableProvider{}, PatchCommand{
+		RecordType: "person", ID: ids.NewV7(), Fields: json.RawMessage(`{"nickname":"Bob"}`),
+	})
+
+	err := call.Guards(context.Background())
+	var badArgs *BadArgsError
+	if !errors.As(err, &badArgs) {
+		t.Fatalf("guarding an unknown field answered %v, want a BadArgsError naming it", err)
+	}
+	if !strings.Contains(err.Error(), "nickname") {
+		t.Errorf("refusal %q does not name the offending field", err.Error())
+	}
+}
+
+// A target the caller cannot see is refused BEFORE anything is staged, the
+// same row-scope answer archive's own Guards gives.
+func TestPatchGuardsRefuseATargetTheCallerCannotSee(t *testing.T) {
+	call := NewPatchCall(unreadableProvider{}, PatchCommand{
+		RecordType: "person", ID: ids.NewV7(), Fields: json.RawMessage(`{"full_name":"X"}`),
+	})
+
+	if err := call.Guards(context.Background()); !errors.Is(err, apperrors.ErrNotFound) {
+		t.Fatalf("guarding an unreadable person answered %v, want the row-scope miss", err)
+	}
+}
+
+// A target whose authority lives in another system of record can never have
+// an approval released for it.
+func TestPatchGuardsRefuseATargetHeldElsewhere(t *testing.T) {
+	call := NewPatchCall(elsewhereProvider{}, PatchCommand{
+		RecordType: "person", ID: ids.NewV7(), Fields: json.RawMessage(`{"full_name":"X"}`),
+	})
+
+	if err := call.Guards(context.Background()); !errors.Is(err, apperrors.ErrUnsupportedBySoR) {
+		t.Fatalf("guarding a mirrored person answered %v, want the unsupported-by-SoR refusal", err)
+	}
+}
+
+// A served patch stages the record TYPE and ID, and no version pin — the pin
+// is taken server-side inside the staging transaction.
+func TestPatchStagesAServedRecordAndID(t *testing.T) {
+	id := ids.NewV7()
+	provider := stubRecordProvider{rec: stagedRecord(datasource.EntityPerson, id, true)}
+	call := NewPatchCall(provider, PatchCommand{
+		RecordType: "person", ID: id, Fields: json.RawMessage(`{"full_name":"Ada"}`),
+	})
+
+	info, err := StageSubject(context.Background(), call)
+	if err != nil {
+		t.Fatalf("staging a readable patch answered %v, want it staged", err)
+	}
+	if info.TargetType != "person" || info.TargetID != id {
+		t.Errorf("staged target = (%s,%s), want (person,%s)", info.TargetType, info.TargetID, id)
+	}
+	if info.TargetVersion != nil {
+		t.Errorf("the resolver supplied target_version %d — the pin comes from inside the staging transaction",
+			*info.TargetVersion)
+	}
+}
+
+// A patch record type the record seam has never heard of still stages, with
+// its own type and id — patchResolver.Guards has no standalone "verb does not
+// serve" refusal (unlike create's: update_record's pre-#982 body never had
+// one), so the servedByTheRecordSeam short-circuit stands down rather than
+// hard-refusing. Staged against a provider that fails EVERY read, so a
+// resolver that consulted the seam anyway is caught here rather than passing
+// on a lenient stub.
+func TestPatchStagesATypeTheRecordSeamDoesNotServe(t *testing.T) {
+	id := ids.NewV7()
+	call := NewPatchCall(unreadableProvider{}, PatchCommand{
+		RecordType: "webhook_subscription", ID: id, Fields: json.RawMessage(`{"state":"paused"}`),
+	})
+
+	info, err := StageSubject(context.Background(), call)
+	if err != nil {
+		t.Fatalf("staging a webhook_subscription patch answered %v, want it staged — PATCH "+
+			"/v1/webhook-subscriptions/{id} is a governed operation whose target the seam simply does not serve", err)
+	}
+	if info.TargetType != "webhook_subscription" || info.TargetID != id {
+		t.Errorf("staged target = (%s,%s), want (webhook_subscription,%s)",
+			info.TargetType, info.TargetID, id)
+	}
+}
+
+// Guards and Subject must describe the SAME reading of the row: Subject
+// itself reads nothing for a patch (its summary names the fields, not the
+// record — describeGenericWrite, not recordLabel), so the only read a staged
+// patch costs is Guards' own.
+func TestPatchReadsItsTargetOnceAcrossGuardsAndSubject(t *testing.T) {
+	provider := &countingProvider{}
+	call := NewPatchCall(provider, PatchCommand{
+		RecordType: "person", ID: ids.NewV7(), Fields: json.RawMessage(`{"full_name":"X"}`),
+	})
+
+	if _, err := StageSubject(context.Background(), call); err != nil {
+		t.Fatalf("staging a readable patch answered %v, want it staged", err)
+	}
+	if provider.reads != 1 {
+		t.Errorf("the resolver read its target %d times, want 1", provider.reads)
+	}
+}

--- a/backend/internal/modules/agents/command_test.go
+++ b/backend/internal/modules/agents/command_test.go
@@ -28,7 +28,7 @@ import (
 // same row for its label and would refuse this too, so a whole-seam assertion
 // passes whether or not the guard is there at all.
 func TestArchiveGuardsRefuseATargetTheCallerCannotSee(t *testing.T) {
-	call := Bind(NewArchiveResolver(unreadableProvider{}), ArchiveCommand{RecordType: "person", ID: ids.NewV7()})
+	call := NewArchiveCall(unreadableProvider{}, ArchiveCommand{RecordType: "person", ID: ids.NewV7()})
 
 	if err := call.Guards(context.Background()); !errors.Is(err, apperrors.ErrNotFound) {
 		t.Fatalf("guarding an unreadable person answered %v, want the row-scope miss — a staged approval "+
@@ -40,7 +40,7 @@ func TestArchiveGuardsRefuseATargetTheCallerCannotSee(t *testing.T) {
 // reason refuseStagingElsewhere states: the decidability probe and the version
 // pin both read OUR tables, so the approval could never be released.
 func TestArchiveGuardsRefuseATargetHeldElsewhere(t *testing.T) {
-	call := Bind(NewArchiveResolver(elsewhereProvider{}), ArchiveCommand{RecordType: "person", ID: ids.NewV7()})
+	call := NewArchiveCall(elsewhereProvider{}, ArchiveCommand{RecordType: "person", ID: ids.NewV7()})
 
 	if err := call.Guards(context.Background()); !errors.Is(err, apperrors.ErrUnsupportedBySoR) {
 		t.Fatalf("guarding a mirrored person answered %v, want the unsupported-by-SoR refusal", err)
@@ -53,7 +53,7 @@ func TestArchiveGuardsRefuseATargetHeldElsewhere(t *testing.T) {
 func TestArchiveSubjectNamesTheRecordAndSuppliesNoPin(t *testing.T) {
 	id := ids.NewV7()
 	provider := stubRecordProvider{rec: stagedRecord(datasource.EntityPerson, id, true)}
-	call := Bind(NewArchiveResolver(provider), ArchiveCommand{RecordType: "person", ID: id})
+	call := NewArchiveCall(provider, ArchiveCommand{RecordType: "person", ID: id})
 
 	info, err := StageSubject(context.Background(), call)
 	if err != nil {
@@ -84,7 +84,7 @@ func TestArchiveStagesATypeTheRecordSeamDoesNotServe(t *testing.T) {
 	id := ids.NewV7()
 	// A provider that fails every read, so a resolver that consulted the seam
 	// for a tag would be caught here rather than passing on a lenient stub.
-	call := Bind(NewArchiveResolver(unreadableProvider{}), ArchiveCommand{RecordType: "tag", ID: id})
+	call := NewArchiveCall(unreadableProvider{}, ArchiveCommand{RecordType: "tag", ID: id})
 
 	info, err := StageSubject(context.Background(), call)
 	if err != nil {
@@ -123,7 +123,7 @@ func (c *countingProvider) Read(_ context.Context, ref datasource.EntityRef) (da
 // with the authority that admitted it.
 func TestBothGovernanceQuestionsAreAnsweredFromOneRead(t *testing.T) {
 	provider := &countingProvider{}
-	call := Bind(NewArchiveResolver(provider), ArchiveCommand{RecordType: "person", ID: ids.NewV7()})
+	call := NewArchiveCall(provider, ArchiveCommand{RecordType: "person", ID: ids.NewV7()})
 
 	if _, err := StageSubject(context.Background(), call); err != nil {
 		t.Fatalf("staging a readable person answered %v, want it staged", err)
@@ -134,12 +134,15 @@ func TestBothGovernanceQuestionsAreAnsweredFromOneRead(t *testing.T) {
 	}
 }
 
-// A resolver asked about a second target reads THAT target. The memo above is
-// per-call by construction, and this is what makes the claim checkable rather
-// than a promise in a comment.
+// A resolver asked about a second target reads THAT target.
+//
+// Nothing outside this package can reach a resolver — NewArchiveCall binds one
+// to its command and hands back the call — so this reaches past the constructor
+// deliberately: the memo's key is what makes the binding a belt rather than the
+// only thing between two callers and a shared read.
 func TestAResolverAskedAboutASecondTargetReadsIt(t *testing.T) {
 	provider := &countingProvider{}
-	resolver := NewArchiveResolver(provider)
+	resolver := &archiveResolver{records: provider}
 	ctx := context.Background()
 
 	first, err := resolver.Subject(ctx, ArchiveCommand{RecordType: "person", ID: ids.NewV7()})

--- a/backend/internal/modules/agents/command_test.go
+++ b/backend/internal/modules/agents/command_test.go
@@ -22,12 +22,15 @@ import (
 // A target the caller cannot see is refused BEFORE anything is staged. The
 // archive itself would answer the same not-found once released, by which point
 // a human has spent a one-shot authority on a call that was never going to run.
+//
+// Asked of Guards directly rather than through StageSubject: Subject reads the
+// same row for its label and would refuse this too, so a whole-seam assertion
+// passes whether or not the guard is there at all.
 func TestArchiveGuardsRefuseATargetTheCallerCannotSee(t *testing.T) {
-	id := ids.NewV7()
-	call := Bind(NewArchiveResolver(unreadableProvider{}), ArchiveCommand{RecordType: "person", ID: id})
+	call := Bind(NewArchiveResolver(unreadableProvider{}), ArchiveCommand{RecordType: "person", ID: ids.NewV7()})
 
-	if _, err := StageSubject(context.Background(), call); !errors.Is(err, apperrors.ErrNotFound) {
-		t.Fatalf("staging an unreadable person answered %v, want the row-scope miss — a staged approval "+
+	if err := call.Guards(context.Background()); !errors.Is(err, apperrors.ErrNotFound) {
+		t.Fatalf("guarding an unreadable person answered %v, want the row-scope miss — a staged approval "+
 			"for a record the caller cannot see is authority nobody asked for", err)
 	}
 }
@@ -38,8 +41,8 @@ func TestArchiveGuardsRefuseATargetTheCallerCannotSee(t *testing.T) {
 func TestArchiveGuardsRefuseATargetHeldElsewhere(t *testing.T) {
 	call := Bind(NewArchiveResolver(elsewhereProvider{}), ArchiveCommand{RecordType: "person", ID: ids.NewV7()})
 
-	if _, err := StageSubject(context.Background(), call); !errors.Is(err, apperrors.ErrUnsupportedBySoR) {
-		t.Fatalf("staging a mirrored person answered %v, want the unsupported-by-SoR refusal", err)
+	if err := call.Guards(context.Background()); !errors.Is(err, apperrors.ErrUnsupportedBySoR) {
+		t.Fatalf("guarding a mirrored person answered %v, want the unsupported-by-SoR refusal", err)
 	}
 }
 

--- a/backend/internal/modules/agents/command_test.go
+++ b/backend/internal/modules/agents/command_test.go
@@ -10,6 +10,7 @@ package agents
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"strings"
 	"testing"
@@ -93,8 +94,68 @@ func TestArchiveStagesATypeTheRecordSeamDoesNotServe(t *testing.T) {
 	if info.TargetType != "tag" || info.TargetID != id {
 		t.Errorf("staged target = (%s,%s), want (tag,%s)", info.TargetType, info.TargetID, id)
 	}
-	if !strings.Contains(info.Summary, id.String()) {
-		t.Errorf("staged summary %q names neither the type nor the id — it is all the inbox has for a "+
-			"target the seam cannot label", info.Summary)
+	if !strings.Contains(info.Summary, "tag") || !strings.Contains(info.Summary, id.String()) {
+		t.Errorf("staged summary %q must name both the type and the id — together they are all the inbox "+
+			"has for a target the seam cannot label", info.Summary)
+	}
+}
+
+// countingProvider answers every read from the same authoritative record and
+// counts how many times it was asked.
+type countingProvider struct {
+	datasource.SystemOfRecordProvider
+	reads int
+}
+
+func (c *countingProvider) Read(_ context.Context, ref datasource.EntityRef) (datasource.Record, error) {
+	c.reads++
+	return datasource.Record{
+		Ref: ref, Fields: json.RawMessage(`{"name":"Acme"}`), Version: 4,
+		Freshness: datasource.FreshnessInfo{Authoritative: true},
+	}, nil
+}
+
+// Both questions are answered from ONE read of the target.
+//
+// Not an efficiency assertion. Two reads are two rows: the guard would judge
+// the authority of one and the subject would describe the other, and a record
+// archived or re-pointed between them makes the approval a human sees disagree
+// with the authority that admitted it.
+func TestBothGovernanceQuestionsAreAnsweredFromOneRead(t *testing.T) {
+	provider := &countingProvider{}
+	call := Bind(NewArchiveResolver(provider), ArchiveCommand{RecordType: "person", ID: ids.NewV7()})
+
+	if _, err := StageSubject(context.Background(), call); err != nil {
+		t.Fatalf("staging a readable person answered %v, want it staged", err)
+	}
+	if provider.reads != 1 {
+		t.Errorf("the resolver read its target %d times, want 1 — the guard and the subject must describe "+
+			"the same row, not two readings of one id", provider.reads)
+	}
+}
+
+// A resolver asked about a second target reads THAT target. The memo above is
+// per-call by construction, and this is what makes the claim checkable rather
+// than a promise in a comment.
+func TestAResolverAskedAboutASecondTargetReadsIt(t *testing.T) {
+	provider := &countingProvider{}
+	resolver := NewArchiveResolver(provider)
+	ctx := context.Background()
+
+	first, err := resolver.Subject(ctx, ArchiveCommand{RecordType: "person", ID: ids.NewV7()})
+	if err != nil {
+		t.Fatalf("the first subject answered %v", err)
+	}
+	second, err := resolver.Subject(ctx, ArchiveCommand{RecordType: "person", ID: ids.NewV7()})
+	if err != nil {
+		t.Fatalf("the second subject answered %v", err)
+	}
+
+	if provider.reads != 2 {
+		t.Errorf("two targets cost %d reads, want 2 — a remembered row must not answer for a record it "+
+			"was not read for", provider.reads)
+	}
+	if first.TargetID == second.TargetID {
+		t.Error("both subjects named the same target id")
 	}
 }

--- a/backend/internal/modules/agents/command_test.go
+++ b/backend/internal/modules/agents/command_test.go
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package agents
+
+// The archive resolver is the seam both doors ask, so its answers are pinned
+// here rather than through either door: what it refuses, what it names, and
+// what it does when the record seam has never heard of the type — the case
+// only the REST door reaches, because the tool's schema cannot express it.
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
+)
+
+// A target the caller cannot see is refused BEFORE anything is staged. The
+// archive itself would answer the same not-found once released, by which point
+// a human has spent a one-shot authority on a call that was never going to run.
+func TestArchiveGuardsRefuseATargetTheCallerCannotSee(t *testing.T) {
+	id := ids.NewV7()
+	call := Bind(NewArchiveResolver(unreadableProvider{}), ArchiveCommand{RecordType: "person", ID: id})
+
+	if _, err := StageSubject(context.Background(), call); !errors.Is(err, apperrors.ErrNotFound) {
+		t.Fatalf("staging an unreadable person answered %v, want the row-scope miss — a staged approval "+
+			"for a record the caller cannot see is authority nobody asked for", err)
+	}
+}
+
+// A target whose authority lives in another system of record is refused for the
+// reason refuseStagingElsewhere states: the decidability probe and the version
+// pin both read OUR tables, so the approval could never be released.
+func TestArchiveGuardsRefuseATargetHeldElsewhere(t *testing.T) {
+	call := Bind(NewArchiveResolver(elsewhereProvider{}), ArchiveCommand{RecordType: "person", ID: ids.NewV7()})
+
+	if _, err := StageSubject(context.Background(), call); !errors.Is(err, apperrors.ErrUnsupportedBySoR) {
+		t.Fatalf("staging a mirrored person answered %v, want the unsupported-by-SoR refusal", err)
+	}
+}
+
+// The staged subject is the record type and the id, and no version pin: the
+// pin is taken server-side inside the staging transaction, and one supplied
+// here would be discarded.
+func TestArchiveSubjectNamesTheRecordAndSuppliesNoPin(t *testing.T) {
+	id := ids.NewV7()
+	provider := stubRecordProvider{rec: stagedRecord(datasource.EntityPerson, id, true)}
+	call := Bind(NewArchiveResolver(provider), ArchiveCommand{RecordType: "person", ID: id})
+
+	info, err := StageSubject(context.Background(), call)
+	if err != nil {
+		t.Fatalf("staging a readable person answered %v, want it staged", err)
+	}
+	if info.TargetType != "person" || info.TargetID != id {
+		t.Errorf("staged target = (%s,%s), want (person,%s) — the engine cannot pin or scope a target it was not given",
+			info.TargetType, info.TargetID, id)
+	}
+	if info.TargetVersion != nil {
+		t.Errorf("the resolver supplied target_version %d — the pin comes from the row inside the staging "+
+			"transaction, and one passed here is discarded", *info.TargetVersion)
+	}
+	// stagedRecord names itself "Acme"; the human reading the inbox is told
+	// which record disappears, not only which id.
+	if !strings.Contains(info.Summary, "Acme") {
+		t.Errorf("staged summary %q does not name the record — an id alone tells an approver nothing about "+
+			"what they are archiving", info.Summary)
+	}
+}
+
+// A type the record seam has never heard of still stages. Six of the twelve
+// archivable types are archived by their own module rather than through the
+// seam, and the seam's refusals do not describe them — asking it would answer
+// "not served here" and refuse an ordinary archive. The tool's schema is what
+// is narrow, not the operation.
+func TestArchiveStagesATypeTheRecordSeamDoesNotServe(t *testing.T) {
+	id := ids.NewV7()
+	// A provider that fails every read, so a resolver that consulted the seam
+	// for a tag would be caught here rather than passing on a lenient stub.
+	call := Bind(NewArchiveResolver(unreadableProvider{}), ArchiveCommand{RecordType: "tag", ID: id})
+
+	info, err := StageSubject(context.Background(), call)
+	if err != nil {
+		t.Fatalf("staging a tag archive answered %v, want it staged — DELETE /v1/tags/{id} is a governed "+
+			"operation whose target the seam simply does not serve", err)
+	}
+	if info.TargetType != "tag" || info.TargetID != id {
+		t.Errorf("staged target = (%s,%s), want (tag,%s)", info.TargetType, info.TargetID, id)
+	}
+	if !strings.Contains(info.Summary, id.String()) {
+		t.Errorf("staged summary %q names neither the type nor the id — it is all the inbox has for a "+
+			"target the seam cannot label", info.Summary)
+	}
+}

--- a/backend/internal/modules/agents/commandaction.go
+++ b/backend/internal/modules/agents/commandaction.go
@@ -79,7 +79,11 @@ func (r retireCustomFieldResolver) Guards(ctx context.Context, cmd RetireCustomF
 }
 
 // UpdateCustomFieldOptionsCommand is one picklist option-set replacement,
-// whichever door asked for it.
+// whichever door asked for it — the routed custom field id only. It does
+// not carry the replacement options: neither Guards nor Subject reads them
+// (the body travels separately, into diff_hash), the same reason
+// UpdateFactCommand's own doc (commandsidecar.go) gives for dropping the
+// corrected value.
 type UpdateCustomFieldOptionsCommand struct {
 	ID ids.UUID
 }
@@ -115,7 +119,11 @@ func (r updateCustomFieldOptionsResolver) Guards(ctx context.Context, cmd Update
 }
 
 // SetStakeholderCommand is one project-stakeholder attach or re-role,
-// whichever door asked for it.
+// whichever door asked for it — the routed project id only. It does not
+// carry the attached person or role: neither Guards nor Subject reads them
+// (setStakeholderResolver.Subject's own doc says why), the same reason
+// UpdateFactCommand's own doc (commandsidecar.go) gives for dropping a
+// value nothing here reads.
 type SetStakeholderCommand struct {
 	ID ids.UUID
 }
@@ -181,8 +189,9 @@ type removeStakeholderResolver struct {
 }
 
 // Subject names the PROJECT the approval binds to, with the person being
-// detached carried into the summary — two detaches from the same project
-// must not render as the same inbox line.
+// detached carried into the summary: the door-agnostic line
+// GovernedCall.Subject owes this operation, distinct per person, even
+// though no door renders it today (confirmFactResolver's own doc says why).
 func (r removeStakeholderResolver) Subject(_ context.Context, cmd RemoveStakeholderCommand) (StageInfo, error) {
 	return StageInfo{
 		TargetType: projectRecordType,

--- a/backend/internal/modules/agents/commandaction.go
+++ b/backend/internal/modules/agents/commandaction.go
@@ -1,0 +1,308 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package agents
+
+// The remaining four confirm-first commands the tool schema cannot express
+// (gradionhq/margince-poc-v1#928 task 5): retiring a custom field (no body
+// at all), replacing a picklist's option set, and attaching or detaching a
+// project stakeholder. None of them is a whole-record field patch, so none
+// of them belongs in command.go's patchResolver — but two of the four
+// (retire, options) target `custom_field`, a type the record seam has never
+// served (command.go's servedByTheRecordSeam), while the other two target
+// `project`, which it serves like any other record. routedRecordTarget
+// (command.go) carries that distinction for all four rather than each
+// resolver restating it.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
+)
+
+const (
+	// customFieldRecordType names this file's first two commands' fixed
+	// target. It is not a datasource.EntityType — a custom field is
+	// catalog/schema metadata, never a record the seam can point at
+	// (servedByTheRecordSeam stands down for it, same as six of the twelve
+	// archivable types) — so it is spelled as a plain string, the same way
+	// ArchiveCommand/PatchCommand carry a record type the seam may or may not
+	// recognize.
+	customFieldRecordType = "custom_field"
+	// projectRecordType names the fixed target of this file's stakeholder
+	// commands.
+	projectRecordType = string(datasource.EntityProject)
+)
+
+// RetireCustomFieldCommand is one custom-field retirement, whichever door
+// asked for it. It carries no body — CUSTOM-FIELDS-WIRE-4 is a bare status
+// flip, no field beyond the routed id.
+type RetireCustomFieldCommand struct {
+	ID ids.UUID
+}
+
+// NewRetireCustomFieldCall binds one retirement to the resolver that
+// answers for it.
+//
+//nolint:ireturn // the call IS the product: a resolver named concretely here is exactly the thing that must not leave this package
+func NewRetireCustomFieldCall(records datasource.SystemOfRecordProvider, cmd RetireCustomFieldCommand) GovernedCall {
+	return bind[RetireCustomFieldCommand](&retireCustomFieldResolver{
+		target: routedRecordTarget{records: records, recordType: customFieldRecordType},
+	}, cmd)
+}
+
+type retireCustomFieldResolver struct {
+	target routedRecordTarget
+}
+
+// Subject names the custom field by id alone: the seam has no row for it to
+// read a better label from — routedRecordTarget.fetch stands down every
+// time, the same as an archive of the six record-seam-unserved archivable
+// types (command.go) — but answers gracefully rather than assuming that
+// forever, the same shape archiveResolver.Subject gives its own six.
+func (r *retireCustomFieldResolver) Subject(ctx context.Context, cmd RetireCustomFieldCommand) (StageInfo, error) {
+	info := StageInfo{
+		TargetType: customFieldRecordType,
+		TargetID:   cmd.ID,
+		Summary:    fmt.Sprintf("Retire custom field %s", cmd.ID),
+	}
+	rec, served, err := r.target.fetch(ctx, cmd.ID)
+	if err != nil {
+		return StageInfo{}, err
+	}
+	if !served {
+		return info, nil
+	}
+	info.Summary = fmt.Sprintf("Retire custom field %s", recordLabel(rec))
+	return info, nil
+}
+
+// Guards stands down: the record seam has no row for a custom field today,
+// so there is nothing here to read and nothing to refuse — but the check is
+// servedByTheRecordSeam itself, not a hand-restated "custom_field has no
+// row" opinion, so a future seam widening (#1021) is picked up automatically
+// rather than silently left blind.
+func (r *retireCustomFieldResolver) Guards(ctx context.Context, cmd RetireCustomFieldCommand) error {
+	rec, served, err := r.target.fetch(ctx, cmd.ID)
+	if err != nil {
+		return err
+	}
+	if !served {
+		return nil
+	}
+	return refuseStagingElsewhere(rec)
+}
+
+// UpdateCustomFieldOptionsCommand is one picklist option-set replacement,
+// whichever door asked for it.
+type UpdateCustomFieldOptionsCommand struct {
+	ID     ids.UUID
+	Fields json.RawMessage
+}
+
+// NewUpdateCustomFieldOptionsCall binds one option-set replacement to the
+// resolver that answers for it.
+//
+//nolint:ireturn // the call IS the product: a resolver named concretely here is exactly the thing that must not leave this package
+func NewUpdateCustomFieldOptionsCall(records datasource.SystemOfRecordProvider, cmd UpdateCustomFieldOptionsCommand) GovernedCall {
+	return bind[UpdateCustomFieldOptionsCommand](&updateCustomFieldOptionsResolver{
+		target: routedRecordTarget{records: records, recordType: customFieldRecordType},
+	}, cmd)
+}
+
+type updateCustomFieldOptionsResolver struct {
+	target routedRecordTarget
+}
+
+// Subject names the custom field by id, plus the replacement options where
+// the body parses — a picklist's allowed values ARE the effect a human is
+// weighing, not a set of field names to describe generically. Standing down
+// gracefully on `served` for the same not-yet reason retireCustomFieldResolver's
+// own Subject does.
+func (r *updateCustomFieldOptionsResolver) Subject(ctx context.Context, cmd UpdateCustomFieldOptionsCommand) (StageInfo, error) {
+	rec, served, err := r.target.fetch(ctx, cmd.ID)
+	if err != nil {
+		return StageInfo{}, err
+	}
+	label := cmd.ID.String()
+	if served {
+		label = recordLabel(rec)
+	}
+	return StageInfo{
+		TargetType: customFieldRecordType,
+		TargetID:   cmd.ID,
+		Summary:    customFieldOptionsSummary(label, cmd.Fields),
+	}, nil
+}
+
+// customFieldOptionsSummary is the best-effort decode of the options body
+// for the inbox line. Guards never depends on this: an unparseable body
+// still leaves label naming the approval.
+func customFieldOptionsSummary(label string, fields json.RawMessage) string {
+	var body struct {
+		Options []string `json:"options"`
+	}
+	//craft:ignore swallowed-errors best-effort option-list extraction for the summary; an unparseable body still leaves label naming the approval
+	_ = json.Unmarshal(fields, &body)
+	if len(body.Options) == 0 {
+		return fmt.Sprintf("Update options for custom field %s", label)
+	}
+	shown := body.Options
+	suffix := ""
+	if len(shown) > summaryFieldLimit {
+		suffix = fmt.Sprintf(", +%d more", len(shown)-summaryFieldLimit)
+		shown = shown[:summaryFieldLimit]
+	}
+	return fmt.Sprintf("Update options for custom field %s to [%s%s]", label, strings.Join(shown, ", "), suffix)
+}
+
+// Guards stands down, the same as retireCustomFieldResolver's — no row, no
+// refusal, derived from servedByTheRecordSeam rather than restated. It does
+// not validate the option set: whether it is non-empty or applies to a
+// picklist field is the engine's own rule (customfields.Service), re-checked
+// at redemption, and restating it here would drift from it.
+func (r *updateCustomFieldOptionsResolver) Guards(ctx context.Context, cmd UpdateCustomFieldOptionsCommand) error {
+	rec, served, err := r.target.fetch(ctx, cmd.ID)
+	if err != nil {
+		return err
+	}
+	if !served {
+		return nil
+	}
+	return refuseStagingElsewhere(rec)
+}
+
+// SetStakeholderCommand is one project-stakeholder attach or re-role,
+// whichever door asked for it.
+type SetStakeholderCommand struct {
+	ID     ids.UUID
+	Fields json.RawMessage
+}
+
+// NewSetStakeholderCall binds one attach/re-role to the resolver that
+// answers for it, reading through the record seam the project itself
+// writes through.
+//
+//nolint:ireturn // the call IS the product: a resolver named concretely here is exactly the thing that must not leave this package
+func NewSetStakeholderCall(records datasource.SystemOfRecordProvider, cmd SetStakeholderCommand) GovernedCall {
+	return bind[SetStakeholderCommand](&setStakeholderResolver{
+		target: routedRecordTarget{records: records, recordType: projectRecordType},
+	}, cmd)
+}
+
+type setStakeholderResolver struct {
+	target routedRecordTarget
+}
+
+// Subject names the PROJECT the approval binds to — a stakeholder edge has
+// no row of its own on the seam — plus who is being attached and in what
+// role where the body parses.
+func (r *setStakeholderResolver) Subject(ctx context.Context, cmd SetStakeholderCommand) (StageInfo, error) {
+	info := StageInfo{
+		TargetType: projectRecordType,
+		TargetID:   cmd.ID,
+		Summary:    fmt.Sprintf("Set a stakeholder on project %s", cmd.ID),
+	}
+	rec, served, err := r.target.fetch(ctx, cmd.ID)
+	if err != nil {
+		return StageInfo{}, err
+	}
+	label := cmd.ID.String()
+	if served {
+		label = recordLabel(rec)
+	}
+	info.Summary = stakeholderSetSummary(label, cmd.Fields)
+	return info, nil
+}
+
+// stakeholderSetSummary is the best-effort decode of the attach body for the
+// inbox line — which person, in which role. Guards never depends on this.
+func stakeholderSetSummary(projectLabel string, fields json.RawMessage) string {
+	var body struct {
+		PersonID string `json:"person_id"`
+		Role     string `json:"role"`
+	}
+	//craft:ignore swallowed-errors best-effort person/role extraction for the summary; an unparseable body still leaves the project naming the approval
+	_ = json.Unmarshal(fields, &body)
+	if body.PersonID == "" || body.Role == "" {
+		return fmt.Sprintf("Set a stakeholder on project %s", projectLabel)
+	}
+	return fmt.Sprintf("Set project %s stakeholder %s as %s", projectLabel, body.PersonID, body.Role)
+}
+
+// Guards refuses, before anything is staged, a project the caller cannot see
+// or whose authority lives elsewhere — the same two refusals
+// patchResolver.Guards makes for its own target. It does not check whether
+// the named person exists or is already a stakeholder: those reads are the
+// handler's, not this approval's.
+func (r *setStakeholderResolver) Guards(ctx context.Context, cmd SetStakeholderCommand) error {
+	rec, served, err := r.target.fetch(ctx, cmd.ID)
+	if err != nil {
+		return err
+	}
+	if !served {
+		return nil
+	}
+	return refuseStagingElsewhere(rec)
+}
+
+// RemoveStakeholderCommand is one project-stakeholder detach, whichever door
+// asked for it. PersonID is a second PATH parameter, not a body field — the
+// operand this whole task exists to carry.
+type RemoveStakeholderCommand struct {
+	ID       ids.UUID
+	PersonID ids.UUID
+}
+
+// NewRemoveStakeholderCall binds one detach to the resolver that answers
+// for it.
+//
+//nolint:ireturn // the call IS the product: a resolver named concretely here is exactly the thing that must not leave this package
+func NewRemoveStakeholderCall(records datasource.SystemOfRecordProvider, cmd RemoveStakeholderCommand) GovernedCall {
+	return bind[RemoveStakeholderCommand](&removeStakeholderResolver{
+		target: routedRecordTarget{records: records, recordType: projectRecordType},
+	}, cmd)
+}
+
+type removeStakeholderResolver struct {
+	target routedRecordTarget
+}
+
+// Subject names the PROJECT the approval binds to, with the person being
+// detached carried into the summary — two detaches from the same project
+// must not render as the same inbox line.
+func (r *removeStakeholderResolver) Subject(ctx context.Context, cmd RemoveStakeholderCommand) (StageInfo, error) {
+	info := StageInfo{
+		TargetType: projectRecordType,
+		TargetID:   cmd.ID,
+		Summary:    fmt.Sprintf("Remove stakeholder %s from project %s", cmd.PersonID, cmd.ID),
+	}
+	rec, served, err := r.target.fetch(ctx, cmd.ID)
+	if err != nil {
+		return StageInfo{}, err
+	}
+	if !served {
+		return info, nil
+	}
+	info.Summary = fmt.Sprintf("Remove stakeholder %s from project %s", cmd.PersonID, recordLabel(rec))
+	return info, nil
+}
+
+// Guards: the same two refusals as setStakeholderResolver's. It does not
+// check whether PersonID is currently a stakeholder — the edge's own
+// existence is the handler's rule, and this approval binds to the project
+// regardless of whether the edge is still there when it is redeemed.
+func (r *removeStakeholderResolver) Guards(ctx context.Context, cmd RemoveStakeholderCommand) error {
+	rec, served, err := r.target.fetch(ctx, cmd.ID)
+	if err != nil {
+		return err
+	}
+	if !served {
+		return nil
+	}
+	return refuseStagingElsewhere(rec)
+}

--- a/backend/internal/modules/agents/commandaction.go
+++ b/backend/internal/modules/agents/commandaction.go
@@ -16,9 +16,7 @@ package agents
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"strings"
 
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
@@ -50,7 +48,7 @@ type RetireCustomFieldCommand struct {
 //
 //nolint:ireturn // the call IS the product: a resolver named concretely here is exactly the thing that must not leave this package
 func NewRetireCustomFieldCall(records datasource.SystemOfRecordProvider, cmd RetireCustomFieldCommand) GovernedCall {
-	return bind[RetireCustomFieldCommand](&retireCustomFieldResolver{
+	return bind[RetireCustomFieldCommand](retireCustomFieldResolver{
 		target: routedRecordTarget{records: records, recordType: customFieldRecordType},
 	}, cmd)
 }
@@ -59,26 +57,16 @@ type retireCustomFieldResolver struct {
 	target routedRecordTarget
 }
 
-// Subject names the custom field by id alone: the seam has no row for it to
-// read a better label from — routedRecordTarget.fetch stands down every
-// time, the same as an archive of the six record-seam-unserved archivable
-// types (command.go) — but answers gracefully rather than assuming that
-// forever, the same shape archiveResolver.Subject gives its own six.
-func (r *retireCustomFieldResolver) Subject(ctx context.Context, cmd RetireCustomFieldCommand) (StageInfo, error) {
-	info := StageInfo{
+// Subject names the custom field by id — the seam has no row for it to read
+// a better label from (routedRecordTarget.refuse stands down every time),
+// the same as an archive of the six record-seam-unserved archivable types
+// (command.go).
+func (r retireCustomFieldResolver) Subject(_ context.Context, cmd RetireCustomFieldCommand) (StageInfo, error) {
+	return StageInfo{
 		TargetType: customFieldRecordType,
 		TargetID:   cmd.ID,
 		Summary:    fmt.Sprintf("Retire custom field %s", cmd.ID),
-	}
-	rec, served, err := r.target.fetch(ctx, cmd.ID)
-	if err != nil {
-		return StageInfo{}, err
-	}
-	if !served {
-		return info, nil
-	}
-	info.Summary = fmt.Sprintf("Retire custom field %s", recordLabel(rec))
-	return info, nil
+	}, nil
 }
 
 // Guards stands down: the record seam has no row for a custom field today,
@@ -86,22 +74,14 @@ func (r *retireCustomFieldResolver) Subject(ctx context.Context, cmd RetireCusto
 // servedByTheRecordSeam itself, not a hand-restated "custom_field has no
 // row" opinion, so a future seam widening (#1021) is picked up automatically
 // rather than silently left blind.
-func (r *retireCustomFieldResolver) Guards(ctx context.Context, cmd RetireCustomFieldCommand) error {
-	rec, served, err := r.target.fetch(ctx, cmd.ID)
-	if err != nil {
-		return err
-	}
-	if !served {
-		return nil
-	}
-	return refuseStagingElsewhere(rec)
+func (r retireCustomFieldResolver) Guards(ctx context.Context, cmd RetireCustomFieldCommand) error {
+	return r.target.refuse(ctx, cmd.ID)
 }
 
 // UpdateCustomFieldOptionsCommand is one picklist option-set replacement,
 // whichever door asked for it.
 type UpdateCustomFieldOptionsCommand struct {
-	ID     ids.UUID
-	Fields json.RawMessage
+	ID ids.UUID
 }
 
 // NewUpdateCustomFieldOptionsCall binds one option-set replacement to the
@@ -109,7 +89,7 @@ type UpdateCustomFieldOptionsCommand struct {
 //
 //nolint:ireturn // the call IS the product: a resolver named concretely here is exactly the thing that must not leave this package
 func NewUpdateCustomFieldOptionsCall(records datasource.SystemOfRecordProvider, cmd UpdateCustomFieldOptionsCommand) GovernedCall {
-	return bind[UpdateCustomFieldOptionsCommand](&updateCustomFieldOptionsResolver{
+	return bind[UpdateCustomFieldOptionsCommand](updateCustomFieldOptionsResolver{
 		target: routedRecordTarget{records: records, recordType: customFieldRecordType},
 	}, cmd)
 }
@@ -118,69 +98,26 @@ type updateCustomFieldOptionsResolver struct {
 	target routedRecordTarget
 }
 
-// Subject names the custom field by id, plus the replacement options where
-// the body parses — a picklist's allowed values ARE the effect a human is
-// weighing, not a set of field names to describe generically. Standing down
-// gracefully on `served` for the same not-yet reason retireCustomFieldResolver's
-// own Subject does.
-func (r *updateCustomFieldOptionsResolver) Subject(ctx context.Context, cmd UpdateCustomFieldOptionsCommand) (StageInfo, error) {
-	rec, served, err := r.target.fetch(ctx, cmd.ID)
-	if err != nil {
-		return StageInfo{}, err
-	}
-	label := cmd.ID.String()
-	if served {
-		label = recordLabel(rec)
-	}
+// Subject, Guards: the same shape as retireCustomFieldResolver's.
+func (r updateCustomFieldOptionsResolver) Subject(_ context.Context, cmd UpdateCustomFieldOptionsCommand) (StageInfo, error) {
 	return StageInfo{
 		TargetType: customFieldRecordType,
 		TargetID:   cmd.ID,
-		Summary:    customFieldOptionsSummary(label, cmd.Fields),
+		Summary:    fmt.Sprintf("Update options for custom field %s", cmd.ID),
 	}, nil
 }
 
-// customFieldOptionsSummary is the best-effort decode of the options body
-// for the inbox line. Guards never depends on this: an unparseable body
-// still leaves label naming the approval.
-func customFieldOptionsSummary(label string, fields json.RawMessage) string {
-	var body struct {
-		Options []string `json:"options"`
-	}
-	//craft:ignore swallowed-errors best-effort option-list extraction for the summary; an unparseable body still leaves label naming the approval
-	_ = json.Unmarshal(fields, &body)
-	if len(body.Options) == 0 {
-		return fmt.Sprintf("Update options for custom field %s", label)
-	}
-	shown := body.Options
-	suffix := ""
-	if len(shown) > summaryFieldLimit {
-		suffix = fmt.Sprintf(", +%d more", len(shown)-summaryFieldLimit)
-		shown = shown[:summaryFieldLimit]
-	}
-	return fmt.Sprintf("Update options for custom field %s to [%s%s]", label, strings.Join(shown, ", "), suffix)
-}
-
-// Guards stands down, the same as retireCustomFieldResolver's — no row, no
-// refusal, derived from servedByTheRecordSeam rather than restated. It does
-// not validate the option set: whether it is non-empty or applies to a
-// picklist field is the engine's own rule (customfields.Service), re-checked
-// at redemption, and restating it here would drift from it.
-func (r *updateCustomFieldOptionsResolver) Guards(ctx context.Context, cmd UpdateCustomFieldOptionsCommand) error {
-	rec, served, err := r.target.fetch(ctx, cmd.ID)
-	if err != nil {
-		return err
-	}
-	if !served {
-		return nil
-	}
-	return refuseStagingElsewhere(rec)
+// Guards does not validate the option set: whether it is non-empty or
+// applies to a picklist field is the engine's own rule (customfields.Service),
+// re-checked at redemption, and restating it here would drift from it.
+func (r updateCustomFieldOptionsResolver) Guards(ctx context.Context, cmd UpdateCustomFieldOptionsCommand) error {
+	return r.target.refuse(ctx, cmd.ID)
 }
 
 // SetStakeholderCommand is one project-stakeholder attach or re-role,
 // whichever door asked for it.
 type SetStakeholderCommand struct {
-	ID     ids.UUID
-	Fields json.RawMessage
+	ID ids.UUID
 }
 
 // NewSetStakeholderCall binds one attach/re-role to the resolver that
@@ -189,7 +126,7 @@ type SetStakeholderCommand struct {
 //
 //nolint:ireturn // the call IS the product: a resolver named concretely here is exactly the thing that must not leave this package
 func NewSetStakeholderCall(records datasource.SystemOfRecordProvider, cmd SetStakeholderCommand) GovernedCall {
-	return bind[SetStakeholderCommand](&setStakeholderResolver{
+	return bind[SetStakeholderCommand](setStakeholderResolver{
 		target: routedRecordTarget{records: records, recordType: projectRecordType},
 	}, cmd)
 }
@@ -199,39 +136,17 @@ type setStakeholderResolver struct {
 }
 
 // Subject names the PROJECT the approval binds to — a stakeholder edge has
-// no row of its own on the seam — plus who is being attached and in what
-// role where the body parses.
-func (r *setStakeholderResolver) Subject(ctx context.Context, cmd SetStakeholderCommand) (StageInfo, error) {
-	info := StageInfo{
+// no row of its own on the seam. Unlike removeStakeholderResolver's, there
+// is no path operand to carry into the summary: person_id and role arrive in
+// the BODY here, and the body's own fields are what the inbox shows beside
+// this line (proposed_change), the same reasoning patchResolver's own
+// Subject gives for not repeating a patch's values.
+func (r setStakeholderResolver) Subject(_ context.Context, cmd SetStakeholderCommand) (StageInfo, error) {
+	return StageInfo{
 		TargetType: projectRecordType,
 		TargetID:   cmd.ID,
 		Summary:    fmt.Sprintf("Set a stakeholder on project %s", cmd.ID),
-	}
-	rec, served, err := r.target.fetch(ctx, cmd.ID)
-	if err != nil {
-		return StageInfo{}, err
-	}
-	label := cmd.ID.String()
-	if served {
-		label = recordLabel(rec)
-	}
-	info.Summary = stakeholderSetSummary(label, cmd.Fields)
-	return info, nil
-}
-
-// stakeholderSetSummary is the best-effort decode of the attach body for the
-// inbox line — which person, in which role. Guards never depends on this.
-func stakeholderSetSummary(projectLabel string, fields json.RawMessage) string {
-	var body struct {
-		PersonID string `json:"person_id"`
-		Role     string `json:"role"`
-	}
-	//craft:ignore swallowed-errors best-effort person/role extraction for the summary; an unparseable body still leaves the project naming the approval
-	_ = json.Unmarshal(fields, &body)
-	if body.PersonID == "" || body.Role == "" {
-		return fmt.Sprintf("Set a stakeholder on project %s", projectLabel)
-	}
-	return fmt.Sprintf("Set project %s stakeholder %s as %s", projectLabel, body.PersonID, body.Role)
+	}, nil
 }
 
 // Guards refuses, before anything is staged, a project the caller cannot see
@@ -239,15 +154,8 @@ func stakeholderSetSummary(projectLabel string, fields json.RawMessage) string {
 // patchResolver.Guards makes for its own target. It does not check whether
 // the named person exists or is already a stakeholder: those reads are the
 // handler's, not this approval's.
-func (r *setStakeholderResolver) Guards(ctx context.Context, cmd SetStakeholderCommand) error {
-	rec, served, err := r.target.fetch(ctx, cmd.ID)
-	if err != nil {
-		return err
-	}
-	if !served {
-		return nil
-	}
-	return refuseStagingElsewhere(rec)
+func (r setStakeholderResolver) Guards(ctx context.Context, cmd SetStakeholderCommand) error {
+	return r.target.refuse(ctx, cmd.ID)
 }
 
 // RemoveStakeholderCommand is one project-stakeholder detach, whichever door
@@ -263,7 +171,7 @@ type RemoveStakeholderCommand struct {
 //
 //nolint:ireturn // the call IS the product: a resolver named concretely here is exactly the thing that must not leave this package
 func NewRemoveStakeholderCall(records datasource.SystemOfRecordProvider, cmd RemoveStakeholderCommand) GovernedCall {
-	return bind[RemoveStakeholderCommand](&removeStakeholderResolver{
+	return bind[RemoveStakeholderCommand](removeStakeholderResolver{
 		target: routedRecordTarget{records: records, recordType: projectRecordType},
 	}, cmd)
 }
@@ -275,34 +183,18 @@ type removeStakeholderResolver struct {
 // Subject names the PROJECT the approval binds to, with the person being
 // detached carried into the summary — two detaches from the same project
 // must not render as the same inbox line.
-func (r *removeStakeholderResolver) Subject(ctx context.Context, cmd RemoveStakeholderCommand) (StageInfo, error) {
-	info := StageInfo{
+func (r removeStakeholderResolver) Subject(_ context.Context, cmd RemoveStakeholderCommand) (StageInfo, error) {
+	return StageInfo{
 		TargetType: projectRecordType,
 		TargetID:   cmd.ID,
 		Summary:    fmt.Sprintf("Remove stakeholder %s from project %s", cmd.PersonID, cmd.ID),
-	}
-	rec, served, err := r.target.fetch(ctx, cmd.ID)
-	if err != nil {
-		return StageInfo{}, err
-	}
-	if !served {
-		return info, nil
-	}
-	info.Summary = fmt.Sprintf("Remove stakeholder %s from project %s", cmd.PersonID, recordLabel(rec))
-	return info, nil
+	}, nil
 }
 
 // Guards: the same two refusals as setStakeholderResolver's. It does not
 // check whether PersonID is currently a stakeholder — the edge's own
 // existence is the handler's rule, and this approval binds to the project
 // regardless of whether the edge is still there when it is redeemed.
-func (r *removeStakeholderResolver) Guards(ctx context.Context, cmd RemoveStakeholderCommand) error {
-	rec, served, err := r.target.fetch(ctx, cmd.ID)
-	if err != nil {
-		return err
-	}
-	if !served {
-		return nil
-	}
-	return refuseStagingElsewhere(rec)
+func (r removeStakeholderResolver) Guards(ctx context.Context, cmd RemoveStakeholderCommand) error {
+	return r.target.refuse(ctx, cmd.ID)
 }

--- a/backend/internal/modules/agents/commandaction_test.go
+++ b/backend/internal/modules/agents/commandaction_test.go
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package agents
+
+// The remaining four commands' resolvers (commandaction.go): retire and
+// update-options target `custom_field`, a type the record seam has never
+// served, so they stage OUTSIDE it the same way an archive of a
+// record-seam-unserved type does; set/remove stakeholder target `project`,
+// which the seam serves like any other record, so they refuse the same two
+// ways patchResolver's own target does.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
+)
+
+// retire and update-options stage OUTSIDE the record seam — the id alone
+// names the target, the same shape TestArchiveStagesATypeTheRecordSeamDoesNotServe
+// proves for an archive of a record-seam-unserved type. Staged against a
+// provider that fails EVERY read, so a resolver that consulted the seam
+// anyway fails here rather than passing on a lenient stub.
+func TestCustomFieldCommandsStageOutsideTheRecordSeam(t *testing.T) {
+	id := ids.NewV7()
+	cases := []struct {
+		name        string
+		call        GovernedCall
+		wantOperand string
+	}{
+		{"retire", NewRetireCustomFieldCall(unreadableProvider{}, RetireCustomFieldCommand{ID: id}), id.String()},
+		{
+			"update_options",
+			NewUpdateCustomFieldOptionsCall(unreadableProvider{}, UpdateCustomFieldOptionsCommand{ID: id, Fields: json.RawMessage(`{"options":["gold","silver"]}`)}),
+			"gold",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			info, err := StageSubject(context.Background(), c.call)
+			if err != nil {
+				t.Fatalf("staging outside the record seam answered %v, want it staged", err)
+			}
+			if info.TargetType != "custom_field" || info.TargetID != id {
+				t.Errorf("staged target = (%s,%s), want (custom_field,%s)", info.TargetType, info.TargetID, id)
+			}
+			if !strings.Contains(info.Summary, c.wantOperand) {
+				t.Errorf("summary %q does not name %q", info.Summary, c.wantOperand)
+			}
+		})
+	}
+}
+
+// An unparseable or empty options body still leaves the id naming the
+// approval — Guards never depends on the decode, only the summary's
+// richness does.
+func TestUpdateOptionsSummaryFallsBackOnAnUnparseableBody(t *testing.T) {
+	id := ids.NewV7()
+	call := NewUpdateCustomFieldOptionsCall(unreadableProvider{}, UpdateCustomFieldOptionsCommand{ID: id, Fields: json.RawMessage(`not json`)})
+
+	info, err := StageSubject(context.Background(), call)
+	if err != nil {
+		t.Fatalf("staging answered %v, want it staged despite the unparseable body", err)
+	}
+	if !strings.Contains(info.Summary, id.String()) {
+		t.Errorf("summary %q does not fall back to naming the id", info.Summary)
+	}
+}
+
+// setStakeholder and removeStakeholder stage against the PROJECT, naming it
+// in words, with the operand — who is being attached or detached — carried
+// into the summary.
+func TestStakeholderCommandsStageTheProjectWithTheOperandInTheSummary(t *testing.T) {
+	projectID := ids.NewV7()
+	personID := ids.NewV7()
+	provider := stubRecordProvider{rec: stagedRecord(datasource.EntityProject, projectID, true)}
+	cases := []struct {
+		name        string
+		call        GovernedCall
+		wantOperand string
+	}{
+		{
+			"set",
+			NewSetStakeholderCall(provider, SetStakeholderCommand{
+				ID: projectID, Fields: json.RawMessage(`{"person_id":"` + personID.String() + `","role":"champion"}`),
+			}),
+			personID.String(),
+		},
+		{
+			"remove",
+			NewRemoveStakeholderCall(provider, RemoveStakeholderCommand{ID: projectID, PersonID: personID}),
+			personID.String(),
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			info, err := StageSubject(context.Background(), c.call)
+			if err != nil {
+				t.Fatalf("staging answered %v, want it staged", err)
+			}
+			if info.TargetType != "project" || info.TargetID != projectID {
+				t.Errorf("staged target = (%s,%s), want (project,%s)", info.TargetType, info.TargetID, projectID)
+			}
+			if !strings.Contains(info.Summary, c.wantOperand) {
+				t.Errorf("summary %q does not name the person %q — two stakeholder changes on the same "+
+					"project must not render as the same inbox line", info.Summary, c.wantOperand)
+			}
+			if !strings.Contains(info.Summary, "Acme") {
+				t.Errorf("summary %q does not name the project", info.Summary)
+			}
+		})
+	}
+}
+
+// A project the caller cannot see is refused before anything is staged, for
+// both stakeholder commands.
+func TestStakeholderCommandsRefuseAnUnreadableProject(t *testing.T) {
+	id, personID := ids.NewV7(), ids.NewV7()
+	cases := []struct {
+		name string
+		call GovernedCall
+	}{
+		{"set", NewSetStakeholderCall(unreadableProvider{}, SetStakeholderCommand{ID: id, Fields: json.RawMessage(`{"person_id":"x","role":"champion"}`)})},
+		{"remove", NewRemoveStakeholderCall(unreadableProvider{}, RemoveStakeholderCommand{ID: id, PersonID: personID})},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if err := c.call.Guards(context.Background()); !errors.Is(err, apperrors.ErrNotFound) {
+				t.Errorf("guarding an unreadable project answered %v, want the row-scope miss", err)
+			}
+		})
+	}
+}
+
+// A project held in another system of record is refused too.
+func TestStakeholderCommandsRefuseAProjectHeldElsewhere(t *testing.T) {
+	id, personID := ids.NewV7(), ids.NewV7()
+	cases := []struct {
+		name string
+		call GovernedCall
+	}{
+		{"set", NewSetStakeholderCall(elsewhereProvider{}, SetStakeholderCommand{ID: id, Fields: json.RawMessage(`{"person_id":"x","role":"champion"}`)})},
+		{"remove", NewRemoveStakeholderCall(elsewhereProvider{}, RemoveStakeholderCommand{ID: id, PersonID: personID})},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if err := c.call.Guards(context.Background()); !errors.Is(err, apperrors.ErrUnsupportedBySoR) {
+				t.Errorf("guarding a mirrored project answered %v, want the unsupported-by-SoR refusal", err)
+			}
+		})
+	}
+}
+
+// Guards never depends on retire/options' body or on whether the named
+// person is currently a stakeholder — only the routed record's own
+// visibility and system of record. custom_field's Guards is proven to stand
+// down entirely by TestCustomFieldCommandsStageOutsideTheRecordSeam already;
+// this proves retire's bare id (no body at all) hits the same stand-down.
+func TestRetireCustomFieldStagesWithNoBody(t *testing.T) {
+	id := ids.NewV7()
+	info, err := StageSubject(context.Background(), NewRetireCustomFieldCall(unreadableProvider{}, RetireCustomFieldCommand{ID: id}))
+	if err != nil {
+		t.Fatalf("staging a retire answered %v, want it staged", err)
+	}
+	if info.TargetType != "custom_field" || info.TargetID != id {
+		t.Errorf("staged target = (%s,%s), want (custom_field,%s)", info.TargetType, info.TargetID, id)
+	}
+}

--- a/backend/internal/modules/agents/commandaction_test.go
+++ b/backend/internal/modules/agents/commandaction_test.go
@@ -5,14 +5,12 @@ package agents
 
 // The remaining four commands' resolvers (commandaction.go): retire and
 // update-options target `custom_field`, a type the record seam has never
-// served, so they stage OUTSIDE it the same way an archive of a
-// record-seam-unserved type does; set/remove stakeholder target `project`,
-// which the seam serves like any other record, so they refuse the same two
-// ways patchResolver's own target does.
+// served, so their Guards always stands down; set/remove stakeholder target
+// `project`, which the seam serves like any other record, so they refuse
+// the same two ways patchResolver's own target does.
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"strings"
 	"testing"
@@ -24,22 +22,17 @@ import (
 
 // retire and update-options stage OUTSIDE the record seam — the id alone
 // names the target, the same shape TestArchiveStagesATypeTheRecordSeamDoesNotServe
-// proves for an archive of a record-seam-unserved type. Staged against a
-// provider that fails EVERY read, so a resolver that consulted the seam
-// anyway fails here rather than passing on a lenient stub.
-func TestCustomFieldCommandsStageOutsideTheRecordSeam(t *testing.T) {
+// proves for an archive of a record-seam-unserved type. Guards is asked
+// against a provider that fails EVERY read, so a resolver that consulted the
+// seam anyway fails here rather than passing on a lenient stub.
+func TestCustomFieldCommandsStageAndAdmitOutsideTheRecordSeam(t *testing.T) {
 	id := ids.NewV7()
 	cases := []struct {
-		name        string
-		call        GovernedCall
-		wantOperand string
+		name string
+		call GovernedCall
 	}{
-		{"retire", NewRetireCustomFieldCall(unreadableProvider{}, RetireCustomFieldCommand{ID: id}), id.String()},
-		{
-			"update_options",
-			NewUpdateCustomFieldOptionsCall(unreadableProvider{}, UpdateCustomFieldOptionsCommand{ID: id, Fields: json.RawMessage(`{"options":["gold","silver"]}`)}),
-			"gold",
-		},
+		{"retire", NewRetireCustomFieldCall(unreadableProvider{}, RetireCustomFieldCommand{ID: id})},
+		{"update_options", NewUpdateCustomFieldOptionsCall(unreadableProvider{}, UpdateCustomFieldOptionsCommand{ID: id})},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -50,71 +43,44 @@ func TestCustomFieldCommandsStageOutsideTheRecordSeam(t *testing.T) {
 			if info.TargetType != "custom_field" || info.TargetID != id {
 				t.Errorf("staged target = (%s,%s), want (custom_field,%s)", info.TargetType, info.TargetID, id)
 			}
-			if !strings.Contains(info.Summary, c.wantOperand) {
-				t.Errorf("summary %q does not name %q", info.Summary, c.wantOperand)
+			if !strings.Contains(info.Summary, id.String()) {
+				t.Errorf("summary %q does not name the id — the seam has no better label to give it", info.Summary)
 			}
 		})
 	}
 }
 
-// An unparseable or empty options body still leaves the id naming the
-// approval — Guards never depends on the decode, only the summary's
-// richness does.
-func TestUpdateOptionsSummaryFallsBackOnAnUnparseableBody(t *testing.T) {
-	id := ids.NewV7()
-	call := NewUpdateCustomFieldOptionsCall(unreadableProvider{}, UpdateCustomFieldOptionsCommand{ID: id, Fields: json.RawMessage(`not json`)})
-
-	info, err := StageSubject(context.Background(), call)
-	if err != nil {
-		t.Fatalf("staging answered %v, want it staged despite the unparseable body", err)
-	}
-	if !strings.Contains(info.Summary, id.String()) {
-		t.Errorf("summary %q does not fall back to naming the id", info.Summary)
-	}
-}
-
-// setStakeholder and removeStakeholder stage against the PROJECT, naming it
-// in words, with the operand — who is being attached or detached — carried
-// into the summary.
-func TestStakeholderCommandsStageTheProjectWithTheOperandInTheSummary(t *testing.T) {
+// setStakeholder and removeStakeholder stage against the PROJECT. Only
+// removeStakeholder carries a path operand (PersonID) into the summary —
+// setStakeholder's person/role arrive in the body, which the inbox shows
+// beside the summary line (proposed_change), the same reasoning patchResolver
+// gives for not repeating a patch's values.
+func TestStakeholderCommandsStageTheProject(t *testing.T) {
 	projectID := ids.NewV7()
 	personID := ids.NewV7()
+	// project IS served (unlike custom_field), so staging it needs a readable
+	// provider — an unreadable one would fail at Guards before Subject ever ran.
 	provider := stubRecordProvider{rec: stagedRecord(datasource.EntityProject, projectID, true)}
-	cases := []struct {
-		name        string
-		call        GovernedCall
-		wantOperand string
-	}{
-		{
-			"set",
-			NewSetStakeholderCall(provider, SetStakeholderCommand{
-				ID: projectID, Fields: json.RawMessage(`{"person_id":"` + personID.String() + `","role":"champion"}`),
-			}),
-			personID.String(),
-		},
-		{
-			"remove",
-			NewRemoveStakeholderCall(provider, RemoveStakeholderCommand{ID: projectID, PersonID: personID}),
-			personID.String(),
-		},
+
+	setInfo, err := StageSubject(context.Background(), NewSetStakeholderCall(provider, SetStakeholderCommand{ID: projectID}))
+	if err != nil {
+		t.Fatalf("staging a set-stakeholder answered %v, want it staged", err)
 	}
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			info, err := StageSubject(context.Background(), c.call)
-			if err != nil {
-				t.Fatalf("staging answered %v, want it staged", err)
-			}
-			if info.TargetType != "project" || info.TargetID != projectID {
-				t.Errorf("staged target = (%s,%s), want (project,%s)", info.TargetType, info.TargetID, projectID)
-			}
-			if !strings.Contains(info.Summary, c.wantOperand) {
-				t.Errorf("summary %q does not name the person %q — two stakeholder changes on the same "+
-					"project must not render as the same inbox line", info.Summary, c.wantOperand)
-			}
-			if !strings.Contains(info.Summary, "Acme") {
-				t.Errorf("summary %q does not name the project", info.Summary)
-			}
-		})
+	if setInfo.TargetType != "project" || setInfo.TargetID != projectID {
+		t.Errorf("staged target = (%s,%s), want (project,%s)", setInfo.TargetType, setInfo.TargetID, projectID)
+	}
+
+	removeInfo, err := StageSubject(context.Background(),
+		NewRemoveStakeholderCall(provider, RemoveStakeholderCommand{ID: projectID, PersonID: personID}))
+	if err != nil {
+		t.Fatalf("staging a remove-stakeholder answered %v, want it staged", err)
+	}
+	if removeInfo.TargetType != "project" || removeInfo.TargetID != projectID {
+		t.Errorf("staged target = (%s,%s), want (project,%s)", removeInfo.TargetType, removeInfo.TargetID, projectID)
+	}
+	if !strings.Contains(removeInfo.Summary, personID.String()) {
+		t.Errorf("remove-stakeholder summary %q does not name the person being detached — two detaches from "+
+			"the same project must not render as the same inbox line", removeInfo.Summary)
 	}
 }
 
@@ -126,7 +92,7 @@ func TestStakeholderCommandsRefuseAnUnreadableProject(t *testing.T) {
 		name string
 		call GovernedCall
 	}{
-		{"set", NewSetStakeholderCall(unreadableProvider{}, SetStakeholderCommand{ID: id, Fields: json.RawMessage(`{"person_id":"x","role":"champion"}`)})},
+		{"set", NewSetStakeholderCall(unreadableProvider{}, SetStakeholderCommand{ID: id})},
 		{"remove", NewRemoveStakeholderCall(unreadableProvider{}, RemoveStakeholderCommand{ID: id, PersonID: personID})},
 	}
 	for _, c := range cases {
@@ -145,7 +111,7 @@ func TestStakeholderCommandsRefuseAProjectHeldElsewhere(t *testing.T) {
 		name string
 		call GovernedCall
 	}{
-		{"set", NewSetStakeholderCall(elsewhereProvider{}, SetStakeholderCommand{ID: id, Fields: json.RawMessage(`{"person_id":"x","role":"champion"}`)})},
+		{"set", NewSetStakeholderCall(elsewhereProvider{}, SetStakeholderCommand{ID: id})},
 		{"remove", NewRemoveStakeholderCall(elsewhereProvider{}, RemoveStakeholderCommand{ID: id, PersonID: personID})},
 	}
 	for _, c := range cases {
@@ -157,18 +123,14 @@ func TestStakeholderCommandsRefuseAProjectHeldElsewhere(t *testing.T) {
 	}
 }
 
-// Guards never depends on retire/options' body or on whether the named
-// person is currently a stakeholder — only the routed record's own
-// visibility and system of record. custom_field's Guards is proven to stand
-// down entirely by TestCustomFieldCommandsStageOutsideTheRecordSeam already;
-// this proves retire's bare id (no body at all) hits the same stand-down.
-func TestRetireCustomFieldStagesWithNoBody(t *testing.T) {
-	id := ids.NewV7()
-	info, err := StageSubject(context.Background(), NewRetireCustomFieldCall(unreadableProvider{}, RetireCustomFieldCommand{ID: id}))
-	if err != nil {
-		t.Fatalf("staging a retire answered %v, want it staged", err)
+// A served, readable project is admitted rather than refused.
+func TestStakeholderCommandsAdmitAReadableProject(t *testing.T) {
+	id, personID := ids.NewV7(), ids.NewV7()
+	provider := stubRecordProvider{rec: stagedRecord(datasource.EntityProject, id, true)}
+	if err := NewSetStakeholderCall(provider, SetStakeholderCommand{ID: id}).Guards(context.Background()); err != nil {
+		t.Fatalf("guarding a readable, authoritative project (set) answered %v, want it admitted", err)
 	}
-	if info.TargetType != "custom_field" || info.TargetID != id {
-		t.Errorf("staged target = (%s,%s), want (custom_field,%s)", info.TargetType, info.TargetID, id)
+	if err := NewRemoveStakeholderCall(provider, RemoveStakeholderCommand{ID: id, PersonID: personID}).Guards(context.Background()); err != nil {
+		t.Fatalf("guarding a readable, authoritative project (remove) answered %v, want it admitted", err)
 	}
 }

--- a/backend/internal/modules/agents/commandaction_test.go
+++ b/backend/internal/modules/agents/commandaction_test.go
@@ -79,8 +79,8 @@ func TestStakeholderCommandsStageTheProject(t *testing.T) {
 		t.Errorf("staged target = (%s,%s), want (project,%s)", removeInfo.TargetType, removeInfo.TargetID, projectID)
 	}
 	if !strings.Contains(removeInfo.Summary, personID.String()) {
-		t.Errorf("remove-stakeholder summary %q does not name the person being detached — two detaches from "+
-			"the same project must not render as the same inbox line", removeInfo.Summary)
+		t.Errorf("remove-stakeholder summary %q does not name the person being detached — Subject owes a "+
+			"line distinct per person even though no door renders it today", removeInfo.Summary)
 	}
 }
 

--- a/backend/internal/modules/agents/commandauto.go
+++ b/backend/internal/modules/agents/commandauto.go
@@ -1,0 +1,214 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package agents
+
+// The four auto-execute commands (gradionhq/margince-poc-v1#928 task 7):
+// logging an activity, drafting a reply, re-associating an activity, and
+// running a report. All four are 🟢 today, so nothing stages them and neither
+// question below is reached on today's tiers — the same standing the seven
+// nested commands (commandnested.go) have.
+//
+// They are registered anyway, for that file's reason: a route with no command
+// of its own falls back to stagedTargetByRoute's GUESS the moment a tier floor
+// (#982) tightens it, and the guess is only ever as good as the route's shape.
+// It happens to be right for three of these and empty for the fourth
+// (runReport's route carries a `{report}` key, not an `{id}`), which is
+// exactly the kind of accident this seam replaces with an answer the operation
+// states itself.
+//
+// What does NOT happen here is the other half of the seam. Their TOOLS gain no
+// StageInfo: a 🟢 tool has no staging path to move a guard off, so there is no
+// second answer for the resolver to displace — and giving one a StageInfo
+// would change what Registry.Stageable reports about the verb, which is what
+// the contract's per-record-type tier floor consults before it may tighten it.
+// That is a tiering decision, not a seam one, and it is not this task's to
+// take.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
+)
+
+// LogActivityCommand is one logged activity, whichever door asked for it. The
+// body IS the activity's fields — the route names no record, because the
+// activity does not exist yet.
+type LogActivityCommand struct {
+	Fields json.RawMessage
+}
+
+// NewLogActivityCall binds one logged activity to the resolver that answers
+// for it. Like createResolver's, it holds no dependency: a create names no ROW,
+// so there is nothing for Guards to read and nothing for Subject to describe
+// beyond the command's own fields.
+//
+//nolint:ireturn // the call IS the product: a resolver named concretely here is exactly the thing that must not leave this package
+func NewLogActivityCall(cmd LogActivityCommand) GovernedCall {
+	return bind[LogActivityCommand](logActivityResolver{}, cmd)
+}
+
+type logActivityResolver struct{}
+
+// Subject names the record TYPE with no id and no pin — the shape every create
+// stages (createResolver, command.go), because there is no row yet for either
+// to describe.
+func (logActivityResolver) Subject(_ context.Context, cmd LogActivityCommand) (StageInfo, error) {
+	return StageInfo{
+		TargetType: string(datasource.EntityActivity),
+		Summary:    describeGenericWrite("Log", string(datasource.EntityActivity), cmd.Fields),
+	}, nil
+}
+
+// Guards stands down. It does not validate the fields against a shape the way
+// createResolver.Guards does: log_activity's body IS crm.yaml's
+// CreateActivityRequest, which the provider re-validates strictly at execution,
+// and this verb never went through createShapes at either door — restating that
+// vocabulary here would be a second, drifting answer to a question the store
+// already answers.
+func (logActivityResolver) Guards(_ context.Context, _ LogActivityCommand) error {
+	return nil
+}
+
+// DraftEmailCommand is one drafted reply, whichever door asked for it — the
+// routed activity is the thread being answered. It does not carry the intent:
+// neither question below reads it.
+type DraftEmailCommand struct {
+	ActivityID ids.UUID
+}
+
+// NewDraftEmailCall binds one draft to the resolver that answers for it,
+// reading the anchor through the record seam.
+//
+//nolint:ireturn // the call IS the product: a resolver named concretely here is exactly the thing that must not leave this package
+func NewDraftEmailCall(records datasource.SystemOfRecordProvider, cmd DraftEmailCommand) GovernedCall {
+	return bind[DraftEmailCommand](&draftEmailResolver{
+		anchor: anchoredRecord{records: records, entityType: datasource.EntityActivity},
+	}, cmd)
+}
+
+type draftEmailResolver struct {
+	anchor anchoredRecord
+}
+
+// Subject names the ANCHOR the draft answers, and pins its version: a draft is
+// composed FROM that thread's content, so an approval given for drafting
+// against the thread as it stands should not survive the thread changing.
+func (r *draftEmailResolver) Subject(ctx context.Context, cmd DraftEmailCommand) (StageInfo, error) {
+	rec, err := r.anchor.row(ctx, cmd.ActivityID)
+	if err != nil {
+		return StageInfo{}, err
+	}
+	return StageInfo{
+		TargetType:    string(datasource.EntityActivity),
+		TargetID:      cmd.ActivityID,
+		TargetVersion: &rec.Version,
+		Summary:       fmt.Sprintf("Draft a reply to activity %s", cmd.ActivityID),
+	}, nil
+}
+
+// Guards refuses an anchor the caller cannot see or whose authority lives
+// elsewhere — the same two refusals patchResolver.Guards makes for its own
+// target.
+func (r *draftEmailResolver) Guards(ctx context.Context, cmd DraftEmailCommand) error {
+	return r.anchor.refuse(ctx, cmd.ActivityID)
+}
+
+// RelinkActivityCommand is one activity re-association, whichever door asked
+// for it: the routed activity and the record it is being linked to. It does
+// not carry replace_existing_of_type — whether the link moves or is added
+// alongside is the executor's business, and neither question below reads it.
+type RelinkActivityCommand struct {
+	ActivityID ids.UUID
+	EntityType string
+	EntityID   ids.UUID
+}
+
+// NewRelinkActivityCall binds one re-association to the resolver that answers
+// for it.
+//
+//nolint:ireturn // the call IS the product: a resolver named concretely here is exactly the thing that must not leave this package
+func NewRelinkActivityCall(records datasource.SystemOfRecordProvider, cmd RelinkActivityCommand) GovernedCall {
+	return bind[RelinkActivityCommand](&relinkActivityResolver{
+		activity: anchoredRecord{records: records, entityType: datasource.EntityActivity},
+	}, cmd)
+}
+
+type relinkActivityResolver struct {
+	activity anchoredRecord
+}
+
+// Subject names the ACTIVITY the approval binds to — the row that changes —
+// and pins its version, with the destination carried into the summary: moving
+// a captured email onto THIS deal and onto that one are different decisions
+// wearing one shape.
+func (r *relinkActivityResolver) Subject(ctx context.Context, cmd RelinkActivityCommand) (StageInfo, error) {
+	rec, err := r.activity.row(ctx, cmd.ActivityID)
+	if err != nil {
+		return StageInfo{}, err
+	}
+	return StageInfo{
+		TargetType:    string(datasource.EntityActivity),
+		TargetID:      cmd.ActivityID,
+		TargetVersion: &rec.Version,
+		Summary: fmt.Sprintf("Re-associate activity %s to %s %s",
+			cmd.ActivityID, cmd.EntityType, cmd.EntityID),
+	}, nil
+}
+
+// Guards refuses a destination type that is not a link target — the same
+// vocabulary the store refuses on, asked before a human is — and then the
+// activity itself, the same two ways patchResolver.Guards refuses its own
+// target.
+//
+// It does not read the DESTINATION record. The store refuses one the caller
+// cannot see, at execution, and closing that here would mean a second read
+// against a type this resolver is not built around; it is the same bound
+// readStageableLinks closes for the verbs that NAME their records, and this
+// one is filed rather than implied away: gradionhq/margince-poc-v1#1021 is
+// where a target's visibility question gets its home.
+func (r *relinkActivityResolver) Guards(ctx context.Context, cmd RelinkActivityCommand) error {
+	if !relinkTargets[cmd.EntityType] {
+		return &BadArgsError{Cause: fmt.Errorf("entity_type %q is not a link target", cmd.EntityType)}
+	}
+	return r.activity.refuse(ctx, cmd.ActivityID)
+}
+
+// RunReportCommand is one report run, whichever door asked for it. The report
+// KEY is the whole of it: the plan arguments narrow what is counted, and the
+// engine — not this seam — owns which of them a report accepts.
+type RunReportCommand struct {
+	Report string
+}
+
+// NewRunReportCall binds one report run to the resolver that answers for it.
+// It holds no dependency: a report names no record at all.
+//
+//nolint:ireturn // the call IS the product: a resolver named concretely here is exactly the thing that must not leave this package
+func NewRunReportCall(cmd RunReportCommand) GovernedCall {
+	return bind[RunReportCommand](runReportResolver{}, cmd)
+}
+
+type runReportResolver struct{}
+
+// Subject names NO record, and that is the honest answer rather than a gap: a
+// report is an aggregate over rows the caller's own scope already bounds, so
+// there is no row an approval could bind to, pin, or be probed against. What
+// it does supply is the KEY — the one thing that says which aggregate is being
+// released — where the route walk it replaces could only offer an empty target
+// with no name attached.
+func (runReportResolver) Subject(_ context.Context, cmd RunReportCommand) (StageInfo, error) {
+	return StageInfo{Summary: fmt.Sprintf("Run report %s", cmd.Report)}, nil
+}
+
+// Guards stands down: the report key's vocabulary is the engine's catalog,
+// which this module is handed rather than owns (ReportRunner, tools_report.go),
+// and a key outside it is refused by the engine at execution with the catalog
+// in hand. Restating it here would be a second answer that drifts the moment an
+// installation's catalog does.
+func (runReportResolver) Guards(_ context.Context, _ RunReportCommand) error {
+	return nil
+}

--- a/backend/internal/modules/agents/commandauto.go
+++ b/backend/internal/modules/agents/commandauto.go
@@ -9,13 +9,12 @@ package agents
 // question below is reached on today's tiers — the same standing the seven
 // nested commands (commandnested.go) have.
 //
-// They are registered anyway, for that file's reason: a route with no command
-// of its own falls back to stagedTargetByRoute's GUESS the moment a tier floor
-// (#982) tightens it, and the guess is only ever as good as the route's shape.
-// It happens to be right for three of these and empty for the fourth
-// (runReport's route carries a `{report}` key, not an `{id}`), which is
-// exactly the kind of accident this seam replaces with an answer the operation
-// states itself.
+// They are registered anyway, for that file's reason: a tier floor (#982)
+// tightening one makes this the answer a human decides from, and the only
+// alternative a route can offer is its own shape. That shape happens to name
+// the right record for three of these and nothing at all for the fourth
+// (runReport's route carries a `{report}` key, not an `{id}`) — the kind of
+// accident this seam replaces with an answer the operation states itself.
 //
 // What does NOT happen here is the other half of the seam. Their TOOLS gain no
 // StageInfo: a 🟢 tool has no staging path to move a guard off, so there is no

--- a/backend/internal/modules/agents/commandauto.go
+++ b/backend/internal/modules/agents/commandauto.go
@@ -171,10 +171,24 @@ func (r *relinkActivityResolver) Subject(ctx context.Context, cmd RelinkActivity
 // one is filed rather than implied away: gradionhq/margince-poc-v1#1021 is
 // where a target's visibility question gets its home.
 func (r *relinkActivityResolver) Guards(ctx context.Context, cmd RelinkActivityCommand) error {
-	if !relinkTargets[cmd.EntityType] {
-		return &BadArgsError{Cause: fmt.Errorf("entity_type %q is not a link target", cmd.EntityType)}
+	if err := requireLinkTarget(cmd.EntityType); err != nil {
+		return err
 	}
 	return r.activity.refuse(ctx, cmd.ActivityID)
+}
+
+// requireLinkTarget admits the record type an activity may be re-associated to.
+//
+// One function for both doors — predicate and sentence together: the staging
+// path asks it through Guards above and the execution path through
+// relinkActivity.Handle, which an approved retry would re-enter without passing
+// Guards. Two copies of the membership test is how the two doors come to
+// disagree about what a link target is.
+func requireLinkTarget(entityType string) error {
+	if relinkTargets[entityType] {
+		return nil
+	}
+	return &BadArgsError{Cause: fmt.Errorf("entity_type %q is not a link target", entityType)}
 }
 
 // RunReportCommand is one report run, whichever door asked for it. The report

--- a/backend/internal/modules/agents/commandcomms.go
+++ b/backend/internal/modules/agents/commandcomms.go
@@ -1,0 +1,217 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package agents
+
+// The two anchored sends: a mail reply and a channel reply
+// (gradionhq/margince-poc-v1#928 task 7). Both answer a conversation that
+// already exists, so both name an ANCHOR activity — the row the effect hangs
+// off, whose version the approval pins and whose authority decides whether an
+// approval could ever be released at all.
+//
+// These are the first commands BOTH doors reach for the same operation: the
+// tool decodes send_email/send_message arguments into them, and the REST door
+// decodes POST /v1/activities/{id}/send-email and .../send-message into the
+// same commands. Every refusal below therefore stops being a rule the tool door
+// makes and the REST door skips, which is what #928 is about.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
+)
+
+// ChannelKinds answers whether an activity kind is a messaging-channel
+// conversation a reply may transmit through.
+//
+// It is the Comms seam's own question narrowed to the one method this
+// resolver needs (Comms embeds it below), because the REST door reaches the
+// resolver without the send machinery around it: that door has no reason to
+// hold a seam that can send mail, book meetings and read calendars in order to
+// ask whether an anchor is a channel. The answer itself is
+// activities.IsChannelKind either way — the same test the store's own
+// SendMessage refuses on — so the two doors cannot come to disagree about a
+// kind.
+type ChannelKinds interface {
+	IsChannelKind(kind string) bool
+}
+
+// SendEmailCommand is one mail reply, whichever door asked for it.
+//
+// It carries the addressees and the subject because both questions below read
+// them: Guards refuses a send with no addressee, and Subject names every
+// recipient in the line a human approves. It carries neither the BODY nor the
+// consent purpose — nothing here reads either (the body travels inside the
+// staged arguments, covered by the diff_hash, and the consent verdict is the
+// gate's own read at execution) — the same call UpdateFactCommand's own doc
+// (commandsidecar.go) makes for dropping a value with no reader.
+type SendEmailCommand struct {
+	ActivityID ids.UUID
+	To         []string
+	Cc         []string
+	Subject    string
+}
+
+// NewSendEmailCall binds one mail reply to the resolver that answers for it,
+// reading the anchor through the record seam.
+//
+//nolint:ireturn // the call IS the product: a resolver named concretely here is exactly the thing that must not leave this package
+func NewSendEmailCall(records datasource.SystemOfRecordProvider, cmd SendEmailCommand) GovernedCall {
+	return bind[SendEmailCommand](&sendEmailResolver{
+		anchor: anchoredRecord{records: records, entityType: datasource.EntityActivity},
+	}, cmd)
+}
+
+type sendEmailResolver struct {
+	anchor anchoredRecord
+}
+
+// Subject names the ANCHOR the approval binds to: the thread being replied to
+// is the row the effect hangs off, so it is what the redemption version pin
+// re-checks.
+//
+// The summary names every addressee, cc included. A human approving from the
+// inbox row reads only this line, so an unnamed recipient is a recipient
+// nobody agreed to — and the diff_hash binds cc faithfully either way, which
+// is precisely what makes omitting it from the display a problem rather than a
+// harmless abbreviation.
+func (r *sendEmailResolver) Subject(ctx context.Context, cmd SendEmailCommand) (StageInfo, error) {
+	rec, err := r.anchor.row(ctx, cmd.ActivityID)
+	if err != nil {
+		return StageInfo{}, err
+	}
+	return StageInfo{
+		TargetType:    string(datasource.EntityActivity),
+		TargetID:      cmd.ActivityID,
+		TargetVersion: &rec.Version,
+		Summary:       describeSend(cmd),
+	}, nil
+}
+
+// Guards refuses, before anything is staged, a send that reaches nobody, and an
+// anchor the caller cannot see or whose authority lives in another system of
+// record. Reaching any of those refusals from the executor instead would cost
+// the human's one-shot approval on the way past: staging mints an approval, a
+// human reads a send with no addressee and says yes, the approved retry
+// consumes that authority, and only THEN does the store refuse.
+//
+// The addressee check runs before the read for the same reason the read is
+// worth avoiding: a call this malformed names no correspondent, and answering
+// it costs a round trip through the record seam to say so.
+//
+// What this does not pre-empt, so neither reads as covered: the consent gate's
+// per-purpose verdict, the workspace's mailbox send capability, and whether an
+// address is syntactically deliverable. All are refusals a human's yes cannot
+// fix, and the first two need reads this call does not have — staging fetches
+// the anchor for the version pin and nothing else.
+func (r *sendEmailResolver) Guards(ctx context.Context, cmd SendEmailCommand) error {
+	if err := requireAddressee(cmd.To); err != nil {
+		return err
+	}
+	return r.anchor.refuse(ctx, cmd.ActivityID)
+}
+
+// describeSend is the one line the inbox shows for a mail send: who it
+// reaches, cc included, and what it says it is about.
+func describeSend(cmd SendEmailCommand) string {
+	summary := fmt.Sprintf("Send an email to %s", strings.Join(cmd.To, ", "))
+	if len(cmd.Cc) > 0 {
+		summary += fmt.Sprintf(", cc %s", strings.Join(cmd.Cc, ", "))
+	}
+	return summary + fmt.Sprintf(", subject %q", cmd.Subject)
+}
+
+// SendMessageCommand is one channel reply, whichever door asked for it.
+//
+// It carries the message BODY where its mail twin does not, and that asymmetry
+// is the transport's rather than an omission: a channel reply names no
+// addressee — the recipient is the person the anchor conversation is with,
+// resolved server-side — so the text IS the whole of what a human is asked to
+// release, and Guards refuses an empty one.
+type SendMessageCommand struct {
+	ActivityID ids.UUID
+	Body       string
+}
+
+// NewSendMessageCall binds one channel reply to the resolver that answers for
+// it. channels is the kind test the anchor is judged by — see
+// sendMessageResolver.Guards for what it refuses and why the seam carries it.
+//
+//nolint:ireturn // the call IS the product: a resolver named concretely here is exactly the thing that must not leave this package
+func NewSendMessageCall(records datasource.SystemOfRecordProvider, channels ChannelKinds, cmd SendMessageCommand) GovernedCall {
+	return bind[SendMessageCommand](&sendMessageResolver{
+		anchor:   anchoredRecord{records: records, entityType: datasource.EntityActivity},
+		channels: channels,
+	}, cmd)
+}
+
+type sendMessageResolver struct {
+	anchor   anchoredRecord
+	channels ChannelKinds
+}
+
+// Subject names the ANCHOR the approval binds to, exactly as the mail twin's
+// does.
+//
+// The inbox shows the human what they are releasing. The message text is the
+// thing being approved, so it belongs in the summary; the recipient does not,
+// because nobody named one — the conversation did.
+func (r *sendMessageResolver) Subject(ctx context.Context, cmd SendMessageCommand) (StageInfo, error) {
+	rec, err := r.anchor.row(ctx, cmd.ActivityID)
+	if err != nil {
+		return StageInfo{}, err
+	}
+	return StageInfo{
+		TargetType:    string(datasource.EntityActivity),
+		TargetID:      cmd.ActivityID,
+		TargetVersion: &rec.Version,
+		Summary:       fmt.Sprintf("Reply on a captured conversation: %q", cmd.Body),
+	}, nil
+}
+
+// Guards refuses, before anything is staged, an anchor the caller cannot see or
+// whose authority lives elsewhere, a text-less message (a channel provider
+// rejects one), and an anchor that is not a messaging-channel conversation at
+// all. The store refuses the last two too — errEmptyMessageBody and
+// NotAChannelConversationError — and reaching them from there costs the human's
+// one-shot approval on the way past.
+//
+// SendMessage has two more permanent refusals this does not guard:
+// ChannelRecipientError (the conversation reaches nobody, or more than one
+// person) and ChannelNotSendCapableError (the workspace has no bot bound for
+// the provider). Both are the same "yes with no path to actually happening"
+// shape as the two guarded here, but closing them needs a reachability read
+// this call does not have: the record read below returns the anchor's fields,
+// not who the conversation resolves to or whether a bot is bound, and answering
+// either question would mean a new datasource seam method plus a database read
+// at staging time.
+func (r *sendMessageResolver) Guards(ctx context.Context, cmd SendMessageCommand) error {
+	rec, err := r.anchor.row(ctx, cmd.ActivityID)
+	if err != nil {
+		return err
+	}
+	if err := refuseStagingElsewhere(rec); err != nil {
+		return err
+	}
+	if strings.TrimSpace(cmd.Body) == "" {
+		return &BadArgsError{Cause: fmt.Errorf("body is empty or whitespace-only; a channel provider rejects a text-less message")}
+	}
+	var anchor struct {
+		Kind string `json:"kind"`
+	}
+	if err := json.Unmarshal(rec.Fields, &anchor); err != nil {
+		return fmt.Errorf("crmagents: activity %s read back with unreadable fields: %w", cmd.ActivityID, err)
+	}
+	if !r.channels.IsChannelKind(anchor.Kind) {
+		return &BadArgsError{
+			Cause: fmt.Errorf("activity %s is a %q activity, not a messaging-channel conversation",
+				cmd.ActivityID, anchor.Kind),
+			Guidance: "reply on the channel the conversation was held on",
+		}
+	}
+	return nil
+}

--- a/backend/internal/modules/agents/commandlifecycle.go
+++ b/backend/internal/modules/agents/commandlifecycle.go
@@ -1,0 +1,249 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package agents
+
+// The four record-lifecycle commands (gradionhq/margince-poc-v1#928 task 7):
+// graduating a lead, retiring one, stepping a project along its phase ladder,
+// and moving a deal between stages. Each names ONE routed record and each
+// question below rests on that one row — Guards on whether an approval for it
+// could ever be released, Subject on the version it pins and the name a human
+// reads — so all four ride anchoredRecord (command.go) for a single read.
+//
+// The vocabulary checks come FIRST in every Guards here, before the read. A
+// trigger that is not genuine engagement, a phase that is not a phase, a close
+// with no reason: none of them names a record worth a round trip to refuse, and
+// each is a refusal the executor makes anyway — reaching it from there instead
+// would spend the human's one-shot approval on the way past.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
+)
+
+// PromoteLeadCommand is one lead promotion, whichever door asked for it.
+//
+// Trigger travels because both questions read it: Guards refuses one that is
+// not genuine engagement, and Subject names it in the line a human approves —
+// "promote this lead" and "promote this lead because they replied" are not the
+// same decision. The evidence note does not: nothing here reads it.
+type PromoteLeadCommand struct {
+	LeadID  ids.UUID
+	Trigger string
+}
+
+// NewPromoteLeadCall binds one promotion to the resolver that answers for it,
+// reading the lead through the record seam.
+//
+//nolint:ireturn // the call IS the product: a resolver named concretely here is exactly the thing that must not leave this package
+func NewPromoteLeadCall(records datasource.SystemOfRecordProvider, cmd PromoteLeadCommand) GovernedCall {
+	return bind[PromoteLeadCommand](&promoteLeadResolver{
+		lead: anchoredRecord{records: records, entityType: datasource.EntityLead},
+	}, cmd)
+}
+
+type promoteLeadResolver struct {
+	lead anchoredRecord
+}
+
+// Subject names the LEAD the approval binds to, pins the version the human's
+// judgment was formed against, and says WHICH engagement justifies the
+// promotion.
+func (r *promoteLeadResolver) Subject(ctx context.Context, cmd PromoteLeadCommand) (StageInfo, error) {
+	rec, err := r.lead.row(ctx, cmd.LeadID)
+	if err != nil {
+		return StageInfo{}, err
+	}
+	return StageInfo{
+		TargetType:    string(datasource.EntityLead),
+		TargetID:      cmd.LeadID,
+		TargetVersion: &rec.Version,
+		Summary:       fmt.Sprintf("Promote lead %s to a contact (%s)", recordLabel(rec), cmd.Trigger),
+	}, nil
+}
+
+// Guards refuses a trigger that is not genuine engagement — cold outbound with
+// no reply must never even reach the inbox — and then the lead itself, the
+// same two ways patchResolver.Guards refuses its own target.
+func (r *promoteLeadResolver) Guards(ctx context.Context, cmd PromoteLeadCommand) error {
+	if !validTriggers[cmd.Trigger] {
+		return &BadArgsError{Cause: fmt.Errorf("trigger %q is not genuine engagement", cmd.Trigger)}
+	}
+	return r.lead.refuse(ctx, cmd.LeadID)
+}
+
+// DisqualifyLeadCommand is one lead retirement, whichever door asked for it.
+// The routed lead is the whole of it: DELETE /v1/leads/{id} carries no body,
+// and the tool's own arguments carry nothing else either.
+type DisqualifyLeadCommand struct {
+	LeadID ids.UUID
+}
+
+// NewDisqualifyLeadCall binds one retirement to the resolver that answers for
+// it.
+//
+//nolint:ireturn // the call IS the product: a resolver named concretely here is exactly the thing that must not leave this package
+func NewDisqualifyLeadCall(records datasource.SystemOfRecordProvider, cmd DisqualifyLeadCommand) GovernedCall {
+	return bind[DisqualifyLeadCommand](&disqualifyLeadResolver{
+		lead: anchoredRecord{records: records, entityType: datasource.EntityLead},
+	}, cmd)
+}
+
+type disqualifyLeadResolver struct {
+	lead anchoredRecord
+}
+
+func (r *disqualifyLeadResolver) Subject(ctx context.Context, cmd DisqualifyLeadCommand) (StageInfo, error) {
+	rec, err := r.lead.row(ctx, cmd.LeadID)
+	if err != nil {
+		return StageInfo{}, err
+	}
+	return StageInfo{
+		TargetType:    string(datasource.EntityLead),
+		TargetID:      cmd.LeadID,
+		TargetVersion: &rec.Version,
+		Summary:       fmt.Sprintf("Disqualify lead %s", recordLabel(rec)),
+	}, nil
+}
+
+func (r *disqualifyLeadResolver) Guards(ctx context.Context, cmd DisqualifyLeadCommand) error {
+	return r.lead.refuse(ctx, cmd.LeadID)
+}
+
+// AdvanceProjectPhaseCommand is one project phase transition, whichever door
+// asked for it.
+//
+// Reason travels even though Subject never renders it, because Guards reads
+// it: closing without one is refused by the contract, and the rule is a
+// property of the PAIR (phase, reason) rather than of either alone. It carries
+// no if_version — the pin an approval binds to is taken server-side inside the
+// staging transaction, so a caller-supplied version has no reader here, the
+// same call PatchCommand's own doc makes.
+type AdvanceProjectPhaseCommand struct {
+	ProjectID ids.UUID
+	ToPhase   string
+	Reason    *string
+}
+
+// NewAdvanceProjectPhaseCall binds one phase transition to the resolver that
+// answers for it.
+//
+//nolint:ireturn // the call IS the product: a resolver named concretely here is exactly the thing that must not leave this package
+func NewAdvanceProjectPhaseCall(records datasource.SystemOfRecordProvider, cmd AdvanceProjectPhaseCommand) GovernedCall {
+	return bind[AdvanceProjectPhaseCommand](&advanceProjectPhaseResolver{
+		project: anchoredRecord{records: records, entityType: datasource.EntityProject},
+	}, cmd)
+}
+
+type advanceProjectPhaseResolver struct {
+	project anchoredRecord
+}
+
+func (r *advanceProjectPhaseResolver) Subject(ctx context.Context, cmd AdvanceProjectPhaseCommand) (StageInfo, error) {
+	rec, err := r.project.row(ctx, cmd.ProjectID)
+	if err != nil {
+		return StageInfo{}, err
+	}
+	return StageInfo{
+		TargetType:    string(datasource.EntityProject),
+		TargetID:      cmd.ProjectID,
+		TargetVersion: &rec.Version,
+		Summary:       fmt.Sprintf("Move project %s to %s", recordLabel(rec), cmd.ToPhase),
+	}, nil
+}
+
+// Guards refuses a phase the ladder does not have and a close with no reason,
+// then the project itself.
+func (r *advanceProjectPhaseResolver) Guards(ctx context.Context, cmd AdvanceProjectPhaseCommand) error {
+	if err := requireProjectPhase(cmd.ToPhase, cmd.Reason); err != nil {
+		return err
+	}
+	return r.project.refuse(ctx, cmd.ProjectID)
+}
+
+// requireProjectPhase admits a transition's destination and the reason the
+// contract attaches to one of them.
+//
+// One function for both doors: the staging path asks it through Guards above
+// and the execution path asks it through advanceProjectPhase.readArgs, so a
+// phase refused before a human is asked cannot be a phase admitted by the
+// approved retry — and neither can the reverse, which is the direction that
+// costs a human's yes.
+func requireProjectPhase(toPhase string, reason *string) error {
+	if !projectPhases[toPhase] {
+		return &BadArgsError{Cause: fmt.Errorf("to_phase %q is not a project phase", toPhase)}
+	}
+	if toPhase == projectPhaseClosed && (reason == nil || strings.TrimSpace(*reason) == "") {
+		return &BadArgsError{Cause: errors.New("reason is required when to_phase is closed")}
+	}
+	return nil
+}
+
+// AdvanceDealCommand is one deal stage move, whichever door asked for it.
+//
+// ToStageID travels because the summary turns on it: the destination's
+// configured SEMANTIC is what makes a move a close, a reopen or a routine step,
+// and those are opposite decisions wearing one shape. It carries neither
+// lost_reason nor if_version — nothing here reads either.
+//
+// It is the command BOTH deal-move tools stage through: progress_deal composes
+// advance_deal with a note (interfaces.md §2.2) and stages the identical act,
+// so it stages the identical shape rather than a second copy of it that could
+// come to describe the same move differently.
+type AdvanceDealCommand struct {
+	DealID    ids.UUID
+	ToStageID ids.UUID
+}
+
+// NewAdvanceDealCall binds one deal move to the resolver that answers for it.
+// stages resolves the destination's configured semantic — the property the
+// summary is written from, never the request's own labels.
+//
+//nolint:ireturn // the call IS the product: a resolver named concretely here is exactly the thing that must not leave this package
+func NewAdvanceDealCall(records datasource.SystemOfRecordProvider, stages StageResolver, cmd AdvanceDealCommand) GovernedCall {
+	return bind[AdvanceDealCommand](&advanceDealResolver{
+		deal:   anchoredRecord{records: records, entityType: datasource.EntityDeal},
+		stages: stages,
+	}, cmd)
+}
+
+type advanceDealResolver struct {
+	deal   anchoredRecord
+	stages StageResolver
+}
+
+// Subject pins the staged move to the deal's CURRENT version, so an approval
+// given for "close this deal as it stands" cannot execute against a deal that
+// changed in between, and names the move by BOTH of its endpoints
+// (dealMoveSummary) — reading the source out of the record this staging
+// already read rather than fetching the deal a second time.
+func (r *advanceDealResolver) Subject(ctx context.Context, cmd AdvanceDealCommand) (StageInfo, error) {
+	rec, err := r.deal.row(ctx, cmd.DealID)
+	if err != nil {
+		return StageInfo{}, err
+	}
+	semantic, _, err := r.stages.StageSemantic(ctx, cmd.ToStageID)
+	if err != nil {
+		return StageInfo{}, err
+	}
+	return StageInfo{
+		TargetType:    string(datasource.EntityDeal),
+		TargetID:      cmd.DealID,
+		TargetVersion: &rec.Version,
+		Summary:       dealMoveSummary(ctx, r.stages, rec, semantic),
+	}, nil
+}
+
+// Guards refuses the deal the same two ways patchResolver.Guards refuses its
+// own target. It does NOT re-derive the move's tier: whether this move needs an
+// approval at all is the gate's question, answered before staging is reached
+// (advanceDealTier, dealmove.go), and asking it again here would be a second
+// opinion about a decision already taken.
+func (r *advanceDealResolver) Guards(ctx context.Context, cmd AdvanceDealCommand) error {
+	return r.deal.refuse(ctx, cmd.DealID)
+}

--- a/backend/internal/modules/agents/commandlifecycle.go
+++ b/backend/internal/modules/agents/commandlifecycle.go
@@ -18,12 +18,14 @@ package agents
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/mcp"
 )
 
 // PromoteLeadCommand is one lead promotion, whichever door asked for it.
@@ -220,10 +222,38 @@ type AdvanceDealCommand struct {
 //
 //nolint:ireturn // the call IS the product: a resolver named concretely here is exactly the thing that must not leave this package
 func NewAdvanceDealCall(records datasource.SystemOfRecordProvider, stages StageResolver, cmd AdvanceDealCommand) GovernedCall {
-	return bind[AdvanceDealCommand](&advanceDealResolver{
-		deal:   anchoredRecord{records: records, entityType: datasource.EntityDeal},
-		stages: stages,
-	}, cmd)
+	return advanceDealCall{
+		GovernedCall: bind[AdvanceDealCommand](&advanceDealResolver{
+			deal:   anchoredRecord{records: records, entityType: datasource.EntityDeal},
+			stages: stages,
+		}, cmd),
+		records: records,
+		stages:  stages,
+		cmd:     cmd,
+	}
+}
+
+// advanceDealCall is the bound deal move plus the one question this operation's
+// tier turns on: 🟢/🟡 is decided per invocation, from BOTH endpoints of the
+// move, so the gate cannot be told what to decide from without being told which
+// move it is.
+//
+// It is its own type rather than a method every bound command carries, because
+// DynamicTierInput's refusal (command.go) has to be a real refusal — a call that
+// answers no tier must be turned away, not handed an empty input the resolver
+// would read as "not open" for a reason nobody chose.
+type advanceDealCall struct {
+	GovernedCall
+	records datasource.SystemOfRecordProvider
+	stages  StageResolver
+	cmd     AdvanceDealCommand
+}
+
+// tierInput shows the gate both endpoints of the move, through the builder every
+// door shares (DealMoveTierInput). args travels because the resolver input
+// carries the call's own arguments alongside the semantics resolved from them.
+func (c advanceDealCall) tierInput(ctx context.Context, args json.RawMessage) (mcp.TierResolverInput, error) {
+	return DealMoveTierInput(ctx, c.records, c.stages, c.cmd.DealID, c.cmd.ToStageID, args)
 }
 
 type advanceDealResolver struct {

--- a/backend/internal/modules/agents/commandlifecycle.go
+++ b/backend/internal/modules/agents/commandlifecycle.go
@@ -71,10 +71,24 @@ func (r *promoteLeadResolver) Subject(ctx context.Context, cmd PromoteLeadComman
 // no reply must never even reach the inbox — and then the lead itself, the
 // same two ways patchResolver.Guards refuses its own target.
 func (r *promoteLeadResolver) Guards(ctx context.Context, cmd PromoteLeadCommand) error {
-	if !validTriggers[cmd.Trigger] {
-		return &BadArgsError{Cause: fmt.Errorf("trigger %q is not genuine engagement", cmd.Trigger)}
+	if err := requireGenuineTrigger(cmd.Trigger); err != nil {
+		return err
 	}
 	return r.lead.refuse(ctx, cmd.LeadID)
+}
+
+// requireGenuineTrigger admits the engagement a promotion rests on.
+//
+// One function for both doors: the staging path asks it through Guards above
+// and the execution path through promoteLead.Handle, which the approved retry
+// re-enters without passing Guards. Two copies of the predicate AND its
+// sentence is how the two doors come to disagree about what counts as
+// engagement, or to say it differently for the same refusal.
+func requireGenuineTrigger(trigger string) error {
+	if validTriggers[trigger] {
+		return nil
+	}
+	return &BadArgsError{Cause: fmt.Errorf("trigger %q is not genuine engagement", trigger)}
 }
 
 // DisqualifyLeadCommand is one lead retirement, whichever door asked for it.

--- a/backend/internal/modules/agents/commandlinked.go
+++ b/backend/internal/modules/agents/commandlinked.go
@@ -1,0 +1,304 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package agents
+
+// The two commands that NAME their records instead of anchoring on one
+// (gradionhq/margince-poc-v1#928 task 7): an account-started email, which
+// files a brand-new conversation under the records it belongs to, and a
+// booking, which says who and what the meeting is about. Neither is handed a
+// row, so both have to answer the same three questions about the list they
+// were given — is it bounded, is it free of repeats, is every record one the
+// caller may actually reach — which toollinks.go answers once for both.
+//
+// Where they part is the staged TARGET. A booking's first link becomes the
+// target and supplies the pin, because a meeting is a commitment ON that
+// record. An account-started send stages a CREATE — target type with no id
+// and no pin — for a reason its own resolver states.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
+)
+
+// namedLinks is the link list both resolvers below rest on, admitted and read
+// ONCE for the two questions that share it.
+//
+// One reading, for the reason anchoredRecord (command.go) gives for an
+// anchor: Guards refuses on what the read finds and Subject describes what it
+// found, and a second reading is a second moment those two answers are free to
+// disagree across — a booking would then pin a version taken after the
+// authority judgment it is supposed to accompany. It also matters more here
+// than for a single row: the read is one row-scoped provider round trip PER
+// link, so asking twice doubles a bounded-but-not-small cost.
+type namedLinks struct {
+	records datasource.SystemOfRecordProvider
+	unique  []RecordLink
+	rows    []datasource.Record
+	read    bool
+}
+
+// stageable de-duplicates the caller's links, bounds them, reads every one and
+// refuses the staging if any cannot carry an approval. It answers the unique
+// list and the rows in that same order, so a caller needing one of the rows —
+// a booking pins its first link's version — reads it here rather than fetching
+// it again.
+func (n *namedLinks) stageable(ctx context.Context, links []RecordLink) ([]RecordLink, []datasource.Record, error) {
+	if n.read {
+		return n.unique, n.rows, nil
+	}
+	unique, err := uniqueRecordLinks(links)
+	if err != nil {
+		return nil, nil, err
+	}
+	rows, err := readStageableLinks(ctx, n.records, unique)
+	if err != nil {
+		return nil, nil, err
+	}
+	n.unique, n.rows, n.read = unique, rows, true
+	return unique, rows, nil
+}
+
+// SendAccountEmailCommand is one account-started email, whichever door asked
+// for it: the reply's operands minus the anchor, plus the records the new
+// conversation is filed under.
+//
+// It carries no body and no consent purpose, for the reason SendEmailCommand's
+// own doc gives — nothing here reads either.
+type SendAccountEmailCommand struct {
+	To      []string
+	Cc      []string
+	Subject string
+	Links   []RecordLink
+}
+
+// NewSendAccountEmailCall binds one account-started send to the resolver that
+// answers for it, reading its named records through the record seam.
+//
+//nolint:ireturn // the call IS the product: a resolver named concretely here is exactly the thing that must not leave this package
+func NewSendAccountEmailCall(records datasource.SystemOfRecordProvider, cmd SendAccountEmailCommand) GovernedCall {
+	return bind[SendAccountEmailCommand](&accountSendResolver{links: namedLinks{records: records}}, cmd)
+}
+
+type accountSendResolver struct {
+	links namedLinks
+}
+
+// Subject stages a CREATE, and the shape says so: target type `activity` with
+// no id and no version pin. This send answers no message, so there is no row
+// its effect depends on — approvals.settledByShape reads that shape as
+// decidable on the object-read floor plus the decision grants.
+//
+// A LINK CANNOT BE THE TARGET here, the way a booking's first link is. The pin
+// is taken SERVER-SIDE from the target pair (approvals.resolveTargetVersion),
+// so an organization target pins a version that an enrichment run bumps while
+// an overnight proposal waits for someone's morning inbox — cancelling a send
+// the record's own content never invalidated. The waiver that declines a pin
+// is reserved for kinds whose effect approvals itself applies
+// (TestEveryContextTargetKindIsAKindWeStage); this effect is performed by the
+// agent's own approved retry.
+//
+// So the approver is bounded by read+create on `activity` and NOT by the row
+// scope of the records the message is filed under, where the reply path binds
+// its approver to the anchor. That difference is stated rather than closed:
+// closing it takes a target derived from the body on BOTH doors, and this
+// command is the half of that which now exists.
+func (r *accountSendResolver) Subject(ctx context.Context, cmd SendAccountEmailCommand) (StageInfo, error) {
+	links, _, err := r.links.stageable(ctx, cmd.Links)
+	if err != nil {
+		return StageInfo{}, err
+	}
+	return StageInfo{
+		TargetType: string(datasource.EntityActivity),
+		Summary:    describeAccountSend(cmd, links),
+	}, nil
+}
+
+// Guards refuses, before anything is staged, a send that reaches nobody, one
+// filed under no record, and one naming a record the caller cannot see or
+// whose authority lives elsewhere.
+//
+// The links are read even though none of them is the staged target, because
+// that is a question about the STAGER's reach rather than the approver's: the
+// store refuses a link the caller cannot see, at execution — so without the
+// same probe here, an agent naming a company it cannot read mints an approval
+// a human reads, approves, and watches fail with the one-shot authority
+// already spent.
+//
+// What this does not pre-empt, so neither reads as covered: the consent gate's
+// per-purpose verdict, the workspace's mailbox send capability, and whether an
+// address belongs to a person on file. All are refusals a human's yes cannot
+// fix, and all need reads staging does not have.
+func (r *accountSendResolver) Guards(ctx context.Context, cmd SendAccountEmailCommand) error {
+	if err := requireAddressee(cmd.To); err != nil {
+		return err
+	}
+	if err := requireAccountSendLinks(cmd.Links); err != nil {
+		return err
+	}
+	_, _, err := r.links.stageable(ctx, cmd.Links)
+	return err
+}
+
+// requireAccountSendLinks enforces what the schema and crm.yaml both state: a
+// new conversation says which records it belongs to.
+//
+// A function rather than a line inside Guards because this verb has two doors
+// past this rule — the staging path and the post-approval execute — and the
+// MCP surface does not validate arguments against an InputSchema (that schema
+// is documentation), so a rule enforced at one door is a rule a caller meets
+// only sometimes.
+func requireAccountSendLinks(links []RecordLink) error {
+	if len(links) > 0 {
+		return nil
+	}
+	return &BadArgsError{
+		Cause: errors.New("`links` needs at least one entry: a message filed under no record " +
+			"is one nobody finds again, and the store refuses it"),
+		Guidance: "name the company, person or deal this conversation is about",
+	}
+}
+
+// describeAccountSend is the one line the inbox shows: who it reaches, cc
+// included, what it says it is about, and how many records it will land on.
+//
+// Every addressee, for the reason describeSend states — an unnamed recipient
+// is a recipient nobody agreed to. The links are COUNTED rather than listed:
+// their ids mean nothing to a human reading one line, and the staged row is
+// decidable on the activity floor rather than on those records, so naming them
+// would disclose more than the decision rests on.
+func describeAccountSend(cmd SendAccountEmailCommand, links []RecordLink) string {
+	summary := fmt.Sprintf("Start an email conversation with %s", strings.Join(cmd.To, ", "))
+	if len(cmd.Cc) > 0 {
+		summary += fmt.Sprintf(", cc %s", strings.Join(cmd.Cc, ", "))
+	}
+	return summary + fmt.Sprintf(", subject %q, filed under %d record(s)", cmd.Subject, len(links))
+}
+
+// BookMeetingCommand is one booking, whichever door asked for it. It carries
+// every operand the two questions below read: the slot, whose calendar it
+// lands on, what it is called, and what it attaches to.
+type BookMeetingCommand struct {
+	HostUserID *ids.UUID
+	Start      time.Time
+	End        time.Time
+	Subject    string
+	Links      []RecordLink
+}
+
+// NewBookMeetingCall binds one booking to the resolver that answers for it,
+// reading its named records through the record seam.
+//
+//nolint:ireturn // the call IS the product: a resolver named concretely here is exactly the thing that must not leave this package
+func NewBookMeetingCall(records datasource.SystemOfRecordProvider, cmd BookMeetingCommand) GovernedCall {
+	return bind[BookMeetingCommand](&bookMeetingResolver{links: namedLinks{records: records}}, cmd)
+}
+
+type bookMeetingResolver struct {
+	links namedLinks
+}
+
+// Subject names the booking's FIRST link as the target and pins its version,
+// which is what makes a booking's staged row bind to a record rather than
+// float free: a meeting is a commitment ON that record, and the human deciding
+// it is the one whose scope reaches it.
+//
+// The empty case is asked again rather than assumed away. Guards refuses it
+// and StageSubject runs Guards first, but a Subject that indexes links[0] on
+// the strength of a caller's ordering is one panic away from being wrong — and
+// requireBookingLinks is ONE function asked at both points, not a second
+// spelling of the rule that could come to say something else.
+func (r *bookMeetingResolver) Subject(ctx context.Context, cmd BookMeetingCommand) (StageInfo, error) {
+	if err := requireBookingLinks(cmd.Links); err != nil {
+		return StageInfo{}, err
+	}
+	links, rows, err := r.links.stageable(ctx, cmd.Links)
+	if err != nil {
+		return StageInfo{}, err
+	}
+	return StageInfo{
+		TargetType:    links[0].EntityType,
+		TargetID:      links[0].EntityID,
+		TargetVersion: &rows[0].Version,
+		Summary:       describeBooking(cmd, links),
+	}, nil
+}
+
+// Guards refuses, before anything is staged, a booking whose end does not
+// follow its start, one attached to nothing, one attached to more records than
+// a request may name, and one naming a record the caller cannot see or whose
+// authority lives elsewhere.
+func (r *bookMeetingResolver) Guards(ctx context.Context, cmd BookMeetingCommand) error {
+	if err := requireBookingWindow(cmd.Start, cmd.End); err != nil {
+		return err
+	}
+	if err := requireBookingLinks(cmd.Links); err != nil {
+		return err
+	}
+	_, _, err := r.links.stageable(ctx, cmd.Links)
+	return err
+}
+
+// requireBookingWindow refuses a booking that ends before it starts.
+//
+// The store refuses it too (errBookingEndNotAfterStart), which is why this is
+// not a correctness hole — but reaching THAT refusal costs the human's
+// approval on the way past, since redemption is consumed before the handler
+// runs. So both doors ask first, the same rule the link checks follow.
+func requireBookingWindow(start, end time.Time) error {
+	if end.After(start) {
+		return nil
+	}
+	return &BadArgsError{Cause: fmt.Errorf(
+		"`end` (%s) does not follow `start` (%s); a booking with no duration would be refused after approval",
+		end.Format(time.RFC3339), start.Format(time.RFC3339))}
+}
+
+// requireBookingLinks enforces what crm.yaml's bookMeeting body states: at
+// least one link. A staged approval with no target is a human asked to release
+// a meeting attached to nothing — nothing to show them, and no version to pin
+// it against.
+//
+// A function for the reason requireAccountSendLinks is one: this verb has two
+// doors past the rule, and the MCP surface does not validate arguments against
+// an InputSchema.
+func requireBookingLinks(links []RecordLink) error {
+	if len(links) > 0 {
+		return nil
+	}
+	return &BadArgsError{Cause: errors.New(
+		"`links` needs at least one entry: a booking names who and what it is about, " +
+			"and one attached to nothing cannot be approved against a record")}
+}
+
+// describeBooking is the one line the inbox shows.
+//
+// It names every operand that changes what gets released — the slot, the
+// subject, WHOSE calendar it lands on, and how many records it attaches to. A
+// human approving from the inbox row sees only this string, so an operand
+// missing from it is an effect nobody agreed to.
+//
+// The subject is the agent's own text, so it is quoted rather than run into
+// the sentence; the approvals engine sanitizes every summary at the single
+// staging path regardless.
+func describeBooking(cmd BookMeetingCommand, links []RecordLink) string {
+	subject := cmd.Subject
+	if strings.TrimSpace(subject) == "" {
+		subject = "(no subject)"
+	}
+	summary := fmt.Sprintf("Book %q from %s to %s",
+		subject, cmd.Start.Format(time.RFC3339), cmd.End.Format(time.RFC3339))
+	if cmd.HostUserID != nil {
+		summary += fmt.Sprintf(" on %s's calendar", cmd.HostUserID)
+	}
+	if len(links) > 0 {
+		summary += fmt.Sprintf(", attached to %d record(s)", len(links))
+	}
+	return summary
+}

--- a/backend/internal/modules/agents/commandlinked.go
+++ b/backend/internal/modules/agents/commandlinked.go
@@ -267,10 +267,24 @@ func requireBookingWindow(start, end time.Time) error {
 		end.Format(time.RFC3339), start.Format(time.RFC3339))}
 }
 
-// requireBookingLinks enforces what crm.yaml's bookMeeting body states: at
-// least one link. A staged approval with no target is a human asked to release
-// a meeting attached to nothing — nothing to show them, and no version to pin
-// it against.
+// requireBookingLinks refuses a booking attached to nothing, because the
+// APPROVAL cannot exist without one: Subject binds to the first link and pins
+// its version, so a link-less booking could only stage against a zero id — an
+// authority object the approvals surface can scope to nobody in particular,
+// which is the defect this seam fixes rather than one it may reintroduce.
+//
+// It does NOT restate the contract, and the difference is worth being exact
+// about. `/bookings` declares `links` a required KEY with `maxItems: 25` and
+// no `minItems`, so `"links": []` is contract-legal, and neither the handler
+// nor activities.Store.BookMeeting refuses one. This rule is the gate's own,
+// and an agent doing what the schema permits now meets it where it previously
+// staged and executed. That disagreement is filed rather than settled here,
+// because closing it the right way is a contract change:
+// gradionhq/margince-poc-v1#1065.
+//
+// requireAccountSendLinks' identical-looking claim IS backed —
+// SendAccountEmailRequest.links carries minItems: 1 — which is why that one
+// cites the contract and this one cannot.
 //
 // A function for the reason requireAccountSendLinks is one: this verb has two
 // doors past the rule, and the MCP surface does not validate arguments against

--- a/backend/internal/modules/agents/commandlinked.go
+++ b/backend/internal/modules/agents/commandlinked.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -39,9 +40,15 @@ import (
 // link, so asking twice doubles a bounded-but-not-small cost.
 type namedLinks struct {
 	records datasource.SystemOfRecordProvider
-	unique  []RecordLink
-	rows    []datasource.Record
-	read    bool
+	// seen is the list the memo was filled for, so a resolver asked about a
+	// second set of links reads THAT set — the same key archiveResolver's and
+	// anchoredRecord's memos carry (command.go), compared elementwise because a
+	// slice is not comparable and a bare "already read" flag would answer the
+	// second question with the first question's records.
+	seen   []RecordLink
+	unique []RecordLink
+	rows   []datasource.Record
+	read   bool
 }
 
 // stageable de-duplicates the caller's links, bounds them, reads every one and
@@ -50,7 +57,7 @@ type namedLinks struct {
 // a booking pins its first link's version — reads it here rather than fetching
 // it again.
 func (n *namedLinks) stageable(ctx context.Context, links []RecordLink) ([]RecordLink, []datasource.Record, error) {
-	if n.read {
+	if n.read && slices.Equal(n.seen, links) {
 		return n.unique, n.rows, nil
 	}
 	unique, err := uniqueRecordLinks(links)
@@ -61,7 +68,7 @@ func (n *namedLinks) stageable(ctx context.Context, links []RecordLink) ([]Recor
 	if err != nil {
 		return nil, nil, err
 	}
-	n.unique, n.rows, n.read = unique, rows, true
+	n.seen, n.unique, n.rows, n.read = slices.Clone(links), unique, rows, true
 	return unique, rows, nil
 }
 

--- a/backend/internal/modules/agents/commandnested.go
+++ b/backend/internal/modules/agents/commandnested.go
@@ -303,6 +303,11 @@ func (r createOfferResolver) Guards(ctx context.Context, cmd CreateOfferCommand)
 // ORGANIZATION, and the upsert IS a field patch on that organization's
 // partner extension, so the approval binds to the organization exactly as
 // commandsidecar.go's four resolvers do (organizationSidecarRecordType).
+// This is also why upsertPartner is deliberately EXCLUDED from
+// agentsplit.go's actionShapedUpdateOps: that set is for operations whose
+// body is NOT a field patch on the routed record, and this one's body is
+// exactly that, so it must take the full §2.1 human-edit-precedence split
+// rather than run unconditionally 🟢.
 type UpsertPartnerCommand struct {
 	ID ids.UUID
 }

--- a/backend/internal/modules/agents/commandnested.go
+++ b/backend/internal/modules/agents/commandnested.go
@@ -7,13 +7,14 @@ package agents
 // a list member add, a tag apply, an offer line item add/update/remove, an
 // offer created under a parent deal, and a partner upsert. All seven are 🟢
 // auto_execute today, so Subject/Guards are unreachable on today's tiers —
-// but a route with no command of its own still answers stagedTargetByRoute's
-// GUESS the moment a tier floor (#982) tightens it, and for createOffer that
-// guess is wrong on its face: the routed {id} is the DEAL the offer is
-// created ON, not an offer id, so the walk would pair
-// target_entity_type=offer with a deal's id — a target that resolves to no
-// row, or to an unrelated offer that happens to share the id space
-// (gradionhq/margince-poc-v1#1046, closed by this file's CreateOfferCommand).
+// but a tier floor (#982) tightening any of them makes this the answer a human
+// decides from, and the REST door has no other one to fall back on. For
+// createOffer that matters on its face: the routed {id} is the DEAL the offer
+// is created ON, not an offer id, so anything reading the target off the route
+// would pair target_entity_type=offer with a deal's id — a target that
+// resolves to no row, or to an unrelated offer that happens to share the id
+// space (gradionhq/margince-poc-v1#1046, closed by this file's
+// CreateOfferCommand).
 //
 // list, tag and offer are all outside the record seam's vocabulary
 // (servedByTheRecordSeam, command.go), the same bound six of the twelve
@@ -269,10 +270,9 @@ type createOfferResolver struct {
 // the shape createResolver stages for every other create (command.go),
 // because an offer does not exist yet either. This is the fix for
 // gradionhq/margince-poc-v1#1046: the routed {id} is the deal, and pairing
-// target_entity_type=offer with the deal's id (stagedTargetByRoute's guess)
-// names a target that resolves to no row, or to an unrelated offer that
-// happens to share the id space. Naming no id at all is the only staged
-// target this create could honestly carry.
+// target_entity_type=offer with the deal's id names a target that resolves to
+// no row, or to an unrelated offer that happens to share the id space. Naming
+// no id at all is the only staged target this create could honestly carry.
 func (r createOfferResolver) Subject(_ context.Context, cmd CreateOfferCommand) (StageInfo, error) {
 	return StageInfo{
 		TargetType: offerRecordType,

--- a/backend/internal/modules/agents/commandnested.go
+++ b/backend/internal/modules/agents/commandnested.go
@@ -1,0 +1,340 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package agents
+
+// The seven remaining bespoke commands (gradionhq/margince-poc-v1#928 task 6):
+// a list member add, a tag apply, an offer line item add/update/remove, an
+// offer created under a parent deal, and a partner upsert. All seven are 🟢
+// auto_execute today, so Subject/Guards are unreachable on today's tiers —
+// but a route with no command of its own still answers stagedTargetByRoute's
+// GUESS the moment a tier floor (#982) tightens it, and for createOffer that
+// guess is wrong on its face: the routed {id} is the DEAL the offer is
+// created ON, not an offer id, so the walk would pair
+// target_entity_type=offer with a deal's id — a target that resolves to no
+// row, or to an unrelated offer that happens to share the id space
+// (gradionhq/margince-poc-v1#1046, closed by this file's CreateOfferCommand).
+//
+// list, tag and offer are all outside the record seam's vocabulary
+// (servedByTheRecordSeam, command.go), the same bound six of the twelve
+// archivable types already stand on — so five of these seven resolvers'
+// Guards stand down, reusing that check rather than a hand-restated opinion
+// (gradionhq/margince-poc-v1#1021). deal and organization ARE served, so
+// createOffer's and upsertPartner's Guards perform a real read.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
+)
+
+const (
+	// listRecordType and tagRecordType name AddListMemberCommand's and
+	// ApplyTagCommand's fixed targets — plain strings, not
+	// datasource.EntityType, for the same reason customFieldRecordType
+	// (commandaction.go) is: the record seam has never served either.
+	listRecordType = "list"
+	tagRecordType  = "tag"
+	// offerRecordType names the three offer-line-item commands' fixed
+	// target. An offer itself is one of the six archivable types the seam
+	// does not serve either.
+	offerRecordType = "offer"
+)
+
+// AddListMemberCommand is one static-list member addition, whichever door
+// asked for it — the routed list id only. It does not carry the member
+// being added: neither Guards nor Subject reads it, the same reason
+// UpdateFactCommand's own doc (commandsidecar.go) gives for dropping a
+// value nothing here reads.
+type AddListMemberCommand struct {
+	ID ids.UUID
+}
+
+// NewAddListMemberCall binds one member addition to the resolver that
+// answers for it.
+//
+//nolint:ireturn // the call IS the product: a resolver named concretely here is exactly the thing that must not leave this package
+func NewAddListMemberCall(records datasource.SystemOfRecordProvider, cmd AddListMemberCommand) GovernedCall {
+	return bind[AddListMemberCommand](addListMemberResolver{
+		target: routedRecordTarget{records: records, recordType: listRecordType},
+	}, cmd)
+}
+
+type addListMemberResolver struct {
+	target routedRecordTarget
+}
+
+// Subject names the LIST the approval binds to — a membership row has no
+// row of its own on the seam.
+func (r addListMemberResolver) Subject(_ context.Context, cmd AddListMemberCommand) (StageInfo, error) {
+	return StageInfo{
+		TargetType: listRecordType,
+		TargetID:   cmd.ID,
+		Summary:    fmt.Sprintf("Add a member to list %s", cmd.ID),
+	}, nil
+}
+
+// Guards stands down: the seam has never served `list`, so there is
+// nothing here to read and nothing to refuse.
+func (r addListMemberResolver) Guards(ctx context.Context, cmd AddListMemberCommand) error {
+	return r.target.refuse(ctx, cmd.ID)
+}
+
+// ApplyTagCommand is one tag application, whichever door asked for it — the
+// routed tag id only. It does not carry which record the tag is applied to:
+// neither Guards nor Subject reads it, the same reasoning AddListMemberCommand's
+// own doc gives.
+type ApplyTagCommand struct {
+	ID ids.UUID
+}
+
+// NewApplyTagCall binds one tag application to the resolver that answers
+// for it.
+//
+//nolint:ireturn // the call IS the product: a resolver named concretely here is exactly the thing that must not leave this package
+func NewApplyTagCall(records datasource.SystemOfRecordProvider, cmd ApplyTagCommand) GovernedCall {
+	return bind[ApplyTagCommand](applyTagResolver{
+		target: routedRecordTarget{records: records, recordType: tagRecordType},
+	}, cmd)
+}
+
+type applyTagResolver struct {
+	target routedRecordTarget
+}
+
+// Subject names the TAG the approval binds to.
+func (r applyTagResolver) Subject(_ context.Context, cmd ApplyTagCommand) (StageInfo, error) {
+	return StageInfo{
+		TargetType: tagRecordType,
+		TargetID:   cmd.ID,
+		Summary:    fmt.Sprintf("Apply tag %s", cmd.ID),
+	}, nil
+}
+
+// Guards stands down: the seam has never served `tag`.
+func (r applyTagResolver) Guards(ctx context.Context, cmd ApplyTagCommand) error {
+	return r.target.refuse(ctx, cmd.ID)
+}
+
+// AddOfferLineItemCommand is one offer line-item addition, whichever door
+// asked for it — the routed offer id only. It does not carry the line
+// item's own fields: neither Guards nor Subject reads them, the same
+// reasoning AddListMemberCommand's own doc gives, and Guards does not check
+// whether the offer is still a draft (the state the handler itself refuses
+// a line-item add against) — that read is the executor's, not this
+// approval's.
+type AddOfferLineItemCommand struct {
+	ID ids.UUID
+}
+
+// NewAddOfferLineItemCall binds one line-item addition to the resolver
+// that answers for it.
+//
+//nolint:ireturn // the call IS the product: a resolver named concretely here is exactly the thing that must not leave this package
+func NewAddOfferLineItemCall(records datasource.SystemOfRecordProvider, cmd AddOfferLineItemCommand) GovernedCall {
+	return bind[AddOfferLineItemCommand](addOfferLineItemResolver{
+		target: routedRecordTarget{records: records, recordType: offerRecordType},
+	}, cmd)
+}
+
+type addOfferLineItemResolver struct {
+	target routedRecordTarget
+}
+
+// Subject names the OFFER the approval binds to.
+func (r addOfferLineItemResolver) Subject(_ context.Context, cmd AddOfferLineItemCommand) (StageInfo, error) {
+	return StageInfo{
+		TargetType: offerRecordType,
+		TargetID:   cmd.ID,
+		Summary:    fmt.Sprintf("Add a line item to offer %s", cmd.ID),
+	}, nil
+}
+
+// Guards stands down: the seam has never served `offer`.
+func (r addOfferLineItemResolver) Guards(ctx context.Context, cmd AddOfferLineItemCommand) error {
+	return r.target.refuse(ctx, cmd.ID)
+}
+
+// UpdateOfferLineItemCommand is one offer line-item edit, whichever door
+// asked for it — the routed offer id plus LineItemID, the SECOND path
+// parameter naming which line changes. It does not carry the edited
+// fields, the same reasoning AddOfferLineItemCommand's own doc gives, and
+// Guards does not check that LineItemID names a line actually on this
+// offer — that existence read is the handler's, and duplicating it here
+// would put a second spelling of the executor's own rule in staging.
+type UpdateOfferLineItemCommand struct {
+	ID         ids.UUID
+	LineItemID ids.UUID
+}
+
+// NewUpdateOfferLineItemCall binds one line-item edit to the resolver that
+// answers for it.
+//
+//nolint:ireturn // the call IS the product: a resolver named concretely here is exactly the thing that must not leave this package
+func NewUpdateOfferLineItemCall(records datasource.SystemOfRecordProvider, cmd UpdateOfferLineItemCommand) GovernedCall {
+	return bind[UpdateOfferLineItemCommand](updateOfferLineItemResolver{
+		target: routedRecordTarget{records: records, recordType: offerRecordType},
+	}, cmd)
+}
+
+type updateOfferLineItemResolver struct {
+	target routedRecordTarget
+}
+
+// Subject names the OFFER the approval binds to, with the line item being
+// edited carried into the summary — the door-agnostic line
+// GovernedCall.Subject owes this operation, distinct per line item even
+// though no door renders it today (confirmFactResolver's own doc,
+// commandsidecar.go, says why).
+func (r updateOfferLineItemResolver) Subject(_ context.Context, cmd UpdateOfferLineItemCommand) (StageInfo, error) {
+	return StageInfo{
+		TargetType: offerRecordType,
+		TargetID:   cmd.ID,
+		Summary:    fmt.Sprintf("Update line item %s on offer %s", cmd.LineItemID, cmd.ID),
+	}, nil
+}
+
+// Guards stands down: the seam has never served `offer`.
+func (r updateOfferLineItemResolver) Guards(ctx context.Context, cmd UpdateOfferLineItemCommand) error {
+	return r.target.refuse(ctx, cmd.ID)
+}
+
+// RemoveOfferLineItemCommand is one offer line-item removal, whichever
+// door asked for it — the same two fields UpdateOfferLineItemCommand
+// carries, for the same reason.
+type RemoveOfferLineItemCommand struct {
+	ID         ids.UUID
+	LineItemID ids.UUID
+}
+
+// NewRemoveOfferLineItemCall binds one line-item removal to the resolver
+// that answers for it.
+//
+//nolint:ireturn // the call IS the product: a resolver named concretely here is exactly the thing that must not leave this package
+func NewRemoveOfferLineItemCall(records datasource.SystemOfRecordProvider, cmd RemoveOfferLineItemCommand) GovernedCall {
+	return bind[RemoveOfferLineItemCommand](removeOfferLineItemResolver{
+		target: routedRecordTarget{records: records, recordType: offerRecordType},
+	}, cmd)
+}
+
+type removeOfferLineItemResolver struct {
+	target routedRecordTarget
+}
+
+// Subject: the same shape as updateOfferLineItemResolver's.
+func (r removeOfferLineItemResolver) Subject(_ context.Context, cmd RemoveOfferLineItemCommand) (StageInfo, error) {
+	return StageInfo{
+		TargetType: offerRecordType,
+		TargetID:   cmd.ID,
+		Summary:    fmt.Sprintf("Remove line item %s from offer %s", cmd.LineItemID, cmd.ID),
+	}, nil
+}
+
+// Guards stands down: the seam has never served `offer`.
+func (r removeOfferLineItemResolver) Guards(ctx context.Context, cmd RemoveOfferLineItemCommand) error {
+	return r.target.refuse(ctx, cmd.ID)
+}
+
+// CreateOfferCommand is one offer creation under a parent deal, whichever
+// door asked for it. DealID is the ROUTED id — POST /v1/deals/{id}/offers
+// names the parent, not an offer, because the offer does not exist yet
+// (gradionhq/margince-poc-v1#1046). Fields is the create body, carried the
+// same way CreateCommand's own is, so Subject can name which fields it sets.
+type CreateOfferCommand struct {
+	DealID ids.UUID
+	Fields json.RawMessage
+}
+
+// NewCreateOfferCall binds one nested offer creation to the resolver that
+// answers for it, reading through the record seam the deal itself writes
+// through.
+//
+//nolint:ireturn // the call IS the product: a resolver named concretely here is exactly the thing that must not leave this package
+func NewCreateOfferCall(records datasource.SystemOfRecordProvider, cmd CreateOfferCommand) GovernedCall {
+	return bind[CreateOfferCommand](createOfferResolver{
+		parent: routedRecordTarget{records: records, recordType: string(datasource.EntityDeal)},
+	}, cmd)
+}
+
+type createOfferResolver struct {
+	// parent, not target: what this resolver reads and refuses is the DEAL
+	// the offer nests under, never an offer — the offer has no row yet.
+	parent routedRecordTarget
+}
+
+// Subject names the record TYPE the approval binds to, with NO id — exactly
+// the shape createResolver stages for every other create (command.go),
+// because an offer does not exist yet either. This is the fix for
+// gradionhq/margince-poc-v1#1046: the routed {id} is the deal, and pairing
+// target_entity_type=offer with the deal's id (stagedTargetByRoute's guess)
+// names a target that resolves to no row, or to an unrelated offer that
+// happens to share the id space. Naming no id at all is the only staged
+// target this create could honestly carry.
+func (r createOfferResolver) Subject(_ context.Context, cmd CreateOfferCommand) (StageInfo, error) {
+	return StageInfo{
+		TargetType: offerRecordType,
+		Summary:    fmt.Sprintf("%s on deal %s", describeGenericWrite("Create", offerRecordType, cmd.Fields), cmd.DealID),
+	}, nil
+}
+
+// Guards refuses, before anything is staged, the DEAL this offer would
+// nest under — unreadable (the row-scope miss) or held in another system
+// of record — the same two refusals patchResolver.Guards makes for its own
+// target. It does not validate `fields`: offer is not a create_record
+// createShapes entry and never will be (the type is created by its own
+// module, never through create_record's own write path), so there is
+// nothing here for rejectUnknownFields to be asked about — the same
+// door-dependent reasoning createResolver.Guards' own comment gives for
+// leaving that question to the door that owns the answer.
+func (r createOfferResolver) Guards(ctx context.Context, cmd CreateOfferCommand) error {
+	return r.parent.refuse(ctx, cmd.DealID)
+}
+
+// UpsertPartnerCommand is one partner-extension upsert, whichever door
+// asked for it — the routed organization id only. It does not carry the
+// partner fields (cert_status, margin_tier, …): neither Guards nor Subject
+// reads them, the same reasoning AddListMemberCommand's own doc gives.
+//
+// The route's own record_type annotation is `partner`, but there is no
+// `partner` id in the path and no row for it on the seam — {id} names the
+// ORGANIZATION, and the upsert IS a field patch on that organization's
+// partner extension, so the approval binds to the organization exactly as
+// commandsidecar.go's four resolvers do (organizationSidecarRecordType).
+type UpsertPartnerCommand struct {
+	ID ids.UUID
+}
+
+// NewUpsertPartnerCall binds one partner upsert to the resolver that
+// answers for it, reading through the record seam the organization itself
+// writes through.
+//
+//nolint:ireturn // the call IS the product: a resolver named concretely here is exactly the thing that must not leave this package
+func NewUpsertPartnerCall(records datasource.SystemOfRecordProvider, cmd UpsertPartnerCommand) GovernedCall {
+	return bind[UpsertPartnerCommand](upsertPartnerResolver{
+		target: routedRecordTarget{records: records, recordType: organizationSidecarRecordType},
+	}, cmd)
+}
+
+type upsertPartnerResolver struct {
+	target routedRecordTarget
+}
+
+// Subject names the ORGANIZATION the approval binds to (this type's own doc
+// says why), not the partner row this route's record_type annotation names.
+func (r upsertPartnerResolver) Subject(_ context.Context, cmd UpsertPartnerCommand) (StageInfo, error) {
+	return StageInfo{
+		TargetType: organizationSidecarRecordType,
+		TargetID:   cmd.ID,
+		Summary:    fmt.Sprintf("Upsert the partner extension on organization %s", cmd.ID),
+	}, nil
+}
+
+// Guards refuses the same two ways patchResolver.Guards refuses its own
+// target: an organization the caller cannot see, or one whose authority
+// lives in another system of record.
+func (r upsertPartnerResolver) Guards(ctx context.Context, cmd UpsertPartnerCommand) error {
+	return r.target.refuse(ctx, cmd.ID)
+}

--- a/backend/internal/modules/agents/commandnested.go
+++ b/backend/internal/modules/agents/commandnested.go
@@ -6,9 +6,14 @@ package agents
 // The seven remaining bespoke commands (gradionhq/margince-poc-v1#928 task 6):
 // a list member add, a tag apply, an offer line item add/update/remove, an
 // offer created under a parent deal, and a partner upsert. All seven are 🟢
-// auto_execute today, so Subject/Guards are unreachable on today's tiers —
-// but a tier floor (#982) tightening any of them makes this the answer a human
-// decides from, and the REST door has no other one to fall back on. For
+// auto_execute today, and six of them therefore never reach Subject/Guards on
+// today's tiers. upsertPartner is the exception, and it is one TODAY: the §2.1
+// human-edit-precedence split stages it through both of splitHumanOwnedUpdate's
+// branches, each of which resolves its staged target through this same command
+// (agentsplit.go, and restCommands' own entry in compose/agentcommand.go says
+// the same). A tier floor (#982) tightening any of the other six makes this the
+// answer a human decides from, and the REST door has no other one to fall back
+// on. For
 // createOffer that matters on its face: the routed {id} is the DEAL the offer
 // is created ON, not an offer id, so anything reading the target off the route
 // would pair target_entity_type=offer with a deal's id — a target that

--- a/backend/internal/modules/agents/commandnested_test.go
+++ b/backend/internal/modules/agents/commandnested_test.go
@@ -89,10 +89,9 @@ func TestOfferLineItemSummariesNameTheLineItem(t *testing.T) {
 // gradionhq/margince-poc-v1#1046: createOffer's staged target must carry NO
 // id. The routed {id} on POST /v1/deals/{id}/offers is the DEAL the offer
 // nests under, not an offer id — the offer does not exist yet — so pairing
-// target_entity_type=offer with that id (stagedTargetByRoute's guess) would
-// name a target that resolves to no row, or to an unrelated offer that
-// happens to share the id space. A resolver of its own is the fix; this is
-// the assertion that pins it.
+// target_entity_type=offer with that id would name a target that resolves to
+// no row, or to an unrelated offer that happens to share the id space. A
+// resolver of its own is the fix; this is the assertion that pins it.
 func TestCreateOfferStagesNoID(t *testing.T) {
 	dealID := ids.NewV7()
 	provider := stubRecordProvider{rec: stagedRecord(datasource.EntityDeal, dealID, true)}

--- a/backend/internal/modules/agents/commandnested_test.go
+++ b/backend/internal/modules/agents/commandnested_test.go
@@ -24,9 +24,10 @@ import (
 // OUTSIDE the record seam (list, tag and offer are none of them served) —
 // the id alone names the target, the same shape
 // TestCustomFieldCommandsStageAndAdmitOutsideTheRecordSeam proves for
-// retire/update-options. Guards is asked against a provider that fails
-// EVERY read, so a resolver that consulted the seam anyway fails here
-// rather than passing on a lenient stub.
+// retire/update-options. Guards is asked — StageSubject (command.go) runs it
+// before Subject, which is what makes this an ADMIT assertion and not only a
+// staging one — against a provider that fails EVERY read, so a resolver that
+// consulted the seam anyway fails here rather than passing on a lenient stub.
 func TestListTagAndLineItemCommandsStageAndAdmitOutsideTheRecordSeam(t *testing.T) {
 	id, lineItemID := ids.NewV7(), ids.NewV7()
 	cases := []struct {

--- a/backend/internal/modules/agents/commandnested_test.go
+++ b/backend/internal/modules/agents/commandnested_test.go
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package agents
+
+// The seven bespoke resolvers' own answers (commandnested.go): five stand
+// down the same way the six record-seam-unserved archivable types do
+// (list, tag, offer), and two — createOffer's parent deal, upsertPartner's
+// organization — refuse the same two ways patchResolver's own target does.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
+)
+
+// addListMember, applyTag and the three offer-line-item commands all stage
+// OUTSIDE the record seam (list, tag and offer are none of them served) —
+// the id alone names the target, the same shape
+// TestCustomFieldCommandsStageAndAdmitOutsideTheRecordSeam proves for
+// retire/update-options. Guards is asked against a provider that fails
+// EVERY read, so a resolver that consulted the seam anyway fails here
+// rather than passing on a lenient stub.
+func TestListTagAndLineItemCommandsStageAndAdmitOutsideTheRecordSeam(t *testing.T) {
+	id, lineItemID := ids.NewV7(), ids.NewV7()
+	cases := []struct {
+		name           string
+		call           GovernedCall
+		wantTargetType string
+	}{
+		{"add_list_member", NewAddListMemberCall(unreadableProvider{}, AddListMemberCommand{ID: id}), "list"},
+		{"apply_tag", NewApplyTagCall(unreadableProvider{}, ApplyTagCommand{ID: id}), "tag"},
+		{"add_offer_line_item", NewAddOfferLineItemCall(unreadableProvider{}, AddOfferLineItemCommand{ID: id}), "offer"},
+		{
+			"update_offer_line_item",
+			NewUpdateOfferLineItemCall(unreadableProvider{}, UpdateOfferLineItemCommand{ID: id, LineItemID: lineItemID}),
+			"offer",
+		},
+		{
+			"remove_offer_line_item",
+			NewRemoveOfferLineItemCall(unreadableProvider{}, RemoveOfferLineItemCommand{ID: id, LineItemID: lineItemID}),
+			"offer",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			info, err := StageSubject(context.Background(), c.call)
+			if err != nil {
+				t.Fatalf("staging outside the record seam answered %v, want it staged", err)
+			}
+			if info.TargetType != c.wantTargetType || info.TargetID != id {
+				t.Errorf("staged target = (%s,%s), want (%s,%s)", info.TargetType, info.TargetID, c.wantTargetType, id)
+			}
+		})
+	}
+}
+
+// The two offer-line-item commands with a second path operand name the LINE
+// ITEM in the summary, distinct per line the same way removeStakeholder's
+// own summary names PersonID.
+func TestOfferLineItemSummariesNameTheLineItem(t *testing.T) {
+	offerID, lineItemID := ids.NewV7(), ids.NewV7()
+
+	updateInfo, err := NewUpdateOfferLineItemCall(unreadableProvider{}, UpdateOfferLineItemCommand{ID: offerID, LineItemID: lineItemID}).
+		Subject(context.Background())
+	if err != nil {
+		t.Fatalf("naming the update subject answered %v, want no error", err)
+	}
+	if !strings.Contains(updateInfo.Summary, lineItemID.String()) {
+		t.Errorf("update summary %q does not name the line item", updateInfo.Summary)
+	}
+
+	removeInfo, err := NewRemoveOfferLineItemCall(unreadableProvider{}, RemoveOfferLineItemCommand{ID: offerID, LineItemID: lineItemID}).
+		Subject(context.Background())
+	if err != nil {
+		t.Fatalf("naming the remove subject answered %v, want no error", err)
+	}
+	if !strings.Contains(removeInfo.Summary, lineItemID.String()) {
+		t.Errorf("remove summary %q does not name the line item", removeInfo.Summary)
+	}
+}
+
+// gradionhq/margince-poc-v1#1046: createOffer's staged target must carry NO
+// id. The routed {id} on POST /v1/deals/{id}/offers is the DEAL the offer
+// nests under, not an offer id — the offer does not exist yet — so pairing
+// target_entity_type=offer with that id (stagedTargetByRoute's guess) would
+// name a target that resolves to no row, or to an unrelated offer that
+// happens to share the id space. A resolver of its own is the fix; this is
+// the assertion that pins it.
+func TestCreateOfferStagesNoID(t *testing.T) {
+	dealID := ids.NewV7()
+	provider := stubRecordProvider{rec: stagedRecord(datasource.EntityDeal, dealID, true)}
+	call := NewCreateOfferCall(provider, CreateOfferCommand{DealID: dealID, Fields: json.RawMessage(`{"currency":"EUR"}`)})
+
+	info, err := StageSubject(context.Background(), call)
+	if err != nil {
+		t.Fatalf("staging a nested offer create answered %v, want it staged", err)
+	}
+	if info.TargetType != "offer" {
+		t.Errorf("staged target_type = %q, want \"offer\"", info.TargetType)
+	}
+	if !info.TargetID.IsZero() {
+		t.Errorf("staged target_id = %s, want zero — the offer does not exist yet, and the routed id names "+
+			"the DEAL, not an offer (gradionhq/margince-poc-v1#1046)", info.TargetID)
+	}
+	if !strings.Contains(info.Summary, dealID.String()) {
+		t.Errorf("summary %q does not name the parent deal", info.Summary)
+	}
+}
+
+// createOffer's Guards reads the DEAL, not an offer — deal IS served by the
+// record seam, so this is a real read, unlike the five stand-downs above.
+func TestCreateOfferGuardsRefuseAnUnreadableDeal(t *testing.T) {
+	call := NewCreateOfferCall(unreadableProvider{}, CreateOfferCommand{DealID: ids.NewV7(), Fields: json.RawMessage(`{}`)})
+
+	if err := call.Guards(context.Background()); !errors.Is(err, apperrors.ErrNotFound) {
+		t.Fatalf("guarding an unreadable deal answered %v, want the row-scope miss", err)
+	}
+}
+
+// A deal held in another system of record is refused too — an approval for
+// it could never be released, the offer's create included.
+func TestCreateOfferGuardsRefuseADealHeldElsewhere(t *testing.T) {
+	call := NewCreateOfferCall(elsewhereProvider{}, CreateOfferCommand{DealID: ids.NewV7(), Fields: json.RawMessage(`{}`)})
+
+	if err := call.Guards(context.Background()); !errors.Is(err, apperrors.ErrUnsupportedBySoR) {
+		t.Fatalf("guarding a mirrored deal answered %v, want the unsupported-by-SoR refusal", err)
+	}
+}
+
+// A served, readable deal is admitted rather than refused.
+func TestCreateOfferGuardsAdmitAReadableDeal(t *testing.T) {
+	id := ids.NewV7()
+	provider := stubRecordProvider{rec: stagedRecord(datasource.EntityDeal, id, true)}
+	if err := NewCreateOfferCall(provider, CreateOfferCommand{DealID: id, Fields: json.RawMessage(`{}`)}).
+		Guards(context.Background()); err != nil {
+		t.Fatalf("guarding a readable, authoritative deal answered %v, want it admitted", err)
+	}
+}
+
+// upsertPartner stages the ORGANIZATION the route names, not a `partner`
+// row — the route's own record_type annotation says `partner`, but there
+// is no partner id in the path and no row for one on the seam.
+func TestUpsertPartnerStagesTheOrganization(t *testing.T) {
+	orgID := ids.NewV7()
+	provider := stubRecordProvider{rec: stagedRecord(datasource.EntityOrganization, orgID, true)}
+	call := NewUpsertPartnerCall(provider, UpsertPartnerCommand{ID: orgID})
+
+	info, err := StageSubject(context.Background(), call)
+	if err != nil {
+		t.Fatalf("staging a partner upsert answered %v, want it staged", err)
+	}
+	if info.TargetType != "organization" || info.TargetID != orgID {
+		t.Errorf("staged target = (%s,%s), want (organization,%s)", info.TargetType, info.TargetID, orgID)
+	}
+}
+
+// An organization the caller cannot see is refused before anything is
+// staged.
+func TestUpsertPartnerGuardsRefuseAnUnreadableOrganization(t *testing.T) {
+	call := NewUpsertPartnerCall(unreadableProvider{}, UpsertPartnerCommand{ID: ids.NewV7()})
+
+	if err := call.Guards(context.Background()); !errors.Is(err, apperrors.ErrNotFound) {
+		t.Fatalf("guarding an unreadable organization answered %v, want the row-scope miss", err)
+	}
+}
+
+// An organization held in another system of record is refused too.
+func TestUpsertPartnerGuardsRefuseAnOrganizationHeldElsewhere(t *testing.T) {
+	call := NewUpsertPartnerCall(elsewhereProvider{}, UpsertPartnerCommand{ID: ids.NewV7()})
+
+	if err := call.Guards(context.Background()); !errors.Is(err, apperrors.ErrUnsupportedBySoR) {
+		t.Fatalf("guarding a mirrored organization answered %v, want the unsupported-by-SoR refusal", err)
+	}
+}
+
+// A served, readable organization is admitted rather than refused.
+func TestUpsertPartnerGuardsAdmitAReadableOrganization(t *testing.T) {
+	id := ids.NewV7()
+	provider := stubRecordProvider{rec: stagedRecord(datasource.EntityOrganization, id, true)}
+	if err := NewUpsertPartnerCall(provider, UpsertPartnerCommand{ID: id}).Guards(context.Background()); err != nil {
+		t.Fatalf("guarding a readable, authoritative organization answered %v, want it admitted", err)
+	}
+}

--- a/backend/internal/modules/agents/commandrecord.go
+++ b/backend/internal/modules/agents/commandrecord.go
@@ -124,6 +124,19 @@ func (r *mergeResolver) halves(ctx context.Context, cmd MergeCommand) (survivor,
 // no longer covers it (version skew, re-stage). The summary names both halves,
 // because a merge that named only the survivor would ask a human to release a
 // change without saying what disappears into it.
+//
+// Naming the survivor as the target also decides WHO may release this, and
+// that bound is stated rather than left to be discovered. The approvals
+// surface scopes an inbox row by probing its target, so the approver is the
+// one whose row scope reaches B — and B alone. An approver who can see the
+// survivor but not the source still decides the source's archival, and reads
+// the source's name out of the summary above. Guards below proves the STAGER
+// can see both halves; nothing proves it of the approver, and closing that
+// needs a second, source-scoped probe the approvals surface has no shape for
+// (gradionhq/margince-poc-v1#1021 is where a target's visibility question
+// gets its home). Both alternatives are worse: binding to the source pins a
+// row the merge is about to archive, and binding to both is not something one
+// approval row can express.
 func (r *mergeResolver) Subject(ctx context.Context, cmd MergeCommand) (StageInfo, error) {
 	survivor, source, err := r.halves(ctx, cmd)
 	if err != nil {

--- a/backend/internal/modules/agents/commandrecord.go
+++ b/backend/internal/modules/agents/commandrecord.go
@@ -1,0 +1,228 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package agents
+
+// The two commands one tool serves through TWO contract operations
+// (gradionhq/margince-poc-v1#928 task 7): merge_records is mergePerson and
+// mergeOrganization, and enrich is scrapeCompany and deepReadCompany. Both are
+// where the seam has to carry meaning rather than shape.
+//
+// A merge is the only command here that names TWO records, and which is which
+// is the whole of it — one row survives and one is archived into it. The REST
+// route says so in two places at once: POST /v1/people/{id}/merge merges the
+// ROUTED person INTO the body's `target_id`, so the routed id is the record
+// merged FROM and the approval binds to the survivor named in the body. The
+// route walk this seam replaces reads the routed id and gets the wrong half.
+//
+// An enrich is the same tool at two depths, and the depth is the difference
+// between reading one page and crawling a whole site. It is carried as a TYPE
+// whose two values each decoder sets STRUCTURALLY — never parsed from a string
+// on the REST door — so there is no string for a mistranslation to hide in: a
+// descriptor that synthesized "site" for scrapeCompany would satisfy every
+// schema and describe a whole-site crawl to a human approving a one-page read.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
+)
+
+// MergeCommand is one merge, whichever door asked for it.
+//
+// SourceID is the record merged FROM — archived and redirected to the
+// survivor — and TargetID is the survivor everything relinks to. Both are
+// operands and both belong here: each is read separately, each carries its own
+// refusal, and the summary names both, so a command holding one of them could
+// only describe half of what happens.
+type MergeCommand struct {
+	RecordType string
+	SourceID   ids.UUID
+	TargetID   ids.UUID
+}
+
+// NewMergeCall binds one merge to the resolver that answers for it, reading
+// both halves through the record seam the merge itself writes through.
+//
+//nolint:ireturn // the call IS the product: a resolver named concretely here is exactly the thing that must not leave this package
+func NewMergeCall(records datasource.SystemOfRecordProvider, cmd MergeCommand) GovernedCall {
+	return bind[MergeCommand](&mergeResolver{records: records}, cmd)
+}
+
+type mergeResolver struct {
+	records datasource.SystemOfRecordProvider
+	// survivor and source are the two rows both questions rest on, remembered
+	// for the reason anchoredRecord (command.go) remembers one: Guards refuses
+	// on what the reads found and Subject pins and names it, and two readings
+	// are two moments those answers are free to describe differently. A pair
+	// rather than two anchoredRecords because the record TYPE is the command's,
+	// not the resolver's — a merge is person-to-person or org-to-org, and the
+	// type arrives with the call.
+	survivor datasource.Record
+	source   datasource.Record
+	read     bool
+}
+
+// errNothingToMerge refuses a merge of a record into itself: there is no
+// survivor and no archived half, so nothing an approval could describe.
+var errNothingToMerge = errors.New("source and target must differ")
+
+// mergeableTypeError refuses a record type that has no merge verb.
+func mergeableTypeError(recordType string) error {
+	return &BadArgsError{
+		Cause:    fmt.Errorf("record_type %q cannot be merged", recordType),
+		Guidance: "mergeable types are " + strings.Join(mergeableTypeNames(), ", "),
+	}
+}
+
+// halves reads both records the merge touches, once, in the order their
+// refusals are reported.
+func (r *mergeResolver) halves(ctx context.Context, cmd MergeCommand) (survivor, source datasource.Record, err error) {
+	if r.read {
+		return r.survivor, r.source, nil
+	}
+	if !mergeableTypes[cmd.RecordType] {
+		return datasource.Record{}, datasource.Record{}, mergeableTypeError(cmd.RecordType)
+	}
+	if cmd.SourceID == cmd.TargetID {
+		return datasource.Record{}, datasource.Record{}, &BadArgsError{Cause: errNothingToMerge}
+	}
+	entity := datasource.EntityType(cmd.RecordType)
+	survivor, err = r.records.Read(ctx, datasource.EntityRef{Type: entity, ID: cmd.TargetID})
+	if err != nil {
+		return datasource.Record{}, datasource.Record{}, err
+	}
+	source, err = r.records.Read(ctx, datasource.EntityRef{Type: entity, ID: cmd.SourceID})
+	if err != nil {
+		return datasource.Record{}, datasource.Record{}, err
+	}
+	r.survivor, r.source, r.read = survivor, source, true
+	return survivor, source, nil
+}
+
+// Subject pins the SURVIVOR's version: the human's yes is a judgment about
+// merging into B as it is now, so if B changes before redemption the approval
+// no longer covers it (version skew, re-stage). The summary names both halves,
+// because a merge that named only the survivor would ask a human to release a
+// change without saying what disappears into it.
+func (r *mergeResolver) Subject(ctx context.Context, cmd MergeCommand) (StageInfo, error) {
+	survivor, source, err := r.halves(ctx, cmd)
+	if err != nil {
+		return StageInfo{}, err
+	}
+	return StageInfo{
+		TargetType:    cmd.RecordType,
+		TargetID:      cmd.TargetID,
+		TargetVersion: &survivor.Version,
+		Summary: fmt.Sprintf("Merge %s %s into %s",
+			cmd.RecordType, recordLabel(source), recordLabel(survivor)),
+	}, nil
+}
+
+// Guards refuses a record type with no merge verb, a merge of a record into
+// itself, either half the caller cannot see, and either half whose authority
+// lives in another system of record.
+//
+// EVERY record this change touches, not just the pinned one, and named so a
+// human reading the refusal knows which half blocked it. Validating only the
+// survivor leaves the other half unguarded: the merge archives and relinks the
+// source, and an externally-held source under a locally-authoritative survivor
+// is still a change no approval could release.
+func (r *mergeResolver) Guards(ctx context.Context, cmd MergeCommand) error {
+	survivor, source, err := r.halves(ctx, cmd)
+	if err != nil {
+		return err
+	}
+	if err := refuseStagingElsewhere(survivor); err != nil {
+		return fmt.Errorf("the record being merged INTO: %w", err)
+	}
+	if err := refuseStagingElsewhere(source); err != nil {
+		return fmt.Errorf("the record being merged FROM: %w", err)
+	}
+	return nil
+}
+
+// EnrichCommand is one site read, whichever door asked for it.
+//
+// Depth is EnrichDepth rather than a string on purpose: the two contract
+// operations behind this one verb differ ONLY in it, and each door sets it
+// structurally — the tool from its own `depth` argument's closed vocabulary,
+// the REST door from which of its two routes was taken. A string here would be
+// a place for scrapeCompany to be described to a human as a whole-site crawl.
+//
+// URL is the caller's override for the organization's own domain, empty when
+// they named none.
+type EnrichCommand struct {
+	OrganizationID ids.UUID
+	URL            string
+	Depth          EnrichDepth
+}
+
+// NewEnrichCall binds one site read to the resolver that answers for it,
+// reading the organization through the record seam.
+//
+//nolint:ireturn // the call IS the product: a resolver named concretely here is exactly the thing that must not leave this package
+func NewEnrichCall(records datasource.SystemOfRecordProvider, cmd EnrichCommand) GovernedCall {
+	return bind[EnrichCommand](&enrichResolver{
+		organization: anchoredRecord{records: records, entityType: datasource.EntityOrganization},
+	}, cmd)
+}
+
+type enrichResolver struct {
+	organization anchoredRecord
+}
+
+// Subject names the ORGANIZATION the approval binds to, pins its version, and
+// says WHICH read is being released — a human approving a whole-site crawl
+// must not read a line that says "page".
+func (r *enrichResolver) Subject(ctx context.Context, cmd EnrichCommand) (StageInfo, error) {
+	rec, err := r.organization.row(ctx, cmd.OrganizationID)
+	if err != nil {
+		return StageInfo{}, err
+	}
+	target := "its own domain"
+	if cmd.URL != "" {
+		target = cmd.URL
+	}
+	return StageInfo{
+		TargetType:    string(datasource.EntityOrganization),
+		TargetID:      cmd.OrganizationID,
+		TargetVersion: &rec.Version,
+		Summary: fmt.Sprintf("Read %s from %s and propose enrichment of %s",
+			cmd.Depth, target, recordLabel(rec)),
+	}, nil
+}
+
+// Guards refuses an override URL the fetch could never take, then the
+// organization itself. It does not admit the DEPTH: the field's type is the
+// admission, so there is no invalid value for a check to answer.
+func (r *enrichResolver) Guards(ctx context.Context, cmd EnrichCommand) error {
+	if err := requireEnrichURL(cmd.URL); err != nil {
+		return err
+	}
+	return r.organization.refuse(ctx, cmd.OrganizationID)
+}
+
+// requireEnrichURL admits the override target: the same admission the REST
+// route applies before it fetches, so a scheme-less or hostless target is a bad
+// argument rather than a thin page. An empty override is not a target at all —
+// the organization's own domain is read instead — so it passes.
+//
+// One function for both doors: the staging path asks it through Guards above
+// and the execution path through readEnrichArgs, so a URL refused before a
+// human is asked cannot be a URL the approved retry fetches.
+func requireEnrichURL(raw string) error {
+	if raw == "" {
+		return nil
+	}
+	parsed, err := url.Parse(raw)
+	if err != nil || (parsed.Scheme != "http" && parsed.Scheme != "https") || parsed.Host == "" {
+		return &BadArgsError{Cause: fmt.Errorf("url %q must be an absolute http(s) URL", raw)}
+	}
+	return nil
+}

--- a/backend/internal/modules/agents/commandrecord.go
+++ b/backend/internal/modules/agents/commandrecord.go
@@ -63,6 +63,10 @@ type mergeResolver struct {
 	// rather than two anchoredRecords because the record TYPE is the command's,
 	// not the resolver's — a merge is person-to-person or org-to-org, and the
 	// type arrives with the call.
+	// seen is the command the pair was read for, so a resolver asked about a
+	// second merge reads that merge — the same key archiveResolver's own memo
+	// carries (command.go), for the same reason its doc gives.
+	seen     MergeCommand
 	survivor datasource.Record
 	source   datasource.Record
 	read     bool
@@ -72,8 +76,18 @@ type mergeResolver struct {
 // survivor and no archived half, so nothing an approval could describe.
 var errNothingToMerge = errors.New("source and target must differ")
 
-// mergeableTypeError refuses a record type that has no merge verb.
-func mergeableTypeError(recordType string) error {
+// requireMergeableType refuses a record type that has no merge verb.
+//
+// One function for both doors — predicate and sentence together: the staging
+// path asks it through Guards below and the execution path through
+// mergeRecords.Handle, which the approved retry re-enters without passing
+// Guards. Two copies of the membership test is how the two doors come to
+// disagree about which types can be merged, or to say it differently for the
+// same refusal.
+func requireMergeableType(recordType string) error {
+	if mergeableTypes[recordType] {
+		return nil
+	}
 	return &BadArgsError{
 		Cause:    fmt.Errorf("record_type %q cannot be merged", recordType),
 		Guidance: "mergeable types are " + strings.Join(mergeableTypeNames(), ", "),
@@ -83,11 +97,11 @@ func mergeableTypeError(recordType string) error {
 // halves reads both records the merge touches, once, in the order their
 // refusals are reported.
 func (r *mergeResolver) halves(ctx context.Context, cmd MergeCommand) (survivor, source datasource.Record, err error) {
-	if r.read {
+	if r.read && r.seen == cmd {
 		return r.survivor, r.source, nil
 	}
-	if !mergeableTypes[cmd.RecordType] {
-		return datasource.Record{}, datasource.Record{}, mergeableTypeError(cmd.RecordType)
+	if err := requireMergeableType(cmd.RecordType); err != nil {
+		return datasource.Record{}, datasource.Record{}, err
 	}
 	if cmd.SourceID == cmd.TargetID {
 		return datasource.Record{}, datasource.Record{}, &BadArgsError{Cause: errNothingToMerge}
@@ -101,7 +115,7 @@ func (r *mergeResolver) halves(ctx context.Context, cmd MergeCommand) (survivor,
 	if err != nil {
 		return datasource.Record{}, datasource.Record{}, err
 	}
-	r.survivor, r.source, r.read = survivor, source, true
+	r.seen, r.survivor, r.source, r.read = cmd, survivor, source, true
 	return survivor, source, nil
 }
 

--- a/backend/internal/modules/agents/commandsidecar.go
+++ b/backend/internal/modules/agents/commandsidecar.go
@@ -1,0 +1,270 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package agents
+
+// The organization-sidecar commands: a fact or a profile field is not a
+// column on `organization` itself but a row keyed by a SECOND path segment
+// (factKey, field) naming WHICH sidecar row the call is about. The approval
+// still binds to the organization — that is the row whose visibility and
+// system-of-record the human's decision actually depends on — but the
+// operand has to travel with the command, or two different facts on the same
+// organization become one indistinguishable call the moment either is
+// staged (gradionhq/margince-poc-v1#928 task 5: "their operand lives in the
+// URL path").
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
+)
+
+// organizationSidecarRecordType is every command in this file's fixed
+// target: the organization the fact or profile field belongs to. There is
+// nothing on the record seam a fact or profile field row could be pointed at
+// on its own.
+const organizationSidecarRecordType = string(datasource.EntityOrganization)
+
+// sidecarValue is the best-effort decode of an update's body for the inbox
+// line — the value replacing the machine's proposal. Guards never depends on
+// this: an unparseable or absent value still leaves the operand (factKey or
+// field) naming the approval, the same fallback recordLabel gives an
+// unlabelable record.
+func sidecarValue(fields json.RawMessage) string {
+	var body struct {
+		Value string `json:"value"`
+	}
+	//craft:ignore swallowed-errors best-effort value extraction for the summary; an unparseable body still leaves the operand naming the approval
+	_ = json.Unmarshal(fields, &body)
+	return body.Value
+}
+
+// ConfirmFactCommand is one organization fact confirmation, whichever door
+// asked for it. It carries no body: PO-AC-N-3 confirmation changes no value,
+// only who last agreed with the machine's extraction.
+type ConfirmFactCommand struct {
+	ID      ids.UUID
+	FactKey string
+}
+
+// NewConfirmFactCall binds one fact confirmation to the resolver that
+// answers for it, reading through the record seam the organization itself
+// writes through.
+//
+//nolint:ireturn // the call IS the product: a resolver named concretely here is exactly the thing that must not leave this package
+func NewConfirmFactCall(records datasource.SystemOfRecordProvider, cmd ConfirmFactCommand) GovernedCall {
+	return bind[ConfirmFactCommand](&confirmFactResolver{
+		target: routedRecordTarget{records: records, recordType: organizationSidecarRecordType},
+	}, cmd)
+}
+
+type confirmFactResolver struct {
+	target routedRecordTarget
+}
+
+// Subject names the ORGANIZATION the approval binds to — a fact has no row
+// of its own on the seam — with the fact key carried into the summary: two
+// facts confirmed on the same organization must not render as the same
+// inbox line.
+func (r *confirmFactResolver) Subject(ctx context.Context, cmd ConfirmFactCommand) (StageInfo, error) {
+	info := StageInfo{
+		TargetType: organizationSidecarRecordType,
+		TargetID:   cmd.ID,
+		Summary:    fmt.Sprintf("Confirm fact %s on organization %s", cmd.FactKey, cmd.ID),
+	}
+	rec, served, err := r.target.fetch(ctx, cmd.ID)
+	if err != nil {
+		return StageInfo{}, err
+	}
+	if !served {
+		return info, nil
+	}
+	info.Summary = fmt.Sprintf("Confirm fact %s on organization %s", cmd.FactKey, recordLabel(rec))
+	return info, nil
+}
+
+// Guards refuses, before anything is staged, an organization the caller
+// cannot see or whose authority lives elsewhere — the same two refusals
+// patchResolver.Guards makes for its own target. It does NOT check whether
+// FactKey names an existing fact: that read is the handler's, not this
+// approval's, and restating it here would be a second copy of the
+// executor's own rule.
+func (r *confirmFactResolver) Guards(ctx context.Context, cmd ConfirmFactCommand) error {
+	rec, served, err := r.target.fetch(ctx, cmd.ID)
+	if err != nil {
+		return err
+	}
+	if !served {
+		return nil
+	}
+	return refuseStagingElsewhere(rec)
+}
+
+// UpdateFactCommand is one organization fact correction, whichever door
+// asked for it.
+type UpdateFactCommand struct {
+	ID      ids.UUID
+	FactKey string
+	Fields  json.RawMessage
+}
+
+// NewUpdateFactCall binds one fact correction to the resolver that answers
+// for it.
+//
+//nolint:ireturn // the call IS the product: a resolver named concretely here is exactly the thing that must not leave this package
+func NewUpdateFactCall(records datasource.SystemOfRecordProvider, cmd UpdateFactCommand) GovernedCall {
+	return bind[UpdateFactCommand](&updateFactResolver{
+		target: routedRecordTarget{records: records, recordType: organizationSidecarRecordType},
+	}, cmd)
+}
+
+type updateFactResolver struct {
+	target routedRecordTarget
+}
+
+// Subject: the same shape as confirmFactResolver's, plus the corrected value
+// where the body parses — a correction's value IS the effect a human is
+// weighing, unlike a whole-record patch's arbitrary field set (tierfloor.go).
+func (r *updateFactResolver) Subject(ctx context.Context, cmd UpdateFactCommand) (StageInfo, error) {
+	info := StageInfo{
+		TargetType: organizationSidecarRecordType,
+		TargetID:   cmd.ID,
+		Summary:    fmt.Sprintf("Update fact %s on organization %s", cmd.FactKey, cmd.ID),
+	}
+	rec, served, err := r.target.fetch(ctx, cmd.ID)
+	if err != nil {
+		return StageInfo{}, err
+	}
+	label := cmd.ID.String()
+	if served {
+		label = recordLabel(rec)
+	}
+	info.Summary = fmt.Sprintf("Update fact %s on organization %s", cmd.FactKey, label)
+	if v := sidecarValue(cmd.Fields); v != "" {
+		info.Summary = fmt.Sprintf("%s to %q", info.Summary, v)
+	}
+	return info, nil
+}
+
+// Guards: the same two refusals as confirmFactResolver's. It does not
+// validate Fields — the value shape a fact write accepts is the handler's
+// business, not this approval's.
+func (r *updateFactResolver) Guards(ctx context.Context, cmd UpdateFactCommand) error {
+	rec, served, err := r.target.fetch(ctx, cmd.ID)
+	if err != nil {
+		return err
+	}
+	if !served {
+		return nil
+	}
+	return refuseStagingElsewhere(rec)
+}
+
+// ConfirmProfileFieldCommand is one organization profile-field confirmation,
+// whichever door asked for it — Field is the closed-vocabulary profile-field
+// key (`display_name`, `icp`, …), never a fact key.
+type ConfirmProfileFieldCommand struct {
+	ID    ids.UUID
+	Field string
+}
+
+// NewConfirmProfileFieldCall binds one profile-field confirmation to the
+// resolver that answers for it.
+//
+//nolint:ireturn // the call IS the product: a resolver named concretely here is exactly the thing that must not leave this package
+func NewConfirmProfileFieldCall(records datasource.SystemOfRecordProvider, cmd ConfirmProfileFieldCommand) GovernedCall {
+	return bind[ConfirmProfileFieldCommand](&confirmProfileFieldResolver{
+		target: routedRecordTarget{records: records, recordType: organizationSidecarRecordType},
+	}, cmd)
+}
+
+type confirmProfileFieldResolver struct {
+	target routedRecordTarget
+}
+
+// Subject, Guards: the same shape as confirmFactResolver's, naming Field
+// instead of FactKey as the summary's operand.
+func (r *confirmProfileFieldResolver) Subject(ctx context.Context, cmd ConfirmProfileFieldCommand) (StageInfo, error) {
+	info := StageInfo{
+		TargetType: organizationSidecarRecordType,
+		TargetID:   cmd.ID,
+		Summary:    fmt.Sprintf("Confirm profile field %s on organization %s", cmd.Field, cmd.ID),
+	}
+	rec, served, err := r.target.fetch(ctx, cmd.ID)
+	if err != nil {
+		return StageInfo{}, err
+	}
+	if !served {
+		return info, nil
+	}
+	info.Summary = fmt.Sprintf("Confirm profile field %s on organization %s", cmd.Field, recordLabel(rec))
+	return info, nil
+}
+
+func (r *confirmProfileFieldResolver) Guards(ctx context.Context, cmd ConfirmProfileFieldCommand) error {
+	rec, served, err := r.target.fetch(ctx, cmd.ID)
+	if err != nil {
+		return err
+	}
+	if !served {
+		return nil
+	}
+	return refuseStagingElsewhere(rec)
+}
+
+// UpdateProfileFieldCommand is one organization profile-field correction,
+// whichever door asked for it.
+type UpdateProfileFieldCommand struct {
+	ID     ids.UUID
+	Field  string
+	Fields json.RawMessage
+}
+
+// NewUpdateProfileFieldCall binds one profile-field correction to the
+// resolver that answers for it.
+//
+//nolint:ireturn // the call IS the product: a resolver named concretely here is exactly the thing that must not leave this package
+func NewUpdateProfileFieldCall(records datasource.SystemOfRecordProvider, cmd UpdateProfileFieldCommand) GovernedCall {
+	return bind[UpdateProfileFieldCommand](&updateProfileFieldResolver{
+		target: routedRecordTarget{records: records, recordType: organizationSidecarRecordType},
+	}, cmd)
+}
+
+type updateProfileFieldResolver struct {
+	target routedRecordTarget
+}
+
+func (r *updateProfileFieldResolver) Subject(ctx context.Context, cmd UpdateProfileFieldCommand) (StageInfo, error) {
+	info := StageInfo{
+		TargetType: organizationSidecarRecordType,
+		TargetID:   cmd.ID,
+		Summary:    fmt.Sprintf("Update profile field %s on organization %s", cmd.Field, cmd.ID),
+	}
+	rec, served, err := r.target.fetch(ctx, cmd.ID)
+	if err != nil {
+		return StageInfo{}, err
+	}
+	label := cmd.ID.String()
+	if served {
+		label = recordLabel(rec)
+	}
+	info.Summary = fmt.Sprintf("Update profile field %s on organization %s", cmd.Field, label)
+	if v := sidecarValue(cmd.Fields); v != "" {
+		info.Summary = fmt.Sprintf("%s to %q", info.Summary, v)
+	}
+	return info, nil
+}
+
+func (r *updateProfileFieldResolver) Guards(ctx context.Context, cmd UpdateProfileFieldCommand) error {
+	rec, served, err := r.target.fetch(ctx, cmd.ID)
+	if err != nil {
+		return err
+	}
+	if !served {
+		return nil
+	}
+	return refuseStagingElsewhere(rec)
+}

--- a/backend/internal/modules/agents/commandsidecar.go
+++ b/backend/internal/modules/agents/commandsidecar.go
@@ -51,10 +51,12 @@ type confirmFactResolver struct {
 }
 
 // Subject names the ORGANIZATION the approval binds to — a fact has no row
-// of its own on the seam — with the fact key carried into the summary: two
-// facts confirmed on the same organization must not render as the same
-// inbox line. It reads nothing: unlike archiveResolver's, there is no
-// per-record label to compose (routedRecordTarget's own doc says why).
+// of its own on the seam — with the fact key carried into the summary: the
+// door-agnostic line GovernedCall.Subject owes this operation, distinct per
+// fact even though no door renders it today (REST takes its own line from
+// restSummary; no tool reaches this command at all — agentgatestaging.go).
+// It reads nothing: unlike archiveResolver's, there is no per-record label
+// to compose (routedRecordTarget's own doc says why).
 func (r confirmFactResolver) Subject(_ context.Context, cmd ConfirmFactCommand) (StageInfo, error) {
 	return StageInfo{
 		TargetType: organizationSidecarRecordType,
@@ -74,7 +76,12 @@ func (r confirmFactResolver) Guards(ctx context.Context, cmd ConfirmFactCommand)
 }
 
 // UpdateFactCommand is one organization fact correction, whichever door
-// asked for it.
+// asked for it — the routed organization id and the fact key being
+// corrected. It does NOT carry the corrected value: neither Guards nor
+// Subject reads one (the body travels separately, into diff_hash, and
+// nothing here renders it — see Subject's own doc), so a field with no
+// reader is not carried, the same call task 4's review made for
+// PatchCommand.IfVersion.
 type UpdateFactCommand struct {
 	ID      ids.UUID
 	FactKey string
@@ -144,7 +151,9 @@ func (r confirmProfileFieldResolver) Guards(ctx context.Context, cmd ConfirmProf
 }
 
 // UpdateProfileFieldCommand is one organization profile-field correction,
-// whichever door asked for it.
+// whichever door asked for it — the routed organization id and the field
+// being corrected. It does not carry the corrected value, the same reason
+// UpdateFactCommand's own doc gives.
 type UpdateProfileFieldCommand struct {
 	ID    ids.UUID
 	Field string

--- a/backend/internal/modules/agents/commandsidecar.go
+++ b/backend/internal/modules/agents/commandsidecar.go
@@ -15,7 +15,6 @@ package agents
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
@@ -27,20 +26,6 @@ import (
 // nothing on the record seam a fact or profile field row could be pointed at
 // on its own.
 const organizationSidecarRecordType = string(datasource.EntityOrganization)
-
-// sidecarValue is the best-effort decode of an update's body for the inbox
-// line — the value replacing the machine's proposal. Guards never depends on
-// this: an unparseable or absent value still leaves the operand (factKey or
-// field) naming the approval, the same fallback recordLabel gives an
-// unlabelable record.
-func sidecarValue(fields json.RawMessage) string {
-	var body struct {
-		Value string `json:"value"`
-	}
-	//craft:ignore swallowed-errors best-effort value extraction for the summary; an unparseable body still leaves the operand naming the approval
-	_ = json.Unmarshal(fields, &body)
-	return body.Value
-}
 
 // ConfirmFactCommand is one organization fact confirmation, whichever door
 // asked for it. It carries no body: PO-AC-N-3 confirmation changes no value,
@@ -56,7 +41,7 @@ type ConfirmFactCommand struct {
 //
 //nolint:ireturn // the call IS the product: a resolver named concretely here is exactly the thing that must not leave this package
 func NewConfirmFactCall(records datasource.SystemOfRecordProvider, cmd ConfirmFactCommand) GovernedCall {
-	return bind[ConfirmFactCommand](&confirmFactResolver{
+	return bind[ConfirmFactCommand](confirmFactResolver{
 		target: routedRecordTarget{records: records, recordType: organizationSidecarRecordType},
 	}, cmd)
 }
@@ -68,22 +53,14 @@ type confirmFactResolver struct {
 // Subject names the ORGANIZATION the approval binds to — a fact has no row
 // of its own on the seam — with the fact key carried into the summary: two
 // facts confirmed on the same organization must not render as the same
-// inbox line.
-func (r *confirmFactResolver) Subject(ctx context.Context, cmd ConfirmFactCommand) (StageInfo, error) {
-	info := StageInfo{
+// inbox line. It reads nothing: unlike archiveResolver's, there is no
+// per-record label to compose (routedRecordTarget's own doc says why).
+func (r confirmFactResolver) Subject(_ context.Context, cmd ConfirmFactCommand) (StageInfo, error) {
+	return StageInfo{
 		TargetType: organizationSidecarRecordType,
 		TargetID:   cmd.ID,
 		Summary:    fmt.Sprintf("Confirm fact %s on organization %s", cmd.FactKey, cmd.ID),
-	}
-	rec, served, err := r.target.fetch(ctx, cmd.ID)
-	if err != nil {
-		return StageInfo{}, err
-	}
-	if !served {
-		return info, nil
-	}
-	info.Summary = fmt.Sprintf("Confirm fact %s on organization %s", cmd.FactKey, recordLabel(rec))
-	return info, nil
+	}, nil
 }
 
 // Guards refuses, before anything is staged, an organization the caller
@@ -92,15 +69,8 @@ func (r *confirmFactResolver) Subject(ctx context.Context, cmd ConfirmFactComman
 // FactKey names an existing fact: that read is the handler's, not this
 // approval's, and restating it here would be a second copy of the
 // executor's own rule.
-func (r *confirmFactResolver) Guards(ctx context.Context, cmd ConfirmFactCommand) error {
-	rec, served, err := r.target.fetch(ctx, cmd.ID)
-	if err != nil {
-		return err
-	}
-	if !served {
-		return nil
-	}
-	return refuseStagingElsewhere(rec)
+func (r confirmFactResolver) Guards(ctx context.Context, cmd ConfirmFactCommand) error {
+	return r.target.refuse(ctx, cmd.ID)
 }
 
 // UpdateFactCommand is one organization fact correction, whichever door
@@ -108,7 +78,6 @@ func (r *confirmFactResolver) Guards(ctx context.Context, cmd ConfirmFactCommand
 type UpdateFactCommand struct {
 	ID      ids.UUID
 	FactKey string
-	Fields  json.RawMessage
 }
 
 // NewUpdateFactCall binds one fact correction to the resolver that answers
@@ -116,7 +85,7 @@ type UpdateFactCommand struct {
 //
 //nolint:ireturn // the call IS the product: a resolver named concretely here is exactly the thing that must not leave this package
 func NewUpdateFactCall(records datasource.SystemOfRecordProvider, cmd UpdateFactCommand) GovernedCall {
-	return bind[UpdateFactCommand](&updateFactResolver{
+	return bind[UpdateFactCommand](updateFactResolver{
 		target: routedRecordTarget{records: records, recordType: organizationSidecarRecordType},
 	}, cmd)
 }
@@ -125,42 +94,17 @@ type updateFactResolver struct {
 	target routedRecordTarget
 }
 
-// Subject: the same shape as confirmFactResolver's, plus the corrected value
-// where the body parses — a correction's value IS the effect a human is
-// weighing, unlike a whole-record patch's arbitrary field set (tierfloor.go).
-func (r *updateFactResolver) Subject(ctx context.Context, cmd UpdateFactCommand) (StageInfo, error) {
-	info := StageInfo{
+// Subject, Guards: the same shape as confirmFactResolver's.
+func (r updateFactResolver) Subject(_ context.Context, cmd UpdateFactCommand) (StageInfo, error) {
+	return StageInfo{
 		TargetType: organizationSidecarRecordType,
 		TargetID:   cmd.ID,
 		Summary:    fmt.Sprintf("Update fact %s on organization %s", cmd.FactKey, cmd.ID),
-	}
-	rec, served, err := r.target.fetch(ctx, cmd.ID)
-	if err != nil {
-		return StageInfo{}, err
-	}
-	label := cmd.ID.String()
-	if served {
-		label = recordLabel(rec)
-	}
-	info.Summary = fmt.Sprintf("Update fact %s on organization %s", cmd.FactKey, label)
-	if v := sidecarValue(cmd.Fields); v != "" {
-		info.Summary = fmt.Sprintf("%s to %q", info.Summary, v)
-	}
-	return info, nil
+	}, nil
 }
 
-// Guards: the same two refusals as confirmFactResolver's. It does not
-// validate Fields — the value shape a fact write accepts is the handler's
-// business, not this approval's.
-func (r *updateFactResolver) Guards(ctx context.Context, cmd UpdateFactCommand) error {
-	rec, served, err := r.target.fetch(ctx, cmd.ID)
-	if err != nil {
-		return err
-	}
-	if !served {
-		return nil
-	}
-	return refuseStagingElsewhere(rec)
+func (r updateFactResolver) Guards(ctx context.Context, cmd UpdateFactCommand) error {
+	return r.target.refuse(ctx, cmd.ID)
 }
 
 // ConfirmProfileFieldCommand is one organization profile-field confirmation,
@@ -176,7 +120,7 @@ type ConfirmProfileFieldCommand struct {
 //
 //nolint:ireturn // the call IS the product: a resolver named concretely here is exactly the thing that must not leave this package
 func NewConfirmProfileFieldCall(records datasource.SystemOfRecordProvider, cmd ConfirmProfileFieldCommand) GovernedCall {
-	return bind[ConfirmProfileFieldCommand](&confirmProfileFieldResolver{
+	return bind[ConfirmProfileFieldCommand](confirmProfileFieldResolver{
 		target: routedRecordTarget{records: records, recordType: organizationSidecarRecordType},
 	}, cmd)
 }
@@ -187,40 +131,23 @@ type confirmProfileFieldResolver struct {
 
 // Subject, Guards: the same shape as confirmFactResolver's, naming Field
 // instead of FactKey as the summary's operand.
-func (r *confirmProfileFieldResolver) Subject(ctx context.Context, cmd ConfirmProfileFieldCommand) (StageInfo, error) {
-	info := StageInfo{
+func (r confirmProfileFieldResolver) Subject(_ context.Context, cmd ConfirmProfileFieldCommand) (StageInfo, error) {
+	return StageInfo{
 		TargetType: organizationSidecarRecordType,
 		TargetID:   cmd.ID,
 		Summary:    fmt.Sprintf("Confirm profile field %s on organization %s", cmd.Field, cmd.ID),
-	}
-	rec, served, err := r.target.fetch(ctx, cmd.ID)
-	if err != nil {
-		return StageInfo{}, err
-	}
-	if !served {
-		return info, nil
-	}
-	info.Summary = fmt.Sprintf("Confirm profile field %s on organization %s", cmd.Field, recordLabel(rec))
-	return info, nil
+	}, nil
 }
 
-func (r *confirmProfileFieldResolver) Guards(ctx context.Context, cmd ConfirmProfileFieldCommand) error {
-	rec, served, err := r.target.fetch(ctx, cmd.ID)
-	if err != nil {
-		return err
-	}
-	if !served {
-		return nil
-	}
-	return refuseStagingElsewhere(rec)
+func (r confirmProfileFieldResolver) Guards(ctx context.Context, cmd ConfirmProfileFieldCommand) error {
+	return r.target.refuse(ctx, cmd.ID)
 }
 
 // UpdateProfileFieldCommand is one organization profile-field correction,
 // whichever door asked for it.
 type UpdateProfileFieldCommand struct {
-	ID     ids.UUID
-	Field  string
-	Fields json.RawMessage
+	ID    ids.UUID
+	Field string
 }
 
 // NewUpdateProfileFieldCall binds one profile-field correction to the
@@ -228,7 +155,7 @@ type UpdateProfileFieldCommand struct {
 //
 //nolint:ireturn // the call IS the product: a resolver named concretely here is exactly the thing that must not leave this package
 func NewUpdateProfileFieldCall(records datasource.SystemOfRecordProvider, cmd UpdateProfileFieldCommand) GovernedCall {
-	return bind[UpdateProfileFieldCommand](&updateProfileFieldResolver{
+	return bind[UpdateProfileFieldCommand](updateProfileFieldResolver{
 		target: routedRecordTarget{records: records, recordType: organizationSidecarRecordType},
 	}, cmd)
 }
@@ -237,34 +164,14 @@ type updateProfileFieldResolver struct {
 	target routedRecordTarget
 }
 
-func (r *updateProfileFieldResolver) Subject(ctx context.Context, cmd UpdateProfileFieldCommand) (StageInfo, error) {
-	info := StageInfo{
+func (r updateProfileFieldResolver) Subject(_ context.Context, cmd UpdateProfileFieldCommand) (StageInfo, error) {
+	return StageInfo{
 		TargetType: organizationSidecarRecordType,
 		TargetID:   cmd.ID,
 		Summary:    fmt.Sprintf("Update profile field %s on organization %s", cmd.Field, cmd.ID),
-	}
-	rec, served, err := r.target.fetch(ctx, cmd.ID)
-	if err != nil {
-		return StageInfo{}, err
-	}
-	label := cmd.ID.String()
-	if served {
-		label = recordLabel(rec)
-	}
-	info.Summary = fmt.Sprintf("Update profile field %s on organization %s", cmd.Field, label)
-	if v := sidecarValue(cmd.Fields); v != "" {
-		info.Summary = fmt.Sprintf("%s to %q", info.Summary, v)
-	}
-	return info, nil
+	}, nil
 }
 
-func (r *updateProfileFieldResolver) Guards(ctx context.Context, cmd UpdateProfileFieldCommand) error {
-	rec, served, err := r.target.fetch(ctx, cmd.ID)
-	if err != nil {
-		return err
-	}
-	if !served {
-		return nil
-	}
-	return refuseStagingElsewhere(rec)
+func (r updateProfileFieldResolver) Guards(ctx context.Context, cmd UpdateProfileFieldCommand) error {
+	return r.target.refuse(ctx, cmd.ID)
 }

--- a/backend/internal/modules/agents/commandsidecar_test.go
+++ b/backend/internal/modules/agents/commandsidecar_test.go
@@ -11,7 +11,6 @@ package agents
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"strings"
 	"testing"
@@ -22,12 +21,11 @@ import (
 )
 
 // Each sidecar command stages against the ORGANIZATION it routes through,
-// naming it in words (recordLabel), with the operand carried into the
-// summary — the property that keeps two facts, or two profile fields, on
-// one organization from rendering as one indistinguishable approval.
+// with the operand carried into the summary — the property that keeps two
+// facts, or two profile fields, on one organization from rendering as one
+// indistinguishable approval.
 func TestSidecarCommandsStageTheOrganizationWithTheOperandInTheSummary(t *testing.T) {
 	orgID := ids.NewV7()
-	provider := stubRecordProvider{rec: stagedRecord(datasource.EntityOrganization, orgID, true)}
 	cases := []struct {
 		name        string
 		call        GovernedCall
@@ -35,30 +33,35 @@ func TestSidecarCommandsStageTheOrganizationWithTheOperandInTheSummary(t *testin
 	}{
 		{
 			"confirm_fact",
-			NewConfirmFactCall(provider, ConfirmFactCommand{ID: orgID, FactKey: "named_customer:acme-inc"}),
+			NewConfirmFactCall(unreadableProvider{}, ConfirmFactCommand{ID: orgID, FactKey: "named_customer:acme-inc"}),
 			"named_customer:acme-inc",
 		},
 		{
 			"update_fact",
-			NewUpdateFactCall(provider, UpdateFactCommand{ID: orgID, FactKey: "named_customer:acme-inc", Fields: json.RawMessage(`{"value":"Acme Inc"}`)}),
+			NewUpdateFactCall(unreadableProvider{}, UpdateFactCommand{ID: orgID, FactKey: "named_customer:acme-inc"}),
 			"named_customer:acme-inc",
 		},
 		{
 			"confirm_profile_field",
-			NewConfirmProfileFieldCall(provider, ConfirmProfileFieldCommand{ID: orgID, Field: "icp"}),
+			NewConfirmProfileFieldCall(unreadableProvider{}, ConfirmProfileFieldCommand{ID: orgID, Field: "icp"}),
 			"icp",
 		},
 		{
 			"update_profile_field",
-			NewUpdateProfileFieldCall(provider, UpdateProfileFieldCommand{ID: orgID, Field: "icp", Fields: json.RawMessage(`{"value":"Payments infra"}`)}),
+			NewUpdateProfileFieldCall(unreadableProvider{}, UpdateProfileFieldCommand{ID: orgID, Field: "icp"}),
 			"icp",
 		},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			info, err := StageSubject(context.Background(), c.call)
+			// call.Subject directly, not StageSubject: these fixtures answer every
+			// Read with not-found, so a Subject that (wrongly) tried to read the
+			// organization for a label would fail here — calling Subject alone
+			// (skipping Guards, unlike StageSubject) proves it needs no read to
+			// name the operand.
+			info, err := c.call.Subject(context.Background())
 			if err != nil {
-				t.Fatalf("staging answered %v, want it staged", err)
+				t.Fatalf("naming the subject answered %v, want no error — Subject reads nothing", err)
 			}
 			if info.TargetType != "organization" || info.TargetID != orgID {
 				t.Errorf("staged target = (%s,%s), want (organization,%s)", info.TargetType, info.TargetID, orgID)
@@ -67,37 +70,7 @@ func TestSidecarCommandsStageTheOrganizationWithTheOperandInTheSummary(t *testin
 				t.Errorf("summary %q does not name the operand %q — a human triaging the inbox cannot tell "+
 					"which fact or field they are deciding about", info.Summary, c.wantOperand)
 			}
-			if !strings.Contains(info.Summary, "Acme") {
-				t.Errorf("summary %q does not name the organization — an id alone tells an approver nothing "+
-					"about which organization is affected", info.Summary)
-			}
 		})
-	}
-}
-
-// A correction's summary names the new value too, where the body parses —
-// the value IS the effect a human is weighing, unlike a whole-record patch's
-// arbitrary field set.
-func TestSidecarUpdateCommandsNameTheCorrectedValue(t *testing.T) {
-	orgID := ids.NewV7()
-	provider := stubRecordProvider{rec: stagedRecord(datasource.EntityOrganization, orgID, true)}
-
-	factInfo, err := StageSubject(context.Background(),
-		NewUpdateFactCall(provider, UpdateFactCommand{ID: orgID, FactKey: "annual_revenue:2026", Fields: json.RawMessage(`{"value":"12000000"}`)}))
-	if err != nil {
-		t.Fatalf("staging a fact correction answered %v", err)
-	}
-	if !strings.Contains(factInfo.Summary, "12000000") {
-		t.Errorf("fact correction summary %q does not name the corrected value", factInfo.Summary)
-	}
-
-	fieldInfo, err := StageSubject(context.Background(),
-		NewUpdateProfileFieldCall(provider, UpdateProfileFieldCommand{ID: orgID, Field: "usp", Fields: json.RawMessage(`{"value":"Fastest onboarding"}`)}))
-	if err != nil {
-		t.Fatalf("staging a profile field correction answered %v", err)
-	}
-	if !strings.Contains(fieldInfo.Summary, "Fastest onboarding") {
-		t.Errorf("profile field correction summary %q does not name the corrected value", fieldInfo.Summary)
 	}
 }
 
@@ -111,9 +84,9 @@ func TestSidecarCommandsRefuseAnUnreadableOrganization(t *testing.T) {
 		call GovernedCall
 	}{
 		{"confirm_fact", NewConfirmFactCall(unreadableProvider{}, ConfirmFactCommand{ID: id, FactKey: "k"})},
-		{"update_fact", NewUpdateFactCall(unreadableProvider{}, UpdateFactCommand{ID: id, FactKey: "k", Fields: json.RawMessage(`{"value":"v"}`)})},
+		{"update_fact", NewUpdateFactCall(unreadableProvider{}, UpdateFactCommand{ID: id, FactKey: "k"})},
 		{"confirm_profile_field", NewConfirmProfileFieldCall(unreadableProvider{}, ConfirmProfileFieldCommand{ID: id, Field: "icp"})},
-		{"update_profile_field", NewUpdateProfileFieldCall(unreadableProvider{}, UpdateProfileFieldCommand{ID: id, Field: "icp", Fields: json.RawMessage(`{"value":"v"}`)})},
+		{"update_profile_field", NewUpdateProfileFieldCall(unreadableProvider{}, UpdateProfileFieldCommand{ID: id, Field: "icp"})},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -134,9 +107,9 @@ func TestSidecarCommandsRefuseAnOrganizationHeldElsewhere(t *testing.T) {
 		call GovernedCall
 	}{
 		{"confirm_fact", NewConfirmFactCall(elsewhereProvider{}, ConfirmFactCommand{ID: id, FactKey: "k"})},
-		{"update_fact", NewUpdateFactCall(elsewhereProvider{}, UpdateFactCommand{ID: id, FactKey: "k", Fields: json.RawMessage(`{"value":"v"}`)})},
+		{"update_fact", NewUpdateFactCall(elsewhereProvider{}, UpdateFactCommand{ID: id, FactKey: "k"})},
 		{"confirm_profile_field", NewConfirmProfileFieldCall(elsewhereProvider{}, ConfirmProfileFieldCommand{ID: id, Field: "icp"})},
-		{"update_profile_field", NewUpdateProfileFieldCall(elsewhereProvider{}, UpdateProfileFieldCommand{ID: id, Field: "icp", Fields: json.RawMessage(`{"value":"v"}`)})},
+		{"update_profile_field", NewUpdateProfileFieldCall(elsewhereProvider{}, UpdateProfileFieldCommand{ID: id, Field: "icp"})},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -147,19 +120,14 @@ func TestSidecarCommandsRefuseAnOrganizationHeldElsewhere(t *testing.T) {
 	}
 }
 
-// Both Guards and Subject read the SAME row: a fact or profile-field
-// correction asks two questions of the organization (its authority, its
-// label), and answering them from two different reads risks a record that
-// changed between them describing itself two ways.
-func TestSidecarCommandsReadTheirTargetOnce(t *testing.T) {
+// A served, readable organization is admitted rather than refused — Guards'
+// counterpart to the two refusal tests above, proving the happy path through
+// the same seam rather than only its failure modes.
+func TestSidecarCommandsAdmitAReadableOrganization(t *testing.T) {
 	id := ids.NewV7()
-	provider := &countingProvider{}
-	call := NewUpdateFactCall(provider, UpdateFactCommand{ID: id, FactKey: "k", Fields: json.RawMessage(`{"value":"v"}`)})
-
-	if _, err := StageSubject(context.Background(), call); err != nil {
-		t.Fatalf("staging answered %v, want it staged", err)
-	}
-	if provider.reads != 1 {
-		t.Errorf("the resolver read its target %d times, want 1", provider.reads)
+	provider := stubRecordProvider{rec: stagedRecord(datasource.EntityOrganization, id, true)}
+	call := NewConfirmFactCall(provider, ConfirmFactCommand{ID: id, FactKey: "k"})
+	if err := call.Guards(context.Background()); err != nil {
+		t.Fatalf("guarding a readable, authoritative organization answered %v, want it admitted", err)
 	}
 }

--- a/backend/internal/modules/agents/commandsidecar_test.go
+++ b/backend/internal/modules/agents/commandsidecar_test.go
@@ -5,9 +5,9 @@ package agents
 
 // The organization-sidecar resolvers (commandsidecar.go): the approval binds
 // to the organization, refuses the same two ways patchResolver's own target
-// does, and the summary names the operand — the fact key or the profile
-// field — so two of either on the same organization never render as the
-// same inbox line.
+// does, and Subject's summary names the operand — the fact key or the
+// profile field — the door-agnostic line GovernedCall.Subject owes this
+// operation, distinct per operand even though no door renders it today.
 
 import (
 	"context"
@@ -67,8 +67,8 @@ func TestSidecarCommandsStageTheOrganizationWithTheOperandInTheSummary(t *testin
 				t.Errorf("staged target = (%s,%s), want (organization,%s)", info.TargetType, info.TargetID, orgID)
 			}
 			if !strings.Contains(info.Summary, c.wantOperand) {
-				t.Errorf("summary %q does not name the operand %q — a human triaging the inbox cannot tell "+
-					"which fact or field they are deciding about", info.Summary, c.wantOperand)
+				t.Errorf("summary %q does not name the operand %q — Subject owes a line distinct per fact or "+
+					"field even though no door renders it today", info.Summary, c.wantOperand)
 			}
 		})
 	}

--- a/backend/internal/modules/agents/commandsidecar_test.go
+++ b/backend/internal/modules/agents/commandsidecar_test.go
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package agents
+
+// The organization-sidecar resolvers (commandsidecar.go): the approval binds
+// to the organization, refuses the same two ways patchResolver's own target
+// does, and the summary names the operand — the fact key or the profile
+// field — so two of either on the same organization never render as the
+// same inbox line.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
+)
+
+// Each sidecar command stages against the ORGANIZATION it routes through,
+// naming it in words (recordLabel), with the operand carried into the
+// summary — the property that keeps two facts, or two profile fields, on
+// one organization from rendering as one indistinguishable approval.
+func TestSidecarCommandsStageTheOrganizationWithTheOperandInTheSummary(t *testing.T) {
+	orgID := ids.NewV7()
+	provider := stubRecordProvider{rec: stagedRecord(datasource.EntityOrganization, orgID, true)}
+	cases := []struct {
+		name        string
+		call        GovernedCall
+		wantOperand string
+	}{
+		{
+			"confirm_fact",
+			NewConfirmFactCall(provider, ConfirmFactCommand{ID: orgID, FactKey: "named_customer:acme-inc"}),
+			"named_customer:acme-inc",
+		},
+		{
+			"update_fact",
+			NewUpdateFactCall(provider, UpdateFactCommand{ID: orgID, FactKey: "named_customer:acme-inc", Fields: json.RawMessage(`{"value":"Acme Inc"}`)}),
+			"named_customer:acme-inc",
+		},
+		{
+			"confirm_profile_field",
+			NewConfirmProfileFieldCall(provider, ConfirmProfileFieldCommand{ID: orgID, Field: "icp"}),
+			"icp",
+		},
+		{
+			"update_profile_field",
+			NewUpdateProfileFieldCall(provider, UpdateProfileFieldCommand{ID: orgID, Field: "icp", Fields: json.RawMessage(`{"value":"Payments infra"}`)}),
+			"icp",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			info, err := StageSubject(context.Background(), c.call)
+			if err != nil {
+				t.Fatalf("staging answered %v, want it staged", err)
+			}
+			if info.TargetType != "organization" || info.TargetID != orgID {
+				t.Errorf("staged target = (%s,%s), want (organization,%s)", info.TargetType, info.TargetID, orgID)
+			}
+			if !strings.Contains(info.Summary, c.wantOperand) {
+				t.Errorf("summary %q does not name the operand %q — a human triaging the inbox cannot tell "+
+					"which fact or field they are deciding about", info.Summary, c.wantOperand)
+			}
+			if !strings.Contains(info.Summary, "Acme") {
+				t.Errorf("summary %q does not name the organization — an id alone tells an approver nothing "+
+					"about which organization is affected", info.Summary)
+			}
+		})
+	}
+}
+
+// A correction's summary names the new value too, where the body parses —
+// the value IS the effect a human is weighing, unlike a whole-record patch's
+// arbitrary field set.
+func TestSidecarUpdateCommandsNameTheCorrectedValue(t *testing.T) {
+	orgID := ids.NewV7()
+	provider := stubRecordProvider{rec: stagedRecord(datasource.EntityOrganization, orgID, true)}
+
+	factInfo, err := StageSubject(context.Background(),
+		NewUpdateFactCall(provider, UpdateFactCommand{ID: orgID, FactKey: "annual_revenue:2026", Fields: json.RawMessage(`{"value":"12000000"}`)}))
+	if err != nil {
+		t.Fatalf("staging a fact correction answered %v", err)
+	}
+	if !strings.Contains(factInfo.Summary, "12000000") {
+		t.Errorf("fact correction summary %q does not name the corrected value", factInfo.Summary)
+	}
+
+	fieldInfo, err := StageSubject(context.Background(),
+		NewUpdateProfileFieldCall(provider, UpdateProfileFieldCommand{ID: orgID, Field: "usp", Fields: json.RawMessage(`{"value":"Fastest onboarding"}`)}))
+	if err != nil {
+		t.Fatalf("staging a profile field correction answered %v", err)
+	}
+	if !strings.Contains(fieldInfo.Summary, "Fastest onboarding") {
+		t.Errorf("profile field correction summary %q does not name the corrected value", fieldInfo.Summary)
+	}
+}
+
+// An organization the caller cannot see is refused before anything is
+// staged, for all four sidecar commands — the row-scope miss, not merely a
+// generic error.
+func TestSidecarCommandsRefuseAnUnreadableOrganization(t *testing.T) {
+	id := ids.NewV7()
+	cases := []struct {
+		name string
+		call GovernedCall
+	}{
+		{"confirm_fact", NewConfirmFactCall(unreadableProvider{}, ConfirmFactCommand{ID: id, FactKey: "k"})},
+		{"update_fact", NewUpdateFactCall(unreadableProvider{}, UpdateFactCommand{ID: id, FactKey: "k", Fields: json.RawMessage(`{"value":"v"}`)})},
+		{"confirm_profile_field", NewConfirmProfileFieldCall(unreadableProvider{}, ConfirmProfileFieldCommand{ID: id, Field: "icp"})},
+		{"update_profile_field", NewUpdateProfileFieldCall(unreadableProvider{}, UpdateProfileFieldCommand{ID: id, Field: "icp", Fields: json.RawMessage(`{"value":"v"}`)})},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if err := c.call.Guards(context.Background()); !errors.Is(err, apperrors.ErrNotFound) {
+				t.Errorf("guarding an unreadable organization answered %v, want the row-scope miss", err)
+			}
+		})
+	}
+}
+
+// An organization held in another system of record is refused too — the
+// decidability probe and the version pin both read our own tables, which
+// the organization has no row in.
+func TestSidecarCommandsRefuseAnOrganizationHeldElsewhere(t *testing.T) {
+	id := ids.NewV7()
+	cases := []struct {
+		name string
+		call GovernedCall
+	}{
+		{"confirm_fact", NewConfirmFactCall(elsewhereProvider{}, ConfirmFactCommand{ID: id, FactKey: "k"})},
+		{"update_fact", NewUpdateFactCall(elsewhereProvider{}, UpdateFactCommand{ID: id, FactKey: "k", Fields: json.RawMessage(`{"value":"v"}`)})},
+		{"confirm_profile_field", NewConfirmProfileFieldCall(elsewhereProvider{}, ConfirmProfileFieldCommand{ID: id, Field: "icp"})},
+		{"update_profile_field", NewUpdateProfileFieldCall(elsewhereProvider{}, UpdateProfileFieldCommand{ID: id, Field: "icp", Fields: json.RawMessage(`{"value":"v"}`)})},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if err := c.call.Guards(context.Background()); !errors.Is(err, apperrors.ErrUnsupportedBySoR) {
+				t.Errorf("guarding a mirrored organization answered %v, want the unsupported-by-SoR refusal", err)
+			}
+		})
+	}
+}
+
+// Both Guards and Subject read the SAME row: a fact or profile-field
+// correction asks two questions of the organization (its authority, its
+// label), and answering them from two different reads risks a record that
+// changed between them describing itself two ways.
+func TestSidecarCommandsReadTheirTargetOnce(t *testing.T) {
+	id := ids.NewV7()
+	provider := &countingProvider{}
+	call := NewUpdateFactCall(provider, UpdateFactCommand{ID: id, FactKey: "k", Fields: json.RawMessage(`{"value":"v"}`)})
+
+	if _, err := StageSubject(context.Background(), call); err != nil {
+		t.Fatalf("staging answered %v, want it staged", err)
+	}
+	if provider.reads != 1 {
+		t.Errorf("the resolver read its target %d times, want 1", provider.reads)
+	}
+}

--- a/backend/internal/modules/agents/commandsingle_test.go
+++ b/backend/internal/modules/agents/commandsingle_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -510,4 +511,36 @@ func linkFixture(p *tallyingProvider) ids.UUID {
 	ref := datasource.EntityRef{Type: datasource.EntityOrganization, ID: id}
 	p.records[ref] = nativeRecord(datasource.Record{Ref: ref, Fields: json.RawMessage(`{}`)})
 	return id
+}
+
+// The archive TOOL refuses a record type its own write path cannot express,
+// before any approval is minted.
+//
+// The seam's resolver deliberately stands down for such a type — six of the
+// twelve archivable types have no seam row and are archived by their own
+// module, which is a real REST archive (archiveResolver.Guards, command.go).
+// That makes the question this door's alone, exactly as create_record's
+// ServesRecordType refusal is: this verb archives ONLY through
+// datasource.SystemOfRecordProvider.Archive, and the surface does not enforce
+// the InputSchema enum, so a raw tools/call can name anything at all.
+//
+// Both halves matter. A type the provider knows nothing about stages a target
+// the approvals surface has no visibility rule for — an authority object that
+// is invisible, undecidable and minted at the caller's choosing. A type it
+// half-knows stages one a human CAN release, onto a retry that then dies at
+// the provider with the one-shot authority already spent.
+func TestTheArchiveToolRefusesARecordTypeItsOwnWritePathCannotArchive(t *testing.T) {
+	for _, recordType := range []string{"tag", "list", "saved_view", "nonsense", ""} {
+		t.Run(recordType, func(t *testing.T) {
+			// A provider that fails EVERY read, so a door that reached the seam
+			// anyway fails here rather than passing on a lenient stub.
+			_, err := archiveRecord{p: unreadableProvider{}}.StageInfo(context.Background(),
+				json.RawMessage(fmt.Sprintf(`{"record_type":%q,"id":%q}`, recordType, ids.NewV7())))
+			var bad *BadArgsError
+			if !errors.As(err, &bad) {
+				t.Fatalf("staging an archive of %q answered %v, want a BadArgsError — an approval for it "+
+					"could never be carried out", recordType, err)
+			}
+		})
+	}
 }

--- a/backend/internal/modules/agents/commandsingle_test.go
+++ b/backend/internal/modules/agents/commandsingle_test.go
@@ -433,3 +433,81 @@ func TestTheCommandsThatNameNoRowStageNoTarget(t *testing.T) {
 			"surface probe and pin a record that is not there", logged.TargetID)
 	}
 }
+
+// A resolver asked about a second call reads THAT call.
+//
+// Nothing outside this package can reach a resolver — the New…Call
+// constructors bind one to its command and hand back the call — so this
+// reaches past the constructor deliberately, the same way
+// TestAResolverAskedAboutASecondTargetReadsIt does for the archive: the memo's
+// key is what makes the binding a belt rather than the only thing between two
+// callers and a shared read. The two memos this task adds carry their own keys
+// for that reason, and this is what holds them to it.
+func TestASecondCallOnTheSameResolverIsReadAfresh(t *testing.T) {
+	t.Run("a merge's two halves", func(t *testing.T) {
+		p := &tallyingProvider{records: map[datasource.EntityRef]datasource.Record{}}
+		resolver := &mergeResolver{records: p}
+		ctx := context.Background()
+
+		first, second := mergeFixture(p), mergeFixture(p)
+		if _, err := resolver.Subject(ctx, first); err != nil {
+			t.Fatalf("the first subject answered %v", err)
+		}
+		got, err := resolver.Subject(ctx, second)
+		if err != nil {
+			t.Fatalf("the second subject answered %v", err)
+		}
+
+		if p.reads != 4 {
+			t.Errorf("two merges cost %d reads, want 4 — a remembered pair must not answer for a merge it "+
+				"was not read for", p.reads)
+		}
+		if got.TargetID != second.TargetID {
+			t.Errorf("the second subject named %s, want the second merge's own survivor %s",
+				got.TargetID, second.TargetID)
+		}
+	})
+
+	t.Run("a call's named links", func(t *testing.T) {
+		p := &tallyingProvider{records: map[datasource.EntityRef]datasource.Record{}}
+		links := &namedLinks{records: p}
+		ctx := context.Background()
+
+		first := []RecordLink{{EntityType: string(datasource.EntityOrganization), EntityID: linkFixture(p)}}
+		second := []RecordLink{{EntityType: string(datasource.EntityOrganization), EntityID: linkFixture(p)}}
+		if _, _, err := links.stageable(ctx, first); err != nil {
+			t.Fatalf("the first read answered %v", err)
+		}
+		got, _, err := links.stageable(ctx, second)
+		if err != nil {
+			t.Fatalf("the second read answered %v", err)
+		}
+
+		if p.reads != 2 {
+			t.Errorf("two link lists cost %d reads, want 2 — a remembered list must not answer for links it "+
+				"was not read for", p.reads)
+		}
+		if len(got) != 1 || got[0] != second[0] {
+			t.Errorf("the second read answered %v, want the second list's own link %v", got, second)
+		}
+	})
+}
+
+// mergeFixture adds an authoritative source and survivor to p and returns the
+// merge that names them.
+func mergeFixture(p *tallyingProvider) MergeCommand {
+	source, survivor := ids.NewV7(), ids.NewV7()
+	for _, id := range []ids.UUID{source, survivor} {
+		ref := datasource.EntityRef{Type: datasource.EntityPerson, ID: id}
+		p.records[ref] = nativeRecord(datasource.Record{Ref: ref, Fields: json.RawMessage(`{}`)})
+	}
+	return MergeCommand{RecordType: "person", SourceID: source, TargetID: survivor}
+}
+
+// linkFixture adds one authoritative organization to p and returns its id.
+func linkFixture(p *tallyingProvider) ids.UUID {
+	id := ids.NewV7()
+	ref := datasource.EntityRef{Type: datasource.EntityOrganization, ID: id}
+	p.records[ref] = nativeRecord(datasource.Record{Ref: ref, Fields: json.RawMessage(`{}`)})
+	return id
+}

--- a/backend/internal/modules/agents/commandsingle_test.go
+++ b/backend/internal/modules/agents/commandsingle_test.go
@@ -1,0 +1,435 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package agents
+
+// The fourteen single-purpose resolvers' own answers (commandcomms.go,
+// commandlinked.go, commandlifecycle.go, commandrecord.go, commandauto.go).
+//
+// The TOOL door's own specs are the proof the move preserved behaviour — they
+// were written against StageInfo and pass unchanged now that StageInfo
+// delegates. What is pinned HERE is what only the resolver can answer: that
+// each refusal a tool used to make is reachable through the command a REST
+// request also builds, that a command's questions rest on ONE reading of the
+// record, and — for enrich and merge, the two commands where the seam has to
+// carry meaning rather than shape — that the meaning survives the crossing.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
+)
+
+// tallyingProvider serves the records it was given, by ref, and counts the
+// reads — so a resolver that asks twice for the row both its questions rest on
+// fails here. countingProvider (command_test.go) answers every ref with one
+// canned record, which cannot express a merge's two halves or a missing row.
+type tallyingProvider struct {
+	datasource.SystemOfRecordProvider
+	records map[datasource.EntityRef]datasource.Record
+	reads   int
+}
+
+func (p *tallyingProvider) Read(_ context.Context, ref datasource.EntityRef) (datasource.Record, error) {
+	p.reads++
+	rec, ok := p.records[ref]
+	if !ok {
+		return datasource.Record{}, apperrors.ErrNotFound
+	}
+	return rec, nil
+}
+
+// oneRecord builds a tallying provider holding a single authoritative row.
+func oneRecord(entity datasource.EntityType, id ids.UUID, fields string, version int64) *tallyingProvider {
+	ref := datasource.EntityRef{Type: entity, ID: id}
+	return &tallyingProvider{records: map[datasource.EntityRef]datasource.Record{
+		ref: nativeRecord(datasource.Record{Ref: ref, Fields: json.RawMessage(fields), Version: version}),
+	}}
+}
+
+// channelKindSet answers the send_message resolver's kind question from a
+// fixed vocabulary — the shape compose's own adapter has, without the store
+// behind it.
+type channelKindSet map[string]bool
+
+func (s channelKindSet) IsChannelKind(kind string) bool { return s[kind] }
+
+// Every command that pins a version answers both of its questions from ONE
+// reading of the record. Two readings are two moments, and the authority
+// judgment would then be about a different state of the row than the sentence
+// a human reads and the version the approval pins.
+func TestEachAnchoredCommandReadsItsRecordOnce(t *testing.T) {
+	id, stage := ids.NewV7(), ids.NewV7()
+	cases := []struct {
+		name     string
+		provider *tallyingProvider
+		call     func(*tallyingProvider) GovernedCall
+	}{
+		{
+			"send_email",
+			oneRecord(datasource.EntityActivity, id, `{"kind":"email"}`, 3),
+			func(p *tallyingProvider) GovernedCall {
+				return NewSendEmailCall(p, SendEmailCommand{ActivityID: id, To: []string{"a@example.test"}})
+			},
+		},
+		{
+			"send_message",
+			oneRecord(datasource.EntityActivity, id, `{"kind":"telegram"}`, 3),
+			func(p *tallyingProvider) GovernedCall {
+				return NewSendMessageCall(p, channelKindSet{"telegram": true},
+					SendMessageCommand{ActivityID: id, Body: "hello"})
+			},
+		},
+		{
+			"promote_lead",
+			oneRecord(datasource.EntityLead, id, `{"full_name":"Ada"}`, 3),
+			func(p *tallyingProvider) GovernedCall {
+				return NewPromoteLeadCall(p, PromoteLeadCommand{LeadID: id, Trigger: "inbound_reply"})
+			},
+		},
+		{
+			"disqualify_lead",
+			oneRecord(datasource.EntityLead, id, `{"full_name":"Ada"}`, 3),
+			func(p *tallyingProvider) GovernedCall {
+				return NewDisqualifyLeadCall(p, DisqualifyLeadCommand{LeadID: id})
+			},
+		},
+		{
+			"advance_project_phase",
+			oneRecord(datasource.EntityProject, id, `{"name":"Rollout"}`, 3),
+			func(p *tallyingProvider) GovernedCall {
+				return NewAdvanceProjectPhaseCall(p, AdvanceProjectPhaseCommand{ProjectID: id, ToPhase: "pursuing"})
+			},
+		},
+		{
+			"advance_deal",
+			oneRecord(datasource.EntityDeal, id, `{"name":"Acme","stage_id":"`+stage.String()+`"}`, 3),
+			func(p *tallyingProvider) GovernedCall {
+				return NewAdvanceDealCall(p, fixedStages{semantic: stageSemanticOpen},
+					AdvanceDealCommand{DealID: id, ToStageID: stage})
+			},
+		},
+		{
+			"enrich",
+			oneRecord(datasource.EntityOrganization, id, `{"name":"Acme"}`, 3),
+			func(p *tallyingProvider) GovernedCall {
+				return NewEnrichCall(p, EnrichCommand{OrganizationID: id, Depth: EnrichDepthPage})
+			},
+		},
+		{
+			"draft_email",
+			oneRecord(datasource.EntityActivity, id, `{"kind":"email"}`, 3),
+			func(p *tallyingProvider) GovernedCall {
+				return NewDraftEmailCall(p, DraftEmailCommand{ActivityID: id})
+			},
+		},
+		{
+			"relink_activity",
+			oneRecord(datasource.EntityActivity, id, `{"kind":"email"}`, 3),
+			func(p *tallyingProvider) GovernedCall {
+				return NewRelinkActivityCall(p, RelinkActivityCommand{
+					ActivityID: id, EntityType: "deal", EntityID: ids.NewV7(),
+				})
+			},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			info, err := StageSubject(context.Background(), c.call(c.provider))
+			if err != nil {
+				t.Fatalf("staging a readable, authoritative record answered %v", err)
+			}
+			if c.provider.reads != 1 {
+				t.Errorf("read the record %d times, want 1 — Guards and Subject must rest on one moment, "+
+					"or the approval pins a version the refusal never judged", c.provider.reads)
+			}
+			if info.TargetVersion == nil || *info.TargetVersion != 3 {
+				t.Errorf("TargetVersion = %v, want the version the read returned", info.TargetVersion)
+			}
+		})
+	}
+}
+
+// Every refusal these commands moved off the tool door, asked through the
+// COMMAND — which is the door-agnostic form a REST request now reaches too.
+// Each is a call the executor would refuse anyway, so reaching it from there
+// instead would spend a human's one-shot approval on the way past.
+func TestTheSinglePurposeGuardsRefuseWhatExecutionWouldRefuse(t *testing.T) {
+	id, other := ids.NewV7(), ids.NewV7()
+	link := RecordLink{EntityType: "organization", EntityID: other}
+	cases := []struct {
+		name  string
+		call  GovernedCall
+		names string
+	}{
+		{
+			"a mail send with no addressee",
+			NewSendEmailCall(oneRecord(datasource.EntityActivity, id, `{}`, 1), SendEmailCommand{ActivityID: id}),
+			"`to`",
+		},
+		{
+			"a channel reply with a whitespace-only body",
+			NewSendMessageCall(oneRecord(datasource.EntityActivity, id, `{"kind":"telegram"}`, 1),
+				channelKindSet{"telegram": true}, SendMessageCommand{ActivityID: id, Body: "   "}),
+			"empty or whitespace-only",
+		},
+		{
+			"a channel reply on an anchor that is not a channel conversation",
+			NewSendMessageCall(oneRecord(datasource.EntityActivity, id, `{"kind":"email"}`, 1),
+				channelKindSet{"telegram": true}, SendMessageCommand{ActivityID: id, Body: "hello"}),
+			"not a messaging-channel conversation",
+		},
+		{
+			"an account-started send with no addressee",
+			NewSendAccountEmailCall(oneRecord(datasource.EntityOrganization, other, `{}`, 1),
+				SendAccountEmailCommand{Links: []RecordLink{link}}),
+			"`to`",
+		},
+		{
+			"an account-started send filed under nothing",
+			NewSendAccountEmailCall(oneRecord(datasource.EntityOrganization, other, `{}`, 1),
+				SendAccountEmailCommand{To: []string{"a@example.test"}}),
+			"`links`",
+		},
+		{
+			"a booking whose end does not follow its start",
+			NewBookMeetingCall(oneRecord(datasource.EntityOrganization, other, `{}`, 1), BookMeetingCommand{
+				Start: time.Date(2026, 8, 10, 9, 30, 0, 0, time.UTC),
+				End:   time.Date(2026, 8, 10, 9, 0, 0, 0, time.UTC),
+				Links: []RecordLink{link},
+			}),
+			"does not follow",
+		},
+		{
+			"a booking attached to nothing",
+			NewBookMeetingCall(oneRecord(datasource.EntityOrganization, other, `{}`, 1), BookMeetingCommand{
+				Start: time.Date(2026, 8, 10, 9, 0, 0, 0, time.UTC),
+				End:   time.Date(2026, 8, 10, 9, 30, 0, 0, time.UTC),
+			}),
+			"`links`",
+		},
+		{
+			"a booking over the per-call link cap",
+			NewBookMeetingCall(oneRecord(datasource.EntityOrganization, other, `{}`, 1), BookMeetingCommand{
+				Start: time.Date(2026, 8, 10, 9, 0, 0, 0, time.UTC),
+				End:   time.Date(2026, 8, 10, 9, 30, 0, 0, time.UTC),
+				Links: distinctLinks(maxRecordLinks + 1),
+			}),
+			"at most",
+		},
+		{
+			"a promotion on a trigger that is not genuine engagement",
+			NewPromoteLeadCall(oneRecord(datasource.EntityLead, id, `{}`, 1),
+				PromoteLeadCommand{LeadID: id, Trigger: "cold_outbound_no_reply"}),
+			"not genuine engagement",
+		},
+		{
+			"a phase outside the ladder",
+			NewAdvanceProjectPhaseCall(oneRecord(datasource.EntityProject, id, `{}`, 1),
+				AdvanceProjectPhaseCommand{ProjectID: id, ToPhase: "shipped"}),
+			"is not a project phase",
+		},
+		{
+			"a closure with no reason",
+			NewAdvanceProjectPhaseCall(oneRecord(datasource.EntityProject, id, `{}`, 1),
+				AdvanceProjectPhaseCommand{ProjectID: id, ToPhase: projectPhaseClosed}),
+			"reason is required",
+		},
+		{
+			"a merge of a record into itself",
+			NewMergeCall(oneRecord(datasource.EntityPerson, id, `{}`, 1),
+				MergeCommand{RecordType: "person", SourceID: id, TargetID: id}),
+			"must differ",
+		},
+		{
+			"a merge of a type with no merge verb",
+			NewMergeCall(oneRecord(datasource.EntityDeal, id, `{}`, 1),
+				MergeCommand{RecordType: "deal", SourceID: id, TargetID: other}),
+			"cannot be merged",
+		},
+		{
+			"an enrich of a target that is not an absolute http(s) URL",
+			NewEnrichCall(oneRecord(datasource.EntityOrganization, id, `{}`, 1),
+				EnrichCommand{OrganizationID: id, URL: "acme.test/about", Depth: EnrichDepthPage}),
+			"absolute http(s) URL",
+		},
+		{
+			"a relink onto a type that is not a link target",
+			NewRelinkActivityCall(oneRecord(datasource.EntityActivity, id, `{}`, 1),
+				RelinkActivityCommand{ActivityID: id, EntityType: "invoice", EntityID: other}),
+			"is not a link target",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			_, err := StageSubject(context.Background(), c.call)
+			if err == nil {
+				t.Fatal("staged a call the executor refuses; a human's yes would be spent discovering that")
+			}
+			var bad *BadArgsError
+			if !errors.As(err, &bad) {
+				t.Fatalf("err = %v (%T), want a BadArgsError — a refusal the caller can act on", err, err)
+			}
+			if !strings.Contains(err.Error(), c.names) {
+				t.Errorf("err = %q, want it to name %q", err, c.names)
+			}
+		})
+	}
+}
+
+// distinctLinks builds n links to distinct organizations, so only the CAP can
+// refuse them — a repeated id would be deduplicated instead and prove nothing.
+func distinctLinks(n int) []RecordLink {
+	links := make([]RecordLink, 0, n)
+	for range n {
+		links = append(links, RecordLink{EntityType: "organization", EntityID: ids.NewV7()})
+	}
+	return links
+}
+
+// A merge names two records and the approval belongs on the SURVIVOR: the
+// human's yes is a judgment about merging into B as it is now, so B's version
+// is what redemption re-checks. Naming the archived half instead would pin a
+// row that is about to stop existing and describe the merge backwards.
+func TestAMergeStagesTheSurvivorAndNamesBothHalves(t *testing.T) {
+	source, survivor := ids.NewV7(), ids.NewV7()
+	sourceRef := datasource.EntityRef{Type: datasource.EntityPerson, ID: source}
+	survivorRef := datasource.EntityRef{Type: datasource.EntityPerson, ID: survivor}
+	p := &tallyingProvider{records: map[datasource.EntityRef]datasource.Record{
+		sourceRef:   nativeRecord(datasource.Record{Ref: sourceRef, Fields: json.RawMessage(`{"full_name":"Ada Old"}`), Version: 2}),
+		survivorRef: nativeRecord(datasource.Record{Ref: survivorRef, Fields: json.RawMessage(`{"full_name":"Ada New"}`), Version: 7}),
+	}}
+
+	info, err := StageSubject(context.Background(), NewMergeCall(p, MergeCommand{
+		RecordType: "person", SourceID: source, TargetID: survivor,
+	}))
+	if err != nil {
+		t.Fatalf("staging a well-formed merge answered %v", err)
+	}
+
+	if info.TargetID != survivor {
+		t.Errorf("staged target %s, want the SURVIVOR %s — an approval bound to the archived half pins a "+
+			"row the merge is about to retire", info.TargetID, survivor)
+	}
+	if info.TargetVersion == nil || *info.TargetVersion != 7 {
+		t.Errorf("TargetVersion = %v, want the survivor's 7", info.TargetVersion)
+	}
+	if !strings.Contains(info.Summary, "Ada Old") || !strings.Contains(info.Summary, "Ada New") {
+		t.Errorf("summary %q names one half of the merge; a human reading it must see what disappears "+
+			"as well as what survives", info.Summary)
+	}
+	// Both halves, so the refusal below has something to refuse ON.
+	if p.reads != 2 {
+		t.Errorf("read %d records, want both halves of the merge", p.reads)
+	}
+}
+
+// Both halves carry the refusal, not only the pinned one: the merge archives
+// and relinks the source, so an externally-held source under a
+// locally-authoritative survivor is still a change no approval could release.
+func TestAMergeRefusesEitherHalfHeldElsewhere(t *testing.T) {
+	local, external := ids.NewV7(), ids.NewV7()
+	localRef := datasource.EntityRef{Type: datasource.EntityPerson, ID: local}
+	externalRef := datasource.EntityRef{Type: datasource.EntityPerson, ID: external}
+	// The external half is deliberately unstamped: its authority lives away.
+	records := map[datasource.EntityRef]datasource.Record{
+		localRef:    nativeRecord(datasource.Record{Ref: localRef, Fields: json.RawMessage(`{}`)}),
+		externalRef: {Ref: externalRef, Fields: json.RawMessage(`{}`)},
+	}
+	for _, c := range []struct {
+		name           string
+		source, target ids.UUID
+		names          string
+	}{
+		{"the survivor is held elsewhere", local, external, "merged INTO"},
+		{"the source is held elsewhere", external, local, "merged FROM"},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			_, err := StageSubject(context.Background(), NewMergeCall(
+				&tallyingProvider{records: records},
+				MergeCommand{RecordType: "person", SourceID: c.source, TargetID: c.target}))
+			if !errors.Is(err, apperrors.ErrUnsupportedBySoR) {
+				t.Fatalf("err = %v, want ErrUnsupportedBySoR", err)
+			}
+			if !strings.Contains(err.Error(), c.names) {
+				t.Errorf("err = %q, want it to name which half blocked the merge", err)
+			}
+		})
+	}
+}
+
+// enrich is ONE verb behind TWO contract operations, and the depth is the
+// whole of the difference: a page read and a whole-site crawl. The commands
+// must differ structurally in it, and the sentence a human approves must say
+// which — approving a site crawl off a line that reads "page" is the failure
+// this typing exists to make unreachable.
+func TestTheTwoEnrichDepthsAreDistinctCommandsWithDistinctSummaries(t *testing.T) {
+	org := ids.NewV7()
+	page := EnrichCommand{OrganizationID: org, Depth: EnrichDepthPage}
+	site := EnrichCommand{OrganizationID: org, Depth: EnrichDepthSite}
+
+	if page == site {
+		t.Fatal("the two enrich operations build the same command; one of them would then be described " +
+			"and guarded as the other")
+	}
+
+	summaries := map[EnrichDepth]string{}
+	for _, cmd := range []EnrichCommand{page, site} {
+		info, err := StageSubject(context.Background(),
+			NewEnrichCall(oneRecord(datasource.EntityOrganization, org, `{"name":"Acme"}`, 1), cmd))
+		if err != nil {
+			t.Fatalf("staging depth %q answered %v", cmd.Depth, err)
+		}
+		summaries[cmd.Depth] = info.Summary
+	}
+
+	if summaries[EnrichDepthPage] == summaries[EnrichDepthSite] {
+		t.Fatalf("both depths stage the sentence %q — a human approving a whole-site crawl would read the "+
+			"same line as one approving a single page", summaries[EnrichDepthPage])
+	}
+	for depth, summary := range summaries {
+		if !strings.Contains(summary, string(depth)) {
+			t.Errorf("the %q summary is %q, which does not say which read it is", depth, summary)
+		}
+	}
+}
+
+// The two commands that name no record at all say so with an EMPTY target
+// rather than a zero id under a record type. stagedTarget (compose) refuses a
+// concrete id with no type, and the approvals surface probes a target's row
+// scope by its type — so a type with no id is the shape a create stages, and
+// neither is what a report run is.
+func TestTheCommandsThatNameNoRowStageNoTarget(t *testing.T) {
+	report, err := StageSubject(context.Background(), NewRunReportCall(RunReportCommand{Report: "deals-by-stage"}))
+	if err != nil {
+		t.Fatalf("staging a report run answered %v", err)
+	}
+	if report.TargetType != "" || !report.TargetID.IsZero() {
+		t.Errorf("a report run staged target (%q,%s); a report is an aggregate over rows the caller's own "+
+			"scope already bounds, and names no row an approval could bind to",
+			report.TargetType, report.TargetID)
+	}
+	if !strings.Contains(report.Summary, "deals-by-stage") {
+		t.Errorf("summary %q does not name which report is being released", report.Summary)
+	}
+
+	logged, err := StageSubject(context.Background(),
+		NewLogActivityCall(LogActivityCommand{Fields: json.RawMessage(`{"kind":"note","body":"hi"}`)}))
+	if err != nil {
+		t.Fatalf("staging a logged activity answered %v", err)
+	}
+	if logged.TargetType != string(datasource.EntityActivity) {
+		t.Errorf("TargetType = %q, want %q", logged.TargetType, datasource.EntityActivity)
+	}
+	if !logged.TargetID.IsZero() {
+		t.Errorf("TargetID = %s; the activity does not exist yet, and naming one makes the approvals "+
+			"surface probe and pin a record that is not there", logged.TargetID)
+	}
+}

--- a/backend/internal/modules/agents/conformance_test.go
+++ b/backend/internal/modules/agents/conformance_test.go
@@ -205,7 +205,7 @@ func (inertLifecycle) AdvanceProjectPhase(context.Context, ids.UUID, string, *st
 	return nil, nil
 }
 
-func (inertLifecycle) EnrichCompany(context.Context, ids.UUID, string, string) (json.RawMessage, error) {
+func (inertLifecycle) EnrichCompany(context.Context, ids.UUID, string, EnrichDepth) (json.RawMessage, error) {
 	return nil, nil
 }
 

--- a/backend/internal/modules/agents/idargs_test.go
+++ b/backend/internal/modules/agents/idargs_test.go
@@ -164,7 +164,7 @@ func (seamProbeLifecycle) AdvanceProjectPhase(context.Context, ids.UUID, string,
 	return nil, errSeamReached
 }
 
-func (seamProbeLifecycle) EnrichCompany(context.Context, ids.UUID, string, string) (json.RawMessage, error) {
+func (seamProbeLifecycle) EnrichCompany(context.Context, ids.UUID, string, EnrichDepth) (json.RawMessage, error) {
 	return nil, errSeamReached
 }
 

--- a/backend/internal/modules/agents/quota_test.go
+++ b/backend/internal/modules/agents/quota_test.go
@@ -89,9 +89,9 @@ func chargingRegistry(t *testing.T, tool mcp.Tool, opts ...chargeTestOption) (*R
 	for _, opt := range opts {
 		opt(&cfg)
 	}
-	r := NewRegistry(nil, auth.NewGate(fullSeatAuthority{}), WithQuotaCharger(cfg.charger))
+	r := NewRegistry(cfg.approvals, auth.NewGate(fullSeatAuthority{}), WithQuotaCharger(cfg.charger))
 	if cfg.noCharger {
-		r = NewRegistry(nil, auth.NewGate(fullSeatAuthority{}))
+		r = NewRegistry(cfg.approvals, auth.NewGate(fullSeatAuthority{}))
 	}
 	r.Register(tool)
 	ctx := principal.WithWorkspaceID(context.Background(), ids.NewV7())
@@ -107,6 +107,7 @@ type chargeTest struct {
 	charger   *countingCharger
 	scope     principal.Scope
 	noCharger bool
+	approvals Approvals
 }
 
 type chargeTestOption func(*chargeTest)
@@ -125,6 +126,12 @@ func withChargerErrorOn(counter agentquota.Counter, err error) chargeTestOption 
 // withScope runs the caller under a scope other than read.
 func withScope(s principal.Scope) chargeTestOption {
 	return func(c *chargeTest) { c.scope = s }
+}
+
+// withApprovals composes the registry with an approvals engine, which is what a
+// call presenting an approval_id needs to be redeemed against at all.
+func withApprovals(a Approvals) chargeTestOption {
+	return func(c *chargeTest) { c.approvals = a }
 }
 
 // withNoCharger composes the registry with no meter at all.
@@ -489,4 +496,55 @@ func TestTheRestChargePointsAreSafeWithNoMeter(t *testing.T) {
 		t.Fatalf("a registry with no meter refused a REST call: %v", err)
 	}
 	r.ChargeEffect(ctx, spec)
+}
+
+// One CALL spends one of the call ceiling, whichever arm carried it — and a
+// call that never ran spends none.
+//
+// The two arms charge at different MOMENTS, and that is what makes the count
+// worth pinning. An unapproved call is charged before dispatch, where nothing
+// has happened yet and an uncountable charge can still refuse it. A call
+// presenting an approval_id skips that point entirely and is charged at the
+// redemption instead, absorbed rather than refusable, because by then the
+// human's approval is consumed and refusing would burn it on a call that never
+// ran. Charging at both would bill one act twice; charging at neither would
+// leave the redeeming arm free, and the REST door mirrors exactly this
+// (compose.TestOneRestCallSpendsOneOfTheCallCeiling).
+func TestOneToolCallSpendsOneOfTheCallCeiling(t *testing.T) {
+	for name, tc := range map[string]struct {
+		tier      mcp.RiskTier
+		presented bool
+		wantCalls int
+		wantErr   error
+	}{
+		"auto-execute, nothing presented":               {tier: mcp.TierAutoExecute, wantCalls: 1},
+		"auto-execute, redeeming a presented approval":  {tier: mcp.TierAutoExecute, presented: true, wantCalls: 1},
+		"confirm-first, redeeming a presented approval": {tier: mcp.TierConfirmationRequired, presented: true, wantCalls: 1},
+		"confirm-first, staged and never run": {
+			tier: mcp.TierConfirmationRequired, wantCalls: 0, wantErr: apperrors.ErrRequiresApproval,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			spec := readToolSpec("update_record")
+			spec.RequiredScope, spec.Tier = principal.ScopeWrite, tc.tier
+			r, charger, ctx := chargingRegistry(t, &servingTool{spec: spec},
+				withScope(principal.ScopeWrite), withApprovals(&recordingApprovals{}))
+
+			args := json.RawMessage(`{}`)
+			if tc.presented {
+				args = json.RawMessage(`{"approval_id":"` + ids.New[ids.ApprovalKind]().String() + `"}`)
+			}
+			_, err := r.Invoke(ctx, spec.Name, args)
+			if tc.wantErr == nil && err != nil {
+				t.Fatalf("the call was refused: %v — this case is not the arm it names", err)
+			}
+			if tc.wantErr != nil && !errors.Is(err, tc.wantErr) {
+				t.Fatalf("the call answered %v, want %v — this case is not the arm it names", err, tc.wantErr)
+			}
+
+			if got := charger.charged[agentquota.Calls]; got != tc.wantCalls {
+				t.Errorf("the call ceiling was charged %d, want %d", got, tc.wantCalls)
+			}
+		})
+	}
 }

--- a/backend/internal/modules/agents/tools.go
+++ b/backend/internal/modules/agents/tools.go
@@ -397,29 +397,21 @@ func (t advanceDeal) ResolverInput(ctx context.Context, in json.RawMessage) (mcp
 	return DealMoveTierInput(ctx, t.p, t.stages, args.DealID, args.ToStageID, in)
 }
 
-// StageInfo pins the staged move to the deal's CURRENT version, so an
-// approval given for "close this deal as it stands" cannot execute
-// against a deal that changed in between.
+// StageInfo decodes this door's arguments into the deal-move command and
+// delegates: the refusals and the staged subject — including the version pin,
+// so an approval given for "close this deal as it stands" cannot execute
+// against a deal that changed in between — live in the resolver
+// (commandlifecycle.go), where the REST door reaches the same ones for the
+// same operation.
 func (t advanceDeal) StageInfo(ctx context.Context, in json.RawMessage) (StageInfo, error) {
 	var args advanceDealArgs
 	if err := decodeArgs(in, &args); err != nil {
 		return StageInfo{}, err
 	}
-	rec, err := t.p.Read(ctx, datasource.EntityRef{Type: datasource.EntityDeal, ID: args.DealID})
-	if err != nil {
-		return StageInfo{}, err
-	}
-	if err := refuseStagingElsewhere(rec); err != nil {
-		return StageInfo{}, err
-	}
-	semantic, _, err := t.stages.StageSemantic(ctx, args.ToStageID)
-	if err != nil {
-		return StageInfo{}, err
-	}
-	return StageInfo{
-		TargetType: "deal", TargetID: args.DealID, TargetVersion: &rec.Version,
-		Summary: dealMoveSummary(ctx, t.stages, rec, semantic),
-	}, nil
+	return StageSubject(ctx, NewAdvanceDealCall(t.p, t.stages, AdvanceDealCommand{
+		DealID:    args.DealID,
+		ToStageID: args.ToStageID,
+	}))
 }
 
 func (t advanceDeal) Handle(ctx context.Context, in json.RawMessage) (json.RawMessage, error) {

--- a/backend/internal/modules/agents/tools.go
+++ b/backend/internal/modules/agents/tools.go
@@ -257,24 +257,19 @@ func (createRecord) ServesRecordType(recordType string) bool {
 // StageInfo puts a create the contract tightened to confirm-first in the inbox
 // instead of dead-ending it (#982).
 //
-// WHAT IT STAGES IS A CREATE, and the shape says so: the record type with no id
-// and no version pin, because the record does not exist yet and there is no row
-// an approval could bind to. That is the shape the REST door stages for the same
+// It decodes this door's arguments into the create command and delegates: the
+// refusals and the staged subject live in the resolver (command.go), where the
+// REST door reaches the same ones for the same operation. WHAT IT STAGES IS A
+// CREATE, and the resolver's shape says so: the record type with no id and no
+// version pin, because the record does not exist yet and there is no row an
+// approval could bind to. That is the shape the REST door stages for the same
 // operation, whose route carries no `{id}` — one operation, one staged shape,
 // whichever door the agent came through.
 //
 // The checks run HERE as well as in Handle, and that is the point: the approved
 // retry re-enters through Handle, so a rule enforced only there is one a human's
 // yes is spent discovering.
-//
-// The record type is checked FIRST and by this verb's own served set, not by
-// rejectUnknownFields — which answers nil for a type it does not know, on the
-// deliberate ground that naming the served vocabulary is the provider's refusal
-// to make. That is right for a call about to reach the provider and wrong for one
-// about to reach a human: `create_record{record_type:"custom_field"}` would
-// otherwise stage cleanly, because the surface does not enforce schema enums, and
-// the approved retry would then die at the provider with the approval spent.
-func (t createRecord) StageInfo(_ context.Context, in json.RawMessage) (StageInfo, error) {
+func (t createRecord) StageInfo(ctx context.Context, in json.RawMessage) (StageInfo, error) {
 	var args struct {
 		RecordType string          `json:"record_type"`
 		Fields     json.RawMessage `json:"fields"`
@@ -282,18 +277,11 @@ func (t createRecord) StageInfo(_ context.Context, in json.RawMessage) (StageInf
 	if err := decodeArgs(in, &args); err != nil {
 		return StageInfo{}, err
 	}
-	if !t.ServesRecordType(args.RecordType) {
-		return StageInfo{}, &BadArgsError{Cause: fmt.Errorf(
-			"this verb does not create %q records, so no approval of it could ever be carried out",
-			args.RecordType)}
-	}
-	if err := rejectUnknownFields(createShapes, args.RecordType, args.Fields); err != nil {
-		return StageInfo{}, err
-	}
-	return StageInfo{
-		TargetType: args.RecordType,
-		Summary:    describeGenericWrite("Create", args.RecordType, args.Fields),
-	}, nil
+	// This door's wire shape IS the command's field set (same reasoning as
+	// archiveRecord.StageInfo, command.go), so it converts rather than
+	// restating the fields: a field CreateCommand grows fails to compile here
+	// instead of quietly leaving it unset.
+	return StageSubject(ctx, NewCreateCall(CreateCommand(args)))
 }
 
 // --- log_activity (🟢 write) ---

--- a/backend/internal/modules/agents/tools.go
+++ b/backend/internal/modules/agents/tools.go
@@ -266,9 +266,24 @@ func (createRecord) ServesRecordType(recordType string) bool {
 // operation, whose route carries no `{id}` — one operation, one staged shape,
 // whichever door the agent came through.
 //
-// The checks run HERE as well as in Handle, and that is the point: the approved
-// retry re-enters through Handle, so a rule enforced only there is one a human's
-// yes is spent discovering.
+// ONE check runs HERE, before the command is even built, rather than inside
+// the shared resolver: a record type this verb's OWN write path cannot make
+// at all. create_record's Handle writes exclusively through
+// datasource.SystemOfRecordProvider.Create, which has no way to express a
+// type outside createShapes, so staging one here would mint an approval whose
+// approved retry dies at the provider with the authority already spent. That
+// is a fact about THIS door's executor — the surface does not enforce the
+// InputSchema enum at this layer, so a raw tool call can still name a type
+// outside it — and it has no REST equivalent: a REST create for the same
+// out-of-schema type reaches its own module's handler, which performs it
+// fine, so the identical command asked of the resolver by that door must NOT
+// be refused here. createResolver.Guards (command.go) says why it stays
+// silent on this question rather than repeating it.
+//
+// Every other check (unknown fields, the staged shape) runs HERE as well as
+// in Handle, and that is the point: the approved retry re-enters through
+// Handle, so a rule enforced only there is one a human's yes is spent
+// discovering.
 func (t createRecord) StageInfo(ctx context.Context, in json.RawMessage) (StageInfo, error) {
 	var args struct {
 		RecordType string          `json:"record_type"`
@@ -276,6 +291,11 @@ func (t createRecord) StageInfo(ctx context.Context, in json.RawMessage) (StageI
 	}
 	if err := decodeArgs(in, &args); err != nil {
 		return StageInfo{}, err
+	}
+	if !t.ServesRecordType(args.RecordType) {
+		return StageInfo{}, &BadArgsError{Cause: fmt.Errorf(
+			"this verb does not create %q records, so no approval of it could ever be carried out",
+			args.RecordType)}
 	}
 	// This door's wire shape IS the command's field set (same reasoning as
 	// archiveRecord.StageInfo, command.go), so it converts rather than

--- a/backend/internal/modules/agents/tools_account_send.go
+++ b/backend/internal/modules/agents/tools_account_send.go
@@ -17,9 +17,6 @@ package agents
 import (
 	"context"
 	"encoding/json"
-	"errors"
-	"fmt"
-	"strings"
 
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
@@ -62,66 +59,34 @@ func (t sendAccountEmailTool) Spec() mcp.ToolSpec {
 	}
 }
 
-// StageInfo puts a refused account-started send in the inbox instead of
-// dead-ending it.
-//
-// WHAT IT STAGES IS A CREATE, and the shape says so: the target type is
-// `activity` with no id and no version pin. This send answers no message, so
-// there is no row its effect depends on — approvals.settledByShape reads that
-// shape as decidable on the object-read floor plus the decision grants, and it
-// is the same row the REST door stages when the identical call arrives as a
-// bearer request (compose.stageRefusal takes its target id from the route's
-// {id} parameter, and this route has none). One operation, one staged shape,
-// whichever door it came through.
-//
-// A LINK CANNOT BE THE TARGET here, the way book_meeting's first link is.
-// Two constraints close it: the REST door takes its target from the route and
-// never reads the body, so naming one would stage a kind two ways; and the pin
-// is taken SERVER-SIDE from the target pair (approvals.resolveTargetVersion),
-// so an organization target pins a version that an enrichment run bumps while
-// an overnight proposal waits for someone's morning inbox — cancelling a send
-// the record's own content never invalidated. The waiver that declines a pin is
-// reserved for kinds whose effect approvals itself applies
-// (TestEveryContextTargetKindIsAKindWeStage); this effect is performed by the
-// agent's own approved retry.
-//
-// So the approver is bounded by read+create on `activity` and NOT by the row
-// scope of the records the message is filed under — a manager whose scope
-// excludes them can still release this send and read its proposed text. The
-// reply path binds its approver to the anchor instead. Closing the difference
-// takes a staging gate that can derive a target from the body, which is shared
-// machinery rather than this verb's: issue #928.
-//
-// The links are still read, because that is a question about the STAGER's
-// reach rather than the approver's: the store refuses a link the caller cannot
-// see, at execution — so without the same probe here, an agent naming a company
-// it cannot read mints an approval a human reads, approves, and watches fail
-// with the one-shot authority already spent.
-//
-// What this does not pre-empt, so neither reads as covered: the consent gate's
-// per-purpose verdict, the workspace's mailbox send capability, and whether an
-// address belongs to a person on file. All are refusals a human's yes cannot
-// fix, and all need reads staging does not have.
+// StageInfo decodes this door's arguments into the account-started send
+// command and delegates: the refusals and the staged subject live in the
+// resolver (commandlinked.go), where the REST door reaches the same ones for
+// the same operation — including the CREATE shape this stages, target type
+// `activity` with no id and no pin, which the REST door used to reach by a
+// different route entirely (its route carries no `{id}` for the walk to read).
 func (t sendAccountEmailTool) StageInfo(ctx context.Context, in json.RawMessage) (StageInfo, error) {
-	args, links, err := readAccountSendArgs(in)
-	if err != nil {
+	var args SendAccountEmailArgs
+	if err := decodeArgs(in, &args); err != nil {
 		return StageInfo{}, err
 	}
-	if _, err := readStageableLinks(ctx, t.p, links); err != nil {
-		return StageInfo{}, err
-	}
-	return StageInfo{
-		TargetType: string(datasource.EntityActivity),
-		Summary:    describeAccountSend(args, links),
-	}, nil
+	return StageSubject(ctx, NewSendAccountEmailCall(t.p, SendAccountEmailCommand{
+		To:      args.To,
+		Cc:      args.Cc,
+		Subject: args.Subject,
+		Links:   args.Links,
+	}))
 }
 
 // readAccountSendArgs decodes one call and applies the refusals the send path
 // would otherwise raise only after a human had approved it.
 //
-// Both doors go through it, and that is the point: the MCP surface does not
+// Handle goes through it, and that is the point: the MCP surface does not
 // validate arguments against an InputSchema — that schema is documentation —
-// so a rule enforced only at staging is one an approved retry never meets.
+// so a rule enforced only at staging is one an approved retry never meets. It
+// calls the SAME two functions the resolver's Guards calls rather than
+// restating either, so the approved retry cannot be admitted by a rule the
+// staging never applied.
 func readAccountSendArgs(in json.RawMessage) (SendAccountEmailArgs, []RecordLink, error) {
 	var args SendAccountEmailArgs
 	if err := decodeArgs(in, &args); err != nil {
@@ -130,35 +95,14 @@ func readAccountSendArgs(in json.RawMessage) (SendAccountEmailArgs, []RecordLink
 	if err := requireAddressee(args.To); err != nil {
 		return SendAccountEmailArgs{}, nil, err
 	}
-	if len(args.Links) == 0 {
-		return SendAccountEmailArgs{}, nil, &BadArgsError{
-			Cause: errors.New("`links` needs at least one entry: a message filed under no record " +
-				"is one nobody finds again, and the store refuses it"),
-			Guidance: "name the company, person or deal this conversation is about",
-		}
+	if err := requireAccountSendLinks(args.Links); err != nil {
+		return SendAccountEmailArgs{}, nil, err
 	}
 	links, err := uniqueRecordLinks(args.Links)
 	if err != nil {
 		return SendAccountEmailArgs{}, nil, err
 	}
 	return args, links, nil
-}
-
-// describeAccountSend is the one line the inbox shows for an account-started
-// send: who it reaches, cc included, what it says it is about, and how many
-// records it will land on.
-//
-// Every addressee, for the reason the reply twin's summary states — an unnamed
-// recipient is a recipient nobody agreed to. The links are counted rather than
-// listed: their ids mean nothing to a human reading one line, and the staged
-// row is decidable on the activity floor rather than on those records, so
-// naming them would disclose more than the decision rests on.
-func describeAccountSend(args SendAccountEmailArgs, links []RecordLink) string {
-	summary := fmt.Sprintf("Start an email conversation with %s", strings.Join(args.To, ", "))
-	if len(args.Cc) > 0 {
-		summary += fmt.Sprintf(", cc %s", strings.Join(args.Cc, ", "))
-	}
-	return summary + fmt.Sprintf(", subject %q, filed under %d record(s)", args.Subject, len(links))
 }
 
 func (t sendAccountEmailTool) Handle(ctx context.Context, in json.RawMessage) (json.RawMessage, error) {

--- a/backend/internal/modules/agents/tools_account_send_test.go
+++ b/backend/internal/modules/agents/tools_account_send_test.go
@@ -96,9 +96,9 @@ func TestTheAccountStartedSendStagesACreate(t *testing.T) {
 // The inbox row is the whole of what a human reads before releasing a send, so
 // an addressee missing from it is a recipient nobody agreed to.
 func TestTheAccountStartedSendSummaryNamesEveryArgumentItReleases(t *testing.T) {
-	got := describeAccountSend(SendAccountEmailArgs{SendEmailArgs: SendEmailArgs{
+	got := describeAccountSend(SendAccountEmailCommand{
 		To: []string{"buyer@example.test"}, Cc: []string{"rival@example.test"}, Subject: "Q3 pricing",
-	}}, []RecordLink{{EntityType: "organization", EntityID: ids.NewV7()}})
+	}, []RecordLink{{EntityType: "organization", EntityID: ids.NewV7()}})
 
 	for _, want := range []string{"buyer@example.test", "rival@example.test", `"Q3 pricing"`, "1 record(s)"} {
 		if !strings.Contains(got, want) {

--- a/backend/internal/modules/agents/tools_comms.go
+++ b/backend/internal/modules/agents/tools_comms.go
@@ -14,8 +14,6 @@ package agents
 import (
 	"context"
 	"encoding/json"
-	"fmt"
-	"strings"
 	"time"
 
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
@@ -38,12 +36,14 @@ type Comms interface {
 	// addressee: the recipient is the person the anchor conversation is with,
 	// resolved server-side, so a reply can only reach the human who opened it.
 	SendMessage(ctx context.Context, anchor ids.UUID, in SendMessageArgs) (SendMessageResult, error)
-	// IsChannelKind reports whether an activity kind is a messaging-channel
-	// conversation send_message may reply on. StageInfo needs the exact
-	// answer activities.IsChannelKind gives — the same test the store's own
-	// SendMessage refuses on — but this module may not import activities
-	// directly (modules never import a sibling), so the seam carries it.
-	IsChannelKind(kind string) bool
+	// ChannelKinds reports whether an activity kind is a messaging-channel
+	// conversation send_message may reply on. The send_message resolver needs
+	// the exact answer activities.IsChannelKind gives — the same test the
+	// store's own SendMessage refuses on — but this module may not import
+	// activities directly (modules never import a sibling), so the seam
+	// carries it. Embedded rather than declared inline because the REST door
+	// reaches that resolver holding the question alone (commandcomms.go).
+	ChannelKinds
 	Availability(ctx context.Context, host *ids.UUID, from, to time.Time, durationMinutes int) (AvailabilityResult, error)
 	BookMeeting(ctx context.Context, in BookMeetingArgs) (json.RawMessage, error)
 }
@@ -174,61 +174,29 @@ type sendEmailToolArgs struct {
 	SendEmailArgs
 }
 
-// StageInfo puts a refused send in the inbox instead of dead-ending it. The
-// anchor is the thread being replied to: it is the row the effect hangs off,
-// so it is what the redemption version pin re-checks.
+// StageInfo decodes this door's arguments into the mail-reply command and
+// delegates: the refusals and the staged subject live in the resolver
+// (commandcomms.go), where the REST door reaches the same ones for the same
+// operation.
 //
-// The recipients are NOT resolved here, and that is the difference from
+// The recipients are NOT resolved, and that is the difference from
 // send_message rather than an omission. A mail send names its own addressees
 // in `to`/`cc`, so they travel inside the staged arguments and are covered by
 // the diff_hash — the approved retry can only reach the addresses the human
 // read. A channel reply names none, which is why its recipient has to be
 // resolved server-side, and why binding an approval to a recipient is an open
 // question there and a settled one here.
-//
-// What this does not pre-empt, so neither reads as covered: the consent gate's
-// per-purpose verdict, the workspace's mailbox send capability, and whether an
-// address is syntactically deliverable. All are refusals a human's yes cannot
-// fix, and the first two need reads this call does not have — staging fetches
-// the anchor for the version pin and nothing else.
 func (t sendEmailTool) StageInfo(ctx context.Context, in json.RawMessage) (StageInfo, error) {
 	var args sendEmailToolArgs
 	if err := decodeArgs(in, &args); err != nil {
 		return StageInfo{}, err
 	}
-	// Refuse here what the store refuses at execution. Otherwise staging mints
-	// an approval, a human reads a send with no addressee and says yes, the
-	// approved retry consumes that one-shot authority, and only then does the
-	// store refuse — a "yes" spent on something that was never going to happen.
-	if err := requireAddressee(args.To); err != nil {
-		return StageInfo{}, err
-	}
-	rec, err := t.p.Read(ctx, datasource.EntityRef{Type: datasource.EntityActivity, ID: args.ActivityID})
-	if err != nil {
-		return StageInfo{}, err
-	}
-	if err := refuseStagingElsewhere(rec); err != nil {
-		return StageInfo{}, err
-	}
-	return StageInfo{
-		TargetType: string(datasource.EntityActivity), TargetID: args.ActivityID, TargetVersion: &rec.Version,
-		// Every addressee, cc included. A human approving from the inbox row
-		// reads only this line, so an unnamed recipient is a recipient nobody
-		// agreed to — the diff_hash faithfully binds cc either way, which is
-		// precisely what makes omitting it from the display a problem rather
-		// than a harmless abbreviation.
-		Summary: describeSend(args),
-	}, nil
-}
-
-// describeSend is the one line the inbox shows for a mail send: who it
-// reaches, cc included, and what it says it is about.
-func describeSend(args sendEmailToolArgs) string {
-	summary := fmt.Sprintf("Send an email to %s", strings.Join(args.To, ", "))
-	if len(args.Cc) > 0 {
-		summary += fmt.Sprintf(", cc %s", strings.Join(args.Cc, ", "))
-	}
-	return summary + fmt.Sprintf(", subject %q", args.Subject)
+	return StageSubject(ctx, NewSendEmailCall(t.p, SendEmailCommand{
+		ActivityID: args.ActivityID,
+		To:         args.To,
+		Cc:         args.Cc,
+		Subject:    args.Subject,
+	}))
 }
 
 func (t sendEmailTool) Handle(ctx context.Context, in json.RawMessage) (json.RawMessage, error) {
@@ -271,58 +239,19 @@ type sendMessageToolArgs struct {
 	SendMessageArgs
 }
 
+// StageInfo decodes this door's arguments into the channel-reply command and
+// delegates. The kind test travels with the call rather than being asked here:
+// the resolver refuses a non-channel anchor for BOTH doors, and this tool's
+// own seam is what supplies the answer either way.
 func (t sendMessageTool) StageInfo(ctx context.Context, in json.RawMessage) (StageInfo, error) {
 	var args sendMessageToolArgs
 	if err := decodeArgs(in, &args); err != nil {
 		return StageInfo{}, err
 	}
-	rec, err := t.p.Read(ctx, datasource.EntityRef{Type: datasource.EntityActivity, ID: args.ActivityID})
-	if err != nil {
-		return StageInfo{}, err
-	}
-	if err := refuseStagingElsewhere(rec); err != nil {
-		return StageInfo{}, err
-	}
-	// Refuse here what Handle's eventual SendMessage call would refuse anyway
-	// (errEmptyMessageBody, NotAChannelConversationError): otherwise staging
-	// mints an approval a human can approve, the approved retry consumes that
-	// one-shot approval on redemption, and only then does the store refuse
-	// permanently — a "yes" with no path to actually happening.
-	//
-	// SendMessage has two more permanent refusals this does not guard:
-	// ChannelRecipientError (the conversation reaches nobody, or more than
-	// one person) and ChannelNotSendCapableError (the workspace has no bot
-	// bound for the provider). Both are the same "yes with no path to
-	// actually happening" shape as the two guarded above, but closing them
-	// needs a reachability read this call does not have: the record read
-	// above returns the anchor's fields, not who the conversation resolves
-	// to or whether a bot is bound, and answering either question here would
-	// mean a new datasource seam method plus a database read at staging
-	// time — staging today only reads the anchor already fetched for
-	// version-pinning.
-	if strings.TrimSpace(args.Body) == "" {
-		return StageInfo{}, &BadArgsError{Cause: fmt.Errorf("body is empty or whitespace-only; a channel provider rejects a text-less message")}
-	}
-	var anchor struct {
-		Kind string `json:"kind"`
-	}
-	if err := json.Unmarshal(rec.Fields, &anchor); err != nil {
-		return StageInfo{}, fmt.Errorf("crmagents: activity %s read back with unreadable fields: %w", args.ActivityID, err)
-	}
-	if !t.comms.IsChannelKind(anchor.Kind) {
-		return StageInfo{}, &BadArgsError{
-			Cause: fmt.Errorf("activity %s is a %q activity, not a messaging-channel conversation",
-				args.ActivityID, anchor.Kind),
-			Guidance: "reply on the channel the conversation was held on",
-		}
-	}
-	return StageInfo{
-		TargetType: string(datasource.EntityActivity), TargetID: args.ActivityID, TargetVersion: &rec.Version,
-		// The inbox shows the human what they are releasing. The message text
-		// is the thing being approved, so it belongs in the summary; the
-		// recipient does not, because nobody named one — the conversation did.
-		Summary: fmt.Sprintf("Reply on a captured conversation: %q", args.Body),
-	}, nil
+	return StageSubject(ctx, NewSendMessageCall(t.p, t.comms, SendMessageCommand{
+		ActivityID: args.ActivityID,
+		Body:       args.Body,
+	}))
 }
 
 func (t sendMessageTool) Handle(ctx context.Context, in json.RawMessage) (json.RawMessage, error) {

--- a/backend/internal/modules/agents/tools_comms_test.go
+++ b/backend/internal/modules/agents/tools_comms_test.go
@@ -433,9 +433,9 @@ func TestAStagedSummaryNamesEveryArgumentItReleases(t *testing.T) {
 	host, deal, org := ids.NewV7(), ids.NewV7(), ids.NewV7()
 
 	t.Run("a send names its cc, not only its to", func(t *testing.T) {
-		got := describeSend(sendEmailToolArgs{SendEmailArgs: SendEmailArgs{
+		got := describeSend(SendEmailCommand{
 			To: []string{"buyer@example.test"}, Cc: []string{"rival@example.test"}, Subject: "Q3 pricing",
-		}})
+		})
 		for _, want := range []string{"buyer@example.test", "rival@example.test", `"Q3 pricing"`} {
 			if !strings.Contains(got, want) {
 				t.Errorf("summary %q does not name %q", got, want)
@@ -444,12 +444,12 @@ func TestAStagedSummaryNamesEveryArgumentItReleases(t *testing.T) {
 	})
 
 	t.Run("a booking names whose calendar and how many records", func(t *testing.T) {
-		args := BookMeetingArgs{
+		cmd := BookMeetingCommand{
 			HostUserID: &host, Subject: "Review",
 			Start: time.Date(2026, 8, 10, 9, 0, 0, 0, time.UTC),
 			End:   time.Date(2026, 8, 10, 9, 30, 0, 0, time.UTC),
 		}
-		got := describeBooking(args, []RecordLink{
+		got := describeBooking(cmd, []RecordLink{
 			{EntityType: "deal", EntityID: deal}, {EntityType: "organization", EntityID: org},
 		})
 		for _, want := range []string{host.String(), "2 record(s)", `"Review"`} {

--- a/backend/internal/modules/agents/tools_confirm.go
+++ b/backend/internal/modules/agents/tools_confirm.go
@@ -14,7 +14,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
-	"strings"
 
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
@@ -114,25 +113,19 @@ func (t promoteLead) Spec() mcp.ToolSpec {
 	}
 }
 
+// StageInfo decodes this door's arguments into the promotion command and
+// delegates: the refusals and the staged subject live in the resolver
+// (commandlifecycle.go), where the REST door reaches the same ones for the
+// same operation.
 func (t promoteLead) StageInfo(ctx context.Context, in json.RawMessage) (StageInfo, error) {
 	var args promoteArgs
 	if err := decodeArgs(in, &args); err != nil {
 		return StageInfo{}, err
 	}
-	if !validTriggers[args.Trigger] {
-		return StageInfo{}, &BadArgsError{Cause: fmt.Errorf("trigger %q is not genuine engagement", args.Trigger)}
-	}
-	rec, err := t.p.Read(ctx, datasource.EntityRef{Type: datasource.EntityLead, ID: args.LeadID})
-	if err != nil {
-		return StageInfo{}, err
-	}
-	if err := refuseStagingElsewhere(rec); err != nil {
-		return StageInfo{}, err
-	}
-	return StageInfo{
-		TargetType: "lead", TargetID: args.LeadID, TargetVersion: &rec.Version,
-		Summary: fmt.Sprintf("Promote lead %s to a contact (%s)", recordLabel(rec), args.Trigger),
-	}, nil
+	return StageSubject(ctx, NewPromoteLeadCall(t.p, PromoteLeadCommand{
+		LeadID:  args.LeadID,
+		Trigger: args.Trigger,
+	}))
 }
 
 // validTriggers mirrors the contract enum — checked BEFORE staging so a
@@ -204,46 +197,21 @@ func (t mergeRecords) Spec() mcp.ToolSpec {
 	}
 }
 
+// StageInfo decodes this door's arguments into the merge command and
+// delegates: the refusals and the staged subject live in the resolver
+// (commandrecord.go), where the REST door reaches the same ones for the same
+// operation.
+//
+// This door's wire shape IS the command's field set — the arguments differ
+// only in carrying JSON tags — so it converts rather than restating the
+// fields, and a command that grows one fails to compile here instead of
+// quietly leaving it unset.
 func (t mergeRecords) StageInfo(ctx context.Context, in json.RawMessage) (StageInfo, error) {
 	var args mergeArgs
 	if err := decodeArgs(in, &args); err != nil {
 		return StageInfo{}, err
 	}
-	if !mergeableTypes[args.RecordType] {
-		return StageInfo{}, &BadArgsError{
-			Cause:    fmt.Errorf("record_type %q cannot be merged", args.RecordType),
-			Guidance: "mergeable types are " + strings.Join(mergeableTypeNames(), ", "),
-		}
-	}
-	if args.SourceID == args.TargetID {
-		return StageInfo{}, &BadArgsError{Cause: fmt.Errorf("source and target must differ")}
-	}
-	// Pin the SURVIVOR's version: the human's yes is a judgment about
-	// merging into B as it is now, so if B changes before redemption the
-	// approval no longer covers it (version skew, re-stage). The source is read
-	// because it is the other half of the change — the merge archives and
-	// relinks it — so its authority is checked too and its label goes in the
-	// summary.
-	survivor, err := t.p.Read(ctx, datasource.EntityRef{Type: datasource.EntityType(args.RecordType), ID: args.TargetID})
-	if err != nil {
-		return StageInfo{}, err
-	}
-	source, err := t.p.Read(ctx, datasource.EntityRef{Type: datasource.EntityType(args.RecordType), ID: args.SourceID})
-	if err != nil {
-		return StageInfo{}, err
-	}
-	// Every record this change touches, not just the pinned one, and named so a
-	// human reading the refusal knows which half of the merge blocked it.
-	if err := refuseStagingElsewhere(survivor); err != nil {
-		return StageInfo{}, fmt.Errorf("the record being merged INTO: %w", err)
-	}
-	if err := refuseStagingElsewhere(source); err != nil {
-		return StageInfo{}, fmt.Errorf("the record being merged FROM: %w", err)
-	}
-	return StageInfo{
-		TargetType: args.RecordType, TargetID: args.TargetID, TargetVersion: &survivor.Version,
-		Summary: fmt.Sprintf("Merge %s %s into %s", args.RecordType, recordLabel(source), recordLabel(survivor)),
-	}, nil
+	return StageSubject(ctx, NewMergeCall(t.p, MergeCommand(args)))
 }
 
 func (t mergeRecords) Handle(ctx context.Context, in json.RawMessage) (json.RawMessage, error) {
@@ -251,8 +219,11 @@ func (t mergeRecords) Handle(ctx context.Context, in json.RawMessage) (json.RawM
 	if err := decodeArgs(in, &args); err != nil {
 		return nil, err
 	}
+	// The resolver's own refusal (commandrecord.go), not a second spelling of
+	// it: the approved retry re-enters here, so a type the staging refused must
+	// read the same way when it is refused again.
 	if !mergeableTypes[args.RecordType] {
-		return nil, &BadArgsError{Cause: fmt.Errorf("record_type %q cannot be merged", args.RecordType)}
+		return nil, mergeableTypeError(args.RecordType)
 	}
 	ref, err := t.p.Merge(ctx, datasource.MergeInput{
 		Type: datasource.EntityType(args.RecordType), SourceID: args.SourceID, TargetID: args.TargetID,

--- a/backend/internal/modules/agents/tools_confirm.go
+++ b/backend/internal/modules/agents/tools_confirm.go
@@ -48,22 +48,16 @@ func (t archiveRecord) Spec() mcp.ToolSpec {
 	}
 }
 
+// StageInfo decodes this door's arguments into the archive command and
+// delegates: the refusals and the staged subject live in the resolver
+// (command.go), where the REST door reaches the same ones for the same
+// operation.
 func (t archiveRecord) StageInfo(ctx context.Context, in json.RawMessage) (StageInfo, error) {
 	var args archiveArgs
 	if err := decodeArgs(in, &args); err != nil {
 		return StageInfo{}, err
 	}
-	rec, err := t.p.Read(ctx, datasource.EntityRef{Type: datasource.EntityType(args.RecordType), ID: args.ID})
-	if err != nil {
-		return StageInfo{}, err
-	}
-	if err := refuseStagingElsewhere(rec); err != nil {
-		return StageInfo{}, err
-	}
-	return StageInfo{
-		TargetType: args.RecordType, TargetID: args.ID, TargetVersion: &rec.Version,
-		Summary: fmt.Sprintf("Archive %s %s", args.RecordType, recordLabel(rec)),
-	}, nil
+	return StageSubject(ctx, Bind(NewArchiveResolver(t.p), ArchiveCommand{RecordType: args.RecordType, ID: args.ID}))
 }
 
 func (t archiveRecord) Handle(ctx context.Context, in json.RawMessage) (json.RawMessage, error) {

--- a/backend/internal/modules/agents/tools_confirm.go
+++ b/backend/internal/modules/agents/tools_confirm.go
@@ -62,7 +62,7 @@ func (t archiveRecord) StageInfo(ctx context.Context, in json.RawMessage) (Stage
 	if err := decodeArgs(in, &args); err != nil {
 		return StageInfo{}, err
 	}
-	return StageSubject(ctx, Bind(NewArchiveResolver(t.p), ArchiveCommand(args)))
+	return StageSubject(ctx, NewArchiveCall(t.p, ArchiveCommand(args)))
 }
 
 func (t archiveRecord) Handle(ctx context.Context, in json.RawMessage) (json.RawMessage, error) {

--- a/backend/internal/modules/agents/tools_confirm.go
+++ b/backend/internal/modules/agents/tools_confirm.go
@@ -56,10 +56,31 @@ func (t archiveRecord) Spec() mcp.ToolSpec {
 // only in carrying JSON tags — so it converts rather than restating the fields,
 // and a command that grows one fails to compile here instead of quietly
 // leaving it unset.
+//
+// ONE check runs HERE, before the command is built, for exactly the reason
+// createRecord.StageInfo's does (tools.go): a record type this verb's OWN
+// write path cannot express. Handle archives exclusively through
+// datasource.SystemOfRecordProvider.Archive, which cannot name a type outside
+// the seam's vocabulary — and the surface does not enforce the InputSchema
+// enum at this layer, so a raw tool call can put any string here. Without it,
+// `record_type:"tag"` stages an approval a human releases onto a retry that
+// dies at the provider, and an arbitrary string stages one with a target type
+// the approvals surface has no visibility rule for at all: a zombie authority
+// object, minted at the caller's choosing.
+//
+// That is a fact about THIS door's executor rather than about the operation,
+// which is why it cannot live in the resolver: the same command reaching it
+// from REST names an archive whose OWN module's handler performs it fine, and
+// archiveResolver.Guards stands down for exactly that reason.
 func (t archiveRecord) StageInfo(ctx context.Context, in json.RawMessage) (StageInfo, error) {
 	var args archiveArgs
 	if err := decodeArgs(in, &args); err != nil {
 		return StageInfo{}, err
+	}
+	if !servedByTheRecordSeam(args.RecordType) {
+		return StageInfo{}, &BadArgsError{Cause: fmt.Errorf(
+			"this verb does not archive %q records, so no approval of it could ever be carried out",
+			args.RecordType)}
 	}
 	return StageSubject(ctx, NewArchiveCall(t.p, ArchiveCommand(args)))
 }

--- a/backend/internal/modules/agents/tools_confirm.go
+++ b/backend/internal/modules/agents/tools_confirm.go
@@ -139,8 +139,8 @@ func (t promoteLead) Handle(ctx context.Context, in json.RawMessage) (json.RawMe
 	if err := decodeArgs(in, &args); err != nil {
 		return nil, err
 	}
-	if !validTriggers[args.Trigger] {
-		return nil, &BadArgsError{Cause: fmt.Errorf("trigger %q is not genuine engagement", args.Trigger)}
+	if err := requireGenuineTrigger(args.Trigger); err != nil {
+		return nil, err
 	}
 	ref, merged, err := t.promoter.PromoteLead(ctx, args.LeadID, args.Trigger, args.EvidenceNote)
 	if err != nil {
@@ -219,11 +219,12 @@ func (t mergeRecords) Handle(ctx context.Context, in json.RawMessage) (json.RawM
 	if err := decodeArgs(in, &args); err != nil {
 		return nil, err
 	}
-	// The resolver's own refusal (commandrecord.go), not a second spelling of
-	// it: the approved retry re-enters here, so a type the staging refused must
-	// read the same way when it is refused again.
-	if !mergeableTypes[args.RecordType] {
-		return nil, mergeableTypeError(args.RecordType)
+	// The resolver's own refusal (commandrecord.go), predicate and sentence
+	// both: the approved retry re-enters here without passing Guards, so a type
+	// the staging refused must be refused again, and read the same way when it
+	// is.
+	if err := requireMergeableType(args.RecordType); err != nil {
+		return nil, err
 	}
 	ref, err := t.p.Merge(ctx, datasource.MergeInput{
 		Type: datasource.EntityType(args.RecordType), SourceID: args.SourceID, TargetID: args.TargetID,

--- a/backend/internal/modules/agents/tools_confirm.go
+++ b/backend/internal/modules/agents/tools_confirm.go
@@ -52,12 +52,17 @@ func (t archiveRecord) Spec() mcp.ToolSpec {
 // delegates: the refusals and the staged subject live in the resolver
 // (command.go), where the REST door reaches the same ones for the same
 // operation.
+//
+// This door's wire shape IS the command's field set — the arguments differ
+// only in carrying JSON tags — so it converts rather than restating the fields,
+// and a command that grows one fails to compile here instead of quietly
+// leaving it unset.
 func (t archiveRecord) StageInfo(ctx context.Context, in json.RawMessage) (StageInfo, error) {
 	var args archiveArgs
 	if err := decodeArgs(in, &args); err != nil {
 		return StageInfo{}, err
 	}
-	return StageSubject(ctx, Bind(NewArchiveResolver(t.p), ArchiveCommand{RecordType: args.RecordType, ID: args.ID}))
+	return StageSubject(ctx, Bind(NewArchiveResolver(t.p), ArchiveCommand(args)))
 }
 
 func (t archiveRecord) Handle(ctx context.Context, in json.RawMessage) (json.RawMessage, error) {

--- a/backend/internal/modules/agents/tools_enrich.go
+++ b/backend/internal/modules/agents/tools_enrich.go
@@ -23,7 +23,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"net/url"
 
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
@@ -31,22 +30,35 @@ import (
 	"github.com/gradionhq/margince/backend/internal/shared/ports/mcp"
 )
 
-// The depth vocabulary: how much of the site a call reads. The two values are
-// two contract operations behind one verb, so the argument is what chooses
-// between them rather than the client picking a route. EXPORTED because the
-// implementation of CompanyEnricher lives in the composition layer and routes
-// on them — a second spelling there would silently send a site read to the
-// one-page path.
+// EnrichDepth is how much of the site a call reads. Its two values are two
+// contract operations behind one verb, so the argument is what chooses between
+// them rather than the client picking a route.
+//
+// A named type rather than a bare string, because the two doors reach this
+// vocabulary from opposite directions: the tool parses one of two words out of
+// its arguments, and the REST door has no word at all — its two routes ARE the
+// two depths, so its decoders set the value structurally (commandrecord.go).
+// A string would let the second of those be spelled wrong in a way every
+// schema accepts (gradionhq/margince-poc-v1#928 task 7).
+//
+// EXPORTED because the implementation of CompanyEnricher lives in the
+// composition layer and routes on it — a second spelling there would silently
+// send a site read to the one-page path.
+type EnrichDepth string
+
+// The two depths, and the whole vocabulary: EnrichDepthPage reads one page and
+// answers with the proposal, EnrichDepthSite queues a multi-page crawl and
+// answers with the read's id and queue state.
 const (
-	EnrichDepthPage = "page"
-	EnrichDepthSite = "site"
+	EnrichDepthPage EnrichDepth = "page"
+	EnrichDepthSite EnrichDepth = "site"
 )
 
 // CompanyEnricher reads a company's website and stages what it found. depth is
 // EnrichDepthPage (one page, answers with the proposal) or EnrichDepthSite (a
 // queued multi-page crawl, answers with the read's id and queue state).
 type CompanyEnricher interface {
-	EnrichCompany(ctx context.Context, orgID ids.UUID, overrideURL, depth string) (json.RawMessage, error)
+	EnrichCompany(ctx context.Context, orgID ids.UUID, overrideURL string, depth EnrichDepth) (json.RawMessage, error)
 }
 
 // RegisterEnrichTool wires the enrich verb over the site-read seam.
@@ -55,9 +67,9 @@ func RegisterEnrichTool(r *Registry, p datasource.SystemOfRecordProvider, enrich
 }
 
 type enrichArgs struct {
-	OrganizationID ids.UUID `json:"organization_id"`
-	URL            string   `json:"url"`
-	Depth          string   `json:"depth"`
+	OrganizationID ids.UUID    `json:"organization_id"`
+	URL            string      `json:"url"`
+	Depth          EnrichDepth `json:"depth"`
 }
 
 type enrichCompany struct {
@@ -90,27 +102,22 @@ func (t enrichCompany) Spec() mcp.ToolSpec {
 	}
 }
 
+// StageInfo decodes this door's arguments into the enrich command and
+// delegates: the refusals and the staged subject live in the resolver
+// (commandrecord.go), where the REST door reaches the same ones for the same
+// operation.
+//
+// The depth is admitted HERE and typed by the command, which is the division
+// this verb needs. This door receives a WORD and has to decide whether it is
+// one of the two; the REST door receives no word at all — its two routes are
+// the two depths — so the vocabulary check belongs to the door that has a
+// string to check, and the command carries only the resolved value.
 func (t enrichCompany) StageInfo(ctx context.Context, in json.RawMessage) (StageInfo, error) {
 	args, err := readEnrichArgs(in)
 	if err != nil {
 		return StageInfo{}, err
 	}
-	rec, err := t.p.Read(ctx, datasource.EntityRef{Type: datasource.EntityOrganization, ID: args.OrganizationID})
-	if err != nil {
-		return StageInfo{}, err
-	}
-	if err := refuseStagingElsewhere(rec); err != nil {
-		return StageInfo{}, err
-	}
-	target := "its own domain"
-	if args.URL != "" {
-		target = args.URL
-	}
-	return StageInfo{
-		TargetType: string(datasource.EntityOrganization), TargetID: args.OrganizationID, TargetVersion: &rec.Version,
-		Summary: fmt.Sprintf("Read %s from %s and propose enrichment of %s",
-			args.Depth, target, recordLabel(rec)),
-	}, nil
+	return StageSubject(ctx, NewEnrichCall(t.p, EnrichCommand(args)))
 }
 
 func (t enrichCompany) Handle(ctx context.Context, in json.RawMessage) (json.RawMessage, error) {
@@ -128,6 +135,10 @@ func (t enrichCompany) Handle(ctx context.Context, in json.RawMessage) (json.Raw
 // readEnrichArgs decodes, defaults the depth and admits the override URL in one
 // place, so a call this refuses can never reach a human's inbox on the staging
 // path and then be refused differently on the execution path.
+//
+// The URL admission is the resolver's own function (requireEnrichURL,
+// commandrecord.go), not a second copy of it: the staging path asks it through
+// Guards, and this asks it for Handle, which the approved retry re-enters.
 func readEnrichArgs(in json.RawMessage) (enrichArgs, error) {
 	var args enrichArgs
 	if err := decodeArgs(in, &args); err != nil {
@@ -140,13 +151,8 @@ func readEnrichArgs(in json.RawMessage) (enrichArgs, error) {
 		return enrichArgs{}, &BadArgsError{Cause: fmt.Errorf("depth %q is not %q or %q",
 			args.Depth, EnrichDepthPage, EnrichDepthSite)}
 	}
-	if args.URL != "" {
-		// The same admission the REST route applies before it fetches: a
-		// scheme-less or hostless target is a bad argument, not a thin page.
-		parsed, err := url.Parse(args.URL)
-		if err != nil || (parsed.Scheme != "http" && parsed.Scheme != "https") || parsed.Host == "" {
-			return enrichArgs{}, &BadArgsError{Cause: fmt.Errorf("url %q must be an absolute http(s) URL", args.URL)}
-		}
+	if err := requireEnrichURL(args.URL); err != nil {
+		return enrichArgs{}, err
 	}
 	return args, nil
 }

--- a/backend/internal/modules/agents/tools_enrich.go
+++ b/backend/internal/modules/agents/tools_enrich.go
@@ -137,8 +137,11 @@ func (t enrichCompany) Handle(ctx context.Context, in json.RawMessage) (json.Raw
 // path and then be refused differently on the execution path.
 //
 // The URL admission is the resolver's own function (requireEnrichURL,
-// commandrecord.go), not a second copy of it: the staging path asks it through
-// Guards, and this asks it for Handle, which the approved retry re-enters.
+// commandrecord.go), not a second copy of it. It is asked TWICE on the staging
+// path — once here, once in Guards — because StageInfo needs this function for
+// the depth defaulting anyway; that redundancy is the price of Handle, which an
+// approved retry re-enters without passing Guards, sharing the one spelling
+// rather than keeping its own.
 func readEnrichArgs(in json.RawMessage) (enrichArgs, error) {
 	var args enrichArgs
 	if err := decodeArgs(in, &args); err != nil {

--- a/backend/internal/modules/agents/tools_enrich_test.go
+++ b/backend/internal/modules/agents/tools_enrich_test.go
@@ -86,10 +86,11 @@ func TestEnrichRefusesToStageAMirrorHeldOrganization(t *testing.T) {
 }
 
 type recordingEnricher struct {
-	url, depth string
+	url   string
+	depth EnrichDepth
 }
 
-func (e *recordingEnricher) EnrichCompany(_ context.Context, _ ids.UUID, url, depth string) (json.RawMessage, error) {
+func (e *recordingEnricher) EnrichCompany(_ context.Context, _ ids.UUID, url string, depth EnrichDepth) (json.RawMessage, error) {
 	e.url, e.depth = url, depth
 	return nil, nil
 }

--- a/backend/internal/modules/agents/tools_lifecycle.go
+++ b/backend/internal/modules/agents/tools_lifecycle.go
@@ -18,7 +18,6 @@ package agents
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
@@ -106,8 +105,8 @@ func (t relinkActivity) Handle(ctx context.Context, in json.RawMessage) (json.Ra
 	if err := decodeArgs(in, &args); err != nil {
 		return nil, err
 	}
-	if !relinkTargets[args.EntityType] {
-		return nil, &BadArgsError{Cause: fmt.Errorf("entity_type %q is not a link target", args.EntityType)}
+	if err := requireLinkTarget(args.EntityType); err != nil {
+		return nil, err
 	}
 	noteEvidence(ctx, datasource.EntityActivity, args.ActivityID)
 	noteEvidence(ctx, datasource.EntityType(args.EntityType), args.EntityID)

--- a/backend/internal/modules/agents/tools_lifecycle.go
+++ b/backend/internal/modules/agents/tools_lifecycle.go
@@ -18,9 +18,7 @@ package agents
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
@@ -141,22 +139,16 @@ func (t disqualifyLead) Spec() mcp.ToolSpec {
 	}
 }
 
+// StageInfo decodes this door's arguments into the retirement command and
+// delegates: the refusals and the staged subject live in the resolver
+// (commandlifecycle.go), where the REST door reaches the same ones for the
+// same operation.
 func (t disqualifyLead) StageInfo(ctx context.Context, in json.RawMessage) (StageInfo, error) {
 	var args disqualifyLeadArgs
 	if err := decodeArgs(in, &args); err != nil {
 		return StageInfo{}, err
 	}
-	rec, err := t.p.Read(ctx, datasource.EntityRef{Type: datasource.EntityLead, ID: args.LeadID})
-	if err != nil {
-		return StageInfo{}, err
-	}
-	if err := refuseStagingElsewhere(rec); err != nil {
-		return StageInfo{}, err
-	}
-	return StageInfo{
-		TargetType: string(datasource.EntityLead), TargetID: args.LeadID, TargetVersion: &rec.Version,
-		Summary: fmt.Sprintf("Disqualify lead %s", recordLabel(rec)),
-	}, nil
+	return StageSubject(ctx, NewDisqualifyLeadCall(t.p, DisqualifyLeadCommand(args)))
 }
 
 func (t disqualifyLead) Handle(ctx context.Context, in json.RawMessage) (json.RawMessage, error) {
@@ -210,22 +202,23 @@ func (t advanceProjectPhase) Spec() mcp.ToolSpec {
 	}
 }
 
+// StageInfo decodes this door's arguments into the phase-transition command
+// and delegates: the refusals — the phase vocabulary, the reason a close
+// requires, and the project itself — and the staged subject live in the
+// resolver (commandlifecycle.go), where the REST door reaches the same ones
+// for the same operation. It decodes without admitting, because Guards admits:
+// StageSubject runs the refusals before the subject, so a phase this door
+// would have rejected still never reaches a human's inbox.
 func (t advanceProjectPhase) StageInfo(ctx context.Context, in json.RawMessage) (StageInfo, error) {
-	args, err := t.readArgs(in)
-	if err != nil {
+	var args advanceProjectPhaseArgs
+	if err := decodeArgs(in, &args); err != nil {
 		return StageInfo{}, err
 	}
-	rec, err := t.p.Read(ctx, datasource.EntityRef{Type: datasource.EntityProject, ID: args.ProjectID})
-	if err != nil {
-		return StageInfo{}, err
-	}
-	if err := refuseStagingElsewhere(rec); err != nil {
-		return StageInfo{}, err
-	}
-	return StageInfo{
-		TargetType: string(datasource.EntityProject), TargetID: args.ProjectID, TargetVersion: &rec.Version,
-		Summary: fmt.Sprintf("Move project %s to %s", recordLabel(rec), args.ToPhase),
-	}, nil
+	return StageSubject(ctx, NewAdvanceProjectPhaseCall(t.p, AdvanceProjectPhaseCommand{
+		ProjectID: args.ProjectID,
+		ToPhase:   args.ToPhase,
+		Reason:    args.Reason,
+	}))
 }
 
 func (t advanceProjectPhase) Handle(ctx context.Context, in json.RawMessage) (json.RawMessage, error) {
@@ -245,23 +238,18 @@ func (t advanceProjectPhase) Handle(ctx context.Context, in json.RawMessage) (js
 	return t.advancer.AdvanceProjectPhase(ctx, args.ProjectID, args.ToPhase, args.Reason, pin)
 }
 
-// readArgs decodes and admits the phase in one place, so the staging path and
-// the execution path cannot disagree about what a valid transition is — a phase
-// this refuses must never reach a human's inbox.
+// readArgs decodes and admits the transition for the EXECUTION path, through
+// the resolver's own requireProjectPhase (commandlifecycle.go) rather than a
+// second copy of it. Closing without a reason is refused by the contract, and
+// refusing it at both doors is what keeps a human from spending an approval on
+// a rule the agent could have been told before anyone was asked.
 func (t advanceProjectPhase) readArgs(in json.RawMessage) (advanceProjectPhaseArgs, error) {
 	var args advanceProjectPhaseArgs
 	if err := decodeArgs(in, &args); err != nil {
 		return advanceProjectPhaseArgs{}, err
 	}
-	if !projectPhases[args.ToPhase] {
-		return advanceProjectPhaseArgs{}, &BadArgsError{Cause: fmt.Errorf("to_phase %q is not a project phase", args.ToPhase)}
-	}
-	// Closing without a reason is refused by the contract, so refusing it here
-	// is what keeps the promise above: without it the call stages, a human
-	// approves, and the redemption then fails on a rule the agent could have
-	// been told before anyone was asked.
-	if args.ToPhase == projectPhaseClosed && (args.Reason == nil || strings.TrimSpace(*args.Reason) == "") {
-		return advanceProjectPhaseArgs{}, &BadArgsError{Cause: errors.New("reason is required when to_phase is closed")}
+	if err := requireProjectPhase(args.ToPhase, args.Reason); err != nil {
+		return advanceProjectPhaseArgs{}, err
 	}
 	return args, nil
 }

--- a/backend/internal/modules/agents/tools_progress.go
+++ b/backend/internal/modules/agents/tools_progress.go
@@ -69,31 +69,23 @@ func (t progressDeal) ResolverInput(ctx context.Context, in json.RawMessage) (mc
 	return DealMoveTierInput(ctx, t.p, t.stages, args.DealID, args.ToStageID, in)
 }
 
-// StageInfo pins the staged move to the deal's CURRENT version, exactly
-// like advance_deal — the approval covers the deal as the human saw it.
+// StageInfo decodes this door's arguments into the SAME command advance_deal
+// stages (AdvanceDealCommand, commandlifecycle.go) and delegates.
+//
+// The same command, not a same-shaped one: the two tools stage the same act,
+// so a human reading an inbox should not have to know which tool proposed a
+// move to understand what approving it does — and the note this intent adds
+// afterwards is not part of the move, so it changes neither the target, the
+// pin, nor the sentence.
 func (t progressDeal) StageInfo(ctx context.Context, in json.RawMessage) (StageInfo, error) {
 	var args progressDealArgs
 	if err := decodeArgs(in, &args); err != nil {
 		return StageInfo{}, err
 	}
-	rec, err := t.p.Read(ctx, datasource.EntityRef{Type: datasource.EntityDeal, ID: args.DealID})
-	if err != nil {
-		return StageInfo{}, err
-	}
-	if err := refuseStagingElsewhere(rec); err != nil {
-		return StageInfo{}, err
-	}
-	semantic, _, err := t.stages.StageSemantic(ctx, args.ToStageID)
-	if err != nil {
-		return StageInfo{}, err
-	}
-	return StageInfo{
-		TargetType: "deal", TargetID: args.DealID, TargetVersion: &rec.Version,
-		// The same sentence advance_deal stages, because the two tools stage the
-		// same act — a human reading an inbox should not have to know which tool
-		// proposed a move to understand what approving it does.
-		Summary: dealMoveSummary(ctx, t.stages, rec, semantic),
-	}, nil
+	return StageSubject(ctx, NewAdvanceDealCall(t.p, t.stages, AdvanceDealCommand{
+		DealID:    args.DealID,
+		ToStageID: args.ToStageID,
+	}))
 }
 
 func (t progressDeal) Handle(ctx context.Context, in json.RawMessage) (json.RawMessage, error) {

--- a/backend/internal/modules/agents/tools_scheduling.go
+++ b/backend/internal/modules/agents/tools_scheduling.go
@@ -15,9 +15,6 @@ package agents
 import (
 	"context"
 	"encoding/json"
-	"errors"
-	"fmt"
-	"strings"
 	"time"
 
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
@@ -96,104 +93,21 @@ func (t bookMeetingTool) Spec() mcp.ToolSpec {
 	}
 }
 
-// StageInfo puts a refused booking in the inbox instead of dead-ending it.
+// StageInfo decodes this door's arguments into the booking command and
+// delegates: the refusals and the staged subject live in the resolver
+// (commandlinked.go), where the REST door reaches the same ones for the same
+// operation.
 //
-// A booking anchors on no existing row, so unlike the two send verbs it has no
-// single target handed to it. What it does have is its links, and every one of
-// them is read through readStageableLinks — the shared rule for a call that
-// names its own records.
-//
-// The first link becomes the displayed target and supplies the pin, which is
-// what makes a booking's staged row bind to a record rather than float free: a
-// meeting is a commitment ON that record, and the human deciding it is the one
-// whose scope reaches it. A booking with NO links is refused before any of
-// that: crm.yaml requires them, and a staged approval with no target is a human
-// asked to release a meeting attached to nothing — nothing to show them, and no
-// version to pin it against.
+// This door's wire shape IS the command's field set — the arguments differ
+// only in carrying JSON tags — so it converts rather than restating the
+// fields, and a command that grows one fails to compile here instead of
+// quietly leaving it unset.
 func (t bookMeetingTool) StageInfo(ctx context.Context, in json.RawMessage) (StageInfo, error) {
 	var args BookMeetingArgs
 	if err := decodeArgs(in, &args); err != nil {
 		return StageInfo{}, err
 	}
-	if err := requireBookingWindow(args); err != nil {
-		return StageInfo{}, err
-	}
-	if err := requireBookingLinks(args); err != nil {
-		return StageInfo{}, err
-	}
-	links, err := uniqueRecordLinks(args.Links)
-	if err != nil {
-		return StageInfo{}, err
-	}
-	records, err := readStageableLinks(ctx, t.p, links)
-	if err != nil {
-		return StageInfo{}, err
-	}
-	return StageInfo{
-		TargetType:    links[0].EntityType,
-		TargetID:      links[0].EntityID,
-		TargetVersion: &records[0].Version,
-		Summary:       describeBooking(args, links),
-	}, nil
-}
-
-// requireBookingWindow refuses a booking that ends before it starts.
-//
-// The store refuses it too (errBookingEndNotAfterStart), which is why this is
-// not a correctness hole — but reaching THAT refusal costs the human's approval
-// on the way past, since redemption is consumed before the handler runs. So
-// both doors ask first, the same rule the link checks below follow.
-func requireBookingWindow(args BookMeetingArgs) error {
-	if args.End.After(args.Start) {
-		return nil
-	}
-	return &BadArgsError{Cause: fmt.Errorf(
-		"`end` (%s) does not follow `start` (%s); a booking with no duration would be refused after approval",
-		args.End.Format(time.RFC3339), args.Start.Format(time.RFC3339))}
-}
-
-// requireBookingLinks enforces what the schema states: at least one link.
-//
-// It is a function rather than a line in StageInfo because the MCP surface does
-// not validate arguments against an InputSchema — that schema is documentation —
-// so the rule holds only where the code puts it, and this verb has two doors: the
-// staging path and the post-approval execute. A rule enforced at one of them is
-// a rule a caller meets only sometimes.
-func requireBookingLinks(args BookMeetingArgs) error {
-	if len(args.Links) > 0 {
-		return nil
-	}
-	return &BadArgsError{Cause: errors.New(
-		"`links` needs at least one entry: a booking names who and what it is about, " +
-			"and one attached to nothing cannot be approved against a record")}
-}
-
-// describeBooking is the one line the inbox shows.
-//
-// It names every argument that changes what gets released — the slot, the
-// subject, WHOSE calendar it lands on, and how many records it attaches to.
-// A human approving from the inbox row sees only this string, so an argument
-// missing from it is an effect nobody agreed to: the REST admission gate's own
-// summary enumerates every body field for exactly this reason, and the two
-// transports stage the same operation.
-//
-// The subject is the agent's own text, so it is quoted rather than run into
-// the sentence; the approvals engine sanitizes every summary at the single
-// staging path regardless.
-func describeBooking(args BookMeetingArgs, links []RecordLink) string {
-	subject := args.Subject
-	if strings.TrimSpace(subject) == "" {
-		subject = "(no subject)"
-	}
-	summary := fmt.Sprintf("Book %q from %s to %s",
-		subject, args.Start.Format(time.RFC3339), args.End.Format(time.RFC3339))
-	if args.HostUserID != nil {
-		summary += fmt.Sprintf(" on %s's calendar", args.HostUserID)
-	}
-	if len(links) > 0 {
-		summary += fmt.Sprintf(", attached to %d record(s)", len(links))
-	}
-	return summary
+	return StageSubject(ctx, NewBookMeetingCall(t.p, BookMeetingCommand(args)))
 }
 
 func (t bookMeetingTool) Handle(ctx context.Context, in json.RawMessage) (json.RawMessage, error) {
@@ -204,13 +118,15 @@ func (t bookMeetingTool) Handle(ctx context.Context, in json.RawMessage) (json.R
 	// Both doors, not just staging. This one is reached with an approval already
 	// redeemed, so a call that skipped StageInfo would otherwise execute a
 	// booking the schema says is impossible — and the cap and the dedupe are
-	// part of that: the human approved "attached to N record(s)" as StageInfo
+	// part of that: the human approved "attached to N record(s)" as the resolver
 	// counted them, and a booking that reaches the seam with the raw list is one
 	// whose approval was read against a different reach than the one it takes.
-	if err := requireBookingWindow(args); err != nil {
+	// The functions are the resolver's own (commandlinked.go), not a second
+	// spelling of them.
+	if err := requireBookingWindow(args.Start, args.End); err != nil {
 		return nil, err
 	}
-	if err := requireBookingLinks(args); err != nil {
+	if err := requireBookingLinks(args.Links); err != nil {
 		return nil, err
 	}
 	links, err := uniqueRecordLinks(args.Links)

--- a/backend/internal/modules/agents/tools_update.go
+++ b/backend/internal/modules/agents/tools_update.go
@@ -86,6 +86,10 @@ func (updateRecord) ServesRecordType(recordType string) bool {
 // StageInfo puts a patch the contract tightened to confirm-first in the inbox
 // instead of dead-ending it (#982).
 //
+// It decodes this door's arguments into the patch command and delegates: the
+// refusals and the staged subject live in the resolver (command.go), where the
+// REST door reaches the same ones for the same operation.
+//
 // It stages the WHOLE call, not the per-field residue Handle's precedence split
 // stages. The two answer different questions and both are real: the split asks
 // "may a machine overwrite what a person typed", and applies everything else
@@ -94,33 +98,16 @@ func (updateRecord) ServesRecordType(recordType string) bool {
 // before admission, so a call that reaches here has already been judged the
 // second way, and an approved retry carries the ApprovalRedeemed marker that
 // sends Handle straight to the full apply.
-//
-// The record is READ, for the reasons its 🟡 siblings read theirs: a patch
-// naming a record the caller cannot see must be refused now rather than after a
-// human has spent a one-shot approval on it, and a record whose authority lives
-// in another system of record can never have that approval released at all.
 func (t updateRecord) StageInfo(ctx context.Context, in json.RawMessage) (StageInfo, error) {
 	var args updateRecordArgs
 	if err := decodeArgs(in, &args); err != nil {
 		return StageInfo{}, err
 	}
-	if err := rejectUnknownFields(updateShapes, args.RecordType, args.Fields); err != nil {
-		return StageInfo{}, err
-	}
-	rec, err := t.p.Read(ctx, datasource.EntityRef{
-		Type: datasource.EntityType(args.RecordType), ID: args.ID,
-	})
-	if err != nil {
-		return StageInfo{}, err
-	}
-	if err := refuseStagingElsewhere(rec); err != nil {
-		return StageInfo{}, err
-	}
-	return StageInfo{
-		TargetType: args.RecordType,
-		TargetID:   args.ID,
-		Summary:    describeGenericWrite("Update", args.RecordType, args.Fields),
-	}, nil
+	// This door's wire shape IS the command's field set (same reasoning as
+	// archiveRecord.StageInfo, command.go), so it converts rather than
+	// restating the fields: a field PatchCommand grows fails to compile here
+	// instead of quietly leaving it unset.
+	return StageSubject(ctx, NewPatchCall(t.p, PatchCommand(args)))
 }
 
 // Handle is the per-field human-edit-precedence split (interfaces.md

--- a/backend/internal/modules/agents/tools_update.go
+++ b/backend/internal/modules/agents/tools_update.go
@@ -103,11 +103,13 @@ func (t updateRecord) StageInfo(ctx context.Context, in json.RawMessage) (StageI
 	if err := decodeArgs(in, &args); err != nil {
 		return StageInfo{}, err
 	}
-	// This door's wire shape IS the command's field set (same reasoning as
-	// archiveRecord.StageInfo, command.go), so it converts rather than
-	// restating the fields: a field PatchCommand grows fails to compile here
-	// instead of quietly leaving it unset.
-	return StageSubject(ctx, NewPatchCall(t.p, PatchCommand(args)))
+	// Named field-by-field rather than a bare conversion: PatchCommand
+	// deliberately does not carry if_version (command.go's own doc comment
+	// says why), so its shape no longer matches updateRecordArgs' and a
+	// conversion would not compile.
+	return StageSubject(ctx, NewPatchCall(t.p, PatchCommand{
+		RecordType: args.RecordType, ID: args.ID, Fields: args.Fields,
+	}))
 }
 
 // Handle is the per-field human-edit-precedence split (interfaces.md

--- a/backend/internal/modules/approvals/decide.go
+++ b/backend/internal/modules/approvals/decide.go
@@ -233,6 +233,11 @@ func applyEditedPayload(ctx context.Context, tx pgx.Tx, id ids.ApprovalID, edite
 	if err := assertSameEntityRefs(a.ProposedChange, canonical); err != nil {
 		return err
 	}
+	// The same rule for the half entityRefs cannot see: a record named inside the
+	// request path rather than as a field of its own.
+	if err := assertSameCallIdentity(a.ProposedChange, canonical); err != nil {
+		return err
+	}
 	if _, err := tx.Exec(ctx,
 		`UPDATE approval SET proposed_change = $2, diff_hash = $3 WHERE id = $1`,
 		id, canonical, editedHash); err != nil {

--- a/backend/internal/modules/approvals/decide.go
+++ b/backend/internal/modules/approvals/decide.go
@@ -50,13 +50,17 @@ func (s *Service) Decide(ctx context.Context, id ids.ApprovalID, approve bool, r
 // re-tiers and re-admits like any other call. The old hash, and any
 // token bound to it, no longer opens anything.
 //
-// What an edit may touch is bounded: the staged payload's entity
-// references are pinned (assertSameEntityRefs), so the edit corrects the
-// action but cannot re-aim it at another record. That bound is the
-// admission control on this arm — a server-proposed effect resolves its
-// target from the payload and may run under a system principal, so the
-// stores' own RBAC and row-scope gates cannot be relied on to re-check
-// what the human wrote.
+// What an edit may touch is bounded by TWO assertions, because a record is
+// named two different ways depending on how the call was staged: the staged
+// payload's entity references are pinned (assertSameEntityRefs) for a value
+// carried as a field, and a REST staging's operation/path are pinned
+// separately (assertSameCallIdentity) for a record named inside the request
+// path instead, which entityRefs cannot see. Together they mean the edit
+// corrects the action but cannot re-aim it at another record or another
+// call. That bound is the admission control on this arm — a server-proposed
+// effect resolves its target from the payload and may run under a system
+// principal, so the stores' own RBAC and row-scope gates cannot be relied on
+// to re-check what the human wrote.
 func (s *Service) DecideEdited(ctx context.Context, id ids.ApprovalID, edited json.RawMessage) (row, error) {
 	if len(edited) == 0 {
 		return row{}, &InvalidEditError{Cause: errors.New("empty payload")}

--- a/backend/internal/modules/approvals/editscope.go
+++ b/backend/internal/modules/approvals/editscope.go
@@ -45,8 +45,14 @@ import (
 type RetargetedEditError struct{ Paths []string }
 
 func (e *RetargetedEditError) Error() string {
-	return "edited_payload changes the entity reference at " + strings.Join(e.Paths, ", ") +
-		"; an edit may correct a staged action's content, never the record it applies to"
+	// "the record it applies to" covers both callers of this type: an entity
+	// reference IS the record (assertSameEntityRefs), and operation/path say
+	// WHICH CALL runs against it (assertSameCallIdentity) — an edited
+	// operation is a different effect on the same or a different record, not
+	// a value change, so the message says what both share rather than
+	// naming "entity reference" on a path that is not one.
+	return "edited_payload changes what runs at " + strings.Join(e.Paths, ", ") +
+		"; an edit may correct a staged action's content, never the call or the record it applies to"
 }
 
 // refEscape makes an object key unambiguous inside a path. The editor CHOOSES
@@ -126,24 +132,36 @@ func assertSameEntityRefs(original, edited json.RawMessage) error {
 	return &RetargetedEditError{Paths: changed}
 }
 
-// callIdentityMembers are the members of a REST staging that say WHICH CALL was
-// staged rather than what it contains. The transport writes them
-// (compose.canonicalRESTCall) and the redemption re-derives them from the retry's
-// own method and URL, so an edit that changes one moves the effect to a different
-// operation or a different record while every other check still reads the original.
+// callIdentityBody is the ONE top-level member of a REST staging that is
+// CONTENT — a human is meant to correct it. Every other top-level member says
+// WHICH CALL was staged: the transport writes them (compose.canonicalRESTCall)
+// and the redemption re-derives them from the retry's own method, URL and
+// headers, so an edit that changes one moves the effect to a different
+// operation, a different record, or a different precondition while every
+// other check still reads the original.
 //
-// They are pinned separately from entityRefs rather than folded into it because
-// entityRefs answers a question about VALUES — is this the same record — by
-// matching strings that parse wholly as a UUID. A path is a string that CONTAINS
-// one, and widening the UUID probe to search inside arbitrary strings would pin
-// every id that ever appears in prose, including a body a human is meant to edit.
-var callIdentityMembers = []string{"operation", "path"}
+// Pinned by EXCLUDING body rather than by naming "operation" and "path"
+// deliberately: a hand-maintained allowlist stays correct only until the
+// canonical call grows a member nobody remembered to add here — and it will,
+// since headers like If-Match and Idempotency-Key are the version pin and the
+// retry key, exactly what this guard exists to protect. Denying by default
+// means a member the transport starts writing tomorrow is pinned by
+// construction, not by someone updating a list.
+const callIdentityBody = "body"
+
+// isRESTStaging reports whether a payload carries the members a REST staging
+// always writes. A tool staging (the MCP door stages tool arguments, not a
+// method/path/body triple) has neither operation nor path, and pinning every
+// one of ITS top-level members here — deny-by-default applied past this gate
+// — would make every tool-staged approval uneditable; entityRefs governs its
+// content instead.
+func isRESTStaging(payload map[string]json.RawMessage) bool {
+	_, hasOp := payload["operation"]
+	_, hasPath := payload["path"]
+	return hasOp || hasPath
+}
 
 // assertSameCallIdentity refuses an edit that changes which call was staged.
-//
-// A staging that carries neither member is not a REST staging — the tool door
-// stages tool arguments — and has no call identity to pin here; entityRefs governs
-// it, as it governs the body of this one.
 func assertSameCallIdentity(original, edited json.RawMessage) error {
 	var before, after map[string]json.RawMessage
 	if err := json.Unmarshal(original, &before); err != nil {
@@ -152,8 +170,22 @@ func assertSameCallIdentity(original, edited json.RawMessage) error {
 	if err := json.Unmarshal(edited, &after); err != nil {
 		return fmt.Errorf("approvals: decoding an edited change to compare its call identity: %w", err)
 	}
+	if !isRESTStaging(before) && !isRESTStaging(after) {
+		return nil
+	}
+	members := map[string]struct{}{}
+	for member := range before {
+		if member != callIdentityBody {
+			members[member] = struct{}{}
+		}
+	}
+	for member := range after {
+		if member != callIdentityBody {
+			members[member] = struct{}{}
+		}
+	}
 	var changed []string
-	for _, member := range callIdentityMembers {
+	for member := range members {
 		was, had := before[member]
 		now, has := after[member]
 		if had != has || !bytes.Equal(was, now) {
@@ -163,5 +195,9 @@ func assertSameCallIdentity(original, edited json.RawMessage) error {
 	if len(changed) == 0 {
 		return nil
 	}
+	// Sorted for the same reason assertSameEntityRefs sorts: the paths come
+	// out of a map, and a refusal that reorders itself on every run is one a
+	// reviewer cannot diff against the last one.
+	sort.Strings(changed)
 	return &RetargetedEditError{Paths: changed}
 }

--- a/backend/internal/modules/approvals/editscope.go
+++ b/backend/internal/modules/approvals/editscope.go
@@ -31,6 +31,7 @@ package approvals
 // is what ADR-0036 §4 is for.
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"sort"
@@ -122,5 +123,45 @@ func assertSameEntityRefs(original, edited json.RawMessage) error {
 	// of a map, and an error message that reorders itself is one a reviewer
 	// cannot diff against the last one.
 	sort.Strings(changed)
+	return &RetargetedEditError{Paths: changed}
+}
+
+// callIdentityMembers are the members of a REST staging that say WHICH CALL was
+// staged rather than what it contains. The transport writes them
+// (compose.canonicalRESTCall) and the redemption re-derives them from the retry's
+// own method and URL, so an edit that changes one moves the effect to a different
+// operation or a different record while every other check still reads the original.
+//
+// They are pinned separately from entityRefs rather than folded into it because
+// entityRefs answers a question about VALUES — is this the same record — by
+// matching strings that parse wholly as a UUID. A path is a string that CONTAINS
+// one, and widening the UUID probe to search inside arbitrary strings would pin
+// every id that ever appears in prose, including a body a human is meant to edit.
+var callIdentityMembers = []string{"operation", "path"}
+
+// assertSameCallIdentity refuses an edit that changes which call was staged.
+//
+// A staging that carries neither member is not a REST staging — the tool door
+// stages tool arguments — and has no call identity to pin here; entityRefs governs
+// it, as it governs the body of this one.
+func assertSameCallIdentity(original, edited json.RawMessage) error {
+	var before, after map[string]json.RawMessage
+	if err := json.Unmarshal(original, &before); err != nil {
+		return fmt.Errorf("approvals: decoding a proposed change to compare its call identity: %w", err)
+	}
+	if err := json.Unmarshal(edited, &after); err != nil {
+		return fmt.Errorf("approvals: decoding an edited change to compare its call identity: %w", err)
+	}
+	var changed []string
+	for _, member := range callIdentityMembers {
+		was, had := before[member]
+		now, has := after[member]
+		if had != has || !bytes.Equal(was, now) {
+			changed = append(changed, "/"+member)
+		}
+	}
+	if len(changed) == 0 {
+		return nil
+	}
 	return &RetargetedEditError{Paths: changed}
 }

--- a/backend/internal/modules/approvals/editscope_decide_integration_test.go
+++ b/backend/internal/modules/approvals/editscope_decide_integration_test.go
@@ -21,11 +21,14 @@ import (
 )
 
 // TestDecideRefusesAnEditThatRepointsARestStagedCall stages a REST-shaped
-// approval (operation + path + body, exactly what compose.canonicalRESTCall
-// produces) against one organization, then asks Decide to release an edit
-// whose PATH names a different organization while its body is untouched. The
-// content stayed identical — only the record moved — which is exactly the
-// shape entityRefs cannot see and assertSameCallIdentity exists to catch.
+// approval — an operation/path/body object, the shape compose.canonicalRESTCall
+// writes (this package cannot import compose to call it directly: compose sits
+// above modules in the dependency graph, so the literal below is hand-built
+// rather than bound to the producer) — against one organization, then asks
+// Decide to release an edit whose PATH names a different organization while
+// its body is untouched. The content stayed identical — only the record
+// moved — which is exactly the shape entityRefs cannot see and
+// assertSameCallIdentity exists to catch.
 func TestDecideRefusesAnEditThatRepointsARestStagedCall(t *testing.T) {
 	e := setupStaging(t)
 	org := e.organization(t)

--- a/backend/internal/modules/approvals/editscope_decide_integration_test.go
+++ b/backend/internal/modules/approvals/editscope_decide_integration_test.go
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package approvals
+
+// An approval a human edits may be corrected, never re-aimed — proved through
+// Decide rather than by calling assertSameCallIdentity directly, because the
+// assertion is only worth anything if the decide path actually calls it. The
+// decide path is also where the row, the diff hash and the audit evidence are
+// all rewritten together in one transaction, which the unit suite cannot show.
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// TestDecideRefusesAnEditThatRepointsARestStagedCall stages a REST-shaped
+// approval (operation + path + body, exactly what compose.canonicalRESTCall
+// produces) against one organization, then asks Decide to release an edit
+// whose PATH names a different organization while its body is untouched. The
+// content stayed identical — only the record moved — which is exactly the
+// shape entityRefs cannot see and assertSameCallIdentity exists to catch.
+func TestDecideRefusesAnEditThatRepointsARestStagedCall(t *testing.T) {
+	e := setupStaging(t)
+	org := e.organization(t)
+	ctx := e.asHumanWith(decidesEverything())
+
+	staged := json.RawMessage(`{"operation":"org_name_promotion","path":"/v1/organizations/` +
+		org.String() + `","body":{"proposed_name":"Acme GmbH"}}`)
+	id, err := e.svc.Stage(ctx, StageInput{
+		Kind:           "org_name_promotion",
+		ProposedChange: staged,
+		DiffHash:       "hash-for-the-call-identity-guard",
+		TargetType:     tableOrganization,
+		TargetID:       org,
+		Summary:        "Rename Acme to Acme GmbH?",
+	})
+	if err != nil {
+		t.Fatalf("staging the REST-shaped approval: %v", err)
+	}
+	before, err := e.svc.Get(ctx, id)
+	if err != nil {
+		t.Fatalf("reading the staged row: %v", err)
+	}
+
+	// The edited payload names a DIFFERENT organization in its path; the body
+	// — the content a human is meant to correct — is byte-identical.
+	other := ids.NewV7()
+	edited := json.RawMessage(`{"operation":"org_name_promotion","path":"/v1/organizations/` +
+		other.String() + `","body":{"proposed_name":"Acme GmbH"}}`)
+
+	_, decideErr := e.svc.DecideEdited(ctx, id, edited)
+	var retargeted *RetargetedEditError
+	if !errors.As(decideErr, &retargeted) {
+		t.Fatalf("DecideEdited(a path-retargeting edit) = %v, want *RetargetedEditError", decideErr)
+	}
+
+	// Any two of the three checks below pass for the wrong reason on their
+	// own: the error type alone does not show the row was left alone, and an
+	// untouched row alone does not show WHICH error refused the edit.
+	after, err := e.svc.Get(ctx, id)
+	if err != nil {
+		t.Fatalf("reading the row after the refused edit: %v", err)
+	}
+	if after.Status != "pending" {
+		t.Errorf("the refused edit left the row %q; nothing should have been decided", after.Status)
+	}
+	if !bytes.Equal(before.ProposedChange, after.ProposedChange) {
+		t.Errorf("proposed_change changed despite the refused edit:\n before = %s\n after  = %s",
+			before.ProposedChange, after.ProposedChange)
+	}
+	if before.DiffHash != after.DiffHash {
+		t.Errorf("diff_hash changed despite the refused edit: before = %q, after = %q", before.DiffHash, after.DiffHash)
+	}
+}

--- a/backend/internal/modules/approvals/editscope_test.go
+++ b/backend/internal/modules/approvals/editscope_test.go
@@ -204,6 +204,17 @@ func TestAssertSameCallIdentityPinsEveryMemberOfTheStagedCallExceptBody(t *testi
 			edited:      `{"operation":"advance_deal","path":"` + dealPath + `","if_match":"9","body":{}}`,
 			wantChanged: []string{"/if_match"},
 		},
+		{
+			// The cross-task seam: compose.canonicalRESTCall now writes a
+			// `headers` member carrying If-Match and Idempotency-Key -- the
+			// version pin and the retry key. Nothing else in this codebase
+			// asserts that member is pinned; this case proves the
+			// deny-by-default rule above already covers it, unchanged.
+			name:        "editing headers (If-Match / Idempotency-Key) is refused, not treated as content",
+			original:    `{"operation":"advance_deal","path":"` + dealPath + `","headers":{"If-Match":"7"},"body":{}}`,
+			edited:      `{"operation":"advance_deal","path":"` + dealPath + `","headers":{"If-Match":"9"},"body":{}}`,
+			wantChanged: []string{"/headers"},
+		},
 	}
 
 	for _, tc := range tests {

--- a/backend/internal/modules/approvals/editscope_test.go
+++ b/backend/internal/modules/approvals/editscope_test.go
@@ -8,6 +8,8 @@ import (
 	"errors"
 	"strings"
 	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
 // The edit-scope rule as a table: an edit corrects what a staged action SAYS,
@@ -100,6 +102,31 @@ func TestAssertSameEntityRefsPinsEveryRecordTheProposalNames(t *testing.T) {
 				t.Errorf("refused paths = %v, want %v", retargeted.Paths, tc.wantChanged)
 			}
 		})
+	}
+}
+
+// A REST staging carries its record inside the request PATH, not as a bare field.
+// entityRefs collects only strings that parse wholly as a UUID, so the id in
+// "/v1/deals/<uuid>/advance" is invisible to it — and an edit that rewrites the
+// path therefore looks like a content correction while it re-aims the effect at a
+// different record. The version pin still re-reads the ORIGINAL target, so nothing
+// downstream notices either.
+func TestAnEditMayNotRepointTheRecordNamedInARestPath(t *testing.T) {
+	staged := ids.NewV7()
+	other := ids.NewV7()
+	// toStageID is fixed across both calls so the ONLY thing that differs
+	// between the staged and edited payload is the record named in the path.
+	// A body id that varied too would let assertSameEntityRefs reject the
+	// edit for catching THAT change, which would prove nothing about
+	// whether it can see the one hidden inside the path.
+	toStageID := ids.NewV7().String()
+	rest := func(id ids.UUID) json.RawMessage {
+		return json.RawMessage(`{"operation":"advanceDeal","path":"/v1/deals/` + id.String() +
+			`/advance","body":{"to_stage_id":"` + toStageID + `"}}`)
+	}
+	if err := assertSameEntityRefs(rest(staged), rest(other)); err == nil {
+		t.Fatal("an edit that moved the call from one deal to another was accepted; the approving " +
+			"human judged the first record and the effect would land on the second")
 	}
 }
 

--- a/backend/internal/modules/approvals/editscope_test.go
+++ b/backend/internal/modules/approvals/editscope_test.go
@@ -196,23 +196,26 @@ func TestAssertSameCallIdentityPinsEveryMemberOfTheStagedCallExceptBody(t *testi
 			wantChanged: []string{"/path"},
 		},
 		{
-			// A member the canonical call does not carry TODAY (If-Match is
-			// the next task's addition) is still pinned: deny-by-default
-			// means this needs no update when that member is added.
+			// A member the canonical call does not carry TODAY is still
+			// pinned: deny-by-default means this needs no update when a
+			// future member is added — proven with an arbitrary name here
+			// precisely so no real member has to be named for the rule to
+			// hold.
 			name:        "an unrecognized top-level member is pinned exactly like operation and path",
 			original:    `{"operation":"advance_deal","path":"` + dealPath + `","if_match":"7","body":{}}`,
 			edited:      `{"operation":"advance_deal","path":"` + dealPath + `","if_match":"9","body":{}}`,
 			wantChanged: []string{"/if_match"},
 		},
 		{
-			// The cross-task seam: compose.canonicalRESTCall now writes a
-			// `headers` member carrying If-Match and Idempotency-Key -- the
-			// version pin and the retry key. Nothing else in this codebase
-			// asserts that member is pinned; this case proves the
-			// deny-by-default rule above already covers it, unchanged.
-			name:        "editing headers (If-Match / Idempotency-Key) is refused, not treated as content",
-			original:    `{"operation":"advance_deal","path":"` + dealPath + `","headers":{"If-Match":"7"},"body":{}}`,
-			edited:      `{"operation":"advance_deal","path":"` + dealPath + `","headers":{"If-Match":"9"},"body":{}}`,
+			// The cross-task seam: compose.canonicalRESTCall writes a
+			// `headers` member carrying Idempotency-Key, the caller's retry
+			// key. Nothing else in this codebase asserts that member is
+			// pinned; this case proves the deny-by-default rule above
+			// already covers the REAL member canonicalRESTCall adds, not
+			// only the placeholder name the case above uses.
+			name:        "editing headers (Idempotency-Key) is refused, not treated as content",
+			original:    `{"operation":"advance_deal","path":"` + dealPath + `","headers":{"Idempotency-Key":"k1"},"body":{}}`,
+			edited:      `{"operation":"advance_deal","path":"` + dealPath + `","headers":{"Idempotency-Key":"k2"},"body":{}}`,
 			wantChanged: []string{"/headers"},
 		},
 	}

--- a/backend/internal/modules/approvals/editscope_test.go
+++ b/backend/internal/modules/approvals/editscope_test.go
@@ -124,44 +124,102 @@ func TestAnEditMayNotRepointTheRecordNamedInARestPath(t *testing.T) {
 		return json.RawMessage(`{"operation":"advanceDeal","path":"/v1/deals/` + id.String() +
 			`/advance","body":{"to_stage_id":"` + toStageID + `"}}`)
 	}
-	if err := assertSameCallIdentity(rest(staged), rest(other)); err == nil {
-		t.Fatal("an edit that moved the call from one deal to another was accepted; the approving " +
+	retargeted := requireRetargeted(t, assertSameCallIdentity(rest(staged), rest(other)),
+		"an edit that moved the call from one deal to another was accepted; the approving "+
 			"human judged the first record and the effect would land on the second")
+	if strings.Join(retargeted.Paths, ",") != "/path" {
+		t.Errorf("refused paths = %v, want [/path]", retargeted.Paths)
 	}
 }
 
-// Content stays editable — that is what ADR-0036 §4 is for. A staging whose body
-// changes while its call identity holds is exactly the correction a human is
-// invited to make.
-func TestAnEditMayStillCorrectTheBodyOfARestStagedCall(t *testing.T) {
-	deal, path := ids.NewV7(), "/v1/deals/"
-	before := json.RawMessage(`{"operation":"advanceDeal","path":"` + path + deal.String() +
-		`/advance","body":{"note":"as discussed"}}`)
-	after := json.RawMessage(`{"operation":"advanceDeal","path":"` + path + deal.String() +
-		`/advance","body":{"note":"as agreed on the call"}}`)
-	if err := assertSameCallIdentity(before, after); err != nil {
-		t.Errorf("a body correction was refused as a retarget: %v", err)
+// requireRetargeted fails the test with msg if err is not a *RetargetedEditError,
+// and returns it otherwise — shared by every call-identity case below that also
+// needs to inspect WHICH member the refusal names.
+func requireRetargeted(t *testing.T, err error, msg string) *RetargetedEditError {
+	t.Helper()
+	var retargeted *RetargetedEditError
+	if !errors.As(err, &retargeted) {
+		t.Fatalf("%s (err = %v)", msg, err)
 	}
+	return retargeted
 }
 
-// A tool staging carries neither member. It must pass rather than fail closed here,
-// or every MCP-staged approval becomes uneditable.
-func TestAToolStagingHasNoCallIdentityToPin(t *testing.T) {
-	before := json.RawMessage(`{"deal_id":"` + ids.NewV7().String() + `","note":"a"}`)
-	after := json.RawMessage(`{"deal_id":"` + ids.NewV7().String() + `","note":"b"}`)
-	if err := assertSameCallIdentity(before, after); err != nil {
-		t.Errorf("a tool staging with no operation or path was treated as retargeted: %v", err)
-	}
-}
+// The call-identity rule as a table: an edit may rewrite `body`, never any
+// other top-level member of a REST staging — pinned by EXCLUDING body rather
+// than by naming "operation" and "path", so a member the canonical call adds
+// tomorrow (an If-Match or Idempotency-Key header, sibling of body) is pinned
+// by construction rather than by someone remembering to list it.
+func TestAssertSameCallIdentityPinsEveryMemberOfTheStagedCallExceptBody(t *testing.T) {
+	const dealPath = `/v1/deals/11111111-1111-4111-8111-111111111111/advance`
 
-// Dropping the member is a change, not an absence: an edit that deletes `path`
-// leaves a payload the redemption re-derives its own path for, which is the same
-// re-aiming by another route.
-func TestDroppingTheCallIdentityIsARetarget(t *testing.T) {
-	before := json.RawMessage(`{"operation":"advanceDeal","path":"/v1/deals/x/advance","body":{}}`)
-	after := json.RawMessage(`{"operation":"advanceDeal","body":{}}`)
-	if err := assertSameCallIdentity(before, after); err == nil {
-		t.Error("an edit that removed the staged path was accepted")
+	tests := []struct {
+		name        string
+		original    string
+		edited      string
+		wantChanged []string
+	}{
+		{
+			name:     "content stays editable — that is what ADR-0036 §4 is for",
+			original: `{"operation":"advance_deal","path":"` + dealPath + `","body":{"note":"as discussed"}}`,
+			edited:   `{"operation":"advance_deal","path":"` + dealPath + `","body":{"note":"as agreed on the call"}}`,
+		},
+		{
+			// A tool staging carries neither operation nor path. It must pass
+			// rather than fail closed here, or every MCP-staged approval
+			// becomes uneditable — entityRefs governs its content instead.
+			name:     "a tool staging (no operation or path) has no call identity to pin",
+			original: `{"deal_id":"11111111-1111-4111-8111-111111111111","note":"a"}`,
+			edited:   `{"deal_id":"11111111-1111-4111-8111-111111111111","note":"b"}`,
+		},
+		{
+			name:        "repointing path is refused",
+			original:    `{"operation":"advance_deal","path":"` + dealPath + `","body":{}}`,
+			edited:      `{"operation":"advance_deal","path":"/v1/deals/other/advance","body":{}}`,
+			wantChanged: []string{"/path"},
+		},
+		{
+			// operation names the call as much as path names the record — a
+			// staging table-driven only on path would leave this arm of the
+			// same guard unexercised.
+			name:        "repointing operation alone is refused",
+			original:    `{"operation":"advance_deal","path":"` + dealPath + `","body":{}}`,
+			edited:      `{"operation":"disqualify_lead","path":"` + dealPath + `","body":{}}`,
+			wantChanged: []string{"/operation"},
+		},
+		{
+			// Dropping a member is a change, not an absence: an edit that
+			// deletes `path` leaves a payload the redemption re-derives its
+			// own path for, which is the same re-aiming by another route.
+			name:        "dropping path is a retarget, not an absence",
+			original:    `{"operation":"advance_deal","path":"` + dealPath + `","body":{}}`,
+			edited:      `{"operation":"advance_deal","body":{}}`,
+			wantChanged: []string{"/path"},
+		},
+		{
+			// A member the canonical call does not carry TODAY (If-Match is
+			// the next task's addition) is still pinned: deny-by-default
+			// means this needs no update when that member is added.
+			name:        "an unrecognized top-level member is pinned exactly like operation and path",
+			original:    `{"operation":"advance_deal","path":"` + dealPath + `","if_match":"7","body":{}}`,
+			edited:      `{"operation":"advance_deal","path":"` + dealPath + `","if_match":"9","body":{}}`,
+			wantChanged: []string{"/if_match"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := assertSameCallIdentity(json.RawMessage(tc.original), json.RawMessage(tc.edited))
+			if len(tc.wantChanged) == 0 {
+				if err != nil {
+					t.Fatalf("edit refused: %v — a human must stay free to correct the action's content", err)
+				}
+				return
+			}
+			retargeted := requireRetargeted(t, err, "edit accepted, want RetargetedEditError naming "+strings.Join(tc.wantChanged, ","))
+			if strings.Join(retargeted.Paths, ",") != strings.Join(tc.wantChanged, ",") {
+				t.Errorf("refused paths = %v, want %v", retargeted.Paths, tc.wantChanged)
+			}
+		})
 	}
 }
 

--- a/backend/internal/modules/approvals/editscope_test.go
+++ b/backend/internal/modules/approvals/editscope_test.go
@@ -124,9 +124,44 @@ func TestAnEditMayNotRepointTheRecordNamedInARestPath(t *testing.T) {
 		return json.RawMessage(`{"operation":"advanceDeal","path":"/v1/deals/` + id.String() +
 			`/advance","body":{"to_stage_id":"` + toStageID + `"}}`)
 	}
-	if err := assertSameEntityRefs(rest(staged), rest(other)); err == nil {
+	if err := assertSameCallIdentity(rest(staged), rest(other)); err == nil {
 		t.Fatal("an edit that moved the call from one deal to another was accepted; the approving " +
 			"human judged the first record and the effect would land on the second")
+	}
+}
+
+// Content stays editable — that is what ADR-0036 §4 is for. A staging whose body
+// changes while its call identity holds is exactly the correction a human is
+// invited to make.
+func TestAnEditMayStillCorrectTheBodyOfARestStagedCall(t *testing.T) {
+	deal, path := ids.NewV7(), "/v1/deals/"
+	before := json.RawMessage(`{"operation":"advanceDeal","path":"` + path + deal.String() +
+		`/advance","body":{"note":"as discussed"}}`)
+	after := json.RawMessage(`{"operation":"advanceDeal","path":"` + path + deal.String() +
+		`/advance","body":{"note":"as agreed on the call"}}`)
+	if err := assertSameCallIdentity(before, after); err != nil {
+		t.Errorf("a body correction was refused as a retarget: %v", err)
+	}
+}
+
+// A tool staging carries neither member. It must pass rather than fail closed here,
+// or every MCP-staged approval becomes uneditable.
+func TestAToolStagingHasNoCallIdentityToPin(t *testing.T) {
+	before := json.RawMessage(`{"deal_id":"` + ids.NewV7().String() + `","note":"a"}`)
+	after := json.RawMessage(`{"deal_id":"` + ids.NewV7().String() + `","note":"b"}`)
+	if err := assertSameCallIdentity(before, after); err != nil {
+		t.Errorf("a tool staging with no operation or path was treated as retargeted: %v", err)
+	}
+}
+
+// Dropping the member is a change, not an absence: an edit that deletes `path`
+// leaves a payload the redemption re-derives its own path for, which is the same
+// re-aiming by another route.
+func TestDroppingTheCallIdentityIsARetarget(t *testing.T) {
+	before := json.RawMessage(`{"operation":"advanceDeal","path":"/v1/deals/x/advance","body":{}}`)
+	after := json.RawMessage(`{"operation":"advanceDeal","body":{}}`)
+	if err := assertSameCallIdentity(before, after); err == nil {
+		t.Error("an edit that removed the staged path was accepted")
 	}
 }
 


### PR DESCRIPTION
## What

The REST agent door and the MCP tool door were two independent implementations of one governed-call
pipeline. They shared exactly one chokepoint — `auth.Gate.Admit`, which answers *what tier is this
call* — and re-derived everything downstream. The REST door did not know what call it was looking
at; it guessed from the route (`chi.URLParam("id")` plus the policy's `RecordType`) where the tool
door held a fact.

Every governance obligation therefore had to be written twice, and the second one was forgotten.
That class had already recurred four times: #928, #813, #812, and #982 (which shipped separately
while this branch was in flight).

**Every agent-reachable mutating operation now has a typed command and one resolver.** Both doors
resolve through it. All 69 mutating routes decode into a command; the route walk is deleted; four
derived gates hold the property.

Closes #928. Closes #812. Closes #1046.

## Why a typed command, and not the two obvious designs

Both obvious designs were built on paper and killed by review before any code was written. The
history is in the branch's design doc; the short version is worth carrying, because both will be
proposed again:

**"Canonicalize a REST call into the backing tool's arguments."** Half the confirm-first routes
have no expressible tool call — `archive_record` admits five record types while twelve routes
archive; `confirmOrganizationFact` has no request body at all, its entire operand being two path
parameters. And hashing a *projection* of a request while executing the *raw* request makes any
dropped operand a degree of freedom the approval no longer pins.

**"Prove the doors agree by checking the REST descriptor's arguments against the tool's schema."**
`enrich` serves both `scrapeCompany` (one page) and `deepReadCompany` (whole-site crawl),
distinguished only by a `depth` enum admitting both values. A descriptor synthesizing `"site"` for
`scrapeCompany` satisfies the schema perfectly while the tool's `StageInfo` describes and guards a
crawl the handler will not run. Schema admission proves syntax, not meaning.

A typed command has no string for a mistranslation to hide in: `scrapeCompany`'s decoder sets
`Depth: EnrichPage` structurally, and a path operand like `factKey` is a field like any other.

## The gates

Derived from the generated policy table, so a new contract annotation cannot ship past them. Each
was verified **red against its own mutation** before being trusted:

1. every `Access: "tool"` mutating route decodes into a command — one gate over all 69, admitting
   on the same two predicates production admits on, with the count derived;
2. both doors resolve one operation to one command, per-door fixtures written from the contract and
   the tool schema independently — all 29 twins, including both enrich routes;
3. the staged row agrees across doors on kind, target pair and pin shape, in the integration lane
   (the pin only exists inside the staging transaction), while asserting the deliberate difference
   in `proposed_change` and `diff_hash`;
4. no confirm-first operation stages a call its own executor would refuse.

Gate 4 found a real defect on its first run: `setProjectStakeholder` staged a body whose `person_id`
was not a UUID, so the handler refused only after redemption had consumed the human's one-shot
approval. Its DELETE twin had always refused that operand.

## Defects found and fixed on the way

- **`upsertPartner` lost §2.1 human-edit precedence.** An implementer read `actionShapedUpdateOps`'
  comment as saying the operation belonged in that map; the comment justifies the opposite, and
  membership means the per-field split is skipped. Caught before review, reverted, the comment
  disambiguated, and a test added that fails with the entry reinstated.
- **A third staging call site was still guessing.** `applyAutoExecuteAndStageResidue` built its
  target from `pol.RecordType` directly, so a mixed-conflict `upsertPartner` patch staged
  `target_entity_type = "partner"` — a type in neither `targetProbes` nor `existenceProbes`, so the
  row was invisible in the inbox and undecidable at the decision. All three sites now resolve
  through one seam.
- **A split residue hashed an idempotency key its retry could never present**, because the
  auto-execute half's 2xx consumes the claim. Introduced by this branch; fixed on the residue path.
- **`createOffer` would have staged the deal's id under record type `offer`** the moment a
  per-record-type floor tightened `offer` — #982's mechanism needs no code change to arm it.

## Behaviour changes

- REST staging now performs reads, and can now refuse: 404 for a target outside row scope, 422 for
  an externally-held record or a bad argument, where it previously answered "staged as approval X".
  That is the point — a human is no longer asked about a call that cannot succeed — and it means an
  agent whose row scope excludes a record loses the ability to stage against it.
- A 🟢 REST call now redeems a presented `X-Approval-Token` for every tool, not just `update_record`,
  and a token that opens nothing costs the caller nothing (matching MCP, which refuses to charge for
  a replayed token precisely so a caller cannot suspend its own passport).
- `POST /v1/bookings` with `"links": []` is now refused 422. The contract permits it (`maxItems: 25`,
  no `minItems`) and neither the store nor the handler checks it, so the gate is currently stricter
  than the contract — raised as #1065.
- A non-UUID `{id}` on `/deals/{id}/advance` answers 404 rather than 422, matching every other
  routed-id decoder's existence-hiding rule.

## Review

Ten tasks, each with an independent review and a scoped re-review, plus a whole-branch review that
returned **no Criticals**. Three separate "justification nobody checks" defects were found and
fixed: a gate waiver citing a test that stages a different operation, a comment describing a
mechanism that does not exist over dead code, and a coverage gate conceding its own hole in a
parenthetical. The last of those had left the four highest-consequence 🟡 verbs — the sends and
`book_meeting` — with no cross-door comparison at all; they have one now.

New product code: 18 files, 163 functions, mean coverage 95.7%.

## Filed, not fixed

#1021, #1065, #1069, #1070, #1071, #1072, #1073, #1074 — each carries the invariant to gate.
#813 remains open and is unchanged by this branch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies REST and MCP governance behind typed commands and shared resolvers so both doors stage the same governed call. Canonicalizes REST call identity, pins approval edits to the staged call, and redeems approval tokens on auto-executed retries across all tools.

- All 69 mutating routes decode into a command; both doors resolve through `backend/internal/modules/agents/*`; the route-walk is removed. Dynamic tiers read from the decoded command.
- Canonical REST hashing binds operation, path, and `Idempotency-Key`; `If-Match` is excluded. Invalid UTF‑8, escaped unpaired surrogates, and trailing content are refused; the `headers` member is omitted when empty. Split‑residue retries hash without `Idempotency-Key`.
- Auto‑executed retries redeem `X-Approval-Token` for all tools and charge only after successful redemption (a token that opens nothing is not charged). Writes condition on the server pin, then the released pin, then the admitted pin.
- Approval edits are bounded by entity refs and the REST call identity (all top‑level members except body); edits that re‑aim a REST‑staged call are refused.
- Resolver fixes: merges bind to the survivor; enrich uses typed depth; bookings pin to the first link; sends/bookings validate at both doors; `upsertPartner` stages against the organization and stages via the resolver on both split branches; mixed‑conflict residues resolve through the resolver; split‑residue refusals occur before any write.
- Minor: unify `If-Match` header spelling.

Behavior changes and migration
- REST staging now performs reads and can refuse early: 404 for out‑of‑scope/non‑existent targets; 422 for bad arguments or externally‑held records. Client action: handle 404/422 instead of assuming an approval id.
- Presenting `X-Approval-Token` on REST retries redeems for all tools; invalid/replayed tokens are refused without consuming quota. Client action: never reuse tokens; expect uniform approval consumption.
- Split‑residue refusals no longer follow a partial write. Client action: expect a 4xx with no side effects.
- `POST /v1/bookings` with `"links": []` is refused 422. Client action: include at least one record link.
- `/v1/deals/{id}/advance` with a non‑UUID `{id}` returns 404 instead of 422. Client action: update tests and error handling.
- Approval edits that change operation/path are refused. Client action: only edit body fields, not the staged call identity.

<sup>Written for commit 46a7f7bb52cf2a89d6b2fe25246ab1061193b589. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1075?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added approval-aware handling for REST actions including create, update, archive, lifecycle, communication, enrichment, and nested record operations.
  * Approval requests now display resolved targets and clearer action summaries.
  * Added consistent request validation and canonicalization for reliable approval redemption.

* **Bug Fixes**
  * Prevented unauthorized, hidden, malformed, or externally managed records from being staged.
  * Prevented edited approvals from redirecting requests to different records or operations.
  * Corrected quota charging so only executed calls consume usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->