### PR TITLE
feat(integrations): what enrichment has cost us, per month and per pool

### DIFF
--- a/backend/internal/compose/integrationsmapping.go
+++ b/backend/internal/compose/integrationsmapping.go
@@ -59,6 +59,10 @@ func toProviderConnection(c integrations.Connection) crmcontracts.ProviderConnec
 		Status:        crmcontracts.ProviderConnectionStatus(c.Status),
 		Configuration: cfg,
 		Credits:       credits,
+		// Ours, not theirs. The balance above is what the PROVIDER says is
+		// left; this is what this installation consumed, and the card must
+		// never let a reader take one for the other.
+		Spend: toProviderSpend(c.Spend),
 		// The ONLY credential fact that ever leaves: whether one is set.
 		CredentialPresent: c.CredentialPresent,
 		ConnectedAt:       c.ConnectedAt,
@@ -76,6 +80,23 @@ func toProviderConnection(c integrations.Connection) crmcontracts.ProviderConnec
 		out.Version = &v
 	}
 	return out
+}
+
+// toProviderSpend renders the consumption series. Always a value, never
+// absent: a card with no history yet shows an empty series and says so, where
+// an omitted field would read as "we do not track this".
+func toProviderSpend(months []integrations.MonthlySpend) *crmcontracts.ProviderSpend {
+	out := crmcontracts.ProviderSpend{Months: []crmcontracts.ProviderMonthlySpend{}}
+	for _, m := range months {
+		out.Months = append(out.Months, crmcontracts.ProviderMonthlySpend{
+			Month:          openapi_types.Date{Time: m.Month},
+			Pool:           m.Pool,
+			ChargedCredits: m.Charged,
+			HeldCredits:    m.Held,
+			Runs:           m.Runs,
+		})
+	}
+	return &out
 }
 
 // fromProviderConfig maps a connect body's optional configuration. Absent

--- a/backend/internal/modules/integrations/budget.go
+++ b/backend/internal/modules/integrations/budget.go
@@ -119,15 +119,19 @@ func (s *Store) lockPool(ctx context.Context, tx pgx.Tx, connID, pool string) (p
 // runs each see an empty ledger and collectively blow through the ceiling —
 // the exact failure the ceiling exists to prevent.
 func (s *Store) poolUsedThisMonth(ctx context.Context, tx pgx.Tx, connID, pool string) (int, error) {
+	// The charge expression and the exclusions are shared with the spend
+	// history (spend.go), not copied: the number a customer READS and the
+	// number that REFUSES their next run come from one definition, so a page
+	// can never say there is budget left while the ceiling says otherwise.
 	var used int
 	err := tx.QueryRow(ctx, `
-		SELECT COALESCE(SUM(COALESCE(r.actual_credits, r.reserved_credits)), 0)
+		SELECT COALESCE(SUM(`+chargedCredits+`), 0)
 		  FROM provider_run_reservation r
 		  JOIN provider_run run ON run.id = r.run_id
 		 WHERE r.pool = $2
 		   AND run.provider = (SELECT provider FROM provider_connection WHERE id = $1)
 		   AND run.created_at >= date_trunc('month', now() AT TIME ZONE 'UTC')
-		   AND run.state <> 'skipped' AND run.state <> 'cancelled'`,
+		   AND `+spendExcludedStates,
 		connID, pool).Scan(&used)
 	if err != nil {
 		return 0, fmt.Errorf("integrations: reading %s spend: %w", pool, err)

--- a/backend/internal/modules/integrations/budget.go
+++ b/backend/internal/modules/integrations/budget.go
@@ -130,7 +130,7 @@ func (s *Store) poolUsedThisMonth(ctx context.Context, tx pgx.Tx, connID, pool s
 		  JOIN provider_run run ON run.id = r.run_id
 		 WHERE r.pool = $2
 		   AND run.provider = (SELECT provider FROM provider_connection WHERE id = $1)
-		   AND run.created_at >= date_trunc('month', now() AT TIME ZONE 'UTC')
+		   AND run.created_at >= (date_trunc('month', now() AT TIME ZONE 'UTC') AT TIME ZONE 'UTC')
 		   AND `+spendExcludedStates,
 		connID, pool).Scan(&used)
 	if err != nil {

--- a/backend/internal/modules/integrations/runs_integration_test.go
+++ b/backend/internal/modules/integrations/runs_integration_test.go
@@ -171,7 +171,13 @@ func setupRuns(t *testing.T, cfg runsConfig) *runsEnv {
 	e.ctx = principal.WithActor(principal.WithWorkspaceID(ctx, e.ws), principal.Principal{
 		Type: principal.PrincipalHuman, ID: "human:" + actor.String(), UserID: actor,
 		Permissions: principal.Permissions{
-			Objects: map[string]principal.ObjectGrant{"person": {Read: true}},
+			Objects: map[string]principal.ObjectGrant{
+				"person": {Read: true},
+				// What enrichment COSTS is readable by any seat that may see
+				// the connection — a rep asking "are we out of credits" is
+				// asking about the installation, not about a person.
+				"integrations": {Read: true},
+			},
 			// Own-scope on purpose: this is the scope a rep has, and the
 			// person they do not own is the one the gate must refuse.
 			RowScope: principal.RowScopeOwn,

--- a/backend/internal/modules/integrations/spend.go
+++ b/backend/internal/modules/integrations/spend.go
@@ -47,6 +47,13 @@ const spendExcludedStates = `run.state <> 'skipped' AND run.state <> 'cancelled'
 // so a reader sees a trend without the connection read growing unbounded.
 const spendMonths = 6
 
+// Both windows below convert the truncated month back to an instant with
+// `AT TIME ZONE 'UTC'`. Truncating alone yields a timestamp WITHOUT a zone,
+// which Postgres then reads in the session's own zone when it meets
+// created_at — so a non-UTC session would draw the month boundary hours away
+// from where the grouping puts it, and the spend total would disagree with the
+// ceiling that refuses the next run.
+
 // MonthlySpend is one calendar month's consumption for one pool.
 type MonthlySpend struct {
 	// Month is the first day of the UTC calendar month, matching the window
@@ -104,8 +111,8 @@ func (s *Store) readSpendHistory(ctx context.Context, tx pgx.Tx, name string) ([
 		  JOIN provider_run run ON run.id = r.run_id
 		 WHERE run.provider = $1
 		   AND `+spendExcludedStates+`
-		   AND run.created_at >= date_trunc('month', now() AT TIME ZONE 'UTC')
-		                          - make_interval(months => $2)
+		   AND run.created_at >= (date_trunc('month', now() AT TIME ZONE 'UTC')
+		                            - make_interval(months => $2)) AT TIME ZONE 'UTC'
 		 GROUP BY month, r.pool
 		 ORDER BY month DESC, r.pool`, name, spendMonths-1)
 	if err != nil {

--- a/backend/internal/modules/integrations/spend.go
+++ b/backend/internal/modules/integrations/spend.go
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package integrations
+
+// Consumption over time (PI-FORM-3): what enrichment cost this installation,
+// per calendar month and per credit pool.
+//
+// It answers a different question from the credit balance beside it on the
+// card. That number is the PROVIDER's — how much is left to spend, and the
+// customer may be spending the same credits through the provider's own app.
+// This is OURS: what this installation consumed, read from the same
+// reservation rows the monthly ceiling is enforced against.
+//
+// Those two must never disagree, which is why the charge expression below is
+// the one poolUsedThisMonth uses, spelled once and shared. A spend figure
+// whose arithmetic differed from the ceiling's would tell a customer they had
+// budget left while the next run was refused for having none.
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/gradionhq/margince/backend/internal/platform/auth"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+)
+
+// chargedCredits is what a reservation row counts as spent.
+//
+// An unreconciled hold counts at its full reserved amount: the provider has
+// not said what it actually charged, and assuming a refund nobody promised
+// would understate the bill in exactly the window where a customer is
+// deciding whether to keep spending.
+//
+//nolint:gosec // G101 false positive: a SQL fragment naming credit columns, not a credential.
+const chargedCredits = `COALESCE(r.actual_credits, r.reserved_credits)`
+
+// spendExcludedStates are the runs that bought nothing. Nothing left the
+// building for either, so neither is a charge — the same exclusion the
+// ceiling makes.
+const spendExcludedStates = `run.state <> 'skipped' AND run.state <> 'cancelled'`
+
+// spendMonths is how far back the card looks: the current month plus five,
+// so a reader sees a trend without the connection read growing unbounded.
+const spendMonths = 6
+
+// MonthlySpend is one calendar month's consumption for one pool.
+type MonthlySpend struct {
+	// Month is the first day of the UTC calendar month, matching the window
+	// the ceiling enforces on — so "this month" means one thing across the
+	// product.
+	Month time.Time
+	Pool  string
+	// Charged is what was consumed, holds included.
+	Charged int
+	// Held is the part of Charged whose outcome was never learned
+	// (submission_unknown, PI-AC-4). Reported SEPARATELY and never folded
+	// away: the platform does not know whether those credits were spent, and
+	// a total that quietly counted them either way would assert something it
+	// cannot support. It is the figure a human reconciles against the
+	// provider's invoice.
+	Held int
+	Runs int
+}
+
+// SpendByMonth reads this installation's own consumption, newest month first.
+//
+// Gated on the integrations READ grant, which is broad: a rep may see what
+// enrichment costs. It is the installation's spend, not any subject's — the
+// rows name no person, and an erasure detaches them from the one they used to
+// name (PI-AC-8), which is what makes this series stable across an Art. 17
+// request by construction.
+func (s *Store) SpendByMonth(ctx context.Context, name string) ([]MonthlySpend, error) {
+	if err := auth.Require(ctx, objectIntegrations, principal.ActionRead); err != nil {
+		return nil, err
+	}
+	var out []MonthlySpend
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
+		months, err := s.readSpendHistory(ctx, tx, name)
+		out = months
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// readSpendHistory is the read itself, inside a transaction the caller already
+// holds. List folds it into each connection, so the card's balance and its
+// history describe one moment rather than two.
+func (s *Store) readSpendHistory(ctx context.Context, tx pgx.Tx, name string) ([]MonthlySpend, error) {
+	rows, err := tx.Query(ctx, `
+		SELECT date_trunc('month', run.created_at AT TIME ZONE 'UTC') AS month,
+		       r.pool,
+		       COALESCE(SUM(`+chargedCredits+`), 0)::int AS charged,
+		       COALESCE(SUM(`+chargedCredits+`) FILTER (
+		         WHERE run.state = 'submission_unknown'), 0)::int AS held,
+		       COUNT(DISTINCT run.id)::int AS runs
+		  FROM provider_run_reservation r
+		  JOIN provider_run run ON run.id = r.run_id
+		 WHERE run.provider = $1
+		   AND `+spendExcludedStates+`
+		   AND run.created_at >= date_trunc('month', now() AT TIME ZONE 'UTC')
+		                          - make_interval(months => $2)
+		 GROUP BY month, r.pool
+		 ORDER BY month DESC, r.pool`, name, spendMonths-1)
+	if err != nil {
+		return nil, fmt.Errorf("integrations: reading the spend history: %w", err)
+	}
+	defer rows.Close()
+
+	var out []MonthlySpend
+	for rows.Next() {
+		var m MonthlySpend
+		if err := rows.Scan(&m.Month, &m.Pool, &m.Charged, &m.Held, &m.Runs); err != nil {
+			return nil, fmt.Errorf("integrations: scanning a spend month: %w", err)
+		}
+		out = append(out, m)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("integrations: reading the spend history: %w", err)
+	}
+	return out, nil
+}

--- a/backend/internal/modules/integrations/spend_integration_test.go
+++ b/backend/internal/modules/integrations/spend_integration_test.go
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integrations
+
+// The spend history: what this installation consumed, per month per pool.
+//
+// Three properties only a real database can prove, and each is a way the
+// number could lie:
+//
+//   - it agrees with the CEILING, because both read the same rows through the
+//     same expression — a page saying budget remains while the next run is
+//     refused is the failure this sharing exists to prevent;
+//   - a run whose outcome was never learned is reported as HELD and never
+//     folded into the charged total, because the platform does not know;
+//   - it survives an erasure, because a scrub detaches the subject and keeps
+//     the accounting (PI-AC-8).
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/gradionhq/margince/backend/internal/shared/ports/provider"
+)
+
+// seedSpendRun writes one run with one reservation, in a named state and
+// month. Hand-built rather than driven through QueueRun: what these tests are
+// about is the arithmetic over a ledger, and a ledger spanning two months
+// cannot be produced by a live pipeline in one test.
+func seedSpendRun(t *testing.T, e *runsEnv, state, pool string, reserved int, actual *int, monthsAgo int) {
+	t.Helper()
+	ctx := context.Background()
+	// The row's own CHECK ties the two together: a skipped run carries a
+	// reason and no other state may.
+	var skipReason *string
+	if state == string(provider.RunSkipped) {
+		reason := string(provider.SkipBudgetExhausted)
+		skipReason = &reason
+	}
+	var runID string
+	if err := e.owner.QueryRow(ctx, `
+		INSERT INTO provider_run
+		  (subject_kind, person_id, provider, trigger, state, skip_reason, input_fingerprint,
+		   external_correlation_id, connection_version, connection_epoch,
+		   configuration_snapshot, requested_categories, created_at, completed_at)
+		VALUES ('person', $1, 'surfe', 'manual', $2, $4, 'fp-' || gen_random_uuid()::text,
+		        gen_random_uuid(), 1, 1, '{}'::jsonb, ARRAY['professional_email'],
+		        date_trunc('month', now() AT TIME ZONE 'UTC') - make_interval(months => $3),
+		        now())
+		RETURNING id::text`, e.mine, state, monthsAgo, skipReason).Scan(&runID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := e.owner.Exec(ctx, `
+		INSERT INTO provider_run_reservation (run_id, pool, reserved_credits, actual_credits)
+		VALUES ($1, $2, $3, $4)`, runID, pool, reserved, actual); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func spendFor(t *testing.T, e *runsEnv, month, pool string) MonthlySpend {
+	t.Helper()
+	months, err := e.store.SpendByMonth(e.ctx, "surfe")
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC()
+	want := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
+	if month == "previous" {
+		want = want.AddDate(0, -1, 0)
+	}
+	for _, m := range months {
+		if m.Pool == pool && m.Month.UTC().Equal(want) {
+			return m
+		}
+	}
+	t.Fatalf("no %s spend for %s in %+v", pool, month, months)
+	return MonthlySpend{}
+}
+
+// The card's number and the ceiling's number come from one definition.
+func TestSpendReportsPerMonthAndAgreesWithTheCeiling(t *testing.T) {
+	e := setupRuns(t, runsConfig{})
+	if _, err := e.owner.Exec(context.Background(), `DELETE FROM provider_run`); err != nil {
+		t.Fatal(err)
+	}
+	three := 3
+	// This month: one reconciled run charged 3, one unreconciled hold of 2.
+	seedSpendRun(t, e, string(provider.RunCompleted), "email", 5, &three, 0)
+	seedSpendRun(t, e, string(provider.RunInProgress), "email", 2, nil, 0)
+	// Last month, a different pool, so the grouping has something to separate.
+	seedSpendRun(t, e, string(provider.RunCompleted), "mobile", 1, nil, 1)
+	// Neither of these bought anything, and neither may appear.
+	seedSpendRun(t, e, string(provider.RunSkipped), "email", 4, nil, 0)
+	seedSpendRun(t, e, string(provider.RunCancelled), "email", 4, nil, 0)
+
+	current := spendFor(t, e, "current", "email")
+	// 3 reconciled + 2 still held. An unreconciled hold counts at its full
+	// reserved amount: assuming a refund nobody promised understates the bill.
+	if current.Charged != 5 {
+		t.Errorf("this month's email charge is %d, want 5 (3 actual + a 2-credit hold)", current.Charged)
+	}
+	if current.Runs != 2 {
+		t.Errorf("this month counted %d runs, want 2 — skipped and cancelled runs bought nothing", current.Runs)
+	}
+
+	previous := spendFor(t, e, "previous", "mobile")
+	if previous.Charged != 1 || previous.Pool != "mobile" {
+		t.Errorf("last month's mobile spend is %+v, want 1 credit", previous)
+	}
+
+	// THE agreement: the ceiling reads the same rows the card shows, so the
+	// number that refuses a run and the number a customer reads cannot differ.
+	var connID string
+	if err := e.owner.QueryRow(context.Background(),
+		`SELECT id::text FROM provider_connection WHERE provider = 'surfe'`).Scan(&connID); err != nil {
+		t.Fatal(err)
+	}
+	var used int
+	if err := e.store.db.Tx(e.ctx, func(tx pgx.Tx) error {
+		n, err := e.store.poolUsedThisMonth(e.ctx, tx, connID, "email")
+		used = n
+		return err
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if used != current.Charged {
+		t.Errorf("the ceiling counts %d email credits this month and the card shows %d — a customer would read budget the next run does not have",
+			used, current.Charged)
+	}
+}
+
+// A run whose outcome was never learned is reported as held, separately.
+func TestAnUnknownOutcomeIsHeldRatherThanFoldedIntoTheCharge(t *testing.T) {
+	e := setupRuns(t, runsConfig{})
+	if _, err := e.owner.Exec(context.Background(), `DELETE FROM provider_run`); err != nil {
+		t.Fatal(err)
+	}
+	seedSpendRun(t, e, string(provider.RunSubmissionUnknown), "email", 2, nil, 0)
+
+	current := spendFor(t, e, "current", "email")
+	if current.Held != 2 {
+		t.Errorf("held = %d, want 2 — PI-AC-4's whole point is that we do not know, and a total that hid it would assert something the platform cannot support", current.Held)
+	}
+	// It still counts against the ceiling, because the credits may have gone.
+	if current.Charged != 2 {
+		t.Errorf("charged = %d, want 2 — a possibly-paid hold must keep occupying the budget", current.Charged)
+	}
+}
+
+// Erasing a subject removes the subject, not the accounting.
+func TestTheSpendHistorySurvivesAnErasure(t *testing.T) {
+	e := setupRuns(t, runsConfig{})
+	if _, err := e.owner.Exec(context.Background(), `DELETE FROM provider_run`); err != nil {
+		t.Fatal(err)
+	}
+	seedSpendRun(t, e, string(provider.RunCompleted), "email", 1, nil, 1)
+	before := spendFor(t, e, "previous", "email")
+
+	// The scrub the erasure performs: the run stops naming anybody and keeps
+	// its reservations. Run here as the statement rather than through the
+	// eraser, which lives in a module this package may not import.
+	if _, err := e.owner.Exec(context.Background(), `
+		UPDATE provider_run
+		   SET person_id = NULL, subject_kind = 'scrubbed',
+		       input_fingerprint = '', provider_job_id = NULL,
+		       requested_by = NULL, configuration_snapshot = '{}'::jsonb
+		 WHERE person_id = $1`, e.mine); err != nil {
+		t.Fatal(err)
+	}
+
+	after := spendFor(t, e, "previous", "email")
+	if after.Charged != before.Charged || after.Runs != before.Runs {
+		t.Errorf("the month's spend changed from %+v to %+v when a subject was erased — what the installation paid is its own fact, and an Art. 17 request must not rewrite the books",
+			before, after)
+	}
+}

--- a/backend/internal/modules/integrations/spend_integration_test.go
+++ b/backend/internal/modules/integrations/spend_integration_test.go
@@ -50,7 +50,9 @@ func seedSpendRun(t *testing.T, e *runsEnv, state, pool string, reserved int, ac
 		   configuration_snapshot, requested_categories, created_at, completed_at)
 		VALUES ('person', $1, 'surfe', 'manual', $2, $4, 'fp-' || gen_random_uuid()::text,
 		        gen_random_uuid(), 1, 1, '{}'::jsonb, ARRAY['professional_email'],
-		        date_trunc('month', now() AT TIME ZONE 'UTC') - make_interval(months => $3),
+		        (date_trunc('month', now() AT TIME ZONE 'UTC')
+			           - make_interval(months => $3)) AT TIME ZONE 'UTC'
+			          + interval '2 hours',
 		        now())
 		RETURNING id::text`, e.mine, state, monthsAgo, skipReason).Scan(&runID); err != nil {
 		t.Fatal(err)
@@ -149,6 +151,67 @@ func TestAnUnknownOutcomeIsHeldRatherThanFoldedIntoTheCharge(t *testing.T) {
 	// It still counts against the ceiling, because the credits may have gone.
 	if current.Charged != 2 {
 		t.Errorf("charged = %d, want 2 — a possibly-paid hold must keep occupying the budget", current.Charged)
+	}
+}
+
+// The month boundary is the same instant for the card and for the ceiling, in
+// any session timezone.
+//
+// Truncating to a month yields a timestamp WITHOUT a zone. Compared against
+// created_at, Postgres reads it in the SESSION's zone — so a connection running
+// as anything but UTC drew the boundary hours away from where the grouping puts
+// it. A run in that gap counted toward one number and not the other, which is
+// the precise failure the shared expression exists to rule out.
+func TestTheMonthBoundaryIsUTCWhateverTheSessionZone(t *testing.T) {
+	e := setupRuns(t, runsConfig{})
+	if _, err := e.owner.Exec(context.Background(), `DELETE FROM provider_run`); err != nil {
+		t.Fatal(err)
+	}
+	// Two hours past the UTC month start, so a boundary read in a zone behind
+	// UTC falls on the far side of it.
+	seedSpendRun(t, e, string(provider.RunCompleted), "email", 7, nil, 0)
+
+	var connID string
+	if err := e.owner.QueryRow(context.Background(),
+		`SELECT id::text FROM provider_connection WHERE provider = 'surfe'`).Scan(&connID); err != nil {
+		t.Fatal(err)
+	}
+
+	// Both reads run in ONE transaction whose zone is set far enough west that
+	// a boundary misread is unambiguous. Setting it on the transaction rather
+	// than the pool is what makes the binding certain: pgx hands out an
+	// arbitrary connection per acquisition.
+	var months []MonthlySpend
+	var used int
+	if err := e.store.db.Tx(e.ctx, func(tx pgx.Tx) error {
+		if _, err := tx.Exec(e.ctx, `SET LOCAL TIME ZONE 'America/Los_Angeles'`); err != nil {
+			return err
+		}
+		m, err := e.store.readSpendHistory(e.ctx, tx, "surfe")
+		if err != nil {
+			return err
+		}
+		months = m
+		n, err := e.store.poolUsedThisMonth(e.ctx, tx, connID, "email")
+		used = n
+		return err
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Now().UTC()
+	wantMonth := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
+	var charged int
+	for _, m := range months {
+		if m.Pool == "email" && m.Month.UTC().Equal(wantMonth) {
+			charged = m.Charged
+		}
+	}
+	if charged != 7 {
+		t.Errorf("this month's email charge is %d, want 7 — the session zone moved the month boundary, so a run fell into the wrong bucket (months: %+v)", charged, months)
+	}
+	if used != charged {
+		t.Errorf("in a non-UTC session the ceiling counts %d email credits and the card shows %d", used, charged)
 	}
 }
 

--- a/backend/internal/modules/integrations/store.go
+++ b/backend/internal/modules/integrations/store.go
@@ -100,13 +100,16 @@ type Connection struct {
 	RefreshAfterDays  *int
 	DailyRunLimit     *int
 	Budgets           []PoolBudget
-	Version           int64
-	SafeStatusCode    string
-	ConnectedAt       *time.Time
-	LastVerifiedAt    *time.Time
-	LastUsedAt        *time.Time
-	CreatedAt         time.Time
-	UpdatedAt         time.Time
+	// Spend is what THIS installation consumed, per month per pool — our
+	// ledger, never the provider's balance beside it (PI-FORM-3).
+	Spend          []MonthlySpend
+	Version        int64
+	SafeStatusCode string
+	ConnectedAt    *time.Time
+	LastVerifiedAt *time.Time
+	LastUsedAt     *time.Time
+	CreatedAt      time.Time
+	UpdatedAt      time.Time
 }
 
 // PoolBudget is one credit pool's ceiling, pause threshold and last known
@@ -134,6 +137,15 @@ func (s *Store) List(ctx context.Context) ([]Connection, error) {
 		}
 		for _, name := range s.registry.Names() {
 			if c, ok := rows[name]; ok {
+				// The card shows what the provider says is LEFT and what this
+				// installation SPENT side by side, so both arrive in one read
+				// — two round trips could show a balance and a history from
+				// different moments.
+				spend, err := s.readSpendHistory(ctx, tx, name)
+				if err != nil {
+					return err
+				}
+				c.Spend = spend
 				out = append(out, c)
 				continue
 			}

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -4376,6 +4376,14 @@ export const de = {
   "provider.credits.pool": "{pool}",
   "provider.credits.none": "Der Anbieter hat uns noch keinen Stand genannt.",
   "provider.constraints": "Geltende Grenzen",
+  "provider.spend": "Was wir verbraucht haben",
+  "provider.spend.hint":
+    "Unsere eigene Aufzeichnung dessen, was die Anreicherung gekostet hat. Nicht die Rechnung des Anbieters — dieselben Guthaben lassen sich auch über dessen App ausgeben, die beiden Zahlen dürfen also auseinandergehen.",
+  "provider.spend.thisMonth": "Diesen Monat",
+  "provider.spend.charged": "{pool}: {credits} Guthaben für {count} Abfragen",
+  "provider.spend.held":
+    "Davon liegen {credits} auf Abfragen, deren Ausgang wir nie erfahren haben.",
+  "provider.spend.none": "Es wurde noch nichts gekauft.",
   "provider.mode": "Wann angereichert wird",
   "provider.mode.automatic_on_create": "Sobald Kontakte entstehen",
   "provider.mode.on_demand": "Nur auf Zuruf",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -4370,6 +4370,14 @@ export const en = {
   "provider.credits.pool": "{pool}",
   "provider.credits.none": "The provider has not told us a balance yet.",
   "provider.constraints": "Limits in force",
+  "provider.spend": "What we have used",
+  "provider.spend.hint":
+    "Our own record of what enrichment consumed. Not the provider's invoice — the same credits can be spent through their app, so the two figures differ legitimately.",
+  "provider.spend.thisMonth": "This month",
+  "provider.spend.charged": "{pool}: {credits} credits over {count} lookups",
+  "provider.spend.held":
+    "{credits} of those are held against lookups whose outcome we never learned.",
+  "provider.spend.none": "Nothing has been bought yet.",
   "provider.mode": "When to enrich",
   "provider.mode.automatic_on_create": "As contacts are added",
   "provider.mode.on_demand": "Only when asked",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -4361,6 +4361,15 @@ export const vi = {
   "provider.credits.pool": "{pool}",
   "provider.credits.none": "Nhà cung cấp chưa cho biết số dư.",
   "provider.constraints": "Giới hạn đang áp dụng",
+  "provider.spend": "Chúng ta đã dùng bao nhiêu",
+  "provider.spend.hint":
+    "Ghi nhận của chính chúng ta về chi phí làm giàu dữ liệu. Đây không phải hoá đơn của nhà cung cấp — cùng số tín dụng đó có thể được tiêu qua ứng dụng của họ, nên hai con số lệch nhau là chuyện bình thường.",
+  "provider.spend.thisMonth": "Tháng này",
+  "provider.spend.charged":
+    "{pool}: {credits} tín dụng cho {count} lượt tra cứu",
+  "provider.spend.held":
+    "Trong đó {credits} đang bị giữ cho những lượt tra cứu mà chúng ta không bao giờ biết kết quả.",
+  "provider.spend.none": "Chưa mua gì cả.",
   "provider.mode": "Khi nào làm giàu",
   "provider.mode.automatic_on_create": "Ngay khi liên hệ được tạo",
   "provider.mode.on_demand": "Chỉ khi được yêu cầu",

--- a/frontend/src/screens/integrations-provider.tsx
+++ b/frontend/src/screens/integrations-provider.tsx
@@ -113,6 +113,7 @@ function ProviderConnectionRow({
         </Badge>
       </header>
       <CreditsBlock connection={connection} />
+      <SpendBlock connection={connection} />
       <PolicyBlock connection={connection} />
       <CredentialBlock connection={connection} />
     </section>
@@ -122,6 +123,59 @@ function ProviderConnectionRow({
 // What the PROVIDER says is left — their number, never ours. A customer may
 // spend the same credits through the provider's own app, so this is a reading
 // of their ledger and the card never presents it as our accounting.
+// What THIS installation consumed, directly under what the provider says is
+// left — the two are the questions a customer asks together, and seeing them
+// side by side is what stops either being mistaken for the other. The label
+// says whose number it is; the hint says why they can legitimately differ.
+function SpendBlock({
+  connection,
+}: Readonly<{ connection: ProviderConnection }>) {
+  const t = useT();
+  const months = connection.spend?.months ?? [];
+  if (months.length === 0) {
+    return (
+      <div>
+        <h3>{t("provider.spend")}</h3>
+        <p className="muted">{t("provider.spend.none")}</p>
+      </div>
+    );
+  }
+  // The series arrives newest first, so the current month heads the list.
+  const current = months[0].month;
+  return (
+    <div>
+      <h3>{t("provider.spend")}</h3>
+      <p className="muted">{t("provider.spend.hint")}</p>
+      {months.map((month) => (
+        <div key={`${month.month}-${month.pool}`}>
+          <span className="muted">
+            {month.month === current
+              ? t("provider.spend.thisMonth")
+              : month.month}
+          </span>{" "}
+          <span>
+            {t("provider.spend.charged", {
+              pool: month.pool,
+              credits: month.charged_credits,
+              count: month.runs,
+            })}
+          </span>
+          {month.held_credits > 0 && (
+            // Never folded into the charge: the platform does not know
+            // whether those credits were spent, and a total that quietly
+            // counted them either way would assert something it cannot
+            // support. This is the figure a human reconciles against the
+            // provider's invoice.
+            <p className="muted">
+              {t("provider.spend.held", { credits: month.held_credits })}
+            </p>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
 function CreditsBlock({
   connection,
 }: Readonly<{ connection: ProviderConnection }>) {

--- a/frontend/src/screens/integrations-provider.tsx
+++ b/frontend/src/screens/integrations-provider.tsx
@@ -140,8 +140,11 @@ function SpendBlock({
       </div>
     );
   }
-  // The series arrives newest first, so the current month heads the list.
-  const current = months[0].month;
+  // The series only carries months that HAD spend, so its newest entry is not
+  // necessarily this one — an installation that bought nothing yet this month
+  // would otherwise see last month's total labelled as the current bill.
+  const now = new Date();
+  const current = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, "0")}-01`;
   return (
     <div>
       <h3>{t("provider.spend")}</h3>


### PR DESCRIPTION
PR-5 of the Surfe enrichment delivery (plan rev 5), and the last build item.

The card showed only the provider's remaining balance — their number, saying nothing about our own consumption. This adds the history.

- The read is **the ceiling's own arithmetic**, generalized over a month range. The charge expression and excluded states are shared with `poolUsedThisMonth`, not copied, so the number a customer reads and the number that refuses their next run cannot disagree. A test asserts it.
- An unreconciled hold counts at full value (assuming an unpromised refund understates the bill); `submission_unknown` is reported as **held, separately** and never folded in; skipped and cancelled appear in neither.
- The card labels it as OUR record and says why it legitimately differs from the provider's invoice.
- It survives an erasure by construction, and a test pins that.

Local gates: full `make check` green, integration lane green (3 new tests), craft static clean, 69 Playwright specs pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a 6‑month, per‑pool enrichment spend history to provider connections and the settings card. Previously we showed only the provider’s remaining balance; now we also show our own consumption, with UTC month boundaries so the card and the ceiling that refuses runs cannot disagree.

**Reviewer focus**
- Backend: New `SpendByMonth` computes six months grouped by pool and shares `chargedCredits` and `spendExcludedStates` with `poolUsedThisMonth`; both queries pin the month window to UTC. Unreconciled holds count at the reserved amount and are also reported as Held; `skipped`/`cancelled` runs are excluded. Viewing requires the `integrations` READ grant. `Store.List` reads spend in the same transaction as the connection and compose always emits a `spend` object on `ProviderConnection` (additive API only). Integration tests cover ceiling agreement (including a non‑UTC session), held handling for `submission_unknown`, and stability across erasure.
- Frontend: `SpendBlock` renders the series beneath the provider balance with an empty state. The “This month” label comes from today’s UTC month instead of the newest series entry. New i18n strings in `en.ts`, `de.ts`, and `vi.ts`.

<sup>Written for commit ada030ecfdfa2c29658a5e007e7a04a2c4f62b3a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1115?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added provider spend history to integration connection details.
  * Display monthly charged credits and run counts, including a separate view of held credits.
  * Identify current-month usage using UTC time and provide an empty state when no spend is recorded.
* **Localization**
  * Added spend-related translations in English, German, and Vietnamese.
* **Bug Fixes**
  * Improved consistency between spend history and budget usage calculations.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->