### PR TITLE
chore(go): 1.26.6, which closes five standard-library vulnerabilities

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -4,7 +4,7 @@ module github.com/gradionhq/margince/backend
 // `ON DELETE SET NULL (column_list)` semantics and current-toolchain
 // tooling. Contributors/operators need the 1.26 toolchain; this is a PoC
 // choice, revisit if broader portability becomes a goal.
-go 1.26.5
+go 1.26.6
 
 // The composed extension set (ADR-0069): a constant import path the role
 // binaries wire — api, worker and mcp today; migrate joins when the

--- a/backend/tools/go.mod
+++ b/backend/tools/go.mod
@@ -13,7 +13,7 @@
 // still tooling — nothing here ships in a binary a customer runs.
 module github.com/gradionhq/margince/backend/tools
 
-go 1.26.5
+go 1.26.6
 
 tool github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen
 

--- a/composition/go.mod
+++ b/composition/go.mod
@@ -8,7 +8,7 @@
 // appears, instead of silently resolving unverified.
 module github.com/gradionhq/margince/composition
 
-go 1.26.5
+go 1.26.6
 
 require github.com/gradionhq/margince/backend v0.0.0
 

--- a/extensions/de/go.mod
+++ b/extensions/de/go.mod
@@ -1,3 +1,3 @@
 module github.com/gradionhq/margince/extensions/de
 
-go 1.26.5
+go 1.26.6

--- a/extensions/notes/go.mod
+++ b/extensions/notes/go.mod
@@ -1,3 +1,3 @@
 module github.com/gradionhq/margince/extensions/notes
 
-go 1.26.5
+go 1.26.6

--- a/extensions/yogi/go.mod
+++ b/extensions/yogi/go.mod
@@ -1,3 +1,3 @@
 module github.com/gradionhq/margince/extensions/yogi
 
-go 1.26.5
+go 1.26.6

--- a/fixtures/extensions/bad-overbudget-table/go.mod
+++ b/fixtures/extensions/bad-overbudget-table/go.mod
@@ -1,3 +1,3 @@
 module example.invalid/margince/fixtures/bad-overbudget-table
 
-go 1.26.5
+go 1.26.6

--- a/fixtures/extensions/bad-unprefixed-table/go.mod
+++ b/fixtures/extensions/bad-unprefixed-table/go.mod
@@ -1,3 +1,3 @@
 module example.invalid/margince/fixtures/bad-unprefixed-table
 
-go 1.26.5
+go 1.26.6

--- a/fixtures/extensions/crm-hello/go.mod
+++ b/fixtures/extensions/crm-hello/go.mod
@@ -1,3 +1,3 @@
 module example.margince.dev/ext/crm-hello
 
-go 1.26.5
+go 1.26.6

--- a/fixtures/extensions/crm-nosy/go.mod
+++ b/fixtures/extensions/crm-nosy/go.mod
@@ -1,3 +1,3 @@
 module example.invalid/margince/fixtures/crm-nosy
 
-go 1.26.5
+go 1.26.6

--- a/go.work
+++ b/go.work
@@ -6,7 +6,7 @@
 // module's go.mod. cli/craft is the code-craftsmanship gate (ADR-0045);
 // stdlib-only, run pre-push via .githooks/pre-push. The local dev stack is a
 // plain shell script (scripts/dev.sh, `make dev`) — no Go module of its own.
-go 1.26.5
+go 1.26.6
 
 use (
 	./backend


### PR DESCRIPTION
## Why

`govulncheck` has been failing on `main`. Five findings, all in the **Go
standard library**, all fixed in **1.26.6**:

| Package | Advisory |
|---|---|
| `net/url` | GO-2026-6218 |
| `crypto/tls` | GO-2026-6090 |
| `net/http` | GO-2026-6089 |
| `encoding/xml`, `encoding/asn1` | (same batch) |

The repo pinned 1.26.5.

## The failures looked intermittent, and that is the point

`bc9782c8` and `5f0fc642` passed; `c0ace3f6` and `65336cd1` failed — with no
relevant difference between them. That is the vulnerability database updating
between runs, not a defect any commit introduced.

`govulncheck` names `gmail.httpAPI.Watch` and `imap.dialLogin` as call paths, but
those are just where the code touches `http.Client.Do` and `tls.Dialer`. They
have done that for months.

A red scan left alone is how everyone learns to read it as noise.

## What changed

Eleven files, every one a version pin: ten `go.mod` (product module, tool chain,
composition stub, three first-party extensions, four extension fixtures) plus the
workspace file. `cli/craft` pins the minor only and needs nothing.

Every CI job resolves its toolchain through `go-version-file: backend/go.mod`, so
the product module's line is what actually moves the runners. The generated
`build/composition/go.work` picks it up from `make composition`, which every
build lane runs.

## Verified

- `make vuln`: **0 vulnerabilities affecting this code**, down from 5
- `make check-backend`, `make craft-static`, `make check-fe`: all green

A patch release can shift behaviour under the fitness tests, which is why the
whole gate ran rather than just the scan.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps the Go toolchain from 1.26.5 to 1.26.6 to close five standard-library vulnerabilities and stabilize security scans. Previously, CI intermittently failed `govulncheck` on 1.26.5 as the vulnerability DB updated; on 1.26.6, scans pass with 0 findings and no code changes.

**Review and rollout**
- Version pins only: updated the `go` directive in 10 `go.mod` files and `go.work`; no source changes.
- Fixes advisories in `net/url`, `crypto/tls`, `net/http`, `encoding/xml`, and `encoding/asn1`; `govulncheck` now reports 0 vulnerabilities.
- CI pulls the toolchain from `backend/go.mod` via the `go-version-file`; developers must use Go 1.26.6 locally.

<sup>Written for commit 722ca1c10e584961d7eaa06f15406af1ad770b47. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1211?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

