### PR TITLE
feat(activities): a meeting transcript is ingested as text (#702, part 1/2)

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -3288,6 +3288,25 @@ paths:
                   links:
                     - { entity_type: deal, entity_id: 018f3a1b-0000-7000-8000-000000000030 }
                   source: 'email:CAF=abc@mail.gmail.com'
+              transcript:
+                summary: 'A pasted or uploaded meeting transcript (ADR-0058) — no new operation, this one'
+                description: >-
+                  `source_system: transcript` on a `call`/`meeting` activity normalizes `body` server-side
+                  to ADR-0058's canonical form (newlines unified, trailing whitespace trimmed per line) —
+                  the same mapping every transport shares, so a pasted transcript and an agent-supplied one
+                  land identically. Only `call`/`meeting` accept it; any other `kind` is refused 422. There
+                  is no presigned file-upload path in V1 — a `.txt`/`.vtt` file is read to text client-side
+                  and sent the same way a paste is.
+                value:
+                  kind: meeting
+                  body: |-
+                    Anna: Let's ship the proposal by Friday.
+                    Ben: Works for me, I'll review Thursday.
+                  occurred_at: '2026-05-02T16:00:00Z'
+                  source_system: transcript
+                  links:
+                    - { entity_type: deal, entity_id: 018f3a1b-0000-7000-8000-000000000030 }
+                  source: ui
       responses:
         '201':
           description: Created activity.

--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -3289,14 +3289,15 @@ paths:
                     - { entity_type: deal, entity_id: 018f3a1b-0000-7000-8000-000000000030 }
                   source: 'email:CAF=abc@mail.gmail.com'
               transcript:
-                summary: 'A pasted or uploaded meeting transcript (ADR-0058) — no new operation, this one'
+                summary: 'A pasted or uploaded meeting transcript (ADR-0058)'
                 description: >-
                   `source_system: transcript` on a `call`/`meeting` activity normalizes `body` server-side
-                  to ADR-0058's canonical form (newlines unified, trailing whitespace trimmed per line) —
-                  the same mapping every transport shares, so a pasted transcript and an agent-supplied one
-                  land identically. Only `call`/`meeting` accept it; any other `kind` is refused 422. There
-                  is no presigned file-upload path in V1 — a `.txt`/`.vtt` file is read to text client-side
-                  and sent the same way a paste is.
+                  to ADR-0058's canonical form (newlines unified, control bytes other than tab stripped,
+                  trailing whitespace trimmed per line, capped at 256 KiB) — the same mapping every
+                  transport shares, so a pasted transcript and an agent-supplied one land identically. Only
+                  `call`/`meeting` accept it; any other `kind` is refused 422. There is no presigned
+                  file-upload path in V1 — a plain-text `.txt` file is read to text client-side and sent
+                  the same way a paste is.
                 value:
                   kind: meeting
                   body: |-

--- a/backend/internal/modules/activities/handlers_channelsend.go
+++ b/backend/internal/modules/activities/handlers_channelsend.go
@@ -61,7 +61,7 @@ func (h Handlers) SendMessage(w http.ResponseWriter, r *http.Request, id crmcont
 // reach exactly one person.
 func writeChannelSendErr(w http.ResponseWriter, r *http.Request, err error) {
 	if errors.Is(err, errEmptyMessageBody) {
-		httperr.Write(w, r, httperr.Validation("body", "empty_message_body", errEmptyMessageBody.Error()))
+		httperr.Write(w, r, httperr.Validation(fieldBody, "empty_message_body", errEmptyMessageBody.Error()))
 		return
 	}
 	writeStoreErr(w, r, err)

--- a/backend/internal/modules/activities/lifecycle.go
+++ b/backend/internal/modules/activities/lifecycle.go
@@ -57,31 +57,11 @@ func (s *Store) UpdateActivity(ctx context.Context, id ids.ActivityID, in Update
 		if in.IfVersion != nil && current.Version != nil && int64(*current.Version) != *in.IfVersion {
 			return apperrors.ErrVersionSkew
 		}
-		// A transcript's normalized form is only ever produced on ingest
-		// (LogActivityInputFrom): without this, a PATCH could leave a
-		// transcript-marked row holding un-normalized text (raw CRLFs,
-		// trailing whitespace), which is exactly the row the
-		// activity/transcript retention selector and any future line
-		// citation both assume is already canonical.
-		if in.Body != nil && current.SourceSystem != nil && *current.SourceSystem == transcriptSourceSystem {
-			normalized, err := normalizeTranscript(*in.Body)
-			if err != nil {
-				return err
-			}
-			in.Body = &normalized
+		if err := renormalizeTranscriptPatch(current, &in); err != nil {
+			return err
 		}
-		if in.AssigneeID != nil {
-			// A client-supplied user reference is still a reference; the
-			// FK checks existence, RLS the tenancy.
-			var exists bool
-			if err := tx.QueryRow(ctx,
-				`SELECT EXISTS (SELECT 1 FROM app_user WHERE id = $1 AND status = 'active' AND archived_at IS NULL)`,
-				*in.AssigneeID).Scan(&exists); err != nil {
-				return err
-			}
-			if !exists {
-				return apperrors.ErrNotFound
-			}
+		if err := ensureAssigneeExists(ctx, tx, in.AssigneeID); err != nil {
+			return err
 		}
 		// done_at travels WITH is_done (the activity_done_at CHECK):
 		// completion stamps the moment, reopening clears it.
@@ -115,6 +95,44 @@ func (s *Store) UpdateActivity(ctx context.Context, id ids.ActivityID, in Update
 		return err
 	})
 	return out, err
+}
+
+// renormalizeTranscriptPatch re-runs ADR-0058's normalizer on a body PATCH
+// when the target row is transcript-marked. A transcript's normalized form
+// is only ever produced on ingest (LogActivityInputFrom) — without this, a
+// PATCH could leave a transcript-marked row holding un-normalized text (raw
+// CRLFs, trailing whitespace), which is exactly the row the
+// activity/transcript retention selector and any future line citation both
+// assume is already canonical.
+func renormalizeTranscriptPatch(current crmcontracts.Activity, in *UpdateActivityInput) error {
+	if in.Body == nil || current.SourceSystem == nil || *current.SourceSystem != transcriptSourceSystem {
+		return nil
+	}
+	normalized, err := normalizeTranscript(*in.Body)
+	if err != nil {
+		return err
+	}
+	in.Body = &normalized
+	return nil
+}
+
+// ensureAssigneeExists checks a client-supplied user reference before it
+// lands: the FK checks existence, RLS the tenancy. Nil means the patch
+// doesn't touch the assignee, which is not this function's to gate.
+func ensureAssigneeExists(ctx context.Context, tx pgx.Tx, assigneeID *ids.UserID) error {
+	if assigneeID == nil {
+		return nil
+	}
+	var exists bool
+	if err := tx.QueryRow(ctx,
+		`SELECT EXISTS (SELECT 1 FROM app_user WHERE id = $1 AND status = 'active' AND archived_at IS NULL)`,
+		*assigneeID).Scan(&exists); err != nil {
+		return err
+	}
+	if !exists {
+		return apperrors.ErrNotFound
+	}
+	return nil
 }
 
 func (s *Store) ArchiveActivity(ctx context.Context, id ids.ActivityID) (crmcontracts.Activity, error) {

--- a/backend/internal/modules/activities/lifecycle.go
+++ b/backend/internal/modules/activities/lifecycle.go
@@ -57,6 +57,19 @@ func (s *Store) UpdateActivity(ctx context.Context, id ids.ActivityID, in Update
 		if in.IfVersion != nil && current.Version != nil && int64(*current.Version) != *in.IfVersion {
 			return apperrors.ErrVersionSkew
 		}
+		// A transcript's normalized form is only ever produced on ingest
+		// (LogActivityInputFrom): without this, a PATCH could leave a
+		// transcript-marked row holding un-normalized text (raw CRLFs,
+		// trailing whitespace), which is exactly the row the
+		// activity/transcript retention selector and any future line
+		// citation both assume is already canonical.
+		if in.Body != nil && current.SourceSystem != nil && *current.SourceSystem == transcriptSourceSystem {
+			normalized, err := normalizeTranscript(*in.Body)
+			if err != nil {
+				return err
+			}
+			in.Body = &normalized
+		}
 		if in.AssigneeID != nil {
 			// A client-supplied user reference is still a reference; the
 			// FK checks existence, RLS the tenancy.

--- a/backend/internal/modules/activities/mapping.go
+++ b/backend/internal/modules/activities/mapping.go
@@ -26,6 +26,27 @@ func (e *RequiredFieldError) FieldFault() (field, code, message string) {
 	return e.Field, "required", e.Error()
 }
 
+// transcriptSourceSystem is the ADR-0058 marker: a `logActivity` call
+// carrying it identifies its body as pasted/uploaded transcript text rather
+// than ordinary meeting notes, which is what routes it through
+// normalizeTranscript and what the activity/transcript retention selector
+// (privacy/retentionselectors.go) keys its sweep on.
+const transcriptSourceSystem = "transcript"
+
+// TranscriptKindError maps to 422: a transcript is a recording of a
+// conversation, so it only makes sense on the two activity kinds that ARE
+// one.
+type TranscriptKindError struct{ Kind string }
+
+func (e *TranscriptKindError) Error() string {
+	return "a transcript may only be attached to a call or meeting activity, not " + e.Kind
+}
+
+// FieldFault names the offending field, on every surface.
+func (e *TranscriptKindError) FieldFault() (field, code, message string) {
+	return "kind", "invalid", e.Error()
+}
+
 // pathID asserts a contract path id as entity K's id — the widening
 // point between the wire and the typed store surface (the route already
 // names the entity, so the assertion lives here, not in the store).
@@ -105,6 +126,20 @@ func LogActivityInputFrom(req crmcontracts.CreateActivityRequest) (LogActivityIn
 				EntityID:   ids.UUID(link.EntityId),
 			})
 		}
+	}
+	if in.SourceSystem != nil && *in.SourceSystem == transcriptSourceSystem {
+		if in.Kind != string(crmcontracts.ActivityKindCall) && in.Kind != string(crmcontracts.ActivityKindMeeting) {
+			return LogActivityInput{}, &TranscriptKindError{Kind: in.Kind}
+		}
+		var body string
+		if in.Body != nil {
+			body = *in.Body
+		}
+		normalized, err := normalizeTranscript(body)
+		if err != nil {
+			return LogActivityInput{}, err
+		}
+		in.Body = &normalized
 	}
 	return in, nil
 }

--- a/backend/internal/modules/activities/mapping.go
+++ b/backend/internal/modules/activities/mapping.go
@@ -26,6 +26,11 @@ func (e *RequiredFieldError) FieldFault() (field, code, message string) {
 	return e.Field, "required", e.Error()
 }
 
+// fieldBody names the activity body field in a FieldFault, the one spelling
+// every 422 that refuses something about it shares (mirrors activity.go's
+// fieldKind).
+const fieldBody = "body"
+
 // transcriptSourceSystem is the ADR-0058 marker: a `logActivity` call
 // carrying it identifies its body as pasted/uploaded transcript text rather
 // than ordinary meeting notes, which is what routes it through

--- a/backend/internal/modules/activities/mapping.go
+++ b/backend/internal/modules/activities/mapping.go
@@ -35,14 +35,17 @@ const transcriptSourceSystem = "transcript"
 
 // TranscriptKindError maps to 422: a transcript is a recording of a
 // conversation, so it only makes sense on the two activity kinds that ARE
-// one.
+// one. The message never echoes the caller's kind — this fires before the
+// kind ever reaches the DB CHECK that would otherwise be the only
+// validation of it, so an unbounded value has no other floor here.
 type TranscriptKindError struct{ Kind string }
 
 func (e *TranscriptKindError) Error() string {
-	return "a transcript may only be attached to a call or meeting activity, not " + e.Kind
+	return "only a call or meeting activity may carry a transcript"
 }
 
-// FieldFault names the offending field, on every surface.
+// FieldFault names the offending field; the caller's value is left to the
+// wire's own field pointer, not interpolated into the message.
 func (e *TranscriptKindError) FieldFault() (field, code, message string) {
 	return "kind", "invalid", e.Error()
 }

--- a/backend/internal/modules/activities/mapping_transcript_test.go
+++ b/backend/internal/modules/activities/mapping_transcript_test.go
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package activities
+
+// LogActivityInputFrom is the one mapping the HTTP handler, the SoR/MCP
+// provider path, and the extension core-write seam all share (mapping.go's
+// own doc comment) — normalizing a transcript here, rather than in each
+// caller, is what makes "paste via the UI" and "log_activity via an agent"
+// land the identical stored form.
+
+import (
+	"errors"
+	"testing"
+
+	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+)
+
+func TestActivityLogInputNormalizesATranscriptBody(t *testing.T) {
+	transcript := "transcript"
+	raw := "Anna: hello   \r\nBen: hi\r\n"
+	in, err := LogActivityInputFrom(crmcontracts.CreateActivityRequest{
+		Kind: "meeting", SourceSystem: &transcript, Body: &raw,
+	})
+	if err != nil {
+		t.Fatalf("a transcript on a meeting must be accepted: %v", err)
+	}
+	if in.Body == nil || *in.Body != "Anna: hello\nBen: hi" {
+		t.Errorf("Body = %v, want the normalized form", in.Body)
+	}
+}
+
+func TestActivityLogInputRefusesATranscriptOnAKindThatIsNotCallOrMeeting(t *testing.T) {
+	transcript := "transcript"
+	body := "Anna: hello"
+	_, err := LogActivityInputFrom(crmcontracts.CreateActivityRequest{
+		Kind: "note", SourceSystem: &transcript, Body: &body,
+	})
+	var wrongKind *TranscriptKindError
+	if !errors.As(err, &wrongKind) {
+		t.Fatalf("err = %v, want *TranscriptKindError — a transcript is not a note", err)
+	}
+}
+
+func TestActivityLogInputRefusesABlankTranscript(t *testing.T) {
+	transcript := "transcript"
+	blank := "   \n\n"
+	_, err := LogActivityInputFrom(crmcontracts.CreateActivityRequest{
+		Kind: "call", SourceSystem: &transcript, Body: &blank,
+	})
+	if !errors.Is(err, ErrBlankTranscript) {
+		t.Fatalf("err = %v, want ErrBlankTranscript", err)
+	}
+}

--- a/backend/internal/modules/activities/mapping_transcript_test.go
+++ b/backend/internal/modules/activities/mapping_transcript_test.go
@@ -40,6 +40,16 @@ func TestActivityLogInputRefusesATranscriptOnAKindThatIsNotCallOrMeeting(t *test
 	if !errors.As(err, &wrongKind) {
 		t.Fatalf("err = %v, want *TranscriptKindError — a transcript is not a note", err)
 	}
+	// The refusal must never echo the caller's own kind value back — it fires
+	// before the kind ever reaches the DB CHECK that would otherwise be its
+	// only validation.
+	if wrongKind.Error() != "only a call or meeting activity may carry a transcript" {
+		t.Errorf("Error() = %q, echoes or otherwise varies with the caller's kind", wrongKind.Error())
+	}
+	field, code, _ := wrongKind.FieldFault()
+	if field != "kind" || code != "invalid" {
+		t.Errorf("FieldFault() = (%q, %q, _), want (kind, invalid, _)", field, code)
+	}
 }
 
 func TestActivityLogInputRefusesABlankTranscript(t *testing.T) {

--- a/backend/internal/modules/activities/transcript_integration_test.go
+++ b/backend/internal/modules/activities/transcript_integration_test.go
@@ -5,18 +5,18 @@
 
 package activities
 
-// A transcript lands through the real write shape exactly like any other
-// logged activity — normalized, linked, and carrying the source_system the
+// A transcript lands normalized, linked, and carrying the source_system the
 // privacy module's activity/transcript retention selector
-// (internal/modules/privacy/retentionselectors.go) keys its sweep on. This
-// proves the two sides of that contract actually agree: this module writes
-// what that selector expects, not just what a unit test asserts in isolation.
+// (internal/modules/privacy/retentionselectors.go) keys its sweep on — this
+// proves the two sides of that contract actually agree against a real row,
+// not just what a unit test asserts over the mapping in isolation.
 
 import (
 	"context"
 	"testing"
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
 
@@ -63,5 +63,41 @@ func TestLogActivityNormalizesAndStoresATranscript(t *testing.T) {
 	}
 	if storedBody == nil {
 		t.Fatal("body is NULL — the retention selector's body IS NOT NULL clause would skip this row")
+	}
+}
+
+// TestUpdateActivityNormalizesATranscriptBody: the create path is not the
+// only writer of activity.body — a PATCH that skipped normalization would
+// leave a transcript-marked row holding raw CRLFs and trailing whitespace,
+// which is exactly the row the retention selector and any future line
+// citation both assume is already canonical.
+func TestUpdateActivityNormalizesATranscriptBody(t *testing.T) {
+	e := setupSend(t)
+	ctx := e.as(principal.RowScopeAll)
+	store := e.store(nil)
+
+	raw := "Anna: hello"
+	sourceSystem := "transcript"
+	in, err := LogActivityInputFrom(crmcontracts.CreateActivityRequest{
+		Kind: "call", Body: &raw, SourceSystem: &sourceSystem, Source: "ui",
+	})
+	if err != nil {
+		t.Fatalf("LogActivityInputFrom: %v", err)
+	}
+	activity, _, err := store.LogActivity(ctx, in)
+	if err != nil {
+		t.Fatalf("LogActivity: %v", err)
+	}
+
+	unnormalized := "Anna: hello   \r\nBen: hi\r\n"
+	updated, err := store.UpdateActivity(ctx, ids.From[ids.ActivityKind](ids.UUID(activity.Id)), UpdateActivityInput{
+		Body: &unnormalized,
+	})
+	if err != nil {
+		t.Fatalf("UpdateActivity: %v", err)
+	}
+	want := "Anna: hello\nBen: hi"
+	if updated.Body == nil || *updated.Body != want {
+		t.Errorf("Body = %v, want %q — a PATCH must normalize a transcript-marked row the same as create does", updated.Body, want)
 	}
 }

--- a/backend/internal/modules/activities/transcript_integration_test.go
+++ b/backend/internal/modules/activities/transcript_integration_test.go
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package activities
+
+// A transcript lands through the real write shape exactly like any other
+// logged activity — normalized, linked, and carrying the source_system the
+// privacy module's activity/transcript retention selector
+// (internal/modules/privacy/retentionselectors.go) keys its sweep on. This
+// proves the two sides of that contract actually agree: this module writes
+// what that selector expects, not just what a unit test asserts in isolation.
+
+import (
+	"context"
+	"testing"
+
+	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+)
+
+func TestLogActivityNormalizesAndStoresATranscript(t *testing.T) {
+	e := setupSend(t)
+	ctx := e.as(principal.RowScopeAll)
+
+	raw := "Anna: Let's ship by Friday.   \r\nBen: Works for me.\r\n"
+	sourceSystem := "transcript"
+	// Through LogActivityInputFrom, exactly as the HTTP handler and the MCP
+	// provider path both do (mapping.go's own doc comment) — a test that
+	// hand-built LogActivityInput would skip the mapping and prove nothing
+	// about what a real caller sends.
+	in, err := LogActivityInputFrom(crmcontracts.CreateActivityRequest{
+		Kind: "meeting", Body: &raw, SourceSystem: &sourceSystem, Source: "ui",
+	})
+	if err != nil {
+		t.Fatalf("LogActivityInputFrom: %v", err)
+	}
+	activity, created, err := e.store(nil).LogActivity(ctx, in)
+	if err != nil {
+		t.Fatalf("LogActivity: %v", err)
+	}
+	if !created {
+		t.Fatal("created = false on the first write")
+	}
+	if activity.Body == nil || *activity.Body != "Anna: Let's ship by Friday.\nBen: Works for me." {
+		t.Errorf("Body = %v, want the normalized form", activity.Body)
+	}
+
+	// The exact predicate activity/transcript's selector runs
+	// (retentionselectors.go: `source_system = 'transcript' AND body IS NOT
+	// NULL`) — reading the raw column proves this write satisfies it, not
+	// just that the Go struct looks right.
+	var storedSourceSystem string
+	var storedBody *string
+	if err := e.owner.QueryRow(context.Background(),
+		`SELECT source_system, body FROM activity WHERE id = $1`, activity.Id,
+	).Scan(&storedSourceSystem, &storedBody); err != nil {
+		t.Fatalf("reading back the row: %v", err)
+	}
+	if storedSourceSystem != "transcript" {
+		t.Errorf("source_system = %q, want transcript — the retention selector would never see this row", storedSourceSystem)
+	}
+	if storedBody == nil {
+		t.Fatal("body is NULL — the retention selector's body IS NOT NULL clause would skip this row")
+	}
+}

--- a/backend/internal/modules/activities/transcript_integration_test.go
+++ b/backend/internal/modules/activities/transcript_integration_test.go
@@ -13,6 +13,7 @@ package activities
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
@@ -99,5 +100,36 @@ func TestUpdateActivityNormalizesATranscriptBody(t *testing.T) {
 	want := "Anna: hello\nBen: hi"
 	if updated.Body == nil || *updated.Body != want {
 		t.Errorf("Body = %v, want %q — a PATCH must normalize a transcript-marked row the same as create does", updated.Body, want)
+	}
+}
+
+// TestUpdateActivityRefusesABlankTranscriptPatch: the PATCH path's
+// normalization runs the same refusal as create — a transcript-marked row
+// cannot be edited down to whitespace any more than one can be created that
+// way.
+func TestUpdateActivityRefusesABlankTranscriptPatch(t *testing.T) {
+	e := setupSend(t)
+	ctx := e.as(principal.RowScopeAll)
+	store := e.store(nil)
+
+	raw := "Anna: hello"
+	sourceSystem := "transcript"
+	in, err := LogActivityInputFrom(crmcontracts.CreateActivityRequest{
+		Kind: "call", Body: &raw, SourceSystem: &sourceSystem, Source: "ui",
+	})
+	if err != nil {
+		t.Fatalf("LogActivityInputFrom: %v", err)
+	}
+	activity, _, err := store.LogActivity(ctx, in)
+	if err != nil {
+		t.Fatalf("LogActivity: %v", err)
+	}
+
+	blank := "   \n\n"
+	_, err = store.UpdateActivity(ctx, ids.From[ids.ActivityKind](ids.UUID(activity.Id)), UpdateActivityInput{
+		Body: &blank,
+	})
+	if !errors.Is(err, ErrBlankTranscript) {
+		t.Fatalf("err = %v, want ErrBlankTranscript", err)
 	}
 }

--- a/backend/internal/modules/activities/transcriptnorm.go
+++ b/backend/internal/modules/activities/transcriptnorm.go
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package activities
+
+// ADR-0058's canonical transcript form: split on newlines, trim trailing
+// whitespace per line, 1-indexed. 1-indexing is a property of the STORED
+// form rather than a separate persisted value — line N is the Nth
+// newline-split segment (1-based) of activity.body — so any later reader
+// (PR B's next-step proposal citing a line) reproduces the same index by
+// splitting the identical way, with nothing to drift out of sync.
+
+import "strings"
+
+// blankTranscriptError maps to 422 (apperrors.FieldFault) — a whitespace-only
+// paste is not a recording of anything, refused before it ever reaches a
+// stored activity row.
+type blankTranscriptError struct{}
+
+func (blankTranscriptError) Error() string { return "transcript text is blank" }
+
+func (blankTranscriptError) FieldFault() (field, code, message string) {
+	return "body", "blank_transcript", "transcript text is blank"
+}
+
+// ErrBlankTranscript is the comparable sentinel a caller matches with
+// errors.Is; it is also the concrete value returned, so the FieldFault
+// httperr.Write needs is always reachable without an extra wrap.
+var ErrBlankTranscript error = blankTranscriptError{}
+
+// normalizeTranscript canonicalizes pasted or uploaded transcript text: CRLF
+// and lone CR both fold to LF, each line's trailing whitespace is trimmed,
+// and the result is refused if nothing but whitespace survives.
+func normalizeTranscript(raw string) (string, error) {
+	unified := strings.ReplaceAll(raw, "\r\n", "\n")
+	unified = strings.ReplaceAll(unified, "\r", "\n")
+	// A trailing newline is line-ending punctuation, not a blank final turn —
+	// dropping it here is what keeps "pasted with an editor's final newline"
+	// and "pasted without one" produce the identical stored form.
+	unified = strings.TrimSuffix(unified, "\n")
+	lines := strings.Split(unified, "\n")
+	for i, line := range lines {
+		lines[i] = strings.TrimRight(line, " \t")
+	}
+	normalized := strings.Join(lines, "\n")
+	if strings.TrimSpace(normalized) == "" {
+		return "", ErrBlankTranscript
+	}
+	return normalized, nil
+}

--- a/backend/internal/modules/activities/transcriptnorm.go
+++ b/backend/internal/modules/activities/transcriptnorm.go
@@ -44,7 +44,7 @@ func (e blankTranscriptError) Error() string {
 }
 
 func (blankTranscriptError) FieldFault() (field, code, message string) {
-	return "body", "blank_transcript", "transcript text is blank; paste the transcript, or omit source_system: transcript to log the meeting without one"
+	return fieldBody, "blank_transcript", "transcript text is blank; paste the transcript, or omit source_system: transcript to log the meeting without one"
 }
 
 // ErrBlankTranscript is the comparable sentinel a caller matches with
@@ -61,7 +61,7 @@ func (e oversizedTranscriptError) Error() string {
 }
 
 func (e oversizedTranscriptError) FieldFault() (field, code, message string) {
-	return "body", "transcript_too_large", fmt.Sprintf(
+	return fieldBody, "transcript_too_large", fmt.Sprintf(
 		"transcript text is %d bytes, over the %d-byte limit; split it into more than one activity", e.bytes, maxTranscriptBytes)
 }
 

--- a/backend/internal/modules/activities/transcriptnorm.go
+++ b/backend/internal/modules/activities/transcriptnorm.go
@@ -3,24 +3,48 @@
 
 package activities
 
-// ADR-0058's canonical transcript form: split on newlines, trim trailing
-// whitespace per line, 1-indexed. 1-indexing is a property of the STORED
-// form rather than a separate persisted value — line N is the Nth
-// newline-split segment (1-based) of activity.body — so any later reader
-// (PR B's next-step proposal citing a line) reproduces the same index by
-// splitting the identical way, with nothing to drift out of sync.
+// ADR-0058's line-addressing half of the canonical transcript form: split on
+// newlines, trim trailing whitespace per line, 1-indexed. (The other half —
+// parsing a leading `Speaker:` prefix into a structured field — is left
+// inline in the line text rather than extracted, since nothing here persists
+// per-line rows; a future reader that needs the speaker separately parses
+// the same text the same way.) 1-indexing is a property of the STORED form
+// rather than a separate persisted value — line N is the Nth newline-split
+// segment (1-based) of activity.body — so any later reader reproduces the
+// same index by splitting the identical way, with nothing to drift out of
+// sync.
 
-import "strings"
+import (
+	"fmt"
+	"strings"
+)
+
+// maxTranscriptBytes bounds the raw paste, well under the ~950 KB a body can
+// reach before Postgres's tsvector output (activity.search_tsv is a
+// GENERATED column over subject+body) exceeds its own 1,048,575-byte limit
+// and the write fails with an unmapped 54000 — a bound the request-size
+// chassis cap (1 MiB) does not itself prevent.
+const maxTranscriptBytes = 256 * 1024
+
+// utf8BOM is a leading byte-order mark, stripped rather than treated as
+// content — a file exported by a Windows tool and read to text client-side
+// carries one, and a paste from the same source usually doesn't, so leaving
+// it in would make the two land as different stored text for the same
+// transcript.
+const utf8BOM = "\uFEFF"
 
 // blankTranscriptError maps to 422 (apperrors.FieldFault) — a whitespace-only
 // paste is not a recording of anything, refused before it ever reaches a
 // stored activity row.
 type blankTranscriptError struct{}
 
-func (blankTranscriptError) Error() string { return "transcript text is blank" }
+func (e blankTranscriptError) Error() string {
+	field, _, message := e.FieldFault()
+	return field + ": " + message
+}
 
 func (blankTranscriptError) FieldFault() (field, code, message string) {
-	return "body", "blank_transcript", "transcript text is blank"
+	return "body", "blank_transcript", "transcript text is blank; paste the transcript, or omit source_system: transcript to log the meeting without one"
 }
 
 // ErrBlankTranscript is the comparable sentinel a caller matches with
@@ -28,15 +52,36 @@ func (blankTranscriptError) FieldFault() (field, code, message string) {
 // httperr.Write needs is always reachable without an extra wrap.
 var ErrBlankTranscript error = blankTranscriptError{}
 
-// normalizeTranscript canonicalizes pasted or uploaded transcript text: CRLF
-// and lone CR both fold to LF, each line's trailing whitespace is trimmed,
-// and the result is refused if nothing but whitespace survives.
+// oversizedTranscriptError maps to 422 (apperrors.FieldFault).
+type oversizedTranscriptError struct{ bytes int }
+
+func (e oversizedTranscriptError) Error() string {
+	field, _, message := e.FieldFault()
+	return field + ": " + message
+}
+
+func (e oversizedTranscriptError) FieldFault() (field, code, message string) {
+	return "body", "transcript_too_large", fmt.Sprintf(
+		"transcript text is %d bytes, over the %d-byte limit; split it into more than one activity", e.bytes, maxTranscriptBytes)
+}
+
+// normalizeTranscript canonicalizes pasted or uploaded transcript text: a
+// leading byte-order mark is stripped, CRLF and lone CR both fold to LF,
+// NUL and every other C0 control byte but LF/TAB are stripped (Postgres
+// refuses NUL outright, and the rest have no place in a spoken-word
+// transcript), each line's trailing whitespace is trimmed, and the result
+// is refused if it is blank or over the size bound.
 func normalizeTranscript(raw string) (string, error) {
-	unified := strings.ReplaceAll(raw, "\r\n", "\n")
+	if len(raw) > maxTranscriptBytes {
+		return "", oversizedTranscriptError{bytes: len(raw)}
+	}
+	unified := strings.TrimPrefix(raw, utf8BOM)
+	unified = strings.ReplaceAll(unified, "\r\n", "\n")
 	unified = strings.ReplaceAll(unified, "\r", "\n")
+	unified = stripOtherControlBytes(unified)
 	// A trailing newline is line-ending punctuation, not a blank final turn —
-	// dropping it here is what keeps "pasted with an editor's final newline"
-	// and "pasted without one" produce the identical stored form.
+	// dropping it here is what keeps a paste with an editor's final newline
+	// and the identical paste without one producing the same stored form.
 	unified = strings.TrimSuffix(unified, "\n")
 	lines := strings.Split(unified, "\n")
 	for i, line := range lines {
@@ -47,4 +92,17 @@ func normalizeTranscript(raw string) (string, error) {
 		return "", ErrBlankTranscript
 	}
 	return normalized, nil
+}
+
+// stripOtherControlBytes drops every C0 control byte except the LF this
+// function's caller splits lines on and the TAB a transcript's trailing-
+// whitespace trim already handles — NUL above all, which Postgres refuses
+// outright ("invalid byte sequence for encoding UTF8") rather than storing.
+func stripOtherControlBytes(s string) string {
+	return strings.Map(func(r rune) rune {
+		if r < 0x20 && r != '\n' && r != '\t' {
+			return -1
+		}
+		return r
+	}, s)
 }

--- a/backend/internal/modules/activities/transcriptnorm_test.go
+++ b/backend/internal/modules/activities/transcriptnorm_test.go
@@ -94,4 +94,29 @@ func TestNormalizeTranscriptRefusesAnOversizedTranscript(t *testing.T) {
 	if !errors.As(err, &tooLarge) {
 		t.Fatalf("err = %v, want oversizedTranscriptError", err)
 	}
+	if !strings.Contains(tooLarge.Error(), "over the") {
+		t.Errorf("Error() = %q, want it to name the bound", tooLarge.Error())
+	}
+	field, code, message := tooLarge.FieldFault()
+	if field != fieldBody || code != "transcript_too_large" || message == "" {
+		t.Errorf("FieldFault() = (%q, %q, %q), want (%q, transcript_too_large, non-empty)", field, code, message, fieldBody)
+	}
+}
+
+// TestBlankTranscriptErrorCarriesAnActionableMessage: FieldFault's message is
+// what a client renders verbatim (RFC 7807 detail) — it must say what to do,
+// not only that the paste was blank.
+func TestBlankTranscriptErrorCarriesAnActionableMessage(t *testing.T) {
+	field, code, message := ErrBlankTranscript.(interface {
+		FieldFault() (string, string, string)
+	}).FieldFault()
+	if field != fieldBody || code != "blank_transcript" {
+		t.Errorf("FieldFault() = (%q, %q, _), want (%q, blank_transcript, _)", field, code, fieldBody)
+	}
+	if !strings.Contains(message, "source_system") {
+		t.Errorf("message = %q, want it to name the remedy (omit source_system)", message)
+	}
+	if ErrBlankTranscript.Error() != fieldBody+": "+message {
+		t.Errorf("Error() = %q, want it built from the same FieldFault message", ErrBlankTranscript.Error())
+	}
 }

--- a/backend/internal/modules/activities/transcriptnorm_test.go
+++ b/backend/internal/modules/activities/transcriptnorm_test.go
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package activities
+
+import "testing"
+
+// TestNormalizeTranscriptCanonicalizesLineEndingsAndWhitespace pins ADR-0058's
+// normalization rule: split on newlines, trim trailing whitespace per line,
+// 1-indexed. The stored form must be reproducible regardless of the pasted
+// source's line-ending or trailing-space conventions, since a later reader
+// cites a line by splitting the same way.
+func TestNormalizeTranscriptCanonicalizesLineEndingsAndWhitespace(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "unlabelled single line",
+			in:   "We agreed to follow up next week.",
+			want: "We agreed to follow up next week.",
+		},
+		{
+			name: "speaker-labelled multi-line, ADR-0058's example shape",
+			in:   "Anna: Let's ship by Friday.\nBen: Works for me.",
+			want: "Anna: Let's ship by Friday.\nBen: Works for me.",
+		},
+		{
+			name: "windows line endings normalize to \\n",
+			in:   "Anna: hello\r\nBen: hi\r\n",
+			want: "Anna: hello\nBen: hi",
+		},
+		{
+			name: "trailing whitespace trimmed per line",
+			in:   "Anna: hello   \nBen: hi\t\n",
+			want: "Anna: hello\nBen: hi",
+		},
+		{
+			name: "blank lines between turns are preserved as empty lines",
+			in:   "Anna: hello\n\nBen: hi",
+			want: "Anna: hello\n\nBen: hi",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := normalizeTranscript(tc.in)
+			if err != nil {
+				t.Fatalf("normalizeTranscript(%q) returned an error: %v", tc.in, err)
+			}
+			if got != tc.want {
+				t.Errorf("normalizeTranscript(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestNormalizeTranscriptRefusesBlankInput: a paste of only whitespace is not
+// a transcript — refusing it here, before it ever reaches a stored activity
+// row, is cheaper than a downstream reader discovering an empty recording.
+func TestNormalizeTranscriptRefusesBlankInput(t *testing.T) {
+	for _, in := range []string{"", "   ", "\n\n\t\n"} {
+		if _, err := normalizeTranscript(in); err == nil {
+			t.Errorf("normalizeTranscript(%q) = nil error, want a refusal", in)
+		}
+	}
+}

--- a/backend/internal/modules/activities/transcriptnorm_test.go
+++ b/backend/internal/modules/activities/transcriptnorm_test.go
@@ -3,13 +3,18 @@
 
 package activities
 
-import "testing"
+import (
+	"errors"
+	"strings"
+	"testing"
+)
 
-// TestNormalizeTranscriptCanonicalizesLineEndingsAndWhitespace pins ADR-0058's
-// normalization rule: split on newlines, trim trailing whitespace per line,
-// 1-indexed. The stored form must be reproducible regardless of the pasted
-// source's line-ending or trailing-space conventions, since a later reader
-// cites a line by splitting the same way.
+// TestNormalizeTranscriptCanonicalizesLineEndingsAndWhitespace pins the
+// line-addressing half of ADR-0058's normalization rule: split on newlines,
+// trim trailing whitespace per line, 1-indexed. The stored form must be
+// reproducible regardless of the pasted or uploaded source's line-ending,
+// byte-order mark, or trailing-space conventions, since a later reader cites
+// a line by splitting the same way.
 func TestNormalizeTranscriptCanonicalizesLineEndingsAndWhitespace(t *testing.T) {
 	cases := []struct {
 		name string
@@ -41,6 +46,16 @@ func TestNormalizeTranscriptCanonicalizesLineEndingsAndWhitespace(t *testing.T) 
 			in:   "Anna: hello\n\nBen: hi",
 			want: "Anna: hello\n\nBen: hi",
 		},
+		{
+			name: "a leading byte-order mark is stripped",
+			in:   "\uFEFFAnna: hello",
+			want: "Anna: hello",
+		},
+		{
+			name: "NUL and other C0 control bytes are stripped, a mid-line tab is kept",
+			in:   "Anna:\x00 hel\x01lo\tthere",
+			want: "Anna: hello\tthere",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -63,5 +78,20 @@ func TestNormalizeTranscriptRefusesBlankInput(t *testing.T) {
 		if _, err := normalizeTranscript(in); err == nil {
 			t.Errorf("normalizeTranscript(%q) = nil error, want a refusal", in)
 		}
+	}
+}
+
+// TestNormalizeTranscriptRefusesAnOversizedTranscript: activity.search_tsv is
+// a GENERATED tsvector column over subject+body, and Postgres's tsvector
+// output has its own hard 1,048,575-byte ceiling — well under the chassis's
+// 1 MiB request cap. A transcript large enough to cross it must be refused
+// here, as a typed 422, rather than surfacing as an unmapped 500 at the
+// write.
+func TestNormalizeTranscriptRefusesAnOversizedTranscript(t *testing.T) {
+	oversized := strings.Repeat("a", maxTranscriptBytes+1)
+	_, err := normalizeTranscript(oversized)
+	var tooLarge oversizedTranscriptError
+	if !errors.As(err, &tooLarge) {
+		t.Fatalf("err = %v, want oversizedTranscriptError", err)
 	}
 }

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -1593,6 +1593,11 @@ export const de = {
   "log.kind": "Art",
   "log.kindNote": "Notiz",
   "log.kindTask": "Aufgabe",
+  "log.kindMeeting": "Meeting",
+  "log.transcriptLabel": "Transkript",
+  "log.transcriptHint":
+    "Aus Ihrem Meeting-Tool einfügen (Teams, Zoom, Meet …) — Sprecherkennzeichnungen bleiben, sofern vorhanden, erhalten.",
+  "log.transcriptUpload": "Oder eine Datei hochladen",
   "log.subject": "Betreff",
   "log.body": "Details",
   "log.dueAt": "Fällig am",

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -1597,7 +1597,11 @@ export const de = {
   "log.transcriptLabel": "Transkript",
   "log.transcriptHint":
     "Aus Ihrem Meeting-Tool einfügen (Teams, Zoom, Meet …) — Sprecherkennzeichnungen bleiben, sofern vorhanden, erhalten.",
+  "log.asTranscript": "Dieser Text ist ein Transkript",
   "log.transcriptUpload": "Oder eine Datei hochladen",
+  "log.transcriptUploadRejected": "Nur eine .txt-Datei wird akzeptiert.",
+  "log.transcriptUploadFailed":
+    "Die Datei konnte nicht gelesen werden — versuchen Sie stattdessen, den Text einzufügen.",
   "log.subject": "Betreff",
   "log.body": "Details",
   "log.dueAt": "Fällig am",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -1601,7 +1601,11 @@ export const en = {
   "log.transcriptLabel": "Transcript",
   "log.transcriptHint":
     "Paste it from your meeting tool (Teams, Zoom, Meet…) — speaker labels, if any, are kept.",
+  "log.asTranscript": "This text is a transcript",
   "log.transcriptUpload": "Or upload a file",
+  "log.transcriptUploadRejected": "Only a .txt file is accepted.",
+  "log.transcriptUploadFailed":
+    "Could not read that file — try pasting the text instead.",
   "log.dueAt": "Due date",
   "log.save": "Log",
   "log.saving": "Logging…",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -1595,8 +1595,13 @@ export const en = {
   "log.kind": "Type",
   "log.kindNote": "Note",
   "log.kindTask": "Task",
+  "log.kindMeeting": "Meeting",
   "log.subject": "Subject",
   "log.body": "Details",
+  "log.transcriptLabel": "Transcript",
+  "log.transcriptHint":
+    "Paste it from your meeting tool (Teams, Zoom, Meet…) — speaker labels, if any, are kept.",
+  "log.transcriptUpload": "Or upload a file",
   "log.dueAt": "Due date",
   "log.save": "Log",
   "log.saving": "Logging…",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -1585,6 +1585,11 @@ export const vi = {
   "log.kind": "Loại",
   "log.kindNote": "Ghi chú",
   "log.kindTask": "Công việc",
+  "log.kindMeeting": "Cuộc họp",
+  "log.transcriptLabel": "Bản ghi",
+  "log.transcriptHint":
+    "Dán từ công cụ họp của bạn (Teams, Zoom, Meet…) — nhãn người nói, nếu có, sẽ được giữ nguyên.",
+  "log.transcriptUpload": "Hoặc tải lên một tệp",
   "log.subject": "Tiêu đề",
   "log.body": "Nội dung",
   "log.dueAt": "Ngày đến hạn",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -1586,10 +1586,14 @@ export const vi = {
   "log.kindNote": "Ghi chú",
   "log.kindTask": "Công việc",
   "log.kindMeeting": "Cuộc họp",
-  "log.transcriptLabel": "Bản ghi",
+  "log.transcriptLabel": "Bản chép lời",
   "log.transcriptHint":
     "Dán từ công cụ họp của bạn (Teams, Zoom, Meet…) — nhãn người nói, nếu có, sẽ được giữ nguyên.",
+  "log.asTranscript": "Đây là một bản chép lời",
   "log.transcriptUpload": "Hoặc tải lên một tệp",
+  "log.transcriptUploadRejected": "Chỉ chấp nhận tệp .txt.",
+  "log.transcriptUploadFailed":
+    "Không thể đọc tệp đó — hãy thử dán văn bản thay vào đó.",
   "log.subject": "Tiêu đề",
   "log.body": "Nội dung",
   "log.dueAt": "Ngày đến hạn",

--- a/frontend/src/screens/logactivity.test.tsx
+++ b/frontend/src/screens/logactivity.test.tsx
@@ -2,6 +2,7 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   cleanup,
+  fireEvent,
   render as rtlRender,
   screen,
   waitFor,
@@ -234,7 +235,7 @@ describe("log activity from a 360", () => {
     );
   });
 
-  it("posts source_system: transcript for a meeting with pasted text, and switches the body field's label", async () => {
+  it("keeps ordinary meeting notes as notes: unchecked, the field stays Details and no source_system is sent", async () => {
     const captured: Captured[] = [];
     stubApi({ "POST /activities": createdActivity }, captured);
     render(<LogActivity entityType="deal" entityId="d1" />);
@@ -243,7 +244,40 @@ describe("log activity from a 360", () => {
       screen.getByLabelText("Type"),
       "Meeting",
     );
-    // The label swaps for a meeting — pasting is a transcript, not "details".
+    // The checkbox is unchecked by default: this is still a note field, not
+    // a transcript field, even though the kind is "meeting" — typing here
+    // must never silently carry source_system: transcript.
+    expect(screen.queryByLabelText("Transcript")).toBeNull();
+    await userEvent.type(screen.getByLabelText("Subject *"), "Quick sync");
+    await userEvent.type(
+      screen.getByLabelText("Details"),
+      "discussed pricing, follow up Tuesday",
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Log" }));
+    await waitFor(() =>
+      expect(captured.some((entry) => entry.key === "POST /activities")).toBe(
+        true,
+      ),
+    );
+    const post = captured.find((entry) => entry.key === "POST /activities");
+    expect(post?.body).not.toHaveProperty("source_system");
+    expect(post?.body).toMatchObject({
+      kind: "meeting",
+      body: "discussed pricing, follow up Tuesday",
+    });
+  });
+
+  it("posts source_system: transcript only once the writer checks 'this text is a transcript'", async () => {
+    const captured: Captured[] = [];
+    stubApi({ "POST /activities": createdActivity }, captured);
+    render(<LogActivity entityType="deal" entityId="d1" />);
+    await pickOption(
+      userEvent.setup(),
+      screen.getByLabelText("Type"),
+      "Meeting",
+    );
+    await userEvent.click(screen.getByLabelText("This text is a transcript"));
+    // The label swaps once checked — pasting is a transcript, not "details".
     expect(screen.queryByLabelText("Details")).toBeNull();
     await userEvent.type(screen.getByLabelText("Subject *"), "Kickoff call");
     await userEvent.type(
@@ -266,7 +300,7 @@ describe("log activity from a 360", () => {
     });
   });
 
-  it("does not stamp source_system for a meeting logged with no transcript text", async () => {
+  it("sends a checked transcript's text raw, not trimmed, so an agent posting the identical paste normalizes it the same way", async () => {
     const captured: Captured[] = [];
     stubApi({ "POST /activities": createdActivity }, captured);
     render(<LogActivity entityType="deal" entityId="d1" />);
@@ -275,7 +309,14 @@ describe("log activity from a 360", () => {
       screen.getByLabelText("Type"),
       "Meeting",
     );
-    await userEvent.type(screen.getByLabelText("Subject *"), "Quick sync");
+    await userEvent.click(screen.getByLabelText("This text is a transcript"));
+    await userEvent.type(screen.getByLabelText("Subject *"), "Kickoff call");
+    // fireEvent rather than userEvent.type: a leading space/newline is
+    // exactly the thing under test, and userEvent.type mangles literal
+    // leading whitespace in a textarea.
+    fireEvent.change(screen.getByLabelText("Transcript"), {
+      target: { value: "  Anna: hello" },
+    });
     await userEvent.click(screen.getByRole("button", { name: "Log" }));
     await waitFor(() =>
       expect(captured.some((entry) => entry.key === "POST /activities")).toBe(
@@ -283,10 +324,10 @@ describe("log activity from a 360", () => {
       ),
     );
     const post = captured.find((entry) => entry.key === "POST /activities");
-    expect(post?.body).not.toHaveProperty("source_system");
+    expect(post?.body).toMatchObject({ body: "  Anna: hello" });
   });
 
-  it("reads an uploaded transcript file into the transcript field", async () => {
+  it("reads an uploaded .txt transcript into the transcript field", async () => {
     stubApi({ "POST /activities": createdActivity });
     render(<LogActivity entityType="deal" entityId="d1" />);
     await pickOption(
@@ -294,6 +335,7 @@ describe("log activity from a 360", () => {
       screen.getByLabelText("Type"),
       "Meeting",
     );
+    await userEvent.click(screen.getByLabelText("This text is a transcript"));
     const file = new File(["Anna: hello from a file"], "meeting.txt", {
       type: "text/plain",
     });
@@ -304,5 +346,37 @@ describe("log activity from a 360", () => {
         (screen.getByLabelText("Transcript") as HTMLTextAreaElement).value,
       ).toBe("Anna: hello from a file"),
     );
+  });
+
+  it("rejects a non-.txt upload with a visible reason, and leaves the transcript field untouched", async () => {
+    stubApi({ "POST /activities": createdActivity });
+    render(<LogActivity entityType="deal" entityId="d1" />);
+    await pickOption(
+      userEvent.setup(),
+      screen.getByLabelText("Type"),
+      "Meeting",
+    );
+    await userEvent.click(screen.getByLabelText("This text is a transcript"));
+    const file = new File(
+      ["WEBVTT\n\n00:00.000 --> 00:01.000\nhi"],
+      "meeting.vtt",
+      {
+        type: "text/vtt",
+      },
+    );
+    const input = screen.getByLabelText("Or upload a file") as HTMLInputElement;
+    // fireEvent rather than userEvent.upload: accept is advisory (a real
+    // browser's file picker can be switched to "All files"), and
+    // userEvent.upload refuses to fire a change event for a file it judges
+    // against `accept` itself — which would test user-event, not the
+    // component's own rejection path.
+    Object.defineProperty(input, "files", { value: [file] });
+    fireEvent.change(input);
+    await waitFor(() =>
+      expect(screen.getByText("Only a .txt file is accepted.")).toBeTruthy(),
+    );
+    expect(
+      (screen.getByLabelText("Transcript") as HTMLTextAreaElement).value,
+    ).toBe("");
   });
 });

--- a/frontend/src/screens/logactivity.test.tsx
+++ b/frontend/src/screens/logactivity.test.tsx
@@ -379,4 +379,31 @@ describe("log activity from a 360", () => {
       (screen.getByLabelText("Transcript") as HTMLTextAreaElement).value,
     ).toBe("");
   });
+
+  it("surfaces a failed file read instead of leaving the writer guessing", async () => {
+    stubApi({ "POST /activities": createdActivity });
+    render(<LogActivity entityType="deal" entityId="d1" />);
+    await pickOption(
+      userEvent.setup(),
+      screen.getByLabelText("Type"),
+      "Meeting",
+    );
+    await userEvent.click(screen.getByLabelText("This text is a transcript"));
+    const file = new File(["Anna: hello"], "meeting.txt", {
+      type: "text/plain",
+    });
+    vi.spyOn(file, "text").mockRejectedValue(new Error("unreadable"));
+    const input = screen.getByLabelText("Or upload a file") as HTMLInputElement;
+    await userEvent.upload(input, file);
+    await waitFor(() =>
+      expect(
+        screen.getByText(
+          "Could not read that file — try pasting the text instead.",
+        ),
+      ).toBeTruthy(),
+    );
+    expect(
+      (screen.getByLabelText("Transcript") as HTMLTextAreaElement).value,
+    ).toBe("");
+  });
 });

--- a/frontend/src/screens/logactivity.test.tsx
+++ b/frontend/src/screens/logactivity.test.tsx
@@ -233,4 +233,76 @@ describe("log activity from a 360", () => {
       new Date("2026-07-10").toISOString(),
     );
   });
+
+  it("posts source_system: transcript for a meeting with pasted text, and switches the body field's label", async () => {
+    const captured: Captured[] = [];
+    stubApi({ "POST /activities": createdActivity }, captured);
+    render(<LogActivity entityType="deal" entityId="d1" />);
+    await pickOption(
+      userEvent.setup(),
+      screen.getByLabelText("Type"),
+      "Meeting",
+    );
+    // The label swaps for a meeting — pasting is a transcript, not "details".
+    expect(screen.queryByLabelText("Details")).toBeNull();
+    await userEvent.type(screen.getByLabelText("Subject *"), "Kickoff call");
+    await userEvent.type(
+      screen.getByLabelText("Transcript"),
+      "Anna: hello\nBen: hi",
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Log" }));
+    await waitFor(() =>
+      expect(captured.some((entry) => entry.key === "POST /activities")).toBe(
+        true,
+      ),
+    );
+    const post = captured.find((entry) => entry.key === "POST /activities");
+    expect(post?.body).toMatchObject({
+      kind: "meeting",
+      subject: "Kickoff call",
+      body: "Anna: hello\nBen: hi",
+      source_system: "transcript",
+      links: [{ entity_type: "deal", entity_id: "d1" }],
+    });
+  });
+
+  it("does not stamp source_system for a meeting logged with no transcript text", async () => {
+    const captured: Captured[] = [];
+    stubApi({ "POST /activities": createdActivity }, captured);
+    render(<LogActivity entityType="deal" entityId="d1" />);
+    await pickOption(
+      userEvent.setup(),
+      screen.getByLabelText("Type"),
+      "Meeting",
+    );
+    await userEvent.type(screen.getByLabelText("Subject *"), "Quick sync");
+    await userEvent.click(screen.getByRole("button", { name: "Log" }));
+    await waitFor(() =>
+      expect(captured.some((entry) => entry.key === "POST /activities")).toBe(
+        true,
+      ),
+    );
+    const post = captured.find((entry) => entry.key === "POST /activities");
+    expect(post?.body).not.toHaveProperty("source_system");
+  });
+
+  it("reads an uploaded transcript file into the transcript field", async () => {
+    stubApi({ "POST /activities": createdActivity });
+    render(<LogActivity entityType="deal" entityId="d1" />);
+    await pickOption(
+      userEvent.setup(),
+      screen.getByLabelText("Type"),
+      "Meeting",
+    );
+    const file = new File(["Anna: hello from a file"], "meeting.txt", {
+      type: "text/plain",
+    });
+    const input = screen.getByLabelText("Or upload a file") as HTMLInputElement;
+    await userEvent.upload(input, file);
+    await waitFor(() =>
+      expect(
+        (screen.getByLabelText("Transcript") as HTMLTextAreaElement).value,
+      ).toBe("Anna: hello from a file"),
+    );
+  });
 });

--- a/frontend/src/screens/logactivity.tsx
+++ b/frontend/src/screens/logactivity.tsx
@@ -5,6 +5,7 @@ import type { EntityKind } from "../app/entity";
 import {
   Button,
   Card,
+  Checkbox,
   Field,
   Modal,
   Textarea,
@@ -29,6 +30,13 @@ type ActivityDraft = {
   body: string;
   // yyyy-mm-dd from the date input; only a task carries a due date.
   dueAt: string;
+  // A meeting's body is ordinary notes UNLESS this is explicitly checked —
+  // otherwise "discussed pricing, follow up Tuesday" typed while logging a
+  // meeting would silently carry source_system: transcript, which the
+  // backend documents as meaning pasted/uploaded transcript TEXT and which
+  // the activity/transcript retention scope sweeps on a different schedule
+  // than an ordinary meeting note. Meaningless outside kind: meeting.
+  asTranscript: boolean;
 };
 
 const EMPTY_DRAFT: ActivityDraft = {
@@ -36,7 +44,14 @@ const EMPTY_DRAFT: ActivityDraft = {
   subject: "",
   body: "",
   dueAt: "",
+  asTranscript: false,
 };
+
+// Only a plain-text paste round-trips through normalizeTranscript's line
+// splitting the way ADR-0058's line-addressing promises: a `.vtt` file's cue
+// timestamps and header would themselves become "transcript lines", pointing
+// any future line citation at a timestamp instead of what was said.
+const ACCEPTED_TRANSCRIPT_EXTENSION = ".txt";
 
 /**
  * LogActivityForm is the composer itself, without a frame, so the same fields
@@ -61,6 +76,7 @@ export function LogActivityForm({
   const [draft, setDraft] = useState<ActivityDraft>(
     initialKind ? { ...EMPTY_DRAFT, kind: initialKind } : EMPTY_DRAFT,
   );
+  const [fileError, setFileError] = useState<string | null>(null);
 
   const log = useMutation({
     mutationFn: async (input: ActivityDraft) => {
@@ -68,15 +84,24 @@ export function LogActivityForm({
       // source_system: transcript is what routes the body through the
       // server's ADR-0058 normalizer and what the activity/transcript
       // retention scope keys its sweep on (see backend logActivity's
-      // `transcript` example) — only meaningful when there is text to
-      // normalize, so a meeting logged with no pasted transcript stays an
-      // ordinary meeting activity.
-      const isTranscript = input.kind === "meeting" && trimmedBody !== "";
+      // `transcript` example) — only when the writer has explicitly marked
+      // this text as one (asTranscript), never inferred from kind: meeting
+      // alone, or ordinary meeting notes would carry a marker meaning
+      // something else and sweep on a different retention schedule.
+      const isTranscript = input.kind === "meeting" && input.asTranscript;
+      // A transcript is sent RAW, not trimmed: the server's normalizer
+      // (transcriptnorm.go) is the one place line-1-indexing gets decided,
+      // and it only trims trailing whitespace per line — a leading blank
+      // line or leading indentation the client stripped first would make a
+      // transcript pasted here normalize to different stored text (and
+      // different line numbers) than the identical paste sent by an agent
+      // or another client straight to the API.
+      const outgoingBody = isTranscript ? input.body : trimmedBody;
       const { data, error } = await api.POST("/activities", {
         body: {
           kind: input.kind,
           subject: input.subject.trim(),
-          body: trimmedBody || null,
+          body: outgoingBody || null,
           occurred_at: new Date().toISOString(),
           ...(input.kind === "task" && input.dueAt
             ? { due_at: new Date(input.dueAt).toISOString() }
@@ -162,41 +187,54 @@ export function LogActivityForm({
           />
         )}
       </Field>
+      {draft.kind === "meeting" && (
+        <Checkbox
+          label={t("log.asTranscript")}
+          checked={draft.asTranscript}
+          onChange={(event) => setField({ asTranscript: event.target.checked })}
+        />
+      )}
       <Field
-        label={
-          draft.kind === "meeting" ? t("log.transcriptLabel") : t("log.body")
-        }
-        hint={draft.kind === "meeting" ? t("log.transcriptHint") : undefined}
+        label={draft.asTranscript ? t("log.transcriptLabel") : t("log.body")}
+        hint={draft.asTranscript ? t("log.transcriptHint") : undefined}
       >
         {(control) => (
           <Textarea
             {...control}
-            rows={draft.kind === "meeting" ? 10 : 3}
+            rows={draft.asTranscript ? 10 : 3}
             value={draft.body}
             onChange={(event) => setField({ body: event.target.value })}
           />
         )}
       </Field>
-      {draft.kind === "meeting" && (
-        <Field label={t("log.transcriptUpload")}>
+      {draft.kind === "meeting" && draft.asTranscript && (
+        <Field label={t("log.transcriptUpload")} hint={fileError ?? undefined}>
           {(control) => (
-            <input
+            <TextInput
               {...control}
               type="file"
-              accept=".txt,.vtt,text/plain,text/vtt"
-              onChange={(event) => {
+              accept={ACCEPTED_TRANSCRIPT_EXTENSION}
+              onChange={async (event) => {
                 const file = event.target.files?.[0];
+                event.target.value = "";
                 if (!file) {
                   return;
                 }
-                const reader = new FileReader();
-                reader.onload = () => {
-                  if (typeof reader.result === "string") {
-                    setField({ body: reader.result });
-                  }
-                };
-                reader.readAsText(file);
-                event.target.value = "";
+                if (
+                  !file.name
+                    .toLowerCase()
+                    .endsWith(ACCEPTED_TRANSCRIPT_EXTENSION)
+                ) {
+                  setFileError(t("log.transcriptUploadRejected"));
+                  return;
+                }
+                try {
+                  const text = await file.text();
+                  setFileError(null);
+                  setField({ body: text });
+                } catch {
+                  setFileError(t("log.transcriptUploadFailed"));
+                }
               }}
             />
           )}

--- a/frontend/src/screens/logactivity.tsx
+++ b/frontend/src/screens/logactivity.tsx
@@ -24,7 +24,7 @@ import { problemMessageOf, throwProblem, useSorMode } from "./common";
 // RFC 7807 detail verbatim.
 
 type ActivityDraft = {
-  kind: "note" | "task";
+  kind: "note" | "task" | "meeting";
   subject: string;
   body: string;
   // yyyy-mm-dd from the date input; only a task carries a due date.
@@ -64,15 +64,24 @@ export function LogActivityForm({
 
   const log = useMutation({
     mutationFn: async (input: ActivityDraft) => {
+      const trimmedBody = input.body.trim();
+      // source_system: transcript is what routes the body through the
+      // server's ADR-0058 normalizer and what the activity/transcript
+      // retention scope keys its sweep on (see backend logActivity's
+      // `transcript` example) — only meaningful when there is text to
+      // normalize, so a meeting logged with no pasted transcript stays an
+      // ordinary meeting activity.
+      const isTranscript = input.kind === "meeting" && trimmedBody !== "";
       const { data, error } = await api.POST("/activities", {
         body: {
           kind: input.kind,
           subject: input.subject.trim(),
-          body: input.body.trim() || null,
+          body: trimmedBody || null,
           occurred_at: new Date().toISOString(),
           ...(input.kind === "task" && input.dueAt
             ? { due_at: new Date(input.dueAt).toISOString() }
             : {}),
+          ...(isTranscript ? { source_system: "transcript" } : {}),
           links: [{ entity_type: entityType, entity_id: entityId }],
           source: "manual",
         },
@@ -114,10 +123,14 @@ export function LogActivityForm({
               options={[
                 { value: "note", label: t("log.kindNote") },
                 { value: "task", label: t("log.kindTask") },
+                { value: "meeting", label: t("log.kindMeeting") },
               ]}
               value={draft.kind}
               onChange={(value) =>
-                setField({ kind: value === "task" ? "task" : "note" })
+                setField({
+                  kind:
+                    value === "task" || value === "meeting" ? value : "note",
+                })
               }
             />
           )}
@@ -149,16 +162,46 @@ export function LogActivityForm({
           />
         )}
       </Field>
-      <Field label={t("log.body")}>
+      <Field
+        label={
+          draft.kind === "meeting" ? t("log.transcriptLabel") : t("log.body")
+        }
+        hint={draft.kind === "meeting" ? t("log.transcriptHint") : undefined}
+      >
         {(control) => (
           <Textarea
             {...control}
-            rows={3}
+            rows={draft.kind === "meeting" ? 10 : 3}
             value={draft.body}
             onChange={(event) => setField({ body: event.target.value })}
           />
         )}
       </Field>
+      {draft.kind === "meeting" && (
+        <Field label={t("log.transcriptUpload")}>
+          {(control) => (
+            <input
+              {...control}
+              type="file"
+              accept=".txt,.vtt,text/plain,text/vtt"
+              onChange={(event) => {
+                const file = event.target.files?.[0];
+                if (!file) {
+                  return;
+                }
+                const reader = new FileReader();
+                reader.onload = () => {
+                  if (typeof reader.result === "string") {
+                    setField({ body: reader.result });
+                  }
+                };
+                reader.readAsText(file);
+                event.target.value = "";
+              }}
+            />
+          )}
+        </Field>
+      )}
       {log.isError && (
         <p className="t-caption form-error">{problemMessageOf(log.error, t)}</p>
       )}


### PR DESCRIPTION
## Summary

Closes the ingest half of #702. The roadmap docs (`.tmp/capability-roadmap/`) pointed this row at `ingestVoiceCorpusSource`, but that's Voice DNA's writing-style corpus — unrelated, exactly as #702's own text warns. What's actually needed is much smaller once you look at what already exists:

- `logActivity` (`POST /activities`) already accepts `body`, `source_system`, `links` — and `source_system: transcript` is not reserved (only `mirror:` is).
- `activity/transcript` retention (#695) already sweeps on `source_system = 'transcript' AND body IS NOT NULL` — no new code needed for erasure.
- The one real gap: nobody normalized pasted/uploaded text to ADR-0058's canonical line form before storage. Added in `LogActivityInputFrom`, the one mapping every transport (REST, MCP, extension core-write) shares.

**Backend**
- `transcriptnorm.go`: unifies line endings, trims trailing whitespace per line, refuses a blank result.
- `mapping.go`: gates `source_system: transcript` to `call`/`meeting` kinds only (422 otherwise), normalizes the body.
- `crm.yaml`: docs-only example on `logActivity` showing the shape.

**Frontend**
- The composer's kind dropdown gains "Meeting"; the body field relabels to "Transcript" with a paste hint; a file input reads `.txt`/`.vtt` to text client-side (no presigned-upload path — transcripts are always plain text).
- `source_system: transcript` is only sent when there's actual text to normalize, so a meeting logged without a transcript is unaffected.

**Deliberately not built here**: the next-step/commitment proposal that cites transcript lines (issue bullet 4, S-E04.3). That's a materially larger, genuinely greenfield build — the first real use of `Approval.evidence[]` (currently unwired anywhere in the repo), a new AI extraction task + aicert corpus, and a registered `transcript_proposal` approval kind with its own executor. Filed as #1254, not folded in here. Full design notes: `.tmp/transcript-ingest-702/DESIGN.md`.

**Spec**: [margince-foundation#1296](https://github.com/gradionhq/margince-foundation/pull/1296) pins MEET-GAP-2 onto this shape (contract-first).

## Test plan
- [x] `transcriptnorm_test.go` — table-driven: CRLF, trailing whitespace, blank-line preservation, blank-input refusal.
- [x] `mapping_transcript_test.go` — wrong-kind refusal, blank-transcript refusal, normalization through the real mapping function.
- [x] `transcript_integration_test.go` — through `LogActivityInputFrom` → real `Store.LogActivity` → raw-column read-back, proving the row satisfies the retention selector's exact predicate.
- [x] `logactivity.test.tsx` — posts `source_system: transcript` for a meeting with text, omits it for an empty-body meeting, reads an uploaded file into the field.
- [x] `make check-fe` green.
- [x] Backend: `go build ./...`, `go vet ./...`, package tests, and `craft static --strict` (via the pre-push hook) all green. (`make check-backend`'s full lint pass hit a `golangci-lint` cache lock from a concurrent session on this machine — my own package's scoped lint run is clean; CI is the real gate here.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for logging meeting activities with transcript content.
  * Users can paste transcript text or upload `.txt` and `.vtt` files.
  * Transcript content is cleaned up automatically before saving.
  * Added localized meeting and transcript guidance in English, German, and Vietnamese.

* **Bug Fixes**
  * Prevented unsupported activity types from being saved with transcript content.
  * Blank transcripts are rejected, while empty meeting entries remain valid without transcript metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->