### PR TITLE
refactor(customfields): the catalog drops the tenant column (ADR-0091 §8 phase D)

### DIFF
--- a/backend/internal/compose/integration/customfields/customfields_integration_test.go
+++ b/backend/internal/compose/integration/customfields/customfields_integration_test.go
@@ -109,12 +109,12 @@ func TestCustomFieldCreate_AtomicRollback_OnCatalogConflict(t *testing.T) {
 	svc := customfieldsmod.NewService(e.Pool, integration.SchemaPool(t))
 	ctx := e.As(e.Rep1, nil, integration.CustomFieldAdminPerms)
 
-	// Same (workspace, object, slug), different column_name: invisible to
-	// the pre-check, fatal to the INSERT.
+	// Same (object, slug), different column_name: invisible to the
+	// pre-check, fatal to the INSERT.
 	if _, err := owner.Exec(context.Background(),
-		`INSERT INTO custom_field (workspace_id, object, slug, label, type, column_name, created_by)
-		 VALUES ($1, 'deal', 'renewal_date', 'Pre-existing', 'text', 'cf_renewal_date_other', $2)`,
-		e.WS, e.Rep1); err != nil {
+		`INSERT INTO custom_field (object, slug, label, type, column_name, created_by)
+		 VALUES ('deal', 'renewal_date', 'Pre-existing', 'text', 'cf_renewal_date_other', $1)`,
+		e.Rep1); err != nil {
 		t.Fatal(err)
 	}
 
@@ -130,34 +130,42 @@ func TestCustomFieldCreate_AtomicRollback_OnCatalogConflict(t *testing.T) {
 	}
 }
 
-func TestCustomFieldCreate_CrossWorkspaceCollision_AnswersColumnTaken(t *testing.T) {
+// A physical column that no catalog row claims is the one shape
+// ColumnTakenError still answers. It used to mean "another workspace holds
+// this column name"; with one installation it means the table already carries
+// the name — a half-applied change, or a core column the cf_ namespace has run
+// into. The refusal matters either way: an ALTER that discovers this itself
+// fails mid-transaction, taking the audit write with it.
+func TestCustomFieldCreate_UnclaimedColumnAnswersColumnTaken(t *testing.T) {
 	e := integration.Setup(t)
 	owner := integration.OwnerConn(t)
 	svc := customfieldsmod.NewService(e.Pool, integration.SchemaPool(t))
 
-	if _, err := svc.Create(e.As(e.Rep1, nil, integration.CustomFieldAdminPerms), dateSpec("Renewal date")); err != nil {
-		t.Fatalf("first workspace's create: %v", err)
+	// Added directly, so no catalog row claims it. The integration harness
+	// resets rows between tests and keeps the schema, so this one drops its
+	// own column rather than leaving every later test in the package facing a
+	// name it never added.
+	if _, err := owner.Exec(context.Background(),
+		`ALTER TABLE deal ADD COLUMN cf_renewal_date date`); err != nil {
+		t.Fatalf("planting the unclaimed column: %v", err)
 	}
-	wsB, ctxB := integration.SeedSecondWorkspace(t, owner, integration.CustomFieldAdminPerms)
+	t.Cleanup(func() {
+		if _, err := owner.Exec(context.Background(),
+			`ALTER TABLE deal DROP COLUMN cf_renewal_date`); err != nil {
+			t.Errorf("dropping the unclaimed column: %v", err)
+		}
+	})
 
-	_, err := svc.Create(ctxB, dateSpec("Renewal date"))
+	_, err := svc.Create(e.As(e.Rep1, nil, integration.CustomFieldAdminPerms), dateSpec("Renewal date"))
 	var taken *customfieldsmod.ColumnTakenError
 	if !errors.As(err, &taken) {
-		t.Fatalf("the second workspace's identical slug must answer ColumnTakenError, got %v", err)
+		t.Fatalf("a column the table already carries must answer ColumnTakenError, got %v", err)
 	}
 	if !errors.Is(err, apperrors.ErrConflict) {
 		t.Fatal("ColumnTakenError must read as the 409 conflict sentinel")
 	}
-	if !columnOnTable(t, owner, "deal", "cf_renewal_date") {
-		t.Fatal("the FIRST workspace's column must survive the refused second claim")
-	}
-	var n int
-	if err := owner.QueryRow(context.Background(),
-		`SELECT count(*) FROM custom_field WHERE workspace_id = $1`, wsB).Scan(&n); err != nil {
-		t.Fatal(err)
-	}
-	if n != 0 {
-		t.Fatalf("the refused workspace must gain no catalog row, got %d", n)
+	if n := e.WsCount(t, `SELECT count(*) FROM custom_field WHERE object = 'deal' AND slug = 'renewal_date'`); n != 0 {
+		t.Fatalf("a refused create must leave no catalog row, got %d", n)
 	}
 }
 

--- a/backend/internal/compose/integration/customfields/customfields_lifecycle_integration_test.go
+++ b/backend/internal/compose/integration/customfields/customfields_lifecycle_integration_test.go
@@ -6,11 +6,11 @@
 package customfields
 
 // The customfields catalog-lifecycle suite: rename/retire (app-pool,
-// catalog-only), the picklist CHECK regeneration, the admin list, and
-// the RBAC/RLS boundaries. The schema-pool tx dance itself is proven in
+// catalog-only), the picklist CHECK regeneration, the admin list, and the RBAC
+// boundaries. The schema-pool tx dance itself is proven in
 // customfields_integration_test.go here, and the fixtures they share come from
-// two places: columnOnTable is this package's, while CustomFieldAdminPerms and
-// SeedSecondWorkspace are the parent's (integration/suitefixtures.go).
+// two places: columnOnTable is this package's, while CustomFieldAdminPerms is
+// the parent's (integration/suitefixtures.go).
 
 import (
 	"errors"

--- a/backend/internal/compose/integration/suitefixtures.go
+++ b/backend/internal/compose/integration/suitefixtures.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
-	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/jurisdiction"
 )
@@ -69,35 +68,6 @@ var CustomFieldAdminPerms = principal.Permissions{
 		"person":       {Create: true, Read: true, Update: true, Delete: true},
 	},
 	RowScope: principal.RowScopeAll,
-}
-
-// SeedSecondWorkspace inserts a second tenant with its own user and returns a
-// context bound to it, carrying perms, for the cross-tenant suites.
-//
-// perms is a parameter rather than a fixed posture because the grants decide what
-// a cross-tenant assertion can mean: a suite proving RLS hides tenant A's rows
-// needs tenant B permitted to ask for them, while a suite proving an RBAC refusal
-// needs the opposite. Each caller states which it is proving.
-func SeedSecondWorkspace(t *testing.T, owner *pgx.Conn, perms principal.Permissions) (ids.UUID, context.Context) {
-	t.Helper()
-	ws, user := ids.NewV7(), ids.NewV7()
-	if _, err := owner.Exec(context.Background(),
-		`INSERT INTO workspace (id, slug) VALUES ($1, $2)`,
-		ws, "tenant-b-"+ws.String()[:8]); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := owner.Exec(context.Background(),
-		`INSERT INTO app_user (id, workspace_id, email, display_name) VALUES ($1, $2, $3, 'B Admin')`,
-		user, ws, "b@tenant-b.test"); err != nil {
-		t.Fatal(err)
-	}
-	ctx := principal.WithWorkspaceID(context.Background(), ws)
-	ctx = principal.WithCorrelationID(ctx, ids.NewV7())
-	ctx = principal.WithActor(ctx, principal.Principal{
-		Type: principal.PrincipalHuman, ID: "human:" + user.String(),
-		UserID: user, Permissions: perms,
-	})
-	return ws, ctx
 }
 
 // ExtractStagedApprovalID pulls the staged approval's id out of the 403

--- a/backend/internal/modules/customfields/catalogreader.go
+++ b/backend/internal/modules/customfields/catalogreader.go
@@ -26,17 +26,17 @@ import (
 // surface.
 
 // ActiveColumns answers the active custom-field columns for one object,
-// scoped to the workspace bound to ctx, ordered by column_name (a stable,
-// deterministic order for SELECT/INSERT column-list building).
+// ordered by column_name (a stable, deterministic order for SELECT/INSERT
+// column-list building).
 //
 // Deliberately runs no auth.Require: this is called from inside a record
 // store's Get/List/Create/Update, whose own RBAC gate already ran before
 // the store reaches for its custom columns. What ActiveColumns exposes —
-// which cf_* columns exist and their type — is workspace-visible schema
-// (the same shape the admin catalog list already answers to anyone
-// holding custom_field:read), not row data a second gate would need to
-// narrow; the row-level RBAC/RLS the calling store enforces is what
-// actually protects the values stored in those columns.
+// which cf_* columns exist and their type — is schema (the same shape the
+// admin catalog list already answers to anyone holding custom_field:read),
+// not row data a second gate would need to narrow; the row-level RBAC the
+// calling store enforces is what actually protects the values stored in
+// those columns.
 func (s *Service) ActiveColumns(ctx context.Context, object string) ([]fieldcatalog.Column, error) {
 	var cols []fieldcatalog.Column
 	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {

--- a/backend/internal/modules/customfields/create.go
+++ b/backend/internal/modules/customfields/create.go
@@ -106,7 +106,7 @@ func (s *Service) createInTx(ctx context.Context, tx pgx.Tx, spec FieldSpec, wsI
 	if err := beginSchemaChange(ctx, tx, wsID, spec.Object); err != nil {
 		return crmcontracts.CustomField{}, err
 	}
-	if err := refuseTakenColumn(ctx, tx, wsID, spec.Object, column); err != nil {
+	if err := refuseTakenColumn(ctx, tx, spec.Object, column); err != nil {
 		return crmcontracts.CustomField{}, err
 	}
 
@@ -138,17 +138,17 @@ func (s *Service) createInTx(ctx context.Context, tx pgx.Tx, spec FieldSpec, wsI
 	if err != nil {
 		return crmcontracts.CustomField{}, err
 	}
-	row := tx.QueryRow(ctx, `INSERT INTO custom_field (workspace_id, object, slug, label, type, column_name, currency, options, created_by)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+	row := tx.QueryRow(ctx, `INSERT INTO custom_field (object, slug, label, type, column_name, currency, options, created_by)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
 		 RETURNING `+catalogColumns,
-		wsID, spec.Object, slug, spec.Label, spec.Type, column, currency, optionsArg, creator)
+		spec.Object, slug, spec.Label, spec.Type, column, currency, optionsArg, creator)
 	out, err := scanCustomField(row)
 	if storekit.IsUniqueViolation(err) {
-		// The per-workspace (object, slug/column_name) unique index fired:
-		// a same-workspace duplicate that raced past the pre-check. The
-		// failed INSERT rolls the whole transaction back, ALTER included.
+		// The (object, slug/column_name) unique index fired: a duplicate
+		// that raced past the pre-check. The failed INSERT rolls the whole
+		// transaction back, ALTER included.
 		return crmcontracts.CustomField{}, fmt.Errorf(
-			"a custom field named %q already exists on %s in this workspace: %w", slug, spec.Object, apperrors.ErrConflict)
+			"a custom field named %q already exists on %s: %w", slug, spec.Object, apperrors.ErrConflict)
 	}
 	if err != nil {
 		return crmcontracts.CustomField{}, fmt.Errorf("customfields: inserting catalog row: %w", err)
@@ -178,10 +178,12 @@ func (s *Service) createInTx(ctx context.Context, tx pgx.Tx, spec FieldSpec, wsI
 
 // beginSchemaChange arms the transaction for a governed DDL step: it
 // binds the workspace GUC (the WithWorkspaceTx spelling — parameterized
-// set_config, never string-built SET LOCAL) so every catalog read and
-// write in this transaction is workspace-scoped, then bounds the lock
-// waits and serializes with the per-table advisory lock
-// (serializeSchemaChange).
+// set_config, never string-built SET LOCAL), then bounds the lock waits
+// and serializes with the per-table advisory lock (serializeSchemaChange).
+//
+// The GUC no longer scopes the catalog — that column is gone (ADR-0091 §8
+// phase D) — but the audit row this transaction writes still stamps its
+// workspace from it, so the binding stays until audit_log drops the column.
 func beginSchemaChange(ctx context.Context, tx pgx.Tx, wsID ids.UUID, object string) error {
 	if _, err := tx.Exec(ctx, `SELECT set_config('app.workspace_id', $1, true)`, wsID.String()); err != nil {
 		return fmt.Errorf("customfields: binding workspace GUC: %w", err)
@@ -219,14 +221,15 @@ func serializeSchemaChange(ctx context.Context, tx pgx.Tx, object string) error 
 	return nil
 }
 
-// refuseTakenColumn is the collision answer, decided
-// under the advisory lock BEFORE the ALTER: the per-workspace unique
-// indexes cannot see that the physical column namespace on the shared
-// table is global. A live column with a catalog row in THIS workspace is
-// the ordinary duplicate-slug conflict; a live column with none is
-// another workspace's claim — an honest 409 naming the remedy, because
-// existence of a bare column name discloses nothing about who holds it.
-func refuseTakenColumn(ctx context.Context, tx pgx.Tx, wsID ids.UUID, object, column string) error {
+// refuseTakenColumn is the collision answer, decided under the advisory
+// lock BEFORE the ALTER: the catalog's uniques govern catalog rows, and
+// they cannot see a physical column that no catalog row claims. A live
+// column WITH a catalog row is the ordinary duplicate-slug conflict; a
+// live column without one is a name already taken on the table — a
+// half-applied change, or a core column the cf_ namespace has run into.
+// Either way an honest 409 naming the remedy, rather than an ALTER that
+// fails mid-transaction.
+func refuseTakenColumn(ctx context.Context, tx pgx.Tx, object, column string) error {
 	var columnExists bool
 	if err := tx.QueryRow(ctx,
 		`SELECT EXISTS (SELECT 1 FROM information_schema.columns
@@ -237,13 +240,11 @@ func refuseTakenColumn(ctx context.Context, tx pgx.Tx, wsID ids.UUID, object, co
 	if !columnExists {
 		return nil
 	}
-	// The explicit workspace predicate keeps this correct even where the
-	// schema pool's role bypasses RLS (a superuser owner in dev).
 	var ownedHere bool
 	if err := tx.QueryRow(ctx,
 		`SELECT EXISTS (SELECT 1 FROM custom_field
-		  WHERE workspace_id = $1 AND object = $2 AND column_name = $3)`,
-		wsID, object, column).Scan(&ownedHere); err != nil {
+		  WHERE object = $1 AND column_name = $2)`,
+		object, column).Scan(&ownedHere); err != nil {
 		return fmt.Errorf("customfields: probing catalog claim: %w", err)
 	}
 	if ownedHere {

--- a/backend/internal/modules/customfields/create.go
+++ b/backend/internal/modules/customfields/create.go
@@ -240,15 +240,15 @@ func refuseTakenColumn(ctx context.Context, tx pgx.Tx, object, column string) er
 	if !columnExists {
 		return nil
 	}
-	var ownedHere bool
+	var claimed bool
 	if err := tx.QueryRow(ctx,
 		`SELECT EXISTS (SELECT 1 FROM custom_field
 		  WHERE object = $1 AND column_name = $2)`,
-		object, column).Scan(&ownedHere); err != nil {
+		object, column).Scan(&claimed); err != nil {
 		return fmt.Errorf("customfields: probing catalog claim: %w", err)
 	}
-	if ownedHere {
-		return fmt.Errorf("a custom field with column %q already exists on %s in this workspace: %w",
+	if claimed {
+		return fmt.Errorf("a custom field with column %q already exists on %s: %w",
 			column, object, apperrors.ErrConflict)
 	}
 	return &ColumnTakenError{Column: column}

--- a/backend/internal/modules/customfields/lifecycle.go
+++ b/backend/internal/modules/customfields/lifecycle.go
@@ -51,11 +51,10 @@ func (f lockedField) mutable() error {
 	return nil
 }
 
-// lockField takes FOR UPDATE on one catalog row. The custom_field
-// catalog is workspace-shared admin config with no owner_id — the object
-// grant is the whole authority question (the pipeline precedent), so
-// there is no row-scope probe to add; RLS pins the
-// workspace. A missing row answers ErrNotFound.
+// lockField takes FOR UPDATE on one catalog row. The custom_field catalog
+// is installation-wide admin config with no owner_id — the object grant is
+// the whole authority question (the pipeline precedent), so there is no
+// row-scope probe to add. A missing row answers ErrNotFound.
 func lockField(ctx context.Context, tx pgx.Tx, id ids.UUID) (lockedField, error) {
 	var f lockedField
 	err := tx.QueryRow(ctx,

--- a/backend/internal/modules/customfields/list.go
+++ b/backend/internal/modules/customfields/list.go
@@ -60,10 +60,10 @@ func (in ListInput) predicate() (string, []any, error) {
 	return where, args, nil
 }
 
-// List reads the catalog page for one (workspace, object) under the
-// contract's default -created_at,id keyset order. Workspace-shared admin
-// config: the object read grant is the authority, RLS pins the tenant,
-// and there is no row scope to compose (the pipeline precedent).
+// List reads the catalog page for one object under the contract's default
+// -created_at,id keyset order. Installation-wide admin config: the object
+// read grant is the whole authority, and there is no row scope to compose
+// (the pipeline precedent).
 func (s *Service) List(ctx context.Context, in ListInput) ([]crmcontracts.CustomField, storekit.Page, error) {
 	if err := auth.Require(ctx, rbacObject, principal.ActionRead); err != nil {
 		return nil, storekit.Page{}, err

--- a/backend/internal/modules/customfields/options.go
+++ b/backend/internal/modules/customfields/options.go
@@ -66,11 +66,11 @@ func (s *Service) SetOptions(ctx context.Context, id ids.UUID, options []string)
 }
 
 // lockPicklistField binds the workspace GUC, takes FOR UPDATE on the
-// catalog row, and refuses a non-picklist or retired target. The GUC
-// binds first so the read is workspace-scoped even where the owner role
-// is subject to the catalog's FORCE RLS; the explicit workspace
-// predicate keeps it correct where it is not (a superuser owner in dev).
-// The type check answers first — type is the operation's precondition;
+// catalog row, and refuses a non-picklist or retired target. The GUC no
+// longer scopes the catalog — that column is gone (ADR-0091 §8 phase D) —
+// but the audit row this transaction goes on to write still stamps its
+// workspace from it, so the binding stays until audit_log drops the column
+// too. The type check answers first — type is the operation's precondition;
 // the status gate then freezes a retired field's options (mutable).
 func lockPicklistField(ctx context.Context, tx pgx.Tx, wsID ids.UUID, id ids.UUID) (lockedField, error) {
 	if _, err := tx.Exec(ctx, `SELECT set_config('app.workspace_id', $1, true)`, wsID.String()); err != nil {
@@ -79,8 +79,8 @@ func lockPicklistField(ctx context.Context, tx pgx.Tx, wsID ids.UUID, id ids.UUI
 	var f lockedField
 	err := tx.QueryRow(ctx,
 		`SELECT object, column_name, type, status, label, options, version
-		   FROM custom_field WHERE id = $1 AND workspace_id = $2 FOR UPDATE`,
-		id, wsID).Scan(&f.Object, &f.ColumnName, &f.Type, &f.Status, &f.Label, &f.OptionsRaw, &f.Version)
+		   FROM custom_field WHERE id = $1 FOR UPDATE`,
+		id).Scan(&f.Object, &f.ColumnName, &f.Type, &f.Status, &f.Label, &f.OptionsRaw, &f.Version)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return lockedField{}, apperrors.ErrNotFound
 	}

--- a/backend/internal/modules/customfields/service.go
+++ b/backend/internal/modules/customfields/service.go
@@ -151,7 +151,7 @@ func (e *ColumnTakenError) Is(target error) bool { return target == apperrors.Er
 
 // catalogColumns is the ONE spelling of the custom_field row selection,
 // in scanCustomField's scan order.
-const catalogColumns = `id, workspace_id, object, slug, label, type, status, archived_at,
+const catalogColumns = `id, object, slug, label, type, status, archived_at,
 	column_name, currency, options, created_by, created_at, updated_at, version`
 
 // scanCustomField scans one catalogColumns row into the contract shape
@@ -159,13 +159,13 @@ const catalogColumns = `id, workspace_id, object, slug, label, type, status, arc
 func scanCustomField(row pgx.Row) (crmcontracts.CustomField, error) {
 	var (
 		out                          crmcontracts.CustomField
-		id, wsID, createdBy          ids.UUID
+		id, createdBy                ids.UUID
 		object, typ, status, colName string
 		currency                     *string
 		optionsRaw                   []byte
 		version                      int64
 	)
-	err := row.Scan(&id, &wsID, &object, &out.Slug, &out.Label, &typ, &status, &out.ArchivedAt,
+	err := row.Scan(&id, &object, &out.Slug, &out.Label, &typ, &status, &out.ArchivedAt,
 		&colName, &currency, &optionsRaw, &createdBy, &out.CreatedAt, &out.UpdatedAt, &version)
 	if err != nil {
 		return crmcontracts.CustomField{}, err

--- a/backend/migrations/core/0229_customfields_drop_workspace.down.sql
+++ b/backend/migrations/core/0229_customfields_drop_workspace.down.sql
@@ -1,4 +1,14 @@
 -- Reverse of 0229: the catalog carries the tenant column again.
+--
+-- The backfill reads `workspace` rather than reconstructing each row's original
+-- tenant, because there is only one to read: 0217's pre-flight refuses to run
+-- against a database holding more than one live workspace, and ADR-0061 §3 has
+-- the API refusing to start in that state. `ORDER BY created_at LIMIT 1` is
+-- determinism about which row of a one-row table, not a choice among tenants.
+--
+-- If `workspace` is empty and the catalog is not, SET NOT NULL fails and the
+-- rollback stops — the honest outcome, since no value this migration could
+-- write would be true.
 
 ALTER TABLE custom_field ADD COLUMN workspace_id uuid;
 

--- a/backend/migrations/core/0229_customfields_drop_workspace.down.sql
+++ b/backend/migrations/core/0229_customfields_drop_workspace.down.sql
@@ -1,0 +1,12 @@
+-- Reverse of 0229: the catalog carries the tenant column again.
+
+ALTER TABLE custom_field ADD COLUMN workspace_id uuid;
+
+UPDATE custom_field SET workspace_id = (SELECT id FROM workspace ORDER BY created_at LIMIT 1);
+
+ALTER TABLE custom_field ALTER COLUMN workspace_id SET NOT NULL;
+ALTER TABLE custom_field ADD CONSTRAINT custom_field_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+
+DROP INDEX idx_custom_field_object;
+CREATE INDEX idx_custom_field_object ON custom_field (workspace_id, object, status);

--- a/backend/migrations/core/0229_customfields_drop_workspace.up.sql
+++ b/backend/migrations/core/0229_customfields_drop_workspace.up.sql
@@ -1,0 +1,11 @@
+-- 0229: the custom-field catalog drops the tenant column (ADR-0091 §8 phase D).
+--
+-- One table and one index. The two uniques already read (object, slug) and
+-- (object, column_name) — phase B collapsed them — which is what makes the
+-- catalog's own "a field with this name already exists" answer true for the
+-- installation rather than for a tenant within it.
+
+DROP INDEX idx_custom_field_object;
+CREATE INDEX idx_custom_field_object ON custom_field (object, status);
+
+ALTER TABLE custom_field DROP COLUMN workspace_id;


### PR DESCRIPTION
Phase D, third slice. One table, one index.

The two uniques already read `(object, slug)` and `(object, column_name)` after phase B — which is what makes the catalog's "a field with this name already exists" answer true for the **installation** rather than for a tenant inside it. The conflict message now says so.

## The GUC binding stays, and the comments say why

Both DDL paths still bind `app.workspace_id`. It no longer scopes the catalog — that column is gone — but the audit row each of those transactions writes still stamps its workspace from it. It goes when `audit_log` drops the column (§6).

Three comments that described tenant scoping as a live mechanism (`ActiveColumns`, `List`, `lockField`) are corrected rather than left to mislead the next reader.

## One test replaced, not deleted

`TestCustomFieldCreate_CrossWorkspaceCollision_AnswersColumnTaken` rested on a second workspace claiming the same column, which is unreachable now. But `ColumnTakenError` still answers a real shape: **a physical column that no catalog row claims** — a half-applied change, or a core column the `cf_` namespace has run into. The replacement plants exactly that and asserts the refusal, so the branch keeps its cover instead of quietly losing it.

`SeedSecondWorkspace` was that test's last caller and goes with it.

## Verification

- Lane applied to an empty database; the down restores the column, its foreign key and the wide index.
- `make check-backend` green.
- `make test-integration`: **OK, 0 skips, 39 packages.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the custom-field catalog installation-wide by dropping the tenant column and updating create/read paths. Old behavior: uniqueness and copy implied workspace scope; new behavior: uniqueness and conflicts apply across the installation, and all messages reflect that. GUC binding stays to stamp audit rows.

- Migration 0229: drops `workspace_id` from `custom_field` and re-creates `idx_custom_field_object` without the workspace key; down restores the column/FK/index and backfills from the single `workspace` row (per 0217/ADR-0061). Run the migration; no app changes are required.
- Create path: pre-ALTER collision check now flags an unclaimed physical column as `ColumnTakenError`; duplicate (object, slug/column_name) conflicts return 409 with installation-wide wording. The refusal avoids mid-transaction ALTER failures.
- Query updates: removed workspace predicates from catalog reads/writes; `catalogColumns` and scanners no longer include `workspace_id`. Comments now state installation-wide admin config (RBAC gate only).
- Tests: replaced the cross-workspace collision test with an “unclaimed column” case; removed the `SeedSecondWorkspace` fixture.

<sup>Written for commit ce2973dc94bce21cca71a3db3137f9ccf0277cdc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1146?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Custom-field definitions now use installation-wide uniqueness, preventing conflicting field names across workspaces.
  - Improved conflict handling prevents creating a custom field when its physical column is already in use.

- **Bug Fixes**
  - Failed custom-field creations no longer leave behind catalog records.
  - Updated rollback behavior restores the previous custom-field schema safely.

- **Documentation**
  - Clarified custom-field visibility, permissions, and installation-wide configuration behavior.
  - Updated integration test guidance to reflect current access-control coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->