### PR TITLE
refactor(automation): the catalog drops the tenant column (ADR-0091 §8 phase D)

### DIFF
--- a/backend/internal/compose/integration/no_activity_reminder_workqueue_integration_test.go
+++ b/backend/internal/compose/integration/no_activity_reminder_workqueue_integration_test.go
@@ -201,9 +201,9 @@ func seedOwnedNoActivityReminder(t *testing.T, owner *pgx.Conn, ws, ownerID ids.
 	t.Helper()
 	params := fmt.Sprintf(`{"no_activity_days":%d}`, days)
 	if _, err := owner.Exec(context.Background(),
-		`INSERT INTO automation (id, workspace_id, key, name, trigger, action, params, owner_id, enabled)
-		 VALUES ($1, $2, 'no_activity_reminder', 'No Activity Reminder', '{"schedule":"clock"}', '{"kind":"create_task"}', $3::jsonb, $4, true)`,
-		ids.NewV7(), ws, params, ownerID); err != nil {
+		`INSERT INTO automation (id, key, name, trigger, action, params, owner_id, enabled)
+		 VALUES ($1, 'no_activity_reminder', 'No Activity Reminder', '{"schedule":"clock"}', '{"kind":"create_task"}', $2::jsonb, $3, true)`,
+		ids.NewV7(), params, ownerID); err != nil {
 		t.Fatalf("seeding the owner-authored no_activity_reminder instance: %v", err)
 	}
 }

--- a/backend/internal/compose/integration/timescan_integration_test.go
+++ b/backend/internal/compose/integration/timescan_integration_test.go
@@ -141,9 +141,9 @@ func seedGenuineTouch(t *testing.T, owner *pgx.Conn, ws, dealID ids.UUID, kind s
 func seedNoActivityReminder(t *testing.T, owner *pgx.Conn, ws ids.UUID) {
 	t.Helper()
 	if _, err := owner.Exec(context.Background(),
-		`INSERT INTO automation (id, workspace_id, key, name, trigger, action, params, enabled)
-		 VALUES ($1, $2, 'no_activity_reminder', 'No Activity Reminder', '{"schedule":"clock"}', '{"kind":"create_task"}', '{}'::jsonb, true)`,
-		ids.NewV7(), ws); err != nil {
+		`INSERT INTO automation (id, key, name, trigger, action, params, enabled)
+		 VALUES ($1, 'no_activity_reminder', 'No Activity Reminder', '{"schedule":"clock"}', '{"kind":"create_task"}', '{}'::jsonb, true)`,
+		ids.NewV7()); err != nil {
 		t.Fatalf("seeding the no_activity_reminder instance: %v", err)
 	}
 }

--- a/backend/internal/compose/integration/workflow_integration_test.go
+++ b/backend/internal/compose/integration/workflow_integration_test.go
@@ -47,9 +47,8 @@ func enableStageChangeCreateTask(t *testing.T, e *SearchEnv) {
 	t.Helper()
 	err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 		_, err := tx.Exec(context.Background(), `
-			INSERT INTO automation (workspace_id, key, name, trigger, action, params, enabled)
-			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid,
-			        'stage_change_create_task', 'Follow up on stage changes',
+			INSERT INTO automation (key, name, trigger, action, params, enabled)
+			VALUES ('stage_change_create_task', 'Follow up on stage changes',
 			        '{"event_type":"deal.stage_changed"}', '{"kind":"create_task"}', '{}'::jsonb, true)`)
 		return err
 	})
@@ -69,9 +68,8 @@ func enableLeadRouting(t *testing.T, e *SearchEnv, params map[string]any) {
 	}
 	err = database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 		_, err := tx.Exec(context.Background(), `
-			INSERT INTO automation (workspace_id, key, name, trigger, action, params, enabled)
-			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid,
-			        'assign_lead_owner', 'Assign new leads an owner', '{"event_type":"lead.created"}', '{"kind":"assign_owner"}',
+			INSERT INTO automation (key, name, trigger, action, params, enabled)
+			VALUES ('assign_lead_owner', 'Assign new leads an owner', '{"event_type":"lead.created"}', '{"kind":"assign_owner"}',
 			        $1, true)`, paramsJSON)
 		return err
 	})
@@ -188,9 +186,8 @@ func TestWorkflowEngineHonorsAutomationInstances(t *testing.T) {
 	var automationID ids.UUID
 	err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 		return tx.QueryRow(context.Background(), `
-			INSERT INTO automation (workspace_id, key, name, trigger, action, params, enabled)
-			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid,
-			        'assign_lead_owner', 'Assign new leads an owner', '{"event_type":"lead.created"}', '{"kind":"assign_owner"}',
+			INSERT INTO automation (key, name, trigger, action, params, enabled)
+			VALUES ('assign_lead_owner', 'Assign new leads an owner', '{"event_type":"lead.created"}', '{"kind":"assign_owner"}',
 			        $1, false)
 			RETURNING id`, fmt.Sprintf(`{"owners": [%q]}`, e.Rep3.String())).Scan(&automationID)
 	})

--- a/backend/internal/modules/automation/autofixture_integration_test.go
+++ b/backend/internal/modules/automation/autofixture_integration_test.go
@@ -126,9 +126,9 @@ func (fx *autoFixture) seedAutomation(t *testing.T, key string) ids.AutomationID
 	t.Helper()
 	id := ids.New[ids.AutomationKind]()
 	fx.exec(t, `
-		INSERT INTO automation (id, workspace_id, key, name, trigger, action, params, enabled, tier)
-		VALUES ($1, $2, $3, $3, '{"event_type":"test"}', '{"kind":"test"}', '{}'::jsonb, true, 'auto_execute')`,
-		id, fx.ws, key)
+		INSERT INTO automation (id, key, name, trigger, action, params, enabled, tier)
+		VALUES ($1, $2, $2, '{"event_type":"test"}', '{"kind":"test"}', '{}'::jsonb, true, 'auto_execute')`,
+		id, key)
 	return id
 }
 
@@ -140,9 +140,9 @@ func (fx *autoFixture) seedAutomationWithOwner(t *testing.T, key string, owner i
 	t.Helper()
 	id := ids.New[ids.AutomationKind]()
 	fx.exec(t, `
-		INSERT INTO automation (id, workspace_id, key, name, trigger, action, params, owner_id, enabled, tier)
-		VALUES ($1, $2, $3, $3, '{"event_type":"test"}', '{"kind":"test"}', '{}'::jsonb, $4, true, 'auto_execute')`,
-		id, fx.ws, key, owner)
+		INSERT INTO automation (id, key, name, trigger, action, params, owner_id, enabled, tier)
+		VALUES ($1, $2, $2, '{"event_type":"test"}', '{"kind":"test"}', '{}'::jsonb, $3, true, 'auto_execute')`,
+		id, key, owner)
 }
 
 // seedRun inserts one recorded firing for the automation, linked the way

--- a/backend/internal/modules/automation/automations.go
+++ b/backend/internal/modules/automation/automations.go
@@ -187,9 +187,8 @@ func (s *AutomationStore) Create(ctx context.Context, in CreateAutomationInput) 
 	err = s.db.Tx(ctx, func(tx pgx.Tx) error {
 		var err error
 		a, err = scanAutomation(tx.QueryRow(ctx, storekit.SQLf(`
-			INSERT INTO automation (workspace_id, key, name, origin, trigger, action, params, owner_id, enabled, tier)
-			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid,
-			        $1, $2, 'catalog', $3, $4, $5, $6, false, $7)
+			INSERT INTO automation (key, name, origin, trigger, action, params, owner_id, enabled, tier)
+			VALUES ($1, $2, 'catalog', $3, $4, $5, $6, false, $7)
 			RETURNING %s`, automationColumns),
 			in.Key, in.Name, triggerJSON, actionJSON, paramsJSON, storekit.UUIDOrNil(actor.UserID), entry.Tier))
 		if err != nil {
@@ -330,9 +329,8 @@ func SeedStarterAutomationsTx(ctx context.Context, tx pgx.Tx) error {
 			return err
 		}
 		if _, err := tx.Exec(ctx, `
-			INSERT INTO automation (workspace_id, key, name, origin, trigger, action, params, enabled, tier)
-			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid,
-			        $1, $2, 'catalog', $3, $4, $5, true, $6)`,
+			INSERT INTO automation (key, name, origin, trigger, action, params, enabled, tier)
+			VALUES ($1, $2, 'catalog', $3, $4, $5, true, $6)`,
 			entry.Key, entry.Name, triggerJSON, actionJSON, paramsJSON, entry.Tier); err != nil {
 			return fmt.Errorf("seed automation %s: %w", entry.Key, err)
 		}

--- a/backend/migrations/core/0233_automation_drop_workspace.down.sql
+++ b/backend/migrations/core/0233_automation_drop_workspace.down.sql
@@ -1,0 +1,20 @@
+-- Reverse of 0233: the catalog carries the tenant column again.
+--
+-- The backfill reads `workspace` because there is exactly one to read: 0217's
+-- pre-flight refuses to run against a database holding more than one live
+-- workspace, and ADR-0061 §3 has the API refusing to start in that state. If
+-- `workspace` is empty and the catalog is not, SET NOT NULL fails and the
+-- rollback stops — the honest outcome, since no value this migration could
+-- write would be true.
+
+ALTER TABLE automation ADD COLUMN workspace_id uuid;
+
+UPDATE automation SET workspace_id = (SELECT id FROM workspace ORDER BY created_at LIMIT 1);
+
+ALTER TABLE automation ALTER COLUMN workspace_id SET NOT NULL;
+ALTER TABLE automation ADD CONSTRAINT automation_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE automation ADD CONSTRAINT uq_automation_ws_id UNIQUE (id);
+
+DROP INDEX idx_automation_key_live;
+CREATE INDEX idx_automation_ws_key_live ON automation (workspace_id, key) WHERE enabled AND archived_at IS NULL;

--- a/backend/migrations/core/0233_automation_drop_workspace.up.sql
+++ b/backend/migrations/core/0233_automation_drop_workspace.up.sql
@@ -1,0 +1,16 @@
+-- 0233: the automation catalog drops the tenant column (ADR-0091 §8 phase D).
+--
+-- One table, one index, one redundant unique. The catalog was held back from
+-- 0232 by migrations 0148/0149 — a one-off reminder repair whose SQL reads
+-- automation.workspace_id, replayed by integration suites that have since been
+-- retired with their premise.
+--
+-- idx_automation_ws_key_live is renamed as it narrows, unlike every other index
+-- in phase D: `ws` was in the NAME, not just the definition, so keeping it
+-- would leave the name claiming a column the index no longer has.
+
+DROP INDEX idx_automation_ws_key_live;
+CREATE INDEX idx_automation_key_live ON automation (key) WHERE enabled AND archived_at IS NULL;
+
+ALTER TABLE automation DROP CONSTRAINT uq_automation_ws_id;
+ALTER TABLE automation DROP COLUMN workspace_id;


### PR DESCRIPTION
One table, one index, one redundant unique. The catalog was held out of #1171 by migrations 0148/0149 — a one-off reminder repair whose SQL reads `automation.workspace_id`, replayed by integration suites that #1175 has since retired with their premise.

`idx_automation_ws_key_live` **is renamed** as it narrows, unlike every other index in phase D: `ws` was in the *name*, not just the definition, so keeping it would leave the name claiming a column the index no longer has.

Verified: the lane applies to an empty database; the down restores the column, the unique and the wide index. `make check-backend` and `make test-integration` (0 skips, 39 packages) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drops the tenant from the automation catalog to complete ADR-0091 phase D. Old: `automation` stored `workspace_id` and indexed `(workspace_id, key)` for live rows. New: `workspace_id` is removed, the live partial index keys on `key` only, and writers no longer set a workspace.

- Migration 0233 up: drop `idx_automation_ws_key_live`, create `idx_automation_key_live` on `(key)` with the same WHERE clause; drop redundant `uq_automation_ws_id`; drop `workspace_id`.
- Migration 0233 down: add `workspace_id`, backfill from the first `workspace.id`, set NOT NULL and FK; restore the unique and the old index. Rollback fails if `workspace` is empty while `automation` has rows.
- Code/tests: remove `workspace_id` from all INSERTs (`AutomationStore.Create`, starter seeding, integration fixtures). No reads depend on it. Tests remain green.

Required actions:
- Update any raw SQL or analytics that reference `automation.workspace_id`.
- If any code refers to the old index name, use `idx_automation_key_live` instead.

<sup>Written for commit e5730bf6b6d121baf5274532fd234e41ded3c06a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1177?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automation records are now managed independently of workspaces, enabling shared system automations and simpler automation setup.
  * Existing automation behavior, triggers, actions, and enabled states remain unchanged.

* **Bug Fixes**
  * Updated automation creation and starter setup to work correctly without workspace associations.
  * Improved compatibility of automation fixtures and integration scenarios with the updated data model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->