### PR TITLE
fix(deploy): the bootstrap credential is written once, not at every boot

### DIFF
--- a/backend/cmd/migrate/main.go
+++ b/backend/cmd/migrate/main.go
@@ -367,51 +367,6 @@ func dropDB(ctx context.Context, conn *pgx.Conn, name string, stdout io.Writer) 
 	return nil
 }
 
-// dbExists prints "true" or "false" — output, not exit code, so callers can
-// tell "absent" apart from "could not ask" (a connection failure still exits
-// non-zero).
-func dbExists(ctx context.Context, conn *pgx.Conn, name string, stdout io.Writer) error {
-	if name == "" {
-		return errors.New("migrate db-exists: --name is required")
-	}
-	if err := fitsIdentifier(ctx, conn, "migrate db-exists: --name", name); err != nil {
-		return err
-	}
-	var exists bool
-	if err := conn.QueryRow(ctx, "SELECT EXISTS (SELECT 1 FROM pg_database WHERE datname = $1)", name).Scan(&exists); err != nil {
-		return fmt.Errorf("migrate db-exists: probing %q: %w", name, err)
-	}
-	if _, err := fmt.Fprintf(stdout, "%t\n", exists); err != nil {
-		return fmt.Errorf("migrate db-exists: writing the answer: %w", err)
-	}
-	return nil
-}
-
-// orgExists reports whether this installation has been bootstrapped — whether an
-// active organization exists — as "true" or "false" on stdout, in the shape
-// dbExists above already answers a yes/no question.
-//
-// It exists so a deployment can tell the two states apart BEFORE the api boots,
-// which is what lets an entrypoint stop materializing a bootstrap credential an
-// already-provisioned installation will never read (ADR-0061 §2: bootstrap
-// values are consumed exactly once, and the section may be deleted once the
-// organization exists).
-//
-// The predicate is the one the api itself applies when it counts organizations
-// at boot — archived_at IS NULL — rather than a second spelling of "active" that
-// could drift from it.
-func orgExists(ctx context.Context, conn *pgx.Conn, stdout io.Writer) error {
-	var exists bool
-	if err := conn.QueryRow(ctx,
-		`SELECT EXISTS (SELECT 1 FROM workspace WHERE archived_at IS NULL)`).Scan(&exists); err != nil {
-		return fmt.Errorf("migrate org-exists: probing for an organization: %w", err)
-	}
-	if _, err := fmt.Fprintf(stdout, "%t\n", exists); err != nil {
-		return fmt.Errorf("migrate org-exists: writing the answer: %w", err)
-	}
-	return nil
-}
-
 // resetPassword is the operator-only recovery path (A107/ADR-0061 §9.1):
 // reset a named user's password directly against the database — the
 // fallback when outbound email is not configured, and the way back in

--- a/backend/cmd/migrate/main.go
+++ b/backend/cmd/migrate/main.go
@@ -50,7 +50,7 @@ func main() {
 
 func run(ctx context.Context, args []string, stdout, stderr io.Writer) error {
 	if len(args) == 0 {
-		return errors.New("usage: migrate <up|down|reset-password|recreate-db|drop-db|db-exists> --dsn <dsn> [--steps n] [--email <address>] [--name <db>] [--template <db>]")
+		return errors.New("usage: migrate <up|down|reset-password|recreate-db|drop-db|db-exists|org-exists> --dsn <dsn> [--steps n] [--email <address>] [--name <db>] [--template <db>]")
 	}
 	direction := args[0]
 
@@ -108,8 +108,10 @@ func run(ctx context.Context, args []string, stdout, stderr io.Writer) error {
 		return dropDB(ctx, conn, *name, stdout)
 	case "db-exists":
 		return dbExists(ctx, conn, *name, stdout)
+	case "org-exists":
+		return orgExists(ctx, conn, stdout)
 	default:
-		return fmt.Errorf("migrate: unknown direction %q (want up, down, reset-password, recreate-db, drop-db or db-exists)", direction)
+		return fmt.Errorf("migrate: unknown direction %q (want up, down, reset-password, recreate-db, drop-db, db-exists or org-exists)", direction)
 	}
 }
 
@@ -381,6 +383,31 @@ func dbExists(ctx context.Context, conn *pgx.Conn, name string, stdout io.Writer
 	}
 	if _, err := fmt.Fprintf(stdout, "%t\n", exists); err != nil {
 		return fmt.Errorf("migrate db-exists: writing the answer: %w", err)
+	}
+	return nil
+}
+
+// orgExists reports whether this installation has been bootstrapped — whether an
+// active organization exists — as "true" or "false" on stdout, in the shape
+// dbExists above already answers a yes/no question.
+//
+// It exists so a deployment can tell the two states apart BEFORE the api boots,
+// which is what lets an entrypoint stop materializing a bootstrap credential an
+// already-provisioned installation will never read (ADR-0061 §2: bootstrap
+// values are consumed exactly once, and the section may be deleted once the
+// organization exists).
+//
+// The predicate is the one the api itself applies when it counts organizations
+// at boot — archived_at IS NULL — rather than a second spelling of "active" that
+// could drift from it.
+func orgExists(ctx context.Context, conn *pgx.Conn, stdout io.Writer) error {
+	var exists bool
+	if err := conn.QueryRow(ctx,
+		`SELECT EXISTS (SELECT 1 FROM workspace WHERE archived_at IS NULL)`).Scan(&exists); err != nil {
+		return fmt.Errorf("migrate org-exists: probing for an organization: %w", err)
+	}
+	if _, err := fmt.Fprintf(stdout, "%t\n", exists); err != nil {
+		return fmt.Errorf("migrate org-exists: writing the answer: %w", err)
 	}
 	return nil
 }

--- a/backend/cmd/migrate/main_integration_test.go
+++ b/backend/cmd/migrate/main_integration_test.go
@@ -5,11 +5,15 @@
 
 package main
 
+// The verbs a shell script depends on, pinned against a real Postgres so a
+// regression fails here rather than as a broken lane or a broken deployment.
+//
 // The database-lifecycle verbs are the integration lane's clone machinery
 // (scripts/lib-testdb.sh db_admin): recreate-db/drop-db own destructive
 // DROP/CREATE DATABASE, and db-exists prints the literal answer the lane's
-// ensure_template string-compares. These tests pin that contract against a
-// real Postgres so a regression fails here, not as a broken lane.
+// ensure_template string-compares. org-exists is the same kind of contract for
+// a different caller: scripts/deploy/api-entrypoint.sh branches on its answer
+// to decide whether a plaintext bootstrap credential is written at all.
 
 import (
 	"bytes"

--- a/backend/cmd/migrate/main_integration_test.go
+++ b/backend/cmd/migrate/main_integration_test.go
@@ -353,6 +353,51 @@ func TestUpAppliesAnExtensionNamespaceAndTheRiverIndex(t *testing.T) {
 	}
 }
 
+// TestOrgExistsAnswersTheEntrypointsQuestion pins the three states the deploy
+// entrypoint distinguishes before it decides whether to materialize a bootstrap
+// credential. The archived case is the one worth having: the api counts
+// organizations with `archived_at IS NULL`, and a probe that merely counted rows
+// would call an archived-only installation provisioned and withhold the
+// credential that could still bootstrap it.
+func TestOrgExistsAnswersTheEntrypointsQuestion(t *testing.T) {
+	maint, base, withDB := testDSNs(t)
+	name := base + "_org_probe"
+	t.Cleanup(func() { mustMigrate(t, "drop-db", "--dsn", maint, "--name", name) })
+	mustMigrate(t, "recreate-db", "--dsn", maint, "--name", name)
+
+	dsn := withDB(name)
+	mustMigrate(t, "up", "--dsn", dsn)
+
+	if out := mustMigrate(t, "org-exists", "--dsn", dsn); out != "false\n" {
+		t.Fatalf("org-exists against a migrated but unbootstrapped installation printed %q, want %q", out, "false\n")
+	}
+
+	ctx := context.Background()
+	conn, err := pgx.Connect(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connecting to seed a workspace: %v", err)
+	}
+	defer func() {
+		if err := conn.Close(ctx); err != nil {
+			t.Errorf("closing the seeding connection: %v", err)
+		}
+	}()
+
+	if _, err := conn.Exec(ctx, `INSERT INTO workspace (slug) VALUES ('org-probe')`); err != nil {
+		t.Fatalf("seeding a workspace: %v", err)
+	}
+	if out := mustMigrate(t, "org-exists", "--dsn", dsn); out != "true\n" {
+		t.Fatalf("org-exists against a bootstrapped installation printed %q, want %q", out, "true\n")
+	}
+
+	if _, err := conn.Exec(ctx, `UPDATE workspace SET archived_at = now() WHERE slug = 'org-probe'`); err != nil {
+		t.Fatalf("archiving the workspace: %v", err)
+	}
+	if out := mustMigrate(t, "org-exists", "--dsn", dsn); out != "false\n" {
+		t.Fatalf("org-exists counted an ARCHIVED organization as present (printed %q); the api's boot count ignores it, so the two disagree", out)
+	}
+}
+
 // assertRecorded proves the version landed in the namespace's OWN tracking
 // table: an extension migration recorded against core's table would be
 // reverted by a plain `migrate down`.

--- a/backend/cmd/migrate/main_test.go
+++ b/backend/cmd/migrate/main_test.go
@@ -10,6 +10,7 @@ package main
 // integration lane alone.
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"os"
@@ -218,6 +219,40 @@ func TestReportExtensionNamespacesPropagatesAWriteFailure(t *testing.T) {
 // scripts/lib-testdb.sh and captures the literal prefix it tests the summary
 // against.
 var shellMatcherPattern = regexp.MustCompile(`\[\[ "\$summary" != "([^"]*)"\* \]\]`)
+
+// entrypointProvisionedPattern finds the deploy entrypoint's comparison against
+// the org-exists answer and captures the literal it expects.
+var entrypointProvisionedPattern = regexp.MustCompile(`\[ "\$provisioned" = "([^"]*)" \]`)
+
+// TestOrgExistsAnswerMatchesTheEntrypointComparison pins the other half of a
+// wire contract that is otherwise only exercised in a container nothing in CI
+// runs: the entrypoint string-compares this verb's stdout to decide whether to
+// write a plaintext bootstrap credential. Drift in either direction is silent
+// and lands on the wrong side of that decision — print "TRUE" and every
+// provisioned installation gets the credential written again.
+func TestOrgExistsAnswerMatchesTheEntrypointComparison(t *testing.T) {
+	const script = "../../../scripts/deploy/api-entrypoint.sh"
+	source, err := os.ReadFile(script)
+	if err != nil {
+		t.Fatalf("reading %s: %v", script, err)
+	}
+	found := entrypointProvisionedPattern.FindSubmatch(source)
+	if found == nil {
+		t.Fatalf("%s no longer compares $provisioned against a literal — the bootstrap-credential branch was rewritten; re-point this test at whatever replaced it", script)
+	}
+	want := string(found[1])
+
+	var out bytes.Buffer
+	// The exact call orgExists makes to report a provisioned installation. The
+	// shell's $(…) strips the trailing newline, so the comparison is against the
+	// trimmed form.
+	if _, err := fmt.Fprintf(&out, "%t\n", true); err != nil {
+		t.Fatalf("rendering the answer: %v", err)
+	}
+	if got := strings.TrimSpace(out.String()); got != want {
+		t.Errorf("org-exists prints %q for a provisioned installation but %s branches on %q — the entrypoint would write a plaintext bootstrap credential onto a live installation; change both together", got, script, want)
+	}
+}
 
 // TestUpSummaryMatchesTheShellMatcher closes a silent-drift risk between two
 // files that cannot see each other: cmd/migrate prints the summary and

--- a/backend/cmd/migrate/probes.go
+++ b/backend/cmd/migrate/probes.go
@@ -19,9 +19,7 @@ import (
 	"github.com/jackc/pgx/v5"
 )
 
-// dbExists prints "true" or "false" — output, not exit code, so callers can
-// tell "absent" apart from "could not ask" (a connection failure still exits
-// non-zero).
+// dbExists answers whether a database of that name is present on the cluster.
 func dbExists(ctx context.Context, conn *pgx.Conn, name string, stdout io.Writer) error {
 	if name == "" {
 		return errors.New("migrate db-exists: --name is required")
@@ -39,13 +37,9 @@ func dbExists(ctx context.Context, conn *pgx.Conn, name string, stdout io.Writer
 	return nil
 }
 
-// orgExists reports whether this installation has been bootstrapped — whether an
-// active organization exists — as "true" or "false" on stdout, in the shape
-// dbExists above already answers a yes/no question.
-//
-// It exists so a deployment can tell the two states apart BEFORE the api boots,
-// which is what lets an entrypoint stop materializing a bootstrap credential an
-// already-provisioned installation will never read (ADR-0061 §2: bootstrap
+// orgExists answers whether this installation holds an active organization —
+// whether it is provisioned. A deployment asks before the api boots, to know
+// whether a bootstrap credential is still needed at all (ADR-0061 §2: bootstrap
 // values are consumed exactly once, and the section may be deleted once the
 // organization exists).
 //

--- a/backend/cmd/migrate/probes.go
+++ b/backend/cmd/migrate/probes.go
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package main
+
+// The probe verbs: each answers one yes/no question by PRINTING the answer
+// rather than by exit code, so a shell caller can branch on it without
+// conflating "the answer is no" with "the command failed". They live together
+// because that output contract is the thing they share and the thing a caller
+// depends on -- scripts/lib-testdb.sh string-compares db-exists, and the deploy
+// entrypoint string-compares org-exists.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// dbExists prints "true" or "false" — output, not exit code, so callers can
+// tell "absent" apart from "could not ask" (a connection failure still exits
+// non-zero).
+func dbExists(ctx context.Context, conn *pgx.Conn, name string, stdout io.Writer) error {
+	if name == "" {
+		return errors.New("migrate db-exists: --name is required")
+	}
+	if err := fitsIdentifier(ctx, conn, "migrate db-exists: --name", name); err != nil {
+		return err
+	}
+	var exists bool
+	if err := conn.QueryRow(ctx, "SELECT EXISTS (SELECT 1 FROM pg_database WHERE datname = $1)", name).Scan(&exists); err != nil {
+		return fmt.Errorf("migrate db-exists: probing %q: %w", name, err)
+	}
+	if _, err := fmt.Fprintf(stdout, "%t\n", exists); err != nil {
+		return fmt.Errorf("migrate db-exists: writing the answer: %w", err)
+	}
+	return nil
+}
+
+// orgExists reports whether this installation has been bootstrapped — whether an
+// active organization exists — as "true" or "false" on stdout, in the shape
+// dbExists above already answers a yes/no question.
+//
+// It exists so a deployment can tell the two states apart BEFORE the api boots,
+// which is what lets an entrypoint stop materializing a bootstrap credential an
+// already-provisioned installation will never read (ADR-0061 §2: bootstrap
+// values are consumed exactly once, and the section may be deleted once the
+// organization exists).
+//
+// The predicate is the one the api itself applies when it counts organizations
+// at boot — archived_at IS NULL — rather than a second spelling of "active" that
+// could drift from it.
+func orgExists(ctx context.Context, conn *pgx.Conn, stdout io.Writer) error {
+	var exists bool
+	if err := conn.QueryRow(ctx,
+		`SELECT EXISTS (SELECT 1 FROM workspace WHERE archived_at IS NULL)`).Scan(&exists); err != nil {
+		return fmt.Errorf("migrate org-exists: probing for an organization: %w", err)
+	}
+	if _, err := fmt.Fprintf(stdout, "%t\n", exists); err != nil {
+		return fmt.Errorf("migrate org-exists: writing the answer: %w", err)
+	}
+	return nil
+}

--- a/backend/internal/compose/extjobseat_integration_test.go
+++ b/backend/internal/compose/extjobseat_integration_test.go
@@ -37,11 +37,13 @@ func TestTheDispatcherResolvesTheSeatBootstrapMinted(t *testing.T) {
 	}
 
 	wsID, created, err := identity.NewService(e.Pool).BootstrapInstallation(ctx,
-		&identity.InstallationBootstrap{
-			OrganizationName: "seatjoin",
-			AdminEmail:       "admin@seatjoin.test",
-			AdminName:        "Admin",
-			AdminPassword:    "a bootstrap password!",
+		func() (identity.InstallationBootstrap, error) {
+			return identity.InstallationBootstrap{
+				OrganizationName: "seatjoin",
+				AdminEmail:       "admin@seatjoin.test",
+				AdminName:        "Admin",
+				AdminPassword:    "a bootstrap password!",
+			}, nil
 		}, nil)
 	if err != nil {
 		t.Fatalf("bootstrap: %v", err)

--- a/backend/internal/compose/installation.go
+++ b/backend/internal/compose/installation.go
@@ -41,22 +41,29 @@ import (
 // Restarts are idempotent — bootstrap values never reconcile into an
 // existing organization.
 func EnsureInstallation(ctx context.Context, pool *pgxpool.Pool, log *slog.Logger, cfg deployconfig.Config) error {
-	var create *identity.InstallationBootstrap
+	var create func() (identity.InstallationBootstrap, error)
 	if b := cfg.BootstrapAdmin; b != nil {
 		if cfg.Organization.Name == "" {
 			return errors.New("compose: bootstrap_admin is configured but organization.name is missing — both are required to bootstrap an empty database")
 		}
-		pw, err := b.Password()
-		if err != nil {
-			return err
-		}
-		create = &identity.InstallationBootstrap{
-			OrganizationName: cfg.Organization.Name,
-			BaseCurrency:     cfg.Organization.BaseCurrency,
-			Timezone:         cfg.Organization.Timezone,
-			AdminEmail:       b.Email,
-			AdminName:        b.DisplayName,
-			AdminPassword:    pw,
+		// The password secret is read inside this closure, which bootstrap
+		// calls only when it is actually creating the organization. Reading it
+		// here would read it on every boot, and ADR-0061 §2 permits deleting
+		// the secret once the organization exists — so an installation that
+		// followed the ADR would stop booting.
+		create = func() (identity.InstallationBootstrap, error) {
+			pw, err := b.Password()
+			if err != nil {
+				return identity.InstallationBootstrap{}, err
+			}
+			return identity.InstallationBootstrap{
+				OrganizationName: cfg.Organization.Name,
+				BaseCurrency:     cfg.Organization.BaseCurrency,
+				Timezone:         cfg.Organization.Timezone,
+				AdminEmail:       b.Email,
+				AdminName:        b.DisplayName,
+				AdminPassword:    pw,
+			}, nil
 		}
 	}
 

--- a/backend/internal/compose/installation_test.go
+++ b/backend/internal/compose/installation_test.go
@@ -10,7 +10,6 @@ import (
 	"context"
 	"io"
 	"log/slog"
-	"path/filepath"
 	"strings"
 	"testing"
 
@@ -34,17 +33,12 @@ func TestEnsureInstallationRefusesAnAdminWithoutAnOrganization(t *testing.T) {
 	}
 }
 
-func TestEnsureInstallationSurfacesAnUnreadablePasswordFile(t *testing.T) {
-	cfg := deployconfig.Config{
-		Version:      1,
-		Organization: deployconfig.Organization{Name: "Gradion"},
-		BootstrapAdmin: &deployconfig.BootstrapAdmin{
-			Email: "a@b.test", DisplayName: "A",
-			PasswordFile: filepath.Join(t.TempDir(), "missing"),
-		},
-	}
-	err := EnsureInstallation(context.Background(), nil, discardLogger(), cfg)
-	if err == nil || !strings.Contains(err.Error(), "password_file") {
-		t.Fatalf("err = %v, want the password-file read error", err)
-	}
-}
+// An unreadable password file is proven to surface by
+// TestFirstBootStillFailsLoudlyOnAnUnreadableSecret in the integration lane, not
+// here. The secret is now read only on the branch that creates the organization
+// — after the database reports itself empty — so no assertion driven by a nil
+// pool can reach it. The property is unchanged and the coverage is stronger for
+// running against a real database; what moved is where it can be observed.
+//
+// The eager half stays below: configuration that is wrong on its face is still
+// refused before anything connects.

--- a/backend/internal/compose/integration/installation_integration_test.go
+++ b/backend/internal/compose/integration/installation_integration_test.go
@@ -19,6 +19,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -209,6 +210,68 @@ func TestBootstrapSeedsTheAiModelRatePriceSheet(t *testing.T) {
 	}
 	if other != 0 {
 		t.Fatalf("ai_model_rate carries %d rows outside the bootstrapped workspace, want 0", other)
+	}
+}
+
+// TestBootBindsWithoutReadingASpentBootstrapSecret is the restart an operator
+// who followed ADR-0061 §2 actually performs. The ADR permits deleting the
+// bootstrap secret once the organization exists, and the deploy entrypoint stops
+// writing it at that point — so a boot that resolved the credential eagerly
+// would fail on precisely the installations that obeyed the ADR, turning every
+// redeploy into a crash loop. The password file is removed here rather than
+// merely left stale, because "absent" is the state the container filesystem
+// actually presents: /app/secrets carries no VOLUME, so a new container starts
+// without it.
+func TestBootBindsWithoutReadingASpentBootstrapSecret(t *testing.T) {
+	e := apptest.SetupApp(t)
+	pwFile := filepath.Join(t.TempDir(), "admin-password")
+	if err := os.WriteFile(pwFile, []byte("correct-horse-battery"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg := deployconfig.Config{
+		Version:      1,
+		Organization: deployconfig.Organization{Name: "Spent Secret Org", BaseCurrency: "EUR", Timezone: "Europe/Berlin"},
+		BootstrapAdmin: &deployconfig.BootstrapAdmin{
+			Email: "ops@spent.test", DisplayName: "Ops", PasswordFile: pwFile,
+		},
+		Seeds: deployconfig.Seeds{StarterAutomations: boolPtr(false), BookingPage: boolPtr(false)},
+	}
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	if err := compose.EnsureInstallation(context.Background(), e.Pool, log, cfg); err != nil {
+		t.Fatalf("first boot: %v", err)
+	}
+
+	if err := os.Remove(pwFile); err != nil {
+		t.Fatalf("retiring the bootstrap secret: %v", err)
+	}
+	// Same configuration, same process role, second start.
+	if err := compose.EnsureInstallation(context.Background(), e.Pool, log, cfg); err != nil {
+		t.Fatalf("restart after the bootstrap secret was retired: %v — the boot path read a credential it only needs to CREATE an organization, so every redeploy of a bootstrapped installation would crash-loop", err)
+	}
+}
+
+// TestFirstBootStillFailsLoudlyOnAnUnreadableSecret is the other half: making
+// the read lazy must not make it optional. An empty database plus a configured
+// bootstrap_admin whose secret cannot be read is an operator error, and it has
+// to surface as one rather than as a silently unbootstrapped installation.
+func TestFirstBootStillFailsLoudlyOnAnUnreadableSecret(t *testing.T) {
+	e := apptest.SetupApp(t)
+	cfg := deployconfig.Config{
+		Version:      1,
+		Organization: deployconfig.Organization{Name: "No Secret Org", BaseCurrency: "EUR", Timezone: "Europe/Berlin"},
+		BootstrapAdmin: &deployconfig.BootstrapAdmin{
+			Email: "ops@nosecret.test", DisplayName: "Ops",
+			PasswordFile: filepath.Join(t.TempDir(), "never-written"),
+		},
+		Seeds: deployconfig.Seeds{StarterAutomations: boolPtr(false), BookingPage: boolPtr(false)},
+	}
+	err := compose.EnsureInstallation(context.Background(), e.Pool,
+		slog.New(slog.NewTextHandler(io.Discard, nil)), cfg)
+	if err == nil {
+		t.Fatal("first boot succeeded with an unreadable bootstrap secret — the deferred read swallowed the error instead of refusing")
+	}
+	if !strings.Contains(err.Error(), "password_file") {
+		t.Errorf("the failure does not name the password file the operator must fix: %v", err)
 	}
 }
 

--- a/backend/internal/modules/identity/installation.go
+++ b/backend/internal/modules/identity/installation.go
@@ -65,7 +65,15 @@ type InstallationBootstrap struct {
 // is minted: the first admin signs in through the normal login, and
 // bootstrap values never reconcile into an existing organization
 // (restart never resets a password, role, or seed).
-func (s *Service) BootstrapInstallation(ctx context.Context, create *InstallationBootstrap, seed func(ctx context.Context, tx pgx.Tx) error) (wsID ids.WorkspaceID, created bool, err error) {
+//
+// create is a FUNCTION, and it is called only on the branch that creates
+// the organization. Resolving the bootstrap input eagerly would read the
+// admin's password secret on every boot of an already-bootstrapped
+// installation — a secret ADR-0061 §2 says may be deleted once the
+// organization exists, so the read would fail on exactly the installations
+// that followed the ADR. What is only needed to CREATE is only resolved
+// when creating.
+func (s *Service) BootstrapInstallation(ctx context.Context, create func() (InstallationBootstrap, error), seed func(ctx context.Context, tx pgx.Tx) error) (wsID ids.WorkspaceID, created bool, err error) {
 	err = database.WithInfraTx(ctx, s.db.Pool(), func(tx pgx.Tx) error {
 		if _, err := tx.Exec(ctx, `SELECT pg_advisory_xact_lock($1)`, installationLockKey); err != nil {
 			return fmt.Errorf("identity: taking the bootstrap advisory lock: %w", err)
@@ -83,7 +91,11 @@ func (s *Service) BootstrapInstallation(ctx context.Context, create *Installatio
 		case create == nil:
 			return ErrNotBootstrapped
 		}
-		wsID, err = createInstallation(ctx, tx, *create, seed)
+		in, err := create()
+		if err != nil {
+			return err
+		}
+		wsID, err = createInstallation(ctx, tx, in, seed)
 		created = err == nil
 		return err
 	})

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -118,6 +118,14 @@ Your `margince.yaml`'s `password_file` **must point to where the entrypoint writ
 `/app/secrets/admin-password`; the api's working dir is `/app`). Set that value in
 your config. (The example config's default differs, so change it to match.)
 
+**After the first boot succeeds, retire both:** remove the `bootstrap_admin`
+section from `margince.yaml` and unset `MARGINCE_ADMIN_PASSWORD`. ADR-0061 §2
+consumes bootstrap values exactly once — restarts never reconcile them into an
+existing organization — so past that point the credential grants nothing and only
+sits at rest. The entrypoint stops writing the file once an organization exists
+and says so on stderr if the variable is still set. Change an existing user's
+password with `margince-migrate reset-password` instead.
+
 ## Routing
 
 Both services sit behind one reverse proxy / ingress, under **one host**:

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -495,7 +495,23 @@ probe.
 migrate <up|down> --dsn <owner-dsn> [--steps n]
 migrate reset-password --dsn <owner-dsn> --email <user-email>
 migrate <recreate-db|drop-db|db-exists> --dsn <owner-maintenance-dsn> --name <db> [--template <db>]
+migrate org-exists --dsn <owner-dsn>
 ```
+
+`org-exists` prints `true` or `false`: whether this installation already holds an
+active organization. It takes no `--name` — it asks about the database the DSN
+names. A deployment asks before the api starts, to know whether a bootstrap
+credential is still needed; `scripts/deploy/api-entrypoint.sh` writes the
+`bootstrap_admin` password file only while the answer is `false`, because
+ADR-0061 §2 consumes bootstrap values exactly once and permits deleting that
+secret once the organization exists. The answer is **printed rather than
+signalled by exit status**, so a caller can tell "no" from "could not ask"; a
+failed probe exits non-zero and must not be read as "unprovisioned".
+
+**Once an installation is bootstrapped, remove the `bootstrap_admin` section from
+`margince.yaml` and unset `MARGINCE_ADMIN_PASSWORD`.** Leaving the section in
+place keeps the api reading a password file that is no longer written. Use
+`migrate reset-password` to change an existing user's password.
 
 | Flag | Env | Default | Meaning |
 |---|---|---|---|

--- a/scripts/deploy/api-entrypoint.sh
+++ b/scripts/deploy/api-entrypoint.sh
@@ -51,7 +51,12 @@ margince-migrate up
 # different path changes it in margince.yaml and here together, and one knob is
 # fewer things to keep in agreement than two.
 admin_password_file="/app/secrets/admin-password"
-if [ -n "${MARGINCE_ADMIN_PASSWORD:-}" ]; then
+# Either condition is worth a probe. The variable being set may mean a
+# credential must be WRITTEN; the file already existing may mean a spent one
+# must be RETIRED. Gating on the variable alone would strand a file left by an
+# earlier boot the moment an operator follows the advice below and unsets it —
+# the exact sequence this block asks for.
+if [ -n "${MARGINCE_ADMIN_PASSWORD:-}" ] || [ -e "$admin_password_file" ]; then
     # Capture the probe's own exit status rather than testing its output
     # directly: inside an `if` condition a command substitution is exempt from
     # `set -e`, so a failed probe would read as empty, miss the "true" branch,
@@ -68,14 +73,23 @@ if [ -n "${MARGINCE_ADMIN_PASSWORD:-}" ]; then
         # ignored must not look like one that was applied. Removing bootstrap_admin
         # from margince.yaml is the action that actually retires it — unsetting only
         # this variable leaves the api reading a file nothing writes.
-        echo "entrypoint: MARGINCE_ADMIN_PASSWORD is set, but this installation already has an organization, so the bootstrap credential is neither written nor read. Remove the bootstrap_admin section from margince.yaml and unset MARGINCE_ADMIN_PASSWORD; use 'margince-migrate reset-password' to change an existing user's password." >&2
+        if [ -n "${MARGINCE_ADMIN_PASSWORD:-}" ]; then
+            echo "entrypoint: MARGINCE_ADMIN_PASSWORD is set, but this installation already has an organization, so the bootstrap credential is neither written nor read. Remove the bootstrap_admin section from margince.yaml and unset MARGINCE_ADMIN_PASSWORD; use 'margince-migrate reset-password' to change an existing user's password." >&2
+        fi
         # Any copy left by an earlier boot is retired here. The invariant is that
         # no plaintext bootstrap credential is at rest once the organization
         # exists — not merely that this start did not add one.
+        #
+        # A failed removal warns and continues rather than refusing to start. The
+        # file is spent: nothing reads it, so its presence is a hygiene defect,
+        # not an escalation — while a read-only /app/secrets (how a Kubernetes
+        # secret projection mounts by default) would turn every start of a
+        # healthy installation into an outage. Refusing here would trade the
+        # failure this change just removed for another one.
         if [ -e "$admin_password_file" ] && ! rm -f "$admin_password_file"; then
             echo "entrypoint: WARNING could not remove the spent bootstrap credential at $admin_password_file — remove it by hand; it is plaintext and nothing reads it now" >&2
         fi
-    else
+    elif [ -n "${MARGINCE_ADMIN_PASSWORD:-}" ]; then
         ( umask 077
           mkdir -p "$(dirname "$admin_password_file")"
           printf '%s' "$MARGINCE_ADMIN_PASSWORD" > "$admin_password_file" )

--- a/scripts/deploy/api-entrypoint.sh
+++ b/scripts/deploy/api-entrypoint.sh
@@ -38,14 +38,11 @@ margince-migrate up
 
 # First-boot bootstrap admin password (from the environment) → the file the
 # mounted margince.yaml's `password_file` references. Written 0600, never baked
-# into the image.
-#
-# It is written ONLY when no organization exists yet. ADR-0061 §2 says bootstrap
-# values are consumed exactly once and the `bootstrap_admin` section may be
-# deleted once the organization exists; writing this file on every start
-# contradicted that, re-materializing a plaintext credential at each boot for the
-# life of the installation even though nothing would ever read it again. The
-# check runs AFTER migrations because it reads a table migrations create.
+# into the image, and ONLY while the installation has no organization: ADR-0061
+# §2 consumes bootstrap values exactly once and permits deleting the
+# `bootstrap_admin` secret once the organization exists, so a plaintext
+# credential at rest past that point protects nothing. The probe runs AFTER
+# migrations because it reads a table migrations create.
 #
 # The path is fixed, and margince.yaml's `password_file` must name the same one:
 # /app/secrets/admin-password, i.e. `secrets/admin-password` relative to the api's
@@ -55,11 +52,29 @@ margince-migrate up
 # fewer things to keep in agreement than two.
 admin_password_file="/app/secrets/admin-password"
 if [ -n "${MARGINCE_ADMIN_PASSWORD:-}" ]; then
-    if [ "$(margince-migrate org-exists)" = "true" ]; then
+    # Capture the probe's own exit status rather than testing its output
+    # directly: inside an `if` condition a command substitution is exempt from
+    # `set -e`, so a failed probe would read as empty, miss the "true" branch,
+    # and write the credential onto a provisioned installation — the one
+    # outcome this block exists to prevent. `org-exists` prints its answer
+    # precisely so a caller can tell "no" from "could not ask"; this is the
+    # shape ensure_template in scripts/lib-testdb.sh already uses.
+    if ! provisioned="$(margince-migrate org-exists)"; then
+        echo "FAIL: could not determine whether this installation already has an organization — fix the error above; a failed probe is not 'unprovisioned', and treating it as one would write a plaintext credential onto a live installation" >&2
+        exit 1
+    fi
+    if [ "$provisioned" = "true" ]; then
         # Say so rather than silently doing nothing: a supplied credential that is
-        # ignored must not look like one that was applied. The operator's next step
-        # is to stop supplying it, and nothing else here will tell them that.
-        echo "entrypoint: MARGINCE_ADMIN_PASSWORD is set, but this installation already has an organization — the bootstrap credential is not written and would never be read. Unset MARGINCE_ADMIN_PASSWORD; use 'margince-migrate reset-password' to change an existing user's password." >&2
+        # ignored must not look like one that was applied. Removing bootstrap_admin
+        # from margince.yaml is the action that actually retires it — unsetting only
+        # this variable leaves the api reading a file nothing writes.
+        echo "entrypoint: MARGINCE_ADMIN_PASSWORD is set, but this installation already has an organization, so the bootstrap credential is neither written nor read. Remove the bootstrap_admin section from margince.yaml and unset MARGINCE_ADMIN_PASSWORD; use 'margince-migrate reset-password' to change an existing user's password." >&2
+        # Any copy left by an earlier boot is retired here. The invariant is that
+        # no plaintext bootstrap credential is at rest once the organization
+        # exists — not merely that this start did not add one.
+        if [ -e "$admin_password_file" ] && ! rm -f "$admin_password_file"; then
+            echo "entrypoint: WARNING could not remove the spent bootstrap credential at $admin_password_file — remove it by hand; it is plaintext and nothing reads it now" >&2
+        fi
     else
         ( umask 077
           mkdir -p "$(dirname "$admin_password_file")"

--- a/scripts/deploy/api-entrypoint.sh
+++ b/scripts/deploy/api-entrypoint.sh
@@ -26,23 +26,6 @@ fi
 : "${MARGINCE_OWNER_DSN:?MARGINCE_OWNER_DSN is required (owner role DSN for migrations + custom-fields DDL)}"
 : "${MARGINCE_DSN:?MARGINCE_DSN is required (app role DSN the api serves under, via the --dsn env fallback)}"
 
-# First-boot bootstrap admin password (from the environment) → the file the
-# mounted margince.yaml's `password_file` references. Written 0600, never baked
-# into the image; only consumed on the first boot against an empty database.
-#
-# The path is fixed, and margince.yaml's `password_file` must name the same one:
-# /app/secrets/admin-password, i.e. `secrets/admin-password` relative to the api's
-# /app working directory. It used to be overridable via
-# MARGINCE_ADMIN_PASSWORD_FILE, which nothing ever set — a deployment that wants a
-# different path changes it in margince.yaml and here together, and one knob is
-# fewer things to keep in agreement than two.
-admin_password_file="/app/secrets/admin-password"
-if [ -n "${MARGINCE_ADMIN_PASSWORD:-}" ]; then
-    ( umask 077
-      mkdir -p "$(dirname "$admin_password_file")"
-      printf '%s' "$MARGINCE_ADMIN_PASSWORD" > "$admin_password_file" )
-fi
-
 # The custom-fields runtime-DDL pool runs as the same owner role migrate uses,
 # unless the deployment set its own MARGINCE_SCHEMA_DSN.
 export MARGINCE_SCHEMA_DSN="${MARGINCE_SCHEMA_DSN:-$MARGINCE_OWNER_DSN}"
@@ -52,6 +35,37 @@ echo "entrypoint: applying core + custom migrations (owner role)…"
 # has already refused to start without it. Passing it as an argument would put the
 # owner credential in this container's process list.
 margince-migrate up
+
+# First-boot bootstrap admin password (from the environment) → the file the
+# mounted margince.yaml's `password_file` references. Written 0600, never baked
+# into the image.
+#
+# It is written ONLY when no organization exists yet. ADR-0061 §2 says bootstrap
+# values are consumed exactly once and the `bootstrap_admin` section may be
+# deleted once the organization exists; writing this file on every start
+# contradicted that, re-materializing a plaintext credential at each boot for the
+# life of the installation even though nothing would ever read it again. The
+# check runs AFTER migrations because it reads a table migrations create.
+#
+# The path is fixed, and margince.yaml's `password_file` must name the same one:
+# /app/secrets/admin-password, i.e. `secrets/admin-password` relative to the api's
+# /app working directory. It used to be overridable via
+# MARGINCE_ADMIN_PASSWORD_FILE, which nothing ever set — a deployment that wants a
+# different path changes it in margince.yaml and here together, and one knob is
+# fewer things to keep in agreement than two.
+admin_password_file="/app/secrets/admin-password"
+if [ -n "${MARGINCE_ADMIN_PASSWORD:-}" ]; then
+    if [ "$(margince-migrate org-exists)" = "true" ]; then
+        # Say so rather than silently doing nothing: a supplied credential that is
+        # ignored must not look like one that was applied. The operator's next step
+        # is to stop supplying it, and nothing else here will tell them that.
+        echo "entrypoint: MARGINCE_ADMIN_PASSWORD is set, but this installation already has an organization — the bootstrap credential is not written and would never be read. Unset MARGINCE_ADMIN_PASSWORD; use 'margince-migrate reset-password' to change an existing user's password." >&2
+    else
+        ( umask 077
+          mkdir -p "$(dirname "$admin_password_file")"
+          printf '%s' "$MARGINCE_ADMIN_PASSWORD" > "$admin_password_file" )
+    fi
+fi
 
 echo "entrypoint: starting api…"
 exec margince-api


### PR DESCRIPTION
Closes the first bootstrap defect tracked in #1252.

## The defect

`scripts/deploy/api-entrypoint.sh` rewrote `/app/secrets/admin-password` from `MARGINCE_ADMIN_PASSWORD` on **every** container start, unconditionally whenever that variable was set — not only on the first. An installation bootstrapped months ago therefore re-materialized a plaintext admin password at each boot, for a value nothing would ever read again.

ADR-0061 §2 says bootstrap values are consumed exactly once and the `bootstrap_admin` section may be deleted once the organization exists. The file reference exists precisely so the secret **can** be deleted — and rewriting it defeated the property that justifies the design. It held only if the operator remembered to unset the variable, which nothing enforced, documented or detected.

## The change

The entrypoint asks before it writes, and **says so when it declines**: a supplied credential that is ignored must not look like one that was applied, so the operator is told to unset the variable and pointed at `margince-migrate reset-password` for what they probably meant. The check moved below `margince-migrate up` because it reads a table migrations create.

`cmd/migrate` grows `org-exists`, in the shape `db-exists` already answers a yes/no question — printed, not an exit code, so a caller can tell "no" from "could not ask". It uses the predicate the api itself applies when counting organizations at boot (`archived_at IS NULL`) rather than a second spelling of *active* that could drift from it.

## On the second commit

Adding the verb pushed `main.go` past the 500-line ceiling. That is the named trigger for a split, not a reason to shrink the addition, so the two printing probes moved to `probes.go` — cut by the contract they share, not by size.

## Verification

- `make check-backend` green; `make craft-static` 0 findings across backend, extensions, fixtures.
- New integration test covers three states: migrated-but-unbootstrapped, bootstrapped, and **archived-only**. The last one matters — a probe that merely counted rows would call an archived-only installation provisioned and withhold the credential that could still bootstrap it.
- Both assertions mutation-tested: dropping the `archived_at` predicate and hardcoding `true` each fail the test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops rewriting the bootstrap admin credential on every start and retires any spent password file after bootstrap. Previously `/app/secrets/admin-password` was re-created when `MARGINCE_ADMIN_PASSWORD` was set and the API always read `bootstrap_admin.password_file`; now we write/read the secret only during first boot and prevent stale secrets from lingering.

- **Changes**
  - Entrypoint (`scripts/deploy/api-entrypoint.sh`): applies migrations first; defaults `MARGINCE_SCHEMA_DSN` to the owner DSN earlier; runs `margince-migrate org-exists` when the env var is set or the password file exists; writes the file only when unprovisioned; on a provisioned install, warns if the env var is set and removes any spent file even if the env var is unset (failed removal warns but does not block boot); treats a failed probe as fatal.
  - Backend: adds `margince-migrate org-exists` (prints `true|false`, archived orgs do not count) and moves yes/no probes to `probes.go`; `BootstrapInstallation` now takes a provider function and `EnsureInstallation` reads the password file only on the create branch.
  - Tests/Docs: integration tests cover unbootstrapped/bootstrapped/archived-only states, restart without the secret, and first-boot failure on unreadable secret; a unit test pins the `org-exists` printed answer to the entrypoint’s comparison; deployment docs instruct retiring bootstrap credentials; reference docs describe `org-exists`.

- **Operator action**
  - After bootstrap, remove the `bootstrap_admin` section from `margince.yaml` and unset `MARGINCE_ADMIN_PASSWORD`. Use `margince-migrate reset-password` to change an existing user’s password.

<sup>Written for commit 15bacd069623f5294fdcdf727538b36b0cc1d555. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1282?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an organization existence check to migration tooling.
  - Archived organizations do not count as active.

- **Bug Fixes**
  - Deployment now applies migrations before continuing.
  - Bootstrap credentials are created only for unprovisioned installations.
  - Bootstrap secrets are read only when needed, allowing restarts after setup.

- **Documentation**
  - Added guidance for removing bootstrap credentials after initial setup and resetting passwords thereafter.

- **Tests**
  - Added coverage for organization detection and bootstrap secret handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->