### PR TITLE
refactor(finance,comms): the modules drop the tenant column (ADR-0091 §8 phase D)

### DIFF
--- a/backend/internal/compose/integration/privacy_channel_delivery_integration_test.go
+++ b/backend/internal/compose/integration/privacy_channel_delivery_integration_test.go
@@ -97,11 +97,11 @@ func seedChannelDelivery(t *testing.T, e *Env, age, body, status string, person 
 		// DEFAULT of an empty JSON array, and a channel row that inherited it
 		// would be refused by comms_outbound_shape.
 		_, err := tx.Exec(ctx, `
-			INSERT INTO comms_outbound (id, workspace_id, activity_id, user_id, provider,
+			INSERT INTO comms_outbound (id, activity_id, user_id, provider,
 			                            channel_user_id, body, consent_purpose, status,
 			                            cc, references_chain,
 			                            sent_at, provider_message_id)
-			VALUES ($1, `+wsClause+`, $2, $3, 'telegram', $4, $5, 'transactional', $6,
+			VALUES ($1, $2, $3, 'telegram', $4, $5, 'transactional', $6,
 			        NULL, NULL,
 			        CASE WHEN $6 = 'sent' THEN now() END,
 			        CASE WHEN $6 = 'sent' THEN $7 END)`,

--- a/backend/internal/compose/integration/privacy_comms_integration_test.go
+++ b/backend/internal/compose/integration/privacy_comms_integration_test.go
@@ -133,10 +133,10 @@ func seedAddressedDelivery(t *testing.T, e *Env, age, subject, body, status stri
 			}
 		}
 		_, err := tx.Exec(ctx, `
-			INSERT INTO comms_outbound (id, workspace_id, activity_id, user_id, provider, message_id,
+			INSERT INTO comms_outbound (id, activity_id, user_id, provider, message_id,
 			                            recipients, cc, subject, body, consent_purpose,
 			                            list_unsubscribe, status, sent_at, provider_message_id, reason)
-			VALUES ($1, `+wsClause+`, $2, $3, 'gmail', $4,
+			VALUES ($1, $2, $3, 'gmail', $4,
 			        jsonb_build_array($5::text), jsonb_build_array($9::text), $6, $7, 'transactional',
 			        '<https://app.test/v1/public/preferences/tok-erika/unsubscribe?purpose=marketing>', $8,
 			        CASE WHEN $8 = 'sent' THEN now() END,

--- a/backend/internal/modules/activities/draftoutcome_integration_test.go
+++ b/backend/internal/modules/activities/draftoutcome_integration_test.go
@@ -51,9 +51,9 @@ func (s *deliveryWritingStager) StageTx(ctx context.Context, tx pgx.Tx, in Deliv
 	}
 	_, err = tx.Exec(ctx, `
 		INSERT INTO comms_outbound
-		  (id, workspace_id, activity_id, user_id, provider, message_id,
+		  (id, activity_id, user_id, provider, message_id,
 		   recipients, subject, body, consent_purpose)
-		VALUES ($1, current_setting('app.workspace_id')::uuid, $2, $3, $4, $5, $6, $7, $8, $9)`,
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
 		ids.NewV7(), in.ActivityID, s.userID, in.Provider, in.MessageID,
 		recipients, in.Subject, in.Body, in.ConsentPurpose)
 	if err != nil {
@@ -70,7 +70,7 @@ func (e *sendEnv) deliveryCount(t *testing.T) int {
 	t.Helper()
 	var n int
 	if err := e.owner.QueryRow(context.Background(),
-		`SELECT count(*) FROM comms_outbound WHERE workspace_id = $1`, e.ws).Scan(&n); err != nil {
+		`SELECT count(*) FROM comms_outbound`).Scan(&n); err != nil {
 		t.Fatalf("counting staged deliveries: %v", err)
 	}
 	return n

--- a/backend/internal/modules/comms/store.go
+++ b/backend/internal/modules/comms/store.go
@@ -35,13 +35,13 @@ const (
 // than a failure.
 var ErrTerminal = errors.New("comms: delivery is already terminal")
 
-// ErrDuplicateMessage marks a second staging of a message identity this
-// workspace already staged. It is the (workspace_id, message_id) idempotency
-// key answering, phrased so the caller learns what to do without learning what
-// the database is called: a wrapped pgx violation carries the constraint and
-// table names, and a client is owed neither.
+// ErrDuplicateMessage marks a second staging of a message identity already
+// staged. It is the message_id idempotency key answering, phrased so the
+// caller learns what to do without learning what the database is called: a
+// wrapped pgx violation carries the constraint and table names, and a client
+// is owed neither.
 var ErrDuplicateMessage = fmt.Errorf(
-	"comms: this message identity is already staged for delivery in this workspace: %w", apperrors.ErrConflict)
+	"comms: this message identity is already staged for delivery: %w", apperrors.ErrConflict)
 
 // ErrNoAddressee marks a delivery staged with nobody to reach. A message with
 // neither a To nor a Cc address can only be refused later — the consent gate
@@ -148,10 +148,10 @@ func (s *Store) StageTx(ctx context.Context, tx pgx.Tx, in StageInput) (ids.UUID
 	id := ids.NewV7()
 	if _, err := tx.Exec(ctx, `
 		INSERT INTO comms_outbound
-		  (id, workspace_id, activity_id, user_id, provider, message_id,
+		  (id, activity_id, user_id, provider, message_id,
 		   recipients, cc, subject, body, consent_purpose, in_reply_to,
 		   references_chain, thread_key, list_unsubscribe, status, created_at, attachments)
-		VALUES ($1, current_setting('app.workspace_id')::uuid, $2, $3, $4, $5,
+		VALUES ($1, $2, $3, $4, $5,
 		        $6, $7, $8, $9, $10, NULLIF($11,''), $12, NULLIF($13,''),
 		        NULLIF($14,''), 'pending', $15, $16)`,
 		id, in.ActivityID, userID, in.Provider, in.MessageID,

--- a/backend/internal/modules/comms/store_channel_integration_test.go
+++ b/backend/internal/modules/comms/store_channel_integration_test.go
@@ -167,10 +167,10 @@ func TestABlankPendingChannelRecipientIsRejectedByTheDatabase(t *testing.T) {
 	insert := func(status string) error {
 		_, err := e.owner.Exec(context.Background(), `
 			INSERT INTO comms_outbound
-			  (id, workspace_id, activity_id, user_id, provider, channel_user_id,
+			  (id, activity_id, user_id, provider, channel_user_id,
 			   body, consent_purpose, cc, references_chain, status)
-			VALUES ($1, $2, $3, $4, 'telegram', '', 'b', 'transactional', NULL, NULL, $5)`,
-			ids.NewV7(), e.ws, e.activity, e.user, status)
+			VALUES ($1, $2, $3, 'telegram', '', 'b', 'transactional', NULL, NULL, $4)`,
+			ids.NewV7(), e.activity, e.user, status)
 		return err
 	}
 	if err := insert("pending"); err == nil {
@@ -215,9 +215,9 @@ func TestTheSchemaRefusesADeliveryThatIsNeitherShape(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			_, err := e.owner.Exec(context.Background(), `
 				INSERT INTO comms_outbound
-				  (id, workspace_id, activity_id, user_id, provider, body, consent_purpose, status, `+tc.columns+`)
-				VALUES ($1, $2, $3, $4, 'telegram', 'b', 'transactional', 'pending', `+tc.values+`)`,
-				ids.NewV7(), e.ws, e.activity, e.user)
+				  (id, activity_id, user_id, provider, body, consent_purpose, status, `+tc.columns+`)
+				VALUES ($1, $2, $3, 'telegram', 'b', 'transactional', 'pending', `+tc.values+`)`,
+				ids.NewV7(), e.activity, e.user)
 			if err == nil {
 				t.Fatal("the row was accepted; comms_outbound_shape is not enforcing")
 			}

--- a/backend/internal/modules/comms/store_integration_test.go
+++ b/backend/internal/modules/comms/store_integration_test.go
@@ -10,7 +10,7 @@ package comms
 // RecordSent/Park/RecordFailure doing what their names say — RecordDeferral,
 // the fourth status-guarded transition, is driven where the pacing policy
 // reaches it (dispatcher_transmit_test.go) — the caller's transaction owning
-// commit/rollback, and the (workspace_id, message_id) idempotency key. This
+// commit/rollback, and the message_id idempotency key. This
 // file also carries the shared fixture
 // (storeEnv/setupStore/actorCtx/stage/baseInput) the other
 // store_*_integration_test.go files in this package ride:
@@ -258,11 +258,11 @@ func TestTheSchemaRefusesANonArrayInAListColumn(t *testing.T) {
 	e := setupStore(t)
 	_, err := e.owner.Exec(context.Background(), `
 		INSERT INTO comms_outbound
-		  (id, workspace_id, activity_id, user_id, provider, message_id,
+		  (id, activity_id, user_id, provider, message_id,
 		   recipients, cc, subject, body, consent_purpose, status)
-		VALUES ($1, $2, $3, $4, 'gmail', 'msg-nullrecipients@example.com',
+		VALUES ($1, $2, $3, 'gmail', 'msg-nullrecipients@example.com',
 		        'null'::jsonb, '[]'::jsonb, 's', 'b', 'transactional', 'pending')`,
-		ids.NewV7(), e.ws, e.activity, e.user)
+		ids.NewV7(), e.activity, e.user)
 	if err == nil {
 		t.Fatal("a delivery with JSON null recipients was accepted; the shape constraint is not enforcing")
 	}
@@ -423,7 +423,7 @@ func TestStageTxRollsBackWithItsCallerTransaction(t *testing.T) {
 	}
 }
 
-// The (workspace_id, message_id) unique constraint is the idempotency key a
+// The message_id unique constraint is the idempotency key a
 // re-ingested provider copy of the same message relies on: a second stage of
 // the same message_id must fail, not silently duplicate.
 //

--- a/backend/internal/modules/comms/storechannel.go
+++ b/backend/internal/modules/comms/storechannel.go
@@ -86,11 +86,11 @@ func (s *Store) StageChannelTx(ctx context.Context, tx pgx.Tx, in StageChannelIn
 	id := ids.NewV7()
 	if _, err := tx.Exec(ctx, `
 		INSERT INTO comms_outbound
-		  (id, workspace_id, activity_id, user_id, provider, channel_user_id,
+		  (id, activity_id, user_id, provider, channel_user_id,
 		   body, consent_purpose, in_reply_to,
 		   message_id, recipients, cc, subject, references_chain,
 		   status, created_at)
-		VALUES ($1, current_setting('app.workspace_id')::uuid, $2, $3, $4, $5,
+		VALUES ($1, $2, $3, $4, $5,
 		        $6, $7, NULLIF($8,''),
 		        NULL, NULL, NULL, NULL, NULL,
 		        'pending', $9)`,

--- a/backend/internal/modules/finance/mirror.go
+++ b/backend/internal/modules/finance/mirror.go
@@ -281,14 +281,14 @@ func insertInvoice(
 	inv := args.invoice
 	_, err := tx.Exec(ctx, `
 		INSERT INTO finance_invoice
-		       (id, workspace_id, connection_id, organization_id, external_id, number,
+		       (id, connection_id, organization_id, external_id, number,
 		        issued_at, due_at, status, currency, net_minor, tax_minor, gross_minor,
 		        open_minor, credited_minor, fully_paid_at, disputed_at, void_at,
 		        credits_invoice_id, source_updated_at, sync_hash, fx_rate_to_base,
 		        fx_rate_date, source, captured_by)
 		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15,
-		        $16, $17, $18, $19, $20, $21, $22, $23, $24, $25)`,
-		id, storekit.MustWorkspace(ctx), args.connectionID, args.organizationID,
+		        $16, $17, $18, $19, $20, $21, $22, $23, $24)`,
+		id, args.connectionID, args.organizationID,
 		inv.ExternalID, nullable(inv.Number), inv.IssuedOn, inv.DueOn, values.status,
 		inv.Currency, inv.NetMinor, inv.TaxMinor, inv.GrossMinor, values.openMinor,
 		values.credited, inv.FullyPaidAt, values.disputedAt, values.voidAt,

--- a/backend/internal/modules/finance/mirrorpayment.go
+++ b/backend/internal/modules/finance/mirrorpayment.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
-	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
@@ -66,11 +65,11 @@ func (s *Store) mirrorPayment(
 	}
 	_, err = tx.Exec(ctx, `
 		INSERT INTO finance_payment
-		       (workspace_id, connection_id, organization_id, external_id, invoice_id,
+		       (connection_id, organization_id, external_id, invoice_id,
 		        paid_at, currency, amount_minor, source_updated_at, sync_hash,
 		        source, captured_by)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)`,
-		storekit.MustWorkspace(ctx), args.connectionID, args.organizationID,
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`,
+		args.connectionID, args.organizationID,
 		pay.ExternalID, resolveInvoice(pay, args.rowIDs), pay.PaidAt, pay.Currency, pay.AmountMinor,
 		pay.UpdatedAt, hash, OfflineProviderName, args.capturedBy)
 	if err != nil {

--- a/backend/internal/modules/finance/sync.go
+++ b/backend/internal/modules/finance/sync.go
@@ -146,15 +146,15 @@ func mirrorCustomers(
 		hash := hashOf(customer.ExternalID, customer.DisplayName)
 		_, err := tx.Exec(ctx, `
 			INSERT INTO finance_external_customer
-			       (workspace_id, connection_id, external_customer_id, display_name,
+			       (connection_id, external_customer_id, display_name,
 			        source_updated_at, sync_hash, source, captured_by)
-			VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+			VALUES ($1, $2, $3, $4, $5, $6, $7)
 			ON CONFLICT (connection_id, external_customer_id)
 			DO UPDATE SET display_name = EXCLUDED.display_name,
 			              source_updated_at = EXCLUDED.source_updated_at,
 			              sync_hash = EXCLUDED.sync_hash
 			      WHERE finance_external_customer.sync_hash <> EXCLUDED.sync_hash`,
-			storekit.MustWorkspace(ctx), connectionID, customer.ExternalID,
+			connectionID, customer.ExternalID,
 			customer.DisplayName, customer.UpdatedAt, hash, OfflineProviderName, by)
 		if err != nil {
 			return fmt.Errorf("mirror the source's customer: %w", err)

--- a/backend/internal/modules/finance/sync_integration_test.go
+++ b/backend/internal/modules/finance/sync_integration_test.go
@@ -74,17 +74,17 @@ func setupFinance(t *testing.T) *financeEnv {
 	}
 	if _, err := owner.Exec(ctx, `
 		INSERT INTO finance_connection
-		       (id, workspace_id, provider, status, credential_ref, source, captured_by)
-		VALUES ($1, $2, $3, 'active', 'offline://test', 'system', 'system:test')`,
-		connID, e.ws, OfflineProviderName); err != nil {
+		       (id, provider, status, credential_ref, source, captured_by)
+		VALUES ($1, $2, 'active', 'offline://test', 'system', 'system:test')`,
+		connID, OfflineProviderName); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := owner.Exec(ctx, `
 		INSERT INTO finance_customer_link
-		       (workspace_id, connection_id, organization_id, external_customer_id,
+		       (connection_id, organization_id, external_customer_id,
 		        sync_hash, source, captured_by)
-		VALUES ($1, $2, $3, $4, 'seed', 'system', 'system:test')`,
-		e.ws, connID, e.org, e.external); err != nil {
+		VALUES ($1, $2, $3, 'seed', 'system', 'system:test')`,
+		connID, e.org, e.external); err != nil {
 		t.Fatal(err)
 	}
 

--- a/backend/migrations/comms_outbound_inflight_rollback_integration_test.go
+++ b/backend/migrations/comms_outbound_inflight_rollback_integration_test.go
@@ -101,9 +101,9 @@ func seedChannelDeliveryForRollback(t *testing.T, conn *pgx.Conn, ws string, inF
 		}
 		return tx.QueryRow(ctx, `
 			INSERT INTO comms_outbound
-			  (id, workspace_id, activity_id, user_id, provider, channel_user_id,
+			  (id, activity_id, user_id, provider, channel_user_id,
 			   body, consent_purpose, cc, references_chain, status, inflight_at)
-			VALUES (uuidv7(), `+wsClause+`, $1, $2, 'telegram', '770011',
+			VALUES (uuidv7(), $1, $2, 'telegram', '770011',
 			        'Shipping Monday.', 'transactional', NULL, NULL, 'pending',
 			        CASE WHEN $3 THEN now() END)
 			RETURNING id`, activityID, userID, inFlight).Scan(&deliveryID)

--- a/backend/migrations/core/0230_finance_comms_drop_workspace.down.sql
+++ b/backend/migrations/core/0230_finance_comms_drop_workspace.down.sql
@@ -1,0 +1,67 @@
+-- Reverse of 0230: the six tables carry the tenant column again.
+--
+-- The backfill reads `workspace` because there is exactly one to read: 0217's
+-- pre-flight refuses to run against a database holding more than one live
+-- workspace, and ADR-0061 §3 has the API refusing to start in that state. If
+-- `workspace` is empty and a table is not, SET NOT NULL fails and the rollback
+-- stops — the honest outcome, since no value this migration could write would
+-- be true.
+
+ALTER TABLE finance_connection ADD COLUMN workspace_id uuid;
+ALTER TABLE finance_external_customer ADD COLUMN workspace_id uuid;
+ALTER TABLE finance_customer_link ADD COLUMN workspace_id uuid;
+ALTER TABLE finance_invoice ADD COLUMN workspace_id uuid;
+ALTER TABLE finance_payment ADD COLUMN workspace_id uuid;
+ALTER TABLE comms_outbound ADD COLUMN workspace_id uuid;
+
+DO $$
+DECLARE ws uuid := (SELECT id FROM workspace ORDER BY created_at LIMIT 1);
+BEGIN
+  UPDATE finance_connection SET workspace_id = ws;
+  UPDATE finance_external_customer SET workspace_id = ws;
+  UPDATE finance_customer_link SET workspace_id = ws;
+  UPDATE finance_invoice SET workspace_id = ws;
+  UPDATE finance_payment SET workspace_id = ws;
+  UPDATE comms_outbound SET workspace_id = ws;
+END $$;
+
+ALTER TABLE finance_connection ALTER COLUMN workspace_id SET NOT NULL;
+ALTER TABLE finance_external_customer ALTER COLUMN workspace_id SET NOT NULL;
+ALTER TABLE finance_customer_link ALTER COLUMN workspace_id SET NOT NULL;
+ALTER TABLE finance_invoice ALTER COLUMN workspace_id SET NOT NULL;
+ALTER TABLE finance_payment ALTER COLUMN workspace_id SET NOT NULL;
+ALTER TABLE comms_outbound ALTER COLUMN workspace_id SET NOT NULL;
+
+ALTER TABLE finance_connection ADD CONSTRAINT finance_connection_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE finance_external_customer ADD CONSTRAINT finance_external_customer_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE finance_customer_link ADD CONSTRAINT finance_customer_link_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE finance_invoice ADD CONSTRAINT finance_invoice_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE finance_payment ADD CONSTRAINT finance_payment_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE comms_outbound ADD CONSTRAINT comms_outbound_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+
+ALTER TABLE finance_connection ADD CONSTRAINT uq_finance_connection_ws_id UNIQUE (id);
+ALTER TABLE finance_invoice ADD CONSTRAINT uq_finance_invoice_ws_id UNIQUE (id);
+
+DROP INDEX finance_invoice_account_ix;
+CREATE INDEX finance_invoice_account_ix ON finance_invoice (workspace_id, organization_id, issued_at DESC);
+
+DROP INDEX finance_invoice_credits_ix;
+CREATE INDEX finance_invoice_credits_ix ON finance_invoice (workspace_id, credits_invoice_id) WHERE credits_invoice_id IS NOT NULL;
+
+DROP INDEX finance_invoice_open_ix;
+CREATE INDEX finance_invoice_open_ix ON finance_invoice (workspace_id, organization_id) WHERE open_minor > 0 AND void_at IS NULL;
+
+DROP INDEX finance_payment_account_ix;
+CREATE INDEX finance_payment_account_ix ON finance_payment (workspace_id, organization_id, paid_at DESC);
+
+DROP INDEX finance_payment_invoice_ix;
+CREATE INDEX finance_payment_invoice_ix ON finance_payment (workspace_id, invoice_id) WHERE invoice_id IS NOT NULL;
+
+DROP INDEX comms_outbound_workspace_activity_ix;
+CREATE INDEX comms_outbound_workspace_activity_ix ON comms_outbound (workspace_id, activity_id);

--- a/backend/migrations/core/0230_finance_comms_drop_workspace.up.sql
+++ b/backend/migrations/core/0230_finance_comms_drop_workspace.up.sql
@@ -1,0 +1,42 @@
+-- 0230: the finance mirror and the outbound-comms ledger drop the tenant
+-- column (ADR-0091 §8 phase D).
+--
+-- Six tables, six indexes, two redundant uniques. Neither module references
+-- the other's tables, which is what makes them one reviewable unit.
+--
+-- The finance mirror's own uniques already key on `connection_id` — an
+-- external customer, invoice or payment is unique within the connection that
+-- mirrored it, and a connection belongs to the installation. Dropping the
+-- tenant column changes nothing about what those answer; it removes a column
+-- that was never part of the question.
+--
+-- `comms_outbound_workspace_activity_ix` narrows to `activity_id` alone, which
+-- is the whole of what it looked up: the ledger row for an activity.
+
+DROP INDEX finance_invoice_account_ix;
+CREATE INDEX finance_invoice_account_ix ON finance_invoice (organization_id, issued_at DESC);
+
+DROP INDEX finance_invoice_credits_ix;
+CREATE INDEX finance_invoice_credits_ix ON finance_invoice (credits_invoice_id) WHERE credits_invoice_id IS NOT NULL;
+
+DROP INDEX finance_invoice_open_ix;
+CREATE INDEX finance_invoice_open_ix ON finance_invoice (organization_id) WHERE open_minor > 0 AND void_at IS NULL;
+
+DROP INDEX finance_payment_account_ix;
+CREATE INDEX finance_payment_account_ix ON finance_payment (organization_id, paid_at DESC);
+
+DROP INDEX finance_payment_invoice_ix;
+CREATE INDEX finance_payment_invoice_ix ON finance_payment (invoice_id) WHERE invoice_id IS NOT NULL;
+
+DROP INDEX comms_outbound_workspace_activity_ix;
+CREATE INDEX comms_outbound_workspace_activity_ix ON comms_outbound (activity_id);
+
+ALTER TABLE finance_connection DROP CONSTRAINT uq_finance_connection_ws_id;
+ALTER TABLE finance_invoice DROP CONSTRAINT uq_finance_invoice_ws_id;
+
+ALTER TABLE finance_connection DROP COLUMN workspace_id;
+ALTER TABLE finance_external_customer DROP COLUMN workspace_id;
+ALTER TABLE finance_customer_link DROP COLUMN workspace_id;
+ALTER TABLE finance_invoice DROP COLUMN workspace_id;
+ALTER TABLE finance_payment DROP COLUMN workspace_id;
+ALTER TABLE comms_outbound DROP COLUMN workspace_id;

--- a/scripts/seed-dev.sql
+++ b/scripts/seed-dev.sql
@@ -208,12 +208,12 @@ BEGIN
 
   SELECT id INTO conn
     FROM finance_connection
-   WHERE workspace_id = ws AND provider = 'offline_demo' AND archived_at IS NULL;
+   WHERE provider = 'offline_demo' AND archived_at IS NULL;
 
   IF conn IS NULL THEN
     INSERT INTO finance_connection
-           (workspace_id, provider, status, credential_ref, source, captured_by)
-    VALUES (ws, 'offline_demo', 'active', 'offline://demo', 'system', 'system:seed')
+           (provider, status, credential_ref, source, captured_by)
+    VALUES ('offline_demo', 'active', 'offline://demo', 'system', 'system:seed')
     RETURNING id INTO conn;
   END IF;
 
@@ -226,9 +226,9 @@ BEGIN
        AND lifecycle = 'customer'
   LOOP
     INSERT INTO finance_customer_link
-           (workspace_id, connection_id, organization_id, external_customer_id,
+           (connection_id, organization_id, external_customer_id,
             sync_hash, source, captured_by)
-    VALUES (ws, conn, org.id, 'DEMO-' || left(replace(org.id::text, '-', ''), 8),
+    VALUES (conn, org.id, 'DEMO-' || left(replace(org.id::text, '-', ''), 8),
             'seed', 'system', 'system:seed')
     ON CONFLICT DO NOTHING;
   END LOOP;


### PR DESCRIPTION
Phase D, fourth slice. Six tables — the finance mirror's five and `comms_outbound` — plus six indexes and two redundant uniques (`uq_finance_connection_ws_id`, `uq_finance_invoice_ws_id`, both second copies of their primary keys since phase B).

Neither module references the other's tables, which is what makes them one reviewable unit.

## What the column was not doing

The finance mirror's own uniques already key on `connection_id`: an external customer, invoice or payment is unique **within the connection that mirrored it**, and a connection belongs to the installation. Dropping the tenant column removes a column that was never part of that question.

`comms_outbound`'s idempotency key is `message_id` alone — two comments and one caller-facing error message still called it `(workspace_id, message_id)`, and now say what the index actually says.

## The dev seed is in the diff

`scripts/seed-dev.sql` writes `finance_connection` and `finance_customer_link` by name. Left out, `live-boot` is where that surfaces — which is exactly how it went in #1104. Run against the collapsed schema here instead.

## Verification

- Lane applied to an empty database; the down restores all six columns with their foreign keys, both uniques, and all six wide indexes.
- The dev seed runs to completion on the collapsed schema.
- `make check-backend` green.
- `make test-integration`: **OK, 0 skips, 39 packages.**

Agents was surveyed for this slice and left out: `runner_job` and `agent_run` lose the column with the scheduler's per-tenant fan-out, whose suite injects a fault through a trigger keyed on `NEW.workspace_id` — the same entanglement that defers webhooks (§5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drops the `workspace_id` tenant column from the finance mirror and `comms_outbound`. Outbound comms idempotency changes from `(workspace_id, message_id)` to `message_id` only; finance uniqueness remains keyed by `connection_id`.

- Schema: removes `workspace_id` from `finance_connection`, `finance_external_customer`, `finance_customer_link`, `finance_invoice`, `finance_payment`, and `comms_outbound`; narrows six indexes (e.g., `comms_outbound_workspace_activity_ix` to `activity_id`); removes redundant `uq_finance_connection_ws_id` and `uq_finance_invoice_ws_id`.
- Code: eliminates `current_setting('app.workspace_id')` inserts and workspace filters; updates comments and the duplicate-message error text to reflect `message_id` idempotency; adjusts `scripts/seed-dev.sql` to write `finance_connection` and `finance_customer_link` without workspace; updates integration tests accordingly.

**Rollout/Migration**
- Apply `0230_finance_comms_drop_workspace.up.sql`. Ensure callers rely on `message_id` being unique installation-wide; do not pass or expect `workspace_id` in these tables.
- If rolling back, the database must have exactly one live workspace. `0230_finance_comms_drop_workspace.down.sql` backfills `workspace_id` from `workspace`, restores foreign keys, wide indexes, and the two uniques.

<sup>Written for commit 511da3c84bb21bcb3b6a03214f9bee1059113e2c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1154?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

