### PR TITLE
fix(voice): a folder's worth of writing samples arrives three at a time

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -3689,6 +3689,8 @@ export const de = {
     "{name} wurde übersprungen – die Datei enthält keinen Text.",
   "settings.voice.noticeDismissed":
     "{name} wurde übersprungen – nichts darin ließ sich dir zuordnen.",
+  "settings.voice.noticeAskQueueFull":
+    "{name} wurde nicht hinzugefügt – beantworte zuerst die offenen Fragen oben und füge die Datei dann erneut hinzu.",
   "settings.voice.noticeFailed":
     "{name} konnte nicht hinzugefügt werden: {detail}",
   "settings.voice.noticeUnexpected": "{name} konnte nicht hinzugefügt werden.",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -3696,6 +3696,8 @@ export const en = {
   "settings.voice.noticeSkippedEmpty": "{name} was skipped — it has no text.",
   "settings.voice.noticeDismissed":
     "{name} was skipped — nothing in it could be attributed to you.",
+  "settings.voice.noticeAskQueueFull":
+    "{name} was not added — answer the speaker questions above first, then add it again.",
   "settings.voice.noticeFailed": "{name} could not be added: {detail}",
   "settings.voice.noticeUnexpected": "{name} could not be added.",
   "settings.voice.refusalUnattributed":

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -3676,6 +3676,8 @@ export const vi = {
     "Đã bỏ qua {name} — tệp không có nội dung.",
   "settings.voice.noticeDismissed":
     "Đã bỏ qua {name} — không phần nào trong đó quy được cho bạn.",
+  "settings.voice.noticeAskQueueFull":
+    "Chưa thêm {name} — hãy trả lời các câu hỏi người nói ở trên trước, rồi thêm lại tệp này.",
   "settings.voice.noticeFailed": "Không thêm được {name}: {detail}",
   "settings.voice.noticeUnexpected": "Không thêm được {name}.",
   "settings.voice.refusalUnattributed":

--- a/frontend/src/screens/use-voice-intake.ts
+++ b/frontend/src/screens/use-voice-intake.ts
@@ -96,10 +96,14 @@ export function useVoiceIntake({ profileId, onChanged }: UseVoiceIntakeArgs) {
     mounted.current = true;
     return () => {
       mounted.current = false;
-      // Work that never got a slot is abandoned with the card: its results
-      // would have nowhere to go.
-      pending.current = [];
     };
+    // Queued work is deliberately NOT discarded here. The card unmounts on a
+    // path the reader takes constantly: the first sample mints the profile,
+    // which swaps the empty state for the full card — so dropping the queue on
+    // unmount would silently lose every file after the first one a new owner
+    // selected. The work does not need this component (the ingest is a request
+    // whose result the server keeps); only the notices do, and those already
+    // check `mounted` before touching state.
   }, []);
 
   // Notices are keyed by source ref: re-adding the same file replaces its
@@ -193,6 +197,9 @@ export function useVoiceIntake({ profileId, onChanged }: UseVoiceIntakeArgs) {
   // the notice is keyed by the label the reader chose it under.
   const runIntake = useCallback(
     (label: string, start: () => Promise<IntakeOutcome>) => {
+      // The counter is raised unconditionally and lowered only while mounted:
+      // work never starts on an unmounted card, and the whole count is
+      // discarded with the state when one goes away, so the pair cannot drift.
       const work = async (): Promise<void> => {
         setInFlight((count) => count + 1);
         try {
@@ -224,7 +231,9 @@ export function useVoiceIntake({ profileId, onChanged }: UseVoiceIntakeArgs) {
           running.current -= 1;
           return;
         }
-        setQueued(pending.current.length);
+        if (mounted.current) {
+          setQueued(pending.current.length);
+        }
         void next().finally(pump);
       };
 

--- a/frontend/src/screens/use-voice-intake.ts
+++ b/frontend/src/screens/use-voice-intake.ts
@@ -38,7 +38,8 @@ export type IntakeNotice = Readonly<{
     | "skippedEmpty"
     | "refused"
     | "failed"
-    | "dismissed";
+    | "dismissed"
+    | "askQueueFull";
   keptWords?: number;
   inputWords?: number;
   reason?: RefusalReason | null;
@@ -49,6 +50,20 @@ export type IntakeNotice = Readonly<{
 // recent results so it stays a readable summary of what just happened rather
 // than an ever-growing log.
 const MAX_NOTICES = 6;
+
+// How many sources are read and previewed at once. Selecting a folder's worth
+// of files used to start every read and every preview simultaneously, which
+// hands the server a burst it has no reason to receive and holds every file's
+// text in memory at the same time. Three keeps a multi-file add feeling
+// immediate while the rest wait their turn.
+const MAX_CONCURRENT_INTAKE = 3;
+
+// How many unanswered speaker questions may be held. Each one retains the full
+// text of its source until it is answered or dismissed, and a reader can only
+// answer them one at a time anyway — a queue longer than this is memory held
+// against a question nobody is going to reach soon. Further conversational
+// files are declined with a notice rather than silently dropped.
+const MAX_PENDING_ASKS = 5;
 
 type UseVoiceIntakeArgs = Readonly<{
   /** null while the owner has no profile — the first add mints it through the
@@ -63,11 +78,27 @@ export function useVoiceIntake({ profileId, onChanged }: UseVoiceIntakeArgs) {
   const [asks, setAsks] = useState<readonly SpeakerAsk[]>([]);
   const [notices, setNotices] = useState<readonly IntakeNotice[]>([]);
   const [inFlight, setInFlight] = useState(0);
+  const [queued, setQueued] = useState(0);
   const mounted = useRef(true);
+  // The work still waiting for a slot, and how many slots are taken. Both live
+  // in refs because the queue is driven from promise callbacks: reading them
+  // from state would read whatever the closure captured when the intake
+  // started, not what is true when it finishes.
+  const pending = useRef<(() => Promise<void>)[]>([]);
+  const running = useRef(0);
+  // The pending questions as they stand RIGHT NOW. Several previews can answer
+  // between two renders, so a count read off `asks` would be the same stale
+  // number for all of them and the cap below would never bite. Every change
+  // goes through this ref and `setAsks` together; it is never re-synced from
+  // the rendered value, which would undo changes made since that render.
+  const asksRef = useRef<readonly SpeakerAsk[]>(asks);
   useEffect(() => {
     mounted.current = true;
     return () => {
       mounted.current = false;
+      // Work that never got a slot is abandoned with the card: its results
+      // would have nowhere to go.
+      pending.current = [];
     };
   }, []);
 
@@ -98,19 +129,39 @@ export function useVoiceIntake({ profileId, onChanged }: UseVoiceIntakeArgs) {
           });
           onChanged();
           return;
-        case "speaker-needed":
-          // A re-upload under the same name supersedes its pending question;
+        case "speaker-needed": {
+          // A re-upload of the same writing supersedes its pending question;
           // the ingest is idempotent on source_ref server-side.
-          setAsks((prev) => [
-            ...prev.filter((ask) => ask.ref !== outcome.ref),
+          const supersedes = asksRef.current.some(
+            (ask) => ask.ref === outcome.ref,
+          );
+          // Each unanswered question holds its source's full text, and they
+          // are answered one at a time. Past the cap the file is declined
+          // outright rather than queued into memory nobody will reach.
+          if (!supersedes && asksRef.current.length >= MAX_PENDING_ASKS) {
+            note({
+              ref: outcome.ref,
+              label: outcome.label,
+              tone: "warn",
+              kind: "askQueueFull",
+            });
+            return;
+          }
+          // The ref is advanced HERE, not only on the next render: several
+          // previews can answer before React re-renders once, and each would
+          // otherwise read the same stale length and queue past the cap.
+          asksRef.current = [
+            ...asksRef.current.filter((ask) => ask.ref !== outcome.ref),
             {
               ref: outcome.ref,
               label: outcome.label,
               content: outcome.content,
               preview: outcome.preview,
             },
-          ]);
+          ];
+          setAsks(asksRef.current);
           return;
+        }
         case "refused":
           note({
             ref: outcome.ref,
@@ -142,10 +193,11 @@ export function useVoiceIntake({ profileId, onChanged }: UseVoiceIntakeArgs) {
   // the notice is keyed by the label the reader chose it under.
   const runIntake = useCallback(
     (label: string, start: () => Promise<IntakeOutcome>) => {
-      setInFlight((count) => count + 1);
-      start()
-        .then(applyOutcome)
-        .catch((err: unknown) => {
+      const work = async (): Promise<void> => {
+        setInFlight((count) => count + 1);
+        try {
+          applyOutcome(await start());
+        } catch (err: unknown) {
           console.error("voice corpus intake failed unexpectedly", err);
           if (mounted.current) {
             note({
@@ -156,12 +208,33 @@ export function useVoiceIntake({ profileId, onChanged }: UseVoiceIntakeArgs) {
               problem: err,
             });
           }
-        })
-        .finally(() => {
+        } finally {
           if (mounted.current) {
             setInFlight((count) => count - 1);
           }
-        });
+        }
+      };
+
+      // Take a slot if one is free, otherwise wait for one. `pump` is what
+      // hands the slot on, so it runs whether the work succeeded or failed —
+      // a source that could not be read must not strand the queue behind it.
+      const pump = () => {
+        const next = pending.current.shift();
+        if (next === undefined) {
+          running.current -= 1;
+          return;
+        }
+        setQueued(pending.current.length);
+        void next().finally(pump);
+      };
+
+      if (running.current < MAX_CONCURRENT_INTAKE) {
+        running.current += 1;
+        void work().finally(pump);
+        return;
+      }
+      pending.current.push(work);
+      setQueued(pending.current.length);
     },
     [applyOutcome, note],
   );
@@ -200,18 +273,26 @@ export function useVoiceIntake({ profileId, onChanged }: UseVoiceIntakeArgs) {
 
   const pendingAsk = asks[0] ?? null;
 
+  // Settling a question frees one of the capped slots, so the ref moves with
+  // the state — otherwise answering questions would never restore capacity
+  // and every later conversational file would be declined.
+  const settleAsk = useCallback((ref: string) => {
+    asksRef.current = asksRef.current.filter((ask) => ask.ref !== ref);
+    setAsks(asksRef.current);
+  }, []);
+
   const answerSpeaker = useCallback(
     (speakerLabel: string) => {
       const ask = asks[0];
       if (ask === undefined) {
         return;
       }
-      setAsks((prev) => prev.filter((candidate) => candidate.ref !== ask.ref));
+      settleAsk(ask.ref);
       runIntake(ask.label, () =>
         intakeTranscript(ask.ref, ask.label, ask.content, speakerLabel),
       );
     },
-    [asks, runIntake],
+    [asks, runIntake, settleAsk],
   );
 
   // Declining to attribute a transcript drops it: none of it can be proven to
@@ -221,14 +302,14 @@ export function useVoiceIntake({ profileId, onChanged }: UseVoiceIntakeArgs) {
     if (ask === undefined) {
       return;
     }
-    setAsks((prev) => prev.filter((candidate) => candidate.ref !== ask.ref));
+    settleAsk(ask.ref);
     note({
       ref: ask.ref,
       label: ask.label,
       tone: "warn",
       kind: "dismissed",
     });
-  }, [asks, note]);
+  }, [asks, note, settleAsk]);
 
   return {
     addFiles,
@@ -239,7 +320,7 @@ export function useVoiceIntake({ profileId, onChanged }: UseVoiceIntakeArgs) {
     notices,
     /** True while any preview, ingest, or unanswered speaker question is open
      * — a build started now would misrepresent what the voice is made of. */
-    busy: inFlight > 0 || asks.length > 0,
+    busy: inFlight > 0 || queued > 0 || asks.length > 0,
     /** The profile the caller was rendered for; the core mints one on the
      * first add when this is null. */
     profileId,

--- a/frontend/src/screens/voice-corpus-settings.test.tsx
+++ b/frontend/src/screens/voice-corpus-settings.test.tsx
@@ -309,6 +309,107 @@ describe("handing a file to the Settings voice card", () => {
   });
 });
 
+// Intake is bounded so that selecting a large batch does not hand the server
+// one request per file at once, or hold every file's text in memory at the
+// same time. What the reader sees is unchanged: every file still lands, and
+// the ones past the bound simply wait their turn.
+describe("adding many files at once", () => {
+  // A stub whose previews stay open until the test releases them, so the
+  // number in flight can actually be counted rather than inferred.
+  function stubHeldPreviews(result: CorpusPreview) {
+    let inFlight = 0;
+    let peak = 0;
+    const ingested: string[] = [];
+    const release: (() => void)[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (request: Request) => {
+        const path = new URL(request.url).pathname.replace(/^\/v1/, "");
+        if (path === "/voice-profiles") {
+          return jsonResponse({
+            data: [{ id: "vp-1" }],
+            page: { next_cursor: null, has_more: false },
+          });
+        }
+        if (path === "/voice-profiles/vp-1/sources/preview") {
+          inFlight += 1;
+          peak = Math.max(peak, inFlight);
+          await new Promise<void>((resolve) => release.push(resolve));
+          inFlight -= 1;
+          return jsonResponse(result);
+        }
+        if (path === "/voice-profiles/vp-1/sources") {
+          const body = JSON.parse(await request.text());
+          ingested.push(String(body.source_label));
+          return jsonResponse(
+            { source: {}, summary: SUMMARY, ingest_stats: STATS },
+            201,
+          );
+        }
+        return jsonResponse({});
+      }),
+    );
+    return {
+      peak: () => peak,
+      ingested: () => ingested,
+      // Drains whatever is waiting, repeatedly: releasing the first batch is
+      // what lets the queue hand slots to the next one.
+      releaseAll: async () => {
+        for (let round = 0; round < 40 && release.length > 0; round++) {
+          release.shift()?.();
+          await new Promise((resolve) => setTimeout(resolve, 0));
+        }
+      },
+    };
+  }
+
+  it("previews at most three files at a time, and still gets through all of them", async () => {
+    const held = stubHeldPreviews(PROSE);
+    render(<VoiceCorpusIntake profileId="vp-1" onChanged={() => {}} />);
+
+    await userEvent.upload(
+      fileInput(),
+      Array.from({ length: 9 }, (_, i) => fileOf(`s${i}.txt`, `Sample ${i}.`)),
+    );
+    await waitFor(() => expect(held.peak()).toBe(3));
+
+    // Releasing lets the queue hand its slots on. Every file still lands —
+    // the bound delays work, it never drops it. (The notices list is capped
+    // at six, so the ingests are what proves all nine got through.)
+    await held.releaseAll();
+    await waitFor(
+      () => {
+        expect(held.ingested().length).toBe(9);
+      },
+      { timeout: 4000 },
+    );
+    expect(new Set(held.ingested()).size).toBe(9);
+    expect(held.peak()).toBe(3);
+  });
+
+  // Each unanswered question holds its source's whole text, and the reader
+  // answers them one at a time. Past the cap a file is declined out loud
+  // rather than queued into memory nobody will reach.
+  it("declines a conversational file once five questions are already waiting", async () => {
+    stubApi(CONVERSATION);
+    render(<VoiceCorpusIntake profileId="vp-1" onChanged={() => {}} />);
+
+    await userEvent.upload(
+      fileInput(),
+      Array.from({ length: 7 }, (_, i) =>
+        fileOf(`talk${i}.vtt`, `Lars: turn ${i}. Sam: ok ${i}.`),
+      ),
+    );
+
+    // Five questions are held; the sixth and seventh are turned away with a
+    // notice that says what to do about it. Only one question is on screen at
+    // a time, so the notice is the visible evidence of the cap.
+    await waitFor(() => {
+      expect(screen.getAllByText(/was not added/).length).toBe(2);
+    });
+  });
+});
+
 describe("dropping a file on the page", () => {
   it("takes a file dropped on the intake area", async () => {
     const bodies = stubApi(PROSE);

--- a/frontend/src/screens/voice-corpus-settings.test.tsx
+++ b/frontend/src/screens/voice-corpus-settings.test.tsx
@@ -94,6 +94,19 @@ function fileOf(name: string, text: string): File {
   return new File([text], name, { type: "text/plain" });
 }
 
+// A file that reports when its contents are read. Holding a file's text is
+// what the concurrency bound is protecting memory against, so the tests count
+// reads directly rather than inferring them from request traffic.
+function countingFileOf(name: string, text: string, onRead: () => void): File {
+  const file = fileOf(name, text);
+  return Object.assign(file, {
+    text: async () => {
+      onRead();
+      return text;
+    },
+  });
+}
+
 // The hidden input the "Choose files" button clicks. userEvent.upload needs
 // the input itself, which carries no accessible name by design.
 function fileInput(): HTMLInputElement {
@@ -314,6 +327,22 @@ describe("handing a file to the Settings voice card", () => {
 // same time. What the reader sees is unchanged: every file still lands, and
 // the ones past the bound simply wait their turn.
 describe("adding many files at once", () => {
+  // Which source an ingest names, read without asserting a shape onto parsed
+  // JSON: the body is whatever the client actually sent, so it is narrowed
+  // rather than cast.
+  function sourceLabelOf(rawBody: string): string {
+    const body: unknown = JSON.parse(rawBody);
+    if (
+      typeof body === "object" &&
+      body !== null &&
+      "source_label" in body &&
+      typeof body.source_label === "string"
+    ) {
+      return body.source_label;
+    }
+    throw new Error(`ingest body carried no source_label: ${rawBody}`);
+  }
+
   // A stub whose previews stay open until the test releases them, so the
   // number in flight can actually be counted rather than inferred.
   function stubHeldPreviews(result: CorpusPreview) {
@@ -339,8 +368,7 @@ describe("adding many files at once", () => {
           return jsonResponse(result);
         }
         if (path === "/voice-profiles/vp-1/sources") {
-          const body = JSON.parse(await request.text());
-          ingested.push(String(body.source_label));
+          ingested.push(sourceLabelOf(await request.text()));
           return jsonResponse(
             { source: {}, summary: SUMMARY, ingest_stats: STATS },
             201,
@@ -365,13 +393,23 @@ describe("adding many files at once", () => {
 
   it("previews at most three files at a time, and still gets through all of them", async () => {
     const held = stubHeldPreviews(PROSE);
+    // Reads are counted as well as requests: the bound exists to stop nine
+    // files' worth of text being held at once, and a version that read every
+    // file up front while only previewing three would satisfy the request
+    // count alone.
+    let reads = 0;
     render(<VoiceCorpusIntake profileId="vp-1" onChanged={() => {}} />);
 
     await userEvent.upload(
       fileInput(),
-      Array.from({ length: 9 }, (_, i) => fileOf(`s${i}.txt`, `Sample ${i}.`)),
+      Array.from({ length: 9 }, (_, i) =>
+        countingFileOf(`s${i}.txt`, `Sample ${i}.`, () => {
+          reads += 1;
+        }),
+      ),
     );
     await waitFor(() => expect(held.peak()).toBe(3));
+    expect(reads).toBe(3);
 
     // Releasing lets the queue hand its slots on. Every file still lands —
     // the bound delays work, it never drops it. (The notices list is capped
@@ -385,6 +423,35 @@ describe("adding many files at once", () => {
     );
     expect(new Set(held.ingested()).size).toBe(9);
     expect(held.peak()).toBe(3);
+  });
+
+  // The card unmounts on a path the reader takes constantly: the first sample
+  // mints the profile, which swaps the empty state for the full card. Files
+  // still waiting for a slot at that moment must survive it — a new owner who
+  // selects six samples must not silently end up with the three that happened
+  // to start first.
+  it("finishes files still queued when the card is replaced mid-intake", async () => {
+    const held = stubHeldPreviews(PROSE);
+    const view = render(
+      <VoiceCorpusIntake profileId="vp-1" onChanged={() => {}} />,
+    );
+
+    await userEvent.upload(
+      fileInput(),
+      Array.from({ length: 6 }, (_, i) => fileOf(`q${i}.txt`, `Sample ${i}.`)),
+    );
+    await waitFor(() => expect(held.peak()).toBe(3));
+
+    // Three are running, three are still queued when the card goes away.
+    view.unmount();
+    await held.releaseAll();
+
+    await waitFor(
+      () => {
+        expect(held.ingested().length).toBe(6);
+      },
+      { timeout: 4000 },
+    );
   });
 
   // Each unanswered question holds its source's whole text, and the reader
@@ -402,10 +469,23 @@ describe("adding many files at once", () => {
     );
 
     // Five questions are held; the sixth and seventh are turned away with a
-    // notice that says what to do about it. Only one question is on screen at
-    // a time, so the notice is the visible evidence of the cap.
+    // notice that says what to do about it.
     await waitFor(() => {
       expect(screen.getAllByText(/was not added/).length).toBe(2);
+    });
+
+    // And the five that were kept are all still reachable: answering one
+    // brings up the next, five times over. Counting refusals alone would pass
+    // just as happily if questions had been dropped instead of queued.
+    for (let answered = 0; answered < 5; answered++) {
+      await screen.findByText(/Which speaker are you in/);
+      await userEvent.click(screen.getByRole("radio", { name: /^Lars/ }));
+      await userEvent.click(
+        screen.getByRole("button", { name: "That one is me" }),
+      );
+    }
+    await waitFor(() => {
+      expect(screen.queryByText(/Which speaker are you in/)).toBeNull();
     });
   });
 });

--- a/frontend/src/screens/voice-corpus-settings.tsx
+++ b/frontend/src/screens/voice-corpus-settings.tsx
@@ -195,6 +195,8 @@ function noticeText(t: ReturnType<typeof useT>, notice: IntakeNotice): string {
       return t("settings.voice.noticeSkippedEmpty", { name: notice.label });
     case "dismissed":
       return t("settings.voice.noticeDismissed", { name: notice.label });
+    case "askQueueFull":
+      return t("settings.voice.noticeAskQueueFull", { name: notice.label });
     case "refused":
       switch (notice.reason) {
         case "unattributed":


### PR DESCRIPTION
Closes #1212.

## What was wrong

`useVoiceIntake.addFiles` started `file.text()` and a `/sources/preview` request for **every selected file at once**, with no bound. Pending speaker questions were likewise uncapped, and each one retains its source's full text until it is answered or dismissed.

Nothing was corrupted — every file was still attributed correctly — but selecting a large batch handed the server one request per file simultaneously and held every file's text in memory at the same time.

## The change

Intake runs **three at a time** through a small queue. The bound only delays work: every file still lands. The test asserts that by counting **ingests**, not notices — the notice list caps at six, so it cannot speak for nine files.

Unanswered speaker questions cap at **five**. Past that a file is declined with a notice that says what to do (answer the open questions, then add it again) rather than being dropped silently.

## The bug found while testing this

The cap did not fire at first. The pending-question count was read off rendered state, and several previews can answer between two renders — so all of them saw the same stale number. The count now lives in a ref that advances at the moment it changes, and answering or dismissing advances the same ref, or settling a question would never restore capacity and every later conversational file would be refused.

## Verification

`make check-fe` green (2581 tests), `make craft-static` clean. Both bounds mutation-checked: raising `MAX_CONCURRENT_INTAKE` fails the concurrency test, removing the queue cap fails the other.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Process voice intake three at a time and cap unanswered speaker questions at five to prevent server bursts and excessive memory use; queued work now survives card unmount so multi-file adds are not lost. Previously every selected file started read/preview simultaneously, questions were uncapped, and queued files could be discarded on unmount.

- Queue in `use-voice-intake`: `MAX_CONCURRENT_INTAKE=3`; refs track pending/running; a pump hands off slots on success/failure; `busy` includes queued work; queued work persists across unmount.
- Speaker question cap: `MAX_PENDING_ASKS=5`; re-uploads supersede existing questions; declines emit `askQueueFull` with new i18n strings (en/de/vi) and UI mapping in `noticeText`.
- Fixed stale-count bug: maintain asks in a ref updated immediately; shared `settleAsk` frees capacity on answer/dismiss.
- Tests: count file reads and assert peak previews stay at 3; ensure queued samples finish after the card is replaced mid-intake; verify the 6th+ conversational files are declined while five remain answerable.

<sup>Written for commit dac6787e3d6bf39500088004f10e7ac560f3ec2e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1217?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

