### PR TITLE
feat(deepread): a company page shows the crawl that failed while nobody was looking

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -2423,6 +2423,30 @@ paths:
             application/problem+json:
               schema: { $ref: '#/components/schemas/Problem' }
 
+  /organizations/{id}/site-reads/latest:
+    parameters:
+      - $ref: '#/components/parameters/Id'
+    get:
+      tags: [Organizations]
+      operationId: getLatestSiteRead
+      summary: The newest deep read on this account, so a crawl that failed after the rep navigated away is still visible.
+      description: |
+        A read id lives only in the browser tab that started the crawl, so a read that
+        ended after the rep left the page could not be found again. An account whose
+        crawl failed then looked exactly like one nobody had tried to enrich — no
+        industry, no description, no facts — and a draft written from it had nothing to
+        stand on. 404 when the account has never been read, which is the honest
+        difference between "never tried" and "tried and got nothing".
+      x-mcp-tool: { verb: read_record, record_type: organization, tier: auto_execute, scope: read }
+      responses:
+        '200':
+          description: The newest read's report.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/SiteReadReport' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '404': { $ref: '#/components/responses/NotFound' }
+
   /organizations/{id}/site-reads/{readId}:
     parameters:
       - $ref: '#/components/parameters/Id'

--- a/backend/internal/compose/agentpolicy_gen.go
+++ b/backend/internal/compose/agentpolicy_gen.go
@@ -184,6 +184,7 @@ var agentPolicies = map[string]agentPolicy{
 	"GET /v1/organizations/{id}/evidence/{entityType}/{entityId}":        {Op: "getClaimEvidence", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"GET /v1/organizations/{id}/growth-fit":                              {Op: "getOrganizationGrowthFit", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"GET /v1/organizations/{id}/logo":                                    {Op: "getOrganizationLogo", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
+	"GET /v1/organizations/{id}/site-reads/latest":                       {Op: "getLatestSiteRead", Access: "tool", Tool: "read_record", RecordType: "organization", Tier: "auto_execute", Scope: "read"},
 	"GET /v1/organizations/{id}/site-reads/{readId}":                     {Op: "getSiteRead", Access: "tool", Tool: "read_record", RecordType: "organization", Tier: "auto_execute", Scope: "read"},
 	"GET /v1/overlay/export":                                             {Op: "downloadOverlayExport", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"GET /v1/overlay/owners":                                             {Op: "listOverlayOwners", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},

--- a/backend/internal/compose/deepreadtransport.go
+++ b/backend/internal/compose/deepreadtransport.go
@@ -170,6 +170,17 @@ func (e *deepReadEngine) report(w http.ResponseWriter, r *http.Request, id, read
 	httperr.WriteJSON(w, http.StatusOK, siteReadReport(read))
 }
 
+// latestReport answers with the newest read on this account, for a page that
+// holds no read id — which is every load after the one that started the crawl.
+func (e *deepReadEngine) latestReport(w http.ResponseWriter, r *http.Request, id openapi_types.UUID) {
+	read, err := e.people.LatestSiteRead(r.Context(), ids.From[ids.OrganizationKind](ids.UUID(id)))
+	if err != nil {
+		httperr.Write(w, r, err)
+		return
+	}
+	httperr.WriteJSON(w, http.StatusOK, siteReadReport(read))
+}
+
 // siteReadReport maps the dossier onto the contract report. Lists are
 // always concrete (empty, never null): the report's whole point is an
 // explicit account.
@@ -241,7 +252,7 @@ func WithDeepRead(inserter *jobs.Runner, brain completer) Option {
 			blob: s.blob,
 		}
 		rollout := s.companyContextRollout
-		s.siteReadHandlers = siteReadHandlers{engine: engine, start: engine.start, report: engine.report, companyContextRollout: rollout}
+		s.siteReadHandlers = siteReadHandlers{engine: engine, start: engine.start, report: engine.report, latest: engine.latestReport, companyContextRollout: rollout}
 		s.assistant = &onboardingCompanyAssistant{
 			state: s.state, people: people.NewStore(InstallationDB(pool)),
 			brain: brain, runtime: ai.NewRunTransparency(InstallationDB(pool)),
@@ -258,6 +269,7 @@ type siteReadHandlers struct {
 	engine                *deepReadEngine
 	start                 func(w http.ResponseWriter, r *http.Request, id openapi_types.UUID)
 	report                func(w http.ResponseWriter, r *http.Request, id, readID openapi_types.UUID)
+	latest                func(w http.ResponseWriter, r *http.Request, id openapi_types.UUID)
 	companyContextRollout string
 }
 
@@ -275,4 +287,12 @@ func (h siteReadHandlers) GetSiteRead(w http.ResponseWriter, r *http.Request, id
 		return
 	}
 	h.report(w, r, id, readID)
+}
+
+func (h siteReadHandlers) GetLatestSiteRead(w http.ResponseWriter, r *http.Request, id openapi_types.UUID) {
+	if h.latest == nil {
+		httperr.NotImplemented(w, r, "getLatestSiteRead (no crawl runner configured)")
+		return
+	}
+	h.latest(w, r, id)
 }

--- a/backend/internal/compose/stubs_gen.go
+++ b/backend/internal/compose/stubs_gen.go
@@ -831,6 +831,10 @@ func (stubs) ConfirmOrganizationProfileField(w nethttp.ResponseWriter, r *nethtt
 	httperr.NotImplemented(w, r, "ConfirmOrganizationProfileField")
 }
 
+func (stubs) GetLatestSiteRead(w nethttp.ResponseWriter, r *nethttp.Request, id crmcontracts.Id) {
+	httperr.NotImplemented(w, r, "GetLatestSiteRead")
+}
+
 func (stubs) GetSiteRead(w nethttp.ResponseWriter, r *nethttp.Request, id crmcontracts.Id, readId openapi_types.UUID) {
 	httperr.NotImplemented(w, r, "GetSiteRead")
 }

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -28843,6 +28843,9 @@ type ServerInterface interface {
 	// Confirm a profile field without changing its value.
 	// (POST /organizations/{id}/profile-fields/{field}/confirm)
 	ConfirmOrganizationProfileField(w http.ResponseWriter, r *http.Request, id Id, field ProfileFieldKey, params ConfirmOrganizationProfileFieldParams)
+	// The newest deep read on this account, so a crawl that failed after the rep navigated away is still visible.
+	// (GET /organizations/{id}/site-reads/latest)
+	GetLatestSiteRead(w http.ResponseWriter, r *http.Request, id Id)
 	// One deep read's progress and outcome — pages read, pages skipped and WHY, what got staged.
 	// (GET /organizations/{id}/site-reads/{readId})
 	GetSiteRead(w http.ResponseWriter, r *http.Request, id Id, readId openapi_types.UUID)
@@ -30526,6 +30529,12 @@ func (_ Unimplemented) UpdateOrganizationProfileField(w http.ResponseWriter, r *
 // Confirm a profile field without changing its value.
 // (POST /organizations/{id}/profile-fields/{field}/confirm)
 func (_ Unimplemented) ConfirmOrganizationProfileField(w http.ResponseWriter, r *http.Request, id Id, field ProfileFieldKey, params ConfirmOrganizationProfileFieldParams) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// The newest deep read on this account, so a crawl that failed after the rep navigated away is still visible.
+// (GET /organizations/{id}/site-reads/latest)
+func (_ Unimplemented) GetLatestSiteRead(w http.ResponseWriter, r *http.Request, id Id) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -40429,6 +40438,40 @@ func (siw *ServerInterfaceWrapper) ConfirmOrganizationProfileField(w http.Respon
 	handler.ServeHTTP(w, r)
 }
 
+// GetLatestSiteRead operation middleware
+func (siw *ServerInterfaceWrapper) GetLatestSiteRead(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "id" -------------
+	var id Id
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", chi.URLParam(r, "id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "uuid"})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	ctx = context.WithValue(ctx, CookieAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetLatestSiteRead(w, r, id)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
 // GetSiteRead operation middleware
 func (siw *ServerInterfaceWrapper) GetSiteRead(w http.ResponseWriter, r *http.Request) {
 
@@ -48463,6 +48506,9 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 	})
 	r.Group(func(r chi.Router) {
 		r.Post(options.BaseURL+"/organizations/{id}/profile-fields/{field}/confirm", wrapper.ConfirmOrganizationProfileField)
+	})
+	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/organizations/{id}/site-reads/latest", wrapper.GetLatestSiteRead)
 	})
 	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/organizations/{id}/site-reads/{readId}", wrapper.GetSiteRead)

--- a/backend/internal/modules/people/latestsiteread_integration_test.go
+++ b/backend/internal/modules/people/latestsiteread_integration_test.go
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package people
+
+// A read id lives only in the browser tab that started the crawl. Everything
+// here exists so a company page loaded later can still find out that the crawl
+// failed — the state that made an account look unenriched when it was in fact
+// unreadable, and left a draft with nothing to write from.
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// The newest read wins, so a retry supersedes the attempt before it rather than
+// the page reporting whichever row the database happened to return first.
+func TestLatestSiteReadAnswersTheNewestAttempt(t *testing.T) {
+	e := setupDedupe(t)
+	ctx := e.as()
+	orgID := seedOrgForRead(ctx, t, e)
+
+	first, _, err := e.store.StartSiteRead(ctx, orgID, "https://voltaq.test", "human:"+e.rep.String())
+	if err != nil {
+		t.Fatalf("start the first read: %v", err)
+	}
+	// The create-or-join rule returns the SAME row for a second start while one
+	// is open, which is correct and is not what this test is about: close the
+	// first so the second is a genuinely new attempt.
+	failRead(ctx, t, e, first.ID)
+
+	second, _, err := e.store.StartSiteRead(ctx, orgID, "https://voltaq.test", "human:"+e.rep.String())
+	if err != nil {
+		t.Fatalf("start the second read: %v", err)
+	}
+	if second.ID == first.ID {
+		t.Fatal("the second start joined the finished read instead of opening a new one")
+	}
+
+	latest, err := e.store.LatestSiteRead(ctx, orgID)
+	if err != nil {
+		t.Fatalf("read the latest: %v", err)
+	}
+	if latest.ID != second.ID {
+		t.Fatalf("expected the newest read %s, got %s", second.ID, latest.ID)
+	}
+}
+
+// A failed crawl is exactly the state the company page could not see, so the
+// status has to survive the read rather than being smoothed into something that
+// looks like an account nobody tried to enrich.
+func TestLatestSiteReadCarriesAFailedStatus(t *testing.T) {
+	e := setupDedupe(t)
+	ctx := e.as()
+	orgID := seedOrgForRead(ctx, t, e)
+
+	read, _, err := e.store.StartSiteRead(ctx, orgID, "https://voltaq.test", "human:"+e.rep.String())
+	if err != nil {
+		t.Fatalf("start the read: %v", err)
+	}
+	failRead(ctx, t, e, read.ID)
+
+	latest, err := e.store.LatestSiteRead(ctx, orgID)
+	if err != nil {
+		t.Fatalf("read the latest: %v", err)
+	}
+	if latest.Status != "failed" {
+		t.Fatalf("expected the failed status to survive, got %q", latest.Status)
+	}
+	if latest.PagesRead != 0 {
+		t.Fatalf("a failed crawl read no pages, got %d", latest.PagesRead)
+	}
+}
+
+// Never read and read-but-empty are different answers, and the page renders
+// them differently: one offers a first crawl, the other reports a failure.
+func TestLatestSiteReadIsNotFoundWhenNothingWasEverRead(t *testing.T) {
+	e := setupDedupe(t)
+	ctx := e.as()
+	orgID := seedOrgForRead(ctx, t, e)
+
+	if _, err := e.store.LatestSiteRead(ctx, orgID); !errors.Is(err, apperrors.ErrNotFound) {
+		t.Fatalf("expected ErrNotFound for an account never read, got %v", err)
+	}
+}
+
+// An account the caller cannot see must answer the same not-found as one that
+// was never read: the existence of a crawl is itself information about a record
+// they were not granted.
+func TestLatestSiteReadHidesAnAccountTheCallerCannotSee(t *testing.T) {
+	e := setupDedupe(t)
+	ctx := e.as()
+
+	unknown := ids.From[ids.OrganizationKind](ids.NewV7())
+	if _, err := e.store.LatestSiteRead(ctx, unknown); !errors.Is(err, apperrors.ErrNotFound) {
+		t.Fatalf("expected existence-hiding ErrNotFound, got %v", err)
+	}
+}
+
+func seedOrgForRead(ctx context.Context, t *testing.T, e *dedupeEnv) ids.OrganizationID {
+	t.Helper()
+	org, err := e.store.CreateOrganization(ctx, CreateOrganizationInput{
+		DisplayName: "Voltaq Systems GmbH", Source: "manual",
+		Domains: []OrgDomainInput{{Domain: "voltaq.test", IsPrimary: true}},
+	})
+	if err != nil {
+		t.Fatalf("seed org: %v", err)
+	}
+	return ids.From[ids.OrganizationKind](ids.UUID(org.Id))
+}
+
+// failRead closes a read the way a real crawl failure closes one. The engine
+// that would do it lives in the worker role, which this store test does not
+// run — but the shape is not a detail this test may invent: site_read_outcome_shape
+// requires a failed row to name its code and detail, and a test that wrote a
+// bare status would be asserting against a row the product never produces.
+func failRead(ctx context.Context, t *testing.T, e *dedupeEnv, readID ids.UUID) {
+	t.Helper()
+	err := e.store.tx(ctx, func(tx pgx.Tx) error {
+		_, err := tx.Exec(ctx, `
+			UPDATE site_read
+			   SET status = 'failed', status_code = 'http_server_error',
+			       status_detail = 'the site answered 503 on every attempt',
+			       finished_at = now()
+			 WHERE id = $1`, readID)
+		return err
+	})
+	if err != nil {
+		t.Fatalf("fail read %s: %v", readID, err)
+	}
+}

--- a/backend/internal/modules/people/siteread.go
+++ b/backend/internal/modules/people/siteread.go
@@ -249,6 +249,12 @@ func (s *Store) createOrJoinSiteRead(ctx context.Context, orgID *ids.Organizatio
 	return out, joined, nil
 }
 
+// UpdateSiteReadProgress records the worker's live position — the phase
+// and how many pages have committed — on a still-running dossier, so the
+// SPA's poll shows movement during the crawl and the model call instead
+// of a silent 'running'. Best-effort by contract: a read that is no
+// longer running is simply not updated (the terminal write won), never
+// an error. No auth.Require, same rationale as BeginSiteRead.
 func (s *Store) UpdateSiteReadProgress(ctx context.Context, readID ids.UUID, phase string, pages []SiteReadPage) error {
 	if phase != "crawling" && phase != "extracting" {
 		return fmt.Errorf("people: %q is not a site-read phase (crawling|extracting)", phase)

--- a/backend/internal/modules/people/siteread.go
+++ b/backend/internal/modules/people/siteread.go
@@ -249,69 +249,6 @@ func (s *Store) createOrJoinSiteRead(ctx context.Context, orgID *ids.Organizatio
 	return out, joined, nil
 }
 
-// GetSiteRead reads one dossier, scoped to the organization the caller
-// named: a read id that exists under another org — or an org the caller
-// cannot see — is ErrNotFound (existence-hiding).
-func (s *Store) GetSiteRead(ctx context.Context, orgID ids.OrganizationID, readID ids.UUID) (SiteRead, error) {
-	if err := auth.Require(ctx, "organization", principal.ActionRead); err != nil {
-		return SiteRead{}, err
-	}
-	var out SiteRead
-	err := s.tx(ctx, func(tx pgx.Tx) error {
-		if err := auth.EnsureVisible(ctx, tx, "organization", orgID.UUID); err != nil {
-			return err
-		}
-		row := tx.QueryRow(ctx, `
-			SELECT `+siteReadColumns+` FROM site_read
-			WHERE id = $1 AND organization_id = $2`, readID, orgID)
-		var err error
-		out, err = scanSiteRead(row)
-		if errors.Is(err, pgx.ErrNoRows) {
-			return apperrors.ErrNotFound
-		}
-		if err != nil {
-			return fmt.Errorf("get site read: %w", err)
-		}
-		return nil
-	})
-	if err != nil {
-		return SiteRead{}, err
-	}
-	return out, nil
-}
-
-// GetOnboardingSiteRead reads an unbound dossier without requiring an anchor
-// row to exist. Workspace RLS and the normal organization read/create authority
-// still gate the operational draft.
-func (s *Store) GetOnboardingSiteRead(ctx context.Context, readID ids.UUID) (SiteRead, error) {
-	if err := auth.Require(ctx, "organization", principal.ActionRead); err != nil {
-		if createErr := auth.Require(ctx, "organization", principal.ActionCreate); createErr != nil {
-			return SiteRead{}, createErr
-		}
-	}
-	var out SiteRead
-	err := s.tx(ctx, func(tx pgx.Tx) error {
-		row := tx.QueryRow(ctx, `SELECT `+siteReadColumns+` FROM site_read
-			WHERE id = $1 AND target_kind = 'onboarding'`, readID)
-		var err error
-		out, err = scanSiteRead(row)
-		if errors.Is(err, pgx.ErrNoRows) {
-			return apperrors.ErrNotFound
-		}
-		if err != nil {
-			return fmt.Errorf("get onboarding site read: %w", err)
-		}
-		return nil
-	})
-	return out, err
-}
-
-// UpdateSiteReadProgress records the worker's live position — the phase
-// and how many pages have committed — on a still-running dossier, so the
-// SPA's poll shows movement during the crawl and the model call instead
-// of a silent 'running'. Best-effort by contract: a read that is no
-// longer running is simply not updated (the terminal write won), never
-// an error. No auth.Require, same rationale as BeginSiteRead.
 func (s *Store) UpdateSiteReadProgress(ctx context.Context, readID ids.UUID, phase string, pages []SiteReadPage) error {
 	if phase != "crawling" && phase != "extracting" {
 		return fmt.Errorf("people: %q is not a site-read phase (crawling|extracting)", phase)

--- a/backend/internal/modules/people/sitereadread.go
+++ b/backend/internal/modules/people/sitereadread.go
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package people
+
+// Reading a dossier back: one read by id, the newest read on an account, and
+// the unbound onboarding read.
+//
+// All three answer the same question — what did a crawl find — and all three
+// hide a record the caller may not see behind the same ErrNotFound the id that
+// names nothing produces. They live apart from the write half because the
+// writes are a state machine (create-or-join, claim, defer, finish) while these
+// are plain reads with a scope rule.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/gradionhq/margince/backend/internal/platform/auth"
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+)
+
+// GetSiteRead reads one dossier, scoped to the organization the caller
+// named: a read id that exists under another org — or an org the caller
+// cannot see — is ErrNotFound (existence-hiding).
+func (s *Store) GetSiteRead(ctx context.Context, orgID ids.OrganizationID, readID ids.UUID) (SiteRead, error) {
+	if err := auth.Require(ctx, "organization", principal.ActionRead); err != nil {
+		return SiteRead{}, err
+	}
+	var out SiteRead
+	err := s.tx(ctx, func(tx pgx.Tx) error {
+		if err := auth.EnsureVisible(ctx, tx, "organization", orgID.UUID); err != nil {
+			return err
+		}
+		row := tx.QueryRow(ctx, `
+			SELECT `+siteReadColumns+` FROM site_read
+			WHERE id = $1 AND organization_id = $2`, readID, orgID)
+		var err error
+		out, err = scanSiteRead(row)
+		if errors.Is(err, pgx.ErrNoRows) {
+			return apperrors.ErrNotFound
+		}
+		if err != nil {
+			return fmt.Errorf("get site read: %w", err)
+		}
+		return nil
+	})
+	if err != nil {
+		return SiteRead{}, err
+	}
+	return out, nil
+}
+
+// LatestSiteRead reads the most recent deep read on an account, or reports
+// ErrNotFound when the account has never been read.
+//
+// The company page needs this because a read id lives only in the browser tab
+// that started the crawl. A read that failed after the rep navigated away was
+// therefore invisible: the page showed an account with no industry, no
+// description and no facts, which looks exactly like an account nobody has
+// tried to enrich — and a draft written from it invented what it could not
+// find. Newest by created_at, so a retry supersedes the attempt before it.
+func (s *Store) LatestSiteRead(ctx context.Context, orgID ids.OrganizationID) (SiteRead, error) {
+	if err := auth.Require(ctx, "organization", principal.ActionRead); err != nil {
+		return SiteRead{}, err
+	}
+	var out SiteRead
+	err := s.tx(ctx, func(tx pgx.Tx) error {
+		if err := auth.EnsureVisible(ctx, tx, "organization", orgID.UUID); err != nil {
+			return err
+		}
+		row := tx.QueryRow(ctx, `
+			SELECT `+siteReadColumns+` FROM site_read
+			WHERE organization_id = $1
+			ORDER BY created_at DESC, id DESC
+			LIMIT 1`, orgID)
+		var err error
+		out, err = scanSiteRead(row)
+		if errors.Is(err, pgx.ErrNoRows) {
+			return apperrors.ErrNotFound
+		}
+		if err != nil {
+			return fmt.Errorf("get latest site read: %w", err)
+		}
+		return nil
+	})
+	if err != nil {
+		return SiteRead{}, err
+	}
+	return out, nil
+}
+
+// GetOnboardingSiteRead reads an unbound dossier without requiring an anchor
+// row to exist. Workspace RLS and the normal organization read/create authority
+// still gate the operational draft.
+func (s *Store) GetOnboardingSiteRead(ctx context.Context, readID ids.UUID) (SiteRead, error) {
+	if err := auth.Require(ctx, "organization", principal.ActionRead); err != nil {
+		if createErr := auth.Require(ctx, "organization", principal.ActionCreate); createErr != nil {
+			return SiteRead{}, createErr
+		}
+	}
+	var out SiteRead
+	err := s.tx(ctx, func(tx pgx.Tx) error {
+		row := tx.QueryRow(ctx, `SELECT `+siteReadColumns+` FROM site_read
+			WHERE id = $1 AND target_kind = 'onboarding'`, readID)
+		var err error
+		out, err = scanSiteRead(row)
+		if errors.Is(err, pgx.ErrNoRows) {
+			return apperrors.ErrNotFound
+		}
+		if err != nil {
+			return fmt.Errorf("get onboarding site read: %w", err)
+		}
+		return nil
+	})
+	return out, err
+}
+
+// UpdateSiteReadProgress records the worker's live position — the phase
+// and how many pages have committed — on a still-running dossier, so the
+// SPA's poll shows movement during the crawl and the model call instead
+// of a silent 'running'. Best-effort by contract: a read that is no
+// longer running is simply not updated (the terminal write won), never
+// an error. No auth.Require, same rationale as BeginSiteRead.

--- a/backend/internal/modules/people/sitereadread.go
+++ b/backend/internal/modules/people/sitereadread.go
@@ -120,10 +120,3 @@ func (s *Store) GetOnboardingSiteRead(ctx context.Context, readID ids.UUID) (Sit
 	})
 	return out, err
 }
-
-// UpdateSiteReadProgress records the worker's live position — the phase
-// and how many pages have committed — on a still-running dossier, so the
-// SPA's poll shows movement during the crawl and the model call instead
-// of a silent 'running'. Best-effort by contract: a read that is no
-// longer running is simply not updated (the terminal write won), never
-// an error. No auth.Require, same rationale as BeginSiteRead.

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -1658,6 +1658,34 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/organizations/{id}/site-reads/latest": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Opaque resource id (UUID; ordering semantics are not exposed). */
+                id: components["parameters"]["Id"];
+            };
+            cookie?: never;
+        };
+        /**
+         * The newest deep read on this account, so a crawl that failed after the rep navigated away is still visible.
+         * @description A read id lives only in the browser tab that started the crawl, so a read that
+         *     ended after the rep left the page could not be found again. An account whose
+         *     crawl failed then looked exactly like one nobody had tried to enrich — no
+         *     industry, no description, no facts — and a draft written from it had nothing to
+         *     stand on. 404 when the account has never been read, which is the honest
+         *     difference between "never tried" and "tried and got nothing".
+         */
+        get: operations["getLatestSiteRead"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/organizations/{id}/site-reads/{readId}": {
         parameters: {
             query?: never;
@@ -18075,6 +18103,31 @@ export interface operations {
                     "application/problem+json": components["schemas"]["Problem"];
                 };
             };
+        };
+    };
+    getLatestSiteRead: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Opaque resource id (UUID; ordering semantics are not exposed). */
+                id: components["parameters"]["Id"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The newest read's report. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SiteReadReport"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            404: components["responses"]["NotFound"];
         };
     };
     getSiteRead: {

--- a/frontend/src/screens/organizations.tsx
+++ b/frontend/src/screens/organizations.tsx
@@ -1,4 +1,4 @@
-import { useMutation, useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import type { ReactNode } from "react";
 import { useState } from "react";
 import { api } from "../api/client";
@@ -965,6 +965,7 @@ function SiteReadPanel({
 // unwired) surface their honest cause instead of a generic failure.
 function DeepReadCard({ orgId }: Readonly<{ orgId: string }>) {
   const t = useT();
+  const queryClient = useQueryClient();
   const [readId, setReadId] = useState<string | null>(null);
   // A read id lives only in the tab that started the crawl, so a read that
   // ended after the rep navigated away used to be unfindable — and an account
@@ -1006,7 +1007,17 @@ function DeepReadCard({ orgId }: Readonly<{ orgId: string }>) {
       }
       return data;
     },
-    onSuccess: (started) => setReadId(started.read_id),
+    onSuccess: (started) => {
+      setReadId(started.read_id);
+      // The started read IS the latest one, so say so rather than leaving the
+      // cached answer to expire. Without this the card holds a 30s stale
+      // "never read" (FE-PARAM-1) that a rep who navigates away and back
+      // inside the window still sees — the same invisible-crawl state this
+      // query was added to end.
+      queryClient.invalidateQueries({
+        queryKey: ["site-read-latest", orgId],
+      });
+    },
   });
 
   return (

--- a/frontend/src/screens/organizations.tsx
+++ b/frontend/src/screens/organizations.tsx
@@ -966,6 +966,28 @@ function SiteReadPanel({
 function DeepReadCard({ orgId }: Readonly<{ orgId: string }>) {
   const t = useT();
   const [readId, setReadId] = useState<string | null>(null);
+  // A read id lives only in the tab that started the crawl, so a read that
+  // ended after the rep navigated away used to be unfindable — and an account
+  // whose crawl FAILED then looked exactly like one nobody had tried to
+  // enrich. 404 is the honest "never read" and leaves the card offering a
+  // first crawl.
+  const latest = useQuery({
+    queryKey: ["site-read-latest", orgId],
+    queryFn: async () => {
+      const { data, error, response } = await api.GET(
+        "/organizations/{id}/site-reads/latest",
+        { params: { path: { id: orgId } } },
+      );
+      if (response.status === 404) {
+        return null;
+      }
+      if (error) {
+        throwProblem(error);
+      }
+      return data ?? null;
+    },
+  });
+  const shownReadId = readId ?? latest.data?.read_id ?? null;
   const start = useMutation({
     mutationFn: async () => {
       const { data, error, response } = await api.POST(
@@ -1003,7 +1025,7 @@ function DeepReadCard({ orgId }: Readonly<{ orgId: string }>) {
           {problemMessageOf(start.error, t)}
         </p>
       )}
-      {readId && <SiteReadPanel orgId={orgId} readId={readId} />}
+      {shownReadId && <SiteReadPanel orgId={orgId} readId={shownReadId} />}
     </Card>
   );
 }


### PR DESCRIPTION
## What was wrong

A site-read id lived only in the browser tab that started the crawl
(`useState` in `DeepReadCard`). A read that ended after the rep navigated away
could not be found again — so an account whose website crawl **failed** looked
exactly like one nobody had ever tried to enrich: no industry, no description,
no facts, and nothing on the page to tell the two apart.

This is the state behind the reported nonsense draft. The account in question
had two site reads — one `failed`, one `cancelled`, both `pages_read = 0` — and
the page showed none of it while the drafter had nothing to write from.

## What changed

`GET /organizations/{id}/site-reads/latest` answers the newest read on an
account. The company page loads it on mount, so a failed crawl is visible on
every later visit rather than only in the tab that started it.

404 remains the honest "never read", which the card treats as null and keeps
offering a first crawl. Never-tried and tried-and-got-nothing are different
answers and the page renders them differently.

`SiteReadPanel` already rendered a failure well — danger badge, page count, fact
count, stop reason. It was simply unreachable.

## Scope and safety

`LatestSiteRead` is gated exactly like `GetSiteRead`: `auth.Require` plus
`EnsureVisible`, so an account the caller cannot see answers the same
existence-hiding not-found as one that was never read.

## Tests

Integration lane (`make test-it DIR=backend/internal/modules/people`), because
this is a store read with a scope rule that unit tests cannot see:

- the newest read wins, so a retry supersedes the attempt before it
- a `failed` status and its zero page count survive the read
- an account never read is `ErrNotFound`
- an account the caller cannot see is the same `ErrNotFound`

The first version of that test wrote `status = 'failed'` with no code or detail
and was rejected by the `site_read_outcome_shape` CHECK — a row the product
never produces. The helper now closes a read the way a real failure closes one.

## Verified running

On a live stack: 404 before any read, then after inserting a failed read,
`200` with `status: failed`, `status_code: http_server_error`,
`status_detail: "the site answered 503 on every attempt"`, `pages_read: 0`.

## Incidental

`siteread.go` crossed the 500-line cap, so the three read methods move to
`sitereadread.go`. The writes are a state machine (create-or-join, claim, defer,
finish); these are plain reads with a scope rule.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows the newest deep read on the company page and refreshes it when a crawl starts, so failures that finish after the rep leaves no longer appear “never read”. Old: the read id lived only in the starting tab; new: the page loads the latest read on mount and invalidates it on start; 404 still means “never read”.

- Adds GET /organizations/{id}/site-reads/latest (newest by created_at then id). Returns the newest report; 404 when never read. Scoped with auth.Require and EnsureVisible; transport, router, agent policy, and stubs wired.
- Frontend `DeepReadCard` loads the latest on mount, uses its `read_id` if no local id exists, and invalidates the “latest” query on start to prevent a stale “never read”.
- Store implements `LatestSiteRead`; read methods move to `sitereadread.go`. Integration tests cover newest-wins, failed status with `pages_read = 0`, never-read, and hidden org. No changes to GET /organizations/{id}/site-reads/{readId} behavior.

<sup>Written for commit 30f2c38fb8ec7a260bfc1814985f924dca27fb10. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1178?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added access to the latest site-read report for an organization.
  * Site-read results now remain available after navigating away or reloading.
  * Newly started reads continue to take priority over previously completed reads.

* **Bug Fixes**
  * Preserved failed read statuses and reports with zero pages.
  * Organizations without accessible or available reads are handled appropriately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->