### PR TITLE
test(bothdoors): the exclusions state what actually keeps them out

### DIFF
--- a/backend/internal/compose/agentcommandbothdoors_test.go
+++ b/backend/internal/compose/agentcommandbothdoors_test.go
@@ -35,6 +35,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -282,6 +283,11 @@ var bothDoorsFixtures = map[string]bothDoorsFixture{
 // can spell — and a set built from the verb alone would demand a tool fixture
 // for an act the tool door has no way to ask for. A composed entry (`getPerson
 // + listActivities`) matches no operationId and drops out on its own.
+//
+// OpenAPIOp is hand-written prose beside each registration, so what it leaves
+// out is an editorial claim rather than a derived one:
+// assertEveryServedOperationIsComparedOrRatified holds the omissions this gate
+// depends on to the reason each of them costs.
 func twinnedOperations(served *agents.Registry) map[string]string {
 	twins := map[string]string{}
 	for op, route := range agentReachableMutations() {
@@ -297,6 +303,113 @@ func twinnedOperations(served *agents.Registry) map[string]string {
 		}
 	}
 	return twins
+}
+
+// notExpressibleByItsVerb ratifies an operation whose verb can stage and whose
+// verb does not put the route's record type outside its own scope — so nothing
+// about the verb's reach explains the omission — and which no call of that verb
+// can nonetheless be asked to perform, because the operation carries an operand
+// the verb's arguments have no member for.
+//
+// Each of the six is one of the bespoke confirm-first operations
+// (agentcommandoperand.go): a second operand that update_record's
+// {record_type, id, fields} cannot express is exactly what put them there, and
+// it is the same reason they cannot be twinned here. The other two of the eight
+// ride a record type update_record does not serve at all, so the verb answers
+// for them before any of this is asked.
+var notExpressibleByItsVerb = gatekit.Waive(map[string]string{
+	"confirmOrganizationFact": "the fact key is a path segment, and the confirm carries no body at all — " +
+		"an update_record call has no member to put it in and no fields to send",
+	"updateOrganizationFact": "the fact key is a path segment naming WHICH fact, where update_record's " +
+		"fields name an organization's own columns — the key is not one of them",
+	"confirmOrganizationProfileField": "the profile field name is a path segment, and the confirm sends no " +
+		"fields — update_record has no argument that says which field is being confirmed rather than written",
+	"updateOrganizationProfileField": "the path segment selects a CORRECTION of one profile field, and " +
+		"where that field is an organization column an update_record patch of it is the plain write — " +
+		"updateOrganization — with no provenance flip and no sidecar history, which no argument can ask for",
+	"setProjectStakeholder": "the stakeholder is an edge to a second record carrying its own role, which " +
+		"update_record's fields cannot spell — they write columns of the project the route names",
+	"removeProjectStakeholder": "the person is a second path parameter naming the edge to drop, and " +
+		"update_record has no argument for a record other than the one it patches",
+})
+
+// advertisedRecordTypes reads the record types a verb's own published
+// InputSchema names, which is the account of its scope a client actually holds
+// — the same published contract the fixtures above are written from.
+//
+// It is only half the question, because the enum is documentation rather than
+// admission (mcp.ToolSpec says so, and archive_record's own StageInfo repeats
+// it): a verb's guard can admit a type its schema never advertised. The caller
+// unions this with Registry.Performs, the derived answer, so a verb is treated
+// as acting on a record type when EITHER account says it does.
+//
+// An empty result means the verb published no record_type argument at all,
+// which is a verb whose scope is UNBOUNDED here rather than empty — the caller
+// reads it that way, and never as "serves nothing".
+func advertisedRecordTypes(t *testing.T, tool string, spec mcp.ToolSpec) []string {
+	t.Helper()
+	var published struct {
+		Properties struct {
+			RecordType struct {
+				Enum []string `json:"enum"`
+			} `json:"record_type"`
+		} `json:"properties"`
+	}
+	if err := json.Unmarshal(spec.InputSchema, &published); err != nil {
+		t.Fatalf("%s publishes an InputSchema that is not JSON, so what it admits cannot be read: %v", tool, err)
+	}
+	return published.Properties.RecordType.Enum
+}
+
+// assertEveryServedOperationIsComparedOrRatified holds the gate's largest
+// exclusion channel to the standard its smallest one already meets.
+//
+// An operation leaves this comparison three ways. Its verb cannot stage at all,
+// which TestEveryVerbTheFloorTightensCanStage already refuses to let happen to
+// a verb the contract tightens; its verb resolves its tier per call, which
+// dynamicTierVerbs ratifies; or OpenAPIOp does not name the operationId —
+// thirty-five of the sixty-nine mutating operations, which until now left in
+// silence. This ratifies the third.
+//
+// Only the omissions that could hide a defect are asked about, and the one
+// thing that makes an omission harmless is the verb's own scope EXCLUDING the
+// record type the route names: archive_record's schema names five record types
+// while twelve routes archive, and demanding a reason for the other seven would
+// be demanding one for the verb's own scope.
+//
+// So the skip turns on a verb being BOUNDED and this record type falling
+// outside the bound — never on the bound being unreadable. A fixed-type verb
+// takes no record_type argument and implements no ServesRecordType, so it
+// excludes nothing and every operation riding it must be compared or ratified.
+// Skipping on "the verb said nothing" instead would have exempted send_email,
+// promote_lead and book_meeting — the verbs with the most to lose from a
+// door-to-door disagreement — from the whole demand.
+func assertEveryServedOperationIsComparedOrRatified(t *testing.T, served *agents.Registry, twins map[string]string) {
+	t.Helper()
+	for op, route := range agentReachableMutations() {
+		if _, compared := twins[op]; compared {
+			continue
+		}
+		pol := agentPolicies[route]
+		spec, registered := served.Spec(pol.Tool)
+		if !registered || !served.Stageable(pol.Tool) {
+			continue
+		}
+		recordType := string(pol.RecordType)
+		advertised := advertisedRecordTypes(t, pol.Tool, spec)
+		bounded := len(advertised) > 0 || served.NamesRecordType(pol.Tool)
+		serves := slices.Contains(advertised, recordType) || served.Performs(pol.Tool, recordType)
+		if bounded && !serves {
+			continue
+		}
+		if !notExpressibleByItsVerb.Waived(t, op) {
+			t.Errorf("%s rides %s, which can stage and does not put %q outside its own scope, and %s's "+
+				"OpenAPIOp does not name the operation — so no two-door fixture is asked for and every "+
+				"comparison below is skipped for it. Either the verb can be asked to perform it, and the "+
+				"operationId belongs in its OpenAPIOp with a fixture here, or it cannot, and what stops it "+
+				"belongs in notExpressibleByItsVerb", op, pol.Tool, pol.RecordType, pol.Tool)
+		}
+	}
 }
 
 // bothDoorsRegistry is the tool door under test: the production registrations,
@@ -403,11 +516,13 @@ func agentDoorCtx() context.Context {
 
 func TestBothDoorsResolveOneOperationToOneCommand(t *testing.T) {
 	defer dynamicTierVerbs.AssertAllMatched(t)
+	defer notExpressibleByItsVerb.AssertAllMatched(t)
 	served := NewRegistry(nil, SendPath{})
 	twins := twinnedOperations(served)
 	if len(twins) == 0 {
 		t.Fatal("no operation has a stageable tool twin — this gate compared nothing")
 	}
+	assertEveryServedOperationIsComparedOrRatified(t, served, twins)
 	for op, tool := range twins {
 		fixture, written := bothDoorsFixtures[op]
 		if !written {


### PR DESCRIPTION
## What

`TestBothDoorsResolveOneOperationToOneCommand` decides who owes a cross-door fixture by
string-matching the operationId against `ToolSpec.OpenAPIOp` — a `/`-separated string written by
hand beside each tool registration. That filter excludes **35 of the 69** agent-reachable mutating
operations, and it excluded them in silence.

Most of those exclusions are sound: `archive_record`'s schema names five record types while twelve
routes archive, so `archiveTag` has no tool twin to compare against. But an operationId left out
because the verb genuinely cannot spell the operation and one left out because somebody forgot to
add it read **exactly alike**, and neither reached the ratification path `dynamicTierVerbs` already
holds the gate's other exclusion to.

`assertEveryServedOperationIsComparedOrRatified` now demands a stated reason for every exclusion the
verb's own scope does not already account for. Six operations qualify, and each now carries what
keeps it out.

## The predicate: bounded-and-outside, never "the verb said nothing"

The skip turns on a verb being **bounded** and the route's record type falling **outside** that
bound. Getting this backwards is what the two reviews caught, twice, in opposite directions.

A verb states its scope two ways, and neither alone is enough. `Registry.Performs` is the derived
answer, but it is only meaningful for a tool implementing `recordTypedTool` — `create_record` and
`update_record`, nothing else — so a `Performs`-only predicate left `archive_record` and
`merge_records` structurally exempt while the comment claimed it distinguished archive's five served
types from its seven unserved ones. `InputSchema`'s `record_type` enum is the published answer, and
it is documentation rather than admission: a verb's guard can admit a type the schema never
advertised. The predicate unions both.

And a verb that publishes **neither** is unbounded, not empty. A fixed-type verb — `send_email`,
`promote_lead`, `book_meeting` — takes no `record_type` argument and implements no
`ServesRecordType`, so it excludes nothing and every operation riding it must be compared or
ratified. Reading that silence as "serves nothing" would have exempted the four outbound verbs, the
ones with the most to lose from a door-to-door disagreement, from the entire demand.

## Verified red, five ways

Each arm was mutated against production code and confirmed to fail before being trusted:

1. A fixed-type verb's operation dropped from `OpenAPIOp` **and** its fixture deleted — the shape a
   newly added operation would wear. Green before this predicate, red now.
2. `archive_record`'s enum gains `activity` → `archiveActivity` reported unratified. Dead under a
   `Performs`-only predicate.
3. `updateOrganization` dropped from `update_record`'s `OpenAPIOp` — the forgotten-entry defect.
4. A ratified exclusion deleted → reported, naming the operation and both ways out.
5. A ratified exclusion gone stale because the verb learned to express it → reported twice, once as
   a missing fixture and once by `AssertAllMatched`.

## Review

Two independent reviews. Four findings, all fixed here:

- **The predicate skipped every fixed-record-type verb.** With `sendEmail` unnamed and its fixture
  removed, the gate passed while the operation stayed reachable on both doors — the exact silent
  exclusion this change exists to close. Fixed by skipping only on a bounded scope that excludes the
  type. (The counterexample as first reported still failed, via the pre-existing
  fixture-without-a-twin loop; the gap is real only for an operation with no fixture yet, which is
  the case that matters.)
- **The predicate was weaker than its comment claimed** for `archive_record` and `merge_records`.
  Fixed by widening the predicate, not by narrowing the prose.
- **`updateOrganizationProfileField`'s reason was false.** It said the profile field is "not a column
  of the organization `update_record` writes"; `ProfileFieldKey` admits `display_name`, `legal_name`
  and `industry`, all of them `UpdateOrganizationRequest` properties. The true reason is that the
  route selects a *correction* — a provenance flip with sidecar history — where an `update_record`
  patch of the same field resolves as the plain `updateOrganization` write, and no argument can ask
  for one rather than the other. A waiver stating a false reason is worse than no waiver.
- **"An operation leaves this comparison two ways" — there are three.** The third is a verb that
  cannot stage at all, already backstopped by `TestEveryVerbTheFloorTightensCanStage`. Counted now.

## Scope

Test-only: one file, no product code, no behaviour change. The six ratified exclusions are the same
six the gate excluded before this change — what is new is that the gate now knows why, and reports
a seventh.