### PR TITLE
feat(email): caller markup is filtered before it reaches a recipient

### DIFF
--- a/backend/.go-arch-lint.yml
+++ b/backend/.go-arch-lint.yml
@@ -158,8 +158,12 @@ deps:
     # in the product module, not tools.
     canUse: [pgx, oapi, fpdf]
   activities:
+    # xnet: the html parser behind the outbound markup allowlist. A mail body a
+    # caller supplies is filtered by PARSING it and re-emitting only what the
+    # allowlist admits — a regex over markup is the approach that always has one
+    # more case, and the tokenizer here is the same one webread already uses.
     mayDependOn: [contracts, platform]
-    canUse: [pgx, oapi]
+    canUse: [pgx, oapi, xnet]
   approvals:
     mayDependOn: [contracts, platform]
     canUse: [pgx, oapi]

--- a/backend/internal/modules/activities/email.go
+++ b/backend/internal/modules/activities/email.go
@@ -228,11 +228,20 @@ func (s *Store) SendEmail(ctx context.Context, origin SendOrigin, in SendEmailIn
 	}
 	messageID := MintMessageID(s.messageIDDomain())
 
+	// Caller markup is filtered BEFORE anything of ours is added to it, so the
+	// signature and the unsubscribe footer below are not themselves subject to
+	// a filter they would only ever pass — and so what the allowlist judges is
+	// exactly what the caller sent.
+	safeHTML, err := SanitizeOutboundHTML(in.HTMLBody)
+	if err != nil {
+		return crmcontracts.Activity{}, err
+	}
+
 	// The markup alternative gets the SAME sign-off and the same unsubscribe
 	// footer, in its own syntax. Two alternatives of one message that disagreed
 	// would be two messages, and which one the recipient reads is their client's
 	// decision rather than ours — including whether they can unsubscribe.
-	htmlBody, err := s.signedHTML(ctx, in.HTMLBody, derived)
+	htmlBody, err := s.signedHTML(ctx, safeHTML, derived)
 	if err != nil {
 		return crmcontracts.Activity{}, err
 	}

--- a/backend/internal/modules/activities/htmlsanitize.go
+++ b/backend/internal/modules/activities/htmlsanitize.go
@@ -24,6 +24,14 @@ package activities
 // is what a business email needs — emphasis, structure, links, line breaks —
 // and everything else is reduced to the text it contained rather than dropped,
 // because a sender whose markup vanished still meant the words inside it.
+//
+// Unwrapping has a consequence worth stating rather than discovering: text a
+// sender HID becomes visible. A `hidden` div or a display:none paragraph loses
+// the attribute that concealed it and keeps its words, so a message can arrive
+// saying more than its author saw in their own composer. That is the honest
+// trade — the alternative is silently deleting prose whenever an element is
+// unfamiliar — and it is why the drop list holds the elements whose content was
+// never message text at all rather than merely being styled out of sight.
 
 import (
 	"fmt"
@@ -48,6 +56,10 @@ var allowedElements = map[atom.Atom]bool{
 // not allowed — a <div> of prose must not lose the prose.
 var droppedWholesale = map[atom.Atom]bool{
 	atom.Script: true, atom.Style: true, atom.Head: true,
+	// Metadata, not message. A <title> is never text a recipient was meant to
+	// read, and unwrapping it would move a document's title into the body as a
+	// sentence nobody wrote there.
+	atom.Title:  true,
 	atom.Iframe: true, atom.Object: true, atom.Embed: true,
 	atom.Form: true, atom.Input: true, atom.Button: true, atom.Select: true,
 	atom.Textarea: true, atom.Template: true, atom.Noscript: true,

--- a/backend/internal/modules/activities/htmlsanitize.go
+++ b/backend/internal/modules/activities/htmlsanitize.go
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package activities
+
+// What of a caller's markup is allowed onto the wire.
+//
+// The html_body a caller supplies is transmitted to a recipient's mail client,
+// not rendered in our own document, so this is not an XSS defence — a mail
+// client is the party that decides what it will run. It is a defence against
+// this product being the instrument of something else:
+//
+//   - A remote image is a read receipt. This product refuses tracking pixels as
+//     a stated position (sequences-and-deliverability.md: "the only engagement
+//     signal is a real reply"), and a sender who embeds one has collected the
+//     signal the product declines to. So no element that loads a remote
+//     resource survives — img, script, iframe, object, link, style.
+//   - A javascript: or data: href is a payload wearing a link's clothes, and
+//     the recipient sees only the text it carries.
+//   - A form posts a recipient's answer to whoever the sender named.
+//
+// The rule is an ALLOWLIST, because the failure of a denylist is silent: an
+// element nobody thought of arrives intact, and nothing says so. What survives
+// is what a business email needs — emphasis, structure, links, line breaks —
+// and everything else is reduced to the text it contained rather than dropped,
+// because a sender whose markup vanished still meant the words inside it.
+
+import (
+	"fmt"
+	"strings"
+
+	"golang.org/x/net/html"
+	"golang.org/x/net/html/atom"
+)
+
+// allowedElements are the tags a formatted business email is made of. Anything
+// else is unwrapped to its text: a <div> becomes its content, a <script>
+// becomes nothing, because it had no text a reader was meant to see.
+var allowedElements = map[atom.Atom]bool{
+	atom.P: true, atom.Br: true,
+	atom.B: true, atom.Strong: true, atom.I: true, atom.Em: true, atom.U: true,
+	atom.Ul: true, atom.Ol: true, atom.Li: true,
+	atom.A: true, atom.Blockquote: true, atom.Hr: true,
+}
+
+// droppedWholesale are the elements whose CONTENT is not text a reader was
+// meant to see. Everything else keeps its children when the element itself is
+// not allowed — a <div> of prose must not lose the prose.
+var droppedWholesale = map[atom.Atom]bool{
+	atom.Script: true, atom.Style: true, atom.Head: true,
+	atom.Iframe: true, atom.Object: true, atom.Embed: true,
+	atom.Form: true, atom.Input: true, atom.Button: true, atom.Select: true,
+	atom.Textarea: true, atom.Template: true, atom.Noscript: true,
+}
+
+// SanitizeOutboundHTML reduces caller-supplied markup to the subset a business
+// email needs, and returns an error rather than a repair when the input is not
+// parseable as HTML at all.
+//
+// It never returns markup it did not build itself: every element and attribute
+// in the output was written by this function from a value that passed the
+// allowlist, so a construct that survives did so deliberately.
+func SanitizeOutboundHTML(markup string) (string, error) {
+	if strings.TrimSpace(markup) == "" {
+		return "", nil
+	}
+	// A fragment, not a document: a mail body is body content, and parsing it
+	// as a document would wrap it in html/head/body we would then have to strip.
+	body := &html.Node{Type: html.ElementNode, Data: "body", DataAtom: atom.Body}
+	nodes, err := html.ParseFragment(strings.NewReader(markup), body)
+	if err != nil {
+		return "", fmt.Errorf("activities: the message markup does not parse as HTML: %w", err)
+	}
+	var out strings.Builder
+	for _, node := range nodes {
+		writeSanitized(&out, node)
+	}
+	return out.String(), nil
+}
+
+// writeSanitized renders one node and its children under the allowlist.
+func writeSanitized(out *strings.Builder, node *html.Node) {
+	switch node.Type {
+	case html.TextNode:
+		// Escaped on the way out, so text that looked like markup in the input
+		// is text in the output rather than markup we did not check.
+		out.WriteString(html.EscapeString(node.Data))
+		return
+	case html.ElementNode:
+		writeSanitizedElement(out, node)
+		return
+	default:
+		// Comments, doctypes and the rest carry nothing a recipient reads, and
+		// a comment can hide markup from a reviewer while a client still parses
+		// it. Their children are walked, because a comment has none.
+		return
+	}
+}
+
+func writeSanitizedElement(out *strings.Builder, node *html.Node) {
+	if droppedWholesale[node.DataAtom] {
+		return
+	}
+	if !allowedElements[node.DataAtom] {
+		// Unwrap: keep what it said, drop what it was.
+		writeChildren(out, node)
+		return
+	}
+	tag := node.Data
+	out.WriteString("<" + tag)
+	if href, ok := safeHref(node); ok {
+		out.WriteString(` href="` + html.EscapeString(href) + `"`)
+	}
+	out.WriteString(">")
+	if !voidElement[node.DataAtom] {
+		writeChildren(out, node)
+		out.WriteString("</" + tag + ">")
+	}
+}
+
+func writeChildren(out *strings.Builder, node *html.Node) {
+	for child := node.FirstChild; child != nil; child = child.NextSibling {
+		writeSanitized(out, child)
+	}
+}
+
+// voidElement names the tags that take no closing tag. Writing one would put a
+// stray </br> in the message.
+var voidElement = map[atom.Atom]bool{atom.Br: true, atom.Hr: true}
+
+// safeHref answers the one attribute that survives, and only on a link.
+//
+// http and https only, and mailto because a business email links an address as
+// often as a page. Everything else — javascript:, data:, file:, a scheme
+// nobody has heard of — is dropped, and the link becomes plain text carrying
+// its own label, which is what the reader was going to read anyway.
+func safeHref(node *html.Node) (string, bool) {
+	if node.DataAtom != atom.A {
+		return "", false
+	}
+	for _, attr := range node.Attr {
+		if !strings.EqualFold(attr.Key, "href") {
+			continue
+		}
+		trimmed := strings.TrimSpace(attr.Val)
+		lowered := strings.ToLower(trimmed)
+		for _, scheme := range []string{"http://", "https://", "mailto:"} {
+			if strings.HasPrefix(lowered, scheme) {
+				return trimmed, true
+			}
+		}
+		return "", false
+	}
+	return "", false
+}

--- a/backend/internal/modules/activities/htmlsanitize_test.go
+++ b/backend/internal/modules/activities/htmlsanitize_test.go
@@ -210,3 +210,29 @@ func TestTheFilterRunsBeforeAnythingOfOursIsAdded(t *testing.T) {
 		t.Fatalf("the message was lost: %q", got)
 	}
 }
+
+// Metadata is not message text. A <title> unwrapped would move a document's
+// title into the body as a sentence nobody wrote there.
+func TestMetadataContentIsNotUnwrappedIntoTheMessage(t *testing.T) {
+	got, err := SanitizeOutboundHTML(`<title>Secret subject</title><p>Visible</p>`)
+	if err != nil {
+		t.Fatalf("sanitizing failed: %v", err)
+	}
+	if got != "<p>Visible</p>" {
+		t.Fatalf("metadata reached the message: %q", got)
+	}
+}
+
+// Text a sender HID becomes visible, because the attribute that concealed it is
+// not one that survives. Pinned rather than fixed: the alternative is deleting
+// prose whenever an element is unfamiliar, which loses more than it protects.
+// What this asserts is that the behaviour is known, not that it is desirable.
+func TestHiddenTextBecomesVisibleAndThatIsTheKnownTrade(t *testing.T) {
+	got, err := SanitizeOutboundHTML(`<div hidden>Hidden note</div><p>Visible</p>`)
+	if err != nil {
+		t.Fatalf("sanitizing failed: %v", err)
+	}
+	if got != "Hidden note<p>Visible</p>" {
+		t.Fatalf("the unwrap rule changed: %q", got)
+	}
+}

--- a/backend/internal/modules/activities/htmlsanitize_test.go
+++ b/backend/internal/modules/activities/htmlsanitize_test.go
@@ -1,0 +1,212 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package activities
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// What a formatted business email is made of survives intact. A sanitiser that
+// eats the formatting is one nobody can use, and the composer above it would
+// then be a toolbar whose buttons do nothing.
+func TestFormattingABusinessEmailNeedsSurvives(t *testing.T) {
+	for name, markup := range map[string]string{
+		"emphasis":   "<p>The <b>deadline</b> is <em>Friday</em>.</p>",
+		"lists":      "<ul><li>One</li><li>Two</li></ul>",
+		"paragraphs": "<p>First.</p><p>Second.</p>",
+		"line break": "<p>One<br>Two</p>",
+		"a quote":    "<blockquote>Their words.</blockquote>",
+		"a rule":     "<p>Above</p><hr><p>Below</p>",
+	} {
+		t.Run(name, func(t *testing.T) {
+			got, err := SanitizeOutboundHTML(markup)
+			if err != nil {
+				t.Fatalf("sanitizing failed: %v", err)
+			}
+			if got != markup {
+				t.Fatalf("formatting changed:\n got %q\nwant %q", got, markup)
+			}
+		})
+	}
+}
+
+// A remote image is a read receipt. This product refuses tracking pixels as a
+// stated position, and a sender who embeds one has collected the signal the
+// product declines to — so the element does not reach the wire.
+func TestNoElementThatLoadsARemoteResourceSurvives(t *testing.T) {
+	for name, markup := range map[string]string{
+		"a tracking pixel": `<p>Hi</p><img src="https://track.test/o.gif?id=42" width="1" height="1">`,
+		"a stylesheet":     `<link rel="stylesheet" href="https://track.test/s.css"><p>Hi</p>`,
+		"a style block":    `<style>@import url(https://track.test/s.css)</style><p>Hi</p>`,
+		"an iframe":        `<iframe src="https://track.test/frame"></iframe><p>Hi</p>`,
+		"an object":        `<object data="https://track.test/x"></object><p>Hi</p>`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			got, err := SanitizeOutboundHTML(markup)
+			if err != nil {
+				t.Fatalf("sanitizing failed: %v", err)
+			}
+			if strings.Contains(got, "track.test") {
+				t.Fatalf("a remote resource survived: %q", got)
+			}
+			if !strings.Contains(got, "Hi") {
+				t.Fatalf("the message text was lost with it: %q", got)
+			}
+		})
+	}
+}
+
+// A script is not text a reader was meant to see, so it goes entirely — content
+// included. Unwrapping it would paste the code into the message as prose.
+func TestAScriptLeavesNothingBehind(t *testing.T) {
+	got, err := SanitizeOutboundHTML(`<p>Before</p><script>alert(1)</script><p>After</p>`)
+	if err != nil {
+		t.Fatalf("sanitizing failed: %v", err)
+	}
+	if strings.Contains(got, "alert") || strings.Contains(got, "script") {
+		t.Fatalf("a script survived in some form: %q", got)
+	}
+	if got != "<p>Before</p><p>After</p>" {
+		t.Fatalf("the surrounding message changed: %q", got)
+	}
+}
+
+// A link keeps its href only for the schemes a business email uses. Anything
+// else becomes plain text carrying its own label — which is what the reader was
+// going to read regardless.
+func TestOnlyWebAndMailSchemesKeepTheirHref(t *testing.T) {
+	for name, tc := range map[string]struct{ markup, want string }{
+		"https": {`<a href="https://gradion.com">us</a>`, `<a href="https://gradion.com">us</a>`},
+		"http":  {`<a href="http://gradion.com">us</a>`, `<a href="http://gradion.com">us</a>`},
+		"mail":  {`<a href="mailto:x@y.test">write</a>`, `<a href="mailto:x@y.test">write</a>`},
+		"javascript": {
+			`<a href="javascript:alert(1)">click</a>`, `<a>click</a>`,
+		},
+		"data": {
+			`<a href="data:text/html;base64,PHNjcmlwdD4=">click</a>`, `<a>click</a>`,
+		},
+		"uppercase javascript": {
+			`<a href="JavaScript:alert(1)">click</a>`, `<a>click</a>`,
+		},
+		"whitespace-padded javascript": {
+			`<a href="  javascript:alert(1)">click</a>`, `<a>click</a>`,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			got, err := SanitizeOutboundHTML(tc.markup)
+			if err != nil {
+				t.Fatalf("sanitizing failed: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// Every attribute other than a safe href is dropped. An event handler is the
+// obvious one, but style carries url() and a class means nothing in a mail
+// client that never saw our stylesheet.
+func TestEveryOtherAttributeIsDropped(t *testing.T) {
+	got, err := SanitizeOutboundHTML(
+		`<p onclick="alert(1)" style="background:url(https://track.test/x)" class="x" id="y">Text</p>`)
+	if err != nil {
+		t.Fatalf("sanitizing failed: %v", err)
+	}
+	if got != "<p>Text</p>" {
+		t.Fatalf("an attribute survived: %q", got)
+	}
+}
+
+// An element nobody allowed keeps its words. A sender whose <div> vanished
+// still meant the sentence inside it, and silently deleting prose is worse than
+// dropping a tag.
+func TestAnUnknownElementKeepsItsText(t *testing.T) {
+	for name, tc := range map[string]struct{ markup, want string }{
+		"a div":           {`<div>Words</div>`, "Words"},
+		"a table cell":    {`<table><tr><td>Cell</td></tr></table>`, "Cell"},
+		"a custom tag":    {`<my-widget>Inside</my-widget>`, "Inside"},
+		"a nested unwrap": {`<div><span>Deep <b>bold</b></span></div>`, "Deep <b>bold</b>"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			got, err := SanitizeOutboundHTML(tc.markup)
+			if err != nil {
+				t.Fatalf("sanitizing failed: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// Text that looks like markup stays text. Re-emitting it raw would let an input
+// that was never parsed as an element become one on the way out.
+func TestTextThatLooksLikeMarkupStaysText(t *testing.T) {
+	got, err := SanitizeOutboundHTML(`<p>Use &lt;script&gt; carefully &amp; well</p>`)
+	if err != nil {
+		t.Fatalf("sanitizing failed: %v", err)
+	}
+	if got != "<p>Use &lt;script&gt; carefully &amp; well</p>" {
+		t.Fatalf("escaping changed: %q", got)
+	}
+}
+
+// A comment can hide markup from a reviewer reading the source while a client
+// still parses it, and it carries nothing a recipient reads.
+func TestCommentsDoNotSurvive(t *testing.T) {
+	got, err := SanitizeOutboundHTML(`<p>A</p><!-- <script>alert(1)</script> --><p>B</p>`)
+	if err != nil {
+		t.Fatalf("sanitizing failed: %v", err)
+	}
+	if got != "<p>A</p><p>B</p>" {
+		t.Fatalf("a comment left something behind: %q", got)
+	}
+}
+
+// Empty in, empty out — and a plain-text send must not gain a markup part.
+func TestEmptyMarkupStaysEmpty(t *testing.T) {
+	for _, in := range []string{"", "   ", "\n\t"} {
+		got, err := SanitizeOutboundHTML(in)
+		if err != nil {
+			t.Fatalf("sanitizing failed: %v", err)
+		}
+		if got != "" {
+			t.Fatalf("%q produced %q", in, got)
+		}
+	}
+}
+
+// The filter runs BEFORE the signature and the footer are added, so what the
+// allowlist judges is exactly what the caller sent — and the parts this product
+// appends are never subject to a filter they would only ever pass.
+//
+// Asserted through signedHTML, which is the function the send path calls with
+// the sanitizer's output: a tracking pixel in the caller's markup is gone, and
+// the sign-off that arrives after it is intact.
+func TestTheFilterRunsBeforeAnythingOfOursIsAdded(t *testing.T) {
+	store := (&Store{}).WithSignature(&stubSignature{body: "Marek Janetzke"})
+
+	safe, err := SanitizeOutboundHTML(
+		`<p>Words</p><img src="https://track.test/o.gif">`)
+	if err != nil {
+		t.Fatalf("sanitizing failed: %v", err)
+	}
+	got, err := store.signedHTML(humanCtx(ids.NewV7()), safe, sendDeliverability{})
+	if err != nil {
+		t.Fatalf("signing the markup failed: %v", err)
+	}
+	if strings.Contains(got, "track.test") {
+		t.Fatalf("a tracking pixel reached the signed body: %q", got)
+	}
+	if !strings.Contains(got, "Marek Janetzke") {
+		t.Fatalf("the sign-off was lost: %q", got)
+	}
+	if !strings.Contains(got, "<p>Words</p>") {
+		t.Fatalf("the message was lost: %q", got)
+	}
+}


### PR DESCRIPTION
Closes half of #1203 — the server-side half. The editor follows separately.

## Why now

`html_body` went to a recipient's mail client exactly as the caller sent it.
Defensible while nothing could write markup; not defensible once a composer makes
it routine.

**This is not an XSS defence.** A mail client decides what it will run, and our
document never renders this. It defends against the product being the *instrument*
of something else:

- **A remote image is a read receipt.** This product refuses tracking pixels as a
  stated position — "the only engagement signal is a real reply" — and a sender
  who embeds one has collected the signal the product declines to. Nothing that
  loads a remote resource survives.
- **A `javascript:` or `data:` href** is a payload wearing a link's clothes.
- **A form** posts the recipient's answer to whoever the sender named.

## Allowlist, and it parses

A denylist fails silently: an element nobody thought of arrives intact and
nothing says so. What survives is what a business email is made of — emphasis,
lists, links, breaks, quotes. Everything else is **unwrapped** to its text rather
than dropped, because a sender whose `<div>` vanished still meant the sentence
inside it. Scripts are the exception that keep nothing.

It parses with `x/net/html` rather than pattern-matching: a regex over markup
always has one more case. The arch-lint grant names that reason.

**The filter runs before** the signature and unsubscribe footer are added, so the
allowlist judges exactly what the caller sent.

## Review found no bypass

Codex checked remote-resource loading, attribute smuggling (quote break-out,
newline splitting), element and foreign-content smuggling (SVG/MathML sharing an
allowed atom), and head handling. No exploitable path.

It did flag one design point, now settled: `<title>` is dropped as metadata, and
**hidden text becoming visible on unwrap is a stated trade** with a test pinning
it — the alternative is deleting prose whenever an element is unfamiliar.

## Verified on a live send

Sent markup with a tracking pixel, a script, a `javascript:` link and a div. The
stored body: `<p>Real <b>words</b>.</p><a>click</a>kept` — pixel and script gone,
link text kept without its payload, div's word kept without the div.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sanitizes caller-supplied email HTML before send to enforce our privacy stance and prevent misuse. Previously `html_body` was sent as-is; now a parse-and-allowlist keeps business-email formatting, drops remote resources and scripts/forms, and unwraps unknown tags to their text. Invalid HTML now fails the send. The filter runs before we add the signature and unsubscribe footer.

- Allowlist: p, br, b/strong, i/em, u, ul/ol/li, a (only http/https/mailto `href`), blockquote, hr. All other attributes are removed.
- Dropped wholesale: script/style/head/title, iframe/object/embed, form/input/button/select/textarea, template/noscript. Comments are removed. Hidden text may become visible due to unwrap; intentional trade.

**Rollout / migration**
- API callers must provide valid HTML fragments; invalid `html_body` causes `SendEmail` to return an error.
- Do not rely on remote images, forms, styles, or custom attributes/classes; they will be stripped.

Notes for review: new `SanitizeOutboundHTML` uses `x/net/html`; `activities` is permitted to use `xnet` in arch lint; `email.go` now sanitizes before signing; comprehensive tests cover bypass attempts.

<sup>Written for commit 7e8592a747e14390eee81014ae4ee4cbccf2d136. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1223?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

