### PR TITLE
fix(person360): an action a rep can press either goes somewhere or says why it cannot

### DIFF
--- a/backend/internal/compose/integration/person360_http_integration_test.go
+++ b/backend/internal/compose/integration/person360_http_integration_test.go
@@ -17,6 +17,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -25,6 +26,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/modules/ai"
 	"github.com/gradionhq/margince/backend/internal/modules/consent"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
 
 // nativeWorkspace is the overlay predicate for a workspace on its own system
@@ -174,5 +176,59 @@ func TestGetPersonProfileFieldsAnswersAnArrayWhenNothingIsEnriched(t *testing.T)
 	}
 	if out.Data == nil {
 		t.Error("the sidecar answered a null list rather than an empty one")
+	}
+}
+
+// A section this reader may not see comes back nil, exactly like a section that
+// is genuinely empty, and the difference is recorded in sections_omitted. A
+// moment rule that reads nil as "there is nothing here" therefore tells a
+// reader without the grant that nothing is scheduled and nobody is waiting on a
+// reply — confident statements about data the page was never allowed to look at.
+//
+// The unit tests for that guard hand-build sections_omitted. This one drives
+// the real assembler with a real principal, so it also proves the guard is
+// keyed to the omission shape assemble.go actually produces rather than to one
+// a test invented.
+func TestAMomentDoesNotClaimAbsenceForASectionTheReaderCouldNotSee(t *testing.T) {
+	e := Setup(t)
+	mine := e.SeedPerson(t, "Anna Weber", &e.Rep1)
+	h := personHandlers(e)
+
+	read := func(ctx context.Context) crmcontracts.Person360 {
+		t.Helper()
+		code, body := call(ctx, http.MethodGet, "/v1/people/"+mine.String()+"/360",
+			func(w http.ResponseWriter, r *http.Request) { h.GetPerson360(w, r, crmcontracts.Id(mine)) })
+		if code != http.StatusOK {
+			t.Fatalf("360 → %d, want 200", code)
+		}
+		var page crmcontracts.Person360
+		if err := json.Unmarshal(body, &page); err != nil {
+			t.Fatalf("the composite did not parse: %v", err)
+		}
+		return page
+	}
+
+	// The same record, read by someone who may not see activities.
+	blind := roomPerms
+	blind.Objects = map[string]principal.ObjectGrant{}
+	for object, grant := range roomPerms.Objects {
+		blind.Objects[object] = grant
+	}
+	delete(blind.Objects, "activity")
+
+	page := read(e.As(e.Rep1, []ids.UUID{e.Team1}, blind))
+	if len(page.SectionsOmitted) == 0 {
+		t.Fatal("a reader without the activity grant must be TOLD which sections were withheld")
+	}
+	if page.Moment == nil {
+		t.Fatal("the page still opens on a moment")
+	}
+	// Whatever the ladder chose, it must not be a verdict about the sections
+	// this reader was refused.
+	for _, claim := range []string{"nobody is waiting on a reply", "nothing is owed"} {
+		if strings.Contains(page.Moment.WhyNow, claim) {
+			t.Errorf("the moment says %q to a reader shown %d withheld section(s): %q",
+				claim, len(page.SectionsOmitted), page.Moment.WhyNow)
+		}
 	}
 }

--- a/backend/internal/compose/person360/momentrules.go
+++ b/backend/internal/compose/person360/momentrules.go
@@ -18,6 +18,8 @@ import (
 	"strings"
 	"time"
 
+	openapi_types "github.com/oapi-codegen/runtime/types"
+
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/relstrength"
 )
@@ -44,11 +46,7 @@ func roleChangeMoment(_ time.Time, page *crmcontracts.Person360) (crmcontracts.P
 		Confidence:          crmcontracts.PersonMomentConfidenceObservedFact,
 		Evidence:            evidence,
 		FreshnessAt:         &change.At,
-		RecommendedAction: crmcontracts.PersonMomentAction{
-			Kind:  crmcontracts.PersonMomentActionKindOpenRecord,
-			Label: "Open the deal",
-			State: crmcontracts.PersonMomentActionStateAvailable,
-		},
+		RecommendedAction:   openDeal(page),
 	}, true
 }
 
@@ -79,12 +77,10 @@ func missingNextStepMoment(_ time.Time, page *crmcontracts.Person360) (crmcontra
 		Confidence:          crmcontracts.PersonMomentConfidenceObservedFact,
 		Evidence:            evidence,
 		RecommendedAction: crmcontracts.PersonMomentAction{
-			Kind:  crmcontracts.PersonMomentActionKindScheduleMeeting,
-			Label: "Book a meeting",
-			State: crmcontracts.PersonMomentActionStateAvailable,
-			Destination: &crmcontracts.PersonMomentDestination{
-				Surface: crmcontracts.PersonMomentDestinationSurfaceRecord,
-			},
+			Kind:        crmcontracts.PersonMomentActionKindScheduleMeeting,
+			Label:       "Book a meeting",
+			State:       crmcontracts.PersonMomentActionStateAvailable,
+			Destination: dealRecord(deal.DealId),
 		},
 	}, true
 }
@@ -118,12 +114,47 @@ func thinRelationshipMoment(_ time.Time, page *crmcontracts.Person360) (crmcontr
 		WhyNow:              "There is no correspondence and no colleague who knows them. Everything about this record is still to be learned.",
 		Confidence:          crmcontracts.PersonMomentConfidenceObservedFact,
 		Evidence:            evidence,
-		RecommendedAction: crmcontracts.PersonMomentAction{
-			Kind:  crmcontracts.PersonMomentActionKindLogActivity,
-			Label: "Log an interaction",
-			State: crmcontracts.PersonMomentActionStateAvailable,
-		},
+		RecommendedAction:   logInteraction(),
 	}, true
+}
+
+// dealRecord points an action at one deal's page.
+//
+// The entity id is the whole content of this destination: the frontend
+// dispatcher navigates only when it has one, so a record surface without an id
+// is a button that looks live and goes nowhere - which is the same defect as an
+// action with no destination at all, wearing a destination.
+func dealRecord(dealID openapi_types.UUID) *crmcontracts.PersonMomentDestination {
+	entity := crmcontracts.PersonMomentDestinationEntityTypeDeal
+	return &crmcontracts.PersonMomentDestination{
+		Surface:    crmcontracts.PersonMomentDestinationSurfaceRecord,
+		EntityType: &entity,
+		EntityId:   &dealID,
+	}
+}
+
+// openDeal offers the deal whose seat just changed hands, when the reader can
+// see one.
+//
+// The relationship change itself names no deal, so the destination comes from
+// the commercial section - and that section is absent for a reader without the
+// deal grant. Blocked there rather than available: an action pointing at a
+// record this caller cannot open would navigate them to a 404, which is worse
+// than a control that says why it is off.
+func openDeal(page *crmcontracts.Person360) crmcontracts.PersonMomentAction {
+	action := crmcontracts.PersonMomentAction{
+		Kind:  crmcontracts.PersonMomentActionKindOpenRecord,
+		Label: "Open the deal",
+		State: crmcontracts.PersonMomentActionStateAvailable,
+	}
+	if page.Commercial == nil || page.Commercial.Deal == nil {
+		reason := "No open deal is visible on this record"
+		action.State = crmcontracts.PersonMomentActionStateBlocked
+		action.BlockedReason = &reason
+		return action
+	}
+	action.Destination = dealRecord(page.Commercial.Deal.DealId)
+	return action
 }
 
 // oldestOverdueCommitment finds the promise of OURS that has been late longest.

--- a/backend/internal/compose/person360/momentrules.go
+++ b/backend/internal/compose/person360/momentrules.go
@@ -24,8 +24,15 @@ import (
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/relstrength"
 )
 
-// roleChangeMoment: a seat on a deal changed, or the relationship crossed a
-// threshold. Derived from what the page already read, never from a fresh query.
+// roleChangeMoment: the relationship crossed a threshold. Derived from what the
+// page already read, never from a fresh query.
+//
+// The rule id is role_change and the only change it reads is replied_after_gap,
+// which is not a role change — relstrength emits four kinds and none of them is
+// one. So the headline states what the evidence actually shows. Naming the rung
+// for a signal the system does not produce is a contract question, tracked
+// separately; what must not happen meanwhile is the page telling a rep that
+// somebody's seat moved on the strength of a reply.
 func roleChangeMoment(_ time.Time, page *crmcontracts.Person360) (crmcontracts.PersonMoment, bool) {
 	change, ok := findChange(page, relstrength.ChangeRepliedAfterGap)
 	if !ok {
@@ -33,7 +40,7 @@ func roleChangeMoment(_ time.Time, page *crmcontracts.Person360) (crmcontracts.P
 	}
 	evidence := []crmcontracts.PersonMomentEvidence{{
 		Type:       crmcontracts.PersonMomentEvidenceTypeRelationshipChange,
-		Label:      "The relationship changed",
+		Label:      "They replied after a long gap",
 		ObservedAt: &change.At,
 	}}
 	return crmcontracts.PersonMoment{
@@ -41,8 +48,8 @@ func roleChangeMoment(_ time.Time, page *crmcontracts.Person360) (crmcontracts.P
 		Rule:                crmcontracts.PersonMomentRuleRoleChange,
 		RuleVersion:         ptr(ruleVersion),
 		EvidenceFingerprint: fingerprintOf(evidence),
-		Headline:            "Their role on this deal changed",
-		WhyNow:              "Who decides has moved. What worked with the old seat may not work with the new one.",
+		Headline:            "They answered after a long silence",
+		WhyNow:              "A relationship that had gone quiet has moved. The window where a reply is expected is now.",
 		Confidence:          crmcontracts.PersonMomentConfidenceObservedFact,
 		Evidence:            evidence,
 		FreshnessAt:         &change.At,
@@ -76,12 +83,13 @@ func missingNextStepMoment(_ time.Time, page *crmcontracts.Person360) (crmcontra
 		WhyNow:              "The deal is live and nothing is scheduled with the person whose seat decides it.",
 		Confidence:          crmcontracts.PersonMomentConfidenceObservedFact,
 		Evidence:            evidence,
-		RecommendedAction: crmcontracts.PersonMomentAction{
-			Kind:        crmcontracts.PersonMomentActionKindScheduleMeeting,
-			Label:       "Book a meeting",
+		RecommendedAction:   bookMeeting(),
+		SecondaryActions: &[]crmcontracts.PersonMomentAction{{
+			Kind:        crmcontracts.PersonMomentActionKindOpenRecord,
+			Label:       "Open the deal",
 			State:       crmcontracts.PersonMomentActionStateAvailable,
 			Destination: dealRecord(deal.DealId),
-		},
+		}},
 	}, true
 }
 
@@ -133,11 +141,10 @@ func dealRecord(dealID openapi_types.UUID) *crmcontracts.PersonMomentDestination
 	}
 }
 
-// openDeal offers the deal whose seat just changed hands, when the reader can
-// see one.
+// openDeal offers the deal this record has open, when the reader can see one.
 //
-// The relationship change itself names no deal, so the destination comes from
-// the commercial section - and that section is absent for a reader without the
+// The relationship change names no deal, so the destination comes from the
+// commercial section - and that section is absent for a reader without the
 // deal grant. Blocked there rather than available: an action pointing at a
 // record this caller cannot open would navigate them to a 404, which is worse
 // than a control that says why it is off.
@@ -155,6 +162,27 @@ func openDeal(page *crmcontracts.Person360) crmcontracts.PersonMomentAction {
 	}
 	action.Destination = dealRecord(page.Commercial.Deal.DealId)
 	return action
+}
+
+// bookMeeting offers the move this rung is actually about, and blocks it.
+//
+// Pointing "Book a meeting" at the deal record would satisfy every check —
+// a real surface, a real entity id, a client that navigates — and still lie.
+// The reader presses a button that says it books a meeting and lands on a deal
+// page, which is a worse kind of dead button than one that does nothing: it
+// does something, and something else.
+//
+// Nothing in the destination vocabulary opens a scheduler, so blocked is the
+// honest state. Opening the deal stays offered beside it, under its own label,
+// where it is true.
+func bookMeeting() crmcontracts.PersonMomentAction {
+	reason := "Booking a meeting from this card is not available yet"
+	return crmcontracts.PersonMomentAction{
+		Kind:          crmcontracts.PersonMomentActionKindScheduleMeeting,
+		Label:         "Book a meeting",
+		State:         crmcontracts.PersonMomentActionStateBlocked,
+		BlockedReason: &reason,
+	}
 }
 
 // oldestOverdueCommitment finds the promise of OURS that has been late longest.

--- a/backend/internal/compose/person360/momentrules.go
+++ b/backend/internal/compose/person360/momentrules.go
@@ -57,9 +57,38 @@ func roleChangeMoment(_ time.Time, page *crmcontracts.Person360) (crmcontracts.P
 	}, true
 }
 
+// withheld reports whether any of these sections was kept from this reader.
+//
+// A section the caller may not read comes back NIL, exactly like a section that
+// is genuinely empty, and assemble.go records the difference in SectionsOmitted
+// instead. A rule that reads nil as "there is nothing here" therefore tells a
+// reader without the grant that nothing is scheduled, that nothing has been
+// captured, that nobody is waiting — three confident statements about data the
+// page was not allowed to look at.
+//
+// So every rule whose FINDING IS AN ABSENCE asks this first. A rule that fires
+// on something present (a meeting exists, a promise is overdue) does not need
+// it: what it saw, it saw.
+func withheld(page *crmcontracts.Person360, sections ...crmcontracts.Person360SectionsOmitted) bool {
+	for _, omitted := range page.SectionsOmitted {
+		for _, section := range sections {
+			if omitted == section {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // missingNextStepMoment: there is an open deal and nothing scheduled with the
 // person who sits on it. The gap is the finding.
 func missingNextStepMoment(_ time.Time, page *crmcontracts.Person360) (crmcontracts.PersonMoment, bool) {
+	// "Nothing is scheduled" is only true if this reader could see the schedule.
+	if withheld(page, crmcontracts.Person360SectionsOmittedNextMeeting,
+		crmcontracts.Person360SectionsOmittedNextSteps,
+		crmcontracts.Person360SectionsOmittedCommercial) {
+		return crmcontracts.PersonMoment{}, false
+	}
 	if page.Commercial == nil || page.Commercial.Deal == nil {
 		return crmcontracts.PersonMoment{}, false
 	}

--- a/backend/internal/compose/person360/moments.go
+++ b/backend/internal/compose/person360/moments.go
@@ -144,23 +144,30 @@ func (s *Service) momentDismissed(ctx context.Context, tx pgx.Tx, personID ids.P
 // inputs this build does not have, and a rule that cannot fire belongs nowhere
 // on the page.
 func deriveMoment(now time.Time, page *crmcontracts.Person360) crmcontracts.PersonMoment {
-	ladder := []func(time.Time, *crmcontracts.Person360) (crmcontracts.PersonMoment, bool){
-		meetingPrepMoment,      // 1. a meeting within 72 hours
-		reEngagedMoment,        // 2. new inbound after a material quiet period
-		overduePromiseMoment,   // 4. an open commitment of ours is overdue
-		goneQuietMoment,        // 5. outbound unanswered past the configured rule
-		roleChangeMoment,       // 6. a new deal role or material relationship change
-		missingNextStepMoment,  // 8. an open deal with no next step involving them
-		thinRelationshipMoment, // 9. no captured interaction or network
-	}
-	for _, rule := range ladder {
-		if moment, ok := rule(now, page); ok {
+	for _, rung := range momentLadder {
+		if moment, ok := rung(now, page); ok {
 			return moment
 		}
 	}
 	// 10. Nothing needs you today. A quiet success state, not a blank card:
 	// "there is nothing here" is an answer, and the reader came for an answer.
 	return nothingNeededMoment(now)
+}
+
+// momentLadder is the ladder itself, named so a test can walk every rung.
+//
+// A rule that is only reachable through deriveMoment can only be tested by
+// constructing a page that makes it win, and the rungs below it then never run
+// at all - which is how three dead buttons sat on untested rungs while a test
+// claiming to be a general rule covered two.
+var momentLadder = []func(time.Time, *crmcontracts.Person360) (crmcontracts.PersonMoment, bool){
+	meetingPrepMoment,      // 1. a meeting within 72 hours
+	reEngagedMoment,        // 2. new inbound after a material quiet period
+	overduePromiseMoment,   // 4. an open commitment of ours is overdue
+	goneQuietMoment,        // 5. outbound unanswered past the configured rule
+	roleChangeMoment,       // 6. a new deal role or material relationship change
+	missingNextStepMoment,  // 8. an open deal with no next step involving them
+	thinRelationshipMoment, // 9. no captured interaction or network
 }
 
 // meetingPrepMoment: a meeting is close enough that preparing for it is the

--- a/backend/internal/compose/person360/moments.go
+++ b/backend/internal/compose/person360/moments.go
@@ -170,6 +170,20 @@ var momentLadder = []func(time.Time, *crmcontracts.Person360) (crmcontracts.Pers
 	thinRelationshipMoment, // 9. no captured interaction or network
 }
 
+// momentLadderNames names the rungs in momentLadder order, for tests that
+// report which rung they are talking about. A rung that does not fire returns
+// a zero PersonMoment whose Rule is empty, so the name cannot come from the
+// value — it has to be stated here.
+var momentLadderNames = []string{
+	"meeting_prep",
+	"re_engaged",
+	"overdue_promise",
+	"gone_quiet",
+	"role_change",
+	"missing_next_step",
+	"thin_relationship",
+}
+
 // meetingPrepMoment: a meeting is close enough that preparing for it is the
 // most valuable thing the reader could do.
 func meetingPrepMoment(now time.Time, page *crmcontracts.Person360) (crmcontracts.PersonMoment, bool) {
@@ -368,7 +382,7 @@ func goneQuietMoment(now time.Time, page *crmcontracts.Person360) (crmcontracts.
 // (GET /people/{id}/network); what is missing is a screen and a destination
 // value naming it.
 func askColleague() crmcontracts.PersonMomentAction {
-	reason := "Asking a colleague needs the network view, which is not built yet"
+	reason := "Margince cannot yet tell you which colleague knows this person"
 	return crmcontracts.PersonMomentAction{
 		Kind:          crmcontracts.PersonMomentActionKindAskColleague,
 		Label:         "Ask for context",
@@ -387,7 +401,7 @@ func askColleague() crmcontracts.PersonMomentAction {
 // page does not route to it and the destination vocabulary has no surface
 // naming it, so an available action here is a button that does nothing.
 func logInteraction() crmcontracts.PersonMomentAction {
-	reason := "Logging from here needs a route to the log-activity screen, which is not wired yet"
+	reason := "Logging an interaction from this card is not available yet"
 	return crmcontracts.PersonMomentAction{
 		Kind:          crmcontracts.PersonMomentActionKindLogActivity,
 		Label:         "Log an interaction",

--- a/backend/internal/compose/person360/moments.go
+++ b/backend/internal/compose/person360/moments.go
@@ -343,12 +343,50 @@ func goneQuietMoment(now time.Time, page *crmcontracts.Person360) (crmcontracts.
 				Prefill: prefill(map[string]string{prefillIntent: "follow_up"}),
 			},
 		},
-		SecondaryActions: &[]crmcontracts.PersonMomentAction{{
-			Kind:  crmcontracts.PersonMomentActionKindAskColleague,
-			Label: "Ask for context",
-			State: crmcontracts.PersonMomentActionStateAvailable,
-		}},
+		SecondaryActions: &[]crmcontracts.PersonMomentAction{askColleague()},
 	}, true
+}
+
+// askColleague offers the second play on a quiet relationship: somebody else
+// here may know why it went quiet.
+//
+// It is BLOCKED, and that is the honest state rather than a placeholder. The
+// action needs a surface that answers "who else knows this person", and none of
+// the five destinations exists for it — so an available action would render as
+// an enabled button that does nothing when pressed, which is what shipped and
+// what a rep learns to distrust the page for.
+//
+// Blocked keeps the play visible and says why, which is the difference between
+// a feature that is coming and one that is broken. The read behind it exists
+// (GET /people/{id}/network); what is missing is a screen and a destination
+// value naming it.
+func askColleague() crmcontracts.PersonMomentAction {
+	reason := "Asking a colleague needs the network view, which is not built yet"
+	return crmcontracts.PersonMomentAction{
+		Kind:          crmcontracts.PersonMomentActionKindAskColleague,
+		Label:         "Ask for context",
+		State:         crmcontracts.PersonMomentActionStateBlocked,
+		BlockedReason: &reason,
+	}
+}
+
+// logInteraction offers the one thing worth doing on a record with nothing
+// pending: write down something that happened off-system.
+//
+// Blocked for the same reason as askColleague, and it was found by the test
+// that pins that rule rather than by a report — which is the argument for
+// having written the rule instead of the one fix. The screen for it exists
+// (frontend logactivity.tsx, the contract's logActivity POST), but the person
+// page does not route to it and the destination vocabulary has no surface
+// naming it, so an available action here is a button that does nothing.
+func logInteraction() crmcontracts.PersonMomentAction {
+	reason := "Logging from here needs a route to the log-activity screen, which is not wired yet"
+	return crmcontracts.PersonMomentAction{
+		Kind:          crmcontracts.PersonMomentActionKindLogActivity,
+		Label:         "Log an interaction",
+		State:         crmcontracts.PersonMomentActionStateBlocked,
+		BlockedReason: &reason,
+	}
 }
 
 // nothingNeededMoment is the quiet success state — rung 10, and the answer far
@@ -368,10 +406,6 @@ func nothingNeededMoment(now time.Time) crmcontracts.PersonMoment {
 		Confidence:          crmcontracts.PersonMomentConfidenceObservedFact,
 		Evidence:            []crmcontracts.PersonMomentEvidence{},
 		FreshnessAt:         &now,
-		RecommendedAction: crmcontracts.PersonMomentAction{
-			Kind:  crmcontracts.PersonMomentActionKindLogActivity,
-			Label: "Log an interaction",
-			State: crmcontracts.PersonMomentActionStateAvailable,
-		},
+		RecommendedAction:   logInteraction(),
 	}
 }

--- a/backend/internal/compose/person360/moments.go
+++ b/backend/internal/compose/person360/moments.go
@@ -371,18 +371,20 @@ func goneQuietMoment(now time.Time, page *crmcontracts.Person360) (crmcontracts.
 // askColleague offers the second play on a quiet relationship: somebody else
 // here may know why it went quiet.
 //
-// It is BLOCKED, and that is the honest state rather than a placeholder. The
-// action needs a surface that answers "who else knows this person", and none of
-// the five destinations exists for it — so an available action would render as
-// an enabled button that does nothing when pressed, which is what shipped and
-// what a rep learns to distrust the page for.
+// It is BLOCKED, and that is the honest state rather than a placeholder. None
+// of the five destinations reaches a screen for asking a colleague, so an
+// available action would render as an enabled button that does nothing when
+// pressed — which is what shipped, and what a rep learns to distrust the page
+// for.
 //
 // Blocked keeps the play visible and says why, which is the difference between
-// a feature that is coming and one that is broken. The read behind it exists
-// (GET /people/{id}/network); what is missing is a screen and a destination
-// value naming it.
+// a feature that is coming and one that is broken. Note what is and is not
+// missing: the rail's "who knows them" card already NAMES the colleagues, from
+// the same GET /people/{id}/network read. What does not exist is the step after
+// that — a screen for asking one of them — so the reason says that, and not
+// that Margince cannot tell who they are. It sits beside a card listing them.
 func askColleague() crmcontracts.PersonMomentAction {
-	reason := "Margince cannot yet tell you which colleague knows this person"
+	reason := "Sending a colleague a request for context is not available yet"
 	return crmcontracts.PersonMomentAction{
 		Kind:          crmcontracts.PersonMomentActionKindAskColleague,
 		Label:         "Ask for context",

--- a/backend/internal/compose/person360/moments.go
+++ b/backend/internal/compose/person360/moments.go
@@ -90,7 +90,7 @@ func (s *Service) momentsSection(ctx context.Context, tx pgx.Tx, personID ids.Pe
 		// Dismissed against THIS evidence. The quiet success state is what the
 		// reader asked for by dismissing, and it is a moment of its own rather
 		// than an empty card.
-		quiet := nothingNeededMoment(now)
+		quiet := nothingNeededMoment(now, out)
 		out.Moment = &quiet
 		return nil
 	}
@@ -151,7 +151,7 @@ func deriveMoment(now time.Time, page *crmcontracts.Person360) crmcontracts.Pers
 	}
 	// 10. Nothing needs you today. A quiet success state, not a blank card:
 	// "there is nothing here" is an answer, and the reader came for an answer.
-	return nothingNeededMoment(now)
+	return nothingNeededMoment(now, page)
 }
 
 // momentLadder is the ladder itself, named so a test can walk every rung.
@@ -418,14 +418,27 @@ func logInteraction() crmcontracts.PersonMomentAction {
 // It is a moment rather than an absence because the reader opened the page to
 // be told what to do, and "nothing" is a legitimate answer that an empty card
 // fails to give.
-func nothingNeededMoment(now time.Time) crmcontracts.PersonMoment {
+func nothingNeededMoment(now time.Time, page *crmcontracts.Person360) crmcontracts.PersonMoment {
+	why := "No meeting is close, nothing is owed, and nobody is waiting on a reply."
+	// Every rung above this one either fired or found nothing, and "found
+	// nothing" includes "was not allowed to look". Saying nobody is waiting on
+	// a reply when the timeline was withheld states a fact about data this
+	// reader could not see, so the sentence says what is actually true instead.
+	if withheld(page, crmcontracts.Person360SectionsOmittedActivities,
+		crmcontracts.Person360SectionsOmittedLastTouch,
+		crmcontracts.Person360SectionsOmittedNextMeeting,
+		crmcontracts.Person360SectionsOmittedNextSteps,
+		crmcontracts.Person360SectionsOmittedClaims,
+		crmcontracts.Person360SectionsOmittedCommercial) {
+		why = "Nothing needs you in what this record shows you. Parts of it are not yours to see, so this is not the whole picture."
+	}
 	return crmcontracts.PersonMoment{
 		ClaimKey:            "moment:nothing_needed",
 		Rule:                crmcontracts.PersonMomentRuleNothingNeeded,
 		RuleVersion:         ptr(ruleVersion),
 		EvidenceFingerprint: "quiet",
 		Headline:            "Nothing needs you today",
-		WhyNow:              "No meeting is close, nothing is owed, and nobody is waiting on a reply.",
+		WhyNow:              why,
 		Confidence:          crmcontracts.PersonMomentConfidenceObservedFact,
 		Evidence:            []crmcontracts.PersonMomentEvidence{},
 		FreshnessAt:         &now,

--- a/backend/internal/compose/person360/moments_test.go
+++ b/backend/internal/compose/person360/moments_test.go
@@ -4,6 +4,7 @@
 package person360
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -325,5 +326,58 @@ func TestTheFingerprintIgnoresProse(t *testing.T) {
 	}})
 	if first != reworded {
 		t.Fatal("the same evidence under a different label is the same evidence")
+	}
+}
+
+// A section this reader may not see comes back NIL, exactly like a section that
+// is genuinely empty. A rule that reads nil as "there is nothing here" then
+// states a confident fact about data the page was never allowed to look at:
+// "nothing is scheduled" when the schedule was withheld, "nobody is waiting on
+// a reply" when the timeline was.
+//
+// That is the same defect the drafting program exists to remove — asserting
+// something the evidence does not carry — arriving through the record page
+// instead of through a draft.
+func TestARuleDoesNotClaimAbsenceForASectionItCouldNotRead(t *testing.T) {
+	deal := &crmcontracts.Person360Commercial{Deal: &crmcontracts.Person360CommercialDeal{
+		DealId: openapi_types.UUID(ids.NewV7()), Title: "Dispatch integration",
+	}}
+
+	// An open deal with no visible schedule. Allowed to look, the page says
+	// nothing is scheduled; forbidden to look, it must not.
+	visible := &crmcontracts.Person360{Commercial: deal}
+	if got := deriveMoment(now, visible).Rule; got != crmcontracts.PersonMomentRuleMissingNextStep {
+		t.Fatalf("with the schedule readable and empty, the gap IS the finding, got %q", got)
+	}
+
+	withheldSchedule := &crmcontracts.Person360{
+		Commercial: deal,
+		SectionsOmitted: []crmcontracts.Person360SectionsOmitted{
+			crmcontracts.Person360SectionsOmittedNextMeeting,
+		},
+	}
+	if got := deriveMoment(now, withheldSchedule).Rule; got == crmcontracts.PersonMomentRuleMissingNextStep {
+		t.Error("the schedule was withheld, so 'nothing is scheduled' is not something this page knows")
+	}
+}
+
+// And the quiet fall-through says so too, rather than reporting a withheld
+// timeline as a clean bill of health.
+func TestNothingNeededAdmitsWhenItCouldNotSeeEverything(t *testing.T) {
+	full := deriveMoment(now, &crmcontracts.Person360{})
+	if full.Rule != crmcontracts.PersonMomentRuleNothingNeeded {
+		t.Fatalf("an empty readable page is the quiet state, got %q", full.Rule)
+	}
+
+	partial := deriveMoment(now, &crmcontracts.Person360{
+		SectionsOmitted: []crmcontracts.Person360SectionsOmitted{
+			crmcontracts.Person360SectionsOmittedActivities,
+		},
+	})
+	if partial.WhyNow == full.WhyNow {
+		t.Error("a reader shown only part of the record must not be told nobody is waiting on a reply")
+	}
+	if !strings.Contains(partial.WhyNow, "not yours to see") {
+		t.Errorf("and it must say WHY the picture is partial, got %q", partial.WhyNow)
 	}
 }

--- a/backend/internal/compose/person360/moments_test.go
+++ b/backend/internal/compose/person360/moments_test.go
@@ -10,6 +10,8 @@ import (
 	openapi_types "github.com/oapi-codegen/runtime/types"
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/relstrength"
 )
 
 // now is a fixed instant, so every case below reads as a claim about the data
@@ -122,37 +124,100 @@ func TestGoneQuietNamesTheRuleItFiredOn(t *testing.T) {
 // nothing at all — which teaches a reader that the page has dead buttons, a
 // worse outcome than the action being visibly unavailable.
 //
-// The rule is general rather than about that one action: any action offered as
-// available names where it goes, and any action that cannot go anywhere says so
-// and gives its reason. The frontend already disables a blocked action and
-// shows the reason as its tooltip; what was missing was the backend saying it.
+// The rule is general: any action offered as available names a destination it
+// can actually reach, and any action that cannot reach one says so with a
+// reason. The frontend disables a blocked action and shows the reason; what was
+// missing was the backend saying it.
+//
+// It walks the LADDER rather than a handful of pages, and that is the point. A
+// first version drove deriveMoment with two shapes, reached two of eight rungs,
+// and passed while three dead buttons sat on rungs it never ran. A rung that
+// only the winning page reaches is a rung no test covers.
 func TestEveryOfferedActionEitherGoesSomewhereOrSaysWhyItCannot(t *testing.T) {
+	// One page per rung, each built to make that rung fire.
 	pages := map[string]*crmcontracts.Person360{
+		"meeting prep": {NextMeeting: &crmcontracts.Person360NextMeeting{StartsAt: ahead(24)}},
 		"gone quiet":   {LastOutboundAt: ptr(at(9)), LastInboundAt: ptr(at(16))},
-		"quiet record": {},
+		"thin relationship": {
+			Activities: activities(),
+			Network: &struct {
+				Colleagues []crmcontracts.PersonNetworkColleague `json:"colleagues"`
+			}{},
+		},
+		"role change": {
+			RelationshipChanges: &[]crmcontracts.PersonRelationshipChange{{
+				Kind: crmcontracts.PersonRelationshipChangeKind(relstrength.ChangeRepliedAfterGap),
+				At:   at(2),
+			}},
+			Commercial: &crmcontracts.Person360Commercial{Deal: &crmcontracts.Person360CommercialDeal{
+				DealId: openapi_types.UUID(ids.NewV7()), Title: "Dispatch integration",
+			}},
+		},
+		// The same rung with NO deal visible, which is the reader who lacks the
+		// deal grant: the action must block rather than point at a record they
+		// cannot open.
+		"role change, no deal": {
+			RelationshipChanges: &[]crmcontracts.PersonRelationshipChange{{
+				Kind: crmcontracts.PersonRelationshipChangeKind(relstrength.ChangeRepliedAfterGap),
+				At:   at(2),
+			}},
+		},
+		"missing next step": {
+			Commercial: &crmcontracts.Person360Commercial{Deal: &crmcontracts.Person360CommercialDeal{
+				DealId: openapi_types.UUID(ids.NewV7()), Title: "Dispatch integration",
+			}},
+		},
+		"nothing needed": {},
 	}
 	for name, page := range pages {
 		t.Run(name, func(t *testing.T) {
-			moment := deriveMoment(now, page)
-			actions := []crmcontracts.PersonMomentAction{moment.RecommendedAction}
-			if moment.SecondaryActions != nil {
-				actions = append(actions, *moment.SecondaryActions...)
-			}
-			for _, action := range actions {
-				switch action.State {
-				case crmcontracts.PersonMomentActionStateBlocked:
-					if action.BlockedReason == nil || *action.BlockedReason == "" {
-						t.Errorf("%q is blocked and gives no reason, so the tooltip is empty",
-							action.Label)
-					}
-				default:
-					if action.Destination == nil {
-						t.Errorf("%q is offered as %q with no destination, so pressing it "+
-							"does nothing", action.Label, action.State)
-					}
+			assertActionsAreHonest(t, deriveMoment(now, page))
+		})
+	}
+
+	// And every rung directly, so a rule the pages above do not reach is still
+	// judged. A rung that does not fire for a given page contributes nothing,
+	// which is why the loop asks each one rather than asserting it fires.
+	t.Run("every rung", func(t *testing.T) {
+		for _, page := range pages {
+			for _, rung := range momentLadder {
+				if moment, ok := rung(now, page); ok {
+					assertActionsAreHonest(t, moment)
 				}
 			}
-		})
+		}
+	})
+}
+
+// assertActionsAreHonest holds the rule for one moment: available means
+// reachable, blocked means explained.
+func assertActionsAreHonest(t *testing.T, moment crmcontracts.PersonMoment) {
+	t.Helper()
+	actions := []crmcontracts.PersonMomentAction{moment.RecommendedAction}
+	if moment.SecondaryActions != nil {
+		actions = append(actions, *moment.SecondaryActions...)
+	}
+	for _, action := range actions {
+		if action.State == crmcontracts.PersonMomentActionStateBlocked {
+			if action.BlockedReason == nil || *action.BlockedReason == "" {
+				t.Errorf("%s: %q is blocked and gives no reason, so its tooltip is empty",
+					moment.Rule, action.Label)
+			}
+			continue
+		}
+		if action.Destination == nil {
+			t.Errorf("%s: %q is offered as %q with no destination, so pressing it does nothing",
+				moment.Rule, action.Label, action.State)
+			continue
+		}
+		// A record surface navigates on the entity id and on nothing else, so
+		// one without an id is a destination that goes nowhere — the same dead
+		// button wearing a destination.
+		if action.Destination.Surface == crmcontracts.PersonMomentDestinationSurfaceRecord &&
+			action.Destination.EntityId == nil {
+			t.Errorf("%s: %q points at a record with no entity id, so the client cannot navigate",
+				moment.Rule, action.Label)
+		}
 	}
 }
 

--- a/backend/internal/compose/person360/moments_test.go
+++ b/backend/internal/compose/person360/moments_test.go
@@ -167,6 +167,22 @@ func TestEveryOfferedActionEitherGoesSomewhereOrSaysWhyItCannot(t *testing.T) {
 				DealId: openapi_types.UUID(ids.NewV7()), Title: "Dispatch integration",
 			}},
 		},
+		// Rung 2 wants inbound that arrived after a long silence of ours.
+		"re-engaged": {
+			LastOutboundAt: ptr(at(40)),
+			LastInboundAt:  ptr(at(3)),
+		},
+		// Rung 4 wants an open commitment OF OURS whose date has passed.
+		"overdue promise": {
+			Claims: &[]crmcontracts.ConversationClaim{{
+				Kind:             crmcontracts.CommitmentOurs,
+				Status:           crmcontracts.ConversationClaimStatusOpen,
+				Body:             "Send the revised dispatch quote",
+				SourceQuote:      "Ich schicke dir das Angebot bis Freitag.",
+				SourceActivityId: openapi_types.UUID(ids.NewV7()),
+				DueAt:            ptr(at(6)),
+			}},
+		},
 		"nothing needed": {},
 	}
 	for name, page := range pages {
@@ -175,18 +191,48 @@ func TestEveryOfferedActionEitherGoesSomewhereOrSaysWhyItCannot(t *testing.T) {
 		})
 	}
 
-	// And every rung directly, so a rule the pages above do not reach is still
-	// judged. A rung that does not fire for a given page contributes nothing,
-	// which is why the loop asks each one rather than asserting it fires.
+	// And every rung directly, because deriveMoment stops at the first rung that
+	// fires: a page reaching rung 1 says nothing about rung 9, and the first
+	// version of this test passed while three lower rungs offered dead buttons.
+	//
+	// Asking each rung is not enough on its own. A rung no page triggers returns
+	// ok=false every time and is judged by nothing, which reads as covered and
+	// is not — so a rung that never fires fails here rather than passing quietly.
 	t.Run("every rung", func(t *testing.T) {
+		fired := make(map[int]bool, len(momentLadder))
 		for _, page := range pages {
-			for _, rung := range momentLadder {
-				if moment, ok := rung(now, page); ok {
-					assertActionsAreHonest(t, moment)
+			for i, rung := range momentLadder {
+				moment, ok := rung(now, page)
+				if !ok {
+					continue
 				}
+				fired[i] = true
+				assertActionsAreHonest(t, moment)
+			}
+		}
+		for i, name := range momentLadderNames {
+			if !fired[i] {
+				t.Errorf("ladder rung %q fires for none of these pages, so its actions are judged by nothing — add a page that reaches it", name)
 			}
 		}
 	})
+}
+
+// dispatchedByThePersonPage is the set of destination surfaces the person page
+// actually opens — the `switch` in frontend/src/screens/personpage.tsx.
+//
+// The contract admits more surfaces than the page handles, and the ones it does
+// not handle fall to a `default` that deliberately does nothing. So a
+// contract-valid destination is not the bar: an action pointing at `task` is
+// enabled, pressed, and inert, which is the dead-button defect this test was
+// written for. This list is the bar, and it is a hand-kept mirror of that
+// switch — a surface added there belongs here, and until it is, offering it
+// fails rather than shipping another quiet nothing.
+var dispatchedByThePersonPage = map[crmcontracts.PersonMomentDestinationSurface]bool{
+	crmcontracts.PersonMomentDestinationSurfaceComposer:     true,
+	crmcontracts.PersonMomentDestinationSurfaceResearch:     true,
+	crmcontracts.PersonMomentDestinationSurfaceMeetingBrief: true,
+	crmcontracts.PersonMomentDestinationSurfaceRecord:       true,
 }
 
 // assertActionsAreHonest holds the rule for one moment: available means
@@ -208,6 +254,11 @@ func assertActionsAreHonest(t *testing.T, moment crmcontracts.PersonMoment) {
 		if action.Destination == nil {
 			t.Errorf("%s: %q is offered as %q with no destination, so pressing it does nothing",
 				moment.Rule, action.Label, action.State)
+			continue
+		}
+		if !dispatchedByThePersonPage[action.Destination.Surface] {
+			t.Errorf("%s: %q points at surface %q, which personpage.tsx does not open — pressing it does nothing",
+				moment.Rule, action.Label, action.Destination.Surface)
 			continue
 		}
 		// A record surface navigates on the entity id and on nothing else, so

--- a/backend/internal/compose/person360/moments_test.go
+++ b/backend/internal/compose/person360/moments_test.go
@@ -117,6 +117,45 @@ func TestGoneQuietNamesTheRuleItFiredOn(t *testing.T) {
 	}
 }
 
+// An action a rep can press has to go somewhere. The "Ask for context" button
+// shipped enabled with no destination, so it rendered as a live control and did
+// nothing at all — which teaches a reader that the page has dead buttons, a
+// worse outcome than the action being visibly unavailable.
+//
+// The rule is general rather than about that one action: any action offered as
+// available names where it goes, and any action that cannot go anywhere says so
+// and gives its reason. The frontend already disables a blocked action and
+// shows the reason as its tooltip; what was missing was the backend saying it.
+func TestEveryOfferedActionEitherGoesSomewhereOrSaysWhyItCannot(t *testing.T) {
+	pages := map[string]*crmcontracts.Person360{
+		"gone quiet":   {LastOutboundAt: ptr(at(9)), LastInboundAt: ptr(at(16))},
+		"quiet record": {},
+	}
+	for name, page := range pages {
+		t.Run(name, func(t *testing.T) {
+			moment := deriveMoment(now, page)
+			actions := []crmcontracts.PersonMomentAction{moment.RecommendedAction}
+			if moment.SecondaryActions != nil {
+				actions = append(actions, *moment.SecondaryActions...)
+			}
+			for _, action := range actions {
+				switch action.State {
+				case crmcontracts.PersonMomentActionStateBlocked:
+					if action.BlockedReason == nil || *action.BlockedReason == "" {
+						t.Errorf("%q is blocked and gives no reason, so the tooltip is empty",
+							action.Label)
+					}
+				default:
+					if action.Destination == nil {
+						t.Errorf("%q is offered as %q with no destination, so pressing it "+
+							"does nothing", action.Label, action.State)
+					}
+				}
+			}
+		})
+	}
+}
+
 // Rung 10 always answers. "Nothing needs you today" is a result the reader came
 // for, and an empty card fails to give it.
 func TestAQuietRecordStillGetsAnAnswer(t *testing.T) {

--- a/frontend/src/screens/personrail.tsx
+++ b/frontend/src/screens/personrail.tsx
@@ -105,10 +105,7 @@ function whenFor(
     return t("person.rail.reviewFirst");
   }
   if (action.state === "blocked") {
-    // The server states why in a sentence a reader can act on. A bare "blocked"
-    // next to a dead button is the complaint that opened #934, so the reason
-    // takes the slot when there is one.
-    return action.blocked_reason ?? t("person.rail.blocked");
+    return t("person.rail.blocked");
   }
   return t("person.rail.ready");
 }

--- a/frontend/src/screens/personrail.tsx
+++ b/frontend/src/screens/personrail.tsx
@@ -70,6 +70,7 @@ function NextBestActions({
           className="pe-rail-row"
           onClick={() => onAction(action)}
           disabled={action.state === "blocked"}
+          title={action.blocked_reason}
         >
           <span className="pe-rail-label">
             {actionIcon(action.kind)}
@@ -104,7 +105,10 @@ function whenFor(
     return t("person.rail.reviewFirst");
   }
   if (action.state === "blocked") {
-    return t("person.rail.blocked");
+    // The server states why in a sentence a reader can act on. A bare "blocked"
+    // next to a dead button is the complaint that opened #934, so the reason
+    // takes the slot when there is one.
+    return action.blocked_reason ?? t("person.rail.blocked");
   }
   return t("person.rail.ready");
 }


### PR DESCRIPTION
Closes #934.

## What shipped

The "Ask for context" button on a quiet relationship was **available with no destination**, so it rendered as a live control and did nothing when pressed. A page with dead buttons is one a reader learns to distrust, which costs more than the missing feature does.

Both frontend renderers (`persontoday.tsx`, `personrail.tsx`) already disable a blocked action and show its `blocked_reason` as the tooltip. The backend simply never said blocked — so the fix is one word plus a reason, and the reason is the useful part: it names what is missing rather than leaving a greyed control nobody can explain.

## The test found a second one

It is written as a **rule** rather than about that button: every offered action either names a destination or is blocked with a reason. It immediately caught "Log an interaction" on the quiet-record moment, with the same defect and unreported.

## Neither is a placeholder

- **Ask for context** needs a surface answering "who else knows this person". The read exists (`GET /people/{id}/network`); the screen does not.
- **Log an interaction** needs a route to the log-activity screen, which exists in the frontend but has no destination value naming it.

Blocked keeps both plays visible and honest until those land.

## Gate

`go test .` and the compose suite green; the pre-push craft gate passed. Mutation-checked: flipping either action back to available fails the rule.

**Note, unrelated to this diff:** `make check-backend` currently fails on `internal/compose/server.go` being 505 lines against a 500 cap. That file is untouched here and is already over on clean main — another change tipped it. Worth someone splitting it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes Person 360 actions honest and navigable. Old behavior: enabled buttons that did nothing, headlines that overstated, and absence-based claims when data was withheld. New behavior: actions either navigate to a dispatched surface with an entity_id or block with a reason; copy reflects the actual signal; absence-based rules respect withheld sections.

- Actions and destinations
  - “Ask for context” and “Log an interaction” are blocked with explicit reasons on quiet/thin and quiet fall-through moments.
  - “Book a meeting” is blocked; “Open the deal” is offered as a secondary action when a deal is visible, and blocks when no deal is visible.
  - Record destinations now include `entity_id`. Actions only target surfaces the person page dispatches.

- Copy, findings, tests, UI
  - Role-change moment headline/why-now describe “replied after a long gap” instead of asserting a role change.
  - Rules whose finding is an absence check `SectionsOmitted`; the quiet state explains partial visibility when sections are withheld.
  - Exposes `momentLadder` and `momentLadderNames`; tests walk every rung, fail when a rung isn’t reached, and enforce: available actions have a dispatched destination with `entity_id`; blocked actions include a reason; destinations match what the person page actually opens.
  - Adds an integration test that drives the real assembler with a principal lacking activity grants to prove the withheld guard matches the actual omission shape.
  - `frontend/src/screens/personrail.tsx` shows the server’s `blocked_reason` in the tooltip while keeping localized status.

<sup>Written for commit d115819908da7aa98f8c1c424ffc1e7b47cdcfdf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1077?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Role-change and missing-next-step actions now link directly to relevant deals when available.
  - Thin-relationship moments now offer a shared interaction-logging action.
  - Quiet relationship moments include an “Ask for context” option.

- **Bug Fixes**
  - Actions without available destinations are clearly marked as blocked.
  - Blocked next-best-action buttons now show the specific reason, with a generic fallback when unavailable.
  - “Nothing needs you today” no longer presents interaction logging as an available action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->