### PR TITLE
feat(voice): a writing sample can be handed to Settings, not only pasted

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -3671,6 +3671,33 @@ export const de = {
   "settings.voice.addSource": "Probe hinzufügen",
   "settings.voice.addFirstLabel": "Deine erste Schreibprobe",
   "settings.voice.addFirstCta": "Hinzufügen und Voice DNA starten",
+  "settings.voice.browseFiles": "Dateien auswählen",
+  "settings.voice.dropHint":
+    "Oder .txt-, .md-, .vtt-, .srt- oder .json-Dateien hier ablegen.",
+  "settings.voice.floorLabel":
+    "Fortschritt bis zum ersten Build ({min} Wörter)",
+  "settings.voice.floorProgress":
+    "{words} von {min} Wörtern bis zum ersten Build",
+  "settings.voice.speakerQuestion": "Wer bist du in „{name}“?",
+  "settings.voice.speakerDetail": "{words} Wörter, {turns} Beiträge",
+  "settings.voice.speakerConfirm": "Das bin ich",
+  "settings.voice.speakerDismiss": "Datei überspringen",
+  "settings.voice.noticeKept": "{name}: {kept} von {total} Wörtern übernommen.",
+  "settings.voice.noticeSkippedType":
+    "{name} wurde übersprungen – lesbar sind nur Textdateien.",
+  "settings.voice.noticeSkippedEmpty":
+    "{name} wurde übersprungen – die Datei enthält keinen Text.",
+  "settings.voice.noticeDismissed":
+    "{name} wurde übersprungen – nichts darin ließ sich dir zuordnen.",
+  "settings.voice.noticeFailed":
+    "{name} konnte nicht hinzugefügt werden: {detail}",
+  "settings.voice.noticeUnexpected": "{name} konnte nicht hinzugefügt werden.",
+  "settings.voice.refusalUnattributed":
+    "{name} ist ein Gespräch, und nichts darin ließ sich dir zuordnen – deshalb wurde nichts übernommen.",
+  "settings.voice.refusalSpeaker":
+    "Diese Person kommt in {name} nicht vor, es wurde nichts übernommen.",
+  "settings.voice.refusalUnsupported":
+    "{name} liegt in einem Format vor, das nicht gelesen werden kann.",
   "settings.voice.buildsTitle": "Builds",
   "settings.voice.building": "Baue…",
   "settings.voice.rebuild": "Voice DNA neu bauen",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -3681,6 +3681,29 @@ export const en = {
   "settings.voice.addSource": "Add sample",
   "settings.voice.addFirstLabel": "Your first writing sample",
   "settings.voice.addFirstCta": "Add it and start my Voice DNA",
+  "settings.voice.browseFiles": "Choose files",
+  "settings.voice.dropHint":
+    "Or drop .txt, .md, .vtt, .srt or .json files here.",
+  "settings.voice.floorLabel": "Progress towards the first build ({min} words)",
+  "settings.voice.floorProgress": "{words} of {min} words to a first build",
+  "settings.voice.speakerQuestion": "Which speaker are you in “{name}”?",
+  "settings.voice.speakerDetail": "{words} words, {turns} turns",
+  "settings.voice.speakerConfirm": "That one is me",
+  "settings.voice.speakerDismiss": "Skip this file",
+  "settings.voice.noticeKept": "{name}: kept {kept} of {total} words.",
+  "settings.voice.noticeSkippedType":
+    "{name} was skipped — only text files can be read.",
+  "settings.voice.noticeSkippedEmpty": "{name} was skipped — it has no text.",
+  "settings.voice.noticeDismissed":
+    "{name} was skipped — nothing in it could be attributed to you.",
+  "settings.voice.noticeFailed": "{name} could not be added: {detail}",
+  "settings.voice.noticeUnexpected": "{name} could not be added.",
+  "settings.voice.refusalUnattributed":
+    "{name} is a conversation, and none of it could be attributed to you — so none of it was added.",
+  "settings.voice.refusalSpeaker":
+    "That speaker was not found in {name}, so nothing was added.",
+  "settings.voice.refusalUnsupported":
+    "{name} is not a format the corpus can read.",
   "settings.voice.buildsTitle": "Builds",
   "settings.voice.building": "Building…",
   "settings.voice.rebuild": "Rebuild Voice DNA",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -3660,6 +3660,30 @@ export const vi = {
   "settings.voice.addSource": "Thêm mẫu văn",
   "settings.voice.addFirstLabel": "Mẫu văn đầu tiên của bạn",
   "settings.voice.addFirstCta": "Thêm và bắt đầu Voice DNA của tôi",
+  "settings.voice.browseFiles": "Chọn tệp",
+  "settings.voice.dropHint":
+    "Hoặc thả tệp .txt, .md, .vtt, .srt hay .json vào đây.",
+  "settings.voice.floorLabel": "Tiến độ tới bản dựng đầu tiên ({min} từ)",
+  "settings.voice.floorProgress": "{words} trên {min} từ tới bản dựng đầu tiên",
+  "settings.voice.speakerQuestion": "Bạn là người nói nào trong “{name}”?",
+  "settings.voice.speakerDetail": "{words} từ, {turns} lượt",
+  "settings.voice.speakerConfirm": "Đó là tôi",
+  "settings.voice.speakerDismiss": "Bỏ qua tệp này",
+  "settings.voice.noticeKept": "{name}: giữ {kept} trên {total} từ.",
+  "settings.voice.noticeSkippedType":
+    "Đã bỏ qua {name} — chỉ đọc được tệp văn bản.",
+  "settings.voice.noticeSkippedEmpty":
+    "Đã bỏ qua {name} — tệp không có nội dung.",
+  "settings.voice.noticeDismissed":
+    "Đã bỏ qua {name} — không phần nào trong đó quy được cho bạn.",
+  "settings.voice.noticeFailed": "Không thêm được {name}: {detail}",
+  "settings.voice.noticeUnexpected": "Không thêm được {name}.",
+  "settings.voice.refusalUnattributed":
+    "{name} là một cuộc trò chuyện, và không phần nào quy được cho bạn — nên không có gì được thêm vào.",
+  "settings.voice.refusalSpeaker":
+    "Không tìm thấy người nói đó trong {name}, nên không có gì được thêm vào.",
+  "settings.voice.refusalUnsupported":
+    "{name} có định dạng mà kho văn bản không đọc được.",
   "settings.voice.buildsTitle": "Bản dựng",
   "settings.voice.building": "Đang dựng…",
   "settings.voice.rebuild": "Dựng lại Voice DNA",

--- a/frontend/src/screens/onboarding-conversation/onboarding-restore.test.tsx
+++ b/frontend/src/screens/onboarding-conversation/onboarding-restore.test.tsx
@@ -247,6 +247,17 @@ function stubApi(options: StubOptions = {}) {
       if (path.includes("/voice-profiles/") && path.endsWith("/versions")) {
         return jsonResponse({ data: options.voiceVersions ?? [], page: {} });
       }
+      // Every source is previewed before it is written, pasted text included:
+      // the server is the one that says whether writing carries speakers.
+      if (path.endsWith("/sources/preview")) {
+        return jsonResponse({
+          detected_format: "txt",
+          total_words: options.pasteWords ?? 0,
+          speakers: [],
+          unattributed_words: options.pasteWords ?? 0,
+          ingestible_as_transcript: false,
+        });
+      }
       if (
         path.includes("/voice-profiles/") &&
         path.endsWith("/sources") &&

--- a/frontend/src/screens/onboarding-conversation/use-voice-corpus.ts
+++ b/frontend/src/screens/onboarding-conversation/use-voice-corpus.ts
@@ -9,8 +9,7 @@ import {
   intakeTranscript,
   intakeUpload,
   isAcceptedCorpusFile,
-  pasteRef,
-  uploadRef,
+  sourceRef,
 } from "../voice-intake-core";
 import type {
   ConversationEvent,
@@ -94,7 +93,6 @@ export function useVoiceCorpus({
   const [asks, setAsks] = useState<readonly SpeakerAsk[]>([]);
   const [probesInFlight, setProbesInFlight] = useState(0);
   const summaryRef = useRef<CorpusSummary | null>(initialSummary);
-  const pasteSeq = useRef(0);
   const mounted = useRef(true);
   useEffect(() => {
     mounted.current = true;
@@ -231,18 +229,27 @@ export function useVoiceCorpus({
     [dispatch, recordIngest, say],
   );
 
-  // Every intake path stamps its request at issue time, so a stale response
-  // arriving late cannot roll the meter backwards.
+  // Each intake is stamped when its INGEST is issued, and only the
+  // newest-stamped summary may drive the meter. A response that settles late
+  // carries the corpus as it stood when the server answered it, so applying it
+  // after a newer one would roll the displayed total — and the build gate that
+  // reads it — backwards. The stamp is taken inside the core's ingest call
+  // rather than here at intake start, because a file that reads and previews
+  // slowly has not written anything yet: ordering it by when the reader picked
+  // it would let a preview delay decide which summary wins.
   const runIntake = useCallback(
     (
-      start: () => Promise<IntakeOutcome>,
+      start: (stamp: () => number) => Promise<IntakeOutcome>,
       reactionKey: MessageKey,
       failureId: string,
     ): void => {
-      ingestSeq.current += 1;
-      const seq = ingestSeq.current;
       setProbesInFlight((count) => count + 1);
-      start()
+      let seq = 0;
+      start(() => {
+        ingestSeq.current += 1;
+        seq = ingestSeq.current;
+        return seq;
+      })
         .then((outcome) => applyOutcome(seq, outcome, reactionKey))
         .catch((err: unknown) => {
           if (mounted.current) {
@@ -270,12 +277,26 @@ export function useVoiceCorpus({
           });
           continue;
         }
-        const ref = uploadRef("onboarding", file.name);
-        dispatch({ type: "UPLOAD_ADDED", id: ref, name: file.name });
+        // The thread shows the file the moment it is handed over, before its
+        // content has been read — so the bubble is identified by name, while
+        // the SOURCE it becomes is keyed by what is in it.
+        dispatch({
+          type: "UPLOAD_ADDED",
+          id: `onboarding:upload:${file.name}`,
+          name: file.name,
+        });
         runIntake(
-          async () => intakeUpload(ref, file.name, await file.text()),
+          async (stamp) => {
+            const text = await file.text();
+            return intakeUpload(
+              sourceRef("upload", text),
+              file.name,
+              text,
+              stamp,
+            );
+          },
           "ob.conv.voice.reactionDocument",
-          `refuse:${ref}`,
+          `refuse:onboarding:upload:${file.name}`,
         );
       }
     },
@@ -284,11 +305,10 @@ export function useVoiceCorpus({
 
   const addPaste = useCallback(
     (text: string, label: string) => {
-      pasteSeq.current += 1;
-      const ref = pasteRef("onboarding", pasteSeq.current);
+      const ref = sourceRef("paste", text);
       dispatch({ type: "UPLOAD_ADDED", id: ref, name: label });
       runIntake(
-        () => intakePaste(ref, label, text),
+        (stamp) => intakePaste(ref, label, text, stamp),
         "ob.conv.voice.reactionDocument",
         `refuse:${ref}`,
       );
@@ -336,7 +356,8 @@ export function useVoiceCorpus({
       }
       setAsks((prev) => prev.filter((candidate) => candidate.ref !== ask.ref));
       runIntake(
-        () => intakeTranscript(ask.ref, ask.label, ask.content, value),
+        (stamp) =>
+          intakeTranscript(ask.ref, ask.label, ask.content, value, stamp),
         "ob.conv.voice.reactionTranscript",
         `refuse:${ask.ref}`,
       );

--- a/frontend/src/screens/onboarding-conversation/use-voice-corpus.ts
+++ b/frontend/src/screens/onboarding-conversation/use-voice-corpus.ts
@@ -1,11 +1,17 @@
 import type { Dispatch } from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { api } from "../../api/client";
 import type { components } from "../../api/schema";
 import type { MessageKey } from "../../i18n/en";
 import { problemMessage } from "../common";
-import { ACCEPTED_CORPUS_FILE, TRANSCRIPT_EXT } from "../onboarding";
-import { ensureProfileId } from "../voice-profile";
+import type { IntakeOutcome, RefusalReason } from "../voice-intake-core";
+import {
+  intakePaste,
+  intakeTranscript,
+  intakeUpload,
+  isAcceptedCorpusFile,
+  pasteRef,
+  uploadRef,
+} from "../voice-intake-core";
 import type {
   ConversationEvent,
   ConversationState,
@@ -23,11 +29,6 @@ import { diffCorpus, useNarrationQueue } from "./narration";
 type CorpusPreview = components["schemas"]["VoiceCorpusPreviewResult"];
 type CorpusSummary = components["schemas"]["VoiceCorpusSummary"];
 type IngestStats = components["schemas"]["VoiceIngestStats"];
-type IngestRequest = components["schemas"]["IngestVoiceCorpusSourceRequest"];
-
-// A .txt is treated as a transcript when the preview attributes at least
-// this share of its spoken words to labelled speakers.
-const ATTRIBUTED_SHARE = 0.8;
 
 export type CorpusManifestEntry = Readonly<{
   ref: string;
@@ -55,53 +56,24 @@ type UseVoiceCorpusArgs = Readonly<{
   initialSummary?: CorpusSummary | null;
 }>;
 
-const refusalKeys: Record<string, MessageKey> = {
-  unattributed_transcript: "ob.conv.voice.refusalUnattributed",
-  speaker_label_required: "ob.conv.voice.refusalUnattributed",
-  speaker_not_found: "ob.conv.voice.refusalSpeaker",
-  unsupported_format: "ob.conv.voice.refusalUnsupported",
+const refusalKeys: Record<RefusalReason, MessageKey> = {
+  unattributed: "ob.conv.voice.refusalUnattributed",
+  speaker: "ob.conv.voice.refusalSpeaker",
+  unsupported: "ob.conv.voice.refusalUnsupported",
 };
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
-}
-
-// Every stable machine code an RFC 7807 body carries: the top-level `code`
-// plus any per-field `details.errors[].code`.
-function problemCodes(problem: unknown): string[] {
-  if (!isRecord(problem)) {
-    return [];
-  }
-  const codes: string[] = [];
-  if (typeof problem.code === "string") {
-    codes.push(problem.code);
-  }
-  const details = problem.details;
-  if (isRecord(details) && Array.isArray(details.errors)) {
-    for (const raw of details.errors) {
-      if (isRecord(raw) && typeof raw.code === "string") {
-        codes.push(raw.code);
-      }
-    }
-  }
-  return codes;
-}
-
-// The 422's stable machine code (top-level or per-field in details.errors)
-// picks the honest refusal line; an unknown code falls back to the server's
-// safe detail.
+// The refusal category the core read off the 422 picks the honest line; a
+// refusal it did not recognize falls back to the server's own safe detail.
 function refusalEntry(
   ref: string,
+  reason: RefusalReason | null,
   problem: unknown,
 ): Extract<ConversationEvent, { type: "NARRATION" }>["entry"] {
-  const known = problemCodes(problem).find(
-    (code) => refusalKeys[code] !== undefined,
-  );
-  if (known !== undefined) {
+  if (reason !== null) {
     return {
       kind: "narration",
       id: `refuse:${ref}`,
-      i18nKey: refusalKeys[known],
+      i18nKey: refusalKeys[reason],
     };
   }
   return {
@@ -110,27 +82,6 @@ function refusalEntry(
     i18nKey: "ob.conv.voice.ingestFailed",
     params: { detail: problemMessage(problem) },
   };
-}
-
-// What one previewed file honestly IS: a conversational source needs the
-// speaker answer first; a transcript-shaped file nobody is attributable in
-// is refused whole (none of it can be proven the owner's own words); and
-// single-author prose ingests directly.
-function routePreview(
-  name: string,
-  preview: CorpusPreview,
-): "ask-speaker" | "refuse" | "document" {
-  const attributedWords = preview.speakers.reduce(
-    (sum, speaker) => sum + speaker.words,
-    0,
-  );
-  const conversational =
-    TRANSCRIPT_EXT.test(name) ||
-    attributedWords >= preview.total_words * ATTRIBUTED_SHARE;
-  if (conversational && preview.ingestible_as_transcript) {
-    return "ask-speaker";
-  }
-  return TRANSCRIPT_EXT.test(name) ? "refuse" : "document";
 }
 
 export function useVoiceCorpus({
@@ -229,165 +180,73 @@ export function useVoiceCorpus({
     [queue, say],
   );
 
-  const ingest = useCallback(
-    async (
-      body: IngestRequest,
-      transcript: boolean,
-      reactionKey: MessageKey,
-    ): Promise<void> => {
-      ingestSeq.current += 1;
-      const seq = ingestSeq.current;
-      const profileId = await ensureProfileId();
-      const { data, error } = await api.POST("/voice-profiles/{id}/sources", {
-        params: { path: { id: profileId } },
-        body,
-      });
-      if (error) {
-        if (mounted.current) {
-          dispatch({
-            type: "NARRATION",
-            entry: refusalEntry(body.source_ref, error),
-          });
-        }
+  // One place the conversation learns what an intake attempt ended as: the
+  // core decides, this translates the verdict into what the thread says.
+  const applyOutcome = useCallback(
+    (seq: number, outcome: IntakeOutcome, reactionKey: MessageKey): void => {
+      if (!mounted.current) {
+        return;
+      }
+      if (outcome.kind === "skipped") {
+        say(`skip:${outcome.label}`, "ob.conv.voice.fileEmpty", {
+          name: outcome.label,
+        });
+        return;
+      }
+      if (outcome.kind === "refused") {
+        dispatch({
+          type: "NARRATION",
+          entry: refusalEntry(outcome.ref, outcome.reason, outcome.problem),
+        });
+        return;
+      }
+      if (outcome.kind === "speaker-needed") {
+        // A re-upload under the same name supersedes its pending question;
+        // the ingest itself is idempotent on source_ref server-side.
+        setAsks((prev) => [
+          ...prev.filter((ask) => ask.ref !== outcome.ref),
+          {
+            ref: outcome.ref,
+            label: outcome.label,
+            content: outcome.content,
+            preview: outcome.preview,
+          },
+        ]);
         return;
       }
       recordIngest(
         seq,
         {
-          ref: body.source_ref,
-          label: body.source_label,
-          keptWords: data.ingest_stats.kept_words,
-          inputWords: data.ingest_stats.input_words,
-          transcript,
+          ref: outcome.ref,
+          label: outcome.label,
+          keptWords: outcome.stats.kept_words,
+          inputWords: outcome.stats.input_words,
+          transcript: outcome.transcript,
         },
-        data.ingest_stats,
-        data.summary,
+        outcome.stats,
+        outcome.summary,
         reactionKey,
       );
     },
-    [dispatch, recordIngest],
+    [dispatch, recordIngest, say],
   );
 
-  // Preview one accepted file and act on what it honestly IS (routePreview);
-  // the empty pre-gate is the only client-side counting anywhere.
-  const classifyUpload = useCallback(
-    async (name: string, text: string): Promise<void> => {
-      const ref = `onboarding:upload:${name}`;
-      if (text.split(/\s+/).filter(Boolean).length === 0) {
-        say(`skip:${name}`, "ob.conv.voice.fileEmpty", { name });
-        return;
-      }
-      const profileId = await ensureProfileId();
-      const { data, error } = await api.POST(
-        "/voice-profiles/{id}/sources/preview",
-        {
-          params: { path: { id: profileId } },
-          body: { format: "transcript", content: text },
-        },
-      );
-      if (error) {
-        if (mounted.current) {
-          dispatch({ type: "NARRATION", entry: refusalEntry(ref, error) });
-        }
-        return;
-      }
-      if (!mounted.current) {
-        return;
-      }
-      const route = routePreview(name, data);
-      if (route === "ask-speaker") {
-        // A re-upload under the same name supersedes its pending question;
-        // the ingest itself is idempotent on source_ref server-side.
-        setAsks((prev) => [
-          ...prev.filter((ask) => ask.ref !== ref),
-          { ref, label: name, content: text, preview: data },
-        ]);
-        return;
-      }
-      if (route === "refuse") {
-        say(`refuse:${ref}`, "ob.conv.voice.refusalUnattributed");
-        return;
-      }
-      await ingest(
-        {
-          kind: "document",
-          register: "general",
-          weight: 1,
-          source_label: name,
-          source_ref: ref,
-          format: "text",
-          speaker_label: null,
-          content: text,
-        },
-        false,
-        "ob.conv.voice.reactionDocument",
-      );
-    },
-    [dispatch, ingest, say],
-  );
-
-  // One intake for all three entry paths: the attach button, a drop onto the
-  // thread, and (via addPaste) the composer. V1 corpus is text only;
-  // anything else is refused by name.
-  const addFiles = useCallback(
-    (files: readonly File[]) => {
-      for (const file of files) {
-        if (!ACCEPTED_CORPUS_FILE.test(file.name)) {
-          say(`skip:${file.name}`, "ob.conv.voice.fileSkipped", {
-            name: file.name,
-          });
-          continue;
-        }
-        dispatch({
-          type: "UPLOAD_ADDED",
-          id: `onboarding:upload:${file.name}`,
-          name: file.name,
-        });
-        setProbesInFlight((count) => count + 1);
-        file
-          .text()
-          .then((text) => classifyUpload(file.name, text))
-          .catch((err: unknown) => {
-            if (mounted.current) {
-              sayUnexpectedFailure(
-                `refuse:onboarding:upload:${file.name}`,
-                err,
-              );
-            }
-          })
-          .finally(() => {
-            if (mounted.current) {
-              setProbesInFlight((count) => count - 1);
-            }
-          });
-      }
-    },
-    [classifyUpload, dispatch, say, sayUnexpectedFailure],
-  );
-
-  const addPaste = useCallback(
-    (text: string, label: string) => {
-      pasteSeq.current += 1;
-      const ref = `onboarding:paste:${pasteSeq.current}`;
-      dispatch({ type: "UPLOAD_ADDED", id: ref, name: label });
+  // Every intake path stamps its request at issue time, so a stale response
+  // arriving late cannot roll the meter backwards.
+  const runIntake = useCallback(
+    (
+      start: () => Promise<IntakeOutcome>,
+      reactionKey: MessageKey,
+      failureId: string,
+    ): void => {
+      ingestSeq.current += 1;
+      const seq = ingestSeq.current;
       setProbesInFlight((count) => count + 1);
-      void ingest(
-        {
-          kind: "other",
-          register: "general",
-          weight: 1,
-          source_label: label,
-          source_ref: ref,
-          format: "text",
-          speaker_label: null,
-          content: text,
-        },
-        false,
-        "ob.conv.voice.reactionDocument",
-      )
+      start()
+        .then((outcome) => applyOutcome(seq, outcome, reactionKey))
         .catch((err: unknown) => {
           if (mounted.current) {
-            sayUnexpectedFailure(`refuse:${ref}`, err);
+            sayUnexpectedFailure(failureId, err);
           }
         })
         .finally(() => {
@@ -396,7 +255,45 @@ export function useVoiceCorpus({
           }
         });
     },
-    [dispatch, ingest, sayUnexpectedFailure],
+    [applyOutcome, sayUnexpectedFailure],
+  );
+
+  // One intake for all three entry paths: the attach button, a drop onto the
+  // thread, and (via addPaste) the composer. V1 corpus is text only;
+  // anything else is refused by name.
+  const addFiles = useCallback(
+    (files: readonly File[]) => {
+      for (const file of files) {
+        if (!isAcceptedCorpusFile(file.name)) {
+          say(`skip:${file.name}`, "ob.conv.voice.fileSkipped", {
+            name: file.name,
+          });
+          continue;
+        }
+        const ref = uploadRef("onboarding", file.name);
+        dispatch({ type: "UPLOAD_ADDED", id: ref, name: file.name });
+        runIntake(
+          async () => intakeUpload(ref, file.name, await file.text()),
+          "ob.conv.voice.reactionDocument",
+          `refuse:${ref}`,
+        );
+      }
+    },
+    [dispatch, runIntake, say],
+  );
+
+  const addPaste = useCallback(
+    (text: string, label: string) => {
+      pasteSeq.current += 1;
+      const ref = pasteRef("onboarding", pasteSeq.current);
+      dispatch({ type: "UPLOAD_ADDED", id: ref, name: label });
+      runIntake(
+        () => intakePaste(ref, label, text),
+        "ob.conv.voice.reactionDocument",
+        `refuse:${ref}`,
+      );
+    },
+    [dispatch, runIntake],
   );
 
   // The machine holds ONE pending question, so speaker asks queue here and
@@ -438,33 +335,13 @@ export function useVoiceCorpus({
         return;
       }
       setAsks((prev) => prev.filter((candidate) => candidate.ref !== ask.ref));
-      setProbesInFlight((count) => count + 1);
-      void ingest(
-        {
-          kind: "transcript",
-          register: "spoken",
-          weight: 1,
-          source_label: ask.label,
-          source_ref: ask.ref,
-          format: "transcript",
-          speaker_label: value,
-          content: ask.content,
-        },
-        true,
+      runIntake(
+        () => intakeTranscript(ask.ref, ask.label, ask.content, value),
         "ob.conv.voice.reactionTranscript",
-      )
-        .catch((err: unknown) => {
-          if (mounted.current) {
-            sayUnexpectedFailure(`refuse:${ask.ref}`, err);
-          }
-        })
-        .finally(() => {
-          if (mounted.current) {
-            setProbesInFlight((count) => count - 1);
-          }
-        });
+        `refuse:${ask.ref}`,
+      );
     },
-    [asks, ingest, sayUnexpectedFailure],
+    [asks, runIntake],
   );
 
   return {

--- a/frontend/src/screens/onboarding-conversation/voice-act.tsx
+++ b/frontend/src/screens/onboarding-conversation/voice-act.tsx
@@ -1,9 +1,10 @@
 import type { ChangeEvent, Dispatch, RefObject } from "react";
-import { useEffect, useRef, useState } from "react";
+import { useRef } from "react";
 import type { components } from "../../api/schema";
 import { useT } from "../../i18n";
 import { problemMessageOf } from "../common";
-import { VOICE_MIN_WORDS } from "../onboarding";
+import { useFileDrop } from "../use-file-drop";
+import { VOICE_MIN_WORDS } from "../voice-intake-core";
 import type {
   ConversationEvent,
   ConversationState,
@@ -48,7 +49,6 @@ export function VoiceAct({ state, dispatch, initialSummary }: VoiceActProps) {
   machine.current = state;
   const corpus = useVoiceCorpus({ state, dispatch, initialSummary });
   const build = useVoiceBuild({ dispatch, machine });
-  const [dragOver, setDragOver] = useState(false);
   const fileRef = useRef<HTMLInputElement>(null);
 
   const collecting =
@@ -66,50 +66,16 @@ export function VoiceAct({ state, dispatch, initialSummary }: VoiceActProps) {
   };
 
   // The scene promises "drop files anywhere in this conversation", so the
-  // WHOLE window is the drop target — a file landing on the rail, the
-  // artifact panel, or a layout gap must feed the corpus, and outside the
-  // collecting phases a stray drop must still be neutralized: the browser's
-  // default is to NAVIGATE to the dropped file, which would tear the user
-  // out of the onboarding mid-act.
-  const { addFiles } = corpus;
-  useEffect(() => {
-    // Only FILE drags are claimed: dragging selected text elsewhere on the
-    // page is a native interaction this act must not swallow.
-    const isFileDrag = (event: globalThis.DragEvent) =>
-      event.dataTransfer?.types.includes("Files") ?? false;
-    const onDragOver = (event: globalThis.DragEvent) => {
-      if (!isFileDrag(event)) {
-        return;
-      }
-      event.preventDefault();
-      setDragOver(collecting);
-    };
-    const onDragLeave = (event: globalThis.DragEvent) => {
-      // relatedTarget is null only when the drag exits the window; moving
-      // between elements inside it must not flicker the affordance off.
-      if (event.relatedTarget === null) {
-        setDragOver(false);
-      }
-    };
-    const onDrop = (event: globalThis.DragEvent) => {
-      if (!isFileDrag(event)) {
-        return;
-      }
-      event.preventDefault();
-      setDragOver(false);
-      if (collecting) {
-        addFiles(Array.from(event.dataTransfer?.files ?? []));
-      }
-    };
-    window.addEventListener("dragover", onDragOver);
-    window.addEventListener("dragleave", onDragLeave);
-    window.addEventListener("drop", onDrop);
-    return () => {
-      window.removeEventListener("dragover", onDragOver);
-      window.removeEventListener("dragleave", onDragLeave);
-      window.removeEventListener("drop", onDrop);
-    };
-  }, [collecting, addFiles]);
+  // WHOLE window is the drop target (container null) — a file landing on the
+  // rail, the artifact panel, or a layout gap must feed the corpus. Outside
+  // the collecting phases a stray drop is still neutralized: the browser's
+  // default is to NAVIGATE to the dropped file, which would tear the user out
+  // of the onboarding mid-act.
+  const { dragOver } = useFileDrop({
+    container: null,
+    active: collecting,
+    onFiles: corpus.addFiles,
+  });
 
   const handleAnswer = (questionId: string, value: string) => {
     dispatch({ type: "QUESTION_ANSWERED", questionId, value });

--- a/frontend/src/screens/onboarding-conversation/voice-scenes.tsx
+++ b/frontend/src/screens/onboarding-conversation/voice-scenes.tsx
@@ -6,9 +6,9 @@ import { Button, Disclosure } from "../../design-system/atoms";
 import { MarginceCoreScene } from "../../design-system/margince-core";
 import { usePrefersReducedMotion } from "../../design-system/motion";
 import { useT } from "../../i18n";
-import { ACCEPTED_CORPUS_ATTR, VOICE_MIN_WORDS } from "../onboarding";
 import type { VoiceInsightsData } from "../voice-insights";
 import { parseVoiceInsights } from "../voice-insights";
+import { ACCEPTED_CORPUS_ATTR, VOICE_MIN_WORDS } from "../voice-intake-core";
 import type { BuildStage, ConversationQuestion } from "./conversation-machine";
 import type { CorpusManifestEntry } from "./use-voice-corpus";
 

--- a/frontend/src/screens/onboarding.tsx
+++ b/frontend/src/screens/onboarding.tsx
@@ -386,17 +386,14 @@ export function wizardStateBody(input: {
   };
 }
 
-// The accepted corpus formats, mirroring the contract's format enum
-// (crm.yaml IngestVoiceCorpusSourceRequest.format: txt/md/vtt/srt/json).
-export const ACCEPTED_CORPUS_FILE = /\.(txt|md|vtt|srt|json)$/i;
-export const ACCEPTED_CORPUS_ATTR = ".txt,.md,.vtt,.srt,.json";
-
-export const TRANSCRIPT_EXT = /\.(vtt|srt|json)$/i;
-
-// 800 mirrors the server's build floor ("at least 800 eligible own-authored
-// words"): gating the build action here turns that 422 into a clear,
-// up-front ask.
-export const VOICE_MIN_WORDS = 800;
+// The corpus intake rules now live with the intake itself, shared by the two
+// surfaces that collect writing samples (this act and the Settings card).
+export {
+  ACCEPTED_CORPUS_ATTR,
+  ACCEPTED_CORPUS_FILE,
+  TRANSCRIPT_EXT,
+  VOICE_MIN_WORDS,
+} from "./voice-intake-core";
 
 // pickBuiltVersion names the version the build just produced: the highest
 // numbered active-or-candidate row — active when it auto-activated,

--- a/frontend/src/screens/use-file-drop.ts
+++ b/frontend/src/screens/use-file-drop.ts
@@ -1,0 +1,75 @@
+import type { RefObject } from "react";
+import { useEffect, useState } from "react";
+
+type UseFileDropArgs = Readonly<{
+  /** The region a dropped file is accepted in. When null, a drop anywhere in
+   * the window feeds the caller — correct only for a surface that is the whole
+   * window and says so. When set, drops outside it are neutralized but NOT
+   * ingested: a file dropped on a global overlay (the command palette, a modal)
+   * belongs to nobody, and silently feeding it to whatever screen sits behind
+   * is worse than doing nothing. */
+  container: RefObject<HTMLElement | null> | null;
+  /** While false: file drags are still claimed so the browser cannot navigate,
+   * but no files are delivered and no affordance shows. */
+  active: boolean;
+  onFiles: (files: readonly File[]) => void;
+}>;
+
+// Window-level drag and drop for file intake. The listeners are on `window`
+// rather than a div because the browser's default action for a dropped file is
+// to NAVIGATE to it, discarding unsaved work on the page — that has to be
+// prevented wherever the file lands, not only over the drop zone.
+export function useFileDrop({ container, active, onFiles }: UseFileDropArgs): {
+  dragOver: boolean;
+} {
+  const [dragOver, setDragOver] = useState(false);
+
+  useEffect(() => {
+    // Only FILE drags are claimed: dragging selected text elsewhere on the
+    // page is a native interaction this must not swallow.
+    const isFileDrag = (event: globalThis.DragEvent) =>
+      event.dataTransfer?.types.includes("Files") ?? false;
+    // Whether the pointer is over the region that actually accepts files.
+    const inZone = (event: globalThis.DragEvent) => {
+      const zone = container?.current;
+      if (!zone) {
+        return container === null;
+      }
+      return event.target instanceof Node && zone.contains(event.target);
+    };
+    const onDragOver = (event: globalThis.DragEvent) => {
+      if (!isFileDrag(event)) {
+        return;
+      }
+      event.preventDefault();
+      setDragOver(active && inZone(event));
+    };
+    const onDragLeave = (event: globalThis.DragEvent) => {
+      // relatedTarget is null only when the drag exits the window; moving
+      // between elements inside it must not flicker the affordance off.
+      if (event.relatedTarget === null) {
+        setDragOver(false);
+      }
+    };
+    const onDrop = (event: globalThis.DragEvent) => {
+      if (!isFileDrag(event)) {
+        return;
+      }
+      event.preventDefault();
+      setDragOver(false);
+      if (active && inZone(event)) {
+        onFiles(Array.from(event.dataTransfer?.files ?? []));
+      }
+    };
+    window.addEventListener("dragover", onDragOver);
+    window.addEventListener("dragleave", onDragLeave);
+    window.addEventListener("drop", onDrop);
+    return () => {
+      window.removeEventListener("dragover", onDragOver);
+      window.removeEventListener("dragleave", onDragLeave);
+      window.removeEventListener("drop", onDrop);
+    };
+  }, [active, container, onFiles]);
+
+  return { dragOver };
+}

--- a/frontend/src/screens/use-voice-intake.ts
+++ b/frontend/src/screens/use-voice-intake.ts
@@ -6,8 +6,7 @@ import {
   intakeTranscript,
   intakeUpload,
   isAcceptedCorpusFile,
-  pasteRef,
-  uploadRef,
+  sourceRef,
 } from "./voice-intake-core";
 
 // The Settings side of the shared voice-corpus intake: the same core the
@@ -65,7 +64,6 @@ export function useVoiceIntake({ profileId, onChanged }: UseVoiceIntakeArgs) {
   const [notices, setNotices] = useState<readonly IntakeNotice[]>([]);
   const [inFlight, setInFlight] = useState(0);
   const mounted = useRef(true);
-  const pasteSeq = useRef(0);
   useEffect(() => {
     mounted.current = true;
     return () => {
@@ -139,16 +137,24 @@ export function useVoiceIntake({ profileId, onChanged }: UseVoiceIntakeArgs) {
   // A rejected promise here is a client-side fault, never a server refusal —
   // the core resolves those as a "refused" outcome. Its message is not shown
   // to the reader (it is not written for them); it is logged, and the card
-  // says only that adding the source failed.
+  // says only that adding the source failed. The source's own key is not known
+  // on that path (a file that could not be read has no content to key on), so
+  // the notice is keyed by the label the reader chose it under.
   const runIntake = useCallback(
-    (ref: string, label: string, start: () => Promise<IntakeOutcome>) => {
+    (label: string, start: () => Promise<IntakeOutcome>) => {
       setInFlight((count) => count + 1);
       start()
         .then(applyOutcome)
         .catch((err: unknown) => {
           console.error("voice corpus intake failed unexpectedly", err);
           if (mounted.current) {
-            note({ ref, label, tone: "warn", kind: "failed", problem: err });
+            note({
+              ref: `failed:${label}`,
+              label,
+              tone: "warn",
+              kind: "failed",
+              problem: err,
+            });
           }
         })
         .finally(() => {
@@ -163,19 +169,21 @@ export function useVoiceIntake({ profileId, onChanged }: UseVoiceIntakeArgs) {
   const addFiles = useCallback(
     (files: readonly File[]) => {
       for (const file of files) {
-        const ref = uploadRef("settings", file.name);
         if (!isAcceptedCorpusFile(file.name)) {
+          // Nothing was read, so there is no content key yet; the name is
+          // enough to tell the reader which file was left out.
           note({
-            ref,
+            ref: `skipped:${file.name}`,
             label: file.name,
             tone: "warn",
             kind: "skippedType",
           });
           continue;
         }
-        runIntake(ref, file.name, async () =>
-          intakeUpload(ref, file.name, await file.text()),
-        );
+        runIntake(file.name, async () => {
+          const text = await file.text();
+          return intakeUpload(sourceRef("upload", text), file.name, text);
+        });
       }
     },
     [note, runIntake],
@@ -183,9 +191,9 @@ export function useVoiceIntake({ profileId, onChanged }: UseVoiceIntakeArgs) {
 
   const addPaste = useCallback(
     (text: string, label: string) => {
-      pasteSeq.current += 1;
-      const ref = pasteRef("settings", pasteSeq.current);
-      runIntake(ref, label, () => intakePaste(ref, label, text));
+      runIntake(label, () =>
+        intakePaste(sourceRef("paste", text), label, text),
+      );
     },
     [runIntake],
   );
@@ -199,7 +207,7 @@ export function useVoiceIntake({ profileId, onChanged }: UseVoiceIntakeArgs) {
         return;
       }
       setAsks((prev) => prev.filter((candidate) => candidate.ref !== ask.ref));
-      runIntake(ask.ref, ask.label, () =>
+      runIntake(ask.label, () =>
         intakeTranscript(ask.ref, ask.label, ask.content, speakerLabel),
       );
     },

--- a/frontend/src/screens/use-voice-intake.ts
+++ b/frontend/src/screens/use-voice-intake.ts
@@ -1,0 +1,239 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { components } from "../api/schema";
+import type { IntakeOutcome, RefusalReason } from "./voice-intake-core";
+import {
+  intakePaste,
+  intakeTranscript,
+  intakeUpload,
+  isAcceptedCorpusFile,
+  pasteRef,
+  uploadRef,
+} from "./voice-intake-core";
+
+// The Settings side of the shared voice-corpus intake: the same core the
+// onboarding act runs on, adapted to a surface that reads its corpus from the
+// server rather than narrating it. There is no local summary here — every
+// successful ingest invalidates the manifest query, so the meter on screen is
+// always the server's count and two concurrent ingests cannot disagree about
+// the total.
+
+type CorpusPreview = components["schemas"]["VoiceCorpusPreviewResult"];
+
+/** A conversational source waiting for the owner to say which speaker is
+ * them. Until it is answered the source is not ingested at all. */
+export type SpeakerAsk = Readonly<{
+  ref: string;
+  label: string;
+  content: string;
+  preview: CorpusPreview;
+}>;
+
+/** What the card tells the owner about one finished intake attempt. */
+export type IntakeNotice = Readonly<{
+  ref: string;
+  label: string;
+  tone: "ok" | "warn";
+  kind:
+    | "kept"
+    | "skippedType"
+    | "skippedEmpty"
+    | "refused"
+    | "failed"
+    | "dismissed";
+  keptWords?: number;
+  inputWords?: number;
+  reason?: RefusalReason | null;
+  problem?: unknown;
+}>;
+
+// A long Settings session can add many sources; the list keeps only the most
+// recent results so it stays a readable summary of what just happened rather
+// than an ever-growing log.
+const MAX_NOTICES = 6;
+
+type UseVoiceIntakeArgs = Readonly<{
+  /** null while the owner has no profile — the first add mints it through the
+   * shared ensureProfileId inside the core. */
+  profileId: string | null;
+  /** Called after every change the server accepted, so the caller can
+   * invalidate the queries that render the corpus. */
+  onChanged: () => void;
+}>;
+
+export function useVoiceIntake({ profileId, onChanged }: UseVoiceIntakeArgs) {
+  const [asks, setAsks] = useState<readonly SpeakerAsk[]>([]);
+  const [notices, setNotices] = useState<readonly IntakeNotice[]>([]);
+  const [inFlight, setInFlight] = useState(0);
+  const mounted = useRef(true);
+  const pasteSeq = useRef(0);
+  useEffect(() => {
+    mounted.current = true;
+    return () => {
+      mounted.current = false;
+    };
+  }, []);
+
+  // Notices are keyed by source ref: re-adding the same file replaces its
+  // previous result instead of stacking a second line about the same source.
+  const note = useCallback((entry: IntakeNotice) => {
+    setNotices((prev) =>
+      [...prev.filter((existing) => existing.ref !== entry.ref), entry].slice(
+        -MAX_NOTICES,
+      ),
+    );
+  }, []);
+
+  const applyOutcome = useCallback(
+    (outcome: IntakeOutcome) => {
+      if (!mounted.current) {
+        return;
+      }
+      switch (outcome.kind) {
+        case "ingested":
+          note({
+            ref: outcome.ref,
+            label: outcome.label,
+            tone: "ok",
+            kind: "kept",
+            keptWords: outcome.stats.kept_words,
+            inputWords: outcome.stats.input_words,
+          });
+          onChanged();
+          return;
+        case "speaker-needed":
+          // A re-upload under the same name supersedes its pending question;
+          // the ingest is idempotent on source_ref server-side.
+          setAsks((prev) => [
+            ...prev.filter((ask) => ask.ref !== outcome.ref),
+            {
+              ref: outcome.ref,
+              label: outcome.label,
+              content: outcome.content,
+              preview: outcome.preview,
+            },
+          ]);
+          return;
+        case "refused":
+          note({
+            ref: outcome.ref,
+            label: outcome.label,
+            tone: "warn",
+            kind: "refused",
+            reason: outcome.reason,
+            problem: outcome.problem,
+          });
+          return;
+        case "skipped":
+          note({
+            ref: outcome.ref,
+            label: outcome.label,
+            tone: "warn",
+            kind: outcome.reason === "empty" ? "skippedEmpty" : "skippedType",
+          });
+          return;
+      }
+    },
+    [note, onChanged],
+  );
+
+  // A rejected promise here is a client-side fault, never a server refusal —
+  // the core resolves those as a "refused" outcome. Its message is not shown
+  // to the reader (it is not written for them); it is logged, and the card
+  // says only that adding the source failed.
+  const runIntake = useCallback(
+    (ref: string, label: string, start: () => Promise<IntakeOutcome>) => {
+      setInFlight((count) => count + 1);
+      start()
+        .then(applyOutcome)
+        .catch((err: unknown) => {
+          console.error("voice corpus intake failed unexpectedly", err);
+          if (mounted.current) {
+            note({ ref, label, tone: "warn", kind: "failed", problem: err });
+          }
+        })
+        .finally(() => {
+          if (mounted.current) {
+            setInFlight((count) => count - 1);
+          }
+        });
+    },
+    [applyOutcome, note],
+  );
+
+  const addFiles = useCallback(
+    (files: readonly File[]) => {
+      for (const file of files) {
+        const ref = uploadRef("settings", file.name);
+        if (!isAcceptedCorpusFile(file.name)) {
+          note({
+            ref,
+            label: file.name,
+            tone: "warn",
+            kind: "skippedType",
+          });
+          continue;
+        }
+        runIntake(ref, file.name, async () =>
+          intakeUpload(ref, file.name, await file.text()),
+        );
+      }
+    },
+    [note, runIntake],
+  );
+
+  const addPaste = useCallback(
+    (text: string, label: string) => {
+      pasteSeq.current += 1;
+      const ref = pasteRef("settings", pasteSeq.current);
+      runIntake(ref, label, () => intakePaste(ref, label, text));
+    },
+    [runIntake],
+  );
+
+  const pendingAsk = asks[0] ?? null;
+
+  const answerSpeaker = useCallback(
+    (speakerLabel: string) => {
+      const ask = asks[0];
+      if (ask === undefined) {
+        return;
+      }
+      setAsks((prev) => prev.filter((candidate) => candidate.ref !== ask.ref));
+      runIntake(ask.ref, ask.label, () =>
+        intakeTranscript(ask.ref, ask.label, ask.content, speakerLabel),
+      );
+    },
+    [asks, runIntake],
+  );
+
+  // Declining to attribute a transcript drops it: none of it can be proven to
+  // be the owner's own words, so ingesting it anyway is what corrupts a voice.
+  const dismissAsk = useCallback(() => {
+    const ask = asks[0];
+    if (ask === undefined) {
+      return;
+    }
+    setAsks((prev) => prev.filter((candidate) => candidate.ref !== ask.ref));
+    note({
+      ref: ask.ref,
+      label: ask.label,
+      tone: "warn",
+      kind: "dismissed",
+    });
+  }, [asks, note]);
+
+  return {
+    addFiles,
+    addPaste,
+    pendingAsk,
+    answerSpeaker,
+    dismissAsk,
+    notices,
+    /** True while any preview, ingest, or unanswered speaker question is open
+     * — a build started now would misrepresent what the voice is made of. */
+    busy: inFlight > 0 || asks.length > 0,
+    /** The profile the caller was rendered for; the core mints one on the
+     * first add when this is null. */
+    profileId,
+  };
+}

--- a/frontend/src/screens/voice-corpus-settings.test.tsx
+++ b/frontend/src/screens/voice-corpus-settings.test.tsx
@@ -1,0 +1,331 @@
+/** @vitest-environment jsdom */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  cleanup,
+  render as rtlRender,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { components } from "../api/schema";
+import { LocaleProvider } from "../i18n";
+import { VoiceCorpusIntake } from "./voice-corpus-settings";
+
+// Building a Voice DNA from Settings has to reach the same bar the onboarding
+// act reaches: a file can be handed over, and a file that turns out to be a
+// conversation is not counted as the owner's own writing until they say which
+// speaker they are. These tests are the ones that were missing while Settings
+// could only accept pasted text.
+
+type CorpusPreview = components["schemas"]["VoiceCorpusPreviewResult"];
+
+const SUMMARY: components["schemas"]["VoiceCorpusSummary"] = {
+  total_words: 900,
+  target_words: 30000,
+  maturity: "provisional",
+  quality_band: "thin",
+  source_count: 1,
+  register_words: { general: 900 },
+};
+
+const STATS: components["schemas"]["VoiceIngestStats"] = {
+  input_words: 1000,
+  kept_words: 640,
+  kept_turns: 4,
+  discarded_turns: 6,
+  speakers_seen: ["Lars", "Sam"],
+};
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function stubApi(
+  previewResult: CorpusPreview | { status: number; body: unknown },
+) {
+  const bodies: Record<string, unknown>[] = [];
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (request: Request) => {
+      const path = new URL(request.url).pathname.replace(/^\/v1/, "");
+      if (path === "/voice-profiles") {
+        return jsonResponse({
+          data: [{ id: "vp-1" }],
+          page: { next_cursor: null, has_more: false },
+        });
+      }
+      if (path === "/voice-profiles/vp-1/sources/preview") {
+        if ("status" in previewResult) {
+          return jsonResponse(previewResult.body, previewResult.status);
+        }
+        return jsonResponse(previewResult);
+      }
+      if (path === "/voice-profiles/vp-1/sources") {
+        bodies.push(JSON.parse(await request.text()));
+        return jsonResponse(
+          { source: {}, summary: SUMMARY, ingest_stats: STATS },
+          201,
+        );
+      }
+      return jsonResponse({});
+    }),
+  );
+  return bodies;
+}
+
+function render(ui: ReactNode) {
+  return rtlRender(
+    <QueryClientProvider
+      client={
+        new QueryClient({ defaultOptions: { queries: { retry: false } } })
+      }
+    >
+      <LocaleProvider initial="en">{ui}</LocaleProvider>
+    </QueryClientProvider>,
+  );
+}
+
+function fileOf(name: string, text: string): File {
+  return new File([text], name, { type: "text/plain" });
+}
+
+// The hidden input the "Choose files" button clicks. userEvent.upload needs
+// the input itself, which carries no accessible name by design.
+function fileInput(): HTMLInputElement {
+  const input = document.querySelector('input[type="file"]');
+  if (!(input instanceof HTMLInputElement)) {
+    throw new Error("the intake rendered no file input");
+  }
+  return input;
+}
+
+const PROSE: CorpusPreview = {
+  total_words: 1000,
+  detected_format: "txt",
+  ingestible_as_transcript: false,
+  unattributed_words: 1000,
+  speakers: [],
+};
+
+const CONVERSATION: CorpusPreview = {
+  total_words: 1000,
+  detected_format: "vtt",
+  ingestible_as_transcript: true,
+  unattributed_words: 0,
+  speakers: [
+    { label: "Lars", words: 640, turns: 12 },
+    { label: "Sam", words: 360, turns: 9 },
+  ],
+};
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe("handing a file to the Settings voice card", () => {
+  it("offers a file control at all — the thing paste-only Settings never had", async () => {
+    stubApi(PROSE);
+    render(<VoiceCorpusIntake profileId="vp-1" onChanged={() => {}} />);
+    expect(screen.getByRole("button", { name: /Choose files/ })).toBeTruthy();
+    expect(fileInput().accept).toBe(".txt,.md,.vtt,.srt,.json");
+  });
+
+  it("ingests single-author prose and reports what the server kept", async () => {
+    const bodies = stubApi(PROSE);
+    const onChanged = vi.fn();
+    render(<VoiceCorpusIntake profileId="vp-1" onChanged={onChanged} />);
+
+    await userEvent.upload(
+      fileInput(),
+      fileOf("letter.txt", "Short sentences. Concrete nouns."),
+    );
+
+    expect(await screen.findByText(/kept 640 of 1,000 words/)).toBeTruthy();
+    expect(bodies[0]).toMatchObject({ kind: "document", format: "text" });
+    // The manifest on screen is the server's, so an ingest has to invalidate it.
+    expect(onChanged).toHaveBeenCalled();
+  });
+
+  // This is the defect the card shipped with: a meeting transcript was posted
+  // straight through as kind:"other", counting every speaker's words as the
+  // owner's own. Nothing may reach the corpus before the question is answered.
+  it("asks who is speaking before a conversation becomes the owner's voice", async () => {
+    const bodies = stubApi(CONVERSATION);
+    render(<VoiceCorpusIntake profileId="vp-1" onChanged={() => {}} />);
+
+    await userEvent.upload(
+      fileInput(),
+      fileOf("standup.vtt", "Lars: we ship Friday. Sam: agreed."),
+    );
+
+    expect(await screen.findByText(/Which speaker are you in/)).toBeTruthy();
+    expect(screen.getByText(/Lars · 640 words, 12 turns/)).toBeTruthy();
+    expect(bodies).toHaveLength(0);
+  });
+
+  it("ingests the chosen speaker's turns as an attributed transcript", async () => {
+    const bodies = stubApi(CONVERSATION);
+    render(<VoiceCorpusIntake profileId="vp-1" onChanged={() => {}} />);
+
+    await userEvent.upload(
+      fileInput(),
+      fileOf("standup.vtt", "Lars: we ship Friday."),
+    );
+    await screen.findByText(/Which speaker are you in/);
+    await userEvent.click(screen.getByRole("radio", { name: /^Lars/ }));
+    await userEvent.click(
+      screen.getByRole("button", { name: "That one is me" }),
+    );
+
+    await waitFor(() => expect(bodies).toHaveLength(1));
+    expect(bodies[0]).toMatchObject({
+      kind: "transcript",
+      register: "spoken",
+      format: "transcript",
+      speaker_label: "Lars",
+    });
+  });
+
+  it("drops a conversation the owner declines to claim", async () => {
+    const bodies = stubApi(CONVERSATION);
+    render(<VoiceCorpusIntake profileId="vp-1" onChanged={() => {}} />);
+
+    await userEvent.upload(fileInput(), fileOf("standup.vtt", "Lars: hi."));
+    await screen.findByText(/Which speaker are you in/);
+    await userEvent.click(
+      screen.getByRole("button", { name: "Skip this file" }),
+    );
+
+    expect(
+      await screen.findByText(/nothing in it could be attributed to you/),
+    ).toBeTruthy();
+    expect(bodies).toHaveLength(0);
+  });
+
+  // The browse dialog filters by `accept`, but a DROP does not: an unreadable
+  // file only ever arrives this way, and it has to be named rather than
+  // silently ignored.
+  it("names a dropped file it cannot read instead of uploading it", async () => {
+    const bodies = stubApi(PROSE);
+    render(<VoiceCorpusIntake profileId="vp-1" onChanged={() => {}} />);
+    const zone = document.querySelector(".vdna-intake");
+    if (!(zone instanceof HTMLElement)) {
+      throw new Error("no drop zone rendered");
+    }
+
+    const drop = new Event("drop", { bubbles: true, cancelable: true });
+    Object.defineProperty(drop, "dataTransfer", {
+      value: {
+        types: ["Files"],
+        files: [new File(["binary"], "photo.png", { type: "image/png" })],
+      },
+    });
+    Object.defineProperty(drop, "target", { value: zone });
+    window.dispatchEvent(drop);
+
+    expect(
+      await screen.findByText(/photo\.png was skipped — only text files/),
+    ).toBeTruthy();
+    expect(bodies).toHaveLength(0);
+  });
+
+  it("quotes the server when it refuses for a reason the client does not know", async () => {
+    stubApi({
+      status: 422,
+      body: {
+        code: "brand_new_rule",
+        title: "Unprocessable",
+        detail: "That source is not eligible.",
+      },
+    });
+    render(<VoiceCorpusIntake profileId="vp-1" onChanged={() => {}} />);
+
+    await userEvent.upload(fileInput(), fileOf("notes.txt", "some words"));
+
+    // An unrecognized refusal must still say something true, never disappear.
+    expect(
+      await screen.findByText(/notes\.txt could not be added/),
+    ).toBeTruthy();
+  });
+});
+
+describe("dropping a file on the page", () => {
+  it("takes a file dropped on the intake area", async () => {
+    const bodies = stubApi(PROSE);
+    render(<VoiceCorpusIntake profileId="vp-1" onChanged={() => {}} />);
+    const zone = document.querySelector(".vdna-intake");
+    if (!(zone instanceof HTMLElement)) {
+      throw new Error("no drop zone rendered");
+    }
+
+    const file = fileOf("letter.txt", "Short sentences.");
+    const dataTransfer = {
+      types: ["Files"],
+      files: [file],
+    };
+    const drop = new Event("drop", { bubbles: true, cancelable: true });
+    Object.defineProperty(drop, "dataTransfer", { value: dataTransfer });
+    Object.defineProperty(drop, "target", { value: zone });
+    window.dispatchEvent(drop);
+
+    await waitFor(() => expect(bodies).toHaveLength(1));
+  });
+
+  // A file dropped on the command palette or any other overlay belongs to
+  // nobody. Feeding it to whatever screen happens to sit behind is how a
+  // stray file silently becomes part of someone's voice.
+  it("ignores a file dropped outside the card, but still stops the browser", async () => {
+    const bodies = stubApi(PROSE);
+    render(<VoiceCorpusIntake profileId="vp-1" onChanged={() => {}} />);
+    const elsewhere = document.createElement("div");
+    document.body.append(elsewhere);
+
+    const drop = new Event("drop", { bubbles: true, cancelable: true });
+    Object.defineProperty(drop, "dataTransfer", {
+      value: { types: ["Files"], files: [fileOf("stray.txt", "words")] },
+    });
+    Object.defineProperty(drop, "target", { value: elsewhere });
+    window.dispatchEvent(drop);
+
+    // Claimed (so the browser cannot navigate away) but not ingested.
+    expect(drop.defaultPrevented).toBe(true);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(bodies).toHaveLength(0);
+  });
+
+  it("leaves a text drag alone so native drag and drop still works", async () => {
+    stubApi(PROSE);
+    render(<VoiceCorpusIntake profileId="vp-1" onChanged={() => {}} />);
+
+    const drop = new Event("drop", { bubbles: true, cancelable: true });
+    Object.defineProperty(drop, "dataTransfer", {
+      value: { types: ["text/plain"], files: [] },
+    });
+    window.dispatchEvent(drop);
+
+    expect(drop.defaultPrevented).toBe(false);
+  });
+
+  it("removes its window listeners when the card goes away", async () => {
+    stubApi(PROSE);
+    const view = render(
+      <VoiceCorpusIntake profileId="vp-1" onChanged={() => {}} />,
+    );
+    view.unmount();
+
+    const drop = new Event("drop", { bubbles: true, cancelable: true });
+    Object.defineProperty(drop, "dataTransfer", {
+      value: { types: ["Files"], files: [fileOf("late.txt", "words")] },
+    });
+    window.dispatchEvent(drop);
+
+    // Nothing is left claiming drops on behalf of a card that is gone.
+    expect(drop.defaultPrevented).toBe(false);
+  });
+});

--- a/frontend/src/screens/voice-corpus-settings.test.tsx
+++ b/frontend/src/screens/voice-corpus-settings.test.tsx
@@ -192,6 +192,60 @@ describe("handing a file to the Settings voice card", () => {
     });
   });
 
+  // Pasting used to skip the preview, so the whole speaker protection could be
+  // walked around by pasting a transcript instead of uploading one.
+  it("asks who is speaking when a transcript is PASTED, not uploaded", async () => {
+    const bodies = stubApi(CONVERSATION);
+    render(<VoiceCorpusIntake profileId="vp-1" onChanged={() => {}} />);
+
+    await userEvent.type(
+      screen.getByPlaceholderText(
+        "Paste an email, post, or anything you've written…",
+      ),
+      "Lars: we ship Friday. Sam: agreed.",
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Add sample" }));
+
+    expect(await screen.findByText(/Which speaker are you in/)).toBeTruthy();
+    expect(bodies).toHaveLength(0);
+  });
+
+  // Two conversational files queue two questions. The second must be asked
+  // fresh: carrying the first answer over would submit a speaker the reader
+  // never chose for that file — silently ingesting the wrong person's words
+  // whenever that name happens to appear in both.
+  it("does not carry one file's chosen speaker into the next file's question", async () => {
+    const bodies = stubApi(CONVERSATION);
+    render(<VoiceCorpusIntake profileId="vp-1" onChanged={() => {}} />);
+
+    await userEvent.upload(fileInput(), [
+      fileOf("one.vtt", "Lars: first. Sam: ok."),
+      fileOf("two.vtt", "Lars: second. Sam: ok."),
+    ]);
+    await screen.findByText(/Which speaker are you in/);
+
+    await userEvent.click(screen.getByRole("radio", { name: /^Lars/ }));
+    await userEvent.click(
+      screen.getByRole("button", { name: "That one is me" }),
+    );
+
+    // The next question is a question, not a pre-filled answer.
+    await waitFor(() => {
+      expect(
+        screen
+          .getAllByRole("radio")
+          .every((r) => !(r as HTMLInputElement).checked),
+      ).toBe(true);
+    });
+    expect(
+      screen
+        .getByRole("button", { name: "That one is me" })
+        .hasAttribute("disabled"),
+    ).toBe(true);
+    // Only the answered file was written.
+    expect(bodies).toHaveLength(1);
+  });
+
   it("drops a conversation the owner declines to claim", async () => {
     const bodies = stubApi(CONVERSATION);
     render(<VoiceCorpusIntake profileId="vp-1" onChanged={() => {}} />);

--- a/frontend/src/screens/voice-corpus-settings.tsx
+++ b/frontend/src/screens/voice-corpus-settings.tsx
@@ -1,0 +1,224 @@
+import { Upload } from "lucide-react";
+import type { ChangeEvent } from "react";
+import { useRef, useState } from "react";
+import { Button, Radio, Textarea } from "../design-system/atoms";
+import { useT } from "../i18n";
+import { problemMessageOf } from "./common";
+import { useFileDrop } from "./use-file-drop";
+import type { IntakeNotice, SpeakerAsk } from "./use-voice-intake";
+import { useVoiceIntake } from "./use-voice-intake";
+import { ACCEPTED_CORPUS_ATTR } from "./voice-intake-core";
+
+// The Settings intake: browse or drop a file, paste writing, and answer who is
+// speaking when a file turns out to be a conversation. It owns the intake hook
+// so the build control beside it can be disabled while a source is still
+// arriving — a build started mid-ingest describes a corpus that no longer
+// exists by the time it finishes.
+
+type VoiceCorpusIntakeProps = Readonly<{
+  /** null for an owner who has no profile yet: the first sample mints it. */
+  profileId: string | null;
+  onChanged: () => void;
+  /** Told when intake is in progress, so the caller can hold the build. */
+  onBusyChange?: (busy: boolean) => void;
+  /** The empty-state box names itself and opens taller — it is the one a
+   * person pastes a whole email into. */
+  first?: boolean;
+}>;
+
+export function VoiceCorpusIntake({
+  profileId,
+  onChanged,
+  onBusyChange,
+  first = false,
+}: VoiceCorpusIntakeProps) {
+  const t = useT();
+  const intake = useVoiceIntake({ profileId, onChanged });
+  const [paste, setPaste] = useState("");
+  const fileRef = useRef<HTMLInputElement>(null);
+  const zoneRef = useRef<HTMLDivElement>(null);
+
+  // Files are accepted only inside this card. The listeners are still on the
+  // window so a file dropped anywhere cannot navigate the browser away from
+  // the app, but a drop on the command palette or a modal belongs to nobody
+  // and must not silently become a writing sample.
+  const { dragOver } = useFileDrop({
+    container: zoneRef,
+    active: intake.pendingAsk === null,
+    onFiles: intake.addFiles,
+  });
+
+  const busy = intake.busy;
+  const busyRef = useRef(busy);
+  if (busyRef.current !== busy) {
+    busyRef.current = busy;
+    onBusyChange?.(busy);
+  }
+
+  const onBrowsed = (event: ChangeEvent<HTMLInputElement>) => {
+    intake.addFiles(Array.from(event.target.files ?? []));
+    // Clearing lets the same file be chosen again after a failed attempt.
+    event.target.value = "";
+  };
+
+  return (
+    <div
+      ref={zoneRef}
+      className={`vdna-intake${dragOver ? " vdna-intake-dragover" : ""}`}
+    >
+      {intake.pendingAsk && (
+        <SpeakerPanel
+          ask={intake.pendingAsk}
+          onAnswer={intake.answerSpeaker}
+          onDismiss={intake.dismissAsk}
+        />
+      )}
+
+      <div className="vdna-composer">
+        {first && (
+          <div className="vdna-label">{t("settings.voice.addFirstLabel")}</div>
+        )}
+        <Textarea
+          rows={first ? 8 : 4}
+          value={paste}
+          placeholder={t("settings.voice.addPlaceholder")}
+          onChange={(e) => setPaste(e.target.value)}
+        />
+        <div className="vdna-composer-actions">
+          <Button
+            small
+            variant={first ? "primary" : undefined}
+            disabled={paste.trim().length === 0}
+            onClick={() => {
+              intake.addPaste(paste, t("settings.voice.pastedLabel"));
+              setPaste("");
+            }}
+          >
+            {first
+              ? t("settings.voice.addFirstCta")
+              : t("settings.voice.addSource")}
+          </Button>
+          <Button small onClick={() => fileRef.current?.click()}>
+            <Upload aria-hidden /> {t("settings.voice.browseFiles")}
+          </Button>
+          <input
+            ref={fileRef}
+            type="file"
+            multiple
+            accept={ACCEPTED_CORPUS_ATTR}
+            hidden
+            onChange={onBrowsed}
+          />
+        </div>
+        <p className="t-small vdna-drophint">{t("settings.voice.dropHint")}</p>
+      </div>
+
+      {intake.notices.length > 0 && (
+        <ul className="vdna-notices">
+          {intake.notices.map((notice) => (
+            <NoticeRow key={notice.ref} notice={notice} />
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+// A file the preview found several speakers in: only the owner's own turns may
+// become their voice, so the source waits here until they say which is theirs.
+function SpeakerPanel({
+  ask,
+  onAnswer,
+  onDismiss,
+}: Readonly<{
+  ask: SpeakerAsk;
+  onAnswer: (speakerLabel: string) => void;
+  onDismiss: () => void;
+}>) {
+  const t = useT();
+  const [choice, setChoice] = useState<string | null>(null);
+  return (
+    <fieldset className="vdna-speaker">
+      <legend className="vdna-label">
+        {t("settings.voice.speakerQuestion", { name: ask.label })}
+      </legend>
+      <ul className="vdna-speaker-options">
+        {ask.preview.speakers.map((speaker) => (
+          <li key={speaker.label}>
+            <Radio
+              name={`speaker:${ask.ref}`}
+              checked={choice === speaker.label}
+              onChange={() => setChoice(speaker.label)}
+              label={`${speaker.label} · ${t("settings.voice.speakerDetail", {
+                words: speaker.words.toLocaleString(),
+                turns: speaker.turns,
+              })}`}
+            />
+          </li>
+        ))}
+      </ul>
+      <div className="vdna-composer-actions">
+        <Button
+          small
+          variant="primary"
+          disabled={choice === null}
+          onClick={() => choice !== null && onAnswer(choice)}
+        >
+          {t("settings.voice.speakerConfirm")}
+        </Button>
+        <Button small onClick={onDismiss}>
+          {t("settings.voice.speakerDismiss")}
+        </Button>
+      </div>
+    </fieldset>
+  );
+}
+
+// What one finished intake says to the reader. A refusal the core did not
+// recognize quotes the server's own detail rather than inventing a reason.
+function noticeText(t: ReturnType<typeof useT>, notice: IntakeNotice): string {
+  switch (notice.kind) {
+    case "kept":
+      return t("settings.voice.noticeKept", {
+        name: notice.label,
+        kept: (notice.keptWords ?? 0).toLocaleString(),
+        total: (notice.inputWords ?? 0).toLocaleString(),
+      });
+    case "skippedType":
+      return t("settings.voice.noticeSkippedType", { name: notice.label });
+    case "skippedEmpty":
+      return t("settings.voice.noticeSkippedEmpty", { name: notice.label });
+    case "dismissed":
+      return t("settings.voice.noticeDismissed", { name: notice.label });
+    case "refused":
+      switch (notice.reason) {
+        case "unattributed":
+          return t("settings.voice.refusalUnattributed", {
+            name: notice.label,
+          });
+        case "speaker":
+          return t("settings.voice.refusalSpeaker", { name: notice.label });
+        case "unsupported":
+          return t("settings.voice.refusalUnsupported", { name: notice.label });
+        default:
+          return t("settings.voice.noticeFailed", {
+            name: notice.label,
+            detail: problemMessageOf(notice.problem, t),
+          });
+      }
+    case "failed":
+      return t("settings.voice.noticeUnexpected", { name: notice.label });
+  }
+}
+
+function NoticeRow({ notice }: Readonly<{ notice: IntakeNotice }>) {
+  const t = useT();
+  return (
+    <li
+      className={`t-small vdna-notice vdna-notice-${notice.tone}`}
+      role={notice.tone === "warn" ? "alert" : undefined}
+    >
+      {noticeText(t, notice)}
+    </li>
+  );
+}

--- a/frontend/src/screens/voice-corpus-settings.tsx
+++ b/frontend/src/screens/voice-corpus-settings.tsx
@@ -1,6 +1,6 @@
 import { Upload } from "lucide-react";
 import type { ChangeEvent } from "react";
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Button, Radio, Textarea } from "../design-system/atoms";
 import { useT } from "../i18n";
 import { problemMessageOf } from "./common";
@@ -48,12 +48,13 @@ export function VoiceCorpusIntake({
     onFiles: intake.addFiles,
   });
 
+  // Told AFTER the render that changed it: calling a parent's setState from a
+  // render body updates one component while another is rendering, which React
+  // does not support.
   const busy = intake.busy;
-  const busyRef = useRef(busy);
-  if (busyRef.current !== busy) {
-    busyRef.current = busy;
+  useEffect(() => {
     onBusyChange?.(busy);
-  }
+  }, [busy, onBusyChange]);
 
   const onBrowsed = (event: ChangeEvent<HTMLInputElement>) => {
     intake.addFiles(Array.from(event.target.files ?? []));
@@ -67,7 +68,11 @@ export function VoiceCorpusIntake({
       className={`vdna-intake${dragOver ? " vdna-intake-dragover" : ""}`}
     >
       {intake.pendingAsk && (
+        // Keyed by the source: when the queue advances to the next file the
+        // panel is a NEW panel, so the previous file's chosen speaker cannot
+        // survive into a question about different people.
         <SpeakerPanel
+          key={intake.pendingAsk.ref}
           ask={intake.pendingAsk}
           onAnswer={intake.answerSpeaker}
           onDismiss={intake.dismissAsk}

--- a/frontend/src/screens/voice-dna.css
+++ b/frontend/src/screens/voice-dna.css
@@ -52,6 +52,73 @@
   flex-wrap: wrap;
 }
 
+/* The region a dropped file is actually accepted in. It is outlined only while
+   a file is over it, so the card does not carry a dashed box at rest. */
+.vdna-intake {
+  border: 1px dashed transparent;
+  border-radius: var(--r-sm);
+  transition:
+    border-color 0.12s ease,
+    background 0.12s ease;
+}
+
+.vdna-intake-dragover {
+  border-color: var(--accent);
+  background: var(--bgHover);
+}
+
+.vdna-drophint {
+  color: var(--textMuted);
+}
+
+/* The distance to the first build, shown only below the floor. */
+.vdna-floor {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.vdna-floor progress {
+  flex: 0 0 8rem;
+}
+
+/* What just happened to each source the reader handed over. */
+.vdna-notices {
+  list-style: none;
+  padding: 0;
+  margin: var(--space-2) 0 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.vdna-notice-warn {
+  color: var(--warn);
+}
+
+/* The speaker question sits above the composer: until it is answered the file
+   it belongs to is not part of the corpus at all. */
+.vdna-speaker {
+  border: 1px solid var(--borderSubtle);
+  border-radius: var(--r-sm);
+  background: var(--warnSurface);
+  padding: var(--space-3);
+  margin: var(--space-3) 0 0;
+  min-inline-size: 0; /* a fieldset otherwise refuses to shrink in a flex column */
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.vdna-speaker-options {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
 /* Wraps the build button so a tooltip has something that still receives
    pointer events while the button itself is disabled. */
 .vdna-build {

--- a/frontend/src/screens/voice-dna.test.tsx
+++ b/frontend/src/screens/voice-dna.test.tsx
@@ -114,6 +114,17 @@ function stubApi() {
           page: emptyPage.page,
         });
       }
+      // Every source is previewed before it is written, pasted text included:
+      // the server is the one that says whether writing carries speakers.
+      if (path === "/voice-profiles/vp-1/sources/preview") {
+        return jsonResponse({
+          detected_format: "txt",
+          total_words: 420,
+          speakers: [],
+          unattributed_words: 420,
+          ingestible_as_transcript: false,
+        });
+      }
       if (path === "/voice-profiles/vp-1/sources") {
         if (request.method === "POST") {
           return jsonResponse(

--- a/frontend/src/screens/voice-dna.tsx
+++ b/frontend/src/screens/voice-dna.tsx
@@ -12,7 +12,9 @@ import {
 } from "../design-system/atoms";
 import { useT } from "../i18n";
 import { problemMessageOf, QueryGate, throwProblem } from "./common";
-import { ensureProfileId, useVoiceProfile } from "./voice-profile";
+import { VoiceCorpusIntake } from "./voice-corpus-settings";
+import { VOICE_MIN_WORDS } from "./voice-intake-core";
+import { useVoiceProfile } from "./voice-profile";
 import { ActiveVoiceInsights, VoiceHistory } from "./voice-versions";
 import "./voice-dna.css";
 
@@ -110,7 +112,8 @@ export function VoiceDnaCard() {
               <b>{t("settings.voice.emptyTitle")}</b>
               <p className="t-small">{t("settings.voice.emptyBody")}</p>
             </EmptyState>
-            <CorpusAddForm
+            <VoiceCorpusIntake
+              first
               profileId={null}
               onChanged={() =>
                 qc.invalidateQueries({ queryKey: ["voice-profile"] })
@@ -144,6 +147,9 @@ function bandLabel(
 function VoiceDnaBody({ profile }: Readonly<{ profile: VoiceProfile }>) {
   const t = useT();
   const qc = useQueryClient();
+  // Intake lives in one card and the build button in another, so the fact that
+  // a sample is still arriving has to be held by the parent they share.
+  const [intakeBusy, setIntakeBusy] = useState(false);
   const invalidate = () => {
     qc.invalidateQueries({ queryKey: ["voice-profile"] });
     qc.invalidateQueries({ queryKey: ["voice-sources", profile.id] });
@@ -194,11 +200,21 @@ function VoiceDnaBody({ profile }: Readonly<{ profile: VoiceProfile }>) {
 
       <Card className="card-stack" title={t("settings.voice.corpusLabel")}>
         <CorpusManifest profileId={profile.id} onChanged={invalidate} />
-        <CorpusAddForm profileId={profile.id} onChanged={invalidate} />
+        <VoiceCorpusIntake
+          profileId={profile.id}
+          onChanged={invalidate}
+          onBusyChange={setIntakeBusy}
+        />
       </Card>
 
       <Card className="card-stack" title={t("settings.voice.buildsTitle")}>
-        <BuildControls profile={profile} onBuilt={invalidate} />
+        {/* A build started while a sample is still arriving would describe a
+            corpus that no longer exists by the time it finishes. */}
+        <BuildControls
+          profile={profile}
+          onBuilt={invalidate}
+          intakeBusy={intakeBusy}
+        />
         <VoiceHistory profileId={profile.id} onChanged={invalidate} />
       </Card>
     </>
@@ -305,6 +321,12 @@ function CorpusManifest({
                 target: manifest.summary.target_words.toLocaleString(),
               })}
             </p>
+            {/* The meter above tracks the 30,000-word quality target, which
+                says nothing about when a first build becomes possible. Below
+                the floor, the distance that actually matters is the 800. */}
+            {manifest.summary.total_words < VOICE_MIN_WORDS && (
+              <FloorMeter words={manifest.summary.total_words} />
+            )}
             <RegisterMix summary={manifest.summary} />
             {manifest.sources.length === 0 ? (
               <p className="t-small">{t("settings.voice.corpusEmpty")}</p>
@@ -333,77 +355,25 @@ function CorpusManifest({
   );
 }
 
-// A null profileId is the owner who has never built a voice: the paste box is
-// the same one, but the add resolves the profile through the shared
-// ensureProfileId first, so the very first sample mints the one profile the
-// onboarding step would have minted — never a second one beside it. That first
-// box is also the one case that names itself: it sits in the empty-state card
-// under the surface's own title, with no "Writing samples" heading above it to
-// say what pasting here does.
-function CorpusAddForm({
-  profileId,
-  onChanged,
-}: Readonly<{ profileId: string | null; onChanged: () => void }>) {
+// How far the corpus still is from the server's first-build floor. It renders
+// only below the floor: once a build is possible, the distance to it is no
+// longer the question the reader is asking.
+function FloorMeter({ words }: Readonly<{ words: number }>) {
   const t = useT();
-  const [paste, setPaste] = useState("");
-  const [error, setError] = useState<string | null>(null);
-  const first = profileId === null;
-
-  const add = useMutation({
-    mutationFn: async () => {
-      const id = profileId ?? (await ensureProfileId());
-      const { error: err } = await api.POST("/voice-profiles/{id}/sources", {
-        params: { path: { id } },
-        body: {
-          kind: "other",
-          register: "general",
-          weight: 1,
-          source_label: t("settings.voice.pastedLabel"),
-          source_ref: `settings:paste:${Date.now()}`,
-          format: "text",
-          content: paste,
-        },
-      });
-      if (err) {
-        throwProblem(err);
-      }
-    },
-    onSuccess: () => {
-      setPaste("");
-      setError(null);
-      onChanged();
-    },
-    onError: reportFailure(setError, t),
-  });
-
   return (
-    <div className="vdna-composer">
-      {first && (
-        <div className="vdna-label">{t("settings.voice.addFirstLabel")}</div>
-      )}
-      {/* The first sample is the one a user pastes a whole email into, so it
-          opens tall enough to show one without scrolling; a later addition to
-          an established corpus is a smaller act and gets a smaller box. */}
-      <Textarea
-        rows={first ? 8 : 4}
-        value={paste}
-        placeholder={t("settings.voice.addPlaceholder")}
-        onChange={(e) => setPaste(e.target.value)}
+    <p className="t-small vdna-floor">
+      <progress
+        value={Math.min(words, VOICE_MIN_WORDS)}
+        max={VOICE_MIN_WORDS}
+        aria-label={t("settings.voice.floorLabel", { min: VOICE_MIN_WORDS })}
       />
-      <div className="vdna-composer-actions">
-        <Button
-          small
-          variant={first ? "primary" : undefined}
-          disabled={paste.trim().length === 0 || add.isPending}
-          onClick={() => add.mutate()}
-        >
-          {first
-            ? t("settings.voice.addFirstCta")
-            : t("settings.voice.addSource")}
-        </Button>
-        {error && <span className="t-small">{error}</span>}
-      </div>
-    </div>
+      <span>
+        {t("settings.voice.floorProgress", {
+          words: words.toLocaleString(),
+          min: VOICE_MIN_WORDS.toLocaleString(),
+        })}
+      </span>
+    </p>
   );
 }
 
@@ -510,7 +480,12 @@ function SourceRow({
 function BuildControls({
   profile,
   onBuilt,
-}: Readonly<{ profile: VoiceProfile; onBuilt: () => void }>) {
+  intakeBusy = false,
+}: Readonly<{
+  profile: VoiceProfile;
+  onBuilt: () => void;
+  intakeBusy?: boolean;
+}>) {
   const t = useT();
   const [status, setStatus] = useState<
     "succeeded" | "failed" | "deferred" | "pending" | null
@@ -594,7 +569,7 @@ function BuildControls({
         <Button
           variant="primary"
           small
-          disabled={build.isPending || tooThin}
+          disabled={build.isPending || tooThin || intakeBusy}
           onClick={() => build.mutate()}
         >
           <Sparkles aria-hidden />{" "}

--- a/frontend/src/screens/voice-intake-core.test.ts
+++ b/frontend/src/screens/voice-intake-core.test.ts
@@ -1,0 +1,290 @@
+/** @vitest-environment jsdom */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { components } from "../api/schema";
+import {
+  intakePaste,
+  intakeTranscript,
+  intakeUpload,
+  isAcceptedCorpusFile,
+  pasteRef,
+  refusalOf,
+  routePreview,
+  uploadRef,
+} from "./voice-intake-core";
+
+// The intake core is what both surfaces that collect writing samples run on.
+// What it decides — what a file honestly is, which body says so, and what the
+// server answered — is the same question on the onboarding act and in
+// Settings, so it is proven once here rather than twice through two UIs.
+
+type CorpusPreview = components["schemas"]["VoiceCorpusPreviewResult"];
+
+// A preview with nothing attributed to anyone by default; a case that cares
+// about attribution passes its own speakers and the words left over.
+function preview(over: Partial<CorpusPreview> = {}): CorpusPreview {
+  return {
+    total_words: 1000,
+    detected_format: "txt",
+    ingestible_as_transcript: false,
+    unattributed_words: 1000,
+    speakers: [],
+    ...over,
+  };
+}
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+const SUMMARY: components["schemas"]["VoiceCorpusSummary"] = {
+  total_words: 900,
+  target_words: 30000,
+  maturity: "provisional",
+  quality_band: "thin",
+  source_count: 1,
+  register_words: { general: 900 },
+};
+
+const STATS: components["schemas"]["VoiceIngestStats"] = {
+  input_words: 1000,
+  kept_words: 900,
+  kept_turns: 4,
+  discarded_turns: 6,
+  speakers_seen: ["Lars", "Sam"],
+};
+
+// The server as the core actually meets it: one profile already exists, the
+// preview answers what the test asked for, and every ingest body is recorded
+// so the request SHAPE can be asserted rather than assumed.
+function stubApi(
+  previewResult: CorpusPreview | { status: number; body: unknown },
+) {
+  const bodies: Record<string, unknown>[] = [];
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (request: Request) => {
+      const path = new URL(request.url).pathname.replace(/^\/v1/, "");
+      if (path === "/voice-profiles") {
+        return jsonResponse({
+          data: [{ id: "vp-1" }],
+          page: { next_cursor: null, has_more: false },
+        });
+      }
+      if (path === "/voice-profiles/vp-1/sources/preview") {
+        if ("status" in previewResult) {
+          return jsonResponse(previewResult.body, previewResult.status);
+        }
+        return jsonResponse(previewResult);
+      }
+      if (path === "/voice-profiles/vp-1/sources") {
+        bodies.push(JSON.parse(await request.text()));
+        return jsonResponse(
+          { source: {}, summary: SUMMARY, ingest_stats: STATS },
+          201,
+        );
+      }
+      return jsonResponse({});
+    }),
+  );
+  return bodies;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("what a previewed file honestly is", () => {
+  it("asks who is speaking when a transcript-named file is attributable", () => {
+    expect(
+      routePreview(
+        "standup.vtt",
+        preview({ ingestible_as_transcript: true, speakers: [] }),
+      ),
+    ).toBe("ask-speaker");
+  });
+
+  it("asks who is speaking when prose is mostly attributed dialogue", () => {
+    // Above the 0.8 attributed share a .txt is a conversation whatever its
+    // extension claims.
+    expect(
+      routePreview(
+        "notes.txt",
+        preview({
+          ingestible_as_transcript: true,
+          unattributed_words: 100,
+          speakers: [
+            { label: "Lars", words: 500, turns: 10 },
+            { label: "Sam", words: 400, turns: 8 },
+          ],
+        }),
+      ),
+    ).toBe("ask-speaker");
+  });
+
+  it("refuses a transcript nobody can be attributed in", () => {
+    // Nothing in it can be proven the owner's own words, and a transcript is
+    // refused whole rather than ingested as if one person wrote it.
+    expect(
+      routePreview("meeting.srt", preview({ ingestible_as_transcript: false })),
+    ).toBe("refuse");
+  });
+
+  it("takes single-author prose as a document", () => {
+    expect(routePreview("letter.txt", preview())).toBe("document");
+  });
+});
+
+describe("which refusal the server named", () => {
+  it("reads the top-level code", () => {
+    expect(refusalOf({ code: "unattributed_transcript" })).toBe("unattributed");
+    expect(refusalOf({ code: "speaker_not_found" })).toBe("speaker");
+    expect(refusalOf({ code: "unsupported_format" })).toBe("unsupported");
+  });
+
+  it("reads a per-field code out of details.errors", () => {
+    expect(
+      refusalOf({
+        code: "validation_failed",
+        details: { errors: [{ code: "speaker_label_required" }] },
+      }),
+    ).toBe("unattributed");
+  });
+
+  // An unknown code must not vanish into a category it does not belong to:
+  // null is what makes the caller quote the server's own detail instead.
+  it("returns null for a code it does not know", () => {
+    expect(refusalOf({ code: "something_new" })).toBeNull();
+    expect(refusalOf(null)).toBeNull();
+    expect(refusalOf("not a problem document")).toBeNull();
+  });
+});
+
+describe("the request bodies the server actually receives", () => {
+  it("sends single-author prose as a text document", async () => {
+    const bodies = stubApi(preview());
+    const outcome = await intakeUpload(
+      uploadRef("settings", "letter.txt"),
+      "letter.txt",
+      "Short sentences. Concrete nouns.",
+    );
+    expect(outcome.kind).toBe("ingested");
+    expect(bodies).toHaveLength(1);
+    expect(bodies[0]).toMatchObject({
+      kind: "document",
+      register: "general",
+      format: "text",
+      speaker_label: null,
+      source_ref: "settings:upload:letter.txt",
+      source_label: "letter.txt",
+    });
+  });
+
+  // The server infers nothing from a filename: a transcript that omits
+  // format:"transcript" is read as prose and refused as unattributed, so the
+  // format and the chosen speaker are asserted together.
+  it("sends an attributed transcript as a transcript, with the speaker", async () => {
+    const bodies = stubApi(preview());
+    const outcome = await intakeTranscript(
+      "settings:upload:standup.vtt",
+      "standup.vtt",
+      "Lars: we ship on Friday.",
+      "Lars",
+    );
+    expect(outcome.kind).toBe("ingested");
+    expect(bodies[0]).toMatchObject({
+      kind: "transcript",
+      register: "spoken",
+      format: "transcript",
+      speaker_label: "Lars",
+    });
+  });
+
+  it("sends pasted writing as prose the owner claimed as their own", async () => {
+    const bodies = stubApi(preview());
+    await intakePaste(pasteRef("settings", 1), "Pasted writing", "Some words.");
+    expect(bodies[0]).toMatchObject({
+      kind: "other",
+      register: "general",
+      format: "text",
+      source_ref: "settings:paste:1",
+    });
+  });
+});
+
+describe("the outcomes an intake can end as", () => {
+  it("reports an empty file as skipped, without asking the server", async () => {
+    const bodies = stubApi(preview());
+    const outcome = await intakeUpload("r", "empty.txt", "   \n  ");
+    expect(outcome).toMatchObject({ kind: "skipped", reason: "empty" });
+    expect(bodies).toHaveLength(0);
+  });
+
+  it("hands back a speaker question instead of ingesting", async () => {
+    const bodies = stubApi(
+      preview({
+        ingestible_as_transcript: true,
+        unattributed_words: 100,
+        speakers: [{ label: "Lars", words: 900, turns: 12 }],
+      }),
+    );
+    const outcome = await intakeUpload("r", "standup.vtt", "Lars: hello.");
+    expect(outcome.kind).toBe("speaker-needed");
+    // Nothing is ingested until the owner says which speaker is theirs.
+    expect(bodies).toHaveLength(0);
+  });
+
+  it("resolves a server refusal as an outcome rather than throwing", async () => {
+    stubApi({
+      status: 422,
+      body: { code: "unsupported_format", detail: "Cannot read that." },
+    });
+    const outcome = await intakeUpload("r", "notes.txt", "some words here");
+    expect(outcome).toMatchObject({ kind: "refused", reason: "unsupported" });
+  });
+
+  it("carries the problem through when the refusal code is unknown", async () => {
+    stubApi({
+      status: 422,
+      body: { code: "brand_new_rule", detail: "Nope." },
+    });
+    const outcome = await intakeUpload("r", "notes.txt", "some words here");
+    expect(outcome).toMatchObject({ kind: "refused", reason: null });
+    if (outcome.kind === "refused") {
+      expect(outcome.problem).toBeTruthy();
+    }
+  });
+});
+
+describe("which files are offered to the server at all", () => {
+  it("accepts the text formats the corpus can read", () => {
+    for (const name of ["a.txt", "b.md", "c.vtt", "d.srt", "e.json"]) {
+      expect(isAcceptedCorpusFile(name)).toBe(true);
+    }
+  });
+
+  it("rejects everything else by name, before any upload", () => {
+    for (const name of ["photo.png", "deck.pdf", "sheet.xlsx", "noext"]) {
+      expect(isAcceptedCorpusFile(name)).toBe(false);
+    }
+  });
+});
+
+describe("source_ref, the key the ingest is idempotent on", () => {
+  it("names the surface and the file, so a retry updates one source", () => {
+    expect(uploadRef("settings", "letter.txt")).toBe(
+      "settings:upload:letter.txt",
+    );
+    expect(uploadRef("settings", "letter.txt")).toBe(
+      uploadRef("settings", "letter.txt"),
+    );
+  });
+
+  it("stays inside the contract's 512-character cap", () => {
+    expect(uploadRef("settings", "x".repeat(900)).length).toBeLessThanOrEqual(
+      512,
+    );
+  });
+});

--- a/frontend/src/screens/voice-intake-core.test.ts
+++ b/frontend/src/screens/voice-intake-core.test.ts
@@ -6,10 +6,9 @@ import {
   intakeTranscript,
   intakeUpload,
   isAcceptedCorpusFile,
-  pasteRef,
   refusalOf,
   routePreview,
-  uploadRef,
+  sourceRef,
 } from "./voice-intake-core";
 
 // The intake core is what both surfaces that collect writing samples run on.
@@ -96,7 +95,7 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
-describe("what a previewed file honestly is", () => {
+describe("what a previewed source honestly is", () => {
   it("asks who is speaking when a transcript-named file is attributable", () => {
     expect(
       routePreview(
@@ -106,9 +105,9 @@ describe("what a previewed file honestly is", () => {
     ).toBe("ask-speaker");
   });
 
-  it("asks who is speaking when prose is mostly attributed dialogue", () => {
-    // Above the 0.8 attributed share a .txt is a conversation whatever its
-    // extension claims.
+  // The server's verdict decides, not the file extension: a .txt that carries
+  // dialogue is a conversation however it was named.
+  it("asks who is speaking when a .txt turns out to carry dialogue", () => {
     expect(
       routePreview(
         "notes.txt",
@@ -124,11 +123,46 @@ describe("what a previewed file honestly is", () => {
     ).toBe("ask-speaker");
   });
 
+  // A .txt of 68% attributed dialogue plus narration used to fall under a
+  // client-side share threshold and ingest as prose — crediting the
+  // counterparty's words to the owner. The server already says it is
+  // ingestible as a transcript, and that answer is the one that counts.
+  it("asks who is speaking even when much of the source is unattributed", () => {
+    expect(
+      routePreview(
+        "mixed.txt",
+        preview({
+          total_words: 888,
+          ingestible_as_transcript: true,
+          unattributed_words: 288,
+          speakers: [
+            { label: "Lars", words: 325, turns: 25 },
+            { label: "Sam", words: 275, turns: 25 },
+          ],
+        }),
+      ),
+    ).toBe("ask-speaker");
+  });
+
   it("refuses a transcript nobody can be attributed in", () => {
     // Nothing in it can be proven the owner's own words, and a transcript is
     // refused whole rather than ingested as if one person wrote it.
     expect(
       routePreview("meeting.srt", preview({ ingestible_as_transcript: false })),
+    ).toBe("refuse");
+  });
+
+  // Named speakers the server could not make ingestible are still speakers:
+  // taking the file as prose would credit all of them to the owner.
+  it("refuses a source with speakers it cannot attribute, whatever its name", () => {
+    expect(
+      routePreview(
+        "notes.txt",
+        preview({
+          ingestible_as_transcript: false,
+          speakers: [{ label: "Sam", words: 400, turns: 8 }],
+        }),
+      ),
     ).toBe("refuse");
   });
 
@@ -165,10 +199,11 @@ describe("which refusal the server named", () => {
 describe("the request bodies the server actually receives", () => {
   it("sends single-author prose as a text document", async () => {
     const bodies = stubApi(preview());
+    const text = "Short sentences. Concrete nouns.";
     const outcome = await intakeUpload(
-      uploadRef("settings", "letter.txt"),
+      sourceRef("upload", text),
       "letter.txt",
-      "Short sentences. Concrete nouns.",
+      text,
     );
     expect(outcome.kind).toBe("ingested");
     expect(bodies).toHaveLength(1);
@@ -177,7 +212,6 @@ describe("the request bodies the server actually receives", () => {
       register: "general",
       format: "text",
       speaker_label: null,
-      source_ref: "settings:upload:letter.txt",
       source_label: "letter.txt",
     });
   });
@@ -202,15 +236,38 @@ describe("the request bodies the server actually receives", () => {
     });
   });
 
-  it("sends pasted writing as prose the owner claimed as their own", async () => {
+  it("sends pasted prose as prose the owner claimed as their own", async () => {
     const bodies = stubApi(preview());
-    await intakePaste(pasteRef("settings", 1), "Pasted writing", "Some words.");
+    const text = "Some words.";
+    await intakePaste(sourceRef("paste", text), "Pasted writing", text);
     expect(bodies[0]).toMatchObject({
       kind: "other",
       register: "general",
       format: "text",
-      source_ref: "settings:paste:1",
     });
+  });
+
+  // Pasting used to skip the preview entirely, so a meeting transcript pasted
+  // into the box was ingested as prose with every speaker credited to the
+  // owner — the same corruption an uploaded file was protected from.
+  it("previews pasted text too, so a pasted transcript still asks who is speaking", async () => {
+    const bodies = stubApi(
+      preview({
+        ingestible_as_transcript: true,
+        unattributed_words: 0,
+        speakers: [
+          { label: "Lars", words: 600, turns: 12 },
+          { label: "Sam", words: 400, turns: 9 },
+        ],
+      }),
+    );
+    const outcome = await intakePaste(
+      sourceRef("paste", "Lars: hi. Sam: hello."),
+      "Pasted writing",
+      "Lars: hi. Sam: hello.",
+    );
+    expect(outcome.kind).toBe("speaker-needed");
+    expect(bodies).toHaveLength(0);
   });
 });
 
@@ -272,18 +329,29 @@ describe("which files are offered to the server at all", () => {
   });
 });
 
+// The server upserts on source_ref, so the key has to identify the WRITING.
+// Keyed by filename, two different files both called "meeting.txt" would
+// silently overwrite each other, and the same file added from two surfaces
+// would be counted twice.
 describe("source_ref, the key the ingest is idempotent on", () => {
-  it("names the surface and the file, so a retry updates one source", () => {
-    expect(uploadRef("settings", "letter.txt")).toBe(
-      "settings:upload:letter.txt",
-    );
-    expect(uploadRef("settings", "letter.txt")).toBe(
-      uploadRef("settings", "letter.txt"),
+  it("is the same for the same writing, so a retry updates one row", () => {
+    expect(sourceRef("upload", "the same words")).toBe(
+      sourceRef("upload", "the same words"),
     );
   });
 
+  it("differs for different writing under the same file name", () => {
+    expect(sourceRef("upload", "one meeting")).not.toBe(
+      sourceRef("upload", "a different meeting"),
+    );
+  });
+
+  it("does not collide when only the length matches", () => {
+    expect(sourceRef("upload", "abcd")).not.toBe(sourceRef("upload", "dcba"));
+  });
+
   it("stays inside the contract's 512-character cap", () => {
-    expect(uploadRef("settings", "x".repeat(900)).length).toBeLessThanOrEqual(
+    expect(sourceRef("upload", "x".repeat(90000)).length).toBeLessThanOrEqual(
       512,
     );
   });

--- a/frontend/src/screens/voice-intake-core.ts
+++ b/frontend/src/screens/voice-intake-core.ts
@@ -31,14 +31,15 @@ export const TRANSCRIPT_EXT = /\.(vtt|srt|json)$/i;
 // words"): gating the build action turns that 422 into a clear, up-front ask.
 export const VOICE_MIN_WORDS = 800;
 
-// A .txt is treated as a transcript when the preview attributes at least this
-// share of its spoken words to labelled speakers.
-const ATTRIBUTED_SHARE = 0.8;
-
-// source_ref is the contract's stable natural key: the ingest is idempotent on
-// it, so retrying an upload that failed halfway updates the one source rather
-// than adding a second copy. It is capped at 512 and source_label at 255, and a
-// long filename is truncated rather than refused by the server for length.
+// source_ref is the contract's stable natural key and the server upserts on it
+// (ON CONFLICT (voice_profile_id, source_ref)). That makes it an identity, not
+// a label: two different files both called "meeting.txt" must not claim the
+// same key, and the same text handed over twice must not become two rows.
+//
+// So the key is derived from the CONTENT. Re-adding the same writing updates
+// the one row it already made, and two different files keep their own rows
+// whatever they are called. The name is not part of it — a file renamed is
+// still the same writing, and a name cannot be trusted to be unique.
 const SOURCE_REF_MAX = 512;
 const SOURCE_LABEL_MAX = 255;
 
@@ -46,33 +47,53 @@ function clamp(value: string, max: number): string {
   return value.length <= max ? value : value.slice(0, max);
 }
 
-export function uploadRef(surface: string, name: string): string {
-  return clamp(`${surface}:upload:${name}`, SOURCE_REF_MAX);
+// FNV-1a over the content: short, stable, and dependency-free. This is an
+// identity for rows the same person is adding to their own corpus, never a
+// security boundary — a collision costs one overwritten sample, and the
+// server's own uniqueness rules still apply on top.
+function contentKey(content: string): string {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < content.length; i++) {
+    hash ^= content.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193) >>> 0;
+  }
+  return `${hash.toString(16).padStart(8, "0")}-${content.length}`;
 }
 
-export function pasteRef(surface: string, seq: number): string {
-  return clamp(`${surface}:paste:${seq}`, SOURCE_REF_MAX);
+/** The key one piece of writing is known by, wherever it was handed over. */
+export function sourceRef(kind: "upload" | "paste", content: string): string {
+  return clamp(`voice:${kind}:${contentKey(content)}`, SOURCE_REF_MAX);
 }
 
-// What one previewed file honestly IS: a conversational source needs the
-// speaker answer first; a transcript-shaped file nobody is attributable in is
-// refused whole (none of it can be proven the owner's own words); and
-// single-author prose ingests directly.
+// What one previewed source honestly IS.
+//
+// `ingestible_as_transcript` is the SERVER's answer to "does this attribute
+// turns to named speakers?", and it is the only authority here. A client-side
+// share threshold used to gate it, which meant a .txt whose dialogue was 68%
+// attributed — the rest narration — was ingested as single-author prose with
+// the counterparty's words counted as the owner's own. Whether the reader
+// happened to name the file .vtt is not evidence about its contents.
+//
+// So: anything the server says carries speakers needs the speaker answer
+// first. A transcript-shaped file it CANNOT attribute is refused whole (none
+// of it can be proven the owner's own words). Everything else is prose.
 export function routePreview(
   name: string,
   preview: CorpusPreview,
 ): "ask-speaker" | "refuse" | "document" {
-  const attributedWords = preview.speakers.reduce(
-    (sum, speaker) => sum + speaker.words,
-    0,
-  );
-  const conversational =
-    TRANSCRIPT_EXT.test(name) ||
-    attributedWords >= preview.total_words * ATTRIBUTED_SHARE;
-  if (conversational && preview.ingestible_as_transcript) {
+  if (preview.ingestible_as_transcript) {
     return "ask-speaker";
   }
-  return TRANSCRIPT_EXT.test(name) ? "refuse" : "document";
+  // A source with named speakers the server could not make ingestible is not
+  // prose either: ingesting it would credit every speaker to the owner. The
+  // speakers list is read defensively because being WRONG here means
+  // misattributing someone's words — an older or partial response must fall
+  // back to refusing a transcript-shaped file, never to ingesting it.
+  const speakers = preview.speakers ?? [];
+  if (TRANSCRIPT_EXT.test(name) || speakers.length > 0) {
+    return "refuse";
+  }
+  return "document";
 }
 
 /** Why the server would not take a source, as a category both surfaces phrase
@@ -213,8 +234,13 @@ async function ingest(
   body: IngestRequest,
   label: string,
   transcript: boolean,
+  onIssue?: () => void,
 ): Promise<IntakeOutcome> {
   const profileId = await ensureProfileId();
+  // Called at the moment this write is issued, so a caller ordering concurrent
+  // ingests stamps them by when the SERVER was asked — not by when the reader
+  // picked the file, which a slow read or preview would distort.
+  onIssue?.();
   const { data, error } = await api.POST("/voice-profiles/{id}/sources", {
     params: { path: { id: profileId } },
     body,
@@ -238,16 +264,22 @@ async function ingest(
   };
 }
 
-/** Preview one accepted file and act on what it honestly is. The empty
- * pre-gate is the only client-side word counting anywhere; every count a
- * surface displays is a server number. */
-export async function intakeUpload(
+// Every source is previewed before anything is written, whether it arrived as
+// a file or as pasted text. Pasting used to skip this, which left the whole
+// corruption intact behind the paste box: paste a meeting transcript and every
+// speaker's words were credited to the owner. The two entry points differ only
+// in which body prose is sent under, so they share one path.
+async function intakePreviewed(
   ref: string,
-  name: string,
+  label: string,
   text: string,
+  proseBody: (ref: string, label: string, content: string) => IngestRequest,
+  onIssue?: () => void,
 ): Promise<IntakeOutcome> {
+  // The empty pre-gate is the only client-side word counting anywhere; every
+  // count a surface displays is a server number.
   if (text.split(/\s+/).filter(Boolean).length === 0) {
-    return { kind: "skipped", ref, label: name, reason: "empty" };
+    return { kind: "skipped", ref, label, reason: "empty" };
   }
   const profileId = await ensureProfileId();
   const { data, error } = await api.POST(
@@ -261,31 +293,47 @@ export async function intakeUpload(
     return {
       kind: "refused",
       ref,
-      label: name,
+      label,
       reason: refusalOf(error),
       problem: error,
     };
   }
-  const route = routePreview(name, data);
+  const route = routePreview(label, data);
   if (route === "ask-speaker") {
-    return {
-      kind: "speaker-needed",
-      ref,
-      label: name,
-      content: text,
-      preview: data,
-    };
+    return { kind: "speaker-needed", ref, label, content: text, preview: data };
   }
   if (route === "refuse") {
     return {
       kind: "refused",
       ref,
-      label: name,
+      label,
       reason: "unattributed",
       problem: null,
     };
   }
-  return ingest(documentBody(ref, name, text), name, false);
+  return ingest(proseBody(ref, label, text), label, false, onIssue);
+}
+
+/** A file the owner handed over: previewed, then ingested as prose or held for
+ * the speaker question. */
+export function intakeUpload(
+  ref: string,
+  name: string,
+  text: string,
+  onIssue?: () => void,
+): Promise<IntakeOutcome> {
+  return intakePreviewed(ref, name, text, documentBody, onIssue);
+}
+
+/** Text the owner pasted. Previewed exactly like a file — a transcript is a
+ * transcript however it reached the box. */
+export function intakePaste(
+  ref: string,
+  label: string,
+  content: string,
+  onIssue?: () => void,
+): Promise<IntakeOutcome> {
+  return intakePreviewed(ref, label, content, pasteBody, onIssue);
 }
 
 /** The owner named themselves in a conversational source: ingest with the
@@ -296,18 +344,14 @@ export function intakeTranscript(
   label: string,
   content: string,
   speakerLabel: string,
+  onIssue?: () => void,
 ): Promise<IntakeOutcome> {
-  return ingest(transcriptBody(ref, label, content, speakerLabel), label, true);
-}
-
-/** Pasted prose. It is not previewed: the owner typed or pasted it as their
- * own writing, and there is no filename to disagree with. */
-export function intakePaste(
-  ref: string,
-  label: string,
-  content: string,
-): Promise<IntakeOutcome> {
-  return ingest(pasteBody(ref, label, content), label, false);
+  return ingest(
+    transcriptBody(ref, label, content, speakerLabel),
+    label,
+    true,
+    onIssue,
+  );
 }
 
 /** Whether a filename is one the corpus accepts at all. */

--- a/frontend/src/screens/voice-intake-core.ts
+++ b/frontend/src/screens/voice-intake-core.ts
@@ -1,0 +1,316 @@
+import { api } from "../api/client";
+import type { components } from "../api/schema";
+import { ensureProfileId } from "./voice-profile";
+
+// The voice-corpus intake, spelled once for both surfaces that collect writing
+// samples: the onboarding voice act and the Settings Voice DNA card. What lives
+// here is everything that is TRUE of an intake regardless of who is asking —
+// what a file honestly is, which request body says so, and what the server
+// answered. Nothing here renders or knows about a conversation machine; each
+// surface adapts the outcomes below into its own vocabulary (narration events
+// there, notices and query invalidation here).
+//
+// Two surfaces previously carried their own copies of half of this. The copies
+// disagreed: Settings never previewed an upload at all, so a meeting transcript
+// was ingested with every speaker's words counted as the owner's own.
+
+type CorpusPreview = components["schemas"]["VoiceCorpusPreviewResult"];
+type CorpusSummary = components["schemas"]["VoiceCorpusSummary"];
+type IngestStats = components["schemas"]["VoiceIngestStats"];
+type IngestRequest = components["schemas"]["IngestVoiceCorpusSourceRequest"];
+
+// The file extensions the corpus accepts, and the subset that is conversational
+// by name. These are a CLIENT-side accept list, not the wire enum: the contract
+// carries `format: text | transcript`, and the concrete detected format appears
+// only in a preview result.
+export const ACCEPTED_CORPUS_FILE = /\.(txt|md|vtt|srt|json)$/i;
+export const ACCEPTED_CORPUS_ATTR = ".txt,.md,.vtt,.srt,.json";
+export const TRANSCRIPT_EXT = /\.(vtt|srt|json)$/i;
+
+// 800 mirrors the server's build floor ("at least 800 eligible own-authored
+// words"): gating the build action turns that 422 into a clear, up-front ask.
+export const VOICE_MIN_WORDS = 800;
+
+// A .txt is treated as a transcript when the preview attributes at least this
+// share of its spoken words to labelled speakers.
+const ATTRIBUTED_SHARE = 0.8;
+
+// source_ref is the contract's stable natural key: the ingest is idempotent on
+// it, so retrying an upload that failed halfway updates the one source rather
+// than adding a second copy. It is capped at 512 and source_label at 255, and a
+// long filename is truncated rather than refused by the server for length.
+const SOURCE_REF_MAX = 512;
+const SOURCE_LABEL_MAX = 255;
+
+function clamp(value: string, max: number): string {
+  return value.length <= max ? value : value.slice(0, max);
+}
+
+export function uploadRef(surface: string, name: string): string {
+  return clamp(`${surface}:upload:${name}`, SOURCE_REF_MAX);
+}
+
+export function pasteRef(surface: string, seq: number): string {
+  return clamp(`${surface}:paste:${seq}`, SOURCE_REF_MAX);
+}
+
+// What one previewed file honestly IS: a conversational source needs the
+// speaker answer first; a transcript-shaped file nobody is attributable in is
+// refused whole (none of it can be proven the owner's own words); and
+// single-author prose ingests directly.
+export function routePreview(
+  name: string,
+  preview: CorpusPreview,
+): "ask-speaker" | "refuse" | "document" {
+  const attributedWords = preview.speakers.reduce(
+    (sum, speaker) => sum + speaker.words,
+    0,
+  );
+  const conversational =
+    TRANSCRIPT_EXT.test(name) ||
+    attributedWords >= preview.total_words * ATTRIBUTED_SHARE;
+  if (conversational && preview.ingestible_as_transcript) {
+    return "ask-speaker";
+  }
+  return TRANSCRIPT_EXT.test(name) ? "refuse" : "document";
+}
+
+/** Why the server would not take a source, as a category both surfaces phrase
+ * in their own words. `null` means the refusal carried no code either surface
+ * knows — the caller states the server's own detail instead of inventing one. */
+export type RefusalReason = "unattributed" | "speaker" | "unsupported";
+
+const refusalReasons: Record<string, RefusalReason> = {
+  unattributed_transcript: "unattributed",
+  speaker_label_required: "unattributed",
+  speaker_not_found: "speaker",
+  unsupported_format: "unsupported",
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+// Every stable machine code an RFC 7807 body carries: the top-level `code` plus
+// any per-field `details.errors[].code`.
+function problemCodes(problem: unknown): string[] {
+  if (!isRecord(problem)) {
+    return [];
+  }
+  const codes: string[] = [];
+  if (typeof problem.code === "string") {
+    codes.push(problem.code);
+  }
+  const details = problem.details;
+  if (isRecord(details) && Array.isArray(details.errors)) {
+    for (const raw of details.errors) {
+      if (isRecord(raw) && typeof raw.code === "string") {
+        codes.push(raw.code);
+      }
+    }
+  }
+  return codes;
+}
+
+// The refusal category a 422 names, or null when no code here recognizes it.
+export function refusalOf(problem: unknown): RefusalReason | null {
+  const known = problemCodes(problem).find(
+    (code) => refusalReasons[code] !== undefined,
+  );
+  return known === undefined ? null : refusalReasons[known];
+}
+
+/** What one intake attempt ended as. Every path a source can take terminates in
+ * exactly one of these — there is no silent outcome. */
+export type IntakeOutcome =
+  | Readonly<{
+      kind: "ingested";
+      ref: string;
+      label: string;
+      stats: IngestStats;
+      summary: CorpusSummary;
+      /** Kept-of-total is worth showing only where filtering discarded turns. */
+      transcript: boolean;
+    }>
+  | Readonly<{
+      kind: "speaker-needed";
+      ref: string;
+      label: string;
+      content: string;
+      preview: CorpusPreview;
+    }>
+  | Readonly<{
+      kind: "refused";
+      ref: string;
+      label: string;
+      /** null when the server's code is unknown here; `problem` carries it. */
+      reason: RefusalReason | null;
+      problem: unknown;
+    }>
+  | Readonly<{
+      kind: "skipped";
+      ref: string;
+      label: string;
+      reason: "type" | "empty";
+    }>;
+
+// The three request bodies, built in one place so both surfaces send the same
+// shape. The server infers nothing from a filename: a transcript that omits
+// `format: "transcript"` is read as prose and refused as unattributed.
+function documentBody(
+  ref: string,
+  label: string,
+  content: string,
+): IngestRequest {
+  return {
+    kind: "document",
+    register: "general",
+    weight: 1,
+    source_label: clamp(label, SOURCE_LABEL_MAX),
+    source_ref: ref,
+    format: "text",
+    speaker_label: null,
+    content,
+  };
+}
+
+function pasteBody(ref: string, label: string, content: string): IngestRequest {
+  return {
+    kind: "other",
+    register: "general",
+    weight: 1,
+    source_label: clamp(label, SOURCE_LABEL_MAX),
+    source_ref: ref,
+    format: "text",
+    speaker_label: null,
+    content,
+  };
+}
+
+function transcriptBody(
+  ref: string,
+  label: string,
+  content: string,
+  speakerLabel: string,
+): IngestRequest {
+  return {
+    kind: "transcript",
+    register: "spoken",
+    weight: 1,
+    source_label: clamp(label, SOURCE_LABEL_MAX),
+    source_ref: ref,
+    format: "transcript",
+    speaker_label: speakerLabel,
+    content,
+  };
+}
+
+// One ingest call: the profile is resolved through the shared ensureProfileId,
+// so a first sample from either surface mints the one profile rather than a
+// second beside it. A server refusal RESOLVES as a "refused" outcome; only a
+// client-side fault (a broken fetch) rejects.
+async function ingest(
+  body: IngestRequest,
+  label: string,
+  transcript: boolean,
+): Promise<IntakeOutcome> {
+  const profileId = await ensureProfileId();
+  const { data, error } = await api.POST("/voice-profiles/{id}/sources", {
+    params: { path: { id: profileId } },
+    body,
+  });
+  if (error) {
+    return {
+      kind: "refused",
+      ref: body.source_ref,
+      label,
+      reason: refusalOf(error),
+      problem: error,
+    };
+  }
+  return {
+    kind: "ingested",
+    ref: body.source_ref,
+    label,
+    stats: data.ingest_stats,
+    summary: data.summary,
+    transcript,
+  };
+}
+
+/** Preview one accepted file and act on what it honestly is. The empty
+ * pre-gate is the only client-side word counting anywhere; every count a
+ * surface displays is a server number. */
+export async function intakeUpload(
+  ref: string,
+  name: string,
+  text: string,
+): Promise<IntakeOutcome> {
+  if (text.split(/\s+/).filter(Boolean).length === 0) {
+    return { kind: "skipped", ref, label: name, reason: "empty" };
+  }
+  const profileId = await ensureProfileId();
+  const { data, error } = await api.POST(
+    "/voice-profiles/{id}/sources/preview",
+    {
+      params: { path: { id: profileId } },
+      body: { format: "transcript", content: text },
+    },
+  );
+  if (error) {
+    return {
+      kind: "refused",
+      ref,
+      label: name,
+      reason: refusalOf(error),
+      problem: error,
+    };
+  }
+  const route = routePreview(name, data);
+  if (route === "ask-speaker") {
+    return {
+      kind: "speaker-needed",
+      ref,
+      label: name,
+      content: text,
+      preview: data,
+    };
+  }
+  if (route === "refuse") {
+    return {
+      kind: "refused",
+      ref,
+      label: name,
+      reason: "unattributed",
+      problem: null,
+    };
+  }
+  return ingest(documentBody(ref, name, text), name, false);
+}
+
+/** The owner named themselves in a conversational source: ingest with the
+ * speaker filter, so only that speaker's server-counted words reach the
+ * corpus. */
+export function intakeTranscript(
+  ref: string,
+  label: string,
+  content: string,
+  speakerLabel: string,
+): Promise<IntakeOutcome> {
+  return ingest(transcriptBody(ref, label, content, speakerLabel), label, true);
+}
+
+/** Pasted prose. It is not previewed: the owner typed or pasted it as their
+ * own writing, and there is no filename to disagree with. */
+export function intakePaste(
+  ref: string,
+  label: string,
+  content: string,
+): Promise<IntakeOutcome> {
+  return ingest(pasteBody(ref, label, content), label, false);
+}
+
+/** Whether a filename is one the corpus accepts at all. */
+export function isAcceptedCorpusFile(name: string): boolean {
+  return ACCEPTED_CORPUS_FILE.test(name);
+}


### PR DESCRIPTION
## What was wrong

Building a Voice DNA from `#/settings/voice` could only take **pasted text**.

- No file input and no drop handling at all — dropping a file on the page hit the browser default and **navigated out of the app**.
- Settings never called `POST /sources/preview`. It posted whatever arrived as `kind:"other"`, so a multi-speaker meeting transcript was ingested with **every speaker's words counted as the owner's own**.
- `ingest_stats` was discarded, so nothing said how much of a source was actually kept.
- `source_ref` was `settings:paste:${Date.now()}`, which defeats the endpoint's idempotency on that key.

Verified against a real server on a dev stack. The same 1520-word two-speaker transcript:

| path | kept |
|---|---|
| old Settings shape (`kind:"other"`, `format:"text"`) | **1601 of 1601** — Sam's words counted as Lars's |
| new path (`kind:"transcript"`, `speaker_label:"Lars"`) | **840 of 1520**, 40 turns discarded |

## The change

The intake both surfaces need is now one module. `voice-intake-core.ts` owns what is true of an intake regardless of who is asking: what a previewed file honestly is, the three request bodies that say so, the stable `source_ref`, and the refusal categories a 422 names. It returns typed outcomes and renders nothing, so the onboarding act keeps its narration and conversation machine while Settings translates the same outcomes into notices and query invalidation.

Settings gains what onboarding already had: a file control, drag and drop, the speaker question before a conversation becomes anyone's voice, kept-of-total feedback, and the 800-word first-build floor meter (the existing meter tracks the 30,000-word quality target, which says nothing about when a first build is possible).

**Drops are scoped to the voice card**, not the whole window. The onboarding act promises "drop anywhere in this conversation" and keeps that. Settings sits under a shell whose rail, command palette and modals stay mounted, and the palette overlay does not stop drop events — a file dropped there must not silently become a writing sample. Window listeners still claim file drags everywhere so the browser cannot navigate away.

## Proof the refactor is behaviour-neutral

The onboarding hooks keep their bodies; only transport and body construction moved beneath them. **All 338 existing onboarding tests pass unmodified** — no test file was edited to accommodate the change.

## Tests

29 new tests across `voice-intake-core.test.ts` and `voice-corpus-settings.test.tsx`, covering the three body shapes against the contract, preview routing, refusal classification including an unknown code that must not vanish, drop scoping (a drop outside the card is neutralized but not ingested), and listener cleanup on unmount.

Two guards were mutation-checked — removing the drop scoping fails 1 test, removing the speaker gate fails 4 — so they cannot pass for the wrong reason.

`make check-fe` green (2568 tests), `make craft-static` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Settings can now take writing samples from files and drag‑and‑drop, not just pasted text. All intakes (uploaded or pasted) are previewed first; conversational sources require a speaker choice; drops no longer navigate away, preventing mis‑attribution and data loss.

**Key changes**
- Adds `voice-intake-core.ts` shared by onboarding and Settings: preview routing defers to the server’s `ingestible_as_transcript`, refuses unattributable transcripts, builds the three request bodies, maps refusal categories, derives `source_ref` from content (not name/time) within contract limits, and sets the 800‑word first‑build floor; ingest ordering is stamped at write time.
- Introduces `VoiceCorpusIntake` in Settings: file picker, paste box, scoped drag‑and‑drop, speaker question, kept‑of‑total notices, and a first‑build floor meter; invalidates queries after ingest; build is disabled while intake is busy; the speaker panel is keyed by source.
- Extracts `use-file-drop` to claim window drops (prevents navigation) but deliver files only when dropped inside a designated container; onboarding uses it with a window‑wide target to preserve “drop anywhere in this conversation”.
- Refactors onboarding to use the shared core; behavior remains unchanged. Adds i18n strings for new notices and speaker flow.

**Review and QA**
- API: uses `POST /voice-profiles/{id}/sources/preview` for uploads and pastes, then `POST /voice-profiles/{id}/sources`.
- Idempotency: `source_ref` is derived from content (`voice:{upload|paste}:<hash>`), so re‑adds update one row and different content never collide.
- Formats: accepts `.txt`, `.md`, `.vtt`, `.srt`, `.json`; non‑text and empty files are skipped and named in notices.
- Tests: new coverage for intake core, Settings intake, refusal mapping, and drop scoping; existing onboarding tests pass unchanged.

<sup>Written for commit c862250b3111c3e990c2e65a5806d413db788c18. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1210?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

