### PR TITLE
fix(siteread): profile the whole crawl, not the first eight pages of it

### DIFF
--- a/backend/internal/compose/deepread.go
+++ b/backend/internal/compose/deepread.go
@@ -156,11 +156,16 @@ func newSiteDeepReadWorker(pool *pgxpool.Pool, brain, factBrain, triageBrain com
 	}
 }
 
-// extractLaneBudget is the parallel extraction's allowance in the
-// job-timeout arithmetic: the page fan-out and the profile call run
-// concurrently, each a small fast call plus the validator's retry-and-
-// escalate headroom.
-const extractLaneBudget = 90 * time.Second
+// extractLaneBudget is the extraction's allowance in the job-timeout
+// arithmetic: the page fan-out and the first profile call run concurrently,
+// each a small fast call plus the validator's retry-and-escalate headroom.
+//
+// The allowance covers TWO profile calls, not one. A crawl that grows well
+// past the profile trigger is asked again over the finished corpus
+// (compose.reprofileOverWholeCrawl), and that call is serial — it reads the
+// whole crawl, so it cannot start until the crawl has ended. Sizing this for
+// one call would time out exactly the large sites the re-run exists for.
+const extractLaneBudget = 150 * time.Second
 
 // deepReadTimeout is the one declared timeout in the tree that cannot be a
 // number in api/jobs.yaml: the crawl wall is an operator's, so the file

--- a/backend/internal/compose/siteextract.go
+++ b/backend/internal/compose/siteextract.go
@@ -4,10 +4,15 @@
 package compose
 
 // The deep read's extraction orchestration: the page-fact fan-out and
-// the one profile call run CONCURRENTLY — their wall clock is the
-// product's read time. Collect-don't-cancel: one page's failure costs
-// that page's findings and degrades the read to partial, never the
-// whole fan-out; the worker and the debug CLI share this exact spine.
+// the profile call run CONCURRENTLY — their wall clock is the product's
+// read time. The profile lane runs at most TWICE: once as soon as there
+// is enough evidence to answer at all, and again over the finished crawl
+// when the corpus grew enough that the first answer was drawn from a
+// fraction of the site (reprofileOverWholeCrawl).
+//
+// Collect-don't-cancel: one page's failure costs that page's findings and
+// degrades the read to partial, never the whole fan-out; the worker and the
+// debug CLI share this exact spine.
 
 import (
 	"context"
@@ -51,7 +56,9 @@ type siteExtraction struct {
 // profileTriggerNonLegalPages is how much commercial evidence the profile
 // lane waits for before firing. A raw page-count trigger can be satisfied
 // entirely by legal pages on policy-heavy sites, permanently producing a
-// legal-only profile because the lane intentionally runs once.
+// legal-only profile: the early answer would then rest on policy text
+// alone, and on a site that never grows enough to warrant the second pass
+// that is the answer the read ships.
 const profileTriggerNonLegalPages = 8
 
 func profileEvidenceReady(pages []crawlPage) bool {
@@ -75,9 +82,10 @@ const (
 // crawlAndExtract OVERLAPS the crawl and the extraction: page-fact
 // calls launch the moment their page commits, and the profile call
 // fires once the top-ranked pages are in (or the crawl ends, whichever
-// is first). The read's wall clock becomes ~max(crawl, slowest lane)
-// instead of their sum. onProgress (may be nil) fires serially with the
-// live phase and the pages fetched so far.
+// is first), then once more over the whole crawl if it grew enough. The
+// read's wall clock becomes ~max(crawl, slowest lane) instead of their sum.
+// onProgress (may be nil) fires serially with the live phase and the pages
+// fetched so far.
 func crawlAndExtract(ctx context.Context, crawler *siteCrawler, x evidenceExtractor, seedURL string, onProgress func(phase string, pages []crawlPage), onDraft func(pageFactsResult)) (siteCrawl, siteExtraction, error) {
 	var out siteExtraction
 	collected := pageFactsCollector{onDraft: onDraft}
@@ -179,21 +187,43 @@ func reprofileOverWholeCrawl(
 	current []evidencedField, collected *pageFactsCollector,
 ) []evidencedField {
 	extra := reprofileIfMuchMoreEvidence(ctx, x, pages, profiled)
-	switch {
-	case extra == nil:
+	if extra == nil {
 		return current
-	case extra.err != nil:
+	}
+	if extra.err != nil {
 		collected.failed = append(collected.failed,
 			fmt.Errorf("profile re-run: %w", extra.err))
 		return current
-	case len(extra.fields) > len(current):
-		return extra.fields
-	default:
-		// A re-run that found LESS is the model being unlucky on a longer
-		// prompt, not new knowledge, and silently replacing a good profile
-		// with a worse one is a regression the caller cannot see.
-		return current
 	}
+	return mergeProfileFields(current, extra.fields)
+}
+
+// mergeProfileFields folds a re-run's profile into the first pass's, keeping
+// every field either of them grounded.
+//
+// Picking the LONGER of the two lists throws away work: the passes read
+// different evidence, so the second can ground `usp` and `history` while
+// missing an `industry` the first had, and a count comparison silently drops
+// it. Both answers are gated the same way, so a field present in either is a
+// field the site supports.
+//
+// The re-run wins a field they both claim: it read the whole crawl, so its
+// value rests on more of the site than the early pass could see.
+func mergeProfileFields(first, second []evidencedField) []evidencedField {
+	if len(second) == 0 {
+		return first
+	}
+	merged := append([]evidencedField(nil), second...)
+	claimed := make(map[string]bool, len(second))
+	for _, field := range second {
+		claimed[field.Field] = true
+	}
+	for _, field := range first {
+		if !claimed[field.Field] {
+			merged = append(merged, field)
+		}
+	}
+	return merged
 }
 
 // profileGrowthFactor is how much bigger the corpus must be before the

--- a/backend/internal/compose/siteextract.go
+++ b/backend/internal/compose/siteextract.go
@@ -155,24 +155,8 @@ func crawlAndExtract(ctx context.Context, crawler *siteCrawler, x evidenceExtrac
 	wg.Wait()
 	profileWg.Wait()
 
-	// The first profile ran on the pages that existed at the trigger, which
-	// on a large site is a fraction of what the crawl went on to find: a
-	// 40-page site was profiled from its first 8, so the About, team and
-	// services pages that arrive later were never read. Ask again, once,
-	// over the whole corpus when the crawl grew enough for that to change
-	// the answer.
-	if extra := reprofileIfMuchMoreEvidence(ctx, x, crawl.Pages, profiledPages); extra != nil {
-		if extra.err != nil {
-			collected.failed = append(collected.failed,
-				fmt.Errorf("profile re-run: %w", extra.err))
-		} else if len(extra.fields) > len(out.fields) {
-			// Keep the richer answer. A re-run that found LESS is the model
-			// being unlucky on a longer prompt, not new knowledge, and
-			// replacing a good profile with a worse one is a regression the
-			// caller cannot see.
-			out.fields = extra.fields
-		}
-	}
+	out.fields = reprofileOverWholeCrawl(ctx, x, crawl.Pages, profiledPages,
+		out.fields, &collected)
 
 	if profileErr != nil {
 		collected.failed = append(collected.failed, fmt.Errorf("profile lane: %w", profileErr))
@@ -181,6 +165,35 @@ func crawlAndExtract(ctx context.Context, crawler *siteCrawler, x evidenceExtrac
 	out.merged = mergeInCommitOrder(crawl, collected.results)
 	out.err = errors.Join(collected.failed...)
 	return crawl, out, nil
+}
+
+// reprofileOverWholeCrawl asks the profile lane again once the crawl has
+// finished, and answers the profile to keep.
+//
+// The first call ran on the pages that existed at the trigger, which on a
+// large site is a fraction of what the crawl went on to find: a 40-page site
+// was profiled from its first 8, so the About, team and services pages that
+// arrive later were never read.
+func reprofileOverWholeCrawl(
+	ctx context.Context, x evidenceExtractor, pages []crawlPage, profiled int,
+	current []evidencedField, collected *pageFactsCollector,
+) []evidencedField {
+	extra := reprofileIfMuchMoreEvidence(ctx, x, pages, profiled)
+	switch {
+	case extra == nil:
+		return current
+	case extra.err != nil:
+		collected.failed = append(collected.failed,
+			fmt.Errorf("profile re-run: %w", extra.err))
+		return current
+	case len(extra.fields) > len(current):
+		return extra.fields
+	default:
+		// A re-run that found LESS is the model being unlucky on a longer
+		// prompt, not new knowledge, and silently replacing a good profile
+		// with a worse one is a regression the caller cannot see.
+		return current
+	}
 }
 
 // profileGrowthFactor is how much bigger the corpus must be before the

--- a/backend/internal/compose/siteextract.go
+++ b/backend/internal/compose/siteextract.go
@@ -95,13 +95,21 @@ func crawlAndExtract(ctx context.Context, crawler *siteCrawler, x evidenceExtrac
 	profileOnce := sync.Once{}
 	var profileWg sync.WaitGroup
 	var profileErr error
+	var profileMu sync.Mutex
+	profiledPages := 0
 	fireProfile := func() {
 		profileOnce.Do(func() {
 			snapshot := snapshotCrawlPages(&committedMu, &committed)
+			profileMu.Lock()
+			profiledPages = len(snapshot)
+			profileMu.Unlock()
 			profileWg.Add(1)
 			go func() {
 				defer profileWg.Done()
-				out.fields, profileErr = safeExtractProfile(ctx, x, snapshot)
+				fields, err := safeExtractProfile(ctx, x, snapshot)
+				profileMu.Lock()
+				out.fields, profileErr = fields, err
+				profileMu.Unlock()
 			}()
 		})
 	}
@@ -147,6 +155,25 @@ func crawlAndExtract(ctx context.Context, crawler *siteCrawler, x evidenceExtrac
 	wg.Wait()
 	profileWg.Wait()
 
+	// The first profile ran on the pages that existed at the trigger, which
+	// on a large site is a fraction of what the crawl went on to find: a
+	// 40-page site was profiled from its first 8, so the About, team and
+	// services pages that arrive later were never read. Ask again, once,
+	// over the whole corpus when the crawl grew enough for that to change
+	// the answer.
+	if extra := reprofileIfMuchMoreEvidence(ctx, x, crawl.Pages, profiledPages); extra != nil {
+		if extra.err != nil {
+			collected.failed = append(collected.failed,
+				fmt.Errorf("profile re-run: %w", extra.err))
+		} else if len(extra.fields) > len(out.fields) {
+			// Keep the richer answer. A re-run that found LESS is the model
+			// being unlucky on a longer prompt, not new knowledge, and
+			// replacing a good profile with a worse one is a regression the
+			// caller cannot see.
+			out.fields = extra.fields
+		}
+	}
+
 	if profileErr != nil {
 		collected.failed = append(collected.failed, fmt.Errorf("profile lane: %w", profileErr))
 	}
@@ -154,6 +181,33 @@ func crawlAndExtract(ctx context.Context, crawler *siteCrawler, x evidenceExtrac
 	out.merged = mergeInCommitOrder(crawl, collected.results)
 	out.err = errors.Join(collected.failed...)
 	return crawl, out, nil
+}
+
+// profileGrowthFactor is how much bigger the corpus must be before the
+// profile is worth asking again. Below it the second call would see nearly
+// the same evidence and cost a model call to confirm the first answer.
+const profileGrowthFactor = 2
+
+// reprofileResult carries a re-run's outcome, or nil when no re-run was
+// warranted.
+type reprofileResult struct {
+	fields []evidencedField
+	err    error
+}
+
+// reprofileIfMuchMoreEvidence re-runs the profile lane over the finished
+// crawl when the first pass saw only a fraction of it.
+//
+// Returns nil when the crawl did not grow enough to justify the call: a site
+// that ended near the trigger was already profiled on what it has.
+func reprofileIfMuchMoreEvidence(
+	ctx context.Context, x evidenceExtractor, pages []crawlPage, profiled int,
+) *reprofileResult {
+	if profiled == 0 || len(pages) < profiled*profileGrowthFactor {
+		return nil
+	}
+	fields, err := safeExtractProfile(ctx, x, pages)
+	return &reprofileResult{fields: fields, err: err}
 }
 
 // pageFactsCollector accumulates the streamed fact lane's outcomes. Pages

--- a/backend/internal/compose/siteextract.go
+++ b/backend/internal/compose/siteextract.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/modules/ai"
 )
 
 // pageExtractConcurrency bounds the fan-out. The calls are tiny and the
@@ -56,9 +57,9 @@ type siteExtraction struct {
 // profileTriggerNonLegalPages is how much commercial evidence the profile
 // lane waits for before firing. A raw page-count trigger can be satisfied
 // entirely by legal pages on policy-heavy sites, permanently producing a
-// legal-only profile: the early answer would then rest on policy text
-// alone, and on a site that never grows enough to warrant the second pass
-// that is the answer the read ships.
+// legal-only profile. A site that never grows enough to warrant the second
+// pass ships that answer, so the trigger counts commercial pages rather than
+// pages.
 const profileTriggerNonLegalPages = 8
 
 func profileEvidenceReady(pages []crawlPage) bool {
@@ -82,10 +83,11 @@ const (
 // crawlAndExtract OVERLAPS the crawl and the extraction: page-fact
 // calls launch the moment their page commits, and the profile call
 // fires once the top-ranked pages are in (or the crawl ends, whichever
-// is first), then once more over the whole crawl if it grew enough. The
-// read's wall clock becomes ~max(crawl, slowest lane) instead of their sum.
-// onProgress (may be nil) fires serially with the live phase and the pages
-// fetched so far.
+// is first). The read's wall clock becomes ~max(crawl, slowest lane) instead
+// of their sum, PLUS the one re-profile call when the crawl grew enough to
+// warrant it (reprofileOverWholeCrawl) — that one is serial, because it reads
+// the finished corpus. onProgress (may be nil) fires serially with the live
+// phase and the pages fetched so far.
 func crawlAndExtract(ctx context.Context, crawler *siteCrawler, x evidenceExtractor, seedURL string, onProgress func(phase string, pages []crawlPage), onDraft func(pageFactsResult)) (siteCrawl, siteExtraction, error) {
 	var out siteExtraction
 	collected := pageFactsCollector{onDraft: onDraft}
@@ -163,10 +165,13 @@ func crawlAndExtract(ctx context.Context, crawler *siteCrawler, x evidenceExtrac
 	wg.Wait()
 	profileWg.Wait()
 
-	out.fields = reprofileOverWholeCrawl(ctx, x, crawl.Pages, profiledPages,
-		out.fields, &collected)
-
-	if profileErr != nil {
+	// A first pass that failed for budget means the workspace is over its
+	// threshold: asking again, with a LARGER prompt, spends against an
+	// allowance that is already exhausted.
+	fields, recovered := reprofileOverWholeCrawl(
+		ctx, x, crawl.Pages, profiledPages, out.fields, profileErr)
+	out.fields = fields
+	if profileErr != nil && !recovered {
 		collected.failed = append(collected.failed, fmt.Errorf("profile lane: %w", profileErr))
 	}
 	out.legalCensusIncomplete = collected.legalCensusIncomplete
@@ -175,6 +180,11 @@ func crawlAndExtract(ctx context.Context, crawler *siteCrawler, x evidenceExtrac
 	return crawl, out, nil
 }
 
+// profileGrowthFactor is how much bigger the corpus must be before the
+// profile is worth asking again. Below it the second call would see nearly
+// the same evidence and cost a model call to confirm the first answer.
+const profileGrowthFactor = 2
+
 // reprofileOverWholeCrawl asks the profile lane again once the crawl has
 // finished, and answers the profile to keep.
 //
@@ -182,20 +192,37 @@ func crawlAndExtract(ctx context.Context, crawler *siteCrawler, x evidenceExtrac
 // large site is a fraction of what the crawl went on to find: a 40-page site
 // was profiled from its first 8, so the About, team and services pages that
 // arrive later were never read.
+//
+// A failure here is LOGGED, never joined into the read's errors. This call is
+// optional refinement over an answer already in hand, and `extraction.err`
+// decides both the read's partial status and whether deferForBudget re-queues
+// it — so joining it would let a bonus call that tripped the budget defer a
+// read whose first pass had already grounded every field.
 func reprofileOverWholeCrawl(
 	ctx context.Context, x evidenceExtractor, pages []crawlPage, profiled int,
-	current []evidencedField, collected *pageFactsCollector,
-) []evidencedField {
-	extra := reprofileIfMuchMoreEvidence(ctx, x, pages, profiled)
-	if extra == nil {
-		return current
+	current []evidencedField, firstErr error,
+) (merged []evidencedField, recoveredFirstPass bool) {
+	if profiled == 0 || len(pages) < profiled*profileGrowthFactor {
+		return current, false
 	}
-	if extra.err != nil {
-		collected.failed = append(collected.failed,
-			fmt.Errorf("profile re-run: %w", extra.err))
-		return current
+	if firstErr != nil && errors.As(firstErr, new(*ai.BudgetDeferralError)) {
+		// The workspace is over its token threshold. A second, larger call
+		// against the same exhausted budget buys nothing and defers again.
+		return current, false
 	}
-	return mergeProfileFields(current, extra.fields)
+	fields, err := safeExtractProfile(ctx, x, pages)
+	if err != nil {
+		slog.WarnContext(ctx, "the profile re-run failed; keeping the first pass",
+			"pages", len(pages), "profiled_at_trigger", profiled, "err", err)
+		return current, false
+	}
+	// `fields` is the RE-RUN and wins a field both passes claim: it read the
+	// whole crawl, so its value rests on more of the site.
+	//
+	// When the FIRST pass failed, this one is the lane's answer rather than a
+	// refinement, so the read is whole: reporting it partial would warn a
+	// user about nothing missing.
+	return mergeProfileFields(current, fields), firstErr != nil
 }
 
 // mergeProfileFields folds a re-run's profile into the first pass's, keeping
@@ -207,8 +234,9 @@ func reprofileOverWholeCrawl(
 // it. Both answers are gated the same way, so a field present in either is a
 // field the site supports.
 //
-// The re-run wins a field they both claim: it read the whole crawl, so its
-// value rests on more of the site than the early pass could see.
+// `second` wins a contested field. Order is not meaningful to any reader of
+// these fields — the legal gate and the name reader select by field name —
+// so the result is `second` followed by the first pass's leftovers.
 func mergeProfileFields(first, second []evidencedField) []evidencedField {
 	if len(second) == 0 {
 		return first
@@ -224,33 +252,6 @@ func mergeProfileFields(first, second []evidencedField) []evidencedField {
 		}
 	}
 	return merged
-}
-
-// profileGrowthFactor is how much bigger the corpus must be before the
-// profile is worth asking again. Below it the second call would see nearly
-// the same evidence and cost a model call to confirm the first answer.
-const profileGrowthFactor = 2
-
-// reprofileResult carries a re-run's outcome, or nil when no re-run was
-// warranted.
-type reprofileResult struct {
-	fields []evidencedField
-	err    error
-}
-
-// reprofileIfMuchMoreEvidence re-runs the profile lane over the finished
-// crawl when the first pass saw only a fraction of it.
-//
-// Returns nil when the crawl did not grow enough to justify the call: a site
-// that ended near the trigger was already profiled on what it has.
-func reprofileIfMuchMoreEvidence(
-	ctx context.Context, x evidenceExtractor, pages []crawlPage, profiled int,
-) *reprofileResult {
-	if profiled == 0 || len(pages) < profiled*profileGrowthFactor {
-		return nil
-	}
-	fields, err := safeExtractProfile(ctx, x, pages)
-	return &reprofileResult{fields: fields, err: err}
 }
 
 // pageFactsCollector accumulates the streamed fact lane's outcomes. Pages

--- a/backend/internal/compose/siteextract_test.go
+++ b/backend/internal/compose/siteextract_test.go
@@ -396,3 +396,40 @@ func TestALargeCrawlIsProfiledOnEverythingItFound(t *testing.T) {
 			len(extraction.fields))
 	}
 }
+
+func TestARerunNeverDiscardsAFieldTheFirstPassGrounded(t *testing.T) {
+	// The two passes read different evidence, so the second can ground
+	// fields the first missed while missing one the first had. Choosing the
+	// LONGER list would drop that field silently -- both answers went
+	// through the same gate, so a field either pass grounded is a field the
+	// site supports.
+	first := []evidencedField{
+		{Field: "industry", Value: "Retail software"},
+		{Field: "display_name", Value: "Acme"},
+	}
+	second := []evidencedField{
+		{Field: "display_name", Value: "Acme SE"},
+		{Field: "usp", Value: "Fastest onboarding in the segment"},
+	}
+
+	merged := mergeProfileFields(first, second)
+
+	got := map[string]string{}
+	for _, field := range merged {
+		got[field.Field] = field.Value
+	}
+	if _, kept := got["industry"]; !kept {
+		t.Errorf("the re-run dropped `industry`, which the first pass grounded: %v", got)
+	}
+	if _, added := got["usp"]; !added {
+		t.Errorf("the merge lost `usp`, which only the re-run found: %v", got)
+	}
+	// The re-run read the whole crawl, so its value for a contested field is
+	// the better grounded one.
+	if got["display_name"] != "Acme SE" {
+		t.Errorf("display_name = %q, want the re-run's value", got["display_name"])
+	}
+	if len(merged) != 3 {
+		t.Errorf("merged %d fields, want 3 distinct ones: %v", len(merged), got)
+	}
+}

--- a/backend/internal/compose/siteextract_test.go
+++ b/backend/internal/compose/siteextract_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/modules/ai"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/model"
 )
 
@@ -346,13 +347,15 @@ func (f growingProfileFake) Complete(ctx context.Context, req model.Request) (mo
 	if strings.HasPrefix(req.System, profileSystem) {
 		f.profile.Add(1)
 		if strings.Contains(req.Messages[0].Content, "Audit 20") {
-			// The later pages are in the prompt, so the richer profile is
-			// available: two fields instead of one.
+			// The whole crawl is in the prompt. This pass grounds fields the
+			// early one could not see -- and DELIBERATELY not `industry`, so
+			// a merge that dropped the first pass's work would be visible.
 			return model.Response{Text: `{"fields":[` +
 				`{"f":"display_name","v":"Acme","e":"s0","c":0.9},` +
-				`{"f":"industry","v":"Audit 20","e":"s0","c":0.9}]}`}, nil
+				`{"f":"usp","v":"Audit 20","e":"s0","c":0.9}]}`}, nil
 		}
-		return model.Response{Text: `{"fields":[{"f":"display_name","v":"Acme","e":"s0","c":0.9}]}`}, nil
+		// The early pass sees only the first pages, and grounds `industry`.
+		return model.Response{Text: `{"fields":[{"f":"industry","v":"Audit 00","e":"s0","c":0.9}]}`}, nil
 	}
 	return f.laneFake.Complete(ctx, req)
 }
@@ -391,9 +394,17 @@ func TestALargeCrawlIsProfiledOnEverythingItFound(t *testing.T) {
 	if got := profileCalls.Load(); got != 2 {
 		t.Fatalf("profile lane fired %d times, want 2 (early answer, then the whole crawl)", got)
 	}
-	if len(extraction.fields) < 2 {
-		t.Fatalf("profile kept %d fields, want the richer answer the second pass found",
-			len(extraction.fields))
+	// Assert by NAME, not by count: a count is satisfied by the re-run's
+	// output alone, so it stays green even if the merge is deleted and the
+	// first pass's work is thrown away.
+	grounded := map[string]bool{}
+	for _, field := range extraction.fields {
+		grounded[field.Field] = true
+	}
+	for _, want := range []string{"industry", "display_name", "usp"} {
+		if !grounded[want] {
+			t.Errorf("%q is missing; the read kept %v", want, grounded)
+		}
 	}
 }
 
@@ -432,4 +443,100 @@ func TestARerunNeverDiscardsAFieldTheFirstPassGrounded(t *testing.T) {
 	if len(merged) != 3 {
 		t.Errorf("merged %d fields, want 3 distinct ones: %v", len(merged), got)
 	}
+}
+
+// budgetDeferringFake fails the FIRST profile call the way an over-budget
+// workspace does, and answers the second normally.
+type budgetDeferringFake struct {
+	laneFake
+	calls *atomic.Int32
+}
+
+func (f budgetDeferringFake) Complete(ctx context.Context, req model.Request) (model.Response, error) {
+	if strings.HasPrefix(req.System, profileSystem) {
+		if f.calls.Add(1) == 1 {
+			return model.Response{}, &ai.BudgetDeferralError{}
+		}
+		return model.Response{Text: `{"fields":[{"f":"industry","v":"Audit 00","e":"s0","c":0.9}]}`}, nil
+	}
+	return f.laneFake.Complete(ctx, req)
+}
+
+func TestAnOverBudgetFirstPassIsNotAskedAgainWithABiggerPrompt(t *testing.T) {
+	// A budget deferral means the workspace is over its token threshold.
+	// Asking again over the WHOLE crawl spends more against an allowance
+	// that is already exhausted, and defers a second time.
+	const pages = profileTriggerNonLegalPages * 3
+	site := streamFixtureSite(pages)
+	var calls atomic.Int32
+	brain := budgetDeferringFake{
+		laneFake: laneFake{pageReplies: map[string]string{}},
+		calls:    &calls,
+	}
+	for i := 0; i < pages; i++ {
+		brain.pageReplies[fmt.Sprintf("%s/services-%02d", seedURL, i)] = `{"facts":[]}`
+	}
+	crawler := testSiteCrawler(site)
+	crawler.fetchWave = 4
+
+	_, extraction, err := crawlAndExtract(context.Background(), crawler,
+		evidenceExtractor{brain: brain, factBrain: brain}, seedURL, nil, nil)
+	if err != nil {
+		t.Fatalf("crawlAndExtract: %v", err)
+	}
+	if got := calls.Load(); got != 1 {
+		t.Errorf("profile lane called %d times after a budget deferral, want 1", got)
+	}
+	// The deferral must still reach the caller: it is how the read is
+	// re-queued rather than shipped half-done.
+	if extraction.err == nil {
+		t.Error("the budget deferral was swallowed; the read cannot be re-queued")
+	}
+}
+
+func TestARerunThatRescuesAFailedFirstPassLeavesTheReadWhole(t *testing.T) {
+	// The first pass failed and the re-run answered, so the lane produced
+	// its profile. Reporting the read partial would warn a user about
+	// nothing missing.
+	const pages = profileTriggerNonLegalPages * 3
+	site := streamFixtureSite(pages)
+	var calls atomic.Int32
+	brain := failThenAnswerFake{
+		laneFake: laneFake{pageReplies: map[string]string{}},
+		calls:    &calls,
+	}
+	for i := 0; i < pages; i++ {
+		brain.pageReplies[fmt.Sprintf("%s/services-%02d", seedURL, i)] = `{"facts":[]}`
+	}
+	crawler := testSiteCrawler(site)
+	crawler.fetchWave = 4
+
+	_, extraction, err := crawlAndExtract(context.Background(), crawler,
+		evidenceExtractor{brain: brain, factBrain: brain}, seedURL, nil, nil)
+	if err != nil {
+		t.Fatalf("crawlAndExtract: %v", err)
+	}
+	if len(extraction.fields) == 0 {
+		t.Fatal("the re-run's profile was lost")
+	}
+	if extraction.err != nil {
+		t.Errorf("the read reports an error though the re-run answered: %v", extraction.err)
+	}
+}
+
+// failThenAnswerFake fails the first profile call with an ordinary provider
+// error -- not a budget deferral -- and answers the second.
+type failThenAnswerFake struct {
+	laneFake
+	calls *atomic.Int32
+}
+
+func (f failThenAnswerFake) Complete(ctx context.Context, req model.Request) (model.Response, error) {
+	if strings.HasPrefix(req.System, profileSystem) {
+		if f.calls.Add(1) == 1 {
+			return model.Response{}, errors.New("provider unavailable")
+		}
+		return model.Response{Text: `{"fields":[{"f":"industry","v":"Audit 00","e":"s0","c":0.9}]}`}, nil
+	}
+	return f.laneFake.Complete(ctx, req)
 }

--- a/backend/internal/compose/siteextract_test.go
+++ b/backend/internal/compose/siteextract_test.go
@@ -196,7 +196,10 @@ func streamFixtureSite(n int) *fakeSite {
 // page-count trigger on a large crawl and via the end-of-crawl fallback
 // on a small one — and the merge is commit-ordered regardless of
 // completion scheduling.
-func TestCrawlAndExtractStreamsDeterministicallyAndFiresProfileOnce(t *testing.T) {
+func TestCrawlAndExtractStreamsDeterministicallyAndProfilesTheWholeCrawl(t *testing.T) {
+	// The first size crosses the trigger and then keeps crawling, so the
+	// profile is asked again on the finished corpus; the second ends below
+	// the trigger and is profiled once, on everything it has.
 	for _, pages := range []int{profileTriggerNonLegalPages + 4, 3} {
 		site := streamFixtureSite(pages)
 		var profileCalls atomic.Int32
@@ -224,8 +227,16 @@ func TestCrawlAndExtractStreamsDeterministicallyAndFiresProfileOnce(t *testing.T
 		if extraction.err != nil {
 			t.Fatalf("clean lanes reported an error: %v", extraction.err)
 		}
-		if got := profileCalls.Load(); got != 1 {
-			t.Fatalf("profile lane fired %d times for %d pages, want exactly once", got, pages)
+		wantProfileCalls := int32(1)
+		if pages >= profileTriggerNonLegalPages*profileGrowthFactor {
+			// The crawl at least doubled after the trigger, so the early
+			// answer was drawn from a fraction of the evidence and is asked
+			// again over the whole of it.
+			wantProfileCalls = 2
+		}
+		if got := profileCalls.Load(); got != wantProfileCalls {
+			t.Fatalf("profile lane fired %d times for %d pages, want %d",
+				got, pages, wantProfileCalls)
 		}
 		if len(extraction.merged.facts) != pages {
 			t.Fatalf("facts = %d, want one per catalog page (%d)", len(extraction.merged.facts), pages)
@@ -319,5 +330,69 @@ func TestExtractSiteProgressCountsEveryPage(t *testing.T) {
 	}
 	if maxDone != len(extractFixturePages()) {
 		t.Fatalf("progress reached %d, want every page (%d)", maxDone, len(extractFixturePages()))
+	}
+}
+
+// growingProfileFake answers the profile lane by how much evidence it was
+// shown: a prompt carrying the later pages yields the richer profile. That
+// is the real asymmetry -- the About and team pages arrive after the
+// trigger, so the first call cannot see them.
+type growingProfileFake struct {
+	laneFake
+	profile *atomic.Int32
+}
+
+func (f growingProfileFake) Complete(ctx context.Context, req model.Request) (model.Response, error) {
+	if strings.HasPrefix(req.System, profileSystem) {
+		f.profile.Add(1)
+		if strings.Contains(req.Messages[0].Content, "Audit 20") {
+			// The later pages are in the prompt, so the richer profile is
+			// available: two fields instead of one.
+			return model.Response{Text: `{"fields":[` +
+				`{"f":"display_name","v":"Acme","e":"s0","c":0.9},` +
+				`{"f":"industry","v":"Audit 20","e":"s0","c":0.9}]}`}, nil
+		}
+		return model.Response{Text: `{"fields":[{"f":"display_name","v":"Acme","e":"s0","c":0.9}]}`}, nil
+	}
+	return f.laneFake.Complete(ctx, req)
+}
+
+func TestALargeCrawlIsProfiledOnEverythingItFound(t *testing.T) {
+	// A 40-page site was profiled from the first 8 pages and never asked
+	// again, so every page the crawl found afterwards -- About, team,
+	// services -- reached the fact lane but never the profile.
+	const pages = profileTriggerNonLegalPages * 3
+	site := streamFixtureSite(pages)
+	var profileCalls atomic.Int32
+	brain := growingProfileFake{
+		laneFake: laneFake{pageReplies: map[string]string{}},
+		profile:  &profileCalls,
+	}
+	for i := 0; i < pages; i++ {
+		pageURL := fmt.Sprintf("%s/services-%02d", seedURL, i)
+		brain.pageReplies[pageURL] = fmt.Sprintf(
+			`{"facts":[{"f":"service","v":"Audit %02d — catalog line","e":"s0"}]}`, i)
+	}
+	crawler := testSiteCrawler(site)
+	// Commit a few pages per round, the way a real crawl arrives. With the
+	// whole site landing in one wave the trigger already sees everything
+	// and a second pass would be pointless -- which is itself correct, and
+	// is what the sibling test covers.
+	crawler.fetchWave = 4
+
+	_, extraction, err := crawlAndExtract(context.Background(), crawler,
+		evidenceExtractor{brain: brain, factBrain: brain}, seedURL, nil, nil)
+	if err != nil {
+		t.Fatalf("crawlAndExtract: %v", err)
+	}
+	if extraction.err != nil {
+		t.Fatalf("clean lanes reported an error: %v", extraction.err)
+	}
+	if got := profileCalls.Load(); got != 2 {
+		t.Fatalf("profile lane fired %d times, want 2 (early answer, then the whole crawl)", got)
+	}
+	if len(extraction.fields) < 2 {
+		t.Fatalf("profile kept %d fields, want the richer answer the second pass found",
+			len(extraction.fields))
 	}
 }

--- a/backend/internal/compose/siteprofile.go
+++ b/backend/internal/compose/siteprofile.go
@@ -165,8 +165,10 @@ func profileExcerptPages(pages []crawlPage) []crawlPage {
 	return out
 }
 
-// extractProfile runs the one profile call and gates its reply against
-// the globally numbered excerpt index.
+// extractProfile runs one profile call and gates its reply against the
+// globally numbered excerpt index. The read may call it twice — see
+// reprofileOverWholeCrawl — so this must stay free of state that assumes
+// a single invocation.
 func (x evidenceExtractor) extractProfile(ctx context.Context, pages []crawlPage) ([]evidencedField, error) {
 	excerpts := profileExcerptPages(pages)
 	idx := newSnippetIndex(excerpts)

--- a/scripts/check-lint-modules.sh
+++ b/scripts/check-lint-modules.sh
@@ -67,8 +67,13 @@ fi
 # a type-checkable package; it has nothing to say here. They are NOT unchecked
 # code: the craft gate, the license header test and the tree-wide gofmt gate all
 # cover fixtures/, and none of the three needs to typecheck to do its job.
+# `s#/\?go\.mod$##` reads as an optional slash under GNU sed and as a LITERAL
+# backslash-slash under the BSD sed macOS ships, so on a developer laptop every
+# path kept its `/go.mod` suffix, `cd` failed with "Not a directory", and the
+# gate reported findings in eight modules it had never entered. Two plain
+# substitutions say the same thing in both dialects.
 modules="$(git ls-files '*go.mod' \
-  | sed 's#/\?go\.mod$##' \
+  | sed -e 's#/go\.mod$##' -e 's#^go\.mod$#.#' \
   | grep -v '^backend$' \
   | grep -v '^fixtures/' \
   | sort)"


### PR DESCRIPTION
The profile lane fires once, as soon as eight non-legal pages exist, and never again. On a forty-page site the company profile is therefore written from a fifth of the evidence: the About, team and services pages the crawl goes on to find reach the fact lane but never the profile.

It now asks again, once, over the finished corpus — but only when the crawl at least doubled after the trigger, so a site that ended near it does not pay for a second call to confirm the first answer.

| site | before | + boilerplate fix (#1355) | + this |
|---|---|---|---|
| shopware.com | 4 | — | **12** |
| algolia.com | 2 | 11 | **12** |
| arvato.com | 2 | 3 | unchanged |

arvato is untouched by this change: its six legal pages delay the trigger past the halfway mark, so no re-run is warranted there.

## Review findings, fixed before merge

- **The second pass discarded valid fields.** Keeping whichever list was longer threw away work, because the passes read different evidence — the re-run can ground `usp` and `history` while missing an `industry` the first pass had. Both answers clear the same evidence gate, so they are merged, with the re-run winning a contested field because it read the whole crawl. Pinned by `TestARerunNeverDiscardsAFieldTheFirstPassGrounded`.
- **Three comments still said the lane runs exactly once**, including `extractProfile`'s own doc — which is where somebody would look before adding state that assumes a single invocation.

## Also: the lint gate has been passing without running

`scripts/check-lint-modules.sh` built its module list with `sed 's#/\?go\.mod$##'` — an optional slash under GNU sed, a literal backslash under the BSD sed macOS ships. Every path kept its `/go.mod` suffix, `cd` failed with "Not a directory", and the gate reported findings in eight modules it had never entered. Reproduced on clean `origin/main` before changing anything.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Profiles the whole crawl instead of only the first eight non-legal pages. Previously the profile fired once at 8 pages; now it may re-run once over the finished corpus when the site at least doubled after the trigger, merging answers so the re-run wins conflicts and no field from the first pass is lost.

- Adds a second, conditional pass (growth factor = 2). The re-run is serial over the finished crawl; at most one extra model call per read.
- Merges profile fields across passes; keeps all grounded fields. The re-run’s value wins on conflicts.
- Re-run failures are logged and do not join `extraction.err`; skips the re-run when the first pass failed for budget; if the re-run succeeds after a first-pass failure, the read is not marked partial.
- Increases `extractLaneBudget` from 90s to 150s to account for the serial re-run.
- Tests cover double-run conditions, merge semantics that keep unique fields, budget-deferral and fail-then-recover cases; deterministic streaming now expects a re-run when warranted and asserts by field name.
- Fixes the lint gate so it runs on macOS and Linux by replacing the GNU-only `sed` pattern in `scripts/check-lint-modules.sh`.

<sup>Written for commit 9bbe742ded6f4d8a01f099e77b9a96ac10ce7493. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1359?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

