### PR TITLE
fix(deps): the type generator parses YAML with a version that cannot be stalled

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,16 @@ jobs:
               # that edits what the lane does — and nothing else — would skip
               # the lane that runs it.
               - 'Makefile'
+              # And the install inputs, because they decide WHICH code the lane
+              # would have run against. A lockfile bump or a pnpm override swaps
+              # the dependency the SPA builds on and the one openapi-typescript
+              # parses the contract with — every frontend job would skip, and a
+              # dependency change is exactly the kind that needs fe-drift,
+              # fe-unit and fe-bundle to have an opinion. pnpm-workspace.yaml is
+              # named because `overrides` lives there: it resolves versions the
+              # lockfile then merely records.
+              - 'pnpm-lock.yaml'
+              - 'pnpm-workspace.yaml'
             e2e:
               - 'backend/**'
               - 'frontend/**'
@@ -145,6 +155,10 @@ jobs:
               - '**/go.sum'
               - '**/package.json'
               - '**/pnpm-lock.yaml'
+              # `overrides` lives here, so this file decides resolved versions
+              # the same way a manifest does — the SBOM and licence lanes must
+              # see a change to it even when nothing else moves.
+              - 'pnpm-workspace.yaml'
               - '.syft.yaml'
               - '.grant.yaml'
               - 'sbom-schemas/**'

--- a/infra/ci-pipeline.md
+++ b/infra/ci-pipeline.md
@@ -38,9 +38,9 @@ output. A required job skipped this way still counts as passing.
 | Scope | Paths | Gates |
 |---|---|---|
 | `backend` | `backend/**`, `infra/**/!(*.md)`, `go.work`, `go.work.sum`, `Makefile`, `scripts/**`, `extensions/**`, `fixtures/**`, `composition/**`, `.github/workflows/ci.yml`, `.github/actions/**`, `AGENTS.md`, `sonar-project.properties`, `frontend/src/mcp-apps/forbidden.json` | Go build/gate, extension reference, craftsmanship, integration, vuln |
-| `frontend` | `frontend/**`, `backend/api/**` (the contract drives FE types), plus the composition inputs the lane now typechecks against — `extensions/**`, `fixtures/**`, `composition/**`, `backend/tools/gen-composition/**`, `Makefile` | frontend lane, UAT |
+| `frontend` | `frontend/**`, `backend/api/**` (the contract drives FE types), plus the composition inputs the lane now typechecks against — `extensions/**`, `fixtures/**`, `composition/**`, `backend/tools/gen-composition/**`, `Makefile` — and the install inputs `pnpm-lock.yaml` and `pnpm-workspace.yaml`, which decide *which* dependency the SPA builds on and which one `openapi-typescript` parses the contract with (`overrides` lives in the workspace file, so it resolves versions the lockfile then merely records) | frontend lane, UAT |
 | `e2e` | `backend/**`, `frontend/**`, `infra/**/!(*.md)`, `extensions/**`, `fixtures/**`, `composition/**` | full-stack live-boot |
-| `deps` | `go.work`, `go.work.sum`, `**/go.mod`, `**/go.sum`, `**/package.json`, `**/pnpm-lock.yaml`, `.syft.yaml`, `.grant.yaml`, `sbom-schemas/**`, `Makefile`, `.github/workflows/ci.yml`, `.github/actions/**` | the license gate |
+| `deps` | `go.work`, `go.work.sum`, `**/go.mod`, `**/go.sum`, `**/package.json`, `**/pnpm-lock.yaml`, `pnpm-workspace.yaml` (`overrides` lives there, so it decides resolved versions the way a manifest does), `.syft.yaml`, `.grant.yaml`, `sbom-schemas/**`, `Makefile`, `.github/workflows/ci.yml`, `.github/actions/**` | the license gate |
 
 Consequences:
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  js-yaml: ^4.3.1
+
 importers:
 
   .: {}
@@ -1405,8 +1408,8 @@ packages:
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsdom@30.0.1:
@@ -2419,7 +2422,7 @@ snapshots:
       colorette: 1.4.0
       https-proxy-agent: 7.0.6(supports-color@10.2.2)
       js-levenshtein: 1.1.6
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       minimatch: 5.1.9
       pluralize: 8.0.0
       yaml-ast-parser: 0.0.43
@@ -3216,7 +3219,7 @@ snapshots:
 
   js-tokens@9.0.1: {}
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -16,3 +16,21 @@ packages:
 # esbuild ships a platform binary and needs its install script to run.
 allowBuilds:
   esbuild: true
+
+# Transitive-dependency floors we hold ourselves because the direct dependency
+# pins below them. Each one is a patch-level lift with a reason to exist and a
+# condition for going away — never a blanket "newest wins".
+overrides:
+  # GHSA-5p4m-2wfm-xmqj: quadratic CPU consumption resolving `!!omap`, fixed in
+  # 4.3.1. Reached only through openapi-typescript -> @redocly/openapi-core,
+  # which depends on the EXACT version 4.3.0, so no update can lift it and an
+  # override is the only route. The exposure here is small — the tool parses our
+  # own backend/api/*.yaml at build time, never anything a user supplies — but
+  # the fix is a patch bump, and a high advisory sitting open on a public
+  # repository costs more than it saves. Drop this once @redocly/openapi-core
+  # ships a range that admits 4.3.1.
+  #
+  # Pinned to the 4.x line on purpose: an open `>=4.3.1` resolves to 5.x, whose
+  # API the consumer was never written against, and swapping a DoS advisory for
+  # a broken type generator is not a trade.
+  js-yaml: '^4.3.1'


### PR DESCRIPTION
## What

Closes Dependabot alert #19 / **GHSA-5p4m-2wfm-xmqj** (high): quadratic CPU
consumption resolving `!!omap` in js-yaml, fixed in 4.3.1.

Two changes. A pnpm override lifting js-yaml to `^4.3.1`, and the CI change
classifier learning that the install inputs belong to the frontend lane —
without which nothing would have checked the first change.

## Why

**The override is the only route.** js-yaml arrives transitively through
`openapi-typescript` → `@redocly/openapi-core`, and that package depends on the
**exact** version `4.3.0` — not a range. No `pnpm update` can lift it, and
`openapi-typescript@7.13.0` is already the latest, so waiting on the dependency
chain means waiting indefinitely.

The exposure was small and worth stating plainly: the generator parses our own
`backend/api/*.yaml` at build time, never anything a user supplies, so the DoS
has no reachable attacker. A patch bump that closes a high advisory on a public
repository is still worth more than the argument against making it.

**Pinned to `^4.3.1`, not `>=4.3.1`.** The open range resolves to js-yaml **5.x**,
whose API the consumer was never written against — I tried it, and swapping a
build-time DoS for a broken type generator is not a trade. The override lives in
`pnpm-workspace.yaml` because that is where this repo keeps pnpm configuration,
next to `allowBuilds`.

**CI would not have checked any of this.** The `frontend` filter listed
`frontend/**`, `backend/api/**` and the composition inputs, but neither install
input — so a change that swaps the dependency the SPA builds on, and the one the
type generator parses the contract with, skipped `fe-drift`, `fe-unit` and
`fe-bundle` entirely. That is the same failure mode the `extensions/**` entries
were added to prevent: a lane skipping generation and passing silently. This PR
would have sailed through without a single frontend job running — and the fix is
self-demonstrating, since `fe-quality`, `fe-unit` and `fe-bundle` now run on this
lockfile-only diff.

Both filters now name the install inputs. `deps` names `pnpm-workspace.yaml`
specifically, because `overrides` resolves versions the lockfile then merely
records — so the licence and SBOM lanes must see that file move too.
`ci-doc-parity` required both be documented in `infra/ci-pipeline.md`; they are.

## How verified

**The lift is inert.** Generating the API types under js-yaml 4.3.0 and again
under 4.3.1 produces **byte-identical** `schema.d.ts` and `public-events.ts`.
That is the claim that matters for a parser swap, and it is measured rather than
assumed.

- `make check` green (exit 0) on this branch, rebased on #1126.
- `make check-backend` green, including `ci-doc-parity` after the classifier edit.
- `make fe-drift` green — it was red on `main` beforehand for an unrelated reason
  (stale contract types), which #1126 fixed.
- `make fe-lint`, `make fe-typecheck`, `make fe-unit`, `make fe-build` all green
  under the new dependency: 197 test files, 2447 tests.

### On a local flake, and how it resolved

The full gate failed twice locally before it passed, and the diagnosis is worth
recording because the failures were **not** caused by this change:

| Run | Result | Which tests |
| --- | --- | --- |
| `make check`, this branch | 11 failed / 4 files | `onboarding-facts`, `company-act`, `onboarding-conversation` |
| `make check`, this branch | 3 failed / 2 files | `logactivity`, `tasks` |
| `make check`, pristine `main` | **green** | — |
| `make check`, this branch | **green** | — |
| `make fe-unit` alone, both branches | green | 2447 passed |

Red, red, green on identical code — with disjoint failure sets each time —
is nondeterminism. A regression fails the same tests twice.

Two structural facts rule this change out as the cause. `pnpm why` shows js-yaml
has exactly one dependent chain (`@redocly/openapi-core` → `openapi-typescript` →
frontend devDependencies), and `openapi-typescript` is invoked only by the
`gen:api` scripts — vitest, Vite and Storybook never load it. And `FE_COVERAGE ?=`
defaults empty, so `fe-unit` executes the identical command standalone and inside
`frontend-check`; there is no configuration difference between the runs that
passed and the ones that failed, only machine state.

The load-sensitivity of those frontend screen tests is a real T11 concern
(`tests prove behaviour or they are noise` — no real-clock flakiness) and
deserves its own issue. It is not in scope here, but it will keep costing CI
re-runs until someone takes it.

- [x] `make check` is green
- [x] `make test-integration` is green (or: this change does not touch tenant data / RLS / the write shape) — does not touch tenant data, RLS, or the write shape
- [x] `make craft-static` reports no new blockers — no Go changes in this PR
- [x] This diff and description carry no secrets, no customer data, no local machine paths, and no private specification paths or contents — the spec is cited by chapter, ADR, or pin ID (this repository is public)

## AI involvement

**Generated.** Authored by Claude Code under human direction and accountability:
the dependency analysis, the override, the classifier fix, and the verification
above. The `>=4.3.1` → `^4.3.1` correction and the flake diagnosis came out of
that verification rather than being caught in review.

## Accountability

By opening this PR I confirm I am **accountable** for this change and can
**explain every line** in it — human-written or AI-assisted. Commits are signed
off (`git commit -s`, DCO). See [CONTRIBUTING.md](/CONTRIBUTING.md) and the
[Code of Conduct](/CODE_OF_CONDUCT.md).
