### PR TITLE
feat(companies): the list shows what a company is, not two empty columns

### DIFF
--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -4049,6 +4049,47 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/capture/blocked-domains": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * The domains refused a company, and why.
+         * @description Every domain carrying a standing admission decision: the vendors and bulk senders the
+         *     system refused a company, and the ones a human deliberately let back in. Each entry says
+         *     WHAT decided it — a model verdict, a heuristic, or a person — so an operator can tell an
+         *     automatic refusal from somebody's deliberate one.
+         *
+         *     Every human role may read the list; changing an entry demands `organization:update`
+         *     (admin/ops). Human-only: this is capture posture, not record data.
+         */
+        get: operations["listBlockedDomains"];
+        /**
+         * Block a domain, or unblock one (admin/ops).
+         * @description `admission: suppressed` refuses the domain a company; `admission: admitted` lets it in
+         *     and KEEPS it in — a human decision is sticky, so no later verdict or heuristic may
+         *     re-refuse a domain a person deliberately admitted.
+         *
+         *     Unblocking re-opens the company question rather than merely clearing a flag: the domain
+         *     was already asked and answered, so nothing would ask again on its own. The disposition
+         *     returns to pending with its attempts reset, the triage sweep picks it up, and the people
+         *     already captured on that domain get their employment edges when the company lands. That
+         *     is the McKinsey case — a newsletter publisher that became a client.
+         *
+         *     Idempotent on the domain, which is normalized to its registrable form. Audit-only write
+         *     (no event stream, EVT-NOEVT-3).
+         */
+        put: operations["setBlockedDomain"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/capture/consumer-mail-baseline": {
         parameters: {
             query?: never;
@@ -7272,6 +7313,51 @@ export interface components {
         UpdateCaptureSettingsRequest: {
             /** @description Toggle captured-organization auto-enrichment. */
             auto_enrich?: boolean;
+        };
+        /**
+         * @description One domain carrying a standing admission decision. `suppressed` refuses it a company —
+         *     a vendor or bulk sender the business does not sell to — while `admitted` is a human
+         *     deliberately letting one in, which no later verdict may undo.
+         */
+        BlockedDomain: {
+            /** @description The registrable domain the decision is about. */
+            domain: string;
+            /**
+             * @description `suppressed` — never a company. `admitted` — allowed, and sticky against later machine refusals.
+             * @enum {string}
+             */
+            admission: "suppressed" | "admitted";
+            /** @description One sentence an operator can act on: why this domain was refused or let in. */
+            reason: string;
+            /**
+             * @description What decided it. `human` decisions outrank every machine one.
+             * @enum {string}
+             */
+            source: "verdict" | "heuristic" | "human";
+            /** Format: date-time */
+            decided_at: string;
+            /**
+             * Format: uuid
+             * @description The company on this domain, when one exists — an admitted domain usually has one.
+             */
+            organization_id?: string | null;
+        };
+        SetBlockedDomainRequest: {
+            /** @description A mail domain; normalized to its registrable form before it is stored. */
+            domain: string;
+            /** @enum {string} */
+            admission: "suppressed" | "admitted";
+            /** @description Why. Required, because a refusal nobody can explain is one nobody can review. */
+            reason: string;
+        };
+        BlockedDomainListResponse: {
+            data: components["schemas"]["BlockedDomain"][];
+            /**
+             * @description How many decisions exist, which is not how many are returned. Refusals accumulate
+             *     automatically from every bulk-sender verdict, so a list that quietly stopped at its
+             *     page size would tell an operator their domain was never refused when it was.
+             */
+            total: number;
         };
         /**
          * @description One entry on the workspace's own consumer-mail list (CAP-PARAM-5). `extra` marks a
@@ -22643,6 +22729,55 @@ export interface operations {
             };
             401: components["responses"]["Unauthorized"];
             403: components["responses"]["Forbidden"];
+        };
+    };
+    listBlockedDomains: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The workspace's blocked and admitted domains. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BlockedDomainListResponse"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+        };
+    };
+    setBlockedDomain: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SetBlockedDomainRequest"];
+            };
+        };
+        responses: {
+            /** @description The stored decision. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BlockedDomain"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            422: components["responses"]["ValidationError"];
         };
     };
     listConsumerMailBaseline: {

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -557,6 +557,8 @@ export const de = {
     "Der Einwilligungszweck-Katalog konnte nicht geladen werden — welche Zwecke ein Double-Opt-in brauchen, lässt sich gerade nicht anzeigen.",
 
   "org.name": "Firma",
+  "org.description": "Was sie tun",
+  "org.website": "Website",
   "org.industry": "Branche",
   "org.size": "Größe",
   "org.classification": "Typ",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -564,6 +564,8 @@ export const en = {
     "Couldn't load the consent purpose catalogue, so which purposes need a double opt-in can't be shown right now.",
 
   "org.name": "Company",
+  "org.description": "What they do",
+  "org.website": "Website",
   "org.industry": "Industry",
   "org.size": "Size",
   "org.classification": "Type",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -553,6 +553,8 @@ export const vi = {
     "Không tải được danh mục mục đích chấp thuận, nên hiện chưa thể cho biết mục đích nào cần xác nhận kép.",
 
   "org.name": "Công ty",
+  "org.description": "Họ làm gì",
+  "org.website": "Trang web",
   "org.industry": "Ngành",
   "org.size": "Quy mô",
   "org.classification": "Loại",

--- a/frontend/src/screens/companyheader.tsx
+++ b/frontend/src/screens/companyheader.tsx
@@ -552,7 +552,7 @@ export function CompanyDescription({ org }: Readonly<{ org: Organization }>) {
 // The scheme is noise in a chip: every one of these is https, and "https://"
 // costs eight characters of a row that has little space to fit it in. A URL
 // we cannot parse is shown whole rather than silently dropped.
-function displayHost(url: string): string {
+export function displayHost(url: string): string {
   try {
     return new URL(url).host.replace(/^www\./, "");
   } catch {

--- a/frontend/src/screens/organizations.tsx
+++ b/frontend/src/screens/organizations.tsx
@@ -78,6 +78,7 @@ import {
   CompanyIdentityLine,
   CompanyLifecycleControl,
   CompanyPrimaryActions,
+  displayHost,
 } from "./companyheader";
 import {
   LIFECYCLE_LABELS,
@@ -575,14 +576,28 @@ export function CompaniesScreen() {
             fixed: true,
           },
           {
-            key: "industry",
-            header: t("org.industry"),
-            cell: (org: Organization) => org.industry ?? "",
+            // What the company DOES, in their own words from their own site.
+            // This replaced industry and size: in a real import size_band was
+            // null for every company and industry for most, so the list's two
+            // widest columns were reliably empty.
+            key: "description",
+            header: t("org.description"),
+            cell: (org: Organization) => org.description ?? "",
           },
           {
-            key: "size",
-            header: t("org.size"),
-            cell: (org: Organization) => org.size_band ?? "",
+            key: "website",
+            header: t("org.website"),
+            cell: (org: Organization) =>
+              org.website_url ? (
+                <a
+                  href={org.website_url}
+                  target="_blank"
+                  rel="noreferrer noopener"
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  {displayHost(org.website_url)}
+                </a>
+              ) : null,
           },
           {
             key: "class",


### PR DESCRIPTION
## The two widest columns were reliably empty

In a real import, `size_band` was NULL for **all 108** companies and `industry` for **40** of them. A rep scanning the companies list read a name and two blanks.

Both are replaced by what the site read already collected and nobody could see: the **one-line description** of what the company does, and its **website**. Both have been in the list payload for some time — the columns simply never existed.

## Also: a drift repair main needs

`frontend/src/api/schema.d.ts` is regenerated here. The blocked-domain endpoints landed in #1125 without it, so **`make check-fe` fails on an unmodified checkout of main today**. Unrelated to the column change, included because the gate cannot pass without it.

## What was cut, and why

This PR originally carried a **"last contact" column** and a **"not a company"** action. Adversarial review found both unsound, and I have removed them rather than patch around the findings.

**last_touch_at** — four defects, the first serious:
- The aggregation checked `organization:read` but never `activity:read` or the activity link-walk row scope, so a caller could learn the exact timestamp of mail belonging to a person they cannot see.
- The employment arm counted archived people and ended employments.
- It required `is_current_primary`, diverging from the established walk, so a consultant at two companies showed contact for only one.
- The `max()` scanned every historical activity link for every organization on the page — unbounded work behind a bounded response.

The root cause is structural: the correct predicate is `activities.OrgReachSet()`, and a module never imports a sibling, so computing this in `people` meant hand-rolling a second spelling of the walk. It belongs in `compose`. → **#1131**

**"Not a company"** — one logical mutation implemented as two HTTP writes, offered without checking `organization:delete` (seeded reps have update but not delete, so the first write lands and the second 403s), and without excluding the anchor. → **#1132**

Both are worth having. Neither was worth shipping in that shape.

## Gates

`make check-fe` and `make check-backend` green, and **69 Playwright E2E tests pass** — this changes user-visible strings, which `check-fe` does not cover.