### PR TITLE
fix(company): a name or a reading too long for its row gives way

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,8 @@ workspace/
 # inspection profiles), not a build input. Machine-local, so it never belongs
 # in a commit.
 /.idea/
+
+# Agent-tooling scratch: state a Claude Code plugin keeps for its own runs,
+# written into whichever tree it was invoked from. Machine-local and per-session,
+# same as the IDE state above.
+/.impeccable/

--- a/frontend/src/app/shell.css
+++ b/frontend/src/app/shell.css
@@ -787,8 +787,10 @@
   margin: 0;
   font-family: var(--f-display);
   line-height: 1.15;
-  /* A record name is user data of unbounded length; it wraps rather than
-     pushing the agent strip off the row. */
+  /* This heading names a SECTION, never a record — a record route prints the
+     trail below instead, and truncates the name it carries. Section titles
+     are translated strings, so wrapping here is a guard against a long
+     translation, not against user data. */
   overflow-wrap: anywhere;
 }
 /* The trail on a record route, standing where the heading stands on every other
@@ -805,6 +807,21 @@
 }
 .pagecrumb > span[aria-hidden] {
   color: var(--borderStrong);
+}
+/* The trail names where you were and where you are; only the second half is
+   user data of unbounded length, so it is the half that gives way. It takes
+   what the row has left and truncates, keeping the trail one line and the
+   agent strip in its place — the record's own name at full size is the next
+   thing down the page, and the title attribute carries it here. */
+.pagecrumb > .pageback,
+.pagecrumb > span[aria-hidden] {
+  flex: none;
+}
+.pagecrumb-name {
+  min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 }
 /* The way back to the list — quieter still than the record it leads away from,
    because it names where you were, not where you are. */

--- a/frontend/src/app/shell.test.tsx
+++ b/frontend/src/app/shell.test.tsx
@@ -1005,10 +1005,11 @@ describe("PageHead", () => {
       <PageHead route={{ screen: "contacts", id: "p-anna" }} />,
     );
     // In mono, so the reader can see it is an identifier and not somebody's
-    // name — and carrying the whole id in `title` when the line has to clip.
+    // name. An id too long for the trail is revealed by the truncation tooltip,
+    // which has its own suite (design-system/tooltip.test.tsx) — the trail's own
+    // promise is that the id is what stands here at all.
     const raw = container.querySelector(".pagecrumb .t-mono");
     expect(raw?.textContent).toBe("p-anna");
-    expect(raw?.getAttribute("title")).toBe("p-anna");
   });
 
   // An id segment that names no record is the screen's own state, not a record:

--- a/frontend/src/app/shell.tsx
+++ b/frontend/src/app/shell.tsx
@@ -21,6 +21,7 @@ import {
 import type { components } from "../api/schema";
 import { Button, Modal } from "../design-system/atoms";
 import { Logomark } from "../design-system/logomark";
+import { useTruncationTooltip } from "../design-system/tooltip";
 import { useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import { useEntityName } from "../screens/entityref";
@@ -597,16 +598,18 @@ const OFF_RAIL_TITLE_KEYS: Record<string, MessageKey> = {
 // nothing.
 function RecordName({ kind, id }: Readonly<{ kind: EntityKind; id: string }>) {
   const name = useEntityName(kind, id);
-  if (name) {
-    return (
-      <span className="pagecrumb-name" title={name}>
-        {name}
-      </span>
-    );
-  }
+  // Truncated to keep the trail on one line, so the tooltip is what carries a
+  // name too long for it.
+  const text = name ?? id;
+  const tip = useTruncationTooltip<HTMLSpanElement>(text);
   return (
-    <span className="pagecrumb-name t-mono" title={id}>
-      {id}
+    <span
+      className={name ? "pagecrumb-name" : "pagecrumb-name t-mono"}
+      ref={tip.ref}
+      {...tip.trigger}
+    >
+      {text}
+      {tip.tip}
     </span>
   );
 }

--- a/frontend/src/app/shell.tsx
+++ b/frontend/src/app/shell.tsx
@@ -598,10 +598,14 @@ const OFF_RAIL_TITLE_KEYS: Record<string, MessageKey> = {
 function RecordName({ kind, id }: Readonly<{ kind: EntityKind; id: string }>) {
   const name = useEntityName(kind, id);
   if (name) {
-    return <span>{name}</span>;
+    return (
+      <span className="pagecrumb-name" title={name}>
+        {name}
+      </span>
+    );
   }
   return (
-    <span className="t-mono" title={id}>
+    <span className="pagecrumb-name t-mono" title={id}>
       {id}
     </span>
   );

--- a/frontend/src/design-system/README.md
+++ b/frontend/src/design-system/README.md
@@ -70,6 +70,7 @@ arrive through props, translated by the caller with `t()`.
 | `RecordView` | The record page shell: identity, readings, timeline | `composed.tsx` | ✅ |
 | `GroupedTimelineList` / `TimelineRow` / `MorningBriefItem` | The activity timeline, grouped, and one brief line | `composed.tsx` | via `RecordView` |
 | `ProviderMark` | A federated provider's own sign-in mark — the ONE file allowed literal colours, because another company's colours are not ours to tokenise | `provider-mark.tsx` | — |
+| `useTruncationTooltip` | The whole of a string its row had to truncate, on hover or focus — and nothing at all when the string already fits. Reach for it wherever user data of unbounded length is drawn on one line: a record name, a trail segment, a rail row's reading | `tooltip.tsx` | ✅ |
 | `usePrefersReducedMotion` / `useTypeStream` / `useDocumentIntro` | Motion, with one rule: reduced motion jumps to the END state, never to nothing | `motion.ts` | — |
 | `subscribeToWindowFocus` and friends | Whether this window has focus — one signal for the draw loop and the stylesheet alike | `window-focus.ts` | — |
 

--- a/frontend/src/design-system/composed.css
+++ b/frontend/src/design-system/composed.css
@@ -193,8 +193,12 @@
   margin: 0;
   justify-content: flex-end;
 }
+/* min-width: 0 is what keeps a long name inside the header: a flex item's
+   floor is otherwise its min-content width, so the name would set the
+   identity block's width and push the controls column off the row. */
 .record-head .record-id {
   flex: 1;
+  min-width: 0;
 }
 /* The name and its one standing badge, on the SAME baseline — the badge
    reads as part of naming the record, not as one more fact under it. */
@@ -218,11 +222,21 @@
   letter-spacing: 0.02em;
   text-transform: uppercase;
 }
+/* One line, cut with an ellipsis. A name long enough to wrap would push the
+   record's standing, its verbs and the whole page below it down the screen,
+   and the reader came for the record rather than for its full legal name —
+   which the Details rail spells out in a place that does wrap. Shrinkable
+   (min-width: 0) but not grown: at its natural width a short name keeps the
+   standing badge beside it on the same row. */
 .record-head h1 {
   font-family: var(--f-display);
   font-size: 22px;
   font-weight: 600;
   color: var(--textPrimary);
+  min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 }
 /* The RECORD page's identity block, at the scale the mockups draw it: the name
    is the largest thing on the page and the mark beside it is a logo rather

--- a/frontend/src/design-system/composed.tsx
+++ b/frontend/src/design-system/composed.tsx
@@ -14,6 +14,7 @@ import { formatDate, formatDuration, formatMoney } from "../format/format";
 import { useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import { Avatar, Badge, Button } from "./atoms";
+import { useTruncationTooltip } from "./tooltip";
 import {
   AutonomyDot,
   type ConfidenceLevel,
@@ -406,6 +407,7 @@ function RecordHead({
   actionsAt: "none" | "inline" | "controls" | "below";
   wide: boolean;
 }>) {
+  const nameTip = useTruncationTooltip<HTMLHeadingElement>(name);
   return (
     <header className={wide ? "record-head record-head-wide" : "record-head"}>
       <Avatar name={name} src={avatarSrc} size="lg" />
@@ -421,9 +423,13 @@ function RecordHead({
               prints the trail that leads here and nothing at heading
               level, so this stays the page's one h1. */}
           {/* A record's name is user data of unbounded length. It is drawn on
-              one line and truncated rather than allowed to grow the header,
-              so the title attribute is what carries the whole of it. */}
-          <h1 title={name}>{name}</h1>
+              one line and truncated rather than allowed to grow the header;
+              the tooltip is what carries the whole of it, and appears only
+              when there was more name than row. */}
+          <h1 ref={nameTip.ref} {...nameTip.trigger}>
+            {name}
+            {nameTip.tip}
+          </h1>
           {nameBadge}
         </div>
         {/* A div, not a p: a caller passing structure — the company page's

--- a/frontend/src/design-system/composed.tsx
+++ b/frontend/src/design-system/composed.tsx
@@ -420,7 +420,10 @@ function RecordHead({
           {/* The shell's page head yields to it on a record route — it
               prints the trail that leads here and nothing at heading
               level, so this stays the page's one h1. */}
-          <h1>{name}</h1>
+          {/* A record's name is user data of unbounded length. It is drawn on
+              one line and truncated rather than allowed to grow the header,
+              so the title attribute is what carries the whole of it. */}
+          <h1 title={name}>{name}</h1>
           {nameBadge}
         </div>
         {/* A div, not a p: a caller passing structure — the company page's

--- a/frontend/src/design-system/fieldgrid.css
+++ b/frontend/src/design-system/fieldgrid.css
@@ -29,6 +29,18 @@
   color: var(--textContent);
   min-width: 0;
 }
+/* A value is user data, and a legal name or a domain can arrive as one run with
+   no space in it to break at. `min-width: 0` above lets the COLUMN shrink; this
+   is what makes the text inside it give way too — without it the run sets the
+   value's width, and the row grows straight through the panel's padding and out
+   over the card's edge. It reaches the editable controls as well as the plain
+   text because that is what a value usually is here: the string sits inside
+   InlineText's or InlineChoice's button, which hugs its own content. */
+.fieldgrid-value,
+.fieldgrid-value .inlinetext,
+.fieldgrid-value .inline-editable {
+  overflow-wrap: anywhere;
+}
 
 /* The exception to the top edge, for a row whose value is not text: a badge or
    a chip is a BOX, taller than the line of text naming it, and a box hung from

--- a/frontend/src/design-system/tooltip.css
+++ b/frontend/src/design-system/tooltip.css
@@ -36,10 +36,11 @@
 }
 /* Reduced motion takes the fade, not the delay: the delay is what keeps a tip
    from flashing at every pointer that crosses the row, which is a comfort
-   rather than a decoration. */
+   rather than a decoration. Only the DURATION is overridden, so the delay, the
+   keyframes and `forwards` all survive — dropping the whole animation would
+   take the delay with it and put a tip under every pointer that passes. */
 @media (prefers-reduced-motion: reduce) {
   .tooltip {
-    animation: none;
-    opacity: 1;
+    animation-duration: 0ms;
   }
 }

--- a/frontend/src/design-system/tooltip.css
+++ b/frontend/src/design-system/tooltip.css
@@ -1,0 +1,45 @@
+/* The tooltip that reveals a string its row could not fit.
+
+   Above the select popup (70) in the layering stack declared in atoms.css: a
+   tip explains what a reader is already pointing at, so it can never be the
+   thing another layer covers. */
+.tooltip {
+  position: fixed;
+  z-index: 80;
+  max-width: 320px;
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--r-sm);
+  background: var(--textPrimary);
+  color: var(--bgCard);
+  font-size: var(--fs-meta);
+  line-height: 1.4;
+  /* The tip carries the string the row truncated, so it is the one place the
+     whole of it must fit: it wraps, and breaks a run with no spaces in it
+     rather than growing past its own max-width. */
+  white-space: normal;
+  overflow-wrap: anywhere;
+  box-shadow: var(--shadow-pop);
+  /* Not interactive and never in the way: a pointer that crosses the tip's box
+     on its way somewhere else passes straight through it. */
+  pointer-events: none;
+  /* The delay lives in CSS rather than a JS timer: the tip is in the DOM the
+     moment the pointer arrives — which is what a test asserts and a screen
+     reader announces — and only its paint waits, so a pointer crossing a row
+     on its way elsewhere never flashes a tip on the way past. */
+  opacity: 0;
+  animation: tooltip-in 90ms ease-out 150ms forwards;
+}
+@keyframes tooltip-in {
+  to {
+    opacity: 1;
+  }
+}
+/* Reduced motion takes the fade, not the delay: the delay is what keeps a tip
+   from flashing at every pointer that crosses the row, which is a comfort
+   rather than a decoration. */
+@media (prefers-reduced-motion: reduce) {
+  .tooltip {
+    animation: none;
+    opacity: 1;
+  }
+}

--- a/frontend/src/design-system/tooltip.stories.tsx
+++ b/frontend/src/design-system/tooltip.stories.tsx
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { ReactNode } from "react";
+import { useTruncationTooltip } from "./tooltip";
+
+/**
+ * The tip that reveals a string its own row had to truncate.
+ *
+ * What these stories are for, in order of what they actually catch: a tip only
+ * appears where the text really is clipped (Clipped And Whole shows both in one
+ * column, and only the first answers), it escapes the `overflow: hidden` that
+ * did the clipping rather than being cut off by it (In A Narrow Card), and it
+ * flips below its anchor when there is no room above (Near The Top). Hover a row
+ * or tab to it — a clipped row takes a tab stop and an unclipped one does not.
+ * Flip the Theme toolbar to see the dark rendering; every value is a token.
+ */
+const meta = {
+  title: "Design System/Tooltip",
+  parameters: { layout: "padded" },
+} satisfies Meta;
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const LONG =
+  "Asigbsdakjgbndkjgbndfkjgndfkjngkjdfsngjdngjndfgbnsdfkjgbdkjfbgkjgjhasfhisj Holdings";
+const SHORT = "Sontana";
+
+// The shape all three call sites share: one line, clipped at the edge, with the
+// whole string on the tip.
+function Row({ text }: Readonly<{ text: string }>) {
+  const tip = useTruncationTooltip<HTMLSpanElement>(text);
+  return (
+    <span
+      ref={tip.ref}
+      style={{
+        display: "block",
+        overflow: "hidden",
+        textOverflow: "ellipsis",
+        whiteSpace: "nowrap",
+      }}
+      {...tip.trigger}
+    >
+      {text}
+      {tip.tip}
+    </span>
+  );
+}
+
+function Card({ children }: Readonly<{ children: ReactNode }>) {
+  return (
+    <div
+      style={{
+        background: "var(--bgCard)",
+        border: "1px solid var(--borderSubtle)",
+        borderRadius: "var(--r-md)",
+        display: "grid",
+        gap: "var(--space-3)",
+        maxWidth: 260,
+        padding: "var(--space-3)",
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+/** The whole point in one frame: the long row answers, the short one does not. */
+export const ClippedAndWhole: Story = {
+  render: () => (
+    <Card>
+      <Row text={LONG} />
+      <Row text={SHORT} />
+    </Card>
+  ),
+};
+
+/**
+ * The case the component exists for. The card clips its own content, which is
+ * what truncates the text — so a tip drawn inside it would be clipped by the
+ * same rule. It is portalled to the body instead.
+ */
+export const InANarrowCard: Story = {
+  render: () => (
+    <div style={{ display: "grid", gap: "var(--space-3)", maxWidth: 200 }}>
+      <Card>
+        <Row text={LONG} />
+      </Card>
+    </div>
+  ),
+};
+
+/** No room above, so the tip goes below the anchor rather than off-screen. */
+export const NearTheTop: Story = {
+  parameters: { layout: "fullscreen" },
+  render: () => (
+    <div style={{ padding: "var(--space-1)" }}>
+      <Card>
+        <Row text={LONG} />
+      </Card>
+    </div>
+  ),
+};

--- a/frontend/src/design-system/tooltip.test.tsx
+++ b/frontend/src/design-system/tooltip.test.tsx
@@ -1,0 +1,118 @@
+/** @vitest-environment jsdom */
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import "@testing-library/jest-dom/vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useTruncationTooltip } from "./tooltip";
+
+// The specs for the tip that reveals a string its row could not fit. The
+// promise the three call sites depend on is narrow and worth stating twice: the
+// tip appears for text that IS clipped and stays away from text that is not,
+// because a tip repeating a name already fully on screen is noise on every row
+// of a page.
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+const LONG = "In contact, but one person carries the whole account.";
+
+// jsdom lays nothing out, so every element reports a width of zero and no text
+// is ever clipped. These are the two measurements the hook reads, and stubbing
+// them is what lets a test say "this string did not fit" at all.
+function stubWidths({ scroll, client }: { scroll: number; client: number }) {
+  vi.spyOn(HTMLElement.prototype, "scrollWidth", "get").mockReturnValue(scroll);
+  vi.spyOn(HTMLElement.prototype, "clientWidth", "get").mockReturnValue(client);
+}
+
+function Row({ text }: Readonly<{ text: string }>) {
+  const tip = useTruncationTooltip<HTMLSpanElement>(text);
+  return (
+    <span ref={tip.ref} {...tip.trigger}>
+      {text}
+      {tip.tip}
+    </span>
+  );
+}
+
+describe("a string too long for its row", () => {
+  it("reveals the whole of it on hover", async () => {
+    stubWidths({ scroll: 480, client: 220 });
+    render(<Row text={LONG} />);
+    expect(screen.queryByRole("tooltip")).toBeNull();
+
+    await userEvent.hover(screen.getByText(LONG));
+
+    expect(screen.getByRole("tooltip")).toHaveTextContent(LONG);
+  });
+
+  it("takes the tip away again when the pointer leaves", async () => {
+    stubWidths({ scroll: 480, client: 220 });
+    render(<Row text={LONG} />);
+    const row = screen.getByText(LONG);
+
+    await userEvent.hover(row);
+    await userEvent.unhover(row);
+
+    expect(screen.queryByRole("tooltip")).toBeNull();
+  });
+
+  it("describes the row it belongs to, so a screen reader reads the two as one", async () => {
+    stubWidths({ scroll: 480, client: 220 });
+    render(<Row text={LONG} />);
+    const row = screen.getByText(LONG);
+
+    await userEvent.hover(row);
+
+    const tip = screen.getByRole("tooltip");
+    expect(row).toHaveAttribute("aria-describedby", tip.id);
+  });
+
+  it("is reachable by keyboard and answers focus, not only a pointer", async () => {
+    stubWidths({ scroll: 480, client: 220 });
+    render(<Row text={LONG} />);
+    // Captured before the tip opens: once it is up, the row and the tip carry
+    // the same string and a text query matches both.
+    const row = screen.getByText(LONG);
+
+    await userEvent.tab();
+
+    expect(row).toHaveFocus();
+    expect(screen.getByRole("tooltip")).toHaveTextContent(LONG);
+  });
+
+  it("dismisses on Escape without waiting for focus to move", async () => {
+    stubWidths({ scroll: 480, client: 220 });
+    render(<Row text={LONG} />);
+    const row = screen.getByText(LONG);
+    await userEvent.tab();
+
+    await userEvent.keyboard("{Escape}");
+
+    expect(screen.queryByRole("tooltip")).toBeNull();
+    // Still focused: Escape dismissed the tip, it did not leave the row.
+    expect(row).toHaveFocus();
+  });
+});
+
+describe("a string its row can already show in full", () => {
+  it("gets no tip on hover, having nothing left to reveal", async () => {
+    stubWidths({ scroll: 220, client: 220 });
+    render(<Row text="Sontana" />);
+
+    await userEvent.hover(screen.getByText("Sontana"));
+
+    expect(screen.queryByRole("tooltip")).toBeNull();
+  });
+
+  it("takes no tab stop, so a page of short names adds none", () => {
+    stubWidths({ scroll: 220, client: 220 });
+    render(<Row text="Sontana" />);
+
+    expect(screen.getByText("Sontana")).not.toHaveAttribute("tabindex");
+  });
+});

--- a/frontend/src/design-system/tooltip.tsx
+++ b/frontend/src/design-system/tooltip.tsx
@@ -1,0 +1,245 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import {
+  type FocusEvent as ReactFocusEvent,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type ReactNode,
+  type RefObject,
+  useCallback,
+  useEffect,
+  useId,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
+import { createPortal } from "react-dom";
+import "./tooltip.css";
+
+// The gap between the anchor's box and the tip, and the margin the tip keeps
+// from the viewport's own edges.
+const ANCHOR_GAP = 6;
+const VIEWPORT_MARGIN = 8;
+
+type TipFrame = Readonly<{
+  left: number;
+  // Exactly one of these is set, for the same reason as the select popup's
+  // frame: a tip placed above the anchor is anchored by its bottom, because
+  // anchoring it by `top` would need its height before it has painted.
+  top?: number;
+  bottom?: number;
+}>;
+
+/**
+ * Where the tip goes: above the anchor by default, below it when the room
+ * above is not enough, and never past the viewport's side edges.
+ *
+ * Above by default because these anchors are headings and row labels — what a
+ * reader wants next is directly under them, and a tip that covers it answers
+ * one question by hiding the next.
+ */
+function frameFor(
+  rect: DOMRect,
+  tip: DOMRect,
+  view: { width: number; height: number },
+): TipFrame {
+  const below = rect.top - ANCHOR_GAP - VIEWPORT_MARGIN < tip.height;
+  const rightEdge = view.width - tip.width - VIEWPORT_MARGIN;
+  // The clamp reads left-to-right: never past the right edge, never before the
+  // left margin. VIEWPORT_MARGIN wins when the tip is wider than the viewport,
+  // which is a tip that has to overflow somewhere and does it on the side the
+  // reader is not reading from.
+  const left = Math.max(VIEWPORT_MARGIN, Math.min(rect.left, rightEdge));
+  return below
+    ? { left, top: rect.bottom + ANCHOR_GAP }
+    : { left, bottom: view.height - rect.top + ANCHOR_GAP };
+}
+
+// The anchor has scrolled out of sight, so the tip has nothing left to point
+// at. A box of zeros is NOT that case: it means nothing has been laid out (a
+// jsdom render, an anchor inside a collapsed section), and there is no position
+// to judge yet.
+function outOfView(rect: DOMRect, viewHeight: number): boolean {
+  const laidOut = rect.width > 0 || rect.height > 0;
+  return laidOut && (rect.bottom <= 0 || rect.top >= viewHeight);
+}
+
+/**
+ * Anchor the tip to its trigger's box.
+ *
+ * Portalled and fixed rather than positioned inside the trigger, because every
+ * trigger this serves is truncating — which means it sits under an
+ * `overflow: hidden` that would clip the tip exactly as it clips the text.
+ *
+ * Deliberately NOT the select's `useAnchoredPopup`: that one sizes its popup to
+ * the trigger's width and gives it a scrollable max-height, which are the two
+ * things a tip must not do — it is as wide as its own wrapped text needs and it
+ * never scrolls. Sharing the hook would mean adding both as options to the
+ * control that has the least room for a regression.
+ */
+function useTipFrame(
+  anchor: RefObject<HTMLElement | null>,
+  tip: RefObject<HTMLElement | null>,
+  open: boolean,
+  onLost: () => void,
+): TipFrame | null {
+  const [frame, setFrame] = useState<TipFrame | null>(null);
+
+  // Layout effect, not effect: the position is computed before the browser
+  // paints, so the tip never appears at the wrong place for one frame.
+  useLayoutEffect(() => {
+    if (!open) {
+      setFrame(null);
+      return;
+    }
+    const place = () => {
+      const element = anchor.current;
+      const box = tip.current;
+      if (!element || !box) {
+        return;
+      }
+      const rect = element.getBoundingClientRect();
+      const view = {
+        width: globalThis.innerWidth,
+        height: globalThis.innerHeight,
+      };
+      if (outOfView(rect, view.height)) {
+        onLost();
+        return;
+      }
+      setFrame(frameFor(rect, box.getBoundingClientRect(), view));
+    };
+    place();
+    // Capture phase: scroll does not bubble, so a listener on the window never
+    // hears the scroller the anchor actually sits in otherwise.
+    globalThis.addEventListener("scroll", place, true);
+    globalThis.addEventListener("resize", place);
+    return () => {
+      globalThis.removeEventListener("scroll", place, true);
+      globalThis.removeEventListener("resize", place);
+    };
+  }, [open, anchor, tip, onLost]);
+
+  return frame;
+}
+
+// A tip is worth showing only for a string the row could not fit. Repeating a
+// name the reader can already read in full is noise, and on a page of short
+// names it would be noise on every row.
+function clipped(element: HTMLElement | null): boolean {
+  return element !== null && element.scrollWidth > element.clientWidth;
+}
+
+type TruncationTooltip<T extends HTMLElement> = Readonly<{
+  /** Goes on the element that truncates. */
+  ref: RefObject<T | null>;
+  /** Spread onto the same element: what opens, closes and describes the tip. */
+  trigger: Readonly<{
+    "aria-describedby"?: string;
+    tabIndex?: number;
+    onPointerEnter: () => void;
+    onPointerLeave: () => void;
+    onFocus: (event: ReactFocusEvent<HTMLElement>) => void;
+    onBlur: () => void;
+    onKeyDown: (event: ReactKeyboardEvent<HTMLElement>) => void;
+  }>;
+  /** Render inside the same element; it portals to the body regardless. */
+  tip: ReactNode;
+}>;
+
+/**
+ * Reveal, on hover or focus, a string that its own row had to truncate.
+ *
+ * A hook rather than a wrapping component because the three strings that need
+ * this are an `h1`, a breadcrumb `span` and a rail row's `span`: a wrapper
+ * would either add an element inside a heading whose one job is to BE the
+ * heading, or take an `as` prop and carry the ref-typing that comes with it.
+ * The caller keeps its own element and spreads this onto it.
+ *
+ * The tip appears only when the text is actually clipped, measured at the
+ * moment of hover rather than at render — the same string is clipped at one
+ * window width and whole at the next, and no render happens in between.
+ *
+ * The element type is the caller's to name (`useTruncationTooltip<HTMLSpanElement>`)
+ * so the ref this hands back fits the element it goes on. A ref typed to
+ * HTMLElement would not: a `Ref<HTMLSpanElement>` may be written by React with
+ * any span, which a holder of the wider type cannot promise to accept.
+ */
+export function useTruncationTooltip<T extends HTMLElement = HTMLElement>(
+  text: string,
+): TruncationTooltip<T> {
+  const anchor = useRef<T | null>(null);
+  const box = useRef<HTMLDivElement | null>(null);
+  const [open, setOpen] = useState(false);
+  // Whether the text is clipped AT REST, which is a different question from
+  // whether to show the tip now: this one decides whether the element is worth
+  // a tab stop, and it has to be answered before anybody reaches it.
+  const [reachable, setReachable] = useState(false);
+  const id = useId();
+  const close = useCallback(() => setOpen(false), []);
+  const frame = useTipFrame(anchor, box, open, close);
+
+  // Measured after every render rather than when `text` changes: the width the
+  // string has to fit in moves for reasons this hook never sees — a rail that
+  // narrowed, a sibling badge that appeared — and re-reading it is one property
+  // read. Setting the same answer twice is a no-op, so this cannot loop.
+  useLayoutEffect(() => {
+    setReachable(clipped(anchor.current));
+  });
+
+  useEffect(() => {
+    const measure = () => setReachable(clipped(anchor.current));
+    globalThis.addEventListener("resize", measure);
+    return () => globalThis.removeEventListener("resize", measure);
+  }, []);
+
+  const reveal = useCallback(() => {
+    const isClipped = clipped(anchor.current);
+    setReachable(isClipped);
+    setOpen(isClipped);
+  }, []);
+
+  return {
+    ref: anchor,
+    trigger: {
+      "aria-describedby": open ? id : undefined,
+      // A truncated string is the one case where a heading or a label earns a
+      // tab stop: without it the whole of it is reachable by pointer only.
+      // Untruncated, it earns nothing and takes none.
+      tabIndex: reachable ? 0 : undefined,
+      onPointerEnter: reveal,
+      onPointerLeave: close,
+      onFocus: reveal,
+      onBlur: close,
+      onKeyDown: (event: ReactKeyboardEvent<HTMLElement>) => {
+        if (event.key === "Escape" && open) {
+          // Stopped, because a tip dismissed by Escape must not also close the
+          // dialog or panel the anchor happens to sit in.
+          event.stopPropagation();
+          close();
+        }
+      },
+    },
+    tip: open
+      ? createPortal(
+          <div
+            className="tooltip"
+            id={id}
+            ref={box}
+            role="tooltip"
+            style={
+              frame
+                ? { left: frame.left, top: frame.top, bottom: frame.bottom }
+                : // Before the first measurement the tip is laid out where it
+                  // can be measured but not seen. It cannot be `display: none`,
+                  // which has no box to measure at all.
+                  { left: 0, top: 0, visibility: "hidden" }
+            }
+          >
+            {text}
+          </div>,
+          document.body,
+        )
+      : null,
+  };
+}

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -682,8 +682,10 @@ export const de = {
   "co.health.payment.onTime": "Zahlt pünktlich.",
   "co.health.sinceInbound": "Sie schrieben zuletzt vor {days} Tagen",
   "co.health.replyBalance": "{percent}% des Austauschs kam von ihnen",
-  "co.health.activeContacts": "{count} Personen hier hatten je Kontakt",
-  "co.health.openCommitments": "{count} offene Zusage(n)",
+  "co.health.activeContacts.one": "{count} Person hier hatte je Kontakt",
+  "co.health.activeContacts.other": "{count} Personen hier hatten je Kontakt",
+  "co.health.openCommitments.one": "{count} offene Zusage",
+  "co.health.openCommitments.other": "{count} offene Zusagen",
   "co.health.singleThreaded": "Ein Kontakt trägt diesen Account",
   "org.partnerSetUp": "Partnerprogramm einrichten",
   // Die Einstufung, wie ein Leser sie sieht. Die Spalte speichert das Enum;

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -692,8 +692,10 @@ export const en = {
   "co.health.payment.onTime": "Pays on time.",
   "co.health.sinceInbound": "They last wrote {days} days ago",
   "co.health.replyBalance": "{percent}% of the exchange came from them",
-  "co.health.activeContacts": "{count} people here have ever interacted",
-  "co.health.openCommitments": "{count} open commitment(s)",
+  "co.health.activeContacts.one": "{count} person here has ever interacted",
+  "co.health.activeContacts.other": "{count} people here have ever interacted",
+  "co.health.openCommitments.one": "{count} open commitment",
+  "co.health.openCommitments.other": "{count} open commitments",
   "co.health.singleThreaded": "One contact carries this account",
   "org.partnerSetUp": "Set up partner programme",
   // The classification values a reader sees. The column stores the enum;

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -676,8 +676,10 @@ export const vi = {
   "co.health.payment.onTime": "Thanh toán đúng hạn.",
   "co.health.sinceInbound": "Họ viết lần cuối cách đây {days} ngày",
   "co.health.replyBalance": "{percent}% lượt trao đổi đến từ họ",
-  "co.health.activeContacts": "{count} người ở đây đã từng tương tác",
-  "co.health.openCommitments": "{count} cam kết đang mở",
+  "co.health.activeContacts.one": "{count} người ở đây đã từng tương tác",
+  "co.health.activeContacts.other": "{count} người ở đây đã từng tương tác",
+  "co.health.openCommitments.one": "{count} cam kết đang mở",
+  "co.health.openCommitments.other": "{count} cam kết đang mở",
   "co.health.singleThreaded": "Cả tài khoản này chỉ dựa vào một contact",
   "org.partnerSetUp": "Thiết lập chương trình đối tác",
   // The classification values a reader sees. The column stores the enum;

--- a/frontend/src/screens/company360.css
+++ b/frontend/src/screens/company360.css
@@ -1033,8 +1033,18 @@
   align-items: baseline;
   justify-content: space-between;
   gap: var(--space-3);
+  /* The row is a grid item, so its floor is its own min-content width — the
+     reason's longest line, which is set nowrap below. Without this the row
+     sizes the rail's whole column and the card overflows; the reason's own
+     min-width: 0 then only decides whether the ellipsis is reachable. */
+  min-width: 0;
 }
+/* min-width: 0 is what makes the ellipsis reachable: a flex item's floor is
+   its min-content width, so without this the longest reason sets the row's
+   width and spills past the rail instead of truncating. The full sentence
+   stays available on the element's title. */
 .co-health-meter-reason {
+  min-width: 0;
   font-size: var(--fs-meta);
   color: var(--textMeta);
   text-align: right;

--- a/frontend/src/screens/companyrail.test.tsx
+++ b/frontend/src/screens/companyrail.test.tsx
@@ -551,6 +551,75 @@ describe("CompanyRail", () => {
     expect(screen.getByText("Replying steadily.")).toBeInTheDocument();
   });
 
+  it("counts one contact and one commitment in the singular", () => {
+    stub();
+    render(
+      <CompanyRail
+        orgId="o-1"
+        view={view({
+          health: {
+            relationship: { rating: "good", reason: "Replying steadily." },
+            active_contacts: 1,
+            open_commitments: 1,
+          },
+        })}
+        loading={false}
+        withPeople
+        composerOpen={false}
+      />,
+    );
+    expect(
+      screen.getByText("1 person here has ever interacted"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("1 open commitment")).toBeInTheDocument();
+  });
+
+  it("counts more than one contact in the plural", () => {
+    stub();
+    render(
+      <CompanyRail
+        orgId="o-1"
+        view={view({
+          health: {
+            relationship: { rating: "good", reason: "Replying steadily." },
+            active_contacts: 3,
+            open_commitments: 2,
+          },
+        })}
+        loading={false}
+        withPeople
+        composerOpen={false}
+      />,
+    );
+    expect(
+      screen.getByText("3 people here have ever interacted"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("2 open commitments")).toBeInTheDocument();
+  });
+
+  // Zero contacts reads as a plural in English, so the count-of-one branch
+  // must not be reached by "not one".
+  it("counts no contacts in the plural", () => {
+    stub();
+    render(
+      <CompanyRail
+        orgId="o-1"
+        view={view({
+          health: {
+            relationship: { rating: "good", reason: "Replying steadily." },
+            active_contacts: 0,
+          },
+        })}
+        loading={false}
+        withPeople
+        composerOpen={false}
+      />,
+    );
+    expect(
+      screen.getByText("0 people here have ever interacted"),
+    ).toBeInTheDocument();
+  });
+
   it("marks a withheld section restricted instead of drawing it empty", () => {
     stub();
     render(

--- a/frontend/src/screens/companyrail.tsx
+++ b/frontend/src/screens/companyrail.tsx
@@ -155,12 +155,22 @@ function HealthSection({
   }
   if (health?.active_contacts != null) {
     lines.push(
-      t("co.health.activeContacts", { count: health.active_contacts }),
+      t(
+        health.active_contacts === 1
+          ? "co.health.activeContacts.one"
+          : "co.health.activeContacts.other",
+        { count: health.active_contacts },
+      ),
     );
   }
   if (health?.open_commitments != null && health.open_commitments > 0) {
     lines.push(
-      t("co.health.openCommitments", { count: health.open_commitments }),
+      t(
+        health.open_commitments === 1
+          ? "co.health.openCommitments.one"
+          : "co.health.openCommitments.other",
+        { count: health.open_commitments },
+      ),
     );
   }
   const state = sectionState(
@@ -199,7 +209,10 @@ function HealthSection({
                   <span className="t-caption">
                     {t(HEALTH_DIMENSION_LABEL[name])}
                   </span>
-                  <span className="co-health-meter-reason">
+                  <span
+                    className="co-health-meter-reason"
+                    title={dimension.reason}
+                  >
                     {dimension.reason}
                   </span>
                 </span>

--- a/frontend/src/screens/companyrail.tsx
+++ b/frontend/src/screens/companyrail.tsx
@@ -6,6 +6,7 @@ import { AvatarStack } from "../design-system/avatarstack";
 import { EvidenceMark } from "../design-system/evidencemark";
 import { Panel, PanelBody, PanelRow } from "../design-system/panel";
 import { Meter } from "../design-system/readings";
+import { useTruncationTooltip } from "../design-system/tooltip";
 import { formatDate } from "../format/format";
 import { useLocale, useT } from "../i18n";
 import { problemCodeOf, throwProblem } from "./common";
@@ -121,6 +122,37 @@ const HEALTH_BADGE_TONE: Record<HealthRating, "danger" | "warn" | "success"> = {
   strong: "success",
 };
 
+// One named dimension: the label, the sentence the rating was read from, and
+// the rating as a bar under both. The reason is server-written prose of no
+// bounded length in a rail this narrow, so it truncates and its tooltip carries
+// the rest — which is also why this is a component and not markup inlined in
+// the map below: the tooltip is a hook, and there is one per dimension.
+function HealthMeter({
+  label,
+  rating,
+  reason,
+}: Readonly<{ label: string; rating: HealthRating; reason?: string }>) {
+  const tip = useTruncationTooltip<HTMLSpanElement>(reason ?? "");
+  return (
+    <div className="co-health-meter">
+      <span className="co-health-meter-head">
+        <span className="t-caption">{label}</span>
+        <span className="co-health-meter-reason" ref={tip.ref} {...tip.trigger}>
+          {reason}
+          {tip.tip}
+        </span>
+      </span>
+      <Meter
+        value={HEALTH_RANK.indexOf(rating) + 1}
+        max={HEALTH_RANK.length}
+        tone={HEALTH_METER_TONE[rating]}
+        flat={!(rating in HEALTH_METER_TONE)}
+        label={label}
+      />
+    </div>
+  );
+}
+
 /**
  * HealthSection is the account's health as one verdict over three named
  * dimensions, each drawn as a meter rather than the badge-and-sentence row
@@ -204,26 +236,12 @@ function HealthSection({
         <PanelBody>
           {dimensions.map(([name, dimension]) =>
             dimension?.rating ? (
-              <div className="co-health-meter" key={name}>
-                <span className="co-health-meter-head">
-                  <span className="t-caption">
-                    {t(HEALTH_DIMENSION_LABEL[name])}
-                  </span>
-                  <span
-                    className="co-health-meter-reason"
-                    title={dimension.reason}
-                  >
-                    {dimension.reason}
-                  </span>
-                </span>
-                <Meter
-                  value={HEALTH_RANK.indexOf(dimension.rating) + 1}
-                  max={HEALTH_RANK.length}
-                  tone={HEALTH_METER_TONE[dimension.rating]}
-                  flat={!(dimension.rating in HEALTH_METER_TONE)}
-                  label={t(HEALTH_DIMENSION_LABEL[name])}
-                />
-              </div>
+              <HealthMeter
+                key={name}
+                label={t(HEALTH_DIMENSION_LABEL[name])}
+                rating={dimension.rating}
+                reason={dimension.reason}
+              />
             ) : null,
           )}
           {lines.length > 0 && (


### PR DESCRIPTION
## What is new

A record's name, the trail segment that carries it, a health dimension's reason, and a FieldGrid value are all user data of unbounded length rendered into a fixed row. Each sat in a flex or grid item whose floor is its own min-content width, so the longest string set the container's width and spilled past the card rather than truncating.

Four places now give way instead:

- **The record header's name** takes one line and truncates. A name at its natural width still keeps the standing badge beside it, so a short name reads exactly as before.
- **The trail's record segment** truncates too, keeping the trail on one line and the agent strip in its place.
- **A health dimension's reason** in the company rail truncates inside its card. This one needed the rule on the grid row above the reason as well: the reason's own `min-width` only decides whether the ellipsis is reachable once the row can shrink at all.
- **A FieldGrid value** breaks a run with no spaces in it. The column could already shrink; the text inside it could not, so a legal name arriving as one long run grew the row straight through the panel's padding and over the card's edge.

The header, the trail and the FieldGrid are shared, so contacts, deals and leads get the same behaviour from the same change.

## Reaching the rest of the string

Truncated, the remainder was unreachable — the reader could see something had been cut and had no way to read it. `useTruncationTooltip` (design-system) is that way.

It is a hook rather than a component because the three anchors are an `h1`, a breadcrumb `span` and a rail `span`: a wrapper would either add an element inside a heading whose one job is to BE the heading, or take an `as` prop and the ref-typing that follows it. The element type is the caller's to name, so the ref fits what it goes on.

Two properties are the whole design:

- **Portalled and fixed**, because every anchor it serves is truncating — which means an `overflow: hidden` that would clip the tip exactly as it clips the text.
- **Only for a string that really is clipped**, measured at the moment of hover rather than at render. A page of short names grows no tips and takes no tab stops; a clipped anchor does take one, since that is the only way the rest of the string is reachable without a pointer.

The show delay is CSS rather than a JS timer, so the tip is in the DOM the moment the pointer arrives — which is what a screen reader announces and what a test can assert without fake timers — and only its paint waits.

## Counting

`co.health.activeContacts` and `co.health.openCommitments` no longer print "1 people here have ever interacted" or "1 open commitment(s)". Both carry `.one`/`.other` forms in every catalog and the caller picks by count, with zero reading as a plural.

## Verification

- `make check-fe` green: lint, typecheck, build, unit, DS gates.
- `make fe-storybook` green — the new story compiles and registers.
- `make fe-uat` green — 14 stories captured, including the three tooltip stories and every component touched here.
- Checked by hand in the browser against a company whose name overruns the header, on a wide and a narrow viewport.

## Known and deliberately not in this change

- The "WHAT THEY ARE" summary value still overruns its card. Same bug class, left for its own change.
- "1 open deals, none stalled." — that plural is written server-side, so it is a backend change rather than one of these.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents long user strings from breaking company pages. Previously, record names, the breadcrumb’s record segment, and health reasons expanded their rows and overflowed cards; now they truncate to one line and reveal the full text via an accessible tooltip. Long unbroken FieldGrid values now wrap; health counts use correct singular/plural.

- CSS/layout: add min-width: 0 to key flex/grid items; ellipsis on the header h1 and `.pagecrumb-name`; keep breadcrumb back/icon fixed; truncate the rail’s reason and its row; set `overflow-wrap: anywhere` for FieldGrid values and inline editors.
- New hook `useTruncationTooltip`: portalled, fixed-position tooltip appears only when text is actually clipped; adds a tab stop only when clipped; Escape dismisses; repositions on scroll/resize; z-index 80; delayed paint via CSS; honors reduced motion by making the fade instant while keeping the show delay.
- Integration: applied to the Record header name (`composed.tsx`), the breadcrumb name (`shell.tsx`), and the company health reason (`companyrail.tsx` via `HealthMeter`).
- i18n: add `.one`/`.other` for `co.health.activeContacts` and `co.health.openCommitments`; callers choose by count (0 uses plural).
- Tests/stories: new tooltip tests and Storybook; updated rail and shell tests.
- Chore: ignore `/.impeccable/` in the repo.

<sup>Written for commit 1a959a29fde3e9eca5c9d518ee45adc6683aa853. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1245?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added accessible tooltips for truncated record names, titles, and health explanations.
  * Long text now truncates or wraps cleanly without disrupting page layouts.
  * Tooltips support keyboard access, Escape dismissal, and reduced-motion preferences.

* **Bug Fixes**
  * Prevented long names and health messages from pushing controls or expanding panels.
  * Improved singular and plural health-summary wording across supported languages.

* **Tests**
  * Added coverage for tooltip behavior, accessibility, truncation, and health-summary pluralization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->