### PR TITLE
feat(license): require a license in production, and refuse a seat past the licensed count

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -6663,21 +6663,24 @@ paths:
         the process runs, so this reports what the installation last resolved rather than
         asking anything.
 
-        `state` is the posture: `valid` (a license the module honored), `absent` (none
-        configured — a supported state that runs), or `rejected` (one the module refused; an
-        installation in that state does not serve, so a client never sees it from a live
-        server).
+        `state` is the posture: `valid` (a license the module honored), `absent` (no license
+        configured, which only a non-production installation may run as), or `rejected` (one
+        the module refused). A serving process boots on a license or does not boot, so a client
+        reading this from a live server sees `valid` — or `absent` on a development
+        installation.
 
         `seats_granted` is ABSENT when there is no seat cap to report — no license, or one
         whose grant carries no seat count. That is not the same as a grant of zero seats, and a
         client that renders a missing value as `0` would tell an admin their license permits
-        nobody. `seats_used` counts full seats that are not deactivated; read seats are
-        unlimited and never metered (A62/ADR-0047).
+        nobody. `seats_used` counts every full seat the installation has not withdrawn —
+        neither deactivated nor suspended; read seats are unlimited and never metered
+        (A62/ADR-0047).
 
         `over_limit` is the server's own verdict on the pair, so a client cannot arrive at a
-        different answer than the one the installation acts on. Being over the limit is
-        reported, never enforced here: the workspace keeps working, which is P7's
-        warning-then-grace rather than a silent mid-month lockout.
+        different answer than the one the installation acts on. Nobody is ever demoted or
+        evicted by it and no session ends — what an exhausted entitlement stops is the NEXT
+        full seat, refused at `POST /users` and at reactivation with `seat_limit_reached`.
+        That is P7's warning-then-refusal rather than a silent mid-month lockout.
 
         Admin/ops-only, read included: a seat meter is the installation's commercial standing,
         and a rep reads their own seat elsewhere (UC-ADMIN-03 F1). Governed by the `license`
@@ -8468,7 +8471,18 @@ paths:
             application/json:
               schema: { $ref: '#/components/schemas/User' }
         '401': { $ref: '#/components/responses/Unauthorized' }
-        '403': { $ref: '#/components/responses/Forbidden' }
+        '403':
+          description: >-
+            Refused, with the reason distinguished by the problem `code`:
+            `permission_denied` (the caller is not an admin), or
+            `seat_limit_reached` — every full seat this installation's license grants is in
+            use. An invited member is a full seat, so no member is created; the `detail`
+            carries the granted and used counts, and an admin resolves it by deactivating a
+            member or licensing more seats. Nothing about it clears on its own, so a client
+            must not retry it.
+          content:
+            application/problem+json:
+              schema: { $ref: '#/components/schemas/Problem' }
         '404':
           description: >-
             Not found, with the reason distinguished by the problem `code`:
@@ -8585,7 +8599,17 @@ paths:
             application/json:
               schema: { $ref: '#/components/schemas/User' }
         '401': { $ref: '#/components/responses/Unauthorized' }
-        '403': { $ref: '#/components/responses/Forbidden' }
+        '403':
+          description: >-
+            Refused, with the reason distinguished by the problem `code`:
+            `permission_denied` (the caller is not an admin), or
+            `seat_limit_reached` — a deactivated member counts against nothing, so returning
+            a FULL seat to active takes one exactly as an invite does, and every seat this
+            installation's license grants is in use. The member stays deactivated. A read
+            seat is never refused here: read seats are unlimited and never counted.
+          content:
+            application/problem+json:
+              schema: { $ref: '#/components/schemas/Problem' }
         '404': { $ref: '#/components/responses/NotFound' }
         '409':
           description: >-
@@ -12947,8 +12971,10 @@ components:
           type: integer
           minimum: 0
           description: |
-            Full seats in use: not deactivated. Read seats are unlimited and never counted
-            (A62/ADR-0047).
+            Full seats in use: every one the installation has not withdrawn — neither
+            deactivated nor suspended — agent seats included. Read seats are unlimited and
+            never counted (A62/ADR-0047). This is the number a seat creation is refused
+            against, so the meter and the ceiling can never disagree.
         over_limit:
           type: boolean
           description: |

--- a/backend/internal/compose/integration/seatceiling_http_integration_test.go
+++ b/backend/internal/compose/integration/seatceiling_http_integration_test.go
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// The licensed seat ceiling as an admin meets it: the number the entitlement
+// screen shows is the number the invite is refused against, and the refusal
+// arrives as a verdict a client can act on rather than a server fault.
+//
+// It runs over the composed api because the wiring is the thing under test. The
+// posture reaches identity's seat writer through the composition root, and the
+// gap that shape exists to close — a role reporting a ceiling it does not
+// enforce — is invisible to any test that calls the service directly.
+
+import (
+	"net/http"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gradionhq/margince/backend/internal/compose"
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
+	"github.com/gradionhq/margince/backend/internal/platform/licensecheck"
+)
+
+// licenseEntitlement is the GET /installation/license body, named here rather
+// than decoded into the generated type so the test reads the WIRE — a field
+// renamed in the contract has to fail this, not follow it.
+type licenseEntitlement struct {
+	State        string `json:"state"`
+	SeatsGranted *int   `json:"seats_granted"`
+	SeatsUsed    int    `json:"seats_used"`
+	OverLimit    bool   `json:"over_limit"`
+}
+
+// problemDocument is the RFC 7807 shape every refusal on this surface takes.
+type problemDocument struct {
+	Status int    `json:"status"`
+	Code   string `json:"code"`
+	Detail string `json:"detail"`
+}
+
+// setupLicensedApp composes an api whose license grants whatever the returned
+// counter is set to. The grant is read at CALL time — as the real posture is,
+// since a watcher re-resolves it while the process runs — so a test can license
+// the installation for exactly the seats it turns out to be using.
+func setupLicensedApp(t *testing.T) (*apptest.AppEnv, *atomic.Int64) {
+	t.Helper()
+	granted := &atomic.Int64{}
+	e := apptest.SetupAppWithOptions(t, compose.WithLicensePosture(func() licensecheck.Posture {
+		return licensecheck.Posture{
+			State:     licensecheck.StateValid,
+			Grants:    licensecheck.Grants{licensecheck.SeatsAttribute: float64(granted.Load())},
+			CheckedAt: time.Date(2026, 8, 15, 9, 0, 0, 0, time.UTC),
+		}
+	}))
+	e.BootstrapWorkspace(t)
+	return e, granted
+}
+
+// invite asks for one more member and reports what the surface answered. A
+// refusal decodes into refusal when one is passed; a 201 body carries nothing
+// this file asserts on, and the entitlement read is what proves the seat.
+func invite(t *testing.T, e *apptest.AppEnv, email string, refusal *problemDocument) int {
+	t.Helper()
+	body := map[string]string{"email": email, "display_name": "Overflow", "role": "rep"}
+	if refusal == nil {
+		return e.Call(t, http.MethodPost, "/v1/users", body, nil, nil)
+	}
+	return e.Call(t, http.MethodPost, "/v1/users", body, nil, refusal)
+}
+
+func TestInviteAtTheLicensedCeilingIsRefusedWithTheNumberTheScreenShows(t *testing.T) {
+	e, granted := setupLicensedApp(t)
+
+	var before licenseEntitlement
+	if status := e.Call(t, http.MethodGet, "/v1/installation/license", nil, nil, &before); status != http.StatusOK {
+		t.Fatalf("GET /installation/license = %d, want 200", status)
+	}
+	if before.SeatsUsed == 0 {
+		t.Fatal("a bootstrapped installation reports no seats in use; every assertion below would hold vacuously")
+	}
+	// Licensed for exactly what it is using: the installation is full, and the
+	// screen says so before anybody is refused anything.
+	granted.Store(int64(before.SeatsUsed))
+
+	var refusal problemDocument
+	status := invite(t, e, "one-too-many@seatceiling.test", &refusal)
+	if status != http.StatusForbidden || refusal.Code != "seat_limit_reached" {
+		t.Fatalf("invite at the ceiling = %d %q, want 403 seat_limit_reached", status, refusal.Code)
+	}
+	// A verdict, not an outage: the detail says what happened and what to do
+	// about it, which is the difference between this and the opaque 500 an
+	// unclassified error would have produced.
+	if refusal.Detail == "" {
+		t.Error("the refusal carries no detail, so the admin is told a number-free 'forbidden'")
+	}
+
+	var after licenseEntitlement
+	e.Call(t, http.MethodGet, "/v1/installation/license", nil, nil, &after)
+	if after.SeatsUsed != before.SeatsUsed {
+		t.Errorf("seats in use = %d after the refused invite, want %d", after.SeatsUsed, before.SeatsUsed)
+	}
+	if after.OverLimit {
+		t.Error("the installation reports itself over its limit after a refusal that was supposed to prevent exactly that")
+	}
+}
+
+// The other side of the same wiring: one more licensed seat and the same
+// request succeeds. Without this, a gate that refused everything would pass the
+// test above.
+func TestInviteBelowTheLicensedCeilingIsAdmitted(t *testing.T) {
+	e, granted := setupLicensedApp(t)
+
+	var before licenseEntitlement
+	e.Call(t, http.MethodGet, "/v1/installation/license", nil, nil, &before)
+	granted.Store(int64(before.SeatsUsed + 1))
+
+	if status := invite(t, e, "welcome@seatceiling.test", nil); status != http.StatusCreated {
+		t.Fatalf("invite into a licensed seat = %d, want 201", status)
+	}
+
+	var after licenseEntitlement
+	e.Call(t, http.MethodGet, "/v1/installation/license", nil, nil, &after)
+	if after.SeatsUsed != before.SeatsUsed+1 {
+		t.Errorf("seats in use = %d after the invite, want %d", after.SeatsUsed, before.SeatsUsed+1)
+	}
+	if after.SeatsGranted == nil || *after.SeatsGranted != after.SeatsUsed {
+		t.Errorf("the screen reports granted=%v used=%d; the installation should now be exactly full",
+			after.SeatsGranted, after.SeatsUsed)
+	}
+	// And the next one is refused, on the same running process: the ceiling is
+	// read live, so an installation that fills up starts refusing without a
+	// restart.
+	var refusal problemDocument
+	if status := invite(t, e, "and-one-more@seatceiling.test", &refusal); status != http.StatusForbidden {
+		t.Errorf("invite once the licensed seats are used = %d %q, want 403", status, refusal.Code)
+	}
+}

--- a/backend/internal/compose/license.go
+++ b/backend/internal/compose/license.go
@@ -31,12 +31,18 @@ import (
 // watcher that holds it. The caller starts the watcher's re-check loop and
 // wires its posture into whatever reports it.
 //
-// It refuses a boot whose configured license the bundled module will not honor,
-// and reports — never refuses — an installation that configured none. The
-// asymmetry is the whole posture: an unlicensed installation is a supported
-// state that every development and CI process here runs in, while a license
-// that is present and refused is an operator mistake nobody downstream can
-// distinguish from a deliberate downgrade.
+// A serving role boots on a license or it does not boot. Three postures refuse
+// it — a license the bundled module will not honor, a module that could not run
+// at all, and, in production, no license configured — and the third is the one
+// the deployment posture decides: an installation that names itself
+// non-production through MARGINCE_ENV keeps running unlicensed, which is how
+// every development, test and CI process in this repository boots. MARGINCE_ENV
+// is fail-closed, so an installation that names nothing is production and is
+// held to a license.
+//
+// Both serving roles ask this question, and neither serves without an answer: an
+// api that refuses to boot beside a worker that shrugs would be a licensing
+// posture nobody could describe.
 func EnsureLicense(ctx context.Context, log *slog.Logger, cfg deployconfig.Config, env runtimeenv.Environment, lookup config.Lookup) (*licensecheck.Watcher, error) {
 	// The SOURCE is handed over, not a token: the watcher re-reads it, so a
 	// license the operator renews in place takes effect on the next re-check
@@ -48,8 +54,28 @@ func EnsureLicense(ctx context.Context, log *slog.Logger, cfg deployconfig.Confi
 		return nil, fmt.Errorf("%w — correct or remove license.token_file (or %s) and start again",
 			err, deployconfig.LicenseTokenEnvVar)
 	}
+	if err := refuseUnlicensedProduction(watcher.Posture(), env); err != nil {
+		return nil, err
+	}
 	logLicensePosture(ctx, log, watcher.Posture(), cfg.License.TokenOrigin(lookup))
 	return watcher, nil
+}
+
+// refuseUnlicensedProduction stops a production boot that configured no license.
+//
+// The error says both halves, because the operator reading it is in one of two
+// situations that look identical from here: the installation is licensed and
+// lost its token reference in a redeploy, or it is a development installation
+// that never named itself one. Naming only the license would send the second
+// operator looking for a token they were never issued.
+func refuseUnlicensedProduction(posture licensecheck.Posture, env runtimeenv.Environment) error {
+	if posture.State != licensecheck.StateAbsent || env.IsNonProduction() {
+		return nil
+	}
+	return fmt.Errorf("no license is configured and this installation is production: "+
+		"point license.token_file (or %s) at the license token issued for this installation, "+
+		"or, if this is a development or test installation, set %s=%s",
+		deployconfig.LicenseTokenEnvVar, runtimeenv.EnvVar, runtimeenv.Development)
 }
 
 // logLicensePosture writes the one boot line an operator greps for. The module
@@ -69,20 +95,22 @@ func logLicensePosture(ctx context.Context, log *slog.Logger, posture licenseche
 		attrs = append(attrs, "seats", seats)
 	}
 	if posture.State == licensecheck.StateAbsent {
-		// A warning, not an error: it boots, and it is meant to be noticed. An
-		// installation nobody licensed is fine; one that lost its license
-		// reference in a redeploy looks exactly the same from here, and only the
-		// operator can tell which this is.
-		log.WarnContext(ctx, "no license configured; the installation is running unlicensed", attrs...)
+		// Only a non-production installation reaches this line — production
+		// refused the boot above — and it is a warning rather than an info
+		// because the posture is worth noticing in a log that gets read: an
+		// installation running unlicensed is entitled to nothing, so nothing it
+		// does here proves what a licensed installation would do.
+		log.WarnContext(ctx, "no license configured; this non-production installation is running unlicensed", attrs...)
 		return
 	}
 	log.InfoContext(ctx, "license verified", attrs...)
 }
 
-// WithLicensePosture wires the resolved posture into this role's /metrics. The
-// function is read at scrape time rather than the value being copied in, so an
-// exposition reports what the watcher last resolved instead of what the process
-// booted with.
+// WithLicensePosture wires the resolved posture into everything this role does
+// with it: the /metrics section, the entitlement surface, and the ceiling seat
+// creation is held to. The function is read at scrape and call time rather than
+// the value being copied in, so each of them reports and enforces what the
+// watcher last resolved instead of what the process booted with.
 func WithLicensePosture(posture func() licensecheck.Posture) Option {
 	return func(s *Server, pool *pgxpool.Pool) {
 		s.licensePosture = posture
@@ -96,6 +124,13 @@ func WithLicensePosture(posture func() licensecheck.Posture) Option {
 			seats:   identity.NewSeatUsage(InstallationDB(pool)),
 			posture: posture,
 		}
+		// The same posture reaches identity's seat writer as a ceiling, from the
+		// same call: a role that reports what a license grants must not be able to
+		// show an admin a number it does not hold them to. The posture is read at
+		// CALL time, so a license renewed in place raises the ceiling on the next
+		// re-check and one that lapses lowers it, without a restart — and nothing
+		// here touches a seat already in use, only the next one.
+		s.authHandlers = s.WithSeatCeiling(func() (int, bool) { return posture().Seats() })
 	}
 }
 

--- a/backend/internal/compose/license_test.go
+++ b/backend/internal/compose/license_test.go
@@ -19,25 +19,39 @@ import (
 	"github.com/gradionhq/margince/backend/internal/shared/runtimeenv"
 )
 
-// unlicensedEnvironment makes the environment say what these tests need it to
-// say: nothing. deployconfig.License.Token reads MARGINCE_LICENSE before it
-// looks at the file reference, so an engineer or CI lane that exports a real
-// license would otherwise fail all three for a reason that has nothing to do
-// with the code — one would stop being absent, and two would stop exercising
-// the file path they name. (the environment travels as a parameter now, so these
-// three do not run parallel.)
-func unlicensedEnvironment(t *testing.T) {
-	t.Helper()
+// Every case here hands EnsureLicense a lookup that answers nothing, which is
+// what makes them tests of the code rather than of the shell they run in: the
+// token is read through that lookup, so an engineer or CI lane exporting a real
+// MARGINCE_LICENSE cannot turn an absent posture into a valid one, or make a
+// case that names a token FILE read a variable instead.
+
+// A production installation serves on a license or it does not serve. The whole
+// point of the gate is that this is the DEFAULT: MARGINCE_ENV is fail-closed, so
+// an installation that names no posture is held to a license.
+func TestEnsureLicenseRefusesAProductionBootWithNoLicense(t *testing.T) {
+	_, err := EnsureLicense(context.Background(), slog.New(slog.DiscardHandler), deployconfig.Config{},
+		runtimeenv.Parse(""), config.Static(nil))
+	if err == nil {
+		t.Fatal("EnsureLicense booted a production installation that configured no license")
+	}
+	// Both ways out are named, because the operator reading this is either
+	// licensed and missing the reference, or running a development installation
+	// that never said so — and the message that names one of the two sends the
+	// other operator after a problem they do not have.
+	for _, want := range []string{"license.token_file", deployconfig.LicenseTokenEnvVar, runtimeenv.EnvVar, string(runtimeenv.Development)} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("boot refusal %q does not name %q", err, want)
+		}
+	}
 }
 
-func TestEnsureLicenseBootsUnlicensedAndSaysSo(t *testing.T) {
-	unlicensedEnvironment(t)
+func TestEnsureLicenseBootsUnlicensedInNonProductionAndSaysSo(t *testing.T) {
 	var log bytes.Buffer
 	logger := slog.New(slog.NewTextHandler(&log, &slog.HandlerOptions{Level: slog.LevelInfo}))
 
-	watcher, err := EnsureLicense(context.Background(), logger, deployconfig.Config{}, runtimeenv.Production, config.Static(nil))
+	watcher, err := EnsureLicense(context.Background(), logger, deployconfig.Config{}, runtimeenv.Development, config.Static(nil))
 	if err != nil {
-		t.Fatalf("EnsureLicense refused an unlicensed installation: %v", err)
+		t.Fatalf("EnsureLicense refused an unlicensed development installation: %v", err)
 	}
 	if got := watcher.Posture().State; got != licensecheck.StateAbsent {
 		t.Errorf("posture = %q, want %q", got, licensecheck.StateAbsent)
@@ -53,23 +67,27 @@ func TestEnsureLicenseBootsUnlicensedAndSaysSo(t *testing.T) {
 	}
 }
 
+// A refused license refuses the boot in EVERY posture. Only the ABSENT case
+// bends for a development installation: naming yourself non-production is how
+// you say you have no license, not a way to run one the module judged.
 func TestEnsureLicenseRefusesTheBootOnALicenseTheModuleWillNotHonor(t *testing.T) {
-	unlicensedEnvironment(t)
 	path := filepath.Join(t.TempDir(), "license")
 	if err := os.WriteFile(path, []byte("not.a.license"), 0o600); err != nil {
 		t.Fatalf("write token file: %v", err)
 	}
 	cfg := deployconfig.Config{License: deployconfig.License{TokenFile: path}}
 
-	_, err := EnsureLicense(context.Background(), slog.New(slog.DiscardHandler), cfg, runtimeenv.Production, config.Static(nil))
-	if err == nil {
-		t.Fatal("EnsureLicense booted on a license the bundled module refuses")
-	}
-	// The refusal has to name the setting to correct, or an operator is left to
-	// guess which of two places the token came from.
-	for _, want := range []string{"license.token_file", deployconfig.LicenseTokenEnvVar} {
-		if !strings.Contains(err.Error(), want) {
-			t.Errorf("boot refusal %q does not name %q", err, want)
+	for _, env := range []runtimeenv.Environment{runtimeenv.Production, runtimeenv.Development} {
+		_, err := EnsureLicense(context.Background(), slog.New(slog.DiscardHandler), cfg, env, config.Static(nil))
+		if err == nil {
+			t.Fatalf("EnsureLicense booted a %s installation on a license the bundled module refuses", env)
+		}
+		// The refusal has to name the setting to correct, or an operator is left to
+		// guess which of two places the token came from.
+		for _, want := range []string{"license.token_file", deployconfig.LicenseTokenEnvVar} {
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("boot refusal %q (%s) does not name %q", err, env, want)
+			}
 		}
 	}
 }
@@ -77,7 +95,6 @@ func TestEnsureLicenseRefusesTheBootOnALicenseTheModuleWillNotHonor(t *testing.T
 // A path that does not resolve fails the boot rather than reading as an
 // unlicensed installation, which is the same posture to everything downstream.
 func TestEnsureLicenseRefusesAnUnreadableTokenFile(t *testing.T) {
-	unlicensedEnvironment(t)
 	cfg := deployconfig.Config{License: deployconfig.License{TokenFile: filepath.Join(t.TempDir(), "typo")}}
 	if _, err := EnsureLicense(context.Background(), slog.New(slog.DiscardHandler), cfg, runtimeenv.Production, config.Static(nil)); err == nil {
 		t.Fatal("EnsureLicense booted with a token_file that does not exist")
@@ -190,10 +207,9 @@ func TestAssembledMetricsSectionsOmitTheLicenseWhenNoneWasWired(t *testing.T) {
 // posture logged without its source cannot answer "which license is this
 // installation running on".
 func TestEnsureLicenseBootLineNamesTheTokenSource(t *testing.T) {
-	unlicensedEnvironment(t)
 	var log bytes.Buffer
 	logger := slog.New(slog.NewTextHandler(&log, &slog.HandlerOptions{Level: slog.LevelInfo}))
-	if _, err := EnsureLicense(context.Background(), logger, deployconfig.Config{}, runtimeenv.Production, config.Static(nil)); err != nil {
+	if _, err := EnsureLicense(context.Background(), logger, deployconfig.Config{}, runtimeenv.Development, config.Static(nil)); err != nil {
 		t.Fatalf("EnsureLicense: %v", err)
 	}
 	if !strings.Contains(log.String(), "token_from=none") {

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -14585,8 +14585,10 @@ type LicenseEntitlement struct {
 	// grant carrying no seat count — which is not a grant of zero.
 	SeatsGranted *int `json:"seats_granted,omitempty"`
 
-	// SeatsUsed Full seats in use: not deactivated. Read seats are unlimited and never counted
-	// (A62/ADR-0047).
+	// SeatsUsed Full seats in use: every one the installation has not withdrawn — neither
+	// deactivated nor suspended — agent seats included. Read seats are unlimited and
+	// never counted (A62/ADR-0047). This is the number a seat creation is refused
+	// against, so the meter and the ceiling can never disagree.
 	SeatsUsed int `json:"seats_used"`
 
 	// State Whether a license was verified, none was configured, or one was refused. A client

--- a/backend/internal/modules/identity/seatceiling.go
+++ b/backend/internal/modules/identity/seatceiling.go
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package identity
+
+// The licensed ceiling on full seats, enforced where a seat comes into use.
+//
+// The LICENSE half of the question is not here — what a license grants is
+// resolved from the deployment file and the bundled validation module, which
+// identity knows nothing about — so the composition root injects the answer and
+// this module counts its own rows against it.
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+)
+
+// SeatCeiling answers how many full seats this installation's license admits.
+//
+// capped is false when nothing caps them: a license that grants no seat count,
+// or an unlicensed installation — which, since a production installation refuses
+// to boot without a license, means a development or test one. The two are
+// deliberately one answer here, because "uncapped" is the only thing identity
+// can do about either.
+type SeatCeiling func() (limit int, capped bool)
+
+// WithSeatCeiling binds the ceiling seat creation is held to, wired once at
+// composition from the same posture the entitlement screen and /metrics report
+// — so the number an admin is refused against is the number they were shown. A
+// role that wired no license posture caps nothing: it has no ceiling to
+// enforce, and inventing one would refuse seats on the strength of a license
+// nobody read.
+//
+// It binds on the SERVICE rather than on the returned handlers, because the
+// refusal has to happen inside the writer's transaction and the handlers are
+// not in it. That the service is shared by pointer is the point: one
+// installation has one licensed ceiling, whichever surface reaches the writer.
+func (h Handlers) WithSeatCeiling(ceiling SeatCeiling) Handlers {
+	if h.svc == nil {
+		// A handler set over no service reaches no writer — every route on it
+		// fails before one — so there is no seat creation here for a ceiling to
+		// hold. Answered rather than dereferenced, because a zero value staying
+		// zero is not the same thing as a wiring mistake.
+		return h
+	}
+	h.svc.seatCeiling = ceiling
+	return h
+}
+
+// refuseWhenNoSeatIsLeft stops a full seat from coming into use once the
+// licensed ceiling is reached. It runs INSIDE the caller's write transaction,
+// before the write it guards.
+//
+// The lock is what makes the count mean anything. Two admins inviting at the
+// same moment would otherwise both read one seat left and both take it, and the
+// installation would sit one seat over a ceiling nothing will bring it back
+// under. Every seat creation in this installation serializes on ONE key,
+// because the ceiling is a property of the SET of seats and not of any row in
+// it — so there is no finer key that would still be correct.
+func (s *Service) refuseWhenNoSeatIsLeft(ctx context.Context, tx pgx.Tx) error {
+	if s.seatCeiling == nil {
+		return nil
+	}
+	limit, capped := s.seatCeiling()
+	if !capped {
+		return nil
+	}
+	if err := storekit.LockWriteIdentity(ctx, tx, seatCeilingLockEntity, seatCeilingLockIdentity); err != nil {
+		return err
+	}
+	var used int
+	if err := tx.QueryRow(ctx, fullSeatsInUseQuery).Scan(&used); err != nil {
+		return fmt.Errorf("identity: counting full seats against the licensed ceiling: %w", err)
+	}
+	if used < limit {
+		return nil
+	}
+	// The numbers reach the admin: "no seats left" without them is a refusal
+	// nobody can act on, and both ways out of it — free one, or license more —
+	// are decisions only a human makes.
+	return fmt.Errorf("%w: this installation's license grants %d full seats and %d are in use; "+
+		"deactivate a member, or raise the licensed seat count", apperrors.ErrSeatLimitReached, limit, used)
+}
+
+// The one lock key every seat creation takes. Named here rather than spelled at
+// the call sites, because two spellings would be two locks and neither would
+// serialize anything.
+const (
+	seatCeilingLockEntity   = "app_user_seat"
+	seatCeilingLockIdentity = "licensed_ceiling"
+)

--- a/backend/internal/modules/identity/seatceiling_integration_test.go
+++ b/backend/internal/modules/identity/seatceiling_integration_test.go
@@ -1,0 +1,231 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package identity
+
+// The licensed full-seat ceiling over a real migrated Postgres: what it
+// refuses, what it admits, and which rows it counts.
+//
+// Every case runs the real writers — InviteUser, DeactivateUser,
+// ReactivateUser — because the ceiling's whole job is to sit inside their
+// transactions. A test that counted rows and asserted arithmetic would pass
+// with the gate deleted.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// licensedSeats is a ceiling the composition root would inject from a verified
+// license granting limit seats.
+func licensedSeats(limit int) SeatCeiling { return func() (int, bool) { return limit, true } }
+
+// licenseFor binds that ceiling the way the composition root does — through the
+// handler seam, which is the only thing that binds one in production. Setting
+// the field here instead would prove the gate works when a test sets it, which
+// is not the claim.
+func licenseFor(t *testing.T, e *revocationEnv, ceiling SeatCeiling) {
+	t.Helper()
+	NewHandlers(e.svc).WithSeatCeiling(ceiling)
+}
+
+// seatsInUse counts what the gate counts, through the gate's OWN statement —
+// the same constant the meter on the entitlement screen runs, so a test cannot
+// agree with a predicate the product does not have.
+//
+// The workspace predicate is the test's own, and the product needs none: an
+// installation serves exactly one organization, so every full seat in the
+// database is one of its seats. This suite seeds a workspace per environment
+// into a database that holds every other suite's, which is the one place that
+// assumption does not hold.
+func seatsInUse(t *testing.T, e *revocationEnv) int {
+	t.Helper()
+	var used int
+	if err := e.owner.QueryRow(context.Background(),
+		fullSeatsInUseQuery+` AND workspace_id = $1`, e.ws).Scan(&used); err != nil {
+		t.Fatalf("counting full seats in use: %v", err)
+	}
+	return used
+}
+
+// inviteOneMore invites a member nobody else in this suite will collide with.
+func inviteOneMore(t *testing.T, e *revocationEnv, who string) error {
+	t.Helper()
+	_, _, err := e.svc.InviteUser(e.wsCtx(e.admin), e.admin, InviteUserInput{
+		Email:       who + "-" + ids.NewV7().String()[24:] + "@seatceiling.test",
+		DisplayName: who,
+		Role:        "rep",
+	})
+	return err
+}
+
+func TestSeatCeilingRefusesAnInviteWhenEveryLicensedSeatIsInUse(t *testing.T) {
+	e := setupRevocationEnv(t, "seat-ceiling-full")
+	used := seatsInUse(t, e)
+	licenseFor(t, e, licensedSeats(used))
+
+	err := inviteOneMore(t, e, "overflow")
+	if !errors.Is(err, apperrors.ErrSeatLimitReached) {
+		t.Fatalf("invite at the ceiling: err = %v, want %v", err, apperrors.ErrSeatLimitReached)
+	}
+	// Both numbers reach the admin. "No seats left" on its own is a refusal
+	// nobody can act on: which of the two ways out to take — free a seat or
+	// license another — is a decision that needs the count to make.
+	for _, want := range []string{fmt.Sprint(used), "deactivate", "licensed seat count"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("the refusal %q does not carry %q", err, want)
+		}
+	}
+	// The refusal has to be the whole transaction's. A member created and then
+	// refused would leave the installation one seat over its license with a row
+	// nobody meant to write.
+	if got := seatsInUse(t, e); got != used {
+		t.Errorf("seats in use after the refused invite = %d, want %d", got, used)
+	}
+}
+
+// The boundary is the licensed number itself, checked from both sides in one
+// test: an off-by-one either refuses the seat the license paid for or hands out
+// one it did not.
+func TestSeatCeilingAdmitsTheLastLicensedSeatAndRefusesTheNext(t *testing.T) {
+	e := setupRevocationEnv(t, "seat-ceiling-last")
+	used := seatsInUse(t, e)
+	licenseFor(t, e, licensedSeats(used+1))
+
+	if err := inviteOneMore(t, e, "last-seat"); err != nil {
+		t.Fatalf("invite into the last licensed seat: %v", err)
+	}
+	if got := seatsInUse(t, e); got != used+1 {
+		t.Fatalf("seats in use = %d after taking the last one, want %d", got, used+1)
+	}
+	if err := inviteOneMore(t, e, "one-too-many"); !errors.Is(err, apperrors.ErrSeatLimitReached) {
+		t.Errorf("invite past the ceiling: err = %v, want %v", err, apperrors.ErrSeatLimitReached)
+	}
+}
+
+// Withdrawn access frees a seat. An admin who suspends somebody to make room —
+// which is what an admin at the ceiling will do — has to actually get the room.
+func TestSeatCeilingCountsNeitherASuspendedNorADeactivatedSeat(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		withdraw func(t *testing.T, e *revocationEnv)
+	}{
+		{
+			name: "deactivated through the real writer",
+			withdraw: func(t *testing.T, e *revocationEnv) {
+				if err := e.svc.DeactivateUser(e.wsCtx(e.admin), e.admin,
+					DeactivateUserInput{UserID: e.member.UserID}); err != nil {
+					t.Fatalf("deactivate: %v", err)
+				}
+			},
+		},
+		{
+			// Suspension has no writer on this surface today — it is set by the
+			// lockout path — so the status is written where the schema holds it.
+			name: "suspended",
+			withdraw: func(t *testing.T, e *revocationEnv) {
+				if _, err := e.owner.Exec(context.Background(),
+					`UPDATE app_user SET status = 'suspended' WHERE id = $1`, e.member.UserID); err != nil {
+					t.Fatalf("suspend: %v", err)
+				}
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			e := setupRevocationEnv(t, "seat-ceiling-withdrawn")
+			atTheCeiling := seatsInUse(t, e)
+			licenseFor(t, e, licensedSeats(atTheCeiling))
+			if err := inviteOneMore(t, e, "before"); !errors.Is(err, apperrors.ErrSeatLimitReached) {
+				t.Fatalf("the installation is not at its ceiling to begin with: err = %v", err)
+			}
+
+			tc.withdraw(t, e)
+
+			if got := seatsInUse(t, e); got != atTheCeiling-1 {
+				t.Fatalf("seats in use after withdrawing one = %d, want %d", got, atTheCeiling-1)
+			}
+			if err := inviteOneMore(t, e, "after"); err != nil {
+				t.Errorf("invite into the freed seat: %v", err)
+			}
+		})
+	}
+}
+
+// Reactivation is a seat coming back into use, so it answers to the same
+// ceiling an invite does. Nothing here demotes or evicts the member: they stay
+// deactivated until the installation has a seat for them (P7).
+func TestSeatCeilingRefusesReactivatingAFullSeatIntoAFullInstallation(t *testing.T) {
+	e := setupRevocationEnv(t, "seat-ceiling-reactivate")
+	if err := e.svc.DeactivateUser(e.wsCtx(e.admin), e.admin,
+		DeactivateUserInput{UserID: e.member.UserID}); err != nil {
+		t.Fatalf("deactivate: %v", err)
+	}
+	withoutThem := seatsInUse(t, e)
+	licenseFor(t, e, licensedSeats(withoutThem))
+
+	err := e.svc.ReactivateUser(e.wsCtx(e.admin), e.admin, e.member.UserID)
+	if !errors.Is(err, apperrors.ErrSeatLimitReached) {
+		t.Fatalf("reactivate at the ceiling: err = %v, want %v", err, apperrors.ErrSeatLimitReached)
+	}
+	var status string
+	if err := e.owner.QueryRow(context.Background(),
+		`SELECT status FROM app_user WHERE id = $1`, e.member.UserID).Scan(&status); err != nil {
+		t.Fatalf("reading the member's status: %v", err)
+	}
+	if status != "deactivated" {
+		t.Errorf("the refused reactivation left status %q, want deactivated", status)
+	}
+
+	licenseFor(t, e, licensedSeats(withoutThem+1))
+	if err := e.svc.ReactivateUser(e.wsCtx(e.admin), e.admin, e.member.UserID); err != nil {
+		t.Errorf("reactivate with a seat licensed for them: %v", err)
+	}
+}
+
+// A read seat is unlimited and never metered (A62/ADR-0047), so returning one
+// to active asks the full-seat ceiling nothing.
+func TestSeatCeilingDoesNotHoldAReadSeatToTheFullSeatGrant(t *testing.T) {
+	e := setupRevocationEnv(t, "seat-ceiling-read")
+	if _, err := e.owner.Exec(context.Background(),
+		`UPDATE app_user SET seat_type = 'read' WHERE id = $1`, e.member.UserID); err != nil {
+		t.Fatalf("make the member a read seat: %v", err)
+	}
+	if err := e.svc.DeactivateUser(e.wsCtx(e.admin), e.admin,
+		DeactivateUserInput{UserID: e.member.UserID}); err != nil {
+		t.Fatalf("deactivate: %v", err)
+	}
+	// Every full seat the installation has is licensed, and no more.
+	licenseFor(t, e, licensedSeats(seatsInUse(t, e)))
+
+	if err := e.svc.ReactivateUser(e.wsCtx(e.admin), e.admin, e.member.UserID); err != nil {
+		t.Errorf("reactivating a read seat against a full full-seat grant: %v", err)
+	}
+}
+
+// What an unlicensed installation and an uncapped license have in common: no
+// number to hold anybody to. Both reach identity as the same answer, and a
+// service nobody wired is the third spelling of it.
+func TestSeatCeilingAdmitsEverySeatWhenNothingCapsThem(t *testing.T) {
+	for name, ceiling := range map[string]SeatCeiling{
+		"a license that caps no seats": func() (int, bool) { return 0, false },
+		"no license posture wired":     nil,
+	} {
+		t.Run(name, func(t *testing.T) {
+			e := setupRevocationEnv(t, "seat-ceiling-uncapped")
+			licenseFor(t, e, ceiling)
+			for _, who := range []string{"first", "second", "third"} {
+				if err := inviteOneMore(t, e, who); err != nil {
+					t.Fatalf("invite %s under %s: %v", who, name, err)
+				}
+			}
+		})
+	}
+}

--- a/backend/internal/modules/identity/seatusage.go
+++ b/backend/internal/modules/identity/seatusage.go
@@ -60,12 +60,29 @@ func (s *SeatUsageStore) FullSeatsInUse(ctx context.Context) (int, error) {
 	}
 	var used int
 	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
-		return tx.QueryRow(ctx,
-			`SELECT count(*) FROM app_user
-			  WHERE seat_type = 'full' AND status <> 'deactivated'`).Scan(&used)
+		return tx.QueryRow(ctx, fullSeatsInUseQuery).Scan(&used)
 	})
 	if err != nil {
 		return 0, fmt.Errorf("identity: counting full seats in use: %w", err)
 	}
 	return used, nil
 }
+
+// fullSeatsInUseQuery is the ONE count the license is measured against: the
+// meter an admin reads on the entitlement screen and the ceiling that refuses
+// them a seat run this same statement. A meter nobody is held to and a ceiling
+// nobody can see are the same defect from two sides, and the only way the two
+// cannot drift is that there is one of them.
+//
+// The predicate is the three decisions above: full seats only, agents included,
+// and neither a suspended nor a deactivated seat — both are access the
+// installation has already withdrawn, and an admin who suspended somebody to
+// free a seat has to actually get it back.
+//
+// It names the statuses that do NOT count rather than the one that does. A seat
+// exists until the installation withdraws it, so a status added later should
+// count until somebody decides otherwise: the wrong way round would silently
+// stop metering a state nobody had thought about, and an installation would
+// issue seats its license never granted.
+const fullSeatsInUseQuery = `SELECT count(*) FROM app_user
+	 WHERE seat_type = 'full' AND status NOT IN ('suspended', 'deactivated')`

--- a/backend/internal/modules/identity/service.go
+++ b/backend/internal/modules/identity/service.go
@@ -52,6 +52,12 @@ type Service struct {
 	// successful resolution (installation.go) — the id is immutable for
 	// the process lifetime, so no request pays the lookup twice.
 	installation atomic.Pointer[ids.WorkspaceID]
+	// seatCeiling answers how many full seats the installation's license
+	// admits, injected by the composition root (seatceiling.go) because what
+	// a license grants is resolved from the deployment file and a validation
+	// module identity never imports. Nil ⟹ nothing caps seats, which is what
+	// a role that resolved no license posture means.
+	seatCeiling SeatCeiling
 }
 
 func NewService(pool *pgxpool.Pool) *Service {

--- a/backend/internal/modules/identity/users.go
+++ b/backend/internal/modules/identity/users.go
@@ -87,6 +87,13 @@ func (s *Service) InviteUser(ctx context.Context, actor Identity, in InviteUserI
 	ctx = actorCtx(ctx, actor)
 	var newUserID ids.UserID
 	err = s.db.Tx(ctx, func(tx pgx.Tx) error {
+		// An invited member is a full seat — the insert below takes the column's
+		// default and there is no read-seat invite — so every invite is one more
+		// seat against the licensed ceiling, and it is refused here rather than
+		// after the member exists.
+		if err := s.refuseWhenNoSeatIsLeft(ctx, tx); err != nil {
+			return err
+		}
 		var roleID ids.UUID
 		roleErr := tx.QueryRow(ctx, `SELECT id FROM role WHERE key = $1`, in.Role).Scan(&roleID)
 		if errors.Is(roleErr, pgx.ErrNoRows) {
@@ -149,10 +156,10 @@ func (s *Service) ReactivateUser(ctx context.Context, actor Identity, userID ids
 	}
 	ctx = actorCtx(ctx, actor)
 	return s.db.Tx(ctx, func(tx pgx.Tx) error {
-		var status string
+		var status, seat string
 		err := tx.QueryRow(ctx,
-			`SELECT status FROM app_user WHERE id = $1 AND archived_at IS NULL FOR UPDATE`,
-			userID).Scan(&status)
+			`SELECT status, seat_type FROM app_user WHERE id = $1 AND archived_at IS NULL FOR UPDATE`,
+			userID).Scan(&status, &seat)
 		if errors.Is(err, pgx.ErrNoRows) {
 			return apperrors.ErrNotFound
 		}
@@ -167,6 +174,15 @@ func (s *Service) ReactivateUser(ctx context.Context, actor Identity, userID ids
 		// cleared by this path.
 		if status != userStatusDeactivated {
 			return errNotDeactivated
+		}
+		// A deactivated member counts against nothing, so returning one to active
+		// takes a seat exactly as an invite does. Only a FULL one: read seats are
+		// unlimited and never metered, and refusing a viewer their account back on
+		// a full-seat ceiling would meter the one thing the license does not.
+		if principal.SeatType(seat) == principal.SeatFull {
+			if err := s.refuseWhenNoSeatIsLeft(ctx, tx); err != nil {
+				return err
+			}
 		}
 		if _, err := tx.Exec(ctx,
 			`UPDATE app_user SET status = 'active' WHERE id = $1`, userID); err != nil {

--- a/backend/internal/platform/httperr/httperr.go
+++ b/backend/internal/platform/httperr/httperr.go
@@ -48,6 +48,7 @@ var mapping = []struct {
 	{apperrors.ErrRequiresApproval, http.StatusForbidden, "approval_required"},
 	{apperrors.ErrApprovalTokenInvalid, http.StatusForbidden, "approval_token_invalid"},
 	{apperrors.ErrSeatTierInsufficient, http.StatusForbidden, "seat_tier_insufficient"},
+	{apperrors.ErrSeatLimitReached, http.StatusForbidden, "seat_limit_reached"},
 	{apperrors.ErrConsentNotGranted, http.StatusConflict, "consent_not_granted"},
 	{apperrors.ErrBudgetExceeded, http.StatusTooManyRequests, "rate_limited"},
 	{apperrors.ErrModeNotOverlay, http.StatusNotFound, "mode_not_overlay"},

--- a/backend/internal/platform/jobs/fault.go
+++ b/backend/internal/platform/jobs/fault.go
@@ -119,6 +119,7 @@ var vocabulary = []struct {
 	{apperrors.ErrIncumbentBudgetExhausted, "the incumbent CRM's API budget is spent; the poller will catch up"},
 	{apperrors.ErrRequiresApproval, "this action needs human approval and was staged rather than executed"},
 	{apperrors.ErrSeatTierInsufficient, "the granting seat's tier does not admit this action"},
+	{apperrors.ErrSeatLimitReached, "the installation's licensed full seats are all in use, so no seat was created"},
 	{apperrors.ErrScopeExceeded, "the passport's scope does not cover this action"},
 	{apperrors.ErrApprovalTokenInvalid, "the approval token was invalid or already spent"},
 	{apperrors.ErrModeNotOverlay, "this workspace is no longer in overlay mode"},

--- a/backend/internal/platform/licensecheck/watcher.go
+++ b/backend/internal/platform/licensecheck/watcher.go
@@ -46,8 +46,12 @@ type Watcher struct {
 }
 
 // NewWatcher resolves the posture once and refuses a rejected one, so the
-// caller's boot fails before the role serves. An absent license is not a
-// refusal: an unlicensed installation runs.
+// caller's boot fails before the role serves.
+//
+// An absent license is a posture here, not a refusal. Whether an installation
+// may RUN unlicensed depends on the deployment posture rather than on the
+// license, so that decision is the composition root's (compose.EnsureLicense)
+// and this package reports what it found.
 func NewWatcher(ctx context.Context, source TokenSource, now func() time.Time, log *slog.Logger, env runtimeenv.Environment) (*Watcher, error) {
 	token, err := source()
 	if err != nil {

--- a/backend/internal/shared/apperrors/apperrors.go
+++ b/backend/internal/shared/apperrors/apperrors.go
@@ -123,6 +123,16 @@ var (
 	// attempted a mutate/send/approve/grant (403 seat_tier_insufficient,
 	// A62/ADR-0047).
 	ErrSeatTierInsufficient = errors.New("seat tier insufficient")
+
+	// ErrSeatLimitReached: this INSTALLATION has no licensed full seat left,
+	// so a seat may not be created (403 seat_limit_reached).
+	//
+	// Distinct from ErrSeatTierInsufficient, which is about the CALLER's own
+	// seat and never clears by an admin's action, and from ErrBudgetExceeded,
+	// which is metered and refills on its own — nothing about this one clears
+	// with time, and telling a caller to retry would be advice that can only
+	// ever fail. It is the licensed ceiling (A36/ADR-0029), not a quota.
+	ErrSeatLimitReached = errors.New("seat limit reached")
 )
 
 // Overlay sentinels — only reachable when workspace.sor_mode = overlay

--- a/config/margince.example.yaml
+++ b/config/margince.example.yaml
@@ -59,12 +59,18 @@ bootstrap_admin:
 # its entitlement like any other. A file reference, never an inline value: the
 # token is a credential and this file is not.
 #
-# Omitted, the installation runs unlicensed, which is what every dev and CI
-# process here does. Configured and REFUSED, the api and the worker both refuse
-# to boot — a license that is present and unhonored is an operator mistake, not a
+# Omitted, a PRODUCTION installation refuses to boot: it serves on a license or
+# it does not serve, and MARGINCE_ENV is fail-closed, so an installation that
+# names no posture is production. A dev or CI process runs unlicensed by saying
+# so (MARGINCE_ENV=dev), which is what every lane in this repository does.
+# Configured and REFUSED, the api and the worker both refuse to boot in every
+# posture — a license that is present and unhonored is an operator mistake, not a
 # downgrade to choose silently. MARGINCE_LICENSE overrides the file when it holds
 # a non-empty value; exporting it empty falls through to the file rather than
 # switching the installation off.
+#
+# What the license grants is also enforced: once every licensed full seat is in
+# use, inviting a member is refused. Nobody already working loses anything.
 # license:
 #   token_file: config/margince-license
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -75,7 +75,10 @@ env template is [`.env.template`](../.env.template). The essentials:
 | `MARGINCE_PUBLIC_BASE_URL` | api, worker | canonical external base URL (buyer-facing links / marketing mail) |
 
 Do **not** set `MARGINCE_ENV=dev` in a deployed environment — it enables dev-only
-trust switches.
+trust switches, and it is what lets an installation run with no license at all.
+A deployed installation needs a license: with none configured, `cmd/api` and
+`cmd/worker` refuse to boot unless the environment says non-production (see
+[configuration.md](reference/configuration.md#license)).
 
 ### First-boot bootstrap config
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -733,9 +733,18 @@ Three postures, and what each one does at boot:
 
 | posture | boot | reported as |
 |---|---|---|
-| **no token configured** | boots, with a warning naming the bundled module | `margince_license_posture{state="absent"} 1` |
+| **no token configured** | **refuses to boot in production**; boots with a warning when `MARGINCE_ENV` is `dev`, `staging` or `test` | `margince_license_posture{state="absent"} 1` |
 | **token verified** | boots | `margince_license_posture{state="valid"} 1`, plus `margince_license_seats` when the license grants a seat count |
 | **token refused** | **refuses to boot** (api and worker alike), naming the module's own reason and the setting to correct | — |
+
+**A production installation serves on a license or it does not serve.** The
+posture decides it, and `MARGINCE_ENV` is fail-closed, so an installation that
+names nothing is production and is held to a license. The refusal names both
+ways out — configure the token, or name the installation non-production — because
+the operator reading it is either licensed and missing the reference, or running
+a development installation that never said so. A refused license refuses the
+boot in *every* posture: naming yourself non-production is how you say you have
+no license, not a way to run one the module has judged.
 
 A refusal covers an untrusted signature, the wrong issuer, expiry past the grace
 period the module carries, and no grant for this product at this generation. A
@@ -753,8 +762,20 @@ variable) each time, so a license renewed in place takes effect within a day
 without a restart. Anything that is not a verdict — an unreadable token, a module
 that failed to run — leaves the posture the process last resolved and is logged
 as itself: none of those is evidence about the license, and degrading on one would
-report a refusal that no license caused. Enforcement of the granted seat count is
-not implemented yet (issue #1190).
+report a refusal that no license caused.
+
+**The granted seat count is enforced where a seat comes into use.** Once every
+licensed full seat is taken, inviting a member and reactivating a deactivated
+full seat are refused with `403 seat_limit_reached`, carrying the granted and
+used counts. Nothing already in use is touched: no seat is demoted, no session
+ends, and a license that lapses mid-month refuses the NEXT seat rather than
+taking away the ones people are working in (P7). Read seats are unlimited and
+never counted; a suspended or deactivated seat frees its own, so an admin at the
+ceiling can make room. A license carrying no seat count caps nothing, and so
+does an unlicensed development installation — the ceiling is read live, so a
+license renewed in place raises it on the next re-check without a restart. The
+number an admin is refused against is the number the entitlement screen and
+`margince_license_seats` report: one count, one statement.
 
 **Which authority a license must come from.** A production installation honors
 exactly one: `margince-license-authority`. That is not redundant with the bundled

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -4370,21 +4370,24 @@ export interface paths {
          *     the process runs, so this reports what the installation last resolved rather than
          *     asking anything.
          *
-         *     `state` is the posture: `valid` (a license the module honored), `absent` (none
-         *     configured — a supported state that runs), or `rejected` (one the module refused; an
-         *     installation in that state does not serve, so a client never sees it from a live
-         *     server).
+         *     `state` is the posture: `valid` (a license the module honored), `absent` (no license
+         *     configured, which only a non-production installation may run as), or `rejected` (one
+         *     the module refused). A serving process boots on a license or does not boot, so a client
+         *     reading this from a live server sees `valid` — or `absent` on a development
+         *     installation.
          *
          *     `seats_granted` is ABSENT when there is no seat cap to report — no license, or one
          *     whose grant carries no seat count. That is not the same as a grant of zero seats, and a
          *     client that renders a missing value as `0` would tell an admin their license permits
-         *     nobody. `seats_used` counts full seats that are not deactivated; read seats are
-         *     unlimited and never metered (A62/ADR-0047).
+         *     nobody. `seats_used` counts every full seat the installation has not withdrawn —
+         *     neither deactivated nor suspended; read seats are unlimited and never metered
+         *     (A62/ADR-0047).
          *
          *     `over_limit` is the server's own verdict on the pair, so a client cannot arrive at a
-         *     different answer than the one the installation acts on. Being over the limit is
-         *     reported, never enforced here: the workspace keeps working, which is P7's
-         *     warning-then-grace rather than a silent mid-month lockout.
+         *     different answer than the one the installation acts on. Nobody is ever demoted or
+         *     evicted by it and no session ends — what an exhausted entitlement stops is the NEXT
+         *     full seat, refused at `POST /users` and at reactivation with `seat_limit_reached`.
+         *     That is P7's warning-then-refusal rather than a silent mid-month lockout.
          *
          *     Admin/ops-only, read included: a seat meter is the installation's commercial standing,
          *     and a rep reads their own seat elsewhere (UC-ADMIN-03 F1). Governed by the `license`
@@ -8334,8 +8337,10 @@ export interface components {
              */
             seats_granted?: number;
             /**
-             * @description Full seats in use: not deactivated. Read seats are unlimited and never counted
-             *     (A62/ADR-0047).
+             * @description Full seats in use: every one the installation has not withdrawn — neither
+             *     deactivated nor suspended — agent seats included. Read seats are unlimited and
+             *     never counted (A62/ADR-0047). This is the number a seat creation is refused
+             *     against, so the meter and the ceiling can never disagree.
              */
             seats_used: number;
             /**
@@ -27111,7 +27116,15 @@ export interface operations {
                 };
             };
             401: components["responses"]["Unauthorized"];
-            403: components["responses"]["Forbidden"];
+            /** @description Refused, with the reason distinguished by the problem `code`: `permission_denied` (the caller is not an admin), or `seat_limit_reached` — every full seat this installation's license grants is in use. An invited member is a full seat, so no member is created; the `detail` carries the granted and used counts, and an admin resolves it by deactivating a member or licensing more seats. Nothing about it clears on its own, so a client must not retry it. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["Problem"];
+                };
+            };
             /** @description Not found, with the reason distinguished by the problem `code`: `unknown_role` — this organization defines no role with the requested key. The `role` enum is documentation, not binding validation, so a mistyped key reaches the server and must say which of the two things was not found. */
             404: {
                 headers: {
@@ -27242,7 +27255,15 @@ export interface operations {
                 };
             };
             401: components["responses"]["Unauthorized"];
-            403: components["responses"]["Forbidden"];
+            /** @description Refused, with the reason distinguished by the problem `code`: `permission_denied` (the caller is not an admin), or `seat_limit_reached` — a deactivated member counts against nothing, so returning a FULL seat to active takes one exactly as an invite does, and every seat this installation's license grants is in use. The member stays deactivated. A read seat is never refused here: read seats are unlimited and never counted. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["Problem"];
+                };
+            };
             404: components["responses"]["NotFound"];
             /** @description Refused with `code: not_deactivated` — only a deactivated member can be reactivated, and this one is in some other state. Both reachable states need a different action, not this one: an `invited` member has never set a password, and a `suspended` member is held for a reason that reactivating would clear without it ever being resolved. (An `active` member is a no-op and answers 200, not this.) */
             409: {

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -3978,7 +3978,7 @@ export const de = {
   "license.meter.label": "{used} von {granted} Sitzplätzen belegt",
   "license.over.title": "Sie überschreiten Ihre Sitzplatzgrenze",
   "license.over.body":
-    "{used} Sitzplätze sind belegt, die Lizenz gewährt {granted}. Es wird nichts blockiert und niemand verliert den Zugang — geben Sie einen Sitzplatz frei oder erhöhen Sie die Grenze.",
+    "{used} Sitzplätze sind belegt, die Lizenz gewährt {granted}. Niemand verliert den Zugang und kein Sitzplatz wird entzogen — aber es kann kein neues Mitglied eingeladen werden, solange die Grenze überschritten ist. Deaktivieren Sie ein Mitglied oder erhöhen Sie die Grenze.",
   "license.holder.title": "Lizenziert für",
   "license.holder.org": "Organisation",
   "license.holder.contact": "Kontakt",
@@ -3993,7 +3993,7 @@ export const de = {
   "license.renewal.body":
     "Die Lizenz läuft am {expiry} ab. Vor diesem Datum ändert sich nichts.",
   "license.counting":
-    "Volle Sitzplätze, die nicht deaktiviert sind, Agenten eingeschlossen. Lesende Sitzplätze sind unbegrenzt und werden nie gezählt.",
+    "Volle Sitzplätze, die weder deaktiviert noch gesperrt sind, Agenten eingeschlossen. Lesende Sitzplätze sind unbegrenzt und werden nie gezählt. Gegen diese Zahl wird ein neues Mitglied zugelassen.",
   "settings.group.you": "Persönlich",
   "settings.group.org": "Organisation",
   "settings.rates.fxTitle": "Währungskurse",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -3984,7 +3984,7 @@ export const en = {
   "license.meter.label": "{used} of {granted} seats in use",
   "license.over.title": "You are over your seat entitlement",
   "license.over.body":
-    "{used} seats are in use and the license grants {granted}. Nothing is blocked and nobody loses access — remove a seat, or raise the entitlement, to come back inside it.",
+    "{used} seats are in use and the license grants {granted}. Nobody loses access and no seat is taken away — but no new member can be invited until you are back inside the entitlement. Deactivate a member, or raise the entitlement.",
   "license.holder.title": "Licensed to",
   "license.holder.org": "Organization",
   "license.holder.contact": "Contact",
@@ -3999,7 +3999,7 @@ export const en = {
   "license.renewal.body":
     "The license expires on {expiry}. Nothing changes before that date.",
   "license.counting":
-    "Full seats that are not deactivated, agents included. Read-only seats are unlimited and never counted.",
+    "Full seats that are neither deactivated nor suspended, agents included. Read-only seats are unlimited and never counted. This is the count a new member is admitted against.",
   "settings.group.you": "You",
   "settings.group.org": "Organization",
   "settings.rates.fxTitle": "Currency rates",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -3960,7 +3960,7 @@ export const vi = {
   "license.meter.label": "Đang dùng {used} trong {granted} chỗ",
   "license.over.title": "Bạn đã vượt quá số chỗ được cấp",
   "license.over.body":
-    "Đang dùng {used} chỗ trong khi giấy phép cấp {granted}. Không có gì bị chặn và không ai mất quyền truy cập — hãy bỏ một chỗ hoặc nâng hạn mức để trở lại trong giới hạn.",
+    "Đang dùng {used} chỗ trong khi giấy phép cấp {granted}. Không ai mất quyền truy cập và không chỗ nào bị thu hồi — nhưng không thể mời thành viên mới cho đến khi trở lại trong hạn mức. Hãy vô hiệu hoá một thành viên hoặc nâng hạn mức.",
   "license.holder.title": "Cấp phép cho",
   "license.holder.org": "Tổ chức",
   "license.holder.contact": "Liên hệ",
@@ -3975,7 +3975,7 @@ export const vi = {
   "license.renewal.body":
     "Giấy phép hết hạn vào {expiry}. Không có gì thay đổi trước ngày đó.",
   "license.counting":
-    "Chỗ đầy đủ chưa bị vô hiệu hoá, bao gồm cả agent. Chỗ chỉ đọc là không giới hạn và không bao giờ được tính.",
+    "Chỗ đầy đủ chưa bị vô hiệu hoá và chưa bị tạm ngưng, bao gồm cả agent. Chỗ chỉ đọc là không giới hạn và không bao giờ được tính. Thành viên mới được xét theo con số này.",
   "settings.group.you": "Cá nhân",
   "settings.group.org": "Tổ chức",
   "settings.rates.fxTitle": "Tỷ giá",

--- a/frontend/src/screens/license.test.tsx
+++ b/frontend/src/screens/license.test.tsx
@@ -172,9 +172,11 @@ describe("LicenseCard", () => {
     const alert = await waitFor(() => screen.getByRole("alert"));
     expect(alert.textContent).toContain("11");
     expect(alert.textContent).toContain("10");
-    // The copy has to say the workspace keeps working, or an admin reads a
-    // warning about seats as a lockout in progress (P7).
-    expect(alert.textContent).toMatch(/nothing is blocked/i);
+    // The copy has to say both halves, because an admin acts on the difference:
+    // nobody currently working loses anything (P7), and the next invitation is
+    // the thing that will not go through.
+    expect(alert.textContent).toMatch(/nobody loses access/i);
+    expect(alert.textContent).toMatch(/no new member can be invited/i);
     // The meter still reads, clamped by the component rather than misreporting:
     // the value is the truth and the maximum is the entitlement.
     const meter = screen.getByRole("meter");


### PR DESCRIPTION
This PR makes the license binding. It adds two rules:

1. A production installation does not start without a license.
2. An installation does not create a new seat past the number the license grants.

This is slice 2 of #1190. It is stacked on #1274, which adds the license screen and the seat meter. **#1274 must merge first.**

## Rule 1: the boot needs a license

Before this PR, an installation with no license started everywhere. It printed a warning. Now the deployment posture decides.

| Posture | No license | License refused |
|---|---|---|
| production (`MARGINCE_ENV` unset or unknown) | boot fails | boot fails |
| `dev`, `staging`, `test` | boots, logs a warning | boot fails |

`MARGINCE_ENV` is fail-closed. An installation that sets nothing is production.

Development and CI need no change. `backend/Makefile` exports `MARGINCE_ENV ?= dev`. `scripts/dev.sh`, the integration runners and the `live-boot` job set it too. Production containers set nothing.

The error names both fixes:

```
no license is configured and this installation is production: point
license.token_file (or MARGINCE_LICENSE) at the license token issued for this
installation, or, if this is a development or test installation, set
MARGINCE_ENV=dev
```

Both are named because the reader is in one of two situations. Either the installation is licensed and lost the token reference in a redeploy. Or it is a development installation that never declared itself one. The process cannot tell these apart.

A refused license fails the boot in every posture. A non-production posture is a statement that there is no license. It is not a way to run a license the module rejected.

## Rule 2: the seat limit stops the next seat

Two operations create a full seat. Both are refused when all licensed seats are in use.

| Operation | Refused when |
|---|---|
| `POST /v1/users` (invite) | all licensed full seats are in use |
| `POST /v1/users/{id}/reactivate` | the seat is `full` and all licensed full seats are in use |

The response is `403` with code `seat_limit_reached`:

```
seat limit reached: this installation's license grants 10 full seats and 10 are
in use; deactivate a member, or raise the licensed seat count
```

The counts are in the message. An admin needs them to choose between the two fixes.

What the limit never does:

- It never demotes a seat.
- It never ends a session.
- It never deactivates an account.
- An installation over its limit keeps every user working. Only the next seat is refused (P7).

What frees a seat: deactivation, and suspension. Read seats are not counted at all.

What is not capped: a license with no seat count, and an unlicensed development installation. Bootstrap is also not gated. The installation writes its own admin and Agent Runner seat before any check could refuse them.

## Two decisions from #1190

**The error.** New sentinel `apperrors.ErrSeatLimitReached`, mapped to `403 seat_limit_reached`. The existing sentinels do not fit. `ErrBudgetExceeded` is `429` and means "retry later", which is never true here. `ErrSeatTierInsufficient` is about the caller's own seat. The spec change is margince-foundation#1312 and **must merge first**, because `apperrors` is the fixed registry of `interfaces.md §0`.

**What an unlicensed installation may do.** The question no longer applies in production, because production always has a verified license. The remaining uncapped cases are a license without a seat count and a development installation. Both cap nothing.

## The seat count

The meter and the limit now run one query, `fullSeatsInUseQuery`. The number on the screen is the number the refusal uses.

Writing that query showed a defect in #1274. The comment said a suspended seat is not counted. The query counted every seat that was not deactivated, so it did count suspended seats. No test covered suspension.

The query now reads `status NOT IN ('suspended','deactivated')`. It names the withdrawn states, not the live one. A status added later is then counted until someone decides otherwise. The reverse would stop metering a new state silently, and the installation would issue seats the license never granted.

## Concurrency

The check runs inside the transaction of the writer, under one advisory lock per installation. Without the lock, two admins inviting at the same time both read one free seat and both take it. The installation ends up one seat over the limit, and nothing brings it back.

## Wiring

`WithLicensePosture` is the only wiring point. It already built the license screen handler and the `/metrics` section. It now also binds the seat limit, from the same posture, read at call time. A role that wires no posture enforces no limit. A role that reports a limit cannot fail to enforce it.

## Text changes

The screen said "nothing is blocked". That was true before this PR. The text now states both facts: nobody loses access, and no new member can be invited. Changed in `en`, `de` and `vi`. The test asserts both statements.

The `seats_used` description in `crm.yaml` and the counting note on the screen also said "not deactivated". Both now say suspended seats are excluded as well.

## Tests

`backend/internal/modules/identity/seatceiling_integration_test.go`, against a real database, through the real writers:

- refused at the limit, with both counts in the message, and no row written
- the last licensed seat is admitted, the next one is refused
- a suspended seat and a deactivated seat each free one seat
- reactivation is refused and the member stays deactivated, then succeeds when a seat is licensed
- a read seat is never refused
- no limit and no wiring both admit every seat

`backend/internal/compose/integration/seatceiling_http_integration_test.go`, against the composed api:

- the number from `GET /v1/installation/license` is the number `POST /v1/users` is refused against
- `403 seat_limit_reached`, and the usage does not change after the refusal
- one more licensed seat, and the same request returns `201`
- the next invite is then refused in the same process, without a restart

`backend/internal/compose/license_test.go`: production without a license fails and names both fixes; a non-production installation boots and logs it; a refused license fails in both postures.

## Gates

Green locally: `make -C backend check`, `make check-fe`, `craft static --strict` over the diff, and both integration packages.

Red on CI for one reason that is not in this diff: `main` took `core/0260` for `scheduled_send_agent_provenance` while #1274 uses `0260_license_rbac`. The renumber belongs to #1274.

No STATUS.md entry. #1274 carries the narrative for this work.
