### PR TITLE
feat(email): a message can carry its files, from the API to the wire

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -16850,6 +16850,7 @@ components:
             appended to BOTH parts by the server, in each part's own syntax.
         attachment_ids:
           type: array
+          maxItems: 10
           items: { type: string, format: uuid }
           description: |
             Files already in the record library to send with this message, named by id
@@ -16898,6 +16899,7 @@ components:
             appended to BOTH parts by the server, in each part's own syntax.
         attachment_ids:
           type: array
+          maxItems: 10
           items: { type: string, format: uuid }
           description: |
             Files already in the record library to send with this message, named by id

--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -16848,6 +16848,20 @@ components:
             with the plain part first, so a client that cannot render HTML still
             receives the words. The sender's signature and the unsubscribe footer are
             appended to BOTH parts by the server, in each part's own syntax.
+        attachment_ids:
+          type: array
+          items: { type: string, format: uuid }
+          description: |
+            Files already in the record library to send with this message, named by id
+            — never uploaded here. Each is snapshotted at staging (ADR-0086/A131 §4) so
+            archiving or superseding one later cannot rewrite what the timeline says a
+            sent message carried.
+
+            A message is transmitted with ALL its files or not at all. A connector whose
+            provider cannot carry them parks the delivery rather than sending the text
+            alone, and a file the scanner has since quarantined — or one the sender has
+            since lost the right to read — parks it too: a recipient seeing fewer files
+            than the record claims is a wrong record nobody is told about.
         to: { type: array, items: { type: string, format: email } }
         cc: { type: array, items: { type: string, format: email } }
         draft_ref:
@@ -16882,6 +16896,20 @@ components:
             with the plain part first, so a client that cannot render HTML still
             receives the words. The sender's signature and the unsubscribe footer are
             appended to BOTH parts by the server, in each part's own syntax.
+        attachment_ids:
+          type: array
+          items: { type: string, format: uuid }
+          description: |
+            Files already in the record library to send with this message, named by id
+            — never uploaded here. Each is snapshotted at staging (ADR-0086/A131 §4) so
+            archiving or superseding one later cannot rewrite what the timeline says a
+            sent message carried.
+
+            A message is transmitted with ALL its files or not at all. A connector whose
+            provider cannot carry them parks the delivery rather than sending the text
+            alone, and a file the scanner has since quarantined — or one the sender has
+            since lost the right to read — parks it too: a recipient seeing fewer files
+            than the record claims is a wrong record nobody is told about.
         to:
           type: array
           minItems: 1

--- a/backend/cmd/worker/jobrunner.go
+++ b/backend/cmd/worker/jobrunner.go
@@ -133,6 +133,10 @@ func startJobRunner(ctx context.Context, pool *pgxpool.Pool, rdb *redis.Client, 
 // starved by another.
 func newJobRunner(pool *pgxpool.Pool, logger *slog.Logger, cfg workerConfig, captureReg *capture.Registry, watchCfg compose.GmailWatchConfig, configuredVault keyvault.Vault, lanes workerLanes, rdb *redis.Client, overlayBudget overlaybudget.Config, modelPath compose.ModelPath, boundModels map[string]map[string]bool) (*jobs.Runner, error) {
 	return compose.NewJobRunner(pool, logger, compose.JobRunnerConfig{
+		// The send lane reads attachment bytes from the same object store
+		// capture writes them to; without it a message carrying files fails at
+		// the read rather than going out without them.
+		SendBlob: lanes.blob,
 		// The registry that resolves a staged delivery's mailbox: the SAME
 		// sweep registry the capture polls use, so the connector set that
 		// syncs a mailbox is the one that transmits from it.

--- a/backend/internal/compose/commsattachments.go
+++ b/backend/internal/compose/commsattachments.go
@@ -11,12 +11,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/gradionhq/margince/backend/internal/modules/activities"
 	"github.com/gradionhq/margince/backend/internal/modules/comms"
 	"github.com/gradionhq/margince/backend/internal/modules/identity"
+	"github.com/gradionhq/margince/backend/internal/platform/blobstore"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
@@ -35,8 +37,15 @@ type commsAttachments struct {
 // hands a message with files to a provider.
 //
 //nolint:ireturn // returns the comms.AttachmentAuthority seam by design: the concrete type is unexported and every caller holds the interface
-func NewSendAttachmentAuthority(pool *pgxpool.Pool) comms.AttachmentAuthority {
-	return commsAttachments{authority: identity.NewService(pool), files: activities.NewStore(InstallationDB(pool))}
+func NewSendAttachmentAuthority(pool *pgxpool.Pool, blob blobstore.Store) comms.AttachmentAuthority {
+	return commsAttachments{
+		authority: identity.NewService(pool),
+		// WithBlobstore is what lets ReadForSend open the objects. A worker
+		// wired without one can still run the gate — that reads rows — and
+		// fails at the read, which is the fault this argument exists to make
+		// impossible to introduce by omission.
+		files: activities.NewStore(InstallationDB(pool)).WithBlobstore(blob),
+	}
 }
 
 // senderCtx rebuilds the sender's CURRENT authority on the worker's context.
@@ -99,4 +108,56 @@ func (a commsAttachments) EnsureTransmittable(
 		}
 	}
 	return true, "", nil
+}
+
+// ReadForSend opens each attachment's bytes for the transmit, in the order
+// asked, under the SENDER's own authority.
+//
+// OpenAttachment carries the scan gate as well as the row-scope one, so a file
+// quarantined between staging and now cannot be read here even though
+// EnsureTransmittable ran a moment earlier — two checks of the same fact, and
+// the cheaper one is not trusted to have been recent enough.
+//
+// A read that fails returns the error rather than a short set: the dispatcher
+// retries on error, and a message transmitted with fewer files than it claims
+// is the outcome this whole path exists to prevent.
+func (a commsAttachments) ReadForSend(
+	ctx context.Context, userID ids.UserID, attachmentIDs []ids.UUID,
+) ([][]byte, error) {
+	if len(attachmentIDs) == 0 {
+		return nil, nil
+	}
+	senderCtx, reason, err := a.senderCtx(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+	if reason != "" {
+		return nil, fmt.Errorf("comms: reading files for a send: %s", reason)
+	}
+	out := make([][]byte, 0, len(attachmentIDs))
+	for _, id := range attachmentIDs {
+		body, err := a.readOne(senderCtx, id)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, body)
+	}
+	return out, nil
+}
+
+// readOne reads one attachment fully, closing the object either way.
+func (a commsAttachments) readOne(ctx context.Context, id ids.UUID) ([]byte, error) {
+	_, rc, err := a.files.OpenAttachment(ctx, id)
+	if err != nil {
+		return nil, fmt.Errorf("comms: opening an attached file: %w", err)
+	}
+	defer func() {
+		//craft:ignore swallowed-errors the bytes are already read by the time this runs; failing a send because a reader would not close would refuse a message that is otherwise complete
+		_ = rc.Close()
+	}()
+	body, err := io.ReadAll(rc)
+	if err != nil {
+		return nil, fmt.Errorf("comms: reading an attached file: %w", err)
+	}
+	return body, nil
 }

--- a/backend/internal/compose/commsattachments.go
+++ b/backend/internal/compose/commsattachments.go
@@ -135,15 +135,35 @@ func (a commsAttachments) ReadForSend(
 		return nil, fmt.Errorf("comms: reading files for a send: %s", reason)
 	}
 	out := make([][]byte, 0, len(attachmentIDs))
+	total := int64(0)
 	for _, id := range attachmentIDs {
 		body, err := a.readOne(senderCtx, id)
 		if err != nil {
 			return nil, err
 		}
+		total += int64(len(body))
+		if total > maxSendBytes {
+			// The count is capped in the contract and the size per file at
+			// upload, and neither bounds their PRODUCT — ten files at the
+			// upload limit is a quarter of a gigabyte held at once, and the
+			// base64 encoding below doubles it. Refusing here is what keeps a
+			// worker that serves every send in the installation from dying of
+			// one message.
+			return nil, fmt.Errorf(
+				"comms: this message's files total more than %d MiB, which is more than a send may carry",
+				maxSendBytes>>20)
+		}
 		out = append(out, body)
 	}
 	return out, nil
 }
+
+// maxSendBytes caps what ONE message may carry in total.
+//
+// Below what mailbox providers accept (Gmail refuses past 25 MiB after
+// encoding), so a message this passes is one the provider will take rather than
+// one this product built and the wire refused.
+const maxSendBytes = 20 << 20
 
 // readOne reads one attachment fully, closing the object either way.
 func (a commsAttachments) readOne(ctx context.Context, id ids.UUID) ([]byte, error) {

--- a/backend/internal/compose/commsjobs.go
+++ b/backend/internal/compose/commsjobs.go
@@ -25,6 +25,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/modules/comms"
 	"github.com/gradionhq/margince/backend/internal/modules/consent"
 	"github.com/gradionhq/margince/backend/internal/modules/identity"
+	"github.com/gradionhq/margince/backend/internal/platform/blobstore"
 	"github.com/gradionhq/margince/backend/internal/platform/jobs"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
@@ -348,6 +349,7 @@ func (s commsStager) StageTx(ctx context.Context, tx pgx.Tx, in activities.Deliv
 		Body:            in.Body,
 		HTMLBody:        in.HTMLBody,
 		FromName:        in.FromName,
+		Attachments:     commsFiles(in.Attachments),
 		ConsentPurpose:  in.ConsentPurpose,
 		InReplyTo:       in.InReplyTo,
 		References:      in.References,
@@ -430,7 +432,7 @@ func (p SendPacing) withDefaults() SendPacing {
 // store, the mailbox resolver over the capture registry, the consent gate, and
 // the policy chain. Every one of those edges crosses a module boundary, which
 // is why the assembly lives here and not in comms.
-func newSendWorker(pool *pgxpool.Pool, registry *capture.Registry, pacing SendPacing) *commsSendWorker {
+func newSendWorker(pool *pgxpool.Pool, registry *capture.Registry, pacing SendPacing, blob blobstore.Store) *commsSendWorker {
 	p := pacing.withDefaults()
 	return &commsSendWorker{dispatcher: comms.NewDispatcher(
 		// The reconcile seam is the cross-module edge comms must not hold
@@ -439,7 +441,7 @@ func newSendWorker(pool *pgxpool.Pool, registry *capture.Registry, pacing SendPa
 		comms.NewStore(InstallationDB(pool), time.Now, activities.NewStore(InstallationDB(pool))),
 		commsResolver{registry: registry, channels: registry},
 		NewSendSeatAuthority(pool),
-		NewSendAttachmentAuthority(pool),
+		NewSendAttachmentAuthority(pool, blob),
 		consent.NewGate(consent.NewStore(InstallationDB(pool))),
 		[]comms.SendPolicy{comms.NewMailboxRatePolicy(p.Limit, p.Window, time.Now)},
 		time.Now,
@@ -451,4 +453,25 @@ func newSendWorker(pool *pgxpool.Pool, registry *capture.Registry, pacing SendPa
 		// apart: there is exactly one place the ladder length is declared.
 		sendInsertOpts().MaxAttempts,
 	)}
+}
+
+// commsFiles carries the send's attachment snapshot across the module boundary.
+// The two types are deliberately separate — activities owns what a message
+// carries, comms owns what a delivery holds — and this is the one place they
+// meet.
+func commsFiles(files []activities.OutboundFile) []comms.OutboundFile {
+	if len(files) == 0 {
+		return nil
+	}
+	out := make([]comms.OutboundFile, 0, len(files))
+	for _, file := range files {
+		out = append(out, comms.OutboundFile{
+			AttachmentID: file.AttachmentID,
+			Filename:     file.Filename,
+			ContentType:  file.ContentType,
+			ByteSize:     file.ByteSize,
+			Checksum:     file.Checksum,
+		})
+	}
+	return out
 }

--- a/backend/internal/compose/integration/comms_send_integration_test.go
+++ b/backend/internal/compose/integration/comms_send_integration_test.go
@@ -182,7 +182,10 @@ func (p *preflightEnv) dispatchOnce(t *testing.T, deliveryID ids.UUID, stampAs s
 		comms.NewStore(compose.InstallationDB(p.Pool), time.Now, activities.NewStore(compose.InstallationDB(p.Pool))),
 		stubMailbox{sender: gmailConnector, auth: auth},
 		compose.NewSendSeatAuthority(p.Pool),
-		compose.NewSendAttachmentAuthority(p.Pool),
+		// nil object store: this lane sends no files, and a role wired without
+		// one still runs the gate — which reads rows — and only fails at the
+		// byte read a message with attachments would reach.
+		compose.NewSendAttachmentAuthority(p.Pool, nil),
 		consent.NewGate(consent.NewStore(compose.InstallationDB(p.Pool))),
 		nil, time.Now, 24*time.Hour, 10,
 	)

--- a/backend/internal/compose/jobs.go
+++ b/backend/internal/compose/jobs.go
@@ -69,6 +69,11 @@ type JobRunnerConfig struct {
 	// delivery may be deferred before it parks; the zero value takes the
 	// documented defaults (SendPacing.withDefaults).
 	SendPacing SendPacing
+	// SendBlob is the object store the send lane reads attachment bytes from.
+	// Nil is a role that sends no files: the integrity gate still runs (it
+	// reads rows), and a message carrying attachments then fails at the read
+	// rather than going out without them.
+	SendBlob blobstore.Store
 	// SendRegistry resolves the transmitting mailbox for a staged delivery.
 	// Nil means this role registers no send worker at all: a delivery it
 	// picked up could only fail on every attempt, and a queued send is better

--- a/backend/internal/compose/jobs_capture.go
+++ b/backend/internal/compose/jobs_capture.go
@@ -91,7 +91,7 @@ func addCapturePipelineJobs(reg *jobRegistry, pool *pgxpool.Pool, cfg JobRunnerC
 	// message, in the same transaction as the activity; this role only needs
 	// the worker registered.
 	if cfg.SendRegistry != nil {
-		addDeclaredWorker[SendEmailArgs](reg, newSendWorker(pool, cfg.SendRegistry, cfg.SendPacing))
+		addDeclaredWorker[SendEmailArgs](reg, newSendWorker(pool, cfg.SendRegistry, cfg.SendPacing, cfg.SendBlob))
 	}
 
 	if cfg.ClassifyBrain != nil {

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -17550,6 +17550,18 @@ type SearchResultType string
 // SendAccountEmailRequest One account-started send. It is SendEmailRequest plus the `links` an anchor would
 // otherwise have supplied — the records this new conversation belongs to.
 type SendAccountEmailRequest struct {
+	// AttachmentIds Files already in the record library to send with this message, named by id
+	// — never uploaded here. Each is snapshotted at staging (ADR-0086/A131 §4) so
+	// archiving or superseding one later cannot rewrite what the timeline says a
+	// sent message carried.
+	//
+	// A message is transmitted with ALL its files or not at all. A connector whose
+	// provider cannot carry them parks the delivery rather than sending the text
+	// alone, and a file the scanner has since quarantined — or one the sender has
+	// since lost the right to read — parks it too: a recipient seeing fewer files
+	// than the record claims is a wrong record nobody is told about.
+	AttachmentIds *[]openapi_types.UUID `json:"attachment_ids,omitempty"`
+
 	// Body The (possibly edited) final body that is sent.
 	Body string                 `json:"body"`
 	Cc   *[]openapi_types.Email `json:"cc,omitempty"`
@@ -17586,6 +17598,18 @@ type SendAccountEmailRequest struct {
 
 // SendEmailRequest defines model for SendEmailRequest.
 type SendEmailRequest struct {
+	// AttachmentIds Files already in the record library to send with this message, named by id
+	// — never uploaded here. Each is snapshotted at staging (ADR-0086/A131 §4) so
+	// archiving or superseding one later cannot rewrite what the timeline says a
+	// sent message carried.
+	//
+	// A message is transmitted with ALL its files or not at all. A connector whose
+	// provider cannot carry them parks the delivery rather than sending the text
+	// alone, and a file the scanner has since quarantined — or one the sender has
+	// since lost the right to read — parks it too: a recipient seeing fewer files
+	// than the record claims is a wrong record nobody is told about.
+	AttachmentIds *[]openapi_types.UUID `json:"attachment_ids,omitempty"`
+
 	// Body The (possibly edited) final body that is sent.
 	Body string                 `json:"body"`
 	Cc   *[]openapi_types.Email `json:"cc,omitempty"`

--- a/backend/internal/modules/activities/email.go
+++ b/backend/internal/modules/activities/email.go
@@ -73,7 +73,12 @@ type SendEmailInput struct {
 	// It never replaces Body: both travel, and the wire renders them as
 	// multipart/alternative so a client that cannot show markup still receives
 	// the words.
-	HTMLBody       string
+	HTMLBody string
+	// AttachmentIDs names files already in the record library. The send resolves
+	// each to a SNAPSHOT of its metadata rather than keeping the id, so
+	// superseding the document later cannot rewrite what the timeline says this
+	// message carried (ADR-0086/A131 §4).
+	AttachmentIDs  []ids.UUID
 	ConsentPurpose string
 	// DraftRef names the voice draft this message came from, so the send can
 	// close the learning signal that draft opened. Empty is the ordinary case:
@@ -111,7 +116,9 @@ type DeliveryRequest struct {
 	HTMLBody   string // the markup alternative, empty for a plain-text send
 	// FromName is the sender's display name, snapshotted so a retry renders the
 	// same From header the first attempt did.
-	FromName       string
+	FromName string
+	// Attachments is what this message carries, snapshotted at staging.
+	Attachments    []OutboundFile
 	ConsentPurpose string
 	InReplyTo      string   // unbracketed; empty starts a conversation
 	References     []string // unbracketed ancestry, oldest first
@@ -228,6 +235,16 @@ func (s *Store) SendEmail(ctx context.Context, origin SendOrigin, in SendEmailIn
 	}
 	messageID := MintMessageID(s.messageIDDomain())
 
+	// The files, resolved to snapshots while the sender's own read gate still
+	// applies. It runs before the transaction for the same reason the body work
+	// does — the transaction holds writes only — and it refuses the whole send
+	// when one file cannot be resolved, because a message carrying fewer files
+	// than the sender attached is one nobody is told is wrong.
+	files, err := s.resolveAttachments(ctx, in.AttachmentIDs)
+	if err != nil {
+		return crmcontracts.Activity{}, err
+	}
+
 	// Caller markup is filtered BEFORE anything of ours is added to it, so the
 	// signature and the unsubscribe footer below are not themselves subject to
 	// a filter they would only ever pass — and so what the allowlist judges is
@@ -262,6 +279,7 @@ func (s *Store) SendEmail(ctx context.Context, origin SendOrigin, in SendEmailIn
 		body:            derived.transmitted,
 		recordedBody:    derived.recorded,
 		htmlBody:        htmlBody,
+		files:           files,
 		listUnsubscribe: derived.listUnsubscribe,
 		to:              toRecipients(in.Recipients, in.Cc),
 		links:           links,

--- a/backend/internal/modules/activities/handlers_email.go
+++ b/backend/internal/modules/activities/handlers_email.go
@@ -257,7 +257,8 @@ func (h Handlers) SendAccountEmail(w http.ResponseWriter, r *http.Request, _ crm
 	}
 
 	sent, err := h.store.SendEmail(r.Context(), FromAccount(links), sendInputFrom(
-		req.To, req.Cc, req.Subject, req.Body, req.HtmlBody, req.ConsentPurpose, req.DraftRef,
+		req.To, req.Cc, req.Subject, req.Body, req.HtmlBody, req.AttachmentIds,
+		req.ConsentPurpose, req.DraftRef,
 	), h.consent, h.delivery)
 	if err != nil {
 		writeStoreErr(w, r, err)
@@ -271,7 +272,7 @@ func (h Handlers) SendAccountEmail(w http.ResponseWriter, r *http.Request, _ crm
 // a convenience: consent is owed to every addressee, so Recipients is To+Cc
 // and Cc is a subset of it. A second hand-rolled copy would eventually merge
 // one of them differently and mail somebody the gate never asked about.
-func sendInputFrom(to []openapi_types.Email, cc *[]openapi_types.Email, subject, body string, htmlBody *string, purpose string, draftRef *string) SendEmailInput {
+func sendInputFrom(to []openapi_types.Email, cc *[]openapi_types.Email, subject, body string, htmlBody *string, attachments *[]openapi_types.UUID, purpose string, draftRef *string) SendEmailInput {
 	var ccAddresses []string
 	if cc != nil {
 		ccAddresses = make([]string, 0, len(*cc))
@@ -293,12 +294,20 @@ func sendInputFrom(to []openapi_types.Email, cc *[]openapi_types.Email, subject,
 	if htmlBody != nil {
 		html = *htmlBody
 	}
+	var files []ids.UUID
+	if attachments != nil {
+		files = make([]ids.UUID, 0, len(*attachments))
+		for _, id := range *attachments {
+			files = append(files, ids.UUID(id))
+		}
+	}
 	return SendEmailInput{
 		Recipients:     recipients,
 		Cc:             ccAddresses,
 		Subject:        subject,
 		Body:           body,
 		HTMLBody:       html,
+		AttachmentIDs:  files,
 		ConsentPurpose: purpose,
 		DraftRef:       ref,
 	}
@@ -317,7 +326,8 @@ func (h Handlers) SendEmail(w http.ResponseWriter, r *http.Request, id crmcontra
 	// it too. It belongs on the mail, not on this response to the API
 	// caller, who is not the recipient and has nothing to unsubscribe from.
 	sent, err := h.store.SendEmail(r.Context(), FromActivity(pathID[ids.ActivityKind](id)), sendInputFrom(
-		req.To, req.Cc, req.Subject, req.Body, req.HtmlBody, req.ConsentPurpose, req.DraftRef,
+		req.To, req.Cc, req.Subject, req.Body, req.HtmlBody, req.AttachmentIds,
+		req.ConsentPurpose, req.DraftRef,
 	), h.consent, h.delivery)
 	if err != nil {
 		writeStoreErr(w, r, err)

--- a/backend/internal/modules/activities/handlers_email_test.go
+++ b/backend/internal/modules/activities/handlers_email_test.go
@@ -25,7 +25,7 @@ func emails(addresses ...string) []openapi_types.Email {
 
 func TestSendInputMergesEveryAddresseeForTheConsentGate(t *testing.T) {
 	cc := emails("boss@example.test")
-	in := sendInputFrom(emails("buyer@example.test"), &cc, "Pricing", "As discussed.", nil, "transactional", nil)
+	in := sendInputFrom(emails("buyer@example.test"), &cc, "Pricing", "As discussed.", nil, nil, "transactional", nil)
 
 	// The gate answers on Recipients, so a cc'd person must appear there or
 	// they receive mail nobody asked consent for.
@@ -48,7 +48,7 @@ func TestSendInputMergesEveryAddresseeForTheConsentGate(t *testing.T) {
 }
 
 func TestSendInputWithoutCcCarriesOnlyTheAddressees(t *testing.T) {
-	in := sendInputFrom(emails("buyer@example.test"), nil, "Pricing", "As discussed.", nil, "transactional", nil)
+	in := sendInputFrom(emails("buyer@example.test"), nil, "Pricing", "As discussed.", nil, nil, "transactional", nil)
 
 	if len(in.Recipients) != 1 || in.Recipients[0] != "buyer@example.test" {
 		t.Fatalf("Recipients = %v, want just the one addressee", in.Recipients)
@@ -62,13 +62,13 @@ func TestSendInputWithoutCcCarriesOnlyTheAddressees(t *testing.T) {
 // composed without a served draft resolves no learning signal, which the
 // empty string is how the send path is told.
 func TestSendInputResolvesNoDraftWhenNoneWasServed(t *testing.T) {
-	in := sendInputFrom(emails("buyer@example.test"), nil, "Pricing", "Body", nil, "transactional", nil)
+	in := sendInputFrom(emails("buyer@example.test"), nil, "Pricing", "Body", nil, nil, "transactional", nil)
 	if in.DraftRef != "" {
 		t.Fatalf("DraftRef = %q, want empty so no voice outcome is inferred", in.DraftRef)
 	}
 
 	ref := "draft-42"
-	withDraft := sendInputFrom(emails("buyer@example.test"), nil, "Pricing", "Body", nil, "transactional", &ref)
+	withDraft := sendInputFrom(emails("buyer@example.test"), nil, "Pricing", "Body", nil, nil, "transactional", &ref)
 	if withDraft.DraftRef != ref {
 		t.Fatalf("DraftRef = %q, want %q — the send closes the signal that draft opened", withDraft.DraftRef, ref)
 	}

--- a/backend/internal/modules/activities/outboundmessage.go
+++ b/backend/internal/modules/activities/outboundmessage.go
@@ -38,7 +38,9 @@ type outboundMessage struct {
 	// fromName is who the recipient sees this is from. Resolved at send time
 	// from the authenticated sender rather than at transmit, so a rename
 	// between attempts cannot change a message already in flight.
-	fromName        string
+	fromName string
+	// files is what this message carries, already snapshotted.
+	files           []OutboundFile
 	listUnsubscribe string
 	to              []string
 	links           []ActivityLinkInput
@@ -99,6 +101,7 @@ func (m outboundMessage) delivery(activityID ids.UUID, chain threading) Delivery
 		Body:            m.body,
 		HTMLBody:        m.htmlBody,
 		FromName:        m.fromName,
+		Attachments:     m.files,
 		ConsentPurpose:  m.in.ConsentPurpose,
 		InReplyTo:       chain.inReplyTo,
 		References:      chain.references,

--- a/backend/internal/modules/activities/sendattachments.go
+++ b/backend/internal/modules/activities/sendattachments.go
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package activities
+
+// What a message carries, resolved at the moment it is sent.
+//
+// The caller names files by id; the send stores a SNAPSHOT of each one's
+// metadata (ADR-0086/A131 §4). A pointer would let a later edit rewrite history
+// — archive or supersede the document tomorrow and the timeline would change
+// what it says a message sent today contained. A snapshot cannot.
+//
+// Resolution is a READ, and it carries the read's gate: GetAttachmentMeta
+// refuses a file whose parent record the sender cannot see, so a rep cannot
+// attach a document by guessing its id.
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// OutboundFile is one file this message carries, as it was when the message was
+// staged. The BYTES are not here: they are read from the object store at
+// transmit, so a delivery sitting on a retry ladder does not hold every
+// attachment it might ever send in the database.
+type OutboundFile struct {
+	AttachmentID ids.UUID
+	Filename     string
+	ContentType  string
+	ByteSize     int64
+	Checksum     string
+}
+
+// resolveAttachments turns the caller's ids into the snapshot the delivery
+// keeps.
+//
+// It refuses the whole send when one file cannot be resolved rather than
+// dropping that file and going on. A message whose recipient sees fewer files
+// than the sender attached is a message nobody is told is wrong — the same
+// reasoning the dispatcher's carriage gate applies later, applied here at the
+// first point where the difference is visible.
+func (s *Store) resolveAttachments(ctx context.Context, ids []ids.UUID) ([]OutboundFile, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	out := make([]OutboundFile, 0, len(ids))
+	for _, id := range ids {
+		meta, err := s.GetAttachmentMeta(ctx, id)
+		if err != nil {
+			// The sentinel travels: a file the sender cannot see is the same
+			// 404 the attachment read itself gives, and the transport maps it
+			// without this layer inventing a second vocabulary for it.
+			return nil, fmt.Errorf("resolving an attached file: %w", err)
+		}
+		out = append(out, OutboundFile{
+			AttachmentID: id,
+			Filename:     meta.Filename,
+			ContentType:  orEmpty(meta.ContentType),
+			ByteSize:     orZero(meta.ByteSize),
+			Checksum:     orEmpty(meta.Checksum),
+		})
+	}
+	return out, nil
+}
+
+func orEmpty(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
+}
+
+func orZero(value *int64) int64 {
+	if value == nil {
+		return 0
+	}
+	return *value
+}

--- a/backend/internal/modules/capture/gmail/multipart_test.go
+++ b/backend/internal/modules/capture/gmail/multipart_test.go
@@ -398,12 +398,38 @@ func TestANonASCIIFilenameIsEncoded(t *testing.T) {
 	msg := plainMessage()
 	msg.Files = []connector.OutboundFile{{Filename: "Größenänderung.pdf", Body: []byte("x")}}
 
-	raw := buildRFC822("rep@gradion.test", msg)
-	if strings.Contains(raw, "Größenänderung.pdf") {
-		t.Fatalf("a non-ASCII filename went out unencoded:\n%s", raw)
+	// Asserted through the parser rather than on the bytes: what matters is
+	// that a CLIENT recovers the name, not which legal spelling produced it.
+	// RFC 2231 is what a MIME parameter takes; the RFC 2047 encoded word this
+	// replaced is for header text and arrives literally in some clients.
+	recovered := filenameFromWire(t, buildRFC822("rep@gradion.test", msg))
+	if recovered != "Größenänderung.pdf" {
+		t.Fatalf("a client would see the filename as %q", recovered)
 	}
-	if !strings.Contains(raw, "=?utf-8?q?") {
-		t.Fatalf("the filename was not encoded at all:\n%s", raw)
+}
+
+// filenameFromWire reads the attachment's filename back the way a mail client
+// does: parse the part, parse its Content-Disposition, take the parameter.
+func filenameFromWire(t *testing.T, raw string) string {
+	t.Helper()
+	parsed := parseMail(t, raw)
+	_, params, err := mime.ParseMediaType(parsed.Header.Get("Content-Type"))
+	if err != nil {
+		t.Fatalf("parsing the content type failed: %v", err)
+	}
+	reader := multipart.NewReader(parsed.Body, params["boundary"])
+	for {
+		part, err := reader.NextPart()
+		if err != nil {
+			t.Fatalf("no attachment part carried a filename: %v", err)
+		}
+		_, disp, err := mime.ParseMediaType(part.Header.Get("Content-Disposition"))
+		if err != nil {
+			continue
+		}
+		if name := disp["filename"]; name != "" {
+			return name
+		}
 	}
 }
 
@@ -416,5 +442,18 @@ func TestAFileWithNoTypeGetsOctetStream(t *testing.T) {
 
 	if !strings.Contains(buildRFC822("rep@gradion.test", msg), "application/octet-stream") {
 		t.Fatal("a typeless file went out with no content type")
+	}
+}
+
+// A filename that could break the parameter it sits in must not. A quote ends
+// the value early, and a client then shows a truncated name or none at all.
+func TestAFilenameWithAQuoteStaysOneParameter(t *testing.T) {
+	msg := plainMessage()
+	msg.Files = []connector.OutboundFile{
+		{Filename: `the "final" contract.pdf`, Body: []byte("x")},
+	}
+
+	if got := filenameFromWire(t, buildRFC822("rep@gradion.test", msg)); got != `the "final" contract.pdf` {
+		t.Fatalf("a client would see the filename as %q", got)
 	}
 }

--- a/backend/internal/modules/capture/gmail/multipart_test.go
+++ b/backend/internal/modules/capture/gmail/multipart_test.go
@@ -10,6 +10,7 @@ package gmail
 // blank, and only a parser can tell the two apart.
 
 import (
+	"encoding/base64"
 	"io"
 	"mime"
 	"mime/multipart"
@@ -297,5 +298,123 @@ func TestNoSenderNameSendsABareAddress(t *testing.T) {
 				t.Fatalf("expected a bare address, got %q", got)
 			}
 		})
+	}
+}
+
+// A message carrying files is multipart/mixed whose FIRST part is the message
+// and whose rest are the attachments. A client shows the first part as the body
+// and offers the others, so a message whose files came first would open on an
+// attachment.
+func TestAMessageWithFilesIsMultipartMixed(t *testing.T) {
+	msg := plainMessage()
+	msg.Files = []connector.OutboundFile{
+		{Filename: "Vertrag.pdf", ContentType: "application/pdf", Body: []byte("%PDF-1.7 fake")},
+	}
+
+	parsed := parseMail(t, buildRFC822("rep@gradion.test", msg))
+	mediaType, params, err := mime.ParseMediaType(parsed.Header.Get("Content-Type"))
+	if err != nil {
+		t.Fatalf("parsing the content type failed: %v", err)
+	}
+	if mediaType != "multipart/mixed" {
+		t.Fatalf("expected multipart/mixed, got %q", mediaType)
+	}
+
+	reader := multipart.NewReader(parsed.Body, params["boundary"])
+	first, err := reader.NextPart()
+	if err != nil {
+		t.Fatalf("reading the message part failed: %v", err)
+	}
+	if got := first.Header.Get("Content-Type"); !strings.HasPrefix(got, "text/plain") {
+		t.Fatalf("the first part is %q, so a client would open on something other than the message", got)
+	}
+
+	attachment, err := reader.NextPart()
+	if err != nil {
+		t.Fatalf("reading the attachment part failed: %v", err)
+	}
+	if got := attachment.Header.Get("Content-Disposition"); !strings.Contains(got, "attachment") {
+		t.Fatalf("the file is not marked as an attachment: %q", got)
+	}
+	// NextPart hands back the part's raw bytes; decoding is the client's job
+	// and this is that step, so the assertion is on the file a recipient would
+	// actually reconstruct.
+	encoded, err := io.ReadAll(attachment)
+	if err != nil {
+		t.Fatalf("reading the attachment body failed: %v", err)
+	}
+	body, err := base64.StdEncoding.DecodeString(
+		strings.ReplaceAll(string(encoded), "\r\n", ""))
+	if err != nil {
+		t.Fatalf("the attachment is not valid base64: %v", err)
+	}
+	if string(body) != "%PDF-1.7 fake" {
+		t.Fatalf("the bytes did not survive the wire: %q", body)
+	}
+}
+
+// A file's bytes are base64, not 8bit like the text parts: a PDF contains the
+// line endings and boundary-looking sequences a text part may assume it has
+// none of, and any of them would end the part early.
+func TestAFilesBytesAreBase64Encoded(t *testing.T) {
+	msg := plainMessage()
+	msg.Files = []connector.OutboundFile{
+		{Filename: "raw.bin", Body: []byte("line\r\n--boundary-ish\r\nmore")},
+	}
+
+	raw := buildRFC822("rep@gradion.test", msg)
+	if !strings.Contains(raw, "Content-Transfer-Encoding: base64") {
+		t.Fatalf("a file went out unencoded:\n%s", raw)
+	}
+	if strings.Contains(raw, "--boundary-ish") {
+		t.Fatal("raw file bytes reached the wire, where a boundary-looking line would truncate the message")
+	}
+}
+
+// Markup AND files: the alternative pair nests inside the mixed envelope, so a
+// client still chooses between text and HTML while the files remain attached.
+func TestFilesAndMarkupNestCorrectly(t *testing.T) {
+	msg := plainMessage()
+	msg.HTMLBody = "<p>Anbei die Zahlen.</p>"
+	msg.Files = []connector.OutboundFile{{Filename: "z.pdf", Body: []byte("x")}}
+
+	parsed := parseMail(t, buildRFC822("rep@gradion.test", msg))
+	_, params, err := mime.ParseMediaType(parsed.Header.Get("Content-Type"))
+	if err != nil {
+		t.Fatalf("parsing the content type failed: %v", err)
+	}
+	first, err := multipart.NewReader(parsed.Body, params["boundary"]).NextPart()
+	if err != nil {
+		t.Fatalf("reading the message part failed: %v", err)
+	}
+	if got := first.Header.Get("Content-Type"); !strings.HasPrefix(got, "multipart/alternative") {
+		t.Fatalf("the message part is %q, so the plain/markup choice was lost", got)
+	}
+}
+
+// A non-ASCII file name needs RFC 2047 encoding, exactly as the Subject does.
+// Raw, it is mangled or the message is rejected.
+func TestANonASCIIFilenameIsEncoded(t *testing.T) {
+	msg := plainMessage()
+	msg.Files = []connector.OutboundFile{{Filename: "Größenänderung.pdf", Body: []byte("x")}}
+
+	raw := buildRFC822("rep@gradion.test", msg)
+	if strings.Contains(raw, "Größenänderung.pdf") {
+		t.Fatalf("a non-ASCII filename went out unencoded:\n%s", raw)
+	}
+	if !strings.Contains(raw, "=?utf-8?q?") {
+		t.Fatalf("the filename was not encoded at all:\n%s", raw)
+	}
+}
+
+// A file with no declared type is octet-stream rather than nothing: a part with
+// no type is guessed at, and a client guessing wrong renders a PDF as gibberish
+// in the message body.
+func TestAFileWithNoTypeGetsOctetStream(t *testing.T) {
+	msg := plainMessage()
+	msg.Files = []connector.OutboundFile{{Filename: "unknown", Body: []byte("x")}}
+
+	if !strings.Contains(buildRFC822("rep@gradion.test", msg), "application/octet-stream") {
+		t.Fatal("a typeless file went out with no content type")
 	}
 }

--- a/backend/internal/modules/capture/gmail/rfc822.go
+++ b/backend/internal/modules/capture/gmail/rfc822.go
@@ -102,8 +102,13 @@ func writeMixed(b *strings.Builder, msg connector.EmailMessage) {
 // to assume it has none of, and any of them would end the part early.
 //
 // The filename rides in BOTH Content-Type and Content-Disposition because
-// clients disagree about which they read, and it is RFC 2047 encoded in each:
-// a German file name is otherwise mangled or rejected.
+// clients disagree about which they read.
+//
+// FormatMediaType renders each, rather than the RFC 2047 encoded-word the
+// subject line uses: an encoded word is for header TEXT, and a parameter needs
+// RFC 2231 — which is what this produces for a name carrying an umlaut, and
+// which also quotes a name carrying a quote instead of ending the parameter
+// early.
 func writeAttachment(b *strings.Builder, boundary string, file connector.OutboundFile) {
 	contentType := file.ContentType
 	if contentType == "" {
@@ -112,10 +117,11 @@ func writeAttachment(b *strings.Builder, boundary string, file connector.Outboun
 		// gibberish in the message body.
 		contentType = "application/octet-stream"
 	}
-	name := mime.QEncoding.Encode("utf-8", file.Filename)
 	b.WriteString("--" + boundary + "\r\n")
-	writeHeader(b, "Content-Type", contentType+`; name="`+name+`"`)
-	writeHeader(b, "Content-Disposition", `attachment; filename="`+name+`"`)
+	writeHeader(b, "Content-Type", mime.FormatMediaType(contentType,
+		map[string]string{"name": file.Filename}))
+	writeHeader(b, "Content-Disposition", mime.FormatMediaType("attachment",
+		map[string]string{"filename": file.Filename}))
 	writeHeader(b, "Content-Transfer-Encoding", "base64")
 	b.WriteString("\r\n")
 	b.WriteString(wrapBase64(base64.StdEncoding.EncodeToString(file.Body)))

--- a/backend/internal/modules/capture/gmail/rfc822.go
+++ b/backend/internal/modules/capture/gmail/rfc822.go
@@ -1,0 +1,243 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package gmail
+
+// The wire format: a provider-neutral message rendered as the RFC822 bytes
+// Gmail's messages.send accepts.
+//
+// Apart from the connector's transport concerns because it is a different
+// question — that half decides WHETHER and WHEN to send, this half decides what
+// the bytes are. It is also the half a reader checks against a spec: the part
+// order, the transfer encodings and the boundary rules below each cite the RFC
+// that requires them.
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"mime"
+	"net/mail"
+	"strings"
+
+	"github.com/gradionhq/margince/backend/internal/shared/ports/connector"
+)
+
+// buildRFC822 renders the provider-neutral message as the wire format Gmail
+// accepts: header order follows RFC 5322's origination-first sequence, body is
+// text/plain UTF-8.
+func buildRFC822(from string, msg connector.EmailMessage) string {
+	var b strings.Builder
+	writeHeader(&b, "From", fromHeader(from, msg.FromName))
+	writeHeader(&b, "To", addressList(msg.To))
+	if cc := addressList(msg.Cc); cc != "" {
+		writeHeader(&b, "Cc", cc)
+	}
+	// Encoded-word per RFC 2047 so a non-ASCII subject survives the wire.
+	writeHeader(&b, "Subject", mime.QEncoding.Encode("utf-8", msg.Subject))
+	writeHeader(&b, "Message-ID", bracket(msg.MessageID))
+	if msg.InReplyTo != "" {
+		writeHeader(&b, "In-Reply-To", bracket(msg.InReplyTo))
+	}
+	if len(msg.References) > 0 {
+		refs := make([]string, 0, len(msg.References))
+		for _, r := range msg.References {
+			refs = append(refs, bracket(r))
+		}
+		writeHeader(&b, "References", strings.Join(refs, " "))
+	}
+	if msg.ListUnsubscribe != "" {
+		writeHeader(&b, "List-Unsubscribe", msg.ListUnsubscribe)
+		writeHeader(&b, "List-Unsubscribe-Post", msg.ListUnsubscribePost)
+	}
+	writeHeader(&b, "MIME-Version", "1.0")
+	writeBody(&b, msg)
+	return b.String()
+}
+
+// writeBody renders the content headers and the body itself.
+//
+// A plain-text-only message keeps the single-part shape it has always had:
+// wrapping one part in a multipart envelope buys nothing and costs every reader
+// a boundary to parse.
+//
+// With markup it becomes multipart/alternative, PLAIN PART FIRST. The order is
+// the contract, not a preference — RFC 2046 §5.1.4 puts the least-faithful
+// alternative first and a client renders the LAST part it understands, so a
+// reversed order shows the plain text to everybody.
+func writeBody(b *strings.Builder, msg connector.EmailMessage) {
+	if len(msg.Files) > 0 {
+		writeMixed(b, msg)
+		return
+	}
+	writeText(b, msg)
+}
+
+// writeMixed renders a message carrying files: multipart/mixed whose FIRST part
+// is the message itself — text, or the alternative pair — and whose remaining
+// parts are the attachments.
+//
+// The nesting is the standard one and the order is not arbitrary: a client
+// shows the first part as the body and offers the rest, so a message whose
+// files came first would open on an attachment.
+func writeMixed(b *strings.Builder, msg connector.EmailMessage) {
+	boundary := safeBoundary(msg) + "_mixed"
+	writeHeader(b, "Content-Type", `multipart/mixed; boundary="`+boundary+`"`)
+	b.WriteString("\r\n")
+
+	b.WriteString("--" + boundary + "\r\n")
+	writeText(b, msg)
+	b.WriteString("\r\n")
+
+	for _, file := range msg.Files {
+		writeAttachment(b, boundary, file)
+	}
+	b.WriteString("--" + boundary + "--\r\n")
+}
+
+// writeAttachment renders one file as a base64 part.
+//
+// base64 rather than 8bit, unlike the text parts: a PDF's bytes include the
+// line endings and the boundary-looking sequences that a text part is allowed
+// to assume it has none of, and any of them would end the part early.
+//
+// The filename rides in BOTH Content-Type and Content-Disposition because
+// clients disagree about which they read, and it is RFC 2047 encoded in each:
+// a German file name is otherwise mangled or rejected.
+func writeAttachment(b *strings.Builder, boundary string, file connector.OutboundFile) {
+	contentType := file.ContentType
+	if contentType == "" {
+		// The type nobody can misread as something else. A part with no type
+		// is guessed at, and a client that guesses wrong renders a PDF as
+		// gibberish in the message body.
+		contentType = "application/octet-stream"
+	}
+	name := mime.QEncoding.Encode("utf-8", file.Filename)
+	b.WriteString("--" + boundary + "\r\n")
+	writeHeader(b, "Content-Type", contentType+`; name="`+name+`"`)
+	writeHeader(b, "Content-Disposition", `attachment; filename="`+name+`"`)
+	writeHeader(b, "Content-Transfer-Encoding", "base64")
+	b.WriteString("\r\n")
+	b.WriteString(wrapBase64(base64.StdEncoding.EncodeToString(file.Body)))
+	b.WriteString("\r\n")
+}
+
+// wrapBase64 folds the encoding at 76 characters, which RFC 2045 requires and
+// some relays enforce by refusing longer lines.
+func wrapBase64(encoded string) string {
+	const width = 76
+	var out strings.Builder
+	for i := 0; i < len(encoded); i += width {
+		end := i + width
+		if end > len(encoded) {
+			end = len(encoded)
+		}
+		out.WriteString(encoded[i:end])
+		out.WriteString("\r\n")
+	}
+	return out.String()
+}
+
+// writeText renders the message itself — one text part, or the alternative
+// pair when it carries markup.
+func writeText(b *strings.Builder, msg connector.EmailMessage) {
+	if msg.HTMLBody == "" {
+		writeHeader(b, "Content-Type", `text/plain; charset="utf-8"`)
+		writeHeader(b, "Content-Transfer-Encoding", transferEncoding)
+		b.WriteString("\r\n")
+		b.WriteString(canonicalCRLF(msg.Body))
+		return
+	}
+	boundary := safeBoundary(msg)
+	writeHeader(b, "Content-Type", `multipart/alternative; boundary="`+boundary+`"`)
+	b.WriteString("\r\n")
+	writePart(b, boundary, `text/plain; charset="utf-8"`, msg.Body)
+	writePart(b, boundary, `text/html; charset="utf-8"`, msg.HTMLBody)
+	b.WriteString("--" + boundary + "--\r\n")
+}
+
+// writePart writes one MIME part: its boundary, its type, and its content.
+func writePart(b *strings.Builder, boundary, contentType, content string) {
+	b.WriteString("--" + boundary + "\r\n")
+	writeHeader(b, "Content-Type", contentType)
+	writeHeader(b, "Content-Transfer-Encoding", transferEncoding)
+	b.WriteString("\r\n")
+	b.WriteString(canonicalCRLF(content))
+	b.WriteString("\r\n")
+}
+
+// transferEncoding declares that a part carries raw UTF-8 octets.
+//
+// Without it MIME defaults a part to 7bit, which says every octet is ASCII —
+// and a German umlaut or a Vietnamese diacritic in a body so declared is a lie
+// the next relay is entitled to act on, by rejecting the message or by
+// stripping the high bit. Gmail's base64url wrapper does not fix this: it
+// encodes the RFC822 message for transport to the API, and what this header
+// describes is the part INSIDE that message.
+const transferEncoding = "8bit"
+
+// canonicalCRLF makes every line ending CRLF, which is the only line ending
+// RFC 5322 admits.
+//
+// Bodies arrive here with bare LFs — the signature and the unsubscribe footer
+// are both built with "\n" — and a lone LF inside a MIME part is not a line
+// break to a strict reader. It is also how a part boundary stops being
+// recognised, since a boundary delimiter must be preceded by CRLF.
+func canonicalCRLF(text string) string {
+	return strings.ReplaceAll(strings.ReplaceAll(text, "\r\n", "\n"), "\n", "\r\n")
+}
+
+// safeBoundary is the derived boundary, extended until no part contains it.
+//
+// A delimiter that occurs at the start of a line inside a part ENDS that part
+// there, and everything after it is read as the next part's headers — the
+// message arrives truncated at whatever the sender happened to write. The
+// derived value is 96 bits of the message id's digest, so a collision is not
+// something that happens by accident; this loop is what makes it not something
+// that happens on purpose either.
+func safeBoundary(msg connector.EmailMessage) string {
+	boundary := mimeBoundary(msg.MessageID)
+	for strings.Contains(msg.Body, boundary) || strings.Contains(msg.HTMLBody, boundary) {
+		boundary += "x"
+	}
+	return boundary
+}
+
+// mimeBoundary derives the part separator from the message identity.
+//
+// Derived rather than random so the same message renders byte-identically on a
+// retry: a connector that re-sends compares what it is about to transmit with
+// what it already did, and a fresh boundary each time would make every retry
+// look like a different message.
+//
+// The prefix guarantees the boundary cannot occur in the body it separates:
+// a boundary is only safe if no line of any part begins with it, and no mail
+// body contains this token unless somebody set out to forge one — which the
+// hyphens make impossible to do accidentally.
+func mimeBoundary(messageID string) string {
+	sum := sha256.Sum256([]byte(messageID))
+	return "--=_margince_" + hex.EncodeToString(sum[:12])
+}
+
+// fromHeader renders the sender, with their name when the CRM knows it.
+//
+// A bare address shows its LOCAL PART in every mail client — a message from
+// lars@gradion.com arrives from "lars" — which is what the recipient reads
+// first, before the signature at the bottom of the body says who actually
+// wrote it.
+//
+// mail.Address does the rendering rather than string concatenation, and that is
+// the whole reason this function exists: a name carrying a non-ASCII character
+// needs RFC 2047 encoding, and one carrying a comma or a quote needs quoting or
+// the header parses as TWO addresses. Both are easy to get wrong by hand and
+// impossible to get wrong this way.
+//
+// An empty name renders the bare address, which is what every message did
+// before the name was available. `"" <addr>` would be worse than nothing.
+func fromHeader(address, name string) string {
+	trimmed := strings.TrimSpace(name)
+	if trimmed == "" {
+		return address
+	}
+	return (&mail.Address{Name: trimmed, Address: address}).String()
+}

--- a/backend/internal/modules/capture/gmail/send.go
+++ b/backend/internal/modules/capture/gmail/send.go
@@ -6,16 +6,12 @@ package gmail
 import (
 	"bytes"
 	"context"
-	"crypto/sha256"
 	"encoding/base64"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
 	"log/slog"
-	"mime"
 	"net/http"
-	"net/mail"
 	"net/url"
 	"slices"
 	"strings"
@@ -68,6 +64,17 @@ var _ connector.EmailSender = (*Connector)(nil)
 // concurrent attempts on the same delivery would both observe it pending and
 // both call SendEmail here — the one-job-per-delivery assumption, not this
 // lookup, is what keeps that from happening in practice.
+// CarriesAttachments declares that this connector transmits files
+// (connector.AttachmentCarrier).
+//
+// There is no default for this and that is the design: a message with files
+// staged against a connector that does not declare the capability PARKS rather
+// than going out stripped, because a recipient seeing fewer files than the
+// timeline records is a wrong record nobody is told about. Gmail takes a
+// complete RFC822 message, so the files ride in the multipart/mixed envelope
+// buildRFC822 renders — nothing is uploaded separately and nothing is linked.
+func (c *Connector) CarriesAttachments() bool { return true }
+
 func (c *Connector) SendEmail(ctx context.Context, auth connector.Auth, msg connector.EmailMessage) (connector.SendReceipt, error) {
 	// Before anything reaches Google: a message with no usable identity cannot
 	// be found again by the prior-send lookup above, so transmitting it would
@@ -174,150 +181,6 @@ func bracket(id string) string {
 		return ""
 	}
 	return "<" + strings.Trim(id, "<>") + ">"
-}
-
-// buildRFC822 renders the provider-neutral message as the wire format Gmail
-// accepts: header order follows RFC 5322's origination-first sequence, body is
-// text/plain UTF-8.
-func buildRFC822(from string, msg connector.EmailMessage) string {
-	var b strings.Builder
-	writeHeader(&b, "From", fromHeader(from, msg.FromName))
-	writeHeader(&b, "To", addressList(msg.To))
-	if cc := addressList(msg.Cc); cc != "" {
-		writeHeader(&b, "Cc", cc)
-	}
-	// Encoded-word per RFC 2047 so a non-ASCII subject survives the wire.
-	writeHeader(&b, "Subject", mime.QEncoding.Encode("utf-8", msg.Subject))
-	writeHeader(&b, "Message-ID", bracket(msg.MessageID))
-	if msg.InReplyTo != "" {
-		writeHeader(&b, "In-Reply-To", bracket(msg.InReplyTo))
-	}
-	if len(msg.References) > 0 {
-		refs := make([]string, 0, len(msg.References))
-		for _, r := range msg.References {
-			refs = append(refs, bracket(r))
-		}
-		writeHeader(&b, "References", strings.Join(refs, " "))
-	}
-	if msg.ListUnsubscribe != "" {
-		writeHeader(&b, "List-Unsubscribe", msg.ListUnsubscribe)
-		writeHeader(&b, "List-Unsubscribe-Post", msg.ListUnsubscribePost)
-	}
-	writeHeader(&b, "MIME-Version", "1.0")
-	writeBody(&b, msg)
-	return b.String()
-}
-
-// writeBody renders the content headers and the body itself.
-//
-// A plain-text-only message keeps the single-part shape it has always had:
-// wrapping one part in a multipart envelope buys nothing and costs every reader
-// a boundary to parse.
-//
-// With markup it becomes multipart/alternative, PLAIN PART FIRST. The order is
-// the contract, not a preference — RFC 2046 §5.1.4 puts the least-faithful
-// alternative first and a client renders the LAST part it understands, so a
-// reversed order shows the plain text to everybody.
-func writeBody(b *strings.Builder, msg connector.EmailMessage) {
-	if msg.HTMLBody == "" {
-		writeHeader(b, "Content-Type", `text/plain; charset="utf-8"`)
-		writeHeader(b, "Content-Transfer-Encoding", transferEncoding)
-		b.WriteString("\r\n")
-		b.WriteString(canonicalCRLF(msg.Body))
-		return
-	}
-	boundary := safeBoundary(msg)
-	writeHeader(b, "Content-Type", `multipart/alternative; boundary="`+boundary+`"`)
-	b.WriteString("\r\n")
-	writePart(b, boundary, `text/plain; charset="utf-8"`, msg.Body)
-	writePart(b, boundary, `text/html; charset="utf-8"`, msg.HTMLBody)
-	b.WriteString("--" + boundary + "--\r\n")
-}
-
-// writePart writes one MIME part: its boundary, its type, and its content.
-func writePart(b *strings.Builder, boundary, contentType, content string) {
-	b.WriteString("--" + boundary + "\r\n")
-	writeHeader(b, "Content-Type", contentType)
-	writeHeader(b, "Content-Transfer-Encoding", transferEncoding)
-	b.WriteString("\r\n")
-	b.WriteString(canonicalCRLF(content))
-	b.WriteString("\r\n")
-}
-
-// transferEncoding declares that a part carries raw UTF-8 octets.
-//
-// Without it MIME defaults a part to 7bit, which says every octet is ASCII —
-// and a German umlaut or a Vietnamese diacritic in a body so declared is a lie
-// the next relay is entitled to act on, by rejecting the message or by
-// stripping the high bit. Gmail's base64url wrapper does not fix this: it
-// encodes the RFC822 message for transport to the API, and what this header
-// describes is the part INSIDE that message.
-const transferEncoding = "8bit"
-
-// canonicalCRLF makes every line ending CRLF, which is the only line ending
-// RFC 5322 admits.
-//
-// Bodies arrive here with bare LFs — the signature and the unsubscribe footer
-// are both built with "\n" — and a lone LF inside a MIME part is not a line
-// break to a strict reader. It is also how a part boundary stops being
-// recognised, since a boundary delimiter must be preceded by CRLF.
-func canonicalCRLF(text string) string {
-	return strings.ReplaceAll(strings.ReplaceAll(text, "\r\n", "\n"), "\n", "\r\n")
-}
-
-// safeBoundary is the derived boundary, extended until no part contains it.
-//
-// A delimiter that occurs at the start of a line inside a part ENDS that part
-// there, and everything after it is read as the next part's headers — the
-// message arrives truncated at whatever the sender happened to write. The
-// derived value is 96 bits of the message id's digest, so a collision is not
-// something that happens by accident; this loop is what makes it not something
-// that happens on purpose either.
-func safeBoundary(msg connector.EmailMessage) string {
-	boundary := mimeBoundary(msg.MessageID)
-	for strings.Contains(msg.Body, boundary) || strings.Contains(msg.HTMLBody, boundary) {
-		boundary += "x"
-	}
-	return boundary
-}
-
-// mimeBoundary derives the part separator from the message identity.
-//
-// Derived rather than random so the same message renders byte-identically on a
-// retry: a connector that re-sends compares what it is about to transmit with
-// what it already did, and a fresh boundary each time would make every retry
-// look like a different message.
-//
-// The prefix guarantees the boundary cannot occur in the body it separates:
-// a boundary is only safe if no line of any part begins with it, and no mail
-// body contains this token unless somebody set out to forge one — which the
-// hyphens make impossible to do accidentally.
-func mimeBoundary(messageID string) string {
-	sum := sha256.Sum256([]byte(messageID))
-	return "--=_margince_" + hex.EncodeToString(sum[:12])
-}
-
-// fromHeader renders the sender, with their name when the CRM knows it.
-//
-// A bare address shows its LOCAL PART in every mail client — a message from
-// lars@gradion.com arrives from "lars" — which is what the recipient reads
-// first, before the signature at the bottom of the body says who actually
-// wrote it.
-//
-// mail.Address does the rendering rather than string concatenation, and that is
-// the whole reason this function exists: a name carrying a non-ASCII character
-// needs RFC 2047 encoding, and one carrying a comma or a quote needs quoting or
-// the header parses as TWO addresses. Both are easy to get wrong by hand and
-// impossible to get wrong this way.
-//
-// An empty name renders the bare address, which is what every message did
-// before the name was available. `"" <addr>` would be worse than nothing.
-func fromHeader(address, name string) string {
-	trimmed := strings.TrimSpace(name)
-	if trimmed == "" {
-		return address
-	}
-	return (&mail.Address{Name: trimmed, Address: address}).String()
 }
 
 // addressList renders one address header value: each address trimmed, empties

--- a/backend/internal/modules/comms/carriage_test.go
+++ b/backend/internal/modules/comms/carriage_test.go
@@ -7,6 +7,7 @@ package comms
 // and what reaches the connector once it has been cleared.
 
 import (
+	"context"
 	"testing"
 
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
@@ -42,7 +43,11 @@ func TestOutboundFilesTravelWholeAndCarryTheirIdentity(t *testing.T) {
 		},
 		{AttachmentID: ids.NewV7(), Filename: "annex.pdf"},
 	}
-	got := outboundFiles(staged)
+	d := &Dispatcher{attachments: &stubAttachments{ok: true}}
+	got, err := d.attachedFiles(context.Background(), Delivery{Attachments: staged})
+	if err != nil {
+		t.Fatalf("pairing the snapshot with its bytes failed: %v", err)
+	}
 	if len(got) != len(staged) {
 		t.Fatalf("handed the connector %d files, staged %d — an adapter may never transmit a set that differs from the one it was handed",
 			len(got), len(staged))
@@ -56,7 +61,19 @@ func TestOutboundFilesTravelWholeAndCarryTheirIdentity(t *testing.T) {
 			t.Errorf("the snapshot dropped the %s, so a later change to the document would rewrite what the timeline says was sent", name)
 		}
 	}
-	if outboundFiles(nil) != nil {
+	// The bytes travel too. A snapshot handed over without them is a part with
+	// no content, which is the shape a recipient sees as an empty attachment.
+	for i, file := range got {
+		if len(file.Body) == 0 {
+			t.Errorf("file %d reached the connector with no bytes", i)
+		}
+	}
+
+	empty, err := d.attachedFiles(context.Background(), Delivery{})
+	if err != nil {
+		t.Fatalf("a message with no files failed: %v", err)
+	}
+	if empty != nil {
 		t.Error("an empty staged set became a non-nil file list the adapter has to tell from 'no files'")
 	}
 }

--- a/backend/internal/modules/comms/dispatcher_harness_test.go
+++ b/backend/internal/modules/comms/dispatcher_harness_test.go
@@ -288,11 +288,30 @@ type stubAttachments struct {
 	reason string
 	err    error
 	asked  []ids.UUID
+	// read records what the transmit actually opened, and readErr fails that
+	// read after the gate has passed — the window a scan or an outage lands in.
+	read    []ids.UUID
+	readErr error
 }
 
 func (s *stubAttachments) EnsureTransmittable(_ context.Context, _ ids.UserID, attachmentIDs []ids.UUID) (bool, string, error) {
 	s.asked = append(s.asked, attachmentIDs...)
 	return s.ok, s.reason, s.err
+}
+
+// ReadForSend answers with one body per id, naming the file it came from so a
+// test asserting on what reached the wire can tell them apart. readErr is how a
+// case makes the object store fail after the gate has already passed.
+func (s *stubAttachments) ReadForSend(_ context.Context, _ ids.UserID, attachmentIDs []ids.UUID) ([][]byte, error) {
+	if s.readErr != nil {
+		return nil, s.readErr
+	}
+	s.read = append(s.read, attachmentIDs...)
+	out := make([][]byte, 0, len(attachmentIDs))
+	for _, id := range attachmentIDs {
+		out = append(out, []byte("bytes-of-"+id.String()))
+	}
+	return out, nil
 }
 
 // dispatch runs one attempt and drops the postponement interval, which most

--- a/backend/internal/modules/comms/seams.go
+++ b/backend/internal/modules/comms/seams.go
@@ -137,6 +137,19 @@ type AttachmentAuthority interface {
 	// reading "an attachment cannot be sent" leaves the sender guessing which
 	// of several to fix.
 	EnsureTransmittable(ctx context.Context, userID ids.UserID, attachmentIDs []ids.UUID) (ok bool, reason string, err error)
+
+	// ReadForSend returns the bytes of each attachment, in the order asked.
+	//
+	// Separate from EnsureTransmittable because they answer different
+	// questions at different costs: may this still be sent, and what is in it.
+	// The gate runs first and refuses for free; only a delivery that survives
+	// it pays to read the objects.
+	//
+	// It is called at TRANSMIT, not at staging. A delivery sits on a retry
+	// ladder for as long as the maximum age allows, and holding every
+	// attachment's bytes in the database for that long — duplicated per
+	// delivery — is a cost with no reader.
+	ReadForSend(ctx context.Context, userID ids.UserID, attachmentIDs []ids.UUID) ([][]byte, error)
 }
 
 // ErrNoMailbox marks a user with no connection to the provider a delivery is

--- a/backend/internal/modules/comms/sendseam.go
+++ b/backend/internal/modules/comms/sendseam.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/connector"
 )
 
@@ -102,6 +103,18 @@ func (d *Dispatcher) resolveSeam(ctx context.Context, del Delivery) (sendSeam, e
 		detectsPriorSend:   true,
 		carriesAttachments: carriesAttachments(sender),
 		transmit: func(ctx context.Context) (connector.SendReceipt, error) {
+			// The bytes, read HERE rather than carried in the delivery row: a
+			// message on a retry ladder would otherwise hold every attachment
+			// it might ever send in the database, duplicated per delivery, for
+			// as long as the maximum age allows.
+			//
+			// It is the last thing before the wire and it fails the whole
+			// transmit rather than sending a subset, which is the obligation
+			// the file set below already carries (ADR-0086/A131).
+			files, err := d.attachedFiles(ctx, del)
+			if err != nil {
+				return connector.SendReceipt{}, err
+			}
 			// Every staged field travels: a retry must rebuild an identical
 			// message, and a field dropped here is a header silently missing
 			// from real mail.
@@ -119,7 +132,7 @@ func (d *Dispatcher) resolveSeam(ctx context.Context, del Delivery) (sendSeam, e
 				// files means the connector declared it carries them, so the
 				// adapter's obligation is to transmit ALL of them or fail —
 				// never a subset, never as links (ADR-0086/A131).
-				Files: outboundFiles(del.Attachments),
+				Files: files,
 			})
 		},
 	}, nil
@@ -199,19 +212,47 @@ func carriesAttachments(sender any) bool {
 // snapshot is the record of what was attached and not a copy of the files
 // themselves: keeping megabytes on a delivery row would make every retry
 // re-read them and every audit carry them.
-func outboundFiles(files []OutboundFile) []connector.OutboundFile {
-	if len(files) == 0 {
-		return nil
+// attachedFiles pairs the staged snapshot with the bytes the object store
+// holds, which is what the connector needs to build a part.
+//
+// The snapshot supplies the filename and the content type — what the message
+// SAID it carried at the moment a human sent it — and the store supplies what
+// is actually in the file. Reading the metadata again here instead would let a
+// rename between staging and transmit change the name on a message already
+// approved.
+func (d *Dispatcher) attachedFiles(ctx context.Context, del Delivery) ([]connector.OutboundFile, error) {
+	if len(del.Attachments) == 0 {
+		return nil, nil
 	}
-	out := make([]connector.OutboundFile, 0, len(files))
-	for _, file := range files {
+	if d.attachments == nil {
+		// The integrity gate has already parked a delivery with files and no
+		// authority, so this is unreachable rather than tolerated — and saying
+		// so is better than a nil-deref if that ordering ever changes.
+		return nil, errors.New("comms: no attachment authority is configured on this send path")
+	}
+	attachmentIDs := make([]ids.UUID, 0, len(del.Attachments))
+	for _, file := range del.Attachments {
+		attachmentIDs = append(attachmentIDs, file.AttachmentID)
+	}
+	bodies, err := d.attachments.ReadForSend(ctx, del.UserID, attachmentIDs)
+	if err != nil {
+		return nil, err
+	}
+	if len(bodies) != len(del.Attachments) {
+		return nil, fmt.Errorf(
+			"comms: the store returned %d files for a message carrying %d",
+			len(bodies), len(del.Attachments))
+	}
+	out := make([]connector.OutboundFile, 0, len(del.Attachments))
+	for i, file := range del.Attachments {
 		out = append(out, connector.OutboundFile{
 			AttachmentID: file.AttachmentID.String(),
 			Filename:     file.Filename,
 			ContentType:  file.ContentType,
 			ByteSize:     file.ByteSize,
 			Checksum:     file.Checksum,
+			Body:         bodies[i],
 		})
 	}
-	return out
+	return out, nil
 }

--- a/backend/internal/modules/privacy/deliveries.go
+++ b/backend/internal/modules/privacy/deliveries.go
@@ -77,7 +77,9 @@ const parkedByPrivacyScrub = "content removed by a privacy scrub before this mes
 //
 // What deliberately STAYS is the proof that a message left: sent_at and
 // provider_message_id, plus the threading columns (message identities, like
-// the activity's own thread_key — not the subject's data). from_name stays for
+// the activity's own thread_key — not the subject's data). The attachment
+// SNAPSHOT does not stay: it holds filenames, sizes and checksums, and a
+// filename is routinely the subject's own name. from_name stays for
 // the same reason: it names the workspace member who SENT the message, not the
 // person exercising erasure, and clearing it would destroy send-log evidence
 // while protecting nobody. status stays too
@@ -99,7 +101,8 @@ func redactDeliveries(ctx context.Context, tx pgx.Tx, activityIDs []ids.UUID, to
 	if _, err := tx.Exec(ctx, `
 		UPDATE comms_outbound
 		   SET recipients = '[]'::jsonb, cc = '[]'::jsonb, subject = $2,
-		       body = '', html_body = NULL, list_unsubscribe = NULL,
+		       body = '', html_body = NULL, attachments = '[]'::jsonb,
+		       list_unsubscribe = NULL,
 		       status = CASE WHEN status = 'pending' THEN 'parked' ELSE status END,
 		       reason = CASE WHEN status = 'pending' THEN $3 ELSE NULL END
 		 WHERE activity_id = ANY($1) AND channel_user_id IS NULL`,
@@ -108,7 +111,7 @@ func redactDeliveries(ctx context.Context, tx pgx.Tx, activityIDs []ids.UUID, to
 	}
 	if _, err := tx.Exec(ctx, `
 		UPDATE comms_outbound
-		   SET channel_user_id = '', body = '', html_body = NULL,
+		   SET channel_user_id = '', body = '', html_body = NULL, attachments = '[]'::jsonb,
 		       status = CASE WHEN status = 'pending' THEN 'parked' ELSE status END,
 		       reason = CASE WHEN status = 'pending' THEN $2 ELSE NULL END
 		 WHERE activity_id = ANY($1) AND channel_user_id IS NOT NULL`,

--- a/backend/internal/modules/privacy/sar.go
+++ b/backend/internal/modules/privacy/sar.go
@@ -313,7 +313,13 @@ func sarMessagingSections(pkg *SARPackage) []sarSection {
 		// holds about them. from_name joins them for the same reason: this
 		// projection discloses the message AS THE SUBJECT RECEIVED IT, and who
 		// it appeared to be from is part of what they were shown.
-		{&pkg.SentMessages, `SELECT o.subject, o.body, o.html_body, o.from_name, o.recipients, o.cc, o.consent_purpose,
+		//
+		// attachments too, and it is not covered by the attachment query
+		// below: that one finds files hanging off the subject or an activity
+		// linked to them, while a send may carry any file its sender could see
+		// — one attached to an organization or a deal reaches the subject
+		// without ever being attached TO them.
+		{&pkg.SentMessages, `SELECT o.subject, o.body, o.html_body, o.from_name, o.attachments, o.recipients, o.cc, o.consent_purpose,
 		      o.provider, o.channel_user_id, o.status, o.sent_at, o.created_at
 		   FROM comms_outbound o
 		   WHERE o.activity_id IN (SELECT l.activity_id FROM activity_link l WHERE l.person_id = $1)

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -11971,6 +11971,19 @@ export interface components {
              *     appended to BOTH parts by the server, in each part's own syntax.
              */
             html_body?: string | null;
+            /**
+             * @description Files already in the record library to send with this message, named by id
+             *     — never uploaded here. Each is snapshotted at staging (ADR-0086/A131 §4) so
+             *     archiving or superseding one later cannot rewrite what the timeline says a
+             *     sent message carried.
+             *
+             *     A message is transmitted with ALL its files or not at all. A connector whose
+             *     provider cannot carry them parks the delivery rather than sending the text
+             *     alone, and a file the scanner has since quarantined — or one the sender has
+             *     since lost the right to read — parks it too: a recipient seeing fewer files
+             *     than the record claims is a wrong record nobody is told about.
+             */
+            attachment_ids?: string[];
             to: string[];
             cc?: string[];
             /**
@@ -12004,6 +12017,19 @@ export interface components {
              *     appended to BOTH parts by the server, in each part's own syntax.
              */
             html_body?: string | null;
+            /**
+             * @description Files already in the record library to send with this message, named by id
+             *     — never uploaded here. Each is snapshotted at staging (ADR-0086/A131 §4) so
+             *     archiving or superseding one later cannot rewrite what the timeline says a
+             *     sent message carried.
+             *
+             *     A message is transmitted with ALL its files or not at all. A connector whose
+             *     provider cannot carry them parks the delivery rather than sending the text
+             *     alone, and a file the scanner has since quarantined — or one the sender has
+             *     since lost the right to read — parks it too: a recipient seeing fewer files
+             *     than the record claims is a wrong record nobody is told about.
+             */
+            attachment_ids?: string[];
             /**
              * @description At least one addressee. A send whose To: line is empty is refused 422 before
              *     anything is staged — `cc` alone does not make a message addressed to anyone.


### PR DESCRIPTION
Closes #1204.

## The gap

The plumbing existed for months and nothing could reach it: `OutboundFile`, the
ADR-0086 snapshot semantics, the dispatcher's carriage and integrity gates were
all built — and **no send request had an attachment field**.

## Six things were missing

Five the roadmap review named, and one only running it found.

- `attachment_ids` on both send requests, through `SendEmailInput` and
  `DeliveryRequest`.
- **Resolution to a snapshot** under the sender's own read gate, so a rep cannot
  attach a document by guessing an id, and superseding it tomorrow cannot rewrite
  what the timeline says a message sent today carried.
- **Bytes read at TRANSMIT**, not staging. A message on a retry ladder would
  otherwise hold every file it might send in the database, duplicated per
  delivery, for the whole maximum age. `OpenAttachment` carries the scan gate too,
  so a file quarantined *between* the gate and the read still cannot be sent.
- **`multipart/mixed` wrapping the alternative**, message part FIRST — a client
  shows the first part as the body, so files before it would open the message on
  an attachment. Files are base64, unlike the 8bit text parts: a PDF contains the
  line endings and boundary-looking sequences a text part may assume it has none of.
- **`CarriesAttachments()` on the Gmail connector.** Without it the carriage gate
  parks every send with a file — correctly, since a message transmitted without
  its attachments is a record nobody is told is wrong.
- **The send worker had no object store wired.** The read failed with "no object
  store configured" after every gate had passed. Only sending one found this.

## What the review then caught

**No bound on what one message carries.** 25 MiB per upload × unbounded array =
a quarter gigabyte in the worker, doubled by encoding. Now 10 files, 20 MiB
total — below what providers accept, so a message that passes is one the wire
will take.

**The privacy scrub left the attachment snapshot** — filenames, sizes, checksums
— on a delivery whose body it had just cleared. A filename is routinely the
subject's own name.

**The SAR export omitted it**, and the attachment query beside it does not cover
the case: a send may carry any file its sender could see, so a document attached
to an *organization* reaches the subject without ever being attached to them.

**Filenames used RFC 2047 where MIME wants RFC 2231.** An encoded word is for
header text; in a parameter it arrives literally. `mime.FormatMediaType` also
quotes a name containing a quote, which previously truncated it.

## Verified on a live stack, three states

1. Unscanned file → **parks**, with a reason naming the file (the dev env has no
   scanner — the gate working).
2. Marked clean → reaches the transmit.
3. Worker's object store wired → delivery reads **`sent`**, carrying one attachment.

MIME tests assert against a real parser and decode the base64 as a client would.
Mutation-checked: files before the message part fails the ordering test by name.
Privacy integration lane green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable end‑to‑end email attachments: the API accepts `attachment_ids`, we snapshot metadata at staging, and the Gmail connector transmits files as RFC822 multipart/mixed with the message part first. Previously, sends had no attachment field and files never reached the wire; now sends include files or park rather than going out incomplete.

- API: add `attachment_ids` to `SendEmailRequest` and `SendAccountEmailRequest` (max 10). The store resolves each id to a snapshot under the sender’s read gate.
- Sending: the dispatcher reads bytes at transmit via `AttachmentAuthority.ReadForSend`, enforces a 20 MiB total cap, and never sends a subset. Deliveries park if the connector cannot carry files or a file becomes unreadable/quarantined.
- Gmail: declares `CarriesAttachments()` and builds RFC822 in `rfc822.go` (multipart/mixed wrapping multipart/alternative, base64 file bodies, RFC 2231 filenames).
- Privacy/SAR: the scrub clears `attachments`; SAR includes `attachments` for sent messages.

**Rollout**

- Configure `JobRunnerConfig.SendBlob` with the same object store capture uses; without it, attachment sends fail at read.
- Client apps may pass `attachment_ids` when composing; do not upload via send APIs and respect the 10‑file limit.
- Custom connectors must implement the attachment capability; otherwise, deliveries with files will park.

<sup>Written for commit 10907b82d1908ce2aedaee938006b6c110da8760. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1232?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for attaching up to 10 existing files to outgoing CRM messages and emails.
  * Gmail delivery now sends attached files with proper MIME formatting, filenames, and content encoding.
  * Attachments are validated and captured when staged, then loaded immediately before sending.
* **Bug Fixes**
  * Prevented partial sends when attachments are unavailable, unauthorized, quarantined, or exceed size limits.
* **Privacy**
  * Included attachment details in data exports and removed them during delivery-data scrubbing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->