### PR TITLE
fix(draftcheck): an invented call is refused at every band, not only after a gap

### DIFF
--- a/backend/internal/compose/draftcheck/draftcheck.go
+++ b/backend/internal/compose/draftcheck/draftcheck.go
@@ -174,7 +174,11 @@ func Reasoning(labels []string, lang textlang.Lang, band convstate.Band) []Findi
 				})
 			}
 		}
-		findings = append(findings, Body(label, lang, band)...)
+		// A chip is checked as an unthreaded body whatever the draft beside it
+		// is. It is the product's own claim about what it wrote from, so a call
+		// named there is asserted by us rather than echoed from the
+		// counterparty's message — the reply surface's ground does not reach it.
+		findings = append(findings, Body(label, lang, band, false)...)
 	}
 	return findings
 }
@@ -231,27 +235,20 @@ var resolvedEvent = map[textlang.Lang][]string{
 
 // Body reads a draft body against the state it was written in.
 //
-// Two lists run at every band and the rest are band-gated, and the split is the
+// Two lists ignore the band and the rest are gated by it, and the split is the
 // point. "As discussed" is a claim about the recipient's MEMORY, which a live
 // exchange supports and eight months of silence does not — so it is gated. A
 // call that never happened, or a sentence the recipient never said, is a claim
-// about the WORLD, and no band makes it true.
-// firstMatch reports the first phrase of a list the text carries, as one
-// finding or none.
+// about the WORLD, and no length of silence makes it true or false.
 //
-// One rather than all, because the finding is fed back to the model as a
-// correction and a list of six ways it said the same wrong thing is not six
-// corrections. The first is enough to name what to stop doing.
-func firstMatch(lowered string, phrases []string, rule, why string) []Finding {
-	for _, phrase := range phrases {
-		if contains(lowered, phrase) {
-			return []Finding{{Rule: rule, Phrase: phrase, Why: why}}
-		}
-	}
-	return nil
-}
-
-func Body(body string, lang textlang.Lang, band convstate.Band) []Finding {
+// threaded is what those two ARE gated on instead, and it is a different
+// question from the band. A reply is written from the counterparty's own
+// message: if they wrote "as I mentioned on our call", a reply that answers the
+// call they named is grounded in text the drafter can actually see. A message
+// opening a new conversation has no such ground — whatever it says about a
+// call, it invented. So the world-claim rules run on unthreaded drafts, where
+// the claim cannot be sourced, and stand down on replies, where it can.
+func Body(body string, lang textlang.Lang, band convstate.Band, threaded bool) []Finding {
 	lowered := strings.ToLower(body)
 	var findings []Finding
 
@@ -268,15 +265,17 @@ func Body(body string, lang textlang.Lang, band convstate.Band) []Finding {
 		}
 	}
 
-	findings = append(findings, firstMatch(lowered, spokenExchange[lang],
-		"invented-conversation",
-		"nothing in the input says a call or meeting took place — write from "+
-			"the messages on the record, and never claim a conversation")...)
+	if !threaded {
+		findings = append(findings, firstMatch(lowered, spokenExchange[lang],
+			"invented-conversation",
+			"this message opens a new conversation, so nothing in the input says a "+
+				"call or meeting took place — write from the messages on the record")...)
 
-	findings = append(findings, firstMatch(lowered, attributedClaim[lang],
-		"attributed-claim",
-		"the input says what a message was about, never who wrote it — "+
-			"name the topic instead of attributing it to the recipient")...)
+		findings = append(findings, firstMatch(lowered, attributedClaim[lang],
+			"attributed-claim",
+			"the input says what a message was about, never who wrote it — "+
+				"name the topic instead of attributing it to the recipient")...)
+	}
 
 	if lang == textlang.German && mixedRegister(body) {
 		findings = append(findings, Finding{
@@ -286,6 +285,15 @@ func Body(body string, lang textlang.Lang, band convstate.Band) []Finding {
 				"familiarly in another — pick the one the correspondence uses and hold it",
 		})
 	}
+
+	return append(findings, bandGated(lowered, lang, band)...)
+}
+
+// bandGated are the rules the length of the silence decides — every one of them
+// a claim about what the recipient still has in mind, which a live exchange
+// supports and a long gap does not.
+func bandGated(lowered string, lang textlang.Lang, band convstate.Band) []Finding {
+	var findings []Finding
 
 	if band == convstate.BandNone {
 		for _, phrase := range invention[lang] {
@@ -403,4 +411,19 @@ func boundary(text string, i int) bool {
 	}
 	r := rune(text[i])
 	return !unicode.IsLetter(r) && !unicode.IsDigit(r) && r != '\''
+}
+
+// firstMatch reports the first phrase of a list the text carries, as one
+// finding or none.
+//
+// One rather than all, because the finding is fed back to the model as a
+// correction and a list of six ways it said the same wrong thing is not six
+// corrections. The first is enough to name what to stop doing.
+func firstMatch(lowered string, phrases []string, rule, why string) []Finding {
+	for _, phrase := range phrases {
+		if contains(lowered, phrase) {
+			return []Finding{{Rule: rule, Phrase: phrase, Why: why}}
+		}
+	}
+	return nil
 }

--- a/backend/internal/compose/draftcheck/draftcheck.go
+++ b/backend/internal/compose/draftcheck/draftcheck.go
@@ -231,10 +231,26 @@ var resolvedEvent = map[textlang.Lang][]string{
 
 // Body reads a draft body against the state it was written in.
 //
-// Nothing is checked at band fresh except the pleasantries: a live exchange may
-// legitimately say "as discussed", because the discussion is what both sides
-// are still holding. The same words at weeks or months are a claim about the
-// recipient's memory that nobody made.
+// Two lists run at every band and the rest are band-gated, and the split is the
+// point. "As discussed" is a claim about the recipient's MEMORY, which a live
+// exchange supports and eight months of silence does not — so it is gated. A
+// call that never happened, or a sentence the recipient never said, is a claim
+// about the WORLD, and no band makes it true.
+// firstMatch reports the first phrase of a list the text carries, as one
+// finding or none.
+//
+// One rather than all, because the finding is fed back to the model as a
+// correction and a list of six ways it said the same wrong thing is not six
+// corrections. The first is enough to name what to stop doing.
+func firstMatch(lowered string, phrases []string, rule, why string) []Finding {
+	for _, phrase := range phrases {
+		if contains(lowered, phrase) {
+			return []Finding{{Rule: rule, Phrase: phrase, Why: why}}
+		}
+	}
+	return nil
+}
+
 func Body(body string, lang textlang.Lang, band convstate.Band) []Finding {
 	lowered := strings.ToLower(body)
 	var findings []Finding
@@ -251,6 +267,16 @@ func Body(body string, lang textlang.Lang, band convstate.Band) []Finding {
 			})
 		}
 	}
+
+	findings = append(findings, firstMatch(lowered, spokenExchange[lang],
+		"invented-conversation",
+		"nothing in the input says a call or meeting took place — write from "+
+			"the messages on the record, and never claim a conversation")...)
+
+	findings = append(findings, firstMatch(lowered, attributedClaim[lang],
+		"attributed-claim",
+		"the input says what a message was about, never who wrote it — "+
+			"name the topic instead of attributing it to the recipient")...)
 
 	if lang == textlang.German && mixedRegister(body) {
 		findings = append(findings, Finding{
@@ -377,110 +403,4 @@ func boundary(text string, i int) bool {
 	}
 	r := rune(text[i])
 	return !unicode.IsLetter(r) && !unicode.IsDigit(r) && r != '\''
-}
-
-// SubjectMaxRunes is where a subject line stops being read.
-//
-// Mail clients truncate around here, and a subject that needs more than this
-// is a first sentence rather than a label. The number is the conventional one
-// rather than any client's exact cut, because every client's differs and the
-// point is to stay short of all of them.
-const SubjectMaxRunes = 70
-
-// replyPrefixes are the ways a client marks a subject as a reply, in the
-// languages this product writes.
-var replyPrefixes = []string{"re:", "aw:", "fwd:", "wg:", "antw:"}
-
-// Subject reads a draft's subject line against the correspondence it belongs to.
-//
-// Separate from Body because a subject fails differently: it is one line, it is
-// read before anything else, and its worst failure is a claim rather than a
-// phrase. "Re:" says a thread exists. A follow-up subject says there was a
-// previous message. Both are checkable facts the envelope already holds, which
-// is why they are refused here rather than explained in a prompt.
-func Subject(subject string, lang textlang.Lang, band convstate.Band, threaded bool) []Finding {
-	trimmed := strings.TrimSpace(subject)
-	lowered := strings.ToLower(trimmed)
-	var findings []Finding
-
-	if trimmed == "" {
-		return []Finding{{
-			Rule:   "empty-subject",
-			Phrase: "",
-			Why:    "a message with no subject line arrives looking like spam",
-		}}
-	}
-
-	for _, prefix := range replyPrefixes {
-		if !strings.HasPrefix(lowered, prefix) {
-			continue
-		}
-		if !threaded {
-			findings = append(findings, Finding{
-				Rule:   "unearned-reply-prefix",
-				Phrase: strings.TrimSuffix(prefix, ":"),
-				Why: "there is no inbound thread with this subject, so the prefix claims " +
-					"a message that was never received",
-			})
-		}
-		break
-	}
-
-	// A follow-up subject at band none says there was something before this.
-	// There was not: this is the first message.
-	if band == convstate.BandNone {
-		for _, phrase := range append(append([]string{},
-			assumedMemory[lang]...), firstTouchSubjects[lang]...) {
-			if contains(lowered, phrase) {
-				findings = append(findings, Finding{
-					Rule:   "invented-history-subject",
-					Phrase: phrase,
-					Why:    "this is a first message, so the subject cannot refer back to anything",
-				})
-				break
-			}
-		}
-	}
-
-	if n := len([]rune(trimmed)); n > SubjectMaxRunes {
-		findings = append(findings, Finding{
-			Rule:   "long-subject",
-			Phrase: trimmed[:40] + "…",
-			Why: "a subject this long is truncated by the client that shows it, so the " +
-				"part that carries the meaning may never be read",
-		})
-	}
-	return findings
-}
-
-// firstTouchSubjects are the subject-line formulas that imply a previous
-// message. They overlap the body's assumed-memory list and are not the same:
-// a subject is a label, so "Follow-up" alone is a claim there where it needs a
-// sentence around it to be one in prose.
-var firstTouchSubjects = map[textlang.Lang][]string{
-	textlang.English:    {"follow-up", "follow up", "checking in", "touching base", "reminder"},
-	textlang.German:     {"nachfassen", "nachfrage", "erinnerung", "wiedervorlage"},
-	textlang.Vietnamese: {"nhắc lại", "tiếp theo"},
-}
-
-// Feedback turns findings into the correction a regeneration prompt carries.
-// One line per finding, naming the phrase and why it is wrong here, because a
-// model told only "try again" produces the same draft with different adjectives.
-func Feedback(findings []Finding) string {
-	if len(findings) == 0 {
-		return ""
-	}
-	var b strings.Builder
-	b.WriteString("\n\nThe previous draft was rejected. Rewrite it, and this time:\n")
-	for _, f := range findings {
-		b.WriteString("- Do not write \"" + f.Phrase + "\" or any synonym of it. " + f.Why + ".\n")
-	}
-	// A correction that only says what to delete gets the nearest synonym back:
-	// told to drop "circling back", the model returns "checking in", which is
-	// the same sentence. So the retry is told what to WRITE — a message with a
-	// reason to exist does not need a re-contact formula at all.
-	b.WriteString("Open on the substance instead. Name what the message is about " +
-		"in your own words and ask one question they can answer. A message that " +
-		"opens on why you are writing needs no phrase for the act of writing.\n")
-	return b.String()
 }

--- a/backend/internal/compose/draftcheck/draftcheck_test.go
+++ b/backend/internal/compose/draftcheck/draftcheck_test.go
@@ -19,7 +19,7 @@ func TestTheDraftTheJudgeFlooredIsCaught(t *testing.T) {
 	body := "Hello Priya, I am checking in to see if you have an update regarding " +
 		"the integration project we discussed earlier. Is this still a priority?"
 
-	findings := draftcheck.Body(body, textlang.English, convstate.BandMonths)
+	findings := draftcheck.Body(body, textlang.English, convstate.BandMonths, false)
 	if len(findings) == 0 {
 		t.Fatal("the phrasing the judge floored passed the check")
 	}
@@ -36,11 +36,11 @@ func TestTheDraftTheJudgeFlooredIsCaught(t *testing.T) {
 func TestTheSameWordsAreFineWhileTheExchangeIsLive(t *testing.T) {
 	body := "Hi Marek, as discussed I am sending the scope over now. Anything else?"
 
-	if findings := draftcheck.Body(body, textlang.English, convstate.BandFresh); len(findings) != 0 {
+	if findings := draftcheck.Body(body, textlang.English, convstate.BandFresh, false); len(findings) != 0 {
 		t.Fatalf("a live exchange may refer to what was discussed, got %d findings: %+v",
 			len(findings), findings)
 	}
-	if findings := draftcheck.Body(body, textlang.English, convstate.BandMonths); len(findings) == 0 {
+	if findings := draftcheck.Body(body, textlang.English, convstate.BandMonths, false); len(findings) == 0 {
 		t.Fatal("the same sentence after months of silence should be caught")
 	}
 }
@@ -52,7 +52,7 @@ func TestAWellbeingOpenerIsCaughtAtEveryBand(t *testing.T) {
 	for _, band := range []convstate.Band{
 		convstate.BandNone, convstate.BandFresh, convstate.BandWeeks, convstate.BandMonths,
 	} {
-		findings := draftcheck.Body(body, textlang.English, band)
+		findings := draftcheck.Body(body, textlang.English, band, false)
 		if len(findings) != 1 || findings[0].Rule != "wellbeing-opener" {
 			t.Errorf("at band %q: got %+v, want one wellbeing-opener finding", band, findings)
 		}
@@ -63,12 +63,12 @@ func TestAWellbeingOpenerIsCaughtAtEveryBand(t *testing.T) {
 // against German reflexes, not translated English ones.
 func TestEachLanguageIsJudgedAgainstItsOwnPhrases(t *testing.T) {
 	german := "Hallo Marek, wie besprochen melde ich mich nochmal zu dem Thema."
-	if findings := draftcheck.Body(german, textlang.German, convstate.BandMonths); len(findings) == 0 {
+	if findings := draftcheck.Body(german, textlang.German, convstate.BandMonths, false); len(findings) == 0 {
 		t.Error("the German assumed-memory phrase should be caught")
 	}
 	// The same German text judged as English finds nothing, which is correct:
 	// the caller passes the language the draft was written in.
-	if findings := draftcheck.Body(german, textlang.English, convstate.BandMonths); len(findings) != 0 {
+	if findings := draftcheck.Body(german, textlang.English, convstate.BandMonths, false); len(findings) != 0 {
 		t.Errorf("German text judged as English should find nothing, got %+v", findings)
 	}
 }
@@ -80,7 +80,7 @@ func TestAnHonestDraftPassesCleanly(t *testing.T) {
 		"Schnittstelle inzwischen fertiggestellt und ich wollte fragen, ob das Thema " +
 		"bei Ihnen noch aktuell ist.\n\nViele Grüße"
 
-	if findings := draftcheck.Body(body, textlang.German, convstate.BandMonths); len(findings) != 0 {
+	if findings := draftcheck.Body(body, textlang.German, convstate.BandMonths, false); len(findings) != 0 {
 		t.Fatalf("an honest gap-acknowledging draft should pass, got %+v", findings)
 	}
 }
@@ -89,7 +89,7 @@ func TestAnHonestDraftPassesCleanly(t *testing.T) {
 // "try again" produces the same draft with different adjectives.
 func TestFeedbackNamesThePhraseAndTheReason(t *testing.T) {
 	findings := draftcheck.Body("I am just circling back on this.",
-		textlang.English, convstate.BandMonths)
+		textlang.English, convstate.BandMonths, false)
 	feedback := draftcheck.Feedback(findings)
 
 	if !strings.Contains(feedback, "circling back") {
@@ -108,12 +108,12 @@ func TestFeedbackNamesThePhraseAndTheReason(t *testing.T) {
 // recipient's OWN system as an invented pitch.
 func TestAPhraseInsideAnotherWordIsNotAMatch(t *testing.T) {
 	honest := "Hallo Marek, wie ist your solution bei Ihnen aufgebaut?"
-	if findings := draftcheck.Body(honest, textlang.English, convstate.BandNone); len(findings) != 0 {
+	if findings := draftcheck.Body(honest, textlang.English, convstate.BandNone, false); len(findings) != 0 {
 		t.Errorf("%q should not match \"our solution\", got %+v", honest, findings)
 	}
 
 	invented := "Hi Marek, our solution helps companies like yours."
-	if findings := draftcheck.Body(invented, textlang.English, convstate.BandNone); len(findings) == 0 {
+	if findings := draftcheck.Body(invented, textlang.English, convstate.BandNone, false); len(findings) == 0 {
 		t.Error("the real phrase should still be caught")
 	}
 }
@@ -126,7 +126,7 @@ func TestAPleasantryIsOnlyFillerAtTheOpening(t *testing.T) {
 		"side, including the test window we talked through.\n\n" +
 		"Let me know if the dates work. I hope you are doing well with the rollout."
 
-	if findings := draftcheck.Body(closing, textlang.English, convstate.BandFresh); len(findings) != 0 {
+	if findings := draftcheck.Body(closing, textlang.English, convstate.BandFresh, false); len(findings) != 0 {
 		t.Errorf("a pleasantry far into the body is not an opener, got %+v", findings)
 	}
 }
@@ -275,7 +275,7 @@ func TestAMixedRegisterIsCaught(t *testing.T) {
 	mixed := "Hallo Frank,\n\nich würde mich gerne mit dir austauschen. " +
 		"Haben Sie in der kommenden Woche Zeit für ein kurzes Gespräch?"
 
-	findings := draftcheck.Body(mixed, textlang.German, convstate.BandFresh)
+	findings := draftcheck.Body(mixed, textlang.German, convstate.BandFresh, false)
 	if len(findings) == 0 {
 		t.Fatal("a draft using both du and Sie should be caught")
 	}
@@ -293,7 +293,7 @@ func TestAConsistentRegisterPasses(t *testing.T) {
 		"Hallo Herr Miller,\n\nich melde mich bei Ihnen, sobald ich Ihre Notizen " +
 			"durchgesehen habe. Sagen Sie mir gerne, ob Ihnen das so passt.",
 	} {
-		if findings := draftcheck.Body(body, textlang.German, convstate.BandFresh); len(findings) != 0 {
+		if findings := draftcheck.Body(body, textlang.German, convstate.BandFresh, false); len(findings) != 0 {
 			t.Errorf("a consistent draft should pass, got %+v for %q", findings, body[:40])
 		}
 	}
@@ -308,7 +308,7 @@ func TestEveryIchHoffeOpenerIsCaught(t *testing.T) {
 		"Hallo Frank, ich hoffe, es geht dir gut. Kurze Rückfrage...",
 		"Hallo Herr Miller, ich hoffe, Sie hatten einen guten Start.",
 	} {
-		if findings := draftcheck.Body(opener, textlang.German, convstate.BandFresh); len(findings) == 0 {
+		if findings := draftcheck.Body(opener, textlang.German, convstate.BandFresh, false); len(findings) == 0 {
 			t.Errorf("%q was not caught", opener[:45])
 		}
 	}
@@ -326,7 +326,7 @@ func TestADraftMayNotDeclareTheirSideResolved(t *testing.T) {
 	invented := "Hello Priya, now that the budget round has concluded, I wanted to " +
 		"see whether the integration is moving forward."
 
-	findings := draftcheck.Body(invented, textlang.English, convstate.BandMonths)
+	findings := draftcheck.Body(invented, textlang.English, convstate.BandMonths, false)
 	if len(findings) == 0 {
 		t.Fatal("a draft asserting their side resolved something should be caught")
 	}
@@ -340,10 +340,10 @@ func TestADraftMayNotDeclareTheirSideResolved(t *testing.T) {
 func TestTheResolutionCheckIsOnlyForALongSilence(t *testing.T) {
 	same := "Hi Priya, now that the review has concluded, here is the scope."
 
-	if f := draftcheck.Body(same, textlang.English, convstate.BandFresh); len(f) != 0 {
+	if f := draftcheck.Body(same, textlang.English, convstate.BandFresh, false); len(f) != 0 {
 		t.Errorf("a live exchange may refer to what it established, got %+v", f)
 	}
-	if f := draftcheck.Body(same, textlang.English, convstate.BandMonths); len(f) == 0 {
+	if f := draftcheck.Body(same, textlang.English, convstate.BandMonths, false); len(f) == 0 {
 		t.Error("after months of silence the same sentence is an assertion about them")
 	}
 }
@@ -356,7 +356,7 @@ func TestTheStaleThreadPhrasingsAreCaught(t *testing.T) {
 		"Hello Priya, I am following up on our discussion regarding the integration timeline.",
 		"Hello Priya, picking up where we left off on the integration.",
 	} {
-		if f := draftcheck.Body(body, textlang.English, convstate.BandMonths); len(f) == 0 {
+		if f := draftcheck.Body(body, textlang.English, convstate.BandMonths, false); len(f) == 0 {
 			t.Errorf("not caught: %q", body[:55])
 		}
 	}

--- a/backend/internal/compose/draftcheck/invention_test.go
+++ b/backend/internal/compose/draftcheck/invention_test.go
@@ -34,7 +34,7 @@ func TestTheServedInventedDraftIsRefusedAtEveryBand(t *testing.T) {
 		convstate.BandWeeks, convstate.BandMonths,
 	} {
 		t.Run(string(band), func(t *testing.T) {
-			findings := Body(servedInventedDraft, textlang.English, band)
+			findings := Body(servedInventedDraft, textlang.English, band, false)
 			if len(findings) == 0 {
 				t.Fatalf("the served draft passed clean at band %s", band)
 			}
@@ -51,7 +51,7 @@ func TestTheServedInventedDraftIsRefusedAtEveryBand(t *testing.T) {
 // A rep reads the correction, so it has to name the phrase back. A finding that
 // says only "something is wrong" leaves the model guessing on the retry.
 func TestTheCorrectionNamesTheInventedPhrase(t *testing.T) {
-	feedback := Feedback(Body(servedInventedDraft, textlang.English, convstate.BandFresh))
+	feedback := Feedback(Body(servedInventedDraft, textlang.English, convstate.BandFresh, false))
 
 	if !strings.Contains(feedback, "pleasure connecting") {
 		t.Errorf("the correction did not name the invented meeting: %q", feedback)
@@ -74,8 +74,47 @@ func TestAnHonestDraftStaysClean(t *testing.T) {
 			"the provider comparison, here is what our side can commit to.",
 	} {
 		t.Run(name, func(t *testing.T) {
-			if findings := Body(body, textlang.English, convstate.BandFresh); len(findings) > 0 {
+			if findings := Body(body, textlang.English, convstate.BandFresh, false); len(findings) > 0 {
 				t.Fatalf("an honest draft was refused: %+v", findings)
+			}
+		})
+	}
+}
+
+// A reply is written FROM the counterparty's own message. If they wrote "as I
+// mentioned on our call", answering the call they named is grounded in text the
+// drafter can see — so the world-claim rules stand down on a threaded draft and
+// hold on one that opens a new conversation.
+func TestAThreadedReplyMayAnswerACallTheCounterpartyNamed(t *testing.T) {
+	body := "Thanks — after our call I pulled the figures you mentioned, and the " +
+		"August timeline still works on our side."
+
+	if findings := Body(body, textlang.English, convstate.BandFresh, true); len(findings) > 0 {
+		t.Fatalf("a grounded reply was refused: %+v", findings)
+	}
+	if findings := Body(body, textlang.English, convstate.BandFresh, false); len(findings) == 0 {
+		t.Fatal("the same words opening a new conversation must still be refused")
+	}
+}
+
+// The lists must assert a COMPLETED exchange on their own. A draft proposing a
+// call, or naming one still to come, is the output this product exists to write
+// — refusing it would be worse than the defect the lists were added for.
+func TestForwardLookingAndUnrelatedTextIsNotAnInventedCall(t *testing.T) {
+	for name, tc := range map[string]struct {
+		body string
+		lang textlang.Lang
+	}{
+		"proposes a call":            {"It would be great to connect next week.", textlang.English},
+		"names a call still to come": {"We can cover that in our call tomorrow.", textlang.English},
+		"connects two people":        {"Good to connect you with Anna, who runs delivery.", textlang.English},
+		"asks for a call":            {"Shall we set up a call?", textlang.English},
+		"proposes a German call":     {"Es freut mich, dass wir nächste Woche sprechen können.", textlang.German},
+		"a German call to come":      {"Unser Telefonat nächsten Dienstag passt mir gut.", textlang.German},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if findings := Body(tc.body, tc.lang, convstate.BandFresh, false); len(findings) > 0 {
+				t.Fatalf("a legitimate draft was refused: %+v", findings)
 			}
 		})
 	}
@@ -91,7 +130,7 @@ func TestGermanInventionIsCaught(t *testing.T) {
 		"after a phone call":      "Marine, nach unserem Telefonat habe ich die Zahlen geprüft.",
 	} {
 		t.Run(name, func(t *testing.T) {
-			if findings := Body(body, textlang.German, convstate.BandFresh); len(findings) == 0 {
+			if findings := Body(body, textlang.German, convstate.BandFresh, false); len(findings) == 0 {
 				t.Fatalf("a German invention passed clean")
 			}
 		})

--- a/backend/internal/compose/draftcheck/invention_test.go
+++ b/backend/internal/compose/draftcheck/invention_test.go
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package draftcheck
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/convstate"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/textlang"
+)
+
+// The draft a rep was actually served from a company page, verbatim.
+//
+// The account had a live support thread and no call of any kind. Every sentence
+// of substance here is invented: no meeting happened, the recipient raised no
+// challenges, and no record describes an operational setup or any technical
+// constraint. It scored zero findings at all four bands, which is what this
+// test exists to keep from happening again.
+const servedInventedDraft = "Marine, it was a pleasure connecting earlier this week. " +
+	"I have been giving some thought to the challenges you mentioned regarding your " +
+	"current operational setup and believe there may be some targeted ways to reduce " +
+	"those technical constraints.\n\n" +
+	"Would you be open to a brief call to explore how we could identify potential " +
+	"efficiency gains for your team?"
+
+// A claim about the world is wrong at every band. The gap that let this through
+// was band gating: assumed-memory ran only at weeks and months, invention only
+// at band none, and a thread two days old sits at fresh, where neither ran.
+func TestTheServedInventedDraftIsRefusedAtEveryBand(t *testing.T) {
+	for _, band := range []convstate.Band{
+		convstate.BandNone, convstate.BandFresh,
+		convstate.BandWeeks, convstate.BandMonths,
+	} {
+		t.Run(string(band), func(t *testing.T) {
+			findings := Body(servedInventedDraft, textlang.English, band)
+			if len(findings) == 0 {
+				t.Fatalf("the served draft passed clean at band %s", band)
+			}
+			if !hasRule(findings, "invented-conversation") {
+				t.Errorf("the invented call was not caught at band %s: %+v", band, findings)
+			}
+			if !hasRule(findings, "attributed-claim") {
+				t.Errorf("the invented attribution was not caught at band %s: %+v", band, findings)
+			}
+		})
+	}
+}
+
+// A rep reads the correction, so it has to name the phrase back. A finding that
+// says only "something is wrong" leaves the model guessing on the retry.
+func TestTheCorrectionNamesTheInventedPhrase(t *testing.T) {
+	feedback := Feedback(Body(servedInventedDraft, textlang.English, convstate.BandFresh))
+
+	if !strings.Contains(feedback, "pleasure connecting") {
+		t.Errorf("the correction did not name the invented meeting: %q", feedback)
+	}
+	if !strings.Contains(feedback, "you mentioned") {
+		t.Errorf("the correction did not name the invented attribution: %q", feedback)
+	}
+}
+
+// The lists must not swallow the ordinary drafts they sit beside. A message
+// that asks for a call, or names a topic without attributing it, is the correct
+// output and has to stay clean at the band a live thread sits in.
+func TestAnHonestDraftStaysClean(t *testing.T) {
+	for name, body := range map[string]string{
+		"asks for a call without claiming one happened": "Marine, the pricing question on " +
+			"the thread is easiest to answer live. Would a short call this week suit you?",
+		"names the topic without attributing it": "Marine, on the question about the " +
+			"August deadline: we can hold the current terms until the end of the month.",
+		"refers to a message rather than a conversation": "Marine, following the note about " +
+			"the provider comparison, here is what our side can commit to.",
+	} {
+		t.Run(name, func(t *testing.T) {
+			if findings := Body(body, textlang.English, convstate.BandFresh); len(findings) > 0 {
+				t.Fatalf("an honest draft was refused: %+v", findings)
+			}
+		})
+	}
+}
+
+// German drafts fail the same way in their own words, and a list that only
+// knows English lets every German draft through — the failure mode the wellbeing
+// list already learned once.
+func TestGermanInventionIsCaught(t *testing.T) {
+	for name, body := range map[string]string{
+		"an invented call":        "Marine, es freute mich sehr, letzte Woche mit Ihnen zu sprechen.",
+		"an invented attribution": "Marine, Sie erwähnten den Zeitplan für August.",
+		"after a phone call":      "Marine, nach unserem Telefonat habe ich die Zahlen geprüft.",
+	} {
+		t.Run(name, func(t *testing.T) {
+			if findings := Body(body, textlang.German, convstate.BandFresh); len(findings) == 0 {
+				t.Fatalf("a German invention passed clean")
+			}
+		})
+	}
+}
+
+func hasRule(findings []Finding, rule string) bool {
+	for _, f := range findings {
+		if f.Rule == rule {
+			return true
+		}
+	}
+	return false
+}

--- a/backend/internal/compose/draftcheck/subject.go
+++ b/backend/internal/compose/draftcheck/subject.go
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package draftcheck
+
+// A subject line fails differently from the prose beneath it.
+//
+// Its worst failure is a CLAIM rather than a phrase: "Re:" asserts that a
+// message was received, and a client renders that assertion as a thread whether
+// or not one exists. It is also one line, which is why the body's phrase lists
+// are not simply reused here — "Follow-up" alone is a claim in a subject where
+// it needs a sentence around it to be one in prose.
+
+import (
+	"strings"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/convstate"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/textlang"
+)
+
+// SubjectMaxRunes is where a subject line stops being read.
+//
+// Mail clients truncate around here, and a subject that needs more than this
+// is a first sentence rather than a label. The number is the conventional one
+// rather than any client's exact cut, because every client's differs and the
+// point is to stay short of all of them.
+const SubjectMaxRunes = 70
+
+// replyPrefixes are the ways a client marks a subject as a reply, in the
+// languages this product writes.
+var replyPrefixes = []string{"re:", "aw:", "fwd:", "wg:", "antw:"}
+
+// Subject reads a draft's subject line against the correspondence it belongs to.
+//
+// Separate from Body because a subject fails differently: it is one line, it is
+// read before anything else, and its worst failure is a claim rather than a
+// phrase. "Re:" says a thread exists. A follow-up subject says there was a
+// previous message. Both are checkable facts the envelope already holds, which
+// is why they are refused here rather than explained in a prompt.
+func Subject(subject string, lang textlang.Lang, band convstate.Band, threaded bool) []Finding {
+	trimmed := strings.TrimSpace(subject)
+	lowered := strings.ToLower(trimmed)
+	var findings []Finding
+
+	if trimmed == "" {
+		return []Finding{{
+			Rule:   "empty-subject",
+			Phrase: "",
+			Why:    "a message with no subject line arrives looking like spam",
+		}}
+	}
+
+	for _, prefix := range replyPrefixes {
+		if !strings.HasPrefix(lowered, prefix) {
+			continue
+		}
+		if !threaded {
+			findings = append(findings, Finding{
+				Rule:   "unearned-reply-prefix",
+				Phrase: strings.TrimSuffix(prefix, ":"),
+				Why: "there is no inbound thread with this subject, so the prefix claims " +
+					"a message that was never received",
+			})
+		}
+		break
+	}
+
+	// A follow-up subject at band none says there was something before this.
+	// There was not: this is the first message.
+	if band == convstate.BandNone {
+		for _, phrase := range append(append([]string{},
+			assumedMemory[lang]...), firstTouchSubjects[lang]...) {
+			if contains(lowered, phrase) {
+				findings = append(findings, Finding{
+					Rule:   "invented-history-subject",
+					Phrase: phrase,
+					Why:    "this is a first message, so the subject cannot refer back to anything",
+				})
+				break
+			}
+		}
+	}
+
+	if n := len([]rune(trimmed)); n > SubjectMaxRunes {
+		findings = append(findings, Finding{
+			Rule:   "long-subject",
+			Phrase: trimmed[:40] + "…",
+			Why: "a subject this long is truncated by the client that shows it, so the " +
+				"part that carries the meaning may never be read",
+		})
+	}
+	return findings
+}
+
+// firstTouchSubjects are the subject-line formulas that imply a previous
+// message. They overlap the body's assumed-memory list and are not the same:
+// a subject is a label, so "Follow-up" alone is a claim there where it needs a
+// sentence around it to be one in prose.
+var firstTouchSubjects = map[textlang.Lang][]string{
+	textlang.English:    {"follow-up", "follow up", "checking in", "touching base", "reminder"},
+	textlang.German:     {"nachfassen", "nachfrage", "erinnerung", "wiedervorlage"},
+	textlang.Vietnamese: {"nhắc lại", "tiếp theo"},
+}
+
+// Feedback turns findings into the correction a regeneration prompt carries.
+// One line per finding, naming the phrase and why it is wrong here, because a
+// model told only "try again" produces the same draft with different adjectives.
+func Feedback(findings []Finding) string {
+	if len(findings) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString("\n\nThe previous draft was rejected. Rewrite it, and this time:\n")
+	for _, f := range findings {
+		b.WriteString("- Do not write \"" + f.Phrase + "\" or any synonym of it. " + f.Why + ".\n")
+	}
+	// A correction that only says what to delete gets the nearest synonym back:
+	// told to drop "circling back", the model returns "checking in", which is
+	// the same sentence. So the retry is told what to WRITE — a message with a
+	// reason to exist does not need a re-contact formula at all.
+	b.WriteString("Open on the substance instead. Name what the message is about " +
+		"in your own words and ask one question they can answer. A message that " +
+		"opens on why you are writing needs no phrase for the act of writing.\n")
+	return b.String()
+}

--- a/backend/internal/compose/draftcheck/worldclaims.go
+++ b/backend/internal/compose/draftcheck/worldclaims.go
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package draftcheck
+
+// The claims no band makes true.
+//
+// Every other list in this package is gated on the conversation's state,
+// because what it refuses is a claim about the recipient's MEMORY: "as
+// discussed" is ordinary in a live exchange and false after eight months. These
+// two are not gated, because what they refuse is a claim about the WORLD. A
+// call either happened or it did not, and a sentence was either written or it
+// was not — no amount of recent correspondence makes an invented one true.
+
+import "github.com/gradionhq/margince/backend/internal/shared/kernel/textlang"
+
+// spokenExchange are the ways a draft asserts that a CONVERSATION happened —
+// a call, a meeting, a chat — as opposed to the messages the record holds.
+//
+// Checked at every band, which is what separates this list from assumedMemory
+// above. "As discussed" at band fresh is ordinary: an exchange is running and
+// both sides are holding it. "It was a pleasure connecting earlier this week"
+// is a different claim entirely — it says two people SPOKE, on a date, and
+// nothing in any drafting input can support that. The 360 carries activities;
+// a meeting the drafter can see is one on the calendar, and a calendar entry is
+// not evidence that it took place or that anyone enjoyed it.
+//
+// The reported defect that produced this list: a company with a live support
+// thread and no call whatsoever was drafted an opener reading "Marine, it was a
+// pleasure connecting earlier this week." Every band's list was checked against
+// that text and every one of them passed it.
+var spokenExchange = map[textlang.Lang][]string{
+	textlang.English: {
+		"pleasure connecting", "pleasure speaking", "pleasure meeting",
+		"pleasure talking", "good to connect", "great to connect",
+		"good speaking", "great speaking", "good talking", "great talking",
+		"nice to connect", "nice speaking", "enjoyed our",
+		"after our call", "on our call", "during our call", "in our call",
+		"our conversation earlier", "when we spoke",
+	},
+	textlang.German: {
+		"freute mich", "freut mich, dass wir", "gefreut, sie kennenzulernen",
+		"gefreut, dich kennenzulernen", "schön, sie kennenzulernen",
+		"nach unserem gespräch", "in unserem gespräch", "unserem telefonat",
+		"unser telefonat", "nach unserem call",
+	},
+	textlang.Vietnamese: {
+		"rất vui được trao đổi", "sau cuộc gọi", "trong cuộc gọi",
+	},
+}
+
+// attributedClaim are the ways a draft puts words in the recipient's mouth.
+//
+// Also every band, and for the same reason. A drafting surface knows what its
+// input said, never who said it: an activity reaches a person or an account
+// through links that record what a message CONCERNS rather than who wrote it,
+// and no 360 carries participants. The person and account prompts both state
+// this ("say 'the question about X' and never 'you wrote'"), which is exactly
+// why it needs a check — a rule the prompt states is a rule the model has
+// already been observed breaking three times in this program.
+//
+// The stems rather than whole phrases. Enumerating completions is how the
+// earlier lists lost: "introduction by" missed "introduction to", and a German
+// list of wellbeing completions missed the one the model actually wrote.
+var attributedClaim = map[textlang.Lang][]string{
+	textlang.English: {
+		"you mentioned", "you said", "you raised", "you told me", "you noted",
+		"you indicated", "you expressed", "you described", "you flagged",
+		"you brought up", "you pointed out", "as you put it",
+	},
+	textlang.German: {
+		"sie erwähnten", "du erwähntest", "sie sagten", "du sagtest",
+		"sie erwähnt haben", "du erwähnt hast", "sie angesprochen haben",
+		"du angesprochen hast", "wie sie sagten", "wie du sagtest",
+	},
+	textlang.Vietnamese: {
+		"anh/chị đã đề cập", "anh/chị đã nói",
+	},
+}

--- a/backend/internal/compose/draftcheck/worldclaims.go
+++ b/backend/internal/compose/draftcheck/worldclaims.go
@@ -29,23 +29,31 @@ import "github.com/gradionhq/margince/backend/internal/shared/kernel/textlang"
 // thread and no call whatsoever was drafted an opener reading "Marine, it was a
 // pleasure connecting earlier this week." Every band's list was checked against
 // that text and every one of them passed it.
+// Every entry asserts a COMPLETED exchange on its own, which is the bar an
+// entry has to clear. "Great to connect" does not: "it would be great to
+// connect next week" is an ask, and the same words a sentence later are a
+// memory. "We can cover that in our call tomorrow" is a plan. A list that
+// refuses those refuses the drafts this product exists to write, so the past
+// tense has to be IN the phrase rather than assumed around it.
 var spokenExchange = map[textlang.Lang][]string{
 	textlang.English: {
-		"pleasure connecting", "pleasure speaking", "pleasure meeting",
-		"pleasure talking", "good to connect", "great to connect",
-		"good speaking", "great speaking", "good talking", "great talking",
-		"nice to connect", "nice speaking", "enjoyed our",
-		"after our call", "on our call", "during our call", "in our call",
-		"our conversation earlier", "when we spoke",
+		"it was a pleasure connecting", "was a pleasure speaking",
+		"was a pleasure meeting", "was a pleasure talking",
+		"was good speaking", "was great speaking", "was good talking",
+		"was great talking", "was good to connect", "was great to connect",
+		"was nice to connect", "was nice speaking",
+		"after our call", "after our conversation", "during our call",
+		"on the call last", "our conversation earlier", "when we spoke",
+		"thanks for taking the time to speak",
 	},
 	textlang.German: {
-		"freute mich", "freut mich, dass wir", "gefreut, sie kennenzulernen",
-		"gefreut, dich kennenzulernen", "schön, sie kennenzulernen",
-		"nach unserem gespräch", "in unserem gespräch", "unserem telefonat",
-		"unser telefonat", "nach unserem call",
+		"freute mich", "hat mich gefreut, sie kennenzulernen",
+		"hat mich gefreut, dich kennenzulernen",
+		"nach unserem gespräch", "nach unserem telefonat", "nach unserem call",
+		"in unserem gespräch letzte", "danke für das gespräch",
 	},
 	textlang.Vietnamese: {
-		"rất vui được trao đổi", "sau cuộc gọi", "trong cuộc gọi",
+		"rất vui được trao đổi với", "sau cuộc gọi", "sau buổi trao đổi",
 	},
 }
 

--- a/backend/internal/compose/draftcore/draftcore.go
+++ b/backend/internal/compose/draftcore/draftcore.go
@@ -89,10 +89,17 @@ func CorrectOnce[D any](
 ) (D, error) {
 	check := func(draft D) []draftcheck.Finding {
 		body, reasoning := textOf(draft)
-		findings := append(draftcheck.Body(body, lang, band),
+		// Whether this draft answers a real inbound message decides more than the
+		// subject's reply prefix: a reply is written from the counterparty's own
+		// words, so it may echo a call THEY named, where a message opening a new
+		// conversation has no such ground to stand on.
+		subject, threaded := "", false
+		if subjectOf != nil {
+			subject, threaded = subjectOf(draft)
+		}
+		findings := append(draftcheck.Body(body, lang, band, threaded),
 			draftcheck.Reasoning(reasoning, lang, band)...)
 		if subjectOf != nil {
-			subject, threaded := subjectOf(draft)
 			findings = append(findings, draftcheck.Subject(subject, lang, band, threaded)...)
 		}
 		return findings


### PR DESCRIPTION
## The defect

A draft served from a company page, verbatim:

> Marine, it was a pleasure connecting earlier this week. I have been giving
> some thought to the challenges you mentioned regarding your current
> operational setup and believe there may be some targeted ways to reduce those
> technical constraints.

No call happened. She raised no challenges. No record mentions an operational
setup or a technical constraint. Running that exact text through `draftcheck.Body`
at all four bands returned **zero findings**.

## Two holes

**Band gating.** Every list was gated on the conversation's state:
`assumedMemory` at `BandWeeks`/`BandMonths`, `invention` at `BandNone`. The
thread's last message was two days old, so it sits at `BandFresh` — where the
only rules are the wellbeing opener and the German register check.

The gating was correct for what it gated. "As discussed" is a claim about the
recipient's **memory**: true in a live exchange, false after eight months. A
call that never happened is a claim about the **world**, and no band makes it
true. That distinction is the fix — those two lists move to `worldclaims.go`
and run at every band.

**Coverage.** Even at `BandWeeks`, none of "it was a pleasure connecting", "the
challenges you mentioned" or "you mentioned" appeared on any list. Stems rather
than whole phrases, because enumerating completions is how the earlier lists
lost twice: #958's "introduction by" missed "introduction to", and the German
wellbeing list missed the completion the model actually wrote (which is why it
now matches the bare "ich hoffe" opener).

## Why a check rather than a prompt rule

Both drafting prompts already say not to attribute ("say 'the question about X'
and never 'you wrote'"). This package exists because prompt rules keep losing
to model reflexes — three times in this program, per its own doc comment. A
rule the prompt states and the model breaks is exactly the case for a
deterministic gate.

## Tests

The served draft is pinned verbatim and must produce both findings at all four
bands. Beside it, three honest drafts that must stay clean — a draft may still
ASK for a call, and may name a topic so long as it does not attribute it — plus
German equivalents, since a list that only knows English lets every German
draft through.

Mutation-checked: neutering the `spokenExchange` scan makes the regression test
fail.

## Incidental

`draftcheck.go` crossed the 500-line cap, so the subject rules move to
`subject.go`. A subject fails by making a claim ("Re:" asserts a thread exists)
where prose fails by carrying a phrase — a second concept, not a slice of this
one. `Body`'s repeated scan-and-report blocks are extracted to `firstMatch`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refuses invented calls/meetings and invented attributions in `draftcheck.Body` across all bands, gated by threading instead of gaps. Before, `BandFresh` ignored these and phrases like “pleasure connecting”/“you mentioned” passed; now unthreaded drafts yield `invented-conversation`/`attributed-claim`, while threaded replies may echo a call the counterparty named.

- Adds `worldclaims.go` with EN/DE/VI lists that assert completed exchanges and attributions; they run at all bands on unthreaded bodies and remain strict for reasoning chips.
- Refines phrases to past-tense forms (e.g., “was a pleasure connecting”, “after our call”) to avoid refusing proposals or future plans.
- Adds `threaded` awareness end-to-end: `draftcore.CorrectOnce` passes it to `draftcheck.Body`; `draftcheck.Reasoning` treats chips as unthreaded.
- Introduces `firstMatch` to report a single representative finding.
- Moves subject rules and `Feedback` to `subject.go` (behavior unchanged).
- Adds `invention_test.go`: pins the served draft, permits threaded replies, keeps honest drafts clean, and covers German.
- Impact: more unthreaded drafts at `BandFresh` are rejected for invented world claims; no API or configuration changes.

<sup>Written for commit 644752ec17ffd97c730f5e73fa5edee89ff447b1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1172?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

