### PR TITLE
feat(integrations): the live Surfe adapter

### DIFF
--- a/backend/internal/compose/providerdescriptorparity_test.go
+++ b/backend/internal/compose/providerdescriptorparity_test.go
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The offline fake and the live Surfe adapter must describe the SAME product.
+//
+// Every test that exercises pricing, cascades or budget through the fake
+// (TestOfflineDescriptorPricesTheCascade, the reservation suites, the whole
+// run pipeline) rests on the fake's own claim to "mirror Surfe's shape so the
+// fake exercises the same cost table, the same cascade and the same two pools
+// the real adapter will". Nothing enforced that, and a divergence in
+// CostTable or Cascades would leave every one of those tests green against a
+// shape production does not have — the money tests passing hardest where they
+// matter least.
+//
+// A fitness function rather than a point fix (review-loop rule 2): the
+// obligation is derived from the two descriptors, so a field added to either
+// is compared without anyone remembering to add it here.
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gradionhq/margince/backend/internal/modules/integrations"
+	"github.com/gradionhq/margince/backend/internal/modules/integrations/surfe"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/provider"
+)
+
+func TestTheOfflineFakeDescribesTheSameProductAsTheLiveAdapter(t *testing.T) {
+	clock := func() time.Time { return time.Date(2026, 8, 13, 12, 0, 0, 0, time.UTC) }
+	fake := integrations.NewOfflineProvider(0, clock).Descriptor()
+	live := surfe.New(clock).Descriptor()
+
+	// The commercial shape: what it costs, what it meters, what it sells. A
+	// difference here makes every fake-driven money test a test of fiction.
+	if fake.Name != live.Name {
+		t.Errorf("provider name: fake %q, live %q", fake.Name, live.Name)
+	}
+	if fake.Transport != live.Transport {
+		t.Errorf("transport: fake %q, live %q — the run state machine differs per transport", fake.Transport, live.Transport)
+	}
+	if fake.Billing != live.Billing {
+		t.Errorf("billing: fake %q, live %q — this decides what a no-match refunds", fake.Billing, live.Billing)
+	}
+	if fake.EgressHost != live.EgressHost {
+		t.Errorf("egress host: fake %q, live %q", fake.EgressHost, live.EgressHost)
+	}
+	if fake.DefaultPreset != live.DefaultPreset {
+		t.Errorf("default preset: fake %q, live %q", fake.DefaultPreset, live.DefaultPreset)
+	}
+	assertSameCategories(t, "credit pools", poolNames(fake.CreditPools), poolNames(live.CreditPools))
+	assertSameCategories(t, "categories", categoryNames(fake.Categories), categoryNames(live.Categories))
+	assertSamePresets(t, fake.Presets, live.Presets)
+	assertSameCosts(t, fake.CostTable, live.CostTable)
+	assertSameCascades(t, fake.Cascades, live.Cascades)
+
+	// The one field that may legitimately differ is the disclosure copy: the
+	// fake is not a vendor and links to nothing a customer must read. Every
+	// field that decides BEHAVIOUR is compared above.
+	if len(live.TermsLinks) == 0 {
+		t.Error("the live adapter publishes no terms links, so the settings card can disclose nothing about who is being paid")
+	}
+}
+
+func poolNames(pools []provider.Pool) []string {
+	out := make([]string, len(pools))
+	for i, p := range pools {
+		out[i] = string(p)
+	}
+	return out
+}
+
+func categoryNames(categories []provider.Category) []string {
+	out := make([]string, len(categories))
+	for i, c := range categories {
+		out[i] = string(c)
+	}
+	return out
+}
+
+// assertSameCategories compares two vocabularies as SETS: the descriptors
+// declare them in whatever order reads best, and only membership is a
+// behavioural fact.
+func assertSameCategories(t *testing.T, what string, fake, live []string) {
+	t.Helper()
+	inFake, inLive := map[string]bool{}, map[string]bool{}
+	for _, v := range fake {
+		inFake[v] = true
+	}
+	for _, v := range live {
+		inLive[v] = true
+	}
+	for v := range inLive {
+		if !inFake[v] {
+			t.Errorf("%s: the live adapter sells %q and the fake does not — a test exercising it would never run against production's shape", what, v)
+		}
+	}
+	for v := range inFake {
+		if !inLive[v] {
+			t.Errorf("%s: the fake offers %q and the live adapter does not — tests pass against a category nobody can buy", what, v)
+		}
+	}
+}
+
+func assertSamePresets(t *testing.T, fake, live map[string][]provider.Category) {
+	t.Helper()
+	for name, liveSet := range live {
+		fakeSet, ok := fake[name]
+		if !ok {
+			t.Errorf("preset %q exists live and not in the fake", name)
+			continue
+		}
+		assertSameCategories(t, "preset "+name, categoryNames(fakeSet), categoryNames(liveSet))
+	}
+	for name := range fake {
+		if _, ok := live[name]; !ok {
+			t.Errorf("preset %q exists in the fake and not live", name)
+		}
+	}
+}
+
+func assertSameCosts(t *testing.T, fake, live map[provider.Category]map[provider.Pool]int) {
+	t.Helper()
+	for category, liveCost := range live {
+		fakeCost, ok := fake[category]
+		if !ok {
+			t.Errorf("cost table: %q is priced live and absent from the fake", category)
+			continue
+		}
+		for pool, n := range liveCost {
+			if fakeCost[pool] != n {
+				t.Errorf("cost table: %q costs %d %s live and %d in the fake — the reservation the fake tests is not the one production takes",
+					category, n, pool, fakeCost[pool])
+			}
+		}
+		for pool, n := range fakeCost {
+			if liveCost[pool] != n {
+				t.Errorf("cost table: %q costs %d %s in the fake and %d live", category, n, pool, liveCost[pool])
+			}
+		}
+	}
+	for category := range fake {
+		if _, ok := live[category]; !ok {
+			t.Errorf("cost table: %q is priced in the fake and absent live", category)
+		}
+	}
+}
+
+// assertSameCascades compares the fallback rules, which are the subtlest
+// money in the descriptor: a cascade's cost, and the categories it excludes,
+// both decide what a run may spend before it ever calls out.
+func assertSameCascades(t *testing.T, fake, live []provider.Cascade) {
+	t.Helper()
+	if len(fake) != len(live) {
+		t.Fatalf("cascades: fake has %d, live has %d", len(fake), len(live))
+	}
+	byCategory := map[provider.Category]provider.Cascade{}
+	for _, c := range live {
+		byCategory[c.Category] = c
+	}
+	for _, f := range fake {
+		l, ok := byCategory[f.Category]
+		if !ok {
+			t.Errorf("cascade %q exists in the fake and not live", f.Category)
+			continue
+		}
+		if f.After != l.After {
+			t.Errorf("cascade %q triggers after %q in the fake and %q live", f.Category, f.After, l.After)
+		}
+		for pool, n := range l.Cost {
+			if f.Cost[pool] != n {
+				t.Errorf("cascade %q costs %d %s live and %d in the fake", f.Category, n, pool, f.Cost[pool])
+			}
+		}
+		assertSameCategories(t, "cascade "+string(f.Category)+" exclusions",
+			categoryNames(f.Excludes), categoryNames(l.Excludes))
+	}
+}

--- a/backend/internal/compose/providerselect.go
+++ b/backend/internal/compose/providerselect.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/gradionhq/margince/backend/internal/modules/integrations"
+	"github.com/gradionhq/margince/backend/internal/modules/integrations/surfe"
 )
 
 // providerModeEnv selects the adapter: "off" (the default), "offline" for the
@@ -46,11 +47,11 @@ func ProviderRegistryFromEnv(now func() time.Time) (*integrations.Registry, bool
 		}
 		return reg, true, nil
 	case "live":
-		// The live adapter lands with the Surfe wire implementation. Until
-		// then this refuses rather than falling back to the fake: a
-		// deployment that asked for live data and silently got invented data
-		// is the worse of the two failures by far.
-		return nil, false, fmt.Errorf("compose: %s=live, but no live provider adapter is compiled into this build", providerModeEnv)
+		reg, err := integrations.NewRegistry(surfe.New(now))
+		if err != nil {
+			return nil, false, fmt.Errorf("compose: registering the Surfe adapter: %w", err)
+		}
+		return reg, true, nil
 	default:
 		return nil, false, fmt.Errorf("compose: %s=%q is not a provider mode (off, offline, live)", providerModeEnv, mode)
 	}

--- a/backend/internal/modules/integrations/budget.go
+++ b/backend/internal/modules/integrations/budget.go
@@ -180,6 +180,17 @@ func (s *Store) reconcile(ctx context.Context, tx pgx.Tx, desc provider.Descript
 		if v, ok := spend[provider.Pool(pool)]; ok {
 			actual = v
 		}
+		// But never ABOVE the hold. The reservation is what this run was
+		// authorized to spend, and actual_credits feeds poolUsedThisMonth,
+		// which enforces the customer's monthly ceiling — so an adapter
+		// reporting more than was held would silently consume budget later
+		// runs were counting on. A vendor cannot charge this installation
+		// more than it agreed to hold; if one claims to have, that is a
+		// discrepancy for a human to take up with them, not a number this
+		// ledger accepts.
+		if actual > reserved {
+			actual = reserved
+		}
 		if _, err := tx.Exec(ctx, `
 			UPDATE provider_run_reservation
 			   SET actual_credits = $3, reconciled_at = now()

--- a/backend/internal/modules/integrations/execute.go
+++ b/backend/internal/modules/integrations/execute.go
@@ -277,8 +277,17 @@ func (s *Store) unseal(ctx context.Context, tx pgx.Tx, ref string) (provider.Cre
 }
 
 // cascadesFor narrows the descriptor's cascades to the ones the frozen
-// category set actually permits: a cascade whose category was not requested
-// was not reserved, and issuing it would spend an unheld credit.
+// category set actually permits — and it uses EXACTLY the test
+// Descriptor.WorstCase uses to price them.
+//
+// Both halves are required: the cascade's own category, and the category
+// whose empty answer triggers it. Testing only the first is how a run comes
+// to issue a cascade nobody reserved — a customer who saved
+// `categories: [personal_email]` alone gets no email reservation at all
+// (CostTable prices personal_email at nothing, and WorstCase skips a cascade
+// whose `After` was not requested), while a request that asked for the
+// fallback would spend two email credits with no row to reconcile them
+// against. They would vanish from the ledger entirely.
 func cascadesFor(desc provider.Descriptor, requested []provider.Category) []provider.Cascade {
 	in := map[provider.Category]bool{}
 	for _, c := range requested {
@@ -286,7 +295,7 @@ func cascadesFor(desc provider.Descriptor, requested []provider.Category) []prov
 	}
 	var out []provider.Cascade
 	for _, c := range desc.Cascades {
-		if in[c.Category] {
+		if in[c.Category] && in[c.After] {
 			out = append(out, c)
 		}
 	}

--- a/backend/internal/modules/integrations/surfe/enrich.go
+++ b/backend/internal/modules/integrations/surfe/enrich.go
@@ -202,10 +202,17 @@ func (a *Adapter) Poll(ctx context.Context, cred provider.Credential, providerJo
 	var out enrichResult
 	status, err := a.call(ctx, cred, http.MethodGet, "/v2/people/enrich/"+providerJobID, nil, &out)
 	if err != nil {
-		// A failed POLL costs nothing and tells us nothing: the sweep asks
-		// again on its next tick, and the run's own expiry bounds how long
-		// that can go on.
-		return provider.PollStatus{}, err
+		// A failed poll costs nothing and settles nothing, so it reads as
+		// PENDING rather than as an error: the sweep asks again on its next
+		// tick and the run's own expiry bounds how long that can go on.
+		//
+		// Returning the error instead would put one unreadable response into
+		// the sweep's joined error on every tick — failing the whole
+		// workspace's drain job, for a run that is merely unfinished.
+		//
+		//nolint:nilerr // the failure IS the outcome: an unread poll is an
+		// unfinished one, and the expiry is what ends it.
+		return provider.PollStatus{Outcome: provider.OutcomePending}, nil
 	}
 	if status != http.StatusOK {
 		outcome, safeCode := refusalFor(status)
@@ -218,7 +225,14 @@ func (a *Adapter) Poll(ctx context.Context, cred provider.Credential, providerJo
 		return provider.PollStatus{Outcome: provider.OutcomeNoMatch, SafeStatusCode: "no_match"}, nil
 	}
 	person := out.People[0]
-	claims := claimsFor(person)
+	claims, err := claimsFor(person)
+	if err != nil {
+		// A result we cannot encode is NOT a no-match: the run completed and
+		// was charged. Surfacing the error leaves it in progress for the
+		// sweep to re-poll rather than releasing a hold against work the
+		// provider actually did.
+		return provider.PollStatus{}, err
+	}
 	if len(claims) == 0 {
 		// Completed, and the vendor found nothing worth returning. A
 		// no-match rather than an empty success: on per-successful-result
@@ -265,8 +279,22 @@ func includeFor(categories []provider.Category) includeFlags {
 }
 
 // refusalFor classifies a vendor status into the port's closed vocabulary.
-// The status code is the ONLY thing read: the body may echo a fragment of the
-// key, and a customer-visible reason must be a closed product code.
+//
+// The named cases are the ones that PROVE no work was done, and only those
+// release the credit hold. Everything else — including an unrecognized 2xx, a
+// 3xx from a proxy, a 408 or a 409 — is AMBIGUOUS: the request reached the
+// vendor, the enrichment may be running and billable, and calling that a
+// definite refusal would release a hold on work the customer may have been
+// charged for. That is the double-charge PI-AC-4 exists to prevent, reached
+// without any retry at all.
+//
+// Closed on the safe side, in other words: the platform's definiteRefusals
+// set is what releases money, so this must never hand it a status it merely
+// failed to recognize.
+//
+// The status code is the ONLY thing read. The body may echo a fragment of the
+// key we just sent, and a customer-visible reason must be a closed product
+// code rather than a vendor's prose.
 func refusalFor(status int) (provider.Outcome, string) {
 	switch {
 	case status == http.StatusUnauthorized, status == http.StatusForbidden:
@@ -275,12 +303,18 @@ func refusalFor(status int) (provider.Outcome, string) {
 		return provider.OutcomeInsufficientCredits, "provider_out_of_credits"
 	case status == http.StatusTooManyRequests:
 		return provider.OutcomeRateLimited, "provider_rate_limited"
+	case status == http.StatusBadRequest, status == http.StatusNotFound,
+		status == http.StatusUnprocessableEntity:
+		// The vendor rejected the REQUEST rather than doing work on it: a
+		// malformed body, an unknown handle, an unsellable selection. No
+		// enrichment ran, so the hold is released.
+		return provider.OutcomeProviderError, "provider_error"
 	case status >= 500:
-		// The vendor's own fault, and a DEFINITE refusal: a 5xx means it did
-		// not do the work, so the hold is released rather than parked.
+		// The vendor's own fault, and a definite refusal: a 5xx means it did
+		// not complete the work.
 		return provider.OutcomeProviderError, "provider_error"
 	default:
-		return provider.OutcomeProviderError, "provider_error"
+		return provider.OutcomeAmbiguous, "unexpected_status"
 	}
 }
 

--- a/backend/internal/modules/integrations/surfe/enrich.go
+++ b/backend/internal/modules/integrations/surfe/enrich.go
@@ -1,0 +1,300 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package surfe
+
+// The four calls the Adapter contract names, over Surfe's v2 asynchronous
+// bulk-enrichment API:
+//
+//	POST /v2/people/enrich      → an enrichment id (202)
+//	GET  /v2/people/enrich/{id} → IN_PROGRESS, or COMPLETED with the people
+//	GET  /v1/credits            → the balance, which is also the credential check
+//
+// Every failure classifies into the port's closed Outcome vocabulary. The one
+// that matters most is OutcomeAmbiguous: a timeout or an unreadable answer
+// AFTER the request left means the charge may have happened, so the run parks
+// with its reservation held rather than retrying into a second charge.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/gradionhq/margince/backend/internal/shared/ports/provider"
+)
+
+// The wire shapes, named as SURFE names them. The tags must match its
+// camelCase format exactly, or the request is rejected and the response
+// silently decodes to zero values — the vendor's keys are not ours to case.
+//
+//nolint:tagliatelle // the vendor's wire format, not this repo's convention.
+type (
+	enrichRequest struct {
+		EnrichmentOptions enrichOptions `json:"enrichmentOptions"`
+		Include           includeFlags  `json:"include"`
+		People            []wirePerson  `json:"people"`
+	}
+	enrichOptions struct {
+		// AcceptedEmailType is how the frozen cascade reaches the vendor:
+		// "professional" asks for a work address only, and the platform
+		// widens to "personal" only where the policy permits that fallback.
+		AcceptedEmailType string `json:"acceptedEmailType,omitempty"`
+		// SkipMobileEnrichmentIfNoEmailFound spends no mobile credit on a
+		// subject the vendor could not place at all.
+		SkipMobileEnrichmentIfNoEmailFound bool `json:"skipMobileEnrichmentIfNoEmailFound"`
+	}
+	includeFlags struct {
+		Email       bool `json:"email"`
+		JobHistory  bool `json:"jobHistory"`
+		LinkedInURL bool `json:"linkedInUrl"`
+		Mobile      bool `json:"mobile"`
+	}
+	wirePerson struct {
+		FirstName     string `json:"firstName,omitempty"`
+		LastName      string `json:"lastName,omitempty"`
+		LinkedInURL   string `json:"linkedinUrl,omitempty"`
+		CompanyName   string `json:"companyName,omitempty"`
+		CompanyDomain string `json:"companyDomain,omitempty"`
+		ExternalID    string `json:"externalID,omitempty"`
+	}
+	enrichAccepted struct {
+		EnrichmentID string `json:"enrichmentID"`
+	}
+	enrichResult struct {
+		Status string       `json:"status"`
+		People []wireResult `json:"people"`
+	}
+	wireResult struct {
+		Status        string       `json:"status"`
+		FirstName     string       `json:"firstName"`
+		LastName      string       `json:"lastName"`
+		Emails        []wireEmail  `json:"emails"`
+		MobilePhones  []wireMobile `json:"mobilePhones"`
+		LinkedInURL   string       `json:"linkedInUrl"`
+		JobTitle      string       `json:"jobTitle"`
+		CompanyName   string       `json:"companyName"`
+		CompanyDomain string       `json:"companyDomain"`
+		JobHistory    []wireJob    `json:"jobHistory"`
+		Location      string       `json:"location"`
+		City          string       `json:"city"`
+		State         string       `json:"state"`
+		Country       string       `json:"country"`
+		Departments   []string     `json:"departments"`
+		Seniorities   []string     `json:"seniorities"`
+	}
+	wireEmail struct {
+		Email string `json:"email"`
+		// EmailType may be ABSENT even under the professional cascade. The
+		// platform then labels the address from what it ASKED for and marks
+		// the source — it never claims the provider said so.
+		EmailType        string `json:"emailType"`
+		ValidationStatus string `json:"validationStatus"`
+	}
+	wireMobile struct {
+		MobilePhone     string   `json:"mobilePhone"`
+		ConfidenceScore *float64 `json:"confidenceScore"`
+	}
+	wireJob struct {
+		CompanyName string `json:"companyName"`
+		JobTitle    string `json:"jobTitle"`
+		LinkedInURL string `json:"linkedInURL"`
+		StartDate   string `json:"startDate"`
+		EndDate     string `json:"endDate"`
+	}
+	creditsResult struct {
+		TotalEmail  int `json:"totalEmail"`
+		TotalMobile int `json:"totalMobile"`
+	}
+)
+
+// statusCompleted is the only vendor status this adapter tests for.
+// Anything else — IN_PROGRESS, or a state they add later — reads as pending,
+// which costs nothing and asks again; treating an unfamiliar status as
+// finished would settle a run against an answer that had not arrived.
+const statusCompleted = "COMPLETED"
+
+// ErrCredentialRefused reports that Surfe rejected the key. Its own error so
+// Connect can answer "that key does not work" rather than a generic failure.
+var ErrCredentialRefused = errors.New("surfe: the credential was refused")
+
+// VerifyCredential reads the credit balance, which is the cheapest call that
+// proves a key works — and the same call Credits makes, which is why the
+// descriptor names one for both.
+func (a *Adapter) VerifyCredential(ctx context.Context, cred provider.Credential) (provider.Credits, error) {
+	return a.Credits(ctx, cred)
+}
+
+// Credits reads the provider's own balance. Reported as THEIR number and
+// never as ours: the customer may spend the same credits through Surfe's own
+// app, so this is a reading, not an accounting.
+func (a *Adapter) Credits(ctx context.Context, cred provider.Credential) (provider.Credits, error) {
+	var out creditsResult
+	status, err := a.call(ctx, cred, http.MethodGet, "/v1/credits", nil, &out)
+	if err != nil {
+		return provider.Credits{}, err
+	}
+	if status == http.StatusUnauthorized || status == http.StatusForbidden {
+		return provider.Credits{}, ErrCredentialRefused
+	}
+	if status != http.StatusOK {
+		return provider.Credits{}, fmt.Errorf("surfe: the credit read answered %d", status)
+	}
+	return provider.Credits{
+		Balances: map[provider.Pool]int{poolEmail: out.TotalEmail, poolMobile: out.TotalMobile},
+		ReadAt:   a.now().UTC(),
+	}, nil
+}
+
+// Submit starts one person's enrichment.
+//
+// The correlation id rides as externalID: it is an opaque handle carrying no
+// subject identity, which is what makes it safe to hand a third party, and it
+// is how a returned result is matched back to its run.
+func (a *Adapter) Submit(ctx context.Context, cred provider.Credential, req provider.Request) (provider.Submission, error) {
+	body := enrichRequest{
+		EnrichmentOptions: enrichOptions{
+			AcceptedEmailType: acceptedEmailType(req),
+			// A subject the vendor cannot place at all yields no mobile
+			// either, and asking for one would spend a mobile credit on a
+			// lookup already known to have failed.
+			SkipMobileEnrichmentIfNoEmailFound: true,
+		},
+		Include: includeFor(req.Categories),
+		People: []wirePerson{{
+			FirstName:     req.Identifiers.FirstName,
+			LastName:      req.Identifiers.LastName,
+			LinkedInURL:   req.Identifiers.LinkedInURL,
+			CompanyName:   req.Identifiers.CompanyName,
+			CompanyDomain: req.Identifiers.CompanyDomain,
+			ExternalID:    req.CorrelationID,
+		}},
+	}
+	var accepted enrichAccepted
+	status, err := a.call(ctx, cred, http.MethodPost, "/v2/people/enrich", body, &accepted)
+	if err != nil {
+		// The request LEFT and its fate is unknown — a timeout, a dropped
+		// connection, an unreadable answer. That is an OUTCOME, not a
+		// failure: returning the error would let the job retry, and a retry
+		// is how one ambiguous charge becomes two certain ones (PI-AC-4).
+		// The caller parks the run with its reservation held.
+		//
+		//nolint:nilerr // the error IS the outcome here; see above.
+		return provider.Submission{Outcome: provider.OutcomeAmbiguous, SafeStatusCode: "submission_timeout"}, nil
+	}
+	if status == http.StatusOK || status == http.StatusAccepted {
+		if accepted.EnrichmentID == "" {
+			// Accepted with no handle to poll: the work may be running and
+			// we can never read it back, which is exactly unknown.
+			return provider.Submission{Outcome: provider.OutcomeAmbiguous, SafeStatusCode: "no_job_handle"}, nil
+		}
+		return provider.Submission{Outcome: provider.OutcomeAccepted, ProviderJobID: accepted.EnrichmentID}, nil
+	}
+	outcome, safeCode := refusalFor(status)
+	return provider.Submission{Outcome: outcome, SafeStatusCode: safeCode}, nil
+}
+
+// Poll re-reads a submitted enrichment by its handle. It is also the recovery
+// read: a completed enrichment re-serves the same result, which is what lets
+// the platform park no payload between hand-off attempts.
+func (a *Adapter) Poll(ctx context.Context, cred provider.Credential, providerJobID string) (provider.PollStatus, error) {
+	var out enrichResult
+	status, err := a.call(ctx, cred, http.MethodGet, "/v2/people/enrich/"+providerJobID, nil, &out)
+	if err != nil {
+		// A failed POLL costs nothing and tells us nothing: the sweep asks
+		// again on its next tick, and the run's own expiry bounds how long
+		// that can go on.
+		return provider.PollStatus{}, err
+	}
+	if status != http.StatusOK {
+		outcome, safeCode := refusalFor(status)
+		return provider.PollStatus{Outcome: outcome, SafeStatusCode: safeCode}, nil
+	}
+	if out.Status != statusCompleted {
+		return provider.PollStatus{Outcome: provider.OutcomePending}, nil
+	}
+	if len(out.People) == 0 {
+		return provider.PollStatus{Outcome: provider.OutcomeNoMatch, SafeStatusCode: "no_match"}, nil
+	}
+	person := out.People[0]
+	claims := claimsFor(person)
+	if len(claims) == 0 {
+		// Completed, and the vendor found nothing worth returning. A
+		// no-match rather than an empty success: on per-successful-result
+		// billing it releases the whole reservation.
+		return provider.PollStatus{Outcome: provider.OutcomeNoMatch, SafeStatusCode: "no_match"}, nil
+	}
+	return provider.PollStatus{
+		Outcome: provider.OutcomeCompleted,
+		Result:  &provider.Result{Claims: claims, PoolSpend: spendFor(person)},
+	}, nil
+}
+
+// acceptedEmailType translates the frozen policy into the vendor's one knob.
+// Personal is asked for only where the run's own cascade permits it; the
+// absence of that cascade means the customer chose professional-only, and
+// widening it here would buy a category they refused.
+func acceptedEmailType(req provider.Request) string {
+	for _, c := range req.Cascades {
+		if c.Category == categoryPersonalEmail {
+			return emailTypePersonal
+		}
+	}
+	return emailTypeProfessional
+}
+
+// includeFor maps the requested categories onto the vendor's four flags.
+// Nothing is asked for that the run did not freeze: a flag set beyond the
+// request would spend a credit the reservation does not cover.
+func includeFor(categories []provider.Category) includeFlags {
+	var flags includeFlags
+	for _, c := range categories {
+		switch c {
+		case categoryProfessionalEmail, categoryPersonalEmail:
+			flags.Email = true
+		case categoryMobile:
+			flags.Mobile = true
+		case categoryLinkedInProfile:
+			flags.LinkedInURL = true
+		case categoryJobHistory:
+			flags.JobHistory = true
+		}
+	}
+	return flags
+}
+
+// refusalFor classifies a vendor status into the port's closed vocabulary.
+// The status code is the ONLY thing read: the body may echo a fragment of the
+// key, and a customer-visible reason must be a closed product code.
+func refusalFor(status int) (provider.Outcome, string) {
+	switch {
+	case status == http.StatusUnauthorized, status == http.StatusForbidden:
+		return provider.OutcomeInvalidCredentials, "credential_rejected"
+	case status == http.StatusPaymentRequired:
+		return provider.OutcomeInsufficientCredits, "provider_out_of_credits"
+	case status == http.StatusTooManyRequests:
+		return provider.OutcomeRateLimited, "provider_rate_limited"
+	case status >= 500:
+		// The vendor's own fault, and a DEFINITE refusal: a 5xx means it did
+		// not do the work, so the hold is released rather than parked.
+		return provider.OutcomeProviderError, "provider_error"
+	default:
+		return provider.OutcomeProviderError, "provider_error"
+	}
+}
+
+// monthOrDate reads the vendor's job dates. The documentation says ISO 8601;
+// the observed values are month-precision ("2019-01"), so both are accepted
+// and anything else is absent rather than guessed.
+func monthOrDate(value string) string {
+	if value == "" {
+		return ""
+	}
+	for _, layout := range []string{"2006-01", time.RFC3339, "2006-01-02"} {
+		if parsed, err := time.Parse(layout, value); err == nil {
+			return parsed.Format("2006-01")
+		}
+	}
+	return ""
+}

--- a/backend/internal/modules/integrations/surfe/normalize.go
+++ b/backend/internal/modules/integrations/surfe/normalize.go
@@ -21,6 +21,7 @@ package surfe
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/gradionhq/margince/backend/internal/shared/ports/provider"
 )
@@ -28,14 +29,17 @@ import (
 // claimsFor normalizes one person's result. A category the vendor answered
 // emptily produces NO claim rather than an empty one, so "we asked and they
 // had nothing" is stored as an absence and reads as one.
-func claimsFor(p wireResult) []provider.Claim {
+func claimsFor(p wireResult) ([]provider.Claim, error) {
 	var claims []provider.Claim
+	var failed error
 	add := func(key provider.ClaimKey, value any) {
 		raw, err := json.Marshal(value)
 		if err != nil {
-			// Marshalling these plain shapes cannot fail. If it somehow did,
-			// dropping the claim is right: a half-encoded value stored as a
-			// purchased fact is worse than a category that reads as absent.
+			// Surfaced, never dropped. A dropped claim is indistinguishable
+			// from a category the vendor had nothing for — and if every claim
+			// dropped, Poll would read the empty set as no_match and release
+			// the reservation for a run that completed and was charged.
+			failed = fmt.Errorf("surfe: encoding the %s claim: %w", key, err)
 			return
 		}
 		claims = append(claims, provider.Claim{Key: key, Value: raw})
@@ -73,7 +77,10 @@ func claimsFor(p wireResult) []provider.Claim {
 	if len(p.Seniorities) > 0 {
 		add(provider.ClaimSeniorities, p.Seniorities)
 	}
-	return claims
+	if failed != nil {
+		return nil, failed
+	}
+	return claims, nil
 }
 
 // splitEmails separates what the vendor labeled personal from everything
@@ -147,29 +154,38 @@ func historyFor(jobs []wireJob) []map[string]any {
 	return out
 }
 
-// spendFor reports what Surfe actually charged, per pool.
+// spendFor reports what Surfe charged, per pool: ONE credit per pool that
+// returned anything.
 //
-// The vendor's response carries no cost figure, so this is derived from what
-// it RETURNED: an address costs an email credit, a mobile number costs a
-// mobile credit, and a category that came back empty costs nothing. That is
-// the same per-successful-result rule the billing basis declares, and the
-// reservation reconciles against it — a run that asked for both and got only
-// an email releases the mobile hold.
+// The vendor's response carries no cost figure, so the charge is derived from
+// what it RETURNED — that is what per-successful-result billing means, and it
+// is why a run that asked for an email and a mobile but got only the email
+// releases the mobile hold.
+//
+// One credit per pool, not one per value, and that is the load-bearing part.
+// Surfe's `emails` array is PLURAL: it returns every address it found for the
+// subject, from the single lookup the run paid for. Counting them would bill
+// a well-documented person more than a thinly-documented one for the same
+// question, and would exceed the reservation the platform took — a number
+// reconcile writes into actual_credits and poolUsedThisMonth sums against the
+// customer's monthly ceiling, so the over-charge would silently eat budget
+// later runs were counting on.
+//
+// The platform clamps this against the run's own reservation as well
+// (integrations.reconcile): this function knows what the vendor answered, and
+// only the ledger knows what was held.
 func spendFor(p wireResult) map[provider.Pool]int {
 	spend := map[provider.Pool]int{}
 	for _, e := range p.Emails {
 		if e.Email != "" {
-			// The personal fallback costs two, per the descriptor's cascade.
-			if e.EmailType == emailTypePersonal {
-				spend[poolEmail] += 2
-				continue
-			}
-			spend[poolEmail]++
+			spend[poolEmail] = 1
+			break
 		}
 	}
 	for _, m := range p.MobilePhones {
 		if m.MobilePhone != "" {
-			spend[poolMobile]++
+			spend[poolMobile] = 1
+			break
 		}
 	}
 	return spend

--- a/backend/internal/modules/integrations/surfe/normalize.go
+++ b/backend/internal/modules/integrations/surfe/normalize.go
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package surfe
+
+// Turning Surfe's answer into the bounded claim shapes the platform stores.
+//
+// Two rules govern everything here, and both exist because the alternative
+// asserts something the vendor never said:
+//
+//   - An EMPTY STRING is not a value. Surfe returns "" for job-history fields
+//     it does not have, and a stored empty string renders as a blank line on
+//     the page and exports as one in an Art. 15 package.
+//   - A label the platform inferred is never presented as the provider's.
+//     emailType is frequently ABSENT even under the professional cascade, so
+//     the address is labeled from what was REQUESTED and marked as such —
+//     the person page reads that marker to say which is which.
+//
+// What the vendor returns beyond the requested categories is dropped: the
+// claim vocabulary is closed, and no raw payload is retained.
+
+import (
+	"encoding/json"
+
+	"github.com/gradionhq/margince/backend/internal/shared/ports/provider"
+)
+
+// claimsFor normalizes one person's result. A category the vendor answered
+// emptily produces NO claim rather than an empty one, so "we asked and they
+// had nothing" is stored as an absence and reads as one.
+func claimsFor(p wireResult) []provider.Claim {
+	var claims []provider.Claim
+	add := func(key provider.ClaimKey, value any) {
+		raw, err := json.Marshal(value)
+		if err != nil {
+			// Marshalling these plain shapes cannot fail. If it somehow did,
+			// dropping the claim is right: a half-encoded value stored as a
+			// purchased fact is worse than a category that reads as absent.
+			return
+		}
+		claims = append(claims, provider.Claim{Key: key, Value: raw})
+	}
+
+	professional, personal := splitEmails(p.Emails)
+	if len(professional) > 0 {
+		add(provider.ClaimProfessionalEmails, professional)
+	}
+	if len(personal) > 0 {
+		add(provider.ClaimPersonalEmails, personal)
+	}
+	if mobiles := mobilesFor(p.MobilePhones); len(mobiles) > 0 {
+		add(provider.ClaimMobilePhones, mobiles)
+	}
+	if p.LinkedInURL != "" {
+		add(provider.ClaimLinkedInProfile, p.LinkedInURL)
+	}
+	if p.JobTitle != "" || p.CompanyName != "" {
+		add(provider.ClaimCurrentEmployment, map[string]any{
+			"company_name":   p.CompanyName,
+			"company_domain": p.CompanyDomain,
+			"job_title":      p.JobTitle,
+		})
+	}
+	if history := historyFor(p.JobHistory); len(history) > 0 {
+		add(provider.ClaimJobHistory, history)
+	}
+	if p.Location != "" {
+		add(provider.ClaimLocation, p.Location)
+	}
+	if len(p.Departments) > 0 {
+		add(provider.ClaimDepartments, p.Departments)
+	}
+	if len(p.Seniorities) > 0 {
+		add(provider.ClaimSeniorities, p.Seniorities)
+	}
+	return claims
+}
+
+// splitEmails separates what the vendor labeled personal from everything
+// else. An address with NO type is professional: that is what the
+// professional cascade asked for, and the platform records that the label
+// came from the request rather than from Surfe (email_type is left absent
+// here, and the reader supplies the requested-cascade marker).
+func splitEmails(emails []wireEmail) (professional, personal []map[string]any) {
+	for _, e := range emails {
+		if e.Email == "" {
+			continue
+		}
+		entry := map[string]any{"value": e.Email}
+		if e.ValidationStatus != "" {
+			entry["validation_status"] = e.ValidationStatus
+		}
+		if e.EmailType != "" {
+			entry["email_type"] = e.EmailType
+		}
+		if e.EmailType == emailTypePersonal {
+			personal = append(personal, entry)
+			continue
+		}
+		professional = append(professional, entry)
+	}
+	return professional, personal
+}
+
+// mobilesFor keeps the number and the vendor's own confidence. The score is
+// carried rather than rounded to a band: it is the vendor's assertion, and
+// the display layer decides how much precision to show.
+func mobilesFor(phones []wireMobile) []map[string]any {
+	var out []map[string]any
+	for _, m := range phones {
+		if m.MobilePhone == "" {
+			continue
+		}
+		entry := map[string]any{"value": m.MobilePhone}
+		if m.ConfidenceScore != nil {
+			entry["confidence"] = *m.ConfidenceScore
+		}
+		out = append(out, entry)
+	}
+	return out
+}
+
+// historyFor normalizes past roles, dropping the empty strings Surfe returns
+// for fields it lacks and the entries that carry no employer at all — a role
+// with no company name is a line the page cannot render.
+func historyFor(jobs []wireJob) []map[string]any {
+	var out []map[string]any
+	for _, j := range jobs {
+		if j.CompanyName == "" {
+			continue
+		}
+		entry := map[string]any{"company_name": j.CompanyName}
+		if j.JobTitle != "" {
+			entry["job_title"] = j.JobTitle
+		}
+		if j.LinkedInURL != "" {
+			entry["linkedin_url"] = j.LinkedInURL
+		}
+		if started := monthOrDate(j.StartDate); started != "" {
+			entry["started_at"] = started
+		}
+		if ended := monthOrDate(j.EndDate); ended != "" {
+			entry["ended_at"] = ended
+		}
+		out = append(out, entry)
+	}
+	return out
+}
+
+// spendFor reports what Surfe actually charged, per pool.
+//
+// The vendor's response carries no cost figure, so this is derived from what
+// it RETURNED: an address costs an email credit, a mobile number costs a
+// mobile credit, and a category that came back empty costs nothing. That is
+// the same per-successful-result rule the billing basis declares, and the
+// reservation reconciles against it — a run that asked for both and got only
+// an email releases the mobile hold.
+func spendFor(p wireResult) map[provider.Pool]int {
+	spend := map[provider.Pool]int{}
+	for _, e := range p.Emails {
+		if e.Email != "" {
+			// The personal fallback costs two, per the descriptor's cascade.
+			if e.EmailType == emailTypePersonal {
+				spend[poolEmail] += 2
+				continue
+			}
+			spend[poolEmail]++
+		}
+	}
+	for _, m := range p.MobilePhones {
+		if m.MobilePhone != "" {
+			spend[poolMobile]++
+		}
+	}
+	return spend
+}

--- a/backend/internal/modules/integrations/surfe/surfe.go
+++ b/backend/internal/modules/integrations/surfe/surfe.go
@@ -1,0 +1,220 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+// Package surfe is the live Surfe adapter: the one place in this build that
+// speaks a vendor's wire protocol (ADR-0101, ARCH-SEAM-17).
+//
+// It translates a frozen request into Surfe's v2 asynchronous bulk-enrichment
+// API and its answer back into the bounded shape the platform stores. It
+// decides no policy, widens nothing that was requested, and never sees the
+// database — everything it knows about a subject arrives in the Request the
+// caller built.
+//
+// One person per request, though the endpoint accepts up to ten thousand.
+// The platform's unit of spend, of consent and of erasure is the RUN, and a
+// run is one subject: batching would tie several subjects' fates together, so
+// one refusal or one ambiguous answer would put every person in the batch
+// into the same unknown state.
+package surfe
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/gradionhq/margince/backend/internal/shared/ports/provider"
+)
+
+const (
+	// baseURL is the ONLY host this adapter may reach, and the descriptor
+	// below declares the same one. The check before each request compares
+	// against the descriptor, so the two cannot drift apart silently.
+	baseURL = "https://api.surfe.com"
+	// egressHost is what an outbound request's URL must resolve to.
+	egressHost = "api.surfe.com"
+
+	// requestTimeout bounds ONE call. Generous for a vendor round trip,
+	// far below the job's own two-minute ceiling, and finite because a hung
+	// vendor must not pin a worker: an expired call answers "ambiguous",
+	// which holds the reservation rather than retrying a possible charge.
+	requestTimeout = 10 * time.Second
+	// maxResponseBytes caps how much of a response is read. The bodies are
+	// small and bounded by construction (one person), so a stream that keeps
+	// going is a fault, not a large answer.
+	maxResponseBytes = 1 << 20
+)
+
+// The vocabulary this adapter speaks on both sides of the seam: the credit
+// pools Surfe meters, and the categories the platform sells against them.
+// Spelled once because the descriptor, the include-flag mapping and the spend
+// arithmetic must all name the same things — a typo in any one of them would
+// price or request a category that silently does not exist.
+const (
+	poolEmail  provider.Pool = "email"
+	poolMobile provider.Pool = "mobile"
+
+	categoryProfessionalEmail provider.Category = "professional_email"
+	categoryPersonalEmail     provider.Category = "personal_email"
+	categoryMobile            provider.Category = "mobile"
+	categoryLinkedInProfile   provider.Category = "linkedin_profile"
+	categoryCurrentEmployment provider.Category = "current_employment"
+	categoryJobHistory        provider.Category = "job_history"
+)
+
+// The vendor's own email-type vocabulary, which is not ours: "personal" is
+// what Surfe calls the fallback, and it appears both in what we ASK for and
+// in what it returns.
+const (
+	emailTypePersonal     = "personal"
+	emailTypeProfessional = "professional"
+)
+
+// HTTPDoer is the transport seam, so a test can answer with a recorded body
+// instead of reaching the network — the same shape webhooks.HTTPDoer takes.
+type HTTPDoer interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+// Adapter speaks Surfe. It holds no credential: the key arrives per call,
+// resolved from the vault at the execution boundary and never stored on
+// anything that outlives the request.
+type Adapter struct {
+	client HTTPDoer
+	now    func() time.Time
+}
+
+// New builds the adapter with the ordinary client. Surfe is a known vendor
+// host reached over TLS, so this is a plain timeout-bounded client rather
+// than the netguard-wrapped one an arbitrary customer-supplied URL needs.
+func New(now func() time.Time) *Adapter {
+	return &Adapter{client: &http.Client{Timeout: requestTimeout}, now: now}
+}
+
+// WithHTTPDoer swaps the transport, for tests that answer from a recorded
+// body rather than the network.
+func (a *Adapter) WithHTTPDoer(doer HTTPDoer) *Adapter {
+	a.client = doer
+	return a
+}
+
+var _ provider.Adapter = (*Adapter)(nil)
+
+// Descriptor is what the platform knows about Surfe without calling it.
+//
+// The cost table and the cascade come from the live calibration the offline
+// fake already encodes: a professional email costs one email credit, a mobile
+// costs one mobile credit, and the personal-email fallback costs two email
+// credits and cannot carry a mobile. The categories that cost nothing are
+// still declared, because a run must be able to REQUEST them.
+func (a *Adapter) Descriptor() provider.Descriptor {
+	return provider.Descriptor{
+		Name:        "surfe",
+		Transport:   provider.TransportPolled,
+		Billing:     provider.BillingPerSuccessfulResult,
+		CreditPools: []provider.Pool{poolEmail, poolMobile},
+		CostTable: map[provider.Category]map[provider.Pool]int{
+			categoryProfessionalEmail: {poolEmail: 1},
+			categoryPersonalEmail:     {},
+			categoryMobile:            {poolMobile: 1},
+			categoryLinkedInProfile:   {},
+			categoryCurrentEmployment: {},
+			categoryJobHistory:        {},
+		},
+		Cascades: []provider.Cascade{{
+			Category: categoryPersonalEmail,
+			After:    categoryProfessionalEmail,
+			Cost:     map[provider.Pool]int{poolEmail: 2},
+			Excludes: []provider.Category{categoryMobile},
+		}},
+		Identifiers:  []string{"LinkedIn profile URL", "first and last name with company name or domain"},
+		EgressHost:   egressHost,
+		Verification: "credit-balance read",
+		TermsLinks: []provider.Link{
+			{Label: "Terms", URL: "https://surfe.com/terms"},
+			{Label: "Privacy", URL: "https://surfe.com/privacy"},
+		},
+		Issuance: provider.IssuanceSelfService,
+		Categories: []provider.Category{
+			categoryProfessionalEmail, categoryMobile, categoryLinkedInProfile,
+			categoryCurrentEmployment, categoryJobHistory, categoryPersonalEmail,
+		},
+		Presets: map[string][]provider.Category{
+			"full": {
+				categoryProfessionalEmail, categoryMobile, categoryLinkedInProfile,
+				categoryCurrentEmployment, categoryJobHistory, categoryPersonalEmail,
+			},
+			"professional_only": {
+				categoryProfessionalEmail, categoryLinkedInProfile,
+				categoryCurrentEmployment, categoryJobHistory,
+			},
+		},
+		DefaultPreset: "full",
+	}
+}
+
+// call issues one request and decodes its body. The egress host is checked
+// HERE, immediately before the request leaves, because nothing else in the
+// platform enforces the descriptor's declared host — the check belongs where
+// the URL is final.
+// The body and the decode target are the only two things a caller varies, and
+// both are JSON shapes this package declares privately above — a constrained
+// type would name a union of six structs that exists nowhere else, and the
+// encoding library takes `any` regardless.
+//
+//craft:ignore naked-any the encoding/json boundary takes any; both arguments are this package's own wire structs.
+func (a *Adapter) call(ctx context.Context, cred provider.Credential, method, path string, body, out any) (int, error) {
+	var payload io.Reader
+	if body != nil {
+		encoded, err := json.Marshal(body)
+		if err != nil {
+			return 0, fmt.Errorf("surfe: encoding the request: %w", err)
+		}
+		payload = bytes.NewReader(encoded)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, baseURL+path, payload)
+	if err != nil {
+		return 0, fmt.Errorf("surfe: building the request: %w", err)
+	}
+	if req.URL.Host != egressHost {
+		// Unreachable while baseURL is a constant, and deliberately checked
+		// anyway: this adapter's whole disclosure to the customer is "it
+		// talks to api.surfe.com", and that promise should be enforced at
+		// the point of egress rather than by reading the source.
+		return 0, fmt.Errorf("surfe: refusing to call %q, which is not the declared egress host", req.URL.Host)
+	}
+	req.Header.Set("Authorization", "Bearer "+string(cred))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := a.client.Do(req)
+	if err != nil {
+		return 0, fmt.Errorf("surfe: %s %s: %w", method, path, err)
+	}
+	// Read, then close, both checked. Not a deferred close: a deferred one
+	// either discards its error or needs a named return to report it, and the
+	// body here is small and bounded, so reading it inline is simpler than
+	// either. Every return below this point has already closed.
+	raw, readErr := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
+	if closeErr := resp.Body.Close(); closeErr != nil && readErr == nil {
+		// Reported only where the read itself succeeded: a teardown fault
+		// must not overwrite the answer the caller actually needs.
+		return resp.StatusCode, fmt.Errorf("surfe: closing the response: %w", closeErr)
+	}
+	if readErr != nil {
+		return resp.StatusCode, fmt.Errorf("surfe: reading the response: %w", readErr)
+	}
+	if len(raw) == 0 {
+		return resp.StatusCode, nil
+	}
+	if err := json.Unmarshal(raw, out); err != nil {
+		// The vendor's body is NOT echoed: it may quote a fragment of the
+		// key we just sent, and an error a customer sees must carry a closed
+		// product reason instead.
+		return resp.StatusCode, fmt.Errorf("surfe: the response was not the documented JSON shape")
+	}
+	return resp.StatusCode, nil
+}

--- a/backend/internal/modules/integrations/surfe/surfe.go
+++ b/backend/internal/modules/integrations/surfe/surfe.go
@@ -87,11 +87,32 @@ type Adapter struct {
 	now    func() time.Time
 }
 
-// New builds the adapter with the ordinary client. Surfe is a known vendor
-// host reached over TLS, so this is a plain timeout-bounded client rather
-// than the netguard-wrapped one an arbitrary customer-supplied URL needs.
+// New builds the adapter. Surfe is a known vendor host reached over TLS, so
+// this is a timeout-bounded client rather than the netguard-wrapped one an
+// arbitrary customer-supplied URL needs — but it REFUSES REDIRECTS, which is
+// not optional here and is what every other outbound caller in this tree does
+// (identity's OAuth metadata fetch, the agent app fetch, webread).
+//
+// Go copies the Authorization header across a redirect to any subdomain of
+// the origin, so without this a 302 from api.surfe.com to anything.surfe.com
+// replays the customer's API key to whoever answered — a compromised vendor
+// edge, a hijacked subdomain, a DNS takeover. The egress-host check below
+// runs once, on the request this code builds; the standard library never
+// consults it again for a redirect hop, so the check alone does not hold.
+//
+// A redirect is also simply a fault: Surfe's documented API does not issue
+// one, and the descriptor promises the customer this adapter talks to exactly
+// one host.
 func New(now func() time.Time) *Adapter {
-	return &Adapter{client: &http.Client{Timeout: requestTimeout}, now: now}
+	return &Adapter{
+		client: &http.Client{
+			Timeout: requestTimeout,
+			CheckRedirect: func(req *http.Request, _ []*http.Request) error {
+				return fmt.Errorf("surfe: refusing a redirect to %q: the credential must not leave the declared egress host", req.URL.Host)
+			},
+		},
+		now: now,
+	}
 }
 
 // WithHTTPDoer swaps the transport, for tests that answer from a recorded

--- a/backend/internal/modules/integrations/surfe/surfe_test.go
+++ b/backend/internal/modules/integrations/surfe/surfe_test.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
@@ -308,6 +309,99 @@ func TestCredentialVerificationReadsTheBalanceAndNamesARefusal(t *testing.T) {
 	refused := &recorder{status: http.StatusUnauthorized, body: `{"message":"unauthorized"}`}
 	if _, err := testAdapter(refused).VerifyCredential(context.Background(), provider.Credential("bad")); err == nil {
 		t.Error("a refused key verified successfully, so it would be sealed and stored")
+	}
+}
+
+// The credential must not leave the declared host. Go copies the
+// Authorization header across a redirect to any SUBDOMAIN of the origin, so
+// without an explicit refusal a 302 from api.surfe.com to anything.surfe.com
+// replays the customer's key to whoever answered.
+func TestARedirectIsRefusedSoTheKeyCannotFollowIt(t *testing.T) {
+	var calls int
+	final := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"totalEmail":1,"totalMobile":1}`))
+	}))
+	defer final.Close()
+	redirector := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		http.Redirect(w, r, final.URL, http.StatusFound)
+	}))
+	defer redirector.Close()
+
+	// The REAL client and its real redirect policy — the thing under test.
+	a := New(time.Now)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, redirector.URL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer SUPERSECRET")
+	resp, err := a.client.Do(req)
+	if err == nil {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			t.Errorf("closing the unexpected response: %v", closeErr)
+		}
+		t.Fatal("the redirect was followed: the customer's key just reached a host the descriptor never declared")
+	}
+	if calls != 1 {
+		t.Errorf("%d servers were called, want 1 — only the declared host may be reached", calls)
+	}
+}
+
+// An unrecognized status is AMBIGUOUS, never a definite refusal: the request
+// reached the vendor and the work may be running and billable, so releasing
+// the hold would be the double-charge PI-AC-4 exists to prevent.
+func TestAnUnrecognizedStatusParksRatherThanReleasingTheHold(t *testing.T) {
+	for _, status := range []int{
+		http.StatusCreated,   // an ordinary answer for a job-creation endpoint
+		http.StatusNoContent, // what a proxy or WAF in front of the vendor emits
+		http.StatusRequestTimeout,
+		http.StatusConflict,
+	} {
+		rec := &recorder{status: status, body: `{}`}
+		sub, err := testAdapter(rec).Submit(context.Background(), provider.Credential("k"), aRequest())
+		if err != nil {
+			t.Fatalf("status %d: %v", status, err)
+		}
+		if sub.Outcome != provider.OutcomeAmbiguous {
+			t.Errorf("status %d → %s, want ambiguous: a definite refusal releases the credit hold on work the vendor may have done and charged for",
+				status, sub.Outcome)
+		}
+	}
+}
+
+// A poll whose body cannot be read settles nothing, so it reads as pending
+// rather than failing the whole workspace's sweep on every tick.
+func TestAnUnreadablePollReadsAsPendingRatherThanFailingTheSweep(t *testing.T) {
+	rec := &recorder{status: http.StatusOK, body: `{"status":"COMPLE`}
+	status, err := testAdapter(rec).Poll(context.Background(), provider.Credential("k"), "enr-9")
+	if err != nil {
+		t.Fatalf("an unreadable poll surfaced as an error, which fails the drain for every other run in the workspace: %v", err)
+	}
+	if status.Outcome != provider.OutcomePending {
+		t.Errorf("outcome = %s, want pending — an unread poll is an unfinished one, and the run's expiry is what ends it", status.Outcome)
+	}
+}
+
+// Surfe returns EVERY address it found from the one lookup the run paid for.
+// Charging per value would bill a well-documented person more than a thinly
+// documented one for the same question, and would exceed the reservation.
+func TestSpendIsOnePerPoolHoweverManyValuesComeBack(t *testing.T) {
+	body := `{"status":"COMPLETED","people":[{
+		"emails":[{"email":"a@example.com"},{"email":"anna@example.com"},{"email":"a.muster@example.com"}],
+		"mobilePhones":[{"mobilePhone":"+49 1"},{"mobilePhone":"+49 2"}]}]}`
+	rec := &recorder{status: http.StatusOK, body: body}
+	status, err := testAdapter(rec).Poll(context.Background(), provider.Credential("k"), "enr-9")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.Result == nil {
+		t.Fatal("a completed enrichment returned no result")
+	}
+	if status.Result.PoolSpend["email"] != 1 || status.Result.PoolSpend["mobile"] != 1 {
+		t.Errorf("pool spend = %v, want one credit per pool — three addresses came from ONE paid lookup, and charging per value would exceed the reservation the platform took",
+			status.Result.PoolSpend)
 	}
 }
 

--- a/backend/internal/modules/integrations/surfe/surfe_test.go
+++ b/backend/internal/modules/integrations/surfe/surfe_test.go
@@ -1,0 +1,328 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package surfe
+
+// The adapter against RECORDED wire shapes, taken from Surfe's published API
+// reference. No network: what these prove is that the translation in both
+// directions matches the documented contract, which is the only thing this
+// package is responsible for.
+//
+// The awkward parts of the real payload are the point — an absent emailType
+// under the professional cascade, empty strings where the vendor has no
+// value, month-precision job dates — because those are what a naive mapping
+// gets wrong and what the person page then renders as blanks or lies.
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gradionhq/margince/backend/internal/shared/ports/provider"
+)
+
+// recorder answers with a canned status and body, and keeps the request so a
+// test can assert what actually left.
+type recorder struct {
+	status int
+	body   string
+	err    error
+	seen   *http.Request
+	sent   string
+}
+
+func (r *recorder) Do(req *http.Request) (*http.Response, error) {
+	r.seen = req
+	if req.Body != nil {
+		raw, _ := io.ReadAll(req.Body)
+		r.sent = string(raw)
+	}
+	if r.err != nil {
+		return nil, r.err
+	}
+	return &http.Response{
+		StatusCode: r.status,
+		Body:       io.NopCloser(strings.NewReader(r.body)),
+		Header:     http.Header{},
+	}, nil
+}
+
+func testAdapter(rec *recorder) *Adapter {
+	return New(func() time.Time { return time.Date(2026, 8, 13, 12, 0, 0, 0, time.UTC) }).WithHTTPDoer(rec)
+}
+
+func aRequest() provider.Request {
+	return provider.Request{
+		CorrelationID: "corr-1",
+		Identifiers: provider.PersonIdentifiers{
+			FirstName: "Anna", LastName: "Muster", CompanyDomain: "example.com",
+		},
+		Categories: []provider.Category{"professional_email", "mobile", "job_history"},
+	}
+}
+
+// What leaves the installation is exactly the closed identifier set, under
+// the documented body shape, with the correlation id as the opaque handle.
+func TestSubmitSendsTheDocumentedBodyAndNothingElse(t *testing.T) {
+	rec := &recorder{status: http.StatusAccepted, body: `{"enrichmentID":"enr-9"}`}
+	sub, err := testAdapter(rec).Submit(context.Background(), provider.Credential("k"), aRequest())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sub.Outcome != provider.OutcomeAccepted || sub.ProviderJobID != "enr-9" {
+		t.Fatalf("submission = %+v, want accepted with the enrichment id", sub)
+	}
+	if got := rec.seen.URL.String(); got != "https://api.surfe.com/v2/people/enrich" {
+		t.Errorf("posted to %q, want the documented enrich endpoint", got)
+	}
+	if got := rec.seen.Header.Get("Authorization"); got != "Bearer k" {
+		t.Errorf("Authorization = %q, want the bearer form the API documents", got)
+	}
+
+	var body enrichRequest
+	if err := json.Unmarshal([]byte(rec.sent), &body); err != nil {
+		t.Fatalf("the request body is not the documented shape: %v", err)
+	}
+	if len(body.People) != 1 {
+		t.Fatalf("sent %d people, want exactly one — a run is one subject, and batching would tie their fates together", len(body.People))
+	}
+	person := body.People[0]
+	if person.FirstName != "Anna" || person.LastName != "Muster" || person.CompanyDomain != "example.com" {
+		t.Errorf("identifiers = %+v, want the ones the run froze", person)
+	}
+	if person.ExternalID != "corr-1" {
+		t.Error("the correlation id did not ride as externalID: a returned result cannot be matched back to its run")
+	}
+	// The request asked for no LinkedIn category, so the flag must be off —
+	// a flag beyond the request spends a credit the reservation does not
+	// cover.
+	if body.Include.LinkedInURL {
+		t.Error("linkedInUrl was requested though the run did not freeze that category")
+	}
+	if !body.Include.Email || !body.Include.Mobile || !body.Include.JobHistory {
+		t.Errorf("include = %+v, want the three categories the run froze", body.Include)
+	}
+	// No cascade was permitted, so the professional-only policy must reach
+	// the vendor rather than widening to personal.
+	if body.EnrichmentOptions.AcceptedEmailType != "professional" {
+		t.Errorf("acceptedEmailType = %q, want professional — the run permitted no personal fallback", body.EnrichmentOptions.AcceptedEmailType)
+	}
+}
+
+// The cascade the run froze is what widens the vendor's email policy.
+func TestAPermittedCascadeWidensTheEmailPolicy(t *testing.T) {
+	rec := &recorder{status: http.StatusAccepted, body: `{"enrichmentID":"enr-9"}`}
+	req := aRequest()
+	req.Cascades = []provider.Cascade{{Category: "personal_email", After: "professional_email"}}
+	if _, err := testAdapter(rec).Submit(context.Background(), provider.Credential("k"), req); err != nil {
+		t.Fatal(err)
+	}
+	var body enrichRequest
+	if err := json.Unmarshal([]byte(rec.sent), &body); err != nil {
+		t.Fatal(err)
+	}
+	if body.EnrichmentOptions.AcceptedEmailType != "personal" {
+		t.Errorf("acceptedEmailType = %q, want personal — the run's cascade permits the fallback", body.EnrichmentOptions.AcceptedEmailType)
+	}
+}
+
+// A transport failure after the request left is AMBIGUOUS, never a retry:
+// the charge may already have happened.
+func TestATransportFailureIsAmbiguousRatherThanAFailure(t *testing.T) {
+	rec := &recorder{err: context.DeadlineExceeded}
+	sub, err := testAdapter(rec).Submit(context.Background(), provider.Credential("k"), aRequest())
+	if err != nil {
+		t.Fatalf("a timeout surfaced as an error rather than an outcome: %v", err)
+	}
+	if sub.Outcome != provider.OutcomeAmbiguous {
+		t.Errorf("outcome = %s, want ambiguous — retrying a request that may have landed is how one charge becomes two", sub.Outcome)
+	}
+}
+
+// An accepted submission with no handle is unknown, not success: the work
+// may be running and can never be read back.
+func TestAcceptedWithNoHandleIsAmbiguous(t *testing.T) {
+	rec := &recorder{status: http.StatusAccepted, body: `{"enrichmentID":""}`}
+	sub, err := testAdapter(rec).Submit(context.Background(), provider.Credential("k"), aRequest())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sub.Outcome != provider.OutcomeAmbiguous {
+		t.Errorf("outcome = %s, want ambiguous: accepted work with no handle can never be polled", sub.Outcome)
+	}
+}
+
+// Every vendor refusal maps onto the closed product vocabulary, and the body
+// is never echoed.
+func TestVendorRefusalsMapOntoClosedProductCodes(t *testing.T) {
+	for _, c := range []struct {
+		status  int
+		outcome provider.Outcome
+		code    string
+	}{
+		{http.StatusUnauthorized, provider.OutcomeInvalidCredentials, "credential_rejected"},
+		{http.StatusForbidden, provider.OutcomeInvalidCredentials, "credential_rejected"},
+		{http.StatusPaymentRequired, provider.OutcomeInsufficientCredits, "provider_out_of_credits"},
+		{http.StatusTooManyRequests, provider.OutcomeRateLimited, "provider_rate_limited"},
+		{http.StatusInternalServerError, provider.OutcomeProviderError, "provider_error"},
+	} {
+		rec := &recorder{status: c.status, body: `{"message":"key sk-live-SECRET is invalid"}`}
+		sub, err := testAdapter(rec).Submit(context.Background(), provider.Credential("k"), aRequest())
+		if err != nil {
+			t.Fatalf("status %d: %v", c.status, err)
+		}
+		if sub.Outcome != c.outcome || sub.SafeStatusCode != c.code {
+			t.Errorf("status %d → %s/%s, want %s/%s", c.status, sub.Outcome, sub.SafeStatusCode, c.outcome, c.code)
+		}
+		if strings.Contains(sub.SafeStatusCode, "SECRET") {
+			t.Error("the vendor's body reached the safe status code, which may quote the key we just sent")
+		}
+	}
+}
+
+// A poll that is still running costs nothing and asserts nothing.
+func TestPollReportsPendingUntilTheVendorCompletes(t *testing.T) {
+	rec := &recorder{status: http.StatusOK, body: `{"status":"IN_PROGRESS","percentCompleted":40,"people":[]}`}
+	status, err := testAdapter(rec).Poll(context.Background(), provider.Credential("k"), "enr-9")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.Outcome != provider.OutcomePending {
+		t.Errorf("outcome = %s, want pending", status.Outcome)
+	}
+}
+
+// completedBody is the shape the reference documents, including the parts a
+// naive mapping gets wrong: an absent emailType, empty-string job-history
+// fields, and month-precision dates.
+const completedBody = `{
+  "enrichmentID": "enr-9",
+  "status": "COMPLETED",
+  "people": [{
+    "status": "COMPLETED",
+    "firstName": "Anna", "lastName": "Muster",
+    "emails": [{"email": "a.muster@example.com", "validationStatus": "valid"}],
+    "mobilePhones": [{"mobilePhone": "+49 170 0000000", "confidenceScore": 0.65}],
+    "linkedInUrl": "https://www.linkedin.com/in/example",
+    "jobTitle": "Head of Operations",
+    "companyName": "Example GmbH", "companyDomain": "example.com",
+    "jobHistory": [
+      {"companyName": "Vorherige AG", "jobTitle": "Operations Manager",
+       "linkedInURL": "", "startDate": "2019-01", "endDate": "2023-06"},
+      {"companyName": "", "jobTitle": "Intern", "linkedInURL": "", "startDate": "", "endDate": ""}
+    ],
+    "location": "Munich, Germany", "city": "Munich", "country": "Germany",
+    "departments": ["Operations"], "seniorities": ["Head"]
+  }]
+}`
+
+func claimByKey(t *testing.T, claims []provider.Claim, key provider.ClaimKey) provider.Claim {
+	t.Helper()
+	for _, c := range claims {
+		if c.Key == key {
+			return c
+		}
+	}
+	t.Fatalf("no %s claim in the normalized result", key)
+	return provider.Claim{}
+}
+
+func TestPollNormalizesTheAwkwardPartsOfTheRealPayload(t *testing.T) {
+	rec := &recorder{status: http.StatusOK, body: completedBody}
+	status, err := testAdapter(rec).Poll(context.Background(), provider.Credential("k"), "enr-9")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.Outcome != provider.OutcomeCompleted || status.Result == nil {
+		t.Fatalf("outcome = %s with result %v, want completed with a result", status.Outcome, status.Result)
+	}
+
+	// An address with NO emailType is professional by REQUEST, and the
+	// adapter must not invent the label — it leaves email_type absent and
+	// the reader marks it as requested-cascade.
+	var emails []map[string]any
+	if err := json.Unmarshal(claimByKey(t, status.Result.Claims, provider.ClaimProfessionalEmails).Value, &emails); err != nil {
+		t.Fatal(err)
+	}
+	if len(emails) != 1 || emails[0]["value"] != "a.muster@example.com" {
+		t.Fatalf("professional emails = %+v, want the one address returned", emails)
+	}
+	if _, claimed := emails[0]["email_type"]; claimed {
+		t.Error("the adapter asserted an email_type the vendor did not return — a request-context label must never masquerade as the provider's")
+	}
+
+	// Empty strings are absent, and an entry with no employer is dropped.
+	var history []map[string]any
+	if err := json.Unmarshal(claimByKey(t, status.Result.Claims, provider.ClaimJobHistory).Value, &history); err != nil {
+		t.Fatal(err)
+	}
+	if len(history) != 1 {
+		t.Fatalf("job history has %d entries, want 1 — the entry with no company name renders as a blank line", len(history))
+	}
+	if _, present := history[0]["linkedin_url"]; present {
+		t.Error("an empty-string LinkedIn URL was stored as a value: the vendor's empty string is an absent field, not a blank link")
+	}
+	if history[0]["started_at"] != "2019-01" {
+		t.Errorf("started_at = %v, want the month-precision date the vendor sends", history[0]["started_at"])
+	}
+
+	// What the run is charged for is derived from what came BACK, which is
+	// what per-successful-result billing means.
+	if status.Result.PoolSpend["email"] != 1 || status.Result.PoolSpend["mobile"] != 1 {
+		t.Errorf("pool spend = %v, want one credit per returned value", status.Result.PoolSpend)
+	}
+}
+
+// A completed enrichment that found nothing is a no-match, which releases
+// the whole reservation on per-successful-result billing.
+func TestACompletedEnrichmentWithNothingFoundIsANoMatch(t *testing.T) {
+	rec := &recorder{status: http.StatusOK, body: `{"status":"COMPLETED","people":[{"status":"NOT_FOUND","firstName":"Anna"}]}`}
+	status, err := testAdapter(rec).Poll(context.Background(), provider.Credential("k"), "enr-9")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.Outcome != provider.OutcomeNoMatch {
+		t.Errorf("outcome = %s, want no_match — an empty completion must release the hold, not read as a purchase", status.Outcome)
+	}
+}
+
+// The credential check is the credit read, and a refused key is its own
+// error so Connect can say "that key does not work".
+func TestCredentialVerificationReadsTheBalanceAndNamesARefusal(t *testing.T) {
+	rec := &recorder{status: http.StatusOK, body: `{"totalEmail":19,"totalMobile":4,"totalSearch":100}`}
+	credits, err := testAdapter(rec).VerifyCredential(context.Background(), provider.Credential("k"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if credits.Balances["email"] != 19 || credits.Balances["mobile"] != 4 {
+		t.Errorf("balances = %v, want the two pools the descriptor declares", credits.Balances)
+	}
+	if got := rec.seen.URL.Path; got != "/v1/credits" {
+		t.Errorf("read %q, want the documented credits endpoint", got)
+	}
+
+	refused := &recorder{status: http.StatusUnauthorized, body: `{"message":"unauthorized"}`}
+	if _, err := testAdapter(refused).VerifyCredential(context.Background(), provider.Credential("bad")); err == nil {
+		t.Error("a refused key verified successfully, so it would be sealed and stored")
+	}
+}
+
+// The descriptor's declared egress host is what the platform discloses to
+// the customer, so the adapter's own calls must honour it.
+func TestEveryCallGoesToTheDeclaredEgressHost(t *testing.T) {
+	a := New(time.Now)
+	if a.Descriptor().EgressHost != egressHost {
+		t.Fatalf("descriptor declares %q but the adapter calls %q", a.Descriptor().EgressHost, egressHost)
+	}
+	rec := &recorder{status: http.StatusOK, body: `{"totalEmail":1,"totalMobile":1}`}
+	if _, err := testAdapter(rec).Credits(context.Background(), provider.Credential("k")); err != nil {
+		t.Fatal(err)
+	}
+	if rec.seen.URL.Host != egressHost {
+		t.Errorf("called %q, want the declared egress host", rec.seen.URL.Host)
+	}
+}


### PR DESCRIPTION
PR-3 of the Surfe enrichment delivery (plan rev 5). Wire shapes taken from Surfe's published API reference (v2 async bulk enrichment), not guessed.

- `POST /v2/people/enrich` → handle; `GET /v2/people/enrich/{id}` → result; `GET /v1/credits` → balance and credential check.
- One person per request: a run is one subject, and batching would tie several subjects' fates together.
- A transport failure after the request left is **ambiguous, never retried** — that is how one ambiguous charge becomes two certain ones.
- An absent `emailType` is not invented; the vendor's empty strings become absent fields; the vendor's error body never reaches a customer-visible message.
- Spend derived from what came back, matching per-successful-result billing.

`MARGINCE_PROVIDER_SURFE=live` now registers it. Ten tests against recorded shapes, no network.

Local gates: full `make check` green, craft static clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the live `surfe` adapter and switches `MARGINCE_PROVIDER_SURFE=live` from refusing to registering it. Hardens transport and accounting to prevent API‑key leakage and double charges.

**Review notes**
- Uses Surfe’s async API: `POST /v2/people/enrich` (handle), `GET /v2/people/enrich/{id}` (poll), `GET /v1/credits` (balance/credential); one person per request.
- Refuses redirects and enforces egress host `api.surfe.com`; 10s request timeout; 1 MiB response cap.
- Status handling: only named refusals release holds (401/403 → invalid credential, 402 → out of credits, 429 → rate limited, 4xx/5xx provider faults); all other statuses and post-send failures return `OutcomeAmbiguous`; accepted-without-handle is ambiguous.
- Result normalization: does not invent `emailType`; drops empty strings; parses month-or-date job history; completed with no useful data → `NoMatch`.
- Spend and budget: charges one credit per returned pool; `reconcile` clamps actual spend to the hold; cascades issue only when both the requested category and its trigger were requested; unreadable poll → `Pending`; claim marshal failures surface.
- Descriptor: declares `email` and `mobile` pools, categories, and the professional→personal email cascade (personal excludes mobile); new parity test keeps the offline fake and live descriptor aligned.
- Tests use recorded shapes; no network.

**Rollout**
- Set `MARGINCE_PROVIDER_SURFE=live` and supply a Surfe API key; Connect verifies via credit read.
- No data migrations.

<sup>Written for commit 319ff3e6382034661d56d1a95445b9272f865de4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1110?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

