### PR TITLE
feat(company): the health card reads its dimensions and counts at a glance

### DIFF
--- a/frontend/src/screens/company360.css
+++ b/frontend/src/screens/company360.css
@@ -1005,11 +1005,41 @@
    apart into one row per dimension, same rhythm as .co-growth-fit-scores). */
 .co-health-meter {
   display: grid;
-  gap: var(--space-1);
+  gap: var(--space-2);
   padding: var(--space-2) 0;
 }
-.co-health-meter + .co-health-meter {
-  border-top: 1px solid var(--borderSubtle);
+.co-health-meter:first-child {
+  padding-top: 0;
+}
+/* Label and its reading share one line; the meter reads as the label's
+   own bar rather than a separate block, so the whole dimension is two
+   lines tall instead of three. */
+.co-health-meter-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-3);
+}
+.co-health-meter-reason {
+  font-size: var(--fs-meta);
+  color: var(--textMeta);
+  text-align: right;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.co-health-meter .meterbar {
+  height: 6px;
+  margin: 0;
+}
+/* The four counting facts read as one tight paragraph, set apart from the
+   meters above by real space so the block reads as a separate answer
+   rather than a fifth meter row. */
+.co-health-lines {
+  margin-top: var(--space-1);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
 }
 
 /* A roster row: the monogram, the name over the title, and, where the graph

--- a/frontend/src/screens/companyrail.tsx
+++ b/frontend/src/screens/companyrail.tsx
@@ -195,8 +195,13 @@ function HealthSection({
           {dimensions.map(([name, dimension]) =>
             dimension?.rating ? (
               <div className="co-health-meter" key={name}>
-                <span className="t-caption">
-                  {t(HEALTH_DIMENSION_LABEL[name])}
+                <span className="co-health-meter-head">
+                  <span className="t-caption">
+                    {t(HEALTH_DIMENSION_LABEL[name])}
+                  </span>
+                  <span className="co-health-meter-reason">
+                    {dimension.reason}
+                  </span>
                 </span>
                 <Meter
                   value={HEALTH_RANK.indexOf(dimension.rating) + 1}
@@ -205,15 +210,18 @@ function HealthSection({
                   flat={!(dimension.rating in HEALTH_METER_TONE)}
                   label={t(HEALTH_DIMENSION_LABEL[name])}
                 />
-                <span className="co-row-meta">{dimension.reason}</span>
               </div>
             ) : null,
           )}
-          {lines.map((line) => (
-            <p className="co-row-meta" key={line}>
-              {line}
-            </p>
-          ))}
+          {lines.length > 0 && (
+            <div className="co-health-lines">
+              {lines.map((line) => (
+                <p className="co-row-meta" key={line}>
+                  {line}
+                </p>
+              ))}
+            </div>
+          )}
           {health?.single_threaded && (
             <p className="co-row-meta">
               <Badge tone="warn">{t("co.health.singleThreaded")}</Badge>


### PR DESCRIPTION
## Summary
- Relationship/Commercial each carry their label, reading, and meter on one compact row instead of stacking label / bar / sentence three deep
- The four supporting counts (last contact, reply balance, active contacts, open commitments) sit together as one tight block below the meters

## Test plan
- [x] `make frontend-check` (biome, vitest 2444 tests, tsc, build) green
- [x] Verified visually via `make dev` against a seeded company record

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Condenses the company health card so each dimension shows its label, reason, and meter on one row, and groups the four supporting counts into one block. This reduces vertical height and makes the card scannable without changing meter values or tones.

- Places each dimension’s reason next to the label, right-aligned with ellipsis; removes per-row border and slightly increases row spacing.
- Sets the meter bar to 6px with zero margins; keeps the `Meter` label for accessibility.
- Wraps the four counts in a `.`co-health-lines` block that renders only when lines exist and is visually separated from the meters.

**Review notes**
- Test long reasons at narrow widths for truncation and alignment.
- Verify meter values/tone unchanged and readability across themes.
- Check the grouped counts read as a distinct block and that spacing changes don’t regress the rail layout.

<sup>Written for commit 395684d5b99cb96079b52e57a6eccabc9e03c582. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1118?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

