### PR TITLE
feat(deals): a pipeline stage can be removed, and refuses while deals sit on it

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -3206,6 +3206,37 @@ paths:
         '404': { $ref: '#/components/responses/NotFound' }
         '409': { $ref: '#/components/responses/Conflict' }
         '422': { $ref: '#/components/responses/ValidationError' }
+    delete:
+      tags: [Pipelines]
+      operationId: archiveStage
+      security: [ { cookieAuth: [] } ]   # human session only — rejects agent bearer/Passport (x-agent-access: human-only)
+      x-agent-access: human-only
+      summary: Remove a stage from its pipeline (soft delete; archive is the delete).
+      description: |
+        The removal half of the bounded stage-configuration surface (DEAL-WIRE-7). Archiving
+        rather than deleting is what keeps the stage-change history readable — a
+        `deal_stage_history` row references the stage a deal moved out of.
+
+        The surviving stages of the pipeline shift down so `position` stays contiguous, which
+        publishes ONE `pipeline.updated` reorder alongside `stage.archived`.
+
+        Two refusals, both `422` (DEAL-WIRE-10). Neither names a request field — the caller
+        sent the removal they meant and what refuses is the workspace's own state — so each
+        carries its machine code as the problem's `code` and its reason as `detail`:
+        * `stage_occupied` while live deals sit on the stage. The detail counts them and
+          names them (bounded, with "and N more" beyond the cap) so they can be moved
+          first; no `deal.stage_id` is ever left pointing at a removed stage.
+        * `terminal_stage_not_removable` on a `won`/`lost` stage: add and remove operate on
+          non-terminal stages only, so the pair the close semantics hang off survives.
+      parameters:
+        - $ref: '#/components/parameters/IfMatch'
+      responses:
+        '204': { description: Archived. }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
+        '409': { $ref: '#/components/responses/Conflict' }
+        '422': { $ref: '#/components/responses/ValidationError' }
 
   # ---------------------------- /activities ---------------------------------
   /activities:

--- a/backend/api/public-events.yaml
+++ b/backend/api/public-events.yaml
@@ -702,10 +702,19 @@ components:
       x-entity-type: stage
       x-version: 1
       description: >-
-        Payload for stage.archived. Never emitted today (no archive path
-        exists for stage); the schema is published so the type is a valid
-        subscription target and the coverage gate can name it explicitly
-        rather than silently omitting it.
+        Payload for stage.archived — a stage was removed from a pipeline
+        (archiveStage; archive is the removal, so the stage-change history
+        referencing it stays readable). The pipeline is named here, as it is
+        on stage.created, because a subscriber holding only the envelope's
+        stage id cannot tell which pipeline reshaped; the shift that closes
+        the vacated position rides its own pipeline.updated.
+      required:
+        - pipeline_id
+      properties:
+        pipeline_id:
+          type: string
+          format: uuid
+          description: The pipeline the stage belonged to.
       additionalProperties: false
 
     PublicEventPersonMergedRelinkCounts:

--- a/backend/internal/compose/agentpolicy_gen.go
+++ b/backend/internal/compose/agentpolicy_gen.go
@@ -121,6 +121,7 @@ var agentPolicies = map[string]agentPolicy{
 	"DELETE /v1/relationships/{id}":                                      {Op: "archiveRelationship", Access: "tool", Tool: "archive_record", RecordType: "relationship", Tier: "confirmation_required", Scope: "write"},
 	"DELETE /v1/retention-policies/{id}":                                 {Op: "deleteRetentionPolicy", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"DELETE /v1/signals/{id}":                                            {Op: "archiveSignal", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
+	"DELETE /v1/stages/{id}":                                             {Op: "archiveStage", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"DELETE /v1/tags/{id}":                                               {Op: "archiveTag", Access: "tool", Tool: "archive_record", RecordType: "tag", Tier: "confirmation_required", Scope: "write"},
 	"DELETE /v1/views/{id}":                                              {Op: "archiveSavedView", Access: "tool", Tool: "archive_record", RecordType: "saved_view", Tier: "confirmation_required", Scope: "write"},
 	"DELETE /v1/voice-profiles/{id}":                                     {Op: "deleteVoiceProfile", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},

--- a/backend/internal/compose/integration/stage_removal_integration_test.go
+++ b/backend/internal/compose/integration/stage_removal_integration_test.go
@@ -112,6 +112,65 @@ func TestStageRemovalTakesTheVersionGuard(t *testing.T) {
 	assertContiguous(t, e, seeded.PipelineID, len(stages))
 }
 
+// Contiguity is a postcondition of the removal, not an invariant the
+// schema holds — createStage and updateStage both take the position they
+// are handed — so a pipeline that was already gapped must come out of a
+// removal renumbered, and a removal that moves nothing must not publish a
+// reorder that did not happen.
+func TestStageRemovalRenumbersWhateverLayoutItFinds(t *testing.T) {
+	e := apptest.SetupApp(t)
+	e.Slug = "stage-rm-gap"
+	apptest.BootstrapWorkspaceSession(t, e, "Stage RM Gap", "stage-rm-gap@fable.test", "Admin")
+
+	var pipeline struct {
+		ID     string `json:"id"`
+		Stages []struct {
+			ID string `json:"id"`
+		} `json:"stages"`
+	}
+	if status := e.Call(t, "POST", "/v1/pipelines", apptest.AnyMap{
+		"name": "Gapped", "stages": []apptest.AnyMap{
+			{"name": "Scout", "position": 2},
+			{"name": "Pitch", "position": 5},
+			{"name": "Close", "position": 9},
+		},
+	}, nil, &pipeline); status != http.StatusCreated {
+		t.Fatalf("create a gapped pipeline → %d", status)
+	}
+	gapped := readStages(t, e, pipeline.ID)
+	if gapped[0].Position != 2 || gapped[2].Position != 9 {
+		t.Fatalf("the fixture is not gapped: %+v", gapped)
+	}
+
+	// Removing the LAST stage moves nothing above it — but the gaps below
+	// are still the removal's to close.
+	if status := e.Call(t, "DELETE", "/v1/stages/"+gapped[2].ID, nil, nil, nil); status != http.StatusNoContent {
+		t.Fatalf("removing the last stage → %d, want 204", status)
+	}
+	assertContiguous(t, e, pipeline.ID, 2)
+
+	// Now the list is 1..n already, so removing its last stage moves
+	// nothing at all — and publishes no reorder.
+	survivors := readStages(t, e, pipeline.ID)
+	if status := e.Call(t, "DELETE", "/v1/stages/"+survivors[1].ID, nil, nil, nil); status != http.StatusNoContent {
+		t.Fatalf("removing the trailing stage → %d, want 204", status)
+	}
+	assertContiguous(t, e, pipeline.ID, 1)
+
+	var reorders int
+	if err := e.Owner.QueryRow(t.Context(),
+		`SELECT count(*) FROM event_outbox
+		 WHERE envelope->>'type' = 'pipeline.updated'
+		   AND envelope->'entity'->>'id' = $1::text
+		   AND envelope->'payload'->'changed_fields'->'stage_positions' IS NOT NULL`,
+		pipeline.ID).Scan(&reorders); err != nil {
+		t.Fatal(err)
+	}
+	if reorders != 1 {
+		t.Fatalf("%d reorder events for this pipeline, want 1 — only the removal that renumbered publishes one", reorders)
+	}
+}
+
 // assertOccupiedRefusal checks the F1b guard: a 422 whose machine code a
 // surface can branch on, and whose sentence names the deal standing in
 // the way so the admin knows what to move.

--- a/backend/internal/compose/integration/stage_removal_integration_test.go
+++ b/backend/internal/compose/integration/stage_removal_integration_test.go
@@ -36,6 +36,12 @@ func TestStageRemovalRefusesWhileDealsSitOnIt(t *testing.T) {
 	dealID := apptest.CreateOpenDeal(t, e, seeded)
 
 	stages := readStages(t, e, seeded.PipelineID)
+	// Named, not indexed-into blindly: this scenario needs an occupied
+	// stage AND an empty one above it, so a seed that stopped supplying
+	// both should say which precondition it broke rather than panic.
+	if len(stages) < 3 {
+		t.Fatalf("the seeded pipeline has %d stages; this scenario removes an empty one above an occupied one", len(stages))
+	}
 	occupied := stages[0] // CreateOpenDeal lands the deal on the first open stage.
 	empty := stages[2]
 	if occupied.ID != seeded.Open {
@@ -138,8 +144,11 @@ func TestStageRemovalRenumbersWhateverLayoutItFinds(t *testing.T) {
 		t.Fatalf("create a gapped pipeline → %d", status)
 	}
 	gapped := readStages(t, e, pipeline.ID)
-	if gapped[0].Position != 2 || gapped[2].Position != 9 {
-		t.Fatalf("the fixture is not gapped: %+v", gapped)
+	// The whole point of this fixture is the layout, so say so before
+	// indexing into it: a create that silently normalized the positions
+	// would otherwise fail somewhere further down, or panic.
+	if len(gapped) != 3 || gapped[0].Position != 2 || gapped[2].Position != 9 {
+		t.Fatalf("the fixture is not the gapped 2/5/9 layout this scenario needs: %+v", gapped)
 	}
 
 	// Removing the LAST stage moves nothing above it — but the gaps below
@@ -152,7 +161,7 @@ func TestStageRemovalRenumbersWhateverLayoutItFinds(t *testing.T) {
 	// Now the list is 1..n already, so removing its last stage moves
 	// nothing at all — and publishes no reorder.
 	survivors := readStages(t, e, pipeline.ID)
-	if status := e.Call(t, "DELETE", "/v1/stages/"+survivors[1].ID, nil, nil, nil); status != http.StatusNoContent {
+	if status := e.Call(t, "DELETE", "/v1/stages/"+survivors[len(survivors)-1].ID, nil, nil, nil); status != http.StatusNoContent {
 		t.Fatalf("removing the trailing stage → %d, want 204", status)
 	}
 	assertContiguous(t, e, pipeline.ID, 1)

--- a/backend/internal/compose/integration/stage_removal_integration_test.go
+++ b/backend/internal/compose/integration/stage_removal_integration_test.go
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// E2E-UC-ADMIN-04.remove-stage-guard (step 6, step 7, F1b): an empty
+// stage is removed and the survivors stay contiguous; a stage still
+// holding deals refuses and names them; the terminal pair is not
+// removable at all; and once the deals move, the stage goes.
+
+import (
+	"net/http"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
+)
+
+// configuredStage is one stage as the stage list answers it — a removal
+// is about position, which the shared DiscoverSeededPipeline fixture
+// deliberately does not carry.
+type configuredStage struct {
+	ID       string `json:"id"`
+	Name     string `json:"name"`
+	Position int    `json:"position"`
+}
+
+func TestStageRemovalRefusesWhileDealsSitOnIt(t *testing.T) {
+	e := apptest.SetupApp(t)
+	e.Slug = "stage-rm"
+	apptest.BootstrapWorkspaceSession(t, e, "Stage RM", "stage-rm@fable.test", "Admin")
+	seeded := apptest.DiscoverSeededPipeline(t, e)
+	dealID := apptest.CreateOpenDeal(t, e, seeded)
+
+	stages := readStages(t, e, seeded.PipelineID)
+	occupied := stages[0] // CreateOpenDeal lands the deal on the first open stage.
+	empty := stages[2]
+	if occupied.ID != seeded.Open {
+		t.Fatalf("the deal sits on %q, not the first open stage this test removes from", occupied.Name)
+	}
+
+	// Step 7: the terminal pair is out of the add/remove surface.
+	var refusal apptest.AnyMap
+	if status := e.Call(t, "DELETE", "/v1/stages/"+seeded.Won, nil, nil, &refusal); status != http.StatusUnprocessableEntity ||
+		refusal["code"] != "terminal_stage_not_removable" {
+		t.Fatalf("removing the won stage → %d %v, want 422 terminal_stage_not_removable", status, refusal)
+	}
+
+	// F1b: the occupied stage refuses AND names what is in the way.
+	assertOccupiedRefusal(t, e, occupied.ID, "Acme rollout")
+
+	// Step 6: the empty stage goes, and the survivors close the gap.
+	if status := e.Call(t, "DELETE", "/v1/stages/"+empty.ID, nil, nil, nil); status != http.StatusNoContent {
+		t.Fatalf("removing the empty %q stage → %d, want 204", empty.Name, status)
+	}
+	assertContiguous(t, e, seeded.PipelineID, len(stages)-1)
+	assertRemovalEvents(t, e, empty.ID, seeded.PipelineID)
+
+	// The archived stage still reads, which is what keeps a historic
+	// stage change renderable: its id resolves to a named row.
+	if status := e.Call(t, "GET", "/v1/stages/"+empty.ID, nil, nil, nil); status != http.StatusOK {
+		t.Fatalf("reading the removed stage → %d, want 200 — the stage-change history references it", status)
+	}
+	// And it is gone from the pipeline: a second removal has nothing live to remove.
+	if status := e.Call(t, "DELETE", "/v1/stages/"+empty.ID, nil, nil, nil); status != http.StatusNotFound {
+		t.Fatalf("removing an already-removed stage → %d, want 404", status)
+	}
+
+	// Once the deal moves, the guard lifts.
+	if status := e.Call(t, "POST", "/v1/deals/"+dealID+"/advance",
+		apptest.AnyMap{"to_stage_id": stages[1].ID}, nil, nil); status != http.StatusOK {
+		t.Fatalf("advancing the deal off the occupied stage → %d, want 200", status)
+	}
+	if status := e.Call(t, "DELETE", "/v1/stages/"+occupied.ID, nil, nil, nil); status != http.StatusNoContent {
+		t.Fatalf("removing the vacated stage → %d, want 204", status)
+	}
+	assertContiguous(t, e, seeded.PipelineID, len(stages)-2)
+
+	// The history the archive existed to protect: the advance's own row
+	// still points at the stage the deal left, which has since been removed.
+	var fromRemoved int
+	if err := e.Owner.QueryRow(t.Context(),
+		`SELECT count(*) FROM deal_stage_history WHERE deal_id = $1 AND from_stage_id = $2`,
+		dealID, occupied.ID).Scan(&fromRemoved); err != nil {
+		t.Fatal(err)
+	}
+	if fromRemoved != 1 {
+		t.Fatalf("%d history rows out of the removed stage, want 1 — archiving is what keeps them readable", fromRemoved)
+	}
+}
+
+func TestStageRemovalTakesTheVersionGuard(t *testing.T) {
+	e := apptest.SetupApp(t)
+	e.Slug = "stage-rm-ver"
+	apptest.BootstrapWorkspaceSession(t, e, "Stage RM Ver", "stage-rm-ver@fable.test", "Admin")
+	seeded := apptest.DiscoverSeededPipeline(t, e)
+	stages := readStages(t, e, seeded.PipelineID)
+
+	var problem apptest.AnyMap
+	if status := e.Call(t, "DELETE", "/v1/stages/"+stages[0].ID, nil,
+		map[string]string{"If-Match": "999"}, &problem); status != http.StatusConflict ||
+		problem["code"] != "version_skew" {
+		t.Fatalf("removing a stage on a stale If-Match → %d %v, want 409 version_skew", status, problem)
+	}
+	// The refused removal left the stage where it was.
+	if status := e.Call(t, "GET", "/v1/stages/"+stages[0].ID, nil, nil, nil); status != http.StatusOK {
+		t.Fatalf("the stage after a refused removal → %d, want 200", status)
+	}
+	assertContiguous(t, e, seeded.PipelineID, len(stages))
+}
+
+// assertOccupiedRefusal checks the F1b guard: a 422 whose machine code a
+// surface can branch on, and whose sentence names the deal standing in
+// the way so the admin knows what to move.
+func assertOccupiedRefusal(t *testing.T, e *apptest.AppEnv, stageID, dealName string) {
+	t.Helper()
+	var refusal struct {
+		Code   string `json:"code"`
+		Detail string `json:"detail"`
+	}
+	status := e.Call(t, "DELETE", "/v1/stages/"+stageID, nil, nil, &refusal)
+	if status != http.StatusUnprocessableEntity || refusal.Code != "stage_occupied" {
+		t.Fatalf("removing an occupied stage → %d %q, want 422 stage_occupied", status, refusal.Code)
+	}
+	if !strings.Contains(refusal.Detail, dealName) {
+		t.Fatalf("the refusal reads %q and never names the deal in the way", refusal.Detail)
+	}
+	// The stage and its deal are untouched by the refusal.
+	var stage struct {
+		ArchivedAt *string `json:"archived_at"`
+	}
+	if status := e.Call(t, "GET", "/v1/stages/"+stageID, nil, nil, &stage); status != http.StatusOK || stage.ArchivedAt != nil {
+		t.Fatalf("the refused stage reads %d archived_at=%v, want 200 and live", status, stage.ArchivedAt)
+	}
+}
+
+// assertContiguous holds UC-ADMIN-04's ordering invariant: the live
+// stages of the pipeline are exactly positions 1..n after a removal.
+func assertContiguous(t *testing.T, e *apptest.AppEnv, pipelineID string, want int) {
+	t.Helper()
+	stages := readStages(t, e, pipelineID)
+	if len(stages) != want {
+		t.Fatalf("%d live stages, want %d", len(stages), want)
+	}
+	for i, s := range stages {
+		if s.Position != i+1 {
+			t.Fatalf("stage %q sits at position %d, want %d — a removal must leave 1..n contiguous",
+				s.Name, s.Position, i+1)
+		}
+	}
+}
+
+// assertRemovalEvents holds the events.md §5.3b split: the stage's own
+// archival is a stage fact carrying its pipeline, and the shift that
+// closed the gap is ONE pipeline.updated, never N stage.updated.
+func assertRemovalEvents(t *testing.T, e *apptest.AppEnv, stageID, pipelineID string) {
+	t.Helper()
+	var archived, reorders int
+	if err := e.Owner.QueryRow(t.Context(),
+		`SELECT count(*) FILTER (WHERE envelope->>'type' = 'stage.archived'
+		                           AND envelope->'entity'->>'id' = $1::text
+		                           AND envelope->'payload'->>'pipeline_id' = $2::text),
+		        count(*) FILTER (WHERE envelope->>'type' = 'pipeline.updated'
+		                           AND envelope->'payload'->'changed_fields'->'stage_positions' IS NOT NULL)
+		 FROM event_outbox`, stageID, pipelineID).Scan(&archived, &reorders); err != nil {
+		t.Fatal(err)
+	}
+	if archived != 1 {
+		t.Fatalf("%d stage.archived events naming the pipeline, want 1", archived)
+	}
+	if reorders != 1 {
+		t.Fatalf("%d pipeline.updated reorder events, want exactly 1 — a reorder is one pipeline fact", reorders)
+	}
+}
+
+// readStages answers the pipeline's live stages ordered by position.
+func readStages(t *testing.T, e *apptest.AppEnv, pipelineID string) []configuredStage {
+	t.Helper()
+	var listed struct {
+		Data []configuredStage `json:"data"`
+	}
+	if status := e.Call(t, "GET", "/v1/stages?pipeline_id="+pipelineID, nil, nil, &listed); status != http.StatusOK {
+		t.Fatalf("listing stages → %d", status)
+	}
+	// The list answers live rows only unless include_archived asks
+	// otherwise, so a removed stage is already out of this slice.
+	sort.Slice(listed.Data, func(i, j int) bool { return listed.Data[i].Position < listed.Data[j].Position })
+	return listed.Data
+}

--- a/backend/internal/compose/integration/stage_removal_race_integration_test.go
+++ b/backend/internal/compose/integration/stage_removal_race_integration_test.go
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// The occupancy guard against genuinely concurrent writers. The refusal
+// is only a guard if the stage a deal is being bound to is LOCKED by the
+// binding write: as a plain read, a deal can resolve a live stage, the
+// removal can count zero and archive it, and the deal's own write still
+// lands — the FK on deal.stage_id asks whether the row exists, and
+// archiving is exactly the operation that leaves it existing.
+//
+// The invariant asserted is the one that must hold whichever side wins:
+// no LIVE deal ever sits on an archived stage. A deal that reached one
+// is invisible on every board read, all of which filter to live stages.
+
+import (
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/modules/deals"
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+func TestNoDealLandsOnAStageBeingRemoved(t *testing.T) {
+	e := Setup(t)
+	pipeline, open, _ := DealFixture(t, e)
+	admin := e.Admin()
+
+	// Each round removes a fresh empty stage while a deal advances onto
+	// it. Several rounds because the interleaving is the machine's to
+	// choose — the assertion below is what makes any round conclusive.
+	const rounds = 8
+	for round := range rounds {
+		target, err := e.Deals.CreateStage(admin, deals.CreateStageInput{
+			PipelineID: pipeline, Name: "Racy", Position: 90 + round, Semantic: "open",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		targetID := ids.From[ids.StageKind](ids.UUID(target.Id))
+		deal := e.SeedDeal(t, "Racer", pipeline, open, &e.Rep1)
+
+		var wg sync.WaitGroup
+		var advanceErr, removeErr error
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			_, advanceErr = e.Deals.AdvanceDeal(admin, ids.From[ids.DealKind](deal),
+				deals.AdvanceDealInput{ToStageID: targetID})
+		}()
+		go func() {
+			defer wg.Done()
+			removeErr = e.Deals.ArchiveStage(admin, targetID, nil)
+		}()
+		wg.Wait()
+
+		assertRemovalOutcome(t, round, advanceErr, removeErr)
+	}
+
+	// The invariant, over everything the rounds produced.
+	if n := e.WsCount(t, `SELECT count(*) FROM deal d JOIN stage s ON s.id = d.stage_id
+	                      WHERE d.archived_at IS NULL AND s.archived_at IS NOT NULL`); n != 0 {
+		t.Fatalf("%d live deal(s) sit on a removed stage — the occupancy count was read, not held", n)
+	}
+	// And the guard is not passing by refusing everything: a removal that
+	// always lost would satisfy the invariant while proving nothing.
+	if n := e.WsCount(t, `SELECT count(*) FROM stage WHERE pipeline_id = $1 AND archived_at IS NOT NULL`,
+		pipeline); n == 0 {
+		t.Fatal("no stage was removed in any round — the race never ran")
+	}
+}
+
+// assertRemovalOutcome holds the pair of outcomes to the two the race may
+// legitimately produce: the removal wins and the advance finds no live
+// stage, or the advance wins and the removal refuses on occupancy. Any
+// other pairing — both succeeding above all — is the defect.
+func assertRemovalOutcome(t *testing.T, round int, advanceErr, removeErr error) {
+	t.Helper()
+	var occupied *deals.StageOccupiedError
+	switch {
+	case advanceErr == nil && removeErr == nil:
+		t.Fatalf("round %d: the deal advanced onto the stage AND the stage was removed", round)
+	case advanceErr == nil && errors.As(removeErr, &occupied):
+		return // the advance won; the removal saw the deal it had just gained.
+	case removeErr == nil && errors.Is(advanceErr, apperrors.ErrNotFound):
+		return // the removal won; the advance found no live stage to move to.
+	default:
+		t.Fatalf("round %d: advance=%v remove=%v — neither side won cleanly", round, advanceErr, removeErr)
+	}
+}

--- a/backend/internal/compose/stubs_gen.go
+++ b/backend/internal/compose/stubs_gen.go
@@ -1315,6 +1315,10 @@ func (stubs) CreateStage(w nethttp.ResponseWriter, r *nethttp.Request, params cr
 	httperr.NotImplemented(w, r, "CreateStage")
 }
 
+func (stubs) ArchiveStage(w nethttp.ResponseWriter, r *nethttp.Request, id crmcontracts.Id, params crmcontracts.ArchiveStageParams) {
+	httperr.NotImplemented(w, r, "ArchiveStage")
+}
+
 func (stubs) GetStage(w nethttp.ResponseWriter, r *nethttp.Request, id crmcontracts.Id) {
 	httperr.NotImplemented(w, r, "GetStage")
 }

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -22170,6 +22170,16 @@ type CreateStageParams struct {
 	IdempotencyKey *IdempotencyKey `json:"Idempotency-Key,omitempty"`
 }
 
+// ArchiveStageParams defines parameters for ArchiveStage.
+type ArchiveStageParams struct {
+	// IfMatch Optional optimistic-concurrency precondition for a mutating request (PATCH/advance/merge):
+	// the last-seen entity `version`. If the row's current `version` differs, the write is
+	// rejected with `409 code: version_skew` (ErrVersionSkew) and no change is made — re-read,
+	// re-apply, retry. Omitting it is last-write-wins (discouraged for agent/automated writers).
+	// Accepted on every native (SoR-mode) mutating endpoint that returns a versioned entity.
+	IfMatch *IfMatch `json:"If-Match,omitempty"`
+}
+
 // UpdateStageParams defines parameters for UpdateStage.
 type UpdateStageParams struct {
 	// IdempotencyKey Client-supplied key making a mutation safe to retry — an update exactly as much as a
@@ -29660,6 +29670,9 @@ type ServerInterface interface {
 	// Create a stage in a pipeline.
 	// (POST /stages)
 	CreateStage(w http.ResponseWriter, r *http.Request, params CreateStageParams)
+	// Remove a stage from its pipeline (soft delete; archive is the delete).
+	// (DELETE /stages/{id})
+	ArchiveStage(w http.ResponseWriter, r *http.Request, id Id, params ArchiveStageParams)
 	// Get a stage by id.
 	// (GET /stages/{id})
 	GetStage(w http.ResponseWriter, r *http.Request, id Id)
@@ -31739,6 +31752,12 @@ func (_ Unimplemented) ListStages(w http.ResponseWriter, r *http.Request, params
 // Create a stage in a pipeline.
 // (POST /stages)
 func (_ Unimplemented) CreateStage(w http.ResponseWriter, r *http.Request, params CreateStageParams) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Remove a stage from its pipeline (soft delete; archive is the delete).
+// (DELETE /stages/{id})
+func (_ Unimplemented) ArchiveStage(w http.ResponseWriter, r *http.Request, id Id, params ArchiveStageParams) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -46499,6 +46518,62 @@ func (siw *ServerInterfaceWrapper) CreateStage(w http.ResponseWriter, r *http.Re
 	handler.ServeHTTP(w, r)
 }
 
+// ArchiveStage operation middleware
+func (siw *ServerInterfaceWrapper) ArchiveStage(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "id" -------------
+	var id Id
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", chi.URLParam(r, "id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "uuid"})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, CookieAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params ArchiveStageParams
+
+	headers := r.Header
+
+	// ------------- Optional header parameter "If-Match" -------------
+	if valueList, found := headers[http.CanonicalHeaderKey("If-Match")]; found {
+		var IfMatch IfMatch
+		n := len(valueList)
+		if n != 1 {
+			siw.ErrorHandlerFunc(w, r, &TooManyValuesForParamError{ParamName: "If-Match", Count: n})
+			return
+		}
+
+		err = runtime.BindStyledParameterWithOptions("simple", "If-Match", valueList[0], &IfMatch, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: false, Type: "string", Format: ""})
+		if err != nil {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "If-Match", Err: err})
+			return
+		}
+
+		params.IfMatch = &IfMatch
+
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ArchiveStage(w, r, id, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
 // GetStage operation middleware
 func (siw *ServerInterfaceWrapper) GetStage(w http.ResponseWriter, r *http.Request) {
 
@@ -49763,6 +49838,9 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 	})
 	r.Group(func(r chi.Router) {
 		r.Post(options.BaseURL+"/stages", wrapper.CreateStage)
+	})
+	r.Group(func(r chi.Router) {
+		r.Delete(options.BaseURL+"/stages/{id}", wrapper.ArchiveStage)
 	})
 	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/stages/{id}", wrapper.GetStage)

--- a/backend/internal/contracts/publicevents_gen.go
+++ b/backend/internal/contracts/publicevents_gen.go
@@ -989,8 +989,11 @@ type PublicEventSignalResolved struct {
 	SignalId openapi_types.UUID `json:"signal_id"`
 }
 
-// PublicEventStageArchived Payload for stage.archived. Never emitted today (no archive path exists for stage); the schema is published so the type is a valid subscription target and the coverage gate can name it explicitly rather than silently omitting it.
-type PublicEventStageArchived struct{}
+// PublicEventStageArchived Payload for stage.archived — a stage was removed from a pipeline (archiveStage; archive is the removal, so the stage-change history referencing it stays readable). The pipeline is named here, as it is on stage.created, because a subscriber holding only the envelope's stage id cannot tell which pipeline reshaped; the shift that closes the vacated position rides its own pipeline.updated.
+type PublicEventStageArchived struct {
+	// PipelineId The pipeline the stage belonged to.
+	PipelineId openapi_types.UUID `json:"pipeline_id"`
+}
 
 // PublicEventStageCreated Payload for stage.created — a stage was added to a pipeline.
 type PublicEventStageCreated struct {

--- a/backend/internal/modules/deals/deal.go
+++ b/backend/internal/modules/deals/deal.go
@@ -30,7 +30,8 @@ import (
 func ensureOpenBirthStage(ctx context.Context, tx pgx.Tx, stageID ids.StageID, pipelineID ids.PipelineID) error {
 	var semantic string
 	err := tx.QueryRow(ctx,
-		`SELECT semantic FROM stage WHERE id = $1 AND pipeline_id = $2 AND archived_at IS NULL`,
+		`SELECT semantic FROM stage WHERE id = $1 AND pipeline_id = $2 AND archived_at IS NULL`+
+			lockLiveStageTarget,
 		stageID, pipelineID).Scan(&semantic)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return apperrors.ErrNotFound

--- a/backend/internal/modules/deals/deal_advance.go
+++ b/backend/internal/modules/deals/deal_advance.go
@@ -161,7 +161,8 @@ func dealStageChangedPayload(current crmcontracts.Deal, toStageID ids.StageID, t
 func resolveAdvanceTarget(ctx context.Context, tx pgx.Tx, toStage ids.StageID, current crmcontracts.Deal) (semantic string, winProbability int, err error) {
 	var stagePipeline ids.PipelineID
 	err = tx.QueryRow(ctx,
-		`SELECT semantic, pipeline_id, win_probability FROM stage WHERE id = $1 AND archived_at IS NULL`,
+		`SELECT semantic, pipeline_id, win_probability FROM stage WHERE id = $1 AND archived_at IS NULL`+
+			lockLiveStageTarget,
 		toStage).Scan(&semantic, &stagePipeline, &winProbability)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return "", 0, apperrors.ErrNotFound

--- a/backend/internal/modules/deals/handlers_stages.go
+++ b/backend/internal/modules/deals/handlers_stages.go
@@ -101,3 +101,19 @@ func (h Handlers) UpdateStage(w http.ResponseWriter, r *http.Request, id crmcont
 	}
 	httperr.WriteJSON(w, http.StatusOK, stage)
 }
+
+// ArchiveStage removes a stage from its pipeline. Both refusals carry
+// their own verdict — StageOccupiedError and TerminalStageError are
+// MessageFaults — so nothing is mapped by hand here: the sentinel choke
+// point renders them, and the datasource seam reads the same verdict.
+func (h Handlers) ArchiveStage(w http.ResponseWriter, r *http.Request, id crmcontracts.Id, _ crmcontracts.ArchiveStageParams) {
+	ifVersion, ok := httperr.IfMatchVersion(w, r)
+	if !ok {
+		return
+	}
+	if err := h.store.ArchiveStage(r.Context(), pathID[ids.StageKind](id), ifVersion); err != nil {
+		writeStoreErr(w, r, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/backend/internal/modules/deals/stageremoval.go
+++ b/backend/internal/modules/deals/stageremoval.go
@@ -1,0 +1,275 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package deals
+
+// The removal half of the bounded stage-configuration surface
+// (DEAL-WIRE-7 / UC-ADMIN-04 step 6). Archive, never delete: a
+// deal_stage_history row references the stage a deal moved out of with
+// ON DELETE RESTRICT, so a removed stage has to stay on disk for the
+// history to stay readable.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	openapi_types "github.com/oapi-codegen/runtime/types"
+
+	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/platform/auth"
+	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+)
+
+// namedBlockingDeals caps how many occupying deals the refusal spells
+// out. The count is always exact; the list is the actionable part, and a
+// stage holding hundreds of deals is answered by "move them", not by a
+// wire body the admin has to scroll.
+const namedBlockingDeals = 10
+
+// BlockingDeal is one live deal standing in the way of a stage removal.
+type BlockingDeal struct {
+	ID   ids.DealID
+	Name string
+}
+
+// StageOccupiedError refuses a removal that would strand deals
+// (UC-ADMIN-04 F1b). It names them because "move the deals first" is
+// only actionable if the admin is told which ones.
+//
+// A MessageFault, not a FieldFault: the caller sent a well-formed
+// removal of the stage they meant, and nothing in the request is theirs
+// to correct — what refuses is the workspace's own state. Naming a field
+// would hand the caller an input to fix that the operation does not have.
+type StageOccupiedError struct {
+	Count int
+	Deals []BlockingDeal
+}
+
+func (e *StageOccupiedError) Error() string {
+	return fmt.Sprintf("stage holds %d live deal(s)", e.Count)
+}
+
+// MessageFault carries the refusal's verdict wherever the error travels —
+// the REST mapper and the datasource seam alike read it, so neither has
+// to keep its own copy of this sentence.
+func (e *StageOccupiedError) MessageFault() (code, message string) {
+	names := make([]string, 0, len(e.Deals))
+	for _, d := range e.Deals {
+		names = append(names, d.Name)
+	}
+	message = fmt.Sprintf("%d deal(s) still sit on this stage: %s", e.Count, strings.Join(names, ", "))
+	// The named list is capped, so a refusal over a busy stage must not
+	// read as the whole truth.
+	if e.Count > len(e.Deals) {
+		message += fmt.Sprintf(" (and %d more)", e.Count-len(e.Deals))
+	}
+	return "stage_occupied", message + ". Move them to another stage first."
+}
+
+// TerminalStageError refuses removal of a won/lost stage: add and remove
+// operate on non-terminal stages only (UC-ADMIN-04 step 7), because the
+// close semantics and the FX freeze resolve through that pair. A
+// MessageFault for the same reason as StageOccupiedError.
+type TerminalStageError struct {
+	Semantic string
+}
+
+func (e *TerminalStageError) Error() string {
+	return "a " + e.Semantic + " stage cannot be removed"
+}
+
+// MessageFault carries this refusal's verdict for the same reason
+// StageOccupiedError's does.
+func (e *TerminalStageError) MessageFault() (code, message string) {
+	return "terminal_stage_not_removable",
+		"the " + e.Semantic + " stage is what closes a deal in this pipeline and cannot be removed"
+}
+
+// ArchiveStage removes a stage from its pipeline. The surviving stages
+// shift down so position stays contiguous, which is a pipeline-level
+// fact and rides ONE pipeline.updated — the same rule UpdateStage's
+// reorder branch follows.
+func (s *Store) ArchiveStage(ctx context.Context, id ids.StageID, ifVersion *int64) error {
+	if err := auth.Require(ctx, "pipeline", principal.ActionDelete); err != nil {
+		return err
+	}
+	return s.tx(ctx, func(tx pgx.Tx) error {
+		// The lock makes the version read, the occupancy check and the
+		// archive one race-free unit: a deal advancing onto this stage
+		// concurrently either lands before the lock (and is then seen by
+		// the occupancy check) or waits for the archive to commit and
+		// fails its own live-stage lookup.
+		if _, err := storekit.LockRow(ctx, tx, "stage", id.UUID, storekit.LiveOnly); err != nil {
+			return err
+		}
+		st, err := lockedStageForRemoval(ctx, tx, id, ifVersion)
+		if err != nil {
+			return err
+		}
+		if _, err := tx.Exec(ctx,
+			`UPDATE stage SET archived_at = $2 WHERE id = $1`, id, time.Now().UTC()); err != nil {
+			return fmt.Errorf("archive stage: %w", err)
+		}
+		moved, err := closeStageGap(ctx, tx, st.pipelineID, st.position)
+		if err != nil {
+			return err
+		}
+		return emitStageArchived(ctx, tx, id, st.pipelineID, moved)
+	})
+}
+
+// removableStage is the locked stage's state the removal decides on.
+type removableStage struct {
+	pipelineID ids.PipelineID
+	position   int
+}
+
+// lockedStageForRemoval reads the locked stage and answers every refusal
+// that does not need the row to be touched: version skew, the terminal
+// pair, and the deals still standing on it.
+func lockedStageForRemoval(
+	ctx context.Context, tx pgx.Tx, id ids.StageID, ifVersion *int64,
+) (removableStage, error) {
+	var st removableStage
+	var version int64
+	var semantic string
+	err := tx.QueryRow(ctx,
+		`SELECT version, pipeline_id, position, semantic FROM stage WHERE id = $1 AND archived_at IS NULL`, id).
+		Scan(&version, &st.pipelineID, &st.position, &semantic)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return st, apperrors.ErrNotFound
+	}
+	if err != nil {
+		return st, fmt.Errorf("read stage before archive: %w", err)
+	}
+	if ifVersion != nil && *ifVersion != version {
+		return st, apperrors.ErrVersionSkew
+	}
+	if StageSemantic(semantic) != SemanticOpen {
+		return st, &TerminalStageError{Semantic: semantic}
+	}
+	return st, refuseIfOccupied(ctx, tx, id)
+}
+
+// refuseIfOccupied answers the occupancy refusal, or nil when the stage
+// holds nothing. Live deals only: an archived deal cannot be moved off
+// the stage, so refusing on one would leave the admin with no way
+// forward — and its FK keeps pointing at a row archiving leaves in place.
+func refuseIfOccupied(ctx context.Context, tx pgx.Tx, id ids.StageID) error {
+	var count int
+	if err := tx.QueryRow(ctx,
+		`SELECT count(*) FROM deal WHERE stage_id = $1 AND archived_at IS NULL`, id).Scan(&count); err != nil {
+		return fmt.Errorf("count deals on stage: %w", err)
+	}
+	if count == 0 {
+		return nil
+	}
+	rows, err := tx.Query(ctx,
+		`SELECT id, name FROM deal WHERE stage_id = $1 AND archived_at IS NULL
+		 ORDER BY created_at LIMIT $2`, id, namedBlockingDeals)
+	if err != nil {
+		return fmt.Errorf("name deals on stage: %w", err)
+	}
+	defer rows.Close()
+	named := make([]BlockingDeal, 0, count)
+	for rows.Next() {
+		var d BlockingDeal
+		if err := rows.Scan(&d.ID, &d.Name); err != nil {
+			return fmt.Errorf("scan deal on stage: %w", err)
+		}
+		named = append(named, d)
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("read deals on stage: %w", err)
+	}
+	return &StageOccupiedError{Count: count, Deals: named}
+}
+
+// closeStageGap pulls the stages above the removed one down by one so
+// positions stay 1..n, and reports the moves for the reorder event.
+//
+// Ascending, one row at a time, on purpose: uq_stage_position is a
+// per-row check, and a single set-based `position - 1` would depend on
+// PostgreSQL visiting the rows in an order that keeps every intermediate
+// state unique — which it does not promise. Walking upward, each row's
+// target was vacated by the archive or by its predecessor's move. A
+// pipeline holds a handful of stages, so the loop is bounded by the
+// bounded-config surface itself.
+//
+// The read takes FOR UPDATE because these rows are read and then written:
+// without it, a concurrent removal or reorder in the same pipeline could
+// move a stage between this SELECT and its UPDATE, and the position
+// written here would be computed from a row state that no longer holds.
+// Locking upward by position is also why two concurrent removals cannot
+// deadlock — neither can hold a stage the other needs without already
+// holding every stage below it.
+func closeStageGap(
+	ctx context.Context, tx pgx.Tx, pipelineID ids.PipelineID, removed int,
+) (map[string]any, error) {
+	rows, err := tx.Query(ctx,
+		`SELECT id FROM stage
+		 WHERE pipeline_id = $1 AND archived_at IS NULL AND position > $2
+		 ORDER BY position FOR UPDATE`, pipelineID, removed)
+	if err != nil {
+		return nil, fmt.Errorf("read stages above the removed one: %w", err)
+	}
+	var above []ids.StageID
+	for rows.Next() {
+		var id ids.StageID
+		if err := rows.Scan(&id); err != nil {
+			rows.Close()
+			return nil, fmt.Errorf("scan stage above the removed one: %w", err)
+		}
+		above = append(above, id)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read stages above the removed one: %w", err)
+	}
+	moved := make(map[string]any, len(above))
+	for i, id := range above {
+		position := removed + i
+		if _, err := tx.Exec(ctx,
+			`UPDATE stage SET position = $2 WHERE id = $1`, id, position); err != nil {
+			return nil, fmt.Errorf("close the gap the removed stage left: %w", err)
+		}
+		moved[id.String()] = position
+	}
+	return moved, nil
+}
+
+// emitStageArchived writes the audit row and the facts it links: the
+// stage's own archival, plus the reorder as ONE pipeline.updated when
+// the gap-close actually moved something (a removal at the end of the
+// list moves nothing, and an empty delta is not a reorder).
+func emitStageArchived(
+	ctx context.Context, tx pgx.Tx, id ids.StageID, pipelineID ids.PipelineID, moved map[string]any,
+) error {
+	auditID, err := storekit.Audit(ctx, tx, "archive", "stage", id.UUID, nil, map[string]any{
+		"pipeline_id": pipelineID,
+	})
+	if err != nil {
+		return fmt.Errorf("audit stage archive: %w", err)
+	}
+	if err := storekit.EmitEvent(ctx, tx, auditID, id.UUID, crmcontracts.PublicEventStageArchived{
+		PipelineId: openapi_types.UUID(pipelineID.UUID),
+	}); err != nil {
+		return fmt.Errorf("emit stage.archived: %w", err)
+	}
+	if len(moved) == 0 {
+		return nil
+	}
+	if err := storekit.EmitEvent(ctx, tx, auditID, pipelineID.UUID, crmcontracts.PublicEventPipelineUpdated{
+		ChangedFields: map[string]any{"stage_positions": moved},
+	}); err != nil {
+		return fmt.Errorf("emit pipeline reorder after stage archive: %w", err)
+	}
+	return nil
+}

--- a/backend/internal/modules/deals/stageremoval.go
+++ b/backend/internal/modules/deals/stageremoval.go
@@ -235,7 +235,10 @@ func refuseIfOccupied(ctx context.Context, tx pgx.Tx, id ids.StageID) error {
 		return fmt.Errorf("name deals on stage: %w", err)
 	}
 	defer rows.Close()
-	named := make([]BlockingDeal, 0, count)
+	// The query is capped, so the count is the wrong capacity: a stage
+	// holding thousands of deals would size this slice for all of them
+	// and fill ten.
+	named := make([]BlockingDeal, 0, min(count, namedBlockingDeals))
 	for rows.Next() {
 		var d BlockingDeal
 		if err := rows.Scan(&d.ID, &d.Name); err != nil {

--- a/backend/internal/modules/deals/stageremoval.go
+++ b/backend/internal/modules/deals/stageremoval.go
@@ -33,6 +33,25 @@ import (
 // wire body the admin has to scroll.
 const namedBlockingDeals = 10
 
+// lockLiveStageTarget ends the two lookups that resolve the live stage a
+// write is about to bind a deal to — create's birth stage and advance's
+// target. It is what makes the occupancy count below a GUARD rather than a
+// hint.
+//
+// As a plain read those lookups take no lock, so a deal could resolve a
+// live stage, the removal could then count zero deals and archive it, and
+// the deal's own write would still land: the FK on deal.stage_id checks
+// that the row EXISTS, and archiving is precisely the operation that leaves
+// it existing. The result is a live deal on a removed stage — invisible to
+// every board read, which all filter on live stages.
+//
+// FOR KEY SHARE is the weakest lock that conflicts with the removal's FOR
+// UPDATE, so a rename or a probability edit still runs alongside a deal
+// moving. Whichever side takes it first, the outcome is right: the removal
+// waits and then counts the deal, or the deal's lookup waits and is
+// re-evaluated against the committed archived_at and finds nothing live.
+const lockLiveStageTarget = ` FOR KEY SHARE`
+
 // BlockingDeal is one live deal standing in the way of a stage removal.
 type BlockingDeal struct {
 	ID   ids.DealID
@@ -92,76 +111,105 @@ func (e *TerminalStageError) MessageFault() (code, message string) {
 		"the " + e.Semantic + " stage is what closes a deal in this pipeline and cannot be removed"
 }
 
-// ArchiveStage removes a stage from its pipeline. The surviving stages
-// shift down so position stays contiguous, which is a pipeline-level
-// fact and rides ONE pipeline.updated — the same rule UpdateStage's
-// reorder branch follows.
+// ArchiveStage removes a stage from its pipeline. The survivors are
+// renumbered so positions stay contiguous, which is a pipeline-level fact
+// and rides ONE pipeline.updated — the same rule UpdateStage's reorder
+// branch follows — and none is published when nothing actually moved.
 func (s *Store) ArchiveStage(ctx context.Context, id ids.StageID, ifVersion *int64) error {
 	if err := auth.Require(ctx, "pipeline", principal.ActionDelete); err != nil {
 		return err
 	}
 	return s.tx(ctx, func(tx pgx.Tx) error {
-		// The lock makes the version read, the occupancy check and the
-		// archive one race-free unit: a deal advancing onto this stage
-		// concurrently either lands before the lock (and is then seen by
-		// the occupancy check) or waits for the archive to commit and
-		// fails its own live-stage lookup.
+		// The pipeline row is the serialization point for every write
+		// that reshapes its stage list — see lockStageConfig. Taken
+		// before the stage's own lock, and by the reorder path too, so
+		// an archive and a reorder racing on one pipeline queue instead
+		// of deadlocking on each other's stage rows.
+		pipelineID, err := lockStageConfig(ctx, tx, id)
+		if err != nil {
+			return err
+		}
 		if _, err := storekit.LockRow(ctx, tx, "stage", id.UUID, storekit.LiveOnly); err != nil {
 			return err
 		}
-		st, err := lockedStageForRemoval(ctx, tx, id, ifVersion)
-		if err != nil {
+		if err := refuseUnremovableStage(ctx, tx, id, ifVersion); err != nil {
 			return err
 		}
 		if _, err := tx.Exec(ctx,
 			`UPDATE stage SET archived_at = $2 WHERE id = $1`, id, time.Now().UTC()); err != nil {
 			return fmt.Errorf("archive stage: %w", err)
 		}
-		moved, err := closeStageGap(ctx, tx, st.pipelineID, st.position)
+		moved, err := renumberStages(ctx, tx, pipelineID)
 		if err != nil {
 			return err
 		}
-		return emitStageArchived(ctx, tx, id, st.pipelineID, moved)
+		return emitStageArchived(ctx, tx, id, pipelineID, moved)
 	})
 }
 
-// removableStage is the locked stage's state the removal decides on.
-type removableStage struct {
-	pipelineID ids.PipelineID
-	position   int
+// lockStageConfig takes the stage's PIPELINE row for update and answers
+// its id — the one serialization point for reshaping a pipeline's stage
+// list.
+//
+// It exists because the removal and the reorder each lock stage rows in an
+// order the other does not follow: an archive holds the stage it is
+// removing and then walks upward, while a reorder holds the stage it is
+// moving and waits on the unique index for the slot the archive just
+// vacated. That is an AB-BA cycle, and PostgreSQL answers it by aborting
+// one side — a 500 on a legitimate admin action. One row taken first by
+// both paths removes the cycle rather than diagnosing it.
+func lockStageConfig(ctx context.Context, tx pgx.Tx, id ids.StageID) (ids.PipelineID, error) {
+	var pipelineID ids.PipelineID
+	err := tx.QueryRow(ctx,
+		`SELECT pipeline_id FROM stage WHERE id = $1 AND archived_at IS NULL`, id).Scan(&pipelineID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return pipelineID, apperrors.ErrNotFound
+	}
+	if err != nil {
+		return pipelineID, fmt.Errorf("read the stage's pipeline: %w", err)
+	}
+	if _, err := storekit.LockRow(ctx, tx, "pipeline", pipelineID.UUID, storekit.LiveOnly); err != nil {
+		return pipelineID, err
+	}
+	return pipelineID, nil
 }
 
-// lockedStageForRemoval reads the locked stage and answers every refusal
-// that does not need the row to be touched: version skew, the terminal
-// pair, and the deals still standing on it.
-func lockedStageForRemoval(
-	ctx context.Context, tx pgx.Tx, id ids.StageID, ifVersion *int64,
-) (removableStage, error) {
-	var st removableStage
+// refuseUnremovableStage answers every refusal the locked stage can be
+// judged on before it is touched: version skew, the terminal pair, and
+// the deals still standing on it.
+func refuseUnremovableStage(ctx context.Context, tx pgx.Tx, id ids.StageID, ifVersion *int64) error {
 	var version int64
 	var semantic string
 	err := tx.QueryRow(ctx,
-		`SELECT version, pipeline_id, position, semantic FROM stage WHERE id = $1 AND archived_at IS NULL`, id).
-		Scan(&version, &st.pipelineID, &st.position, &semantic)
+		`SELECT version, semantic FROM stage WHERE id = $1 AND archived_at IS NULL`, id).
+		Scan(&version, &semantic)
 	if errors.Is(err, pgx.ErrNoRows) {
-		return st, apperrors.ErrNotFound
+		return apperrors.ErrNotFound
 	}
 	if err != nil {
-		return st, fmt.Errorf("read stage before archive: %w", err)
+		return fmt.Errorf("read stage before archive: %w", err)
 	}
 	if ifVersion != nil && *ifVersion != version {
-		return st, apperrors.ErrVersionSkew
+		return apperrors.ErrVersionSkew
 	}
 	if StageSemantic(semantic) != SemanticOpen {
-		return st, &TerminalStageError{Semantic: semantic}
+		return &TerminalStageError{Semantic: semantic}
 	}
-	return st, refuseIfOccupied(ctx, tx, id)
+	return refuseIfOccupied(ctx, tx, id)
 }
 
 // refuseIfOccupied answers the occupancy refusal, or nil when the stage
 // holds nothing. Live deals only: an archived deal cannot be moved off
 // the stage, so refusing on one would leave the admin with no way
 // forward — and its FK keeps pointing at a row archiving leaves in place.
+//
+// The COUNT is unscoped and the NAMES are row-scoped, and the split is
+// deliberate. Occupancy is a fact about the stage: a removal that skipped
+// the deals its caller cannot see would strand exactly the rows the guard
+// exists to protect. The names are records, and a record handed back
+// carries the row-scope gate like any other read — so a caller whose scope
+// hides a blocking deal is told the true count and names only what they
+// may see, with the cap's "and N more" covering the rest.
 func refuseIfOccupied(ctx context.Context, tx pgx.Tx, id ids.StageID) error {
 	var count int
 	if err := tx.QueryRow(ctx,
@@ -171,9 +219,18 @@ func refuseIfOccupied(ctx context.Context, tx pgx.Tx, id ids.StageID) error {
 	if count == 0 {
 		return nil
 	}
-	rows, err := tx.Query(ctx,
-		`SELECT id, name FROM deal WHERE stage_id = $1 AND archived_at IS NULL
-		 ORDER BY created_at LIMIT $2`, id, namedBlockingDeals)
+	args := []any{id, namedBlockingDeals}
+	arg := func(v any) int { args = append(args, v); return len(args) }
+	scope, err := auth.ScopeClauseFor(ctx, "deal", "", arg)
+	if err != nil {
+		return err
+	}
+	if scope != "" {
+		scope = " AND " + scope
+	}
+	rows, err := tx.Query(ctx, storekit.SQLf(
+		`SELECT id, name FROM deal WHERE stage_id = $1 AND archived_at IS NULL%s
+		 ORDER BY created_at LIMIT $2`, scope), args...)
 	if err != nil {
 		return fmt.Errorf("name deals on stage: %w", err)
 	}
@@ -192,55 +249,69 @@ func refuseIfOccupied(ctx context.Context, tx pgx.Tx, id ids.StageID) error {
 	return &StageOccupiedError{Count: count, Deals: named}
 }
 
-// closeStageGap pulls the stages above the removed one down by one so
-// positions stay 1..n, and reports the moves for the reorder event.
+// renumberStages restates the pipeline's surviving stages as positions
+// 1..n in their existing order, and reports the rows that actually moved
+// for the reorder event.
 //
-// Ascending, one row at a time, on purpose: uq_stage_position is a
-// per-row check, and a single set-based `position - 1` would depend on
-// PostgreSQL visiting the rows in an order that keeps every intermediate
-// state unique — which it does not promise. Walking upward, each row's
-// target was vacated by the archive or by its predecessor's move. A
+// It renumbers the WHOLE list, not just the stages above the removed one,
+// because contiguity is a postcondition of the removal and not an
+// invariant the schema holds: uq_stage_position enforces uniqueness only,
+// and both createStage and updateStage take the position they are handed.
+// Shifting only the tail would leave a pipeline that was already gapped
+// gapped, so the removal's own promise would hold on a seeded pipeline and
+// quietly not on a hand-configured one. Rows already at their rank are
+// left alone, so the ordinary case still touches only the tail.
+//
+// Ascending, one row at a time, on purpose: uq_stage_position is a per-row
+// check, and one set-based statement would depend on PostgreSQL visiting
+// the rows in an order that keeps every intermediate state unique — which
+// it does not promise. Ascending, the i-th row's target is i+1, which no
+// row still holds: the rows below it have already moved down, and a row
+// above it sits at a position strictly greater than its own index. A
 // pipeline holds a handful of stages, so the loop is bounded by the
 // bounded-config surface itself.
 //
-// The read takes FOR UPDATE because these rows are read and then written:
-// without it, a concurrent removal or reorder in the same pipeline could
-// move a stage between this SELECT and its UPDATE, and the position
-// written here would be computed from a row state that no longer holds.
-// Locking upward by position is also why two concurrent removals cannot
-// deadlock — neither can hold a stage the other needs without already
-// holding every stage below it.
-func closeStageGap(
-	ctx context.Context, tx pgx.Tx, pipelineID ids.PipelineID, removed int,
-) (map[string]any, error) {
+// FOR UPDATE because these rows are read and then written; the pipeline
+// lock the caller already holds is what keeps a concurrent reorder out.
+func renumberStages(ctx context.Context, tx pgx.Tx, pipelineID ids.PipelineID) (map[string]any, error) {
 	rows, err := tx.Query(ctx,
-		`SELECT id FROM stage
-		 WHERE pipeline_id = $1 AND archived_at IS NULL AND position > $2
-		 ORDER BY position FOR UPDATE`, pipelineID, removed)
+		`SELECT id, position FROM stage
+		 WHERE pipeline_id = $1 AND archived_at IS NULL
+		 ORDER BY position FOR UPDATE`, pipelineID)
 	if err != nil {
-		return nil, fmt.Errorf("read stages above the removed one: %w", err)
+		return nil, fmt.Errorf("read the surviving stages: %w", err)
 	}
-	var above []ids.StageID
+	type placed struct {
+		id       ids.StageID
+		position int
+	}
+	var surviving []placed
 	for rows.Next() {
-		var id ids.StageID
-		if err := rows.Scan(&id); err != nil {
+		var s placed
+		if err := rows.Scan(&s.id, &s.position); err != nil {
 			rows.Close()
-			return nil, fmt.Errorf("scan stage above the removed one: %w", err)
+			return nil, fmt.Errorf("scan a surviving stage: %w", err)
 		}
-		above = append(above, id)
+		surviving = append(surviving, s)
 	}
 	rows.Close()
 	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("read stages above the removed one: %w", err)
+		return nil, fmt.Errorf("read the surviving stages: %w", err)
 	}
-	moved := make(map[string]any, len(above))
-	for i, id := range above {
-		position := removed + i
-		if _, err := tx.Exec(ctx,
-			`UPDATE stage SET position = $2 WHERE id = $1`, id, position); err != nil {
-			return nil, fmt.Errorf("close the gap the removed stage left: %w", err)
+	moved := map[string]any{}
+	for i, s := range surviving {
+		rank := i + 1
+		if s.position == rank {
+			continue
 		}
-		moved[id.String()] = position
+		if _, err := tx.Exec(ctx,
+			`UPDATE stage SET position = $2 WHERE id = $1`, s.id, rank); err != nil {
+			if storekit.IsUniqueViolation(err) {
+				return nil, apperrors.ErrConflict
+			}
+			return nil, fmt.Errorf("renumber the surviving stages: %w", err)
+		}
+		moved[s.id.String()] = rank
 	}
 	return moved, nil
 }

--- a/backend/internal/modules/deals/stageremoval_test.go
+++ b/backend/internal/modules/deals/stageremoval_test.go
@@ -54,10 +54,11 @@ func TestTheOccupiedRefusalSaysHowManyItLeftUnnamed(t *testing.T) {
 	}
 }
 
-// Both refusals travel to the MCP surface through the datasource seam,
-// which never runs the HTTP mapper: the verdict has to be on the error
-// itself or a governed refusal reports as an internal fault an agent is
-// told to retry.
+// The verdict lives on the error, not in a per-module HTTP mapper: that
+// is what lets one choke point render both refusals, and what the
+// seam-coverage gate demands of any 422 a module can raise, since a
+// surface reaching the store without that mapper would otherwise report
+// a governed refusal as an internal fault.
 func TestBothRemovalRefusalsCarryTheirOwnVerdict(t *testing.T) {
 	for _, err := range []error{
 		&StageOccupiedError{Count: 1, Deals: blockingDealsFixture(1)},

--- a/backend/internal/modules/deals/stageremoval_test.go
+++ b/backend/internal/modules/deals/stageremoval_test.go
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package deals
+
+// The occupied-stage refusal has to stay actionable when the stage holds
+// more deals than the message names: the count is exact, the list is
+// capped, and the sentence says so rather than reading as the whole truth.
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+func blockingDealsFixture(n int) []BlockingDeal {
+	deals := make([]BlockingDeal, 0, n)
+	for i := range n {
+		deals = append(deals, BlockingDeal{ID: ids.New[ids.DealKind](), Name: fmt.Sprintf("Deal %d", i+1)})
+	}
+	return deals
+}
+
+func TestTheOccupiedRefusalNamesEveryDealItCounted(t *testing.T) {
+	named := blockingDealsFixture(3)
+	code, message := (&StageOccupiedError{Count: len(named), Deals: named}).MessageFault()
+
+	if code != "stage_occupied" {
+		t.Fatalf("the refusal carries code %q, which no surface is mapping", code)
+	}
+	for _, d := range named {
+		if !strings.Contains(message, d.Name) {
+			t.Fatalf("the refusal %q leaves out %q, which the admin has to move", message, d.Name)
+		}
+	}
+	if strings.Contains(message, "more") {
+		t.Fatalf("the refusal %q claims deals it did not name, but it named all of them", message)
+	}
+}
+
+func TestTheOccupiedRefusalSaysHowManyItLeftUnnamed(t *testing.T) {
+	named := blockingDealsFixture(namedBlockingDeals)
+	_, message := (&StageOccupiedError{Count: namedBlockingDeals + 7, Deals: named}).MessageFault()
+
+	if !strings.Contains(message, fmt.Sprintf("%d deal(s)", namedBlockingDeals+7)) {
+		t.Fatalf("the refusal %q does not lead with the true count", message)
+	}
+	if !strings.Contains(message, "(and 7 more)") {
+		t.Fatalf("the refusal %q reads as the whole list while it named only %d of %d",
+			message, namedBlockingDeals, namedBlockingDeals+7)
+	}
+}
+
+// Both refusals travel to the MCP surface through the datasource seam,
+// which never runs the HTTP mapper: the verdict has to be on the error
+// itself or a governed refusal reports as an internal fault an agent is
+// told to retry.
+func TestBothRemovalRefusalsCarryTheirOwnVerdict(t *testing.T) {
+	for _, err := range []error{
+		&StageOccupiedError{Count: 1, Deals: blockingDealsFixture(1)},
+		&TerminalStageError{Semantic: string(SemanticWon)},
+	} {
+		fault, ok := err.(apperrors.MessageFault)
+		if !ok {
+			t.Fatalf("%T does not carry its own verdict", err)
+		}
+		code, message := fault.MessageFault()
+		if code == "" || message == "" {
+			t.Fatalf("%T answers code=%q message=%q — a surface has nothing to say", err, code, message)
+		}
+	}
+}
+
+func TestTheTerminalRefusalNamesTheSemanticItRefused(t *testing.T) {
+	for _, semantic := range []string{string(SemanticWon), string(SemanticLost)} {
+		code, message := (&TerminalStageError{Semantic: semantic}).MessageFault()
+		if code != "terminal_stage_not_removable" {
+			t.Fatalf("the refusal carries code %q, which no surface is mapping", code)
+		}
+		if !strings.Contains(message, semantic) {
+			t.Fatalf("the refusal %q does not say which stage kind it refused", message)
+		}
+	}
+}

--- a/backend/internal/modules/deals/stages.go
+++ b/backend/internal/modules/deals/stages.go
@@ -257,16 +257,23 @@ func (s *Store) UpdateStage(ctx context.Context, id ids.StageID, in UpdateStageI
 	}
 	var out crmcontracts.Stage
 	err := s.tx(ctx, func(tx pgx.Tx) error {
+		// The pipeline row first, then the stage's own: a reorder and a
+		// removal both reshape this list, and taking the same row first
+		// on both paths is what keeps them queueing rather than
+		// deadlocking (lockStageConfig).
+		pipelineID, err := lockStageConfig(ctx, tx, id)
+		if err != nil {
+			return err
+		}
 		// The row lock makes the version read and the update below one
 		// race-free unit.
 		if _, err := storekit.LockRow(ctx, tx, "stage", id.UUID, storekit.LiveOnly); err != nil {
 			return err
 		}
 		var version int64
-		var pipelineID ids.PipelineID
-		err := tx.QueryRow(ctx,
-			`SELECT version, pipeline_id FROM stage WHERE id = $1 AND archived_at IS NULL`, id).
-			Scan(&version, &pipelineID)
+		err = tx.QueryRow(ctx,
+			`SELECT version FROM stage WHERE id = $1 AND archived_at IS NULL`, id).
+			Scan(&version)
 		if errors.Is(err, pgx.ErrNoRows) {
 			return apperrors.ErrNotFound
 		}

--- a/frontend/src/api/public-events.ts
+++ b/frontend/src/api/public-events.ts
@@ -303,8 +303,14 @@ export interface components {
             /** @description The stage's new win probability (absent when this update did not touch it). */
             win_probability?: number;
         };
-        /** @description Payload for stage.archived. Never emitted today (no archive path exists for stage); the schema is published so the type is a valid subscription target and the coverage gate can name it explicitly rather than silently omitting it. */
-        PublicEventStageArchived: Record<string, never>;
+        /** @description Payload for stage.archived — a stage was removed from a pipeline (archiveStage; archive is the removal, so the stage-change history referencing it stays readable). The pipeline is named here, as it is on stage.created, because a subscriber holding only the envelope's stage id cannot tell which pipeline reshaped; the shift that closes the vacated position rides its own pipeline.updated. */
+        PublicEventStageArchived: {
+            /**
+             * Format: uuid
+             * @description The pipeline the stage belonged to.
+             */
+            pipeline_id: string;
+        };
         /** @description How many child rows on each side were repointed from the merged- away person onto the survivor (people/merge.go relinkCounts). */
         PublicEventPersonMergedRelinkCounts: {
             /**

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -2118,7 +2118,25 @@ export interface paths {
         get: operations["getStage"];
         put?: never;
         post?: never;
-        delete?: never;
+        /**
+         * Remove a stage from its pipeline (soft delete; archive is the delete).
+         * @description The removal half of the bounded stage-configuration surface (DEAL-WIRE-7). Archiving
+         *     rather than deleting is what keeps the stage-change history readable — a
+         *     `deal_stage_history` row references the stage a deal moved out of.
+         *
+         *     The surviving stages of the pipeline shift down so `position` stays contiguous, which
+         *     publishes ONE `pipeline.updated` reorder alongside `stage.archived`.
+         *
+         *     Two refusals, both `422` (DEAL-WIRE-10). Neither names a request field — the caller
+         *     sent the removal they meant and what refuses is the workspace's own state — so each
+         *     carries its machine code as the problem's `code` and its reason as `detail`:
+         *     * `stage_occupied` while live deals sit on the stage. The detail counts them and
+         *       names them (bounded, with "and N more" beyond the cap) so they can be moved
+         *       first; no `deal.stage_id` is ever left pointing at a removed stage.
+         *     * `terminal_stage_not_removable` on a `won`/`lost` stage: add and remove operate on
+         *       non-terminal stages only, so the pair the close semantics hang off survives.
+         */
+        delete: operations["archiveStage"];
         options?: never;
         head?: never;
         /** Update a stage (rename / reorder / probability). */
@@ -19833,6 +19851,41 @@ export interface operations {
                 };
             };
             404: components["responses"]["NotFound"];
+        };
+    };
+    archiveStage: {
+        parameters: {
+            query?: never;
+            header?: {
+                /**
+                 * @description Optional optimistic-concurrency precondition for a mutating request (PATCH/advance/merge):
+                 *     the last-seen entity `version`. If the row's current `version` differs, the write is
+                 *     rejected with `409 code: version_skew` (ErrVersionSkew) and no change is made — re-read,
+                 *     re-apply, retry. Omitting it is last-write-wins (discouraged for agent/automated writers).
+                 *     Accepted on every native (SoR-mode) mutating endpoint that returns a versioned entity.
+                 */
+                "If-Match"?: components["parameters"]["IfMatch"];
+            };
+            path: {
+                /** @description Opaque resource id (UUID; ordering semantics are not exposed). */
+                id: components["parameters"]["Id"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Archived. */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            404: components["responses"]["NotFound"];
+            409: components["responses"]["Conflict"];
+            422: components["responses"]["ValidationError"];
         };
     };
     updateStage: {

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -2086,6 +2086,11 @@ export const de = {
   "stage.semOpen": "Offen",
   "stage.semWon": "Gewonnen",
   "stage.semLost": "Verloren",
+  "stage.remove": "Entfernen",
+  "stage.removeConfirm": "Phase entfernen",
+  "stage.removeTitle": "Diese Phase entfernen?",
+  "stage.removeBody":
+    "„{name}“ verlässt die Pipeline, die nachfolgenden Phasen rücken auf. Frühere Phasenwechsel bleiben lesbar. Deals, die noch darauf stehen, müssen zuerst umziehen.",
 
   "ob.read": "Einlesen",
   "ob.confirm": "Bestätigen",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -2081,6 +2081,11 @@ export const en = {
   "stage.semOpen": "Open",
   "stage.semWon": "Won",
   "stage.semLost": "Lost",
+  "stage.remove": "Remove",
+  "stage.removeConfirm": "Remove stage",
+  "stage.removeTitle": "Remove this stage?",
+  "stage.removeBody":
+    "“{name}” leaves the pipeline and the stages after it move up. Past stage changes stay readable. Deals still sitting on it have to move first.",
 
   "ob.read": "Read",
   "ob.confirm": "Confirm",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -2074,6 +2074,11 @@ export const vi = {
   "stage.semOpen": "Đang mở",
   "stage.semWon": "Thắng",
   "stage.semLost": "Thua",
+  "stage.remove": "Gỡ bỏ",
+  "stage.removeConfirm": "Gỡ giai đoạn",
+  "stage.removeTitle": "Gỡ giai đoạn này?",
+  "stage.removeBody":
+    "“{name}” sẽ rời khỏi pipeline và các giai đoạn sau dồn lên. Lịch sử chuyển giai đoạn vẫn đọc được. Các deal còn nằm ở đây phải chuyển đi trước.",
 
   "ob.read": "Đọc",
   "ob.confirm": "Xác nhận",

--- a/frontend/src/screens/settings.test.tsx
+++ b/frontend/src/screens/settings.test.tsx
@@ -1460,6 +1460,10 @@ function settingsStub(opts: {
   roles: string[];
   allow?: GrantSpec;
   onStagePost?: (body: unknown) => void;
+  onStageDelete?: (url: string) => void;
+  // What the server answers a removal with, when the scenario is about a
+  // refusal: a stage still holding deals, or the terminal pair.
+  stageDeleteRefusal?: { status: number; body: unknown };
 }) {
   return vi.fn(async (input: RequestInfo | URL) => {
     const url = String(input instanceof Request ? input.url : input);
@@ -1498,6 +1502,16 @@ function settingsStub(opts: {
       opts.onStagePost?.(body);
       return jsonResponse(body);
     }
+    if (url.includes("/stages/") && method === "DELETE") {
+      opts.onStageDelete?.(url);
+      if (opts.stageDeleteRefusal) {
+        return jsonResponse(
+          opts.stageDeleteRefusal.body,
+          opts.stageDeleteRefusal.status,
+        );
+      }
+      return new Response(null, { status: 204 });
+    }
     return jsonResponse({ data: [], page: { next_cursor: null } });
   });
 }
@@ -1535,6 +1549,77 @@ describe("PipelinesCard", () => {
     render(<PipelinesCard />);
     expect(await screen.findByText("New pipeline")).toBeTruthy();
     expect(screen.queryByTestId("new-stage-pl")).toBeNull();
+  });
+
+  // Removal is pipeline:delete, a different verb from everything else on
+  // this card — a principal who may add and rename stages must not be
+  // shown a control the server would only ever 403.
+  it("withholds stage removal from a principal holding update alone", async () => {
+    vi.stubGlobal(
+      "fetch",
+      settingsStub({
+        roles: ["admin"],
+        allow: { pipeline: ["read", "update"] },
+      }),
+    );
+    render(<PipelinesCard />);
+    expect(await screen.findByTestId("new-stage-pl")).toBeTruthy();
+    expect(screen.queryByTestId("remove-stage-s1")).toBeNull();
+  });
+
+  it("removes a stage through DELETE once the confirm is taken", async () => {
+    const deleted: string[] = [];
+    vi.stubGlobal(
+      "fetch",
+      settingsStub({
+        roles: ["admin"],
+        allow: { pipeline: ["read", "update", "delete"] },
+        onStageDelete: (url) => deleted.push(url),
+      }),
+    );
+    render(<PipelinesCard />);
+    await userEvent.click(await screen.findByTestId("remove-stage-s1"));
+    // The dialog names the stage, so the confirm is about a stage the
+    // reader recognises rather than "this one".
+    expect(screen.getByText(/leaves the pipeline/).textContent).toContain(
+      "Qualify",
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Remove stage" }));
+    await waitFor(() => expect(deleted).toHaveLength(1));
+    expect(deleted[0]).toContain("/stages/s1");
+  });
+
+  // The refusal is the server's, and it names the deals in the way. The
+  // dialog stays open showing it: a closed dialog would drop the only
+  // sentence telling the admin what to move.
+  it("shows the occupied-stage refusal and keeps the stage", async () => {
+    vi.stubGlobal(
+      "fetch",
+      settingsStub({
+        roles: ["admin"],
+        allow: { pipeline: ["read", "update", "delete"] },
+        stageDeleteRefusal: {
+          status: 422,
+          body: {
+            type: "https://errors.gradion.com/stage_occupied",
+            title: "Validation failed",
+            status: 422,
+            code: "stage_occupied",
+            detail:
+              "1 deal(s) still sit on this stage: Acme rollout. Move them to another stage first.",
+            details: {
+              deal_count: 1,
+              deals: [{ id: "d1", name: "Acme rollout" }],
+            },
+          },
+        },
+      }),
+    );
+    render(<PipelinesCard />);
+    await userEvent.click(await screen.findByTestId("remove-stage-s1"));
+    await userEvent.click(screen.getByRole("button", { name: "Remove stage" }));
+    expect(await screen.findByText(/Acme rollout/)).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Remove stage" })).toBeTruthy();
   });
 
   it("create stage posts the pipeline_id + semantic + win_probability", async () => {

--- a/frontend/src/screens/settings.test.tsx
+++ b/frontend/src/screens/settings.test.tsx
@@ -1600,17 +1600,17 @@ describe("PipelinesCard", () => {
         allow: { pipeline: ["read", "update", "delete"] },
         stageDeleteRefusal: {
           status: 422,
+          // Exactly what the server sends: a MessageFault renders a
+          // machine code and a reason, and no per-field details body —
+          // a fixture that invented one would document a contract the
+          // backend does not have.
           body: {
             type: "https://errors.gradion.com/stage_occupied",
-            title: "Validation failed",
+            title: "Unprocessable Entity",
             status: 422,
             code: "stage_occupied",
             detail:
               "1 deal(s) still sit on this stage: Acme rollout. Move them to another stage first.",
-            details: {
-              deal_count: 1,
-              deals: [{ id: "d1", name: "Acme rollout" }],
-            },
           },
         },
       }),

--- a/frontend/src/screens/settings.tsx
+++ b/frontend/src/screens/settings.tsx
@@ -1502,7 +1502,10 @@ function StageCreate({ pipelineId }: Readonly<{ pipelineId: string }>) {
 // from the row: the refusal names the deals standing in the way, which is
 // the part an admin acts on, and a board read a minute ago would name the
 // wrong ones.
-function StageRemove({ stage }: Readonly<{ stage: Stage }>) {
+function StageRemove({
+  stage,
+  returnFocusTo,
+}: Readonly<{ stage: Stage; returnFocusTo: () => HTMLElement | null }>) {
   const t = useT();
   const [open, setOpen] = useState(false);
   const queryClient = useQueryClient();
@@ -1556,6 +1559,10 @@ function StageRemove({ stage }: Readonly<{ stage: Stage }>) {
         pending={remove.isPending}
         error={remove.isError ? problemMessageOf(remove.error, t) : null}
         onConfirm={() => remove.mutate()}
+        // The stage list, not the trigger: a successful removal unmounts
+        // the row this button lives in, so there is nothing to hand focus
+        // back to (design-system/confirmmodal).
+        returnFocusTo={returnFocusTo}
       >
         <p className="t-small">{t("stage.removeBody", { name: stage.name })}</p>
       </ConfirmModal>
@@ -1567,10 +1574,12 @@ function StageRow({
   stage,
   canEdit,
   t,
+  returnFocusTo,
 }: Readonly<{
   stage: Stage;
   canEdit: boolean;
   t: ReturnType<typeof useT>;
+  returnFocusTo: () => HTMLElement | null;
 }>) {
   return (
     <li
@@ -1586,14 +1595,17 @@ function StageRow({
         {stageSemanticLabel(stage.semantic, t)}
       </Badge>
       <span className="t-mono t-small">{stage.win_probability}%</span>
-      {canEdit && (
-        <span
-          style={{
-            display: "flex",
-            gap: "var(--space-2)",
-            alignItems: "center",
-          }}
-        >
+      {/* Each control carries its own verb — editing a stage is
+          pipeline:update, removing one is pipeline:delete — so a role
+          holding one without the other still sees the one it may use. */}
+      <span
+        style={{
+          display: "flex",
+          gap: "var(--space-2)",
+          alignItems: "center",
+        }}
+      >
+        {canEdit && (
           <EditAction
             label={t("stage.edit")}
             invalidate="pipelines"
@@ -1617,9 +1629,9 @@ function StageRow({
               return data;
             }}
           />
-          <StageRemove stage={stage} />
-        </span>
-      )}
+        )}
+        <StageRemove stage={stage} returnFocusTo={returnFocusTo} />
+      </span>
     </li>
   );
 }
@@ -1633,6 +1645,7 @@ function PipelineRow({
   canEdit: boolean;
   t: ReturnType<typeof useT>;
 }>) {
+  const stageList = useRef<HTMLUListElement>(null);
   const stages = [...(pipeline.stages ?? [])].sort(
     (a, b) => a.position - b.position,
   );
@@ -1687,7 +1700,12 @@ function PipelineRow({
           </>
         )}
       </div>
+      {/* tabIndex -1 so a removal can hand focus to the list it changed:
+          the row's own Remove button is gone by then, and focus dropped to
+          <body> leaves a screen-reader user at the top of the document. */}
       <ul
+        ref={stageList}
+        tabIndex={-1}
         style={{
           listStyle: "none",
           display: "flex",
@@ -1697,7 +1715,13 @@ function PipelineRow({
         }}
       >
         {stages.map((stage) => (
-          <StageRow key={stage.id} stage={stage} canEdit={canEdit} t={t} />
+          <StageRow
+            key={stage.id}
+            stage={stage}
+            canEdit={canEdit}
+            t={t}
+            returnFocusTo={() => stageList.current}
+          />
         ))}
       </ul>
     </Card>

--- a/frontend/src/screens/settings.tsx
+++ b/frontend/src/screens/settings.tsx
@@ -1496,6 +1496,73 @@ function StageCreate({ pipelineId }: Readonly<{ pipelineId: string }>) {
   );
 }
 
+// The removal half of the bounded stage surface. Both refusals are the
+// server's — a stage still holding deals, and the terminal won/lost pair —
+// so this asks and then shows what it was told rather than pre-judging
+// from the row: the refusal names the deals standing in the way, which is
+// the part an admin acts on, and a board read a minute ago would name the
+// wrong ones.
+function StageRemove({ stage }: Readonly<{ stage: Stage }>) {
+  const t = useT();
+  const [open, setOpen] = useState(false);
+  const queryClient = useQueryClient();
+  // Removal is pipeline:delete, not the pipeline:update everything else on
+  // this card runs on — the server gates it that way, so a principal who
+  // may add and rename stages but not remove one is not shown a control
+  // that could only ever answer 403. Read before the early return: the
+  // hooks a render performs must not depend on the answer.
+  const canRemove = useCanWrite("pipeline", "delete");
+  const remove = useMutation({
+    mutationFn: async () => {
+      const { error } = await api.DELETE("/stages/{id}", {
+        params: { path: { id: stage.id } },
+      });
+      if (error) {
+        throwProblem(error);
+      }
+    },
+    onSuccess: async () => {
+      // The refetched pipelines FIRST, then the dialog: closing it hands
+      // focus back to a list that must no longer hold this row.
+      await queryClient.invalidateQueries({ queryKey: ["pipelines"] });
+      setOpen(false);
+    },
+  });
+  // A refusal is about the workspace's state, not the dialog's: reopening
+  // must ask again rather than reprint what the last attempt was told.
+  const close = () => {
+    remove.reset();
+    setOpen(false);
+  };
+  if (!canRemove) {
+    return null;
+  }
+  return (
+    <>
+      <Button
+        small
+        variant="danger"
+        data-testid={`remove-stage-${stage.id}`}
+        onClick={() => setOpen(true)}
+      >
+        {t("stage.remove")}
+      </Button>
+      <ConfirmModal
+        open={open}
+        onClose={close}
+        title={t("stage.removeTitle")}
+        confirmLabel={t("stage.removeConfirm")}
+        confirmVariant="danger"
+        pending={remove.isPending}
+        error={remove.isError ? problemMessageOf(remove.error, t) : null}
+        onConfirm={() => remove.mutate()}
+      >
+        <p className="t-small">{t("stage.removeBody", { name: stage.name })}</p>
+      </ConfirmModal>
+    </>
+  );
+}
+
 function StageRow({
   stage,
   canEdit,
@@ -1520,29 +1587,38 @@ function StageRow({
       </Badge>
       <span className="t-mono t-small">{stage.win_probability}%</span>
       {canEdit && (
-        <EditAction
-          label={t("stage.edit")}
-          invalidate="pipelines"
-          recordKey="stage"
-          record={{
-            id: stage.id,
-            name: stage.name,
-            position: String(stage.position),
-            semantic: stage.semantic,
-            win_probability: String(stage.win_probability),
+        <span
+          style={{
+            display: "flex",
+            gap: "var(--space-2)",
+            alignItems: "center",
           }}
-          fields={stageFields(t)}
-          update={async (values) => {
-            const { data, error } = await api.PATCH("/stages/{id}", {
-              params: { path: { id: stage.id } },
-              body: mapStageBody(values),
-            });
-            if (error) {
-              throwProblem(error);
-            }
-            return data;
-          }}
-        />
+        >
+          <EditAction
+            label={t("stage.edit")}
+            invalidate="pipelines"
+            recordKey="stage"
+            record={{
+              id: stage.id,
+              name: stage.name,
+              position: String(stage.position),
+              semantic: stage.semantic,
+              win_probability: String(stage.win_probability),
+            }}
+            fields={stageFields(t)}
+            update={async (values) => {
+              const { data, error } = await api.PATCH("/stages/{id}", {
+                params: { path: { id: stage.id } },
+                body: mapStageBody(values),
+              });
+              if (error) {
+                throwProblem(error);
+              }
+              return data;
+            }}
+          />
+          <StageRemove stage={stage} />
+        </span>
       )}
     </li>
   );


### PR DESCRIPTION
Closes #717.

## Why

You could create, rename, reorder and re-probability a pipeline stage, but never remove one — so a stage
added by mistake was permanent, and the workaround was building a second pipeline and leaving the first
lying around. `UC-ADMIN-04` ratified removal as bounded configuration on **2026-07-03**, guard included
("removal is refused while deals sit on that stage, and the refusal names the blocking deals"), and
nothing implemented it. `DEAL-WIRE-7` had never grown the operation either, which is why this went
**spec-first**: [margince-foundation#1300](https://github.com/gradionhq/margince-foundation/pull/1300)
names `archiveStage` on that row and pins both refusals as `DEAL-WIRE-10`. It is merged.

## What ships

`DELETE /v1/stages/{id}` → `archiveStage`, `204`, human-only (`cookieAuth` + `x-agent-access: human-only`,
matching `createStage`/`updateStage`), optional `If-Match`, gated on `pipeline:delete` — which admin and
ops hold today and manager/rep do not, exactly UC-ADMIN-04's actor set.

**Archive, not delete.** `deal_stage_history.to_stage_id` is `ON DELETE RESTRICT` and past stage changes
have to stay readable, so the row stays on disk. `stage.archived_at`, the partial `uq_stage_position`
index and every read's archived filter already existed — **no migration**.

**The survivors close the gap** so positions stay `1..n` (step 6). Walked upward one row at a time under
`SELECT … FOR UPDATE`: `uq_stage_position` is a per-row check, so a set-based `position - 1` would rest on
a visit order PostgreSQL does not promise, and locking by ascending position is also why two concurrent
removals cannot deadlock. The shift publishes **ONE** `pipeline.updated` — the rule reorders already
follow — beside `stage.archived`, which until now was a published type nothing emitted and which gains
the `pipeline_id` the event catalog always specified for it.

**Both refusals are `MessageFault`s, not hand-mapped 422s.** The caller sent a well-formed removal of the
stage they meant; what refuses is the workspace's own state, so there is no request field to name. The
verdict rides on the error and reads the same on REST and through the datasource seam — which is what
`TestSeamReachableModulesCarryTheirOwnFieldVerdict` demanded when the first draft mapped them by hand in
the transport.

| refusal | when |
|---|---|
| `422 stage_occupied` | live deals sit on the stage; the detail counts and names them (bounded, `and N more` past the cap) so they can be moved first |
| `422 terminal_stage_not_removable` | a `won`/`lost` stage — add and remove operate on non-terminal stages only (step 7) |

**UI:** a danger-toned Remove on each stage row behind a `ConfirmModal`, gated on `pipeline:delete` rather
than the `pipeline:update` the rest of the card runs on, so nobody is shown a control that could only ever
403. The dialog stays open on a refusal — closing it would drop the only sentence telling the admin what
to move.

## Proof

- `E2E-UC-ADMIN-04.remove-stage-guard` as the spec derives it, in
  `compose/integration/stage_removal_integration_test.go`: terminal refused → occupied refused, naming
  the deal, stage untouched → empty stage removed, positions contiguous, both events → archived stage
  still reads → second removal 404s → deal advanced away → stage now removes → **the advance's history
  row still points at the removed stage**. Plus the stale-`If-Match` guard.
- The contiguity assertion was **mutation-verified**: disabling the gap-close fails it with
  `stage "Negotiation" sits at position 4, want 3`.
- `make check` (backend + frontend), `make craft-static`, and the full integration lane —
  `OK: integration passed with 0 skips (40 packages)` — all green locally.

## Left out on purpose

The issue's build item 3 — a transactional MULTI-stage reorder in one operation — is not in its own
"Done when" list, and removal's own compaction is transactional here. A bulk reorder is a separate
contract addition; it gets its own issue rather than widening this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allows removing a pipeline stage via DELETE /v1/stages/{id} without stranding deals and keeps stage positions contiguous. Previously stages were permanent; now removal archives the stage, refuses for occupied or terminal stages, renumbers survivors, and emits explicit change events.

- API: returns 204; human-only (`cookieAuth`, `x-agent-access: human-only`); requires `pipeline:delete`; optional `If-Match` → 409 `version_skew`. Refusals are 422 `MessageFault`s:
  - `stage_occupied`: exact count; names up to 10 row-scoped blocking deals with “and N more”. Allocation sized to the cap to avoid over-allocating on large stages.
  - `terminal_stage_not_removable`: `won`/`lost` stages are not removable.
- Concurrency/locking: deal create/advance now locks target stages with FOR KEY SHARE so occupancy is a true guard under race. Removal and reorder both lock the pipeline row first, then stage rows, preventing AB-BA deadlocks.
- Data/events: archive (set `archived_at`), never delete; history stays readable. Survivors renumber across the entire list to 1..n (also fixes pre-existing gaps). Emits `stage.archived` with `pipeline_id` and exactly one `pipeline.updated` only when positions change.
- Frontend: danger-toned Remove per stage behind a ConfirmModal, gated on `pipeline:delete`. Dialog stays open on refusal and shows the server message; focus returns to the stage list. i18n and `public-events`/schema updated.
- Tests: integration and race tests cover guards, contiguous renumbering (including already-gapped pipelines), version precondition, and the invariant “no live deal on an archived stage.”
- Rollout/QA: no migration. Ensure roles that need removal hold `pipeline:delete`. Verify subscribers handle `stage.archived` with `pipeline_id` and a single `pipeline.updated` when renumbering occurs.

<sup>Written for commit fb76945892c8286d6765d1d75eb5c5bd61617318. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1292?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to remove pipeline stages from settings with permission checks and confirmation.
  - Stage removal preserves historical records and automatically reorders remaining stages.
  - Deals must be moved before a stage containing active deals can be removed.
  - Terminal stages cannot be removed.
  - Clear error messages identify blocking deals and version conflicts.
- **Improvements**
  - Archive events now include the associated pipeline.
  - Added English, German, and Vietnamese text for stage removal actions and warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->