### PR TITLE
fix(identity): waive the SSRF rule on the metadata-document fetch, and fix the guards it relies on

### DIFF
--- a/backend/internal/modules/identity/oauth_cimd.go
+++ b/backend/internal/modules/identity/oauth_cimd.go
@@ -32,6 +32,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -86,6 +87,13 @@ type cimdDocument struct {
 // spellings of one identity, and the equality check further down compares the
 // PRESENTED string against the document's own claim: a normalizer here would
 // mean the string this server compares is not the string the client sent.
+//
+// A "." or ".." path segment is refused for the same reason and is the sharpest
+// case of it: /a/../b and /b are one document to every server that will ever
+// serve it and two distinct client ids here, so a document published once would
+// speak for unboundedly many identities — each with its own row and its own
+// redirect list. Refused in the DECODED path, so %2e%2e is the same refusal as
+// .. rather than a way around it.
 func cimdClientID(raw string) error {
 	if !strings.HasPrefix(raw, "https://") {
 		return errNotCIMD
@@ -99,9 +107,14 @@ func cimdClientID(raw string) error {
 		return errNotCIMD
 	case u.Path == "" || u.Path == "/":
 		return errNotCIMD
+	case slices.ContainsFunc(strings.Split(u.Path, "/"), isDotSegment):
+		return errNotCIMD
 	}
 	return nil
 }
+
+// isDotSegment reports whether a path segment is the relative "." or "..".
+func isDotSegment(segment string) bool { return segment == "." || segment == ".." }
 
 // resolveCIMDClient makes a metadata-document client resolvable by the ordinary
 // authorize path: it ensures the oauth_client row for clientID exists and is

--- a/backend/internal/modules/identity/oauth_cimd.go
+++ b/backend/internal/modules/identity/oauth_cimd.go
@@ -57,6 +57,11 @@ const (
 	// authorize, which turns one consent page into an outbound request the
 	// client controls the rate of; without a ceiling a rotated redirect_uris
 	// list would take a year to be believed.
+	//
+	// The floor bounds a KNOWN client only. A fetch that fails writes no row, and
+	// a client_id never seen before has none, so neither is cached and a caller
+	// naming a fresh URL each time still gets one outbound request per authorize.
+	// What bounds that is the authorize rate limit, not this.
 	cimdMinCache = 5 * time.Minute
 	cimdMaxCache = 24 * time.Hour
 )
@@ -88,12 +93,18 @@ type cimdDocument struct {
 // PRESENTED string against the document's own claim: a normalizer here would
 // mean the string this server compares is not the string the client sent.
 //
-// A "." or ".." path segment is refused for the same reason and is the sharpest
-// case of it: /a/../b and /b are one document to every server that will ever
-// serve it and two distinct client ids here, so a document published once would
-// speak for unboundedly many identities — each with its own row and its own
-// redirect list. Refused in the DECODED path, so %2e%2e is the same refusal as
-// .. rather than a way around it.
+// A "." or ".." path segment is refused because the profile prohibits it and
+// because /a/../c.json and /c.json are one document to the server that serves
+// them and two client ids here, each with its own row and its own redirect
+// list. It is checked on the DECODED path, so %2e%2e is the same refusal.
+//
+// It is hygiene, NOT the gate, and the difference matters to whoever edits this
+// next: other spellings normalize on some origin servers and not here (a
+// ";params" segment, a backslash, overlong UTF-8), so this can never be the
+// reason a document is trusted. What makes a document speak for its own URL and
+// no other is the byte-for-byte equality check in validCIMD, which holds with
+// or without this. Removing that one is removing the mechanism's security;
+// removing this one costs tidiness.
 func cimdClientID(raw string) error {
 	if !strings.HasPrefix(raw, "https://") {
 		return errNotCIMD

--- a/backend/internal/modules/identity/oauth_cimd_test.go
+++ b/backend/internal/modules/identity/oauth_cimd_test.go
@@ -114,8 +114,8 @@ func TestARedirectInADocumentIsHeldToTheSameRuleAsARegisteredOne(t *testing.T) {
 	}
 }
 
-// reachableCIMDClient points the package's fetch at the production client with
-// ONLY its transport replaced, and restores it when the test ends.
+// useReachableCIMDClient points the package's fetch at the production client
+// with ONLY its transport replaced, and restores it when the test ends.
 //
 // The dialer is what has to go and the only thing that may: netguard refuses a
 // loopback address in its Control hook and httptest listens on one, so with the
@@ -125,7 +125,7 @@ func TestARedirectInADocumentIsHeldToTheSameRuleAsARegisteredOne(t *testing.T) {
 // mean deleting it from the client changes nothing about the tests that claim
 // to hold it. The address guard keeps its own test, which is the only one in
 // this file that uses the real client whole.
-func reachableCIMDClient(t *testing.T) {
+func useReachableCIMDClient(t *testing.T) {
 	t.Helper()
 	guarded := cimdClient
 	reachable := *guarded
@@ -138,7 +138,7 @@ func reachableCIMDClient(t *testing.T) {
 // a malformed input: an oversized body spends this server's memory, and a
 // non-JSON answer or a 404 is a page that was never a metadata document.
 func TestTheFetchRefusesWhatIsNotAMetadataDocument(t *testing.T) {
-	reachableCIMDClient(t)
+	useReachableCIMDClient(t)
 
 	oversized := strings.Repeat("x", cimdMaxDocument+1)
 	cases := map[string]http.HandlerFunc{
@@ -163,9 +163,8 @@ func TestTheFetchRefusesWhatIsNotAMetadataDocument(t *testing.T) {
 	}
 
 	// The control, and it is load-bearing: a VALID document must be accepted
-	// through the same client. Without it every refusal above could still be a
-	// connect failure wearing a different name, which is the defect this test
-	// had before the swap.
+	// through the same client. Without it every refusal above could equally be a
+	// connect failure wearing a different name.
 	valid := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		//craft:ignore swallowed-errors a test server's write failure is the client hanging up
@@ -188,7 +187,7 @@ func TestTheFetchRefusesWhatIsNotAMetadataDocument(t *testing.T) {
 // the one the caller presented, not the one that answered — so a document
 // published anywhere would speak for a client id belonging to somewhere else.
 func TestTheFetchDoesNotFollowARedirect(t *testing.T) {
-	reachableCIMDClient(t)
+	useReachableCIMDClient(t)
 
 	// The first server is bound but not serving yet, so its own URL is known
 	// before the second server has to name it. A variable written after both are
@@ -210,8 +209,16 @@ func TestTheFetchDoesNotFollowARedirect(t *testing.T) {
 	first.Start()
 	defer first.Close()
 
-	if _, _, err := fetchCIMD(t.Context(), clientID); err == nil {
+	_, _, err := fetchCIMD(t.Context(), clientID)
+
+	if err == nil {
 		t.Fatal("the fetch followed a redirect: the document that answered was published at a URL the client_id equality check never saw")
+	}
+	// And it must be the 30x itself that refused it. Any other refusal means the
+	// hop was taken and something downstream caught the result, which is the
+	// redirect policy being untested rather than held.
+	if !strings.Contains(err.Error(), "answered 302") {
+		t.Fatalf("the fetch failed with %q, want the redirect refused as a status this server does not accept", err)
 	}
 }
 

--- a/backend/internal/modules/identity/oauth_cimd_test.go
+++ b/backend/internal/modules/identity/oauth_cimd_test.go
@@ -24,10 +24,21 @@ func TestOnlyAnHTTPSURLWithAPathIsAMetadataDocumentClientID(t *testing.T) {
 		"http://app.example.com/client.json":         false, // the profile pins https
 		"https://user:pw@app.example.com/client.jsn": false, // userinfo is a second spelling of one id
 		"https://app.example.com/c.json#frag":        false, // so is a fragment
-		"s6BhdRkqt3":                                 false, // an opaque DCR id
-		"":                                           false,
-		"https://":                                   false,
-		"::not a url":                                false,
+		// Dot segments are the sharpest spelling problem: each of these names the
+		// same document as /client.json to the server that serves it, and a
+		// distinct client id here.
+		"https://app.example.com/a/../client.json":   false,
+		"https://app.example.com/./client.json":      false,
+		"https://app.example.com/a/%2e%2e/client.js": false, // percent-encoded, decoded before the check
+		"https://app.example.com/..":                 false,
+		// A segment that merely CONTAINS dots is an ordinary name, not a
+		// relative reference, and stays a valid id.
+		"https://app.example.com/..client.json": true,
+		"https://app.example.com/a...b/c.json":  true,
+		"s6BhdRkqt3":                            false, // an opaque DCR id
+		"":                                      false,
+		"https://":                              false,
+		"::not a url":                           false,
 	}
 	for raw, want := range cases {
 		err := cimdClientID(raw)
@@ -103,24 +114,31 @@ func TestARedirectInADocumentIsHeldToTheSameRuleAsARegisteredOne(t *testing.T) {
 	}
 }
 
-// The fetch's guards, against a real server. Each case is an attack rather than
-// a malformed input: an oversized body spends this server's memory, a redirect
-// walks past the address guard on its next hop, and a non-JSON answer is a page
-// that was never a metadata document.
+// reachableCIMDClient points the package's fetch at the production client with
+// ONLY its transport replaced, and restores it when the test ends.
 //
-// The egress guard is SWAPPED OUT for the duration, and that is what makes these
-// assertions mean anything. netguard refuses a loopback address in the dialer's
-// Control hook, and httptest listens on one — so with the real client every case
-// below fails at connect time, none of them reaches the handler, and all four
-// pass on a guard they are not about. That is exactly the shape of a test that
-// cannot fail. The address guard keeps its own test, immediately below, which is
-// the only one here that uses the real client.
-func TestTheFetchRefusesWhatIsNotAMetadataDocument(t *testing.T) {
+// The dialer is what has to go and the only thing that may: netguard refuses a
+// loopback address in its Control hook and httptest listens on one, so with the
+// real transport every case below would fail at connect time and pass on a
+// guard it is not about. Everything else stays the production client's own —
+// the redirect policy above all, since a hand-written copy of it here would
+// mean deleting it from the client changes nothing about the tests that claim
+// to hold it. The address guard keeps its own test, which is the only one in
+// this file that uses the real client whole.
+func reachableCIMDClient(t *testing.T) {
+	t.Helper()
 	guarded := cimdClient
-	cimdClient = &http.Client{Timeout: cimdFetchTimeout, CheckRedirect: func(*http.Request, []*http.Request) error {
-		return http.ErrUseLastResponse
-	}}
+	reachable := *guarded
+	reachable.Transport = &http.Transport{}
+	cimdClient = &reachable
 	t.Cleanup(func() { cimdClient = guarded })
+}
+
+// The fetch's guards, against a real server. Each case is an attack rather than
+// a malformed input: an oversized body spends this server's memory, and a
+// non-JSON answer or a 404 is a page that was never a metadata document.
+func TestTheFetchRefusesWhatIsNotAMetadataDocument(t *testing.T) {
+	reachableCIMDClient(t)
 
 	oversized := strings.Repeat("x", cimdMaxDocument+1)
 	cases := map[string]http.HandlerFunc{
@@ -128,9 +146,6 @@ func TestTheFetchRefusesWhatIsNotAMetadataDocument(t *testing.T) {
 			w.Header().Set("Content-Type", "application/json")
 			//craft:ignore swallowed-errors a test server's write failure is the client hanging up
 			_, _ = w.Write([]byte(`{"padding":"` + oversized + `"}`))
-		},
-		"a redirect to somewhere else": func(w http.ResponseWriter, r *http.Request) {
-			http.Redirect(w, r, "https://elsewhere.example/client.json", http.StatusFound)
 		},
 		"an HTML page": func(w http.ResponseWriter, _ *http.Request) {
 			w.Header().Set("Content-Type", "text/html")
@@ -163,16 +178,59 @@ func TestTheFetchRefusesWhatIsNotAMetadataDocument(t *testing.T) {
 	}
 }
 
+// A redirect is not followed, and the second hop here is built to SUCCEED if it
+// were: the document it serves claims the first URL, so the equality check, the
+// media type, the size limit and the status check all pass on it. Only the
+// refusal to take the hop refuses this fetch.
+//
+// That is the attack it closes. A followed redirect is a second URL the caller
+// chose and the equality check never sees — the client_id it is held against is
+// the one the caller presented, not the one that answered — so a document
+// published anywhere would speak for a client id belonging to somewhere else.
+func TestTheFetchDoesNotFollowARedirect(t *testing.T) {
+	reachableCIMDClient(t)
+
+	// The first server is bound but not serving yet, so its own URL is known
+	// before the second server has to name it. A variable written after both are
+	// running would be read from the server's goroutine instead.
+	first := httptest.NewUnstartedServer(nil)
+	clientID := "http://" + first.Listener.Addr().String() + "/client.json"
+
+	second := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		//craft:ignore swallowed-errors a test server's write failure is the client hanging up
+		_, _ = w.Write([]byte(`{"client_id":"` + clientID + `","client_name":"n",` +
+			`"redirect_uris":["https://a.example/cb"]}`))
+	}))
+	defer second.Close()
+
+	first.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, second.URL+"/client.json", http.StatusFound)
+	})
+	first.Start()
+	defer first.Close()
+
+	if _, _, err := fetchCIMD(t.Context(), clientID); err == nil {
+		t.Fatal("the fetch followed a redirect: the document that answered was published at a URL the client_id equality check never saw")
+	}
+}
+
 // A private or loopback address is refused at CONNECT time, on the resolved IP,
 // so a public-looking hostname that resolves inward cannot make this server
 // probe its own network. httptest listens on 127.0.0.1, which is exactly the
 // address the guard exists to refuse — so a successful fetch here would BE the
 // vulnerability.
+//
+// The document served is VALID and claims the URL it is served from, which is
+// what makes this test able to fail: a document that claimed anything else
+// would be refused by the equality check even after a successful connect, and
+// the test would pass with the dialer's guard deleted.
 func TestTheFetchRefusesAnAddressInsideTheDeployment(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		//craft:ignore swallowed-errors a test server's write failure is the client hanging up
-		_, _ = w.Write([]byte(`{"client_id":"x","client_name":"n","redirect_uris":["https://a/cb"]}`))
+		_, _ = w.Write([]byte(`{"client_id":"http://` + r.Host + `/client.json","client_name":"n",` +
+			`"redirect_uris":["https://a.example/cb"]}`))
 	}))
 	defer srv.Close()
 
@@ -180,6 +238,12 @@ func TestTheFetchRefusesAnAddressInsideTheDeployment(t *testing.T) {
 
 	if err == nil {
 		t.Fatal("a metadata document on a loopback address was fetched; an unauthenticated caller can probe this deployment's network")
+	}
+	// And it must be the ADDRESS that refused it. Any other refusal here means
+	// the connect succeeded and something downstream caught the document, which
+	// is the guard being untested rather than held.
+	if !strings.Contains(err.Error(), "non-public") {
+		t.Fatalf("the fetch failed with %q, want netguard's non-public refusal — the loopback connect was not what stopped it", err)
 	}
 }
 

--- a/backend/internal/platform/netguard/netguard.go
+++ b/backend/internal/platform/netguard/netguard.go
@@ -14,19 +14,36 @@ import (
 	"syscall"
 )
 
-// reservedNets are the non-public ranges the stdlib predicates miss: the
-// "this-network" 0.0.0.0/8 (only the exact 0.0.0.0 is IsUnspecified, but the
-// whole block routes to loopback on Linux), CGNAT, benchmark, documentation,
-// protocol-assignment and broadcast, plus the IPv6 ranges that translate to
-// IPv4 internals — NAT64 (64:ff9b::/96, e.g. 64:ff9b::a9fe:a9fe → link-local
-// metadata) and IPv4-compatible ::/96 — which To4()/IsPrivate() do not catch.
+// reservedNets are the non-public ranges the stdlib predicates miss — every
+// IANA special-purpose entry whose "Globally Reachable" is False and that
+// IsLoopback/IsPrivate/IsLinkLocalUnicast/IsMulticast/IsUnspecified do not
+// already cover.
+//
+// Three groups, because they are refused for three different reasons. Ranges
+// that are simply not routable to anyone (this-network 0.0.0.0/8 — only the
+// exact 0.0.0.0 is IsUnspecified, but the whole block routes to loopback on
+// Linux — CGNAT, benchmarking, documentation, protocol assignments, broadcast,
+// discard-only, SRv6 SIDs, deprecated site-local). Ranges that EMBED another
+// address and are therefore a way to name an internal one: both NAT64 prefixes
+// (the well-known 64:ff9b::/96 and the local-use 64:ff9b:1::/48 — e.g.
+// 64:ff9b::a9fe:a9fe is link-local metadata wearing a v6 address), 6to4
+// 2002::/16, and IPv4-compatible ::/96. And 2001::/23 whole, which is where
+// Teredo, AMT and ORCHIDv2 live — each an encapsulation or an identifier
+// rather than a host this server has business dialing.
+//
+// IPv4-mapped (::ffff:0:0/96) is deliberately NOT here: it is the same host by
+// another spelling, and both the stdlib predicates and net.IPNet.Contains
+// normalize it, so ::ffff:127.0.0.1 is already refused as loopback while
+// ::ffff:8.8.8.8 stays reachable.
 var reservedNets = func() []*net.IPNet {
 	// These literal reserved/special-use ranges ARE the guard: the SSRF
 	// denylist must name them explicitly. NOSONAR: hardcoding them is the point.
 	cidrs := []string{
-		"0.0.0.0/8", "100.64.0.0/10", "192.0.0.0/24", "192.0.2.0/24", //NOSONAR
-		"198.18.0.0/15", "198.51.100.0/24", "203.0.113.0/24", "240.0.0.0/4", //NOSONAR
-		"2001:db8::/32", "64:ff9b::/96", "::/96",
+		"0.0.0.0/8", "100.64.0.0/10", "192.0.0.0/24", "192.0.2.0/24", // NOSONAR
+		"192.88.99.0/24", "198.18.0.0/15", "198.51.100.0/24", // NOSONAR
+		"203.0.113.0/24", "240.0.0.0/4", // NOSONAR
+		"100::/64", "2001::/23", "2001:db8::/32", "2002::/16", "3fff::/20",
+		"5f00::/16", "64:ff9b::/96", "64:ff9b:1::/48", "fec0::/10", "::/96",
 	}
 	nets := make([]*net.IPNet, len(cidrs))
 	for i, c := range cidrs {

--- a/backend/internal/platform/netguard/netguard.go
+++ b/backend/internal/platform/netguard/netguard.go
@@ -14,27 +14,36 @@ import (
 	"syscall"
 )
 
-// reservedNets are the non-public ranges the stdlib predicates miss — every
-// IANA special-purpose entry whose "Globally Reachable" is False and that
+// reservedNets are the non-public ranges the stdlib predicates miss: every IANA
+// special-purpose range that is not globally reachable and that
 // IsLoopback/IsPrivate/IsLinkLocalUnicast/IsMulticast/IsUnspecified do not
-// already cover.
+// already cover, plus two blankets taken whole, described below.
 //
-// Three groups, because they are refused for three different reasons. Ranges
-// that are simply not routable to anyone (this-network 0.0.0.0/8 — only the
-// exact 0.0.0.0 is IsUnspecified, but the whole block routes to loopback on
-// Linux — CGNAT, benchmarking, documentation, protocol assignments, broadcast,
-// discard-only, SRv6 SIDs, deprecated site-local). Ranges that EMBED another
-// address and are therefore a way to name an internal one: both NAT64 prefixes
-// (the well-known 64:ff9b::/96 and the local-use 64:ff9b:1::/48 — e.g.
-// 64:ff9b::a9fe:a9fe is link-local metadata wearing a v6 address), 6to4
-// 2002::/16, and IPv4-compatible ::/96. And 2001::/23 whole, which is where
-// Teredo, AMT and ORCHIDv2 live — each an encapsulation or an identifier
-// rather than a host this server has business dialing.
+// Two groups, because they are refused for two different reasons. Ranges that
+// reach nobody, so a request to one is a request to this deployment or to
+// nothing: this-network 0.0.0.0/8 (only the exact 0.0.0.0 is IsUnspecified, but
+// the whole block routes to loopback on Linux), CGNAT, benchmarking,
+// documentation (v4, 2001:db8::/32 and the newer 3fff::/20), protocol
+// assignments, broadcast, discard-only 100::/64, the dummy prefix
+// 100:0:0:1::/64, SRv6 SIDs and deprecated site-local.
 //
-// IPv4-mapped (::ffff:0:0/96) is deliberately NOT here: it is the same host by
-// another spelling, and both the stdlib predicates and net.IPNet.Contains
-// normalize it, so ::ffff:127.0.0.1 is already refused as loopback while
-// ::ffff:8.8.8.8 stays reachable.
+// And ranges that CARRY another address inside them, which is how an internal
+// address is named without looking like one: both NAT64 prefixes (well-known
+// 64:ff9b::/96 and local-use 64:ff9b:1::/48 — 64:ff9b::a9fe:a9fe is link-local
+// metadata wearing a v6 address), 6to4 2002::/16 with its relay anycast
+// 192.88.99.0/24 (2002:7f00:1::1 is 127.0.0.1), IPv4-compatible ::/96 and
+// IPv4-translated ::ffff:0:0:0/96.
+//
+// The two blankets are 2001::/23 and the NAT64 prefixes. Both hold entries IANA
+// marks globally reachable, so they are wider than the rule above: what lives
+// there is Teredo, AMT and ORCHIDv2 — encapsulations and identifiers, not hosts
+// this deployment has business dialing on a tenant's say-so.
+//
+// IPv4-MAPPED ::ffff:0:0/96 is deliberately NOT here, and is not the same thing
+// as IPv4-translated one paragraph up: it is an ordinary host under a second
+// spelling, and both the stdlib predicates and net.IPNet.Contains fold it
+// through To4(), so ::ffff:127.0.0.1 is already refused as loopback while
+// ::ffff:8.8.8.8 stays reachable. Listing it would block the public internet.
 var reservedNets = func() []*net.IPNet {
 	// These literal reserved/special-use ranges ARE the guard: the SSRF
 	// denylist must name them explicitly. NOSONAR: hardcoding them is the point.
@@ -42,8 +51,9 @@ var reservedNets = func() []*net.IPNet {
 		"0.0.0.0/8", "100.64.0.0/10", "192.0.0.0/24", "192.0.2.0/24", // NOSONAR
 		"192.88.99.0/24", "198.18.0.0/15", "198.51.100.0/24", // NOSONAR
 		"203.0.113.0/24", "240.0.0.0/4", // NOSONAR
-		"100::/64", "2001::/23", "2001:db8::/32", "2002::/16", "3fff::/20",
-		"5f00::/16", "64:ff9b::/96", "64:ff9b:1::/48", "fec0::/10", "::/96",
+		"100::/64", "100:0:0:1::/64", "2001::/23", "2001:db8::/32", "2002::/16",
+		"3fff::/20", "5f00::/16", "64:ff9b::/96", "64:ff9b:1::/48", "fec0::/10",
+		"::ffff:0:0:0/96", "::/96",
 	}
 	nets := make([]*net.IPNet, len(cidrs))
 	for i, c := range cidrs {

--- a/backend/internal/platform/netguard/netguard_test.go
+++ b/backend/internal/platform/netguard/netguard_test.go
@@ -37,12 +37,16 @@ func TestPublicIPClassifiesReservedRanges(t *testing.T) {
 		{"2001::1", false},              // Teredo, inside the 2001::/23 protocol assignments
 		{"2001:20::1", false},           // ORCHIDv2, same block
 		{"100::1", false},               // discard-only
+		{"100:0:0:1::1", false},         // dummy prefix
 		{"5f00::1", false},              // SRv6 SIDs
 		{"fec0::1", false},              // deprecated site-local
 		{"::0.1.2.3", false},            // IPv4-compatible ::/96
+		{"::ffff:0:a9fe:a9fe", false},   // IPv4-translated → 169.254.169.254, the third 4-in-6 spelling
 		{"::ffff:8.8.8.8", true},        // IPv4-mapped public — still reachable
 		{"::ffff:127.0.0.1", false},     // IPv4-mapped loopback — the same host, another spelling
 		{"2606:4700::1111", true},       // an ordinary public v6 neighbour of the blocks above
+		{"2001:200::1", true},           // the first RIR allocation, one bit past 2001::/23
+		{"2001:4860:4860::8888", true},  // ordinary public resolver, above the blanket
 	}
 	for _, c := range cases {
 		ip := net.ParseIP(c.ip)

--- a/backend/internal/platform/netguard/netguard_test.go
+++ b/backend/internal/platform/netguard/netguard_test.go
@@ -17,20 +17,32 @@ func TestPublicIPClassifiesReservedRanges(t *testing.T) {
 		{"8.8.8.8", true},
 		{"1.1.1.1", true},
 		{"2606:4700:4700::1111", true},
-		{"127.0.0.1", false},          // loopback
-		{"::1", false},                // loopback v6
-		{"10.0.0.5", false},           // private
-		{"192.168.1.10", false},       // private
-		{"172.16.0.1", false},         // private
-		{"169.254.169.254", false},    // link-local (cloud metadata)
-		{"100.64.1.1", false},         // CGNAT (reserved)
-		{"192.0.2.5", false},          // documentation (reserved)
-		{"0.0.0.0", false},            // unspecified
-		{"0.1.2.3", false},            // 0.0.0.0/8 "this network" (routes to loopback)
-		{"2001:db8::1", false},        // documentation v6 (reserved)
-		{"64:ff9b::a9fe:a9fe", false}, // NAT64 → 169.254.169.254 (metadata)
-		{"::0.1.2.3", false},          // IPv4-compatible ::/96
-		{"::ffff:8.8.8.8", true},      // IPv4-mapped public — still reachable
+		{"127.0.0.1", false},            // loopback
+		{"::1", false},                  // loopback v6
+		{"10.0.0.5", false},             // private
+		{"192.168.1.10", false},         // private
+		{"172.16.0.1", false},           // private
+		{"169.254.169.254", false},      // link-local (cloud metadata)
+		{"100.64.1.1", false},           // CGNAT (reserved)
+		{"192.0.2.5", false},            // documentation (reserved)
+		{"192.88.99.1", false},          // 6to4 relay anycast (deprecated)
+		{"0.0.0.0", false},              // unspecified
+		{"0.1.2.3", false},              // 0.0.0.0/8 "this network" (routes to loopback)
+		{"2001:db8::1", false},          // documentation v6 (reserved)
+		{"3fff::1", false},              // documentation v6 (RFC 9637)
+		{"64:ff9b::a9fe:a9fe", false},   // NAT64 → 169.254.169.254 (metadata)
+		{"64:ff9b:1::a9fe:a9fe", false}, // local-use NAT64 → the same metadata address
+		{"2002:7f00:1::1", false},       // 6to4 embedding 127.0.0.1
+		{"2002:0a00:5::1", false},       // 6to4 embedding 10.0.0.5
+		{"2001::1", false},              // Teredo, inside the 2001::/23 protocol assignments
+		{"2001:20::1", false},           // ORCHIDv2, same block
+		{"100::1", false},               // discard-only
+		{"5f00::1", false},              // SRv6 SIDs
+		{"fec0::1", false},              // deprecated site-local
+		{"::0.1.2.3", false},            // IPv4-compatible ::/96
+		{"::ffff:8.8.8.8", true},        // IPv4-mapped public — still reachable
+		{"::ffff:127.0.0.1", false},     // IPv4-mapped loopback — the same host, another spelling
+		{"2606:4700::1111", true},       // an ordinary public v6 neighbour of the blocks above
 	}
 	for _, c := range cases {
 		ip := net.ParseIP(c.ip)
@@ -48,10 +60,12 @@ func TestRefusePrivateBlocksNonPublicAndAllowsPublic(t *testing.T) {
 		t.Errorf("public address should dial: %v", err)
 	}
 	for _, addr := range []string{
-		"169.254.169.254:80",       // cloud metadata
-		"127.0.0.1:993",            // loopback
-		"10.1.2.3:993",             // private
-		"[64:ff9b::a9fe:a9fe]:993", // NAT64 → metadata
+		"169.254.169.254:80",         // cloud metadata
+		"127.0.0.1:993",              // loopback
+		"10.1.2.3:993",               // private
+		"[64:ff9b::a9fe:a9fe]:993",   // NAT64 → metadata
+		"[64:ff9b:1::a9fe:a9fe]:993", // local-use NAT64 → the same
+		"[2002:7f00:1::1]:993",       // 6to4 → 127.0.0.1
 	} {
 		if err := RefusePrivate("tcp", addr, nil); err == nil {
 			t.Errorf("RefusePrivate(%q) should refuse, got nil", addr)

--- a/backend/netguardparity_test.go
+++ b/backend/netguardparity_test.go
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build !integration
+
+package backendarch
+
+// The egress SSRF denylist exists twice. internal/platform/netguard owns it;
+// extensions/dispact-connector restates it because an extension unit is its own
+// module and may import only the published pkg/** surface, which this guard is
+// not on yet.
+//
+// A copy drifts, and this one drifted the moment the core list grew: the unit
+// dials a member-supplied host, so a range the core refuses and the copy admits
+// is not a style difference, it is the way around the core's guard. Only this
+// module can see both files, so the comparison lives here rather than beside
+// either list.
+//
+// It compares the CIDR sets, not the file text: the two are formatted
+// differently and grouped differently on purpose.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"slices"
+	"strconv"
+	"testing"
+)
+
+// egressDenylists names where each copy lives and the identifier that holds it.
+var egressDenylists = map[string]struct{ file, ident string }{
+	"core":      {"internal/platform/netguard/netguard.go", "reservedNets"},
+	"extension": {"../extensions/dispact-connector/client.go", "reservedCIDRs"},
+}
+
+func TestTheExtensionCopyOfTheEgressDenylistMatchesTheCore(t *testing.T) {
+	core := cidrLiteralsIn(t, egressDenylists["core"].file, egressDenylists["core"].ident)
+	extension := cidrLiteralsIn(t, egressDenylists["extension"].file, egressDenylists["extension"].ident)
+
+	for _, cidr := range core {
+		if !slices.Contains(extension, cidr) {
+			t.Errorf("%s refuses %s and the extension copy does not — a member-supplied host reaches it there",
+				egressDenylists["core"].file, cidr)
+		}
+	}
+	for _, cidr := range extension {
+		if !slices.Contains(core, cidr) {
+			t.Errorf("the extension copy refuses %s and %s does not — the core guard is the weaker of the two",
+				cidr, egressDenylists["core"].file)
+		}
+	}
+}
+
+// cidrLiteralsIn reads the string literals of the []string the named identifier
+// is declared from. It fails rather than returning nothing when the identifier
+// is gone: an empty list would compare equal to an empty list and report two
+// matching denylists where there is no denylist at all.
+func cidrLiteralsIn(t *testing.T, file, ident string) []string {
+	t.Helper()
+	parsed, err := parser.ParseFile(token.NewFileSet(), file, nil, 0)
+	if err != nil {
+		t.Fatalf("reading %s: %v", file, err)
+	}
+
+	var cidrs []string
+	ast.Inspect(parsed, func(node ast.Node) bool {
+		spec, ok := node.(*ast.ValueSpec)
+		if !ok || !slices.ContainsFunc(spec.Names, func(name *ast.Ident) bool { return name.Name == ident }) {
+			return true
+		}
+		ast.Inspect(spec, func(inner ast.Node) bool {
+			literal, ok := inner.(*ast.BasicLit)
+			if !ok || literal.Kind != token.STRING {
+				return true
+			}
+			value, err := strconv.Unquote(literal.Value)
+			if err != nil {
+				t.Fatalf("%s: %s holds an unreadable literal %s", file, ident, literal.Value)
+			}
+			cidrs = append(cidrs, value)
+			return true
+		})
+		return false
+	})
+
+	if len(cidrs) == 0 {
+		t.Fatalf("%s: found no CIDR literals under %s — it was renamed or moved, and this test now compares nothing",
+			file, ident)
+	}
+	return cidrs
+}

--- a/extensions/dispact-connector/client.go
+++ b/extensions/dispact-connector/client.go
@@ -202,9 +202,11 @@ func refusePrivate(_, address string, _ syscall.RawConn) error {
 // error constants above). A parse per CIDR on a call that is about to cross a
 // network is not a cost worth engineering around.
 var reservedCIDRs = []string{
-	"0.0.0.0/8", "100.64.0.0/10", "192.0.0.0/24", "192.0.2.0/24",
-	"192.88.99.0/24", "198.18.0.0/15", "198.51.100.0/24",
-	"203.0.113.0/24", "240.0.0.0/4",
+	// These literal reserved ranges ARE the guard: the denylist must name them
+	// explicitly. NOSONAR: hardcoding them is the point.
+	"0.0.0.0/8", "100.64.0.0/10", "192.0.0.0/24", "192.0.2.0/24", // NOSONAR
+	"192.88.99.0/24", "198.18.0.0/15", "198.51.100.0/24", // NOSONAR
+	"203.0.113.0/24", "240.0.0.0/4", // NOSONAR
 	"100::/64", "100:0:0:1::/64", "2001::/23", "2001:db8::/32", "2002::/16",
 	"3fff::/20", "5f00::/16", "64:ff9b::/96", "64:ff9b:1::/48", "fec0::/10",
 	"::ffff:0:0:0/96", "::/96",

--- a/extensions/dispact-connector/client.go
+++ b/extensions/dispact-connector/client.go
@@ -184,19 +184,30 @@ func refusePrivate(_, address string, _ syscall.RawConn) error {
 }
 
 // reservedCIDRs are the non-public ranges the stdlib predicates miss: the
-// this-network block, CGNAT, benchmark, documentation, protocol-assignment and
-// broadcast, plus the IPv6 ranges that translate to IPv4 internals — NAT64 and
-// IPv4-compatible — which To4()/IsPrivate() do not catch. Naming them IS the
-// guard, so they are literals.
+// this-network block, CGNAT, benchmark, documentation, protocol-assignment,
+// broadcast and discard space, plus the IPv6 ranges that carry an IPv4 address
+// inside them — both NAT64 prefixes, 6to4 and its relay anycast, IPv4-compatible
+// and IPv4-translated — which To4()/IsPrivate() do not catch, and which are
+// therefore how an internal address is named without looking like one. Naming
+// them IS the guard, so they are literals.
+//
+// This list is the core's netguard.reservedNets, and the two are the same list
+// or this unit is the way around the core's guard. Only the core module can see
+// both files, so the comparison lives there
+// (TestTheExtensionCopyOfTheEgressDenylistMatchesTheCore); when it fails, the
+// answer is to copy the core's list here, never to relax the test.
 //
 // They stay TEXT and are parsed per dial rather than once at import, because a
 // unit's root package may hold no initializer that calls anything (see the
-// error constants above). Eleven ParseCIDRs on a call that is about to cross a
+// error constants above). A parse per CIDR on a call that is about to cross a
 // network is not a cost worth engineering around.
 var reservedCIDRs = []string{
 	"0.0.0.0/8", "100.64.0.0/10", "192.0.0.0/24", "192.0.2.0/24",
-	"198.18.0.0/15", "198.51.100.0/24", "203.0.113.0/24", "240.0.0.0/4",
-	"2001:db8::/32", "64:ff9b::/96", "::/96",
+	"192.88.99.0/24", "198.18.0.0/15", "198.51.100.0/24",
+	"203.0.113.0/24", "240.0.0.0/4",
+	"100::/64", "100:0:0:1::/64", "2001::/23", "2001:db8::/32", "2002::/16",
+	"3fff::/20", "5f00::/16", "64:ff9b::/96", "64:ff9b:1::/48", "fec0::/10",
+	"::ffff:0:0:0/96", "::/96",
 }
 
 // publicIP reports whether ip is a globally routable unicast address.

--- a/extensions/dispact-connector/client_test.go
+++ b/extensions/dispact-connector/client_test.go
@@ -36,19 +36,29 @@ func TestTheEgressGuardRefusesEveryNonPublicAddress(t *testing.T) {
 		// The ranges the stdlib predicates miss, and the reason the list of
 		// CIDRs exists at all: each of these reads as ordinary public space to
 		// IsPrivate.
-		"0.0.0.0":            false,
-		"0.1.2.3":            false,
-		"100.64.0.1":         false, // CGNAT
-		"192.0.0.1":          false, // protocol assignment
-		"192.0.2.5":          false, // documentation
-		"198.18.0.1":         false, // benchmarking
-		"198.51.100.5":       false,
-		"203.0.113.5":        false,
-		"240.0.0.1":          false, // reserved
-		"255.255.255.255":    false,
-		"2001:db8::1":        false, // documentation
-		"64:ff9b::a9fe:a9fe": false, // NAT64 onto the metadata address
-		"::ffff:127.0.0.1":   false, // IPv4-mapped loopback
+		"0.0.0.0":              false,
+		"0.1.2.3":              false,
+		"100.64.0.1":           false, // CGNAT
+		"192.0.0.1":            false, // protocol assignment
+		"192.0.2.5":            false, // documentation
+		"198.18.0.1":           false, // benchmarking
+		"198.51.100.5":         false,
+		"203.0.113.5":          false,
+		"240.0.0.1":            false, // reserved
+		"255.255.255.255":      false,
+		"192.88.99.1":          false, // 6to4 relay anycast
+		"2001:db8::1":          false, // documentation
+		"3fff::1":              false, // documentation, the newer range
+		"64:ff9b::a9fe:a9fe":   false, // NAT64 onto the metadata address
+		"64:ff9b:1::a9fe:a9fe": false, // local-use NAT64 onto the same address
+		"2002:7f00:1::1":       false, // 6to4 carrying 127.0.0.1
+		"2001::1":              false, // Teredo, inside the 2001::/23 blanket
+		"100::1":               false, // discard-only
+		"100:0:0:1::1":         false, // dummy prefix
+		"5f00::1":              false, // SRv6 SIDs
+		"fec0::1":              false, // deprecated site-local
+		"::ffff:0:a9fe:a9fe":   false, // IPv4-translated onto the metadata address
+		"::ffff:127.0.0.1":     false, // IPv4-mapped loopback
 	} {
 		t.Run(address, func(t *testing.T) {
 			ip := net.ParseIP(address)

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -120,7 +120,7 @@ sonar.coverage.exclusions=\
   frontend/src/**/*.stories.tsx
 
 # --- Targeted rule tuning (files stay analyzed for every other rule) ---
-sonar.issue.ignore.multicriteria=e1,e2,e3,e4,e5,e6,e7,e8,e9
+sonar.issue.ignore.multicriteria=e1,e2,e3,e4,e5,e6,e7,e8,e9,e10
 # Cognitive Complexity (go:S3776) fires on table-driven test harnesses whose
 # structure is intentional and read as a spec; keep it enforced on production
 # code, drop it for tests.
@@ -193,3 +193,36 @@ sonar.issue.ignore.multicriteria.e8.resourceKey=scripts/mcp-inspector.sh
 # no longer exists is a waiver nobody can evaluate.
 sonar.issue.ignore.multicriteria.e9.ruleKey=typescript:S2819
 sonar.issue.ignore.multicriteria.e9.resourceKey=frontend/src/mcp-apps/bridge.ts
+# gosecurity:S5144 (SSRF) on the Client ID Metadata Document fetch, and the
+# taint flow it reports is REAL: an unauthenticated caller passes client_id on
+# /oauth/authorize and this server dereferences that URL. That is not a defect
+# to be removed — it is what a metadata-document client id IS (ADR-0092 §4,
+# draft-ietf-oauth-client-id-metadata-document-00). A client identifies itself
+# by a URL that resolves to its own document, so there is no allowlist of hosts
+# to check the value against; an allowlist would be the same thing as not
+# supporting the mechanism.
+#
+# What the rule cannot see is that the egress is bounded everywhere it matters,
+# and none of it happens at request construction, which is where the sink is
+# reported. Before the fetch: only an https URL WITH a path is treated as a
+# document id (userinfo and fragment refused, not stripped), and the document
+# must claim byte-for-byte the client_id it was fetched from. During it, on the
+# one process-wide client in oauth_cimd.go: the dialer's Control hook runs
+# netguard.RefusePrivate against the RESOLVED IP, so a public-looking hostname
+# that answers 169.254.169.254 is refused at connect time rather than trusted
+# for having looked public; redirects are not followed (a followed hop is a
+# second URL the caller chose, past both of the above); the body is read through
+# a 64 KiB limit and refused if it exceeds it; and the whole exchange is capped
+# at 5s. After it, a refusal is answered `invalid_client` and nothing more, so
+# this server does not report the shape of its own network back to the prober.
+#
+# Every one of those is gated by a test that fails if it is removed —
+# TestTheFetchRefusesAnAddressInsideTheDeployment drives the REAL guarded client
+# at a loopback httptest server (a successful fetch there would be the
+# vulnerability), TestTheFetchRefusesWhatIsNotAMetadataDocument covers the
+# redirect, size, media-type and status refusals against a control that proves a
+# valid document still passes, and the URL-shape and equality rules keep their
+# own. So this waiver cannot become cover for dropping the guards it names. It
+# is scoped to the one file whose entire subject is that fetch.
+sonar.issue.ignore.multicriteria.e10.ruleKey=gosecurity:S5144
+sonar.issue.ignore.multicriteria.e10.resourceKey=backend/internal/modules/identity/oauth_cimd.go

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -205,24 +205,41 @@ sonar.issue.ignore.multicriteria.e9.resourceKey=frontend/src/mcp-apps/bridge.ts
 # What the rule cannot see is that the egress is bounded everywhere it matters,
 # and none of it happens at request construction, which is where the sink is
 # reported. Before the fetch: only an https URL WITH a path is treated as a
-# document id (userinfo and fragment refused, not stripped), and the document
+# document id (userinfo, fragment and dot path segments refused, not stripped,
+# so one document cannot spell unboundedly many client ids), and the document
 # must claim byte-for-byte the client_id it was fetched from. During it, on the
 # one process-wide client in oauth_cimd.go: the dialer's Control hook runs
 # netguard.RefusePrivate against the RESOLVED IP, so a public-looking hostname
 # that answers 169.254.169.254 is refused at connect time rather than trusted
-# for having looked public; redirects are not followed (a followed hop is a
-# second URL the caller chose, past both of the above); the body is read through
-# a 64 KiB limit and refused if it exceeds it; and the whole exchange is capped
-# at 5s. After it, a refusal is answered `invalid_client` and nothing more, so
-# this server does not report the shape of its own network back to the prober.
+# for having looked public — and netguard refuses every IANA special-purpose
+# range that is not globally reachable, including the ones that EMBED an
+# internal address (both NAT64 prefixes, 6to4, IPv4-compatible) rather than only
+# the obvious literals; redirects are not followed (a followed hop is a second
+# URL the caller chose, past both of the above); the body is read through a
+# 64 KiB limit and refused if it exceeds it; and the whole exchange is capped at
+# 5s. After it, a refusal is answered `invalid_client` and nothing more, so this
+# server does not report the shape of its own network back to the prober.
 #
-# Every one of those is gated by a test that fails if it is removed —
+# Every one of those is gated by a test that FAILS IF THE GUARD IS REMOVED, which
+# is a stronger claim than being covered and was checked by removing each one:
 # TestTheFetchRefusesAnAddressInsideTheDeployment drives the REAL guarded client
-# at a loopback httptest server (a successful fetch there would be the
-# vulnerability), TestTheFetchRefusesWhatIsNotAMetadataDocument covers the
-# redirect, size, media-type and status refusals against a control that proves a
-# valid document still passes, and the URL-shape and equality rules keep their
-# own. So this waiver cannot become cover for dropping the guards it names. It
-# is scoped to the one file whose entire subject is that fetch.
+# at a loopback httptest server serving a document that would otherwise be
+# accepted, and demands netguard's own refusal, so a fetch that merely fails
+# later does not satisfy it; TestTheFetchDoesNotFollowARedirect points the first
+# hop at a second server whose document claims the FIRST url, so following the
+# redirect succeeds and only the refusal to take it fails the fetch;
+# TestTheFetchRefusesWhatIsNotAMetadataDocument covers the size, media-type and
+# status refusals against a control that proves a valid document still passes,
+# and it replaces only the client's TRANSPORT, so the redirect policy those tests
+# rest on is the production one rather than a copy. The URL-shape and equality
+# rules keep their own. So this waiver cannot become cover for dropping the
+# guards it names.
+#
+# Its scope is a real cost, stated rather than glossed: Sonar drops this rule for
+# the WHOLE file, so a future S5144 introduced in oauth_cimd.go is hidden too, not
+# just the sink named above. That is the narrowest scope the scanner offers for a
+# taint rule, and it is tolerable only because this file has exactly one egress
+# and exists for nothing else. A second outbound call belongs in another file, or
+# this waiver has to be reconsidered with it.
 sonar.issue.ignore.multicriteria.e10.ruleKey=gosecurity:S5144
 sonar.issue.ignore.multicriteria.e10.resourceKey=backend/internal/modules/identity/oauth_cimd.go


### PR DESCRIPTION
SonarCloud's quality gate fails on one open vulnerability: [`gosecurity:S5144`](https://sonarcloud.io/project/issues?id=gradionhq_margince-poc-v1&open=AZ_iiNPsnhynfjhWcsZo) (SSRF) in `backend/internal/modules/identity/oauth_cimd.go`.

This PR waives that rule for that file, and fixes the guards and tests the waiver depends on.

## Why the finding cannot be removed

Sonar's taint path is correct: `client_id` from `/oauth/authorize` → `resolveCIMDClient` → `fetchCIMD` → an HTTP request. An unauthenticated caller supplies a URL and the server fetches it.

That is how Client ID Metadata Documents work (ADR-0092 §4). The client identifies itself by an HTTPS URL that serves its own metadata, with no prior registration. There is no host allowlist to check the value against, because an allowlist would mean not supporting the mechanism.

## How the fetch is bounded

- Before the fetch: the `client_id` must be an HTTPS URL with a path. Userinfo, fragments and dot path segments are rejected, not normalized. The fetched document must contain the exact `client_id` string it was fetched from.
- During the fetch: the dialer's `Control` hook rejects non-public IPs after DNS resolution, so a public-looking hostname that resolves to an internal address is rejected at connect time. Redirects are not followed. The body is limited to 64 KiB. The request times out after 5s.
- After the fetch: any failure returns `invalid_client` with no detail. `/oauth/authorize` is rate limited (60/min per session or peer, 600/min per peer).

## What this PR changes

**1. Two tests did not test their guard.**

The address test fetched a loopback URL but served a document with `client_id: "x"`. The document check rejected it whether or not the dialer did, so removing `netguard.RefusePrivate` left the test green. It now serves a valid document and requires netguard's own rejection message.

The redirect case swapped in a test-local HTTP client with its own `CheckRedirect`, and pointed at a hostname that does not resolve. Removing the production redirect policy changed nothing. `TestTheFetchDoesNotFollowARedirect` now redirects to a second server whose document claims the first URL, so following the redirect would succeed; only refusing to follow it fails the fetch. It requires the 302 to be the rejection reason.

Both were verified by deleting the guard and confirming the test fails.

**2. The address guard was incomplete.**

`netguard` missed ranges that carry an IPv4 address inside an IPv6 one: local-use NAT64 `64:ff9b:1::/48` and 6to4 `2002::/16` (`2002:7f00:1::1` is `127.0.0.1`). Both were dialable. Added those plus `2001::/23`, `100::/64`, `100:0:0:1::/64`, `5f00::/16`, `fec0::/10`, `3fff::/20`, `192.88.99.0/24` and `::ffff:0:0:0/96`.

IPv4-mapped `::ffff:0:0/96` is deliberately not listed. The stdlib predicates and `net.IPNet.Contains` already normalize it, so `::ffff:127.0.0.1` is rejected and `::ffff:8.8.8.8` still works. Both directions are now in the test table. Nothing routable is newly blocked: `2001::/23` ends before the first RIR allocation, and the rest is documentation, SRv6 or deprecated space.

**3. The same denylist existed in `extensions/dispact-connector` and was not updated.**

That unit copies the guard because an extension is a separate Go module. It dials a member-supplied `base_url`, so the two lists disagreeing meant 6to4 and local-use NAT64 were blocked in the core and allowed on the connector poll. Both lists now match, and `TestTheExtensionCopyOfTheEgressDenylistMatchesTheCore` compares them from the core module (the only place both files are visible), so future drift fails a test.

**4. Dot path segments are rejected in `client_id`.**

The draft prohibits `.` and `..` segments. Checked on the decoded path, so `%2e%2e` is rejected too. The comment states that this is hygiene, not the security control: other spellings normalize on some origin servers and not here, and the byte-for-byte equality check in `validCIMD` is what actually prevents one document from speaking for another client id.

## The gate change

One `sonar.issue.ignore.multicriteria` entry (`e10`), scoped to rule `gosecurity:S5144` and file `oauth_cimd.go`, with the reasoning next to the other nine. `gosec` already carries the same suppression in-source (`//nolint:gosec // G704`).

The waiver text states its cost: Sonar drops the rule for the whole file, so a future S5144 in `oauth_cimd.go` would also be hidden. That is the narrowest scope the scanner offers for a taint rule. It is acceptable only because this file has exactly one outbound call, so a second one belongs in a different file or the waiver has to be revisited.

## Known limits, not fixed here

A caller can still cause one outbound request per authorize by naming a new URL each time. Failed fetches and unseen client ids are not cached, so the cache floor does not bound them; the authorize rate limit does. The comment now says this instead of implying the floor covers it.

## Gates

`make check-backend` and `make craft-static` pass. The pre-push hook (diff-scoped `craft static --strict`, `check-rls-store-path`, `check-no-jurisdiction`) passed. CI including SonarCloud was green on the previous push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
