### PR TITLE
feat(extensions): a unit records its own writes, and hears what happened

### DIFF
--- a/backend/cmd/worker/boot.go
+++ b/backend/cmd/worker/boot.go
@@ -113,7 +113,13 @@ type workerLanes struct {
 	background *sync.WaitGroup
 	// stop ends every lane goroutine. It pairs with background: join() is the
 	// only thing that should call either, so the lanes have one shutdown.
-	stop      context.CancelFunc
+	stop context.CancelFunc
+	// laneCtx is what stop cancels, carried so a lane started LATER than this
+	// value — the extension subscriptions, which wait for the runtime binding
+	// the job runner makes — still lives and dies with all the others. A second
+	// context there would be a second shutdown, and join() would return with a
+	// consumer still reading the bus.
+	ctx       context.Context //nolint:containedctx // the lanes' lifetime IS this value; join() is the only thing that ends it.
 	runner    *compose.RunnerService
 	deliverer func(*database.DB) *webhooks.Deliverer
 	blob      blobstore.Store
@@ -142,7 +148,7 @@ func (l workerLanes) join() {
 // stack trace where the boot error belongs.
 func startEventLanes(ctx context.Context, cfg workerConfig, pool *pgxpool.Pool, rdb *redis.Client, modelPath compose.ModelPath, logger *slog.Logger, stdout io.Writer) (workerLanes, error) {
 	laneCtx, stopLanes := context.WithCancel(ctx)
-	lanes := workerLanes{background: &sync.WaitGroup{}, stop: stopLanes}
+	lanes := workerLanes{background: &sync.WaitGroup{}, stop: stopLanes, ctx: laneCtx}
 
 	if err := startRunnerLane(laneCtx, cfg, pool, rdb, modelPath, &lanes, logger, stdout); err != nil {
 		return lanes, err
@@ -191,13 +197,20 @@ func startEventLanes(ctx context.Context, cfg workerConfig, pool *pgxpool.Pool, 
 		return lanes, err
 	}
 	startWorkflowLane(laneCtx, pool, rdb, modelPath, lanes.background, logger, stdout)
-	startExtensionSubscriptionLanes(laneCtx, pool, rdb, lanes.background, logger, stdout)
 	return lanes, nil
 }
 
 // startExtensionSubscriptionLanes starts one consumer per composed unit
 // subscription — the tier's half of the bus, and this role's alone: every role
 // composes the same units, and the worker is the role that consumes.
+//
+// It is started from run(), AFTER the job runner, rather than with the lanes
+// above. A delivery reaches the installation through the per-call Runtime, and
+// this role's unconditional BindExtensionRuntime is the job runner's; started
+// with its siblings, a retained entry redelivered in the window before that
+// bind would fail on the wiring and then wait out the subscriber's whole
+// reclaim interval before anything tried again. It still runs on the LANES'
+// context, so it ends when they do.
 //
 // A listener whose group cannot be built is LOGGED and skipped rather than
 // failing the boot, because the boot already refused the only way that can
@@ -214,7 +227,7 @@ func startExtensionSubscriptionLanes(ctx context.Context, pool *pgxpool.Pool, rd
 				"unit", string(sub.Unit), "subscription", sub.Sub.Name, "error", err)
 			continue
 		}
-		handler := sub.Handler(pool)
+		handler := sub.Handler(pool, logger)
 		_, _ = fmt.Fprintf(stdout, "worker delivering %s to %s/%s (%s)\n",
 			strings.Join(sub.Sub.Events, ", "), sub.Unit, sub.Sub.Name, group.Name)
 		background.Go(func() { runGroupSubscriber(ctx, rdb, group, handler, logger, 0) })

--- a/backend/cmd/worker/boot.go
+++ b/backend/cmd/worker/boot.go
@@ -191,7 +191,34 @@ func startEventLanes(ctx context.Context, cfg workerConfig, pool *pgxpool.Pool, 
 		return lanes, err
 	}
 	startWorkflowLane(laneCtx, pool, rdb, modelPath, lanes.background, logger, stdout)
+	startExtensionSubscriptionLanes(laneCtx, pool, rdb, lanes.background, logger, stdout)
 	return lanes, nil
+}
+
+// startExtensionSubscriptionLanes starts one consumer per composed unit
+// subscription — the tier's half of the bus, and this role's alone: every role
+// composes the same units, and the worker is the role that consumes.
+//
+// A listener whose group cannot be built is LOGGED and skipped rather than
+// failing the boot, because the boot already refused the only way that can
+// happen: RegisterExtensions preflights every declared type against the
+// catalog. Reaching this branch means those two disagree, which is a defect in
+// this binary rather than in the deployment — and taking down the worker's
+// other lanes over one unit's listener would turn a unit-sized fault into an
+// installation-sized one.
+func startExtensionSubscriptionLanes(ctx context.Context, pool *pgxpool.Pool, rdb *redis.Client, background *sync.WaitGroup, logger *slog.Logger, stdout io.Writer) {
+	for _, sub := range compose.ComposedSubscriptions() {
+		group, err := sub.Group()
+		if err != nil {
+			logger.Error("worker: an extension subscription has no consumer group, so it would receive nothing",
+				"unit", string(sub.Unit), "subscription", sub.Sub.Name, "error", err)
+			continue
+		}
+		handler := sub.Handler(pool)
+		_, _ = fmt.Fprintf(stdout, "worker delivering %s to %s/%s (%s)\n",
+			strings.Join(sub.Sub.Events, ", "), sub.Unit, sub.Sub.Name, group.Name)
+		background.Go(func() { runGroupSubscriber(ctx, rdb, group, handler, logger, 0) })
+	}
 }
 
 // startWorkflowLane starts the cg:workflows dispatcher. It needs nothing the job

--- a/backend/cmd/worker/boot.go
+++ b/backend/cmd/worker/boot.go
@@ -32,6 +32,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/platform/events"
 	"github.com/gradionhq/margince/backend/internal/platform/jobs"
 	"github.com/gradionhq/margince/backend/internal/platform/keyvault"
+	kevents "github.com/gradionhq/margince/backend/internal/shared/kernel/events"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/runtimeenv"
 )
@@ -220,6 +221,27 @@ func startEventLanes(ctx context.Context, cfg workerConfig, pool *pgxpool.Pool, 
 // other lanes over one unit's listener would turn a unit-sized fault into an
 // installation-sized one.
 func startExtensionSubscriptionLanes(ctx context.Context, pool *pgxpool.Pool, rdb *redis.Client, background *sync.WaitGroup, logger *slog.Logger, stdout io.Writer) {
+	for _, lane := range extensionSubscriptionLanes(pool, logger, stdout) {
+		background.Go(func() { runGroupSubscriber(ctx, rdb, lane.group, lane.handler, logger, 0) })
+	}
+}
+
+// subscriptionLane is one composed listener resolved to what running it takes:
+// the group to consume, and the handler to consume it with.
+type subscriptionLane struct {
+	group   kevents.Group
+	handler events.Handler
+}
+
+// extensionSubscriptionLanes resolves every composed listener, announcing the
+// ones it can run and skipping the ones it cannot.
+//
+// It is split from the starter above so this decision — which lanes exist, and
+// what happens to a listener that cannot be resolved — can be exercised without
+// a bus to consume from. The skip is the part worth pinning: one unresolvable
+// listener must not cost the others their lane.
+func extensionSubscriptionLanes(pool *pgxpool.Pool, logger *slog.Logger, stdout io.Writer) []subscriptionLane {
+	var lanes []subscriptionLane
 	for _, sub := range compose.ComposedSubscriptions() {
 		group, err := sub.Group()
 		if err != nil {
@@ -227,11 +249,11 @@ func startExtensionSubscriptionLanes(ctx context.Context, pool *pgxpool.Pool, rd
 				"unit", string(sub.Unit), "subscription", sub.Sub.Name, "error", err)
 			continue
 		}
-		handler := sub.Handler(pool, logger)
 		_, _ = fmt.Fprintf(stdout, "worker delivering %s to %s/%s (%s)\n",
 			strings.Join(sub.Sub.Events, ", "), sub.Unit, sub.Sub.Name, group.Name)
-		background.Go(func() { runGroupSubscriber(ctx, rdb, group, handler, logger, 0) })
+		lanes = append(lanes, subscriptionLane{group: group, handler: sub.Handler(pool, logger)})
 	}
+	return lanes
 }
 
 // startWorkflowLane starts the cg:workflows dispatcher. It needs nothing the job

--- a/backend/cmd/worker/extruntimebinding_test.go
+++ b/backend/cmd/worker/extruntimebinding_test.go
@@ -167,3 +167,91 @@ func TestTheRoleBindsFromExactlyTheTwoKnownSites(t *testing.T) {
 		}
 	}
 }
+
+// TestSubscriptionsStartAfterTheRuntimeIsBound is the same class of fact as the
+// binding's position, one step further along: a bus DELIVERY reaches the
+// installation through the per-call Runtime too, so a subscriber started before
+// the job lane's unconditional binding consumes into a process that refuses.
+//
+// The cost is not a lost event but a slow one, which is why it needs a gate
+// rather than a bug report: the entry stays pending and re-delivers, so the
+// reaction lands one whole reclaim interval late, exactly once, on a worker
+// with no model configured. Nothing in the logs says the two were out of order.
+//
+// Asserted over the source for the reason the binding is: the failure is a
+// POSITION. Both calls have to sit in one function so their order is a fact
+// this walk can read at all — if a later refactor moves either behind another
+// helper, this fails and says so rather than passing over a pair it can no
+// longer compare.
+func TestSubscriptionsStartAfterTheRuntimeIsBound(t *testing.T) {
+	const runner, subscriptions = "startJobRunner", "startExtensionSubscriptionLanes"
+	sites := callSites(t, runner, subscriptions)
+	for _, fn := range []string{runner, subscriptions} {
+		if len(sites[fn]) != 1 {
+			t.Fatalf("%s is called %d time(s) in cmd/worker; this test compares one call to one call", fn, len(sites[fn]))
+		}
+	}
+	if sites[runner][0].enclosing != sites[subscriptions][0].enclosing {
+		t.Fatalf("%s runs in %s and %s in %s — their order is no longer a fact this walk can read",
+			runner, sites[runner][0].enclosing, subscriptions, sites[subscriptions][0].enclosing)
+	}
+	if sites[subscriptions][0].pos < sites[runner][0].pos {
+		t.Fatalf("%s is called before %s — a delivery arriving in that window reaches an unbound runtime, and the entry then waits out the subscriber's whole reclaim interval",
+			subscriptions, runner)
+	}
+}
+
+// callSite is one call to one of the functions above: where it is, and inside
+// what.
+type callSite struct {
+	enclosing string
+	pos       token.Pos
+}
+
+// callSites finds every call to the named package-level functions in
+// cmd/worker, keyed by callee name.
+func callSites(t *testing.T, names ...string) map[string][]callSite {
+	t.Helper()
+	wanted := make(map[string]bool, len(names))
+	for _, n := range names {
+		wanted[n] = true
+	}
+	fset := token.NewFileSet()
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("reading cmd/worker: %v", err)
+	}
+	found := map[string][]callSite{}
+	scanned := 0
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".go") {
+			continue
+		}
+		file, err := parser.ParseFile(fset, entry.Name(), nil, parser.SkipObjectResolution)
+		if err != nil {
+			t.Fatalf("parsing %s: %v", entry.Name(), err)
+		}
+		scanned++
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Body == nil {
+				continue
+			}
+			ast.Inspect(fn.Body, func(n ast.Node) bool {
+				call, ok := n.(*ast.CallExpr)
+				if !ok {
+					return true
+				}
+				if callee, ok := call.Fun.(*ast.Ident); ok && wanted[callee.Name] {
+					found[callee.Name] = append(found[callee.Name],
+						callSite{enclosing: fn.Name.Name, pos: call.Pos()})
+				}
+				return true
+			})
+		}
+	}
+	if scanned < 2 {
+		t.Fatalf("scanned only %d Go file(s) in cmd/worker — the walk matched almost nothing", scanned)
+	}
+	return found
+}

--- a/backend/cmd/worker/extsubscriptionlanes_test.go
+++ b/backend/cmd/worker/extsubscriptionlanes_test.go
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package main
+
+// Which listeners this role runs, and what one it cannot resolve costs the
+// others.
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/compose"
+	"github.com/gradionhq/margince/backend/pkg/extension"
+)
+
+func noopHandler(context.Context, extension.Runtime, extension.Delivery) error { return nil }
+
+// TestOneUnresolvableListenerDoesNotCostTheOthersTheirLane.
+//
+// A listener whose group cannot be built is a defect in this binary — the boot
+// preflights every declared type against the catalog, so the two disagreeing is
+// not a deployment's doing. What matters is the SHAPE of the response: it is
+// logged and skipped, so a unit-sized fault stays unit-sized, where a return or
+// a fatal would take every other unit's deliveries down with it.
+func TestOneUnresolvableListenerDoesNotCostTheOthersTheirLane(t *testing.T) {
+	t.Cleanup(func() { compose.SetComposedSubscriptionsForTest(nil) })
+	compose.SetComposedSubscriptionsForTest([]compose.ComposedSubscription{
+		{
+			Unit: "alpha", Version: "1.0.0",
+			Sub: extension.Subscription{Name: "unroutable", Events: []string{"invoice.created"}, Handle: noopHandler},
+		},
+		{
+			Unit: "beta", Version: "1.0.0",
+			Sub: extension.Subscription{Name: "listens", Events: []string{"activity.archived"}, Handle: noopHandler},
+		},
+	})
+
+	var announced bytes.Buffer
+	var logged bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logged, nil))
+
+	lanes := extensionSubscriptionLanes(nil, logger, &announced)
+
+	if len(lanes) != 1 {
+		t.Fatalf("resolved %d lanes, want only the routable one", len(lanes))
+	}
+	if lanes[0].group.Name != "cg:ext-beta-listens" {
+		t.Errorf("the surviving lane consumes %q, want beta's", lanes[0].group.Name)
+	}
+	// The one that was skipped is SAID, and says which listener it was: nothing
+	// else in the process will ever mention it again.
+	for _, want := range []string{"alpha", "unroutable"} {
+		if !strings.Contains(logged.String(), want) {
+			t.Errorf("the skip does not name %q: %s", want, logged.String())
+		}
+	}
+	// And the operator's boot output names only what is actually running.
+	if strings.Contains(announced.String(), "unroutable") {
+		t.Errorf("the boot announced a lane it did not start: %s", announced.String())
+	}
+	if !strings.Contains(announced.String(), "cg:ext-beta-listens") {
+		t.Errorf("the boot did not announce the lane it started: %s", announced.String())
+	}
+}
+
+// With nothing composed there is nothing to run, and nothing said about it.
+func TestNoSubscriptionsStartNoLanes(t *testing.T) {
+	t.Cleanup(func() { compose.SetComposedSubscriptionsForTest(nil) })
+	compose.SetComposedSubscriptionsForTest(nil)
+	var announced bytes.Buffer
+	if lanes := extensionSubscriptionLanes(nil, slog.New(slog.DiscardHandler), &announced); len(lanes) != 0 {
+		t.Fatalf("resolved %d lanes with nothing composed", len(lanes))
+	}
+	if announced.Len() != 0 {
+		t.Errorf("the boot announced %q with no listener composed", announced.String())
+	}
+}

--- a/backend/cmd/worker/main.go
+++ b/backend/cmd/worker/main.go
@@ -221,14 +221,26 @@ func runResumeSubscriber(ctx context.Context, rdb *redis.Client, svc *compose.Ru
 // reclaim window for a group whose handler runs longer than the default;
 // zero keeps it.
 func runSubscriber(ctx context.Context, rdb *redis.Client, groupName string, handler events.Handler, log *slog.Logger, minIdle time.Duration) {
-	var group kevents.Group
 	for _, g := range kevents.Groups() {
 		if g.Name == groupName {
-			group = g
+			runGroupSubscriber(ctx, rdb, g, handler, log, minIdle)
+			return
 		}
 	}
+	// A name no catalog group answers to is a typo in this role's wiring. Said
+	// out loud rather than run: the zero Group subscribes to no streams, so the
+	// lane would come up, log nothing, and deliver nothing forever.
+	log.Error("worker: no such consumer group, so this lane delivers nothing", "group", groupName)
+}
+
+// runGroupSubscriber consumes one consumer group, whether the catalog declared
+// it or a composed extension subscription did (compose.ComposedSubscription
+// builds its own, over the streams its declared types route to). Everything
+// after the group is identical for both, which is the point: a unit's listener
+// is an ordinary consumer, not a second delivery mechanism.
+func runGroupSubscriber(ctx context.Context, rdb *redis.Client, group kevents.Group, handler events.Handler, log *slog.Logger, minIdle time.Duration) {
 	sub := events.NewSubscriber(rdb, group, events.Dedupe(rdb, group.Name, handler), log).WithMinIdle(minIdle)
 	if err := sub.Run(ctx); err != nil && !errors.Is(err, context.Canceled) {
-		log.Error("subscriber "+groupName, "err", err)
+		log.Error("subscriber "+group.Name, "err", err)
 	}
 }

--- a/backend/cmd/worker/main.go
+++ b/backend/cmd/worker/main.go
@@ -122,6 +122,18 @@ func run(ctx context.Context, args []string, stdout io.Writer) error {
 		return err
 	}
 	defer stopJobs()
+	// AFTER the job runner, because that is where this role's unconditional
+	// BindExtensionRuntime happens and a delivery needs it: a unit's handler
+	// reaches the installation through the per-call Runtime, which refuses
+	// while nothing is bound. Started earlier, a retained entry redelivered in
+	// that window would fail on the wiring and then wait out the subscriber's
+	// whole reclaim interval before anyone tried again — on a worker with no
+	// model configured, which never reaches the runner lane's own binding.
+	// The context is the LANES', which is this function's own ctx with their
+	// cancel around it (startEventLanes) — carried on the value rather than
+	// re-derived here, so this lane ends when its siblings do instead of
+	// outliving them under a second shutdown.
+	startExtensionSubscriptionLanes(lanes.ctx, pool, rdb, lanes.background, logger, stdout) //nolint:contextcheck // the lanes' ctx IS derived from this one; see above.
 	// Every phase a replica needs to do work has returned; /readyz may say so.
 	started.complete()
 	// Deferred AFTER complete, so LIFO runs it FIRST: readiness goes false at

--- a/backend/internal/compose/extcore.go
+++ b/backend/internal/compose/extcore.go
@@ -149,9 +149,14 @@ func (c extensionCore) refuseUnattended() error {
 		//
 		// It is load-bearing rather than tidy, and most sharply for a delivery:
 		// that one runs as PrincipalSystem, which auth.Require bypasses
-		// entirely, so this refusal is the whole distance between a bus event
-		// and an unchecked core write. The unit's OWN tables stay writable,
-		// which is what an unattended run is for.
+		// entirely, so without this refusal the GOVERNED door would be wide
+		// open to a caller nothing checks. It does not make a unit unable to
+		// touch a core table — Tx's three SQL verbs run on the shared
+		// application role and reach whatever that role reaches, which
+		// runtime.go states in the open and issue #628 tracks closing. What it
+		// keeps shut is the door that would make such a write look authorized.
+		// The unit's OWN tables stay writable, which is what an unattended run
+		// is for.
 		return fmt.Errorf("%w: a scheduled job and a bus delivery run with no caller, and a core write is checked against the caller's own permissions", extension.ErrForbidden)
 	}
 	return nil

--- a/backend/internal/compose/extcore.go
+++ b/backend/internal/compose/extcore.go
@@ -58,11 +58,12 @@ type extensionCore struct {
 	// live caller could not have made. What a handler passes now contributes
 	// cancellation, deadline and its own values — never an identity.
 	authority func(context.Context) (context.Context, error)
-	// tick marks an invocation with no human behind it. Held rather than
-	// re-derived because the reason a tick is refused is about the INVOCATION,
-	// not about the context the handler passes in.
-	tick bool
-	deps extensionRuntimeBinding
+	// unattended marks an invocation with nobody behind it — a scheduled job
+	// tick, a bus delivery. Held rather than re-derived because the reason it
+	// is refused is about the INVOCATION, not about the context the handler
+	// passes in.
+	unattended bool
+	deps       extensionRuntimeBinding
 }
 
 //nolint:ireturn // returning the published repo IS the seam: a unit holds extension.ActivityRepo, never a core type.
@@ -74,11 +75,12 @@ type extensionActivities struct{ core extensionCore }
 
 // Create files one activity through the product's own write path.
 func (a extensionActivities) Create(ctx context.Context, in crm.CreateActivityRequest) (crm.Activity, error) {
-	// The tick refusal is FIRST, before anything is bound or read, because it
-	// is about what the invocation IS rather than about anything it asked for:
-	// there is no caller here whose authority a core write could be checked
-	// against, so nothing later in this function has a question to answer.
-	if err := a.core.refuseTick(); err != nil {
+	// The unattended refusal is FIRST, before anything is bound or read,
+	// because it is about what the invocation IS rather than about anything it
+	// asked for: there is no caller here whose authority a core write could be
+	// checked against, so nothing later in this function has a question to
+	// answer.
+	if err := a.core.refuseUnattended(); err != nil {
 		return crm.Activity{}, err
 	}
 	ctx, err := a.core.authorised(ctx)
@@ -135,17 +137,22 @@ func (c extensionCore) authorised(ctx context.Context) (context.Context, error) 
 	return bound, nil
 }
 
-// refuseTick refuses the invocation that has no caller behind it.
-func (c extensionCore) refuseTick() error {
-	if c.tick {
-		// A tick runs as the unit, with nobody behind it. Core writes are
-		// checked against the CALLER's live RBAC, and there is no caller to
-		// check — the alternatives are a system principal, which passes every
-		// check ever written, or resolving the workspace's agent seat, which is
-		// a governance surface of its own. Both are features; this is a
-		// refusal. A tick's own tables stay writable, which is what a tick is
-		// for.
-		return fmt.Errorf("%w: a scheduled job runs with no caller, and a core write is checked against the caller's own permissions", extension.ErrForbidden)
+// refuseUnattended refuses the invocation that has no caller behind it.
+func (c extensionCore) refuseUnattended() error {
+	if c.unattended {
+		// A job tick and a bus delivery both run with nobody behind them. Core
+		// writes are checked against the CALLER's live RBAC, and there is no
+		// caller to check — the alternatives are a system principal, which
+		// passes every check ever written, or resolving the workspace's agent
+		// seat, which is a governance surface of its own. Both are features;
+		// this is a refusal.
+		//
+		// It is load-bearing rather than tidy, and most sharply for a delivery:
+		// that one runs as PrincipalSystem, which auth.Require bypasses
+		// entirely, so this refusal is the whole distance between a bus event
+		// and an unchecked core write. The unit's OWN tables stay writable,
+		// which is what an unattended run is for.
+		return fmt.Errorf("%w: a scheduled job and a bus delivery run with no caller, and a core write is checked against the caller's own permissions", extension.ErrForbidden)
 	}
 	return nil
 }

--- a/backend/internal/compose/extcore_test.go
+++ b/backend/internal/compose/extcore_test.go
@@ -29,7 +29,7 @@ import (
 func TestAJobTickCannotWriteACoreRecord(t *testing.T) {
 	// No pool and no transaction, deliberately. If admit ever stopped refusing
 	// first, this test would panic rather than pass.
-	core := extensionCore{tick: true}
+	core := extensionCore{unattended: true}
 
 	_, err := core.Activities().Create(context.Background(), crm.CreateActivityRequest{
 		Kind: crm.CreateActivityRequestKindNote, Source: "extension:probe",

--- a/backend/internal/compose/extensions.go
+++ b/backend/internal/compose/extensions.go
@@ -6,6 +6,7 @@ package compose
 import (
 	"fmt"
 	"slices"
+	"strings"
 	"sync"
 
 	"github.com/gradionhq/margince/backend/internal/platform/jobs"
@@ -145,6 +146,7 @@ func ComposedVerbs() []extension.Verb {
 // capabilities registered while the boot reports failure.
 func validateExtensionSet(exts []extension.Extension) error {
 	seen := make(map[extension.Name]bool, len(exts))
+	namespaces := make(map[string]extension.Name, len(exts))
 	packCodes := make(map[jurisdiction.Code]extension.Name, len(exts))
 	for _, e := range exts {
 		if err := e.Name.Validate(); err != nil {
@@ -154,6 +156,9 @@ func validateExtensionSet(exts []extension.Extension) error {
 			return fmt.Errorf("compose: extension %q composed twice — the enabled set under extensions/ carries one directory per unit", e.Name)
 		}
 		seen[e.Name] = true
+		if err := reserveNamespace(e.Name, namespaces); err != nil {
+			return err
+		}
 		if err := e.Version.Validate(); err != nil {
 			return fmt.Errorf("compose: extension %q: %w", e.Name, err)
 		}
@@ -176,6 +181,43 @@ func validateExtensionSet(exts []extension.Extension) error {
 	return nil
 }
 
+// reserveNamespace refuses a composed set in which one unit's SQL namespace is
+// a PREFIX of another's.
+//
+// Unit `foo` owns `ext_foo`, unit `foo-bar` owns `ext_foo_bar`, and every
+// identifier derived from a namespace is `<namespace>_<suffix>` — so
+// `ext_foo_bar_note` is a legitimate spelling for BOTH: foo's table named
+// `bar_note`, and foo-bar's table named `note`. Nothing downstream can tell
+// them apart, because nothing downstream holds the split.
+//
+// The generator already refuses the case where the two units both DECLARE that
+// table (checkDerivedIdentifiers, "the collision is at the join"). What it
+// cannot see is a unit merely NAMING the ambiguous identifier at run time — a
+// ledger row, an event's subject — where the honest answer to "whose table is
+// this" does not exist. Refusing the pair at boot is what makes every such
+// answer exact, and it costs an installation only a rename.
+//
+// The names are reported both ways round, because an author reading this has no
+// other way to find the other side of the clash.
+func reserveNamespace(name extension.Name, taken map[string]extension.Name) error {
+	namespace, err := name.Namespace()
+	if err != nil {
+		return fmt.Errorf("compose: %w", err)
+	}
+	for other, owner := range taken {
+		short, long, shortOwner, longOwner := other, namespace, owner, name
+		if len(namespace) < len(other) {
+			short, long, shortOwner, longOwner = namespace, other, name, owner
+		}
+		if strings.HasPrefix(long, short+"_") {
+			return fmt.Errorf("compose: extensions %q and %q derive the namespaces %q and %q, and one opens the other — an identifier like %s_… names a table either unit could own, so no ledger row or event about it has one honest owner. Rename one of them",
+				shortOwner, longOwner, short, long, long)
+		}
+	}
+	taken[namespace] = name
+	return nil
+}
+
 // preflightSubscriptions validates one unit's listeners through the same
 // published Subscription.Validate a unit's own tests run, and then asks the one
 // question the published type cannot: is every declared event type ROUTABLE?
@@ -186,6 +228,15 @@ func validateExtensionSet(exts []extension.Extension) error {
 // means its listener would be created, hold a cursor, and never receive
 // anything. A subscription that silently never fires is indistinguishable from
 // a product where that fact never happens.
+//
+// WHAT IT CANNOT CATCH, so nobody reads more into a green boot than it says: an
+// EXTENSION type is routable by SHAPE. `ext_notse.note_added` — a typo for a
+// sibling unit's event — boots clean, builds a group over the extension stream
+// and never fires, exactly the silence this check removes for core types. It is
+// not checkable here and would not be checkable anywhere: a unit's verbs are
+// chosen where they are published, at the Record call, and nothing declares
+// them in advance. A misspelt core type is caught; a misspelt extension type is
+// the unit author's to notice.
 func preflightSubscriptions(e extension.Extension) error {
 	seen := make(map[string]bool, len(e.Subscriptions))
 	for _, sub := range e.Subscriptions {

--- a/backend/internal/compose/extensions.go
+++ b/backend/internal/compose/extensions.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 
 	"github.com/gradionhq/margince/backend/internal/platform/jobs"
+	kevents "github.com/gradionhq/margince/backend/internal/shared/kernel/events"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/jurisdiction"
 	"github.com/gradionhq/margince/backend/pkg/extension"
 )
@@ -75,6 +76,7 @@ func RegisterExtensions(exts []extension.Extension, verbs []extension.Verb, jobD
 		return err
 	}
 	setComposedJobs(composedSet)
+	setComposedSubscriptions(buildExtensionSubscriptions(exts))
 	setComposedTools(tools)
 	setComposedVerbs(verbs)
 	setComposedExtensions(exts)
@@ -167,8 +169,77 @@ func validateExtensionSet(exts []extension.Extension) error {
 		if err := preflightJobs(e); err != nil {
 			return err
 		}
+		if err := preflightSubscriptions(e); err != nil {
+			return err
+		}
 	}
 	return nil
+}
+
+// preflightSubscriptions validates one unit's listeners through the same
+// published Subscription.Validate a unit's own tests run, and then asks the one
+// question the published type cannot: is every declared event type ROUTABLE?
+//
+// The catalog is not reachable from pkg/extension (it is stdlib-only), so this
+// is the first and only place the answer exists — and it has to be an answer at
+// BOOT rather than at delivery, because an unroutable type has no stream, which
+// means its listener would be created, hold a cursor, and never receive
+// anything. A subscription that silently never fires is indistinguishable from
+// a product where that fact never happens.
+func preflightSubscriptions(e extension.Extension) error {
+	seen := make(map[string]bool, len(e.Subscriptions))
+	for _, sub := range e.Subscriptions {
+		if err := sub.Validate(); err != nil {
+			return fmt.Errorf("compose: extension %q: %w", e.Name, err)
+		}
+		if seen[sub.Name] {
+			return fmt.Errorf("compose: extension %q declares subscription %q twice", e.Name, sub.Name)
+		}
+		seen[sub.Name] = true
+		for _, eventType := range sub.Events {
+			if _, err := kevents.StreamFor(eventType); err != nil {
+				return fmt.Errorf("compose: extension %q, subscription %q: %w", e.Name, sub.Name, err)
+			}
+		}
+	}
+	return nil
+}
+
+// composedSubscriptions holds this boot's registered listeners, written once by
+// RegisterExtensions before any surface serves. Same shape and same reason as
+// composedTools: the mutex guards the write-then-read ORDERING across the
+// boot/serve boundary, not concurrent registrations.
+var composedSubscriptions struct {
+	mu   sync.RWMutex
+	subs []ComposedSubscription
+}
+
+func setComposedSubscriptions(subs []ComposedSubscription) {
+	composedSubscriptions.mu.Lock()
+	defer composedSubscriptions.mu.Unlock()
+	composedSubscriptions.subs = subs
+}
+
+// ComposedSubscriptions returns this boot's registered listeners, each already
+// carrying the unit identity its deliveries are attributed to. The worker role
+// reads it to start one consumer per listener; every other role composes them
+// and starts none, because consuming the bus is the worker's job.
+func ComposedSubscriptions() []ComposedSubscription {
+	composedSubscriptions.mu.RLock()
+	defer composedSubscriptions.mu.RUnlock()
+	return slices.Clone(composedSubscriptions.subs)
+}
+
+// buildExtensionSubscriptions flattens the validated set into one list of
+// listeners, each stamped with the unit that declared it.
+func buildExtensionSubscriptions(exts []extension.Extension) []ComposedSubscription {
+	var subs []ComposedSubscription
+	for _, e := range exts {
+		for _, sub := range e.Subscriptions {
+			subs = append(subs, ComposedSubscription{Unit: e.Name, Version: e.Version, Sub: sub})
+		}
+	}
+	return subs
 }
 
 // validateVerbSet refuses two operations that would mount the same route.

--- a/backend/internal/compose/extensions.go
+++ b/backend/internal/compose/extensions.go
@@ -281,6 +281,17 @@ func ComposedSubscriptions() []ComposedSubscription {
 	return slices.Clone(composedSubscriptions.subs)
 }
 
+// SetComposedSubscriptionsForTest installs a listener set without a boot.
+//
+// Exported for the WORKER's own tests: the lane starter reads this registry,
+// and the thing worth testing there — that one unresolvable listener does not
+// cost the others their lane — needs a set containing one. cmd/worker cannot
+// reach an unexported setter, and reconstructing the registry there would be a
+// second source of the same fact.
+func SetComposedSubscriptionsForTest(subs []ComposedSubscription) {
+	setComposedSubscriptions(subs)
+}
+
 // buildExtensionSubscriptions flattens the validated set into one list of
 // listeners, each stamped with the unit that declared it.
 func buildExtensionSubscriptions(exts []extension.Extension) []ComposedSubscription {

--- a/backend/internal/compose/extensiontx.go
+++ b/backend/internal/compose/extensiontx.go
@@ -35,11 +35,20 @@ type extensionTx struct {
 	// has a caller, and what the role bound at boot, are facts about the call,
 	// not about the transaction.
 	core extensionCore
+	// ledger records what the unit's OWN SQL did — the audit row and the bus
+	// event the three verbs below cannot write for it. Built by the Runtime for
+	// the same reason core is: which unit is writing, and under whose identity,
+	// are facts about the invocation rather than about the transaction.
+	ledger extensionLedger
 }
 
 //nolint:ireturn // returning the published port IS the seam: a unit holds extension.Core, never a core type.
 func (t extensionTx) Core() extension.Core {
 	return t.core
+}
+
+func (t extensionTx) Record(ctx context.Context, ch extension.Change, ev extension.Event) error {
+	return t.ledger.Record(ctx, ch, ev)
 }
 
 func (t extensionTx) Exec(ctx context.Context, sql string, args ...any) (int64, error) {

--- a/backend/internal/compose/extledger.go
+++ b/backend/internal/compose/extledger.go
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The core's half of extension.Tx.Audit and extension.Receipt: the ledger row
+// and the bus event a unit's OWN write records, written through the product's
+// own storekit seam on the transaction the unit already holds.
+//
+// Everything here is a translation and a set of refusals. The WRITES are
+// storekit.Audit and storekit.Emit — the same two calls every module store
+// makes — so the actor resolution, the workspace binding, the attribution merge
+// and the envelope validation are inherited rather than re-implemented. What
+// this file adds is the one thing storekit cannot know: which unit is asking,
+// and therefore which rows and which event names are its own to write.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/provenance"
+	"github.com/gradionhq/margince/backend/pkg/extension"
+)
+
+// extensionLedger is one transaction's ledger seam.
+//
+// It holds the CALLER's transaction for the reason extensionCore does: the
+// unit's row, the audit row and the outbox row are one commit or none, which is
+// the whole write shape. It reaches for no connection of its own.
+type extensionLedger struct {
+	tx pgx.Tx
+	// namespace is the invoking unit's `ext_<name>`, derived where the unit is
+	// known and never taken from anything a handler passes. It is what makes
+	// "its own tables" and "its own event names" answerable at all: a unit that
+	// could spell a namespace could write another unit's history.
+	namespace string
+	// authority re-binds the INVOCATION's workspace, actor, correlation and
+	// attribution onto whatever context a verb is handed — the Runtime's own
+	// scoped. Without it a handler could pass a context it kept from an earlier,
+	// higher-privileged call and put that actor on the ledger row.
+	authority func(context.Context) (context.Context, error)
+}
+
+// Record writes the ledger row and stages the event for one write to the unit's
+// own tables, on the caller's transaction.
+//
+// The two are one call because they are one obligation: the write shape the
+// product holds itself to is domain row + audit row + outbox event in a single
+// transaction, and a seam that let a unit take the first two would be offering
+// it a weaker rule than the core keeps. It also means the event's subject is the
+// ledger row's subject by construction — the entity is named once, here, so the
+// two cannot drift.
+func (l extensionLedger) Record(ctx context.Context, ch extension.Change, ev extension.Event) error {
+	if err := ch.Validate(); err != nil {
+		return err
+	}
+	if err := ev.Validate(); err != nil {
+		return err
+	}
+	if err := l.ownTable(ch.Entity); err != nil {
+		return err
+	}
+	entityID, err := ids.Parse(ch.ID)
+	if err != nil {
+		// Unreachable through Change.Validate's canonical-UUID grammar, and
+		// checked anyway: this value becomes a uuid bind parameter, and the
+		// grammar and the parser agreeing is not something this call should
+		// assume on the strength of having read both.
+		return fmt.Errorf("extension: %q is not a row id", ch.ID)
+	}
+	ctx, err = l.authorised(ctx)
+	if err != nil {
+		return err
+	}
+	ctx, err = withChangeDetail(ctx, ch.Detail)
+	if err != nil {
+		return err
+	}
+
+	auditID, err := storekit.Audit(ctx, l.tx, string(ch.Action), ch.Entity, entityID,
+		imageOrNil(ch.Before), imageOrNil(ch.After))
+	if err != nil {
+		return ledgerFailure(ctx, "writing the ledger row for an extension's own write", err)
+	}
+	// The type is BUILT here, from the namespace the core derived and the verb
+	// the unit chose. There is no path by which a unit names the left-hand side,
+	// which is why the port needs no check that it did not: `person.created`
+	// from a unit is not refused, it is unsayable.
+	eventType := l.namespace + "." + ev.Verb
+	if err := storekit.Emit(ctx, l.tx, auditID, eventType, ch.Entity, entityID,
+		imageOrNil(ev.Payload)); err != nil {
+		return ledgerFailure(ctx, "staging an extension's own event", err)
+	}
+	return nil
+}
+
+// ownTable refuses a ledger row against anything outside the invoking unit's
+// namespace.
+//
+// A ledger row is a RECORD's history. One written against `person` would put a
+// line into a core record's trail describing a write the core never made,
+// attributed to a caller who never made it — and the same holds for another
+// unit's table. The check is on the namespace the core derived from the
+// invocation, so a unit has nothing to spell here and nothing to get past.
+func (l extensionLedger) ownTable(entity string) error {
+	if !strings.HasPrefix(entity, l.namespace+"_") {
+		return fmt.Errorf("extension: %q is not this unit's table — a unit audits rows in its own %s_ namespace", entity, l.namespace)
+	}
+	return nil
+}
+
+// authorised re-binds the invocation's authority onto the context a verb was
+// handed, and refuses on a Runtime the call has finished with.
+func (l extensionLedger) authorised(ctx context.Context) (context.Context, error) {
+	if l.authority == nil {
+		return nil, errors.New("compose: this ledger seam was built without the invocation's authority, so no row can be attributed to it")
+	}
+	return l.authority(ctx)
+}
+
+// withChangeDetail carries the unit's free-form context into the attribution
+// entry the core stamps.
+//
+// It travels on the CONTEXT rather than as an evidence argument because
+// storekit refuses a caller-supplied `extension` evidence member outright: the
+// member is core-owned, and it is the same member the unit name, version and
+// via ride in. So the port re-binds a copy of the attribution the Runtime
+// already bound, with detail filled in, for this one write. What a unit can
+// influence stays exactly one member deep.
+func withChangeDetail(ctx context.Context, detail json.RawMessage) (context.Context, error) {
+	if len(detail) == 0 {
+		return ctx, nil
+	}
+	ext, ok := provenance.ExtensionFrom(ctx)
+	if !ok {
+		// The Runtime binds attribution on every scoped context, so an absent
+		// one is a core wiring fault rather than anything the unit did — and
+		// writing the detail without it would put unattributed free-form
+		// content into a core-owned evidence member.
+		return nil, errors.New("compose: no extension attribution is bound to this call, so a unit's audit detail has nothing to hang off")
+	}
+	ext.Detail = detail
+	return provenance.WithExtension(ctx, ext), nil
+}
+
+// imageOrNil hands storekit a JSON image or SQL NULL.
+//
+// The nil check cannot be left to storekit: a nil json.RawMessage inside an
+// `any` is not a nil interface, so it would marshal to the four bytes `null`
+// and land as jsonb null — a value, not the absence of one. The two read
+// differently in every query that asks whether an image is there.
+//
+//craft:ignore naked-any storekit's jsonb seam takes any; this is the one place that decides between bytes and NULL
+func imageOrNil(raw json.RawMessage) any {
+	if len(raw) == 0 {
+		return nil
+	}
+	return raw
+}
+
+// ledgerFailure reports that a ledger write failed without telling a unit how.
+//
+// The text of a failed audit or outbox write is a relation name, a constraint
+// and a SQL state, written for the people who operate the installation. A unit
+// is other people's code, so what it gets is that the write failed — which is
+// all it can act on, since its own transaction is going back either way. The
+// detail stays where the operators already look.
+func ledgerFailure(ctx context.Context, what string, err error) error {
+	slog.Default().ErrorContext(ctx, "compose: "+what, "error", err)
+	return errors.New("extension: the core could not record this write, so nothing was committed")
+}

--- a/backend/internal/compose/extledger.go
+++ b/backend/internal/compose/extledger.go
@@ -3,9 +3,9 @@
 
 package compose
 
-// The core's half of extension.Tx.Audit and extension.Receipt: the ledger row
-// and the bus event a unit's OWN write records, written through the product's
-// own storekit seam on the transaction the unit already holds.
+// The core's half of extension.Tx.Record: the ledger row and the bus event a
+// unit's OWN write records, written through the product's own storekit seam on
+// the transaction the unit already holds.
 //
 // Everything here is a translation and a set of refusals. The WRITES are
 // storekit.Audit and storekit.Emit — the same two calls every module store

--- a/backend/internal/compose/extledger_integration_test.go
+++ b/backend/internal/compose/extledger_integration_test.go
@@ -24,8 +24,11 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"log/slog"
 	"reflect"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 
@@ -229,55 +232,143 @@ func TestAFailedUnitWriteTakesItsLedgerRowAndItsEventWithIt(t *testing.T) {
 	}
 }
 
-// TestADeliveryMayRecordItsOwnWriteAndMayNotWriteACoreRecord is the unattended
-// pair, asserted together because they are one decision.
+// TestADeliveryThroughTheRealHandlerRecordsAndRefuses drives the whole
+// delivery path: an ENVELOPE goes into the handler the worker actually runs,
+// and what comes out is a ledger row, an event, and a refused core write.
 //
-// A bus delivery runs as the system principal, which auth.Require does not
-// check at all — so the port's refusal is the whole distance between an event
-// arriving and an unchecked core write. And the LEDGER stays open, because
-// recording what the unit did to its own rows needs no authority over anything
-// else: a reaction nobody can audit would be the worse half of the trade.
-func TestADeliveryMayRecordItsOwnWriteAndMayNotWriteACoreRecord(t *testing.T) {
+// It is deliberately not built out of deliveryRuntimeFor and a context of this
+// test's own. Everything that would make a delivery wrong is established inside
+// ComposedSubscription.Handler — the workspace it resolves, the system actor it
+// binds, the correlation it carries through, the causation it links, and the
+// unattended Runtime that shuts the core port — so a test that supplied those
+// itself would be asserting its own arithmetic and would stay green through
+// exactly the regression that matters.
+func TestADeliveryThroughTheRealHandlerRecordsAndRefuses(t *testing.T) {
 	e := setupExtRuntime(t)
-	ctx := e.callCtx(e.WS)
-	rt := deliveryRuntimeFor(ctx, "alpha", "1.0.0", "subscription/probe",
-		extensionRuntimeBinding{pool: e.Pool, vault: e.vault})
-	rowID := ids.NewV7()
+	rowID, correlation, cause := ids.NewV7(), ids.NewV7(), ids.NewV7()
 
-	if err := rt.Tx(ctx, func(ctx context.Context, tx extension.Tx) error {
-		_, coreErr := tx.Core().Activities().Create(ctx, crm.CreateActivityRequest{
-			Kind: crm.CreateActivityRequestKindNote, Source: "extension:probe",
-		})
-		if !errors.Is(coreErr, extension.ErrForbidden) {
-			t.Errorf("a delivery's core write answered %v, want ErrForbidden", coreErr)
-		}
-		return tx.Record(ctx,
-			extension.Change{
-				Action: extension.AuditUpdate, Entity: ledgerEntity, ID: rowID.String(),
-				After: json.RawMessage(`{"filed_activity_id":null}`),
+	var coreErr error
+	sub := ComposedSubscription{
+		Unit: "alpha", Version: "1.0.0",
+		Sub: extension.Subscription{
+			Name: "probe", Events: []string{"activity.archived"},
+			Handle: func(ctx context.Context, rt extension.Runtime, d extension.Delivery) error {
+				if rt.Caller() != (extension.Caller{}) {
+					t.Errorf("the handler was given caller %+v, want nobody", rt.Caller())
+				}
+				if d.Type != "activity.archived" || d.Entity.Type != "activity" {
+					t.Errorf("delivery = %+v, want the archived activity", d)
+				}
+				return rt.Tx(ctx, func(ctx context.Context, tx extension.Tx) error {
+					_, coreErr = tx.Core().Activities().Create(ctx, crm.CreateActivityRequest{
+						Kind: crm.CreateActivityRequestKindNote, Source: "extension:probe",
+					})
+					return tx.Record(ctx,
+						extension.Change{
+							Action: extension.AuditUpdate, Entity: ledgerEntity, ID: rowID.String(),
+							After: json.RawMessage(`{"filed_activity_id":null}`),
+						},
+						extension.Event{Verb: "thing_changed"})
+				})
 			},
-			extension.Event{Verb: "thing_changed"})
-	}); err != nil {
-		t.Fatal(err)
+		},
 	}
 
-	if _, action, _, evidence := auditedRow(t, e, rowID); action != string(extension.AuditUpdate) {
-		t.Errorf("the delivery's ledger row records %q, want an update", action)
-	} else if !json.Valid(evidence) {
-		t.Errorf("the delivery's ledger row carries no readable evidence: %s", evidence)
+	// The envelope a real archive puts on the bus, correlation and all.
+	if err := sub.Handler(e.Pool, slog.New(slog.DiscardHandler))(context.Background(), events.Envelope{
+		EventID: cause, Type: "activity.archived", OccurredAt: time.Now().UTC(),
+		Entity: events.EntityRef{Type: "activity", ID: ids.NewV7()},
+		Trace:  events.Trace{CorrelationID: correlation, AuditLogID: ids.NewV7()},
+	}); err != nil {
+		t.Fatalf("the delivery failed: %v", err)
 	}
-	// And the attribution says which listener carried it, not merely which
-	// unit: an audit reader asking "what did this" gets the subscription.
-	_, _, _, evidence := auditedRow(t, e, rowID)
+
+	// The core port is shut for a caller auth.Require would not have checked.
+	if !errors.Is(coreErr, extension.ErrForbidden) {
+		t.Errorf("a delivery's core write answered %v, want ErrForbidden", coreErr)
+	}
+
+	// And the unit's own write landed, under the identity the HANDLER bound.
+	_, action, actorID, evidence := auditedRow(t, e, rowID)
+	if action != string(extension.AuditUpdate) {
+		t.Errorf("the delivery's ledger row records %q, want an update", action)
+	}
+	if actorID != "system" {
+		t.Errorf("actor_id = %q, want the system principal a delivery runs as", actorID)
+	}
 	var recorded struct {
-		Extension struct {
-			Via string `json:"via"`
-		} `json:"extension"`
+		Extension struct{ Via string } `json:"extension"`
 	}
 	if err := json.Unmarshal(evidence, &recorded); err != nil {
 		t.Fatal(err)
 	}
 	if recorded.Extension.Via != "subscription/probe" {
 		t.Errorf("evidence.extension.via = %q, want the subscription that ran", recorded.Extension.Via)
+	}
+
+	// The trace is the whole point of a reaction: the event this published
+	// carries the correlation of the fact that caused it, and names that fact
+	// as its cause. Read together they are one story.
+	envelope := publishedEnvelope(t, e, "ext_alpha.thing_changed")
+	if envelope.Trace.CorrelationID != correlation {
+		t.Errorf("the reaction's correlation is %s, want the triggering event's %s",
+			envelope.Trace.CorrelationID, correlation)
+	}
+	if envelope.Trace.CausationID == nil || *envelope.Trace.CausationID != cause {
+		t.Errorf("the reaction's causation is %v, want the event that caused it (%s)",
+			envelope.Trace.CausationID, cause)
+	}
+}
+
+// TestAPanickingHandlerFailsTheDeliveryRatherThanTheWorker: nothing sits above
+// a delivery but the subscriber's goroutine, so an unrecovered panic in one
+// unit's listener takes down the relay, the job runner and every other unit's
+// lane — and the entry that caused it is un-acked, so the restarted worker is
+// handed the same event and dies again. One bad delivery would be an
+// installation-wide crash loop.
+//
+// It runs in the database lane because the panic has to happen where the real
+// one would: inside a handler that the real Handler actually reached, past the
+// tenant read a fake pool cannot answer.
+func TestAPanickingHandlerFailsTheDeliveryRatherThanTheWorker(t *testing.T) {
+	e := setupExtRuntime(t)
+	var ran bool
+	sub := ComposedSubscription{
+		Unit: "alpha", Version: "1.0.0",
+		Sub: extension.Subscription{
+			Name: "probe", Events: []string{"activity.archived"},
+			Handle: func(context.Context, extension.Runtime, extension.Delivery) error {
+				ran = true
+				panic("a unit's own nil map")
+			},
+		},
+	}
+
+	var err error
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("the panic escaped the delivery and reached the lane: %v", r)
+			}
+		}()
+		err = sub.Handler(e.Pool, slog.New(slog.DiscardHandler))(context.Background(), events.Envelope{
+			EventID: ids.NewV7(), Type: "activity.archived", OccurredAt: time.Now().UTC(),
+			Entity: events.EntityRef{Type: "activity", ID: ids.NewV7()},
+			Trace:  events.Trace{CorrelationID: ids.NewV7(), AuditLogID: ids.NewV7()},
+		})
+	}()
+
+	if !ran {
+		t.Fatal("the handler never ran, so this proves nothing about a panic inside one")
+	}
+	if err == nil {
+		t.Fatal("a panicking delivery was acked — the fact it panicked on would be dropped")
+	}
+	// The failure names the unit and the subscription: the bus entry cannot,
+	// and an operator reading a failed delivery has nothing else to go on.
+	for _, want := range []string{"alpha", "probe"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("the failure does not name %q: %v", want, err)
+		}
 	}
 }

--- a/backend/internal/compose/extledger_integration_test.go
+++ b/backend/internal/compose/extledger_integration_test.go
@@ -1,0 +1,283 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package compose
+
+// What the ledger seam does once it is live, over real migrated Postgres: the
+// three rows a unit's write produces land in ONE transaction and leave together
+// when it rolls back, the ledger row carries the attribution the core stamped,
+// and the envelope on the bus is routable and joined to that ledger row.
+//
+// None of it is checkable without a database. Atomicity is a property of a
+// transaction, the evidence merge happens inside an INSERT, and the envelope is
+// validated on its way into the outbox — a fake at any of those three points
+// would be asserting this test's own arithmetic.
+//
+// The unit's OWN row is a `workspace` update, for the reason
+// TestRuntimeTxCommitsAndRollsBack gives: the ext_* tables arrive with a unit,
+// and this seam has to be right before there is one. What is under test is the
+// pairing, not the table.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/gradionhq/margince/backend/internal/platform/database"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/events"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/pkg/extension"
+	"github.com/gradionhq/margince/backend/pkg/extension/crm"
+)
+
+// ledgerEntity is a table in the probe unit's namespace (`alpha` →
+// `ext_alpha`). audit_log.entity_type is free text, so what makes this the
+// unit's own is the port's check against the invoking unit — which is exactly
+// what these rows are here to demonstrate landing.
+const ledgerEntity = "ext_alpha_thing"
+
+// auditedRow reads back the one ledger row written for an entity.
+//
+// It reads inside a WORKSPACE-BOUND transaction because audit_log carries
+// forced row-level security: the app pool the lane runs on is bound per
+// transaction, so the same query outside one matches nothing at all — and a
+// count of zero read that way would look exactly like a write that never
+// happened.
+func auditedRow(t *testing.T, e *extRuntimeEnv, entityID ids.UUID) (auditID ids.UUID, action, actorID string, evidence []byte) {
+	t.Helper()
+	ctx := e.callCtx(e.WS)
+	if err := database.WithWorkspaceTx(ctx, e.Pool, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx,
+			`SELECT id, action, actor_id, evidence FROM audit_log WHERE entity_type = $1 AND entity_id = $2`,
+			ledgerEntity, entityID).Scan(&auditID, &action, &actorID, &evidence)
+	}); err != nil {
+		t.Fatalf("reading the ledger row for %s/%s: %v", ledgerEntity, entityID, err)
+	}
+	return auditID, action, actorID, evidence
+}
+
+// TestAUnitsOwnWriteLandsAsARowALedgerRowAndAnEvent: the write shape, for a
+// table the core has never heard of. The unit describes its own change; the
+// core supplies the actor, the workspace, the attribution and the trace.
+func TestAUnitsOwnWriteLandsAsARowALedgerRowAndAnEvent(t *testing.T) {
+	e := setupExtRuntime(t)
+	rt, ctx := e.runtime("alpha")
+	rowID := ids.NewV7()
+
+	if err := rt.Tx(ctx, func(ctx context.Context, tx extension.Tx) error {
+		if _, err := tx.Exec(ctx, `UPDATE workspace SET slug = $1 WHERE id = $2`, "ledger-probe", e.WS); err != nil {
+			return err
+		}
+		return tx.Record(ctx,
+			extension.Change{
+				Action: extension.AuditCreate,
+				Entity: ledgerEntity,
+				ID:     rowID.String(),
+				After:  json.RawMessage(`{"body":"the row the unit wrote"}`),
+				Detail: json.RawMessage(`{"cause":"a probe"}`),
+			},
+			extension.Event{Verb: "thing_added", Payload: json.RawMessage(`{"kind":"thing"}`)})
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	auditID, action, actorID, evidence := auditedRow(t, e, rowID)
+	if action != string(extension.AuditCreate) {
+		t.Errorf("the ledger row records %q, want %q", action, extension.AuditCreate)
+	}
+	// The actor is the INVOCATION's, never the unit: who acted and what carried
+	// the action are different answers, and this is the first one.
+	if actorID != "system:extruntime-test" {
+		t.Errorf("actor_id = %q, want the invocation's own principal", actorID)
+	}
+	assertAttribution(t, evidence)
+
+	envelope := publishedEnvelope(t, e, "ext_alpha.thing_added")
+	if envelope.Version != events.ExtensionEventVersion {
+		t.Errorf("the envelope claims version %d, want %d", envelope.Version, events.ExtensionEventVersion)
+	}
+	if envelope.Entity.Type != ledgerEntity || envelope.Entity.ID != rowID {
+		t.Errorf("the envelope names %s/%s, want the audited row %s/%s",
+			envelope.Entity.Type, envelope.Entity.ID, ledgerEntity, rowID)
+	}
+	// The join a consumer needs: the event and the governance record of the
+	// same write. It is what makes an extension event auditable at all.
+	if envelope.Trace.AuditLogID != auditID {
+		t.Errorf("the envelope's trace names ledger row %s, want the one this write made (%s)",
+			envelope.Trace.AuditLogID, auditID)
+	}
+	assertSameJSON(t, "the envelope's payload", envelope.Payload, `{"kind":"thing"}`)
+}
+
+// assertAttribution reads the core-stamped members and the unit's own detail
+// out of one evidence document.
+func assertAttribution(t *testing.T, evidence []byte) {
+	t.Helper()
+	var recorded struct {
+		Extension struct {
+			Unit    string          `json:"unit"`
+			Version string          `json:"version"`
+			Via     string          `json:"via"`
+			Detail  json.RawMessage `json:"detail"`
+		} `json:"extension"`
+	}
+	if err := json.Unmarshal(evidence, &recorded); err != nil {
+		t.Fatalf("the ledger row's evidence does not decode: %v (%s)", err, evidence)
+	}
+	if recorded.Extension.Unit != "alpha" || recorded.Extension.Version != "1.0.0" {
+		t.Errorf("evidence.extension names %s/%s, want the invoked unit alpha/1.0.0",
+			recorded.Extension.Unit, recorded.Extension.Version)
+	}
+	if recorded.Extension.Via != "tool/probe" {
+		t.Errorf("evidence.extension.via = %q, want the surface the call arrived on", recorded.Extension.Via)
+	}
+	// Compared as a VALUE, not as bytes. Both columns this rides through are
+	// jsonb, which re-renders what it stores — whitespace and key order are
+	// the database's from here on — so a unit's guarantee is that its document
+	// survives, never that its formatting does.
+	assertSameJSON(t, "evidence.extension.detail", recorded.Extension.Detail, `{"cause":"a probe"}`)
+}
+
+// publishedEnvelope reads back the one outbox row staged for a type, and
+// asserts on its way past that the row was routed to the extension stream.
+func publishedEnvelope(t *testing.T, e *extRuntimeEnv, eventType string) events.Envelope {
+	t.Helper()
+	var stream string
+	var raw []byte
+	ctx := e.callCtx(e.WS)
+	// event_outbox is one of the infra tables outside RLS (0014), so this read
+	// needs no binding of its own — it runs on the same pool as everything
+	// else here for consistency, not for visibility.
+	if err := database.WithWorkspaceTx(ctx, e.Pool, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx,
+			`SELECT stream, envelope FROM event_outbox WHERE envelope->>'type' = $1`, eventType).Scan(&stream, &raw)
+	}); err != nil {
+		t.Fatalf("reading the outbox row for %s: %v", eventType, err)
+	}
+	if stream != events.ExtensionStream() {
+		t.Errorf("%s was staged on %q, want the extension stream", eventType, stream)
+	}
+	var envelope events.Envelope
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		t.Fatalf("the staged envelope does not decode: %v", err)
+	}
+	return envelope
+}
+
+// assertSameJSON compares two JSON documents as values.
+//
+// Everything a unit publishes lands in a jsonb column, which normalizes what it
+// stores: whitespace goes, key order becomes the database's, duplicate members
+// collapse. So the honest assertion — and the honest promise to a unit — is
+// about the document, not its bytes.
+func assertSameJSON(t *testing.T, what string, got json.RawMessage, want string) {
+	t.Helper()
+	var gotValue, wantValue any
+	if err := json.Unmarshal(got, &gotValue); err != nil {
+		t.Fatalf("%s does not decode: %v (%s)", what, err, got)
+	}
+	if err := json.Unmarshal([]byte(want), &wantValue); err != nil {
+		t.Fatalf("the expectation for %s does not decode: %v", what, err)
+	}
+	if !reflect.DeepEqual(gotValue, wantValue) {
+		t.Errorf("%s = %s, want %s", what, got, want)
+	}
+}
+
+// TestAFailedUnitWriteTakesItsLedgerRowAndItsEventWithIt: the ledger runs on
+// the CALLER's transaction, so a handler that changes its mind afterwards
+// leaves no history of a write that never happened. The rows are counted with
+// the transaction already rolled back, which is the state a later reader meets.
+func TestAFailedUnitWriteTakesItsLedgerRowAndItsEventWithIt(t *testing.T) {
+	e := setupExtRuntime(t)
+	rt, ctx := e.runtime("alpha")
+	rowID := ids.NewV7()
+	abandoned := errors.New("the handler changed its mind")
+
+	if err := rt.Tx(ctx, func(ctx context.Context, tx extension.Tx) error {
+		if err := tx.Record(ctx,
+			extension.Change{
+				Action: extension.AuditCreate, Entity: ledgerEntity, ID: rowID.String(),
+				After: json.RawMessage(`{"body":"never committed"}`),
+			},
+			extension.Event{Verb: "thing_added"}); err != nil {
+			return err
+		}
+		return abandoned
+	}); !errors.Is(err, abandoned) {
+		t.Fatalf("Tx returned %v, want the callback's own error", err)
+	}
+
+	var audits, staged int
+	countCtx := e.callCtx(e.WS)
+	if err := database.WithWorkspaceTx(countCtx, e.Pool, func(tx pgx.Tx) error {
+		return tx.QueryRow(countCtx,
+			`SELECT (SELECT count(*) FROM audit_log WHERE entity_id = $1),
+			        (SELECT count(*) FROM event_outbox WHERE envelope->'entity'->>'id' = $1::text)`,
+			rowID).Scan(&audits, &staged)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if audits != 0 || staged != 0 {
+		t.Errorf("a rolled-back write left %d ledger rows and %d staged events, want none", audits, staged)
+	}
+}
+
+// TestADeliveryMayRecordItsOwnWriteAndMayNotWriteACoreRecord is the unattended
+// pair, asserted together because they are one decision.
+//
+// A bus delivery runs as the system principal, which auth.Require does not
+// check at all — so the port's refusal is the whole distance between an event
+// arriving and an unchecked core write. And the LEDGER stays open, because
+// recording what the unit did to its own rows needs no authority over anything
+// else: a reaction nobody can audit would be the worse half of the trade.
+func TestADeliveryMayRecordItsOwnWriteAndMayNotWriteACoreRecord(t *testing.T) {
+	e := setupExtRuntime(t)
+	ctx := e.callCtx(e.WS)
+	rt := deliveryRuntimeFor(ctx, "alpha", "1.0.0", "subscription/probe",
+		extensionRuntimeBinding{pool: e.Pool, vault: e.vault})
+	rowID := ids.NewV7()
+
+	if err := rt.Tx(ctx, func(ctx context.Context, tx extension.Tx) error {
+		_, coreErr := tx.Core().Activities().Create(ctx, crm.CreateActivityRequest{
+			Kind: crm.CreateActivityRequestKindNote, Source: "extension:probe",
+		})
+		if !errors.Is(coreErr, extension.ErrForbidden) {
+			t.Errorf("a delivery's core write answered %v, want ErrForbidden", coreErr)
+		}
+		return tx.Record(ctx,
+			extension.Change{
+				Action: extension.AuditUpdate, Entity: ledgerEntity, ID: rowID.String(),
+				After: json.RawMessage(`{"filed_activity_id":null}`),
+			},
+			extension.Event{Verb: "thing_changed"})
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, action, _, evidence := auditedRow(t, e, rowID); action != string(extension.AuditUpdate) {
+		t.Errorf("the delivery's ledger row records %q, want an update", action)
+	} else if !json.Valid(evidence) {
+		t.Errorf("the delivery's ledger row carries no readable evidence: %s", evidence)
+	}
+	// And the attribution says which listener carried it, not merely which
+	// unit: an audit reader asking "what did this" gets the subscription.
+	_, _, _, evidence := auditedRow(t, e, rowID)
+	var recorded struct {
+		Extension struct {
+			Via string `json:"via"`
+		} `json:"extension"`
+	}
+	if err := json.Unmarshal(evidence, &recorded); err != nil {
+		t.Fatal(err)
+	}
+	if recorded.Extension.Via != "subscription/probe" {
+		t.Errorf("evidence.extension.via = %q, want the subscription that ran", recorded.Extension.Via)
+	}
+}

--- a/backend/internal/compose/extledger_test.go
+++ b/backend/internal/compose/extledger_test.go
@@ -1,0 +1,263 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// What the ledger port refuses before any SQL runs, and what a unit cannot say
+// at all. Every case here holds with NO database: a write reaching a pool to be
+// told no would mean the check ran too late.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/provenance"
+	"github.com/gradionhq/margince/backend/pkg/extension"
+)
+
+// ledgerRowID is a canonical UUID, which is what the entity_id column takes.
+const ledgerRowID = "018f3a2b-6c7d-7e8f-9a0b-1c2d3e4f5061"
+
+// notesLedger is the port as the notes unit holds it, over a transaction that
+// PANICS if anything is executed on it.
+//
+// That is the assertion, not the scaffolding. Every refusal below has to happen
+// before a statement runs — a write reaching the database to be told no would
+// mean the check ran too late — and a test that only asked "was there an error"
+// would pass just as happily on a refusal the DATABASE made, or on one a nil
+// handle produced. Under this transaction, a check that stopped refusing shows
+// up as a panic naming the statement it let through.
+func notesLedger() extensionLedger {
+	return extensionLedger{
+		tx:        refusingTx{},
+		namespace: "ext_notes",
+		// The Runtime's own scoped, standing in — and it binds the actor and the
+		// correlation as well as the attribution ON PURPOSE. storekit refuses a
+		// write carrying neither, so a stub that bound only the attribution
+		// would stop every case below on the plumbing rather than on the
+		// refusal it is named for, and the panicking transaction would never be
+		// reached to prove anything at all.
+		authority: func(ctx context.Context) (context.Context, error) {
+			ctx = principal.WithActor(ctx, principal.Principal{
+				Type: principal.PrincipalHuman, ID: "human:the-caller", UserID: ids.NewV7(),
+			})
+			ctx = principal.WithCorrelationID(ctx, ids.NewV7())
+			return provenance.WithExtension(ctx, provenance.Extension{
+				Unit: "notes", Version: "1.0.0", Via: "tool/add_note",
+			}), nil
+		},
+	}
+}
+
+// refusingTx is a pgx.Tx no statement may reach. Every method panics: the port
+// is supposed to refuse before any of them, so reaching one is the defect these
+// tests exist to catch rather than a path worth stubbing.
+type refusingTx struct{}
+
+func (refusingTx) Exec(context.Context, string, ...any) (pgconn.CommandTag, error) {
+	panic("extledger_test: a refusal let a statement through to the database")
+}
+
+func (refusingTx) Query(context.Context, string, ...any) (pgx.Rows, error) {
+	panic("extledger_test: a refusal let a query through to the database")
+}
+
+func (refusingTx) QueryRow(context.Context, string, ...any) pgx.Row {
+	panic("extledger_test: a refusal let a query through to the database")
+}
+func (refusingTx) Begin(context.Context) (pgx.Tx, error) { panic("refusingTx: Begin") }
+func (refusingTx) Commit(context.Context) error          { panic("refusingTx: Commit") }
+func (refusingTx) Rollback(context.Context) error        { panic("refusingTx: Rollback") }
+
+func (refusingTx) CopyFrom(context.Context, pgx.Identifier, []string, pgx.CopyFromSource) (int64, error) {
+	panic("refusingTx: CopyFrom")
+}
+
+func (refusingTx) SendBatch(context.Context, *pgx.Batch) pgx.BatchResults {
+	panic("refusingTx: SendBatch")
+}
+func (refusingTx) LargeObjects() pgx.LargeObjects { panic("refusingTx: LargeObjects") }
+
+func (refusingTx) Prepare(context.Context, string, string) (*pgconn.StatementDescription, error) {
+	panic("refusingTx: Prepare")
+}
+func (refusingTx) Conn() *pgx.Conn { panic("refusingTx: Conn") }
+
+var _ pgx.Tx = refusingTx{}
+
+// A unit audits its own rows. The refusal is the point of the namespace being
+// derived from the INVOCATION: a ledger row against a core record would be a
+// line in that record's history describing a write the core never made, and one
+// against a sibling unit's table would be the same forgery a directory away.
+func TestTheLedgerRefusesATableTheUnitDoesNotOwn(t *testing.T) {
+	ledger := notesLedger()
+	for name, entity := range map[string]string{
+		"a core record":            "person",
+		"the audit log itself":     "audit_log",
+		"another unit's table":     "ext_de_retention",
+		"a near-miss on the name":  "ext_notes2_note",
+		"the namespace with no _":  "ext_notes",
+		"a schema-qualified table": "ext.ext_notes_note",
+	} {
+		err := ledger.Record(context.Background(),
+			extension.Change{Action: extension.AuditCreate, Entity: entity, ID: ledgerRowID},
+			extension.Event{Verb: "thing_added"})
+		if err == nil {
+			t.Errorf("the ledger accepted %s (%q)", name, entity)
+		}
+	}
+}
+
+// The published rules are enforced at the port too, so a unit that skipped
+// Change.Validate cannot reach the audit statement with a value the column
+// would refuse — where the report is a SQLSTATE.
+func TestTheLedgerRefusesAChangeTheColumnsCannotHold(t *testing.T) {
+	ledger := notesLedger()
+	for name, ch := range map[string]extension.Change{
+		"an action outside the ledger's vocabulary": {
+			Action: "merge", Entity: "ext_notes_note", ID: ledgerRowID,
+		},
+		"an id that is not a UUID": {
+			Action: extension.AuditCreate, Entity: "ext_notes_note", ID: "note-7",
+		},
+		"an image that is not JSON": {
+			Action: extension.AuditCreate, Entity: "ext_notes_note", ID: ledgerRowID,
+			After: json.RawMessage("{"),
+		},
+	} {
+		if err := ledger.Record(context.Background(), ch, extension.Event{Verb: "thing_added"}); err == nil {
+			t.Errorf("the ledger accepted %s", name)
+		}
+	}
+}
+
+// A port built without the invocation's authority writes nothing. It is a
+// wiring fault rather than anything a unit did, and it must fail loudly: a
+// ledger row with no bound actor would be attributed to nobody.
+func TestTheLedgerRefusesAWriteItCannotAttribute(t *testing.T) {
+	unbound := extensionLedger{tx: refusingTx{}, namespace: "ext_notes"}
+	err := unbound.Record(context.Background(),
+		extension.Change{Action: extension.AuditCreate, Entity: "ext_notes_note", ID: ledgerRowID},
+		extension.Event{Verb: "thing_added"})
+	if err == nil || !strings.Contains(err.Error(), "authority") {
+		t.Fatalf("err = %v, want the missing-authority refusal", err)
+	}
+}
+
+// The detail a unit supplies rides INSIDE the core's attribution entry, and
+// nowhere else. The core's own members are beside it and are not the unit's to
+// write — storekit refuses a caller-supplied `extension` member outright, so
+// this is how a unit says anything at all about its own write.
+func TestAUnitsDetailRidesInsideTheAttributionEntry(t *testing.T) {
+	detail := json.RawMessage(`{"cause":"activity.archived"}`)
+	ctx, err := withChangeDetail(provenance.WithExtension(context.Background(), provenance.Extension{
+		Unit: "notes", Version: "1.0.0", Via: "subscription/withdraw_filing",
+	}), detail)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bound, ok := provenance.ExtensionFrom(ctx)
+	if !ok {
+		t.Fatal("the attribution did not survive the detail binding")
+	}
+	entry := bound.EvidenceEntry()
+	for member, want := range map[string]string{
+		"unit": "notes", "version": "1.0.0", "via": "subscription/withdraw_filing",
+	} {
+		if got, _ := entry[member].(string); got != want {
+			t.Errorf("evidence.extension.%s = %v, want %q — the core's members must survive a unit's detail", member, entry[member], want)
+		}
+	}
+	got, isRaw := entry["detail"].(json.RawMessage)
+	if !isRaw || string(got) != string(detail) {
+		t.Errorf("evidence.extension.detail = %v, want %s", entry["detail"], detail)
+	}
+
+	// No detail leaves the member OUT: `"detail": null` would be a unit saying
+	// something where it said nothing.
+	if entry := (provenance.Extension{Unit: "notes"}).EvidenceEntry(); entry["detail"] != nil {
+		t.Errorf("an empty detail rendered as %v, want the member absent", entry["detail"])
+	}
+}
+
+// A unit that has no attribution bound cannot supply detail either: the entry
+// it would hang off does not exist, and writing free-form content into a
+// core-owned evidence member with nothing naming its author is worse than
+// refusing.
+func TestDetailWithNoAttributionIsRefused(t *testing.T) {
+	if _, err := withChangeDetail(context.Background(), json.RawMessage(`{"a":1}`)); err == nil {
+		t.Fatal("detail was accepted with no attribution bound")
+	}
+	// With no detail there is nothing to hang, so an unattributed context is
+	// simply passed through — the ordinary core write, which stamps nothing.
+	if _, err := withChangeDetail(context.Background(), nil); err != nil {
+		t.Fatalf("a write with no detail was refused: %v", err)
+	}
+}
+
+// A published event's TYPE is the namespace the core derived plus the verb the
+// unit chose. The half a unit spells is the verb, so publishing under another
+// unit's name is not refused — it is unsayable, and the grammar is what makes
+// it so. The derivation itself is asserted over a real transaction in the
+// database lane, where the type reaches the outbox.
+func TestAVerbCannotSmuggleANamespace(t *testing.T) {
+	for _, verb := range []string{"ext_de.note_added", "person.created", "Note_Added", ""} {
+		if err := (extension.Event{Verb: verb}).Validate(); err == nil {
+			t.Errorf("the event grammar accepted %q as a verb", verb)
+		}
+	}
+}
+
+// An event the bus could not carry refuses the WHOLE call, before the ledger
+// row is written: the two halves are one write, so a malformed event must not
+// leave a history behind claiming something was announced.
+func TestAnEventTheBusRefusesWritesNoLedgerRow(t *testing.T) {
+	err := notesLedger().Record(context.Background(),
+		extension.Change{Action: extension.AuditCreate, Entity: "ext_notes_note", ID: ledgerRowID},
+		extension.Event{Verb: "Note Added"})
+	if err == nil {
+		t.Fatal("the port accepted an event the bus grammar refuses")
+	}
+}
+
+// imageOrNil decides between bytes and SQL NULL, and the distinction is not
+// cosmetic: a nil json.RawMessage inside an `any` marshals to the four bytes
+// `null`, which lands as jsonb null — a VALUE. "There was no such state" and
+// "the state was null" read differently in every query that asks.
+func TestAnAbsentImageIsNullAndNotTheBytesNull(t *testing.T) {
+	if got := imageOrNil(nil); got != nil {
+		t.Errorf("imageOrNil(nil) = %v, want a nil bind parameter", got)
+	}
+	if got := imageOrNil(json.RawMessage{}); got != nil {
+		t.Errorf("imageOrNil(empty) = %v, want a nil bind parameter", got)
+	}
+	raw := json.RawMessage(`{"body":"hello"}`)
+	got, ok := imageOrNil(raw).(json.RawMessage)
+	if !ok || string(got) != string(raw) {
+		t.Errorf("imageOrNil(%s) = %v, want the bytes through unchanged", raw, got)
+	}
+}
+
+// A failed ledger write tells a unit that the write failed and nothing about
+// how: the text of one is a relation, a constraint and a SQL state, written for
+// the people who operate the installation.
+func TestALedgerFailureLeaksNoCoreDetail(t *testing.T) {
+	internal := errors.New(`insert into "audit_log" violates constraint audit_log_action_check`)
+	got := ledgerFailure(context.Background(), "probing", internal)
+	if got == nil {
+		t.Fatal("a failed ledger write was mapped to success")
+	}
+	for _, leaked := range []string{"audit_log", "constraint"} {
+		if strings.Contains(got.Error(), leaked) {
+			t.Errorf("the core's own error text reached the unit: %v", got)
+		}
+	}
+}

--- a/backend/internal/compose/extrbac_test.go
+++ b/backend/internal/compose/extrbac_test.go
@@ -72,14 +72,62 @@ func TestTwoUnitsDerivingOneRbacObjectAreRefusedByName(t *testing.T) {
 			t.Errorf("the refusal does not name %s: %v", want, err)
 		}
 	}
-	// And it reaches the boot rather than being a local nicety.
+	// And the boot refuses the pair — EARLIER than this check, and for the
+	// reason underneath it. The two unit names that can derive one object name
+	// are exactly the two whose namespaces open one another (`ext_crm`,
+	// `ext_crm_demo`), and reserveNamespace turns that pair away before any
+	// capability is read: the ambiguity was never confined to RBAC objects — an
+	// identifier like ext_crm_demo_widget names a table, a ledger subject and an
+	// event subject either unit could own. The check above remains the one that
+	// catches two units declaring one object they did not both DERIVE.
 	t.Cleanup(identity.ResetRbacObjectsForTest)
 	t.Cleanup(func() { setComposedTools(nil); setComposedVerbs(nil) })
 	bootErr := RegisterExtensions([]extension.Extension{
 		{Name: "crm", Version: "0.1.0"}, {Name: "crm-demo", Version: "0.1.0"},
 	}, []extension.Verb{crm, crmDemo}, nil)
-	if bootErr == nil || !strings.Contains(bootErr.Error(), "both derive RBAC object") {
-		t.Fatalf("boot err = %v, want the derived-name collision", bootErr)
+	if bootErr == nil || !strings.Contains(bootErr.Error(), "one opens the other") {
+		t.Fatalf("boot err = %v, want the overlapping-namespace refusal", bootErr)
+	}
+	for _, want := range []string{`"crm"`, `"crm-demo"`} {
+		if !strings.Contains(bootErr.Error(), want) {
+			t.Errorf("the boot refusal does not name %s: %v", want, bootErr)
+		}
+	}
+}
+
+// TestOverlappingUnitNamespacesAreRefused: two units whose namespaces open one
+// another cannot both compose, whatever they declare.
+//
+// It is the hazard the generator's derived-identifier check already names —
+// "unit a-b table c and unit a table b_c both derive ext_a_b_c" — seen from the
+// other end. That one refuses the two units DECLARING one table; this refuses
+// the pair existing at all, because a unit NAMING the ambiguous identifier at
+// run time (a ledger row's subject, an event's subject) has no honest owner and
+// nothing downstream holds the split.
+func TestOverlappingUnitNamespacesAreRefused(t *testing.T) {
+	t.Cleanup(func() { setComposedExtensions(nil); setComposedSubscriptions(nil) })
+	for name, set := range map[string][]extension.Extension{
+		"a hyphen that becomes an underscore": {
+			{Name: "crm", Version: "0.1.0"}, {Name: "crm-demo", Version: "0.1.0"},
+		},
+		// Declaration order must not decide it: the longer name first is the
+		// same clash read the other way round.
+		"the longer name first": {
+			{Name: "crm-demo", Version: "0.1.0"}, {Name: "crm", Version: "0.1.0"},
+		},
+	} {
+		if err := RegisterExtensions(set, nil, nil); err == nil {
+			t.Errorf("%s: the boot composed two units whose namespaces overlap", name)
+		}
+	}
+
+	// Names that merely SHARE A PREFIX compose fine — `ext_crmdemo_x` can never
+	// be read as a table of `ext_crm`, because every derivation joins with an
+	// underscore. A refusal here would be this check overreaching.
+	if err := RegisterExtensions([]extension.Extension{
+		{Name: "crm", Version: "0.1.0"}, {Name: "crmdemo", Version: "0.1.0"},
+	}, nil, nil); err != nil {
+		t.Errorf("two units with distinct namespaces were refused: %v", err)
 	}
 }
 

--- a/backend/internal/compose/extruntime.go
+++ b/backend/internal/compose/extruntime.go
@@ -15,6 +15,7 @@ package compose
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"sync"
 
@@ -128,10 +129,12 @@ type callRuntime struct {
 	// are the published Runtime's and cannot grow a parameter for it.
 	callCtx context.Context //nolint:containedctx // the invocation's tenant scope IS this value's lifetime; see above.
 
-	// systemCaller forces Caller to answer the zero value whatever principal
-	// callCtx carries. Exactly one path sets it — a job tick — and the reason
-	// is in jobRuntimeFor.
-	systemCaller bool
+	// unattended forces Caller to answer the zero value whatever principal
+	// callCtx carries, and refuses the core port. Two paths set it — a job tick
+	// (jobRuntimeFor) and a bus delivery (deliveryRuntimeFor) — and they share
+	// the one fact that decides both: nobody is there, so there is no authority
+	// a core write could be checked against.
+	unattended bool
 
 	// mu orders live: it is read and written under the same lock, so release
 	// and a handler-spawned goroutine cannot race the FLAG. It does not order
@@ -170,7 +173,22 @@ func runtimeFor(ctx context.Context, unit, version, via string, deps extensionRu
 // one every capability and every policy sees.
 func jobRuntimeFor(ctx context.Context, unit, version, via string, deps extensionRuntimeBinding) *callRuntime {
 	rt := runtimeFor(ctx, unit, version, via, deps)
-	rt.systemCaller = true
+	rt.unattended = true
+	return rt
+}
+
+// deliveryRuntimeFor mints the Runtime for one BUS DELIVERY — a subscription
+// hearing that something happened.
+//
+// It is unattended for a plainer reason than a tick's: a tick at least ran
+// because a schedule the installation configured said so, while a delivery ran
+// because a fact arrived. Neither has a person behind it, and this one's
+// principal is the system actor the subscriber binds (see
+// extsubscribe.go), which auth.Require does not check at all — so the
+// unattended flag is what keeps the core port shut rather than wide open.
+func deliveryRuntimeFor(ctx context.Context, unit, version, via string, deps extensionRuntimeBinding) *callRuntime {
+	rt := runtimeFor(ctx, unit, version, via, deps)
+	rt.unattended = true
 	return rt
 }
 
@@ -290,6 +308,14 @@ func (r *callRuntime) Tx(ctx context.Context, fn func(ctx context.Context, tx ex
 	if err != nil {
 		return err
 	}
+	// Derived BEFORE the transaction opens. The unit name was validated at
+	// registration, so an invalid one here is a composition that should never
+	// have booted — and learning that inside a transaction would only make the
+	// report harder to read than it needs to be.
+	namespace, err := extension.Name(r.unit).Namespace()
+	if err != nil {
+		return fmt.Errorf("compose: the invoking unit's name has no SQL namespace: %w", err)
+	}
 	return database.WithWorkspaceTx(ctx, r.deps.pool, func(tx pgx.Tx) error {
 		// Re-checked inside: opening a transaction is a round trip, and a
 		// Runtime released during it must not reach the callback with a live
@@ -297,9 +323,13 @@ func (r *callRuntime) Tx(ctx context.Context, fn func(ctx context.Context, tx ex
 		if err := r.usable(); err != nil {
 			return err
 		}
-		return fn(ctx, extensionTx{tx: tx, core: extensionCore{
-			tx: tx, tick: r.systemCaller, deps: r.deps, authority: r.scoped,
-		}})
+		return fn(ctx, extensionTx{
+			tx: tx,
+			core: extensionCore{
+				tx: tx, unattended: r.unattended, deps: r.deps, authority: r.scoped,
+			},
+			ledger: extensionLedger{tx: tx, namespace: namespace, authority: r.scoped},
+		})
 	})
 }
 
@@ -322,7 +352,7 @@ func (r *callRuntime) Tx(ctx context.Context, fn func(ctx context.Context, tx ex
 // holds.
 func (r *callRuntime) Caller() extension.Caller {
 	actor, ok := principal.Actor(r.callCtx)
-	if !ok || r.systemCaller {
+	if !ok || r.unattended {
 		// No principal is the unauthenticated or unbound path, and the zero
 		// Caller is CallerSystem — the least authority, so a wiring gap reads
 		// as "nobody" rather than as a human whose id happens to be empty.

--- a/backend/internal/compose/extruntime.go
+++ b/backend/internal/compose/extruntime.go
@@ -172,9 +172,7 @@ func runtimeFor(ctx context.Context, unit, version, via string, deps extensionRu
 // call. Nothing else about the tick changes: the actor on callCtx is still the
 // one every capability and every policy sees.
 func jobRuntimeFor(ctx context.Context, unit, version, via string, deps extensionRuntimeBinding) *callRuntime {
-	rt := runtimeFor(ctx, unit, version, via, deps)
-	rt.unattended = true
-	return rt
+	return unattendedRuntimeFor(ctx, unit, version, via, deps)
 }
 
 // deliveryRuntimeFor mints the Runtime for one BUS DELIVERY — a subscription
@@ -183,10 +181,20 @@ func jobRuntimeFor(ctx context.Context, unit, version, via string, deps extensio
 // It is unattended for a plainer reason than a tick's: a tick at least ran
 // because a schedule the installation configured said so, while a delivery ran
 // because a fact arrived. Neither has a person behind it, and this one's
-// principal is the system actor the subscriber binds (see
-// extsubscribe.go), which auth.Require does not check at all — so the
-// unattended flag is what keeps the core port shut rather than wide open.
+// principal is the system actor the subscriber binds (see extsubscribe.go),
+// which auth.Require does not check at all — so the unattended flag is what
+// keeps the governed core port shut for a caller nothing else would refuse.
 func deliveryRuntimeFor(ctx context.Context, unit, version, via string, deps extensionRuntimeBinding) *callRuntime {
+	return unattendedRuntimeFor(ctx, unit, version, via, deps)
+}
+
+// unattendedRuntimeFor is what both of the above are: a Runtime for an
+// invocation with nobody behind it. They stay separate NAMES because the two
+// call sites are the two kinds of unattended work and a reader at either one
+// should see which it is — but the behaviour is one fact, spelled here, so a
+// later change to what "unattended" means cannot reach one kind and miss the
+// other.
+func unattendedRuntimeFor(ctx context.Context, unit, version, via string, deps extensionRuntimeBinding) *callRuntime {
 	rt := runtimeFor(ctx, unit, version, via, deps)
 	rt.unattended = true
 	return rt
@@ -272,6 +280,17 @@ func (r *callRuntime) scoped(ctx context.Context) (context.Context, error) {
 	}
 	if correlation, bound := principal.CorrelationID(r.callCtx); bound {
 		ctx = principal.WithCorrelationID(ctx, correlation)
+	}
+	// The CAUSATION travels the same way, and it matters most where the
+	// invocation is a reaction: a bus delivery binds the event that triggered
+	// it, so what the unit publishes chains back to what caused it. Left to the
+	// handler's context it would be right only while the handler passed the
+	// context it was given — and wrong in the two ways a handler gets it wrong,
+	// each silently: a context built fresh publishes a reaction with no cause,
+	// and one retained from an earlier delivery publishes this reaction as
+	// caused by that earlier event.
+	if causation, bound := principal.CausationEvent(r.callCtx); bound {
+		ctx = principal.WithCausationEvent(ctx, causation)
 	}
 	// And WHAT carried the action, which is a second dimension beside who took
 	// it: every core write made under this context records the unit, its

--- a/backend/internal/compose/extsubscribe.go
+++ b/backend/internal/compose/extsubscribe.go
@@ -15,6 +15,7 @@ package compose
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"slices"
 
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -89,16 +90,42 @@ func (c ComposedSubscription) Group() (kevents.Group, error) {
 // system principal — the same one every core bus consumer writes under — and
 // the Runtime is minted unattended, which shuts the core port. Those two facts
 // belong together: PrincipalSystem is a principal auth.Require does not check,
-// so the port's refusal is the whole distance between a bus event and an
-// unchecked core write. The unit's own tables stay writable, auditable and
-// publishable, which is what reacting to a fact consists of.
+// so without the port's refusal the governed door would stand open to a caller
+// nothing checks. It is not a containment claim about core TABLES — Tx's three
+// SQL verbs run on the shared application role here as everywhere else, which
+// runtime.go states in the open and issue #628 tracks. The unit's own tables
+// stay writable, auditable and publishable, which is what reacting to a fact
+// consists of.
 //
 // The correlation id CARRIES THROUGH from the triggering event and the event
 // itself becomes the causation, so a fact, the reaction to it, and whatever the
 // reaction publishes read as one story rather than three unrelated ones.
-func (c ComposedSubscription) Handler(pool *pgxpool.Pool) func(context.Context, kevents.Envelope) error {
+func (c ComposedSubscription) Handler(pool *pgxpool.Pool, log *slog.Logger) func(context.Context, kevents.Envelope) error {
 	db := InstallationDB(pool)
-	return func(ctx context.Context, env kevents.Envelope) error {
+	return func(ctx context.Context, env kevents.Envelope) (err error) {
+		// Installed FIRST, so it covers the whole delivery rather than the
+		// handler alone: a panic anywhere under this frame — the unit's code,
+		// or the core's own on its behalf — becomes a failed delivery. There is
+		// nothing above it but the subscriber's goroutine, so an unrecovered
+		// one takes the entire worker down: the relay, the job runner, every
+		// other unit's lane. The entry is then un-acked, so the restarted
+		// worker is handed the same event and dies again — one bad delivery
+		// would be an installation-wide crash loop. The job seam recovers its
+		// tick for a weaker version of the same reason (extjobsrun.go).
+		//
+		// It becomes an error rather than an ack, deliberately: the entry stays
+		// pending and re-delivers, which is right for a panic a retry can clear
+		// and merely repetitive for one it cannot. Acking would silently drop a
+		// fact somebody's unit was written to react to. The log names the unit
+		// and the subscription, which the bus entry cannot.
+		defer func() {
+			if r := recover(); r != nil {
+				log.Error("extension subscription delivery panicked",
+					"unit", string(c.Unit), "subscription", c.Sub.Name,
+					"event", env.EventID.String(), "type", env.Type, "panic", r)
+				err = fmt.Errorf("compose: extension %q subscription %q panicked: %v", c.Unit, c.Sub.Name, r)
+			}
+		}()
 		if !slices.Contains(c.Sub.Events, env.Type) {
 			// The group's streams carry more than this listener asked for —
 			// one activity event means the whole activity stream — so the

--- a/backend/internal/compose/extsubscribe.go
+++ b/backend/internal/compose/extsubscribe.go
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The core's half of extension.Subscription: which consumer group one unit's
+// listener gets, and what happens when an event lands on it.
+//
+// The consuming machinery is the product's own — a consumer group per listener,
+// XREADGROUP, the reclaim pass, Dedupe around the handler — so nothing here
+// re-implements delivery. What this file owns is the translation: an envelope
+// becomes a published Delivery, and the context it runs on is bound to an
+// invocation that has nobody behind it.
+
+import (
+	"context"
+	"fmt"
+	"slices"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	kevents "github.com/gradionhq/margince/backend/internal/shared/kernel/events"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+	"github.com/gradionhq/margince/backend/pkg/extension"
+)
+
+// systemActor is the actor id a bus delivery runs under — the same spelling
+// every other system-driven pass in this layer writes, because the audit rows
+// they produce are read together.
+const systemActor = "system"
+
+// ComposedSubscription is one registered listener: the declaration, plus the
+// identity of the unit that declared it.
+//
+// The unit's name and version travel WITH the subscription because a delivery
+// is attributed like every other extension-carried write — the ledger row a
+// handler writes names the unit, its version, and the surface the work arrived
+// on, which for a delivery is this subscription. The declaration alone cannot
+// say any of that.
+type ComposedSubscription struct {
+	Unit    extension.Name
+	Version extension.Version
+	Sub     extension.Subscription
+}
+
+// GroupName is the consumer group this listener consumes on:
+// `cg:ext-<unit>-<subscription>`.
+//
+// One group per SUBSCRIPTION rather than per unit, which is the line the core's
+// own groups already draw (cg:graph-edge exists apart from cg:context-graph for
+// exactly this reason): consumers on one group share a pending entry, so a
+// handler that keeps failing would hold up a sibling that has nothing to do
+// with it.
+//
+// It is derived from names that never change under a unit — renaming a
+// subscription starts a fresh group, which re-reads the stream's retained
+// history from the beginning, and Subscription.Name says so.
+func (c ComposedSubscription) GroupName() string {
+	return "cg:ext-" + string(c.Unit) + "-" + c.Sub.Name
+}
+
+// Group is the consumer group to run this listener on: its name, and the
+// distinct streams its declared event types route to.
+//
+// Deriving the streams from the TYPES is what keeps a unit off streams it did
+// not ask for. A listener that names one activity event consumes the activity
+// stream and nothing else, so the events it never asked about are not even
+// read, let alone filtered in process.
+func (c ComposedSubscription) Group() (kevents.Group, error) {
+	streams := make([]string, 0, len(c.Sub.Events))
+	for _, eventType := range c.Sub.Events {
+		stream, err := kevents.StreamFor(eventType)
+		if err != nil {
+			return kevents.Group{}, fmt.Errorf("compose: extension %q, subscription %q: %w", c.Unit, c.Sub.Name, err)
+		}
+		if !slices.Contains(streams, stream) {
+			streams = append(streams, stream)
+		}
+	}
+	slices.Sort(streams)
+	return kevents.Group{Name: c.GroupName(), Streams: streams}, nil
+}
+
+// Handler is the bus consumer for this listener: it filters to the declared
+// types, binds the delivery's authority, and runs the unit's handler under a
+// Runtime that lives exactly as long as the delivery.
+//
+// WHAT A DELIVERY RUNS AS. There is nobody behind it, so the actor is the
+// system principal — the same one every core bus consumer writes under — and
+// the Runtime is minted unattended, which shuts the core port. Those two facts
+// belong together: PrincipalSystem is a principal auth.Require does not check,
+// so the port's refusal is the whole distance between a bus event and an
+// unchecked core write. The unit's own tables stay writable, auditable and
+// publishable, which is what reacting to a fact consists of.
+//
+// The correlation id CARRIES THROUGH from the triggering event and the event
+// itself becomes the causation, so a fact, the reaction to it, and whatever the
+// reaction publishes read as one story rather than three unrelated ones.
+func (c ComposedSubscription) Handler(pool *pgxpool.Pool) func(context.Context, kevents.Envelope) error {
+	db := InstallationDB(pool)
+	return func(ctx context.Context, env kevents.Envelope) error {
+		if !slices.Contains(c.Sub.Events, env.Type) {
+			// The group's streams carry more than this listener asked for —
+			// one activity event means the whole activity stream — so the
+			// filter is ordinary, not a defence. Acked, because a delivery
+			// nobody wants is delivered successfully.
+			return nil
+		}
+		// The envelope carries no tenant (ADR-0091 §6); the installation's
+		// handle names it, exactly as every other consumer resolves it.
+		ws, err := db.Workspace(ctx)
+		if err != nil {
+			return err
+		}
+		ctx = principal.WithWorkspaceID(ctx, ws.UUID)
+		ctx = principal.WithActor(ctx, principal.Principal{Type: principal.PrincipalSystem, ID: systemActor})
+		ctx = principal.WithCorrelationID(ctx, env.Trace.CorrelationID)
+		ctx = principal.WithCausationEvent(ctx, env.EventID)
+
+		rt := deliveryRuntimeFor(ctx, string(c.Unit), string(c.Version),
+			"subscription/"+c.Sub.Name, boundExtensionRuntime())
+		defer rt.release()
+		return c.Sub.Handle(ctx, rt, deliveryOf(env))
+	}
+}
+
+// deliveryOf renders an envelope as the published Delivery.
+//
+// Ids become strings because the published surface exports no id type, and the
+// entity ref is passed through as it arrived — including empty, for the core's
+// entity-less pipeline events, which Delivery.Entity says a handler must check
+// for rather than have invented a zero UUID here to hide.
+func deliveryOf(env kevents.Envelope) extension.Delivery {
+	d := extension.Delivery{
+		EventID:    env.EventID.String(),
+		Type:       env.Type,
+		OccurredAt: env.OccurredAt,
+		Payload:    env.Payload,
+	}
+	if env.Entity.Type != "" && !env.Entity.ID.IsZero() {
+		d.Entity = extension.EntityRef{Type: env.Entity.Type, ID: env.Entity.ID.String()}
+	}
+	return d
+}

--- a/backend/internal/compose/extsubscribe_test.go
+++ b/backend/internal/compose/extsubscribe_test.go
@@ -10,6 +10,7 @@ package compose
 import (
 	"context"
 	"encoding/json"
+	"log/slog"
 	"reflect"
 	"strings"
 	"testing"
@@ -35,7 +36,8 @@ func composedSubscription(events ...string) ComposedSubscription {
 // about: an event it does not want is not filtered in process, it is not read.
 func TestAListenersGroupCoversTheStreamsItsTypesRouteTo(t *testing.T) {
 	group, err := composedSubscription(
-		"activity.archived", "activity.captured", "person.archived", "ext_notes.note_added").Group()
+		"activity.archived", "activity.captured", "person.archived", "ext_notes.note_added",
+	).Group()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -121,7 +123,7 @@ func TestADeliveryOfAnUndeclaredTypeIsAckedWithoutRunningTheHandler(t *testing.T
 	}
 	// A nil pool is safe here BECAUSE the filter runs first; if it ever stopped
 	// running first, this test would fail on the tenant read rather than pass.
-	err := sub.Handler(nil)(context.Background(), kevents.Envelope{
+	err := sub.Handler(nil, slog.New(slog.DiscardHandler))(context.Background(), kevents.Envelope{
 		EventID: ids.NewV7(), Type: "activity.captured",
 		Entity: kevents.EntityRef{Type: "activity", ID: ids.NewV7()},
 	})

--- a/backend/internal/compose/extsubscribe_test.go
+++ b/backend/internal/compose/extsubscribe_test.go
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// What a unit's listener consumes, what one delivery carries, and what the boot
+// refuses to register. The write a delivery makes is the database lane's
+// question; these are the ones that must hold with no database at all.
+
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	kevents "github.com/gradionhq/margince/backend/internal/shared/kernel/events"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/pkg/extension"
+)
+
+func composedSubscription(events ...string) ComposedSubscription {
+	return ComposedSubscription{
+		Unit: "notes", Version: "1.0.0",
+		Sub: extension.Subscription{
+			Name: "withdraw_filing", Events: events,
+			Handle: func(context.Context, extension.Runtime, extension.Delivery) error { return nil },
+		},
+	}
+}
+
+// A listener consumes the streams its DECLARED types route to, and no others.
+// Deriving them from the types is what keeps a unit off a stream it never asked
+// about: an event it does not want is not filtered in process, it is not read.
+func TestAListenersGroupCoversTheStreamsItsTypesRouteTo(t *testing.T) {
+	group, err := composedSubscription(
+		"activity.archived", "activity.captured", "person.archived", "ext_notes.note_added").Group()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if group.Name != "cg:ext-notes-withdraw_filing" {
+		t.Errorf("group name = %q, want cg:ext-notes-withdraw_filing", group.Name)
+	}
+	want := []string{"gw:events:crm:activity", "gw:events:crm:extension", "gw:events:crm:person"}
+	if !reflect.DeepEqual(group.Streams, want) {
+		t.Errorf("streams = %v, want %v — deduplicated and sorted", group.Streams, want)
+	}
+}
+
+// One group per SUBSCRIPTION, not per unit: consumers on one group share a
+// pending entry, so a handler that kept failing would hold up a sibling with
+// nothing to do with it.
+func TestTwoListenersOfOneUnitGetDistinctGroups(t *testing.T) {
+	first := composedSubscription("activity.archived")
+	second := composedSubscription("person.archived")
+	second.Sub.Name = "another_listener"
+	if first.GroupName() == second.GroupName() {
+		t.Fatalf("both listeners consume %q", first.GroupName())
+	}
+}
+
+// An unroutable type has no stream, so its listener would be created, hold a
+// cursor and never receive anything — indistinguishable from a product where
+// that fact never happens. The boot says so instead.
+func TestTheBootRefusesASubscriptionNothingCouldDeliver(t *testing.T) {
+	for name, sub := range map[string]extension.Subscription{
+		"a type outside the catalog": {
+			Name: "listens", Events: []string{"invoice.created"},
+			Handle: func(context.Context, extension.Runtime, extension.Delivery) error { return nil },
+		},
+		"a malformed extension type": {
+			Name: "listens", Events: []string{"ext_notes.NoteAdded"},
+			Handle: func(context.Context, extension.Runtime, extension.Delivery) error { return nil },
+		},
+		"no handler": {Name: "listens", Events: []string{"activity.archived"}},
+		"no events": {
+			Name:   "listens",
+			Handle: func(context.Context, extension.Runtime, extension.Delivery) error { return nil },
+		},
+	} {
+		err := preflightSubscriptions(extension.Extension{
+			Name: "notes", Version: "1.0.0", Subscriptions: []extension.Subscription{sub},
+		})
+		if err == nil {
+			t.Errorf("the boot registered a subscription with %s", name)
+		}
+	}
+
+	// Two listeners of one name would key one consumer group twice.
+	handler := func(context.Context, extension.Runtime, extension.Delivery) error { return nil }
+	duplicate := extension.Subscription{Name: "listens", Events: []string{"activity.archived"}, Handle: handler}
+	if err := preflightSubscriptions(extension.Extension{
+		Name: "notes", Version: "1.0.0", Subscriptions: []extension.Subscription{duplicate, duplicate},
+	}); err == nil || !strings.Contains(err.Error(), "twice") {
+		t.Errorf("err = %v, want the duplicate-subscription refusal", err)
+	}
+
+	// And the well-formed one registers, so the refusals above are not passing
+	// over a preflight that refuses everything.
+	if err := preflightSubscriptions(extension.Extension{
+		Name: "notes", Version: "1.0.0",
+		Subscriptions: []extension.Subscription{
+			{Name: "listens", Events: []string{"activity.archived", "ext_notes.note_added"}, Handle: handler},
+		},
+	}); err != nil {
+		t.Errorf("a well-formed subscription was refused: %v", err)
+	}
+}
+
+// A group's streams carry more than one listener asked for — one activity event
+// means the whole activity stream — so a delivery it did not declare is ACKED
+// rather than failed. It can never succeed on a retry, and an entry that fails
+// forever stalls every later event on the group.
+func TestADeliveryOfAnUndeclaredTypeIsAckedWithoutRunningTheHandler(t *testing.T) {
+	var ran bool
+	sub := composedSubscription("activity.archived")
+	sub.Sub.Handle = func(context.Context, extension.Runtime, extension.Delivery) error {
+		ran = true
+		return nil
+	}
+	// A nil pool is safe here BECAUSE the filter runs first; if it ever stopped
+	// running first, this test would fail on the tenant read rather than pass.
+	err := sub.Handler(nil)(context.Background(), kevents.Envelope{
+		EventID: ids.NewV7(), Type: "activity.captured",
+		Entity: kevents.EntityRef{Type: "activity", ID: ids.NewV7()},
+	})
+	if err != nil {
+		t.Fatalf("an undeclared type was not acked: %v", err)
+	}
+	if ran {
+		t.Error("the handler ran for a type its subscription never declared")
+	}
+}
+
+// What a unit is handed is a REF and a payload, never the record. The ids are
+// strings because the published surface exports no id type.
+func TestADeliveryCarriesTheEnvelopesRefAndNothingElse(t *testing.T) {
+	eventID, subject := ids.NewV7(), ids.NewV7()
+	occurred := time.Date(2026, 8, 13, 9, 30, 0, 0, time.UTC)
+	got := deliveryOf(kevents.Envelope{
+		EventID: eventID, Type: "activity.archived", OccurredAt: occurred,
+		Entity:  kevents.EntityRef{Type: "activity", ID: subject},
+		Payload: json.RawMessage(`{"reason":"noise"}`),
+	})
+	want := extension.Delivery{
+		EventID: eventID.String(), Type: "activity.archived", OccurredAt: occurred,
+		Entity:  extension.EntityRef{Type: "activity", ID: subject.String()},
+		Payload: json.RawMessage(`{"reason":"noise"}`),
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("delivery = %+v, want %+v", got, want)
+	}
+}
+
+// The core's entity-less pipeline events name nothing at all, and a Delivery
+// must say so rather than hand a unit an all-zero UUID it would happily use as
+// a subject.
+func TestAnEntitylessEventDeliversAnEmptyRef(t *testing.T) {
+	got := deliveryOf(kevents.Envelope{
+		EventID: ids.NewV7(), Type: "capture.skipped", OccurredAt: time.Now().UTC(),
+	})
+	if got.Entity != (extension.EntityRef{}) {
+		t.Errorf("entity = %+v, want the empty ref", got.Entity)
+	}
+}
+
+// NOBODY is behind a delivery. rt.Caller() answers the zero Caller — the least
+// authority — however the delivery's own principal is bound, and the runtime is
+// unattended, which is what shuts the core port. The two travel together
+// deliberately: a delivery runs as PrincipalSystem, which auth.Require does not
+// check at all, so the port's refusal is the whole distance between a bus event
+// and an unchecked core write.
+func TestADeliveryRunsAsNobody(t *testing.T) {
+	rt := deliveryRuntimeFor(context.Background(), "notes", "1.0.0",
+		"subscription/withdraw_filing", extensionRuntimeBinding{})
+	if rt.Caller() != (extension.Caller{}) {
+		t.Errorf("Caller() = %+v, want the zero Caller", rt.Caller())
+	}
+	if !rt.unattended {
+		t.Fatal("a delivery's runtime is not unattended, so the core port would be open to it")
+	}
+	// The refusal that flag reaches, asserted here rather than assumed: the
+	// join through Tx needs a pool and is the database lane's.
+	if err := (extensionCore{unattended: rt.unattended}).refuseUnattended(); err == nil {
+		t.Error("an unattended invocation was allowed a core write")
+	}
+}

--- a/backend/internal/shared/kernel/events/catalog.go
+++ b/backend/internal/shared/kernel/events/catalog.go
@@ -5,6 +5,7 @@ package events
 
 import (
 	"fmt"
+	"regexp"
 	"sort"
 	"strings"
 )
@@ -31,6 +32,47 @@ const (
 // once because the catalog below repeats it across every mirror.* entry.
 const streamOverlay = "overlay"
 
+// extensionStreamEntity is the one stream every EXTENSION-authored event rides,
+// whichever unit published it.
+//
+// One stream for the whole tier rather than one per unit, because the stream SET
+// is static everywhere it is read — the ops surface enumerates it, the purge
+// unlinks it, a consumer group declares its streams at construction — while the
+// composed unit set is a property of the build. Per-unit streams would make
+// every one of those depend on which units an installation happens to ship.
+const extensionStreamEntity = "extension"
+
+// ExtensionEventVersion is the payload schema version every extension event
+// carries, and it is 1 forever.
+//
+// A unit changes the shape of what it publishes by naming a NEW VERB, never by
+// bumping this. The alternative is version negotiation across a boundary with no
+// shared schema registry: the core cannot validate a unit's payload against
+// anything, so a number here would be a promise neither side could keep, and a
+// consumer trusting it would be trusting the publisher's own word about a shape
+// nobody checked.
+const ExtensionEventVersion = 1
+
+// extensionTypeGrammar is the extension event type law, `ext_<namespace>.<verb>`
+// — the SQL namespace a unit owns (`ext_` plus its name with hyphens turned to
+// underscores), then a lower snake_case verb.
+//
+// The namespace half keeps one unit's events out of another's name and out of
+// the core families entirely, and it is the same token that opens the unit's
+// tables and its database role, so a reader who knows one knows the others.
+// Nothing here is a grant: the publisher's namespace is derived from the
+// INVOCATION at the port, where a unit never spells it, and this grammar only
+// says what such a type looks like so the bus can route one.
+var extensionTypeGrammar = regexp.MustCompile(`^ext_[a-z0-9_]+\.[a-z][a-z0-9_]*$`)
+
+// IsExtensionType reports whether an event type is extension-authored. It is a
+// question about SHAPE, not a registry lookup: the catalog below is the core's
+// closed set, while the extension set is whatever the composed units publish —
+// which no file in this repository can enumerate.
+func IsExtensionType(eventType string) bool {
+	return extensionTypeGrammar.MatchString(eventType)
+}
+
 // streamEntities are the V1 family streams from events.md, plus the §5.6a
 // identity/access-revocation stream, the voice owner-private lifecycle
 // stream, and the §5.10 overlay-mirror stream (overlay-mode-only).
@@ -42,15 +84,43 @@ var streamEntities = []string{
 	streamOverlay,
 }
 
-// Streams returns the full stream key set, sorted, for the subscriber
-// and the ops surface to enumerate.
+// Streams returns the full stream key set, sorted, for the ops surface to
+// enumerate — the core families AND the extension tier's one stream. A stream
+// left out here is one the data reset does not unlink and no operator can see,
+// which is a worse outcome than the entries it would leave behind.
 func Streams() []string {
+	out := make([]string, 0, len(streamEntities)+1)
+	for _, e := range streamEntities {
+		out = append(out, StreamPrefix+e)
+	}
+	out = append(out, StreamPrefix+extensionStreamEntity)
+	sort.Strings(out)
+	return out
+}
+
+// coreStreams is what a CORE consumer group means when it subscribes to
+// "everything": the family streams, and deliberately NOT the extension one.
+//
+// A core consumer has nothing to do with a unit's event and no way to act on
+// one. The automation engine would load every live instance and match no
+// trigger; the webhook deliverer would query subscriptions for a type the
+// public catalog cannot name. Both are pure cost on every extension event, both
+// are invisible, and both grow with the tier. A unit's event is delivered to
+// the units that ASKED for it, through their own groups.
+func coreStreams() []string {
 	out := make([]string, len(streamEntities))
 	for i, e := range streamEntities {
 		out[i] = StreamPrefix + e
 	}
 	sort.Strings(out)
 	return out
+}
+
+// ExtensionStream is the stream key every extension-authored event rides. The
+// composition builds a unit's consumer group over it by name, and the routing
+// test pins that no core group carries it.
+func ExtensionStream() string {
+	return StreamPrefix + extensionStreamEntity
 }
 
 // catalog is the enumerable V1 event catalog (events.md §5.1–§5.10, plus
@@ -230,20 +300,34 @@ func Types() []string {
 // StreamFor routes an event type to its stream key. An unknown type is a
 // programming error the publisher must surface before the outbox write —
 // an unroutable row would wedge the relay forever.
+//
+// The catalog is consulted FIRST and the extension grammar second, so a core
+// type can never be routed by shape. That ordering is belt to the braces of
+// TestNoCatalogTypeLooksLikeAnExtensionType, which holds the two vocabularies
+// apart at their source.
 func StreamFor(eventType string) (string, error) {
-	spec, ok := catalog[eventType]
-	if !ok {
-		return "", fmt.Errorf("events: %q is not in the events.md §5 catalog", eventType)
+	if spec, ok := catalog[eventType]; ok {
+		return StreamPrefix + spec.stream, nil
 	}
-	return StreamPrefix + spec.stream, nil
+	if IsExtensionType(eventType) {
+		return ExtensionStream(), nil
+	}
+	return "", fmt.Errorf("events: %q is neither an events.md §5 catalog type nor an ext_<namespace>.<verb> extension type", eventType)
 }
 
 // VersionOf returns the current payload schema version of a catalog type
-// (0 for an unknown type; Validate rejects those via StreamFor first).
-// Publishers stamp envelopes from here — never a literal — so a future
-// v2 bump happens in exactly one place.
+// (0 for an unknown type; Validate rejects those via StreamFor first), and
+// ExtensionEventVersion for an extension type. Publishers stamp envelopes
+// from here — never a literal — so a future v2 bump happens in exactly one
+// place, and so the extension port has no version of its own to get wrong.
 func VersionOf(eventType string) int {
-	return catalog[eventType].version
+	if spec, ok := catalog[eventType]; ok {
+		return spec.version
+	}
+	if IsExtensionType(eventType) {
+		return ExtensionEventVersion
+	}
+	return 0
 }
 
 // Group is a §4.3 consumer group: one per consuming module, so each
@@ -260,7 +344,7 @@ type Group struct {
 // consumer groups can only partition by stream, not by envelope field —
 // the actor filter is in-process, like the workspace filter.
 func Groups() []Group {
-	all := Streams()
+	all := coreStreams()
 	forEntities := func(entities ...string) []string {
 		keys := make([]string, len(entities))
 		for i, e := range entities {

--- a/backend/internal/shared/kernel/events/catalog.go
+++ b/backend/internal/shared/kernel/events/catalog.go
@@ -57,13 +57,21 @@ const ExtensionEventVersion = 1
 // — the SQL namespace a unit owns (`ext_` plus its name with hyphens turned to
 // underscores), then a lower snake_case verb.
 //
+// The namespace half mirrors what a unit NAME can actually derive: the name
+// grammar admits `[a-z0-9]+` segments joined by SINGLE hyphens, so the
+// namespace is those segments joined by single underscores and nothing else.
+// Spelling it that way rather than as a loose `[a-z0-9_]+` is what makes
+// `ext__notes.x` and `ext_notes_.x` unroutable — neither is a namespace any
+// unit could own, so a subscription declaring one is a typo the boot can catch
+// instead of a listener that quietly never fires.
+//
 // The namespace half keeps one unit's events out of another's name and out of
 // the core families entirely, and it is the same token that opens the unit's
 // tables and its database role, so a reader who knows one knows the others.
 // Nothing here is a grant: the publisher's namespace is derived from the
 // INVOCATION at the port, where a unit never spells it, and this grammar only
 // says what such a type looks like so the bus can route one.
-var extensionTypeGrammar = regexp.MustCompile(`^ext_[a-z0-9_]+\.[a-z][a-z0-9_]*$`)
+var extensionTypeGrammar = regexp.MustCompile(`^ext_[a-z0-9]+(_[a-z0-9]+)*\.[a-z][a-z0-9_]*$`)
 
 // IsExtensionType reports whether an event type is extension-authored. It is a
 // question about SHAPE, not a registry lookup: the catalog below is the core's

--- a/backend/internal/shared/kernel/events/events_test.go
+++ b/backend/internal/shared/kernel/events/events_test.go
@@ -11,29 +11,39 @@ import (
 	"encoding/json"
 	"reflect"
 	"regexp"
+	"sort"
 	"testing"
 	"time"
 
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
+// coreFamilyStreams is the events.md §4.1 stream set, spelled out rather than
+// derived: these tests exist to catch a change to the stream layout, and an
+// expectation computed from the code under test would move with it.
+var coreFamilyStreams = []string{
+	"gw:events:crm:activity",
+	"gw:events:crm:approval",
+	"gw:events:crm:audit",
+	"gw:events:crm:capture",
+	"gw:events:crm:coldstart",
+	"gw:events:crm:deal",
+	"gw:events:crm:identity",
+	"gw:events:crm:lead",
+	"gw:events:crm:organization",
+	"gw:events:crm:overlay",
+	"gw:events:crm:person",
+	"gw:events:crm:voice",
+}
+
 func TestStreamsMatchSpecList(t *testing.T) {
-	want := []string{
-		"gw:events:crm:activity",
-		"gw:events:crm:approval",
-		"gw:events:crm:audit",
-		"gw:events:crm:capture",
-		"gw:events:crm:coldstart",
-		"gw:events:crm:deal",
-		"gw:events:crm:identity",
-		"gw:events:crm:lead",
-		"gw:events:crm:organization",
-		"gw:events:crm:overlay",
-		"gw:events:crm:person",
-		"gw:events:crm:voice",
-	}
+	// The families, plus the extension tier's one stream — enumerated here
+	// because the data reset unlinks exactly what this returns, and a stream
+	// missing from it is one a reset silently leaves behind.
+	want := append(append([]string{}, coreFamilyStreams...), "gw:events:crm:extension")
+	sort.Strings(want)
 	if got := Streams(); !reflect.DeepEqual(got, want) {
-		t.Errorf("Streams() = %v, want the events.md stream set %v", got, want)
+		t.Errorf("Streams() = %v, want the events.md stream set plus the extension stream %v", got, want)
 	}
 }
 
@@ -122,7 +132,10 @@ func TestStreamForRoutesFamiliesWithoutOwnStream(t *testing.T) {
 }
 
 func TestGroupStreamSetsMatchSpecTable(t *testing.T) {
-	all := Streams()
+	// "Everything" a CORE group subscribes to is the FAMILY streams. The
+	// extension stream is deliberately not among them; see
+	// TestNoCoreGroupCarriesTheExtensionStream.
+	all := coreFamilyStreams
 	want := map[string][]string{
 		"cg:context-graph": {"gw:events:crm:activity", "gw:events:crm:deal", "gw:events:crm:lead", "gw:events:crm:organization", "gw:events:crm:person"},
 		// The interaction-edge projection (ADR-0078): activity events move an

--- a/backend/internal/shared/kernel/events/extensiontypes_test.go
+++ b/backend/internal/shared/kernel/events/extensiontypes_test.go
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package events
+
+// The extension tier's half of the bus contract: a unit-authored type routes to
+// the one extension stream, the two vocabularies cannot shadow each other, and
+// no core consumer group carries the tier's traffic.
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+func TestExtensionTypesRouteToTheExtensionStream(t *testing.T) {
+	for _, typ := range []string{"ext_notes.note_added", "ext_de.retention_recomputed", "ext_a1.x"} {
+		stream, err := StreamFor(typ)
+		if err != nil {
+			t.Errorf("StreamFor(%q) refused a well-formed extension type: %v", typ, err)
+			continue
+		}
+		if stream != "gw:events:crm:extension" {
+			t.Errorf("StreamFor(%q) = %q, want the extension stream", typ, stream)
+		}
+		if got := VersionOf(typ); got != ExtensionEventVersion {
+			t.Errorf("VersionOf(%q) = %d, want %d — a unit names a new verb rather than a version", typ, got, ExtensionEventVersion)
+		}
+	}
+}
+
+func TestMalformedExtensionTypesAreUnroutable(t *testing.T) {
+	// Each of these is a way a type could ALMOST look like a unit's and must
+	// not route: an unroutable outbox row wedges the relay, so the refusal
+	// belongs at the publisher.
+	for _, typ := range map[string]string{
+		"ext_notes.NoteAdded": "an upper-case verb",
+		"ext_notes.":          "no verb at all",
+		"ext_notes":           "no verb segment",
+		"extnotes.added":      "no ext_ namespace prefix",
+		"ext_.added":          "an empty namespace",
+		"ext_notes.2nd_try":   "a verb starting with a digit",
+		"notes.added":         "a bare unit name, which would read as a core family",
+	} {
+		if _, err := StreamFor(typ); err == nil {
+			t.Errorf("StreamFor(%q) routed a malformed extension type", typ)
+		}
+		if IsExtensionType(typ) {
+			t.Errorf("IsExtensionType(%q) accepted a malformed extension type", typ)
+		}
+	}
+}
+
+// The two vocabularies are held apart at their source. If a catalog type ever
+// matched the extension grammar, StreamFor's catalog-first ordering would be
+// the only thing keeping it on its own stream — and a publisher naming it
+// would be indistinguishable from a unit.
+func TestNoCatalogTypeLooksLikeAnExtensionType(t *testing.T) {
+	types := Types()
+	if len(types) == 0 {
+		t.Fatal("the catalog is empty; this test would pass over nothing")
+	}
+	for _, typ := range types {
+		if IsExtensionType(typ) {
+			t.Errorf("catalog type %q matches the extension grammar — a core family may not be spelled ext_<ns>.<verb>", typ)
+		}
+	}
+}
+
+// A unit's event is delivered to the units that ASKED for it. A core group
+// carrying the extension stream would wake the automation engine and the
+// webhook fan-out for every unit event, match nothing, and cost a database
+// round trip each — invisibly, and growing with the tier.
+func TestNoCoreGroupCarriesTheExtensionStream(t *testing.T) {
+	extension := ExtensionStream()
+	// Asserted first, so the absence below cannot pass merely because the
+	// stream does not exist.
+	var published bool
+	for _, s := range Streams() {
+		if s == extension {
+			published = true
+		}
+	}
+	if !published {
+		t.Fatalf("Streams() does not carry %q, so nothing purges or measures it", extension)
+	}
+
+	groups := Groups()
+	if len(groups) == 0 {
+		t.Fatal("Groups() is empty; this test would pass over nothing")
+	}
+	for _, g := range groups {
+		for _, s := range g.Streams {
+			if s == extension {
+				t.Errorf("core group %s subscribes to %q", g.Name, extension)
+			}
+		}
+	}
+}
+
+func TestExtensionEnvelopeValidates(t *testing.T) {
+	env := Envelope{
+		EventID:    ids.NewV7(),
+		Type:       "ext_notes.filing_withdrawn",
+		Version:    ExtensionEventVersion,
+		OccurredAt: time.Date(2026, 8, 13, 9, 0, 0, 0, time.UTC),
+		Actor:      Actor{Type: "system", ID: "system"},
+		// The subject is the unit's OWN row, named by the unit's own table.
+		Entity:  EntityRef{Type: "ext_notes_note", ID: ids.NewV7()},
+		Payload: json.RawMessage(`{"activity_id":"1e2d"}`),
+		Trace:   Trace{CorrelationID: ids.NewV7(), AuditLogID: ids.NewV7()},
+	}
+	if err := env.Validate(); err != nil {
+		t.Fatalf("a complete extension envelope was refused: %v", err)
+	}
+
+	// The version is stamped from VersionOf, never written at the port; an
+	// envelope claiming another one is a publisher that stopped agreeing with
+	// the bus contract.
+	skewed := env
+	skewed.Version = ExtensionEventVersion + 1
+	if err := skewed.Validate(); err == nil {
+		t.Error("Validate accepted an extension envelope at a version the tier does not have")
+	}
+
+	// An extension event is not a pipeline event: it names its subject, or it
+	// is a fact no consumer can read back.
+	subjectless := env
+	subjectless.Entity = EntityRef{}
+	if err := subjectless.Validate(); err == nil {
+		t.Error("Validate accepted an extension envelope with no entity ref")
+	}
+}

--- a/backend/internal/shared/kernel/events/extensiontypes_test.go
+++ b/backend/internal/shared/kernel/events/extensiontypes_test.go
@@ -16,7 +16,10 @@ import (
 )
 
 func TestExtensionTypesRouteToTheExtensionStream(t *testing.T) {
-	for _, typ := range []string{"ext_notes.note_added", "ext_de.retention_recomputed", "ext_a1.x"} {
+	// The third is a HYPHENATED unit name as its namespace (`crm-demo` →
+	// `ext_crm_demo`), which is the shape the grammar has to keep admitting
+	// while refusing the near-misses below it.
+	for _, typ := range []string{"ext_notes.note_added", "ext_de.retention_recomputed", "ext_crm_demo.widget_changed", "ext_a1.x"} {
 		stream, err := StreamFor(typ)
 		if err != nil {
 			t.Errorf("StreamFor(%q) refused a well-formed extension type: %v", typ, err)
@@ -35,7 +38,7 @@ func TestMalformedExtensionTypesAreUnroutable(t *testing.T) {
 	// Each of these is a way a type could ALMOST look like a unit's and must
 	// not route: an unroutable outbox row wedges the relay, so the refusal
 	// belongs at the publisher.
-	for _, typ := range map[string]string{
+	for typ, why := range map[string]string{
 		"ext_notes.NoteAdded": "an upper-case verb",
 		"ext_notes.":          "no verb at all",
 		"ext_notes":           "no verb segment",
@@ -43,12 +46,17 @@ func TestMalformedExtensionTypesAreUnroutable(t *testing.T) {
 		"ext_.added":          "an empty namespace",
 		"ext_notes.2nd_try":   "a verb starting with a digit",
 		"notes.added":         "a bare unit name, which would read as a core family",
+		// A namespace no unit NAME can derive: the name grammar joins its
+		// segments with single hyphens, so a doubled or trailing underscore is
+		// a typo rather than somebody's namespace.
+		"ext__notes.note_added": "a doubled underscore in the namespace",
+		"ext_notes_.note_added": "a trailing underscore in the namespace",
 	} {
 		if _, err := StreamFor(typ); err == nil {
-			t.Errorf("StreamFor(%q) routed a malformed extension type", typ)
+			t.Errorf("StreamFor(%q) routed a type with %s", typ, why)
 		}
 		if IsExtensionType(typ) {
-			t.Errorf("IsExtensionType(%q) accepted a malformed extension type", typ)
+			t.Errorf("IsExtensionType(%q) accepted a type with %s", typ, why)
 		}
 	}
 }

--- a/backend/internal/shared/kernel/provenance/extension.go
+++ b/backend/internal/shared/kernel/provenance/extension.go
@@ -3,7 +3,10 @@
 
 package provenance
 
-import "context"
+import (
+	"context"
+	"encoding/json"
+)
 
 // Extension is the attribution a core write carries when an extension unit
 // made it: which unit, which version of it, and through which of its verbs.
@@ -28,6 +31,16 @@ type Extension struct {
 	// `route/POST /ext/notes/file` — so an audit reader can tell an agent's
 	// call from a person's without a second lookup.
 	Via string
+
+	// Detail is the unit's OWN free-form context about ONE write, and the only
+	// member of this entry a unit supplies. The three above are stamped per
+	// INVOCATION; this one is bound per write by the ledger port, because it
+	// describes a statement rather than a call.
+	//
+	// Raw JSON, because that is how it arrives from the published surface —
+	// already checked for validity there — and decoding it into a map here
+	// would only give this package a shape of its own to get wrong.
+	Detail json.RawMessage
 }
 
 // ExtensionEvidenceKey is the one audit-evidence member extension attribution
@@ -62,7 +75,17 @@ func ExtensionFrom(ctx context.Context) (Extension, bool) {
 
 // EvidenceEntry renders the attribution as the value its evidence member holds.
 //
+// Detail is nested UNDER this entry rather than placed beside it, so the whole
+// tier stays one member of the evidence namespace — the property that keeps a
+// unit from ever colliding with the ~20 bare keys the core's modules write. An
+// absent detail leaves the member out entirely: `"detail": null` would be a
+// unit saying something rather than a unit saying nothing.
+//
 //craft:ignore naked-any the audit evidence seam is jsonb; this is one member of it
 func (e Extension) EvidenceEntry() map[string]any {
-	return map[string]any{"unit": e.Unit, "version": e.Version, "via": e.Via}
+	entry := map[string]any{"unit": e.Unit, "version": e.Version, "via": e.Via}
+	if len(e.Detail) > 0 {
+		entry["detail"] = e.Detail
+	}
+	return entry
 }

--- a/backend/pkg/extension/extension.go
+++ b/backend/pkg/extension/extension.go
@@ -38,18 +38,18 @@
 //     mutation returning change descriptors. It is now joined by two doors
 //     instead. Tx.Core() makes the core's own write onto the product's records
 //     — the RBAC check, the audit row, the outbox event, the attribution — and
-//     Tx.Audit records what the unit's own SQL did in the same ledger, handing
-//     back the receipt its event is published through. Between them a unit's
-//     write can carry everything a core write carries, which is what the
-//     descriptor design was reaching for; Tx's three SQL verbs stay for the
-//     unit's OWN tables, which is what they were always the right shape for.
+//     Tx.Record writes the ledger row and the bus event for what the unit's own
+//     SQL did. Between them a unit's write can carry everything a core write
+//     carries, which is what the descriptor design was reaching for; Tx's three
+//     SQL verbs stay for the unit's OWN tables, which is what they were always
+//     the right shape for.
 //
 //     What remains unstable is their REACH: a unit's SQL runs on the shared
 //     application role today, and narrowing it to a per-unit database role
-//     (issue #628) is a change every unit's SQL feels. And the ledger doors are
-//     OFFERED, not enforced — a unit may still write its tables and record
-//     nothing — so a later release that makes recording mandatory would be
-//     felt by any unit that had not adopted them.
+//     (issue #628) is a change every unit's SQL feels. And Record is OFFERED,
+//     not enforced — a unit may still write its tables and record nothing — so
+//     a later release that makes recording mandatory would be felt by any unit
+//     that had not adopted it.
 //
 //   - The frontend surface a unit screen imports, whose exported client type
 //     currently infers foreign types (openapi-fetch) into the published shape.

--- a/backend/pkg/extension/extension.go
+++ b/backend/pkg/extension/extension.go
@@ -35,14 +35,21 @@
 //     required to write.
 //
 //     This entry USED to say Tx would be removed and replaced by a governed
-//     mutation returning change descriptors. It is now joined by one instead:
-//     Tx.Core() is the governed door, and it makes the core's own write — the
-//     RBAC check, the audit row, the outbox event, the attribution — rather
-//     than describing a change for the core to make. Tx's three SQL verbs stay
-//     for the unit's OWN tables, which is what they were always the right
-//     shape for. What remains unstable is their reach: a unit's SQL runs on the
-//     shared application role today, and narrowing it to a per-unit database
-//     role (issue #628) is a change every unit's SQL feels.
+//     mutation returning change descriptors. It is now joined by two doors
+//     instead. Tx.Core() makes the core's own write onto the product's records
+//     — the RBAC check, the audit row, the outbox event, the attribution — and
+//     Tx.Audit records what the unit's own SQL did in the same ledger, handing
+//     back the receipt its event is published through. Between them a unit's
+//     write can carry everything a core write carries, which is what the
+//     descriptor design was reaching for; Tx's three SQL verbs stay for the
+//     unit's OWN tables, which is what they were always the right shape for.
+//
+//     What remains unstable is their REACH: a unit's SQL runs on the shared
+//     application role today, and narrowing it to a per-unit database role
+//     (issue #628) is a change every unit's SQL feels. And the ledger doors are
+//     OFFERED, not enforced — a unit may still write its tables and record
+//     nothing — so a later release that makes recording mandatory would be
+//     felt by any unit that had not adopted them.
 //
 //   - The frontend surface a unit screen imports, whose exported client type
 //     currently infers foreign types (openapi-fetch) into the published shape.
@@ -206,6 +213,21 @@ type Extension struct {
 	// outbound scope (autonomous outbound authority on a clock), where the
 	// served-tool seam refuses the same two shapes for weaker reasons.
 	Jobs []Job
+
+	// Subscriptions are the events the unit reacts to: named listeners over the
+	// installation's own event bus, each naming the types it wants and the
+	// function one delivery runs.
+	//
+	// Like a Job this pairs a declaration with behavior, and unlike a Job the
+	// declaration is HERE rather than in a contract fragment — there is no HTTP
+	// surface, no cadence and no queue to spell, only which facts the unit
+	// listens for. That list is derived into manifest.generated.json, so what a
+	// unit consumes is visible to an operator without reading its source.
+	//
+	// A delivery has NOBODY behind it, which is what separates a subscription
+	// from a tool: no caller, and so no permissions a core write could be
+	// checked against. See EventHandler.
+	Subscriptions []Subscription
 
 	// Migrations is the unit's SQL schema layer: a read-only filesystem
 	// holding the MigrationsDir directory of NNNN_name.up.sql/.down.sql

--- a/backend/pkg/extension/ledger.go
+++ b/backend/pkg/extension/ledger.go
@@ -10,6 +10,7 @@ package extension
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"regexp"
 )
@@ -128,6 +129,17 @@ func (c Change) Validate() error {
 		if len(image.raw) > 0 && !json.Valid(image.raw) {
 			return fmt.Errorf("extension: the %s image is not valid JSON, and the ledger column holding it is jsonb", image.what)
 		}
+	}
+	// An image the ACTION says cannot exist. A create with a before-image and an
+	// erase with an after-image are each a ledger row that contradicts itself,
+	// and the contradiction is permanent: audit_log is append-only, so nobody
+	// can correct it afterwards. Refusing the write is the only moment this can
+	// be said.
+	if c.Action == AuditCreate && len(c.Before) > 0 {
+		return errors.New("extension: a create carries a before image — the row did not exist, so there was no state to record")
+	}
+	if c.Action == AuditErase && len(c.After) > 0 {
+		return errors.New("extension: an erase carries an after image — the row is gone, so there is no state left to record")
 	}
 	return nil
 }

--- a/backend/pkg/extension/ledger.go
+++ b/backend/pkg/extension/ledger.go
@@ -1,0 +1,197 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+// The ledger seam — what a unit's write to its OWN tables records, and the
+// event it publishes — is part of the published extension surface.
+//
+//margince:extension-surface
+
+package extension
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+)
+
+// AuditAction is what a write to a unit's own table DID, in the core's own
+// audit vocabulary rather than a second one invented for the tier.
+//
+// The five below are the actions that have an honest meaning for a row a unit
+// owns. The core's ledger admits more (merge, promote, export, login…), and
+// each of those is a thing the PRODUCT does to a record it understands — a unit
+// naming one would be describing an operation nothing else in the system agrees
+// happened.
+type AuditAction string
+
+const (
+	// AuditCreate is a row that did not exist before this write.
+	AuditCreate AuditAction = "create"
+	// AuditUpdate is a row that changed.
+	AuditUpdate AuditAction = "update"
+	// AuditArchive is a row withdrawn from use but still present.
+	AuditArchive AuditAction = "archive"
+	// AuditRestore is an archived row brought back.
+	AuditRestore AuditAction = "restore"
+	// AuditErase is a row that is gone — the honest action for a hard DELETE,
+	// where the ledger row and its before-image are the only remaining trace.
+	AuditErase AuditAction = "erase"
+)
+
+// Validate reports whether the action is one the ledger admits. The refusal
+// names the vocabulary because the alternative is a constraint violation from
+// the database, whose message is written for nobody.
+func (a AuditAction) Validate() error {
+	switch a {
+	case AuditCreate, AuditUpdate, AuditArchive, AuditRestore, AuditErase:
+		return nil
+	}
+	return fmt.Errorf("extension: %q is not an audit action (create, update, archive, restore, erase)", string(a))
+}
+
+// entityGrammar is a unit table's name as the ledger records it: the unit's own
+// `ext_<namespace>_<table>` identifier, unqualified. Unqualified because
+// audit_log.entity_type names a KIND of record, not a path to one — the `ext.`
+// schema belongs in the SQL a unit writes, and a reader joining the ledger to
+// anything else would have to strip it back off.
+var entityGrammar = regexp.MustCompile(`^ext_[a-z0-9_]+$`)
+
+// uuidGrammar is the canonical spelling of a row id, checked here because
+// entity_id is a uuid column: a non-canonical string fails at the driver,
+// inside the transaction, with a message about a text-to-uuid cast.
+var uuidGrammar = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
+
+// Change is one write to a unit's own table, as the ledger will record it.
+//
+// A unit's own SQL is the one write in the product that the core cannot
+// describe — it has no entity type, no id and no field images to derive,
+// because it is a statement the core does not parse (see Tx). So the unit
+// describes it, and everything else about the ledger row — the actor, the
+// workspace, the authorization rule, the attribution naming the unit — is
+// stamped by the core from the invocation and is not the unit's to influence.
+type Change struct {
+	// Action is what the write did.
+	Action AuditAction
+
+	// Entity is the unit's own table, `ext_<namespace>_<table>`, unqualified.
+	// It must be a table in the INVOKING unit's namespace: a ledger row is a
+	// record's history, and one written against a core record — or another
+	// unit's — would be a line in that record's trail describing a write its
+	// owner never made.
+	Entity string
+
+	// ID is the row's id, a canonical UUID.
+	ID string
+
+	// Before and After are the row's field images either side of the write.
+	// They are the RECORD's own shape: what the row looked like, not why it
+	// changed. A create leaves Before empty; an erase leaves After empty.
+	//
+	// json.RawMessage rather than a Go value, because these bytes become
+	// jsonb: the raw type says so, and it makes a value that cannot be
+	// marshaled impossible to hand over in the first place.
+	Before json.RawMessage
+	After  json.RawMessage
+
+	// Detail is context ABOUT the write — which core event caused it, which of
+	// the unit's own rules fired — and never the record's fields. Folding
+	// operational context into the images above makes every downstream reader
+	// of field history see changes that never happened on the record.
+	//
+	// It lands under the unit's own attribution entry, at
+	// `evidence.extension.detail`, so the whole tier stays inside the one
+	// evidence member the core stamps for it. A unit cannot write the members
+	// beside it (the unit name, its version, the surface the call arrived on):
+	// those are the core's answer to "what carried this", and a unit able to
+	// write them could sign another unit's name.
+	Detail json.RawMessage
+}
+
+// Validate checks the SHAPE of a change — everything decidable without knowing
+// which unit is writing it. Whether Entity is in the CALLER's namespace is the
+// core's check, made at the port against the invocation, for the same reason a
+// Job's tier is checked where it is registered rather than where it is declared.
+func (c Change) Validate() error {
+	if err := c.Action.Validate(); err != nil {
+		return err
+	}
+	if !entityGrammar.MatchString(c.Entity) {
+		return fmt.Errorf("extension: %q is not a unit table (ext_<namespace>_<table>, unqualified) — a unit audits its own rows", c.Entity)
+	}
+	if !uuidGrammar.MatchString(c.ID) {
+		return fmt.Errorf("extension: %q is not a row id — an id is a canonical lower-case UUID", c.ID)
+	}
+	for _, image := range []struct {
+		what string
+		raw  json.RawMessage
+	}{{"before", c.Before}, {"after", c.After}, {"detail", c.Detail}} {
+		if len(image.raw) > 0 && !json.Valid(image.raw) {
+			return fmt.Errorf("extension: the %s image is not valid JSON, and the ledger column holding it is jsonb", image.what)
+		}
+	}
+	return nil
+}
+
+// MaxEventPayloadBytes caps what one published event may carry.
+//
+// A bus entry is read by every consumer of its stream and held in memory by the
+// broker until each of them has acked it, so an oversized payload is not the
+// publisher's problem — it is everyone else's, and it arrives without warning.
+// The cap is generous next to what a payload is FOR (see Event.Payload) and
+// small next to anything that would hurt.
+const MaxEventPayloadBytes = 32 * 1024
+
+// Event is one domain fact a unit publishes: the name it gives the write it
+// just described, and what a listener needs in order to act on it.
+//
+// It is a PARAMETER of Tx.Record rather than a call of its own, and that is the
+// whole of how the write shape is kept. An event with no ledger row is
+// unauditable — the bus contract requires every envelope to name the row
+// written in its own transaction — and a ledger row with no event is a change
+// the rest of the installation is never told about, which is the exemption the
+// core does not grant itself either. Neither is expressible here.
+type Event struct {
+	// Verb is what happened, lower snake_case and past tense by convention
+	// (`note_added`, `filing_withdrawn`).
+	//
+	// It is a VERB, not a type: the core prefixes the publishing unit's own
+	// namespace, so the type on the bus is `ext_<namespace>.<verb>`. A unit
+	// therefore cannot publish under another unit's name, or inside a core
+	// family, because this surface gives it no way to say either.
+	Verb string
+
+	// Payload is what a consumer needs in order to DECIDE whether to read the
+	// record, and nothing more. An event carries a ref, never the body: a
+	// consumer that needs the record reads it back under its own capabilities,
+	// which is what keeps a fact on the bus from becoming a copy of the record
+	// that goes stale. Optional — many facts are fully carried by their subject.
+	//
+	// The DOCUMENT survives, the bytes do not. It is stored as jsonb on its way
+	// out, which normalizes whitespace and key order and collapses a duplicate
+	// member, so a consumer sees the value this carried and never its
+	// formatting. Nothing should be signed or compared as raw text across it.
+	Payload json.RawMessage
+}
+
+// eventVerbGrammar is the verb half of an extension event type. The namespace
+// half is the core's to supply, so this is the whole of what a unit spells.
+var eventVerbGrammar = regexp.MustCompile(`^[a-z][a-z0-9_]*$`)
+
+// Validate checks the shape of an event: the verb's grammar, the payload's
+// JSON, and the payload's size against MaxEventPayloadBytes.
+func (e Event) Validate() error {
+	if !eventVerbGrammar.MatchString(e.Verb) {
+		return fmt.Errorf("extension: %q is not an event verb (lower snake_case, e.g. note_added)", e.Verb)
+	}
+	if len(e.Payload) > MaxEventPayloadBytes {
+		return fmt.Errorf("extension: the %s event's payload is %d bytes, over the %d-byte cap every consumer of the stream pays for", e.Verb, len(e.Payload), MaxEventPayloadBytes)
+	}
+	if len(e.Payload) > 0 && !json.Valid(e.Payload) {
+		return fmt.Errorf("extension: the %s event's payload is not valid JSON", e.Verb)
+	}
+	return nil
+}
+
+// Validate on Change and Event is the whole of what this package can decide.
+// Whether the entity and the verb belong to the INVOKING unit is the core's
+// check, made at the port against the invocation — see Tx.Record.

--- a/backend/pkg/extension/ledger_test.go
+++ b/backend/pkg/extension/ledger_test.go
@@ -62,6 +62,14 @@ func TestChangeValidateRefusesWhatTheLedgerCannotHold(t *testing.T) {
 		"a before image that is not JSON": func(c *Change) { c.Before = json.RawMessage(`{`) },
 		"an after image that is not JSON": func(c *Change) { c.After = json.RawMessage(`nope`) },
 		"a detail that is not JSON":       func(c *Change) { c.Detail = json.RawMessage(`{"a":}`) },
+		// An image the action says cannot exist. audit_log is append-only, so a
+		// row that contradicts itself is a contradiction nobody can correct.
+		"a create with a before image": func(c *Change) {
+			c.Action, c.Before = AuditCreate, json.RawMessage(`{"body":"was never there"}`)
+		},
+		"an erase with an after image": func(c *Change) {
+			c.Action, c.After = AuditErase, json.RawMessage(`{"body":"is gone"}`)
+		},
 	} {
 		ch := valid
 		mutate(&ch)

--- a/backend/pkg/extension/ledger_test.go
+++ b/backend/pkg/extension/ledger_test.go
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package extension
+
+// What the published ledger surface refuses before any core sees it. Every case
+// here is a value a unit could reasonably build and the core would otherwise
+// discover inside a transaction, where the honest report is a SQLSTATE.
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+const testRowID = "018f3a2b-6c7d-7e8f-9a0b-1c2d3e4f5061"
+
+func TestChangeValidateAcceptsAWellFormedWrite(t *testing.T) {
+	ch := Change{
+		Action: AuditUpdate,
+		Entity: "ext_notes_note",
+		ID:     testRowID,
+		Before: json.RawMessage(`{"filed_activity_id":"a"}`),
+		After:  json.RawMessage(`{"filed_activity_id":null}`),
+		Detail: json.RawMessage(`{"cause":"activity.archived"}`),
+	}
+	if err := ch.Validate(); err != nil {
+		t.Fatalf("a well-formed change was refused: %v", err)
+	}
+
+	// A create has no before-image and an erase has no after-image; neither is
+	// a malformed change, and refusing either would make the honest write
+	// impossible to describe.
+	for _, ch := range []Change{
+		{Action: AuditCreate, Entity: "ext_notes_note", ID: testRowID, After: json.RawMessage(`{}`)},
+		{Action: AuditErase, Entity: "ext_notes_note", ID: testRowID, Before: json.RawMessage(`{}`)},
+	} {
+		if err := ch.Validate(); err != nil {
+			t.Errorf("a %s with one image was refused: %v", ch.Action, err)
+		}
+	}
+}
+
+func TestChangeValidateRefusesWhatTheLedgerCannotHold(t *testing.T) {
+	valid := Change{Action: AuditCreate, Entity: "ext_notes_note", ID: testRowID}
+	for name, mutate := range map[string]func(*Change){
+		// The ledger's action column is a closed CHECK; an unknown verb would
+		// fail inside the transaction with a constraint name for a message.
+		"an action outside the ledger's vocabulary": func(c *Change) { c.Action = "merge" },
+		"no action at all":                          func(c *Change) { c.Action = "" },
+		// entity_type names a KIND of record. A core one would put a line into
+		// a core record's history describing a write the core never made.
+		"a core entity type":       func(c *Change) { c.Entity = "person" },
+		"a schema-qualified table": func(c *Change) { c.Entity = "ext.ext_notes_note" },
+		"no entity":                func(c *Change) { c.Entity = "" },
+		// entity_id is a uuid column.
+		"an id that is not a UUID": func(c *Change) { c.ID = "note-7" },
+		"an upper-case UUID":       func(c *Change) { c.ID = strings.ToUpper(testRowID) },
+		"no id":                    func(c *Change) { c.ID = "" },
+		// The three images are jsonb.
+		"a before image that is not JSON": func(c *Change) { c.Before = json.RawMessage(`{`) },
+		"an after image that is not JSON": func(c *Change) { c.After = json.RawMessage(`nope`) },
+		"a detail that is not JSON":       func(c *Change) { c.Detail = json.RawMessage(`{"a":}`) },
+	} {
+		ch := valid
+		mutate(&ch)
+		if err := ch.Validate(); err == nil {
+			t.Errorf("Change.Validate accepted %s", name)
+		}
+	}
+}
+
+func TestEventValidateRefusesWhatTheBusCannotCarry(t *testing.T) {
+	if err := (Event{Verb: "note_added", Payload: json.RawMessage(`{"id":"x"}`)}).Validate(); err != nil {
+		t.Fatalf("a well-formed event was refused: %v", err)
+	}
+	// An event with no payload is the common case: the subject carries it.
+	if err := (Event{Verb: "note_added"}).Validate(); err != nil {
+		t.Fatalf("an event with no payload was refused: %v", err)
+	}
+
+	for name, ev := range map[string]Event{
+		"a verb that is not lower snake_case": {Verb: "NoteAdded"},
+		"a verb starting with a digit":        {Verb: "2nd_note"},
+		"a namespaced type rather than a verb": {
+			// The namespace is the core's to supply. A unit spelling one would
+			// be publishing under a name it does not own — here it is simply
+			// not a verb.
+			Verb: "ext_notes.note_added",
+		},
+		"no verb":                    {},
+		"a payload that is not JSON": {Verb: "note_added", Payload: json.RawMessage(`{`)},
+		"a payload past the cap": {
+			Verb:    "note_added",
+			Payload: json.RawMessage(`"` + strings.Repeat("x", MaxEventPayloadBytes) + `"`),
+		},
+	} {
+		if err := ev.Validate(); err == nil {
+			t.Errorf("Event.Validate accepted %s", name)
+		}
+	}
+}
+
+// The pairing the surface exists to guarantee: one call carries the ledger row
+// and the event, so neither can be written without the other. It is the
+// product's own write shape, and a unit gets it by construction rather than by
+// remembering to make a second call.
+func TestOneCallRecordsTheLedgerRowAndTheEvent(t *testing.T) {
+	tx := &fakeTx{}
+	if err := tx.Record(context.Background(), Change{
+		Action: AuditCreate, Entity: "ext_notes_note", ID: testRowID,
+		After: json.RawMessage(`{"body":"hello"}`),
+	}, Event{Verb: "note_added"}); err != nil {
+		t.Fatalf("recording a well-formed write: %v", err)
+	}
+	if len(tx.audited) != 1 || len(tx.published) != 1 {
+		t.Fatalf("audited %d changes and published %d events, want 1 and 1", len(tx.audited), len(tx.published))
+	}
+	if tx.published[0].Verb != "note_added" {
+		t.Errorf("published verb %q, want note_added", tx.published[0].Verb)
+	}
+
+	// Either half being malformed refuses the whole call, so a unit can never
+	// end up with one of the two written.
+	for name, call := range map[string]struct {
+		ch Change
+		ev Event
+	}{
+		"a change the ledger refuses": {
+			Change{Action: AuditCreate, Entity: "person", ID: testRowID}, Event{Verb: "note_added"},
+		},
+		"an event the bus refuses": {
+			Change{Action: AuditCreate, Entity: "ext_notes_note", ID: testRowID}, Event{Verb: "Note Added"},
+		},
+	} {
+		before, published := len(tx.audited), len(tx.published)
+		if err := tx.Record(context.Background(), call.ch, call.ev); err == nil {
+			t.Errorf("Record accepted %s", name)
+		}
+		if len(tx.audited) != before || len(tx.published) != published {
+			t.Errorf("%s left a half-written record behind", name)
+		}
+	}
+}

--- a/backend/pkg/extension/runtime.go
+++ b/backend/pkg/extension/runtime.go
@@ -215,7 +215,7 @@ type Tx interface {
 	// published as an event — is a property of going through it rather than
 	// around it. See Core.
 	//
-	// It is the door onto the PRODUCT's records; Audit below is the one onto
+	// It is the door onto the PRODUCT's records; Record below is the one onto
 	// the unit's own.
 	Core() Core
 

--- a/backend/pkg/extension/runtime.go
+++ b/backend/pkg/extension/runtime.go
@@ -210,11 +210,43 @@ type Caller struct {
 type Tx interface {
 	// Core is the governed door onto the installation's own records, on THIS
 	// transaction: a unit's own row and the core record it files commit
-	// together or not at all. Everything the three verbs below are not —
+	// together or not at all. Everything the three SQL verbs below are not —
 	// authorized against the caller's live RBAC, audited, attributed, and
 	// published as an event — is a property of going through it rather than
 	// around it. See Core.
+	//
+	// It is the door onto the PRODUCT's records; Audit below is the one onto
+	// the unit's own.
 	Core() Core
+
+	// Record writes the ledger row AND the event for a write to the unit's OWN
+	// tables, on this transaction: the unit's row, its history and its
+	// announcement commit together or not at all.
+	//
+	// BOTH, ALWAYS, and that is the point rather than an inconvenience. It is
+	// the product's own non-negotiable write shape — domain row + audit row +
+	// outbox event in one transaction — offered to a unit in the one call that
+	// makes the pairing impossible to get wrong. An event with no ledger row is
+	// unauditable; a ledger row with no event is a change nothing downstream is
+	// told about, and the core grants itself no such exemption either.
+	//
+	// The three verbs below cannot do this for a unit, for the reason their own
+	// doc gives: the core does not parse the SQL, so it has no entity, no id and
+	// no field images to derive from an Exec. What it CAN do — and does here —
+	// is stamp everything that must not be the unit's to choose: the actor the
+	// invocation arrived as, the workspace, the authorization rule, the
+	// attribution naming the unit and the surface the call came in on, the
+	// event's namespace, and the trace joining the event to the ledger row.
+	//
+	// Nothing checks the caller's permissions here, deliberately. The door that
+	// admitted this call already authorized it, and the row is the unit's own —
+	// there is no core object an RBAC vocabulary could name.
+	//
+	// It is offered, not enforced: a unit may still write its tables through
+	// Exec and record nothing, exactly as it could before. What this makes
+	// possible is a unit whose own history is as readable as the product's, out
+	// of the same table, under the same joins.
+	Record(ctx context.Context, ch Change, ev Event) error
 
 	// Exec runs a statement that returns no rows (INSERT, UPDATE, DELETE)
 	// and reports how many rows it affected — which is how a delete says

--- a/backend/pkg/extension/runtime_test.go
+++ b/backend/pkg/extension/runtime_test.go
@@ -41,12 +41,33 @@ func (r *fakeRuntime) Tx(ctx context.Context, fn func(context.Context, Tx) error
 	return fn(ctx, &fakeTx{rows: r.rows})
 }
 
-type fakeTx struct{ rows [][]string }
+type fakeTx struct {
+	rows      [][]string
+	audited   []Change
+	published []Event
+}
 
 // Core is the port a fake transaction does not serve: these tests exercise the
 // three SQL verbs, and a Core here would be a second implementation of the seam
 // rather than a use of it.
 func (t *fakeTx) Core() Core { return nil }
+
+// Record records rather than writes. What these tests prove is the SHAPE a unit
+// compiles against — one call carrying both halves, so there is no way to
+// express a ledger row with no event or an event with no ledger row — which is
+// exactly the part the core's implementation cannot change without breaking
+// every unit.
+func (t *fakeTx) Record(_ context.Context, ch Change, ev Event) error {
+	if err := ch.Validate(); err != nil {
+		return err
+	}
+	if err := ev.Validate(); err != nil {
+		return err
+	}
+	t.audited = append(t.audited, ch)
+	t.published = append(t.published, ev)
+	return nil
+}
 
 func (t *fakeTx) Exec(_ context.Context, _ string, args ...any) (int64, error) {
 	return int64(len(args)), nil

--- a/backend/pkg/extension/subscription.go
+++ b/backend/pkg/extension/subscription.go
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+// The subscription seam — how a unit hears that something happened — is part
+// of the published extension surface.
+//
+//margince:extension-surface
+
+package extension
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// EntityRef names the subject of a delivered event: a REF, never the record.
+// A consumer that needs the record reads it back under its own capabilities,
+// which is what keeps a fact on the bus from ageing into a stale copy of the
+// row it describes.
+type EntityRef struct {
+	// Type is the kind of record — a core entity type (`activity`, `person`)
+	// for a core event, a unit's own table for an extension one.
+	Type string
+	// ID is the record's id, a canonical UUID.
+	ID string
+}
+
+// Delivery is one event as a unit receives it.
+//
+// It is named apart from Event, which is what a unit PUBLISHES, because the two
+// directions are not the same shape and one name for both is how a handler ends
+// up republishing what it was handed.
+type Delivery struct {
+	// EventID is the bus event's own id. It is the idempotency key: the core
+	// suppresses a redelivery it has already seen for this subscription, and a
+	// handler that keeps its own record of what it has processed keys on this.
+	EventID string
+
+	// Type is the full event type — `activity.archived` for a core fact,
+	// `ext_<namespace>.<verb>` for another unit's.
+	Type string
+
+	// OccurredAt is when the fact happened, not when it was delivered. The two
+	// differ by the relay, by a retry, and by however long a consumer was down.
+	OccurredAt time.Time
+
+	// Entity is the subject. It is empty for the handful of core pipeline
+	// events that name nothing at all (a message excluded from capture creates
+	// no row), so a handler that keys on the subject checks it.
+	Entity EntityRef
+
+	// Payload is the event's own body as its publisher wrote it, re-rendered
+	// by the jsonb column it travelled through: the document is the
+	// publisher's, the whitespace and key order are the database's. The core
+	// makes no promise about the SHAPE — for a core event it is the contract's,
+	// for another unit's it is that unit's — so a handler decodes the fields it
+	// needs and tolerates the ones it does not know.
+	Payload json.RawMessage
+}
+
+// EventHandler runs ONE delivery of ONE subscribed event.
+//
+// It is the BEHAVIOR half of a subscription, exactly as ToolHandler is a tool's
+// and JobHandler is a job's, and like them it is not derivable from the AST —
+// the manifest records WHAT a unit subscribes to, and this is the part a static
+// document cannot hold.
+//
+// rt arrives HERE, at delivery, because a declaration is inert data: a
+// Subscription value sitting in a slice holds no route into the core. The core
+// mints rt for this one delivery and releases it when the handler returns.
+//
+// THERE IS NOBODY BEHIND A DELIVERY. rt.Caller() answers the zero Caller and
+// rt.Tx(…).Core() refuses, for the same reason a job tick's does: a core write
+// is checked against the caller's own permissions and a bus event has no
+// caller. A handler may read and write the unit's OWN tables, audit those
+// writes, and publish — which is what reacting to a fact consists of.
+//
+// THE BUS IS AT-LEAST-ONCE. The core suppresses the redelivery it can see (the
+// same event to the same subscription), but a handler must still be safe to run
+// twice: the suppression is a cache, and a crash between the effect and the ack
+// is exactly the case it cannot cover. Returning an error leaves the entry
+// pending and re-delivers it later; returning nil acks it. So a handler that
+// cannot succeed — a malformed payload, a subject it does not recognize —
+// returns nil and logs, rather than failing forever on a delivery no retry can
+// fix.
+type EventHandler func(ctx context.Context, rt Runtime, d Delivery) error
+
+// Subscription is the BEHAVIOR half of one thing a unit listens for: which
+// events, and the Go function that runs when one arrives.
+//
+// The event list is DECLARED rather than filtered in code, and that is a
+// governance property rather than a convenience: it is derived into the unit's
+// manifest.generated.json, so an operator reading the manifest can see which of
+// the installation's facts a unit consumes without reading its source.
+type Subscription struct {
+	// Name identifies the subscription within its unit, lower snake_case. It
+	// keys the consumer group the core builds for it, so it is stable
+	// FOREVER for a given unit: renaming one starts a fresh group, which
+	// re-reads the stream's retained history from the beginning.
+	Name string
+
+	// Events are the event types this subscription wants, spelled in full —
+	// `activity.archived`, `ext_notes.note_added`. A type the installation
+	// cannot route is refused at boot rather than silently never delivered.
+	//
+	// A unit may name any routable type, its own or the product's. What a unit
+	// learns from one is an id and a verb; reading the record behind it is
+	// bounded by the capabilities the unit already holds.
+	Events []string
+
+	// Handle is the behavior. A nil Handle is the same as no entry at all, so
+	// a unit with nothing to run declares no Subscription rather than one
+	// holding nil — and the core says so at boot rather than registering a
+	// group that acks every delivery into nothing.
+	Handle EventHandler
+}
+
+// Validate enforces everything about a subscription that must hold wherever it
+// is read, and nothing about the EVENTS' routability: whether a type exists is
+// a question only the core can answer (the catalog is not reachable from this
+// package), so it is asked at registration, exactly as a job's tier is.
+func (s Subscription) Validate() error {
+	if err := s.ValidateDeclaration(); err != nil {
+		return err
+	}
+	if s.Handle == nil {
+		return fmt.Errorf("subscription %q has no handler — declare nothing rather than a subscription that acks every delivery into nothing", s.Name)
+	}
+	return nil
+}
+
+// ValidateDeclaration is Validate minus the handler check: the part a STATIC
+// reader can decide.
+//
+// It exists because the manifest generator derives a unit's subscriptions from
+// the source without compiling it, so the one thing it can never see is whether
+// Handle is nil — and the alternative to this split is a generator that
+// re-implements the name and event rules, which is how gen-time acceptance
+// drifts from boot-time.
+func (s Subscription) ValidateDeclaration() error {
+	if !toolNameGrammar.MatchString(s.Name) {
+		return fmt.Errorf("subscription name %q is not a valid subscription name (lower snake_case, e.g. withdraw_filing)", s.Name)
+	}
+	if len(s.Events) == 0 {
+		return fmt.Errorf("subscription %q names no events — a subscription to nothing is a consumer group that never delivers", s.Name)
+	}
+	seen := make(map[string]bool, len(s.Events))
+	for _, e := range s.Events {
+		if e == "" {
+			return fmt.Errorf("subscription %q names an empty event type", s.Name)
+		}
+		if seen[e] {
+			return fmt.Errorf("subscription %q names %q twice", s.Name, e)
+		}
+		seen[e] = true
+	}
+	return nil
+}

--- a/backend/pkg/extension/subscription.go
+++ b/backend/pkg/extension/subscription.go
@@ -87,8 +87,10 @@ type Delivery struct {
 // fix.
 type EventHandler func(ctx context.Context, rt Runtime, d Delivery) error
 
-// Subscription is the BEHAVIOR half of one thing a unit listens for: which
-// events, and the Go function that runs when one arrives.
+// Subscription is one thing a unit listens for: which events, and the Go
+// function that runs when one arrives. Unlike a Tool or a Job it is BOTH halves
+// in one value — there is no contract fragment to carry the declaration, so the
+// event list and the behavior are declared together (see Extension).
 //
 // The event list is DECLARED rather than filtered in code, and that is a
 // governance property rather than a convenience: it is derived into the unit's
@@ -103,7 +105,14 @@ type Subscription struct {
 
 	// Events are the event types this subscription wants, spelled in full —
 	// `activity.archived`, `ext_notes.note_added`. A type the installation
-	// cannot route is refused at boot rather than silently never delivered.
+	// cannot ROUTE is refused at boot rather than silently never delivered.
+	//
+	// Routable is not the same as real, and the difference is worth knowing
+	// before a debugging session: a core type is checked against the catalog,
+	// so a typo in one is refused; an extension type is checked against its
+	// grammar, so `ext_notse.note_added` boots clean and simply never arrives.
+	// Nothing declares which verbs a unit publishes, so nothing can check the
+	// right-hand side of one.
 	//
 	// A unit may name any routable type, its own or the product's. What a unit
 	// learns from one is an id and a verb; reading the record behind it is

--- a/backend/pkg/extension/subscription_test.go
+++ b/backend/pkg/extension/subscription_test.go
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package extension
+
+import (
+	"context"
+	"testing"
+)
+
+func noopDelivery(context.Context, Runtime, Delivery) error { return nil }
+
+func TestSubscriptionValidateAcceptsADeclaredListener(t *testing.T) {
+	s := Subscription{
+		Name:   "withdraw_filing",
+		Events: []string{"activity.archived", "ext_notes.note_added"},
+		Handle: noopDelivery,
+	}
+	if err := s.Validate(); err != nil {
+		t.Fatalf("a well-formed subscription was refused: %v", err)
+	}
+}
+
+func TestSubscriptionValidateRefusesADeclarationNothingCouldServe(t *testing.T) {
+	for name, s := range map[string]Subscription{
+		"a name that is not lower snake_case": {
+			Name: "WithdrawFiling", Events: []string{"activity.archived"}, Handle: noopDelivery,
+		},
+		"no name": {Events: []string{"activity.archived"}, Handle: noopDelivery},
+		// A consumer group that never delivers is worse than no group: it is
+		// created, it holds a cursor, and it looks like a working subscription.
+		"no events": {Name: "withdraw_filing", Handle: noopDelivery},
+		"an empty event type": {
+			Name: "withdraw_filing", Events: []string{""}, Handle: noopDelivery,
+		},
+		"the same event twice": {
+			Name:   "withdraw_filing",
+			Events: []string{"activity.archived", "activity.archived"},
+			Handle: noopDelivery,
+		},
+		// Registering this would ack every delivery into nothing, which reads
+		// exactly like a handler that decided to ignore them.
+		"no handler": {Name: "withdraw_filing", Events: []string{"activity.archived"}},
+	} {
+		if err := s.Validate(); err == nil {
+			t.Errorf("Subscription.Validate accepted %s", name)
+		}
+	}
+}
+
+// Validate says nothing about whether a type is ROUTABLE. It cannot: the
+// catalog lives in the core, which this package may not import — so the check
+// is the registration's, exactly as a job's tier refusal is the serving side's.
+func TestSubscriptionValidateDoesNotJudgeEventTypes(t *testing.T) {
+	s := Subscription{
+		Name:   "listens_for_nothing_real",
+		Events: []string{"invoice.created"},
+		Handle: noopDelivery,
+	}
+	if err := s.Validate(); err != nil {
+		t.Fatalf("Validate refused an unroutable type; that judgment belongs to registration: %v", err)
+	}
+}

--- a/backend/tools/gen-composition/astreader.go
+++ b/backend/tools/gen-composition/astreader.go
@@ -264,6 +264,7 @@ func (r *unitReader) readExtension(fn *ast.FuncDecl, file *ast.File) (unitManife
 		}
 		return m.Secrets[i].Scope < m.Secrets[j].Scope
 	})
+	sort.Slice(m.Subscriptions, func(i, j int) bool { return m.Subscriptions[i].Name < m.Subscriptions[j].Name })
 	return m, nil
 }
 
@@ -335,6 +336,12 @@ func (r *unitReader) readExtensionField(elt ast.Expr, file *ast.File, m *unitMan
 		secrets, err = r.readSecrets(kv.Value, file)
 		if err == nil {
 			m.Secrets = append(m.Secrets, secrets...)
+		}
+	case "Subscriptions":
+		var subs []subscriptionRequest
+		subs, err = r.readSubscriptions(kv.Value, file)
+		if err == nil {
+			m.Subscriptions = append(m.Subscriptions, subs...)
 		}
 	default:
 		// Fail closed: a field this generator does not recognize could be a

--- a/backend/tools/gen-composition/astreader_subscriptions.go
+++ b/backend/tools/gen-composition/astreader_subscriptions.go
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package main
+
+import (
+	"go/ast"
+	"sort"
+
+	"github.com/gradionhq/margince/backend/pkg/extension"
+)
+
+// readSubscriptions reads a Subscriptions field's slice literal into the
+// manifest's declared listeners.
+//
+// What reaches the manifest is the NAME and the EVENT TYPES, never the handler:
+// the behavior is a function, which no static reader can describe, and the
+// thing an operator needs to see is which of the installation's facts a unit
+// consumes. That list is the whole governance surface of a subscription — there
+// is no tier and no scope to resolve — so a manifest carrying it says
+// everything there is to say about the request.
+func (r *unitReader) readSubscriptions(expr ast.Expr, file *ast.File) ([]subscriptionRequest, error) {
+	lit, ok := expr.(*ast.CompositeLit)
+	if !ok {
+		return nil, r.errAt(expr, "Subscriptions must be a slice literal")
+	}
+	ext := importAlias(file, extensionPkgPath)
+	out := make([]subscriptionRequest, 0, len(lit.Elts))
+	seen := map[string]bool{}
+	for _, elt := range lit.Elts {
+		sub, err := r.readSubscription(elt, ext)
+		if err != nil {
+			return nil, err
+		}
+		if seen[sub.Name] {
+			return nil, r.errAt(elt, "subscription %q declared twice", sub.Name)
+		}
+		seen[sub.Name] = true
+		out = append(out, sub)
+	}
+	return out, nil
+}
+
+// readSubscription reads one extension.Subscription literal and validates it
+// through the same published grammar the boot preflight runs (see
+// extension.Subscription.Validate), so gen-time acceptance cannot diverge from
+// boot-time.
+//
+// Handle is RECOGNIZED and skipped, exactly as a Tool's is: it is the behavior
+// half, and a manifest describing a function would be describing something it
+// cannot read.
+func (r *unitReader) readSubscription(elt ast.Expr, ext string) (subscriptionRequest, error) {
+	lit, ok := elt.(*ast.CompositeLit)
+	if !ok || (lit.Type != nil && !isSelector(lit.Type, ext, "Subscription")) {
+		return subscriptionRequest{}, r.errAt(elt, "a Subscriptions entry must be an extension.Subscription literal")
+	}
+	var sub subscriptionRequest
+	for _, e := range lit.Elts {
+		kv, ok := e.(*ast.KeyValueExpr)
+		if !ok {
+			return subscriptionRequest{}, r.errAt(e, "Subscription fields must be keyed")
+		}
+		k, ok := kv.Key.(*ast.Ident)
+		if !ok {
+			return subscriptionRequest{}, r.errAt(kv.Key, "Subscription fields must be keyed by name")
+		}
+		var err error
+		switch k.Name {
+		case "Name":
+			sub.Name, err = r.stringLit(kv.Value, "Subscription.Name")
+		case "Events":
+			sub.Events, err = r.readEventTypes(kv.Value)
+		case "Handle":
+			// The behavior half. Present in the source, absent from the
+			// manifest, by the same rule that keeps a Tool's handler out.
+		default:
+			err = r.errAt(kv, "Subscription field %s is not derivable by this generator", k.Name)
+		}
+		if err != nil {
+			return subscriptionRequest{}, err
+		}
+	}
+	// The published rules, run here rather than restated: the declaration half
+	// of Validate is exactly what a static reader can decide, and whether
+	// Handle is nil is left to the boot, which is the only place it is
+	// observable at all.
+	declared := extension.Subscription{Name: sub.Name, Events: sub.Events}
+	if err := declared.ValidateDeclaration(); err != nil {
+		return subscriptionRequest{}, r.errPos(lit, "%v", err)
+	}
+	sort.Strings(sub.Events)
+	return sub, nil
+}
+
+// readEventTypes reads the Events slice literal — plain string literals, like
+// every other value this generator derives, because the manifest is read
+// without compiling or executing the unit.
+func (r *unitReader) readEventTypes(expr ast.Expr) ([]string, error) {
+	lit, ok := expr.(*ast.CompositeLit)
+	if !ok {
+		return nil, r.errAt(expr, "Subscription.Events must be a slice literal")
+	}
+	out := make([]string, 0, len(lit.Elts))
+	for _, elt := range lit.Elts {
+		typ, err := r.stringLit(elt, "Subscription.Events entry")
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, typ)
+	}
+	return out, nil
+}

--- a/backend/tools/gen-composition/astreader_subscriptions_test.go
+++ b/backend/tools/gen-composition/astreader_subscriptions_test.go
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// subscriptionsUnitSource is a unit declaring the given Subscriptions slice
+// elements.
+func subscriptionsUnitSource(entries string) string {
+	return `package x
+
+import (
+	"context"
+
+	"github.com/gradionhq/margince/backend/pkg/extension"
+)
+
+func react(context.Context, extension.Runtime, extension.Delivery) error { return nil }
+
+func New() extension.Extension {
+	return extension.Extension{
+		Name:    "x",
+		Version: "0.1.0",
+		Subscriptions: []extension.Subscription{
+` + entries + `
+		},
+	}
+}
+`
+}
+
+// TestSubscriptionsDeriveIntoManifest: what an operator needs from a listener
+// is its REACH — which of the installation's facts the unit consumes — so the
+// name and the event types derive, sorted, and the handler does not.
+func TestSubscriptionsDeriveIntoManifest(t *testing.T) {
+	src := subscriptionsUnitSource(
+		"\t\t\t{Name: \"withdraw_filing\", Events: []string{\"person.archived\", \"activity.archived\"}, Handle: react},\n" +
+			"\t\t\t{Name: \"another_listener\", Events: []string{\"deal.created\"}, Handle: react},\n")
+	derived, err := deriveSynthetic(t, "x", src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(derived)
+	for _, want := range []string{
+		`"name": "withdraw_filing"`, `"activity.archived"`, `"person.archived"`,
+		`"name": "another_listener"`, `"deal.created"`,
+	} {
+		if !strings.Contains(s, want) {
+			t.Errorf("derived manifest misses %s:\n%s", want, s)
+		}
+	}
+	if strings.Index(s, "another_listener") > strings.Index(s, "withdraw_filing") {
+		t.Errorf("subscriptions are not sorted by name:\n%s", s)
+	}
+	if strings.Index(s, "activity.archived") > strings.Index(s, "person.archived") {
+		t.Errorf("event types are not sorted:\n%s", s)
+	}
+	if strings.Contains(s, "react") || strings.Contains(s, "Handle") {
+		t.Errorf("the handler reached the manifest, which is read without compiling the unit:\n%s", s)
+	}
+}
+
+// TestNoSubscriptionsOmitsTheField: every manifest already committed to the
+// tree predates this field, so an unconditional key would rewrite all of them
+// for something they do not declare.
+func TestNoSubscriptionsOmitsTheField(t *testing.T) {
+	derived, err := deriveSynthetic(t, "x", toolUnitSource("\t\t\tName: \"t\","),
+		syntheticVerb("x", "t", "auto_execute", "read"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(derived), "subscription") {
+		t.Fatalf("the subscriptions field must be omitted when nothing is declared:\n%s", derived)
+	}
+}
+
+// TestDuplicateSubscriptionIsRejected: two listeners of one name would key one
+// consumer group twice, and the manifest could only show one of them.
+func TestDuplicateSubscriptionIsRejected(t *testing.T) {
+	src := subscriptionsUnitSource(
+		"\t\t\t{Name: \"withdraw_filing\", Events: []string{\"activity.archived\"}, Handle: react},\n" +
+			"\t\t\t{Name: \"withdraw_filing\", Events: []string{\"person.archived\"}, Handle: react},\n")
+	_, err := deriveSynthetic(t, "x", src)
+	if err == nil || !strings.Contains(err.Error(), "declared twice") {
+		t.Fatalf("err = %v, want the duplicate-subscription refusal", err)
+	}
+}
+
+// TestSubscriptionRulesAreThePublishedOnes pins that the generator refuses
+// through extension.Subscription's own declaration rules rather than a second
+// copy of them — gen-time acceptance cannot diverge from boot-time.
+func TestSubscriptionRulesAreThePublishedOnes(t *testing.T) {
+	for name, entry := range map[string]string{
+		"a name that is not lower snake_case": "\t\t\t{Name: \"WithdrawFiling\", Events: []string{\"activity.archived\"}, Handle: react},\n",
+		"no events at all":                    "\t\t\t{Name: \"withdraw_filing\", Events: []string{}, Handle: react},\n",
+		"the same event twice":                "\t\t\t{Name: \"withdraw_filing\", Events: []string{\"activity.archived\", \"activity.archived\"}, Handle: react},\n",
+	} {
+		if _, err := deriveSynthetic(t, "x", subscriptionsUnitSource(entry)); err == nil {
+			t.Errorf("the generator accepted %s", name)
+		}
+	}
+}
+
+// TestSubscriptionsFieldMustBeASliceLiteral: a computed Subscriptions value
+// cannot be derived without evaluating it, which a static reader must not do.
+func TestSubscriptionsFieldMustBeASliceLiteral(t *testing.T) {
+	src := `package x
+
+import "github.com/gradionhq/margince/backend/pkg/extension"
+
+func subs() []extension.Subscription { return nil }
+
+func New() extension.Extension {
+	return extension.Extension{Name: "x", Version: "0.1.0", Subscriptions: subs()}
+}
+`
+	_, err := deriveSynthetic(t, "x", src)
+	if err == nil || !strings.Contains(err.Error(), "Subscriptions must be a slice literal") {
+		t.Fatalf("err = %v, want the non-literal-Subscriptions refusal", err)
+	}
+}
+
+// TestSubscriptionEventsMustBeStringLiterals: an event type resolved from a
+// constant or a call is one the manifest reader cannot see, and a listener
+// whose reach is invisible is the thing this field exists to prevent.
+func TestSubscriptionEventsMustBeStringLiterals(t *testing.T) {
+	src := subscriptionsUnitSource(
+		"\t\t\t{Name: \"withdraw_filing\", Events: []string{archivedEvent}, Handle: react},\n") +
+		"\nconst archivedEvent = \"activity.archived\"\n"
+	_, err := deriveSynthetic(t, "x", src)
+	if err == nil {
+		t.Fatal("the generator derived an event type it could not read as a literal")
+	}
+}
+
+// TestSubscriptionEntryUnrecognizedFieldFailsClosed mirrors every other
+// declaration reader's default: a field this generator does not know could be
+// a future part of the request, and omitting it would hide it.
+func TestSubscriptionEntryUnrecognizedFieldFailsClosed(t *testing.T) {
+	src := subscriptionsUnitSource(
+		"\t\t\t{Name: \"withdraw_filing\", Events: []string{\"activity.archived\"}, Handle: react, Future: nil},\n")
+	_, err := deriveSynthetic(t, "x", src)
+	if err == nil || !strings.Contains(err.Error(), "is not derivable by this generator") {
+		t.Fatalf("err = %v, want the unrecognized-field refusal", err)
+	}
+}
+
+// TestSubscriptionEntryMustBeKeyed and the wrong-literal case mirror the same
+// two refusals every other entry reader in this generator applies.
+func TestSubscriptionEntryMustBeKeyed(t *testing.T) {
+	src := subscriptionsUnitSource("\t\t\t{\"withdraw_filing\", []string{\"activity.archived\"}, react},\n")
+	_, err := deriveSynthetic(t, "x", src)
+	if err == nil || !strings.Contains(err.Error(), "must be keyed") {
+		t.Fatalf("err = %v, want the must-be-keyed refusal", err)
+	}
+}
+
+func TestSubscriptionEntryMustBeASubscriptionLiteral(t *testing.T) {
+	src := subscriptionsUnitSource("\t\t\textension.Tool{Name: \"t\"},\n")
+	_, err := deriveSynthetic(t, "x", src)
+	if err == nil || !strings.Contains(err.Error(), "must be an extension.Subscription literal") {
+		t.Fatalf("err = %v, want the wrong-literal-type refusal", err)
+	}
+}

--- a/backend/tools/gen-composition/unitmanifest.go
+++ b/backend/tools/gen-composition/unitmanifest.go
@@ -60,6 +60,14 @@ type unitManifest struct {
 	// the tree predates this field, so an unconditional key would rewrite
 	// every one of them for a field they do not use.
 	Secrets []secretsRequest `json:"secrets,omitempty"`
+
+	// Subscriptions are the events the unit listens for (see
+	// extension.Subscription). They carry no tier and no scope — a listener has
+	// nothing an operator RESOLVES — so they sit apart from RiskTiers, and what
+	// they record is REACH: which of the installation's facts this unit
+	// consumes, readable without opening its source. omitempty for the reason
+	// Secrets has it: every manifest already in the tree predates the field.
+	Subscriptions []subscriptionRequest `json:"subscriptions,omitempty"`
 }
 
 // secretsRequest is one declared secret key and scope (see
@@ -68,6 +76,15 @@ type unitManifest struct {
 type secretsRequest struct {
 	Key   string `json:"key"`
 	Scope string `json:"scope"`
+}
+
+// subscriptionRequest is one declared listener: its name and the event types it
+// wants, both sorted so the encoding does not depend on declaration order. The
+// handler is absent by design — it is behavior, and this file is read without
+// compiling the unit.
+type subscriptionRequest struct {
+	Name   string   `json:"name"`
+	Events []string `json:"events"`
 }
 
 // riskTierRequest is one governed operation and the risk tier it requests,

--- a/docs/explanation/extensibility.md
+++ b/docs/explanation/extensibility.md
@@ -207,9 +207,12 @@ Validate-then-apply makes "partially registered extension" a state the system ca
 
 ## What an extension can do today — and how that grows
 
-**Today: two capability kinds.** A **jurisdiction pack** supplies *country-specific policy the core
-consults; it is never an actor* — it exposes no governed operation, so it never appears in the unit
-manifest. An **agent tool** (`extension.Tool`) is the first *governed* kind: it derives a risk-tier
+**The kinds, and which of them an operator resolves.** A **jurisdiction pack** supplies
+*country-specific policy the core consults; it is never an actor* — it exposes no governed operation,
+so it never appears in the unit manifest. A **scheduled job** and a **subscription** are the two that
+run with nobody behind them; a subscription's manifest entry records its REACH (which event types it
+consumes) rather than a tier, because there is nothing about a listener for an operator to resolve. An
+**agent tool** (`extension.Tool`) is the *governed* kind proper: it derives a risk-tier
 request into `manifest.generated.json` for operator resolution (§7), and a tool declaring a `Handle`
 **is served** — `buildExtensionTools` adapts it to the core `mcp.Tool` seam and boot registers it into
 the same `agents.Registry`, admission gate, and tool listing the core tools ride (`extensions/yogi` is
@@ -265,6 +268,21 @@ validated to the full identifier budget, so a name chosen today stays valid for 
   workspace child per live tenant.
 - **Its own secret namespace** — reached through `Runtime.Secrets()`, keyed by the unit's own bare names.
 - **Its own RBAC objects** — `ext_<name>_*`, registered into the vocabulary `/me` serves.
+- **Its own history and its own events** — `tx.Record(change, event)` writes the ledger row AND the
+  outbox event for a write to the unit's own tables, in the caller's transaction. One call, both
+  halves, always: it is the product's own write shape (domain row + audit row + outbox event, one
+  transaction) offered to a unit in a form that cannot be half-used — an event with no ledger row is
+  unauditable, and a ledger row with no event is a change nothing downstream is told about, which the
+  core grants itself no exemption from either. The type on the bus is `ext_<namespace>.<verb>` — the
+  core prefixes the namespace from the invocation, so a unit can publish neither under another unit's
+  name nor inside a core family — and every extension event rides one stream,
+  `gw:events:crm:extension`, which no core consumer group carries.
+- **Its own reactions** — a `Subscription` names the event types the unit listens for (a core type or
+  another unit's) and the function one delivery runs. Each gets its own consumer group,
+  `cg:ext-<unit>-<subscription>`, started in the worker role. A delivery has **nobody** behind it: the
+  caller is the zero `Caller` and `tx.Core()` refuses, while the unit's own tables stay writable,
+  auditable and publishable. The declared type list derives into `manifest.generated.json`, so which
+  of the installation's facts a unit consumes is readable without opening its source.
 
 - **Its own frontend** — a `frontend/` directory whose screen is aliased into the SPA and rendered at
   the unit's route. Removing a unit is a one-place operation again: delete the unit directory. An
@@ -322,7 +340,11 @@ The tier is defended by fitness tests and scripts, so the guarantees can't rot i
 | Every unit table grants the runtime role exactly `SELECT, INSERT, UPDATE, DELETE` — a table granting *nothing* satisfied the old one-sided allowlist and then answered `permission denied` at the first call | `make check-ext-migrations` |
 | A unit's SQL names only that unit's own `ext.ext_<name>_…` tables — the mistake-defence half of the shared-role reach described above, reading through the string constants a table name is spelled with | `backend/extensionsqlscope_test.go` |
 | A unit's write to a CORE record goes through the product's own write path — the caller's live RBAC, the row-scope check on the subject, the audit row, the outbox event — and carries the unit's attribution under a core-stamped evidence member no caller may supply | `extension.Tx.Core()` (`internal/compose/extcore.go`), `storekit.withExtensionAttribution` |
-| A scheduled tick writes no core record at all: it runs as the unit with no caller, and a core write is checked against the caller's own permissions | `internal/compose/extcore.go` (`admit`) |
+| A scheduled tick and a bus delivery write no core record at all: both run with no caller, and a core write is checked against the caller's own permissions | `internal/compose/extcore.go` (`refuseUnattended`), `extsubscribe_test.go`, `extledger_integration_test.go` |
+| A unit's ledger row names a table in that unit's own namespace, and its event a verb in that unit's own namespace — the namespace comes from the invocation, so neither is a string a unit can spell | `internal/compose/extledger.go`, `extledger_test.go` |
+| A unit's own write records BOTH its ledger row and its event, or neither — the same write shape the core holds itself to, in one call that cannot be half-made | `extension.Tx.Record`, `backend/writeshape_test.go`, `extledger_integration_test.go` |
+| A unit's listener consumes only the streams its declared event types route to, and no core group consumes the extension stream | `internal/compose/extsubscribe.go`, `internal/shared/kernel/events/extensiontypes_test.go` |
+| A subscription naming an event type nothing can route is refused at boot, rather than registering a consumer group that never delivers | `internal/compose/extensions.go` (`preflightSubscriptions`) |
 | A core write is refused in an overlay workspace rather than landing in a native table nothing reads, resolved FRESH per write | `internal/compose/extcore.go` (`admit` → `overlayModeOf`) |
 | A unit's shipped `migrations/` is actually embedded and applied — the directory and the field are two facts, and the gates read different ones | `backend/tools/gen-composition` (the `Migrations` field must name a var whose `//go:embed` covers the layer) |
 | The runtime pool is not the migration owner: no superuser, no BYPASSRLS, and no ownership of the `ext` schema *or* anything in it | `compose.AssertRuntimeRole`, at boot and on `/readyz` |

--- a/docs/explanation/extensibility.md
+++ b/docs/explanation/extensibility.md
@@ -268,12 +268,14 @@ validated to the full identifier budget, so a name chosen today stays valid for 
   workspace child per live tenant.
 - **Its own secret namespace** — reached through `Runtime.Secrets()`, keyed by the unit's own bare names.
 - **Its own RBAC objects** — `ext_<name>_*`, registered into the vocabulary `/me` serves.
-- **Its own history and its own events** — `tx.Record(change, event)` writes the ledger row AND the
-  outbox event for a write to the unit's own tables, in the caller's transaction. One call, both
+- **Its own history and its own events** — `tx.Record(ctx, change, event)` writes the ledger row AND
+  the outbox event for a write to the unit's own tables, in the caller's transaction. One call, both
   halves, always: it is the product's own write shape (domain row + audit row + outbox event, one
   transaction) offered to a unit in a form that cannot be half-used — an event with no ledger row is
   unauditable, and a ledger row with no event is a change nothing downstream is told about, which the
-  core grants itself no exemption from either. The type on the bus is `ext_<namespace>.<verb>` — the
+  core grants itself no exemption from either. It is OFFERED rather than enforced: the three SQL
+  verbs still write whatever a unit tells them to, and a write made through `Exec` alone records
+  nothing, which is a choice a unit makes (`extensions/notes/heartbeat.go` makes it, and says why). The type on the bus is `ext_<namespace>.<verb>` — the
   core prefixes the namespace from the invocation, so a unit can publish neither under another unit's
   name nor inside a core family — and every extension event rides one stream,
   `gw:events:crm:extension`, which no core consumer group carries.

--- a/extensions/notes/fake_test.go
+++ b/extensions/notes/fake_test.go
@@ -119,6 +119,15 @@ type fakeTx struct {
 	// lastRows is the cursor Query handed the handler, kept so a test can ask
 	// whether the handler closed it.
 	lastRows *fakeRows
+
+	// audited and published are what the handler recorded about its own write.
+	// recordErr is their own error script rather than failFrom's, because a
+	// ledger write is not a statement this fake counts — and because "the
+	// record failed" and "the third statement failed" are different failures a
+	// handler must propagate from different places.
+	audited   []extension.Change
+	published []extension.Event
+	recordErr error
 }
 
 func (t *fakeTx) record(sql string, args []any) {
@@ -130,6 +139,31 @@ func (t *fakeTx) record(sql string, args []any) {
 // file, which is the accurate answer for those: a handler that reached for the
 // core port when the test did not expect one panics rather than passing.
 func (t *fakeTx) Core() extension.Core { return t.core }
+
+// Record records the ledger row and the event a handler asked for.
+//
+// It runs the PUBLISHED Validate on both halves rather than accepting whatever
+// it is given, because that is the part of the real port a unit's own suite can
+// and should feel: an entity outside this unit's namespace, an id that is not a
+// UUID, an image that is not JSON, a verb that is not a verb are all refusals
+// the core would make, and a fake that waved them through would let a handler
+// ship a call the real port rejects. What it deliberately does NOT model is the
+// core's half — the actor, the workspace, the attribution, the namespace the
+// event type is built from — which is tested where it lives.
+func (t *fakeTx) Record(_ context.Context, ch extension.Change, ev extension.Event) error {
+	if err := ch.Validate(); err != nil {
+		return err
+	}
+	if err := ev.Validate(); err != nil {
+		return err
+	}
+	if t.recordErr != nil {
+		return t.recordErr
+	}
+	t.audited = append(t.audited, ch)
+	t.published = append(t.published, ev)
+	return nil
+}
 
 // fakeCore is the governed port as a filing test needs it: it records what the
 // unit asked the core to write, and answers with what the test scripted.

--- a/extensions/notes/fake_test.go
+++ b/extensions/notes/fake_test.go
@@ -105,8 +105,15 @@ type fakeTx struct {
 	statements []string
 	args       [][]any
 
-	core     *fakeCore
-	rows     [][]any // what Query hands back, one slice per row
+	core *fakeCore
+	// rows is what the NEXT Query hands back, one slice per row, and it is
+	// CONSUMED by that call. A second Query in the same test therefore matches
+	// nothing — which is what the database does to the statement these rows
+	// stand in for: `UPDATE … WHERE filed_activity_id = $1 RETURNING` returns
+	// its rows once and never again, because the first run is what stopped them
+	// matching. A fake that answered the same rows forever could not tell a
+	// handler that is idempotent from one that is not.
+	rows [][]any
 	row      []any   // what QueryRow scans into dest
 	affected int64
 	err      error
@@ -207,6 +214,7 @@ func (t *fakeTx) Query(_ context.Context, sql string, args ...any) (extension.Ro
 		return nil, err
 	}
 	t.lastRows = &fakeRows{rows: t.rows}
+	t.rows = nil
 	return t.lastRows, nil
 }
 

--- a/extensions/notes/filing.go
+++ b/extensions/notes/filing.go
@@ -79,7 +79,29 @@ func fileNote(ctx context.Context, rt extension.Runtime, in json.RawMessage) (js
 			`INSERT INTO `+noteTable+` (workspace_id, kind, body, author_user_id, author_is_agent, filed_activity_id)
 			 VALUES (`+callerWorkspace+`, $1, $2, $3::uuid, $4::boolean, $5::uuid)
 			 RETURNING `+noteColumns, string(kindNote), body, authorID, authorIsAgent, filed.Id).Scan)
-		return scanErr
+		if scanErr != nil {
+			return scanErr
+		}
+		// The note's OWN ledger row, beside the activity's. The port wrote one
+		// for the activity above — that record's history belongs to the core —
+		// and this is the notepad's: one write recorded once on each side of
+		// the seam, so either can be read without the other.
+		//
+		// The RECORD the note was filed to rides in the evidence rather than
+		// the image, because the note's own columns say which ACTIVITY it
+		// reached and not which record that activity sits on.
+		detail, err := json.Marshal(struct {
+			SubjectType string `json:"subject_type"`
+			SubjectID   string `json:"subject_id"`
+		}{SubjectType: args.SubjectType, SubjectID: args.SubjectID})
+		if err != nil {
+			return err
+		}
+		payload, err := notePayload(n)
+		if err != nil {
+			return err
+		}
+		return recordNote(ctx, tx, extension.AuditCreate, eventNoteFiled, nil, &n, detail, payload)
 	})
 	if err != nil {
 		return nil, filingRefusal(err)

--- a/extensions/notes/filing_test.go
+++ b/extensions/notes/filing_test.go
@@ -88,6 +88,33 @@ func TestFilingWritesTheNoteAndTheActivityTogether(t *testing.T) {
 	}
 }
 
+// TestAFilingRecordsBothHistories: the port wrote the ACTIVITY's ledger row —
+// that record's history is the core's — and this asserts the other half, the
+// notepad's own, which no core write could have made because no core code knows
+// this table exists. The record the note reached rides in the evidence, because
+// the note's own columns name the activity and not what it sits on.
+func TestAFilingRecordsBothHistories(t *testing.T) {
+	rt := filingRuntime()
+	if _, err := fileOne(t, rt, "a filed note"); err != nil {
+		t.Fatalf("fileNote: %v", err)
+	}
+	if len(rt.tx.audited) != 1 {
+		t.Fatalf("the filing recorded %d ledger rows of its own, want 1", len(rt.tx.audited))
+	}
+	change := rt.tx.audited[0]
+	if change.Action != extension.AuditCreate || change.Entity != noteEntity {
+		t.Errorf("recorded %s on %s, want a create of %s", change.Action, change.Entity, noteEntity)
+	}
+	for _, want := range []string{"person", subjectID} {
+		if !strings.Contains(string(change.Detail), want) {
+			t.Errorf("the evidence does not name the record the note was filed to (%q): %s", want, change.Detail)
+		}
+	}
+	if len(rt.tx.published) != 1 || rt.tx.published[0].Verb != eventNoteFiled {
+		t.Errorf("published %v, want one %s", rt.tx.published, eventNoteFiled)
+	}
+}
+
 // The activity is written FIRST, so a refused core write leaves no note behind
 // — the whole point of one transaction, asserted on the half that would
 // otherwise be silent.

--- a/extensions/notes/frontend/i18n/de.json
+++ b/extensions/notes/frontend/i18n/de.json
@@ -15,6 +15,7 @@
   "extNotes.notes.addFailed": "Das Hinzufügen der Notiz ist fehlgeschlagen. Ob sie gespeichert wurde, ist offen — prüfen Sie die Liste unten, bevor Sie sie erneut hinzufügen.",
   "extNotes.notes.bodyLabel": "Neue Notiz",
   "extNotes.notes.empty": "Noch keine Notizen.",
+  "extNotes.notes.filed": "Abgelegt",
   "extNotes.notes.noGrant": "Sie haben keinen Lesezugriff auf die Notizen dieser Erweiterung.",
   "extNotes.notes.remove": "Entfernen",
   "extNotes.notes.removeFailed": "Das Entfernen der Notiz ist fehlgeschlagen. Prüfen Sie die Liste unten.",

--- a/extensions/notes/frontend/i18n/en.json
+++ b/extensions/notes/frontend/i18n/en.json
@@ -15,6 +15,7 @@
   "extNotes.notes.addFailed": "The note was not added. Nothing was changed.",
   "extNotes.notes.bodyLabel": "New note",
   "extNotes.notes.empty": "No notes yet.",
+  "extNotes.notes.filed": "Filed",
   "extNotes.notes.noGrant": "You do not hold read access to this extension's notes.",
   "extNotes.notes.remove": "Remove",
   "extNotes.notes.removeFailed": "The note was not removed. Nothing was changed.",

--- a/extensions/notes/frontend/i18n/vi.json
+++ b/extensions/notes/frontend/i18n/vi.json
@@ -15,6 +15,7 @@
   "extNotes.notes.addFailed": "Thêm ghi chú thất bại. Chưa rõ ghi chú đã được lưu hay chưa — hãy kiểm tra danh sách bên dưới trước khi thêm lại.",
   "extNotes.notes.bodyLabel": "Ghi chú mới",
   "extNotes.notes.empty": "Chưa có ghi chú nào.",
+  "extNotes.notes.filed": "Đã lưu hồ sơ",
   "extNotes.notes.noGrant": "Bạn không có quyền đọc ghi chú của tiện ích mở rộng này.",
   "extNotes.notes.remove": "Xóa",
   "extNotes.notes.removeFailed": "Xóa ghi chú thất bại. Hãy kiểm tra danh sách bên dưới.",

--- a/extensions/notes/frontend/screen.test.tsx
+++ b/extensions/notes/frontend/screen.test.tsx
@@ -175,6 +175,39 @@ describe("the Demo Notepad screen", () => {
     expect(screen.getByText(/heartbeat — tick #7/)).toBeTruthy();
   });
 
+  it("marks a note as filed only while the row still names an activity", async () => {
+    // The badge is read from the ROW, which is what makes it survivable: a
+    // filing is withdrawn when the activity is archived on the timeline —
+    // nowhere near this screen — and the unit's subscription clears the
+    // column. A badge this component remembered would go on claiming a filing
+    // the notepad no longer has.
+    const { fetchStub } = stubTransport(FULL_GRANT, {
+      "/ext/notes/list": () => ({
+        notes: [
+          {
+            id: "11111111-1111-4111-8111-111111111111",
+            body: "still filed",
+            filed_activity_id: "3f2504e0-4f89-41d3-9a0c-0305e82c3301",
+            created_at: "2026-08-09T09:14:00Z",
+          },
+          {
+            id: "22222222-2222-4222-8222-222222222222",
+            body: "filing withdrawn",
+            created_at: "2026-08-09T09:10:00Z",
+          },
+        ],
+      }),
+      "/ext/notes/signing-key/status": () => ({ stored: false }),
+    });
+    vi.stubGlobal("fetch", vi.fn(fetchStub));
+
+    renderScreen();
+    const filedRow = (await screen.findByText(/still filed/)).closest("li");
+    expect(filedRow?.textContent).toContain("Filed");
+    const withdrawnRow = screen.getByText(/filing withdrawn/).closest("li");
+    expect(withdrawnRow?.textContent).not.toContain("Filed");
+  });
+
   it("reports the signing key as absent, then present, without ever showing it", async () => {
     let stored = false;
     const { fetchStub, calls } = stubTransport(FULL_GRANT, {

--- a/extensions/notes/frontend/screen.tsx
+++ b/extensions/notes/frontend/screen.tsx
@@ -613,6 +613,14 @@ function NotesCard() {
             {notes.data?.map((item) => (
               <li key={item.id}>
                 {formatDateTime(item.created_at, locale, zone)} — {item.body}
+                {/* The filing, as the ROW reports it rather than as this screen
+                    remembers it. A note stops being filed when the activity it
+                    reached is archived — which happens on the timeline, not
+                    here, and reaches this unit through its subscription — so
+                    the column is the only rendering that stays true. */}
+                {item.filed_activity_id ? (
+                  <Badge tone="success">{t("extNotes.notes.filed")}</Badge>
+                ) : null}
                 {canRemove ? (
                   <Button
                     variant="ghost"

--- a/extensions/notes/frontend/screen.tsx
+++ b/extensions/notes/frontend/screen.tsx
@@ -619,7 +619,10 @@ function NotesCard() {
                     here, and reaches this unit through its subscription — so
                     the column is the only rendering that stays true. */}
                 {item.filed_activity_id ? (
-                  <Badge tone="success">{t("extNotes.notes.filed")}</Badge>
+                  <>
+                    {" "}
+                    <Badge tone="success">{t("extNotes.notes.filed")}</Badge>
+                  </>
                 ) : null}
                 {canRemove ? (
                   <Button

--- a/extensions/notes/heartbeat.go
+++ b/extensions/notes/heartbeat.go
@@ -51,6 +51,23 @@ import (
 // watch happen. A bounded history keeps both properties, and it also bounds
 // the table, which a filtered read would not.
 //
+// THE TICK RECORDS NOTHING, and it is the one write in this unit that does not.
+// Every other own-table write goes through recordNote — a ledger row and an
+// event — because each is a fact somebody may later ask about: who added this
+// note, who filed it, who took the filing away. A tick is none of those. It
+// writes a row nobody asked for, at a cadence, and prunes it again minutes
+// later; recording it would put 1,440 immutable audit rows per workspace per
+// day into a table nothing prunes, to say that a demonstration ran. The history
+// of the demo would outlive, and outnumber, the history of what the demo is
+// for.
+//
+// The exemption is about CADENCE and about what the row means, not about
+// convenience. A unit whose unattended pass writes something a person could be
+// asked about later should record it, and the withdrawal handler beside this
+// one does exactly that, under the same no-caller conditions. `tx.Record` is
+// offered rather than enforced (extension.Tx), and this is what declining it
+// looks like when the choice is deliberate.
+//
 // An error fails the attempt, which the dispatcher's next tick retries. There
 // is no result — nobody is waiting for one.
 func heartbeat(ctx context.Context, rt extension.Runtime) error {

--- a/extensions/notes/ledger.go
+++ b/extensions/notes/ledger.go
@@ -53,7 +53,7 @@ func recordNote(ctx context.Context, tx extension.Tx, action extension.AuditActi
 		subject = before
 	}
 	if subject == nil {
-		return fmt.Errorf("notes: recording a %s with neither image names no row", verb)
+		return fmt.Errorf("notes: recording a %s needs one image — the row's id comes from whichever side of the write it has", verb)
 	}
 	beforeImage, err := noteImage(before)
 	if err != nil {

--- a/extensions/notes/ledger.go
+++ b/extensions/notes/ledger.go
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package notes
+
+// What this unit records about its OWN writes: the ledger row, and the event
+// other listeners hear.
+//
+// The notepad's rows are the unit's, so nothing in the core can describe a
+// write to them — no entity type, no field images, no verb. This file is where
+// the unit says those things, and the core supplies everything a unit must not
+// choose: the actor, the workspace, the attribution and the trace.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/gradionhq/margince/backend/pkg/extension"
+)
+
+// noteEntity is what the LEDGER calls this unit's table, and noteTable is what
+// SQL calls it. Both, because they are two different names for one thing:
+// audit_log.entity_type names a kind of record and takes no schema, while a
+// statement resolves through a search_path the ext schema is not on. Deriving
+// one from the other keeps them from drifting apart.
+const noteEntity = "ext_notes_note"
+
+// noteEvent is a fact this unit publishes about its own rows. The type on the
+// bus is `ext_notes.<verb>` — the core prefixes the namespace, so these are
+// verbs and not types.
+const (
+	eventNoteAdded       = "note_added"
+	eventNoteFiled       = "note_filed"
+	eventNoteRemoved     = "note_removed"
+	eventFilingWithdrawn = "filing_withdrawn"
+)
+
+// recordNote writes the ledger row and the event for one note write, in the
+// caller's transaction.
+//
+// It is a shape helper over tx.Record and nothing more: what it saves each
+// handler is marshaling two images and remembering which entity this unit owns.
+//
+// before and after are the row's own images, which the notepad has in hand: the
+// insert and the update both RETURN the row they wrote, so what is recorded is
+// what the database holds rather than what this code believed it sent.
+func recordNote(ctx context.Context, tx extension.Tx, action extension.AuditAction, verb string,
+	before, after *note, detail, payload json.RawMessage,
+) error {
+	subject := after
+	if subject == nil {
+		subject = before
+	}
+	if subject == nil {
+		return fmt.Errorf("notes: recording a %s with neither image names no row", verb)
+	}
+	beforeImage, err := noteImage(before)
+	if err != nil {
+		return err
+	}
+	afterImage, err := noteImage(after)
+	if err != nil {
+		return err
+	}
+	return tx.Record(ctx,
+		extension.Change{
+			Action: action,
+			Entity: noteEntity,
+			ID:     subject.ID,
+			Before: beforeImage,
+			After:  afterImage,
+			Detail: detail,
+		},
+		extension.Event{Verb: verb, Payload: payload})
+}
+
+// noteImage renders one side of a change, or nothing at all.
+//
+// A missing image is nil rather than `null`: a create has no before and an
+// erase has no after, and the ledger's own reading of "there was no such state"
+// is an absent column, not a JSON null sitting in one.
+func noteImage(n *note) (json.RawMessage, error) {
+	if n == nil {
+		return nil, nil
+	}
+	raw, err := json.Marshal(n)
+	if err != nil {
+		return nil, err
+	}
+	return raw, nil
+}
+
+// notePayload is what a listener is told about one of this unit's rows: enough
+// to decide whether the row is worth reading, and nothing more. The subject's
+// id rides the envelope, so what is left is the kind — the one field that
+// separates a person's note from the heartbeat's own rows.
+func notePayload(n note) (json.RawMessage, error) {
+	return json.Marshal(struct {
+		Kind noteKind `json:"kind"`
+	}{Kind: n.Kind})
+}

--- a/extensions/notes/manifest.generated.json
+++ b/extensions/notes/manifest.generated.json
@@ -137,5 +137,13 @@
       "key": "signing",
       "scope": "workspace"
     }
+  ],
+  "subscriptions": [
+    {
+      "name": "withdraw_filing",
+      "events": [
+        "activity.archived"
+      ]
+    }
   ]
 }

--- a/extensions/notes/note.go
+++ b/extensions/notes/note.go
@@ -267,7 +267,19 @@ func addNote(ctx context.Context, rt extension.Runtime, in json.RawMessage) (jso
 			`INSERT INTO `+noteTable+` (workspace_id, kind, body, author_user_id, author_is_agent)
 			 VALUES (`+callerWorkspace+`, $1, $2, $3::uuid, $4::boolean)
 			 RETURNING `+noteColumns, string(kindNote), body, authorID, authorIsAgent).Scan)
-		return scanErr
+		if scanErr != nil {
+			return scanErr
+		}
+		payload, err := notePayload(n)
+		if err != nil {
+			return err
+		}
+		// In the SAME transaction as the insert, which is the whole point of
+		// the ledger hanging off the transaction rather than the runtime: a
+		// note that exists with no ledger row, or a ledger row for a note the
+		// insert rolled back, would each be a history that disagrees with the
+		// notepad.
+		return recordNote(ctx, tx, extension.AuditCreate, eventNoteAdded, nil, &n, nil, payload)
 	})
 	if err != nil {
 		return nil, err
@@ -324,17 +336,35 @@ func removeNote(ctx context.Context, rt extension.Runtime, in json.RawMessage) (
 	if !isCanonicalUUID(id) {
 		return nil, fmt.Errorf("notes: %q is not a note id — an id is a canonical UUID, as the contract declares", id)
 	}
-	var affected int64
+	var removed bool
 	err = rt.Tx(ctx, func(ctx context.Context, tx extension.Tx) error {
-		affected, err = tx.Exec(ctx, `DELETE FROM `+noteTable+` WHERE id = $1::uuid`, id)
-		return err
+		// RETURNING rather than a row count, because an erase's ledger row is
+		// the ONLY remaining trace of what was there: the row is gone, so a
+		// before-image read after the fact is impossible and one read before it
+		// would be a second answer that could differ from what was deleted.
+		gone, err := scanNote(tx.QueryRow(ctx,
+			`DELETE FROM `+noteTable+` WHERE id = $1::uuid RETURNING `+noteColumns, id).Scan)
+		if errors.Is(err, extension.ErrNoRows) {
+			// Not here, or not this workspace's — the policy makes those the
+			// same answer, and it is the one this unit is entitled to give.
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		removed = true
+		payload, err := notePayload(gone)
+		if err != nil {
+			return err
+		}
+		return recordNote(ctx, tx, extension.AuditErase, eventNoteRemoved, &gone, nil, nil, payload)
 	})
 	if err != nil {
 		return nil, err
 	}
 	return json.Marshal(struct {
 		Removed bool `json:"removed"`
-	}{Removed: affected > 0})
+	}{Removed: removed})
 }
 
 // decode reads a handler's arguments strictly.

--- a/extensions/notes/note_test.go
+++ b/extensions/notes/note_test.go
@@ -328,23 +328,82 @@ func TestAddNotePropagatesTheWriteFailure(t *testing.T) {
 	}
 }
 
+// TestAddNoteRecordsItsOwnWrite: the notepad's rows are the unit's, so nothing
+// in the core can describe a write to them — this unit says what happened, in
+// the same ledger the product keeps for its own records, and tells anybody
+// listening.
+func TestAddNoteRecordsItsOwnWrite(t *testing.T) {
+	const addedID = "11111111-1111-4111-8111-111111111111"
+	rt := newRuntime()
+	rt.tx.row = noteRow(addedID, kindNote, "hello", callerUserID, false, stamp)
+	if _, err := addNote(context.Background(), rt, json.RawMessage(`{"body":"hello"}`)); err != nil {
+		t.Fatal(err)
+	}
+	if len(rt.tx.audited) != 1 {
+		t.Fatalf("the insert recorded %d ledger rows, want 1", len(rt.tx.audited))
+	}
+	change := rt.tx.audited[0]
+	if change.Action != extension.AuditCreate || change.Entity != noteEntity || change.ID != addedID {
+		t.Errorf("recorded %s on %s/%s, want a create of %s/%s",
+			change.Action, change.Entity, change.ID, noteEntity, addedID)
+	}
+	if change.Before != nil {
+		t.Errorf("a create recorded a before image: %s", change.Before)
+	}
+	// The after image is the row the DATABASE wrote, not the arguments this
+	// handler sent: the two differ wherever a default, a trigger or a CHECK has
+	// an opinion, and the ledger records what is there.
+	if !strings.Contains(string(change.After), addedID) {
+		t.Errorf("the after image is not the row that was written: %s", change.After)
+	}
+	if len(rt.tx.published) != 1 || rt.tx.published[0].Verb != eventNoteAdded {
+		t.Fatalf("published %v, want one %s", rt.tx.published, eventNoteAdded)
+	}
+	// The payload carries what a listener needs to DECIDE whether to read the
+	// row — the kind, which separates a person's note from the heartbeat's.
+	if !strings.Contains(string(rt.tx.published[0].Payload), string(kindNote)) {
+		t.Errorf("the payload does not name the kind: %s", rt.tx.published[0].Payload)
+	}
+}
+
+// TestAddNoteFailsWhenItsHistoryCannotBeWritten: the ledger row rides the same
+// transaction as the insert, so a note that could exist with no history must
+// not exist at all — the handler propagates rather than answering a stored note
+// whose write nothing recorded.
+func TestAddNoteFailsWhenItsHistoryCannotBeWritten(t *testing.T) {
+	rt := newRuntime()
+	rt.tx.row = noteRow("11111111-1111-4111-8111-111111111111", kindNote, "hello", callerUserID, false, stamp)
+	rt.tx.recordErr = errors.New("the ledger row could not be written")
+	if _, err := addNote(context.Background(), rt, json.RawMessage(`{"body":"hello"}`)); err == nil {
+		t.Fatal("a note whose ledger row failed was answered as stored")
+	}
+}
+
+const removedNoteID = "11111111-1111-4111-8111-111111111111"
+
 func TestRemoveNoteReportsWhetherItRemovedAnything(t *testing.T) {
 	for _, tc := range []struct {
-		name     string
-		affected int64
-		want     string
+		name string
+		// row is what the DELETE returned: the note that went, or nothing at
+		// all. It RETURNs the row rather than a count because an erase's ledger
+		// row carries the only remaining image of what was there.
+		row  []any
+		want string
 	}{
-		{"a note this workspace holds", 1, `{"removed":true}`},
+		{
+			"a note this workspace holds",
+			noteRow(removedNoteID, kindNote, "gone", callerUserID, false, time.Now().UTC()),
+			`{"removed":true}`,
+		},
 		// Not an error: the policy makes another tenant's row invisible rather
 		// than forbidden, so "no such note here" and "no such note anywhere"
 		// are the same answer — and the only one this unit is entitled to give.
-		{"an id this workspace does not hold", 0, `{"removed":false}`},
+		{"an id this workspace does not hold", nil, `{"removed":false}`},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			rt := newRuntime()
-			rt.tx.affected = tc.affected
-			out, err := removeNote(context.Background(), rt,
-				json.RawMessage(`{"id":"11111111-1111-4111-8111-111111111111"}`))
+			rt.tx.row = tc.row
+			out, err := removeNote(context.Background(), rt, json.RawMessage(`{"id":"`+removedNoteID+`"}`))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -355,6 +414,44 @@ func TestRemoveNoteReportsWhetherItRemovedAnything(t *testing.T) {
 				t.Errorf("the delete does not cast the id, so an unparseable one would match nothing silently:\n%s", sql)
 			}
 		})
+	}
+}
+
+// TestRemoveNoteRecordsTheEraseWithTheRowThatWent: an erase leaves nothing
+// behind, so the ledger's before-image is the only remaining trace of what the
+// notepad held — and an id that matched nothing must record NOTHING, rather
+// than a history of a deletion that never happened.
+func TestRemoveNoteRecordsTheEraseWithTheRowThatWent(t *testing.T) {
+	rt := newRuntime()
+	rt.tx.row = noteRow(removedNoteID, kindNote, "gone", callerUserID, false, time.Now().UTC())
+	if _, err := removeNote(context.Background(), rt, json.RawMessage(`{"id":"`+removedNoteID+`"}`)); err != nil {
+		t.Fatal(err)
+	}
+	if len(rt.tx.audited) != 1 {
+		t.Fatalf("the erase recorded %d ledger rows, want 1", len(rt.tx.audited))
+	}
+	change := rt.tx.audited[0]
+	if change.Action != extension.AuditErase || change.Entity != noteEntity || change.ID != removedNoteID {
+		t.Errorf("recorded %s on %s/%s, want an erase of %s/%s",
+			change.Action, change.Entity, change.ID, noteEntity, removedNoteID)
+	}
+	if !strings.Contains(string(change.Before), "gone") {
+		t.Errorf("the before image does not carry the row that went: %s", change.Before)
+	}
+	if change.After != nil {
+		t.Errorf("an erase recorded an after image: %s", change.After)
+	}
+	if len(rt.tx.published) != 1 || rt.tx.published[0].Verb != eventNoteRemoved {
+		t.Errorf("published %v, want one %s", rt.tx.published, eventNoteRemoved)
+	}
+
+	unmatched := newRuntime()
+	if _, err := removeNote(context.Background(), unmatched, json.RawMessage(`{"id":"`+removedNoteID+`"}`)); err != nil {
+		t.Fatal(err)
+	}
+	if len(unmatched.tx.audited) != 0 || len(unmatched.tx.published) != 0 {
+		t.Errorf("an id that matched nothing recorded %d changes and %d events, want none",
+			len(unmatched.tx.audited), len(unmatched.tx.published))
 	}
 }
 

--- a/extensions/notes/notes.go
+++ b/extensions/notes/notes.go
@@ -81,6 +81,9 @@ func New() extension.Extension {
 		Jobs: []extension.Job{
 			{Name: "heartbeat", Handle: heartbeat},
 		},
+		Subscriptions: []extension.Subscription{
+			{Name: "withdraw_filing", Events: []string{"activity.archived"}, Handle: withdrawFiling},
+		},
 		Migrations: migrations,
 	}
 }
@@ -89,7 +92,11 @@ func New() extension.Extension {
 // package writes it through this constant: the ext schema is on no search_path
 // the app connects with, so an unqualified name would resolve to a public table
 // the unit does not own.
-const noteTable = "ext.ext_notes_note"
+//
+// The LEDGER names the same table without the schema (noteEntity), because
+// audit_log.entity_type names a kind of record rather than a path to one. One
+// is derived from the other so the two spellings cannot drift into two tables.
+const noteTable = "ext." + noteEntity
 
 // callerWorkspace is the tenant the invocation is pinned to, as SQL sees it.
 //

--- a/extensions/notes/withdraw.go
+++ b/extensions/notes/withdraw.go
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package notes
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/gradionhq/margince/backend/pkg/extension"
+)
+
+// withdrawFiling clears a note's filing when the activity it was filed to is
+// archived.
+//
+// WHY THIS IS AN OBLIGATION RATHER THAN A DEMONSTRATION. file_note writes two
+// rows: this unit's note, and a core activity on the record's timeline. The
+// note keeps the activity's id, which is what lets the screen say a note
+// reached a record. Archiving that activity takes the timeline entry away — and
+// leaves the note claiming a filing whose entry nobody can see. Nothing in the
+// core knows this unit's column exists, so if the unit does not listen, the
+// claim stays wrong forever.
+//
+// NOBODY IS BEHIND THIS CALL. rt.Caller() is the zero Caller and the core port
+// is shut, which is exactly right for the work: the row this touches is the
+// unit's own, and the archive that triggered it was already authorized by
+// whoever made it.
+//
+// IT IS SAFE TO RUN TWICE, which the bus requires: the UPDATE matches on the
+// filing that is being withdrawn, so a redelivery matches nothing, writes no
+// ledger row and publishes nothing. An audit trail of writes that did not
+// happen would be worse than no trail at all.
+func withdrawFiling(ctx context.Context, rt extension.Runtime, d extension.Delivery) error {
+	if d.Entity.Type != "activity" || !isCanonicalUUID(d.Entity.ID) {
+		// A delivery this handler cannot act on is ACKED, not failed. It can
+		// never succeed on a retry either, and an entry that fails forever
+		// stalls every later event on the same group.
+		return nil
+	}
+	return rt.Tx(ctx, func(ctx context.Context, tx extension.Tx) error {
+		withdrawn, err := clearFilings(ctx, tx, d.Entity.ID)
+		if err != nil {
+			return err
+		}
+		for _, n := range withdrawn {
+			if err := recordWithdrawal(ctx, tx, n, d); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+// clearFilings takes the filing off every note that named this activity, and
+// answers the rows as they now stand.
+//
+// EVERY note, not the first: nothing in the schema stops two notes naming one
+// activity, and a loop that handled one would leave the others claiming a
+// filing — the exact state this handler exists to remove.
+func clearFilings(ctx context.Context, tx extension.Tx, activityID string) ([]note, error) {
+	rows, err := tx.Query(ctx,
+		`UPDATE `+noteTable+` SET filed_activity_id = NULL
+		 WHERE filed_activity_id = $1::uuid
+		 RETURNING `+noteColumns, activityID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var withdrawn []note
+	for rows.Next() {
+		n, err := scanNote(rows.Scan)
+		if err != nil {
+			return nil, err
+		}
+		withdrawn = append(withdrawn, n)
+	}
+	return withdrawn, rows.Err()
+}
+
+// recordWithdrawal writes the ledger row for one withdrawal and publishes it.
+//
+// The BEFORE image is reconstructed rather than read back, and it is exact: the
+// UPDATE changed one column, and the value it held is the id of the activity
+// whose archive is being handled. A second read to fetch what this statement
+// just overwrote would be a round trip for a value already in hand — and it
+// would have to run before the write, where it could disagree with the row the
+// UPDATE actually matched.
+func recordWithdrawal(ctx context.Context, tx extension.Tx, after note, d extension.Delivery) error {
+	activityID := d.Entity.ID
+	before := after
+	before.FiledActivityID = &activityID
+
+	// The CAUSE of the write, which belongs in evidence rather than in the
+	// images: the note's own fields did not record why they changed, and a
+	// reader asking "who un-filed this" is asking about the event, not the row.
+	detail, err := json.Marshal(struct {
+		Cause      string `json:"cause"`
+		ActivityID string `json:"activity_id"`
+		EventID    string `json:"event_id"`
+	}{Cause: d.Type, ActivityID: activityID, EventID: d.EventID})
+	if err != nil {
+		return err
+	}
+	payload, err := json.Marshal(struct {
+		ActivityID string `json:"activity_id"`
+	}{ActivityID: activityID})
+	if err != nil {
+		return err
+	}
+	return recordNote(ctx, tx, extension.AuditUpdate, eventFilingWithdrawn, &before, &after, detail, payload)
+}

--- a/extensions/notes/withdraw.go
+++ b/extensions/notes/withdraw.go
@@ -32,9 +32,11 @@ import (
 // happen would be worse than no trail at all.
 func withdrawFiling(ctx context.Context, rt extension.Runtime, d extension.Delivery) error {
 	if d.Entity.Type != "activity" || !isCanonicalUUID(d.Entity.ID) {
-		// A delivery this handler cannot act on is ACKED, not failed. It can
-		// never succeed on a retry either, and an entry that fails forever
-		// stalls every later event on the same group.
+		// A delivery this handler cannot act on is ACKED, not failed. Failing
+		// it would put it back in the pending set for the reclaim pass to hand
+		// over again, forever, at the cost of one wasted handler run per pass —
+		// and it would say "this failed" about an event that simply is not this
+		// handler's business.
 		return nil
 	}
 	return rt.Tx(ctx, func(ctx context.Context, tx extension.Tx) error {

--- a/extensions/notes/withdraw_test.go
+++ b/extensions/notes/withdraw_test.go
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package notes
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gradionhq/margince/backend/pkg/extension"
+)
+
+const archivedActivityID = "22222222-2222-4222-8222-222222222222"
+
+// archivedDelivery is the bus delivery this unit listens for.
+func archivedDelivery() extension.Delivery {
+	return extension.Delivery{
+		EventID:    "33333333-3333-4333-8333-333333333333",
+		Type:       "activity.archived",
+		OccurredAt: time.Now().UTC(),
+		Entity:     extension.EntityRef{Type: "activity", ID: archivedActivityID},
+	}
+}
+
+// TestWithdrawFilingClearsTheFilingAndRecordsWhy: the note kept the id of an
+// activity that is no longer on any timeline, and nothing in the core knows
+// this unit's column exists — so the claim only becomes false-and-corrected if
+// the unit hears the archive itself.
+func TestWithdrawFilingClearsTheFilingAndRecordsWhy(t *testing.T) {
+	rt := newRuntime()
+	rt.tx.rows = [][]any{
+		filedNoteRow(removedNoteID, kindNote, "filed once", callerUserID, false, "", time.Now().UTC()),
+	}
+	if err := withdrawFiling(context.Background(), rt, archivedDelivery()); err != nil {
+		t.Fatal(err)
+	}
+
+	sql := rt.tx.only(t)
+	for _, want := range []string{"UPDATE", "filed_activity_id = NULL", "WHERE filed_activity_id = $1::uuid", "RETURNING"} {
+		if !strings.Contains(sql, want) {
+			t.Errorf("the withdrawal statement misses %q:\n%s", want, sql)
+		}
+	}
+	if got := rt.tx.args[0][0]; got != archivedActivityID {
+		t.Errorf("the withdrawal matched on %v, want the archived activity %s", got, archivedActivityID)
+	}
+
+	if len(rt.tx.audited) != 1 {
+		t.Fatalf("the withdrawal recorded %d ledger rows, want 1", len(rt.tx.audited))
+	}
+	change := rt.tx.audited[0]
+	if change.Action != extension.AuditUpdate || change.Entity != noteEntity || change.ID != removedNoteID {
+		t.Errorf("recorded %s on %s/%s, want an update of %s/%s",
+			change.Action, change.Entity, change.ID, noteEntity, removedNoteID)
+	}
+	// The images are the two states of the one column that moved: the before
+	// carries the filing that was there, the after carries none.
+	if !strings.Contains(string(change.Before), archivedActivityID) {
+		t.Errorf("the before image does not carry the filing that was withdrawn: %s", change.Before)
+	}
+	if strings.Contains(string(change.After), archivedActivityID) {
+		t.Errorf("the after image still carries the withdrawn filing: %s", change.After)
+	}
+	// Why it changed is evidence, not a field: the note's own columns never
+	// recorded the archive.
+	for _, want := range []string{"activity.archived", archivedActivityID} {
+		if !strings.Contains(string(change.Detail), want) {
+			t.Errorf("the evidence does not say %q: %s", want, change.Detail)
+		}
+	}
+	if len(rt.tx.published) != 1 || rt.tx.published[0].Verb != eventFilingWithdrawn {
+		t.Errorf("published %v, want one %s", rt.tx.published, eventFilingWithdrawn)
+	}
+}
+
+// TestWithdrawFilingIsSafeToRunTwice: the bus is at-least-once, and the second
+// delivery matches nothing because the first already cleared the column. A
+// ledger row for a write that changed nothing would be a history of an event
+// that did not happen.
+func TestWithdrawFilingIsSafeToRunTwice(t *testing.T) {
+	rt := newRuntime()
+	rt.tx.rows = nil // the UPDATE matched no rows the second time round
+	if err := withdrawFiling(context.Background(), rt, archivedDelivery()); err != nil {
+		t.Fatal(err)
+	}
+	if len(rt.tx.audited) != 0 || len(rt.tx.published) != 0 {
+		t.Errorf("a redelivery recorded %d changes and %d events, want none",
+			len(rt.tx.audited), len(rt.tx.published))
+	}
+}
+
+// TestWithdrawFilingClearsEveryNoteFiledToTheActivity: nothing in the schema
+// stops two notes naming one activity, and a handler that stopped at the first
+// would leave the rest claiming a filing — the state it exists to remove.
+func TestWithdrawFilingClearsEveryNoteFiledToTheActivity(t *testing.T) {
+	const secondID = "44444444-4444-4444-8444-444444444444"
+	rt := newRuntime()
+	now := time.Now().UTC()
+	rt.tx.rows = [][]any{
+		filedNoteRow(removedNoteID, kindNote, "first", callerUserID, false, "", now),
+		filedNoteRow(secondID, kindNote, "second", callerUserID, false, "", now),
+	}
+	if err := withdrawFiling(context.Background(), rt, archivedDelivery()); err != nil {
+		t.Fatal(err)
+	}
+	if len(rt.tx.audited) != 2 || len(rt.tx.published) != 2 {
+		t.Fatalf("recorded %d changes and %d events for two withdrawn notes, want 2 and 2",
+			len(rt.tx.audited), len(rt.tx.published))
+	}
+	if rt.tx.audited[0].ID == rt.tx.audited[1].ID {
+		t.Errorf("both ledger rows name the same note %s", rt.tx.audited[0].ID)
+	}
+}
+
+// TestWithdrawFilingIgnoresADeliveryItCannotActOn: an event whose subject is
+// not an activity, or whose id is not a UUID, can never succeed on a retry
+// either — and an entry that fails forever stalls every later event on the
+// group. It is acked without touching the database.
+func TestWithdrawFilingIgnoresADeliveryItCannotActOn(t *testing.T) {
+	for name, d := range map[string]extension.Delivery{
+		"a subject that is not an activity": {
+			Type: "activity.archived", Entity: extension.EntityRef{Type: "person", ID: archivedActivityID},
+		},
+		"no subject at all": {Type: "activity.archived"},
+		"an id that is not a UUID": {
+			Type: "activity.archived", Entity: extension.EntityRef{Type: "activity", ID: "activity-7"},
+		},
+	} {
+		rt := newRuntime()
+		if err := withdrawFiling(context.Background(), rt, d); err != nil {
+			t.Errorf("%s: err = %v, want it acked", name, err)
+		}
+		if len(rt.tx.statements) != 0 {
+			t.Errorf("%s: it still reached the database: %v", name, rt.tx.statements)
+		}
+	}
+}
+
+// TestWithdrawFilingPropagatesAFailedWrite: an error leaves the entry pending
+// and re-delivers it, which is the right outcome for a database that was
+// briefly unavailable — and the wrong one to swallow, because the note would
+// keep a filing nobody would ever correct.
+func TestWithdrawFilingPropagatesAFailedWrite(t *testing.T) {
+	rt := newRuntime()
+	rt.tx.err = errors.New("deadlock detected")
+	if err := withdrawFiling(context.Background(), rt, archivedDelivery()); err == nil {
+		t.Fatal("a failed withdrawal was acked")
+	}
+
+	// The same holds for the ledger half: a cleared filing whose history was
+	// not written must roll the whole transaction back.
+	ledgerFailed := newRuntime()
+	ledgerFailed.tx.rows = [][]any{
+		filedNoteRow(removedNoteID, kindNote, "filed once", callerUserID, false, "", time.Now().UTC()),
+	}
+	ledgerFailed.tx.recordErr = errors.New("the ledger row could not be written")
+	if err := withdrawFiling(context.Background(), ledgerFailed, archivedDelivery()); err == nil {
+		t.Fatal("a withdrawal whose ledger row failed was acked")
+	}
+}

--- a/extensions/notes/withdraw_test.go
+++ b/extensions/notes/withdraw_test.go
@@ -76,19 +76,42 @@ func TestWithdrawFilingClearsTheFilingAndRecordsWhy(t *testing.T) {
 	}
 }
 
-// TestWithdrawFilingIsSafeToRunTwice: the bus is at-least-once, and the second
-// delivery matches nothing because the first already cleared the column. A
-// ledger row for a write that changed nothing would be a history of an event
-// that did not happen.
+// TestWithdrawFilingIsSafeToRunTwice: the bus is at-least-once, so the SAME
+// delivery arrives twice and the second one must leave nothing behind. A ledger
+// row for a write that changed nothing is a history of an event that did not
+// happen.
+//
+// It runs the handler twice against a fake whose table remembers the first run,
+// rather than asserting the second run's shape from a fixture set up to look
+// like one: what makes the redelivery a no-op is that the first run cleared the
+// column its UPDATE matches on, and a test that pre-cleared it would prove
+// only that this handler does nothing when handed nothing.
 func TestWithdrawFilingIsSafeToRunTwice(t *testing.T) {
 	rt := newRuntime()
-	rt.tx.rows = nil // the UPDATE matched no rows the second time round
-	if err := withdrawFiling(context.Background(), rt, archivedDelivery()); err != nil {
+	// The UPDATE matches on the filing, so the row comes back once and never
+	// again — which is exactly what the database does after the first commit.
+	rt.tx.rows = [][]any{
+		filedNoteRow(removedNoteID, kindNote, "filed once", callerUserID, false, "", time.Now().UTC()),
+	}
+
+	first := archivedDelivery()
+	if err := withdrawFiling(context.Background(), rt, first); err != nil {
 		t.Fatal(err)
 	}
-	if len(rt.tx.audited) != 0 || len(rt.tx.published) != 0 {
-		t.Errorf("a redelivery recorded %d changes and %d events, want none",
+	if len(rt.tx.audited) != 1 || len(rt.tx.published) != 1 {
+		t.Fatalf("the first delivery recorded %d changes and %d events, want 1 and 1",
 			len(rt.tx.audited), len(rt.tx.published))
+	}
+
+	if err := withdrawFiling(context.Background(), rt, first); err != nil {
+		t.Fatal(err)
+	}
+	if len(rt.tx.audited) != 1 || len(rt.tx.published) != 1 {
+		t.Errorf("the redelivery recorded %d changes and %d events in total, want the first run's 1 and 1",
+			len(rt.tx.audited), len(rt.tx.published))
+	}
+	if len(rt.tx.statements) != 2 {
+		t.Errorf("the handler issued %d statements over two deliveries, want one each", len(rt.tx.statements))
 	}
 }
 
@@ -116,9 +139,10 @@ func TestWithdrawFilingClearsEveryNoteFiledToTheActivity(t *testing.T) {
 }
 
 // TestWithdrawFilingIgnoresADeliveryItCannotActOn: an event whose subject is
-// not an activity, or whose id is not a UUID, can never succeed on a retry
-// either — and an entry that fails forever stalls every later event on the
-// group. It is acked without touching the database.
+// not an activity, or whose id is not a UUID, is ACKED without touching the
+// database. Failing it would re-deliver it forever — the reclaim pass hands
+// back an entry nothing can ever make succeed — where an ack says the honest
+// thing, that this handler has nothing to do with it.
 func TestWithdrawFilingIgnoresADeliveryItCannotActOn(t *testing.T) {
 	for name, d := range map[string]extension.Delivery{
 		"a subject that is not an activity": {


### PR DESCRIPTION
SP2 of the extension-tier programme. SP1 (#1092, #1106) gave a unit a governed door onto CORE
records; its OWN tables were still a write with no ledger row, no event, and no way for anything in
the installation to react. This closes both, with `notes` as the consumer end to end.

## `tx.Record(change, event)` — one call, both halves, always

A write to a unit's own table now records the `audit_log` row **and** the `event_outbox` event, on
the caller's transaction. It is the product's own non-negotiable write shape offered to a unit in a
form it cannot half-use: an event with no ledger row is unauditable, and a ledger row with no event
is a change nothing downstream is told about.

That shape is not what the design started with. It began as `tx.Audit` returning a `Receipt` whose
`Publish` was optional — and `backend/writeshape_test.go` refused it. Every one of that gate's ~40
ratified exceptions says the same thing, *the closed catalog defines no verb for this*, and an
extension's verb space is open, so the exception could not be earned honestly. The two-call shape had
quietly offered units a weaker write shape than the core keeps for itself.

The core stamps everything a unit must not choose: the actor the invocation arrived as, the
workspace, the authorization rule, the attribution (`evidence.extension`, with the unit's own
free-form `detail` nested inside the one member the tier owns), the event's namespace, and the trace
joining the event to the ledger row.

## The type grammar: `ext_<namespace>.<verb>`

A unit spells the **verb**; the core prefixes the namespace from the invocation. Publishing under
another unit's name, or inside a core family, is not refused — it is unsayable.

Every extension event rides one stream, `gw:events:crm:extension`. It is in `Streams()` (the data
reset unlinks it, ops can see it) and in **no core consumer group**: the automation engine would load
every live instance and match no trigger, the webhook deliverer would query subscriptions for a type
the public catalog cannot name — a database round trip each, per unit event, invisibly, growing with
the tier. A test pins the exclusion.

## `Extension.Subscriptions` — a unit reacts

A declaration names the event types it wants (a core type or another unit's) and the function one
delivery runs. Each listener gets its own consumer group, `cg:ext-<unit>-<subscription>`, started in
the worker and `Dedupe`-wrapped, over exactly the streams its declared types route to.

A delivery has **nobody** behind it: `Caller()` is the zero Caller and `tx.Core()` refuses. That is
load-bearing rather than tidy — a delivery runs as `PrincipalSystem`, which `auth.Require` does not
check at all, so the refusal is the whole distance between a bus event and an unchecked core write.
The unit's own tables stay writable, auditable and publishable.

The declared list derives into `manifest.generated.json` (the generator fails closed on an unknown
declaration field, so teaching the reader was not optional), which makes a unit's reach over the
installation's facts readable without opening its source.

## The exemplar

`file_note` writes a note **and** a core activity; the note keeps the activity's id, which is what
lets the screen say a note reached a record. Archiving that activity on the timeline leaves the note
claiming a filing whose entry nobody can see — and nothing in the core knows this unit's column
exists. So `notes` now hears `activity.archived`, clears the filing on every note that named it,
records the withdrawal with the archived activity as evidence, and publishes `filing_withdrawn`.
`add`, `file` and `remove` record their own history and publish it too. The screen reads the column
rather than remembering a badge, so a filing withdrawn on the timeline disappears from the notepad.

## Gates

Every guard here was **mutation-verified** — and two of them were inert on the first pass: the
ownership and validate refusals passed under a mutation because a missing actor stopped the write
before the check they were named for. They now run over a `pgx.Tx` that panics on any statement, so a
refusal arriving late is a failure rather than a pass.

- kernel: an extension type routes to the extension stream at version 1; no core catalog type matches
  the extension grammar; the extension stream is in `Streams()` and in no group.
- the port: a ledger row outside the invoking unit's namespace, a malformed change, an event the bus
  grammar refuses, a write with no bound authority — each refused before any statement runs.
- boot: a subscription naming an unroutable type, a duplicate name, an empty list, a nil handler.
- integration (real Postgres): the row, the ledger row and the event commit together and roll back
  together; the envelope is on the extension stream, at version 1, naming the audited row, with its
  trace joined to that ledger row; a delivery may record its own write and may **not** write a core
  record.
- `make check` (both halves), the full integration lane (`0 skips`), and the whole-tree
  `golangci-lint run ./...` CI lints wider than `make check` — all green locally.

## Notes for the reviewer

- **A payload is a document, not bytes.** Both columns it travels through are jsonb, which re-renders
  what it stores. Found by the integration lane; recorded on `Event.Payload` and `Delivery.Payload`
  so no unit signs or compares raw text across the bus.
- `systemCaller`/`tick` became `unattended`: a job tick and a bus delivery are now two producers of
  one fact, and the refusal's wording says both.
- Design and reasoning: `.tmp/ext-core-write-port/DESIGN-SP2.md` (local, not in this repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes extension-owned writes auditable and observable, and lets units react to events. Previously, own-table writes had no ledger row or event; now `Tx.Record()` writes both atomically, and subscriptions deliver workspace-aware events to unit handlers.

- Adds `Tx.Record(change, event)` on `extension.Tx`. Validates change/action consistency and writes the audit row and outbox event on the same transaction. Tightens event grammar: `ext_<unit>.<verb>`; hyphenated unit names map to underscores. Invalid namespaces (e.g., `ext__notes.*`, `ext_notes_.*`) are refused at boot. All extension events route to `gw:events:crm:extension` at version 1; no core consumer group consumes it.
- Introduces `extension.Subscription` (`Name`, `Events`, `Handle`). Each runs in group `cg:ext-<unit>-<subscription>`, Dedupe-wrapped, with panic recovery. Deliveries are unattended: the caller is zero and `Tx.Core()` is refused. Worker starts subscription lanes after the job runner binds the runtime and shuts them down with the lanes’ context. An unresolvable listener is logged and skipped; other lanes start.
- Composition rejects overlapping namespaces (e.g., `ext_crm` and `ext_crm_demo`) so ownership checks are exact. The generator derives `subscriptions` into unit manifests for operator visibility.
- Exemplar (`notes`): `add`, `file`, and `remove` record their own history and publish events. `withdraw_filing` listens for `activity.archived`, is idempotent, clears filings, records withdrawals with evidence, and publishes. UI renders a “Filed” badge from the column with correct spacing. Improves one error message for clarity.

**Rollout**
- To audit and publish own-table writes, call `Tx.Record()` with a valid `Change` and `Event`.
- Event types must follow `ext_<unit>.<verb>`; payloads are JSON. Invalid namespaces are refused during composition.
- Subscriptions must declare `Name`, `Events`, and a handler; manifests will include `subscriptions`. Handlers cannot call `Tx.Core()` and run only when the worker is active.
- Operators will see the `gw:events:crm:extension` stream; no core consumer group changes are required.

<sup>Written for commit 7bf02131db60f69d3b614787a47b07def2eb21c3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1142?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Extensions can subscribe to events and receive workspace-aware deliveries.
  - Extension changes can record audit history and publish related events atomically.
  - Notes now display a “Filed” status when applicable.
  - Archived activities automatically withdraw associated note filings and preserve the audit trail.
  - Extension events use dedicated routing and subscription groups.

- **Bug Fixes**
  - Invalid, unauthorized, duplicate, or unroutable extension subscriptions are rejected early.
  - Unattended extension activity is prevented from performing restricted core writes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->