### PR TITLE
refactor(ai): the voice tables drop the tenant column (ADR-0091 §8 phase D)

### DIFF
--- a/backend/internal/compose/integration/retention_integration_test.go
+++ b/backend/internal/compose/integration/retention_integration_test.go
@@ -165,24 +165,24 @@ func TestRetentionErasesOverAgeVoiceSignalPlaintext(t *testing.T) {
 	inWindow := ids.NewV7()
 	err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 		if _, err := tx.Exec(context.Background(), `
-			INSERT INTO voice_profile (id, workspace_id, owner_id, scope, source, captured_by)
-			VALUES ($1, $2, $3, 'user', 'ui', 'human:x')`, profileID, e.WS, e.Rep1); err != nil {
+			INSERT INTO voice_profile (id, owner_id, scope, source, captured_by)
+			VALUES ($1, $2, 'user', 'ui', 'human:x')`, profileID, e.Rep1); err != nil {
 			return err
 		}
 		if _, err := tx.Exec(context.Background(), `
 			INSERT INTO voice_learning_signal
-			  (id, workspace_id, voice_profile_id, draft_ref_hash, outcome, generated_original,
+			  (id, voice_profile_id, draft_ref_hash, outcome, generated_original,
 			   retention_until, source, captured_by)
-			VALUES ($1, $2, $3, sha256('over-age'::bytea), 'drafted', 'over-age plaintext',
-			        now() - interval '1 day', 'draft', 'human:x')`, overAge, e.WS, profileID); err != nil {
+			VALUES ($1, $2, sha256('over-age'::bytea), 'drafted', 'over-age plaintext',
+			        now() - interval '1 day', 'draft', 'human:x')`, overAge, profileID); err != nil {
 			return err
 		}
 		_, err := tx.Exec(context.Background(), `
 			INSERT INTO voice_learning_signal
-			  (id, workspace_id, voice_profile_id, draft_ref_hash, outcome, generated_original,
+			  (id, voice_profile_id, draft_ref_hash, outcome, generated_original,
 			   retention_until, source, captured_by)
-			VALUES ($1, $2, $3, sha256('in-window'::bytea), 'drafted', 'fresh plaintext',
-			        now() + interval '90 days', 'draft', 'human:x')`, inWindow, e.WS, profileID)
+			VALUES ($1, $2, sha256('in-window'::bytea), 'drafted', 'fresh plaintext',
+			        now() + interval '90 days', 'draft', 'human:x')`, inWindow, profileID)
 		return err
 	})
 	if err != nil {

--- a/backend/internal/compose/integration/voice_lifecycle_http_integration_test.go
+++ b/backend/internal/compose/integration/voice_lifecycle_http_integration_test.go
@@ -66,14 +66,14 @@ const voiceLifecycleEvaluation = `{
   "passed": true
 }`
 
-func seedVoiceLifecycleHistory(t *testing.T, e *apptest.AppEnv, profileID string) (ids.UUID, ids.UUID) {
+func seedVoiceLifecycleHistory(t *testing.T, e *apptest.AppEnv, profileID string) ids.UUID {
 	t.Helper()
 	ctx := context.Background()
-	var workspaceID, ownerID ids.UUID
+	var ownerID ids.UUID
 	if err := e.Owner.QueryRow(
 		ctx,
-		`SELECT workspace_id, owner_id FROM voice_profile WHERE id = $1`, profileID,
-	).Scan(&workspaceID, &ownerID); err != nil {
+		`SELECT owner_id FROM voice_profile WHERE id = $1`, profileID,
+	).Scan(&ownerID); err != nil {
 		t.Fatal(err)
 	}
 	capturedBy := "human:" + ownerID.String()
@@ -86,25 +86,24 @@ func seedVoiceLifecycleHistory(t *testing.T, e *apptest.AppEnv, profileID string
 	}
 	if _, err := e.Owner.Exec(ctx, `
 		INSERT INTO voice_profile_version
-		  (workspace_id, voice_profile_id, profile_version, status, voice_profile_md,
+		  (voice_profile_id, profile_version, status, voice_profile_md,
 		   profile_json, stats_json, source_hash, source_count, reason,
 		   model_provider, model_name, builder_version, activation_policy_version,
 		   evaluation_json, review_reasons, activated_at, source, captured_by, updated_at)
-		VALUES ($1, $2, 1, 'active', 'active version 1',
+		VALUES ($1, 1, 'active', 'active version 1',
 		        '{"document":"active version 1"}', '{"avg_sentence_words":8}',
 		        'active-hash', 1, 'manual', 'test', 'test-model', 'test-builder', '1',
-		        $3::jsonb, '{}', now(), 'ui', $4, now())`,
-		workspaceID, profileID, voiceLifecycleEvaluation, capturedBy); err != nil {
+		        $2::jsonb, '{}', now(), 'ui', $3, now())`,
+		profileID, voiceLifecycleEvaluation, capturedBy); err != nil {
 		t.Fatal(err)
 	}
-	seedVoiceLifecycleCandidate(t, e, workspaceID, profileID, 2, 1, capturedBy)
-	return workspaceID, ownerID
+	seedVoiceLifecycleCandidate(t, e, profileID, 2, 1, capturedBy)
+	return ownerID
 }
 
 func seedVoiceLifecycleCandidate(
 	t *testing.T,
 	e *apptest.AppEnv,
-	workspaceID ids.UUID,
 	profileID string,
 	profileVersion int,
 	predecessor int,
@@ -115,39 +114,39 @@ func seedVoiceLifecycleCandidate(
 	artifact := "candidate version " + strconv.Itoa(profileVersion)
 	if _, err := e.Owner.Exec(ctx, `
 		INSERT INTO voice_profile_version
-		  (workspace_id, voice_profile_id, profile_version, status, voice_profile_md,
+		  (voice_profile_id, profile_version, status, voice_profile_md,
 		   profile_json, stats_json, source_hash, source_count, reason, predecessor_version,
 		   model_provider, model_name, builder_version, activation_policy_version,
 		   evaluation_json, review_reasons, source, captured_by, updated_at)
-		VALUES ($1, $2, $3, 'candidate', $4,
-		        jsonb_build_object('document', $4::text), '{"avg_sentence_words":9}',
-		        $5, 2, 'automatic', $6, 'test', 'test-model', 'test-builder', '1',
-		        $7::jsonb, ARRAY['owner review'], 'system', $8, now())`,
-		workspaceID, profileID, profileVersion, artifact,
+		VALUES ($1, $2, 'candidate', $3,
+		        jsonb_build_object('document', $3::text), '{"avg_sentence_words":9}',
+		        $4, 2, 'automatic', $5, 'test', 'test-model', 'test-builder', '1',
+		        $6::jsonb, ARRAY['owner review'], 'system', $7, now())`,
+		profileID, profileVersion, artifact,
 		"candidate-hash-"+strconv.Itoa(profileVersion), predecessor,
 		voiceLifecycleEvaluation, capturedBy); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := e.Owner.Exec(ctx, `
 		INSERT INTO voice_profile_delta
-		  (workspace_id, voice_profile_id, from_version, to_version, classification,
+		  (voice_profile_id, from_version, to_version, classification,
 		   activation_outcome, delta_json)
-		VALUES ($1, $2, $3, $4, 'routine', 'review_required',
+		VALUES ($1, $2, $3, 'routine', 'review_required',
 		        '{"words_added":10,"sources_added":1,"sources_excluded":0,"identity_word_jaccard":1,"signature_set_jaccard":1,"avoid_rules_added":0,"avoid_rules_removed":0,"register_rules_removed":0}')`,
-		workspaceID, profileID, predecessor, profileVersion); err != nil {
+		profileID, predecessor, profileVersion); err != nil {
 		t.Fatal(err)
 	}
 }
 
-func seedVoiceDraftSignal(t *testing.T, e *apptest.AppEnv, workspaceID ids.UUID, profileID string, ownerID ids.UUID, draftRef string) {
+func seedVoiceDraftSignal(t *testing.T, e *apptest.AppEnv, profileID string, ownerID ids.UUID, draftRef string) {
 	t.Helper()
 	hash := sha256.Sum256([]byte(draftRef))
 	if _, err := e.Owner.Exec(context.Background(), `
 		INSERT INTO voice_learning_signal
-		  (workspace_id, voice_profile_id, profile_version, draft_ref_hash, outcome,
+		  (voice_profile_id, profile_version, draft_ref_hash, outcome,
 		   generated_original, transformations, retention_until, source, captured_by)
-		VALUES ($1, $2, 2, $3, 'drafted', 'generated draft', '[]', $4, 'system', $5)`,
-		workspaceID, profileID, hash[:], time.Now().UTC().Add(30*24*time.Hour),
+		VALUES ($1, 2, $2, 'drafted', 'generated draft', '[]', $3, 'system', $4)`,
+		profileID, hash[:], time.Now().UTC().Add(30*24*time.Hour),
 		"human:"+ownerID.String()); err != nil {
 		t.Fatal(err)
 	}
@@ -170,7 +169,7 @@ func TestVoiceLifecycleHTTPRoundTrip(t *testing.T) {
 	if removed.ID != removable.Source.ID || removed.Version != removable.Source.Version+1 {
 		t.Fatalf("removed source = %+v, want archived version of %+v", removed, removable.Source)
 	}
-	workspaceID, ownerID := seedVoiceLifecycleHistory(t, e, created.ID)
+	ownerID := seedVoiceLifecycleHistory(t, e, created.ID)
 
 	if status := e.Call(t, "GET", base+"/versions?cursor=not-a-cursor", nil, nil, nil); status != http.StatusUnprocessableEntity {
 		t.Fatalf("invalid version cursor → %d, want 422", status)
@@ -227,7 +226,7 @@ func TestVoiceLifecycleHTTPRoundTrip(t *testing.T) {
 		t.Fatalf("applied version = %+v", applied)
 	}
 
-	seedVoiceLifecycleCandidate(t, e, workspaceID, created.ID, 3, 2, "human:"+ownerID.String())
+	seedVoiceLifecycleCandidate(t, e, created.ID, 3, 2, "human:"+ownerID.String())
 	var rejected voiceVersionWire
 	if status := e.Call(t, "POST", base+"/versions/3/reject", nil,
 		map[string]string{"If-Match": "1"}, &rejected); status != http.StatusOK {
@@ -253,7 +252,7 @@ func TestVoiceLifecycleHTTPRoundTrip(t *testing.T) {
 	}
 
 	draftRef := "draft:lifecycle-http"
-	seedVoiceDraftSignal(t, e, workspaceID, created.ID, ownerID, draftRef)
+	seedVoiceDraftSignal(t, e, created.ID, ownerID, draftRef)
 	var beforeReject voiceLearningSummaryWire
 	if status := e.Call(t, "GET", base+"/learning", nil, nil, &beforeReject); status != http.StatusOK {
 		t.Fatalf("learning summary → %d", status)

--- a/backend/internal/compose/integration/voice_sendoutcome_integration_test.go
+++ b/backend/internal/compose/integration/voice_sendoutcome_integration_test.go
@@ -54,9 +54,13 @@ func setupVoiceSend(t *testing.T) *voiceSendEnv {
 	profile := createVoiceProfile(t, e)
 
 	var workspaceID, ownerID ids.UUID
-	if err := e.Owner.QueryRow(context.Background(),
-		`SELECT workspace_id, owner_id FROM voice_profile WHERE id = $1`, profile.ID).
-		Scan(&workspaceID, &ownerID); err != nil {
+	// The workspace comes from the profile's OWNER now: app_user still carries
+	// the column and voice_profile does not, and the colleague this suite seeds
+	// has to land in the same one.
+	if err := e.Owner.QueryRow(context.Background(), `
+		SELECT u.workspace_id, p.owner_id
+		FROM voice_profile p JOIN app_user u ON u.id = p.owner_id
+		WHERE p.id = $1`, profile.ID).Scan(&workspaceID, &ownerID); err != nil {
 		t.Fatalf("resolving the profile's workspace and owner: %v", err)
 	}
 
@@ -128,9 +132,9 @@ func (e *voiceSendEnv) openVoiceDraft(t *testing.T, opts voiceDraftOptions) (ref
 		}
 		var foreign ids.UUID
 		if err := e.Owner.QueryRow(ctx, `
-			INSERT INTO voice_profile (workspace_id, owner_id, scope, status, source, captured_by)
-			VALUES ($1, $2, 'user', 'ready', 'ui', $3) RETURNING id`,
-			e.workspaceID, colleague, "human:"+colleague.String()).Scan(&foreign); err != nil {
+			INSERT INTO voice_profile (owner_id, scope, status, source, captured_by)
+			VALUES ($1, 'user', 'ready', 'ui', $2) RETURNING id`,
+			colleague, "human:"+colleague.String()).Scan(&foreign); err != nil {
 			t.Fatalf("seeding the colleague's voice profile: %v", err)
 		}
 		profileID, ownerID = foreign, colleague
@@ -144,10 +148,10 @@ func (e *voiceSendEnv) openVoiceDraft(t *testing.T, opts voiceDraftOptions) (ref
 	}
 	if err := e.Owner.QueryRow(ctx, `
 		INSERT INTO voice_learning_signal
-		  (workspace_id, voice_profile_id, draft_ref_hash, outcome, generated_original,
+		  (voice_profile_id, draft_ref_hash, outcome, generated_original,
 		   content_erased_at, retention_until, source, captured_by)
-		VALUES ($1, $2, $3, 'drafted', $4, $5, $6, 'draft', $7) RETURNING id`,
-		e.workspaceID, profileID, hash[:], generated, erasedAt,
+		VALUES ($1, $2, 'drafted', $3, $4, $5, 'draft', $6) RETURNING id`,
+		profileID, hash[:], generated, erasedAt,
 		time.Now().UTC().Add(180*24*time.Hour), "human:"+ownerID.String()).Scan(&signal); err != nil {
 		t.Fatalf("seeding the drafted learning signal: %v", err)
 	}

--- a/backend/internal/compose/integration/voicestore_integration_test.go
+++ b/backend/internal/compose/integration/voicestore_integration_test.go
@@ -41,29 +41,29 @@ var voiceRepPerms = principal.Permissions{
 	RowScope: principal.RowScopeTeam,
 }
 
-func seedVoiceCandidate(t *testing.T, pool *pgxpool.Pool, workspaceID, profileID ids.UUID, profileVersion, predecessor int, classification string) {
+func seedVoiceCandidate(t *testing.T, pool *pgxpool.Pool, profileID ids.UUID, profileVersion, predecessor int, classification string) {
 	t.Helper()
 	ctx := context.Background()
 	evaluation := `{"held_out_prompts":5,"repeats_per_prompt":3,"active_median_voice_score":1,"candidate_median_voice_score":1,"anti_ai_hard_failures":0,"structured_output_valid":true,"corpus_citations_valid":true,"identity_word_jaccard":1,"signature_set_jaccard":1,"removed_avoid_rules":0,"removed_register_rules":0,"classification":"` + classification + `","passed":true}`
 	if _, err := pool.Exec(ctx, `
 		INSERT INTO voice_profile_version
-		  (workspace_id, voice_profile_id, profile_version, status, voice_profile_md,
+		  (voice_profile_id, profile_version, status, voice_profile_md,
 		   profile_json, stats_json, source_hash, source_count, reason, predecessor_version,
 		   model_provider, model_name, builder_version, activation_policy_version,
 		   evaluation_json, review_reasons, source, captured_by, updated_at)
-		VALUES ($1, $2, $3, 'candidate', $4::text, jsonb_build_object('document', $4::text), '{}'::jsonb,
-		        'candidate-hash', 1, 'automatic', $5, 'test', 'test', 'test', 'test',
-		        $6::jsonb, ARRAY['owner review'], 'system', 'system', now())`,
-		workspaceID, profileID, profileVersion, "candidate version "+strconv.Itoa(profileVersion), predecessor, evaluation); err != nil {
+		VALUES ($1, $2, 'candidate', $3::text, jsonb_build_object('document', $3::text), '{}'::jsonb,
+		        'candidate-hash', 1, 'automatic', $4, 'test', 'test', 'test', 'test',
+		        $5::jsonb, ARRAY['owner review'], 'system', 'system', now())`,
+		profileID, profileVersion, "candidate version "+strconv.Itoa(profileVersion), predecessor, evaluation); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := pool.Exec(ctx, `
 		INSERT INTO voice_profile_delta
-		  (workspace_id, voice_profile_id, from_version, to_version, classification,
+		  (voice_profile_id, from_version, to_version, classification,
 		   activation_outcome, delta_json)
-		VALUES ($1, $2, $3, $4, $5, 'review_required',
+		VALUES ($1, $2, $3, $4, 'review_required',
 		        '{"words_added":1,"sources_added":1,"sources_excluded":0,"identity_word_jaccard":1,"signature_set_jaccard":1,"avoid_rules_added":0,"avoid_rules_removed":0,"register_rules_removed":0}')`,
-		workspaceID, profileID, predecessor, profileVersion, classification); err != nil {
+		profileID, predecessor, profileVersion, classification); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -365,7 +365,7 @@ func TestVoiceCandidateTransitionsUseCandidateConcurrencyAndForwardRollback(t *t
 		t.Fatal(err)
 	}
 
-	seedVoiceCandidate(t, ownerDB, e.WS, profile.ID, 2, 1, "material")
+	seedVoiceCandidate(t, ownerDB, profile.ID, 2, 1, "material")
 	candidateVersion := int64(1)
 	applied, err := voice.ApplyVersion(owner, profile.ID, 2, &candidateVersion)
 	if err != nil {
@@ -382,7 +382,7 @@ func TestVoiceCandidateTransitionsUseCandidateConcurrencyAndForwardRollback(t *t
 		t.Fatalf("profile after apply = %+v", active)
 	}
 
-	seedVoiceCandidate(t, ownerDB, e.WS, profile.ID, 3, 2, "material")
+	seedVoiceCandidate(t, ownerDB, profile.ID, 3, 2, "material")
 	rejected, err := voice.RejectVersion(owner, profile.ID, 3, &candidateVersion)
 	if err != nil {
 		t.Fatal(err)
@@ -480,10 +480,10 @@ func TestVoiceDraftRejectionIsIdempotentAndTerminalSafe(t *testing.T) {
 	var signalID ids.UUID
 	if err := ownerDB.QueryRow(context.Background(), `
 		INSERT INTO voice_learning_signal
-		  (workspace_id, voice_profile_id, draft_ref_hash, outcome, generated_original,
+		  (voice_profile_id, draft_ref_hash, outcome, generated_original,
 		   retention_until, source, captured_by)
-		VALUES ($1, $2, $3, 'drafted', 'private generated text', $4, 'system', 'system')
-		RETURNING id`, e.WS, profile.ID, draftHash[:], time.Now().Add(24*time.Hour)).Scan(&signalID); err != nil {
+		VALUES ($1, $2, 'drafted', 'private generated text', $3, 'system', 'system')
+		RETURNING id`, profile.ID, draftHash[:], time.Now().Add(24*time.Hour)).Scan(&signalID); err != nil {
 		t.Fatal(err)
 	}
 	summary, err := voice.RejectDraft(owner, profile.ID, draftRef)
@@ -520,9 +520,9 @@ func TestVoiceDraftRejectionIsIdempotentAndTerminalSafe(t *testing.T) {
 	acceptedHash := sha256.Sum256([]byte(acceptedRef))
 	if _, err := ownerDB.Exec(context.Background(), `
 		INSERT INTO voice_learning_signal
-		  (workspace_id, voice_profile_id, draft_ref_hash, outcome, retention_until, source, captured_by)
-		VALUES ($1, $2, $3, 'accepted', $4, 'system', 'system')`,
-		e.WS, profile.ID, acceptedHash[:], time.Now().Add(24*time.Hour)); err != nil {
+		  (voice_profile_id, draft_ref_hash, outcome, retention_until, source, captured_by)
+		VALUES ($1, $2, 'accepted', $3, 'system', 'system')`,
+		profile.ID, acceptedHash[:], time.Now().Add(24*time.Hour)); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := voice.RejectDraft(owner, profile.ID, acceptedRef); !errors.Is(err, apperrors.ErrConflict) {
@@ -548,11 +548,11 @@ func TestVoiceClearCorpusScrubsQualifyingLearningSignal(t *testing.T) {
 	qualHash := sha256.Sum256([]byte("reply:edited-sent-1"))
 	if _, err := ownerDB.Exec(context.Background(), `
 		INSERT INTO voice_learning_signal
-		  (workspace_id, voice_profile_id, draft_ref_hash, outcome, final_text,
+		  (voice_profile_id, draft_ref_hash, outcome, final_text,
 		   final_captured_by, qualifies_as_source, retention_until, source, captured_by)
-		VALUES ($1, $2, $3, 'edited_sent', 'the human-authored final text',
-		        'human:ada', true, $4, 'system', 'system')`,
-		e.WS, profile.ID, qualHash[:], time.Now().Add(24*time.Hour)); err != nil {
+		VALUES ($1, $2, 'edited_sent', 'the human-authored final text',
+		        'human:ada', true, $3, 'system', 'system')`,
+		profile.ID, qualHash[:], time.Now().Add(24*time.Hour)); err != nil {
 		t.Fatal(err)
 	}
 
@@ -564,8 +564,8 @@ func TestVoiceClearCorpusScrubsQualifyingLearningSignal(t *testing.T) {
 	var finalText *string
 	if err := ownerDB.QueryRow(context.Background(), `
 		SELECT qualifies_as_source, final_text FROM voice_learning_signal
-		WHERE workspace_id = $1 AND voice_profile_id = $2`,
-		e.WS, profile.ID).Scan(&qualifies, &finalText); err != nil {
+		WHERE voice_profile_id = $1`,
+		profile.ID).Scan(&qualifies, &finalText); err != nil {
 		t.Fatal(err)
 	}
 	if qualifies || finalText != nil {

--- a/backend/internal/compose/sendvoiceoutcome_integration_test.go
+++ b/backend/internal/compose/sendvoiceoutcome_integration_test.go
@@ -108,9 +108,9 @@ func seedVoiceProfile(t *testing.T, owner *pgx.Conn, workspace, ownerUser ids.UU
 	t.Helper()
 	var profile ids.UUID
 	if err := owner.QueryRow(context.Background(), `
-		INSERT INTO voice_profile (workspace_id, owner_id, scope, status, source, captured_by)
-		VALUES ($1, $2, 'user', 'ready', 'ui', $3) RETURNING id`,
-		workspace, ownerUser, "human:"+ownerUser.String()).Scan(&profile); err != nil {
+		INSERT INTO voice_profile (owner_id, scope, status, source, captured_by)
+		VALUES ($1, 'user', 'ready', 'ui', $2) RETURNING id`,
+		ownerUser, "human:"+ownerUser.String()).Scan(&profile); err != nil {
 		t.Fatalf("seeding the voice profile: %v", err)
 	}
 	return profile
@@ -126,10 +126,10 @@ func (e *voiceSendEnv) openDraft(t *testing.T) voiceDraft {
 	hash := sha256.Sum256([]byte(draft.ref))
 	if err := e.owner.QueryRow(context.Background(), `
 		INSERT INTO voice_learning_signal
-		  (workspace_id, voice_profile_id, draft_ref_hash, outcome, generated_original,
+		  (voice_profile_id, draft_ref_hash, outcome, generated_original,
 		   retention_until, source, captured_by)
-		VALUES ($1, $2, $3, 'drafted', $4, $5, 'draft', $6) RETURNING id`,
-		e.WS, draft.profile, hash[:], voiceDraftBody,
+		VALUES ($1, $2, 'drafted', $3, $4, 'draft', $5) RETURNING id`,
+		draft.profile, hash[:], voiceDraftBody,
 		time.Now().UTC().Add(180*24*time.Hour), "human:"+e.Rep1.String()).Scan(&draft.signal); err != nil {
 		t.Fatalf("seeding the drafted learning signal: %v", err)
 	}

--- a/backend/internal/modules/ai/voice.go
+++ b/backend/internal/modules/ai/voice.go
@@ -230,9 +230,8 @@ func (s *VoiceStore) CreateProfile(ctx context.Context, in CreateVoiceProfileInp
 		var err error
 		p, err = scanVoiceProfile(tx.QueryRow(ctx, storekit.SQLf(`
 			INSERT INTO voice_profile
-			  (workspace_id, owner_id, scope, status, personality_md, source, captured_by, updated_at)
-			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid,
-			        $1, 'user', 'collecting', $2, 'ui', $3, $4)
+			  (owner_id, scope, status, personality_md, source, captured_by, updated_at)
+			VALUES ($1, 'user', 'collecting', $2, 'ui', $3, $4)
 			RETURNING %s`, voiceProfileColumns),
 			actor.UserID, in.PersonalityMD, actor.ID, s.now().UTC()))
 		if storekit.IsUniqueViolation(err) {

--- a/backend/internal/modules/ai/voice_build_complete.go
+++ b/backend/internal/modules/ai/voice_build_complete.go
@@ -194,12 +194,11 @@ func (s *VoiceStore) persistBuildVersion(ctx context.Context, tx pgx.Tx, build V
 	}
 	version, err := scanVoiceVersion(tx.QueryRow(ctx, storekit.SQLf(`
 		INSERT INTO voice_profile_version
-		  (workspace_id, voice_profile_id, profile_version, status, voice_profile_md,
+		  (voice_profile_id, profile_version, status, voice_profile_md,
 		   profile_json, stats_json, source_hash, source_count, reason, predecessor_version,
 		   model_provider, model_name, builder_version, activation_policy_version,
 		   evaluation_json, review_reasons, activated_at, source, captured_by, updated_at)
-		VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid,
-		        $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, '2', $14, $15, $16, 'build', $17, $18)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, '2', $14, $15, $16, 'build', $17, $18)
 		RETURNING %s`, voiceVersionColumns),
 		build.ProfileID, nextVersion, status, outcome.Artifact.Markdown,
 		storekit.JSONArg(profileJSON), statsJSON,
@@ -247,10 +246,9 @@ func insertVoiceBuildDelta(ctx context.Context, tx pgx.Tx, build VoiceBuild, pro
 	}
 	_, err := tx.Exec(ctx, `
 		INSERT INTO voice_profile_delta
-		  (workspace_id, voice_profile_id, from_version, to_version, classification,
+		  (voice_profile_id, from_version, to_version, classification,
 		   activation_outcome, delta_json)
-		VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid,
-		        $1, $2, $3, $4, $5, $6)`,
+		VALUES ($1, $2, $3, $4, $5, $6)`,
 		build.ProfileID, voicePredecessor(profile.ProfileVersion), nextVersion,
 		outcome.Classification, outcome.Action, storekit.JSONArg(delta))
 	return err

--- a/backend/internal/modules/ai/voice_draftread.go
+++ b/backend/internal/modules/ai/voice_draftread.go
@@ -95,10 +95,9 @@ func (s *VoiceStore) RecordDraftedSignal(ctx context.Context, profileID ids.UUID
 		var signalID ids.UUID
 		err := tx.QueryRow(ctx, `
 			INSERT INTO voice_learning_signal
-			  (workspace_id, voice_profile_id, profile_version, draft_ref_hash, outcome,
+			  (voice_profile_id, profile_version, draft_ref_hash, outcome,
 			   generated_original, retention_until, source, captured_by, updated_at)
-			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid,
-			        $1, $2, $3, 'drafted', $4, $5, 'draft', $6, $7)
+			VALUES ($1, $2, $3, 'drafted', $4, $5, 'draft', $6, $7)
 			ON CONFLICT (draft_ref_hash) DO NOTHING
 			RETURNING id`, profileID, profileVersion, hash[:], generatedOriginal,
 			now.Add(voiceLearningSignalRetention), actor.ID, now).Scan(&signalID)

--- a/backend/internal/modules/ai/voice_lifecycle.go
+++ b/backend/internal/modules/ai/voice_lifecycle.go
@@ -119,10 +119,9 @@ func (s *VoiceStore) CreateBuild(ctx context.Context, profileID ids.UUID, in Cre
 		}
 		build, err = scanVoiceBuild(tx.QueryRow(ctx, storekit.SQLf(`
 			INSERT INTO voice_build
-			  (workspace_id, voice_profile_id, requested_by, reason, status, source_hash,
+			  (voice_profile_id, requested_by, reason, status, source_hash,
 			   source_count, updated_at)
-			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid,
-			        $1, $2, $3, 'queued', $4, $5, $6)
+			VALUES ($1, $2, $3, 'queued', $4, $5, $6)
 			ON CONFLICT DO NOTHING
 			RETURNING %s`, voiceBuildColumns), profileID, actor.UserID, in.Reason,
 			sourceHash, sourceCount, s.now().UTC()))

--- a/backend/internal/modules/ai/voice_profile_artifact.go
+++ b/backend/internal/modules/ai/voice_profile_artifact.go
@@ -145,12 +145,11 @@ func persistDerivedVoiceVersion(ctx context.Context, tx pgx.Tx, build derivedPro
 	var versionID ids.UUID
 	err := tx.QueryRow(ctx, `
 			INSERT INTO voice_profile_version
-			  (workspace_id, voice_profile_id, profile_version, status, voice_profile_md,
+			  (voice_profile_id, profile_version, status, voice_profile_md,
 			   profile_json, stats_json, source_hash, source_count, reason, predecessor_version,
 			   model_provider, model_name, builder_version, activation_policy_version,
 			   evaluation_json, activated_at, source, captured_by, updated_at)
-			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid,
-			        $1, $2, 'active', $3, $4, '{}'::jsonb, $5, $6, 'manual', $7,
+			VALUES ($1, $2, 'active', $3, $4, '{}'::jsonb, $5, $6, 'manual', $7,
 			        'internal', $8, 'legacy-set-derived', '1', $9, $10, 'ui', $11, $10)
 			RETURNING id`, build.profileID, build.nextVersion, build.voiceProfileMD,
 		storekit.JSONArg(map[string]any{voiceKeyDocument: build.voiceProfileMD}), build.sourceHash,
@@ -187,10 +186,9 @@ func insertDerivedProfileDelta(ctx context.Context, tx pgx.Tx, build derivedProf
 	}
 	_, err := tx.Exec(ctx, `
 			INSERT INTO voice_profile_delta
-			  (workspace_id, voice_profile_id, from_version, to_version, classification,
+			  (voice_profile_id, from_version, to_version, classification,
 			   activation_outcome, delta_json)
-			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid,
-			        $1, $2, $3, 'routine', 'manually_activated', $4)`,
+			VALUES ($1, $2, $3, 'routine', 'manually_activated', $4)`,
 		build.profileID, build.predecessorVersion, build.nextVersion, storekit.JSONArg(delta))
 	return err
 }

--- a/backend/internal/modules/ai/voice_sendoutcome_integration_test.go
+++ b/backend/internal/modules/ai/voice_sendoutcome_integration_test.go
@@ -122,9 +122,9 @@ func (e *sendOutcomeEnv) seedDraft(t *testing.T, opts draftOptions) draftFixture
 
 	var profile ids.UUID
 	if err := e.owner.QueryRow(ctx, `
-		INSERT INTO voice_profile (workspace_id, owner_id, scope, status, source, captured_by)
-		VALUES ($1, $2, 'user', 'ready', 'ui', $3) RETURNING id`,
-		workspace, profileOwner, "human:"+profileOwner.String()).Scan(&profile); err != nil {
+		INSERT INTO voice_profile (owner_id, scope, status, source, captured_by)
+		VALUES ($1, 'user', 'ready', 'ui', $2) RETURNING id`,
+		profileOwner, "human:"+profileOwner.String()).Scan(&profile); err != nil {
 		t.Fatal(err)
 	}
 
@@ -148,10 +148,10 @@ func (e *sendOutcomeEnv) seedDraft(t *testing.T, opts draftOptions) draftFixture
 	var signal ids.UUID
 	if err := e.owner.QueryRow(ctx, `
 		INSERT INTO voice_learning_signal
-		  (workspace_id, voice_profile_id, draft_ref_hash, outcome, generated_original,
+		  (voice_profile_id, draft_ref_hash, outcome, generated_original,
 		   retention_until, content_erased_at, archived_at, source, captured_by)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, 'draft', $9) RETURNING id`,
-		workspace, profile, hash[:], outcome, generated, draftRetentionUntil,
+		VALUES ($1, $2, $3, $4, $5, $6, $7, 'draft', $8) RETURNING id`,
+		profile, hash[:], outcome, generated, draftRetentionUntil,
 		erasedAt, archivedAt, "human:"+profileOwner.String()).Scan(&signal); err != nil {
 		t.Fatal(err)
 	}

--- a/backend/internal/modules/ai/voice_source_store.go
+++ b/backend/internal/modules/ai/voice_source_store.go
@@ -118,11 +118,10 @@ func (s *VoiceStore) persistPreparedSource(ctx context.Context, tx pgx.Tx, profi
 	var sourceID ids.UUID
 	row := tx.QueryRow(ctx, `
 			INSERT INTO voice_corpus_source
-			  (workspace_id, voice_profile_id, origin, kind, register, weight, source_label,
+			  (voice_profile_id, origin, kind, register, weight, source_label,
 			   source_ref, content, content_hash, word_count, excluded, exclusion_reason,
 			   extractor_version, occurred_at, source, captured_by, updated_at)
-			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid,
-			        $1, 'manual', $2, $3, $4, $5, $6, $7, $8, $9,
+			VALUES ($1, 'manual', $2, $3, $4, $5, $6, $7, $8, $9,
 			        false, NULL, 'voice-v1', $10, 'ui', $11, $12)
 			ON CONFLICT (voice_profile_id, source_ref) DO UPDATE SET
 			  origin = 'manual',

--- a/backend/internal/modules/ai/voice_versions.go
+++ b/backend/internal/modules/ai/voice_versions.go
@@ -289,12 +289,11 @@ func (s *VoiceStore) RollbackVersion(ctx context.Context, profileID ids.UUID, so
 		}
 		result, err = scanVoiceVersion(tx.QueryRow(ctx, storekit.SQLf(`
 			INSERT INTO voice_profile_version
-			  (workspace_id, voice_profile_id, profile_version, status, voice_profile_md,
+			  (voice_profile_id, profile_version, status, voice_profile_md,
 			   profile_json, stats_json, source_hash, source_count, reason, predecessor_version,
 			   model_provider, model_name, builder_version, activation_policy_version,
 			   evaluation_json, review_reasons, activated_at, source, captured_by, updated_at)
-			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid,
-			        $1, $2, 'active', $3, $4, $5, $6, $7, 'rollback', $8,
+			VALUES ($1, $2, 'active', $3, $4, $5, $6, $7, 'rollback', $8,
 			        $9, $10, $11, $12, $13, $14, $15, 'ui', $16, $15)
 			RETURNING %s`, voiceVersionColumns), profileID, nextVersion, source.VoiceProfileMD,
 			storekit.JSONArg(source.ProfileJSON), storekit.JSONArg(source.StatsJSON), source.SourceHash,
@@ -319,10 +318,9 @@ func (s *VoiceStore) RollbackVersion(ctx context.Context, profileID ids.UUID, so
 		}
 		if _, err := tx.Exec(ctx, `
 			INSERT INTO voice_profile_delta
-			  (workspace_id, voice_profile_id, from_version, to_version, classification,
+			  (voice_profile_id, from_version, to_version, classification,
 			   activation_outcome, delta_json)
-			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid,
-			        $1, $2, $3, 'routine', 'rollback', $4)`,
+			VALUES ($1, $2, $3, 'routine', 'rollback', $4)`,
 			profileID, profile.ProfileVersion, result.ProfileVersion, storekit.JSONArg(delta)); err != nil {
 			return err
 		}

--- a/backend/migrations/core/0227_signals_drop_workspace.down.sql
+++ b/backend/migrations/core/0227_signals_drop_workspace.down.sql
@@ -14,8 +14,8 @@
 ALTER TABLE signal ADD COLUMN workspace_id uuid;
 ALTER TABLE signal_resolution ADD COLUMN workspace_id uuid;
 
-UPDATE signal SET workspace_id = (SELECT id FROM workspace ORDER BY created_at LIMIT 1);
-UPDATE signal_resolution SET workspace_id = (SELECT id FROM workspace ORDER BY created_at LIMIT 1);
+UPDATE signal SET workspace_id = (SELECT id FROM workspace WHERE archived_at IS NULL ORDER BY created_at LIMIT 1);
+UPDATE signal_resolution SET workspace_id = (SELECT id FROM workspace WHERE archived_at IS NULL ORDER BY created_at LIMIT 1);
 
 ALTER TABLE signal ALTER COLUMN workspace_id SET NOT NULL;
 ALTER TABLE signal_resolution ALTER COLUMN workspace_id SET NOT NULL;

--- a/backend/migrations/core/0228_collections_quotas_drop_workspace.down.sql
+++ b/backend/migrations/core/0228_collections_quotas_drop_workspace.down.sql
@@ -14,7 +14,7 @@ ALTER TABLE saved_view ADD COLUMN workspace_id uuid;
 ALTER TABLE quota ADD COLUMN workspace_id uuid;
 
 DO $$
-DECLARE ws uuid := (SELECT id FROM workspace ORDER BY created_at LIMIT 1);
+DECLARE ws uuid := (SELECT id FROM workspace WHERE archived_at IS NULL ORDER BY created_at LIMIT 1);
 BEGIN
   UPDATE list SET workspace_id = ws;
   UPDATE list_member SET workspace_id = ws;

--- a/backend/migrations/core/0229_customfields_drop_workspace.down.sql
+++ b/backend/migrations/core/0229_customfields_drop_workspace.down.sql
@@ -1,10 +1,12 @@
 -- Reverse of 0229: the catalog carries the tenant column again.
 --
--- The backfill reads `workspace` rather than reconstructing each row's original
--- tenant, because there is only one to read: 0217's pre-flight refuses to run
--- against a database holding more than one live workspace, and ADR-0061 §3 has
--- the API refusing to start in that state. `ORDER BY created_at LIMIT 1` is
--- determinism about which row of a one-row table, not a choice among tenants.
+-- The backfill reads the LIVE workspace, and the predicate is the point: 0217's
+-- pre-flight refuses to run against a database holding more than one workspace
+-- with archived_at IS NULL, so there is exactly one live row — but an
+-- installation that resolved to one organization by ARCHIVING the others still
+-- has those rows, and 0217 names that residue explicitly. Ordering by
+-- created_at alone would hand every restored row to whichever workspace
+-- happened to be created first, archived or not.
 --
 -- If `workspace` is empty and the catalog is not, SET NOT NULL fails and the
 -- rollback stops — the honest outcome, since no value this migration could
@@ -12,7 +14,7 @@
 
 ALTER TABLE custom_field ADD COLUMN workspace_id uuid;
 
-UPDATE custom_field SET workspace_id = (SELECT id FROM workspace ORDER BY created_at LIMIT 1);
+UPDATE custom_field SET workspace_id = (SELECT id FROM workspace WHERE archived_at IS NULL ORDER BY created_at LIMIT 1);
 
 ALTER TABLE custom_field ALTER COLUMN workspace_id SET NOT NULL;
 ALTER TABLE custom_field ADD CONSTRAINT custom_field_workspace_id_fkey

--- a/backend/migrations/core/0230_finance_comms_drop_workspace.down.sql
+++ b/backend/migrations/core/0230_finance_comms_drop_workspace.down.sql
@@ -1,8 +1,12 @@
 -- Reverse of 0230: the six tables carry the tenant column again.
 --
--- The backfill reads `workspace` because there is exactly one to read: 0217's
--- pre-flight refuses to run against a database holding more than one live
--- workspace, and ADR-0061 §3 has the API refusing to start in that state. If
+-- The backfill reads the LIVE workspace, and the predicate is the point: 0217's
+-- pre-flight refuses to run against a database holding more than one workspace
+-- with archived_at IS NULL, so there is exactly one live row — but an
+-- installation that resolved to one organization by ARCHIVING the others still
+-- has those rows, and 0217 names that residue explicitly. Ordering by
+-- created_at alone would hand every restored row to whichever workspace
+-- happened to be created first, archived or not. If
 -- `workspace` is empty and a table is not, SET NOT NULL fails and the rollback
 -- stops — the honest outcome, since no value this migration could write would
 -- be true.
@@ -15,7 +19,7 @@ ALTER TABLE finance_payment ADD COLUMN workspace_id uuid;
 ALTER TABLE comms_outbound ADD COLUMN workspace_id uuid;
 
 DO $$
-DECLARE ws uuid := (SELECT id FROM workspace ORDER BY created_at LIMIT 1);
+DECLARE ws uuid := (SELECT id FROM workspace WHERE archived_at IS NULL ORDER BY created_at LIMIT 1);
 BEGIN
   UPDATE finance_connection SET workspace_id = ws;
   UPDATE finance_external_customer SET workspace_id = ws;

--- a/backend/migrations/core/0231_consent_drop_workspace.down.sql
+++ b/backend/migrations/core/0231_consent_drop_workspace.down.sql
@@ -1,8 +1,12 @@
 -- Reverse of 0231: the eight tables carry the tenant column again.
 --
--- The backfill reads `workspace` because there is exactly one to read: 0217's
--- pre-flight refuses to run against a database holding more than one live
--- workspace, and ADR-0061 §3 has the API refusing to start in that state. If
+-- The backfill reads the LIVE workspace, and the predicate is the point: 0217's
+-- pre-flight refuses to run against a database holding more than one workspace
+-- with archived_at IS NULL, so there is exactly one live row — but an
+-- installation that resolved to one organization by ARCHIVING the others still
+-- has those rows, and 0217 names that residue explicitly. Ordering by
+-- created_at alone would hand every restored row to whichever workspace
+-- happened to be created first, archived or not. If
 -- `workspace` is empty and a table is not, SET NOT NULL fails and the rollback
 -- stops — the honest outcome, since no value this migration could write would
 -- be true.
@@ -17,7 +21,7 @@ ALTER TABLE data_subject_request ADD COLUMN workspace_id uuid;
 ALTER TABLE preference_token ADD COLUMN workspace_id uuid;
 
 DO $$
-DECLARE ws uuid := (SELECT id FROM workspace ORDER BY created_at LIMIT 1);
+DECLARE ws uuid := (SELECT id FROM workspace WHERE archived_at IS NULL ORDER BY created_at LIMIT 1);
 BEGIN
   UPDATE consent_purpose SET workspace_id = ws;
   UPDATE person_consent SET workspace_id = ws;

--- a/backend/migrations/core/0232_approvals_workflowrun_drop_workspace.down.sql
+++ b/backend/migrations/core/0232_approvals_workflowrun_drop_workspace.down.sql
@@ -1,9 +1,13 @@
 -- Reverse of 0232: the table takes its old name back and the three carry the
 -- tenant column again.
 --
--- The backfill reads `workspace` because there is exactly one to read: 0217's
--- pre-flight refuses to run against a database holding more than one live
--- workspace, and ADR-0061 §3 has the API refusing to start in that state. If
+-- The backfill reads the LIVE workspace, and the predicate is the point: 0217's
+-- pre-flight refuses to run against a database holding more than one workspace
+-- with archived_at IS NULL, so there is exactly one live row — but an
+-- installation that resolved to one organization by ARCHIVING the others still
+-- has those rows, and 0217 names that residue explicitly. Ordering by
+-- created_at alone would hand every restored row to whichever workspace
+-- happened to be created first, archived or not. If
 -- `workspace` is empty and a table is not, SET NOT NULL fails and the rollback
 -- stops — the honest outcome, since no value this migration could write would
 -- be true.
@@ -16,7 +20,7 @@ ALTER TABLE workflow_run ADD COLUMN workspace_id uuid;
 ALTER TABLE workspace_signing_key ADD COLUMN workspace_id uuid;
 
 DO $$
-DECLARE ws uuid := (SELECT id FROM workspace ORDER BY created_at LIMIT 1);
+DECLARE ws uuid := (SELECT id FROM workspace WHERE archived_at IS NULL ORDER BY created_at LIMIT 1);
 BEGIN
   UPDATE approval SET workspace_id = ws;
   UPDATE workflow_run SET workspace_id = ws;

--- a/backend/migrations/core/0233_automation_drop_workspace.down.sql
+++ b/backend/migrations/core/0233_automation_drop_workspace.down.sql
@@ -1,15 +1,19 @@
 -- Reverse of 0233: the catalog carries the tenant column again.
 --
--- The backfill reads `workspace` because there is exactly one to read: 0217's
--- pre-flight refuses to run against a database holding more than one live
--- workspace, and ADR-0061 §3 has the API refusing to start in that state. If
+-- The backfill reads the LIVE workspace, and the predicate is the point: 0217's
+-- pre-flight refuses to run against a database holding more than one workspace
+-- with archived_at IS NULL, so there is exactly one live row — but an
+-- installation that resolved to one organization by ARCHIVING the others still
+-- has those rows, and 0217 names that residue explicitly. Ordering by
+-- created_at alone would hand every restored row to whichever workspace
+-- happened to be created first, archived or not. If
 -- `workspace` is empty and the catalog is not, SET NOT NULL fails and the
 -- rollback stops — the honest outcome, since no value this migration could
 -- write would be true.
 
 ALTER TABLE automation ADD COLUMN workspace_id uuid;
 
-UPDATE automation SET workspace_id = (SELECT id FROM workspace ORDER BY created_at LIMIT 1);
+UPDATE automation SET workspace_id = (SELECT id FROM workspace WHERE archived_at IS NULL ORDER BY created_at LIMIT 1);
 
 ALTER TABLE automation ALTER COLUMN workspace_id SET NOT NULL;
 ALTER TABLE automation ADD CONSTRAINT automation_workspace_id_fkey

--- a/backend/migrations/core/0234_voice_drop_workspace.down.sql
+++ b/backend/migrations/core/0234_voice_drop_workspace.down.sql
@@ -1,11 +1,16 @@
 -- Reverse of 0234: the six voice tables carry the tenant column again.
 --
--- The backfill reads `workspace` because there is exactly one to read: 0217's
--- pre-flight refuses to run against a database holding more than one live
--- workspace, and ADR-0061 §3 has the API refusing to start in that state. If
--- `workspace` is empty and a table is not, SET NOT NULL fails and the rollback
--- stops — the honest outcome, since no value this migration could write would
--- be true.
+-- The backfill reads the LIVE workspace, and the predicate is the point: 0217's
+-- pre-flight refuses to run against a database holding more than one workspace
+-- with archived_at IS NULL, so there is exactly one live row — but an
+-- installation that resolved to one organization by ARCHIVING the others still
+-- has those rows, and 0217 names that residue explicitly. Ordering by
+-- created_at alone would hand every restored row to whichever workspace
+-- happened to be created first, archived or not.
+--
+-- If no live workspace exists and a table is not empty, SET NOT NULL fails and
+-- the rollback stops — the honest outcome, since no value this migration could
+-- write would be true.
 
 ALTER TABLE voice_profile ADD COLUMN workspace_id uuid;
 ALTER TABLE voice_corpus_source ADD COLUMN workspace_id uuid;
@@ -15,7 +20,7 @@ ALTER TABLE voice_profile_delta ADD COLUMN workspace_id uuid;
 ALTER TABLE voice_learning_signal ADD COLUMN workspace_id uuid;
 
 DO $$
-DECLARE ws uuid := (SELECT id FROM workspace ORDER BY created_at LIMIT 1);
+DECLARE ws uuid := (SELECT id FROM workspace WHERE archived_at IS NULL ORDER BY created_at LIMIT 1);
 BEGIN
   UPDATE voice_profile SET workspace_id = ws;
   UPDATE voice_corpus_source SET workspace_id = ws;

--- a/backend/migrations/core/0234_voice_drop_workspace.down.sql
+++ b/backend/migrations/core/0234_voice_drop_workspace.down.sql
@@ -1,0 +1,74 @@
+-- Reverse of 0234: the six voice tables carry the tenant column again.
+--
+-- The backfill reads `workspace` because there is exactly one to read: 0217's
+-- pre-flight refuses to run against a database holding more than one live
+-- workspace, and ADR-0061 §3 has the API refusing to start in that state. If
+-- `workspace` is empty and a table is not, SET NOT NULL fails and the rollback
+-- stops — the honest outcome, since no value this migration could write would
+-- be true.
+
+ALTER TABLE voice_profile ADD COLUMN workspace_id uuid;
+ALTER TABLE voice_corpus_source ADD COLUMN workspace_id uuid;
+ALTER TABLE voice_build ADD COLUMN workspace_id uuid;
+ALTER TABLE voice_profile_version ADD COLUMN workspace_id uuid;
+ALTER TABLE voice_profile_delta ADD COLUMN workspace_id uuid;
+ALTER TABLE voice_learning_signal ADD COLUMN workspace_id uuid;
+
+DO $$
+DECLARE ws uuid := (SELECT id FROM workspace ORDER BY created_at LIMIT 1);
+BEGIN
+  UPDATE voice_profile SET workspace_id = ws;
+  UPDATE voice_corpus_source SET workspace_id = ws;
+  UPDATE voice_build SET workspace_id = ws;
+  UPDATE voice_profile_version SET workspace_id = ws;
+  UPDATE voice_profile_delta SET workspace_id = ws;
+  UPDATE voice_learning_signal SET workspace_id = ws;
+END $$;
+
+ALTER TABLE voice_profile ALTER COLUMN workspace_id SET NOT NULL;
+ALTER TABLE voice_corpus_source ALTER COLUMN workspace_id SET NOT NULL;
+ALTER TABLE voice_build ALTER COLUMN workspace_id SET NOT NULL;
+ALTER TABLE voice_profile_version ALTER COLUMN workspace_id SET NOT NULL;
+ALTER TABLE voice_profile_delta ALTER COLUMN workspace_id SET NOT NULL;
+ALTER TABLE voice_learning_signal ALTER COLUMN workspace_id SET NOT NULL;
+
+ALTER TABLE voice_profile ADD CONSTRAINT voice_profile_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE voice_corpus_source ADD CONSTRAINT voice_corpus_source_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE voice_build ADD CONSTRAINT voice_build_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE voice_profile_version ADD CONSTRAINT voice_profile_version_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE voice_profile_delta ADD CONSTRAINT voice_profile_delta_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE voice_learning_signal ADD CONSTRAINT voice_learning_signal_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+
+ALTER TABLE voice_profile ADD CONSTRAINT uq_voice_profile_ws_id UNIQUE (id);
+ALTER TABLE voice_build ADD CONSTRAINT uq_voice_build_ws_id UNIQUE (id);
+ALTER TABLE voice_learning_signal ADD CONSTRAINT uq_voice_learning_signal_ws_id UNIQUE (id);
+ALTER TABLE voice_profile_delta ADD CONSTRAINT uq_voice_profile_delta_ws_id UNIQUE (id);
+ALTER TABLE voice_profile_version ADD CONSTRAINT uq_voice_profile_version_ws_id UNIQUE (id);
+
+DROP INDEX idx_voice_corpus_profile;
+CREATE INDEX idx_voice_corpus_profile ON voice_corpus_source (workspace_id, voice_profile_id, created_at DESC);
+
+DROP INDEX voice_build_deferred_due;
+CREATE INDEX voice_build_deferred_due ON voice_build (workspace_id, next_attempt_at, id) WHERE status = 'deferred' AND archived_at IS NULL;
+
+DROP INDEX voice_build_poll;
+CREATE INDEX voice_build_poll ON voice_build (workspace_id, voice_profile_id, created_at DESC, id DESC) WHERE archived_at IS NULL;
+
+DROP INDEX voice_corpus_source_manifest;
+CREATE INDEX voice_corpus_source_manifest ON voice_corpus_source (workspace_id, voice_profile_id, created_at DESC, id DESC) WHERE archived_at IS NULL;
+
+DROP INDEX voice_learning_signal_retention;
+CREATE INDEX voice_learning_signal_retention ON voice_learning_signal (workspace_id, retention_until) WHERE content_erased_at IS NULL;
+
+DROP INDEX voice_profile_delta_history;
+CREATE INDEX voice_profile_delta_history ON voice_profile_delta (workspace_id, voice_profile_id, created_at DESC, id DESC) WHERE archived_at IS NULL;
+
+DROP INDEX voice_profile_version_history;
+CREATE INDEX voice_profile_version_history ON voice_profile_version (workspace_id, voice_profile_id, created_at DESC, id DESC) WHERE archived_at IS NULL;
+

--- a/backend/migrations/core/0234_voice_drop_workspace.up.sql
+++ b/backend/migrations/core/0234_voice_drop_workspace.up.sql
@@ -1,0 +1,39 @@
+-- 0234: the voice tables drop the tenant column (ADR-0091 §8 phase D).
+--
+-- Six tables, seven indexes, five redundant uniques. The module writes none of
+-- the column's names in Go — every voice write goes through storekit's shape —
+-- so this slice is schema plus the fixtures that seeded a profile by hand.
+
+DROP INDEX idx_voice_corpus_profile;
+CREATE INDEX idx_voice_corpus_profile ON voice_corpus_source (voice_profile_id, created_at DESC);
+
+DROP INDEX voice_build_deferred_due;
+CREATE INDEX voice_build_deferred_due ON voice_build (next_attempt_at, id) WHERE status = 'deferred' AND archived_at IS NULL;
+
+DROP INDEX voice_build_poll;
+CREATE INDEX voice_build_poll ON voice_build (voice_profile_id, created_at DESC, id DESC) WHERE archived_at IS NULL;
+
+DROP INDEX voice_corpus_source_manifest;
+CREATE INDEX voice_corpus_source_manifest ON voice_corpus_source (voice_profile_id, created_at DESC, id DESC) WHERE archived_at IS NULL;
+
+DROP INDEX voice_learning_signal_retention;
+CREATE INDEX voice_learning_signal_retention ON voice_learning_signal (retention_until) WHERE content_erased_at IS NULL;
+
+DROP INDEX voice_profile_delta_history;
+CREATE INDEX voice_profile_delta_history ON voice_profile_delta (voice_profile_id, created_at DESC, id DESC) WHERE archived_at IS NULL;
+
+DROP INDEX voice_profile_version_history;
+CREATE INDEX voice_profile_version_history ON voice_profile_version (voice_profile_id, created_at DESC, id DESC) WHERE archived_at IS NULL;
+
+ALTER TABLE voice_profile DROP CONSTRAINT uq_voice_profile_ws_id;
+ALTER TABLE voice_build DROP CONSTRAINT uq_voice_build_ws_id;
+ALTER TABLE voice_learning_signal DROP CONSTRAINT uq_voice_learning_signal_ws_id;
+ALTER TABLE voice_profile_delta DROP CONSTRAINT uq_voice_profile_delta_ws_id;
+ALTER TABLE voice_profile_version DROP CONSTRAINT uq_voice_profile_version_ws_id;
+
+ALTER TABLE voice_profile DROP COLUMN workspace_id;
+ALTER TABLE voice_corpus_source DROP COLUMN workspace_id;
+ALTER TABLE voice_build DROP COLUMN workspace_id;
+ALTER TABLE voice_profile_version DROP COLUMN workspace_id;
+ALTER TABLE voice_profile_delta DROP COLUMN workspace_id;
+ALTER TABLE voice_learning_signal DROP COLUMN workspace_id;


### PR DESCRIPTION
Phase D. Six tables — `voice_profile`, `voice_corpus_source`, `voice_build`, `voice_profile_version`, `voice_profile_delta`, `voice_learning_signal` — seven indexes, five redundant uniques.

**Ten production writes lose the column, and none loses a placeholder with it.** Every one spelled the tenant as a literal `NULLIF(current_setting(...))` expression rather than a bound parameter, so the argument lists are untouched and there is no renumbering to get wrong. The voice column constants never listed it either, so the reads needed no change at all.

One process note worth carrying: the module is **`ai`**, not `voice`. A first grep for `internal/modules/voice` found nothing and said so — the wrong kind of clean. `tableownership_test.go` is the reliable index into where a table's writers live.

## Verification

- Lane applied to an empty database; the down restores all six columns with their foreign keys, the five uniques and all seven wide indexes.
- `make check-backend` green.
- `make test-integration`: **OK, 0 skips, 39 packages.**

One unrelated test (`TestEmbedReindexConfirmRequiresAdminOrOps`) failed on an intermediate run and passed on re-run, in isolation, and on an unmodified tree — filed separately rather than absorbed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drops `workspace_id` from all voice tables and updates rollbacks to backfill to the live workspace. Previously, writes set the tenant via `current_setting(...)`; now tables are tenantless and writes omit the column. Reads are unchanged.

- Schema: removes `workspace_id` from `voice_profile`, `voice_corpus_source`, `voice_build`, `voice_profile_version`, `voice_profile_delta`, `voice_learning_signal`; drops five workspace-scoped uniques; rewrites seven indexes to non-workspace keys.
- App: updates ten production writes in `ai` to stop specifying the column; SQL argument ordering is unchanged; no read-path changes.
- Tests: stop seeding `workspace_id` in integration fixtures; when a workspace is needed, derive it from `app_user` rather than `voice_profile`.
- Migrations: add `core/0234_voice_drop_workspace.up.sql`; rollback re-adds columns, FKs, and wide indexes and backfills from the LIVE workspace (`archived_at IS NULL`). Aligns downs in `0227`–`0233` to the same rule; rollback fails if no live workspace exists and tables are non-empty.

<sup>Written for commit 3ea549407d1da56e93f5577f280835f1473ef900. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1179?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Streamlined voice profile, version, learning, and source data handling around profile ownership.
  - Updated voice creation, lifecycle, rollback, retention, and send-outcome workflows for consistent behavior.
  - Preserved retention rules, draft conflict handling, idempotency, and corpus-clearing safeguards.

- **Database**
  - Updated voice data structures and indexes to support profile-scoped access.
  - Improved rollback handling for restoring the prior data structure when needed.
  - Enhanced rollback safety by excluding archived workspaces during data restoration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->