### PR TITLE
fix(voice): dropping several files keeps every one of them

### DIFF
--- a/frontend/src/screens/onboarding-conversation/use-voice-corpus.ts
+++ b/frontend/src/screens/onboarding-conversation/use-voice-corpus.ts
@@ -289,7 +289,7 @@ export function useVoiceCorpus({
           async (stamp) => {
             const text = await file.text();
             return intakeUpload(
-              sourceRef("upload", text),
+              sourceRef("upload", file.name, text),
               file.name,
               text,
               stamp,
@@ -305,7 +305,7 @@ export function useVoiceCorpus({
 
   const addPaste = useCallback(
     (text: string, label: string) => {
-      const ref = sourceRef("paste", text);
+      const ref = sourceRef("paste", label, text);
       dispatch({ type: "UPLOAD_ADDED", id: ref, name: label });
       runIntake(
         (stamp) => intakePaste(ref, label, text, stamp),

--- a/frontend/src/screens/use-voice-intake.ts
+++ b/frontend/src/screens/use-voice-intake.ts
@@ -264,7 +264,11 @@ export function useVoiceIntake({ profileId, onChanged }: UseVoiceIntakeArgs) {
         }
         runIntake(file.name, async () => {
           const text = await file.text();
-          return intakeUpload(sourceRef("upload", text), file.name, text);
+          return intakeUpload(
+            sourceRef("upload", file.name, text),
+            file.name,
+            text,
+          );
         });
       }
     },
@@ -274,7 +278,7 @@ export function useVoiceIntake({ profileId, onChanged }: UseVoiceIntakeArgs) {
   const addPaste = useCallback(
     (text: string, label: string) => {
       runIntake(label, () =>
-        intakePaste(sourceRef("paste", text), label, text),
+        intakePaste(sourceRef("paste", label, text), label, text),
       );
     },
     [runIntake],

--- a/frontend/src/screens/voice-corpus-settings.test.tsx
+++ b/frontend/src/screens/voice-corpus-settings.test.tsx
@@ -512,6 +512,67 @@ describe("dropping a file on the page", () => {
     await waitFor(() => expect(bodies).toHaveLength(1));
   });
 
+  // Reported from the running product: dropping several files took only the
+  // first. Every drop test here used ONE file, so nothing caught it.
+  it("takes every file in a multi-file drop", async () => {
+    const bodies = stubApi(PROSE);
+    render(<VoiceCorpusIntake profileId="vp-1" onChanged={() => {}} />);
+    const zone = document.querySelector(".vdna-intake");
+    if (!(zone instanceof HTMLElement)) {
+      throw new Error("no drop zone rendered");
+    }
+
+    const drop = new Event("drop", { bubbles: true, cancelable: true });
+    Object.defineProperty(drop, "dataTransfer", {
+      value: {
+        types: ["Files"],
+        files: [
+          fileOf("one.txt", "First sample."),
+          fileOf("two.txt", "Second sample."),
+          fileOf("three.txt", "Third sample."),
+        ],
+      },
+    });
+    Object.defineProperty(drop, "target", { value: zone });
+    window.dispatchEvent(drop);
+
+    await waitFor(() => expect(bodies).toHaveLength(3), { timeout: 4000 });
+  });
+
+  // The real defect behind that report: the server upserts on source_ref, and
+  // a key derived from content ALONE gave three files holding the same text
+  // one key — so each silently replaced the last and the drop looked like it
+  // had taken a single file. Copies of a sample, or several drafts exported
+  // from one template, are exactly this shape.
+  it("keeps files that share their text but not their name", async () => {
+    const bodies = stubApi(PROSE);
+    render(<VoiceCorpusIntake profileId="vp-1" onChanged={() => {}} />);
+    const zone = document.querySelector(".vdna-intake");
+    if (!(zone instanceof HTMLElement)) {
+      throw new Error("no drop zone rendered");
+    }
+
+    const same = "The same words in every one of these files.";
+    const drop = new Event("drop", { bubbles: true, cancelable: true });
+    Object.defineProperty(drop, "dataTransfer", {
+      value: {
+        types: ["Files"],
+        files: [
+          fileOf("dup1.txt", same),
+          fileOf("dup2.txt", same),
+          fileOf("dup3.txt", same),
+        ],
+      },
+    });
+    Object.defineProperty(drop, "target", { value: zone });
+    window.dispatchEvent(drop);
+
+    await waitFor(() => expect(bodies).toHaveLength(3), { timeout: 4000 });
+    // Three DISTINCT rows, not one row written over three times.
+    const refs = new Set(bodies.map((body) => body.source_ref));
+    expect(refs.size).toBe(3);
+  });
+
   // A file dropped on the command palette or any other overlay belongs to
   // nobody. Feeding it to whatever screen happens to sit behind is how a
   // stray file silently becomes part of someone's voice.

--- a/frontend/src/screens/voice-intake-core.test.ts
+++ b/frontend/src/screens/voice-intake-core.test.ts
@@ -201,7 +201,7 @@ describe("the request bodies the server actually receives", () => {
     const bodies = stubApi(preview());
     const text = "Short sentences. Concrete nouns.";
     const outcome = await intakeUpload(
-      sourceRef("upload", text),
+      sourceRef("upload", "letter.txt", text),
       "letter.txt",
       text,
     );
@@ -239,7 +239,11 @@ describe("the request bodies the server actually receives", () => {
   it("sends pasted prose as prose the owner claimed as their own", async () => {
     const bodies = stubApi(preview());
     const text = "Some words.";
-    await intakePaste(sourceRef("paste", text), "Pasted writing", text);
+    await intakePaste(
+      sourceRef("paste", "Pasted writing", text),
+      "Pasted writing",
+      text,
+    );
     expect(bodies[0]).toMatchObject({
       kind: "other",
       register: "general",
@@ -262,7 +266,7 @@ describe("the request bodies the server actually receives", () => {
       }),
     );
     const outcome = await intakePaste(
-      sourceRef("paste", "Lars: hi. Sam: hello."),
+      sourceRef("paste", "Pasted writing", "Lars: hi. Sam: hello."),
       "Pasted writing",
       "Lars: hi. Sam: hello.",
     );
@@ -329,30 +333,44 @@ describe("which files are offered to the server at all", () => {
   });
 });
 
-// The server upserts on source_ref, so the key has to identify the WRITING.
-// Keyed by filename, two different files both called "meeting.txt" would
-// silently overwrite each other, and the same file added from two surfaces
-// would be counted twice.
+// The server upserts on source_ref, so any two sources sharing a key become
+// ONE row and the later silently replaces the earlier. The key is the name and
+// the content together: either half alone loses real sources.
 describe("source_ref, the key the ingest is idempotent on", () => {
-  it("is the same for the same writing, so a retry updates one row", () => {
-    expect(sourceRef("upload", "the same words")).toBe(
-      sourceRef("upload", "the same words"),
+  it("is the same for the same file, so a retry updates one row", () => {
+    expect(sourceRef("upload", "letter.txt", "the same words")).toBe(
+      sourceRef("upload", "letter.txt", "the same words"),
     );
   });
 
+  // The reported bug: dropping several files that happen to hold the same
+  // text — copies of a sample, or exports from one template — collapsed into
+  // a single row, so the drop looked like it had taken only the first.
+  it("keeps differently-named files apart even when their text is identical", () => {
+    const same = "The same words in every one of these files.";
+    const refs = new Set([
+      sourceRef("upload", "dup1.txt", same),
+      sourceRef("upload", "dup2.txt", same),
+      sourceRef("upload", "dup3.txt", same),
+    ]);
+    expect(refs.size).toBe(3);
+  });
+
   it("differs for different writing under the same file name", () => {
-    expect(sourceRef("upload", "one meeting")).not.toBe(
-      sourceRef("upload", "a different meeting"),
+    expect(sourceRef("upload", "meeting.txt", "one meeting")).not.toBe(
+      sourceRef("upload", "meeting.txt", "a different meeting"),
     );
   });
 
   it("does not collide when only the length matches", () => {
-    expect(sourceRef("upload", "abcd")).not.toBe(sourceRef("upload", "dcba"));
+    expect(sourceRef("upload", "a.txt", "abcd")).not.toBe(
+      sourceRef("upload", "a.txt", "dcba"),
+    );
   });
 
   it("stays inside the contract's 512-character cap", () => {
-    expect(sourceRef("upload", "x".repeat(90000)).length).toBeLessThanOrEqual(
-      512,
-    );
+    expect(
+      sourceRef("upload", "y".repeat(9000), "x".repeat(90000)).length,
+    ).toBeLessThanOrEqual(512);
   });
 });

--- a/frontend/src/screens/voice-intake-core.ts
+++ b/frontend/src/screens/voice-intake-core.ts
@@ -32,14 +32,19 @@ export const TRANSCRIPT_EXT = /\.(vtt|srt|json)$/i;
 export const VOICE_MIN_WORDS = 800;
 
 // source_ref is the contract's stable natural key and the server upserts on it
-// (ON CONFLICT (voice_profile_id, source_ref)). That makes it an identity, not
-// a label: two different files both called "meeting.txt" must not claim the
-// same key, and the same text handed over twice must not become two rows.
+// (ON CONFLICT (voice_profile_id, source_ref)), so two sources that share a key
+// become ONE row and the later one silently replaces the earlier.
 //
-// So the key is derived from the CONTENT. Re-adding the same writing updates
-// the one row it already made, and two different files keep their own rows
-// whatever they are called. The name is not part of it — a file renamed is
-// still the same writing, and a name cannot be trusted to be unique.
+// The key is therefore the name AND the content together. Content alone is
+// wrong: dropping several files that happen to hold the same text — three
+// exported drafts from one template, or copies of a sample under different
+// names — collapsed them into a single row, so a multi-file drop looked like
+// it had taken only the first. Name alone is wrong the other way: two
+// different files both called "meeting.txt" would overwrite each other.
+//
+// Together they say what a reader means: re-adding the same file updates the
+// one row it already made, and anything that differs in either name or content
+// keeps its own.
 const SOURCE_REF_MAX = 512;
 const SOURCE_LABEL_MAX = 255;
 
@@ -60,9 +65,18 @@ function contentKey(content: string): string {
   return `${hash.toString(16).padStart(8, "0")}-${content.length}`;
 }
 
-/** The key one piece of writing is known by, wherever it was handed over. */
-export function sourceRef(kind: "upload" | "paste", content: string): string {
-  return clamp(`voice:${kind}:${contentKey(content)}`, SOURCE_REF_MAX);
+/** The key one source is known by: what it is called and what it says. The
+ * label is hashed rather than embedded so a long filename cannot push the
+ * content half of the key past the contract's 512-character cap. */
+export function sourceRef(
+  kind: "upload" | "paste",
+  label: string,
+  content: string,
+): string {
+  return clamp(
+    `voice:${kind}:${contentKey(label)}:${contentKey(content)}`,
+    SOURCE_REF_MAX,
+  );
 }
 
 // What one previewed source honestly IS.


### PR DESCRIPTION
Reported from the running product: dragging multiple files onto the Settings voice card appeared to take only the first.

## The cause was the source key, not the drop handler

The drop handler passes the whole `FileList` and the intake loops over all of it — both were fine. Since #1217 the `source_ref` was derived from the file's **content alone**, and the server upserts on that key (`ON CONFLICT (voice_profile_id, source_ref)`). Several files holding the same text therefore claimed **one row**, each silently replacing the last.

Reproduced against a running server before the fix — three files, three POSTs, all returning 201, all carrying the same key:

```
dup1.txt|voice:upload:bcb61ae1-1320
dup2.txt|voice:upload:bcb61ae1-1320
dup3.txt|voice:upload:bcb61ae1-1320
```

Copies of a sample, or several drafts exported from one template, are exactly this shape.

## The fix

The key is the **name and the content together**. Either half alone loses real sources: content alone collapses same-text files, and name alone would let two different files both called `meeting.txt` overwrite each other. Together they say what a reader means — re-adding the same file updates the one row it already made, and anything differing in either keeps its own. The label is hashed rather than embedded so a long filename cannot push the content half past the contract's 512-character cap.

After, on the same server: three rows, 810 words.

```
dup1.txt | 270 words | voice:upload:80db0893-8:bcb61ae1-1320
dup2.txt | 270 words | voice:upload:7d9f83aa-8:bcb61ae1-1320
dup3.txt | 270 words | voice:upload:f2114649-8:bcb61ae1-1320
```

## Why no test caught it

**Every existing drop test used a single file.** Two new ones close that: one drops three ordinary files, one drops three that share their text and asserts three *distinct* `source_ref`s. Both mutation-checked against the old content-only key — the second fails with "expected 1 to be 3", which is exactly the reported symptom.

`make check-fe` green (2585 tests), `make craft-static` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes multi-file drop in Voice intake: files that share text no longer collapse into one row. Previously `source_ref` used content only; now it uses name + content (both hashed) so the server upsert preserves each distinct file.

- Review notes:
  - `sourceRef` now takes `(kind, label, content)` and builds `voice:${kind}:${hash(label)}:${hash(content)}` capped at 512 chars. Call sites for uploads and paste updated.
  - Re-adding the same file updates one row; same content with different names keeps separate rows; same name with different content keeps separate rows.
  - Adds tests for multi-file drops and identical-content/different-name cases to prevent regressions.

<sup>Written for commit a7fffd8d4a7320eabd43a75adc973cc943ef68f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1220?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

