### PR TITLE
refactor(consent): the module drops the tenant column (ADR-0091 §8 phase D)

### DIFF
--- a/backend/internal/compose/datareset.go
+++ b/backend/internal/compose/datareset.go
@@ -34,6 +34,11 @@ import (
 	"github.com/gradionhq/margince/backend/internal/shared/runtimeenv"
 )
 
+// objectWorkspace names the installation's own row. It is one string doing the
+// two jobs this repo keeps aligned on purpose: the table, and the audit/RBAC
+// object that operations on the installation itself are recorded against.
+const objectWorkspace = "workspace"
+
 // errResetConfirmationMismatch means the caller's typed confirmation did not
 // match the workspace's organization name — the reset is refused before any
 // data is touched.
@@ -234,14 +239,12 @@ func (h dataResetHandlers) sweepAndReseed(ctx context.Context, wsID ids.UUID, co
 		if err := sweepWorkspaceData(ctx, tx, tables); err != nil {
 			return err
 		}
-		// The provider platform, swept explicitly: its five tables have no
-		// workspace_id, so the catalog-derived list above does not include
-		// them, and a reset that skipped this would leave purchased personal
-		// data about people it had just deleted.
-		if err := sweepProviderTables(ctx, tx); err != nil {
-			return err
-		}
-		counts.TablesCleared = len(tables) + len(providerResetTables)
+		// The provider platform needs no pass of its own any more. It used to:
+		// its five tables carry no workspace_id, so the sweep's old
+		// column-derived list could not see them, and a reset left purchased
+		// personal data about people it had just deleted. The list is derived
+		// by exclusion now, so they are ordinary targets.
+		counts.TablesCleared = len(tables)
 
 		// A first-boot installation is native, and everything overlay mode
 		// depends on was just swept: the incumbent connection, the mirror, the
@@ -306,7 +309,7 @@ func (h dataResetHandlers) sweepAndReseed(ctx context.Context, wsID ids.UUID, co
 		}
 
 		// Record the reset under the invoking admin principal.
-		_, err = storekit.AuditWithEvidence(ctx, tx, "reset_data", "workspace", wsID, nil, nil,
+		_, err = storekit.AuditWithEvidence(ctx, tx, "reset_data", objectWorkspace, wsID, nil, nil,
 			resetEvidence(*counts))
 		return err
 	})

--- a/backend/internal/compose/datareset_integration_test.go
+++ b/backend/internal/compose/datareset_integration_test.go
@@ -65,24 +65,25 @@ func TestSweepWorkspaceDataClearsDomainKeepsIdentity(t *testing.T) {
 	}
 }
 
-// TestPreserveSetIntegrity is the fitness rail for the mass delete: every
-// preserved table must still exist as a real workspace_id base table (a rename
-// or drop that left preservedResetTables stale would silently sweep it), and no
-// preserved table may appear in the sweep target set. Derived from
-// information_schema — independent of resetTargetTables' pg_catalog query — so
-// it genuinely fails on schema drift.
+// TestPreserveSetIntegrity is the fitness rail for the mass delete, and it
+// carries more weight than it used to. The sweep no longer derives its targets
+// from the presence of a workspace_id column — it deletes everything the
+// preserve set does not name — so a stale entry there is not a table that keeps
+// an extra column, it is a table that gets emptied.
+//
+// Both halves matter: every preserved name must still be a real base table (a
+// rename or drop leaves the list pointing at nothing while the table it meant
+// to protect is swept), and no preserved table may appear among the targets.
+// Derived from information_schema, independent of resetTargetTables' own
+// pg_catalog query, so it genuinely fails on drift rather than agreeing with
+// the code under test.
 func TestPreserveSetIntegrity(t *testing.T) {
 	e := integration.Setup(t)
 	ctx := e.Admin()
 	if err := database.WithWorkspaceTx(ctx, e.Pool, func(tx pgx.Tx) error {
 		rows, err := tx.Query(ctx, `
-			SELECT c.table_name
-			FROM information_schema.columns c
-			JOIN information_schema.tables t
-			  ON t.table_schema = c.table_schema AND t.table_name = c.table_name
-			WHERE c.table_schema = 'public'
-			  AND c.column_name = 'workspace_id'
-			  AND t.table_type = 'BASE TABLE'`)
+			SELECT table_name FROM information_schema.tables
+			WHERE table_schema = 'public' AND table_type = 'BASE TABLE'`)
 		if err != nil {
 			return err
 		}
@@ -101,7 +102,7 @@ func TestPreserveSetIntegrity(t *testing.T) {
 		}
 		for name := range preservedResetTables {
 			if !existing[name] {
-				t.Errorf("preserved table %q is not a current workspace_id base table (renamed/dropped?) — it would be swept", name)
+				t.Errorf("preserved table %q is not a current base table (renamed/dropped?) — the list protects nothing and the table it named is swept", name)
 			}
 		}
 		targets, err := resetTargetTables(ctx, tx)
@@ -109,8 +110,8 @@ func TestPreserveSetIntegrity(t *testing.T) {
 			return err
 		}
 		for _, tgt := range targets {
-			if preservedResetTables[tgt] {
-				t.Errorf("preserved table %q appears in the sweep target set", tgt)
+			if preservedResetTables[tgt.name] {
+				t.Errorf("preserved table %q appears in the sweep target set", tgt.name)
 			}
 		}
 		return nil
@@ -297,8 +298,8 @@ func TestSweepTargetsCarryNoDeleteBlockingTrigger(t *testing.T) {
 			return err
 		}
 		targetSet := make(map[string]bool, len(targets))
-		for _, name := range targets {
-			targetSet[name] = true
+		for _, target := range targets {
+			targetSet[target.name] = true
 		}
 		// tgtype bit 0x08 marks a trigger that fires on DELETE; tgisinternal
 		// excludes FK-enforcement triggers so only real guards remain.

--- a/backend/internal/compose/datasweep.go
+++ b/backend/internal/compose/datasweep.go
@@ -21,32 +21,40 @@ import (
 	"github.com/gradionhq/margince/backend/internal/platform/database"
 )
 
-// preservedResetTables are the workspace_id tables a reset must NOT delete:
-// the identity/auth layer (so every user, including the admin, stays logged in
-// and the org survives) and the append-only ledgers (their immutability trigger
-// forbids DELETE, and operational history should outlive a data reset). Every
-// other workspace_id table is domain/config data and is swept, then re-seeded.
+// preservedResetTables are the tables a reset must NOT delete. Everything else
+// in the public schema is domain/config data: swept, then re-seeded.
+//
+// This list is the whole definition, and it did not used to be. The sweep
+// derived its targets from the presence of a workspace_id column, which was a
+// proxy for "holds this tenant's data" — a proxy ADR-0091 §8 phase D is
+// removing table by table. Under it, a module that dropped the column silently
+// stopped being reset: consent_purpose was the first, and the reset then failed
+// re-seeding purposes it had not deleted. So the derivation is inverted. What a
+// reset must keep is a decision someone has to make; what it deletes follows.
+//
+// Four kinds are kept:
+//
+//   - identity and auth, so every user (the admin above all) stays logged in
+//     and the installation survives its own reset;
+//   - the append-only ledgers, whose immutability trigger forbids DELETE and
+//     whose operational history should outlive a data reset;
+//   - installation configuration and secrets, which are not this workspace's
+//     records — a reset that cleared them would leave an installation unable
+//     to reach the providers and mailboxes it is still configured for;
+//   - the job runtime, which is River's to manage and not ours to truncate
+//     underneath a running worker.
 var preservedResetTables = map[string]bool{
-	"app_user": true, "role": true, "role_assignment": true,
+	// identity and auth
+	objectWorkspace: true, "app_user": true, "role": true, "role_assignment": true,
 	"team": true, "team_membership": true,
 	"session": true, "passport": true, "auth_token": true,
+	// append-only ledgers
 	"audit_log": true, "system_log": true,
-}
-
-// providerResetTables are the licensed-data-provider tables, deleted in
-// FK-safe order (children first, the same order migration 0219's down takes).
-//
-// They need naming because the catalog sweep below cannot see them: every one
-// deliberately carries NO workspace_id column — the platform is
-// installation-scoped configuration (ADR-0061/A107), so a reset that only
-// swept workspace_id tables left provider_run and person_provider_claim
-// holding purchased personal data about the very people it had just deleted.
-var providerResetTables = []string{
-	"person_provider_claim",
-	"provider_run_reservation",
-	"provider_run",
-	"provider_connection_budget",
-	"provider_connection",
+	// installation configuration and secrets
+	"setting": true, "vault_secret": true, "ai_call_config": true,
+	"embed_store_binding": true,
+	// in-flight delivery: drained by the outbox pass, not deleted under it
+	"event_outbox": true,
 }
 
 // providerCredentialRefs collects the sealed API keys the provider
@@ -75,48 +83,60 @@ func providerCredentialRefs(ctx context.Context, tx pgx.Tx) ([]string, error) {
 	return refs, nil
 }
 
-// sweepProviderTables clears the provider platform. Ordinary DELETEs rather
-// than the catalog sweep's per-workspace predicate, because these tables have
-// no workspace to predicate on: one installation, one provider platform.
-func sweepProviderTables(ctx context.Context, tx pgx.Tx) error {
-	for _, table := range providerResetTables {
-		if _, err := tx.Exec(ctx, `DELETE FROM `+pgx.Identifier{table}.Sanitize()); err != nil {
-			return fmt.Errorf("data reset: clearing %s: %w", table, err)
-		}
-	}
-	return nil
-}
-
-// resetTargetTables lists every public base table carrying a workspace_id
-// column that is not preserved — derived from the catalog so a newly added
-// tenant table is swept automatically rather than escaping a hand-kept list.
-func resetTargetTables(ctx context.Context, tx pgx.Tx) ([]string, error) {
+// resetTargetTables lists every public base table a reset sweeps: all of them,
+// less the preserved set above, the migration ledgers, and River's own schema.
+// Derived from the catalog so a newly added table is swept automatically rather
+// than escaping a hand-kept list — the burden of naming falls on what must be
+// KEPT, where forgetting an entry fails loudly (the admin loses their session,
+// the installation loses its config) instead of quietly leaving a tenant's rows
+// behind after a reset that reported success.
+func resetTargetTables(ctx context.Context, tx pgx.Tx) ([]resetTarget, error) {
 	rows, err := tx.Query(ctx, `
-		SELECT c.relname
+		SELECT c.relname,
+		       EXISTS (SELECT 1 FROM pg_attribute a
+		                WHERE a.attrelid = c.oid AND a.attname = 'workspace_id'
+		                  AND a.attnum > 0 AND NOT a.attisdropped) AS tenant_scoped
 		FROM pg_class c
 		JOIN pg_namespace n ON n.oid = c.relnamespace
-		JOIN pg_attribute a ON a.attrelid = c.oid
 		WHERE n.nspname = 'public'
 		  AND c.relkind = 'r'
-		  AND c.relname NOT LIKE 'schema_migrations_%'
-		  AND a.attname = 'workspace_id'
-		  AND a.attnum > 0 AND NOT a.attisdropped
+		  AND c.relname NOT LIKE 'schema_migrations%'
+		  AND c.relname NOT LIKE 'river_%'
 		ORDER BY c.relname`)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var out []string
+	var out []resetTarget
 	for rows.Next() {
-		var name string
-		if err := rows.Scan(&name); err != nil {
+		var t resetTarget
+		if err := rows.Scan(&t.name, &t.tenantScoped); err != nil {
 			return nil, err
 		}
-		if !preservedResetTables[name] {
-			out = append(out, name)
+		if !preservedResetTables[t.name] {
+			out = append(out, t)
 		}
 	}
 	return out, rows.Err()
+}
+
+// resetTarget is one table to sweep and whether it still carries the tenant
+// column. A table that has one keeps its predicate: phase D is mid-flight, and
+// the two spellings agree on every row an installation with one live workspace
+// holds (ADR-0061 §3), so the narrower one costs nothing and keeps a reset from
+// widening ahead of the schema. The predicate goes when the last column does.
+type resetTarget struct {
+	name         string
+	tenantScoped bool
+}
+
+// deleteStatement is the sweep's DELETE for one target.
+func (t resetTarget) deleteStatement() string {
+	stmt := `DELETE FROM ` + pgx.Identifier{t.name}.Sanitize()
+	if t.tenantScoped {
+		stmt += ` WHERE workspace_id = current_setting('app.workspace_id')::uuid`
+	}
+	return stmt
 }
 
 // sweepWorkspaceData deletes every row of the target tables for the bound
@@ -125,18 +145,16 @@ func resetTargetTables(ctx context.Context, tx pgx.Tx) ([]string, error) {
 // still-populated table behind a savepoint and defers the ones a child FK still
 // blocks to the next pass, until all are clear. A pass with no progress means an
 // unbreakable FK cycle — surfaced explicitly, never silently skipped.
-func sweepWorkspaceData(ctx context.Context, tx pgx.Tx, tables []string) error {
-	remaining := append([]string(nil), tables...)
+func sweepWorkspaceData(ctx context.Context, tx pgx.Tx, tables []resetTarget) error {
+	remaining := append([]resetTarget(nil), tables...)
 	for len(remaining) > 0 {
-		var stuck []string
+		var stuck []resetTarget
 		progressed := false
 		for _, t := range remaining {
 			if _, err := tx.Exec(ctx, "SAVEPOINT reset_sp"); err != nil {
 				return err
 			}
-			_, delErr := tx.Exec(ctx,
-				`DELETE FROM `+pgx.Identifier{t}.Sanitize()+
-					` WHERE workspace_id = current_setting('app.workspace_id')::uuid`)
+			_, delErr := tx.Exec(ctx, t.deleteStatement())
 			if delErr == nil {
 				if _, err := tx.Exec(ctx, "RELEASE SAVEPOINT reset_sp"); err != nil {
 					return err

--- a/backend/internal/compose/export.go
+++ b/backend/internal/compose/export.go
@@ -234,7 +234,7 @@ func auditExport(ctx context.Context, pool *pgxpool.Pool, incumbent string, summ
 		return errors.New("compose: no workspace bound to export context")
 	}
 	return database.WithWorkspaceTx(ctx, pool, func(tx pgx.Tx) error {
-		_, err := storekit.Audit(ctx, tx, "export", "workspace", wsID, nil, map[string]any{
+		_, err := storekit.Audit(ctx, tx, "export", objectWorkspace, wsID, nil, map[string]any{
 			auditFieldFormat: exportFormat, "row_counts": summary.RowCounts, "omitted": summary.Omitted,
 			"canonical_data_resides_in": incumbent,
 		})

--- a/backend/internal/compose/integration/concurrency_integration_test.go
+++ b/backend/internal/compose/integration/concurrency_integration_test.go
@@ -142,9 +142,9 @@ func TestMergeWithdrawalCarriesAConsentProofEvent(t *testing.T) {
 	srcID, tgtID := PersonIDOf(ids.UUID(src.Id)), PersonIDOf(ids.UUID(tgt.Id))
 
 	purpose := ids.NewV7()
-	e.WsExec(t, `INSERT INTO consent_purpose (id, workspace_id, key, label) VALUES ($1, $2, 'marketing_email', 'Marketing')`, purpose, e.WS)
-	e.WsExec(t, `INSERT INTO person_consent (id, workspace_id, person_id, purpose_id, state) VALUES ($1, $2, $3, $4, 'withdrawn')`, ids.NewV7(), e.WS, srcID, purpose)
-	e.WsExec(t, `INSERT INTO person_consent (id, workspace_id, person_id, purpose_id, state) VALUES ($1, $2, $3, $4, 'granted')`, ids.NewV7(), e.WS, tgtID, purpose)
+	e.WsExec(t, `INSERT INTO consent_purpose (id, key, label) VALUES ($1, 'marketing_email', 'Marketing')`, purpose)
+	e.WsExec(t, `INSERT INTO person_consent (id, person_id, purpose_id, state) VALUES ($1, $2, $3, 'withdrawn')`, ids.NewV7(), srcID, purpose)
+	e.WsExec(t, `INSERT INTO person_consent (id, person_id, purpose_id, state) VALUES ($1, $2, $3, 'granted')`, ids.NewV7(), tgtID, purpose)
 
 	if _, err := e.People.MergePerson(admin, srcID, tgtID); err != nil {
 		t.Fatalf("merge: %v", err)

--- a/backend/internal/compose/integration/erasure_integration_test.go
+++ b/backend/internal/compose/integration/erasure_integration_test.go
@@ -71,8 +71,8 @@ func seedSubject(t *testing.T, e *Env) ids.UUID {
 			return err
 		}
 		if _, err := tx.Exec(ctx,
-			`INSERT INTO preference_token (workspace_id, person_id, token, expires_at)
-			 VALUES (`+wsClause+`, $1, $2, now() + interval '30 days')`,
+			`INSERT INTO preference_token (person_id, token, expires_at)
+			 VALUES ($1, $2, now() + interval '30 days')`,
 			personID, seededPreferenceToken(personID)); err != nil {
 			return err
 		}

--- a/backend/internal/compose/integration/merge_integration_test.go
+++ b/backend/internal/compose/integration/merge_integration_test.go
@@ -103,9 +103,9 @@ func TestMergePerson_consentMergesRestrictively(t *testing.T) {
 	// may do: A's withdrawal propagates to B, so the survivor ends up
 	// withdrawn — never the other way round.
 	purpose := ids.NewV7()
-	e.WsExec(t, `INSERT INTO consent_purpose (id, workspace_id, key, label) VALUES ($1, $2, 'marketing', 'Marketing')`, purpose, e.WS)
-	e.WsExec(t, `INSERT INTO person_consent (workspace_id, person_id, purpose_id, state) VALUES ($1, $2, $3, 'withdrawn')`, e.WS, source, purpose)
-	e.WsExec(t, `INSERT INTO person_consent (workspace_id, person_id, purpose_id, state) VALUES ($1, $2, $3, 'granted')`, e.WS, target, purpose)
+	e.WsExec(t, `INSERT INTO consent_purpose (id, key, label) VALUES ($1, 'marketing', 'Marketing')`, purpose)
+	e.WsExec(t, `INSERT INTO person_consent (person_id, purpose_id, state) VALUES ($1, $2, 'withdrawn')`, source, purpose)
+	e.WsExec(t, `INSERT INTO person_consent (person_id, purpose_id, state) VALUES ($1, $2, 'granted')`, target, purpose)
 
 	if _, err := e.People.MergePerson(admin, PersonIDOf(source), PersonIDOf(target)); err != nil {
 		t.Fatalf("merge: %v", err)

--- a/backend/internal/compose/integration/org360/org360_integration_test.go
+++ b/backend/internal/compose/integration/org360/org360_integration_test.go
@@ -152,10 +152,9 @@ func TestOrganization360ContactsCarryStrengthRolesAndConsent(t *testing.T) {
 		integration.LinkActivity(t, owner, e.WS, activity, "person", contact)
 	}
 
-	purpose := integration.SeedRow(t, owner, `INSERT INTO consent_purpose (id, workspace_id, key, label)
-		VALUES ($1, $2, 'marketing_email', 'Marketing email')`, e.WS)
-	e.WsExec(t, `INSERT INTO person_consent (workspace_id, person_id, purpose_id, state)
-		VALUES ($1, $2, $3, 'granted')`, e.WS, contact, purpose)
+	purpose := seedConsentPurpose(t, owner, "marketing_email", "Marketing email")
+	e.WsExec(t, `INSERT INTO person_consent (person_id, purpose_id, state)
+		VALUES ($1, $2, 'granted')`, contact, purpose)
 
 	view, err := svc.Assemble(admin, ids.From[ids.OrganizationKind](org))
 	if err != nil {
@@ -207,8 +206,7 @@ func TestOrganization360ConsentReportsEveryPurposeEvenWithoutARow(t *testing.T) 
 	contact := e.SeedPerson(t, "Silent Contact", &e.Rep1)
 	e.WsExec(t, `INSERT INTO relationship (workspace_id, kind, person_id, organization_id, source, captured_by)
 		VALUES ($1, 'employment', $2, $3, 'manual', 'human:x')`, e.WS, contact, org)
-	integration.SeedRow(t, owner, `INSERT INTO consent_purpose (id, workspace_id, key, label)
-		VALUES ($1, $2, 'product_updates', 'Product updates')`, e.WS)
+	seedConsentPurpose(t, owner, "product_updates", "Product updates")
 
 	view, err := svc.Assemble(e.Admin(), ids.From[ids.OrganizationKind](org))
 	if err != nil {
@@ -630,6 +628,19 @@ var org360NoActivityPerms = principal.Permissions{
 // pgx will not decode into time.Time. Every 360 request 500'd the moment any
 // deal on the account carried a close date — invisible to a test that hands
 // the fold rows it built itself, and immediately visible on real data.
+// seedConsentPurpose plants one purpose and returns its id. SeedRow cannot
+// serve here: it supplies a workspace for $2, and consent_purpose has no tenant
+// column to put it in.
+func seedConsentPurpose(t *testing.T, owner *pgx.Conn, key, label string) ids.UUID {
+	t.Helper()
+	id := ids.NewV7()
+	if _, err := owner.Exec(context.Background(),
+		`INSERT INTO consent_purpose (id, key, label) VALUES ($1, $2, $3)`, id, key, label); err != nil {
+		t.Fatalf("seeding the %s consent purpose: %v", key, err)
+	}
+	return id
+}
+
 func TestOrg360_StateStripPricesOpenDealsAndNamesTheirCloseDate(t *testing.T) {
 	e := integration.Setup(t)
 	pipeline, stage, _ := integration.DealFixture(t, e)

--- a/backend/internal/compose/integration/preference_token_integration_test.go
+++ b/backend/internal/compose/integration/preference_token_integration_test.go
@@ -36,15 +36,14 @@ func seedRecipient(t *testing.T, e *Env, name, email string, owner *ids.UUID) {
 	}
 }
 
-// livePreferenceTokens counts the workspace's minted tokens. preference_token
-// is deliberately outside RLS (it IS the token→tenant resolver), so the app
-// pool reads it directly here — the assertion is that the refused mint wrote
-// NOTHING, which a scoped read could not distinguish from a hidden row.
+// livePreferenceTokens counts the minted tokens. The assertion resting on it
+// is that a refused mint wrote NOTHING, so it counts rows rather than the ones
+// some scope admits.
 func livePreferenceTokens(t *testing.T, e *Env) int {
 	t.Helper()
 	var n int
 	if err := e.Pool.QueryRow(context.Background(),
-		`SELECT count(*) FROM preference_token WHERE workspace_id = $1`, e.WS).Scan(&n); err != nil {
+		`SELECT count(*) FROM preference_token`).Scan(&n); err != nil {
 		t.Fatalf("counting preference tokens: %v", err)
 	}
 	return n

--- a/backend/internal/compose/integration/signals_integration_test.go
+++ b/backend/internal/compose/integration/signals_integration_test.go
@@ -122,13 +122,13 @@ func (e *SearchEnv) grantConsent(t *testing.T, personID ids.UUID) {
 	t.Helper()
 	purposeID := ids.NewV7()
 	if _, err := e.Owner.Exec(context.Background(),
-		`INSERT INTO consent_purpose (id, workspace_id, key, label) VALUES ($1, $2, 'outreach', 'Outreach')`,
-		purposeID, e.WS); err != nil {
+		`INSERT INTO consent_purpose (id, key, label) VALUES ($1, 'outreach', 'Outreach')`,
+		purposeID); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := e.Owner.Exec(context.Background(),
-		`INSERT INTO person_consent (id, workspace_id, person_id, purpose_id, state, source)
-		 VALUES ($1, $2, $3, $4, 'granted', 'manual')`, ids.NewV7(), e.WS, personID, purposeID); err != nil {
+		`INSERT INTO person_consent (id, person_id, purpose_id, state, source)
+		 VALUES ($1, $2, $3, 'granted', 'manual')`, ids.NewV7(), personID, purposeID); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/backend/internal/compose/publicpreferences.go
+++ b/backend/internal/compose/publicpreferences.go
@@ -64,16 +64,20 @@ func publicPreferences(store *consent.Store, limits publicPreferenceLimiters) fu
 				return
 			}
 
-			ref, err := store.ResolvePreferenceToken(r.Context(), token)
-			if err != nil {
-				// Unknown and revoked tokens read identically as absent — the
-				// surface never becomes a consent-state oracle.
+			// Resolved for its refusal, not its answer: the handlers resolve
+			// the token again for the person it names, while this gate exists
+			// to turn an unknown, revoked or expired token away before any of
+			// them run. Unknown and revoked read identically as absent — the
+			// surface never becomes a consent-state oracle.
+			if _, err := store.ResolvePreferenceToken(r.Context(), token); err != nil {
 				httperr.Write(w, r, err)
 				return
 			}
 
-			ctx := principal.WithWorkspaceID(r.Context(), ref.WorkspaceID.UUID)
-			ctx = principal.WithActor(ctx, principal.Principal{
+			// The workspace is already bound: the identity middleware binds
+			// the installation's into every request context, public paths
+			// included, before this runs.
+			ctx := principal.WithActor(r.Context(), principal.Principal{
 				Type: principal.PrincipalSystem,
 				ID:   "system:public_preferences",
 			})

--- a/backend/internal/modules/consent/channelconsent_integration_test.go
+++ b/backend/internal/modules/consent/channelconsent_integration_test.go
@@ -85,9 +85,9 @@ func setupChannelConsent(t *testing.T) *channelConsentEnv {
 		t.Fatal(err)
 	}
 	if _, err := owner.Exec(ctx, `
-		INSERT INTO consent_purpose (id, workspace_id, key, label, requires_double_opt_in)
-		VALUES ($1, $3, 'newsletter', 'Newsletter', false), ($2, $3, 'doi_newsletter', 'DOI Newsletter', true)`,
-		e.newsletter, e.doiNews, e.ws); err != nil {
+		INSERT INTO consent_purpose (id, key, label, requires_double_opt_in)
+		VALUES ($1, 'newsletter', 'Newsletter', false), ($2, 'doi_newsletter', 'DOI Newsletter', true)`,
+		e.newsletter, e.doiNews); err != nil {
 		t.Fatal(err)
 	}
 	// A Telegram-only subject: no person_email row at all, which is exactly the

--- a/backend/internal/modules/consent/doi.go
+++ b/backend/internal/modules/consent/doi.go
@@ -92,8 +92,8 @@ func (s *Store) IssueDoubleOptIn(ctx context.Context, personID ids.PersonID, pur
 		// entity, so the row id stays untyped.
 		var tokenRowID ids.UUID
 		if err := tx.QueryRow(ctx, `
-			INSERT INTO consent_doi_token (workspace_id, person_id, purpose_id, token_hash, issued_at, expires_at)
-			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, $2, $3, $4, $5)
+			INSERT INTO consent_doi_token (person_id, purpose_id, token_hash, issued_at, expires_at)
+			VALUES ($1, $2, $3, $4, $5)
 			RETURNING id`,
 			personID, purposeID, hashDOIToken(token), issued, issued.Add(doiTokenTTL)).Scan(&tokenRowID); err != nil {
 			return err

--- a/backend/internal/modules/consent/dsr.go
+++ b/backend/internal/modules/consent/dsr.go
@@ -198,8 +198,8 @@ func (s *Store) CreateDSR(ctx context.Context, in CreateDSRInput) (dsrRow, error
 	var out dsrRow
 	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		row := tx.QueryRow(ctx, `
-			INSERT INTO data_subject_request (workspace_id, kind, subject_ref, assignee_id, due_at)
-			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, $2, $3, $4)
+			INSERT INTO data_subject_request (kind, subject_ref, assignee_id, due_at)
+			VALUES ($1, $2, $3, $4)
 			RETURNING `+dsrColumns,
 			in.Kind, strings.TrimSpace(in.SubjectRef), in.AssigneeID, in.DueAt)
 		var err error

--- a/backend/internal/modules/consent/leadconsent_integration_test.go
+++ b/backend/internal/modules/consent/leadconsent_integration_test.go
@@ -81,9 +81,9 @@ func setupLeadConsent(t *testing.T) *leadConsentEnv {
 		t.Fatal(err)
 	}
 	if _, err := owner.Exec(ctx, `
-		INSERT INTO consent_purpose (id, workspace_id, key, label, requires_double_opt_in)
-		VALUES ($1, $3, 'newsletter', 'Newsletter', false), ($2, $3, 'doi_newsletter', 'DOI Newsletter', true)`,
-		e.newsletter, e.doiNews, e.ws); err != nil {
+		INSERT INTO consent_purpose (id, key, label, requires_double_opt_in)
+		VALUES ($1, 'newsletter', 'Newsletter', false), ($2, 'doi_newsletter', 'DOI Newsletter', true)`,
+		e.newsletter, e.doiNews); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := owner.Exec(ctx,

--- a/backend/internal/modules/consent/preference.go
+++ b/backend/internal/modules/consent/preference.go
@@ -44,10 +44,9 @@ func LockedPurpose(key string) bool {
 	return strings.TrimSpace(strings.ToLower(key)) == PurposeTransactional
 }
 
-// PreferenceRef is a token's resolution: which workspace, whose consent.
+// PreferenceRef is a token's resolution: whose consent.
 type PreferenceRef struct {
-	WorkspaceID ids.WorkspaceID
-	PersonID    ids.PersonID
+	PersonID ids.PersonID
 }
 
 // PurposeChoice is one row of the preference center: the purpose, the
@@ -79,18 +78,22 @@ const preferenceTokenTTLDays = 30
 // one TTL.
 const preferenceTokenMaxAgeDays = 180
 
-// ResolvePreferenceToken answers the token→tenant lookup the public
-// middleware binds the workspace from. preference_token is deliberately
-// outside RLS (it IS the resolver — 0048); an unknown, revoked or expired
-// token reads as absent, all three identically, so the surface never becomes
-// an oracle for which of the three it was.
+// ResolvePreferenceToken answers which recipient a public preference link
+// speaks for. An unknown, revoked or expired token reads as absent, all three
+// identically, so the surface never becomes an oracle for which of the three
+// it was.
+//
+// The token used to answer WHICH TENANT as well — preference_token sat outside
+// row-level security (0048) precisely because it was the resolver for a
+// surface that has no session. There is one installation now, and the identity
+// middleware binds it into every request context before this runs.
 func (s *Store) ResolvePreferenceToken(ctx context.Context, token string) (PreferenceRef, error) {
 	var ref PreferenceRef
 	err := database.WithInfraTx(ctx, s.db.Pool(), func(tx pgx.Tx) error {
 		err := tx.QueryRow(ctx, `
-			SELECT workspace_id, person_id FROM preference_token
+			SELECT person_id FROM preference_token
 			 WHERE token = $1 AND revoked_at IS NULL AND expires_at > now()`,
-			token).Scan(&ref.WorkspaceID, &ref.PersonID)
+			token).Scan(&ref.PersonID)
 		if errors.Is(err, pgx.ErrNoRows) {
 			return apperrors.ErrNotFound
 		}
@@ -178,8 +181,7 @@ func ensurePreferenceTokenTx(ctx context.Context, tx pgx.Tx, personID ids.Person
 	err := tx.QueryRow(ctx, `
 		UPDATE preference_token
 		   SET expires_at = now() + make_interval(days => $2)
-		 WHERE workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid
-		   AND person_id = $1 AND revoked_at IS NULL
+		 WHERE person_id = $1 AND revoked_at IS NULL
 		   AND expires_at > now()
 		   AND created_at > now() - make_interval(days => $3)
 		RETURNING token`, personID, preferenceTokenTTLDays, preferenceTokenMaxAgeDays).Scan(&token)
@@ -197,8 +199,7 @@ func ensurePreferenceTokenTx(ctx context.Context, tx pgx.Tx, personID ids.Person
 	// declared for in 0048 and never had.
 	if _, err := tx.Exec(ctx, `
 		UPDATE preference_token SET revoked_at = now()
-		 WHERE workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid
-		   AND person_id = $1 AND revoked_at IS NULL`, personID); err != nil {
+		 WHERE person_id = $1 AND revoked_at IS NULL`, personID); err != nil {
 		return "", err
 	}
 	fresh, err := newPreferenceToken()
@@ -206,9 +207,8 @@ func ensurePreferenceTokenTx(ctx context.Context, tx pgx.Tx, personID ids.Person
 		return "", err
 	}
 	err = tx.QueryRow(ctx, `
-		INSERT INTO preference_token (workspace_id, person_id, token, expires_at)
-		VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, $2,
-		        now() + make_interval(days => $3))
+		INSERT INTO preference_token (person_id, token, expires_at)
+		VALUES ($1, $2, now() + make_interval(days => $3))
 		ON CONFLICT (person_id) WHERE revoked_at IS NULL DO NOTHING
 		RETURNING token`, personID, fresh, preferenceTokenTTLDays).Scan(&token)
 	if errors.Is(err, pgx.ErrNoRows) {
@@ -217,8 +217,7 @@ func ensurePreferenceTokenTx(ctx context.Context, tx pgx.Tx, personID ids.Person
 		// value rather than the zero one this scan is about to overwrite.
 		if err := tx.QueryRow(ctx, `
 			SELECT token FROM preference_token
-			 WHERE workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid
-			   AND person_id = $1 AND revoked_at IS NULL`, personID).Scan(&token); err != nil {
+			 WHERE person_id = $1 AND revoked_at IS NULL`, personID).Scan(&token); err != nil {
 			return "", err
 		}
 		return token, nil

--- a/backend/internal/modules/consent/seed.go
+++ b/backend/internal/modules/consent/seed.go
@@ -62,16 +62,16 @@ func SeedPurposesTx(ctx context.Context, tx pgx.Tx, purposes []PurposeSeed) erro
 		{Key: "business_correspondence", Label: "Business correspondence", Class: ClassBusinessCorrespondence},
 	} {
 		if _, err := tx.Exec(ctx, `
-			INSERT INTO consent_purpose (workspace_id, key, label, requires_double_opt_in, class)
-			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, $2, false, $3)`,
+			INSERT INTO consent_purpose (key, label, requires_double_opt_in, class)
+			VALUES ($1, $2, false, $3)`,
 			invariant.Key, invariant.Label, invariant.Class); err != nil {
 			return err
 		}
 	}
 	for _, p := range purposes {
 		if _, err := tx.Exec(ctx, `
-			INSERT INTO consent_purpose (workspace_id, key, label, requires_double_opt_in, class)
-			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, $2, $3, $4)`,
+			INSERT INTO consent_purpose (key, label, requires_double_opt_in, class)
+			VALUES ($1, $2, $3, $4)`,
 			p.Key, p.Label, p.DoubleOptIn, p.classOrMarketing()); err != nil {
 			return err
 		}

--- a/backend/internal/modules/consent/store.go
+++ b/backend/internal/modules/consent/store.go
@@ -36,7 +36,6 @@ func NewStore(db *database.DB) *Store {
 
 type Purpose struct {
 	ID                  ids.PurposeID
-	WorkspaceID         ids.WorkspaceID
 	Key                 string
 	Label               string
 	RequiresDoubleOptIn bool
@@ -75,7 +74,7 @@ func (s *Store) ListPurposes(ctx context.Context) ([]Purpose, error) {
 	var out []Purpose
 	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		rows, err := tx.Query(ctx, `
-			SELECT id, workspace_id, key, label, requires_double_opt_in, created_at
+			SELECT id, key, label, requires_double_opt_in, created_at
 			FROM consent_purpose WHERE archived_at IS NULL ORDER BY key`)
 		if err != nil {
 			return err
@@ -83,7 +82,7 @@ func (s *Store) ListPurposes(ctx context.Context) ([]Purpose, error) {
 		defer rows.Close()
 		for rows.Next() {
 			var p Purpose
-			if err := rows.Scan(&p.ID, &p.WorkspaceID, &p.Key, &p.Label, &p.RequiresDoubleOptIn, &p.CreatedAt); err != nil {
+			if err := rows.Scan(&p.ID, &p.Key, &p.Label, &p.RequiresDoubleOptIn, &p.CreatedAt); err != nil {
 				return err
 			}
 			out = append(out, p)
@@ -107,11 +106,11 @@ func (s *Store) CreatePurpose(ctx context.Context, key, label string, requiresDO
 	var p Purpose
 	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		err := tx.QueryRow(ctx, `
-			INSERT INTO consent_purpose (workspace_id, key, label, requires_double_opt_in)
-			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, $2, $3)
-			RETURNING id, workspace_id, key, label, requires_double_opt_in, created_at`,
+			INSERT INTO consent_purpose (key, label, requires_double_opt_in)
+			VALUES ($1, $2, $3)
+			RETURNING id, key, label, requires_double_opt_in, created_at`,
 			key, label, requiresDOI).
-			Scan(&p.ID, &p.WorkspaceID, &p.Key, &p.Label, &p.RequiresDoubleOptIn, &p.CreatedAt)
+			Scan(&p.ID, &p.Key, &p.Label, &p.RequiresDoubleOptIn, &p.CreatedAt)
 		if constraint, ok := storekit.UniqueViolation(err); ok && constraint == "consent_purpose_key_unique" {
 			return fmt.Errorf("purpose %q: %w", key, apperrors.ErrConflict)
 		}
@@ -431,8 +430,8 @@ func (s *Store) resolveDOIConfirmation(ctx context.Context, tx pgx.Tx, in Record
 // lead×purpose); the other arm's column stays NULL.
 func upsertConsentWithProof(ctx context.Context, tx pgx.Tx, in RecordInput, sub subject, doiConfirmedAt *time.Time, capturedAt time.Time, actorID string) error {
 	if _, err := tx.Exec(ctx, `
-		INSERT INTO person_consent (workspace_id, `+sub.column+`, purpose_id, state, lawful_basis, captured_at, source)
-		VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, $2, $3, $4, $5, $6)
+		INSERT INTO person_consent (`+sub.column+`, purpose_id, state, lawful_basis, captured_at, source)
+		VALUES ($1, $2, $3, $4, $5, $6)
 		ON CONFLICT (`+sub.column+`, purpose_id)
 		DO UPDATE SET state = EXCLUDED.state, lawful_basis = EXCLUDED.lawful_basis,
 		              captured_at = EXCLUDED.captured_at, source = EXCLUDED.source`,
@@ -440,10 +439,9 @@ func upsertConsentWithProof(ctx context.Context, tx pgx.Tx, in RecordInput, sub 
 		return err
 	}
 	_, err := tx.Exec(ctx, `
-		INSERT INTO consent_event (workspace_id, `+sub.column+`, purpose_id, new_state, lawful_basis, source,
+		INSERT INTO consent_event (`+sub.column+`, purpose_id, new_state, lawful_basis, source,
 		                           policy_text, policy_version, double_opt_in_confirmed_at, captured_at, captured_by)
-		VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid,
-		        $1, $2, $3, $4, coalesce($5, 'api'), coalesce($6, 'recorded via API'), coalesce($7, 'v1'), $8, $9, $10)`,
+		VALUES ($1, $2, $3, $4, coalesce($5, 'api'), coalesce($6, 'recorded via API'), coalesce($7, 'v1'), $8, $9, $10)`,
 		sub.id, in.PurposeID, in.NewState, in.LawfulBasis, in.Source,
 		in.PolicyText, in.PolicyVersion, doiConfirmedAt, capturedAt, actorID)
 	return err

--- a/backend/internal/modules/consent/verdict.go
+++ b/backend/internal/modules/consent/verdict.go
@@ -333,10 +333,9 @@ func RecordDerivedQualifyingEvent(ctx context.Context, tx pgx.Tx, personID strin
 	// source record is what actually makes this idempotent.
 	_, err := tx.Exec(ctx, `
 		INSERT INTO consent_qualifying_event
-			(workspace_id, person_id, kind, source_entity_type, source_entity_id,
+			(person_id, kind, source_entity_type, source_entity_id,
 			 occurred_at, source, captured_by)
-		VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid,
-		        $1, $2, $3, $4, $5, 'derived', $6)
+		VALUES ($1, $2, $3, $4, $5, 'derived', $6)
 		ON CONFLICT (person_id, source_entity_type, source_entity_id)
 		  WHERE source_entity_id IS NOT NULL
 		  DO NOTHING`,

--- a/backend/internal/modules/people/merge.go
+++ b/backend/internal/modules/people/merge.go
@@ -295,9 +295,9 @@ func mergeConsent(ctx context.Context, tx pgx.Tx, sourceID, targetID ids.PersonI
 		    AND a.state = 'withdrawn' AND b.state <> 'withdrawn'
 		  RETURNING b.purpose_id
 		)
-		INSERT INTO consent_event (workspace_id, person_id, purpose_id, new_state, source,
+		INSERT INTO consent_event (person_id, purpose_id, new_state, source,
 		                           policy_text, policy_version, captured_at, captured_by)
-		SELECT NULLIF(current_setting('app.workspace_id', true), '')::uuid, $2, purpose_id, 'withdrawn', 'merge',
+		SELECT $2, purpose_id, 'withdrawn', 'merge',
 		       'withdrawal carried over from a merged duplicate record', 'merge', $3, $4
 		FROM flipped`,
 		sourceID, targetID, time.Now().UTC(), by); err != nil {

--- a/backend/internal/modules/people/promote.go
+++ b/backend/internal/modules/people/promote.go
@@ -165,9 +165,9 @@ func carryLeadConsent(ctx context.Context, tx pgx.Tx, leadID ids.LeadID, personI
 		    AND a.state = 'withdrawn' AND b.state <> 'withdrawn'
 		  RETURNING b.purpose_id
 		)
-		INSERT INTO consent_event (workspace_id, person_id, purpose_id, new_state, source,
+		INSERT INTO consent_event (person_id, purpose_id, new_state, source,
 		                           policy_text, policy_version, captured_at, captured_by)
-		SELECT NULLIF(current_setting('app.workspace_id', true), '')::uuid, $2, purpose_id, 'withdrawn', 'promotion',
+		SELECT $2, purpose_id, 'withdrawn', 'promotion',
 		       'withdrawal carried over from the promoted lead', 'promotion', $3, $4
 		FROM flipped`,
 		leadID, personID, time.Now().UTC(), by); err != nil {

--- a/backend/internal/modules/people/promoteconsent_integration_test.go
+++ b/backend/internal/modules/people/promoteconsent_integration_test.go
@@ -81,8 +81,8 @@ func setupPromoteConsent(t *testing.T) *promoteConsentEnv {
 	}
 	for id, key := range map[ids.UUID]string{e.newsletter: "newsletter", e.updates: "product_updates"} {
 		if _, err := owner.Exec(ctx,
-			`INSERT INTO consent_purpose (id, workspace_id, key, label) VALUES ($1, $2, $3, $3)`,
-			id, e.ws, key); err != nil {
+			`INSERT INTO consent_purpose (id, key, label) VALUES ($1, $2, $2)`,
+			id, key); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -126,15 +126,15 @@ func (e *promoteConsentEnv) seedLeadConsent(t *testing.T, lead ids.LeadID, purpo
 	t.Helper()
 	now := time.Now().UTC()
 	if _, err := e.owner.Exec(context.Background(),
-		`INSERT INTO person_consent (workspace_id, lead_id, purpose_id, state, captured_at, source)
-		 VALUES ($1, $2, $3, $4, $5, 'form')`,
-		e.ws, lead, purpose, state, now); err != nil {
+		`INSERT INTO person_consent (lead_id, purpose_id, state, captured_at, source)
+		 VALUES ($1, $2, $3, $4, 'form')`,
+		lead, purpose, state, now); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := e.owner.Exec(context.Background(),
-		`INSERT INTO consent_event (workspace_id, lead_id, purpose_id, new_state, source, policy_text, policy_version, captured_at, captured_by)
-		 VALUES ($1, $2, $3, $4, 'form', 'seeded wording', 'v1', $5, 'human:x')`,
-		e.ws, lead, purpose, state, now); err != nil {
+		`INSERT INTO consent_event (lead_id, purpose_id, new_state, source, policy_text, policy_version, captured_at, captured_by)
+		 VALUES ($1, $2, $3, 'form', 'seeded wording', 'v1', $4, 'human:x')`,
+		lead, purpose, state, now); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -222,8 +222,8 @@ func TestPromotionMergeAppliesWithdrawalWinsAndStateStands(t *testing.T) {
 		t.Fatal(err)
 	}
 	if _, err := e.owner.Exec(context.Background(),
-		`INSERT INTO person_consent (workspace_id, person_id, purpose_id, state, captured_at, source)
-		 VALUES ($1, $2, $3, 'granted', now(), 'manual')`, e.ws, personID, e.newsletter); err != nil {
+		`INSERT INTO person_consent (person_id, purpose_id, state, captured_at, source)
+		 VALUES ($1, $2, 'granted', now(), 'manual')`, personID, e.newsletter); err != nil {
 		t.Fatal(err)
 	}
 

--- a/backend/internal/modules/privacy/erasure.go
+++ b/backend/internal/modules/privacy/erasure.go
@@ -423,14 +423,9 @@ func deleteSubjectIdentifierRows(ctx context.Context, tx pgx.Tx, personID ids.Pe
 // consent_event, audit and outbox rows through the exact capability this
 // erasure certifies destroyed. Deleted rather than revoked, like the address
 // and phone rows beside it — a revoked row still holds the subject's person
-// link. The workspace predicate is explicit because preference_token is
-// deliberately outside RLS (it IS the token→tenant resolver, 0048), so
-// nothing else scopes this statement.
+// link.
 func deletePreferenceToken(ctx context.Context, tx pgx.Tx, personID ids.PersonID) error {
-	_, err := tx.Exec(ctx, `
-		DELETE FROM preference_token
-		 WHERE workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid
-		   AND person_id = $1`, personID)
+	_, err := tx.Exec(ctx, `DELETE FROM preference_token WHERE person_id = $1`, personID)
 	return err
 }
 

--- a/backend/migrations/core/0231_consent_drop_workspace.down.sql
+++ b/backend/migrations/core/0231_consent_drop_workspace.down.sql
@@ -1,0 +1,73 @@
+-- Reverse of 0231: the eight tables carry the tenant column again.
+--
+-- The backfill reads `workspace` because there is exactly one to read: 0217's
+-- pre-flight refuses to run against a database holding more than one live
+-- workspace, and ADR-0061 §3 has the API refusing to start in that state. If
+-- `workspace` is empty and a table is not, SET NOT NULL fails and the rollback
+-- stops — the honest outcome, since no value this migration could write would
+-- be true.
+
+ALTER TABLE consent_purpose ADD COLUMN workspace_id uuid;
+ALTER TABLE person_consent ADD COLUMN workspace_id uuid;
+ALTER TABLE consent_event ADD COLUMN workspace_id uuid;
+ALTER TABLE consent_doi_token ADD COLUMN workspace_id uuid;
+ALTER TABLE consent_qualifying_event ADD COLUMN workspace_id uuid;
+ALTER TABLE consent_existing_customer_flag ADD COLUMN workspace_id uuid;
+ALTER TABLE data_subject_request ADD COLUMN workspace_id uuid;
+ALTER TABLE preference_token ADD COLUMN workspace_id uuid;
+
+DO $$
+DECLARE ws uuid := (SELECT id FROM workspace ORDER BY created_at LIMIT 1);
+BEGIN
+  UPDATE consent_purpose SET workspace_id = ws;
+  UPDATE person_consent SET workspace_id = ws;
+  UPDATE consent_event SET workspace_id = ws;
+  UPDATE consent_doi_token SET workspace_id = ws;
+  UPDATE consent_qualifying_event SET workspace_id = ws;
+  UPDATE consent_existing_customer_flag SET workspace_id = ws;
+  UPDATE data_subject_request SET workspace_id = ws;
+  UPDATE preference_token SET workspace_id = ws;
+END $$;
+
+ALTER TABLE consent_purpose ALTER COLUMN workspace_id SET NOT NULL;
+ALTER TABLE person_consent ALTER COLUMN workspace_id SET NOT NULL;
+ALTER TABLE consent_event ALTER COLUMN workspace_id SET NOT NULL;
+ALTER TABLE consent_doi_token ALTER COLUMN workspace_id SET NOT NULL;
+ALTER TABLE consent_qualifying_event ALTER COLUMN workspace_id SET NOT NULL;
+ALTER TABLE consent_existing_customer_flag ALTER COLUMN workspace_id SET NOT NULL;
+ALTER TABLE data_subject_request ALTER COLUMN workspace_id SET NOT NULL;
+ALTER TABLE preference_token ALTER COLUMN workspace_id SET NOT NULL;
+
+ALTER TABLE consent_purpose ADD CONSTRAINT consent_purpose_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE person_consent ADD CONSTRAINT person_consent_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE consent_event ADD CONSTRAINT consent_event_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE consent_doi_token ADD CONSTRAINT consent_doi_token_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE consent_qualifying_event ADD CONSTRAINT consent_qualifying_event_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE consent_existing_customer_flag ADD CONSTRAINT consent_existing_customer_flag_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE data_subject_request ADD CONSTRAINT data_subject_request_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE preference_token ADD CONSTRAINT preference_token_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+
+ALTER TABLE consent_purpose ADD CONSTRAINT uq_consent_purpose_ws_id UNIQUE (id);
+
+DROP INDEX consent_qualifying_event_person_ix;
+CREATE INDEX consent_qualifying_event_person_ix ON consent_qualifying_event (workspace_id, person_id, occurred_at DESC);
+
+DROP INDEX idx_consent_doi_token_person;
+CREATE INDEX idx_consent_doi_token_person ON consent_doi_token (workspace_id, person_id, purpose_id);
+
+DROP INDEX idx_consent_event_lead;
+CREATE INDEX idx_consent_event_lead ON consent_event (workspace_id, lead_id, captured_at DESC) WHERE lead_id IS NOT NULL;
+
+DROP INDEX idx_consent_event_person;
+CREATE INDEX idx_consent_event_person ON consent_event (workspace_id, person_id, captured_at DESC);
+
+DROP INDEX idx_dsr_open;
+CREATE INDEX idx_dsr_open ON data_subject_request (workspace_id, due_at) WHERE status IN ('open', 'in_progress');

--- a/backend/migrations/core/0231_consent_drop_workspace.up.sql
+++ b/backend/migrations/core/0231_consent_drop_workspace.up.sql
@@ -1,0 +1,37 @@
+-- 0231: the consent module drops the tenant column (ADR-0091 §8 phase D).
+--
+-- Eight tables, five indexes, one redundant unique.
+--
+-- `preference_token` is the one to read twice. It was deliberately OUTSIDE
+-- row-level security (0048) because it IS the resolver: the public preference
+-- centre has no session, so the token was what told the server which tenant
+-- the request belonged to. That question has one answer now — the identity
+-- middleware binds the installation's workspace into every request context,
+-- public paths included, before the preference middleware runs — so the
+-- column was already answering a question nobody was asking.
+
+DROP INDEX consent_qualifying_event_person_ix;
+CREATE INDEX consent_qualifying_event_person_ix ON consent_qualifying_event (person_id, occurred_at DESC);
+
+DROP INDEX idx_consent_doi_token_person;
+CREATE INDEX idx_consent_doi_token_person ON consent_doi_token (person_id, purpose_id);
+
+DROP INDEX idx_consent_event_lead;
+CREATE INDEX idx_consent_event_lead ON consent_event (lead_id, captured_at DESC) WHERE lead_id IS NOT NULL;
+
+DROP INDEX idx_consent_event_person;
+CREATE INDEX idx_consent_event_person ON consent_event (person_id, captured_at DESC);
+
+DROP INDEX idx_dsr_open;
+CREATE INDEX idx_dsr_open ON data_subject_request (due_at) WHERE status IN ('open', 'in_progress');
+
+ALTER TABLE consent_purpose DROP CONSTRAINT uq_consent_purpose_ws_id;
+
+ALTER TABLE consent_purpose DROP COLUMN workspace_id;
+ALTER TABLE person_consent DROP COLUMN workspace_id;
+ALTER TABLE consent_event DROP COLUMN workspace_id;
+ALTER TABLE consent_doi_token DROP COLUMN workspace_id;
+ALTER TABLE consent_qualifying_event DROP COLUMN workspace_id;
+ALTER TABLE consent_existing_customer_flag DROP COLUMN workspace_id;
+ALTER TABLE data_subject_request DROP COLUMN workspace_id;
+ALTER TABLE preference_token DROP COLUMN workspace_id;


### PR DESCRIPTION
Phase D, fifth slice. Eight tables, five indexes, one redundant unique.

## `preference_token` is the one to read twice

It sat **outside** row-level security (0048) on purpose, because it WAS the resolver: the public preference centre has no session, so the token was what told the server which tenant a request belonged to.

That question has one answer now. The identity middleware binds the installation's workspace into every request context — public paths included — before the preference middleware runs, so the re-binding was already writing the value it was overwriting. `PreferenceRef` answers only *whose consent*, and the public middleware now resolves the token for its **refusal** (unknown, revoked and expired read identically as absent) rather than for a tenant.

## The reset sweep had to change with it, and that is the finding worth carrying

`resetTargetTables` derived its targets from the presence of a `workspace_id` column — a proxy for "holds this tenant's data" that phase D is removing table by table. Under it, **a module that dropped the column silently stopped being reset.** `consent_purpose` was the first: the reset then failed re-seeding purposes it had never deleted (`duplicate key … consent_purpose_key_unique`), which is how this surfaced.

So the derivation is inverted: the sweep deletes every public base table the **preserve set** does not name. What a reset must keep is a decision a person has to make; what it deletes follows. Forgetting an entry now fails loudly — the admin loses their session, the installation loses its config — instead of quietly leaving a tenant's rows behind after a reset that reported success. `TestPreserveSetIntegrity` is updated to guard the list that now carries the whole definition.

A table that still has the column keeps its predicate, so this does not widen what a reset destroys ahead of the schema.

The provider tables lose their separate pass with it: they needed one only because the column-derived list could not see them.

## Verification

- Lane applied to an empty database; the down restores all eight columns with their foreign keys, the unique and all five wide indexes.
- `make check-backend` green.
- `make test-integration`: **OK, 0 skips, 39 packages** — including the overlay sweep-backoff suite, which had been failing on rows the reset left behind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drops `workspace_id` from the consent module and switches the reset sweep to “delete all non-preserved tables” so modules that remove the tenant column keep resetting correctly. Public preference links now resolve only the recipient; the workspace is bound by identity middleware.

- Consent schema: removes `workspace_id` from 8 tables (`consent_purpose`, `person_consent`, `consent_event`, `consent_doi_token`, `consent_qualifying_event`, `consent_existing_customer_flag`, `data_subject_request`, `preference_token`), updates 5 indexes to drop workspace keys, and removes a redundant unique.
- Public preferences: `ResolvePreferenceToken` returns only the person; middleware stops rebinding the workspace and uses the token strictly as a refusal gate (unknown/revoked/expired read as absent).
- Data reset: targets are now “all public base tables minus the preserved set, migration ledgers, and `river_*`.” Tables that still carry `workspace_id` keep a per-workspace predicate so the sweep does not widen ahead of the schema. Provider tables are included automatically; their separate pass is removed.
- Preserved set: extended to include identity/auth, append-only ledgers, installation config/secrets, and outbox. Integrity test now validates the list against the catalog and the computed targets.
- Auditing: centralizes the workspace audit object name; no behavior change. Tests and DML updated across modules to reflect dropped tenant columns.

**Rollout and migration**
- Apply migration 0231. The down restores all eight columns, FKs, updated indexes, and backfills from the single `workspace` row.
- If you add a base table that must survive a reset, add its name to `preservedResetTables`. All other public base tables are swept by default.

<sup>Written for commit fa0fd6afd93e480bb7eeb2a34300ec628fad3772. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1164?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

