### PR TITLE
test(person): the story catalog renders the states the contact page has

### DIFF
--- a/frontend/src/screens/people.stories.tsx
+++ b/frontend/src/screens/people.stories.tsx
@@ -2,8 +2,11 @@
 // SPDX-FileCopyrightText: 2026 Gradion
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { components } from "../api/schema";
 import { ContactsScreen, PersonScreen } from "./people";
 import { installFetchStub, jsonResponse, StoryProviders } from "./story-utils";
+
+type Person = components["schemas"]["Person"];
 
 // ContactsScreen (list) and PersonScreen (360 Overview) both read through
 // the api client on mount — fixtures mirror people.test.tsx's `anna` +
@@ -51,6 +54,138 @@ export const ContactsList: Story = {
   },
 };
 
+// The empty list: no rows, the "unit.contacts" copy from ListSurface's
+// generic empty branch (table.none), nothing else on the page to distract
+// from it.
+export const ContactsListEmpty: Story = {
+  render: () => {
+    installFetchStub({
+      "GET /people": () =>
+        jsonResponse({
+          data: [],
+          page: { next_cursor: null, has_more: false },
+        }),
+    });
+    return (
+      <StoryProviders>
+        <ContactsScreen />
+      </StoryProviders>
+    );
+  },
+};
+
+// A never-resolving GET is the house pattern for a pending story: the query
+// never settles, so ListTable stays on its skeleton rows rather than racing
+// a timer against Storybook's own render.
+export const ContactsListLoading: Story = {
+  render: () => {
+    installFetchStub({
+      "GET /people": () => new Promise<Response>(() => undefined),
+    });
+    return (
+      <StoryProviders>
+        <ContactsScreen />
+      </StoryProviders>
+    );
+  },
+};
+
+// A non-2xx body is what useListQuery's isError branch renders: the problem
+// detail plus the retry button (listquery.tsx's `problem` slot), never a
+// thrown exception the story would surface as a broken render instead.
+export const ContactsListFailed: Story = {
+  render: () => {
+    installFetchStub({
+      "GET /people": () =>
+        jsonResponse(
+          { title: "Forbidden", detail: "missing scope people:read" },
+          403,
+        ),
+    });
+    return (
+      <StoryProviders>
+        <ContactsScreen />
+      </StoryProviders>
+    );
+  },
+};
+
+// has_more: true with a next_cursor is what lights the pager's "next" button
+// even though only one page has loaded yet (design-system/listtable.tsx's
+// Pager: `disabled={current === lastPage && !hasMore}`), so the load-more
+// affordance is that button, not a separate control.
+export const ContactsListMorePages: Story = {
+  render: () => {
+    installFetchStub({
+      "GET /people": () =>
+        jsonResponse({
+          data: [anna],
+          page: { next_cursor: "cursor-2", has_more: true },
+        }),
+    });
+    return (
+      <StoryProviders>
+        <ContactsScreen />
+      </StoryProviders>
+    );
+  },
+};
+
+// A row whose archived_at is set: the warn badge next to the name
+// (people.tsx's name column) renders off the row's own field, independent
+// of the includeArchived toggle's checked state. The checkbox itself starts
+// unchecked every render (useListQuery seeds includeArchived: false with no
+// prop to override it) and only flips on click, so this story shows the
+// badge a toggled-on list would surface without claiming the checkbox is
+// lit.
+const archivedContact: Person = {
+  id: "p-2",
+  full_name: "Mara Voss",
+  title: "Former Head of Ops",
+  // Every field the contract makes required, not just the ones the row
+  // happens to paint: a partial email object still satisfies the response
+  // stub, whose body is `unknown`, so the shape only fails where it is
+  // typed. Typing it here is what catches the omission at all.
+  emails: [
+    {
+      id: "e-2",
+      email: "mara.voss@brandt.example",
+      email_type: "work",
+      is_primary: true,
+      position: 0,
+      source: "manual",
+      captured_by: "human:u1",
+    },
+  ],
+  captured_by: "human:u1",
+  source: "manual",
+  version: 1,
+  created_at: "2026-05-01T08:00:00Z",
+  updated_at: "2026-07-01T08:00:00Z",
+  archived_at: "2026-07-01T08:00:00Z",
+};
+
+export const ContactsListArchivedRow: Story = {
+  render: () => {
+    installFetchStub({
+      "GET /people": () =>
+        jsonResponse({
+          data: [anna, archivedContact],
+          page: { next_cursor: null, has_more: false },
+        }),
+    });
+    return (
+      <StoryProviders>
+        <ContactsScreen />
+      </StoryProviders>
+    );
+  },
+};
+
+// PersonScreen (the 360 view below) is UNROUTED DEAD CODE: App.tsx routes
+// ContactsScreen for the list and PersonPageV2 for the record, never this
+// component. Left in place rather than expanded or deleted so a future
+// reader does not mistake it for a live surface.
 export const PersonOverview: Story = {
   render: () => {
     installFetchStub({

--- a/frontend/src/screens/personpage.stories.tsx
+++ b/frontend/src/screens/personpage.stories.tsx
@@ -270,6 +270,226 @@ const goneQuietMoment: components["schemas"]["PersonMoment"] = {
   ],
 };
 
+// The eight rungs of the ladder LeadMoment/LeadMomentWarning above never
+// reach: PersonToday renders one PersonMomentRule per fixture, and a gallery
+// with only meeting_prep and gone_quiet on screen hides the other eight the
+// component can render. Spread across them: two evidence items (the
+// "sources" plural), a `will_confirm` action, a `blocked` one with its
+// reason, and a freshness older than the moment's own headline date.
+
+const reEngagedMoment: components["schemas"]["PersonMoment"] = {
+  claim_key: "re_engaged:p-1",
+  evidence_fingerprint: "fp-reengaged-1",
+  rule: "re_engaged",
+  rule_version: "v1",
+  headline: "Dana wrote back after six weeks quiet.",
+  why_now: "A reply landed after a long silence, the door is open again.",
+  confidence: "observed_fact",
+  freshness_at: "2026-08-13T09:00:00Z",
+  evidence: [
+    {
+      type: "activity",
+      id: "a-3",
+      label: "Re: still interested in the retrofit",
+      observed_at: "2026-08-13T08:00:00Z",
+    },
+    {
+      type: "activity",
+      id: "a-1",
+      label: "Re: retrofit timeline",
+      observed_at: "2026-08-01T10:15:00Z",
+    },
+  ],
+  recommended_action: {
+    kind: "draft_reply",
+    label: "Welcome her back",
+    state: "will_confirm",
+  },
+  secondary_actions: [
+    { kind: "schedule_meeting", label: "Book a catch-up", state: "available" },
+  ],
+};
+
+const jobChangeMoment: components["schemas"]["PersonMoment"] = {
+  claim_key: "job_change:p-1",
+  evidence_fingerprint: "fp-jobchange-1",
+  rule: "job_change",
+  rule_version: "v1",
+  headline: "Dana moved to Head of Fleet at Brandt Automotive.",
+  why_now: "A recorded employment change: the buying context here just moved.",
+  confidence: "observed_fact",
+  // Older than the headline's own evidence, so the "updated N days ago" wording
+  // reads as a real gap rather than same-day freshness.
+  freshness_at: "2026-08-05T09:00:00Z",
+  evidence: [
+    {
+      type: "relationship_change",
+      label: "Employment updated: Head of Fleet at Brandt Automotive GmbH",
+      observed_at: "2026-08-05T09:00:00Z",
+    },
+  ],
+  recommended_action: {
+    kind: "open_record",
+    label: "Review the account",
+    destination: { surface: "record", entity_type: "organization" },
+    state: "available",
+  },
+  secondary_actions: [
+    {
+      kind: "draft_reply",
+      label: "Congratulate her",
+      state: "blocked",
+      blocked_reason: "No consent recorded for marketing outreach yet.",
+    },
+  ],
+};
+
+const overduePromiseMoment: components["schemas"]["PersonMoment"] = {
+  claim_key: "overdue_promise:p-1:c-1",
+  evidence_fingerprint: "fp-overdue-1",
+  rule: "overdue_promise",
+  rule_version: "v1",
+  headline: "The updated retrofit quote is three days late.",
+  why_now: "A commitment past its own due date, still open.",
+  confidence: "observed_fact",
+  freshness_at: "2026-08-13T09:00:00Z",
+  evidence: [
+    {
+      type: "activity",
+      id: "a-1",
+      label: "Re: retrofit timeline",
+      snippet: "Can we push the fleet retrofit review back a week?",
+      observed_at: "2026-08-01T10:15:00Z",
+    },
+  ],
+  recommended_action: {
+    kind: "draft_reply",
+    label: "Send the quote",
+    state: "available",
+  },
+};
+
+const roleChangeMoment: components["schemas"]["PersonMoment"] = {
+  claim_key: "role_change:p-1",
+  evidence_fingerprint: "fp-rolechange-1",
+  rule: "role_change",
+  rule_version: "v1",
+  headline: "Dana's recorded buying role moved from influencer to champion.",
+  why_now: "A committee seat changed, the pitch to her changes with it.",
+  confidence: "observed_fact",
+  freshness_at: "2026-08-12T09:00:00Z",
+  evidence: [
+    {
+      type: "relationship_change",
+      label: "Buying role updated: champion",
+      observed_at: "2026-08-12T09:00:00Z",
+    },
+  ],
+  recommended_action: {
+    kind: "open_record",
+    label: "Open the deal",
+    destination: { surface: "record", entity_type: "deal" },
+    state: "available",
+  },
+};
+
+const publicSignalMoment: components["schemas"]["PersonMoment"] = {
+  claim_key: "public_signal:p-1",
+  evidence_fingerprint: "fp-publicsignal-1",
+  rule: "public_signal",
+  rule_version: "v1",
+  headline: "Dana posted about the depot's EV rollout timeline.",
+  why_now: "A public statement that bears on the retrofit conversation.",
+  confidence: "medium",
+  freshness_at: "2026-08-11T09:00:00Z",
+  evidence: [
+    {
+      type: "activity",
+      label: 'LinkedIn post: "2027 is the depot\'s EV deadline"',
+      observed_at: "2026-08-11T09:00:00Z",
+    },
+  ],
+  recommended_action: {
+    kind: "draft_reply",
+    label: "Reference it in your next note",
+    state: "available",
+  },
+};
+
+const missingNextStepMoment: components["schemas"]["PersonMoment"] = {
+  claim_key: "missing_next_step:p-1",
+  evidence_fingerprint: "fp-missingstep-1",
+  rule: "missing_next_step",
+  rule_version: "v1",
+  headline: "The retrofit walkthrough has no next step booked after it.",
+  why_now: "A meeting is on the calendar with nothing recorded for after it.",
+  confidence: "observed_fact",
+  freshness_at: "2026-08-13T09:00:00Z",
+  evidence: [
+    {
+      type: "task",
+      label: "Fleet retrofit walkthrough, 20 Aug",
+      observed_at: "2026-08-20T13:00:00Z",
+    },
+  ],
+  recommended_action: {
+    kind: "schedule_meeting",
+    label: "Book the follow-up",
+    state: "available",
+  },
+};
+
+const thinRelationshipMoment: components["schemas"]["PersonMoment"] = {
+  claim_key: "thin_relationship:p-1",
+  evidence_fingerprint: "fp-thin-1",
+  rule: "thin_relationship",
+  rule_version: "v1",
+  headline: "Dana is the only contact captured at Brandt Automotive.",
+  why_now: "One thread carries the whole account, nobody else is on record.",
+  confidence: "observed_fact",
+  freshness_at: "2026-08-13T09:00:00Z",
+  evidence: [
+    {
+      type: "relationship_change",
+      label: "One employment edge on this account",
+      observed_at: "2026-06-01T08:00:00Z",
+    },
+  ],
+  recommended_action: {
+    kind: "ask_colleague",
+    label: "Ask who else to loop in",
+    state: "available",
+  },
+};
+
+// Rung 10, the quiet-success case: nothing needs the reader today, and it
+// renders through this same component rather than an empty card
+// (persontoday.tsx's own comment on `isQuiet`).
+const nothingNeededMoment: components["schemas"]["PersonMoment"] = {
+  claim_key: "nothing_needed:p-1",
+  evidence_fingerprint: "fp-nothingneeded-1",
+  rule: "nothing_needed",
+  rule_version: "v1",
+  headline: "Nothing needs you on this account today.",
+  why_now: "Every open loop is answered and the next meeting is booked.",
+  confidence: "observed_fact",
+  freshness_at: "2026-08-13T09:00:00Z",
+  evidence: [
+    {
+      type: "activity",
+      id: "a-2",
+      label: "Fleet retrofit walkthrough, 20 Aug",
+      observed_at: "2026-08-20T13:00:00Z",
+    },
+  ],
+  recommended_action: {
+    kind: "open_record",
+    label: "Open the record",
+    destination: { surface: "record", entity_type: "person", entity_id: "p-1" },
+    state: "available",
+  },
+};
+
 // The same record read by someone whose grant covers none of the relationship
 // sections: every reading says so instead of reading as a thin or dormant
 // contact. No seeded demo grant reaches this state, so this fixture is the
@@ -294,6 +514,11 @@ const withheld: View = {
 
 function Page() {
   installFetchStub({
+    // Without this the page falls back to the empty /me the story-utils
+    // default returns, which has no `.user`: useCan then fails closed and
+    // the embedded rail renders read-only no matter what the fixture below
+    // grants, which is not what a permitted reader actually sees.
+    "GET /me": () => jsonResponse(meFixture({ allow: { person: ["update"] } })),
     "GET /people/p-1/360": () => jsonResponse(populated),
     "GET /people/p-1/brief": () =>
       jsonResponse({
@@ -371,6 +596,19 @@ export const ReadingsWithheld: Story = {
   ),
 };
 
+// The danger tone: a consent verdict that refuses rather than merely being
+// unrecorded. Every other fixture in this file reads "allowed" or "unknown":
+// this is the only place the strip's red slot renders at all.
+export const ReadingsBlocked: Story = {
+  render: () => (
+    <StoryProviders>
+      <div style={{ maxWidth: 900 }}>
+        <PersonStrip view={populated} consentVerdict="blocked" />
+      </div>
+    </StoryProviders>
+  ),
+};
+
 // --- Lead moment: PersonToday in both tints ---------------------------------
 
 export const LeadMoment: Story = {
@@ -396,6 +634,46 @@ export const LeadMomentWarning: Story = {
           firstName="Dana"
           onAction={() => {}}
         />
+      </div>
+    </StoryProviders>
+  ),
+};
+
+// The eight rungs LeadMoment and LeadMomentWarning above don't reach, stacked
+// rather than split into eight near-identical stories: each one differs only
+// in its moment, so a designer scanning this gallery sees the whole ladder in
+// one scroll instead of hunting eight sidebar entries for the same panel.
+const REMAINING_MOMENTS: ReadonlyArray<components["schemas"]["PersonMoment"]> =
+  [
+    reEngagedMoment,
+    jobChangeMoment,
+    overduePromiseMoment,
+    roleChangeMoment,
+    publicSignalMoment,
+    missingNextStepMoment,
+    thinRelationshipMoment,
+    nothingNeededMoment,
+  ];
+
+export const LeadMomentLadder: Story = {
+  render: () => (
+    <StoryProviders>
+      <div
+        style={{
+          maxWidth: 720,
+          display: "flex",
+          flexDirection: "column",
+          gap: "var(--space-4)",
+        }}
+      >
+        {REMAINING_MOMENTS.map((moment) => (
+          <PersonToday
+            key={moment.claim_key}
+            moment={moment}
+            firstName="Dana"
+            onAction={() => {}}
+          />
+        ))}
       </div>
     </StoryProviders>
   ),
@@ -497,6 +775,171 @@ export const RailEmployments: Story = {
   },
 };
 
+// The rail's consent slot when a purpose is refused rather than merely
+// unrecorded: verdictClass (personrail.tsx) reads this as the refused/warn
+// treatment, the same red-toned reason the strip's own consentTone renders
+// as its danger tone (see ReadingsBlocked above for that surface).
+export const RailConsentBlocked: Story = {
+  render: () => {
+    installFetchStub({
+      "GET /me": () =>
+        jsonResponse(meFixture({ allow: { person: ["update"] } })),
+    });
+    return (
+      <StoryProviders>
+        <div style={{ maxWidth: 320 }}>
+          <PersonRail
+            view={populated}
+            guard={{
+              person_id: "p-1",
+              entries: [
+                {
+                  purpose_key: "business_correspondence",
+                  purpose_class: "business_correspondence",
+                  channel: "email",
+                  verdict: "blocked",
+                  reason:
+                    "She opted out of business correspondence on 3 Aug 2026.",
+                },
+                {
+                  purpose_key: "phone_outreach",
+                  purpose_class: "phone_outreach",
+                  channel: "phone",
+                  verdict: "unknown",
+                  reason: "No consent recorded.",
+                },
+              ],
+            }}
+            firstName="Dana"
+            onExplain={() => {}}
+          />
+        </div>
+      </StoryProviders>
+    );
+  },
+};
+
+// A record with an open deal, an empty committee and no meeting booked, and
+// a last inbound reply well past the 14-day threshold: the shape that fires
+// three of derivedSignals' four warnings at once (personrail.tsx) plus the
+// pulse's own "cooling" trend and "at risk" overall word, none of which any
+// other fixture in this file reaches because none of them carries a deal.
+const dealAtRisk: View = {
+  ...populated,
+  last_inbound_at: "2026-07-10T09:00:00Z",
+  last_outbound_at: "2026-07-25T09:00:00Z",
+  commercial: {
+    role: "champion",
+    deal: {
+      deal_id: "d-1",
+      title: "Fleet retrofit, 40 vehicles",
+      stage: "negotiation",
+      amount_minor: 9_500_000,
+      currency: "EUR",
+      close_date: "2026-09-30",
+    },
+    committee: [],
+  },
+  next_meeting: undefined,
+};
+
+export const RailAtRisk: Story = {
+  render: () => {
+    installFetchStub({
+      "GET /me": () =>
+        jsonResponse(meFixture({ allow: { person: ["update"] } })),
+    });
+    return (
+      <StoryProviders>
+        <div style={{ maxWidth: 320 }}>
+          <PersonRail
+            view={dealAtRisk}
+            guard={undefined}
+            firstName="Dana"
+            onExplain={() => {}}
+          />
+        </div>
+      </StoryProviders>
+    );
+  },
+};
+
+// The thin end of every rail section at once: no reply ever captured (so the
+// pulse's "thin" overall word and the signals' own empty state both render),
+// one direction only (the one-sided reading, since twoWay needs both), no
+// employer, nobody who knows her, and nothing in the recent-activity list.
+// A record can genuinely look like this the day after it is captured.
+const thinContact: View = {
+  ...populated,
+  last_inbound_at: undefined,
+  last_outbound_at: "2026-08-10T09:00:00Z",
+  network: { colleagues: [] },
+  employments: { data: [], page },
+  activities: { data: [], page },
+  commercial: { role: null, committee: [] },
+  next_meeting: undefined,
+};
+
+export const RailThin: Story = {
+  render: () => {
+    installFetchStub({
+      "GET /me": () =>
+        jsonResponse(meFixture({ allow: { person: ["update"] } })),
+    });
+    return (
+      <StoryProviders>
+        <div style={{ maxWidth: 320 }}>
+          <PersonRail
+            view={thinContact}
+            guard={undefined}
+            firstName="Dana"
+            onExplain={() => {}}
+          />
+        </div>
+      </StoryProviders>
+    );
+  },
+};
+
+// Every profile field DetailsGrid can hold, unset at once: title, linkedin,
+// city, email and phone all blank. Email and phone are always read-only
+// (personrail.tsx's CONTACT_METHOD_IMMUTABLE), so they read `field.unset`
+// here whether or not the reader can edit; title, linkedin and city ARE
+// editable under this fixture's granted /me, so they read as the "Add …"
+// placeholder instead: the two empty-field states side by side.
+const unsetFields: View = {
+  ...populated,
+  person: {
+    ...populated.person,
+    title: null,
+    social: {},
+    address: undefined,
+    emails: [],
+    phones: [],
+  },
+};
+
+export const RailUnsetFields: Story = {
+  render: () => {
+    installFetchStub({
+      "GET /me": () =>
+        jsonResponse(meFixture({ allow: { person: ["update"] } })),
+    });
+    return (
+      <StoryProviders>
+        <div style={{ maxWidth: 320 }}>
+          <PersonRail
+            view={unsetFields}
+            guard={undefined}
+            firstName="Dana"
+            onExplain={() => {}}
+          />
+        </div>
+      </StoryProviders>
+    );
+  },
+};
+
 // --- Brief states: the band's populated and empty readings side by side ----
 
 // A record with no open deal, no committed loop and no captured priority —
@@ -576,6 +1019,149 @@ export const OverviewPanels: Story = {
         <PersonCommitmentsCard view={populated} firstName="Dana" />
         <PersonMattersCard view={populated} firstName="Dana" />
         <PersonMemory view={populated} />
+      </div>
+    </StoryProviders>
+  ),
+};
+
+// A deal with money, stage and a close date, and more than one stakeholder in
+// the room: the populated end of PersonCommercialCard that `populated`
+// itself never reaches (its own commercial section carries no deal).
+const dealWithCommittee: View = {
+  ...populated,
+  commercial: {
+    role: "champion",
+    deal: {
+      deal_id: "d-1",
+      title: "Fleet retrofit, 40 vehicles",
+      stage: "negotiation",
+      amount_minor: 9_500_000,
+      currency: "EUR",
+      close_date: "2026-09-30",
+    },
+    committee: [
+      { person_id: "p-2", full_name: "Mika Voss", role: "economic_buyer" },
+      { person_id: "p-3", full_name: "Jonas Reiter", role: "influencer" },
+    ],
+  },
+};
+
+// One of every loop kind PersonCommitmentsCard renders, plus a `done` row:
+// `populated` carries only a single `commitment_ours`, so neither
+// `commitment_theirs`, `open_question` nor the done state ever appear.
+const richLoops: View = {
+  ...populated,
+  claims: [
+    ...(populated.claims ?? []),
+    {
+      id: "c-3",
+      kind: "commitment_theirs",
+      body: "send the fleet utilization numbers",
+      source_activity_id: "a-1",
+      source_quote: "I'll get you the utilization numbers by Friday.",
+      source_label: "Re: retrofit timeline",
+      occurred_at: "2026-08-01T10:15:00Z",
+      status: "open",
+      needs_review: false,
+    },
+    {
+      id: "c-4",
+      kind: "open_question",
+      body: "whether the depot needs a second charger bank",
+      source_activity_id: "a-1",
+      source_quote: "Not sure yet if one charger bank covers the whole depot.",
+      source_label: "Re: retrofit timeline",
+      occurred_at: "2026-08-01T10:15:00Z",
+      status: "open",
+      needs_review: false,
+    },
+    {
+      id: "c-5",
+      kind: "commitment_ours",
+      body: "confirm the installation window",
+      source_activity_id: "a-1",
+      source_quote: "We'll confirm the installation window by Monday.",
+      source_label: "Re: retrofit timeline",
+      occurred_at: "2026-07-28T10:15:00Z",
+      status: "done",
+      needs_review: false,
+    },
+  ],
+};
+
+// Every channel PersonMemory labels (meeting, call, note, beside the email
+// entries every other fixture already carries) and a `replied` status, none
+// of which the single email entry on `populated` reaches.
+const richMemory: View = {
+  ...populated,
+  conversation_memory: [
+    ...(populated.conversation_memory ?? []),
+    {
+      key: "thread-2",
+      channel: "meeting",
+      direction: "internal",
+      title: "Fleet retrofit kickoff",
+      summary: "Walked through the retrofit scope and the depot's constraints.",
+      generated_by: "deterministic",
+      occurred_at: "2026-07-15T13:00:00Z",
+      activity_count: 1,
+      status: null,
+      linked_deal_id: null,
+      first_activity_id: "a-4",
+    },
+    {
+      key: "thread-3",
+      channel: "call",
+      direction: "outbound",
+      title: "Check-in call",
+      summary: "Confirmed the depot's offline window with Dana.",
+      generated_by: "deterministic",
+      occurred_at: "2026-07-22T09:30:00Z",
+      activity_count: 1,
+      status: "replied",
+      linked_deal_id: null,
+      first_activity_id: "a-5",
+    },
+    {
+      key: "thread-4",
+      channel: "note",
+      direction: "internal",
+      title: "Internal note",
+      summary:
+        "Sam flagged Dana as the sole technical contact on this account.",
+      generated_by: "deterministic",
+      occurred_at: "2026-07-10T09:00:00Z",
+      activity_count: 1,
+      status: null,
+      linked_deal_id: null,
+      first_activity_id: "a-6",
+    },
+  ],
+};
+
+// No thread, no meeting, no captured activity to fold: the honest empty
+// state, distinct from `populated`'s one email entry.
+const emptyMemory: View = {
+  ...populated,
+  conversation_memory: [],
+  activities: { data: [], page },
+};
+
+// The gaps `OverviewPanels` above leaves: the withheld commercial card, the
+// populated one with a deal and a committee, every commitments loop kind
+// including a done row, the brief's loading and undefined-brief readings,
+// and the memory panel's full channel set plus its empty state.
+export const OverviewGaps: Story = {
+  render: () => (
+    <StoryProviders>
+      <div className="pe-overview-stack" style={{ maxWidth: 720 }}>
+        <PersonBriefCard brief={undefined} loading view={populated} />
+        <PersonBriefCard brief={undefined} loading={false} view={populated} />
+        <PersonCommercialCard view={withheld} />
+        <PersonCommercialCard view={dealWithCommittee} />
+        <PersonCommitmentsCard view={richLoops} firstName="Dana" />
+        <PersonMemory view={richMemory} />
+        <PersonMemory view={emptyMemory} />
       </div>
     </StoryProviders>
   ),
@@ -669,6 +1255,211 @@ export const ResearchDrawer: Story = {
           personId="p-1"
           personName="Dana Buyer"
           providerProfile={providerNotConnected}
+          open
+          onClose={() => {}}
+        />
+      </StoryProviders>
+    );
+  },
+};
+
+// A run that landed with values on every branch ProviderValues renders
+// (personprovider.tsx): `providerNotConnected` above leaves every array
+// empty, so none of emails/mobiles/employment/job history/location/
+// departments/seniorities, nor the EnrichNow button, ever render without
+// this fixture.
+const completedRun: components["schemas"]["ProviderRun"] = {
+  id: "run-1",
+  subject_kind: "person",
+  person_id: "p-1",
+  provider: "surfe",
+  trigger: "manual",
+  state: "completed",
+  skip_reason: null,
+  connection_version: 1,
+  configuration_snapshot: {
+    mode: "on_demand",
+    preset: "professional_only",
+    automatic_individual_create: true,
+    automatic_import: false,
+    categories: { email: true, mobile: true },
+  },
+  requested_categories: ["email", "mobile"],
+  reservations: [{ pool: "email", reserved_credits: 1, actual_credits: 1 }],
+  claims_unwritten: false,
+  submitted_at: "2026-08-12T09:00:00Z",
+  completed_at: "2026-08-12T09:02:00Z",
+  safe_status_code: null,
+  created_at: "2026-08-12T09:00:00Z",
+  updated_at: "2026-08-12T09:02:00Z",
+};
+
+const providerCompleted: components["schemas"]["PersonProviderProfile"] = {
+  state: "completed",
+  provider: "surfe",
+  retrieved_at: "2026-08-12T09:02:00Z",
+  safe_status_code: null,
+  // Both categories were asked for and both came back, so nothing here is
+  // reported as skipped: `mobile_phones` below is populated, and claiming it
+  // as "not requested" beside a value the run actually returned would say
+  // two contradictory things about the same run.
+  categories_not_requested: [],
+  emails: [
+    {
+      value: "dana.buyer@surfe.example",
+      email_type: "professional",
+      email_type_source: "provider",
+      validation_status: "valid",
+    },
+  ],
+  mobile_phones: [{ value: "+491701234567", confidence: 0.82 }],
+  linkedin_url: "https://linkedin.com/in/danabuyer",
+  current_employment: {
+    company_name: "Brandt Automotive GmbH",
+    company_domain: "brandt-automotive.example",
+    job_title: "Head of Fleet",
+  },
+  job_history: [
+    {
+      company_name: "Voss Logistics",
+      job_title: "Fleet Coordinator",
+      started_at: "2018-01-01T00:00:00Z",
+      ended_at: "2022-02-01T00:00:00Z",
+    },
+  ],
+  location: "Munich, Germany",
+  city: "Munich",
+  region: "Bavaria",
+  country: "DE",
+  departments: ["Operations"],
+  seniorities: ["Head"],
+  latest_run: completedRun,
+};
+
+export const ResearchDrawerProviderCompleted: Story = {
+  render: () => {
+    installFetchStub({
+      "POST /people/p-1/research": () =>
+        jsonResponse({
+          person_id: "p-1",
+          state: "ready",
+          generated_at: "2026-08-13T09:00:00Z",
+          claims: [],
+        }),
+    });
+    return (
+      <StoryProviders>
+        <PersonResearchDrawer
+          personId="p-1"
+          personName="Dana Buyer"
+          providerProfile={providerCompleted}
+          open
+          onClose={() => {}}
+        />
+      </StoryProviders>
+    );
+  },
+};
+
+// A run still moving: RunWatch polls `GET .../enrichment-runs/{run_id}`
+// while `isRunning` holds, and the badge reads "In progress" rather than any
+// terminal word: a state `providerNotConnected` and `providerCompleted`
+// above never reach.
+const inProgressRun: components["schemas"]["ProviderRun"] = {
+  ...completedRun,
+  id: "run-2",
+  state: "in_progress",
+  completed_at: null,
+  submitted_at: "2026-08-13T09:00:00Z",
+  requested_categories: ["email"],
+};
+
+const providerRunning: components["schemas"]["PersonProviderProfile"] = {
+  state: "in_progress",
+  provider: "surfe",
+  retrieved_at: null,
+  // This run asked for email only, so mobile is honestly "not requested"
+  // rather than "requested but not yet back": the run has nothing to show
+  // for either while it is still moving.
+  categories_not_requested: ["mobile"],
+  emails: [],
+  mobile_phones: [],
+  job_history: [],
+  departments: [],
+  seniorities: [],
+  latest_run: inProgressRun,
+};
+
+export const ResearchDrawerProviderRunning: Story = {
+  render: () => {
+    installFetchStub({
+      "POST /people/p-1/research": () =>
+        jsonResponse({
+          person_id: "p-1",
+          state: "not_connected",
+          generated_at: "2026-08-13T09:00:00Z",
+          claims: [],
+        }),
+      "GET /people/p-1/enrichment-runs/run-2": () =>
+        jsonResponse(inProgressRun),
+    });
+    return (
+      <StoryProviders>
+        <PersonResearchDrawer
+          personId="p-1"
+          personName="Dana Buyer"
+          providerProfile={providerRunning}
+          open
+          onClose={() => {}}
+        />
+      </StoryProviders>
+    );
+  },
+};
+
+// A run the provider refused: paid nothing (no run reached the vendor's
+// meter) and returned nothing, so the badge carries the danger tone
+// (provider-status.ts's PROFILE_TONE) rather than the neutral or success one
+// every other provider fixture here shows.
+const failedRun: components["schemas"]["ProviderRun"] = {
+  ...completedRun,
+  id: "run-3",
+  state: "failed",
+  completed_at: "2026-08-13T09:05:00Z",
+  safe_status_code: "provider_unavailable",
+};
+
+const providerError: components["schemas"]["PersonProviderProfile"] = {
+  state: "provider_error",
+  provider: "surfe",
+  retrieved_at: null,
+  safe_status_code: "provider_unavailable",
+  categories_not_requested: [],
+  emails: [],
+  mobile_phones: [],
+  job_history: [],
+  departments: [],
+  seniorities: [],
+  latest_run: failedRun,
+};
+
+export const ResearchDrawerProviderError: Story = {
+  render: () => {
+    installFetchStub({
+      "POST /people/p-1/research": () =>
+        jsonResponse({
+          person_id: "p-1",
+          state: "not_connected",
+          generated_at: "2026-08-13T09:00:00Z",
+          claims: [],
+        }),
+    });
+    return (
+      <StoryProviders>
+        <PersonResearchDrawer
+          personId="p-1"
+          personName="Dana Buyer"
+          providerProfile={providerError}
           open
           onClose={() => {}}
         />


### PR DESCRIPTION
## Why

Same audit as #1235, applied to the contact page. `fe-uat` asserts a changed component has a story and that it renders clean; nothing asserts the story exercises the states the component can produce, so the catalog drifted while every gate stayed green.

**The bug first:** `PageStory`, the story that assembles the whole page, never stubbed `GET /me`. `useCan` fails closed (`app/capability.ts:78-86`), so the composed page has always drawn the **read-only** rail: no inline edit, no add-employment, no overflow menus. The editable rail existed only in the isolated `Rail`/`RailEmployments` stories, so the page's writable path was never shown end to end. Same failure mode fixed in `companyrail.stories.tsx` in #1235.

Beyond that, every person fixture was healthy, recently contacted, fully populated and carried no open deal, which left whole readings structurally unreachable.

## What now renders that did not

| Area | State |
|---|---|
| consent | a `blocked` verdict, on both the strip and the rail |
| rail signals | a stale reply against an open deal with an empty committee and no booked meeting, so the no-reply, single-threaded and no-meeting readings fire at all (no prior fixture set `commercial.deal`) |
| rail, thin | a one-sided relationship with its empty signal, employment, colleague and activity states |
| rail, unset | title, profile link and city unset, so the placeholder a permitted reader can press shows beside the two fields nobody may edit |
| moment ladder | all ten rungs rather than two, including the quiet-success rung, distributing the confirm-first and blocked action states, a plural evidence line, and a reading older than its own headline |
| provider | a completed profile with its values, a run still in flight with its polling badge, and a failed one, where before only an unconnected profile with every list empty |
| cards, memory | a deal with its committee, withheld commercial, the other commitment kinds and a done row, brief loading and absent, and the meeting/call/note channels with a replied status |
| contact list | empty, pending, refused, further-pages, archived row |

## Deliberately absent

Search, the archived toggle and the sort tabs each derive from list state that only a keystroke or a click changes, and this pass adds no interaction driver. No `play` functions: those were the only thing that failed the gate on #1235.

`PersonOverview` is left as it was, with a comment recording that the screen it renders (`PersonScreen`) is **not routed** at all: `App.tsx` mounts `ContactsScreen` and `PersonPageV2`. Expanding coverage of unreachable UI would be waste.

## Verification

- `make fe-uat` — 30/30 stories render clean and captured, first run
- `tsc -b`, biome — clean

## Found, not fixed here

Product behaviour, out of scope for a stories-only change, being addressed separately:

- `blocked` consent maps to `danger` in `PersonStrip.consentTone` but to the same **warn** class as unknown in `PersonRail.verdictClass`, so one refusal reads two ways
- a `status: "done"` commitment still shows the **Open** badge: `LoopStatus` branches on `due_at` and kind, never on `status`
- `why_now` paints only for the two rules treated as warn, so eight rungs carry schema-required text that never renders

Stories only. No product code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores editable contact-page stories and broadens Storybook coverage to match real UI states. The page story now stubs `GET /me`, fixing the old behavior where `useCan` failed closed and the composed page always rendered a read‑only rail.

- Adds state coverage: blocked consent tone (strip and rail), at‑risk rail with open deal and empty committee, thin rail (one‑sided/no colleagues/no activity), unset editable fields vs immutable empties, and the full ten‑rung moment ladder including quiet‑success, confirm‑first, blocked actions, and plural evidence.
- Expands overview panels: commercial card with deal+committee, commitments of all kinds including a done row, brief loading and undefined, memory across meeting/call/note plus empty state.
- Research drawer: provider completed with values, in‑progress with polling badge, and provider error.
- Contacts list: empty, loading (pending), failed (403), more pages, and archived row.
- Stories only; no product code changed. `PersonScreen` remains unrouted. Search, archived toggle, and sort tabs are intentionally not exercised (no interaction driver).

<sup>Written for commit e570f4bf9800d831215cee233618355e995f8b52. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1242?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

