### PR TITLE
fix(capture): a counterparty the installation already knows gets their real name

### DIFF
--- a/backend/internal/modules/people/counterpartyname.go
+++ b/backend/internal/modules/people/counterpartyname.go
@@ -29,6 +29,11 @@ import (
 // to — the display name on the app_user row with that address, or "" when the
 // address is nobody the installation knows.
 //
+// Scoped to the CURRENT workspace and to an ACTIVE seat. Row-level security is
+// retired, so the workspace predicate is the query's own job now; and a
+// deactivated member keeps their row, so archived_at alone would still hand out
+// the name of somebody the installation has stopped trusting.
+//
 // It exists because the header is not always the best evidence available. A
 // message signed only "Lars" from lars@jankowfsky.de parses to a single token,
 // which the parser refuses to split — correctly, since one word is a first
@@ -43,7 +48,10 @@ func KnownHumanName(ctx context.Context, tx pgx.Tx, email string) (string, error
 	var name string
 	err := tx.QueryRow(ctx, `
 		SELECT display_name FROM app_user
-		 WHERE lower(email) = $1 AND archived_at IS NULL`, normalized).Scan(&name)
+		 WHERE lower(email) = $1
+		   AND workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid
+		   AND archived_at IS NULL
+		   AND status = 'active'`, normalized).Scan(&name)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return "", nil
 	}
@@ -71,6 +79,19 @@ func (s *Store) nameCounterparty(ctx context.Context, tx pgx.Tx, in EnsureCounte
 	if parsed.Confident {
 		return parsed, nil
 	}
+	// The From header is FORGEABLE, and this is the one place that would turn a
+	// forged one into an identity claim: a spoofed "Lars <someone@gmail.com>"
+	// would otherwise attach a colleague's real stored name to a stranger's
+	// record. So the address must have carried attested correspondence — mail
+	// this installation itself sent there, or a provider-vouched sent copy —
+	// before their stored name is trusted over the header.
+	attested, err := addressAttestedTx(ctx, tx, in.Email)
+	if err != nil {
+		return ParsedName{}, err
+	}
+	if !attested {
+		return parsed, nil
+	}
 	known, err := KnownHumanName(ctx, tx, in.Email)
 	if err != nil {
 		return ParsedName{}, err
@@ -86,4 +107,28 @@ func (s *Store) nameCounterparty(ctx context.Context, tx pgx.Tx, in EnsureCounte
 		return parsed, nil
 	}
 	return fromUser, nil
+}
+
+// addressAttestedTx reports whether this installation has provably corresponded
+// with an address — the same unforgeable evidence capture's T1 gate reads.
+//
+// It is deliberately NOT the direction column: direction is derived by
+// comparing a forgeable From header against the owner, so a spoofed message
+// would vouch for itself. counterparty_outbound_attested is stamped only by a
+// connector reading the mailbox owner's own sent copy, or by the governed send
+// path itself.
+func addressAttestedTx(ctx context.Context, tx pgx.Tx, email string) (bool, error) {
+	normalized := strings.ToLower(strings.TrimSpace(email))
+	if normalized == "" {
+		return false, nil
+	}
+	var attested bool
+	if err := tx.QueryRow(ctx, `
+		SELECT EXISTS (
+		  SELECT 1 FROM activity
+		   WHERE counterparty_email = $1 AND counterparty_outbound_attested)`,
+		normalized).Scan(&attested); err != nil {
+		return false, fmt.Errorf("people: reading whether %s was written to: %w", normalized, err)
+	}
+	return attested, nil
 }

--- a/backend/internal/modules/people/counterpartyname.go
+++ b/backend/internal/modules/people/counterpartyname.go
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package people
+
+// Naming a counterparty from what the INSTALLATION knows, when the header does
+// not say enough on its own.
+//
+// personname.go reads one message's header and is deliberately willing to
+// abstain: a display name of "Lars" is one token, and one token is a first
+// name, a surname or a nickname with nothing to say which. That is the right
+// answer for a stranger and the wrong one for somebody the workspace already
+// has on file — mail from lars@jankowfsky.de is not a mystery when there is an
+// app_user row with that address and a full name a person typed.
+//
+// So this file is the second question, asked only when the first abstains:
+// does this installation already know who this is.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// KnownHumanName is what the installation already knows a mail address belongs
+// to — the display name on the app_user row with that address, or "" when the
+// address is nobody the installation knows.
+//
+// It exists because the header is not always the best evidence available. A
+// message signed only "Lars" from lars@jankowfsky.de parses to a single token,
+// which the parser refuses to split — correctly, since one word is a first
+// name, a surname or a nickname and the header does not say which. But when
+// that address is a HUMAN THIS INSTALLATION HAS, the answer is not a guess: the
+// workspace already holds their full name, typed by a person.
+func KnownHumanName(ctx context.Context, tx pgx.Tx, email string) (string, error) {
+	normalized := strings.ToLower(strings.TrimSpace(email))
+	if normalized == "" {
+		return "", nil
+	}
+	var name string
+	err := tx.QueryRow(ctx, `
+		SELECT display_name FROM app_user
+		 WHERE lower(email) = $1 AND archived_at IS NULL`, normalized).Scan(&name)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("people: reading the human behind %s: %w", normalized, err)
+	}
+	return strings.TrimSpace(name), nil
+}
+
+// nameCounterparty reads the best name available for a captured address.
+//
+// The header is the usual evidence and the parser reads it well, but it is not
+// always the BEST evidence the installation holds. A message signed only "Lars"
+// parses to one token, which the parser refuses to split — one word is a first
+// name, a surname or a nickname, and the header does not say which. When that
+// same address belongs to a human this installation already has, the workspace
+// holds their full name, typed by a person: better evidence than a header, and
+// not a guess.
+//
+// It only ever fills a blank. A CONFIDENT header parse stands, because the
+// header is what that person calls themselves in mail, and a stale app_user
+// display name must not overwrite it.
+func (s *Store) nameCounterparty(ctx context.Context, tx pgx.Tx, in EnsureCounterpartyInput) (ParsedName, error) {
+	parsed := ParsePersonName(in.DisplayName, in.Email)
+	if parsed.Confident {
+		return parsed, nil
+	}
+	known, err := KnownHumanName(ctx, tx, in.Email)
+	if err != nil {
+		return ParsedName{}, err
+	}
+	if known == "" {
+		return parsed, nil
+	}
+	// Re-parsed rather than stored raw: an app_user display name is typed by a
+	// human and can carry the same shapes a header does — "Jankowfsky, Lars",
+	// a trailing company — and it deserves the same reading.
+	fromUser := ParsePersonName(known, in.Email)
+	if fromUser.Full == "" {
+		return parsed, nil
+	}
+	return fromUser, nil
+}

--- a/backend/internal/modules/people/ensure.go
+++ b/backend/internal/modules/people/ensure.go
@@ -167,7 +167,10 @@ func (s *Store) ensurePerson(ctx context.Context, tx pgx.Tx, in EnsureCounterpar
 	if err := auth.Require(ctx, entityPerson, principal.ActionCreate); err != nil {
 		return err
 	}
-	parsed := ParsePersonName(in.DisplayName, in.Email)
+	parsed, err := s.nameCounterparty(ctx, tx, in)
+	if err != nil {
+		return err
+	}
 	name := parsed.Full
 	// The workspace's own consumer-mail list travels with the candidate: the
 	// employer-agreement term must judge a shared domain the same way capture

--- a/backend/internal/modules/people/ensure.go
+++ b/backend/internal/modules/people/ensure.go
@@ -402,14 +402,21 @@ func fillMissingPersonName(ctx context.Context, tx pgx.Tx, personID ids.PersonID
 	// named. The predicate is also the concurrency guard: a writer who filled
 	// either half between the dedupe read and this write keeps it, because
 	// Postgres re-checks the predicate after waiting on their lock.
+	// full_name moves WITH the split columns, and only when it is still the
+	// shorter thing the parser refused to split. A record displaying "Lars"
+	// while its columns say Lars Jankowfsky is a fill that reported success and
+	// changed nothing a human can see — the defect this predicate closes.
+	// A full_name a person typed is longer or different, and is left alone.
 	tag, err := tx.Exec(ctx, `
 		UPDATE person
 		   SET first_name = $2,
 		       last_name  = $3,
+		       full_name  = CASE WHEN full_name = $2 OR full_name = $3
+		                         THEN $4 ELSE full_name END,
 		       updated_at = now()
 		 WHERE id = $1
 		   AND first_name IS NULL AND last_name IS NULL`,
-		personID, parsed.First, parsed.Last)
+		personID, parsed.First, parsed.Last, parsed.Full)
 	if err != nil {
 		return fmt.Errorf("people: filling the missing name of person %s: %w", personID, err)
 	}

--- a/backend/internal/modules/people/ensurename_integration_test.go
+++ b/backend/internal/modules/people/ensurename_integration_test.go
@@ -172,6 +172,10 @@ func TestACounterpartyWhoIsAKnownHumanGetsTheirRealName(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// The installation has written to this address, which is the unforgeable
+	// half: without it a spoofed From could claim any colleague's identity.
+	e.attestOutbound(ctx, t, addr)
+
 	res, err := e.store.EnsureCounterparty(ctx, e.ensureInput(ctx, t, addr, "Lars", "jankowfsky.test"))
 	if err != nil || !res.PersonCreated {
 		t.Fatalf("ensure = %+v (err %v), want a created person", res, err)
@@ -206,5 +210,81 @@ func TestAConfidentHeaderOutranksAKnownHumansStoredName(t *testing.T) {
 	}
 	if full, _, last := e.storedName(ctx, t, res.PersonID); full != "Anna Weber" || nameOrNull(last) != "Weber" {
 		t.Fatalf("stored %q / %q, want the name she signs her own mail with", full, nameOrNull(last))
+	}
+}
+
+// attestOutbound records that this installation provably wrote to an address —
+// the T1 evidence, stamped only by a connector reading the owner's own sent
+// copy or by the governed send path.
+func (e *dedupeEnv) attestOutbound(ctx context.Context, t *testing.T, email string) {
+	t.Helper()
+	if err := e.store.tx(ctx, func(tx pgx.Tx) error {
+		_, err := tx.Exec(ctx, `
+			INSERT INTO activity (id, workspace_id, kind, subject, counterparty_email,
+			                      counterparty_outbound_attested, source, captured_by)
+			VALUES ($1, $2, 'email', 'hi', $3, true, 'test', 'human:test')`,
+			ids.NewV7(), e.ws, email)
+		return err
+	}); err != nil {
+		t.Fatalf("attesting outbound to %s: %v", email, err)
+	}
+}
+
+// A forged From naming a colleague's address must not put that colleague's
+// stored name on a stranger's record. The header is forgeable; the installation
+// having WRITTEN to the address is not.
+func TestASpoofedHeaderCannotBorrowAKnownHumansName(t *testing.T) {
+	e := setupDedupe(t)
+	ctx := e.as()
+	const addr = "colleague@elsewhere.test"
+
+	if err := e.store.tx(ctx, func(tx pgx.Tx) error {
+		_, err := tx.Exec(ctx, `
+			INSERT INTO app_user (id, workspace_id, email, display_name)
+			VALUES ($1, $2, $3, 'Real Colleague')`, ids.NewV7(), e.ws, addr)
+		return err
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// No attested correspondence: nothing proves this installation ever wrote
+	// to the address, so the name stays what the header actually said.
+	res, err := e.store.EnsureCounterparty(ctx, e.ensureInput(ctx, t, addr, "Lars", "elsewhere.test"))
+	if err != nil {
+		t.Fatalf("ensure: %v", err)
+	}
+	full, first, last := e.storedName(ctx, t, res.PersonID)
+	if full != "Lars" || first != nil || last != nil {
+		t.Fatalf("stored %q / %q / %q, want the header's own word and no borrowed identity",
+			full, nameOrNull(first), nameOrNull(last))
+	}
+}
+
+// The record a person LOOKS at has to change. A fill that writes the split
+// columns and leaves full_name reading "Lars" reports success and changes
+// nothing visible.
+func TestFillingASplitNameAlsoFixesTheDisplayedName(t *testing.T) {
+	e := setupDedupe(t)
+	ctx := e.as()
+	const addr = "lars@displayed.test"
+
+	// First contact: the header says one word, so that is what is stored.
+	first, err := e.store.EnsureCounterparty(ctx, e.ensureInput(ctx, t, addr, "Lars", "displayed.test"))
+	if err != nil {
+		t.Fatalf("first ensure: %v", err)
+	}
+	if full, _, _ := e.storedName(ctx, t, first.PersonID); full != "Lars" {
+		t.Fatalf("full_name = %q on first contact, want the header's word", full)
+	}
+
+	// A later message carries the whole name.
+	if _, err := e.store.EnsureCounterparty(ctx,
+		e.ensureInput(ctx, t, addr, "Lars Jankowfsky", "displayed.test")); err != nil {
+		t.Fatalf("second ensure: %v", err)
+	}
+	full, f, l := e.storedName(ctx, t, first.PersonID)
+	if full != "Lars Jankowfsky" || nameOrNull(f) != "Lars" || nameOrNull(l) != "Jankowfsky" {
+		t.Fatalf("stored %q / %q / %q, want the displayed name fixed too",
+			full, nameOrNull(f), nameOrNull(l))
 	}
 }

--- a/backend/internal/modules/people/ensurename_integration_test.go
+++ b/backend/internal/modules/people/ensurename_integration_test.go
@@ -153,3 +153,58 @@ func TestEnsureCounterpartyNeverOverwritesANameAHumanSet(t *testing.T) {
 			full, nameOrNull(first), nameOrNull(last))
 	}
 }
+
+// A message signed only "Lars" from an address the installation KNOWS is not a
+// one-token mystery: the workspace already holds that human's full name, typed
+// by a person. The header alone would parse to "Lars" with no first or last,
+// which is honest but worse than the evidence available.
+func TestACounterpartyWhoIsAKnownHumanGetsTheirRealName(t *testing.T) {
+	e := setupDedupe(t)
+	ctx := e.as()
+	const addr = "lars@jankowfsky.test"
+
+	if err := e.store.tx(ctx, func(tx pgx.Tx) error {
+		_, err := tx.Exec(ctx, `
+			INSERT INTO app_user (id, workspace_id, email, display_name)
+			VALUES ($1, $2, $3, 'Lars Jankowfsky')`, ids.NewV7(), e.ws, addr)
+		return err
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := e.store.EnsureCounterparty(ctx, e.ensureInput(ctx, t, addr, "Lars", "jankowfsky.test"))
+	if err != nil || !res.PersonCreated {
+		t.Fatalf("ensure = %+v (err %v), want a created person", res, err)
+	}
+	full, first, last := e.storedName(ctx, t, res.PersonID)
+	if full != "Lars Jankowfsky" || nameOrNull(first) != "Lars" || nameOrNull(last) != "Jankowfsky" {
+		t.Fatalf("stored %q / %q / %q, want the name the installation already knew",
+			full, nameOrNull(first), nameOrNull(last))
+	}
+}
+
+// The header still wins when it actually says something. An app_user display
+// name can be stale — a maiden name, a placeholder typed at setup — and it must
+// not overwrite what a person signs their own mail with.
+func TestAConfidentHeaderOutranksAKnownHumansStoredName(t *testing.T) {
+	e := setupDedupe(t)
+	ctx := e.as()
+	const addr = "anna@known.test"
+
+	if err := e.store.tx(ctx, func(tx pgx.Tx) error {
+		_, err := tx.Exec(ctx, `
+			INSERT INTO app_user (id, workspace_id, email, display_name)
+			VALUES ($1, $2, $3, 'Anna Old-Surname')`, ids.NewV7(), e.ws, addr)
+		return err
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := e.store.EnsureCounterparty(ctx, e.ensureInput(ctx, t, addr, "Anna Weber", "known.test"))
+	if err != nil {
+		t.Fatalf("ensure: %v", err)
+	}
+	if full, _, last := e.storedName(ctx, t, res.PersonID); full != "Anna Weber" || nameOrNull(last) != "Weber" {
+		t.Fatalf("stored %q / %q, want the name she signs her own mail with", full, nameOrNull(last))
+	}
+}


### PR DESCRIPTION
## The record you reported

Mail from `lars@jankowfsky.de` signed only **"Lars"** was stored as a person called `Lars`, with no first or last name.

The parser was right to refuse the split — one token is a first name, a surname or a nickname, and the header does not say which. It was wrong to stop there: that address has an `app_user` row carrying the full name a person typed at setup. The header was not the best evidence the installation held.

## The fix

When the header parse **abstains**, the ensure asks a second question: does this installation already know who this is. An address matching a live, active user in this workspace takes that human's display name, re-parsed rather than stored raw.

A **confident header parse still wins** — the header is what a person calls themselves in their own mail, and a stored display name can be stale (a maiden name, a placeholder typed at setup).

## What review caught

Four defects, one of which meant the fix did not fix your record:

- **`fillMissingPersonName` never wrote `full_name`.** An existing "Lars" would have gained the split columns and still *displayed* "Lars" — a fill that reports success and changes nothing visible. `full_name` now moves with them, and only while it is still the shorter thing the parser refused to split.
- **A forged `From` could borrow a colleague's identity.** Preferring a stored name over an abstaining header turns a forgeable header into an identity claim: a spoofed `Lars <someone@gmail.com>` would attach the real colleague's name to a stranger's record, and `quarantineSuspect` does not catch that shape. The installation must now have **provably written** to the address first — the same unforgeable attestation capture's T1 gate reads.
- **No workspace predicate on the lookup.** RLS is retired, so scoping is the query's own job now; without it a user in another workspace could supply the name.
- **Any non-archived row was accepted.** Deactivation changes `status` without archiving, so a member the installation has stopped trusting could still lend their name.

## Tests

Four integration tests: the known human is used, a confident header outranks it, a spoofed header cannot borrow it, and the displayed name is actually fixed. The lookup is mutation-checked — stubbing it out fails the first test.

Gates: `make check-backend` green, `craft-static` 0 findings, both greps clean, people and capture-integration lanes green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Counterparty naming now falls back to the installation’s stored user name when the From header parse abstains, fixing cases like mail signed “Lars” being stored as just “Lars.” Previously we kept the single-token header; now we use the workspace’s known human after outbound attestation, and a confident header still wins.

**Key changes**
- Adds a second-step resolver that, after a non-confident parse, looks up the address’s `app_user` in the current workspace with active status and re-parses their display name.
- Requires provable outbound correspondence before trusting the stored name to block spoofed From headers borrowing a colleague’s identity.
- Scopes the lookup to the current workspace; deactivated users are ignored.
- Keeps the header when confident; only fills a blank from stored data.
- Fixes name fills to update `full_name` with the split columns when it still reflects the shorter, unsplit token.
- Adds integration tests covering: known human used, confident header outranks stored name, spoof cannot borrow identity, and displayed `full_name` updates.

<sup>Written for commit e0adb1f49352c10d5d88fa503a61cd82b37b4168. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1165?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

