### PR TITLE
fix(integrations): a polled run never finished, and the card showed credits for a destroyed key

### DIFF
--- a/backend/internal/compose/jobactor_test.go
+++ b/backend/internal/compose/jobactor_test.go
@@ -52,7 +52,14 @@ var storeBuilders = regexp.MustCompile(`(providerRunStore|workspaceJobDB)\(`)
 
 // actorBinders are the ways a worker legitimately names its principal: the
 // helper in this package, or principal.WithActor directly.
-var actorBinders = regexp.MustCompile(`(providerJobActor|principal\.WithActor)\(`)
+//
+// The ASSIGNMENT is part of the pattern, not decoration. Both calls return a
+// new context and mutate nothing, so `providerJobActor(wsCtx)` on its own line
+// compiles, reads like a binding, and leaves the store holding a context with
+// no actor in it — the precise bug this gate exists to catch, sailing past a
+// check that only asked whether the name appeared.
+var actorBinders = regexp.MustCompile(
+	`\w+\s*(=|:=)\s*(providerJobActor|principal\.WithActor)\(`)
 
 // workMethod matches a River worker's entry point and captures its receiver,
 // which is the worker's name in the failure message.
@@ -68,8 +75,11 @@ func TestEveryJobWorkerThatReachesAStoreBindsAnActor(t *testing.T) {
 	offenders := map[string]string{}
 	var checked int
 	for _, f := range files {
+		// Every .go file in the package, not just jobs_*.go: a worker lives
+		// wherever its author put it (capturejobs.go, for one), and a gate that
+		// trusts a filename convention misses the file that broke it.
 		name := f.Name()
-		if !strings.HasPrefix(name, "jobs_") || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+		if !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
 			continue
 		}
 		src, err := os.ReadFile(name)

--- a/backend/internal/compose/jobactor_test.go
+++ b/backend/internal/compose/jobactor_test.go
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// Every job worker that reaches a store must bind an ACTOR, not just a
+// workspace.
+//
+// A queue is not a request: it inherits no principal, so a worker that binds
+// only its tenant reaches the first RBAC gate with nothing to check and the
+// write is refused. The provider-run workers shipped that way — the poll job
+// failed with "no actor bound to context" on every pass, so a paid enrichment
+// run sat in_progress forever and the values it bought reached nobody. The
+// money was spent and there was nothing to show for it.
+//
+// Nothing could have caught that but this shape of test. The failure is in the
+// wiring rather than in any store, it needs a real queue to reproduce, and it
+// looks exactly like a slow provider from the outside.
+//
+// So this reads the wiring itself: every Work method that builds a store must
+// also bind an actor. Derived from the tree rather than a hand-kept list,
+// because the next job added is the one nobody remembers to check.
+//
+// Three older workers are waived below rather than fixed. They have the same
+// shape, but whether each one actually reaches a gated write is a question
+// about three other subsystems, and answering it wrongly would either break
+// working jobs or paper over a live defect. Issue #1127 tracks that audit; the
+// waiver is a ratchet — a waived worker that starts binding an actor fails
+// this test until its entry is removed.
+
+import (
+	"os"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/gatekit"
+)
+
+// jobActorUnbound: workers that predate this gate and bind no actor. Each
+// needs its own subsystem checked before it is changed — see #1127.
+var jobActorUnbound = gatekit.Waive(map[string]string{
+	"privacyRetentionWorkspaceWorker": "retention sweep; whether its writes are gated is #1127's question",
+	"timeScanWorkspaceWorker":         "automation time-scan; same audit",
+	"webhookRetryWorkspaceWorker":     "webhook delivery retry; same audit",
+})
+
+// storeBuilders are the per-workspace store constructors. A Work method that
+// calls one is about to reach an RBAC-gated entry point.
+var storeBuilders = regexp.MustCompile(`(providerRunStore|workspaceJobDB)\(`)
+
+// actorBinders are the ways a worker legitimately names its principal: the
+// helper in this package, or principal.WithActor directly.
+var actorBinders = regexp.MustCompile(`(providerJobActor|principal\.WithActor)\(`)
+
+// workMethod matches a River worker's entry point and captures its receiver,
+// which is the worker's name in the failure message.
+var workMethod = regexp.MustCompile(`func \(\w+ \*(\w+)\) Work\(`)
+
+func TestEveryJobWorkerThatReachesAStoreBindsAnActor(t *testing.T) {
+	defer jobActorUnbound.AssertAllMatched(t)
+	files, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("reading the compose package: %v", err)
+	}
+
+	offenders := map[string]string{}
+	var checked int
+	for _, f := range files {
+		name := f.Name()
+		if !strings.HasPrefix(name, "jobs_") || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		src, err := os.ReadFile(name)
+		if err != nil {
+			t.Fatalf("reading %s: %v", name, err)
+		}
+		for _, body := range workMethodBodies(string(src)) {
+			checked++
+			if !storeBuilders.MatchString(body.text) {
+				continue
+			}
+			if actorBinders.MatchString(body.text) {
+				continue
+			}
+			if jobActorUnbound.Waived(t, body.worker) {
+				continue
+			}
+			offenders[body.worker] = name
+		}
+	}
+
+	if checked == 0 {
+		t.Fatal("no job Work methods found — this gate would pass vacuously; check the jobs_*.go naming")
+	}
+
+	names := make([]string, 0, len(offenders))
+	for w := range offenders {
+		names = append(names, w)
+	}
+	sort.Strings(names)
+	for _, w := range names {
+		t.Errorf("%s.Work (%s) builds a store but binds no actor — its first RBAC-gated write will be refused with \"no actor bound to context\", and a queue carries no principal to inherit. Bind one the way providerJobActor does",
+			w, offenders[w])
+	}
+}
+
+type workBody struct {
+	worker string
+	text   string
+}
+
+// workMethodBodies splits a file into its Work methods. A method runs to the
+// next top-level `func ` or to end of file, which is enough structure here: the
+// question is only which calls appear inside one.
+func workMethodBodies(src string) []workBody {
+	locs := workMethod.FindAllStringSubmatchIndex(src, -1)
+	out := make([]workBody, 0, len(locs))
+	for i, loc := range locs {
+		end := len(src)
+		if next := regexp.MustCompile(`(?m)^func `).FindStringIndex(src[loc[1]:]); next != nil {
+			end = loc[1] + next[0]
+		}
+		if i+1 < len(locs) && locs[i+1][0] < end {
+			end = locs[i+1][0]
+		}
+		out = append(out, workBody{worker: src[loc[2]:loc[3]], text: src[loc[0]:end]})
+	}
+	return out
+}

--- a/backend/internal/compose/jobs_providerruns.go
+++ b/backend/internal/compose/jobs_providerruns.go
@@ -21,6 +21,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/platform/jobs"
 	"github.com/gradionhq/margince/backend/internal/platform/keyvault"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
 
 // ProviderRunsConfig is the provider-run lanes' slice of the runner's boot
@@ -96,6 +97,7 @@ func (w *providerRunSubmitWorker) Work(ctx context.Context, job *river.Job[Provi
 	if err != nil {
 		return jobs.FaultContext(ctx, err)
 	}
+	wsCtx = providerJobActor(wsCtx)
 	store, err := providerRunStore(w.pool, w.cfg, job.Args)
 	if err != nil {
 		return jobs.FaultContext(ctx, err)
@@ -112,6 +114,24 @@ func (ProviderRunPollSweepArgs) Kind() string { return "provider_run_poll_sweep"
 // FleetWide marks this a dispatcher: it enumerates and enqueues, and does no
 // tenant work of its own (jobs.FleetWide).
 func (ProviderRunPollSweepArgs) FleetWide() {}
+
+// providerJobActor binds the principal a provider run executes as.
+//
+// The connector is the actor because every value these runs write is bought
+// from the provider, not typed by anybody: the claim rows carry
+// `connector:surfe` provenance, and a reader must be able to tell purchased
+// data from a colleague's entry. It also carries a correlation id, which the
+// outbox envelope requires.
+//
+// Without this the hand-off refused with "no actor bound to context" and every
+// polled run stayed in_progress forever — the run was paid for, the provider
+// had answered, and the values reached nobody.
+func providerJobActor(ctx context.Context) context.Context {
+	ctx = principal.WithActor(ctx, principal.Principal{
+		Type: principal.PrincipalSystem, ID: "connector:surfe",
+	})
+	return principal.WithCorrelationID(ctx, ids.NewV7())
+}
 
 // providerRunPollSweepWorker fans one drain job out per live workspace.
 type providerRunPollSweepWorker struct {
@@ -148,6 +168,7 @@ func (w *providerRunPollWorker) Work(ctx context.Context, job *river.Job[Provide
 	if err != nil {
 		return jobs.FaultContext(ctx, err)
 	}
+	wsCtx = providerJobActor(wsCtx)
 	store, err := providerRunStore(w.pool, w.cfg, job.Args)
 	if err != nil {
 		return jobs.FaultContext(ctx, err)

--- a/backend/internal/modules/integrations/connect.go
+++ b/backend/internal/modules/integrations/connect.go
@@ -197,6 +197,18 @@ func (s *Store) Disconnect(ctx context.Context, name string) error {
 			 WHERE provider = $1 AND state = 'queued'`, name); err != nil {
 			return fmt.Errorf("integrations: cancelling queued runs: %w", err)
 		}
+		// The balance goes with the credential that read it. It was obtained BY
+		// presenting the key we just destroyed, so keeping it would leave the
+		// card showing "19 credits left" beside "Not connected" — a number we
+		// have no way to refresh and no standing to assert. The ceilings stay:
+		// those are the customer's own policy, not the provider's reading.
+		if _, err := tx.Exec(ctx, `
+			UPDATE provider_connection_budget b
+			   SET last_known_balance = NULL, balance_read_at = NULL
+			  FROM provider_connection c
+			 WHERE c.id = b.connection_id AND c.provider = $1`, name); err != nil {
+			return fmt.Errorf("integrations: clearing the provider balance: %w", err)
+		}
 		if _, err := storekit.Audit(ctx, tx, "disconnect", "provider_connection", uuidOf(id),
 			map[string]any{auditKeyProvider: name}, nil); err != nil {
 			return err

--- a/backend/internal/modules/integrations/execute_integration_test.go
+++ b/backend/internal/modules/integrations/execute_integration_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/provider"
 )
 
@@ -158,6 +159,61 @@ func TestAmbiguousSubmissionParksUnknownAndHoldsTheReservation(t *testing.T) {
 	}
 	if held == 0 {
 		t.Fatal("the reservation was released on an unknown outcome — the next run could double-spend credits the customer may have been charged")
+	}
+}
+
+// Disconnecting takes the provider's balance with the credential.
+//
+// The number was obtained BY presenting the key the disconnect destroys, so
+// keeping it leaves the settings card showing "19 credits left" beside "Not
+// connected" — a figure nothing can refresh and nobody has standing to assert.
+// The customer's own ceilings survive, because those are their policy rather
+// than the provider's reading.
+func TestDisconnectClearsTheProviderBalanceAndKeepsTheCeilings(t *testing.T) {
+	e := setupRuns(t, runsConfig{ceilings: map[string]int{"email": 25}})
+	sealCredential(t, e)
+
+	ctx := context.Background()
+	if _, err := e.owner.Exec(ctx, `
+		UPDATE provider_connection_budget b
+		   SET last_known_balance = 19, balance_read_at = now()
+		  FROM provider_connection c
+		 WHERE c.id = b.connection_id AND c.provider = 'surfe'`); err != nil {
+		t.Fatal(err)
+	}
+
+	// Its own principal: disconnecting is a DELETE on integrations, and the
+	// shared rep context deliberately carries read only. Widening that would
+	// weaken every other test in this file.
+	admin := principal.WithActor(e.ctx, principal.Principal{
+		Type: principal.PrincipalHuman, ID: "human:admin-" + e.ws.String(),
+		Permissions: principal.Permissions{
+			Objects:  map[string]principal.ObjectGrant{"integrations": {Read: true, Delete: true}},
+			RowScope: principal.RowScopeAll,
+		},
+	})
+	if err := e.store.Disconnect(admin, "surfe"); err != nil {
+		t.Fatal(err)
+	}
+
+	var balance, ceiling *int
+	var readAt *time.Time
+	if err := e.owner.QueryRow(ctx, `
+		SELECT b.last_known_balance, b.balance_read_at, b.monthly_ceiling
+		  FROM provider_connection_budget b
+		  JOIN provider_connection c ON c.id = b.connection_id
+		 WHERE c.provider = 'surfe' AND b.pool = 'email'`).
+		Scan(&balance, &readAt, &ceiling); err != nil {
+		t.Fatal(err)
+	}
+	if balance != nil {
+		t.Errorf("the balance survived the disconnect (%d credits) — the card would show credits for a key that no longer exists", *balance)
+	}
+	if readAt != nil {
+		t.Errorf("the balance timestamp survived the disconnect (%s) — it dates a reading whose credential is gone", readAt.Format(time.RFC3339))
+	}
+	if ceiling == nil || *ceiling != 25 {
+		t.Errorf("the monthly ceiling is %v, want 25 — disconnecting withdraws the provider's number, not the customer's own limit", ceiling)
 	}
 }
 

--- a/backend/internal/modules/integrations/offline.go
+++ b/backend/internal/modules/integrations/offline.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -37,8 +38,12 @@ type OfflineProvider struct {
 	// pollsBeforeDone makes the polled transport real: the first N polls
 	// answer pending, like Surfe's ~9 one-second polls.
 	pollsBeforeDone int
-	polls           map[string]*atomic.Int64
-	now             func() time.Time
+	// polls counts them per provider job id. A sync.Map because the poll sweep
+	// is genuinely concurrent — one process polls many runs at once, and a
+	// plain map lost entries here, which reset the count to 1 on every sweep so
+	// a run in the dev stack never left in_progress.
+	polls sync.Map
+	now   func() time.Time
 }
 
 // NewOfflineProvider builds the fake. pollsBeforeDone of 0 completes on the
@@ -47,7 +52,6 @@ type OfflineProvider struct {
 func NewOfflineProvider(pollsBeforeDone int, now func() time.Time) *OfflineProvider {
 	return &OfflineProvider{
 		pollsBeforeDone: pollsBeforeDone,
-		polls:           map[string]*atomic.Int64{},
 		now:             now,
 	}
 }
@@ -169,10 +173,12 @@ func (p *OfflineProvider) Submit(ctx context.Context, cred provider.Credential, 
 // platform parks no payload between attempts.
 func (p *OfflineProvider) Poll(ctx context.Context, cred provider.Credential, jobID string) (provider.PollStatus, error) {
 	p.calls.Add(1)
-	counter, ok := p.polls[jobID]
+	// LoadOrStore, not load-then-store: two sweeps polling the same run at once
+	// would otherwise each install their own counter and neither would climb.
+	entry, _ := p.polls.LoadOrStore(jobID, &atomic.Int64{})
+	counter, ok := entry.(*atomic.Int64)
 	if !ok {
-		counter = &atomic.Int64{}
-		p.polls[jobID] = counter
+		return provider.PollStatus{}, fmt.Errorf("offline provider: poll counter for %s has type %T", jobID, entry)
 	}
 	if int(counter.Add(1)) <= p.pollsBeforeDone {
 		return provider.PollStatus{Outcome: provider.OutcomePending}, nil

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -4049,6 +4049,47 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/capture/blocked-domains": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * The domains refused a company, and why.
+         * @description Every domain carrying a standing admission decision: the vendors and bulk senders the
+         *     system refused a company, and the ones a human deliberately let back in. Each entry says
+         *     WHAT decided it — a model verdict, a heuristic, or a person — so an operator can tell an
+         *     automatic refusal from somebody's deliberate one.
+         *
+         *     Every human role may read the list; changing an entry demands `organization:update`
+         *     (admin/ops). Human-only: this is capture posture, not record data.
+         */
+        get: operations["listBlockedDomains"];
+        /**
+         * Block a domain, or unblock one (admin/ops).
+         * @description `admission: suppressed` refuses the domain a company; `admission: admitted` lets it in
+         *     and KEEPS it in — a human decision is sticky, so no later verdict or heuristic may
+         *     re-refuse a domain a person deliberately admitted.
+         *
+         *     Unblocking re-opens the company question rather than merely clearing a flag: the domain
+         *     was already asked and answered, so nothing would ask again on its own. The disposition
+         *     returns to pending with its attempts reset, the triage sweep picks it up, and the people
+         *     already captured on that domain get their employment edges when the company lands. That
+         *     is the McKinsey case — a newsletter publisher that became a client.
+         *
+         *     Idempotent on the domain, which is normalized to its registrable form. Audit-only write
+         *     (no event stream, EVT-NOEVT-3).
+         */
+        put: operations["setBlockedDomain"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/capture/consumer-mail-baseline": {
         parameters: {
             query?: never;
@@ -7272,6 +7313,51 @@ export interface components {
         UpdateCaptureSettingsRequest: {
             /** @description Toggle captured-organization auto-enrichment. */
             auto_enrich?: boolean;
+        };
+        /**
+         * @description One domain carrying a standing admission decision. `suppressed` refuses it a company —
+         *     a vendor or bulk sender the business does not sell to — while `admitted` is a human
+         *     deliberately letting one in, which no later verdict may undo.
+         */
+        BlockedDomain: {
+            /** @description The registrable domain the decision is about. */
+            domain: string;
+            /**
+             * @description `suppressed` — never a company. `admitted` — allowed, and sticky against later machine refusals.
+             * @enum {string}
+             */
+            admission: "suppressed" | "admitted";
+            /** @description One sentence an operator can act on: why this domain was refused or let in. */
+            reason: string;
+            /**
+             * @description What decided it. `human` decisions outrank every machine one.
+             * @enum {string}
+             */
+            source: "verdict" | "heuristic" | "human";
+            /** Format: date-time */
+            decided_at: string;
+            /**
+             * Format: uuid
+             * @description The company on this domain, when one exists — an admitted domain usually has one.
+             */
+            organization_id?: string | null;
+        };
+        SetBlockedDomainRequest: {
+            /** @description A mail domain; normalized to its registrable form before it is stored. */
+            domain: string;
+            /** @enum {string} */
+            admission: "suppressed" | "admitted";
+            /** @description Why. Required, because a refusal nobody can explain is one nobody can review. */
+            reason: string;
+        };
+        BlockedDomainListResponse: {
+            data: components["schemas"]["BlockedDomain"][];
+            /**
+             * @description How many decisions exist, which is not how many are returned. Refusals accumulate
+             *     automatically from every bulk-sender verdict, so a list that quietly stopped at its
+             *     page size would tell an operator their domain was never refused when it was.
+             */
+            total: number;
         };
         /**
          * @description One entry on the workspace's own consumer-mail list (CAP-PARAM-5). `extra` marks a
@@ -22643,6 +22729,55 @@ export interface operations {
             };
             401: components["responses"]["Unauthorized"];
             403: components["responses"]["Forbidden"];
+        };
+    };
+    listBlockedDomains: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The workspace's blocked and admitted domains. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BlockedDomainListResponse"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+        };
+    };
+    setBlockedDomain: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SetBlockedDomainRequest"];
+            };
+        };
+        responses: {
+            /** @description The stored decision. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BlockedDomain"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            422: components["responses"]["ValidationError"];
         };
     };
     listConsumerMailBaseline: {

--- a/frontend/src/design-system/provider-mark.tsx
+++ b/frontend/src/design-system/provider-mark.tsx
@@ -122,5 +122,34 @@ export function ProviderMark({
       </svg>
     );
   }
+  if (providerKey === "surfe") {
+    return (
+      <svg
+        className="provider-mark"
+        viewBox="0 0 24 24"
+        aria-hidden="true"
+        focusable="false"
+      >
+        {/* Surfe's own dark, on the same badge shape the others use.
+            Deliberately their INITIAL rather than a redrawing of their logo:
+            the marks above are each vendor's published logo geometry, and
+            approximating one from memory would put a wrong mark in their
+            colours — worse than a plain letter that claims to be nothing more
+            than a letter. Replace it if Surfe publish usage terms and artwork. */}
+        <rect width="24" height="24" rx="4" fill="#1A1A2E" />
+        <text
+          x="12"
+          y="17"
+          textAnchor="middle"
+          fill="#fff"
+          fontSize="14"
+          fontWeight="700"
+          fontFamily="system-ui, sans-serif"
+        >
+          S
+        </text>
+      </svg>
+    );
+  }
   return <KeyRound className="provider-mark" aria-hidden="true" />;
 }

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -4353,6 +4353,11 @@ export const de = {
   "provider.connect": "Verbinden",
   "provider.reconnect": "Schlüssel ersetzen",
   "provider.apiKey": "API-Schlüssel",
+  "provider.apiKeyStored": "API-Schlüssel ersetzen",
+  "provider.apiKeyReplaceHint":
+    "Ein Schlüssel ist hinterlegt und aktiv. Er lässt sich nicht erneut anzeigen, deshalb bleibt dieses Feld leer — einen neuen nur einsetzen, wenn Sie ihn austauschen wollen.",
+  "provider.apiKeyReplacePlaceholder":
+    "Neuen Schlüssel einsetzen, um den hinterlegten zu ersetzen",
   "provider.apiKeyHint":
     "Wird nach der Prüfung sofort versiegelt. Er wird nie wieder angezeigt und verlässt diese Installation nur Richtung Anbieter.",
   "provider.connectConfirm.title": "Datenanbieter verbinden?",
@@ -4375,14 +4380,18 @@ export const de = {
   "provider.credits": "Restguthaben beim Anbieter",
   "provider.credits.pool": "{pool}",
   "provider.credits.none": "Der Anbieter hat uns noch keinen Stand genannt.",
+  "provider.credits.notConnected":
+    "Mit einem hinterlegten Schlüssel sehen Sie hier Ihr Guthaben beim Anbieter.",
   "provider.constraints": "Geltende Grenzen",
   "provider.spend": "Was wir verbraucht haben",
   "provider.spend.hint":
     "Unsere eigene Aufzeichnung dessen, was die Anreicherung gekostet hat. Nicht die Rechnung des Anbieters — dieselben Guthaben lassen sich auch über dessen App ausgeben, die beiden Zahlen dürfen also auseinandergehen.",
   "provider.spend.thisMonth": "Diesen Monat",
-  "provider.spend.charged": "{pool}: {credits} Guthaben für {count} Abfragen",
-  "provider.spend.held":
-    "Davon liegen {credits} auf Abfragen, deren Ausgang wir nie erfahren haben.",
+  "provider.spend.month": "Monat",
+  "provider.spend.pool": "Kontingent",
+  "provider.spend.chargedHead": "Guthaben",
+  "provider.spend.heldHead": "Reserviert",
+  "provider.spend.runsHead": "Abfragen",
   "provider.spend.none": "Es wurde noch nichts gekauft.",
   "provider.mode": "Wann angereichert wird",
   "provider.mode.automatic_on_create": "Sobald Kontakte entstehen",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -4350,6 +4350,11 @@ export const en = {
   "provider.apiKey": "API key",
   "provider.apiKeyHint":
     "Sealed as soon as it is verified. It is never shown again, and never leaves this installation except to the provider.",
+  "provider.apiKeyStored": "Replace the API key",
+  "provider.apiKeyReplaceHint":
+    "A key is stored and in use. It cannot be shown again, so this box stays empty — paste a new one only if you are replacing it.",
+  "provider.apiKeyReplacePlaceholder":
+    "Paste a new key to replace the stored one",
   "provider.connectConfirm.title": "Connect this data provider?",
   "provider.connectConfirm.body":
     "The key is checked against the provider before anything is saved. Once connected, enriching a contact spends your credits.",
@@ -4369,14 +4374,21 @@ export const en = {
   "provider.credits": "Credits left with the provider",
   "provider.credits.pool": "{pool}",
   "provider.credits.none": "The provider has not told us a balance yet.",
+  "provider.credits.notConnected":
+    "Connect a key to see what credit you have with the provider.",
   "provider.constraints": "Limits in force",
   "provider.spend": "What we have used",
   "provider.spend.hint":
     "Our own record of what enrichment consumed. Not the provider's invoice — the same credits can be spent through their app, so the two figures differ legitimately.",
   "provider.spend.thisMonth": "This month",
-  "provider.spend.charged": "{pool}: {credits} credits over {count} lookups",
-  "provider.spend.held":
-    "{credits} of those are held against lookups whose outcome we never learned.",
+  "provider.spend.month": "Month",
+  "provider.spend.pool": "Pool",
+  "provider.spend.chargedHead": "Credits",
+  // "Held" rather than "unknown": the column holds credits whose outcome the
+  // provider never reported, which is what a human reconciles against the
+  // invoice. Kept out of the Credits column on purpose.
+  "provider.spend.heldHead": "Held",
+  "provider.spend.runsHead": "Lookups",
   "provider.spend.none": "Nothing has been bought yet.",
   "provider.mode": "When to enrich",
   "provider.mode.automatic_on_create": "As contacts are added",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -4340,6 +4340,10 @@ export const vi = {
   "provider.connect": "Kết nối",
   "provider.reconnect": "Thay khoá",
   "provider.apiKey": "Khoá API",
+  "provider.apiKeyStored": "Thay khóa API",
+  "provider.apiKeyReplaceHint":
+    "Đã có một khóa được lưu và đang dùng. Khóa không thể hiển thị lại nên ô này để trống — chỉ dán khóa mới nếu bạn muốn thay.",
+  "provider.apiKeyReplacePlaceholder": "Dán khóa mới để thay khóa đang lưu",
   "provider.apiKeyHint":
     "Được niêm phong ngay sau khi xác minh. Khoá không bao giờ hiển thị lại và chỉ rời bản cài đặt này để đến nhà cung cấp.",
   "provider.connectConfirm.title": "Kết nối nhà cung cấp dữ liệu này?",
@@ -4360,15 +4364,18 @@ export const vi = {
   "provider.credits": "Tín dụng còn lại ở nhà cung cấp",
   "provider.credits.pool": "{pool}",
   "provider.credits.none": "Nhà cung cấp chưa cho biết số dư.",
+  "provider.credits.notConnected":
+    "Kết nối khóa API để xem số dư của bạn với nhà cung cấp.",
   "provider.constraints": "Giới hạn đang áp dụng",
   "provider.spend": "Chúng ta đã dùng bao nhiêu",
   "provider.spend.hint":
     "Ghi nhận của chính chúng ta về chi phí làm giàu dữ liệu. Đây không phải hoá đơn của nhà cung cấp — cùng số tín dụng đó có thể được tiêu qua ứng dụng của họ, nên hai con số lệch nhau là chuyện bình thường.",
   "provider.spend.thisMonth": "Tháng này",
-  "provider.spend.charged":
-    "{pool}: {credits} tín dụng cho {count} lượt tra cứu",
-  "provider.spend.held":
-    "Trong đó {credits} đang bị giữ cho những lượt tra cứu mà chúng ta không bao giờ biết kết quả.",
+  "provider.spend.month": "Tháng",
+  "provider.spend.pool": "Nhóm tín dụng",
+  "provider.spend.chargedHead": "Tín dụng",
+  "provider.spend.heldHead": "Đang giữ",
+  "provider.spend.runsHead": "Lượt tra cứu",
   "provider.spend.none": "Chưa mua gì cả.",
   "provider.mode": "Khi nào làm giàu",
   "provider.mode.automatic_on_create": "Ngay khi liên hệ được tạo",

--- a/frontend/src/screens/integrations-provider.css
+++ b/frontend/src/screens/integrations-provider.css
@@ -1,0 +1,146 @@
+/* The contact-data provider card.
+ *
+ * The card answers four questions in a fixed order, and the layout has to keep
+ * them apart: who this provider is, what credit is left with THEM, what WE
+ * spent, and how the key is managed. Run together as one column of prose — the
+ * first version — a reader could not tell the provider's balance from our own
+ * accounting, which is the one confusion this card exists to prevent.
+ */
+
+.provider-card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5);
+  padding: var(--space-5);
+  border: 1px solid var(--borderSubtle);
+  border-radius: 10px;
+}
+
+.provider-card + .provider-card {
+  margin-top: var(--space-4);
+}
+
+/* Header: the mark, the name, the state. */
+.provider-card-head {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.provider-card-mark {
+  display: grid;
+  place-items: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+  flex: none;
+}
+
+.provider-card-name {
+  font-size: 15px;
+  font-weight: 600;
+  /* The provider's own capitalization, not the lowercase registry key. */
+  text-transform: capitalize;
+}
+
+/* Every block below the header carries its own heading, so the eye can land
+ * on one question at a time. */
+.provider-block-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--textSecondary);
+  margin-bottom: var(--space-2);
+}
+
+.provider-block-hint {
+  font-size: 13px;
+  color: var(--textSecondary);
+  margin-top: var(--space-2);
+}
+
+/* Balances: one row per pool, the number reading as the figure it is rather
+ * than as body text. */
+.provider-pools {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.provider-pool {
+  display: grid;
+  grid-template-columns: 6rem 1fr auto;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.provider-pool-name {
+  font-size: 13px;
+  color: var(--textSecondary);
+  text-transform: capitalize;
+}
+
+.provider-pool-value {
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+  min-width: 3ch;
+  text-align: right;
+}
+
+/* Spend: a small table, because it is a series of figures and reads as one.
+ * Tabular numerals so the columns line up down the page. */
+.provider-spend-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+
+.provider-spend-table th {
+  text-align: left;
+  font-weight: 500;
+  color: var(--textSecondary);
+  padding-bottom: var(--space-2);
+  border-bottom: 1px solid var(--borderSubtle);
+}
+
+/* Month and pool are labels and read left; the three figure columns read right
+ * so their digits line up under each other, each holding a fixed width so they
+ * stay grouped instead of stranded across the table. */
+.provider-spend-table th:nth-child(n + 3),
+.provider-spend-table td:nth-child(n + 3) {
+  width: 6rem;
+  text-align: right;
+}
+
+.provider-spend-table td {
+  padding: var(--space-2) 0;
+  font-variant-numeric: tabular-nums;
+  border-bottom: 1px solid var(--borderSubtle);
+}
+
+.provider-spend-table tr:last-child td {
+  border-bottom: none;
+}
+
+/* A held figure is not a charge. It reads quieter than the total beside it so
+ * nobody adds the two together by eye. */
+.provider-held {
+  color: var(--textSecondary);
+}
+
+/* The key form and its actions, fenced off from the numbers above. */
+.provider-credential {
+  padding-top: var(--space-4);
+  border-top: 1px solid var(--borderSubtle);
+}
+
+.provider-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  margin-top: var(--space-3);
+}
+
+.provider-empty {
+  font-size: 13px;
+  color: var(--textSecondary);
+}

--- a/frontend/src/screens/integrations-provider.tsx
+++ b/frontend/src/screens/integrations-provider.tsx
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
+import "./integrations-provider.css";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Database, Plug, Trash2 } from "lucide-react";
+import { Plug, Trash2 } from "lucide-react";
 import { useState } from "react";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
@@ -17,6 +18,7 @@ import {
 } from "../design-system/atoms";
 import { Callout } from "../design-system/callout";
 import { ConfirmModal } from "../design-system/confirmmodal";
+import { ProviderMark } from "../design-system/provider-mark";
 import { Meter } from "../design-system/readings";
 import { useT } from "../i18n";
 import {
@@ -102,12 +104,12 @@ function ProviderConnectionRow({
 }: Readonly<{ connection: ProviderConnection }>) {
   const t = useT();
   return (
-    <section className="pe-card">
-      <header
-        style={{ display: "flex", alignItems: "center", gap: "var(--space-2)" }}
-      >
-        <Database aria-hidden />
-        <strong>{connection.provider}</strong>
+    <section className="provider-card">
+      <header className="provider-card-head">
+        <span className="provider-card-mark">
+          <ProviderMark providerKey={connection.provider} />
+        </span>
+        <span className="provider-card-name">{connection.provider}</span>
         <Badge tone={connectionTone(connection.status)}>
           {t(connectionLabel(connection.status))}
         </Badge>
@@ -135,8 +137,8 @@ function SpendBlock({
   if (months.length === 0) {
     return (
       <div>
-        <h3>{t("provider.spend")}</h3>
-        <p className="muted">{t("provider.spend.none")}</p>
+        <div className="provider-block-title">{t("provider.spend")}</div>
+        <p className="provider-empty">{t("provider.spend.none")}</p>
       </div>
     );
   }
@@ -147,34 +149,41 @@ function SpendBlock({
   const current = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, "0")}-01`;
   return (
     <div>
-      <h3>{t("provider.spend")}</h3>
-      <p className="muted">{t("provider.spend.hint")}</p>
-      {months.map((month) => (
-        <div key={`${month.month}-${month.pool}`}>
-          <span className="muted">
-            {month.month === current
-              ? t("provider.spend.thisMonth")
-              : month.month}
-          </span>{" "}
-          <span>
-            {t("provider.spend.charged", {
-              pool: month.pool,
-              credits: month.charged_credits,
-              count: month.runs,
-            })}
-          </span>
-          {month.held_credits > 0 && (
-            // Never folded into the charge: the platform does not know
-            // whether those credits were spent, and a total that quietly
-            // counted them either way would assert something it cannot
-            // support. This is the figure a human reconciles against the
-            // provider's invoice.
-            <p className="muted">
-              {t("provider.spend.held", { credits: month.held_credits })}
-            </p>
-          )}
-        </div>
-      ))}
+      <div className="provider-block-title">{t("provider.spend")}</div>
+      <table className="provider-spend-table">
+        <thead>
+          <tr>
+            <th>{t("provider.spend.month")}</th>
+            <th>{t("provider.spend.pool")}</th>
+            <th>{t("provider.spend.chargedHead")}</th>
+            <th>{t("provider.spend.heldHead")}</th>
+            <th>{t("provider.spend.runsHead")}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {months.map((month) => (
+            <tr key={`${month.month}-${month.pool}`}>
+              <td>
+                {month.month === current
+                  ? t("provider.spend.thisMonth")
+                  : month.month}
+              </td>
+              <td>{month.pool}</td>
+              <td>{month.charged_credits}</td>
+              {/* Never folded into the charge: the platform does not know
+                  whether those credits were spent, and a total that quietly
+                  counted them either way would assert something it cannot
+                  support. This is the figure a human reconciles against the
+                  provider's invoice. */}
+              <td className="provider-held">
+                {month.held_credits > 0 ? month.held_credits : "—"}
+              </td>
+              <td>{month.runs}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <p className="provider-block-hint">{t("provider.spend.hint")}</p>
     </div>
   );
 }
@@ -185,26 +194,39 @@ function CreditsBlock({
   const t = useT();
   // Iterated, never hardcoded to email/mobile: the pool names are the
   // PROVIDER's own vocabulary, and a second provider meters different ones.
-  const pools = Object.entries(connection.credits?.pools ?? {});
+  // A pool whose balance is null is a pool we have no reading for — the
+  // disconnect clears the number with the credential that fetched it. Rendering
+  // it as 0 would assert an empty account, which is a different claim from
+  // "we do not know" and the one thing this block must never say by accident.
+  const pools = Object.entries(connection.credits?.pools ?? {}).filter(
+    ([, balance]) => balance !== null && balance !== undefined,
+  );
   if (pools.length === 0) {
-    return <p className="muted">{t("provider.credits.none")}</p>;
+    // Two different silences. With no key we never asked, and saying the
+    // provider "has not told us" would blame them for our own empty state.
+    return (
+      <p className="muted">
+        {connection.credential_present
+          ? t("provider.credits.none")
+          : t("provider.credits.notConnected")}
+      </p>
+    );
   }
   const highest = Math.max(1, ...pools.map(([, balance]) => balance ?? 0));
   return (
     <div>
-      <h3>{t("provider.credits")}</h3>
-      {pools.map(([pool, balance]) => (
-        <div key={pool}>
-          <span>{t("provider.credits.pool", { pool })}</span>
-          <Meter
-            value={balance ?? 0}
-            max={highest}
-            label={String(balance ?? 0)}
-          />
-        </div>
-      ))}
+      <div className="provider-block-title">{t("provider.credits")}</div>
+      <div className="provider-pools">
+        {pools.map(([pool, balance]) => (
+          <div className="provider-pool" key={pool}>
+            <span className="provider-pool-name">{pool}</span>
+            <Meter value={balance ?? 0} max={highest} label="" />
+            <span className="provider-pool-value">{balance ?? 0}</span>
+          </div>
+        ))}
+      </div>
       {(connection.effective_constraints ?? []).length > 0 && (
-        <p className="muted">
+        <p className="provider-block-hint">
           {t("provider.constraints")}:{" "}
           {(connection.effective_constraints ?? []).join(", ")}
         </p>
@@ -360,7 +382,7 @@ function CredentialBlock({
 
   const connected = connection.credential_present;
   return (
-    <div>
+    <div className="provider-credential">
       <form
         className="form-stack"
         onSubmit={(event) => {
@@ -370,7 +392,20 @@ function CredentialBlock({
           }
         }}
       >
-        <Field label={t("provider.apiKey")} hint={t("provider.apiKeyHint")}>
+        {/* The field is write-only in both states: a sealed key is never sent
+            back to the browser, so the box is empty even when one is in place.
+            Left unexplained that reads as "no key connected" while the card
+            above shows a live balance — so the label and the hint say which
+            state this is, and the placeholder does not pretend to hold a
+            value. */}
+        <Field
+          label={connected ? t("provider.apiKeyStored") : t("provider.apiKey")}
+          hint={
+            connected
+              ? t("provider.apiKeyReplaceHint")
+              : t("provider.apiKeyHint")
+          }
+        >
           {(control) => (
             <TextInput
               {...control}
@@ -378,11 +413,14 @@ function CredentialBlock({
               autoComplete="off"
               value={key}
               required
+              placeholder={
+                connected ? t("provider.apiKeyReplacePlaceholder") : ""
+              }
               onChange={(event) => setKey(event.target.value)}
             />
           )}
         </Field>
-        <div style={{ display: "flex", gap: "var(--space-2)" }}>
+        <div className="provider-actions">
           <Button
             small
             variant="primary"


### PR DESCRIPTION
Four defects found by walking the feature in a browser rather than by any test. All were invisible to the unit gate.

**1. A polled run never finished.** The submit and poll jobs bound their workspace but no principal, so the claim hand-off was refused with `store: no actor bound to context`. Runs sat `in_progress` forever — credits spent, provider answered, values reaching nobody. Both workers now bind `connector:surfe` plus a correlation id, the shape `jobs_finance.go` uses. The connector is the right actor rather than a bare system principal: the claim rows carry that provenance, so a reader can tell purchased data from a colleague's entry.

New gate: `TestEveryJobWorkerThatReachesAStoreBindsAnActor` reads every `Work` method in `jobs_*.go` and fails on one that builds a store without an actor. It found three older workers in the same shape — waived with reasons and tracked in #1127, since whether each reaches a gated write is a question about three other subsystems.

**2. The offline provider lost its poll counters.** A plain map written from concurrent poll jobs; entries went missing so the count reset every sweep and a dev run never completed. Now a `sync.Map` with `LoadOrStore`.

**3. Disconnect left the balance behind.** The card read "Not connected" directly above "Credits left: Email 19, Mobile 4" — numbers for a key that had just been destroyed. The balance now clears with the credential that read it; the customer's own ceilings stay. The frontend also stopped rendering a cleared balance as `0`, which claims an empty account rather than an unknown one.

**4. The card was misleading about what it knew.** With no key it blamed the provider for not answering a question we never asked. And the API key field is write-only in both states, so an empty box under a live balance read as "no key connected" — it now says the stored key cannot be shown again.

Plus layout: the card was one column of prose at a single weight, so the provider's number and ours were indistinguishable. Now a header with the provider's mark, balances as rows, spend as a table with tabular numerals, and the key form behind a rule. Surfe's mark went into `design-system/provider-mark.tsx` beside Google's, Microsoft's and LinkedIn's — the existing named exclusion in both colour gates.

Verified end to end: creating a contact queues a run, the run completes, and eight claims land on the person, each stamped `connector:surfe`.

Local gates: `make check` green, integration lane green, craft static clean, 69 Playwright specs pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stuck provider-run jobs and stale provider balances. Previously, submit/poll workers bound no actor so completed runs stayed in_progress and wrote nothing; disconnect left the last provider balance visible for a destroyed key. Workers now bind `connector:surfe` with a correlation id so runs finish and claims carry connector provenance, and disconnect clears cached balances while keeping monthly ceilings.

- Backend
  - Submit and poll workers bind `connector:surfe` and a correlation id; runs complete and claims write with connector provenance.
  - Job-actor gate: new test scans the entire `compose` package and requires an assignment-based actor bind for any Work method that builds a store; a few legacy workers are waived temporarily.
  - Offline provider’s poll counting uses `sync.Map` with `LoadOrStore`, making poll sweeps concurrent-safe so dev runs complete.
  - Disconnect clears `last_known_balance` and `balance_read_at`; monthly ceilings remain. Test added.

- Frontend
  - Credits block hides null readings and, when not connected, explains that a key is needed to show a balance.
  - API key field is clearly write‑only: labeled “Replace the API key” when connected, with updated hint and placeholder.
  - Provider card layout: header with mark, balances as rows with tabular numerals, spend as a table (Month/Pool/Credits/Held/Lookups), key form separated by a rule. Adds the Surfe mark and localized copy.

<sup>Written for commit 0bdea1e33e7b5f5b54776a932288b6d340ea399a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1133?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

