### PR TITLE
docs(status): the approval lifecycle shipped, and its spec half is upstream

### DIFF
--- a/STATUS-ARCHIVE.md
+++ b/STATUS-ARCHIVE.md
@@ -21,6 +21,78 @@
 > [CHANGELOG.md](CHANGELOG.md) and [README.md → *What works
 > today*](README.md#what-works-today).
 
+## 2026-08-15 — the three approval-lifecycle gaps #1296 left open (PR #1328)
+
+Issues #1303, #1305 and #1304 — the follow-ups #1296's review filed — shipped as
+one PR, because they are one story: what happens to a staged approval after
+somebody stops looking at it.
+
+**#1303, expiry was a reading rather than a state.** A stale staging *displayed*
+as expired while its row still said `pending`: nothing was audited, nothing was
+emitted, and an automation parked behind it waited forever on a verdict already
+taken against it. `ExpireDue` now writes the transition for real — status, audit
+row, outbox event, one transaction — under a re-read row lock, so a human
+deciding under the wire wins and the clock loses that race. Attributed to
+`system:approval-expiry` with `decided_by` left NULL: nobody decided this, and a
+human's id there would put their name on a refusal they never made (APPR-AC-2).
+72h default with a per-item override (APPR-PARAM-1). The run transition rides the
+`approval.decided` event rather than the job reaching into another module.
+
+**#1305, erasure and subject-access could not reach a message nobody had decided
+yet.** Every outbound scrub keys off the activity a message became, and a message
+waiting in an inbox has none — so a subject could exercise Art. 17 tonight and
+have their draft released by a colleague at nine tomorrow. Staged proposals are
+now emptied *and* withdrawn (a blanked card still in the inbox is one somebody
+can approve), decided rows keep their verdict, and Art. 15 lists the staged
+message.
+
+**#1304 was bigger than filed.** The issue said approving left the effect unrun.
+The root cause was worse: `assign_owner` and `emit_flow_event` had **no
+decision-grant mapping**, and `requireDecisionGrants` fails closed — so those
+stagings were hidden from every inbox and could not be decided by anybody. The
+existing census could not see them because it enumerated kinds with a *registered
+effect*, and an automation stages kinds that have none. Both grants came from the
+action catalog's own `RequiredPermission` pins. `emit_flow_event` completes its
+run on approval (its whole effect is the asking); `assign_owner` got a release
+executor performing the same provider write its 🟢 branch performs;
+`advance_deal` and `send_email` stopped staging, because the closed catalog can
+emit neither and a card whose approval reaches no executor is worse than a
+refusal at plan time.
+
+**Four review passes, and three of them found defects in the fix itself.** Fable
+found that the erasure work *recreated the permanently-parked run this very PR
+existed to abolish* — a withdrawal emits no event and the sweep cannot reach an
+already-terminal row. CodeRabbit found `ExpireDue` had no principal check, which
+made it an authenticated user's way to refuse every pending approval in the
+installation, each audited as though the clock had done it. The security redteam
+found that the LIKE fix from the round before was half a fix: escaping stops an
+address acting as a *wildcard*, not as a *substring*, and `m@acme.com` is a
+suffix of `tim@acme.com` — so erasure still destroyed a third party's staged work
+and the Art. 15 export still disclosed their message body. The craft pass found
+that withdrawal backdated `expires_at` without a terminal status, which with an
+exempt-kind filter applied *after* the `LIMIT` would have let withdrawn scheduled
+sends collect at the front of every batch until the sweep silently stopped
+working.
+
+Nine comments asserting invariants the code no longer held were fixed across
+three consecutive rounds — including one claiming `StageableKinds` was *derived
+from* the staging switch when it was hand-written. That defect class turned out
+to be far easier to reintroduce while fixing something else than expected.
+
+Five fitness functions now close the classes rather than the instances: every
+stageable kind must be decidable, must either ask-only or have a release
+executor, must leave its run terminal when approved, a new staging arm in
+`applyOne` trips a source-scanning tripwire, and the two erasure guards fail
+against the exact defects they name. All mutation-verified — the first attempt at
+one of those verifications was a silent `perl` no-op that made a weak test look
+proven, which is worse than no verification at all.
+
+Contract-first: the `expired` verdict and an optional `decided_by` needed the
+event catalog to move, so `margince-foundation` PR #1310 carries it upstream
+together with AUTO-NOTE-1's discharge (AUTO-PARAM-7 maps the seven authoring
+actions onto the 🟡-held effect classes, and records that close and archive have
+no automation path at all).
+
 ## 2026-08-14 — a committed CSV import can be undone, and one review pass wasn't enough (PR #1231)
 
 Issue #723, wave 5 of `.tmp/capability-roadmap`, picked up the moment #690

--- a/STATUS.md
+++ b/STATUS.md
@@ -18,6 +18,27 @@
 Every section in this file, in order. Read this list first and jump; nobody
 needs the whole file to start a session.
 
+- Open, upstream (2026-08-15): **the approval lifecycle's spec half**
+  ([margince-foundation#1310](https://github.com/gradionhq/margince-foundation/pull/1310)).
+  The build half shipped in [#1328](https://github.com/gradionhq/margince-poc-v1/pull/1328)
+  — approvals now genuinely expire (72h, system-actor audit row, outbox event)
+  rather than merely displaying as expired; erasure and subject-access reach the
+  messages nobody has decided yet; and approving an automation's staged action
+  executes it and completes the parked run. That last one was bigger than filed:
+  `assign_owner` and `emit_flow_event` had no decision-grant mapping and
+  `requireDecisionGrants` fails closed, so their stagings were invisible to every
+  inbox and decidable by nobody. The spec PR carries the `expired` verdict and an
+  optional `decided_by` into the event catalog (which still declares
+  `approved | rejected`, so the build currently diverges), and discharges
+  AUTO-NOTE-1 with AUTO-PARAM-7. **Known follow-ups, all filed**:
+  [#1329](https://github.com/gradionhq/margince-poc-v1/issues/1329) an overlay
+  sync-backoff test races the real clock under parallel load;
+  [#1335](https://github.com/gradionhq/margince-poc-v1/issues/1335) an
+  approved-but-unredeemed agent staging survives erasure for the redemption
+  window (its payload is emptied, its token is not);
+  [#1340](https://github.com/gradionhq/margince-poc-v1/issues/1340) the
+  design-system emoji scan walks the whole tree against a 5s ceiling and times
+  out under CI load — it blocked this merge once and cleared on a plain re-run.
 - Open, in review (2026-08-15): **twelve configuration pages in the record page's
   voice** ([#1225](https://github.com/gradionhq/margince-poc-v1/pull/1225)). Ready for
   review; not merged, because the founder wants a manual frontend pass first. Settings and


### PR DESCRIPTION
Session record for [#1328](https://github.com/gradionhq/margince-poc-v1/pull/1328)
(merged) plus the one thing still open.

- **STATUS-ARCHIVE.md** takes the narrative, per the house rule that STATUS.md
  should not accumulate it.
- **STATUS.md** takes one index entry: the foundation PR
  ([margince-foundation#1310](https://github.com/gradionhq/margince-foundation/pull/1310))
  carrying the `expired` verdict and an optional `decided_by` into the event
  catalog — the build currently diverges from the spec there, so it is real open
  work — and the three filed follow-ups (#1329, #1335, #1340).

The archive entry leads with what the review rounds found rather than what the
feature does, because that is the part worth reading later: **three of four
passes found defects in the fix itself**, including an erasure path that
recreated the permanently-parked run the same PR existed to abolish, and an
address escape that stopped the wildcard but not the substring (`m@acme.com` is
a suffix of `tim@acme.com`).

Docs only — no code, no contract, no migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents the shipped approval lifecycle and indexes the still-open spec change. Previously expiry was display-only and some staged actions were undecidable; now approvals genuinely expire, erasure/subject-access cover staged messages, and approving automation executes and completes runs.

- Moves the session narrative to STATUS-ARCHIVE.md; STATUS.md keeps a single index entry.
- Index entry links to upstream spec PR `margince-foundation#1310` adding the `expired` verdict and optional `decided_by` (current build diverges until merged).
- Notes filed follow-ups: #1329, #1335, #1340.
- Docs only; no code, contracts, or migration.

<sup>Written for commit a51cf25f17ce2acbee87aded4bb1b3e967d2be22. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1343?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

