### PR TITLE
fix(email): the sender has a name on the envelope, not just in the signature

### DIFF
--- a/backend/internal/compose/commsjobs.go
+++ b/backend/internal/compose/commsjobs.go
@@ -347,6 +347,7 @@ func (s commsStager) StageTx(ctx context.Context, tx pgx.Tx, in activities.Deliv
 		Subject:         in.Subject,
 		Body:            in.Body,
 		HTMLBody:        in.HTMLBody,
+		FromName:        in.FromName,
 		ConsentPurpose:  in.ConsentPurpose,
 		InReplyTo:       in.InReplyTo,
 		References:      in.References,

--- a/backend/internal/compose/sendpath.go
+++ b/backend/internal/compose/sendpath.go
@@ -28,6 +28,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/modules/activities"
 	"github.com/gradionhq/margince/backend/internal/modules/ai"
 	"github.com/gradionhq/margince/backend/internal/modules/consent"
+	"github.com/gradionhq/margince/backend/internal/modules/identity"
 	"github.com/gradionhq/margince/backend/internal/modules/people"
 )
 
@@ -135,6 +136,7 @@ func sendStore(pool *pgxpool.Pool, send SendPath) *activities.Store {
 		// because the request arrived on the tool surface. An agent principal
 		// still signs nothing — signedBody decides that, not this wiring.
 		WithSignature(people.NewStore(InstallationDB(pool))).
+		WithSenderName(identity.NewServiceFor(InstallationDB(pool))).
 		WithDraftOutcome(send.DraftOutcome)
 }
 

--- a/backend/internal/compose/serverassembly.go
+++ b/backend/internal/compose/serverassembly.go
@@ -63,7 +63,12 @@ func newActivitiesHandlers(pool *pgxpool.Pool) activitiesHandlers {
 		// it owns the person the seat belongs to; activities appends it because
 		// it owns the one send. The edge is injected here rather than imported,
 		// like every other cross-module edge on this path.
-		WithSignature(people.NewStore(InstallationDB(pool)))
+		WithSignature(people.NewStore(InstallationDB(pool))).
+		// The name on the envelope. identity owns who the acting human is —
+		// including the human an agent acts on behalf of — and that resolution
+		// must be the same one the audit log records, so it is injected rather
+		// than re-derived here.
+		WithSenderName(identity.NewServiceFor(InstallationDB(pool)))
 }
 
 // wireCaptureSettingsSurface binds the workspace's own capture posture

--- a/backend/internal/modules/activities/email.go
+++ b/backend/internal/modules/activities/email.go
@@ -101,14 +101,17 @@ type DeliveryStager interface {
 // the authenticated principal at the far side of this seam, never named by
 // a caller, exactly as captured_by is stamped everywhere else.
 type DeliveryRequest struct {
-	ActivityID     ids.ActivityID
-	Provider       string
-	MessageID      string
-	Recipients     []string // To: only — the merged consent list minus Cc
-	Cc             []string
-	Subject        string
-	Body           string // the unsubscribe footer, when there is one, is already applied
-	HTMLBody       string // the markup alternative, empty for a plain-text send
+	ActivityID ids.ActivityID
+	Provider   string
+	MessageID  string
+	Recipients []string // To: only — the merged consent list minus Cc
+	Cc         []string
+	Subject    string
+	Body       string // the unsubscribe footer, when there is one, is already applied
+	HTMLBody   string // the markup alternative, empty for a plain-text send
+	// FromName is the sender's display name, snapshotted so a retry renders the
+	// same From header the first attempt did.
+	FromName       string
 	ConsentPurpose string
 	InReplyTo      string   // unbracketed; empty starts a conversation
 	References     []string // unbracketed ancestry, oldest first
@@ -234,9 +237,19 @@ func (s *Store) SendEmail(ctx context.Context, origin SendOrigin, in SendEmailIn
 		return crmcontracts.Activity{}, err
 	}
 
+	// Who the recipient sees this is from. Resolved here, beside the signature
+	// and before the transaction, because both answer "who is sending this" and
+	// a message whose header and sign-off named different people would be one
+	// message telling two stories.
+	fromName, err := s.senderDisplayName(ctx)
+	if err != nil {
+		return crmcontracts.Activity{}, err
+	}
+
 	message := outboundMessage{
 		in:              in,
 		messageID:       messageID,
+		fromName:        fromName,
 		body:            derived.transmitted,
 		recordedBody:    derived.recorded,
 		htmlBody:        htmlBody,

--- a/backend/internal/modules/activities/outboundmessage.go
+++ b/backend/internal/modules/activities/outboundmessage.go
@@ -34,7 +34,11 @@ type outboundMessage struct {
 	// carries the SAME sign-off and the same unsubscribe footer as body: two
 	// alternatives of one message that disagreed would be two messages, and the
 	// recipient's client decides which one they read.
-	htmlBody        string
+	htmlBody string
+	// fromName is who the recipient sees this is from. Resolved at send time
+	// from the authenticated sender rather than at transmit, so a rename
+	// between attempts cannot change a message already in flight.
+	fromName        string
 	listUnsubscribe string
 	to              []string
 	links           []ActivityLinkInput
@@ -94,6 +98,7 @@ func (m outboundMessage) delivery(activityID ids.UUID, chain threading) Delivery
 		Subject:         m.in.Subject,
 		Body:            m.body,
 		HTMLBody:        m.htmlBody,
+		FromName:        m.fromName,
 		ConsentPurpose:  m.in.ConsentPurpose,
 		InReplyTo:       chain.inReplyTo,
 		References:      chain.references,

--- a/backend/internal/modules/activities/sendername.go
+++ b/backend/internal/modules/activities/sendername.go
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package activities
+
+// Who the recipient sees a message is from.
+//
+// Separate from the signature seam beside it, and deliberately: a signature is
+// what the sender WROTE and this is who they ARE. They also come from different
+// owners — the signature is the person's own text, the display name is the seat
+// the identity module holds — and a message can honestly carry one without the
+// other.
+//
+// A From header with no display name shows the address's local part in every
+// mail client, so a message from lars@gradion.com arrives from "lars". The name
+// exists in app_user; this seam is how it reaches the wire.
+
+import "context"
+
+// SenderNameReader answers what the human behind this call is called.
+//
+// It takes no user id, unlike SignatureFor. The identity module resolves the
+// acting human itself — including the human an agent acts on behalf of — and
+// that resolution is the one this send must not second-guess: the name on the
+// envelope has to be the same human the audit log records.
+type SenderNameReader interface {
+	ActorIdentity(ctx context.Context) (name, email string, err error)
+}
+
+// WithSenderName wires the display name the From header carries. Compose calls
+// this; the zero Store sends a bare address, which is what every message did
+// before the name was available.
+func (s *Store) WithSenderName(reader SenderNameReader) *Store {
+	clone := *s
+	clone.senderName = reader
+	return &clone
+}
+
+// WithSenderName returns handlers whose send path names its sender.
+func (h Handlers) WithSenderName(reader SenderNameReader) Handlers {
+	h.store = h.store.WithSenderName(reader)
+	return h
+}
+
+// senderDisplayName resolves the name for this send, or empty.
+//
+// Empty is never an error. A system principal, a seat this workspace no longer
+// holds, and a member who has no display name on file all resolve to nothing —
+// and a bare address is a correct From header. Refusing to send because a name
+// could not be read would trade a cosmetic gap for a delivery failure.
+func (s *Store) senderDisplayName(ctx context.Context) (string, error) {
+	if s.senderName == nil {
+		return "", nil
+	}
+	name, _, err := s.senderName.ActorIdentity(ctx)
+	if err != nil {
+		return "", err
+	}
+	return name, nil
+}

--- a/backend/internal/modules/activities/sendername.go
+++ b/backend/internal/modules/activities/sendername.go
@@ -15,14 +15,18 @@ package activities
 // mail client, so a message from lars@gradion.com arrives from "lars". The name
 // exists in app_user; this seam is how it reaches the wire.
 
-import "context"
+import (
+	"context"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+)
 
 // SenderNameReader answers what the human behind this call is called.
 //
-// It takes no user id, unlike SignatureFor. The identity module resolves the
-// acting human itself — including the human an agent acts on behalf of — and
-// that resolution is the one this send must not second-guess: the name on the
-// envelope has to be the same human the audit log records.
+// It takes no user id, unlike SignatureFor: the identity module resolves the
+// acting human itself. Note that it resolves an AGENT to the human it acts for,
+// which is right for a draft and wrong for an envelope — senderDisplayName
+// below refuses that case rather than passing it through.
 type SenderNameReader interface {
 	ActorIdentity(ctx context.Context) (name, email string, err error)
 }
@@ -44,12 +48,29 @@ func (h Handlers) WithSenderName(reader SenderNameReader) Handlers {
 
 // senderDisplayName resolves the name for this send, or empty.
 //
-// Empty is never an error. A system principal, a seat this workspace no longer
-// holds, and a member who has no display name on file all resolve to nothing —
-// and a bare address is a correct From header. Refusing to send because a name
-// could not be read would trade a cosmetic gap for a delivery failure.
+// An agent send carries NO name, for the same reason it carries no signature:
+// it acts under a human's authority but it is not that human, and a message
+// arriving under somebody's name claims a hand that never touched it. The
+// approval authorizes the sending; it does not make the approver the author.
+// ActorIdentity resolves an agent to the human it acts for — which is right for
+// a draft, where the model needs to know who it writes AS — so the refusal has
+// to be made here rather than left to that resolution.
+//
+// The From header is the stronger claim of the two: a signature sits at the
+// bottom of a message somebody may not read, and this is the line the inbox
+// shows before anything is opened. Naming a human there while deliberately
+// withholding their sign-off below would be the same lie told louder.
+//
+// Empty is never an error otherwise. A system principal, a seat this workspace
+// no longer holds, and a member with no display name on file all resolve to
+// nothing — and a bare address is a correct From header. Refusing to send
+// because a name could not be read would trade a cosmetic gap for a delivery
+// failure.
 func (s *Store) senderDisplayName(ctx context.Context) (string, error) {
 	if s.senderName == nil {
+		return "", nil
+	}
+	if actor, ok := principal.Actor(ctx); !ok || actor.Type != principal.PrincipalHuman {
 		return "", nil
 	}
 	name, _, err := s.senderName.ActorIdentity(ctx)

--- a/backend/internal/modules/activities/signature_test.go
+++ b/backend/internal/modules/activities/signature_test.go
@@ -253,3 +253,54 @@ func TestAFailedSenderNameReadSurfaces(t *testing.T) {
 		t.Fatalf("expected the read error to surface, got %v", err)
 	}
 }
+
+// An agent send carries no name, for the same reason it carries no signature:
+// the approval authorizes the sending, it does not make the approver the author.
+// ActorIdentity resolves an agent to the human it acts for — right for a draft,
+// wrong for an envelope — so the refusal has to be made at this seam.
+func TestAnAgentSendCarriesNoSenderName(t *testing.T) {
+	reader := &stubSenderName{name: "Lars Jankowfsky"}
+	store := (&Store{}).WithSenderName(reader)
+	ctx := principal.WithActor(context.Background(), principal.Principal{
+		Type: principal.PrincipalAgent, ID: "agent:assistant", UserID: ids.NewV7(),
+	})
+
+	got, err := store.senderDisplayName(ctx)
+	if err != nil {
+		t.Fatalf("resolving the sender name failed: %v", err)
+	}
+	if got != "" {
+		t.Fatalf("an agent send was named %q", got)
+	}
+}
+
+// The header and the sign-off must agree about authorship. A message naming a
+// human on the envelope while deliberately withholding their signature below
+// would be the same claim told louder, in the line the inbox shows first.
+func TestTheEnvelopeAndTheSignOffAgreeAboutAuthorship(t *testing.T) {
+	store := (&Store{}).
+		WithSenderName(&stubSenderName{name: "Lars Jankowfsky"}).
+		WithSignature(&stubSignature{body: "Lars Jankowfsky"})
+
+	for name, ctx := range map[string]context.Context{
+		"human": humanCtx(ids.NewV7()),
+		"agent": principal.WithActor(context.Background(), principal.Principal{
+			Type: principal.PrincipalAgent, ID: "agent:assistant", UserID: ids.NewV7(),
+		}),
+	} {
+		t.Run(name, func(t *testing.T) {
+			envelope, err := store.senderDisplayName(ctx)
+			if err != nil {
+				t.Fatalf("resolving the sender name failed: %v", err)
+			}
+			signed, err := store.signedBody(ctx, "Body")
+			if err != nil {
+				t.Fatalf("signing the body failed: %v", err)
+			}
+			named := envelope != ""
+			if signedOff := signed != "Body"; named != signedOff {
+				t.Fatalf("envelope named=%v but signed=%v — the two disagree", named, signedOff)
+			}
+		})
+	}
+}

--- a/backend/internal/modules/activities/signature_test.go
+++ b/backend/internal/modules/activities/signature_test.go
@@ -208,3 +208,48 @@ func TestBothPartsCarryTheUnsubscribeSurface(t *testing.T) {
 		t.Fatalf("the markup part carries no unsubscribe surface: %q", got)
 	}
 }
+
+type stubSenderName struct {
+	name string
+	err  error
+}
+
+func (s *stubSenderName) ActorIdentity(context.Context) (string, string, error) {
+	return s.name, "", s.err
+}
+
+// The name reaches the send when identity knows it.
+func TestTheSenderNameIsResolvedForTheSend(t *testing.T) {
+	store := (&Store{}).WithSenderName(&stubSenderName{name: "Lars Jankowfsky"})
+
+	got, err := store.senderDisplayName(humanCtx(ids.NewV7()))
+	if err != nil {
+		t.Fatalf("resolving the sender name failed: %v", err)
+	}
+	if got != "Lars Jankowfsky" {
+		t.Fatalf("expected the sender's name, got %q", got)
+	}
+}
+
+// A role wired without the seam sends a bare address rather than refusing.
+func TestNoSenderNameReaderSendsUnnamed(t *testing.T) {
+	got, err := (&Store{}).senderDisplayName(humanCtx(ids.NewV7()))
+	if err != nil {
+		t.Fatalf("resolving the sender name failed: %v", err)
+	}
+	if got != "" {
+		t.Fatalf("a store with no reader produced a name: %q", got)
+	}
+}
+
+// A name that cannot be read is not a reason to refuse a send: the message is
+// correct without it, and trading a cosmetic gap for a delivery failure is the
+// worse answer. The error still surfaces rather than being swallowed.
+func TestAFailedSenderNameReadSurfaces(t *testing.T) {
+	boom := errors.New("identity is unreachable")
+	store := (&Store{}).WithSenderName(&stubSenderName{err: boom})
+
+	if _, err := store.senderDisplayName(humanCtx(ids.NewV7())); !errors.Is(err, boom) {
+		t.Fatalf("expected the read error to surface, got %v", err)
+	}
+}

--- a/backend/internal/modules/activities/store.go
+++ b/backend/internal/modules/activities/store.go
@@ -39,6 +39,9 @@ type Store struct {
 	// send; nil means unsigned, which is what every role did before the
 	// signature existed (WithSignature wires it).
 	signature SignatureReader
+	// senderName resolves the display name the From header carries; nil sends a
+	// bare address (WithSenderName wires it).
+	senderName SenderNameReader
 	// sendAuthority pre-flights the credential behind the transport a send is
 	// about to use; nil skips the pre-flight (WithSendAuthority wires it) and
 	// the delivery path still refuses at transmission.

--- a/backend/internal/modules/capture/gmail/multipart_test.go
+++ b/backend/internal/modules/capture/gmail/multipart_test.go
@@ -227,3 +227,75 @@ func TestABodyHoldingTheBoundaryForcesADifferentOne(t *testing.T) {
 		t.Fatalf("the chosen boundary still occurs in a part: %q", chosen)
 	}
 }
+
+// A bare From header shows the address's LOCAL PART in every mail client, so a
+// message from lars@gradion.com arrives from "lars" — which is what a recipient
+// reads first, before the signature at the bottom says who wrote it.
+func TestTheSenderIsNamedWhenTheNameIsKnown(t *testing.T) {
+	msg := plainMessage()
+	msg.FromName = "Lars Jankowfsky"
+
+	parsed := parseMail(t, buildRFC822("lars@gradion.test", msg))
+	addr, err := mail.ParseAddress(parsed.Header.Get("From"))
+	if err != nil {
+		t.Fatalf("the From header does not parse as an address: %v", err)
+	}
+	if addr.Name != "Lars Jankowfsky" {
+		t.Fatalf("the sender's name is %q", addr.Name)
+	}
+	if addr.Address != "lars@gradion.test" {
+		t.Fatalf("the sender's address changed: %q", addr.Address)
+	}
+}
+
+// A name with no ASCII spelling needs RFC 2047 encoding, exactly as the Subject
+// gets. Concatenated raw it is either mangled or rejected.
+func TestANonASCIISenderNameSurvivesTheWire(t *testing.T) {
+	msg := plainMessage()
+	msg.FromName = "Weiß Konrad"
+
+	raw := buildRFC822("weiss@gradion.test", msg)
+	if strings.Contains(raw, "From: Weiß") {
+		t.Fatalf("a non-ASCII name went out unencoded:\n%s", raw)
+	}
+	addr, err := mail.ParseAddress(parseMail(t, raw).Header.Get("From"))
+	if err != nil {
+		t.Fatalf("the From header does not parse: %v", err)
+	}
+	if addr.Name != "Weiß Konrad" {
+		t.Fatalf("the name did not survive the round trip: %q", addr.Name)
+	}
+}
+
+// A comma in a display name splits an unquoted header into TWO addresses, which
+// is a message from somebody the sender never named.
+func TestASenderNameWithACommaStaysOneAddress(t *testing.T) {
+	msg := plainMessage()
+	msg.FromName = "Jankowfsky, Lars"
+
+	header := parseMail(t, buildRFC822("lars@gradion.test", msg)).Header.Get("From")
+	list, err := mail.ParseAddressList(header)
+	if err != nil {
+		t.Fatalf("the From header does not parse: %v", err)
+	}
+	if len(list) != 1 {
+		t.Fatalf("a comma in the name produced %d addresses: %q", len(list), header)
+	}
+	if list[0].Name != "Jankowfsky, Lars" {
+		t.Fatalf("the name changed: %q", list[0].Name)
+	}
+}
+
+// No name on file sends a bare address, which is what every message did before
+// the name was available. `"" <addr>` would be worse than nothing.
+func TestNoSenderNameSendsABareAddress(t *testing.T) {
+	for name, given := range map[string]string{"unset": "", "only spaces": "   "} {
+		t.Run(name, func(t *testing.T) {
+			msg := plainMessage()
+			msg.FromName = given
+			if got := parseMail(t, buildRFC822("lars@gradion.test", msg)).Header.Get("From"); got != "lars@gradion.test" {
+				t.Fatalf("expected a bare address, got %q", got)
+			}
+		})
+	}
+}

--- a/backend/internal/modules/capture/gmail/send.go
+++ b/backend/internal/modules/capture/gmail/send.go
@@ -15,6 +15,7 @@ import (
 	"log/slog"
 	"mime"
 	"net/http"
+	"net/mail"
 	"net/url"
 	"slices"
 	"strings"
@@ -180,7 +181,7 @@ func bracket(id string) string {
 // text/plain UTF-8.
 func buildRFC822(from string, msg connector.EmailMessage) string {
 	var b strings.Builder
-	writeHeader(&b, "From", from)
+	writeHeader(&b, "From", fromHeader(from, msg.FromName))
 	writeHeader(&b, "To", addressList(msg.To))
 	if cc := addressList(msg.Cc); cc != "" {
 		writeHeader(&b, "Cc", cc)
@@ -294,6 +295,29 @@ func safeBoundary(msg connector.EmailMessage) string {
 func mimeBoundary(messageID string) string {
 	sum := sha256.Sum256([]byte(messageID))
 	return "--=_margince_" + hex.EncodeToString(sum[:12])
+}
+
+// fromHeader renders the sender, with their name when the CRM knows it.
+//
+// A bare address shows its LOCAL PART in every mail client — a message from
+// lars@gradion.com arrives from "lars" — which is what the recipient reads
+// first, before the signature at the bottom of the body says who actually
+// wrote it.
+//
+// mail.Address does the rendering rather than string concatenation, and that is
+// the whole reason this function exists: a name carrying a non-ASCII character
+// needs RFC 2047 encoding, and one carrying a comma or a quote needs quoting or
+// the header parses as TWO addresses. Both are easy to get wrong by hand and
+// impossible to get wrong this way.
+//
+// An empty name renders the bare address, which is what every message did
+// before the name was available. `"" <addr>` would be worse than nothing.
+func fromHeader(address, name string) string {
+	trimmed := strings.TrimSpace(name)
+	if trimmed == "" {
+		return address
+	}
+	return (&mail.Address{Name: trimmed, Address: address}).String()
 }
 
 // addressList renders one address header value: each address trimmed, empties

--- a/backend/internal/modules/comms/delivery.go
+++ b/backend/internal/modules/comms/delivery.go
@@ -33,6 +33,8 @@ type Delivery struct {
 	Body       string
 	// HTMLBody is the markup alternative, empty for a plain-text send.
 	HTMLBody string
+	// FromName is the sender's display name; empty sends a bare address.
+	FromName string
 	// Attachments is what this message was staged to carry. Empty for the
 	// overwhelming majority of deliveries; non-empty is what the carriage gate
 	// asks the channel about before anything reaches the wire.

--- a/backend/internal/modules/comms/sendseam.go
+++ b/backend/internal/modules/comms/sendseam.go
@@ -108,6 +108,7 @@ func (d *Dispatcher) resolveSeam(ctx context.Context, del Delivery) (sendSeam, e
 			return sender.SendEmail(ctx, auth, connector.EmailMessage{
 				To: del.Recipients, Cc: del.Cc,
 				Subject: del.Subject, Body: del.Body, HTMLBody: del.HTMLBody,
+				FromName:            del.FromName,
 				MessageID:           del.MessageID,
 				InReplyTo:           del.InReplyTo,
 				References:          del.References,

--- a/backend/internal/modules/comms/store.go
+++ b/backend/internal/modules/comms/store.go
@@ -99,6 +99,10 @@ type StageInput struct {
 	// never replaces Body: a retry rebuilds the message from this snapshot, so
 	// a shape stored here is the shape that goes out.
 	HTMLBody string
+	// FromName is the sender's display name at the moment of staging. Empty
+	// sends a bare address, which is what every message did before the name
+	// was available.
+	FromName string
 	// Attachments is the set this message will carry, snapshotted at staging.
 	// The dispatcher asks the resolved channel whether it can carry them before
 	// anything reaches the wire.
@@ -153,13 +157,13 @@ func (s *Store) StageTx(ctx context.Context, tx pgx.Tx, in StageInput) (ids.UUID
 	if _, err := tx.Exec(ctx, `
 		INSERT INTO comms_outbound
 		  (id, activity_id, user_id, provider, message_id,
-		   recipients, cc, subject, body, html_body, consent_purpose, in_reply_to,
+		   recipients, cc, subject, body, html_body, from_name, consent_purpose, in_reply_to,
 		   references_chain, thread_key, list_unsubscribe, status, created_at, attachments)
 		VALUES ($1, $2, $3, $4, $5,
-		        $6, $7, $8, $9, NULLIF($10,''), $11, NULLIF($12,''), $13, NULLIF($14,''),
-		        NULLIF($15,''), 'pending', $16, $17)`,
+		        $6, $7, $8, $9, NULLIF($10,''), NULLIF($11,''), $12, NULLIF($13,''), $14,
+		        NULLIF($15,''), NULLIF($16,''), 'pending', $17, $18)`,
 		id, in.ActivityID, userID, in.Provider, in.MessageID,
-		recipients, cc, in.Subject, in.Body, in.HTMLBody, in.ConsentPurpose,
+		recipients, cc, in.Subject, in.Body, in.HTMLBody, in.FromName, in.ConsentPurpose,
 		in.InReplyTo, refs, in.ThreadKey, in.ListUnsubscribe, s.now().UTC(), files); err != nil {
 		// The idempotency key is an ANSWER, and it is mapped rather than
 		// wrapped: a raw violation carries the constraint and table names, and
@@ -237,12 +241,13 @@ func (s *Store) Load(ctx context.Context, id ids.UUID) (Delivery, error) {
 			 WHERE id = $1 AND status = 'pending'
 			RETURNING id, activity_id, user_id, provider, coalesce(message_id, ''),
 			          coalesce(recipients, '[]'::jsonb), coalesce(cc, '[]'::jsonb),
-			          coalesce(subject, ''), body, coalesce(html_body, ''), channel_user_id, consent_purpose,
+			          coalesce(subject, ''), body, coalesce(html_body, ''), coalesce(from_name, ''),
+			          channel_user_id, consent_purpose,
 			          coalesce(in_reply_to, ''), coalesce(references_chain, '[]'::jsonb),
 			          coalesce(list_unsubscribe, ''), inflight_at, status, attempts, created_at,
 			          attachments`,
 			id).Scan(&d.ID, &d.ActivityID, &d.UserID, &d.Provider, &d.MessageID,
-			&recipients, &cc, &d.Subject, &d.Body, &d.HTMLBody, &d.ChannelUserID, &d.ConsentPurpose,
+			&recipients, &cc, &d.Subject, &d.Body, &d.HTMLBody, &d.FromName, &d.ChannelUserID, &d.ConsentPurpose,
 			&d.InReplyTo, &refs, &d.ListUnsubscribe, &d.InFlightAt, &d.Status, &d.Attempts, &d.CreatedAt,
 			&files)
 	})

--- a/backend/internal/modules/privacy/deliveries.go
+++ b/backend/internal/modules/privacy/deliveries.go
@@ -77,7 +77,10 @@ const parkedByPrivacyScrub = "content removed by a privacy scrub before this mes
 //
 // What deliberately STAYS is the proof that a message left: sent_at and
 // provider_message_id, plus the threading columns (message identities, like
-// the activity's own thread_key — not the subject's data). status stays too
+// the activity's own thread_key — not the subject's data). from_name stays for
+// the same reason: it names the workspace member who SENT the message, not the
+// person exercising erasure, and clearing it would destroy send-log evidence
+// while protecting nobody. status stays too
 // wherever it is already terminal: a message that went out did go out, and a
 // scrub that rewrote that would falsify the send log.
 //

--- a/backend/internal/modules/privacy/sar.go
+++ b/backend/internal/modules/privacy/sar.go
@@ -310,8 +310,10 @@ func sarMessagingSections(pkg *SARPackage) []sarSection {
 		// html_body rides beside body rather than instead of it: a message
 		// carrying both is ONE message the subject received in two renderings,
 		// and disclosing only the plain one withholds markup the system still
-		// holds about them.
-		{&pkg.SentMessages, `SELECT o.subject, o.body, o.html_body, o.recipients, o.cc, o.consent_purpose,
+		// holds about them. from_name joins them for the same reason: this
+		// projection discloses the message AS THE SUBJECT RECEIVED IT, and who
+		// it appeared to be from is part of what they were shown.
+		{&pkg.SentMessages, `SELECT o.subject, o.body, o.html_body, o.from_name, o.recipients, o.cc, o.consent_purpose,
 		      o.provider, o.channel_user_id, o.status, o.sent_at, o.created_at
 		   FROM comms_outbound o
 		   WHERE o.activity_id IN (SELECT l.activity_id FROM activity_link l WHERE l.person_id = $1)

--- a/backend/internal/shared/ports/connector/outbound.go
+++ b/backend/internal/shared/ports/connector/outbound.go
@@ -79,8 +79,16 @@ type OutboundFile struct {
 // JSON — so no caller ever builds MIME. It is the mirror of Normalize, which
 // owns decoding on the way in.
 type EmailMessage struct {
-	To      []string
-	Cc      []string
+	To []string
+	Cc []string
+	// FromName is the sender's display name, or empty to send a bare address.
+	//
+	// A From header with no display name shows the address's LOCAL PART in every
+	// mail client, so a message from lars@gradion.com arrives from "lars". The
+	// address itself is the connector's own (the connected mailbox); this is the
+	// human the CRM records as having sent it.
+	FromName string
+
 	Subject string
 	Body    string // text/plain; always present, and the only part a text client reads
 

--- a/backend/migrations/core/0237_comms_outbound_from_name.down.sql
+++ b/backend/migrations/core/0237_comms_outbound_from_name.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE comms_outbound DROP COLUMN from_name;

--- a/backend/migrations/core/0237_comms_outbound_from_name.up.sql
+++ b/backend/migrations/core/0237_comms_outbound_from_name.up.sql
@@ -1,0 +1,16 @@
+-- 0237: the staged message remembers who it is from, by name.
+--
+-- The From header carried a bare address, so every message this product sent
+-- arrived from the LOCAL PART of the mailbox — a mail from lars@gradion.com
+-- showed up as "lars". The name the CRM already holds (app_user.display_name)
+-- never reached the wire.
+--
+-- It is snapshotted here rather than resolved at transmit time for the same
+-- reason every other wire field is: a retry rebuilds the message from this row
+-- alone, and a sender who renames themselves between the first attempt and the
+-- second must not change what the recipient sees on a message already in
+-- flight.
+--
+-- NULL is a sender with no name on file, which renders the bare address exactly
+-- as before.
+ALTER TABLE comms_outbound ADD COLUMN from_name text NULL;


### PR DESCRIPTION
## The defect

Lars sent himself a mail and it arrived from **"lars"**.

`gmail.Send` passes `st.Owner` — which is `owner_email`, an address and nothing
else — into `buildRFC822`, which writes it raw. With no display name, every mail
client falls back to the address's local part.

The name was never missing: `app_user.display_name` holds it, and
`identity.ActorIdentity` already resolves it for the drafting surfaces. It simply
never reached the mailer.

**It undid the point of the signature** that shipped in #1193. A signature puts
the sender's name at the bottom of the message while the header above it reads
like a machine account — and the header is what a recipient sees first, in the
inbox list, before they open anything.

## Why `fromHeader` is a function

The rendering goes through `mail.Address`, not string concatenation:

- a name with a non-ASCII character needs RFC 2047 encoding, exactly as the
  Subject already gets
- a name with a comma or a quote needs quoting, **or the header parses as two
  addresses** — a message from somebody the sender never named

Both are easy to get wrong by hand and impossible to get wrong this way. An
empty name still renders the bare address: `"" <addr>` would be worse than
nothing.

## Snapshotted, not resolved at transmit

`from_name` is stored on the delivery row (core 0237) for the same reason every
other wire field is: a retry rebuilds the message from that row, and a sender who
renames themselves between attempts must not change what the recipient sees on a
message already in flight.

## Its own seam

`SenderNameReader`, not an extension of `SignatureReader`. A signature is what
the sender **wrote**; this is who they **are** — different owners, and a message
can honestly carry one without the other. `identity` resolves the acting human
including the one an agent acts on behalf of, so the name on the envelope is the
same human `captured_by` records.

Both send stores are wired, so the HTTP transport and the tool surface cannot
disagree about the sender.

## Verified on the wire

```
"Demo Admin"        -> From: "Demo Admin" <lars@gradion.com>
"Weiß Konrad"       -> From: =?utf-8?q?Wei=C3=9F_Konrad?= <lars@gradion.com>
"Jankowfsky, Lars"  -> From: "Jankowfsky, Lars" <lars@gradion.com>
""                  -> From: lars@gradion.com
```

Mutation-checked: replacing `mail.Address` with hand-built concatenation fails
both the non-ASCII and comma tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the sender’s display name in the email From header instead of a bare address; agent sends carry no name to match the no‑signature policy. Previously messages arrived from the address’s local part (e.g., "lars"); now we resolve the human name from identity, snapshot it at staging, and render it safely.

- Review and rollout
  - Run migration core `0237_comms_outbound_from_name` (adds `from_name` to `comms_outbound`; rollback included).
  - API/wire: add `FromName` to `connector.EmailMessage`, `comms.Delivery`, and staging input; `gmail.Send` builds From via `fromHeader` using `net/mail.Address` (RFC 2047 encoding and quoting).
  - Wiring: add `WithSenderName` seam; wire it with `identity.NewServiceFor` so HTTP and tool sends resolve the same name.
  - Behavior: empty/whitespace name sends a bare address; non‑human principals (agents) send unnamed; envelope/sign‑off agree on authorship; name read errors surface; retries reuse the stored name; signature behavior unchanged.
  - Data handling: SAR export includes `from_name`; privacy scrub retains `from_name` (send‑log evidence, not subject data).

<sup>Written for commit 7753d32af2ac1f3d793c3fb3c27329e6f544f267. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1208?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

