### PR TITLE
chore(identity): regenerate the RBAC artifacts the integrations object already changed

### DIFF
--- a/backend/migrations/testdata/rbac_seeded_defaults.json
+++ b/backend/migrations/testdata/rbac_seeded_defaults.json
@@ -79,6 +79,12 @@
         "read": true,
         "update": true
       },
+      "integrations": {
+        "create": true,
+        "delete": true,
+        "read": true,
+        "update": true
+      },
       "lead": {
         "create": true,
         "delete": true,
@@ -265,6 +271,12 @@
         "update": false
       },
       "installation_settings": {
+        "create": false,
+        "delete": false,
+        "read": true,
+        "update": false
+      },
+      "integrations": {
         "create": false,
         "delete": false,
         "read": true,
@@ -461,6 +473,12 @@
         "read": true,
         "update": true
       },
+      "integrations": {
+        "create": true,
+        "delete": true,
+        "read": true,
+        "update": true
+      },
       "lead": {
         "create": true,
         "delete": true,
@@ -652,6 +670,12 @@
         "read": true,
         "update": false
       },
+      "integrations": {
+        "create": false,
+        "delete": false,
+        "read": true,
+        "update": false
+      },
       "lead": {
         "create": false,
         "delete": false,
@@ -838,6 +862,12 @@
         "update": false
       },
       "installation_settings": {
+        "create": false,
+        "delete": false,
+        "read": true,
+        "update": false
+      },
+      "integrations": {
         "create": false,
         "delete": false,
         "read": true,

--- a/docs/reference/rbac-matrix.md
+++ b/docs/reference/rbac-matrix.md
@@ -72,6 +72,7 @@ the workspace but changes none of them.
 | `fx_rate` | CRU- | ---- | ---- | ---- | CRU- |
 | `import_run` | CRUD | ---- | ---- | ---- | CRUD |
 | `installation_settings` | -RU- | -R-- | -R-- | -R-- | -RU- |
+| `integrations` | CRUD | -R-- | -R-- | -R-- | CRUD |
 | `lead` | CRUD | CRUD | CRUD | -R-- | CRUD |
 | `list` | CRUD | CRUD | CRU- | -R-- | CRUD |
 | `offer` | CRUD | CRUD | CRU- | -R-- | CRUD |


### PR DESCRIPTION
Closes #1080.

`make check-backend` is red on a **clean checkout of main**, on every branch, regardless of what it changed. Two tests in `internal/modules/identity` fail because the seeded role documents gained an `integrations` object and neither pinned artifact was regenerated with it:

- `TestSeededRBACRoleDocumentsMatchTheCommittedReplayFixture` → `migrations/testdata/rbac_seeded_defaults.json`
- `TestPublishedRBACMatrixMatchesTheSeededRoleDocuments` → `docs/reference/rbac-matrix.md`

## What is in the diff

Generated output only, produced by the command both tests print themselves:

```
go test ./internal/modules/identity/ -run RBAC -update
```

It is additive — one new object across the role documents and one new matrix row. **Admin** and **Ops** get CRUD; every other role reads only. That is what the seed already grants at runtime; this only records it where the gates can see it, so I am not changing anyone's permissions here.

## Why it is worth its own PR

A permanently red merge gate trains everyone to read `check-backend` as noise, which is exactly how a real failure gets waved through. Three of my open PRs are blocked behind this one and none of them touches identity.

Same root cause as the frontend twin: `frontend/src/api/schema.d.ts` lagged the contract by the whole `/provider-connections` surface and broke `make check-fe` the same way. That one is regenerated in #1082.

## Gate

`go test ./internal/modules/identity/ .` green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Regenerates RBAC artifacts to include the `integrations` resource the seed already grants, fixing the always-red `make check-backend` on main. Previously the artifacts omitted `integrations`; now they include it with Admin and Ops = CRUD and all other roles = read-only, with no runtime permission changes.

**Review notes**
- Generated output only via `go test ./internal/modules/identity/ -run RBAC -update`.
- Touches `backend/migrations/testdata/rbac_seeded_defaults.json` and `docs/reference/rbac-matrix.md` only.
- Gate is green: `go test ./internal/modules/identity`. Closes #1080.

<sup>Written for commit 0ca88ca9259c691bef6a0e90462f65e01400c66e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1083?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

