### PR TITLE
fix(siteread): a mega-menu no longer eats the profile lane's evidence budget

### DIFF
--- a/backend/internal/compose/siteboilerplate.go
+++ b/backend/internal/compose/siteboilerplate.go
@@ -1,0 +1,287 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// Navigation is not evidence, and on a mega-menu site it is most of what the
+// profile lane gets to read.
+//
+// Every page's excerpt is capped from its START (profileExcerptPages), and a
+// large B2B site opens each page with the same header, mega-menu and language
+// switcher. The budget is then spent before the page's own prose begins: on
+// algolia.com the /about excerpt is still listing "Auto Parts, B2B Commerce,
+// Ecommerce, Fashion, Grocery" at the cut, and the profile came back with two
+// fields out of fifteen. Sites without that chrome — bestit.de, admetrics.io —
+// return twelve to fifteen from the same budget.
+//
+// The fix needs no model call and no extra fetch, because the crawl already
+// holds the whole corpus: text that appears near-verbatim at the head of most
+// pages of one site is chrome BY DEFINITION, and can be measured. Nothing is
+// inferred about what navigation looks like; the repetition is the evidence.
+//
+// Deliberately conservative. It only trims a COMMON PREFIX, only when several
+// pages share it, and it always leaves the page's own text alone — a page that
+// happens to be short, or a site with no shared header, passes through
+// untouched. Over-trimming would destroy real evidence, and a missing fact is
+// harder to notice than a noisy one.
+
+import (
+	"strings"
+	"unicode/utf8"
+)
+
+const (
+	// boilerplateMinPages is how many pages must agree before a shared
+	// opening counts as chrome. Two pages can share an opening by accident
+	// — a locale pair, or two pages of one template — and trimming on that
+	// evidence would cut real text from a small site.
+	boilerplateMinPages = 4
+	// boilerplateMinShare is the fraction of pages that must carry the
+	// prefix. A menu is on nearly every page; a section header is not.
+	boilerplateMinShare = 0.6
+	// boilerplateMinRunes is the shortest prefix worth removing. Below
+	// this the win is noise and the risk of eating a real sentence is real.
+	boilerplateMinRunes = 200
+	// boilerplateMinRemainderRunes is how much a page must retain after the
+	// prefix comes off to count as still carrying content. Below this the
+	// page is a stub, and a prefix that stubs nearly every page is not a
+	// header -- it is the pages being near-identical.
+	boilerplateMinRemainderRunes = 120
+	// boilerplateMaxShare bounds how much of a page the prefix may be. A
+	// "shared prefix" covering ALL of a page means the pages are near
+	// duplicates, not that they share a header, and cutting it would leave
+	// nothing to read.
+	//
+	// Set on what SURVIVES rather than on how big the block is: algolia's
+	// mega-menu is legitimately most of a page, and refusing to cut it is
+	// refusing to fix the only case that needs fixing. What must not
+	// happen is every page being reduced to a stub, which is what
+	// near-identical pages produce.
+	boilerplateMaxStubShare = 0.5
+	// boilerplateMinSurvivingRunes is how much of a page must remain after
+	// the shared run is cut for the cut to be worth making. Algolia keeps
+	// ~5,800 runes; a page left with a few hundred was never a page with a
+	// header, it was a page that repeats its neighbours.
+	boilerplateMinSurvivingRunes = 400
+)
+
+// stripSharedPrefix removes the navigation chrome that opens most of a site's
+// pages, so the profile excerpt spends its budget on the company's own words.
+//
+// Returns the pages in the same order, with Text trimmed where a shared
+// opening was found. The input is not modified.
+func stripSharedPrefix(pages []crawlPage) []crawlPage {
+	out := make([]crawlPage, len(pages))
+	copy(out, pages)
+	if len(pages) < boilerplateMinPages {
+		return out
+	}
+
+	prefix := sharedOpening(pages)
+	if utf8.RuneCountInString(prefix) < boilerplateMinRunes {
+		return out
+	}
+
+	for i, page := range out {
+		// The block may sit behind the page's own title, so cut it out
+		// wherever it starts rather than only at rune zero.
+		at := strings.Index(page.Text, prefix)
+		if at < 0 {
+			continue
+		}
+		// Only a block at the TOP is chrome. The same text found deep in a
+		// page is that page's own content -- near-identical pages share
+		// long passages, and cutting one out of the middle mangles the
+		// prose instead of removing a menu.
+		if utf8.RuneCountInString(page.Text[:at]) > chromeSearchRunes {
+			continue
+		}
+		trimmed := strings.TrimSpace(page.Text[:at] + " " + page.Text[at+len(prefix):])
+		// Never hand back an empty page: a page that is ONLY chrome keeps
+		// its text, so the reader still sees it exists rather than
+		// silently losing a URL from the corpus.
+		if trimmed == "" {
+			continue
+		}
+		out[i].Text = trimmed
+	}
+	return out
+}
+
+// chromeSearchRunes is how far into a page the shared header may start. Real
+// pages open with their own <title> ("About | Algolia", "Contact | Algolia")
+// BEFORE the menu, so a strict prefix comparison finds nothing on exactly the
+// sites this exists for. The menu still starts early; it just is not at rune
+// zero.
+const chromeSearchRunes = 300
+
+// sharedOpening finds the longest opening that enough pages begin with,
+// allowing each page a short unique lead-in first.
+//
+// It grows the candidate from the most common first-page opening rather than
+// comparing every pair: the header is identical across pages by construction,
+// so the pairwise common prefix of any two chrome-carrying pages already IS
+// the header.
+func sharedOpening(pages []crawlPage) string {
+	best := ""
+	// Try each page as the reference. A site whose FIRST page is atypical
+	// (a landing page with no menu) would otherwise defeat the whole check.
+	for _, candidate := range pages {
+		if utf8.RuneCountInString(candidate.Text) < boilerplateMinRunes {
+			continue
+		}
+		// Skip past this page's own lead-in and take the run that follows
+		// as the chrome candidate. Anchoring on a mid-page offset is what
+		// lets a menu be found under a per-page <title>.
+		for _, start := range chromeStarts(candidate.Text) {
+			block := blockFrom(candidate, start, pages)
+			if utf8.RuneCountInString(block) > utf8.RuneCountInString(best) {
+				best = block
+			}
+		}
+	}
+	return best
+}
+
+// blockFrom narrows one candidate opening against every other page and
+// answers the shared run, or "" when the pages do not agree it is chrome.
+func blockFrom(candidate crawlPage, start int, pages []crawlPage) string {
+	common := candidate.Text[start:]
+	agreeing := 0
+	for _, other := range pages {
+		if other.URL == candidate.URL {
+			continue
+		}
+		shared := longestSharedRun(common, other.Text)
+		if utf8.RuneCountInString(shared) < boilerplateMinRunes {
+			continue
+		}
+		// Shrink to what this page also has, so the result is what the
+		// AGREEING pages share rather than what one page happens to open with.
+		common = shared
+		agreeing++
+	}
+	if agreeing == 0 {
+		return ""
+	}
+	if float64(agreeing+1)/float64(len(pages)) < boilerplateMinShare {
+		return ""
+	}
+	if tooLargeAShare(common, pages) || blockDominatesPages(common, pages) {
+		return ""
+	}
+	return common
+}
+
+// chromeStarts are the byte offsets worth testing as the head of the shared
+// block: the very start, and each word boundary within the first
+// chromeSearchRunes. Bounded on purpose — the menu is near the top or it is
+// not chrome.
+func chromeStarts(text string) []int {
+	starts := []int{0}
+	limit := len(text)
+	if runes := []rune(text); len(runes) > chromeSearchRunes {
+		limit = len(string(runes[:chromeSearchRunes]))
+	}
+	for i := 1; i < limit; i++ {
+		if text[i-1] == ' ' && text[i] != ' ' {
+			starts = append(starts, i)
+		}
+	}
+	return starts
+}
+
+// longestSharedRun returns the longest run of `head` that also appears near
+// the top of `other`, cut back to a word boundary.
+func longestSharedRun(head, other string) string {
+	limit := len(other)
+	if runes := []rune(other); len(runes) > chromeSearchRunes {
+		limit = len(string(runes[:chromeSearchRunes]))
+	}
+	for start := 0; start < limit; start++ {
+		if start > 0 && (other[start-1] != ' ' || other[start] == ' ') {
+			continue
+		}
+		if shared := commonPrefix(head, other[start:]); utf8.RuneCountInString(shared) >= boilerplateMinRunes {
+			return shared
+		}
+	}
+	return ""
+}
+
+// blockDominatesPages reports whether removing the shared run would leave a
+// page that is mostly gone.
+//
+// A menu is a large slice of a page but not the whole of it: algolia's is 45%
+// of its /about page, and 5,800 runes of that page survive. Pages that merely
+// repeat one another share nearly everything, so what remains is a spliced
+// fragment rather than prose worth extracting from.
+func blockDominatesPages(block string, pages []crawlPage) bool {
+	dominated, carrying := 0, 0
+	for _, page := range pages {
+		at := strings.Index(page.Text, block)
+		if at < 0 {
+			continue
+		}
+		carrying++
+		remainder := strings.TrimSpace(page.Text[:at] + " " + page.Text[at+len(block):])
+		if utf8.RuneCountInString(remainder) < boilerplateMinSurvivingRunes {
+			dominated++
+		}
+	}
+	if carrying == 0 {
+		return false
+	}
+	return float64(dominated)/float64(carrying) > 0.5
+}
+
+// tooLargeAShare reports whether removing the prefix would leave the pages
+// with nothing to distinguish them.
+//
+// Judged on what SURVIVES, not on the ratio: a mega-menu legitimately is most
+// of a short page, and that is the case this whole file exists to fix. What is
+// not legitimate is a "shared prefix" that leaves every page a stub, which is
+// what near-duplicate pages produce.
+func tooLargeAShare(prefix string, pages []crawlPage) bool {
+	carrying, stubs := 0, 0
+	for _, page := range pages {
+		at := strings.Index(page.Text, prefix)
+		if at < 0 {
+			continue
+		}
+		carrying++
+		remainder := strings.TrimSpace(page.Text[:at] + " " + page.Text[at+len(prefix):])
+		if utf8.RuneCountInString(remainder) < boilerplateMinRemainderRunes {
+			stubs++
+		}
+	}
+	if carrying == 0 {
+		return false
+	}
+	return float64(stubs)/float64(carrying) > boilerplateMaxStubShare
+}
+
+// commonPrefix returns the longest rune-aligned prefix shared by a and b,
+// cut back to the last word boundary so a half-word is never left behind.
+func commonPrefix(a, b string) string {
+	limit := len(a)
+	if len(b) < limit {
+		limit = len(b)
+	}
+	end := 0
+	for end < limit && a[end] == b[end] {
+		end++
+	}
+	shared := a[:end]
+	if !utf8.ValidString(shared) {
+		// The cut landed inside a multi-byte rune; back up to the last
+		// valid boundary.
+		for len(shared) > 0 && !utf8.ValidString(shared) {
+			shared = shared[:len(shared)-1]
+		}
+	}
+	if space := strings.LastIndexAny(shared, " \t\n"); space > 0 {
+		shared = shared[:space]
+	}
+	return shared
+}

--- a/backend/internal/compose/siteboilerplate.go
+++ b/backend/internal/compose/siteboilerplate.go
@@ -63,6 +63,14 @@ const (
 	// ~5,800 runes; a page left with a few hundred was never a page with a
 	// header, it was a page that repeats its neighbours.
 	boilerplateMinSurvivingRunes = 400
+	// boilerplateMaxBlockBytes caps how far two pages are compared. A header
+	// is at most a few thousand runes; scanning further only lets a hostile
+	// corpus set the cost.
+	boilerplateMaxBlockBytes = 24_000
+	// boilerplateMaxCorpusBytes is the total text this will look at. Past
+	// it the pages are returned untouched -- the profile lane still works,
+	// it just keeps the chrome, which is the pre-existing behaviour.
+	boilerplateMaxCorpusBytes = 4 << 20
 )
 
 // stripSharedPrefix removes the navigation chrome that opens most of a site's
@@ -74,6 +82,15 @@ func stripSharedPrefix(pages []crawlPage) []crawlPage {
 	out := make([]crawlPage, len(pages))
 	copy(out, pages)
 	if len(pages) < boilerplateMinPages {
+		return out
+	}
+	total := 0
+	for _, page := range pages {
+		total += len(page.Text)
+	}
+	if total > boilerplateMaxCorpusBytes {
+		// Fail open: keeping the chrome is the old behaviour, and it beats
+		// spending unbounded CPU on a corpus the crawled site chose.
 		return out
 	}
 
@@ -96,7 +113,13 @@ func stripSharedPrefix(pages []crawlPage) []crawlPage {
 		if utf8.RuneCountInString(page.Text[:at]) > chromeSearchRunes {
 			continue
 		}
-		trimmed := strings.TrimSpace(page.Text[:at] + " " + page.Text[at+len(prefix):])
+		// Keep ONLY what follows the chrome. Joining the lead-in to the
+		// tail would create a sentence the page never contained, and that
+		// spliced string becomes the evidence quote a human is shown when
+		// approving the proposal -- the citation gate would be satisfied by
+		// text formed at the join rather than by the site's own writing.
+		// The lead-in is the page's <title> and is restated in the body.
+		trimmed := strings.TrimSpace(page.Text[at+len(prefix):])
 		// Never hand back an empty page: a page that is ONLY chrome keeps
 		// its text, so the reader still sees it exists rather than
 		// silently losing a URL from the corpus.
@@ -115,6 +138,11 @@ func stripSharedPrefix(pages []crawlPage) []crawlPage {
 // zero.
 const chromeSearchRunes = 300
 
+// chromeMaxStarts bounds how many candidate offsets are tried per page. Each
+// one is compared against every other page, so an adversarial corpus of very
+// short words would otherwise turn this quadratic in page length.
+const chromeMaxStarts = 60
+
 // sharedOpening finds the longest opening that enough pages begin with,
 // allowing each page a short unique lead-in first.
 //
@@ -126,7 +154,7 @@ func sharedOpening(pages []crawlPage) string {
 	best := ""
 	// Try each page as the reference. A site whose FIRST page is atypical
 	// (a landing page with no menu) would otherwise defeat the whole check.
-	for _, candidate := range pages {
+	for i, candidate := range pages {
 		if utf8.RuneCountInString(candidate.Text) < boilerplateMinRunes {
 			continue
 		}
@@ -134,7 +162,7 @@ func sharedOpening(pages []crawlPage) string {
 		// as the chrome candidate. Anchoring on a mid-page offset is what
 		// lets a menu be found under a per-page <title>.
 		for _, start := range chromeStarts(candidate.Text) {
-			block := blockFrom(candidate, start, pages)
+			block := blockFrom(candidate, i, start, pages)
 			if utf8.RuneCountInString(block) > utf8.RuneCountInString(best) {
 				best = block
 			}
@@ -145,11 +173,13 @@ func sharedOpening(pages []crawlPage) string {
 
 // blockFrom narrows one candidate opening against every other page and
 // answers the shared run, or "" when the pages do not agree it is chrome.
-func blockFrom(candidate crawlPage, start int, pages []crawlPage) string {
+func blockFrom(candidate crawlPage, self, start int, pages []crawlPage) string {
 	common := candidate.Text[start:]
 	agreeing := 0
-	for _, other := range pages {
-		if other.URL == candidate.URL {
+	for j, other := range pages {
+		// Identity by INDEX: a corpus carrying the same URL twice would
+		// otherwise skip every page as "self" and silently strip nothing.
+		if j == self {
 			continue
 		}
 		shared := longestSharedRun(common, other.Text)
@@ -186,6 +216,14 @@ func chromeStarts(text string) []int {
 	for i := 1; i < limit; i++ {
 		if text[i-1] == ' ' && text[i] != ' ' {
 			starts = append(starts, i)
+			// The offsets are tried against every other page, so an
+			// input of single letters ("a a a a ...") would otherwise
+			// make this quadratic on a corpus a hostile site controls.
+			// A menu begins within the first few dozen words or it is
+			// not a menu.
+			if len(starts) >= chromeMaxStarts {
+				return starts
+			}
 		}
 	}
 	return starts
@@ -224,7 +262,7 @@ func blockDominatesPages(block string, pages []crawlPage) bool {
 			continue
 		}
 		carrying++
-		remainder := strings.TrimSpace(page.Text[:at] + " " + page.Text[at+len(block):])
+		remainder := strings.TrimSpace(page.Text[at+len(block):])
 		if utf8.RuneCountInString(remainder) < boilerplateMinSurvivingRunes {
 			dominated++
 		}
@@ -250,7 +288,7 @@ func tooLargeAShare(prefix string, pages []crawlPage) bool {
 			continue
 		}
 		carrying++
-		remainder := strings.TrimSpace(page.Text[:at] + " " + page.Text[at+len(prefix):])
+		remainder := strings.TrimSpace(page.Text[at+len(prefix):])
 		if utf8.RuneCountInString(remainder) < boilerplateMinRemainderRunes {
 			stubs++
 		}
@@ -267,6 +305,14 @@ func commonPrefix(a, b string) string {
 	limit := len(a)
 	if len(b) < limit {
 		limit = len(b)
+	}
+	// Chrome is a header, never a whole page, so the comparison stops at a
+	// header's worth of text. Without this the scan runs to end-of-page and
+	// the nested search becomes quadratic in page length: a site serving 40
+	// pages of 800 KB that all open alike cost 2m18s of a worker goroutine,
+	// which the deep read accepts from any attacker-chosen URL.
+	if limit > boilerplateMaxBlockBytes {
+		limit = boilerplateMaxBlockBytes
 	}
 	end := 0
 	for end < limit && a[end] == b[end] {

--- a/backend/internal/compose/siteboilerplate_test.go
+++ b/backend/internal/compose/siteboilerplate_test.go
@@ -4,8 +4,10 @@
 package compose
 
 import (
+	"fmt"
 	"strings"
 	"testing"
+	"time"
 )
 
 // The mega-menu that opens every page of a large B2B site. Long enough to
@@ -168,5 +170,51 @@ func TestProfileExcerptSpendsItsBudgetOnRealTextNotChrome(t *testing.T) {
 	if !strings.Contains(corpus.String(), claim) {
 		t.Fatalf("the excerpt lost the company's own sentence; got %.200q",
 			corpus.String())
+	}
+}
+
+func TestAHostileCorpusCannotBurnAWorkerGoroutine(t *testing.T) {
+	// The deep read accepts an attacker-chosen URL (POST /company/site-reads
+	// creates an unbound dossier), so the crawled site chooses this input.
+	// Before the comparison was bounded, forty pages that all opened alike
+	// cost minutes of CPU per read -- enough to occupy the workers by
+	// repeating the call.
+	pages := make([]crawlPage, 0, 40)
+	opening := strings.Repeat("a ", 200_000)
+	for i := 0; i < 40; i++ {
+		pages = append(pages, crawlPage{
+			URL:  fmt.Sprintf("https://hostile.test/p%d", i),
+			Text: opening + fmt.Sprintf("%d", i),
+		})
+	}
+
+	start := time.Now()
+	stripSharedPrefix(pages)
+
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Fatalf("a hostile corpus took %v; the comparison is unbounded again", elapsed)
+	}
+}
+
+func TestTheCutNeverInventsAPassageThePageDidNotContain(t *testing.T) {
+	// The surviving text becomes the evidence quote a human is shown when
+	// approving a staged proposal, and the citation gate checks containment
+	// against it. Joining the pre-chrome lead-in to the post-chrome body
+	// would form a sentence that appears nowhere on the page.
+	pages := pagesWithChrome(
+		"Our competitor Globex is the market leader in this segment.",
+		"Careers. We are hiring engineers in Berlin and Hamburg.",
+		"Contact. Reach the team at the Dortmund office any weekday.",
+		"Services. Consulting, implementation and long-term support.",
+	)
+	for i := range pages {
+		pages[i].Text = fmt.Sprintf("Page %d title ", i) + pages[i].Text
+	}
+
+	for i, page := range stripSharedPrefix(pages) {
+		if !strings.Contains(pages[i].Text, page.Text) {
+			t.Errorf("page %d now carries text the source never had:\n%.140q",
+				i, page.Text)
+		}
 	}
 }

--- a/backend/internal/compose/siteboilerplate_test.go
+++ b/backend/internal/compose/siteboilerplate_test.go
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+import (
+	"strings"
+	"testing"
+)
+
+// The mega-menu that opens every page of a large B2B site. Long enough to
+// exceed boilerplateMinRunes, which is the point: this is what eats the
+// profile lane's excerpt budget on a real site.
+const megaMenu = "Products AI Search and Retrieval Overview Search Show users " +
+	"what they are looking for with AI-driven results. Recommendations Use " +
+	"behavioural cues to drive higher engagement. Personalization Show each " +
+	"user what they need across their journey. Analytics All your insights " +
+	"in one dashboard. Solutions Industries SEE ALL Auto Parts B2B Commerce " +
+	"Ecommerce Fashion Grocery Higher Education Marketplaces Media Retail " +
+	"Company Partners Support Login Logout Language English Deutsch "
+
+// filler stands in for the paragraphs a real page carries under its menu.
+// The fixtures need it: a page of two sentences is not the case this file
+// exists for, and a survivor threshold tuned for real pages would reject it.
+func filler(topic string) string {
+	return strings.Repeat(" "+topic+" is described here in the detail a real "+
+		"page carries, across several sentences of ordinary prose.", 6)
+}
+
+func pagesWithChrome(bodies ...string) []crawlPage {
+	pages := make([]crawlPage, 0, len(bodies))
+	for i, body := range bodies {
+		pages = append(pages, crawlPage{
+			URL:  "https://example.test/p" + string(rune('a'+i)),
+			Text: megaMenu + body + filler(body),
+		})
+	}
+	return pages
+}
+
+func TestSharedNavigationIsStrippedSoThePageOwnWordsSurvive(t *testing.T) {
+	const about = "About us. We were founded in 2009 in Dortmund and build " +
+		"commerce software for mid-market retailers across Europe."
+	pages := pagesWithChrome(
+		about,
+		"Careers. We are hiring engineers in Berlin and Hamburg.",
+		"Contact. Reach the team at the Dortmund office any weekday.",
+		"Services. Consulting, implementation and long-term platform support.",
+		"Products. The platform covers search, merchandising and analytics.",
+	)
+
+	stripped := stripSharedPrefix(pages)
+
+	// The menu must be gone. A few words of it may survive: commonPrefix
+	// stops at a word boundary rather than mid-token, so the tail between
+	// the last shared space and the page's own text stays. What matters is
+	// that the excerpt budget now buys the company's own prose.
+	if before, after := len(pages[0].Text), len(stripped[0].Text); after >= before {
+		t.Fatalf("chrome was not removed: %d chars became %d", before, after)
+	}
+	if removed := len(pages[0].Text) - len(stripped[0].Text); removed < len(megaMenu)/2 {
+		t.Fatalf("only %d chars removed from a %d-char menu", removed, len(megaMenu))
+	}
+	for i, page := range stripped {
+		if strings.Contains(page.Text, "Auto Parts B2B Commerce") {
+			t.Errorf("page %d kept the mega-menu body: %.80q", i, page.Text)
+		}
+	}
+	if !strings.Contains(stripped[0].Text, "founded in 2009 in Dortmund") {
+		t.Errorf("the page's own sentence was lost: %.120q", stripped[0].Text)
+	}
+}
+
+func TestAPageThatIsOnlyNavigationKeepsItsText(t *testing.T) {
+	// A URL whose whole body is chrome must not become empty: an empty page
+	// vanishes from the corpus, and losing a page is worse than a noisy one.
+	pages := pagesWithChrome(
+		"About us. We build commerce software for mid-market retailers.",
+		"Careers. We are hiring engineers in Berlin and Hamburg.",
+		"Contact. Reach the team at the Dortmund office any weekday.",
+		"Products. The platform covers search, merchandising and analytics.",
+	)
+	// One page is nothing but the menu.
+	pages = append(pages, crawlPage{URL: "https://example.test/chrome", Text: megaMenu})
+
+	stripped := stripSharedPrefix(pages)
+
+	if strings.TrimSpace(stripped[4].Text) == "" {
+		t.Fatal("a chrome-only page was emptied; it must keep its text")
+	}
+}
+
+func TestASiteWithoutSharedNavigationIsLeftAlone(t *testing.T) {
+	pages := []crawlPage{
+		{URL: "https://example.test/a", Text: "About us. Founded in Dortmund in 2009, we build commerce software."},
+		{URL: "https://example.test/b", Text: "Careers. Engineering roles in Berlin, Hamburg and Munich are open."},
+		{URL: "https://example.test/c", Text: "Contact. The office is on Adessoplatz and answers on weekdays."},
+		{URL: "https://example.test/d", Text: "Services. Consulting, implementation and platform support for retail."},
+	}
+
+	stripped := stripSharedPrefix(pages)
+
+	for i := range pages {
+		if stripped[i].Text != pages[i].Text {
+			t.Errorf("page %d was trimmed though nothing is shared:\n got %q\nwant %q",
+				i, stripped[i].Text, pages[i].Text)
+		}
+	}
+}
+
+func TestTooFewPagesToJudgeLeavesThemUntouched(t *testing.T) {
+	// Two pages can share an opening by coincidence -- a locale pair, or one
+	// template used twice -- and trimming on that evidence cuts real text.
+	pages := pagesWithChrome(
+		"About us. We build commerce software for retailers.",
+		"Careers. We are hiring engineers in Berlin.",
+	)
+
+	stripped := stripSharedPrefix(pages)
+
+	for i := range pages {
+		if stripped[i].Text != pages[i].Text {
+			t.Errorf("page %d trimmed on only %d pages of evidence", i, len(pages))
+		}
+	}
+}
+
+func TestNearDuplicatePagesAreNotGutted(t *testing.T) {
+	// When the "shared prefix" is most of every page, the pages are near
+	// duplicates rather than pages sharing a header. Removing it would
+	// leave nothing to extract from.
+	body := strings.Repeat("The same paragraph on every page. ", 20)
+	pages := []crawlPage{
+		{URL: "https://example.test/a", Text: body + "A"},
+		{URL: "https://example.test/b", Text: body + "B"},
+		{URL: "https://example.test/c", Text: body + "C"},
+		{URL: "https://example.test/d", Text: body + "D"},
+		{URL: "https://example.test/e", Text: body + "E"},
+	}
+
+	stripped := stripSharedPrefix(pages)
+
+	for i := range pages {
+		if stripped[i].Text != pages[i].Text {
+			t.Errorf("page %d was gutted: %.60q", i, stripped[i].Text)
+		}
+	}
+}
+
+func TestProfileExcerptSpendsItsBudgetOnRealTextNotChrome(t *testing.T) {
+	// The end-to-end point of the change: with chrome removed, the excerpt
+	// the model is shown contains the company's own words.
+	const claim = "Founded in 2009 in Dortmund, we build commerce software."
+	pages := pagesWithChrome(
+		"About us. "+claim,
+		"Careers. We are hiring engineers in Berlin and Hamburg.",
+		"Contact. Reach the team at the Dortmund office any weekday.",
+		"Services. Consulting, implementation and long-term support.",
+		"Products. Search, merchandising and analytics in one platform.",
+	)
+
+	excerpts := profileExcerptPages(pages)
+
+	var corpus strings.Builder
+	for _, page := range excerpts {
+		corpus.WriteString(page.Text)
+	}
+	if !strings.Contains(corpus.String(), claim) {
+		t.Fatalf("the excerpt lost the company's own sentence; got %.200q",
+			corpus.String())
+	}
+}

--- a/backend/internal/compose/siteprofile.go
+++ b/backend/internal/compose/siteprofile.go
@@ -107,8 +107,11 @@ func profileSchema(snippetIDs []string) json.RawMessage {
 // profile prompt represents at most one legal page and reserves room for
 // About, services, products, home, contact, and team evidence.
 func profileExcerptPages(pages []crawlPage) []crawlPage {
-	ranked := make([]crawlPage, len(pages))
-	copy(ranked, pages)
+	// Drop the navigation chrome first, so the per-page cap below is spent
+	// on the company's own words rather than on the mega-menu every page
+	// opens with. See siteboilerplate.go for why this is measured from the
+	// corpus rather than guessed at.
+	ranked := stripSharedPrefix(pages)
 	sortPagesByCorpusRank(ranked)
 	var out []crawlPage
 	used := 0


### PR DESCRIPTION
The deep read profiles a company from at most 2,500 runes per page, taken from the start. A large B2B site opens every page with the same header and mega-menu, so on those sites the budget is spent before the company's own words begin, and the profile comes back nearly empty.

Measured across 21 real company sites: what predicts the yield is not size but repeated navigation. `algolia.com` returned 2 profile fields of a possible 15 from 40 pages; `bestit.de` returned 15 from the same 40. At the 2,500-rune cut algolia's `/about` is still listing "Auto Parts, B2B Commerce, Fashion, Grocery" while bestit's is already in prose.

It was never the evidence gate — algolia and arvato had **zero** profile-lane drops. Nothing was refused; the model was shown chrome and had nothing to claim.

Text repeated at the head of most pages of one site is chrome by definition, and the crawl already holds the whole corpus, so this needs no model call and no extra fetch. The block is found wherever it starts (real pages open with their own title before the menu) and is cut only when several pages agree, only near the top, and only when the page keeps enough text to be worth reading.

**Result: algolia.com now returns 11 fields instead of 2.**

## Security review findings, both fixed in the second commit

- **CPU exhaustion.** `commonPrefix` scanned two pages for as long as they agreed with no ceiling, inside a search nested over pages and offsets. Forty pages of 800 KB that all opened alike cost 2m18s of a worker goroutine, and `POST /company/site-reads` takes an attacker-chosen URL with no company record needed. The comparison now stops at a header's worth of text, and an oversized corpus is returned untouched.
- **Fabricated evidence quotes.** The cut joined the text before the chrome to the text after it. That spliced string is what the citation gate checks containment against and what a human is shown as the verbatim evidence when approving a proposal, so the quote could be a sentence appearing nowhere on the page, formed at a join the site controls both sides of. Only the text following the chrome is kept now.
- Identity in `blockFrom` was by URL, so a corpus carrying one URL twice skipped every page as "self" and silently stripped nothing.

Both are pinned by tests: a hostile corpus must finish in seconds, and no page may end up carrying text its source did not.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the profile lane from spending its excerpt budget on site chrome. Previously we capped from the start of each page, so mega‑menus consumed up to 2,500 runes and profiles were sparse; now we detect a shared opening near the top across pages and cut only that block before excerpting.

- Removes a common prefix only when enough pages agree; keeps only post‑chrome text; leaves pages untouched if cutting would stub them or the corpus is oversized; no extra fetches or model calls.
- Improves yield on mega‑menu sites (e.g., algolia.com: 11 fields vs 2).

**Safety**
- Bounds comparisons to a header‑sized window and caps corpus size to prevent CPU exhaustion; identifies pages by index to avoid skip‑all on duplicate URLs.
- Never splices pre‑ and post‑chrome text, so evidence quotes remain source‑exact; tests pin hostile‑corpus timing and quote containment.

<sup>Written for commit fc8181bfa1678bc7b419012cdf4736285aceb853. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1355?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

