### PR TITLE
feat(company): the account brief names the deal it cites, not just its kind

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -13622,6 +13622,15 @@ components:
       properties:
         entity_type: { type: string, enum: [deal, activity, person, organization, fact, profile_field] }
         entity_id: { type: string, format: uuid }
+        name:
+          type: string
+          description: |
+            The record's own display name, when the writer had it at hand — a
+            deal's name, an activity's subject. Absent for evidence kinds with
+            no name of their own (fact, profile_field) and never invented: the
+            writer either already knew the name from the record it read, or
+            leaves this out. Descriptive only — grounding checks type and id,
+            never the name.
 
     OrganizationFinanceSummary:
       type: object

--- a/backend/internal/compose/claims/claims.go
+++ b/backend/internal/compose/claims/claims.go
@@ -30,6 +30,20 @@ import (
 type Evidence struct {
 	EntityType string `json:"entity_type"`
 	EntityID   string `json:"entity_id"`
+	// Name is the record's own display name, when the caller had it at hand —
+	// a deal's name, an activity's subject. Descriptive only: it plays no part
+	// in identity, so Grounded compares type and id alone (a citation the
+	// writer forgot to name must still ground on the pair it actually has).
+	Name string `json:"name,omitempty"`
+}
+
+// identity is the pair Grounded and Dedupe key on: the record a citation
+// names, never the name it happens to carry alongside that. Comparing full
+// Evidence values would make a citation's grounding depend on whether SOME
+// caller remembered to set Name — the known-set built at knownRecords time
+// never does, so a name-bearing sentence would fail every lookup against it.
+func identity(e Evidence) Evidence {
+	return Evidence{EntityType: e.EntityType, EntityID: e.EntityID}
 }
 
 // Sentence is one claim plus the records it was written from.
@@ -75,8 +89,10 @@ func Grounded(sentence Sentence, known map[Evidence]bool) bool {
 	}
 	for _, cited := range sentence.Evidence {
 		// Keyed on the (kind, identity) PAIR, so a valid identity of the wrong
-		// kind is still dropped.
-		if !known[cited] {
+		// kind is still dropped. Stripped to identity() first: known is built
+		// with no Name set, and comparing the full struct would fail a
+		// name-bearing citation against a record it correctly cites.
+		if !known[identity(cited)] {
 			return false
 		}
 	}
@@ -143,10 +159,14 @@ func Dedupe(sentences []Sentence) []Sentence {
 		seen := make(map[Evidence]bool, len(sentence.Evidence))
 		unique := make([]Evidence, 0, len(sentence.Evidence))
 		for _, cited := range sentence.Evidence {
-			if seen[cited] {
+			// Keyed on identity(), not the citation itself: two citations of
+			// the same record must collapse into one chip even if only one
+			// of them happened to carry the record's Name.
+			key := identity(cited)
+			if seen[key] {
 				continue
 			}
-			seen[cited] = true
+			seen[key] = true
 			unique = append(unique, cited)
 		}
 		sentence.Evidence = unique

--- a/backend/internal/compose/orgbrief/service.go
+++ b/backend/internal/compose/orgbrief/service.go
@@ -147,7 +147,10 @@ func (s *Service) Get(ctx context.Context, orgID ids.OrganizationID, force bool)
 		Version:     storedVersion,
 		GeneratedAt: s.now().UTC(),
 		GeneratedBy: by,
-		Sections:    sections,
+		// Named AFTER grounding, whichever lane wrote the sections: a name is
+		// cosmetic, read from the input the brief was written from rather
+		// than trusted from the model's own reply.
+		Sections: withSectionEvidenceNames(sections, in),
 	}
 	if err := s.save(ctx, userID, orgID, written); err != nil {
 		return crmcontracts.OrganizationBrief{}, err
@@ -189,7 +192,7 @@ func (s *Service) Ask(
 		Question:       question,
 		GeneratedAt:    s.now().UTC(),
 		GeneratedBy:    by,
-		Sentences:      wireSentences(sentences),
+		Sentences:      wireSentences(withEvidenceNames(sentences, in)),
 	}, nil
 }
 
@@ -255,10 +258,14 @@ func wireSentences(in []Sentence) []crmcontracts.OrganizationBriefSentence {
 				malformed = true
 				break
 			}
-			evidence = append(evidence, crmcontracts.OrganizationBriefEvidence{
+			wired := crmcontracts.OrganizationBriefEvidence{
 				EntityId:   openapi_types.UUID(parsed),
 				EntityType: crmcontracts.OrganizationBriefEvidenceEntityType(cited.EntityType),
-			})
+			}
+			if cited.Name != "" {
+				wired.Name = &cited.Name
+			}
+			evidence = append(evidence, wired)
 		}
 		if malformed {
 			continue

--- a/backend/internal/compose/orgbrief/write.go
+++ b/backend/internal/compose/orgbrief/write.go
@@ -349,6 +349,66 @@ func knownRecords(orgID string, in Input) map[Evidence]bool {
 	return known
 }
 
+// recordKey is knownRecords' pair without the citation's descriptive Name, so
+// a name lookup and a grounding lookup can share one shape without either
+// caring what the other keys on.
+type recordKey struct {
+	EntityType string
+	EntityID   string
+}
+
+// recordNames is every citable record's own display name, read from the SAME
+// input the brief was written from — never from the model's reply, which
+// cannot be trusted to relay a record's name correctly, and never from the
+// evidence a sentence already carries, which for the model lane has none.
+func recordNames(in Input) map[recordKey]string {
+	names := make(map[recordKey]string, len(in.OpenDeals)+len(in.Recent)+len(in.Contacts)+len(in.OpenTasks))
+	for _, deal := range in.OpenDeals {
+		names[recordKey{citeDeal, deal.ID}] = deal.Name
+	}
+	for _, act := range in.Recent {
+		names[recordKey{citeActivity, act.ID}] = act.Subject
+	}
+	for _, contact := range in.Contacts {
+		names[recordKey{citePerson, contact.ID}] = contact.Name
+	}
+	for _, task := range in.OpenTasks {
+		names[recordKey{citeActivity, task.ID}] = task.Name
+	}
+	return names
+}
+
+// withEvidenceNames attaches each citation's own display name to sentences
+// already accepted by the grounding filter — the ONE place that runs for
+// both writers, so a "deal" chip names the deal whichever lane wrote the
+// sentence about it. Run after grounding, never before: a name is cosmetic,
+// and attaching it earlier would risk a caller comparing full Evidence
+// values before they learn to strip it, exactly the trap Grounded and Dedupe
+// guard against in package claims.
+func withEvidenceNames(sentences []Sentence, in Input) []Sentence {
+	names := recordNames(in)
+	for i := range sentences {
+		evidence := sentences[i].Evidence
+		for j := range evidence {
+			key := recordKey{evidence[j].EntityType, evidence[j].EntityID}
+			if name, ok := names[key]; ok && name != "" {
+				evidence[j].Name = name
+			}
+		}
+	}
+	return sentences
+}
+
+// withSectionEvidenceNames is withEvidenceNames over a brief's sections
+// rather than a flat sentence list — the shape Write returns, and the shape
+// Get caches.
+func withSectionEvidenceNames(sections []Section, in Input) []Section {
+	for i := range sections {
+		sections[i].Sentences = withEvidenceNames(sections[i].Sentences, in)
+	}
+	return sections
+}
+
 // The section kinds, DERIVED from the contract's enum rather than re-spelled,
 // so a rename upstream fails to compile here instead of laundering a
 // hand-typed string past the type.

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -14528,6 +14528,14 @@ type OrganizationBrief struct {
 type OrganizationBriefEvidence struct {
 	EntityId   openapi_types.UUID                  `json:"entity_id"`
 	EntityType OrganizationBriefEvidenceEntityType `json:"entity_type"`
+
+	// Name The record's own display name, when the writer had it at hand — a
+	// deal's name, an activity's subject. Absent for evidence kinds with
+	// no name of their own (fact, profile_field) and never invented: the
+	// writer either already knew the name from the record it read, or
+	// leaves this out. Descriptive only — grounding checks type and id,
+	// never the name.
+	Name *string `json:"name,omitempty"`
 }
 
 // OrganizationBriefEvidenceEntityType defines model for OrganizationBriefEvidence.EntityType.

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -9172,6 +9172,15 @@ export interface components {
             entity_type: "deal" | "activity" | "person" | "organization" | "fact" | "profile_field";
             /** Format: uuid */
             entity_id: string;
+            /**
+             * @description The record's own display name, when the writer had it at hand — a
+             *     deal's name, an activity's subject. Absent for evidence kinds with
+             *     no name of their own (fact, profile_field) and never invented: the
+             *     writer either already knew the name from the record it read, or
+             *     leaves this out. Descriptive only — grounding checks type and id,
+             *     never the name.
+             */
+            name?: string;
         };
         /**
          * @description What the accounting mirror knows about one customer (ADR-0083/A128).

--- a/frontend/src/screens/company360.tsx
+++ b/frontend/src/screens/company360.tsx
@@ -1658,7 +1658,17 @@ type CitedKind = Cited["entity_type"];
  * open.
  */
 export type CitationChip =
-  | { openable: true; entityType: CitedKind; entityId: string; count: number }
+  | {
+      openable: true;
+      entityType: CitedKind;
+      entityId: string;
+      count: number;
+      // The record's own name, when the citation carried one — a deal's
+      // name, an activity's subject. Absent on a grouped chip: a count
+      // already speaks for several records, and one of their names would
+      // read as though it spoke for the rest.
+      name?: string;
+    }
   | { openable: false; entityType: CitedKind; count: number };
 
 /**
@@ -1700,6 +1710,7 @@ export function citationChips(
         entityType: cited.entity_type,
         entityId: cited.entity_id,
         count: 1,
+        name: cited.name,
       });
       continue;
     }
@@ -1805,12 +1816,17 @@ function Citations({
             {/* A grouped chip (fact/profile_field, several of the same kind
                 in one prose block) opens the FIRST and names the count; the
                 drawer's own stepper reaches the rest, which is the receipt
-                kind's whole reason for having one. */}
-            {chip.count === 1
-              ? t(`co.brief.cite.${chip.entityType}`)
-              : t(`co.brief.cite.${chip.entityType}.many`, {
-                  count: chip.count,
-                })}
+                kind's whole reason for having one. A single deal or person
+                names ITSELF rather than its kind — "deal" told a reader
+                nothing they could not already see; the deal's own name tells
+                them which one. */}
+            {chip.count === 1 && chip.name
+              ? chip.name
+              : chip.count === 1
+                ? t(`co.brief.cite.${chip.entityType}`)
+                : t(`co.brief.cite.${chip.entityType}.many`, {
+                    count: chip.count,
+                  })}
           </button>
         ) : (
           <span key={chip.entityType} className="co-brief-cite-flat">


### PR DESCRIPTION
## Summary
- Brief citation chips (deal, person) now show the record's own name — a deal's name, an activity's subject — read from the input the brief was written from, instead of a bare kind label like "deal".
- Grounding is unchanged: identity is checked on type+id only, so a citation without a name still grounds correctly.
- "The account, in short" panel: two-column layout (label beside its prose), assembled timestamp moved into the panel header, citations collected once per section instead of chipped after every sentence.

## Test plan
- [x] `go test ./internal/compose/claims/... ./internal/compose/orgbrief/...` — all pass
- [x] `vitest run src/screens/company360.test.tsx` — 87/87 pass
- [x] `craft static --strict` — 0 findings
- [x] Verified live: linked a deal to a company, confirmed the brief's "how it stands" citation shows the deal's actual name

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Brief citation chips now show the cited record’s own name for single records (e.g., a deal’s name or an activity’s subject) instead of a generic kind label. Grounding and dedupe behavior is unchanged: identity is type+id only.

- API/contracts: add optional `name` to `OrganizationBriefEvidence` in `backend/api/crm.yaml`; TS types regenerated. Writers may omit it; identity remains type+id.
- Backend: attach evidence names from the same input used to write the brief, after grounding; ignore `name` in `Grounded`/`Dedupe` via an identity-only key; include `name` in `Get`/`Ask` responses.
- Frontend: citation chips accept an optional `name`; single-record chips render the record’s name, grouped chips still show counts; the “account-in-short” panel uses a two-column layout with the timestamp in the header.

<sup>Written for commit c4cbfa3952bd0abb591e3c4be0e925348affb3ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1136?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

