### PR TITLE
feat(send): a scheduled message ends where every other message ends

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -3736,7 +3736,7 @@ paths:
         - name: status
           in: query
           required: false
-          schema: { type: string, enum: [scheduled, released, cancelled, held] }
+          schema: { type: string, enum: [scheduled, released, sent, cancelled, held] }
           description: Omit for every state; supply one to filter.
       responses:
         '200':
@@ -17284,12 +17284,14 @@ components:
         id: { type: string, format: uuid }
         status:
           type: string
-          enum: [scheduled, released, cancelled, held]
+          enum: [scheduled, released, sent, cancelled, held]
           description: |
             `scheduled` — waiting; the rep may move or cancel it.
-            `released` — it fired: the activity, the delivery row and the dispatch job exist.
-            Deliberately NOT "sent": the provider has not been called yet and the delivery can
-            still park or fail, so delivery truth lives on the outbound record, not here.
+            `released` — it fired: the activity, the delivery row and the dispatch job exist,
+            and the provider has not been called yet, so the delivery can still park or fail.
+            A step rather than an ending.
+            `sent` — the provider confirmed receipt. A message this system sent reads the same
+            whether a rep scheduled it or sent it directly.
             `cancelled` — withdrawn before it fired; nothing was transmitted.
             `held` — a gate refused at fire, or the window was missed. It will not send itself;
             a human reschedules or cancels it.

--- a/backend/gatecensus_test.go
+++ b/backend/gatecensus_test.go
@@ -50,7 +50,7 @@ const (
 	// Permitting the marker without counting it would let it spread quietly and
 	// reopen the class these rules close; pinned, every new one moves a number a
 	// reviewer sees.
-	wantFixtureAnnotations = 14
+	wantFixtureAnnotations = 16
 )
 
 // censusDecl is one package-level declaration this census governs — a map from

--- a/backend/internal/compose/approval_kinds_test.go
+++ b/backend/internal/compose/approval_kinds_test.go
@@ -15,12 +15,19 @@ package compose
 import (
 	"context"
 	"encoding/json"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/gradionhq/margince/backend/internal/modules/activities"
 	"github.com/gradionhq/margince/backend/internal/modules/agents"
 	"github.com/gradionhq/margince/backend/internal/modules/approvals"
+	"github.com/gradionhq/margince/backend/internal/modules/deals"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/mcp"
@@ -206,4 +213,286 @@ func TestEveryConfirmationRequiredPolicyHasAnApprovalKind(t *testing.T) {
 	if checked == 0 {
 		t.Fatal("no confirm-first tool routes in the generated policy — the gate covers nothing")
 	}
+}
+
+// TestEveryKindComposeStagesHasADecisionGrantMapping closes the gap the three
+// tests above leave: they derive their kinds from the TOOL registry and the
+// effect registry, so a kind staged by a WORKER — no tool, no effect — is
+// invisible to all of them.
+//
+// That gap is not hypothetical. The held-scheduled-send item (ADR-0104 §5) was
+// staged by the fire path, landed in the approval table, and appeared in nobody's
+// inbox: decidable() fails closed on an unmapped kind, so every row was written
+// and then filtered out of the one surface that exists to show it. It looked
+// exactly like a notifier that never ran.
+//
+// Derived from the SOURCE rather than a list: every approvals.StageInput literal
+// in this package names its kind, and each one has to be decidable by somebody.
+func TestEveryKindComposeStagesHasADecisionGrantMapping(t *testing.T) {
+	fset := token.NewFileSet()
+	files := parsePackageFiles(t, fset, ".")
+	// Every string constant this package declares, so a Kind named by an
+	// identifier resolves to the value it will carry at run time.
+	consts := map[string]string{}
+	for _, file := range files {
+		collectStringConsts(file, consts)
+	}
+	kinds := map[string]token.Position{}
+	var unresolved []string
+	for _, file := range files {
+		{
+			ast.Inspect(file, func(n ast.Node) bool {
+				lit, ok := n.(*ast.CompositeLit)
+				if !ok || !isStageInput(lit) {
+					return true
+				}
+				kind, pos, outcome := stagedKind(lit, consts)
+				switch outcome {
+				case kindResolved:
+					kinds[kind] = fset.Position(pos)
+				case kindUnreadable:
+					// A Kind this gate cannot read is a stager it cannot judge,
+					// and silence there would be the same invisibility the gate
+					// exists to catch — one level up.
+					unresolved = append(unresolved, fset.Position(lit.Pos()).String())
+				case kindAbsent:
+					// A literal with no Kind field at all is a zero value or a
+					// partial build — an error return, a struct assembled
+					// field-by-field elsewhere. There is no kind here to judge.
+				}
+				return true
+			})
+		}
+	}
+	if len(kinds) == 0 {
+		t.Fatal("no approvals.StageInput literals found in compose — this gate resolved nothing and would demand nothing")
+	}
+	for _, where := range unresolved {
+		t.Errorf("%s stages an approval whose Kind this gate cannot resolve — teach stagedKind to read it, or the stager rides in unjudged",
+			where)
+	}
+	for kind, pos := range kinds {
+		// The target type is what a target-RESOLVED kind derives its second
+		// grant from. Passing "activity" resolves those without pinning this
+		// gate to any one kind's target: what it asks is whether the kind is
+		// MAPPED at all, and an unmapped one errors before the type is read.
+		if _, err := approvals.DecisionGrantObjects(kind, "activity"); err != nil {
+			t.Errorf("%s stages approval kind %q, which approvals has no decision-grant mapping for — every such row is written and then filtered out of the inbox, so it reads as a stager that never ran (%v)",
+				pos, kind, err)
+		}
+	}
+}
+
+// isStageInput reports whether a composite literal builds an approvals.StageInput.
+func isStageInput(lit *ast.CompositeLit) bool {
+	sel, ok := lit.Type.(*ast.SelectorExpr)
+	if !ok || sel.Sel.Name != "StageInput" {
+		return false
+	}
+	pkg, ok := sel.X.(*ast.Ident)
+	return ok && pkg.Name == "approvals"
+}
+
+// kindOutcome says what reading a literal's Kind field found: a value this gate
+// can judge, a field it could not read, or no field at all. The three are
+// deliberately distinct — collapsing "unreadable" into "absent" is how a stager
+// rides in unjudged.
+type kindOutcome int
+
+const (
+	kindAbsent kindOutcome = iota
+	kindResolved
+	kindUnreadable
+)
+
+// stagedKind resolves the Kind field of a StageInput literal: a string literal
+// directly, a constant declared in this package, or an exported approvals kind.
+//
+// A Kind that is a plain identifier resolving to nothing is a PARAMETER — the
+// stager is a helper several callers share, and its kind is whatever they pass.
+// Those are reported as unreadable rather than skipped, because the gate cannot
+// see which kinds actually reach them.
+func stagedKind(lit *ast.CompositeLit, consts map[string]string) (string, token.Pos, kindOutcome) {
+	for _, elt := range lit.Elts {
+		kv, ok := elt.(*ast.KeyValueExpr)
+		if !ok {
+			continue
+		}
+		key, ok := kv.Key.(*ast.Ident)
+		if !ok || key.Name != "Kind" {
+			continue
+		}
+		switch v := kv.Value.(type) {
+		case *ast.BasicLit:
+			if v.Kind == token.STRING {
+				return strings.Trim(v.Value, `"`), v.Pos(), kindResolved
+			}
+		case *ast.Ident:
+			// A constant this package declares, resolved to its value.
+			if value, found := consts[v.Name]; found {
+				return value, v.Pos(), kindResolved
+			}
+			// Otherwise a function parameter: the helper is shared and its kind
+			// is whatever each caller passes, which this gate cannot see from
+			// the literal. Those callers are covered by the tool and effect
+			// registries above — the two gates together are what make the
+			// coverage total.
+			return "", token.NoPos, kindAbsent
+		case *ast.SelectorExpr:
+			// approvals.KindX used inline, resolved through the live package —
+			// the value the build compiles is the one this gate must judge.
+			if pkg, ok := v.X.(*ast.Ident); ok {
+				if value, found := crossPackageKinds[pkg.Name+"."+v.Sel.Name]; found {
+					return value, v.Pos(), kindResolved
+				}
+				// A selector on something that is not a package — in.Kind on a
+				// request struct — is a kind supplied by whoever CALLS this
+				// helper. The gate cannot see those from here; the adapter's
+				// own caller-side gate is what covers them (the tool and effect
+				// registries above), which is why this is a pass rather than a
+				// finding.
+				if !isPackageQualifier(pkg.Name) {
+					return "", token.NoPos, kindAbsent
+				}
+			}
+		}
+		return "", kv.Value.Pos(), kindUnreadable
+	}
+	return "", token.NoPos, kindAbsent
+}
+
+// collectStringConsts records every package-level string constant, so a Kind
+// written as an identifier resolves to the value it carries at run time.
+func collectStringConsts(file *ast.File, into map[string]string) {
+	for _, decl := range file.Decls {
+		gen, ok := decl.(*ast.GenDecl)
+		if !ok || gen.Tok != token.CONST {
+			continue
+		}
+		for _, spec := range gen.Specs {
+			vs, ok := spec.(*ast.ValueSpec)
+			if !ok {
+				continue
+			}
+			for i, name := range vs.Names {
+				if i >= len(vs.Values) {
+					continue
+				}
+				switch v := vs.Values[i].(type) {
+				case *ast.BasicLit:
+					if v.Kind == token.STRING {
+						into[name.Name] = strings.Trim(v.Value, `"`)
+					}
+				case *ast.SelectorExpr:
+					// A local alias for another package's exported kind
+					// (approvals.KindX). Resolved through the live package
+					// rather than by re-parsing it: the value the build uses is
+					// the one this gate must judge, and a second reading of the
+					// source is a second chance to disagree with it.
+					if pkg, ok := v.X.(*ast.Ident); ok && pkg.Name == "approvals" {
+						if value, found := exportedApprovalKinds[v.Sel.Name]; found {
+							into[name.Name] = value
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+// exportedApprovalKinds is every kind constant the approvals module exports for
+// another package to stage under. Listed here rather than reflected, because a
+// constant has no runtime identity to reflect on — and the list is short
+// because exporting one is the deliberate act of saying "compose stages this".
+//
+// A kind exported there and missing here makes this gate skip a stager, so the
+// companion assertion below fails when the two fall out of step.
+// gatekit:fixture the value each exported approvals kind constant carries —
+// resolved constant data, not a cost.
+var exportedApprovalKinds = map[string]string{
+	"KindQuotaRelease": approvals.KindQuotaRelease,
+}
+
+// crossPackageKinds resolves a kind another module exports and compose stages
+// under, keyed as written at the call site.
+// gatekit:fixture the value each cross-package kind constant carries, keyed as
+// written at the call site — resolved constant data, not a cost.
+var crossPackageKinds = map[string]string{
+	"approvals.KindQuotaRelease":    approvals.KindQuotaRelease,
+	"deals.CloseDateCorrectionKind": deals.CloseDateCorrectionKind,
+	"deals.FollowUpReconcileKind":   deals.FollowUpReconcileKind,
+}
+
+// isPackageQualifier reports whether an identifier names an imported package
+// rather than a local variable. Kept as the short list compose actually stages
+// through, so a NEW module's kind is unreadable — and therefore reported —
+// until somebody adds it here rather than silently skipped.
+func isPackageQualifier(name string) bool {
+	switch name {
+	case "approvals", "deals", "people", "activities", "agents":
+		return true
+	}
+	return false
+}
+
+// TestTheExportedApprovalKindMapIsComplete is the companion the gate above
+// depends on: exportedApprovalKinds is written by hand, and a kind exported by
+// approvals but missing from it makes that gate skip a stager silently.
+//
+// Derived from the approvals SOURCE rather than a second list, so exporting a
+// new kind fails here until the map catches up.
+func TestTheExportedApprovalKindMapIsComplete(t *testing.T) {
+	fset := token.NewFileSet()
+	exported := map[string]bool{}
+	for _, file := range parsePackageFiles(t, fset, "../modules/approvals") {
+		consts := map[string]string{}
+		collectStringConsts(file, consts)
+		for name := range consts {
+			if strings.HasPrefix(name, "Kind") {
+				exported[name] = true
+			}
+		}
+	}
+	if len(exported) == 0 {
+		t.Fatal("no exported Kind constants found in approvals — this gate resolved nothing")
+	}
+	for name := range exported {
+		if _, mapped := exportedApprovalKinds[name]; !mapped {
+			t.Errorf("approvals exports %s and exportedApprovalKinds does not carry it — every compose stager using it would be skipped by the decision-grant gate", name)
+		}
+	}
+	for name := range exportedApprovalKinds {
+		if !exported[name] {
+			t.Errorf("exportedApprovalKinds carries %s, which approvals no longer exports — stale entry", name)
+		}
+	}
+}
+
+// parsePackageFiles parses every non-test Go file in a directory.
+//
+// Explicit rather than parser.ParseDir, which is deprecated for ignoring build
+// tags: this gate wants every file whatever tags it carries, because a stager
+// behind a tag stages just as really as one without.
+func parsePackageFiles(t *testing.T, fset *token.FileSet, dir string) []*ast.File {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("reading %s: %v", dir, err)
+	}
+	var files []*ast.File
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		file, err := parser.ParseFile(fset, filepath.Join(dir, name), nil, parser.ParseComments)
+		if err != nil {
+			t.Fatalf("parsing %s: %v", name, err)
+		}
+		files = append(files, file)
+	}
+	if len(files) == 0 {
+		t.Fatalf("no Go files parsed from %s — this gate would resolve nothing", dir)
+	}
+	return files
 }

--- a/backend/internal/compose/commsscheduled.go
+++ b/backend/internal/compose/commsscheduled.go
@@ -160,7 +160,7 @@ func (w *scheduledSendWorker) Work(ctx context.Context, job *river.Job[Scheduled
 		// The scheduler lost their account or their seat. Holding under a
 		// system scope, because the authority we would otherwise hold under is
 		// exactly the one that just failed to resolve.
-		if err := w.hold(sendWorkerScope(wsCtx), id, activities.HeldSenderInactive); err != nil {
+		if err := w.hold(w.holdScope(wsCtx, scheduler), id, activities.HeldSenderInactive); err != nil {
 			return jobs.FaultContext(ctx, err)
 		}
 		return nil
@@ -172,7 +172,7 @@ func (w *scheduledSendWorker) Work(ctx context.Context, job *river.Job[Scheduled
 			// Last rung. A row left 'scheduled' with no live timer is a message
 			// nobody will ever see fail, so the ladder ends by handing it to a
 			// human instead of going quiet.
-			if holdErr := w.hold(sendWorkerScope(wsCtx), id, activities.HeldTimerExhausted); holdErr != nil {
+			if holdErr := w.hold(w.holdScope(wsCtx, scheduler), id, activities.HeldTimerExhausted); holdErr != nil {
 				return jobs.FaultContext(ctx, errors.Join(err, holdErr))
 			}
 			return nil
@@ -250,6 +250,11 @@ func (w *scheduledSendWorker) fireAs(ctx context.Context, userID ids.UUID, kind 
 		TeamIDs:     rbac.TeamIDs,
 		SeatType:    seat,
 		Permissions: rbac.Permissions,
+		// The rep this message belongs to, named even when they ARE the actor.
+		// A fire is work done FOR somebody: the audit rows it writes should say
+		// whose message it was, not merely who executed it, and an agent-kind
+		// fire below carries the same human underneath.
+		OnBehalfOf: userID,
 	}
 	if kind == "agent" {
 		// An agent acting under this human's authority — which is what it was
@@ -259,6 +264,23 @@ func (w *scheduledSendWorker) fireAs(ctx context.Context, userID ids.UUID, kind 
 	}
 	fireCtx := principal.WithActor(ctx, actor)
 	return principal.WithCorrelationID(fireCtx, ids.NewV7()), false, nil
+}
+
+// holdScope is the system scope a hold runs under, naming the rep it acts FOR.
+//
+// The system is the actor — this is the alarm doing what a human asked for
+// earlier, not that human acting again — but the message is one rep's, and an
+// audit trail that recorded only "the system held something" would not say
+// whose message stopped. Surfacing a held message TO that rep is #1312; this is
+// the provenance any such surface will read.
+func (w *scheduledSendWorker) holdScope(wsCtx context.Context, scheduler ids.UUID) context.Context {
+	ctx := sendWorkerScope(wsCtx)
+	actor, ok := principal.Actor(ctx)
+	if !ok {
+		return ctx
+	}
+	actor.OnBehalfOf = scheduler
+	return principal.WithActor(ctx, actor)
 }
 
 // hold hands a message to a human with the reason they need.

--- a/backend/internal/compose/integration/scheduledsend_integration_test.go
+++ b/backend/internal/compose/integration/scheduledsend_integration_test.go
@@ -36,6 +36,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -289,6 +290,108 @@ func TestAScheduledMessageWritesNothingUntilItFires(t *testing.T) {
 		t.Fatalf("a fired message reads %q, want %q — 'sent' would claim the provider was called, and it has not been",
 			status, activities.ScheduledStatusReleased)
 	}
+}
+
+// DRAFT-AC-N-10a. Firing hands the message to the delivery machinery and stops
+// at `released`, which is honest at that instant — the provider has not been
+// called. When it IS called and confirms, the scheduled row has to follow: a
+// message this system sent reads "sent" whether a rep scheduled it or pressed
+// the button. Anything else leaves a rep looking at a message that demonstrably
+// arrived while its record still says it was merely handed over.
+func TestAConfirmedReceiptCarriesTheScheduledSendToSent(t *testing.T) {
+	p := setupPreflight(t)
+	p.connect(t, gmailReadonlyScope, gmailSendScope)
+
+	id := p.scheduleFor(t, time.Now().Add(2*time.Hour))
+	p.makeDue(t, id)
+	p.fire(t, id)
+
+	// Handed over, not yet delivered. This is the state the fire leaves behind.
+	if status, _ := p.scheduledStatus(t, id); status != activities.ScheduledStatusReleased {
+		t.Fatalf("a fired message reads %q, want %q before the provider is called",
+			status, activities.ScheduledStatusReleased)
+	}
+
+	// A real dispatch through the real connector to a real receipt.
+	activityID := p.releasedActivity(t, id)
+	deliveryID, _ := p.deliveryFor(t, activityID)
+	p.transmit(t, deliveryID, "")
+
+	if status := p.scheduledStatusThroughAPI(t, id); status != activities.ScheduledStatusSent {
+		t.Fatalf("after the provider confirmed receipt the message reads %q, want %q — a rep would be looking at a message that has arrived while its record says it was only handed over",
+			status, activities.ScheduledStatusSent)
+	}
+}
+
+// The filter has to read the SAME state the projection renders. A derived
+// status rendered on the way out while the raw column is filtered on the way in
+// is the shape where `?status=sent` returns nothing and `?status=released`
+// returns rows that read "sent" — each half correct, the pair useless.
+func TestFilteringByStatusFindsTheStateTheListActuallyShows(t *testing.T) {
+	p := setupPreflight(t)
+	p.connect(t, gmailReadonlyScope, gmailSendScope)
+
+	id := p.scheduleFor(t, time.Now().Add(2*time.Hour))
+	p.makeDue(t, id)
+	p.fire(t, id)
+	activityID := p.releasedActivity(t, id)
+	deliveryID, _ := p.deliveryFor(t, activityID)
+	p.transmit(t, deliveryID, "")
+
+	// The list renders it as sent, so the sent filter must find it.
+	if got := p.listScheduledIDs(t, activities.ScheduledStatusSent); !slices.Contains(got, id.String()) {
+		t.Errorf("?status=sent did not return the message the list renders as sent: %v", got)
+	}
+	// …and the released filter must not, because no rep sees it that way.
+	if got := p.listScheduledIDs(t, activities.ScheduledStatusReleased); slices.Contains(got, id.String()) {
+		t.Errorf("?status=released returned a message the list renders as sent: %v", got)
+	}
+}
+
+// releasedActivity reads the activity a fired scheduled send produced.
+func (p *preflightEnv) releasedActivity(t *testing.T, id ids.UUID) ids.UUID {
+	t.Helper()
+	var activityID ids.UUID
+	if err := apptest.InWorkspace(p.AppEnv, t, p.Slug, func(tx pgx.Tx) error {
+		return tx.QueryRow(context.Background(),
+			`SELECT activity_id FROM scheduled_send WHERE id = $1`, id).Scan(&activityID)
+	}); err != nil {
+		t.Fatalf("reading the activity the fire produced: %v", err)
+	}
+	return activityID
+}
+
+// scheduledStatusThroughAPI reads the status the way a REP sees it — through the
+// endpoint, where the derived state is computed. scheduledStatus reads the raw
+// column, which stays 'released': the difference between the two IS the
+// behaviour under test.
+func (p *preflightEnv) scheduledStatusThroughAPI(t *testing.T, id ids.UUID) string {
+	t.Helper()
+	var got struct {
+		Status string `json:"status"`
+	}
+	if status := p.Call(t, "GET", "/v1/scheduled-sends/"+id.String(), nil, nil, &got); status != http.StatusOK {
+		t.Fatalf("reading the scheduled send → %d", status)
+	}
+	return got.Status
+}
+
+// listScheduledIDs reads the rep's list filtered by one status, through the
+// endpoint rather than the table: the filter and the projection are the two
+// halves this asserts agree.
+func (p *preflightEnv) listScheduledIDs(t *testing.T, status string) []string {
+	t.Helper()
+	var rows []struct {
+		ID string `json:"id"`
+	}
+	if code := p.Call(t, "GET", "/v1/scheduled-sends?status="+status, nil, nil, &rows); code != http.StatusOK {
+		t.Fatalf("listing scheduled sends with status=%s → %d", status, code)
+	}
+	out := make([]string, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, row.ID)
+	}
+	return out
 }
 
 func TestConsentWithdrawnBeforeFiringHoldsTheMessage(t *testing.T) {

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -7188,6 +7188,7 @@ const (
 	ScheduledSendStatusHeld      ScheduledSendStatus = "held"
 	ScheduledSendStatusReleased  ScheduledSendStatus = "released"
 	ScheduledSendStatusScheduled ScheduledSendStatus = "scheduled"
+	ScheduledSendStatusSent      ScheduledSendStatus = "sent"
 )
 
 // Valid indicates whether the value is a known member of the ScheduledSendStatus enum.
@@ -7200,6 +7201,8 @@ func (e ScheduledSendStatus) Valid() bool {
 	case ScheduledSendStatusReleased:
 		return true
 	case ScheduledSendStatusScheduled:
+		return true
+	case ScheduledSendStatusSent:
 		return true
 	default:
 		return false
@@ -9915,6 +9918,7 @@ const (
 	Held      ListScheduledSendsParamsStatus = "held"
 	Released  ListScheduledSendsParamsStatus = "released"
 	Scheduled ListScheduledSendsParamsStatus = "scheduled"
+	Sent      ListScheduledSendsParamsStatus = "sent"
 )
 
 // Valid indicates whether the value is a known member of the ListScheduledSendsParamsStatus enum.
@@ -9927,6 +9931,8 @@ func (e ListScheduledSendsParamsStatus) Valid() bool {
 	case Released:
 		return true
 	case Scheduled:
+		return true
+	case Sent:
 		return true
 	default:
 		return false
@@ -17763,9 +17769,11 @@ type ScheduledSend struct {
 	ScheduledTz string `json:"scheduled_tz"`
 
 	// Status `scheduled` — waiting; the rep may move or cancel it.
-	// `released` — it fired: the activity, the delivery row and the dispatch job exist.
-	// Deliberately NOT "sent": the provider has not been called yet and the delivery can
-	// still park or fail, so delivery truth lives on the outbound record, not here.
+	// `released` — it fired: the activity, the delivery row and the dispatch job exist,
+	// and the provider has not been called yet, so the delivery can still park or fail.
+	// A step rather than an ending.
+	// `sent` — the provider confirmed receipt. A message this system sent reads the same
+	// whether a rep scheduled it or sent it directly.
 	// `cancelled` — withdrawn before it fired; nothing was transmitted.
 	// `held` — a gate refused at fire, or the window was missed. It will not send itself;
 	// a human reschedules or cancels it.
@@ -17784,9 +17792,11 @@ type ScheduledSend struct {
 type ScheduledSendHeldReason string
 
 // ScheduledSendStatus `scheduled` — waiting; the rep may move or cancel it.
-// `released` — it fired: the activity, the delivery row and the dispatch job exist.
-// Deliberately NOT "sent": the provider has not been called yet and the delivery can
-// still park or fail, so delivery truth lives on the outbound record, not here.
+// `released` — it fired: the activity, the delivery row and the dispatch job exist,
+// and the provider has not been called yet, so the delivery can still park or fail.
+// A step rather than an ending.
+// `sent` — the provider confirmed receipt. A message this system sent reads the same
+// whether a rep scheduled it or sent it directly.
 // `cancelled` — withdrawn before it fired; nothing was transmitted.
 // `held` — a gate refused at fire, or the window was missed. It will not send itself;
 // a human reschedules or cancels it.

--- a/backend/internal/modules/activities/scheduledsend.go
+++ b/backend/internal/modules/activities/scheduledsend.go
@@ -139,12 +139,21 @@ type ScheduledSend struct {
 	UpdatedAt   time.Time
 }
 
-// Scheduled-send states. 'released' is deliberately not 'sent': at the end of
-// the fire transaction the provider has not been called, and the delivery can
-// still park or fail. Delivery truth lives on the delivery row (ADR-0104 §5).
+// Scheduled-send states.
+//
+// 'released' is deliberately not 'sent' AT THAT MOMENT: the fire transaction has
+// handed the message to the delivery machinery and the provider has not been
+// called, so the delivery can still park or fail. It is a step, not an ending —
+// when the provider confirms receipt the row reads 'sent' like any other message
+// this system sent (ADR-0104 §5).
+//
+// 'sent' is never WRITTEN here. It is derived at read from the delivery's own
+// status (scheduledSendColumns), because comms owns the receipt and a second
+// writer would be a second place for the two to disagree about one message.
 const (
 	ScheduledStatusScheduled = "scheduled"
 	ScheduledStatusReleased  = "released"
+	ScheduledStatusSent      = "sent"
 	ScheduledStatusCancelled = "cancelled"
 	ScheduledStatusHeld      = "held"
 )

--- a/backend/internal/modules/activities/scheduledsendstore.go
+++ b/backend/internal/modules/activities/scheduledsendstore.go
@@ -24,8 +24,30 @@ import (
 
 // scheduledSendColumns is the read shape, spelled once so the list and the
 // detail read cannot drift into scanning different rows.
+// scheduledSendStatusExpr is the status a REP sees, spelled once because the
+// projection and the filter must agree: rendering a derived state while
+// filtering the raw column makes `?status=sent` return nothing and
+// `?status=released` return rows that read "sent".
+const scheduledSendStatusExpr = `
+	CASE WHEN status = 'released'
+	       AND EXISTS (SELECT 1 FROM comms_outbound o
+	                    WHERE o.id = scheduled_send.delivery_id AND o.status = 'sent')
+	     THEN 'sent' ELSE status END`
+
 const scheduledSendColumns = `
-	id, status, scheduled_at, scheduled_tz, origin_kind,
+	id,
+	-- 'released' is where the fire transaction leaves the row: the message has
+	-- been handed to the delivery machinery and the provider has not been called
+	-- yet. When the provider confirms receipt the DELIVERY records it, and the
+	-- scheduled send follows — a message this system sent reads "sent" whether a
+	-- rep scheduled it or pressed the button (ADR-0104 §5, DRAFT-AC-N-10a).
+	--
+	-- DERIVED at read rather than written by a second writer. comms owns the
+	-- receipt and this table belongs to activities, so a cross-module write
+	-- would be a second place for the two to disagree about one message. Reading
+	-- the delivery's own status cannot drift from it.
+	` + scheduledSendStatusExpr + ` AS status,
+	scheduled_at, scheduled_tz, origin_kind,
 	anchor_activity_id, payload, scheduled_by, activity_id,
 	held_reason, version, created_at, updated_at`
 
@@ -47,7 +69,7 @@ func (s *Store) ListScheduledSends(ctx context.Context, status string) ([]Schedu
 		rows, err := tx.Query(ctx, `
 			SELECT`+scheduledSendColumns+`
 			  FROM scheduled_send
-			 WHERE scheduled_by = $1 AND ($2 = '' OR status = $2)
+			 WHERE scheduled_by = $1 AND ($2 = '' OR `+scheduledSendStatusExpr+` = $2)
 			 ORDER BY scheduled_at ASC`,
 			actor.UserID, status)
 		if err != nil {


### PR DESCRIPTION
Implements the ratified correction to ADR-0104 (A155, **DECIDED** 2026-08-15), plus two defects the review rounds found.

## `released` is a step, not an ending

`released` was terminal on the ground that the provider has not been called yet. True at that instant, wrong as an ending: when the provider confirms receipt the delivery records it, and the scheduled send now **follows it to `sent`**. A message this system sent reads "sent" whether a rep scheduled it or pressed the button, which is how every other message already behaves.

Derived at read from the delivery's own status rather than written by a second writer — comms owns the receipt and `scheduled_send` belongs to activities, so a cross-module write would be a second place for the two to disagree about one message.

## The filter has to read the state the list renders

Rendering a derived status on the way out while filtering the raw column on the way in makes `?status=sent` return **nothing** and `?status=released` return rows that display as "sent". Each half individually correct; the pair useless. One expression now, used by both, with a test.

## The approval-kind gate was blind two ways

It derived its subject set from the **tool registry**, so a kind staged by a *worker* was invisible to it — and an unmapped kind is written to the approval table and then filtered out of the inbox, which looks exactly like a stager that never ran. It now derives from every `StageInput` in compose, and **reports** a Kind it cannot resolve rather than skipping it silently.

Strengthening it surfaced five more stagers it had been passing over. Both halves mutation-checked: remove a mapping and it fails; drop a file from its list and the parity assertion fails.

## Deliberately not included

**The inbox item ADR-0104 §5 requires for a held message.** I built it and withdrew it before merging: the generic inbox renders Accept/Reject, the kind had no registered effect, and either button would have dismissed the item while the message stayed held. An action item that lies about having resolved something is worse than none.

[#1312](https://github.com/gradionhq/margince-poc-v1/issues/1312) carries the full design and everything learned — including the object-read floor that made the item invisible, why the target type must be `activity` rather than an invented one, and the three registration points.

## Tests

Two new integration cases over a real Postgres, driving a real dispatch to a real provider receipt. Full backend gate, craft gate, RLS and jurisdiction greps all green; integration lane green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scheduled sends now end in status `sent` when the provider confirms receipt; previously `released` was terminal. `released` is now an intermediate step, and status is derived from the delivery record to keep modules in agreement. The list filter reads the same derived status, so `?status=sent` works and no longer returns nothing.

- Adds `sent` to the scheduled-send status enum in `crm.yaml` and generated `api_gen.go`.
- Derives status at read via one SQL expression shared by the projection and the list filter; no schema changes.
- Captures `OnBehalfOf` for scheduled-send fire/hold so audits show whose message was acted on.
- Strengthens the approval-kind gate in `compose`: scans every `approvals.StageInput`, reports unresolved kinds, and adds cross-package kind mappings; census count updated. New tests also assert the exported kind map stays complete.
- New integration tests cover “released → sent” and filter/projection consistency.
- Not included: the held-message inbox item (tracked in #1312).

**Migration/rollout**
- API clients must accept and, if filtering, request `status=sent` for delivered scheduled sends. If you previously filtered on `released` to find delivered items, switch to `sent`.

<sup>Written for commit 5fddf2e9891cd842a1af88dff7ff4aa035c40cd4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1313?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

