### PR TITLE
feat(frontend): the provider surfaces — settings card, person section, company title hint

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -4339,4 +4339,95 @@ export const de = {
   "co.strip.healthSummary.failingOf": "{failing} von {rated} gefährdet",
   "co.strip.healthSummary.of": "{rated} von 3 bewertet",
   "today.source.suggestions": "die Empfehlungen",
+
+  // Der Datenanbieter (ADR-0101). Zwei Oberflächen teilen sich diese
+  // Begriffe — die Einstellungskarte und die Personenseite —, damit ein
+  // Zustand überall gleich heißt.
+  "provider.title": "Kontaktdaten",
+  "provider.sub":
+    "Geprüfte Kontaktdaten zu den Personen in Ihrem CRM zukaufen. Bezahlt wird beim Anbieter mit Guthaben; was davon hier verbraucht wurde, steht unten.",
+  "provider.notConfigured":
+    "In dieser Installation ist kein Datenanbieter verfügbar. Es wird nichts zugekauft, und es kann auch nichts zugekauft werden.",
+  "provider.status.connected": "Verbunden",
+  "provider.status.disconnected": "Nicht verbunden",
+  "provider.status.validating": "Schlüssel wird geprüft …",
+  "provider.status.invalidCredentials": "Schlüssel abgelehnt",
+  "provider.status.insufficientCredits": "Kein Guthaben mehr",
+  "provider.status.rateLimited": "Zu viele Anfragen",
+  "provider.status.providerError": "Beim Anbieter klemmt es gerade",
+  "provider.connect": "Verbinden",
+  "provider.reconnect": "Schlüssel ersetzen",
+  "provider.apiKey": "API-Schlüssel",
+  "provider.apiKeyHint":
+    "Wird nach der Prüfung sofort versiegelt. Er wird nie wieder angezeigt und verlässt diese Installation nur Richtung Anbieter.",
+  "provider.connectConfirm.title": "Datenanbieter verbinden?",
+  "provider.connectConfirm.body":
+    "Der Schlüssel wird beim Anbieter geprüft, bevor irgendetwas gespeichert wird. Ab dann kostet jede Anreicherung Guthaben.",
+  "provider.disconnect": "Trennen",
+  "provider.disconnectConfirm.title": "Verbindung trennen?",
+  "provider.disconnectConfirm.body":
+    "Neue Abfragen hören sofort auf, der Schlüssel wird vernichtet. Bereits gekaufte Daten bleiben an den Datensätzen — Trennen löscht nichts.",
+  "provider.deleteData": "Gekaufte Daten löschen",
+  "provider.deleteDataConfirm.title":
+    "Alles löschen, was von diesem Anbieter stammt?",
+  "provider.deleteDataConfirm.body":
+    "Jeder Wert dieses Anbieters verschwindet von jedem Kontakt. Was Sie ausgegeben haben, bleibt in den Aufzeichnungen; die Daten nicht. Das lässt sich nicht rückgängig machen.",
+  "provider.deleteDataConfirm.typed":
+    "Zum Bestätigen den Namen des Anbieters eingeben",
+  "provider.autoEnrich": "Neue Kontakte automatisch anreichern",
+  "provider.autoEnrichHint":
+    "Wenn jemand einen Kontakt von Hand anlegt, dessen Daten gleich mitkaufen.",
+  "provider.credits": "Restguthaben beim Anbieter",
+  "provider.credits.pool": "{pool}",
+  "provider.credits.none": "Der Anbieter hat uns noch keinen Stand genannt.",
+  "provider.constraints": "Geltende Grenzen",
+  "provider.mode": "Wann angereichert wird",
+  "provider.mode.automatic_on_create": "Sobald Kontakte entstehen",
+  "provider.mode.on_demand": "Nur auf Zuruf",
+  "provider.preset": "Was gekauft wird",
+
+  // Der Abschnitt auf der Personenseite. Die drei „nichts da"-Zustände sind
+  // mit Absicht drei verschiedene Sätze: nur bei einem davon kann der Leser
+  // etwas tun.
+  "provider.profile.title": "Zugekaufte Kontaktdaten",
+  "provider.profile.notConnected":
+    "Es ist kein Datenanbieter verbunden, also wurde nichts gekauft.",
+  "provider.profile.notEligible":
+    "Für diesen Kontakt nicht zulässig — er hat widersprochen, oder der Datensatz ist archiviert.",
+  "provider.profile.neverRun":
+    "Diesen Kontakt hat noch niemand nachgeschlagen.",
+  "provider.profile.queued": "In der Warteschlange",
+  "provider.profile.inProgress": "Wird nachgeschlagen …",
+  "provider.profile.completed": "Gefunden",
+  "provider.profile.noMatch": "Der Anbieter hatte nichts zu diesem Kontakt.",
+  "provider.profile.stale":
+    "Früher gekauft. Der Anbieter ist nicht mehr verbunden, eine Auffrischung ist deshalb nicht möglich.",
+  "provider.profile.invalidCredentials":
+    "Der Anbieter hat unseren Schlüssel abgelehnt, die Abfrage lief nicht.",
+  "provider.profile.insufficientCredits":
+    "Nicht gekauft: das Guthabenbudget für diesen Monat ist aufgebraucht.",
+  "provider.profile.rateLimited":
+    "Nicht gekauft: der Anbieter hat uns gebremst.",
+  "provider.profile.providerError": "Der Anbieter konnte nicht antworten.",
+  "provider.profile.submissionUnknown":
+    "Wie diese Abfrage ausgegangen ist, haben wir nie erfahren. Sie kann berechnet worden sein.",
+  "provider.profile.claimsUnwritten":
+    "Bezahlt, aber die Daten sind nie an diesem Datensatz angekommen. Niemand muss danach suchen — das hier ist die Lücke.",
+  "provider.profile.enrichNow": "Kontakt nachschlagen",
+  "provider.profile.emails": "E-Mail-Adressen",
+  "provider.profile.emailType.provider": "{type}, so vom Anbieter bezeichnet",
+  "provider.profile.emailType.requested":
+    "{type}, weil wir genau danach gefragt haben",
+  "provider.profile.mobiles": "Mobilnummern",
+  "provider.profile.confidence": "{percent} % Sicherheit",
+  "provider.profile.linkedin": "LinkedIn",
+  "provider.profile.employment": "Aktuelle Rolle",
+  "provider.profile.jobHistory": "Frühere Rollen",
+  "provider.profile.location": "Standort",
+  "provider.profile.departments": "Bereiche",
+  "provider.profile.seniorities": "Ebene",
+  "provider.profile.notRequested":
+    "Nicht angefragt: {categories}. Eine Lücke heißt hier, dass niemand danach gekauft hat — nicht, dass der Anbieter nichts hatte.",
+  "provider.profile.retrievedAt": "Gekauft am {date}",
+  "provider.profile.source": "Geliefert von {provider}",
 } as const satisfies Record<MessageKey, string>;

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -4334,6 +4334,95 @@ export const en = {
   "co.strip.healthSummary.failingOf": "{failing} of {rated} at risk",
   "co.strip.healthSummary.of": "{rated} of 3 rated",
   "today.source.suggestions": "the advice",
+
+  // The licensed data provider (ADR-0101). Two surfaces share this
+  // vocabulary — the Settings card and the person page — so a state reads
+  // the same wherever it appears.
+  "provider.title": "Contact data",
+  "provider.sub":
+    "Buy verified contact details for the people in your CRM. You pay the provider in credits; what you spend here is shown below.",
+  "provider.notConfigured":
+    "No data provider is available in this installation. Nothing is being bought and nothing can be.",
+  "provider.status.connected": "Connected",
+  "provider.status.disconnected": "Not connected",
+  "provider.status.validating": "Checking the key…",
+  "provider.status.invalidCredentials": "The key was refused",
+  "provider.status.insufficientCredits": "Out of credits",
+  "provider.status.rateLimited": "Rate limited",
+  "provider.status.providerError": "The provider is having trouble",
+  "provider.connect": "Connect",
+  "provider.reconnect": "Replace the key",
+  "provider.apiKey": "API key",
+  "provider.apiKeyHint":
+    "Sealed as soon as it is verified. It is never shown again, and never leaves this installation except to the provider.",
+  "provider.connectConfirm.title": "Connect this data provider?",
+  "provider.connectConfirm.body":
+    "The key is checked against the provider before anything is saved. Once connected, enriching a contact spends your credits.",
+  "provider.disconnect": "Disconnect",
+  "provider.disconnectConfirm.title": "Disconnect the provider?",
+  "provider.disconnectConfirm.body":
+    "New lookups stop immediately and the key is destroyed. Data already bought stays on your records — disconnecting is not deleting.",
+  "provider.deleteData": "Delete bought data",
+  "provider.deleteDataConfirm.title":
+    "Delete everything bought from this provider?",
+  "provider.deleteDataConfirm.body":
+    "Every value this provider supplied is removed from every contact. What you spent stays in your records; the data does not. This cannot be undone.",
+  "provider.deleteDataConfirm.typed": "Type the provider's name to confirm",
+  "provider.autoEnrich": "Enrich new contacts automatically",
+  "provider.autoEnrichHint":
+    "When somebody adds a contact by hand, buy their details straight away.",
+  "provider.credits": "Credits left with the provider",
+  "provider.credits.pool": "{pool}",
+  "provider.credits.none": "The provider has not told us a balance yet.",
+  "provider.constraints": "Limits in force",
+  "provider.mode": "When to enrich",
+  "provider.mode.automatic_on_create": "As contacts are added",
+  "provider.mode.on_demand": "Only when asked",
+  "provider.preset": "What to buy",
+
+  // The person page's section. The three "nothing here" states are three
+  // different sentences on purpose: only one of them is something the
+  // reader can act on.
+  "provider.profile.title": "Bought contact data",
+  "provider.profile.notConnected":
+    "No data provider is connected, so nothing has been bought.",
+  "provider.profile.notEligible":
+    "This contact is not eligible — they have objected, or the record is archived.",
+  "provider.profile.neverRun": "Nobody has looked this contact up yet.",
+  "provider.profile.queued": "Queued",
+  "provider.profile.inProgress": "Looking them up…",
+  "provider.profile.completed": "Found",
+  "provider.profile.noMatch": "The provider had nothing for this contact.",
+  "provider.profile.stale":
+    "Bought earlier. The provider is no longer connected, so this cannot be refreshed.",
+  "provider.profile.invalidCredentials":
+    "The provider refused our key, so this lookup could not run.",
+  "provider.profile.insufficientCredits":
+    "Not bought: the credit budget for this month is spent.",
+  "provider.profile.rateLimited":
+    "Not bought: the provider asked us to slow down.",
+  "provider.profile.providerError": "The provider could not answer.",
+  "provider.profile.submissionUnknown":
+    "We never learned how this lookup ended. It may have been charged for.",
+  "provider.profile.claimsUnwritten":
+    "Paid for, but the details never reached this record. Nobody has to hunt for them — this is the gap.",
+  "provider.profile.enrichNow": "Look this contact up",
+  "provider.profile.emails": "Email addresses",
+  "provider.profile.emailType.provider": "{type}, as the provider labelled it",
+  "provider.profile.emailType.requested":
+    "{type}, because that is what we asked for",
+  "provider.profile.mobiles": "Mobile numbers",
+  "provider.profile.confidence": "{percent}% confidence",
+  "provider.profile.linkedin": "LinkedIn",
+  "provider.profile.employment": "Current role",
+  "provider.profile.jobHistory": "Earlier roles",
+  "provider.profile.location": "Location",
+  "provider.profile.departments": "Departments",
+  "provider.profile.seniorities": "Seniority",
+  "provider.profile.notRequested":
+    "Not asked for: {categories}. A blank here means nobody bought it, not that the provider had nothing.",
+  "provider.profile.retrievedAt": "Bought {date}",
+  "provider.profile.source": "Provided by {provider}",
 } as const;
 
 export type MessageKey = keyof typeof en;

--- a/frontend/src/i18n/i18n.test.ts
+++ b/frontend/src/i18n/i18n.test.ts
@@ -38,6 +38,12 @@ const KEPT_IN_ENGLISH = new Set<string>([
   "ob.s4.provMicrosoft",
   "ob.conv.connect.linkedinName",
   "co.chip.linkedin",
+  // A bare placeholder: the credit pool's name comes from the PROVIDER's own
+  // vocabulary ("email", "mobile"), so there is no literal here to translate
+  // and a translation could only rename somebody else's pool.
+  "provider.credits.pool",
+  // The same proper noun as co.chip.linkedin, one surface over.
+  "provider.profile.linkedin",
   "person.page.linkedin",
   "auth.coreProviderAnthropic",
   "auth.coreProviderGemini",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -4326,4 +4326,91 @@ export const vi = {
   "co.strip.healthSummary.failingOf": "{failing}/{rated} đang gặp rủi ro",
   "co.strip.healthSummary.of": "{rated}/3 đã được đánh giá",
   "today.source.suggestions": "các đề xuất",
+
+  // Nhà cung cấp dữ liệu liên hệ (ADR-0101). Hai màn hình dùng chung bộ từ
+  // vựng này — thẻ Cài đặt và trang cá nhân — để một trạng thái luôn đọc
+  // giống nhau ở mọi nơi.
+  "provider.title": "Dữ liệu liên hệ",
+  "provider.sub":
+    "Mua thông tin liên hệ đã được xác minh cho những người trong CRM. Bạn trả cho nhà cung cấp bằng tín dụng; phần đã dùng ở đây được hiển thị bên dưới.",
+  "provider.notConfigured":
+    "Bản cài đặt này không có nhà cung cấp dữ liệu nào. Không có gì đang được mua và cũng không thể mua.",
+  "provider.status.connected": "Đã kết nối",
+  "provider.status.disconnected": "Chưa kết nối",
+  "provider.status.validating": "Đang kiểm tra khoá…",
+  "provider.status.invalidCredentials": "Khoá bị từ chối",
+  "provider.status.insufficientCredits": "Hết tín dụng",
+  "provider.status.rateLimited": "Bị giới hạn tần suất",
+  "provider.status.providerError": "Nhà cung cấp đang gặp sự cố",
+  "provider.connect": "Kết nối",
+  "provider.reconnect": "Thay khoá",
+  "provider.apiKey": "Khoá API",
+  "provider.apiKeyHint":
+    "Được niêm phong ngay sau khi xác minh. Khoá không bao giờ hiển thị lại và chỉ rời bản cài đặt này để đến nhà cung cấp.",
+  "provider.connectConfirm.title": "Kết nối nhà cung cấp dữ liệu này?",
+  "provider.connectConfirm.body":
+    "Khoá được kiểm tra với nhà cung cấp trước khi lưu bất cứ thứ gì. Sau khi kết nối, mỗi lần làm giàu dữ liệu sẽ tiêu tín dụng.",
+  "provider.disconnect": "Ngắt kết nối",
+  "provider.disconnectConfirm.title": "Ngắt kết nối nhà cung cấp?",
+  "provider.disconnectConfirm.body":
+    "Các lượt tra cứu mới dừng ngay lập tức và khoá bị huỷ. Dữ liệu đã mua vẫn ở lại trên hồ sơ — ngắt kết nối không phải là xoá.",
+  "provider.deleteData": "Xoá dữ liệu đã mua",
+  "provider.deleteDataConfirm.title": "Xoá mọi thứ đã mua từ nhà cung cấp này?",
+  "provider.deleteDataConfirm.body":
+    "Mọi giá trị nhà cung cấp này đã cấp sẽ bị gỡ khỏi mọi liên hệ. Khoản bạn đã chi vẫn được ghi lại; dữ liệu thì không. Không thể hoàn tác.",
+  "provider.deleteDataConfirm.typed": "Nhập tên nhà cung cấp để xác nhận",
+  "provider.autoEnrich": "Tự động làm giàu liên hệ mới",
+  "provider.autoEnrichHint":
+    "Khi ai đó thêm một liên hệ thủ công, mua luôn thông tin của họ.",
+  "provider.credits": "Tín dụng còn lại ở nhà cung cấp",
+  "provider.credits.pool": "{pool}",
+  "provider.credits.none": "Nhà cung cấp chưa cho biết số dư.",
+  "provider.constraints": "Giới hạn đang áp dụng",
+  "provider.mode": "Khi nào làm giàu",
+  "provider.mode.automatic_on_create": "Ngay khi liên hệ được tạo",
+  "provider.mode.on_demand": "Chỉ khi được yêu cầu",
+  "provider.preset": "Mua những gì",
+
+  // Phần trên trang cá nhân. Ba trạng thái "không có gì" là ba câu khác
+  // nhau có chủ đích: chỉ một trong số đó là điều người đọc có thể xử lý.
+  "provider.profile.title": "Dữ liệu liên hệ đã mua",
+  "provider.profile.notConnected":
+    "Chưa kết nối nhà cung cấp dữ liệu nào, nên chưa mua gì cả.",
+  "provider.profile.notEligible":
+    "Liên hệ này không đủ điều kiện — họ đã phản đối, hoặc hồ sơ đã được lưu trữ.",
+  "provider.profile.neverRun": "Chưa ai tra cứu liên hệ này.",
+  "provider.profile.queued": "Trong hàng đợi",
+  "provider.profile.inProgress": "Đang tra cứu…",
+  "provider.profile.completed": "Đã tìm thấy",
+  "provider.profile.noMatch": "Nhà cung cấp không có gì về liên hệ này.",
+  "provider.profile.stale":
+    "Đã mua trước đây. Nhà cung cấp không còn kết nối nên không thể làm mới.",
+  "provider.profile.invalidCredentials":
+    "Nhà cung cấp từ chối khoá của chúng ta nên lượt tra cứu không chạy.",
+  "provider.profile.insufficientCredits":
+    "Không mua: ngân sách tín dụng tháng này đã hết.",
+  "provider.profile.rateLimited":
+    "Không mua: nhà cung cấp yêu cầu chúng ta chậm lại.",
+  "provider.profile.providerError": "Nhà cung cấp không thể trả lời.",
+  "provider.profile.submissionUnknown":
+    "Chúng ta không bao giờ biết lượt tra cứu này kết thúc ra sao. Nó có thể đã bị tính phí.",
+  "provider.profile.claimsUnwritten":
+    "Đã trả tiền, nhưng thông tin chưa bao giờ đến hồ sơ này. Không ai phải đi tìm — đây chính là chỗ thiếu.",
+  "provider.profile.enrichNow": "Tra cứu liên hệ này",
+  "provider.profile.emails": "Địa chỉ email",
+  "provider.profile.emailType.provider": "{type}, theo nhãn của nhà cung cấp",
+  "provider.profile.emailType.requested":
+    "{type}, vì đó là thứ chúng ta đã hỏi",
+  "provider.profile.mobiles": "Số di động",
+  "provider.profile.confidence": "Độ tin cậy {percent}%",
+  "provider.profile.linkedin": "LinkedIn",
+  "provider.profile.employment": "Vai trò hiện tại",
+  "provider.profile.jobHistory": "Vai trò trước đây",
+  "provider.profile.location": "Địa điểm",
+  "provider.profile.departments": "Bộ phận",
+  "provider.profile.seniorities": "Cấp bậc",
+  "provider.profile.notRequested":
+    "Không hỏi tới: {categories}. Chỗ trống ở đây nghĩa là không ai mua, chứ không phải nhà cung cấp không có.",
+  "provider.profile.retrievedAt": "Mua ngày {date}",
+  "provider.profile.source": "Do {provider} cung cấp",
 } as const satisfies Record<MessageKey, string>;

--- a/frontend/src/screens/company360.tsx
+++ b/frontend/src/screens/company360.tsx
@@ -23,6 +23,7 @@ import {
 } from "../design-system/atoms";
 import { AvatarStack } from "../design-system/avatarstack";
 import { type TimelineEntry, TimelineRow } from "../design-system/composed";
+import { EvidenceMark } from "../design-system/evidencemark";
 import { Panel, PanelBody, PanelRow } from "../design-system/panel";
 import { Select } from "../design-system/select";
 import {
@@ -31,7 +32,6 @@ import {
   formatMoney,
   formatMoneyCompact,
 } from "../format/format";
-
 import { type Locale, useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import {
@@ -973,8 +973,12 @@ function ContactRow({
   // badges — "Sales Manager · Champion on Pilot" is one fact about who this
   // person is, and a badge per clause said the same thing louder than it
   // needed to.
+  // A purchased title fills the gap where nobody typed one (PO-EXT-9). The
+  // server decides that — it sends provider_title only where the canonical
+  // one is empty — so this reads the field rather than re-deciding the
+  // precedence, which is how the two would come to disagree.
   const subline = [
-    contact.title,
+    contact.title ?? contact.provider_title,
     ...roles.map((entry) => {
       const deal = nameOfDeal(entry.deal_id);
       return deal
@@ -999,7 +1003,23 @@ function ContactRow({
         >
           {contact.full_name}
         </button>
-        {subline && <span className="co-person-sub">{subline}</span>}
+        {subline && (
+          <span className="co-person-sub">
+            {/* ONE mark, on the whole line, and only where the title was
+                bought. A mark per clause would turn a quiet subline into a
+                run of badges, which is what this line was written to avoid. */}
+            {contact.title_source === "provider" ? (
+              <EvidenceMark
+                value={subline}
+                source={{
+                  provenance: { kind: "connector", connector: "provider" },
+                }}
+              />
+            ) : (
+              subline
+            )}
+          </span>
+        )}
       </span>
       <span className="co-person-end">
         {/* Where this person stands with us. "No reply" and "never asked"

--- a/frontend/src/screens/companyrail.tsx
+++ b/frontend/src/screens/companyrail.tsx
@@ -3,6 +3,7 @@ import { api } from "../api/client";
 import type { components } from "../api/schema";
 import { Avatar, Badge, Disclosure } from "../design-system/atoms";
 import { AvatarStack } from "../design-system/avatarstack";
+import { EvidenceMark } from "../design-system/evidencemark";
 import { Panel, PanelBody, PanelRow } from "../design-system/panel";
 import { Meter } from "../design-system/readings";
 import { formatDate } from "../format/format";
@@ -283,8 +284,22 @@ function PersonRow({ contact }: Readonly<{ contact: Contact }>) {
       <Avatar name={contact.full_name} tinted />
       <span className="co-person-id">
         <span className="co-person-name">{contact.full_name}</span>
-        {contact.title && (
-          <span className="co-person-role">{contact.title}</span>
+        {/* The same fallback the tab makes, because a rail that disagreed
+            with the tab about somebody's role is worse than neither showing
+            one. The server decides the precedence; both surfaces read it. */}
+        {(contact.title ?? contact.provider_title) && (
+          <span className="co-person-role">
+            {contact.title_source === "provider" ? (
+              <EvidenceMark
+                value={contact.provider_title ?? ""}
+                source={{
+                  provenance: { kind: "connector", connector: "provider" },
+                }}
+              />
+            ) : (
+              contact.title
+            )}
+          </span>
         )}
       </span>
       {colleagues.length > 0 && (

--- a/frontend/src/screens/companyrail.tsx
+++ b/frontend/src/screens/companyrail.tsx
@@ -28,6 +28,7 @@ import { DetailsGrid } from "./companyraildetails";
 import { SectionSummary, sectionAnswered } from "./companyrailshared";
 import { TagsSection } from "./companyrailtags";
 import { byReach } from "./coverage";
+import { roleOf } from "./provider-status";
 
 // The record page's LEFT rail (mockup State A): the account's context,
 // beside the work rather than under it. Passed to RecordView's `rail` slot,
@@ -286,18 +287,21 @@ function PersonRow({ contact }: Readonly<{ contact: Contact }>) {
         <span className="co-person-name">{contact.full_name}</span>
         {/* The same fallback the tab makes, because a rail that disagreed
             with the tab about somebody's role is worse than neither showing
-            one. The server decides the precedence; both surfaces read it. */}
-        {(contact.title ?? contact.provider_title) && (
+            one. The server decides the precedence; both surfaces read it.
+            Branched on the VALUE, not on title_source — that field is
+            optional, and a server sending a purchased title without it would
+            otherwise render an empty, padded span. */}
+        {roleOf(contact) && (
           <span className="co-person-role">
             {contact.title_source === "provider" ? (
               <EvidenceMark
-                value={contact.provider_title ?? ""}
+                value={roleOf(contact)}
                 source={{
                   provenance: { kind: "connector", connector: "provider" },
                 }}
               />
             ) : (
-              contact.title
+              roleOf(contact)
             )}
           </span>
         )}

--- a/frontend/src/screens/integrations-provider.tsx
+++ b/frontend/src/screens/integrations-provider.tsx
@@ -1,0 +1,404 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Database, Plug, Trash2 } from "lucide-react";
+import { useState } from "react";
+import { api } from "../api/client";
+import type { components } from "../api/schema";
+import {
+  Badge,
+  Button,
+  Card,
+  Checkbox,
+  EmptyState,
+  Field,
+  TextInput,
+} from "../design-system/atoms";
+import { Callout } from "../design-system/callout";
+import { ConfirmModal } from "../design-system/confirmmodal";
+import { Meter } from "../design-system/readings";
+import { useT } from "../i18n";
+import {
+  problemCode,
+  problemMessageOf,
+  QueryGate,
+  throwProblem,
+} from "./common";
+import { connectionLabel, connectionTone } from "./provider-status";
+
+// The licensed-data-provider card (ADR-0101, PI-WIRE-1..5): connect a key,
+// see what the provider says is left, decide whether new contacts are
+// enriched automatically, and — separately — stop the flow or destroy what
+// was bought.
+//
+// Disconnect and delete-data are two buttons because they are two decisions.
+// Disconnecting stops new lookups and destroys the key; the data already paid
+// for stays on the records. A customer may want either without the other, and
+// a single button would make one of them a surprise.
+
+type ProviderConnection = components["schemas"]["ProviderConnection"];
+
+type ConnectionsResult = {
+  /** True when this build carries no adapter at all. Not an error: it is the
+   *  supported "no provider" configuration, and the card says so plainly
+   *  rather than showing a broken control (PI-AC-9). */
+  notConfigured: boolean;
+  connections: ProviderConnection[];
+};
+
+function useProviderConnections() {
+  return useQuery({
+    queryKey: ["provider-connections"],
+    queryFn: async (): Promise<ConnectionsResult> => {
+      const { data, error, response } = await api.GET("/provider-connections");
+      // 501 is a deployment fact, not a failure — the same shape connectors.tsx
+      // uses for a connector nobody configured.
+      if (response.status === 501 && problemCode(error) === "not_implemented") {
+        return { notConfigured: true, connections: [] };
+      }
+      if (error || !response.ok) {
+        throwProblem(error);
+      }
+      return { notConfigured: false, connections: data?.data ?? [] };
+    },
+  });
+}
+
+export function ProviderCard() {
+  const t = useT();
+  const query = useProviderConnections();
+  return (
+    <Card>
+      <h2>{t("provider.title")}</h2>
+      <p className="muted">{t("provider.sub")}</p>
+      <QueryGate query={query}>
+        {(result) =>
+          result.notConfigured ? (
+            <EmptyState>{t("provider.notConfigured")}</EmptyState>
+          ) : (
+            <>
+              {result.connections.map((connection) => (
+                <ProviderConnectionRow
+                  key={connection.provider}
+                  connection={connection}
+                />
+              ))}
+            </>
+          )
+        }
+      </QueryGate>
+    </Card>
+  );
+}
+
+function ProviderConnectionRow({
+  connection,
+}: Readonly<{ connection: ProviderConnection }>) {
+  const t = useT();
+  return (
+    <section className="pe-card">
+      <header
+        style={{ display: "flex", alignItems: "center", gap: "var(--space-2)" }}
+      >
+        <Database aria-hidden />
+        <strong>{connection.provider}</strong>
+        <Badge tone={connectionTone(connection.status)}>
+          {t(connectionLabel(connection.status))}
+        </Badge>
+      </header>
+      <CreditsBlock connection={connection} />
+      <PolicyBlock connection={connection} />
+      <CredentialBlock connection={connection} />
+    </section>
+  );
+}
+
+// What the PROVIDER says is left — their number, never ours. A customer may
+// spend the same credits through the provider's own app, so this is a reading
+// of their ledger and the card never presents it as our accounting.
+function CreditsBlock({
+  connection,
+}: Readonly<{ connection: ProviderConnection }>) {
+  const t = useT();
+  // Iterated, never hardcoded to email/mobile: the pool names are the
+  // PROVIDER's own vocabulary, and a second provider meters different ones.
+  const pools = Object.entries(connection.credits?.pools ?? {});
+  if (pools.length === 0) {
+    return <p className="muted">{t("provider.credits.none")}</p>;
+  }
+  const highest = Math.max(1, ...pools.map(([, balance]) => balance ?? 0));
+  return (
+    <div>
+      <h3>{t("provider.credits")}</h3>
+      {pools.map(([pool, balance]) => (
+        <div key={pool}>
+          <span>{t("provider.credits.pool", { pool })}</span>
+          <Meter
+            value={balance ?? 0}
+            max={highest}
+            label={String(balance ?? 0)}
+          />
+        </div>
+      ))}
+      {(connection.effective_constraints ?? []).length > 0 && (
+        <p className="muted">
+          {t("provider.constraints")}:{" "}
+          {(connection.effective_constraints ?? []).join(", ")}
+        </p>
+      )}
+    </div>
+  );
+}
+
+function usePatchConfiguration(provider: string, version: number) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (automaticIndividualCreate: boolean) => {
+      const { data, error } = await api.PATCH(
+        "/provider-connections/{provider}",
+        {
+          params: {
+            path: { provider: provider as ProviderConnection["provider"] },
+            // The saved policy carries a version, and a blind write would
+            // silently overwrite a colleague's edit. A 409 is version skew,
+            // which the refetch below resolves by showing what is actually
+            // stored.
+            header: { "If-Match": String(version) },
+          },
+          body: {
+            configuration: {
+              automatic_individual_create: automaticIndividualCreate,
+            },
+          },
+        },
+      );
+      if (error) {
+        throwProblem(error);
+      }
+      return data;
+    },
+    onSuccess: (updated) => {
+      queryClient.setQueryData(
+        ["provider-connections"],
+        (current: ConnectionsResult | undefined) =>
+          current
+            ? {
+                ...current,
+                connections: current.connections.map((c) =>
+                  c.provider === updated?.provider ? updated : c,
+                ),
+              }
+            : current,
+      );
+    },
+    onError: () => {
+      void queryClient.invalidateQueries({
+        queryKey: ["provider-connections"],
+      });
+    },
+  });
+}
+
+function PolicyBlock({
+  connection,
+}: Readonly<{ connection: ProviderConnection }>) {
+  const t = useT();
+  const patch = usePatchConfiguration(connection.provider, connection.version);
+  const configuration = connection.configuration;
+  return (
+    <div>
+      <Checkbox
+        checked={configuration.automatic_individual_create ?? false}
+        disabled={patch.isPending || connection.status !== "connected"}
+        onChange={(event) => patch.mutate(event.target.checked)}
+        label={t("provider.autoEnrich")}
+      />
+      <p className="muted">{t("provider.autoEnrichHint")}</p>
+      {patch.error && (
+        <Callout tone="danger">{problemMessageOf(patch.error, t)}</Callout>
+      )}
+    </div>
+  );
+}
+
+function CredentialBlock({
+  connection,
+}: Readonly<{ connection: ProviderConnection }>) {
+  const t = useT();
+  const queryClient = useQueryClient();
+  const [key, setKey] = useState("");
+  const [confirming, setConfirming] = useState(false);
+  const [disconnecting, setDisconnecting] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [typed, setTyped] = useState("");
+
+  const connect = useMutation({
+    mutationFn: async () => {
+      const { error } = await api.PUT("/provider-connections/{provider}", {
+        params: { path: { provider: connection.provider } },
+        body: { api_key: key },
+      });
+      if (error) {
+        throwProblem(error);
+      }
+    },
+    onSuccess: () => {
+      // The key never lives in this component longer than the request: it is
+      // sealed server-side and never returned, so holding it would keep a
+      // secret in the page for no purpose.
+      setKey("");
+      setConfirming(false);
+      void queryClient.invalidateQueries({
+        queryKey: ["provider-connections"],
+      });
+    },
+  });
+
+  const disconnect = useMutation({
+    mutationFn: async () => {
+      const { error } = await api.DELETE("/provider-connections/{provider}", {
+        params: { path: { provider: connection.provider } },
+      });
+      if (error) {
+        throwProblem(error);
+      }
+    },
+    onSuccess: () => {
+      setDisconnecting(false);
+      void queryClient.invalidateQueries({
+        queryKey: ["provider-connections"],
+      });
+    },
+  });
+
+  const deleteData = useMutation({
+    mutationFn: async () => {
+      const { error } = await api.DELETE(
+        "/provider-connections/{provider}/data",
+        {
+          params: { path: { provider: connection.provider } },
+        },
+      );
+      if (error) {
+        throwProblem(error);
+      }
+    },
+    onSuccess: () => {
+      setDeleting(false);
+      setTyped("");
+      void queryClient.invalidateQueries({
+        queryKey: ["provider-connections"],
+      });
+    },
+  });
+
+  const connected = connection.credential_present;
+  return (
+    <div>
+      <form
+        className="form-stack"
+        onSubmit={(event) => {
+          event.preventDefault();
+          if (key.trim() !== "") {
+            setConfirming(true);
+          }
+        }}
+      >
+        <Field label={t("provider.apiKey")} hint={t("provider.apiKeyHint")}>
+          {(control) => (
+            <TextInput
+              {...control}
+              type="password"
+              autoComplete="off"
+              value={key}
+              required
+              onChange={(event) => setKey(event.target.value)}
+            />
+          )}
+        </Field>
+        <div style={{ display: "flex", gap: "var(--space-2)" }}>
+          <Button
+            small
+            variant="primary"
+            type="submit"
+            disabled={key.trim() === ""}
+          >
+            <Plug aria-hidden />{" "}
+            {connected ? t("provider.reconnect") : t("provider.connect")}
+          </Button>
+          {connected && (
+            <>
+              <Button
+                small
+                variant="danger"
+                type="button"
+                onClick={() => setDisconnecting(true)}
+              >
+                {t("provider.disconnect")}
+              </Button>
+              <Button
+                small
+                variant="danger"
+                type="button"
+                onClick={() => setDeleting(true)}
+              >
+                <Trash2 aria-hidden /> {t("provider.deleteData")}
+              </Button>
+            </>
+          )}
+        </div>
+      </form>
+      {connect.error && (
+        <Callout tone="danger">{problemMessageOf(connect.error, t)}</Callout>
+      )}
+
+      <ConfirmModal
+        open={confirming}
+        title={t("provider.connectConfirm.title")}
+        confirmLabel={t("provider.connect")}
+        onConfirm={() => connect.mutate()}
+        onClose={() => setConfirming(false)}
+        pending={connect.isPending}
+      >
+        {t("provider.connectConfirm.body")}
+      </ConfirmModal>
+
+      <ConfirmModal
+        open={disconnecting}
+        confirmVariant="danger"
+        title={t("provider.disconnectConfirm.title")}
+        confirmLabel={t("provider.disconnect")}
+        onConfirm={() => disconnect.mutate()}
+        onClose={() => setDisconnecting(false)}
+        pending={disconnect.isPending}
+      >
+        {t("provider.disconnectConfirm.body")}
+      </ConfirmModal>
+
+      {/* Typed confirmation, like the data reset: this destroys purchased
+          data on every contact, and a misclick must not be able to do it. */}
+      <ConfirmModal
+        open={deleting}
+        confirmVariant="danger"
+        title={t("provider.deleteDataConfirm.title")}
+        confirmLabel={t("provider.deleteData")}
+        confirmDisabled={typed !== connection.provider}
+        onConfirm={() => deleteData.mutate()}
+        pending={deleteData.isPending}
+        onClose={() => {
+          setDeleting(false);
+          setTyped("");
+        }}
+      >
+        <p>{t("provider.deleteDataConfirm.body")}</p>
+        <Field label={t("provider.deleteDataConfirm.typed")}>
+          {(control) => (
+            <TextInput
+              {...control}
+              value={typed}
+              onChange={(event) => setTyped(event.target.value)}
+            />
+          )}
+        </Field>
+      </ConfirmModal>
+    </div>
+  );
+}

--- a/frontend/src/screens/integrations-provider.tsx
+++ b/frontend/src/screens/integrations-provider.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Database, Plug, Trash2 } from "lucide-react";
 import { useState } from "react";
@@ -71,7 +74,12 @@ export function ProviderCard() {
       <p className="muted">{t("provider.sub")}</p>
       <QueryGate query={query}>
         {(result) =>
-          result.notConfigured ? (
+          // An empty list means the same thing a 501 does: no adapter is
+          // compiled in. The server returns a row for every REGISTERED
+          // provider — including one nobody has connected yet, which is how
+          // the key field appears at all — so "no rows" cannot mean "not
+          // connected", and both cases read as the honest no-provider state.
+          result.notConfigured || result.connections.length === 0 ? (
             <EmptyState>{t("provider.notConfigured")}</EmptyState>
           ) : (
             <>
@@ -148,7 +156,10 @@ function CreditsBlock({
   );
 }
 
-function usePatchConfiguration(provider: string, version: number) {
+function usePatchConfiguration(
+  provider: ProviderConnection["provider"],
+  version: number,
+) {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: async (automaticIndividualCreate: boolean) => {
@@ -156,7 +167,7 @@ function usePatchConfiguration(provider: string, version: number) {
         "/provider-connections/{provider}",
         {
           params: {
-            path: { provider: provider as ProviderConnection["provider"] },
+            path: { provider },
             // The saved policy carries a version, and a blind write would
             // silently overwrite a colleague's edit. A 409 is version skew,
             // which the refetch below resolves by showing what is actually

--- a/frontend/src/screens/persondrawers.tsx
+++ b/frontend/src/screens/persondrawers.tsx
@@ -19,6 +19,7 @@ import {
 } from "../design-system/atoms";
 import { useT } from "../i18n";
 import { throwProblem } from "./common";
+import { PersonProviderSection } from "./personprovider";
 
 // Only http(s) may become a link. A provider-supplied URL is untrusted input,
 // and a javascript: or data: href executes the moment a reader clicks it.
@@ -191,11 +192,16 @@ export function PersonComposer({
 export function PersonResearchDrawer({
   personId,
   personName,
+  providerProfile,
   open,
   onClose,
 }: Readonly<{
   personId: string;
   personName: string;
+  // What a licensed provider was PAID to tell us about this person
+  // (ADR-0101). Passed in rather than fetched here: the page already holds
+  // the assembled 360, and a second read could disagree with what it shows.
+  providerProfile?: components["schemas"]["PersonProviderProfile"];
   open: boolean;
   onClose: () => void;
 }>) {
@@ -253,6 +259,11 @@ export function PersonResearchDrawer({
       </div>
 
       <div className="drawer-body">
+        {/* What was BOUGHT sits above what a public read found: it cost
+            money, it is the firmer of the two, and a rep looking somebody up
+            should see it before a page crawl's guesses. */}
+        <PersonProviderSection personId={personId} profile={providerProfile} />
+
         {run.isLoading && (
           <p className="pe-prose">{t("person.research.running")}</p>
         )}

--- a/frontend/src/screens/personpage.tsx
+++ b/frontend/src/screens/personpage.tsx
@@ -279,6 +279,7 @@ export function PersonPageV2({
         <PersonResearchDrawer
           personId={id}
           personName={person.full_name}
+          providerProfile={view.data.provider_profile}
           open={drawer === "research"}
           onClose={() => setDrawer(null)}
         />

--- a/frontend/src/screens/personprovider.tsx
+++ b/frontend/src/screens/personprovider.tsx
@@ -1,0 +1,246 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Search } from "lucide-react";
+import { api } from "../api/client";
+import type { components } from "../api/schema";
+import { Badge, Button } from "../design-system/atoms";
+import { EvidenceMark } from "../design-system/evidencemark";
+import { useT } from "../i18n";
+import {
+  canEnrichNow,
+  isRunning,
+  profileLabel,
+  profileTone,
+} from "./provider-status";
+
+// What a licensed data provider was PAID to tell us about this person
+// (ADR-0101), shown BESIDE the canonical record and never folded into it.
+//
+// Every value carries a provenance mark, because a bought value and one a
+// colleague typed are different kinds of fact and a page that renders them
+// alike invites a rep to treat a purchase as a confirmation.
+
+type Person360 = components["schemas"]["Person360"];
+type Profile = components["schemas"]["PersonProviderProfile"];
+
+/** The mark every value in this section carries: bought from a named third
+ *  party, on a date. `connector` rather than `agent` — nothing inferred this,
+ *  somebody sold it to us. */
+function boughtFrom(profile: Profile) {
+  return {
+    provenance: {
+      kind: "connector" as const,
+      connector: profile.provider ?? "provider",
+    },
+    at: profile.retrieved_at ?? null,
+  };
+}
+
+export function PersonProviderSection({
+  personId,
+  profile,
+}: Readonly<{ personId: string; profile: Profile | undefined }>) {
+  const t = useT();
+  if (!profile) {
+    // Absent means the caller lacks the grant — `sections_omitted` names it —
+    // which is not the same as empty, so the section stays away entirely
+    // rather than claiming this person has nothing.
+    return null;
+  }
+  return (
+    <section className="pe-card">
+      <header
+        style={{ display: "flex", alignItems: "center", gap: "var(--space-2)" }}
+      >
+        <h3>{t("provider.profile.title")}</h3>
+        <Badge tone={profileTone(profile.state)}>
+          {t(profileLabel(profile.state))}
+        </Badge>
+      </header>
+      <ProviderValues profile={profile} />
+      <EnrichNow personId={personId} profile={profile} />
+    </section>
+  );
+}
+
+function ProviderValues({ profile }: Readonly<{ profile: Profile }>) {
+  const t = useT();
+  const source = boughtFrom(profile);
+  return (
+    <>
+      {profile.emails.length > 0 && (
+        <div>
+          <h4>{t("provider.profile.emails")}</h4>
+          {profile.emails.map((email) => (
+            <div key={email.value}>
+              <EvidenceMark value={email.value} source={source} />
+              {email.email_type && (
+                <span className="muted">
+                  {/* Which label this is, and WHOSE it is. An address the
+                      provider did not classify is labelled from what we
+                      asked for, and saying so is the whole point of the
+                      distinction. */}
+                  {email.email_type_source === "provider"
+                    ? t("provider.profile.emailType.provider", {
+                        type: email.email_type,
+                      })
+                    : t("provider.profile.emailType.requested", {
+                        type: email.email_type,
+                      })}
+                </span>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+      {profile.mobile_phones.length > 0 && (
+        <div>
+          <h4>{t("provider.profile.mobiles")}</h4>
+          {profile.mobile_phones.map((phone) => (
+            <div key={phone.value}>
+              <EvidenceMark value={phone.value} source={source} />
+              {phone.confidence != null && (
+                <span className="muted">
+                  {t("provider.profile.confidence", {
+                    percent: String(Math.round(phone.confidence * 100)),
+                  })}
+                </span>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+      {profile.linkedin_url && (
+        <div>
+          <h4>{t("provider.profile.linkedin")}</h4>
+          <EvidenceMark value={profile.linkedin_url} source={source} />
+        </div>
+      )}
+      {profile.current_employment && (
+        <div>
+          <h4>{t("provider.profile.employment")}</h4>
+          <EvidenceMark
+            value={[
+              profile.current_employment.job_title,
+              profile.current_employment.company_name,
+            ]
+              .filter(Boolean)
+              .join(" · ")}
+            source={source}
+          />
+        </div>
+      )}
+      {profile.job_history.length > 0 && (
+        <div>
+          <h4>{t("provider.profile.jobHistory")}</h4>
+          {profile.job_history.map((job) => (
+            <div key={`${job.company_name}-${job.job_title ?? ""}`}>
+              <EvidenceMark
+                value={[job.job_title, job.company_name]
+                  .filter(Boolean)
+                  .join(" · ")}
+                source={source}
+              />
+            </div>
+          ))}
+        </div>
+      )}
+      {profile.location && (
+        <div>
+          <h4>{t("provider.profile.location")}</h4>
+          <EvidenceMark value={profile.location} source={source} />
+        </div>
+      )}
+      {profile.departments.length > 0 && (
+        <div>
+          <h4>{t("provider.profile.departments")}</h4>
+          <EvidenceMark
+            value={profile.departments.join(", ")}
+            source={source}
+          />
+        </div>
+      )}
+      {profile.seniorities.length > 0 && (
+        <div>
+          <h4>{t("provider.profile.seniorities")}</h4>
+          <EvidenceMark
+            value={profile.seniorities.join(", ")}
+            source={source}
+          />
+        </div>
+      )}
+      {profile.categories_not_requested.length > 0 && (
+        // The difference between "we asked and they had nothing" and "we
+        // never asked". Without this line a blank field reads as the first
+        // when it is often the second.
+        <p className="muted">
+          {t("provider.profile.notRequested", {
+            categories: profile.categories_not_requested.join(", "),
+          })}
+        </p>
+      )}
+    </>
+  );
+}
+
+function EnrichNow({
+  personId,
+  profile,
+}: Readonly<{ personId: string; profile: Profile }>) {
+  const t = useT();
+  const queryClient = useQueryClient();
+
+  const enrich = useMutation({
+    mutationFn: async () => {
+      const { data, error } = await api.POST("/people/{id}/enrichment-runs", {
+        params: { path: { id: personId } },
+        body: { provider: profile.provider ?? "surfe" },
+      });
+      if (error) {
+        throw error;
+      }
+      return data;
+    },
+    onSuccess: () => {
+      // The run is durable and the provider has not been called yet, so the
+      // page re-reads and the poll below picks the run up from there.
+      void queryClient.invalidateQueries({ queryKey: ["person360", personId] });
+    },
+  });
+
+  // While a run is moving, ask again — and ONLY while it is moving. Polling a
+  // terminal run spends requests to learn nothing.
+  useQuery({
+    queryKey: ["person360-provider-poll", personId],
+    queryFn: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: ["person360", personId],
+      });
+      return null;
+    },
+    enabled: isRunning(profile.state),
+    refetchInterval: 2500,
+  });
+
+  if (!canEnrichNow(profile.state)) {
+    return null;
+  }
+  return (
+    <Button
+      small
+      type="button"
+      disabled={enrich.isPending}
+      onClick={() => enrich.mutate()}
+    >
+      <Search size={15} aria-hidden="true" /> {t("provider.profile.enrichNow")}
+    </Button>
+  );
+}
+
+/** The section's own read of the assembled page, for a caller that already
+ *  holds it. Exported so personpage can pass what it fetched rather than the
+ *  section fetching the whole 360 again. */
+export function providerProfileOf(
+  view: Person360 | undefined,
+): Profile | undefined {
+  return view?.provider_profile;
+}

--- a/frontend/src/screens/personprovider.tsx
+++ b/frontend/src/screens/personprovider.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Search } from "lucide-react";
 import { api } from "../api/client";
@@ -5,6 +8,7 @@ import type { components } from "../api/schema";
 import { Badge, Button } from "../design-system/atoms";
 import { EvidenceMark } from "../design-system/evidencemark";
 import { useT } from "../i18n";
+import { throwProblem } from "./common";
 import {
   canEnrichNow,
   isRunning,
@@ -19,7 +23,6 @@ import {
 // colleague typed are different kinds of fact and a page that renders them
 // alike invites a rep to treat a purchase as a confirmation.
 
-type Person360 = components["schemas"]["Person360"];
 type Profile = components["schemas"]["PersonProviderProfile"];
 
 /** The mark every value in this section carries: bought from a named third
@@ -58,8 +61,20 @@ export function PersonProviderSection({
       </header>
       <ProviderValues profile={profile} />
       <EnrichNow personId={personId} profile={profile} />
+      <RunWatch personId={personId} profile={profile} />
     </section>
   );
+}
+
+// A component rather than a hook call in the section, so the watch mounts
+// only where a profile exists — the section returns early without one, and a
+// hook cannot sit behind that return.
+function RunWatch({
+  personId,
+  profile,
+}: Readonly<{ personId: string; profile: Profile }>) {
+  useRunWatch(personId, profile);
+  return null;
 }
 
 function ProviderValues({ profile }: Readonly<{ profile: Profile }>) {
@@ -202,23 +217,9 @@ function EnrichNow({
     },
     onSuccess: () => {
       // The run is durable and the provider has not been called yet, so the
-      // page re-reads and the poll below picks the run up from there.
+      // page re-reads and RunWatch picks the run up from there.
       void queryClient.invalidateQueries({ queryKey: ["person360", personId] });
     },
-  });
-
-  // While a run is moving, ask again — and ONLY while it is moving. Polling a
-  // terminal run spends requests to learn nothing.
-  useQuery({
-    queryKey: ["person360-provider-poll", personId],
-    queryFn: async () => {
-      await queryClient.invalidateQueries({
-        queryKey: ["person360", personId],
-      });
-      return null;
-    },
-    enabled: isRunning(profile.state),
-    refetchInterval: 2500,
   });
 
   if (!canEnrichNow(profile.state)) {
@@ -236,11 +237,48 @@ function EnrichNow({
   );
 }
 
-/** The section's own read of the assembled page, for a caller that already
- *  holds it. Exported so personpage can pass what it fetched rather than the
- *  section fetching the whole 360 again. */
-export function providerProfileOf(
-  view: Person360 | undefined,
-): Profile | undefined {
-  return view?.provider_profile;
+/** Watches a run that is still moving and refreshes the page when it lands.
+ *
+ *  It polls the RUN, not the page, and reads whether to continue from the
+ *  response it just received — which is the only version that can stop
+ *  itself. Deciding from the `profile` prop instead would freeze the answer
+ *  at whatever state mounted the poll: the prop only changes when the page
+ *  refetches, which is the thing the poll exists to cause.
+ */
+function useRunWatch(personId: string, profile: Profile) {
+  const queryClient = useQueryClient();
+  const runId = profile.latest_run?.id;
+  useQuery({
+    queryKey: ["provider-run", personId, runId],
+    queryFn: async () => {
+      const { data, error } = await api.GET(
+        "/people/{id}/enrichment-runs/{run_id}",
+        { params: { path: { id: personId, run_id: runId ?? "" } } },
+      );
+      if (error) {
+        throwProblem(error);
+      }
+      // A run that has stopped moving is the page's cue to re-read: the
+      // claims land in the same transaction as the terminal state, so by
+      // now the section has something new to show.
+      if (data && !RUNNING_RUN_STATES.has(data.state)) {
+        void queryClient.invalidateQueries({
+          queryKey: ["person360", personId],
+        });
+      }
+      return data;
+    },
+    enabled: runId != null && isRunning(profile.state),
+    refetchInterval: (query) =>
+      query.state.data && RUNNING_RUN_STATES.has(query.state.data.state)
+        ? 2500
+        : false,
+  });
 }
+
+/** The run states that are still moving. `submitting` counts: the run is
+ *  mid-flight to the provider, and treating it as finished would offer a
+ *  second "look them up" while the first is still out. */
+const RUNNING_RUN_STATES = new Set<
+  components["schemas"]["ProviderRun"]["state"]
+>(["queued", "submitting", "in_progress"]);

--- a/frontend/src/screens/provider-status.test.ts
+++ b/frontend/src/screens/provider-status.test.ts
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import { describe, expect, it } from "vitest";
+import { en } from "../i18n/en";
+import {
+  canEnrichNow,
+  connectionLabel,
+  connectionTone,
+  isRunning,
+  type ProviderConnectionStatus,
+  type ProviderProfileState,
+  profileLabel,
+  profileTone,
+  roleOf,
+} from "./provider-status";
+
+// The status vocabulary two surfaces share. TypeScript proves the maps are
+// TOTAL — a state added to the contract fails the build — but not that any
+// entry is RIGHT: pointing `stale` at the completed message compiles clean and
+// ships a page that says data is current when it is not.
+//
+// So these tests assert the things the type system cannot: that every state
+// resolves to a real message, that the two "is a run moving" answers agree,
+// and that the tones say what the states mean.
+
+const CONNECTION_STATUSES: ProviderConnectionStatus[] = [
+  "connected",
+  "disconnected",
+  "validating",
+  "invalid_credentials",
+  "insufficient_credits",
+  "rate_limited",
+  "provider_error",
+];
+
+const PROFILE_STATES: ProviderProfileState[] = [
+  "not_connected",
+  "not_eligible",
+  "never_run",
+  "queued",
+  "in_progress",
+  "completed",
+  "no_match",
+  "stale",
+  "invalid_credentials",
+  "insufficient_credits",
+  "rate_limited",
+  "provider_error",
+  "submission_unknown",
+  "completed_claims_unwritten",
+];
+
+describe("the provider status vocabulary", () => {
+  it("resolves every state to a message that exists", () => {
+    for (const status of CONNECTION_STATUSES) {
+      expect(en[connectionLabel(status)], status).toBeTruthy();
+    }
+    for (const state of PROFILE_STATES) {
+      expect(en[profileLabel(state)], state).toBeTruthy();
+    }
+  });
+
+  it("gives every state its own sentence", () => {
+    // Two states sharing one message is how "the budget ran out" comes to
+    // read as "this person is not eligible" — a fact about the wallet
+    // rendered as a fact about the human.
+    const messages = PROFILE_STATES.map((state) => en[profileLabel(state)]);
+    expect(new Set(messages).size).toBe(PROFILE_STATES.length);
+  });
+
+  it("never offers a second purchase while one is in flight", () => {
+    // THE money invariant of this module. A run that is still moving cannot
+    // be bought again — the live-run index refuses it — so offering the
+    // button teaches a rep to click something that does nothing, and any
+    // state where both answers were true would be a double-spend invitation.
+    for (const state of PROFILE_STATES) {
+      if (isRunning(state)) {
+        expect(canEnrichNow(state), state).toBe(false);
+      }
+    }
+  });
+
+  it("offers the purchase exactly where one could succeed", () => {
+    // not_connected has nobody to ask; not_eligible has been refused for
+    // this subject. Every other terminal state is a fair retry.
+    expect(canEnrichNow("not_connected")).toBe(false);
+    expect(canEnrichNow("not_eligible")).toBe(false);
+    expect(canEnrichNow("never_run")).toBe(true);
+    expect(canEnrichNow("no_match")).toBe(true);
+    expect(canEnrichNow("completed")).toBe(true);
+    expect(canEnrichNow("provider_error")).toBe(true);
+  });
+
+  it("colours a refused key as danger and an unconnected provider as neither", () => {
+    // A provider nobody connected is a configuration, not a fault: painting
+    // it red tells an operator to fix something that is not broken. A
+    // refused key IS broken and nothing will work until somebody rotates it.
+    expect(connectionTone("invalid_credentials")).toBe("danger");
+    expect(connectionTone("disconnected")).toBeUndefined();
+    expect(connectionTone("connected")).toBe("success");
+    // Recoverable vendor conditions warn rather than alarm.
+    expect(connectionTone("rate_limited")).toBe("warn");
+    expect(connectionTone("insufficient_credits")).toBe("warn");
+  });
+
+  it("warns on a charge with nothing to show for it", () => {
+    // Paid, and the values never arrived. Neither a success nor a failure,
+    // and the one state somebody has to actually see.
+    expect(profileTone("completed_claims_unwritten")).toBe("warn");
+    // The outcome was never learned, and the run may have been charged.
+    expect(profileTone("submission_unknown")).toBe("warn");
+    // Bought earlier and no longer refreshable — real data, stale label.
+    expect(profileTone("stale")).toBe("warn");
+    expect(profileTone("completed")).toBe("success");
+  });
+
+  it("reads the same three empty states as three different things", () => {
+    const empties = ["not_connected", "not_eligible", "never_run"] as const;
+    const messages = empties.map((state) => en[profileLabel(state)]);
+    expect(new Set(messages).size).toBe(3);
+    // None of them alarms: an empty section is not a fault.
+    for (const state of empties) {
+      expect(profileTone(state), state).toBeUndefined();
+    }
+  });
+});
+
+describe("the roster's job title", () => {
+  it("prefers what a human typed over what was bought", () => {
+    expect(roleOf({ title: "Head of Ops", provider_title: "VP Sales" })).toBe(
+      "Head of Ops",
+    );
+  });
+
+  it("fills a gap with the purchased title", () => {
+    expect(roleOf({ title: null, provider_title: "VP Sales" })).toBe(
+      "VP Sales",
+    );
+  });
+
+  it("answers empty when there is no title at all", () => {
+    // The callers render nothing on an empty string. Returning undefined
+    // would work too; an empty string is what keeps `{roleOf(c) && …}` from
+    // rendering a padded, wordless element.
+    expect(roleOf({ title: null, provider_title: null })).toBe("");
+  });
+});

--- a/frontend/src/screens/provider-status.ts
+++ b/frontend/src/screens/provider-status.ts
@@ -114,6 +114,23 @@ export function profileLabel(state: ProviderProfileState): MessageKey {
   return PROFILE_LABEL[state];
 }
 
+/** The job title a company roster shows for one contact: what a human typed,
+ *  or a purchased one filling the gap (PO-EXT-9).
+ *
+ *  Both the tab and the rail read it, because a rail that disagreed with the
+ *  tab about somebody's role is worse than neither showing one. It branches
+ *  on the VALUE rather than on title_source, which is optional — a server
+ *  sending a purchased title without the discriminator must not leave an
+ *  empty, padded element behind. */
+export function roleOf(
+  contact: Pick<
+    components["schemas"]["Organization360Contact"],
+    "title" | "provider_title"
+  >,
+): string {
+  return contact.title ?? contact.provider_title ?? "";
+}
+
 /** Whether this state means a run is still moving, so the page should keep
  *  asking. Everything else is terminal: polling a completed or refused run
  *  spends requests to learn nothing. */

--- a/frontend/src/screens/provider-status.ts
+++ b/frontend/src/screens/provider-status.ts
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import type { components } from "../api/schema";
+import type { MessageKey } from "../i18n/en";
+
+// The licensed-data-provider status vocabulary, in one place because two
+// surfaces render it: the Settings card says whether the connection works,
+// and the person page says what happened to one subject's enrichment. The
+// same word must mean the same thing on both — a card reading "connected"
+// beside a person page reading "not connected" is a bug the reader cannot
+// diagnose.
+//
+// Extracted as a pure module, like connector-status.ts, so the mapping can be
+// tested without rendering anything.
+
+type ProviderConnection = components["schemas"]["ProviderConnection"];
+type PersonProviderProfile = components["schemas"]["PersonProviderProfile"];
+
+export type ProviderConnectionStatus = ProviderConnection["status"];
+export type ProviderProfileState = PersonProviderProfile["state"];
+
+/** The tone a status carries, in the design system's own Badge vocabulary so
+ *  a caller passes it straight through rather than mapping twice.
+ *
+ *  `undefined` is the neutral tone and is deliberately NOT `danger`: a
+ *  provider nobody connected is a configuration, not a fault, and colouring
+ *  it red tells an operator to fix something that is not broken. */
+export type StatusTone = "success" | "warn" | "danger" | undefined;
+
+const CONNECTION_TONE: Record<ProviderConnectionStatus, StatusTone> = {
+  connected: "success",
+  disconnected: undefined,
+  validating: undefined,
+  // The key was refused. Danger rather than warning: nothing will work until
+  // a human rotates it, and no amount of waiting helps.
+  invalid_credentials: "danger",
+  // Recoverable provider conditions. The connection is intact and the key is
+  // good; the vendor is refusing this moment's work.
+  insufficient_credits: "warn",
+  rate_limited: "warn",
+  provider_error: "warn",
+};
+
+const CONNECTION_LABEL: Record<ProviderConnectionStatus, MessageKey> = {
+  connected: "provider.status.connected",
+  disconnected: "provider.status.disconnected",
+  validating: "provider.status.validating",
+  invalid_credentials: "provider.status.invalidCredentials",
+  insufficient_credits: "provider.status.insufficientCredits",
+  rate_limited: "provider.status.rateLimited",
+  provider_error: "provider.status.providerError",
+};
+
+export function connectionTone(status: ProviderConnectionStatus): StatusTone {
+  return CONNECTION_TONE[status];
+}
+
+export function connectionLabel(status: ProviderConnectionStatus): MessageKey {
+  return CONNECTION_LABEL[status];
+}
+
+// The person page's fourteen states. Three of them mean "nothing here" and
+// they are deliberately three: nobody connected a provider, this person is
+// not eligible for one, and nobody has asked yet are different answers to
+// "why is this empty", and only one of them is something the reader can act
+// on.
+const PROFILE_TONE: Record<ProviderProfileState, StatusTone> = {
+  not_connected: undefined,
+  not_eligible: undefined,
+  never_run: undefined,
+  queued: undefined,
+  in_progress: undefined,
+  completed: "success",
+  no_match: undefined,
+  // The data is real but old enough that the platform will not vouch for it —
+  // or the provider was disconnected and it can no longer be refreshed.
+  stale: "warn",
+  invalid_credentials: "danger",
+  insufficient_credits: "warn",
+  rate_limited: "warn",
+  provider_error: "warn",
+  // The outcome was never learned, and the run may have been charged for.
+  submission_unknown: "warn",
+  // Paid, and the values never reached the record. Its own state because it
+  // is neither a success nor a failure: somebody was charged and has nothing
+  // to show for it, which a person needs to SEE rather than discover as
+  // missing data.
+  completed_claims_unwritten: "warn",
+};
+
+const PROFILE_LABEL: Record<ProviderProfileState, MessageKey> = {
+  not_connected: "provider.profile.notConnected",
+  not_eligible: "provider.profile.notEligible",
+  never_run: "provider.profile.neverRun",
+  queued: "provider.profile.queued",
+  in_progress: "provider.profile.inProgress",
+  completed: "provider.profile.completed",
+  no_match: "provider.profile.noMatch",
+  stale: "provider.profile.stale",
+  invalid_credentials: "provider.profile.invalidCredentials",
+  insufficient_credits: "provider.profile.insufficientCredits",
+  rate_limited: "provider.profile.rateLimited",
+  provider_error: "provider.profile.providerError",
+  submission_unknown: "provider.profile.submissionUnknown",
+  completed_claims_unwritten: "provider.profile.claimsUnwritten",
+};
+
+export function profileTone(state: ProviderProfileState): StatusTone {
+  return PROFILE_TONE[state];
+}
+
+export function profileLabel(state: ProviderProfileState): MessageKey {
+  return PROFILE_LABEL[state];
+}
+
+/** Whether this state means a run is still moving, so the page should keep
+ *  asking. Everything else is terminal: polling a completed or refused run
+ *  spends requests to learn nothing. */
+export function isRunning(state: ProviderProfileState): boolean {
+  return state === "queued" || state === "in_progress";
+}
+
+/** Whether an "enrich now" button should be offered. Not while one is
+ *  running — a second click cannot buy a second answer, the live-run index
+ *  refuses it — and not where no provider is connected, since there is
+ *  nothing to ask. */
+export function canEnrichNow(state: ProviderProfileState): boolean {
+  return (
+    state !== "not_connected" && state !== "not_eligible" && !isRunning(state)
+  );
+}

--- a/frontend/src/screens/settings.tsx
+++ b/frontend/src/screens/settings.tsx
@@ -88,6 +88,7 @@ import { EmbedReindexCard } from "./embedreindex";
 import { EntityRef } from "./entityref";
 import { ExtensionAccessCard } from "./extension-access";
 import { InstallationSettingsCard } from "./installation-settings";
+import { ProviderCard } from "./integrations-provider";
 import { LinkedInImportCard } from "./linkedin-import";
 import { LinkedInReachCard } from "./linkedin-reach";
 import { OverlayCard } from "./overlay";
@@ -216,6 +217,7 @@ function tabContent(id: SettingsTabId): ReactNode {
       return (
         <>
           <ConnectorsCard />
+          <ProviderCard />
           <CaptureSettingsCard />
           <ConsumerMailDomainsCard />
           <LinkedInImportCard />


### PR DESCRIPTION
PR-4 of the Surfe enrichment delivery (plan rev 5). **The feature becomes clickable.**

- **Settings card**: connect/rotate a key behind a confirm, credits per pool (iterated — the pool names are the vendor's own), auto-enrich toggle with If-Match, and disconnect vs delete-data as two separate decisions. A build with no adapter shows the honest empty state, not a broken control.
- **Person section** (in the research drawer, above what a public read found): every value carries a provenance mark, and an address the provider did not classify says it was labelled from what we asked for. All 14 states stay distinct.
- **Company roster**: purchased title where nobody typed one, one mark on the subline; tab and rail change together.
- Three i18n catalogs; German written from the meaning rather than translated.

Local gates: full `make check` green, `check-fe` green, all 69 Playwright specs pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the licensed data provider feature usable across three surfaces and fixes polling and role rendering so states stay consistent and no second purchase is offered while one is in flight.

- Settings card: connect/rotate the API key behind a confirm; separate Disconnect (stops new lookups, destroys the key) and Delete bought data (typed confirm); shows provider credits per pool and limits; renders an honest “not configured” empty state when no adapter is present.
- Person drawer: “Bought contact data” above public findings; every value carries provenance; emails/mobiles show provider/requested labels and confidence; LinkedIn, employment, job history, location, departments, seniorities; “Not asked for” categories; “Enrich now” only when eligible; polling now watches the run and stops on terminal states, counting “submitting” as running to prevent double-spend.
- Company roster tab and rail: fill a missing title with the purchased one, with one evidence mark on the subline; both surfaces use shared `roleOf` and follow server precedence.
- Shared status vocabulary in `provider-status.ts` for connection and all 14 profile states; new tests assert unique messages, correct tones, and the “no double purchase while running” invariant.
- i18n: EN/DE/VI; keep `provider.credits.pool` and `provider.profile.linkedin` in English; tests updated.

**Review notes**
- API: GET/PUT/PATCH/DELETE `/provider-connections`; DELETE `/provider-connections/{provider}/data`; POST `/people/{id}/enrichment-runs`; GET `/people/{id}/enrichment-runs/{run_id}` for polling. 501 means “not configured.”
- Concurrency: policy PATCH uses `If-Match` with the saved `version`; on mismatch the UI refetches.
- Safety: the API key is sealed and never re-shown; destructive delete requires typing the provider’s name.

<sup>Written for commit 792d55d2dfd1d678a9f1515e8a82d688f72bb95b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1113?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

