### PR TITLE
fix(siteread): a failed website read says why, and is tried again when that helps

### DIFF
--- a/backend/internal/compose/deepreadstop.go
+++ b/backend/internal/compose/deepreadstop.go
@@ -128,13 +128,18 @@ func (w *siteDeepReadWorker) fail(ctx context.Context, readID ids.UUID, cause er
 	code, detail := diagnoseCrawlFailure(cause)
 	failure := people.FinishSiteReadInput{Status: "failed", StatusCode: code, StatusDetail: detail}
 	if people.SiteReadFailureCodes[code] {
-		// A cause that commonly clears on its own earns another attempt. Without
-		// this a single 403 from an edge's bot protection settles a company's
-		// site forever, which is how a real business ends up with a record
-		// holding nothing but its domain.
+		// A cause that commonly clears on its own names its own next attempt,
+		// which BeginSiteRead's failed-and-due arm re-claims. Without it a single
+		// 403 from an edge's bot protection settles a live company's site for
+		// good — the dossier is terminal, and nothing would ever ask again.
 		next := w.now().Add(siteReadRetryAfter)
 		failure.NextAttemptAt = &next
 	}
+	// Whether anything re-offers the read is the domain triage's decision, not
+	// this function's: the disposition ledger carries its own attempt budget and
+	// backoff (domaintriage.go), and it is what brings a domain back around. The
+	// retry time here is what stops that second visit from being refused by a
+	// dossier that already called itself finished.
 	if err := w.people.FinishSiteRead(tctx, readID, failure); err != nil {
 		return errors.Join(cause, fmt.Errorf("recording the failure on the dossier: %w", err))
 	}

--- a/backend/internal/compose/deepreadstop.go
+++ b/backend/internal/compose/deepreadstop.go
@@ -10,16 +10,70 @@ package compose
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"errors"
 	"fmt"
+	"net"
+	"net/http"
+	"time"
 
 	"github.com/gradionhq/margince/backend/internal/modules/people"
+	"github.com/gradionhq/margince/backend/internal/platform/webread"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
-// fail records the terminal failure on the dossier and returns the cause
-// so River logs it on the job. A retry after a recorded failure is safe
-// by construction — BeginSiteRead CAS-misses and the attempt no-ops.
+// siteReadRetryAfter is how long a retryable failure waits. Long enough that a
+// site under load or rate-limiting us is not hit again while it is still
+// unhappy, short enough that a company is not missing from the CRM for a week
+// over a transient block.
+const siteReadRetryAfter = 6 * time.Hour
+
+// diagnoseCrawlFailure turns a crawl error into the closed code an operator
+// groups by and one sentence they can act on.
+//
+// It reads TYPED errors, never message text: the status travels on
+// webread.StatusError and the network faults are net.Error, so the classifier
+// asks the error what it is instead of pattern-matching a string that any
+// wrapper could reword. The detail is written for a human reading a list of
+// failed companies — it says what the site did, not what our stack was doing.
+func diagnoseCrawlFailure(cause error) (code, detail string) {
+	switch {
+	case cause == nil:
+		return "internal", "The read failed without recording a cause."
+	case errors.Is(cause, webread.ErrRobotsDisallowed):
+		return "robots_disallowed", "The site's robots.txt asks this crawler not to read the page."
+	}
+	var status *webread.StatusError
+	if errors.As(cause, &status) {
+		if status.Retryable() {
+			if status.Status == http.StatusForbidden || status.Status == http.StatusTooManyRequests {
+				return "bot_blocked", fmt.Sprintf(
+					"The site answered %d — bot protection or rate limiting refused the read. Another attempt is scheduled.",
+					status.Status)
+			}
+			return "http_server_error", fmt.Sprintf(
+				"The site answered %d. Another attempt is scheduled.", status.Status)
+		}
+		return "http_client_error", fmt.Sprintf("The site answered %d for its own front page.", status.Status)
+	}
+	var netErr net.Error
+	if errors.As(cause, &netErr) && netErr.Timeout() || errors.Is(cause, context.DeadlineExceeded) {
+		return "timeout", "The site did not answer in time. Another attempt is scheduled."
+	}
+	var certErr *tls.CertificateVerificationError
+	var hostErr x509.HostnameError
+	var authErr x509.UnknownAuthorityError
+	if errors.As(cause, &certErr) || errors.As(cause, &hostErr) || errors.As(cause, &authErr) {
+		return "tls", "The site's HTTPS certificate could not be verified, so it was not read."
+	}
+	var dnsErr *net.DNSError
+	if errors.As(cause, &dnsErr) {
+		return "dns", "The domain name does not resolve to a server."
+	}
+	return "unreadable", "The site could not be read; no page returned usable content."
+}
+
 // autoEnrichMaxPages is the page ceiling every AUTOMATIC read runs under
 // (ADR-0072 §9). A read nobody asked for should cost a fraction of one somebody
 // did: the setting is on by default and sweeps up to ten organizations a day
@@ -64,10 +118,24 @@ func (w *siteDeepReadWorker) abandon(ctx context.Context, readID ids.UUID, reaso
 	return nil
 }
 
+// fail records the terminal failure on the dossier, WITH its diagnosis, and
+// returns the cause so River logs it on the job. A retry after a recorded
+// failure is safe by construction — BeginSiteRead CAS-misses and the attempt
+// no-ops.
 func (w *siteDeepReadWorker) fail(ctx context.Context, readID ids.UUID, cause error) error {
 	tctx, cancel := terminalCtx(ctx)
 	defer cancel()
-	if err := w.people.FinishSiteRead(tctx, readID, people.FinishSiteReadInput{Status: "failed"}); err != nil {
+	code, detail := diagnoseCrawlFailure(cause)
+	failure := people.FinishSiteReadInput{Status: "failed", StatusCode: code, StatusDetail: detail}
+	if people.SiteReadFailureCodes[code] {
+		// A cause that commonly clears on its own earns another attempt. Without
+		// this a single 403 from an edge's bot protection settles a company's
+		// site forever, which is how a real business ends up with a record
+		// holding nothing but its domain.
+		next := w.now().Add(siteReadRetryAfter)
+		failure.NextAttemptAt = &next
+	}
+	if err := w.people.FinishSiteRead(tctx, readID, failure); err != nil {
 		return errors.Join(cause, fmt.Errorf("recording the failure on the dossier: %w", err))
 	}
 	// The dossier is terminal now, and a failed read is one no confirmation

--- a/backend/internal/compose/deepreadstop.go
+++ b/backend/internal/compose/deepreadstop.go
@@ -40,38 +40,42 @@ const siteReadRetryAfter = 6 * time.Hour
 func diagnoseCrawlFailure(cause error) (code, detail string) {
 	switch {
 	case cause == nil:
-		return "internal", "The read failed without recording a cause."
+		return people.SiteReadFailureInternal, "The read failed without recording a cause."
 	case errors.Is(cause, webread.ErrRobotsDisallowed):
-		return "robots_disallowed", "The site's robots.txt asks this crawler not to read the page."
+		return people.SiteReadFailureRobots, "The site's robots.txt asks this crawler not to read the page."
 	}
 	var status *webread.StatusError
 	if errors.As(cause, &status) {
 		if status.Retryable() {
 			if status.Status == http.StatusForbidden || status.Status == http.StatusTooManyRequests {
-				return "bot_blocked", fmt.Sprintf(
+				return people.SiteReadFailureBotBlocked, fmt.Sprintf(
 					"The site answered %d — bot protection or rate limiting refused the read. Another attempt is scheduled.",
 					status.Status)
 			}
-			return "http_server_error", fmt.Sprintf(
+			return people.SiteReadFailureServerError, fmt.Sprintf(
 				"The site answered %d. Another attempt is scheduled.", status.Status)
 		}
-		return "http_client_error", fmt.Sprintf("The site answered %d for its own front page.", status.Status)
+		return people.SiteReadFailureClientError, fmt.Sprintf("The site answered %d for its own front page.", status.Status)
 	}
 	var netErr net.Error
 	if errors.As(cause, &netErr) && netErr.Timeout() || errors.Is(cause, context.DeadlineExceeded) {
-		return "timeout", "The site did not answer in time. Another attempt is scheduled."
+		return people.SiteReadFailureTimeout, "The site did not answer in time. Another attempt is scheduled."
 	}
 	var certErr *tls.CertificateVerificationError
 	var hostErr x509.HostnameError
 	var authErr x509.UnknownAuthorityError
 	if errors.As(cause, &certErr) || errors.As(cause, &hostErr) || errors.As(cause, &authErr) {
-		return "tls", "The site's HTTPS certificate could not be verified, so it was not read."
+		return people.SiteReadFailureTLS, "The site's HTTPS certificate could not be verified, so it was not read."
 	}
 	var dnsErr *net.DNSError
 	if errors.As(cause, &dnsErr) {
-		return "dns", "The domain name does not resolve to a server."
+		return people.SiteReadFailureDNS, "The domain name does not resolve to a server."
 	}
-	return "unreadable", "The site could not be read; no page returned usable content."
+	// Nothing recognized it, so it is not evidence about the SITE. Most callers
+	// of fail() are our own machinery — the settings store, a proposal hash, a
+	// finding write — and blaming those on the company's website would file our
+	// bug under their domain and settle it as permanently unreadable.
+	return people.SiteReadFailureInternal, "The read failed inside this system rather than at the site."
 }
 
 // autoEnrichMaxPages is the page ceiling every AUTOMATIC read runs under

--- a/backend/internal/compose/deepreadtriage.go
+++ b/backend/internal/compose/deepreadtriage.go
@@ -241,6 +241,14 @@ func (w *siteDeepReadWorker) finishTriageRead(ctx context.Context, args SiteDeep
 	if warning != "" {
 		in.Warnings = []string{warning}
 	}
+	if status == siteReadWireStatusFailed {
+		// A failed dossier must name its cause. The triage lane reaches here
+		// having already decided the site said nothing usable — it has no error
+		// to classify, so it records exactly that rather than a guess, and the
+		// warning it already wrote is the sentence a human reads.
+		in.StatusCode = people.SiteReadFailureUnreadable
+		in.StatusDetail = triageFailureDetail(warning)
+	}
 	if payload != nil {
 		in.Pages = siteReadPages(payload.Crawl.Pages)
 		in.FactCount = len(payload.Fields) + len(payload.Facts)
@@ -360,4 +368,15 @@ func triageCompanyEvidence(stated string, entities int) string {
 // people.TriageSeedURL and not a parse of anything a human typed.
 func triageDomainOf(seedURL string) string {
 	return freemail.Registrable(strings.TrimPrefix(seedURL, people.TriageSeedScheme))
+}
+
+// triageFailureDetail is the sentence a failed triage dossier carries. The
+// lane's own warning already says what happened, so it is reused verbatim; the
+// fallback exists because status_detail is required and an empty one would fail
+// the write on a path that has nothing left to report.
+func triageFailureDetail(warning string) string {
+	if warning != "" {
+		return warning
+	}
+	return "The site could not be read, and nothing said why."
 }

--- a/backend/internal/compose/onboardinglogo_integration_test.go
+++ b/backend/internal/compose/onboardinglogo_integration_test.go
@@ -498,8 +498,15 @@ func claimedOnboardingRead(t *testing.T, e *integration.Env) (SiteDeepReadArgs, 
 func endedOnboardingRead(t *testing.T, e *integration.Env, status string) (SiteDeepReadArgs, people.SiteReadClaim) {
 	t.Helper()
 	args, claim := claimedOnboardingRead(t, e)
+	outcome := people.FinishSiteReadInput{Status: status}
+	if status == "failed" {
+		// A failure names its cause; the store refuses one that does not. What
+		// this test is about is the parked mark, so any honest diagnosis does.
+		outcome.StatusCode = "unreadable"
+		outcome.StatusDetail = "The site could not be read."
+	}
 	if err := e.People.FinishSiteRead(deepReadWorkerCtx(context.Background(), args),
-		args.SiteReadID, people.FinishSiteReadInput{Status: status}); err != nil {
+		args.SiteReadID, outcome); err != nil {
 		t.Fatalf("end the onboarding read as %s: %v", status, err)
 	}
 	return args, claim

--- a/backend/internal/compose/sitecrawl.go
+++ b/backend/internal/compose/sitecrawl.go
@@ -74,12 +74,18 @@ type siteCrawl struct {
 type siteFetcher interface {
 	FetchPage(ctx context.Context, rawURL string) (webread.Page, error)
 	FetchSitemap(ctx context.Context, origin string) ([]string, error)
+	// CrawlDelay reports what the host's robots.txt asks between requests,
+	// from the policy a fetch already resolved. False means it asked for none.
+	CrawlDelay(rawURL string) (time.Duration, bool)
 }
 
 // crawlPacer is the per-crawl politeness seam (*webread.Pacer in production).
 type crawlPacer interface {
 	Wait(ctx context.Context) error
 	Done()
+	// SlowTo raises the gap between requests to what the site's robots.txt
+	// asked for. It only ever slows the crawl.
+	SlowTo(delay time.Duration)
 }
 
 // CrawlCaps bounds one deep read. The zero value means "the defaults":

--- a/backend/internal/compose/sitecrawl_test.go
+++ b/backend/internal/compose/sitecrawl_test.go
@@ -38,6 +38,16 @@ type fakeSite struct {
 	mu      sync.Mutex
 	fetched []string
 	onFetch func(url string)
+	// crawlDelays is what each host's robots.txt asks between requests, by the
+	// URL the crawl reached it on. Absent means the site asked for nothing.
+	crawlDelays map[string]time.Duration
+}
+
+// CrawlDelay answers from the fixture the way the real fetcher answers from the
+// robots policy its own fetch cached.
+func (s *fakeSite) CrawlDelay(rawURL string) (time.Duration, bool) {
+	delay, asked := s.crawlDelays[rawURL]
+	return delay, asked && delay > 0
 }
 
 type fakeSitePage struct {
@@ -108,12 +118,18 @@ func (s *fakeSite) FetchSitemap(context.Context, string) ([]string, error) {
 	return s.sitemap, nil
 }
 
-// instantPacer removes real-clock politeness from crawler tests; pacing has
-// its own proof in platform/webread.
-type instantPacer struct{}
+// instantPacer removes real-clock politeness from crawler tests; pacing has its
+// own proof in platform/webread. It records the slowest rate it was asked to
+// hold, so a test can still prove the crawl honored a published Crawl-delay.
+type instantPacer struct{ slowedTo *time.Duration }
 
 func (instantPacer) Wait(context.Context) error { return nil }
 func (instantPacer) Done()                      {}
+func (p instantPacer) SlowTo(delay time.Duration) {
+	if p.slowedTo != nil && delay > *p.slowedTo {
+		*p.slowedTo = delay
+	}
+}
 
 func testSiteCrawler(site *fakeSite) *siteCrawler {
 	crawler := newSiteCrawler(site, CrawlCaps{})

--- a/backend/internal/compose/sitereadfailure_test.go
+++ b/backend/internal/compose/sitereadfailure_test.go
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// What a failed site read RECORDS, and which failures are worth another try.
+//
+// Before this, every failure was stored as a bare status='failed' with no code,
+// no sentence and no retry time: a real import produced 58 of them, all
+// identical, and the companies behind them kept an empty record whose cause
+// nobody could see. These cases pin each cause to the code an operator groups
+// by and to the retry decision that follows from it.
+
+import (
+	"context"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"net"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/modules/people"
+	"github.com/gradionhq/margince/backend/internal/platform/webread"
+)
+
+func TestDiagnoseCrawlFailureNamesTheCauseAndItsRetryPolicy(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name      string
+		cause     error
+		wantCode  string
+		wantRetry bool
+	}{
+		{
+			// The Surfe shape: an edge refused the crawler, intermittently.
+			// Settling the domain on this is how a real business ends up
+			// permanently recorded as nothing but its domain name.
+			name:     "bot protection is worth another attempt",
+			cause:    &webread.StatusError{Status: 403, URL: "https://surfe.com"},
+			wantCode: "bot_blocked", wantRetry: true,
+		},
+		{
+			name:     "rate limiting is the same answer",
+			cause:    &webread.StatusError{Status: 429, URL: "https://example.test"},
+			wantCode: "bot_blocked", wantRetry: true,
+		},
+		{
+			name:     "the site's own fault clears on its own",
+			cause:    &webread.StatusError{Status: 503, URL: "https://example.test"},
+			wantCode: "http_server_error", wantRetry: true,
+		},
+		{
+			name:     "a missing page will still be missing tomorrow",
+			cause:    &webread.StatusError{Status: 404, URL: "https://example.test"},
+			wantCode: "http_client_error", wantRetry: false,
+		},
+		{
+			// The Ausgezeichnet shape: the apex served a certificate that does
+			// not verify.
+			name:     "an unverifiable certificate is not retried",
+			cause:    fmt.Errorf("get: %w", x509.UnknownAuthorityError{}),
+			wantCode: "tls", wantRetry: false,
+		},
+		{
+			name:     "a name that does not resolve is not retried",
+			cause:    fmt.Errorf("dial: %w", &net.DNSError{Err: "no such host", Name: "nope.test"}),
+			wantCode: "dns", wantRetry: false,
+		},
+		{
+			name:     "a robots refusal is the site's answer, not a failure to repeat",
+			cause:    fmt.Errorf("fetch: %w", webread.ErrRobotsDisallowed),
+			wantCode: "robots_disallowed", wantRetry: false,
+		},
+		{
+			name:     "a timeout is worth another attempt",
+			cause:    fmt.Errorf("read: %w", context.DeadlineExceeded),
+			wantCode: "timeout", wantRetry: true,
+		},
+		{
+			name:     "anything else is recorded as unreadable rather than guessed at",
+			cause:    errors.New("something went sideways"),
+			wantCode: "unreadable", wantRetry: false,
+		},
+		{
+			name:     "a failure with no cause still says so",
+			cause:    nil,
+			wantCode: "internal", wantRetry: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			code, detail := diagnoseCrawlFailure(tc.cause)
+			if code != tc.wantCode {
+				t.Errorf("code = %q, want %q", code, tc.wantCode)
+			}
+			if detail == "" {
+				t.Error("detail is empty — a failure with no sentence is the state this replaces")
+			}
+			if retry := people.SiteReadFailureCodes[code]; retry != tc.wantRetry {
+				t.Errorf("retryable = %v, want %v", retry, tc.wantRetry)
+			}
+		})
+	}
+}
+
+// Every code the classifier can emit has to be one the store and the database
+// accept, or a real failure would be recorded as a constraint violation.
+func TestEveryDiagnosedCodeIsInTheStoreVocabulary(t *testing.T) {
+	t.Parallel()
+	causes := []error{
+		nil,
+		errors.New("unknown"),
+		&webread.StatusError{Status: 403},
+		&webread.StatusError{Status: 500},
+		&webread.StatusError{Status: 404},
+		fmt.Errorf("%w", webread.ErrRobotsDisallowed),
+		fmt.Errorf("%w", context.DeadlineExceeded),
+		&net.DNSError{Err: "no such host"},
+		x509.UnknownAuthorityError{},
+	}
+	for _, cause := range causes {
+		code, _ := diagnoseCrawlFailure(cause)
+		if _, known := people.SiteReadFailureCodes[code]; !known {
+			t.Errorf("diagnoseCrawlFailure(%v) produced %q, which the store would reject", cause, code)
+		}
+	}
+}

--- a/backend/internal/compose/sitereadfailure_test.go
+++ b/backend/internal/compose/sitereadfailure_test.go
@@ -77,9 +77,12 @@ func TestDiagnoseCrawlFailureNamesTheCauseAndItsRetryPolicy(t *testing.T) {
 			wantCode: "timeout", wantRetry: true,
 		},
 		{
-			name:     "anything else is recorded as unreadable rather than guessed at",
+			// An unrecognized error is OUR machinery failing, not evidence about
+			// the site. Filing it as unreadable would blame the company's
+			// website for our bug and settle the domain permanently.
+			name:     "an unrecognized error is ours, not the site's",
 			cause:    errors.New("something went sideways"),
-			wantCode: "unreadable", wantRetry: false,
+			wantCode: "internal", wantRetry: false,
 		},
 		{
 			name:     "a failure with no cause still says so",

--- a/backend/internal/compose/sitereadstore_integration_test.go
+++ b/backend/internal/compose/sitereadstore_integration_test.go
@@ -294,3 +294,120 @@ func TestSiteReadIsScopedToTheOrganizationTheCallerCanSee(t *testing.T) {
 		t.Fatalf("GetSiteRead on an invisible org → %v, want ErrNotFound", err)
 	}
 }
+
+func TestATransientlyFailedReadIsClaimedAgainWhenItsRetryFallsDue(t *testing.T) {
+	// A 403 from an edge's bot protection is not the site's final answer, so the
+	// failure names a time to try again. Without the claim honoring it the retry
+	// time would be state nothing reads, and one bad minute would settle a live
+	// company's site for ever.
+	e := integration.Setup(t)
+	store := people.NewStore(e.DB())
+	human := e.As(e.Rep1, nil, integration.AdminPerms)
+	worker := siteReadWorkerCtx(e)
+	org := siteReadOrg(e.SeedOrg(t, "Surfe", &e.Rep1))
+	read, _, err := store.StartSiteRead(human, org, "https://surfe.example", "human:"+e.Rep1.String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.BeginSiteRead(worker, read.ID, 10*time.Minute); err != nil {
+		t.Fatal(err)
+	}
+	next := time.Now().UTC().Add(6 * time.Hour).Truncate(time.Second)
+	if err := store.FinishSiteRead(worker, read.ID, people.FinishSiteReadInput{
+		Status:        "failed",
+		StatusCode:    "bot_blocked",
+		StatusDetail:  "The site answered 403 — bot protection refused the read.",
+		NextAttemptAt: &next,
+	}); err != nil {
+		t.Fatalf("finish as bot_blocked: %v", err)
+	}
+
+	failed, err := store.GetSiteRead(human, org, read.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if failed.StatusCode == nil || *failed.StatusCode != "bot_blocked" || failed.StatusDetail == nil {
+		t.Fatalf("failed dossier lost its diagnosis: %+v", failed)
+	}
+	if failed.NextAttemptAt == nil || !failed.NextAttemptAt.Equal(next) {
+		t.Fatalf("failed dossier did not keep its retry time: %+v", failed)
+	}
+
+	// Not yet due: the failure stands.
+	if _, err := store.BeginSiteRead(worker, read.ID, 10*time.Minute); !errors.Is(err, apperrors.ErrNotFound) {
+		t.Fatalf("claim before next_attempt_at: %v, want ErrNotFound", err)
+	}
+	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		_, err := tx.Exec(context.Background(),
+			`UPDATE site_read SET next_attempt_at = now() - interval '1 second' WHERE id = $1`, read.ID)
+		return err
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.BeginSiteRead(worker, read.ID, 10*time.Minute); err != nil {
+		t.Fatalf("claim due failed read: %v", err)
+	}
+	retried, err := store.GetSiteRead(human, org, read.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if retried.Status != "running" || retried.StatusCode != nil || retried.NextAttemptAt != nil {
+		t.Fatalf("retried dossier = %+v, want a clean running claim", retried)
+	}
+}
+
+func TestAPermanentlyFailedReadIsNeverClaimedAgain(t *testing.T) {
+	// A domain that does not resolve will not resolve tomorrow either. It sets
+	// no retry time, and nothing may re-claim it — re-crawling those is the
+	// noise the retry arm must not create.
+	e := integration.Setup(t)
+	store := people.NewStore(e.DB())
+	human := e.As(e.Rep1, nil, integration.AdminPerms)
+	worker := siteReadWorkerCtx(e)
+	org := siteReadOrg(e.SeedOrg(t, "Nowhere", &e.Rep1))
+	read, _, err := store.StartSiteRead(human, org, "https://nowhere.example", "human:"+e.Rep1.String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.BeginSiteRead(worker, read.ID, 10*time.Minute); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.FinishSiteRead(worker, read.ID, people.FinishSiteReadInput{
+		Status:       "failed",
+		StatusCode:   "dns",
+		StatusDetail: "The domain name does not resolve to a server.",
+	}); err != nil {
+		t.Fatalf("finish as dns: %v", err)
+	}
+	if _, err := store.BeginSiteRead(worker, read.ID, 10*time.Minute); !errors.Is(err, apperrors.ErrNotFound) {
+		t.Fatalf("claim of a terminal failure: %v, want ErrNotFound", err)
+	}
+}
+
+func TestASucceededReadCarriesNoDiagnosis(t *testing.T) {
+	// The columns say what went wrong. A read that worked has nothing to say
+	// there, and the store refuses the contradiction rather than storing it.
+	e := integration.Setup(t)
+	store := people.NewStore(e.DB())
+	human := e.As(e.Rep1, nil, integration.AdminPerms)
+	worker := siteReadWorkerCtx(e)
+	org := siteReadOrg(e.SeedOrg(t, "Fine", &e.Rep1))
+	read, _, err := store.StartSiteRead(human, org, "https://fine.example", "human:"+e.Rep1.String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.BeginSiteRead(worker, read.ID, 10*time.Minute); err != nil {
+		t.Fatal(err)
+	}
+	err = store.FinishSiteRead(worker, read.ID, people.FinishSiteReadInput{
+		Status: "done", StatusCode: "tls", StatusDetail: "not a failure",
+	})
+	if err == nil {
+		t.Fatal("a done read accepted a failure diagnosis")
+	}
+	if err := store.FinishSiteRead(worker, read.ID, people.FinishSiteReadInput{
+		Status: "failed", StatusCode: "bot_blocked",
+	}); err == nil {
+		t.Fatal("a failure was accepted with no sentence a human can act on")
+	}
+}

--- a/backend/internal/compose/siteseed.go
+++ b/backend/internal/compose/siteseed.go
@@ -38,6 +38,7 @@ func (c *siteCrawler) fetchSeed(ctx context.Context, pacer crawlPacer, seedURL s
 		page, err = c.fetchPaced(ctx, pacer, seedURL)
 	}
 	if err == nil || errors.Is(err, webread.ErrRobotsDisallowed) {
+		c.applyCrawlDelay(pacer, seedURL)
 		return seedURL, page, err
 	}
 	for _, candidate := range seedFallbacks(seedURL) {
@@ -52,6 +53,7 @@ func (c *siteCrawler) fetchSeed(ctx context.Context, pacer crawlPacer, seedURL s
 			retryPage, retryErr = c.fetchPaced(ctx, pacer, candidate)
 		}
 		if retryErr == nil {
+			c.applyCrawlDelay(pacer, candidate)
 			return candidate, retryPage, nil
 		}
 		// A refusal is the site's answer, not a spelling that failed to
@@ -113,4 +115,17 @@ func seedFallbacks(seedURL string) []string {
 		}
 	}
 	return out
+}
+
+// applyCrawlDelay slows the rest of the crawl to the rate the site publishes.
+//
+// It runs after the seed answered, which is exactly when the host's robots.txt
+// has been fetched and cached — asking earlier would either force a second
+// network round trip or read an empty cache and conclude the site asked for
+// nothing. Every later page of this crawl goes through the same pacer, so one
+// call here governs the whole read.
+func (c *siteCrawler) applyCrawlDelay(pacer crawlPacer, answeredURL string) {
+	if delay, asked := c.fetch.CrawlDelay(answeredURL); asked {
+		pacer.SlowTo(delay)
+	}
 }

--- a/backend/internal/modules/people/siteread.go
+++ b/backend/internal/modules/people/siteread.go
@@ -383,6 +383,13 @@ func (s *Store) BeginSiteRead(ctx context.Context, readID ids.UUID, reclaimAfter
 				next_attempt_at = NULL, started_at = now(), updated_at = now()
 			WHERE id = $1 AND (status = 'queued' OR
 			  (status = 'deferred' AND next_attempt_at <= now()) OR
+			  -- A failure the classifier judged transient — bot protection, a
+			  -- 5xx, a timeout — names its own next attempt, and this is what
+			  -- honours it. Without this arm the retry time would be written
+			  -- and never read, and one 403 would settle a live site for good.
+			  -- Failures with no next_attempt_at (a 404, a DNS miss, a robots
+			  -- refusal) are terminal and never re-claimed.
+			  (status = 'failed' AND next_attempt_at IS NOT NULL AND next_attempt_at <= now()) OR
 			  (status = 'running' AND started_at < now() - ($2 * interval '1 microsecond')))
 			RETURNING organization_id, target_kind, seed_url, requested_by, started_at`, readID, reclaimAfter.Microseconds()).
 			Scan(&claim.OrganizationID, &claim.TargetKind, &claim.SeedURL, &claim.RequestedBy, &claim.ClaimedAt)

--- a/backend/internal/modules/people/sitereadfinish.go
+++ b/backend/internal/modules/people/sitereadfinish.go
@@ -68,6 +68,21 @@ type FinishSiteReadInput struct {
 	ProposalHash  string
 }
 
+// The failure codes, named so callers cite the vocabulary instead of repeating
+// its spellings. Every one appears in the CHECK migration 0221 installs.
+const (
+	SiteReadFailureBotBlocked   = "bot_blocked"
+	SiteReadFailureServerError  = "http_server_error"
+	SiteReadFailureTimeout      = "timeout"
+	SiteReadFailureClientError  = "http_client_error"
+	SiteReadFailureDNS          = "dns"
+	SiteReadFailureTLS          = "tls"
+	SiteReadFailureRobots       = "robots_disallowed"
+	SiteReadFailureUnreadable   = "unreadable"
+	SiteReadFailureInternal     = "internal"
+	SiteReadFailureStaleReclaim = "stale_reclaim"
+)
+
 // SiteReadFailureCodes is the closed vocabulary a failed read is diagnosed
 // with, and the retry policy that goes with each. True means the cause commonly
 // clears on its own, so another attempt is worth scheduling.
@@ -77,15 +92,20 @@ type FinishSiteReadInput struct {
 // naming the field, rather than as a constraint violation from three layers
 // down that no operator can act on.
 var SiteReadFailureCodes = map[string]bool{
-	"bot_blocked":       true,  // 403/429 from an edge or bot protection
-	"http_server_error": true,  // 5xx — the site's own fault, usually transient
-	"timeout":           true,  // the site did not answer in time
-	"http_client_error": false, // 404 and friends: the page is simply not there
-	"dns":               false, // the name does not resolve
-	"tls":               false, // the certificate does not verify
-	"robots_disallowed": false, // the site's own answer, not a failure to retry
-	"unreadable":        false, // fetched, but nothing readable came back
-	"internal":          false, // our bug, not the site's — fix it, don't retry
+	SiteReadFailureBotBlocked:  true,  // 403/429 from an edge or bot protection
+	SiteReadFailureServerError: true,  // 5xx — the site's own fault, usually transient
+	SiteReadFailureTimeout:     true,  // the site did not answer in time
+	SiteReadFailureClientError: false, // 404 and friends: the page is simply not there
+	SiteReadFailureDNS:         false, // the name does not resolve
+	SiteReadFailureTLS:         false, // the certificate does not verify
+	SiteReadFailureRobots:      false, // the site's own answer, not a failure to retry
+	SiteReadFailureUnreadable:  false, // fetched, but nothing readable came back
+	SiteReadFailureInternal:    false, // our bug, not the site's — fix it, don't retry
+	// stale_reclaim is written by the triage sweep (RetireStaleTriageRead), not
+	// by a crawl: a read that stopped reporting is retired so the DOMAIN can be
+	// asked again. The domain's own disposition carries that retry, so the
+	// dossier itself needs none.
+	SiteReadFailureStaleReclaim: false,
 }
 
 // validateSiteReadOutcome enforces the shape the outcome CHECK requires, at the

--- a/backend/internal/modules/people/sitereadfinish.go
+++ b/backend/internal/modules/people/sitereadfinish.go
@@ -11,6 +11,7 @@ package people
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -38,7 +39,22 @@ type SiteReadClaim struct {
 
 // FinishSiteReadInput is the worker's completed crawl report.
 type FinishSiteReadInput struct {
-	Status        string // done | partial | failed | cancelled
+	Status string // done | partial | failed | cancelled
+	// StatusCode and StatusDetail diagnose a FAILED read: the closed code an
+	// operator groups by, and the one sentence they read. Both are required
+	// when Status is "failed" and forbidden otherwise — a read that worked has
+	// nothing to diagnose, and a failure with neither is the state this pair
+	// exists to end.
+	//
+	// Distinct from StoppedReason, whose vocabulary is only budget/page_cap/
+	// byte_cap/deadline: that says why a crawl stopped EARLY having read
+	// pages, which is not why one failed to read any.
+	StatusCode   string
+	StatusDetail string
+	// NextAttemptAt schedules another try. Set for causes that commonly clear
+	// on their own — bot protection, a 5xx, a timeout — and nil for the ones
+	// that will not, so a domain is not re-crawled forever over a 404.
+	NextAttemptAt *time.Time
 	Pages         []SiteReadPage
 	Skipped       []SiteReadSkip
 	StoppedReason *string
@@ -52,6 +68,49 @@ type FinishSiteReadInput struct {
 	ProposalHash  string
 }
 
+// SiteReadFailureCodes is the closed vocabulary a failed read is diagnosed
+// with, and the retry policy that goes with each. True means the cause commonly
+// clears on its own, so another attempt is worth scheduling.
+//
+// It mirrors the CHECK in migration 0221 deliberately: the database is the
+// authority, and this map is what lets a wrong value fail as a named Go error
+// naming the field, rather than as a constraint violation from three layers
+// down that no operator can act on.
+var SiteReadFailureCodes = map[string]bool{
+	"bot_blocked":       true,  // 403/429 from an edge or bot protection
+	"http_server_error": true,  // 5xx — the site's own fault, usually transient
+	"timeout":           true,  // the site did not answer in time
+	"http_client_error": false, // 404 and friends: the page is simply not there
+	"dns":               false, // the name does not resolve
+	"tls":               false, // the certificate does not verify
+	"robots_disallowed": false, // the site's own answer, not a failure to retry
+	"unreadable":        false, // fetched, but nothing readable came back
+	"internal":          false, // our bug, not the site's — fix it, don't retry
+}
+
+// validateSiteReadOutcome enforces the shape the outcome CHECK requires, at the
+// boundary where the caller can still be told which field is wrong.
+func validateSiteReadOutcome(in FinishSiteReadInput) error {
+	if in.Status != siteReadStatusFailed {
+		if in.StatusCode != "" || in.StatusDetail != "" || in.NextAttemptAt != nil {
+			return fmt.Errorf(
+				"people: a %s site read carries no diagnosis (status_code/status_detail/next_attempt_at are for a failure)",
+				in.Status)
+		}
+		return nil
+	}
+	if _, known := SiteReadFailureCodes[in.StatusCode]; !known {
+		return fmt.Errorf("people: %q is not a site-read failure code", in.StatusCode)
+	}
+	if in.StatusDetail == "" {
+		return errors.New("people: a failed site read needs a status_detail a human can act on")
+	}
+	return nil
+}
+
+// siteReadStatusFailed is the one terminal status that carries a diagnosis.
+const siteReadStatusFailed = "failed"
+
 // FinishSiteRead records the crawl's outcome in one guarded UPDATE from
 // running to a terminal status. No auth.Require, same as BeginSiteRead:
 // the worker runs under the job's workspace context, not a human
@@ -63,6 +122,9 @@ func (s *Store) FinishSiteRead(ctx context.Context, readID ids.UUID, in FinishSi
 	}
 	if in.StoppedReason != nil && !siteReadStopReasons[*in.StoppedReason] {
 		return fmt.Errorf("people: %q is not a site-read stop reason (budget|page_cap|byte_cap|deadline)", *in.StoppedReason)
+	}
+	if err := validateSiteReadOutcome(in); err != nil {
+		return err
 	}
 	pages, err := marshalSiteReadList(in.Pages)
 	if err != nil {
@@ -104,12 +166,15 @@ func (s *Store) FinishSiteRead(ctx context.Context, readID ids.UUID, in FinishSi
 			    fact_count = $6, proposal_ids = $7, profile_fields = $8, facts = $9,
 			    people = $10, warnings = $11, proposal_hash = $12,
 			    legal_entities = $15,
+			    status_code = NULLIF($16, ''), status_detail = NULLIF($17, ''),
+			    next_attempt_at = $18,
 			    draft_version = draft_version + 1, pages_read = $13, phase = NULL,
 			    first_grounded_at = CASE WHEN $14 THEN COALESCE(first_grounded_at, now()) ELSE first_grounded_at END,
 			    finished_at = now(), updated_at = now()
 			WHERE id = $1 AND status = 'running'`,
 			readID, in.Status, pages, skipped, in.StoppedReason, in.FactCount, proposals,
-			profileFields, facts, people, warnings, in.ProposalHash, len(in.Pages), grounded, entities)
+			profileFields, facts, people, warnings, in.ProposalHash, len(in.Pages), grounded, entities,
+			in.StatusCode, in.StatusDetail, in.NextAttemptAt)
 		if err != nil {
 			return fmt.Errorf("finish site read: %w", err)
 		}

--- a/backend/internal/platform/webread/crawldelay_test.go
+++ b/backend/internal/platform/webread/crawldelay_test.go
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package webread
+
+// Honoring the rate a site publishes.
+//
+// The pacer's own floor is a burst budget — eight requests in flight, 25ms
+// apart — which is far more aggressive than a site asking for seconds between
+// them. A crawler that ignores Crawl-delay while claiming to respect robots.txt
+// is walking past the one directive that governs rate, and on a site behind bot
+// protection it is also how the read gets refused.
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseRobotsReadsCrawlDelay(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		body string
+		want time.Duration
+	}{
+		{
+			name: "a whole number of seconds",
+			body: "User-agent: *\nCrawl-delay: 10\n",
+			want: 10 * time.Second,
+		},
+		{
+			name: "a decimal value",
+			body: "User-agent: *\nCrawl-delay: 0.5\n",
+			want: 500 * time.Millisecond,
+		},
+		{
+			name: "a group naming this bot outranks the wildcard",
+			body: "User-agent: *\nCrawl-delay: 1\n\nUser-agent: " + robotsAgentProduct + "\nCrawl-delay: 4\n",
+			want: 4 * time.Second,
+		},
+		{
+			// Same reasoning as a second Disallow: combining groups must not let
+			// a later one buy back a faster rate than an earlier one asked for.
+			name: "the longest delay across matching groups wins",
+			body: "User-agent: " + robotsAgentProduct + "\nCrawl-delay: 2\n\nUser-agent: " + robotsAgentProduct + "\nCrawl-delay: 7\n",
+			want: 7 * time.Second,
+		},
+		{
+			name: "an absurd value is capped rather than obeyed",
+			body: "User-agent: *\nCrawl-delay: 86400\n",
+			want: maxHonoredCrawlDelay,
+		},
+		{
+			name: "a value we cannot read is no delay, not an invented one",
+			body: "User-agent: *\nCrawl-delay: soon\n",
+			want: 0,
+		},
+		{
+			name: "a negative value is not a licence to go faster",
+			body: "User-agent: *\nCrawl-delay: -5\n",
+			want: 0,
+		},
+		{
+			name: "no directive is no delay",
+			body: "User-agent: *\nDisallow: /private\n",
+			want: 0,
+		},
+		{
+			name: "a delay before any user-agent line addresses nobody",
+			body: "Crawl-delay: 9\nUser-agent: *\nDisallow: /x\n",
+			want: 0,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := parseRobots(tc.body).crawlDelay; got != tc.want {
+				t.Errorf("crawlDelay = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// A Crawl-delay line must not disturb the rules around it: the directive is
+// unknown to RFC 9309, and mishandling it could silently drop a Disallow.
+func TestCrawlDelayDoesNotDisturbTheRules(t *testing.T) {
+	t.Parallel()
+	policy := parseRobots("User-agent: *\nCrawl-delay: 3\nDisallow: /private\nAllow: /private/ok\n")
+	if policy.crawlDelay != 3*time.Second {
+		t.Errorf("crawlDelay = %v, want 3s", policy.crawlDelay)
+	}
+	if policy.allows("/private/secret") {
+		t.Error("/private/secret is allowed, but the group disallows it")
+	}
+	if !policy.allows("/private/ok") {
+		t.Error("/private/ok is refused, but a longer Allow permits it")
+	}
+	if !policy.allows("/public") {
+		t.Error("/public is refused, but no rule covers it")
+	}
+}
+
+func TestPacerSlowToOnlyEverSlows(t *testing.T) {
+	t.Parallel()
+	pacer := NewPacer()
+	if pacer.interval != pacerMinInterval {
+		t.Fatalf("a fresh pacer holds %v, want the burst budget %v", pacer.interval, pacerMinInterval)
+	}
+	pacer.SlowTo(2 * time.Second)
+	if pacer.interval != 2*time.Second {
+		t.Errorf("interval = %v after asking for 2s, want 2s", pacer.interval)
+	}
+	// A site asking for less than the crawl already allows is not granting
+	// permission to speed up, and neither is a second, smaller ask.
+	pacer.SlowTo(time.Millisecond)
+	if pacer.interval != 2*time.Second {
+		t.Errorf("interval = %v after a smaller ask, want it held at 2s", pacer.interval)
+	}
+	pacer.SlowTo(0)
+	if pacer.interval != 2*time.Second {
+		t.Errorf("interval = %v after a zero ask, want it held at 2s", pacer.interval)
+	}
+}

--- a/backend/internal/platform/webread/pacer.go
+++ b/backend/internal/platform/webread/pacer.go
@@ -29,6 +29,10 @@ type Pacer struct {
 
 	mu        sync.Mutex
 	lastStart time.Time
+	// interval is the floor between request STARTS. It begins at the burst
+	// budget and is raised — never lowered — when the site's robots.txt asks
+	// for more room (SlowTo).
+	interval time.Duration
 
 	// now and sleep are seams so pacing is provable without a real clock.
 	now   func() time.Time
@@ -38,10 +42,26 @@ type Pacer struct {
 // NewPacer builds a real-clock pacer.
 func NewPacer() *Pacer {
 	return &Pacer{
-		slots: make(chan struct{}, pacerMaxConcurrent),
-		now:   time.Now,
-		sleep: sleepCtx,
+		slots:    make(chan struct{}, pacerMaxConcurrent),
+		interval: pacerMinInterval,
+		now:      time.Now,
+		sleep:    sleepCtx,
 	}
+}
+
+// SlowTo raises the floor between requests to what the site asked for in its
+// robots.txt Crawl-delay.
+//
+// It only ever SLOWS the crawl: a site asking for less than the burst budget
+// already allows is not granting permission to go faster, and a second call
+// with a smaller value cannot undo the first. Concurrency is left alone
+// deliberately — the delay governs how often requests START, and Wait already
+// serializes starts through the same interval, so eight in-flight requests
+// spaced by the site's own delay is the rate it asked for.
+func (p *Pacer) SlowTo(delay time.Duration) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.interval = max(p.interval, delay)
 }
 
 // Wait blocks until a request may start: a concurrency slot is free AND the
@@ -56,7 +76,7 @@ func (p *Pacer) Wait(ctx context.Context) error {
 	}
 	for {
 		p.mu.Lock()
-		wait := pacerMinInterval - p.now().Sub(p.lastStart)
+		wait := p.interval - p.now().Sub(p.lastStart)
 		if wait <= 0 {
 			p.lastStart = p.now()
 			p.mu.Unlock()

--- a/backend/internal/platform/webread/robots.go
+++ b/backend/internal/platform/webread/robots.go
@@ -3,16 +3,29 @@
 
 package webread
 
-import "strings"
+import (
+	"strconv"
+	"strings"
+	"time"
+)
 
 // robotsPolicy is the REP (RFC 9309) rule set this bot obeys: the union of
 // every group addressed to it (by product name, falling back to the union of
 // the * groups), longest-match wins, Allow beating Disallow at equal length,
 // with `*` (any run) and `$` (end anchor) interpreted as REP operators.
-// Crawl-delay/sitemap directives are ignored here — pacing is the crawler's
-// own, stricter policy.
+// Crawl-delay is honored: the pacer's own floor is a burst budget (8 in flight,
+// 25ms apart), which is far MORE aggressive than a site asking for seconds
+// between requests, so ignoring the directive would mean claiming to respect
+// robots while walking past the one line that governs rate. Sitemap and unknown
+// directives remain out of scope — this type answers "may I read this path",
+// and a sitemap is a discovery hint, not a permission.
 type robotsPolicy struct {
 	rules []robotsRule
+	// crawlDelay is the pause the site asks for between requests, zero when it
+	// asks for none. Non-standard (it predates RFC 9309 and is absent from it)
+	// but widely published and widely honored, so a crawler that ignores it is
+	// the impolite one regardless of what the RFC enumerates.
+	crawlDelay time.Duration
 }
 
 type robotsRule struct {
@@ -22,8 +35,9 @@ type robotsRule struct {
 
 // robotsGroup is one User-agent block and its rules.
 type robotsGroup struct {
-	agents []string
-	rules  []robotsRule
+	crawlDelay time.Duration
+	agents     []string
+	rules      []robotsRule
 }
 
 // allows reports whether the policy permits fetching target — the escaped
@@ -144,8 +158,14 @@ func parseRobots(body string) robotsPolicy {
 				continue
 			}
 			current.rules = append(current.rules, robotsRule{path: value, allow: key == "allow"})
+		case "crawl-delay":
+			inAgentRun = false
+			if current == nil {
+				continue // a delay before any User-agent line addresses nobody
+			}
+			current.crawlDelay = parseCrawlDelay(value)
 		default:
-			// Sitemap, Crawl-delay, unknown directives: not this policy's job.
+			// Sitemap and unknown directives: not this policy's job.
 			inAgentRun = false
 		}
 	}
@@ -160,6 +180,12 @@ func parseRobots(body string) robotsPolicy {
 // neither, everything is allowed.
 func selectPolicy(groups []robotsGroup) robotsPolicy {
 	var named, wildcard []robotsRule
+	var namedDelay, wildcardDelay time.Duration
+	// Whether a group ADDRESSED us at all, which is not the same as whether it
+	// carried rules: a group whose only directive is Crawl-delay still speaks
+	// to this bot, and reading its presence off a nil rule slice would discard
+	// the rate it asked for.
+	var addressed bool
 	for i := range groups {
 		namesUs, isWildcard := false, false
 		for _, agent := range groups[i].agents {
@@ -170,13 +196,37 @@ func selectPolicy(groups []robotsGroup) robotsPolicy {
 		// whole agent list decides, not whichever line happens to come first.
 		switch {
 		case namesUs:
+			addressed = true
 			named = append(named, groups[i].rules...)
+			// The LONGEST delay across matching groups wins: combining groups
+			// must not let a second one buy a faster rate than the first asked
+			// for, the same way a second Disallow cannot be bypassed.
+			namedDelay = max(namedDelay, groups[i].crawlDelay)
 		case isWildcard:
 			wildcard = append(wildcard, groups[i].rules...)
+			wildcardDelay = max(wildcardDelay, groups[i].crawlDelay)
 		}
 	}
-	if named != nil {
-		return robotsPolicy{rules: named}
+	if addressed {
+		return robotsPolicy{rules: named, crawlDelay: namedDelay}
 	}
-	return robotsPolicy{rules: wildcard}
+	return robotsPolicy{rules: wildcard, crawlDelay: wildcardDelay}
+}
+
+// maxHonoredCrawlDelay bounds what a site can ask for. A crawl runs under a wall
+// clock, so an unbounded delay would not make the read polite — it would make it
+// impossible, and the read would end as a timeout that reads like the site was
+// broken. Past this the delay is capped and the crawl reads fewer pages.
+const maxHonoredCrawlDelay = 10 * time.Second
+
+// parseCrawlDelay reads the directive's value: seconds, integer or decimal.
+// Anything unparseable, negative, or absent is no delay — a value we cannot
+// read is not a licence to invent one, in either direction.
+func parseCrawlDelay(value string) time.Duration {
+	seconds, err := strconv.ParseFloat(strings.TrimSpace(value), 64)
+	if err != nil || seconds <= 0 {
+		return 0
+	}
+	delay := time.Duration(seconds * float64(time.Second))
+	return min(delay, maxHonoredCrawlDelay)
 }

--- a/backend/internal/platform/webread/webread.go
+++ b/backend/internal/platform/webread/webread.go
@@ -68,6 +68,28 @@ const (
 // a failure.
 var ErrRobotsDisallowed = errors.New("webread: robots.txt disallows this path")
 
+// StatusError is a page or asset that answered with a status other than 200.
+//
+// The status travels as a TYPED value rather than inside a formatted string
+// because callers act on it differently: a 403 from an edge's bot protection is
+// worth another attempt later, a 404 is not. A caller that reconstructed the
+// number by parsing an error message would be guessing at its own data.
+type StatusError struct {
+	Status int
+	URL    string
+}
+
+func (e *StatusError) Error() string {
+	return fmt.Sprintf("webread: %s answered %d", e.URL, e.Status)
+}
+
+// Retryable reports whether the status is one that commonly changes on its own.
+// Bot protection (403, 429) and server faults (5xx) do; a 404 does not.
+func (e *StatusError) Retryable() bool {
+	return e.Status == http.StatusForbidden || e.Status == http.StatusTooManyRequests ||
+		e.Status >= http.StatusInternalServerError
+}
+
 // Fetcher is the production fetcher. Safe for concurrent use.
 type Fetcher struct {
 	client *http.Client
@@ -178,7 +200,7 @@ func (f *Fetcher) fetchDoc(ctx context.Context, rawURL, accept string) (body, me
 		return "", "", nil, err
 	}
 	if got.status != http.StatusOK {
-		return "", "", nil, fmt.Errorf("webread: page answered %d", got.status)
+		return "", "", nil, &StatusError{Status: got.status, URL: rawURL}
 	}
 	final = got.finalURL
 	if final == nil {
@@ -214,7 +236,7 @@ func (f *Fetcher) FetchAsset(ctx context.Context, rawURL string) ([]byte, string
 		return nil, "", err
 	}
 	if got.status != http.StatusOK {
-		return nil, "", fmt.Errorf("webread: asset answered %d", got.status)
+		return nil, "", &StatusError{Status: got.status, URL: rawURL}
 	}
 	if len(got.body) > maxAssetBytes {
 		return nil, "", fmt.Errorf("webread: asset exceeds the %d-byte cap", maxAssetBytes)
@@ -292,6 +314,27 @@ func (f *Fetcher) pathAllowed(ctx context.Context, page *url.URL) (bool, error) 
 		f.mu.Unlock()
 	}
 	return entry.policy.allows(robotsTarget(page)), nil
+}
+
+// CrawlDelay reports the pause the URL's host asks between requests, and false
+// when it asks for none or has not been consulted yet.
+//
+// It reads only the cache a fetch already populated — it never fetches
+// robots.txt itself. A caller asks AFTER its first fetch of the host, which is
+// when the policy is known; before that the honest answer is "no opinion
+// recorded", not a network round trip from a pacing helper.
+func (f *Fetcher) CrawlDelay(rawURL string) (time.Duration, bool) {
+	parsed, err := url.Parse(rawURL)
+	if err != nil || parsed.Host == "" {
+		return 0, false
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	entry, cached := f.robots[parsed.Scheme+"://"+parsed.Host]
+	if !cached || entry.policy.crawlDelay <= 0 {
+		return 0, false
+	}
+	return entry.policy.crawlDelay, true
 }
 
 // robotsTarget renders the URL the way a robots rule is written against it:

--- a/backend/internal/platform/webread/webread.go
+++ b/backend/internal/platform/webread/webread.go
@@ -382,6 +382,11 @@ func (f *Fetcher) fetchRobots(ctx context.Context, origin string) (robotsPolicy,
 	case resp.StatusCode >= 400 && resp.StatusCode < 500:
 		return robotsPolicy{}, nil // no policy declared — allow-all
 	default:
-		return robotsPolicy{}, fmt.Errorf("webread: robots.txt answered %d (refusing to guess what %s permits)", resp.StatusCode, origin)
+		// Typed, so a caller classifying the failure sees the STATUS: a 5xx on
+		// robots.txt is the site being unwell, which clears on its own, and
+		// reporting it as an opaque error would file a transient outage as a
+		// permanent verdict on the domain.
+		return robotsPolicy{}, fmt.Errorf("refusing to guess what %s permits: %w",
+			origin, &StatusError{Status: resp.StatusCode, URL: origin + "/robots.txt"})
 	}
 }

--- a/backend/migrations/core/0221_site_read_failure_diagnostics.down.sql
+++ b/backend/migrations/core/0221_site_read_failure_diagnostics.down.sql
@@ -6,6 +6,13 @@
 -- real loss of information, and it is the price of the revert — the failures
 -- themselves are preserved, only the reason they failed is dropped.
 
+-- Order matters, and getting it wrong makes the rollback impossible: the new
+-- CHECK requires a failed row to NAME its cause, so nulling those columns while
+-- it is still active violates it on every diagnosed failure — including the rows
+-- the up migration backfilled. The constraint comes off FIRST, and the old one
+-- goes on only once the data fits it again.
+ALTER TABLE site_read DROP CONSTRAINT site_read_outcome_shape;
+
 DO $$
 DECLARE ws uuid;
 BEGIN
@@ -19,8 +26,6 @@ BEGIN
        AND site_read.workspace_id = ws;
   END LOOP;
 END $$;
-
-ALTER TABLE site_read DROP CONSTRAINT site_read_outcome_shape;
 
 ALTER TABLE site_read
   ADD CONSTRAINT site_read_deferral_shape CHECK (

--- a/backend/migrations/core/0221_site_read_failure_diagnostics.down.sql
+++ b/backend/migrations/core/0221_site_read_failure_diagnostics.down.sql
@@ -1,0 +1,36 @@
+-- Reverting to 0104's shape, where only a deferred read may carry
+-- status_code/status_detail/next_attempt_at.
+--
+-- The diagnoses recorded under 0221 have to go: the old constraint forbids them
+-- on a failed row, so keeping them would make the table unrestorable. That is a
+-- real loss of information, and it is the price of the revert — the failures
+-- themselves are preserved, only the reason they failed is dropped.
+
+DO $$
+DECLARE ws uuid;
+BEGIN
+  FOR ws IN SELECT id FROM workspace LOOP
+    PERFORM set_config('app.workspace_id', ws::text, true);
+
+    UPDATE site_read
+       SET status_code = NULL, status_detail = NULL, next_attempt_at = NULL
+     WHERE status <> 'deferred'
+       AND (status_code IS NOT NULL OR status_detail IS NOT NULL OR next_attempt_at IS NOT NULL)
+       AND site_read.workspace_id = ws;
+  END LOOP;
+END $$;
+
+ALTER TABLE site_read DROP CONSTRAINT site_read_outcome_shape;
+
+ALTER TABLE site_read
+  ADD CONSTRAINT site_read_deferral_shape CHECK (
+    (status = 'deferred' AND status_code = 'budget_deferred' AND
+      status_detail IS NOT NULL AND next_attempt_at IS NOT NULL) OR
+    (status <> 'deferred' AND status_code IS NULL AND
+      status_detail IS NULL AND next_attempt_at IS NULL)
+  );
+
+DROP INDEX idx_site_read_retry_due;
+CREATE INDEX idx_site_read_deferred_due
+  ON site_read (workspace_id, next_attempt_at, id)
+  WHERE status = 'deferred';

--- a/backend/migrations/core/0221_site_read_failure_diagnostics.up.sql
+++ b/backend/migrations/core/0221_site_read_failure_diagnostics.up.sql
@@ -57,9 +57,16 @@ ALTER TABLE site_read
     -- it is set for the causes worth retrying (a 403 from bot protection, a
     -- 5xx, a timeout) and left NULL for the ones that will not change on their
     -- own (a robots refusal, a domain that does not resolve).
-    (status = 'failed' AND status_code IN (
+    -- status_code IS NOT NULL is not redundant with the IN list: a NULL makes
+    -- `status_code IN (...)` evaluate to UNKNOWN, and a CHECK passes on UNKNOWN.
+    -- Without it the database would accept exactly the undiagnosed failure this
+    -- migration exists to end, while the Go validator refused it.
+    (status = 'failed' AND status_code IS NOT NULL AND status_code IN (
         'bot_blocked', 'http_client_error', 'http_server_error', 'timeout',
-        'dns', 'tls', 'robots_disallowed', 'unreadable', 'internal')
+        'dns', 'tls', 'robots_disallowed', 'unreadable', 'internal',
+        -- Written by the triage sweep rather than a crawl: a read that stopped
+        -- reporting, retired so its domain can be asked again.
+        'stale_reclaim')
       AND status_detail IS NOT NULL)
     OR
     (status IN ('queued', 'running', 'done', 'partial', 'cancelled') AND

--- a/backend/migrations/core/0221_site_read_failure_diagnostics.up.sql
+++ b/backend/migrations/core/0221_site_read_failure_diagnostics.up.sql
@@ -1,0 +1,74 @@
+-- 0221: a failed website read says WHY it failed, and whether it is worth
+-- another attempt.
+--
+-- 0104 gave site_read status_code/status_detail/next_attempt_at and then
+-- reserved all three for status='deferred', because budget deferral was the
+-- only non-terminal outcome that existed. Every other failure was recorded as
+-- a bare status='failed' with the three columns NULL — so a TLS error, a DNS
+-- miss, a robots refusal and an edge 403 were stored identically, as nothing.
+-- In a real import that produced 58 failed reads, all 58 with no diagnosis and
+-- no scheduled retry, and the companies behind them kept an empty record
+-- nobody could see the reason for.
+--
+-- The shape now says: deferred keeps its exact budget spelling; a failed read
+-- MUST name a cause and MAY carry a retry time; done/partial/cancelled carry
+-- none of the three. status_code is a closed vocabulary rather than free text
+-- so an operator can group by it, and status_detail is the one sentence a
+-- human reads.
+
+ALTER TABLE site_read DROP CONSTRAINT site_read_deferral_shape;
+
+-- Reads that already failed under the old shape carry no diagnosis, and none
+-- can be recovered — the worker discarded the cause before writing the row.
+-- They are labelled for exactly that rather than guessed at, because a made-up
+-- code would be indistinguishable from a measured one and would poison the
+-- first honest grouping an operator does. No retry time is set: nothing here
+-- says whether another attempt would help.
+--
+-- The predicate names its own target rather than every failed row, so re-running
+-- this on a database where the new writer has already recorded real causes
+-- cannot overwrite them.
+-- The per-workspace loop: site_read is a tenant table, so the write binds
+-- app.workspace_id per workspace and scopes the statement to that workspace by
+-- predicate. The binding makes the rows visible under row-level security; the
+-- predicate is what keeps a BYPASSRLS executor (every dev machine and CI) from
+-- re-running the same update once per workspace.
+DO $$
+DECLARE ws uuid;
+BEGIN
+  FOR ws IN SELECT id FROM workspace LOOP
+    PERFORM set_config('app.workspace_id', ws::text, true);
+
+    UPDATE site_read
+       SET status_code = 'unreadable',
+           status_detail = 'Recorded before failures carried a diagnosis; the original cause was not stored.'
+     WHERE status = 'failed'
+       AND (status_code IS NULL OR status_detail IS NULL)
+       AND site_read.workspace_id = ws;
+  END LOOP;
+END $$;
+
+ALTER TABLE site_read
+  ADD CONSTRAINT site_read_outcome_shape CHECK (
+    (status = 'deferred' AND status_code = 'budget_deferred' AND
+      status_detail IS NOT NULL AND next_attempt_at IS NOT NULL)
+    OR
+    -- A failure names its cause. next_attempt_at is nullable here on purpose:
+    -- it is set for the causes worth retrying (a 403 from bot protection, a
+    -- 5xx, a timeout) and left NULL for the ones that will not change on their
+    -- own (a robots refusal, a domain that does not resolve).
+    (status = 'failed' AND status_code IN (
+        'bot_blocked', 'http_client_error', 'http_server_error', 'timeout',
+        'dns', 'tls', 'robots_disallowed', 'unreadable', 'internal')
+      AND status_detail IS NOT NULL)
+    OR
+    (status IN ('queued', 'running', 'done', 'partial', 'cancelled') AND
+      status_code IS NULL AND status_detail IS NULL AND next_attempt_at IS NULL)
+  );
+
+-- The due-retry index covers failed reads now, not just deferred ones: both are
+-- rows a sweep must find again at a time the row itself names.
+DROP INDEX idx_site_read_deferred_due;
+CREATE INDEX idx_site_read_retry_due
+  ON site_read (workspace_id, next_attempt_at, id)
+  WHERE status IN ('deferred', 'failed') AND next_attempt_at IS NOT NULL;


### PR DESCRIPTION
## What was wrong

Every crawl failure was stored as a bare `status='failed'` with `status_code`, `status_detail` and `next_attempt_at` all NULL. The columns existed, but migration `0104` reserved them for budget deferral. A real import produced **58 failed reads, all indistinguishable** — a certificate that would not verify, a domain that does not resolve, a robots refusal and an edge answering 403 looked exactly the same. The companies behind them kept a record holding nothing but their domain, and nothing said why.

Two are worth naming, because both are real sites that work:

- **ausgezeichnet.org** — the apex serves a certificate that fails verification; `www` answers 200.
- **surfe.com** — sits behind bot protection that refused the crawler intermittently. I reproduced a 403 and then a 200 minutes later with the same agent.

Neither was ever retried, because a failed read set no `next_attempt_at` and the claim only ever took deferred ones.

## What this does

A failure now carries a **closed `status_code`** an operator can group by, and one sentence they can act on. Causes that commonly clear on their own — bot protection, a 5xx, a timeout — schedule another attempt six hours out; a 404, a DNS miss, an unverifiable certificate and a robots refusal do not, because re-crawling those is noise.

The classifier reads **typed errors**, so `webread` now carries the HTTP status on a `StatusError` rather than formatting it into a message a caller would parse back out.

`BeginSiteRead` claims a failed read whose retry has fallen due. Without that the retry time is state nothing reads — which is exactly what the first commit of this branch got wrong, and the second fixed.

## Crawl-delay

It is honored now, and the comment claiming it needn't be is gone. It said pacing was *"the crawler's own, stricter policy"*. The pacer allows 8 requests in flight 25ms apart, so against a site asking for 10 seconds we were roughly **400× more aggressive than it asked** — and that is a good way to trip exactly the bot protection above. The delay only ever slows a crawl, is capped so one hostile value cannot stall a read past its wall clock, and the longest delay across matching groups wins.

Writing those tests found a bug: a group whose only directive is `Crawl-delay` carries no rules, and group selection keyed on rules existing — so its delay was silently discarded.

## Migration 0221

Replaces the deferral-shape CHECK with one covering every outcome, and labels the 58 existing rows for what they are: recorded before failures carried a diagnosis. It does **not** invent causes for them — a guessed code is indistinguishable from a measured one and would poison the first honest grouping anybody does.

## Gates

`make check-backend` green, `craft-static` 0 findings across all three roots, both greps clean, and the **migrations, people and compose integration lanes** all green — including the migration replay as a non-superuser owner. The retry claim was mutation-checked: removing the failed-and-due arm fails `TestATransientlyFailedReadIsClaimedAgainWhenItsRetryFallsDue`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Failed website reads now record a diagnosis and, for transient causes, schedule a retry; the worker also reclaims failed-and-due reads. Previously all failures were indistinguishable and never retried; now operators can group by a closed code, and the crawler honors robots.txt Crawl-delay to reduce bot blocks.

- Adds a typed `webread.StatusError` and a classifier that maps failures to closed codes; retryable (`bot_blocked`, `http_server_error`, `timeout`) schedule a retry in 6h; terminal (`http_client_error`, `dns`, `tls`, `robots_disallowed`, `unreadable`, `internal`, `stale_reclaim`) do not. Unrecognized errors are classified as `internal`.
- `people.FinishSiteRead` validates outcome shape: failures must provide `status_code` and `status_detail` (and may set `next_attempt_at`); non-failures must not. The vocabulary is enforced in Go and by the DB CHECK.
- `people.BeginSiteRead` now claims failed reads whose `next_attempt_at` is due.
- Honors Crawl-delay: `webread` parses it, `Fetcher.CrawlDelay` exposes it after the first fetch, `Pacer.SlowTo` raises the pacing floor (never speeds up). Longest matching delay wins and is capped; fixes the bug where a group with only `Crawl-delay` was ignored. 5xx on robots.txt returns a typed status error so retry logic applies.
- Updates the due-retry index to include failed reads; adds tests for diagnosis, retry-claiming, Crawl-delay parsing, and pacing behavior.

Migration 0221
- Replaces the deferral-only CHECK with an outcome-wide CHECK that requires `status_code IS NOT NULL` for failures and forbids diagnosis on other statuses.
- Labels existing undiagnosed `failed` rows as `status_code='unreadable'` with an explanatory `status_detail`. No retry times are invented.
- Fixes rollback order so `down` drops the new CHECK before nulling diagnosis fields; restores the old deferral shape afterward.
- Required action: run the migration; no manual backfill is needed. Revert drops stored diagnoses to fit the old shape.

<sup>Written for commit 9ec1864334e6311b1ed19599a84dc2b367d0d0a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1100?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

