### PR TITLE
refactor(jobs): the second role is `worker`, not `workspace` (ADR-0103 §2)

### DIFF
--- a/backend/api/jobs.yaml
+++ b/backend/api/jobs.yaml
@@ -156,7 +156,7 @@ kinds:
     fan_out_unit: workspace
 
   agent_scheduler_workspace:
-    role: workspace
+    role: worker
     go_type: AgentSchedulerWorkspaceArgs
     queue: agent_scheduler
     timeout:
@@ -180,7 +180,7 @@ kinds:
       hasten it.
 
   ai_model_rate_refresh:
-    role: workspace
+    role: worker
     go_type: AiModelRateRefreshArgs
     queue: rate_refresh
     timeout: 20m
@@ -211,7 +211,7 @@ kinds:
       day into it.
 
   capture_auto_enrich_workspace:
-    role: workspace
+    role: worker
     go_type: CaptureAutoEnrichWorkspaceArgs
     queue: default
     timeout: 5m
@@ -243,7 +243,7 @@ kinds:
       is what it calls stale.
 
   finance_sync:
-    role: workspace
+    role: worker
     go_type: FinanceSyncArgs
     queue: default
     timeout: 5m
@@ -260,7 +260,7 @@ kinds:
       on the next sweep.
 
   capture_backfill:
-    role: workspace
+    role: worker
     go_type: CaptureBackfillArgs
     queue: default
     timeout: 8m
@@ -298,7 +298,7 @@ kinds:
       the backlog index makes a caught-up tenant one cheap probe.
 
   capture_classify_workspace:
-    role: workspace
+    role: worker
     go_type: CaptureClassifyWorkspaceArgs
     queue: ai_capture
     timeout: 15m
@@ -331,7 +331,7 @@ kinds:
       before the tick.
 
   capture_counterparty_verdict_workspace:
-    role: workspace
+    role: worker
     go_type: CounterpartyVerdictWorkspaceArgs
     queue: ai_capture
     timeout: 20m
@@ -360,7 +360,7 @@ kinds:
       a missed night, so a morning is never silently empty.
 
   capture_digest_workspace:
-    role: workspace
+    role: worker
     go_type: CaptureDigestWorkspaceArgs
     queue: default
     timeout: 5m
@@ -389,7 +389,7 @@ kinds:
       dispatcher lands.
 
   capture_enrich_workspace:
-    role: workspace
+    role: worker
     go_type: CaptureEnrichWorkspaceArgs
     queue: ai_capture
     timeout: 20m
@@ -404,7 +404,7 @@ kinds:
       The nightly cycle picks up whatever a stopped pass did not reach.
 
   capture_sync:
-    role: workspace
+    role: worker
     go_type: CaptureSyncArgs
     queue: default
     timeout: 8m
@@ -448,7 +448,7 @@ kinds:
     fan_out_unit: workspace
 
   close_date_workspace:
-    role: workspace
+    role: worker
     go_type: CloseDateWorkspaceArgs
     queue: default
     timeout: 5m
@@ -464,7 +464,7 @@ kinds:
       River's ladder spans minutes at these rungs — comfortably inside one tick.
 
   comms_send_email:
-    role: workspace
+    role: worker
     go_type: SendEmailArgs
     queue: default
     timeout: 5m
@@ -500,7 +500,7 @@ kinds:
       registers neither embed_drift kind.
 
   embed_drift_workspace:
-    role: workspace
+    role: worker
     go_type: EmbedDriftWorkspaceArgs
     queue: default
     timeout:
@@ -549,7 +549,7 @@ kinds:
       insert-many.
 
   embed_reindex_workspace:
-    role: workspace
+    role: worker
     go_type: EmbedReindexWorkspaceArgs
     queue: ai_capture
     timeout:
@@ -594,7 +594,7 @@ kinds:
     fan_out_unit: workspace
 
   follow_up_workspace:
-    role: workspace
+    role: worker
     go_type: FollowUpWorkspaceArgs
     queue: default
     timeout: 5m
@@ -609,7 +609,7 @@ kinds:
       would cost a workspace a full day over a transient blip.
 
   fx_rate_refresh:
-    role: workspace
+    role: worker
     go_type: FxRateRefreshArgs
     queue: rate_refresh
     timeout: 10m
@@ -650,7 +650,7 @@ kinds:
     fan_out_unit: connection
 
   gmail_watch_renew_connection:
-    role: workspace
+    role: worker
     go_type: GmailWatchRenewArgs
     queue: default
     timeout: 2m
@@ -680,7 +680,7 @@ kinds:
       loosening the cadence without amending the migration makes it a lie.
 
   graph_edge_workspace:
-    role: workspace
+    role: worker
     go_type: GraphEdgeWorkspaceArgs
     queue: default
     timeout: 15m
@@ -711,7 +711,7 @@ kinds:
       expired personal data sitting past its purpose.
 
   agent_task_retention_workspace:
-    role: workspace
+    role: worker
     go_type: AgentTaskRetentionWorkspaceArgs
     queue: default
     timeout: 5m
@@ -739,7 +739,7 @@ kinds:
       expired personal data sitting past its purpose.
 
   idempotency_retention_workspace:
-    role: workspace
+    role: worker
     go_type: IdempotencyRetentionWorkspaceArgs
     queue: default
     timeout: 5m
@@ -768,7 +768,7 @@ kinds:
       the morning should not wait until tomorrow to see it on an account.
 
   linkedin_rematch_workspace:
-    role: workspace
+    role: worker
     go_type: LinkedInRematchWorkspaceArgs
     queue: default
     timeout: 10m
@@ -796,7 +796,7 @@ kinds:
       this one weighs.
 
   org_name_promotion_workspace:
-    role: workspace
+    role: worker
     go_type: OrgNamePromotionWorkspaceArgs
     queue: default
     timeout: 5m
@@ -828,7 +828,7 @@ kinds:
       scan and the sweep is swept under its CURRENT identity.
 
   overlay_reconcile_workspace:
-    role: workspace
+    role: worker
     go_type: OverlayReconcileWorkspaceArgs
     queue: overlay_reconcile
     timeout: 20m
@@ -865,7 +865,7 @@ kinds:
       the retry.
 
   overlay_refetch:
-    role: workspace
+    role: worker
     go_type: OverlayRefetchArgs
     queue: default
     timeout: 2m
@@ -901,7 +901,7 @@ kinds:
       restore or an import can reintroduce unattributed rows.
 
   participant_backfill_workspace:
-    role: workspace
+    role: worker
     go_type: ParticipantBackfillWorkspaceArgs
     queue: default
     timeout: 10m
@@ -926,7 +926,7 @@ kinds:
     fan_out_unit: workspace
 
   privacy_retention_workspace:
-    role: workspace
+    role: worker
     go_type: PrivacyRetentionWorkspaceArgs
     queue: privacy_retention
     timeout:
@@ -942,7 +942,7 @@ kinds:
       Workspace: id
 
   provider_run_submit:
-    role: workspace
+    role: worker
     go_type: ProviderRunSubmitArgs
     queue: default
     timeout: 2m
@@ -976,7 +976,7 @@ kinds:
       partial index.
 
   provider_run_poll:
-    role: workspace
+    role: worker
     go_type: ProviderRunPollArgs
     queue: default
     timeout: 2m
@@ -1010,7 +1010,7 @@ kinds:
       workspace.
 
   signal_scan_workspace:
-    role: workspace
+    role: worker
     go_type: SignalScanWorkspaceArgs
     queue: ai_capture
     timeout: 20m
@@ -1030,7 +1030,7 @@ kinds:
       every reading it paid for and the next tick resumes on the backlog.
 
   site_deep_read:
-    role: workspace
+    role: worker
     go_type: SiteDeepReadArgs
     queue: deep_read
     timeout: {operator: DeepReadCaps}
@@ -1056,7 +1056,7 @@ kinds:
       registration.
 
   telegram_ingest:
-    role: workspace
+    role: worker
     go_type: TelegramIngestArgs
     queue: default
     timeout: 2m
@@ -1071,7 +1071,7 @@ kinds:
       database-only, one update at a time, with no provider call in it at all.
 
   telegram_poll:
-    role: workspace
+    role: worker
     go_type: TelegramPollArgs
     queue: default
     timeout: {derived: telegramPollJobTimeout, value: 2m}
@@ -1112,7 +1112,7 @@ kinds:
     fan_out_unit: workspace
 
   time_scan_workspace:
-    role: workspace
+    role: worker
     go_type: TimeScanWorkspaceArgs
     queue: default
     timeout: 10m
@@ -1127,7 +1127,7 @@ kinds:
       matched set is a tenant's standing automations rather than a batch bound.
 
   voice_build:
-    role: workspace
+    role: worker
     go_type: VoiceBuildArgs
     queue: default
     timeout: {derived: voiceBuildTimeout, value: 10m}
@@ -1172,7 +1172,7 @@ kinds:
     fan_out_unit: workspace
 
   webhook_retry_workspace:
-    role: workspace
+    role: worker
     go_type: WebhookRetryWorkspaceArgs
     queue: webhook_retry
     timeout:

--- a/backend/internal/compose/extjobs.go
+++ b/backend/internal/compose/extjobs.go
@@ -191,7 +191,7 @@ func composedJobSpecs(set []composedJob) []jobs.Spec {
 			jobs.Spec{
 				Kind:        j.decl.ChildKind(),
 				GoType:      "extJobWorkspaceArgs",
-				Role:        jobs.Workspace,
+				Role:        jobs.Worker,
 				Queue:       j.decl.Queue,
 				Timeout:     jobs.TimeoutPolicy{Fixed: j.decl.Timeout},
 				MaxAttempts: j.decl.MaxAttempts,

--- a/backend/internal/compose/extjobs_test.go
+++ b/backend/internal/compose/extjobs_test.go
@@ -143,7 +143,7 @@ func TestComposedJobSpecsDeclareBothKindsAndTheEdgeBetweenThem(t *testing.T) {
 	if dispatcher.Cadence.Fixed != d.Cadence || dispatcher.Timeout.Duration(0) != d.DispatcherTimeout {
 		t.Fatalf("dispatcher mechanics = %+v", dispatcher)
 	}
-	if child.Kind != d.ChildKind() || child.Role != jobs.Workspace || child.OptsOwner != jobs.OptsFanOut {
+	if child.Kind != d.ChildKind() || child.Role != jobs.Worker || child.OptsOwner != jobs.OptsFanOut {
 		t.Fatalf("child spec = %+v", child)
 	}
 	if child.MaxAttempts != d.MaxAttempts || child.Timeout.Duration(0) != d.Timeout || child.Queue != d.Queue {

--- a/backend/internal/compose/jobdeclared.go
+++ b/backend/internal/compose/jobdeclared.go
@@ -91,8 +91,8 @@ func roleName(r jobs.Role) string {
 	switch r {
 	case jobs.Dispatcher:
 		return "dispatcher"
-	case jobs.Workspace:
-		return "workspace"
+	case jobs.Worker:
+		return "worker"
 	}
 	return "undeclared"
 }

--- a/backend/internal/compose/jobdeclared_test.go
+++ b/backend/internal/compose/jobdeclared_test.go
@@ -76,7 +76,7 @@ func TestTheCatalogueNamesEveryDeclaredKindsRole(t *testing.T) {
 		series := infoSeriesFor(t, out, kind)
 		want := map[jobs.Role]string{
 			jobs.Dispatcher: `role="dispatcher"`,
-			jobs.Workspace:  `role="workspace"`,
+			jobs.Worker:     `role="worker"`,
 		}[spec.Role]
 		if want == "" {
 			t.Fatalf("%s carries role %d, which the declaration does not define", kind, spec.Role)
@@ -420,7 +420,7 @@ func TestAComposedExtensionKindIsNotUnrecognised(t *testing.T) {
 	if err := jobs.RegisterComposed([]jobs.Spec{{
 		Kind:      kind,
 		GoType:    "extJobWorkspaceArgs",
-		Role:      jobs.Workspace,
+		Role:      jobs.Worker,
 		Queue:     "default",
 		Timeout:   jobs.TimeoutPolicy{Fixed: 5 * time.Minute},
 		OptsOwner: jobs.OptsFanOut,

--- a/backend/internal/compose/jobkinds_gen.go
+++ b/backend/internal/compose/jobkinds_gen.go
@@ -13,7 +13,7 @@ import (
 // jobContractHash is the sha256 of api/jobs.yaml this file was generated
 // from — the same fingerprint jobs.JobContractHash carries, so a stale
 // half of the pair is visible without diffing the two tables.
-const jobContractHash = "58ac230e447ccec90881634f0fc20a69f635084026353a1564f38d56bb5147a9"
+const jobContractHash = "bae6430067d6228e1df86e7194ca073cee82ec501a0421fb7e604f7baebcddff"
 
 // declaredJobArgs is every args type api/jobs.yaml declares, and nothing
 // else. A job kind the file has never heard of cannot satisfy it, so it

--- a/backend/internal/compose/workspaceguard_test.go
+++ b/backend/internal/compose/workspaceguard_test.go
@@ -188,7 +188,7 @@ func TestEveryWorkspaceWorkerRefusesArgsNamingNoWorkspace(t *testing.T) {
 
 	declared := 0
 	for kind, spec := range jobs.Declared() {
-		if spec.Role != jobs.Workspace {
+		if spec.Role != jobs.Worker {
 			continue
 		}
 		declared++
@@ -202,7 +202,7 @@ func TestEveryWorkspaceWorkerRefusesArgsNamingNoWorkspace(t *testing.T) {
 	}
 	for kind := range refusals {
 		spec, declaredKind := jobs.SpecFor(kind)
-		if !declaredKind || spec.Role != jobs.Workspace {
+		if !declaredKind || spec.Role != jobs.Worker {
 			t.Errorf("%s is driven here but api/jobs.yaml declares no workspace kind by that name — the suite is pinning something the fleet does not run", kind)
 		}
 	}

--- a/backend/internal/platform/jobs/composed_test.go
+++ b/backend/internal/platform/jobs/composed_test.go
@@ -26,7 +26,7 @@ func extSpec(kind string) Spec {
 	return Spec{
 		Kind:        kind,
 		GoType:      "extJobWorkspaceArgs",
-		Role:        Workspace,
+		Role:        Worker,
 		Queue:       "default",
 		Timeout:     TimeoutPolicy{Fixed: time.Minute},
 		MaxAttempts: 3,

--- a/backend/internal/platform/jobs/spec.go
+++ b/backend/internal/platform/jobs/spec.go
@@ -13,18 +13,19 @@ import (
 	"time"
 )
 
-// Role is what a declared kind DOES. A dispatcher enumerates and enqueues and
-// touches no tenant data; a workspace kind carries one tenant's pass and is
-// enqueued, never ticked. The zero value names neither — every Spec compiled
-// from the contract sets it, so a zero Role means a Spec nobody declared.
+// Role is what a declared kind DOES. A dispatcher enumerates a work unit and
+// enqueues one child per item, touching no record data itself; a worker does
+// the work — ticked by its own schedule, or enqueued by a dispatcher and
+// carrying the unit it stands for. The zero value names neither: every Spec
+// compiled from the contract sets it, so a zero Role means a Spec nobody
+// declared.
 type Role int
 
-// The two roles the fleet has. A third would be a change to what a job IS,
-// not data: both surfaces (the health report and the metrics) read this to
-// decide whether a null workspace_id is correct or a defect.
+// The two roles a job has. A third would be a change to what a job IS, not
+// data: the health report and the metrics both read this.
 const (
 	Dispatcher Role = iota + 1
-	Workspace
+	Worker
 )
 
 // FanOutUnit is what one child of a fan-out stands for. A dispatcher enqueues

--- a/backend/internal/platform/jobs/specs_gen.go
+++ b/backend/internal/platform/jobs/specs_gen.go
@@ -11,7 +11,7 @@ import "time"
 // would believe. It says nothing about the file on disk — a pair
 // regenerated TOGETHER from a stale contract matches here, and the drift
 // gate is what catches that.
-const JobContractHash = "58ac230e447ccec90881634f0fc20a69f635084026353a1564f38d56bb5147a9"
+const JobContractHash = "bae6430067d6228e1df86e7194ca073cee82ec501a0421fb7e604f7baebcddff"
 
 // specs is every declared kind. A kind absent from this table is a kind
 // nobody declared, and MustBeTotal is what names them: the runner calls it
@@ -33,7 +33,7 @@ var specs = map[string]Spec{
 	"agent_scheduler_workspace": {
 		Kind:         "agent_scheduler_workspace",
 		GoType:       "AgentSchedulerWorkspaceArgs",
-		Role:         Workspace,
+		Role:         Worker,
 		Queue:        "agent_scheduler",
 		Timeout:      TimeoutPolicy{Fixed: 65 * time.Minute, DerivedFrom: "agentSchedulerPassTimeout"},
 		MaxAttempts:  1,
@@ -55,7 +55,7 @@ var specs = map[string]Spec{
 	"agent_task_retention_workspace": {
 		Kind:        "agent_task_retention_workspace",
 		GoType:      "AgentTaskRetentionWorkspaceArgs",
-		Role:        Workspace,
+		Role:        Worker,
 		Queue:       "default",
 		Timeout:     TimeoutPolicy{Fixed: 5 * time.Minute},
 		MaxAttempts: 3,
@@ -65,7 +65,7 @@ var specs = map[string]Spec{
 	"ai_model_rate_refresh": {
 		Kind:      "ai_model_rate_refresh",
 		GoType:    "AiModelRateRefreshArgs",
-		Role:      Workspace,
+		Role:      Worker,
 		Queue:     "rate_refresh",
 		Timeout:   TimeoutPolicy{Fixed: 20 * time.Minute},
 		OptsOwner: OptsCaller,
@@ -85,7 +85,7 @@ var specs = map[string]Spec{
 	"capture_auto_enrich_workspace": {
 		Kind:        "capture_auto_enrich_workspace",
 		GoType:      "CaptureAutoEnrichWorkspaceArgs",
-		Role:        Workspace,
+		Role:        Worker,
 		Queue:       "default",
 		Timeout:     TimeoutPolicy{Fixed: 5 * time.Minute},
 		MaxAttempts: 3,
@@ -95,7 +95,7 @@ var specs = map[string]Spec{
 	"capture_backfill": {
 		Kind:         "capture_backfill",
 		GoType:       "CaptureBackfillArgs",
-		Role:         Workspace,
+		Role:         Worker,
 		Queue:        "default",
 		Timeout:      TimeoutPolicy{Fixed: 8 * time.Minute},
 		OptsOwner:    OptsCaller,
@@ -118,7 +118,7 @@ var specs = map[string]Spec{
 	"capture_classify_workspace": {
 		Kind:         "capture_classify_workspace",
 		GoType:       "CaptureClassifyWorkspaceArgs",
-		Role:         Workspace,
+		Role:         Worker,
 		Queue:        "ai_capture",
 		Timeout:      TimeoutPolicy{Fixed: 15 * time.Minute},
 		MaxAttempts:  3,
@@ -140,7 +140,7 @@ var specs = map[string]Spec{
 	"capture_counterparty_verdict_workspace": {
 		Kind:        "capture_counterparty_verdict_workspace",
 		GoType:      "CounterpartyVerdictWorkspaceArgs",
-		Role:        Workspace,
+		Role:        Worker,
 		Queue:       "ai_capture",
 		Timeout:     TimeoutPolicy{Fixed: 20 * time.Minute},
 		MaxAttempts: 3,
@@ -162,7 +162,7 @@ var specs = map[string]Spec{
 	"capture_digest_workspace": {
 		Kind:         "capture_digest_workspace",
 		GoType:       "CaptureDigestWorkspaceArgs",
-		Role:         Workspace,
+		Role:         Worker,
 		Queue:        "default",
 		Timeout:      TimeoutPolicy{Fixed: 5 * time.Minute},
 		MaxAttempts:  3,
@@ -185,7 +185,7 @@ var specs = map[string]Spec{
 	"capture_enrich_workspace": {
 		Kind:         "capture_enrich_workspace",
 		GoType:       "CaptureEnrichWorkspaceArgs",
-		Role:         Workspace,
+		Role:         Worker,
 		Queue:        "ai_capture",
 		Timeout:      TimeoutPolicy{Fixed: 20 * time.Minute},
 		MaxAttempts:  3,
@@ -196,7 +196,7 @@ var specs = map[string]Spec{
 	"capture_sync": {
 		Kind:         "capture_sync",
 		GoType:       "CaptureSyncArgs",
-		Role:         Workspace,
+		Role:         Worker,
 		Queue:        "default",
 		Timeout:      TimeoutPolicy{Fixed: 8 * time.Minute},
 		MaxAttempts:  25,
@@ -219,7 +219,7 @@ var specs = map[string]Spec{
 	"close_date_workspace": {
 		Kind:        "close_date_workspace",
 		GoType:      "CloseDateWorkspaceArgs",
-		Role:        Workspace,
+		Role:        Worker,
 		Queue:       "default",
 		Timeout:     TimeoutPolicy{Fixed: 5 * time.Minute},
 		MaxAttempts: 5,
@@ -229,7 +229,7 @@ var specs = map[string]Spec{
 	"comms_send_email": {
 		Kind:         "comms_send_email",
 		GoType:       "SendEmailArgs",
-		Role:         Workspace,
+		Role:         Worker,
 		Queue:        "default",
 		Timeout:      TimeoutPolicy{Fixed: 5 * time.Minute},
 		OptsOwner:    OptsCaller,
@@ -251,7 +251,7 @@ var specs = map[string]Spec{
 	"embed_drift_workspace": {
 		Kind:         "embed_drift_workspace",
 		GoType:       "EmbedDriftWorkspaceArgs",
-		Role:         Workspace,
+		Role:         Worker,
 		Queue:        "default",
 		Timeout:      TimeoutPolicy{None: true},
 		MaxAttempts:  3,
@@ -275,7 +275,7 @@ var specs = map[string]Spec{
 	"embed_reindex_workspace": {
 		Kind:         "embed_reindex_workspace",
 		GoType:       "EmbedReindexWorkspaceArgs",
-		Role:         Workspace,
+		Role:         Worker,
 		Queue:        "ai_capture",
 		Timeout:      TimeoutPolicy{None: true},
 		MaxAttempts:  5,
@@ -286,7 +286,7 @@ var specs = map[string]Spec{
 	"finance_sync": {
 		Kind:        "finance_sync",
 		GoType:      "FinanceSyncArgs",
-		Role:        Workspace,
+		Role:        Worker,
 		Queue:       "default",
 		Timeout:     TimeoutPolicy{Fixed: 5 * time.Minute},
 		MaxAttempts: 3,
@@ -318,7 +318,7 @@ var specs = map[string]Spec{
 	"follow_up_workspace": {
 		Kind:        "follow_up_workspace",
 		GoType:      "FollowUpWorkspaceArgs",
-		Role:        Workspace,
+		Role:        Worker,
 		Queue:       "default",
 		Timeout:     TimeoutPolicy{Fixed: 5 * time.Minute},
 		MaxAttempts: 5,
@@ -328,7 +328,7 @@ var specs = map[string]Spec{
 	"fx_rate_refresh": {
 		Kind:      "fx_rate_refresh",
 		GoType:    "FxRateRefreshArgs",
-		Role:      Workspace,
+		Role:      Worker,
 		Queue:     "rate_refresh",
 		Timeout:   TimeoutPolicy{Fixed: 10 * time.Minute},
 		OptsOwner: OptsCaller,
@@ -361,7 +361,7 @@ var specs = map[string]Spec{
 	"gmail_watch_renew_connection": {
 		Kind:         "gmail_watch_renew_connection",
 		GoType:       "GmailWatchRenewArgs",
-		Role:         Workspace,
+		Role:         Worker,
 		Queue:        "default",
 		Timeout:      TimeoutPolicy{Fixed: 2 * time.Minute},
 		MaxAttempts:  3,
@@ -383,7 +383,7 @@ var specs = map[string]Spec{
 	"graph_edge_workspace": {
 		Kind:        "graph_edge_workspace",
 		GoType:      "GraphEdgeWorkspaceArgs",
-		Role:        Workspace,
+		Role:        Worker,
 		Queue:       "default",
 		Timeout:     TimeoutPolicy{Fixed: 15 * time.Minute},
 		MaxAttempts: 3,
@@ -404,7 +404,7 @@ var specs = map[string]Spec{
 	"idempotency_retention_workspace": {
 		Kind:        "idempotency_retention_workspace",
 		GoType:      "IdempotencyRetentionWorkspaceArgs",
-		Role:        Workspace,
+		Role:        Worker,
 		Queue:       "default",
 		Timeout:     TimeoutPolicy{Fixed: 5 * time.Minute},
 		MaxAttempts: 3,
@@ -425,7 +425,7 @@ var specs = map[string]Spec{
 	"linkedin_rematch_workspace": {
 		Kind:        "linkedin_rematch_workspace",
 		GoType:      "LinkedInRematchWorkspaceArgs",
-		Role:        Workspace,
+		Role:        Worker,
 		Queue:       "default",
 		Timeout:     TimeoutPolicy{Fixed: 10 * time.Minute},
 		MaxAttempts: 3,
@@ -446,7 +446,7 @@ var specs = map[string]Spec{
 	"org_name_promotion_workspace": {
 		Kind:        "org_name_promotion_workspace",
 		GoType:      "OrgNamePromotionWorkspaceArgs",
-		Role:        Workspace,
+		Role:        Worker,
 		Queue:       "default",
 		Timeout:     TimeoutPolicy{Fixed: 5 * time.Minute},
 		MaxAttempts: 3,
@@ -468,7 +468,7 @@ var specs = map[string]Spec{
 	"overlay_reconcile_workspace": {
 		Kind:         "overlay_reconcile_workspace",
 		GoType:       "OverlayReconcileWorkspaceArgs",
-		Role:         Workspace,
+		Role:         Worker,
 		Queue:        "overlay_reconcile",
 		Timeout:      TimeoutPolicy{Fixed: 20 * time.Minute},
 		MaxAttempts:  1,
@@ -480,7 +480,7 @@ var specs = map[string]Spec{
 	"overlay_refetch": {
 		Kind:         "overlay_refetch",
 		GoType:       "OverlayRefetchArgs",
-		Role:         Workspace,
+		Role:         Worker,
 		Queue:        "default",
 		Timeout:      TimeoutPolicy{Fixed: 2 * time.Minute},
 		OptsOwner:    OptsCaller,
@@ -501,7 +501,7 @@ var specs = map[string]Spec{
 	"participant_backfill_workspace": {
 		Kind:        "participant_backfill_workspace",
 		GoType:      "ParticipantBackfillWorkspaceArgs",
-		Role:        Workspace,
+		Role:        Worker,
 		Queue:       "default",
 		Timeout:     TimeoutPolicy{Fixed: 10 * time.Minute},
 		MaxAttempts: 3,
@@ -522,7 +522,7 @@ var specs = map[string]Spec{
 	"privacy_retention_workspace": {
 		Kind:        "privacy_retention_workspace",
 		GoType:      "PrivacyRetentionWorkspaceArgs",
-		Role:        Workspace,
+		Role:        Worker,
 		Queue:       "privacy_retention",
 		Timeout:     TimeoutPolicy{Fixed: 305 * time.Minute, DerivedFrom: "privacyRetentionPassTimeout"},
 		MaxAttempts: 3,
@@ -532,7 +532,7 @@ var specs = map[string]Spec{
 	"provider_run_poll": {
 		Kind:         "provider_run_poll",
 		GoType:       "ProviderRunPollArgs",
-		Role:         Workspace,
+		Role:         Worker,
 		Queue:        "default",
 		Timeout:      TimeoutPolicy{Fixed: 2 * time.Minute},
 		MaxAttempts:  3,
@@ -555,7 +555,7 @@ var specs = map[string]Spec{
 	"provider_run_submit": {
 		Kind:         "provider_run_submit",
 		GoType:       "ProviderRunSubmitArgs",
-		Role:         Workspace,
+		Role:         Worker,
 		Queue:        "default",
 		Timeout:      TimeoutPolicy{Fixed: 2 * time.Minute},
 		OptsOwner:    OptsArgs,
@@ -576,7 +576,7 @@ var specs = map[string]Spec{
 	"signal_scan_workspace": {
 		Kind:        "signal_scan_workspace",
 		GoType:      "SignalScanWorkspaceArgs",
-		Role:        Workspace,
+		Role:        Worker,
 		Queue:       "ai_capture",
 		Timeout:     TimeoutPolicy{Fixed: 20 * time.Minute},
 		MaxAttempts: 3,
@@ -586,7 +586,7 @@ var specs = map[string]Spec{
 	"site_deep_read": {
 		Kind:         "site_deep_read",
 		GoType:       "SiteDeepReadArgs",
-		Role:         Workspace,
+		Role:         Worker,
 		Queue:        "deep_read",
 		Timeout:      TimeoutPolicy{OperatorField: "DeepReadCaps"},
 		OptsOwner:    OptsCaller,
@@ -596,7 +596,7 @@ var specs = map[string]Spec{
 	"telegram_ingest": {
 		Kind:      "telegram_ingest",
 		GoType:    "TelegramIngestArgs",
-		Role:      Workspace,
+		Role:      Worker,
 		Queue:     "default",
 		Timeout:   TimeoutPolicy{Fixed: 2 * time.Minute},
 		OptsOwner: OptsCaller,
@@ -605,7 +605,7 @@ var specs = map[string]Spec{
 	"telegram_poll": {
 		Kind:         "telegram_poll",
 		GoType:       "TelegramPollArgs",
-		Role:         Workspace,
+		Role:         Worker,
 		Queue:        "default",
 		Timeout:      TimeoutPolicy{Fixed: 2 * time.Minute, DerivedFrom: "telegramPollJobTimeout"},
 		OptsOwner:    OptsArgs,
@@ -638,7 +638,7 @@ var specs = map[string]Spec{
 	"time_scan_workspace": {
 		Kind:        "time_scan_workspace",
 		GoType:      "TimeScanWorkspaceArgs",
-		Role:        Workspace,
+		Role:        Worker,
 		Queue:       "default",
 		Timeout:     TimeoutPolicy{Fixed: 10 * time.Minute},
 		MaxAttempts: 3,
@@ -648,7 +648,7 @@ var specs = map[string]Spec{
 	"voice_build": {
 		Kind:         "voice_build",
 		GoType:       "VoiceBuildArgs",
-		Role:         Workspace,
+		Role:         Worker,
 		Queue:        "default",
 		Timeout:      TimeoutPolicy{Fixed: 10 * time.Minute, DerivedFrom: "voiceBuildTimeout"},
 		OptsOwner:    OptsCaller,
@@ -682,7 +682,7 @@ var specs = map[string]Spec{
 	"webhook_retry_workspace": {
 		Kind:         "webhook_retry_workspace",
 		GoType:       "WebhookRetryWorkspaceArgs",
-		Role:         Workspace,
+		Role:         Worker,
 		Queue:        "webhook_retry",
 		Timeout:      TimeoutPolicy{Fixed: 1580 * time.Second, DerivedFrom: "webhookRetrySweepTimeout"},
 		MaxAttempts:  3,

--- a/backend/internal/platform/jobs/stats.go
+++ b/backend/internal/platform/jobs/stats.go
@@ -296,7 +296,7 @@ func statsBySweep(ctx context.Context, pool *pgxpool.Pool) ([]SweepPass, error) 
 // The kind→key pairing arrives as two aligned arrays and is JOINED against
 // rather than spliced into the SQL, so a kind name and an args key never reach
 // the statement as text. The unnest join is also what bounds the scan to the
-// declared sub-workspace kinds: a row of any other kind matches no pair and is
+// declared sub-unit kinds: a row of any other kind matches no pair and is
 // not read.
 //
 // The workspace predicate is carried over from statsBySweep unchanged, for the

--- a/backend/tools/gen-composition/extjobs.go
+++ b/backend/tools/gen-composition/extjobs.go
@@ -12,7 +12,7 @@ package main
 // and RequestedScope and must keep refusing inside a bare role binary.
 //
 // A scheduled job is TWO kinds. gen-jobs' validateCadence forbids a cadence on
-// a workspace-role kind, so a unit declares a cadenced DISPATCHER and the
+// a worker, so a unit declares a cadenced DISPATCHER and the
 // workspace CHILD it fans out to, and this reader pairs them by name:
 // ext_<ns>_<job> and ext_<ns>_<job>_ws.
 
@@ -178,7 +178,7 @@ func namespaceOf(kind string, owners map[string]string) string {
 	return ""
 }
 
-// pairExtensionKinds joins each dispatcher to the workspace child it implies,
+// pairExtensionKinds joins each dispatcher to the worker child it implies,
 // and refuses every half-declared pair. A dispatcher with no child would tick
 // and enqueue rows of a kind nothing declares; a child with no dispatcher would
 // be a worker no clock ever reaches.
@@ -195,7 +195,7 @@ func pairExtensionKinds(entries []namedExtKind, queues []string) ([]extension.Jo
 		childKind := e.kind + extension.JobKindSuffix
 		child, ok := byKind[childKind]
 		if !ok {
-			return nil, fmt.Errorf("kind %s is a dispatcher but nothing declares %s — a scheduled job is a cadenced dispatcher AND the workspace child it fans out to, because a cadence on a workspace-role kind is refused", e.kind, childKind)
+			return nil, fmt.Errorf("kind %s is a dispatcher but nothing declares %s — a scheduled job is a cadenced dispatcher AND the worker child it fans out to, because a cadence on an enqueued worker is refused", e.kind, childKind)
 		}
 		if child.def.Role != extRoleWorker {
 			return nil, fmt.Errorf("kind %s declares role %q — the child of a dispatcher does the work for one unit and its role is %q", childKind, child.def.Role, extRoleWorker)
@@ -214,13 +214,13 @@ func pairExtensionKinds(entries []namedExtKind, queues []string) ([]extension.Jo
 		}
 		// The parent must exist AND be a dispatcher. Existence alone is not the
 		// question the loop above answers: `a_ws` and `a_ws_ws` are both
-		// workspace kinds, and the second one's suffix-stripped name resolves
+		// worker kinds, and the second one's suffix-stripped name resolves
 		// to the first — so it looks claimed here while the dispatcher loop,
 		// which only ever visits dispatchers, never enqueued it. The result is
 		// a kind the contract declares, the manifest omits and nothing works.
 		parent, ok := byKind[strings.TrimSuffix(e.kind, extension.JobKindSuffix)]
 		if !ok || !strings.HasSuffix(e.kind, extension.JobKindSuffix) || parent.def.Role != extRoleDispatcher {
-			return nil, fmt.Errorf("kind %s is a workspace kind that no dispatcher fans out to — name it <dispatcher>%s and declare the dispatcher, or delete it", e.kind, extension.JobKindSuffix)
+			return nil, fmt.Errorf("kind %s is a worker that no dispatcher fans out to — name it <dispatcher>%s and declare the dispatcher, or delete it", e.kind, extension.JobKindSuffix)
 		}
 	}
 	return decls, nil
@@ -258,7 +258,7 @@ func declarationFrom(dispatcher, child namedExtKind, queues []string) (extension
 		return extension.JobDeclaration{}, fmt.Errorf("kind %s: %w", child.kind, err)
 	}
 	if child.def.Cadence != "" {
-		return extension.JobDeclaration{}, fmt.Errorf("kind %s declares a cadence — a workspace kind is enqueued by its dispatcher, never ticked", child.kind)
+		return extension.JobDeclaration{}, fmt.Errorf("kind %s declares a cadence — an enqueued worker is never ticked", child.kind)
 	}
 	if dispatcher.def.MaxAttempts != 0 {
 		return fail("declares max_attempts — the attempt cap is the CHILD's, and a dispatcher's retry is its own next tick")

--- a/backend/tools/gen-composition/extjobs.go
+++ b/backend/tools/gen-composition/extjobs.go
@@ -68,7 +68,7 @@ type extJobKind struct {
 
 const (
 	extRoleDispatcher = "dispatcher"
-	extRoleWorkspace  = "workspace"
+	extRoleWorker  = "worker"
 )
 
 // extensionJobs reads every enabled unit's scheduled jobs out of the merged
@@ -151,8 +151,8 @@ func extensionKindEntries(kinds *yaml.Node, owners map[string]string) ([]namedEx
 		// mistyped `role: dispatchr` is not refused by either — it falls out of
 		// both loops and the kind vanishes: no registration, no manifest entry,
 		// no error. A misspelling must not be able to un-declare a job.
-		if def.Role != extRoleDispatcher && def.Role != extRoleWorkspace {
-			return nil, fmt.Errorf("kind %s declares role %q — an extension job kind is %q or %q, and any other value would leave the kind declared by the contract and registered by nothing", kind, def.Role, extRoleDispatcher, extRoleWorkspace)
+		if def.Role != extRoleDispatcher && def.Role != extRoleWorker {
+			return nil, fmt.Errorf("kind %s declares role %q — an extension job kind is %q or %q, and any other value would leave the kind declared by the contract and registered by nothing", kind, def.Role, extRoleDispatcher, extRoleWorker)
 		}
 		out = append(out, namedExtKind{kind: kind, unit: unit, def: def})
 	}
@@ -197,8 +197,8 @@ func pairExtensionKinds(entries []namedExtKind, queues []string) ([]extension.Jo
 		if !ok {
 			return nil, fmt.Errorf("kind %s is a dispatcher but nothing declares %s — a scheduled job is a cadenced dispatcher AND the workspace child it fans out to, because a cadence on a workspace-role kind is refused", e.kind, childKind)
 		}
-		if child.def.Role != extRoleWorkspace {
-			return nil, fmt.Errorf("kind %s declares role %q — the child of a dispatcher carries one tenant's pass and its role is %q", childKind, child.def.Role, extRoleWorkspace)
+		if child.def.Role != extRoleWorker {
+			return nil, fmt.Errorf("kind %s declares role %q — the child of a dispatcher does the work for one unit and its role is %q", childKind, child.def.Role, extRoleWorker)
 		}
 		d, err := declarationFrom(e, child, queues)
 		if err != nil {
@@ -209,7 +209,7 @@ func pairExtensionKinds(entries []namedExtKind, queues []string) ([]extension.Jo
 	// Every child must have been claimed by the loop above; one that was not is
 	// a worker nothing schedules.
 	for _, e := range entries {
-		if e.def.Role != extRoleWorkspace {
+		if e.def.Role != extRoleWorker {
 			continue
 		}
 		// The parent must exist AND be a dispatcher. Existence alone is not the

--- a/backend/tools/gen-composition/extjobs_test.go
+++ b/backend/tools/gen-composition/extjobs_test.go
@@ -114,7 +114,7 @@ func TestExtensionJobsRefusesTheShapesAFragmentMustNotPublish(t *testing.T) {
 			want: "no dispatcher fans out to",
 		},
 		{
-			name:  "a cadence on the workspace kind",
+			name:  "a cadence on the worker kind",
 			kinds: wellFormedPair + "    cadence: 1h\n",
 			want:  "declares a cadence",
 		},
@@ -171,7 +171,7 @@ func TestExtensionJobsRefusesTheShapesAFragmentMustNotPublish(t *testing.T) {
 			// suffix-stripped lookup finds an entry and the claim check passed
 			// — while the dispatcher loop, which only visits dispatchers, never
 			// enqueued it.
-			name:  "a workspace child hanging off a workspace kind",
+			name:  "a worker child hanging off a worker kind",
 			kinds: wellFormedPair + strings.ReplaceAll(wellFormedPair[strings.Index(wellFormedPair, "  ext_demo_refresh_ws:"):], "ext_demo_refresh_ws", "ext_demo_refresh_ws_ws"),
 			want:  "no dispatcher fans out to",
 		},

--- a/backend/tools/gen-composition/extjobs_test.go
+++ b/backend/tools/gen-composition/extjobs_test.go
@@ -40,7 +40,7 @@ const wellFormedPair = `
     scope: read
   ext_demo_refresh_ws:
     job: refresh
-    role: workspace
+    role: worker
     queue: default
     timeout: 5m
     max_attempts: 3
@@ -106,7 +106,7 @@ func TestExtensionJobsRefusesTheShapesAFragmentMustNotPublish(t *testing.T) {
 			kinds: `
   ext_demo_orphan_ws:
     job: orphan
-    role: workspace
+    role: worker
     queue: default
     timeout: 5m
     max_attempts: 3
@@ -212,7 +212,7 @@ func TestExtensionJobsAttributesAKindToTheLongestOwnedNamespace(t *testing.T) {
     scope: read
   ext_a_b_refresh_ws:
     job: refresh
-    role: workspace
+    role: worker
     queue: default
     timeout: 5m
     max_attempts: 3

--- a/backend/tools/gen-jobs/emitkinds.go
+++ b/backend/tools/gen-jobs/emitkinds.go
@@ -122,7 +122,7 @@ func writeRoleAssertions(b *strings.Builder, c contract) {
 	b.WriteString("// pass and says which in its own args.\n")
 	b.WriteString("var (\n")
 	for _, name := range c.sortedKinds() {
-		if def := c.Kinds[name]; def.Role == roleWorkspace {
+		if def := c.Kinds[name]; def.Role == roleWorker {
 			fmt.Fprintf(b, "\t_ jobs.WorkspaceScoped = %s{}\n", def.GoType)
 		}
 	}

--- a/backend/tools/gen-jobs/emitspecs.go
+++ b/backend/tools/gen-jobs/emitspecs.go
@@ -167,7 +167,7 @@ func timeoutLiteral(t timeoutDef) string {
 }
 
 // cadenceLiteral returns "" only for a kind that has no schedule to declare —
-// a workspace kind, which is enqueued by its dispatcher and never ticked. A
+// a worker, which is enqueued by its dispatcher and never ticked. A
 // dispatcher a human's confirm enqueues renders {OnDemand: true} instead: the
 // compiled table is what every consumer reads, and a dropped field would make
 // a deliberate absence indistinguishable from a schedule someone lost.

--- a/backend/tools/gen-jobs/emitspecs.go
+++ b/backend/tools/gen-jobs/emitspecs.go
@@ -124,7 +124,7 @@ func roleConst(role string) string {
 	if role == roleDispatcher {
 		return "Dispatcher"
 	}
-	return "Workspace"
+	return "Worker"
 }
 
 func unitConst(unit string) string {

--- a/backend/tools/gen-jobs/main_test.go
+++ b/backend/tools/gen-jobs/main_test.go
@@ -33,7 +33,7 @@ func TestParseRejectsAWorkspaceKindWithNoTimeout(t *testing.T) {
 	mustFail(t, validQueues+`
 kinds:
   foo_workspace:
-    role: workspace
+    role: worker
     go_type: FooWorkspaceArgs
     queue: default
     opts_owner: fan_out
@@ -54,7 +54,7 @@ kinds:
     fans_out_to: foo_workspace
     fan_out_unit: workspace
   foo_workspace:
-    role: workspace
+    role: worker
     go_type: FooWorkspaceArgs
     queue: default
     timeout: 2m
@@ -89,7 +89,7 @@ kinds:
     fans_out_to: foo_workspace
     fan_out_unit: workspace
   foo_workspace:
-    role: workspace
+    role: worker
     go_type: FooWorkspaceArgs
     queue: default
     timeout: 2m
@@ -101,7 +101,7 @@ func TestParseRejectsMaxAttemptsOnAKindTheFileDoesNotGovern(t *testing.T) {
 	mustFail(t, validQueues+`
 kinds:
   foo_workspace:
-    role: workspace
+    role: worker
     go_type: FooWorkspaceArgs
     queue: default
     timeout: 2m
@@ -119,7 +119,7 @@ func TestParseRejectsAFanOutChildWithNoMaxAttempts(t *testing.T) {
 	mustFail(t, validQueues+`
 kinds:
   foo_workspace:
-    role: workspace
+    role: worker
     go_type: FooWorkspaceArgs
     queue: default
     timeout: 2m
@@ -160,7 +160,7 @@ kinds:
     cadence: 24h
     fans_out_to: foo_workspace
   foo_workspace:
-    role: workspace
+    role: worker
     go_type: FooWorkspaceArgs
     queue: default
     timeout: 2m
@@ -195,7 +195,7 @@ kinds:
     fans_out_to: shared_child
     fan_out_unit: connection
   shared_child:
-    role: workspace
+    role: worker
     go_type: SharedChildArgs
     queue: default
     timeout: 2m
@@ -227,7 +227,7 @@ kinds:
     fans_out_to: shared_child
     fan_out_unit: workspace
   shared_child:
-    role: workspace
+    role: worker
     go_type: SharedChildArgs
     queue: default
     timeout: 2m
@@ -248,7 +248,7 @@ kinds:
     fans_out_to: foo_workspace
     fan_out_unit: tenant
   foo_workspace:
-    role: workspace
+    role: worker
     go_type: FooWorkspaceArgs
     queue: default
     timeout: 2m
@@ -260,13 +260,13 @@ func TestParseRejectsADuplicateKindString(t *testing.T) {
 	mustFail(t, validQueues+`
 kinds:
   foo_workspace:
-    role: workspace
+    role: worker
     go_type: FooWorkspaceArgs
     queue: default
     timeout: 2m
     opts_owner: caller
   foo_workspace:
-    role: workspace
+    role: worker
     go_type: OtherWorkspaceArgs
     queue: default
     timeout: 5m
@@ -294,7 +294,7 @@ func TestParseRejectsAnUnknownKeyInsideACustomDecodedBlock(t *testing.T) {
 			src: `
 kinds:
   foo_workspace:
-    role: workspace
+    role: worker
     go_type: FooWorkspaceArgs
     queue: default
     timeout: 2m
@@ -308,7 +308,7 @@ kinds:
 			src: `
 kinds:
   foo_workspace:
-    role: workspace
+    role: worker
     go_type: FooWorkspaceArgs
     queue: default
     timeout: {none: true, resaon: bounded by a backlog, not a wall clock}
@@ -321,7 +321,7 @@ kinds:
 			src: `
 kinds:
   foo_workspace:
-    role: workspace
+    role: worker
     go_type: FooWorkspaceArgs
     queue: default
     timeout: 2m
@@ -354,7 +354,7 @@ kinds:
     fans_out_to: foo_workspace
     fan_out_unit: workspace
   foo_workspace:
-    role: workspace
+    role: worker
     go_type: FooWorkspaceArgs
     queue: default
     timeout: 2m
@@ -370,7 +370,7 @@ func TestParseRejectsASecondDocument(t *testing.T) {
 	mustFail(t, validQueues+`
 kinds:
   foo_workspace:
-    role: workspace
+    role: worker
     go_type: FooWorkspaceArgs
     queue: default
     timeout: 2m
@@ -378,7 +378,7 @@ kinds:
 ---
 kinds:
   bar_workspace:
-    role: workspace
+    role: worker
     go_type: BarWorkspaceArgs
     queue: default
     timeout: 2m
@@ -390,13 +390,13 @@ func TestParseRejectsTwoKindsSharingOneGoType(t *testing.T) {
 	mustFail(t, validQueues+`
 kinds:
   foo_workspace:
-    role: workspace
+    role: worker
     go_type: FooWorkspaceArgs
     queue: default
     timeout: 2m
     opts_owner: caller
   bar_workspace:
-    role: workspace
+    role: worker
     go_type: FooWorkspaceArgs
     queue: default
     timeout: 2m
@@ -408,7 +408,7 @@ func TestParseRejectsADerivedTimeoutWithNoValue(t *testing.T) {
 	mustFail(t, validQueues+`
 kinds:
   foo_workspace:
-    role: workspace
+    role: worker
     go_type: FooWorkspaceArgs
     queue: default
     timeout: {derived: fooPassTimeout}
@@ -437,25 +437,25 @@ kinds:
 const fourForms = validQueues + `
 kinds:
   a_workspace:
-    role: workspace
+    role: worker
     go_type: AWorkspaceArgs
     queue: default
     timeout: 90s
     opts_owner: caller
   b_workspace:
-    role: workspace
+    role: worker
     go_type: BWorkspaceArgs
     queue: default
     timeout: {derived: bPassTimeout, value: 26m20s}
     opts_owner: caller
   c_workspace:
-    role: workspace
+    role: worker
     go_type: CWorkspaceArgs
     queue: default
     timeout: {operator: SomeCaps}
     opts_owner: caller
   d_workspace:
-    role: workspace
+    role: worker
     go_type: DWorkspaceArgs
     queue: default
     timeout: {none: true, reason: "bounded by a backlog, not a wall clock"}
@@ -589,7 +589,7 @@ kinds:
     fans_out_to: a_kind
     fan_out_unit: workspace
   a_kind:
-    role: workspace
+    role: worker
     go_type: AKindArgs
     queue: default
     timeout: 2m
@@ -632,7 +632,7 @@ func TestParseRejectsAFaultWaiverWithNoRationale(t *testing.T) {
 	mustFail(t, validQueues+`
 kinds:
   foo:
-    role: workspace
+    role: worker
     go_type: FooArgs
     queue: default
     timeout: 2m
@@ -647,7 +647,7 @@ func TestParseRejectsAScalarArgsFieldWithNoReason(t *testing.T) {
 	mustFail(t, validQueues+`
 kinds:
   foo:
-    role: workspace
+    role: worker
     go_type: FooArgs
     queue: default
     timeout: 2m
@@ -663,7 +663,7 @@ func TestParseRejectsAnEmptyArgsFieldMapping(t *testing.T) {
 	mustFail(t, validQueues+`
 kinds:
   foo:
-    role: workspace
+    role: worker
     go_type: FooArgs
     queue: default
     timeout: 2m
@@ -681,7 +681,7 @@ func TestParseAcceptsAReasonOnAnIdField(t *testing.T) {
 	c, err := parseContract([]byte(validQueues + `
 kinds:
   foo:
-    role: workspace
+    role: worker
     go_type: FooArgs
     queue: default
     timeout: 2m
@@ -709,7 +709,7 @@ func TestParseRejectsAnUnexportedArgsFieldName(t *testing.T) {
 	mustFail(t, validQueues+`
 kinds:
   foo:
-    role: workspace
+    role: worker
     go_type: FooArgs
     queue: default
     timeout: 2m
@@ -726,7 +726,7 @@ func TestParseAcceptsTheIdShorthandAndAnArguedScalar(t *testing.T) {
 	c, err := parseContract([]byte(validQueues + `
 kinds:
   foo:
-    role: workspace
+    role: worker
     go_type: FooArgs
     queue: default
     timeout: 2m

--- a/backend/tools/gen-jobs/main_test.go
+++ b/backend/tools/gen-jobs/main_test.go
@@ -572,7 +572,7 @@ func TestEmitRendersTheDeclarationsAConsumerReads(t *testing.T) {
 	}
 
 	if block := specBlock(t, src, "a_workspace"); strings.Contains(block, "Cadence{") {
-		t.Errorf("a_workspace rendered as:\n%s\na workspace kind is enqueued by its dispatcher and never ticked, so it must carry no cadence at all", block)
+		t.Errorf("a_workspace rendered as:\n%s\na worker enqueued by a dispatcher is never ticked, so it must carry no cadence at all", block)
 	}
 }
 

--- a/backend/tools/gen-jobs/validate.go
+++ b/backend/tools/gen-jobs/validate.go
@@ -285,11 +285,11 @@ func (c contract) validateFanOut(name string, def kindDef) error {
 }
 
 // validateCadence holds the schedule to the role: a dispatcher is ticked and a
-// workspace kind is enqueued, and neither may claim the other's posture.
+// worker is enqueued, and neither may claim the other's posture.
 func (c contract) validateCadence(name string, def kindDef) error {
 	if def.Role != roleDispatcher {
 		if def.Cadence != nil {
-			return fmt.Errorf("kind %q: declares a cadence but its role is %q — a workspace kind is enqueued by its dispatcher, never ticked", name, def.Role)
+			return fmt.Errorf("kind %q: declares a cadence but its role is %q — an enqueued worker is never ticked", name, def.Role)
 		}
 		return nil
 	}

--- a/backend/tools/gen-jobs/validate.go
+++ b/backend/tools/gen-jobs/validate.go
@@ -18,7 +18,7 @@ import (
 // one is a change to what a job IS, and it has to land in both places at once.
 const (
 	roleDispatcher = "dispatcher"
-	roleWorkspace  = "workspace"
+	roleWorker  = "worker"
 
 	unitWorkspace  = "workspace"
 	unitConnection = "connection"
@@ -50,7 +50,7 @@ const (
 )
 
 var (
-	roles     = map[string]bool{roleDispatcher: true, roleWorkspace: true}
+	roles     = map[string]bool{roleDispatcher: true, roleWorker: true}
 	fanUnits  = map[string]bool{unitWorkspace: true, unitConnection: true, unitBuild: true}
 	optsOwner = map[string]bool{optsFanOut: true, optsArgs: true, optsCaller: true}
 
@@ -126,7 +126,7 @@ func (c contract) validateKind(name string, def kindDef) error {
 		return fmt.Errorf("kind %q: name must match %s — River persists it in river_job.kind", name, kindNameRE)
 	}
 	if !roles[def.Role] {
-		return fmt.Errorf("kind %q: role must be %q or %q, got %q", name, roleDispatcher, roleWorkspace, def.Role)
+		return fmt.Errorf("kind %q: role must be %q or %q, got %q", name, roleDispatcher, roleWorker, def.Role)
 	}
 	if !goTypeRE.MatchString(def.GoType) {
 		return fmt.Errorf("kind %q: go_type %q must match %s — it names the compose args struct", name, def.GoType, goTypeRE)
@@ -278,8 +278,8 @@ func (c contract) validateFanOut(name string, def kindDef) error {
 	if !ok {
 		return fmt.Errorf("kind %q: fans_out_to %q, which no kinds: entry declares", name, def.FansOutTo)
 	}
-	if child.Role != roleWorkspace {
-		return fmt.Errorf("kind %q: fans_out_to %q, whose role is %q — a fan-out child carries one tenant's pass", name, def.FansOutTo, child.Role)
+	if child.Role != roleWorker {
+		return fmt.Errorf("kind %q: fans_out_to %q, whose role is %q — a fan-out child does the work for one unit", name, def.FansOutTo, child.Role)
 	}
 	return nil
 }

--- a/docs/explanation/extensibility.md
+++ b/docs/explanation/extensibility.md
@@ -265,7 +265,7 @@ validated to the full identifier budget, so a name chosen today stays valid for 
 - **Its own governed tools** — an `x-mcp-tool` verb on a declared operation, served through the same
   admission gate a core tool passes, at the tier and scope the contract declares.
 - **Its own scheduled jobs** — declared in a `jobs.yaml` fragment, dispatched as a fleet fan-out with a
-  workspace child per live tenant.
+  worker child per live tenant.
 - **Its own secret namespace** — reached through `Runtime.Secrets()`, keyed by the unit's own bare names.
 - **Its own RBAC objects** — `ext_<name>_*`, registered into the vocabulary `/me` serves.
 - **Its own history and its own events** — `tx.Record(ctx, change, event)` writes the ledger row AND

--- a/docs/explanation/job-fleet.md
+++ b/docs/explanation/job-fleet.md
@@ -8,7 +8,7 @@ That contract has two halves. Every job kind is **declared** in `backend/api/job
 exists in code — and the declaration is what the running system obeys, so a worker cannot choose its
 own timeout, its own queue or its own attempt cap. And every fleet-wide pass is **two** kinds: a
 dispatcher that enumerates the fleet (the "fleet" is every workspace on the installation) and
-enqueues, plus a workspace kind that carries exactly one tenant's work.
+enqueues, plus a worker that carries exactly one unit's work.
 
 This is the deep reference. To *add* a job, jump to [how-to/add-a-job.md](../how-to/add-a-job.md);
 for the operator's reading of the same fleet, see
@@ -80,7 +80,7 @@ Five fields are declared for **every** kind:
 Three more are **conditional on what the kind is**, and generation refuses the mismatch in both
 directions — a field owed and absent fails, and a field declared where it means nothing fails too:
 
-- **`cadence`** — required on a dispatcher, refused on a workspace kind (*"a workspace kind is
+- **`cadence`** — required on a dispatcher, refused on an enqueued worker (*"an enqueued worker is
   enqueued by its dispatcher, never ticked"*). Exactly one of a duration, `{operator: Field}` naming
   the `JobRunnerConfig` dial the number comes from, or `on_demand`. `on_demand` is a *declaration*,
   not an absence: `embed_reindex` is enqueued by a human's confirm and by no clock, and an absent

--- a/docs/explanation/job-fleet.md
+++ b/docs/explanation/job-fleet.md
@@ -32,7 +32,7 @@ backend/api/jobs.yaml
         │  enumerate the fleet — compose/dispatch.go, the ONE scan
         │  dispatchPerWorkspace | dispatchWith | dispatchOne
         ▼  one child per fan-out UNIT, one InsertMany, tagged `sweep`
-   WORKSPACE row × N         role: workspace    ·   jobs.WorkspaceScoped
+   WORKER row × N            role: worker       ·   jobs.WorkspaceScoped
         │  workspaceJobCtx binds args.WorkspaceID() → app.workspace_id (RLS)
         │  Work(…) ──► jobs.FaultContext(ctx, err)
         ▼
@@ -88,7 +88,7 @@ directions — a field owed and absent fails, and a field declared where it mean
   third posture — the workers stay registered and only the tick goes away.
 - **`fans_out_to` + `fan_out_unit`** — one declaration, never one without the other. Required on a
   dispatcher (*"a dispatcher that fans out to nothing … does no work at all"*), refused elsewhere,
-  and the named child must itself be `role: workspace`. The unit is `workspace`, `connection` or
+  and the named child must itself be `role: worker`. The unit is `workspace`, `connection` or
   `build`, and it is what makes a child row readable: a `gmail_watch_renew_connection` row is one
   *connection's* renewal, not one tenant's. The unit is declared on the **dispatcher**, beside the
   edge it names, because that is where the fan-out decision is made.
@@ -221,7 +221,7 @@ workspace-scoped — and there is no third role. A third would be a change to wh
 data: both operational surfaces read `Role` to decide whether a null `args->>'workspace_id'` is
 correct or a defect.
 
-**The biconditional.** `role: workspace` ⟺ the args type implements `jobs.WorkspaceScoped`, and
+**The biconditional.** `role: worker` ⟺ the args type implements `jobs.WorkspaceScoped`, and
 `role: dispatcher` ⟺ it implements `jobs.FleetWide`. Generation emits one `var _ jobs.FleetWide =
 XArgs{}` / `var _ jobs.WorkspaceScoped = XArgs{}` line per kind, so a *declared* kind's role is the
 compiler's to check. Two halves the generated assertions provably cannot reach are gates instead: a

--- a/docs/explanation/job-fleet.md
+++ b/docs/explanation/job-fleet.md
@@ -63,7 +63,7 @@ Five fields are declared for **every** kind:
 
 | Field | Meaning |
 |---|---|
-| `role` | `dispatcher` or `workspace` — §4. Held to the Go marker interface by a generated assertion |
+| `role` | `dispatcher` or `worker` — §4. Held to the Go marker interface by a generated assertion |
 | `go_type` | the compose args struct that returns this kind (`^[A-Z][A-Za-z0-9]*Args$`). Carried as data, not as an import, so a gate can assert the kind↔type pairing still holds |
 | `queue` | must name an entry in the file's own `queues:` block; every non-`default` queue owes a `reason` for having been split out of the default pool |
 | `timeout` | the whole-job wall clock — §3. There is **no default** |
@@ -216,8 +216,8 @@ type FleetWide interface {
 }
 ```
 
-The contract declares **fifty-five** kinds today — twenty-four dispatchers and thirty-one
-workspace-scoped — and there is no third role. A third would be a change to what a job *is*, not
+The contract declares **sixty-two** kinds today — twenty-seven dispatchers and thirty-five
+workers — and there is no third role. A third would be a change to what a job *is*, not
 data: both operational surfaces read `Role` to decide whether a null `args->>'workspace_id'` is
 correct or a defect.
 

--- a/docs/how-to/add-a-job.md
+++ b/docs/how-to/add-a-job.md
@@ -165,7 +165,7 @@ The failures you are most likely to meet, in the order you would meet them:
 | Where | Message | What it means |
 |---|---|---|
 | `make gen` | `kind "x": declares no timeout — an absent one is River's silent 1-minute default, which is what this contract removes` | Pick one of the four `timeout` forms. There is no default and absence is not one of them |
-| `make gen` | `kind "x": is a dispatcher that fans out to nothing` / `fans_out_to "y", whose role is "dispatcher"` | A dispatcher must declare `fans_out_to` + `fan_out_unit`, and the child must be `role: workspace` |
+| `make gen` | `kind "x": is a dispatcher that fans out to nothing` / `fans_out_to "y", whose role is "dispatcher"` | A dispatcher must declare `fans_out_to` + `fan_out_unit`, and the child must be `role: worker` |
 | `make gen` | `kind "x": declares a cadence but its role is "workspace"` | A workspace kind is enqueued by its dispatcher, never ticked. Move the cadence to the dispatcher |
 | `make gen` | `kind "x": opts_owner is fan_out but no max_attempts is declared` | The fan-out helper reads that number and nothing else supplies it; its absence is River's silent 25-rung ladder |
 | `make gen` | `kind "x": args field "F" is declared a scalar with no reason` | A value that is not an id must say why it is safe in a table Art. 17 erasure never reaches |

--- a/docs/how-to/add-a-job.md
+++ b/docs/how-to/add-a-job.md
@@ -10,7 +10,7 @@ file has never heard of does not compile. For *why* it works this way, see
 writes through, see [explanation/write-backbone.md](../explanation/write-backbone.md).
 
 Most new work is **two** kinds, not one: a dispatcher that enumerates the fleet and enqueues, and a
-workspace kind that does one tenant's work. Declare both.
+worker that does the work. Declare both.
 
 ## Steps
 
@@ -46,12 +46,12 @@ workspace kind that does one tenant's work. Declare both.
    two files (never hand-edit either): `backend/internal/platform/jobs/specs_gen.go`, the Spec table every
    reader walks, and `backend/internal/compose/jobkinds_gen.go`, the closed `declaredJobArgs` union plus one
    compile-time role assertion per kind. This step fails loudly on a contract that cannot hold — a
-   missing timeout, a fan-out to a kind nobody declares, a cadence on a workspace kind.
+   missing timeout, a fan-out to a kind nobody declares, a cadence on an enqueued worker.
 
    The build does **not** compile yet: the generated assertions name args types you have not written.
 
 3. **Write the args type** — in the matching `backend/internal/compose/jobs_<concern>.go` (create one for a
-   new concern). A workspace kind carries its tenant in a field named `Workspace`, because Go forbids
+   new concern). A tenant-scoped worker carries its tenant in a field named `Workspace`, because Go forbids
    a method and a field of the same name, and the wire key is fixed:
 
    ```go
@@ -166,7 +166,7 @@ The failures you are most likely to meet, in the order you would meet them:
 |---|---|---|
 | `make gen` | `kind "x": declares no timeout — an absent one is River's silent 1-minute default, which is what this contract removes` | Pick one of the four `timeout` forms. There is no default and absence is not one of them |
 | `make gen` | `kind "x": is a dispatcher that fans out to nothing` / `fans_out_to "y", whose role is "dispatcher"` | A dispatcher must declare `fans_out_to` + `fan_out_unit`, and the child must be `role: worker` |
-| `make gen` | `kind "x": declares a cadence but its role is "workspace"` | A workspace kind is enqueued by its dispatcher, never ticked. Move the cadence to the dispatcher |
+| `make gen` | `kind "x": declares a cadence but its role is "worker"` | An enqueued worker is never ticked. Move the cadence to the dispatcher |
 | `make gen` | `kind "x": opts_owner is fan_out but no max_attempts is declared` | The fan-out helper reads that number and nothing else supplies it; its absence is River's silent 25-rung ladder |
 | `make gen` | `kind "x": args field "F" is declared a scalar with no reason` | A value that is not an id must say why it is safe in a table Art. 17 erasure never reaches |
 | `go build` | `CloseDateWorkspaceArgs does not satisfy declaredJobArgs` | The kind is not in `api/jobs.yaml`, or you have not run `make gen` since declaring it |

--- a/docs/how-to/add-a-job.md
+++ b/docs/how-to/add-a-job.md
@@ -17,7 +17,7 @@ worker that does the work. Declare both.
 1. **Declare the kind** — `backend/api/jobs.yaml`, under `kinds:`, alphabetically. Five fields are
    required of every kind:
 
-   - **`role`** — `dispatcher` or `workspace`.
+   - **`role`** — `dispatcher` or `worker`.
    - **`go_type`** — the compose args struct that returns this kind; must match
      `^[A-Z][A-Za-z0-9]*Args$` and be unique across the file (one args struct is one River kind).
    - **`queue`** — must name an entry in the file's own `queues:` block. Reuse `default` unless the

--- a/docs/how-to/add-an-extension.md
+++ b/docs/how-to/add-an-extension.md
@@ -395,7 +395,7 @@ carries a tenant is refused — it has no honest answer for whose data the tick 
 
 Which half declares what is a rule, not a convention, and the composer refuses the other spellings:
 
-- **`role` is `dispatcher` or `workspace`, exactly.** A mistyped third value used to match neither
+- **`role` is `dispatcher` or `worker`, exactly.** A mistyped third value used to match neither
   arm of the pairing and quietly *un-declare* the kind: no registration, no manifest entry, no error.
 - **Governance is the dispatcher's.** `tier` and `scope` go on the dispatcher and nowhere else — the
   pair resolves as one governed job, so a second copy on the child is a line an author writes, a

--- a/docs/how-to/add-an-extension.md
+++ b/docs/how-to/add-an-extension.md
@@ -400,10 +400,10 @@ Which half declares what is a rule, not a convention, and the composer refuses t
 - **Governance is the dispatcher's.** `tier` and `scope` go on the dispatcher and nowhere else — the
   pair resolves as one governed job, so a second copy on the child is a line an author writes, a
   reviewer reads, an operator resolves against, and the runtime never applies.
-- **`cadence` is the dispatcher's; `max_attempts` is the child's.** A cadence on a workspace kind and
+- **`cadence` is the dispatcher's; `max_attempts` is the child's.** A cadence on an enqueued worker and
   an attempt cap on a dispatcher are both refused; a dispatcher's retry *is* its next tick.
 - **Both halves share one queue**, and the child's kind is the dispatcher's name plus `_ws` — a
-  workspace kind no dispatcher fans out to is a worker no clock ever reaches.
+  worker no dispatcher fans out to is one no clock ever reaches.
 
 ```go
 Jobs: []extension.Job{{Name: "heartbeat", Handle: heartbeat}},

--- a/extensions/dispact-connector/api/jobs.yaml
+++ b/extensions/dispact-connector/api/jobs.yaml
@@ -42,7 +42,7 @@ actions:
   - target: $.kinds['ext_dispact_connector_poll_inbox_ws']
     update:
       job: poll_inbox
-      role: workspace
+      role: worker
       queue: default
       timeout: 300s
       # Small on purpose, like every other fan-out child's: the real retry

--- a/extensions/notes/api/jobs.yaml
+++ b/extensions/notes/api/jobs.yaml
@@ -41,7 +41,7 @@ actions:
   - target: $.kinds['ext_notes_heartbeat_ws']
     update:
       job: heartbeat
-      role: workspace
+      role: worker
       queue: default
       timeout: 30s
       # Small on purpose, like every other fan-out child's: the real retry


### PR DESCRIPTION
First step of the fleet collapse decided in **ADR-0103 / A154**, done on its own so the collapses that follow are about *jobs* rather than about vocabulary.

**Nothing changes at runtime**: the same 62 kinds, the same schedules, the same generated registry shape. What changes is what the second role is *named* — and the name is about to stop being true. A job whose whole identity was "one tenant's pass" becomes, module by module, a job that does the work for a **connection**, a **build**, or for the **installation itself**.

`role: workspace` was accepted in three manifests (the installation's and both first-party extensions'), validated in two generators, asserted by the census and kind gates, and drawn in two docs pages. They all move together, and the drift gate holds the generated output equal.

**`fan_out_unit: workspace` deliberately stays.** It is still true of the 23 dispatchers that have not collapsed yet, and retiring it while they exist would leave the manifest describing a fan-out it cannot name. It goes with the last of them.

`make check-backend` green; `make test-integration` OK, 0 skips, 40 packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renames the second job role from “workspace” to “worker” per ADR‑0103 §2 so the name matches upcoming non‑tenant units. Old: role: workspace and `jobs.Workspace`; new: role: worker and `jobs.Worker`. Runtime behavior and the 62 kinds/schedules are unchanged.

- Contract and generated tables now emit role: worker; table hashes change only due to the rename.
- Replaces the `jobs.Role` constant `Workspace` with `Worker`; `jobs.WorkspaceScoped` and the `Workspace` args field stay as the tenant scope.
- Aligns generators, validators, tests, and first‑party extension manifests; examples and error messages now say “worker”.
- Updates author‑facing docs (job recipe, extension recipe, fleet reference) to use role: worker and correct the kind counts.
- Keeps `fan_out_unit: workspace` until the remaining dispatchers collapse.

- Required migration:
  - Replace role: workspace with role: worker in any out‑of‑tree job manifests and extensions.
  - Update references to `jobs.Workspace` to `jobs.Worker`; no changes are needed to args types implementing `jobs.WorkspaceScoped`.

<sup>Written for commit 92f1d666a49fa6b68f8063370025755f1d081bd4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1240?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Renamed the `workspace` job role to `worker` across job definitions and validation.
  * Dispatcher child jobs must now declare `role: worker`.

* **Documentation**
  * Updated job-fleet, extension, and job-authoring guidance to reflect worker terminology and fan-out requirements.

* **Bug Fixes**
  * Improved consistency when composing, validating, generating, and scheduling worker job specifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->