### PR TITLE
fix(compose): green the merge gate the integrations merges broke

### DIFF
--- a/backend/.go-arch-lint.yml
+++ b/backend/.go-arch-lint.yml
@@ -69,6 +69,7 @@ components:
   privacy:     { in: internal/modules/privacy }
   deals:       { in: internal/modules/deals }
   finance:     { in: internal/modules/finance }
+  integrations: { in: [internal/modules/integrations, internal/modules/integrations/**] }
   activities:  { in: internal/modules/activities }
   approvals:   { in: internal/modules/approvals }
   customfields: { in: internal/modules/customfields }
@@ -135,6 +136,12 @@ deps:
   finance:
     mayDependOn: [contracts, platform]
     canUse: [pgx, oapi]
+  # The licensed-data-provider platform (ADR-0101). Same posture as every
+  # other module: contracts + platform, never a sibling — the domain edges
+  # (claim writes, the subject fence) are injected by compose as func types.
+  integrations:
+    mayDependOn: [contracts, platform]
+    canUse: [pgx, oapi]
   deals:
     mayDependOn: [contracts, platform]
     # fpdf backs offer_pdf.go's branded PDF render (offers-depth arc 4a
@@ -175,7 +182,7 @@ deps:
     mayDependOn: [contracts, platform]
     canUse: [pgx, oapi]
   compose:
-    mayDependOn: [compose, identity, people, privacy, deals, activities, approvals, agents, automation, ai, search, capture, consent, collections, signals, customfields, quotas, overlay, migration, webhooks, comms, finance, contracts, platform, migrations]
+    mayDependOn: [compose, identity, people, privacy, deals, activities, approvals, agents, automation, ai, search, capture, consent, collections, signals, customfields, quotas, overlay, migration, webhooks, comms, finance, integrations, contracts, platform, migrations]
     # xtext: the evidence gate normalizes page text to NFC before matching
     # (evidencematch.go) — Unicode normal forms need golang.org/x/text.
     # yaml: aicert's corpus loader parses scenario files directly — the
@@ -201,5 +208,5 @@ deps:
     mayDependOn: [contracts, compose]
     canUse: [yaml]
   cmd:
-    mayDependOn: [compose, identity, people, privacy, deals, activities, approvals, agents, automation, ai, search, capture, consent, collections, signals, customfields, quotas, overlay, migration, webhooks, comms, finance, contracts, platform, migrations]
+    mayDependOn: [compose, identity, people, privacy, deals, activities, approvals, agents, automation, ai, search, capture, consent, collections, signals, customfields, quotas, overlay, migration, webhooks, comms, finance, integrations, contracts, platform, migrations]
     canUse: [pgx, redis, xterm, composition]

--- a/backend/internal/compose/integrationsmapping.go
+++ b/backend/internal/compose/integrationsmapping.go
@@ -9,11 +9,11 @@ package compose
 // channel connections — two different things called "a connection".
 
 import (
-	"github.com/google/uuid"
 	openapi_types "github.com/oapi-codegen/runtime/types"
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/modules/integrations"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/provider"
 )
 
@@ -231,9 +231,12 @@ func toProviderSnapshot(s provider.Snapshot) crmcontracts.ProviderConfiguration 
 // programming error rather than a caller's mistake, and the zero uuid is the
 // honest rendering of "this row's id did not parse".
 func mustUUID(s string) openapi_types.UUID {
-	parsed, err := uuid.Parse(s)
+	// ids.Parse rather than uuid.Parse: the kernel helper is what the rest of
+	// compose speaks, and reaching for the vendor package directly is an
+	// import this layer is not granted (go-arch-lint).
+	parsed, err := ids.Parse(s)
 	if err != nil {
 		return openapi_types.UUID{}
 	}
-	return parsed
+	return openapi_types.UUID(parsed)
 }

--- a/backend/internal/compose/paramerror.go
+++ b/backend/internal/compose/paramerror.go
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+import (
+	"net/http"
+
+	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/platform/httperr"
+)
+
+// paramParseError maps a generated request-parameter parse failure onto
+// the same 422 validation_error shape every other bad query input uses
+// (mirrors httperr's malformed-cursor path). It names only the offending
+// parameter — never the wrapped parser text, which can carry internal
+// detail — so a bad cursor/limit/sort/UUID answers problem+json, not a
+// text/plain leak.
+func paramParseError(w http.ResponseWriter, r *http.Request, err error) {
+	param := "request"
+	switch e := err.(type) {
+	case *crmcontracts.RequiredParamError:
+		param = e.ParamName
+	case *crmcontracts.InvalidParamFormatError:
+		param = e.ParamName
+	case *crmcontracts.TooManyValuesForParamError:
+		param = e.ParamName
+	case *crmcontracts.UnmarshalingParamError:
+		param = e.ParamName
+	case *crmcontracts.UnescapedCookieParamError:
+		param = e.ParamName
+	}
+	httperr.Write(w, r, httperr.Validation(param, "invalid_parameter",
+		"parameter is missing or malformed"))
+}

--- a/backend/internal/compose/server.go
+++ b/backend/internal/compose/server.go
@@ -44,11 +44,9 @@ import (
 	"github.com/gradionhq/margince/backend/internal/platform/agentquota"
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
 	"github.com/gradionhq/margince/backend/internal/platform/blobstore"
-	"github.com/gradionhq/margince/backend/internal/platform/httperr"
 	"github.com/gradionhq/margince/backend/internal/platform/httpserver"
 	"github.com/gradionhq/margince/backend/internal/platform/keyvault"
 	"github.com/gradionhq/margince/backend/internal/platform/overlaybudget"
-	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
 // Server satisfies crmcontracts.ServerInterface by embedding: every
@@ -462,44 +460,4 @@ func (s *Server) rebuildToolRegistry(pool *pgxpool.Pool) {
 		s.replyDrafter, s.resolveOverlayIncumbent(pool), s.send, companyEnricher{srv: s},
 		s.retrievalEmbedder,
 		agents.WithQuotaCharger(s.quotaMeter), agents.WithCostShare(s.quotaMeter))
-}
-
-// signalStrength bridges people's §4 relationship-strength computation to
-// the slice the warm room consumes (signals.StrengthSource). It carries
-// only the score and its bucket across the seam — the full explainable
-// decomposition stays with its owner. This is the arch-legal edge: signals
-// declares its own seam type, and the cross-module dependency lives here in
-// compose, never as a signals→people import.
-type signalStrength struct{ people *people.Store }
-
-func (s signalStrength) PersonStrength(ctx context.Context, personID ids.PersonID, now time.Time) (signals.RelationshipStrength, error) {
-	rs, err := s.people.PersonStrength(ctx, personID, now)
-	if err != nil {
-		return signals.RelationshipStrength{}, err
-	}
-	return signals.RelationshipStrength{Strength: rs.Strength, Bucket: rs.Bucket}, nil
-}
-
-// paramParseError maps a generated request-parameter parse failure onto
-// the same 422 validation_error shape every other bad query input uses
-// (mirrors httperr's malformed-cursor path). It names only the offending
-// parameter — never the wrapped parser text, which can carry internal
-// detail — so a bad cursor/limit/sort/UUID answers problem+json, not a
-// text/plain leak.
-func paramParseError(w http.ResponseWriter, r *http.Request, err error) {
-	param := "request"
-	switch e := err.(type) {
-	case *crmcontracts.RequiredParamError:
-		param = e.ParamName
-	case *crmcontracts.InvalidParamFormatError:
-		param = e.ParamName
-	case *crmcontracts.TooManyValuesForParamError:
-		param = e.ParamName
-	case *crmcontracts.UnmarshalingParamError:
-		param = e.ParamName
-	case *crmcontracts.UnescapedCookieParamError:
-		param = e.ParamName
-	}
-	httperr.Write(w, r, httperr.Validation(param, "invalid_parameter",
-		"parameter is missing or malformed"))
 }

--- a/backend/internal/compose/signalstrength.go
+++ b/backend/internal/compose/signalstrength.go
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+import (
+	"context"
+	"time"
+
+	"github.com/gradionhq/margince/backend/internal/modules/people"
+	"github.com/gradionhq/margince/backend/internal/modules/signals"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// signalStrength bridges people's §4 relationship-strength computation to
+// the slice the warm room consumes (signals.StrengthSource). It carries
+// only the score and its bucket across the seam — the full explainable
+// decomposition stays with its owner. This is the arch-legal edge: signals
+// declares its own seam type, and the cross-module dependency lives here in
+// compose, never as a signals→people import.
+type signalStrength struct{ people *people.Store }
+
+func (s signalStrength) PersonStrength(ctx context.Context, personID ids.PersonID, now time.Time) (signals.RelationshipStrength, error) {
+	rs, err := s.people.PersonStrength(ctx, personID, now)
+	if err != nil {
+		return signals.RelationshipStrength{}, err
+	}
+	return signals.RelationshipStrength{Strength: rs.Strength, Bucket: rs.Bucket}, nil
+}

--- a/backend/internal/modules/integrations/budget_integration_test.go
+++ b/backend/internal/modules/integrations/budget_integration_test.go
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integrations
+
+// Reconciliation settles a hold against what the provider actually charged,
+// and the billing basis decides what a no-match does to it. Both arms are
+// money: releasing a hold the provider kept understates the bill, and holding
+// one it refunded silently shrinks the customer's ceiling for the month.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/gradionhq/margince/backend/internal/shared/ports/provider"
+)
+
+// reserveOneRun queues a run through the real pipeline and returns its id, so
+// the reservations under test are the ones production writes.
+func reserveOneRun(t *testing.T, e *runsEnv) string {
+	t.Helper()
+	run, err := e.store.QueueRun(e.ctx, provider.QueueInput{
+		PersonID: e.mine.String(), Provider: "surfe", Trigger: provider.TriggerManual,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if run.State != provider.RunQueued {
+		t.Fatalf("run is %s, want queued", run.State)
+	}
+	return run.ID
+}
+
+func creditsFor(t *testing.T, e *runsEnv, runID, pool string) (reserved int, actual *int) {
+	t.Helper()
+	if err := e.owner.QueryRow(context.Background(),
+		`SELECT reserved_credits, actual_credits FROM provider_run_reservation
+		  WHERE run_id = $1 AND pool = $2`, runID, pool).Scan(&reserved, &actual); err != nil {
+		t.Fatal(err)
+	}
+	return reserved, actual
+}
+
+// A provider that charges only for a successful result owes nothing on a
+// no-match, so the whole hold is released.
+func TestReconcileReleasesTheHoldWhenNothingWasBought(t *testing.T) {
+	e := setupRuns(t, runsConfig{})
+	runID := reserveOneRun(t, e)
+	desc := NewOfflineProvider(0, e.store.now).Descriptor()
+
+	if err := e.store.db.Tx(e.ctx, func(tx pgx.Tx) error {
+		return e.store.reconcile(e.ctx, tx, desc, runID, nil, false)
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	_, actual := creditsFor(t, e, runID, "email")
+	if actual == nil || *actual != 0 {
+		t.Errorf("actual_credits = %v, want 0 — a per-successful-result provider refunds a no-match, and holding those credits would shrink the customer's ceiling for nothing", actual)
+	}
+}
+
+// On a match, the provider's own number wins where it gave one.
+func TestReconcileRecordsWhatTheProviderActuallyCharged(t *testing.T) {
+	e := setupRuns(t, runsConfig{})
+	runID := reserveOneRun(t, e)
+	desc := NewOfflineProvider(0, e.store.now).Descriptor()
+
+	if err := e.store.db.Tx(e.ctx, func(tx pgx.Tx) error {
+		return e.store.reconcile(e.ctx, tx, desc, runID,
+			map[provider.Pool]int{"email": 1, "mobile": 1}, true)
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, pool := range []string{"email", "mobile"} {
+		_, actual := creditsFor(t, e, runID, pool)
+		if actual == nil || *actual != 1 {
+			t.Errorf("%s actual_credits = %v, want 1", pool, actual)
+		}
+	}
+}
+
+// Where the provider said nothing about a pool, the hold stands as spent:
+// assuming a refund nobody promised understates what the customer was charged.
+func TestReconcileTreatsSilenceAsSpent(t *testing.T) {
+	e := setupRuns(t, runsConfig{})
+	runID := reserveOneRun(t, e)
+	desc := NewOfflineProvider(0, e.store.now).Descriptor()
+
+	if err := e.store.db.Tx(e.ctx, func(tx pgx.Tx) error {
+		// A match, but the provider reported no per-pool cost at all.
+		return e.store.reconcile(e.ctx, tx, desc, runID, nil, true)
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	reserved, actual := creditsFor(t, e, runID, "email")
+	if actual == nil || *actual != reserved {
+		t.Errorf("actual_credits = %v, want the reserved %d — silence is not a refund", actual, reserved)
+	}
+}

--- a/backend/internal/shared/ports/provider/provider.go
+++ b/backend/internal/shared/ports/provider/provider.go
@@ -183,7 +183,7 @@ const (
 	OutcomeCompleted Outcome = "completed"
 	OutcomeNoMatch   Outcome = "no_match"
 
-	OutcomeInvalidCredentials  Outcome = "invalid_credentials"
+	OutcomeInvalidCredentials  Outcome = "invalid_credentials" //nolint:gosec // G101 false positive: an outcome NAME the adapter returns, not a credential
 	OutcomeInsufficientCredits Outcome = "insufficient_credits"
 	OutcomeRateLimited         Outcome = "rate_limited"
 	OutcomeProviderError       Outcome = "provider_error"


### PR DESCRIPTION
`check-backend` has been red on `main` since #1076. Four separate failures, all mine. #1083 fixed the RBAC-artifact half; this fixes the rest.

## What was broken

**The integrations module was never declared in `.go-arch-lint.yml`.** Every file in it read as *"not attached to any component"*, and compose's import of it was unauthorized — the module has been outside the architecture it is supposed to obey since the day it landed. It now declares the same posture as every sibling: `contracts + platform`, never another module, with the domain edges injected by compose as func types.

**`server.go` crossed the 500-line cap** (505) when it gained the integrations handler embed. Two things that were never server assembly move out: `signalStrength` (the people→signals seam) and `paramParseError` (the generated-parameter 422 mapping). One concept per file, which is what the cap is asking for rather than an arbitrary trim. 463 lines now.

**`integrationsmapping.go` reached for `github.com/google/uuid` directly.** compose is not granted that vendor import and did not need it — `ids.Parse` is what the rest of the layer speaks.

**golangci flagged two things, one false and one real.**
- The gosec G101 hit on `OutcomeInvalidCredentials` is a false positive — an outcome *name* an adapter returns, not a credential — and takes an inline waiver with that reason, per the house convention.
- `reconcile` being unused was **not** a false positive. It is the function that settles a credit hold against what the provider actually charged, and it shipped with no caller and no test.

## The tests that came with the real one

`reconcile` now has three, one per arm that decides money:
- a per-successful-result provider **releases the whole hold on a no-match** — holding those credits would shrink the customer's ceiling for something they were never charged;
- **the provider's own number wins** where it reported one;
- **silence is not a refund** — where the provider said nothing about a pool, the hold stands as spent, because assuming a refund nobody promised understates the bill.

They queue through the real `QueueRun` pipeline rather than hand-inserting reservations, so what they assert about is what production writes.

## Verification

- `make check-backend` passes end to end — the exact gate that was red.
- `make test-it DIR=backend/internal/modules/integrations` — 12 tests green on real Postgres.
- `make arch-lint` clean; `make lint` reports 0 issues; `make go-file-length` OK with 0 waivers.

## The lesson

My local runs used `go test .` and I called that a gate. It is not: `arch-lint` needs the `go-arch-lint` binary and `lint` needs golangci, and skipping either hides exactly this class of defect. Full `make check` before every push, as CLAUDE.md already says.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Greens the backend merge gate by fixing architecture- and lint-breaks from the integrations work. No runtime behavior changes; we declare the `integrations` module, split `server.go`, correct an import, and add reconciliation tests.

- Declare `integrations` in `.go-arch-lint.yml`; restrict it to `contracts` + `platform`; authorize `compose` and `cmd` to depend on it.
- Move `signalStrength` and `paramParseError` from `server.go` into separate files to satisfy the 500-line cap; behavior unchanged.
- Replace `github.com/google/uuid` with kernel `ids.Parse` in `integrationsmapping.go`, returning `openapi_types.UUID`.
- Add `//nolint:gosec` to `OutcomeInvalidCredentials` for a G101 false positive.
- Add integration tests for `reconcile`: releases holds on no-match for per-success billing; uses provider-reported per-pool costs; treats silence as spent. Tests run through the real `QueueRun` path.
- Verification: `make check-backend`, `make arch-lint`, and `make lint` pass; integrations tests green on Postgres. No migrations.

<sup>Written for commit 6860f6a68d5dba2954c2fa93398bd92abe26992c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1089?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

