### PR TITLE
fix(migrations): classify the two provider FKs that name a person

### DIFF
--- a/backend/migrations/schema_fitness_integration_test.go
+++ b/backend/migrations/schema_fitness_integration_test.go
@@ -225,6 +225,15 @@ var rowScopedFKDecisions = gatekit.Waive(map[string]string{
 	"organization_domain_disposition.organization_id": "server-derived: set only by ResolveDomainTriage, to the organization that same transaction created or adopted through the gated dedupe chokepoint",
 	"person_email.person_id":                          "child row: written through the person's own gated paths",
 	"person_phone.person_id":                          "child row: written through the person's own gated paths",
+	// The licensed-data-provider platform (ADR-0101). A run names the subject
+	// it spends credits on, so admitting one IS a read of that person: QueueRun
+	// takes auth.EnsureVisible inside the queueing transaction, before any
+	// fence, price or reservation. Without it a rep could name any person id
+	// and buy data on a record outside their scope.
+	"provider_run.person_id": "gated: auth.EnsureVisible in QueueRun, inside the transaction that inserts the run — the object grant alone answers \"may this role read people\", never \"may this caller see THIS person\"",
+	// The claim is a child of the run: it is written only by the domain's
+	// claim sink, from the run's own person_id, and never from a request body.
+	"person_provider_claim.person_id": "child row: written by the claim hand-off from the run's own subject, which QueueRun already gated; the fence is re-run immediately before every write (PI-AC-7)",
 	// telegram-oa design §6.4: the channel-aware ensure contract creates the
 	// Person (owner_id NULL) and this identity satellite in the same
 	// transaction, from the inbound message's own channel principal —


### PR DESCRIPTION
The integration lane has been red since #1076. `TestFK_rowScopedTargetsHaveVisibilityDecision` refuses a foreign key pointing at a row-scoped record that nobody classified, and both of the provider platform's person references were unclassified:

```
FK person_provider_claim.person_id -> person has no visibility decision
FK provider_run.person_id -> person has no visibility decision
```

## These are decisions, not waivers

Both FKs are genuinely gated, so the entries record how — they do not excuse an absence.

**`provider_run.person_id`** — a run names the subject it spends credits on, so admitting one *is* a read of that person. `QueueRun` takes `auth.EnsureVisible` inside the queueing transaction, before any fence, price or reservation. The object grant alone answers "may this role read people at all"; it never answers "may this caller see THIS person", which is the question that matters when the answer costs money. (That gate was itself added after a review round caught its absence.)

**`person_provider_claim.person_id`** — a child of the run: written only by the claim hand-off, from the run's own subject, never from a request body. The fence is re-run immediately before every write (PI-AC-7).

## How this was missed

Found by CI, not locally, because the gate that catches it lives in the **integration lane** and I had run only the unit gate — the same blind spot that produced #1089, one lane further out. The implementation plan named this exact entry as required work; the implementation skipped it.

Both #1089 and this one are now folded into batman mode's gate: run every local check, including `make test-it` for anything touching a store, SQL or a migration.

## Verification

- `make check-backend` — green, exit 0.
- `make test-it DIR=backend/migrations` — the whole package green on real Postgres, including the test that was failing.
- The second failing CI job ("integration (RLS + erasure + HTTP e2e)") is the shard aggregator reporting this same failure, not a separate defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Classifies the two provider FKs that point to person so the integration visibility gate passes. Previously they were unclassified and TestFK_rowScopedTargetsHaveVisibilityDecision failed; now both are recorded as decisions because reads are gated in their write paths.

- provider_run.person_id — gated: QueueRun calls auth.EnsureVisible inside the queueing transaction; admitting a run is a read of that person.
- person_provider_claim.person_id — child row: written only from the run’s person_id by the claim sink; the fence is re-run before every write (PI-AC-7).

- No schema or runtime changes; test-only classification.
- Integration lane should turn green; no migration actions.

<sup>Written for commit 4078b205b8218d07602a736debccefde79e03efd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1090?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

