### PR TITLE
refactor(collections,quotas): the modules drop the tenant column (ADR-0091 §8 phase D)

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -610,17 +610,65 @@ rediscover:
   forbids. The fail-closed branch it exercised stays, with the comment saying
   why an unreachable guard is still worth its lines.
 
-**Next: phase D** — drop the `workspace_id` columns and narrow the 119 indexes
-that still lead with them — then §9 step 6 retires the orphaned gates
+### Phase D is under way, module by module — the shape it takes
+
+Phase D fans out (§8): each module drops the column from its own tables and
+narrows its own indexes, in one PR with the Go change that stops naming it.
+Signals went first (#1124), then collections and quotas. **Roughly 130 tables
+remain**, so what a slice costs is worth knowing before starting the next one.
+
+Three kinds of object go, and only the first is obvious: the **column** (which
+takes its foreign key into `workspace` with it, unasked); the **indexes that
+lead with it**, which cost a comparison per row scanned and buy nothing; and
+the **`uq_<table>_ws_id` constraints**, which `0019` created as composite
+foreign-key targets and phase B collapsed into second copies of the primary
+key. Some of those are constraints rather than bare indexes — `DROP INDEX`
+refuses, `ALTER TABLE … DROP CONSTRAINT` is what works. Index names do not
+change: a narrowed index answers the same queries, and renaming it would make
+every later reader diff two names to learn that nothing moved.
+
+An index on the tenant ALONE has no narrowed form — `idx_quota_ws_live` was
+`(workspace_id) WHERE archived_at IS NULL`, and without the column the
+predicate is the whole selection. It drops rather than being rebuilt on
+nothing.
+
+**The compiler finds none of this, and the module's own directory finds only
+half of it.** Both misses in the collections/quotas slice were outside the
+module: `compose/org360` selected `t.workspace_id` from `tag`, and
+`people/person_list.go` joined `taggable` to `tag` on it. Grep every file that
+names the table, not every file in the module — and re-read the row STRUCT and
+its scanner, which is where a dropped select column turns into "number of field
+descriptions must equal number of destinations" at runtime.
+
+**Webhooks is deliberately deferred.** Its retry sweep is one job row per live
+tenant, with an integration suite built on a second tenant's parked delivery
+and a fault injected through the workspace GUC. Dropping the column first would
+leave that suite asserting an isolation the schema no longer has, so the tables
+and the fleet loop go together (§5).
+
+After phase D: §9 step 6 retires the remaining orphaned gates
 (`check-rls-store-path.sh`, ADR-0061 §3's bootstrap check) and §5 collapses the
 two `Tx` helpers, which is where `principal.WorkspaceID` and
-`storekit.MustWorkspace` finally fall.
+`storekit.MustWorkspace` finally fall. The migration tenant-scope gate has
+already gone (#1121): phase A removed the row-level security it rested on, and
+phase D's down migrations — which backfill the column they restore — were the
+first writes to prove it.
 
-**Renumber late, and expect to do it twice.** This branch collided with `main`
-on migration 0219, then 0222, then 0223, and the last of those also landed
-`NULLS NOT DISTINCT` on `retention_policy_unique` — a qualifier the collapse
-would have silently dropped along with the tenant column. A migration PR's
-rebase is not mechanical: re-read what the base added to the tables you touch.
+**Renumber late, and expect to do it more than twice.** The B/C branch collided
+with `main` on 0219, 0222, 0223 and 0224; the signals slice collided on 0226.
+One of those collisions also landed `NULLS NOT DISTINCT` on
+`retention_policy_unique` — a qualifier the collapse would have silently
+dropped along with the tenant column — so a migration PR's rebase is not
+mechanical: re-read what the base added to the tables you touch.
+
+Twice this went further than a renumber and broke `main` outright, because
+required status checks are **not strict** — a branch never has to be up to
+date before merging, so two PRs green against different bases merge without
+ever being compiled together. Issue
+[#1130](https://github.com/gradionhq/margince-poc-v1/issues/1130) carries the
+evidence and the two candidate fixes; until one is chosen, rebase and re-run
+the gates immediately before merging anything that adds a migration or changes
+a key.
 
 Phase 2 spans roughly nine hundred `WithWorkspaceTx` occurrences, a bit over
 four hundred of them outside tests, across a couple of hundred non-test files.

--- a/backend/internal/compose/integration/quotas_integration_test.go
+++ b/backend/internal/compose/integration/quotas_integration_test.go
@@ -165,8 +165,8 @@ func TestQuotaWrite_NegativeTargetRefused(t *testing.T) {
 	// a write path that bypasses the store still cannot land a negative
 	// target.
 	_, err = OwnerConn(t).Exec(context.Background(),
-		`INSERT INTO quota (workspace_id, owner_id, period_start, period_end, target_minor, currency)
-		 VALUES ($1, $2, $3, $4, -1, 'EUR')`, e.WS, e.Rep1, q1Start, q1End)
+		`INSERT INTO quota (owner_id, period_start, period_end, target_minor, currency)
+		 VALUES ($1, $2, $3, -1, 'EUR')`, e.Rep1, q1Start, q1End)
 	if constraint, ok := storekit.CheckViolation(err); !ok || constraint != "quota_target_nonneg" {
 		t.Fatalf("a direct negative-target insert must violate quota_target_nonneg, got %v", err)
 	}

--- a/backend/internal/compose/org360/collections.go
+++ b/backend/internal/compose/org360/collections.go
@@ -21,7 +21,7 @@ import (
 // tagsSection reads the tags applied to the account.
 func tagsSection(ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID) ([]crmcontracts.Tag, error) {
 	rows, err := tx.Query(ctx, `
-		SELECT t.id, t.workspace_id, t.name, t.color, t.created_at, t.updated_at, t.archived_at
+		SELECT t.id, t.name, t.color, t.created_at, t.updated_at, t.archived_at
 		FROM tag t
 		JOIN taggable g ON g.tag_id = t.id AND g.entity_type = 'organization' AND g.entity_id = $1
 		WHERE t.archived_at IS NULL
@@ -32,8 +32,8 @@ func tagsSection(ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID) ([]cr
 	}
 	return pgx.CollectRows(rows, func(row pgx.CollectableRow) (crmcontracts.Tag, error) {
 		var t crmcontracts.Tag
-		var id, wsID ids.UUID
-		if err := row.Scan(&id, &wsID, &t.Name, &t.Color, &t.CreatedAt, &t.UpdatedAt, &t.ArchivedAt); err != nil {
+		var id ids.UUID
+		if err := row.Scan(&id, &t.Name, &t.Color, &t.CreatedAt, &t.UpdatedAt, &t.ArchivedAt); err != nil {
 			return t, err
 		}
 		t.Id = openapi_types.UUID(id)
@@ -52,7 +52,7 @@ func listMembershipsSection(ctx context.Context, tx pgx.Tx, orgID ids.Organizati
 		return nil, err
 	}
 	rows, err := tx.Query(ctx, fmt.Sprintf(`
-		SELECT l.id, l.workspace_id, l.name, l.entity_type, l.list_type, l.definition,
+		SELECT l.id, l.name, l.entity_type, l.list_type, l.definition,
 		       l.owner_id, l.team_id, l.created_at, l.updated_at, l.archived_at
 		FROM list l
 		JOIN list_member m ON m.list_id = l.id AND m.entity_type = 'organization' AND m.entity_id = $%d
@@ -64,10 +64,10 @@ func listMembershipsSection(ctx context.Context, tx pgx.Tx, orgID ids.Organizati
 	}
 	return pgx.CollectRows(rows, func(row pgx.CollectableRow) (crmcontracts.List, error) {
 		var l crmcontracts.List
-		var id, wsID ids.UUID
+		var id ids.UUID
 		var ownerID, teamID *ids.UUID
 		var entityType, listType string
-		if err := row.Scan(&id, &wsID, &l.Name, &entityType, &listType, &l.Definition,
+		if err := row.Scan(&id, &l.Name, &entityType, &listType, &l.Definition,
 			&ownerID, &teamID, &l.CreatedAt, &l.UpdatedAt, &l.ArchivedAt); err != nil {
 			return l, err
 		}

--- a/backend/internal/modules/collections/lists.go
+++ b/backend/internal/modules/collections/lists.go
@@ -69,7 +69,7 @@ var memberEntityVocabulary = func() string {
 	return strings.Join(names, "|")
 }()
 
-const listColumns = `id, workspace_id, name, entity_type, list_type, definition, owner_id, team_id, created_at, updated_at, archived_at`
+const listColumns = `id, name, entity_type, list_type, definition, owner_id, team_id, created_at, updated_at, archived_at`
 
 // catalogCap bounds the un-paginated catalog reads. Lists and tags are
 // workspace-curated vocabulary — tens of rows, not record data — which
@@ -80,22 +80,21 @@ const listColumns = `id, workspace_id, name, entity_type, list_type, definition,
 const catalogCap = 1000
 
 type listRow struct {
-	ID          ids.ListID
-	WorkspaceID ids.WorkspaceID
-	Name        string
-	EntityType  string
-	ListType    string
-	Definition  map[string]any
-	OwnerID     *ids.UserID
-	TeamID      *ids.TeamID
-	CreatedAt   time.Time
-	UpdatedAt   time.Time
-	ArchivedAt  *time.Time
+	ID         ids.ListID
+	Name       string
+	EntityType string
+	ListType   string
+	Definition map[string]any
+	OwnerID    *ids.UserID
+	TeamID     *ids.TeamID
+	CreatedAt  time.Time
+	UpdatedAt  time.Time
+	ArchivedAt *time.Time
 }
 
 func scanList(r pgx.Row) (listRow, error) {
 	var l listRow
-	err := r.Scan(&l.ID, &l.WorkspaceID, &l.Name, &l.EntityType, &l.ListType,
+	err := r.Scan(&l.ID, &l.Name, &l.EntityType, &l.ListType,
 		&l.Definition, &l.OwnerID, &l.TeamID, &l.CreatedAt, &l.UpdatedAt, &l.ArchivedAt)
 	return l, err
 }
@@ -189,8 +188,8 @@ func (s *Store) CreateList(ctx context.Context, in CreateListInput) (listRow, er
 	var out listRow
 	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		row := tx.QueryRow(ctx, `
-			INSERT INTO list (workspace_id, name, entity_type, list_type, definition, owner_id, team_id)
-			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, $2, $3, $4, $5, $6)
+			INSERT INTO list (name, entity_type, list_type, definition, owner_id, team_id)
+			VALUES ($1, $2, $3, $4, $5, $6)
 			RETURNING `+listColumns,
 			in.Name, in.EntityType, in.ListType, in.Definition, in.OwnerID, in.TeamID)
 		var err error

--- a/backend/internal/modules/collections/members.go
+++ b/backend/internal/modules/collections/members.go
@@ -158,8 +158,8 @@ func (s *Store) AddMember(ctx context.Context, listID ids.ListID, entityType str
 			return err
 		}
 		row := tx.QueryRow(ctx, `
-			INSERT INTO list_member (workspace_id, list_id, entity_type, entity_id, added_by)
-			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, $2, $3, $4)
+			INSERT INTO list_member (list_id, entity_type, entity_id, added_by)
+			VALUES ($1, $2, $3, $4)
 			ON CONFLICT (list_id, entity_type, entity_id) DO NOTHING
 			RETURNING id, list_id, entity_type, entity_id, added_by, created_at`,
 			listID, entityType, entityID, actor.ID)

--- a/backend/internal/modules/collections/savedviews.go
+++ b/backend/internal/modules/collections/savedviews.go
@@ -31,7 +31,7 @@ import (
 // workspace record governed by the RBAC object matrix's own/team/all
 // scope.
 
-const savedViewColumns = `id, workspace_id, owner_id, shared_scope, resource, name, query, version, created_at, updated_at, archived_at`
+const savedViewColumns = `id, owner_id, shared_scope, resource, name, query, version, created_at, updated_at, archived_at`
 
 // selectSavedView is the shared projection prefix for every saved_view read —
 // one spelling so the columns can't drift between the list, get, and delete paths.
@@ -39,7 +39,6 @@ const selectSavedView = "SELECT " + savedViewColumns + " FROM saved_view WHERE "
 
 type savedViewRow struct {
 	ID          ids.SavedViewID
-	WorkspaceID ids.WorkspaceID
 	OwnerID     ids.UserID
 	SharedScope string
 	Resource    string
@@ -69,7 +68,7 @@ func wireSavedView(v savedViewRow) crmcontracts.SavedView {
 
 func scanSavedView(r pgx.Row) (savedViewRow, error) {
 	var v savedViewRow
-	err := r.Scan(&v.ID, &v.WorkspaceID, &v.OwnerID, &v.SharedScope, &v.Resource,
+	err := r.Scan(&v.ID, &v.OwnerID, &v.SharedScope, &v.Resource,
 		&v.Name, &v.Query, &v.Version, &v.CreatedAt, &v.UpdatedAt, &v.ArchivedAt)
 	return v, err
 }
@@ -164,8 +163,8 @@ func (s *Store) CreateSavedView(ctx context.Context, in CreateSavedViewInput) (s
 	var out savedViewRow
 	err = s.db.Tx(ctx, func(tx pgx.Tx) error {
 		row := tx.QueryRow(ctx, `
-			INSERT INTO saved_view (workspace_id, owner_id, shared_scope, resource, name, query)
-			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, 'private', $2, $3, $4)
+			INSERT INTO saved_view (owner_id, shared_scope, resource, name, query)
+			VALUES ($1, 'private', $2, $3, $4)
 			RETURNING `+savedViewColumns,
 			owner, in.Resource, in.Name, in.Query)
 		var err error

--- a/backend/internal/modules/collections/tags.go
+++ b/backend/internal/modules/collections/tags.go
@@ -23,20 +23,19 @@ import (
 )
 
 type tagRow struct {
-	ID          ids.TagID
-	WorkspaceID ids.WorkspaceID
-	Name        string
-	Color       *string
-	CreatedAt   time.Time
-	UpdatedAt   time.Time
-	ArchivedAt  *time.Time
+	ID         ids.TagID
+	Name       string
+	Color      *string
+	CreatedAt  time.Time
+	UpdatedAt  time.Time
+	ArchivedAt *time.Time
 }
 
-const tagColumns = `id, workspace_id, name, color, created_at, updated_at, archived_at`
+const tagColumns = `id, name, color, created_at, updated_at, archived_at`
 
 func scanTag(r pgx.Row) (tagRow, error) {
 	var t tagRow
-	err := r.Scan(&t.ID, &t.WorkspaceID, &t.Name, &t.Color, &t.CreatedAt, &t.UpdatedAt, &t.ArchivedAt)
+	err := r.Scan(&t.ID, &t.Name, &t.Color, &t.CreatedAt, &t.UpdatedAt, &t.ArchivedAt)
 	return t, err
 }
 
@@ -89,8 +88,8 @@ func (s *Store) CreateTag(ctx context.Context, name string, color *string) (tagR
 	var out tagRow
 	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		row := tx.QueryRow(ctx, `
-			INSERT INTO tag (workspace_id, name, color)
-			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, $2)
+			INSERT INTO tag (name, color)
+			VALUES ($1, $2)
 			RETURNING `+tagColumns, strings.TrimSpace(name), color)
 		var err error
 		if out, err = scanTag(row); err != nil {
@@ -165,8 +164,8 @@ func (s *Store) ApplyTag(ctx context.Context, tagID ids.TagID, entityType string
 			return err
 		}
 		row := tx.QueryRow(ctx, `
-			INSERT INTO taggable (workspace_id, tag_id, entity_type, entity_id)
-			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, $2, $3)
+			INSERT INTO taggable (tag_id, entity_type, entity_id)
+			VALUES ($1, $2, $3)
 			ON CONFLICT (tag_id, entity_type, entity_id) DO NOTHING
 			RETURNING id, tag_id, entity_type, entity_id, created_at`,
 			tagID, entityType, entityID)

--- a/backend/internal/modules/people/person_list.go
+++ b/backend/internal/modules/people/person_list.go
@@ -76,18 +76,15 @@ var personListFields = map[string]string{
 //
 // EXISTS rather than a join: a person carries many tags, and a join would
 // return them once per matching link — rows the keyset cursor would then page
-// over as if they were distinct people. Both tables are workspace-qualified
-// against the person's own workspace, which RLS already guarantees and
-// `idx_taggable_entity` needs as its leading column.
+// over as if they were distinct people.
 func personTagClause(tag *string, arg func(any) int) string {
 	if tag == nil {
 		return ""
 	}
 	return storekit.SQLf(`EXISTS (
 		SELECT 1 FROM taggable tg
-		  JOIN tag t ON t.id = tg.tag_id AND t.workspace_id = tg.workspace_id
-		WHERE tg.workspace_id = person.workspace_id
-		  AND tg.entity_type = $%d AND tg.entity_id = person.id
+		  JOIN tag t ON t.id = tg.tag_id
+		WHERE tg.entity_type = $%d AND tg.entity_id = person.id
 		  AND lower(t.name) = $%d)`,
 		arg(personEntity), arg(foldTagName(*tag)))
 }

--- a/backend/internal/modules/quotas/quotas.go
+++ b/backend/internal/modules/quotas/quotas.go
@@ -119,9 +119,9 @@ func (s *Store) CreateQuota(ctx context.Context, in CreateQuotaInput) (crmcontra
 	err := s.tx(ctx, func(tx pgx.Tx) error {
 		id := ids.NewV7()
 		_, err := tx.Exec(ctx,
-			`INSERT INTO quota (id, workspace_id, owner_id, team_id, period_start, period_end, target_minor, currency)
-			 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
-			id, storekit.MustWorkspace(ctx), in.OwnerID, in.TeamID,
+			`INSERT INTO quota (id, owner_id, team_id, period_start, period_end, target_minor, currency)
+			 VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+			id, in.OwnerID, in.TeamID,
 			in.PeriodStart, in.PeriodEnd, in.TargetMinor, in.Currency)
 		if err != nil {
 			return mapQuotaWriteError(err, "insert quota")
@@ -410,7 +410,7 @@ func mapQuotaWriteError(err error, op string) error {
 	return fmt.Errorf("%s: %w", op, err)
 }
 
-const quotaColumns = `id, workspace_id, owner_id, team_id, period_start, period_end,
+const quotaColumns = `id, owner_id, team_id, period_start, period_end,
 	target_minor, currency, version, created_at, updated_at, archived_at`
 
 func readQuota(ctx context.Context, tx pgx.Tx, id ids.UUID, archived storekit.ArchivedFilter) (crmcontracts.Quota, error) {
@@ -430,13 +430,13 @@ func readQuota(ctx context.Context, tx pgx.Tx, id ids.UUID, archived storekit.Ar
 // cursor key — the scanDeal precedent).
 func scanQuota(row pgx.Row, extra ...any) (crmcontracts.Quota, error) {
 	var q crmcontracts.Quota
-	var id, wsID ids.UUID
+	var id ids.UUID
 	var ownerID, teamID *ids.UUID
 	var periodStart, periodEnd time.Time
 	var version int64
 
 	dests := []any{
-		&id, &wsID, &ownerID, &teamID, &periodStart, &periodEnd,
+		&id, &ownerID, &teamID, &periodStart, &periodEnd,
 		&q.TargetMinor, &q.Currency, &version, &q.CreatedAt, &q.UpdatedAt, &q.ArchivedAt,
 	}
 	err := row.Scan(append(dests, extra...)...)

--- a/backend/migrations/core/0228_collections_quotas_drop_workspace.down.sql
+++ b/backend/migrations/core/0228_collections_quotas_drop_workspace.down.sql
@@ -1,0 +1,65 @@
+-- Reverse of 0228: the six tables carry the tenant column again.
+--
+-- The column returns nullable, is filled from the installation's single
+-- workspace, and only then becomes NOT NULL — the shape 0227 established.
+-- If `workspace` is empty and a table is not, SET NOT NULL fails and the
+-- rollback stops, which is the honest outcome: the rows belonged to a
+-- workspace that no longer exists.
+
+ALTER TABLE list ADD COLUMN workspace_id uuid;
+ALTER TABLE list_member ADD COLUMN workspace_id uuid;
+ALTER TABLE tag ADD COLUMN workspace_id uuid;
+ALTER TABLE taggable ADD COLUMN workspace_id uuid;
+ALTER TABLE saved_view ADD COLUMN workspace_id uuid;
+ALTER TABLE quota ADD COLUMN workspace_id uuid;
+
+DO $$
+DECLARE ws uuid := (SELECT id FROM workspace ORDER BY created_at LIMIT 1);
+BEGIN
+  UPDATE list SET workspace_id = ws;
+  UPDATE list_member SET workspace_id = ws;
+  UPDATE tag SET workspace_id = ws;
+  UPDATE taggable SET workspace_id = ws;
+  UPDATE saved_view SET workspace_id = ws;
+  UPDATE quota SET workspace_id = ws;
+END $$;
+
+ALTER TABLE list ALTER COLUMN workspace_id SET NOT NULL;
+ALTER TABLE list_member ALTER COLUMN workspace_id SET NOT NULL;
+ALTER TABLE tag ALTER COLUMN workspace_id SET NOT NULL;
+ALTER TABLE taggable ALTER COLUMN workspace_id SET NOT NULL;
+ALTER TABLE saved_view ALTER COLUMN workspace_id SET NOT NULL;
+ALTER TABLE quota ALTER COLUMN workspace_id SET NOT NULL;
+
+ALTER TABLE list ADD CONSTRAINT list_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE list_member ADD CONSTRAINT list_member_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE tag ADD CONSTRAINT tag_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE taggable ADD CONSTRAINT taggable_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE saved_view ADD CONSTRAINT saved_view_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE quota ADD CONSTRAINT quota_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+
+ALTER TABLE list ADD CONSTRAINT uq_list_ws_id UNIQUE (id);
+ALTER TABLE tag ADD CONSTRAINT uq_tag_ws_id UNIQUE (id);
+
+DROP INDEX idx_list_member_entity;
+CREATE INDEX idx_list_member_entity ON list_member (workspace_id, entity_type, entity_id);
+
+DROP INDEX idx_taggable_entity;
+CREATE INDEX idx_taggable_entity ON taggable (workspace_id, entity_type, entity_id);
+
+DROP INDEX idx_saved_view_owner;
+CREATE INDEX idx_saved_view_owner ON saved_view (workspace_id, owner_id, resource) WHERE archived_at IS NULL;
+
+DROP INDEX idx_quota_owner;
+CREATE INDEX idx_quota_owner ON quota (workspace_id, owner_id) WHERE owner_id IS NOT NULL;
+
+DROP INDEX idx_quota_team;
+CREATE INDEX idx_quota_team ON quota (workspace_id, team_id) WHERE team_id IS NOT NULL;
+
+CREATE INDEX idx_quota_ws_live ON quota (workspace_id) WHERE archived_at IS NULL;

--- a/backend/migrations/core/0228_collections_quotas_drop_workspace.up.sql
+++ b/backend/migrations/core/0228_collections_quotas_drop_workspace.up.sql
@@ -1,0 +1,51 @@
+-- 0228: collections and quotas drop the tenant column (ADR-0091 §8 phase D).
+--
+-- Two modules in one migration because neither references the other's tables:
+-- phase D depends on phase C per TABLE, and a set with no edges between its
+-- members is one reviewable unit rather than two.
+--
+-- Webhooks is deliberately NOT here. Its tables lose the column together with
+-- the retry sweep's per-tenant fan-out — one job row per live workspace, with
+-- an integration suite built on a second tenant's parked delivery. Dropping
+-- the column first would leave that suite asserting an isolation the schema no
+-- longer has, which is worse than leaving both for one slice (§5).
+--
+-- Same three kinds of object as 0227, and the same rule about names: a
+-- narrowed index answers the queries its wide predecessor answered, so it
+-- keeps the name. `uq_list_ws_id`, `uq_tag_ws_id` and
+-- `webhook_subscription_ws_id_key` are the redundant copies of their tables'
+-- primary keys — 0019 created them as composite foreign-key targets, phase C
+-- rewrote the last references away, phase B collapsed them to UNIQUE (id).
+
+DROP INDEX idx_list_member_entity;
+CREATE INDEX idx_list_member_entity ON list_member (entity_type, entity_id);
+
+DROP INDEX idx_taggable_entity;
+CREATE INDEX idx_taggable_entity ON taggable (entity_type, entity_id);
+
+DROP INDEX idx_saved_view_owner;
+CREATE INDEX idx_saved_view_owner ON saved_view (owner_id, resource) WHERE archived_at IS NULL;
+
+DROP INDEX idx_quota_owner;
+CREATE INDEX idx_quota_owner ON quota (owner_id) WHERE owner_id IS NOT NULL;
+
+DROP INDEX idx_quota_team;
+CREATE INDEX idx_quota_team ON quota (team_id) WHERE team_id IS NOT NULL;
+
+-- idx_quota_ws_live indexed the tenant alone over live rows. Without the
+-- tenant there is no column left to index: the predicate IS the selection, and
+-- a single-column index on nothing is not an index. The queries it served scan
+-- or use idx_quota_owner / idx_quota_team.
+DROP INDEX idx_quota_ws_live;
+
+
+
+ALTER TABLE list DROP CONSTRAINT uq_list_ws_id;
+ALTER TABLE tag DROP CONSTRAINT uq_tag_ws_id;
+
+ALTER TABLE list DROP COLUMN workspace_id;
+ALTER TABLE list_member DROP COLUMN workspace_id;
+ALTER TABLE tag DROP COLUMN workspace_id;
+ALTER TABLE taggable DROP COLUMN workspace_id;
+ALTER TABLE saved_view DROP COLUMN workspace_id;
+ALTER TABLE quota DROP COLUMN workspace_id;


### PR DESCRIPTION
Phase D, second slice. Two modules in one migration because neither references the other's tables: phase D depends on phase C **per table**, so a set with no edges between its members is one reviewable unit.

Six tables — `list`, `list_member`, `tag`, `taggable`, `saved_view`, `quota` — lose the column, seven indexes narrow, and `uq_list_ws_id` / `uq_tag_ws_id` go: phase B collapsed them into second copies of their primary keys.

**`idx_quota_ws_live` has no narrowed form.** It indexed the tenant alone over live rows; without the column the predicate is the whole selection, so it drops rather than being rebuilt on nothing.

## The finding worth carrying into the rest of phase D

Two of the call sites this touches are **outside** the two modules:

- `compose/org360/collections.go` selected `t.workspace_id` from `tag` and `l.workspace_id` from `list`;
- `people/person_list.go` joined `taggable` to `tag` on it, and scoped the EXISTS to `person.workspace_id`.

Neither is visible from the module's own directory, and the compiler sees neither — a dropped select column surfaces at runtime as `number of field descriptions must equal number of destinations`, which is how the `tag` and `saved_view` row structs and their scanners were caught. **Grep every file that names the table, then re-read the row struct.**

## Webhooks was drafted in and taken back out

Its tables lose the column together with the retry sweep's per-tenant fan-out — one job row per live workspace, an integration suite built on a second tenant's parked delivery, and a fault injected through the workspace GUC. Dropping the column first would leave that suite asserting an isolation the schema no longer has, so both go in one slice with §5's fleet-loop collapse.

## Verification

- Lane applied to an empty database, then the down run against the migrated schema: **all six columns, their foreign keys, both uniques and all seven wide indexes come back.**
- `make check-backend` green.
- `make test-integration`: **OK, 0 skips, 39 packages.**

STATUS.md records the slice shape and the two-miss lesson for whoever picks up the next module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drops the tenant column `workspace_id` from `collections` and `quotas` and narrows dependent indexes so queries no longer compare on tenant. Previously inserts/queries required `workspace_id`; now the column is gone, creates/reads omit it, and `idx_quota_ws_live` is removed because it indexed only the tenant.

- Schema: remove `workspace_id` from `list`, `list_member`, `tag`, `taggable`, `saved_view`, `quota`; drop `uq_list_ws_id` and `uq_tag_ws_id`; narrow `idx_list_member_entity`, `idx_taggable_entity`, `idx_saved_view_owner`, `idx_quota_owner`, `idx_quota_team`; drop `idx_quota_ws_live`. Adds `0228` up/down migrations (down restores columns, FKs, uniques, and wide indexes).
- Code: stop selecting/inserting `workspace_id` in `collections` (`lists.go`, `members.go`, `tags.go`, `savedviews.go`) and `quotas`. Fix external call sites that referenced the column: `compose/org360` and `people/person_list.go` now scan/join without it.
- Rollout: apply migration `0228` before deploying this backend. No config changes. Quota listing may use owner/team indexes or scan where `idx_quota_ws_live` was used.

<sup>Written for commit 91b2a85deb64b36d888d8fdc163e10f13bf5c5fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1137?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

