### PR TITLE
chore(go): the developer toolchain pin follows the security bump, and a gate keeps it there

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-golang 1.26.5
+golang 1.26.6
 golangci-lint 2.12.2

--- a/backend/goversionpins_test.go
+++ b/backend/goversionpins_test.go
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package backendarch
+
+// One Go version, pinned in several places, and they have to agree.
+//
+// The pins exist for different readers: go.mod is what the compiler and CI
+// resolve (every workflow job uses `go-version-file: backend/go.mod`),
+// .tool-versions is what a developer's asdf/mise shell installs, and the
+// extension how-to is what somebody copies when they start a new unit. Nothing
+// made them move together, so a security bump updated the modules and left the
+// developer pin a patch release behind — which is how a machine keeps building
+// with the vulnerable toolchain the bump was for.
+//
+// This derives the answer from backend/go.mod rather than holding a list: the
+// product module is the pin CI actually reads, so it is the one that decides.
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// goDirective matches the `go 1.26.6` line a module or workspace file carries.
+var goDirective = regexp.MustCompile(`(?m)^go (\d+\.\d+(?:\.\d+)?)$`)
+
+func TestEveryGoVersionPinMatchesTheProductModule(t *testing.T) {
+	want := goVersionOf(t, "go.mod")
+	if strings.Count(want, ".") != 2 {
+		t.Fatalf("backend/go.mod pins %q; a patch version is what the other pins have to match", want)
+	}
+
+	// Each of these is read by somebody the others are not: the workspace by
+	// every bare go command, .tool-versions by a developer's shell, the
+	// how-to by whoever writes the next extension.
+	t.Run("the workspace file", func(t *testing.T) {
+		if got := goVersionOf(t, "../go.work"); got != want {
+			t.Errorf("go.work pins go %s, backend/go.mod pins %s", got, want)
+		}
+	})
+
+	for _, module := range []string{
+		"tools/go.mod",
+		"../composition/go.mod",
+		"../extensions/de/go.mod",
+		"../extensions/notes/go.mod",
+		"../extensions/yogi/go.mod",
+	} {
+		t.Run(module, func(t *testing.T) {
+			if got := goVersionOf(t, module); got != want {
+				t.Errorf("%s pins go %s, backend/go.mod pins %s", module, got, want)
+			}
+		})
+	}
+
+	t.Run("the developer toolchain pin", func(t *testing.T) {
+		pinned := readFile(t, "../.tool-versions")
+		if !strings.Contains(pinned, "golang "+want+"\n") {
+			t.Errorf("`.tool-versions` does not pin golang %s:\n%s\n\n"+
+				"A developer's shell installs what this file says, so a stale pin here "+
+				"keeps building with the toolchain the bump replaced.", want, pinned)
+		}
+	})
+
+	// The how-to is a template somebody copies verbatim into a new module, so a
+	// stale version there is a stale pin in every extension written from it.
+	t.Run("the extension how-to", func(t *testing.T) {
+		doc := readFile(t, "../docs/how-to/add-an-extension.md")
+		if strings.Contains(doc, "go 1.") && !strings.Contains(doc, "go "+want) {
+			t.Errorf("docs/how-to/add-an-extension.md does not show go %s; "+
+				"the template is copied into new modules verbatim", want)
+		}
+	})
+}
+
+func goVersionOf(t *testing.T, path string) string {
+	t.Helper()
+	match := goDirective.FindStringSubmatch(readFile(t, path))
+	if match == nil {
+		t.Fatalf("%s carries no `go <version>` directive", path)
+	}
+	return match[1]
+}
+
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading %s: %v", path, err)
+	}
+	return string(body)
+}

--- a/docs/how-to/add-an-extension.md
+++ b/docs/how-to/add-an-extension.md
@@ -35,7 +35,7 @@ tier owner's review.
    ```text
    module github.com/gradionhq/margince/extensions/<name>
 
-   go 1.26.5
+   go 1.26.6
    ```
 
 3. **Write the declaration** `extensions/<name>/<name>.go`, starting with the BUSL SPDX header (every


### PR DESCRIPTION
Follow-up to #1211, found by the stop-time review.

## What was missed

#1211 moved every `go.mod` and the workspace file to 1.26.6 and left
**`.tool-versions` on 1.26.5**.

That file is what a developer's asdf/mise shell installs. So the machine writing
the code kept building with the exact toolchain the security bump existed to
replace — while CI, which reads `backend/go.mod`, reported green. A vulnerability
fix that lands in CI and not on the developer's machine is the half that matters
least.

Confirmed rather than assumed: `go version` on this machine reported **1.26.5**
before this change and **1.26.6** after it, with nothing else touched.

The extension how-to's template moves too. It is copied verbatim into new
modules, so a stale version there becomes a stale pin in every extension written
from it.

## The gate

`TestEveryGoVersionPinMatchesTheProductModule` derives the answer from
`backend/go.mod` — the pin CI actually resolves — rather than holding a list, and
checks the workspace file, the tool-chain module, the composition stub, the three
first-party extensions, the developer pin and the how-to against it.

Nothing made these move together before, which is precisely why they did not.
Mutation-checked: reverting `.tool-versions` to 1.26.5 fails the subtest by name.

The extension **fixtures** are deliberately excluded — they are synthetic modules
a generator reads, several deliberately malformed, and pinning their contents to
the product's toolchain would make a Go bump edit test data.

## Verified

`make check-backend` and `make craft-static` both green — and this is the first
gate run on 1.26.6 itself.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns all Go version pins to 1.26.6 and adds a test gate to prevent drift. Previously CI resolved 1.26.6 via backend/go.mod while developers installed 1.26.5 from `.tool-versions`; now both resolve 1.26.6 and drift fails fast.

- Updates `.tool-versions` and the extension how-to template to 1.26.6.
- Adds TestEveryGoVersionPinMatchesTheProductModule: derives the version from backend/go.mod and checks go.work, tools/go.mod, composition stub, first-party extensions, `.tool-versions`, and the how-to; intentionally excludes fixtures. 
- Migration: developers using asdf/mise must run mise install or asdf install to install Go 1.26.6.

<sup>Written for commit 937400f4f11023f7ec28376dfc8b6174bf1d9a61. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1216?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

