### PR TITLE
docs(status): the collapse's open question is the attempt cap, not the shape

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -701,6 +701,40 @@ workspace GUC; the agent scheduler's suite injects its fault through a trigger
 keyed on `NEW.workspace_id`. Privacy's retention sweep and search's re-embed
 fan-out are the same shape. Their tables go with the fleet loops (§5).
 
+**The vocabulary step is done (#1240); the first collapse hit one open
+question, and it is worth answering before writing code.** `role: worker` now
+exists and the generator accepts a worker that carries its own cadence — that
+much is settled. What stopped the webhook collapse is the **attempt cap**.
+
+`opts_owner` says who supplies River's insert options: `fan_out` (the dispatch
+helper reads `max_attempts` off the spec), `args` (the args type carries them),
+or `caller` (the scheduling code builds them). The manifest refuses a
+`max_attempts` unless the owner is `fan_out`, and it is right to: publishing a
+number nothing enforces is exactly the declared-versus-actual drift the file
+exists to remove.
+
+A collapsed pass is inserted by the periodic schedule, so its owner is `caller`
+or `args` — and today the periodic path (`sweepInsertOpts`) sets uniqueness and
+no cap at all. That was harmless for a dispatcher, whose retry IS its next tick.
+It is not harmless for the sweep it becomes: `webhook_retry_workspace` declared
+`max_attempts: 3` against a 26-minute timeout, and inheriting River's silent
+25-rung ladder instead would be a real change nobody chose.
+
+Three ways out, in the order they seem worth considering:
+
+1. **Let a worker declare `max_attempts` with `opts_owner: args`**, and gate that
+   the args type's `InsertOpts` actually carry the declared number. Keeps the cap
+   in the census, where the whole point of the manifest is that it is visible.
+2. **Set the cap in the caller** beside the periodic insert. Consistent with how
+   all 27 dispatchers work today, and it puts a materially different retry
+   ladder somewhere the census cannot see.
+3. **Give the periodic path a per-kind opts hook** — the general form of (2),
+   and probably more machinery than one number deserves.
+
+(1) looks right and is a small extension rather than a new concept, but it is a
+change to what the contract governs, so it wants deciding rather than
+discovering. Nothing else in the collapse is blocked on it.
+
 **The target shape is decided upstream — build against it, do not re-derive
 it.** ADR-0103 / DECISIONS **A154** (margince-foundation, PROPOSED 2026-08-14)
 settles what ADR-0091 §5 left open.


### PR DESCRIPTION
The vocabulary step landed (#1240) and the generator now accepts a worker that carries its own cadence. The **webhook collapse then stopped on something ADR-0103 did not reach**: who owns the attempt cap once a pass is *ticked* rather than *fanned out*.

`opts_owner` says who supplies River's insert options — `fan_out` (the dispatch helper reads `max_attempts` off the spec), `args`, or `caller`. The manifest **refuses** a `max_attempts` unless the owner is `fan_out`, and it is right to: publishing a number nothing enforces is the declared-versus-actual drift the file exists to remove.

A collapsed pass is inserted by the periodic schedule, so its owner is `caller` or `args` — and the periodic path (`sweepInsertOpts`) sets uniqueness and **no cap at all**. Harmless for a dispatcher, whose retry *is* its next tick. Not harmless for the sweep it becomes: `webhook_retry_workspace` declared `max_attempts: 3` against a 26-minute timeout, and silently inheriting River's 25-rung ladder would be a change nobody chose.

Three ways out are written down with a recommendation (let a worker declare the cap with `opts_owner: args`, gated so the args type's `InsertOpts` actually carry it — keeps the number in the census). It is a small extension to what the contract governs, which is exactly the kind of thing worth deciding rather than discovering halfway through a module.

Nothing else in the collapse is blocked on it. Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents the open decision in STATUS.md: who owns the retry attempt cap when collapsing webhook fan-out into a scheduled worker. This avoids an unintended shift from a declared 3 attempts to River’s default 25.

**What’s recorded**
- Clarifies `opts_owner` (`fan_out`, `args`, `caller`) and the current rule that the manifest only accepts `max_attempts` when `opts_owner: fan_out`.
- Notes the periodic path (`sweepInsertOpts`) sets uniqueness but no cap, so collapsed passes would inherit the default ladder.
- Lists three paths and recommends allowing workers to declare `max_attempts` via `opts_owner: args`, gated by the args type’s `InsertOpts`, to keep the cap visible in the census.
- Docs only; no behavior change. Other collapse work is not blocked on this.

<sup>Written for commit f75407f1fc9dc320184b4a76739e9f17b9d77a04. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1246?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a status note documenting the completed job vocabulary update.
  - Recorded the remaining webhook-collapse blocker related to retry limits for periodic workers.
  - Clarified ownership rules for maximum attempts and documented the discrepancy between the declared three-attempt limit and current retry behavior.
  - Listed potential implementation approaches for enforcing retry caps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->