### PR TITLE
feat(overlay): a flip refuses a projection an older mapping produced

### DIFF
--- a/backend/internal/compose/capturejobs_integration_test.go
+++ b/backend/internal/compose/capturejobs_integration_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/riverqueue/river"
 
 	"github.com/gradionhq/margince/backend/internal/platform/jobs"
@@ -77,7 +78,7 @@ func TestBackfillCompletionBuildsTheDigest(t *testing.T) {
 	// The boot pass placed its own dispatcher row, so "no dispatcher exists" is
 	// not the claim to make — "the completion added none" is. Read the count
 	// before the backfill runs and hold it to that afterwards.
-	dispatchersBefore := countJobsOfKind(ctx, t, b, CaptureDigestArgs{}.Kind())
+	dispatchersBefore := countJobsOfKind(ctx, t, b.env.Pool, CaptureDigestArgs{}.Kind())
 
 	// Now schedule the backfill; the worker pages it to done and enqueues the
 	// same-day digest off the completion edge.
@@ -98,7 +99,7 @@ func TestBackfillCompletionBuildsTheDigest(t *testing.T) {
 
 	// A dispatcher row added here would be one workspace's backfill running
 	// the digest for every workspace in the installation.
-	if after := countJobsOfKind(ctx, t, b, CaptureDigestArgs{}.Kind()); after != dispatchersBefore {
+	if after := countJobsOfKind(ctx, t, b.env.Pool, CaptureDigestArgs{}.Kind()); after != dispatchersBefore {
 		t.Errorf("capture_digest rows went %d -> %d across the backfill; a completion must enqueue the "+
 			"CHILD kind for its own workspace, never the dispatcher that fans out over the whole fleet",
 			dispatchersBefore, after)
@@ -142,10 +143,12 @@ func TestBackfillCompletionBuildsTheDigest(t *testing.T) {
 }
 
 // countJobsOfKind answers how many river_job rows of a kind exist right now.
-func countJobsOfKind(ctx context.Context, t *testing.T, b *backfillWireEnv, kind string) int {
+// Every suite resets the database before it runs, so the count is this test's
+// own inserts and nothing else.
+func countJobsOfKind(ctx context.Context, t *testing.T, pool *pgxpool.Pool, kind string) int {
 	t.Helper()
 	var n int
-	if err := b.env.Pool.QueryRow(ctx, `SELECT count(*) FROM river_job WHERE kind = $1`, kind).Scan(&n); err != nil {
+	if err := pool.QueryRow(ctx, `SELECT count(*) FROM river_job WHERE kind = $1`, kind).Scan(&n); err != nil {
 		t.Fatalf("counting %s rows: %v", kind, err)
 	}
 	return n

--- a/backend/internal/compose/integration/overlay/overlay_e2e_integration_test.go
+++ b/backend/internal/compose/integration/overlay/overlay_e2e_integration_test.go
@@ -75,6 +75,25 @@ type budgetWire struct {
 	Band     string  `json:"band"`
 }
 
+// asCurrentProjection stamps rec with the fingerprint of the declaration the
+// composed server projects incumbentClass through today (asked of compose,
+// which is the one package sanctioned to name the concrete incumbent). The
+// fake stands in for that adapter's OUTPUT, so a fixture that means "a row the
+// current mapping produced" must say so with the registry's own digest: the
+// server compares every mirror row against it, and a row no current
+// declaration accounts for reads as stale — which is the whole point of the
+// comparison, and would otherwise hold every flip fixture short of ready. A
+// fixture that means the opposite sets the field itself.
+func asCurrentProjection(t *testing.T, rec overlaymod.Record, incumbentClass string) overlaymod.Record {
+	t.Helper()
+	fingerprint, ok := compose.OverlayProjectionFingerprints()[incumbentClass]
+	if !ok {
+		t.Fatalf("no current declaration for incumbent class %q — the fixture names a class the registry never declared", incumbentClass)
+	}
+	rec.ProjectionFingerprint = fingerprint
+	return rec
+}
+
 // openAppPool opens a second, independent app-role pool over the SAME
 // real database the httptest server (env.ts) is backed by.
 func openAppPool(t *testing.T) *pgxpool.Pool {
@@ -210,7 +229,7 @@ func backfillOneMirroredContact(t *testing.T, pool *pgxpool.Pool, wsID, adminID 
 	rec := fake.Rec("555000111", map[string]any{"first_name": "Ada", "last_name": "Overlay"})
 	rec.ObjectClass = "person"
 	rec.OwnerExternalID = "owner-1"
-	fakeInc.Seed(overlaymod.IncumbentClassContacts, rec)
+	fakeInc.Seed(overlaymod.IncumbentClassContacts, asCurrentProjection(t, rec, overlaymod.IncumbentClassContacts))
 	if _, err := overlaymod.Backfill(adminCtx, fakeInc, mirror, overlaymod.IncumbentClassContacts, time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)); err != nil {
 		t.Fatalf("backfilling the fake incumbent's contacts: %v", err)
 	}

--- a/backend/internal/compose/integration/overlay/overlay_flip_integration_test.go
+++ b/backend/internal/compose/integration/overlay/overlay_flip_integration_test.go
@@ -191,7 +191,7 @@ func setupFlipEstate(t *testing.T) flipEstate {
 		rec := fake.Rec(ext, fields)
 		rec.ObjectClass = canonicalClass
 		rec.OwnerExternalID = "owner-1"
-		fakeInc.Seed(incumbentClass, rec)
+		fakeInc.Seed(incumbentClass, asCurrentProjection(t, rec, incumbentClass))
 	}
 	// Child fields are seeded as COLLECTIONS carrying the attributes the
 	// mapping declares, the shape overlaymod.Apply actually lands them in
@@ -221,7 +221,7 @@ func setupFlipEstate(t *testing.T) flipEstate {
 	// at every tier, while the mirror row was hidden from every seat).
 	unowned := fake.Rec("p-unowned", map[string]any{"full_name": "Unassigned Contact"})
 	unowned.ObjectClass = "person"
-	fakeInc.Seed(overlaymod.IncumbentClassContacts, unowned)
+	fakeInc.Seed(overlaymod.IncumbentClassContacts, asCurrentProjection(t, unowned, overlaymod.IncumbentClassContacts))
 	seed(overlaymod.IncumbentClassDeals, "deal", "d-open", map[string]any{
 		"name": "Packaging QA", "stage_id": "appointmentscheduled", "amount_minor": int64(21200000), "currency": "EUR",
 	})

--- a/backend/internal/compose/integration/overlay/overlay_flip_integration_test.go
+++ b/backend/internal/compose/integration/overlay/overlay_flip_integration_test.go
@@ -809,3 +809,60 @@ func TestAFlipAdoptsAHalfLandedDealAndFinishesClosingIt(t *testing.T) {
 		t.Errorf("won deals for d-won = %d, want 1 — the adopted deal was left parked open and the estate's revenue is wrong", won)
 	}
 }
+
+// The preflight judges every mirror row against the projection fingerprints
+// the COMPOSED server carries — the ones compose/overlay.go injects from the
+// hubspot mapping registry — not against a map a test hands the service. The
+// fake incumbent stamps its own constant, which no hubspot declaration
+// produces, so a row it projected is exactly the case the guard exists for: a
+// payload the current mapping would never emit, which the flip would otherwise
+// write as a permanent native row. Without that injection the deployment can
+// judge no class at all, every row passes as current, and the first verdict
+// below comes back ready.
+func TestFlipRefusesAMirrorRowNoCurrentDeclarationProduced(t *testing.T) {
+	f := setupFlipEstate(t)
+
+	// Seeded through the mirror's own Ingest — the writer Backfill drives —
+	// so the row lands in the shape production stores, fingerprint included.
+	// The estate's own fixtures all pass through asCurrentProjection; this one
+	// deliberately keeps fake.ProjectionFingerprint.
+	byOlderDeclaration := fake.Rec("p-older-declaration", map[string]any{"full_name": "Older Declaration"})
+	byOlderDeclaration.ObjectClass = "person"
+	byOlderDeclaration.OwnerExternalID = "owner-1"
+	if byOlderDeclaration.ProjectionFingerprint != fake.ProjectionFingerprint {
+		t.Fatalf("fixture fingerprint = %q, want the fake's — the row must be one no hubspot declaration produced",
+			byOlderDeclaration.ProjectionFingerprint)
+	}
+	if err := f.mirror.Ingest(f.adminCtx, byOlderDeclaration); err != nil {
+		t.Fatalf("seeding the row projected by an older declaration: %v", err)
+	}
+	// After the ingest, never before: the export gate wants a bundle newer
+	// than the mirror's freshest row (exportCutoff), so a bundle written
+	// ahead of a mirror write would block on export_missing instead.
+	f.writePreflipExport(t)
+
+	var verdict crmcontracts.OverlayFlipPreflight
+	if code := f.e.Call(t, "POST", "/v1/overlay/flip:preflight", apptest.AnyMap{}, nil, &verdict); code != http.StatusOK {
+		t.Fatalf("preflight = %d", code)
+	}
+	if verdict.Ready || len(verdict.Blocking) != 1 || !hasBlocking(verdict, "force_fresh_incomplete") {
+		t.Fatalf("verdict = %+v, want not-ready blocking on force_fresh_incomplete alone — the server judged a row no current declaration produced as fresh", verdict)
+	}
+	if verdict.Snapshot != nil {
+		t.Fatal("a blocked preflight must not leave a sealed snapshot")
+	}
+
+	// Re-projected through the declaration the server does produce, at the
+	// same incumbent baseline (the record is untouched upstream): the one
+	// blocker clears, and nothing else takes its place.
+	if err := f.mirror.Ingest(f.adminCtx, asCurrentProjection(t, byOlderDeclaration, overlaymod.IncumbentClassContacts)); err != nil {
+		t.Fatalf("re-projecting the row through the current declaration: %v", err)
+	}
+	f.writePreflipExport(t)
+	if code := f.e.Call(t, "POST", "/v1/overlay/flip:preflight", apptest.AnyMap{}, nil, &verdict); code != http.StatusOK {
+		t.Fatalf("preflight after the re-projection = %d", code)
+	}
+	if !verdict.Ready || len(verdict.Blocking) != 0 {
+		t.Fatalf("verdict = %+v, want ready once every mirror row carries a current declaration", verdict)
+	}
+}

--- a/backend/internal/compose/jobs_overlay.go
+++ b/backend/internal/compose/jobs_overlay.go
@@ -31,9 +31,10 @@ import (
 // posture the embed-reindex wiring takes — it is periodicFor's to resolve from
 // the same declaration this gate reads.
 //
-// The mirror store and the budget meter are built once and shared by the two
-// workers that use them, which is why this is a block rather than three lines
-// in the runner.
+// The budget meter is built once and shared by the two workers that spend
+// against it, which is why this is a block rather than three lines in the
+// runner. The mirror store is NOT shared: it is workspace-bound, so each
+// worker builds its own for the workspace it is working (ADR-0091 §9 step 3).
 func addOverlayJobs(reg *jobRegistry, pool *pgxpool.Pool, cfg JobRunnerConfig, log *slog.Logger) {
 	if cfg.OverlayVault == nil {
 		return
@@ -50,11 +51,11 @@ func addOverlayJobs(reg *jobRegistry, pool *pgxpool.Pool, cfg JobRunnerConfig, l
 		pool: pool, vault: cfg.OverlayVault, meter: meter, log: log,
 		newIncumbent: overlayIncumbentFactory(cfg.OverlayBackfillLimit),
 	})
-	// The webhook-as-signal re-fetch worker (OVA-WIRE-10): consumes the
-	// coalesced OverlayRefetchArgs the receiver enqueues, refreshing one record
-	// through the same store the poller uses. Registered whenever the overlay
-	// vault is present (the receiver only enqueues when the api role has the
-	// app secret wired).
+	// The targeted re-fetch worker (OVA-WIRE-10): consumes the coalesced
+	// OverlayRefetchArgs both producers enqueue — a portal-bound webhook and
+	// the sweep's re-projection phase — refreshing one record through the same
+	// ingest the poller uses. Registered whenever the overlay vault is present,
+	// which is what either producer needs to have its job worked.
 	addDeclaredWorker[OverlayRefetchArgs](reg, &overlayRefetchWorker{
 		pool: pool, vault: cfg.OverlayVault, meter: meter, log: log,
 		newIncumbent: overlayIncumbentFactory(cfg.OverlayBackfillLimit),
@@ -323,9 +324,8 @@ func reconcileConnection(ctx context.Context, pool *pgxpool.Pool, vault keyvault
 		return err
 	}
 	// The re-projection phase's re-fetches ride the River client working this
-	// sweep's own job (ambientRefetchEnqueuer) — the poller has no second
-	// client, and a re-fetch enqueued from anywhere else would be a job the
-	// sweep cannot see the result of.
+	// sweep's own job (ambientRefetchEnqueuer), so the poller needs no second
+	// client of its own.
 	return sweepObjectClasses(ctx, sweepDeps{inc: inc, ms: ms, meter: meter, enqueue: ambientRefetchEnqueuer{}, log: log}, d)
 }
 

--- a/backend/internal/compose/jobs_overlay.go
+++ b/backend/internal/compose/jobs_overlay.go
@@ -322,7 +322,11 @@ func reconcileConnection(ctx context.Context, pool *pgxpool.Pool, vault keyvault
 	if err := revalidateOwnerEmailMappings(ctx, ms, inc, d, log); err != nil {
 		return err
 	}
-	return sweepObjectClasses(ctx, sweepDeps{inc: inc, ms: ms, meter: meter, log: log}, d)
+	// The re-projection phase's re-fetches ride the River client working this
+	// sweep's own job (ambientRefetchEnqueuer) — the poller has no second
+	// client, and a re-fetch enqueued from anywhere else would be a job the
+	// sweep cannot see the result of.
+	return sweepObjectClasses(ctx, sweepDeps{inc: inc, ms: ms, meter: meter, enqueue: ambientRefetchEnqueuer{}, log: log}, d)
 }
 
 // seedUserMapFromOwners seeds mirror_user_map from the incumbent's owners
@@ -394,7 +398,7 @@ func sweepObjectClasses(ctx context.Context, deps sweepDeps, d overlay.DueOverla
 		// classes are swept best-effort with no requested scope, so a portal
 		// that gates one of them (a 403/404 for that object alone) skips just
 		// that class here — overlaySweepAborts encodes the distinction.
-		if err := sweepObjectClass(ctx, deps, d.Workspace.String(), objectClass, d.ConnectedAt); err != nil {
+		if err := sweepObjectClass(ctx, deps, d.Workspace, objectClass, d.ConnectedAt); err != nil {
 			if overlaySweepAborts(objectClass, err) {
 				return err
 			}

--- a/backend/internal/compose/jobs_overlay_ambient_integration_test.go
+++ b/backend/internal/compose/jobs_overlay_ambient_integration_test.go
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package compose
+
+// The sweep enqueues its re-fetches through the River client that is working
+// the sweep's own job, so the poller carries no second client. This is that
+// resolution proved against a real client and a real river_job table: a job
+// context inserts, and a context with no client is reported rather than
+// swallowed — the difference between a class the next pass re-enqueues and a
+// class that silently never converges while the flip stays blocked.
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/riverqueue/river"
+	"github.com/riverqueue/river/riverdriver/riverpgxv5"
+	"github.com/riverqueue/river/rivertest"
+
+	"github.com/gradionhq/margince/backend/internal/compose/integration"
+	"github.com/gradionhq/margince/backend/internal/modules/overlay"
+)
+
+func TestAmbientRefetchEnqueuerInsertsThroughTheClientWorkingTheJob(t *testing.T) {
+	e := integration.Setup(t)
+	integration.ApplyRiverSchema(t)
+	ctx := context.Background()
+	// The client is built here rather than taken from platform/jobs because
+	// rivertest.WorkContext needs the *river.Client itself, which the Runner
+	// holds unexported — an insert-only client, exactly the shape jobs.NewInserter
+	// builds, so what this drives is the real insert path and not a stand-in.
+	client, err := river.NewClient(riverpgxv5.New(e.Pool), &river.Config{
+		Logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	if err != nil {
+		t.Fatalf("river.NewClient: %v", err)
+	}
+
+	args := OverlayRefetchArgs{
+		Workspace:      e.WS,
+		IncumbentClass: overlay.IncumbentClassCalls,
+		ExternalID:     "calls:123",
+	}
+	if err := (ambientRefetchEnqueuer{}).Enqueue(rivertest.WorkContext(ctx, client), args, reprojectionInsertOpts()); err != nil {
+		t.Fatalf("Enqueue on a job's own context: %v", err)
+	}
+
+	job := rivertest.RequireInserted(ctx, t, riverpgxv5.New(e.Pool), OverlayRefetchArgs{}, nil)
+	if job.Args != args {
+		t.Fatalf("the inserted job carries %+v, want %+v — a re-fetch that names another record converges nothing", job.Args, args)
+	}
+}
+
+func TestAmbientRefetchEnqueuerReportsAContextCarryingNoClient(t *testing.T) {
+	e := integration.Setup(t)
+	integration.ApplyRiverSchema(t)
+	args := OverlayRefetchArgs{Workspace: e.WS, IncumbentClass: overlay.IncumbentClassCalls, ExternalID: "calls:123"}
+
+	err := ambientRefetchEnqueuer{}.Enqueue(context.Background(), args, reprojectionInsertOpts())
+	if err == nil {
+		t.Fatal("Enqueue off a job context returned nil — a re-fetch that was never inserted must not read as one that was")
+	}
+	if n := countJobsOfKind(context.Background(), t, e.Pool, args.Kind()); n != 0 {
+		t.Fatalf("%d %s row(s) after a refused enqueue, want 0", n, args.Kind())
+	}
+}

--- a/backend/internal/compose/jobs_overlay_refetch.go
+++ b/backend/internal/compose/jobs_overlay_refetch.go
@@ -27,13 +27,19 @@ import (
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
-// OverlayRefetchArgs is the webhook-as-signal targeted re-fetch (OVA-WIRE-10):
-// a validly-signed, portal-bound webhook enqueues one of these to refresh the
-// named record through the same idempotent ingest the poller uses. The args
+// OverlayRefetchArgs is a targeted single-record re-fetch, enqueued by two
+// producers: a validly-signed, portal-bound webhook (webhook-as-signal,
+// OVA-WIRE-10) and the sweep's re-projection phase (jobs_overlay_sweep.go),
+// which names the rows an older mapping declaration projected. Both refresh
+// the named record through the same idempotent ingest the poller uses. The args
 // ARE the coalescing key — River's unique-by-args (OVA-PARAM-10, scheduled a
 // short window ahead) collapses a record edited rapidly in the incumbent to
-// ONE re-fetch rather than N. IncumbentClass is the HubSpot object class
-// (contacts/companies/deals/leads); ExternalID is the mirror external id.
+// ONE re-fetch rather than N. IncumbentClass is the HubSpot object class the
+// record is read back under — any of the four record classes
+// (contacts/companies/deals/leads) or the five engagement classes
+// (calls/meetings/emails/notes/tasks); ExternalID is the mirror external id,
+// which for an engagement carries its own class namespace ("calls:123",
+// OVA-MAP-7) and is bare otherwise.
 type OverlayRefetchArgs struct {
 	Workspace      ids.UUID `json:"workspace_id"`
 	IncumbentClass string   `json:"incumbent_class"`
@@ -46,7 +52,7 @@ func (OverlayRefetchArgs) Kind() string { return "overlay_refetch" }
 // WorkspaceID binds this mirror re-fetch to its tenant (jobs.WorkspaceScoped).
 func (a OverlayRefetchArgs) WorkspaceID() ids.UUID { return a.Workspace }
 
-// overlayRefetchWorker executes one webhook-driven single-record re-fetch: it
+// overlayRefetchWorker executes one targeted single-record re-fetch: it
 // resolves the workspace's active connection, builds a live incumbent adapter
 // over its vaulted token, reads the one record, and ingests it through the
 // fenced, resolver-bound store — the SAME idempotent, owner-revalidating path
@@ -56,7 +62,7 @@ type overlayRefetchWorker struct {
 	pool  *pgxpool.Pool
 	vault keyvault.Vault
 	ms    *overlay.MirrorStore
-	// meter is the OVB budget. A webhook re-fetch is a live single-record REST
+	// meter is the OVB budget. A targeted re-fetch is a live single-record REST
 	// read-through — the same traffic category force-fresh meters, so it
 	// reserves against SourceForceFresh before the incumbent read and SHEDS to
 	// the poller when the budget is spent. A single-record GET is GATE-able
@@ -133,10 +139,15 @@ func (w *overlayRefetchWorker) refetchAndIngest(wsCtx context.Context, conn over
 		return fmt.Errorf("overlay refetch: resolving the vaulted token: %w", err)
 	}
 	inc := w.newIncumbent(conn.Region, string(token))
-	// Reserve one REST unit BEFORE the live read (OVB-AC-2/AC-5), so the
-	// webhook lane's incumbent calls are accounted for like every other. On
-	// shed skip the re-fetch — the signal is an optimization, and the poller
-	// heals within its interval; never spend live quota we cannot account for.
+	// Reserve one REST unit BEFORE the live read (OVB-AC-2/AC-5), so this lane's
+	// incumbent calls are accounted for like every other. On shed skip the
+	// re-fetch: never spend live quota we cannot account for. Dropping it costs
+	// nothing durable either way, though for different reasons per producer — a
+	// webhook is an optimization the watermark poller heals within its interval,
+	// while a re-projection is NOT something the poller heals (it is
+	// watermark-driven and never re-reads a record the incumbent has not
+	// touched); the row simply stays in the stale set until a re-fetch lands, so
+	// the next re-projection pass names it again.
 	// A role wired without a configured meter gets the fail-closed placeholder
 	// (nil Redis client) here, which sheds every reservation — so an
 	// unaccountable read is skipped, never made. A meter error is transient —

--- a/backend/internal/compose/jobs_overlay_refetch.go
+++ b/backend/internal/compose/jobs_overlay_refetch.go
@@ -3,8 +3,9 @@
 
 package compose
 
-// This file owns the webhook-as-signal targeted re-fetch (OVA-WIRE-10): the
-// job args, the worker, and its pre-flight/fetch-and-ingest split.
+// This file owns the targeted single-record re-fetch (OVA-WIRE-10) both of its
+// producers enqueue — a webhook signal and the sweep's re-projection phase:
+// the job args, the worker, and its pre-flight/fetch-and-ingest split.
 // reconcileWorkerCtx and isConnectionLevelIncumbentError stay in
 // jobs_overlay.go, which owns the periodic reconcile sweep: both are shared
 // with it.
@@ -57,11 +58,13 @@ func (a OverlayRefetchArgs) WorkspaceID() ids.UUID { return a.Workspace }
 // over its vaulted token, reads the one record, and ingests it through the
 // fenced, resolver-bound store — the SAME idempotent, owner-revalidating path
 // the reconcile sweep uses, so a webhook refresh and a poller sweep converge
-// on one mirror state. The poller still heals any gap a signal misses.
+// on one mirror state. A dropped job is not a lost record either way: a signal
+// this lane drops is healed by the poller's next watermark pass, and a
+// re-projection it drops is named again by the next sweep's re-projection
+// phase, since the row keeps the declaration it was projected under.
 type overlayRefetchWorker struct {
 	pool  *pgxpool.Pool
 	vault keyvault.Vault
-	ms    *overlay.MirrorStore
 	// meter is the OVB budget. A targeted re-fetch is a live single-record REST
 	// read-through — the same traffic category force-fresh meters, so it
 	// reserves against SourceForceFresh before the incumbent read and SHEDS to
@@ -155,27 +158,37 @@ func (w *overlayRefetchWorker) refetchAndIngest(wsCtx context.Context, conn over
 	if allowed, err := w.meter.ReserveREST(wsCtx, conn.Incumbent, overlaybudget.SourceForceFresh, 1); err != nil {
 		return fmt.Errorf("overlay refetch: reserving the incumbent budget: %w", err)
 	} else if !allowed {
-		w.log.InfoContext(wsCtx, "overlay refetch: incumbent budget shed, deferring to the poller",
+		w.log.InfoContext(wsCtx, "overlay refetch: incumbent budget shed, skipping the live read",
 			"workspace", job.Args.Workspace, "class", job.Args.IncumbentClass, "id", job.Args.ExternalID)
 		return nil
 	}
 	rec, err := inc.Get(wsCtx, job.Args.IncumbentClass, job.Args.ExternalID)
 	if err != nil {
 		// A connection-level failure (rate-limit/auth/unreachable) is retryable
-		// — return it so River backs off and retries. A record that is simply
-		// gone or unmappable is not retryable: the deletion feed / poller
-		// reconciles it, so log and drop rather than retry forever.
+		// — return it so River backs off and retries. A record the incumbent
+		// will not hand back is not: the same read returns the same answer,
+		// however many attempts it is given. What the mirror is left holding
+		// depends on why: an archived record is retired by the deletion feed,
+		// while a record the incumbent still holds but this build cannot map
+		// keeps its current payload and stays in the stale set, so every
+		// re-projection pass names it again — one reserved REST unit and one
+		// live read per tick, with force_fresh_incomplete holding the flip shut
+		// meanwhile (issue #1187).
 		if isConnectionLevelIncumbentError(err) {
 			return fmt.Errorf("overlay refetch: reading %s/%s: %w", job.Args.IncumbentClass, job.Args.ExternalID, err)
 		}
-		w.log.WarnContext(wsCtx, "overlay refetch: record read failed (not retryable), leaving it to the poller",
+		w.log.WarnContext(wsCtx, "overlay refetch: reading the record failed in a way a retry cannot change; the mirror keeps what it holds",
 			"workspace", job.Args.Workspace, "class", job.Args.IncumbentClass, "id", job.Args.ExternalID, "err", err)
 		return nil
 	}
+	// Built for the workspace THIS re-fetch names: the mirror store writes
+	// tenant rows over a workspace-bound handle, so one instance cannot serve
+	// the workspaces a role re-fetches for (ADR-0091 §9 step 3).
+	ms := overlay.NewMirrorStore(database.BindTo(w.pool, conn.Workspace), unresolvedOwnerEmails{})
 	// WithFenceIdentity on conn's OWN connected_at: a signal that outlives a
 	// disconnect+reconnect (coalesced 5s ahead, OVA-PARAM-10) must not ingest
 	// under the connection it was enqueued for once a NEW one is live.
-	if err := w.ms.WithResolver(inc).WithFenceIdentity(conn.ConnectedAt).Ingest(wsCtx, rec); err != nil {
+	if err := ms.WithResolver(inc).WithFenceIdentity(conn.ConnectedAt).Ingest(wsCtx, rec); err != nil {
 		if errors.Is(err, overlay.ErrConnectionGone) {
 			// Disconnected (or disconnected+reconnected) mid-refetch — the
 			// fence aborted the write, nothing resurrected or misattributed.

--- a/backend/internal/compose/jobs_overlay_refetch_failures_integration_test.go
+++ b/backend/internal/compose/jobs_overlay_refetch_failures_integration_test.go
@@ -16,7 +16,6 @@ package compose
 import (
 	"context"
 	"errors"
-	"log/slog"
 	"testing"
 	"time"
 
@@ -66,14 +65,12 @@ func newRefetchFixture(t *testing.T) refetchFixture {
 	return refetchFixture{e: e, vault: vault, ms: ms, meter: budgettest.Meter(t, budgettest.SmallConfig("hubspot"))}
 }
 
-// worker builds the re-fetch worker over inc, exposed (rather than folded into
-// signal) so a test can vary one dependency — the vault, say — before the run.
-func (f refetchFixture) worker(inc overlay.Incumbent) *overlayRefetchWorker {
-	return &overlayRefetchWorker{
-		pool: f.e.Pool, vault: f.vault, ms: f.ms, meter: f.meter,
-		log:          slog.New(slog.DiscardHandler),
-		newIncumbent: func(_, _ string) overlay.Incumbent { return inc },
-	}
+// worker takes THIS build's registered re-fetch worker and points it at inc,
+// exposed (rather than folded into signal) so a test can vary one dependency —
+// the vault, say — before the run.
+func (f refetchFixture) worker(t *testing.T, inc overlay.Incumbent) *overlayRefetchWorker {
+	t.Helper()
+	return registeredRefetchWorker(t, f.e.Pool, f.vault, f.meter, inc)
 }
 
 // signal executes one coalesced webhook signal for contacts/c-1 — the record
@@ -125,7 +122,7 @@ func TestOverlayRefetchWorkerStopsCleanlyWhenTheWorkspaceDisconnected(t *testing
 	}
 
 	spy := &getCountingIncumbent{Adapter: seededPortal()}
-	if err := f.signal(f.worker(spy)); err != nil {
+	if err := f.signal(f.worker(t, spy)); err != nil {
 		t.Fatalf("a signal for a disconnected workspace must be a clean stop, got: %v", err)
 	}
 	if spy.gets != 0 {
@@ -156,7 +153,7 @@ func TestOverlayRefetchWorkerSkipsAHaltedMirror(t *testing.T) {
 	}
 
 	spy := &getCountingIncumbent{Adapter: seededPortal()}
-	if err := f.signal(f.worker(spy)); err != nil {
+	if err := f.signal(f.worker(t, spy)); err != nil {
 		t.Fatalf("a signal for a halted mirror must be a clean stop, got: %v", err)
 	}
 	if spy.gets != 0 {
@@ -169,10 +166,9 @@ func TestOverlayRefetchWorkerSkipsAHaltedMirror(t *testing.T) {
 
 // TestOverlayRefetchWorkerLeavesAnUnreadableRecordToThePoller proves the
 // worker distinguishes "gone" from "broken": a record the incumbent will not
-// return (archived between the webhook and the job, or unmappable) is not
-// retryable — retrying it forever would burn quota on a record that is never
-// coming back — so the worker stops cleanly and leaves reconciliation to the
-// poller's deletion feed.
+// return — archived between the signal and the job — is not retryable, since
+// the same read gives the same answer however many attempts it is given, so
+// the worker stops cleanly and leaves the row to the poller's deletion feed.
 func TestOverlayRefetchWorkerLeavesAnUnreadableRecordToThePoller(t *testing.T) {
 	f := newRefetchFixture(t)
 	// A portal WITHOUT the signalled record: its Get fails with a plain
@@ -180,7 +176,7 @@ func TestOverlayRefetchWorkerLeavesAnUnreadableRecordToThePoller(t *testing.T) {
 	empty := fake.New()
 	empty.SeedOwner("owner-1", "a@authz.test")
 
-	if err := f.signal(f.worker(empty)); err != nil {
+	if err := f.signal(f.worker(t, empty)); err != nil {
 		t.Fatalf("an unreadable record must not be retried, got: %v", err)
 	}
 	if f.mirrored(t) {
@@ -206,7 +202,7 @@ func (g getFailingIncumbent) Get(context.Context, string, string) (overlay.Recor
 // and retry — swallowing it would silently drop the signal.
 func TestOverlayRefetchWorkerRetriesAConnectionLevelReadFailure(t *testing.T) {
 	f := newRefetchFixture(t)
-	err := f.signal(f.worker(getFailingIncumbent{Adapter: seededPortal(), err: apperrors.ErrPermissionDenied}))
+	err := f.signal(f.worker(t, getFailingIncumbent{Adapter: seededPortal(), err: apperrors.ErrPermissionDenied}))
 	if !errors.Is(err, apperrors.ErrPermissionDenied) {
 		t.Fatalf("a connection-level read failure = %v, want it surfaced so River retries", err)
 	}
@@ -221,7 +217,7 @@ func TestOverlayRefetchWorkerRetriesAConnectionLevelReadFailure(t *testing.T) {
 // failure worth retrying — not a record that stopped existing.
 func TestOverlayRefetchWorkerSurfacesAnUnresolvableToken(t *testing.T) {
 	f := newRefetchFixture(t)
-	w := f.worker(seededPortal())
+	w := f.worker(t, seededPortal())
 	w.vault = keyvault.NewMemory() // a vault that never held this connection's secret
 	if err := f.signal(w); err == nil {
 		t.Fatal("an unresolvable vaulted token must surface as an error, not a silent no-op")
@@ -263,7 +259,7 @@ func (r *revokeOnGetIncumbent) Get(ctx context.Context, objectClass, externalID 
 func TestOverlayRefetchWorkerStopsCleanlyOnADisconnectMidRefetch(t *testing.T) {
 	f := newRefetchFixture(t)
 	inc := &revokeOnGetIncumbent{Adapter: seededPortal(), pool: f.e.Pool}
-	if err := f.signal(f.worker(inc)); err != nil {
+	if err := f.signal(f.worker(t, inc)); err != nil {
 		t.Fatalf("a disconnect mid-refetch must be a clean stop, got: %v", err)
 	}
 	if f.mirrored(t) {

--- a/backend/internal/compose/jobs_overlay_reprojection_integration_test.go
+++ b/backend/internal/compose/jobs_overlay_reprojection_integration_test.go
@@ -252,16 +252,14 @@ func TestSweepReprojectionConvergesOnceTheRefetchLands(t *testing.T) {
 		t.Fatalf("the first sweep enqueued %d re-fetches, want 1 — nothing to converge otherwise", len(r.inc.enqueued))
 	}
 
-	// Work the job the phase enqueued, through the real worker: the point of
-	// this test is that the two halves fit — the phase names a row, the
-	// re-fetch re-projects it under the current declaration, and the row
-	// leaves the stale set.
-	worker := &overlayRefetchWorker{
-		pool: r.env.Pool, vault: r.vault, ms: r.ms,
-		meter:        budgettest.Meter(t, budgettest.SmallConfig("hubspot")),
-		log:          slog.New(slog.DiscardHandler),
-		newIncumbent: func(_, _ string) overlay.Incumbent { return r.inc },
-	}
+	// Work the job the phase enqueued, through the worker THIS build registers
+	// (registeredRefetchWorker): the point of this test is that the two halves
+	// fit in the wiring a deployed process runs — the phase names a row, the
+	// re-fetch re-projects it under the current declaration, and the row leaves
+	// the stale set. A worker assembled here instead would prove only that the
+	// phase fits a worker this file built.
+	worker := registeredRefetchWorker(t, r.env.Pool, r.vault,
+		budgettest.Meter(t, budgettest.SmallConfig("hubspot")), r.inc)
 	if err := worker.Work(context.Background(), &river.Job[OverlayRefetchArgs]{Args: r.inc.enqueued[0]}); err != nil {
 		t.Fatalf("refetch Work: %v", err)
 	}
@@ -307,10 +305,10 @@ func TestSweepReprojectionAttributesActivityRowsByTheirMirrorNamespace(t *testin
 	}
 }
 
-// The Critical case attribution has to survive: renaming a declaration's
-// constant is an ordinary registry edit, and it changes the declaration's
-// fingerprint — so every row the old declaration projected is stale at once and
-// the flip blocks on them. Attributing those rows by anything the declaration
+// The hardest case for attribution: renaming a declaration's constant is an
+// ordinary registry edit, and it changes the declaration's fingerprint — so
+// every row the old declaration projected is stale at once and the flip blocks
+// on them. Attributing those rows by anything the declaration
 // writes INTO the payload would select none of them in exactly that pass, and
 // the block would never clear. The mirror id's namespace is not the
 // declaration's to change, so the sweep still names them.

--- a/backend/internal/compose/jobs_overlay_reprojection_integration_test.go
+++ b/backend/internal/compose/jobs_overlay_reprojection_integration_test.go
@@ -32,6 +32,8 @@ import (
 	"github.com/gradionhq/margince/backend/internal/compose/integration"
 	"github.com/gradionhq/margince/backend/internal/modules/overlay"
 	"github.com/gradionhq/margince/backend/internal/modules/overlay/fake"
+	"github.com/gradionhq/margince/backend/internal/modules/overlay/hubspot"
+	"github.com/gradionhq/margince/backend/internal/platform/jobs"
 	"github.com/gradionhq/margince/backend/internal/platform/keyvault"
 	"github.com/gradionhq/margince/backend/internal/platform/overlaybudget"
 	"github.com/gradionhq/margince/backend/internal/platform/overlaybudget/budgettest"
@@ -174,25 +176,56 @@ func setupReprojection(t *testing.T) *reprojectionEnv {
 	}
 }
 
-// sweepContacts runs one full contacts sweep — every phase, in order — the way
-// reconcileConnection composes it for a live connection.
-func (r *reprojectionEnv) sweepContacts(t *testing.T) {
+// sweep runs one full sweep of incumbentClass — every phase, in order — the way
+// reconcileConnection composes it for a live connection, recording what the
+// re-projection phase scheduled instead of inserting it.
+func (r *reprojectionEnv) sweep(t *testing.T, incumbentClass string) {
+	t.Helper()
+	r.sweepWith(t, incumbentClass, r.inc)
+}
+
+// sweepWith is sweep with the re-fetch enqueuer named, so a pass can be driven
+// through the real insert surface (*jobs.Runner) instead of the recorder.
+func (r *reprojectionEnv) sweepWith(t *testing.T, incumbentClass string, enqueue refetchEnqueuer) {
 	t.Helper()
 	deps := sweepDeps{
 		inc:     r.inc,
 		ms:      r.ms.WithResolver(r.inc).WithFenceIdentity(r.due.ConnectedAt),
 		meter:   r.meter,
-		enqueue: r.inc,
+		enqueue: enqueue,
 		log:     slog.New(slog.DiscardHandler),
 	}
-	if err := sweepObjectClass(r.sweepCtx, deps, r.due.Workspace, overlay.IncumbentClassContacts, r.due.ConnectedAt); err != nil {
-		t.Fatalf("sweepObjectClass: %v", err)
+	if err := sweepObjectClass(r.sweepCtx, deps, r.due.Workspace, incumbentClass, r.due.ConnectedAt); err != nil {
+		t.Fatalf("sweepObjectClass(%s): %v", incumbentClass, err)
 	}
+}
+
+// seedMirroredActivity mirrors ONE engagement record through the real ingest:
+// the fake serves it under its own incumbent class, the sweep's backfill writes
+// it, and it lands in the shared canonical "activity" bucket under the mirror
+// id a real adapter mints for that class — "<class>:<id>", OVA-MAP-7. Every
+// class is given the SAME numeric id, which is what HubSpot's per-type id space
+// permits and what the namespace exists to keep apart. fingerprint is the
+// declaration the row records as its producer. It answers the mirror id, which
+// is what a re-fetch of the row names.
+func (r *reprojectionEnv) seedMirroredActivity(t *testing.T, incumbentClass, fingerprint string) string {
+	t.Helper()
+	externalID := incumbentClass + ":123"
+	rec := fake.Rec(externalID, map[string]any{"subject": "Kickoff"})
+	rec.ObjectClass, rec.OwnerExternalID = "activity", "owner-1"
+	// Modified before the connection, for the reason setupReprojection states:
+	// the watermark phases must not re-read it, so re-projection is the only
+	// thing that can converge it.
+	rec.ModifiedAt = time.Now().Add(-24 * time.Hour)
+	rec.ProjectionFingerprint = fingerprint
+	r.inc.Seed(incumbentClass, rec)
+	r.sweep(t, incumbentClass)
+	return externalID
 }
 
 func TestSweepReprojectionEnqueuesOnlyTheRowsAnOlderDeclarationProjected(t *testing.T) {
 	r := setupReprojection(t)
-	r.sweepContacts(t)
+	r.sweep(t, overlay.IncumbentClassContacts)
 
 	want := []OverlayRefetchArgs{{
 		Workspace:      r.env.WS,
@@ -214,7 +247,7 @@ func TestSweepReprojectionEnqueuesOnlyTheRowsAnOlderDeclarationProjected(t *test
 
 func TestSweepReprojectionConvergesOnceTheRefetchLands(t *testing.T) {
 	r := setupReprojection(t)
-	r.sweepContacts(t)
+	r.sweep(t, overlay.IncumbentClassContacts)
 	if len(r.inc.enqueued) != 1 {
 		t.Fatalf("the first sweep enqueued %d re-fetches, want 1 — nothing to converge otherwise", len(r.inc.enqueued))
 	}
@@ -242,8 +275,107 @@ func TestSweepReprojectionConvergesOnceTheRefetchLands(t *testing.T) {
 	}
 
 	r.inc.enqueued = nil
-	r.sweepContacts(t)
+	r.sweep(t, overlay.IncumbentClassContacts)
 	if len(r.inc.enqueued) != 0 {
 		t.Fatalf("the second sweep enqueued %v, want none — a converged class must cost nothing every tick", r.inc.enqueued)
+	}
+}
+
+// The five engagement classes share the canonical "activity" bucket, so a
+// calls pass and a meetings pass select from the same rows — and a re-fetch
+// names the INCUMBENT class, so a row handed to the wrong pass is a live read
+// for a record that class does not hold. Attribution is by the mirror id's own
+// namespace, and this is the case it exists for: two rows of one canonical
+// class, projected by different declarations, carrying the same numeric
+// incumbent id.
+func TestSweepReprojectionAttributesActivityRowsByTheirMirrorNamespace(t *testing.T) {
+	r := setupReprojection(t)
+	callID := r.seedMirroredActivity(t, overlay.IncumbentClassCalls, staleDeclarationFingerprint)
+	meetingID := r.seedMirroredActivity(t, overlay.IncumbentClassMeetings, staleDeclarationFingerprint)
+
+	r.inc.enqueued = nil
+	r.sweep(t, overlay.IncumbentClassCalls)
+
+	want := []OverlayRefetchArgs{{
+		Workspace:      r.env.WS,
+		IncumbentClass: overlay.IncumbentClassCalls,
+		ExternalID:     callID,
+	}}
+	if !slices.Equal(r.inc.enqueued, want) {
+		t.Fatalf("the calls sweep enqueued %v, want %v — %q is just as stale, but only the calls endpoint can serve %q, "+
+			"and re-reading a meeting under /calls can only 404", r.inc.enqueued, want, meetingID, callID)
+	}
+}
+
+// The Critical case attribution has to survive: renaming a declaration's
+// constant is an ordinary registry edit, and it changes the declaration's
+// fingerprint — so every row the old declaration projected is stale at once and
+// the flip blocks on them. Attributing those rows by anything the declaration
+// writes INTO the payload would select none of them in exactly that pass, and
+// the block would never clear. The mirror id's namespace is not the
+// declaration's to change, so the sweep still names them.
+func TestStaleProjectionsSurviveADeclarationConstantChange(t *testing.T) {
+	r := setupReprojection(t)
+	callID := r.seedMirroredActivity(t, overlay.IncumbentClassCalls, currentFingerprintFor(t, overlay.IncumbentClassCalls))
+	meetingID := r.seedMirroredActivity(t, overlay.IncumbentClassMeetings, currentFingerprintFor(t, overlay.IncumbentClassMeetings))
+
+	m, ok := hubspot.Mapping(overlay.IncumbentClassCalls)
+	if !ok {
+		t.Fatalf("Mapping(%q): the registry declares no calls mapping", overlay.IncumbentClassCalls)
+	}
+	stale, err := r.ms.StaleProjections(r.sweepCtx, m, reprojectionEnqueueLimit)
+	if err != nil {
+		t.Fatalf("StaleProjections under today's declaration: %v", err)
+	}
+	if len(stale) != 0 {
+		t.Fatalf("today's declaration reports %v stale — the rows it just projected must be current, "+
+			"or the assertion below proves nothing", stale)
+	}
+
+	// The registry edit: the constant naming the activity kind is renamed.
+	m.Const = map[string]any{"kind": "call-renamed"}
+	stale, err = r.ms.StaleProjections(r.sweepCtx, m, reprojectionEnqueueLimit)
+	if err != nil {
+		t.Fatalf("StaleProjections under the renamed declaration: %v", err)
+	}
+	if !slices.Equal(stale, []string{callID}) {
+		t.Fatalf("the renamed declaration reports %v stale, want [%s] — every row it projected went stale with the rename, "+
+			"so a sweep that names none of them leaves the flip blocked forever, and one that names %q re-reads a meeting as a call",
+			stale, callID, meetingID)
+	}
+}
+
+// currentFingerprintFor answers the fingerprint today's declaration for
+// incumbentClass stamps, failing loudly rather than letting a row seeded with an
+// empty string read as "projected by the current mapping".
+func currentFingerprintFor(t *testing.T, incumbentClass string) string {
+	t.Helper()
+	fingerprint, ok := OverlayProjectionFingerprints()[incumbentClass]
+	if !ok || fingerprint == "" {
+		t.Fatalf("the %s declaration has no current fingerprint", incumbentClass)
+	}
+	return fingerprint
+}
+
+// A sweep tick runs again long before an earlier re-fetch has been worked, so
+// the phase re-selects a row it already named — every pass, until the re-fetch
+// lands. What keeps that from stacking one live incumbent read per tick is
+// River's own coalescing over reprojectionInsertOpts, which only a real insert
+// exercises: this pass enqueues through *jobs.Runner, the same insert surface
+// the webhook lane's receiver uses, and counts the rows it left behind.
+func TestSweepReprojectionCoalescesRepeatedPassesIntoOneJob(t *testing.T) {
+	r := setupReprojection(t)
+	integration.ApplyRiverSchema(t)
+	inserter, err := jobs.NewInserter(r.env.Pool, slog.New(slog.DiscardHandler))
+	if err != nil {
+		t.Fatalf("NewInserter: %v", err)
+	}
+	ctx := context.Background()
+	for pass := 1; pass <= 2; pass++ {
+		r.sweepWith(t, overlay.IncumbentClassContacts, inserter)
+		if got := countJobsOfKind(ctx, t, r.env.Pool, OverlayRefetchArgs{}.Kind()); got != 1 {
+			t.Fatalf("%d overlay_refetch rows after sweep pass %d, want exactly 1 — a pass that stacks a second job "+
+				"for a row still queued spends one live incumbent read per tick on a record already waiting to be read", got, pass)
+		}
 	}
 }

--- a/backend/internal/compose/jobs_overlay_reprojection_integration_test.go
+++ b/backend/internal/compose/jobs_overlay_reprojection_integration_test.go
@@ -1,0 +1,249 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package compose
+
+// The sweep's re-projection phase, proved against a real Postgres: a mirror
+// row an OLDER mapping declaration projected is re-fetched, a row already at
+// today's declaration is left alone, and once the re-fetch has landed the row
+// leaves the stale set for good. Without this phase nothing clears a stale
+// projection — the sweep is watermark-driven, and a record the incumbent has
+// not touched is never re-read — so the flip preflight's block on those rows
+// would be permanent rather than temporary.
+//
+// The assertions are on the ENQUEUED job, not on a completed re-fetch: what
+// the job then does is overlay_refetch's own tested behaviour, and asserting
+// it here would make an unrelated change to that worker fail this suite for
+// the wrong reason. The one place this suite does run the worker is the
+// convergence check, where the point is precisely that the two fit together.
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/riverqueue/river"
+
+	"github.com/gradionhq/margince/backend/internal/compose/integration"
+	"github.com/gradionhq/margince/backend/internal/modules/overlay"
+	"github.com/gradionhq/margince/backend/internal/modules/overlay/fake"
+	"github.com/gradionhq/margince/backend/internal/platform/keyvault"
+	"github.com/gradionhq/margince/backend/internal/platform/overlaybudget"
+	"github.com/gradionhq/margince/backend/internal/platform/overlaybudget/budgettest"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// staleDeclarationFingerprint stands in for a declaration that has since
+// changed: it is not a fingerprint hubspot.ProjectionFingerprints answers
+// today, which is the whole condition the phase selects on.
+const staleDeclarationFingerprint = "a-declaration-that-has-since-changed"
+
+// errUnexpectedJobKind is what the recorder answers when the phase hands it
+// anything other than a re-fetch: an unchecked assertion would let a wrong job
+// kind read as an enqueue of the right one.
+var errUnexpectedJobKind = errors.New("compose: the re-projection phase enqueued something other than an overlay_refetch")
+
+// reprojectionSweep is the sweep's incumbent AND its job queue, in one value,
+// because the property under test spans both: which records the phases read,
+// in what order, and what the last phase enqueued once they were done.
+//
+// Its Get re-stamps the record with today's declaration fingerprint while
+// Backfill/Modified hand back whatever was seeded. That is the timeline the
+// phase exists for — an estate mirrored under an older declaration, re-read
+// after the declaration changed — and the fake cannot express it any other
+// way, since it projects through no mapping of its own.
+type reprojectionSweep struct {
+	*fake.Adapter
+	currentFingerprint string
+	// phases records each incumbent-driven phase as it runs, and
+	// phasesAtEnqueue snapshots that list at the moment a re-fetch was
+	// enqueued — which is how the ordering claim ("re-projection runs after
+	// the watermark phases") is checked rather than assumed.
+	phases          []string
+	phasesAtEnqueue []string
+	enqueued        []OverlayRefetchArgs
+}
+
+func (r *reprojectionSweep) Backfill(ctx context.Context, objectClass, cursor string) (overlay.Page, error) {
+	r.phases = append(r.phases, "backfill")
+	return r.Adapter.Backfill(ctx, objectClass, cursor)
+}
+
+func (r *reprojectionSweep) Modified(ctx context.Context, objectClass string, since time.Time, cursor string) (overlay.Page, error) {
+	r.phases = append(r.phases, "modified")
+	return r.Adapter.Modified(ctx, objectClass, since, cursor)
+}
+
+func (r *reprojectionSweep) Deletions(ctx context.Context, objectClass string, since time.Time, cursor string) (overlay.DeletionPage, error) {
+	r.phases = append(r.phases, "deletions")
+	return r.Adapter.Deletions(ctx, objectClass, since, cursor)
+}
+
+func (r *reprojectionSweep) Get(ctx context.Context, objectClass, externalID string) (overlay.Record, error) {
+	rec, err := r.Adapter.Get(ctx, objectClass, externalID)
+	if err != nil {
+		return overlay.Record{}, err
+	}
+	rec.ProjectionFingerprint = r.currentFingerprint
+	return rec, nil
+}
+
+// Enqueue satisfies refetchEnqueuer, recording what the phase scheduled
+// instead of inserting it — the sweep under test runs outside a River job, and
+// the claim being checked is which rows it named, not River's insert.
+func (r *reprojectionSweep) Enqueue(_ context.Context, args river.JobArgs, _ *river.InsertOpts) error {
+	refetch, ok := args.(OverlayRefetchArgs)
+	if !ok {
+		return errUnexpectedJobKind
+	}
+	r.phasesAtEnqueue = slices.Clone(r.phases)
+	r.enqueued = append(r.enqueued, refetch)
+	return nil
+}
+
+// reprojectionEnv is one connected overlay workspace with its mirror store,
+// its recording incumbent, and the contexts the sweep and the re-fetch worker
+// each run under.
+type reprojectionEnv struct {
+	env      *integration.Env
+	vault    keyvault.Vault
+	ms       *overlay.MirrorStore
+	inc      *reprojectionSweep
+	due      overlay.DueOverlayConnection
+	sweepCtx context.Context
+	meter    *overlaybudget.Meter
+}
+
+// setupReprojection connects a workspace and seeds two contacts records: one
+// carrying a declaration fingerprint that is no longer current, one already
+// carrying today's. Both are mirrored by the first sweep's backfill through
+// the real ingest, so the rows under test are written the way production
+// writes them rather than hand-inserted.
+func setupReprojection(t *testing.T) *reprojectionEnv {
+	t.Helper()
+	e := integration.Setup(t)
+	vault := keyvault.NewMemory()
+	ms := overlay.NewMirrorStore(e.DB(), unresolvedOwnerEmails{})
+	adminCtx := overlayAdminCtx(e.WS, e.Rep1)
+	if _, err := overlay.NewService(e.DB(), vault, ms).
+		Connect(adminCtx, overlay.ConnectInput{Incumbent: "hubspot", Region: "eu1", Token: "tok"}); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+
+	current, ok := OverlayProjectionFingerprints()[overlay.IncumbentClassContacts]
+	if !ok || current == "" {
+		t.Fatal("the contacts declaration has no current fingerprint; every assertion below would be vacuous")
+	}
+	inc := &reprojectionSweep{Adapter: fake.New(), currentFingerprint: current}
+	inc.SeedOwner("owner-1", "a@authz.test")
+	// The owner map every live sweep seeds from the incumbent's directory
+	// (reconcileConnection does it before the object classes): without it the
+	// mirrored rows are readable by no one, and this suite's reads of them
+	// would fail for a reason that has nothing to do with re-projection.
+	// owner-1's directory email is Rep1's in the shared harness.
+	if err := ms.WithResolver(inc).SeedUserMap(adminCtx, incumbentHubSpot,
+		[]overlay.OwnerRef{{ExternalID: "owner-1", Email: "a@authz.test"}}); err != nil {
+		t.Fatalf("SeedUserMap: %v", err)
+	}
+	// Modified well before the connection: the incremental phase's floor is
+	// connected_at, so neither record is re-read by the watermark phases and
+	// the re-projection phase is the only thing that can converge them —
+	// which is exactly the production condition (a record the incumbent has
+	// not touched since the mapping changed).
+	for fingerprint, externalID := range map[string]string{
+		staleDeclarationFingerprint: "c-old-declaration",
+		current:                     "c-current-declaration",
+	} {
+		rec := fake.Rec(externalID, map[string]any{"firstname": "Ada"})
+		rec.ObjectClass, rec.OwnerExternalID = "person", "owner-1"
+		rec.ModifiedAt = time.Now().Add(-24 * time.Hour)
+		rec.ProjectionFingerprint = fingerprint
+		inc.Seed(overlay.IncumbentClassContacts, rec)
+	}
+
+	due := dueConnectionFor(adminCtx, t, e.Pool, e.WS)
+	return &reprojectionEnv{
+		env: e, vault: vault, ms: ms, inc: inc, due: due,
+		sweepCtx: reconcileWorkerCtx(context.Background(), ids.From[ids.WorkspaceKind](e.WS)),
+		meter:    workerBudgetMeter(t),
+	}
+}
+
+// sweepContacts runs one full contacts sweep — every phase, in order — the way
+// reconcileConnection composes it for a live connection.
+func (r *reprojectionEnv) sweepContacts(t *testing.T) {
+	t.Helper()
+	deps := sweepDeps{
+		inc:     r.inc,
+		ms:      r.ms.WithResolver(r.inc).WithFenceIdentity(r.due.ConnectedAt),
+		meter:   r.meter,
+		enqueue: r.inc,
+		log:     slog.New(slog.DiscardHandler),
+	}
+	if err := sweepObjectClass(r.sweepCtx, deps, r.due.Workspace, overlay.IncumbentClassContacts, r.due.ConnectedAt); err != nil {
+		t.Fatalf("sweepObjectClass: %v", err)
+	}
+}
+
+func TestSweepReprojectionEnqueuesOnlyTheRowsAnOlderDeclarationProjected(t *testing.T) {
+	r := setupReprojection(t)
+	r.sweepContacts(t)
+
+	want := []OverlayRefetchArgs{{
+		Workspace:      r.env.WS,
+		IncumbentClass: overlay.IncumbentClassContacts,
+		ExternalID:     "c-old-declaration",
+	}}
+	if !slices.Equal(r.inc.enqueued, want) {
+		t.Fatalf("the sweep enqueued %v, want %v — a row already carrying today's declaration must cost no incumbent read, "+
+			"and a row an older one projected must be re-fetched or the flip stays blocked on it forever", r.inc.enqueued, want)
+	}
+	// Ordering: the re-fetch was scheduled only after every watermark phase had
+	// run, so re-projection spends what the incumbent budget has left rather
+	// than what keeping the mirror fresh needs.
+	wantPhases := []string{"backfill", "modified", "deletions"}
+	if !slices.Equal(r.inc.phasesAtEnqueue, wantPhases) {
+		t.Errorf("phases completed before the re-projection enqueue = %v, want %v", r.inc.phasesAtEnqueue, wantPhases)
+	}
+}
+
+func TestSweepReprojectionConvergesOnceTheRefetchLands(t *testing.T) {
+	r := setupReprojection(t)
+	r.sweepContacts(t)
+	if len(r.inc.enqueued) != 1 {
+		t.Fatalf("the first sweep enqueued %d re-fetches, want 1 — nothing to converge otherwise", len(r.inc.enqueued))
+	}
+
+	// Work the job the phase enqueued, through the real worker: the point of
+	// this test is that the two halves fit — the phase names a row, the
+	// re-fetch re-projects it under the current declaration, and the row
+	// leaves the stale set.
+	worker := &overlayRefetchWorker{
+		pool: r.env.Pool, vault: r.vault, ms: r.ms,
+		meter:        budgettest.Meter(t, budgettest.SmallConfig("hubspot")),
+		log:          slog.New(slog.DiscardHandler),
+		newIncumbent: func(_, _ string) overlay.Incumbent { return r.inc },
+	}
+	if err := worker.Work(context.Background(), &river.Job[OverlayRefetchArgs]{Args: r.inc.enqueued[0]}); err != nil {
+		t.Fatalf("refetch Work: %v", err)
+	}
+	row, err := r.ms.Get(overlayReaderCtx(r.env.WS, r.env.Rep1), "person", "c-old-declaration")
+	if err != nil {
+		t.Fatalf("reading the re-projected row: %v", err)
+	}
+	if row.ProjectionFingerprint != r.inc.currentFingerprint {
+		t.Fatalf("the re-fetched row records %q, want the current declaration %q — the ingest guard admits a re-projection "+
+			"at the same baseline, and without that nothing here converges", row.ProjectionFingerprint, r.inc.currentFingerprint)
+	}
+
+	r.inc.enqueued = nil
+	r.sweepContacts(t)
+	if len(r.inc.enqueued) != 0 {
+		t.Fatalf("the second sweep enqueued %v, want none — a converged class must cost nothing every tick", r.inc.enqueued)
+	}
+}

--- a/backend/internal/compose/jobs_overlay_sweep.go
+++ b/backend/internal/compose/jobs_overlay_sweep.go
@@ -6,27 +6,59 @@ package compose
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"time"
 
+	"github.com/jackc/pgx/v5"
+	"github.com/riverqueue/river"
+
 	"github.com/gradionhq/margince/backend/internal/modules/overlay"
+	"github.com/gradionhq/margince/backend/internal/modules/overlay/hubspot"
 	"github.com/gradionhq/margince/backend/internal/platform/overlaybudget"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
 // The overlay sweep's per-object-class phases: backfill, then modified, then
-// deletion. Split out of jobs_overlay.go, which owns the reconcile job's
-// dispatcher/worker pair and the connection-level orchestration these phases
-// run under.
+// deletion, then re-projection. Split out of jobs_overlay.go, which owns the
+// reconcile job's dispatcher/worker pair and the connection-level
+// orchestration these phases run under.
 
 // sweepDeps bundles sweepObjectClass's per-connection collaborators — the
-// live incumbent adapter, the identity-fenced store, the OVB meter, and the
-// logger — so the phase functions below (and reconcileConnection's call
-// site) pass one value instead of four positional ones.
+// live incumbent adapter, the identity-fenced store, the OVB meter, the
+// re-fetch enqueuer, and the logger — so the phase functions below (and
+// reconcileConnection's call site) pass one value instead of five positional
+// ones.
 type sweepDeps struct {
 	inc   overlay.Incumbent
 	ms    *overlay.MirrorStore
 	meter *overlaybudget.Meter
-	log   *slog.Logger
+	// enqueue schedules the re-projection phase's re-fetches. It is the
+	// webhook receiver's own narrow insert surface (refetchEnqueuer,
+	// overlaywebhook.go): both lanes ask for exactly one record to be read
+	// again through the ingest the poller uses, so they enqueue the same job
+	// the same way. Injected rather than reached for, so a test drives the
+	// phase without standing up a River client.
+	enqueue refetchEnqueuer
+	log     *slog.Logger
+}
+
+// ambientRefetchEnqueuer schedules a re-fetch through the River client that is
+// working the sweep job, so the poller needs no second client of its own — the
+// posture ambientTelegramEnqueuer takes for the same reason. A context with no
+// client is reported, never swallowed: the phase logs it and the next pass
+// re-enqueues, rather than silently converging nothing.
+type ambientRefetchEnqueuer struct{}
+
+func (ambientRefetchEnqueuer) Enqueue(ctx context.Context, args river.JobArgs, opts *river.InsertOpts) error {
+	client, err := river.ClientFromContextSafely[pgx.Tx](ctx)
+	if err != nil {
+		return fmt.Errorf("overlay reconcile: no River client on the sweep's context: %w", err)
+	}
+	if _, err := client.Insert(ctx, args, opts); err != nil {
+		return fmt.Errorf("overlay reconcile: enqueueing %s: %w", args.Kind(), err)
+	}
+	return nil
 }
 
 // sweepMustStop reports whether err is the disconnect-race fence's clean-stop
@@ -44,13 +76,14 @@ func sweepMustStop(err error) bool {
 
 // sweepObjectClass runs one object class's full convergence for a
 // connection: the initial backfill (a cheap no-op once its cursor has
-// converged), the incremental modified-record sweep, then the
-// opposite-direction deletion sweep — each on its own persisted watermark,
-// each its own phase function below. Any phase's failure is logged and
+// converged), the incremental modified-record sweep, the opposite-direction
+// deletion sweep — each on its own persisted watermark — and finally the
+// re-projection of rows an older mapping declaration produced, each its own
+// phase function below. Any phase's failure is logged and
 // skips the REST of this class's sweep this tick (the next tick resumes from
 // the checkpoint), never aborting the other classes on its own — that
-// distinction is sweepMustStop's, below. workspace is the stringified id,
-// for logging only; connectedAt floors the incremental sweep of a class
+// distinction is sweepMustStop's, below. workspace names the tenant this
+// sweep runs for; connectedAt floors the incremental sweep of a class
 // that has no watermark yet.
 //
 // It returns a non-nil error only when sweepMustStop says so — a
@@ -60,7 +93,7 @@ func sweepMustStop(err error) bool {
 // stop). A per-object failure (a mapping/data defect, a DB read/write blip)
 // is logged and skips the rest of THIS class with a nil return, so the
 // connection-level loop moves on to the next class.
-func sweepObjectClass(ctx context.Context, deps sweepDeps, workspace, objectClass string, connectedAt time.Time) error {
+func sweepObjectClass(ctx context.Context, deps sweepDeps, workspace ids.WorkspaceID, objectClass string, connectedAt time.Time) error {
 	proceed, err := sweepBackfillPhase(ctx, deps, workspace, objectClass, connectedAt)
 	if err != nil {
 		return err
@@ -75,7 +108,11 @@ func sweepObjectClass(ctx context.Context, deps sweepDeps, workspace, objectClas
 	if !proceed {
 		return nil // the phase already logged and skipped (watermark read failed)
 	}
-	return sweepDeletionPhase(ctx, deps, workspace, objectClass)
+	if err := sweepDeletionPhase(ctx, deps, workspace, objectClass); err != nil {
+		return err
+	}
+	sweepReprojectionPhase(ctx, deps, workspace, objectClass)
+	return nil
 }
 
 // sweepBackfillPhase runs the initial full load before the incremental
@@ -90,19 +127,19 @@ func sweepObjectClass(ctx context.Context, deps sweepDeps, workspace, objectClas
 // incumbent quota sweeping a class whose initial load never converged this
 // tick — the same "stop the rest of this class, not the others" contract
 // every phase here honors.
-func sweepBackfillPhase(ctx context.Context, deps sweepDeps, workspace, objectClass string, connectedAt time.Time) (proceed bool, err error) {
+func sweepBackfillPhase(ctx context.Context, deps sweepDeps, workspace ids.WorkspaceID, objectClass string, connectedAt time.Time) (proceed bool, err error) {
 	truncated, err := overlay.Backfill(ctx, deps.inc, deps.ms, objectClass, connectedAt)
 	if err != nil {
 		if sweepMustStop(err) {
 			return false, err
 		}
 		deps.log.WarnContext(ctx, "overlay reconcile: backfill pass failed, skipping this object class this tick",
-			"workspace", workspace, "object_class", objectClass, "err", err)
+			"workspace", workspace.String(), "object_class", objectClass, "err", err)
 		return false, nil
 	}
 	if truncated {
 		deps.log.WarnContext(ctx, "overlay reconcile: backfill capped by MARGINCE_OVERLAY_BACKFILL_LIMIT; this object class will report backfill-complete=false until its overlay_backfill_cursor row is cleared (unsetting the cap alone does not resume it)",
-			"workspace", workspace, "object_class", objectClass)
+			"workspace", workspace.String(), "object_class", objectClass)
 	}
 	return true, nil
 }
@@ -117,14 +154,14 @@ func sweepBackfillPhase(ctx context.Context, deps sweepDeps, workspace, objectCl
 // this tick" outcomes (an unreadable watermark, a failed Reconcile pass),
 // matching the original single-function behavior where either failure
 // returned before ever reaching ReconcileDeletions.
-func sweepModifiedPhase(ctx context.Context, deps sweepDeps, workspace, objectClass string, connectedAt time.Time) (proceed bool, err error) {
+func sweepModifiedPhase(ctx context.Context, deps sweepDeps, workspace ids.WorkspaceID, objectClass string, connectedAt time.Time) (proceed bool, err error) {
 	watermark, err := deps.ms.LoadReconcileWatermark(ctx, objectClass)
 	if err != nil {
 		// A watermark read is a local DB call, not an incumbent one — a blip
 		// here is not a connection-level failure, so skip this class rather
 		// than back the whole connection off.
 		deps.log.WarnContext(ctx, "overlay reconcile: loading the persisted watermark failed, skipping this object class",
-			"workspace", workspace, "object_class", objectClass, "err", err)
+			"workspace", workspace.String(), "object_class", objectClass, "err", err)
 		return false, nil
 	}
 	newWatermark, err := overlay.Reconcile(ctx, deps.inc, deps.ms, deps.meter, objectClass, watermark, connectedAt)
@@ -133,7 +170,7 @@ func sweepModifiedPhase(ctx context.Context, deps sweepDeps, workspace, objectCl
 			return false, err
 		}
 		deps.log.WarnContext(ctx, "overlay reconcile sweep failed",
-			"workspace", workspace, "object_class", objectClass, "err", err)
+			"workspace", workspace.String(), "object_class", objectClass, "err", err)
 		return false, nil
 	}
 	if newWatermark.After(watermark) {
@@ -142,7 +179,7 @@ func sweepModifiedPhase(ctx context.Context, deps sweepDeps, workspace, objectCl
 				return false, err
 			}
 			deps.log.WarnContext(ctx, "overlay reconcile: persisting the new watermark failed",
-				"workspace", workspace, "object_class", objectClass, "err", err)
+				"workspace", workspace.String(), "object_class", objectClass, "err", err)
 		}
 	}
 	return true, nil
@@ -157,14 +194,92 @@ func sweepModifiedPhase(ctx context.Context, deps sweepDeps, workspace, objectCl
 // same row. The sweep full-scans the archived feed each pass and purges
 // idempotently (ReconcileDeletions' own doc explains why a watermark would
 // be unsound over HubSpot's unordered archived feed).
-func sweepDeletionPhase(ctx context.Context, deps sweepDeps, workspace, objectClass string) error {
+func sweepDeletionPhase(ctx context.Context, deps sweepDeps, workspace ids.WorkspaceID, objectClass string) error {
 	if err := overlay.ReconcileDeletions(ctx, deps.inc, deps.ms, deps.meter, objectClass); err != nil {
 		if sweepMustStop(err) {
 			return err
 		}
 		deps.log.WarnContext(ctx, "overlay reconcile: deletion sweep failed",
-			"workspace", workspace, "object_class", objectClass, "err", err)
+			"workspace", workspace.String(), "object_class", objectClass, "err", err)
 		return nil
 	}
 	return nil
+}
+
+// reprojectionEnqueueLimit bounds how many rows one pass re-projects per
+// object class. A declaration change puts EVERY row of a class out of date at
+// once, and an estate can hold far more of them than a tick's worth of
+// incumbent quota could ever re-read: unbounded, one pass would enqueue a
+// re-fetch per row, and the queue — not the budget the meter guards at
+// execution — would carry the whole estate. Bounded, a pass takes a prefix and
+// leaves the rest for the next one, which is what makes convergence a matter
+// of passes rather than of one burst.
+//
+// It is deliberately NOT MARGINCE_OVERLAY_BACKFILL_LIMIT: that knob is a
+// dev/demo cap on the initial load and is unset in production, so bounding
+// re-projection by it would mean "unbounded" in exactly the deployment that
+// needs the bound.
+const reprojectionEnqueueLimit = 200
+
+// sweepReprojectionPhase re-fetches the rows an OLDER mapping declaration
+// projected. A mirror row holds a projection and is re-projected only when the
+// incumbent's own baseline advances, so a mapping change leaves every
+// already-mirrored row holding a payload today's declaration would never
+// produce — and the flip freezes the mirror and writes whatever a row holds as
+// a durable native row. The flip preflight refuses exactly these rows
+// (overlay's projectionstaleness.go); this phase is what clears them, so that
+// block is temporary rather than permanent.
+//
+// It runs LAST, after the watermark phases, so freshness and the incumbent
+// budget keep priority: an estate under budget pressure stays fresh while it
+// converges slowly, and the flip stays blocked meanwhile, which is correct.
+//
+// It needs no cursor of its own. Ingest stamps the fingerprint of the
+// declaration that produced the record, so a row leaves the stale set as soon
+// as its re-fetch lands; successive passes select the next rows still in it,
+// and the phase becomes a no-op once the class has converged.
+//
+// It reports nothing to its caller. Every failure here belongs to this object
+// class alone — an undeclared class, a failed read, a refused enqueue — and
+// the next pass retries it, so there is no later phase to gate and no
+// connection-level condition to propagate.
+func sweepReprojectionPhase(ctx context.Context, deps sweepDeps, workspace ids.WorkspaceID, objectClass string) {
+	m, ok := hubspot.Mapping(objectClass)
+	if !ok {
+		// An honest gap, not a guess: with no declaration there is no
+		// fingerprint to judge this class's rows against, and calling them all
+		// stale would re-read the class every pass forever.
+		deps.log.WarnContext(ctx, "overlay reconcile: no mapping declaration for this object class, skipping re-projection",
+			"workspace", workspace.String(), "object_class", objectClass)
+		return
+	}
+	stale, err := deps.ms.StaleProjections(ctx, m, reprojectionEnqueueLimit)
+	if err != nil {
+		deps.log.WarnContext(ctx, "overlay reconcile: listing the rows an older declaration projected failed",
+			"workspace", workspace.String(), "object_class", objectClass, "err", err)
+		return
+	}
+	for _, externalID := range stale {
+		if err := deps.enqueue.Enqueue(ctx, OverlayRefetchArgs{
+			Workspace:      workspace.UUID,
+			IncumbentClass: objectClass,
+			ExternalID:     externalID,
+		}, reprojectionInsertOpts()); err != nil {
+			// One refused insert says the queue is unavailable, not that this
+			// row is special: stop this class here rather than logging the
+			// same failure once per row, and let the next pass re-enqueue.
+			deps.log.WarnContext(ctx, "overlay reconcile: enqueueing a re-projection re-fetch failed",
+				"workspace", workspace.String(), "object_class", objectClass, "external_id", externalID, "err", err)
+			return
+		}
+	}
+}
+
+// reprojectionInsertOpts is unique-by-args over the states a job passes
+// through before it is worked: a sweep tick that runs again while an earlier
+// re-fetch is still queued must not stack a second read of the same record —
+// the args ARE the coalescing key, exactly as they are for the webhook lane's
+// signal-driven re-fetch (overlaywebhook.go).
+func reprojectionInsertOpts() *river.InsertOpts {
+	return &river.InsertOpts{UniqueOpts: river.UniqueOpts{ByArgs: true, ByState: activeSweepStates}}
 }

--- a/backend/internal/compose/jobs_overlay_sweep.go
+++ b/backend/internal/compose/jobs_overlay_sweep.go
@@ -219,6 +219,12 @@ func sweepDeletionPhase(ctx context.Context, deps sweepDeps, workspace ids.Works
 // dev/demo cap on the initial load and is unset in production, so bounding
 // re-projection by it would mean "unbounded" in exactly the deployment that
 // needs the bound.
+//
+// 200 is what the poller's own cadence makes of it: --overlay-reconcile-interval
+// defaults to 2 minutes (cmd/worker/config.go), so one class converges at up to
+// 6,000 rows an hour and an estate of 100,000 rows of that class inside a day —
+// fast enough that a mapping change is not a week-long flip freeze, slow enough
+// that the queue never holds more than a tick's worth of re-fetches.
 const reprojectionEnqueueLimit = 200
 
 // sweepReprojectionPhase re-fetches the rows an OLDER mapping declaration
@@ -246,9 +252,11 @@ const reprojectionEnqueueLimit = 200
 func sweepReprojectionPhase(ctx context.Context, deps sweepDeps, workspace ids.WorkspaceID, objectClass string) {
 	m, ok := hubspot.Mapping(objectClass)
 	if !ok {
-		// An honest gap, not a guess: with no declaration there is no
-		// fingerprint to judge this class's rows against, and calling them all
-		// stale would re-read the class every pass forever.
+		// Unreachable while overlayObjectClasses is exactly the set the
+		// registry declares, and handled rather than assumed away because the
+		// two are separate lists: an undeclared class has no fingerprint to
+		// judge its rows against, and calling them all stale would re-read the
+		// class every pass forever.
 		deps.log.WarnContext(ctx, "overlay reconcile: no mapping declaration for this object class, skipping re-projection",
 			"workspace", workspace.String(), "object_class", objectClass)
 		return

--- a/backend/internal/compose/jobs_overlay_sweep.go
+++ b/backend/internal/compose/jobs_overlay_sweep.go
@@ -220,11 +220,20 @@ func sweepDeletionPhase(ctx context.Context, deps sweepDeps, workspace ids.Works
 // re-projection by it would mean "unbounded" in exactly the deployment that
 // needs the bound.
 //
-// 200 is what the poller's own cadence makes of it: --overlay-reconcile-interval
-// defaults to 2 minutes (cmd/worker/config.go), so one class converges at up to
-// 6,000 rows an hour and an estate of 100,000 rows of that class inside a day —
-// fast enough that a mapping change is not a week-long flip freeze, slow enough
-// that the queue never holds more than a tick's worth of re-fetches.
+// 200 bounds the QUEUE, and is not a throughput promise: what governs how fast
+// a class converges is the incumbent's DAILY REST allocation. Every re-fetch
+// enqueued here reserves one REST unit against SourceForceFresh before its live
+// read (jobs_overlay_refetch.go), and the meter sheds on the whole UTC day's
+// REST total across every source — with the built-in HubSpot budget
+// (deployconfig/overlaybudget.go: a 90,000 cap, shed at 0.90 of it) that is
+// ~81,000 live reads a day, shared with the poller's own spend and with
+// interactive force-fresh. So a class holding more stale rows than the day's
+// remaining allocation cannot converge inside that day however often the sweep
+// ticks, and a mapping change is felt past the flip: it drives the shared daily
+// total toward the shed band, where interactive force-fresh degrades to
+// mirror-with-staleness (AC-OV-7) for the rest of the UTC day. What the bound
+// buys is that the spend arrives as a trickle the meter can arbitrate against
+// live reads, rather than as a queue the sweep has already committed to.
 const reprojectionEnqueueLimit = 200
 
 // sweepReprojectionPhase re-fetches the rows an OLDER mapping declaration

--- a/backend/internal/compose/jobs_overlay_worker_integration_test.go
+++ b/backend/internal/compose/jobs_overlay_worker_integration_test.go
@@ -540,6 +540,34 @@ func TestReconcileConnectionBackfillsTheWebhookPortalBinding(t *testing.T) {
 	}
 }
 
+// registeredRefetchWorker is the overlay_refetch worker THIS build wires: it
+// is taken out of the registry wireJobs assembles, so every dependency the
+// worker runs on is the one the registration puts there. A hand-built worker
+// proves nothing about that — a field the registration never fills reads as
+// filled, and this worker only reaches its store AFTER it has reserved the
+// budget and spent a live incumbent read, so the gap surfaces as a panic per
+// re-fetch rather than as a missing wire.
+//
+// Only the incumbent boundary is replaced, for the reason every sibling test
+// replaces it: the alternative is a live HubSpot portal. A nil meter is left
+// nil on purpose where a test wants the shed posture, because the registration
+// itself substitutes the fail-closed meter for a role wired without one.
+func registeredRefetchWorker(t *testing.T, pool *pgxpool.Pool, vault keyvault.Vault, meter *overlaybudget.Meter, inc overlay.Incumbent) *overlayRefetchWorker {
+	t.Helper()
+	reg, _ := wireJobs(pool, slog.New(slog.DiscardHandler), JobRunnerConfig{OverlayVault: vault, OverlayMeter: meter})
+	kind := OverlayRefetchArgs{}.Kind()
+	wired, registered := reg.wired[kind]
+	if !registered {
+		t.Fatalf("this build registers no %s worker, so nothing works the jobs the sweep and the webhook enqueue", kind)
+	}
+	w, isRefetch := wired.worker.(*overlayRefetchWorker)
+	if !isRefetch {
+		t.Fatalf("%s is worked by %T, want *overlayRefetchWorker", kind, wired.worker)
+	}
+	w.newIncumbent = func(_, _ string) overlay.Incumbent { return inc }
+	return w
+}
+
 // TestOverlayRefetchWorkerFreshensTheMirrorRecord is the webhook-signal
 // re-fetch worker's real-Postgres proof (OVA-WIRE-10): given an active HubSpot
 // overlay whose owner map the poller has already seeded, one Work call Gets a
@@ -593,11 +621,7 @@ func TestOverlayRefetchWorkerFreshensTheMirrorRecord(t *testing.T) {
 	restMeter := budgettest.Meter(t, budgettest.SmallConfig("hubspot"))
 	runRefetch := func(inc *fake.Adapter) {
 		t.Helper()
-		w := &overlayRefetchWorker{
-			pool: e.Pool, vault: vault, ms: ms, meter: restMeter,
-			log:          slog.New(slog.DiscardHandler),
-			newIncumbent: func(_, _ string) overlay.Incumbent { return inc },
-		}
+		w := registeredRefetchWorker(t, e.Pool, vault, restMeter, inc)
 		if err := w.Work(context.Background(), &river.Job[OverlayRefetchArgs]{
 			Args: OverlayRefetchArgs{Workspace: e.WS, IncumbentClass: overlay.IncumbentClassContacts, ExternalID: "c-1"},
 		}); err != nil {
@@ -670,12 +694,10 @@ func TestOverlayRefetchWorkerShedsWhenBudgetExhausted(t *testing.T) {
 	// Spy on the incumbent so the test proves the live READ was skipped, not
 	// merely that nothing was ingested (the reserve gates before inc.Get).
 	spy := &getCountingIncumbent{Adapter: inc}
-	// failClosedOverlayMeter sheds every reservation (no window to account into).
-	w := &overlayRefetchWorker{
-		pool: e.Pool, vault: vault, ms: ms, meter: failClosedOverlayMeter(),
-		log:          slog.New(slog.DiscardHandler),
-		newIncumbent: func(_, _ string) overlay.Incumbent { return spy },
-	}
+	// A role wired with no meter at all, which the registration answers with
+	// failClosedOverlayMeter — it sheds every reservation, having no window to
+	// account into.
+	w := registeredRefetchWorker(t, e.Pool, vault, nil, spy)
 	if err := w.Work(context.Background(), &river.Job[OverlayRefetchArgs]{
 		Args: OverlayRefetchArgs{Workspace: e.WS, IncumbentClass: overlay.IncumbentClassContacts, ExternalID: "c-1"},
 	}); err != nil {

--- a/backend/internal/compose/overlay.go
+++ b/backend/internal/compose/overlay.go
@@ -8,9 +8,13 @@ package compose
 // so overlay never imports keyvault's concrete provider selection (the
 // same posture capture.go documents for NewCaptureRegistry). This also
 // wires the sync-status/budget surface: the shared OVB meter every
-// force-fresh read and the budget read must agree on, and the
+// force-fresh read and the budget read must agree on, the
 // canonical->incumbent class translator SyncStatus's backfill-
-// completeness lookup needs. ReconcileOverlay's on-demand sweep request
+// completeness lookup needs, and the mapping registry's current projection
+// fingerprints, which the flip preflight compares every mirror row against.
+// All three are injected here because the overlay module must never import
+// its own hubspot subpackage — that subpackage imports IT.
+// ReconcileOverlay's on-demand sweep request
 // (overlay.Service.RequestSweep) needs none of this compose-level wiring —
 // it only marks the workspace due, which the worker's own periodic sweep
 // (jobs_overlay.go) then picks up.
@@ -91,11 +95,24 @@ func NewOverlayHandlers(pool *pgxpool.Pool, vault keyvault.Vault, meter *overlay
 	svc := overlay.NewService(InstallationDB(pool), vault, ms).
 		WithBudgetMeter(meter).
 		WithIncumbentClassesTranslator(hubspot.IncumbentClassesFor).
+		WithProjectionFingerprints(OverlayProjectionFingerprints()).
 		WithIncumbentFactory(incumbent).
 		WithModeFlipObserver(onModeFlip).
 		WithFlipImportProbe(FlipImportProbe).
 		WithLogger(log)
 	return overlay.NewHandlers(svc).WithFlipRunner(newFlipRunner(pool, svc, ms, log))
+}
+
+// OverlayProjectionFingerprints answers the current declaration fingerprint of
+// every incumbent class this composition mirrors — what NewOverlayHandlers
+// injects, and therefore what the flip preflight judges every mirror row
+// against. It is exported because this package is the ONE sanctioned place
+// that names the concrete incumbent (AC-OV-1): a suite that seeds the mirror
+// through the fake incumbent still needs to stamp its rows with the
+// declaration the composed server recognises as current, and asks HERE rather
+// than reaching for the adapter itself.
+func OverlayProjectionFingerprints() map[string]string {
+	return hubspot.ProjectionFingerprints()
 }
 
 // hubspotIncumbentFactory builds a live HubSpot adapter over one

--- a/backend/internal/modules/overlay/connection.go
+++ b/backend/internal/modules/overlay/connection.go
@@ -133,8 +133,14 @@ type Service struct {
 	ms                 *MirrorStore
 	meter              *overlaybudget.Meter
 	toIncumbentClasses func(canonical string) (incumbentClasses []string, ok bool)
-	incumbent          func(region, token string) Incumbent
-	log                *slog.Logger
+	// projectionFingerprints is each INCUMBENT class's current declaration
+	// fingerprint, injected for the same reason toIncumbentClasses is: the
+	// mapping registry lives in the overlay/hubspot subpackage, which imports
+	// THIS package. Keyed by incumbent class because a canonical type can be
+	// backed by several declarations; projectionstaleness.go translates.
+	projectionFingerprints map[string]string
+	incumbent              func(region, token string) Incumbent
+	log                    *slog.Logger
 	// modeFlipped observes a committed x_sor_mode flip (Connect →
 	// overlay, Disconnect → native) so a mode-caching read dispatcher
 	// can drop its entry instead of serving the OLD mode for a cache

--- a/backend/internal/modules/overlay/fake/adapter.go
+++ b/backend/internal/modules/overlay/fake/adapter.go
@@ -69,13 +69,26 @@ func (a *Adapter) SeedAccountID(id string) { a.accountID = id }
 // bind" no-op a real adapter with no accessor would produce.
 func (a *Adapter) AccountID(context.Context) (string, error) { return a.accountID, nil }
 
+// ProjectionFingerprint is the declaration fingerprint every record this fake
+// produces carries. A real adapter stamps the digest of the mapping it
+// projected through; the fake projects through no mapping, so one constant is
+// the honest equivalent — what matters is that the fake stamps SOMETHING, as
+// the real one does, rather than leaving the field empty and making every
+// mirrored row read as projected by an unknown declaration.
+//
+// A test that wants a row projected by an older declaration sets the field on
+// the Record it seeds; Seed takes the Record whole, so no second constructor
+// is needed for it.
+const ProjectionFingerprint = "fake-projection-fingerprint"
+
 // Rec builds an overlay.Record for externalID carrying fields, stamped
 // with the current time as ModifiedAt.
 func Rec(externalID string, fields map[string]any) overlay.Record {
 	return overlay.Record{
-		ExternalID: externalID,
-		Fields:     fields,
-		ModifiedAt: time.Now(),
+		ExternalID:            externalID,
+		Fields:                fields,
+		ModifiedAt:            time.Now(),
+		ProjectionFingerprint: ProjectionFingerprint,
 	}
 }
 
@@ -289,10 +302,11 @@ func (a *Adapter) Create(_ context.Context, canonicalClass string, fields map[st
 		return overlay.WriteResult{}, fmt.Errorf("fake: cannot create a %s with no fields", canonicalClass)
 	}
 	rec := overlay.Record{
-		ExternalID:  a.nextWriteID(),
-		ObjectClass: canonicalClass,
-		Fields:      fields,
-		ModifiedAt:  writeEpoch.Add(time.Duration(a.writeSeq) * time.Second),
+		ExternalID:            a.nextWriteID(),
+		ObjectClass:           canonicalClass,
+		Fields:                fields,
+		ModifiedAt:            writeEpoch.Add(time.Duration(a.writeSeq) * time.Second),
+		ProjectionFingerprint: ProjectionFingerprint,
 	}
 	a.records[canonicalClass] = append(a.records[canonicalClass], rec)
 	// The fake does no incumbent mapping, so its "written properties" are the

--- a/backend/internal/modules/overlay/fingerprint.go
+++ b/backend/internal/modules/overlay/fingerprint.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"hash"
 	"sort"
+	"strconv"
 )
 
 // Fingerprint digests one object mapping's declaration. Two mappings that
@@ -33,17 +34,31 @@ func Fingerprint(m ObjectMapping) string {
 	writeField(h, "unmapped_policy", m.UnmappedPolicy)
 	writeSortedMap(h, "const", m.Const)
 	for i, f := range m.Fields {
-		// The index is part of the digest because Apply projects fields in
-		// declaration order, so a reordering can change which writer lands
-		// last on a shared target.
-		writeField(h, fmt.Sprintf("field.%d.from", i), fmt.Sprint(f.From))
+		// The index is hashed conservatively, not because a reorder is known to
+		// matter: order-independence rests on guards declared elsewhere —
+		// checkTargetCollisions rejects a shared target outright, and
+		// sortChildRowsByPosition re-sorts one parent's child rows by positions
+		// checkChildRowDeclarations keeps unique. Pinning the index costs a
+		// re-projection whenever Fields is reordered; leaving it out would bet
+		// the estate on those guards never being relaxed, and a missed
+		// re-projection is the failure this digest exists to prevent.
+		//
+		// From is written element by element, prefixed with its count, because a
+		// flattened rendering cannot separate ["a","b"] from ["a b"] — one
+		// TargetAssembler gathering two raw properties from one gathering a
+		// single property whose name contains a space. The count also keeps a nil
+		// From and an empty one equal, which they are: neither gathers anything.
+		writeField(h, fmt.Sprintf("field.%d.from.count", i), strconv.Itoa(len(f.From)))
+		for j, from := range f.From {
+			writeField(h, fmt.Sprintf("field.%d.from.%d", i, j), from)
+		}
 		writeField(h, fmt.Sprintf("field.%d.to", i), f.To)
 		writeField(h, fmt.Sprintf("field.%d.kind", i), f.Kind.String())
 		writeField(h, fmt.Sprintf("field.%d.transform", i), f.Transform)
 		writeField(h, fmt.Sprintf("field.%d.resolve", i), f.Resolve)
-		writeField(h, fmt.Sprintf("field.%d.always_emit", i), fmt.Sprint(f.AlwaysEmit))
+		writeField(h, fmt.Sprintf("field.%d.always_emit", i), strconv.FormatBool(f.AlwaysEmit))
 		if f.Child != nil {
-			writeField(h, fmt.Sprintf("field.%d.child.position", i), fmt.Sprint(f.Child.Position))
+			writeField(h, fmt.Sprintf("field.%d.child.position", i), strconv.Itoa(f.Child.Position))
 			writeSortedMap(h, fmt.Sprintf("field.%d.child.attrs", i), f.Child.Attrs)
 		}
 	}
@@ -63,6 +78,15 @@ func writeField(h hash.Hash, name, value string) {
 // iteration order varies per run and a fingerprint that varied would mark
 // every mirrored row stale forever.
 //
+// Values carry their dynamic type and their Go-syntax form, because Const and
+// Attrs are copied verbatim into the projected payload and a plain rendering is
+// type-blind: the bool true and the string "true" both render as "true", and
+// so do 1, 1.0 and "1" — a declaration edit that flips one for the other
+// changes the mirrored JSON. The Go-syntax form quotes strings and delimits
+// container members, so the same separation holds a level down into the nested
+// values a decoded-JSON declaration can carry. fmt sorts map keys, so a nested
+// map is as stable across runs as the ordering above.
+//
 //craft:ignore naked-any the declaration maps hold decoded JSON values; the any is the declared type, not a missed one
 func writeSortedMap(h hash.Hash, name string, values map[string]any) {
 	keys := make([]string, 0, len(values))
@@ -71,6 +95,6 @@ func writeSortedMap(h hash.Hash, name string, values map[string]any) {
 	}
 	sort.Strings(keys)
 	for _, k := range keys {
-		writeField(h, name+"."+k, fmt.Sprint(values[k]))
+		writeField(h, name+"."+k, fmt.Sprintf("%T=%#v", values[k], values[k]))
 	}
 }

--- a/backend/internal/modules/overlay/fingerprint.go
+++ b/backend/internal/modules/overlay/fingerprint.go
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package overlay
+
+// The mirror stores a PROJECTION, not the incumbent's raw record, and a row is
+// re-projected only when the incumbent's own baseline advances. So a mapping
+// change leaves every already-mirrored row holding a payload this code would
+// never produce again, indefinitely. The fingerprint is how a row says which
+// declaration produced it, so that condition is detectable rather than silent.
+//
+// It hashes the declaration's DATA, never its source text: a comment or
+// formatting edit must not invalidate an estate, and a semantic change must
+// not fail to.
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"hash"
+	"sort"
+)
+
+// Fingerprint digests one object mapping's declaration. Two mappings that
+// would project the same raw record identically share a fingerprint; any
+// difference that could change a projected payload changes it.
+func Fingerprint(m ObjectMapping) string {
+	h := sha256.New()
+	writeField(h, "source", m.Source)
+	writeField(h, "target", m.Target)
+	writeField(h, "external_key", m.ExternalKey)
+	writeField(h, "baseline", m.Baseline)
+	writeField(h, "unmapped_policy", m.UnmappedPolicy)
+	writeSortedMap(h, "const", m.Const)
+	for i, f := range m.Fields {
+		// The index is part of the digest because Apply projects fields in
+		// declaration order, so a reordering can change which writer lands
+		// last on a shared target.
+		writeField(h, fmt.Sprintf("field.%d.from", i), fmt.Sprint(f.From))
+		writeField(h, fmt.Sprintf("field.%d.to", i), f.To)
+		writeField(h, fmt.Sprintf("field.%d.kind", i), f.Kind.String())
+		writeField(h, fmt.Sprintf("field.%d.transform", i), f.Transform)
+		writeField(h, fmt.Sprintf("field.%d.resolve", i), f.Resolve)
+		writeField(h, fmt.Sprintf("field.%d.always_emit", i), fmt.Sprint(f.AlwaysEmit))
+		if f.Child != nil {
+			writeField(h, fmt.Sprintf("field.%d.child.position", i), fmt.Sprint(f.Child.Position))
+			writeSortedMap(h, fmt.Sprintf("field.%d.child.attrs", i), f.Child.Attrs)
+		}
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// writeField feeds one named value into the digest length-prefixed, so no
+// concatenation of two values can collide with a different pair. The parameter
+// is a hash.Hash rather than an io.Writer because that interface documents a
+// Write which never returns an error — there is no failure here to report.
+func writeField(h hash.Hash, name, value string) {
+	field := fmt.Sprintf("%d:%s=%d:%s;", len(name), name, len(value), value)
+	h.Write([]byte(field))
+}
+
+// writeSortedMap feeds a declaration map in key order, because Go's map
+// iteration order varies per run and a fingerprint that varied would mark
+// every mirrored row stale forever.
+//
+//craft:ignore naked-any the declaration maps hold decoded JSON values; the any is the declared type, not a missed one
+func writeSortedMap(h hash.Hash, name string, values map[string]any) {
+	keys := make([]string, 0, len(values))
+	for k := range values {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		writeField(h, name+"."+k, fmt.Sprint(values[k]))
+	}
+}

--- a/backend/internal/modules/overlay/fingerprint_test.go
+++ b/backend/internal/modules/overlay/fingerprint_test.go
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package overlay_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/modules/overlay"
+)
+
+// baseMapping is the shape every mutation below perturbs by exactly one
+// declaration detail. It is deliberately not a real HubSpot mapping: the
+// question is whether the fingerprint notices a change, not whether this
+// particular projection is one the product ships.
+func baseMapping() overlay.ObjectMapping {
+	return overlay.ObjectMapping{
+		Source: "contacts", Target: "person",
+		ExternalKey: "hs_object_id", Baseline: "lastmodifieddate",
+		UnmappedPolicy: "flag",
+		Const:          map[string]any{"kind": "note"},
+		Fields: []overlay.FieldMapping{
+			{From: []string{"firstname"}, To: "first_name", Kind: overlay.TargetColumn},
+			{
+				From: []string{"email"}, To: "person_email.email", Kind: overlay.TargetChild,
+				Transform: "lowercase",
+				Child:     &overlay.ChildRow{Attrs: map[string]any{"email_type": "work"}, Position: 0},
+			},
+		},
+	}
+}
+
+// A projection is only as good as the declaration that produced it, so any
+// change to that declaration has to change the fingerprint — otherwise a
+// mapping edit leaves already-mirrored rows claiming to be current when the
+// projection they hold is one this code would never produce again.
+func TestFingerprintChangesWithEveryDeclarationDetail(t *testing.T) {
+	base := overlay.Fingerprint(baseMapping())
+	for _, tc := range []struct {
+		name   string
+		mutate func(*overlay.ObjectMapping)
+	}{
+		{"source", func(m *overlay.ObjectMapping) { m.Source = "companies" }},
+		{"target", func(m *overlay.ObjectMapping) { m.Target = "organization" }},
+		{"external key", func(m *overlay.ObjectMapping) { m.ExternalKey = "id" }},
+		{"baseline", func(m *overlay.ObjectMapping) { m.Baseline = "hs_lastmodifieddate" }},
+		{"unmapped policy", func(m *overlay.ObjectMapping) { m.UnmappedPolicy = "drop" }},
+		{"const value", func(m *overlay.ObjectMapping) { m.Const["kind"] = "call" }},
+		{"const key", func(m *overlay.ObjectMapping) { m.Const = map[string]any{"other": "note"} }},
+		{"field from", func(m *overlay.ObjectMapping) { m.Fields[0].From = []string{"lastname"} }},
+		{"field to", func(m *overlay.ObjectMapping) { m.Fields[0].To = "last_name" }},
+		{"field kind", func(m *overlay.ObjectMapping) { m.Fields[0].Kind = overlay.TargetAssembler }},
+		{"field transform", func(m *overlay.ObjectMapping) { m.Fields[1].Transform = "uppercase" }},
+		{"field resolve", func(m *overlay.ObjectMapping) { m.Fields[0].Resolve = "mirror_user_map" }},
+		{"field always-emit", func(m *overlay.ObjectMapping) { m.Fields[0].AlwaysEmit = true }},
+		{"child attrs", func(m *overlay.ObjectMapping) { m.Fields[1].Child.Attrs["email_type"] = "personal" }},
+		{"child position", func(m *overlay.ObjectMapping) { m.Fields[1].Child.Position = 1 }},
+		{"field added", func(m *overlay.ObjectMapping) {
+			m.Fields = append(m.Fields, overlay.FieldMapping{From: []string{"jobtitle"}, To: "title"})
+		}},
+		{"field removed", func(m *overlay.ObjectMapping) { m.Fields = m.Fields[:1] }},
+		{"field order", func(m *overlay.ObjectMapping) { m.Fields[0], m.Fields[1] = m.Fields[1], m.Fields[0] }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m := baseMapping()
+			tc.mutate(&m)
+			if got := overlay.Fingerprint(m); got == base {
+				t.Errorf("changing the %s left the fingerprint at %s, so rows projected by the old "+
+					"declaration would read as current. Include it in Fingerprint.", tc.name, got)
+			}
+		})
+	}
+}
+
+// The mutation table above is only exhaustive while the structs it perturbs
+// are. A new field on either has to be decided about — hashed, or explicitly
+// not — and this pin is what forces that decision instead of letting the
+// field default into being ignored.
+func TestFingerprintCoversEveryDeclarationField(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		//craft:ignore naked-any the pinned shapes are heterogeneous struct types read through reflection — the any is the reflection boundary itself
+		shape any
+		want  int
+	}{
+		{"ObjectMapping", overlay.ObjectMapping{}, 7},
+		{"FieldMapping", overlay.FieldMapping{}, 7},
+		{"ChildRow", overlay.ChildRow{}, 2},
+	} {
+		if got := reflect.TypeOf(tc.shape).NumField(); got != tc.want {
+			t.Errorf("%s has %d fields, pinned at %d. A field was added or removed: decide whether it "+
+				"belongs in Fingerprint, add or remove its case in TestFingerprintChangesWithEveryDeclarationDetail, "+
+				"then move this pin.", tc.name, got, tc.want)
+		}
+	}
+}
+
+// A fingerprint that varied between processes would mark every row stale
+// forever and block the flip permanently, so map iteration order must not
+// reach the digest.
+func TestFingerprintIsStableAcrossRuns(t *testing.T) {
+	first := overlay.Fingerprint(baseMapping())
+	for i := 0; i < 50; i++ {
+		if got := overlay.Fingerprint(baseMapping()); got != first {
+			t.Fatalf("run %d produced %s, want %s — an unstable fingerprint marks every row stale forever", i, got, first)
+		}
+	}
+	if first == "" {
+		t.Fatal("Fingerprint answered the empty string; a row stamped with it could never be compared")
+	}
+}

--- a/backend/internal/modules/overlay/fingerprint_test.go
+++ b/backend/internal/modules/overlay/fingerprint_test.go
@@ -5,6 +5,7 @@ package overlay_test
 
 import (
 	"reflect"
+	"sort"
 	"testing"
 
 	"github.com/gradionhq/margince/backend/internal/modules/overlay"
@@ -14,18 +15,31 @@ import (
 // declaration detail. It is deliberately not a real HubSpot mapping: the
 // question is whether the fingerprint notices a change, not whether this
 // particular projection is one the product ships.
+//
+// Const and Attrs carry several keys each, and values of several types, because
+// a one-key map makes the ordering the digest depends on unobservable —
+// sorting one key is indistinguishable from not sorting at all, so the
+// stability test below could only pass. Their mixed types are what makes a
+// type-blind rendering of a value observable too.
 func baseMapping() overlay.ObjectMapping {
 	return overlay.ObjectMapping{
 		Source: "contacts", Target: "person",
 		ExternalKey: "hs_object_id", Baseline: "lastmodifieddate",
 		UnmappedPolicy: "flag",
-		Const:          map[string]any{"kind": "note"},
+		Const: map[string]any{
+			"kind": "note", "origin": "hubspot", "archived": false, "revision": 2,
+		},
 		Fields: []overlay.FieldMapping{
 			{From: []string{"firstname"}, To: "first_name", Kind: overlay.TargetColumn},
 			{
 				From: []string{"email"}, To: "person_email.email", Kind: overlay.TargetChild,
 				Transform: "lowercase",
-				Child:     &overlay.ChildRow{Attrs: map[string]any{"email_type": "work"}, Position: 0},
+				Child: &overlay.ChildRow{
+					Attrs: map[string]any{
+						"email_type": "work", "is_primary": true, "verified": false, "rank": 1,
+					},
+					Position: 0,
+				},
 			},
 		},
 	}
@@ -54,7 +68,9 @@ func TestFingerprintChangesWithEveryDeclarationDetail(t *testing.T) {
 		{"field transform", func(m *overlay.ObjectMapping) { m.Fields[1].Transform = "uppercase" }},
 		{"field resolve", func(m *overlay.ObjectMapping) { m.Fields[0].Resolve = "mirror_user_map" }},
 		{"field always-emit", func(m *overlay.ObjectMapping) { m.Fields[0].AlwaysEmit = true }},
+		{"const value type", func(m *overlay.ObjectMapping) { m.Const["revision"] = "2" }},
 		{"child attrs", func(m *overlay.ObjectMapping) { m.Fields[1].Child.Attrs["email_type"] = "personal" }},
+		{"child attr value type", func(m *overlay.ObjectMapping) { m.Fields[1].Child.Attrs["is_primary"] = "true" }},
 		{"child position", func(m *overlay.ObjectMapping) { m.Fields[1].Child.Position = 1 }},
 		{"field added", func(m *overlay.ObjectMapping) {
 			m.Fields = append(m.Fields, overlay.FieldMapping{From: []string{"jobtitle"}, To: "title"})
@@ -77,22 +93,120 @@ func TestFingerprintChangesWithEveryDeclarationDetail(t *testing.T) {
 // are. A new field on either has to be decided about — hashed, or explicitly
 // not — and this pin is what forces that decision instead of letting the
 // field default into being ignored.
+//
+// The pin is on the field NAMES, not their count: a change that swaps one field
+// for another in a single edit keeps the count identical, and that is exactly
+// the case where the replacement silently misses the digest.
 func TestFingerprintCoversEveryDeclarationField(t *testing.T) {
 	for _, tc := range []struct {
 		name string
 		//craft:ignore naked-any the pinned shapes are heterogeneous struct types read through reflection — the any is the reflection boundary itself
 		shape any
-		want  int
+		want  []string
 	}{
-		{"ObjectMapping", overlay.ObjectMapping{}, 7},
-		{"FieldMapping", overlay.FieldMapping{}, 7},
-		{"ChildRow", overlay.ChildRow{}, 2},
+		{"ObjectMapping", overlay.ObjectMapping{}, []string{
+			"Baseline", "Const", "ExternalKey", "Fields", "Source", "Target", "UnmappedPolicy",
+		}},
+		{"FieldMapping", overlay.FieldMapping{}, []string{
+			"AlwaysEmit", "Child", "From", "Kind", "Resolve", "To", "Transform",
+		}},
+		{"ChildRow", overlay.ChildRow{}, []string{"Attrs", "Position"}},
 	} {
-		if got := reflect.TypeOf(tc.shape).NumField(); got != tc.want {
-			t.Errorf("%s has %d fields, pinned at %d. A field was added or removed: decide whether it "+
+		if got := sortedFieldNames(tc.shape); !reflect.DeepEqual(got, tc.want) {
+			t.Errorf("%s declares %v, pinned at %v. A field was added, removed or renamed: decide whether it "+
 				"belongs in Fingerprint, add or remove its case in TestFingerprintChangesWithEveryDeclarationDetail, "+
 				"then move this pin.", tc.name, got, tc.want)
 		}
+	}
+}
+
+// sortedFieldNames answers a struct's field names in a stable order, so the pin
+// above reads as the set it is and a reordering of the declaration alone does
+// not fail it.
+//
+//craft:ignore naked-any the argument is whichever declaration struct is being pinned — the any is the reflection boundary itself
+func sortedFieldNames(shape any) []string {
+	shapeType := reflect.TypeOf(shape)
+	names := make([]string, 0, shapeType.NumField())
+	for i := range shapeType.NumField() {
+		names = append(names, shapeType.Field(i).Name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// A rendering that flattens a value before it reaches the digest collides on
+// declarations that project differently. Each pair below is one such collision:
+// the two sides are distinct declarations, so the mapping edit between them has
+// to re-project the estate rather than leave it claiming to be current.
+func TestFingerprintSeparatesDeclarationsThatFlattenAlike(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		left    func(*overlay.ObjectMapping)
+		right   func(*overlay.ObjectMapping)
+		because string
+	}{
+		{
+			name: "a two-property From against a one-property From naming a space",
+			left: func(m *overlay.ObjectMapping) {
+				m.Fields[0].Kind = overlay.TargetAssembler
+				m.Fields[0].From = []string{"a", "b"}
+			},
+			right: func(m *overlay.ObjectMapping) {
+				m.Fields[0].Kind = overlay.TargetAssembler
+				m.Fields[0].From = []string{"a b"}
+			},
+			because: "an assembler gathering two raw properties projects a different payload from one " +
+				"gathering a single property whose name contains a space",
+		},
+		{
+			name:  "a bool const against the string spelling it",
+			left:  func(m *overlay.ObjectMapping) { m.Const["archived"] = true },
+			right: func(m *overlay.ObjectMapping) { m.Const["archived"] = "true" },
+			because: "Const values are copied verbatim into the mirrored payload, where the JSON true " +
+				"and the JSON \"true\" are different values",
+		},
+		{
+			name:  "a bool child attribute against the string spelling it",
+			left:  func(m *overlay.ObjectMapping) { m.Fields[1].Child.Attrs["is_primary"] = true },
+			right: func(m *overlay.ObjectMapping) { m.Fields[1].Child.Attrs["is_primary"] = "true" },
+			because: "Attrs are copied verbatim into the mirrored child row, where the JSON true and " +
+				"the JSON \"true\" are different values",
+		},
+		{
+			name:  "a numeric const against the string spelling it",
+			left:  func(m *overlay.ObjectMapping) { m.Const["revision"] = 2 },
+			right: func(m *overlay.ObjectMapping) { m.Const["revision"] = "2" },
+			because: "a mirrored number and a mirrored string are different JSON values, and a consumer " +
+				"reading the column gets a different type",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			left, right := baseMapping(), baseMapping()
+			tc.left(&left)
+			tc.right(&right)
+			if overlay.Fingerprint(left) == overlay.Fingerprint(right) {
+				t.Errorf("both declarations fingerprint to %s, so switching between them would leave every "+
+					"mirrored row reading as current — but %s. Feed the difference into Fingerprint.",
+					overlay.Fingerprint(left), tc.because)
+			}
+		})
+	}
+}
+
+// The other half of the same obligation: a difference that CANNOT change a
+// projected payload must not move the digest, or the estate re-projects for
+// nothing. A nil From and an empty one both gather no raw property.
+func TestFingerprintTreatsAnAbsentAndAnEmptyFromAlike(t *testing.T) {
+	nilFrom, emptyFrom := baseMapping(), baseMapping()
+	nilFrom.Fields[0].From = nil
+	emptyFrom.Fields[0].From = []string{}
+
+	got, want := overlay.Fingerprint(nilFrom), overlay.Fingerprint(emptyFrom)
+	if got != want {
+		t.Errorf("a nil From fingerprints to %s and an empty one to %s, but neither gathers a raw property, "+
+			"so the two project identically; re-projecting the estate to move between them buys nothing. "+
+			"Hash the length, not the container.", got, want)
 	}
 }
 

--- a/backend/internal/modules/overlay/fingerprint_test.go
+++ b/backend/internal/modules/overlay/fingerprint_test.go
@@ -210,10 +210,11 @@ func TestFingerprintTreatsAnAbsentAndAnEmptyFromAlike(t *testing.T) {
 	}
 }
 
-// A fingerprint that varied between processes would mark every row stale
-// forever and block the flip permanently, so map iteration order must not
-// reach the digest.
-func TestFingerprintIsStableAcrossRuns(t *testing.T) {
+// A declaration fingerprinted twice must answer the same digest both times:
+// the mapping is walked over Go maps, whose iteration order differs per call,
+// and a digest that took that order in would mark every row stale forever and
+// block the flip permanently.
+func TestFingerprintDoesNotVaryWithMapIterationOrder(t *testing.T) {
 	first := overlay.Fingerprint(baseMapping())
 	for i := 0; i < 50; i++ {
 		if got := overlay.Fingerprint(baseMapping()); got != first {

--- a/backend/internal/modules/overlay/flipreads.go
+++ b/backend/internal/modules/overlay/flipreads.go
@@ -64,7 +64,8 @@ func (s *MirrorStore) FlipRows(ctx context.Context, objectClass string, offset, 
 	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		rows, err := tx.Query(ctx, `
 			SELECT object_class, external_id, fields, updated_at_baseline,
-			       coalesce(owner_external_id, ''), sync_state, last_synced_at
+			       coalesce(owner_external_id, ''), sync_state, last_synced_at,
+			       coalesce(projection_fingerprint, '')
 			FROM overlay_mirror
 			WHERE object_class = $1
 			ORDER BY external_id
@@ -76,7 +77,7 @@ func (s *MirrorStore) FlipRows(ctx context.Context, objectClass string, offset, 
 		for rows.Next() {
 			var r Row
 			if err := rows.Scan(&r.ObjectClass, &r.ExternalID, &r.Fields, &r.UpdatedAtBaseline,
-				&r.OwnerExternalID, &r.SyncState, &r.LastSyncedAt); err != nil {
+				&r.OwnerExternalID, &r.SyncState, &r.LastSyncedAt, &r.ProjectionFingerprint); err != nil {
 				return fmt.Errorf("overlay: scanning a %s estate row for the flip: %w", objectClass, err)
 			}
 			out = append(out, r)

--- a/backend/internal/modules/overlay/flipstate.go
+++ b/backend/internal/modules/overlay/flipstate.go
@@ -54,7 +54,13 @@ type FlipChecks struct {
 	// the OVA-AC-6(a) incumbent-unreachable block.
 	ConnectionStatus string
 	// ForceFreshDone: a sweep has succeeded, no mirror row is stale, and
-	// every mirrored class's backfill has genuinely converged.
+	// every mirrored class's backfill has genuinely converged. A row counts
+	// as stale two ways: its sync_state says so, or its payload was
+	// projected by a declaration that is no longer current — including a row
+	// that records no declaration at all (projectionstaleness.go). The flip
+	// writes durable native rows from the frozen mirror, so a projection
+	// nothing has re-checked against the current mapping would become
+	// permanent.
 	ForceFreshDone bool
 	// PendingSyncCount: rows with un-drained local writes — the flip
 	// waits until they drain (AC-mode-flip-4).
@@ -102,13 +108,22 @@ func (s *Service) FlipChecks(ctx context.Context) (FlipChecks, error) {
 			return fmt.Errorf("overlay: reading the connection status for the flip preflight: %w", err)
 		}
 
+		classes, err := mirroredClasses(ctx, tx)
+		if err != nil {
+			return err
+		}
+		currentFingerprints, err := s.currentProjectionFingerprints(classes)
+		if err != nil {
+			return err
+		}
+
 		var pending, stale int
 		var lastSynced *time.Time
 		if err := tx.QueryRow(ctx, `
 			SELECT count(*) FILTER (WHERE sync_state = $1),
-			       count(*) FILTER (WHERE sync_state = $2),
+			       count(*) FILTER (WHERE sync_state = $2 OR `+staleProjectionSQL+`),
 			       count(*), max(last_synced_at)
-			FROM overlay_mirror`, syncStatePendingSync, syncStateStale,
+			FROM overlay_mirror`, syncStatePendingSync, syncStateStale, currentFingerprints,
 		).Scan(&pending, &stale, &checks.MirrorRows, &lastSynced); err != nil {
 			return fmt.Errorf("overlay: aggregating mirror state for the flip preflight: %w", err)
 		}
@@ -118,7 +133,7 @@ func (s *Service) FlipChecks(ctx context.Context) (FlipChecks, error) {
 		}
 
 		var lastSweep *time.Time
-		err := tx.QueryRow(ctx, `SELECT last_success_at FROM overlay_sync_state`).Scan(&lastSweep)
+		err = tx.QueryRow(ctx, `SELECT last_success_at FROM overlay_sync_state`).Scan(&lastSweep)
 		if err != nil && !errors.Is(err, pgx.ErrNoRows) {
 			return fmt.Errorf("overlay: reading sweep state for the flip preflight: %w", err)
 		}
@@ -127,7 +142,7 @@ func (s *Service) FlipChecks(ctx context.Context) (FlipChecks, error) {
 			checks.LastSweepAt = *lastSweep
 		}
 
-		backfilled, err := s.allMirroredClassesBackfilled(ctx, tx)
+		backfilled, err := s.allMirroredClassesBackfilled(ctx, tx, classes)
 		if err != nil {
 			return err
 		}
@@ -141,20 +156,12 @@ func (s *Service) FlipChecks(ctx context.Context) (FlipChecks, error) {
 }
 
 // allMirroredClassesBackfilled answers whether every object class the
-// mirror holds has a genuinely converged backfill (backfillCompleteFor's
-// done-and-not-truncated, per incumbent class). An empty mirror answers
-// true — convergence on an empty incumbent object set is a valid
-// force-fresh state; the sweep-success check beside it keeps "never
-// synced at all" from slipping through as ready.
-func (s *Service) allMirroredClassesBackfilled(ctx context.Context, tx pgx.Tx) (bool, error) {
-	rows, err := tx.Query(ctx, `SELECT DISTINCT object_class FROM overlay_mirror ORDER BY object_class`)
-	if err != nil {
-		return false, fmt.Errorf("overlay: listing mirrored classes for the flip preflight: %w", err)
-	}
-	classes, err := pgx.CollectRows(rows, pgx.RowTo[string])
-	if err != nil {
-		return false, fmt.Errorf("overlay: collecting mirrored classes for the flip preflight: %w", err)
-	}
+// mirror holds (classes, read once by the caller) has a genuinely converged
+// backfill (backfillCompleteFor's done-and-not-truncated, per incumbent
+// class). An empty mirror answers true — convergence on an empty incumbent
+// object set is a valid force-fresh state; the sweep-success check beside it
+// keeps "never synced at all" from slipping through as ready.
+func (s *Service) allMirroredClassesBackfilled(ctx context.Context, tx pgx.Tx, classes []string) (bool, error) {
 	for _, class := range classes {
 		complete, err := s.backfillCompleteFor(ctx, tx, class)
 		if err != nil {

--- a/backend/internal/modules/overlay/flipstate_integration_test.go
+++ b/backend/internal/modules/overlay/flipstate_integration_test.go
@@ -117,6 +117,151 @@ func flipService(db *database.DB) *Service {
 	})
 }
 
+// The declarations these tests judge rows against: what the contacts mapping
+// currently is, and one it used to be. Both are opaque digests to everything
+// under test — the flip preflight compares them, it never computes them.
+const (
+	currentContactsDeclaration = "contacts-declaration-current"
+	oldContactsDeclaration     = "contacts-declaration-superseded"
+)
+
+// flipServiceJudgingContacts is flipService with the current declarations
+// injected — for contacts ONLY. The companies mapping is deliberately absent:
+// it stands for a class this deployment cannot judge, which must be spared
+// rather than counted stale forever.
+func flipServiceJudgingContacts(db *database.DB) *Service {
+	return flipService(db).WithProjectionFingerprints(map[string]string{
+		IncumbentClassContacts: currentContactsDeclaration,
+	})
+}
+
+// ingestMirrorRow seeds one row through the real ingest, so the fingerprint
+// column is written by the writer production uses rather than by the test.
+func ingestMirrorRow(ctx context.Context, t *testing.T, ms *MirrorStore, objectClass, ext, fingerprint string, baseline time.Time) {
+	t.Helper()
+	err := ms.Ingest(ctx, Record{
+		ObjectClass: objectClass, ExternalID: ext,
+		Fields:                map[string]any{"full_name": "Ingested Row"},
+		ModifiedAt:            baseline,
+		ProjectionFingerprint: fingerprint,
+	})
+	if err != nil {
+		t.Fatalf("ingesting %s/%s: %v", objectClass, ext, err)
+	}
+}
+
+// TestFlipChecksRefuseAProjectionAnOlderDeclarationProduced is the flip's
+// reason for comparing at all: it freezes the mirror and writes what every row
+// holds as durable native rows, so a payload the current mapping would no
+// longer produce would become permanent. Re-projecting the row is the way out,
+// and the check must then clear.
+func TestFlipChecksRefuseAProjectionAnOlderDeclarationProduced(t *testing.T) {
+	ctx, pool, ws := testWorkspaceCtx(t)
+	seedOverlayWorkspace(ctx, t, pool)
+	db := database.BindTo(pool, ids.From[ids.WorkspaceKind](ws))
+	svc := flipServiceJudgingContacts(db)
+	ms := NewMirrorStore(db, nil)
+	recordSweepSuccess(ctx, t, pool)
+	markBackfillDone(ctx, t, pool, IncumbentClassContacts)
+
+	baseline := time.Date(2026, 5, 13, 6, 44, 38, 0, time.UTC)
+	ingestMirrorRow(ctx, t, ms, "person", "p-current", currentContactsDeclaration, baseline)
+	checks, err := svc.FlipChecks(ctx)
+	if err != nil {
+		t.Fatalf("FlipChecks: %v", err)
+	}
+	if !checks.ForceFreshDone {
+		t.Fatalf("checks = %+v, want force-fresh done with every projection current", checks)
+	}
+
+	ingestMirrorRow(ctx, t, ms, "person", "p-legacy", oldContactsDeclaration, baseline)
+	checks, err = svc.FlipChecks(ctx)
+	if err != nil {
+		t.Fatalf("FlipChecks: %v", err)
+	}
+	if checks.ForceFreshDone {
+		t.Fatal("force-fresh reported done while a row still holds a projection an older declaration produced")
+	}
+
+	// Re-projecting at the SAME baseline is the convergence path (the
+	// incumbent has not touched the record, so nothing else can change).
+	ingestMirrorRow(ctx, t, ms, "person", "p-legacy", currentContactsDeclaration, baseline)
+	checks, err = svc.FlipChecks(ctx)
+	if err != nil {
+		t.Fatalf("FlipChecks: %v", err)
+	}
+	if !checks.ForceFreshDone {
+		t.Fatal("force-fresh stayed blocked after the row was re-projected by the current declaration")
+	}
+}
+
+// TestFlipChecksCountARowThatRecordsNoDeclarationAsStale covers the rows the
+// fingerprint column arrived after (issue #1038): they record NULL, which the
+// read paths coalesce to the empty string. Neither is a current declaration,
+// and nothing has checked what produced them — treating that as "unknown, let
+// it through" is exactly how an unverifiable projection becomes permanent.
+func TestFlipChecksCountARowThatRecordsNoDeclarationAsStale(t *testing.T) {
+	ctx, pool, ws := testWorkspaceCtx(t)
+	seedOverlayWorkspace(ctx, t, pool)
+	db := database.BindTo(pool, ids.From[ids.WorkspaceKind](ws))
+	svc := flipServiceJudgingContacts(db)
+	ms := NewMirrorStore(db, nil)
+	recordSweepSuccess(ctx, t, pool)
+	markBackfillDone(ctx, t, pool, IncumbentClassContacts)
+
+	baseline := time.Date(2026, 5, 13, 6, 44, 38, 0, time.UTC)
+	ingestMirrorRow(ctx, t, ms, "person", "p-unfingerprinted", "", baseline)
+	var stored *string
+	if err := database.WithWorkspaceTx(ctx, pool, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx,
+			`SELECT projection_fingerprint FROM overlay_mirror WHERE external_id = 'p-unfingerprinted'`,
+		).Scan(&stored)
+	}); err != nil {
+		t.Fatalf("reading back the seeded row: %v", err)
+	}
+	if stored != nil {
+		t.Fatalf("projection_fingerprint = %q, want NULL — the case this test exists for", *stored)
+	}
+
+	checks, err := svc.FlipChecks(ctx)
+	if err != nil {
+		t.Fatalf("FlipChecks: %v", err)
+	}
+	if checks.ForceFreshDone {
+		t.Fatal("force-fresh reported done while a row records no declaration at all")
+	}
+}
+
+// TestFlipChecksSpareAClassNoCurrentDeclarationJudges is the escape hatch that
+// keeps the check clearable. A class this deployment holds no current
+// declaration for — a retired mapping — can never match one, so counting its
+// rows as stale would block the flip forever with no way to converge:
+// removing a mapping would brick the cutover.
+func TestFlipChecksSpareAClassNoCurrentDeclarationJudges(t *testing.T) {
+	ctx, pool, ws := testWorkspaceCtx(t)
+	seedOverlayWorkspace(ctx, t, pool)
+	db := database.BindTo(pool, ids.From[ids.WorkspaceKind](ws))
+	svc := flipServiceJudgingContacts(db)
+	ms := NewMirrorStore(db, nil)
+	recordSweepSuccess(ctx, t, pool)
+	markBackfillDone(ctx, t, pool, IncumbentClassContacts)
+	markBackfillDone(ctx, t, pool, IncumbentClassCompanies)
+
+	baseline := time.Date(2026, 5, 13, 6, 44, 38, 0, time.UTC)
+	ingestMirrorRow(ctx, t, ms, "person", "p-current", currentContactsDeclaration, baseline)
+	// organization resolves to companies, which the injected map does not
+	// name — and the row carries a fingerprint that matches nothing.
+	ingestMirrorRow(ctx, t, ms, "organization", "org-retired", "companies-declaration-retired", baseline)
+
+	checks, err := svc.FlipChecks(ctx)
+	if err != nil {
+		t.Fatalf("FlipChecks: %v", err)
+	}
+	if !checks.ForceFreshDone {
+		t.Fatalf("checks = %+v, want force-fresh done — a class with no current declaration must not block the flip", checks)
+	}
+}
+
 func TestFlipChecksReportUnreachableStaleAndPending(t *testing.T) {
 	ctx, pool, ws := testWorkspaceCtx(t)
 	seedOverlayWorkspace(ctx, t, pool)

--- a/backend/internal/modules/overlay/flipstate_integration_test.go
+++ b/backend/internal/modules/overlay/flipstate_integration_test.go
@@ -196,8 +196,8 @@ func TestFlipChecksRefuseAProjectionAnOlderDeclarationProduced(t *testing.T) {
 }
 
 // TestFlipChecksCountARowThatRecordsNoDeclarationAsStale covers the rows the
-// fingerprint column arrived after (issue #1038): they record NULL, which the
-// read paths coalesce to the empty string. Neither is a current declaration,
+// fingerprint column arrived after: they record NULL, which the read paths
+// coalesce to the empty string. Neither is a current declaration,
 // and nothing has checked what produced them — treating that as "unknown, let
 // it through" is exactly how an unverifiable projection becomes permanent.
 func TestFlipChecksCountARowThatRecordsNoDeclarationAsStale(t *testing.T) {

--- a/backend/internal/modules/overlay/freshness.go
+++ b/backend/internal/modules/overlay/freshness.go
@@ -61,10 +61,11 @@ type FreshnessReader struct {
 	//
 	// It is PLURAL because a canonical type can map to more than one
 	// incumbent class ("activity" ← the five v3 engagement classes,
-	// OVA-MAP-1). A single-record force-fresh needs exactly ONE class, so
-	// Read degrades a multi-source type to the mirror (the mirror row does
-	// not record which engagement class it came from — a tracked follow-up;
-	// no force-fresh caller exists yet).
+	// OVA-MAP-1). A single-record force-fresh needs exactly ONE class, and the
+	// canonical name alone names none of them, so Read degrades a multi-source
+	// type to the mirror rather than guessing one. The class is recorded per
+	// row — an engagement's mirror external_id is namespaced "<class>:<id>"
+	// (OVA-MAP-7) — for a caller that needs to resolve it.
 	toIncumbentClasses func(canonical string) (incumbentClasses []string, ok bool)
 }
 
@@ -223,9 +224,9 @@ func (f *FreshnessReader) reserveForceFreshUnit(ctx context.Context, inc Incumbe
 // given) declares no mapping for anything (ok=false, never a fabricated
 // pass-through of canonical itself). A canonical type backed by MORE than
 // one incumbent class ("activity" ← the five engagement classes) is
-// under-determined for a single-record fetch — the mirror row does not
-// record which class it came from — so it also answers ok=false and Read
-// degrades to the mirror rather than guessing a class.
+// under-determined for a single-record fetch — the canonical name names
+// none of them — so it also answers ok=false and Read degrades to the
+// mirror rather than guessing a class.
 func (f *FreshnessReader) incumbentClassFor(canonical string) (string, bool) {
 	if f.toIncumbentClasses == nil {
 		return "", false

--- a/backend/internal/modules/overlay/hubspot/activityid_internal_test.go
+++ b/backend/internal/modules/overlay/hubspot/activityid_internal_test.go
@@ -3,7 +3,44 @@
 
 package hubspot
 
-import "testing"
+import (
+	"slices"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/modules/overlay"
+)
+
+// TestNamespacedClassesAreExactlyTheModulesEngagementList binds the list that
+// MINTS a namespaced mirror id to the list that READS one back. engagementClasses
+// (this file) decides at ingest whether a record's id becomes "<class>:<id>";
+// overlay.IncumbentEngagementClasses is what the re-projection sweep builds its
+// "<class>:" row filter from, and what the identity bridge reverses. The two are
+// separate lists on either side of the module seam — overlay cannot import
+// hubspot — so nothing but this holds them together.
+//
+// A class the module names but this file omits mints BARE ids while the sweep
+// filters on the prefix: it selects zero rows, the class never re-projects, and
+// the flip stays blocked with every other gate green. The mirror image mints
+// namespaced ids no caller can attribute.
+func TestNamespacedClassesAreExactlyTheModulesEngagementList(t *testing.T) {
+	named := overlay.IncumbentEngagementClasses()
+	for _, class := range named {
+		if !engagementClasses[class] {
+			t.Errorf("overlay names %q an engagement class but engagementClasses (hubspot/activityid.go) omits it, "+
+				"so its rows get bare mirror ids while the sweep filters on %q and selects none of them: "+
+				"add %q to engagementClasses — the list that mints the id and the list that reads it back must agree",
+				class, class+":", class)
+		}
+	}
+	for class := range engagementClasses {
+		if !slices.Contains(named, class) {
+			t.Errorf("engagementClasses (hubspot/activityid.go) namespaces %q's mirror ids but overlay does not name it an "+
+				"engagement class, so no caller can attribute a row of it: add %q to incumbentEngagementClasses "+
+				"(overlay/incumbent.go) — the list that mints the id and the list that reads it back must agree",
+				class, class)
+		}
+	}
+}
 
 // TestMirrorActivityExternalIDNamespacesEngagementsOnly proves OVA-MAP-7's
 // mirror-side rule: the five engagement classes get their incumbent id

--- a/backend/internal/modules/overlay/hubspot/adapter.go
+++ b/backend/internal/modules/overlay/hubspot/adapter.go
@@ -435,6 +435,10 @@ func mapRecord(m overlay.ObjectMapping, objectClass string, raw ObjectRecord) (o
 		Fields:          out,
 		ModifiedAt:      modifiedAt,
 		OwnerExternalID: ownerID,
+		// Stamped from the declaration that produced Fields just above, so the
+		// row the mirror stores names its own projection rather than whichever
+		// declaration is current when someone later asks.
+		ProjectionFingerprint: overlay.Fingerprint(m),
 	}, nil
 }
 

--- a/backend/internal/modules/overlay/hubspot/mapping_hs.go
+++ b/backend/internal/modules/overlay/hubspot/mapping_hs.go
@@ -148,12 +148,14 @@ func ProjectionFingerprints() map[string]string {
 // The result is a SLICE because a canonical type can be backed by more than
 // one incumbent class: "activity" is the five v3 engagement classes
 // (calls/meetings/emails/notes/tasks) at once (OVA-MAP-1), so a completeness
-// question ("is activity fully backfilled?") means "are all five done", and
-// a single-record force-fresh of an activity is under-determined until the
-// mirror row records which class it came from (a tracked follow-up; no
-// force-fresh caller exists yet). Classes are returned in objectMappings
-// order. A canonical name with no declared mapping (ok=false) is an honest
-// gap, not a guessed answer.
+// question ("is activity fully backfilled?") means "are all five done". A
+// single-record read cannot pick one of the five from the canonical name alone,
+// so the FreshnessReader degrades such a read to the mirror rather than
+// guessing a class — but the class is not lost: an activity's mirror
+// external_id carries the class that produced it ("calls:123", OVA-MAP-7),
+// which is where a caller that needs it resolves it from, never from this
+// slice. Classes are returned in objectMappings order. A canonical name with no
+// declared mapping (ok=false) is an honest gap, not a guessed answer.
 func IncumbentClassesFor(canonical string) ([]string, bool) {
 	var classes []string
 	for _, m := range objectMappings {

--- a/backend/internal/modules/overlay/hubspot/mapping_hs.go
+++ b/backend/internal/modules/overlay/hubspot/mapping_hs.go
@@ -116,6 +116,25 @@ var objectMappings = []overlay.ObjectMapping{
 	callsMapping, meetingsMapping, emailsMapping, notesMapping, tasksMapping,
 }
 
+// ProjectionFingerprints answers every declared incumbent class's CURRENT
+// declaration fingerprint — the digest overlay.Fingerprint takes of the
+// mapping this registry would project that class through today. A mirror row
+// stamped with a fingerprint this map no longer holds was projected by an
+// older declaration, which is what the flip preflight refuses to freeze
+// (flipstate.go). It is keyed by the INCUMBENT class, the same asymmetry
+// IncumbentClassesFor documents: five engagement declarations project onto the
+// one canonical "activity", so a canonical key could name only one of them.
+//
+// Derived from objectMappings, never a second hand-written list, so a mapping
+// added or removed here can never leave a stale fingerprint behind.
+func ProjectionFingerprints() map[string]string {
+	out := make(map[string]string, len(objectMappings))
+	for _, m := range objectMappings {
+		out[m.Source] = overlay.Fingerprint(m)
+	}
+	return out
+}
+
 // IncumbentClassesFor reverse-resolves canonical (a Margince entity-type
 // name, e.g. "person") to the HubSpot object class(es) that map onto it
 // (e.g. "contacts"). This is the seam's asymmetry, made explicit: every

--- a/backend/internal/modules/overlay/hubspot/mapping_hs_test.go
+++ b/backend/internal/modules/overlay/hubspot/mapping_hs_test.go
@@ -4,6 +4,7 @@
 package hubspot_test
 
 import (
+	"reflect"
 	"slices"
 	"testing"
 
@@ -617,6 +618,54 @@ func TestIncumbentClassesForReverseResolvesEveryMappedTarget(t *testing.T) {
 	if _, ok := hubspot.IncumbentClassesFor("no-such-canonical-type"); ok {
 		t.Error("IncumbentClassesFor: want ok=false for a canonical name with no declared mapping")
 	}
+}
+
+// TestEveryDeclarationSharingATargetIsSeparableByItsConstants holds the
+// registry to the premise the mirror's re-projection rests on: the mirror is
+// keyed by the CANONICAL class, so two declarations projecting onto one target
+// put their rows in the same bucket, while every re-read of a record names the
+// INCUMBENT class. A row can only be re-fetched under the declaration that
+// produced it, and Const — copied verbatim into every payload the declaration
+// projects — is what tells the rows apart (overlay's governedRowsFilter). Two
+// siblings that did not contradict on a shared key would leave the mirror with
+// rows nothing can attribute, and the sweep would re-read a call as a task: a
+// live incumbent read that can only 404, repeated every pass, forever.
+//
+// Derived from ProjectionFingerprints' keys, which the registry itself
+// derives, so a declaration added later is held to this without anyone
+// remembering to add it here.
+func TestEveryDeclarationSharingATargetIsSeparableByItsConstants(t *testing.T) {
+	byTarget := map[string][]overlay.ObjectMapping{}
+	for source := range hubspot.ProjectionFingerprints() {
+		m, ok := hubspot.Mapping(source)
+		if !ok {
+			t.Fatalf("Mapping(%q): the registry fingerprints a class it does not declare", source)
+		}
+		byTarget[m.Target] = append(byTarget[m.Target], m)
+	}
+	for target, siblings := range byTarget {
+		for i, a := range siblings {
+			for _, b := range siblings[i+1:] {
+				if !constantsContradict(a.Const, b.Const) {
+					t.Errorf("declarations %q and %q both project onto %q but no constant contradicts between them, "+
+						"so a mirror row of that class cannot be attributed to either; give each the constant that names it",
+						a.Source, b.Source, target)
+				}
+			}
+		}
+	}
+}
+
+// constantsContradict reports whether a and b declare a shared key with
+// different values — the property that makes a jsonb containment filter for
+// one of them exclude every row the other produced.
+func constantsContradict(a, b map[string]any) bool {
+	for key, left := range a {
+		if right, shared := b[key]; shared && !reflect.DeepEqual(left, right) {
+			return true
+		}
+	}
+	return false
 }
 
 // TestMappingReportsAnUndeclaredObjectClassAsAnHonestGap proves Mapping's

--- a/backend/internal/modules/overlay/hubspot/mapping_hs_test.go
+++ b/backend/internal/modules/overlay/hubspot/mapping_hs_test.go
@@ -4,7 +4,6 @@
 package hubspot_test
 
 import (
-	"reflect"
 	"slices"
 	"testing"
 
@@ -620,52 +619,42 @@ func TestIncumbentClassesForReverseResolvesEveryMappedTarget(t *testing.T) {
 	}
 }
 
-// TestEveryDeclarationSharingATargetIsSeparableByItsConstants holds the
-// registry to the premise the mirror's re-projection rests on: the mirror is
-// keyed by the CANONICAL class, so two declarations projecting onto one target
-// put their rows in the same bucket, while every re-read of a record names the
-// INCUMBENT class. A row can only be re-fetched under the declaration that
-// produced it, and Const — copied verbatim into every payload the declaration
-// projects — is what tells the rows apart (overlay's governedRowsFilter). Two
-// siblings that did not contradict on a shared key would leave the mirror with
-// rows nothing can attribute, and the sweep would re-read a call as a task: a
-// live incumbent read that can only 404, repeated every pass, forever.
+// TestEveryDeclarationSharingATargetMintsNamespacedMirrorIDs holds the registry
+// to the premise the mirror's re-projection rests on: the mirror is keyed by
+// the CANONICAL class, so two declarations projecting onto one target put their
+// rows in the same bucket, while every re-read of a record names the INCUMBENT
+// class. A row can only be re-fetched under the declaration that produced it,
+// and the mirror id's own "<class>:" namespace (OVA-MAP-7, activityid.go) is
+// what tells the rows apart. A declaration that joined a shared target with
+// bare ids would leave the mirror with rows nothing can attribute, and the
+// sweep would re-read a call as a task: a live incumbent read that can only
+// 404, repeated every pass, forever.
 //
 // Derived from ProjectionFingerprints' keys, which the registry itself
 // derives, so a declaration added later is held to this without anyone
 // remembering to add it here.
-func TestEveryDeclarationSharingATargetIsSeparableByItsConstants(t *testing.T) {
-	byTarget := map[string][]overlay.ObjectMapping{}
+func TestEveryDeclarationSharingATargetMintsNamespacedMirrorIDs(t *testing.T) {
+	sourcesByTarget := map[string][]string{}
 	for source := range hubspot.ProjectionFingerprints() {
 		m, ok := hubspot.Mapping(source)
 		if !ok {
 			t.Fatalf("Mapping(%q): the registry fingerprints a class it does not declare", source)
 		}
-		byTarget[m.Target] = append(byTarget[m.Target], m)
+		sourcesByTarget[m.Target] = append(sourcesByTarget[m.Target], m.Source)
 	}
-	for target, siblings := range byTarget {
-		for i, a := range siblings {
-			for _, b := range siblings[i+1:] {
-				if !constantsContradict(a.Const, b.Const) {
-					t.Errorf("declarations %q and %q both project onto %q but no constant contradicts between them, "+
-						"so a mirror row of that class cannot be attributed to either; give each the constant that names it",
-						a.Source, b.Source, target)
-				}
+	namespaced := overlay.IncumbentEngagementClasses()
+	for target, sources := range sourcesByTarget {
+		if len(sources) < 2 {
+			continue // the declaration has its target to itself; every row of it is its own
+		}
+		for _, source := range sources {
+			if !slices.Contains(namespaced, source) {
+				t.Errorf("declaration %q shares the canonical target %q with %d other(s) but mints bare mirror ids, "+
+					"so a row of that class cannot be attributed to it; namespace its ids by its own class (OVA-MAP-7)",
+					source, target, len(sources)-1)
 			}
 		}
 	}
-}
-
-// constantsContradict reports whether a and b declare a shared key with
-// different values — the property that makes a jsonb containment filter for
-// one of them exclude every row the other produced.
-func constantsContradict(a, b map[string]any) bool {
-	for key, left := range a {
-		if right, shared := b[key]; shared && !reflect.DeepEqual(left, right) {
-			return true
-		}
-	}
-	return false
 }
 
 // TestMappingReportsAnUndeclaredObjectClassAsAnHonestGap proves Mapping's

--- a/backend/internal/modules/overlay/incumbent.go
+++ b/backend/internal/modules/overlay/incumbent.go
@@ -59,6 +59,10 @@ type Record struct {
 	Fields          map[string]any
 	ModifiedAt      time.Time
 	OwnerExternalID string
+	// ProjectionFingerprint identifies the mapping declaration that produced
+	// Fields, so a row projected by a declaration that has since changed is
+	// detectable without re-reading the incumbent.
+	ProjectionFingerprint string
 }
 
 // WriteResult is what a write through the Incumbent seam (Create/Update)

--- a/backend/internal/modules/overlay/mirrorpage.go
+++ b/backend/internal/modules/overlay/mirrorpage.go
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package overlay
+
+// The mirror's paged read and the cursor it hands back — kept together, and
+// apart from mirrorstore.go's ingest and single-row reads, because the page
+// bounds, the keyset query and the token encoding are one contract: a change
+// to the ordering is a change to what an outstanding cursor means.
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
+)
+
+const (
+	defaultListLimit = 50
+	maxListLimit     = 200
+)
+
+// clampListLimit maps a caller's page size onto the bounds above: absent or
+// nonsensical takes the default, oversized takes the ceiling. Every paged read
+// in this package resolves it here, so a page's size cannot mean one thing on
+// the mirror walk and another on the user map.
+func clampListLimit(limit int) int {
+	switch {
+	case limit <= 0:
+		return defaultListLimit
+	case limit > maxListLimit:
+		return maxListLimit
+	default:
+		return limit
+	}
+}
+
+const selectVisibleMirrorPageSQL = `
+SELECT m.object_class, m.external_id, m.fields, m.updated_at_baseline,
+       coalesce(m.owner_external_id, ''), m.sync_state, m.last_synced_at,
+       coalesce(m.projection_fingerprint, '')
+FROM overlay_mirror m
+%s
+WHERE m.object_class = $2 AND m.external_id > $3
+ORDER BY m.external_id
+LIMIT $4`
+
+// List pages mirror rows for one object class in external_id order, a
+// stable (if not incumbent-numeric) keyset — the cursor only has to be a
+// consistent Margince-side ordering, not replicate HubSpot's own paging
+// scheme. Gated by the same mirror_visibility deny-join as Get (design.md
+// §4.6); an unmapped ctx principal answers apperrors.ErrNotFound before
+// the page query ever runs.
+func (s *MirrorStore) List(ctx context.Context, objectClass, cursor string, limit int) ([]Row, string, error) {
+	after, err := decodeMirrorCursor(cursor)
+	if err != nil {
+		return nil, "", err
+	}
+	limit = clampListLimit(limit)
+
+	var rows []Row
+	err = s.db.Tx(ctx, func(tx pgx.Tx) error {
+		mirrorUserID, err := resolveActingMirrorUserID(ctx, tx)
+		if err != nil {
+			return err
+		}
+		joinClause, args := visibilityJoin(mirrorUserID)
+		args = append(args, objectClass, after, limit)
+		query := fmt.Sprintf(selectVisibleMirrorPageSQL, joinClause)
+		pgRows, err := tx.Query(ctx, query, args...)
+		if err != nil {
+			return fmt.Errorf("overlay: listing mirror rows for %s: %w", objectClass, err)
+		}
+		defer pgRows.Close()
+		for pgRows.Next() {
+			var row Row
+			if err := pgRows.Scan(
+				&row.ObjectClass, &row.ExternalID, &row.Fields, &row.UpdatedAtBaseline,
+				&row.OwnerExternalID, &row.SyncState, &row.LastSyncedAt, &row.ProjectionFingerprint,
+			); err != nil {
+				return fmt.Errorf("overlay: scanning mirror row for %s: %w", objectClass, err)
+			}
+			rows = append(rows, row)
+		}
+		return pgRows.Err()
+	})
+	if err != nil {
+		return nil, "", err
+	}
+
+	next := ""
+	if len(rows) == limit {
+		next = encodeMirrorCursor(rows[len(rows)-1].ExternalID)
+	}
+	return rows, next, nil
+}
+
+// encodeMirrorCursor/decodeMirrorCursor keep the List cursor opaque to
+// callers (a client must never construct or edit one by hand) while
+// staying a plain external_id underneath — there is no sort/direction
+// variance to encode, unlike storekit's general keyset cursor.
+func encodeMirrorCursor(externalID string) string {
+	return base64.RawURLEncoding.EncodeToString([]byte(externalID))
+}
+
+// decodeMirrorCursor answers storekit.MalformedCursorError, not a bare wrap:
+// the cursor is client-supplied input on every surface that pages this store,
+// so a token that does not decode is the caller's mistake and httperr must be
+// able to say so (422 malformed_cursor). An opaque wrap falls through to a 500
+// and sends an admin looking for an outage that is not there. The base64
+// cause is deliberately dropped — it tells the client nothing it can act on
+// beyond "the token is not one we minted".
+func decodeMirrorCursor(cursor string) (string, error) {
+	if cursor == "" {
+		return "", nil
+	}
+	raw, err := base64.RawURLEncoding.DecodeString(cursor)
+	if err != nil {
+		return "", &storekit.MalformedCursorError{}
+	}
+	return string(raw), nil
+}

--- a/backend/internal/modules/overlay/mirrorstore.go
+++ b/backend/internal/modules/overlay/mirrorstore.go
@@ -250,9 +250,9 @@ func (s *MirrorStore) ingestTx(ctx context.Context, tx pgx.Tx, rec Record) (bool
 	// between two such records false, so a path that never fingerprints
 	// (a fixture, a hand-built Record) keeps the plain staleness behaviour
 	// instead of re-writing the row on every sweep.
-	var fingerprintArg any
+	var fingerprintArg *string
 	if rec.ProjectionFingerprint != "" {
-		fingerprintArg = rec.ProjectionFingerprint
+		fingerprintArg = &rec.ProjectionFingerprint
 	}
 	if err := s.assertFence(ctx, tx); err != nil {
 		return false, err

--- a/backend/internal/modules/overlay/mirrorstore.go
+++ b/backend/internal/modules/overlay/mirrorstore.go
@@ -5,7 +5,6 @@ package overlay
 
 import (
 	"context"
-	"encoding/base64"
 	"errors"
 	"fmt"
 	"time"
@@ -13,7 +12,6 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/gradionhq/margince/backend/internal/platform/database"
-	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 )
 
@@ -36,6 +34,12 @@ type Row struct {
 	OwnerExternalID   string
 	SyncState         string
 	LastSyncedAt      time.Time
+	// ProjectionFingerprint is the mapping declaration Fields was projected
+	// by, empty for a row that records none — either mirrored before the
+	// column existed or ingested from a Record that declared none. Empty
+	// therefore means "no declaration is known to have produced this", never
+	// "the current one did".
+	ProjectionFingerprint string
 }
 
 // MirrorStore owns the overlay_mirror / overlay_association tables: the
@@ -117,25 +121,35 @@ func (s *MirrorStore) WithResolver(r OwnerEmailResolver) *MirrorStore {
 //   - tombstone-guard (WHERE NOT EXISTS …): an erased external_id is
 //     never re-created — the sweep that would otherwise resurrect it
 //     never gets the chance to see the row at all.
-//   - staleness (ON CONFLICT … WHERE excluded.updated_at_baseline > …):
-//     an older incumbent read can never clobber a newer one, so ingest
-//     is safe to call with a stale poller page racing a fresher read of
-//     the same record.
+//   - staleness (ON CONFLICT … WHERE excluded.updated_at_baseline > …
+//     OR the projection fingerprint differs): an older incumbent read can
+//     never clobber a newer one, so ingest is safe to call with a stale
+//     poller page racing a fresher read of the same record. A re-projection
+//     is admitted anyway: the incumbent has not touched the record, so its
+//     baseline does not advance, but the same record under a changed
+//     declaration is not an older read — refusing it would strand the row
+//     holding a payload the current mapping would never produce. The
+//     comparison is IS DISTINCT FROM, so a row recording no declaration
+//     (NULL — mirrored before the column existed) compares as different
+//     rather than as unknown, which would refuse exactly the rows nothing
+//     has verified.
 //   - no-clobber-dirty (… AND sync_state <> 'pending_sync'): a row with
 //     an un-drained local write (branch 2) is not blindly overwritten by
 //     an inbound incumbent change; it is held for the conflict path
 //     (mirror.conflict, not implemented until branch 2's write path
 //     lands — see the ProjectOwnerVisibility seam note in Ingest below).
 const ingestSQL = `
-INSERT INTO overlay_mirror (workspace_id, object_class, external_id, fields, updated_at_baseline, owner_external_id, last_synced_at, sync_state)
-SELECT NULLIF(current_setting('app.workspace_id',true),'')::uuid, $1, $2, $3, $4, $5, now(), 'fresh'
+INSERT INTO overlay_mirror (workspace_id, object_class, external_id, fields, updated_at_baseline, owner_external_id, projection_fingerprint, last_synced_at, sync_state)
+SELECT NULLIF(current_setting('app.workspace_id',true),'')::uuid, $1, $2, $3, $4, $5, $6, now(), 'fresh'
 WHERE NOT EXISTS (SELECT 1 FROM overlay_tombstone t
     WHERE t.workspace_id = NULLIF(current_setting('app.workspace_id',true),'')::uuid AND t.object_class=$1 AND t.external_id=$2)
 ON CONFLICT (object_class, external_id) DO UPDATE
    SET fields=EXCLUDED.fields, updated_at_baseline=EXCLUDED.updated_at_baseline,
-       owner_external_id=EXCLUDED.owner_external_id, last_synced_at=now()
+       owner_external_id=EXCLUDED.owner_external_id,
+       projection_fingerprint=EXCLUDED.projection_fingerprint, last_synced_at=now()
    WHERE overlay_mirror.sync_state <> 'pending_sync'
-     AND EXCLUDED.updated_at_baseline > overlay_mirror.updated_at_baseline`
+     AND (EXCLUDED.updated_at_baseline > overlay_mirror.updated_at_baseline
+          OR overlay_mirror.projection_fingerprint IS DISTINCT FROM EXCLUDED.projection_fingerprint)`
 
 // Ingest upserts one incumbent record into the mirror — the single entry
 // point every sync trigger calls (design.md §4.4: "push and pull
@@ -225,6 +239,16 @@ func (s *MirrorStore) ingestTx(ctx context.Context, tx pgx.Tx, rec Record) (bool
 	if rec.OwnerExternalID != "" {
 		ownerArg = rec.OwnerExternalID
 	}
+	// A record that declares no fingerprint stores NULL rather than '': the
+	// column's meaning is "the declaration known to have produced this row",
+	// and an empty string is not one. It also keeps the guard's comparison
+	// between two such records false, so a path that never fingerprints
+	// (a fixture, a hand-built Record) keeps the plain staleness behaviour
+	// instead of re-writing the row on every sweep.
+	var fingerprintArg any
+	if rec.ProjectionFingerprint != "" {
+		fingerprintArg = rec.ProjectionFingerprint
+	}
 	if err := s.assertFence(ctx, tx); err != nil {
 		return false, err
 	}
@@ -258,7 +282,7 @@ func (s *MirrorStore) ingestTx(ctx context.Context, tx pgx.Tx, rec Record) (bool
 
 	tag, err := tx.Exec(
 		ctx, ingestSQL,
-		rec.ObjectClass, rec.ExternalID, rec.Fields, rec.ModifiedAt, ownerArg,
+		rec.ObjectClass, rec.ExternalID, rec.Fields, rec.ModifiedAt, ownerArg, fingerprintArg,
 	)
 	if err != nil {
 		return false, fmt.Errorf("overlay: ingesting %s/%s: %w", rec.ObjectClass, rec.ExternalID, err)
@@ -334,7 +358,8 @@ func (s *MirrorStore) UpsertAssoc(ctx context.Context, a Assoc) error {
 // its tests.
 const selectRawMirrorRowSQL = `
 SELECT object_class, external_id, fields, updated_at_baseline,
-       coalesce(owner_external_id, ''), sync_state, last_synced_at
+       coalesce(owner_external_id, ''), sync_state, last_synced_at,
+       coalesce(projection_fingerprint, '')
 FROM overlay_mirror
 WHERE object_class = $1 AND external_id = $2`
 
@@ -343,7 +368,7 @@ func (s *MirrorStore) getRaw(ctx context.Context, objectClass, externalID string
 	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		return tx.QueryRow(ctx, selectRawMirrorRowSQL, objectClass, externalID).Scan(
 			&row.ObjectClass, &row.ExternalID, &row.Fields, &row.UpdatedAtBaseline,
-			&row.OwnerExternalID, &row.SyncState, &row.LastSyncedAt,
+			&row.OwnerExternalID, &row.SyncState, &row.LastSyncedAt, &row.ProjectionFingerprint,
 		)
 	})
 	if err != nil {
@@ -357,7 +382,8 @@ func (s *MirrorStore) getRaw(ctx context.Context, objectClass, externalID string
 
 const selectVisibleMirrorRowSQL = `
 SELECT m.object_class, m.external_id, m.fields, m.updated_at_baseline,
-       coalesce(m.owner_external_id, ''), m.sync_state, m.last_synced_at
+       coalesce(m.owner_external_id, ''), m.sync_state, m.last_synced_at,
+       coalesce(m.projection_fingerprint, '')
 FROM overlay_mirror m
 %s
 WHERE m.object_class = $2 AND m.external_id = $3`
@@ -379,7 +405,7 @@ func (s *MirrorStore) Get(ctx context.Context, objectClass, externalID string) (
 		query := fmt.Sprintf(selectVisibleMirrorRowSQL, joinClause)
 		return tx.QueryRow(ctx, query, args...).Scan(
 			&row.ObjectClass, &row.ExternalID, &row.Fields, &row.UpdatedAtBaseline,
-			&row.OwnerExternalID, &row.SyncState, &row.LastSyncedAt,
+			&row.OwnerExternalID, &row.SyncState, &row.LastSyncedAt, &row.ProjectionFingerprint,
 		)
 	})
 	if err != nil {
@@ -389,109 +415,4 @@ func (s *MirrorStore) Get(ctx context.Context, objectClass, externalID string) (
 		return Row{}, fmt.Errorf("overlay: reading mirror row %s/%s: %w", objectClass, externalID, err)
 	}
 	return row, nil
-}
-
-const (
-	defaultListLimit = 50
-	maxListLimit     = 200
-)
-
-// clampListLimit maps a caller's page size onto the bounds above: absent or
-// nonsensical takes the default, oversized takes the ceiling. Every paged read
-// in this package resolves it here, so a page's size cannot mean one thing on
-// the mirror walk and another on the user map.
-func clampListLimit(limit int) int {
-	switch {
-	case limit <= 0:
-		return defaultListLimit
-	case limit > maxListLimit:
-		return maxListLimit
-	default:
-		return limit
-	}
-}
-
-const selectVisibleMirrorPageSQL = `
-SELECT m.object_class, m.external_id, m.fields, m.updated_at_baseline,
-       coalesce(m.owner_external_id, ''), m.sync_state, m.last_synced_at
-FROM overlay_mirror m
-%s
-WHERE m.object_class = $2 AND m.external_id > $3
-ORDER BY m.external_id
-LIMIT $4`
-
-// List pages mirror rows for one object class in external_id order, a
-// stable (if not incumbent-numeric) keyset — the cursor only has to be a
-// consistent Margince-side ordering, not replicate HubSpot's own paging
-// scheme. Gated by the same mirror_visibility deny-join as Get (design.md
-// §4.6); an unmapped ctx principal answers apperrors.ErrNotFound before
-// the page query ever runs.
-func (s *MirrorStore) List(ctx context.Context, objectClass, cursor string, limit int) ([]Row, string, error) {
-	after, err := decodeMirrorCursor(cursor)
-	if err != nil {
-		return nil, "", err
-	}
-	limit = clampListLimit(limit)
-
-	var rows []Row
-	err = s.db.Tx(ctx, func(tx pgx.Tx) error {
-		mirrorUserID, err := resolveActingMirrorUserID(ctx, tx)
-		if err != nil {
-			return err
-		}
-		joinClause, args := visibilityJoin(mirrorUserID)
-		args = append(args, objectClass, after, limit)
-		query := fmt.Sprintf(selectVisibleMirrorPageSQL, joinClause)
-		pgRows, err := tx.Query(ctx, query, args...)
-		if err != nil {
-			return fmt.Errorf("overlay: listing mirror rows for %s: %w", objectClass, err)
-		}
-		defer pgRows.Close()
-		for pgRows.Next() {
-			var row Row
-			if err := pgRows.Scan(
-				&row.ObjectClass, &row.ExternalID, &row.Fields, &row.UpdatedAtBaseline,
-				&row.OwnerExternalID, &row.SyncState, &row.LastSyncedAt,
-			); err != nil {
-				return fmt.Errorf("overlay: scanning mirror row for %s: %w", objectClass, err)
-			}
-			rows = append(rows, row)
-		}
-		return pgRows.Err()
-	})
-	if err != nil {
-		return nil, "", err
-	}
-
-	next := ""
-	if len(rows) == limit {
-		next = encodeMirrorCursor(rows[len(rows)-1].ExternalID)
-	}
-	return rows, next, nil
-}
-
-// encodeMirrorCursor/decodeMirrorCursor keep the List cursor opaque to
-// callers (a client must never construct or edit one by hand) while
-// staying a plain external_id underneath — there is no sort/direction
-// variance to encode, unlike storekit's general keyset cursor.
-func encodeMirrorCursor(externalID string) string {
-	return base64.RawURLEncoding.EncodeToString([]byte(externalID))
-}
-
-// decodeMirrorCursor answers storekit.MalformedCursorError, not a bare wrap:
-// the cursor is client-supplied input on every surface that pages this store,
-// so a token that does not decode is the caller's mistake and httperr must be
-// able to say so (422 malformed_cursor). An opaque wrap falls through to a 500
-// and sends an admin looking for an outage that is not there. The base64
-// cause is deliberately dropped — it tells the client nothing it can act on
-// beyond "the token is not one we minted".
-func decodeMirrorCursor(cursor string) (string, error) {
-	if cursor == "" {
-		return "", nil
-	}
-	raw, err := base64.RawURLEncoding.DecodeString(cursor)
-	if err != nil {
-		return "", &storekit.MalformedCursorError{}
-	}
-	return string(raw), nil
 }

--- a/backend/internal/modules/overlay/mirrorstore.go
+++ b/backend/internal/modules/overlay/mirrorstore.go
@@ -240,9 +240,12 @@ func (s *MirrorStore) ingestTx(ctx context.Context, tx pgx.Tx, rec Record) (bool
 	if rec.ObjectClass == "" || rec.ExternalID == "" {
 		return false, fmt.Errorf("overlay: ingest requires a non-empty object class and external id")
 	}
-	var ownerArg any
+	// A record naming no owner stores NULL rather than '': the column holds an
+	// incumbent owner reference, and the empty string is not one. A nil *string
+	// is the SQL NULL the column needs, stated in the type.
+	var ownerArg *string
 	if rec.OwnerExternalID != "" {
-		ownerArg = rec.OwnerExternalID
+		ownerArg = &rec.OwnerExternalID
 	}
 	// A record that declares no fingerprint stores NULL rather than '': the
 	// column's meaning is "the declaration known to have produced this row",

--- a/backend/internal/modules/overlay/mirrorstore.go
+++ b/backend/internal/modules/overlay/mirrorstore.go
@@ -121,18 +121,22 @@ func (s *MirrorStore) WithResolver(r OwnerEmailResolver) *MirrorStore {
 //   - tombstone-guard (WHERE NOT EXISTS …): an erased external_id is
 //     never re-created — the sweep that would otherwise resurrect it
 //     never gets the chance to see the row at all.
-//   - staleness (ON CONFLICT … WHERE excluded.updated_at_baseline > …
-//     OR the projection fingerprint differs): an older incumbent read can
-//     never clobber a newer one, so ingest is safe to call with a stale
-//     poller page racing a fresher read of the same record. A re-projection
-//     is admitted anyway: the incumbent has not touched the record, so its
-//     baseline does not advance, but the same record under a changed
-//     declaration is not an older read — refusing it would strand the row
-//     holding a payload the current mapping would never produce. The
-//     comparison is IS DISTINCT FROM, so a row recording no declaration
-//     (NULL — mirrored before the column existed) compares as different
-//     rather than as unknown, which would refuse exactly the rows nothing
-//     has verified.
+//   - staleness (ON CONFLICT … WHERE excluded.updated_at_baseline > …):
+//     an older incumbent read can never clobber a newer one, so ingest is
+//     safe to call with a stale poller page racing a fresher read of the
+//     same record. A re-projection is admitted at the SAME baseline only:
+//     the incumbent has not touched the record, so its baseline does not
+//     advance, but the same record under a changed declaration is not an
+//     older read — refusing it would strand the row holding a payload the
+//     current mapping would never produce. An OLDER read stays refused
+//     whatever its fingerprint says, because a stale page carries a stale
+//     projection too, and admitting it on a fingerprint difference would
+//     let the sweep's own laggard pages overwrite fresher rows — which a
+//     declaration change makes likely, since it puts every row's
+//     fingerprint out of date at once. The comparison is IS DISTINCT FROM,
+//     so a row recording no declaration (NULL — mirrored before the column
+//     existed) compares as different rather than as unknown, which would
+//     refuse exactly the rows nothing has verified.
 //   - no-clobber-dirty (… AND sync_state <> 'pending_sync'): a row with
 //     an un-drained local write (branch 2) is not blindly overwritten by
 //     an inbound incumbent change; it is held for the conflict path
@@ -149,7 +153,8 @@ ON CONFLICT (object_class, external_id) DO UPDATE
        projection_fingerprint=EXCLUDED.projection_fingerprint, last_synced_at=now()
    WHERE overlay_mirror.sync_state <> 'pending_sync'
      AND (EXCLUDED.updated_at_baseline > overlay_mirror.updated_at_baseline
-          OR overlay_mirror.projection_fingerprint IS DISTINCT FROM EXCLUDED.projection_fingerprint)`
+          OR (EXCLUDED.updated_at_baseline = overlay_mirror.updated_at_baseline
+              AND overlay_mirror.projection_fingerprint IS DISTINCT FROM EXCLUDED.projection_fingerprint))`
 
 // Ingest upserts one incumbent record into the mirror — the single entry
 // point every sync trigger calls (design.md §4.4: "push and pull

--- a/backend/internal/modules/overlay/mirrorstore_integration_test.go
+++ b/backend/internal/modules/overlay/mirrorstore_integration_test.go
@@ -111,6 +111,137 @@ func TestIngestHonorsStalenessAndTombstone(t *testing.T) {
 	}
 }
 
+// TestIngestAcceptsAReprojectionAtTheSameBaseline pins the one case the
+// staleness guard must NOT refuse. A re-projection re-fetches a record the
+// incumbent has not touched, so the baseline does not advance. The guard
+// exists to stop an older read clobbering a newer one — but a re-projection
+// is not older data, it is the same data projected by a declaration that has
+// since changed, and refusing it would leave the row holding a payload the
+// current mapping would never produce, with no way to converge.
+func TestIngestAcceptsAReprojectionAtTheSameBaseline(t *testing.T) {
+	ctx, pool, ws := testWorkspaceCtx(t)
+	store := NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), noOwnerEmails{})
+	const objectClass = "person"
+	const externalID = "1"
+
+	baseline := time.Date(2026, 5, 13, 6, 44, 38, 0, time.UTC)
+	first := Record{
+		ObjectClass: objectClass, ExternalID: externalID,
+		Fields:                map[string]any{"first_name": "Ada"},
+		ModifiedAt:            baseline,
+		ProjectionFingerprint: "fingerprint-one",
+	}
+	if err := store.Ingest(ctx, first); err != nil {
+		t.Fatalf("first ingest: %v", err)
+	}
+
+	second := first
+	second.Fields = map[string]any{"first_name": "Ada", "title": "CTO"}
+	second.ProjectionFingerprint = "fingerprint-two"
+	if err := store.Ingest(ctx, second); err != nil {
+		t.Fatalf("re-projection ingest: %v", err)
+	}
+
+	row, err := store.getRaw(ctx, objectClass, externalID)
+	if err != nil {
+		t.Fatalf("reading back after the re-projection: %v", err)
+	}
+	if row.ProjectionFingerprint != "fingerprint-two" {
+		t.Errorf("fingerprint = %q, want the re-projection's", row.ProjectionFingerprint)
+	}
+	if row.Fields["title"] != "CTO" {
+		t.Errorf("fields = %v, want the re-projected payload; the staleness guard refused a same-baseline re-projection", row.Fields)
+	}
+}
+
+// TestIngestAcceptsAReprojectionOverAnUnfingerprintedRow covers the rows the
+// fingerprint column arrived after: they record no declaration at all, which
+// is exactly the state a re-projection must be able to leave. The guard
+// compares with IS DISTINCT FROM rather than <> for this row and no other —
+// under <> the comparison answers NULL, which is not true, and the write the
+// row most needs is the one silently refused.
+func TestIngestAcceptsAReprojectionOverAnUnfingerprintedRow(t *testing.T) {
+	ctx, pool, ws := testWorkspaceCtx(t)
+	store := NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), noOwnerEmails{})
+	const objectClass = "person"
+	const externalID = "2"
+
+	baseline := time.Date(2026, 5, 13, 6, 44, 38, 0, time.UTC)
+	unfingerprinted := Record{
+		ObjectClass: objectClass, ExternalID: externalID,
+		Fields:     map[string]any{"first_name": "Grace"},
+		ModifiedAt: baseline,
+	}
+	if err := store.Ingest(ctx, unfingerprinted); err != nil {
+		t.Fatalf("ingest of an unfingerprinted record: %v", err)
+	}
+	row, err := store.getRaw(ctx, objectClass, externalID)
+	if err != nil {
+		t.Fatalf("reading back the unfingerprinted row: %v", err)
+	}
+	if row.ProjectionFingerprint != "" {
+		t.Fatalf("fingerprint = %q, want none recorded for a record that declared none", row.ProjectionFingerprint)
+	}
+
+	reprojected := unfingerprinted
+	reprojected.Fields = map[string]any{"first_name": "Grace", "title": "Rear Admiral"}
+	reprojected.ProjectionFingerprint = "fingerprint-one"
+	if err := store.Ingest(ctx, reprojected); err != nil {
+		t.Fatalf("re-projection ingest: %v", err)
+	}
+
+	row, err = store.getRaw(ctx, objectClass, externalID)
+	if err != nil {
+		t.Fatalf("reading back after the re-projection: %v", err)
+	}
+	if row.ProjectionFingerprint != "fingerprint-one" {
+		t.Errorf("fingerprint = %q, want the re-projection's", row.ProjectionFingerprint)
+	}
+	if row.Fields["title"] != "Rear Admiral" {
+		t.Errorf("fields = %v, want the re-projected payload; a row recording no declaration was refused a re-projection", row.Fields)
+	}
+}
+
+// TestIngestStillRefusesAnOlderReadAtTheSameFingerprint holds the guard to its
+// original job. Admitting a re-projection widens what the ON CONFLICT clause
+// accepts, and the widening is bounded by the declaration having changed: with
+// the declaration unchanged, a stale poller page racing a fresher read of the
+// same record must still lose.
+func TestIngestStillRefusesAnOlderReadAtTheSameFingerprint(t *testing.T) {
+	ctx, pool, ws := testWorkspaceCtx(t)
+	store := NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), noOwnerEmails{})
+	const objectClass = "person"
+	const externalID = "3"
+	const fingerprint = "fingerprint-one"
+
+	newer := time.Date(2026, 5, 13, 6, 44, 38, 0, time.UTC)
+	if err := store.Ingest(ctx, Record{
+		ObjectClass: objectClass, ExternalID: externalID,
+		Fields:                map[string]any{"first_name": "Katherine"},
+		ModifiedAt:            newer,
+		ProjectionFingerprint: fingerprint,
+	}); err != nil {
+		t.Fatalf("newer ingest: %v", err)
+	}
+
+	if err := store.Ingest(ctx, Record{
+		ObjectClass: objectClass, ExternalID: externalID,
+		Fields:                map[string]any{"first_name": "Stale"},
+		ModifiedAt:            newer.Add(-24 * time.Hour),
+		ProjectionFingerprint: fingerprint,
+	}); err != nil {
+		t.Fatalf("older ingest: %v", err)
+	}
+
+	row, err := store.getRaw(ctx, objectClass, externalID)
+	if err != nil {
+		t.Fatalf("reading back after the older ingest: %v", err)
+	}
+	if row.Fields["first_name"] != "Katherine" || !row.UpdatedAtBaseline.Equal(newer) {
+		t.Fatalf("an older read at the same fingerprint must not clobber the fresher row: got %+v", row)
+	}
+}
+
 // seedTombstone inserts the fixture the tombstone-guard test asserts
 // against, through the same tenant-scoped transaction helper the store
 // itself uses — the fixture must be workspace-visible to the guard's own

--- a/backend/internal/modules/overlay/mirrorstore_integration_test.go
+++ b/backend/internal/modules/overlay/mirrorstore_integration_test.go
@@ -242,6 +242,49 @@ func TestIngestStillRefusesAnOlderReadAtTheSameFingerprint(t *testing.T) {
 	}
 }
 
+// A stale page carries a stale projection too, so a differing fingerprint is
+// no reason to admit an older read. Letting one through would turn the
+// re-projection allowance into a hole in the staleness guard, and the sweep's
+// own laggard pages would overwrite fresher rows — which is precisely what a
+// declaration change makes likely, since it puts every row's fingerprint out
+// of date at once.
+func TestIngestRefusesAnOlderReadEvenAtADifferentFingerprint(t *testing.T) {
+	ctx, pool, ws := testWorkspaceCtx(t)
+	store := NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), noOwnerEmails{})
+	const objectClass = "person"
+	const externalID = "4"
+
+	newer := time.Date(2026, 5, 13, 6, 44, 38, 0, time.UTC)
+	if err := store.Ingest(ctx, Record{
+		ObjectClass: objectClass, ExternalID: externalID,
+		Fields:                map[string]any{"first_name": "Katherine"},
+		ModifiedAt:            newer,
+		ProjectionFingerprint: "fingerprint-one",
+	}); err != nil {
+		t.Fatalf("newer ingest: %v", err)
+	}
+
+	if err := store.Ingest(ctx, Record{
+		ObjectClass: objectClass, ExternalID: externalID,
+		Fields:                map[string]any{"first_name": "Stale"},
+		ModifiedAt:            newer.Add(-24 * time.Hour),
+		ProjectionFingerprint: "fingerprint-two",
+	}); err != nil {
+		t.Fatalf("older ingest at a different fingerprint: %v", err)
+	}
+
+	row, err := store.getRaw(ctx, objectClass, externalID)
+	if err != nil {
+		t.Fatalf("reading back after the older ingest: %v", err)
+	}
+	if row.Fields["first_name"] != "Katherine" || !row.UpdatedAtBaseline.Equal(newer) {
+		t.Fatalf("an older read must not clobber a fresher row whatever its fingerprint says: got %+v", row)
+	}
+	if row.ProjectionFingerprint != "fingerprint-one" {
+		t.Errorf("fingerprint = %q, want the fresher row's — a refused write must leave the column alone", row.ProjectionFingerprint)
+	}
+}
+
 // seedTombstone inserts the fixture the tombstone-guard test asserts
 // against, through the same tenant-scoped transaction helper the store
 // itself uses — the fixture must be workspace-visible to the guard's own

--- a/backend/internal/modules/overlay/projectionstaleness.go
+++ b/backend/internal/modules/overlay/projectionstaleness.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"slices"
 
 	"github.com/jackc/pgx/v5"
 )
@@ -110,7 +111,7 @@ func (s *Service) fingerprintsFor(canonicalClass string) []string {
 }
 
 // staleProjectionIDsSQL names the rows ONE declaration must re-project: the
-// rows it governs (the containment filter, $2 — see governedRowsFilter) whose
+// rows it governs (its mirror-id namespace, $2 — see mirrorIDNamespace) whose
 // stored payload it did not produce (staleProjectionSQL over $3, holding that
 // declaration's own current fingerprint). Ordered by external id so a bounded
 // pass takes a stable prefix rather than a different arbitrary slice each time,
@@ -124,7 +125,7 @@ func (s *Service) fingerprintsFor(canonicalClass string) []string {
 const staleProjectionIDsSQL = `
 SELECT external_id FROM overlay_mirror
 WHERE object_class = $1
-  AND fields @> $2::jsonb
+  AND starts_with(external_id, $2)
   AND sync_state <> $4
   AND ` + staleProjectionSQL + `
 ORDER BY external_id
@@ -139,12 +140,8 @@ LIMIT $5`
 // The ids are the INCUMBENT's own (external_id), which is what a re-fetch
 // names, and the caller re-reads them under m.Source.
 func (s *MirrorStore) StaleProjections(ctx context.Context, m ObjectMapping, limit int) ([]string, error) {
-	governed, err := governedRowsFilter(m)
-	if err != nil {
-		return nil, err
-	}
 	// m's own fingerprint alone, not every declaration projecting onto
-	// m.Target: the containment filter has already narrowed the rows to the
+	// m.Target: the namespace filter has already narrowed the rows to the
 	// ones m produced, so a sibling declaration's fingerprint cannot appear
 	// among them — and admitting one would spare a row nothing re-projects.
 	current, err := encodeFingerprintSets(map[string][]string{m.Target: {Fingerprint(m)}})
@@ -153,7 +150,7 @@ func (s *MirrorStore) StaleProjections(ctx context.Context, m ObjectMapping, lim
 	}
 	var externalIDs []string
 	err = s.db.Tx(ctx, func(tx pgx.Tx) error {
-		rows, err := tx.Query(ctx, staleProjectionIDsSQL, m.Target, governed, current, syncStatePendingSync, limit)
+		rows, err := tx.Query(ctx, staleProjectionIDsSQL, m.Target, mirrorIDNamespace(m.Source), current, syncStatePendingSync, limit)
 		if err != nil {
 			return fmt.Errorf("overlay: listing the %s rows an older declaration projected: %w", m.Source, err)
 		}
@@ -169,27 +166,35 @@ func (s *MirrorStore) StaleProjections(ctx context.Context, m ObjectMapping, lim
 	return externalIDs, nil
 }
 
-// governedRowsFilter renders the jsonb containment filter that picks out the
-// mirror rows m's declaration produced, as opposed to a sibling declaration's.
-// The mirror is keyed by the CANONICAL class, and several declarations can
-// project onto one — the five engagement classes all land on "activity" —
-// while a re-fetch names the INCUMBENT class, so a row read back under the
-// wrong sibling would be a live incumbent read for a record that class does
-// not hold. Const is what separates them: its entries are copied verbatim into
-// every payload the declaration projects (mapping.go's Apply), and each
-// registry's own TestEveryDeclarationSharingATargetIsSeparableByItsConstants
-// holds it to declaring constants that contradict between siblings. A
-// declaration with no constants therefore has its target to itself, and the
-// empty object — which every payload contains — is the honest filter for it.
-func governedRowsFilter(m ObjectMapping) (string, error) {
-	if len(m.Const) == 0 {
-		return "{}", nil
+// mirrorIDNamespace renders the external-id prefix that picks out the mirror
+// rows the declaration reading incumbentClass produced, as opposed to a sibling
+// declaration's. The mirror is keyed by the CANONICAL class, and several
+// declarations can project onto one — the five engagement classes all land on
+// "activity" — while a re-fetch names the INCUMBENT class, so a row read back
+// under the wrong sibling would be a live incumbent read for a record that
+// class does not hold.
+//
+// The mirror key's own namespace is what separates them: an engagement's
+// external_id is "<class>:<id>" (OVA-MAP-7), which is what keeps two classes
+// from colliding on (workspace, object_class, external_id) and what the id
+// bridge reads a class back out of (provider.go). Attribution therefore rests
+// on the row's IDENTITY, which no declaration edit can move — changing a
+// namespace would break the mirror key, the association join and PurgeRecord
+// long before it broke re-projection. Anything a declaration writes INTO the
+// payload is instead an input to the very digest whose change defines
+// staleness, so it would select nothing in exactly the pass where every row of
+// the class had just gone stale.
+//
+// A class that owns its canonical target namespaces nothing and needs no
+// narrowing: the empty prefix, which every id starts with, is the honest filter
+// for it. It is also the cheaper predicate either way — it reads the key column
+// the rows are already ordered by, rather than testing containment against a
+// payload no index covers.
+func mirrorIDNamespace(incumbentClass string) string {
+	if !slices.Contains(incumbentEngagementClasses, incumbentClass) {
+		return ""
 	}
-	encoded, err := json.Marshal(m.Const)
-	if err != nil {
-		return "", fmt.Errorf("overlay: encoding the %s declaration's constant fields: %w", m.Source, err)
-	}
-	return string(encoded), nil
+	return incumbentClass + ":"
 }
 
 // mirroredClasses lists the canonical object classes overlay_mirror currently

--- a/backend/internal/modules/overlay/projectionstaleness.go
+++ b/backend/internal/modules/overlay/projectionstaleness.go
@@ -9,9 +9,11 @@ package overlay
 // current declaration would never produce, indefinitely — and the flip freezes
 // the mirror and writes those payloads as durable native rows, so whatever a
 // row holds at flip time becomes permanent. This file owns the one comparison
-// that detects it, shared by the flip preflight (flipstate.go) and the
-// operator-facing sync status (syncstatus.go) so the two can never disagree
-// about which rows are out of date.
+// that detects it, shared by the flip preflight (flipstate.go), the
+// operator-facing sync status (syncstatus.go), and the sweep phase that
+// converges those rows (StaleProjections, below) so the three can never
+// disagree about which rows are out of date — the flip must block on exactly
+// the rows the sweep re-fetches, or it blocks on rows nothing will ever clear.
 
 import (
 	"context"
@@ -61,9 +63,16 @@ func (s *Service) currentProjectionFingerprints(mirroredClasses []string) (strin
 			byClass[class] = fingerprints
 		}
 	}
-	// Encoded here rather than handed to pgx as a map, so the argument's wire
-	// shape is this package's decision and not an inference from how Postgres
-	// happens to resolve the parameter's type behind the cast.
+	return encodeFingerprintSets(byClass)
+}
+
+// encodeFingerprintSets renders the staleProjectionSQL argument — canonical
+// object class → the fingerprints a current declaration could have stamped on
+// its rows — as the jsonb object literal the predicate reads. Encoded here
+// rather than handed to pgx as a map, so the argument's wire shape is this
+// package's decision and not an inference from how Postgres happens to resolve
+// the parameter's type behind the cast.
+func encodeFingerprintSets(byClass map[string][]string) (string, error) {
 	encoded, err := json.Marshal(byClass)
 	if err != nil {
 		return "", fmt.Errorf("overlay: encoding the current projection fingerprints: %w", err)
@@ -98,6 +107,89 @@ func (s *Service) fingerprintsFor(canonicalClass string) []string {
 		return nil
 	}
 	return fingerprints
+}
+
+// staleProjectionIDsSQL names the rows ONE declaration must re-project: the
+// rows it governs (the containment filter, $2 — see governedRowsFilter) whose
+// stored payload it did not produce (staleProjectionSQL over $3, holding that
+// declaration's own current fingerprint). Ordered by external id so a bounded
+// pass takes a stable prefix rather than a different arbitrary slice each time,
+// and a row already re-projected simply drops out of the set.
+//
+// A row with an un-drained local write ($4) is left out: ingest's
+// no-clobber-dirty guard would refuse the re-projection, so re-fetching it
+// would spend an incumbent read on a write that cannot land. Such a row blocks
+// the flip on its own pending state anyway, and it re-enters this set as soon
+// as the write drains.
+const staleProjectionIDsSQL = `
+SELECT external_id FROM overlay_mirror
+WHERE object_class = $1
+  AND fields @> $2::jsonb
+  AND sync_state <> $4
+  AND ` + staleProjectionSQL + `
+ORDER BY external_id
+LIMIT $5`
+
+// StaleProjections answers up to limit external ids of the mirror rows m
+// governs whose payload m's CURRENT declaration did not produce — the set the
+// reconcile sweep re-fetches so they converge on today's mapping. It embeds
+// the same predicate the flip preflight and the sync status count with, so the
+// rows the sweep clears are exactly the rows the flip blocks on.
+//
+// The ids are the INCUMBENT's own (external_id), which is what a re-fetch
+// names, and the caller re-reads them under m.Source.
+func (s *MirrorStore) StaleProjections(ctx context.Context, m ObjectMapping, limit int) ([]string, error) {
+	governed, err := governedRowsFilter(m)
+	if err != nil {
+		return nil, err
+	}
+	// m's own fingerprint alone, not every declaration projecting onto
+	// m.Target: the containment filter has already narrowed the rows to the
+	// ones m produced, so a sibling declaration's fingerprint cannot appear
+	// among them — and admitting one would spare a row nothing re-projects.
+	current, err := encodeFingerprintSets(map[string][]string{m.Target: {Fingerprint(m)}})
+	if err != nil {
+		return nil, err
+	}
+	var externalIDs []string
+	err = s.db.Tx(ctx, func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, staleProjectionIDsSQL, m.Target, governed, current, syncStatePendingSync, limit)
+		if err != nil {
+			return fmt.Errorf("overlay: listing the %s rows an older declaration projected: %w", m.Source, err)
+		}
+		externalIDs, err = pgx.CollectRows(rows, pgx.RowTo[string])
+		if err != nil {
+			return fmt.Errorf("overlay: collecting the %s rows an older declaration projected: %w", m.Source, err)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return externalIDs, nil
+}
+
+// governedRowsFilter renders the jsonb containment filter that picks out the
+// mirror rows m's declaration produced, as opposed to a sibling declaration's.
+// The mirror is keyed by the CANONICAL class, and several declarations can
+// project onto one — the five engagement classes all land on "activity" —
+// while a re-fetch names the INCUMBENT class, so a row read back under the
+// wrong sibling would be a live incumbent read for a record that class does
+// not hold. Const is what separates them: its entries are copied verbatim into
+// every payload the declaration projects (mapping.go's Apply), and each
+// registry's own TestEveryDeclarationSharingATargetIsSeparableByItsConstants
+// holds it to declaring constants that contradict between siblings. A
+// declaration with no constants therefore has its target to itself, and the
+// empty object — which every payload contains — is the honest filter for it.
+func governedRowsFilter(m ObjectMapping) (string, error) {
+	if len(m.Const) == 0 {
+		return "{}", nil
+	}
+	encoded, err := json.Marshal(m.Const)
+	if err != nil {
+		return "", fmt.Errorf("overlay: encoding the %s declaration's constant fields: %w", m.Source, err)
+	}
+	return string(encoded), nil
 }
 
 // mirroredClasses lists the canonical object classes overlay_mirror currently

--- a/backend/internal/modules/overlay/projectionstaleness.go
+++ b/backend/internal/modules/overlay/projectionstaleness.go
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package overlay
+
+// A mirror row holds a PROJECTION, and it is re-projected only when the
+// incumbent's own baseline advances (mirrorstore.go's staleness guard). A
+// mapping change therefore leaves already-mirrored rows holding a payload the
+// current declaration would never produce, indefinitely — and the flip freezes
+// the mirror and writes those payloads as durable native rows, so whatever a
+// row holds at flip time becomes permanent. This file owns the one comparison
+// that detects it, shared by the flip preflight (flipstate.go) and the
+// operator-facing sync status (syncstatus.go) so the two can never disagree
+// about which rows are out of date.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// WithProjectionFingerprints wires the current declaration fingerprints
+// (e.g. hubspot.ProjectionFingerprints) the flip preflight and the sync status
+// compare every mirror row against — keyed by INCUMBENT class, resolved to the
+// mirror's canonical object_class through WithIncumbentClassesTranslator. See
+// the Service doc for why this package cannot hold the registry itself.
+// Returns s so compose can chain it onto NewService's result.
+func (s *Service) WithProjectionFingerprints(byIncumbentClass map[string]string) *Service {
+	s.projectionFingerprints = byIncumbentClass
+	return s
+}
+
+// staleProjectionSQL is the predicate both aggregations apply to one
+// overlay_mirror row: its class is one this deployment can currently judge,
+// and no current declaration for that class produced the payload it holds. It
+// reads $3 — the jsonb currentProjectionFingerprints returns — so every query
+// embedding it must bind that object at position 3.
+//
+// The outer `?` tests KEY existence on the object, which is what excludes a
+// class the map does not name: a retired mapping can never match a current
+// fingerprint, so counting its rows as stale would block the flip with a
+// staleness nothing could ever clear. The inner `?` tests ELEMENT existence in
+// that class's array, since several declarations can project onto one
+// canonical class. coalesce makes a row that records NO declaration — NULL,
+// mirrored before the column existed — compare as stale rather than as
+// unknown: nothing verified that payload against the current mapping either.
+const staleProjectionSQL = `($3::jsonb ? object_class
+	    AND NOT ($3::jsonb -> object_class ? coalesce(projection_fingerprint, '')))`
+
+// currentProjectionFingerprints builds the staleProjectionSQL argument for the
+// classes the mirror actually holds: canonical object_class → the fingerprints
+// a current declaration could have stamped on it, as the jsonb object literal
+// the predicate reads. A class it omits is one this deployment cannot judge,
+// and is excluded from staleness entirely rather than guessed at.
+func (s *Service) currentProjectionFingerprints(mirroredClasses []string) (string, error) {
+	byClass := make(map[string][]string, len(mirroredClasses))
+	for _, class := range mirroredClasses {
+		if fingerprints := s.fingerprintsFor(class); len(fingerprints) > 0 {
+			byClass[class] = fingerprints
+		}
+	}
+	// Encoded here rather than handed to pgx as a map, so the argument's wire
+	// shape is this package's decision and not an inference from how Postgres
+	// happens to resolve the parameter's type behind the cast.
+	encoded, err := json.Marshal(byClass)
+	if err != nil {
+		return "", fmt.Errorf("overlay: encoding the current projection fingerprints: %w", err)
+	}
+	return string(encoded), nil
+}
+
+// fingerprintsFor answers the fingerprints a CURRENT declaration could have
+// stamped on a row of canonicalClass, or nil when this deployment cannot say.
+// Three ways it cannot: neither collaborator is wired (a role composed without
+// them judges nothing rather than declaring every row stale), the class has no
+// declared mapping at all (a retired one — its rows must not block a flip
+// forever), and the partial case below.
+func (s *Service) fingerprintsFor(canonicalClass string) []string {
+	if s.toIncumbentClasses == nil || len(s.projectionFingerprints) == 0 {
+		return nil
+	}
+	incumbentClasses, ok := s.toIncumbentClasses(canonicalClass)
+	if !ok {
+		return nil
+	}
+	fingerprints := make([]string, 0, len(incumbentClasses))
+	for _, incumbentClass := range incumbentClasses {
+		if fingerprint := s.projectionFingerprints[incumbentClass]; fingerprint != "" {
+			fingerprints = append(fingerprints, fingerprint)
+		}
+	}
+	// A class only PARTLY fingerprinted cannot be judged either: one of the
+	// declarations that project onto it is unaccounted for, and a row this
+	// comparison would call stale might be exactly what that one produces.
+	if len(fingerprints) != len(incumbentClasses) {
+		return nil
+	}
+	return fingerprints
+}
+
+// mirroredClasses lists the canonical object classes overlay_mirror currently
+// holds — the classes both the backfill-convergence check and the projection
+// comparison are asked about, read once so a preflight never asks the same
+// question twice inside its own transaction.
+func mirroredClasses(ctx context.Context, tx pgx.Tx) ([]string, error) {
+	rows, err := tx.Query(ctx, `SELECT DISTINCT object_class FROM overlay_mirror ORDER BY object_class`)
+	if err != nil {
+		return nil, fmt.Errorf("overlay: listing the mirrored classes: %w", err)
+	}
+	classes, err := pgx.CollectRows(rows, pgx.RowTo[string])
+	if err != nil {
+		return nil, fmt.Errorf("overlay: collecting the mirrored classes: %w", err)
+	}
+	return classes, nil
+}

--- a/backend/internal/modules/overlay/projectionstaleness_test.go
+++ b/backend/internal/modules/overlay/projectionstaleness_test.go
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package overlay
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestEveryClassSharingACanonicalTargetIsSeparableByItsMirrorNamespace holds
+// the module to the premise re-projection rests on: the mirror is keyed by the
+// CANONICAL class, so every declaration that projects onto one target puts its
+// rows in the same bucket, while every re-read of a record names the INCUMBENT
+// class. A row can only be re-fetched under the class that produced it, and the
+// mirror id's "<class>:" namespace (OVA-MAP-7) is what tells the rows apart.
+//
+// The ids are built through the identity bridge rather than concatenated here,
+// because the bridge is what a namespace change would have to survive: it is
+// the same reversal a force-fresh recovers a class with, so a namespace this
+// filter could not reproduce would be a mirror key nothing could resolve.
+func TestEveryClassSharingACanonicalTargetIsSeparableByItsMirrorNamespace(t *testing.T) {
+	for _, class := range incumbentEngagementClasses {
+		id, err := externalIDToUUID(class + ":123")
+		if err != nil {
+			t.Fatalf("externalIDToUUID(%q): %v", class+":123", err)
+		}
+		mirrorID := uuidToExternalID(id)
+		if prefix := mirrorIDNamespace(class); !strings.HasPrefix(mirrorID, prefix) || prefix == "" {
+			t.Errorf("mirrorIDNamespace(%q) = %q, which does not namespace that class's own mirror id %q — "+
+				"the sweep would re-project rows no declaration of %q produced, or none of them", class, prefix, mirrorID, class)
+		}
+		for _, sibling := range incumbentEngagementClasses {
+			if sibling != class && strings.HasPrefix(mirrorID, mirrorIDNamespace(sibling)) {
+				t.Errorf("%q's mirror id %q also carries %q's namespace, so a re-fetch would read a %s as a %s: "+
+					"a live incumbent read that can only 404, repeated every pass", class, mirrorID, sibling, class, sibling)
+			}
+		}
+	}
+	// A class that owns its canonical target shares the bucket with nobody, so
+	// it narrows nothing: the empty prefix every id starts with.
+	if prefix := mirrorIDNamespace(IncumbentClassContacts); prefix != "" {
+		t.Errorf("mirrorIDNamespace(%q) = %q, want the empty prefix — a class with its target to itself "+
+			"must select every row of it, and its ids are bare", IncumbentClassContacts, prefix)
+	}
+}

--- a/backend/internal/modules/overlay/syncstatus.go
+++ b/backend/internal/modules/overlay/syncstatus.go
@@ -138,13 +138,6 @@ func (s *Service) SyncStatus(ctx context.Context) ([]ObjectSyncStatus, error) {
 
 	var out []ObjectSyncStatus
 	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
-		// Drain the aggregate query FULLY before running any further query
-		// on this same tx — pgx ties the connection up while a Rows result
-		// is still open, so calling backfillCompleteFor's own tx.QueryRow
-		// per row WHILE this Query's rows are still being iterated would
-		// contend with it on the same connection (observed: it silently
-		// answered "no row", not a panic — exactly the kind of quiet
-		// wrong-answer a second, nested pass on the drained slice avoids).
 		classes, err := mirroredClasses(ctx, tx)
 		if err != nil {
 			return err
@@ -153,6 +146,13 @@ func (s *Service) SyncStatus(ctx context.Context) ([]ObjectSyncStatus, error) {
 		if err != nil {
 			return err
 		}
+		// Drain the aggregate query FULLY before running any further query
+		// on this same tx — pgx ties the connection up while a Rows result
+		// is still open, so calling backfillCompleteFor's own tx.QueryRow
+		// per row WHILE this Query's rows are still being iterated would
+		// contend with it on the same connection (observed: it silently
+		// answered "no row", not a panic — exactly the kind of quiet
+		// wrong-answer a second, nested pass on the drained slice avoids).
 		rows, err := tx.Query(ctx, selectMirrorSyncAggregateSQL, syncStatePendingSync, syncStateStale, currentFingerprints)
 		if err != nil {
 			return fmt.Errorf("overlay: aggregating mirror sync state: %w", err)

--- a/backend/internal/modules/overlay/syncstatus.go
+++ b/backend/internal/modules/overlay/syncstatus.go
@@ -32,8 +32,12 @@ import (
 // "person"), not the incumbent's class name — the same vocabulary
 // datasource.EntityType and every other overlay read verb already uses.
 type ObjectSyncStatus struct {
-	Object           string
-	LastSyncedAt     time.Time
+	Object       string
+	LastSyncedAt time.Time
+	// State is the WORST state present across the class's mirror rows —
+	// including a row whose payload an older declaration projected, which
+	// reads as stale because that is what it is: the mirror holds a
+	// projection the current mapping would not produce.
 	State            string
 	BackfillComplete bool
 	// FrozenForFlip marks a mirror held still by a pending overlay→native
@@ -102,10 +106,16 @@ func (s *Service) resolveOverlayMode(ctx context.Context) (incumbent string, err
 // stale row behind a majority-fresh count) and the most recent
 // last_synced_at across the class's rows (the class's own freshest
 // watermark, the number a UI's "last synced" affordance shows).
+//
+// A row an older declaration projected counts toward the class's staleness on
+// exactly the same footing as a stale sync_state (staleProjectionSQL): both
+// mean the mirror holds a payload the current mapping would not produce, and
+// both hold the flip's force-fresh check open — so reading this surface is how
+// an operator sees WHICH class keeps force_fresh_incomplete from clearing.
 const selectMirrorSyncAggregateSQL = `
 SELECT object_class, max(last_synced_at),
        bool_or(sync_state = $1) AS any_pending,
-       bool_or(sync_state = $2) AS any_stale
+       bool_or(sync_state = $2 OR ` + staleProjectionSQL + `) AS any_stale
 FROM overlay_mirror
 GROUP BY object_class
 ORDER BY object_class`
@@ -135,7 +145,15 @@ func (s *Service) SyncStatus(ctx context.Context) ([]ObjectSyncStatus, error) {
 		// contend with it on the same connection (observed: it silently
 		// answered "no row", not a panic — exactly the kind of quiet
 		// wrong-answer a second, nested pass on the drained slice avoids).
-		rows, err := tx.Query(ctx, selectMirrorSyncAggregateSQL, syncStatePendingSync, syncStateStale)
+		classes, err := mirroredClasses(ctx, tx)
+		if err != nil {
+			return err
+		}
+		currentFingerprints, err := s.currentProjectionFingerprints(classes)
+		if err != nil {
+			return err
+		}
+		rows, err := tx.Query(ctx, selectMirrorSyncAggregateSQL, syncStatePendingSync, syncStateStale, currentFingerprints)
 		if err != nil {
 			return fmt.Errorf("overlay: aggregating mirror sync state: %w", err)
 		}

--- a/backend/internal/modules/overlay/syncstatus_integration_test.go
+++ b/backend/internal/modules/overlay/syncstatus_integration_test.go
@@ -78,6 +78,69 @@ func TestBackfillCompleteForRequiresEveryEngagementClass(t *testing.T) {
 	}
 }
 
+// TestSyncStatusShowsWhichClassHoldsAnOlderProjection is how an operator sees
+// WHY the flip's force-fresh check will not clear: the same comparison the
+// preflight aggregates into one verdict, reported per class on the surface
+// that already exists — no new wire field. It also pins the two classes the
+// comparison must spare, which is what keeps the verdict clearable at all:
+// one whose declaration this deployment no longer holds, and one with no
+// declared mapping left.
+func TestSyncStatusShowsWhichClassHoldsAnOlderProjection(t *testing.T) {
+	ctx, pool, ws := testWorkspaceCtx(t)
+	seedOverlayWorkspace(ctx, t, pool)
+	db := database.BindTo(pool, ids.From[ids.WorkspaceKind](ws))
+	store := NewMirrorStore(db, noOwnerEmails{})
+	svc := NewService(db, keyvault.NewMemory(), store).
+		WithIncumbentClassesTranslator(func(canonical string) ([]string, bool) {
+			switch canonical {
+			case "person":
+				return []string{IncumbentClassContacts}, true
+			case "organization":
+				return []string{IncumbentClassCompanies}, true
+			default:
+				return nil, false
+			}
+		}).
+		WithProjectionFingerprints(map[string]string{IncumbentClassContacts: "contacts-declaration-current"})
+
+	baseline := time.Date(2026, 5, 13, 6, 44, 38, 0, time.UTC)
+	for _, row := range []struct{ objectClass, ext, fingerprint string }{
+		{"person", "p-legacy", "contacts-declaration-superseded"},
+		// companies has no current declaration injected, and widget has no
+		// mapping at all — neither class can be judged, so neither is stale.
+		{"organization", "org-1", "companies-declaration-retired"},
+		{"widget", "w-1", "widget-declaration-retired"},
+	} {
+		if err := store.Ingest(ctx, Record{
+			ObjectClass: row.objectClass, ExternalID: row.ext,
+			Fields:                map[string]any{"full_name": "Ingested Row"},
+			ModifiedAt:            baseline,
+			ProjectionFingerprint: row.fingerprint,
+		}); err != nil {
+			t.Fatalf("ingesting %s/%s: %v", row.objectClass, row.ext, err)
+		}
+	}
+
+	statuses, err := svc.SyncStatus(ctx)
+	if err != nil {
+		t.Fatalf("SyncStatus: %v", err)
+	}
+	states := make(map[string]string, len(statuses))
+	for _, s := range statuses {
+		states[s.Object] = s.State
+	}
+	want := map[string]string{
+		"person":       syncStateStale,
+		"organization": syncStateFresh,
+		"widget":       syncStateFresh,
+	}
+	for object, wantState := range want {
+		if states[object] != wantState {
+			t.Errorf("sync state for %s = %q, want %q (all states: %v)", object, states[object], wantState, states)
+		}
+	}
+}
+
 func TestSyncStatusAndBudgetRefuseANativeModeWorkspace(t *testing.T) {
 	ctx, pool, ws := testWorkspaceCtx(t) // never flips to overlay mode
 	svc := NewService(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), keyvault.NewMemory(), NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), noOwnerEmails{})).

--- a/backend/migrations/custom/20260813140000_overlay_projection_fingerprint.down.sql
+++ b/backend/migrations/custom/20260813140000_overlay_projection_fingerprint.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE overlay_mirror DROP COLUMN projection_fingerprint;

--- a/backend/migrations/custom/20260813140000_overlay_projection_fingerprint.up.sql
+++ b/backend/migrations/custom/20260813140000_overlay_projection_fingerprint.up.sql
@@ -1,0 +1,10 @@
+-- A mirror row holds a PROJECTION of the incumbent's record, produced by a
+-- mapping declaration that can change under it. The fingerprint records which
+-- declaration produced this row, so a projection the current mapping would
+-- never produce is detectable rather than silent — the flip freezes whatever
+-- the mirror holds, and a wrong projection there becomes a durable native row.
+--
+-- Nullable with no backfill on purpose: a row written before this column is
+-- exactly a row whose projection nothing has verified, so NULL reads as stale
+-- and the sweep re-projects it.
+ALTER TABLE overlay_mirror ADD COLUMN projection_fingerprint text;

--- a/backend/rbacgate_test.go
+++ b/backend/rbacgate_test.go
@@ -128,6 +128,7 @@ var ungatedEntryPoints = gatekit.Waive(map[string]string{ // #nosec G101 -- waiv
 	"internal/modules/overlay:SaveReconcileWatermark":        "reconcile-poller checkpoint write; sweep state, not a record",
 	"internal/modules/overlay:SeedUserMap":                   "seeds mirror_user_map at connect time and on the sweep; the connect handler above it takes overlay_connection:update, and the sweep runs as system",
 	"internal/modules/overlay:SetManualUserMap":              "same: only usermapservice.go calls it, behind requireUserMapAdmin",
+	"internal/modules/overlay:StaleProjections":              "names the mirror rows an older mapping declaration projected, for the reconcile sweep's re-projection phase, under the worker's system principal — no request path reaches it and no human actor exists on it. What comes back is external ids of rows this workspace's own mirror already holds, inside its workspace-bound transaction: no record and no field of one leaves the call, so there is no row whose visibility a gate could decide",
 	"internal/modules/overlay:UpsertAssoc":                   "the same sweep's edge write, from backfill",
 	"internal/modules/overlay:UpsertUserMap":                 "the per-entry write SeedUserMap and the visibility recompute drive; same two paths, no independent entry",
 	"internal/modules/people:ExhaustedDomains":               "triage sweep (compose/capturedomaintriage.go) under the system principal: reads domains whose crawl attempts are spent so the sweep can settle them rather than strand them; no record, no human actor",


### PR DESCRIPTION
The overlay mirror stores a **projection** of an incumbent record — the result of running it through a declared mapping — not the record itself. A row is re-projected only when the incumbent's own baseline advances (`ingestSQL` guards on `EXCLUDED.updated_at_baseline >`), and `Backfill` short-circuits on a converged cursor. So a record the incumbent never touches again is never re-projected, by the poller or by re-running the backfill.

That means a **mapping** change strands every already-mirrored row holding a payload the current mapping would never produce. On the read path that is survivable — readers accept both shapes. On the overlay→native flip it is permanent: the flip writes durable native rows and freezes the mirror, so whatever a row holds at flip time becomes the native row, and `ForceFreshDone` only ever asked whether rows were stale and the backfill converged. A record synced before a mapping change is neither.

The address rename that prompted #996 was the first instance. Every future mapping change inherited the class.

## What this adds

A **fingerprint of each mapping declaration**, stamped on every mirror row at ingest. Staleness is computed by comparing a row's stored fingerprint against the current one for its class — no marker pass, correct the instant new code deploys. The flip folds that into its existing stale count, so the existing `ForceFreshIncomplete` reason covers it: **no contract change, no `crm.yaml` edit**. The background sweep gains a final phase that re-fetches stale rows, yielding to watermark work so an estate under budget pressure stays *fresh* while it converges slowly.

Rows written before the column carry NULL, which reads as stale and re-projects — which is why this also closes #1038.

## Three decisions worth knowing

**The ingest guard admits a re-projection at the same baseline only.** A re-fetch of an untouched record does not advance the baseline, so the write would otherwise be refused and nothing would ever converge. But an *older* read stays refused whatever its fingerprint says: a stale page carries a stale projection too, and admitting it on a fingerprint difference let laggard sweep pages overwrite fresher rows.

**The current-fingerprint map is keyed by incumbent class, not canonical.** `activity` is backed by five declarations at once and the fingerprint hashes the source, so a canonical→one-fingerprint map is unsatisfiable — four fifths of every activity estate would be permanently stale.

**The sweep attributes a stale row by its mirror key, not its payload.** Attribution by the declaration's constants is self-defeating, because the fingerprint hashes those constants: changing one makes every row of that class stale while the filter searches for the new value and matches nothing. The OVA-MAP-7 id namespace (`calls:123`) is invariant under declaration edits.

## Bounded claim

The first deploy converges the whole estate, bounded per sweep pass, spending metered incumbent API budget proportional to the mirror. That is the intended trade: a blocked flip beats a permanently wrong one.

Closes #996, closes #1038.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Blocks overlay→native flips when mirror rows were projected by older mappings and re-projects them so native rows don’t freeze outdated projections. Previously the flip ignored mapping drift; now each row stores a mapping fingerprint, preflight treats NULL/mismatch as stale, and the sweep clears them.

- Schema: add nullable `projection_fingerprint` to `overlay_mirror`; NULL or mismatch marks the row stale.
- Ingest/adapters: `hubspot` stamps `overlay.Fingerprint(m)`; the fake adapter stamps a constant. The staleness guard admits a same-baseline re-projection but still rejects older reads. Fingerprint and owner inputs are pointers to encode SQL NULL for pre-existing rows.
- Flip and sync status: `ForceFreshDone` now also requires zero stale projections; classes with no current declaration are excluded; sync status reports stale-by-class.
- Sweep: adds a post-watermark re-projection phase that selects stale rows via the shared predicate, attributes by namespaced mirror key, enqueues `overlay_refetch` through the job’s ambient River client, and respects the budget meter.
- Jobs/wiring: the re-fetch worker now builds a workspace-bound mirror store per job (not shared) to prevent panics and unmetered retries; the budget meter remains shared. Compose injects current projection fingerprints (keyed by incumbent class) into `overlay.Service`. List paging moves to `mirrorpage.go`.

**Rollout**
- Run the migration. The first deploy will re-fetch NULL/mismatched rows and may increase incumbent API usage proportional to mirror size. No config changes or `crm.yaml` edits required.

<sup>Written for commit 3170e46c3e868a4cd482bbd8601fd8708044e81b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1183?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added projection tracking to identify mirror records created by outdated mappings.
  - Automatically queues bounded re-projection and refetch work during overlay sweeps.
  - Re-projection retries stale records and coalesces duplicate jobs.
- **Bug Fixes**
  - Flip preflight and sync status now correctly flag outdated or missing projections.
  - Re-projected records recover cleanly while preserving activity attribution.
  - Improved handling for unmapped classes and shared canonical targets.
- **Tests**
  - Added comprehensive integration coverage for stale detection, re-projection, retries, and job enqueueing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->