### PR TITLE
chore(compose): move the two adapters out of server.go, under the size cap

### DIFF
--- a/backend/internal/compose/server.go
+++ b/backend/internal/compose/server.go
@@ -44,11 +44,9 @@ import (
 	"github.com/gradionhq/margince/backend/internal/platform/agentquota"
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
 	"github.com/gradionhq/margince/backend/internal/platform/blobstore"
-	"github.com/gradionhq/margince/backend/internal/platform/httperr"
 	"github.com/gradionhq/margince/backend/internal/platform/httpserver"
 	"github.com/gradionhq/margince/backend/internal/platform/keyvault"
 	"github.com/gradionhq/margince/backend/internal/platform/overlaybudget"
-	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
 // Server satisfies crmcontracts.ServerInterface by embedding: every
@@ -462,44 +460,4 @@ func (s *Server) rebuildToolRegistry(pool *pgxpool.Pool) {
 		s.replyDrafter, s.resolveOverlayIncumbent(pool), s.send, companyEnricher{srv: s},
 		s.retrievalEmbedder,
 		agents.WithQuotaCharger(s.quotaMeter), agents.WithCostShare(s.quotaMeter))
-}
-
-// signalStrength bridges people's §4 relationship-strength computation to
-// the slice the warm room consumes (signals.StrengthSource). It carries
-// only the score and its bucket across the seam — the full explainable
-// decomposition stays with its owner. This is the arch-legal edge: signals
-// declares its own seam type, and the cross-module dependency lives here in
-// compose, never as a signals→people import.
-type signalStrength struct{ people *people.Store }
-
-func (s signalStrength) PersonStrength(ctx context.Context, personID ids.PersonID, now time.Time) (signals.RelationshipStrength, error) {
-	rs, err := s.people.PersonStrength(ctx, personID, now)
-	if err != nil {
-		return signals.RelationshipStrength{}, err
-	}
-	return signals.RelationshipStrength{Strength: rs.Strength, Bucket: rs.Bucket}, nil
-}
-
-// paramParseError maps a generated request-parameter parse failure onto
-// the same 422 validation_error shape every other bad query input uses
-// (mirrors httperr's malformed-cursor path). It names only the offending
-// parameter — never the wrapped parser text, which can carry internal
-// detail — so a bad cursor/limit/sort/UUID answers problem+json, not a
-// text/plain leak.
-func paramParseError(w http.ResponseWriter, r *http.Request, err error) {
-	param := "request"
-	switch e := err.(type) {
-	case *crmcontracts.RequiredParamError:
-		param = e.ParamName
-	case *crmcontracts.InvalidParamFormatError:
-		param = e.ParamName
-	case *crmcontracts.TooManyValuesForParamError:
-		param = e.ParamName
-	case *crmcontracts.UnmarshalingParamError:
-		param = e.ParamName
-	case *crmcontracts.UnescapedCookieParamError:
-		param = e.ParamName
-	}
-	httperr.Write(w, r, httperr.Validation(param, "invalid_parameter",
-		"parameter is missing or malformed"))
 }

--- a/backend/internal/compose/serveradapters.go
+++ b/backend/internal/compose/serveradapters.go
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The two adapters the composed Server needs but does not consist of: one
+// cross-module seam, and one error mapping. They sit here rather than in
+// server.go because that file's job is to say WHAT the installation is wired
+// out of, and a reader answering that question does not need either body.
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/modules/people"
+	"github.com/gradionhq/margince/backend/internal/modules/signals"
+	"github.com/gradionhq/margince/backend/internal/platform/httperr"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// signalStrength bridges people's §4 relationship-strength computation to
+// the slice the warm room consumes (signals.StrengthSource). It carries
+// only the score and its bucket across the seam — the full explainable
+// decomposition stays with its owner. This is the arch-legal edge: signals
+// declares its own seam type, and the cross-module dependency lives here in
+// compose, never as a signals→people import.
+type signalStrength struct{ people *people.Store }
+
+func (s signalStrength) PersonStrength(ctx context.Context, personID ids.PersonID, now time.Time) (signals.RelationshipStrength, error) {
+	rs, err := s.people.PersonStrength(ctx, personID, now)
+	if err != nil {
+		return signals.RelationshipStrength{}, err
+	}
+	return signals.RelationshipStrength{Strength: rs.Strength, Bucket: rs.Bucket}, nil
+}
+
+// paramParseError maps a generated request-parameter parse failure onto
+// the same 422 validation_error shape every other bad query input uses
+// (mirrors httperr's malformed-cursor path). It names only the offending
+// parameter — never the wrapped parser text, which can carry internal
+// detail — so a bad cursor/limit/sort/UUID answers problem+json, not a
+// text/plain leak.
+func paramParseError(w http.ResponseWriter, r *http.Request, err error) {
+	param := "request"
+	switch e := err.(type) {
+	case *crmcontracts.RequiredParamError:
+		param = e.ParamName
+	case *crmcontracts.InvalidParamFormatError:
+		param = e.ParamName
+	case *crmcontracts.TooManyValuesForParamError:
+		param = e.ParamName
+	case *crmcontracts.UnmarshalingParamError:
+		param = e.ParamName
+	case *crmcontracts.UnescapedCookieParamError:
+		param = e.ParamName
+	}
+	httperr.Write(w, r, httperr.Validation(param, "invalid_parameter",
+		"parameter is missing or malformed"))
+}


### PR DESCRIPTION
The second half of main's red merge gate (the first is #1083).

`internal/compose/server.go` was **505 lines against a 500-line cap**, so `deterministic-gates` failed on a clean checkout of main and on every branch, regardless of what it changed:

```
FAIL: backend/internal/compose/server.go is 505 lines (> 500) — split into one-concept-per-file packages
FAIL: go-file-length — the 500-LOC cap (ratcheted via scripts/go-file-length-waivers.txt)
```

## What moved

Two adapters, verbatim, into `serveradapters.go`:

- **`signalStrength`** — the arch-legal signals→people seam. signals declares its own seam type and the cross-module edge lives in compose, never as a signals→people import.
- **`paramParseError`** — maps a generated request-parameter parse failure onto the same 422 `validation_error` shape every other bad query input uses.

## Why these two

`server.go`'s job is to say **what this installation is wired out of** — the embedded handler sets, the `ServerInterface` assertion that makes a missing handler a compile error, and the wiring in `newServer`. A reader answering that question does not need either adapter body. Neither is part of what the composed Server *is*.

No behaviour change: both bodies are unchanged and their imports followed them. I did not take a waiver, because the file genuinely reads better split and a waiver would just move the problem.

## Gate

`make go-file-length` now passes (`no hand-written Go file exceeds 500 LOC, waivers: 0`), `go build ./...`, `go vet`, and `go test ./internal/compose/... .` all green. server.go is 465 lines.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves two adapters from `backend/internal/compose/server.go` to `backend/internal/compose/serveradapters.go` to get under the 500-LOC cap and unblock `deterministic-gates`. No behavior change; code moved verbatim and imports followed.

- Moved `signalStrength` (signals→people seam) and `paramParseError` (maps generated param parse failures to 422 `validation_error`); `server.go` now focuses on wiring.
- `server.go` is 465 LOC; `make go-file-length` passes; `go build`, `go vet`, and `go test ./internal/compose/...` are green.

<sup>Written for commit 67c5c782565444dc92095b4855f413f7f3813f47. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1084?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

