### PR TITLE
fix(overlay): close the four mechanical follow-ups from the field-registry work

### DIFF
--- a/backend/internal/compose/overlaywire.go
+++ b/backend/internal/compose/overlaywire.go
@@ -11,12 +11,12 @@ package compose
 // `source: overlay`, the FULL canonical payload rides `raw` (nothing the
 // mapper landed is dropped just because a typed slot doesn't exist for
 // it), and a timestamp is the incumbent's own wherever the mapping mirrors
-// one: a person's and an organization's created_at is the incumbent's create
-// instant and its updated_at the incumbent's last-modified instant, each
-// falling back to the mirror's own last-synced instant — the only time the
-// mirror can claim for itself — where the incumbent stamped none. The other
-// three entities read the mirror's own last-synced instant into both slots,
-// even where the mapping landed the incumbent's (#1016).
+// one: every entity's updated_at is the incumbent's last-modified instant, and
+// a person's and an organization's created_at is the incumbent's create
+// instant — each falling back to the mirror's own last-synced instant, the only
+// time the mirror can claim for itself, where the incumbent stamped none. A
+// deal's, a lead's and an activity's created_at is that fallback throughout,
+// since no mapping for those classes reads a create property.
 
 import (
 	"context"
@@ -223,7 +223,7 @@ func overlayWireDeal(ctx context.Context, rec datasource.Record) (crmcontracts.D
 		Currency:   fieldStringPtr(fields, "currency"),
 		Status:     overlayDealStatus(fieldString(fields, "stage_id")),
 		CreatedAt:  syncedAt,
-		UpdatedAt:  syncedAt,
+		UpdatedAt:  overlayTimeOr(fields, overlayCanonicalLastModified, syncedAt),
 		Raw:        &fields,
 	}
 	if minor, ok := fieldInt64(fields, "amount_minor"); ok {
@@ -268,7 +268,7 @@ func overlayWireLead(ctx context.Context, rec datasource.Record) (crmcontracts.L
 		Score:       0,
 		Status:      crmcontracts.LeadStatusNew,
 		CreatedAt:   syncedAt,
-		UpdatedAt:   syncedAt,
+		UpdatedAt:   overlayTimeOr(fields, overlayCanonicalLastModified, syncedAt),
 		Raw:         &fields,
 	}
 	if email := strings.TrimSpace(fieldString(fields, "email")); email != "" {
@@ -307,7 +307,7 @@ func overlayWireActivity(ctx context.Context, rec datasource.Record) (crmcontrac
 		Body:       fieldStringPtr(fields, "body"),
 		OccurredAt: overlayTimeOr(fields, "occurred_at", syncedAt),
 		CreatedAt:  syncedAt,
-		UpdatedAt:  syncedAt,
+		UpdatedAt:  overlayTimeOr(fields, overlayCanonicalLastModified, syncedAt),
 		Raw:        &fields,
 	}
 	if dir := crmcontracts.ActivityDirection(strings.ToLower(fieldString(fields, "direction"))); dir == crmcontracts.ActivityDirectionInbound || dir == crmcontracts.ActivityDirectionOutbound {

--- a/backend/internal/compose/overlaywire.go
+++ b/backend/internal/compose/overlaywire.go
@@ -142,6 +142,7 @@ func overlayWireOrganization(ctx context.Context, rec datasource.Record) (crmcon
 		displayName = overlayUnnamed
 	}
 	orgID := openapi_types.UUID(rec.Ref.ID)
+	domains := overlayOrganizationDomains(orgID, fields)
 	org := crmcontracts.Organization{
 		Id:          orgID,
 		Source:      overlaySource,
@@ -149,7 +150,8 @@ func overlayWireOrganization(ctx context.Context, rec datasource.Record) (crmcon
 		DisplayName: displayName,
 		Industry:    fieldStringPtr(fields, "industry"),
 		Address:     overlayAddress(fields),
-		Domains:     overlayOrganizationDomains(orgID, fields),
+		Domains:     domains,
+		WebsiteUrl:  overlayWebsiteURL(domains),
 		CreatedAt:   overlayTimeOr(fields, "created_at", syncedAt),
 		UpdatedAt:   overlayTimeOr(fields, overlayCanonicalLastModified, syncedAt),
 		Raw:         &fields,

--- a/backend/internal/compose/overlaywire.go
+++ b/backend/internal/compose/overlaywire.go
@@ -16,7 +16,7 @@ package compose
 // instant — each falling back to the mirror's own last-synced instant, the only
 // time the mirror can claim for itself, where the incumbent stamped none. A
 // deal's, a lead's and an activity's created_at is that fallback throughout,
-// since no mapping for those classes reads a create property.
+// since no mapping for those classes maps an incumbent create instant.
 
 import (
 	"context"

--- a/backend/internal/compose/overlaywirecoverage_test.go
+++ b/backend/internal/compose/overlaywirecoverage_test.go
@@ -124,21 +124,51 @@ type wireGate struct {
 	unmirrored map[string]any
 }
 
-// check holds every binding the registry calls mapped to reaching a caller. An
-// entity that declares none is a failure rather than a pass: this gate would
-// otherwise report green while checking nothing.
+// check holds every binding that claims the mirror reaches a caller — mapped
+// and derived alike — to actually reaching one. An entity that declares no
+// mapped binding is a failure rather than a pass: this gate would otherwise
+// report green while checking nothing. The guard counts only mapped bindings,
+// because a derived one cannot stand in for a mapped one anyway — the registry
+// obliges every derived slot to name mapped sources on this same entity — and
+// counting it would let the vacuity check be answered by a slot with no
+// mirrored input of its own.
 func (g wireGate) check(t *testing.T) {
 	t.Helper()
 	mapped := 0
 	for _, b := range g.entity.Bindings {
-		if b.Disposition != overlay.DispositionMapped {
-			continue
+		switch b.Disposition {
+		case overlay.DispositionMapped:
+			mapped++
+			g.checkBinding(t, b)
+		case overlay.DispositionDerived:
+			g.checkDerived(t, b)
 		}
-		mapped++
-		g.checkBinding(t, b)
 	}
 	if mapped == 0 {
 		t.Fatalf("%s declares no mapped bindings; this gate would pass while checking nothing", g.entity.Entity)
+	}
+}
+
+// checkDerived holds a derived binding to the same end state a mapped one is
+// held to — the slot reaches the caller carrying a value the mirror caused —
+// while asking nothing about a canonical key or an incumbent property it
+// deliberately claims none of. Its sources are checked as mapped bindings in
+// their own right, so what remains here is the step nothing else observes: that
+// the wire performs the derivation at all.
+func (g wireGate) checkDerived(t *testing.T, b overlay.FieldBinding) {
+	t.Helper()
+	value, present := g.mirrored[b.WireSlot]
+	if !present || value == nil {
+		t.Errorf("%s.%s is declared derived from %v, but the assembled body leaves it empty. Either %s never "+
+			"computes it, or the binding claims a derivation nothing performs.",
+			g.entity.Entity, b.WireSlot, b.DerivedFrom, g.assembler)
+		return
+	}
+	if reflect.DeepEqual(value, g.unmirrored[b.WireSlot]) {
+		t.Errorf("%s.%s is declared derived from %v, but the assembled body carries %v — the very value a record "+
+			"with an EMPTY payload produces, so nothing the mirror holds reached the caller. Have %s derive it "+
+			"from %v, or give %s inputs whose result differs from the fallback.",
+			g.entity.Entity, b.WireSlot, b.DerivedFrom, value, g.assembler, b.DerivedFrom, g.fixture)
 	}
 }
 

--- a/backend/internal/compose/overlaywirederived_test.go
+++ b/backend/internal/compose/overlaywirederived_test.go
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The wire's DERIVED slots: the ones the mirror carries no key for, computed
+// from the mirrored collections the same body already publishes. A derived
+// slot has two ways to be wrong that a mapped one does not — it can compute
+// from the wrong row, and it can invent a value where the native path
+// publishes none — so each is held here to the answer the native read path
+// gives for the same facts.
+//
+// The payloads are canonical rather than seeded through the HubSpot mapping,
+// which lands exactly one domain row: what is under test is which of SEVERAL
+// rows the derivation picks, a shape no incumbent fixture can pose. That the
+// derivation survives the real ingest pipeline end to end is the wire
+// reachability gate's assertion, on the same binding.
+
+import (
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
+)
+
+// website_url is DERIVED from the primary domain row and never stored
+// (ADR-0085), so a mirrored company owes the value a native one publishes —
+// including which row counts: the one flagged primary, wherever it sits in the
+// collection.
+func TestOverlayWireOrganizationDerivesWebsiteURLFromThePrimaryDomain(t *testing.T) {
+	rec := wireRecord(t, datasource.EntityOrganization, map[string]any{
+		"display_name": "Acme",
+		"organization_domain": []map[string]any{
+			{"domain": "acme.de", "position": 0},
+			{"domain": "acme.io", "is_primary": true, "position": 1},
+		},
+	})
+	org, err := overlayWireOrganization(wireCtx(), rec)
+	if err != nil {
+		t.Fatalf("overlayWireOrganization: %v", err)
+	}
+	if org.WebsiteUrl == nil {
+		t.Fatal("WebsiteUrl = nil, want the primary domain rendered as a URL")
+	}
+	if *org.WebsiteUrl != "https://acme.io" {
+		t.Errorf("WebsiteUrl = %q, want https://acme.io — the primary row, not the leading one", *org.WebsiteUrl)
+	}
+}
+
+// Which domain is the company's is the mapping's assertion; a reader that fell
+// back to the first row would publish a host no mapping ever nominated, and
+// the native path publishes nothing at all on those same rows.
+func TestOverlayWireOrganizationOmitsWebsiteURLWithoutAPrimaryDomain(t *testing.T) {
+	for name, fields := range map[string]map[string]any{
+		"no row claims the flag": {
+			"display_name":        "Acme",
+			"organization_domain": []map[string]any{{"domain": "acme.de", "position": 0}},
+		},
+		"no domain rows at all": {"display_name": "Acme"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			org, err := overlayWireOrganization(wireCtx(), wireRecord(t, datasource.EntityOrganization, fields))
+			if err != nil {
+				t.Fatalf("overlayWireOrganization: %v", err)
+			}
+			if org.WebsiteUrl != nil {
+				t.Errorf("WebsiteUrl = %q, want absent — no mirrored row claims to be primary, so there is no "+
+					"domain to render and the native path publishes none either", *org.WebsiteUrl)
+			}
+		})
+	}
+}

--- a/backend/internal/compose/overlaywirefields.go
+++ b/backend/internal/compose/overlaywirefields.go
@@ -212,6 +212,29 @@ func overlayOrganizationDomains(parent openapi_types.UUID, fields map[string]any
 	return &out
 }
 
+// overlayWebsiteURL renders a mirrored company's website from its primary
+// domain row. website_url is DERIVED and never stored (ADR-0085): the native
+// read path renders "https://" + the primary domain, and a mirrored company
+// owes the caller the same answer from the same fact. It reads the collection
+// this wire already publishes rather than the payload a second time, so the two
+// can never name different domains. A collection where no row claims the flag
+// yields nothing — which domain is the company's is the mapping's assertion,
+// never this reader's to pick by position, and the native path leaves the slot
+// absent on exactly the same rows.
+func overlayWebsiteURL(domains *[]crmcontracts.OrganizationDomain) *string {
+	if domains == nil {
+		return nil
+	}
+	for _, row := range *domains {
+		if !row.IsPrimary {
+			continue
+		}
+		website := "https://" + row.Domain
+		return &website
+	}
+	return nil
+}
+
 // The attribute vocabulary a mirrored child row declares, in one place next to
 // the readers below: everything a row carries beyond its own mapped column.
 // The mapping module writes these keys (overlay's ChildRow.Attrs and its

--- a/backend/internal/compose/overlaywirestamps_test.go
+++ b/backend/internal/compose/overlaywirestamps_test.go
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// "Recently updated" is a question a user asks of the records, not of the
+// sweep. A mirrored record's updated_at must therefore be the incumbent's own
+// last-modified instant, which the mapping lands under the canonical
+// last_synced_at key from its Baseline property — NOT Record.Freshness.
+// LastSyncedAt, the mirror row's ingest time, which every record in a workspace
+// shares after one sweep. The two are one word apart and mean opposite things,
+// so each entity is held to the canonical one here.
+//
+// The records are seeded through the REAL mapping for their incumbent class, so
+// what is under test is the payload production writes: a hand-built canonical
+// fixture would prove only that the wire reads its own author.
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
+)
+
+// wireIncumbentModifiedAt is the incumbent's own last-modified instant in the
+// fixtures below, deliberately far from wireSyncedAt so a wire reading the
+// mirror's ingest time cannot pass by coincidence.
+var wireIncumbentModifiedAt = time.Date(2026, 5, 13, 6, 44, 38, 727000000, time.UTC)
+
+// wireIncumbentModified is that instant in HubSpot's own wire spelling.
+const wireIncumbentModified = "2026-05-13T06:44:38.727Z"
+
+func TestOverlayWireDealReportsTheIncumbentsOwnStamps(t *testing.T) {
+	canonical := canonicalFromMapping(t, "deals", "the deal fixture", map[string]any{
+		"hs_object_id":        "77123456789",
+		"dealname":            "Overlay renewal",
+		"hs_lastmodifieddate": wireIncumbentModified,
+	})
+	deal, err := overlayWireDeal(wireCtx(), wireRecord(t, datasource.EntityDeal, canonical))
+	if err != nil {
+		t.Fatalf("overlayWireDeal: %v", err)
+	}
+	checkMirroredStamps(t, "deal", canonical, deal.CreatedAt, deal.UpdatedAt)
+}
+
+func TestOverlayWireLeadReportsTheIncumbentsOwnStamps(t *testing.T) {
+	canonical := canonicalFromMapping(t, "leads", "the lead fixture", map[string]any{
+		"hs_object_id":        "88123456789",
+		"hs_lead_name":        "Ada Overlay",
+		"hs_lastmodifieddate": wireIncumbentModified,
+	})
+	lead, err := overlayWireLead(wireCtx(), wireRecord(t, datasource.EntityLead, canonical))
+	if err != nil {
+		t.Fatalf("overlayWireLead: %v", err)
+	}
+	checkMirroredStamps(t, "lead", canonical, lead.CreatedAt, lead.UpdatedAt)
+}
+
+func TestOverlayWireActivityReportsTheIncumbentsOwnStamps(t *testing.T) {
+	canonical := canonicalFromMapping(t, "calls", "the call fixture", map[string]any{
+		"hs_object_id":        "99123456789",
+		"hs_call_title":       "Intro call",
+		"hs_lastmodifieddate": wireIncumbentModified,
+	})
+	act, err := overlayWireActivity(wireCtx(), wireRecord(t, datasource.EntityActivity, canonical))
+	if err != nil {
+		t.Fatalf("overlayWireActivity: %v", err)
+	}
+	checkMirroredStamps(t, "activity", canonical, act.CreatedAt, act.UpdatedAt)
+}
+
+// checkMirroredStamps holds one assembled record's two timestamps to what the
+// canonical payload actually carries. created_at is asserted against the
+// mapping rather than against a remembered fact: none of these three classes
+// maps an incumbent create instant today, so the sync instant is the honest
+// answer — and the day one of them does, this fails and says to read it instead
+// of quietly reporting the sweep's time for a value the mirror now holds.
+func checkMirroredStamps(t *testing.T, entity string, canonical map[string]any, created, updated time.Time) {
+	t.Helper()
+	if !updated.Equal(wireIncumbentModifiedAt) {
+		t.Errorf("%s updated_at = %s, want the incumbent's own last-modified %s. The mirror row's ingest instant "+
+			"reports every record in the workspace as modified when the sweep ran, so \"recently updated\" answers "+
+			"the same for all of them; read the canonical %q key the mapping's Baseline lands.",
+			entity, updated, wireIncumbentModifiedAt, overlayCanonicalLastModified)
+	}
+	if _, landed := canonical["created_at"]; landed {
+		t.Fatalf("the %s mapping now lands a created_at canonical key, so created_at must read it rather than the "+
+			"mirror's sync instant", entity)
+	}
+	if !created.Equal(wireSyncedAt) {
+		t.Errorf("%s created_at = %s, want the mirror's own sync instant %s: this class's mapping lands no "+
+			"incumbent create stamp, and the sync instant is the only time the mirror can honestly claim",
+			entity, created, wireSyncedAt)
+	}
+}

--- a/backend/internal/modules/overlay/fieldbinding.go
+++ b/backend/internal/modules/overlay/fieldbinding.go
@@ -27,16 +27,32 @@ const (
 	// no mirror could ever supply it (a version counter, a relationship
 	// strength computed from captured interactions).
 	DispositionNativeOnly Disposition = "native_only"
+	// DispositionDerived means the mirror carries this slot's INPUTS and the
+	// wire computes the slot from them, so it reads no canonical key of its
+	// own. It exists because the alternative spellings are both false: mapped
+	// would claim a key a second slot already reads, and the registry rejects
+	// two slots claiming one key precisely so a real double-write cannot hide;
+	// native_only would say no mirror could help, when the mirror is exactly
+	// where the value comes from. The line between the two is whose data the
+	// computation runs over — native_only computes from THIS installation's
+	// own rows, derived computes from mirrored ones. DerivedFrom names the
+	// wire slots it is computed from, and each must be mapped on the same
+	// entity: a slot derived from something the mirror does not carry is
+	// native_only wearing a friendlier name.
+	DispositionDerived Disposition = "derived"
 )
 
 // FieldBinding is one contract field's overlay disposition for one entity.
 // CanonicalKey is the mirror's own jsonb key, which keeps the core column's
 // spelling rather than the contract's where the two differ; it is empty
-// unless the field is mapped.
+// unless the field is mapped. DerivedFrom names the wire slots a derived
+// field is computed from — slots, not canonical keys, so the dependency is
+// stated in the vocabulary the wire assembly itself reads back.
 type FieldBinding struct {
 	WireSlot     string
 	CanonicalKey string
 	Incumbent    []string
+	DerivedFrom  []string
 	Transform    string
 	Disposition  Disposition
 	Reason       string

--- a/backend/internal/modules/overlay/fieldbinding.go
+++ b/backend/internal/modules/overlay/fieldbinding.go
@@ -173,13 +173,12 @@ var personBindings = EntityBinding{
 // organizationBindings disposition every contract Organization field. Armed,
 // on the same terms personBindings is.
 //
-// Seven fields the incumbent could fill are deferred rather than mapped, and
+// Six fields the incumbent could fill are deferred rather than mapped, and
 // each names the reason it is not a one-line addition: one needs a projection
 // that does not exist yet (an association sweep for the parent), four need a
 // decision the mapping cannot make on its own (a length rule, a URL
 // normalization, two remaps onto vocabularies this product defines on its own
-// axes), and two need a read the adapter does not perform (the archive flag,
-// the primary-domain derivation).
+// axes), and one needs a read the adapter does not perform (the archive flag).
 //
 //nolint:goconst // the rows are read as data, and each column is its own vocabulary: a wire slot, the mirror's jsonb key and an incumbent property spell "address" and "industry" alike here by coincidence, so hiding any of them behind one shared name would assert a correspondence the table exists to keep separate
 var organizationBindings = EntityBinding{
@@ -194,9 +193,10 @@ var organizationBindings = EntityBinding{
 		{WireSlot: "created_at", CanonicalKey: "created_at", Incumbent: []string{"createdate"}, Disposition: DispositionMapped},
 		{WireSlot: "updated_at", CanonicalKey: "last_synced_at", Incumbent: []string{"hs_lastmodifieddate"}, Disposition: DispositionMapped},
 
+		{WireSlot: "website_url", Disposition: DispositionDerived, DerivedFrom: []string{"domains"}},
+
 		{WireSlot: "parent_org_id", Disposition: DispositionDeferred, IssueURL: "https://github.com/gradionhq/margince-poc-v1/issues/1023"},
 		{WireSlot: "archived_at", Disposition: DispositionDeferred, IssueURL: "https://github.com/gradionhq/margince-poc-v1/issues/1024"},
-		{WireSlot: "website_url", Disposition: DispositionDeferred, IssueURL: "https://github.com/gradionhq/margince-poc-v1/issues/1025"},
 		{WireSlot: "description", Disposition: DispositionDeferred, IssueURL: "https://github.com/gradionhq/margince-poc-v1/issues/1026"},
 		{WireSlot: "linkedin_url", Disposition: DispositionDeferred, IssueURL: "https://github.com/gradionhq/margince-poc-v1/issues/1027"},
 		{WireSlot: "lifecycle", Disposition: DispositionDeferred, IssueURL: "https://github.com/gradionhq/margince-poc-v1/issues/1028"},

--- a/backend/internal/modules/overlay/fieldbinding.go
+++ b/backend/internal/modules/overlay/fieldbinding.go
@@ -38,7 +38,12 @@ const (
 	// own rows, derived computes from mirrored ones. DerivedFrom names the
 	// wire slots it is computed from, and each must be mapped on the same
 	// entity: a slot derived from something the mirror does not carry is
-	// native_only wearing a friendlier name.
+	// native_only wearing a friendlier name. What the gates reach stops
+	// there, and an author declaring one should know it: they prove the named
+	// sources are mapped and that the slot's value follows from the mirrored
+	// payload, but nothing proves the computation reads THOSE sources — a slot
+	// computed from other mirrored data passes both. The list is a claim about
+	// the code that has to be kept true by reading it.
 	DispositionDerived Disposition = "derived"
 )
 

--- a/backend/internal/modules/overlay/fieldbinding_test.go
+++ b/backend/internal/modules/overlay/fieldbinding_test.go
@@ -39,6 +39,38 @@ func TestFieldBindingsAreInternallyConsistent(t *testing.T) {
 			}
 			checkDisposition(t, entity.Entity, b)
 		}
+		checkDerivedFrom(t, entity)
+	}
+}
+
+// checkDerivedFrom holds every derived binding to the invariant that gives the
+// disposition its meaning: a slot the wire computes must be computed from
+// slots the mirror really carries. Unenforced, "derived" would be a way to
+// claim mirrored data for a field no mirrored value ever reaches — native_only
+// with a friendlier name. It is checked per entity rather than per binding
+// because the sources are named in the same entity's vocabulary; a slot mapped
+// on a sibling entity says nothing about this one's mirror.
+func checkDerivedFrom(t *testing.T, entity overlay.EntityBinding) {
+	t.Helper()
+	mapped := map[string]bool{}
+	for _, b := range entity.Bindings {
+		if b.Disposition == overlay.DispositionMapped {
+			mapped[b.WireSlot] = true
+		}
+	}
+	for _, b := range entity.Bindings {
+		if b.Disposition != overlay.DispositionDerived {
+			continue
+		}
+		for _, source := range b.DerivedFrom {
+			if mapped[source] {
+				continue
+			}
+			t.Errorf("%s.%s is derived from %s.%s, which is not a mapped binding on this entity — so the mirror "+
+				"carries no input the derivation could run over. Map %q, or point %q's DerivedFrom at the slots "+
+				"the mirror really supplies.",
+				entity.Entity, b.WireSlot, entity.Entity, source, source, b.WireSlot)
+		}
 	}
 }
 
@@ -47,6 +79,10 @@ func TestFieldBindingsAreInternallyConsistent(t *testing.T) {
 // it carries nothing — an unexplained absence is how a gap becomes permanent.
 func checkDisposition(t *testing.T, entity string, b overlay.FieldBinding) {
 	t.Helper()
+	if b.Disposition != overlay.DispositionDerived && len(b.DerivedFrom) > 0 {
+		t.Errorf("%s.%s is %s but names DerivedFrom %v; only a derived slot is computed from other slots, so the "+
+			"list would be read by nothing", entity, b.WireSlot, b.Disposition, b.DerivedFrom)
+	}
 	switch b.Disposition {
 	case overlay.DispositionMapped:
 		if b.CanonicalKey == "" || len(b.Incumbent) == 0 {
@@ -58,6 +94,16 @@ func checkDisposition(t *testing.T, entity string, b overlay.FieldBinding) {
 		}
 		if b.CanonicalKey != "" || len(b.Incumbent) > 0 || b.Transform != "" {
 			t.Errorf("%s.%s is deferred but names a canonical key, an incumbent property or a transform; a slot nothing fills must claim no source, or the registry reads as a working mapping", entity, b.WireSlot)
+		}
+	case overlay.DispositionDerived:
+		if len(b.DerivedFrom) == 0 {
+			t.Errorf("%s.%s is derived but names no source slot; set DerivedFrom to the wire slots it is computed "+
+				"from, or say plainly which of the other four dispositions it really is", entity, b.WireSlot)
+		}
+		if b.CanonicalKey != "" || len(b.Incumbent) > 0 {
+			t.Errorf("%s.%s is derived but claims canonical key %q and incumbent properties %v; a derived slot "+
+				"reads no source of its own — the ones it depends on belong to the DerivedFrom slots %v",
+				entity, b.WireSlot, b.CanonicalKey, b.Incumbent, b.DerivedFrom)
 		}
 	case overlay.DispositionUnmappable, overlay.DispositionNativeOnly:
 		if strings.TrimSpace(b.Reason) == "" {

--- a/backend/internal/modules/overlay/hubspot/fieldbindingsources_internal_test.go
+++ b/backend/internal/modules/overlay/hubspot/fieldbindingsources_internal_test.go
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package hubspot
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/modules/overlay"
+)
+
+// A mapped binding makes two claims: that a canonical key holds the value, and
+// that named incumbent properties are where it comes from. The wire gate in
+// compose proves the first end to end, but it can only prove the second against
+// a hand-written fixture — so a binding naming a property the mapping never
+// reads goes green the moment somebody adds that property to the fixture.
+// propertyNames is the production answer to what a class consumes: it builds
+// the `properties=` list the adapter asks HubSpot for, so a property missing
+// from it is a property that never arrives, whatever any fixture supplies.
+func TestEveryMappedBindingNamesAPropertyItsMappingReads(t *testing.T) {
+	checked := 0
+	for _, entity := range overlay.FieldBindings() {
+		// Only an armed entity has been decided field by field; deal, lead and
+		// activity carry mappings chosen before this registry existed, and hold
+		// no bindings to check.
+		if !entity.Armed {
+			continue
+		}
+		classes, consumed := propertiesReadFor(t, entity.Entity)
+		for _, b := range entity.Bindings {
+			if b.Disposition != overlay.DispositionMapped {
+				continue
+			}
+			checked++
+			checkIncumbentProperties(t, entity.Entity, b, classes, consumed)
+		}
+	}
+	if checked == 0 {
+		t.Fatal("no armed entity declares a mapped binding; this gate would pass while checking nothing")
+	}
+}
+
+// checkIncumbentProperties holds one mapped binding's source properties to what
+// its entity's mappings actually request.
+func checkIncumbentProperties(t *testing.T, entity string, b overlay.FieldBinding, classes []string, consumed map[string]bool) {
+	t.Helper()
+	source := strings.Join(classes, "/")
+	for _, property := range b.Incumbent {
+		if consumed[property] {
+			continue
+		}
+		t.Errorf("overlay %s.%s is declared mapped from %q, but the %s mapping never asks HubSpot for that "+
+			"property, so no value under that name ever reaches the mirror. Either give the %s mapping in "+
+			"mapping_hs.go a field reading %q, or correct Incumbent on that binding in "+
+			"internal/modules/overlay/fieldbinding.go to the property the mapping really reads.",
+			entity, b.WireSlot, property, source, source, property)
+	}
+}
+
+// propertiesReadFor answers the incumbent classes backing one canonical entity
+// and the union of the properties their mappings request. The union is what a
+// binding is held to because a canonical entity may be backed by several
+// classes, each of which spells its own properties.
+func propertiesReadFor(t *testing.T, entity string) ([]string, map[string]bool) {
+	t.Helper()
+	classes, ok := IncumbentClassesFor(entity)
+	if !ok {
+		t.Fatalf("IncumbentClassesFor(%q) found no incumbent class, but the overlay registry arms that entity; "+
+			"one of the two names an entity the other does not know", entity)
+	}
+	consumed := map[string]bool{}
+	for _, class := range classes {
+		m, found := Mapping(class)
+		if !found {
+			t.Fatalf("Mapping(%q): want the mapping IncumbentClassesFor(%q) just named", class, entity)
+		}
+		for _, property := range propertyNames(m) {
+			consumed[property] = true
+		}
+	}
+	return classes, consumed
+}

--- a/backend/internal/modules/overlay/mapping.go
+++ b/backend/internal/modules/overlay/mapping.go
@@ -133,10 +133,13 @@ const childPositionKey = "position"
 // matched no declared mapping (UnmappedPolicy governs what the caller
 // does with them — "flag" surfaces them, never silently drops per
 // UC-E18-01 F3), and an error if the mapping itself is malformed (an
-// unknown Transform name, an unrecognized TargetKind, or child rows of one
-// parent that collide).
+// unknown Transform name, an unrecognized TargetKind, child rows of one
+// parent that collide, or two fields writing one target).
 func Apply(m ObjectMapping, raw map[string]any) (map[string]any, []string, error) {
 	if err := checkChildRowDeclarations(m); err != nil {
+		return nil, nil, err
+	}
+	if err := checkTargetCollisions(m); err != nil {
 		return nil, nil, err
 	}
 
@@ -225,6 +228,42 @@ func checkChildRowDeclarations(m ObjectMapping) error {
 			return fmt.Errorf("overlay: two child rows of %q both claim position %d; the collection's order would be arbitrary — give each row of one parent its own position", parent, f.Child.Position)
 		}
 		seen[f.Child.Position] = true
+	}
+	return nil
+}
+
+// checkTargetCollisions rejects a mapping whose fields would write one target
+// twice. applyField writes each field into the target map in declaration order,
+// so a second writer is no error while projecting — it simply wins, taking
+// either the first field's column value or, where a column lands on a child
+// collection's parent key, every row of that collection with it. The check runs
+// on the declaration for the same reason the child-row one does: a record
+// carrying neither property projects cleanly, so a collision found while
+// projecting is a defect that reaches production and waits for the data that
+// populates both.
+//
+// Rows of ONE child collection are the shape the child kind exists for: they
+// share a parent key by design, and checkChildRowDeclarations already keeps
+// each row's position within it unique.
+func checkTargetCollisions(m ObjectMapping) error {
+	writers := make(map[string]FieldMapping, len(m.Fields))
+	for _, f := range m.Fields {
+		target := f.To
+		if f.Kind == TargetChild {
+			target, _, _ = strings.Cut(f.To, ".")
+		}
+		first, claimed := writers[target]
+		if !claimed {
+			writers[target] = f
+			continue
+		}
+		if first.Kind == TargetChild && f.Kind == TargetChild {
+			continue
+		}
+		return fmt.Errorf("overlay: %s target %q (from %v) and %s target %q (from %v) both write %q, and the "+
+			"second silently replaces the first; give one of them a target of its own, or, where the two are rows "+
+			"of one collection, declare both as child targets with their own positions",
+			first.Kind, first.To, first.From, f.Kind, f.To, f.From, target)
 	}
 	return nil
 }

--- a/backend/internal/modules/overlay/mapping.go
+++ b/backend/internal/modules/overlay/mapping.go
@@ -113,8 +113,8 @@ type ObjectMapping struct {
 }
 
 // keyExternalID/keyLastSyncedAt are the two structural mirror targets Apply
-// writes directly (from ExternalKey/Baseline) — reserved, so a mapping's
-// Const may never claim them.
+// writes directly (from ExternalKey/Baseline) — reserved, so neither a
+// mapping's Const nor a field's target may claim them.
 const (
 	keyExternalID   = "external_id"
 	keyLastSyncedAt = "last_synced_at"
@@ -134,7 +134,7 @@ const childPositionKey = "position"
 // does with them — "flag" surfaces them, never silently drops per
 // UC-E18-01 F3), and an error if the mapping itself is malformed (an
 // unknown Transform name, an unrecognized TargetKind, child rows of one
-// parent that collide, or two fields writing one target).
+// parent that collide, or two writers landing on one target).
 func Apply(m ObjectMapping, raw map[string]any) (map[string]any, []string, error) {
 	if err := checkChildRowDeclarations(m); err != nil {
 		return nil, nil, err
@@ -245,12 +245,23 @@ func checkChildRowDeclarations(m ObjectMapping) error {
 // Rows of ONE child collection are the shape the child kind exists for: they
 // share a parent key by design, and checkChildRowDeclarations already keeps
 // each row's position within it unique.
+//
+// Apply's own structural writes are in the matrix too: they land before the
+// field loop runs, so a field claiming one of them is the same silent
+// replacement with the mirror's identity or its watermark as the value lost.
 func checkTargetCollisions(m ObjectMapping) error {
+	structural := structuralWriters(m)
 	writers := make(map[string]FieldMapping, len(m.Fields))
 	for _, f := range m.Fields {
 		target := f.To
 		if f.Kind == TargetChild {
 			target, _, _ = strings.Cut(f.To, ".")
+		}
+		if declaration, reserved := structural[target]; reserved {
+			return fmt.Errorf("overlay: %s target %q (from %v) writes %q, which the mapping's %s already writes, "+
+				"so the field silently replaces it; %q and %q are the mirror's own identity and watermark and no "+
+				"field may land on them — give this one a target of its own",
+				f.Kind, f.To, f.From, target, declaration, keyExternalID, keyLastSyncedAt)
 		}
 		first, claimed := writers[target]
 		if !claimed {
@@ -266,6 +277,21 @@ func checkTargetCollisions(m ObjectMapping) error {
 			first.Kind, first.To, first.From, f.Kind, f.To, f.From, target)
 	}
 	return nil
+}
+
+// structuralWriters answers the canonical targets the mapping's own structural
+// declarations write, each named as the reader would have to name it to fix a
+// collision. A declaration left empty writes nothing, so it reserves nothing:
+// a mapping with no Baseline is free to land last_synced_at from a field.
+func structuralWriters(m ObjectMapping) map[string]string {
+	writers := map[string]string{}
+	if m.ExternalKey != "" {
+		writers[keyExternalID] = fmt.Sprintf("ExternalKey %q", m.ExternalKey)
+	}
+	if m.Baseline != "" {
+		writers[keyLastSyncedAt] = fmt.Sprintf("Baseline %q", m.Baseline)
+	}
+	return writers
 }
 
 // checkChildRow validates one TargetChild field's row declaration and answers

--- a/backend/internal/modules/overlay/mapping_test.go
+++ b/backend/internal/modules/overlay/mapping_test.go
@@ -605,6 +605,64 @@ func TestAColumnWritingAChildCollectionsParentIsADeclarationError(t *testing.T) 
 	}
 }
 
+// external_id and last_synced_at are Apply's own writes, from ExternalKey and
+// Baseline, and the field loop runs after them — so a field claiming either
+// wins in silence, and the mirror loses the identity a record is matched by or
+// the incumbent last-modified instant the wire reports as updated_at.
+func TestAFieldWritingAStructuralTargetIsADeclarationError(t *testing.T) {
+	for _, tc := range []struct {
+		target      string
+		declaration string
+	}{
+		{target: "external_id", declaration: "ExternalKey"},
+		{target: "last_synced_at", declaration: "Baseline"},
+	} {
+		t.Run(tc.target, func(t *testing.T) {
+			m := overlay.ObjectMapping{
+				Source: "contacts", Target: "person",
+				ExternalKey: "hs_object_id", Baseline: "hs_lastmodifieddate",
+				Fields: []overlay.FieldMapping{
+					{From: []string{"hs_legacy_key"}, To: tc.target, Kind: overlay.TargetColumn},
+				},
+			}
+			// The record carries none of the mapped properties, so the field writes
+			// nothing and only a check made on the declaration itself can catch it.
+			_, _, err := overlay.Apply(m, map[string]any{"unrelated": "x"})
+			if err == nil {
+				t.Fatalf("Apply accepted a field writing %s, which %s already writes; the field silently replaces it", tc.target, tc.declaration)
+			}
+			if !strings.Contains(err.Error(), tc.target) || !strings.Contains(err.Error(), "hs_legacy_key") {
+				t.Errorf("error %q does not name both the contested target and the offending field, so it does not say where to look", err)
+			}
+			if !strings.Contains(err.Error(), tc.declaration) {
+				t.Errorf("error %q does not name %s as the other writer, leaving a reader hunting for a field that writes %s and finding none",
+					err, tc.declaration, tc.target)
+			}
+		})
+	}
+}
+
+// The reservation follows the declaration, not the key name: a mapping that
+// declares no ExternalKey and no Baseline writes neither structural target, so
+// a field may land both — and an omitted declaration must never reserve the
+// empty string as a target of its own.
+func TestAFieldMayWriteAStructuralKeyNoDeclarationClaims(t *testing.T) {
+	m := overlay.ObjectMapping{
+		Source: "contacts", Target: "person",
+		Fields: []overlay.FieldMapping{
+			{From: []string{"hs_object_id"}, To: "external_id", Kind: overlay.TargetColumn},
+			{From: []string{"hs_lastmodifieddate"}, To: "last_synced_at", Kind: overlay.TargetColumn},
+		},
+	}
+	out, _, err := overlay.Apply(m, map[string]any{"hs_object_id": "1", "hs_lastmodifieddate": "2026-08-01T09:00:00Z"})
+	if err != nil {
+		t.Fatalf("Apply rejected fields landing structural keys the mapping declares no writer for: %v", err)
+	}
+	if out["external_id"] != "1" || out["last_synced_at"] != "2026-08-01T09:00:00Z" {
+		t.Errorf("out = %v, want the fields' own values on external_id and last_synced_at", out)
+	}
+}
+
 // Rows of ONE collection are the shape the child kind exists for: they share a
 // parent key by design, and each declares its own position within it.
 func TestTwoChildRowsOfOneCollectionAreNotACollision(t *testing.T) {

--- a/backend/internal/modules/overlay/mapping_test.go
+++ b/backend/internal/modules/overlay/mapping_test.go
@@ -553,3 +553,75 @@ func TestApplyFlagsARawKeyNoMappingConsumes(t *testing.T) {
 		t.Errorf("unmapped = %v, want it to contain %q (no declared mapping consumes it)", unmapped, "hs_unknown_property")
 	}
 }
+
+// Two fields writing one target clobber in declaration order — whichever runs
+// second wins, and the loser's value is gone with nothing to show for it. The
+// pair below is the flat case: one column, two writers.
+func TestTwoColumnFieldsWritingOneTargetAreADeclarationError(t *testing.T) {
+	m := overlay.ObjectMapping{
+		Source: "contacts", Target: "person", ExternalKey: "hs_object_id",
+		Fields: []overlay.FieldMapping{
+			{From: []string{"firstname"}, To: "display_name", Kind: overlay.TargetColumn},
+			{From: []string{"lastname"}, To: "display_name", Kind: overlay.TargetColumn},
+		},
+	}
+	// The record carries NEITHER colliding property, so only a check made on
+	// the declaration itself can catch it.
+	_, _, err := overlay.Apply(m, map[string]any{"hs_object_id": "1"})
+	if err == nil {
+		t.Fatal("Apply accepted two fields writing display_name; the second silently overwrites the first")
+	}
+	if !strings.Contains(err.Error(), "display_name") {
+		t.Errorf("error %q does not name the contested target, so it does not say where to look", err)
+	}
+	if !strings.Contains(err.Error(), "lastname") || !strings.Contains(err.Error(), "firstname") {
+		t.Errorf("error %q does not name both writers, leaving the reader to find the other one", err)
+	}
+}
+
+// The same collision across kinds is the worse one: a column landing on a
+// child collection's parent key replaces every mirrored row of it (or is
+// replaced by them), so a contact loses all its addresses rather than one
+// value.
+func TestAColumnWritingAChildCollectionsParentIsADeclarationError(t *testing.T) {
+	m := overlay.ObjectMapping{
+		Source: "contacts", Target: "person", ExternalKey: "hs_object_id",
+		Fields: []overlay.FieldMapping{
+			{
+				From: []string{"email"}, To: "person_email.email", Kind: overlay.TargetChild,
+				Child: &overlay.ChildRow{Attrs: map[string]any{"email_type": "work"}, Position: 0},
+			},
+			{From: []string{"work_email"}, To: "person_email", Kind: overlay.TargetColumn},
+		},
+	}
+	// The record carries NEITHER colliding property, so only a check made on
+	// the declaration itself can catch it.
+	_, _, err := overlay.Apply(m, map[string]any{"hs_object_id": "1"})
+	if err == nil {
+		t.Fatal("Apply accepted a column writing person_email, the parent key a child collection lands under")
+	}
+	if !strings.Contains(err.Error(), "person_email") {
+		t.Errorf("error %q does not name the contested target, so it does not say where to look", err)
+	}
+}
+
+// Rows of ONE collection are the shape the child kind exists for: they share a
+// parent key by design, and each declares its own position within it.
+func TestTwoChildRowsOfOneCollectionAreNotACollision(t *testing.T) {
+	m := overlay.ObjectMapping{
+		Source: "contacts", Target: "person", ExternalKey: "hs_object_id",
+		Fields: []overlay.FieldMapping{
+			{
+				From: []string{"phone"}, To: "person_phone.phone", Kind: overlay.TargetChild,
+				Child: &overlay.ChildRow{Attrs: map[string]any{"phone_type": "work"}, Position: 0},
+			},
+			{
+				From: []string{"mobilephone"}, To: "person_phone.phone", Kind: overlay.TargetChild,
+				Child: &overlay.ChildRow{Attrs: map[string]any{"phone_type": "mobile"}, Position: 1},
+			},
+		},
+	}
+	if _, _, err := overlay.Apply(m, map[string]any{"hs_object_id": "1", "phone": "+4930111"}); err != nil {
+		t.Fatalf("Apply rejected two rows of one collection: %v", err)
+	}
+}


### PR DESCRIPTION
Four follow-ups filed during #1044, each mechanical and none blocked on a product decision or a portal capture.

**#1006 — a mapped binding's source properties are the ones its mapping reads.** The registry's `CanonicalKey` claim was already enforced (the wire gate runs the real `Apply` and asserts the key landed), but `Incumbent` was only checked against a hand-written fixture — so a binding could name a property the mapping never reads, and pass as soon as someone added it to the fixture. It is now held to `propertyNames()`, the production function that builds the `properties=` list sent to HubSpot. That closes the chain: a `mapped` binding's sources are properties the incumbent is genuinely asked for.

**#1016 — deal, lead and activity report the incumbent's last-modified.** All three assemblers read `Freshness.LastSyncedAt`, which is the mirror row's *ingest* time — so "recently updated" meant "recently synced", the same answer for every record in the workspace. They now read the canonical payload key, as person and organization already did. None of the three mappings lands a create instant, so `created_at` keeps the sync-instant fallback; the tests assert that absence rather than trusting the survey, so they point at the fix the day a mapping lands one.

**#1039 — two fields writing one canonical target are a declaration error.** Rejected before the first record is projected, so a broken mapping fails immediately rather than on particular data. This also reserves the two structural targets: `external_id` and `last_synced_at` are written by `ExternalKey`/`Baseline`, and a field landing on either silently replaced them — which #1016 made costlier, since five wire slots now read that key.

**#1025 — a mirrored company shows its website.** `website_url` is derived, never stored (ADR-0085): `https://` + the primary domain, matching `attachOrgDomains` exactly, including publishing nothing when no row is primary.

That needed a fifth disposition. `website_url` is computed from the same mirror key `domains` already names, which would have made two wire slots claim one `CanonicalKey` — a rule worth keeping. `derived` says what is actually true: the mirror carries the inputs and the wire computes the slot. It carries no canonical key, and a new `DerivedFrom` must name sibling bindings that are themselves `mapped`, so a derived slot cannot be declared over data the mirror does not hold. The wire gate additionally proves the value is caused by the payload — it assembles the record twice, once empty, with the same identity, so a slot computed from anything but mirrored data is identical across both runs and fails.

Closes #1006, closes #1016, closes #1025, closes #1039.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes four mechanical follow-ups in the overlay: validates mapped sources against the real mapping, derives organization website from the primary domain, reads the incumbent last-modified for updated_at, and rejects double-writes to one target. This removes false greens in tests, corrects timestamps, publishes the expected website, and prevents silent clobbering.

- Validates mapped bindings: holds `Incumbent` properties to the production `propertyNames()` for each armed entity, not a hand-written fixture (#1006).
- Corrects stamps: deal, lead, and activity now set updated_at from the canonical `last_synced_at` (the incumbent’s last-modified); created_at stays the sync instant for those classes (#1016).
- Prevents target collisions: `Apply` rejects two fields writing the same target and a column landing on a child collection’s parent key; reserves `external_id` and `last_synced_at` for structural writers when declared (#1039).
- Adds a new disposition: `derived` with `DerivedFrom`, and uses it to compute `organization.website_url` from the primary domain in `domains` (renders https:// + primary; omits when none is primary) (#1025).
- Strengthens gates and tests: expands the wire reachability gate to check derived slots, adds declaration checks for `derived`, and adds coverage for stamps and website derivation.

Bold rollout/migration
- Update any mapping that writes the same target twice; give each field a unique target or declare both as child rows with positions.
- Do not target `external_id` or `last_synced_at` from fields when the mapping declares them structurally.
- For derived fields, set `DispositionDerived` and list mapped sources in `DerivedFrom` on the same entity.
- Fix bindings whose `Incumbent` properties are not in the mapping’s `properties=` list.

<sup>Written for commit 6b9b9468be29309db1fc65dd500689286de60da6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1103?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Organization records now populate website URLs from their primary domain.
  * Derived fields are supported for values calculated from mapped data.
* **Bug Fixes**
  * Deal, lead, and activity records now retain the source system’s last-modified timestamp while preserving sync creation time.
  * Prevented conflicting field mappings from overwriting structural or duplicate targets.
* **Validation**
  * Added checks to ensure derived fields have valid source mappings and mapped fields reference available source properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->