### PR TITLE
feat(setup): the first-run claim has a screen, not just an endpoint

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -229,6 +229,60 @@ describe("auth boundary states (login spec §4)", () => {
     );
   });
 
+  // ADR-0105: "not ready" is two product states, and only one of them has
+  // something the person in front of the browser can do.
+  it("offers the claim screen when the unready installation is waiting to be claimed", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: Request | string | URL) => {
+        const url = String(input instanceof Request ? input.url : input);
+        if (url.endsWith("/v1/me")) {
+          return new Response(JSON.stringify({ code: "x" }), {
+            status: 503,
+            headers: { "Content-Type": "application/problem+json" },
+          });
+        }
+        if (url.endsWith("/setup/status")) {
+          return new Response(JSON.stringify({ claimable: true }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          });
+        }
+        return new Response(JSON.stringify({}), { status: 200 });
+      }),
+    );
+    mount();
+    expect(
+      await screen.findByRole("heading", { name: "Claim this installation" }),
+    ).toBeTruthy();
+    // The availability message is REPLACED, not stacked beside it.
+    expect(screen.queryByText("Installation not ready")).toBeNull();
+  });
+
+  it("keeps the availability message when the setup probe cannot answer", async () => {
+    // A probe that fails must not replace a true message with a claim screen
+    // the installation may not actually offer.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: Request | string | URL) => {
+        const url = String(input instanceof Request ? input.url : input);
+        if (url.endsWith("/setup/status")) throw new TypeError("probe down");
+        if (url.endsWith("/v1/me")) {
+          return new Response(JSON.stringify({ code: "x" }), {
+            status: 503,
+            headers: { "Content-Type": "application/problem+json" },
+          });
+        }
+        return new Response(JSON.stringify({}), { status: 200 });
+      }),
+    );
+    mount();
+    expect(await screen.findByText("Installation not ready")).toBeTruthy();
+    expect(
+      screen.queryByRole("heading", { name: "Claim this installation" }),
+    ).toBeNull();
+  });
+
   it("renders the connection problem when the probe cannot reach the API at all", async () => {
     vi.stubGlobal(
       "fetch",

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -283,6 +283,41 @@ describe("auth boundary states (login spec §4)", () => {
     ).toBeNull();
   });
 
+  it("recovers the claim screen when retry follows a failed setup probe", async () => {
+    // The probe resolves rather than throws, so a one-off failure caches a
+    // `false`. Without refetching it on retry, an installation that has been
+    // claimable all along would stay behind the availability screen until the
+    // page was reloaded.
+    let probeCalls = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: Request | string | URL) => {
+        const url = String(input instanceof Request ? input.url : input);
+        if (url.endsWith("/setup/status")) {
+          probeCalls += 1;
+          if (probeCalls === 1) throw new TypeError("probe down");
+          return new Response(JSON.stringify({ claimable: true }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          });
+        }
+        if (url.endsWith("/v1/me")) {
+          return new Response(JSON.stringify({ code: "x" }), {
+            status: 503,
+            headers: { "Content-Type": "application/problem+json" },
+          });
+        }
+        return new Response(JSON.stringify({}), { status: 200 });
+      }),
+    );
+    mount();
+    expect(await screen.findByText("Installation not ready")).toBeTruthy();
+    await userEvent.click(screen.getByRole("button", { name: "Try again" }));
+    expect(
+      await screen.findByRole("heading", { name: "Claim this installation" }),
+    ).toBeTruthy();
+  });
+
   it("renders the connection problem when the probe cannot reach the API at all", async () => {
     vi.stubGlobal(
       "fetch",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -314,13 +314,23 @@ function UnavailableOrClaimable({
     enabled: kind === "installation",
     retry: false,
   });
+  // Retry re-probes BOTH. fetchSetupStatus resolves rather than throws, so a
+  // one-off failure caches a `false` under this key — without refetching it,
+  // "Try again" would keep showing the availability screen for an installation
+  // that has been claimable all along, and only a page reload would recover.
+  const retryBoth = () => {
+    onRetry();
+    if (kind === "installation") {
+      void claimable.refetch();
+    }
+  };
   if (kind === "installation" && claimable.data?.claimable) {
     // A successful claim provisions the installation, so the same /v1/me probe
     // that sent us here now answers — the boundary re-resolves rather than this
     // screen deciding where to go next.
     return <SetupClaimScreen onClaimed={onRetry} />;
   }
-  return <AvailabilityScreen kind={kind} onRetry={onRetry} />;
+  return <AvailabilityScreen kind={kind} onRetry={retryBoth} />;
 }
 
 // AuthGate: everything behind the session probes GET /v1/me, and the

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,5 @@
 import { extensionScreens as composedScreens } from "@composition/screens";
+import { useQuery } from "@tanstack/react-query";
 import {
   type ReactNode,
   useCallback,
@@ -47,6 +48,7 @@ import { PreferenceCenterScreen } from "./screens/preferences";
 import { ReportsScreen } from "./screens/reports";
 import { SearchScreen } from "./screens/search";
 import { SettingsScreen } from "./screens/settings";
+import { fetchSetupStatus, SetupClaimScreen } from "./screens/setupclaim";
 import { ShareScreen } from "./screens/share";
 import { TasksScreen } from "./screens/tasks";
 
@@ -291,6 +293,36 @@ export function App() {
   return <AuthedApp route={route} />;
 }
 
+// UnavailableOrClaimable splits the 503 the boundary already reached into its
+// two product states. "Not ready" is true of both, but only one of them has
+// something the person in front of the browser can do: an installation that
+// holds no organization and is WAITING to be claimed (ADR-0105) gets the claim
+// screen; anything else keeps the availability message.
+//
+// The probe runs only on this branch, and only for the installation kind: a
+// connectivity failure says nothing about whether a claim is possible, and
+// asking would replace a true message with a guess. While it is in flight the
+// availability screen stands — it is the honest answer until the probe says
+// otherwise, and it is what the user would have seen anyway.
+function UnavailableOrClaimable({
+  kind,
+  onRetry,
+}: Readonly<{ kind: "connection" | "installation"; onRetry: () => void }>) {
+  const claimable = useQuery({
+    queryKey: ["setup-status"],
+    queryFn: fetchSetupStatus,
+    enabled: kind === "installation",
+    retry: false,
+  });
+  if (kind === "installation" && claimable.data?.claimable) {
+    // A successful claim provisions the installation, so the same /v1/me probe
+    // that sent us here now answers — the boundary re-resolves rather than this
+    // screen deciding where to go next.
+    return <SetupClaimScreen onClaimed={onRetry} />;
+  }
+  return <AvailabilityScreen kind={kind} onRetry={onRetry} />;
+}
+
 // AuthGate: everything behind the session probes GET /v1/me, and the
 // boundary branches on the TYPED failure (§4 of the login spec):
 // 401 → login, network/5xx → connection problem, 503 → installation
@@ -366,7 +398,7 @@ function AuthedApp({
     if (kind !== "unauthorized") {
       return (
         <RaillessFrame>
-          <AvailabilityScreen kind={kind} onRetry={() => me.refetch()} />
+          <UnavailableOrClaimable kind={kind} onRetry={() => me.refetch()} />
         </RaillessFrame>
       );
     }

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -3497,6 +3497,8 @@ export const de = {
     "Diese Installation hat bereits eine Organisation. Melden Sie sich an oder bitten Sie Ihren Betreiber um ein Zurücksetzen.",
   "setup.errorFields":
     "Im Formular stimmt etwas nicht. Prüfen Sie die Felder und versuchen Sie es erneut.",
+  "setup.errorServer":
+    "Margince konnte die Einrichtung nicht abschließen. Es wurde nichts angelegt. Versuchen Sie es gleich noch einmal; bei wiederholtem Fehlschlag prüfen Sie das Serverprotokoll.",
   "setup.errorNetwork":
     "Margince war nicht erreichbar. Prüfen Sie Ihre Verbindung und versuchen Sie es erneut.",
   "auth.forgotLink": "Passwort vergessen?",

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -3474,6 +3474,31 @@ export const de = {
   // wird korrigiert, nicht repariert — repariert werden Geräte.
   "auth.unavailableBody":
     "Diese Margince-Installation kann dich noch nicht anmelden. Ein Betreiber muss die Einrichtung abschließen oder korrigieren.",
+  "setup.pageTitle": "Margince einrichten",
+  "setup.title": "Diese Installation übernehmen",
+  "setup.body":
+    "Diese Margince-Installation hat noch keine Organisation. Ihr Betreiber hat ein einmaliges Einrichtungs-Token aus dem Serverprotokoll.",
+  "setup.token": "Einrichtungs-Token",
+  "setup.tokenHint":
+    "Aus dem Serverprotokoll beim ersten Start oder aus der Token-Datei daneben.",
+  "setup.organization": "Name der Organisation",
+  "setup.adminName": "Ihr Name",
+  "setup.adminEmail": "Ihre E-Mail-Adresse",
+  "setup.adminPassword": "Passwort wählen",
+  "setup.passwordHint": "Mindestens 12 Zeichen.",
+  "setup.passwordShort": "Zu kurz. Verwenden Sie mindestens 12 Zeichen.",
+  "setup.rootWarning":
+    "Damit entsteht das Administratorkonto für die gesamte Installation. Es hat alle Berechtigungen, einschließlich der Verwaltung aller anderen.",
+  "setup.claim": "Organisation anlegen",
+  "setup.claiming": "Wird angelegt…",
+  "setup.errorToken":
+    "Dieses Einrichtungs-Token gilt nicht für diese Installation. Prüfen Sie das Serverprotokoll vom ersten Start.",
+  "setup.errorAlready":
+    "Diese Installation hat bereits eine Organisation. Melden Sie sich an oder bitten Sie Ihren Betreiber um ein Zurücksetzen.",
+  "setup.errorFields":
+    "Im Formular stimmt etwas nicht. Prüfen Sie die Felder und versuchen Sie es erneut.",
+  "setup.errorNetwork":
+    "Margince war nicht erreichbar. Prüfen Sie Ihre Verbindung und versuchen Sie es erneut.",
   "auth.forgotLink": "Passwort vergessen?",
   "auth.forgotTitle": "Passwort zurücksetzen",
   // "gibt", nicht "existiert" (Amtsdeutsch), und das Feld will eine Adresse, keine

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -3486,6 +3486,34 @@ export const en = {
   "auth.unavailableTitle": "Installation not ready",
   "auth.unavailableBody":
     "This Margince installation isn't ready to sign you in. An operator needs to complete or repair the setup.",
+  // The first-run claim (ADR-0105). An installation with no configured admin
+  // waits to be claimed; this is the only screen that creates an account
+  // without one, so it names what it is creating.
+  "setup.pageTitle": "Set up Margince",
+  "setup.title": "Claim this installation",
+  "setup.body":
+    "This Margince installation has no organization yet. Your operator has a one-time setup token from the server log.",
+  "setup.token": "Setup token",
+  "setup.tokenHint":
+    "From the server log on first start, or the token file beside it.",
+  "setup.organization": "Organization name",
+  "setup.adminName": "Your name",
+  "setup.adminEmail": "Your email",
+  "setup.adminPassword": "Choose a password",
+  "setup.passwordHint": "At least 12 characters.",
+  "setup.passwordShort": "Too short. Use at least 12 characters.",
+  "setup.rootWarning":
+    "This creates the administrator account for the whole installation. It has every permission, including managing everyone else.",
+  "setup.claim": "Create the organization",
+  "setup.claiming": "Creating…",
+  "setup.errorToken":
+    "That setup token isn't valid for this installation. Check the server log for the token issued at first start.",
+  "setup.errorAlready":
+    "This installation already has an organization. Sign in instead, or ask your operator to reset it.",
+  "setup.errorFields":
+    "Something in the form needs fixing. Check the fields and try again.",
+  "setup.errorNetwork":
+    "Margince couldn't be reached. Check your connection and try again.",
   "auth.forgotLink": "Forgot password?",
   "auth.forgotTitle": "Reset your password",
   // Two sentences, sentence-cased, with no dash. VOICE-RULE-5 forbids an em or

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -3512,6 +3512,8 @@ export const en = {
     "This installation already has an organization. Sign in instead, or ask your operator to reset it.",
   "setup.errorFields":
     "Something in the form needs fixing. Check the fields and try again.",
+  "setup.errorServer":
+    "Margince couldn't complete the setup. Nothing was created. Try again in a moment; if it keeps failing, check the server log.",
   "setup.errorNetwork":
     "Margince couldn't be reached. Check your connection and try again.",
   "auth.forgotLink": "Forgot password?",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -3491,6 +3491,8 @@ export const vi = {
     "Bản cài đặt này đã có tổ chức. Hãy đăng nhập, hoặc nhờ người vận hành đặt lại.",
   "setup.errorFields":
     "Có trường chưa hợp lệ. Hãy kiểm tra lại và thử lần nữa.",
+  "setup.errorServer":
+    "Margince không hoàn tất được thiết lập. Chưa có gì được tạo. Hãy thử lại sau giây lát; nếu vẫn lỗi, hãy kiểm tra nhật ký máy chủ.",
   "setup.errorNetwork":
     "Không kết nối được tới Margince. Hãy kiểm tra kết nối và thử lại.",
   "auth.forgotLink": "Quên mật khẩu?",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -3468,6 +3468,31 @@ export const vi = {
   "auth.unavailableTitle": "Bản cài đặt chưa sẵn sàng",
   "auth.unavailableBody":
     "Bản cài đặt Margince này chưa sẵn sàng để bạn đăng nhập. Cần người vận hành hoàn tất hoặc sửa lại phần thiết lập.",
+  "setup.pageTitle": "Thiết lập Margince",
+  "setup.title": "Nhận quyền quản trị bản cài đặt này",
+  "setup.body":
+    "Bản cài đặt Margince này chưa có tổ chức nào. Người vận hành của bạn có mã thiết lập dùng một lần trong nhật ký máy chủ.",
+  "setup.token": "Mã thiết lập",
+  "setup.tokenHint":
+    "Lấy từ nhật ký máy chủ ở lần khởi động đầu tiên, hoặc tệp mã đặt cạnh đó.",
+  "setup.organization": "Tên tổ chức",
+  "setup.adminName": "Tên của bạn",
+  "setup.adminEmail": "Email của bạn",
+  "setup.adminPassword": "Chọn mật khẩu",
+  "setup.passwordHint": "Ít nhất 12 ký tự.",
+  "setup.passwordShort": "Quá ngắn. Hãy dùng ít nhất 12 ký tự.",
+  "setup.rootWarning":
+    "Thao tác này tạo tài khoản quản trị cho toàn bộ bản cài đặt. Tài khoản đó có mọi quyền, kể cả quản lý tất cả người khác.",
+  "setup.claim": "Tạo tổ chức",
+  "setup.claiming": "Đang tạo…",
+  "setup.errorToken":
+    "Mã thiết lập không hợp lệ với bản cài đặt này. Hãy kiểm tra nhật ký máy chủ ở lần khởi động đầu tiên.",
+  "setup.errorAlready":
+    "Bản cài đặt này đã có tổ chức. Hãy đăng nhập, hoặc nhờ người vận hành đặt lại.",
+  "setup.errorFields":
+    "Có trường chưa hợp lệ. Hãy kiểm tra lại và thử lần nữa.",
+  "setup.errorNetwork":
+    "Không kết nối được tới Margince. Hãy kiểm tra kết nối và thử lại.",
   "auth.forgotLink": "Quên mật khẩu?",
   "auth.forgotTitle": "Đặt lại mật khẩu",
   // Two sentences, sentence-cased, with no dash. VOICE-RULE-5 forbids an em or

--- a/frontend/src/screens/auth.tsx
+++ b/frontend/src/screens/auth.tsx
@@ -336,7 +336,7 @@ export function Wordmark({
 
 // usePageTitle stamps the document title for the unauthenticated surface
 // (§7.1) and restores the product name on unmount.
-function usePageTitle(title: string) {
+export function usePageTitle(title: string) {
   useEffect(() => {
     const previous = document.title;
     document.title = title;
@@ -1024,7 +1024,7 @@ function Notice({
   );
 }
 
-function Field({
+export function Field({
   id,
   label,
   labelEnd,

--- a/frontend/src/screens/setupclaim.stories.tsx
+++ b/frontend/src/screens/setupclaim.stories.tsx
@@ -1,0 +1,131 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { userEvent, within } from "storybook/test";
+import { SetupClaimScreen } from "./setupclaim";
+import { installFetchStub, jsonResponse, StoryProviders } from "./story-utils";
+
+/**
+ * The first-run claim (ADR-0105).
+ *
+ * An installation whose deployment file names no `bootstrap_admin` holds no
+ * organization. Its boundary would otherwise render "installation not ready" —
+ * true, and a dead end. This screen is what stands there when the installation
+ * is instead WAITING to be claimed, and it is the only screen in the product
+ * that creates an account without one.
+ *
+ * The states worth looking at are the ones a screenshot settles rather than an
+ * assertion: whether the warning that this account is the installation's ROOT
+ * reads as a warning, whether the token field reads as something copied from a
+ * server log rather than a password, and whether a refusal is legible next to a
+ * form the person has just filled in. The three refusals differ in meaning, not
+ * just wording — a wrong token, an installation someone else already claimed,
+ * and a field to fix are three different next actions — so each is a story.
+ */
+const meta: Meta<typeof SetupClaimScreen> = {
+  title: "Screens/Setup claim",
+  component: SetupClaimScreen,
+  parameters: { layout: "fullscreen" },
+  decorators: [
+    (Story) => (
+      <StoryProviders>
+        <Story />
+      </StoryProviders>
+    ),
+  ],
+  args: { onClaimed: () => {} },
+};
+export default meta;
+
+type Story = StoryObj<typeof SetupClaimScreen>;
+
+/**
+ * fill drives the form to the state a person reaches before pressing submit.
+ * Shared by every story below, so the refusals differ only in what the server
+ * answers — which is the thing each of them is about.
+ */
+async function fill(canvasElement: HTMLElement) {
+  const canvas = within(canvasElement);
+  const user = userEvent.setup();
+  await user.type(
+    canvas.getByLabelText(/setup token/i),
+    "9f2c-not-a-real-token",
+  );
+  await user.type(
+    canvas.getByLabelText(/organization name/i),
+    "Brandt Automotive",
+  );
+  await user.type(canvas.getByLabelText(/your name/i), "Ilse Brandt");
+  await user.type(canvas.getByLabelText(/your email/i), "ilse@brandt.example");
+  await user.type(
+    canvas.getByLabelText(/choose a password/i),
+    "correct horse battery",
+  );
+  return { canvas, user };
+}
+
+/** submitAgainst stubs the claim endpoint with one status and presses submit. */
+async function submitAgainst(canvasElement: HTMLElement, status: number) {
+  installFetchStub({
+    "POST /setup/claim": () => jsonResponse({}, status),
+  });
+  const { canvas, user } = await fill(canvasElement);
+  await user.click(
+    canvas.getByRole("button", { name: /create the organization/i }),
+  );
+}
+
+/** The screen an operator's first visit lands on. */
+export const Empty: Story = {};
+
+/**
+ * Filled in and ready. The submit button is enabled only once every field is
+ * present and the password clears the floor the server applies, so "ready" is a
+ * visible state rather than something discovered by pressing it.
+ */
+export const Ready: Story = {
+  play: async ({ canvasElement }) => {
+    await fill(canvasElement);
+  },
+};
+
+/**
+ * A password below the floor. The hint replaces the ordinary one and the button
+ * stays disabled — the refusal happens here rather than as a 422 after a round
+ * trip the person has already waited for.
+ */
+export const PasswordTooShort: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const user = userEvent.setup();
+    await user.type(
+      canvas.getByLabelText(/setup token/i),
+      "9f2c-not-a-real-token",
+    );
+    await user.type(
+      canvas.getByLabelText(/organization name/i),
+      "Brandt Automotive",
+    );
+    await user.type(canvas.getByLabelText(/your name/i), "Ilse Brandt");
+    await user.type(
+      canvas.getByLabelText(/your email/i),
+      "ilse@brandt.example",
+    );
+    await user.type(canvas.getByLabelText(/choose a password/i), "short");
+  },
+};
+
+/** The token is not this installation's — check the server log from first start. */
+export const WrongToken: Story = {
+  play: async ({ canvasElement }) => {
+    await submitAgainst(canvasElement, 401);
+  },
+};
+
+/**
+ * Someone else got there first. This is the state a second operator sees, and
+ * it must not read as a typo: the next action is to sign in, not to retype.
+ */
+export const AlreadyClaimed: Story = {
+  play: async ({ canvasElement }) => {
+    await submitAgainst(canvasElement, 409);
+  },
+};

--- a/frontend/src/screens/setupclaim.test.tsx
+++ b/frontend/src/screens/setupclaim.test.tsx
@@ -117,6 +117,23 @@ describe("SetupClaimScreen", () => {
     );
   });
 
+  it("says a server failure is a server failure, not a form to fix", async () => {
+    const user = userEvent.setup();
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("{}", { status: 500 }),
+    );
+    renderClaim();
+    await fillValid(user);
+    await user.click(
+      screen.getByRole("button", { name: /create the organization/i }),
+    );
+    const alert = await screen.findByRole("alert");
+    // Telling someone to check fields that are already correct sends them
+    // hunting for a mistake they did not make.
+    expect(alert).toHaveTextContent(/nothing was created/i);
+    expect(alert).not.toHaveTextContent(/needs fixing/i);
+  });
+
   it("does not hand back to the boundary when the claim was refused", async () => {
     const user = userEvent.setup();
     vi.spyOn(globalThis, "fetch").mockResolvedValue(

--- a/frontend/src/screens/setupclaim.test.tsx
+++ b/frontend/src/screens/setupclaim.test.tsx
@@ -1,0 +1,162 @@
+/** @vitest-environment jsdom */
+import "@testing-library/jest-dom/vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { LocaleProvider } from "../i18n";
+import { fetchSetupStatus, SetupClaimScreen } from "./setupclaim";
+
+// The claim screen is the one place in the product that creates an account
+// without one. What these cases hold is that it cannot be submitted into a weak
+// root credential, that each refusal reads as the thing that happened, and that
+// a probe which cannot answer never claims the installation is claimable.
+
+function renderClaim(onClaimed = vi.fn()) {
+  render(
+    <LocaleProvider initial="en">
+      <SetupClaimScreen onClaimed={onClaimed} />
+    </LocaleProvider>,
+  );
+  return onClaimed;
+}
+
+async function fillValid(user: ReturnType<typeof userEvent.setup>) {
+  await user.type(screen.getByLabelText(/setup token/i), "a-token");
+  await user.type(screen.getByLabelText(/organization name/i), "Acme");
+  await user.type(screen.getByLabelText(/your name/i), "Ops");
+  await user.type(screen.getByLabelText(/your email/i), "ops@acme.test");
+  await user.type(
+    screen.getByLabelText(/choose a password/i),
+    "a bootstrap password!",
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("SetupClaimScreen", () => {
+  it("says what it is creating, because minting root quietly is not honest", () => {
+    renderClaim();
+    expect(
+      screen.getByText(/administrator account for the whole installation/i),
+    ).toBeInTheDocument();
+  });
+
+  it("refuses to submit a password below the server's floor", async () => {
+    const user = userEvent.setup();
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    renderClaim();
+
+    await user.type(screen.getByLabelText(/setup token/i), "a-token");
+    await user.type(screen.getByLabelText(/organization name/i), "Acme");
+    await user.type(screen.getByLabelText(/your name/i), "Ops");
+    await user.type(screen.getByLabelText(/your email/i), "ops@acme.test");
+    await user.type(screen.getByLabelText(/choose a password/i), "short");
+
+    // The button is the gate, and the hint says why — a form that lets you
+    // press submit and then reports a 422 has wasted the round trip and the
+    // person's attention.
+    expect(
+      screen.getByRole("button", { name: /create the organization/i }),
+    ).toBeDisabled();
+    expect(screen.getByText(/at least 12 characters/i)).toBeInTheDocument();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("sends the claim and hands back to the boundary on success", async () => {
+    const user = userEvent.setup();
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ workspace_id: "ws-1" }), { status: 201 }),
+    );
+    const onClaimed = renderClaim();
+
+    await fillValid(user);
+    await user.click(
+      screen.getByRole("button", { name: /create the organization/i }),
+    );
+
+    await waitFor(() => expect(onClaimed).toHaveBeenCalledOnce());
+    const [, init] = vi.mocked(globalThis.fetch).mock.calls[0];
+    const body = JSON.parse(String(init?.body));
+    expect(body.setup_token).toBe("a-token");
+    expect(body.admin_email).toBe("ops@acme.test");
+    // The field name the server reads. A camelCase key here would decode to an
+    // empty password, which is the failure this whole path exists to prevent.
+    expect(body.admin_password).toBe("a bootstrap password!");
+  });
+
+  it("tells a wrong token apart from an installation someone else claimed", async () => {
+    const user = userEvent.setup();
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("{}", { status: 401 }),
+    );
+    renderClaim();
+    await fillValid(user);
+    await user.click(
+      screen.getByRole("button", { name: /create the organization/i }),
+    );
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      /setup token isn't valid/i,
+    );
+  });
+
+  it("says the installation is already claimed on a conflict", async () => {
+    const user = userEvent.setup();
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("{}", { status: 409 }),
+    );
+    renderClaim();
+    await fillValid(user);
+    await user.click(
+      screen.getByRole("button", { name: /create the organization/i }),
+    );
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      /already has an organization/i,
+    );
+  });
+
+  it("does not hand back to the boundary when the claim was refused", async () => {
+    const user = userEvent.setup();
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("{}", { status: 401 }),
+    );
+    const onClaimed = renderClaim();
+    await fillValid(user);
+    await user.click(
+      screen.getByRole("button", { name: /create the organization/i }),
+    );
+    await screen.findByRole("alert");
+    expect(onClaimed).not.toHaveBeenCalled();
+  });
+});
+
+describe("fetchSetupStatus", () => {
+  it("reads a claimable installation", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ claimable: true }), { status: 200 }),
+    );
+    await expect(fetchSetupStatus()).resolves.toEqual({ claimable: true });
+  });
+
+  it("answers not-claimable when the probe fails, rather than throwing", async () => {
+    // The caller is a boundary that has already decided the installation is
+    // unavailable. A probe that cannot answer must leave the true message
+    // standing, not replace it with a claim screen or an error page.
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("offline"));
+    await expect(fetchSetupStatus()).resolves.toEqual({ claimable: false });
+
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("nope", { status: 500 }),
+    );
+    await expect(fetchSetupStatus()).resolves.toEqual({ claimable: false });
+  });
+
+  it("treats a body that is not the expected shape as not claimable", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ claimable: "yes" }), { status: 200 }),
+    );
+    await expect(fetchSetupStatus()).resolves.toEqual({ claimable: false });
+  });
+});

--- a/frontend/src/screens/setupclaim.tsx
+++ b/frontend/src/screens/setupclaim.tsx
@@ -1,0 +1,236 @@
+import { useState } from "react";
+import { Button } from "../design-system/atoms";
+import { useT } from "../i18n";
+import { Field, usePageTitle, Wordmark } from "./auth";
+import { AuthExperience } from "./auth-core";
+import "./auth.css";
+
+// The first-run claim (ADR-0105). An installation whose deployment file names no
+// bootstrap_admin holds no organization, so /v1/me answers 503 and the boundary
+// would otherwise render "installation not ready" — true, but a dead end. When
+// the installation is instead WAITING to be claimed, this screen is what stands
+// there.
+//
+// It is the only screen in the product that creates an account without one, and
+// it says so: the operator's setup token is the authorization, and the account
+// it creates is the installation's root. An interface that mints root quietly is
+// not honest about what it is doing.
+
+export type SetupStatus = { claimable: boolean };
+
+/**
+ * fetchSetupStatus asks whether this installation is waiting to be claimed.
+ *
+ * A failure is reported as "not claimable" rather than thrown: this runs only
+ * on a boundary that has ALREADY decided the installation is unavailable, and
+ * the honest fallback there is the availability screen the user would otherwise
+ * have seen. A probe that cannot answer must not replace a true message with a
+ * blank one.
+ */
+export async function fetchSetupStatus(): Promise<SetupStatus> {
+  try {
+    const response = await fetch("/setup/status", {
+      headers: { Accept: "application/json" },
+    });
+    if (!response.ok) return { claimable: false };
+    const body: unknown = await response.json();
+    return {
+      claimable:
+        typeof body === "object" &&
+        body !== null &&
+        (body as SetupStatus).claimable === true,
+    };
+  } catch {
+    return { claimable: false };
+  }
+}
+
+type ClaimFields = {
+  organizationName: string;
+  adminName: string;
+  adminEmail: string;
+  adminPassword: string;
+  setupToken: string;
+};
+
+const EMPTY: ClaimFields = {
+  organizationName: "",
+  adminName: "",
+  adminEmail: "",
+  adminPassword: "",
+  setupToken: "",
+};
+
+/** The floor the server applies, restated so the form can say it before submitting. */
+const MIN_PASSWORD = 12;
+
+export function SetupClaimScreen({
+  onClaimed,
+}: Readonly<{ onClaimed: () => void }>) {
+  const t = useT();
+  usePageTitle(t("setup.pageTitle"));
+  const [fields, setFields] = useState<ClaimFields>(EMPTY);
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  const set = (key: keyof ClaimFields) => (value: string) =>
+    setFields((current) => ({ ...current, [key]: value }));
+
+  // The browser's own timezone, offered as the default. An installation is
+  // almost always claimed from where it will be used, and the alternative is
+  // asking a human to name a zone they have no reason to know.
+  const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
+
+  async function submit(event: React.FormEvent) {
+    event.preventDefault();
+    setError(null);
+    setSubmitting(true);
+    try {
+      const response = await fetch("/setup/claim", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          setup_token: fields.setupToken.trim(),
+          organization_name: fields.organizationName.trim(),
+          timezone,
+          base_currency: "EUR",
+          admin_email: fields.adminEmail.trim(),
+          admin_name: fields.adminName.trim(),
+          admin_password: fields.adminPassword,
+        }),
+      });
+      if (response.ok) {
+        onClaimed();
+        return;
+      }
+      // Each refusal means something different to the person reading it: a
+      // token that is not this installation's, a claim that arrived after
+      // someone else's, or a field to fix. Collapsing them into one message
+      // would leave the second case looking like a typo.
+      setError(
+        t(
+          response.status === 401
+            ? "setup.errorToken"
+            : response.status === 409
+              ? "setup.errorAlready"
+              : "setup.errorFields",
+        ),
+      );
+    } catch {
+      setError(t("setup.errorNetwork"));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  const passwordShort =
+    fields.adminPassword.length > 0 &&
+    [...fields.adminPassword].length < MIN_PASSWORD;
+  const complete =
+    fields.setupToken.trim() !== "" &&
+    fields.organizationName.trim() !== "" &&
+    fields.adminName.trim() !== "" &&
+    fields.adminEmail.trim() !== "" &&
+    !passwordShort &&
+    fields.adminPassword !== "";
+
+  return (
+    <AuthExperience phase="unavailable">
+      <Wordmark alt={t("auth.title")} />
+      <form className="auth-card" onSubmit={submit}>
+        <h1>{t("setup.title")}</h1>
+        <p className="card-sub">{t("setup.body")}</p>
+        {error && (
+          <p className="auth-error" role="alert">
+            {error}
+          </p>
+        )}
+        <div className="auth-fields">
+          <Field
+            id="setup-token"
+            label={t("setup.token")}
+            hint={t("setup.tokenHint")}
+          >
+            <input
+              id="setup-token"
+              className="auth-input"
+              name="setup-token"
+              required
+              autoComplete="off"
+              autoCapitalize="none"
+              autoCorrect="off"
+              spellCheck={false}
+              value={fields.setupToken}
+              onChange={(event) => set("setupToken")(event.target.value)}
+            />
+          </Field>
+          <Field id="setup-org" label={t("setup.organization")}>
+            <input
+              id="setup-org"
+              className="auth-input"
+              name="organization"
+              required
+              value={fields.organizationName}
+              onChange={(event) => set("organizationName")(event.target.value)}
+            />
+          </Field>
+          <Field id="setup-admin-name" label={t("setup.adminName")}>
+            <input
+              id="setup-admin-name"
+              className="auth-input"
+              name="admin-name"
+              required
+              autoComplete="name"
+              value={fields.adminName}
+              onChange={(event) => set("adminName")(event.target.value)}
+            />
+          </Field>
+          <Field id="setup-admin-email" label={t("setup.adminEmail")}>
+            <input
+              id="setup-admin-email"
+              className="auth-input"
+              type="email"
+              name="admin-email"
+              required
+              autoComplete="username"
+              inputMode="email"
+              autoCapitalize="none"
+              autoCorrect="off"
+              spellCheck={false}
+              value={fields.adminEmail}
+              onChange={(event) => set("adminEmail")(event.target.value)}
+            />
+          </Field>
+          <Field
+            id="setup-admin-password"
+            label={t("setup.adminPassword")}
+            hint={
+              passwordShort ? t("setup.passwordShort") : t("setup.passwordHint")
+            }
+          >
+            <input
+              id="setup-admin-password"
+              className="auth-input"
+              type="password"
+              name="admin-password"
+              required
+              autoComplete="new-password"
+              value={fields.adminPassword}
+              onChange={(event) => set("adminPassword")(event.target.value)}
+            />
+          </Field>
+        </div>
+        <p className="card-sub">{t("setup.rootWarning")}</p>
+        <div className="auth-actions">
+          <Button
+            type="submit"
+            variant="primary"
+            disabled={!complete || submitting}
+          >
+            {submitting ? t("setup.claiming") : t("setup.claim")}
+          </Button>
+        </div>
+      </form>
+    </AuthExperience>
+  );
+}

--- a/frontend/src/screens/setupclaim.tsx
+++ b/frontend/src/screens/setupclaim.tsx
@@ -34,12 +34,15 @@ export async function fetchSetupStatus(): Promise<SetupStatus> {
     });
     if (!response.ok) return { claimable: false };
     const body: unknown = await response.json();
-    return {
-      claimable:
-        typeof body === "object" &&
-        body !== null &&
-        (body as SetupStatus).claimable === true,
-    };
+    // Narrowed, not asserted: this body arrives from the network, and an `as`
+    // here would promise the compiler a shape nothing checked. Anything that is
+    // not literally `true` reads as not-claimable, which is the safe direction —
+    // the cost of getting it wrong is a claim screen on an installation that
+    // cannot be claimed.
+    if (typeof body === "object" && body !== null && "claimable" in body) {
+      return { claimable: body.claimable === true };
+    }
+    return { claimable: false };
   } catch {
     return { claimable: false };
   }
@@ -103,17 +106,21 @@ export function SetupClaimScreen({
         onClaimed();
         return;
       }
-      // Each refusal means something different to the person reading it: a
-      // token that is not this installation's, a claim that arrived after
-      // someone else's, or a field to fix. Collapsing them into one message
-      // would leave the second case looking like a typo.
+      // Each refusal means something different to the person reading it, and
+      // each implies a different next action: find the right token, sign in
+      // instead, fix a field, or wait and try again. Collapsing them would
+      // leave three of the four telling someone to correct a form that is
+      // already correct — a 500 above all, which is not their fault and not
+      // theirs to fix.
       setError(
         t(
           response.status === 401
             ? "setup.errorToken"
             : response.status === 409
               ? "setup.errorAlready"
-              : "setup.errorFields",
+              : response.status >= 500
+                ? "setup.errorServer"
+                : "setup.errorFields",
         ),
       );
     } catch {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -125,6 +125,11 @@ export default defineConfig({
     // product's port, and the api's own is an implementation detail.
     proxy: {
       "/v1": { target: proxyTarget, changeOrigin: false, secure: false },
+      // The claim surface (ADR-0105). It sits beside the probes rather than
+      // under /v1 because it must answer before an organization exists, so it
+      // needs its own proxy entry — without one the SPA's first-run screen
+      // gets the dev server's index.html instead of the api.
+      "/setup": { target: proxyTarget, changeOrigin: false, secure: false },
       "/readyz": { target: proxyTarget, changeOrigin: false, secure: false },
       "/healthz": { target: proxyTarget, changeOrigin: false, secure: false },
       "/metrics": { target: proxyTarget, changeOrigin: false, secure: false },


### PR DESCRIPTION
Completes #1268. The backend half (#1336) left an installation that boots unprovisioned with a working claim endpoint and **no way to reach it** — the boundary saw 503 on `/v1/me` and rendered "installation not ready", which is true and a dead end.

## The split

That 503 is two product states. `UnavailableOrClaimable` separates them: an installation **waiting to be claimed** gets the claim screen; anything else keeps the availability message.

The probe runs only on the installation branch, and only after the boundary has already decided. A connectivity failure says nothing about whether a claim is possible, so asking would replace a true message with a guess — and a probe that *cannot answer* reads as not-claimable for the same reason.

## The screen says what it is creating

It is the only place in the product that makes an account without one, and the account it makes is the installation's **root**, with every permission including managing everyone else. An interface that mints that quietly isn't being honest about what it's doing, so it's stated on the screen.

The server's password floor is restated in the form: a weak credential is refused *before* the round trip, rather than as a 422 after the person has waited for it. The three refusals stay distinct — a wrong token, an installation someone else already claimed, and a field to fix are three different next actions, and collapsing them would make the second look like a typo.

## One wiring bug this would have shipped with

`vite.config.ts` had no `/setup` proxy entry, so the dev server answered the SPA's own `index.html` for the probe — the screen could never have appeared under `make dev`. The routes sit beside the health probes rather than under `/v1` precisely because they must answer before an organization exists, which is exactly why they needed their own entry.

## Verification

- 9 screen tests: the root warning is present, a short password disables submit **and never reaches fetch**, the request body carries the snake_case keys the server reads (a camelCase `admin_password` would decode to an empty password — the failure the backend PR exists to prevent), each refusal renders its own message, and a refused claim does not call back into the boundary.
- 2 boundary tests in `App.test.tsx`, **mutation-tested**: forcing the branch to fall through fails them.
- Stories cover the states a screenshot settles rather than an assertion; the refusals drive a real submit against a stubbed status, so none is fiction.
- `fe-quality`, `fe-unit` (2680 tests), `fe-bundle` and `fe-typecheck` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Splits the boundary’s 503 state and adds a first‑run claim screen. Previously a 503 from `/v1/me` always showed “Installation not ready”; now claimable installations render the claim screen, and “Try again” re‑probes claim status. Claim failures on 5xx now show a server error, not a form error.

- Boundary: adds `UnavailableOrClaimable`, which calls `fetchSetupStatus` via `@tanstack/react-query` only on the installation branch; while the probe is in flight or fails, it keeps the availability message; when claimable, it renders `SetupClaimScreen` and, after a successful claim, retriggers the boundary probe; “Try again” now refetches both `/v1/me` and setup status to recover from one‑off probe failures.
- Claim screen: creates the root admin with a one‑time setup token; blocks submit below a 12‑character password; posts snake_case fields (`setup_token`, `organization_name`, `admin_email`, `admin_name`, `admin_password`) plus the browser timezone and `base_currency: "EUR"`; distinguishes 401 (wrong token), 409 (already claimed), 5xx (server couldn’t complete; nothing created), and network failure; `fetchSetupStatus` treats probe errors or invalid bodies as not claimable rather than throwing.
- Dev: adds a `/setup` proxy in `vite.config.ts` so the screen can reach the API in dev.
- Tests and stories: new screen tests (password gate, payload shape, error branches, no hand‑off on refusal), boundary tests for retry re‑probing, and Storybook stories for ready and refusal states; i18n strings added for `en`, `de`, and `vi`.
- Backend expectation: `/setup/status` and `/setup/claim` endpoints must exist.

<sup>Written for commit acd287e27b2d4acb8fb6eb6c1c86b07773d4db7a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1348?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a first-run installation claim screen for configuring an organization and administrator account.
  * Added setup token guidance, password validation, submission feedback, and clear error messages.
  * Added English, German, and Vietnamese translations for the setup flow.

* **Bug Fixes**
  * Installations now correctly distinguish between claimable, unavailable, and not-yet-ready states.
  * Setup failures no longer incorrectly display the claim screen.
  * Retrying after a temporary setup check failure now refreshes installation status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->