### PR TITLE
fix(siteread): read a multilingual site, and stop calling an industry page an imprint

### DIFF
--- a/backend/internal/compose/siteboilerplate.go
+++ b/backend/internal/compose/siteboilerplate.go
@@ -37,8 +37,17 @@ const (
 	// evidence would cut real text from a small site.
 	boilerplateMinPages = 4
 	// boilerplateMinShare is the fraction of pages that must carry the
-	// prefix. A menu is on nearly every page; a section header is not.
-	boilerplateMinShare = 0.6
+	// prefix. A menu is on nearly every page of ONE language; a section
+	// header is on a few.
+	//
+	// A quarter, not a majority, because a multilingual site has one menu
+	// per language: arvato.com crawls in English, German, Dutch and
+	// Portuguese, so its largest single menu covers 9 of 38 pages (26%) and
+	// a 60% bar found nothing on the site that needed it most. Each menu is
+	// still removed from the pages that carry it — the trimming is per page
+	// — and the other guards keep a section heading shared by a handful of
+	// pages from qualifying.
+	boilerplateMinShare = 0.25
 	// boilerplateMinRunes is the shortest prefix worth removing. Below
 	// this the win is noise and the risk of eating a real sentence is real.
 	boilerplateMinRunes = 200
@@ -71,6 +80,10 @@ const (
 	// it the pages are returned untouched -- the profile lane still works,
 	// it just keeps the chrome, which is the pre-existing behaviour.
 	boilerplateMaxCorpusBytes = 4 << 20
+	// boilerplateMaxRounds bounds the per-language passes. A site with more
+	// menus than this keeps the rest of its chrome, which is the old
+	// behaviour and costs only excerpt budget.
+	boilerplateMaxRounds = 6
 )
 
 // stripSharedPrefix removes the navigation chrome that opens most of a site's
@@ -94,11 +107,27 @@ func stripSharedPrefix(pages []crawlPage) []crawlPage {
 		return out
 	}
 
-	prefix := sharedOpening(pages)
+	// A multilingual site has one menu PER LANGUAGE, and each covers only
+	// its own pages: arvato.com's largest covers 10 of 38. One pass removes
+	// one menu and leaves the other locales carrying theirs, so the search
+	// repeats on what remains until nothing more qualifies.
+	for round := 0; round < boilerplateMaxRounds; round++ {
+		if !stripOneSharedBlock(out) {
+			break
+		}
+	}
+	return out
+}
+
+// stripOneSharedBlock finds the single most-shared opening in pages and cuts
+// it from every page carrying it, in place. Reports whether it cut anything.
+func stripOneSharedBlock(out []crawlPage) bool {
+	prefix := sharedOpening(out)
 	if utf8.RuneCountInString(prefix) < boilerplateMinRunes {
-		return out
+		return false
 	}
 
+	cut := false
 	for i, page := range out {
 		// The block may sit behind the page's own title, so cut it out
 		// wherever it starts rather than only at rune zero.
@@ -127,8 +156,9 @@ func stripSharedPrefix(pages []crawlPage) []crawlPage {
 			continue
 		}
 		out[i].Text = trimmed
+		cut = true
 	}
-	return out
+	return cut
 }
 
 // chromeSearchRunes is how far into a page the shared header may start. Real
@@ -142,6 +172,11 @@ const chromeSearchRunes = 300
 // one is compared against every other page, so an adversarial corpus of very
 // short words would otherwise turn this quadratic in page length.
 const chromeMaxStarts = 60
+
+// chromeAnchorRunes is how many of a candidate's opening characters are
+// looked for in another page. Long enough to be distinctive, short enough
+// that a page which starts the menu at a different character still matches.
+const chromeAnchorRunes = 60
 
 // sharedOpening finds the longest opening that enough pages begin with,
 // allowing each page a short unique lead-in first.
@@ -231,20 +266,33 @@ func chromeStarts(text string) []int {
 
 // longestSharedRun returns the longest run of `head` that also appears near
 // the top of `other`, cut back to a word boundary.
+// It anchors on the head's first WORDS rather than scanning every offset:
+// the same menu begins at a different character in each page (arvato's pages
+// open with titles of different lengths), so requiring the match to start on
+// a word boundary in BOTH pages found nothing — the boundaries do not line
+// up. Locating the head's opening words inside the other page finds the run
+// wherever it sits.
 func longestSharedRun(head, other string) string {
+	anchor := head
+	if runes := []rune(anchor); len(runes) > chromeAnchorRunes {
+		anchor = string(runes[:chromeAnchorRunes])
+	}
+	if strings.TrimSpace(anchor) == "" {
+		return ""
+	}
 	limit := len(other)
 	if runes := []rune(other); len(runes) > chromeSearchRunes {
 		limit = len(string(runes[:chromeSearchRunes]))
 	}
-	for start := 0; start < limit; start++ {
-		if start > 0 && (other[start-1] != ' ' || other[start] == ' ') {
-			continue
-		}
-		if shared := commonPrefix(head, other[start:]); utf8.RuneCountInString(shared) >= boilerplateMinRunes {
-			return shared
-		}
+	at := strings.Index(other[:min(limit+len(anchor), len(other))], anchor)
+	if at < 0 {
+		return ""
 	}
-	return ""
+	shared := commonPrefix(head, other[at:])
+	if utf8.RuneCountInString(shared) < boilerplateMinRunes {
+		return ""
+	}
+	return shared
 }
 
 // blockDominatesPages reports whether removing the shared run would leave a

--- a/backend/internal/compose/siteboilerplate_test.go
+++ b/backend/internal/compose/siteboilerplate_test.go
@@ -218,3 +218,42 @@ func TestTheCutNeverInventsAPassageThePageDidNotContain(t *testing.T) {
 		}
 	}
 }
+
+func TestEachLanguageLosesItsOwnMenu(t *testing.T) {
+	// A multilingual site carries one menu per language, and no single menu
+	// is on a majority of pages: arvato.com crawls in four languages, so its
+	// largest covers 10 of 38. One pass strips one menu and leaves the other
+	// locales carrying theirs, so the search has to repeat.
+	const englishMenu = "Products Solutions Industries Resources Company " +
+		"Partners Support Login Logout Language English Deutsch Nederlands " +
+		"Automotive Consumer Products Healthcare Retail Technology Careers " +
+		"Investors Press Contact About us Why we exist Customers "
+	const germanMenu = "Produkte Lösungen Branchen Ressourcen Unternehmen " +
+		"Partner Support Anmelden Abmelden Sprache English Deutsch Nederlands " +
+		"Automobil Konsumgüter Gesundheit Handel Technologie Karriere " +
+		"Investoren Presse Kontakt Über uns Warum es uns gibt Kunden "
+
+	var pages []crawlPage
+	for i, menu := range []string{englishMenu, germanMenu} {
+		for j := 0; j < 4; j++ {
+			body := fmt.Sprintf("Page %d-%d. ", i, j) +
+				filler(fmt.Sprintf("topic %d-%d", i, j))
+			pages = append(pages, crawlPage{
+				URL:  fmt.Sprintf("https://example.test/l%d/p%d", i, j),
+				Text: fmt.Sprintf("Title %d-%d ", i, j) + menu + body,
+			})
+		}
+	}
+
+	stripped := stripSharedPrefix(pages)
+
+	for i, page := range stripped {
+		if strings.Contains(page.Text, "Investors Press Contact") ||
+			strings.Contains(page.Text, "Investoren Presse Kontakt") {
+			t.Errorf("page %d kept its menu: %.90q", i, page.Text)
+		}
+		if !strings.Contains(page.Text, "topic") {
+			t.Errorf("page %d lost its own text: %.90q", i, page.Text)
+		}
+	}
+}

--- a/backend/internal/compose/sitecrawlrank.go
+++ b/backend/internal/compose/sitecrawlrank.go
@@ -97,8 +97,18 @@ func legalIdentityPath(rawURL string) bool {
 		return false
 	}
 	last := segments[len(segments)-1]
-	if containsAny(last, "impressum", "imprint") || last == "legal-notice" || last == "publisher" {
+	if containsAny(last, "impressum", "imprint") || last == "legal-notice" {
 		return true
+	}
+	// "publisher" is an imprint only at the TOP of a site, because it is also
+	// an ordinary industry a company sells to. arvato.com publishes
+	// /industries/publisher in four languages, and reading those as legal
+	// pages cost the profile lane its whole budget: six of its 38 pages were
+	// counted as legal, which both starves the commercial evidence the
+	// profile is built from and votes in the multi-entity census that decides
+	// whether the legal fields are withheld at all.
+	if last == "publisher" {
+		return len(segments) == 1
 	}
 	if last != "legal" {
 		return false

--- a/backend/internal/compose/sitecrawlrank_test.go
+++ b/backend/internal/compose/sitecrawlrank_test.go
@@ -75,3 +75,34 @@ func TestUntakenCandidatesIncludesLinksDiscoveredByAStoppingCommit(t *testing.T)
 		t.Fatalf("new queue entries without a taken slot are untaken, got %+v", got)
 	}
 }
+
+func TestAnIndustryPageNamedPublisherIsNotAnImprint(t *testing.T) {
+	// "publisher" names an imprint at the top of a site and an ordinary
+	// industry everywhere else. arvato.com publishes /industries/publisher
+	// in four languages; reading those as legal pages counted six of its 38
+	// pages as legal, which starves the commercial evidence the profile is
+	// built from and votes in the census that withholds the legal fields.
+	legal := []string{
+		"https://example.test/publisher",
+		"https://example.test/de/publisher",
+		"https://example.test/impressum",
+	}
+	for _, rawURL := range legal {
+		if !legalIdentityPath(rawURL) {
+			t.Errorf("%s should be read as the site's imprint", rawURL)
+		}
+	}
+
+	notLegal := []string{
+		"https://example.test/industries/publisher",
+		"https://example.test/de/branchen/publisher",
+		"https://example.test/nl/branches/publisher",
+		"https://example.test/pt/setores/publisher",
+		"https://example.test/solutions/publisher",
+	}
+	for _, rawURL := range notLegal {
+		if legalIdentityPath(rawURL) {
+			t.Errorf("%s is an industry page, not the site's imprint", rawURL)
+		}
+	}
+}


### PR DESCRIPTION
arvato.com returned 2 profile fields of a possible 15. Two separate defects, both found by reading its crawl rather than reasoning about it.

**An industry page was classified as the company's imprint.** `legalIdentityPath` treated any URL ending in `publisher` as legal identity, so `arvato.com/industries/publisher` and its three translations counted as legal pages — six of 38. That starves the commercial evidence the profile is built from *and* votes in the multi-entity census that decides whether the legal fields are withheld at all; the read carried a "disagreeing legal pages" warning throughout. `publisher` now means an imprint only at the top of a site, which is where the probe list looks for it. Across the 107 companies crawled so far this reclassifies exactly the four arvato pages — verified, not assumed.

**The boilerplate stripper then found nothing on the site**, for two reasons. It matched a candidate against another page only at a word boundary in *both*, and a menu starts at a different character in each page when the titles differ in length — so it anchors on the candidate's opening words instead. And it required a majority of pages to share the block, while a multilingual site has one menu **per language**: arvato's largest covers 10 of 38 pages, so a 60% bar excluded the only site that needed it. The bar is a quarter now, and the search repeats so each language loses its own menu (35% of arvato's corpus removed, all 38 pages).

| site | original | previous | now |
|---|---|---|---|
| arvato.com | 2 | 3 | **10** |
| algolia.com | 2 | 12 | 12 |
| bestit.de | 15 | 13 | 13 |

Both new behaviours are mutation-checked: reverting the publisher rule or the repeat-until-clean loop fails the tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reads multilingual sites correctly and stops misclassifying industry pages named "publisher" as the site's imprint. Previously, any URL ending in "publisher" counted as legal; now only a top-level `/publisher` qualifies. The boilerplate stripper now removes per-language menus; before, it found nothing on multilingual sites.

- legal page classification: treat "publisher" as imprint only at the site root; paths like `/industries/publisher` are industry pages, not legal identity. Removes the "disagreeing legal pages" warning and restores commercial evidence in profiles.
- boilerplate removal: lower shared-block threshold from 60% to 25%, anchor matches on the opening words (first 60 runes) instead of requiring both pages’ word boundaries to align, and repeat removal per-language up to 6 rounds. Existing guards remain (>=4 pages, >=200 runes, search within first 300 runes, corpus cap 4 MiB).
- impact: `arvato.com` returns 10 fields (was 2), warning removed; `algolia.com` remains 12; `bestit.de` remains 13. Tests cover per-language menus and "publisher" classification; mutation checks fail if either change is reverted.

<sup>Written for commit 1e24751a660391b50697ebfc7269a3ca77d0a78b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1361?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

