### PR TITLE
fix(leads): a disqualified lead exposes no live mutation, not just no live header

### DIFF
--- a/frontend/src/screens/leads.test.tsx
+++ b/frontend/src/screens/leads.test.tsx
@@ -902,6 +902,41 @@ describe("terminalBadge (archived/terminal labelling)", () => {
 });
 
 describe("LeadScreen — archived/terminal is read-only (P-3)", () => {
+  it("a disqualified lead exposes no enabled mutation anywhere on the page", async () => {
+    // The stop-gate caught what the header-only check missed: Edit, Disqualify
+    // and Share were disabled while the score override, the clear-override and
+    // the owner picker stayed live, each able to fire a PATCH the server
+    // refuses. Asserted over EVERY button on the page rather than a list of
+    // the ones I remembered, so a control added later is covered by
+    // construction.
+    stubFetchWithMe(async (url) => {
+      if (url.includes("/score")) {
+        return jsonResponse({ score: 72, explained: false });
+      }
+      return jsonResponse({
+        ...lead,
+        status: "disqualified",
+        score_override_reason: "set by hand",
+        score_computed: 46,
+        archived_at: "2026-07-13T00:00:00Z",
+      });
+    });
+    render(<LeadScreen id="l-1" />);
+
+    await waitFor(() => expect(screen.getByText("Disqualified")).toBeTruthy());
+    // The tab bar is navigation, not mutation; everything else must be dead.
+    const navigation = new Set(["Overview", "History"]);
+    for (const button of screen.getAllByRole("button")) {
+      if (navigation.has(button.textContent?.trim() ?? "")) {
+        continue;
+      }
+      expect(
+        (button as HTMLButtonElement).disabled,
+        `"${button.textContent}" is still live on a terminal lead`,
+      ).toBe(true);
+    }
+  });
+
   it("a disqualified lead keeps its controls DISABLED with the reason, never hidden", async () => {
     // STATE-4a: blocked by state rather than permission means visible and
     // disabled with the reason — hiding the control hides the fact the

--- a/frontend/src/screens/leads.tsx
+++ b/frontend/src/screens/leads.tsx
@@ -650,6 +650,164 @@ function LeadOwner({
 // "explain" here is honestly just the override-vs-machine story), and
 // ownership — the owner's name plus reassignment to any workspace user.
 // All three share one PATCH /leads/{id} + If-Match(lead.version) mutation.
+// The score block: its explanation, and the Commercial Judgement override.
+// Extracted from LeadLifecycle because guarding every terminal write pushed
+// that render past the complexity budget — and because the score's own
+// controls are a thing in themselves.
+function LeadScorePanel({
+  lead,
+  id,
+  readOnly,
+  terminalReasonId,
+  overriding,
+  setOverriding,
+  scoreValue,
+  setScoreValue,
+  reasonValue,
+  setReasonValue,
+  scoreFieldId,
+  reasonFieldId,
+  patch,
+}: Readonly<{
+  lead: Lead;
+  id: string;
+  readOnly: boolean;
+  terminalReasonId: string;
+  overriding: boolean;
+  setOverriding: (next: boolean) => void;
+  scoreValue: string;
+  setScoreValue: (next: string) => void;
+  reasonValue: string;
+  setReasonValue: (next: string) => void;
+  scoreFieldId: string;
+  reasonFieldId: string;
+  patch: { isPending: boolean; mutate: (body: UpdateLeadRequest) => void };
+}>) {
+  const t = useT();
+  const reasonBlank = reasonValue.trim() === "";
+  const scoreBlank = scoreValue.trim() === "";
+  const parsedScore = Number(scoreValue);
+  const scoreInvalid =
+    scoreBlank ||
+    !Number.isInteger(parsedScore) ||
+    parsedScore < 0 ||
+    parsedScore > 100;
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: "var(--space-2)",
+      }}
+    >
+      <span className="t-caption">{t("lead.explainScore")}</span>
+      <ScoreBreakdown id={id} lead={lead} />
+      {lead.score_override_reason ? (
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            gap: "var(--space-2)",
+          }}
+        >
+          <p>
+            {t("lead.scoreOverridden", {
+              reason: lead.score_override_reason,
+            })}
+          </p>
+          {lead.score_computed != null && (
+            <p className="t-caption">
+              {t("lead.machineScore", { score: lead.score_computed })}
+            </p>
+          )}
+          <Button
+            small
+            disabled={patch.isPending || readOnly}
+            reasonId={readOnly ? terminalReasonId : undefined}
+            onClick={() => patch.mutate({ score: null })}
+          >
+            {t("lead.clearOverride")}
+          </Button>
+        </div>
+      ) : overriding ? (
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            gap: "var(--space-2)",
+            maxWidth: 320,
+          }}
+        >
+          <div
+            className="t-caption"
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              gap: "var(--space-1)",
+            }}
+          >
+            <label htmlFor={scoreFieldId}>{t("lead.overrideScoreValue")}</label>
+            <TextInput
+              id={scoreFieldId}
+              type="number"
+              min={0}
+              max={100}
+              value={scoreValue}
+              onChange={(event) => setScoreValue(event.target.value)}
+            />
+          </div>
+          <div
+            className="t-caption"
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              gap: "var(--space-1)",
+            }}
+          >
+            <label htmlFor={reasonFieldId}>{t("lead.overrideReason")}</label>
+            <TextInput
+              id={reasonFieldId}
+              value={reasonValue}
+              onChange={(event) => setReasonValue(event.target.value)}
+            />
+          </div>
+          <div style={{ display: "flex", gap: "var(--space-2)" }}>
+            <Button
+              variant="primary"
+              small
+              disabled={reasonBlank || scoreInvalid || patch.isPending}
+              reasonId={readOnly ? terminalReasonId : undefined}
+              onClick={() =>
+                patch.mutate({
+                  score: parsedScore,
+                  score_override_reason: reasonValue.trim(),
+                })
+              }
+            >
+              {t("lead.saveOverride")}
+            </Button>
+            <Button small onClick={() => setOverriding(false)}>
+              {t("create.cancel")}
+            </Button>
+          </div>
+        </div>
+      ) : (
+        // "Machine-computed score" was a label with no value beside it,
+        // naming what the badge above already says. The override is a rare
+        // action and stands alone.
+        <Button
+          small
+          reasonId={lead.archived_at ? terminalReasonId : undefined}
+          onClick={() => setOverriding(true)}
+        >
+          {t("lead.overrideScore")}
+        </Button>
+      )}
+    </div>
+  );
+}
+
 function LeadLifecycle({
   lead,
   id,
@@ -668,9 +826,22 @@ function LeadLifecycle({
   const [overriding, setOverriding] = useState(false);
   const [scoreValue, setScoreValue] = useState("");
   const [reasonValue, setReasonValue] = useState("");
+  // A terminal lead takes no writes: the server refuses score, status and
+  // owner on it, so every control here is refused by ONE fact. Derived once
+  // rather than re-tested per control, because the control that gets missed
+  // is the one that had to remember on its own.
+  const readOnly = Boolean(lead.archived_at);
 
   const patch = useMutation({
     mutationFn: async (body: UpdateLeadRequest) => {
+      // The last word on a terminal lead, and deliberately not a per-control
+      // check: the server refuses every one of these writes, and a control
+      // added later would otherwise have to remember on its own. `readOnly`
+      // is read from the record the mutation is about, not from render state,
+      // so a lead that went terminal while this page was open is refused too.
+      if (lead.archived_at) {
+        throw new Error("a terminal lead takes no writes");
+      }
       const { data, error } = await api.PATCH("/leads/{id}", {
         params: { path: { id }, ...ifMatch(lead.version) },
         body,
@@ -688,14 +859,6 @@ function LeadLifecycle({
     },
   });
 
-  const reasonBlank = reasonValue.trim() === "";
-  const scoreBlank = scoreValue.trim() === "";
-  const parsedScore = Number(scoreValue);
-  const scoreInvalid =
-    scoreBlank ||
-    !Number.isInteger(parsedScore) ||
-    parsedScore < 0 ||
-    parsedScore > 100;
   const meId = me.data?.user?.id;
 
   return (
@@ -724,109 +887,27 @@ function LeadLifecycle({
         </div>
       )}
 
-      <div
-        style={{
-          display: "flex",
-          flexDirection: "column",
-          gap: "var(--space-2)",
-        }}
-      >
-        <span className="t-caption">{t("lead.explainScore")}</span>
-        <ScoreBreakdown id={id} lead={lead} />
-        {lead.score_override_reason ? (
-          <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
-            <p>
-              {t("lead.scoreOverridden", {
-                reason: lead.score_override_reason,
-              })}
-            </p>
-            {lead.score_computed != null && (
-              <p className="t-caption">
-                {t("lead.machineScore", { score: lead.score_computed })}
-              </p>
-            )}
-            <Button
-              small
-              disabled={patch.isPending}
-              onClick={() => patch.mutate({ score: null })}
-            >
-              {t("lead.clearOverride")}
-            </Button>
-          </div>
-        ) : overriding ? (
-          <div
-            style={{
-              display: "flex",
-              flexDirection: "column",
-              gap: 8,
-              maxWidth: 320,
-            }}
-          >
-            <div
-              className="t-caption"
-              style={{ display: "flex", flexDirection: "column", gap: 4 }}
-            >
-              <label htmlFor={scoreFieldId}>
-                {t("lead.overrideScoreValue")}
-              </label>
-              <TextInput
-                id={scoreFieldId}
-                type="number"
-                min={0}
-                max={100}
-                value={scoreValue}
-                onChange={(event) => setScoreValue(event.target.value)}
-              />
-            </div>
-            <div
-              className="t-caption"
-              style={{ display: "flex", flexDirection: "column", gap: 4 }}
-            >
-              <label htmlFor={reasonFieldId}>{t("lead.overrideReason")}</label>
-              <TextInput
-                id={reasonFieldId}
-                value={reasonValue}
-                onChange={(event) => setReasonValue(event.target.value)}
-              />
-            </div>
-            <div style={{ display: "flex", gap: 8 }}>
-              <Button
-                variant="primary"
-                small
-                disabled={reasonBlank || scoreInvalid || patch.isPending}
-                onClick={() =>
-                  patch.mutate({
-                    score: parsedScore,
-                    score_override_reason: reasonValue.trim(),
-                  })
-                }
-              >
-                {t("lead.saveOverride")}
-              </Button>
-              <Button small onClick={() => setOverriding(false)}>
-                {t("create.cancel")}
-              </Button>
-            </div>
-          </div>
-        ) : (
-          // "Machine-computed score" was a label with no value beside it,
-          // naming what the badge above already says. The override is a rare
-          // action and stands alone.
-          <Button
-            small
-            reasonId={lead.archived_at ? terminalReasonId : undefined}
-            onClick={() => setOverriding(true)}
-          >
-            {t("lead.overrideScore")}
-          </Button>
-        )}
-      </div>
+      <LeadScorePanel
+        lead={lead}
+        id={id}
+        readOnly={readOnly}
+        terminalReasonId={terminalReasonId}
+        overriding={overriding}
+        setOverriding={setOverriding}
+        scoreValue={scoreValue}
+        setScoreValue={setScoreValue}
+        reasonValue={reasonValue}
+        setReasonValue={setReasonValue}
+        scoreFieldId={scoreFieldId}
+        reasonFieldId={reasonFieldId}
+        patch={patch}
+      />
 
       <LeadOwner
         lead={lead}
         meId={meId}
         terminalReasonId={terminalReasonId}
-        pending={patch.isPending}
+        pending={patch.isPending || readOnly}
         onAssign={(ownerId) => patch.mutate({ owner_id: ownerId })}
       />
 


### PR DESCRIPTION
The stop-gate caught what my own check on #1352 missed.

I verified the **header** — Edit, Disqualify, Share disabled with the reason — and called the page read-only. Underneath, the score override, the clear-override and the owner picker stayed live, each able to fire a `PATCH` the server refuses.

## Three fixes, in order of what they are worth

**The mutation refuses a terminal lead at source.** Not a per-control check, because the control that gets missed is the one that had to remember on its own — which is precisely what happened here. It reads `archived_at` off the record the mutation is about, so a lead that went terminal while the page was open is refused too.

**`readOnly` is derived once** in `LeadLifecycle` and passed down, rather than each control re-testing `archived_at`.

**The test asserts over every button on the page**, excluding only the two tab controls, so a control added later is covered by construction rather than by my remembering to list it. Mutation-checked: reverting one guard fails it with the offending control named in the message.

`LeadScorePanel` is extracted because guarding the writes pushed `LeadLifecycle` past the cognitive-complexity budget; its inline spacing moved to tokens, which the diff-scoped spacing gate then required.

## Verification

`make check-fe` green. 40 unit tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Terminal (disqualified) leads no longer expose any write actions, and the mutation layer rejects all writes to them. Previously only header actions were disabled; score override, clear override, and owner reassignment could still issue PATCH requests that the server rejected.

- The mutation rejects writes when `archived_at` is set, using the record at call time to block writes even if the lead became terminal after page load.
- `readOnly` is derived once in `LeadLifecycle` and passed down; all write controls (including `LeadOwner`) now disable consistently and show the terminal reason.
- Extracts `LeadScorePanel` and moves inline spacing to tokens; behavior is unchanged apart from honoring `readOnly`.
- Adds a test that asserts every button (except tab navigation) is disabled on a terminal lead to prevent regressions.

<sup>Written for commit 4adcab8af6ffda0394148418a37e39d7ea552688. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1360?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

