### PR TITLE
fix(flakes): the sweep is scheduled by one clock, and a tree scan gets a tree-sized budget

### DIFF
--- a/STATUS-ARCHIVE.md
+++ b/STATUS-ARCHIVE.md
@@ -42,6 +42,23 @@ functions now take no clock at all, so the column is written by the one clock
 that reads it, and no future caller can reintroduce a second one. The test needs
 no clock either — the sleep-free, injection-free version is now the honest one.
 
+The rule is a gate rather than a paragraph (`syncclock_test.go`), because the
+defect is invisible at runtime on any machine whose two clocks agree — which is
+every CI runner and every laptop, so no test that exercised the store could have
+failed against it. It derives both write spellings from the package source: an
+assignment's RHS must start at `now()`, and the INSERT column-list position must
+be `now()` outright, with a subject count so a renamed column fails the gate
+instead of emptying it. Beside it, an integration assertion now measures how far
+out the store actually paced the sweep, which due/not-due cannot see: an interval
+handed to Postgres in the wrong unit reads as "not due" exactly like a correct
+one. Both were verified against the defects they describe before being trusted.
+
+The same two clocks are still running in capture's ADR-0063 sync-state, filed as
+[#1346](https://github.com/gradionhq/margince-poc-v1/issues/1346) rather than
+fixed here — a connector-pacing change does not belong behind a flake fix. It is
+the more dangerous half: capture's skew can run the other way and *shorten* a
+backoff, and its rate-limited branch paces on a provider's own `Retry-After`.
+
 **#1340 — a repo sweep sized like a unit test.** The design-system conformance
 gates read, and mostly TypeScript-parse, the whole source tree, against vitest's
 5s per-test default. The heaviest leg measures ~1.1s locally under the coverage

--- a/STATUS-ARCHIVE.md
+++ b/STATUS-ARCHIVE.md
@@ -21,6 +21,37 @@
 > [CHANGELOG.md](CHANGELOG.md) and [README.md → *What works
 > today*](README.md#what-works-today).
 
+## 2026-08-15 — two flakes: one clock too many, one budget too small (PR #1344)
+
+#1329 and #1340, the two load-dependent flakes #1328 filed on its way through.
+Neither was a regression. Both were a measurement taken against something that
+was never going to hold still.
+
+**#1329 — the overlay sweep was scheduled by two clocks.** The due-scan gates on
+`COALESCE(s.next_sweep_at, now()) <= now()`, so `overlay_sync_state.next_sweep_at`
+is only ever compared against the clock *inside* Postgres. `RequestSweep` and the
+flip seal already wrote it with that clock; `RecordSweepSuccess` and
+`RecordSweepFailure` took a `time.Time` from the caller and wrote the app
+process's clock instead. The failure path has minutes of margin and never
+noticed. The success path means *due immediately* and has none: whenever the
+app's clock ran ahead of the database's, the reset landed in the future — a
+healed connection stayed backed off for as long as the skew lasted, and nothing
+anywhere said so. In the integration lane the same skew read as
+`TestSweepBackoffGatesDueOverlayConnections` failing under parallel load. Both
+functions now take no clock at all, so the column is written by the one clock
+that reads it, and no future caller can reintroduce a second one. The test needs
+no clock either — the sleep-free, injection-free version is now the honest one.
+
+**#1340 — a repo sweep sized like a unit test.** The design-system conformance
+gates read, and mostly TypeScript-parse, the whole source tree, against vitest's
+5s per-test default. The heaviest leg measures ~1.1s locally under the coverage
+instrumentation `fe-unit` runs with, and had already blown 5s on a loaded CI
+runner — reported against a job named `fe-unit (vitest + coverage)`, so it read
+as a coverage-threshold failure until you opened the log. The budget is declared
+once on the suite now, an order of magnitude above the worst observed cost:
+these scans are synchronous file I/O, so there is no hang for a tight ceiling to
+catch and a generous one costs nothing. Every gate the file grows inherits it.
+
 ## 2026-08-15 — the three approval-lifecycle gaps #1296 left open (PR #1328)
 
 Issues #1303, #1305 and #1304 — the follow-ups #1296's review filed — shipped as

--- a/STATUS.md
+++ b/STATUS.md
@@ -30,15 +30,12 @@ needs the whole file to start a session.
   inbox and decidable by nobody. The spec PR carries the `expired` verdict and an
   optional `decided_by` into the event catalog (which still declares
   `approved | rejected`, so the build currently diverges), and discharges
-  AUTO-NOTE-1 with AUTO-PARAM-7. **Known follow-ups, all filed**:
-  [#1329](https://github.com/gradionhq/margince-poc-v1/issues/1329) an overlay
-  sync-backoff test races the real clock under parallel load;
+  AUTO-NOTE-1 with AUTO-PARAM-7. **One follow-up still open**:
   [#1335](https://github.com/gradionhq/margince-poc-v1/issues/1335) an
   approved-but-unredeemed agent staging survives erasure for the redemption
-  window (its payload is emptied, its token is not);
-  [#1340](https://github.com/gradionhq/margince-poc-v1/issues/1340) the
-  design-system emoji scan walks the whole tree against a 5s ceiling and times
-  out under CI load — it blocked this merge once and cleared on a plain re-run.
+  window (its payload is emptied, its token is not). The two flakes filed
+  beside it — the overlay sweep scheduled by two clocks (#1329) and the
+  design-system tree scan sized like a unit test (#1340) — are fixed.
 - Open, in review (2026-08-15): **twelve configuration pages in the record page's
   voice** ([#1225](https://github.com/gradionhq/margince-poc-v1/pull/1225)). Ready for
   review; not merged, because the founder wants a manual frontend pass first. Settings and

--- a/backend/internal/compose/integration/overlay/overlay_flip_integration_test.go
+++ b/backend/internal/compose/integration/overlay/overlay_flip_integration_test.go
@@ -259,7 +259,7 @@ func setupFlipEstate(t *testing.T) flipEstate {
 		}
 	}
 
-	if err := mirror.RecordSweepSuccess(adminCtx, time.Now()); err != nil {
+	if err := mirror.RecordSweepSuccess(adminCtx); err != nil {
 		t.Fatalf("recording sweep success: %v", err)
 	}
 

--- a/backend/internal/compose/jobs_overlay.go
+++ b/backend/internal/compose/jobs_overlay.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/riverqueue/river"
@@ -214,13 +213,13 @@ func (w *overlayReconcileWorkspaceWorker) Work(ctx context.Context, job *river.J
 	// A fenced ErrConnectionGone in the RECORDING means the connection was
 	// revoked between the sweep and this write — benign, nothing to pace.
 	if sweepErr != nil {
-		if recErr := recMS.RecordSweepFailure(wsCtx, sweepErr, time.Now()); recErr != nil && !errors.Is(recErr, overlay.ErrConnectionGone) {
+		if recErr := recMS.RecordSweepFailure(wsCtx, sweepErr); recErr != nil && !errors.Is(recErr, overlay.ErrConnectionGone) {
 			w.log.WarnContext(wsCtx, "overlay reconcile: recording the sweep-failure backoff failed",
 				"workspace", d.Workspace.String(), "err", recErr)
 		}
 		return jobs.FaultContext(ctx, sweepErr)
 	}
-	if recErr := recMS.RecordSweepSuccess(wsCtx, time.Now()); recErr != nil && !errors.Is(recErr, overlay.ErrConnectionGone) {
+	if recErr := recMS.RecordSweepSuccess(wsCtx); recErr != nil && !errors.Is(recErr, overlay.ErrConnectionGone) {
 		w.log.WarnContext(wsCtx, "overlay reconcile: resetting the sweep backoff after success failed",
 			"workspace", d.Workspace.String(), "err", recErr)
 	}

--- a/backend/internal/modules/overlay/syncbackoff.go
+++ b/backend/internal/modules/overlay/syncbackoff.go
@@ -82,21 +82,29 @@ func sweepBackoffDelay(consecutiveFailures int) time.Duration {
 // RecordSweepSuccess resets the backoff for ctx's workspace: the next
 // sweep is due immediately and the failure ladder is cleared. One clean
 // sweep heals a backed-off connection.
-func (s *MirrorStore) RecordSweepSuccess(ctx context.Context, now time.Time) error {
+//
+// "Immediately" has zero margin, which is why the schedule is written from
+// the DATABASE's clock and never the caller's: DueOverlayConnections
+// compares next_sweep_at against now() INSIDE Postgres, so a reset stamped
+// from the app process's clock lands in the future whenever that clock runs
+// ahead of the database's — a reset that silently does not reset, for as
+// long as the skew lasts. RequestSweep, the flip seal and the failure
+// pacing below all write this column the same way, so one clock schedules
+// the whole sweep.
+func (s *MirrorStore) RecordSweepSuccess(ctx context.Context) error {
 	return s.db.Tx(ctx, func(tx pgx.Tx) error {
 		if err := s.assertFence(ctx, tx); err != nil {
 			return err
 		}
 		_, err := tx.Exec(ctx, `
 			INSERT INTO overlay_sync_state (workspace_id, next_sweep_at, consecutive_failures, last_success_at, last_error_class, updated_at)
-			VALUES (NULLIF(current_setting('app.workspace_id',true),'')::uuid, $1, 0, $1, NULL, now())
+			VALUES (NULLIF(current_setting('app.workspace_id',true),'')::uuid, now(), 0, now(), NULL, now())
 			ON CONFLICT ((true)) DO UPDATE SET
-			  next_sweep_at = EXCLUDED.next_sweep_at,
+			  next_sweep_at = now(),
 			  consecutive_failures = 0,
-			  last_success_at = EXCLUDED.last_success_at,
+			  last_success_at = now(),
 			  last_error_class = NULL,
-			  updated_at = now()`,
-			now)
+			  updated_at = now()`)
 		return err
 	})
 }
@@ -131,7 +139,7 @@ func (s *MirrorStore) RequestSweep(ctx context.Context) error {
 // longer floor) — so a failing connection stops re-sweeping hot. It never
 // tombstones: the connection stays selectable, just paced. The error
 // detail is logged to system_log; the sidecar row carries only the class.
-func (s *MirrorStore) RecordSweepFailure(ctx context.Context, sweepErr error, now time.Time) error {
+func (s *MirrorStore) RecordSweepFailure(ctx context.Context, sweepErr error) error {
 	class := classifySweepError(sweepErr)
 	return s.db.Tx(ctx, func(tx pgx.Tx) error {
 		if err := s.assertFence(ctx, tx); err != nil {
@@ -140,23 +148,27 @@ func (s *MirrorStore) RecordSweepFailure(ctx context.Context, sweepErr error, no
 		var failures int
 		if err := tx.QueryRow(ctx, `
 			INSERT INTO overlay_sync_state (workspace_id, next_sweep_at, consecutive_failures, last_error_class, last_failure_at, updated_at)
-			VALUES (NULLIF(current_setting('app.workspace_id',true),'')::uuid, $1, 1, $2, $1, now())
+			VALUES (NULLIF(current_setting('app.workspace_id',true),'')::uuid, now(), 1, $1, now(), now())
 			ON CONFLICT ((true)) DO UPDATE SET
 			  consecutive_failures = overlay_sync_state.consecutive_failures + 1,
 			  last_error_class = EXCLUDED.last_error_class,
-			  last_failure_at = EXCLUDED.last_failure_at,
+			  last_failure_at = now(),
 			  updated_at = now()
 			RETURNING consecutive_failures`,
-			now, string(class)).Scan(&failures); err != nil {
+			string(class)).Scan(&failures); err != nil {
 			return fmt.Errorf("overlay: recording the sweep failure: %w", err)
 		}
 
-		next := now.Add(sweepBackoffDelay(failures))
-		if class == classSweepRateLimited && next.Sub(now) < rateLimitedFloor {
-			next = now.Add(rateLimitedFloor)
+		// The ladder is a DELAY, applied to the database's clock for the same
+		// reason the reset above is (RecordSweepSuccess's doc comment).
+		delay := sweepBackoffDelay(failures)
+		if class == classSweepRateLimited && delay < rateLimitedFloor {
+			delay = rateLimitedFloor
 		}
-		if _, err := tx.Exec(ctx, `UPDATE overlay_sync_state SET next_sweep_at = $1 WHERE workspace_id = NULLIF(current_setting('app.workspace_id',true),'')::uuid`,
-			next); err != nil {
+		if _, err := tx.Exec(ctx, `
+			UPDATE overlay_sync_state SET next_sweep_at = now() + make_interval(secs => $1::double precision)
+			WHERE workspace_id = NULLIF(current_setting('app.workspace_id',true),'')::uuid`,
+			delay.Seconds()); err != nil {
 			return fmt.Errorf("overlay: pacing the next sweep after failure: %w", err)
 		}
 

--- a/backend/internal/modules/overlay/syncbackoff.go
+++ b/backend/internal/modules/overlay/syncbackoff.go
@@ -11,6 +11,17 @@ package overlay
 // honors a longer floor), and RecordSweepSuccess resets it. The row lives
 // in overlay_sync_state and is read by DueOverlayConnections' due-scan;
 // error DETAIL goes to system_log, the row carries only the class.
+//
+// EVERY next_sweep_at write here takes the DATABASE's clock, never a
+// timestamp bound from Go. The due-scan compares the column against now()
+// inside Postgres (connectionreads.go), so a deadline derived from the app
+// process makes that a cross-clock comparison, and the two clocks are only
+// ever coincidentally equal. A backoff has minutes of margin and survives the
+// skew; a reset means "due immediately" and has none — stamped by a process
+// running ahead of the database it lands in the future, and the connection it
+// was supposed to heal stays backed off for as long as the skew lasts.
+// syncclock_test.go derives that rule from this source rather than trusting
+// this paragraph.
 
 import (
 	"context"
@@ -81,16 +92,8 @@ func sweepBackoffDelay(consecutiveFailures int) time.Duration {
 
 // RecordSweepSuccess resets the backoff for ctx's workspace: the next
 // sweep is due immediately and the failure ladder is cleared. One clean
-// sweep heals a backed-off connection.
-//
-// "Immediately" has zero margin, which is why the schedule is written from
-// the DATABASE's clock and never the caller's: DueOverlayConnections
-// compares next_sweep_at against now() INSIDE Postgres, so a reset stamped
-// from the app process's clock lands in the future whenever that clock runs
-// ahead of the database's — a reset that silently does not reset, for as
-// long as the skew lasts. RequestSweep, the flip seal and the failure
-// pacing below all write this column the same way, so one clock schedules
-// the whole sweep.
+// sweep heals a backed-off connection. It takes no clock: the reset is the
+// zero-margin case of this file's database-clock rule.
 func (s *MirrorStore) RecordSweepSuccess(ctx context.Context) error {
 	return s.db.Tx(ctx, func(tx pgx.Tx) error {
 		if err := s.assertFence(ctx, tx); err != nil {
@@ -159,14 +162,14 @@ func (s *MirrorStore) RecordSweepFailure(ctx context.Context, sweepErr error) er
 			return fmt.Errorf("overlay: recording the sweep failure: %w", err)
 		}
 
-		// The ladder is a DELAY, applied to the database's clock for the same
-		// reason the reset above is (RecordSweepSuccess's doc comment).
+		// The ladder is a DELAY, not a deadline, so the database applies it to
+		// its own clock (this file's rule).
 		delay := sweepBackoffDelay(failures)
 		if class == classSweepRateLimited && delay < rateLimitedFloor {
 			delay = rateLimitedFloor
 		}
 		if _, err := tx.Exec(ctx, `
-			UPDATE overlay_sync_state SET next_sweep_at = now() + make_interval(secs => $1::double precision)
+			UPDATE overlay_sync_state SET next_sweep_at = now() + make_interval(secs => $1)
 			WHERE workspace_id = NULLIF(current_setting('app.workspace_id',true),'')::uuid`,
 			delay.Seconds()); err != nil {
 			return fmt.Errorf("overlay: pacing the next sweep after failure: %w", err)

--- a/backend/internal/modules/overlay/syncbackoff_integration_test.go
+++ b/backend/internal/modules/overlay/syncbackoff_integration_test.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"errors"
 	"testing"
-	"time"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -21,10 +20,11 @@ import (
 )
 
 // isDue reports whether ws itself appears in DueOverlayConnections' fleet-
-// wide scan. It tests MEMBERSHIP, never a count: this package's integration
-// tests run in parallel against one shared clone database, so a concurrent
-// test's own connection would inflate any len(due) assertion into a flaky
-// one — filtering to ws is what keeps this deterministic.
+// wide scan. It tests MEMBERSHIP, never a count: the scan walks every
+// workspace in the database, and tests here seed more than one on purpose
+// (the harness resets once per test, not once per workspace), so a len(due)
+// assertion would be asserting on the fixture next door — filtering to ws is
+// what keeps this about ws.
 func isDue(ctx context.Context, t *testing.T, pool *pgxpool.Pool, ws ids.UUID) bool {
 	t.Helper()
 	due, err := DueOverlayConnections(ctx, pool)
@@ -43,10 +43,11 @@ func isDue(ctx context.Context, t *testing.T, pool *pgxpool.Pool, ws ids.UUID) b
 // end: a freshly connected workspace is due; a connection-level failure
 // backs it off so DueOverlayConnections stops selecting it (no more
 // hot re-sweeping a dead/throttled connection); and one successful sweep
-// resets the backoff so it is due again. now() is the real clock because
-// the due-scan compares next_sweep_at against the DATABASE's now() — a
-// backoff is always minutes in the future, a reset is always now-or-past,
-// so the OUTCOME is deterministic without any sleep.
+// resets the backoff so it is due again. It needs no clock of its own and
+// no sleep: the store schedules against the DATABASE's now() and the
+// due-scan reads the same one (syncbackoff.go), so a backoff is always
+// minutes in the future and a reset is always now-or-past — whatever this
+// process's clock happens to read.
 func TestSweepBackoffGatesDueOverlayConnections(t *testing.T) {
 	ctx, pool, ws := testWorkspaceCtx(t)
 	vault := keyvault.NewMemory()
@@ -61,7 +62,7 @@ func TestSweepBackoffGatesDueOverlayConnections(t *testing.T) {
 	}
 
 	// A connection-level failure backs the sweep off into the future.
-	if err := store.RecordSweepFailure(ctx, apperrors.ErrIncumbentBudgetExhausted, time.Now()); err != nil {
+	if err := store.RecordSweepFailure(ctx, apperrors.ErrIncumbentBudgetExhausted); err != nil {
 		t.Fatalf("RecordSweepFailure: %v", err)
 	}
 	if isDue(ctx, t, pool, ws) {
@@ -69,7 +70,7 @@ func TestSweepBackoffGatesDueOverlayConnections(t *testing.T) {
 	}
 
 	// One clean sweep resets the backoff — due again.
-	if err := store.RecordSweepSuccess(ctx, time.Now()); err != nil {
+	if err := store.RecordSweepSuccess(ctx); err != nil {
 		t.Fatalf("RecordSweepSuccess: %v", err)
 	}
 	if !isDue(ctx, t, pool, ws) {
@@ -88,7 +89,7 @@ func TestRequestSweepMakesTheWorkspaceDueNow(t *testing.T) {
 		t.Fatalf("Connect: %v", err)
 	}
 
-	if err := store.RecordSweepFailure(ctx, errors.New("boom"), time.Now()); err != nil {
+	if err := store.RecordSweepFailure(ctx, errors.New("boom")); err != nil {
 		t.Fatalf("RecordSweepFailure: %v", err)
 	}
 	if isDue(ctx, t, pool, ws) {

--- a/backend/internal/modules/overlay/syncbackoff_integration_test.go
+++ b/backend/internal/modules/overlay/syncbackoff_integration_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -21,10 +22,10 @@ import (
 
 // isDue reports whether ws itself appears in DueOverlayConnections' fleet-
 // wide scan. It tests MEMBERSHIP, never a count: the scan walks every
-// workspace in the database, and tests here seed more than one on purpose
-// (the harness resets once per test, not once per workspace), so a len(due)
-// assertion would be asserting on the fixture next door — filtering to ws is
-// what keeps this about ws.
+// workspace in the database, and the harness resets once per TEST rather than
+// once per workspace (testsupport_integration.go), precisely because several
+// tests in this package seed two. What else the database holds is therefore
+// not this assertion's business — filtering to ws is what keeps it about ws.
 func isDue(ctx context.Context, t *testing.T, pool *pgxpool.Pool, ws ids.UUID) bool {
 	t.Helper()
 	due, err := DueOverlayConnections(ctx, pool)
@@ -39,15 +40,42 @@ func isDue(ctx context.Context, t *testing.T, pool *pgxpool.Pool, ws ids.UUID) b
 	return false
 }
 
+// assertPacedWithin checks how far out the store actually paced the next
+// sweep, measured by the database against its own clock. want is the delay the
+// store intended; the observed remainder is at most that and at most one
+// minute short of it, since the only thing between the pacing write and this
+// read is the rest of the test.
+//
+// Due/not-due cannot see this. A ladder handed to Postgres in the wrong unit —
+// make_interval(mins) where the code means seconds — reads as "not due" just
+// like a correct one, and would sit there as a 60x backoff nobody measured.
+func assertPacedWithin(ctx context.Context, t *testing.T, pool *pgxpool.Pool, want time.Duration) {
+	t.Helper()
+	var secs float64
+	if err := database.WithWorkspaceTx(ctx, pool, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx,
+			`SELECT EXTRACT(EPOCH FROM (next_sweep_at - now())) FROM overlay_sync_state`).Scan(&secs)
+	}); err != nil {
+		t.Fatalf("reading the paced next_sweep_at: %v", err)
+	}
+	got := time.Duration(secs * float64(time.Second))
+	if got > want || got < want-time.Minute {
+		t.Fatalf("next sweep paced %v out, want within [%v, %v]", got, want-time.Minute, want)
+	}
+}
+
 // TestSweepBackoffGatesDueOverlayConnections proves the backoff end to
 // end: a freshly connected workspace is due; a connection-level failure
 // backs it off so DueOverlayConnections stops selecting it (no more
 // hot re-sweeping a dead/throttled connection); and one successful sweep
-// resets the backoff so it is due again. It needs no clock of its own and
-// no sleep: the store schedules against the DATABASE's now() and the
-// due-scan reads the same one (syncbackoff.go), so a backoff is always
-// minutes in the future and a reset is always now-or-past — whatever this
-// process's clock happens to read.
+// resets the backoff so it is due again. It needs no clock of its own and no
+// sleep: the store schedules against the DATABASE's now() (syncbackoff.go) and
+// the due-scan compares against that same now() (connectionreads.go), so a
+// backoff is always minutes in the future and a reset is always now-or-past —
+// whatever this process's clock happens to read. The pacing assertion covers
+// the units of the interval the store hands Postgres, which no assertion on
+// due/not-due can see: a ladder written in minutes instead of seconds still
+// reads as "not due".
 func TestSweepBackoffGatesDueOverlayConnections(t *testing.T) {
 	ctx, pool, ws := testWorkspaceCtx(t)
 	vault := keyvault.NewMemory()
@@ -68,6 +96,7 @@ func TestSweepBackoffGatesDueOverlayConnections(t *testing.T) {
 	if isDue(ctx, t, pool, ws) {
 		t.Fatal("a backed-off workspace must NOT be due until next_sweep_at")
 	}
+	assertPacedWithin(ctx, t, pool, rateLimitedFloor)
 
 	// One clean sweep resets the backoff — due again.
 	if err := store.RecordSweepSuccess(ctx); err != nil {

--- a/backend/internal/modules/overlay/syncclock_test.go
+++ b/backend/internal/modules/overlay/syncclock_test.go
@@ -1,0 +1,222 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package overlay
+
+// The sweep schedule is written by ONE clock, derived from this package's
+// source rather than remembered. DueOverlayConnections compares next_sweep_at
+// against now() INSIDE Postgres (connectionreads.go), so every statement that
+// writes the column has to take its value from that same now(); a deadline
+// bound from Go makes the comparison cross-clock, and two clocks are only ever
+// coincidentally equal.
+//
+// This is a gate rather than a paragraph because a comment cannot fail. The
+// same rationale is now written twice in the tree — capture's MarkQueued
+// carries it for next_attempt_at — and on both occasions nothing but habit was
+// keeping it true. It reads the source because the defect is invisible at
+// runtime on any machine whose two clocks agree, which is every CI runner and
+// every developer laptop: a test that exercised the store could not fail
+// against the bug this gate describes.
+//
+// Scope is this package because overlay_sync_state is owned here, pinned by
+// tableownership_test.go — no other package may write the column at all.
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// scheduleColumn is the column under the rule. Its two write spellings are an
+// assignment (`SET`/`DO UPDATE SET`) and a position in an INSERT column list,
+// and the gate reads both.
+const scheduleColumn = "next_sweep_at"
+
+// databaseClock is the only sanctioned start point for a scheduling value.
+// A delay is added to it (`now() + make_interval(secs => $1)`), which is why
+// this is a prefix test and not equality.
+const databaseClock = "now()"
+
+// TestEverySweepScheduleAssignmentTakesTheDatabaseClock covers the assignment
+// form: `next_sweep_at = <expr>`. The expression has to start at the database
+// clock — `$1` (a Go timestamp) and `EXCLUDED.next_sweep_at` (whatever the
+// INSERT proposed, which may itself have been bound) both fail.
+func TestEverySweepScheduleAssignmentTakesTheDatabaseClock(t *testing.T) {
+	subjects := 0
+	for _, file := range packageSourceFiles(t) {
+		for _, rhs := range assignmentsTo(sourceOf(t, file), scheduleColumn) {
+			subjects++
+			if !strings.HasPrefix(rhs, databaseClock) {
+				t.Errorf("%s: `%s = %s` schedules from something other than the database clock — "+
+					"the due-scan compares this column against Postgres now(), so the value must start at now()",
+					filepath.Base(file), scheduleColumn, rhs)
+			}
+		}
+	}
+	requireSubjects(t, subjects)
+}
+
+// TestEverySweepScheduleInsertTakesTheDatabaseClock covers the other form: the
+// column named in an INSERT column list, whose value is positional. A fresh
+// row is due immediately, so the VALUES item is the bare clock — a backoff on
+// a first insert would be pacing a sweep that has never run.
+func TestEverySweepScheduleInsertTakesTheDatabaseClock(t *testing.T) {
+	subjects := 0
+	for _, file := range packageSourceFiles(t) {
+		for _, value := range insertedValuesFor(sourceOf(t, file), scheduleColumn) {
+			subjects++
+			if value != databaseClock {
+				t.Errorf("%s: INSERT writes %s as `%s`, want the database clock `%s`",
+					filepath.Base(file), scheduleColumn, value, databaseClock)
+			}
+		}
+	}
+	requireSubjects(t, subjects)
+}
+
+// requireSubjects fails a gate that examined nothing. Both checks here are
+// keyed on a column NAME, so renaming the column — or moving the writes behind
+// a query builder — would leave them iterating an empty set and reporting
+// success. An absence-assertion passes for free; this is what makes these two
+// report on something.
+func requireSubjects(t *testing.T, found int) {
+	t.Helper()
+	if found == 0 {
+		t.Fatalf("no %s write site found in this package — the gate examined nothing, "+
+			"which is not the same as finding nothing wrong. If the column was renamed or the "+
+			"writes moved, retarget scheduleColumn; the database-clock rule still holds.", scheduleColumn)
+	}
+}
+
+// packageSourceFiles lists this package's hand-written Go, test files
+// excluded. A fixture may legitimately stamp a schedule into the past or the
+// future to put the store in a state — that is the test describing a world,
+// not production choosing a clock.
+func packageSourceFiles(t *testing.T) []string {
+	t.Helper()
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("reading the package directory: %v", err)
+	}
+	var files []string
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		files = append(files, name)
+	}
+	if len(files) == 0 {
+		t.Fatal("no package source files found — the gate would pass over an empty set")
+	}
+	return files
+}
+
+func sourceOf(t *testing.T, file string) string {
+	t.Helper()
+	text, err := os.ReadFile(file)
+	if err != nil {
+		t.Fatalf("reading %s: %v", file, err)
+	}
+	return string(text)
+}
+
+// assignmentsTo returns the right-hand side of every `column = ...` in text,
+// read to the end of its line. The repo writes one assignment per line inside
+// its SQL literals, so the line IS the expression; a trailing comma from the
+// SET list is not part of it.
+func assignmentsTo(text, column string) []string {
+	var found []string
+	for _, line := range strings.Split(text, "\n") {
+		_, rhs, ok := strings.Cut(line, column+" = ")
+		if !ok {
+			continue
+		}
+		found = append(found, strings.TrimSpace(strings.TrimSuffix(strings.TrimSpace(rhs), ",")))
+	}
+	return found
+}
+
+// insertedValuesFor returns the VALUES item matching column for every
+// `INSERT INTO ... (cols) VALUES (vals)` in text. It matches by POSITION,
+// which is what Postgres does; a gate that merely looked for the column name
+// near a now() would pass a statement whose columns and values had drifted
+// out of step.
+func insertedValuesFor(text, column string) []string {
+	var found []string
+	rest := text
+	for {
+		_, after, ok := strings.Cut(rest, "INSERT INTO ")
+		if !ok {
+			return found
+		}
+		rest = after
+		cols, tail, ok := parenGroup(rest)
+		if !ok {
+			continue
+		}
+		_, afterValues, ok := strings.Cut(tail, "VALUES")
+		if !ok {
+			continue
+		}
+		vals, _, ok := parenGroup(afterValues)
+		if !ok {
+			continue
+		}
+		names, items := splitTopLevel(cols), splitTopLevel(vals)
+		for i, name := range names {
+			if name == column && i < len(items) {
+				found = append(found, items[i])
+			}
+		}
+	}
+}
+
+// parenGroup returns the contents of the first parenthesised group in text
+// and whatever follows it, matching nested parens so a group containing a
+// function call is not cut short.
+func parenGroup(text string) (group, tail string, ok bool) {
+	start := strings.Index(text, "(")
+	if start < 0 {
+		return "", "", false
+	}
+	depth := 0
+	for i := start; i < len(text); i++ {
+		switch text[i] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				return text[start+1 : i], text[i+1:], true
+			}
+		}
+	}
+	return "", "", false
+}
+
+// splitTopLevel splits a comma-separated SQL list, ignoring commas nested in
+// parentheses or quotes. The workspace-GUC expression every INSERT here opens
+// with is ONE item that contains two commas of its own; a gate that split it
+// into three would misalign every position after it, and then report the
+// misalignment as a clock violation.
+func splitTopLevel(list string) []string {
+	var items []string
+	depth, quoted, start := 0, false, 0
+	for i := 0; i < len(list); i++ {
+		switch c := list[i]; {
+		case c == '\'':
+			quoted = !quoted
+		case quoted:
+		case c == '(':
+			depth++
+		case c == ')':
+			depth--
+		case c == ',' && depth == 0:
+			items = append(items, strings.TrimSpace(list[start:i]))
+			start = i + 1
+		}
+	}
+	return append(items, strings.TrimSpace(list[start:]))
+}

--- a/backend/internal/modules/overlay/teardown_integration_test.go
+++ b/backend/internal/modules/overlay/teardown_integration_test.go
@@ -411,10 +411,10 @@ func TestFencedSyncWritesAbortOnceTheConnectionIsRevoked(t *testing.T) {
 		// teardown purges that row, so recording a backoff or success after a
 		// disconnect would resurrect it.
 		"RecordSweepSuccess": func() error {
-			return fenced.RecordSweepSuccess(ctx, time.Date(2026, 7, 7, 0, 0, 0, 0, time.UTC))
+			return fenced.RecordSweepSuccess(ctx)
 		},
 		"RecordSweepFailure": func() error {
-			return fenced.RecordSweepFailure(ctx, errors.New("boom"), time.Date(2026, 7, 7, 0, 0, 0, 0, time.UTC))
+			return fenced.RecordSweepFailure(ctx, errors.New("boom"))
 		},
 	}
 	for name, w := range fencedWrites {

--- a/frontend/src/design-system/conformance.test.ts
+++ b/frontend/src/design-system/conformance.test.ts
@@ -39,7 +39,20 @@ const allowedFamilies = new Set([
   "monospace",
 ]);
 
-describe("design-system conformance gates (B-EP09.1)", () => {
+// Every gate below reads — and most of them TypeScript-parse — the whole
+// source tree, so what each costs is a function of how much source exists and
+// how loaded the runner is. Vitest's 5s per-test default is sized for a unit
+// test, not for a repo sweep, and it left no margin: the heaviest leg measures
+// ~1.1s locally under the coverage instrumentation `fe-unit` runs with, and
+// has already blown the 5s ceiling on a loaded CI runner (reported against a
+// job named "vitest + coverage", so it read as a coverage failure). The suite
+// budget below is an order of magnitude above that worst observed cost,
+// because the tree only grows and because these scans are synchronous file
+// I/O — there is no hang for a tight timeout to catch, so a generous one costs
+// nothing. Declared on the suite so every gate this file grows inherits it.
+const scanBudget = { timeout: 60_000 };
+
+describe("design-system conformance gates (B-EP09.1)", scanBudget, () => {
   it("uses only the three §2 type families", () => {
     for (const file of files) {
       const text = readFileSync(file, "utf8");


### PR DESCRIPTION
Closes #1329. Closes #1340.

Neither flake was a regression. Both were a measurement taken against something
that was never going to hold still.

## #1329 — the overlay sweep was scheduled by two clocks

The due-scan gates on `COALESCE(s.next_sweep_at, now()) <= now()`, so
`overlay_sync_state.next_sweep_at` is only ever compared against the clock
*inside* Postgres. `RequestSweep` and the flip seal already wrote it with that
clock; `RecordSweepSuccess` and `RecordSweepFailure` took a `time.Time` from the
caller and wrote the app process's clock instead.

The failure path has minutes of margin and never noticed. The success path means
*due immediately* and has none: whenever the app's clock ran ahead of the
database's, the reset landed in the future — a healed connection stayed backed
off for as long as the skew lasted, and nothing anywhere said so. In the
integration lane the same skew read as
`TestSweepBackoffGatesDueOverlayConnections` failing under load.

Both functions now take no clock at all, so the column is written by the one
clock that reads it, and no future caller can reintroduce a second one. Fixing
it at the API shape rather than in the test is deliberate: a test-side backdate
would have made the lane green and left the production skew in place.

**Proof of the mechanism**, from a throwaway integration probe (not committed):

```
zzprobe_integration_test.go:35: database-clock reset -> due (the fixed shape)
zzprobe_integration_test.go:49: app-clock reset under +2s skew -> NOT due (the flake)
--- PASS: TestProbeAppClockResetIsNotDue (0.09s)
```

A `next_sweep_at` stamped 2s ahead of the database's clock is not due; the
database-clock reset is. That is #1329's failure mode, reproduced on demand.

## #1340 — a repo sweep sized like a unit test

The design-system conformance gates read, and mostly TypeScript-parse, the whole
source tree against vitest's 5s per-test default. Measured per leg, warm, under
the coverage instrumentation `fe-unit` actually runs with:

| gate | cost |
|---|---|
| emoji glyphs (§2b) | 1058 ms |
| literal colours | 922 ms |
| hard-coded copy | 766 ms |
| type families | 487 ms |

That is already a fifth of the ceiling on a quiet laptop, and it had blown 5s on
a loaded CI runner — reported against a job named `fe-unit (vitest + coverage)`,
so it read as a coverage-threshold failure until you opened the log.

The budget is declared once on the suite now, an order of magnitude above the
worst observed cost. These scans are synchronous file I/O: there is no hang for
a tight ceiling to catch, so a generous one costs nothing, and every gate the
file grows inherits it.

## Two stale comments went with them

- The sweep test justified using the real clock because a reset "is always
  now-or-past" — that was the assumption that broke.
- `isDue` justified its membership filter with intra-package parallelism the
  lane does not have (`test-integration-parallel.sh`: packages run in parallel,
  tests inside one still run `-p 1`). The filter is right; the reason was not —
  several tests here seed more than one workspace, and the fleet-wide scan sees
  them all.

## Verification

- `make check` — EXIT=0.
- `make test-it` green on all three affected integration packages:
  `internal/modules/overlay`, `internal/compose/integration/overlay`,
  `internal/compose`.
- `pnpm vitest run` — 2669 passed, 0 failed.
- Pre-push gate: `craft static` 0 blocker / 0 major / 0 minor; rls-store-path
  and no-jurisdiction both OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Eliminates two CI flakes by scheduling overlay sweeps with the database clock and giving the design‑system repo scan a suite‑level timeout. Old: app clock wrote `next_sweep_at` and Vitest’s 5s default timed out; new: all sweep scheduling uses Postgres `now()` and the suite declares a 60s budget. Side effect: healed connections become due immediately under skew; backoff floors still apply. No DB migration.

- Backend: `RecordSweepSuccess` and `RecordSweepFailure` drop the caller clock; all writes to `overlay_sync_state.next_sweep_at` use `now()` and `now() + make_interval(secs => ...)`. Adds a package gate (`syncclock_test.go`) that enforces the database‑clock rule for assignments and INSERT positions, plus an integration assertion that verifies pacing delay units. Review `backend/internal/modules/overlay/syncbackoff.go` and updated call sites in `backend/internal/compose/jobs_overlay.go` and integration tests.
- Frontend: `frontend/src/design-system/conformance.test.ts` adds a suite‑level `{ timeout: 60_000 }`; removes per‑test 5s timeouts without changing logic or coverage.

<sup>Written for commit 2aad001bbcfdaa4b26f9e2454b16873196fbd8b1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1344?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

