### PR TITLE
fix(deps): postcss names its inputs with a nanoid that cannot spin

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1573,8 +1573,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -3360,7 +3360,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.17: {}
+  nanoid@3.3.18: {}
 
   node-html-parser@9.0.1:
     dependencies:
@@ -3446,7 +3446,7 @@ snapshots:
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 


### PR DESCRIPTION
Closes the open Dependabot alert (#20) on the default branch.

## The advisory

GHSA-2v37-7h3g-55p8 / CVE-2026-67213 (high, CWE-835): nanoid's
`customAlphabet` and `customRandom` never satisfy their exit condition when
called with `size: 0`, spinning the calling thread. Fixed in 3.3.18 on the 3.x
line.

## The route, and why the lockfile is the whole change

nanoid is transitive here: `vite -> postcss -> nanoid`. postcss@8.5.25 already
declares `nanoid: ^3.3.16`, so the range admits 3.3.18 and lifting the lockfile
is sufficient.

No `overrides` entry. The block in `pnpm-workspace.yaml` exists for a transitive
dependency whose direct dependent pins *below* the fix — the js-yaml case, where
`@redocly/openapi-core` requires an exact 4.3.0. That does not apply here, and
adding an override we do not need would leave a floor nobody can later prove is
safe to remove.

## Exposure on this codebase: none

Worth stating plainly rather than lifting on the severity label alone:

- postcss calls nanoid at exactly one site — `nanoid(6)` in `lib/input.js`,
  naming an input for source maps. That is the plain generator at a **hardcoded
  size**, not the `customAlphabet` / `customRandom` pair the advisory concerns.
- postcss arrives through vite, so it runs at **build time** and never ships to
  a browser. There is no attacker-controlled `size` anywhere on the path.

The bump is hygiene: a high advisory standing open on a public repository costs
more than a patch-level lift of a leaf package.

## Note for reviewers on the diff size

Regenerated with **pnpm 11**, the version `pnpm/action-setup` pins in CI, so the
diff is the four nanoid lines and nothing else. pnpm 10 resolves the same graph
but writes the older peer-suffix shape, which rewrites ~60 unrelated lines and
buries the change that matters. Worth knowing before touching this lockfile from
a machine whose pnpm is still on 10.

## Verification

- `make check-fe` green: `fe-typecheck-composed`, `fe-ds-gates`, `fe-drift`,
  `fe-lint`, `fe-unit`, `fe-build`, and `fe-test-ext` (21 tests).
- `nanoid@3.3.18` on disk; no 3.3.17 remains in the lockfile.
- CI's `frontend` filter lists `pnpm-lock.yaml` and `deps` lists
  `**/pnpm-lock.yaml`, so the FE lanes and the licence/SBOM lanes both see this
  change — no filter edit needed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolves the Dependabot alert by updating transitive `nanoid` to 3.3.18 via `pnpm-lock.yaml`. Behavior is unchanged: `postcss` uses `nanoid(6)` at build time (through `vite`), not the vulnerable `customAlphabet`/`customRandom` APIs.

**Review notes**
- Lockfile-only change; `postcss@8.5.25` already ranges `nanoid: ^3.3.16`, so the fix version is selected without `overrides`.
- No runtime exposure: path is `vite -> postcss -> nanoid`, executed during builds with a hardcoded size.
- Regenerated with `pnpm` 11 (as in CI) to avoid unrelated peer-suffix churn; the diff is four lines.

<sup>Written for commit a1ca2f6205a7bb4eafd6715a2bd74ae45b24027c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1222?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

