### PR TITLE
fix(siteread): read the imprint for people, because German law puts the board on it

### DIFF
--- a/backend/internal/compose/sitepagefacts.go
+++ b/backend/internal/compose/sitepagefacts.go
@@ -45,7 +45,17 @@ func menuForKind(kind crmcontracts.SiteReadPageKind) (pageMenu, bool) {
 	offeringAndMarket := factFields("offering", "market")
 	switch kind {
 	case crmcontracts.SiteReadPageKindImpressum:
-		return pageMenu{factFields: company, entities: true}, true
+		// The imprint carries the people lane because German law puts the
+		// board on it: §5 TMG requires a company to name its
+		// Vertretungsberechtigte, so adesso.de/impressum prints five board
+		// members and the supervisory board chair. That page is often the
+		// ONLY place a large firm names anyone -- adesso publishes no team
+		// directory the crawl reaches, and read without this lane it
+		// yielded a hundred facts and zero people.
+		//
+		// The testimonial risk that shaped the About lane does not exist
+		// here: an imprint quotes no customers.
+		return pageMenu{factFields: company, entities: true, people: true}, true
 	case crmcontracts.SiteReadPageKindContact:
 		return pageMenu{factFields: company}, true
 	case crmcontracts.SiteReadPageKindServices, crmcontracts.SiteReadPageKindProducts:

--- a/backend/internal/compose/sitepagefacts_test.go
+++ b/backend/internal/compose/sitepagefacts_test.go
@@ -54,8 +54,8 @@ func TestMenuForKindRoutesFactBearingKindsOnly(t *testing.T) {
 		t.Fatal("unclassified pages must make no call")
 	}
 	menu, ok := menuForKind(crmcontracts.SiteReadPageKindImpressum)
-	if !ok || !menu.entities || menu.people {
-		t.Fatalf("impressum menu = %+v, want company fields + entities", menu)
+	if !ok || !menu.entities || !menu.people {
+		t.Fatalf("impressum menu = %+v, want company fields + entities + people", menu)
 	}
 	menu, ok = menuForKind(crmcontracts.SiteReadPageKindServices)
 	if !ok || menu.entities || menu.people {
@@ -487,5 +487,24 @@ func TestAPersonWithNoPublishedEmailIsNotProposed(t *testing.T) {
 	}
 	if reasons := dropReasons(dropped); reasons["Bernd Beispiel"] != dropNoPublishedEmail {
 		t.Fatalf("Bernd must drop for having no published address: %+v", dropped)
+	}
+}
+
+func TestTheImprintIsReadForPeopleBecauseGermanLawPutsTheBoardOnIt(t *testing.T) {
+	// §5 TMG requires a company to name its Vertretungsberechtigte on the
+	// imprint, so for a large German firm that page is often the only place
+	// anyone is named: adesso.de publishes no team directory the crawl
+	// reaches, and its imprint names five board members plus the
+	// supervisory board chair.
+	menu, ok := menuForKind(crmcontracts.SiteReadPageKindImpressum)
+	if !ok {
+		t.Fatal("the imprint must make a call")
+	}
+	if !menu.people {
+		t.Error("the imprint carries no people lane, so a board nobody else " +
+			"publishes is never read")
+	}
+	if !menu.entities {
+		t.Error("the imprint still owes the entity census its vote")
 	}
 }


### PR DESCRIPTION
adesso.de returned a hundred facts and **zero people**. It publishes no team directory the crawl reaches — but its imprint names five board members and the supervisory board chair, because §5 TMG requires a company to name its Vertretungsberechtigte there.

The imprint's menu carried the fact and entity lanes and not the people lane, so that page was read for an address and never for who runs the company. For a large German firm it is often the only page that names anyone: **four of the ten companies read so far name executives only on their imprint** (adesso, 2txt, 7Learnings, akeneo).

The testimonial risk that shaped the About lane does not apply here — an imprint quotes no customers.

adesso now yields Mark Lohweber (Vorstandsvorsitzender), Benedikt Bonnmann, Kristina Gerwert, Michael Knopp, Andreas Prenneis and Prof. Dr. Volker Gruhn, verified name for name against the live page.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reads people from the imprint page to capture board/executive names listed under §5 TMG. Previously the imprint read company fields and entities only; now it also reads the people lane, fixing cases where firms list leadership only on the imprint.

- Review notes
  - The imprint menu now returns people: true and entities: true; other page kinds are unchanged.
  - Tests updated to expect people on the imprint and to assert both entities and people are present.
  - No configuration changes or migrations required.

<sup>Written for commit c69df9bb7373ac64805cf7e5a8413fbc6dafa2c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1365?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

