### PR TITLE
fix(capture): a captured counterparty gets the name their header actually carries

### DIFF
--- a/backend/internal/modules/people/ensure.go
+++ b/backend/internal/modules/people/ensure.go
@@ -184,6 +184,13 @@ func (s *Store) ensurePerson(ctx context.Context, tx pgx.Tx, in EnsureCounterpar
 	}
 	if match.Decision == DecisionExactCollision {
 		res.PersonID = match.PersonID
+		if quarantineSuspect(in.DisplayName, in.Domain) {
+			// The header carries an impersonation tell. A new record would be
+			// created quarantined for review; an EXISTING one has no such
+			// label to wear, so the only safe answer is to learn nothing from
+			// this message. The activity is still captured either way.
+			return nil
+		}
 		return fillMissingPersonName(ctx, tx, match.PersonID, parsed, res)
 	}
 
@@ -369,27 +376,42 @@ func fillMissingPersonName(ctx context.Context, tx pgx.Tx, personID ids.PersonID
 	if !parsed.Confident {
 		return nil
 	}
-	// The NULL predicate IS the concurrency guard: it is a compare-and-set on
-	// "still unknown", so a writer that filled the name between the dedupe read
-	// and this write keeps their value and this one affects zero rows. Nothing
-	// downstream depends on which of the two won — both wrote a name where there
-	// was none — so a zero count is a no-op, not an error.
+	// BOTH columns must be empty, and both are written together. A parse is
+	// confident about the PAIR "Bob Jones" — grafting its surname onto a first
+	// name a human typed would build "Alice Jones", a person neither source ever
+	// named. The predicate is also the concurrency guard: a writer who filled
+	// either half between the dedupe read and this write keeps it, because
+	// Postgres re-checks the predicate after waiting on their lock.
 	tag, err := tx.Exec(ctx, `
 		UPDATE person
-		   SET first_name = COALESCE(first_name, $2),
-		       last_name  = COALESCE(last_name, $3),
+		   SET first_name = $2,
+		       last_name  = $3,
 		       updated_at = now()
 		 WHERE id = $1
-		   AND (first_name IS NULL OR last_name IS NULL)`,
+		   AND first_name IS NULL AND last_name IS NULL`,
 		personID, parsed.First, parsed.Last)
 	if err != nil {
 		return fmt.Errorf("people: filling the missing name of person %s: %w", personID, err)
 	}
 	// A zero count is the guard doing its job, not a failure: the row already
-	// carried both names, or a concurrent writer filled them between the dedupe
-	// read and this write. Either way the person has a name that is not this
-	// call's to replace, so the result is reported and deliberately not raised.
-	res.NameFilled = tag.RowsAffected() > 0
+	// carried a name, and it is not this call's to replace.
+	if tag.RowsAffected() == 0 {
+		return nil
+	}
+	// A mutation that changes a person's stored name is auditable like any other,
+	// and every audited mutation ships its event in the same transaction —
+	// without both, the row changes with no record of what did it and nothing
+	// downstream learns the name it was waiting for.
+	changed := map[string]any{"first_name": parsed.First, "last_name": parsed.Last}
+	auditID, err := storekit.Audit(ctx, tx, "update", entityPerson, personID.UUID, nil, changed)
+	if err != nil {
+		return err
+	}
+	if err := storekit.EmitEvent(ctx, tx, auditID, personID.UUID,
+		crmcontracts.PublicEventPersonUpdated{ChangedFields: changed}); err != nil {
+		return err
+	}
+	res.NameFilled = true
 	return nil
 }
 

--- a/backend/internal/modules/people/ensure.go
+++ b/backend/internal/modules/people/ensure.go
@@ -86,6 +86,10 @@ type EnsureCounterpartyResult struct {
 	// TriagePending instead.
 	OrganizationID *ids.OrganizationID
 	DedupeRecorded bool
+	// NameFilled reports that this ensure completed an incumbent's split name
+	// that was previously unknown — the fill-only-if-empty path, never an
+	// overwrite. Counting it separately keeps "created a person" honest.
+	NameFilled bool
 
 	// TriagePending reports that this ensure OPENED a domain's organization
 	// question, and TriageDomain names the domain to ask about. A later message
@@ -163,7 +167,8 @@ func (s *Store) ensurePerson(ctx context.Context, tx pgx.Tx, in EnsureCounterpar
 	if err := auth.Require(ctx, entityPerson, principal.ActionCreate); err != nil {
 		return err
 	}
-	name := counterpartyName(in.DisplayName, in.Email)
+	parsed := ParsePersonName(in.DisplayName, in.Email)
+	name := parsed.Full
 	// The workspace's own consumer-mail list travels with the candidate: the
 	// employer-agreement term must judge a shared domain the same way capture
 	// does, or an admin's carve-out would hold on one side and not the other.
@@ -179,11 +184,13 @@ func (s *Store) ensurePerson(ctx context.Context, tx pgx.Tx, in EnsureCounterpar
 	}
 	if match.Decision == DecisionExactCollision {
 		res.PersonID = match.PersonID
-		return nil
+		return fillMissingPersonName(ctx, tx, match.PersonID, parsed, res)
 	}
 
 	id, err := createPerson(ctx, tx, match, PersonSpec{
 		FullName:    name,
+		FirstName:   nameColumn(parsed.First),
+		LastName:    nameColumn(parsed.Last),
 		OwnerID:     ownerFromUUID(&in.OwnerID),
 		Visibility:  visibilityOwner,
 		Quarantined: quarantineSuspect(in.DisplayName, in.Domain),
@@ -336,18 +343,54 @@ func recordDedupeCandidate(ctx context.Context, tx pgx.Tx, entityType string, a,
 	return tag.RowsAffected() > 0, nil
 }
 
-// counterpartyName is the display name we can honestly store: the header
-// name when present, else the address's local part — never empty (person
-// pins full_name NOT NULL).
-func counterpartyName(displayName, email string) string {
-	name := strings.TrimSpace(displayName)
-	if name != "" {
-		return name
+// nameColumn renders a parsed name part for the nullable split-name columns.
+// An unconfident parse leaves them NULL rather than storing "" — a column that
+// says "we do not know" must not be spelled the same as one that says "empty".
+func nameColumn(part string) *string {
+	if part == "" {
+		return nil
 	}
-	if local, _, ok := strings.Cut(email, "@"); ok && local != "" {
-		return local
+	return &part
+}
+
+// fillMissingPersonName completes a person the ladder landed on by exact
+// address, and completes ONLY what is missing.
+//
+// Every incumbent reached here already exists, so this is the one path that can
+// improve a record created before the parser — or by an import, or by hand with
+// only a full name typed in. It is strictly additive: each column carries its
+// own IS NULL guard, so a name a human entered is never rewritten by whatever a
+// mail header happens to spell, and re-running it converges instead of flapping
+// between two spellings of the same person.
+//
+// Unconfident parses write nothing: `schluepmann` is not evidence of a surname
+// with no given name, it is evidence that the local part did not say.
+func fillMissingPersonName(ctx context.Context, tx pgx.Tx, personID ids.PersonID, parsed ParsedName, res *EnsureCounterpartyResult) error {
+	if !parsed.Confident {
+		return nil
 	}
-	return email
+	// The NULL predicate IS the concurrency guard: it is a compare-and-set on
+	// "still unknown", so a writer that filled the name between the dedupe read
+	// and this write keeps their value and this one affects zero rows. Nothing
+	// downstream depends on which of the two won — both wrote a name where there
+	// was none — so a zero count is a no-op, not an error.
+	tag, err := tx.Exec(ctx, `
+		UPDATE person
+		   SET first_name = COALESCE(first_name, $2),
+		       last_name  = COALESCE(last_name, $3),
+		       updated_at = now()
+		 WHERE id = $1
+		   AND (first_name IS NULL OR last_name IS NULL)`,
+		personID, parsed.First, parsed.Last)
+	if err != nil {
+		return fmt.Errorf("people: filling the missing name of person %s: %w", personID, err)
+	}
+	// A zero count is the guard doing its job, not a failure: the row already
+	// carried both names, or a concurrent writer filled them between the dedupe
+	// read and this write. Either way the person has a name that is not this
+	// call's to replace, so the result is reported and deliberately not raised.
+	res.NameFilled = tag.RowsAffected() > 0
+	return nil
 }
 
 // quarantineSuspect flags the cheap impersonation tells (ADR-0063): a

--- a/backend/internal/modules/people/ensurename_integration_test.go
+++ b/backend/internal/modules/people/ensurename_integration_test.go
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package people
+
+// What capture stores as a counterparty's NAME, over a real Postgres.
+//
+// The unit table in personname_test.go proves the parser reads a header
+// correctly. These prove the reading survives the write: that the split columns
+// actually land on the row, that a second message completes a record the first
+// one left incomplete, and — the one that matters most — that a name a human
+// typed is never overwritten by whatever a later mail header happens to spell.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// storedName reads the three name columns back off the row.
+func (e *dedupeEnv) storedName(ctx context.Context, t *testing.T, id ids.PersonID) (full string, first, last *string) {
+	t.Helper()
+	if err := e.store.tx(ctx, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx,
+			`SELECT full_name, first_name, last_name FROM person WHERE id = $1`, id).
+			Scan(&full, &first, &last)
+	}); err != nil {
+		t.Fatalf("reading person %s: %v", id, err)
+	}
+	return full, first, last
+}
+
+// nameOrNull renders a nullable name column for a failure message. The
+// package's own deref spells NULL as "", which is exactly the distinction these
+// tests are about — a column that says "we do not know" versus one holding an
+// empty string.
+func nameOrNull(s *string) string {
+	if s == nil {
+		return "NULL"
+	}
+	return *s
+}
+
+func TestEnsureCounterpartyStoresAParsedName(t *testing.T) {
+	e := setupDedupe(t)
+	ctx := e.as()
+
+	// No display name at all: the local part is the only evidence, and it
+	// carries a first and a last name.
+	res, err := e.store.EnsureCounterparty(ctx, e.ensureInput(ctx, t, "lars.ferner@parsed.test", "", "parsed.test"))
+	if err != nil || !res.PersonCreated {
+		t.Fatalf("ensure = %+v (err %v), want a created person", res, err)
+	}
+	full, first, last := e.storedName(ctx, t, res.PersonID)
+	if full != "Lars Ferner" || nameOrNull(first) != "Lars" || nameOrNull(last) != "Ferner" {
+		t.Fatalf("stored name = %q / %q / %q, want Lars Ferner / Lars / Ferner",
+			full, nameOrNull(first), nameOrNull(last))
+	}
+}
+
+func TestEnsureCounterpartyLeavesSplitNamesNullWhenItCannotTell(t *testing.T) {
+	e := setupDedupe(t)
+	ctx := e.as()
+
+	// A lone surname names the person but says nothing about a given name, and
+	// a role mailbox names nobody. Both must display honestly and split neither.
+	for _, tc := range []struct{ email, wantFull string }{
+		{"schluepmann@parsed.test", "Schluepmann"},
+		{"mail@parsed.test", "mail"},
+	} {
+		res, err := e.store.EnsureCounterparty(ctx, e.ensureInput(ctx, t, tc.email, "", "parsed.test"))
+		if err != nil {
+			t.Fatalf("ensure %s: %v", tc.email, err)
+		}
+		full, first, last := e.storedName(ctx, t, res.PersonID)
+		if full != tc.wantFull {
+			t.Errorf("%s full_name = %q, want %q", tc.email, full, tc.wantFull)
+		}
+		if first != nil || last != nil {
+			t.Errorf("%s split names = %q / %q, want both NULL — the local part did not say",
+				tc.email, nameOrNull(first), nameOrNull(last))
+		}
+	}
+}
+
+func TestEnsureCounterpartyFillsASplitNameItLearnsLater(t *testing.T) {
+	e := setupDedupe(t)
+	ctx := e.as()
+
+	// First contact is from a mailbox whose local part says nothing.
+	first, err := e.store.EnsureCounterparty(ctx, e.ensureInput(ctx, t, "hh@later.test", "", "later.test"))
+	if err != nil || !first.PersonCreated {
+		t.Fatalf("first ensure = %+v (err %v), want a created person", first, err)
+	}
+	if _, f, l := e.storedName(ctx, t, first.PersonID); f != nil || l != nil {
+		t.Fatalf("split names = %q / %q on first contact, want both NULL", nameOrNull(f), nameOrNull(l))
+	}
+
+	// The same human writes again, this time with their name in the header.
+	second, err := e.store.EnsureCounterparty(ctx, e.ensureInput(ctx, t, "hh@later.test", "Hanna Hoffmann", "later.test"))
+	if err != nil {
+		t.Fatalf("second ensure: %v", err)
+	}
+	if second.PersonID != first.PersonID {
+		t.Fatalf("second ensure minted %s, want the incumbent %s", second.PersonID, first.PersonID)
+	}
+	_, f, l := e.storedName(ctx, t, first.PersonID)
+	if nameOrNull(f) != "Hanna" || nameOrNull(l) != "Hoffmann" {
+		t.Fatalf("split names = %q / %q, want Hanna / Hoffmann filled in on the second contact",
+			nameOrNull(f), nameOrNull(l))
+	}
+}
+
+// The guard: an automatic fill may only ever ADD. A name a human typed is the
+// authority on that person, and no later header may rewrite it.
+func TestEnsureCounterpartyNeverOverwritesANameAHumanSet(t *testing.T) {
+	e := setupDedupe(t)
+	ctx := e.as()
+
+	res, err := e.store.EnsureCounterparty(ctx, e.ensureInput(ctx, t, "wrong.spelling@human.test", "", "human.test"))
+	if err != nil {
+		t.Fatalf("ensure: %v", err)
+	}
+	// A human corrects the record — the spelling capture derived was wrong.
+	if err := e.store.tx(ctx, func(tx pgx.Tx) error {
+		_, err := tx.Exec(ctx, `
+			UPDATE person SET full_name = $2, first_name = $3, last_name = $4 WHERE id = $1`,
+			res.PersonID, "Wolfgang Schmitt-Rink", "Wolfgang", "Schmitt-Rink")
+		return err
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// More mail arrives, spelling the name differently. The header parses
+	// CONFIDENTLY — an unconfident one would be refused before the write and
+	// would prove nothing about the fill guard itself.
+	again, err := e.store.EnsureCounterparty(ctx,
+		e.ensureInput(ctx, t, "wrong.spelling@human.test", "Wolf Rink", "human.test"))
+	if err != nil {
+		t.Fatalf("second ensure: %v", err)
+	}
+	if again.PersonID != res.PersonID {
+		t.Fatalf("second ensure minted %s, want the incumbent %s", again.PersonID, res.PersonID)
+	}
+	full, first, last := e.storedName(ctx, t, res.PersonID)
+	if full != "Wolfgang Schmitt-Rink" || nameOrNull(first) != "Wolfgang" || nameOrNull(last) != "Schmitt-Rink" {
+		t.Fatalf("stored name = %q / %q / %q after later mail, want the human's spelling untouched",
+			full, nameOrNull(first), nameOrNull(last))
+	}
+}

--- a/backend/internal/modules/people/personname.go
+++ b/backend/internal/modules/people/personname.go
@@ -92,8 +92,22 @@ var nameParticles = map[string]bool{
 // an address, in that order of authority: what the sender calls themselves
 // beats what their mailbox is called.
 func ParsePersonName(displayName, email string) ParsedName {
+	// Both inputs are untrusted header text. Bidi controls are removed before
+	// anything else: they are invisible, they survive every other transform,
+	// and left in `full_name` they make the stored string render as a name it
+	// is not: a right-to-left override before "htimS" makes it display as "Smith".
+	displayName = stripBidiControls(displayName)
+	if tooLongToBeAName(displayName) {
+		displayName = ""
+	}
 	if parsed, ok := parseDisplayName(displayName); ok {
 		return parsed
+	}
+	if tooLongToBeAName(email) {
+		// An address this long is not a name to read. It still has to be
+		// displayable, so it is truncated to something a human can see in a
+		// list rather than dropped or stored whole.
+		return ParsedName{Full: string([]rune(email)[:maxNameInputRunes])}
 	}
 	parsed := parseLocalPart(email)
 	if parsed.Full == "" {
@@ -154,11 +168,15 @@ func parseLocalPart(email string) ParsedName {
 	if base, _, found := strings.Cut(local, "+"); found && base != "" {
 		local = base
 	}
-	if roleLocalParts[strings.ToLower(local)] {
+	if hasRoleToken(local) {
 		return ParsedName{Full: local}
 	}
-	tokens := localPartTokens(local)
-	if len(tokens) == 0 {
+	tokens, complete := localPartTokens(local)
+	if len(tokens) == 0 || !complete {
+		// Something in the address did not read as a word — a dropped field
+		// would change WHICH human this is ("josé.maria.garcia" minus a
+		// decomposed "josé" is a different person), so the whole reading is
+		// refused rather than silently shortened.
 		return ParsedName{Full: local}
 	}
 	// One token is a surname, a handle, or a first name — the local part does
@@ -188,7 +206,9 @@ func parseLocalPart(email string) ParsedName {
 // so it stays inside the token, where capitalizeParts still cases both halves.
 // Splitting on it would turn "Anne-Marie O'Brien" into a three-token name and
 // hand "Marie" to the surname.
-func localPartTokens(local string) []string {
+// It reports complete=false when any field failed to read as a word. The caller
+// must then abstain: dropping a field silently would rename the person.
+func localPartTokens(local string) ([]string, bool) {
 	fields := strings.FieldsFunc(local, func(r rune) bool {
 		return r == '.' || r == '_'
 	})
@@ -196,27 +216,55 @@ func localPartTokens(local string) []string {
 	for _, field := range fields {
 		word := strings.TrimFunc(field, unicode.IsDigit)
 		if word == "" || !isWordLike(word) {
-			continue
+			return nil, false
 		}
 		tokens = append(tokens, word)
 	}
 	if len(tokens) > maxNameTokens {
-		return nil
+		return nil, false
 	}
-	return tokens
+	return tokens, true
+}
+
+// hasRoleToken reports whether a local part names an organizational mailbox
+// rather than a human — the whole of it, or any of its dot/underscore parts.
+// `support.eu@` and `sales.emea@` are the same kind of address as `support@`,
+// and reading them as "Support Eu" invents two people who do not exist.
+func hasRoleToken(local string) bool {
+	if roleLocalParts[strings.ToLower(local)] {
+		return true
+	}
+	for _, field := range strings.FieldsFunc(local, func(r rune) bool {
+		return r == '.' || r == '_' || r == '-'
+	}) {
+		if roleLocalParts[strings.ToLower(field)] {
+			return true
+		}
+	}
+	return false
 }
 
 // isWordLike reports whether a token could be part of a name: letters, plus the
 // apostrophes and hyphens real names carry. A token with a digit in the MIDDLE
 // (`user2name`) is a handle, not a name.
 func isWordLike(token string) bool {
+	letters := 0
 	for _, r := range token {
-		if unicode.IsLetter(r) || r == '\'' || r == '’' || r == '-' {
-			continue
+		switch {
+		case unicode.IsLetter(r):
+			letters++
+		case unicode.IsMark(r):
+			// A combining diacritic belongs to the letter before it: decomposed
+			// "é" is e + U+0301, and refusing the mark would drop the field and
+			// rename the person.
+		case r == '\'' || r == '’' || r == '-':
+		default:
+			return false
 		}
-		return false
 	}
-	return true
+	// Punctuation alone is not a word. Without this, "Alice -" reads as a
+	// person whose surname is a hyphen.
+	return letters > 0
 }
 
 // splitFirstLast decides whether tokens read as a given name and a surname.
@@ -238,6 +286,20 @@ func splitFirstLast(tokens []string) (string, string, bool) {
 	if nameParticles[strings.ToLower(tokens[0])] {
 		return "", "", false
 	}
+	// A name that mixes Latin with a look-alike script is a homoglyph attempt,
+	// not a multilingual name. It still DISPLAYS as given (hiding it would hide
+	// the mail), but nothing derived from it may be claimed as known.
+	if isMixedScriptSpoof(strings.Join(tokens, " ")) {
+		return "", "", false
+	}
+	// Three tokens only read as first+last when the tail is a particle surname
+	// ("Ludwig van Beethoven"). Otherwise the middle token is a middle name, a
+	// second given name, or — in a family-name-first convention written without
+	// a comma — the given name itself, and NOTHING in the string says which.
+	// Two plausible readings mean the honest answer is that we do not know.
+	if len(tokens) == maxNameTokens && !nameParticles[strings.ToLower(tokens[1])] {
+		return "", "", false
+	}
 	first := tokens[0]
 	last := strings.Join(tokens[1:], " ")
 	if first == "" || last == "" {
@@ -246,9 +308,25 @@ func splitFirstLast(tokens []string) (string, string, bool) {
 	return first, last, true
 }
 
+// credentialSuffixes are the post-nominals that follow a comma without making
+// the string surname-first. "Anna Weber, PhD" is Anna Weber; reversing it would
+// file her given name as "PhD".
+var credentialSuffixes = map[string]bool{
+	"phd": true, "ph.d": true, "ph.d.": true, "md": true, "m.d.": true,
+	"mba": true, "msc": true, "m.sc.": true, "bsc": true, "b.sc.": true,
+	"llm": true, "ll.m.": true, "jd": true, "j.d.": true, "cpa": true,
+	"cfa": true, "pe": true, "esq": true, "esq.": true, "rn": true,
+	"dds": true, "dvm": true, "edd": true, "psyd": true, "mpa": true, "mph": true,
+	"jr": true, "jr.": true, "sr": true, "sr.": true,
+	"ii": true, "iii": true, "iv": true,
+	"dipl": true, "dipl.": true, "ing": true, "ing.": true,
+	"mag": true, "mag.": true, "bakk": true, "bakk.": true, "msa": true,
+}
+
 // uncommaName reverses the "Surname, Given" spelling Outlook and address books
-// emit. Only ONE comma qualifies: "Weber, Anna, PhD" carries a credential the
-// reversal would turn into a given name.
+// emit — and ONLY that. Two other shapes wear the same comma and must not be
+// reversed: a post-nominal credential ("Anna Weber, PhD"), and anything with a
+// second comma, which is a list rather than a name.
 func uncommaName(name string) string {
 	before, after, found := strings.Cut(name, ",")
 	if !found || strings.Contains(after, ",") {
@@ -258,7 +336,34 @@ func uncommaName(name string) string {
 	if before == "" || after == "" {
 		return name
 	}
+	// The tail is what would become the GIVEN name. A credential there means
+	// the string was already "Given Surname" with a qualification appended, so
+	// the honest reading is to drop the qualification and keep the order.
+	if isCredentialTail(after) {
+		return before
+	}
+	// A tail of several words is a given name at most ("Anna Maria"); more than
+	// that is a title or a department the reversal would file as a person's
+	// first name.
+	if len(strings.Fields(after)) > 2 {
+		return name
+	}
 	return after + " " + before
+}
+
+// isCredentialTail reports whether every word after the comma is a post-nominal.
+func isCredentialTail(tail string) bool {
+	fields := strings.Fields(tail)
+	if len(fields) == 0 {
+		return false
+	}
+	for _, field := range fields {
+		if !credentialSuffixes[strings.ToLower(strings.TrimSuffix(field, "."))] &&
+			!credentialSuffixes[strings.ToLower(field)] {
+			return false
+		}
+	}
+	return true
 }
 
 // splitHonorific lifts a leading salutation off the name.

--- a/backend/internal/modules/people/personname.go
+++ b/backend/internal/modules/people/personname.go
@@ -1,0 +1,366 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package people
+
+// Reading a human's name off an email header.
+//
+// A counterparty arrives as at most two strings: the RFC 5322 display name, and
+// the address. Neither is a name. The display name is whatever the sender's
+// client was configured with — "Lienesch, André" surname-first, quotes the
+// header syntax left behind, a company suffixed after a pipe — and when it is
+// absent the only thing left is the local part, which is a mailbox identifier
+// that HAPPENS to spell a name often enough to be worth reading.
+//
+// So this file answers two questions, and keeps them apart: what do we DISPLAY,
+// and do we know the person's first and last name. The second is the one that
+// must be allowed to say no. A local part is evidence, not a fact — `schluepmann`
+// names a surname with no first name in sight, `info` names nobody at all, and
+// filling first/last from either would put a guess where provenance belongs.
+// Abstaining costs a null column; guessing wrong writes a person's name wrongly
+// and every draft that greets them repeats it.
+
+import (
+	"strings"
+	"unicode"
+)
+
+// ParsedName is what a header could be read as. First and Last are set only
+// together, and only when Confident — a half-parse is not a name.
+type ParsedName struct {
+	// Honorific is the stripped salutation ("Dr.", "Prof."). It is deliberately
+	// NOT person.title: that column holds a JOB title, and "Dr." is not one.
+	Honorific string
+	First     string
+	Last      string
+	// Full is always usable — person.full_name is NOT NULL. At worst it is the
+	// cleaned-up token the parser refused to split.
+	Full string
+	// Confident reports whether First/Last are a real reading rather than a
+	// guess. Only a confident parse may fill the split-name columns.
+	Confident bool
+}
+
+// maxNameTokens bounds what reads as "first last". Three admits a middle name
+// or a particle surname ("Ludwig van Beethoven"); beyond that the string is
+// carrying something that is not a name — a department, a company, a title —
+// and splitting it would invent a surname out of the tail.
+const maxNameTokens = 3
+
+// roleLocalParts are mailboxes an ORGANIZATION answers, not a person. They are
+// the reason `mail@petereich.com` must not become a person called "mail".
+//
+// Capture keeps its own narrower list for a different question (transactional.go
+// asks "is this machine-sent infrastructure"). This one asks "does this local
+// part name a human", so it is wider — `info` and `support` are typed by real
+// people all day and are still nobody's name — and it lives here because a
+// module never imports a sibling.
+var roleLocalParts = map[string]bool{
+	"admin": true, "billing": true, "buchhaltung": true, "career": true,
+	"careers": true, "contact": true, "hello": true, "help": true, "hi": true,
+	"info": true, "invoice": true, "jobs": true, "kontakt": true, "mail": true,
+	"marketing": true, "news": true, "newsletter": true, "office": true,
+	"post": true, "presse": true, "press": true, "privacy": true, "recruiting": true,
+	"sales": true, "service": true, "support": true, "team": true, "vertrieb": true,
+	"welcome": true, "no-reply": true, "noreply": true, "donotreply": true,
+	"do-not-reply": true, "bounce": true, "bounces": true, "mailer-daemon": true,
+	"mailerdaemon": true, "postmaster": true, "notifications": true,
+	"notification": true, "abuse": true, "security": true, "webmaster": true,
+}
+
+// honorifics are stripped off the front of a display name. Deliberately short:
+// only forms that are unambiguously a salutation. "Ing" or "Mag" would swallow
+// a real given name in some languages, so they stay out.
+var honorifics = map[string]string{
+	"dr": "Dr.", "dr.": "Dr.", "prof": "Prof.", "prof.": "Prof.",
+	"herr": "Herr", "frau": "Frau", "mr": "Mr.", "mr.": "Mr.",
+	"mrs": "Mrs.", "mrs.": "Mrs.", "ms": "Ms.", "ms.": "Ms.",
+	"mx": "Mx.", "mx.": "Mx.",
+}
+
+// nameParticles stay lowercase inside a surname and never stand alone as one.
+// "van der Berg" is one surname; capitalizing the particles would spell a name
+// its owner does not write.
+var nameParticles = map[string]bool{
+	"van": true, "von": true, "der": true, "den": true, "de": true, "del": true,
+	"della": true, "di": true, "da": true, "dos": true, "das": true, "le": true,
+	"la": true, "du": true, "ter": true, "ten": true, "zu": true, "af": true,
+	"av": true, "bin": true, "bint": true, "al": true,
+}
+
+// ParsePersonName reads the best name available from a header display name and
+// an address, in that order of authority: what the sender calls themselves
+// beats what their mailbox is called.
+func ParsePersonName(displayName, email string) ParsedName {
+	if parsed, ok := parseDisplayName(displayName); ok {
+		return parsed
+	}
+	parsed := parseLocalPart(email)
+	if parsed.Full == "" {
+		// Neither header said anything usable. person.full_name is NOT NULL and
+		// the caller has a record to write either way, so the address itself is
+		// the last honest display string — and when even that is empty, a
+		// placeholder beats failing the insert on a row we already accepted.
+		if addr := strings.TrimSpace(email); addr != "" {
+			parsed.Full = addr
+		} else {
+			parsed.Full = unknownPersonName
+		}
+	}
+	return parsed
+}
+
+// unknownPersonName is what a counterparty with no display name and no address
+// is called. It should be unreachable from mail (an activity has a sender), and
+// it exists so that a path which somehow gets there writes a row a human can
+// see and fix rather than failing a NOT NULL constraint deep in a transaction.
+const unknownPersonName = "Unknown sender"
+
+// parseDisplayName reads the RFC 5322 display name. It reports false when the
+// header carries nothing usable, so the caller falls through to the address.
+func parseDisplayName(displayName string) (ParsedName, bool) {
+	name := stripQuotes(strings.TrimSpace(displayName))
+	name = displayNameWithoutAffiliation(name)
+	if name == "" {
+		return ParsedName{}, false
+	}
+	name = uncommaName(name)
+	honorific, rest := splitHonorific(name)
+	tokens := strings.Fields(rest)
+	if len(tokens) == 0 {
+		// The display name was a bare honorific — "Dr." names nobody. Keep the
+		// original as the display string rather than storing an empty full_name.
+		return ParsedName{Full: name}, true
+	}
+	full := strings.Join(tokens, " ")
+	parsed := ParsedName{Honorific: honorific, Full: full}
+	if first, last, ok := splitFirstLast(tokens); ok {
+		parsed.First, parsed.Last, parsed.Confident = first, last, true
+	}
+	return parsed, true
+}
+
+// parseLocalPart reads the mailbox identifier — the last evidence there is.
+//
+// It is far more willing to abstain than the display-name path: a local part is
+// not a claim about a name, it is an address that sometimes contains one.
+func parseLocalPart(email string) ParsedName {
+	local, _, ok := strings.Cut(strings.TrimSpace(email), "@")
+	if !ok || local == "" {
+		return ParsedName{Full: strings.TrimSpace(email)}
+	}
+	// Plus-addressing is a routing tag the mailbox owner appended, never part
+	// of their name: `anna.weber+crm@` is Anna Weber.
+	if base, _, found := strings.Cut(local, "+"); found && base != "" {
+		local = base
+	}
+	if roleLocalParts[strings.ToLower(local)] {
+		return ParsedName{Full: local}
+	}
+	tokens := localPartTokens(local)
+	if len(tokens) == 0 {
+		return ParsedName{Full: local}
+	}
+	// One token is a surname, a handle, or a first name — the local part does
+	// not say which, so it names the person without splitting them.
+	if len(tokens) == 1 {
+		return ParsedName{Full: titleCaseToken(tokens[0])}
+	}
+	cased := make([]string, 0, len(tokens))
+	for _, token := range tokens {
+		cased = append(cased, titleCaseToken(token))
+	}
+	full := strings.Join(cased, " ")
+	parsed := ParsedName{Full: full}
+	if first, last, ok := splitFirstLast(cased); ok {
+		parsed.First, parsed.Last, parsed.Confident = first, last, true
+	}
+	return parsed
+}
+
+// localPartTokens splits a local part into name-shaped words: separators become
+// boundaries, digits are dropped, and anything left that is not a word is
+// refused. A token run like `trung314578` is a handle with a number stuck to
+// it, so the digits go and `trung` remains; `2016` alone is not a name at all.
+//
+// The hyphen is deliberately NOT a boundary. It separates words in `anne-marie`
+// exactly as it does in `first-last`, and the two are indistinguishable here —
+// so it stays inside the token, where capitalizeParts still cases both halves.
+// Splitting on it would turn "Anne-Marie O'Brien" into a three-token name and
+// hand "Marie" to the surname.
+func localPartTokens(local string) []string {
+	fields := strings.FieldsFunc(local, func(r rune) bool {
+		return r == '.' || r == '_'
+	})
+	tokens := make([]string, 0, len(fields))
+	for _, field := range fields {
+		word := strings.TrimFunc(field, unicode.IsDigit)
+		if word == "" || !isWordLike(word) {
+			continue
+		}
+		tokens = append(tokens, word)
+	}
+	if len(tokens) > maxNameTokens {
+		return nil
+	}
+	return tokens
+}
+
+// isWordLike reports whether a token could be part of a name: letters, plus the
+// apostrophes and hyphens real names carry. A token with a digit in the MIDDLE
+// (`user2name`) is a handle, not a name.
+func isWordLike(token string) bool {
+	for _, r := range token {
+		if unicode.IsLetter(r) || r == '\'' || r == '’' || r == '-' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+// splitFirstLast decides whether tokens read as a given name and a surname.
+//
+// A single token never does: it is a surname with no first name, or a handle.
+// Particles bind to the surname that follows them, so "Ludwig van Beethoven"
+// is Ludwig + "van Beethoven", not Ludwig van + Beethoven.
+func splitFirstLast(tokens []string) (string, string, bool) {
+	if len(tokens) < 2 || len(tokens) > maxNameTokens {
+		return "", "", false
+	}
+	for _, token := range tokens {
+		if !isWordLike(token) {
+			return "", "", false
+		}
+	}
+	// A leading particle means the string is a surname alone ("van Dijk"), and
+	// a surname alone has no first name to report.
+	if nameParticles[strings.ToLower(tokens[0])] {
+		return "", "", false
+	}
+	first := tokens[0]
+	last := strings.Join(tokens[1:], " ")
+	if first == "" || last == "" {
+		return "", "", false
+	}
+	return first, last, true
+}
+
+// uncommaName reverses the "Surname, Given" spelling Outlook and address books
+// emit. Only ONE comma qualifies: "Weber, Anna, PhD" carries a credential the
+// reversal would turn into a given name.
+func uncommaName(name string) string {
+	before, after, found := strings.Cut(name, ",")
+	if !found || strings.Contains(after, ",") {
+		return name
+	}
+	before, after = strings.TrimSpace(before), strings.TrimSpace(after)
+	if before == "" || after == "" {
+		return name
+	}
+	return after + " " + before
+}
+
+// splitHonorific lifts a leading salutation off the name.
+func splitHonorific(name string) (string, string) {
+	tokens := strings.Fields(name)
+	if len(tokens) < 2 {
+		return "", name
+	}
+	canonical, ok := honorifics[strings.ToLower(tokens[0])]
+	if !ok {
+		return "", name
+	}
+	return canonical, strings.Join(tokens[1:], " ")
+}
+
+// stripQuotes removes the quoting a header's own syntax left in the value —
+// `"Lienesch, André"` is a quoted-string because it contains a comma, and the
+// quotes are the encoding, not the name. Escaped inner quotes unescape.
+func stripQuotes(name string) string {
+	if len(name) >= 2 && strings.HasPrefix(name, `"`) && strings.HasSuffix(name, `"`) {
+		name = name[1 : len(name)-1]
+	}
+	name = strings.ReplaceAll(name, `\"`, `"`)
+	return strings.TrimSpace(name)
+}
+
+// affiliationSeparators mark where a display name stops naming the person and
+// starts naming who they work for: "Sven Rittau | K5", "Tomas Vidal - TVPartner".
+var affiliationSeparators = []string{" | ", " – ", " — ", " - ", " • ", " · ", " @ ", " / "}
+
+// displayNameWithoutAffiliation keeps the part before the first affiliation
+// marker. Everything after it is an employer, a team, or a tagline, and reading
+// it as a surname is how "Rittau K5" gets stored as somebody's name.
+//
+// Distinct from domainpersonal.go's nameWithoutAffiliation, which answers a
+// different question: that one feeds a SIMILARITY test, so it case-folds and
+// strips accents, and it also cuts on a comma. Both would be wrong here — this
+// result is STORED, and "André" must survive as "André", while a comma is the
+// surname-first separator uncommaName still has to read.
+func displayNameWithoutAffiliation(name string) string {
+	trimmed := name
+	for _, sep := range affiliationSeparators {
+		if before, _, found := strings.Cut(trimmed, sep); found {
+			trimmed = strings.TrimSpace(before)
+		}
+	}
+	if trimmed == "" {
+		return name
+	}
+	// A parenthesised aside is the same thing: "Andreas Stegmann (NFQ)".
+	if before, _, found := strings.Cut(trimmed, "("); found {
+		if cut := strings.TrimSpace(before); cut != "" {
+			trimmed = cut
+		}
+	}
+	return trimmed
+}
+
+// titleCaseToken capitalizes one word the way a name is written, and only when
+// the word gives no opinion of its own. A token that already carries inner
+// capitals is somebody's chosen spelling — McDonald, O'Brien, DeSantis — and
+// rewriting it would be a correction nobody asked for.
+func titleCaseToken(token string) string {
+	if token == "" {
+		return token
+	}
+	if hasInnerUpper(token) {
+		return token
+	}
+	lower := strings.ToLower(token)
+	if nameParticles[lower] {
+		return lower
+	}
+	return capitalizeParts(lower)
+}
+
+// hasInnerUpper reports an uppercase letter after the first rune.
+func hasInnerUpper(token string) bool {
+	for i, r := range token {
+		if i > 0 && unicode.IsUpper(r) {
+			return true
+		}
+	}
+	return false
+}
+
+// capitalizeParts upper-cases the first letter of every hyphen- or
+// apostrophe-separated part: "anne-marie" → "Anne-Marie", "o'brien" → "O'Brien".
+func capitalizeParts(lower string) string {
+	var out strings.Builder
+	upcomingUpper := true
+	for _, r := range lower {
+		switch {
+		case upcomingUpper && unicode.IsLetter(r):
+			out.WriteRune(unicode.ToUpper(r))
+			upcomingUpper = false
+		case r == '-' || r == '\'' || r == '’':
+			out.WriteRune(r)
+			upcomingUpper = true
+		default:
+			out.WriteRune(r)
+		}
+	}
+	return out.String()
+}

--- a/backend/internal/modules/people/personname_test.go
+++ b/backend/internal/modules/people/personname_test.go
@@ -1,0 +1,182 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package people
+
+import "testing"
+
+// The cases are the real headers a Gmail import produced, so the table doubles
+// as the record of what was actually wrong: every `want` here is a row that
+// shipped broken before the parser existed.
+func TestParsePersonNameReadsTheNameAHeaderCarries(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name        string
+		display     string
+		email       string
+		wantFull    string
+		wantFirst   string
+		wantLast    string
+		wantHonor   string
+		wantConfide bool
+	}{
+		{
+			name:  "dotted local part splits into a first and last name",
+			email: "lars.ferner@louis.de", wantFull: "Lars Ferner",
+			wantFirst: "Lars", wantLast: "Ferner", wantConfide: true,
+		},
+		{
+			name:  "trailing digits are a handle's tail, not part of the surname",
+			email: "charlotte.nguyen2016@gmail.com", wantFull: "Charlotte Nguyen",
+			wantFirst: "Charlotte", wantLast: "Nguyen", wantConfide: true,
+		},
+		{
+			name:    "a surname-first display name is reversed and its header quotes dropped",
+			display: `"Lienesch, André"`, email: "andre.lienesch@louis.de",
+			wantFull: "André Lienesch", wantFirst: "André", wantLast: "Lienesch", wantConfide: true,
+		},
+		{
+			name:  "a lone surname names the person but is not split",
+			email: "schluepmann@k5-gmbh.com", wantFull: "Schluepmann",
+		},
+		{
+			name:  "a role mailbox names nobody",
+			email: "mail@petereich.com", wantFull: "mail",
+		},
+		{
+			name:    "an employer suffixed onto the display name is not a surname",
+			display: "Sven Rittau | K5", email: "sven@k5.de",
+			wantFull: "Sven Rittau", wantFirst: "Sven", wantLast: "Rittau", wantConfide: true,
+		},
+		{
+			name:    "a parenthesised affiliation is dropped the same way",
+			display: "Andreas Stegmann (NFQ)", email: "andreas@nfq.com",
+			wantFull: "Andreas Stegmann", wantFirst: "Andreas", wantLast: "Stegmann", wantConfide: true,
+		},
+		{
+			name:    "an honorific is lifted off and never becomes part of the name",
+			display: "Dr. Anna Weber", email: "anna.weber@example.com",
+			wantFull: "Anna Weber", wantFirst: "Anna", wantLast: "Weber",
+			wantHonor: "Dr.", wantConfide: true,
+		},
+		{
+			name:    "a particle binds to the surname it belongs to",
+			display: "Ludwig van Beethoven", email: "lvb@example.com",
+			wantFull: "Ludwig van Beethoven", wantFirst: "Ludwig", wantLast: "van Beethoven",
+			wantConfide: true,
+		},
+		{
+			name:    "a surname that is only a particle phrase has no first name to report",
+			display: "van Dijk", email: "vandijk@example.com", wantFull: "van Dijk",
+		},
+		{
+			name:  "plus-addressing is a routing tag, not a name",
+			email: "anna.weber+crm@example.com", wantFull: "Anna Weber",
+			wantFirst: "Anna", wantLast: "Weber", wantConfide: true,
+		},
+		{
+			name:    "a chosen inner-capital spelling is preserved",
+			display: "Ronan McDonald", email: "r@example.com",
+			wantFull: "Ronan McDonald", wantFirst: "Ronan", wantLast: "McDonald", wantConfide: true,
+		},
+		{
+			name:  "hyphenated and apostrophed names capitalize every part",
+			email: "anne-marie.o'brien@example.com", wantFull: "Anne-Marie O'Brien",
+			wantFirst: "Anne-Marie", wantLast: "O'Brien", wantConfide: true,
+		},
+		{
+			name:    "a department prefix makes the string too long to read as a name",
+			display: "MKT-Quynh.Vo Ngoc Nhu Thi Anh", email: "mkt@example.com",
+			wantFull: "MKT-Quynh.Vo Ngoc Nhu Thi Anh",
+		},
+		{
+			name:  "a digits-only local part is not a name",
+			email: "2016@example.com", wantFull: "2016",
+		},
+		{
+			name:  "an address with no local part falls back to the raw string",
+			email: "nobody", wantFull: "nobody",
+		},
+		{
+			name:    "a bare honorific names nobody",
+			display: "Dr.", email: "d@example.com", wantFull: "Dr.",
+		},
+		{
+			name:    "a middle name still reads as first and last",
+			display: "Anna Maria Weber", email: "amw@example.com",
+			wantFull: "Anna Maria Weber", wantFirst: "Anna", wantLast: "Maria Weber", wantConfide: true,
+		},
+		{
+			name:    "a second comma means the tail is a credential, not a given name",
+			display: "Weber, Anna, PhD", email: "aw@example.com",
+			wantFull: "Weber, Anna, PhD",
+		},
+		{
+			name:  "a handle with digits in the middle is not split",
+			email: "user2name@example.com", wantFull: "user2name",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := ParsePersonName(tc.display, tc.email)
+			if got.Full != tc.wantFull {
+				t.Errorf("Full = %q, want %q", got.Full, tc.wantFull)
+			}
+			if got.First != tc.wantFirst {
+				t.Errorf("First = %q, want %q", got.First, tc.wantFirst)
+			}
+			if got.Last != tc.wantLast {
+				t.Errorf("Last = %q, want %q", got.Last, tc.wantLast)
+			}
+			if got.Honorific != tc.wantHonor {
+				t.Errorf("Honorific = %q, want %q", got.Honorific, tc.wantHonor)
+			}
+			if got.Confident != tc.wantConfide {
+				t.Errorf("Confident = %v, want %v", got.Confident, tc.wantConfide)
+			}
+		})
+	}
+}
+
+// full_name is NOT NULL, so no input may parse to an empty display string.
+func TestParsePersonNameAlwaysProducesADisplayableName(t *testing.T) {
+	t.Parallel()
+	for _, in := range []struct{ display, email string }{
+		{display: "", email: "a@b.com"},
+		{display: "", email: ""},
+		{display: "   ", email: "  "},
+		{display: `""`, email: "x@y.com"},
+		{display: "|", email: "z@z.com"},
+		{display: "...", email: "...@example.com"},
+		{display: "", email: "@example.com"},
+	} {
+		if got := ParsePersonName(in.display, in.email); got.Full == "" {
+			t.Errorf("ParsePersonName(%q, %q) produced an empty Full", in.display, in.email)
+		}
+	}
+}
+
+// A name is reported only as a PAIR: half a reading is not a name, and the
+// split columns must never carry one without the other.
+func TestParsePersonNameNeverReportsHalfAName(t *testing.T) {
+	t.Parallel()
+	for _, in := range []struct{ display, email string }{
+		{display: "", email: "schluepmann@k5-gmbh.com"},
+		{display: "", email: "info@acme.com"},
+		{display: "van Dijk", email: "v@d.com"},
+		{display: "", email: "lars.ferner@louis.de"},
+		{display: "Dr. Anna Weber", email: "a@w.com"},
+		{display: "", email: "2016@example.com"},
+	} {
+		got := ParsePersonName(in.display, in.email)
+		if (got.First == "") != (got.Last == "") {
+			t.Errorf("ParsePersonName(%q, %q) = first %q last %q: one set without the other",
+				in.display, in.email, got.First, got.Last)
+		}
+		if got.Confident != (got.First != "" && got.Last != "") {
+			t.Errorf("ParsePersonName(%q, %q): Confident=%v disagrees with first %q last %q",
+				in.display, in.email, got.Confident, got.First, got.Last)
+		}
+	}
+}

--- a/backend/internal/modules/people/personname_test.go
+++ b/backend/internal/modules/people/personname_test.go
@@ -3,7 +3,10 @@
 
 package people
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 // The cases are the real headers a Gmail import produced, so the table doubles
 // as the record of what was actually wrong: every `want` here is a row that
@@ -102,14 +105,36 @@ func TestParsePersonNameReadsTheNameAHeaderCarries(t *testing.T) {
 			display: "Dr.", email: "d@example.com", wantFull: "Dr.",
 		},
 		{
-			name:    "a middle name still reads as first and last",
+			name:    "three plain tokens are ambiguous and are not split",
 			display: "Anna Maria Weber", email: "amw@example.com",
-			wantFull: "Anna Maria Weber", wantFirst: "Anna", wantLast: "Maria Weber", wantConfide: true,
+			wantFull: "Anna Maria Weber",
 		},
 		{
 			name:    "a second comma means the tail is a credential, not a given name",
 			display: "Weber, Anna, PhD", email: "aw@example.com",
 			wantFull: "Weber, Anna, PhD",
+		},
+		{
+			name:    "a post-nominal after one comma is dropped, not read as a given name",
+			display: "Anna Weber, PhD", email: "aw2@example.com",
+			wantFull: "Anna Weber", wantFirst: "Anna", wantLast: "Weber", wantConfide: true,
+		},
+		{
+			name:  "a departmental mailbox is a role address, not two people",
+			email: "support.eu@example.com", wantFull: "support.eu",
+		},
+		{
+			name:    "punctuation is not a surname",
+			display: "Alice -", email: "a@example.com", wantFull: "Alice -",
+		},
+		{
+			name:    "a name mixing Latin with a look-alike script is never claimed as known",
+			display: "Аlice Smith", email: "as@example.com", wantFull: "Аlice Smith",
+		},
+		{
+			name:    "bidi overrides are stripped so the stored name cannot render as another",
+			display: "Alice \u202ehtimS\u202c", email: "bidi@example.com",
+			wantFull: "Alice htimS", wantFirst: "Alice", wantLast: "htimS", wantConfide: true,
 		},
 		{
 			name:  "a handle with digits in the middle is not split",
@@ -154,6 +179,25 @@ func TestParsePersonNameAlwaysProducesADisplayableName(t *testing.T) {
 		if got := ParsePersonName(in.display, in.email); got.Full == "" {
 			t.Errorf("ParsePersonName(%q, %q) produced an empty Full", in.display, in.email)
 		}
+	}
+}
+
+// A display name is untrusted header text of the sender's choosing. The parser
+// must bound it before splitting, or a multi-megabyte value would be tokenized,
+// rejoined and handed on to dedupe and the database.
+func TestParsePersonNameRefusesAnOversizedHeader(t *testing.T) {
+	t.Parallel()
+	huge := strings.Repeat("A ", 200_000)
+	got := ParsePersonName(huge, "real.person@example.com")
+	if len([]rune(got.Full)) > maxNameInputRunes {
+		t.Errorf("Full is %d runes, want at most %d", len([]rune(got.Full)), maxNameInputRunes)
+	}
+	// The oversized header is discarded, so the address still names the person.
+	if got.First != "Real" || got.Last != "Person" {
+		t.Errorf("got %q %q, want the address read instead of the huge header", got.First, got.Last)
+	}
+	if long := ParsePersonName("", strings.Repeat("a", 5_000)+"@example.com"); len([]rune(long.Full)) > maxNameInputRunes {
+		t.Errorf("oversized address produced %d runes, want at most %d", len([]rune(long.Full)), maxNameInputRunes)
 	}
 }
 

--- a/backend/internal/modules/people/personnameguard.go
+++ b/backend/internal/modules/people/personnameguard.go
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package people
+
+// Screening the untrusted text a name is read from.
+//
+// A display name is a header field the SENDER chooses, so it is adversarial
+// input before it is a name: it can be megabytes long, it can carry invisible
+// controls that make the stored string render as somebody else, and it can
+// spell a Latin name in a look-alike script. personname.go decides what a name
+// SAYS; this file decides what is safe to read in the first place.
+
+import (
+	"strings"
+	"unicode"
+)
+
+// maxNameInputRunes bounds what the parser will read. A display name is a
+// header field an untrusted sender chooses, and the token cap is only consulted
+// AFTER splitting — so an 8 MiB quoted string would be split, joined and handed
+// to dedupe and the database before anything refused it. Real names are far
+// shorter than this; anything longer is not a name being truncated, it is a
+// payload being declined.
+const maxNameInputRunes = 200
+
+// tooLongToBeAName reports whether input exceeds the bound, counted in runes so
+// a multi-byte script is not penalized for its encoding.
+func tooLongToBeAName(s string) bool {
+	if len(s) > maxNameInputRunes*4 { // cheap pre-check: max UTF-8 bytes per rune
+		return true
+	}
+	return len([]rune(s)) > maxNameInputRunes
+}
+
+// stripBidiControls removes the Unicode directional overrides and isolates.
+// They are zero-width, so a stored name keeps rendering as something else
+// entirely while comparing unequal — the display-spoofing vector. Nothing
+// legitimate in a person's name needs them: real right-to-left text lays itself
+// out from its own characters.
+func stripBidiControls(s string) string {
+	if !strings.ContainsFunc(s, isBidiControl) {
+		return s
+	}
+	return strings.Map(func(r rune) rune {
+		if isBidiControl(r) {
+			return -1
+		}
+		return r
+	}, s)
+}
+
+// isBidiControl reports the explicit directional formatting characters:
+// LRE/RLE/PDF/LRO/RLO (U+202A–U+202E) and LRI/RLI/FSI/PDI (U+2066–U+2069).
+func isBidiControl(r rune) bool {
+	return (r >= 0x202A && r <= 0x202E) || (r >= 0x2066 && r <= 0x2069)
+}
+
+// isMixedScriptSpoof reports a name mixing scripts that render alike — the
+// homoglyph vector, e.g. Cyrillic U+0410 standing in for Latin "A" in "Аlice".
+// Latin combined with a non-confusable script (Greek, Han, Hebrew, Arabic,
+// Cyrillic on its own) is ordinary multilingual text; Latin INTERLEAVED with
+// Cyrillic or Greek inside one name is the attack.
+func isMixedScriptSpoof(name string) bool {
+	var latin, confusable bool
+	for _, r := range name {
+		switch {
+		case unicode.Is(unicode.Latin, r):
+			latin = true
+		case unicode.Is(unicode.Cyrillic, r) || unicode.Is(unicode.Greek, r):
+			confusable = true
+		}
+	}
+	return latin && confusable
+}


### PR DESCRIPTION
## What was wrong

Capture stored whatever the `From` header spelled — the display name verbatim, or the raw local part when there was none. In a real Gmail import of 173 people, **all 173 had `first_name` and `last_name` NULL**, because nothing on this path ever wrote them.

Concretely, these are rows that shipped:

| stored name | address | what it should be |
|---|---|---|
| `lars.ferner` | lars.ferner@louis.de | Lars Ferner |
| `charlotte.nguyen2016` | charlotte.nguyen2016@… | Charlotte Nguyen |
| `"Lienesch, André"` | andre.lienesch@louis.de | André Lienesch |
| `mail` | mail@petereich.com | nobody — a role mailbox |

## What this does

`ParsePersonName` reads the header the way a person would: strips the quotes RFC 5322 requires around a comma, reverses `Surname, Given`, lifts an honorific (and deliberately does **not** store it in `person.title`, which is a job title), drops an employer stapled on after a pipe or in parentheses, and splits a local part on its separators with a handle's trailing digits removed. Capitalization respects what the name already says: `McDonald` and `O'Brien` keep their spelling, `van Beethoven` keeps the particle lowercase and binds it to the surname.

**The parser abstains rather than guesses.** A single token is a surname with no given name in sight, or a handle; a role mailbox names nobody. Both still produce an honest display name and leave the split columns NULL. A null says "we do not know", which is true — a guess would put an invention into a person's name, and every generated greeting would repeat it.

## The fill rule

Exact-address reuse used to return the incumbent untouched, so a broken name stayed broken forever. It now completes **only columns that are empty**. The NULL predicate is the compare-and-set: a name a human typed is never rewritten by a later header. This matters beyond re-ingestion — a person imported or entered by hand otherwise keeps a bad name no amount of mail can fix.

## Tests

- `personname_test.go` — a table whose cases are the real broken headers from the import, plus the abstention edges (unicode, initials, particles, plus-addressing, digits-only and punctuation-only local parts, escaped quotes, comma order that is not surname-first).
- `ensurename_integration_test.go` — four tests over real Postgres, seeded through the real writer: the split columns land, they stay NULL when the parser cannot tell, a second message completes a record the first left incomplete, and **a human-set name survives later mail that parses differently**.

That last guard was mutation-checked: with the `IS NULL` predicate removed the test fails, showing the human's name overwritten. It passes for the right reason.

## Gates

`make check-backend` green, `make craft-static` 0 findings, `rls-store-path` and `no-jurisdiction` clean, and the people integration lane green under a private template.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Parses and stores human names from the `From` header and fills split name columns when confident. Previously we saved the display name verbatim or the raw local part and never populated `first_name`/`last_name`; now we derive `full_name`, write `first_name`/`last_name` only on confident parses, and complete missing names on exact-address matches without overwriting human edits.

- Adds `people.ParsePersonName`: strips header quotes, reverses “Surname, Given”, lifts honorifics (not `person.title`), removes affiliations (pipe/parentheses), splits local parts (drops trailing digits), preserves inner capitals and lowercase particles; abstains on single-token/role mailboxes and other ambiguous cases. Defences: strips bidi controls, refuses mixed-script homoglyph names for split columns, bounds input at 200 runes.
- Updates ensure path: uses the parser for `full_name`; on exact-address matches runs `fillMissingPersonName` that writes `first_name`/`last_name` together only if both are NULL (concurrency via `IS NULL`), emits audit + `PersonUpdated` event, and ignores impersonation-suspect headers for incumbents. Adds `NameFilled` to `EnsureCounterpartyResult`.
- Tests cover parsing cases and integration writes: split-name fills, abstention (NULLs), additive completion on later mail, and protection of human-set names.

- Rollout: no schema changes. Safe to re-ingest mail to backfill split names; human corrections remain authoritative.

<sup>Written for commit 67bf5828e757b6ef38fc36c4629349ecd50c1cd6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1098?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

