### PR TITLE
fix(person): the consent panel explains a refusal, it does not route around one

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -4467,11 +4467,11 @@ export const de = {
     "Mit dem Senden geht diese Nachricht aus Ihrem eigenen Postfach raus.",
   "person.composer.purpose": "Einwilligungszweck",
   "person.composer.blockedLead":
-    "Unter diesem Zweck können Sie nicht senden. Das geht:",
-  "person.composer.blockedSwitch": "Stattdessen als {purpose} senden",
-  "person.composer.blockedOpenConsent": "Einwilligung dieser Person öffnen",
-  "person.composer.blockedWaitForReply":
-    "Oder abwarten — Geschäftskorrespondenz öffnet sich von selbst, sobald die Person Ihnen schreibt.",
+    "Unter diesem Zweck kann diese Nachricht nicht rausgehen.",
+  "person.composer.blockedRewrite":
+    "Eine Nachricht unter einem anderen Zweck muss auch diese Art von Nachricht SEIN — sie umzuetikettieren macht sie nicht dazu.",
+  "person.composer.blockedRecordConsent":
+    "Wenn Sie eine Rechtsgrundlage haben, erfassen Sie die Einwilligungsentscheidung am Kontakt.",
   "person.composer.consentPickPurpose":
     "Wählen Sie, wofür diese Nachricht ist — die Einwilligung gilt je Zweck.",
   "person.composer.intent": "Worum soll es gehen?",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -4477,11 +4477,11 @@ export const en = {
     "Pressing send delivers this message from your own mailbox.",
   "person.composer.purpose": "Consent purpose",
   "person.composer.blockedLead":
-    "You cannot send under this purpose. What works:",
-  "person.composer.blockedSwitch": "Send as {purpose} instead",
-  "person.composer.blockedOpenConsent": "Open their consent record",
-  "person.composer.blockedWaitForReply":
-    "Or wait — business correspondence opens by itself once they write to you.",
+    "This message cannot go out under this purpose.",
+  "person.composer.blockedRewrite":
+    "A message sent under another purpose has to BE that kind of message — relabelling this one does not make it so.",
+  "person.composer.blockedRecordConsent":
+    "If you have a basis for writing, record the consent decision on their contact record.",
   "person.composer.consentPickPurpose":
     "Choose what this message is for — consent is decided per purpose.",
   "person.composer.intent": "What should it be about?",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -4450,12 +4450,11 @@ export const vi = {
   "person.composer.sendNote":
     "Khi bấm gửi, thư sẽ đi từ hộp thư của chính bạn.",
   "person.composer.purpose": "Mục đích đồng ý",
-  "person.composer.blockedLead":
-    "Bạn không thể gửi với mục đích này. Những cách khả thi:",
-  "person.composer.blockedSwitch": "Gửi với mục đích {purpose}",
-  "person.composer.blockedOpenConsent": "Mở hồ sơ đồng ý của họ",
-  "person.composer.blockedWaitForReply":
-    "Hoặc chờ — thư từ công việc sẽ tự mở khi họ viết cho bạn.",
+  "person.composer.blockedLead": "Thư này không thể gửi với mục đích đã chọn.",
+  "person.composer.blockedRewrite":
+    "Thư gửi với mục đích khác thì phải THỰC SỰ là loại thư đó — đổi nhãn không làm nó thành như vậy.",
+  "person.composer.blockedRecordConsent":
+    "Nếu bạn có cơ sở để viết, hãy ghi nhận quyết định đồng ý trên hồ sơ liên hệ.",
   "person.composer.consentPickPurpose":
     "Hãy chọn mục đích của thư này — sự đồng ý được xét theo từng mục đích.",
   "person.composer.intent": "Nội dung nên nói về điều gì?",

--- a/frontend/src/screens/persondrawers.tsx
+++ b/frontend/src/screens/persondrawers.tsx
@@ -201,18 +201,6 @@ function SendFailure({
   return <p className="pe-send-error">{problemMessageOf(error, t)}</p>;
 }
 
-// Every email purpose this person may currently be written to under.
-//
-// The guard answers per purpose and the composer already holds all of them, so
-// when the chosen one is refused it can name the ones that are not — which is
-// the difference between telling a rep they may not send and telling them what
-// would work.
-function allowedPurposes(guard: PersonConsentGuard | undefined) {
-  return (guard?.entries ?? []).filter(
-    (entry) => entry.channel === "email" && entry.verdict === "allowed",
-  );
-}
-
 // What to do about a send this person's consent state refuses.
 //
 // A verdict on its own is a dead end: the composer said why it would not send
@@ -226,43 +214,22 @@ function allowedPurposes(guard: PersonConsentGuard | undefined) {
 function ConsentWayOut({
   purpose,
   guard,
-  personId,
-  onPick,
 }: Readonly<{
   purpose: string;
   guard: PersonConsentGuard | undefined;
-  personId: string;
-  onPick: (purpose: string) => void;
 }>) {
   const t = useT();
-  if (purpose === "" || emailGuardFor(guard, purpose)?.verdict === "allowed") {
+  const entry = emailGuardFor(guard, purpose);
+  if (purpose === "" || entry === undefined || entry.verdict === "allowed") {
     return null;
   }
-  const alternatives = allowedPurposes(guard);
   return (
     <div className="pe-consent-wayout">
       <p className="t-caption">{t("person.composer.blockedLead")}</p>
       <ul className="pe-consent-moves">
-        {alternatives.map((entry) => (
-          <li key={entry.purpose_key}>
-            <button
-              type="button"
-              className="link-button"
-              onClick={() => onPick(entry.purpose_key ?? "")}
-            >
-              {t("person.composer.blockedSwitch", {
-                purpose: entry.purpose_label ?? entry.purpose_key ?? "",
-              })}
-            </button>
-          </li>
-        ))}
-        <li>
-          <a className="link-button" href={`#/contacts/${personId}`}>
-            {t("person.composer.blockedOpenConsent")}
-          </a>
-        </li>
+        <li className="t-caption">{t("person.composer.blockedRewrite")}</li>
         <li className="t-caption">
-          {t("person.composer.blockedWaitForReply")}
+          {t("person.composer.blockedRecordConsent")}
         </li>
       </ul>
     </div>
@@ -393,12 +360,7 @@ export function PersonComposer({
                 : t("person.composer.consentPickPurpose"))}
           </span>
         </div>
-        <ConsentWayOut
-          purpose={purpose}
-          guard={guard}
-          personId={personId}
-          onPick={setPurpose}
-        />
+        <ConsentWayOut purpose={purpose} guard={guard} />
       </div>
 
       <div className="drawer-body">

--- a/frontend/src/screens/personstrip.test.tsx
+++ b/frontend/src/screens/personstrip.test.tsx
@@ -19,7 +19,11 @@ type Person360 = components["schemas"]["Person360"];
 // — a participant row, a thread the person appears on — is what would split
 // them.
 
-function viewWith(directions: readonly string[]): Person360 {
+// The three directions the contract admits (Activity.direction), so the
+// fixture cannot drift into values the server never sends.
+type Direction = "inbound" | "outbound" | "internal";
+
+function viewWith(directions: readonly Direction[]): Person360 {
   return {
     person: { id: "p1", full_name: "Marine Raucoules" },
     activities: {
@@ -63,12 +67,12 @@ describe("the reciprocity reading", () => {
     expect(screen.getByText("0 in · 0 out")).toBeTruthy();
   });
 
-  // A row whose direction is neither is not evidence that they wrote: a note,
-  // a task, an internal record. Counting "not outbound" as inbound is the
-  // shape that would make the strip claim a message the consent gate cannot
-  // see — which is exactly the contradiction this pins.
-  it("counts a directionless row as neither", () => {
-    renderStrip(viewWith(["outbound", "internal", ""]));
+  // "internal" is a real direction the contract admits, and it is not evidence
+  // that they wrote to us. Counting "not outbound" as inbound is the shape that
+  // would make the strip claim a message the consent gate cannot see — which is
+  // exactly the contradiction this pins.
+  it("counts an internal row as neither", () => {
+    renderStrip(viewWith(["outbound", "internal"]));
 
     expect(screen.getByText("0 in · 1 out")).toBeTruthy();
   });


### PR DESCRIPTION
Fixes a **consent-gate bypass** I introduced in 36f6464a, caught by review.

## What was wrong

The blocked-send panel listed every purpose this person may be written to under,
one click each. That turned a blocked **marketing** message into a
**transactional** one without changing a word of it.

Consent is default-deny per purpose precisely so that the purpose describes the
message. The server takes `consent_purpose` from the client and must — a human
declares what a message is *for* — so the only thing between a marketing mail and
a transactional label is the rep's honesty. A one-click relabel of unchanged text
is a bypass with a helpful face on it.

## What it says now

The refusal, its reason, and the two things that are true: a message sent under
another purpose has to BE that kind of message, and a rep with a basis can record
the consent decision on the record.

## Two more from the same review

**The "wait for a reply" line was legally wrong.** An objection is evaluated
BEFORE any qualifying inbound event (`consent/verdict.go`), so a reply cannot lift
a withdrawal. Claiming otherwise is wrong exactly when a rep needs it right.

**A missing guard entry read as a refusal.** If the purpose catalog loads before
the guard, or the guard fails, picking a purpose announced "you cannot send"
before any verdict existed.

## Removed rather than fixed

"Open their consent record" pointed at `#/contacts/{id}` — the page the composer
is already open on. It closed nothing and opened nothing. A real consent
destination is worth having; a link pretending to be one is not.

## Process note

The two commits this fixes went to `main` directly. A `git switch -c` in a
compound command left the shell on `main`, so both landed there and the second
push reached `origin/main` with no PR and no review. This PR is that review's
output. Nothing in those commits touched the backend, schema or the send path.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops routing around consent: the blocked-send panel no longer offers purpose switching or a consent-record link. Instead, it explains the refusal and clarifies that sending under another purpose requires the message to actually be of that type.

- Panel shows only when a consent entry exists and the verdict is refused; it does not appear for missing guard entries.
- Removes the legally wrong “wait for a reply” guidance.
- Updates copy keys in `en`, `de`, and `vi`: replaces action links with `person.composer.blockedRewrite` and `person.composer.blockedRecordConsent`.
- Simplifies `ConsentWayOut` by removing purpose-listing and click-to-switch; no changes to backend or send path.
- Tightens tests: restricts activity directions to `"inbound" | "outbound" | "internal"` and asserts that `internal` does not count as inbound.

<sup>Written for commit 757f47306ec2cb8eafe813fe81599df80fef0122. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1209?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Improved consent-blocking messages in English, German, and Vietnamese.
  * Clarified when a selected message purpose is unavailable and explained that relabeling does not change the message category.
  * Added guidance to record consent on the contact profile.
  * Simplified the blocked-message guidance by removing unavailable alternative actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->