### PR TITLE
test(perf): the budgets we publish are measured, in a lane no merge gate runs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@
 # one target here that invokes the compiler directly instead of delegating.
 GO ?= go
 
-.PHONY: help install ai-routing-local dev-fresh check check-backend check-q check-go check-gates check-fe build test test-v test-cover test-integration e2e-siteread e2e-ai e2e-ai-report ai-probe test-db-up test-it test-integration-serial bench-perf lint arch-lint vet gen gen-workflow mcp-apps-vocab gen-types gen-types-check drift composition check-composition test-extensions db-up db-init db-wait migrate migrate-up migrate-down run psql redis-cli tidy dev dev-stop dev-logs clean vuln tools tools-go infra-up infra-down infra-logs infra-reset seed-dev seed-dev-db seed-reset verify-boot frontend-check frontend-e2e e2e-company fe-install fe-typecheck fe-typecheck-composed fe-lint fe-build fe-preview fe-format fe-test fe-test-ext fe-ds-gates fe-drift fe-unit fe-quality fe-bundle fe-storybook ds-purity font-lock icon-lint ds-spacing space-tokens native-controls ext-imports fitness-jurisdiction storybook fe-uat craft-static craft-test craft-residue check-craft-doc secret-scan test-secret-scan check-image-pins check-host-ports ci-doc-parity make-target-parity check-ext-migrations contract-breaking-check migration-versions test-lanes env-reads gofmt lint-modules go-file-length rls-store-path no-jurisdiction pkg-freeze hooks sbom sbom-normalize sbom-supplement sbom-parity sbom-validate sbom-sign sbom-check
+.PHONY: help install ai-routing-local dev-fresh check check-backend check-q check-go check-gates check-fe build test test-v test-cover test-integration e2e-siteread e2e-ai e2e-ai-report ai-probe test-db-up test-it test-integration-serial bench-perf bench-record bench-capture lint arch-lint vet gen gen-workflow mcp-apps-vocab gen-types gen-types-check drift composition check-composition test-extensions db-up db-init db-wait migrate migrate-up migrate-down run psql redis-cli tidy dev dev-stop dev-logs clean vuln tools tools-go infra-up infra-down infra-logs infra-reset seed-dev seed-dev-db seed-reset verify-boot frontend-check frontend-e2e bench-mobile e2e-company fe-install fe-typecheck fe-typecheck-composed fe-lint fe-build fe-preview fe-format fe-test fe-test-ext fe-ds-gates fe-drift fe-unit fe-quality fe-bundle fe-storybook ds-purity font-lock icon-lint ds-spacing space-tokens native-controls ext-imports fitness-jurisdiction storybook fe-uat craft-static craft-test craft-residue check-craft-doc secret-scan test-secret-scan check-image-pins check-host-ports ci-doc-parity make-target-parity check-ext-migrations contract-breaking-check migration-versions test-lanes env-reads gofmt lint-modules go-file-length rls-store-path no-jurisdiction pkg-freeze hooks sbom sbom-normalize sbom-supplement sbom-parity sbom-validate sbom-sign sbom-check
 
 # Bare `make` lists every command instead of running the first target.
 .DEFAULT_GOAL := help
@@ -129,7 +129,7 @@ dev-stop:
 dev-logs:
 	@bash scripts/dev-logs.sh
 
-build test test-v test-cover test-integration e2e-siteread e2e-ai e2e-ai-report ai-probe test-db-up test-it test-integration-serial bench-perf lint arch-lint vet gen gen-workflow mcp-apps-vocab drift composition check-composition test-extensions db-up db-init db-wait seed-reset seed-dev-db migrate migrate-up migrate-down run psql redis-cli tidy clean vuln tools tools-go infra-logs infra-reset:
+build test test-v test-cover test-integration e2e-siteread e2e-ai e2e-ai-report ai-probe test-db-up test-it test-integration-serial bench-perf bench-record bench-capture lint arch-lint vet gen gen-workflow mcp-apps-vocab drift composition check-composition test-extensions db-up db-init db-wait seed-reset seed-dev-db migrate migrate-up migrate-down run psql redis-cli tidy clean vuln tools tools-go infra-logs infra-reset:
 	$(MAKE) -C backend $@
 
 ## check-fe — the frontend half of the gate (part of `make check`). Fails loudly
@@ -180,7 +180,7 @@ fe-test:
 ## ran with none of them from a unit. They were typechecked and never executed.
 fe-test-ext: composition
 	@[ -f build/composition/frontend/extlocales.gen.ts ] || { echo "fe-test-ext: build/composition/frontend/extlocales.gen.ts is missing after 'make composition' — a unit screen's suite would resolve the empty-tree copy registry and fail on every string" >&2; exit 1; }
-	cd frontend && pnpm install --frozen-lockfile && \
+	cd frontend && pnpm install --frozen-lockfile && pnpm build && \
 		MARGINCE_COMPOSITION_FRONTEND=../build/composition/frontend pnpm test:ext
 
 ## ds-purity — design-system token purity (no raw hex/rgb outside tokens.css).
@@ -343,6 +343,15 @@ fe-typecheck-composed: composition
 frontend-e2e:
 	cd frontend && pnpm install --frozen-lockfile && pnpm e2e
 
+## bench-mobile — MOBILE-AC-2: record open p95 under the 300ms PERCEIVED budget
+## on a throttled Fast-3G profile at 390px (MOBILE-PARAM-2). A measurement run
+## BY HAND, like the backend bench-* targets: `pnpm e2e` does not collect this
+## spec and this target collects nothing else. The UNTHROTTLED half of the same
+## budget stays where it already is, as a normal AC test in e2e/ac.spec.ts.
+bench-mobile:
+	cd frontend && pnpm install --frozen-lockfile && pnpm build && \
+		MARGINCE_BENCH_MOBILE=1 pnpm exec playwright test
+
 ## e2e-company — the company record page against the V2 mockups in
 ## docs/explanation/assets/company-record-page-v2/. Region ORDER and PRESENCE,
 ## never pixels: it runs on the LIVE stack (make dev, then make seed-dev),
@@ -374,7 +383,7 @@ storybook:
 ## — it is the fe-only UAT lane a coordinator runs instead of the full stack.
 ## Optional: ARGS="--allow-missing".
 fe-uat:
-	cd frontend && pnpm install --frozen-lockfile && \
+	cd frontend && pnpm install --frozen-lockfile && pnpm build && \
 		pnpm exec playwright install chromium >/dev/null 2>&1 && \
 		node scripts/fe-uat.mjs $(ARGS)
 

--- a/backend/.golangci.strict.yml
+++ b/backend/.golangci.strict.yml
@@ -11,10 +11,11 @@ version: "2"
 
 run:
   # The baseline lints only untagged code; this pass also covers the
-  # integration and livesmoke lanes so new test-harness code is gated too.
+  # integration, livesmoke and bench lanes so new test-harness code is gated too.
   build-tags:
     - integration
     - livesmoke
+    - bench
 
 issues:
   # Only findings introduced after the merge-base with origin/main fail.

--- a/backend/.golangci.yml
+++ b/backend/.golangci.yml
@@ -11,6 +11,10 @@ run:
   build-tags:
     - integration
     - livesmoke
+    # The by-hand benchmark lane (make bench-record / bench-capture). It needs
+    # this more than the others do: no scheduled job runs those files, so lint
+    # and `go vet -tags 'integration bench'` are the only passes that read them.
+    - bench
 
 linters:
   default: standard

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -120,7 +120,7 @@ test-extensions: composition ## Every enabled extension's own test lane (each un
 build: composition ## Compile every package (composed workspace)
 	$(GOWORK_COMPOSED) $(GO) build ./...
 
-vet: composition ## Run go vet over every package, untagged AND -tags integration (composed workspace)
+vet: composition ## Run go vet over every package, untagged AND -tags 'integration bench' (composed workspace)
 	$(GOWORK_COMPOSED) $(GO) vet ./...
 	# The INTEGRATION lane, type-checked. `make check` otherwise never compiles
 	# a single //go:build integration file — build, vet, lint and test all run
@@ -133,7 +133,13 @@ vet: composition ## Run go vet over every package, untagged AND -tags integratio
 	# vet, not test: type-checking the tagged lane needs no database, no Docker
 	# and no fixtures, so it costs seconds and belongs in the always-on gate.
 	# RUNNING those tests is the integration lane's job and stays there.
-	$(GOWORK_COMPOSED) $(GO) vet -tags integration ./...
+	#
+	# `bench` rides along and needs this MORE than the integration lane does:
+	# the bench files are run by hand from a make target, so unlike the
+	# integration lane nothing scheduled ever compiles them. Setting a tag only
+	# ADDS files, so this one invocation still covers everything `-tags
+	# integration` alone would.
+	$(GOWORK_COMPOSED) $(GO) vet -tags 'integration bench' ./...
 
 test: composition ## Unit tests (the root fitness tests run uncached)
 	$(GOWORK_COMPOSED) $(GO) test ./...
@@ -247,7 +253,32 @@ test-integration-serial: composition ## Escape hatch: the old sequential lane, a
 # The integration lane above runs the same harness on the SMB tier as a
 # standing canary; this target is the tier the PERF-7 SLO binds at.
 bench-perf: composition ## PERF-3/PERF-7 benchmark harness on the mid-market §6.7 tier (needs db-up; seeds 250k contacts)
-	MARGINCE_BENCH_TIER=mid_market $(GOWORK_COMPOSED) $(GO) test -tags integration -run TestPerfBudgetsHoldOnSeededVolumeTier -v -timeout 30m ./internal/compose/integration
+	MARGINCE_BENCH_TIER=mid_market $(GOWORK_COMPOSED) $(GO) test -tags integration -run TestPerfBudgetsHoldOnSeededVolumeTier -count=1 -v -timeout 30m ./internal/compose/integration
+
+# The `bench` lane: measurements run BY HAND, never by a merge gate.
+#
+# bench-perf above is the older shape and stays as it is — its suite carries
+# only the `integration` tag, so the standing lane runs it at the SMB tier as a
+# canary and this target re-runs it at mid-market. The two targets below are the
+# opposite posture by request: their suites carry `integration && bench`, so no
+# CI lane runs them at all. `make vet` and both golangci passes still TYPE-CHECK
+# them, which is the only thing standing between a by-hand lane and rot.
+#
+# Separate targets rather than one, because they measure unrelated promises and
+# cost unrelated amounts of time: a reader chasing a slow save should not have
+# to seed a mailbox to find out.
+#
+# `-count=1` on all three is load-bearing, not habit. Go caches a passing test
+# result keyed on the binary and its inputs, and a cached PASS replays the
+# ORIGINAL run's log — so a second `make bench-record` printed p50=3.276875ms a
+# second time, to the nanosecond, having measured nothing. A benchmark that can
+# answer from cache reports the past as the present, which is worse than not
+# running: the number looks fresh and is not.
+bench-record: composition ## PERF-1/PERF-4 record open + save budgets, measured over HTTP (needs db-up)
+	$(GOWORK_COMPOSED) $(GO) test -tags 'integration bench' -run TestRecordOpenAndSaveBudgets -count=1 -v -timeout 15m ./internal/compose/integration
+
+bench-capture: composition ## CAP-PARAM-1 capture-to-timeline latency, 60s p95 (needs db-up)
+	$(GOWORK_COMPOSED) $(GO) test -tags 'integration bench' -run TestCaptureToTimelineLatencyBudget -count=1 -v -timeout 15m ./internal/compose/integration/capture
 
 # golangci-lint is the one gate tool this Makefile installs rather than
 # runs via pinned `go run` (arch-lint/vuln/oasdiff do): `go run` would

--- a/backend/internal/compose/integration/capture/perfcapture_bench_test.go
+++ b/backend/internal/compose/integration/capture/perfcapture_bench_test.go
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration && bench
+
+package capture
+
+// CAP-PARAM-1, measured: from a message's RECEIPT to that message being visible
+// on the matched timeline, 60 s p95, "including auto-create + link of new
+// participants".
+//
+// The receipt instant is INJECTED — it is the fixture's own `Date:` header,
+// stamped at the moment the message is handed to the connector, which is what
+// the chapter means by "integration-tested with a clock assert". Nothing here
+// sleeps and nothing waits on a wall-clock deadline; the only real-clock reading
+// is the elapsed time being measured, and a budget of 60 s against a path that
+// completes in milliseconds leaves four orders of magnitude of headroom, so
+// there is no timing this can lose.
+//
+// Every sample uses a FRESH counterparty on a fresh domain, and the thread shape
+// is the one that actually auto-creates: a stranger's first message defers, so
+// the budget's "auto-create + link" only happens once the owner's own attested
+// reply makes the sender a counterparty (ADR-0072 §1). Measuring a deferred
+// message would report the budget as held by the path that does no work.
+//
+// Run it with `make bench-capture`.
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/gradionhq/margince/backend/internal/compose/integration"
+	"github.com/gradionhq/margince/backend/internal/modules/search"
+	"github.com/gradionhq/margince/backend/internal/platform/database"
+)
+
+// capParam1Budget is the published capture-to-timeline budget (capture.md
+// CAP-PARAM-1, restated by AC1.1 and AC3.4). A calibration value: changing it is
+// a noted budget revision, never a bump to make a red run green.
+const capParam1Budget = 60 * time.Second
+
+// captureBenchSamples is the measured thread count. Lower than the record
+// benchmark's because each sample drives a whole three-message sync with an
+// auto-create behind it, not one HTTP round trip.
+const captureBenchSamples = 20
+
+// renderNotBlockedTimeout bounds the pre-capture timeline read. It exists to
+// turn AC3.4's "never blocks the inbound-mail timeline render" into something
+// that can FAIL: if the read path ever waited on capture, it would wait here,
+// where there is nothing to wait for, and the deadline fires instead of the
+// suite hanging until the lane times out.
+const renderNotBlockedTimeout = 5 * time.Second
+
+func TestCaptureToTimelineLatencyBudget(t *testing.T) {
+	env := newCaptureEnv(t)
+
+	assertTimelineRenderIsNotBlockedByCapture(t, env.e)
+
+	durations := make([]time.Duration, 0, captureBenchSamples)
+	for i := range captureBenchSamples {
+		durations = append(durations, captureOneThread(t, env, i))
+	}
+
+	stats, err := search.MeasureQuery("capture_to_timeline", capParam1Budget, durations)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("perfbench [capture]: %s p50=%s p95=%s p99=%s (budget %s, %d samples)",
+		stats.Query, stats.P50, stats.P95, stats.P99, stats.Budget, stats.Samples)
+
+	report := search.BenchReport{Tier: search.BenchTierSMB, Queries: []search.QueryStats{stats}}
+	if err := report.Gate(); err != nil {
+		t.Fatalf("CAP-PARAM-1 budget gate is red: %v", err)
+	}
+}
+
+// captureOneThread measures one message's whole journey: stamp the receipt,
+// hand the thread to the connector, and stop the clock once the message is
+// readable on the counterparty's own timeline.
+//
+// The elapsed time is taken from the message's DATE — the receipt the budget is
+// measured from — not from the moment the sync call started, so the connector's
+// own work is inside the number rather than beside it.
+func captureOneThread(t *testing.T, env captureEnv, sample int) time.Duration {
+	t.Helper()
+	counterparty := fmt.Sprintf("alice%d@acme%d.example", sample, sample)
+	inbound := "in" + strconv.Itoa(sample) + "@acme.example"
+	reply := "out" + strconv.Itoa(sample) + "@myco.example"
+	followUp := "in" + strconv.Itoa(sample) + "b@acme.example"
+
+	receipt := time.Now()
+	env.syncSent(t, map[string]bool{reply: true},
+		benchEmailAt(counterparty, "Alice Example", captureOwner, inbound, "", receipt),
+		benchEmailAt(captureOwner, "", counterparty, reply, inbound, receipt),
+		benchEmailAt(counterparty, "Alice Example", captureOwner, followUp, inbound, receipt),
+	)
+	visible := timelineActivityCount(t, env.e, counterparty)
+	elapsed := time.Since(receipt)
+
+	// A sample that linked nothing is not a fast capture, it is a capture that
+	// did not happen — recording its duration would report the budget as held
+	// by the run that skipped the work.
+	if visible == 0 {
+		t.Fatalf("sample %d: %s has no activity on their timeline after the sync — "+
+			"the thread did not auto-create, so this sample measures nothing", sample, counterparty)
+	}
+	return elapsed
+}
+
+// assertTimelineRenderIsNotBlockedByCapture proves AC3.4's second half. Read a
+// counterparty's timeline BEFORE anything about them has been captured: the
+// read must answer — promptly, and with nothing — rather than wait for a
+// capture that is not coming.
+func assertTimelineRenderIsNotBlockedByCapture(t *testing.T, e *integration.SearchEnv) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(e.Admin(), renderNotBlockedTimeout)
+	defer cancel()
+
+	var n int
+	err := database.WithWorkspaceTx(ctx, e.Pool, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx, `
+			SELECT count(*) FROM activity_link al JOIN person_email pe ON pe.person_id = al.person_id
+			WHERE al.entity_type = 'person' AND pe.email = 'nobody@uncaptured.example'`).Scan(&n)
+	})
+	if err != nil {
+		t.Fatalf("the timeline render waited on a capture that never came (AC3.4): %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("an uncaptured counterparty has %d timeline rows, want 0 — the fixture is wrong", n)
+	}
+}
+
+// timelineActivityCount is what "visible on the matched timeline" means in the
+// schema: activities linked to the person the message was matched to.
+func timelineActivityCount(t *testing.T, e *integration.SearchEnv, email string) int {
+	t.Helper()
+	var n int
+	err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		return tx.QueryRow(context.Background(), `
+			SELECT count(*) FROM activity_link al JOIN person_email pe ON pe.person_id = al.person_id
+			WHERE al.entity_type = 'person' AND pe.email = $1`, email).Scan(&n)
+	})
+	if err != nil {
+		t.Fatalf("reading %s's timeline: %v", email, err)
+	}
+	return n
+}
+
+// benchEmailAt is email() with the receipt instant as a parameter. It is not a
+// change to email() because every other suite in this package wants that Date
+// FIXED — a fixture whose timestamp moves would make their assertions depend on
+// when they ran. Here the Date is the measurement's zero point and has to move.
+func benchEmailAt(from, fromName, to, msgID, refs string, at time.Time) []byte {
+	fromHeader := from
+	if fromName != "" {
+		fromHeader = fmt.Sprintf("%s <%s>", fromName, from)
+	}
+	lines := []string{
+		"From: " + fromHeader,
+		"To: " + to,
+		"Subject: project",
+		"Date: " + at.UTC().Format(time.RFC1123Z),
+		"Message-ID: <" + msgID + ">",
+	}
+	if refs != "" {
+		lines = append(lines, "References: <"+refs+">")
+	}
+	lines = append(lines, "Content-Type: text/plain", "", "hello", "")
+	return []byte(strings.Join(lines, "\r\n"))
+}

--- a/backend/internal/compose/integration/perfrecord_bench_test.go
+++ b/backend/internal/compose/integration/perfrecord_bench_test.go
@@ -1,0 +1,265 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration && bench
+
+package integration
+
+// The PERF-1 / PERF-4 record benchmarks: how long the SERVER takes to open a
+// record and to save one, measured at the transport the number is published
+// about.
+//
+// Two deliberate differences from perfbench_integration_test.go next door,
+// which measures PERF-3/PERF-7:
+//
+//   - It measures through the BOOTED APPLICATION, not the store. PERF-3 and
+//     PERF-7 are query budgets ("search", "context-graph assembly") and a store
+//     call is the honest unit for them. PERF-1 and PERF-4 are budgets on an
+//     OPERATION a person performs, and their column says "server" — routing,
+//     admission, the RLS transaction and serialization are all inside the number
+//     a customer is quoted, so measuring underneath them would report a figure
+//     nobody promised.
+//   - It carries the `bench` tag, so the merge gate never RUNS it. `make vet`
+//     still type-checks this lane, which is the only reason a file no test lane
+//     compiles does not rot.
+//
+// Run it with `make bench-record`.
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
+	"github.com/gradionhq/margince/backend/internal/modules/search"
+)
+
+// The published budgets (acceptance-standards.md §Parameters — performance
+// budgets). They are calibration values per ADR-0021 §5: changing one is a
+// noted budget revision, never a silent bump to make a red run green.
+const (
+	// perf1RecordOpenBudget bounds opening a person, organization or deal.
+	// PERF-1's other half — 300 ms PERCEIVED — is a browser measurement and
+	// belongs to the throttled mobile profile (MOBILE-AC-2), not here.
+	perf1RecordOpenBudget = 100 * time.Millisecond
+	// perf4RecordSaveBudget bounds a save/mutation (PERF-4).
+	perf4RecordSaveBudget = 150 * time.Millisecond
+)
+
+// recordBenchSpec sizes the measurement loop. benchRuns reads only warmups and
+// sample off a spec — the seeding fields belong to the volume-tier benchmark
+// next door and are left zero here on purpose, because this suite seeds through
+// its own path rather than seedBenchTier's.
+//
+// More samples than the tier harness takes: an HTTP round trip is cheaper than
+// a 250k-row graph walk, so the runs are affordable, and a p95 over 30 samples
+// is read off the 29th value rather than the 19th.
+var recordBenchSpec = benchTierSpec{tier: search.BenchTierSMB, warmups: 5, sample: 30}
+
+// The background volume the measured record sits in. A record open against an
+// empty database measures nothing anybody will experience: the planner picks
+// different paths at three rows than at ten thousand, and an index that is never
+// exercised looks exactly as fast as one that does not exist.
+const (
+	recordBenchPersons       = 10_000
+	recordBenchOrganizations = 1_000
+	recordBenchActivities    = 20_000
+)
+
+func TestRecordOpenAndSaveBudgets(t *testing.T) {
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
+	seedRecordBenchVolume(t, e)
+
+	person := createBenchPerson(t, e)
+	organization, deal := createBenchOrganizationAndDeal(t, e)
+
+	report := search.BenchReport{Tier: recordBenchSpec.tier, Queries: []search.QueryStats{
+		benchRecordOpen(t, e, "record_open_person", "/v1/people/"+person),
+		benchRecordOpen(t, e, "record_open_organization", "/v1/organizations/"+organization),
+		benchRecordOpen(t, e, "record_open_deal", "/v1/deals/"+deal),
+		benchRecordSave(t, e, person),
+	}}
+
+	for _, q := range report.Queries {
+		t.Logf("perfbench [%s]: %s p50=%s p95=%s p99=%s (budget %s, %d samples)",
+			report.Tier, q.Query, q.P50, q.P95, q.P99, q.Budget, q.Samples)
+	}
+	if err := report.Gate(); err != nil {
+		t.Fatalf("PERF-1/PERF-4 budget gate is red: %v", err)
+	}
+}
+
+// benchRecordOpen measures one GET the record page issues (PERF-1). A non-200
+// fails the run rather than being recorded: a 404 answered quickly is not a
+// record open, and averaging it in would report a budget as held by the one
+// response that does no work.
+func benchRecordOpen(t *testing.T, e *apptest.AppEnv, name, path string) search.QueryStats {
+	t.Helper()
+	stats, err := benchRuns(name, perf1RecordOpenBudget, recordBenchSpec, func() error {
+		return benchExpectOK(t, e, http.MethodGet, path, nil)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return stats
+}
+
+// benchRecordSave measures the PATCH a record edit issues (PERF-4). The body
+// changes the title on every run so no run can be answered by a no-op write —
+// a save that stores nothing is not the operation the budget is about.
+func benchRecordSave(t *testing.T, e *apptest.AppEnv, personID string) search.QueryStats {
+	t.Helper()
+	edit := 0
+	stats, err := benchRuns("record_save_person", perf4RecordSaveBudget, recordBenchSpec, func() error {
+		edit++
+		return benchExpectOK(t, e, http.MethodPatch, "/v1/people/"+personID,
+			apptest.AnyMap{"title": "Rear Admiral " + strconv.Itoa(edit)})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return stats
+}
+
+// seedRecordBenchVolume bulk-loads background rows into the bootstrapped
+// organization's workspace through the owner connection, set-based.
+//
+// The GUC is set inside the transaction because FORCE RLS binds the table owner
+// too — an unbound INSERT here does not fail loudly, it writes rows no policy
+// will ever return, and the benchmark would then measure an empty table while
+// reporting a seeded one.
+func seedRecordBenchVolume(t *testing.T, e *apptest.AppEnv) {
+	t.Helper()
+	ctx := context.Background()
+
+	var workspace string
+	if err := e.Owner.QueryRow(ctx, `SELECT id FROM workspace WHERE slug = $1`, e.Slug).Scan(&workspace); err != nil {
+		t.Fatalf("resolving the bootstrapped workspace: %v", err)
+	}
+	tx, err := e.Owner.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	//craft:ignore swallowed-errors error-path safety net only — the Commit below is asserted, after which this rollback is a designed no-op
+	defer func() { _ = tx.Rollback(ctx) }()
+	if _, err := tx.Exec(ctx, `SELECT set_config('app.workspace_id', $1, true)`, workspace); err != nil {
+		t.Fatalf("binding the workspace GUC: %v", err)
+	}
+	for _, seed := range recordBenchSeeds(workspace) {
+		if _, err := tx.Exec(ctx, seed.sql, seed.args...); err != nil {
+			t.Fatalf("seeding %s: %v", seed.what, err)
+		}
+	}
+	if err := tx.Commit(ctx); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+}
+
+// recordBenchSeeds is the seeding program, one statement per row kind. It is a
+// list rather than a run of Exec calls so the failure above can name WHICH kind
+// failed — a bare "seeding: constraint violated" over four statements sends the
+// reader to read all four.
+func recordBenchSeeds(workspace string) []struct {
+	what string
+	sql  string
+	args []any
+} {
+	return []struct {
+		what string
+		sql  string
+		args []any
+	}{
+		{"persons", `INSERT INTO person (workspace_id, full_name, source, captured_by)
+		   SELECT $1, 'Bench Person ' || i, 'manual', 'human:bench'
+		   FROM generate_series(1, $2) AS i`, []any{workspace, recordBenchPersons}},
+		{"organizations", `INSERT INTO organization (workspace_id, display_name, source, captured_by)
+		   SELECT $1, 'Bench Org ' || i, 'manual', 'human:bench'
+		   FROM generate_series(1, $2) AS i`, []any{workspace, recordBenchOrganizations}},
+		{"activities", `INSERT INTO activity (workspace_id, kind, subject, body, occurred_at, source, captured_by)
+		   SELECT $1, 'email', 'Bench subject ' || i, 'Bench body ' || i,
+		          now() - (i % 720 || ' hours')::interval, 'manual', 'human:bench'
+		   FROM generate_series(1, $2) AS i`, []any{workspace, recordBenchActivities}},
+		// The planner chooses differently against stale statistics, and a
+		// benchmark that measures the plan for an empty table is measuring the
+		// fixture rather than the product.
+		{"statistics", `ANALYZE person, organization, activity`, nil},
+	}
+}
+
+// createBenchPerson creates the measured person through the real endpoint, so
+// the row the benchmark opens is one the product's own writer produced.
+func createBenchPerson(t *testing.T, e *apptest.AppEnv) string {
+	t.Helper()
+	var person apptest.AnyMap
+	if status := e.Call(t, http.MethodPost, "/v1/people", apptest.AnyMap{
+		"full_name": "Grace Hopper",
+		"source":    "ui",
+		"emails":    []apptest.AnyMap{{"email": "grace@navy.mil", "is_primary": true}},
+	}, nil, &person); status != http.StatusCreated {
+		t.Fatalf("create person = %d %v", status, person)
+	}
+	return benchID(t, person, "person")
+}
+
+// createBenchOrganizationAndDeal creates the other two records PERF-1 names.
+// The deal needs the organization, so the two are made together rather than
+// through two fixtures that would each have to make one.
+func createBenchOrganizationAndDeal(t *testing.T, e *apptest.AppEnv) (string, string) {
+	t.Helper()
+	stages := apptest.DiscoverSeededPipeline(t, e)
+
+	var org apptest.AnyMap
+	if status := e.Call(t, http.MethodPost, "/v1/organizations", apptest.AnyMap{
+		"display_name": "Acme GmbH",
+		"source":       "ui",
+		"domains":      []apptest.AnyMap{{"domain": "acme.example", "is_primary": true}},
+	}, nil, &org); status != http.StatusCreated {
+		t.Fatalf("create organization = %d %v", status, org)
+	}
+	orgID := benchID(t, org, "organization")
+
+	var deal apptest.AnyMap
+	if status := e.Call(t, http.MethodPost, "/v1/deals", apptest.AnyMap{
+		"name": "Acme rollout", "amount_minor": 250_000_00, "currency": "EUR",
+		"pipeline_id": stages.PipelineID, "stage_id": stages.Open,
+		"organization_id": orgID, "source": "ui",
+	}, nil, &deal); status != http.StatusCreated {
+		t.Fatalf("create deal = %d %v", status, deal)
+	}
+	return orgID, benchID(t, deal, "deal")
+}
+
+// benchID reads the created record's id, failing on a payload that carries none
+// rather than measuring requests against an empty path.
+func benchID(t *testing.T, record apptest.AnyMap, what string) string {
+	t.Helper()
+	id, ok := record["id"].(string)
+	if !ok {
+		t.Fatalf("the created %s carries no string id: %v", what, record)
+	}
+	return id
+}
+
+// benchExpectOK issues one measured request and turns a non-200 into the error
+// benchRuns reports, so a broken fixture reads as a broken fixture rather than
+// as a very fast budget. The error names the call and what the server said
+// about it, because "run 7 failed" sends the reader nowhere.
+//
+// reqBody stays a nil interface when there is no body: a typed nil map handed
+// to Call is not nil to it, and would be marshalled as a literal `null`.
+func benchExpectOK(t *testing.T, e *apptest.AppEnv, method, path string, body apptest.AnyMap) error {
+	t.Helper()
+	var reqBody any
+	if body != nil {
+		reqBody = body
+	}
+	var out apptest.AnyMap
+	if status := e.Call(t, method, path, reqBody, nil, &out); status != http.StatusOK {
+		return fmt.Errorf("%s %s → %d %v", method, path, status, out)
+	}
+	return nil
+}

--- a/backend/jobregistrationban_test.go
+++ b/backend/jobregistrationban_test.go
@@ -274,7 +274,10 @@ func TestTheOwningConfigLintsTheTaggedLanes(t *testing.T) {
 		t.Fatal("no config enables forbidigo, so there is no owner to hold to anything")
 	}
 	tags := readGolangciConfig(t, owner).Run.BuildTags
-	for _, tag := range []string{"integration", "livesmoke"} {
+	// `bench` carries a sharper version of the same obligation: the by-hand
+	// benchmark lane is run by NO scheduled job, so lint and `go vet -tags
+	// 'integration bench'` are the only passes that ever compile those files.
+	for _, tag := range []string{"integration", "livesmoke", "bench"} {
 		if !slices.Contains(tags, tag) {
 			t.Errorf("%s owns forbidigo but does not declare the %q build tag, so the %s-only files are linted by nothing", owner, tag, tag)
 		}

--- a/docs/reference/make-targets.md
+++ b/docs/reference/make-targets.md
@@ -95,7 +95,29 @@ root gates (each is a small script; all merge-blocking):
 | `test-v` / `test-cover` | Verbose unit tests / unit tests with a coverage summary |
 | `db-wait` / `infra-logs` / `infra-reset` | Block until Postgres answers / tail the dev-stack logs / wipe volumes and restart the stack |
 | `bench-perf` | The PERF benchmark harness on the mid-market tier (needs `db-up`; seeds 250k contacts) |
+| `bench-record` | PERF-1/PERF-4: record open and save p50/p95/p99, measured over HTTP against the booted app (needs `db-up`) |
+| `bench-capture` | CAP-PARAM-1: capture-to-timeline latency, 60 s p95, over the auto-create path (needs `db-up`) |
 | `tidy` | `go mod tidy` |
+
+### The `bench` lane — measurements, run by hand
+
+`bench-record` and `bench-capture` carry `//go:build integration && bench`, so
+**no CI lane runs them**: not `make check`, not the integration lane. They report
+the numbers behind the budgets `acceptance-standards.md` publishes rather than
+gating a merge on them, which is why each prints p50/p95/p99 beside its budget
+instead of only passing or failing. `bench-mobile` below is the frontend half of
+the same posture.
+
+They are still **type-checked** on every `make check`: `go vet -tags 'integration
+bench'` and both golangci passes carry the tag. That is load-bearing rather than
+tidiness — nothing scheduled compiles these files, so without it a renamed helper
+would break them silently and nobody would find out until the next person ran a
+benchmark by hand and had to debug the harness instead of reading a number.
+
+`bench-perf` is the older shape and is **not** in this lane: its suite carries
+only the `integration` tag, so the standing integration lane runs it at the SMB
+tier as a canary and `bench-perf` re-runs it at mid-market, where the PERF-7 SLO
+actually binds.
 
 ## Root-only (frontend lane)
 
@@ -114,6 +136,7 @@ root gates (each is a small script; all merge-blocking):
 | `verify-boot` | Prove a running, seeded stack end to end: seeded-admin login, seeded people over `/v1`, frontend production build — pure client, fails loudly |
 | `ai-routing-local` | Seed the gitignored `config/ai-routing.yaml` from the committed template on first run (never clobbers an existing copy) |
 | `frontend-e2e` | The screen-acceptance UAT harness: AC-named tests + 390px sweep + axe WCAG 2.2 AA + perceived-perf budgets, against the built app over the seed mock (`BASE_URL=…` targets a live backend). Wired into CI as the `uat` job |
+| `bench-mobile` | MOBILE-AC-2: record open p95 against the 300 ms **perceived** budget on a throttled Fast-3G profile at 390px (MOBILE-PARAM-2). The by-hand frontend measurement, and the throttled half of PERF-1's perceived budget — the unthrottled half stays a normal AC test in `e2e/ac.spec.ts`. Switched on by `MARGINCE_BENCH_MOBILE=1`, which is what keeps the two runs from collecting each other's specs: `pnpm e2e` does not see `perf-mobile.spec.ts`, and this target sees nothing else |
 | `storybook` | The component workbench on `:6006` — the design-system catalog and the story surface `fe-uat` renders. Stories live beside their component as `<name>.stories.tsx` |
 | `fe-uat` | Change-scoped Storybook render+capture UAT for frontend-only diffs: renders THIS branch's changed component's stories in headless Chromium and screenshots them (no live stack, no DB). Fails on an unclean render, an unregistered story, or a changed component with no story. Artifact: `.tmp/fe-uat/manifest.json`. Deliberately **not** in `make check` — the fe-only UAT lane a coordinator runs instead of the full stack. `ARGS="--allow-missing"` |
 

--- a/frontend/e2e/perf-mobile.spec.ts
+++ b/frontend/e2e/perf-mobile.spec.ts
@@ -1,0 +1,95 @@
+import { expect, type Page, test } from "@playwright/test";
+import { mockApi } from "./seed";
+
+/**
+ * MOBILE-AC-2: record open p95 < 300 ms perceived, on a throttled Fast-3G
+ * profile at 390px. The BUDGET is PERF-1's and is single-homed there;
+ * MOBILE-PARAM-2 pins only the condition it has to hold under.
+ *
+ * This is the throttled half of PERF-1's perceived budget. The unthrottled half
+ * already exists as `PERF-1: record open renders under the 300ms perceived
+ * budget` in ac.spec.ts, and it stays there — this file does not restate it on
+ * a fast link, it measures the same interaction on a slow one.
+ *
+ * Run it with `make bench-mobile`. It is not collected by `pnpm e2e`.
+ */
+
+// Chrome DevTools' own Fast-3G preset. Named constants rather than inline
+// arithmetic because these are the numbers MOBILE-PARAM-2 refers to by name,
+// and a reader has to be able to check them against the profile they claim.
+const FAST_3G = {
+  downloadThroughput: (1.6 * 1024 * 1024) / 8, // 1.6 Mbit/s
+  uploadThroughput: (750 * 1024) / 8, // 750 kbit/s
+  latency: 562.5, // ms round trip
+};
+
+const SAMPLES = 20;
+const PERCEIVED_BUDGET_MS = 300;
+
+/**
+ * Throttle the link the way a phone experiences it.
+ *
+ * TWO mechanisms, because either alone would measure a lie here. CDP throttling
+ * shapes real network traffic — the bundle, the fonts — but the seed fixture is
+ * mocked at the network edge, and a fulfilled route never touches the transport
+ * CDP is shaping. So the API's round-trip cost has to be paid explicitly.
+ *
+ * The delay route is registered AFTER mockApi so it matches FIRST (Playwright
+ * runs handlers in reverse registration order), waits out one round trip, and
+ * then falls back to the seed mock rather than answering in its place.
+ */
+async function throttle(page: Page) {
+  const session = await page.context().newCDPSession(page);
+  await session.send("Network.enable");
+  await session.send("Network.emulateNetworkConditions", {
+    offline: false,
+    ...FAST_3G,
+  });
+  await page.route("**/v1/**", async (route) => {
+    await new Promise((resolve) => setTimeout(resolve, FAST_3G.latency));
+    await route.fallback();
+  });
+}
+
+/** Nearest-rank p95, the same method the Go harness reports — so a value here
+ * is a latency that actually happened rather than an interpolation between two
+ * that did not. */
+function p95(samples: number[]): number {
+  const sorted = [...samples].sort((a, b) => a - b);
+  const rank = Math.ceil(sorted.length * 0.95) - 1;
+  return sorted[Math.min(Math.max(rank, 0), sorted.length - 1)];
+}
+
+test("MOBILE-AC-2: record open holds the 300ms perceived budget on Fast-3G at 390px", async ({
+  page,
+}) => {
+  await mockApi(page);
+  await throttle(page);
+
+  const samples: number[] = [];
+  for (let i = 0; i < SAMPLES; i++) {
+    await page.goto("/#/contacts");
+    // Anchor on a settled screen before measuring, for the reason ac.spec.ts
+    // records: a click during hydration lands on a row whose handler is not
+    // attached, the navigation never happens, and the assertion times out as a
+    // phantom perf failure. Under throttling this is likelier, not less likely.
+    await page.waitForLoadState("networkidle");
+    const row = page.getByText("Anna Weber");
+    await expect(row).toBeVisible();
+
+    const start = Date.now();
+    await row.click();
+    // The record's OWN header, not the shell's: the head shows only the trail
+    // on a record route and renders from the router before any record read
+    // returns, so waiting on it would measure routing rather than the open.
+    await expect(page.locator(".record-head h1")).toHaveText("Anna Weber");
+    samples.push(Date.now() - start);
+  }
+
+  const measured = p95(samples);
+  console.log(
+    `perfbench [fast-3g/390px]: record_open_perceived p95=${measured}ms ` +
+      `(budget ${PERCEIVED_BUDGET_MS}ms, ${SAMPLES} samples)`,
+  );
+  expect(measured).toBeLessThan(PERCEIVED_BUDGET_MS);
+});

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -5,13 +5,36 @@ import { defineConfig } from "@playwright/test";
 // the network edge. Suites run at desktop AND 390px (§3.8) — the mobile
 // checks set their viewport explicitly. Point BASE_URL at a live api+seed
 // to run the same suite unmocked.
+
+// The throttled mobile benchmark (MOBILE-PARAM-2 / MOBILE-AC-2) is a run of its
+// own, by request: it is a MEASUREMENT rather than a gate, and it is slow by
+// construction because a Fast-3G profile is slow on purpose.
+//
+// The switch is an env var rather than a project filter because a filter still
+// leaves the spec discoverable — `pnpm e2e` would collect it, and one forgotten
+// `--project` would put a throttled benchmark back in the lane it was taken out
+// of. With this, the two runs cannot see each other's specs at all: the normal
+// run does not collect the benchmark, and `make bench-mobile` collects NOTHING
+// else. It is the same posture as the Go `bench` build tag.
+const benchMobile = process.env.MARGINCE_BENCH_MOBILE === "1";
+
 export default defineConfig({
   testDir: "./e2e",
-  timeout: 30_000,
+  ...(benchMobile
+    ? { testMatch: ["**/perf-mobile.spec.ts"] }
+    : { testIgnore: ["**/perf-mobile.spec.ts"] }),
+  // A throttled profile spends most of its budget waiting, and the default 30s
+  // is a per-test bound that a 20-sample loop over a slow link will exceed for
+  // reasons that are the point rather than a fault.
+  timeout: benchMobile ? 300_000 : 30_000,
   fullyParallel: true,
   use: {
     baseURL: process.env.BASE_URL ?? "http://localhost:4317",
-    viewport: { width: 1280, height: 800 },
+    // MOBILE-AC-2 measures the mobile viewport (§3.8's 390px), so the benchmark
+    // run does not inherit the desktop default the AC suites are written at.
+    viewport: benchMobile
+      ? { width: 390, height: 844 }
+      : { width: 1280, height: 800 },
     // The AC criteria assert the German chrome; detectLocale reads the
     // browser's language, so pin it — otherwise the suite only passes on a
     // machine whose system locale happens to be German.

--- a/scripts/test-integration-parallel.sh
+++ b/scripts/test-integration-parallel.sh
@@ -33,7 +33,8 @@
 # so each shard runs a deterministic round-robin slice of every package's
 # top-level Test functions via -run. Discovery is static (`func Test…` in the
 # package's *_test.go files) so it costs no compile; files under the known
-# opt-in lane tags (e2e_llm, livesmoke, voicelive) are skipped exactly as the compiler
+# opt-in lane tags (e2e_llm, livesmoke, voicelive) and the by-hand benchmark lane
+# (`integration && bench`) are skipped exactly as the compiler
 # skips them, and any other constraint — an expression, or a lone tag the
 # allowlist does not know (a satisfied built-in like linux or cgo would
 # compile but never be sliced) — fails discovery loudly instead of being
@@ -244,6 +245,19 @@ while IFS='|' read -r d rel; do
         # lane's build always satisfies the tag.
         '!integration') skip_file=1 ;;
         e2e_llm|livesmoke|voicelive) skip_file=1 ;;
+        # `integration && bench` is the by-hand benchmark lane (make bench-record
+        # / bench-capture). It is a CONJUNCTION rather than a lone tag on
+        # purpose: those files use this lane's own harness — apptest.AppEnv,
+        # newCaptureEnv, benchRuns — so they need `integration` to compile at
+        # all, and `bench` is what keeps them out of every scheduled run.
+        #
+        # Statically decidable for the same reason the lone tags are: this
+        # lane's build sets `integration` and never sets `bench`, so the
+        # compiler excludes the file and so does this. The general worry above —
+        # a satisfied built-in tag compiling under `go test` yet landing in no
+        # slice — does not apply, because `bench` is not built-in and nothing
+        # in this lane defines it.
+        'integration && bench') skip_file=1 ;;
         *)
           echo "FAIL: $f carries build constraint '$expr' — not one the static shard discovery knows" >&2
           echo "  teach the allowlist in scripts/test-integration-parallel.sh or simplify the constraint" >&2


### PR DESCRIPTION
We quote four performance promises in security and procurement reviews and
measured none of them. This measures all four, and does it in a lane that
runs BY HAND rather than on every push.

## The lane

A `bench` build tag, spelled `//go:build integration && bench`. The CI
integration lane sets only `integration`, so it never compiles these files —
proven both directions: `-tags integration` lists one perf test,
`-tags 'integration bench'` lists two.

`make vet` and both golangci passes DO carry the tag. That is the load-bearing
part: nothing scheduled compiles a by-hand lane, so without type-checking it a
renamed helper breaks these files silently and the next person to run a
benchmark debugs the harness instead of reading a number. The vet target's own
comment already records that lesson being learned once.

## What is measured

- `make bench-record` — PERF-1 record open and PERF-4 save, over HTTP against
  the booted app rather than the store. PERF-3/PERF-7 next door are QUERY
  budgets and a store call is their honest unit; PERF-1/PERF-4 are budgets on
  an operation, and their column says "server", so routing, admission, the RLS
  transaction and serialization are inside the number a customer is quoted.
- `make bench-capture` — CAP-PARAM-1, receipt to visible-on-the-matched-
  timeline, 60s p95. The receipt instant is injected as the fixture's own
  `Date:` header, which is the chapter's "clock assert"; nothing sleeps. Each
  sample uses a fresh counterparty and the thread shape that actually
  auto-creates, because a stranger's first message defers and measuring the
  deferred path would report the budget as held by the work that did not
  happen. It also proves AC3.4's second half: a timeline read issued before
  any capture must ANSWER rather than wait for one.
- `make bench-mobile` — MOBILE-AC-2, the 300ms perceived budget on a throttled
  Fast-3G profile at 390px. Throttled two ways, because either alone would
  measure a lie: CDP shapes real traffic, but the seed fixture is mocked at the
  network edge and a fulfilled route never touches the transport CDP is
  shaping, so the API's round trip is paid explicitly by a delay route that
  falls back to the mock.

## Measured, on this machine

    record_open_person        p95 3.7ms    budget 100ms
    record_open_organization  p95 3.4ms    budget 100ms
    record_open_deal          p95 2.5ms    budget 100ms
    record_save_person        p95 6.4ms    budget 150ms
    capture_to_timeline       p95 309ms    budget 60s
    record_open_perceived     p95 71ms     budget 300ms  (Fast-3G, 390px)

## Two corrections to the issue's census

The issue says the perceived budget is not measured. Half right: it IS, at the
default viewport with no throttling, as `PERF-1: record open renders under the
300ms perceived budget` in `e2e/ac.spec.ts`. Only the THROTTLED profile was
missing, so this adds that and leaves the existing test where it is.

`bench-perf` gained `-count=1` along with the two new targets. Go caches a
passing result and replays the original run's log, so a second `make
bench-record` printed p50=3.276875ms again, to the nanosecond, having measured
nothing. A benchmark that can answer from cache reports the past as the
present, which is worse than not running.

## Verification

Every budget gate was mutation-tested rather than assumed: each one goes RED
when its budget is lowered, and the record gate named its three breaches while
correctly omitting the one query still inside budget. The capture suite's
"this sample linked nothing" guard was proven the same way, by removing the
attestation that makes auto-create happen.

Refs #697

Signed-off-by: Tin Nguyen <tin.nguyen@gradion.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Measures our published performance budgets in a hand-run `bench` lane; CI behavior is unchanged. Previously the integration shard discovery aborted on `integration && bench`; now it skips those files, and `bench-perf` disables cached results.

- Backend and CI
  - Adds `perfrecord_bench_test.go` (PERF‑1 open, PERF‑4 save over HTTP) and `capture/perfcapture_bench_test.go` (CAP‑PARAM‑1) under `//go:build integration && bench`; type‑checked via `go vet -tags 'integration bench'` and `golangci-lint`, but not run by any gate.
  - New targets: `bench-record`, `bench-capture`; `bench-perf` now uses `-count=1`. `.golangci.yml`/`.golangci.strict.yml` declare the `bench` tag, and the fitness test enforces it.
  - `scripts/test-integration-parallel.sh` ignores `integration && bench` files so the integration lane does not abort.

- Frontend
  - Adds `perf-mobile.spec.ts` to measure MOBILE‑AC‑2 (p95 ≤ 300 ms perceived on Fast‑3G at 390px); collected only when `MARGINCE_BENCH_MOBILE=1` via `bench-mobile`.
  - `playwright.config.ts` isolates the spec, sets 390px viewport and longer timeouts for the throttled run; throttling combines CDP shaping with an API latency route. Root `Makefile` runs `pnpm build` before `fe-test-ext`, `fe-uat`, and `bench-mobile`.

<sup>Written for commit 49c4d27ea9b366bf8d95f5cae4c5305c01bff884. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1345?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

