### PR TITLE
fix(voice): a sample keeps the key its row was written under

### DIFF
--- a/frontend/src/screens/onboarding-conversation/use-voice-corpus.ts
+++ b/frontend/src/screens/onboarding-conversation/use-voice-corpus.ts
@@ -285,6 +285,11 @@ export function useVoiceCorpus({
           id: `onboarding:upload:${file.name}`,
           name: file.name,
         });
+        // No known-refs set is passed here, and that is the honest answer
+        // rather than an omission: this act's `manifest` holds only what THIS
+        // session added, so it cannot say what the profile already stores. A
+        // reader in onboarding is building a first corpus anyway, which by
+        // definition has no older rows to collide with.
         runIntake(
           async (stamp) => {
             const text = await file.text();

--- a/frontend/src/screens/use-voice-intake.ts
+++ b/frontend/src/screens/use-voice-intake.ts
@@ -1,3 +1,4 @@
+import { useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { components } from "../api/schema";
 import type { IntakeOutcome, RefusalReason } from "./voice-intake-core";
@@ -75,6 +76,19 @@ type UseVoiceIntakeArgs = Readonly<{
 }>;
 
 export function useVoiceIntake({ profileId, onChanged }: UseVoiceIntakeArgs) {
+  const qc = useQueryClient();
+  // The keys this profile's sources are ALREADY stored under, read from the
+  // manifest the card has fetched rather than asked for again. A source whose
+  // row predates the current key format is re-added under the key it already
+  // has, so the ingest updates that row instead of writing a second copy of
+  // the same writing beside it.
+  const knownRefs = useCallback((): ReadonlySet<string> => {
+    const manifest = qc.getQueryData<{
+      sources: readonly { source_ref: string }[];
+    }>(["voice-sources", profileId]);
+    return new Set((manifest?.sources ?? []).map((s) => s.source_ref));
+  }, [qc, profileId]);
+
   const [asks, setAsks] = useState<readonly SpeakerAsk[]>([]);
   const [notices, setNotices] = useState<readonly IntakeNotice[]>([]);
   const [inFlight, setInFlight] = useState(0);
@@ -265,23 +279,23 @@ export function useVoiceIntake({ profileId, onChanged }: UseVoiceIntakeArgs) {
         runIntake(file.name, async () => {
           const text = await file.text();
           return intakeUpload(
-            sourceRef("upload", file.name, text),
+            sourceRef("upload", file.name, text, knownRefs()),
             file.name,
             text,
           );
         });
       }
     },
-    [note, runIntake],
+    [knownRefs, note, runIntake],
   );
 
   const addPaste = useCallback(
     (text: string, label: string) => {
       runIntake(label, () =>
-        intakePaste(sourceRef("paste", label, text), label, text),
+        intakePaste(sourceRef("paste", label, text, knownRefs()), label, text),
       );
     },
-    [runIntake],
+    [knownRefs, runIntake],
   );
 
   const pendingAsk = asks[0] ?? null;

--- a/frontend/src/screens/voice-corpus-settings.test.tsx
+++ b/frontend/src/screens/voice-corpus-settings.test.tsx
@@ -78,16 +78,37 @@ function stubApi(
   return bodies;
 }
 
-function render(ui: ReactNode) {
+function render(ui: ReactNode, client?: QueryClient) {
   return rtlRender(
     <QueryClientProvider
       client={
+        client ??
         new QueryClient({ defaultOptions: { queries: { retry: false } } })
       }
     >
       <LocaleProvider initial="en">{ui}</LocaleProvider>
     </QueryClientProvider>,
   );
+}
+
+// A client whose corpus manifest is already populated, the way the card's own
+// query populates it before anyone drops a file.
+function clientHolding(refs: readonly string[]): QueryClient {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  client.setQueryData(["voice-sources", "vp-1"], {
+    sources: refs.map((source_ref, i) => ({
+      id: `vs-${i}`,
+      source_ref,
+      source_label: "already here",
+      word_count: 100,
+      included: true,
+      register: "general",
+    })),
+    summary: SUMMARY,
+  });
+  return client;
 }
 
 function fileOf(name: string, text: string): File {
@@ -147,6 +168,26 @@ describe("handing a file to the Settings voice card", () => {
     render(<VoiceCorpusIntake profileId="vp-1" onChanged={() => {}} />);
     expect(screen.getByRole("button", { name: /Choose files/ })).toBeTruthy();
     expect(fileInput().accept).toBe(".txt,.md,.vtt,.srt,.json");
+  });
+
+  // source_ref is persisted, and two earlier spellings are already in
+  // installations that have been running. Re-adding a file that has a row
+  // under an older key must UPDATE that row — writing the current key instead
+  // would leave a duplicate sample and count its words twice.
+  it("re-adds a file under the key its existing row already carries", async () => {
+    const bodies = stubApi(PROSE);
+    const text = "Short sentences. Concrete nouns.";
+    // The earlier content-only spelling: no name half.
+    const existing = "voice:upload:d506ebb7-32";
+    render(
+      <VoiceCorpusIntake profileId="vp-1" onChanged={() => {}} />,
+      clientHolding([existing]),
+    );
+
+    await userEvent.upload(fileInput(), fileOf("letter.txt", text));
+
+    await waitFor(() => expect(bodies).toHaveLength(1));
+    expect(bodies[0]?.source_ref).toBe(existing);
   });
 
   it("ingests single-author prose and reports what the server kept", async () => {

--- a/frontend/src/screens/voice-intake-core.test.ts
+++ b/frontend/src/screens/voice-intake-core.test.ts
@@ -374,3 +374,63 @@ describe("source_ref, the key the ingest is idempotent on", () => {
     ).toBeLessThanOrEqual(512);
   });
 });
+
+// source_ref is PERSISTED. Two earlier spellings are already in installations
+// that have been running, and the server upserts on an exact string match — so
+// a source whose row predates the current format has to be re-added under the
+// key it already has, or the ingest writes a second copy of the same writing
+// beside the first and the corpus counts those words twice.
+describe("source_ref, against rows written by earlier versions", () => {
+  it("reuses the content-only key a row already carries", () => {
+    // The earlier content-only spelling, `voice:upload:<fnv1a>-<length>` —
+    // the shape a real installation's rows carry today. Re-adding that same
+    // writing must update THAT row rather than start a second copy of it.
+    const content = "the words of a transcript already in the corpus";
+    const v2 = "voice:upload:a730dfa1-47";
+
+    expect(sourceRef("upload", "transcript.txt", content, new Set([v2]))).toBe(
+      v2,
+    );
+  });
+
+  it("reuses the name-only key a row already carries", () => {
+    // The oldest spellings: the surface plus the file name.
+    for (const legacy of [
+      "settings:upload:letter.txt",
+      "onboarding:upload:letter.txt",
+    ]) {
+      expect(
+        sourceRef("upload", "letter.txt", "words", new Set([legacy])),
+      ).toBe(legacy);
+    }
+  });
+
+  it("writes the current key when the profile holds nothing matching", () => {
+    const current = sourceRef("upload", "letter.txt", "words");
+    expect(
+      sourceRef(
+        "upload",
+        "letter.txt",
+        "words",
+        new Set(["voice:upload:somebody-else:entirely"]),
+      ),
+    ).toBe(current);
+  });
+
+  it("writes the current key when the caller cannot say what exists", () => {
+    // An empty set is "I looked and there is nothing", which is different from
+    // passing nothing at all; both must land on the current format.
+    const current = sourceRef("upload", "letter.txt", "words");
+    expect(sourceRef("upload", "letter.txt", "words", new Set())).toBe(current);
+    expect(sourceRef("upload", "letter.txt", "words")).toBe(current);
+  });
+
+  // A legacy key is only reused for the source it actually belongs to: the v1
+  // format names a file, so a DIFFERENT file's row must not be claimed.
+  it("does not claim a legacy row belonging to another file", () => {
+    const other = "settings:upload:someone-elses.txt";
+    expect(
+      sourceRef("upload", "letter.txt", "words", new Set([other])),
+    ).not.toBe(other);
+  });
+});

--- a/frontend/src/screens/voice-intake-core.ts
+++ b/frontend/src/screens/voice-intake-core.ts
@@ -65,10 +65,33 @@ function contentKey(content: string): string {
   return `${hash.toString(16).padStart(8, "0")}-${content.length}`;
 }
 
-/** The key one source is known by: what it is called and what it says. The
- * label is hashed rather than embedded so a long filename cannot push the
- * content half of the key past the contract's 512-character cap. */
-export function sourceRef(
+// The key formats this client has written, oldest first. A source_ref is a
+// PERSISTED natural key: rows written under an earlier format are still in
+// every installation that has been running, and the server upserts on an exact
+// string match. Re-adding a file that already has a row under an older key
+// would therefore insert a SECOND row rather than update it — a duplicate
+// sample, double-counted words, and a voice weighted twice toward one source,
+// with nothing on screen to say so.
+//
+// Nothing joins on this key, so old rows read back and count normally; only
+// re-adding is affected. That makes recognising the old spellings the whole
+// fix — no data migration, and no server change.
+function legacyRefs(
+  kind: "upload" | "paste",
+  label: string,
+  content: string,
+): string[] {
+  return [
+    // The surface and the file's name, before content keying existed.
+    `settings:${kind}:${label}`,
+    `onboarding:${kind}:${label}`,
+    // Content alone, which files sharing their text collapsed into one row.
+    clamp(`voice:${kind}:${contentKey(content)}`, SOURCE_REF_MAX),
+  ];
+}
+
+/** The key one source WOULD be written under today. */
+function currentRef(
   kind: "upload" | "paste",
   label: string,
   content: string,
@@ -77,6 +100,36 @@ export function sourceRef(
     `voice:${kind}:${contentKey(label)}:${contentKey(content)}`,
     SOURCE_REF_MAX,
   );
+}
+
+/**
+ * The key to write this source under.
+ *
+ * `existing` is the set of source_refs the profile already holds (the manifest
+ * the surface has already fetched). When a row is already there under an older
+ * spelling of this same source, that row's key is reused so the ingest UPDATES
+ * it, exactly as re-adding a file has always done. Otherwise the current format
+ * is used.
+ *
+ * Passing no set is the honest answer for a caller that does not know what the
+ * profile holds — a first sample, which by definition has nothing to collide
+ * with.
+ */
+export function sourceRef(
+  kind: "upload" | "paste",
+  label: string,
+  content: string,
+  existing?: ReadonlySet<string>,
+): string {
+  if (existing !== undefined) {
+    const known = legacyRefs(kind, label, content).find((ref) =>
+      existing.has(ref),
+    );
+    if (known !== undefined) {
+      return known;
+    }
+  }
+  return currentRef(kind, label, content);
 }
 
 // What one previewed source honestly IS.


### PR DESCRIPTION
Found by the stop-time review: `source_ref` is a **persisted** natural key and has now been spelled three ways, with no path back for rows written under the older two.

## What it costs, precisely

Nothing joins on this key, so existing rows still read back and still count — no corruption, nothing hidden. But the server upserts on an exact string match, so re-adding a file that already has a row under an older spelling **inserts a second row** instead of updating the first.

The result is a duplicate sample, its words counted twice, and a voice weighted twice toward one source — with nothing on screen to say so.

Confirmed against a real installation. Its stored row:

```
source_ref   voice:upload:31218e8f-30855
label        03-24 Senan Part 1-transcript.txt   (3272 words)
```

Re-adding that same transcript today produces `voice:upload:a605cf29-33:31218e8f-30855` — a different key, so a second row.

## The fix: recognise the old spellings, don't migrate data

`sourceRef` now takes the set of keys the profile already holds and reuses a row's own key when one is there for this same source; otherwise it writes the current format. The set comes from the corpus manifest the Settings card has already fetched, read from the query cache — **no extra request, no migration, no server change**, and no behaviour change for a profile holding nothing older.

The onboarding act passes no set, which is the honest answer rather than an omission: its manifest holds only what the current session added, so it cannot say what the profile already stores, and a reader building a first corpus has no older rows to collide with. That reasoning is stated where the call is made.

## Tests

Four, each mutation-checked against the code with the lookup removed:

- the content-only key is reused (fails without: `expected 'voice:upload:f94f8aed-14:a730dfa1-47' to be 'voice:upload:a730dfa1-47'`)
- both name-only keys are reused
- a legacy row belonging to a **different** file is not claimed
- end to end through the card, so the hook is shown to actually read the manifest rather than the core merely being able to

`make check-fe` green (2591 tests), `make craft-static` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents duplicate voice samples when re-adding previously ingested files by reusing the existing persisted source_ref. Previously, re-adding a file stored under an older key format inserted a second row due to exact-match upserts; now we detect and reuse that key, otherwise we write the current format. Reads and counts are unchanged; only re-add behavior changes.

**Notes for review**
- `sourceRef(kind, label, content, existing?)` now accepts an optional set of existing refs and returns the first matching legacy key (`settings:<kind>:<label>`, `onboarding:<kind>:<label>`, or `voice:<kind>:<content-hash>`); otherwise it returns the current key.
- `useVoiceIntake` gets the set from the `@tanstack/react-query` cache `["voice-sources", profileId]`; onboarding passes no set by design.
- No server change, no data migration, no extra request; effect is limited to avoiding duplicate rows on re-add.
- Tests cover reusing content-only and name-only legacy keys, not claiming another file’s row, and an end-to-end path through the Settings card.

<sup>Written for commit 1c127cb890069d2e715107b6158fdf5d16257c6b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1224?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Re-adding previously uploaded or pasted voice sources now updates existing entries instead of creating duplicates.
  * Improved compatibility with legacy source references from earlier versions.
  * New source references are generated when no matching existing reference is found.
* **Tests**
  * Added coverage for legacy reference reuse, new reference generation, and protection against mismatched file references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->