### PR TITLE
docs(status): the fleet collapse has a decided shape — ADR-0103 / A154

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -700,15 +700,38 @@ workspace GUC; the agent scheduler's suite injects its fault through a trigger
 keyed on `NEW.workspace_id`. Privacy's retention sweep and search's re-embed
 fan-out are the same shape. Their tables go with the fleet loops (§5).
 
-**Read this before starting that collapse — it is bigger than it looks.**
-`api/jobs.yaml` declares 62 jobs and every one is either `role: dispatcher`
-(27) or `role: workspace` (35). There is no third role, so collapsing the
-fan-out is not four edits: it is a change to the job vocabulary itself, plus
-the generator that turns those declarations into `platform/jobs/specs_gen.go`,
-plus the census and kind gates that hold the two in agreement, plus ~85 call
-sites of `dispatchPerWorkspace` / `FleetWide()` / `WorkspaceID()`. The first
-decision is what a collapsed job's role IS — and since `api/jobs.yaml` is a
-declared surface, that decision may belong upstream (P3) before any code moves.
+**The target shape is decided upstream — build against it, do not re-derive
+it.** ADR-0103 / DECISIONS **A154** (margince-foundation, PROPOSED 2026-08-14,
+awaiting founder ratification) settles what ADR-0091 §5 left open. The short
+form, because the distinction is what makes the work tractable:
+
+- **A pass over the installation is ONE job.** The 23 dispatchers that fan out
+  over `workspace` merge with the child they exist to enqueue. The survivor
+  takes the dispatcher's KIND and CADENCE and the child's QUEUE, TIMEOUT, RETRY
+  and registration condition. Getting that split backwards is the one way this
+  breaks production quietly: the long passes sit off the default queue for
+  reasons about DURATION, not tenancy.
+- **A fan-out over a real work unit STAYS.** Four dispatchers enumerate a
+  connector `connection` (3) or a voice `build` (1), and an installation has
+  many of those. They keep their per-unit failure isolation — one hung mailbox
+  must not delay the next.
+- `role` becomes `dispatcher` + `worker`; `role: workspace` retires; `Workspace`
+  leaves all 35 argument lists (13 of which already carry the real subject).
+
+Cost, so nobody is surprised: 23 job kinds disappear from the job table, the
+health screen and the per-kind metrics, and a release note owes operators that
+list. A failed pass reports once rather than twice.
+
+The work is still not four edits — the vocabulary change reaches the generator
+behind `platform/jobs/specs_gen.go`, the census and kind gates that hold the two
+in agreement, and ~85 call sites of `dispatchPerWorkspace` / `FleetWide()` /
+`WorkspaceID()` — but the design question is answered, and the columns for
+webhooks, agents, privacy and search move with the loop that held them.
+
+A154 also swept two contract schemas ADR-0091 §6 missed: `EmbedReindexStatus`
+and `EmbedReindexPreview` lose their `per_workspace` arrays. This repo had
+already made that change, which under P3 it should not have done first; the
+spec has reconciled it, and `utilization_impact` stays hoisted.
 
 One table has already been renamed as well as narrowed: `workspace_signing_key`
 is `signing_key` (#1171). ADR-0091 §1 asks for it, and the reason is worth

--- a/STATUS.md
+++ b/STATUS.md
@@ -701,9 +701,17 @@ keyed on `NEW.workspace_id`. Privacy's retention sweep and search's re-embed
 fan-out are the same shape. Their tables go with the fleet loops (§5).
 
 **The target shape is decided upstream — build against it, do not re-derive
-it.** ADR-0103 / DECISIONS **A154** (margince-foundation, PROPOSED 2026-08-14,
-awaiting founder ratification) settles what ADR-0091 §5 left open. The short
-form, because the distinction is what makes the work tractable:
+it.** ADR-0103 / DECISIONS **A154** (margince-foundation, PROPOSED 2026-08-14)
+settles what ADR-0091 §5 left open.
+
+**It is PROPOSED, not ratified, and that does not gate the work.** Proposals
+land on the spec's `main` and the build works from them; what ratification
+changes is the record, not the permission. If the founder moves the shape, the
+move lands upstream as an amendment first and the build follows it — the one
+thing that must not happen is the build improvising a different answer and
+leaving two shapes in the tree.
+
+The short form, because the distinction is what makes the work tractable:
 
 - **A pass over the installation is ONE job.** The 23 dispatchers that fan out
   over `workspace` merge with the child they exist to enqueue. The survivor


### PR DESCRIPTION
The pickup note said the collapse's design question might belong upstream. It did, it went (margince-foundation#1293), and it is answered — **ADR-0103 / DECISIONS A154**, PROPOSED, awaiting founder ratification.

What the next session needs from it is written here rather than left to a click-through:

- **A pass over the installation is one job.** The 23 dispatchers that fan out over `workspace` merge with the child they exist to enqueue; the survivor takes the dispatcher's **kind and cadence** and the child's **queue, timeout, retry**. Backwards is the one way this breaks production quietly — the long passes sit off the default queue for reasons about *duration*, not tenancy.
- **A fan-out over a real work unit stays.** Four dispatchers enumerate a connector `connection` or a voice `build`; an installation has many of those, and they keep the per-unit failure isolation that stops one hung mailbox delaying the next.
- `role: workspace` retires; `Workspace` leaves all 35 argument lists.

Cost recorded so nobody is surprised: 23 job kinds disappear from the job table, the health screen and the per-kind metrics, and a release note owes operators that list.

Also notes that A154 swept two contract schemas ADR-0091 §6 missed (`EmbedReindexStatus` / `EmbedReindexPreview`) — a change **this repo made first**, which under P3 it should not have; the spec has now reconciled it.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents the upstream-approved shape for collapsing fleet fan-outs (ADR-0103 / A154) and clarifies that its PROPOSED status does not block implementation. Old: 23 `workspace` fan-out dispatchers and a `workspace` role. New: one installation-wide job per pass, fan-out only for real units, and a split vocabulary (`dispatcher` + `worker`).

- Merge each `workspace` dispatcher into its child worker; the survivor takes the dispatcher's kind/cadence and the child's queue/timeout/retry/registration. Keep long passes off the default queue.
- Keep fan-out only for real units (connector `connection`, voice `build`) to preserve per-unit failure isolation.
- Replace `role` with `dispatcher` + `worker`; retire `role: workspace`. Remove `Workspace` from 35 job arg lists.
- Operator impact: 23 job kinds disappear from the job table/health/per-kind metrics; a failed pass reports once, not twice. Include the removed kinds in release notes.
- Implementation scope: update `api/jobs.yaml`, the generator behind `platform/jobs/specs_gen.go`, census/kind gates, and ~85 call sites of `dispatchPerWorkspace`/`FleetWide()`/`WorkspaceID()`.
- Contract alignment: drop `per_workspace` arrays from `EmbedReindexStatus` and `EmbedReindexPreview`; `utilization_impact` stays hoisted.
- Process note: build against ADR-0103 / A154 while PROPOSED; ratification updates the record only. If the shape moves, it amends upstream first—do not re-derive a different shape locally.

<sup>Written for commit ebaf1bbb468816a4306eec6f5173520d32780b1f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1237?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Installation-wide processing now runs as a single job.
  * Connector and voice-build fan-outs continue as separate work-unit jobs.
  * Job responsibilities are now clearly separated into dispatcher and worker roles.

* **Improvements**
  * Metrics, health reporting, generation workflows, and validation checks now reflect the streamlined job model.
  * Removed obsolete job types and updated the documented job vocabulary for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->