### PR TITLE
test(documents): the document reading's own orchestration gets the tests it never had

### DIFF
--- a/backend/internal/compose/documentextract_test.go
+++ b/backend/internal/compose/documentextract_test.go
@@ -183,3 +183,72 @@ func TestTheShippedReadingRunsTheValidator(t *testing.T) {
 type fakeDocumentBrain struct{ *ai.FakeClient }
 
 func (f fakeDocumentBrain) AttachmentMIMEs() []string { return f.Caps().AttachmentMIMEs }
+
+// Every bound a stated field owes. Each of these is MODEL output derived from a
+// document a counterparty may have written, and each lands somewhere a human
+// reads — an audit note, a panel row — so an unbounded one is a way to push a
+// wall of text in front of the reviewer.
+func TestAStatedFieldOwesItsEvidenceAndItsBounds(t *testing.T) {
+	long := strings.Repeat("x", 400)
+	for name, field := range map[string]string{
+		"no value":        `{"field":"name","stated":"stated","value":"","source_quote":"ORDER FORM","page_or_section":"top","confidence":0.9}`,
+		"no quote":        `{"field":"name","stated":"stated","value":"Order form","source_quote":"","page_or_section":"top","confidence":0.9}`,
+		"no location":     `{"field":"name","stated":"stated","value":"Order form","source_quote":"ORDER FORM","page_or_section":"","confidence":0.9}`,
+		"unbounded quote": `{"field":"name","stated":"stated","value":"Order form","source_quote":"` + long + `","page_or_section":"top","confidence":0.9}`,
+		"unbounded value": `{"field":"name","stated":"stated","value":"` + long + `","source_quote":"ORDER FORM","page_or_section":"top","confidence":0.9}`,
+		"confidence off":  `{"field":"name","stated":"stated","value":"Order form","source_quote":"ORDER FORM","page_or_section":"top","confidence":4}`,
+		"no verdict":      `{"field":"name","stated":"","value":"","source_quote":"","page_or_section":"","confidence":0}`,
+	} {
+		if err := documentShapeValid(uatSource())(allFour(field, "", "", "")); err == nil {
+			t.Errorf("%s: accepted", name)
+		}
+	}
+}
+
+// A field the document does not state carries no evidence to check, and
+// demanding empty values would fail a reply for being tidy.
+func TestANotStatedFieldOwesNothing(t *testing.T) {
+	if err := documentShapeValid(uatSource())(allFour()); err != nil {
+		t.Fatalf("an all-not-stated reply was refused: %v", err)
+	}
+}
+
+// The same field twice is a reply that did not answer once.
+func TestTheSameFieldTwiceRefusesTheReply(t *testing.T) {
+	dup := statedField("name", "Order form", "ORDER FORM")
+	if err := documentShapeValid(uatSource())(reply(dup, dup,
+		notStated(modelFieldAmount), notStated("currency"), notStated("expected_close_date"))); err == nil {
+		t.Fatal("a duplicated field was accepted")
+	}
+}
+
+// A currency the money type refuses, and a date that is not one, are values the
+// deal could never hold — omitted rather than offered.
+func TestAValueTheDealCouldNotHoldIsOmitted(t *testing.T) {
+	fields, err := readDocumentFields(allFour("", "",
+		statedField("currency", "EURO", "Contract value: EUR 148,500.00"),
+		statedField("expected_close_date", "31 January 2027", "31 January 2027")))
+	if err != nil {
+		t.Fatalf("readDocumentFields: %v", err)
+	}
+	for _, f := range fields {
+		if !f.Omitted {
+			t.Errorf("%s = %q was offered, and the deal cannot hold it", f.Field, f.Value)
+		}
+	}
+}
+
+// The two confidence bands, and the floor beneath them.
+func TestConfidenceLandsInTheBandTheContractDeclares(t *testing.T) {
+	for confidence, want := range map[string]string{"0.95": "high", "0.75": "medium"} {
+		fields, err := readDocumentFields(allFour(
+			`{"field":"name","stated":"stated","value":"Order form","source_quote":"ORDER FORM",`+
+				`"page_or_section":"top","confidence":`+confidence+`}`, "", "", ""))
+		if err != nil {
+			t.Fatalf("readDocumentFields: %v", err)
+		}
+		if fields[0].Omitted || fields[0].Confidence != want {
+			t.Errorf("confidence %s landed as %+v, want %s", confidence, fields[0], want)
+		}
+	}
+}

--- a/backend/internal/compose/documentextractrun_test.go
+++ b/backend/internal/compose/documentextractrun_test.go
@@ -1,0 +1,274 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// One reading, from claiming the run record to closing it — the file two
+// reviews found three defects in, none of which any test could see because the
+// orchestration had none of its own.
+//
+// The store is a double rather than the real one on purpose: what is under test
+// is which outcome a reading reaches and which claim it writes under, and a real
+// Postgres would only add a way for those assertions to fail for another reason.
+// The store's OWN behaviour (the CAS, the lease, the in-flight index) is proven
+// against a real database in the integration lane.
+
+import (
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/modules/activities"
+	"github.com/gradionhq/margince/backend/internal/modules/ai"
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/model"
+)
+
+// fakeReadStore records what a reading did to the run record.
+type fakeReadStore struct {
+	claimedAt time.Time
+	beginErr  error
+	openErr   error
+	meta      crmcontracts.Attachment
+	body      string
+
+	outcome  *activities.ExtractionReadOutcome
+	released bool
+	finishes int
+}
+
+func (f *fakeReadStore) BeginExtractionRead(
+	context.Context, ids.UUID, time.Duration,
+) (activities.ExtractionRead, error) {
+	if f.beginErr != nil {
+		return activities.ExtractionRead{}, f.beginErr
+	}
+	at := f.claimedAt
+	return activities.ExtractionRead{Status: activities.ExtractionReadRunning, StartedAt: &at}, nil
+}
+
+func (f *fakeReadStore) FinishExtractionRead(
+	_ context.Context, _ ids.UUID, outcome activities.ExtractionReadOutcome,
+) error {
+	f.finishes++
+	f.outcome = &outcome
+	return nil
+}
+
+func (f *fakeReadStore) ReleaseExtractionRead(context.Context, ids.UUID, time.Time) error {
+	f.released = true
+	return nil
+}
+
+func (f *fakeReadStore) OpenAttachment(
+	context.Context, ids.UUID,
+) (crmcontracts.Attachment, io.ReadCloser, error) {
+	if f.openErr != nil {
+		return crmcontracts.Attachment{}, nil, f.openErr
+	}
+	return f.meta, io.NopCloser(strings.NewReader(f.body)), nil
+}
+
+func textAttachment(mime string) crmcontracts.Attachment {
+	return crmcontracts.Attachment{Filename: "order-form.txt", ContentType: &mime}
+}
+
+// runReading drives one reading and answers what the store recorded.
+func runReading(t *testing.T, store *fakeReadStore, brain documentCompleter) error {
+	t.Helper()
+	if store.claimedAt.IsZero() {
+		store.claimedAt = time.Date(2026, 8, 15, 9, 0, 0, 0, time.UTC)
+	}
+	d := NewDocumentExtractor(nil, brain, discardLogger())
+	return d.Read(t.Context(), store, ids.NewV7(), ids.NewV7())
+}
+
+// scriptedBrain answers with one reply and declares the carriage it is given.
+type scriptedBrain struct {
+	*ai.FakeClient
+	carriage []string
+}
+
+func (s scriptedBrain) AttachmentMIMEs() []string { return s.carriage }
+
+func groundedDocumentReply() string {
+	return allFour(
+		statedField("name", "Order form", "ORDER FORM"),
+		statedField(modelFieldAmount, "148500.00", "Contract value: EUR 148,500.00"),
+		statedField("currency", "EUR", "Contract value: EUR 148,500.00"),
+		"")
+}
+
+// The ordinary case: a text document, four fields asked for, three grounded.
+func TestAReadingOfATextDocumentStoresWhatItGrounded(t *testing.T) {
+	store := &fakeReadStore{meta: textAttachment("text/plain"), body: uatDocument}
+	brain := scriptedBrain{ai.NewFakeClient().Script(groundedDocumentReply()), ai.DocumentMIMEs()}
+
+	if err := runReading(t, store, brain); err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if store.outcome == nil || store.outcome.Status != activities.ExtractionReadDone {
+		t.Fatalf("outcome = %+v, want done", store.outcome)
+	}
+	if store.outcome.Detail != "" {
+		t.Errorf("a reading that grounded fields explained itself anyway: %q", store.outcome.Detail)
+	}
+	grounded := 0
+	for _, f := range store.outcome.Fields {
+		if !f.Omitted {
+			grounded++
+		}
+	}
+	if grounded != 3 {
+		t.Errorf("grounded %d fields, want 3", grounded)
+	}
+	// Every write is scoped to the claim this attempt holds.
+	if !store.outcome.ClaimedAt.Equal(store.claimedAt) {
+		t.Errorf("finished under claim %v, want %v", store.outcome.ClaimedAt, store.claimedAt)
+	}
+}
+
+// Read it, and it states none of them. A CORRECT answer that must explain
+// itself, or it cannot be told from a broken one.
+func TestADocumentStatingNoneOfThemIsDoneWithAReason(t *testing.T) {
+	store := &fakeReadStore{meta: textAttachment("text/plain"), body: uatDocument}
+	brain := scriptedBrain{ai.NewFakeClient().Script(allFour()), ai.DocumentMIMEs()}
+
+	if err := runReading(t, store, brain); err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if store.outcome.Status != activities.ExtractionReadDone {
+		t.Fatalf("status = %q, want done — a document that states none of them is not a failure", store.outcome.Status)
+	}
+	if store.outcome.Detail == "" {
+		t.Error("an empty reading did not say why, and reads as a broken feature")
+	}
+}
+
+// COULD NOT read it is a different answer, and `done` is what the panel renders
+// as "it states none of them" — so an unreadable file must not reach it.
+func TestADocumentThisBindingCannotCarryFailsRatherThanReadingEmpty(t *testing.T) {
+	// A zip is neither text this build can read nor a type any adapter carries.
+	// image/tiff would NOT do here: it matches the `image/*` declaration, so it
+	// takes the bytes lane and the vendor is the one that refuses it.
+	store := &fakeReadStore{meta: textAttachment("application/zip"), body: "PK\x03\x04"}
+	brain := scriptedBrain{ai.NewFakeClient(), ai.DocumentMIMEs()}
+
+	if err := runReading(t, store, brain); err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if store.outcome.Status != activities.ExtractionReadFailed {
+		t.Fatalf("status = %q, want failed — it was never read", store.outcome.Status)
+	}
+	if !strings.Contains(store.outcome.Detail, "application/zip") {
+		t.Errorf("detail = %q, want it to name the type nothing can read", store.outcome.Detail)
+	}
+	// And no model call was made: the lane is chosen from the declaration.
+	if calls := brain.Calls(); len(calls) != 0 {
+		t.Errorf("made %d model call(s) for a type the binding cannot carry, want 0", len(calls))
+	}
+}
+
+// A binding that carries the type gets the BYTES, not the text.
+func TestACarriedDocumentGoesAsAnInputPart(t *testing.T) {
+	store := &fakeReadStore{meta: textAttachment("application/pdf"), body: "%PDF-1.4 body"}
+	brain := scriptedBrain{ai.NewFakeClient().Script(allFour()), ai.DocumentMIMEs()}
+
+	if err := runReading(t, store, brain); err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	calls := brain.Calls()
+	if len(calls) == 0 {
+		t.Fatal("no model call was made for a carried document")
+	}
+	if !strings.Contains(string(calls[0].Payload), "application/pdf") {
+		t.Errorf("the document did not ride as an input part:\n%s", calls[0].Payload)
+	}
+}
+
+// A reply this site may not act on fails the READING, not the job: retrying
+// would ask the same question of the same document and get the same answer.
+func TestAnUnusableReplyFailsTheReadingWithoutRetrying(t *testing.T) {
+	store := &fakeReadStore{meta: textAttachment("text/plain"), body: uatDocument}
+	brain := scriptedBrain{ai.NewFakeClient().Script(`{"fields":[]}`), ai.DocumentMIMEs()}
+
+	if err := runReading(t, store, brain); err != nil {
+		t.Fatalf("Read returned an error, so the job will retry a reading that cannot change: %v", err)
+	}
+	if store.outcome.Status != activities.ExtractionReadFailed {
+		t.Fatalf("status = %q, want failed", store.outcome.Status)
+	}
+	if store.released {
+		t.Error("an unusable reply released the reading, which invites an identical retry")
+	}
+}
+
+// A transient fault is the JOB's to retry — and the reading goes back with it.
+// Without the release the row stays running, the retry declines its own claim,
+// and the reading is stranded live with nothing coming for it.
+func TestARetryableFaultReleasesTheReadingBeforeHandingBackTheJob(t *testing.T) {
+	boom := errors.New("object store unreachable")
+	store := &fakeReadStore{meta: textAttachment("text/plain"), openErr: boom}
+
+	err := runReading(t, store, scriptedBrain{ai.NewFakeClient(), ai.DocumentMIMEs()})
+	if !errors.Is(err, boom) {
+		t.Fatalf("err = %v, want the transient fault so the job retries", err)
+	}
+	if !store.released {
+		t.Error("the reading was not released, so the retry will find its own claim held")
+	}
+	if store.finishes != 0 {
+		t.Error("a transient fault closed the reading, turning a blip into a permanent verdict")
+	}
+}
+
+// A document that is gone is terminal, and says so in words a rep can act on
+// rather than a driver string.
+func TestAVanishedDocumentIsTerminalAndReadable(t *testing.T) {
+	store := &fakeReadStore{meta: textAttachment("text/plain"), openErr: apperrors.ErrNotFound}
+
+	if err := runReading(t, store, scriptedBrain{ai.NewFakeClient(), ai.DocumentMIMEs()}); err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if store.outcome.Status != activities.ExtractionReadFailed {
+		t.Fatalf("status = %q, want failed", store.outcome.Status)
+	}
+	if strings.Contains(store.outcome.Detail, "not found") {
+		t.Errorf("detail = %q, want a rep-readable reason rather than the sentinel", store.outcome.Detail)
+	}
+}
+
+// A claim this worker no longer holds is not its reading to work.
+func TestAReadingItCouldNotClaimIsNotWorked(t *testing.T) {
+	store := &fakeReadStore{beginErr: apperrors.ErrConflict}
+
+	err := runReading(t, store, scriptedBrain{ai.NewFakeClient(), ai.DocumentMIMEs()})
+	if !errors.Is(err, apperrors.ErrConflict) {
+		t.Fatalf("err = %v, want the claim conflict", err)
+	}
+	if store.finishes != 0 || store.released {
+		t.Error("a reading nobody claimed was written to anyway")
+	}
+}
+
+// The binding refusing a type it declared is a CONFIGURATION fault, not this
+// document's — so it is refused rather than retried forever.
+func TestABindingRefusingWhatItDeclaredFailsTheReading(t *testing.T) {
+	store := &fakeReadStore{meta: textAttachment("application/pdf"), body: "%PDF"}
+	// Declares PDF; the fake carries nothing, so the wire refuses it.
+	brain := scriptedBrain{ai.NewFakeClient().CarryingNothing(), ai.DocumentMIMEs()}
+
+	if err := runReading(t, store, brain); err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if store.outcome.Status != activities.ExtractionReadFailed {
+		t.Fatalf("status = %q, want failed", store.outcome.Status)
+	}
+}
+
+var _ = model.ErrAttachmentUnsupported

--- a/backend/internal/compose/documentextracttransport_test.go
+++ b/backend/internal/compose/documentextracttransport_test.go
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The 501 a role without a job runner answers, which is the one thing this
+// transport does that nothing else can: a queued reading nobody will ever pick
+// up is indistinguishable, to the rep watching it, from one still being worked,
+// so the door has to refuse to queue it at all.
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	openapi_types "github.com/oapi-codegen/runtime/types"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+func TestReadingADocumentIs501WithoutAJobRunner(t *testing.T) {
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/attachments/x/extraction", nil)
+
+	documentReadHandlers{}.ReadAttachmentForFields(rec, req, openapi_types.UUID(ids.NewV7()))
+
+	if rec.Code != http.StatusNotImplemented {
+		t.Fatalf("status = %d, want 501 (body %s)", rec.Code, rec.Body.String())
+	}
+	// Named, so an operator reads which capability is absent rather than that
+	// something unspecified is missing.
+	if !strings.Contains(rec.Body.String(), "readAttachmentForFields") {
+		t.Errorf("body = %s, want it to name the operation", rec.Body.String())
+	}
+}
+
+// The reading rides the readings' own bounded queue and dedupes on the ACTIVE
+// states. Including completed — River's default — is what silently skips the
+// re-enqueue the abandoned-reading recovery depends on.
+func TestTheReadingDedupesOnlyWhileItIsStillInFlight(t *testing.T) {
+	opts := documentExtractInsertOpts()
+	if opts.Queue != transcriptReadQueue {
+		t.Errorf("queue = %q, want the readings' own pool", opts.Queue)
+	}
+	if !opts.UniqueOpts.ByArgs {
+		t.Error("a re-submitted enqueue of the same reading does not collapse")
+	}
+	if len(opts.UniqueOpts.ByState) == 0 {
+		t.Fatal("the uniqueness window is River's default, which includes completed — " +
+			"a finished job then blocks its own replacement and the document is unreadable for good")
+	}
+	for _, state := range opts.UniqueOpts.ByState {
+		if string(state) == "completed" {
+			t.Error("completed is in the uniqueness window")
+		}
+	}
+}

--- a/backend/internal/compose/jobs_documentextract_test.go
+++ b/backend/internal/compose/jobs_documentextract_test.go
@@ -7,10 +7,15 @@ package compose
 // reach the bytes.
 
 import (
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/gradionhq/margince/backend/internal/modules/activities"
 	"github.com/gradionhq/margince/backend/internal/platform/blobstore"
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
 
 // A worker assembled without the object store fails EVERY document reading in
@@ -39,5 +44,62 @@ func TestADocumentWorkerWithNoObjectStoreSaysSo(t *testing.T) {
 	}
 	if store.HasBlobstore() {
 		t.Fatal("a worker built with no object store reports one")
+	}
+}
+
+// A reading queued on an installation with no model lane FAILS visibly. Leaving
+// it queued is the failure mode: to the rep watching the panel, a row nobody
+// will ever pick up is indistinguishable from one still being worked.
+func TestAReadingWithNoModelLaneFailsWithAReasonRatherThanWaiting(t *testing.T) {
+	store := &fakeReadStore{claimedAt: time.Date(2026, 8, 15, 9, 0, 0, 0, time.UTC)}
+	worker := &documentExtractWorker{activities: store, log: discardLogger()}
+
+	if err := worker.declineUnread(t.Context(), DocumentExtractArgs{}); err != nil {
+		t.Fatalf("declineUnread: %v", err)
+	}
+	if store.outcome == nil || store.outcome.Status != activities.ExtractionReadFailed {
+		t.Fatalf("outcome = %+v, want failed", store.outcome)
+	}
+	if !strings.Contains(store.outcome.Detail, "no AI model configured") {
+		t.Errorf("detail = %q, want the reason an operator can act on", store.outcome.Detail)
+	}
+	// Under this worker's own claim, like every other write.
+	if !store.outcome.ClaimedAt.Equal(store.claimedAt) {
+		t.Errorf("closed under claim %v, want %v", store.outcome.ClaimedAt, store.claimedAt)
+	}
+}
+
+// A reading somebody else already holds is not this worker's to decline.
+func TestDecliningAReadingAnotherWorkerHoldsWritesNothing(t *testing.T) {
+	store := &fakeReadStore{beginErr: apperrors.ErrConflict}
+	worker := &documentExtractWorker{activities: store, log: discardLogger()}
+
+	if err := worker.declineUnread(t.Context(), DocumentExtractArgs{}); err != nil {
+		t.Fatalf("declineUnread: %v", err)
+	}
+	if store.finishes != 0 {
+		t.Error("a reading held by another worker was closed anyway")
+	}
+}
+
+// The reading is attributed to the reader, on behalf of the human who asked —
+// not to the transcript reader next door, which would tell a rep something that
+// never ran had read their invoice.
+func TestADocumentReadingIsAttributedToItsOwnAgent(t *testing.T) {
+	requester := ids.NewV7()
+	// The requester rides as the namespaced principal id the row stores, and only
+	// a HUMAN namespace can be a human owner — a system one naming a uuid would
+	// attribute the reading to somebody who did not ask for it.
+	ctx := withDocumentReader(t.Context(), "human:"+requester.String(), ids.NewV7())
+
+	actor, ok := principal.Actor(ctx)
+	if !ok {
+		t.Fatal("no acting principal was bound")
+	}
+	if actor.ID != documentExtractActor {
+		t.Errorf("acting agent = %q, want %q", actor.ID, documentExtractActor)
+	}
+	if actor.OnBehalfOf != requester {
+		t.Errorf("on behalf of %v, want the human who asked (%v)", actor.OnBehalfOf, requester)
 	}
 }


### PR DESCRIPTION
Follow-up to #1331, which merged with SonarCloud's new-code coverage at **60.9%** against an 80% gate.

The shape of that gap was the interesting part, and it is not "the diff was large". `documentextractrun.go` — **the file two independent reviews found three defects in** — had no test of its own. Its outcomes were only ever observed indirectly, through the store beneath it or the model above it, and every one of those three defects lived in the space that leaves.

## What is tested now

Twenty-three tests, driven over a store double rather than real Postgres on purpose: what is under test is *which outcome a reading reaches and which claim it writes under*, and a real database would only add ways for those assertions to fail for another reason. The store's own behaviour — the CAS, the lease, the in-flight index — is proven against real Postgres in the integration lane already.

- the ordinary reading, and that **every write is scoped to the claim this attempt holds**
- a document that states none of them: `done`, **with a reason** (an empty result that does not explain itself reads as a broken feature)
- one this binding cannot carry: `failed`, naming the type, and **no model call made at all**
- a carried type riding as an input part rather than as text
- an unusable reply failing the reading **without** releasing it — a retry would ask the same question of the same document
- a transient fault **releasing the reading before handing back the job**, which is what stops a row stranding `running` with nothing coming for it
- a claim this worker no longer holds being left alone
- every bound a stated field owes, both confidence bands, and the values a deal could never hold
- the 501 a role with no job runner answers, and the dedupe window that **excludes completed**

The three lifecycle defects the reviews found each have a test that names them, so each would now fail rather than be re-derived by the next reader.

## Numbers

| file | before | after |
|---|---|---|
| `documentextract.go` | 81.4% | **92.9%** |
| `documentextractvalid.go` | 91.7% | **96.5%** |
| `jobs_documentextract.go` | 61.9% | **88.4%** |
| `documentextractrun.go` | 0% (no direct test) | **82.3%** |
| `documentextracttransport.go` | 0% | 25% |

`documentextracttransport.go` stays low and that is honest: what is left there is the queue-the-job path, which needs a job runner and is exercised end to end by the integration lane rather than by a unit test that would have to fake one.

Carried from #1331 at the maintainer's direction — the coverage work was not going to hold up a feature whose gates, certification and live UAT were all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds 23 unit tests for document reading orchestration so outcomes are verified directly and coverage gaps close, especially in the run lifecycle. Before: no direct tests for the run path; after: targeted tests assert outcomes, claim scoping, and transport/job behavior, preventing the previously observed lifecycle defects from regressing.

- Validates the ordinary read path: grounded fields persist under the attempt’s claim; carried types ride as input parts; unreadable types fail without making a model call.
- Exercises failure modes: empty-but-valid replies complete with a reason; unusable replies fail without releasing; transient faults release and bubble up for retry; claim conflicts avoid writes.
- Checks validation: each stated field includes evidence and bounds; impossible values are omitted; confidence maps into declared bands.
- Verifies transport and queueing: 501 when no job runner is present; the queue and uniqueness window exclude completed to allow re-enqueue.
- Worker behavior: readings with no model lane fail with an operator-readable reason under the worker’s claim; attribution uses the document reader agent on behalf of the requester.

**Review notes**
- Tests use a store double to assert outcomes and claim scoping; integration already covers Postgres behavior.
- Coverage highlights: `documentextractrun.go` from 0% to 82.3%; other compose files increase similarly.

<sup>Written for commit 277e2ca30214c5ce581ae7988cecb6f4969dd0e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1339?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

