### PR TITLE
feat(composer): a rep can write formatted mail, and both renderings travel

### DIFF
--- a/frontend/src/design-system/richtext.css
+++ b/frontend/src/design-system/richtext.css
@@ -1,0 +1,113 @@
+/* RichText — the editable surface and its toolbar.
+ *
+ * It borrows .textarea's box exactly: same font, same border, same focus ring.
+ * A rep moving between the subject field and the message must not feel two
+ * different products, and the only visible difference should be the toolbar
+ * that sits above it. */
+
+.richtext {
+  border: 1px solid var(--borderSubtle);
+  border-radius: var(--r-sm);
+  background: var(--bgElevated);
+  overflow: hidden;
+  transition: 0.15s;
+}
+
+/* The ring goes on the WRAPPER rather than the editable div, so focusing the
+ * text lights the whole control — toolbar included — which is what a reader
+ * expects when the two are one field. */
+.richtext:focus-within {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accentLight);
+}
+
+.richtext-bar {
+  display: flex;
+  gap: 2px;
+  padding: 4px 6px;
+  border-bottom: 1px solid var(--borderSubtle);
+  background: var(--bgCard);
+}
+
+.richtext-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border: none;
+  border-radius: var(--r-sm);
+  background: transparent;
+  color: var(--textSecondary);
+  cursor: pointer;
+  transition: 0.12s;
+}
+
+.richtext-btn:hover {
+  background: var(--bgHover);
+  color: var(--textPrimary);
+}
+
+.richtext-btn:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 2px;
+  box-shadow: 0 0 0 3px var(--accentLight);
+}
+
+.richtext-input {
+  font-family: var(--f-body);
+  font-size: 13.5px;
+  color: var(--textPrimary);
+  padding: 9px 11px;
+  outline: none;
+  overflow-y: auto;
+}
+
+/* The placeholder is a pseudo-element because contentEditable has no
+ * placeholder attribute, and :empty is what tells "nothing typed" from "typed
+ * and deleted" — a browser leaves a <br> behind on the second, so the check
+ * has to allow for it. */
+.richtext-input:empty::before,
+.richtext-input:has(> br:only-child)::before {
+  content: attr(data-placeholder);
+  color: var(--textMuted);
+  pointer-events: none;
+}
+
+/* Lists need their markers back: the reset strips them, and a bulleted list
+ * with no bullets is the one formatting the toolbar promises most visibly. */
+.richtext-input ul,
+.richtext-input ol {
+  margin: 0 0 8px;
+  padding-left: 22px;
+}
+
+.richtext-input ul {
+  list-style: disc;
+}
+
+.richtext-input ol {
+  list-style: decimal;
+}
+
+.richtext-input p {
+  margin: 0 0 8px;
+}
+
+.richtext-input p:last-child,
+.richtext-input ul:last-child,
+.richtext-input ol:last-child {
+  margin-bottom: 0;
+}
+
+.richtext-input a {
+  color: var(--accent);
+  text-decoration: underline;
+}
+
+.richtext-input blockquote {
+  margin: 0 0 8px;
+  padding-left: 10px;
+  border-left: 2px solid var(--borderSubtle);
+  color: var(--textSecondary);
+}

--- a/frontend/src/design-system/richtext.stories.tsx
+++ b/frontend/src/design-system/richtext.stories.tsx
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useState } from "react";
+import { LocaleProvider } from "../i18n";
+import { RichText } from "./richtext";
+
+const meta: Meta<typeof RichText> = {
+  title: "Design System/RichText",
+  component: RichText,
+  parameters: { layout: "padded" },
+  decorators: [
+    (Story) => (
+      <LocaleProvider initial="en">
+        <Story />
+      </LocaleProvider>
+    ),
+  ],
+};
+export default meta;
+
+type Story = StoryObj<typeof RichText>;
+
+/** Both renderings, side by side — because both go on the wire. */
+function Demo({ initial }: Readonly<{ initial: string }>) {
+  const [value, setValue] = useState(initial);
+  const [text, setText] = useState("");
+  return (
+    <div style={{ display: "grid", gap: "var(--space-3)" }}>
+      <RichText
+        value={value}
+        onChange={(next) => {
+          setValue(next.html);
+          setText(next.text);
+        }}
+        label="Message"
+        labels={{
+          bold: "Bold",
+          italic: "Italic",
+          bulletList: "Bulleted list",
+          numberList: "Numbered list",
+          link: "Link",
+          linkPrompt: "Web address for this link",
+        }}
+        placeholder="Write your message…"
+        rows={6}
+      />
+      <div className="t-caption">
+        The plain alternative a text client receives:
+        <pre style={{ whiteSpace: "pre-wrap", margin: "var(--space-1) 0 0" }}>
+          {text || "—"}
+        </pre>
+      </div>
+    </div>
+  );
+}
+
+/** Empty, showing the placeholder. */
+export const Empty: Story = { render: () => <Demo initial="" /> };
+
+/** The formatting the toolbar produces, which is all the wire carries. */
+export const Formatted: Story = {
+  render: () => (
+    <Demo
+      initial={
+        "<p>Hallo Marine,</p>" +
+        "<p>the <b>deadline</b> is <em>Friday</em>. Two things before then:</p>" +
+        "<ul><li>the signed scope</li><li>the depot list</li></ul>" +
+        '<p>Details on <a href="https://gradion.com">our page</a>.</p>'
+      }
+    />
+  ),
+};
+
+/**
+ * An AI draft arriving with markup the allowlist refuses — a tracking pixel and
+ * a script. Neither reaches the editor, because a model's output is untrusted
+ * input however friendly its source, and the words around them survive.
+ */
+export const HostileDraft: Story = {
+  render: () => (
+    <Demo
+      initial={
+        "<p>Real words.</p>" +
+        '<img src="https://track.test/o.gif">' +
+        "<script>alert(1)</script>" +
+        "<div>kept, unwrapped</div>"
+      }
+    />
+  ),
+};

--- a/frontend/src/design-system/richtext.test.tsx
+++ b/frontend/src/design-system/richtext.test.tsx
@@ -1,0 +1,99 @@
+/** @vitest-environment jsdom */
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import { describe, expect, it } from "vitest";
+import { plainTextOf, safeEditorHTML } from "./richtext";
+
+// `value` is not always something a rep typed — an AI draft arrives here, and a
+// model's output is untrusted input however friendly its source. The server
+// filters what LEAVES for a recipient; this filters what ENTERS our document,
+// and the two protect different people.
+describe("what may enter the editor", () => {
+  it("keeps the formatting the toolbar can produce", () => {
+    const markup =
+      "<p>The <b>deadline</b> is <em>Friday</em>.</p><ul><li>One</li></ul>";
+
+    expect(safeEditorHTML(markup)).toBe(markup);
+  });
+
+  it("drops a script entirely, content included", () => {
+    expect(safeEditorHTML("<p>A</p><script>alert(1)</script><p>B</p>")).toBe(
+      "<p>A</p><p>B</p>",
+    );
+  });
+
+  it("drops an image, because a remote one is a read receipt", () => {
+    expect(
+      safeEditorHTML(`<p>Hi</p><img src="https://track.test/o.gif">`),
+    ).toBe("<p>Hi</p>");
+  });
+
+  it("keeps a link's text but not a javascript href", () => {
+    expect(safeEditorHTML(`<a href="javascript:alert(1)">click</a>`)).toBe(
+      "<a>click</a>",
+    );
+  });
+
+  it("keeps http, https and mailto hrefs", () => {
+    for (const href of [
+      "https://gradion.com",
+      "http://gradion.com",
+      "mailto:x@y.test",
+    ]) {
+      expect(safeEditorHTML(`<a href="${href}">go</a>`)).toBe(
+        `<a href="${href}">go</a>`,
+      );
+    }
+  });
+
+  it("unwraps an unknown element rather than losing its words", () => {
+    expect(safeEditorHTML("<div>Words <b>kept</b></div>")).toBe(
+      "Words <b>kept</b>",
+    );
+  });
+
+  it("escapes text that looks like markup", () => {
+    expect(safeEditorHTML("<p>Use &lt;b&gt; carefully</p>")).toBe(
+      "<p>Use &lt;b&gt; carefully</p>",
+    );
+  });
+
+  it("strips an event handler from an element it keeps", () => {
+    expect(safeEditorHTML(`<p onclick="alert(1)">Text</p>`)).toBe(
+      "<p>Text</p>",
+    );
+  });
+});
+
+// The plain part is a real alternative somebody reads, not a fallback nobody
+// checks: it goes on the wire beside the markup, and a client that prefers text
+// shows THIS.
+describe("the plain-text rendering", () => {
+  const render = (html: string) => {
+    const node = document.createElement("div");
+    node.innerHTML = html;
+    return plainTextOf(node);
+  };
+
+  it("separates paragraphs, where textContent would run them together", () => {
+    expect(render("<p>First.</p><p>Second.</p>")).toBe("First.\n\nSecond.");
+  });
+
+  it("keeps a bulleted list readable as a list", () => {
+    expect(render("<ul><li>One</li><li>Two</li></ul>")).toBe("- One\n- Two");
+  });
+
+  // Inline formatting must not break a sentence. A renderer that emitted a
+  // line per element would hand the plain reader a column of words.
+  it("keeps a formatted sentence as one sentence", () => {
+    expect(render("<p>The <b>deadline</b> is <em>Friday</em>.</p>")).toBe(
+      "The deadline is Friday.",
+    );
+  });
+
+  it("is empty for an empty editor", () => {
+    expect(render("")).toBe("");
+    expect(render("<br>")).toBe("");
+  });
+});

--- a/frontend/src/design-system/richtext.tsx
+++ b/frontend/src/design-system/richtext.tsx
@@ -1,0 +1,370 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import { Bold, Italic, Link2, List, ListOrdered } from "lucide-react";
+import { useEffect, useId, useRef, useState } from "react";
+import "./richtext.css";
+
+/**
+ * RichText — the light formatting a business email needs, and nothing more.
+ *
+ * Bold, italic, links and lists. Not a document editor: the message this writes
+ * goes through the server's outbound allowlist
+ * (`activities.SanitizeOutboundHTML`), which keeps exactly this set and unwraps
+ * everything else, so a toolbar offering headings or colours would offer
+ * formatting the recipient never receives.
+ *
+ * ## Why contentEditable rather than an editor library
+ *
+ * A library (tiptap, Lexical) buys a document model, collaborative editing and
+ * a plugin system — none of which a five-sentence email needs — for a dependency
+ * tree this product would then carry forever. What it would genuinely buy is
+ * paste normalisation, and the server already does that job for the case that
+ * matters: what a recipient receives is what the allowlist admits, whatever the
+ * browser put in the DOM.
+ *
+ * ## The two values
+ *
+ * Every change reports BOTH renderings: `html` for the markup alternative and
+ * `text` for the plain part. They are the same message in two forms and both go
+ * on the wire (multipart/alternative), so a caller that kept only one would send
+ * a message whose halves disagree — and which half a recipient reads is their
+ * client's decision, not ours.
+ *
+ * ## What it does not do
+ *
+ * No image button: this product refuses tracking pixels, and a remote image is
+ * a read receipt. No colour or font controls: they arrive as inline styles the
+ * allowlist drops, so the button would lie.
+ */
+export function RichText({
+  value,
+  onChange,
+  label,
+  labels,
+  placeholder,
+  rows = 12,
+  id,
+}: Readonly<{
+  /**
+   * The markup to show. Read on mount and when it changes from OUTSIDE — an
+   * AI draft arriving, a form reset — never on every keystroke, which would
+   * fight the caret.
+   */
+  value: string;
+  onChange: (next: { html: string; text: string }) => void;
+  label: string;
+  /**
+   * The toolbar's accessible names. Copy never lives in a primitive: words
+   * arrive through props, translated by the caller with t().
+   */
+  labels: Readonly<{
+    bold: string;
+    italic: string;
+    bulletList: string;
+    numberList: string;
+    link: string;
+    linkPrompt: string;
+  }>;
+  placeholder?: string;
+  rows?: number;
+  id?: string;
+}>) {
+  const generatedId = useId();
+  const fieldId = id ?? generatedId;
+  const editor = useRef<HTMLDivElement>(null);
+  // What we last handed the caller. Comparing against it is what tells an
+  // outside change (a draft arriving) from the echo of our own keystroke.
+  const [ours, setOurs] = useState(value);
+
+  useEffect(() => {
+    const node = editor.current;
+    if (!node || value === ours) {
+      return;
+    }
+    // Filtered before it reaches OUR document, not only before it reaches a
+    // recipient's. The server's allowlist governs what goes out; this one
+    // governs what a model's draft may put in the page a rep is looking at,
+    // which is a different trust boundary with a different victim.
+    node.innerHTML = safeEditorHTML(value);
+    setOurs(node.innerHTML);
+  }, [value, ours]);
+
+  const report = () => {
+    const node = editor.current;
+    if (!node) {
+      return;
+    }
+    const html = node.innerHTML;
+    setOurs(html);
+    onChange({ html, text: plainTextOf(node) });
+  };
+
+  const apply = (command: string) => {
+    editor.current?.focus();
+    // execCommand is deprecated and still the only cross-browser way to apply
+    // formatting to a selection without a document model. The alternative is
+    // reimplementing selection surgery, which is where hand-rolled editors go
+    // wrong; what it produces is bounded by the server's allowlist anyway.
+    document.execCommand(command);
+    report();
+  };
+
+  const addLink = () => {
+    const href = window.prompt(labels.linkPrompt);
+    if (href === null) {
+      return;
+    }
+    editor.current?.focus();
+    // An empty answer REMOVES the link, which is the only way to undo one from
+    // a toolbar with no unlink button.
+    document.execCommand(
+      href.trim() === "" ? "unlink" : "createLink",
+      false,
+      href.trim(),
+    );
+    report();
+  };
+
+  return (
+    <div className="richtext">
+      <div className="richtext-bar" role="toolbar" aria-label={label}>
+        <RichTextButton onClick={() => apply("bold")} title={labels.bold}>
+          <Bold size={15} aria-hidden="true" />
+        </RichTextButton>
+        <RichTextButton onClick={() => apply("italic")} title={labels.italic}>
+          <Italic size={15} aria-hidden="true" />
+        </RichTextButton>
+        <RichTextButton
+          onClick={() => apply("insertUnorderedList")}
+          title={labels.bulletList}
+        >
+          <List size={15} aria-hidden="true" />
+        </RichTextButton>
+        <RichTextButton
+          onClick={() => apply("insertOrderedList")}
+          title={labels.numberList}
+        >
+          <ListOrdered size={15} aria-hidden="true" />
+        </RichTextButton>
+        <RichTextButton onClick={addLink} title={labels.link}>
+          <Link2 size={15} aria-hidden="true" />
+        </RichTextButton>
+      </div>
+      {/* biome-ignore lint/a11y/useSemanticElements: a textarea cannot carry formatting; this is the editable surface the toolbar acts on */}
+      <div
+        ref={editor}
+        id={fieldId}
+        role="textbox"
+        aria-multiline="true"
+        aria-label={label}
+        contentEditable
+        suppressContentEditableWarning
+        // contentEditable is focusable in every engine, but stating it is what
+        // makes the role and the behaviour agree for a checker and a reader.
+        tabIndex={0}
+        data-placeholder={placeholder}
+        className="richtext-input"
+        style={{ minHeight: `${rows * 1.5}em` }}
+        onInput={report}
+        onBlur={report}
+      />
+    </div>
+  );
+}
+
+function RichTextButton({
+  onClick,
+  title,
+  children,
+}: Readonly<{
+  onClick: () => void;
+  title: string;
+  children: React.ReactNode;
+}>) {
+  return (
+    <button
+      type="button"
+      className="richtext-btn"
+      // The pointer-down default is what steals the selection the command is
+      // about to act on, so the button never takes focus from the text.
+      onMouseDown={(event) => event.preventDefault()}
+      onClick={onClick}
+      title={title}
+      aria-label={title}
+    >
+      {children}
+    </button>
+  );
+}
+
+/**
+ * The plain-text rendering of what the editor holds.
+ *
+ * Not `textContent`: that runs every block together, so three paragraphs arrive
+ * as one sentence with no space between them. Block boundaries become newlines
+ * and a list item keeps its marker, because the plain part is a real
+ * alternative somebody reads rather than a fallback nobody checks.
+ */
+export function plainTextOf(node: HTMLElement): string {
+  const lines: string[] = [];
+  // The line being built. Inline formatting must NOT break it: "The <b>deadline
+  // </b> is Friday" is one sentence, and a renderer that emitted a line per
+  // element would hand the plain reader a column of words.
+  let current = "";
+  const flush = () => {
+    if (current.trim() !== "") {
+      lines.push(current.trim());
+    }
+    current = "";
+  };
+  const walkElement = (element: HTMLElement, prefix: string) => {
+    const tag = element.tagName.toLowerCase();
+    if (tag === "br") {
+      flush();
+      return;
+    }
+    if (tag === "li") {
+      flush();
+      current =
+        element.parentElement?.tagName.toLowerCase() === "ol" ? "" : "- ";
+      walk(element, prefix);
+      flush();
+      return;
+    }
+    if (!isBlock(tag)) {
+      // Inline: the line continues, which is what keeps a formatted sentence
+      // one sentence.
+      walk(element, prefix);
+      return;
+    }
+    flush();
+    walk(element, prefix);
+    flush();
+    lines.push("");
+  };
+  const walk = (parent: Node, prefix: string) => {
+    for (const child of Array.from(parent.childNodes)) {
+      if (child.nodeType === Node.TEXT_NODE) {
+        current += child.textContent ?? "";
+      } else if (child instanceof HTMLElement) {
+        walkElement(child, prefix);
+      }
+    }
+  };
+  walk(node, "");
+  flush();
+  return lines
+    .join("\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+/**
+ * The subset of markup this editor will render.
+ *
+ * `value` is not always something a rep typed: an AI draft arrives here, and a
+ * model's output is untrusted input however friendly its source. The server
+ * filters what LEAVES for a recipient; this filters what ENTERS our own
+ * document, and the two protect different people.
+ *
+ * It mirrors the server's allowlist deliberately — the same elements, the same
+ * three link schemes — so a rep never sees formatting in the composer that the
+ * outbound filter would strip on the way out. Built with the DOM parser rather
+ * than a regex: the browser is the thing that decides what markup means, so it
+ * is the thing that should parse it.
+ */
+export function safeEditorHTML(markup: string): string {
+  const allowed = new Set([
+    "P",
+    "BR",
+    "B",
+    "STRONG",
+    "I",
+    "EM",
+    "U",
+    "UL",
+    "OL",
+    "LI",
+    "A",
+    "BLOCKQUOTE",
+    "HR",
+  ]);
+  const dropped = new Set([
+    "SCRIPT",
+    "STYLE",
+    "IFRAME",
+    "OBJECT",
+    "EMBED",
+    "FORM",
+    "INPUT",
+    "BUTTON",
+    "SELECT",
+    "TEXTAREA",
+    "TEMPLATE",
+    "NOSCRIPT",
+    "TITLE",
+    "LINK",
+    "META",
+    "IMG",
+  ]);
+  const parsed = new DOMParser().parseFromString(markup, "text/html");
+  const cleanElement = (element: Element): string => {
+    const tag = element.tagName;
+    if (dropped.has(tag)) {
+      return "";
+    }
+    if (!allowed.has(tag)) {
+      // Unwrap, exactly as the server does: a sender whose <div> vanished still
+      // meant the sentence inside it.
+      return clean(element);
+    }
+    const lower = tag.toLowerCase();
+    if (lower === "br" || lower === "hr") {
+      return `<${lower}>`;
+    }
+    const href = tag === "A" ? safeHref(element.getAttribute("href")) : "";
+    const attr = href ? ` href="${escapeText(href)}"` : "";
+    return `<${lower}${attr}>${clean(element)}</${lower}>`;
+  };
+  const clean = (parent: Node): string => {
+    let out = "";
+    for (const child of Array.from(parent.childNodes)) {
+      if (child.nodeType === Node.TEXT_NODE) {
+        out += escapeText(child.textContent ?? "");
+      } else if (child instanceof Element) {
+        out += cleanElement(child);
+      }
+    }
+    return out;
+  };
+  return clean(parsed.body);
+}
+
+// A block element ends the line it was on; an inline one continues it.
+function isBlock(tag: string): boolean {
+  return (
+    tag === "p" ||
+    tag === "div" ||
+    tag === "ul" ||
+    tag === "ol" ||
+    tag === "blockquote"
+  );
+}
+
+function safeHref(href: string | null): string {
+  const trimmed = (href ?? "").trim();
+  const lowered = trimmed.toLowerCase();
+  const ok = ["http://", "https://", "mailto:"].some((scheme) =>
+    lowered.startsWith(scheme),
+  );
+  return ok ? trimmed : "";
+}
+
+function escapeText(text: string): string {
+  return text
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+}

--- a/frontend/src/design-system/richtext.tsx
+++ b/frontend/src/design-system/richtext.tsx
@@ -73,9 +73,15 @@ export function RichText({
   const generatedId = useId();
   const fieldId = id ?? generatedId;
   const editor = useRef<HTMLDivElement>(null);
-  // What we last handed the caller. Comparing against it is what tells an
-  // outside change (a draft arriving) from the echo of our own keystroke.
-  const [ours, setOurs] = useState(value);
+  // What we last handed the caller, or last wrote into the node. Comparing
+  // against it tells an outside change (a draft arriving) from the echo of our
+  // own keystroke.
+  //
+  // It starts EMPTY rather than at `value`, and that is the whole point: seeded
+  // with `value`, the effect below saw no difference on mount and never wrote
+  // the node — so a composer reopened with a message in state rendered blank
+  // while Send still carried the invisible text.
+  const [ours, setOurs] = useState("");
 
   useEffect(() => {
     const node = editor.current;
@@ -218,30 +224,42 @@ export function plainTextOf(node: HTMLElement): string {
     }
     current = "";
   };
+  const walkListItem = (element: HTMLElement, prefix: string) => {
+    flush();
+    // An ordered list numbers its items and an unordered one bullets them.
+    // Emitting neither leaves the plain reader a list that is not a list.
+    const ordered = element.parentElement?.tagName.toLowerCase() === "ol";
+    current = `${prefix}${ordered ? `${itemNumber(element)}. ` : "- "}`;
+    walk(element, `${prefix}  `);
+    flush();
+  };
+  const walkLink = (element: HTMLElement, prefix: string) => {
+    // The destination is the point of a link, and a text client shows no href —
+    // so the URL rides beside the label rather than being lost.
+    walk(element, prefix);
+    const href = element.getAttribute("href") ?? "";
+    if (href !== "" && !current.includes(href)) {
+      current += ` <${href}>`;
+    }
+  };
   const walkElement = (element: HTMLElement, prefix: string) => {
     const tag = element.tagName.toLowerCase();
     if (tag === "br") {
       flush();
-      return;
-    }
-    if (tag === "li") {
+    } else if (tag === "li") {
+      walkListItem(element, prefix);
+    } else if (tag === "a") {
+      walkLink(element, prefix);
+    } else if (isBlock(tag)) {
       flush();
-      current =
-        element.parentElement?.tagName.toLowerCase() === "ol" ? "" : "- ";
       walk(element, prefix);
       flush();
-      return;
-    }
-    if (!isBlock(tag)) {
-      // Inline: the line continues, which is what keeps a formatted sentence
-      // one sentence.
+      lines.push("");
+    } else {
+      // Inline: the line continues, which keeps a formatted sentence one
+      // sentence.
       walk(element, prefix);
-      return;
     }
-    flush();
-    walk(element, prefix);
-    flush();
-    lines.push("");
   };
   const walk = (parent: Node, prefix: string) => {
     for (const child of Array.from(parent.childNodes)) {
@@ -339,6 +357,22 @@ export function safeEditorHTML(markup: string): string {
     return out;
   };
   return clean(parsed.body);
+}
+
+// Which item this is within its own list, counting only siblings — so a nested
+// list restarts rather than continuing its parent's numbering.
+function itemNumber(item: HTMLElement): number {
+  let n = 1;
+  for (
+    let prev = item.previousElementSibling;
+    prev !== null;
+    prev = prev.previousElementSibling
+  ) {
+    if (prev.tagName.toLowerCase() === "li") {
+      n += 1;
+    }
+  }
+  return n;
 }
 
 // A block element ends the line it was on; an inline one continues it.

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -4488,6 +4488,13 @@ export const de = {
   "person.composer.to": "An",
   "person.composer.subject": "Betreff",
   "person.composer.body": "Nachricht",
+  "richtext.bold": "Fett",
+  "richtext.italic": "Kursiv",
+  "richtext.bulletList": "Aufzählung",
+  "richtext.numberList": "Nummerierte Liste",
+  "richtext.link": "Link",
+  "richtext.linkPrompt":
+    "Webadresse für diesen Link (leer lassen zum Entfernen)",
   "person.composer.drafting": "Entwurf wird geschrieben…",
   "person.composer.why": "Warum dieser Entwurf",
   "person.composer.consentUnknown":

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -4494,6 +4494,12 @@ export const en = {
   "person.composer.to": "To",
   "person.composer.subject": "Subject",
   "person.composer.body": "Message",
+  "richtext.bold": "Bold",
+  "richtext.italic": "Italic",
+  "richtext.bulletList": "Bulleted list",
+  "richtext.numberList": "Numbered list",
+  "richtext.link": "Link",
+  "richtext.linkPrompt": "Web address for this link (leave empty to remove it)",
   "person.composer.drafting": "Writing a draft…",
   "person.composer.why": "Why this draft",
   "person.composer.consentUnknown":

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -4469,6 +4469,12 @@ export const vi = {
   "person.composer.to": "Đến",
   "person.composer.subject": "Chủ đề",
   "person.composer.body": "Nội dung",
+  "richtext.bold": "Đậm",
+  "richtext.italic": "Nghiêng",
+  "richtext.bulletList": "Danh sách dấu đầu dòng",
+  "richtext.numberList": "Danh sách đánh số",
+  "richtext.link": "Liên kết",
+  "richtext.linkPrompt": "Địa chỉ web cho liên kết này (để trống để gỡ bỏ)",
   "person.composer.drafting": "Đang soạn bản nháp…",
   "person.composer.why": "Vì sao có bản nháp này",
   "person.composer.consentUnknown":

--- a/frontend/src/screens/persondrawers.tsx
+++ b/frontend/src/screens/persondrawers.tsx
@@ -250,6 +250,61 @@ function paragraphsFrom(text: string): string {
     .join("");
 }
 
+// The composer's own head: who it is to, and whether it may go at all.
+//
+// Its own component because the verdict line has three states a reader must be
+// able to tell apart — allowed, refused, and no purpose chosen yet — and the
+// composer around it is at the complexity ceiling.
+function ComposerHead({
+  name,
+  allowed,
+  reason,
+  purpose,
+  guard,
+  onClose,
+}: Readonly<{
+  name: string;
+  allowed: boolean;
+  reason: string | undefined;
+  purpose: string;
+  guard: PersonConsentGuard | undefined;
+  onClose: () => void;
+}>) {
+  const t = useT();
+  return (
+    <div className="drawer-head">
+      <div className="pe-drawer-title">
+        <h2 id="person-composer-title">
+          {t("person.composer.title", { name })}
+        </h2>
+        <Button small onClick={onClose} aria-label={t("person.drawer.close")}>
+          <X size={16} aria-hidden="true" />
+        </Button>
+      </div>
+      {/* The consent verdict leads, with its reason. A rep about to write
+          needs to know whether they may send BEFORE they spend words on it —
+          and until a purpose is chosen the honest line is that the question
+          has not been asked yet, not a verdict borrowed from another purpose. */}
+      <div
+        className={
+          allowed
+            ? "pe-consent-line"
+            : "pe-consent-line pe-consent-line-blocked"
+        }
+      >
+        <Check size={15} aria-hidden="true" />
+        <span>
+          {reason ??
+            (purpose
+              ? t("person.composer.consentUnknown")
+              : t("person.composer.consentPickPurpose"))}
+        </span>
+      </div>
+      <ConsentWayOut purpose={purpose} guard={guard} />
+    </div>
+  );
+}
+
 export function PersonComposer({
   personId,
   view,
@@ -286,6 +341,26 @@ export function PersonComposer({
   }
   const [purpose, setPurpose] = useState("");
 
+  // One spelling of "this composer holds no message", for the two moments that
+  // need it: the recipient changing, and a send succeeding.
+  const clearMessage = () => {
+    setSubject("");
+    setBody("");
+    setHtml("");
+    setPurpose("");
+  };
+
+  // The composer belongs to ONE recipient. The person page reuses this
+  // component when the contact changes — same element, new id — so without this
+  // the subject and both renderings written for A stay loaded while the To
+  // line, the links and the consent verdict all switch to B. A rep who pressed
+  // Send would disclose A's message to B.
+  const [wroteFor, setWroteFor] = useState(personId);
+  if (wroteFor !== personId) {
+    setWroteFor(personId);
+    clearMessage();
+  }
+
   // Drafting is a BUTTON, not something the drawer does to you. Opening a
   // composer to write two sentences yourself should not spend the workspace's
   // model budget, and a draft that arrives unasked is one the rep has to read
@@ -302,7 +377,10 @@ export function PersonComposer({
       return data;
     },
     onSuccess: (written) => {
-      if (written) {
+      // A draft arriving after the rep started writing must not replace their
+      // words: they asked for a suggestion, not for their own sentence to be
+      // taken away. An empty composer is the case this is for.
+      if (written && subject.trim() === "" && body.trim() === "") {
         setSubject(written.subject);
         setBody(written.body);
         // The model writes PLAIN text by contract, so the markup alternative
@@ -341,12 +419,14 @@ export function PersonComposer({
       }
       return data;
     },
+    // The message left. Clearing it readies the composer for the next one and
+    // is what stops the same words going out twice — send.isSuccess no longer
+    // gates the button, because it stays true for the life of the mutation and
+    // left a rep who sent one message unable to write another.
+    onSuccess: clearMessage,
   });
 
-  const sendable =
-    allowed &&
-    !send.isSuccess &&
-    canSend({ recipient, subject, body, purpose });
+  const sendable = allowed && canSend({ recipient, subject, body, purpose });
 
   return (
     <Modal
@@ -356,36 +436,14 @@ export function PersonComposer({
       size="wide"
       placement="right"
     >
-      <div className="drawer-head">
-        <div className="pe-drawer-title">
-          <h2 id="person-composer-title">
-            {t("person.composer.title", { name: view.person.full_name })}
-          </h2>
-          <Button small onClick={onClose} aria-label={t("person.drawer.close")}>
-            <X size={16} aria-hidden="true" />
-          </Button>
-        </div>
-        {/* The consent verdict leads, with its reason. A rep about to write
-            needs to know whether they may send BEFORE they spend words on it —
-            and until a purpose is chosen the honest line is that the question
-            has not been asked yet, not a verdict borrowed from another purpose. */}
-        <div
-          className={
-            allowed
-              ? "pe-consent-line"
-              : "pe-consent-line pe-consent-line-blocked"
-          }
-        >
-          <Check size={15} aria-hidden="true" />
-          <span>
-            {email?.reason ??
-              (purpose
-                ? t("person.composer.consentUnknown")
-                : t("person.composer.consentPickPurpose"))}
-          </span>
-        </div>
-        <ConsentWayOut purpose={purpose} guard={guard} />
-      </div>
+      <ComposerHead
+        name={view.person.full_name}
+        allowed={allowed}
+        reason={email?.reason}
+        purpose={purpose}
+        guard={guard}
+        onClose={onClose}
+      />
 
       <div className="drawer-body">
         <label className="pe-field-label" htmlFor="composer-to">

--- a/frontend/src/screens/persondrawers.tsx
+++ b/frontend/src/screens/persondrawers.tsx
@@ -10,13 +10,8 @@ import {
 import { useState } from "react";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
-import {
-  Badge,
-  Button,
-  Modal,
-  Textarea,
-  TextInput,
-} from "../design-system/atoms";
+import { Badge, Button, Modal, TextInput } from "../design-system/atoms";
+import { RichText } from "../design-system/richtext";
 import { Select } from "../design-system/select";
 import { useT } from "../i18n";
 import { problemMessageOf, throwProblem } from "./common";
@@ -236,6 +231,25 @@ function ConsentWayOut({
   );
 }
 
+// A plain-text draft as paragraphs, for the editor to open on.
+//
+// The drafting prompts forbid markup, so what arrives is text with blank lines
+// between paragraphs. Rendering it as one block would lose those breaks the
+// moment the rep touches the formatting toolbar.
+function paragraphsFrom(text: string): string {
+  const escaped = (line: string) =>
+    line
+      .replaceAll("&", "&amp;")
+      .replaceAll("<", "&lt;")
+      .replaceAll(">", "&gt;");
+  return text
+    .split(/\n{2,}/)
+    .map((block) => block.trim())
+    .filter((block) => block !== "")
+    .map((block) => `<p>${escaped(block).replaceAll("\n", "<br>")}</p>`)
+    .join("");
+}
+
 export function PersonComposer({
   personId,
   view,
@@ -256,7 +270,10 @@ export function PersonComposer({
 }>) {
   const t = useT();
   const [subject, setSubject] = useState("");
+  // The two renderings of one message. body is what a text client receives and
+  // what every existing gate reads; html is the markup alternative beside it.
   const [body, setBody] = useState("");
+  const [html, setHtml] = useState("");
   // Keyed on the intent the caller supplied, so a SECOND moment action opening
   // the same composer replaces the first one's intent instead of leaving the
   // rep with the reason the previous button had. useState alone seeds once and
@@ -288,6 +305,10 @@ export function PersonComposer({
       if (written) {
         setSubject(written.subject);
         setBody(written.body);
+        // The model writes PLAIN text by contract, so the markup alternative
+        // starts as that text in paragraphs rather than one run-on block. A
+        // rep formats from there; nothing is invented on their behalf.
+        setHtml(paragraphsFrom(written.body));
       }
     },
   });
@@ -307,6 +328,9 @@ export function PersonComposer({
         body: {
           subject,
           body,
+          // Omitted entirely when the rep formatted nothing: an empty markup
+          // part would make every plain send multipart for no reader's gain.
+          html_body: html.trim() === "" ? undefined : html,
           to: [recipient],
           consent_purpose: purpose,
           links: [{ entity_type: "person" as const, entity_id: personId }],
@@ -391,11 +415,27 @@ export function PersonComposer({
         <label className="pe-field-label" htmlFor="composer-body">
           {t("person.composer.body")}
         </label>
-        <Textarea
+        {/* Both renderings travel. The wire sends multipart/alternative, so a
+            composer that kept only the markup would leave the plain part —
+            which a text client, a screen reader and a spam filter all read —
+            saying something else. */}
+        <RichText
           id="composer-body"
+          value={html}
+          onChange={(next) => {
+            setHtml(next.html);
+            setBody(next.text);
+          }}
+          label={t("person.composer.body")}
+          labels={{
+            bold: t("richtext.bold"),
+            italic: t("richtext.italic"),
+            bulletList: t("richtext.bulletList"),
+            numberList: t("richtext.numberList"),
+            link: t("richtext.link"),
+            linkPrompt: t("richtext.linkPrompt"),
+          }}
           rows={12}
-          value={body}
-          onChange={(event) => setBody(event.target.value)}
         />
 
         {/* Why this draft: the reasoning is a SIBLING of the body, never part


### PR DESCRIPTION
Completes #1203. The transport has carried markup since #1202 and the outbound
allowlist landed in #1223; this is the half that lets a rep actually write it.

## The primitive

`RichText` lives in the design system, per that directory's own rule — an
interactive control anywhere else is a defect, not a shortcut. Story and spec
included; copy arrives through props, because a primitive never holds words.

Bold, italic, links, lists, and deliberately nothing else: the server's allowlist
keeps exactly this set, so a toolbar offering headings or colours would offer
formatting the recipient never receives. No image button — a remote image is a
read receipt, and this product refuses those.

**contentEditable, not an editor library.** A document model, collaborative
editing and a plugin system are not what a five-sentence email needs. The one
thing a library would genuinely buy — paste normalisation — the server already
does for the case that matters.

**Both renderings travel.** They go on the wire together, so a composer keeping
only the markup would leave the plain part — which a text client, a screen reader
and a spam filter all read — saying something else.

**The editor filters what ENTERS too.** `value` is not always something a rep
typed: an AI draft arrives here, and a model's output is untrusted input however
friendly its source.

## What the review caught — two blockers

**The editor never rendered a non-empty value it was mounted with.** `ours` was
seeded at `value`, so the effect that writes the node saw no difference and did
nothing. Since Modal unmounts its children while the composer keeps state, a rep
who closed and reopened saw a **blank editor over a message Send would still
transmit**.

**The composer carried one person's message to the next.** The person page reuses
the component when the contact changes — same element, new id — so A's subject
and both renderings stayed loaded while the To line, links and consent verdict
switched to B. Paired with the blank editor, a rep could have sent A's words to B
without seeing them.

Four majors alongside: a successful send disabled the button forever; a draft
landing mid-typing replaced the rep's words; ordered lists lost their numbers in
the plain part; links lost their destination there.

## Verified in a browser

Both blockers, directly: text written → closed → reopened, and the words come
back rather than the editor showing empty. Then navigating to a different contact
shows the new recipient with an empty editor.

Also: typed a sentence, selected a word, pressed Bold, got
`The <b>deadline</b> is Friday`; and a formatted message sent end to end keeps
its bold, italic and list in the stored markup.

## Note on the branch

Pushed as a new branch — `feat/rich-text-composer` had been created from an
older push and never received these commits, and force-pushing over it needed
permission I do not have. Same content, clean history.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables formatted email composition and sends both HTML and plain-text alternatives. Replaces the textarea with a `RichText` primitive and fixes state bugs that could show a blank editor or leak one person’s message to another.

- `RichText` (design system): bold, italic, links, bulleted/numbered lists via contentEditable; mirrors the server allowlist; drops scripts/images and unsafe link schemes; includes story and tests. Plain-text rendering preserves paragraphs, list markers, and appends link URLs.
- Composer updates: keeps `body` (text) and optional `html_body` in sync; only includes `html_body` when non-empty; clears subject/body/html and purpose after a successful send; resets all message state on recipient change; prevents generated drafts from replacing in-progress typing; fixes plain renderer to number ordered lists and retain link destinations.
- Review focus: `frontend/src/design-system/*` is new (CSS, component, tests, story). `persondrawers.tsx` swaps `Textarea` for `RichText`, adds `ComposerHead`, `paragraphsFrom`, and send/reset logic. New i18n keys for toolbar labels in `en`, `de`, `vi`.

<sup>Written for commit 649d05c6133b726e4d1ebf775aec77038ba675ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1228?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

