### PR TITLE
feat(email): a send can carry blind copies

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -16865,6 +16865,20 @@ components:
             than the record claims is a wrong record nobody is told about.
         to: { type: array, items: { type: string, format: email } }
         cc: { type: array, items: { type: string, format: email } }
+        bcc:
+          type: array
+          items: { type: string, format: email }
+          description: |
+            Blind copies. They receive the message and are therefore owed consent
+            exactly as To and Cc are — the gate answers on every addressee, however
+            they were addressed — and they are absent from the headers the recipients
+            see, which is the whole of what "blind" means.
+
+            A message with a tokenized unsubscribe link may still have only ONE
+            addressee in total: that token is a bearer credential over one person's
+            consent record, so a bcc'd copy of a marketing send is refused 422
+            `shared_unsubscribe_token` rather than handing a stranger somebody else's
+            preference link.
         draft_ref:
           type: [string, 'null']
           description: |
@@ -16920,6 +16934,20 @@ components:
             anything is staged — `cc` alone does not make a message addressed to anyone.
           items: { type: string, format: email }
         cc: { type: array, items: { type: string, format: email } }
+        bcc:
+          type: array
+          items: { type: string, format: email }
+          description: |
+            Blind copies. They receive the message and are therefore owed consent
+            exactly as To and Cc are — the gate answers on every addressee, however
+            they were addressed — and they are absent from the headers the recipients
+            see, which is the whole of what "blind" means.
+
+            A message with a tokenized unsubscribe link may still have only ONE
+            addressee in total: that token is a bearer credential over one person's
+            consent record, so a bcc'd copy of a marketing send is refused 422
+            `shared_unsubscribe_token` rather than handing a stranger somebody else's
+            preference link.
         draft_ref:
           type: [string, 'null']
           description: |

--- a/backend/internal/compose/commsjobs.go
+++ b/backend/internal/compose/commsjobs.go
@@ -345,6 +345,7 @@ func (s commsStager) StageTx(ctx context.Context, tx pgx.Tx, in activities.Deliv
 		MessageID:       in.MessageID,
 		Recipients:      in.Recipients,
 		Cc:              in.Cc,
+		Bcc:             in.Bcc,
 		Subject:         in.Subject,
 		Body:            in.Body,
 		HTMLBody:        in.HTMLBody,

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -17562,6 +17562,18 @@ type SendAccountEmailRequest struct {
 	// than the record claims is a wrong record nobody is told about.
 	AttachmentIds *[]openapi_types.UUID `json:"attachment_ids,omitempty"`
 
+	// Bcc Blind copies. They receive the message and are therefore owed consent
+	// exactly as To and Cc are — the gate answers on every addressee, however
+	// they were addressed — and they are absent from the headers the recipients
+	// see, which is the whole of what "blind" means.
+	//
+	// A message with a tokenized unsubscribe link may still have only ONE
+	// addressee in total: that token is a bearer credential over one person's
+	// consent record, so a bcc'd copy of a marketing send is refused 422
+	// `shared_unsubscribe_token` rather than handing a stranger somebody else's
+	// preference link.
+	Bcc *[]openapi_types.Email `json:"bcc,omitempty"`
+
 	// Body The (possibly edited) final body that is sent.
 	Body string                 `json:"body"`
 	Cc   *[]openapi_types.Email `json:"cc,omitempty"`
@@ -17609,6 +17621,18 @@ type SendEmailRequest struct {
 	// since lost the right to read — parks it too: a recipient seeing fewer files
 	// than the record claims is a wrong record nobody is told about.
 	AttachmentIds *[]openapi_types.UUID `json:"attachment_ids,omitempty"`
+
+	// Bcc Blind copies. They receive the message and are therefore owed consent
+	// exactly as To and Cc are — the gate answers on every addressee, however
+	// they were addressed — and they are absent from the headers the recipients
+	// see, which is the whole of what "blind" means.
+	//
+	// A message with a tokenized unsubscribe link may still have only ONE
+	// addressee in total: that token is a bearer credential over one person's
+	// consent record, so a bcc'd copy of a marketing send is refused 422
+	// `shared_unsubscribe_token` rather than handing a stranger somebody else's
+	// preference link.
+	Bcc *[]openapi_types.Email `json:"bcc,omitempty"`
 
 	// Body The (possibly edited) final body that is sent.
 	Body string                 `json:"body"`

--- a/backend/internal/modules/activities/email.go
+++ b/backend/internal/modules/activities/email.go
@@ -60,15 +60,19 @@ var errNoDeliveryStager = errors.New("activities: send path has no delivery mach
 // SendEmailInput is one consented outbound send anchored to an
 // existing activity (the thread being replied to).
 type SendEmailInput struct {
-	// Recipients is the MERGED addressee list — every To AND Cc address —
+	// Recipients is the MERGED addressee list — every To, Cc AND Bcc address —
 	// because consent is owed to everyone who receives the message, however
-	// they were addressed. Cc below is a SUBSET of it, by design and not by
-	// accident: the delivery's To: line is what remains once the Cc
-	// addresses come out.
+	// they were addressed. Cc and Bcc below are SUBSETS of it, by design and
+	// not by accident: the delivery's To: line is what remains once both come
+	// out.
 	Recipients []string
 	Cc         []string
-	Subject    string
-	Body       string
+	// Bcc receives the message and appears in no header the other recipients
+	// see. It is in Recipients like every other addressee — a blind copy is
+	// blind to the RECIPIENTS, never to the consent gate.
+	Bcc     []string
+	Subject string
+	Body    string
 	// HTMLBody is the same message as markup, empty for a plain-text send.
 	// It never replaces Body: both travel, and the wire renders them as
 	// multipart/alternative so a client that cannot show markup still receives
@@ -109,11 +113,14 @@ type DeliveryRequest struct {
 	ActivityID ids.ActivityID
 	Provider   string
 	MessageID  string
-	Recipients []string // To: only — the merged consent list minus Cc
+	Recipients []string // To: only — the merged consent list minus Cc and Bcc
 	Cc         []string
-	Subject    string
-	Body       string // the unsubscribe footer, when there is one, is already applied
-	HTMLBody   string // the markup alternative, empty for a plain-text send
+	// Bcc is transmitted to but never rendered into a header the recipients
+	// read. The connector addresses it; the message does not name it.
+	Bcc      []string
+	Subject  string
+	Body     string // the unsubscribe footer, when there is one, is already applied
+	HTMLBody string // the markup alternative, empty for a plain-text send
 	// FromName is the sender's display name, snapshotted so a retry renders the
 	// same From header the first attempt did.
 	FromName string
@@ -165,7 +172,12 @@ func (s *Store) refuseUnsendable(ctx context.Context, in SendEmailInput, gate Co
 	// that named nobody at all. A FieldFault pointing at `to` is the difference
 	// between a caller who can fix their argument and one who goes looking for
 	// a consent record that was never the problem.
-	if len(toRecipients(in.Recipients, in.Cc)) == 0 {
+	//
+	// It asks whether anyone is ADDRESSED, not whether the To line has
+	// somebody on it: a message sent only to blind copies has an empty To line
+	// and real recipients, and refusing it would refuse the ordinary way to
+	// mail a group without disclosing the group.
+	if len(in.Recipients) == 0 {
 		return &NoRecipientsError{}
 	}
 	// The composition guards report a deployment defect, and a caller who may
@@ -281,7 +293,7 @@ func (s *Store) SendEmail(ctx context.Context, origin SendOrigin, in SendEmailIn
 		htmlBody:        htmlBody,
 		files:           files,
 		listUnsubscribe: derived.listUnsubscribe,
-		to:              toRecipients(in.Recipients, in.Cc),
+		to:              toRecipients(in.Recipients, in.Cc, in.Bcc),
 		links:           links,
 	}
 
@@ -344,12 +356,18 @@ func (s *Store) messageIDDomain() string {
 // (consent is owed to every addressee), so rendering it as To: would copy
 // every cc'd person twice. Addresses are matched case- and space-
 // insensitively, the way a mail server treats them.
-func toRecipients(recipients, cc []string) []string {
-	if len(cc) == 0 {
+func toRecipients(recipients, cc, bcc []string) []string {
+	if len(cc) == 0 && len(bcc) == 0 {
 		return recipients
 	}
-	copied := make(map[string]bool, len(cc))
+	// Both come out. A bcc address left in the To line is not a blind copy at
+	// all — it is the failure the feature exists to prevent, and it is visible
+	// to every other recipient the moment the message arrives.
+	copied := make(map[string]bool, len(cc)+len(bcc))
 	for _, addr := range cc {
+		copied[normalizeAddress(addr)] = true
+	}
+	for _, addr := range bcc {
 		copied[normalizeAddress(addr)] = true
 	}
 	to := make([]string, 0, len(recipients))

--- a/backend/internal/modules/activities/email.go
+++ b/backend/internal/modules/activities/email.go
@@ -173,11 +173,14 @@ func (s *Store) refuseUnsendable(ctx context.Context, in SendEmailInput, gate Co
 	// between a caller who can fix their argument and one who goes looking for
 	// a consent record that was never the problem.
 	//
-	// It asks whether anyone is ADDRESSED, not whether the To line has
-	// somebody on it: a message sent only to blind copies has an empty To line
-	// and real recipients, and refusing it would refuse the ordinary way to
-	// mail a group without disclosing the group.
-	if len(in.Recipients) == 0 {
+	// The check is on the VISIBLE addressee line, which is the contract's own
+	// rule: `to` carries minItems 1, and "cc alone does not make a message
+	// addressed to anyone" (crm.yaml). A bcc-only send is therefore not a
+	// shape this product offers — a blind copy accompanies a message that is
+	// addressed to somebody, rather than replacing the addressee — and
+	// loosening this in Go while the contract still refuses it would make the
+	// two disagree about what a valid send is.
+	if len(toRecipients(in.Recipients, in.Cc, in.Bcc)) == 0 {
 		return &NoRecipientsError{}
 	}
 	// The composition guards report a deployment defect, and a caller who may

--- a/backend/internal/modules/activities/email_test.go
+++ b/backend/internal/modules/activities/email_test.go
@@ -115,17 +115,46 @@ func TestMintMessageIDIsUnbracketedAndFreshPerMessage(t *testing.T) {
 	}
 }
 
-// Recipients is the MERGED consent list (to + cc) by design, so the delivery's
-// To: is what remains once the Cc: addresses come out — rendering the merged
-// list as To: would copy every cc'd person twice and expose the cc list as
-// primary recipients.
+// Recipients is the MERGED consent list (to + cc + bcc) by design, so the
+// delivery's To: is what remains once the Cc: and Bcc: addresses come out —
+// rendering the merged list as To: would copy every cc'd person twice and
+// expose both lists as primary recipients.
 func TestDeliveryToRecipientsExcludeTheCcAddresses(t *testing.T) {
 	to := toRecipients(
 		[]string{"buyer@example.test", "boss@example.test", "Watcher@Example.test"},
 		[]string{"boss@example.test", "watcher@example.test "},
+		nil,
 	)
 	if len(to) != 1 || to[0] != "buyer@example.test" {
 		t.Fatalf("To: = %v, want only the non-cc'd recipient (case and padding are not a different address)", to)
+	}
+}
+
+// A bcc'd address in the To: line is not a blind copy at all — every other
+// recipient reads it the moment the message arrives, which is the single
+// failure this feature exists to prevent.
+func TestDeliveryToRecipientsExcludeTheBccAddresses(t *testing.T) {
+	to := toRecipients(
+		[]string{"buyer@example.test", "quiet@example.test", "Watcher@Example.test"},
+		[]string{"watcher@example.test"},
+		[]string{"Quiet@Example.test "},
+	)
+	if len(to) != 1 || to[0] != "buyer@example.test" {
+		t.Fatalf("To: = %v — a blind copy reached the visible addressee line", to)
+	}
+}
+
+// A message addressed ONLY to blind copies has an empty To: line and real
+// recipients. It is the ordinary way to mail a group without disclosing the
+// group, and refusing it for having no To: would refuse the feature.
+func TestABccOnlySendHasNoVisibleAddressee(t *testing.T) {
+	to := toRecipients(
+		[]string{"one@example.test", "two@example.test"},
+		nil,
+		[]string{"one@example.test", "two@example.test"},
+	)
+	if len(to) != 0 {
+		t.Fatalf("To: = %v, want nobody visible on a bcc-only send", to)
 	}
 }
 

--- a/backend/internal/modules/activities/email_test.go
+++ b/backend/internal/modules/activities/email_test.go
@@ -144,9 +144,11 @@ func TestDeliveryToRecipientsExcludeTheBccAddresses(t *testing.T) {
 	}
 }
 
-// A message addressed ONLY to blind copies has an empty To: line and real
-// recipients. It is the ordinary way to mail a group without disclosing the
-// group, and refusing it for having no To: would refuse the feature.
+// A blind copy accompanies an addressed message rather than replacing its
+// addressee: the contract carries minItems 1 on `to`, so a send whose every
+// recipient is blind is refused at the API before it reaches here. What this
+// pins is the derivation — the To line is empty when every address is blind,
+// which is what makes refuseUnsendable's check catch that shape.
 func TestABccOnlySendHasNoVisibleAddressee(t *testing.T) {
 	to := toRecipients(
 		[]string{"one@example.test", "two@example.test"},

--- a/backend/internal/modules/activities/handlers_email.go
+++ b/backend/internal/modules/activities/handlers_email.go
@@ -257,7 +257,7 @@ func (h Handlers) SendAccountEmail(w http.ResponseWriter, r *http.Request, _ crm
 	}
 
 	sent, err := h.store.SendEmail(r.Context(), FromAccount(links), sendInputFrom(
-		req.To, req.Cc, req.Subject, req.Body, req.HtmlBody, req.AttachmentIds,
+		req.To, req.Cc, req.Bcc, req.Subject, req.Body, req.HtmlBody, req.AttachmentIds,
 		req.ConsentPurpose, req.DraftRef,
 	), h.consent, h.delivery)
 	if err != nil {
@@ -272,7 +272,7 @@ func (h Handlers) SendAccountEmail(w http.ResponseWriter, r *http.Request, _ crm
 // a convenience: consent is owed to every addressee, so Recipients is To+Cc
 // and Cc is a subset of it. A second hand-rolled copy would eventually merge
 // one of them differently and mail somebody the gate never asked about.
-func sendInputFrom(to []openapi_types.Email, cc *[]openapi_types.Email, subject, body string, htmlBody *string, attachments *[]openapi_types.UUID, purpose string, draftRef *string) SendEmailInput {
+func sendInputFrom(to []openapi_types.Email, cc, bcc *[]openapi_types.Email, subject, body string, htmlBody *string, attachments *[]openapi_types.UUID, purpose string, draftRef *string) SendEmailInput {
 	var ccAddresses []string
 	if cc != nil {
 		ccAddresses = make([]string, 0, len(*cc))
@@ -284,7 +284,12 @@ func sendInputFrom(to []openapi_types.Email, cc *[]openapi_types.Email, subject,
 	for _, addr := range to {
 		recipients = append(recipients, string(addr))
 	}
+	bccAddresses := addressesOf(bcc)
+	// Every addressee joins the merged list. A blind copy is blind to the
+	// RECIPIENTS and never to the consent gate: they receive the message, so
+	// consent is owed to them exactly as it is to a To or a Cc.
 	recipients = append(recipients, ccAddresses...)
+	recipients = append(recipients, bccAddresses...)
 
 	ref := ""
 	if draftRef != nil {
@@ -304,6 +309,7 @@ func sendInputFrom(to []openapi_types.Email, cc *[]openapi_types.Email, subject,
 	return SendEmailInput{
 		Recipients:     recipients,
 		Cc:             ccAddresses,
+		Bcc:            bccAddresses,
 		Subject:        subject,
 		Body:           body,
 		HTMLBody:       html,
@@ -326,7 +332,7 @@ func (h Handlers) SendEmail(w http.ResponseWriter, r *http.Request, id crmcontra
 	// it too. It belongs on the mail, not on this response to the API
 	// caller, who is not the recipient and has nothing to unsubscribe from.
 	sent, err := h.store.SendEmail(r.Context(), FromActivity(pathID[ids.ActivityKind](id)), sendInputFrom(
-		req.To, req.Cc, req.Subject, req.Body, req.HtmlBody, req.AttachmentIds,
+		req.To, req.Cc, req.Bcc, req.Subject, req.Body, req.HtmlBody, req.AttachmentIds,
 		req.ConsentPurpose, req.DraftRef,
 	), h.consent, h.delivery)
 	if err != nil {
@@ -335,4 +341,16 @@ func (h Handlers) SendEmail(w http.ResponseWriter, r *http.Request, id crmcontra
 	}
 	// 202: accepted for delivery, the activity is the durable fact.
 	httperr.WriteJSON(w, http.StatusAccepted, sent)
+}
+
+// addressesOf flattens an optional address list, which both cc and bcc are.
+func addressesOf(list *[]openapi_types.Email) []string {
+	if list == nil {
+		return nil
+	}
+	out := make([]string, 0, len(*list))
+	for _, addr := range *list {
+		out = append(out, string(addr))
+	}
+	return out
 }

--- a/backend/internal/modules/activities/handlers_email_test.go
+++ b/backend/internal/modules/activities/handlers_email_test.go
@@ -10,6 +10,7 @@ package activities
 // was never asked about.
 
 import (
+	"slices"
 	"testing"
 
 	openapi_types "github.com/oapi-codegen/runtime/types"
@@ -25,7 +26,7 @@ func emails(addresses ...string) []openapi_types.Email {
 
 func TestSendInputMergesEveryAddresseeForTheConsentGate(t *testing.T) {
 	cc := emails("boss@example.test")
-	in := sendInputFrom(emails("buyer@example.test"), &cc, "Pricing", "As discussed.", nil, nil, "transactional", nil)
+	in := sendInputFrom(emails("buyer@example.test"), &cc, nil, "Pricing", "As discussed.", nil, nil, "transactional", nil)
 
 	// The gate answers on Recipients, so a cc'd person must appear there or
 	// they receive mail nobody asked consent for.
@@ -42,13 +43,13 @@ func TestSendInputMergesEveryAddresseeForTheConsentGate(t *testing.T) {
 		t.Fatalf("Cc = %v, want the cc list travelling separately so the delivery can render two lines", in.Cc)
 	}
 	// The To: line is what remains once the Cc addresses come out.
-	if to := toRecipients(in.Recipients, in.Cc); len(to) != 1 || to[0] != "buyer@example.test" {
+	if to := toRecipients(in.Recipients, in.Cc, in.Bcc); len(to) != 1 || to[0] != "buyer@example.test" {
 		t.Fatalf("To: = %v, want the merged list minus the cc'd address", to)
 	}
 }
 
 func TestSendInputWithoutCcCarriesOnlyTheAddressees(t *testing.T) {
-	in := sendInputFrom(emails("buyer@example.test"), nil, "Pricing", "As discussed.", nil, nil, "transactional", nil)
+	in := sendInputFrom(emails("buyer@example.test"), nil, nil, "Pricing", "As discussed.", nil, nil, "transactional", nil)
 
 	if len(in.Recipients) != 1 || in.Recipients[0] != "buyer@example.test" {
 		t.Fatalf("Recipients = %v, want just the one addressee", in.Recipients)
@@ -62,14 +63,41 @@ func TestSendInputWithoutCcCarriesOnlyTheAddressees(t *testing.T) {
 // composed without a served draft resolves no learning signal, which the
 // empty string is how the send path is told.
 func TestSendInputResolvesNoDraftWhenNoneWasServed(t *testing.T) {
-	in := sendInputFrom(emails("buyer@example.test"), nil, "Pricing", "Body", nil, nil, "transactional", nil)
+	in := sendInputFrom(emails("buyer@example.test"), nil, nil, "Pricing", "Body", nil, nil, "transactional", nil)
 	if in.DraftRef != "" {
 		t.Fatalf("DraftRef = %q, want empty so no voice outcome is inferred", in.DraftRef)
 	}
 
 	ref := "draft-42"
-	withDraft := sendInputFrom(emails("buyer@example.test"), nil, "Pricing", "Body", nil, nil, "transactional", &ref)
+	withDraft := sendInputFrom(emails("buyer@example.test"), nil, nil, "Pricing", "Body", nil, nil, "transactional", &ref)
 	if withDraft.DraftRef != ref {
 		t.Fatalf("DraftRef = %q, want %q — the send closes the signal that draft opened", withDraft.DraftRef, ref)
+	}
+}
+
+// A blind copy is blind to the RECIPIENTS and never to the consent gate. The
+// gate answers on Recipients, so a bcc'd address missing from that list is a
+// person who receives mail nobody asked consent for — which is the same defect
+// as an unconsented To, with the added property that nobody can see it happened.
+func TestSendInputMergesBlindCopiesForTheConsentGate(t *testing.T) {
+	cc := emails("boss@example.test")
+	bcc := emails("archive@example.test", "Quiet@Example.test")
+	in := sendInputFrom(emails("buyer@example.test"), &cc, &bcc,
+		"Pricing", "As discussed.", nil, nil, "transactional", nil)
+
+	want := []string{
+		"buyer@example.test", "boss@example.test",
+		"archive@example.test", "Quiet@Example.test",
+	}
+	if len(in.Recipients) != len(want) {
+		t.Fatalf("Recipients = %v, want every addressee including the blind ones", in.Recipients)
+	}
+	for _, addr := range want {
+		if !slices.Contains(in.Recipients, addr) {
+			t.Errorf("%q receives the message and never reaches the consent gate", addr)
+		}
+	}
+	if len(in.Bcc) != 2 {
+		t.Fatalf("Bcc = %v, want the blind list kept apart so the wire can omit it", in.Bcc)
 	}
 }

--- a/backend/internal/modules/activities/outboundmessage.go
+++ b/backend/internal/modules/activities/outboundmessage.go
@@ -97,6 +97,7 @@ func (m outboundMessage) delivery(activityID ids.UUID, chain threading) Delivery
 		MessageID:       m.messageID,
 		Recipients:      m.to,
 		Cc:              m.in.Cc,
+		Bcc:             m.in.Bcc,
 		Subject:         m.in.Subject,
 		Body:            m.body,
 		HTMLBody:        m.htmlBody,

--- a/backend/internal/modules/capture/gmail/multipart_test.go
+++ b/backend/internal/modules/capture/gmail/multipart_test.go
@@ -457,3 +457,47 @@ func TestAFilenameWithAQuoteStaysOneParameter(t *testing.T) {
 		t.Fatalf("a client would see the filename as %q", got)
 	}
 }
+
+// A bcc'd address must never appear in a header the recipients read. This is
+// the whole of what "blind" means, and the To line is where it would leak.
+func TestABlindCopyIsAbsentFromTheVisibleHeaders(t *testing.T) {
+	msg := plainMessage()
+	msg.To = []string{"visible@surfe.test"}
+	msg.Bcc = []string{"blind@surfe.test"}
+
+	parsed := parseMail(t, buildRFC822("rep@gradion.test", msg))
+	for _, header := range []string{"To", "Cc"} {
+		if strings.Contains(parsed.Header.Get(header), "blind@surfe.test") {
+			t.Fatalf("a blind copy reached the %s header: %q", header, parsed.Header.Get(header))
+		}
+	}
+	// The Bcc header itself IS written: messages.send takes the raw message
+	// and no envelope list, so it is the only way to address a blind copy —
+	// and the submission agent strips it before delivery (RFC 5322 §3.6.3).
+	if !strings.Contains(parsed.Header.Get("Bcc"), "blind@surfe.test") {
+		t.Fatal("the blind copy was not addressed at all")
+	}
+}
+
+// A bare "To:" is a malformed header some relays refuse, so an empty visible
+// addressee line is omitted rather than written.
+//
+// The send path refuses a message with no visible addressee before it reaches
+// this renderer, so this is a defence in depth rather than a shape the product
+// produces: a renderer that emits a header it was handed nothing for is one
+// defect away from putting a malformed message on the wire.
+func TestABccOnlyMessageOmitsTheToHeaderEntirely(t *testing.T) {
+	msg := plainMessage()
+	msg.To = nil
+	msg.Bcc = []string{"one@surfe.test", "two@surfe.test"}
+
+	raw := buildRFC822("rep@gradion.test", msg)
+	for _, line := range strings.Split(raw, "\r\n") {
+		if strings.HasPrefix(line, "To:") {
+			t.Fatalf("an empty To header was written: %q", line)
+		}
+	}
+	if !strings.Contains(raw, "Bcc: one@surfe.test, two@surfe.test") {
+		t.Fatalf("the blind copies were not addressed:\n%s", raw)
+	}
+}

--- a/backend/internal/modules/capture/gmail/rfc822.go
+++ b/backend/internal/modules/capture/gmail/rfc822.go
@@ -29,7 +29,14 @@ import (
 func buildRFC822(from string, msg connector.EmailMessage) string {
 	var b strings.Builder
 	writeHeader(&b, "From", fromHeader(from, msg.FromName))
-	writeHeader(&b, "To", addressList(msg.To))
+	// An empty To line is omitted rather than written bare. A message sent
+	// only to blind copies has no visible addressee — that is what it IS — and
+	// "To:" with nothing after it is a malformed header some relays refuse,
+	// where an absent one is ordinary (RFC 5322 requires an originator, not a
+	// destination).
+	if to := addressList(msg.To); to != "" {
+		writeHeader(&b, "To", to)
+	}
 	if cc := addressList(msg.Cc); cc != "" {
 		writeHeader(&b, "Cc", cc)
 	}

--- a/backend/internal/modules/capture/gmail/rfc822.go
+++ b/backend/internal/modules/capture/gmail/rfc822.go
@@ -33,6 +33,21 @@ func buildRFC822(from string, msg connector.EmailMessage) string {
 	if cc := addressList(msg.Cc); cc != "" {
 		writeHeader(&b, "Cc", cc)
 	}
+	// Bcc is written HERE and delivered to NOBODY who can read it.
+	//
+	// messages.send takes the raw message and nothing else — there is no
+	// envelope list beside it — so this header is the only way to address a
+	// blind copy through this API. Gmail strips it before delivery, which is
+	// the behaviour every submission agent has and the reason a Bcc header is
+	// specified at all (RFC 5322 §3.6.3).
+	//
+	// It is therefore the one header whose PRESENCE here and ABSENCE at the
+	// recipient are both required. A renderer that omitted it would silently
+	// drop the recipients; one that could not rely on the strip would disclose
+	// them. Only the first is this code's to get right.
+	if bcc := addressList(msg.Bcc); bcc != "" {
+		writeHeader(&b, "Bcc", bcc)
+	}
 	// Encoded-word per RFC 2047 so a non-ASCII subject survives the wire.
 	writeHeader(&b, "Subject", mime.QEncoding.Encode("utf-8", msg.Subject))
 	writeHeader(&b, "Message-ID", bracket(msg.MessageID))

--- a/backend/internal/modules/comms/bccconsent_test.go
+++ b/backend/internal/modules/comms/bccconsent_test.go
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package comms
+
+import (
+	"slices"
+	"testing"
+)
+
+// The dispatch-time consent recheck asks about every person the delivery
+// reaches, and a blind copy reaches one.
+//
+// This is the check that runs at TRANSMIT rather than at staging, so it is the
+// one that sees a withdrawal made in between — a one-click unsubscribe, an
+// erasure. Omitting blind copies here would leave them the only recipients
+// whose suppression changed nothing about the message they received, and the
+// invisibility is exactly why nobody would notice.
+func TestTheConsentRecheckAsksAboutBlindCopies(t *testing.T) {
+	got := addressees(Delivery{
+		Recipients: []string{"buyer@example.test"},
+		Cc:         []string{"boss@example.test"},
+		Bcc:        []string{"Quiet@Example.test "},
+	})
+
+	for _, addr := range []string{"buyer@example.test", "boss@example.test", "quiet@example.test"} {
+		if !slices.Contains(got, addr) {
+			t.Errorf("%q receives the message and is not asked about: %v", addr, got)
+		}
+	}
+}
+
+// The same address in two lists is one person to a mail server, so it is one
+// question to the gate — and the normalized spelling is what travels, because
+// the gate cannot resolve a padded one.
+func TestAnAddressInTwoListsIsAskedAboutOnce(t *testing.T) {
+	got := addressees(Delivery{
+		Recipients: []string{"one@example.test"},
+		Bcc:        []string{" One@Example.test "},
+	})
+
+	if len(got) != 1 || got[0] != "one@example.test" {
+		t.Fatalf("addressees = %v, want the one normalized address", got)
+	}
+}

--- a/backend/internal/modules/comms/delivery.go
+++ b/backend/internal/modules/comms/delivery.go
@@ -31,6 +31,8 @@ type Delivery struct {
 	Cc         []string
 	Subject    string
 	Body       string
+	// Bcc receives the message and appears in no header.
+	Bcc []string
 	// HTMLBody is the markup alternative, empty for a plain-text send.
 	HTMLBody string
 	// FromName is the sender's display name; empty sends a bare address.

--- a/backend/internal/modules/comms/seams.go
+++ b/backend/internal/modules/comms/seams.go
@@ -226,16 +226,18 @@ func consentRecipients(del Delivery) []connector.Recipient {
 	return connector.EmailRecipients(addressees(del))
 }
 
-// addressees is every person this delivery reaches — To and Cc together, in
-// To-then-Cc order, deduplicated case- and space-insensitively the way a mail
+// addressees is every person this delivery reaches — To, Cc and Bcc together,
+// in that order, deduplicated case- and space-insensitively the way a mail
 // server treats an address.
 //
-// The delivery stores the two lists apart because the wire needs them apart,
+// The delivery stores the three lists apart because the wire needs them apart,
 // and consent is owed to EVERY addressee however they were addressed. Gating on
 // the To list alone would leave a Cc'd person no suppression at all: their
 // one-click unsubscribe, and an erasure of their record, would both land
 // between staging and transmit and change nothing about the message they
-// receive.
+// receive. A blind copy is the same person with less visibility, not less
+// standing — and the invisibility is exactly why omitting them here would go
+// unnoticed.
 //
 // It fills a slice of its own and never appends onto the delivery's, because
 // the wire rendering downstream reads Recipients and Cc as the separate lists
@@ -247,9 +249,10 @@ func consentRecipients(del Delivery) []connector.Recipient {
 // about one the gate cannot resolve — a legitimate send parked as "consent not
 // granted", which reads as a recipient who opted out.
 func addressees(del Delivery) []string {
-	all := make([]string, 0, len(del.Recipients)+len(del.Cc))
-	seen := make(map[string]bool, len(del.Recipients)+len(del.Cc))
-	for _, list := range [][]string{del.Recipients, del.Cc} {
+	size := len(del.Recipients) + len(del.Cc) + len(del.Bcc)
+	all := make([]string, 0, size)
+	seen := make(map[string]bool, size)
+	for _, list := range [][]string{del.Recipients, del.Cc, del.Bcc} {
 		for _, addr := range list {
 			key := strings.ToLower(strings.TrimSpace(addr))
 			if key == "" || seen[key] {

--- a/backend/internal/modules/comms/sendseam.go
+++ b/backend/internal/modules/comms/sendseam.go
@@ -119,7 +119,7 @@ func (d *Dispatcher) resolveSeam(ctx context.Context, del Delivery) (sendSeam, e
 			// message, and a field dropped here is a header silently missing
 			// from real mail.
 			return sender.SendEmail(ctx, auth, connector.EmailMessage{
-				To: del.Recipients, Cc: del.Cc,
+				To: del.Recipients, Cc: del.Cc, Bcc: del.Bcc,
 				Subject: del.Subject, Body: del.Body, HTMLBody: del.HTMLBody,
 				FromName:            del.FromName,
 				MessageID:           del.MessageID,

--- a/backend/internal/modules/comms/store.go
+++ b/backend/internal/modules/comms/store.go
@@ -93,8 +93,11 @@ type StageInput struct {
 	MessageID  string // unbracketed
 	Recipients []string
 	Cc         []string
-	Subject    string
-	Body       string // unsubscribe footer already applied
+	// Bcc receives the message and is rendered into no header. It is stored so
+	// a retry addresses the same people the first attempt did.
+	Bcc     []string
+	Subject string
+	Body    string // unsubscribe footer already applied
 	// HTMLBody is the same message as markup, NULL for a plain-text send. It
 	// never replaces Body: a retry rebuilds the message from this snapshot, so
 	// a shape stored here is the shape that goes out.
@@ -143,6 +146,10 @@ func (s *Store) StageTx(ctx context.Context, tx pgx.Tx, in StageInput) (ids.UUID
 	if err != nil {
 		return ids.UUID{}, fmt.Errorf("comms: encoding cc: %w", err)
 	}
+	bcc, err := marshalList(in.Bcc)
+	if err != nil {
+		return ids.UUID{}, fmt.Errorf("comms: encoding bcc: %w", err)
+	}
 	refs, err := marshalList(in.References)
 	if err != nil {
 		return ids.UUID{}, fmt.Errorf("comms: encoding references: %w", err)
@@ -157,13 +164,13 @@ func (s *Store) StageTx(ctx context.Context, tx pgx.Tx, in StageInput) (ids.UUID
 	if _, err := tx.Exec(ctx, `
 		INSERT INTO comms_outbound
 		  (id, activity_id, user_id, provider, message_id,
-		   recipients, cc, subject, body, html_body, from_name, consent_purpose, in_reply_to,
+		   recipients, cc, bcc, subject, body, html_body, from_name, consent_purpose, in_reply_to,
 		   references_chain, thread_key, list_unsubscribe, status, created_at, attachments)
 		VALUES ($1, $2, $3, $4, $5,
-		        $6, $7, $8, $9, NULLIF($10,''), NULLIF($11,''), $12, NULLIF($13,''), $14,
-		        NULLIF($15,''), NULLIF($16,''), 'pending', $17, $18)`,
+		        $6, $7, $8, $9, $10, NULLIF($11,''), NULLIF($12,''), $13, NULLIF($14,''), $15,
+		        NULLIF($16,''), NULLIF($17,''), 'pending', $18, $19)`,
 		id, in.ActivityID, userID, in.Provider, in.MessageID,
-		recipients, cc, in.Subject, in.Body, in.HTMLBody, in.FromName, in.ConsentPurpose,
+		recipients, cc, bcc, in.Subject, in.Body, in.HTMLBody, in.FromName, in.ConsentPurpose,
 		in.InReplyTo, refs, in.ThreadKey, in.ListUnsubscribe, s.now().UTC(), files); err != nil {
 		// The idempotency key is an ANSWER, and it is mapped rather than
 		// wrapped: a raw violation carries the constraint and table names, and
@@ -233,7 +240,7 @@ func marshalList(values []string) ([]byte, error) {
 // of them NULL is the answer this scan needs rather than a value to substitute.
 func (s *Store) Load(ctx context.Context, id ids.UUID) (Delivery, error) {
 	var d Delivery
-	var recipients, cc, refs, files []byte
+	var recipients, cc, bcc, refs, files []byte
 	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		return tx.QueryRow(ctx, `
 			UPDATE comms_outbound
@@ -241,13 +248,14 @@ func (s *Store) Load(ctx context.Context, id ids.UUID) (Delivery, error) {
 			 WHERE id = $1 AND status = 'pending'
 			RETURNING id, activity_id, user_id, provider, coalesce(message_id, ''),
 			          coalesce(recipients, '[]'::jsonb), coalesce(cc, '[]'::jsonb),
+			          coalesce(bcc, '[]'::jsonb),
 			          coalesce(subject, ''), body, coalesce(html_body, ''), coalesce(from_name, ''),
 			          channel_user_id, consent_purpose,
 			          coalesce(in_reply_to, ''), coalesce(references_chain, '[]'::jsonb),
 			          coalesce(list_unsubscribe, ''), inflight_at, status, attempts, created_at,
 			          attachments`,
 			id).Scan(&d.ID, &d.ActivityID, &d.UserID, &d.Provider, &d.MessageID,
-			&recipients, &cc, &d.Subject, &d.Body, &d.HTMLBody, &d.FromName, &d.ChannelUserID, &d.ConsentPurpose,
+			&recipients, &cc, &bcc, &d.Subject, &d.Body, &d.HTMLBody, &d.FromName, &d.ChannelUserID, &d.ConsentPurpose,
 			&d.InReplyTo, &refs, &d.ListUnsubscribe, &d.InFlightAt, &d.Status, &d.Attempts, &d.CreatedAt,
 			&files)
 	})
@@ -269,6 +277,9 @@ func (s *Store) Load(ctx context.Context, id ids.UUID) (Delivery, error) {
 	}
 	if err := json.Unmarshal(cc, &d.Cc); err != nil {
 		return Delivery{}, fmt.Errorf("comms: decoding cc: %w", err)
+	}
+	if err := json.Unmarshal(bcc, &d.Bcc); err != nil {
+		return Delivery{}, fmt.Errorf("comms: decoding bcc: %w", err)
 	}
 	if err := json.Unmarshal(refs, &d.References); err != nil {
 		return Delivery{}, fmt.Errorf("comms: decoding references: %w", err)

--- a/backend/internal/modules/comms/store.go
+++ b/backend/internal/modules/comms/store.go
@@ -47,6 +47,11 @@ var ErrDuplicateMessage = fmt.Errorf(
 // neither a To nor a Cc address can only be refused later — the consent gate
 // asks about an empty list and answers no — so it is refused here, where the
 // caller is still in the transaction that would have written the row.
+//
+// Bcc is deliberately NOT counted here, matching the contract: `to` carries
+// minItems 1 and a blind copy accompanies an addressed message rather than
+// replacing its addressee. A delivery that reached this with only blind copies
+// would have passed a guard the API layer already refuses.
 var ErrNoAddressee = errors.New("comms: a delivery needs at least one recipient or cc address")
 
 // Store is the comms_outbound seam: staging, loading with attempt-counting,

--- a/backend/internal/modules/privacy/deliveries.go
+++ b/backend/internal/modules/privacy/deliveries.go
@@ -100,7 +100,7 @@ func redactDeliveries(ctx context.Context, tx pgx.Tx, activityIDs []ids.UUID, to
 	}
 	if _, err := tx.Exec(ctx, `
 		UPDATE comms_outbound
-		   SET recipients = '[]'::jsonb, cc = '[]'::jsonb, subject = $2,
+		   SET recipients = '[]'::jsonb, cc = '[]'::jsonb, bcc = '[]'::jsonb, subject = $2,
 		       body = '', html_body = NULL, attachments = '[]'::jsonb,
 		       list_unsubscribe = NULL,
 		       status = CASE WHEN status = 'pending' THEN 'parked' ELSE status END,

--- a/backend/internal/modules/privacy/erasure_selectors.go
+++ b/backend/internal/modules/privacy/erasure_selectors.go
@@ -155,7 +155,8 @@ var unlinkedSubjectMail = `
 	         SELECT 1 FROM comms_outbound d
 	         WHERE d.activity_id = m.id
 	           AND EXISTS (
-	             SELECT 1 FROM jsonb_array_elements_text(d.recipients || d.cc) AS addr
+	             SELECT 1 FROM jsonb_array_elements_text(
+	                            d.recipients || d.cc || coalesce(d.bcc, '[]'::jsonb)) AS addr
 	             WHERE lower(addr) = ANY($2))))
 	  AND NOT EXISTS (
 	    SELECT 1 FROM activity_link o

--- a/backend/internal/modules/privacy/sar.go
+++ b/backend/internal/modules/privacy/sar.go
@@ -314,17 +314,27 @@ func sarMessagingSections(pkg *SARPackage) []sarSection {
 		// projection discloses the message AS THE SUBJECT RECEIVED IT, and who
 		// it appeared to be from is part of what they were shown.
 		//
-		// The address match spans bcc as well. A blind copy is blind to the
-		// other RECIPIENTS and never to the subject themselves: a person
-		// bcc'd on a message with no activity link would otherwise be absent
-		// from their own export of a message they received.
+		// The address match spans bcc, and the DISCLOSURE of it is narrowed to
+		// the subject's own address.
+		//
+		// Both halves are required and they pull opposite ways. A person bcc'd
+		// on a message with no activity link would otherwise be absent from
+		// their own export of a message they received — and exporting the
+		// whole bcc array would hand one subject every other blind recipient's
+		// address, which is the disclosure a blind copy exists to prevent. So
+		// the row is FOUND on any addressee and the blind list is REDUCED to
+		// the asker.
 		//
 		// attachments too, and it is not covered by the attachment query
 		// below: that one finds files hanging off the subject or an activity
 		// linked to them, while a send may carry any file its sender could see
 		// — one attached to an organization or a deal reaches the subject
 		// without ever being attached TO them.
-		{&pkg.SentMessages, `SELECT o.subject, o.body, o.html_body, o.from_name, o.attachments, o.recipients, o.cc, o.bcc, o.consent_purpose,
+		{&pkg.SentMessages, `SELECT o.subject, o.body, o.html_body, o.from_name, o.attachments, o.recipients, o.cc,
+		      (SELECT coalesce(jsonb_agg(addr), '[]'::jsonb)
+		         FROM jsonb_array_elements_text(coalesce(o.bcc, '[]'::jsonb)) AS addr
+		        WHERE lower(addr) IN (SELECT email FROM person_email WHERE person_id = $1)) AS bcc,
+		      o.consent_purpose,
 		      o.provider, o.channel_user_id, o.status, o.sent_at, o.created_at
 		   FROM comms_outbound o
 		   WHERE o.activity_id IN (SELECT l.activity_id FROM activity_link l WHERE l.person_id = $1)

--- a/backend/internal/modules/privacy/sar.go
+++ b/backend/internal/modules/privacy/sar.go
@@ -314,17 +314,23 @@ func sarMessagingSections(pkg *SARPackage) []sarSection {
 		// projection discloses the message AS THE SUBJECT RECEIVED IT, and who
 		// it appeared to be from is part of what they were shown.
 		//
+		// The address match spans bcc as well. A blind copy is blind to the
+		// other RECIPIENTS and never to the subject themselves: a person
+		// bcc'd on a message with no activity link would otherwise be absent
+		// from their own export of a message they received.
+		//
 		// attachments too, and it is not covered by the attachment query
 		// below: that one finds files hanging off the subject or an activity
 		// linked to them, while a send may carry any file its sender could see
 		// — one attached to an organization or a deal reaches the subject
 		// without ever being attached TO them.
-		{&pkg.SentMessages, `SELECT o.subject, o.body, o.html_body, o.from_name, o.attachments, o.recipients, o.cc, o.consent_purpose,
+		{&pkg.SentMessages, `SELECT o.subject, o.body, o.html_body, o.from_name, o.attachments, o.recipients, o.cc, o.bcc, o.consent_purpose,
 		      o.provider, o.channel_user_id, o.status, o.sent_at, o.created_at
 		   FROM comms_outbound o
 		   WHERE o.activity_id IN (SELECT l.activity_id FROM activity_link l WHERE l.person_id = $1)
 		      OR EXISTS (
-		           SELECT 1 FROM jsonb_array_elements_text(o.recipients || o.cc) AS addr
+		           SELECT 1 FROM jsonb_array_elements_text(
+		                          o.recipients || o.cc || coalesce(o.bcc, '[]'::jsonb)) AS addr
 		           WHERE lower(addr) IN (SELECT email FROM person_email WHERE person_id = $1))`},
 	}
 }

--- a/backend/internal/shared/ports/connector/outbound.go
+++ b/backend/internal/shared/ports/connector/outbound.go
@@ -81,6 +81,14 @@ type OutboundFile struct {
 type EmailMessage struct {
 	To []string
 	Cc []string
+	// Bcc receives the message and is rendered into NO header.
+	//
+	// The distinction lives here rather than in the renderer because it is a
+	// fact about the addressees, not about one wire format: a provider that
+	// takes an addressee list separately from the message (Graph, SES) needs
+	// the same separation, and a renderer that had to infer it would have to
+	// be told twice.
+	Bcc []string
 	// FromName is the sender's display name, or empty to send a bare address.
 	//
 	// A From header with no display name shows the address's LOCAL PART in every

--- a/backend/migrations/core/0238_comms_outbound_bcc.down.sql
+++ b/backend/migrations/core/0238_comms_outbound_bcc.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE comms_outbound DROP COLUMN bcc;

--- a/backend/migrations/core/0238_comms_outbound_bcc.up.sql
+++ b/backend/migrations/core/0238_comms_outbound_bcc.up.sql
@@ -1,0 +1,17 @@
+-- 0238: a staged delivery remembers its blind copies.
+--
+-- comms_outbound is the retry snapshot: the dispatcher rebuilds the message
+-- from this row alone, so an addressee the column cannot hold is an addressee
+-- the retry silently drops. A bcc'd recipient who received the first attempt
+-- and not the second is the shape that failure takes.
+--
+-- Stored beside cc rather than folded into it, because the two differ in
+-- exactly one way that matters: cc is rendered into a header every recipient
+-- reads and bcc is not. One column holding both would make "blind" a property
+-- of the rendering code rather than of the data, and the next reader of that
+-- code would have no way to tell which addresses were which.
+--
+-- The privacy scrub clears it with recipients and cc (privacy/deliveries.go):
+-- a blind copy is still a person's address, and an erasure that left it would
+-- keep the one recipient list nobody else could see.
+ALTER TABLE comms_outbound ADD COLUMN bcc jsonb NULL;

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -11987,6 +11987,19 @@ export interface components {
             to: string[];
             cc?: string[];
             /**
+             * @description Blind copies. They receive the message and are therefore owed consent
+             *     exactly as To and Cc are — the gate answers on every addressee, however
+             *     they were addressed — and they are absent from the headers the recipients
+             *     see, which is the whole of what "blind" means.
+             *
+             *     A message with a tokenized unsubscribe link may still have only ONE
+             *     addressee in total: that token is a bearer credential over one person's
+             *     consent record, so a bcc'd copy of a marketing send is refused 422
+             *     `shared_unsubscribe_token` rather than handing a stranger somebody else's
+             *     preference link.
+             */
+            bcc?: string[];
+            /**
              * @description Opaque reference returned by the drafting operation. After a successful send, the
              *     server compares this protected original with the final body and records accepted or
              *     edited-and-sent metadata. Only a guarded, human-authored final edit may become a
@@ -12036,6 +12049,19 @@ export interface components {
              */
             to: string[];
             cc?: string[];
+            /**
+             * @description Blind copies. They receive the message and are therefore owed consent
+             *     exactly as To and Cc are — the gate answers on every addressee, however
+             *     they were addressed — and they are absent from the headers the recipients
+             *     see, which is the whole of what "blind" means.
+             *
+             *     A message with a tokenized unsubscribe link may still have only ONE
+             *     addressee in total: that token is a bearer credential over one person's
+             *     consent record, so a bcc'd copy of a marketing send is refused 422
+             *     `shared_unsubscribe_token` rather than handing a stranger somebody else's
+             *     preference link.
+             */
+            bcc?: string[];
             /**
              * @description Opaque reference returned by the drafting operation, exactly as on `send_email`.
              *     Omit for independently composed mail.


### PR DESCRIPTION
Half of #1205. Send-later is deliberately left out — it needs product decisions
(edit/cancel semantics, when the activity becomes visible, approval at schedule
or transmit time) and gets its own plan.

## The rule the whole change follows

**A blind copy is blind to the RECIPIENTS and never to the consent gate.**

So a bcc'd address joins the merged `Recipients` list every other addressee is
on — they receive the message, and consent is owed to whoever receives it — and
it comes OUT of the To line alongside Cc, because a bcc address left there is
read by every other recipient the moment the message arrives.

**Verified live, and the refusal is the better half:** sending to a blind address
with no consent record returns 409 *naming that address*. Nobody receives mail
unasked for merely by being copied invisibly.

## Two consequences that needed no new code

The invariants were already written on the merged list:

- The multi-recipient unsubscribe refusal counts distinct addresses in
  `Recipients`, so a bcc'd marketing send is refused rather than handing a
  stranger somebody else's preference token.
- The consent gate asks about every merged address, so bcc is covered wherever
  that list is used.

## What the review caught — four, and the first is mine

**BLOCKER: the SAR export selected the whole bcc array.** A subject matching a
delivery any way at all received every *other* blind recipient's address. Fixing
the gap where a bcc'd person was missing from their own export had opened the
disclosure bcc exists to prevent. The row is now FOUND on any addressee and the
blind list REDUCED to the asker's own address.

**The dispatch-time consent recheck omitted bcc.** That check runs at transmit,
so it is the one that sees a withdrawal made after staging — leaving blind
copies the only recipients whose suppression changed nothing.

**The erasure selector missed a non-primary bcc subject**, so their message was
never handed to the scrub that would have cleared it.

**I had loosened the empty-addressee guard** to allow a bcc-only send without
changing the contract that refuses one. Restored to agree with `minItems: 1`.

## A note on verification

The first bcc-only check passed against a **stale binary** and reported a false
pass. Re-run after `make dev`, it correctly returns 422. That is the trap
CLAUDE.md names, and the reason the result was re-taken rather than trusted.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds blind-copy (Bcc) support for outbound email so blind recipients receive mail, pass the consent gate, and never appear in visible headers. Previously only To and Cc were supported.

- API: adds optional `bcc` on send requests; handlers merge To+Cc+Bcc into `Recipients` for consent, and derive the visible To list by removing Cc and Bcc. A bcc‑only send is still rejected (minItems 1 on `to`).
- Consent: staging and dispatch-time recheck include Bcc; if any blind recipient lacks consent, the send fails (409 naming that address). Multi‑recipient unsubscribe refusal already counts the merged list.
- Storage/rendering: `comms_outbound` persists `bcc` (JSONB) so retries address the same people; dispatcher and connector structs carry Bcc; RFC822 writer omits an empty To header and writes a Bcc header that Gmail strips before delivery.
- Privacy/SAR: erasure selectors now include Bcc; privacy scrub clears `bcc`; SAR matches on Bcc and only discloses the requester’s own blind address.

**Rollout**
- Run migration `0238_comms_outbound_bcc` to add the `bcc` column.
- Deploy backend and clients together. Callers may include `bcc` but must still provide at least one visible addressee in `to`.

<sup>Written for commit 5a9bb3bf165726e1bc1fc0c9ebecdc32ef57cb0f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1238?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

