### PR TITLE
refactor(webhooks): the retry sweep is one job, and its tables drop the tenant

### DIFF
--- a/backend/api/jobs.yaml
+++ b/backend/api/jobs.yaml
@@ -1160,20 +1160,18 @@ kinds:
       Deferrals are hours long, so a fifteen-minute scan is prompt without being
       busywork.
 
+  # One job, not a dispatcher and a child (ADR-0103 §1). It keeps the
+  # dispatcher's KIND and CADENCE — the name an operator alerts on, the interval
+  # an operator sets — and the child's QUEUE, TIMEOUT and ATTEMPT CAP, which
+  # describe the sweep rather than the enumeration that used to precede it.
+  #
+  # opts_owner is `args` rather than `caller` so the cap stays declared: the
+  # periodic insert supplies uniqueness and no attempt policy, so a caller-owned
+  # collapse would silently trade three attempts for River's 25-rung default
+  # against a 26-minute timeout.
   webhook_retry:
-    role: dispatcher
-    go_type: WebhookRetryArgs
-    queue: default
-    timeout: 2m
-    opts_owner: caller
-    cadence: {operator: WebhookRetry.Interval, schedule_when_positive: WebhookRetry.Interval}
-    registration: {when: [WebhookRetry.Deliverer], absent: registers_nothing}
-    fans_out_to: webhook_retry_workspace
-    fan_out_unit: workspace
-
-  webhook_retry_workspace:
     role: worker
-    go_type: WebhookRetryWorkspaceArgs
+    go_type: WebhookRetryArgs
     queue: webhook_retry
     timeout:
       derived: webhookRetrySweepTimeout
@@ -1183,7 +1181,6 @@ kinds:
         times its per-attempt bound — and the margin covers the per-delivery
         database round trips between attempts.
     max_attempts: 3
-    opts_owner: fan_out
+    opts_owner: args
+    cadence: {operator: WebhookRetry.Interval, schedule_when_positive: WebhookRetry.Interval}
     registration: {when: [WebhookRetry.Deliverer], absent: registers_nothing}
-    args:
-      Workspace: id

--- a/backend/internal/compose/integration/jobtest/jobtest.go
+++ b/backend/internal/compose/integration/jobtest/jobtest.go
@@ -175,3 +175,30 @@ func StartTestJobRunner(t *testing.T, pool *pgxpool.Pool, cfg compose.JobRunnerC
 	})
 	return runner, completed, failed
 }
+
+// AwaitKindOutcome blocks until one row of the named kind reports either way,
+// and answers whether it succeeded. No polling, no sleep.
+//
+// The single-pass sibling of AwaitWorkspaceJobOutcomes, and it exists because a
+// collapsed pass has no tenant to key an outcome on (ADR-0103 §1): there is one
+// row, and the question is whether that row completed or failed. The same
+// caveat applies for the same reason — the FIRST report is taken, so a suite
+// planting a retryable fault would read the attempt rather than the verdict.
+// Every caller plants a permanent one.
+func AwaitKindOutcome(ctx context.Context, t *testing.T, completed, failed <-chan *river.Event, kind string) bool {
+	t.Helper()
+	for {
+		select {
+		case <-ctx.Done():
+			t.Fatalf("timed out waiting for a %s outcome: %v", kind, ctx.Err())
+		case ev := <-completed:
+			if ev.Job != nil && ev.Job.Kind == kind {
+				return true
+			}
+		case ev := <-failed:
+			if ev.Job != nil && ev.Job.Kind == kind {
+				return false
+			}
+		}
+	}
+}

--- a/backend/internal/compose/integration/webhooks/webhookretry_pass_integration_test.go
+++ b/backend/internal/compose/integration/webhooks/webhookretry_pass_integration_test.go
@@ -5,11 +5,11 @@
 
 package webhooks
 
-// The outbound-webhook retry sweep is one job row per live tenant. A workspace
-// whose due-retry scan fails must say so: a sweep that reported success is
-// indistinguishable from a sweep that found nothing due, and what it hides is a
-// tenant whose parked deliveries are never re-attempted at all — the subscriber
-// simply stops receiving, with no failed row anywhere to read.
+// The outbound-webhook retry sweep is one job row per pass. A pass whose
+// due-retry scan fails must say so: a sweep that reported success is
+// indistinguishable from a sweep that found nothing due, and what it hides is
+// parked deliveries never being re-attempted at all — the subscriber simply
+// stops receiving, with no failed row anywhere to read.
 
 import (
 	"context"
@@ -136,52 +136,7 @@ func parkOneDelivery(t *testing.T, we *webhookEnv, deliverer *webhooks.Deliverer
 	assertDeliveryStatus(t, we, subID, "retrying", 1)
 }
 
-// parkDueDeliveryIn plants a live subscription and an already-due parked
-// delivery in a workspace OTHER than the harness's own, so a second tenant has
-// real work for a sweep to find. A tenant with nothing due never reads a
-// delivery row at all, which would leave any claim about its sweep resting on a
-// scan that never happened.
-//
-// It copies the harness subscription's sealed secret rather than minting one:
-// the deployment key seals it with nothing bound to a tenant or a subscription,
-// so the copy signs and POSTs exactly as the original does. The owner
-// connection is a superuser and so bypasses RLS, which is what lets one
-// statement write into a workspace this process has no bound context for.
-func parkDueDeliveryIn(t *testing.T, we *webhookEnv, owner *pgx.Conn, ws ids.UUID, targetURL string, dueAt time.Time) {
-	t.Helper()
-	ctx := context.Background()
-	var sealed string
-	if err := owner.QueryRow(ctx,
-		`SELECT signing_secret_ref FROM webhook_subscription WHERE workspace_id = $1`,
-		we.wsID).Scan(&sealed); err != nil {
-		t.Fatalf("reading the harness subscription's sealed secret: %v", err)
-	}
-	user, sub := ids.NewV7(), ids.NewV7()
-	if _, err := owner.Exec(ctx, `
-		INSERT INTO app_user (id, workspace_id, email, display_name)
-		VALUES ($1, $2, $3, 'Sweep Fixture')`, user, ws, "sweep-"+ws.String()+"@example.test"); err != nil {
-		t.Fatalf("seeding the subscription owner in %s: %v", ws, err)
-	}
-	if _, err := owner.Exec(ctx, `
-		INSERT INTO webhook_subscription (id, workspace_id, owner_id, target_url, event_types, signing_secret_ref)
-		VALUES ($1, $2, $3, $4, ARRAY['deal.created'], $5)`, sub, ws, user, targetURL, sealed); err != nil {
-		t.Fatalf("seeding the subscription in %s: %v", ws, err)
-	}
-	if _, err := owner.Exec(ctx, `
-		INSERT INTO webhook_delivery (workspace_id, subscription_id, event_id, event_type, payload,
-		                              status, attempts, next_retry_at)
-		VALUES ($1, $2, $3, 'deal.created', '{}', 'retrying', 1, $4)`,
-		ws, sub, ids.NewV7(), dueAt); err != nil {
-		t.Fatalf("parking the due delivery in %s: %v", ws, err)
-	}
-}
-
-// TestWebhookRetryReportsTheWorkspaceWhoseDueScanFailed is the
-// characterization: a tenant whose due-retry scan hits a database error must
-// reach its caller as an error. A sweep that reported success over it leaves
-// every delivery parked in that tenant parked forever, and records a healthy
-// pass while doing so.
-func TestWebhookRetryReportsTheWorkspaceWhoseDueScanFailed(t *testing.T) {
+func TestWebhookRetryReportsASweepWhoseDueScanFailed(t *testing.T) {
 	we := setupWebhooks(t)
 	owner := integration.OwnerConn(t)
 
@@ -189,16 +144,6 @@ func TestWebhookRetryReportsTheWorkspaceWhoseDueScanFailed(t *testing.T) {
 	now := time.Now().UTC()
 	deliverer := newTestDeliverer(we, &now, rcv.server.Client())
 	parkOneDelivery(t, we, deliverer, rcv)
-	// The second tenant arrives only AFTER the harness has used the HTTP
-	// surface, and that order is load-bearing: a request path resolves the
-	// installation's one workspace (ADR-0061/A107) and refuses outright once
-	// there are two. A sweep is the opposite kind of caller — it is handed the
-	// tenant it runs for — so the fan-out this suite is about still reads both.
-	healthy := integration.SeedExtraWorkspace(t, owner, "healthy", false)
-	// The healthy tenant gets real due work of its own, so its sweep below
-	// actually scans and re-attempts. Without a row it would read nothing, and
-	// an assertion about a scan that never ran proves nothing about isolation.
-	parkDueDeliveryIn(t, we, owner, healthy, rcv.server.URL+"/hook", now)
 
 	// One healthy pass first: it proves the parked delivery is reachable by a
 	// sweep at this clock reading, so the "not re-attempted" assertion below
@@ -216,35 +161,23 @@ func TestWebhookRetryReportsTheWorkspaceWhoseDueScanFailed(t *testing.T) {
 
 	err := deliverer.SweepOnce(webhookSweepCtx(we.wsID))
 	if got := rcv.count.Load(); got != 2 {
-		t.Fatalf("the fault injection did not hold: the victim's parked delivery was re-attempted %d more times, so its due scan never failed", got-2)
+		t.Fatalf("the fault injection did not hold: the parked delivery was re-attempted %d more times, so the due scan never failed", got-2)
 	}
 	if err == nil {
-		t.Fatal("a workspace whose due-retry scan failed reported success — every delivery parked in that tenant stays parked and nothing records that the sweep never scanned")
-	}
-
-	// The fault is one tenant's, and the pass now takes the tenant it is given:
-	// with the policy still armed, the healthy tenant scans its own due row and
-	// re-attempts it. The receiver hit is the load-bearing half — a pass that
-	// returned nil without delivering would have scanned nothing.
-	// A deliverer of the healthy tenant's own: the workspace a sweep runs for
-	// is a property of the handle it was built on, not of the ctx it is called
-	// with, so reusing the victim's deliverer here would sweep the victim again
-	// and read as the fault leaking across tenants.
-	if err := newTestDelivererOn(we, we.DBFor(healthy), &now, rcv.server.Client()).
-		SweepOnce(webhookSweepCtx(healthy)); err != nil {
-		t.Fatalf("the healthy tenant's sweep, while the victim's is faulted: %v", err)
-	}
-	if got := rcv.count.Load(); got != 3 {
-		t.Fatalf("the endpoint saw %d attempts, want one more from the healthy tenant's sweep — its pass reported success without scanning", got)
+		t.Fatal("a sweep whose due-retry scan failed reported success — every parked delivery stays parked and nothing records that the scan never ran")
 	}
 }
 
-// TestWebhookRetryFansOutOneJobPerLiveWorkspaceAndFailsOnlyTheFailedTenant is
-// the converted shape: the dispatcher enqueues one row per LIVE workspace —
-// archived ones excluded, because a delivery parked for a subscription nobody
-// is listening on any more is work nobody wants — each row names its own tenant
-// on the wire, and the tenant whose scan failed is the only row that fails.
-func TestWebhookRetryFansOutOneJobPerLiveWorkspaceAndFailsOnlyTheFailedTenant(t *testing.T) {
+// TestWebhookRetryRecordsAFailedPassAsAFailedRow is what survives the fan-out.
+//
+// It used to enqueue one row per live workspace and prove that the tenant whose
+// scan failed was the ONLY row that failed — the per-tenant row was the unit of
+// failure. A pass is one row now (ADR-0103 §1), so the property worth pinning is
+// the half that never depended on there being several: a sweep that could not
+// scan must leave a FAILED row behind, because a pass reporting success is
+// indistinguishable from a pass that found nothing due, and what it hides is
+// every parked delivery never being re-attempted again.
+func TestWebhookRetryRecordsAFailedPassAsAFailedRow(t *testing.T) {
 	we := setupWebhooks(t)
 	owner := integration.OwnerConn(t)
 
@@ -252,18 +185,13 @@ func TestWebhookRetryFansOutOneJobPerLiveWorkspaceAndFailsOnlyTheFailedTenant(t 
 	now := time.Now().UTC()
 	deliverer := newTestDeliverer(we, &now, rcv.server.Client())
 	parkOneDelivery(t, we, deliverer, rcv)
-	// Seeded after the HTTP subscription above, and for the same reason: the
-	// request path resolves the installation's one workspace and refuses when a
-	// second exists, while the fan-out under test is handed its tenant.
-	healthy := integration.SeedExtraWorkspace(t, owner, "healthy", false)
-	archived := integration.SeedExtraWorkspace(t, owner, "archived", true)
-	// Past the parked delivery's backoff, so the victim's sweep has something
-	// due to scan for: a tenant with nothing due never reads a row and so never
-	// meets the fault.
+	// Past the parked delivery's backoff, so the sweep has something due to
+	// scan for: a pass with nothing due never reads a row and so never meets
+	// the fault.
 	now = now.Add(64 * time.Second)
 	// Permanent, not transient: the row fires a failure event on every attempt,
-	// and a fault that healed would let attempt 2 complete and record the
-	// tenant as green — the exact outcome this test denies.
+	// and a fault that healed would let a later attempt complete and record the
+	// pass as green — the exact outcome this test denies.
 	failDueScansFor(t, owner, we.wsID)
 
 	_, completed, failed := jobtest.StartTestJobRunner(t, we.pool, compose.JobRunnerConfig{
@@ -272,11 +200,6 @@ func TestWebhookRetryFansOutOneJobPerLiveWorkspaceAndFailsOnlyTheFailedTenant(t 
 		TimeScanInterval:  time.Hour,
 		WebhookRetry: compose.WebhookRetryConfig{
 			Interval: time.Hour,
-			// The fan-out builds one deliverer per workspace it sweeps, and the
-			// factory honours that: each tenant's worker gets a deliverer over
-			// the handle it was given. A factory that answered with one shared
-			// deliverer would sweep a single tenant twice and report the fan-out
-			// as working.
 			Deliverer: func(db *database.DB) *webhooks.Deliverer {
 				return newTestDelivererOn(we, db, &now, rcv.server.Client())
 			},
@@ -284,31 +207,9 @@ func TestWebhookRetryFansOutOneJobPerLiveWorkspaceAndFailsOnlyTheFailedTenant(t 
 	})
 	waitCtx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
-	kind := compose.WebhookRetryWorkspaceArgs{}.Kind()
-	outcomes := jobtest.AwaitWorkspaceJobOutcomes(waitCtx, t, completed, failed, kind, 2)
-
-	if _, fannedOut := outcomes[healthy.String()]; !fannedOut {
-		t.Errorf("no retry sweep ran for workspace %s — a tenant the fan-out skipped keeps its deliveries parked and no row records that it did", healthy)
-	}
-	if !outcomes[healthy.String()] {
-		t.Error("the healthy tenant's retry sweep failed")
-	}
-	if outcomes[we.wsID.String()] {
-		t.Error("the tenant whose due scan could not run reported a completed job — the failure the per-workspace row exists to record was swallowed")
-	}
-
-	// The archived tenant must have no row at all. This count is fenced on the
-	// two outcomes above rather than read early: the fan-out is ONE atomic
-	// InsertMany, so any child reporting proves that insert committed — and it
-	// carried every workspace the dispatcher enumerated.
-	var dispatched int
-	if err := we.pool.QueryRow(context.Background(),
-		`SELECT count(*) FROM river_job WHERE kind = $1 AND args->>'workspace_id' = $2`,
-		kind, archived.String()).Scan(&dispatched); err != nil {
-		t.Fatalf("counting the archived tenant's retry jobs: %v", err)
-	}
-	if dispatched != 0 {
-		t.Errorf("%d %s rows were dispatched for an ARCHIVED workspace — re-attempting a delivery for a subscription nobody listens on any more spends outbound attempts on work nobody wants", dispatched, kind)
+	kind := compose.WebhookRetryArgs{}.Kind()
+	if outcome := jobtest.AwaitKindOutcome(waitCtx, t, completed, failed, kind); outcome {
+		t.Error("the pass whose due scan could not run reported a completed job — the failure the row exists to record was swallowed")
 	}
 }
 
@@ -364,9 +265,8 @@ func TestWebhookRetryWithoutAnIntervalSchedulesNothingButStillWorksAQueuedRow(t 
 		TimeScanInterval:  time.Hour,
 		WebhookRetry:      compose.WebhookRetryConfig{Interval: 0, Deliverer: func(*database.DB) *webhooks.Deliverer { return deliverer }},
 	})
-	if err := runner.Enqueue(context.Background(),
-		compose.WebhookRetryWorkspaceArgs{Workspace: we.wsID}, nil); err != nil {
-		t.Fatalf("enqueueing the workspace pass an earlier boot would have left: %v", err)
+	if err := runner.Enqueue(context.Background(), compose.WebhookRetryArgs{}, nil); err != nil {
+		t.Fatalf("enqueueing the pass an earlier boot would have left: %v", err)
 	}
 
 	// The close-date sweep is the FENCE, and it has to be: River inserts every
@@ -379,16 +279,21 @@ func TestWebhookRetryWithoutAnIntervalSchedulesNothingButStillWorksAQueuedRow(t 
 	waitCtx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 	jobtest.AwaitKindsCompleted(waitCtx, t, completed,
-		compose.CloseDateSweepArgs{}.Kind(), compose.WebhookRetryWorkspaceArgs{}.Kind())
+		compose.CloseDateSweepArgs{}.Kind(), compose.WebhookRetryArgs{}.Kind())
 
+	// Exactly the one row this test queued by hand. The count used to be zero
+	// because the schedule and the work were different kinds — the dispatcher's
+	// absence was countable on its own. One kind does both now, so the shape of
+	// a spinning schedule is not "a row exists" but "rows keep arriving", and
+	// the hand-queued row is the floor a spin would rise above.
 	var dispatched int
 	if err := we.pool.QueryRow(context.Background(),
 		`SELECT count(*) FROM river_job WHERE kind = $1`,
 		compose.WebhookRetryArgs{}.Kind()).Scan(&dispatched); err != nil {
 		t.Fatalf("counting the dispatched retry passes: %v", err)
 	}
-	if dispatched != 0 {
-		t.Errorf("%d %s rows were dispatched by a runner given no retry interval — a zero duration is not a cadence, and River spins on it rather than refusing it",
+	if dispatched != 1 {
+		t.Errorf("%d %s rows exist after a runner was given no retry interval, want only the one queued here — a zero duration is not a cadence, and River spins on it rather than refusing it",
 			dispatched, compose.WebhookRetryArgs{}.Kind())
 	}
 }

--- a/backend/internal/compose/integration/webhooks/webhookretry_pass_integration_test.go
+++ b/backend/internal/compose/integration/webhooks/webhookretry_pass_integration_test.go
@@ -14,6 +14,7 @@ package webhooks
 import (
 	"context"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -166,6 +167,13 @@ func TestWebhookRetryReportsASweepWhoseDueScanFailed(t *testing.T) {
 	if err == nil {
 		t.Fatal("a sweep whose due-retry scan failed reported success — every parked delivery stays parked and nothing records that the scan never ran")
 	}
+	// The failure is the one this test injected, not any failure. Without this
+	// the assertion above passes on an unrelated break — including the one it is
+	// least able to notice, a fault that stopped reaching the scan while
+	// something else failed in its place.
+	if !strings.Contains(err.Error(), "webhook due-scan fault injection") {
+		t.Errorf("the sweep failed with %v, which does not name the injected due-scan fault", err)
+	}
 }
 
 // TestWebhookRetryRecordsAFailedPassAsAFailedRow is what survives the fan-out.
@@ -211,6 +219,11 @@ func TestWebhookRetryRecordsAFailedPassAsAFailedRow(t *testing.T) {
 	if outcome := jobtest.AwaitKindOutcome(waitCtx, t, completed, failed, kind); outcome {
 		t.Error("the pass whose due scan could not run reported a completed job — the failure the row exists to record was swallowed")
 	}
+
+	// What the ROW records is the classified message — River stores the
+	// classified fault and keeps the cause in the process log — so the proof
+	// that this failure is the injected one lives next door, in the test that
+	// calls the sweep directly and can read the raw error.
 }
 
 // TestWebhookRetryDispatchRepeatsOnItsConfiguredInterval pins the half of the

--- a/backend/internal/compose/jobactor_test.go
+++ b/backend/internal/compose/jobactor_test.go
@@ -43,12 +43,18 @@ import (
 var jobActorUnbound = gatekit.Waive(map[string]string{
 	"privacyRetentionWorkspaceWorker": "retention sweep; whether its writes are gated is #1127's question",
 	"timeScanWorkspaceWorker":         "automation time-scan; same audit",
-	"webhookRetryWorkspaceWorker":     "webhook delivery retry; same audit",
+	"webhookRetryWorker":              "webhook delivery retry; same audit",
 })
 
-// storeBuilders are the per-workspace store constructors. A Work method that
-// calls one is about to reach an RBAC-gated entry point.
-var storeBuilders = regexp.MustCompile(`(providerRunStore|workspaceJobDB)\(`)
+// storeBuilders are the handle constructors a store is built on. A Work method
+// that calls one is about to reach an RBAC-gated entry point.
+//
+// InstallationDB belongs here for the same reason workspaceJobDB does, and it
+// had to be added rather than assumed: a pass that collapses out of the
+// per-tenant fan-out (ADR-0103 §1) stops calling workspaceJobDB and starts
+// calling this one, so a regex naming only the old constructor would let every
+// collapsed worker slip out of this gate's sight while reading as green.
+var storeBuilders = regexp.MustCompile(`(providerRunStore|workspaceJobDB|InstallationDB)\(`)
 
 // actorBinders are the ways a worker legitimately names its principal: the
 // helper in this package, or principal.WithActor directly.

--- a/backend/internal/compose/jobdeclared_test.go
+++ b/backend/internal/compose/jobdeclared_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/riverqueue/river"
+
 	"github.com/gradionhq/margince/backend/internal/platform/jobs"
 )
 
@@ -460,4 +462,54 @@ func TestAnIdleFleetEmitsNoUnrecognisedExtensionKindSeries(t *testing.T) {
 	if strings.Contains(out, "margince_job_unrecognised_extension_kind") {
 		t.Errorf("a healthy fleet emitted an unrecognised-extension-kind family\ngot:\n%s", out)
 	}
+}
+
+// TestArgsOwnedAttemptCapsMatchTheirDeclaration is what earns an args-owned
+// kind the right to publish a `max_attempts` at all.
+//
+// The manifest refuses that number from a caller-owned kind, on the ground that
+// publishing a cap nothing applies is declared-versus-actual drift. An
+// args-owned kind escapes that refusal only because its own InsertOpts carry
+// the number — which is a promise about Go code the contract cannot see. This
+// is the sight: every declared cap is read back off the args type River will
+// actually insert with, so a manifest edit that forgets the Go side, or a Go
+// edit that quietly retunes the ladder, fails here rather than in production
+// three attempts later than anyone expected.
+func TestArgsOwnedAttemptCapsMatchTheirDeclaration(t *testing.T) {
+	checked := 0
+	for kind, spec := range jobs.Declared() {
+		if spec.OptsOwner != jobs.OptsArgs || spec.MaxAttempts == 0 {
+			continue
+		}
+		args, ok := argsForKind[kind]
+		if !ok {
+			t.Errorf("kind %q declares max_attempts %d but this test knows no args value for it — add one, "+
+				"or the declaration is unchecked", kind, spec.MaxAttempts)
+			continue
+		}
+		withOpts, ok := args.(river.JobArgsWithInsertOpts)
+		if !ok {
+			t.Errorf("kind %q declares max_attempts %d with opts_owner=args, but %T supplies no InsertOpts — "+
+				"nothing applies the number the contract publishes", kind, spec.MaxAttempts, args)
+			continue
+		}
+		if got := withOpts.InsertOpts().MaxAttempts; got != spec.MaxAttempts {
+			t.Errorf("kind %q: the contract declares max_attempts %d and %T inserts with %d",
+				kind, spec.MaxAttempts, args, got)
+		}
+		checked++
+	}
+	// A derivation that silently checks nothing passes every declaration, which
+	// is the one way this gate fails without failing.
+	if checked == 0 {
+		t.Fatal("no args-owned kind declares an attempt cap — either the vocabulary changed or this gate stopped finding them")
+	}
+}
+
+// argsForKind is the args value each checked kind inserts with. Hand-listed
+// rather than reflected: the contract names a Go TYPE, and a test that
+// constructed one from its name would be asserting against its own reflection
+// rather than against the type the runtime registers.
+var argsForKind = map[string]river.JobArgs{
+	WebhookRetryArgs{}.Kind(): WebhookRetryArgs{},
 }

--- a/backend/internal/compose/jobkinds_gen.go
+++ b/backend/internal/compose/jobkinds_gen.go
@@ -13,7 +13,7 @@ import (
 // jobContractHash is the sha256 of api/jobs.yaml this file was generated
 // from — the same fingerprint jobs.JobContractHash carries, so a stale
 // half of the pair is visible without diffing the two tables.
-const jobContractHash = "bae6430067d6228e1df86e7194ca073cee82ec501a0421fb7e604f7baebcddff"
+const jobContractHash = "c0476c093a374625d793aa469f0b9b3e74bde63b3012fded767b528220c9bbb3"
 
 // declaredJobArgs is every args type api/jobs.yaml declares, and nothing
 // else. A job kind the file has never heard of cannot satisfy it, so it
@@ -85,8 +85,7 @@ type declaredJobArgs interface {
 		TimeScanWorkspaceArgs |
 		VoiceBuildArgs |
 		VoiceBuildRetryArgs |
-		WebhookRetryArgs |
-		WebhookRetryWorkspaceArgs
+		WebhookRetryArgs
 }
 
 // addDeclaredWorker is the sanctioned registration path. Its type parameter
@@ -145,11 +144,10 @@ var (
 	_ jobs.FleetWide = TelegramPollSweepArgs{}
 	_ jobs.FleetWide = TimeScanArgs{}
 	_ jobs.FleetWide = VoiceBuildRetryArgs{}
-	_ jobs.FleetWide = WebhookRetryArgs{}
 )
 
-// The declared workspace-scoped kinds: each carries exactly one tenant's
-// pass and says which in its own args.
+// The declared tenant-scoped kinds: each says which workspace it is for
+// in its own args.
 var (
 	_ jobs.WorkspaceScoped = AgentSchedulerWorkspaceArgs{}
 	_ jobs.WorkspaceScoped = AgentTaskRetentionWorkspaceArgs{}
@@ -185,5 +183,4 @@ var (
 	_ jobs.WorkspaceScoped = TelegramPollArgs{}
 	_ jobs.WorkspaceScoped = TimeScanWorkspaceArgs{}
 	_ jobs.WorkspaceScoped = VoiceBuildArgs{}
-	_ jobs.WorkspaceScoped = WebhookRetryWorkspaceArgs{}
 )

--- a/backend/internal/compose/jobs_webhookretry.go
+++ b/backend/internal/compose/jobs_webhookretry.go
@@ -19,7 +19,6 @@ import (
 	"github.com/gradionhq/margince/backend/internal/modules/webhooks"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/jobs"
-	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
 const (
@@ -75,77 +74,53 @@ type WebhookRetryConfig struct {
 	Deliverer func(*database.DB) *webhooks.Deliverer
 }
 
-// addWebhookRetryJobs registers the retry workers and returns the dispatcher's
-// periodic schedule for the caller to append. A non-positive interval
-// registers the workers but no schedule — the posture the declaration states
-// and jobschedule.go resolves.
+// addWebhookRetryJobs registers the retry worker and returns its periodic
+// schedule for the caller to append. A non-positive interval registers the
+// worker but no schedule — the posture the declaration states and
+// jobschedule.go resolves.
 func addWebhookRetryJobs(reg *jobRegistry, pool *pgxpool.Pool, cfg JobRunnerConfig) []*river.PeriodicJob {
 	if cfg.WebhookRetry.Deliverer == nil {
 		return nil
 	}
-	addDeclaredWorker[WebhookRetryArgs](reg, &webhookRetryWorker{pool: pool})
-	addDeclaredWorker[WebhookRetryWorkspaceArgs](reg, &webhookRetryWorkspaceWorker{pool: pool, deliverer: cfg.WebhookRetry.Deliverer})
+	addDeclaredWorker[WebhookRetryArgs](reg, &webhookRetryWorker{pool: pool, deliverer: cfg.WebhookRetry.Deliverer})
 	return periodicFor(cfg, WebhookRetryArgs{})
 }
 
-// WebhookRetryArgs schedules one fleet-wide pass over due retries.
+// WebhookRetryArgs is one pass over the installation's due retries.
+//
+// It used to be a dispatcher that enumerated live workspaces and enqueued one
+// child per tenant. Under one installation that enumeration reads a single row,
+// so the pair collapsed into this (ADR-0091 §5, ADR-0103 §1).
 type WebhookRetryArgs struct{}
 
-// Kind is the stable job identifier River persists in river_job.
+// Kind is the stable job identifier River persists in river_job. It is the
+// DISPATCHER's old kind, deliberately: it is the name operators alert on, and
+// the child's `_workspace` kind is the one that had to go.
 func (WebhookRetryArgs) Kind() string { return "webhook_retry" }
 
-// FleetWide marks this a dispatcher: it enumerates and enqueues,
-// and does no tenant work of its own (jobs.FleetWide).
-func (WebhookRetryArgs) FleetWide() {}
+// InsertOpts carries the attempt cap the declaration publishes, because the
+// periodic insert supplies uniqueness and no attempt policy of its own. Without
+// it this pass would take River's silent 25-rung ladder against a 26-minute
+// timeout — three attempts is what the fan-out child was governed by, and the
+// number is held equal to api/jobs.yaml by
+// TestArgsOwnedAttemptCapsMatchTheirDeclaration.
+func (WebhookRetryArgs) InsertOpts() river.InsertOpts {
+	return river.InsertOpts{
+		Queue:       webhookRetryQueue,
+		MaxAttempts: 3,
+		UniqueOpts:  river.UniqueOpts{ByState: activeSweepStates},
+	}
+}
 
-// webhookRetryWorker is the dispatcher. It enumerates the LIVE workspaces
-// only: a delivery parked in an archived tenant belongs to a subscription
-// nobody is listening on any more, so re-attempting it spends outbound
-// attempts on work nobody wants.
+// webhookRetryWorker re-attempts the due deliveries.
 type webhookRetryWorker struct {
-	pool *pgxpool.Pool
-}
-
-func (w *webhookRetryWorker) Work(ctx context.Context, _ *river.Job[WebhookRetryArgs]) error {
-	return jobs.FaultContext(ctx, dispatchPerWorkspace(ctx, w.pool,
-		// The dispatcher's tick is the real retry cadence for a failed
-		// workspace — it re-enqueues the tenant on the next pass — so River's
-		// ladder is here only to ride out a transient blip inside one tick.
-		workspaceSweepOpts(WebhookRetryWorkspaceArgs{}.Kind()),
-		func(ws ids.UUID) river.JobArgs { return WebhookRetryWorkspaceArgs{Workspace: ws} }))
-}
-
-// WebhookRetryWorkspaceArgs re-attempts one workspace's due deliveries.
-type WebhookRetryWorkspaceArgs struct {
-	Workspace ids.UUID `json:"workspace_id"`
-}
-
-// Kind is the stable job identifier River persists in river_job.
-func (WebhookRetryWorkspaceArgs) Kind() string { return "webhook_retry_workspace" }
-
-// WorkspaceID binds this pass to its tenant (jobs.WorkspaceScoped).
-func (a WebhookRetryWorkspaceArgs) WorkspaceID() ids.UUID { return a.Workspace }
-
-// webhookRetryWorkspaceWorker sweeps one workspace.
-type webhookRetryWorkspaceWorker struct {
 	pool      *pgxpool.Pool
 	deliverer func(*database.DB) *webhooks.Deliverer
 }
 
-// Work binds the tenant and nothing else: the sweep re-sends deliveries that
-// were already authorized against their owner's scope when they were enqueued,
-// so it resolves no principal and writes no audited row of its own.
-func (w *webhookRetryWorkspaceWorker) Work(ctx context.Context, job *river.Job[WebhookRetryWorkspaceArgs]) error {
-	wsCtx, err := workspaceJobCtx(ctx, job.Args)
-	if err != nil {
-		return jobs.FaultContext(ctx, err)
-	}
-	// Built for the workspace THIS pass sweeps: the deliverer's store writes
-	// delivery rows, and a fleet pass cannot share one across the workspaces it
-	// re-attempts (ADR-0091 §9 step 3).
-	db, err := workspaceJobDB(w.pool, job.Args)
-	if err != nil {
-		return jobs.FaultContext(ctx, err)
-	}
-	return jobs.FaultContext(ctx, w.deliverer(db).SweepOnce(wsCtx))
+// Work resolves no principal and writes no audited row of its own: the sweep
+// re-sends deliveries that were already authorized against their owner's scope
+// when they were enqueued.
+func (w *webhookRetryWorker) Work(ctx context.Context, _ *river.Job[WebhookRetryArgs]) error {
+	return jobs.FaultContext(ctx, w.deliverer(InstallationDB(w.pool)).SweepOnce(ctx))
 }

--- a/backend/internal/compose/jobschedule_test.go
+++ b/backend/internal/compose/jobschedule_test.go
@@ -274,18 +274,22 @@ func periodicSiteKinds(t *testing.T) map[string]int {
 	return wired
 }
 
-// TestEveryScheduledDispatcherIsWiredExactlyOnce derives the wiring obligation
-// from the contract instead of keeping it as a list: a dispatcher whose
-// declaration carries a clock must have exactly one periodicFor site, and a
-// site must not name a kind with no schedule to place. A dispatcher that lost
-// its site is otherwise silent — nothing fails, the pass simply never ticks —
-// which is the failure mode of splitting twenty schedules across five files.
-func TestEveryScheduledDispatcherIsWiredExactlyOnce(t *testing.T) {
+// TestEveryScheduledKindIsWiredExactlyOnce derives the wiring obligation from
+// the contract instead of keeping it as a list: a kind whose declaration
+// carries a clock must have exactly one periodicFor site, and a site must not
+// name a kind with no schedule to place. A pass that lost its site is otherwise
+// silent — nothing fails, it simply never ticks — which is the failure mode of
+// splitting twenty schedules across five files.
+//
+// The obligation follows the CADENCE, not the role. A dispatcher always carries
+// one; a worker carries one when it is a pass in its own right rather than a
+// dispatcher's child (ADR-0103 §1).
+func TestEveryScheduledKindIsWiredExactlyOnce(t *testing.T) {
 	wired := periodicSiteKinds(t)
 
 	scheduled := 0
 	for kind, spec := range jobs.Declared() {
-		wantSite := spec.Role == jobs.Dispatcher && !spec.Cadence.OnDemand
+		wantSite := declaresAClock(spec.Cadence) && !spec.Cadence.OnDemand
 		if !wantSite {
 			if wired[kind] > 0 {
 				t.Errorf("%s has %d periodicFor site(s) but declares no schedule to place", kind, wired[kind])
@@ -301,4 +305,11 @@ func TestEveryScheduledDispatcherIsWiredExactlyOnce(t *testing.T) {
 		t.Fatalf("only %d dispatchers declare a cadence, under the floor of %d — this gate is no longer reading the contract",
 			scheduled, scheduledDispatcherFloor)
 	}
+}
+
+// declaresAClock reports whether the contract gives this kind a schedule of its
+// own — a fixed interval, or an operator field that carries one. A kind with
+// neither is reached by its dispatcher, and has no periodicFor site to own.
+func declaresAClock(c jobs.Cadence) bool {
+	return c.Fixed != 0 || c.OperatorField != "" || c.OnDemand
 }

--- a/backend/internal/compose/workspaceguard_test.go
+++ b/backend/internal/compose/workspaceguard_test.go
@@ -160,9 +160,6 @@ func TestEveryWorkspaceWorkerRefusesArgsNamingNoWorkspace(t *testing.T) {
 		PrivacyRetentionWorkspaceArgs{}.Kind(): func(ctx context.Context) error {
 			return (&privacyRetentionWorkspaceWorker{}).Work(ctx, &river.Job[PrivacyRetentionWorkspaceArgs]{})
 		},
-		WebhookRetryWorkspaceArgs{}.Kind(): func(ctx context.Context) error {
-			return (&webhookRetryWorkspaceWorker{}).Work(ctx, &river.Job[WebhookRetryWorkspaceArgs]{})
-		},
 		ProviderRunPollArgs{}.Kind(): func(ctx context.Context) error {
 			return (&providerRunPollWorker{}).Work(ctx, &river.Job[ProviderRunPollArgs]{})
 		},
@@ -188,7 +185,7 @@ func TestEveryWorkspaceWorkerRefusesArgsNamingNoWorkspace(t *testing.T) {
 
 	declared := 0
 	for kind, spec := range jobs.Declared() {
-		if spec.Role != jobs.Worker {
+		if !bindsAWorkspace(spec) {
 			continue
 		}
 		declared++
@@ -202,8 +199,8 @@ func TestEveryWorkspaceWorkerRefusesArgsNamingNoWorkspace(t *testing.T) {
 	}
 	for kind := range refusals {
 		spec, declaredKind := jobs.SpecFor(kind)
-		if !declaredKind || spec.Role != jobs.Worker {
-			t.Errorf("%s is driven here but api/jobs.yaml declares no workspace kind by that name — the suite is pinning something the fleet does not run", kind)
+		if !declaredKind || !bindsAWorkspace(spec) {
+			t.Errorf("%s is driven here but api/jobs.yaml declares no workspace-binding kind by that name — the suite is pinning something the fleet does not run", kind)
 		}
 	}
 
@@ -234,4 +231,18 @@ func TestTheWorkspaceGuardBindsTheWorkspaceTheArgsDeclare(t *testing.T) {
 	if got != want {
 		t.Fatalf("the guard bound %s, want the %s its args declared", got, want)
 	}
+}
+
+// bindsAWorkspace reads the obligation off the ARGS rather than off the role.
+// A worker binds a tenant while its args still name one, and ADR-0091 §8 is
+// removing those a module at a time — so a collapsed pass that no longer
+// carries a workspace has nothing to refuse, and demanding a refusal from it
+// would be demanding a guard against a field that does not exist.
+func bindsAWorkspace(spec jobs.Spec) bool {
+	for _, arg := range spec.Args {
+		if arg.Name == "Workspace" {
+			return true
+		}
+	}
+	return false
 }

--- a/backend/internal/modules/webhooks/deliverystore.go
+++ b/backend/internal/modules/webhooks/deliverystore.go
@@ -165,13 +165,8 @@ func (s *Store) matchingSubscriptions(ctx context.Context, eventType string) ([]
 	var out []subCandidate
 	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		rows, err := tx.Query(ctx, `
-			-- The workspace predicate is the fan-out's own, and it is the one
-			-- that matters most in this file: the caller creates a delivery
-			-- for every subscription this returns, so an unscoped match sends
-			-- one tenant's event payload to another tenant's target_url.
 			SELECT id, owner_id FROM webhook_subscription
-			WHERE workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid
-			  AND state = 'active' AND archived_at IS NULL
+			WHERE state = 'active' AND archived_at IS NULL
 			  AND event_types @> ARRAY[$1]::text[]`, eventType)
 		if err != nil {
 			return err
@@ -208,9 +203,8 @@ func (s *Store) enqueueForSubscriptions(ctx context.Context, subIDs []ids.UUID, 
 				WHERE id = ANY($4::uuid[]) AND state = 'active' AND archived_at IS NULL
 			), created AS (
 				INSERT INTO webhook_delivery
-				  (workspace_id, subscription_id, event_id, event_type, payload, status)
-				SELECT NULLIF(current_setting('app.workspace_id', true), '')::uuid,
-				       m.id, $2, $1, $3::text, 'pending'
+				  (subscription_id, event_id, event_type, payload, status)
+				SELECT m.id, $2, $1, $3::text, 'pending'
 				FROM matched m
 				ON CONFLICT (subscription_id, event_id) DO NOTHING
 				RETURNING id, subscription_id
@@ -243,13 +237,8 @@ func (s *Store) dueRetries(ctx context.Context, now time.Time, limit int) ([]ids
 		rows, err := tx.Query(ctx, `
 			SELECT d.id
 			FROM webhook_delivery d
-			JOIN webhook_subscription s
-			  ON s.workspace_id = d.workspace_id AND s.id = d.subscription_id
-			-- The workspace predicate is the scan's own: tenant isolation used
-			-- to bound it, so a sweep saw only its own tenant's parked
-			-- deliveries without saying so (ADR-0091 §8 phase A).
-			WHERE d.workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid
-			  AND d.status = 'retrying' AND d.next_retry_at <= $1
+			JOIN webhook_subscription s ON s.id = d.subscription_id
+			WHERE d.status = 'retrying' AND d.next_retry_at <= $1
 			  AND s.state = 'active' AND s.archived_at IS NULL
 			ORDER BY d.next_retry_at
 			LIMIT $2`, now, limit)
@@ -271,7 +260,7 @@ func (s *Store) dueRetries(ctx context.Context, now time.Time, limit int) ([]ids
 
 // loadTarget rehydrates a delivery into an attemptTarget for retry/replay:
 // the stored body plus the subscription's current target URL and sealed
-// secret (so a rotation between attempts takes effect). Runs in-workspace.
+// secret (so a rotation between attempts takes effect).
 func (s *Store) loadTarget(ctx context.Context, deliveryID ids.UUID) (attemptTarget, error) {
 	var t attemptTarget
 	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
@@ -279,13 +268,8 @@ func (s *Store) loadTarget(ctx context.Context, deliveryID ids.UUID) (attemptTar
 			SELECT d.id, d.subscription_id, s.target_url, s.signing_secret_ref,
 			       d.event_type, d.event_id, d.payload, d.attempts
 			FROM webhook_delivery d
-			JOIN webhook_subscription s
-			  ON s.workspace_id = d.workspace_id AND s.id = d.subscription_id
-			-- Scoped as well as keyed: a delivery id from another workspace
-			-- must answer not-found rather than hand back that tenant's
-			-- target_url and sealed signing secret.
-			WHERE d.id = $1
-			  AND d.workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid`, deliveryID).
+			JOIN webhook_subscription s ON s.id = d.subscription_id
+			WHERE d.id = $1`, deliveryID).
 			Scan(&t.deliveryID, &t.subID, &t.targetURL, &t.sealedSecret,
 				&t.eventType, &t.eventID, &t.payload, &t.priorAttempts)
 	})

--- a/backend/internal/modules/webhooks/store.go
+++ b/backend/internal/modules/webhooks/store.go
@@ -76,26 +76,25 @@ type BadInputError struct {
 
 func (e *BadInputError) Error() string { return e.Field + ": " + e.Reason }
 
-const subscriptionColumns = `id, workspace_id, owner_id, target_url, event_types, state, version, created_at, updated_at, archived_at`
+const subscriptionColumns = `id, owner_id, target_url, event_types, state, version, created_at, updated_at, archived_at`
 
 // Subscription is the metadata view of a subscription — the signing
 // secret is deliberately absent: it exists on the wire exactly once.
 type Subscription struct {
-	ID          ids.UUID
-	WorkspaceID ids.UUID
-	OwnerID     ids.UUID
-	TargetURL   string
-	EventTypes  []string
-	State       string
-	Version     int64
-	CreatedAt   time.Time
-	UpdatedAt   time.Time
-	ArchivedAt  *time.Time
+	ID         ids.UUID
+	OwnerID    ids.UUID
+	TargetURL  string
+	EventTypes []string
+	State      string
+	Version    int64
+	CreatedAt  time.Time
+	UpdatedAt  time.Time
+	ArchivedAt *time.Time
 }
 
 func scanSubscription(r pgx.Row) (Subscription, error) {
 	var s Subscription
-	err := r.Scan(&s.ID, &s.WorkspaceID, &s.OwnerID, &s.TargetURL, &s.EventTypes,
+	err := r.Scan(&s.ID, &s.OwnerID, &s.TargetURL, &s.EventTypes,
 		&s.State, &s.Version, &s.CreatedAt, &s.UpdatedAt, &s.ArchivedAt)
 	return s, err
 }
@@ -181,8 +180,8 @@ func (s *Store) CreateSubscription(ctx context.Context, in CreateSubscriptionInp
 	err = s.db.Tx(ctx, func(tx pgx.Tx) error {
 		row := tx.QueryRow(ctx, `
 			INSERT INTO webhook_subscription
-			  (workspace_id, owner_id, target_url, event_types, signing_secret_ref, state)
-			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, $2, $3, $4, 'active')
+			  (owner_id, target_url, event_types, signing_secret_ref, state)
+			VALUES ($1, $2, $3, $4, 'active')
 			RETURNING `+subscriptionColumns,
 			ownerID, in.TargetURL, in.EventTypes, sealed)
 		var err error

--- a/backend/internal/modules/webhooks/unit_test.go
+++ b/backend/internal/modules/webhooks/unit_test.go
@@ -51,14 +51,13 @@ func TestAttemptRefusesWithoutAUsableSecret(t *testing.T) {
 func TestWireSubscriptionMapsEveryFieldAndHidesNoSecret(t *testing.T) {
 	archived := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
 	s := Subscription{
-		ID:          ids.NewV7(),
-		WorkspaceID: ids.NewV7(),
-		OwnerID:     ids.NewV7(),
-		TargetURL:   "https://ok.example/hook",
-		EventTypes:  []string{"deal.created"},
-		State:       "active",
-		Version:     3,
-		ArchivedAt:  &archived,
+		ID:         ids.NewV7(),
+		OwnerID:    ids.NewV7(),
+		TargetURL:  "https://ok.example/hook",
+		EventTypes: []string{"deal.created"},
+		State:      "active",
+		Version:    3,
+		ArchivedAt: &archived,
 	}
 	got := wireSubscription(s)
 	if got.TargetUrl != s.TargetURL || string(got.State) != s.State || got.Version != s.Version {

--- a/backend/internal/platform/jobs/specs_gen.go
+++ b/backend/internal/platform/jobs/specs_gen.go
@@ -11,7 +11,7 @@ import "time"
 // would believe. It says nothing about the file on disk — a pair
 // regenerated TOGETHER from a stale contract matches here, and the drift
 // gate is what catches that.
-const JobContractHash = "bae6430067d6228e1df86e7194ca073cee82ec501a0421fb7e604f7baebcddff"
+const JobContractHash = "c0476c093a374625d793aa469f0b9b3e74bde63b3012fded767b528220c9bbb3"
 
 // specs is every declared kind. A kind absent from this table is a kind
 // nobody declared, and MustBeTotal is what names them: the runner calls it
@@ -670,25 +670,13 @@ var specs = map[string]Spec{
 	"webhook_retry": {
 		Kind:         "webhook_retry",
 		GoType:       "WebhookRetryArgs",
-		Role:         Dispatcher,
-		Queue:        "default",
-		Timeout:      TimeoutPolicy{Fixed: 2 * time.Minute},
-		FanOutUnit:   FanOutWorkspace,
-		FanOutTo:     "webhook_retry_workspace",
-		OptsOwner:    OptsCaller,
-		Cadence:      Cadence{OperatorField: "WebhookRetry.Interval", ScheduleWhenPositive: "WebhookRetry.Interval"},
-		Registration: Registration{When: []string{"WebhookRetry.Deliverer"}},
-	},
-	"webhook_retry_workspace": {
-		Kind:         "webhook_retry_workspace",
-		GoType:       "WebhookRetryWorkspaceArgs",
 		Role:         Worker,
 		Queue:        "webhook_retry",
 		Timeout:      TimeoutPolicy{Fixed: 1580 * time.Second, DerivedFrom: "webhookRetrySweepTimeout"},
 		MaxAttempts:  3,
-		OptsOwner:    OptsFanOut,
+		OptsOwner:    OptsArgs,
+		Cadence:      Cadence{OperatorField: "WebhookRetry.Interval", ScheduleWhenPositive: "WebhookRetry.Interval"},
 		Registration: Registration{When: []string{"WebhookRetry.Deliverer"}},
-		Args:         []ArgField{{Name: "Workspace"}},
 	},
 }
 

--- a/backend/migrations/core/0239_webhooks_drop_workspace.down.sql
+++ b/backend/migrations/core/0239_webhooks_drop_workspace.down.sql
@@ -1,0 +1,39 @@
+-- Reverse of 0239: the two webhook tables carry the tenant column again.
+--
+-- The backfill reads the LIVE workspace, and the predicate is the point: 0217's
+-- pre-flight refuses to run against a database holding more than one workspace
+-- with archived_at IS NULL, so there is exactly one live row — but an
+-- installation that resolved to one organization by ARCHIVING the others still
+-- has those rows, and 0217 names that residue explicitly. Ordering by
+-- created_at alone would hand every restored row to whichever workspace
+-- happened to be created first, archived or not.
+--
+-- If no live workspace exists and a table is not empty, SET NOT NULL fails and
+-- the rollback stops — the honest outcome, since no value this migration could
+-- write would be true.
+
+ALTER TABLE webhook_subscription ADD COLUMN workspace_id uuid;
+ALTER TABLE webhook_delivery ADD COLUMN workspace_id uuid;
+
+DO $$
+DECLARE ws uuid := (SELECT id FROM workspace WHERE archived_at IS NULL ORDER BY created_at LIMIT 1);
+BEGIN
+  UPDATE webhook_subscription SET workspace_id = ws;
+  UPDATE webhook_delivery SET workspace_id = ws;
+END $$;
+
+ALTER TABLE webhook_subscription ALTER COLUMN workspace_id SET NOT NULL;
+ALTER TABLE webhook_delivery ALTER COLUMN workspace_id SET NOT NULL;
+
+ALTER TABLE webhook_subscription ADD CONSTRAINT webhook_subscription_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE webhook_delivery ADD CONSTRAINT webhook_delivery_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+
+ALTER TABLE webhook_subscription ADD CONSTRAINT webhook_subscription_ws_id_key UNIQUE (id);
+
+DROP INDEX idx_webhook_delivery_by_subscription;
+CREATE INDEX idx_webhook_delivery_by_subscription ON webhook_delivery (workspace_id, subscription_id, created_at DESC);
+
+DROP INDEX idx_webhook_subscription_live;
+CREATE INDEX idx_webhook_subscription_live ON webhook_subscription (workspace_id, state) WHERE archived_at IS NULL;

--- a/backend/migrations/core/0239_webhooks_drop_workspace.up.sql
+++ b/backend/migrations/core/0239_webhooks_drop_workspace.up.sql
@@ -1,0 +1,17 @@
+-- 0239: the webhook tables drop the tenant column (ADR-0091 §8 phase D).
+--
+-- They were held back from every earlier slice because the retry sweep fanned
+-- out one job per live tenant, and the suite proving that fan-out asserted
+-- isolation between two of them. The sweep is one pass now (ADR-0103 §1), so
+-- the columns have nothing left to hold.
+
+DROP INDEX idx_webhook_delivery_by_subscription;
+CREATE INDEX idx_webhook_delivery_by_subscription ON webhook_delivery (subscription_id, created_at DESC);
+
+DROP INDEX idx_webhook_subscription_live;
+CREATE INDEX idx_webhook_subscription_live ON webhook_subscription (state) WHERE archived_at IS NULL;
+
+ALTER TABLE webhook_subscription DROP CONSTRAINT webhook_subscription_ws_id_key;
+
+ALTER TABLE webhook_subscription DROP COLUMN workspace_id;
+ALTER TABLE webhook_delivery DROP COLUMN workspace_id;

--- a/backend/tools/gen-jobs/contract.go
+++ b/backend/tools/gen-jobs/contract.go
@@ -230,6 +230,15 @@ type kindDef struct {
 	DerivesFrom  string                 `yaml:"derives-from"`
 }
 
+// hasWorkspaceArg reports whether this kind's args name a workspace, which is
+// what decides whether the type can bind one. It is asked instead of the role
+// because a worker's tenant is a fact about its args, and ADR-0091 §8 is
+// removing those one module at a time.
+func (k kindDef) hasWorkspaceArg() bool {
+	_, ok := k.Args["Workspace"]
+	return ok
+}
+
 // sortedArgs is the deterministic order the emitted args list walks; Go map
 // iteration is not stable and an unsorted emitter drifts the drift gate.
 func (k kindDef) sortedArgs() []string {

--- a/backend/tools/gen-jobs/emitkinds.go
+++ b/backend/tools/gen-jobs/emitkinds.go
@@ -118,11 +118,16 @@ func writeRoleAssertions(b *strings.Builder, c contract) {
 	}
 	b.WriteString(")\n\n")
 
-	b.WriteString("// The declared workspace-scoped kinds: each carries exactly one tenant's\n")
-	b.WriteString("// pass and says which in its own args.\n")
+	// Keyed on the ARGS, not on the role. A worker carries a tenant while its
+	// module still has one to carry (ADR-0091 §8 phase D is removing them one
+	// module at a time), and a worker whose args no longer name a workspace must
+	// not be asserted to bind one — the marker would be a claim about a field
+	// that does not exist.
+	b.WriteString("// The declared tenant-scoped kinds: each says which workspace it is for\n")
+	b.WriteString("// in its own args.\n")
 	b.WriteString("var (\n")
 	for _, name := range c.sortedKinds() {
-		if def := c.Kinds[name]; def.Role == roleWorker {
+		if def := c.Kinds[name]; def.Role == roleWorker && def.hasWorkspaceArg() {
 			fmt.Fprintf(b, "\t_ jobs.WorkspaceScoped = %s{}\n", def.GoType)
 		}
 	}

--- a/backend/tools/gen-jobs/validate.go
+++ b/backend/tools/gen-jobs/validate.go
@@ -18,7 +18,7 @@ import (
 // one is a change to what a job IS, and it has to land in both places at once.
 const (
 	roleDispatcher = "dispatcher"
-	roleWorker  = "worker"
+	roleWorker     = "worker"
 
 	unitWorkspace  = "workspace"
 	unitConnection = "connection"
@@ -144,8 +144,14 @@ func (c contract) validateKind(name string, def kindDef) error {
 		return fmt.Errorf("kind %q: opts_owner is fan_out but no max_attempts is declared — the fan-out helper reads this number and nothing else supplies it, so its absence is River's silent 25-rung ladder in place of the dispatcher's tick", name)
 	}
 	if def.MaxAttempts != nil {
-		if def.OptsOwner != optsFanOut {
-			return fmt.Errorf("kind %q: max_attempts is declared but opts_owner is %q — the file governs the attempt cap only for a fan-out child, and publishing one it does not enforce is the declared-vs-actual drift this contract exists to remove",
+		// Two owners can actually APPLY the number, so two may declare it: the
+		// fan-out helper reads it off the spec, and an args type carries it in
+		// its own InsertOpts (held equal to this declaration by
+		// TestArgsOwnedAttemptCapsMatchTheirDeclaration). A caller-owned kind
+		// may not, because nothing would enforce what the file published, which
+		// is the declared-vs-actual drift this contract exists to remove.
+		if def.OptsOwner != optsFanOut && def.OptsOwner != optsArgs {
+			return fmt.Errorf("kind %q: max_attempts is declared but opts_owner is %q — only a fan-out child or an args-owned kind applies the number the file publishes, and publishing one nothing enforces is the declared-vs-actual drift this contract exists to remove",
 				name, def.OptsOwner)
 		}
 		if *def.MaxAttempts <= 0 {
@@ -284,12 +290,29 @@ func (c contract) validateFanOut(name string, def kindDef) error {
 	return nil
 }
 
-// validateCadence holds the schedule to the role: a dispatcher is ticked and a
-// worker is enqueued, and neither may claim the other's posture.
+// isFannedOutTo reports whether some dispatcher enqueues this kind. It is the
+// difference between a worker that carries its own clock and one whose clock is
+// its dispatcher's.
+func (c contract) isFannedOutTo(name string) bool {
+	for _, def := range c.Kinds {
+		if def.FansOutTo == name {
+			return true
+		}
+	}
+	return false
+}
+
+// validateCadence holds the schedule to how the kind is REACHED, which is not
+// the same question as its role. A dispatcher is always ticked. A worker is
+// ticked when it is scheduled in its own right and enqueued when a dispatcher
+// fans out to it — and the manifest already says which, because a fanned-out
+// worker is named by exactly one `fans_out_to`. So the refusal is narrow: an
+// ENQUEUED worker may not also carry a clock, because two things would then
+// decide when it runs.
 func (c contract) validateCadence(name string, def kindDef) error {
 	if def.Role != roleDispatcher {
-		if def.Cadence != nil {
-			return fmt.Errorf("kind %q: declares a cadence but its role is %q — an enqueued worker is never ticked", name, def.Role)
+		if def.Cadence != nil && c.isFannedOutTo(name) {
+			return fmt.Errorf("kind %q: declares a cadence and is fanned out to by a dispatcher — a worker is reached one way or the other, never both", name)
 		}
 		return nil
 	}


### PR DESCRIPTION
The first collapse ADR-0103 §1 decides, and the module's phase D with it. They had to move together: the suite proving the fan-out asserted **isolation between two tenants**, and would otherwise have gone on asserting it against a schema that no longer has any.

## The pass

The survivor keeps the dispatcher's **kind and cadence** and the child's **queue, timeout and attempt cap**. `webhook_retry_workspace` is gone; 62 declared kinds become 61.

The cap is the part that needed the decision: `opts_owner: args`, not `caller`. The periodic insert supplies uniqueness and *no attempt policy*, so a caller-owned collapse would have silently traded three attempts for River's 25-rung default against a **26-minute timeout**. `TestArgsOwnedAttemptCapsMatchTheirDeclaration` holds the declared number equal to the one the args type actually inserts with — an args-owned kind earns the right to publish a cap by proving it applies it.

## Two gates were finding their subjects by a rule the collapse invalidates

Worth reading, because both would have gone quiet rather than red:

- **The workspace guard** demanded a refusal from every `worker`. For a pass carrying no workspace that is a guard against a field that does not exist. It reads the **args** now, which is also how the generated `jobs.WorkspaceScoped` assertion is emitted.
- **The actor gate** found its subjects with `workspaceJobDB(`. A collapsed pass calls `InstallationDB` instead — so every future collapse would have slipped out of its sight **while reading green**. The regex names both.

## Verification

- Lane applied to an empty database; the down restores both columns, the unique and both wide indexes.
- `make check-backend` green — including the job census, which caught the args type inserting on `default` while the manifest declared the `webhook_retry` queue.
- `make test-integration`: OK, 0 skips, 40 packages.

Phase D: 107 → 105 tables. Three fan-out modules left (agents, privacy, search) and they follow this shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Collapses the outbound‑webhook retry sweep from a dispatcher plus per‑workspace worker into a single scheduled `webhook_retry` worker and removes `workspace_id` from `webhook_subscription` and `webhook_delivery`. The job keeps the old kind and cadence, runs one installation‑wide pass per tick, and preserves the child’s queue, timeout, and three‑attempt cap.

- `webhook_retry` is now a worker with queue `webhook_retry`, derived timeout, `max_attempts: 3`, `opts_owner: args`, and ByState uniqueness; one pass per tick using `InstallationDB`.
- Webhook queries drop workspace predicates and joins while still filtering `state='active' AND archived_at IS NULL`; subscription create/enqueue and retry scans/load now operate installation‑wide.
- Guards/tests/tooling follow args, not role: the workspace guard only applies to kinds whose args include `Workspace`; the actor gate regex also matches `InstallationDB`; the schedule wiring test checks “scheduled kinds,” not only dispatchers; codegen asserts `jobs.WorkspaceScoped` only when args include `Workspace`.
- New test pins args‑owned attempt caps to their manifest declaration; integration tests convert to single‑pass semantics and assert the injected due‑scan fault by name where the raw error is available; new `AwaitKindOutcome` waits for a pass‑level outcome.
- Migrations: apply `0239_webhooks_drop_workspace.up.sql` (drops tenant columns and reindexes). Rollback: `0239_webhooks_drop_workspace.down.sql` backfills `workspace_id` to the single live workspace and fails if multiple live workspaces exist while tables are non‑empty.

<sup>Written for commit 570fdfada7e11418f87b22a2a566872923eb8115. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1255?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Webhook retries now run as a single sweep job per scheduled pass.
  * Retry jobs retain a maximum of three attempts with updated queue and timeout settings.
  * Webhook processing no longer requires workspace-specific records.

* **Bug Fixes**
  * Failed retry sweeps are now recorded and reported accurately.
  * Retry scans and delivery matching use consistent webhook identifiers.

* **Tests**
  * Expanded validation for scheduled jobs, retry limits, workspace scoping, and failed retry passes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->