### PR TITLE
fix(webread): the reduced page text decodes character references

### DIFF
--- a/backend/internal/platform/webread/striptags.go
+++ b/backend/internal/platform/webread/striptags.go
@@ -3,23 +3,31 @@
 
 package webread
 
-import "strings"
+import (
+	"html"
+	"strings"
+)
 
-// StripTags reduces HTML to whitespace-normalized text. Deliberately crude:
-// evidence snippets are matched against THIS text, so the same reduction
-// defines both what the model sees and what counts as verbatim — any change
-// here silently invalidates stored evidence, treat the output as a contract.
-func StripTags(html string) string {
+// StripTags reduces HTML to whitespace-normalized text with character
+// references decoded. Deliberately crude otherwise: evidence snippets are
+// matched against THIS text, so the same reduction defines both what the
+// model sees and what counts as verbatim — any change here silently
+// invalidates stored evidence, treat the output as a contract.
+//
+// Decoding is part of that contract: a page printing "Zitadellenstra&szlig;e"
+// must reduce to the "Zitadellenstraße" a model will quote back, or the
+// verbatim gates refuse the site's own address as unprinted.
+func StripTags(doc string) string {
 	var b strings.Builder
 	inTag, inScript := false, false
-	for i, r := range html {
+	for i, r := range doc {
 		switch {
 		case inScript:
-			if r == '<' && (tagPrefix(html[i:], "</script") || tagPrefix(html[i:], "</style")) {
+			if r == '<' && (tagPrefix(doc[i:], "</script") || tagPrefix(doc[i:], "</style")) {
 				inScript, inTag = false, true
 			}
 		case r == '<':
-			if tagPrefix(html[i:], "<script") || tagPrefix(html[i:], "<style") {
+			if tagPrefix(doc[i:], "<script") || tagPrefix(doc[i:], "<style") {
 				inScript = true
 			} else {
 				inTag = true
@@ -31,7 +39,9 @@ func StripTags(html string) string {
 			b.WriteRune(r)
 		}
 	}
-	return strings.Join(strings.Fields(b.String()), " ")
+	// Unescape before collapsing: &nbsp; decodes to U+00A0, which is
+	// whitespace the collapse must still fold to one plain space.
+	return strings.Join(strings.Fields(html.UnescapeString(b.String())), " ")
 }
 
 // tagPrefix is an ASCII case-insensitive TAG-NAME test on the ORIGINAL bytes:

--- a/backend/internal/platform/webread/webread_test.go
+++ b/backend/internal/platform/webread/webread_test.go
@@ -26,6 +26,18 @@ func TestStripTagsSurvivesUnicodeCaseFolding(t *testing.T) {
 	}
 }
 
+func TestStripTagsDecodesCharacterReferences(t *testing.T) {
+	// German legal notices routinely arrive entity-encoded. The reduced
+	// text is what the verbatim evidence gates compare a model's quote
+	// against, so it must carry the decoded spelling the model will use —
+	// undecoded, a site's own registered address is refused as unprinted.
+	got := StripTags("<p>Zitadellenstra&szlig;e 14a</p><p>D-&nbsp;21079 Hamburg f&uuml;r &quot;BJA&quot;</p>")
+	want := `Zitadellenstraße 14a D- 21079 Hamburg für "BJA"`
+	if got != want {
+		t.Fatalf("StripTags = %q, want %q", got, want)
+	}
+}
+
 // The policy reading is REP (RFC 9309): longest match wins, Allow beats
 // Disallow at equal length, the group naming this bot beats *, and an empty
 // Disallow means allow-all.


### PR DESCRIPTION
## What

`webread.StripTags` now runs `html.UnescapeString` on the reduced text before the whitespace collapse, with a regression test.

## Why

A coldstart of judithandresen.com reported the registered address as "not stated on your legal or imprint page". The impressum prints it — entity-encoded (`Zitadellenstra&szlig;e 14a`). The model quotes the decoded spelling back, so `groundedDetail`'s whole-token evidence match refused the site's own address as unprinted (`value_not_in_snippet`). The same mismatch dropped ~20 further findings on that one site (every value carrying `f&uuml;r`, `&quot;`, …); any entity-encoded German page loses its umlaut-carrying facts wholesale.

Decoding in `StripTags` keeps the evidence contract single-sourced: the model sees decoded text and the gates compare decoded against decoded. Unescaping runs before the collapse so `&nbsp;` still folds to one plain space.

## Verification

- `worker siteread https://www.judithandresen.com/` before: `DROPPED value_not_in_snippet legal registered_address "Zitadellenstraße 14a, D- 21079 Hamburg"`. After: the impressum yields `location "Hamburg — Zitadellenstraße 14a, D- 21079 Hamburg"` and the legal entity survives with no drop.
- `make check-backend` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Decode HTML character references in reduced page text to align snippet matching with model quotes. Previously `webread.StripTags` preserved entities (e.g., `&szlig;`), causing evidence mismatches; now it runs `html.UnescapeString` before whitespace collapsing so decoded text is used and `&nbsp;` still folds to a single space.

- Adjusts `webread.StripTags` to decode character references, keeping the evidence contract consistent with model output.
- Adds `TestStripTagsDecodesCharacterReferences` to lock behavior.
- No API or signature changes; the reduced text content will differ due to decoding.

<sup>Written for commit 70df044ee33ca42ebee0a8134706e3d582e96b6d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1156?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTML text extraction by decoding character references, including accented characters, special symbols, and non-breaking spaces.
  * Ensured decoded whitespace is normalized consistently in extracted content.

* **Tests**
  * Added coverage for character-reference decoding in German text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->