### PR TITLE
feat(extensions): a unit picks a record by name, not by UUID

### DIFF
--- a/extensions/notes/frontend/i18n/de.json
+++ b/extensions/notes/frontend/i18n/de.json
@@ -8,7 +8,7 @@
   "extNotes.filing.noGrant": "Ihnen wurde das Heften nicht gewährt.",
   "extNotes.filing.organization": "Unternehmen",
   "extNotes.filing.person": "Person",
-  "extNotes.filing.subjectIdLabel": "Datensatz-ID",
+  "extNotes.filing.subjectSearchLabel": "Datensatz über den Namen suchen",
   "extNotes.filing.subjectTypeLabel": "Datensatztyp",
   "extNotes.filing.title": "Notiz an einen Datensatz heften",
   "extNotes.notes.add": "Hinzufügen",

--- a/extensions/notes/frontend/i18n/de.json
+++ b/extensions/notes/frontend/i18n/de.json
@@ -8,7 +8,7 @@
   "extNotes.filing.noGrant": "Ihnen wurde das Heften nicht gewährt.",
   "extNotes.filing.organization": "Unternehmen",
   "extNotes.filing.person": "Person",
-  "extNotes.filing.subjectSearchLabel": "Datensatz über den Namen suchen",
+  "extNotes.filing.subjectSearchLabel": "Datensatz nach Namen suchen",
   "extNotes.filing.subjectTypeLabel": "Datensatztyp",
   "extNotes.filing.title": "Notiz an einen Datensatz heften",
   "extNotes.notes.add": "Hinzufügen",

--- a/extensions/notes/frontend/i18n/en.json
+++ b/extensions/notes/frontend/i18n/en.json
@@ -8,7 +8,7 @@
   "extNotes.filing.noGrant": "You have not been granted filing.",
   "extNotes.filing.organization": "Company",
   "extNotes.filing.person": "Person",
-  "extNotes.filing.subjectIdLabel": "Record id",
+  "extNotes.filing.subjectSearchLabel": "Find the record by name",
   "extNotes.filing.subjectTypeLabel": "Record type",
   "extNotes.filing.title": "File a note to a record",
   "extNotes.notes.add": "Add",

--- a/extensions/notes/frontend/i18n/vi.json
+++ b/extensions/notes/frontend/i18n/vi.json
@@ -8,7 +8,7 @@
   "extNotes.filing.noGrant": "Bạn chưa được cấp quyền đính ghi chú.",
   "extNotes.filing.organization": "Công ty",
   "extNotes.filing.person": "Người",
-  "extNotes.filing.subjectIdLabel": "Mã bản ghi",
+  "extNotes.filing.subjectSearchLabel": "Tìm bản ghi theo tên",
   "extNotes.filing.subjectTypeLabel": "Loại bản ghi",
   "extNotes.filing.title": "Đính ghi chú vào một bản ghi",
   "extNotes.notes.add": "Thêm",

--- a/extensions/notes/frontend/screen.test.tsx
+++ b/extensions/notes/frontend/screen.test.tsx
@@ -459,6 +459,21 @@ const FILING_GRANT = {
 
 describe("filing a note to a record", () => {
   const listOnly = { "/ext/notes/list": () => ({ notes: [] }) };
+  // One candidate, from the product's own cross-object search. The picker
+  // debounces, so every case that picks one waits on findBy* rather than
+  // asserting straight after typing.
+  const searchAnswers = {
+    "/search": () => ({
+      data: [
+        {
+          type: "deal",
+          id: "7c9e6679-7425-40de-944b-e07fc1f90ae7",
+          title: "Acme renewal",
+        },
+      ],
+      page: { has_more: false },
+    }),
+  };
 
   it("is absent for a seat that was not granted it", async () => {
     const { fetchStub } = stubTransport(FULL_GRANT, listOnly);
@@ -473,6 +488,7 @@ describe("filing a note to a record", () => {
   it("sends the note, the record kind and the record it was filed to", async () => {
     const { calls, fetchStub } = stubTransport(FILING_GRANT, {
       ...listOnly,
+      ...searchAnswers,
       "/ext/notes/file": () => ({
         id: "11111111-1111-4111-8111-111111111111",
         kind: "note",
@@ -489,15 +505,21 @@ describe("filing a note to a record", () => {
       await screen.findByLabelText("Note to file"),
       "a filed note",
     );
-    await user.type(
-      screen.getByLabelText("Record id"),
-      "7c9e6679-7425-40de-944b-e07fc1f90ae7",
-    );
     // Through the Select, not on its default: the narrowing that turns the
     // control's string back into the contract's enum is the code this case is
     // about, and a filing that never touches the control never runs it.
     await user.click(screen.getByLabelText("Record type"));
     await user.click(await screen.findByRole("option", { name: "Deal" }));
+    // The record is CHOSEN, by name. Nobody types the id — which is the whole
+    // point of the control — so the id in the request can only have come from
+    // the candidate the search answered with.
+    await user.type(
+      screen.getByLabelText("Find the record by name"),
+      "renewal",
+    );
+    await user.click(
+      await screen.findByRole("button", { name: "Acme renewal" }),
+    );
     await user.click(screen.getByRole("button", { name: "File to record" }));
 
     await waitFor(() => {
@@ -515,11 +537,111 @@ describe("filing a note to a record", () => {
     ).toBeTruthy();
   });
 
+  // The search is SCOPED to the record type the form is on. Unscoped, a query
+  // for "acme" while the form says Person would offer the Acme organization,
+  // and filing it would name a person id that is an organization's.
+  it("searches only the record type the form is on", async () => {
+    const { calls, fetchStub } = stubTransport(FILING_GRANT, {
+      ...listOnly,
+      ...searchAnswers,
+    });
+    vi.stubGlobal("fetch", vi.fn(fetchStub));
+    renderScreen();
+
+    const user = userEvent.setup();
+    await user.click(await screen.findByLabelText("Record type"));
+    await user.click(await screen.findByRole("option", { name: "Deal" }));
+    await user.type(screen.getByLabelText("Find the record by name"), "acme");
+
+    await waitFor(() => {
+      expect(calls.some((call) => call.path === "/search")).toBe(true);
+    });
+    const search = calls.find((call) => call.path === "/search");
+    expect(search?.query.types).toBe("deal");
+    expect(search?.query.q).toBe("acme");
+  });
+
+  // Changing the TYPE clears the pick. A contact chosen while the form said
+  // Person is not a deal, and a stale pick would file the note against
+  // whatever record happens to hold that id — or, far more often, against
+  // nothing, with a refusal nobody can read.
+  it("drops the picked record when the record type changes", async () => {
+    const { fetchStub } = stubTransport(FILING_GRANT, {
+      ...listOnly,
+      ...searchAnswers,
+    });
+    vi.stubGlobal("fetch", vi.fn(fetchStub));
+    renderScreen();
+
+    const user = userEvent.setup();
+    await user.type(
+      await screen.findByLabelText("Note to file"),
+      "a filed note",
+    );
+    await user.type(screen.getByLabelText("Find the record by name"), "acme");
+    await user.click(
+      await screen.findByRole("button", { name: "Acme renewal" }),
+    );
+    // Filing is possible: a body and a record.
+    expect(
+      screen.getByRole<HTMLButtonElement>("button", { name: "File to record" })
+        .disabled,
+    ).toBe(false);
+
+    await user.click(screen.getByLabelText("Record type"));
+    await user.click(await screen.findByRole("option", { name: "Deal" }));
+
+    // And is not any more, because the record it would have named is gone.
+    expect(
+      screen.getByRole<HTMLButtonElement>("button", { name: "File to record" })
+        .disabled,
+    ).toBe(true);
+  });
+
+  // A hit the contract types as nullable-titled is DROPPED rather than
+  // rendered as an empty row: a candidate nobody can read is one nobody can
+  // choose on purpose.
+  it("offers no candidate for a hit with no title", async () => {
+    const { calls, fetchStub } = stubTransport(FILING_GRANT, {
+      ...listOnly,
+      "/search": () => ({
+        data: [
+          {
+            type: "deal",
+            id: "7c9e6679-7425-40de-944b-e07fc1f90ae7",
+            title: null,
+          },
+        ],
+        page: { has_more: false },
+      }),
+    });
+    vi.stubGlobal("fetch", vi.fn(fetchStub));
+    renderScreen();
+
+    const user = userEvent.setup();
+    await user.type(
+      await screen.findByLabelText("Find the record by name"),
+      "acme",
+    );
+    // The search ran and answered; nothing became pickable, so filing stays
+    // impossible. Asserted on the control rather than on the absence of a row,
+    // because "no row appeared" is also what a search that never ran looks
+    // like — the /search call is what separates them.
+    await waitFor(() => {
+      expect(calls.some((call) => call.path === "/search")).toBe(true);
+    });
+    expect(
+      screen.getByRole<HTMLButtonElement>("button", { name: "File to record" })
+        .disabled,
+    ).toBe(true);
+  });
+
   // The two grants are separate and the second one is the server's to check, so
   // the copy says what is true either way: nothing was written.
   it("says nothing was written when the server refuses", async () => {
     const { fetchStub } = stubTransport(FILING_GRANT, {
       ...listOnly,
+      ...searchAnswers,
       "/ext/notes/file": () => {
         throw new Error("refused");
       },
@@ -532,9 +654,9 @@ describe("filing a note to a record", () => {
       await screen.findByLabelText("Note to file"),
       "a filed note",
     );
-    await user.type(
-      screen.getByLabelText("Record id"),
-      "7c9e6679-7425-40de-944b-e07fc1f90ae7",
+    await user.type(screen.getByLabelText("Find the record by name"), "acme");
+    await user.click(
+      await screen.findByRole("button", { name: "Acme renewal" }),
     );
     await user.click(screen.getByRole("button", { name: "File to record" }));
 

--- a/extensions/notes/frontend/screen.test.tsx
+++ b/extensions/notes/frontend/screen.test.tsx
@@ -601,14 +601,23 @@ describe("filing a note to a record", () => {
   // A hit the contract types as nullable-titled is DROPPED rather than
   // rendered as an empty row: a candidate nobody can read is one nobody can
   // choose on purpose.
-  it("offers no candidate for a hit with no title", async () => {
-    const { calls, fetchStub } = stubTransport(FILING_GRANT, {
+  //
+  // Two hits, one of each, because the assertion has to be about the FILTER.
+  // "No candidate appeared" is also what a search that never ran looks like,
+  // and a titled hit beside the titleless one is what tells them apart.
+  it("offers the hit that has a title and drops the one that does not", async () => {
+    const { fetchStub } = stubTransport(FILING_GRANT, {
       ...listOnly,
       "/search": () => ({
         data: [
           {
-            type: "deal",
+            type: "person",
             id: "7c9e6679-7425-40de-944b-e07fc1f90ae7",
+            title: "Acme renewal",
+          },
+          {
+            type: "person",
+            id: "3f2504e0-4f89-41d3-9a0c-0305e82c3301",
             title: null,
           },
         ],
@@ -623,17 +632,52 @@ describe("filing a note to a record", () => {
       await screen.findByLabelText("Find the record by name"),
       "acme",
     );
-    // The search ran and answered; nothing became pickable, so filing stays
-    // impossible. Asserted on the control rather than on the absence of a row,
-    // because "no row appeared" is also what a search that never ran looks
-    // like — the /search call is what separates them.
-    await waitFor(() => {
-      expect(calls.some((call) => call.path === "/search")).toBe(true);
-    });
+
+    // The readable one is offered...
     expect(
-      screen.getByRole<HTMLButtonElement>("button", { name: "File to record" })
-        .disabled,
-    ).toBe(true);
+      await screen.findByRole("button", { name: "Acme renewal" }),
+    ).toBeTruthy();
+    // ...and it is the ONLY candidate: the titleless hit would render as a
+    // button with no accessible name, which is what this counts.
+    const candidates = screen
+      .getAllByRole("button")
+      .filter((button) => button.textContent?.trim() !== "");
+    expect(
+      candidates.filter((button) => button.textContent === "Acme renewal"),
+    ).toHaveLength(1);
+    expect(
+      screen
+        .queryAllByRole("button")
+        .filter((button) => button.textContent?.trim() === ""),
+    ).toHaveLength(0);
+  });
+
+  // The candidates already on SCREEN belong to the search space they came
+  // from. Switching the record type mid-search leaves the previous type's
+  // results rendered and clickable until the new search resolves — and picking
+  // one there files a person against a deal.
+  it("drops the candidates on screen when the record type changes", async () => {
+    const { fetchStub } = stubTransport(FILING_GRANT, {
+      ...listOnly,
+      ...searchAnswers,
+    });
+    vi.stubGlobal("fetch", vi.fn(fetchStub));
+    renderScreen();
+
+    const user = userEvent.setup();
+    await user.type(
+      await screen.findByLabelText("Find the record by name"),
+      "acme",
+    );
+    expect(
+      await screen.findByRole("button", { name: "Acme renewal" }),
+    ).toBeTruthy();
+
+    await user.click(screen.getByLabelText("Record type"));
+    await user.click(await screen.findByRole("option", { name: "Deal" }));
+
+    // Gone at once, rather than when the next search happens to answer.
+    expect(screen.queryByRole("button", { name: "Acme renewal" })).toBeNull();
   });
 
   // The two grants are separate and the second one is the server's to check, so

--- a/extensions/notes/frontend/screen.tsx
+++ b/extensions/notes/frontend/screen.tsx
@@ -396,10 +396,10 @@ async function searchSubjects(
   type: SubjectType,
   q: string,
 ): Promise<RecordPickerCandidate[]> {
-  const { data, error } = await api.GET("/search", {
+  const { data, error, response } = await api.GET("/search", {
     params: { query: { q, types: [type], limit: SUBJECT_CANDIDATES } },
   });
-  if (error) {
+  if (error || !response.ok) {
     throwProblem(error);
   }
   return data.data.flatMap((hit) =>
@@ -440,22 +440,37 @@ function FilingCard() {
   // needs the name, and holding the candidate keeps the two from disagreeing.
   const [subject, setSubject] = useState<RecordPickerCandidate | null>(null);
   const [filed, setFiled] = useState(false);
-  // Bound to the type the form is on, and MEMOISED on it: RecordPicker's
-  // debounce effect depends on this function, so a fresh closure per render
-  // would restart the timer on every keystroke and never fire.
+  // Bound to the type the form is on, and MEMOISED on it — which is
+  // load-bearing rather than tidy. RecordPicker keys BOTH of its effects on
+  // this function: the debounce, and the one that empties the candidate list
+  // when the search space changes. This card re-renders whenever the note body
+  // is typed or the filing mutation flips state, so an unmemoised closure
+  // would be a new search space on each of those — clearing the candidates
+  // somebody is reading, and restarting the debounce under them.
   const searchSubjectsFor = useCallback(
     (q: string) => searchSubjects(subjectType, q),
     [subjectType],
   );
 
+  // The filing takes its values as mutation VARIABLES rather than closing over
+  // the form's state, and that is not style: a mutationFn is captured at
+  // render and its options are refreshed in a passive effect, so a close-run
+  // submit can invoke the function from a render where the record was still
+  // unpicked. Passed in, the request cannot name a record the person had not
+  // chosen — and the type below says so, which is why there is no `?? ""`
+  // fallback left to reason about.
   const file = useMutation({
-    mutationFn: async () => {
+    mutationFn: async (filing: {
+      body: string;
+      subjectType: SubjectType;
+      subjectID: string;
+    }) => {
       setFiled(false);
       const { error, response } = await api.POST("/ext/notes/file", {
         body: {
-          body,
-          subject_type: subjectType,
-          subject_id: subject?.id ?? "",
+          body: filing.body,
+          subject_type: filing.subjectType,
+          subject_id: filing.subjectID,
         },
       });
       if (error || !response.ok) {
@@ -533,9 +548,9 @@ function FilingCard() {
       </Field>
       {/*
         The record itself, by name. It is not wrapped in a Field: RecordPicker
-        renders its own labelled search input, and a second label around it
-        would be two labels for one control — which is what a screen reader
-        would then read out.
+        renders its own labelled search input and takes no id, so a Field
+        around it would render a label pointing at an element that does not
+        exist — a dangling `htmlFor`, which is worse than the plain control.
       */}
       <RecordPicker
         label={t("extNotes.filing.subjectSearchLabel")}
@@ -549,7 +564,15 @@ function FilingCard() {
       />
       <Button
         disabled={body.trim() === "" || subject === null || file.isPending}
-        onClick={() => file.mutate()}
+        onClick={() => {
+          // Narrowed HERE rather than trusted from the disabled condition: the
+          // button's state is a rendering, and the request's argument is the
+          // fact.
+          if (subject === null) {
+            return;
+          }
+          file.mutate({ body, subjectType, subjectID: subject.id });
+        }}
       >
         {t("extNotes.filing.file")}
       </Button>

--- a/extensions/notes/frontend/screen.tsx
+++ b/extensions/notes/frontend/screen.tsx
@@ -12,12 +12,14 @@ import {
   Card,
   EmptyState,
   Field,
+  RecordPicker,
+  type RecordPickerCandidate,
   SectionHeader,
   Select,
   TextInput,
 } from "@margince/frontend/design-system";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useRef, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 
 // #/ext/notes — "Demo Notepad", the reference extension's one screen.
 //
@@ -372,6 +374,49 @@ const SUBJECT_TYPES: readonly SubjectType[] = [
 ];
 
 /**
+ * The candidates for one subject type, through the product's own search.
+ *
+ * `/search` rather than the per-type list endpoints, and the reason is not
+ * convenience: `/deals` takes no `q`. A picker built on the list endpoints
+ * would cover person, organization and lead and leave `deal` typing a UUID,
+ * which is the state this control exists to remove. The cross-object search
+ * takes all four, scoped by `types` so a query for "acme" while the form says
+ * Person cannot offer the Acme organization.
+ *
+ * The results are the CALLER's: `/search` is RBAC-scoped, so a seat that
+ * cannot see a record is not offered it — the picker shows what filing would
+ * actually be allowed to name, rather than teaching somebody which records
+ * exist.
+ *
+ * A hit with no title is dropped rather than rendered as an empty row: the
+ * contract types `title` as nullable, and a candidate a person cannot read is
+ * one they cannot choose on purpose.
+ */
+async function searchSubjects(
+  type: SubjectType,
+  q: string,
+): Promise<RecordPickerCandidate[]> {
+  const { data, error } = await api.GET("/search", {
+    params: { query: { q, types: [type], limit: SUBJECT_CANDIDATES } },
+  });
+  if (error) {
+    throwProblem(error);
+  }
+  return data.data.flatMap((hit) =>
+    hit.title ? [{ id: hit.id, name: hit.title }] : [],
+  );
+}
+
+/**
+ * How many candidates one search offers.
+ *
+ * Ten is what fits above the fold under the field without the card growing a
+ * scroll region of its own. A person who cannot see their record in ten
+ * results types more of the name, which is faster than reading fifty.
+ */
+const SUBJECT_CANDIDATES = 10;
+
+/**
  * File a note to a record: the unit's own row and a core activity, together.
  *
  * This is the one card on this screen that writes something the PRODUCT owns,
@@ -391,14 +436,27 @@ function FilingCard() {
   // the four the operation admits, and a widened state is how a fifth value
   // reaches a request the schema refuses.
   const [subjectType, setSubjectType] = useState<SubjectType>("person");
-  const [subjectID, setSubjectID] = useState("");
+  // The PICKED record, not a typed id: the request needs the id and the person
+  // needs the name, and holding the candidate keeps the two from disagreeing.
+  const [subject, setSubject] = useState<RecordPickerCandidate | null>(null);
   const [filed, setFiled] = useState(false);
+  // Bound to the type the form is on, and MEMOISED on it: RecordPicker's
+  // debounce effect depends on this function, so a fresh closure per render
+  // would restart the timer on every keystroke and never fire.
+  const searchSubjectsFor = useCallback(
+    (q: string) => searchSubjects(subjectType, q),
+    [subjectType],
+  );
 
   const file = useMutation({
     mutationFn: async () => {
       setFiled(false);
       const { error, response } = await api.POST("/ext/notes/file", {
-        body: { body, subject_type: subjectType, subject_id: subjectID },
+        body: {
+          body,
+          subject_type: subjectType,
+          subject_id: subject?.id ?? "",
+        },
       });
       if (error || !response.ok) {
         throwProblem(error);
@@ -409,7 +467,7 @@ function FilingCard() {
     // they typed.
     onSuccess: () => {
       setBody("");
-      setSubjectID("");
+      setSubject(null);
       setFiled(true);
     },
     // onSettled, and the same key the notepad reads under — the two spellings
@@ -457,6 +515,13 @@ function FilingCard() {
               const picked = SUBJECT_TYPES.find((type) => type === value);
               if (picked) {
                 setSubjectType(picked);
+                // The pick goes with the type it was made under. A contact
+                // chosen while the form said Person is not a deal, and leaving
+                // it selected would file the note against whatever record
+                // happens to share that id — or, more often, against nothing,
+                // with a refusal nobody can read.
+                setSubject(null);
+                setFiled(false);
               }
             }}
             options={SUBJECT_TYPES.map((type) => ({
@@ -466,25 +531,24 @@ function FilingCard() {
           />
         )}
       </Field>
-      <Field label={t("extNotes.filing.subjectIdLabel")}>
-        {(control) => (
-          <TextInput
-            {...control}
-            value={subjectID}
-            onChange={(event) => {
-              // Trimmed at the edge: the contract declares format: uuid, and a
-              // pasted id with a stray space is a request the server refuses
-              // for a reason the person cannot see.
-              setSubjectID(event.target.value.trim());
-              setFiled(false);
-            }}
-          />
-        )}
-      </Field>
+      {/*
+        The record itself, by name. It is not wrapped in a Field: RecordPicker
+        renders its own labelled search input, and a second label around it
+        would be two labels for one control — which is what a screen reader
+        would then read out.
+      */}
+      <RecordPicker
+        label={t("extNotes.filing.subjectSearchLabel")}
+        searchTargets={searchSubjectsFor}
+        selected={subject}
+        onPick={(candidate) => {
+          setSubject(candidate);
+          setFiled(false);
+        }}
+        disabled={file.isPending}
+      />
       <Button
-        disabled={
-          body.trim() === "" || subjectID.trim() === "" || file.isPending
-        }
+        disabled={body.trim() === "" || subject === null || file.isPending}
         onClick={() => file.mutate()}
       >
         {t("extNotes.filing.file")}

--- a/frontend/src/design-system/recordpicker.test.tsx
+++ b/frontend/src/design-system/recordpicker.test.tsx
@@ -203,4 +203,64 @@ describe("RecordPicker", () => {
     await waitFor(() => expect(screen.getByText("Otto Fischer")).toBeTruthy());
     expect(screen.queryByText("Anna Weber")).toBeNull();
   });
+
+  // A NEW searchTargets is a new search SPACE, and the candidates on screen
+  // answered the old one. Discarding the in-flight search is not enough: the
+  // rows already rendered stay clickable through the next debounce and its
+  // round trip, and a caller that changed the space — notes' filing control
+  // changes it with the record TYPE — would take a pick of the wrong kind.
+  it("drops the rendered candidates when the search space changes", async () => {
+    const people = vi
+      .fn()
+      .mockResolvedValue([{ id: "p-1", name: "Anna Weber" }]);
+    const companies = vi
+      .fn()
+      .mockResolvedValue([{ id: "o-1", name: "Weber GmbH" }]);
+    const { rerender } = rtlRender(
+      <RecordPicker label="Search…" searchTargets={people} onPick={vi.fn()} />,
+    );
+
+    await userEvent.type(screen.getByRole("searchbox"), "weber");
+    await waitFor(() => expect(screen.getByText("Anna Weber")).toBeTruthy());
+
+    rerender(
+      <RecordPicker
+        label="Search…"
+        searchTargets={companies}
+        onPick={vi.fn()}
+      />,
+    );
+
+    // Gone immediately — before the new search has answered, which is the
+    // window a person can click in.
+    expect(screen.queryByText("Anna Weber")).toBeNull();
+    expect(companies).not.toHaveBeenCalled();
+
+    // The TERM survives, so the new space is searched for the same words and
+    // the list refills without anybody retyping.
+    expect(screen.getByRole<HTMLInputElement>("searchbox").value).toBe("weber");
+    await waitFor(() => expect(screen.getByText("Weber GmbH")).toBeTruthy());
+  });
+
+  // A failed search that is then made in a new space must not leave its line
+  // behind: it described a question nobody is asking any more.
+  it("drops a failed search's message when the search space changes", async () => {
+    const failing = vi.fn().mockRejectedValue(new Error("search unavailable"));
+    const working = vi
+      .fn()
+      .mockResolvedValue([{ id: "o-1", name: "Weber GmbH" }]);
+    const { rerender } = rtlRender(
+      <RecordPicker label="Search…" searchTargets={failing} onPick={vi.fn()} />,
+    );
+
+    await userEvent.type(screen.getByRole("searchbox"), "weber");
+    await waitFor(() =>
+      expect(screen.getByText(/search unavailable/)).toBeTruthy(),
+    );
+
+    rerender(
+      <RecordPicker label="Search…" searchTargets={working} onPick={vi.fn()} />,
+    );
+    expect(screen.queryByText(/search unavailable/)).toBeNull();
+  });
 });

--- a/frontend/src/design-system/recordpicker.tsx
+++ b/frontend/src/design-system/recordpicker.tsx
@@ -2,14 +2,19 @@ import { Check } from "lucide-react";
 import { useEffect, useState } from "react";
 import { SearchField } from "./atoms";
 
-// The shared debounced search→candidate-list→pick pattern: this used to
-// live duplicated, near-identically, inline in MergeAction
-// (screens/merge.tsx) and AddRelationshipAction (screens/relationships.tsx)
-// — both wire a search transport, debounce 250ms, render candidates as
-// pickable buttons, and surface a search failure inline rather than
-// throwing it. Neither call site has been migrated onto this extraction
-// yet; offers.tsx (buyer-org and product pickers) is its only consumer
-// today.
+// The shared debounced search→candidate-list→pick pattern: this used to live
+// duplicated, near-identically, inline in MergeAction (screens/merge.tsx) and
+// AddRelationshipAction (screens/relationships.tsx) — both wire a search
+// transport, debounce 250ms, render candidates as pickable buttons, and
+// surface a search failure inline rather than throwing it. Neither of those
+// two has been migrated onto this extraction yet.
+//
+// It is now PUBLISHED to the extension tier (surface/design-system.ts), which
+// makes this comment something third parties read. Two things it does not do,
+// so nobody builds on a promise it does not keep: a stale answer is ignored
+// rather than aborted (the request still reaches the server), and the
+// candidate list is a list of buttons rather than a combobox — no
+// role=combobox, no aria-expanded, no arrow-key navigation.
 
 const SEARCH_DEBOUNCE_MS = 250;
 
@@ -37,6 +42,36 @@ export function RecordPicker({
   const [term, setTerm] = useState("");
   const [candidates, setCandidates] = useState<RecordPickerCandidate[]>([]);
   const [searchError, setSearchError] = useState<string | null>(null);
+
+  // A NEW search space empties the list, at once.
+  //
+  // The effect below cancels the update the previous searchTargets would have
+  // made, but cancelling a future answer does nothing about the answers
+  // already on screen: they stay rendered, and clickable, until the new search
+  // debounces and resolves. A caller that changes searchTargets has changed
+  // what it is asking about — notes' filing control does it when the record
+  // TYPE changes — so a candidate from the old space is not a wrong-looking
+  // answer, it is an answer to a question nobody asked any more, and picking
+  // one hands the caller a record of the wrong kind.
+  //
+  // Done in RENDER rather than in an effect, which is React's own shape for
+  // adjusting state when a prop changes: an effect would paint one frame with
+  // the stale rows still on screen, and one frame is a click.
+  //
+  // The TERM survives on purpose: the same words usually mean the same search
+  // in the new space, and the effect below re-runs on searchTargets anyway, so
+  // the list refills without the person retyping.
+  // Both halves take the FUNCTIONAL form because the value is a function:
+  // useState(fn) reads fn as a lazy initializer and calls it, and
+  // setState(fn) reads it as an updater — so the plain spellings store the
+  // RESULT of searching for nothing, which is a promise that never equals the
+  // prop, which is an infinite render.
+  const [searchSpace, setSearchSpace] = useState(() => searchTargets);
+  if (searchSpace !== searchTargets) {
+    setSearchSpace(() => searchTargets);
+    setCandidates([]);
+    setSearchError(null);
+  }
 
   useEffect(() => {
     const query = term.trim();

--- a/frontend/src/surface/design-system.ts
+++ b/frontend/src/surface/design-system.ts
@@ -23,6 +23,24 @@ export {
   SectionHeader,
   TextInput,
 } from "../design-system/atoms";
+// RecordPicker, because the alternative is every unit that touches a core
+// record asking a person to paste a UUID.
+//
+// Picking a record is the one interaction a unit cannot avoid the moment it
+// writes anything the product owns, and it is not a control anybody should
+// rebuild: debounce, in-flight cancellation, the failed-search line, the
+// selected state and the keyboard behaviour are five decisions each, and a
+// unit getting one of them wrong is a screen that looks like the product and
+// behaves like a prototype.
+//
+// It carries NO transport of its own — the caller supplies searchTargets — so
+// exporting it publishes a rendering promise and no data one. A unit reaches
+// its candidates through the api surface, under the caller's own RBAC, exactly
+// as a core screen does.
+export {
+  RecordPicker,
+  type RecordPickerCandidate,
+} from "../design-system/recordpicker";
 // Select and its option type, because a unit offering a CLOSED choice has no
 // other way to: check-native-controls refuses a bare <select> in
 // extensions/*/frontend exactly as it does in core, and a unit left with only

--- a/frontend/src/surface/design-system.ts
+++ b/frontend/src/surface/design-system.ts
@@ -28,10 +28,23 @@ export {
 //
 // Picking a record is the one interaction a unit cannot avoid the moment it
 // writes anything the product owns, and it is not a control anybody should
-// rebuild: debounce, in-flight cancellation, the failed-search line, the
-// selected state and the keyboard behaviour are five decisions each, and a
-// unit getting one of them wrong is a screen that looks like the product and
-// behaves like a prototype.
+// rebuild: the debounce, a late answer ignored rather than rendered, the
+// candidates dropped when the search space changes, and the selected state are
+// four decisions each, and a unit getting one of them wrong is a screen that
+// looks like the product and behaves like a prototype.
+//
+// WHAT IT DOES NOT DO, because the difference costs a caller nothing to know
+// and everything to assume:
+//
+//   - It ignores a stale answer; it does not ABORT the request. Rapid typing
+//     still reaches the server, so a searchTargets that is expensive to answer
+//     needs a bound of its own.
+//   - Its failed-search line is the component's own English, from the caught
+//     error. A unit that needs that line translated cannot supply it here yet
+//     — the honest workaround is a searchTargets that resolves empty and says
+//     so in the unit's own copy.
+//   - It is a labelled field over a list of buttons, not a combobox: no
+//     role=combobox, no aria-expanded, no arrow-key navigation.
 //
 // It carries NO transport of its own — the caller supplies searchTargets — so
 // exporting it publishes a rendering promise and no data one. A unit reaches

--- a/frontend/src/surface/surface.test.ts
+++ b/frontend/src/surface/surface.test.ts
@@ -37,6 +37,7 @@ describe("the published frontend surface", () => {
       "Card",
       "EmptyState",
       "Field",
+      "RecordPicker",
       "SectionHeader",
       "Select",
       "TextInput",


### PR DESCRIPTION
Follow-up to #1142. The filing control on `#/ext/notes` asked for a **Record id** and took a raw UUID in a text input — the one place the reference extension was worse than the product it exists to demonstrate. Nobody has a record id; they have a name.

## What it uses

`RecordPicker` already solved this: the debounced search → candidate list → pick control `offers.tsx` uses twice (buyer org, product), carrying **no transport of its own** — the caller passes `searchTargets`.

What stopped a unit using it was the published surface, which named Badge, Button, Card, EmptyState, Field, SectionHeader, TextInput and Select and nothing else. So this **widens the published frontend surface**, which that file's own doc calls a reviewed act: *"Adding a name here says the core will keep rendering it for units it did not write."*

The promise is worth making. Picking a record is the first thing any unit that writes a core record needs, and the alternative is every unit hand-rolling a combobox against a design system that already refuses a bare `<select>`. What is published is a **rendering** promise and no data one — a unit still reaches its candidates through the api surface, under the caller's own RBAC, exactly as a core screen does.

## Why `/search` and not the list endpoints

`GET /search?q=…&types=<type>` is cross-object, RBAC-scoped, and returns `{type, id, title}`.

The obvious alternative — one list endpoint per subject type — does not work, and the reason is worth recording rather than rediscovering: **`/deals` takes no `q`.** `/people`, `/organizations` and `/leads` do. A picker built on the list endpoints would have covered three of the four record types the filing accepts and left `deal` typing a UUID, which is the state this change removes.

Being RBAC-scoped matters twice: a seat is offered only what filing would actually be allowed to name, and the picker never becomes a way to learn which records exist.

## The two behaviours worth knowing

- **The search is scoped to the record type the form is on.** Unscoped, a query for "acme" while the form says Person would offer the Acme organization, and filing it would name a person id that is an organization's.
- **Changing the type clears the pick.** A contact chosen while the form said Person is not a deal; a stale pick would file against whatever record holds that id — or, far more often, against nothing, with a refusal nobody can read.

A hit whose `title` is null is dropped rather than rendered as an empty row: the contract types it nullable, and a candidate nobody can read is one nobody can choose on purpose.

## Tests

Three new cases in the unit's own suite, both new guards **mutation-verified**:

- the filing sends the id the picker resolved, and nobody types one (mutating the scoping breaks it);
- the search carries `types=<selected type>`;
- changing the type disables filing again, because the record it would have named is gone;
- a titleless hit offers no candidate — asserted against the `/search` call having happened, since "no row appeared" is also what a search that never ran looks like.

## Not in scope, deliberately

- No endpoint, no contract change, no core screen change.
- No prompt, AI task or corpus is touched, so **no aicert re-run is owed**.
- The MCP tool surface is unchanged: `file_note` still takes `subject_type` + `subject_id`, so an agent calling it is unaffected. This is the human screen only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Let users file notes by picking a record by name instead of pasting a UUID. Replaces the “Record id” input with a searchable `RecordPicker`; changing the record type clears the selected record and any visible candidates to avoid filing against the wrong record.

- Uses `/search` with `types=[subjectType]` and `limit=10`; drops hits with null `title`. Submit enables only with a note body and a picked record; request sends `subject_type` and `subject_id` from the pick.
- Fix: `RecordPicker` now empties its candidate list immediately when `searchTargets` changes; stale answers are ignored (requests are not aborted). The design-system suite pins clearing candidates and removing a failed-search message on search-space change.
- Publishes `RecordPicker` and `RecordPickerCandidate` from `frontend/src/surface/design-system.ts`; surface test updated. No API or contract changes.
- UI copy: new `extNotes.filing.subjectSearchLabel` in `en`, `de`, and `vi`.
- Tests cover id-from-pick, `types` scoping, clearing on type and search-space change, null-title filtering, and mutation variables; `/search` checks `response.ok`.

<sup>Written for commit 7e5030280011f3fcc3012fc381750a14be237707. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1163?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

