### PR TITLE
refactor(activities): a message records the transport that carried it, not its kind

### DIFF
--- a/backend/internal/compose/channelprovider.go
+++ b/backend/internal/compose/channelprovider.go
@@ -3,11 +3,16 @@
 
 package compose
 
-// The boot-time reconcile for the derived channel vocabulary (DESIGN-SP4 §4):
-// the ONE place activity_kind and channel_provider are written, and the ONE
-// place activities.SetChannelProviders and comms.SetChannelProviders are
-// called — so the DB registry and both packages' in-memory snapshots cannot
-// be set two different ways.
+// The boot-time reconcile for the derived channel vocabulary: the ONE place
+// channel_provider is written, and the ONE place
+// activities.SetChannelProviders and comms.SetChannelProviders are called — so
+// the DB registry and both packages' in-memory snapshots cannot be set two
+// different ways.
+//
+// It does NOT write activity_kind. A provider names a transport; an activity
+// kind names what sort of interaction happened. Those are different axes, and
+// the vocabulary of interaction kinds is fixed by the contract and seeded by
+// the core migration, so boot has nothing to add to it.
 //
 // Called from NewCaptureRegistry, which this codebase already constructs more
 // than once per process (a role-specific alternate wiring path, the worker's
@@ -25,10 +30,9 @@ import (
 	"github.com/gradionhq/margince/backend/internal/platform/database"
 )
 
-// reconcileChannelProviders inserts an activity_kind row and a matching
-// channel_provider row (transport='core') for every name in providers not
-// already present, then sets both packages' in-memory snapshots to exactly
-// the composed set passed in.
+// reconcileChannelProviders inserts a channel_provider row (transport='core')
+// for every name in providers not already present, then sets both packages'
+// in-memory snapshots to exactly the composed set passed in.
 //
 // It runs over database.WithInfraTx, not the workspace-bound database.DB.Tx:
 // activity_kind and channel_provider carry no workspace_id, so binding a
@@ -37,12 +41,10 @@ import (
 // with no organization bootstrapped yet, which is exactly when a process
 // first constructs this registry.
 //
-// activity_kind is inserted FIRST, in the same transaction: channel_provider
-// FKs into it, so a provider this binary just compiled in but that the core
-// migration's fixed seed never anticipated (a future core channel connector
-// beyond telegram) would otherwise fail this very insert with a foreign-key
-// violation — the exact deployment fact this reconcile exists to establish,
-// self-inflicted.
+// A provider name has to satisfy channel_provider's own grammar constraint,
+// which is where an unusable name is refused — not here. The alternative, a
+// check in Go beside the insert, would be a second spelling of the rule that
+// could disagree with the column's.
 //
 // It never DELETEs. A provider whose supplier is gone on a later boot keeps
 // its row — activity and person_channel_identity rows still reference it, the
@@ -51,11 +53,6 @@ import (
 func reconcileChannelProviders(ctx context.Context, pool *pgxpool.Pool, providers []string) error {
 	err := database.WithInfraTx(ctx, pool, func(tx pgx.Tx) error {
 		for _, provider := range providers {
-			if _, err := tx.Exec(ctx, `
-				INSERT INTO activity_kind (kind) VALUES ($1)
-				ON CONFLICT (kind) DO NOTHING`, provider); err != nil {
-				return err
-			}
 			if _, err := tx.Exec(ctx, `
 				INSERT INTO channel_provider (provider, transport) VALUES ($1, 'core')
 				ON CONFLICT (provider) DO NOTHING`, provider); err != nil {

--- a/backend/internal/compose/channelprovider_axis_integration_test.go
+++ b/backend/internal/compose/channelprovider_axis_integration_test.go
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package compose
+
+// The transport axis is separate from the interaction axis, asserted against the
+// schema rather than against anyone's memory of it. The behavioural halves live
+// where the behaviour is — the send path's refusal in
+// internal/modules/activities, the boot reconcile's in
+// channelprovider_integration_test.go — and what is left here is the shape those
+// depend on.
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgconn"
+
+	"github.com/gradionhq/margince/backend/internal/compose/integration"
+)
+
+// A provider is a transport and names no interaction kind, so channel_provider
+// must not reference activity_kind. The FK it originally shipped with asserted
+// the opposite, and it is the reason boot had to mint an activity_kind row per
+// provider — which would silently restore whatever a kind-narrowing migration
+// removed, on the next boot.
+//
+// Introspection rather than a behavioural probe because the failure this guards
+// is a RE-ADD: an FK restored by a later migration breaks nothing until an
+// extension registers a provider that is not also a kind, which is far too late
+// to learn it.
+func TestChannelProviderDoesNotReferenceActivityKind(t *testing.T) {
+	integration.Setup(t) // triggers EnsureSchema — the migrations this test asserts on
+	owner := integration.OwnerConn(t)
+
+	var referenced []string
+	rows, err := owner.Query(context.Background(), `
+		SELECT confrelid::regclass::text
+		FROM pg_constraint
+		WHERE conrelid = 'channel_provider'::regclass AND contype = 'f'`)
+	if err != nil {
+		t.Fatalf("querying channel_provider's foreign keys: %v", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var target string
+		if err := rows.Scan(&target); err != nil {
+			t.Fatalf("scanning a foreign key row: %v", err)
+		}
+		referenced = append(referenced, target)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("reading channel_provider's foreign keys: %v", err)
+	}
+
+	for _, target := range referenced {
+		if target == "activity_kind" {
+			t.Fatal("channel_provider references activity_kind again — that FK asserts every transport is also an interaction kind, " +
+				"which refuses any provider that names no kind, and forces boot to mint kind rows a narrowing migration would then have to remove twice")
+		}
+	}
+}
+
+// activity.channel_provider is the transport, and it must FK into the registry:
+// the column's whole claim is that it names a provider this installation has,
+// and without the reference it is a free-text field that agrees with the
+// registry only for as long as every writer happens to.
+func TestActivityChannelProviderReferencesTheRegistry(t *testing.T) {
+	integration.Setup(t)
+	owner := integration.OwnerConn(t)
+
+	var target string
+	if err := owner.QueryRow(context.Background(), `
+		SELECT confrelid::regclass::text
+		FROM pg_constraint
+		WHERE conrelid = 'activity'::regclass AND contype = 'f'
+		  AND conkey = ARRAY[(SELECT attnum FROM pg_attribute
+		                      WHERE attrelid = 'activity'::regclass AND attname = 'channel_provider')]`).Scan(&target); err != nil {
+		t.Fatalf("activity.channel_provider has no foreign key: %v", err)
+	}
+	if target != "channel_provider" {
+		t.Fatalf("activity.channel_provider references %q, want channel_provider", target)
+	}
+}
+
+// The registry refuses an unregistered transport on the activity itself, which is
+// the guarantee the send path's read depends on: a provider read back off a row
+// is a provider this installation actually composed.
+//
+// The provider name is one no unit could ever be called, deliberately: naming a
+// real extension here would make the test pass or fail on whether that unit
+// happens to be composed, which is a different question from the one it asks.
+func TestActivityChannelProviderFKRefusesAnUnregisteredProvider(t *testing.T) {
+	e := integration.Setup(t)
+
+	_, err := integration.OwnerConn(t).Exec(context.Background(), `
+		INSERT INTO activity (workspace_id, kind, channel_provider, source, captured_by)
+		VALUES ($1, 'note', 'no_such_transport', 'manual', 'test')`, e.WS)
+	var pgErr *pgconn.PgError
+	if !errors.As(err, &pgErr) || pgErr.ConstraintName != "activity_channel_provider_fkey" {
+		t.Fatalf("insert failed with %v, want a foreign_key_violation on activity_channel_provider_fkey specifically — "+
+			"any other failure (a bad column, a grammar refusal) would pass this test for the wrong reason", err)
+	}
+}

--- a/backend/internal/compose/channelprovider_integration_test.go
+++ b/backend/internal/compose/channelprovider_integration_test.go
@@ -27,46 +27,86 @@ func TestReconcileChannelProvidersInsertsAnUnseenProvider(t *testing.T) {
 	// set, and a later test in this process must not see it.
 	defer activities.SetChannelProviders([]string{capture.ProviderTelegram})
 	defer comms.SetChannelProviders([]string{capture.ProviderTelegram})
+	// Deleting the channel_provider row keeps the shared test database tidy for
+	// the tests that follow. The activity_kind row is deliberately NOT cleaned
+	// up: nothing should have written one, and the assertion below is what says
+	// so — a defensive delete here would tidy away the evidence of a regression.
 	t.Cleanup(func() {
-		if _, err := owner.Exec(context.Background(), `DELETE FROM channel_provider WHERE provider = 'fake-core-channel'`); err != nil {
+		if _, err := owner.Exec(context.Background(), `DELETE FROM channel_provider WHERE provider = 'fake_core_channel'`); err != nil {
 			t.Errorf("cleaning up channel_provider: %v", err)
-		}
-		if _, err := owner.Exec(context.Background(), `DELETE FROM activity_kind WHERE kind = 'fake-core-channel'`); err != nil {
-			t.Errorf("cleaning up activity_kind: %v", err)
 		}
 	})
 
-	// telegram is already seeded by migration 0240; assert the reconcile is a
-	// no-op for it and does insert BOTH the activity_kind and channel_provider
-	// rows for a genuinely new one — standing in for "core ships a second
-	// channel connector" without adding one.
-	if err := reconcileChannelProviders(ctx, e.Pool, []string{"telegram", "fake-core-channel"}); err != nil {
+	// telegram is already seeded by the core migration; assert the reconcile is
+	// a no-op for it and inserts a genuinely new one — standing in for "core
+	// ships a second channel connector" without adding one.
+	if err := reconcileChannelProviders(ctx, e.Pool, []string{"telegram", "fake_core_channel"}); err != nil {
 		t.Fatalf("reconcileChannelProviders: %v", err)
-	}
-
-	var kindExists bool
-	if err := owner.QueryRow(ctx,
-		`SELECT EXISTS(SELECT 1 FROM activity_kind WHERE kind = 'fake-core-channel')`).Scan(&kindExists); err != nil {
-		t.Fatalf("querying activity_kind: %v", err)
-	}
-	if !kindExists {
-		t.Fatal("reconcileChannelProviders did not insert the activity_kind row a new provider needs before channel_provider can FK into it")
 	}
 
 	var transport string
 	if err := owner.QueryRow(ctx,
-		`SELECT transport FROM channel_provider WHERE provider = 'fake-core-channel'`).Scan(&transport); err != nil {
+		`SELECT transport FROM channel_provider WHERE provider = 'fake_core_channel'`).Scan(&transport); err != nil {
 		t.Fatalf("querying the inserted row: %v", err)
 	}
 	if transport != "core" {
 		t.Fatalf("transport = %q, want core", transport)
 	}
 
+	// The mirror, and the point of the whole reconcile change: registering a
+	// transport must NOT mint an interaction kind. A provider says how a message
+	// travelled; an activity kind says what sort of interaction it was. While
+	// those two shared a vocabulary, boot had to insert an activity_kind row for
+	// every provider just to satisfy a foreign key — and the moment the kind
+	// vocabulary narrows to its semantic members, that insert would put back
+	// exactly the rows the narrowing removed, on the next boot, for as long as
+	// nobody noticed.
+	var kindExists bool
+	if err := owner.QueryRow(ctx,
+		`SELECT EXISTS(SELECT 1 FROM activity_kind WHERE kind = 'fake_core_channel')`).Scan(&kindExists); err != nil {
+		t.Fatalf("querying activity_kind: %v", err)
+	}
+	if kindExists {
+		t.Fatal("reconcileChannelProviders minted an activity_kind row for a provider — a transport is not an interaction kind, " +
+			"and a boot that keeps inserting these will silently restore whatever the kind-narrowing migration removes")
+	}
+
 	// Idempotent: calling it again with the SAME set changes nothing and
 	// errors on nothing — a role that constructs the registry twice (the
 	// worker's one-shot backfill helper does) must not fail its second call.
-	if err := reconcileChannelProviders(ctx, e.Pool, []string{"telegram", "fake-core-channel"}); err != nil {
+	if err := reconcileChannelProviders(ctx, e.Pool, []string{"telegram", "fake_core_channel"}); err != nil {
 		t.Fatalf("reconcileChannelProviders, second call: %v", err)
+	}
+}
+
+// A provider name the registry's own grammar refuses fails the reconcile
+// loudly, rather than being skipped into a half-composed installation. The
+// grammar lives on the column itself — the channel_provider_provider_grammar
+// constraint — so this is also the proof that boot keeps no second, disagreeing
+// spelling of the rule.
+func TestReconcileChannelProvidersRefusesAProviderNameTheGrammarRejects(t *testing.T) {
+	e := integration.Setup(t)
+	ctx := context.Background()
+	defer activities.SetChannelProviders([]string{capture.ProviderTelegram})
+	defer comms.SetChannelProviders([]string{capture.ProviderTelegram})
+
+	// Hyphens and capitals are both outside ^[a-z][a-z0-9_]*$ — and this exact
+	// spelling was a test fixture in this file before the grammar existed, which
+	// is how a name no installation could ever register got used as the stand-in
+	// for one that could.
+	err := reconcileChannelProviders(ctx, e.Pool, []string{"fake-core-channel"})
+	if err == nil {
+		t.Fatal("reconcileChannelProviders accepted a provider name the channel_provider grammar refuses; " +
+			"a name that cannot be stored must fail at boot, not become a provider the registry silently lacks")
+	}
+
+	var exists bool
+	if qErr := integration.OwnerConn(t).QueryRow(ctx,
+		`SELECT EXISTS(SELECT 1 FROM channel_provider WHERE provider = 'fake-core-channel')`).Scan(&exists); qErr != nil {
+		t.Fatalf("querying channel_provider: %v", qErr)
+	}
+	if exists {
+		t.Fatal("the refused provider was stored anyway")
 	}
 }
 

--- a/backend/internal/compose/datasweep.go
+++ b/backend/internal/compose/datasweep.go
@@ -53,13 +53,13 @@ var preservedResetTables = map[string]bool{
 	// installation configuration and secrets
 	"setting": true, "vault_secret": true, "ai_call_config": true,
 	"embed_store_binding": true,
-	// The derived channel-provider registry (DESIGN-SP4 §4): installation-global
-	// reference data, not this workspace's records, on the SAME footing as
-	// `setting` above — a reset that cleared it would leave the installation
-	// unable to recognise the connectors it has compiled in, and (for
-	// channel_provider specifically) the sweep's unconditional, non-tenant-scoped
-	// DELETE would hit the activity_kind_fkey/channel_provider_provider_fkey
-	// constraints and abort the whole sweep transaction outright.
+	// The derived channel-provider registry: installation-global reference data,
+	// not this workspace's records, on the SAME footing as `setting` above — a
+	// reset that cleared it would leave the installation unable to recognise the
+	// connectors it has compiled in, and the sweep's unconditional,
+	// non-tenant-scoped DELETE would hit the activity_kind_fkey and
+	// activity_channel_provider_fkey constraints and abort the whole sweep
+	// transaction outright.
 	"activity_kind": true, "channel_provider": true,
 	// in-flight delivery: drained by the outbox pass, not deleted under it
 	"event_outbox": true,

--- a/backend/internal/compose/extingress.go
+++ b/backend/internal/compose/extingress.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"log/slog"
 
+	"github.com/gradionhq/margince/backend/internal/modules/activities"
 	"github.com/gradionhq/margince/backend/internal/modules/capture"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
@@ -182,11 +183,23 @@ func (r *callRuntime) normalized(rec extension.Record) connector.NormalizedRecor
 		EntityType: datasource.EntityActivity,
 		NaturalKey: r.naturalKey(rec),
 		Fields: capture.ActivityFields{
-			Kind:       rec.Activity.Kind,
-			Subject:    rec.Activity.Subject,
-			Body:       rec.Activity.Body,
-			OccurredAt: rec.Activity.OccurredAt,
-			Direction:  rec.Activity.Direction,
+			Kind: rec.Activity.Kind,
+			// A unit landing a kind that IS a registered transport is landing a
+			// channel record, and the row records the transport. Without this a
+			// unit could write a channel-looking activity carrying no transport —
+			// repliable by the kind test the agent surface still applies, and
+			// refused by the send path, which reads the column.
+			//
+			// A unit supplies no transport of its own yet, so this only ever fires
+			// for a kind that names a CORE connector, which a unit has no business
+			// claiming. The slice that gives a unit a declared channel is the one
+			// that turns this into a refusal — a unit may land its own provider and
+			// no other — rather than a normalization.
+			ChannelProvider: activities.ChannelProviderForKind(rec.Activity.Kind),
+			Subject:         rec.Activity.Subject,
+			Body:            rec.Activity.Body,
+			OccurredAt:      rec.Activity.OccurredAt,
+			Direction:       rec.Activity.Direction,
 		},
 		Source:     r.sourceSystem(rec.System),
 		CapturedBy: ingressPrincipalPrefix + r.unit,

--- a/backend/internal/compose/extingressdrift_test.go
+++ b/backend/internal/compose/extingressdrift_test.go
@@ -75,6 +75,18 @@ func TestThePublishedRecordMirrorsTheCaptureEnvelope(t *testing.T) {
 	waivedEnvelopeFields.AssertAllMatched(t)
 }
 
+// waivedActivityFields are the core activity shape's fields a unit deliberately
+// cannot state. The bar is higher here than on the envelope: the envelope's
+// waivers are mostly "core stamps it", whereas an unpublished field on THIS
+// shape means a unit's message carries the zero value for something the timeline
+// stores — so the reason has to say why that zero value is the right answer, not
+// merely why the unit is not asked.
+var waivedActivityFields = gatekit.Waive(map[string]string{
+	"ChannelProvider": "the messaging transport a record arrived on, and a reference into the channel_provider registry. " +
+		"A unit supplies no channel transport, so it has no provider to name and the empty value is the accurate answer rather than a dropped one — " +
+		"the same reason Counterparty.ChannelIdentity is waived below. A unit that does supply one publishes this alongside the declaration that makes it true",
+})
+
 // TestThePublishedActivityMirrorsTheCoreOne is the same rule one level in. The
 // activity shape is the payload the sink switches on, and a field added there
 // is one a unit's captured message would silently never carry.
@@ -86,10 +98,12 @@ func TestThePublishedActivityMirrorsTheCoreOne(t *testing.T) {
 	}
 	for i := range core.NumField() {
 		field := core.Field(i)
-		if !published[field.Name] {
-			t.Errorf("capture.ActivityFields.%s is not on extension.ActivityFields — a unit cannot state it, so every ingested activity takes the zero value", field.Name)
+		if !published[field.Name] && !waivedActivityFields.Waived(t, field.Name) {
+			t.Errorf("capture.ActivityFields.%s is not on extension.ActivityFields — a unit cannot state it, so every ingested activity takes the zero value. "+
+				"Publish it, or waive it in this file with the reason the zero value is correct", field.Name)
 		}
 	}
+	waivedActivityFields.AssertAllMatched(t)
 	// And the other way, which is the failure mode the mirror alone misses: a
 	// published field the port has nothing to map onto is a promise to a unit
 	// that the core drops on the floor.
@@ -105,7 +119,7 @@ func TestThePublishedActivityMirrorsTheCoreOne(t *testing.T) {
 // counterparty, where the interesting fields are the ones a unit must NOT be
 // able to state.
 var waivedCounterpartyFields = gatekit.Waive(map[string]string{
-	"ChannelIdentity": "keys person_channel_identity, whose provider vocabulary is a core CHECK — a unit reaching it would be an extension name entering a closed set",
+	"ChannelIdentity": "keys person_channel_identity, whose provider vocabulary is a foreign key into the channel_provider registry — a unit reaching it would be naming a transport it does not supply",
 	"ListUnsubscribe": "the bulk-mail corroboration a mail connector reads off an RFC 2369 header. A chat record has no such header, and a unit asserting one would be evidence for a suppression decision that nothing produced",
 })
 

--- a/backend/internal/compose/integration/channels/telegram_ingress_integration_test.go
+++ b/backend/internal/compose/integration/channels/telegram_ingress_integration_test.go
@@ -49,17 +49,29 @@ const captureLatencyBudget = 60 * time.Second
 // under its chat-scoped natural key, and the person the ensure linked it to.
 // Both must exist — an activity with no link is the connector's own retry
 // marker, not a captured conversation.
+//
+// It also asserts the transport landed on the row. That check lives HERE, in the
+// shared read-back, rather than in a case of its own: every test that reads a
+// captured message then proves the invariant, so a writer that stops recording
+// the provider fails wherever it is exercised instead of only where somebody
+// remembered to look. A message whose transport is missing is a message the reply
+// path will refuse — a conversation the rep can read and cannot answer.
 func (c *telegramEnv) capturedMessage(t *testing.T, u telegramUpdate) (activityID, personID string) {
 	t.Helper()
+	var provider string
 	if err := apptest.InWorkspace(c.AppEnv, t, c.Slug, func(tx pgx.Tx) error {
 		return tx.QueryRow(context.Background(), `
-			SELECT a.id::text, l.person_id::text
+			SELECT a.id::text, l.person_id::text, coalesce(a.channel_provider, '')
 			  FROM activity a
 			  JOIN activity_link l ON l.activity_id = a.id AND l.entity_type = 'person'
 			 WHERE a.source_system = 'telegram' AND a.source_id = $1`, u.naturalKey()).
-			Scan(&activityID, &personID)
+			Scan(&activityID, &personID, &provider)
 	}); err != nil {
 		t.Fatalf("reading back the captured message %s: %v", u.naturalKey(), err)
+	}
+	if provider != "telegram" {
+		t.Fatalf("captured message %s landed with channel_provider %q, want telegram — the ingest is not recording which transport carried it, "+
+			"so the reply path has nothing to resolve and every answer on this conversation is refused", u.naturalKey(), provider)
 	}
 	return activityID, personID
 }

--- a/backend/internal/compose/integration/channelsend_integration_test.go
+++ b/backend/internal/compose/integration/channelsend_integration_test.go
@@ -114,15 +114,17 @@ func (c *channelSendEnv) bindIdentity(t *testing.T) {
 
 // seedInboundMessage writes the conversation being answered: an inbound telegram
 // activity filed under the chat's thread key and linked to the person, which is
-// the shape capture leaves behind.
+// the shape capture leaves behind — including the TRANSPORT that carried it. The
+// reply path resolves the provider from that column, so an anchor seeded without
+// it is not a channel conversation and every reply on it is refused.
 func (c *channelSendEnv) seedInboundMessage(t *testing.T) {
 	t.Helper()
 	if err := apptest.InWorkspace(c.AppEnv, t, c.Slug, func(tx pgx.Tx) error {
 		ctx := context.Background()
 		if err := tx.QueryRow(ctx, `
-			INSERT INTO activity (workspace_id, kind, body, occurred_at, direction,
+			INSERT INTO activity (workspace_id, kind, channel_provider, body, occurred_at, direction,
 			                      source_system, source_id, source, captured_by, thread_key)
-			VALUES ($1, 'telegram', 'Is this still available?', now(), 'inbound',
+			VALUES ($1, 'telegram', 'telegram', 'Is this still available?', now(), 'inbound',
 			        'telegram', '8100:770011:5', 'telegram:8100:770011:5', 'connector:telegram', $2)
 			RETURNING id`, c.ws, channelSendThreadKey).Scan(&c.activityID); err != nil {
 			return err

--- a/backend/internal/compose/telegramingest.go
+++ b/backend/internal/compose/telegramingest.go
@@ -187,7 +187,8 @@ func (w *telegramIngestWorker) captureRecords(actorCtx context.Context, records 
 			return fmt.Errorf("telegram_ingest: normalized record carries %T, want telegram.ActivityFields", rec.Fields)
 		}
 		rec.Fields = capture.ActivityFields{
-			Kind: fields.Kind, Body: fields.Body, OccurredAt: fields.OccurredAt, Direction: fields.Direction,
+			Kind: fields.Kind, ChannelProvider: fields.ChannelProvider,
+			Body: fields.Body, OccurredAt: fields.OccurredAt, Direction: fields.Direction,
 		}
 		if _, err := w.sink.Upsert(actorCtx, rec); err != nil {
 			if errors.Is(err, connector.ErrSkip) {

--- a/backend/internal/modules/activities/activity.go
+++ b/backend/internal/modules/activities/activity.go
@@ -34,17 +34,24 @@ func activityCapturedPayload(kind string) crmcontracts.PublicEventActivityCaptur
 }
 
 type LogActivityInput struct {
-	Kind         string
-	Subject      *string
-	Body         *string
-	OccurredAt   *time.Time
-	Direction    *string
-	DueAt        *time.Time
-	RemindAt     *time.Time
-	AssigneeID   *ids.UserID
-	HostUserID   *ids.UserID
-	SourceSystem *string
-	SourceID     *string
+	Kind string
+	// ChannelProvider names the messaging transport that carried this activity —
+	// a channel_provider row — and is empty for anything that did not travel on
+	// one. Separate from Kind because they answer separate questions: what sort
+	// of interaction happened, versus how it travelled. Only the outbound
+	// channel reply sets it today; a hand-logged activity has no transport to
+	// name, and there is no request field for one.
+	ChannelProvider string
+	Subject         *string
+	Body            *string
+	OccurredAt      *time.Time
+	Direction       *string
+	DueAt           *time.Time
+	RemindAt        *time.Time
+	AssigneeID      *ids.UserID
+	HostUserID      *ids.UserID
+	SourceSystem    *string
+	SourceID        *string
 	// ThreadKey files this activity under a conversation. Empty stores NULL.
 	// It is written at insert time or not at all: the (source_system,
 	// source_id) upsert both capture and this path key on does nothing when
@@ -118,12 +125,14 @@ func logActivityInTx(ctx context.Context, tx pgx.Tx, in LogActivityInput) (crmco
 
 	id := ids.New[ids.ActivityKind]()
 	_, err = tx.Exec(ctx,
-		`INSERT INTO activity (id, workspace_id, kind, subject, body, occurred_at, direction,
+		`INSERT INTO activity (id, workspace_id, kind, channel_provider, subject, body, occurred_at, direction,
 		                       due_at, remind_at, assignee_id, host_user_id, source_system, source_id, source, captured_by,
 		                       thread_key, counterparty_email, counterparty_outbound_attested)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, NULLIF($16, ''),
-		         NULLIF($17, ''), $18)`,
-		id, wsID, in.Kind, in.Subject, in.Body, occurredAt, in.Direction,
+		 VALUES ($1, $2, $3, NULLIF($4, ''), $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, NULLIF($17, ''),
+		         NULLIF($18, ''), $19)`,
+		// NULLIF on channel_provider: the column FKs into channel_provider, and
+		// '' names no provider, so anything without a transport stores NULL.
+		id, wsID, in.Kind, in.ChannelProvider, in.Subject, in.Body, occurredAt, in.Direction,
 		in.DueAt, in.RemindAt, in.AssigneeID, in.HostUserID, in.SourceSystem, in.SourceID, in.Source, by,
 		in.ThreadKey, in.CounterpartyEmail, in.CounterpartyOutboundAttested)
 	if err != nil {

--- a/backend/internal/modules/activities/channelsend.go
+++ b/backend/internal/modules/activities/channelsend.go
@@ -72,6 +72,28 @@ func SetChannelProviders(providers []string) {
 	channelProvidersMu.Unlock()
 }
 
+// ChannelProviderForKind answers which transport a caller naming this kind is
+// naming, and empty when the kind names none.
+//
+// It exists because the two vocabularies still overlap: while a channel is spelled
+// the same as a kind, a caller who says `kind: "telegram"` is stating a transport
+// and has no other field to state it in. Recording it at the write is what keeps a
+// hand-logged channel activity repliable, and what keeps every channel row's
+// transport non-NULL — the invariant the kind-narrowing slice's CHECK will depend
+// on already being true.
+//
+// Exported because the extension-ingress bridge in the composition root has the
+// same input shape to translate, and one spelling of this rule is the point.
+//
+// It disappears with that slice: once the contract carries a provider of its own,
+// the caller says it directly and nothing infers it.
+func ChannelProviderForKind(kind string) string {
+	if IsChannelKind(kind) {
+		return kind
+	}
+	return ""
+}
+
 // IsChannelKind reports whether an activity kind names a messaging-channel
 // conversation this module can answer.
 //
@@ -257,9 +279,21 @@ func (s *Store) SendMessage(ctx context.Context, anchorID ids.ActivityID, in Sen
 	if strings.TrimSpace(in.Body) == "" {
 		return crmcontracts.Activity{}, errEmptyMessageBody
 	}
-	provider := string(anchor.Kind)
-	if !IsChannelKind(provider) {
-		return crmcontracts.Activity{}, &NotAChannelConversationError{Kind: provider}
+	// The transport is READ, not recovered by reading the anchor's kind back as a
+	// provider name. Those are two vocabularies that coincide for every channel
+	// shipped so far, and the coincidence is not a rule: a transport that names
+	// no interaction kind makes the old derivation answer "not a channel
+	// conversation" for a conversation that plainly is one. An empty provider is
+	// the anchor saying it never travelled on a channel.
+	provider, err := s.channelProviderOf(ctx, anchorID)
+	if err != nil {
+		return crmcontracts.Activity{}, err
+	}
+	if provider == "" {
+		// Reported by the anchor's KIND, which is what a rep recognises — being
+		// told "a note is not a messaging-channel conversation" names the mistake,
+		// where an empty provider would name the storage.
+		return crmcontracts.Activity{}, &NotAChannelConversationError{Kind: string(anchor.Kind)}
 	}
 	// The bot binding is the workspace's, and its absence is knowable now: a
 	// send accepted without one can only park where the rep never sees it.
@@ -311,16 +345,31 @@ type channelConversation struct {
 	recipient connector.ChannelIdentity
 }
 
-// resolveConversation resolves both, in one read transaction, and refuses rather
-// than guessing when the conversation does not reach exactly one account.
+// channelProviderOf reads which messaging transport carried an activity, and
+// returns empty when it carried none.
 //
-// Reachability is checked HERE and not again inside the write transaction, which
-// is deliberate and bounded: a block that lands between this read and the commit
-// leaves a staged message the provider itself refuses — Telegram answers a
-// definite error for a chat that blocked the bot, so the delivery fails visibly
-// instead of arriving. That is the same fail-fast split the consent gate makes,
-// where transmission-time is the authority and the request-time check exists to
-// answer the rep while they are still looking at the screen.
+// It is a read of a record, so it carries the row-scope gate for the reason
+// resolveConversation states below: an out-of-scope anchor reads as ErrNotFound,
+// the same answer a missing one gives, so the send path cannot become an
+// existence oracle for activities the caller may not see.
+func (s *Store) channelProviderOf(ctx context.Context, anchorID ids.ActivityID) (string, error) {
+	var provider string
+	err := s.tx(ctx, func(tx pgx.Tx) error {
+		if err := auth.EnsureActivityVisible(ctx, tx, anchorID.UUID); err != nil {
+			return err
+		}
+		if err := tx.QueryRow(ctx,
+			`SELECT coalesce(channel_provider, '') FROM activity WHERE id = $1`, anchorID).Scan(&provider); err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return apperrors.ErrNotFound
+			}
+			return err
+		}
+		return nil
+	})
+	return provider, err
+}
+
 func (s *Store) resolveConversation(ctx context.Context, anchorID ids.ActivityID, provider string) (channelConversation, error) {
 	var out channelConversation
 	err := s.tx(ctx, func(tx pgx.Tx) error {
@@ -404,11 +453,18 @@ type outboundChannelMessage struct {
 func (m outboundChannelMessage) activity() LogActivityInput {
 	direction := "outbound"
 	return LogActivityInput{
-		Kind:      m.provider,
-		Body:      &m.in.Body,
-		Direction: &direction,
-		Links:     m.links,
-		Source:    sourceManual,
+		// Kind and ChannelProvider are both the provider here only because every
+		// channel this path can reach today is spelled the same in both
+		// vocabularies. ChannelProvider is the one the NEXT send resolves from;
+		// Kind is what the timeline calls it. Capture's reply-match still reads
+		// kind — moving it is the kind-narrowing slice's work, because until then
+		// kind is what separates a channel thread from a mail one.
+		Kind:            m.provider,
+		ChannelProvider: m.provider,
+		Body:            &m.in.Body,
+		Direction:       &direction,
+		Links:           m.links,
+		Source:          sourceManual,
 		// The same conversation the anchor is filed under: capture's
 		// reply-detection joins an inbound message against outbound activities
 		// on this key, so a reply filed anywhere else is a reply that

--- a/backend/internal/modules/activities/channelsend_integration_test.go
+++ b/backend/internal/modules/activities/channelsend_integration_test.go
@@ -75,17 +75,31 @@ func (e *sendEnv) channelStore(reach ChannelReachability) *Store {
 
 // seedChannelAnchor writes the captured conversation being answered: an inbound
 // telegram activity filed under the chat, as the table owner — the shape ingress
-// leaves behind.
-func (e *sendEnv) seedChannelAnchor(t *testing.T, kind string) ids.ActivityID {
+// leaves behind, carrying BOTH the kind and the transport that brought it.
+func (e *sendEnv) seedChannelAnchor(t *testing.T) ids.ActivityID {
+	t.Helper()
+	return e.seedAnchorWithTransport(t, "telegram", "telegram")
+}
+
+// seedAnchorWithoutProvider writes an activity that never travelled on a
+// messaging channel: a kind, and no transport. Mail is the honest example, and a
+// channel-shaped KIND with no provider is the interesting one — see
+// TestSendMessageRefusesAChannelKindThatCarriesNoProvider.
+func (e *sendEnv) seedAnchorWithoutProvider(t *testing.T, kind string) ids.ActivityID {
+	t.Helper()
+	return e.seedAnchorWithTransport(t, kind, "")
+}
+
+func (e *sendEnv) seedAnchorWithTransport(t *testing.T, kind, provider string) ids.ActivityID {
 	t.Helper()
 	id := ids.New[ids.ActivityKind]()
 	if _, err := e.owner.Exec(context.Background(), `
-		INSERT INTO activity (id, workspace_id, kind, body, occurred_at, direction,
+		INSERT INTO activity (id, workspace_id, kind, channel_provider, body, occurred_at, direction,
 		                      source_system, source_id, source, captured_by, thread_key)
-		VALUES ($1, $2, $3, 'Is this still available?', now(), 'inbound',
-		        'telegram', $4, 'telegram', 'connector:telegram', $5)`,
-		id, e.ws, kind, "8100:"+testChannelAccount+":"+id.String(), testChannelThreadKey); err != nil {
-		t.Fatalf("seeding the channel anchor: %v", err)
+		VALUES ($1, $2, $3, NULLIF($4, ''), 'Is this still available?', now(), 'inbound',
+		        'telegram', $5, 'telegram', 'connector:telegram', $6)`,
+		id, e.ws, kind, provider, "8100:"+testChannelAccount+":"+id.String(), testChannelThreadKey); err != nil {
+		t.Fatalf("seeding the anchor: %v", err)
 	}
 	return id
 }
@@ -122,7 +136,7 @@ func channelInput() SendMessageInput {
 // message with no chat to deliver into.
 func TestSendMessageRefusesAnAnchorThatIsNotAChannelConversation(t *testing.T) {
 	e := setupSend(t)
-	anchor := e.seedChannelAnchor(t, "email")
+	anchor := e.seedAnchorWithoutProvider(t, "email")
 	person := e.linkPerson(t, anchor, "Mail Buyer")
 	stager := &recordingChannelStager{}
 
@@ -138,13 +152,47 @@ func TestSendMessageRefusesAnAnchorThatIsNotAChannelConversation(t *testing.T) {
 	}
 }
 
+// The transport is read from the anchor's own column and never recovered from its
+// kind. This anchor's kind IS a registered provider's name, so the old derivation
+// — reading the kind back as a provider — would have accepted it and gone on to
+// resolve a recipient for a conversation that no channel ever carried.
+//
+// This case is the gate on that derivation, and it is a behavioural one rather
+// than a search for the old expression: reinstate `provider := string(anchor.Kind)`
+// anywhere on this path and this test fails, whatever the expression is spelled
+// like. It matters most for as long as every provider is ALSO a kind, which is
+// exactly the window in which the two look interchangeable.
+func TestSendMessageRefusesAChannelKindThatCarriesNoProvider(t *testing.T) {
+	e := setupSend(t)
+	anchor := e.seedAnchorWithoutProvider(t, "telegram")
+	person := e.linkPerson(t, anchor, "Chat Buyer")
+	stager := &recordingChannelStager{}
+
+	_, err := e.channelStore(reaches(map[ids.UUID]string{person: testChannelAccount})).SendMessage(
+		e.as(principal.RowScopeAll), anchor, channelInput(), stubConsentGate{}, stager)
+
+	var refusal *NotAChannelConversationError
+	if !errors.As(err, &refusal) {
+		t.Fatalf("reply on a telegram-KIND anchor carrying no provider → %v, want a NotAChannelConversationError; "+
+			"the send path is deriving the transport from the kind again", err)
+	}
+	// Reported by the kind, because that is the word the rep sees on the record —
+	// an empty provider would name the storage instead of the mistake.
+	if refusal.Kind != "telegram" {
+		t.Fatalf("refusal names kind %q, want telegram", refusal.Kind)
+	}
+	if len(stager.staged) != 0 || e.outboundCount(t) != 0 {
+		t.Fatal("a refused reply still staged a delivery or logged an activity")
+	}
+}
+
 // A channel reply addresses one person. When the conversation reaches two, the
 // send path refuses rather than picking: the two accounts are two chats, and a
 // reply delivered to the wrong one messages a customer somewhere they never
 // wrote from.
 func TestSendMessageRefusesWhenTheConversationReachesTwoPeople(t *testing.T) {
 	e := setupSend(t)
-	anchor := e.seedChannelAnchor(t, "telegram")
+	anchor := e.seedChannelAnchor(t)
 	first := e.linkPerson(t, anchor, "First Buyer")
 	second := e.linkPerson(t, anchor, "Second Buyer")
 	stager := &recordingChannelStager{}
@@ -173,7 +221,7 @@ func TestSendMessageRefusesWhenTheConversationReachesTwoPeople(t *testing.T) {
 // conversation is still readable, and the reply must not be accepted.
 func TestSendMessageRefusesWhenTheConversationReachesNobody(t *testing.T) {
 	e := setupSend(t)
-	anchor := e.seedChannelAnchor(t, "telegram")
+	anchor := e.seedChannelAnchor(t)
 	e.linkPerson(t, anchor, "Blocked Buyer")
 	stager := &recordingChannelStager{}
 
@@ -194,7 +242,7 @@ func TestSendMessageRefusesWhenTheConversationReachesNobody(t *testing.T) {
 // suppression silently stops applying to a whole channel.
 func TestSendMessageAsksTheConsentGateAboutTheResolvedRecipient(t *testing.T) {
 	e := setupSend(t)
-	anchor := e.seedChannelAnchor(t, "telegram")
+	anchor := e.seedChannelAnchor(t)
 	person := e.linkPerson(t, anchor, "Telegram Buyer")
 	stager := &recordingChannelStager{}
 	gate := &recordingConsentGate{}
@@ -231,7 +279,7 @@ func TestSendMessageAsksTheConsentGateAboutTheResolvedRecipient(t *testing.T) {
 // mail test kept passing.
 func TestSendMessagePreFlightsTheChannelProviderRatherThanTheMailbox(t *testing.T) {
 	e := setupSend(t)
-	anchor := e.seedChannelAnchor(t, "telegram")
+	anchor := e.seedChannelAnchor(t)
 	person := e.linkPerson(t, anchor, "Telegram Buyer")
 	authority := &stubSendAuthority{capable: true}
 	stager := &recordingChannelStager{}
@@ -251,7 +299,7 @@ func TestSendMessagePreFlightsTheChannelProviderRatherThanTheMailbox(t *testing.
 // 202 for a message that can only park.
 func TestSendMessageRefusesWhenNoBotIsBound(t *testing.T) {
 	e := setupSend(t)
-	anchor := e.seedChannelAnchor(t, "telegram")
+	anchor := e.seedChannelAnchor(t)
 	person := e.linkPerson(t, anchor, "Telegram Buyer")
 	stager := &recordingChannelStager{}
 	gate := &recordingConsentGate{}
@@ -284,7 +332,7 @@ func TestSendMessageRefusesWhenNoBotIsBound(t *testing.T) {
 // they may not read.
 func TestSendMessageAnswersAnUnauthorizedCallerBeforeTheWiringGuards(t *testing.T) {
 	e := setupSend(t)
-	anchor := e.seedChannelAnchor(t, "telegram")
+	anchor := e.seedChannelAnchor(t)
 	e.linkToPersonOwnedBy(t, anchor, e.other)
 
 	// Composed with NO delivery machinery and no identity seam: either wiring
@@ -304,7 +352,7 @@ func TestSendMessageAnswersAnUnauthorizedCallerBeforeTheWiringGuards(t *testing.
 // — the same fail-closed posture the consent gate and the delivery stager take.
 func TestSendMessageRefusesWhenTheIdentitySeamIsUnwired(t *testing.T) {
 	e := setupSend(t)
-	anchor := e.seedChannelAnchor(t, "telegram")
+	anchor := e.seedChannelAnchor(t)
 	e.linkPerson(t, anchor, "Telegram Buyer")
 
 	_, err := e.channelStore(nil).SendMessage(
@@ -323,7 +371,7 @@ func TestSendMessageRefusesWhenTheIdentitySeamIsUnwired(t *testing.T) {
 // on a conversation they have no way to correct.
 func TestSendMessageCommitsNoActivityWhenChannelStagingFails(t *testing.T) {
 	e := setupSend(t)
-	anchor := e.seedChannelAnchor(t, "telegram")
+	anchor := e.seedChannelAnchor(t)
 	person := e.linkPerson(t, anchor, "Telegram Buyer")
 	stager := &recordingChannelStager{err: errors.New("delivery table unavailable")}
 

--- a/backend/internal/modules/activities/mapping.go
+++ b/backend/internal/modules/activities/mapping.go
@@ -117,16 +117,31 @@ func LogActivityInputFrom(req crmcontracts.CreateActivityRequest) (LogActivityIn
 		return LogActivityInput{}, err
 	}
 	in := LogActivityInput{
-		Kind:         string(req.Kind),
-		Subject:      req.Subject,
-		Body:         req.Body,
-		OccurredAt:   req.OccurredAt,
-		DueAt:        req.DueAt,
-		RemindAt:     req.RemindAt,
-		SourceSystem: req.SourceSystem,
-		SourceID:     req.SourceId,
-		Source:       req.Source,
-		AssigneeID:   idArg[ids.UserKind](req.AssigneeId),
+		Kind: string(req.Kind),
+		// A caller naming a kind that IS a registered transport is naming the
+		// transport, and the row records it. The contract has no provider field
+		// yet, so this is the only place that intent can be read — and without it
+		// a hand-logged or agent-logged channel activity would store no transport,
+		// which would make it unrepliable while an identical row written before the
+		// column existed stayed repliable, because the migration backfilled that
+		// one. Same data, different behaviour decided by write date.
+		//
+		// This is a translation of a legacy input shape, not a rule: it holds only
+		// while kind still carries provider names, and it goes away when the
+		// contract gains a provider of its own and kind narrows to the interaction
+		// vocabulary. It is NOT the derivation the send path used to do — that one
+		// read a stored kind back as a provider at reply time, long after any
+		// caller could say what they meant.
+		ChannelProvider: ChannelProviderForKind(string(req.Kind)),
+		Subject:         req.Subject,
+		Body:            req.Body,
+		OccurredAt:      req.OccurredAt,
+		DueAt:           req.DueAt,
+		RemindAt:        req.RemindAt,
+		SourceSystem:    req.SourceSystem,
+		SourceID:        req.SourceId,
+		Source:          req.Source,
+		AssigneeID:      idArg[ids.UserKind](req.AssigneeId),
 	}
 	if req.Direction != nil {
 		d := string(*req.Direction)

--- a/backend/internal/modules/activities/mapping_channelprovider_test.go
+++ b/backend/internal/modules/activities/mapping_channelprovider_test.go
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package activities
+
+// A caller naming a kind that is also a registered transport is naming the
+// transport, and the mapped input records it. Without this, a hand-logged or
+// agent-logged channel activity would store no transport and be unrepliable —
+// while an identical row written before the column existed stayed repliable,
+// because the migration backfilled that one. Same data, different behaviour
+// decided by write date.
+//
+// These are mirrored deliberately: the positive case alone would pass just as
+// well if the mapping recorded the kind as a transport unconditionally, which
+// would put 'note' and 'email' in a column that references the provider registry
+// and fail the foreign key at the insert.
+
+import (
+	"testing"
+
+	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+)
+
+func TestLogActivityInputRecordsTheTransportForAChannelKind(t *testing.T) {
+	// Set explicitly rather than leaning on the package's pre-registry default:
+	// what this asserts is a rule about the REGISTERED set, and a test that only
+	// passes while a particular default happens to be in place is asserting the
+	// default.
+	t.Cleanup(func() { SetChannelProviders([]string{"telegram"}) })
+	SetChannelProviders([]string{"telegram"})
+
+	in, err := LogActivityInputFrom(crmcontracts.CreateActivityRequest{
+		Kind: crmcontracts.CreateActivityRequestKindTelegram,
+	})
+	if err != nil {
+		t.Fatalf("mapping a telegram activity: %v", err)
+	}
+	if in.ChannelProvider != "telegram" {
+		t.Fatalf("ChannelProvider = %q, want telegram — a hand-logged channel activity that records no transport cannot be replied to", in.ChannelProvider)
+	}
+	if in.Kind != "telegram" {
+		t.Fatalf("Kind = %q, want telegram: the transport is recorded ALONGSIDE the kind, never instead of it", in.Kind)
+	}
+}
+
+func TestLogActivityInputRecordsNoTransportForANonChannelKind(t *testing.T) {
+	t.Cleanup(func() { SetChannelProviders([]string{"telegram"}) })
+	SetChannelProviders([]string{"telegram"})
+
+	for _, kind := range []crmcontracts.CreateActivityRequestKind{
+		crmcontracts.CreateActivityRequestKindNote,
+		crmcontracts.CreateActivityRequestKindEmail,
+		crmcontracts.CreateActivityRequestKindMeeting,
+	} {
+		in, err := LogActivityInputFrom(crmcontracts.CreateActivityRequest{Kind: kind})
+		if err != nil {
+			t.Fatalf("mapping a %s activity: %v", kind, err)
+		}
+		if in.ChannelProvider != "" {
+			t.Errorf("kind %s recorded transport %q, want none — the column references the provider registry, "+
+				"so a kind that names no transport must store NULL or fail the foreign key", kind, in.ChannelProvider)
+		}
+	}
+}
+
+// A provider that is not registered in THIS installation is not a transport here,
+// whatever the contract's kind enum still admits. The registry is the authority,
+// so an installation that composes no telegram connector records no telegram
+// transport — and the row is refused by the foreign key rather than pointing at a
+// provider nothing can deliver on.
+func TestLogActivityInputRecordsNoTransportWhenTheProviderIsNotRegistered(t *testing.T) {
+	t.Cleanup(func() { SetChannelProviders([]string{"telegram"}) })
+	SetChannelProviders([]string{})
+
+	in, err := LogActivityInputFrom(crmcontracts.CreateActivityRequest{
+		Kind: crmcontracts.CreateActivityRequestKindTelegram,
+	})
+	if err != nil {
+		t.Fatalf("mapping a telegram activity with no registered providers: %v", err)
+	}
+	if in.ChannelProvider != "" {
+		t.Fatalf("ChannelProvider = %q with an empty registry, want none", in.ChannelProvider)
+	}
+}

--- a/backend/internal/modules/capture/fields.go
+++ b/backend/internal/modules/capture/fields.go
@@ -11,7 +11,20 @@ import "time"
 
 // ActivityFields is a captured interaction bound for the timeline.
 type ActivityFields struct {
-	Kind       string // email | call | meeting | note | whatsapp | telegram
+	Kind string // email | call | meeting | note | whatsapp | telegram
+
+	// ChannelProvider names the messaging transport that carried this record —
+	// a channel_provider row — and is empty for anything that did not arrive on
+	// one (a mail capture, a meeting, a note).
+	//
+	// It is a separate field from Kind because they answer separate questions:
+	// Kind is what sort of interaction happened, ChannelProvider is how it
+	// travelled. They were one column for as long as the only channels were
+	// named as kinds, and the send path recovered the transport by reading a
+	// kind back as a provider name — which stops being possible the moment a
+	// provider that is not also a kind exists.
+	ChannelProvider string
+
 	Subject    string
 	Body       string
 	OccurredAt time.Time

--- a/backend/internal/modules/capture/sink.go
+++ b/backend/internal/modules/capture/sink.go
@@ -326,13 +326,16 @@ func (s *Sink) upsertActivity(ctx context.Context, tx pgx.Tx, rec connector.Norm
 	occurredAt := fields.OccurredAt
 	var id ids.ActivityID
 	err := tx.QueryRow(ctx, `
-		INSERT INTO activity (workspace_id, kind, subject, body, occurred_at, direction, source_system, source_id, source, captured_by, thread_key, counterparty_email, counterparty_outbound_attested, bulk_mail_attested)
+		INSERT INTO activity (workspace_id, kind, channel_provider, subject, body, occurred_at, direction, source_system, source_id, source, captured_by, thread_key, counterparty_email, counterparty_outbound_attested, bulk_mail_attested)
 		VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid,
-		        $1, NULLIF($2, ''), NULLIF($3, ''), $4, NULLIF($5, ''), $6, $7, $8, $9, NULLIF($10, ''), NULLIF($11, ''), $12, $13)
+		        $1, NULLIF($2, ''), NULLIF($3, ''), NULLIF($4, ''), $5, NULLIF($6, ''), $7, $8, $9, $10, NULLIF($11, ''), NULLIF($12, ''), $13, $14)
 		ON CONFLICT (source_system, source_id) WHERE source_system IS NOT NULL AND source_id IS NOT NULL
 		DO NOTHING
 		RETURNING id`,
-		fields.Kind, fields.Subject, fields.Body, occurredAt, fields.Direction,
+		// NULLIF on channel_provider, not the empty string: the column FKs into
+		// channel_provider, and '' names no provider — so a non-channel record
+		// has to store NULL or the insert fails the foreign key.
+		fields.Kind, fields.ChannelProvider, fields.Subject, fields.Body, occurredAt, fields.Direction,
 		rec.NaturalKey.SourceSystem, rec.NaturalKey.SourceID, captureSource(rec), capturedByFor(ctx, rec), rec.ThreadKey,
 		// Normalized lowercased at the write (a connector need not lowercase the
 		// header case), matching the person_email normalization, so the T1

--- a/backend/internal/modules/capture/telegram/normalize.go
+++ b/backend/internal/modules/capture/telegram/normalize.go
@@ -22,17 +22,18 @@ import (
 )
 
 // ActivityFields is the pure Telegram-side mirror of capture.ActivityFields
-// (Kind/Body/OccurredAt/Direction) — a duplicate shape, not an oversight:
-// package capture already imports capture/telegram (channelconn.go's Bot API
-// client for Connect), so this package importing capture back would cycle.
-// The ingest worker (compose, which legitimately imports both) converts this
-// 1:1 into capture.ActivityFields immediately before handing the record to
+// (Kind/ChannelProvider/Body/OccurredAt/Direction) — a duplicate shape, not an
+// oversight: package capture already imports capture/telegram (channelconn.go's
+// Bot API client for Connect), so this package importing capture back would
+// cycle. The ingest worker (compose, which legitimately imports both) converts
+// this 1:1 into capture.ActivityFields immediately before handing the record to
 // the Sink, which is the one place that type actually has to exist.
 type ActivityFields struct {
-	Kind       string
-	Body       string
-	OccurredAt time.Time
-	Direction  string
+	Kind            string
+	ChannelProvider string
+	Body            string
+	OccurredAt      time.Time
+	Direction       string
 }
 
 // Provider is the source_system / NaturalKey namespace every Telegram record
@@ -196,10 +197,17 @@ func Normalize(_ context.Context, raw connector.RawRecord) ([]connector.Normaliz
 		EntityType: datasource.EntityActivity,
 		NaturalKey: connector.NaturalKey{SourceSystem: Provider, SourceID: naturalID},
 		Fields: ActivityFields{
-			Kind:       Provider,
-			Body:       messageBody(msg),
-			OccurredAt: time.Unix(msg.Date, 0).UTC(),
-			Direction:  connector.DirectionInbound,
+			// Kind and ChannelProvider are both Provider here, and that is a
+			// coincidence of this connector rather than a rule: telegram is
+			// spelled the same in the kind vocabulary and the provider registry.
+			// A connector whose provider is not also a kind sets only
+			// ChannelProvider, which is the whole reason the two are separate
+			// fields.
+			Kind:            Provider,
+			ChannelProvider: Provider,
+			Body:            messageBody(msg),
+			OccurredAt:      time.Unix(msg.Date, 0).UTC(),
+			Direction:       connector.DirectionInbound,
 		},
 		Source:     Provider + ":" + naturalID,
 		CapturedBy: CapturedByTelegram,

--- a/backend/migrations/core/0247_activity_channel_provider.down.sql
+++ b/backend/migrations/core/0247_activity_channel_provider.down.sql
@@ -1,0 +1,31 @@
+-- Reversing this DISCARDS which provider carried each message, and that is worth
+-- stating rather than discovering. At THIS migration the fact is still recoverable,
+-- because activity.kind holds the provider name too — the column and the kind agree
+-- for every channel row. It stops being recoverable at the migration that narrows
+-- kind to its semantic members: after that one, dropping this column erases the
+-- only place the transport is recorded, and no down migration can reconstruct it.
+
+ALTER TABLE activity DROP COLUMN channel_provider;
+
+ALTER TABLE channel_provider DROP CONSTRAINT channel_provider_provider_grammar;
+
+-- Restoring the provider->kind FK is the half that can legitimately FAIL, and it
+-- is worth being explicit about rather than letting Postgres report it as a raw
+-- constraint violation on a rollback somebody is already unhappy about.
+--
+-- After the up migration, boot registers a provider WITHOUT minting an
+-- activity_kind row for it — that is the whole point of dropping this FK. So any
+-- installation whose composed set grew a provider beyond the seeded ones now holds
+-- a channel_provider row with no matching kind, and re-adding the FK validates
+-- against exactly that row and refuses.
+--
+-- The kind rows are re-created for precisely those providers first, which is the
+-- state 0240 would have left behind, so the FK can validate. It is additive and
+-- idempotent, and it does not invent a kind for anything the registry does not
+-- already carry.
+INSERT INTO activity_kind (kind)
+SELECT provider FROM channel_provider
+ON CONFLICT (kind) DO NOTHING;
+
+ALTER TABLE channel_provider ADD CONSTRAINT channel_provider_provider_fkey
+  FOREIGN KEY (provider) REFERENCES activity_kind (kind);

--- a/backend/migrations/core/0247_activity_channel_provider.up.sql
+++ b/backend/migrations/core/0247_activity_channel_provider.up.sql
@@ -1,0 +1,59 @@
+-- The transport axis leaves activity.kind (DESIGN-SP5 §1). Which provider carried
+-- a message becomes its own column — a reference into the channel_provider
+-- registry — instead of being recovered by reinterpreting the interaction kind as
+-- a provider name, which is what activities/channelsend.go's
+-- `provider := string(anchor.Kind)` does today.
+--
+-- kind is UNCHANGED here: a channel message still carries 'telegram', and every
+-- reader of kind keeps working. This migration adds the column and populates it so
+-- the writers and readers can move onto it in the same change. Narrowing kind to
+-- its six semantic members is the NEXT slice, and it depends on this column
+-- already being correct for every row.
+
+ALTER TABLE activity ADD COLUMN channel_provider text
+  REFERENCES channel_provider (provider);
+
+-- Populated FROM THE REGISTRY rather than from a literal provider list, and it is
+-- exactly correct today precisely BECAUSE the old model stored the provider in
+-- kind. That equivalence is the whole reason this backfill needs no judgement
+-- about which rows were channel messages.
+UPDATE activity SET channel_provider = kind
+  WHERE kind IN (SELECT provider FROM channel_provider);
+
+-- whatsapp is deliberately NOT touched, and it is NOT asserted absent. It is a
+-- kind the contract admits on POST /v1/activities and that the log_activity agent
+-- tool advertises, so a rep or an agent may already have hand-logged one — an
+-- earlier draft of this migration asserted zero such rows and would have bricked
+-- the deploy of any installation that had. It also buys nothing here: whatsapp has
+-- never been a channel_provider row, so a whatsapp activity was not a channel
+-- conversation before this migration and is not one after. Its NULL
+-- channel_provider is the accurate answer, not a gap.
+--
+-- The kind-narrowing slice is where whatsapp has to be decided, and it has to be
+-- decided by closing or mapping the WRITERS, not by asserting an instant: rows can
+-- keep arriving until they are closed.
+
+-- The registry's own grammar. channel_provider.provider was a bare text primary
+-- key, so the published ProviderRef pattern described a grammar the column did not
+-- enforce. A boot reconcile inserting on behalf of a composed unit is the wrong
+-- place to discover that a provider name is unusable, and the wrong place to
+-- decide it: the column that owns the name owns the rule. 32 characters matches
+-- the cap the extension surface already applies to IngressSource.System.
+ALTER TABLE channel_provider ADD CONSTRAINT channel_provider_provider_grammar
+  CHECK (provider ~ '^[a-z][a-z0-9_]*$' AND char_length(provider) <= 32);
+
+-- channel_provider.provider REFERENCES activity_kind (kind) is the conflation in
+-- schema form: it asserts that every transport is also an interaction kind, which
+-- holds only while provider names live in activity.kind. An extension unit's
+-- provider is a transport and names no interaction kind at all, so the FK would
+-- refuse a legitimate registration. Dropping it here — one slice before the rows
+-- it constrains move — is also what lets the boot reconcile stop inserting an
+-- activity_kind row per provider.
+ALTER TABLE channel_provider DROP CONSTRAINT channel_provider_provider_fkey;
+
+-- No index on the column, deliberately. The send path resolves an anchor's
+-- provider by primary key, and capture's reply-match still selects on
+-- (thread_key, kind) — so nothing queries BY provider yet, and an index with no
+-- reader is weight on every write to the busiest table in the schema. The slice
+-- that moves the reply-match onto this column is the one that should add it,
+-- together with the query that uses it.


### PR DESCRIPTION
## Summary

`activity.kind` has been answering two questions at once: **what sort of interaction happened**
(email, call, meeting, note, task) and **which messaging transport carried it** (telegram). The send
path recovered the second by reading the first back as a provider name:

```go
provider := string(anchor.Kind)   // activities/channelsend.go
```

That equivalence is a coincidence, not a rule. It holds only while every transport is *also* spelled
as a kind, and it makes a transport that names no interaction kind unreachable — the derivation
answers "not a channel conversation" for a conversation that plainly is one.

So the transport becomes its own column: `activity.channel_provider`, referencing the
`channel_provider` registry. Every writer records it, and the send path reads it.

**`kind` is deliberately UNCHANGED.** It still carries `'telegram'`, every reader of it still works,
no contract enum moves, there is no frontend change and no new endpoint. Narrowing `kind` to its six
semantic members is a separate PR that depends on this column already being correct for every row —
which is why the migration backfills it *from the registry* and an integration assertion proves no
channel activity lacks one.

This is slice 1a of `.tmp/ext-core-write-port/DESIGN-SP5-channel-axis.md` (plan:
`PLAN-05-channel-axis.md`). It supersedes `DESIGN-SP4.md`, whose §4 shipped as #1264.

## What is in it

- **Migration `0247_activity_channel_provider`** — the nullable column with its FK into the registry;
  a backfill derived from the registry (`WHERE kind IN (SELECT provider FROM channel_provider)`),
  exact today *precisely because* the old model stored the provider in the kind; and the
  `^[a-z][a-z0-9_]*$` + 32-char grammar CHECK that `ProviderRef` already documented but the column
  never enforced.
- **`channel_provider_provider_fkey` dropped.** `channel_provider.provider REFERENCES
  activity_kind (kind)` is the conflation in schema form — it asserts every transport is also an
  interaction kind, which refuses any provider that names no kind.
- **The boot reconcile stops minting `activity_kind` rows.** It only ever did so to satisfy that FK.
  Left in place, the next boot after the kind-narrowing migration would put the removed rows straight
  back, so that slice's fitness assertion would pass or fail depending on whether a boot had run.
- **The write spine** — `capture.ActivityFields` and `activities.LogActivityInput` gain
  `ChannelProvider`; both INSERTs carry it; telegram's normalizer, the ingest bridge, the outbound
  reply, and the REST/agent mapping all set it.
- **The read side** — `provider := string(anchor.Kind)` is gone, replaced by `channelProviderOf`, a
  narrow row-scope-gated read. An empty provider answers the same `NotAChannelConversationError` as
  before, reported by the anchor's **kind**, because that is the word a rep sees on the record.

## Review

Reviewed by **Fable and Codex** independently, against the diff. Both raised the same central
finding, and it was a real behavioural regression the tests had not caught:

- **Writers could still mint a channel-kind row with a NULL transport.** `POST /v1/activities` and the
  `log_activity` agent tool both accept `kind: "telegram"` (`recordshapes_gen.go:32` advertises it),
  and extension ingress passes a unit-supplied kind through. A row written that way would have been
  unrepliable, while an identical row written *before* this migration stayed repliable because the
  backfill covered it — same data, different behaviour decided by write date. Fixed by recording the
  transport at the write, in the one place REST and the agent surface share
  (`LogActivityInputFrom`) plus the ingress bridge, with mirrored tests.

Fable additionally found, all fixed:

- **The migration could have bricked a deploy.** An earlier draft asserted zero `whatsapp` rows on the
  premise that nothing writes that kind. False — it is contract-valid on `POST /v1/activities` and
  advertised to the agent, so any installation that had ever hand-logged one would fail the migration
  with no repair path. The assertion also bought nothing: `whatsapp` has never been a
  `channel_provider` row, so such an activity was not a channel conversation before this change and
  is not one after. Removed, with the reasoning recorded in the migration.
- **Two comments asserted the opposite of the shipped code**, and the index they justified had no
  reader — the send path resolves by primary key and capture's reply-match still selects on
  `(thread_key, kind)`. Comments corrected and the index dropped; the slice that moves the
  reply-match onto the column is the one that should add it, with the query that uses it.
- **A doc-comment split** — `channelProviderOf` had been inserted between `resolveConversation`'s doc
  block and its function, so godoc would attribute the wrong comment. Moved.
- A stale `datasweep.go` comment naming the dropped FK, and an FK test that asserted only `err != nil`
  while using a real extension unit's name as its "unregistered" provider.

Codex additionally found:

- **A migration-number collision** with `0246_agents_drop_workspace` on `origin/main` (this is the
  third collision this branch has hit — `0244`, `0246`, now settled at `0247`).
- **The down migration restored the provider→kind FK blindly.** Since the reconcile no longer mints
  kind rows, any installation whose composed set grew a provider would fail rollback with a raw
  constraint error. It now re-creates the kind rows for exactly those providers first. Verified by
  reproducing the failing state (a registered provider with no matching kind) and rolling back
  successfully.

## Gates

- `make check-backend` — green (its earlier `contract-breaking-check` failure was purely a stale base;
  `origin/main` had moved).
- `make test-integration` — **OK: integration passed with 0 skips (2440 tests, 40 packages)**.
- `make craft-static` — 0 blocker, 0 major, 0 minor across `backend/`, `extensions/`, `fixtures/`.
- Pre-push hook — craft-static, `rls-store-path`, `no-jurisdiction` all OK.
- **New-code coverage: 92.5%** (99/107 changed statement lines), measured against the merge-base with
  the integration lane's own covdata merged with a unit profile. The 8 uncovered lines are error paths
  in `channelProviderOf`, including a defensive row-scope re-probe that `GetActivity` already refuses
  ahead of — matching `resolveConversation`'s documented re-probe idiom. Reaching them would require
  bypassing the real call order.
- `make e2e-ai-report` — this diff touches no prompt, corpus or tool-schema file, so no certification
  record can be staled by it. (The 17 stale / 7 absent records are pre-existing on `origin/main`.)

## UAT

On a live isolated stack (`DEV_SLUG=sp5axis`, fresh database), through HTTP and psql:

```
1. the migration is applied on this live installation
  PASS activity.channel_provider exists
  PASS channel_provider carries its grammar CHECK
  PASS the provider->kind FK is gone (a transport is not an interaction kind)

2. boot registered the transport and minted NO interaction kind for it
     channel_provider: telegram
     activity_kind:    call,email,meeting,note,task,telegram,whatsapp
  PASS telegram is registered as a transport
  PASS activity_kind is exactly the migration's seed — boot added nothing

3. logging in
  PASS authenticated as the bootstrap admin (session cookie)

4. a hand-logged CHANNEL activity records its transport
     activity 01a0012a-e07e-... -> kind=telegram channel_provider=telegram
  PASS the transport was recorded at the write (this is the reviewed regression, closed)

5. a hand-logged NON-channel activity records no transport
     activity 01a0012a-e116-... -> kind=note channel_provider=<NULL>
  PASS no transport recorded, as a note never travelled on one

6. the send path READS the column: a reply on an anchor with no transport is refused
     POST /v1/activities/01a0012a-e116-.../send-message -> HTTP 422 code=not_a_channel_conversation
     detail: a note activity is not a messaging-channel conversation; reply on the channel the
             conversation was held on
  PASS refused as not a channel conversation, decided by the column
  PASS the refusal names the anchor's kind, so the rep can act on it

RESULT: ALL CHECKS PASSED
```

Script and captured output: `.tmp/ext-core-write-port/uat/uat-sp5-1a.{sh,out}`.
Fresh-install boot recording: `.tmp/ext-core-write-port/uat/sp5-1a-fresh-install-boot-uat.gif`.

**A live Telegram send/receive is NOT part of this UAT** — no bot credentials exist in this
environment, the same limit #1264 recorded. What is proven above is the migration on a real boot, the
reconcile's new behaviour, the write-side recording, and the live refusal path. A real
unit-supplied-transport send is the acceptance test of the slice that builds one.

## Deliberate deviations from the plan, with reasons

- **Capture's reply-match stays on `kind`.** The plan said move it to the provider. Reading the code
  disproved that: `kind = $2` is a **security control**. `thread_key` is one flat namespace holding
  both a channel's `<provider>:<bot>:<chat>` key and a mail thread root, and the mail half is
  *attacker-supplied* (the sender's own `References` root) — the medium match is what stops a forged
  header manufacturing a reply fact against a Telegram conversation. A straight swap also silently
  breaks mail, which has no provider. It moves in the narrowing slice, where it is forced and testable.
- **`activityColumns` does not select the column.** Nothing reads the provider off the contract
  `Activity` shape until that shape has a field for it. Selecting an unconsumed column in the module's
  hottest read would be dead weight.

## Notes

- The behavioural gate on the old derivation is a test, not a grep:
  `TestSendMessageRefusesAChannelKindThatCarriesNoProvider` seeds `kind='telegram'` with a NULL
  provider and requires a refusal. **Mutation-verified** — restoring `provider := string(anchor.Kind)`
  fails it with its own diagnostic.
- The "every channel activity carries a transport" assertion lives *inside* the shared
  `capturedMessage` read-back helper, so every existing telegram ingest test proves it through the
  real writer rather than a hand-inserted row.
- `compose/extingressdrift_test.go` gains a waiver path in its core→published direction, which it did
  not have. Publishing `ChannelProvider` on the extension surface now would put a field there no unit
  can meaningfully set until it has a declared channel; the waiver records why the empty value is the
  accurate answer, and commits a future channel-supplying unit to publishing it.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Records each message’s transport in `activity.channel_provider` and makes the send path read it. Previously the send path derived transport from `activity.kind`; now it refuses replies when `channel_provider` is empty. `kind` is unchanged.

- Adds `activity.channel_provider` referencing `channel_provider`; backfills from the registry (`UPDATE activity SET channel_provider = kind WHERE kind IN (SELECT provider FROM channel_provider)`).
- Drops `channel_provider.provider → activity_kind(kind)` FK; adds `channel_provider` name grammar CHECK (`^[a-z][a-z0-9_]*$`, ≤32 chars).
- Replaces `provider := string(anchor.Kind)` with a row-scoped `channelProviderOf` read; empty provider returns `NotAChannelConversationError` named by the anchor’s kind.
- Writers now record the transport:
  - `activities.LogActivityInput` and `capture.ActivityFields` gain `ChannelProvider`.
  - REST/agent mapping sets it via `activities.ChannelProviderForKind(req.Kind)`.
  - Telegram normalize and compose ingress set `ChannelProvider`; `capture.Sink` inserts it (NULL when empty).
- Boot reconcile stops inserting `activity_kind` rows; it only upserts `channel_provider`.

**Rollout/Migration**
- Run core migration `0247_activity_channel_provider` (adds column, backfills, adds grammar, drops FK). Down migration recreates missing `activity_kind` rows before restoring the FK.
- No API or UI change; `kind` continues to carry channel names until a later narrowing slice.
- Action required only if composed provider names violate the new grammar; rename providers before boot or the reconcile will fail.

<sup>Written for commit c8ee530fe16d6edc3906bf54907fd5be5cf9f203. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1293?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

