### PR TITLE
fix(privacy): a subject-access export carries the mail nobody has sent yet

### DIFF
--- a/backend/internal/compose/integration/scheduledsend_integration_test.go
+++ b/backend/internal/compose/integration/scheduledsend_integration_test.go
@@ -34,6 +34,7 @@ package integration
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"strings"
 	"testing"
@@ -48,6 +49,72 @@ import (
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
+
+// seedConsentedRecipient creates a person with one address and a granted
+// transactional purpose — the minimum a send's consent gate demands of an
+// addressee, spelled once because a multi-recipient fixture needs it per head.
+func (p *preflightEnv) seedConsentedRecipient(t *testing.T, name, email string) {
+	t.Helper()
+	var person struct {
+		ID string `json:"id"`
+	}
+	if status := p.Call(t, "POST", "/v1/people", apptest.AnyMap{
+		"full_name": name,
+		"emails":    []apptest.AnyMap{{"email": email}},
+	}, nil, &person); status != http.StatusCreated {
+		t.Fatalf("create %s → %d", email, status)
+	}
+	var purposes struct {
+		Data []struct {
+			ID  string `json:"id"`
+			Key string `json:"key"`
+		} `json:"data"`
+	}
+	if status := p.Call(t, "GET", "/v1/consent-purposes", nil, nil, &purposes); status != http.StatusOK {
+		t.Fatalf("list purposes → %d", status)
+	}
+	var transactional string
+	for _, purpose := range purposes.Data {
+		if purpose.Key == "transactional" {
+			transactional = purpose.ID
+		}
+	}
+	if transactional == "" {
+		t.Fatalf("bootstrap seeded no transactional purpose: %+v", purposes.Data)
+	}
+	if status := p.Call(t, "POST", "/v1/people/"+person.ID+"/consent", apptest.AnyMap{
+		"purpose_id": transactional, "new_state": "granted", "lawful_basis": "contract",
+	}, nil, nil); status != http.StatusOK {
+		t.Fatalf("grant consent for %s → %d", email, status)
+	}
+}
+
+// privacyAdmin binds the context both privileged privacy paths demand: a HUMAN
+// holding person.delete. Erasure and the subject-access export ask the same
+// trust level on purpose — one destroys the data and the other discloses all of
+// it — so the two tests share one spelling of it rather than each inventing a
+// principal that walks past the gates they are supposed to exercise.
+func (p *preflightEnv) privacyAdmin(t *testing.T) context.Context {
+	t.Helper()
+	ctx := principal.WithWorkspaceID(context.Background(), p.workspaceID(t))
+	ctx = principal.WithCorrelationID(ctx, ids.NewV7())
+	return principal.WithActor(ctx, principal.Principal{
+		Type: principal.PrincipalHuman, ID: "human:" + p.user,
+		UserID:   uuidOf(t, p.user),
+		SeatType: principal.SeatFull,
+		Permissions: principal.Permissions{
+			RoleKeys: []string{"admin"},
+			// The export deliberately crosses the caller's row scope: Art. 15
+			// owes the subject everything held, not the slice one rep can see,
+			// so a bounded caller is refused outright.
+			RowScope: principal.RowScopeAll,
+			Objects: map[string]principal.ObjectGrant{
+				"person":   {Create: true, Read: true, Update: true, Delete: true},
+				"activity": {Create: true, Read: true, Update: true, Delete: true},
+			},
+		},
+	})
+}
 
 // uuidOf parses a harness-held id, failing the test rather than the assertion.
 func uuidOf(t *testing.T, raw string) ids.UUID {
@@ -309,25 +376,8 @@ func TestErasingARecipientEmptiesAndStopsTheirScheduledMail(t *testing.T) {
 	if err != nil {
 		t.Fatalf("person id %q: %v", p.personID, err)
 	}
-	// Run under the bootstrapped admin this harness already signed in, rather
-	// than a synthetic principal: the eraser's own gates are part of what this
-	// asserts, and a hand-built unbounded actor would walk past them.
-	admin := principal.WithActor(
-		principal.WithCorrelationID(principal.WithWorkspaceID(context.Background(), p.workspaceID(t)), ids.NewV7()),
-		principal.Principal{
-			Type: principal.PrincipalHuman, ID: "human:" + p.user,
-			UserID:   uuidOf(t, p.user),
-			SeatType: principal.SeatFull,
-			Permissions: principal.Permissions{
-				RoleKeys: []string{"admin"},
-				Objects: map[string]principal.ObjectGrant{
-					"person":   {Create: true, Read: true, Update: true, Delete: true},
-					"activity": {Create: true, Read: true, Update: true, Delete: true},
-				},
-			},
-		})
 	if err := privacy.NewEraser(compose.InstallationDB(p.Pool)).ErasePerson(
-		admin, personID, "art-17"); err != nil {
+		p.privacyAdmin(t), personID, "art-17"); err != nil {
 		t.Fatalf("erasing the recipient: %v", err)
 	}
 
@@ -352,6 +402,120 @@ func TestErasingARecipientEmptiesAndStopsTheirScheduledMail(t *testing.T) {
 	}
 	if strings.Contains(payload, "Written the night before.") {
 		t.Fatalf("the body of a message to an erased person survives: %s", payload)
+	}
+}
+
+// Art. 15 owes the subject the data held about them, and a message somebody
+// wrote to them and has not sent is data held about them. It reaches the export
+// by a route the sent-message projection cannot take: a scheduled send has no
+// activity and no delivery row, so all three of that query's clauses miss it.
+func TestASubjectAccessExportCarriesTheMailNobodyHasSentYet(t *testing.T) {
+	p := setupPreflight(t)
+	p.connect(t, gmailReadonlyScope, gmailSendScope)
+
+	// Scheduled through the real endpoint, so the row under test is the one the
+	// product writes — payload shape included, which is what the export reads.
+	p.scheduleFor(t, time.Now().Add(6*time.Hour))
+
+	personID, err := ids.Parse(p.personID)
+	if err != nil {
+		t.Fatalf("person id %q: %v", p.personID, err)
+	}
+	pkg, err := privacy.AssembleSAR(
+		p.privacyAdmin(t), compose.InstallationDB(p.Pool), ids.From[ids.PersonKind](personID))
+	if err != nil {
+		t.Fatalf("AssembleSAR: %v", err)
+	}
+
+	if len(pkg.ScheduledMessages) != 1 {
+		t.Fatalf("the export carried %d unsent messages, want the one waiting for this person: %#v",
+			len(pkg.ScheduledMessages), pkg.ScheduledMessages)
+	}
+	row := pkg.ScheduledMessages[0]
+	if subject, _ := row["subject"].(string); subject != "Monday morning" {
+		t.Errorf("the unsent message came back with subject %q, want the one that was scheduled", subject)
+	}
+	if body, _ := row["body"].(string); !strings.Contains(body, "Written the night before") {
+		t.Errorf("the export withheld the body of a message written to this person: %#v", row)
+	}
+	// The state is part of the answer: a subject told a message exists, but not
+	// whether it is still going to arrive, has been told half a fact.
+	if status, _ := row["status"].(string); status != activities.ScheduledStatusScheduled {
+		t.Errorf("the export reported status %q, want %q", status, activities.ScheduledStatusScheduled)
+	}
+}
+
+// The blind-copy rule has two halves that pull opposite ways, and only a
+// message with SEVERAL blind recipients can show both: a bcc'd subject must
+// find their own message in their export, and must not learn who else was
+// blind-copied on it. A projection that satisfied one half would look correct
+// against a single-recipient fixture.
+func TestABlindCopiedSubjectSeesTheirOwnMailAndNobodyElsesAddress(t *testing.T) {
+	p := setupPreflight(t)
+	p.connect(t, gmailReadonlyScope, gmailSendScope)
+
+	// The subject is BLIND-copied; somebody else is the visible addressee, and
+	// a third party shares the blind list with them.
+	//
+	// Both extra addressees need a person on file and a granted purpose,
+	// because consent is owed to EVERY addressee however they were addressed —
+	// the same rule that makes a blind copy a consent question at all. Without
+	// them the send is refused 409 before it can be scheduled, which would say
+	// nothing about the export.
+	//
+	// The other blind address is typed in MIXED CASE on purpose. The send path
+	// removes blind copies from the To line case-insensitively; an export that
+	// compared raw would leave this one sitting in the visible list while the
+	// message itself correctly hid it, and the two derivations of "who is on
+	// the To line" would disagree about the same message.
+	const otherBlind = "Third.Party@Preflight.test"
+	p.seedConsentedRecipient(t, "Visible Addressee", "visible@preflight.test")
+	p.seedConsentedRecipient(t, "Other Blind", otherBlind)
+	var scheduled struct {
+		ID string `json:"id"`
+	}
+	status := p.Call(t, "POST", "/v1/emails", apptest.AnyMap{
+		"subject": "Quiet copy", "body": "You were blind-copied on this.",
+		"to":              []string{"visible@preflight.test"},
+		"bcc":             []string{"buyer@preflight.test", otherBlind},
+		"consent_purpose": "transactional",
+		"links": []apptest.AnyMap{
+			{"entity_type": "person", "entity_id": p.personID},
+		},
+		"scheduled_at": time.Now().Add(6 * time.Hour).UTC().Format(time.RFC3339),
+		"scheduled_tz": "Europe/Berlin",
+	}, nil, &scheduled)
+	if status != http.StatusCreated {
+		t.Fatalf("scheduling a blind-copied message → %d, want 201", status)
+	}
+
+	personID, err := ids.Parse(p.personID)
+	if err != nil {
+		t.Fatalf("person id %q: %v", p.personID, err)
+	}
+	pkg, err := privacy.AssembleSAR(
+		p.privacyAdmin(t), compose.InstallationDB(p.Pool), ids.From[ids.PersonKind](personID))
+	if err != nil {
+		t.Fatalf("AssembleSAR: %v", err)
+	}
+
+	// Found on the blind list: without this the subject is absent from their own
+	// export of a message they were going to receive.
+	if len(pkg.ScheduledMessages) != 1 {
+		t.Fatalf("a blind-copied subject got %d unsent messages, want 1: %#v",
+			len(pkg.ScheduledMessages), pkg.ScheduledMessages)
+	}
+	// …and narrowed to themselves: exporting the whole blind list would hand
+	// this subject a stranger's address, which is what a blind copy exists to
+	// prevent.
+	rendered := fmt.Sprintf("%#v", pkg.ScheduledMessages[0])
+	if !strings.Contains(rendered, "buyer@preflight.test") {
+		t.Errorf("the export withheld the subject's own blind address: %s", rendered)
+	}
+	// Case-insensitive, because the leak this guards against does not care how
+	// the address was typed.
+	if strings.Contains(strings.ToLower(rendered), strings.ToLower(otherBlind)) {
+		t.Errorf("the export disclosed another blind recipient's address to this subject: %s", rendered)
 	}
 }
 

--- a/backend/internal/modules/privacy/sar.go
+++ b/backend/internal/modules/privacy/sar.go
@@ -79,6 +79,12 @@ type SARPackage struct {
 	// The governed outbound messages addressed to the subject: what was sent
 	// to them, when, and whether it left (comms_outbound).
 	SentMessages []map[string]any `json:"sent_messages"`
+	// The messages addressed to the subject that have NOT been sent: waiting
+	// for their moment, withdrawn, or held for a human (scheduled_send,
+	// ADR-0104). Held apart from SentMessages because the distinction is the
+	// subject's to know — one is a message they received, the other is one
+	// somebody wrote to them that the system is still holding.
+	ScheduledMessages []map[string]any `json:"scheduled_messages"`
 }
 
 // AssembleSAR builds the package. It is a privileged read: the caller must be
@@ -264,84 +270,6 @@ func sarRecordSections(pkg *SARPackage) []sarSection {
 		   WHERE (at.entity_type = 'person' AND at.entity_id = $1)
 		      OR (at.entity_type = 'activity' AND at.entity_id IN (
 		            SELECT l.activity_id FROM activity_link l WHERE l.person_id = $1))`},
-	}
-}
-
-// sarMessagingSections gather both directions of the messaging boundary: what
-// capture decided about mail arriving from the subject, and what this
-// installation sent out about or to them.
-func sarMessagingSections(pkg *SARPackage) []sarSection {
-	return []sarSection{
-		{&pkg.CaptureDispositions, `SELECT p.email, p.display_name, p.status, p.disposition_reason, p.created_at, p.resolved_at
-		   FROM capture_pending_counterparty p
-		   WHERE p.email IN (SELECT email FROM person_email WHERE person_id = $1)`},
-		// The governed outbound messages this installation sent about or to the
-		// subject. Reached BOTH ways on purpose, unlike the erasure cascade: a
-		// send whose activity was never linked to their record still went to
-		// their address, and one addressed to a third party but filed on their
-		// timeline is still a message about them.
-		//
-		// The two arms err in OPPOSITE directions and both are deliberate.
-		// Reaching by address alone would miss the timeline; reaching by link
-		// alone would miss the unlinked send.
-		//
-		// The PROJECTION is deliberate too: recipients and cc are returned
-		// whole, so a message the subject shared with other people hands the
-		// export those people's addresses as well — whichever arm matched the
-		// row. Narrowing the arrays to the subject's own address would be the
-		// safer default in a self-serve export, and it is rejected here for two
-		// reasons. An address list is part of what the message WAS, and Art. 15
-		// owes the subject the data held about them rather than a redraft of
-		// it. And this assembly is admin-mediated (AssembleSAR demands the
-		// person.delete grant and an unbounded scope, above), so the disclosure
-		// is a human handing a package to a subject, not an endpoint answering
-		// one — the same posture, and the same tolerated over-inclusion, as the
-		// Activities and Attachments sections, whose free text and filenames
-		// name third parties for exactly the same reason. It is what separates
-		// this from the erasure cascade, which must refuse the equivalent
-		// reach: a disclosure to an admin-mediated export is recoverable, and
-		// destroying another subject's evidence is not.
-		//
-		// It spans BOTH shapes the row admits (comms_outbound_shape, 0155): a
-		// channel delivery leaves subject/recipients/cc null and names its
-		// addressee in channel_user_id, so a mail-only projection would hand a
-		// channel-only subject a message with no addressee — withholding the
-		// account id the row holds about them.
-		// html_body rides beside body rather than instead of it: a message
-		// carrying both is ONE message the subject received in two renderings,
-		// and disclosing only the plain one withholds markup the system still
-		// holds about them. from_name joins them for the same reason: this
-		// projection discloses the message AS THE SUBJECT RECEIVED IT, and who
-		// it appeared to be from is part of what they were shown.
-		//
-		// The address match spans bcc, and the DISCLOSURE of it is narrowed to
-		// the subject's own address.
-		//
-		// Both halves are required and they pull opposite ways. A person bcc'd
-		// on a message with no activity link would otherwise be absent from
-		// their own export of a message they received — and exporting the
-		// whole bcc array would hand one subject every other blind recipient's
-		// address, which is the disclosure a blind copy exists to prevent. So
-		// the row is FOUND on any addressee and the blind list is REDUCED to
-		// the asker.
-		//
-		// attachments too, and it is not covered by the attachment query
-		// below: that one finds files hanging off the subject or an activity
-		// linked to them, while a send may carry any file its sender could see
-		// — one attached to an organization or a deal reaches the subject
-		// without ever being attached TO them.
-		{&pkg.SentMessages, `SELECT o.subject, o.body, o.html_body, o.from_name, o.attachments, o.recipients, o.cc,
-		      (SELECT coalesce(jsonb_agg(addr), '[]'::jsonb)
-		         FROM jsonb_array_elements_text(coalesce(o.bcc, '[]'::jsonb)) AS addr
-		        WHERE lower(addr) IN (SELECT email FROM person_email WHERE person_id = $1)) AS bcc,
-		      o.consent_purpose,
-		      o.provider, o.channel_user_id, o.status, o.sent_at, o.created_at
-		   FROM comms_outbound o
-		   WHERE o.activity_id IN (SELECT l.activity_id FROM activity_link l WHERE l.person_id = $1)
-		      OR EXISTS (
-		           SELECT 1 FROM jsonb_array_elements_text(
-		                          o.recipients || o.cc || coalesce(o.bcc, '[]'::jsonb)) AS addr
-		           WHERE lower(addr) IN (SELECT email FROM person_email WHERE person_id = $1))`},
 	}
 }
 

--- a/backend/internal/modules/privacy/sarmessages.go
+++ b/backend/internal/modules/privacy/sarmessages.go
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package privacy
+
+// The messages half of a subject-access package: what was captured, what was
+// sent to the subject, and what is still waiting to be sent to them. Split from
+// sar.go because these three projections carry the file's hardest rule — which
+// addresses may be disclosed to whom — and it is easier to check when it is not
+// interleaved with the identity and provenance sections.
+
+// sarMessagingSections gather both directions of the messaging boundary: what
+// capture decided about mail arriving from the subject, and what this
+// installation sent out about or to them.
+func sarMessagingSections(pkg *SARPackage) []sarSection {
+	return []sarSection{
+		{&pkg.CaptureDispositions, `SELECT p.email, p.display_name, p.status, p.disposition_reason, p.created_at, p.resolved_at
+		   FROM capture_pending_counterparty p
+		   WHERE p.email IN (SELECT email FROM person_email WHERE person_id = $1)`},
+		// The governed outbound messages this installation sent about or to the
+		// subject. Reached BOTH ways on purpose, unlike the erasure cascade: a
+		// send whose activity was never linked to their record still went to
+		// their address, and one addressed to a third party but filed on their
+		// timeline is still a message about them.
+		//
+		// The two arms err in OPPOSITE directions and both are deliberate.
+		// Reaching by address alone would miss the timeline; reaching by link
+		// alone would miss the unlinked send.
+		//
+		// The PROJECTION is deliberate too: recipients and cc are returned
+		// whole, so a message the subject shared with other people hands the
+		// export those people's addresses as well — whichever arm matched the
+		// row. Narrowing the arrays to the subject's own address would be the
+		// safer default in a self-serve export, and it is rejected here for two
+		// reasons. An address list is part of what the message WAS, and Art. 15
+		// owes the subject the data held about them rather than a redraft of
+		// it. And this assembly is admin-mediated (AssembleSAR demands the
+		// person.delete grant and an unbounded scope, above), so the disclosure
+		// is a human handing a package to a subject, not an endpoint answering
+		// one — the same posture, and the same tolerated over-inclusion, as the
+		// Activities and Attachments sections, whose free text and filenames
+		// name third parties for exactly the same reason. It is what separates
+		// this from the erasure cascade, which must refuse the equivalent
+		// reach: a disclosure to an admin-mediated export is recoverable, and
+		// destroying another subject's evidence is not.
+		//
+		// It spans BOTH shapes the row admits (comms_outbound_shape, 0155): a
+		// channel delivery leaves subject/recipients/cc null and names its
+		// addressee in channel_user_id, so a mail-only projection would hand a
+		// channel-only subject a message with no addressee — withholding the
+		// account id the row holds about them.
+		// html_body rides beside body rather than instead of it: a message
+		// carrying both is ONE message the subject received in two renderings,
+		// and disclosing only the plain one withholds markup the system still
+		// holds about them. from_name joins them for the same reason: this
+		// projection discloses the message AS THE SUBJECT RECEIVED IT, and who
+		// it appeared to be from is part of what they were shown.
+		//
+		// The address match spans bcc, and the DISCLOSURE of it is narrowed to
+		// the subject's own address.
+		//
+		// Both halves are required and they pull opposite ways. A person bcc'd
+		// on a message with no activity link would otherwise be absent from
+		// their own export of a message they received — and exporting the
+		// whole bcc array would hand one subject every other blind recipient's
+		// address, which is the disclosure a blind copy exists to prevent. So
+		// the row is FOUND on any addressee and the blind list is REDUCED to
+		// the asker.
+		//
+		// attachments too, and it is not covered by the attachment query
+		// below: that one finds files hanging off the subject or an activity
+		// linked to them, while a send may carry any file its sender could see
+		// — one attached to an organization or a deal reaches the subject
+		// without ever being attached TO them.
+		{&pkg.SentMessages, `SELECT o.subject, o.body, o.html_body, o.from_name, o.attachments, o.recipients, o.cc,
+		      (SELECT coalesce(jsonb_agg(addr), '[]'::jsonb)
+		         FROM jsonb_array_elements_text(coalesce(o.bcc, '[]'::jsonb)) AS addr
+		        WHERE lower(addr) IN (SELECT email FROM person_email WHERE person_id = $1)) AS bcc,
+		      o.consent_purpose,
+		      o.provider, o.channel_user_id, o.status, o.sent_at, o.created_at
+		   FROM comms_outbound o
+		   WHERE o.activity_id IN (SELECT l.activity_id FROM activity_link l WHERE l.person_id = $1)
+		      OR EXISTS (
+		           SELECT 1 FROM jsonb_array_elements_text(
+		                          o.recipients || o.cc || coalesce(o.bcc, '[]'::jsonb)) AS addr
+		           WHERE lower(addr) IN (SELECT email FROM person_email WHERE person_id = $1))`},
+		// The messages nobody has sent yet. They hold the subject's address and
+		// the body BEFORE any activity exists, so none of the three routes the
+		// query above takes can reach them — and a message written to this
+		// person, sitting unsent, is data held about them that Art. 15 owes
+		// them sight of.
+		//
+		// Same two-sided address rule as the sent projection, pulling the same
+		// two ways: the row is FOUND on any addressee including a blind one, so
+		// a bcc'd subject is not absent from their own export; and the blind
+		// list is REDUCED to the asker, so they do not learn who else was
+		// blind-copied. Exporting the whole bcc array would hand one subject
+		// every other blind recipient's address, which is the disclosure a
+		// blind copy exists to prevent.
+		//
+		// status and held_reason are disclosed because they are the honest
+		// answer to "what is happening to this message" — waiting, withdrawn,
+		// or stopped by a gate and waiting for a human. Showing the content
+		// while hiding the state would tell the subject a message exists
+		// without telling them whether it is still going to arrive.
+		{&pkg.ScheduledMessages, `SELECT s.payload->>'subject' AS subject,
+		      s.payload->>'body' AS body,
+		      s.payload->>'html_body' AS html_body,
+		      -- The To LINE, derived by subtracting cc and bcc from the merged
+		      -- list. payload.recipients is the CONSENT superset — every To, Cc
+		      -- AND Bcc address — which is the right shape for a gate and the
+		      -- wrong one to disclose: handing it over verbatim would give this
+		      -- subject every other blind recipient's address, which is exactly
+		      -- what narrowing the bcc column below exists to prevent. The sent
+		      -- projection above needs no such subtraction because
+		      -- comms_outbound keeps the To line and the blind list apart.
+		      --
+		      -- Compared case-insensitively and trimmed, which is what
+		      -- activities.normalizeAddress does on the send side. Matching raw
+		      -- would leave a differently-cased blind address in the To line
+		      -- here while the send itself correctly removed it — the one place
+		      -- the two derivations must not disagree.
+		      (SELECT coalesce(jsonb_agg(addr), '[]'::jsonb)
+		         FROM jsonb_array_elements_text(coalesce(s.payload->'recipients', '[]'::jsonb)) AS addr
+		        WHERE lower(btrim(addr)) NOT IN (
+		                SELECT lower(btrim(c))
+		                  FROM jsonb_array_elements_text(coalesce(s.payload->'cc', '[]'::jsonb)) AS c
+		                UNION ALL
+		                SELECT lower(btrim(b))
+		                  FROM jsonb_array_elements_text(coalesce(s.payload->'bcc', '[]'::jsonb)) AS b)) AS recipients,
+		      s.payload->'cc' AS cc,
+		      (SELECT coalesce(jsonb_agg(addr), '[]'::jsonb)
+		         FROM jsonb_array_elements_text(coalesce(s.payload->'bcc', '[]'::jsonb)) AS addr
+		        WHERE lower(addr) IN (SELECT email FROM person_email WHERE person_id = $1)) AS bcc,
+		      s.payload->>'consent_purpose' AS consent_purpose,
+		      s.status, s.held_reason, s.scheduled_at, s.scheduled_tz, s.created_at
+		   FROM scheduled_send s
+		   WHERE EXISTS (
+		           SELECT 1 FROM jsonb_array_elements_text(
+		                          coalesce(s.payload->'recipients', '[]'::jsonb)
+		                          || coalesce(s.payload->'cc', '[]'::jsonb)
+		                          || coalesce(s.payload->'bcc', '[]'::jsonb)) AS addr
+		           WHERE lower(addr) IN (SELECT email FROM person_email WHERE person_id = $1))`},
+	}
+}

--- a/backend/piicoverage_test.go
+++ b/backend/piicoverage_test.go
@@ -175,6 +175,16 @@ var piiTables = map[string]piiHandling{
 	"preference_token": {erasureWrite: true, sarForbidden: true},
 }
 
+// sarAssemblyFiles are the files whose SQL literals make up the Art. 15
+// package. Listed rather than globbed: the gate asks what the EXPORT reads, and
+// a glob over the package would read erasure's DELETE statements as disclosures.
+// A new file carrying SAR sections joins this list; the section-count assertion
+// below is what fails if one is forgotten.
+var sarAssemblyFiles = []string{
+	"internal/modules/privacy/sar.go",
+	"internal/modules/privacy/sarmessages.go",
+}
+
 // fromJoinRe extracts the table named by a FROM/JOIN clause — SAR reads are
 // SELECTs, invisible to sqlWriteTargets.
 var fromJoinRe = regexp.MustCompile(`(?is)\b(?:from|join)\s+([a-z_][a-z0-9_]*)`)
@@ -275,10 +285,17 @@ func TestErasureAndSARReachEveryPIITable(t *testing.T) {
 			}
 		}
 	}
+	// The files the SAR assembly is SPLIT ACROSS, not one named file and not
+	// the whole package. One filename reports a section missing the moment
+	// somebody moves it — a rename passing itself off as an Art. 15 gap — and
+	// the whole package sweeps in erasure's own DELETE ... FROM statements,
+	// which fromJoinRe cannot tell from a SELECT.
 	reads := map[string]bool{}
-	for _, lit := range sqlLiterals(t, "internal/modules/privacy/sar.go") {
-		for _, m := range fromJoinRe.FindAllStringSubmatch(lit, -1) {
-			reads[m[1]] = true
+	for _, path := range sarAssemblyFiles {
+		for _, lit := range sqlLiterals(t, path) {
+			for _, m := range fromJoinRe.FindAllStringSubmatch(lit, -1) {
+				reads[m[1]] = true
+			}
 		}
 	}
 


### PR DESCRIPTION
Closes #1256. Erasure already reached scheduled sends; this is the read side of the same obligation.

## What was wrong

A scheduled message holds the recipient's address, subject and body **before any activity exists**, and the sent-message projection finds outbound mail *through* the activity — all three of its clauses miss a message that has not fired. So a person who asked what we hold about them was told about the mail we had sent them, and not about the mail sitting in the system addressed to them.

## The blind-copy rule is the hard half, and the test caught me getting it wrong

Two requirements pull opposite ways: the export must **find** a bcc'd subject's own message (otherwise they are absent from their own export of a message they were about to receive), and must **not disclose** who else was blind-copied.

My first version narrowed the `bcc` column correctly and then handed over `payload.recipients` verbatim — which is the **consent superset**: every To, Cc *and* Bcc address merged. It is the right shape for a gate and the wrong one to disclose. The To line is now derived by subtracting cc and bcc, case-insensitively and trimmed, matching `activities.normalizeAddress`; a differently-cased blind address would otherwise sit in the visible list here while the send itself correctly hid it.

The sent projection needs no such subtraction — `comms_outbound` keeps the To line and the blind list in separate columns.

## Two supporting changes

The messaging sections move to their own file: they carry that disclosure rule, and it is easier to check when it is not interleaved with the identity and provenance sections.

The PII coverage gate now reads the files the assembly is **split across** rather than one hardcoded filename — it would otherwise report a section missing whenever somebody moved it, which is a rename passing itself off as an Art. 15 gap. Scanning the whole package was the obvious fix and the wrong one: it reads erasure's own `DELETE ... FROM` as a disclosure.

## Tests

Three integration cases over a real database, driving the real endpoints. Mutation-checked both ways: drop the section and the export test fails; drop a file from the gate's list and the coverage test fails.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Include scheduled (unsent) emails in subject-access exports and apply correct BCC disclosure. Previously, exports only listed sent messages found via activity links; unsent scheduled messages with no activity were missing.

- Add ScheduledMessages to the SAR package from `scheduled_send`: include subject/body/html, status/held_reason/scheduled_at. Derive the To list from `payload.recipients` minus `cc` and `bcc` (case-insensitive, trimmed). Narrow `bcc` to the requesting subject’s addresses only.
- Keep SentMessages behavior, which already stores To and BCC separately; continue narrowing `bcc` to the subject.
- Move messaging SAR SQL to `internal/modules/privacy/sarmessages.go`. Update the PII coverage gate to scan both `internal/modules/privacy/sar.go` and `internal/modules/privacy/sarmessages.go`. When adding SAR sections, update `sarAssemblyFiles` in the coverage test.
- Add integration tests covering unsent message export and the BCC rule; share a `privacyAdmin` helper and reuse it in erasure tests.

<sup>Written for commit 3bc82fae7e9539faf9d48b416531690181f73d95. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1306?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

