### PR TITLE
fix(migrations): the scheduled-send row's two references say what they mean

### DIFF
--- a/backend/migrations/core/0248_scheduled_send_references.down.sql
+++ b/backend/migrations/core/0248_scheduled_send_references.down.sql
@@ -1,0 +1,9 @@
+ALTER TABLE scheduled_send
+  DROP CONSTRAINT IF EXISTS scheduled_send_delivery_id_fkey;
+
+ALTER TABLE scheduled_send
+  DROP CONSTRAINT IF EXISTS scheduled_send_activity_id_fkey;
+
+ALTER TABLE scheduled_send
+  ADD CONSTRAINT scheduled_send_activity_id_fkey
+  FOREIGN KEY (activity_id) REFERENCES activity(id) ON DELETE SET NULL;

--- a/backend/migrations/core/0248_scheduled_send_references.up.sql
+++ b/backend/migrations/core/0248_scheduled_send_references.up.sql
@@ -1,0 +1,31 @@
+-- 0248: the scheduled-send row's two references say what they mean.
+--
+-- 0242 declared `delivery_id` as "the comms_outbound row that owns delivery
+-- truth from here on" and gave it no foreign key, so nothing but that comment
+-- held the two together. And it declared `activity_id ON DELETE SET NULL` while
+-- its own state-shape CHECK forbids a released row with a null activity — an
+-- action the constraint guarantees can never succeed.
+--
+-- Neither is reachable through the product today: an activity is
+-- erasure-SCRUBBED rather than hard-deleted, and a delivery is not deleted at
+-- all. That is what makes this a correctness repair rather than an incident,
+-- and also why it is worth doing now — a DDL-level delete during maintenance is
+-- exactly the moment nobody is watching.
+--
+-- RESTRICT on both, because the state model already decided this: a released
+-- scheduled send NAMES the activity and the delivery it produced, and a row
+-- that outlived either would be a claim about a message with nothing behind it.
+-- Deleting them has to be refused, not papered over with a null the CHECK will
+-- reject one statement later.
+ALTER TABLE scheduled_send
+  DROP CONSTRAINT IF EXISTS scheduled_send_activity_id_fkey;
+
+ALTER TABLE scheduled_send
+  ADD CONSTRAINT scheduled_send_activity_id_fkey
+  FOREIGN KEY (activity_id) REFERENCES activity(id) ON DELETE RESTRICT;
+
+-- The delivery this send handed the message to. Nullable for the same reason
+-- activity_id is: it exists only once the row has been released.
+ALTER TABLE scheduled_send
+  ADD CONSTRAINT scheduled_send_delivery_id_fkey
+  FOREIGN KEY (delivery_id) REFERENCES comms_outbound(id) ON DELETE RESTRICT;


### PR DESCRIPTION
Closes #1259. Migration-only, no code changes.

Two referential-integrity mistakes in `0242`:

- **`delivery_id` had no foreign key**, though it is documented as naming the `comms_outbound` row that owns delivery truth. Nothing but that comment held the two together.
- **`activity_id` declared `ON DELETE SET NULL`, which its own state-shape CHECK forbids.** A released row requires a non-null `activity_id`, so the declared action is one the constraint guarantees can never succeed — deleting an activity would fail outright rather than nulling the reference as advertised.

Neither is reachable through the product today (activities are erasure-scrubbed rather than hard-deleted; deliveries are not deleted at all), which is what makes this a repair rather than an incident — and also why it is worth doing now, because a DDL-level delete during maintenance is exactly the moment nobody is watching.

`RESTRICT` on both, because the state model already decided it: a released scheduled send *names* the activity and the delivery it produced, and a row that outlived either would be a claim about a message with nothing behind it. The anchor keeps its `CASCADE` deliberately — a scheduled reply to a deleted conversation has no thread left to join.

Verified on a rebuilt schema: `activity_id` now reports `RESTRICT` where it reported `SET NULL`, and `delivery_id` has a constraint where it had none. Migration load and apply-reverse-reapply both green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `scheduled_send` foreign keys to match the state model and prevent orphans. Previously, `delivery_id` had no FK and `activity_id` used ON DELETE SET NULL (blocked by a CHECK); now both use ON DELETE RESTRICT for predictable deletes and integrity.

- Add FK: `scheduled_send.delivery_id` → `comms_outbound(id)` ON DELETE RESTRICT.
- Replace FK: `scheduled_send.activity_id` → `activity(id)` ON DELETE RESTRICT (was SET NULL).
- Down migration drops these and restores SET NULL on `activity_id`.

**Review/Rollout**
- Migration only; no app code changes. Deleting `activity` or `comms_outbound` now fails if referenced by `scheduled_send` instead of breaking links.
- If you must hard-delete an activity or delivery, delete dependent `scheduled_send` rows first.

<sup>Written for commit 3125de310374d32f4136e3b32120411ab4431809. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1309?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

