### PR TITLE
fix(company): tidy the company360 KPI strip

### DIFF
--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -605,7 +605,7 @@ export const en = {
   "co.description.placeholder": "Add description",
   "co.chip.linkedin": "LinkedIn",
   "co.strip.netInvoicedLifetime": "Net invoiced · lifetime",
-  "co.strip.netInvoiced": "Net invoiced · 12 months",
+  "co.strip.netInvoiced": "Net invoiced · 12 mo",
   "co.strip.overdue": "Overdue",
   // The collapsed slot's label, shown once in place of the strip's money
   // readings when the connection cannot answer any of them. Generic on
@@ -626,7 +626,7 @@ export const en = {
   "co.strip.expectedClose": "Expected close",
   "co.strip.health": "Relationship",
   "co.strip.healthOneSided": "One-sided",
-  "co.strip.healthBalanced": "Balanced exchange",
+  "co.strip.healthBalanced": "Balanced",
   "co.strip.replyShare": "{percent}% of the exchange is theirs",
   "co.strip.healthActive": "In conversation",
   "co.strip.healthQuiet": "Gone quiet",

--- a/frontend/src/screens/company360.css
+++ b/frontend/src/screens/company360.css
@@ -258,15 +258,22 @@
 /* Set narrower than the panel it sits in and read top to bottom once, not
    scanned — the account's own statement about itself, not a metric. */
 .co-brief-body {
-  max-width: 64ch;
+  max-width: 72ch;
+}
+.co-brief-foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
 }
 .co-brief-lines {
   list-style: none;
   display: flex;
   flex-direction: column;
   gap: 6px;
-  margin: 8px 0;
-  font-size: 13.5px;
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.55;
   color: var(--textContent);
 }
 /* A sentence's citations sit in their own wrapping row after the prose, each
@@ -589,14 +596,13 @@
      ("typically 4 days early") on one line in the narrowest slot without
      wrapping to three, so it sits below the money-only size the figures alone
      could have carried. The clamp lets it shrink with the column instead. */
-  font-size: clamp(14px, 1.05vw, 17px);
+  font-size: clamp(13px, 0.9vw, 15px);
   line-height: 1.3;
   letter-spacing: -0.01em;
 }
 
-/* A strip slot is narrower than a free-standing stat card, so the source badge
-   wraps to its own line instead of squeezing the label beside it into two
-   lines that then collide with the figure. */
+/* A strip slot is narrower than a free-standing stat card, so a label that
+   does not fit wraps to a second line rather than colliding with the figure. */
 .co-strip .stat-card-label {
   flex-wrap: wrap;
   justify-content: flex-start;
@@ -609,20 +615,28 @@
   font-size: 11px;
 }
 
-/* The brief under the questions it answers. Sections are separated by space
-   rather than rules: a boxed heading reads as a card, and these are parts of
-   one reading. */
+/* The brief under the questions it answers. Label and prose sit side by side
+   in one row — the label is a column heading read once per row, not a
+   caption stacked above its own paragraph — and sections are separated by
+   space rather than rules: a boxed heading reads as a card, and these are
+   parts of one reading. */
+.co-brief-section {
+  display: grid;
+  grid-template-columns: 138px 1fr;
+  column-gap: var(--space-5);
+  align-items: baseline;
+}
 .co-brief-section + .co-brief-section {
-  margin-block-start: 0.7rem;
+  margin-block-start: 1.75rem;
 }
 
-.co-brief-section-label {
+.co-brief-section-label.t-caption {
   font-size: 11px;
   font-weight: 600;
   letter-spacing: 0.04em;
   text-transform: uppercase;
   color: var(--textMeta);
-  margin-block-end: 0.2rem;
+  white-space: nowrap;
 }
 
 /* The growth fit sits between the brief and the next steps: what this account

--- a/frontend/src/screens/company360.test.tsx
+++ b/frontend/src/screens/company360.test.tsx
@@ -2201,7 +2201,7 @@ describe("a customer's KPI row reports what the account is worth", () => {
     await waitFor(() => expect(region.textContent).not.toMatch(/Loading…/));
 
     expect(within(region).getByText("Net invoiced · lifetime")).toBeTruthy();
-    expect(within(region).getByText("Net invoiced · 12 months")).toBeTruthy();
+    expect(within(region).getByText("Net invoiced · 12 mo")).toBeTruthy();
     // Abbreviated: the strip's slots share its width, and a full euro amount
     // wraps mid-number there. The finance card renders the exact figure.
     expect(within(region).getByText(/428(\.0)?K/i)).toBeTruthy();
@@ -2414,7 +2414,7 @@ describe("the money row collapses only when every slot shares one cause", () => 
     // The three individual questions are gone with it, not just deduplicated
     // text — a reader sweeping the row sees one statement, not three blanks.
     expect(within(region).queryByText("Net invoiced · lifetime")).toBeNull();
-    expect(within(region).queryByText("Net invoiced · 12 months")).toBeNull();
+    expect(within(region).queryByText("Net invoiced · 12 mo")).toBeNull();
     expect(within(region).queryByText("Overdue")).toBeNull();
   });
 
@@ -2437,7 +2437,7 @@ describe("the money row collapses only when every slot shares one cause", () => 
     expect(within(region).getByText(/428(\.0)?K/i)).toBeTruthy();
     // The other two still ask their own question, each carrying the shared
     // reason on its own line rather than one line speaking for the row.
-    expect(within(region).getByText("Net invoiced · 12 months")).toBeTruthy();
+    expect(within(region).getByText("Net invoiced · 12 mo")).toBeTruthy();
     expect(within(region).getByText("Overdue")).toBeTruthy();
     expect(
       within(region).getAllByText("Not matched to a customer yet").length,
@@ -2513,7 +2513,7 @@ describe("the money row collapses only when every slot shares one cause", () => 
     expect(within(region).getByText("Relationship")).toBeTruthy();
     expect(within(region).getByText("Health")).toBeTruthy();
     expect(within(region).getByText("Net invoiced · lifetime")).toBeTruthy();
-    expect(within(region).getByText("Net invoiced · 12 months")).toBeTruthy();
+    expect(within(region).getByText("Net invoiced · 12 mo")).toBeTruthy();
     expect(within(region).getByText("Overdue")).toBeTruthy();
     expect(within(region).getByText(/428(\.0)?K/i)).toBeTruthy();
     expect(within(region).getByText(/186(\.4)?K/i)).toBeTruthy();

--- a/frontend/src/screens/company360.tsx
+++ b/frontend/src/screens/company360.tsx
@@ -1956,6 +1956,7 @@ function BriefSections({
           <SentenceList
             sentences={section.sentences}
             onOpenRecord={onOpenRecord}
+            citations="collected"
           />
         </div>
       ))}
@@ -2045,13 +2046,8 @@ export function AccountBrief({
   // own sourcing, so it sits in the footer band rather than inside the prose
   // it is sourcing.
   const footer = readable && (
-    <>
+    <div className="co-brief-foot">
       <WrittenBy by={readable.generated_by} />
-      <span className="t-small">
-        {t("co.brief.generatedAt", {
-          when: formatDateTime(readable.generated_at, locale, RECORD_ZONE),
-        })}
-      </span>
       <Button
         small
         onClick={() => rewrite.mutate()}
@@ -2059,10 +2055,23 @@ export function AccountBrief({
       >
         {rewrite.isPending ? t("co.brief.rewriting") : t("co.brief.rewrite")}
       </Button>
-    </>
+    </div>
+  );
+  // The "as of" timestamp reads as the header's own fact — when this record
+  // was last assembled — rather than a footnote under the rewrite control.
+  const titleAction = readable && (
+    <span className="t-small">
+      {t("co.brief.generatedAt", {
+        when: formatDateTime(readable.generated_at, locale, RECORD_ZONE),
+      })}
+    </span>
   );
   return (
-    <Panel title={t("co.brief.title")} footer={footer}>
+    <Panel
+      title={t("co.brief.title")}
+      titleAction={titleAction}
+      footer={footer}
+    >
       <PanelBody className="co-brief-body">
         {brief.isPending && <Skeleton width="100%" height={64} />}
         {/* Errored, or answered with a payload this build cannot read: both are
@@ -2546,16 +2555,18 @@ function FinanceStat({
     <StatCard
       label={t(`co.strip.${reading}`)}
       value={formatMoneyCompact(amount.amount_minor, amount.currency, locale)}
-      source={
-        namesSource && data?.provider ? (
-          <Badge>{data.provider}</Badge>
-        ) : undefined
-      }
       // The source is named ONCE, on the trailing-year slot — the row's
       // primary money reading, and the one a connected account always has. Which
       // accounting system a figure came from is a fact about the CONNECTION,
       // not about each figure, and five slots reading one query would repeat
       // it five times across a strip that has to stay one line.
+      //
+      // As the detail line, not a badge: a strip slot is narrower than a
+      // free-standing stat card, and a badge beside the label wraps onto its
+      // own row underneath it — the one slot naming its source then stood
+      // taller than every sibling in the row. The detail line already exists
+      // for exactly this (a caveat on the figure above it), so the provider
+      // name takes it when there is no caveat to show instead.
       //
       // A figure that is not current is shown WITH its caveat rather than
       // withheld: the last known number is usually the right one, and hiding
@@ -2566,7 +2577,7 @@ function FinanceStat({
       // the date matters. `error` is the last good answer after an attempt
       // that failed. Calling either one the other is a wrong claim about
       // whether anything is broken.
-      detail={caveat && t(caveat)}
+      detail={caveat ? t(caveat) : (namesSource && data?.provider) || undefined}
     />
   );
 }


### PR DESCRIPTION
## Summary
- Net invoiced's provider name moves from a badge beside the label to the detail line, so a wrapped label no longer stacks a third row under that slot and throws its baseline off from the rest of the strip.
- Strip value text sized down slightly.
- "Net invoiced · 12 months" → "Net invoiced · 12 mo" so the label stays on one line.
- "Balanced exchange" → "Balanced".

## Test plan
- [x] `npx vitest run src/screens/company360.test.tsx` (87 passed)
- [x] `npx tsc -b`
- [x] `npx biome check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tidies the Company 360 KPI strip to keep slots aligned and readable. Previously, the provider badge beside “Net invoiced” could wrap to a third row and misalign the strip; now the provider renders in the detail line when no caveat is present, and labels are shortened.

- Moves the “Net invoiced” provider from a badge beside the label to the detail line; caveats still take precedence.
- Shrinks strip value text slightly to reduce wrapping.
- Shortens labels: “Net invoiced · 12 months” → “Net invoiced · 12 mo”, “Balanced exchange” → “Balanced”.
- Ensures wrapped labels don’t collide with figures in a narrow slot.
- Updates tests to match the new copy and layout.

**Brief layout**
- Moves the “generated at” timestamp to the panel header as `titleAction`; keeps `WrittenBy` and the rewrite button in a new footer bar.
- Reflows sections into a two‑column grid (label + prose), tightens spacing/typography, and collects citations via `SentenceList` with `citations="collected"`.

<sup>Written for commit 963c6a3ffeec79021f52f903abefb3c6107d78ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1128?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Improved company brief layout with clearer two-column sections, spacing, typography, and responsive footer presentation.
  * Moved brief metadata and rewrite controls into the panel header and footer for easier access.
  * Grouped brief citations beneath their relevant sections.
  * Refined finance attribution and KPI labels for a cleaner, more concise presentation.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->