### PR TITLE
feat(person): the composer sends, asks before drafting, and knows why it was opened

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -4427,10 +4427,23 @@ export const de = {
   "person.composer.why": "Warum dieser Entwurf",
   "person.composer.consentUnknown":
     "Für diesen Kanal ist keine Einwilligungsentscheidung erfasst.",
-  "person.composer.confirmFirst":
-    "Der Versand erfolgt erst nach Freigabe. Dieser Entwurf wird nicht ohne Ihre Zustimmung gesendet.",
-  "person.composer.reviewSend": "Prüfen & senden",
-  "person.composer.staged": "Zur Freigabe vorgemerkt",
+  "person.composer.sendNote":
+    "Mit dem Senden geht diese Nachricht aus Ihrem eigenen Postfach raus.",
+  "person.composer.purpose": "Einwilligungszweck",
+  "person.composer.consentPickPurpose":
+    "Wählen Sie, wofür diese Nachricht ist — die Einwilligung gilt je Zweck.",
+  "person.composer.intent": "Worum soll es gehen?",
+  "person.composer.intentHint":
+    "Optional — z. B. um einen Termin in der ersten Septemberwoche bitten",
+  "person.composer.draftWithAi": "Mit KI entwerfen",
+  "person.composer.intentAgenda":
+    "eine Agenda für den anstehenden Termin vorschlagen",
+  "person.composer.intentReply": "auf die letzte Nachricht antworten",
+  "person.composer.intentCommitment": "einlösen, was wir zugesagt haben",
+  "person.composer.intentFollowUp": "nachfassen — es ist still geworden",
+  "person.composer.send": "Senden",
+  "person.composer.sending": "Wird gesendet…",
+  "person.composer.sent": "Gesendet",
   "person.composer.aiDisclosure":
     "KI-unterstützter Entwurf · jedes Wort prüfen",
   "person.research.title": "Tiefenrecherche · {name}",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -4431,10 +4431,22 @@ export const en = {
   "person.composer.why": "Why this draft",
   "person.composer.consentUnknown":
     "No consent decision is recorded for this channel.",
-  "person.composer.confirmFirst":
-    "Sending is confirm-first. This draft is not sent until you approve.",
-  "person.composer.reviewSend": "Review & send",
-  "person.composer.staged": "Staged for approval",
+  "person.composer.sendNote":
+    "Pressing send delivers this message from your own mailbox.",
+  "person.composer.purpose": "Consent purpose",
+  "person.composer.consentPickPurpose":
+    "Choose what this message is for — consent is decided per purpose.",
+  "person.composer.intent": "What should it be about?",
+  "person.composer.intentHint":
+    "Optional — e.g. ask for a date in the first week of September",
+  "person.composer.draftWithAi": "Draft with AI",
+  "person.composer.intentAgenda": "propose an agenda for the upcoming meeting",
+  "person.composer.intentReply": "reply to their last message",
+  "person.composer.intentCommitment": "deliver what we promised them",
+  "person.composer.intentFollowUp": "follow up — it has gone quiet",
+  "person.composer.send": "Send",
+  "person.composer.sending": "Sending…",
+  "person.composer.sent": "Sent",
   "person.composer.aiDisclosure": "AI-assisted draft · review every word",
   "person.research.title": "Deep research · {name}",
   "person.research.publicOnly": "Public sources only",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -4411,10 +4411,22 @@ export const vi = {
   "person.composer.why": "Vì sao có bản nháp này",
   "person.composer.consentUnknown":
     "Chưa có quyết định về sự đồng ý cho kênh này.",
-  "person.composer.confirmFirst":
-    "Việc gửi cần xác nhận trước. Bản nháp này chỉ được gửi sau khi bạn duyệt.",
-  "person.composer.reviewSend": "Xem lại & gửi",
-  "person.composer.staged": "Đã đưa vào chờ duyệt",
+  "person.composer.sendNote":
+    "Khi bấm gửi, thư sẽ đi từ hộp thư của chính bạn.",
+  "person.composer.purpose": "Mục đích đồng ý",
+  "person.composer.consentPickPurpose":
+    "Hãy chọn mục đích của thư này — sự đồng ý được xét theo từng mục đích.",
+  "person.composer.intent": "Nội dung nên nói về điều gì?",
+  "person.composer.intentHint":
+    "Tùy chọn — ví dụ: xin một buổi hẹn trong tuần đầu tháng 9",
+  "person.composer.draftWithAi": "Soạn bằng AI",
+  "person.composer.intentAgenda": "đề xuất chương trình cho buổi hẹn sắp tới",
+  "person.composer.intentReply": "trả lời tin nhắn gần nhất của họ",
+  "person.composer.intentCommitment": "thực hiện điều chúng ta đã hứa",
+  "person.composer.intentFollowUp": "nhắc lại — đã lâu không có phản hồi",
+  "person.composer.send": "Gửi",
+  "person.composer.sending": "Đang gửi…",
+  "person.composer.sent": "Đã gửi",
   "person.composer.aiDisclosure": "Bản nháp có hỗ trợ AI · hãy đọc kỹ từng từ",
   "person.research.title": "Nghiên cứu sâu · {name}",
   "person.research.publicOnly": "Chỉ nguồn công khai",

--- a/frontend/src/screens/compose.tsx
+++ b/frontend/src/screens/compose.tsx
@@ -682,7 +682,7 @@ function DraftBar({
 // failing. Anything outside this list keeps the server's own message on the
 // modal's generic error line: inventing copy for a condition this surface does
 // not understand would put words in the server's mouth.
-type Refusal = "consent" | "mailbox" | "sharedUnsubscribe" | null;
+export type Refusal = "consent" | "mailbox" | "sharedUnsubscribe" | null;
 
 // The consent gate is a sentinel-mapped 409 and names itself at the top level;
 // the two pre-flight refusals are 422s, where the top-level code is only ever
@@ -690,7 +690,7 @@ type Refusal = "consent" | "mailbox" | "sharedUnsubscribe" | null;
 // server asserted. Matching the field too keeps the copy tied to the input it
 // is about: "reconnect your mailbox" is an answer about `from`, and would be
 // wrong advice if some later rule refused `recipients` under the same code.
-function refusalOf(error: unknown): Refusal {
+export function refusalOf(error: unknown): Refusal {
   if (error instanceof ProblemError && isConsentNotGranted(error.problem)) {
     return "consent";
   }
@@ -711,7 +711,7 @@ function refusalOf(error: unknown): Refusal {
 // grant and the provider will not widen one in place, so reconnecting is the
 // whole fix. And a message carrying an unsubscribe link carries ONE recipient's
 // consent credential, so it may only ever have one addressee.
-function SendRefusal({
+export function SendRefusal({
   refusal,
   personId,
 }: Readonly<{ refusal: Refusal; personId?: string }>) {

--- a/frontend/src/screens/person360.css
+++ b/frontend/src/screens/person360.css
@@ -661,6 +661,27 @@
   margin-top: 0;
 }
 
+/* The steering field and the button that uses it, on one line: typing what the
+   mail should be about and asking for it are one action, and splitting them
+   down the drawer would read as two unrelated controls. */
+.pe-draft-row {
+  display: flex;
+  gap: var(--space-2);
+  align-items: center;
+}
+
+.pe-draft-row > :first-child {
+  flex: 1;
+}
+
+/* A refusal the rep has to act on — a consent gate, an unsendable mailbox —
+   sits beside the control that produced it rather than replacing the drawer. */
+.pe-send-error {
+  margin: var(--space-2) 0 0;
+  font-size: 13px;
+  color: var(--danger);
+}
+
 /* "Why this draft": the reasoning is a SIBLING of the body, never part of it.
    A body that explained itself is a body the rep has to edit before sending. */
 .pe-why {

--- a/frontend/src/screens/persondrawers.tsx
+++ b/frontend/src/screens/persondrawers.tsx
@@ -20,6 +20,7 @@ import {
 import { Select } from "../design-system/select";
 import { useT } from "../i18n";
 import { problemMessageOf, throwProblem } from "./common";
+import { refusalOf, SendRefusal } from "./compose";
 import { useConsentPurposes } from "./consent";
 import { PersonProviderSection } from "./personprovider";
 
@@ -176,6 +177,28 @@ function PurposePicker({
       />
     </>
   );
+}
+
+// Why a send was refused, in terms the rep can act on.
+//
+// The three named refusals are the SAME ones the company composer meets, so
+// they are named once rather than twice: a consent gate that says which record
+// to open, a mailbox whose grant predates sending, and an unsubscribe token
+// belonging to one recipient. Anything else falls back to the problem's own
+// message, which is still better than "something went wrong".
+function SendFailure({
+  error,
+  personId,
+}: Readonly<{ error: unknown; personId: string }>) {
+  const t = useT();
+  if (error == null) {
+    return null;
+  }
+  const refusal = refusalOf(error);
+  if (refusal !== null) {
+    return <SendRefusal refusal={refusal} personId={personId} />;
+  }
+  return <p className="pe-send-error">{problemMessageOf(error, t)}</p>;
 }
 
 export function PersonComposer({
@@ -367,9 +390,10 @@ export function PersonComposer({
           <AlertTriangle size={14} aria-hidden="true" />
           {t("person.composer.sendNote")}
         </span>
-        {send.isError && (
-          <p className="pe-send-error">{problemMessageOf(send.error, t)}</p>
-        )}
+        <SendFailure
+          error={send.isError ? send.error : null}
+          personId={personId}
+        />
         <Button
           variant="primary"
           disabled={!sendable || send.isPending}

--- a/frontend/src/screens/persondrawers.tsx
+++ b/frontend/src/screens/persondrawers.tsx
@@ -17,8 +17,10 @@ import {
   Textarea,
   TextInput,
 } from "../design-system/atoms";
+import { Select } from "../design-system/select";
 import { useT } from "../i18n";
-import { throwProblem } from "./common";
+import { problemMessageOf, throwProblem } from "./common";
+import { useConsentPurposes } from "./consent";
 import { PersonProviderSection } from "./personprovider";
 
 // Only http(s) may become a link. A provider-supplied URL is untrusted input,
@@ -46,49 +48,223 @@ type PersonConsentGuard = components["schemas"]["PersonConsentGuard"];
 
 // --- The composer (State D) ------------------------------------------------
 
+// What the send button says, in the three states it can be in. A sent message
+// keeps saying so: the button is disabled afterwards, and a label that returned
+// to "Send" would invite a second copy of a mail already delivered.
+function sendPhase(
+  send: Readonly<{ isPending: boolean; isSuccess: boolean }>,
+  t: ReturnType<typeof useT>,
+): string {
+  if (send.isSuccess) {
+    return t("person.composer.sent");
+  }
+  return send.isPending
+    ? t("person.composer.sending")
+    : t("person.composer.send");
+}
+
+// The steering field and the button that uses it.
+//
+// Its own component because the composer around it is at the complexity
+// ceiling, and because these two controls are ONE action: what the mail should
+// be about, and the request to write it.
+function DraftBar({
+  intent,
+  onIntentChange,
+  pending,
+  error,
+  onDraft,
+}: Readonly<{
+  intent: string;
+  onIntentChange: (next: string) => void;
+  pending: boolean;
+  error: unknown;
+  onDraft: () => void;
+}>) {
+  const t = useT();
+  return (
+    <>
+      {/* Steering, then the draft. The order matters: a rep who types what the
+          mail is about before pressing the button gets a draft about that, and
+          a rep who presses it first gets the record's own reading. */}
+      <label className="pe-field-label" htmlFor="composer-intent">
+        {t("person.composer.intent")}
+      </label>
+      <div className="pe-draft-row">
+        <TextInput
+          id="composer-intent"
+          value={intent}
+          placeholder={t("person.composer.intentHint")}
+          onChange={(event) => onIntentChange(event.target.value)}
+        />
+        <Button small disabled={pending} onClick={onDraft}>
+          <Sparkles size={14} aria-hidden="true" />
+          {pending
+            ? t("person.composer.drafting")
+            : t("person.composer.draftWithAi")}
+        </Button>
+      </div>
+      {error != null && (
+        <p className="pe-send-error">{problemMessageOf(error, t)}</p>
+      )}
+    </>
+  );
+}
+
+// The guard entry that governs THIS send.
+//
+// Consent is decided per purpose, so the guard carries one email entry per
+// purpose — business correspondence, transactional, marketing. "May I email
+// them" therefore has no answer until the rep says what for, and reading the
+// first email entry would let whichever purpose sorts first speak for all of
+// them: a send the server permits would be refused here, under a reason
+// belonging to a purpose nobody chose.
+function emailGuardFor(guard: PersonConsentGuard | undefined, purpose: string) {
+  if (!purpose) {
+    return undefined;
+  }
+  return guard?.entries.find(
+    (entry) => entry.channel === "email" && entry.purpose_key === purpose,
+  );
+}
+
+// Everything a send needs before the button may be pressed. Separate from the
+// consent verdict beside it: one asks whether the message is complete, the
+// other whether it may go at all, and a rep denied for the wrong reason cannot
+// tell which they must fix.
+function canSend(
+  fields: Readonly<{
+    recipient: string;
+    subject: string;
+    body: string;
+    purpose: string;
+  }>,
+): boolean {
+  return (
+    fields.recipient !== "" &&
+    fields.subject.trim() !== "" &&
+    fields.body.trim() !== "" &&
+    fields.purpose !== ""
+  );
+}
+
+// The consent purpose this send falls under. Its own component because the
+// composer is at the complexity ceiling, and because the list comes from the
+// server: a workspace's purposes are configuration, not a fixed enum.
+function PurposePicker({
+  purpose,
+  onChange,
+}: Readonly<{ purpose: string; onChange: (next: string) => void }>) {
+  const t = useT();
+  const purposes = useConsentPurposes();
+  return (
+    <>
+      <label className="pe-field-label" htmlFor="composer-purpose">
+        {t("person.composer.purpose")}
+      </label>
+      <Select
+        aria-label={t("person.composer.purpose")}
+        options={[
+          { value: "", label: "—" },
+          ...(purposes.data?.data ?? []).map((entry) => ({
+            value: entry.key,
+            label: entry.label,
+          })),
+        ]}
+        value={purpose}
+        onChange={onChange}
+      />
+    </>
+  );
+}
+
 export function PersonComposer({
   personId,
   view,
   guard,
   open,
+  intent: initialIntent,
   onClose,
 }: Readonly<{
   personId: string;
   view: Person360;
   guard: PersonConsentGuard | undefined;
   open: boolean;
+  // What the rep (or the moment action that opened this) wants the draft to be
+  // about. A rung that fired knows WHY — "their reply is overdue", "the meeting
+  // needs an agenda" — and that reason shaped nothing until it arrived here.
+  intent?: string;
   onClose: () => void;
 }>) {
   const t = useT();
   const [subject, setSubject] = useState("");
   const [body, setBody] = useState("");
-  const [sent, setSent] = useState(false);
+  // Keyed on the intent the caller supplied, so a SECOND moment action opening
+  // the same composer replaces the first one's intent instead of leaving the
+  // rep with the reason the previous button had. useState alone seeds once and
+  // would silently ignore every later action.
+  const [intent, setIntent] = useState(initialIntent ?? "");
+  const [seededFrom, setSeededFrom] = useState(initialIntent ?? "");
+  if ((initialIntent ?? "") !== seededFrom) {
+    setSeededFrom(initialIntent ?? "");
+    setIntent(initialIntent ?? "");
+  }
+  const [purpose, setPurpose] = useState("");
 
-  // The draft is fetched when the drawer opens, not on page load: it spends
-  // the workspace's model budget, and a rep who never opens the composer
-  // should not pay for prose nobody reads.
-  const draft = useQuery({
-    enabled: open,
-    queryKey: ["personDraft", personId],
-    queryFn: async () => {
+  // Drafting is a BUTTON, not something the drawer does to you. Opening a
+  // composer to write two sentences yourself should not spend the workspace's
+  // model budget, and a draft that arrives unasked is one the rep has to read
+  // before they can ignore it. The company composer has always worked this way.
+  const draft = useMutation({
+    mutationFn: async () => {
       const { data, error } = await api.POST("/people/{id}/draft-email", {
         params: { path: { id: personId } },
-        body: {},
+        body: intent.trim() ? { intent: intent.trim() } : {},
       });
       if (error) {
         throwProblem(error);
       }
-      if (data) {
-        setSubject(data.subject);
-        setBody(data.body);
+      return data;
+    },
+    onSuccess: (written) => {
+      if (written) {
+        setSubject(written.subject);
+        setBody(written.body);
+      }
+    },
+  });
+
+  const email = emailGuardFor(guard, purpose);
+  const allowed = email?.verdict === "allowed";
+  const recipient = view.person.emails?.[0]?.email ?? "";
+
+  // The send itself. It was a setState — the button said "Staged for approval"
+  // and no request left the browser, so every draft written here was
+  // unsendable. A person-started message opens a new conversation, so it is
+  // POST /emails (the anchored /activities/{id}/send-email answers one), and it
+  // carries the person as its link.
+  const send = useMutation({
+    mutationFn: async () => {
+      const { data, error } = await api.POST("/emails", {
+        body: {
+          subject,
+          body,
+          to: [recipient],
+          consent_purpose: purpose,
+          links: [{ entity_type: "person" as const, entity_id: personId }],
+        },
+      });
+      if (error) {
+        throwProblem(error);
       }
       return data;
     },
   });
 
-  const email = guard?.entries.find((entry) => entry.channel === "email");
-  const allowed = email?.verdict === "allowed";
-  const recipient = view.person.emails?.[0]?.email ?? "";
+  const sendable =
+    allowed &&
+    !send.isSuccess &&
+    canSend({ recipient, subject, body, purpose });
 
   return (
     <Modal
@@ -108,7 +284,9 @@ export function PersonComposer({
           </Button>
         </div>
         {/* The consent verdict leads, with its reason. A rep about to write
-            needs to know whether they may send BEFORE they spend words on it. */}
+            needs to know whether they may send BEFORE they spend words on it —
+            and until a purpose is chosen the honest line is that the question
+            has not been asked yet, not a verdict borrowed from another purpose. */}
         <div
           className={
             allowed
@@ -117,7 +295,12 @@ export function PersonComposer({
           }
         >
           <Check size={15} aria-hidden="true" />
-          <span>{email?.reason ?? t("person.composer.consentUnknown")}</span>
+          <span>
+            {email?.reason ??
+              (purpose
+                ? t("person.composer.consentUnknown")
+                : t("person.composer.consentPickPurpose"))}
+          </span>
         </div>
       </div>
 
@@ -126,6 +309,16 @@ export function PersonComposer({
           {t("person.composer.to")}
         </label>
         <TextInput id="composer-to" value={recipient} readOnly />
+
+        <PurposePicker purpose={purpose} onChange={setPurpose} />
+
+        <DraftBar
+          intent={intent}
+          onIntentChange={setIntent}
+          pending={draft.isPending}
+          error={draft.isError ? draft.error : null}
+          onDraft={() => draft.mutate()}
+        />
 
         <label className="pe-field-label" htmlFor="composer-subject">
           {t("person.composer.subject")}
@@ -142,7 +335,7 @@ export function PersonComposer({
         <Textarea
           id="composer-body"
           rows={12}
-          value={draft.isLoading ? t("person.composer.drafting") : body}
+          value={body}
           onChange={(event) => setBody(event.target.value)}
         />
 
@@ -167,20 +360,23 @@ export function PersonComposer({
       </div>
 
       <div className="drawer-foot">
-        {/* Confirm-first is stated, not implied. The rep is told what the
-            button will do before they press it, because "Send" that does not
-            send is the surprise this notice exists to prevent. */}
+        {/* The human's own click IS the approval for their own send (ADR-0055),
+            so this says what the button does rather than promising a second
+            step that never comes. */}
         <span className="pe-confirm-note">
           <AlertTriangle size={14} aria-hidden="true" />
-          {t("person.composer.confirmFirst")}
+          {t("person.composer.sendNote")}
         </span>
+        {send.isError && (
+          <p className="pe-send-error">{problemMessageOf(send.error, t)}</p>
+        )}
         <Button
           variant="primary"
-          disabled={!allowed || sent}
-          onClick={() => setSent(true)}
+          disabled={!sendable || send.isPending}
+          onClick={() => send.mutate()}
         >
           <Send size={15} aria-hidden="true" />
-          {sent ? t("person.composer.staged") : t("person.composer.reviewSend")}
+          {sendPhase(send, t)}
         </Button>
       </div>
     </Modal>

--- a/frontend/src/screens/personpage.tsx
+++ b/frontend/src/screens/personpage.tsx
@@ -85,6 +85,31 @@ export function isPersonTab(value: string | undefined): value is PersonTab {
   return PERSON_TABS.includes((value ?? "") as PersonTab);
 }
 
+// The intent phrases a moment action can ask the composer to open with. The
+// server names the reason in its own vocabulary ("agenda", "follow_up"); the
+// composer hands what it holds to a language model and shows it to a rep, so
+// both need a sentence rather than an enum value.
+const COMPOSER_INTENT_KEYS: Readonly<Record<string, MessageKey>> = {
+  agenda: "person.composer.intentAgenda",
+  reply: "person.composer.intentReply",
+  deliver_commitment: "person.composer.intentCommitment",
+  follow_up: "person.composer.intentFollowUp",
+};
+
+// What the composer opens with, from an action's prefill.
+//
+// An intent this client does not know opens an EMPTY composer rather than
+// passing the raw token through: "deliver_commitment" in the intent field is
+// worse than nothing, because a rep reads it as something the product meant to
+// say, and the model reads it as an instruction nobody wrote.
+function composerIntentOf(
+  prefill: Readonly<Record<string, string>> | undefined,
+  t: ReturnType<typeof useT>,
+): string {
+  const key = COMPOSER_INTENT_KEYS[prefill?.intent ?? ""];
+  return key ? t(key) : "";
+}
+
 export function PersonPageV2({
   id,
   tab,
@@ -132,6 +157,11 @@ export function PersonPageV2({
   // Which drawer is open, if any. One at a time: two surfaces over the same
   // record would each claim to be the thing the reader is doing.
   const [drawer, setDrawer] = useState<Drawer>(null);
+  // What the action that opened the composer wanted written. A rung knows WHY
+  // it fired and says so in its prefill; before this the client dropped that
+  // on the floor and opened the same empty composer as the generic button, so
+  // "Draft a follow-up" and "Write an email" did exactly the same thing.
+  const [composerIntent, setComposerIntent] = useState("");
 
   if (view.isLoading) {
     return <div className="wrap">{t("person.page.loading")}</div>;
@@ -142,8 +172,14 @@ export function PersonPageV2({
 
   const person = view.data.person;
   const firstName = person.full_name.split(" ")[0];
-  const emailVerdict = guard.data?.entries.find(
-    (entry) => entry.channel === "email",
+  // Consent is decided per PURPOSE, so the guard carries one email entry per
+  // purpose. The hero button asks a wider question than any single entry —
+  // "is there anything we may write to them about" — and reading only the
+  // first entry answered it with whichever purpose sorted first, disabling the
+  // button on a contact the product would happily let you mail transactionally.
+  // Which purpose applies is then the composer's own question.
+  const emailAllowed = (guard.data?.entries ?? []).some(
+    (entry) => entry.channel === "email" && entry.verdict === "allowed",
   );
 
   // The action loop. Every surface the contract can name routes here.
@@ -158,12 +194,14 @@ export function PersonPageV2({
       // An action with no destination is its own destination — the composer is
       // the sensible home for the drafting kinds.
       if (action.kind === "draft_reply") {
+        setComposerIntent("");
         setDrawer("composer");
       }
       return;
     }
     switch (destination.surface) {
       case "composer":
+        setComposerIntent(composerIntentOf(destination.prefill, t));
         setDrawer("composer");
         return;
       case "research":
@@ -194,7 +232,7 @@ export function PersonPageV2({
         controls={<PersonOwner view={view.data} />}
         actions={
           <PersonActions
-            guardAllows={emailVerdict?.verdict === "allowed"}
+            guardAllows={emailAllowed}
             personId={id}
             onEmail={() => setDrawer("composer")}
             onResearch={() => setDrawer("research")}
@@ -212,7 +250,10 @@ export function PersonPageV2({
           />
         }
       >
-        <PersonStrip view={view.data} consentVerdict={emailVerdict?.verdict} />
+        <PersonStrip
+          view={view.data}
+          consentVerdict={emailAllowed ? "allowed" : undefined}
+        />
 
         <div className="pe-tabs">
           <SegmentedControl
@@ -274,6 +315,7 @@ export function PersonPageV2({
           view={view.data}
           guard={guard.data}
           open={drawer === "composer"}
+          intent={composerIntent}
           onClose={() => setDrawer(null)}
         />
         <PersonResearchDrawer


### PR DESCRIPTION
Four defects on the person composer, all the same shape: a control that says one
thing and does another.

## The Send button did nothing

`persondrawers.tsx` bound Send to `onClick={() => setSent(true)}`. It then read
"Staged for approval" — but nothing was staged, no request left the browser, and
no approval record existed. **Every draft written on a person page was
unsendable.**

It posts to `POST /emails` now (the account-started send; `/activities/{id}/send-email`
is reply-only and needs an anchor), carries the person as its link, and says
"Sent" only after the server has it.

## The drawer drafted on open

A `useQuery` wrapping a POST fired whenever the drawer opened, so opening the
composer to write two sentences yourself spent the workspace's model budget and
handed you prose you had to read before you could ignore it. It also set state
inside `queryFn`, which misbehaves on refetch.

Drafting is a button now — as it has always been on the company composer — with
an intent field beside it.

## Moment actions dropped their prefill (#1085)

Four rungs carry a `prefill` naming why they fired; the client discarded it, so
"Draft a follow-up" opened exactly the same empty composer as "Write an email".

The intent now arrives as a readable sentence. An intent this client does not
recognise opens EMPTY rather than passing `deliver_commitment` through — a raw
token is worse than nothing, because the rep reads it as something the product
meant to say and the model reads it as an instruction nobody wrote.

## The consent gate read the wrong entry

Found while testing this in a browser. The guard answers **per purpose** and
returns one email entry per purpose:

```
email  business_correspondence  unknown
email  transactional            allowed
email  marketing_email          unknown
```

Both the composer and the page's Email button did `.find(channel === "email")`,
so whichever purpose sorted first spoke for all of them. A contact the product
would happily let you mail transactionally had the Email button disabled.

The composer asks which purpose the send falls under and gates on that entry.
The page button asks the wider question — is there anything we may write to them
about — which is `.some(...allowed)`.

## Verified running

In a browser, end to end: opened the composer (empty, no auto-draft), typed an
intent, pressed Draft with AI (got a German draft honouring the intent), picked
Transactional, pressed Send. `GET /activities?entity_type=person` then shows
`email | outbound | Teamentwicklung bei Ihrem Unternehmen`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Person composer now actually sends, drafts only when asked, and applies consent per purpose. Old behavior: Send set local state and never sent; drafting fired on open; consent read the first email entry. New behavior: Send POSTs to /emails and shows Sending/Sent, drafting is a button with an optional intent, and the composer picks a consent purpose and gates on that; the page Email button allows if any purpose is allowed. Send failures now use the same actionable reasons as the company composer via shared helpers.

- Reviewer focus: frontend/src/screens/persondrawers.tsx (send mutation, purpose picker, draft bar, per‑purpose consent gating, shared refusal handling), frontend/src/screens/personpage.tsx (intent sentence mapping, any‑purpose allow check, pass intent to composer), frontend/src/screens/compose.tsx (exported `Refusal`, `refusalOf`, `SendRefusal`), frontend/src/screens/person360.css (draft row layout, inline error style), i18n updates in en/de/vi.
- Validate: send requires recipient, subject, body, and consent purpose; unknown action intents open empty; button shows Sending/Sent and disables after success; refusal messages render inline with actionable guidance for consent, mailbox reconnect, or shared unsubscribe.

<sup>Written for commit 2b06ed97ce30ac67ebda88d79c89223d28ac73ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1189?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Send emails directly from a person’s mailbox after selecting a consent purpose.
  - Optionally draft email content with AI using predefined intents such as agenda, reply, commitment, or follow-up.
  - Added localized composer guidance and messaging in English, German, and Vietnamese.

- **Bug Fixes**
  - Improved email consent handling when multiple consent entries are available.
  - Added validation for recipients, subject, message content, and consent purpose.

- **User Experience**
  - Added clear sending and sent states, error messages, and protection against duplicate sends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->