### PR TITLE
feat(leads): the lead page is designed, not assembled (ADR-0108/A159)

### DIFF
--- a/frontend/src/design-system/README.md
+++ b/frontend/src/design-system/README.md
@@ -135,12 +135,18 @@ things a surface can be that are not content. Reach for it before hand-rolling
 a message line: it already knows that withheld, unavailable and unsupported are
 three different sentences, and that only `empty` may claim there is none.
 
-Two more things carry this properly and are worth copying: `Switch`'s `reason`
-prop, which renders the explanation **and** points the control at it with
-`aria-describedby` — the only accessibility-wired denial in the tree — and
-`FieldGuard`, for a withheld VALUE rather than a withheld surface. What is left
-hand-rolls `<EmptyState><p className="t-small">{t(…)}</p></EmptyState>` as the
-card body, which is the shape to match where `SurfaceState` does not fit.
+Three more things carry this properly and are worth copying. `Switch`'s
+`reason` prop renders the explanation **and** points the control at it with
+`aria-describedby`. `Button`'s `reason` does the same for an ACTION — it
+disables the button, renders the sentence beside it and wires
+`aria-describedby` — because a `title` on a disabled button is announced by no
+screen reader and a disabled button cannot be focused, so a reason living only
+in `title` reaches exactly nobody who needed it; `Button`'s `reasonId` points
+several refused controls at ONE sentence already on the page, for a surface
+where one fact refuses all of them. And `FieldGuard` covers a withheld VALUE
+rather than a withheld surface. What is left hand-rolls
+`<EmptyState><p className="t-small">{t(…)}</p></EmptyState>` as the card body,
+which is the shape to match where `SurfaceState` does not fit.
 
 `Switch` versus `Checkbox` follows from the same honesty: a `Checkbox` states an
 intent that something later submits, a `Switch` **is** the action. A control that

--- a/frontend/src/design-system/atoms.tsx
+++ b/frontend/src/design-system/atoms.tsx
@@ -27,11 +27,26 @@ export function Button({
   variant = "ghost",
   small,
   className,
+  reason,
   ...rest
 }: ButtonHTMLAttributes<HTMLButtonElement> & {
   variant?: ButtonVariant;
   small?: boolean;
+  /**
+   * Why this action is unavailable. Passing it DISABLES the button, renders
+   * the explanation beside it, and points the control at that text with
+   * `aria-describedby` — the same contract `Switch.reason` carries, and for
+   * the same reason: a `title` on a disabled button is announced by no screen
+   * reader and a disabled button cannot be focused, so a reason that lives
+   * only in `title` reaches nobody who needed it.
+   *
+   * STATE-4a decides WHEN to use it: a control blocked by state rather than
+   * permission — an archived record, a frozen setting — stays visible and
+   * says why, because the reason is the information and it can change.
+   */
+  reason?: string;
 }) {
+  const reasonId = useId();
   const classes = [
     "btn",
     `btn-${variant}`,
@@ -40,7 +55,26 @@ export function Button({
   ]
     .filter(Boolean)
     .join(" ");
-  return <button type="button" className={classes} {...rest} />;
+  const button = (
+    <button
+      type="button"
+      className={classes}
+      disabled={rest.disabled || reason !== undefined}
+      aria-describedby={reason === undefined ? undefined : reasonId}
+      {...rest}
+    />
+  );
+  if (reason === undefined) {
+    return button;
+  }
+  return (
+    <span className="btn-with-reason">
+      {button}
+      <span id={reasonId} className="t-caption">
+        {reason}
+      </span>
+    </span>
+  );
 }
 
 export function Badge({

--- a/frontend/src/design-system/atoms.tsx
+++ b/frontend/src/design-system/atoms.tsx
@@ -28,25 +28,33 @@ export function Button({
   small,
   className,
   reason,
+  reasonId,
   ...rest
 }: ButtonHTMLAttributes<HTMLButtonElement> & {
   variant?: ButtonVariant;
   small?: boolean;
   /**
-   * Why this action is unavailable. Passing it DISABLES the button, renders
-   * the explanation beside it, and points the control at that text with
-   * `aria-describedby` — the same contract `Switch.reason` carries, and for
-   * the same reason: a `title` on a disabled button is announced by no screen
-   * reader and a disabled button cannot be focused, so a reason that lives
-   * only in `title` reaches nobody who needed it.
+   * Why this action is unavailable. Passing it DISABLES the button and points
+   * the control at the explanation with `aria-describedby` — a `title` on a
+   * disabled button is announced by no screen reader, and a disabled button
+   * cannot be focused, so a reason living only in `title` reaches nobody who
+   * needed it. `Switch.reason` carries the same contract.
    *
    * STATE-4a decides WHEN to use it: a control blocked by state rather than
    * permission — an archived record, a frozen setting — stays visible and
    * says why, because the reason is the information and it can change.
    */
   reason?: string;
+  /**
+   * The id of an element ALREADY on the page carrying that explanation, for
+   * a surface where several controls are refused by ONE fact. Printing the
+   * same sentence beside every control states it as many times as there are
+   * buttons; naming it once and pointing every control at it says it once
+   * and still reaches a screen reader from each of them.
+   */
+  reasonId?: string;
 }) {
-  const reasonId = useId();
+  const ownReasonId = useId();
   const classes = [
     "btn",
     `btn-${variant}`,
@@ -55,12 +63,15 @@ export function Button({
   ]
     .filter(Boolean)
     .join(" ");
+  const refused = reason !== undefined || reasonId !== undefined;
   const button = (
     <button
       type="button"
       className={classes}
-      disabled={rest.disabled || reason !== undefined}
-      aria-describedby={reason === undefined ? undefined : reasonId}
+      disabled={rest.disabled || refused}
+      aria-describedby={
+        reasonId ?? (reason === undefined ? undefined : ownReasonId)
+      }
       {...rest}
     />
   );
@@ -70,7 +81,7 @@ export function Button({
   return (
     <span className="btn-with-reason">
       {button}
-      <span id={reasonId} className="t-caption">
+      <span id={ownReasonId} className="t-caption">
         {reason}
       </span>
     </span>

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -1244,6 +1244,7 @@ export const de = {
     "Zum Kontakt befördert — dieser Lead ist jetzt schreibgeschützt.",
   "lead.terminalDisqualified":
     "Disqualifiziert — dieser Lead ist jetzt schreibgeschützt.",
+  "lead.marker": "Lead",
   "lead.assign": "Zuweisen",
   "lead.assignToMe": "Mir zuweisen",
   "lead.assignToSomeone": "Jemand anderem zuweisen",

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -1211,14 +1211,14 @@ export const de = {
   "lead.clearOverride": "Überschreibung aufheben",
   "lead.overrideReason": "Begründung",
   "lead.machineComputed": "Maschinell berechneter Score",
-  "lead.shortfall.lead": "Auf diesen Score zahlt bisher nichts ein:",
+  "lead.shortfall.lead": "Womit dieser Score arbeitet:",
+  "lead.shortfall.engagementMoves":
+    "Am stärksten bewegen ihn eine Antwort oder ein Termin.",
   "lead.shortfall.noTitle": "Keine Position hinterlegt.",
   "lead.shortfall.titleNotSenior":
     "„{title}“ gehört nicht zu den Positionen, auf die das Modell achtet.",
   "lead.shortfall.sourceNoIntent":
     "Kam über „{source}“ herein — daraus allein spricht noch kein Kaufinteresse.",
-  "lead.shortfall.noEngagement":
-    "Noch keine Antwort, kein Termin — das bewegt den Score am stärksten.",
   "lead.scoreNotStoredYet":
     "Die Aufschlüsselung zu diesem Score ist noch nicht gespeichert — die nächste Aktualisierung zeigt sie.",
   "lead.scoreLoading": "Begründung wird geladen…",

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -1240,8 +1240,6 @@ export const de = {
   "lead.ownerYou": "Sie",
   "lead.overriddenBadge": "überschrieben",
   "lead.unassigned": "Nicht zugewiesen",
-  "lead.terminalPromoted":
-    "Zum Kontakt befördert — dieser Lead ist jetzt schreibgeschützt.",
   "lead.terminalDisqualified":
     "Disqualifiziert — dieser Lead ist jetzt schreibgeschützt.",
   "lead.marker": "Lead",

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -1210,10 +1210,13 @@ export const de = {
   "lead.overrideScore": "Score überschreiben",
   "lead.clearOverride": "Überschreibung aufheben",
   "lead.overrideReason": "Begründung",
-  "lead.machineComputed": "Maschinell berechneter Score",
   "lead.shortfall.lead": "Womit dieser Score arbeitet:",
   "lead.shortfall.engagementMoves":
     "Am stärksten bewegen ihn eine Antwort oder ein Termin.",
+  "lead.shortfall.noSource":
+    "Keine Quelle hinterlegt — es ist nicht festgehalten, woher dieser Lead kam.",
+  "lead.shortfall.sourcePenalised":
+    "Kam über „{source}“ herein, was den Score mindert.",
   "lead.shortfall.noTitle": "Keine Position hinterlegt.",
   "lead.shortfall.titleNotSenior":
     "„{title}“ gehört nicht zu den Positionen, auf die das Modell achtet.",
@@ -1222,8 +1225,6 @@ export const de = {
   "lead.scoreNotStoredYet":
     "Die Aufschlüsselung zu diesem Score ist noch nicht gespeichert — die nächste Aktualisierung zeigt sie.",
   "lead.scoreLoading": "Begründung wird geladen…",
-  "lead.scoreNotYetExplained":
-    "Dieser Score stammt aus der Zeit vor der Aufschlüsselung. Die nächste Aktualisierung erklärt ihn.",
   "lead.scoreNoFactors": "Bisher zahlt nichts auf diesen Score ein.",
   "lead.scoreFactorsExplainMachine":
     "Sie haben diesen Score selbst gesetzt. Die Faktoren unten erklären den Wert des Modells: {score}.",
@@ -1245,7 +1246,6 @@ export const de = {
   "lead.marker": "Lead",
   "lead.assign": "Zuweisen",
   "lead.assignToMe": "Mir zuweisen",
-  "lead.assignToSomeone": "Jemand anderem zuweisen",
   "lead.assignTo": "Diesen Lead zuweisen an",
   "lead.assignChoose": "Kollegin oder Kollegen wählen",
   "lead.assignNobodyElse":

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -1211,6 +1211,14 @@ export const de = {
   "lead.clearOverride": "Überschreibung aufheben",
   "lead.overrideReason": "Begründung",
   "lead.machineComputed": "Maschinell berechneter Score",
+  "lead.shortfall.lead": "Auf diesen Score zahlt bisher nichts ein:",
+  "lead.shortfall.noTitle": "Keine Position hinterlegt.",
+  "lead.shortfall.titleNotSenior":
+    "„{title}“ gehört nicht zu den Positionen, auf die das Modell achtet.",
+  "lead.shortfall.sourceNoIntent":
+    "Kam über „{source}“ herein — daraus allein spricht noch kein Kaufinteresse.",
+  "lead.shortfall.noEngagement":
+    "Noch keine Antwort, kein Termin — das bewegt den Score am stärksten.",
   "lead.scoreLoading": "Begründung wird geladen…",
   "lead.scoreNotYetExplained":
     "Dieser Score stammt aus der Zeit vor der Aufschlüsselung. Die nächste Aktualisierung erklärt ihn.",
@@ -1230,6 +1238,11 @@ export const de = {
   "lead.ownerYou": "Sie",
   "lead.overriddenBadge": "überschrieben",
   "lead.unassigned": "Nicht zugewiesen",
+  "lead.terminalPromoted":
+    "Zum Kontakt befördert — dieser Lead ist jetzt schreibgeschützt.",
+  "lead.terminalDisqualified":
+    "Disqualifiziert — dieser Lead ist jetzt schreibgeschützt.",
+  "lead.assign": "Zuweisen",
   "lead.assignToMe": "Mir zuweisen",
   "lead.assignToSomeone": "Jemand anderem zuweisen",
   "lead.assignTo": "Diesen Lead zuweisen an",

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -1219,6 +1219,8 @@ export const de = {
     "Kam über „{source}“ herein — daraus allein spricht noch kein Kaufinteresse.",
   "lead.shortfall.noEngagement":
     "Noch keine Antwort, kein Termin — das bewegt den Score am stärksten.",
+  "lead.scoreNotStoredYet":
+    "Die Aufschlüsselung zu diesem Score ist noch nicht gespeichert — die nächste Aktualisierung zeigt sie.",
   "lead.scoreLoading": "Begründung wird geladen…",
   "lead.scoreNotYetExplained":
     "Dieser Score stammt aus der Zeit vor der Aufschlüsselung. Die nächste Aktualisierung erklärt ihn.",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -1252,8 +1252,6 @@ export const en = {
   "lead.ownerYou": "You",
   "lead.overriddenBadge": "overridden",
   "lead.unassigned": "Unassigned",
-  "lead.terminalPromoted":
-    "Promoted to a contact — this lead is now read-only.",
   "lead.terminalDisqualified": "Disqualified — this lead is now read-only.",
   "lead.marker": "Lead",
   "lead.assign": "Assign",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -1255,6 +1255,7 @@ export const en = {
   "lead.terminalPromoted":
     "Promoted to a contact — this lead is now read-only.",
   "lead.terminalDisqualified": "Disqualified — this lead is now read-only.",
+  "lead.marker": "Lead",
   "lead.assign": "Assign",
   "lead.assignToMe": "Assign to me",
   "lead.assignToSomeone": "Assign to someone else",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -1222,10 +1222,13 @@ export const en = {
   "lead.overrideScore": "Override score",
   "lead.clearOverride": "Clear override",
   "lead.overrideReason": "Reason",
-  "lead.machineComputed": "Machine-computed score",
   "lead.shortfall.lead": "What this score has to work with:",
   "lead.shortfall.engagementMoves":
     "A reply or a meeting is what moves it most.",
+  "lead.shortfall.noSource":
+    "No source on record — nothing says where this lead came from.",
+  "lead.shortfall.sourcePenalised":
+    "Came in as “{source}”, which counts against the score.",
   "lead.shortfall.noTitle": "No job title on record.",
   "lead.shortfall.titleNotSenior":
     "“{title}” isn’t one of the senior titles the model looks for.",
@@ -1234,8 +1237,6 @@ export const en = {
   "lead.scoreNotStoredYet":
     "The breakdown for this score isn’t stored yet — the next update will show it.",
   "lead.scoreLoading": "Working out why…",
-  "lead.scoreNotYetExplained":
-    "This score predates the breakdown. The next update will explain it.",
   "lead.scoreNoFactors": "Nothing counted toward this score yet.",
   "lead.scoreFactorsExplainMachine":
     "You set this score by hand. The factors below explain what the model says: {score}.",
@@ -1256,7 +1257,6 @@ export const en = {
   "lead.marker": "Lead",
   "lead.assign": "Assign",
   "lead.assignToMe": "Assign to me",
-  "lead.assignToSomeone": "Assign to someone else",
   "lead.assignTo": "Assign this lead to",
   "lead.assignChoose": "Choose a colleague",
   "lead.assignNobodyElse": "No other user to assign this lead to.",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -1223,14 +1223,14 @@ export const en = {
   "lead.clearOverride": "Clear override",
   "lead.overrideReason": "Reason",
   "lead.machineComputed": "Machine-computed score",
-  "lead.shortfall.lead": "Nothing counts toward this score yet:",
+  "lead.shortfall.lead": "What this score has to work with:",
+  "lead.shortfall.engagementMoves":
+    "A reply or a meeting is what moves it most.",
   "lead.shortfall.noTitle": "No job title on record.",
   "lead.shortfall.titleNotSenior":
     "“{title}” isn’t one of the senior titles the model looks for.",
   "lead.shortfall.sourceNoIntent":
     "Came in as “{source}”, which carries no buying intent on its own.",
-  "lead.shortfall.noEngagement":
-    "No reply or meeting yet — that’s what moves the score most.",
   "lead.scoreNotStoredYet":
     "The breakdown for this score isn’t stored yet — the next update will show it.",
   "lead.scoreLoading": "Working out why…",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -1231,6 +1231,8 @@ export const en = {
     "Came in as “{source}”, which carries no buying intent on its own.",
   "lead.shortfall.noEngagement":
     "No reply or meeting yet — that’s what moves the score most.",
+  "lead.scoreNotStoredYet":
+    "The breakdown for this score isn’t stored yet — the next update will show it.",
   "lead.scoreLoading": "Working out why…",
   "lead.scoreNotYetExplained":
     "This score predates the breakdown. The next update will explain it.",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -1223,6 +1223,14 @@ export const en = {
   "lead.clearOverride": "Clear override",
   "lead.overrideReason": "Reason",
   "lead.machineComputed": "Machine-computed score",
+  "lead.shortfall.lead": "Nothing counts toward this score yet:",
+  "lead.shortfall.noTitle": "No job title on record.",
+  "lead.shortfall.titleNotSenior":
+    "“{title}” isn’t one of the senior titles the model looks for.",
+  "lead.shortfall.sourceNoIntent":
+    "Came in as “{source}”, which carries no buying intent on its own.",
+  "lead.shortfall.noEngagement":
+    "No reply or meeting yet — that’s what moves the score most.",
   "lead.scoreLoading": "Working out why…",
   "lead.scoreNotYetExplained":
     "This score predates the breakdown. The next update will explain it.",
@@ -1242,6 +1250,10 @@ export const en = {
   "lead.ownerYou": "You",
   "lead.overriddenBadge": "overridden",
   "lead.unassigned": "Unassigned",
+  "lead.terminalPromoted":
+    "Promoted to a contact — this lead is now read-only.",
+  "lead.terminalDisqualified": "Disqualified — this lead is now read-only.",
+  "lead.assign": "Assign",
   "lead.assignToMe": "Assign to me",
   "lead.assignToSomeone": "Assign to someone else",
   "lead.assignTo": "Assign this lead to",

--- a/frontend/src/i18n/i18n.test.ts
+++ b/frontend/src/i18n/i18n.test.ts
@@ -155,6 +155,10 @@ const KEPT_IN_ENGLISH = new Set<string>([
   // catalog, so spelling out "trí tuệ nhân tạo" on the settings entry alone
   // would make one subject read as two.
   "settings.tab.ai",
+  // "Lead" is the loanword in both de and vi — every other lead key in this
+  // catalog leaves it untranslated, and the marker on the record page names
+  // the same object those keys do.
+  "lead.marker",
 
   // Other cases verified individually against the source.
   "shell.logoAria",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -1203,10 +1203,13 @@ export const vi = {
   "lead.overrideScore": "Ghi đè điểm",
   "lead.clearOverride": "Xoá ghi đè",
   "lead.overrideReason": "Lý do",
-  "lead.machineComputed": "Điểm do máy tính toán",
   "lead.shortfall.lead": "Điểm này đang dựa trên:",
   "lead.shortfall.engagementMoves":
     "Phản hồi hoặc cuộc họp là thứ thay đổi điểm nhiều nhất.",
+  "lead.shortfall.noSource":
+    "Chưa có nguồn — không ghi nhận lead này đến từ đâu.",
+  "lead.shortfall.sourcePenalised":
+    "Đến từ “{source}”, điều này làm giảm điểm.",
   "lead.shortfall.noTitle": "Chưa có chức danh.",
   "lead.shortfall.titleNotSenior":
     "“{title}” không thuộc nhóm chức danh mà mô hình tìm.",
@@ -1215,8 +1218,6 @@ export const vi = {
   "lead.scoreNotStoredYet":
     "Phần giải thích cho điểm này chưa được lưu — lần cập nhật tới sẽ hiển thị.",
   "lead.scoreLoading": "Đang tải lý do…",
-  "lead.scoreNotYetExplained":
-    "Điểm này có trước phần giải thích. Lần cập nhật tới sẽ giải thích nó.",
   "lead.scoreNoFactors": "Chưa có gì cộng vào điểm này.",
   "lead.scoreFactorsExplainMachine":
     "Bạn đã tự đặt điểm này. Các yếu tố bên dưới giải thích giá trị của mô hình: {score}.",
@@ -1237,7 +1238,6 @@ export const vi = {
   "lead.marker": "Lead",
   "lead.assign": "Giao",
   "lead.assignToMe": "Giao cho tôi",
-  "lead.assignToSomeone": "Giao cho người khác",
   "lead.assignTo": "Giao lead này cho",
   "lead.assignChoose": "Chọn một đồng nghiệp",
   "lead.assignNobodyElse": "Không có người nào khác để giao lead này.",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -1204,6 +1204,14 @@ export const vi = {
   "lead.clearOverride": "Xoá ghi đè",
   "lead.overrideReason": "Lý do",
   "lead.machineComputed": "Điểm do máy tính toán",
+  "lead.shortfall.lead": "Chưa có gì cộng vào điểm này:",
+  "lead.shortfall.noTitle": "Chưa có chức danh.",
+  "lead.shortfall.titleNotSenior":
+    "“{title}” không thuộc nhóm chức danh mà mô hình tìm.",
+  "lead.shortfall.sourceNoIntent":
+    "Đến từ “{source}”, tự nó chưa thể hiện ý định mua.",
+  "lead.shortfall.noEngagement":
+    "Chưa có phản hồi hay cuộc họp — đó mới là thứ thay đổi điểm nhiều nhất.",
   "lead.scoreLoading": "Đang tải lý do…",
   "lead.scoreNotYetExplained":
     "Điểm này có trước phần giải thích. Lần cập nhật tới sẽ giải thích nó.",
@@ -1223,6 +1231,9 @@ export const vi = {
   "lead.ownerYou": "Bạn",
   "lead.overriddenBadge": "đã ghi đè",
   "lead.unassigned": "Chưa giao",
+  "lead.terminalPromoted": "Đã chuyển thành liên hệ — lead này giờ chỉ đọc.",
+  "lead.terminalDisqualified": "Đã loại — lead này giờ chỉ đọc.",
+  "lead.assign": "Giao",
   "lead.assignToMe": "Giao cho tôi",
   "lead.assignToSomeone": "Giao cho người khác",
   "lead.assignTo": "Giao lead này cho",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -1212,6 +1212,8 @@ export const vi = {
     "Đến từ “{source}”, tự nó chưa thể hiện ý định mua.",
   "lead.shortfall.noEngagement":
     "Chưa có phản hồi hay cuộc họp — đó mới là thứ thay đổi điểm nhiều nhất.",
+  "lead.scoreNotStoredYet":
+    "Phần giải thích cho điểm này chưa được lưu — lần cập nhật tới sẽ hiển thị.",
   "lead.scoreLoading": "Đang tải lý do…",
   "lead.scoreNotYetExplained":
     "Điểm này có trước phần giải thích. Lần cập nhật tới sẽ giải thích nó.",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -1235,6 +1235,7 @@ export const vi = {
   "lead.unassigned": "Chưa giao",
   "lead.terminalPromoted": "Đã chuyển thành liên hệ — lead này giờ chỉ đọc.",
   "lead.terminalDisqualified": "Đã loại — lead này giờ chỉ đọc.",
+  "lead.marker": "Lead",
   "lead.assign": "Giao",
   "lead.assignToMe": "Giao cho tôi",
   "lead.assignToSomeone": "Giao cho người khác",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -1204,14 +1204,14 @@ export const vi = {
   "lead.clearOverride": "Xoá ghi đè",
   "lead.overrideReason": "Lý do",
   "lead.machineComputed": "Điểm do máy tính toán",
-  "lead.shortfall.lead": "Chưa có gì cộng vào điểm này:",
+  "lead.shortfall.lead": "Điểm này đang dựa trên:",
+  "lead.shortfall.engagementMoves":
+    "Phản hồi hoặc cuộc họp là thứ thay đổi điểm nhiều nhất.",
   "lead.shortfall.noTitle": "Chưa có chức danh.",
   "lead.shortfall.titleNotSenior":
     "“{title}” không thuộc nhóm chức danh mà mô hình tìm.",
   "lead.shortfall.sourceNoIntent":
     "Đến từ “{source}”, tự nó chưa thể hiện ý định mua.",
-  "lead.shortfall.noEngagement":
-    "Chưa có phản hồi hay cuộc họp — đó mới là thứ thay đổi điểm nhiều nhất.",
   "lead.scoreNotStoredYet":
     "Phần giải thích cho điểm này chưa được lưu — lần cập nhật tới sẽ hiển thị.",
   "lead.scoreLoading": "Đang tải lý do…",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -1233,7 +1233,6 @@ export const vi = {
   "lead.ownerYou": "Bạn",
   "lead.overriddenBadge": "đã ghi đè",
   "lead.unassigned": "Chưa giao",
-  "lead.terminalPromoted": "Đã chuyển thành liên hệ — lead này giờ chỉ đọc.",
   "lead.terminalDisqualified": "Đã loại — lead này giờ chỉ đọc.",
   "lead.marker": "Lead",
   "lead.assign": "Giao",

--- a/frontend/src/screens/archive.tsx
+++ b/frontend/src/screens/archive.tsx
@@ -47,7 +47,7 @@ export function ArchiveAction<Archived extends { id: string }>({
   invalidate,
   recordKey,
   onArchived,
-  disabledReason,
+  disabledReasonId,
 }: Readonly<{
   label: string;
   confirmText: string;
@@ -60,7 +60,7 @@ export function ArchiveAction<Archived extends { id: string }>({
   // rather than permission — an archived record — stays visible and
   // disabled WITH the reason, because the reason is the information and
   // hiding the control hides a fact the reader needs.
-  disabledReason?: string;
+  disabledReasonId?: string;
 }>) {
   const t = useT();
   const headingId = useId();
@@ -80,7 +80,7 @@ export function ArchiveAction<Archived extends { id: string }>({
       <Button
         small
         variant="danger"
-        reason={disabledReason}
+        reasonId={disabledReasonId}
         onClick={() => setConfirming(true)}
         data-testid="archive-record"
       >

--- a/frontend/src/screens/archive.tsx
+++ b/frontend/src/screens/archive.tsx
@@ -47,6 +47,7 @@ export function ArchiveAction<Archived extends { id: string }>({
   invalidate,
   recordKey,
   onArchived,
+  disabledReason,
 }: Readonly<{
   label: string;
   confirmText: string;
@@ -54,6 +55,12 @@ export function ArchiveAction<Archived extends { id: string }>({
   invalidate: string;
   recordKey: string;
   onArchived: () => void;
+  // Why this action is unavailable, when it is. STATE-4a settles the
+  // absent-vs-disabled question by CAUSE: a control blocked by STATE
+  // rather than permission — an archived record — stays visible and
+  // disabled WITH the reason, because the reason is the information and
+  // hiding the control hides a fact the reader needs.
+  disabledReason?: string;
 }>) {
   const t = useT();
   const headingId = useId();
@@ -73,6 +80,8 @@ export function ArchiveAction<Archived extends { id: string }>({
       <Button
         small
         variant="danger"
+        disabled={Boolean(disabledReason)}
+        title={disabledReason}
         onClick={() => setConfirming(true)}
         data-testid="archive-record"
       >

--- a/frontend/src/screens/archive.tsx
+++ b/frontend/src/screens/archive.tsx
@@ -80,8 +80,7 @@ export function ArchiveAction<Archived extends { id: string }>({
       <Button
         small
         variant="danger"
-        disabled={Boolean(disabledReason)}
-        title={disabledReason}
+        reason={disabledReason}
         onClick={() => setConfirming(true)}
         data-testid="archive-record"
       >

--- a/frontend/src/screens/edit.tsx
+++ b/frontend/src/screens/edit.tsx
@@ -263,8 +263,7 @@ export function EditAction<Updated extends { id: string }>({
     <>
       <Button
         small
-        disabled={Boolean(disabledReason)}
-        title={disabledReason}
+        reason={disabledReason}
         onClick={() => setEditing(true)}
         data-testid="edit-record"
       >

--- a/frontend/src/screens/edit.tsx
+++ b/frontend/src/screens/edit.tsx
@@ -220,8 +220,16 @@ export function EditAction<Updated extends { id: string }>({
   invalidate,
   recordKey,
   resolveExisting,
+  disabledReason,
 }: Readonly<{
   label: string;
+  // Why this action is unavailable, when it is. STATE-4a settles the
+  // absent-vs-disabled question by CAUSE: a control blocked by STATE
+  // rather than permission — an archived record — stays visible and
+  // disabled WITH the reason, because the reason is the information and
+  // hiding the control hides a fact the reader needs.
+  disabledReason?: string;
+
   // See EditRecordModal — an optional one-sentence advisory over the form.
   notice?: string;
   fields: CreateField[];
@@ -253,7 +261,13 @@ export function EditAction<Updated extends { id: string }>({
     isVersionSkew(mutation.error.problem);
   return (
     <>
-      <Button small onClick={() => setEditing(true)} data-testid="edit-record">
+      <Button
+        small
+        disabled={Boolean(disabledReason)}
+        title={disabledReason}
+        onClick={() => setEditing(true)}
+        data-testid="edit-record"
+      >
         {label}
       </Button>
       <EditRecordModal

--- a/frontend/src/screens/edit.tsx
+++ b/frontend/src/screens/edit.tsx
@@ -220,7 +220,7 @@ export function EditAction<Updated extends { id: string }>({
   invalidate,
   recordKey,
   resolveExisting,
-  disabledReason,
+  disabledReasonId,
 }: Readonly<{
   label: string;
   // Why this action is unavailable, when it is. STATE-4a settles the
@@ -228,7 +228,7 @@ export function EditAction<Updated extends { id: string }>({
   // rather than permission — an archived record — stays visible and
   // disabled WITH the reason, because the reason is the information and
   // hiding the control hides a fact the reader needs.
-  disabledReason?: string;
+  disabledReasonId?: string;
 
   // See EditRecordModal — an optional one-sentence advisory over the form.
   notice?: string;
@@ -263,7 +263,7 @@ export function EditAction<Updated extends { id: string }>({
     <>
       <Button
         small
-        reason={disabledReason}
+        reasonId={disabledReasonId}
         onClick={() => setEditing(true)}
         data-testid="edit-record"
       >

--- a/frontend/src/screens/leads.stories.tsx
+++ b/frontend/src/screens/leads.stories.tsx
@@ -74,3 +74,96 @@ export const LeadOverview: Story = {
     );
   },
 };
+
+// A lead that earns nothing, which is the common shape of a fresh one: the
+// panel states the reasons rather than the score's storage history, so a 0
+// stops reading as a bad prospect when it means an unassessed one
+// (ADR-0108 §4).
+export const LeadScoringZero: Story = {
+  render: () => {
+    installFetchStub({
+      "GET /leads/l-1": () =>
+        jsonResponse({ ...lead, score: 0, title: "Boss", source: "manual" }),
+      "GET /leads/l-1/score": () =>
+        jsonResponse({ score: 0, explained: false }),
+      "GET /me": () =>
+        jsonResponse({
+          user: { id: "u-9", display_name: "Me" },
+          roles: ["rep"],
+          teams: [],
+        }),
+    });
+    return (
+      <StoryProviders>
+        <LeadScreen id="l-1" />
+      </StoryProviders>
+    );
+  },
+};
+
+// The score explained: factors with their points and the decay as arithmetic
+// a reader can check, plus the line that reconciles them to the stored score.
+export const LeadScoreExplained: Story = {
+  render: () => {
+    installFetchStub({
+      "GET /leads/l-1": () => jsonResponse(lead),
+      "GET /leads/l-1/score": () =>
+        jsonResponse({
+          score: 72,
+          explained: true,
+          current: {
+            score: 72,
+            score_computed: 72,
+            raw_sum: 71.6,
+            rounded_sum: 72,
+            computed_at: "2026-06-04T00:00:00Z",
+            factors: [
+              { factor: "decision_maker_title", points: 15 },
+              { factor: "high_intent_source", points: 8 },
+              { factor: "reply", points: 22.6, base_points: 25 },
+            ],
+          },
+        }),
+      "GET /me": () =>
+        jsonResponse({
+          user: { id: "u-9", display_name: "Me" },
+          roles: ["rep"],
+          teams: [],
+        }),
+    });
+    return (
+      <StoryProviders>
+        <LeadScreen id="l-1" />
+      </StoryProviders>
+    );
+  },
+};
+
+// A disqualified lead keeps its controls, DISABLED with the reason — hiding
+// them hid the fact the reader needed (STATE-4a). A promoted lead never
+// reaches this page; it redirects to the person it became.
+export const LeadDisqualified: Story = {
+  render: () => {
+    installFetchStub({
+      "GET /leads/l-1": () =>
+        jsonResponse({
+          ...lead,
+          status: "disqualified",
+          archived_at: "2026-07-13T00:00:00Z",
+        }),
+      "GET /leads/l-1/score": () =>
+        jsonResponse({ score: 72, explained: false }),
+      "GET /me": () =>
+        jsonResponse({
+          user: { id: "u-9", display_name: "Me" },
+          roles: ["rep"],
+          teams: [],
+        }),
+    });
+    return (
+      <StoryProviders>
+        <LeadScreen id="l-1" />
+      </StoryProviders>
+    );
+  },
+};

--- a/frontend/src/screens/leads.stories.tsx
+++ b/frontend/src/screens/leads.stories.tsx
@@ -64,8 +64,6 @@ export const LeadOverview: Story = {
           roles: ["rep"],
           teams: [],
         }),
-      "GET /records/lead/l-1/context": () =>
-        jsonResponse({ anchor: { type: "lead", id: "l-1" }, sections: [] }),
     });
     return (
       <StoryProviders>

--- a/frontend/src/screens/leads.test.tsx
+++ b/frontend/src/screens/leads.test.tsx
@@ -782,22 +782,32 @@ describe("LeadScreen — score explain + override (P-10)", () => {
 });
 
 describe("LeadScreen — owner display + assign to me (P-11)", () => {
-  it("shows Unassigned and Assign to me PATCHes owner_id to the current user", async () => {
+  it("shows Unassigned and assigning to yourself PATCHes owner_id to the current user", async () => {
     let patchBody: unknown = null;
     stubFetchWithMe(async (url, method, request) => {
       if (method === "PATCH" && url.includes("/leads/l-1")) {
         patchBody = JSON.parse(await request.text());
         return jsonResponse({ ...lead, owner_id: "u-9", version: 2 });
       }
+      if (url.includes("/users")) {
+        // The viewer is an ordinary roster entry now — the picker offers them
+        // first rather than a separate button doing it.
+        return jsonResponse({ data: [{ id: "u-9", display_name: "Me" }] });
+      }
       return undefined;
     }, "u-9");
     render(<LeadScreen id="l-1" />);
 
     await waitFor(() => expect(screen.getByText("Unassigned")).toBeTruthy());
-    await waitFor(() =>
-      expect(screen.getByRole("button", { name: "Assign to me" })).toBeTruthy(),
+    // ONE control, not a self-assign button beside a picker: the viewer is
+    // simply its first option (ADR-0108 §5).
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Assign" }),
     );
-    await userEvent.click(screen.getByRole("button", { name: "Assign to me" }));
+    await userEvent.click(await screen.findByRole("combobox"));
+    await userEvent.click(
+      await screen.findByRole("option", { name: "Assign to me" }),
+    );
 
     await waitFor(() => expect(patchBody).toBeTruthy());
     expect(patchBody).toMatchObject({ owner_id: "u-9" });
@@ -942,7 +952,7 @@ describe("LeadScreen — archived/terminal is read-only (P-3)", () => {
     ).toBeTruthy();
   });
 
-  it("says a pre-existing score is not yet explained rather than showing an empty breakdown", async () => {
+  it("says why a lead scores nothing rather than explaining our storage history", async () => {
     stubFetchWithMe(async (url) => {
       if (url.includes("/score")) {
         return jsonResponse({ score: 72, explained: false });
@@ -951,15 +961,20 @@ describe("LeadScreen — archived/terminal is read-only (P-3)", () => {
     });
     render(<LeadScreen id="l-1" />);
 
-    // An empty factor list would read as "nothing contributed", which is a
-    // different and false claim about a score that predates the series.
+    // The reasons a lead earns nothing are derivable from the lead itself, and
+    // they are what the reader came for. "This score predates the breakdown"
+    // answered a question nobody asked and left a 0 looking like a bad
+    // prospect rather than an unassessed one (ADR-0108 §4).
     await waitFor(() =>
       expect(
-        screen.getByText(
-          "This score predates the breakdown. The next update will explain it.",
-        ),
+        screen.getByText("Nothing counts toward this score yet:"),
       ).toBeTruthy(),
     );
+    expect(
+      screen.getByText(
+        "No reply or meeting yet — that\u2019s what moves the score most.",
+      ),
+    ).toBeTruthy();
   });
 
   it("names the owner 'You' when the lead is owned by the current user", async () => {
@@ -1007,7 +1022,7 @@ describe("LeadScreen — archived/terminal is read-only (P-3)", () => {
     render(<LeadScreen id="l-1" />);
 
     await userEvent.click(
-      await screen.findByRole("button", { name: "Assign to someone else" }),
+      await screen.findByRole("button", { name: "Assign" }),
     );
     // The listbox is opened ONCE and the option awaited inside it: clicking
     // the trigger again would toggle it shut, and the popup re-renders in

--- a/frontend/src/screens/leads.test.tsx
+++ b/frontend/src/screens/leads.test.tsx
@@ -900,24 +900,32 @@ describe("terminalBadge (archived/terminal labelling)", () => {
 });
 
 describe("LeadScreen — archived/terminal is read-only (P-3)", () => {
-  it("a promoted lead reads Archived (not Disqualified) and hides edit/disqualify/promote/override", async () => {
+  it("a disqualified lead keeps its controls DISABLED with the reason, never hidden", async () => {
+    // STATE-4a: blocked by state rather than permission means visible and
+    // disabled with the reason — hiding the control hides the fact the
+    // reader needs. (A PROMOTED lead never reaches this page; it redirects
+    // to the person it became.)
     stubFetchWithMe(async () =>
       jsonResponse({
         ...lead,
-        status: "promoted",
+        status: "disqualified",
         archived_at: "2026-07-13T00:00:00Z",
       }),
     );
     render(<LeadScreen id="l-1" />);
 
-    await waitFor(() => expect(screen.getByText("Archived")).toBeTruthy());
-    expect(screen.queryByText("Disqualified")).toBeNull();
-    expect(screen.queryByTestId("edit-record")).toBeNull();
-    expect(screen.queryByTestId("archive-record")).toBeNull();
+    await waitFor(() => expect(screen.getByText("Disqualified")).toBeTruthy());
+    const reason = "Disqualified — this lead is now read-only.";
+    for (const testId of ["edit-record", "archive-record"]) {
+      const control = screen.getByTestId(testId) as HTMLButtonElement;
+      expect(control.disabled).toBe(true);
+      expect(control.getAttribute("title")).toBe(reason);
+    }
+    // Promote is gone rather than disabled: a disqualified lead is not a
+    // promotable one, and the header's primary action is for live leads.
     expect(
       screen.queryByRole("button", { name: "Promote to contact" }),
     ).toBeNull();
-    expect(screen.queryByRole("button", { name: "Override score" })).toBeNull();
   });
 
   it("shows an 'overridden' badge when the score is human-overridden", async () => {

--- a/frontend/src/screens/leads.test.tsx
+++ b/frontend/src/screens/leads.test.tsx
@@ -217,26 +217,40 @@ describe("LeadsScreen + LeadScreen (B-EP09.10b, §3.5 segregation)", () => {
     await waitFor(() => expect(window.location.hash).toBe("#/contacts/p-9"));
   });
 
-  it("promote is disabled for an ineligible lead", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async (request: Request) =>
-        new URL(request.url).pathname.endsWith("/context")
-          ? jsonResponse({ anchor: { type: "lead", id: "l-1" }, sections: [] })
-          : jsonResponse({ ...lead, status: "promoted" }),
-      ),
+  it("a promoted lead redirects to the person it became", async () => {
+    // The record moved, so the page follows it (ADR-0108 §1). Before this,
+    // the redirect only fired as the tail of a promote you had just done, so
+    // revisiting or deep-linking a promoted lead landed on a read-only husk
+    // of a record that lives elsewhere.
+    stubFetch(async () =>
+      jsonResponse({
+        ...lead,
+        status: "promoted",
+        promoted_person_id: "p-42",
+        archived_at: "2026-06-20T08:00:00Z",
+      }),
     );
     render(<LeadScreen id="l-1" />);
+    await waitFor(() => expect(window.location.hash).toBe("#/contacts/p-42"));
+  });
+
+  it("promote is disabled for an ineligible lead, and the button says why", async () => {
+    // A LIVE lead with no email: ineligible, but still on screen. A promoted
+    // lead would redirect to the person it became, so it cannot stand in for
+    // "ineligible" any more (ADR-0108 §1).
+    stubFetch(async () => jsonResponse({ ...lead, email: null }));
+    render(<LeadScreen id="l-1" />);
+    const button = await screen.findByRole("button", {
+      name: "Promote to contact",
+    });
     await waitFor(() =>
-      expect(
-        (
-          screen.getByRole("button", {
-            name: "Promote to contact",
-          }) as HTMLButtonElement
-        ).disabled,
-      ).toBe(true),
+      expect((button as HTMLButtonElement).disabled).toBe(true),
     );
-    expect(screen.getByText("needs an email and an open status")).toBeTruthy();
+    // The reason rides the control, not a sentence beside it: a disabled
+    // button whose reason lives elsewhere is a dead button (ADR-0108 §6).
+    expect(button.getAttribute("title")).toBe(
+      "needs an email and an open status",
+    );
   });
 });
 

--- a/frontend/src/screens/leads.test.tsx
+++ b/frontend/src/screens/leads.test.tsx
@@ -246,9 +246,11 @@ describe("LeadsScreen + LeadScreen (B-EP09.10b, §3.5 segregation)", () => {
     await waitFor(() =>
       expect((button as HTMLButtonElement).disabled).toBe(true),
     );
-    // The reason rides the control, not a sentence beside it: a disabled
-    // button whose reason lives elsewhere is a dead button (ADR-0108 §6).
-    expect(button.getAttribute("title")).toBe(
+    // The reason is wired to the control with aria-describedby, not stuffed
+    // into a title a screen reader never announces on a disabled button.
+    const describedBy = button.getAttribute("aria-describedby");
+    expect(describedBy).toBeTruthy();
+    expect(document.getElementById(describedBy as string)?.textContent).toBe(
       "needs an email and an open status",
     );
   });
@@ -919,7 +921,11 @@ describe("LeadScreen — archived/terminal is read-only (P-3)", () => {
     for (const testId of ["edit-record", "archive-record"]) {
       const control = screen.getByTestId(testId) as HTMLButtonElement;
       expect(control.disabled).toBe(true);
-      expect(control.getAttribute("title")).toBe(reason);
+      const describedBy = control.getAttribute("aria-describedby");
+      expect(describedBy).toBeTruthy();
+      expect(document.getElementById(describedBy as string)?.textContent).toBe(
+        reason,
+      );
     }
     // Promote is gone rather than disabled: a disqualified lead is not a
     // promotable one, and the header's primary action is for live leads.
@@ -972,6 +978,27 @@ describe("LeadScreen — archived/terminal is read-only (P-3)", () => {
     expect(
       screen.getByText("45.60 adds up, rounds to 46, scored 46"),
     ).toBeTruthy();
+  });
+
+  it("never prints an absent source into the sentence about it", async () => {
+    // The suite let this ship: a lead with no source interpolated the missing
+    // value and rendered "Came in as undefined" at a rep.
+    stubFetchWithMe(async (url) => {
+      if (url.includes("/score")) {
+        return jsonResponse({ score: 0, explained: false });
+      }
+      return jsonResponse({ ...lead, score: 0, source: null, title: null });
+    });
+    render(<LeadScreen id="l-1" />);
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(
+          "No source on record — nothing says where this lead came from.",
+        ),
+      ).toBeTruthy(),
+    );
+    expect(screen.queryByText(/undefined/)).toBeNull();
   });
 
   it("never claims nothing counts when the score is not zero", async () => {

--- a/frontend/src/screens/leads.test.tsx
+++ b/frontend/src/screens/leads.test.tsx
@@ -952,12 +952,36 @@ describe("LeadScreen — archived/terminal is read-only (P-3)", () => {
     ).toBeTruthy();
   });
 
-  it("says why a lead scores nothing rather than explaining our storage history", async () => {
+  it("never claims nothing counts when the score is not zero", async () => {
+    // The render caught this: a lead scoring 72 with no retained breakdown
+    // was told "Nothing counts toward this score yet", which is the opposite
+    // of true. Something counted; this client cannot say what.
     stubFetchWithMe(async (url) => {
       if (url.includes("/score")) {
         return jsonResponse({ score: 72, explained: false });
       }
-      return jsonResponse(lead);
+      return jsonResponse({ ...lead, score: 72 });
+    });
+    render(<LeadScreen id="l-1" />);
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(
+          "The breakdown for this score isn\u2019t stored yet — the next update will show it.",
+        ),
+      ).toBeTruthy(),
+    );
+    expect(
+      screen.queryByText("Nothing counts toward this score yet:"),
+    ).toBeNull();
+  });
+
+  it("says why a lead scores nothing rather than explaining our storage history", async () => {
+    stubFetchWithMe(async (url) => {
+      if (url.includes("/score")) {
+        return jsonResponse({ score: 0, explained: false });
+      }
+      return jsonResponse({ ...lead, score: 0, title: null });
     });
     render(<LeadScreen id="l-1" />);
 

--- a/frontend/src/screens/leads.test.tsx
+++ b/frontend/src/screens/leads.test.tsx
@@ -971,9 +971,7 @@ describe("LeadScreen — archived/terminal is read-only (P-3)", () => {
         ),
       ).toBeTruthy(),
     );
-    expect(
-      screen.queryByText("Nothing counts toward this score yet:"),
-    ).toBeNull();
+    expect(screen.queryByText("What this score has to work with:")).toBeNull();
   });
 
   it("says why a lead scores nothing rather than explaining our storage history", async () => {
@@ -991,13 +989,14 @@ describe("LeadScreen — archived/terminal is read-only (P-3)", () => {
     // prospect rather than an unassessed one (ADR-0108 §4).
     await waitFor(() =>
       expect(
-        screen.getByText("Nothing counts toward this score yet:"),
+        screen.getByText("What this score has to work with:"),
       ).toBeTruthy(),
     );
+    // Deliberately NOT "no reply yet": engagement lives in linked activities
+    // this client never reads, so the page states what MOVES the score rather
+    // than asserting the prospect has done nothing.
     expect(
-      screen.getByText(
-        "No reply or meeting yet — that\u2019s what moves the score most.",
-      ),
+      screen.getByText("A reply or a meeting is what moves it most."),
     ).toBeTruthy();
   });
 

--- a/frontend/src/screens/leads.tsx
+++ b/frontend/src/screens/leads.tsx
@@ -530,11 +530,13 @@ function LeadOwner({
   meId,
   pending,
   onAssign,
+  terminalReasonId,
 }: Readonly<{
   lead: Lead;
   meId: string | undefined;
   pending: boolean;
   onAssign: (ownerId: string) => void;
+  terminalReasonId: string;
 }>) {
   const t = useT();
   const pickerId = useId();
@@ -583,7 +585,7 @@ function LeadOwner({
         <Button
           small
           disabled={pending}
-          reason={lead.archived_at ? t("lead.terminalDisqualified") : undefined}
+          reasonId={lead.archived_at ? terminalReasonId : undefined}
           aria-expanded={picking}
           aria-controls={pickerId}
           onClick={() => setPicking(!picking)}
@@ -652,7 +654,13 @@ function LeadLifecycle({
   lead,
   id,
   onChanged,
-}: Readonly<{ lead: Lead; id: string; onChanged: () => void }>) {
+  terminalReasonId,
+}: Readonly<{
+  lead: Lead;
+  id: string;
+  onChanged: () => void;
+  terminalReasonId: string;
+}>) {
   const t = useT();
   const me = useMe();
   const scoreFieldId = useId();
@@ -806,9 +814,7 @@ function LeadLifecycle({
           // action and stands alone.
           <Button
             small
-            reason={
-              lead.archived_at ? t("lead.terminalDisqualified") : undefined
-            }
+            reasonId={lead.archived_at ? terminalReasonId : undefined}
             onClick={() => setOverriding(true)}
           >
             {t("lead.overrideScore")}
@@ -819,6 +825,7 @@ function LeadLifecycle({
       <LeadOwner
         lead={lead}
         meId={meId}
+        terminalReasonId={terminalReasonId}
         pending={patch.isPending}
         onAssign={(ownerId) => patch.mutate({ owner_id: ownerId })}
       />
@@ -867,6 +874,7 @@ function LeadOverviewPane({
   lead,
   id,
   headingId,
+  terminalReasonId,
   promoteOpen,
   closePromote,
   trigger,
@@ -881,6 +889,7 @@ function LeadOverviewPane({
   lead: Lead;
   id: string;
   headingId: string;
+  terminalReasonId: string;
   promoteOpen: boolean;
   closePromote: () => void;
   trigger: PromoteTrigger;
@@ -975,7 +984,12 @@ function LeadOverviewPane({
           Hiding the whole body left the page blank below the tab bar, which
           reads as a broken render rather than a closed lead. The controls
           inside it are individually disabled by their own state. */}
-      <LeadLifecycle lead={lead} id={id} onChanged={onLifecycleChanged} />
+      <LeadLifecycle
+        lead={lead}
+        id={id}
+        onChanged={onLifecycleChanged}
+        terminalReasonId={terminalReasonId}
+      />
       <CustomFieldsCard object="lead" record={lead} />
     </>
   );
@@ -991,12 +1005,17 @@ function LeadActions({
   cf,
   overlay,
   onPromote,
+  terminalReasonId,
 }: Readonly<{
   lead: Lead;
   id: string;
   cf: ReturnType<typeof useObjectCustomFields>;
   overlay: boolean;
   onPromote: () => void;
+  // The id of the ONE sentence this page prints about being closed. Every
+  // refused control points at it rather than repeating it, which is what
+  // stops a terminal lead printing the same line five times.
+  terminalReasonId: string;
 }>) {
   const t = useT();
   return (
@@ -1022,9 +1041,7 @@ function LeadActions({
           person, so the terminal lead that reaches this page is a
           disqualified one. */}
       <EditAction
-        disabledReason={
-          lead.archived_at ? t("lead.terminalDisqualified") : undefined
-        }
+        disabledReasonId={lead.archived_at ? terminalReasonId : undefined}
         label={t("record.edit")}
         notice={overlay ? t("overlay.partialWriteBack") : undefined}
         fields={[...leadEditFields, ...cf.formFields]}
@@ -1065,9 +1082,7 @@ function LeadActions({
       {!overlay && (
         <>
           <ArchiveAction
-            disabledReason={
-              lead.archived_at ? t("lead.terminalDisqualified") : undefined
-            }
+            disabledReasonId={lead.archived_at ? terminalReasonId : undefined}
             label={t("record.disqualify")}
             confirmText={t("record.disqualifyConfirm")}
             archive={async () => {
@@ -1086,9 +1101,7 @@ function LeadActions({
           <ShareAction
             recordType="lead"
             recordId={lead.id}
-            disabledReason={
-              lead.archived_at ? t("lead.terminalDisqualified") : undefined
-            }
+            disabledReasonId={lead.archived_at ? terminalReasonId : undefined}
           />
         </>
       )}
@@ -1101,6 +1114,9 @@ export function LeadScreen({ id }: Readonly<{ id: string }>) {
   const cf = useObjectCustomFields("lead");
   const queryClient = useQueryClient();
   const headingId = useId();
+  // ONE sentence about this lead being closed, minted here and pointed at by
+  // every control the closure refuses (ADR-0108 §6).
+  const terminalReasonId = useId();
   const [tab, setTab] = useState<LeadTab>("overview");
   // The seam serves update for a mirrored lead (write-back projects onto the
   // incumbent, overlay/provider_writes.go), so Edit renders in overlay too.
@@ -1196,6 +1212,7 @@ export function LeadScreen({ id }: Readonly<{ id: string }>) {
                 id={id}
                 cf={cf}
                 overlay={overlay}
+                terminalReasonId={terminalReasonId}
                 onPromote={() => setPromoteOpen(true)}
               />
             }
@@ -1206,7 +1223,20 @@ export function LeadScreen({ id }: Readonly<{ id: string }>) {
             // The readings ride the band, above the columns: they describe the
             // PROSPECT, and a strip that vanished on the History tab would
             // move the tab bar and re-flow the page under the reader.
-            band={<LeadBadges lead={lead} />}
+            band={
+              <>
+                <LeadBadges lead={lead} />
+                {/* Stated ONCE for the page. Every control the closure
+                    refuses points at this element by id, so a screen reader
+                    reaches it from each of them without the sentence being
+                    printed beside all six. */}
+                {lead.archived_at && (
+                  <p id={terminalReasonId} className="t-caption">
+                    {t("lead.terminalDisqualified")}
+                  </p>
+                )}
+              </>
+            }
           >
             {/* The bar leads the column it governs. */}
             <div style={{ marginBottom: "var(--space-4)" }}>
@@ -1225,6 +1255,7 @@ export function LeadScreen({ id }: Readonly<{ id: string }>) {
                 lead={lead}
                 id={id}
                 headingId={headingId}
+                terminalReasonId={terminalReasonId}
                 promoteOpen={promoteOpen}
                 closePromote={closePromote}
                 trigger={trigger}

--- a/frontend/src/screens/leads.tsx
+++ b/frontend/src/screens/leads.tsx
@@ -1,5 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useId, useState } from "react";
+import { useEffect, useId, useState } from "react";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
 import { ifMatch } from "../api/version";
@@ -10,11 +10,11 @@ import {
   Button,
   Card,
   Modal,
-  SectionHeader,
   SegmentedControl,
   Textarea,
   TextInput,
 } from "../design-system/atoms";
+import { RecordView } from "../design-system/composed";
 import { Select } from "../design-system/select";
 import { ProvenanceTag } from "../design-system/trust";
 import { useT } from "../i18n";
@@ -852,7 +852,6 @@ function LeadOverviewPane({
   id,
   headingId,
   promoteOpen,
-  onOpenPromote,
   closePromote,
   trigger,
   setTrigger,
@@ -867,7 +866,6 @@ function LeadOverviewPane({
   id: string;
   headingId: string;
   promoteOpen: boolean;
-  onOpenPromote: () => void;
   closePromote: () => void;
   trigger: PromoteTrigger;
   setTrigger: (trigger: PromoteTrigger) => void;
@@ -886,24 +884,9 @@ function LeadOverviewPane({
     <>
       {!lead.archived_at && !overlay && (
         <>
-          <div
-            style={{
-              marginTop: 14,
-              display: "flex",
-              gap: 8,
-              alignItems: "center",
-            }}
-          >
-            <Button
-              variant="primary"
-              disabled={!promoteEligible(lead) || promotePending}
-              onClick={onOpenPromote}
-            >
-              {t("lead.promote")}
-            </Button>
-            {!promoteEligible(lead) && (
-              <span className="t-caption">{t("lead.promoteIneligible")}</span>
-            )}
+          {/* The button moved to the header (ADR-0108 §6); the dialog it
+              opens stays here, where the promote state lives. */}
+          <div>
             <Modal
               open={promoteOpen}
               onClose={closePromote}
@@ -981,27 +964,38 @@ function LeadOverviewPane({
 // the terminal-state branch pushed that render past the complexity budget,
 // and because a header is a thing in its own right: the name, why the verbs
 // are gone when they are, and the verbs themselves.
-function LeadHeader({
+function LeadActions({
   lead,
   id,
   cf,
   overlay,
+  onPromote,
 }: Readonly<{
   lead: Lead;
   id: string;
   cf: ReturnType<typeof useObjectCustomFields>;
   overlay: boolean;
+  onPromote: () => void;
 }>) {
   const t = useT();
   return (
-    <div className="list-head">
-      {/* The lead's name is this page's name: the shell's page head
-            yields to a record route and prints only the trail that leads
-            here, so without this the page would carry no heading at all. */}
-      <SectionHeader
-        level={1}
-        title={lead.full_name ?? lead.email ?? t("nav.leads")}
-      />
+    <>
+      {/* Promote is the page's ONE primary action and it leads, in the header
+          where a reader looks for the verb (ADR-0108 §6). Ineligibility is
+          stated on the control itself rather than as a sentence beside it —
+          a disabled button whose reason is elsewhere is a dead button. */}
+      {!lead.archived_at && (
+        <Button
+          variant="primary"
+          disabled={!promoteEligible(lead)}
+          title={
+            promoteEligible(lead) ? undefined : t("lead.promoteIneligible")
+          }
+          onClick={onPromote}
+        >
+          {t("lead.promote")}
+        </Button>
+      )}
       {/* A promoted or disqualified lead is archived and terminal —
             the backend rejects edit/disqualify/promote/score-override on
             it, so those affordances would only 404. STATE-4a wants the
@@ -1073,7 +1067,7 @@ function LeadHeader({
           <ShareAction recordType="lead" recordId={lead.id} />
         </>
       )}
-    </div>
+    </>
   );
 }
 
@@ -1146,15 +1140,51 @@ export function LeadScreen({ id }: Readonly<{ id: string }>) {
       ? problemMessageOf(promote.error, t)
       : null;
 
+  // A promoted lead IS the person it became — the record moved, so the page
+  // follows it (ADR-0108 §1). Until now this only happened as the tail of a
+  // promote you had just performed, so revisiting or deep-linking a promoted
+  // lead landed on a read-only husk of a record that exists elsewhere.
+  const promotedPersonId = leadQuery.data?.promoted_person_id;
+  useEffect(() => {
+    if (promotedPersonId) {
+      navigate({ screen: "contacts", id: promotedPersonId });
+    }
+  }, [promotedPersonId]);
+
   return (
     <div className="wrap lead-surface">
       <QueryGate query={leadQuery}>
         {(lead) => (
-          <Card as="div" className="lead-detail">
-            <LeadHeader lead={lead} id={id} cf={cf} overlay={overlay} />
-            <LeadBadges lead={lead} />
-            {lead.email && <p className="t-mono">{lead.email}</p>}
-            <div style={{ marginBottom: 16 }}>
+          <RecordView
+            name={lead.full_name ?? lead.email ?? t("nav.leads")}
+            avatarSrc={null}
+            // The "Lead" marker rides the identity, not a badge among badges:
+            // a reader has to know this is a prospect and not a contact
+            // BEFORE they read anything else about them (ADR-0108 §1).
+            subtitle={<Badge tone="accent">{t("lead.marker")}</Badge>}
+            pulse={
+              lead.email ? <span className="t-mono">{lead.email}</span> : null
+            }
+            actions={
+              <LeadActions
+                lead={lead}
+                id={id}
+                cf={cf}
+                overlay={overlay}
+                onPromote={() => setPromoteOpen(true)}
+              />
+            }
+            actionsInline
+            // Required by the shell for timeline timestamps; this page passes
+            // no timeline, so the viewer's own zone is the honest default.
+            zone={Intl.DateTimeFormat().resolvedOptions().timeZone}
+            // The readings ride the band, above the columns: they describe the
+            // PROSPECT, and a strip that vanished on the History tab would
+            // move the tab bar and re-flow the page under the reader.
+            band={<LeadBadges lead={lead} />}
+          >
+            {/* The bar leads the column it governs. */}
+            <div style={{ marginBottom: "var(--space-4)" }}>
               <SegmentedControl
                 options={LEAD_TABS}
                 value={tab}
@@ -1171,7 +1201,6 @@ export function LeadScreen({ id }: Readonly<{ id: string }>) {
                 id={id}
                 headingId={headingId}
                 promoteOpen={promoteOpen}
-                onOpenPromote={() => setPromoteOpen(true)}
                 closePromote={closePromote}
                 trigger={trigger}
                 setTrigger={setTrigger}
@@ -1196,7 +1225,7 @@ export function LeadScreen({ id }: Readonly<{ id: string }>) {
               <RecordHistoryTab kind="lead" id={lead.id} />
             )}
             {tab === "history" && overlay && <OverlayUnavailable />}
-          </Card>
+          </RecordView>
         )}
       </QueryGate>
     </div>

--- a/frontend/src/screens/leads.tsx
+++ b/frontend/src/screens/leads.tsx
@@ -413,12 +413,20 @@ function ScoreBreakdown({ id, lead }: Readonly<{ id: string; lead: Lead }>) {
   }
   const current = explain.data?.current;
   if (!explain.data?.explained || !current) {
-    // No retained decomposition. The reasons a lead scores nothing are still
+    // No retained decomposition. For a score of ZERO the reasons are still
     // derivable from the lead in hand, and they are what the reader came for
     // — "this score predates the breakdown" answers a question nobody asked
     // and leaves a 0 looking like a bad prospect rather than an unassessed
     // one (ADR-0108 §4).
-    return <ScoreShortfall lead={lead} />;
+    //
+    // A NON-zero score is a different case: something did count, this client
+    // cannot say what, and listing what is missing would state the opposite
+    // of the truth. It says only that the breakdown is not stored yet.
+    return lead.score === 0 ? (
+      <ScoreShortfall lead={lead} />
+    ) : (
+      <span className="t-caption">{t("lead.scoreNotStoredYet")}</span>
+    );
   }
   const factors = current.factors ?? [];
   // Under a Commercial Judgement override the displayed score is the

--- a/frontend/src/screens/leads.tsx
+++ b/frontend/src/screens/leads.tsx
@@ -791,12 +791,12 @@ function LeadLifecycle({
             </div>
           </div>
         ) : (
-          <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
-            <span className="t-caption">{t("lead.machineComputed")}</span>
-            <Button small onClick={() => setOverriding(true)}>
-              {t("lead.overrideScore")}
-            </Button>
-          </div>
+          // "Machine-computed score" was a label with no value beside it,
+          // naming what the badge above already says. The override is a rare
+          // action and stands alone.
+          <Button small onClick={() => setOverriding(true)}>
+            {t("lead.overrideScore")}
+          </Button>
         )}
       </div>
 
@@ -996,59 +996,58 @@ function LeadActions({
           {t("lead.promote")}
         </Button>
       )}
-      {/* A promoted or disqualified lead is archived and terminal —
-            the backend rejects edit/disqualify/promote/score-override on
-            it, so those affordances would only 404. STATE-4a wants the
-            controls disabled WITH the reason rather than hidden, and
-            EditAction/ArchiveAction/ShareAction carry no reason prop to
-            do that with; until they do, the page at least SAYS why the
-            actions are gone instead of leaving the reader to guess
-            (ADR-0108 §6, tracked as issue 1325). */}
-      {lead.archived_at && (
-        <span className="t-caption">
-          {lead.status === "promoted"
-            ? t("lead.terminalPromoted")
-            : t("lead.terminalDisqualified")}
-        </span>
-      )}
-      {!lead.archived_at && (
-        <EditAction
-          label={t("record.edit")}
-          notice={overlay ? t("overlay.partialWriteBack") : undefined}
-          fields={[...leadEditFields, ...cf.formFields]}
-          record={{
-            id: lead.id,
-            version: lead.version,
-            full_name: lead.full_name ?? "",
-            email: lead.email ?? "",
-            title: lead.title ?? "",
-            company_name: lead.company_name ?? "",
-            candidate_org_key: lead.candidate_org_key ?? "",
-            ...cf.recordSlice(lead),
-          }}
-          update={async (values) => {
-            const { data, error } = await api.PATCH("/leads/{id}", {
-              params: {
-                path: { id },
-                ...ifMatch(lead.version),
-              },
-              body: {
-                ...mapLeadUpdate(values),
-                ...cf.toBody(values),
-              },
-            });
-            if (error) {
-              throwProblem(error);
-            }
-            return data;
-          }}
-          invalidate="leads"
-          recordKey="lead"
-        />
-      )}
-      {!lead.archived_at && !overlay && (
+      {/* A terminal lead keeps its controls, DISABLED with the reason
+          (STATE-4a): the reason is the information, and hiding the control
+          hides a fact the reader needs. A promoted lead redirects to its
+          person, so the terminal lead that reaches this page is a
+          disqualified one. */}
+      <EditAction
+        disabledReason={
+          lead.archived_at ? t("lead.terminalDisqualified") : undefined
+        }
+        label={t("record.edit")}
+        notice={overlay ? t("overlay.partialWriteBack") : undefined}
+        fields={[...leadEditFields, ...cf.formFields]}
+        record={{
+          id: lead.id,
+          version: lead.version,
+          full_name: lead.full_name ?? "",
+          email: lead.email ?? "",
+          title: lead.title ?? "",
+          company_name: lead.company_name ?? "",
+          candidate_org_key: lead.candidate_org_key ?? "",
+          ...cf.recordSlice(lead),
+        }}
+        update={async (values) => {
+          const { data, error } = await api.PATCH("/leads/{id}", {
+            params: {
+              path: { id },
+              ...ifMatch(lead.version),
+            },
+            body: {
+              ...mapLeadUpdate(values),
+              ...cf.toBody(values),
+            },
+          });
+          if (error) {
+            throwProblem(error);
+          }
+          return data;
+        }}
+        invalidate="leads"
+        recordKey="lead"
+      />
+      {/* The overlay seam refuses disqualify (a cross-type lifecycle
+          transition) and share (a grant probes a native row a mirror lead
+          does not have), so in overlay these are genuinely UNSUPPORTED
+          rather than state-blocked — a different STATE-4a cause, and the
+          answer for that one is absence. */}
+      {!overlay && (
         <>
           <ArchiveAction
+            disabledReason={
+              lead.archived_at ? t("lead.terminalDisqualified") : undefined
+            }
             label={t("record.disqualify")}
             confirmText={t("record.disqualifyConfirm")}
             archive={async () => {
@@ -1064,7 +1063,13 @@ function LeadActions({
             recordKey="lead"
             onArchived={() => navigate({ screen: "leads" })}
           />
-          <ShareAction recordType="lead" recordId={lead.id} />
+          <ShareAction
+            recordType="lead"
+            recordId={lead.id}
+            disabledReason={
+              lead.archived_at ? t("lead.terminalDisqualified") : undefined
+            }
+          />
         </>
       )}
     </>

--- a/frontend/src/screens/leads.tsx
+++ b/frontend/src/screens/leads.tsx
@@ -336,14 +336,17 @@ function isOpenStatus(status: Lead["status"]): status is LeadOpenStatus {
 // with the decay shown as arithmetic rather than asserted.
 //
 // The read serves what was STORED with the score, so a lead scored before
-// this shipped honestly says it has no explanation yet instead of showing
-// an empty list, which would read as "nothing contributed".
 // The decision-maker title pattern the score uses (formulas §3.1). Mirrored
 // here ONLY to say why a title earned nothing; the score itself is computed
 // server-side and this never adds to it.
 const DECISION_MAKER_TITLE =
   /(chief|vp|head|director|founder|owner|c[a-z]o)\b/i;
 const HIGH_INTENT_SOURCES = new Set(["inbound", "webform", "referral"]);
+// The server PENALISES these five points rather than merely granting nothing
+// (leadscore.go). Calling that "no buying intent on its own" would soften a
+// subtraction into a neutral, which is a different and kinder claim than the
+// model made.
+const LOW_INTENT_SOURCES = new Set(["import", "crawl"]);
 
 // What a lead is missing, in the model's own terms — shown when no retained
 // decomposition exists yet.
@@ -361,7 +364,13 @@ function ScoreShortfall({ lead }: Readonly<{ lead: Lead }>) {
   } else if (!DECISION_MAKER_TITLE.test(lead.title)) {
     missing.push(t("lead.shortfall.titleNotSenior", { title: lead.title }));
   }
-  if (!lead.source || !HIGH_INTENT_SOURCES.has(lead.source)) {
+  if (!lead.source) {
+    // Split exactly as the title pair above is: interpolating an absent value
+    // would print "Came in as undefined" at a rep.
+    missing.push(t("lead.shortfall.noSource"));
+  } else if (LOW_INTENT_SOURCES.has(lead.source)) {
+    missing.push(t("lead.shortfall.sourcePenalised", { source: lead.source }));
+  } else if (!HIGH_INTENT_SOURCES.has(lead.source)) {
     missing.push(t("lead.shortfall.sourceNoIntent", { source: lead.source }));
   }
   // Deliberately NOT a claim that no reply or meeting exists. Engagement lives
@@ -574,6 +583,7 @@ function LeadOwner({
         <Button
           small
           disabled={pending}
+          reason={lead.archived_at ? t("lead.terminalDisqualified") : undefined}
           aria-expanded={picking}
           aria-controls={pickerId}
           onClick={() => setPicking(!picking)}
@@ -794,7 +804,13 @@ function LeadLifecycle({
           // "Machine-computed score" was a label with no value beside it,
           // naming what the badge above already says. The override is a rare
           // action and stands alone.
-          <Button small onClick={() => setOverriding(true)}>
+          <Button
+            small
+            reason={
+              lead.archived_at ? t("lead.terminalDisqualified") : undefined
+            }
+            onClick={() => setOverriding(true)}
+          >
             {t("lead.overrideScore")}
           </Button>
         )}
@@ -952,9 +968,14 @@ function LeadOverviewPane({
               </div>
             </Modal>
           </div>
-          <LeadLifecycle lead={lead} id={id} onChanged={onLifecycleChanged} />
         </>
       )}
+      {/* Outside the terminal gate: a disqualified lead still has a score,
+          a status and an owner, and a reader who opens it came to see them.
+          Hiding the whole body left the page blank below the tab bar, which
+          reads as a broken render rather than a closed lead. The controls
+          inside it are individually disabled by their own state. */}
+      <LeadLifecycle lead={lead} id={id} onChanged={onLifecycleChanged} />
       <CustomFieldsCard object="lead" record={lead} />
     </>
   );
@@ -987,8 +1008,7 @@ function LeadActions({
       {!lead.archived_at && (
         <Button
           variant="primary"
-          disabled={!promoteEligible(lead)}
-          title={
+          reason={
             promoteEligible(lead) ? undefined : t("lead.promoteIneligible")
           }
           onClick={onPromote}

--- a/frontend/src/screens/leads.tsx
+++ b/frontend/src/screens/leads.tsx
@@ -31,7 +31,6 @@ import {
   useSorMode,
   useViewerId,
 } from "./common";
-import { RecordContextPanel } from "./context";
 import { CreateAction, type CreateField } from "./create";
 import { CustomFieldsCard } from "./customfields.card";
 import { useObjectCustomFields } from "./customfields.form";
@@ -339,7 +338,57 @@ function isOpenStatus(status: Lead["status"]): status is LeadOpenStatus {
 // The read serves what was STORED with the score, so a lead scored before
 // this shipped honestly says it has no explanation yet instead of showing
 // an empty list, which would read as "nothing contributed".
-function ScoreBreakdown({ id }: Readonly<{ id: string }>) {
+// The decision-maker title pattern the score uses (formulas §3.1). Mirrored
+// here ONLY to say why a title earned nothing; the score itself is computed
+// server-side and this never adds to it.
+const DECISION_MAKER_TITLE =
+  /(chief|vp|head|director|founder|owner|c[a-z]o)\b/i;
+const HIGH_INTENT_SOURCES = new Set(["inbound", "webform", "referral"]);
+
+// What a lead is missing, in the model's own terms — shown when no retained
+// decomposition exists yet.
+//
+// A zero score and an unscored lead look identical as a number and mean
+// opposite things: "we assessed this and it earns nothing" versus "nothing
+// has been assessed". A rep reads both as a bad prospect, and only one of
+// them is (ADR-0108 §4). These reasons are always derivable, so the page
+// states them rather than explaining our own storage history.
+function ScoreShortfall({ lead }: Readonly<{ lead: Lead }>) {
+  const t = useT();
+  const missing: string[] = [];
+  if (!lead.title) {
+    missing.push(t("lead.shortfall.noTitle"));
+  } else if (!DECISION_MAKER_TITLE.test(lead.title)) {
+    missing.push(t("lead.shortfall.titleNotSenior", { title: lead.title }));
+  }
+  if (!lead.source || !HIGH_INTENT_SOURCES.has(lead.source)) {
+    missing.push(t("lead.shortfall.sourceNoIntent", { source: lead.source }));
+  }
+  // Behavioral points are the only ones that move after capture, so this line
+  // is the actionable one: it names what would change the score.
+  missing.push(t("lead.shortfall.noEngagement"));
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: "var(--space-1)",
+      }}
+    >
+      <span className="t-caption">{t("lead.shortfall.lead")}</span>
+      <ul style={{ listStyle: "none", margin: 0, padding: 0 }}>
+        {missing.map((reason) => (
+          <li key={reason} className="t-caption">
+            {reason}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function ScoreBreakdown({ id, lead }: Readonly<{ id: string; lead: Lead }>) {
   const t = useT();
   const explain = useQuery({
     queryKey: ["lead", id, "score"],
@@ -364,7 +413,12 @@ function ScoreBreakdown({ id }: Readonly<{ id: string }>) {
   }
   const current = explain.data?.current;
   if (!explain.data?.explained || !current) {
-    return <span className="t-caption">{t("lead.scoreNotYetExplained")}</span>;
+    // No retained decomposition. The reasons a lead scores nothing are still
+    // derivable from the lead in hand, and they are what the reader came for
+    // — "this score predates the breakdown" answers a question nobody asked
+    // and leaves a 0 looking like a bad prospect rather than an unassessed
+    // one (ADR-0108 §4).
+    return <ScoreShortfall lead={lead} />;
   }
   const factors = current.factors ?? [];
   // Under a Commercial Judgement override the displayed score is the
@@ -466,12 +520,16 @@ function LeadOwner({
   const pickerId = useId();
   const [picking, setPicking] = useState(false);
   const roster = useRoster("user", picking);
-  // The viewer is excluded as well as the current owner: "Assign to me" sits
-  // right beside this picker, and offering the same person under a second
-  // label would run one mutation from two controls that read differently.
-  const candidates = (roster.data ?? []).filter(
-    (entry) => entry.id !== lead.owner_id && entry.id !== meId,
-  );
+  // Everyone but the current owner, with the VIEWER first: assigning to
+  // yourself is the common case on a small team, and it is now an option in
+  // this one control rather than a button of its own (ADR-0108 §5).
+  const candidates = (roster.data ?? [])
+    .filter((entry) => entry.id !== lead.owner_id)
+    .sort((a, b) => {
+      if (a.id === meId) return -1;
+      if (b.id === meId) return 1;
+      return 0;
+    });
 
   return (
     <div
@@ -488,20 +546,20 @@ function LeadOwner({
           alignItems: "center",
         }}
       >
-        <span className="t-caption">
-          {lead.owner_id ? t("lead.ownerLabel") : t("lead.unassigned")}
-        </span>
-        {lead.owner_id &&
-          (lead.owner_id === meId ? (
+        <span className="t-caption">{t("lead.ownerLabel")}</span>
+        {lead.owner_id ? (
+          lead.owner_id === meId ? (
             <span className="t-caption">{t("lead.ownerYou")}</span>
           ) : (
             <EntityRef kind="user" id={lead.owner_id} />
-          ))}
-        {meId && meId !== lead.owner_id && (
-          <Button small disabled={pending} onClick={() => onAssign(meId)}>
-            {t("lead.assignToMe")}
-          </Button>
+          )
+        ) : (
+          <span className="t-caption">{t("lead.unassigned")}</span>
         )}
+        {/* ONE control, not a button that assigns to you beside a button
+            that reveals a picker nobody can see until they press it
+            (ADR-0108 §5). The viewer is the first option because
+            self-assignment is the common case on a small team. */}
         <Button
           small
           disabled={pending}
@@ -509,7 +567,7 @@ function LeadOwner({
           aria-controls={pickerId}
           onClick={() => setPicking(!picking)}
         >
-          {t("lead.assignToSomeone")}
+          {t("lead.assign")}
         </Button>
       </div>
 
@@ -542,11 +600,15 @@ function LeadOwner({
               disabled={pending}
               options={candidates.map((entry) => ({
                 value: entry.id,
-                // A user with no display name still has to be pickable, so the
-                // id stands in rather than rendering a blank row.
+                // The viewer reads as "Me" — a rep scanning this list looks
+                // for themselves, not for their own name among colleagues'.
+                // A user with no display name still has to be pickable, so
+                // the id stands in rather than rendering a blank row.
                 label:
-                  ("display_name" in entry ? entry.display_name : null) ??
-                  entry.id,
+                  entry.id === meId
+                    ? t("lead.assignToMe")
+                    : (("display_name" in entry ? entry.display_name : null) ??
+                      entry.id),
               }))}
               onChange={(value) => {
                 onAssign(value);
@@ -641,7 +703,7 @@ function LeadLifecycle({
         }}
       >
         <span className="t-caption">{t("lead.explainScore")}</span>
-        <ScoreBreakdown id={id} />
+        <ScoreBreakdown id={id} lead={lead} />
         {lead.score_override_reason ? (
           <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
             <p>
@@ -900,8 +962,107 @@ function LeadOverviewPane({
         </>
       )}
       <CustomFieldsCard object="lead" record={lead} />
-      <RecordContextPanel entityType="lead" id={lead.id} />
     </>
+  );
+}
+
+// The lead's identity row and its verbs. Extracted from LeadScreen because
+// the terminal-state branch pushed that render past the complexity budget,
+// and because a header is a thing in its own right: the name, why the verbs
+// are gone when they are, and the verbs themselves.
+function LeadHeader({
+  lead,
+  id,
+  cf,
+  overlay,
+}: Readonly<{
+  lead: Lead;
+  id: string;
+  cf: ReturnType<typeof useObjectCustomFields>;
+  overlay: boolean;
+}>) {
+  const t = useT();
+  return (
+    <div className="list-head">
+      {/* The lead's name is this page's name: the shell's page head
+            yields to a record route and prints only the trail that leads
+            here, so without this the page would carry no heading at all. */}
+      <SectionHeader
+        level={1}
+        title={lead.full_name ?? lead.email ?? t("nav.leads")}
+      />
+      {/* A promoted or disqualified lead is archived and terminal —
+            the backend rejects edit/disqualify/promote/score-override on
+            it, so those affordances would only 404. STATE-4a wants the
+            controls disabled WITH the reason rather than hidden, and
+            EditAction/ArchiveAction/ShareAction carry no reason prop to
+            do that with; until they do, the page at least SAYS why the
+            actions are gone instead of leaving the reader to guess
+            (ADR-0108 §6, tracked as issue 1325). */}
+      {lead.archived_at && (
+        <span className="t-caption">
+          {lead.status === "promoted"
+            ? t("lead.terminalPromoted")
+            : t("lead.terminalDisqualified")}
+        </span>
+      )}
+      {!lead.archived_at && (
+        <EditAction
+          label={t("record.edit")}
+          notice={overlay ? t("overlay.partialWriteBack") : undefined}
+          fields={[...leadEditFields, ...cf.formFields]}
+          record={{
+            id: lead.id,
+            version: lead.version,
+            full_name: lead.full_name ?? "",
+            email: lead.email ?? "",
+            title: lead.title ?? "",
+            company_name: lead.company_name ?? "",
+            candidate_org_key: lead.candidate_org_key ?? "",
+            ...cf.recordSlice(lead),
+          }}
+          update={async (values) => {
+            const { data, error } = await api.PATCH("/leads/{id}", {
+              params: {
+                path: { id },
+                ...ifMatch(lead.version),
+              },
+              body: {
+                ...mapLeadUpdate(values),
+                ...cf.toBody(values),
+              },
+            });
+            if (error) {
+              throwProblem(error);
+            }
+            return data;
+          }}
+          invalidate="leads"
+          recordKey="lead"
+        />
+      )}
+      {!lead.archived_at && !overlay && (
+        <>
+          <ArchiveAction
+            label={t("record.disqualify")}
+            confirmText={t("record.disqualifyConfirm")}
+            archive={async () => {
+              const { data, error } = await api.DELETE("/leads/{id}", {
+                params: { path: { id } },
+              });
+              if (error) {
+                throwProblem(error, t);
+              }
+              return data;
+            }}
+            invalidate="leads"
+            recordKey="lead"
+            onArchived={() => navigate({ screen: "leads" })}
+          />
+          <ShareAction recordType="lead" recordId={lead.id} />
+        </>
+      )}
+    </div>
   );
 }
 
@@ -979,76 +1140,7 @@ export function LeadScreen({ id }: Readonly<{ id: string }>) {
       <QueryGate query={leadQuery}>
         {(lead) => (
           <Card as="div" className="lead-detail">
-            <div className="list-head">
-              {/* The lead's name is this page's name: the shell's page head
-                  yields to a record route and prints only the trail that leads
-                  here, so without this the page would carry no heading at all. */}
-              <SectionHeader
-                level={1}
-                title={lead.full_name ?? lead.email ?? t("nav.leads")}
-                sub={t("lead.segregated")}
-              />
-              {/* A promoted or disqualified lead is archived and terminal —
-                  the backend rejects edit/disqualify/promote/score-override on
-                  it, so those affordances would only 404. Read-only past that
-                  point. */}
-              {!lead.archived_at && (
-                <EditAction
-                  label={t("record.edit")}
-                  notice={overlay ? t("overlay.partialWriteBack") : undefined}
-                  fields={[...leadEditFields, ...cf.formFields]}
-                  record={{
-                    id: lead.id,
-                    version: lead.version,
-                    full_name: lead.full_name ?? "",
-                    email: lead.email ?? "",
-                    title: lead.title ?? "",
-                    company_name: lead.company_name ?? "",
-                    candidate_org_key: lead.candidate_org_key ?? "",
-                    ...cf.recordSlice(lead),
-                  }}
-                  update={async (values) => {
-                    const { data, error } = await api.PATCH("/leads/{id}", {
-                      params: {
-                        path: { id },
-                        ...ifMatch(lead.version),
-                      },
-                      body: {
-                        ...mapLeadUpdate(values),
-                        ...cf.toBody(values),
-                      },
-                    });
-                    if (error) {
-                      throwProblem(error);
-                    }
-                    return data;
-                  }}
-                  invalidate="leads"
-                  recordKey="lead"
-                />
-              )}
-              {!lead.archived_at && !overlay && (
-                <>
-                  <ArchiveAction
-                    label={t("record.disqualify")}
-                    confirmText={t("record.disqualifyConfirm")}
-                    archive={async () => {
-                      const { data, error } = await api.DELETE("/leads/{id}", {
-                        params: { path: { id } },
-                      });
-                      if (error) {
-                        throwProblem(error, t);
-                      }
-                      return data;
-                    }}
-                    invalidate="leads"
-                    recordKey="lead"
-                    onArchived={() => navigate({ screen: "leads" })}
-                  />
-                  <ShareAction recordType="lead" recordId={lead.id} />
-                </>
-              )}
-            </div>
+            <LeadHeader lead={lead} id={id} cf={cf} overlay={overlay} />
             <LeadBadges lead={lead} />
             {lead.email && <p className="t-mono">{lead.email}</p>}
             <div style={{ marginBottom: 16 }}>

--- a/frontend/src/screens/leads.tsx
+++ b/frontend/src/screens/leads.tsx
@@ -364,9 +364,12 @@ function ScoreShortfall({ lead }: Readonly<{ lead: Lead }>) {
   if (!lead.source || !HIGH_INTENT_SOURCES.has(lead.source)) {
     missing.push(t("lead.shortfall.sourceNoIntent", { source: lead.source }));
   }
-  // Behavioral points are the only ones that move after capture, so this line
-  // is the actionable one: it names what would change the score.
-  missing.push(t("lead.shortfall.noEngagement"));
+  // Deliberately NOT a claim that no reply or meeting exists. Engagement lives
+  // in linked activities the client never reads, and a decayed reply can round
+  // to nothing while still being a reply — "no reply yet" would be a statement
+  // about the prospect this page cannot support. What it CAN say is what
+  // would move the score, which is the actionable half anyway.
+  missing.push(t("lead.shortfall.engagementMoves"));
 
   return (
     <div

--- a/frontend/src/screens/share.tsx
+++ b/frontend/src/screens/share.tsx
@@ -86,8 +86,7 @@ export function ShareAction({
   const t = useT();
   return (
     <Button
-      disabled={Boolean(disabledReason)}
-      title={disabledReason}
+      reason={disabledReason}
       small
       data-testid="share-record"
       onClick={() =>

--- a/frontend/src/screens/share.tsx
+++ b/frontend/src/screens/share.tsx
@@ -72,7 +72,7 @@ function isRecordType(value: string): value is RecordType {
 export function ShareAction({
   recordType,
   recordId,
-  disabledReason,
+  disabledReasonId,
 }: Readonly<{
   recordType: RecordType;
   recordId: string;
@@ -81,12 +81,12 @@ export function ShareAction({
   // rather than permission — an archived record — stays visible and
   // disabled WITH the reason, because the reason is the information and
   // hiding the control hides a fact the reader needs.
-  disabledReason?: string;
+  disabledReasonId?: string;
 }>) {
   const t = useT();
   return (
     <Button
-      reason={disabledReason}
+      reasonId={disabledReasonId}
       small
       data-testid="share-record"
       onClick={() =>

--- a/frontend/src/screens/share.tsx
+++ b/frontend/src/screens/share.tsx
@@ -72,10 +72,22 @@ function isRecordType(value: string): value is RecordType {
 export function ShareAction({
   recordType,
   recordId,
-}: Readonly<{ recordType: RecordType; recordId: string }>) {
+  disabledReason,
+}: Readonly<{
+  recordType: RecordType;
+  recordId: string;
+  // Why this action is unavailable, when it is. STATE-4a settles the
+  // absent-vs-disabled question by CAUSE: a control blocked by STATE
+  // rather than permission — an archived record — stays visible and
+  // disabled WITH the reason, because the reason is the information and
+  // hiding the control hides a fact the reader needs.
+  disabledReason?: string;
+}>) {
   const t = useT();
   return (
     <Button
+      disabled={Boolean(disabledReason)}
+      title={disabledReason}
       small
       data-testid="share-record"
       onClick={() =>


### PR DESCRIPTION
Implements ratified decision **ADR-0108 / A159** ([foundation#1308](https://github.com/gradionhq/margince-foundation/pull/1308)), which closed `LEADS-AC-OPEN-1`.

## Why

Every acceptance criterion this product has for leads was written for the **list**. A detail page was built anyway — a row has to click through to something — and assembled from whatever those ACs happened to say. Lars reported the result from the running product: the list's segregation notice printed under every prospect's name; a score of 0 answered with *"This score predates the breakdown"* where the reason belonged; an evidence panel citing the lead as evidence for itself with a raw `lead:<uuid>`; and status, score and ownership sharing one grey panel with ownership as two competing buttons.

## What changed

**The score explains itself honestly.** A zero states the reasons it is zero — they are always derivable from the lead in hand. A non-zero score with no stored breakdown says only that, because something counted and this client cannot say what. It asserts nothing about engagement, which lives in linked activities the page never reads.

**The page uses the record shell.** `RecordView` replaces the hand-rolled card: identity with a "Lead" marker, Promote as the only primary action in the header, badges as a readings band. A promoted lead redirects to the person it became.

**One Assign control** replaces the button-plus-hidden-picker pair, with the viewer listed first.

**A terminal lead keeps its controls, disabled with the reason** (STATE-4a), and the evidence panel is omitted rather than rendered empty — the context walk has no lead arm, so it could only ever cite the lead as evidence for itself.

## Review found four things worth having

An adversarial pass and a craft pass between them caught: a **blocker** where the panel claimed "nothing counts" for a lead scoring 72; a second where a lead with no source rendered `Came in as "undefined"`; the mirrored source list flattening a *penalty* into a neutral; and — the one I'd have shipped — `title` on a disabled button reaching no screen reader at all, which is the STATE-4a failure the change existed to fix, in a new costume.

`Button` now carries `reason` and `reasonId` the way `Switch` carries `reason`, wired with `aria-describedby`. Six controls use it. The README documents it as the third accessibility-wired denial.

Two defects the **render** caught that no test did: a disqualified lead showed a blank page below the tab bar, and then, once fixed, printed the same sentence six times across an overflowing header. Stories now cover the states this change introduces, which is the cheapest place to see them.

## Verification

`make check-fe` green. 39 unit tests. `make fe-uat` renders five lead stories clean; the one unrelated failure (`screens-webhooks--rotate-secret-revealed`) reproduces on untouched `origin/main`.

Deferred: **#1325** (the other record screens took the same hiding shortcut and want the same sweep), **#1323** (the evidence chip's raw-uuid source, backend).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redesigns the Lead page to use `RecordView`, tell the truth about score state, and lead with Promote in the header (ADR‑0108/A159). Old page misled on 0/non‑0 scores, split assignment across two controls, and hid or silently removed actions; new page explains a zero via lead shortfalls, says “breakdown not stored yet” for non‑zero, redirects promoted leads, and keeps terminal actions visible, disabled, and accessible with one shared reason.

- Adopts `RecordView`: identity carries a “Lead” marker, badges ride the band, email shows as pulse, and the terminal notice prints once and is referenced by controls via `reasonId`; drops the self‑referential context panel.
- Promote moves to the header with its ineligibility reason on the button (wired with `aria-describedby`); a promoted lead redirects to its person.
- Consolidates assignment into one Assign control with the viewer first; owner shows “You”; Edit/Disqualify/Share/Assign/Override disable against the shared terminal notice, while overlay leaves Disqualify/Share absent.
- Adds `reason` and `reasonId` to `Button`; updates `EditAction`, `ArchiveAction`, and `ShareAction` to use `reasonId` instead of `title` so disabled controls announce their reason.
- Score panel: zero shows shortfalls (title/source plus “engagement moves”), non‑zero without a stored breakdown says “breakdown not stored yet”; removes the “Machine‑computed score” label.
- Fixes “Came in as undefined,” removes “nothing counts” for non‑zero scores, and prevents the terminal notice from repeating or leaving the page blank below the tabs.
- Adds stories and tests for zero/non‑zero/explained, disqualified disabled controls, promoted‑redirect, and unified assign; updates i18n keys in `en`, `de`, and `vi`. No migration required; use `reason`/`reasonId` instead of `title` when disabling actions.

<sup>Written for commit 8a9a1ac103ac0430a518e62bbf3480715055ef20. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1352?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

