### PR TITLE
refactor(approvals): the approval spine drops the tenant column, and signing_key drops it from its name

### DIFF
--- a/backend/internal/compose/integration/approval_bundle_http_integration_test.go
+++ b/backend/internal/compose/integration/approval_bundle_http_integration_test.go
@@ -79,11 +79,11 @@ func stageBundleRows(t *testing.T, e *apptest.AppEnv, orgID string, kinds ...str
 	for i, kind := range kinds {
 		payload := siteReadPayload(kind, orgID, readID.String(), fmt.Sprintf("person%d", i))
 		if _, err := e.Owner.Exec(ctx, `
-			INSERT INTO approval (workspace_id, kind, proposed_by, on_behalf_of, target_entity_type,
+			INSERT INTO approval (kind, proposed_by, on_behalf_of, target_entity_type,
 			                      target_entity_id, summary, proposed_change, diff_hash, expires_at, bundle_id)
-			VALUES ($1, $2, 'agent:site-read', $3, 'organization', $4, $5, $6::jsonb, $7,
-			        now() + interval '1 day', $8)`,
-			wsID, kind, adminID, orgID, "Staged by the site read", payload,
+			VALUES ($1, 'agent:site-read', $2, 'organization', $3, $4, $5::jsonb, $6,
+			        now() + interval '1 day', $7)`,
+			kind, adminID, orgID, "Staged by the site read", payload,
 			ids.NewV7().String(), bundle); err != nil {
 			t.Fatalf("staging member %d (%s): %v", i, kind, err)
 		}

--- a/backend/internal/compose/integration/automation_runs_preview_integration_test.go
+++ b/backend/internal/compose/integration/automation_runs_preview_integration_test.go
@@ -91,9 +91,9 @@ func seedWorkflowRun(t *testing.T, e *apptest.AppEnv, wsID, automationID, status
 		plannedJSON = *planned
 	}
 	if _, err := e.Owner.Exec(context.Background(), `
-		INSERT INTO workflow_run (id, workspace_id, handler, idempotency_key, trigger_event, planned, applied, status, detail, created_at)
-		VALUES ($1, $2, 'assign_lead_owner', $3, $4, $5, $6, $7, $8, $9)`,
-		runID, wsID, fmt.Sprintf("assign_lead_owner:%s@%s", runID, automationID),
+		INSERT INTO workflow_run (id, handler, idempotency_key, trigger_event, planned, applied, status, detail, created_at)
+		VALUES ($1, 'assign_lead_owner', $2, $3, $4, $5, $6, $7, $8)`,
+		runID, fmt.Sprintf("assign_lead_owner:%s@%s", runID, automationID),
 		ids.NewV7(), plannedJSON, applied, status, detail, at); err != nil {
 		t.Fatalf("seeding workflow_run: %v", err)
 	}

--- a/backend/internal/compose/integration/jobfanout/runnerreap_integration_test.go
+++ b/backend/internal/compose/integration/jobfanout/runnerreap_integration_test.go
@@ -114,11 +114,11 @@ func (re *runnerEnv) seedApproval(t *testing.T) ids.UUID {
 	t.Helper()
 	id := ids.NewV7()
 	if _, err := re.Owner.Exec(context.Background(), `
-		INSERT INTO approval (id, workspace_id, kind, proposed_by, target_entity_type, target_entity_id,
+		INSERT INTO approval (id, kind, proposed_by, target_entity_type, target_entity_id,
 		                      summary, proposed_change, diff_hash, expires_at)
-		VALUES ($1, $2, 'advance_deal', 'agent:test', 'deal', $3,
+		VALUES ($1, 'advance_deal', 'agent:test', 'deal', $2,
 		        'staged for the sweep test', '{}'::jsonb, 'sha256:test', now() + interval '30 days')`,
-		id, re.wsID, ids.NewV7()); err != nil {
+		id, ids.NewV7()); err != nil {
 		t.Fatalf("seeding the pending approval: %v", err)
 	}
 	return id

--- a/backend/internal/compose/integration/overlay/overlay_toolsurface_integration_test.go
+++ b/backend/internal/compose/integration/overlay/overlay_toolsurface_integration_test.go
@@ -231,7 +231,7 @@ func TestOverlayUpdateRecordRefusesAnAgentRatherThanWritingBack(t *testing.T) {
 	// both read tables a mirrored record has no row in.
 	var staged int
 	if err := integration.OwnerConn(t).QueryRow(ctx,
-		`SELECT count(*) FROM approval WHERE workspace_id = $1`, overlayWS).Scan(&staged); err != nil {
+		`SELECT count(*) FROM approval`).Scan(&staged); err != nil {
 		t.Fatalf("counting staged approvals: %v", err)
 	}
 	if staged != 0 {

--- a/backend/internal/compose/integration/webhooks/webhooks_integration_test.go
+++ b/backend/internal/compose/integration/webhooks/webhooks_integration_test.go
@@ -668,11 +668,11 @@ func (we *webhookEnv) seedProduct(t *testing.T, name string) ids.UUID {
 func (we *webhookEnv) insertApproval(t *testing.T, id ids.UUID, targetType *string, targetID *ids.UUID) {
 	t.Helper()
 	we.execInWorkspace(t, `
-		INSERT INTO approval (id, workspace_id, kind, proposed_by, target_entity_type, target_entity_id,
+		INSERT INTO approval (id, kind, proposed_by, target_entity_type, target_entity_id,
 		                      summary, proposed_change, diff_hash, expires_at)
-		VALUES ($1, $2, 'advance_deal', 'agent:test', $3, $4,
+		VALUES ($1, 'advance_deal', 'agent:test', $2, $3,
 		        'staged change', '{}'::jsonb, 'sha256:test', now() + interval '1 day')`,
-		id, we.wsID, targetType, targetID)
+		id, targetType, targetID)
 }
 
 // execInWorkspace runs one statement under a workspace-bound owner tx so

--- a/backend/internal/modules/approvals/bundle_integration_test.go
+++ b/backend/internal/modules/approvals/bundle_integration_test.go
@@ -407,11 +407,11 @@ func TestABundleTooLargeToDecideIsRefusedAndStillHiddenFromOutsiders(t *testing.
 	// Inserted directly: staging one past the cap through the service would
 	// prove nothing this test is about and would cost a transaction each.
 	if _, err := e.owner.Exec(context.Background(), `
-		INSERT INTO approval (workspace_id, kind, proposed_by, on_behalf_of, target_entity_type,
+		INSERT INTO approval (kind, proposed_by, on_behalf_of, target_entity_type,
 		                      target_entity_id, proposed_change, diff_hash, expires_at, bundle_id)
-		SELECT $1, $2, 'human:seed', $3, $4, $5, '{}'::jsonb, 'hash-' || n, now() + interval '1 day', $6
-		FROM generate_series(1, $7) AS n`,
-		e.ws, kindSiteLead, e.rep, tableOrganization, org, bundle, bundleDecisionCap+1); err != nil {
+		SELECT $1, 'human:seed', $2, $3, $4, '{}'::jsonb, 'hash-' || n, now() + interval '1 day', $5
+		FROM generate_series(1, $6) AS n`,
+		kindSiteLead, e.rep, tableOrganization, org, bundle, bundleDecisionCap+1); err != nil {
 		t.Fatalf("seeding an oversized bundle: %v", err)
 	}
 

--- a/backend/internal/modules/approvals/inbox.go
+++ b/backend/internal/modules/approvals/inbox.go
@@ -26,17 +26,12 @@ import (
 
 // row is the store shape of one approval.
 type row struct {
-	ID ids.ApprovalID
-	// WorkspaceID is read back rather than assumed from the bound GUC: the
-	// contract declares it REQUIRED on every approval the API returns, and a
-	// field the wire shape promises is either read from the row or it is a
-	// zero uuid nobody can tell from a real one.
-	WorkspaceID ids.UUID
-	Kind        string
-	Status      string
-	ProposedBy  string
-	OnBehalfOf  *ids.UserID
-	PassportID  *ids.PassportID
+	ID         ids.ApprovalID
+	Kind       string
+	Status     string
+	ProposedBy string
+	OnBehalfOf *ids.UserID
+	PassportID *ids.PassportID
 	// TargetType + TargetID are the polymorphic pointer to the entity the
 	// staging acts on (deal, org, person, lead, activity, …); the id stays
 	// untyped because the pair IS the discriminated reference.
@@ -56,14 +51,14 @@ type row struct {
 	BundleID *ids.UUID
 }
 
-const columns = `id, workspace_id, kind, status, proposed_by, on_behalf_of, passport_id,
+const columns = `id, kind, status, proposed_by, on_behalf_of, passport_id,
 	target_entity_type, target_entity_id, target_version, summary,
 	proposed_change, diff_hash, expires_at, decided_by, decided_at, consumed_at, created_at,
 	bundle_id`
 
 func scan(r pgx.Row) (row, error) {
 	var a row
-	err := r.Scan(&a.ID, &a.WorkspaceID, &a.Kind, &a.Status, &a.ProposedBy, &a.OnBehalfOf, &a.PassportID,
+	err := r.Scan(&a.ID, &a.Kind, &a.Status, &a.ProposedBy, &a.OnBehalfOf, &a.PassportID,
 		&a.TargetType, &a.TargetID, &a.TargetVersion, &a.Summary,
 		&a.ProposedChange, &a.DiffHash, &a.ExpiresAt, &a.DecidedBy, &a.DecidedAt, &a.ConsumedAt, &a.CreatedAt,
 		&a.BundleID)

--- a/backend/internal/modules/approvals/stageunlessdeclined_integration_test.go
+++ b/backend/internal/modules/approvals/stageunlessdeclined_integration_test.go
@@ -159,11 +159,11 @@ func TestStageUnlessDeclinedWaitsForACompetingPassBeforeReading(t *testing.T) {
 
 	// Now the competing pass finishes: the offer exists and has been refused.
 	if _, err := blocker.Exec(ctx, `
-		INSERT INTO approval (workspace_id, kind, status, proposed_change, diff_hash,
+		INSERT INTO approval (kind, status, proposed_change, diff_hash,
 		                      target_entity_type, target_entity_id, summary, proposed_by,
 		                      decided_by, decided_at, expires_at)
-		VALUES ($1, $2, 'rejected', $3, $4, $5, $6, $7, $8, $9, now(), now() + interval '1 day')`,
-		e.ws, in.Kind, in.ProposedChange, in.DiffHash, in.TargetType, in.TargetID,
+		VALUES ($1, 'rejected', $2, $3, $4, $5, $6, $7, $8, now(), now() + interval '1 day')`,
+		in.Kind, in.ProposedChange, in.DiffHash, in.TargetType, in.TargetID,
 		in.Summary, "human:"+e.rep.String(), e.rep); err != nil {
 		t.Fatalf("writing the refused offer: %v", err)
 	}
@@ -179,8 +179,8 @@ func TestStageUnlessDeclinedWaitsForACompetingPassBeforeReading(t *testing.T) {
 	}
 	var offers int
 	if err := e.owner.QueryRow(context.Background(),
-		`SELECT count(*) FROM approval WHERE workspace_id = $1 AND target_entity_id = $2`,
-		e.ws, target).Scan(&offers); err != nil {
+		`SELECT count(*) FROM approval WHERE target_entity_id = $1`,
+		target).Scan(&offers); err != nil {
 		t.Fatal(err)
 	}
 	if offers != 1 {
@@ -263,8 +263,8 @@ func TestStageUnlessDeclinedStagesWhenNothingWasRefused(t *testing.T) {
 		}
 		var offers int
 		if err := e.owner.QueryRow(context.Background(),
-			`SELECT count(*) FROM approval WHERE workspace_id = $1 AND target_entity_id = $2`,
-			e.ws, target).Scan(&offers); err != nil {
+			`SELECT count(*) FROM approval WHERE target_entity_id = $1`,
+			target).Scan(&offers); err != nil {
 			t.Fatal(err)
 		}
 		if offers != 1 {
@@ -277,8 +277,8 @@ func TestStageUnlessDeclinedStagesWhenNothingWasRefused(t *testing.T) {
 		// nothing about whether the same proposal may be made again — and for a
 		// nightly stager it usually means the work simply came round again.
 		if _, err := e.owner.Exec(context.Background(),
-			`UPDATE approval SET status = 'approved', decided_by = $2, decided_at = now()
-			  WHERE workspace_id = $1 AND target_entity_id = $3`, e.ws, e.rep, target); err != nil {
+			`UPDATE approval SET status = 'approved', decided_by = $1, decided_at = now()
+			  WHERE target_entity_id = $2`, e.rep, target); err != nil {
 			t.Fatal(err)
 		}
 		_, staged, err := e.svc.StageUnlessDeclined(e.as(), in)
@@ -314,8 +314,8 @@ func TestStageUnlessDeclinedRefusesWithoutJoinPending(t *testing.T) {
 		t.Fatalf("first staging: staged=%v err=%v", staged, err)
 	}
 	if _, err := e.owner.Exec(context.Background(),
-		`UPDATE approval SET status = 'rejected', decided_by = $2, decided_at = now()
-		  WHERE workspace_id = $1 AND target_entity_id = $3`, e.ws, e.rep, target); err != nil {
+		`UPDATE approval SET status = 'rejected', decided_by = $1, decided_at = now()
+		  WHERE target_entity_id = $2`, e.rep, target); err != nil {
 		t.Fatal(err)
 	}
 	_, staged, err := e.svc.StageUnlessDeclined(e.as(), in)

--- a/backend/internal/modules/approvals/staging.go
+++ b/backend/internal/modules/approvals/staging.go
@@ -211,9 +211,9 @@ func (s *Service) stageOrJoinPendingInTx(ctx context.Context, tx pgx.Tx, in Stag
 	// re-evaluated, so a settled row is simply not found and the re-proposal
 	// creates the live member it meant to.
 	err := tx.QueryRow(ctx, `SELECT id FROM approval
-			WHERE workspace_id = $1 AND kind = $2 AND target_entity_id IS NOT DISTINCT FROM $3 AND diff_hash = $4
+			WHERE kind = $1 AND target_entity_id IS NOT DISTINCT FROM $2 AND diff_hash = $3
 			  AND status = 'pending' AND expires_at > now()
-			ORDER BY created_at DESC LIMIT 1 FOR UPDATE`, wsID, in.Kind, nullUUID(in.TargetID), in.DiffHash).Scan(&id)
+			ORDER BY created_at DESC LIMIT 1 FOR UPDATE`, in.Kind, nullUUID(in.TargetID), in.DiffHash).Scan(&id)
 	switch {
 	case err == nil:
 		if err := s.rebundleJoinedInTx(ctx, tx, in, id); err != nil {
@@ -227,7 +227,7 @@ func (s *Service) stageOrJoinPendingInTx(ctx context.Context, tx pgx.Tx, in Stag
 		return ids.ApprovalID{}, fmt.Errorf("find pending approval identity: %w", err)
 	}
 	if len(in.Identity) > 0 {
-		if err := s.supersedePendingInTx(ctx, tx, wsID, in, id); err != nil {
+		if err := s.supersedePendingInTx(ctx, tx, in, id); err != nil {
 			return ids.ApprovalID{}, err
 		}
 	}
@@ -290,7 +290,7 @@ func (s *Service) rebundleJoinedInTx(ctx context.Context, tx pgx.Tx, in StageInp
 // inbox reads the row as expired on every surface (effectiveStatus, decide,
 // redeem). The status CHECK and the public ApprovalStatus enum stay closed; the
 // audit row carries the why and the survivor.
-func (s *Service) supersedePendingInTx(ctx context.Context, tx pgx.Tx, wsID ids.UUID, in StageInput, survivor ids.ApprovalID) error {
+func (s *Service) supersedePendingInTx(ctx context.Context, tx pgx.Tx, in StageInput, survivor ids.ApprovalID) error {
 	p, ok := principal.Actor(ctx)
 	if !ok {
 		return errors.New("crmapprovals: no actor bound to context")
@@ -300,7 +300,7 @@ func (s *Service) supersedePendingInTx(ctx context.Context, tx pgx.Tx, wsID ids.
 	// which is nobody's order in particular — and a bundle decision walking the
 	// same rows in (created_at, id) is precisely the transaction on the other
 	// side of that. See lockOrder.
-	superseded, err := lockPendingUnderIdentity(ctx, tx, wsID, in, survivor)
+	superseded, err := lockPendingUnderIdentity(ctx, tx, in, survivor)
 	if err != nil {
 		return err
 	}
@@ -332,14 +332,14 @@ func (s *Service) supersedePendingInTx(ctx context.Context, tx pgx.Tx, wsID ids.
 // Split from the write because the order is the point: the predicate is the
 // one that used to sit on the UPDATE itself, and reading it under lockOrder
 // first is what stops this transaction taking those locks in scan order.
-func lockPendingUnderIdentity(ctx context.Context, tx pgx.Tx, wsID ids.UUID, in StageInput, survivor ids.ApprovalID) ([]ids.UUID, error) {
+func lockPendingUnderIdentity(ctx context.Context, tx pgx.Tx, in StageInput, survivor ids.ApprovalID) ([]ids.UUID, error) {
 	rows, err := tx.Query(ctx, `
 		SELECT id FROM approval
-		 WHERE workspace_id = $1 AND kind = $2 AND target_entity_id IS NOT DISTINCT FROM $3
+		 WHERE kind = $1 AND target_entity_id IS NOT DISTINCT FROM $2
 		   AND status = 'pending' AND expires_at > now()
-		   AND id <> $4 AND proposed_change @> $5
+		   AND id <> $3 AND proposed_change @> $4
 		 `+lockOrder+`
-		 FOR UPDATE`, wsID, in.Kind, nullUUID(in.TargetID), survivor, in.Identity)
+		 FOR UPDATE`, in.Kind, nullUUID(in.TargetID), survivor, in.Identity)
 	if err != nil {
 		return nil, fmt.Errorf("lock the proposals this one supersedes: %w", err)
 	}
@@ -426,7 +426,6 @@ func (s *Service) insertProposalInTx(ctx context.Context, tx pgx.Tx, in StageInp
 	if pinned {
 		in.TargetVersion = &current
 	}
-	wsID, _ := principal.WorkspaceID(ctx)
 	id := ids.New[ids.ApprovalKind]()
 	// Compute ONE absolute expiry and use it for BOTH the persisted row and
 	// the payload — deriving the row's expires_at from the DB now() while the
@@ -434,11 +433,11 @@ func (s *Service) insertProposalInTx(ctx context.Context, tx pgx.Tx, in StageInp
 	// from what the approval row actually stored.
 	expiresAt := s.now().UTC().Add(stagingTTL)
 	if _, err := tx.Exec(ctx,
-		`INSERT INTO approval (id, workspace_id, kind, proposed_by, on_behalf_of, passport_id,
+		`INSERT INTO approval (id, kind, proposed_by, on_behalf_of, passport_id,
 			                       target_entity_type, target_entity_id, target_version,
 			                       summary, proposed_change, diff_hash, expires_at, bundle_id)
-			 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)`,
-		id, wsID, in.Kind, p.ID, nullUUID(p.OnBehalfOf), nullUUID(p.PassportID),
+			 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)`,
+		id, in.Kind, p.ID, nullUUID(p.OnBehalfOf), nullUUID(p.PassportID),
 		nullStr(in.TargetType), nullUUID(in.TargetID), in.TargetVersion,
 		nullStr(in.Summary), in.ProposedChange, in.DiffHash, expiresAt,
 		nullUUID(in.BundleID)); err != nil {

--- a/backend/internal/modules/approvals/stagingidentity.go
+++ b/backend/internal/modules/approvals/stagingidentity.go
@@ -75,18 +75,14 @@ const lockOrder = `ORDER BY created_at, id`
 // not held by this. Serializing the stagers of one group is what would close
 // that, at the cost of running them one at a time, and it is not closed here.
 func (s *Service) LockPendingGroupInTx(ctx context.Context, tx pgx.Tx, targetID ids.UUID, kinds ...string) error {
-	wsID, ok := principal.WorkspaceID(ctx)
-	if !ok {
-		return errors.New("crmapprovals: no workspace bound to context")
-	}
 	if len(kinds) == 0 {
 		return errors.New("crmapprovals: a group pre-lock that names no kind locks nothing")
 	}
 	if _, err := tx.Exec(ctx, `SELECT id FROM approval
-		 WHERE workspace_id = $1 AND kind = ANY($2) AND target_entity_id IS NOT DISTINCT FROM $3
+		 WHERE kind = ANY($1) AND target_entity_id IS NOT DISTINCT FROM $2
 		   AND status = 'pending' AND expires_at > now()
 		 `+lockOrder+`
-		 FOR UPDATE`, wsID, kinds, nullUUID(targetID)); err != nil {
+		 FOR UPDATE`, kinds, nullUUID(targetID)); err != nil {
 		return fmt.Errorf("lock the pending proposals this act will re-propose: %w", err)
 	}
 	return nil
@@ -214,14 +210,14 @@ func (s *Service) WithdrawInTx(ctx context.Context, tx pgx.Tx, id ids.ApprovalID
 // decision the human actually made: this record, this proposed value.
 func declinedProbeSQL(byIdentity bool) string {
 	const prefix = `SELECT status FROM approval
-		 WHERE workspace_id = $1 AND kind = $2 AND target_entity_id IS NOT DISTINCT FROM $3 AND `
+		 WHERE kind = $1 AND target_entity_id IS NOT DISTINCT FROM $2 AND `
 	const suffix = `
 		 ` + lockOrder + `
 		 FOR UPDATE`
 	if byIdentity {
-		return prefix + `proposed_change @> $4` + suffix
+		return prefix + `proposed_change @> $3` + suffix
 	}
-	return prefix + `diff_hash = $4` + suffix
+	return prefix + `diff_hash = $3` + suffix
 }
 
 // RejectedChangesFor returns the proposed_change of every REJECTED proposal of
@@ -345,7 +341,7 @@ func (s *Service) StageUnlessDeclined(ctx context.Context, in StageInput) (ids.A
 		if byIdentity {
 			discriminator = in.Identity
 		}
-		rows, err := tx.Query(ctx, declinedProbeSQL(byIdentity), wsID, in.Kind, nullUUID(in.TargetID), discriminator)
+		rows, err := tx.Query(ctx, declinedProbeSQL(byIdentity), in.Kind, nullUUID(in.TargetID), discriminator)
 		if err != nil {
 			return fmt.Errorf("lock the prior offers for this proposal: %w", err)
 		}

--- a/backend/internal/modules/approvals/token_jws.go
+++ b/backend/internal/modules/approvals/token_jws.go
@@ -117,7 +117,7 @@ func (s *Service) VerifyApprovalToken(ctx context.Context, token string) (Approv
 	var publicKey []byte
 	err = s.db.Tx(ctx, func(tx pgx.Tx) error {
 		return tx.QueryRow(ctx,
-			`SELECT public_key FROM workspace_signing_key WHERE kid = $1 AND retired_at IS NULL`,
+			`SELECT public_key FROM signing_key WHERE kid = $1 AND retired_at IS NULL`,
 			header.Kid).Scan(&publicKey)
 	})
 	if errors.Is(err, pgx.ErrNoRows) {
@@ -147,7 +147,7 @@ func signingKey(ctx context.Context, tx pgx.Tx) (string, ed25519.PrivateKey, err
 	var kid string
 	var private []byte
 	err := tx.QueryRow(ctx, `
-		SELECT kid, private_key FROM workspace_signing_key
+		SELECT kid, private_key FROM signing_key
 		WHERE retired_at IS NULL ORDER BY created_at DESC LIMIT 1`).Scan(&kid, &private)
 	if err == nil {
 		return kid, ed25519.PrivateKey(private), nil
@@ -161,8 +161,8 @@ func signingKey(ctx context.Context, tx pgx.Tx) (string, ed25519.PrivateKey, err
 	}
 	kid = ids.NewV7().String()
 	if _, err := tx.Exec(ctx, `
-		INSERT INTO workspace_signing_key (workspace_id, kid, private_key, public_key)
-		VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, $2, $3)`,
+		INSERT INTO signing_key (kid, private_key, public_key)
+		VALUES ($1, $2, $3)`,
 		kid, []byte(fresh), []byte(public)); err != nil {
 		return "", nil, err
 	}

--- a/backend/internal/modules/approvals/wirecompleteness_test.go
+++ b/backend/internal/modules/approvals/wirecompleteness_test.go
@@ -96,7 +96,6 @@ func fullyPopulatedRow(t *testing.T, now time.Time) row {
 	}
 	return row{
 		ID:             ids.New[ids.ApprovalKind](),
-		WorkspaceID:    ids.NewV7(),
 		Kind:           "orgname",
 		Status:         statusPending,
 		ProposedBy:     "agent:test",

--- a/backend/internal/modules/automation/autofixture_integration_test.go
+++ b/backend/internal/modules/automation/autofixture_integration_test.go
@@ -154,9 +154,9 @@ func (fx *autoFixture) seedRun(t *testing.T, automationID ids.AutomationID, key,
 	t.Helper()
 	id := ids.NewV7()
 	fx.exec(t, `
-		INSERT INTO workflow_run (id, workspace_id, handler, idempotency_key, trigger_event, planned, status, detail, created_at)
-		VALUES ($1, $2, $3, $4, $5, '[]'::jsonb, $6, $7, $8)`,
-		id, fx.ws, key, fmt.Sprintf("%s:%s@%s", key, id, automationID), ids.NewV7(), status, detail, at)
+		INSERT INTO workflow_run (id, handler, idempotency_key, trigger_event, planned, status, detail, created_at)
+		VALUES ($1, $2, $3, $4, '[]'::jsonb, $5, $6, $7)`,
+		id, key, fmt.Sprintf("%s:%s@%s", key, id, automationID), ids.NewV7(), status, detail, at)
 }
 
 // scriptedWorkflow lets each engine test case pin one phase's behavior.
@@ -213,7 +213,7 @@ type recordedRun struct {
 func (fx *autoFixture) runsByHandler(t *testing.T) map[string]recordedRun {
 	t.Helper()
 	rows, err := fx.owner.Query(context.Background(),
-		`SELECT handler, status, detail, planned::text FROM workflow_run WHERE workspace_id = $1`, fx.ws)
+		`SELECT handler, status, detail, planned::text FROM workflow_run`)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/backend/internal/modules/automation/automationpreview_integration_test.go
+++ b/backend/internal/modules/automation/automationpreview_integration_test.go
@@ -118,7 +118,7 @@ func TestPreviewMatchesCurrentRecordsWithoutApplying(t *testing.T) {
 	if n := fx.count(t, `SELECT count(*) FROM activity WHERE workspace_id = $1`, fx.ws); n != 0 {
 		t.Fatalf("preview minted %d activities — it must never apply the plan", n)
 	}
-	if n := fx.count(t, `SELECT count(*) FROM workflow_run WHERE workspace_id = $1`, fx.ws); n != 0 {
+	if n := fx.count(t, `SELECT count(*) FROM workflow_run`); n != 0 {
 		t.Fatalf("preview recorded %d runs — a dry-run is not a firing", n)
 	}
 }

--- a/backend/internal/modules/automation/engine_run.go
+++ b/backend/internal/modules/automation/engine_run.go
@@ -208,8 +208,8 @@ func (e *WorkflowEngine) claimRun(ctx context.Context, h workflow.Handler, ev wo
 	claimed := false
 	err := e.db.Tx(ctx, func(tx pgx.Tx) error {
 		tag, err := tx.Exec(ctx, `
-			INSERT INTO workflow_run (workspace_id, handler, idempotency_key, trigger_event, planned, status, detail)
-			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, $2, $3, $4, $5, $6)
+			INSERT INTO workflow_run (handler, idempotency_key, trigger_event, planned, status, detail)
+			VALUES ($1, $2, $3, $4, $5, $6)
 			ON CONFLICT (handler, idempotency_key) DO NOTHING`,
 			h.Spec().Name, runKey(h, ev), ev.ID, planned, status, detail)
 		if err != nil {

--- a/backend/internal/modules/automation/handlers_clock.go
+++ b/backend/internal/modules/automation/handlers_clock.go
@@ -186,7 +186,7 @@ func anchorReminderTaskEffect(ev workflow.Event, subject string) (workflow.Effec
 // redundant pass), and only a NEW anchor re-arms it.
 //
 // The entity is part of the key because the claim is UNIQUE on
-// (workspace_id, handler, idempotency_key) alone. Two records can share
+// (handler, idempotency_key) alone. Two records can share
 // one anchor instant — one captured mail linked to a person and to their
 // employer gives both the identical last touch — and an anchor-only key
 // would let the first of them claim the row while the second silently

--- a/backend/internal/modules/automation/handlers_clock_integration_test.go
+++ b/backend/internal/modules/automation/handlers_clock_integration_test.go
@@ -200,7 +200,7 @@ func TestRenewalReminderScanIsANoOpWhenUnconfigured(t *testing.T) {
 		t.Fatalf("ScanWorkspace: %v", err)
 	}
 
-	n := fx.count(t, `SELECT count(*) FROM workflow_run WHERE workspace_id = $1 AND handler = $2`, fx.ws, renewalReminderName)
+	n := fx.count(t, `SELECT count(*) FROM workflow_run WHERE handler = $1`, renewalReminderName)
 	if n != 0 {
 		t.Errorf("workflow_run rows for renewal_reminder = %d, want 0 — its candidate source is deferred, a scan pass must never fire it", n)
 	}

--- a/backend/internal/modules/automation/occurrence_integration_test.go
+++ b/backend/internal/modules/automation/occurrence_integration_test.go
@@ -54,8 +54,8 @@ func runsForKey(t *testing.T, fx *autoFixture, handler, key string) []clockRun {
 	t.Helper()
 	rows, err := fx.owner.Query(context.Background(), `
 		SELECT status, trigger_event FROM workflow_run
-		WHERE workspace_id = $1 AND handler = $2 AND idempotency_key = $3
-		ORDER BY created_at`, fx.ws, handler, key)
+		WHERE handler = $1 AND idempotency_key = $2
+		ORDER BY created_at`, handler, key)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/backend/migrations/core/0232_approvals_workflowrun_drop_workspace.down.sql
+++ b/backend/migrations/core/0232_approvals_workflowrun_drop_workspace.down.sql
@@ -1,0 +1,43 @@
+-- Reverse of 0232: the table takes its old name back and the three carry the
+-- tenant column again.
+--
+-- The backfill reads `workspace` because there is exactly one to read: 0217's
+-- pre-flight refuses to run against a database holding more than one live
+-- workspace, and ADR-0061 §3 has the API refusing to start in that state. If
+-- `workspace` is empty and a table is not, SET NOT NULL fails and the rollback
+-- stops — the honest outcome, since no value this migration could write would
+-- be true.
+
+ALTER INDEX signing_key_pkey RENAME TO workspace_signing_key_pkey;
+ALTER TABLE signing_key RENAME TO workspace_signing_key;
+
+ALTER TABLE approval ADD COLUMN workspace_id uuid;
+ALTER TABLE workflow_run ADD COLUMN workspace_id uuid;
+ALTER TABLE workspace_signing_key ADD COLUMN workspace_id uuid;
+
+DO $$
+DECLARE ws uuid := (SELECT id FROM workspace ORDER BY created_at LIMIT 1);
+BEGIN
+  UPDATE approval SET workspace_id = ws;
+  UPDATE workflow_run SET workspace_id = ws;
+  UPDATE workspace_signing_key SET workspace_id = ws;
+END $$;
+
+ALTER TABLE approval ALTER COLUMN workspace_id SET NOT NULL;
+ALTER TABLE workflow_run ALTER COLUMN workspace_id SET NOT NULL;
+ALTER TABLE workspace_signing_key ALTER COLUMN workspace_id SET NOT NULL;
+
+ALTER TABLE approval ADD CONSTRAINT approval_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE workflow_run ADD CONSTRAINT workflow_run_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE workspace_signing_key ADD CONSTRAINT workspace_signing_key_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+
+ALTER TABLE approval ADD CONSTRAINT uq_approval_ws_id UNIQUE (id);
+
+DROP INDEX idx_approval_bundle;
+CREATE INDEX idx_approval_bundle ON approval (workspace_id, bundle_id, created_at) WHERE bundle_id IS NOT NULL;
+
+DROP INDEX idx_approval_inbox;
+CREATE INDEX idx_approval_inbox ON approval (workspace_id, created_at) WHERE status = 'pending';

--- a/backend/migrations/core/0232_approvals_workflowrun_drop_workspace.up.sql
+++ b/backend/migrations/core/0232_approvals_workflowrun_drop_workspace.up.sql
@@ -1,0 +1,33 @@
+-- 0232: the approval spine drops the tenant column, and the signing-key table
+-- drops it from its NAME (ADR-0091 §8 phase D, §1).
+--
+-- Three tables. `automation` is deliberately not among them: migrations 0148
+-- and 0149 are a one-off reminder repair whose SQL reads
+-- automation.workspace_id, and two integration suites replay that SQL against
+-- the head schema to prove the repair did what it claimed. Dropping the column
+-- here would retire eleven tests as a side effect of a column drop. It goes
+-- with `activity`, whose column those same migrations also read.
+--
+-- `workspace_signing_key` becomes `signing_key`: ADR-0091 §1
+-- names it as one of the two tables whose name carries the boundary, and a
+-- table called workspace_* with no workspace column would be the worst of both
+-- — the reader still has to ask which workspace, and the schema no longer
+-- answers. Its primary key is `kid`, so nothing else moves with the rename.
+--
+-- `idx_approval_target` is untouched on purpose: it already leads with
+-- target_entity_id, which is the lookup, and the tenant never prefixed it.
+
+DROP INDEX idx_approval_bundle;
+CREATE INDEX idx_approval_bundle ON approval (bundle_id, created_at) WHERE bundle_id IS NOT NULL;
+
+DROP INDEX idx_approval_inbox;
+CREATE INDEX idx_approval_inbox ON approval (created_at) WHERE status = 'pending';
+
+ALTER TABLE approval DROP CONSTRAINT uq_approval_ws_id;
+
+ALTER TABLE approval DROP COLUMN workspace_id;
+ALTER TABLE workflow_run DROP COLUMN workspace_id;
+ALTER TABLE workspace_signing_key DROP COLUMN workspace_id;
+
+ALTER TABLE workspace_signing_key RENAME TO signing_key;
+ALTER INDEX workspace_signing_key_pkey RENAME TO signing_key_pkey;

--- a/backend/tableownership_test.go
+++ b/backend/tableownership_test.go
@@ -138,9 +138,9 @@ var tableOwners = map[string]string{
 	"linkedin_connection": "internal/modules/people",
 	"attachment":          "internal/modules/activities",
 	"booking_page":        "internal/modules/activities",
-	// approvals (workspace_signing_key backs the approval-token JWS)
-	"approval":              "internal/modules/approvals",
-	"workspace_signing_key": "internal/modules/approvals",
+	// approvals (signing_key backs the approval-token JWS)
+	"approval":    "internal/modules/approvals",
+	"signing_key": "internal/modules/approvals",
 	// consent (the DSR case queue and the retention-policy catalog are
 	// consent's; the engines that EXECUTE them live in privacy)
 	"consent_purpose":   "internal/modules/consent",


### PR DESCRIPTION
Phase D, sixth slice. Three tables — `approval`, `workflow_run`, `workspace_signing_key` — two indexes, and the redundant `uq_approval_ws_id`.

## The rename is part of the ADR, not a flourish

ADR-0091 §1 names `workspace_signing_key` as one of the two tables whose **name** carries the boundary. A table called `workspace_*` with no workspace column is the worst of both: the reader still has to ask which workspace, and the schema no longer answers. Its primary key is `kid`, so nothing moves with the rename, and the down puts both the name and the index back.

## Parameters go with the predicates

`supersedePendingInTx`, `lockPendingUnderIdentity` and the declined-offer probe each took a workspace to spell a predicate that no longer exists, so the parameter goes rather than being threaded and ignored.

`lockProposalIdentity` **keeps** its workspace. That one is an advisory **lock key**, not a column — a key with one more component is still a key, and rewriting it here would change which callers serialize against each other for no gain.

## `automation` was drafted into this slice and taken back out

Migrations 0148 and 0149 are a one-off reminder repair whose SQL reads `automation.workspace_id`, and two integration suites replay that SQL against the head schema to prove the repair did what it claimed. Dropping the column here would **retire eleven tests as a side effect of a column drop**. Whether to keep migration-replay coverage at all is a real question — the replays can only get harder as phase D proceeds — but it deserves its own change rather than being settled silently. `automation` goes with `activity`, whose column those same migrations also read.

## Verification

- Lane applied to an empty database; the down restores the three columns with their foreign keys, the unique, both wide indexes, and the old table name.
- `make check-backend` green.
- `make test-integration`: **OK, 0 skips, 39 packages.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drops `workspace_id` from `approval` and `workflow_run`, and renames `workspace_signing_key` to `signing_key` while removing its tenant column. Old behavior scoped approvals/workflow runs and queries by workspace; new behavior treats them as global and removes workspace predicates. This aligns with ADR-0091 and avoids a misleading `workspace_*` table name without workspace scope.

- Migrates via 0232:
  - Drops `approval.workspace_id`, `workflow_run.workspace_id`, and `workspace_signing_key.workspace_id`; renames `workspace_signing_key` → `signing_key`.
  - Recreates `idx_approval_bundle` and `idx_approval_inbox` without the workspace prefix; drops redundant `uq_approval_ws_id`.
  - Down migration restores columns, FKs, unique/indexes, and the old table name; it backfills `workspace_id` from the single row in `workspace`. Roll back only if exactly one workspace exists.

- Code updates:
  - Approvals remove workspace from predicates and parameters (`supersedePendingInTx`, `lockPendingUnderIdentity`, declined-offer probe). The advisory lock key that includes workspace remains unchanged.
  - Approval token JWS now reads/writes keys from `signing_key`.
  - Automation reads/writes `workflow_run` without `workspace_id`. The `automation` and `activity` tables keep their workspace columns to preserve migration-replay tests.

<sup>Written for commit 42a1dfdfbac15b86acda0b60f72abd0d20b0319a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1171?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified approval and workflow-run data handling by removing redundant workspace-specific associations.
  * Centralized approval-token signing-key storage for consistent access across contexts.
  * Updated idempotency and approval matching to use their core identifiers directly.

* **Tests**
  * Updated integration coverage and fixtures to reflect the streamlined data model.
  * Expanded validation to check records across the full database where appropriate.

* **Documentation**
  * Clarified idempotency uniqueness rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->