### PR TITLE
docs(frontend): the two frontend rules no gate enforces

### DIFF
--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -1,0 +1,102 @@
+# CLAUDE.md — working in `frontend/`
+
+Scoped to this directory. The root [CLAUDE.md](../CLAUDE.md) still governs
+everything else: the branch/PR loop, the license header, the commit rules.
+Two things are frontend-only and neither has a gate that will catch them for
+you, so they are written down here.
+
+`craft static` sweeps the Go trees only. No `*.test.tsx` in this repo is in
+scope for the craftsmanship catalog today, T11 (*tests prove behaviour or they
+are noise*, no real-clock flakiness) included. In this directory the rule holds
+because the author holds it.
+
+## A test may not depend on how busy the machine is
+
+The frontend suite has produced two distinct flake families, and reading them
+the wrong way cost the team several rounds of re-running CI. Both lessons below
+are load-bearing.
+
+### A wait that expires is usually waiting for something that never arrives
+
+When a test times out under full-suite load and passes in isolation, the first
+instinct is "the runner was slow, raise the budget". Measure before believing
+it. The `company-context` family (#545, #652, #782, #981) was chased as a load
+problem for a month; the file actually takes 271ms inside the full suite against
+192ms isolated, 1.4x, nowhere near the 40x needed to exhaust a 10s waiter.
+
+The real cause was a product bug. React Query re-arms `useMutation`'s options in
+a **passive** effect, so between the commit that renders an enabled control and
+that effect running, the observer still holds the *previous* render's closure.
+A click landing in that window ran against stale state, the mutation refused it,
+and the test then waited out its full budget for a render that was never coming.
+Under load the window is simply wider.
+
+So: **a wait that dies close to its full budget is a signal that the thing never
+arrived, not that it was late.** Raising the timeout hides it. Capture the
+assertion's error text and the rendered DOM on the failing run; that is what
+separated a refusal from a slow render, and none of the first four reports had it.
+
+The rule that came out of it, and the gate that holds it:
+
+- **A `mutationFn` takes what it needs as a variable. It never closes over
+  render state.** The click handler belongs to the committed render, so a
+  variable it passes cannot be older than the control that carried it.
+- A falsy guard at the top of a `mutationFn` (`if (!form) return`) is not a
+  protection, it is the thing that *fires* when a stale closure happens, and
+  what it does to a user is refuse a form they have filled in. Two of the six
+  sites found this way were worse than a refusal: they would have submitted
+  choices nobody made.
+- `src/screens/mutation-variable-coverage.test.ts` walks the TSX with the
+  TypeScript compiler API and fails on the pattern. Do not work around it.
+
+### Drive the UI in a way that does not cost wall-clock time
+
+`userEvent.setup()` advances on real timers: every simulated keystroke and click
+awaits a real macrotask, so a test's cost scales with its interaction count.
+Calling `setup()` per interaction instead of once multiplies the fixed cost by
+the number of interactions, which is what pushes the interaction-heavy screen
+suites past vitest's 5s default under contention (#1144, open).
+
+When writing or touching a screen test:
+
+- Call `userEvent.setup()` **once per test**, never per interaction.
+- Wait on a condition, not on a duration. `findBy*` / `waitFor` over the settled
+  state, not a `SETTLE_MS` ceiling that a slow scheduler can starve.
+- No `setTimeout`, no sleep, no real clock. Inject fake timers, and drive
+  interactions through `userEvent.setup({ advanceTimers })` when the component
+  is timer-driven.
+- If a test only passes because it got the machine to itself, it is not a test
+  yet. Prove it: run the file alone and inside `make fe-unit`, and compare.
+- Test files split at 1000 lines, the same ceiling the Go test trees hold.
+  `onboarding-facts.test.tsx`, `company-act.test.tsx` and
+  `onboarding-conversation.test.tsx` are already past it. Do not grow them.
+
+## Storybook is documentation, and it goes stale silently
+
+Stories live beside their component as `<name>.stories.tsx`. That co-location is
+what `frontend/scripts/fe-uat.mjs` keys on, and `pnpm storybook` serves the
+catalog on :6006 with a Theme control that flips `data-theme` exactly the way the
+shell does.
+
+What the gates actually cover, so you know what they do not:
+
+- `make fe-bundle` builds the catalog in CI and **is** a required check, so a
+  story that fails to compile or fails to register is caught deterministically.
+- `make fe-uat` is the change-scoped render gate. It fails on a render error,
+  on a changed component with **no** story, and on a changed story the build
+  does not register, but it is a coordinator lane and **not required**, so
+  nothing stops a component from shipping without one.
+
+That second gap is the rule you keep by hand. When a change adds or alters a
+component in `src/design-system/` or a screen surface:
+
+- Add or update its `.stories.tsx` in the same commit, covering the states the
+  change introduces, not just the happy one.
+- Check it in **both themes** before calling the surface done. Every derived
+  value is a `color-mix()` of a canonical token and follows the dark accent lift,
+  so a surface can be correct in light and wrong in dark.
+- Run `make fe-uat` locally on a frontend change. Being unrequired is a fact
+  about CI, not permission to skip it.
+- `src/design-system/README.md` is the catalog and the prose that goes with it.
+  A new control, a new variant, or a changed prop contract updates that file too.
+  It is what the next person reads instead of hand-rolling a second dropdown.

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -21,8 +21,9 @@ are load-bearing.
 When a test times out under full-suite load and passes in isolation, the first
 instinct is "the runner was slow, raise the budget". Measure before believing
 it. The `company-context` family (#545, #652, #782, #981) was chased as a load
-problem for a month; the file actually takes 271ms inside the full suite against
-192ms isolated, 1.4x, nowhere near the 40x needed to exhaust a 10s waiter.
+problem for a month; the file actually takes 271 ms in the full suite versus
+192 ms in isolation, a factor of 1.4, nowhere near the factor of 40 that
+exhausting a 10s waiter would need.
 
 The real cause was a product bug. React Query re-arms `useMutation`'s options in
 a **passive** effect, so between the commit that renders an enabled control and
@@ -51,11 +52,17 @@ The rule that came out of it, and the gate that holds it:
 
 ### Drive the UI in a way that does not cost wall-clock time
 
-`userEvent.setup()` advances on real timers: every simulated keystroke and click
-awaits a real macrotask, so a test's cost scales with its interaction count.
-Calling `setup()` per interaction instead of once multiplies the fixed cost by
-the number of interactions, which is what pushes the interaction-heavy screen
+`userEvent` advances on real timers. Its `delay` defaults to `0`, which is still
+a number, so `wait()` schedules a real `setTimeout` and every simulated keystroke
+and click yields a macrotask (`user-event` 14.6.3, `utils/misc/wait.js:9`). A
+test's cost therefore scales with its interaction count, on a queue it shares
+with every other jsdom suite, which is what pushes the interaction-heavy screen
 suites past vitest's 5s default under contention (#1144, open).
+
+The cost is per event, not per `setup()`, so constructing an instance per
+interaction is not itself the expense. Do it once per test anyway: one instance
+carries the shared input-device state, and a second one silently forgets which
+keys and buttons the first left held.
 
 When writing or touching a screen test:
 
@@ -84,8 +91,9 @@ What the gates actually cover, so you know what they do not:
   story that fails to compile or fails to register is caught deterministically.
 - `make fe-uat` is the change-scoped render gate. It fails on a render error,
   on a changed component with **no** story, and on a changed story the build
-  does not register, but it is a coordinator lane and **not required**, so
-  nothing stops a component from shipping without one.
+  does not register. Two things weaken it: it is a coordinator lane and **not
+  required**, and `ARGS="--allow-missing"` turns the missing-story failure off.
+  Nothing, then, stops a component from shipping without a story.
 
 That second gap is the rule you keep by hand. When a change adds or alters a
 component in `src/design-system/` or a screen surface:


### PR DESCRIPTION
`craft static` sweeps the Go trees only, so T11 (*tests prove behaviour or they are noise*, no real-clock flakiness) covers no `*.test.tsx` in this tree. `make fe-uat` does fail on a changed component with no story, but it is a coordinator lane rather than a required check. Both rules therefore hold only if the author holds them, and neither was written down anywhere.

A directory-scoped `frontend/CLAUDE.md` records them where they apply: it loads when a session touches `frontend/`, and stays out of every backend session's context.

## What it carries

The reasoning the flake investigations produced, not only the resulting rule, because reading these the wrong way is what cost the rounds of CI re-runs:

- **A wait that dies near its full budget means the awaited thing never arrived, not that it was late.** The company-context family (#545, #652, #782, #981) established this by measurement: 271ms inside the full suite against 192ms isolated, against the 40x that exhausting a 10s waiter would need. Raising the budget hides it.
- **A `mutationFn` takes what it needs as a variable and never closes over render state**, since React Query re-arms the observer's options in a passive effect. A falsy guard at the top of one is what *fires* when a stale closure happens, not what protects against it, and what it does to a user is refuse a form they have filled in. `src/screens/mutation-variable-coverage.test.ts` already holds this.
- **`userEvent.setup()` is called once per test**, because it advances on real timers and per-interaction construction multiplies the fixed cost (#1144, open).
- A wait is on a condition, never on a duration a slow scheduler can starve; test files split at the 1000-line ceiling the Go test trees hold.

For Storybook it states what the gates actually cover, so the uncovered half is visible: `make fe-bundle` is a required check and catches a story that cannot compile or register, while a component shipping with **no** story at all is caught by nothing. That half is the hand-kept rule, along with checking a surface in both themes and updating `src/design-system/README.md` when a control or prop contract changes.

## Scope

Docs only, one new file. No pointer added from the root `CLAUDE.md`: a nested file loads on touching the directory, so a session that never opens `frontend/` has no use for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents two frontend-only rules that CI does not enforce: write load-agnostic tests and keep Storybook coverage complete. Adds `frontend/CLAUDE.md`; clarifies that `userEvent` cost scales with interactions and that `make fe-uat` can skip missing-story failures; no runtime or build changes.

- Review focus:
  - Testing: `mutationFn` gets inputs via variables (no render-state closures); call `userEvent.setup()` once per test for shared input state; waits are condition-based and use fake timers.
  - Storybook gates: `make fe-bundle` is required; `make fe-uat` is optional and `ARGS="--allow-missing"` disables the missing-story failure.
  - Verify references/commands: `src/screens/mutation-variable-coverage.test.ts`, `make fe-bundle`, `make fe-uat`, `.stories.tsx` co-location, `src/design-system/README.md`.

- Required actions for contributors:
  - In tests: use condition waits, avoid sleeps/real clocks, call `userEvent.setup()` once per test, and pass inputs to `mutationFn` via variables.
  - For UI changes: add/update the co-located `.stories.tsx`, verify in both themes, run `make fe-uat` locally, and update `src/design-system/README.md` when adding variants or changing prop contracts.

<sup>Written for commit 004838be4936f331818b568072fd651e9e716865. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1263?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added frontend development guidance covering testing practices, timer handling, Storybook coverage, theme verification, user acceptance testing, and design-system documentation updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->