### PR TITLE
fix(frontend): the contract types catch up with the blocked-domains routes

### DIFF
--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -4049,6 +4049,47 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/capture/blocked-domains": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * The domains refused a company, and why.
+         * @description Every domain carrying a standing admission decision: the vendors and bulk senders the
+         *     system refused a company, and the ones a human deliberately let back in. Each entry says
+         *     WHAT decided it — a model verdict, a heuristic, or a person — so an operator can tell an
+         *     automatic refusal from somebody's deliberate one.
+         *
+         *     Every human role may read the list; changing an entry demands `organization:update`
+         *     (admin/ops). Human-only: this is capture posture, not record data.
+         */
+        get: operations["listBlockedDomains"];
+        /**
+         * Block a domain, or unblock one (admin/ops).
+         * @description `admission: suppressed` refuses the domain a company; `admission: admitted` lets it in
+         *     and KEEPS it in — a human decision is sticky, so no later verdict or heuristic may
+         *     re-refuse a domain a person deliberately admitted.
+         *
+         *     Unblocking re-opens the company question rather than merely clearing a flag: the domain
+         *     was already asked and answered, so nothing would ask again on its own. The disposition
+         *     returns to pending with its attempts reset, the triage sweep picks it up, and the people
+         *     already captured on that domain get their employment edges when the company lands. That
+         *     is the McKinsey case — a newsletter publisher that became a client.
+         *
+         *     Idempotent on the domain, which is normalized to its registrable form. Audit-only write
+         *     (no event stream, EVT-NOEVT-3).
+         */
+        put: operations["setBlockedDomain"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/capture/consumer-mail-baseline": {
         parameters: {
             query?: never;
@@ -7272,6 +7313,51 @@ export interface components {
         UpdateCaptureSettingsRequest: {
             /** @description Toggle captured-organization auto-enrichment. */
             auto_enrich?: boolean;
+        };
+        /**
+         * @description One domain carrying a standing admission decision. `suppressed` refuses it a company —
+         *     a vendor or bulk sender the business does not sell to — while `admitted` is a human
+         *     deliberately letting one in, which no later verdict may undo.
+         */
+        BlockedDomain: {
+            /** @description The registrable domain the decision is about. */
+            domain: string;
+            /**
+             * @description `suppressed` — never a company. `admitted` — allowed, and sticky against later machine refusals.
+             * @enum {string}
+             */
+            admission: "suppressed" | "admitted";
+            /** @description One sentence an operator can act on: why this domain was refused or let in. */
+            reason: string;
+            /**
+             * @description What decided it. `human` decisions outrank every machine one.
+             * @enum {string}
+             */
+            source: "verdict" | "heuristic" | "human";
+            /** Format: date-time */
+            decided_at: string;
+            /**
+             * Format: uuid
+             * @description The company on this domain, when one exists — an admitted domain usually has one.
+             */
+            organization_id?: string | null;
+        };
+        SetBlockedDomainRequest: {
+            /** @description A mail domain; normalized to its registrable form before it is stored. */
+            domain: string;
+            /** @enum {string} */
+            admission: "suppressed" | "admitted";
+            /** @description Why. Required, because a refusal nobody can explain is one nobody can review. */
+            reason: string;
+        };
+        BlockedDomainListResponse: {
+            data: components["schemas"]["BlockedDomain"][];
+            /**
+             * @description How many decisions exist, which is not how many are returned. Refusals accumulate
+             *     automatically from every bulk-sender verdict, so a list that quietly stopped at its
+             *     page size would tell an operator their domain was never refused when it was.
+             */
+            total: number;
         };
         /**
          * @description One entry on the workspace's own consumer-mail list (CAP-PARAM-5). `extra` marks a
@@ -22643,6 +22729,55 @@ export interface operations {
             };
             401: components["responses"]["Unauthorized"];
             403: components["responses"]["Forbidden"];
+        };
+    };
+    listBlockedDomains: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The workspace's blocked and admitted domains. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BlockedDomainListResponse"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+        };
+    };
+    setBlockedDomain: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SetBlockedDomainRequest"];
+            };
+        };
+        responses: {
+            /** @description The stored decision. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BlockedDomain"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            422: components["responses"]["ValidationError"];
         };
     };
     listConsumerMailBaseline: {


### PR DESCRIPTION
## Main is red on its own head

#1125 added `/capture/blocked-domains` to `backend/api/crm.yaml` without the regenerated client types. On `origin/main` right now:

```
$ git show origin/main:backend/api/crm.yaml           | grep -c blocked-domains   # 2
$ git show origin/main:frontend/src/api/schema.d.ts   | grep -c blocked-domains   # 0
```

So `make check` → `frontend-check` → `fe-drift` fails on main, and every branch cut from it inherits a red gate for a change it did not make. (Found from a desktop branch — #1120 — whose diff touches no backend or frontend source at all.)

## The fix

`pnpm gen:api` over the committed contract. Nothing hand-written; `src/api/public-events.ts` is unchanged, so only `schema.d.ts` moves — **135 insertions, 0 deletions**, exactly the two new operations and their component schemas.

## Verification

`make fe-drift` — green (it was red on this same tree before the commit; the gate diffs against HEAD, so the fix only registers once committed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Regenerates frontend API contract types to include the `/capture/blocked-domains` routes, resolving the backend–frontend drift. Previously, `schema.d.ts` lacked these routes and `fe-drift` failed on `main`; now the types exist and the gate passes.

- Generated via `pnpm gen:api` against `backend/api/crm.yaml`; no hand edits.
- Only `frontend/src/api/schema.d.ts` changed (+135, 0 deletions).
- Adds `listBlockedDomains`, `setBlockedDomain`, and related schemas (`BlockedDomain`, `SetBlockedDomainRequest`, `BlockedDomainListResponse`).
- No runtime behavior change; this aligns the client with the contract and restores a green `fe-drift` check.

<sup>Written for commit 4140fd0bf68b552dc492382a3fd3c9da9ce2bbc9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1126?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

