### PR TITLE
fix(forecast): the weighted number is computed once, per deal, on the server

### DIFF
--- a/backend/internal/compose/derivation_test.go
+++ b/backend/internal/compose/derivation_test.go
@@ -185,7 +185,7 @@ func TestForecastSpecShape(t *testing.T) {
 	if got := spec.fromClause(); got != "deal t JOIN stage s ON s.id = t.stage_id" {
 		t.Errorf("fromClause = %q", got)
 	}
-	if spec.measures["weighted_amount_minor"] != "round((t.amount_minor * s.win_probability) / 100.0)::bigint" {
+	if spec.measures["weighted_amount_minor"] != "round((t.amount_minor::numeric * s.win_probability) / 100.0)::bigint" {
 		t.Errorf("weighted measure = %q", spec.measures["weighted_amount_minor"])
 	}
 	if spec.measures["amount_minor"] != "t.amount_minor" {

--- a/backend/internal/compose/report.go
+++ b/backend/internal/compose/report.go
@@ -35,8 +35,12 @@ const (
 	whereArchivedNull = "t.archived_at IS NULL"
 
 	// joinStageForWinProbability is the one join a spec adds when it needs the
-	// deal's current stage for win_probability — a to-one lookup (deal.stage_id
-	// is NOT NULL, stage.id is its PK), so it never widens the row grain.
+	// deal's current stage for win_probability. It is safe from BOTH directions
+	// a join can go wrong: it cannot MULTIPLY rows (a to-one lookup — deal.stage_id
+	// is NOT NULL, stage.id is its PK) and it cannot DROP one under the workspace
+	// GUC either — every deal's stage_id is validated against the SAME workspace
+	// at write time (modules/deals writes inside the RLS tx), so a deal's stage row
+	// is never invisible to the deal's own scope.
 	joinStageForWinProbability = "JOIN stage s ON s.id = t.stage_id"
 	colWinProbability          = "s.win_probability"
 
@@ -44,11 +48,23 @@ const (
 	// §6, AC-F1): round PER DEAL, half away from zero, so a roll-up over it
 	// equals the sum of its own rows exactly. Shared by every spec that joins
 	// stage for win_probability, so the forecast report and any other
-	// per-stage weighted figure cannot drift apart (review-loop rule 1).
-	weightedAmountMinorExpr = "round((t.amount_minor * s.win_probability) / 100.0)::bigint"
+	// per-stage weighted figure cannot drift apart. The multiply casts to
+	// numeric first — amount_minor is an unbounded bigint, and bigint × smallint
+	// overflows before the /100.0 below would otherwise widen it.
+	weightedAmountMinorExpr = "round((t.amount_minor::numeric * s.win_probability) / 100.0)::bigint"
 	// fieldWeightedAmountMinor is the API-facing measure name every spec that
 	// defines weightedAmountMinorExpr registers it under.
 	fieldWeightedAmountMinor = "weighted_amount_minor"
+
+	// fieldStageID, fieldStatus and fieldWinProbability are report-vocabulary
+	// field NAMES (map keys) — distinct from the col* constants above, which
+	// are the SQL expressions those names resolve to. Declared here, not
+	// borrowed from an unrelated surface's vocabulary (overlay's query-param
+	// names happen to share these spellings, but renaming one must never
+	// rename the other).
+	fieldStageID        = "stage_id"
+	fieldStatus         = "status"
+	fieldWinProbability = "win_probability"
 )
 
 type reportAggregate struct {
@@ -134,17 +150,21 @@ var prebuiltReports = map[string]reportSpec{
 		baseWhere: whereArchivedNull,
 		basePlain: "live (unarchived) deals",
 		dimensions: map[string]string{
-			paramStageID:      colStageID,
-			paramStatus:       "t.status",
-			paramPipelineID:   colPipelineID,
-			"win_probability": colWinProbability,
+			fieldStageID:        colStageID,
+			fieldStatus:         "t.status",
+			"pipeline_id":       colPipelineID,
+			fieldWinProbability: colWinProbability,
 		},
 		measures: map[string]string{
 			"amount_minor":           colAmountMinor,
 			fieldWeightedAmountMinor: weightedAmountMinorExpr,
 		},
-		filters:   map[string]string{paramPipelineID: colPipelineID, paramStatus: "t.status", paramOwnerID: colOwnerID, paramStageID: colStageID},
-		defaultBy: []string{paramStageID},
+		// No stage_id filter: nothing serves it (the screen groups BY stage_id
+		// instead), and a filter key this report has no caller for is public
+		// agent surface (the run_report catalog, mcp-info.{json,md}) with no
+		// concrete use behind it.
+		filters:   map[string]string{"pipeline_id": colPipelineID, fieldStatus: "t.status", "owner_id": colOwnerID},
+		defaultBy: []string{fieldStageID},
 		defaultAggs: []reportAggregate{
 			{Fn: "count", As: "deals"},
 			{Fn: "sum", Field: "amount_minor", As: "amount_minor_sum"},
@@ -179,21 +199,21 @@ var prebuiltReports = map[string]reportSpec{
 		baseWhere: "t.archived_at IS NULL AND t.status = 'open'",
 		basePlain: "open, unarchived deals (win probability read live from the deal's current stage; a commit/best_case deal whose close date is past, missing, or provisional reports as 'slipped' instead, per formulas §11)",
 		dimensions: map[string]string{
-			paramOwnerID:        colOwnerID,
-			paramStageID:        colStageID,
-			paramPipelineID:     colPipelineID,
+			"owner_id":          colOwnerID,
+			fieldStageID:        colStageID,
+			"pipeline_id":       colPipelineID,
 			"forecast_category": forecastCategoryExpr,
 			"currency":          "t.currency",
-			"win_probability":   colWinProbability,
+			fieldWinProbability: colWinProbability,
 		},
 		measures: map[string]string{
 			"amount_minor":           colAmountMinor,
 			fieldWeightedAmountMinor: weightedAmountMinorExpr,
 		},
 		filters: map[string]string{
-			paramOwnerID:        colOwnerID,
-			paramStageID:        colStageID,
-			paramPipelineID:     colPipelineID,
+			"owner_id":          colOwnerID,
+			fieldStageID:        colStageID,
+			"pipeline_id":       colPipelineID,
 			"forecast_category": forecastCategoryExpr,
 			"currency":          "t.currency",
 		},

--- a/backend/internal/compose/report.go
+++ b/backend/internal/compose/report.go
@@ -33,6 +33,19 @@ const (
 	colPipelineID     = "t.pipeline_id"
 	colStageID        = "t.stage_id"
 	whereArchivedNull = "t.archived_at IS NULL"
+
+	// joinStageForWinProbability is the one join a spec adds when it needs the
+	// deal's current stage for win_probability — a to-one lookup (deal.stage_id
+	// is NOT NULL, stage.id is its PK), so it never widens the row grain.
+	joinStageForWinProbability = "JOIN stage s ON s.id = t.stage_id"
+	colWinProbability          = "s.win_probability"
+
+	// weightedAmountMinorExpr is the one spelling of "weighted value" (formulas
+	// §6, AC-F1): round PER DEAL, half away from zero, so a roll-up over it
+	// equals the sum of its own rows exactly. Shared by every spec that joins
+	// stage for win_probability, so the forecast report and any other
+	// per-stage weighted figure cannot drift apart (review-loop rule 1).
+	weightedAmountMinorExpr = "round((t.amount_minor * s.win_probability) / 100.0)::bigint"
 )
 
 type reportAggregate struct {
@@ -112,14 +125,23 @@ var prebuiltReports = map[string]reportSpec{
 		},
 	},
 	"deals-by-stage": {
-		entity:     datasource.EntityDeal,
-		table:      "deal",
-		baseWhere:  whereArchivedNull,
-		basePlain:  "live (unarchived) deals",
-		dimensions: map[string]string{"stage_id": colStageID, "status": "t.status", "pipeline_id": colPipelineID},
-		measures:   map[string]string{"amount_minor": colAmountMinor},
-		filters:    map[string]string{"pipeline_id": colPipelineID, "status": "t.status", "owner_id": colOwnerID},
-		defaultBy:  []string{"stage_id"},
+		entity:    datasource.EntityDeal,
+		table:     "deal",
+		joins:     []string{joinStageForWinProbability},
+		baseWhere: whereArchivedNull,
+		basePlain: "live (unarchived) deals",
+		dimensions: map[string]string{
+			"stage_id":        colStageID,
+			"status":          "t.status",
+			"pipeline_id":     colPipelineID,
+			"win_probability": colWinProbability,
+		},
+		measures: map[string]string{
+			"amount_minor":          colAmountMinor,
+			"weighted_amount_minor": weightedAmountMinorExpr,
+		},
+		filters:   map[string]string{"pipeline_id": colPipelineID, "status": "t.status", "owner_id": colOwnerID, "stage_id": colStageID},
+		defaultBy: []string{"stage_id"},
 		defaultAggs: []reportAggregate{
 			{Fn: "count", As: "deals"},
 			{Fn: "sum", Field: "amount_minor", As: "amount_minor_sum"},

--- a/backend/internal/compose/report.go
+++ b/backend/internal/compose/report.go
@@ -46,6 +46,9 @@ const (
 	// stage for win_probability, so the forecast report and any other
 	// per-stage weighted figure cannot drift apart (review-loop rule 1).
 	weightedAmountMinorExpr = "round((t.amount_minor * s.win_probability) / 100.0)::bigint"
+	// fieldWeightedAmountMinor is the API-facing measure name every spec that
+	// defines weightedAmountMinorExpr registers it under.
+	fieldWeightedAmountMinor = "weighted_amount_minor"
 )
 
 type reportAggregate struct {
@@ -131,17 +134,17 @@ var prebuiltReports = map[string]reportSpec{
 		baseWhere: whereArchivedNull,
 		basePlain: "live (unarchived) deals",
 		dimensions: map[string]string{
-			"stage_id":        colStageID,
-			"status":          "t.status",
-			"pipeline_id":     colPipelineID,
+			paramStageID:      colStageID,
+			paramStatus:       "t.status",
+			paramPipelineID:   colPipelineID,
 			"win_probability": colWinProbability,
 		},
 		measures: map[string]string{
-			"amount_minor":          colAmountMinor,
-			"weighted_amount_minor": weightedAmountMinorExpr,
+			"amount_minor":           colAmountMinor,
+			fieldWeightedAmountMinor: weightedAmountMinorExpr,
 		},
-		filters:   map[string]string{"pipeline_id": colPipelineID, "status": "t.status", "owner_id": colOwnerID, "stage_id": colStageID},
-		defaultBy: []string{"stage_id"},
+		filters:   map[string]string{paramPipelineID: colPipelineID, paramStatus: "t.status", paramOwnerID: colOwnerID, paramStageID: colStageID},
+		defaultBy: []string{paramStageID},
 		defaultAggs: []reportAggregate{
 			{Fn: "count", As: "deals"},
 			{Fn: "sum", Field: "amount_minor", As: "amount_minor_sum"},
@@ -172,25 +175,25 @@ var prebuiltReports = map[string]reportSpec{
 	"forecast": {
 		entity:    datasource.EntityDeal,
 		table:     "deal",
-		joins:     []string{"JOIN stage s ON s.id = t.stage_id"},
+		joins:     []string{joinStageForWinProbability},
 		baseWhere: "t.archived_at IS NULL AND t.status = 'open'",
 		basePlain: "open, unarchived deals (win probability read live from the deal's current stage; a commit/best_case deal whose close date is past, missing, or provisional reports as 'slipped' instead, per formulas §11)",
 		dimensions: map[string]string{
-			"owner_id":          colOwnerID,
-			"stage_id":          colStageID,
-			"pipeline_id":       colPipelineID,
+			paramOwnerID:        colOwnerID,
+			paramStageID:        colStageID,
+			paramPipelineID:     colPipelineID,
 			"forecast_category": forecastCategoryExpr,
 			"currency":          "t.currency",
-			"win_probability":   "s.win_probability",
+			"win_probability":   colWinProbability,
 		},
 		measures: map[string]string{
-			"amount_minor":          colAmountMinor,
-			"weighted_amount_minor": "round((t.amount_minor * s.win_probability) / 100.0)::bigint",
+			"amount_minor":           colAmountMinor,
+			fieldWeightedAmountMinor: weightedAmountMinorExpr,
 		},
 		filters: map[string]string{
-			"owner_id":          colOwnerID,
-			"stage_id":          colStageID,
-			"pipeline_id":       colPipelineID,
+			paramOwnerID:        colOwnerID,
+			paramStageID:        colStageID,
+			paramPipelineID:     colPipelineID,
 			"forecast_category": forecastCategoryExpr,
 			"currency":          "t.currency",
 		},
@@ -198,7 +201,7 @@ var prebuiltReports = map[string]reportSpec{
 		defaultAggs: []reportAggregate{
 			{Fn: "count", As: "deals"},
 			{Fn: "sum", Field: "amount_minor", As: "unweighted_minor"},
-			{Fn: "sum", Field: "weighted_amount_minor", As: "weighted_minor"},
+			{Fn: "sum", Field: fieldWeightedAmountMinor, As: "weighted_minor"},
 		},
 	},
 }

--- a/backend/internal/compose/report_dealsbystage_integration_test.go
+++ b/backend/internal/compose/report_dealsbystage_integration_test.go
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package compose
+
+// The deals-by-stage report's weighted figure (AC-F1): the
+// per-stage weighted total must equal the sum of each constituent deal's
+// OWN rounded weighted value, not the stage's probability applied once to
+// the summed raw total — the same invariant the forecast report already
+// proves for itself in report_forecast_integration_test.go. The board
+// (frontend/src/screens/deals.tsx) and the reports screen's deals-by-stage
+// table both need this figure; neither carries per-deal rows to round
+// client-side, so the engine has to compute it the AC-F1 way.
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func (e *forecastEnv) runDealsByStage(t *testing.T, ctx context.Context, body string) reportResultWire {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/v1/reports/deals-by-stage", strings.NewReader(body)).WithContext(ctx)
+	rec := httptest.NewRecorder()
+	e.handlers.RunReport(rec, req, "deals-by-stage")
+	var result reportResultWire
+	decodeWire(t, rec, http.StatusOK, &result)
+	return result
+}
+
+func TestDealsByStageWeightedReconcilesToPerDealRounding(t *testing.T) {
+	e := setupForecast(t)
+
+	// Amounts chosen so per-deal rounding is exercised (12341×60% is not
+	// whole after /100): round(Σamount×p/100) and Σround(amount×p/100)
+	// disagree for this exact stage's constituents.
+	e.seedOpenDeal(t, "Alpha", 60, nil, int64p(100000), stringp("commit"))
+	e.seedOpenDeal(t, "Beta", 60, nil, int64p(12341), stringp("commit"))
+
+	result := e.runDealsByStage(t, e.Admin(), fmt.Sprintf(
+		`{"group_by":["stage_id"],"aggregates":[{"fn":"count","as":"deals"},{"fn":"sum","field":"amount_minor","as":"amount_minor_sum"},{"fn":"sum","field":"weighted_amount_minor","as":"weighted_minor"}],"filters":{"stage_id":%q}}`,
+		e.stages[60].String()))
+	if len(result.Rows) != 1 {
+		t.Fatalf("rows = %+v, want exactly one stage group", result.Rows)
+	}
+	row := result.Rows[0]
+
+	wantWeighted := weightedMinor(100000, 60) + weightedMinor(12341, 60)
+	wrongWeighted := int64(100000+12341) * 60 / 100 // round(Σamount × p / 100): the bug this measure fixes
+	if got := wireInt(t, row, "weighted_minor"); got != wantWeighted {
+		if got == wrongWeighted {
+			t.Fatalf("weighted_minor = %d (round(sum)×p/100), want %d (Σround(amount×p/100) — per-deal rounding)", got, wantWeighted)
+		}
+		t.Fatalf("weighted_minor = %d, want %d", got, wantWeighted)
+	}
+	if got := wireInt(t, row, "amount_minor_sum"); got != 100000+12341 {
+		t.Errorf("amount_minor_sum = %d, want %d", got, 100000+12341)
+	}
+}
+
+// The measure is published on the catalog and readable through
+// "Explain This Number" like every other measure on this report — no
+// second, undocumented vocabulary.
+func TestDealsByStageWeightedIsInTheCatalog(t *testing.T) {
+	spec, ok := prebuiltReports["deals-by-stage"]
+	if !ok {
+		t.Fatal("deals-by-stage is not a served report")
+	}
+	if _, ok := spec.measures["weighted_amount_minor"]; !ok {
+		t.Fatal("deals-by-stage has no weighted_amount_minor measure")
+	}
+	if _, ok := spec.dimensions["win_probability"]; !ok {
+		t.Fatal("deals-by-stage has no win_probability dimension to derive the weighted measure from")
+	}
+	found := false
+	for _, entry := range reportToolCatalog() {
+		if entry.Report != "deals-by-stage" {
+			continue
+		}
+		for _, name := range entry.Aggregates {
+			if name == "weighted_amount_minor" {
+				found = true
+			}
+		}
+	}
+	if !found {
+		t.Error("reportToolCatalog does not advertise deals-by-stage's weighted_amount_minor measure")
+	}
+}

--- a/backend/internal/compose/report_dealsbystage_integration_test.go
+++ b/backend/internal/compose/report_dealsbystage_integration_test.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 )
 
-func (e *forecastEnv) runDealsByStage(t *testing.T, ctx context.Context, body string) reportResultWire {
+func (e *forecastEnv) runDealsByStage(ctx context.Context, t *testing.T, body string) reportResultWire {
 	t.Helper()
 	req := httptest.NewRequest(http.MethodPost, "/v1/reports/deals-by-stage", strings.NewReader(body)).WithContext(ctx)
 	rec := httptest.NewRecorder()
@@ -42,7 +42,7 @@ func TestDealsByStageWeightedReconcilesToPerDealRounding(t *testing.T) {
 	e.seedOpenDeal(t, "Alpha", 60, nil, int64p(100000), stringp("commit"))
 	e.seedOpenDeal(t, "Beta", 60, nil, int64p(12341), stringp("commit"))
 
-	result := e.runDealsByStage(t, e.Admin(), fmt.Sprintf(
+	result := e.runDealsByStage(e.Admin(), t, fmt.Sprintf(
 		`{"group_by":["stage_id"],"aggregates":[{"fn":"count","as":"deals"},{"fn":"sum","field":"amount_minor","as":"amount_minor_sum"},{"fn":"sum","field":"weighted_amount_minor","as":"weighted_minor"}],"filters":{"stage_id":%q}}`,
 		e.stages[60].String()))
 	if len(result.Rows) != 1 {
@@ -71,7 +71,7 @@ func TestDealsByStageWeightedIsInTheCatalog(t *testing.T) {
 	if !ok {
 		t.Fatal("deals-by-stage is not a served report")
 	}
-	if _, ok := spec.measures["weighted_amount_minor"]; !ok {
+	if _, ok := spec.measures[fieldWeightedAmountMinor]; !ok {
 		t.Fatal("deals-by-stage has no weighted_amount_minor measure")
 	}
 	if _, ok := spec.dimensions["win_probability"]; !ok {
@@ -83,7 +83,7 @@ func TestDealsByStageWeightedIsInTheCatalog(t *testing.T) {
 			continue
 		}
 		for _, name := range entry.Aggregates {
-			if name == "weighted_amount_minor" {
+			if name == fieldWeightedAmountMinor {
 				found = true
 			}
 		}

--- a/backend/internal/compose/report_dealsbystage_integration_test.go
+++ b/backend/internal/compose/report_dealsbystage_integration_test.go
@@ -21,6 +21,8 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 )
 
 func (e *forecastEnv) runDealsByStage(ctx context.Context, t *testing.T, body string) reportResultWire {
@@ -33,14 +35,26 @@ func (e *forecastEnv) runDealsByStage(ctx context.Context, t *testing.T, body st
 	return result
 }
 
+func (e *forecastEnv) explainDealsByStage(ctx context.Context, t *testing.T, handleURL string) derivationWire {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, handleURL, nil).WithContext(ctx)
+	rec := httptest.NewRecorder()
+	e.handlers.ExplainReport(rec, req, "deals-by-stage", crmcontracts.ExplainReportParams{})
+	var result derivationWire
+	decodeWire(t, rec, http.StatusOK, &result)
+	return result
+}
+
 func TestDealsByStageWeightedReconcilesToPerDealRounding(t *testing.T) {
 	e := setupForecast(t)
 
-	// Amounts chosen so per-deal rounding is exercised (12341×60% is not
-	// whole after /100): round(Σamount×p/100) and Σround(amount×p/100)
-	// disagree for this exact stage's constituents.
-	e.seedOpenDeal(t, "Alpha", 60, nil, int64p(100000), stringp("commit"))
-	e.seedOpenDeal(t, "Beta", 60, nil, int64p(12341), stringp("commit"))
+	// Two equal deals whose OWN weighted values each round UP (12341×60% =
+	// 7404.6 → 7405), while their combined raw total rounds DOWN
+	// (24682×60% = 14809.2 → 14809): round(Σamount×p/100) and
+	// Σround(amount×p/100) disagree by exactly 1 for this stage.
+	const dealAmount = int64(12341)
+	e.seedOpenDeal(t, "Alpha", 60, nil, int64p(dealAmount), stringp("commit"))
+	e.seedOpenDeal(t, "Beta", 60, nil, int64p(dealAmount), stringp("commit"))
 
 	result := e.runDealsByStage(e.Admin(), t, fmt.Sprintf(
 		`{"group_by":["stage_id"],"aggregates":[{"fn":"count","as":"deals"},{"fn":"sum","field":"amount_minor","as":"amount_minor_sum"},{"fn":"sum","field":"weighted_amount_minor","as":"weighted_minor"}],"filters":{"stage_id":%q}}`,
@@ -50,45 +64,68 @@ func TestDealsByStageWeightedReconcilesToPerDealRounding(t *testing.T) {
 	}
 	row := result.Rows[0]
 
-	wantWeighted := weightedMinor(100000, 60) + weightedMinor(12341, 60)
-	wrongWeighted := int64(100000+12341) * 60 / 100 // round(Σamount × p / 100): the bug this measure fixes
+	wantWeighted := weightedMinor(dealAmount, 60) + weightedMinor(dealAmount, 60)
+	wrongWeighted := weightedMinor(2*dealAmount, 60) // round(Σamount × p / 100): the bug this measure fixes
+	if wantWeighted == wrongWeighted {
+		t.Fatal("fixture is broken: the two methodologies agree, so this test cannot discriminate between them")
+	}
 	if got := wireInt(t, row, "weighted_minor"); got != wantWeighted {
 		if got == wrongWeighted {
 			t.Fatalf("weighted_minor = %d (round(sum)×p/100), want %d (Σround(amount×p/100) — per-deal rounding)", got, wantWeighted)
 		}
 		t.Fatalf("weighted_minor = %d, want %d", got, wantWeighted)
 	}
-	if got := wireInt(t, row, "amount_minor_sum"); got != 100000+12341 {
-		t.Errorf("amount_minor_sum = %d, want %d", got, 100000+12341)
+	if got := wireInt(t, row, "amount_minor_sum"); got != 2*dealAmount {
+		t.Errorf("amount_minor_sum = %d, want %d", got, 2*dealAmount)
 	}
 }
 
-// The measure is published on the catalog and readable through
-// "Explain This Number" like every other measure on this report — no
-// second, undocumented vocabulary.
-func TestDealsByStageWeightedIsInTheCatalog(t *testing.T) {
-	spec, ok := prebuiltReports["deals-by-stage"]
-	if !ok {
-		t.Fatal("deals-by-stage is not a served report")
+// The measure's vocabulary membership (catalog advertises it, engine
+// accepts it) is already proven generically, for every measure of every
+// report, by TestReportToolCatalogPublishesOnlyWhatTheEngineAccepts and
+// TestReportToolCatalogOmitsNothingTheEngineAccepts in reportcatalog_test.go
+// — both derive their expectations from prebuiltReports, so this measure
+// is covered the moment it exists in the spec. What those generic tests
+// cannot prove is that "Explain This Number" resolves it correctly: the
+// drill-through source rows must carry weighted_amount_minor and reconcile
+// exactly to the displayed weighted_minor, the same AC-F1 guarantee the
+// forecast report proves for itself.
+func TestDealsByStageWeightedDerivationReconcilesExactly(t *testing.T) {
+	e := setupForecast(t)
+	e.seedOpenDeal(t, "Alpha", 60, nil, int64p(12341), stringp("commit"))
+	e.seedOpenDeal(t, "Beta", 60, nil, int64p(12341), stringp("commit"))
+	// A different stage's deal must not leak into the group being explained.
+	e.seedOpenDeal(t, "Elsewhere", 20, nil, int64p(999999), stringp("commit"))
+
+	result := e.runDealsByStage(e.Admin(), t, fmt.Sprintf(
+		`{"group_by":["stage_id"],"aggregates":[{"fn":"count","as":"deals"},{"fn":"sum","field":"amount_minor","as":"amount_minor_sum"},{"fn":"sum","field":"weighted_amount_minor","as":"weighted_minor"}],"filters":{"stage_id":%q}}`,
+		e.stages[60].String()))
+	if len(result.Rows) != 1 {
+		t.Fatalf("rows = %+v, want exactly one stage group", result.Rows)
 	}
-	if _, ok := spec.measures[fieldWeightedAmountMinor]; !ok {
-		t.Fatal("deals-by-stage has no weighted_amount_minor measure")
+	row := result.Rows[0]
+	handle, ok := row["derivation_url"].(string)
+	if !ok || handle == "" {
+		t.Fatalf("aggregate row has no derivation_url: %+v", row)
 	}
-	if _, ok := spec.dimensions["win_probability"]; !ok {
-		t.Fatal("deals-by-stage has no win_probability dimension to derive the weighted measure from")
+
+	derivation := e.explainDealsByStage(e.Admin(), t, handle)
+	if len(derivation.Rows) != 2 || derivation.TotalRows != 2 {
+		t.Fatalf("drill-through = %d rows (total %d), want the stage's 2 deals: %+v",
+			len(derivation.Rows), derivation.TotalRows, derivation.Rows)
 	}
-	found := false
-	for _, entry := range reportToolCatalog() {
-		if entry.Report != "deals-by-stage" {
-			continue
+	var weighted int64
+	for _, source := range derivation.Rows {
+		amount := wireInt(t, source, "amount_minor")
+		probability := wireInt(t, source, "win_probability")
+		rowWeighted := wireInt(t, source, "weighted_amount_minor")
+		if rowWeighted != weightedMinor(amount, probability) {
+			t.Errorf("source row weighted = %d, want round(%d × %d%%) = %d",
+				rowWeighted, amount, probability, weightedMinor(amount, probability))
 		}
-		for _, name := range entry.Aggregates {
-			if name == fieldWeightedAmountMinor {
-				found = true
-			}
-		}
+		weighted += rowWeighted
 	}
-	if !found {
-		t.Error("reportToolCatalog does not advertise deals-by-stage's weighted_amount_minor measure")
+	if weighted != wireInt(t, row, "weighted_minor") {
+		t.Errorf("drill-through weighted sum %d != displayed %d", weighted, wireInt(t, row, "weighted_minor"))
 	}
 }

--- a/backend/internal/compose/report_dealsbystage_integration_test.go
+++ b/backend/internal/compose/report_dealsbystage_integration_test.go
@@ -32,7 +32,7 @@ func TestDealsByStageWeightedReconcilesToPerDealRounding(t *testing.T) {
 	// A different stage's deal must not fold into the group under test.
 	e.seedOpenDeal(t, "Elsewhere", 20, nil, int64p(999999), stringp("commit"))
 
-	result := e.runReport(t, e.Admin(), "deals-by-stage",
+	result := e.runReport(e.Admin(), t, "deals-by-stage",
 		`{"group_by":["stage_id"],"aggregates":[{"fn":"count","as":"deals"},{"fn":"sum","field":"amount_minor","as":"amount_minor_sum"},{"fn":"sum","field":"weighted_amount_minor","as":"weighted_minor"}]}`)
 	row := dealsByStageRow(t, result, e.stages[60].String())
 
@@ -62,7 +62,7 @@ func TestDealsByStageWeightedDerivationReconcilesExactly(t *testing.T) {
 	e.seedOpenDeal(t, "Beta", 60, nil, int64p(12341), stringp("commit"))
 	e.seedOpenDeal(t, "Elsewhere", 20, nil, int64p(999999), stringp("commit"))
 
-	result := e.runReport(t, e.Admin(), "deals-by-stage",
+	result := e.runReport(e.Admin(), t, "deals-by-stage",
 		`{"group_by":["stage_id"],"aggregates":[{"fn":"count","as":"deals"},{"fn":"sum","field":"amount_minor","as":"amount_minor_sum"},{"fn":"sum","field":"weighted_amount_minor","as":"weighted_minor"}]}`)
 	row := dealsByStageRow(t, result, e.stages[60].String())
 	handle, ok := row["derivation_url"].(string)
@@ -70,7 +70,7 @@ func TestDealsByStageWeightedDerivationReconcilesExactly(t *testing.T) {
 		t.Fatalf("aggregate row has no derivation_url: %+v", row)
 	}
 
-	derivation := e.explainReport(t, e.Admin(), "deals-by-stage", handle)
+	derivation := e.explainReport(e.Admin(), t, "deals-by-stage", handle)
 	if len(derivation.Rows) != 2 || derivation.TotalRows != 2 {
 		t.Fatalf("drill-through = %d rows (total %d), want the stage's 2 deals: %+v",
 			len(derivation.Rows), derivation.TotalRows, derivation.Rows)
@@ -101,7 +101,7 @@ func TestDealsByStageDerivationHonorsRowScope(t *testing.T) {
 	e.seedOpenDeal(t, "Theirs", 60, &e.Rep3, int64p(999999), stringp("commit"))
 
 	rep := e.dealReadCtx(e.Rep1, nil, principal.RowScopeOwn)
-	result := e.runReport(t, rep, "deals-by-stage",
+	result := e.runReport(rep, t, "deals-by-stage",
 		`{"group_by":["stage_id"],"aggregates":[{"fn":"count","as":"deals"},{"fn":"sum","field":"amount_minor","as":"amount_minor_sum"},{"fn":"sum","field":"weighted_amount_minor","as":"weighted_minor"}]}`)
 	row := dealsByStageRow(t, result, e.stages[60].String())
 	if got := wireInt(t, row, "deals"); got != 1 {
@@ -115,7 +115,7 @@ func TestDealsByStageDerivationHonorsRowScope(t *testing.T) {
 	if !ok || handle == "" {
 		t.Fatalf("aggregate row has no derivation_url: %+v", row)
 	}
-	derivation := e.explainReport(t, rep, "deals-by-stage", handle)
+	derivation := e.explainReport(rep, t, "deals-by-stage", handle)
 	if derivation.TotalRows != 1 {
 		t.Errorf("own-scope drill-through total = %d, want 1 (never the foreign deal)", derivation.TotalRows)
 	}

--- a/backend/internal/compose/report_dealsbystage_integration_test.go
+++ b/backend/internal/compose/report_dealsbystage_integration_test.go
@@ -5,45 +5,19 @@
 
 package compose
 
-// The deals-by-stage report's weighted figure (AC-F1): the
-// per-stage weighted total must equal the sum of each constituent deal's
-// OWN rounded weighted value, not the stage's probability applied once to
-// the summed raw total — the same invariant the forecast report already
-// proves for itself in report_forecast_integration_test.go. The board
-// (frontend/src/screens/deals.tsx) and the reports screen's deals-by-stage
-// table both need this figure; neither carries per-deal rows to round
-// client-side, so the engine has to compute it the AC-F1 way.
+// The deals-by-stage report's weighted figure (AC-F1): the per-stage
+// weighted total must equal the sum of each constituent deal's OWN rounded
+// weighted value, not the stage's probability applied once to the summed
+// raw total — the same invariant the forecast report already proves for
+// itself in report_forecast_integration_test.go. The reports screen's
+// deals-by-stage table reads a server aggregate with no per-deal rows to
+// round client-side, so the engine has to compute it the AC-F1 way.
 
 import (
-	"context"
-	"fmt"
-	"net/http"
-	"net/http/httptest"
-	"strings"
 	"testing"
 
-	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
-
-func (e *forecastEnv) runDealsByStage(ctx context.Context, t *testing.T, body string) reportResultWire {
-	t.Helper()
-	req := httptest.NewRequest(http.MethodPost, "/v1/reports/deals-by-stage", strings.NewReader(body)).WithContext(ctx)
-	rec := httptest.NewRecorder()
-	e.handlers.RunReport(rec, req, "deals-by-stage")
-	var result reportResultWire
-	decodeWire(t, rec, http.StatusOK, &result)
-	return result
-}
-
-func (e *forecastEnv) explainDealsByStage(ctx context.Context, t *testing.T, handleURL string) derivationWire {
-	t.Helper()
-	req := httptest.NewRequest(http.MethodGet, handleURL, nil).WithContext(ctx)
-	rec := httptest.NewRecorder()
-	e.handlers.ExplainReport(rec, req, "deals-by-stage", crmcontracts.ExplainReportParams{})
-	var result derivationWire
-	decodeWire(t, rec, http.StatusOK, &result)
-	return result
-}
 
 func TestDealsByStageWeightedReconcilesToPerDealRounding(t *testing.T) {
 	e := setupForecast(t)
@@ -55,23 +29,21 @@ func TestDealsByStageWeightedReconcilesToPerDealRounding(t *testing.T) {
 	const dealAmount = int64(12341)
 	e.seedOpenDeal(t, "Alpha", 60, nil, int64p(dealAmount), stringp("commit"))
 	e.seedOpenDeal(t, "Beta", 60, nil, int64p(dealAmount), stringp("commit"))
+	// A different stage's deal must not fold into the group under test.
+	e.seedOpenDeal(t, "Elsewhere", 20, nil, int64p(999999), stringp("commit"))
 
-	result := e.runDealsByStage(e.Admin(), t, fmt.Sprintf(
-		`{"group_by":["stage_id"],"aggregates":[{"fn":"count","as":"deals"},{"fn":"sum","field":"amount_minor","as":"amount_minor_sum"},{"fn":"sum","field":"weighted_amount_minor","as":"weighted_minor"}],"filters":{"stage_id":%q}}`,
-		e.stages[60].String()))
-	if len(result.Rows) != 1 {
-		t.Fatalf("rows = %+v, want exactly one stage group", result.Rows)
-	}
-	row := result.Rows[0]
+	result := e.runReport(t, e.Admin(), "deals-by-stage",
+		`{"group_by":["stage_id"],"aggregates":[{"fn":"count","as":"deals"},{"fn":"sum","field":"amount_minor","as":"amount_minor_sum"},{"fn":"sum","field":"weighted_amount_minor","as":"weighted_minor"}]}`)
+	row := dealsByStageRow(t, result, e.stages[60].String())
 
 	wantWeighted := weightedMinor(dealAmount, 60) + weightedMinor(dealAmount, 60)
-	wrongWeighted := weightedMinor(2*dealAmount, 60) // round(Σamount × p / 100): the bug this measure fixes
-	if wantWeighted == wrongWeighted {
+	sumFirstWeighted := weightedMinor(2*dealAmount, 60) // round(Σamount × p / 100) — the rejected methodology
+	if wantWeighted == sumFirstWeighted {
 		t.Fatal("fixture is broken: the two methodologies agree, so this test cannot discriminate between them")
 	}
 	if got := wireInt(t, row, "weighted_minor"); got != wantWeighted {
-		if got == wrongWeighted {
-			t.Fatalf("weighted_minor = %d (round(sum)×p/100), want %d (Σround(amount×p/100) — per-deal rounding)", got, wantWeighted)
+		if got == sumFirstWeighted {
+			t.Fatalf("weighted_minor = %d (rounded the column sum once), want %d (Σround(amount×p/100) — rounded per deal, then summed)", got, wantWeighted)
 		}
 		t.Fatalf("weighted_minor = %d, want %d", got, wantWeighted)
 	}
@@ -80,36 +52,25 @@ func TestDealsByStageWeightedReconcilesToPerDealRounding(t *testing.T) {
 	}
 }
 
-// The measure's vocabulary membership (catalog advertises it, engine
-// accepts it) is already proven generically, for every measure of every
-// report, by TestReportToolCatalogPublishesOnlyWhatTheEngineAccepts and
-// TestReportToolCatalogOmitsNothingTheEngineAccepts in reportcatalog_test.go
-// — both derive their expectations from prebuiltReports, so this measure
-// is covered the moment it exists in the spec. What those generic tests
-// cannot prove is that "Explain This Number" resolves it correctly: the
-// drill-through source rows must carry weighted_amount_minor and reconcile
-// exactly to the displayed weighted_minor, the same AC-F1 guarantee the
-// forecast report proves for itself.
+// "Explain This Number" must resolve the new measure too: its drill-through
+// source rows carry weighted_amount_minor and reconcile exactly to the
+// displayed weighted_minor, the same AC-F1 guarantee the forecast report
+// proves for itself in TestForecastDerivationDrillThroughReconcilesExactly.
 func TestDealsByStageWeightedDerivationReconcilesExactly(t *testing.T) {
 	e := setupForecast(t)
 	e.seedOpenDeal(t, "Alpha", 60, nil, int64p(12341), stringp("commit"))
 	e.seedOpenDeal(t, "Beta", 60, nil, int64p(12341), stringp("commit"))
-	// A different stage's deal must not leak into the group being explained.
 	e.seedOpenDeal(t, "Elsewhere", 20, nil, int64p(999999), stringp("commit"))
 
-	result := e.runDealsByStage(e.Admin(), t, fmt.Sprintf(
-		`{"group_by":["stage_id"],"aggregates":[{"fn":"count","as":"deals"},{"fn":"sum","field":"amount_minor","as":"amount_minor_sum"},{"fn":"sum","field":"weighted_amount_minor","as":"weighted_minor"}],"filters":{"stage_id":%q}}`,
-		e.stages[60].String()))
-	if len(result.Rows) != 1 {
-		t.Fatalf("rows = %+v, want exactly one stage group", result.Rows)
-	}
-	row := result.Rows[0]
+	result := e.runReport(t, e.Admin(), "deals-by-stage",
+		`{"group_by":["stage_id"],"aggregates":[{"fn":"count","as":"deals"},{"fn":"sum","field":"amount_minor","as":"amount_minor_sum"},{"fn":"sum","field":"weighted_amount_minor","as":"weighted_minor"}]}`)
+	row := dealsByStageRow(t, result, e.stages[60].String())
 	handle, ok := row["derivation_url"].(string)
 	if !ok || handle == "" {
 		t.Fatalf("aggregate row has no derivation_url: %+v", row)
 	}
 
-	derivation := e.explainDealsByStage(e.Admin(), t, handle)
+	derivation := e.explainReport(t, e.Admin(), "deals-by-stage", handle)
 	if len(derivation.Rows) != 2 || derivation.TotalRows != 2 {
 		t.Fatalf("drill-through = %d rows (total %d), want the stage's 2 deals: %+v",
 			len(derivation.Rows), derivation.TotalRows, derivation.Rows)
@@ -128,4 +89,50 @@ func TestDealsByStageWeightedDerivationReconcilesExactly(t *testing.T) {
 	if weighted != wireInt(t, row, "weighted_minor") {
 		t.Errorf("drill-through weighted sum %d != displayed %d", weighted, wireInt(t, row, "weighted_minor"))
 	}
+}
+
+// The stage join must not widen what a team-scoped rep's drill-through sees:
+// the same row-scope clause the forecast suite proves in
+// TestForecastDerivationHonorsRowScope applies here too, and a foreign
+// owner's deal in the SAME stage must stay invisible.
+func TestDealsByStageDerivationHonorsRowScope(t *testing.T) {
+	e := setupForecast(t)
+	e.seedOpenDeal(t, "Mine", 60, &e.Rep1, int64p(10000), stringp("commit"))
+	e.seedOpenDeal(t, "Theirs", 60, &e.Rep3, int64p(999999), stringp("commit"))
+
+	rep := e.dealReadCtx(e.Rep1, nil, principal.RowScopeOwn)
+	result := e.runReport(t, rep, "deals-by-stage",
+		`{"group_by":["stage_id"],"aggregates":[{"fn":"count","as":"deals"},{"fn":"sum","field":"amount_minor","as":"amount_minor_sum"},{"fn":"sum","field":"weighted_amount_minor","as":"weighted_minor"}]}`)
+	row := dealsByStageRow(t, result, e.stages[60].String())
+	if got := wireInt(t, row, "deals"); got != 1 {
+		t.Fatalf("deals = %d, want 1 — the foreign rep's deal in the same stage must not be counted", got)
+	}
+	if got := wireInt(t, row, "weighted_minor"); got != weightedMinor(10000, 60) {
+		t.Errorf("weighted_minor = %d, want %d (only the caller's own deal)", got, weightedMinor(10000, 60))
+	}
+
+	handle, ok := row["derivation_url"].(string)
+	if !ok || handle == "" {
+		t.Fatalf("aggregate row has no derivation_url: %+v", row)
+	}
+	derivation := e.explainReport(t, rep, "deals-by-stage", handle)
+	if derivation.TotalRows != 1 {
+		t.Errorf("own-scope drill-through total = %d, want 1 (never the foreign deal)", derivation.TotalRows)
+	}
+}
+
+// dealsByStageRow picks the aggregate row for one stage out of a
+// group-by-stage_id result — the report is fetched with no stage_id
+// filter (there is no caller for one; grouping already answers "per
+// stage"), so the test selects its row the way TestForecastByOwnerCounts…
+// selects by owner_id.
+func dealsByStageRow(t *testing.T, result reportResultWire, stageID string) map[string]any {
+	t.Helper()
+	for _, row := range result.Rows {
+		if row["stage_id"] == stageID {
+			return row
+		}
+	}
+	t.Fatalf("no row for stage_id %q in %+v", stageID, result.Rows)
+	return nil
 }

--- a/backend/internal/compose/report_forecast_integration_test.go
+++ b/backend/internal/compose/report_forecast_integration_test.go
@@ -203,7 +203,7 @@ func decodeWire(t *testing.T, rec *httptest.ResponseRecorder, wantStatus int, in
 // suite in this package shares one spelling of "POST /reports/{report}" and
 // "GET .../derivation" against the real handlers, rather than each report's
 // suite growing its own copy that differs only in the key.
-func (e *forecastEnv) runReport(t *testing.T, ctx context.Context, report, body string) reportResultWire {
+func (e *forecastEnv) runReport(ctx context.Context, t *testing.T, report, body string) reportResultWire {
 	t.Helper()
 	req := httptest.NewRequest(http.MethodPost, "/v1/reports/"+report, strings.NewReader(body)).WithContext(ctx)
 	rec := httptest.NewRecorder()
@@ -213,7 +213,7 @@ func (e *forecastEnv) runReport(t *testing.T, ctx context.Context, report, body 
 	return result
 }
 
-func (e *forecastEnv) explainReport(t *testing.T, ctx context.Context, report, handleURL string) derivationWire {
+func (e *forecastEnv) explainReport(ctx context.Context, t *testing.T, report, handleURL string) derivationWire {
 	t.Helper()
 	req := httptest.NewRequest(http.MethodGet, handleURL, nil).WithContext(ctx)
 	rec := httptest.NewRecorder()
@@ -274,7 +274,7 @@ func TestForecastRollupReconcilesToConstituentDeals(t *testing.T) {
 	e.seed(t, `INSERT INTO deal (id, workspace_id, name, pipeline_id, stage_id, amount_minor, currency, archived_at, source, captured_by)
 		VALUES ($1, $2, 'Archived', $3, $4, 77777, 'EUR', now(), 'manual', 'human:x')`, e.pipeline, e.stages[60])
 
-	result := e.runReport(t, e.Admin(), "forecast", `{"group_by":["forecast_category"]}`)
+	result := e.runReport(e.Admin(), t, "forecast", `{"group_by":["forecast_category"]}`)
 	if len(result.Rows) != 3 {
 		t.Fatalf("rows = %d (%+v), want commit + best_case + the NULL group", len(result.Rows), result.Rows)
 	}
@@ -342,7 +342,7 @@ func TestForecastByOwnerCountsAMultiStakeholderDealOnce(t *testing.T) {
 			VALUES ($1, $2, 'deal_stakeholder', $3, $4, $5, 'manual', 'human:x')`, dealID, personID, role)
 	}
 
-	result := e.runReport(t, e.Admin(), "forecast", `{"group_by":["owner_id"]}`)
+	result := e.runReport(e.Admin(), t, "forecast", `{"group_by":["owner_id"]}`)
 	if len(result.Rows) != 1 {
 		t.Fatalf("rows = %+v, want exactly one owner group", result.Rows)
 	}
@@ -372,7 +372,7 @@ func TestForecastDerivationDrillThroughReconcilesExactly(t *testing.T) {
 	e.seedOpenDeal(t, "Gamma", 55, &e.Rep1, nil, stringp("commit"))
 	e.seedOpenDeal(t, "Foreign owner", 60, &e.Rep3, int64p(999999), stringp("commit"))
 
-	result := e.runReport(t, e.Admin(), "forecast", `{"group_by":["owner_id"]}`)
+	result := e.runReport(e.Admin(), t, "forecast", `{"group_by":["owner_id"]}`)
 	var row map[string]any
 	for _, r := range result.Rows {
 		if r["owner_id"] == e.Rep1.String() {
@@ -387,7 +387,7 @@ func TestForecastDerivationDrillThroughReconcilesExactly(t *testing.T) {
 	if !ok || handle == "" {
 		t.Fatalf("aggregate row has no derivation_url: %+v", row)
 	}
-	derivation := e.explainReport(t, e.Admin(), "forecast", handle)
+	derivation := e.explainReport(e.Admin(), t, "forecast", handle)
 
 	for _, phrase := range []string{
 		"open, unarchived deals",
@@ -445,12 +445,12 @@ func TestForecastDerivationHonorsRowScope(t *testing.T) {
 	e.seedOpenDeal(t, "Theirs", 20, &e.Rep3, int64p(40000), stringp("commit"))
 
 	rep := e.dealReadCtx(e.Rep1, []ids.UUID{e.Team1}, principal.RowScopeTeam)
-	result := e.runReport(t, rep, "forecast", `{"group_by":["owner_id"]}`)
+	result := e.runReport(rep, t, "forecast", `{"group_by":["owner_id"]}`)
 	if len(result.Rows) != 1 || result.Rows[0]["owner_id"] != e.Rep1.String() {
 		t.Fatalf("team-scoped report rows = %+v, want only rep1's group", result.Rows)
 	}
 
-	derivation := e.explainReport(t, rep, "forecast", result.DerivationURL)
+	derivation := e.explainReport(rep, t, "forecast", result.DerivationURL)
 	if derivation.TotalRows != 2 || len(derivation.Rows) != 2 {
 		t.Fatalf("team-scoped drill-through = %d rows (total %d), want rep1's 2 deals",
 			len(derivation.Rows), derivation.TotalRows)
@@ -465,14 +465,14 @@ func TestForecastDerivationHonorsRowScope(t *testing.T) {
 
 	// A handle pinned to the foreign owner resolves to an EMPTY set
 	// under team scope — anything that returns a record is a read.
-	foreign := e.explainReport(t, rep, "forecast", "/v1/reports/forecast/derivation?by=owner_id&agg=count%3A%3Adeals&owner_id="+e.Rep3.String())
+	foreign := e.explainReport(rep, t, "forecast", "/v1/reports/forecast/derivation?by=owner_id&agg=count%3A%3Adeals&owner_id="+e.Rep3.String())
 	if foreign.TotalRows != 0 || len(foreign.Rows) != 0 {
 		t.Errorf("foreign-owner drill-through leaked %d rows (total %d)", len(foreign.Rows), foreign.TotalRows)
 	}
 
 	// Admin (row_scope=all) sees all three — the scope, not the data,
 	// made the difference.
-	full := e.explainReport(t, e.Admin(), "forecast", result.DerivationURL)
+	full := e.explainReport(e.Admin(), t, "forecast", result.DerivationURL)
 	if full.TotalRows != 3 {
 		t.Errorf("admin drill-through total = %d, want 3", full.TotalRows)
 	}

--- a/backend/internal/compose/report_forecast_integration_test.go
+++ b/backend/internal/compose/report_forecast_integration_test.go
@@ -199,21 +199,25 @@ func decodeWire(t *testing.T, rec *httptest.ResponseRecorder, wantStatus int, in
 	}
 }
 
-func (e *forecastEnv) runForecast(t *testing.T, ctx context.Context, body string) reportResultWire {
+// runReport and explainReport are generic over the report key so every
+// suite in this package shares one spelling of "POST /reports/{report}" and
+// "GET .../derivation" against the real handlers, rather than each report's
+// suite growing its own copy that differs only in the key.
+func (e *forecastEnv) runReport(t *testing.T, ctx context.Context, report, body string) reportResultWire {
 	t.Helper()
-	req := httptest.NewRequest(http.MethodPost, "/v1/reports/forecast", strings.NewReader(body)).WithContext(ctx)
+	req := httptest.NewRequest(http.MethodPost, "/v1/reports/"+report, strings.NewReader(body)).WithContext(ctx)
 	rec := httptest.NewRecorder()
-	e.handlers.RunReport(rec, req, "forecast")
+	e.handlers.RunReport(rec, req, report)
 	var result reportResultWire
 	decodeWire(t, rec, http.StatusOK, &result)
 	return result
 }
 
-func (e *forecastEnv) explain(t *testing.T, ctx context.Context, handleURL string) derivationWire {
+func (e *forecastEnv) explainReport(t *testing.T, ctx context.Context, report, handleURL string) derivationWire {
 	t.Helper()
 	req := httptest.NewRequest(http.MethodGet, handleURL, nil).WithContext(ctx)
 	rec := httptest.NewRecorder()
-	e.handlers.ExplainReport(rec, req, "forecast", crmcontracts.ExplainReportParams{})
+	e.handlers.ExplainReport(rec, req, report, crmcontracts.ExplainReportParams{})
 	var result derivationWire
 	decodeWire(t, rec, http.StatusOK, &result)
 	return result
@@ -270,7 +274,7 @@ func TestForecastRollupReconcilesToConstituentDeals(t *testing.T) {
 	e.seed(t, `INSERT INTO deal (id, workspace_id, name, pipeline_id, stage_id, amount_minor, currency, archived_at, source, captured_by)
 		VALUES ($1, $2, 'Archived', $3, $4, 77777, 'EUR', now(), 'manual', 'human:x')`, e.pipeline, e.stages[60])
 
-	result := e.runForecast(t, e.Admin(), `{"group_by":["forecast_category"]}`)
+	result := e.runReport(t, e.Admin(), "forecast", `{"group_by":["forecast_category"]}`)
 	if len(result.Rows) != 3 {
 		t.Fatalf("rows = %d (%+v), want commit + best_case + the NULL group", len(result.Rows), result.Rows)
 	}
@@ -338,7 +342,7 @@ func TestForecastByOwnerCountsAMultiStakeholderDealOnce(t *testing.T) {
 			VALUES ($1, $2, 'deal_stakeholder', $3, $4, $5, 'manual', 'human:x')`, dealID, personID, role)
 	}
 
-	result := e.runForecast(t, e.Admin(), `{"group_by":["owner_id"]}`)
+	result := e.runReport(t, e.Admin(), "forecast", `{"group_by":["owner_id"]}`)
 	if len(result.Rows) != 1 {
 		t.Fatalf("rows = %+v, want exactly one owner group", result.Rows)
 	}
@@ -368,7 +372,7 @@ func TestForecastDerivationDrillThroughReconcilesExactly(t *testing.T) {
 	e.seedOpenDeal(t, "Gamma", 55, &e.Rep1, nil, stringp("commit"))
 	e.seedOpenDeal(t, "Foreign owner", 60, &e.Rep3, int64p(999999), stringp("commit"))
 
-	result := e.runForecast(t, e.Admin(), `{"group_by":["owner_id"]}`)
+	result := e.runReport(t, e.Admin(), "forecast", `{"group_by":["owner_id"]}`)
 	var row map[string]any
 	for _, r := range result.Rows {
 		if r["owner_id"] == e.Rep1.String() {
@@ -383,7 +387,7 @@ func TestForecastDerivationDrillThroughReconcilesExactly(t *testing.T) {
 	if !ok || handle == "" {
 		t.Fatalf("aggregate row has no derivation_url: %+v", row)
 	}
-	derivation := e.explain(t, e.Admin(), handle)
+	derivation := e.explainReport(t, e.Admin(), "forecast", handle)
 
 	for _, phrase := range []string{
 		"open, unarchived deals",
@@ -441,12 +445,12 @@ func TestForecastDerivationHonorsRowScope(t *testing.T) {
 	e.seedOpenDeal(t, "Theirs", 20, &e.Rep3, int64p(40000), stringp("commit"))
 
 	rep := e.dealReadCtx(e.Rep1, []ids.UUID{e.Team1}, principal.RowScopeTeam)
-	result := e.runForecast(t, rep, `{"group_by":["owner_id"]}`)
+	result := e.runReport(t, rep, "forecast", `{"group_by":["owner_id"]}`)
 	if len(result.Rows) != 1 || result.Rows[0]["owner_id"] != e.Rep1.String() {
 		t.Fatalf("team-scoped report rows = %+v, want only rep1's group", result.Rows)
 	}
 
-	derivation := e.explain(t, rep, result.DerivationURL)
+	derivation := e.explainReport(t, rep, "forecast", result.DerivationURL)
 	if derivation.TotalRows != 2 || len(derivation.Rows) != 2 {
 		t.Fatalf("team-scoped drill-through = %d rows (total %d), want rep1's 2 deals",
 			len(derivation.Rows), derivation.TotalRows)
@@ -461,14 +465,14 @@ func TestForecastDerivationHonorsRowScope(t *testing.T) {
 
 	// A handle pinned to the foreign owner resolves to an EMPTY set
 	// under team scope — anything that returns a record is a read.
-	foreign := e.explain(t, rep, "/v1/reports/forecast/derivation?by=owner_id&agg=count%3A%3Adeals&owner_id="+e.Rep3.String())
+	foreign := e.explainReport(t, rep, "forecast", "/v1/reports/forecast/derivation?by=owner_id&agg=count%3A%3Adeals&owner_id="+e.Rep3.String())
 	if foreign.TotalRows != 0 || len(foreign.Rows) != 0 {
 		t.Errorf("foreign-owner drill-through leaked %d rows (total %d)", len(foreign.Rows), foreign.TotalRows)
 	}
 
 	// Admin (row_scope=all) sees all three — the scope, not the data,
 	// made the difference.
-	full := e.explain(t, e.Admin(), result.DerivationURL)
+	full := e.explainReport(t, e.Admin(), "forecast", result.DerivationURL)
 	if full.TotalRows != 3 {
 		t.Errorf("admin drill-through total = %d, want 3", full.TotalRows)
 	}

--- a/docs/reference/mcp-info.json
+++ b/docs/reference/mcp-info.json
@@ -10,16 +10,16 @@
   "totals": {
     "tools": 38,
     "resources": 8,
-    "tool_catalog_bytes": 108431,
+    "tool_catalog_bytes": 108481,
     "resource_catalog_bytes": 3108,
-    "approx_wire_tokens_total": 27884,
-    "largest_tool_bytes": 4151,
+    "approx_wire_tokens_total": 27897,
+    "largest_tool_bytes": 4201,
     "largest_tool": "run_report",
     "tool_catalog_composition": {
       "description_bytes": 29194,
-      "input_schema_bytes": 24979,
+      "input_schema_bytes": 25029,
       "output_schema_bytes": 45953,
-      "description_plus_input_schema_bytes": 54173
+      "description_plus_input_schema_bytes": 54223
     }
   },
   "tools": {
@@ -5099,7 +5099,7 @@
               "type": "array"
             },
             "report": {
-              "description": "The prebuilt report to run. Send `report` alone to get its defaults; the three plan arguments accept ONLY the names listed for that report. activities-by-kind — group_by: direction, kind; filters: direction, kind; aggregate fields: (none); default: count as activities grouped by kind. deals-by-stage — group_by: pipeline_id, stage_id, status; filters: owner_id, pipeline_id, status; aggregate fields: amount_minor; default: count as deals, sum(amount_minor) as amount_minor_sum grouped by stage_id. forecast — group_by: currency, forecast_category, owner_id, pipeline_id, stage_id, win_probability; filters: currency, forecast_category, owner_id, pipeline_id, stage_id; aggregate fields: amount_minor, weighted_amount_minor; default: count as deals, sum(amount_minor) as unweighted_minor, sum(weighted_amount_minor) as weighted_minor grouped by forecast_category. open-deals-per-company — group_by: organization_id, owner_id; filters: owner_id, pipeline_id; aggregate fields: amount_minor; default: count as open_deals grouped by organization_id. A `pipeline_id` or `stage_id` used here comes from list_pipelines — no other tool on this surface yields one.",
+              "description": "The prebuilt report to run. Send `report` alone to get its defaults; the three plan arguments accept ONLY the names listed for that report. activities-by-kind — group_by: direction, kind; filters: direction, kind; aggregate fields: (none); default: count as activities grouped by kind. deals-by-stage — group_by: pipeline_id, stage_id, status, win_probability; filters: owner_id, pipeline_id, stage_id, status; aggregate fields: amount_minor, weighted_amount_minor; default: count as deals, sum(amount_minor) as amount_minor_sum grouped by stage_id. forecast — group_by: currency, forecast_category, owner_id, pipeline_id, stage_id, win_probability; filters: currency, forecast_category, owner_id, pipeline_id, stage_id; aggregate fields: amount_minor, weighted_amount_minor; default: count as deals, sum(amount_minor) as unweighted_minor, sum(weighted_amount_minor) as weighted_minor grouped by forecast_category. open-deals-per-company — group_by: organization_id, owner_id; filters: owner_id, pipeline_id; aggregate fields: amount_minor; default: count as open_deals grouped by organization_id. A `pipeline_id` or `stage_id` used here comes from list_pipelines — no other tool on this surface yields one.",
               "enum": [
                 "activities-by-kind",
                 "deals-by-stage",

--- a/docs/reference/mcp-info.json
+++ b/docs/reference/mcp-info.json
@@ -10,16 +10,16 @@
   "totals": {
     "tools": 38,
     "resources": 8,
-    "tool_catalog_bytes": 108481,
+    "tool_catalog_bytes": 108471,
     "resource_catalog_bytes": 3108,
-    "approx_wire_tokens_total": 27897,
-    "largest_tool_bytes": 4201,
+    "approx_wire_tokens_total": 27894,
+    "largest_tool_bytes": 4191,
     "largest_tool": "run_report",
     "tool_catalog_composition": {
       "description_bytes": 29194,
-      "input_schema_bytes": 25029,
+      "input_schema_bytes": 25019,
       "output_schema_bytes": 45953,
-      "description_plus_input_schema_bytes": 54223
+      "description_plus_input_schema_bytes": 54213
     }
   },
   "tools": {
@@ -5099,7 +5099,7 @@
               "type": "array"
             },
             "report": {
-              "description": "The prebuilt report to run. Send `report` alone to get its defaults; the three plan arguments accept ONLY the names listed for that report. activities-by-kind — group_by: direction, kind; filters: direction, kind; aggregate fields: (none); default: count as activities grouped by kind. deals-by-stage — group_by: pipeline_id, stage_id, status, win_probability; filters: owner_id, pipeline_id, stage_id, status; aggregate fields: amount_minor, weighted_amount_minor; default: count as deals, sum(amount_minor) as amount_minor_sum grouped by stage_id. forecast — group_by: currency, forecast_category, owner_id, pipeline_id, stage_id, win_probability; filters: currency, forecast_category, owner_id, pipeline_id, stage_id; aggregate fields: amount_minor, weighted_amount_minor; default: count as deals, sum(amount_minor) as unweighted_minor, sum(weighted_amount_minor) as weighted_minor grouped by forecast_category. open-deals-per-company — group_by: organization_id, owner_id; filters: owner_id, pipeline_id; aggregate fields: amount_minor; default: count as open_deals grouped by organization_id. A `pipeline_id` or `stage_id` used here comes from list_pipelines — no other tool on this surface yields one.",
+              "description": "The prebuilt report to run. Send `report` alone to get its defaults; the three plan arguments accept ONLY the names listed for that report. activities-by-kind — group_by: direction, kind; filters: direction, kind; aggregate fields: (none); default: count as activities grouped by kind. deals-by-stage — group_by: pipeline_id, stage_id, status, win_probability; filters: owner_id, pipeline_id, status; aggregate fields: amount_minor, weighted_amount_minor; default: count as deals, sum(amount_minor) as amount_minor_sum grouped by stage_id. forecast — group_by: currency, forecast_category, owner_id, pipeline_id, stage_id, win_probability; filters: currency, forecast_category, owner_id, pipeline_id, stage_id; aggregate fields: amount_minor, weighted_amount_minor; default: count as deals, sum(amount_minor) as unweighted_minor, sum(weighted_amount_minor) as weighted_minor grouped by forecast_category. open-deals-per-company — group_by: organization_id, owner_id; filters: owner_id, pipeline_id; aggregate fields: amount_minor; default: count as open_deals grouped by organization_id. A `pipeline_id` or `stage_id` used here comes from list_pipelines — no other tool on this surface yields one.",
               "enum": [
                 "activities-by-kind",
                 "deals-by-stage",

--- a/docs/reference/mcp-info.md
+++ b/docs/reference/mcp-info.md
@@ -15,7 +15,7 @@ receives it. This page is rendered from that file.
 | Resources | 8 |
 | Tool catalog | 105.9 KB |
 | Resource catalog | 3.0 KB |
-| Approx. wire tokens | 27884 |
+| Approx. wire tokens | 27897 |
 | Largest tool | `run_report` (4.1 KB) |
 | Scopes rendered | `read`, `draft`, `write`, `send`, `enrich` |
 
@@ -32,7 +32,7 @@ budget in `agenttooldescriptions_test.go`.
 | Descriptions (incl. governance clause) | 28.5 KB | 26% | Yes, every step |
 | Input schemas | 24.4 KB | 23% | Yes, every step |
 | _Names, annotations, punctuation_ | 8.1 KB | 7% | Partly |
-| **Description + input schema** | **52.9 KB** | **49%** | **the recurring cost** |
+| **Description + input schema** | **53.0 KB** | **49%** | **the recurring cost** |
 
 So the headline total is dominated by the part a model is never charged for, and
 descriptions are a minority of it. Trimming the copy to shrink the total trades a
@@ -88,7 +88,7 @@ resource, the way `margince://schema/record-fields` did, not by writing less.
 | [`relink_activity`](#relink_activity) | Re-associate an activity to a record |  |  | 2.3 KB |
 | [`resolve_entities`](#resolve_entities) | Resolve people and companies | yes |  | 3.6 KB |
 | [`review_commitments`](#review_commitments) | Review open commitments | yes | [`ui://margince/commitments.html`](#commitments_view) | 2.8 KB |
-| [`run_report`](#run_report) | Run a report | yes |  | 4.0 KB |
+| [`run_report`](#run_report) | Run a report | yes |  | 4.1 KB |
 | [`search_context`](#search_context) | Search for relevant material | yes |  | 3.0 KB |
 | [`search_records`](#search_records) | Search records | yes |  | 2.7 KB |
 | [`send_account_email`](#send_account_email) | Start an email conversation from a record |  |  | 3.1 KB |
@@ -5598,7 +5598,7 @@ Answer a question about totals, counts or breakdowns — pipeline by stage, deal
       "type": "array"
     },
     "report": {
-      "description": "The prebuilt report to run. Send `report` alone to get its defaults; the three plan arguments accept ONLY the names listed for that report. activities-by-kind — group_by: direction, kind; filters: direction, kind; aggregate fields: (none); default: count as activities grouped by kind. deals-by-stage — group_by: pipeline_id, stage_id, status; filters: owner_id, pipeline_id, status; aggregate fields: amount_minor; default: count as deals, sum(amount_minor) as amount_minor_sum grouped by stage_id. forecast — group_by: currency, forecast_category, owner_id, pipeline_id, stage_id, win_probability; filters: currency, forecast_category, owner_id, pipeline_id, stage_id; aggregate fields: amount_minor, weighted_amount_minor; default: count as deals, sum(amount_minor) as unweighted_minor, sum(weighted_amount_minor) as weighted_minor grouped by forecast_category. open-deals-per-company — group_by: organization_id, owner_id; filters: owner_id, pipeline_id; aggregate fields: amount_minor; default: count as open_deals grouped by organization_id. A `pipeline_id` or `stage_id` used here comes from list_pipelines — no other tool on this surface yields one.",
+      "description": "The prebuilt report to run. Send `report` alone to get its defaults; the three plan arguments accept ONLY the names listed for that report. activities-by-kind — group_by: direction, kind; filters: direction, kind; aggregate fields: (none); default: count as activities grouped by kind. deals-by-stage — group_by: pipeline_id, stage_id, status, win_probability; filters: owner_id, pipeline_id, stage_id, status; aggregate fields: amount_minor, weighted_amount_minor; default: count as deals, sum(amount_minor) as amount_minor_sum grouped by stage_id. forecast — group_by: currency, forecast_category, owner_id, pipeline_id, stage_id, win_probability; filters: currency, forecast_category, owner_id, pipeline_id, stage_id; aggregate fields: amount_minor, weighted_amount_minor; default: count as deals, sum(amount_minor) as unweighted_minor, sum(weighted_amount_minor) as weighted_minor grouped by forecast_category. open-deals-per-company — group_by: organization_id, owner_id; filters: owner_id, pipeline_id; aggregate fields: amount_minor; default: count as open_deals grouped by organization_id. A `pipeline_id` or `stage_id` used here comes from list_pipelines — no other tool on this surface yields one.",
       "enum": [
         "activities-by-kind",
         "deals-by-stage",

--- a/docs/reference/mcp-info.md
+++ b/docs/reference/mcp-info.md
@@ -15,7 +15,7 @@ receives it. This page is rendered from that file.
 | Resources | 8 |
 | Tool catalog | 105.9 KB |
 | Resource catalog | 3.0 KB |
-| Approx. wire tokens | 27897 |
+| Approx. wire tokens | 27894 |
 | Largest tool | `run_report` (4.1 KB) |
 | Scopes rendered | `read`, `draft`, `write`, `send`, `enrich` |
 
@@ -32,7 +32,7 @@ budget in `agenttooldescriptions_test.go`.
 | Descriptions (incl. governance clause) | 28.5 KB | 26% | Yes, every step |
 | Input schemas | 24.4 KB | 23% | Yes, every step |
 | _Names, annotations, punctuation_ | 8.1 KB | 7% | Partly |
-| **Description + input schema** | **53.0 KB** | **49%** | **the recurring cost** |
+| **Description + input schema** | **52.9 KB** | **49%** | **the recurring cost** |
 
 So the headline total is dominated by the part a model is never charged for, and
 descriptions are a minority of it. Trimming the copy to shrink the total trades a
@@ -5598,7 +5598,7 @@ Answer a question about totals, counts or breakdowns — pipeline by stage, deal
       "type": "array"
     },
     "report": {
-      "description": "The prebuilt report to run. Send `report` alone to get its defaults; the three plan arguments accept ONLY the names listed for that report. activities-by-kind — group_by: direction, kind; filters: direction, kind; aggregate fields: (none); default: count as activities grouped by kind. deals-by-stage — group_by: pipeline_id, stage_id, status, win_probability; filters: owner_id, pipeline_id, stage_id, status; aggregate fields: amount_minor, weighted_amount_minor; default: count as deals, sum(amount_minor) as amount_minor_sum grouped by stage_id. forecast — group_by: currency, forecast_category, owner_id, pipeline_id, stage_id, win_probability; filters: currency, forecast_category, owner_id, pipeline_id, stage_id; aggregate fields: amount_minor, weighted_amount_minor; default: count as deals, sum(amount_minor) as unweighted_minor, sum(weighted_amount_minor) as weighted_minor grouped by forecast_category. open-deals-per-company — group_by: organization_id, owner_id; filters: owner_id, pipeline_id; aggregate fields: amount_minor; default: count as open_deals grouped by organization_id. A `pipeline_id` or `stage_id` used here comes from list_pipelines — no other tool on this surface yields one.",
+      "description": "The prebuilt report to run. Send `report` alone to get its defaults; the three plan arguments accept ONLY the names listed for that report. activities-by-kind — group_by: direction, kind; filters: direction, kind; aggregate fields: (none); default: count as activities grouped by kind. deals-by-stage — group_by: pipeline_id, stage_id, status, win_probability; filters: owner_id, pipeline_id, status; aggregate fields: amount_minor, weighted_amount_minor; default: count as deals, sum(amount_minor) as amount_minor_sum grouped by stage_id. forecast — group_by: currency, forecast_category, owner_id, pipeline_id, stage_id, win_probability; filters: currency, forecast_category, owner_id, pipeline_id, stage_id; aggregate fields: amount_minor, weighted_amount_minor; default: count as deals, sum(amount_minor) as unweighted_minor, sum(weighted_amount_minor) as weighted_minor grouped by forecast_category. open-deals-per-company — group_by: organization_id, owner_id; filters: owner_id, pipeline_id; aggregate fields: amount_minor; default: count as open_deals grouped by organization_id. A `pipeline_id` or `stage_id` used here comes from list_pipelines — no other tool on this surface yields one.",
       "enum": [
         "activities-by-kind",
         "deals-by-stage",

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -1676,7 +1676,7 @@ export const de = {
   "reports.reportForecast": "Forecast",
   "reports.reportOpenByCompany": "Offene Deals pro Firma",
   "reports.forecastBanner":
-    "Kategoriesummen sind ungewichtet; die gewichtete Zahl des Boards ist Σ(Betrag × Phasenwahrscheinlichkeit) — bewusst zwei verschiedene Zahlen.",
+    "Jede Kachel zeigt die Rohsumme und darunter die gewichtete Summe — pro Deal gerundet, sodass sie immer mit „Diese Zahl erklären“ übereinstimmt.",
   "reports.company": "Firma",
   "reports.openDeals": "Offene Deals",
   "explain.sources": "Quellzeilen",

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -1226,6 +1226,7 @@ export const de = {
   "deal.fcBestCase": "Best Case",
   "deal.fcPipeline": "Pipeline",
   "deal.fcOmitted": "Ausgeschlossen",
+  "deal.fcSlipped": "Verschoben",
 
   "deals.pipeline": "Pipeline",
   "deals.filterStalled": "Nur ins Stocken geraten",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -1235,6 +1235,7 @@ export const en = {
   "deal.fcBestCase": "Best case",
   "deal.fcPipeline": "Pipeline",
   "deal.fcOmitted": "Omitted",
+  "deal.fcSlipped": "Slipped",
 
   "deals.pipeline": "Pipeline",
   "deals.filterStalled": "Stalled only",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -1678,7 +1678,7 @@ export const en = {
   "reports.reportForecast": "Forecast",
   "reports.reportOpenByCompany": "Open deals per company",
   "reports.forecastBanner":
-    "Category totals are unweighted; the board's weighted figure is Σ(amount × stage probability) — two different numbers on purpose.",
+    "Each tile shows the raw total and, beneath it, the probability-weighted total — rounded per deal, so it always reconciles to Explain This Number.",
   "reports.company": "Company",
   "reports.openDeals": "Open deals",
   "explain.sources": "Source rows",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -1667,7 +1667,7 @@ export const vi = {
   "reports.reportForecast": "Dự báo",
   "reports.reportOpenByCompany": "Deal đang mở theo công ty",
   "reports.forecastBanner":
-    "Tổng theo nhóm là chưa trọng số; con số có trọng số trên bảng là Σ(giá trị × xác suất giai đoạn) — hai con số khác nhau, và đó là chủ ý.",
+    'Mỗi ô hiển thị tổng chưa trọng số, và bên dưới là tổng có trọng số — được làm tròn theo từng deal, nên luôn khớp với "Giải thích con số này".',
   "reports.company": "Công ty",
   "reports.openDeals": "Deal đang mở",
   "explain.sources": "Các dòng nguồn",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -1223,6 +1223,7 @@ export const vi = {
   "deal.fcBestCase": "Khả quan nhất",
   "deal.fcPipeline": "Pipeline",
   "deal.fcOmitted": "Loại trừ",
+  "deal.fcSlipped": "Trượt tiến độ",
 
   "deals.pipeline": "Pipeline",
   "deals.filterStalled": "Chỉ deal đình trệ",

--- a/frontend/src/screens/deals.test.tsx
+++ b/frontend/src/screens/deals.test.tsx
@@ -186,6 +186,20 @@ describe("buildColumns", () => {
     expect(columns[0].weightedMinor).toBe(60_000);
     expect(columns[1].sumHidden).toBe(true);
   });
+
+  // AC-F1: the weighted column must round PER DEAL, then sum —
+  // not sum the raw amounts and round once. 12343 × 20% = 2468.6, which
+  // rounds up to 2469 per deal (two deals: 4938); summing first gives
+  // 24686 × 20% = 4937.2, which rounds DOWN to 4937. The two derivations
+  // disagree by exactly the case this asserts.
+  it("rounds each deal's weighted value before summing, not the column sum", () => {
+    const columns = buildColumns(stages, [
+      deal({ id: "a", stage_id: "s1", amount_minor: 12_343, currency: "EUR" }),
+      deal({ id: "b", stage_id: "s1", amount_minor: 12_343, currency: "EUR" }),
+    ]);
+    expect(columns[0].rawMinor).toBe(24_686);
+    expect(columns[0].weightedMinor).toBe(4_938);
+  });
 });
 
 function stubBackend(

--- a/frontend/src/screens/deals.tsx
+++ b/frontend/src/screens/deals.tsx
@@ -391,13 +391,25 @@ export function buildColumns(
       const raw = currency
         ? stageDeals.reduce((sum, deal) => sum + (deal.amount_minor ?? 0), 0)
         : null;
+      // Weighted rounds PER DEAL then sums (formulas §6 / AC-F1), matching
+      // the forecast report's own methodology — rounding the column sum
+      // once instead disagrees by the rounding residue of every deal in it.
+      const weighted = currency
+        ? stageDeals.reduce(
+            (sum, deal) =>
+              sum +
+              Math.round(
+                ((deal.amount_minor ?? 0) * stage.win_probability) / 100,
+              ),
+            0,
+          )
+        : null;
       return {
         stage: stage.id,
         label: stage.name,
         probabilityPct: stage.win_probability,
         rawMinor: raw ?? 0,
-        weightedMinor:
-          raw === null ? 0 : Math.round((raw * stage.win_probability) / 100),
+        weightedMinor: weighted ?? 0,
         currency: currency ?? "EUR",
         deals: stageDeals.map((deal) => toBoardDeal(deal, orgs)),
         sumHidden: raw === null,

--- a/frontend/src/screens/reports.test.tsx
+++ b/frontend/src/screens/reports.test.tsx
@@ -130,6 +130,7 @@ describe("ReportsScreen", () => {
           {
             forecast_category: "commit",
             raw_minor: 500000,
+            weighted_minor: 300000,
             deal_count: 3,
             currency: "EUR",
           },
@@ -149,6 +150,75 @@ describe("ReportsScreen", () => {
           b.body.group_by.includes("forecast_category"),
       ),
     ).toBe(true);
+    // AC-F1: the weighted forecast is the server's own figure —
+    // requested and rendered, not left computed-and-unshown.
+    expect(
+      bodies.some(
+        (b) =>
+          b.key === "forecast" &&
+          Array.isArray(b.body.aggregates) &&
+          (b.body.aggregates as { field?: string }[]).some(
+            (a) => a.field === "weighted_amount_minor",
+          ),
+      ),
+    ).toBe(true);
+  });
+
+  it("renders the slipped bucket in the Forecast tiles", async () => {
+    vi.stubGlobal(
+      "fetch",
+      reportsStub({
+        forecastRows: [
+          {
+            forecast_category: "slipped",
+            raw_minor: 90000,
+            weighted_minor: 45000,
+            deal_count: 1,
+            currency: "EUR",
+          },
+        ],
+      }),
+    );
+    render(<ReportsScreen />);
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Forecast" }),
+    );
+    await waitFor(() => expect(screen.getByText("Slipped")).toBeTruthy());
+  });
+
+  it("deals-by-stage requests and renders the server's weighted_minor, not a client re-derivation", async () => {
+    const bodies: { key: string; body: Record<string, unknown> }[] = [];
+    vi.stubGlobal(
+      "fetch",
+      reportsStub({
+        onRun: (key, body) => bodies.push({ key, body }),
+        // 12343 × 20% per deal (2469 × 2 = 4938) — a figure a client can only
+        // reproduce by rounding round(24686 × 20%) = 4937, the wrong way.
+        stageRows: [
+          {
+            stage_id: "pl-s1",
+            raw_minor: 24686,
+            weighted_minor: 4938,
+            deal_count: 2,
+            currency: "EUR",
+          },
+        ],
+      }),
+    );
+    render(<ReportsScreen />);
+    await waitFor(() => expect(screen.getByText("Qualify")).toBeTruthy());
+    expect(
+      bodies.some(
+        (b) =>
+          b.key === "deals-by-stage" &&
+          Array.isArray(b.body.aggregates) &&
+          (b.body.aggregates as { field?: string }[]).some(
+            (a) => a.field === "weighted_amount_minor",
+          ),
+      ),
+    ).toBe(true);
+    expect(await screen.findByText("€49.38")).toBeTruthy();
+    expect(screen.queryByText("€49.37")).toBeNull();
   });
 
   it("switching to Open deals per company groups by organization_id and renders a table", async () => {

--- a/frontend/src/screens/reports.tsx
+++ b/frontend/src/screens/reports.tsx
@@ -1,6 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { type ReactNode, useState } from "react";
 import { api } from "../api/client";
+import type { components } from "../api/schema";
 import {
   Button,
   Card,
@@ -32,9 +33,9 @@ import { QuotasView } from "./quotas";
 type StageAgg = {
   stageId: string;
   stageName: string;
-  probabilityPct: number;
   count: number;
   rawMinor: number;
+  weightedMinor: number;
   currency: string | null;
 };
 
@@ -49,6 +50,31 @@ const REPORT_GROUP_BY: Record<ReportKey, string> = {
   "deals-by-stage": "stage_id",
   forecast: "forecast_category",
   "open-deals-per-company": "organization_id",
+};
+
+type ReportAggregate = NonNullable<
+  components["schemas"]["RunReportRequest"]["aggregates"]
+>[number];
+
+// Which aggregates each report's own vocabulary serves (report.go's
+// per-spec measures) — `weighted_amount_minor` only exists where a stage
+// join computes it (deals-by-stage, forecast); requesting it against
+// open-deals-per-company's narrower vocabulary would 422.
+const REPORT_AGGREGATES: Record<ReportKey, ReportAggregate[]> = {
+  "deals-by-stage": [
+    { fn: "sum", field: "amount_minor", as: "raw_minor" },
+    { fn: "sum", field: "weighted_amount_minor", as: "weighted_minor" },
+    { fn: "count", as: "deal_count" },
+  ],
+  forecast: [
+    { fn: "sum", field: "amount_minor", as: "raw_minor" },
+    { fn: "sum", field: "weighted_amount_minor", as: "weighted_minor" },
+    { fn: "count", as: "deal_count" },
+  ],
+  "open-deals-per-company": [
+    { fn: "sum", field: "amount_minor", as: "raw_minor" },
+    { fn: "count", as: "deal_count" },
+  ],
 };
 
 // Parse a server-minted `derivation_url` into the typed derivation query.
@@ -73,33 +99,49 @@ function derivationReportKey(url: string): string {
   return url.match(/reports\/([^/?]+)\/derivation/)?.[1] ?? "";
 }
 
+// forecast_category dimension values (report.go's forecastCategoryExpr):
+// the four the deal itself can carry, plus the server-derived "slipped" —
+// a claimed commit/best_case deal whose close date is past, missing, or
+// still provisional (formulas §11). Omitting it here doesn't shrink the
+// total; it moves the deal's amount into no tile at all.
 const FORECAST_CATEGORIES = [
   { key: "commit", labelKey: "deal.fcCommit" },
   { key: "best_case", labelKey: "deal.fcBestCase" },
   { key: "pipeline", labelKey: "deal.fcPipeline" },
   { key: "omitted", labelKey: "deal.fcOmitted" },
+  { key: "slipped", labelKey: "deal.fcSlipped" },
 ] as const;
 
 // Prop-driven money tile for a forecast category — exported for the
 // Storybook task so it can render without a live fetch (mirrors how
-// FxLine in deals.tsx typed its `locale`).
+// FxLine in deals.tsx typed its `locale`). `weightedMinor` is optional so
+// the tile still renders (raw only) for a caller with no weighted figure
+// to hand — the storybook task among them.
 export function ForecastTile({
   label,
   amountMinor,
+  weightedMinor,
   currency,
   locale,
 }: Readonly<{
   label: string;
   amountMinor: number;
+  weightedMinor?: number;
   currency: string;
   locale: Locale;
 }>) {
+  const t = useT();
   return (
     <Card>
       <span className="t-label">{label}</span>
       <p className="t-mono t-display">
         {formatMoney(amountMinor, currency, locale)}
       </p>
+      {weightedMinor != null && (
+        <p className="t-mono t-caption">
+          {t("reports.weighted")}: {formatMoney(weightedMinor, currency, locale)}
+        </p>
+      )}
     </Card>
   );
 }
@@ -141,10 +183,7 @@ export function ReportsScreen() {
         params: { path: { report } },
         body: {
           group_by: [REPORT_GROUP_BY[report]],
-          aggregates: [
-            { fn: "sum", field: "amount_minor", as: "raw_minor" },
-            { fn: "count", as: "deal_count" },
-          ],
+          aggregates: REPORT_AGGREGATES[report],
         },
       });
       if (error) {
@@ -258,6 +297,7 @@ export function ReportsScreen() {
                         key={category.key}
                         label={t(category.labelKey)}
                         amountMinor={Number(row?.raw_minor ?? 0)}
+                        weightedMinor={Number(row?.weighted_minor ?? 0)}
                         currency={
                           typeof row?.currency === "string"
                             ? row.currency
@@ -320,9 +360,12 @@ export function ReportsScreen() {
               return {
                 stageId,
                 stageName: stage?.name ?? stageId,
-                probabilityPct: stage?.win_probability ?? 0,
                 count: Number(row.deal_count ?? 0),
                 rawMinor: Number(row.raw_minor ?? 0),
+                // AC-F1: the server's own per-deal-rounded weighted sum
+                // (weighted_amount_minor), never round(rawMinor × p / 100)
+                // — that rounds the column sum once instead of every deal.
+                weightedMinor: Number(row.weighted_minor ?? 0),
                 currency:
                   typeof row.currency === "string" ? row.currency : "EUR",
               };
@@ -359,7 +402,7 @@ export function ReportsScreen() {
                     render: (row: StageAgg) => (
                       <span className="t-mono">
                         {formatMoney(
-                          Math.round((row.rawMinor * row.probabilityPct) / 100),
+                          row.weightedMinor,
                           row.currency ?? "EUR",
                           locale,
                         )}

--- a/frontend/src/screens/reports.tsx
+++ b/frontend/src/screens/reports.tsx
@@ -139,7 +139,8 @@ export function ForecastTile({
       </p>
       {weightedMinor != null && (
         <p className="t-mono t-caption">
-          {t("reports.weighted")}: {formatMoney(weightedMinor, currency, locale)}
+          {t("reports.weighted")}:{" "}
+          {formatMoney(weightedMinor, currency, locale)}
         </p>
       )}
     </Card>

--- a/frontend/src/screens/reports.tsx
+++ b/frontend/src/screens/reports.tsx
@@ -22,13 +22,12 @@ import {
 import { QuotasView } from "./quotas";
 
 // Reports (B-EP09.12c, D-11): a picker over three reports — deals-by-stage
-// (unweighted next to weighted, unchanged since B-EP09.12c), forecast
-// (unweighted category tiles — deterministic, no confidence dots — with a
-// banner naming the weighted-vs-unweighted distinction), and open deals per
-// company. "Explain this number" opens the executed plan + the exact rows
-// the headline reconciles to. Weighted display on deals-by-stage uses each
-// stage's win_probability against the report's own sums — same page-local
-// rule as the board.
+// (unweighted next to weighted), forecast (category tiles, each showing
+// unweighted and weighted, plus the server-derived "slipped" bucket), and
+// open deals per company. "Explain this number" opens the executed plan +
+// the exact rows the headline reconciles to. Both weighted figures come
+// straight off the report's own weighted_amount_minor measure (AC-F1: round
+// PER DEAL, then sum) — neither screen re-derives it from the raw total.
 
 type StageAgg = {
   stageId: string;


### PR DESCRIPTION
## Summary

Closes #719, rewritten per `.tmp/capability-roadmap/PROGRESS.md`/`PLAN.md` (F2)
— it is a correctness bug, not a missing display feature.

- The board's stage columns (`deals.tsx`) and the reports screen's
  deals-by-stage table both computed the weighted figure as
  `round(Σamount × probability / 100)` — rounding the column's SUM once.
  The `forecast` report already computes `Σround(amount × probability / 100)`
  (AC-F1: round PER DEAL, then sum) — a different number, off by the rounding
  residue of every deal in the group.
- Fix: `deals-by-stage`'s reportSpec gains a `win_probability` dimension and
  a `weighted_amount_minor` measure, sharing the exact SQL expression
  `forecast` already used (one spelling, not two). The board sums each
  deal's own rounded weighted value (it already has every deal's
  `amount_minor` locally); the reports screen now requests and renders the
  server's `weighted_minor` aggregate instead of re-deriving it client-side.
- The forecast tab now requests and renders the weighted figure it always
  computed server-side but never showed, and gains a `slipped` tile — a
  real server-derived category (`forecastCategoryExpr`) that nothing
  rendered before, so those deals' amounts appeared in no tile at all.
- The forecast banner (en/de/vi) described the pre-fix screen; rewritten to
  match what the tiles now actually show.

**Out of scope, on purpose:** the original issue's third bullet (pipeline
coverage vs. target) is a distinct, much larger capability —
`rolling-coverage` (REPORT-KEY-5) and the whole S-E09.6 coverage-risk
screen in `margince-foundation`, neither of which exist and neither of
which this roadmap schedules under this wave. Filing a follow-up issue for
it rather than growing this PR.

## Test plan

- [x] TDD throughout: every change has a red-first test (1 new Go
  integration test file, 2 Vitest files touched).
- [x] `make check-backend` — green (build, vet, lint incl. strict new-code
  gate, unit tests).
- [x] `make check-fe` — green (biome, vitest, tsc, build).
- [x] `make test-integration` — green, 0 skips (an unrelated
  `internal/modules/overlay` flake on the first run reproduced 5/5 in
  isolation and the very next full run was clean — not this change).
- [x] `craft static --strict` diff-scoped — 0 blocker/major/minor.
- [x] Independent Fable review pass — 2 real findings fixed (a test fixture
  that couldn't actually discriminate the bug it was written to catch, and
  a stale banner contradicting the new UI) before push.
- [ ] Manual UAT on a live dev stack (forecast tab shows weighted + slipped;
  board and reports-table weighted columns match the report engine) —
  running now, report to follow.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make weighted totals consistent by rounding per deal on the server and using that figure everywhere. Previously the board and Deals by stage rounded the column sum once; now both read or compute Σround(amount × probability / 100), and Forecast tiles show both raw and weighted totals plus the server-derived “slipped” category.

- Backend: `deals-by-stage` joins `stage` for `win_probability` and adds a `weighted_amount_minor` measure shared with Forecast; the SQL casts `amount_minor` to numeric before multiplying to prevent bigint overflow. Drops the unused `stage_id` filter. Adds integration tests for per‑deal rounding, “Explain This Number” reconciliation, and row‑scope. Generalizes report test helpers.
- Frontend: Board sums each deal’s rounded weighted value. Reports request and render the server’s `weighted_amount_minor` for Deals by stage and Forecast; Forecast tiles include raw and weighted totals and the “slipped” bucket. Copy updated in `en`, `de`, `vi`. Tests assert aggregate requests and per‑deal rounding.
- Docs: `run_report` catalog documents `deals-by-stage` support for `win_probability` and `weighted_amount_minor`. No breaking changes; clients may use the new measure.

<sup>Written for commit f656f41b6f7c6b0f6583c44ead6d2a8eb00aeca7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1143?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

