### PR TITLE
feat(extensions): a unit supplies a real messaging transport, end to end

### DIFF
--- a/backend/internal/compose/channelprovider.go
+++ b/backend/internal/compose/channelprovider.go
@@ -33,10 +33,14 @@ import (
 	"github.com/gradionhq/margince/backend/internal/platform/database"
 )
 
-// reconcileChannelProviders upserts a channel_provider row (transport='core')
-// for every composed provider, carrying the display facts the discovery
-// endpoint publishes, then sets both packages' in-memory snapshots to exactly
-// the composed set passed in.
+// reconcileChannelProviders upserts a channel_provider row for every transport
+// this binary composed — the core connectors passed in, plus every channel the
+// composed UNITS declare — carrying the display facts the discovery endpoint
+// publishes, then sets both packages' in-memory snapshots to the subset a reply
+// can actually leave on.
+//
+// It is also where a unit shadowing a core connector is refused, because this is
+// the first point at which both sets exist (unitChannelFacts).
 //
 // It runs over database.WithInfraTx, not the workspace-bound database.DB.Tx:
 // activity_kind and channel_provider carry no workspace_id, so binding a
@@ -55,35 +59,57 @@ import (
 // FK would refuse the delete anyway, and ErrConnectorNotConfigured already
 // parks a send against it rather than needing the row gone.
 func reconcileChannelProviders(ctx context.Context, pool *pgxpool.Pool, providers []string) error {
-	err := database.WithInfraTx(ctx, pool, func(tx pgx.Tx) error {
-		for _, facts := range channelProviderFactsFor(providers, providers) {
+	units, err := unitChannelFacts(providers)
+	if err != nil {
+		return err
+	}
+	rows := append(channelProviderFactsFor(providers, providers), units...)
+	if err := database.WithInfraTx(ctx, pool, func(tx pgx.Tx) error {
+		for _, facts := range rows {
 			// The display facts are UPSERTED, not left alone on conflict: they
 			// describe the composed connector, so the running binary is their
 			// only source of truth and a row written by an older build must be
 			// corrected rather than preserved. The provider itself still lands
 			// once — the primary key sees to that.
+			//
+			// `transport` is upserted with them, and it has to be: a provider
+			// that moves from a core connector to a unit (or back) is exactly
+			// the case where a stale value would tell the send path to resolve
+			// the wrong credential.
 			if _, err := tx.Exec(ctx, `
 				INSERT INTO channel_provider (provider, transport, label, credential_model, supplies_transport)
-				VALUES ($1, 'core', $2, $3, $4)
+				VALUES ($1, $2, $3, $4, $5)
 				ON CONFLICT (provider) DO UPDATE SET
+					transport         = EXCLUDED.transport,
 					label             = EXCLUDED.label,
 					credential_model  = EXCLUDED.credential_model,
 					supplies_transport = EXCLUDED.supplies_transport`,
-				facts.provider, facts.label, facts.credentialModel, facts.suppliesTransport); err != nil {
+				facts.provider, facts.transport, facts.label, facts.credentialModel, facts.suppliesTransport); err != nil {
 				return err
 			}
 		}
 		return nil
-	})
-	if err != nil {
+	}); err != nil {
 		return err
 	}
 	// These two take the COMPOSED set: they answer "can a reply leave this
 	// installation", which is a question about what was compiled in. What a
 	// message may NAME is a different set, loaded from the registry itself by
 	// LoadChannelProviderDirectory — see there for why it is not written here.
-	activities.SetChannelProviders(providers)
-	comms.SetChannelProviders(providers)
+	//
+	// A unit transport belongs in it exactly when the unit declared a Send. The
+	// send path's own pre-flight reads this set, so a unit channel left out of
+	// it would register, publish, capture — and park every reply a rep wrote
+	// under "this installation cannot send on that", which is the one failure a
+	// rep cannot tell from a broken provider.
+	sendable := slices.Clone(providers)
+	for _, unit := range units {
+		if unit.suppliesTransport {
+			sendable = append(sendable, unit.provider)
+		}
+	}
+	activities.SetChannelProviders(sendable)
+	comms.SetChannelProviders(sendable)
 	return nil
 }
 

--- a/backend/internal/compose/channelprovider.go
+++ b/backend/internal/compose/channelprovider.go
@@ -21,6 +21,7 @@ package compose
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"slices"
 	"sync"
@@ -59,32 +60,22 @@ import (
 // FK would refuse the delete anyway, and ErrConnectorNotConfigured already
 // parks a send against it rather than needing the row gone.
 func reconcileChannelProviders(ctx context.Context, pool *pgxpool.Pool, providers []string) error {
-	units, err := unitChannelFacts(providers)
-	if err != nil {
-		return err
-	}
-	rows := append(channelProviderFactsFor(providers, providers), units...)
+	var units []channelProviderFacts
 	if err := database.WithInfraTx(ctx, pool, func(tx pgx.Tx) error {
-		for _, facts := range rows {
-			// The display facts are UPSERTED, not left alone on conflict: they
-			// describe the composed connector, so the running binary is their
-			// only source of truth and a row written by an older build must be
-			// corrected rather than preserved. The provider itself still lands
-			// once — the primary key sees to that.
-			//
-			// `transport` is upserted with them, and it has to be: a provider
-			// that moves from a core connector to a unit (or back) is exactly
-			// the case where a stale value would tell the send path to resolve
-			// the wrong credential.
-			if _, err := tx.Exec(ctx, `
-				INSERT INTO channel_provider (provider, transport, label, credential_model, supplies_transport)
-				VALUES ($1, $2, $3, $4, $5)
-				ON CONFLICT (provider) DO UPDATE SET
-					transport         = EXCLUDED.transport,
-					label             = EXCLUDED.label,
-					credential_model  = EXCLUDED.credential_model,
-					supplies_transport = EXCLUDED.supplies_transport`,
-				facts.provider, facts.transport, facts.label, facts.credentialModel, facts.suppliesTransport); err != nil {
+		reserved, err := reservedCoreProviders(ctx, tx, providers)
+		if err != nil {
+			return err
+		}
+		// Inside the transaction, and BEFORE any write: the reserved set is read
+		// from the same snapshot the upsert runs against, so a unit cannot be
+		// admitted against a registry that changed underneath the check. A
+		// refused set writes nothing at all — the boot dies with the collision
+		// uninstalled rather than half-installed.
+		if units, err = unitChannelFacts(reserved); err != nil {
+			return err
+		}
+		for _, facts := range append(channelProviderFactsFor(providers, providers), units...) {
+			if err := upsertChannelProvider(ctx, tx, facts); err != nil {
 				return err
 			}
 		}
@@ -110,6 +101,73 @@ func reconcileChannelProviders(ctx context.Context, pool *pgxpool.Pool, provider
 	}
 	activities.SetChannelProviders(sendable)
 	comms.SetChannelProviders(sendable)
+	return nil
+}
+
+// reservedCoreProviders is every transport this installation holds for the
+// core: the registry's own `transport='core'` rows, plus the connectors this
+// binary composed.
+//
+// BOTH halves, because neither is the whole answer. The registry knows names no
+// binary has a connector for — `whatsapp` is registered by migration so a
+// hand-logged WhatsApp message can say what carried it — and those are exactly
+// the ones a composed-set check misses. The composed list covers the mirror
+// case: a fresh database whose reconcile has not run yet, or a core connector
+// registered after this one, where the row is not there to be read.
+func reservedCoreProviders(ctx context.Context, tx pgx.Tx, composed []string) (map[string]bool, error) {
+	reserved := make(map[string]bool, len(composed))
+	for _, p := range composed {
+		reserved[p] = true
+	}
+	rows, err := tx.Query(ctx, `SELECT provider FROM channel_provider WHERE transport = 'core'`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var p string
+		if err := rows.Scan(&p); err != nil {
+			return nil, err
+		}
+		reserved[p] = true
+	}
+	return reserved, rows.Err()
+}
+
+// upsertChannelProvider writes one transport's row.
+//
+// The display facts are UPSERTED, not left alone on conflict: they describe the
+// composed supplier, so the running binary is their only source of truth and a
+// row written by an older build must be corrected rather than preserved. The
+// provider itself still lands once — the primary key sees to that. `transport`
+// is upserted with them because a provider that moves between suppliers is
+// exactly the case where a stale value would tell the send path to resolve the
+// wrong credential.
+//
+// The WHERE clause is the belt to reservedCoreProviders' braces, and it is here
+// because the two failures are different: that check refuses a KNOWN collision
+// with an explanation, and this refuses to overwrite a core row under any
+// circumstance the check did not foresee. A unit taking over a core transport
+// is silent by nature — the same conversation, transmitted by somebody else —
+// so the write itself must not be able to do it.
+func upsertChannelProvider(ctx context.Context, tx pgx.Tx, facts channelProviderFacts) error {
+	tag, err := tx.Exec(ctx, `
+		INSERT INTO channel_provider (provider, transport, label, credential_model, supplies_transport)
+		VALUES ($1, $2, $3, $4, $5)
+		ON CONFLICT (provider) DO UPDATE SET
+			transport          = EXCLUDED.transport,
+			label              = EXCLUDED.label,
+			credential_model   = EXCLUDED.credential_model,
+			supplies_transport = EXCLUDED.supplies_transport
+		WHERE channel_provider.transport = EXCLUDED.transport`,
+		facts.provider, facts.transport, facts.label, facts.credentialModel, facts.suppliesTransport)
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("compose: the transport %q is already registered by a different supplier than %q — a registered transport does not change hands, because every message and every identity binding already filed on it would start resolving a different credential",
+			facts.provider, facts.transport)
+	}
 	return nil
 }
 

--- a/backend/internal/compose/channelprovider_integration_test.go
+++ b/backend/internal/compose/channelprovider_integration_test.go
@@ -269,6 +269,51 @@ func TestReconcileChannelProvidersRefusesAUnitThatShadowsACoreConnector(t *testi
 	}
 }
 
+// A unit may not seize a transport the REGISTRY reserves for the core, even
+// when this binary composed no connector for it — and `whatsapp` is exactly
+// that shape: registered by migration so a hand-logged WhatsApp message can say
+// what carried it, with no Go connector behind it.
+//
+// It is the case a composed-set check misses, and it shipped that way once.
+// `capture.Registry.ChannelProviders` returns only connectors implementing the
+// message seam, so a unit declaring `whatsapp` passed the collision check, the
+// upsert re-pointed the core row at the unit, and every previously-unrepliable
+// WhatsApp conversation in the installation became one the unit transmits — on
+// its own credential, with nothing on any screen different.
+func TestReconcileChannelProvidersRefusesAUnitThatSeizesARegisteredCoreTransport(t *testing.T) {
+	e := integration.Setup(t)
+	ctx := context.Background()
+	defer activities.SetChannelProviders([]string{capture.ProviderTelegram})
+	defer comms.SetChannelProviders([]string{capture.ProviderTelegram})
+	// whatsapp is deliberately NOT in the composed set below, which is the
+	// truth about this binary: nothing composes a WhatsApp connector.
+	declaresTransport(t, "impostor", extension.Channel{
+		Provider: "whatsapp", Send: (&capturedSend{}).send, Live: answersLive(true, nil),
+	})
+
+	err := reconcileChannelProviders(ctx, e.Pool, []string{capture.ProviderTelegram})
+
+	if err == nil {
+		t.Fatal("a unit seized a registered core transport it composed no connector for; every hand-logged conversation on it became repliable by the unit")
+	}
+	var transport string
+	var supplies bool
+	if qErr := integration.OwnerConn(t).QueryRow(ctx,
+		`SELECT transport, supplies_transport FROM channel_provider WHERE provider = 'whatsapp'`).
+		Scan(&transport, &supplies); qErr != nil {
+		t.Fatalf("querying channel_provider: %v", qErr)
+	}
+	if transport != "core" {
+		t.Errorf("whatsapp's transport is now %q; the refused reconcile rewrote the row it was refusing", transport)
+	}
+	if supplies {
+		t.Error("whatsapp is now marked as supplying transport; this installation composes no connector for it")
+	}
+	if activities.CanSendOnProvider("whatsapp") {
+		t.Error("whatsapp entered the sendable set, so every hand-logged WhatsApp conversation would now accept a reply")
+	}
+}
+
 // The seam SHIPS, not just the function: NewCaptureRegistry — the real
 // composition-root entry point every process role calls — sets both
 // activities' and comms' in-memory snapshots as a side effect of registering

--- a/backend/internal/compose/channelprovider_integration_test.go
+++ b/backend/internal/compose/channelprovider_integration_test.go
@@ -7,17 +7,17 @@ package compose
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/gradionhq/margince/backend/internal/compose/integration"
 	"github.com/gradionhq/margince/backend/internal/modules/activities"
 	"github.com/gradionhq/margince/backend/internal/modules/capture"
 	"github.com/gradionhq/margince/backend/internal/modules/comms"
+	"github.com/gradionhq/margince/backend/pkg/extension"
 )
 
-// A provider not already seeded is inserted, with transport='core' (this
-// reconcile only ever handles core connectors — a unit's declared channel is
-// its own later slice).
+// A core connector not already seeded is inserted, with transport='core'.
 func TestReconcileChannelProvidersInsertsAnUnseenProvider(t *testing.T) {
 	e := integration.Setup(t)
 	ctx := context.Background()
@@ -132,6 +132,140 @@ func TestReconcileChannelProvidersNeverDeletesARetiredRow(t *testing.T) {
 	}
 	if count != 1 {
 		t.Fatalf("telegram's row was deleted when it dropped out of the composed set (count=%d)", count)
+	}
+}
+
+// A UNIT's declared channel becomes a registry row of its own — and until it
+// does, no message can reference it: activity.channel_provider is a foreign key
+// into this table, so a captured chat message would be refused by the database
+// rather than landing under an unregistered name.
+//
+// What the row SAYS is the other half. transport='unit' is what the send path
+// branches on to resolve a per-member credential instead of the workspace's bot,
+// and credential_model='per_member' is what an operator reads to know that
+// connecting is each member's own act rather than an admin's one-time binding.
+func TestReconcileChannelProvidersRegistersAUnitsDeclaredTransport(t *testing.T) {
+	e := integration.Setup(t)
+	ctx := context.Background()
+	owner := integration.OwnerConn(t)
+	defer activities.SetChannelProviders([]string{capture.ProviderTelegram})
+	defer comms.SetChannelProviders([]string{capture.ProviderTelegram})
+	declaresTransport(t, "mine", extension.Channel{
+		Provider: "mine_chat", Send: (&capturedSend{}).send, Live: answersLive(true, nil),
+	})
+	t.Cleanup(func() {
+		if _, err := owner.Exec(context.Background(), `DELETE FROM channel_provider WHERE provider = 'mine_chat'`); err != nil {
+			t.Errorf("cleaning up channel_provider: %v", err)
+		}
+	})
+
+	if err := reconcileChannelProviders(ctx, e.Pool, []string{capture.ProviderTelegram}); err != nil {
+		t.Fatalf("reconcileChannelProviders: %v", err)
+	}
+
+	var transport, credentialModel, label string
+	var supplies bool
+	if err := owner.QueryRow(ctx,
+		`SELECT transport, credential_model, label, supplies_transport
+		   FROM channel_provider WHERE provider = 'mine_chat'`).
+		Scan(&transport, &credentialModel, &label, &supplies); err != nil {
+		t.Fatalf("querying the unit's row: %v", err)
+	}
+	switch {
+	case transport != "unit":
+		t.Errorf("transport = %q, want unit — the send path branches on it to resolve a per-member credential", transport)
+	case credentialModel != "per_member":
+		t.Errorf("credential_model = %q, want per_member — a unit holds one sealed secret per member and no installation credential", credentialModel)
+	case label != "Mine Chat":
+		t.Errorf("label = %q, want a name derived from the id — this endpoint is readable by every seat, so nothing an operator typed belongs in it", label)
+	case !supplies:
+		t.Errorf("supplies_transport = false for a channel that declares a Send")
+	}
+
+	// And the in-memory half, which is what actually lets a reply leave: the send
+	// path's own pre-flight reads this set, so a unit transport left out of it
+	// would register, publish, capture — and park every reply a rep wrote under
+	// "this installation cannot send on that", which is the one failure a rep
+	// cannot tell from a broken provider.
+	if !activities.CanSendOnProvider("mine_chat") {
+		t.Error("the unit's transport is not in the sendable set; every reply on it would be refused before it was staged")
+	}
+	// Without narrowing the core's: a unit declaring a channel must not
+	// deregister the workspace's own bot.
+	if !activities.CanSendOnProvider(capture.ProviderTelegram) {
+		t.Error("registering a unit transport dropped the core connector out of the sendable set")
+	}
+}
+
+// A capture-only unit registers its provider and is NOT sendable. The two are
+// separate columns because the difference is real and a rep sees it: the
+// timeline can name what carried a message on a transport nothing can answer on.
+func TestReconcileChannelProvidersRegistersACaptureOnlyUnitTransportAsUnsendable(t *testing.T) {
+	e := integration.Setup(t)
+	ctx := context.Background()
+	owner := integration.OwnerConn(t)
+	defer activities.SetChannelProviders([]string{capture.ProviderTelegram})
+	defer comms.SetChannelProviders([]string{capture.ProviderTelegram})
+	declaresTransport(t, "mine", extension.Channel{Provider: "mine_chat"})
+	t.Cleanup(func() {
+		if _, err := owner.Exec(context.Background(), `DELETE FROM channel_provider WHERE provider = 'mine_chat'`); err != nil {
+			t.Errorf("cleaning up channel_provider: %v", err)
+		}
+	})
+
+	if err := reconcileChannelProviders(ctx, e.Pool, []string{capture.ProviderTelegram}); err != nil {
+		t.Fatalf("reconcileChannelProviders: %v", err)
+	}
+
+	var supplies bool
+	if err := owner.QueryRow(ctx,
+		`SELECT supplies_transport FROM channel_provider WHERE provider = 'mine_chat'`).Scan(&supplies); err != nil {
+		t.Fatalf("querying the unit's row: %v", err)
+	}
+	if supplies {
+		t.Error("a channel declaring no Send was registered as supplying transport")
+	}
+	if activities.CanSendOnProvider("mine_chat") {
+		t.Error("a capture-only transport is in the sendable set; a reply would be staged against a unit that cannot transmit")
+	}
+}
+
+// A unit SHADOWING a core connector fails the boot, and this is the sharpest
+// failure the whole surface has: every Telegram reply a rep wrote would leave on
+// the unit's per-member credential instead of the workspace's bot — the same
+// message, sent by a different person, with nothing on the screen different.
+//
+// It is refused HERE rather than in the extension preflight because this is the
+// first point at which both sets exist: the core's transports are decided when
+// the capture registry is built, which can happen after extension registration,
+// so the preflight would answer from an empty set and pass the collision it
+// exists to catch.
+func TestReconcileChannelProvidersRefusesAUnitThatShadowsACoreConnector(t *testing.T) {
+	e := integration.Setup(t)
+	ctx := context.Background()
+	defer activities.SetChannelProviders([]string{capture.ProviderTelegram})
+	defer comms.SetChannelProviders([]string{capture.ProviderTelegram})
+	declaresTransport(t, "impostor", extension.Channel{
+		Provider: capture.ProviderTelegram, Send: (&capturedSend{}).send, Live: answersLive(true, nil),
+	})
+
+	err := reconcileChannelProviders(ctx, e.Pool, []string{capture.ProviderTelegram})
+
+	if err == nil {
+		t.Fatal("a unit declaring the core's own transport was accepted; every reply on it would leave under the unit's credential")
+	}
+	if !strings.Contains(err.Error(), capture.ProviderTelegram) {
+		t.Errorf("the refusal %q does not name the transport in dispute, which is the one thing an operator must rename", err)
+	}
+	// And it refuses BEFORE writing anything: a boot that dies with the row
+	// already re-pointed would leave the collision installed.
+	var transport string
+	if qErr := integration.OwnerConn(t).QueryRow(ctx,
+		`SELECT transport FROM channel_provider WHERE provider = $1`, capture.ProviderTelegram).Scan(&transport); qErr != nil {
+		t.Fatalf("querying channel_provider: %v", qErr)
+	}
+	if transport != "core" {
+		t.Errorf("telegram's transport is now %q; the refused reconcile rewrote the row it was refusing", transport)
 	}
 }
 

--- a/backend/internal/compose/channelproviderfacts.go
+++ b/backend/internal/compose/channelproviderfacts.go
@@ -133,6 +133,17 @@ func channelProviderFactsFor(registered, sending []string) []channelProviderFact
 // to catch. The unit-vs-unit half is still the preflight's — that one needs no
 // core knowledge, and refusing it earlier is a better error.
 //
+// WHAT COUNTS AS A CORE TRANSPORT is the REGISTRY's answer, not the composed
+// sender list's, and the difference is a hole this check shipped with once.
+// `capture.Registry.ChannelProviders` returns only connectors that implement
+// the message seam — `telegram` and nothing else — while `channel_provider`
+// carries every reserved core name, `whatsapp` among them: registered by
+// migration so a hand-logged WhatsApp message can say what carried it, with no
+// Go connector behind it. Checked against the composed list alone, a unit
+// declaring `whatsapp` passed, the upsert re-pointed the core row at the unit,
+// and every previously-unrepliable WhatsApp conversation in the installation
+// became one the unit transmits.
+//
 // credential_model is per_member for every unit transport, because that is what
 // the tier makes available: a unit holds one sealed secret per member (the
 // user-scoped SecretsRequest) and has no installation credential to send under.
@@ -141,16 +152,12 @@ func channelProviderFactsFor(registered, sending []string) []channelProviderFact
 // The label is DERIVED from the id rather than declared, which is the same
 // decision providerLabel documents: this endpoint is readable by every
 // authenticated seat, and a derived name cannot carry text somebody typed.
-func unitChannelFacts(coreProviders []string) ([]channelProviderFacts, error) {
-	core := make(map[string]bool, len(coreProviders))
-	for _, p := range coreProviders {
-		core[p] = true
-	}
+func unitChannelFacts(reserved map[string]bool) ([]channelProviderFacts, error) {
 	var out []channelProviderFacts
 	for _, ext := range ComposedExtensions() {
 		for _, ch := range ext.Channels {
-			if core[ch.Provider] {
-				return nil, fmt.Errorf("compose: extension %q declares the transport %q, which a core connector already supplies — a message on it would leave on the unit's credential instead of the workspace's, so rename the unit's channel", ext.Name, ch.Provider)
+			if reserved[ch.Provider] {
+				return nil, fmt.Errorf("compose: extension %q declares the transport %q, which this installation reserves for the core — a message on it would leave on the unit's credential instead of the workspace's, so rename the unit's channel", ext.Name, ch.Provider)
 			}
 			out = append(out, channelProviderFacts{
 				provider:          ch.Provider,

--- a/backend/internal/compose/channelproviderfacts.go
+++ b/backend/internal/compose/channelproviderfacts.go
@@ -12,6 +12,7 @@ package compose
 // scope a query by, so a module has no unscoped pool to read it from either.
 
 import (
+	"fmt"
 	"strings"
 	"unicode"
 )
@@ -25,9 +26,23 @@ const (
 	credentialPerMember    = "per_member"
 )
 
+// transportCore and transportUnit are who SUPPLIES a transport: a connector
+// compiled into the core, or an extension unit under extensions/. Closed for
+// credentialWorkspaceBot's reason — it describes the shape of the supply, not
+// which providers exist.
+const (
+	transportCore = "core"
+	transportUnit = "unit"
+)
+
 // channelProviderFacts is one transport as the discovery endpoint publishes it.
 type channelProviderFacts struct {
-	provider          string
+	provider string
+	// transport is who supplies it. It is a fact about the INSTALLATION rather
+	// than about the provider: `telegram` is a core transport here and could be
+	// a unit's somewhere else, which is why the collision between the two is a
+	// boot failure rather than a naming convention.
+	transport         string
 	label             string
 	credentialModel   string
 	suppliesTransport bool
@@ -80,10 +95,8 @@ func providerLabel(provider string) string {
 // transport until A103's connector lands.
 //
 // credential_model is workspace_bot for every core connector, because a core
-// channel connector binds ONE bot for the installation. per_member arrives with
-// the unit channel surface, where a member deposits their own secret — the
-// constant is named here so the vocabulary is complete rather than growing a
-// second spelling when that lands.
+// channel connector binds ONE bot for the installation. A unit's is per_member —
+// see unitChannelFacts.
 func channelProviderFactsFor(registered, sending []string) []channelProviderFacts {
 	sends := make(map[string]bool, len(sending))
 	for _, p := range sending {
@@ -93,10 +106,60 @@ func channelProviderFactsFor(registered, sending []string) []channelProviderFact
 	for _, p := range registered {
 		out = append(out, channelProviderFacts{
 			provider:          p,
+			transport:         transportCore,
 			label:             providerLabel(p),
 			credentialModel:   credentialWorkspaceBot,
 			suppliesTransport: sends[p],
 		})
 	}
 	return out
+}
+
+// unitChannelFacts describes every transport this boot's UNITS supply, and
+// holds the one rule a unit's declaration cannot check for itself: it may not
+// shadow a core connector.
+//
+// THE COLLISION IS THE SHARPEST FAILURE THIS SURFACE HAS, which is why it is a
+// boot failure and not a warning. A unit declaring `telegram` would take over
+// the row the workspace's own bot is registered under, and every Telegram reply
+// a rep wrote would then leave on the unit's per-member credential instead —
+// the same message, sent by a different person, with nothing on the screen
+// different. Refusing at boot costs an installation a rename.
+//
+// It lives HERE rather than in preflightChannels because this is the first
+// point at which both sets exist: the core's transports are decided when the
+// capture registry is built, which can happen after extension registration, so
+// the preflight would answer from an empty set and pass the collision it exists
+// to catch. The unit-vs-unit half is still the preflight's — that one needs no
+// core knowledge, and refusing it earlier is a better error.
+//
+// credential_model is per_member for every unit transport, because that is what
+// the tier makes available: a unit holds one sealed secret per member (the
+// user-scoped SecretsRequest) and has no installation credential to send under.
+// A unit that grows a workspace-wide one declares it, and this derives it.
+//
+// The label is DERIVED from the id rather than declared, which is the same
+// decision providerLabel documents: this endpoint is readable by every
+// authenticated seat, and a derived name cannot carry text somebody typed.
+func unitChannelFacts(coreProviders []string) ([]channelProviderFacts, error) {
+	core := make(map[string]bool, len(coreProviders))
+	for _, p := range coreProviders {
+		core[p] = true
+	}
+	var out []channelProviderFacts
+	for _, ext := range ComposedExtensions() {
+		for _, ch := range ext.Channels {
+			if core[ch.Provider] {
+				return nil, fmt.Errorf("compose: extension %q declares the transport %q, which a core connector already supplies — a message on it would leave on the unit's credential instead of the workspace's, so rename the unit's channel", ext.Name, ch.Provider)
+			}
+			out = append(out, channelProviderFacts{
+				provider:          ch.Provider,
+				transport:         transportUnit,
+				label:             providerLabel(ch.Provider),
+				credentialModel:   credentialPerMember,
+				suppliesTransport: ch.SuppliesTransport(),
+			})
+		}
+	}
+	return out, nil
 }

--- a/backend/internal/compose/commschannel.go
+++ b/backend/internal/compose/commschannel.go
@@ -50,13 +50,19 @@ var _ channelSenders = (*capture.Registry)(nil)
 // operator disconnecting the surplus binding repairs every message still pending,
 // so parking on it would destroy sends that nothing is wrong with.
 //
-// userID is unused here: a core connector (telegram) is bound once for the
-// whole workspace, not per member, so ChannelSenderFor takes no user id
-// either. A unit-supplied provider's own resolve path is what actually reads
-// it — out of scope for this change.
+// A UNIT-supplied transport resolves somewhere else entirely, and the branch is
+// FIRST because the two answer different questions: a core binding is the
+// workspace's one bot and takes no user id, while a unit's credential is the
+// member's own and is useless without one. Asking the capture registry about a
+// unit's provider would answer ErrConnectorNotConfigured — a true statement
+// about the core that would park a message the installation can perfectly well
+// send.
 //
 //nolint:ireturn // implements comms.ConnectionResolver, whose contract returns the optional connector.MessageSender seam
-func (r commsResolver) ResolveChannel(ctx context.Context, _ ids.UserID, provider string) (connector.MessageSender, connector.Auth, error) {
+func (r commsResolver) ResolveChannel(ctx context.Context, userID ids.UserID, provider string) (connector.MessageSender, connector.Auth, error) {
+	if transport, supplied := composedUnitTransport(provider); supplied {
+		return r.resolveUnitChannel(ctx, userID, transport)
+	}
 	sender, auth, err := r.channels.ChannelSenderFor(ctx, provider)
 	switch {
 	case errors.Is(err, capture.ErrNoConnection):

--- a/backend/internal/compose/extchannelsend.go
+++ b/backend/internal/compose/extchannelsend.go
@@ -20,6 +20,7 @@ package compose
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/gradionhq/margince/backend/internal/modules/comms"
@@ -111,17 +112,52 @@ func (s unitChannelSender) SendMessage(ctx context.Context, _ connector.Auth, ms
 		Attempt: msg.Attempt + 1,
 	})
 	if err != nil {
-		// Returned as-is, and that is a decision: the dispatcher classifies the
-		// deployment facts at RESOLVE, so a refusal here rides the retry ladder
-		// whatever it says. A revoked credential parks on the next attempt,
-		// where Live answers false — which is the conservative order, because
-		// re-sending a message that already arrived is the one failure a human
-		// cannot undo.
-		return connector.SendReceipt{}, err
+		return connector.SendReceipt{}, unitSendRefusal(err)
 	}
 	// No RFC822 identity: a channel message has none, which is why the channel
 	// seam keys its retry safety on the idempotency key instead.
 	return connector.SendReceipt{ProviderMessageID: receipt.ProviderMessageID}, nil
+}
+
+// unitSendRefusal translates a unit's refusal into the core's own, and it
+// carries exactly ONE class across because only one changes what the
+// dispatcher does.
+//
+// The channel seam does not detect a prior send: it records a transmission as
+// in flight BEFORE the call, and then treats every error that is not
+// ErrSendOutcomeUnknown as a definite answer from the provider — which is to
+// say as proof that nothing went out — clears the marker, and puts the delivery
+// back on the ladder. That is correct for a refusal the provider actually sent
+// and catastrophic for a POST whose answer was lost: the recipient gets the
+// rep's message twice and nothing in the system can tell.
+//
+// So a unit reporting extension.ErrSendOutcomeUnknown STOPS the delivery, with
+// the uncertainty on the record. Everything else rides the ladder, including a
+// revoked credential — which parks on the next attempt, where Live answers
+// false, rather than being classified from an error string here.
+func unitSendRefusal(err error) error {
+	if errors.Is(err, extension.ErrSendOutcomeUnknown) {
+		return fmt.Errorf("%w: %w", connector.ErrSendOutcomeUnknown, err)
+	}
+	return err
+}
+
+// unitSendCapable answers the REQUEST-time pre-flight for a unit transport:
+// can this member send on it right now.
+//
+// It asks the unit's own Live, which is the same question the delivery asks and
+// deliberately the same answer — a rep told "you can send" at the composer and
+// then parked at transmission has been told two things by one installation.
+//
+// A unit that cannot ANSWER reports the fault rather than a verdict, which is
+// the mail arm's own rule one branch below: a pre-flight that cannot ask must
+// not answer, because asserting a capability nobody read is how a rep learns at
+// transmission what they should have been told at the composer.
+func unitSendCapable(ctx context.Context, transport unitTransport, member ids.UserID) (bool, error) {
+	if !transport.channel.SuppliesTransport() {
+		return false, nil
+	}
+	return unitConnectionLive(ctx, transport, extension.UserID(member.String()), boundExtensionRuntime())
 }
 
 // resolveUnitChannel binds a unit's transport to the member whose credential
@@ -146,7 +182,7 @@ func (r commsResolver) resolveUnitChannel(ctx context.Context, userID ids.UserID
 	}
 	deps := boundExtensionRuntime()
 	member := extension.UserID(userID.String())
-	live, err := r.unitConnectionLive(ctx, transport, member, deps)
+	live, err := unitConnectionLive(ctx, transport, member, deps)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -163,7 +199,7 @@ func (r commsResolver) resolveUnitChannel(ctx context.Context, userID ids.UserID
 // A separate Runtime from the send's, and released before the send is built: the
 // two are two invocations of the unit, and a Runtime that outlived its call is
 // the thing release exists to prevent.
-func (commsResolver) unitConnectionLive(ctx context.Context, transport unitTransport, member extension.UserID, deps extensionRuntimeBinding) (bool, error) {
+func unitConnectionLive(ctx context.Context, transport unitTransport, member extension.UserID, deps extensionRuntimeBinding) (bool, error) {
 	rt := sendRuntimeFor(ctx, string(transport.unit), transport.version,
 		"channel/"+transport.channel.Provider, deps)
 	defer rt.release()

--- a/backend/internal/compose/extchannelsend.go
+++ b/backend/internal/compose/extchannelsend.go
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The send half of the unit channel surface: how a delivery staged against a
+// UNIT's transport reaches that unit's Send (DESIGN-SP5 §9, ADR-0107/A158).
+//
+// Everything upstream of here is the product's ordinary channel reply — the
+// rep's reply box, the recipient resolved from the conversation, the consent
+// gate, the staged delivery, the retry ladder. This file is the last edge: the
+// core's own MessageSender seam, implemented over a unit's declaration.
+//
+// WHOSE CREDENTIAL TRANSMITS is the whole difference from a core connector. A
+// core channel binding is the workspace's one bot; a unit's is the MEMBER's own
+// sealed secret, so the delivery's user id is not decoration here — it selects
+// the credential. It is the sending human's id, staged with the delivery and
+// re-read at transmission, which is why a message cannot be made to leave under
+// somebody else's connection by anything that happens after staging.
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gradionhq/margince/backend/internal/modules/comms"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/connector"
+	"github.com/gradionhq/margince/backend/pkg/extension"
+)
+
+// unitTransport is one composed unit channel, resolved by provider: which unit
+// declared it, and the declaration itself.
+type unitTransport struct {
+	unit    extension.Name
+	version string
+	channel extension.Channel
+}
+
+// composedUnitTransport finds the unit that supplies a provider in THIS boot's
+// composition.
+//
+// It reads the composed declarations for composedIngressFor's reason — the set
+// the boot reconciliation validated is the only honest answer — and the boot has
+// already refused a provider claimed twice (preflightChannels) or shared with a
+// core connector (unitChannelFacts), so the first match here is the only match.
+func composedUnitTransport(provider string) (unitTransport, bool) {
+	for _, ext := range ComposedExtensions() {
+		for _, ch := range ext.Channels {
+			if ch.Provider == provider {
+				return unitTransport{unit: ext.Name, version: string(ext.Version), channel: ch}, true
+			}
+		}
+	}
+	return unitTransport{}, false
+}
+
+// unitChannelSender transmits one delivery through a unit's declared Send,
+// under one member's credential.
+//
+// It is built per resolve rather than held, because the member it is bound to is
+// the delivery's and a sender shared across deliveries would be a credential
+// shared across people.
+type unitChannelSender struct {
+	transport unitTransport
+	member    extension.UserID
+	deps      extensionRuntimeBinding
+}
+
+var _ connector.MessageSender = unitChannelSender{}
+
+// SendMessage hands the message to the unit.
+//
+// auth is IGNORED, and the signature keeps it because the seam is shared with
+// core connectors, whose credential the core unseals and passes. A unit's is the
+// unit's: it lives under the unit's own secret scope, sealed per member, and the
+// core never holds it — which is also why nothing here can log or leak it.
+//
+// The Runtime is UNATTENDED, the same shape a job tick gets. Nobody is at the
+// keyboard when a delivery transmits: the human staged it, the seat gate re-read
+// them, and the worker is running the ladder. What the unit may do with an
+// unattended Runtime is already decided — its own tables and its own secrets,
+// with the governed core port shut.
+func (s unitChannelSender) SendMessage(ctx context.Context, _ connector.Auth, msg connector.ChannelMessage) (connector.SendReceipt, error) {
+	if s.transport.channel.Send == nil {
+		// Reachable only if the sendable set and the declaration disagree, which
+		// the reconcile builds one from the other to prevent. Refused by name
+		// rather than dereferenced, because the alternative is a nil call in the
+		// worker at the moment a rep's message is due to leave.
+		return connector.SendReceipt{}, fmt.Errorf("%w: extension %q declares the transport %q with no sender",
+			comms.ErrCannotSend, s.transport.unit, s.transport.channel.Provider)
+	}
+	rt := sendRuntimeFor(ctx, string(s.transport.unit), s.transport.version,
+		"channel/"+s.transport.channel.Provider, s.deps)
+	defer rt.release()
+	receipt, err := s.transport.channel.Send(ctx, rt, extension.OutboundMessage{
+		Member: s.member,
+		// The provider plus the account id ARE the recipient key, exactly as the
+		// dispatcher built them. The display handle is deliberately not carried:
+		// a handle can be released and re-claimed, so nothing may route on it.
+		Recipient: extension.ChannelIdentity{
+			Provider:      msg.Recipient.Provider,
+			ChannelUserID: msg.Recipient.ChannelUserID,
+		},
+		Body:           msg.Body,
+		ReplyTo:        msg.ReplyTo,
+		IdempotencyKey: msg.IdempotencyKey,
+		// The seam counts retries from 0 and the published surface from 1, and
+		// the shift is stated rather than shared: a unit logging "attempt 1" for
+		// the first try is what a human reads, and a unit is other people's code
+		// that should not have to know the core's convention.
+		Attempt: msg.Attempt + 1,
+	})
+	if err != nil {
+		// Returned as-is, and that is a decision: the dispatcher classifies the
+		// deployment facts at RESOLVE, so a refusal here rides the retry ladder
+		// whatever it says. A revoked credential parks on the next attempt,
+		// where Live answers false — which is the conservative order, because
+		// re-sending a message that already arrived is the one failure a human
+		// cannot undo.
+		return connector.SendReceipt{}, err
+	}
+	// No RFC822 identity: a channel message has none, which is why the channel
+	// seam keys its retry safety on the idempotency key instead.
+	return connector.SendReceipt{ProviderMessageID: receipt.ProviderMessageID}, nil
+}
+
+// resolveUnitChannel binds a unit's transport to the member whose credential
+// carries the delivery, and answers the deployment facts the dispatcher parks on.
+//
+// LIVENESS IS ASKED HERE, before the message is handed over, and that is the
+// whole reason Channel.Live is required of a unit that declares a Send. A member
+// who disconnected between staging and transmission has nothing to retry into,
+// so the delivery must PARK where a human can see it — while a provider that
+// could not answer is a failure to get an answer, and parking on one would
+// destroy a send that nothing is wrong with. The two are told apart by the
+// unit's own contract: false versus an error.
+//
+//nolint:ireturn // half of ResolveChannel's own return, whose contract is the optional connector.MessageSender seam
+func (r commsResolver) resolveUnitChannel(ctx context.Context, userID ids.UserID, transport unitTransport) (connector.MessageSender, connector.Auth, error) {
+	if !transport.channel.SuppliesTransport() {
+		// The unit captures on this provider and cannot send on it — the
+		// documented capture-only case, and a fact about the deployment rather
+		// than about this message.
+		return nil, nil, fmt.Errorf("%w: extension %q supplies %q for capture only",
+			comms.ErrCannotSend, transport.unit, transport.channel.Provider)
+	}
+	deps := boundExtensionRuntime()
+	member := extension.UserID(userID.String())
+	live, err := r.unitConnectionLive(ctx, transport, member, deps)
+	if err != nil {
+		return nil, nil, err
+	}
+	if !live {
+		return nil, nil, fmt.Errorf("%w: this member has no live connection to %q",
+			comms.ErrNoMailbox, transport.channel.Provider)
+	}
+	return unitChannelSender{transport: transport, member: member, deps: deps}, nil, nil
+}
+
+// unitConnectionLive asks the unit whether this member can still send, on a
+// Runtime of its own.
+//
+// A separate Runtime from the send's, and released before the send is built: the
+// two are two invocations of the unit, and a Runtime that outlived its call is
+// the thing release exists to prevent.
+func (commsResolver) unitConnectionLive(ctx context.Context, transport unitTransport, member extension.UserID, deps extensionRuntimeBinding) (bool, error) {
+	rt := sendRuntimeFor(ctx, string(transport.unit), transport.version,
+		"channel/"+transport.channel.Provider, deps)
+	defer rt.release()
+	live, err := transport.channel.Live(ctx, rt, member)
+	if err != nil {
+		// Deliberately NOT a deployment fact: the unit says it could not tell,
+		// and the dispatcher retries what it cannot classify.
+		return false, fmt.Errorf("compose: extension %q could not confirm this member's %q connection: %w",
+			transport.unit, transport.channel.Provider, err)
+	}
+	return live, nil
+}

--- a/backend/internal/compose/extchannelsend_test.go
+++ b/backend/internal/compose/extchannelsend_test.go
@@ -1,0 +1,201 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The unit-transport resolve, proven without a database for the reason the core
+// one is (commschannel_test.go): a deployment fact read as a fault leaves a
+// message queued against a connection that is gone, and a fault read as a fact
+// destroys a message nothing was wrong with. Here the two are told apart by what
+// the UNIT answered — false versus an error — so this is where that contract is
+// pinned.
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/modules/comms"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/connector"
+	"github.com/gradionhq/margince/backend/pkg/extension"
+)
+
+// declaresTransport installs a composed set holding one unit that supplies one
+// channel, restoring whatever the process had when the test ends.
+//
+// It writes the REAL registry rather than a stub, because what is under test is
+// that the resolve reads the boot's own composed declarations: a fake set here
+// would prove it consults something, not that it consults that.
+func declaresTransport(t *testing.T, unit string, ch extension.Channel) {
+	t.Helper()
+	composeUnit(t, extension.Extension{
+		Name: extension.Name(unit), Version: "1.0.0", Channels: []extension.Channel{ch},
+	})
+}
+
+// capturedSend records what the core handed the unit, and answers what the test
+// told it to. It stands in for a unit's own Send — the only seam this file is
+// about — so it is a boundary double rather than a re-implementation.
+type capturedSend struct {
+	got     extension.OutboundMessage
+	receipt extension.Receipt
+	err     error
+}
+
+func (c *capturedSend) send(_ context.Context, _ extension.Runtime, msg extension.OutboundMessage) (extension.Receipt, error) {
+	c.got = msg
+	return c.receipt, c.err
+}
+
+// answersLive is a unit's Live, fixed.
+func answersLive(live bool, err error) extension.ConnectionLiveChecker {
+	return func(context.Context, extension.Runtime, extension.UserID) (bool, error) { return live, err }
+}
+
+// A unit's transport is resolved instead of the capture registry's — and the
+// registry is deliberately wired to answer "no such connector", which is what it
+// would really say about a provider it never compiled in. Reaching it would park
+// a message the installation can perfectly well send.
+func TestResolveChannelPrefersTheUnitThatSuppliesTheTransport(t *testing.T) {
+	sender := &capturedSend{}
+	declaresTransport(t, "mine", extension.Channel{
+		Provider: "mine_chat", Send: sender.send, Live: answersLive(true, nil),
+	})
+	r := commsResolver{channels: stubChannelSenders{err: errors.New("the capture registry was asked and should not have been")}}
+
+	resolved, auth, err := r.ResolveChannel(context.Background(), ids.New[ids.UserKind](), "mine_chat")
+	if err != nil {
+		t.Fatalf("ResolveChannel: %v", err)
+	}
+	if resolved == nil {
+		t.Fatal("ResolveChannel returned no sender for a transport a composed unit supplies")
+	}
+	// No credential crosses this seam: a unit's is sealed under its own secret
+	// scope, per member, and the core never holds it.
+	if auth != nil {
+		t.Errorf("auth = %q, want nil — a unit's credential is the unit's and does not travel through the core", auth)
+	}
+}
+
+// The two deployment facts a unit transport can report, and the one fault it
+// must NOT be mistaken for. A member who disconnected has nothing to retry into,
+// so the delivery parks where a human can see it; a provider that could not
+// answer is a failure to get an answer, and parking on one would destroy a send
+// that nothing is wrong with.
+func TestResolveUnitChannelTranslatesOnlyTheDeploymentFacts(t *testing.T) {
+	provider := errors.New("the provider timed out")
+	for _, tc := range []struct {
+		name    string
+		channel extension.Channel
+		want    error
+	}{
+		{
+			name:    "a capture-only transport parks",
+			channel: extension.Channel{Provider: "mine_chat"},
+			want:    comms.ErrCannotSend,
+		},
+		{
+			name: "a member who disconnected parks",
+			channel: extension.Channel{
+				Provider: "mine_chat", Send: (&capturedSend{}).send, Live: answersLive(false, nil),
+			},
+			want: comms.ErrNoMailbox,
+		},
+		{
+			name: "a provider that could not answer is retried",
+			channel: extension.Channel{
+				Provider: "mine_chat", Send: (&capturedSend{}).send, Live: answersLive(false, provider),
+			},
+			want: provider,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			declaresTransport(t, "mine", tc.channel)
+			r := commsResolver{}
+
+			_, _, err := r.ResolveChannel(context.Background(), ids.New[ids.UserKind](), "mine_chat")
+
+			if !errors.Is(err, tc.want) {
+				t.Fatalf("ResolveChannel → %v, want it to match %v", err, tc.want)
+			}
+			if tc.want == provider && (errors.Is(err, comms.ErrNoMailbox) ||
+				errors.Is(err, comms.ErrCannotSend) || errors.Is(err, comms.ErrProviderNotConfigured)) {
+				t.Fatalf("a fault was translated into a parking sentinel: %v", err)
+			}
+		})
+	}
+}
+
+// What the core hands the unit is the delivery, unchanged where it matters and
+// shifted exactly where the two surfaces differ.
+func TestTheUnitSenderHandsOverTheDeliveryTheDispatcherBuilt(t *testing.T) {
+	sender := &capturedSend{receipt: extension.Receipt{ProviderMessageID: "provider-42"}}
+	member := ids.New[ids.UserKind]()
+	declaresTransport(t, "mine", extension.Channel{
+		Provider: "mine_chat", Send: sender.send, Live: answersLive(true, nil),
+	})
+	r := commsResolver{}
+	resolved, _, err := r.ResolveChannel(context.Background(), member, "mine_chat")
+	if err != nil {
+		t.Fatalf("ResolveChannel: %v", err)
+	}
+
+	receipt, err := resolved.SendMessage(context.Background(), nil, connector.ChannelMessage{
+		Recipient:      connector.ChannelIdentity{Provider: "mine_chat", ChannelUserID: "acct-7", Username: "handle"},
+		Body:           "the reply",
+		ReplyTo:        "upstream-9",
+		IdempotencyKey: "delivery-1",
+		Attempt:        0,
+	})
+	if err != nil {
+		t.Fatalf("SendMessage: %v", err)
+	}
+
+	got := sender.got
+	// WHOSE credential transmits is the whole point of this seam.
+	if string(got.Member) != member.String() {
+		t.Errorf("Member = %q, want the delivery's own sending member %q — a message must not leave under somebody else's connection", got.Member, member)
+	}
+	if got.Recipient.ChannelUserID != "acct-7" || got.Recipient.Provider != "mine_chat" {
+		t.Errorf("Recipient = %+v, want the provider and account id the dispatcher resolved", got.Recipient)
+	}
+	// The handle is deliberately NOT carried: it can be released and re-claimed,
+	// so nothing may route on it.
+	if got.Recipient.DisplayName != "" {
+		t.Errorf("the display handle %q crossed the seam; a re-claimable handle must not reach a routing decision", got.Recipient.DisplayName)
+	}
+	if got.Body != "the reply" || got.ReplyTo != "upstream-9" || got.IdempotencyKey != "delivery-1" {
+		t.Errorf("the message was altered in transit: %+v", got)
+	}
+	// The seam counts retries from 0 and the published surface from 1.
+	if got.Attempt != 1 {
+		t.Errorf("Attempt = %d, want 1 for a first transmission — a unit logging attempt 0 reads as a repeat", got.Attempt)
+	}
+	if receipt.ProviderMessageID != "provider-42" {
+		t.Errorf("ProviderMessageID = %q, want the unit's own receipt — it is what makes a later reply anchorable", receipt.ProviderMessageID)
+	}
+	// A channel message carries no RFC822 identity, which is why the seam keys
+	// retry safety on the idempotency key instead.
+	if receipt.RFC822MessageID != "" {
+		t.Errorf("RFC822MessageID = %q; a channel message has none", receipt.RFC822MessageID)
+	}
+}
+
+// A provider no composed unit supplies falls through to the capture registry, or
+// a core connector's own transport would stop resolving the moment any unit
+// declared any channel.
+func TestResolveChannelStillReachesTheCoreRegistryForACoreTransport(t *testing.T) {
+	declaresTransport(t, "mine", extension.Channel{
+		Provider: "mine_chat", Send: (&capturedSend{}).send, Live: answersLive(true, nil),
+	})
+	r := commsResolver{channels: stubChannelSenders{sender: stubChannelSender{}}}
+
+	sender, auth, err := r.ResolveChannel(context.Background(), ids.New[ids.UserKind](), "telegram")
+	if err != nil {
+		t.Fatalf("ResolveChannel: %v", err)
+	}
+	if sender == nil || string(auth) != "bot-token" {
+		t.Fatalf("ResolveChannel = %v/%q, want the core binding unchanged", sender, auth)
+	}
+}

--- a/backend/internal/compose/extchannelsend_test.go
+++ b/backend/internal/compose/extchannelsend_test.go
@@ -13,6 +13,8 @@ package compose
 import (
 	"context"
 	"errors"
+	"slices"
+	"strings"
 	"testing"
 
 	"github.com/gradionhq/margince/backend/internal/modules/comms"
@@ -51,6 +53,62 @@ func (c *capturedSend) send(_ context.Context, _ extension.Runtime, msg extensio
 // answersLive is a unit's Live, fixed.
 func answersLive(live bool, err error) extension.ConnectionLiveChecker {
 	return func(context.Context, extension.Runtime, extension.UserID) (bool, error) { return live, err }
+}
+
+// The boot preflight for a channel declaration, which holds the two rules
+// Channel.Validate cannot: the same provider declared twice inside one unit,
+// and the same provider claimed by two DIFFERENT units.
+//
+// Both are facts about the composed SET rather than about a declaration, and
+// both refuse at BOOT rather than at the send — the send is the moment the
+// mistake becomes a message somebody receives. The THIRD collision, against a
+// core connector, is deliberately not here: see unitChannelFacts.
+func TestThePreflightHoldsChannelDeclarationsToTheComposedSet(t *testing.T) {
+	sender := &capturedSend{}
+	mine := extension.Extension{
+		Name: "mine", Version: "1.0.0",
+		Channels: []extension.Channel{{Provider: "mine_chat", Send: sender.send, Live: answersLive(true, nil)}},
+	}
+
+	claimed := map[string]extension.Name{}
+	if err := preflightChannels(mine, claimed); err != nil {
+		t.Fatalf("a well-formed channel declaration was refused: %v", err)
+	}
+	if claimed["mine_chat"] != "mine" {
+		t.Errorf("the provider was not recorded as claimed by %q; the next unit's collision would go unseen", mine.Name)
+	}
+
+	// The published grammar, reached through the preflight — so a declaration
+	// that arrived outside the generator path is held to the same rule the
+	// manifest generator applies.
+	ungrammatical := mine
+	ungrammatical.Channels = []extension.Channel{{Provider: "mine-chat"}}
+	if err := preflightChannels(ungrammatical, map[string]extension.Name{}); err == nil {
+		t.Error("a provider the registry grammar refuses was accepted; it would fail on the column instead, under a constraint name")
+	}
+
+	twice := mine
+	twice.Channels = append(slices.Clone(mine.Channels), mine.Channels[0])
+	if err := preflightChannels(twice, map[string]extension.Name{}); err == nil {
+		t.Error("one provider declared twice within a unit was accepted")
+	}
+
+	// The collision that matters most of the three that live here: two units,
+	// one provider, and nothing downstream able to say whose transport a
+	// message travelled on.
+	theirs := extension.Extension{
+		Name: "theirs", Version: "1.0.0",
+		Channels: []extension.Channel{{Provider: "mine_chat"}},
+	}
+	err := preflightChannels(theirs, claimed)
+	if err == nil {
+		t.Fatal("two units claiming one provider were accepted; one provider names one transport")
+	}
+	// Both names, because an author reading this has no other way to find the
+	// other side of the clash.
+	if !strings.Contains(err.Error(), "mine") || !strings.Contains(err.Error(), "theirs") {
+		t.Errorf("the refusal %q names only one side of the collision", err)
+	}
 }
 
 // A unit's transport is resolved instead of the capture registry's — and the
@@ -179,6 +237,53 @@ func TestTheUnitSenderHandsOverTheDeliveryTheDispatcherBuilt(t *testing.T) {
 	// retry safety on the idempotency key instead.
 	if receipt.RFC822MessageID != "" {
 		t.Errorf("RFC822MessageID = %q; a channel message has none", receipt.RFC822MessageID)
+	}
+}
+
+// The one refusal class that crosses the seam, and the reason it is the only
+// one: the dispatcher records a channel transmission as in flight BEFORE the
+// call and then treats every error that is NOT ErrSendOutcomeUnknown as a
+// definite answer from the provider — proof that nothing went out — clearing
+// the marker and putting the delivery back on the ladder.
+//
+// A channel has no prior-send lookup, so a POST whose answer was lost and
+// reported as an ordinary failure delivers the rep's message twice, with
+// nothing able to detect it. Anything else must NOT be translated, or a refusal
+// a retry would have recovered from stops the delivery instead.
+func TestOnlyAnUnknownOutcomeStopsTheDeliveryRatherThanRetryingIt(t *testing.T) {
+	ordinary := errors.New("the provider refused this message")
+	for name, tc := range map[string]struct {
+		from error
+		stop bool
+	}{
+		"a lost answer stops the delivery":     {from: extension.ErrSendOutcomeUnknown, stop: true},
+		"an ordinary refusal rides the ladder": {from: ordinary},
+	} {
+		t.Run(name, func(t *testing.T) {
+			sender := &capturedSend{err: tc.from}
+			declaresTransport(t, "mine", extension.Channel{
+				Provider: "mine_chat", Send: sender.send, Live: answersLive(true, nil),
+			})
+			r := commsResolver{}
+			resolved, _, err := r.ResolveChannel(context.Background(), ids.New[ids.UserKind](), "mine_chat")
+			if err != nil {
+				t.Fatalf("ResolveChannel: %v", err)
+			}
+
+			_, err = resolved.SendMessage(context.Background(), nil, connector.ChannelMessage{
+				Recipient: connector.ChannelIdentity{Provider: "mine_chat", ChannelUserID: "acct-7"},
+				Body:      "the reply", IdempotencyKey: "delivery-1",
+			})
+
+			if got := errors.Is(err, connector.ErrSendOutcomeUnknown); got != tc.stop {
+				t.Errorf("ErrSendOutcomeUnknown = %v, want %v — got %v", got, tc.stop, err)
+			}
+			// The unit's own cause survives translation either way, so the
+			// delivery's log still says what the unit actually answered.
+			if !errors.Is(err, tc.from) {
+				t.Errorf("the underlying cause %v was dropped from %v", tc.from, err)
+			}
+		})
 	}
 }
 

--- a/backend/internal/compose/extcore.go
+++ b/backend/internal/compose/extcore.go
@@ -64,6 +64,23 @@ type extensionCore struct {
 	// passes in.
 	unattended bool
 	deps       extensionRuntimeBinding
+	// unit is which extension this port is writing for, and it is here for one
+	// reason: what a unit may name at this door is bounded by what that unit
+	// DECLARED. Taken from the Runtime rather than from the request, for the
+	// reason every other derived identity here is.
+	unit string
+}
+
+// providerNamed reads the transport off the transcoded request, where it is
+// optional. An absent field and an empty one are ONE answer — "this record
+// names no transport" — because the pairing rule asks whether a transport was
+// named, and a nil pointer answering differently from an empty string would be
+// two spellings of one record with two outcomes.
+func providerNamed(ref *crmcontracts.ProviderRef) string {
+	if ref == nil {
+		return ""
+	}
+	return string(*ref)
 }
 
 //nolint:ireturn // returning the published repo IS the seam: a unit holds extension.ActivityRepo, never a core type.
@@ -104,12 +121,12 @@ func (a extensionActivities) Create(ctx context.Context, in crm.CreateActivityRe
 	if err != nil {
 		return crm.Activity{}, fmt.Errorf("%w: %s", extension.ErrInvalid, err)
 	}
-	// The SAME refusal the ingress door applies, because a unit has two ways to
+	// The SAME rule the ingress door applies, because a unit has two ways to
 	// write an activity and the rule is about the unit, not about the door. This
 	// one is the dangerous half: the published request carries channel_provider,
 	// so without this a unit could name a core connector's transport and mint a
 	// valid send anchor for a conversation it does not own.
-	if err := refuseUnitMessageKind(string(request.Kind)); err != nil {
+	if err := refuseUndeclaredTransport(a.core.unit, string(request.Kind), providerNamed(request.ChannelProvider)); err != nil {
 		return crm.Activity{}, err
 	}
 	mapped, err := activities.LogActivityInputFrom(request)

--- a/backend/internal/compose/extensions.go
+++ b/backend/internal/compose/extensions.go
@@ -148,6 +148,15 @@ func validateExtensionSet(exts []extension.Extension) error {
 	seen := make(map[extension.Name]bool, len(exts))
 	namespaces := make(map[string]extension.Name, len(exts))
 	packCodes := make(map[jurisdiction.Code]extension.Name, len(exts))
+	// Which provider each unit has claimed — a fact about the composed SET, so
+	// it is accumulated across the loop rather than asked of one declaration.
+	//
+	// The OTHER collision, against a core connector, is deliberately not here:
+	// the core's own transport set is decided when the capture registry is
+	// constructed, which can happen after this runs, so asking now would answer
+	// from an empty set and pass a collision it could not see. The reconcile
+	// holds that one, where both sets exist.
+	claimedProviders := make(map[string]extension.Name)
 	for _, e := range exts {
 		if err := e.Name.Validate(); err != nil {
 			return fmt.Errorf("compose: %w", err)
@@ -178,6 +187,9 @@ func validateExtensionSet(exts []extension.Extension) error {
 			return err
 		}
 		if err := preflightIngress(e); err != nil {
+			return err
+		}
+		if err := preflightChannels(e, claimedProviders); err != nil {
 			return err
 		}
 	}
@@ -351,47 +363,6 @@ func preflightSecrets(e extension.Extension) error {
 			return fmt.Errorf("compose: extension %q declares secret %q at %s scope twice", e.Name, req.Key, req.Scope)
 		}
 		seen[req] = true
-	}
-	return nil
-}
-
-// preflightIngress validates one unit's declared ingress sources through the
-// same published IngressSource.Validate the manifest generator runs, and
-// rejects the same system declared twice.
-//
-// A duplicate is not harmless here the way a duplicate description would be:
-// the system key is half of every landed record's natural key, so two entries
-// naming one system are two declarations an operator resolves separately about
-// one provenance namespace — and if they ever disagree about Lands, which of
-// them the port answered from would be declaration order.
-func preflightIngress(e extension.Extension) error {
-	seen := make(map[string]bool, len(e.Ingress))
-	for _, source := range e.Ingress {
-		if err := source.Validate(); err != nil {
-			return fmt.Errorf("compose: extension %q: %w", e.Name, err)
-		}
-		if seen[source.System] {
-			return fmt.Errorf("compose: extension %q declares ingress source %q twice", e.Name, source.System)
-		}
-		seen[source.System] = true
-	}
-	return nil
-}
-
-// preflightJobs validates one unit's scheduled jobs through the same published
-// Job.Validate the manifest generator runs, and rejects a job name declared
-// twice within the unit — the same fail-closed boundary preflightTools holds,
-// for a declaration that reached the composed set outside the generator path.
-func preflightJobs(e extension.Extension) error {
-	seen := make(map[string]bool, len(e.Jobs))
-	for _, job := range e.Jobs {
-		if err := job.Validate(); err != nil {
-			return fmt.Errorf("compose: extension %q: %w", e.Name, err)
-		}
-		if seen[job.Name] {
-			return fmt.Errorf("compose: extension %q declares job %q twice", e.Name, job.Name)
-		}
-		seen[job.Name] = true
 	}
 	return nil
 }

--- a/backend/internal/compose/extingress.go
+++ b/backend/internal/compose/extingress.go
@@ -81,7 +81,10 @@ func (r *callRuntime) Ingest(ctx context.Context, on extension.UserID, rec exten
 	if err := rec.Validate(); err != nil {
 		return extension.Result{}, fmt.Errorf("%w: %s", extension.ErrInvalid, err.Error())
 	}
-	if err := refuseUnitMessageKind(rec.Activity.Kind); err != nil {
+	if err := refuseUndeclaredTransport(r.unit, rec.Activity.Kind, rec.Activity.ChannelProvider); err != nil {
+		return extension.Result{}, err
+	}
+	if err := refuseUnitIdentity(r.unit, rec.Counterparty.ChannelIdentity.Provider); err != nil {
 		return extension.Result{}, err
 	}
 	// Whether this ROLE can accept a record at all is answered before the
@@ -188,13 +191,14 @@ func (r *callRuntime) normalized(rec extension.Record) connector.NormalizedRecor
 		NaturalKey: r.naturalKey(rec),
 		Fields: capture.ActivityFields{
 			Kind: rec.Activity.Kind,
-			// No transport, and no way for a unit to name one yet: the extension
-			// record shape carries no channel, so a unit landing KindMessage is
-			// refused before it gets here (refuseUnitMessageKind).
-			Subject:    rec.Activity.Subject,
-			Body:       rec.Activity.Body,
-			OccurredAt: rec.Activity.OccurredAt,
-			Direction:  rec.Activity.Direction,
+			// The transport the unit named, already held to what it DECLARED
+			// (refuseUndeclaredTransport) — so this carries a provider the
+			// installation registered rather than a string the unit chose.
+			ChannelProvider: rec.Activity.ChannelProvider,
+			Subject:         rec.Activity.Subject,
+			Body:            rec.Activity.Body,
+			OccurredAt:      rec.Activity.OccurredAt,
+			Direction:       rec.Activity.Direction,
 		},
 		Source:     r.sourceSystem(rec.System),
 		CapturedBy: ingressPrincipalPrefix + r.unit,
@@ -206,32 +210,89 @@ func (r *callRuntime) normalized(rec extension.Record) connector.NormalizedRecor
 			DisplayName: rec.Counterparty.DisplayName,
 			Domain:      rec.Counterparty.Domain,
 			Direction:   rec.Counterparty.Direction,
+			// The binding that makes the record repliable, held to the same
+			// declared set the activity's own transport is (refuseUnitIdentity):
+			// a unit that could bind an identity under a core connector's
+			// provider would be writing into the table the workspace's own
+			// reply path resolves its recipients from.
+			//
+			// DisplayName lands on Username, which is the core's display-only
+			// field for exactly this: a handle nothing routes, authorizes or
+			// deduplicates on. The two names differ because the core's is
+			// Telegram-shaped and the published one is not, and renaming either
+			// would be a change at a security-sensitive identity for a word.
+			ChannelIdentity: connector.ChannelIdentity{
+				Provider:      rec.Counterparty.ChannelIdentity.Provider,
+				ChannelUserID: rec.Counterparty.ChannelIdentity.ChannelUserID,
+				Username:      rec.Counterparty.ChannelIdentity.DisplayName,
+			},
 		},
 	}
 }
 
-// refuseUnitMessageKind stops a unit filing a channel message on ANY of its
+// refuseUndeclaredTransport holds the kind/transport pairing on ANY of a unit's
 // write doors, and it is deliberately one function rather than a check at each.
 //
-// A unit has no channel of its own until slice 2, so it may not claim a
-// transport it does not own. The two doors fail differently without this and
-// only one of them is obvious: capture ingress carries no provider field at all,
-// so a message would violate the CHECK and surface as an unattributable 500 —
-// while the core-write door DOES carry channel_provider, so a unit could name a
-// core connector's transport and mint a row that is a valid SEND ANCHOR. A rep
-// or an approved agent replying on it would transmit a real message from the
-// workspace's bot to whoever the unit linked: the unit picks the target, the
-// human supplies the authority. It would also inherit the GoBD statutory floor,
-// pinning unit-supplied text past the workspace's own retention policy.
+// It is a BOUNDED PERMISSION, and the bound is the point. A unit may file a
+// message on a transport it DECLARED (extension.Channel) and on no other. What
+// it may not do is name somebody else's: the core-write door carries
+// channel_provider on the published request, so a unit naming `telegram` would
+// mint a row that is a valid SEND ANCHOR for a conversation it does not own —
+// a rep or an approved agent replying on it would transmit a real message from
+// the workspace's bot to whoever the unit linked, the unit picking the target
+// and the human supplying the authority. It would also inherit that transport's
+// statutory retention floor, pinning unit-supplied text past the workspace's
+// own policy.
 //
-// Slice 2 turns this from a refusal into a bounded permission — a unit may name
-// its own declared provider and no other.
-func refuseUnitMessageKind(kind string) error {
+// The other direction is refused too, and it is the quieter defect: a NON-message
+// naming a transport is a record claiming to have travelled somewhere it did
+// not. The send path reads the provider column and not the kind since
+// ADR-0107/A158, so such a row would be repliable — a note that answers back.
+func refuseUndeclaredTransport(unit, kind, provider string) error {
 	if kind != activities.KindMessage {
+		if provider == "" {
+			return nil
+		}
+		return fmt.Errorf("%w: a %q activity names the transport %q — only a %q carries one, and a record claiming a transport it did not travel on is one the reply path would answer on",
+			extension.ErrInvalid, kind, provider, activities.KindMessage)
+	}
+	if provider == "" {
+		return fmt.Errorf("%w: a %q activity names no transport — a message that does not say what carried it cannot be replied to on anything",
+			extension.ErrInvalid, activities.KindMessage)
+	}
+	for _, declared := range composedChannelsFor(unit) {
+		if declared.Provider == provider {
+			return nil
+		}
+	}
+	return fmt.Errorf("%w: this unit does not supply the transport %q — a unit may file a message on a channel it declared and on no other",
+		extension.ErrInvalid, provider)
+}
+
+// refuseUnitIdentity holds a record's counterparty BINDING to the same declared
+// set its transport is held to.
+//
+// It is a second check rather than a reuse of the pairing above because it
+// answers about a different row. The activity's provider decides where a reply
+// would be SENT; this one writes person_channel_identity, which is where the
+// core's reply path resolves WHO it is sent to. A unit able to bind an identity
+// under `telegram` could attach an account it controls to somebody else's person
+// record, and the next Telegram reply a rep writes on that person's conversation
+// would go to the unit's account instead — no message the unit filed involved.
+//
+// An empty provider is a record that identifies its counterparty by address, and
+// binds nothing.
+func refuseUnitIdentity(unit, provider string) error {
+	if provider == "" {
 		return nil
 	}
-	return fmt.Errorf("%w: a unit cannot file a %q activity — a message must name the transport that carried it, and a unit may not claim a transport it does not supply",
-		extension.ErrInvalid, activities.KindMessage)
+	for _, declared := range composedChannelsFor(unit) {
+		if declared.Provider == provider {
+			return nil
+		}
+	}
+	return fmt.Errorf("%w: this unit does not supply the transport %q, so it cannot bind an account on it — the reply path resolves its recipients from those bindings",
+		extension.ErrInvalid, provider)
 }
 
 // naturalKey is the idempotency key the database's unique index enforces. Its

--- a/backend/internal/compose/extingress_integration_test.go
+++ b/backend/internal/compose/extingress_integration_test.go
@@ -27,6 +27,9 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/gradionhq/margince/backend/internal/compose/integration"
+	"github.com/gradionhq/margince/backend/internal/modules/activities"
+	"github.com/gradionhq/margince/backend/internal/modules/capture"
+	"github.com/gradionhq/margince/backend/internal/modules/comms"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/extsecrets"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
@@ -40,6 +43,11 @@ const (
 	ingressProbeSystem  = "probe-chat"
 	ingressProbeSource  = "ext:" + ingressUnit + ":" + ingressProbeSystem
 	ingressProbeCapture = "connector:ext:" + ingressUnit
+	// The transport the probe unit supplies. It is SNAKE where the ingress
+	// system above is kebab, and that is the rule rather than a typo: a
+	// provider is a channel_provider row and satisfies that column's own
+	// grammar, which is not the ingress declaration's.
+	ingressProbeProvider = "probe_chat"
 )
 
 // ingressEnv is the runtime env plus everything an ingest needs to be allowed
@@ -53,9 +61,15 @@ type ingressEnv struct {
 func setupIngress(t *testing.T) *ingressEnv {
 	t.Helper()
 	e := setupExtRuntime(t)
-	composeIngressFor(t, ingressUnit, extension.IngressSource{
-		System: ingressProbeSystem, Lands: []extension.RecordKind{extension.KindActivity},
-	})
+	composeCapturingUnit(t, ingressUnit,
+		// The probe unit SUPPLIES a transport as well as capturing from one, which
+		// is the shape a channel unit actually has — and what a unit may name on a
+		// message is bounded by this declaration, so a set without it would leave
+		// the message tests refused for a reason the test never chose.
+		[]extension.Channel{{Provider: ingressProbeProvider}},
+		extension.IngressSource{
+			System: ingressProbeSystem, Lands: []extension.RecordKind{extension.KindActivity},
+		})
 	bindCaptureForTest(t, e)
 	grantCapture(t, e, e.Rep1)
 	depositCredential(t, e, e.Rep1)
@@ -248,6 +262,143 @@ func TestAUnitsRecordLandsAsAnActivityWithEvidenceAndTheWriteShape(t *testing.T)
 	if got := e.countAsWorkspace(t,
 		`SELECT count(*) FROM event_outbox WHERE envelope->'entity'->>'id' = $1`, activityID.String()); got == 0 {
 		t.Error("the landing published no event — an audit row with no event is the write shape half-kept")
+	}
+}
+
+// aChannelMessage is the same record as a message on the unit's own transport,
+// naming the account it can be answered at.
+func aChannelMessage(key, senderEmail, account string) extension.Record {
+	rec := aProviderRecord(key, senderEmail)
+	rec.Activity.Kind = extension.ActivityKindMessage
+	rec.Activity.ChannelProvider = ingressProbeProvider
+	// ONE naming, never both: the core refuses a counterparty named by an
+	// address AND by a channel account, because the two resolve through
+	// different ladders. A channel record is named by the account it can be
+	// answered at, so the address goes.
+	rec.Counterparty = extension.Counterparty{
+		DisplayName: "A Sender", Direction: extension.DirectionInbound,
+		ChannelIdentity: extension.ChannelIdentity{
+			Provider: ingressProbeProvider, ChannelUserID: account, DisplayName: "A Sender",
+		},
+	}
+	// The addresses stay: they are a different question — every party the
+	// message names, which is what the internal-colleague gate reads, and an
+	// empty set disables that gate rather than passing it.
+	rec.Addresses = []string{senderEmail, "a@authz.test"}
+	return rec
+}
+
+// registerProbeTransport puts the unit's transport in the registry, through the
+// real reconcile.
+//
+// It is not optional bookkeeping: activity.channel_provider is a foreign key
+// into channel_provider, so a captured message naming an unregistered transport
+// is refused by the database — which is exactly the failure a unit channel would
+// have if the boot reconcile did not write it.
+func registerProbeTransport(t *testing.T, e *ingressEnv) {
+	t.Helper()
+	// The reconcile sets BOTH packages' in-memory sendable snapshots to what it
+	// was passed. Restore the pre-registry default rather than leaving this
+	// test's set behind, or a later test in the same process sees an
+	// installation with no Telegram transport — which is a failure that names
+	// somebody else's code.
+	t.Cleanup(func() {
+		activities.SetChannelProviders([]string{capture.ProviderTelegram})
+		comms.SetChannelProviders([]string{capture.ProviderTelegram})
+	})
+	if err := reconcileChannelProviders(context.Background(), e.Pool, []string{capture.ProviderTelegram}); err != nil {
+		t.Fatalf("registering the unit's transport: %v", err)
+	}
+	t.Cleanup(func() {
+		// In dependency order, and the order itself is the finding: the registry
+		// row is a foreign-key parent of every message filed on it AND of every
+		// identity bound on it, which is what stops a live transport being
+		// deregistered out from under the conversations that reference it. That
+		// is also why the boot reconcile never deletes.
+		owner := integration.OwnerConn(t)
+		for _, statement := range []string{
+			`DELETE FROM activity WHERE channel_provider = $1`,
+			`DELETE FROM person_channel_identity WHERE provider = $1`,
+			`DELETE FROM channel_provider WHERE provider = $1`,
+		} {
+			if _, err := owner.Exec(context.Background(), statement, ingressProbeProvider); err != nil {
+				t.Errorf("cleaning up after the probe transport (%s): %v", statement, err)
+			}
+		}
+	})
+}
+
+// A unit's captured chat message lands as a MESSAGE on the unit's own transport,
+// with the account it can be answered at bound to the person behind it.
+//
+// This is the whole point of the slice, and each half is separately load-bearing.
+// The kind and the provider are the two axes stated separately (ADR-0107/A158):
+// the send path reads the PROVIDER column, so a message filed as a `note` — which
+// is what this unit landed before it supplied a channel — is a conversation
+// nothing can reply on. And the identity binding is what the reply path resolves
+// its recipient FROM: without it the message is repliable in principle and
+// answers "nobody on this conversation can be reached" in practice.
+func TestAUnitsChannelMessageLandsAsARepliableConversation(t *testing.T) {
+	e := setupIngress(t)
+	registerProbeTransport(t, e)
+	rt := e.ingestingRuntime()
+
+	result, err := rt.Ingest(context.Background(), extension.UserID(e.member.String()),
+		aChannelMessage("ws-7:3001", "someone@gmail.com", "probe-channel-1"))
+	if err != nil {
+		t.Fatalf("Ingest: %v", err)
+	}
+	if result.Disposition != extension.DispositionAccepted {
+		t.Fatalf("disposition = %q, want accepted", result.Disposition)
+	}
+
+	var kind, provider string
+	e.readAsWorkspace(t, func(ctx context.Context, tx pgx.Tx) error {
+		return tx.QueryRow(ctx,
+			`SELECT kind, coalesce(channel_provider, '') FROM activity WHERE id = $1`,
+			ids.MustParse(result.Ref.ID)).Scan(&kind, &provider)
+	})
+	if kind != extension.ActivityKindMessage {
+		t.Errorf("kind = %q, want %q — the timeline must know this was a message at all", kind, extension.ActivityKindMessage)
+	}
+	if provider != ingressProbeProvider {
+		t.Errorf("channel_provider = %q, want %q — the send path reads this column, and an empty one is a conversation no reply can leave on",
+			provider, ingressProbeProvider)
+	}
+
+	// The binding, which is what makes the recipient resolvable — and it names
+	// the account the UNIT reported, not one derived from the address.
+	if got := e.countAsWorkspace(t,
+		`SELECT count(*) FROM person_channel_identity WHERE provider = $1 AND channel_user_id = $2`,
+		ingressProbeProvider, "probe-channel-1"); got != 1 {
+		t.Errorf("channel identity bindings = %d, want the one the reply path resolves its recipient from", got)
+	}
+}
+
+// A unit naming a transport it does NOT supply is refused, and nothing lands.
+//
+// This is the sharpest refusal on the write door: `telegram` is a real
+// registered transport with a real workspace bot behind it, so the row would be
+// a valid SEND ANCHOR for a conversation the unit does not own — a rep replying
+// on it would transmit a message from the workspace's own bot to whoever the
+// unit linked, the unit choosing the target and the human supplying the
+// authority.
+func TestAUnitCannotFileAMessageOnACoreConnectorsTransport(t *testing.T) {
+	e := setupIngress(t)
+	rt := e.ingestingRuntime()
+
+	stolen := aChannelMessage("ws-7:3002", "someone@gmail.com", "probe-channel-2")
+	stolen.Activity.ChannelProvider = "telegram"
+	stolen.Counterparty.ChannelIdentity.Provider = "telegram"
+
+	_, err := rt.Ingest(context.Background(), extension.UserID(e.member.String()), stolen)
+
+	if !errors.Is(err, extension.ErrInvalid) {
+		t.Fatalf("Ingest → %v, want extension.ErrInvalid — a unit may name only a transport it declared", err)
+	}
+	if got := e.countAsWorkspace(t,
+		`SELECT count(*) FROM activity WHERE source = $1 AND source_id = $2`, ingressProbeSource, "ws-7:3002"); got != 0 {
+		t.Errorf("activity rows = %d, want none — the refusal must land nothing, not land it and complain", got)
 	}
 }
 

--- a/backend/internal/compose/extingress_test.go
+++ b/backend/internal/compose/extingress_test.go
@@ -34,10 +34,20 @@ import (
 // is not serving, which is the reason composedIngressFor reads this one.
 func composeIngressFor(t *testing.T, unit string, sources ...extension.IngressSource) {
 	t.Helper()
+	composeCapturingUnit(t, unit, nil, sources...)
+}
+
+// composeCapturingUnit is the same, for a unit that also SUPPLIES a transport.
+// The two are one function because what a unit may file is decided by both
+// declarations together: the source it captures from, and the channel it is
+// allowed to name on a message.
+func composeCapturingUnit(t *testing.T, unit string, channels []extension.Channel, sources ...extension.IngressSource) {
+	t.Helper()
 	composeUnit(t, extension.Extension{
-		Name:    extension.Name(unit),
-		Version: "1.0.0",
-		Ingress: sources,
+		Name:     extension.Name(unit),
+		Version:  "1.0.0",
+		Ingress:  sources,
+		Channels: channels,
 		// The user-scoped credential a member deposits, declared — because
 		// what the port reads as consent is a secret under a key this unit
 		// DECLARES, and a composed set without one describes a unit no member

--- a/backend/internal/compose/extingressauthority.go
+++ b/backend/internal/compose/extingressauthority.go
@@ -41,6 +41,20 @@ func composedIngressFor(unit string) []extension.IngressSource {
 	return nil
 }
 
+// composedChannelsFor returns the transports the named unit declared in THIS
+// boot's composition, and it is composedIngressFor's twin for the same reason:
+// what a unit may name at a write door is what the boot reconciliation
+// validated, never a second registry that could describe a unit that is not
+// serving.
+func composedChannelsFor(unit string) []extension.Channel {
+	for _, ext := range ComposedExtensions() {
+		if string(ext.Name) == unit {
+			return ext.Channels
+		}
+	}
+	return nil
+}
+
 // declaredUserSecretKeys are the user-scoped secret keys the named unit
 // declares in THIS boot's composition.
 //

--- a/backend/internal/compose/extingressdrift_test.go
+++ b/backend/internal/compose/extingressdrift_test.go
@@ -289,4 +289,16 @@ func TestAUnitMayBindAnAccountOnlyOnItsOwnTransport(t *testing.T) {
 	} else if !errors.Is(err, extension.ErrInvalid) {
 		t.Errorf("the refusal is %v, want extension.ErrInvalid", err)
 	}
+
+	// And its REACH, which is the half that regresses. Only the ingress door
+	// maps a Counterparty today — the published core-write request carries no
+	// channel identity — so this pins the one door that does, and fails loudly
+	// if that door stops calling the gate.
+	src, err := os.ReadFile("extingress.go")
+	if err != nil {
+		t.Fatalf("reading extingress.go: %v", err)
+	}
+	if !strings.Contains(string(src), "refuseUnitIdentity(") {
+		t.Error("extingress.go maps a counterparty for a unit and does not call refuseUnitIdentity; that door can bind an account under a transport the unit does not supply")
+	}
 }

--- a/backend/internal/compose/extingressdrift_test.go
+++ b/backend/internal/compose/extingressdrift_test.go
@@ -85,11 +85,13 @@ func TestThePublishedRecordMirrorsTheCaptureEnvelope(t *testing.T) {
 // shape means a unit's message carries the zero value for something the timeline
 // stores — so the reason has to say why that zero value is the right answer, not
 // merely why the unit is not asked.
-var waivedActivityFields = gatekit.Waive(map[string]string{
-	"ChannelProvider": "the messaging transport a record arrived on, and a reference into the channel_provider registry. " +
-		"A unit supplies no channel transport, so it has no provider to name and the empty value is the accurate answer rather than a dropped one — " +
-		"the same reason Counterparty.ChannelIdentity is waived below. A unit that does supply one publishes this alongside the declaration that makes it true",
-})
+//
+// It is EMPTY, and that is the state this arc arrived at rather than a gap:
+// ChannelProvider was waived here while a unit supplied no transport, and the
+// waiver said what would retire it — "a unit that does supply one publishes this
+// alongside the declaration that makes it true". A unit does, so it is published
+// and bounded at the write door instead (refuseUndeclaredTransport).
+var waivedActivityFields = gatekit.Waive(map[string]string{})
 
 // TestThePublishedActivityMirrorsTheCoreOne is the same rule one level in. The
 // activity shape is the payload the sink switches on, and a field added there
@@ -123,7 +125,6 @@ func TestThePublishedActivityMirrorsTheCoreOne(t *testing.T) {
 // counterparty, where the interesting fields are the ones a unit must NOT be
 // able to state.
 var waivedCounterpartyFields = gatekit.Waive(map[string]string{
-	"ChannelIdentity": "keys person_channel_identity, whose provider vocabulary is a foreign key into the channel_provider registry — a unit reaching it would be naming a transport it does not supply",
 	"ListUnsubscribe": "the bulk-mail corroboration a mail connector reads off an RFC 2369 header. A chat record has no such header, and a unit asserting one would be evidence for a suppression decision that nothing produced",
 })
 
@@ -156,6 +157,18 @@ func TestTheDirectionVocabulariesAgree(t *testing.T) {
 	}
 	if extension.DirectionOutbound != connector.DirectionOutbound {
 		t.Errorf("outbound: published %q, core %q", extension.DirectionOutbound, connector.DirectionOutbound)
+	}
+}
+
+// The message KIND is a third restated vocabulary, and it drifts the same way
+// the directions would — worse, in fact, because the pairing rule keys on it: a
+// unit filing the published spelling against a core that had moved to another
+// would have its record refused as "a non-message naming a transport", which
+// names neither the cause nor anything the unit's author can act on.
+func TestTheMessageKindVocabulariesAgree(t *testing.T) {
+	if extension.ActivityKindMessage != activities.KindMessage {
+		t.Errorf("the message kind: published %q, core %q — a unit naming the published one would have every captured message refused",
+			extension.ActivityKindMessage, activities.KindMessage)
 	}
 }
 
@@ -192,31 +205,50 @@ func fieldsOf(t reflect.Type) map[string]bool {
 	return out
 }
 
-// A unit has TWO doors it can write an activity through, and the rule that it
-// may not claim a messaging transport is about the unit rather than about a
-// door. This walks both against the same refusal, because the failure mode is
-// asymmetric and only one half is loud: capture ingress carries no provider
-// field, so a message there dies on the CHECK as an unattributable 500 — while
-// the core-write door DOES carry channel_provider, so a unit could name a core
-// connector's transport and mint a row that is a valid SEND ANCHOR for a
-// conversation it does not own.
+// A unit has TWO doors it can write an activity through, and the rule bounding
+// which transport it may name is about the unit rather than about a door. This
+// walks both against the same gate, because the failure mode is asymmetric and
+// only one half is loud: capture ingress dies on the CHECK as an unattributable
+// 500 — while the core-write door carries channel_provider on the published
+// request, so a unit could name a core connector's transport and mint a row that
+// is a valid SEND ANCHOR for a conversation it does not own.
 //
 // Two halves, because the rule and its reach can fail separately: the block
-// below pins what the refusal DOES, and the source assertion after it pins that
+// below pins what the gate DOES, and the source assertion after it pins that
 // both doors actually call it — which is the half that regresses, since a door
 // can be added or rewritten without anyone noticing the gate went missing.
-func TestAUnitMayNotFileAMessageThroughEitherDoor(t *testing.T) {
-	if err := refuseUnitMessageKind(activities.KindMessage); err == nil {
-		t.Fatalf("a unit filing %q was permitted; it would mint a send anchor for a transport the unit does not supply", activities.KindMessage)
-	} else if !errors.Is(err, extension.ErrInvalid) {
-		t.Errorf("the refusal is %v, want extension.ErrInvalid so the unit reads it as a bad record rather than a core fault", err)
+func TestAUnitMayNameOnlyItsOwnTransportThroughEitherDoor(t *testing.T) {
+	declaresTransport(t, "mine", extension.Channel{Provider: "mine_chat"})
+
+	if err := refuseUndeclaredTransport("mine", activities.KindMessage, "mine_chat"); err != nil {
+		t.Errorf("a unit filing a message on the transport it declared was refused (%v); the declaration is what the permission is bounded by, so this is the case that must pass", err)
 	}
 
-	// And it refuses ONLY that: a unit's ordinary records must still land, or
-	// the guard has quietly closed the ingress surface it was meant to bound.
+	// The transport it did NOT declare — a core connector's — is the row that
+	// would become a send anchor for a conversation the unit does not own.
+	for _, provider := range []string{"telegram", "someone_elses"} {
+		if err := refuseUndeclaredTransport("mine", activities.KindMessage, provider); err == nil {
+			t.Errorf("a unit filing a message on %q was permitted; it declares only mine_chat", provider)
+		} else if !errors.Is(err, extension.ErrInvalid) {
+			t.Errorf("the refusal is %v, want extension.ErrInvalid so the unit reads it as a bad record rather than a core fault", err)
+		}
+	}
+
+	// A message that names nothing is refused too: it would be a conversation
+	// with no transport, which nothing can reply on.
+	if err := refuseUndeclaredTransport("mine", activities.KindMessage, ""); err == nil {
+		t.Error("a message naming no transport was permitted; it lands as a conversation no reply can leave on")
+	}
+
+	// And the other direction, which is the quieter defect: a record that is not
+	// a message may name no transport at all, or it would be repliable — a note
+	// that answers back.
 	for _, kind := range []string{"note", "email", "call", "meeting", "task"} {
-		if err := refuseUnitMessageKind(kind); err != nil {
-			t.Errorf("a unit filing %q was refused (%v); only the message kind is withheld", kind, err)
+		if err := refuseUndeclaredTransport("mine", kind, ""); err != nil {
+			t.Errorf("a unit filing %q was refused (%v); only a message is bounded here", kind, err)
+		}
+		if err := refuseUndeclaredTransport("mine", kind, "mine_chat"); err == nil {
+			t.Errorf("a %q naming a transport was permitted; the send path reads the provider column and would answer on it", kind)
 		}
 	}
 
@@ -230,8 +262,31 @@ func TestAUnitMayNotFileAMessageThroughEitherDoor(t *testing.T) {
 		if err != nil {
 			t.Fatalf("reading %s: %v", door, err)
 		}
-		if !strings.Contains(string(src), "refuseUnitMessageKind(") {
-			t.Errorf("%s writes an activity for a unit and does not call refuseUnitMessageKind; that door can mint a message a unit has no transport for", door)
+		if !strings.Contains(string(src), "refuseUndeclaredTransport(") {
+			t.Errorf("%s writes an activity for a unit and does not call refuseUndeclaredTransport; that door can mint a message on a transport the unit does not supply", door)
 		}
+	}
+}
+
+// The counterparty BINDING is bounded by the same declaration, and it is a
+// separate gate because it writes a different row. The activity's provider
+// decides where a reply would be sent; this one writes person_channel_identity,
+// which is where the core resolves WHO it is sent to — so a unit able to bind an
+// account under a core connector's provider could attach an account it controls
+// to somebody else's person record and inherit the replies meant for them.
+func TestAUnitMayBindAnAccountOnlyOnItsOwnTransport(t *testing.T) {
+	declaresTransport(t, "mine", extension.Channel{Provider: "mine_chat"})
+
+	if err := refuseUnitIdentity("mine", "mine_chat"); err != nil {
+		t.Errorf("binding an account on the unit's own transport was refused (%v)", err)
+	}
+	// A record identified by address binds nothing, and must still land.
+	if err := refuseUnitIdentity("mine", ""); err != nil {
+		t.Errorf("a record with no channel identity was refused (%v); it identifies its counterparty by address", err)
+	}
+	if err := refuseUnitIdentity("mine", "telegram"); err == nil {
+		t.Error("a unit bound an account under telegram; the next reply on that person's conversation would go to the unit's account")
+	} else if !errors.Is(err, extension.ErrInvalid) {
+		t.Errorf("the refusal is %v, want extension.ErrInvalid", err)
 	}
 }

--- a/backend/internal/compose/extpreflight.go
+++ b/backend/internal/compose/extpreflight.go
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The boot preflights for what a unit declares it can DO with the outside
+// world: land records, run on a clock, and transmit messages.
+//
+// Split from extensions.go because they share a shape the other preflights do
+// not: each validates through the SAME published Validate the manifest
+// generator runs, so what a generated manifest accepted cannot be refused at
+// boot (or worse, the reverse). Grouped rather than scattered so the next
+// capability added has an obvious home.
+
+import (
+	"fmt"
+
+	"github.com/gradionhq/margince/backend/pkg/extension"
+)
+
+// preflightIngress validates one unit's declared ingress sources through the
+// same published IngressSource.Validate the manifest generator runs, and
+// rejects the same system declared twice.
+//
+// A duplicate is not harmless here the way a duplicate description would be:
+// the system key is half of every landed record's natural key, so two entries
+// naming one system are two declarations an operator resolves separately about
+// one provenance namespace — and if they ever disagree about Lands, which of
+// them the port answered from would be declaration order.
+func preflightIngress(e extension.Extension) error {
+	seen := make(map[string]bool, len(e.Ingress))
+	for _, source := range e.Ingress {
+		if err := source.Validate(); err != nil {
+			return fmt.Errorf("compose: extension %q: %w", e.Name, err)
+		}
+		if seen[source.System] {
+			return fmt.Errorf("compose: extension %q declares ingress source %q twice", e.Name, source.System)
+		}
+		seen[source.System] = true
+	}
+	return nil
+}
+
+// preflightJobs validates one unit's scheduled jobs through the same published
+// Job.Validate the manifest generator runs, and rejects a job name declared
+// twice within the unit — the same fail-closed boundary preflightTools holds,
+// for a declaration that reached the composed set outside the generator path.
+func preflightJobs(e extension.Extension) error {
+	seen := make(map[string]bool, len(e.Jobs))
+	for _, job := range e.Jobs {
+		if err := job.Validate(); err != nil {
+			return fmt.Errorf("compose: extension %q: %w", e.Name, err)
+		}
+		if seen[job.Name] {
+			return fmt.Errorf("compose: extension %q declares job %q twice", e.Name, job.Name)
+		}
+		seen[job.Name] = true
+	}
+	return nil
+}
+
+// preflightChannels validates one unit's declared channels, and holds the two
+// rules a single declaration cannot check for itself (DESIGN-SP5 §9.1).
+//
+// Channel.Validate already covers the provider grammar and the Send/Live
+// pairing. What is added here is unit-vs-unit COLLISION, which is a fact about
+// the composed set rather than about one declaration.
+//
+// The collision against a CORE connector is the sharper one — a unit shadowing
+// `telegram` would have every Telegram reply transmitted on the unit's
+// credential instead of the workspace's bot, a silent change of who is sending
+// rather than a visible failure — and it is held in the reconcile, which is
+// where the core's own transport set is known. Asking here would answer from a
+// registry that may not be built yet, and pass the collision it exists to catch.
+//
+// Both refuse at BOOT rather than at the send, because the send is the moment
+// the mistake becomes a message somebody receives.
+func preflightChannels(e extension.Extension, claimed map[string]extension.Name) error {
+	seen := make(map[string]bool, len(e.Channels))
+	for _, ch := range e.Channels {
+		if err := ch.Validate(); err != nil {
+			return fmt.Errorf("compose: extension %q: %w", e.Name, err)
+		}
+		if seen[ch.Provider] {
+			return fmt.Errorf("compose: extension %q declares channel %q twice", e.Name, ch.Provider)
+		}
+		seen[ch.Provider] = true
+		if other, taken := claimed[ch.Provider]; taken {
+			return fmt.Errorf("compose: extension %q declares channel %q, already claimed by extension %q — one provider names one transport",
+				e.Name, ch.Provider, other)
+		}
+		claimed[ch.Provider] = e.Name
+	}
+	return nil
+}

--- a/backend/internal/compose/extruntime.go
+++ b/backend/internal/compose/extruntime.go
@@ -199,61 +199,6 @@ type callRuntime struct {
 
 var _ extension.Runtime = (*callRuntime)(nil)
 
-// runtimeFor mints the Runtime for one invocation of one unit's tool. ctx is
-// the invocation's, not a handler's.
-//
-// It returns the concrete type rather than the published interface because
-// the caller needs release, which is the core's side of the lifetime contract
-// and deliberately not on the surface a handler holds.
-func runtimeFor(ctx context.Context, unit, version, via string, deps extensionRuntimeBinding) *callRuntime {
-	return &callRuntime{unit: unit, version: version, via: via, deps: deps, callCtx: ctx, live: true}
-}
-
-// jobRuntimeFor mints the Runtime for one JOB tick, which differs from an
-// invocation in exactly one way: who it answers as.
-//
-// A tick's context carries a principal — deriveAuthority re-reads the
-// dispatcher's seat at execution and binds it, because the tenant policies and
-// the audit rows need an actor. That actor is an AGENT seat with no human
-// behind it: its OnBehalfOf is zero and its UserID is the workspace's is_agent
-// app_user, which bootstrap wrote and the dispatcher resolved. Mapping it
-// through Caller's ordinary rules
-// would hand a unit precisely the thing Caller.UserID promises never to be —
-// "a synthetic id for the agent" rather than the person accountable for the
-// row — and would contradict Runtime.Caller's promise that a tick answers the
-// zero Caller. So the tick says so at construction rather than leaving Caller
-// to guess it from a principal that looks, field by field, like a real agent
-// call. Nothing else about the tick changes: the actor on callCtx is still the
-// one every capability and every policy sees.
-func jobRuntimeFor(ctx context.Context, unit, version, via string, deps extensionRuntimeBinding) *callRuntime {
-	return unattendedRuntimeFor(ctx, unit, version, via, deps)
-}
-
-// deliveryRuntimeFor mints the Runtime for one BUS DELIVERY — a subscription
-// hearing that something happened.
-//
-// It is unattended for a plainer reason than a tick's: a tick at least ran
-// because a schedule the installation configured said so, while a delivery ran
-// because a fact arrived. Neither has a person behind it, and this one's
-// principal is the system actor the subscriber binds (see extsubscribe.go),
-// which auth.Require does not check at all — so the unattended flag is what
-// keeps the governed core port shut for a caller nothing else would refuse.
-func deliveryRuntimeFor(ctx context.Context, unit, version, via string, deps extensionRuntimeBinding) *callRuntime {
-	return unattendedRuntimeFor(ctx, unit, version, via, deps)
-}
-
-// unattendedRuntimeFor is what both of the above are: a Runtime for an
-// invocation with nobody behind it. They stay separate NAMES because the two
-// call sites are the two kinds of unattended work and a reader at either one
-// should see which it is — but the behaviour is one fact, spelled here, so a
-// later change to what "unattended" means cannot reach one kind and miss the
-// other.
-func unattendedRuntimeFor(ctx context.Context, unit, version, via string, deps extensionRuntimeBinding) *callRuntime {
-	rt := runtimeFor(ctx, unit, version, via, deps)
-	rt.unattended = true
-	return rt
-}
-
 // release ends the Runtime's lifetime. Called when the handler returns, so a
 // retained Runtime answers ErrRuntimeExpired rather than working against
 // resources the call has finished with.

--- a/backend/internal/compose/extruntimefor.go
+++ b/backend/internal/compose/extruntimefor.go
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// How a Runtime is MINTED for each kind of invocation, which is one concept and
+// not four: every constructor here builds the same callRuntime and they differ
+// only in who the invocation answers as.
+//
+// Split from extruntime.go — which owns the Runtime's lifetime and its bound
+// dependencies — because these are the choices a reader compares against each
+// other. An attended tool call has a caller whose authority a core write is
+// checked against; a job tick, a bus delivery and an outbound transmission have
+// nobody, and each says WHY in its own words.
+
+import (
+	"context"
+)
+
+// runtimeFor mints the Runtime for one invocation of one unit's tool. ctx is
+// the invocation's, not a handler's.
+//
+// It returns the concrete type rather than the published interface because
+// the caller needs release, which is the core's side of the lifetime contract
+// and deliberately not on the surface a handler holds.
+func runtimeFor(ctx context.Context, unit, version, via string, deps extensionRuntimeBinding) *callRuntime {
+	return &callRuntime{unit: unit, version: version, via: via, deps: deps, callCtx: ctx, live: true}
+}
+
+// jobRuntimeFor mints the Runtime for one JOB tick, which differs from an
+// invocation in exactly one way: who it answers as.
+//
+// A tick's context carries a principal — deriveAuthority re-reads the
+// dispatcher's seat at execution and binds it, because the tenant policies and
+// the audit rows need an actor. That actor is an AGENT seat with no human
+// behind it: its OnBehalfOf is zero and its UserID is the workspace's is_agent
+// app_user, which bootstrap wrote and the dispatcher resolved. Mapping it
+// through Caller's ordinary rules
+// would hand a unit precisely the thing Caller.UserID promises never to be —
+// "a synthetic id for the agent" rather than the person accountable for the
+// row — and would contradict Runtime.Caller's promise that a tick answers the
+// zero Caller. So the tick says so at construction rather than leaving Caller
+// to guess it from a principal that looks, field by field, like a real agent
+// call. Nothing else about the tick changes: the actor on callCtx is still the
+// one every capability and every policy sees.
+func jobRuntimeFor(ctx context.Context, unit, version, via string, deps extensionRuntimeBinding) *callRuntime {
+	return unattendedRuntimeFor(ctx, unit, version, via, deps)
+}
+
+// deliveryRuntimeFor mints the Runtime for one BUS DELIVERY — a subscription
+// hearing that something happened.
+//
+// It is unattended for a plainer reason than a tick's: a tick at least ran
+// because a schedule the installation configured said so, while a delivery ran
+// because a fact arrived. Neither has a person behind it, and this one's
+// principal is the system actor the subscriber binds (see extsubscribe.go),
+// which auth.Require does not check at all — so the unattended flag is what
+// keeps the governed core port shut for a caller nothing else would refuse.
+func deliveryRuntimeFor(ctx context.Context, unit, version, via string, deps extensionRuntimeBinding) *callRuntime {
+	return unattendedRuntimeFor(ctx, unit, version, via, deps)
+}
+
+// sendRuntimeFor mints the Runtime for one outbound TRANSMISSION on a unit's
+// channel — the unit's Send or its Live, invoked by the delivery dispatcher.
+//
+// Unattended, and the reason is worth stating because a human IS involved
+// somewhere: the rep wrote the message and their seat is re-read at
+// transmission (gateSeat). But they wrote it earlier, on a different request,
+// and what runs now is a worker walking a retry ladder — so there is no live
+// authority here for the governed core port to check a write against, and a
+// unit that could reach it from a transmission would be writing records under
+// an authority nobody is exercising.
+func sendRuntimeFor(ctx context.Context, unit, version, via string, deps extensionRuntimeBinding) *callRuntime {
+	return unattendedRuntimeFor(ctx, unit, version, via, deps)
+}
+
+// unattendedRuntimeFor is what each of those three is: a Runtime for an
+// invocation with nobody behind it. They stay separate NAMES because the call
+// sites are the distinct kinds of unattended work and a reader at any one of
+// them should see which it is — but the behaviour is one fact, spelled here, so
+// a later change to what "unattended" means cannot reach one kind and miss the
+// others.
+func unattendedRuntimeFor(ctx context.Context, unit, version, via string, deps extensionRuntimeBinding) *callRuntime {
+	rt := runtimeFor(ctx, unit, version, via, deps)
+	rt.unattended = true
+	return rt
+}

--- a/backend/internal/compose/extruntimetx.go
+++ b/backend/internal/compose/extruntimetx.go
@@ -114,7 +114,7 @@ func (r *callRuntime) Tx(ctx context.Context, fn func(ctx context.Context, tx ex
 		return fn(ctx, extensionTx{
 			tx: tx,
 			core: extensionCore{
-				tx: tx, unattended: r.unattended, deps: r.deps, authority: r.scoped,
+				tx: tx, unattended: r.unattended, deps: r.deps, authority: r.scoped, unit: r.unit,
 			},
 			ledger: extensionLedger{tx: tx, namespace: namespace, authority: r.scoped},
 		})

--- a/backend/internal/compose/sendpreflight.go
+++ b/backend/internal/compose/sendpreflight.go
@@ -112,6 +112,14 @@ func (m mailboxAuthority) SendCapable(ctx context.Context, provider string) (boo
 		// here rather than at transmission.
 		return false, nil
 	}
+	// A UNIT-supplied transport is asked FIRST, and it has to be: the channel arm
+	// below reads channel_connection, which is the workspace-bot binding table a
+	// unit never writes (DESIGN-SP5 §7). Left to fall through, every unit send
+	// would be refused here — before staging, with a message telling the rep to
+	// have an admin bind a bot that has nothing to do with this transport.
+	if transport, supplied := composedUnitTransport(provider); supplied {
+		return unitSendCapable(ctx, transport, ids.From[ids.UserKind](actor.UserID))
+	}
 	scope, capability := comms.SendScopeFor(provider)
 	switch capability {
 	case comms.CannotSend:

--- a/backend/internal/compose/sendpreflight_test.go
+++ b/backend/internal/compose/sendpreflight_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/modules/comms"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+	"github.com/gradionhq/margince/backend/pkg/extension"
 )
 
 type stubGrants struct {
@@ -172,5 +173,71 @@ func assertLookupsAsked(t *testing.T, grants *stubGrants, provider string, wantG
 	}
 	if grants.channelCalls != wantChannelCalls {
 		t.Fatalf("the channel-binding lookup was asked %d time(s), want %d", grants.channelCalls, wantChannelCalls)
+	}
+}
+
+// The UNIT arm, which is a different table question again — or rather, no table
+// question at all.
+//
+// This is the defect DESIGN-SP5 §8.1 warns about and the slice-2 plan missed: a
+// unit-supplied transport falling through to the channel arm asks
+// ChannelSendCapable, which reads channel_connection — the workspace-bot binding
+// a unit never writes. Every unit reply was then refused at the composer, and
+// the refusal a rep reads is "ask an admin to bind a bot", about a bot that has
+// nothing to do with the transport they are replying on.
+//
+// So the assertion that matters most here is the NEGATIVE one: the workspace
+// lookup must not be asked at all.
+func TestSendCapableAsksTheUnitRatherThanTheWorkspaceBotTable(t *testing.T) {
+	human := principal.WithActor(context.Background(), principal.Principal{
+		Type: principal.PrincipalHuman, ID: "human:x", UserID: ids.NewV7(),
+	})
+	unreachable := errors.New("the provider timed out")
+
+	for name, tc := range map[string]struct {
+		channel extension.Channel
+		want    bool
+		wantErr error
+	}{
+		"a live connection can send": {
+			channel: extension.Channel{Provider: "mine_chat", Send: (&capturedSend{}).send, Live: answersLive(true, nil)},
+			want:    true,
+		},
+		"a member who disconnected cannot": {
+			channel: extension.Channel{Provider: "mine_chat", Send: (&capturedSend{}).send, Live: answersLive(false, nil)},
+		},
+		"a capture-only transport cannot": {
+			channel: extension.Channel{Provider: "mine_chat"},
+		},
+		// A pre-flight that cannot ask must not answer — the mail arm's own
+		// rule, applied here so a rep is never told at the composer something
+		// the transmission will contradict.
+		"a unit that could not answer reports the fault": {
+			channel: extension.Channel{Provider: "mine_chat", Send: (&capturedSend{}).send, Live: answersLive(false, unreachable)},
+			wantErr: unreachable,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			declaresTransport(t, "mine", tc.channel)
+			grants := &stubGrants{channelBound: true}
+			authority := mailboxAuthority{grants: grants, mailAppConfigured: func(string) bool { return false }}
+
+			got, err := authority.SendCapable(human, "mine_chat")
+
+			if got != tc.want {
+				t.Errorf("SendCapable = %v, want %v", got, tc.want)
+			}
+			switch {
+			case tc.wantErr != nil && !errors.Is(err, tc.wantErr):
+				t.Errorf("SendCapable error = %v, want it to match %v", err, tc.wantErr)
+			case tc.wantErr == nil && err != nil:
+				t.Errorf("SendCapable error = %v, want none", err)
+			}
+			// The stub is wired to answer "a bot IS bound", so a fall-through
+			// would make even the refusal cases pass for the wrong reason.
+			if grants.channelCalls != 0 {
+				t.Errorf("the workspace bot table was read %d time(s) for a unit transport; a unit never writes it, and asking it is what refused every unit reply", grants.channelCalls)
+			}
+		})
 	}
 }

--- a/backend/pkg/extension/channel.go
+++ b/backend/pkg/extension/channel.go
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package extension
+
+// The channel surface: a unit supplying TRANSPORT for a messaging provider
+// (DESIGN-SP5 §9, ADR-0107/A158).
+//
+// It is a separate declaration from IngressSource on purpose. Ingress says
+// "records arrive from here"; a channel says "messages can leave through here",
+// and the two are neither implied by nor sufficient for each other — a unit may
+// capture a provider it cannot send on, which is the capture-only case below.
+//
+// The provider named here is NOT an activity kind. A channel message lands as
+// kind `message` with this provider on its own column; that separation is the
+// decision this whole arc implements, and a unit that could name a kind would
+// undo it from the outside.
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+)
+
+// providerGrammar and maxProviderLength are `channel_provider.provider`'s own
+// CHECK, restated here so a unit's declaration is refused at boot with an
+// explanation rather than at the first write with a constraint name. The two
+// are the same rule in two places on purpose; a fitness test holds them equal.
+var providerGrammar = regexp.MustCompile(`^[a-z][a-z0-9_]*$`)
+
+const maxProviderLength = 32
+
+// Channel is one messaging provider a unit supplies transport for.
+//
+// Inert declaration plus function fields, matching Job and Subscription: the
+// Runtime arrives per invocation, and the unit holds no handle into the core.
+type Channel struct {
+	// Provider is the unit's key for the provider — a row in channel_provider,
+	// and never an activity kind.
+	//
+	// The grammar is ProviderRef's (`^[a-z][a-z0-9_]*$`, 32 runes), which is
+	// the CHECK on channel_provider.provider itself. It is deliberately NOT
+	// IngressSource.System's, and the difference is easy to miss: that one is
+	// kebab (`a-z0-9` with `-`), this one is snake (`_`). A provider is a row
+	// in a table with its own constraint, so the declaration must satisfy the
+	// column rather than a sibling declaration that happens to look similar —
+	// `deal-room` is a legal ingress system and an illegal provider.
+	Provider string
+
+	// Send transmits one message.
+	//
+	// NIL IS MEANINGFUL: a channel declared without it is capture-only, and a
+	// reply attempt is answered with the deployment fact rather than a fault.
+	// This follows Job's idiom (a nil Handle is no entry) rather than
+	// Subscription's (which refuses nil at Validate), and the difference is
+	// real: a subscription with no handler is a listener nobody hears, always a
+	// mistake; a channel with no Send is the documented capture-only case.
+	Send MessageSender
+
+	// Live answers, for ONE member, whether this unit's connection to the
+	// provider is usable for sending right now — without spending the
+	// credential, the same shape as a dry run.
+	//
+	// It takes no message because liveness does not depend on what is being
+	// sent, only on whether the member's connection still exists and has not
+	// been revoked since a delivery was staged. A confirmed "not usable"
+	// answers false; "I could not tell" returns an error, and the core treats
+	// those two differently — one parks a delivery, the other retries it.
+	//
+	// REQUIRED whenever Send is non-nil: a transport that can send and cannot
+	// say whether it still may is one the core would have to guess about at the
+	// exact moment guessing is most expensive.
+	Live ConnectionLiveChecker
+}
+
+// MessageSender transmits one outbound message on a unit's channel.
+type MessageSender func(ctx context.Context, rt Runtime, msg OutboundMessage) (Receipt, error)
+
+// ConnectionLiveChecker answers whether one member's connection is usable now.
+type ConnectionLiveChecker func(ctx context.Context, rt Runtime, member UserID) (bool, error)
+
+// OutboundMessage is one message handed to a unit for transmission.
+type OutboundMessage struct {
+	// Member is WHOSE credential transmits — the rep who staged the send, not
+	// the caller who released it. A unit sends as a person, never as the
+	// installation.
+	Member UserID
+	// Recipient is the provider account id, never the username: a username is
+	// re-assignable and an account id is not, so routing on the readable one
+	// delivers to whoever holds the handle today.
+	Recipient ChannelIdentity
+	Body      string
+	// ReplyTo anchors the message on a provider message id, empty for none.
+	ReplyTo string
+	// IdempotencyKey is the delivery id: minted per send and never reused, so a
+	// retried attempt is recognisable to a provider that supports it.
+	IdempotencyKey string
+	// Attempt counts from 1. A unit that cannot make its send idempotent can at
+	// least log the difference between a first try and a repeat.
+	Attempt int
+}
+
+// Receipt is what a provider returns for an accepted message.
+type Receipt struct {
+	// ProviderMessageID is the provider's own id for the sent message, and it
+	// is what makes a later reply anchorable. Empty is allowed: not every
+	// provider returns one, and a unit inventing an id would make a thread key
+	// that matches nothing.
+	ProviderMessageID string
+}
+
+// ChannelIdentity is a party at a messaging provider.
+//
+// The name deliberately matches core's own connector.ChannelIdentity rather
+// than introducing a second name for the same routing key: a silent rename at a
+// security-sensitive identity is exactly the drift a matching name avoids
+// having to test for.
+type ChannelIdentity struct {
+	// Provider is the transport the account belongs to. It is carried rather
+	// than assumed from the channel that routes the message, because a record
+	// naming a party has to be readable on its own.
+	Provider string
+	// ChannelUserID is the provider's account id.
+	ChannelUserID string
+	// DisplayName is what a human calls them, for a person record that has no
+	// other name yet. Never used for routing.
+	DisplayName string
+}
+
+// Validate enforces the provider grammar and the Send/Live pairing, and nothing
+// else — every other rule a channel is subject to is a rule about the composed
+// SET (a provider may not collide with another unit's, or with a core
+// connector's), which one declaration cannot see and the boot resolves.
+func (c Channel) Validate() error {
+	if !providerGrammar.MatchString(c.Provider) {
+		return fmt.Errorf("%w: channel provider %q must start with a letter and contain only lower-case letters, digits and underscores — it is a channel_provider row and has to satisfy that column's own CHECK",
+			ErrInvalid, c.Provider)
+	}
+	if len([]rune(c.Provider)) > maxProviderLength {
+		return fmt.Errorf("%w: channel provider %q is longer than %d characters",
+			ErrInvalid, c.Provider, maxProviderLength)
+	}
+	// The pairing, refused HERE rather than at the send: a transport that can
+	// transmit and cannot report its own liveness would force the core to
+	// decide between parking a delivery it might have sent and retrying one it
+	// already did, at the one moment that choice is unrecoverable.
+	if c.Send != nil && c.Live == nil {
+		return fmt.Errorf("%w: channel %q declares Send without Live — a transport that can send must be able to say whether it still may",
+			ErrInvalid, c.Provider)
+	}
+	return nil
+}
+
+// SuppliesTransport reports whether this channel can carry an outbound message
+// at all. It is the declaration's own answer to the question the transport
+// directory publishes, so the endpoint and the boot cannot disagree about it.
+func (c Channel) SuppliesTransport() bool { return c.Send != nil }

--- a/backend/pkg/extension/channel.go
+++ b/backend/pkg/extension/channel.go
@@ -18,6 +18,7 @@ package extension
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"regexp"
 )
@@ -150,6 +151,29 @@ func (c Channel) Validate() error {
 	}
 	return nil
 }
+
+// ErrSendOutcomeUnknown is the one refusal a Send MUST report rather than
+// describe: the request went out and no usable answer came back — a timeout, a
+// reset connection, a response that could not be read. The message may be on
+// its way and may not, and nothing the unit has can tell.
+//
+// IT IS NOT A DEGREE OF FAILURE, it is a different kind. Every other error a
+// Send returns is read by the core as a DEFINITE answer from the provider, and
+// therefore as proof that nothing was transmitted — the delivery goes back on
+// the retry ladder. A channel has no prior-send lookup and no provider-honoured
+// idempotency key, so no later attempt can ever discover that an earlier one
+// already arrived; report an unanswered POST as an ordinary transport failure
+// and the recipient gets the rep's message twice, with nothing in the system
+// able to detect it.
+//
+// So the rule is narrow and worth stating twice: a failure of the CALL that
+// transmits is this class. A failure to open a client, to unseal a credential,
+// or a refusal the provider actually sent, is not — those are answers.
+//
+// A delivery reported this way STOPS, with the uncertainty on the record for a
+// human to resolve. That is deliberately worse than a retry for the unit author
+// and better for the recipient.
+var ErrSendOutcomeUnknown = errors.New("extension: the provider never reported the outcome of this transmission")
 
 // SuppliesTransport reports whether this channel can carry an outbound message
 // at all. It is the declaration's own answer to the question the transport

--- a/backend/pkg/extension/channel_test.go
+++ b/backend/pkg/extension/channel_test.go
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package extension_test
+
+// The published channel declaration: what a unit may say it transports, and the
+// two rules one declaration can settle for itself. Everything else a channel is
+// subject to — colliding with another unit's provider, or with a core
+// connector's — is a fact about the composed SET, and lives in the boot.
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/pkg/extension"
+)
+
+func aSender() extension.MessageSender {
+	return func(context.Context, extension.Runtime, extension.OutboundMessage) (extension.Receipt, error) {
+		return extension.Receipt{}, nil
+	}
+}
+
+func aLiveCheck() extension.ConnectionLiveChecker {
+	return func(context.Context, extension.Runtime, extension.UserID) (bool, error) { return true, nil }
+}
+
+// A transport that can send and a transport that only captures are both
+// well-formed, and the second is the one worth pinning: a nil Send is the
+// documented capture-only case, not an incomplete declaration.
+func TestAWellFormedChannelIsAcceptedSendingOrNot(t *testing.T) {
+	for name, ch := range map[string]extension.Channel{
+		"a transport that sends": {Provider: "dispact", Send: aSender(), Live: aLiveCheck()},
+		"a capture-only channel": {Provider: "dispact"},
+		"digits and underscores": {Provider: "deal_room2"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if err := ch.Validate(); err != nil {
+				t.Fatalf("a well-formed channel was refused: %v", err)
+			}
+		})
+	}
+}
+
+// The grammar is `channel_provider.provider`'s own CHECK, restated so a unit is
+// refused at BOOT with an explanation rather than at the first write with a
+// constraint name.
+//
+// The kebab case is the one that matters: DESIGN-SP5 §9 claimed a channel
+// provider shares IngressSource.System's grammar, and it does not — ingress is
+// kebab, a provider is snake — so `deal-room` is a legal ingress system and an
+// illegal provider. A declaration that took the sibling's rule would boot and
+// then violate the column.
+func TestTheProviderGrammarIsTheRegistryColumnsAndNotTheIngressDeclarations(t *testing.T) {
+	for name, provider := range map[string]string{
+		"empty":                     "",
+		"kebab, which ingress uses": "deal-room",
+		"leading digit":             "1chat",
+		"leading underscore":        "_chat",
+		"upper case":                "Dispact",
+		"a dot":                     "dispact.chat",
+		"a space":                   "deal room",
+		"over the length cap":       strings.Repeat("c", 33),
+	} {
+		t.Run(name, func(t *testing.T) {
+			if err := (extension.Channel{Provider: provider}).Validate(); err == nil {
+				t.Fatalf("the grammar accepted %q, which channel_provider's own CHECK would refuse", provider)
+			}
+		})
+	}
+}
+
+// Send and Live travel together, and it is refused at the DECLARATION rather
+// than at the send: a transport that can transmit and cannot report its own
+// liveness would leave the core choosing between parking a delivery it might
+// have sent and retrying one it already did, at the one moment that choice is
+// unrecoverable.
+func TestATransportThatCanSendMustBeAbleToSayWhetherItStillMay(t *testing.T) {
+	err := extension.Channel{Provider: "dispact", Send: aSender()}.Validate()
+	if err == nil {
+		t.Fatal("a channel declaring Send without Live was accepted")
+	}
+	if !strings.Contains(err.Error(), "Live") {
+		t.Errorf("the refusal %q does not name the missing half, which is the one thing the author has to add", err)
+	}
+	// The other way round is legal: a capture-only channel may still answer
+	// whether the member's connection exists, and there is nothing unsafe about
+	// knowing it.
+	if err := (extension.Channel{Provider: "dispact", Live: aLiveCheck()}).Validate(); err != nil {
+		t.Fatalf("a capture-only channel that can report liveness was refused: %v", err)
+	}
+}
+
+// SuppliesTransport is the declaration's own answer to the question the
+// transport directory publishes, so the endpoint and the boot cannot disagree
+// about which registered transports a reply can actually leave on.
+func TestSuppliesTransportIsTheDeclarationsOwnAnswer(t *testing.T) {
+	if (extension.Channel{Provider: "dispact"}).SuppliesTransport() {
+		t.Error("a channel with no Send reported that it supplies transport; every reply staged against it would park")
+	}
+	if !(extension.Channel{Provider: "dispact", Send: aSender(), Live: aLiveCheck()}).SuppliesTransport() {
+		t.Error("a channel with a Send reported that it supplies none")
+	}
+}

--- a/backend/pkg/extension/extension.go
+++ b/backend/pkg/extension/extension.go
@@ -199,6 +199,16 @@ type Extension struct {
 	// a tool is a governed capability and appears in manifest.generated.json.
 	Tools []Tool
 
+	// Channels are the messaging providers this unit supplies TRANSPORT for
+	// (ADR-0107/A158). Separate from Ingress because the two are neither
+	// implied by nor sufficient for each other: a unit may capture a provider
+	// it cannot send on, and the channel declaration is what says which.
+	//
+	// A channel names a PROVIDER, never an activity kind. The kind a channel
+	// message lands under is the core's and is fixed by the contract; letting a
+	// unit name one would undo the axis split from outside the core.
+	Channels []Channel
+
 	// Secrets are the secret keys the unit declares it will use, by name and
 	// scope. Like a Tool's tier these are REQUESTS an operator resolves, not
 	// facts: declaring a key mints nothing and reads nothing, and the live

--- a/backend/pkg/extension/ingress.go
+++ b/backend/pkg/extension/ingress.go
@@ -306,8 +306,23 @@ func (r Record) validateKey() error {
 }
 
 func (r Record) validateAddresses() error {
+	// A record that names no ADDRESS at all may name no addresses: a chat
+	// message can have none anywhere in it, and the core's own shape already
+	// says so — connector.NormalizedRecord treats an empty set as "I cannot
+	// enumerate the parties", which the internal-message gate reads as NOT
+	// internal and keeps. Refusing it here would have turned away every record
+	// from a provider that issues opaque account ids and no mail, before it
+	// reached a core that would have accepted it.
+	//
+	// The condition is the counterparty's EMAIL rather than "is this a channel
+	// record", because that is the partition the core itself draws: a record
+	// naming its human by a channel account and one naming nobody at all are
+	// the same case here, and both are legal.
 	if len(r.Addresses) == 0 {
-		return errors.New("extension: the record names no addresses — the internal-message gate reads every party from this set, and over an empty one it answers \"not internal\" and keeps the record, so leaving it empty disables the gate rather than passing it")
+		if r.Counterparty.Email == "" {
+			return nil
+		}
+		return errors.New("extension: the record names an address for its counterparty and no addresses at all — the internal-message gate reads every party from that set, and over an empty one it answers \"not internal\" and keeps the record, so leaving it empty disables the gate rather than passing it")
 	}
 	if len(r.Addresses) > MaxAddresses {
 		return fmt.Errorf("extension: the record names %d addresses, over the cap of %d", len(r.Addresses), MaxAddresses)

--- a/backend/pkg/extension/ingress.go
+++ b/backend/pkg/extension/ingress.go
@@ -32,6 +32,17 @@ type RecordKind string
 // side cannot keep.
 const KindActivity RecordKind = "activity"
 
+// ActivityKindMessage is the timeline kind a message on a messaging channel
+// lands as, published here because a unit cannot reach the core's own
+// vocabulary and would otherwise spell the string blind.
+//
+// It is the ONE kind whose transport is separable from it (ADR-0107/A158): a
+// message names what carried it on ActivityFields.ChannelProvider, and every
+// other kind names nothing there. A fitness test outside this package holds
+// this constant equal to the core's own, so the two cannot drift into a unit
+// filing a kind the core no longer calls a message.
+const ActivityKindMessage = "message"
+
 // IngressSource is one provider a unit brings records in from: the unit's own
 // stable key for it, and which kinds it lands.
 //
@@ -120,6 +131,16 @@ type Counterparty struct {
 	// Direction is relative to the connected member: a message they received is
 	// inbound. A record with no honest direction leaves it empty.
 	Direction string
+	// ChannelIdentity is the channel twin of Email: the account this party holds
+	// at a messaging provider, for a record that has no address to carry.
+	//
+	// It is what makes a captured message REPLIABLE. The core binds it to the
+	// person it resolves, and the reply path resolves its recipient from that
+	// binding — so a channel record that leaves this empty lands a message
+	// nobody can answer, which looks exactly like a message with no reply box.
+	//
+	// Zero for every record that identifies its counterparty by address.
+	ChannelIdentity ChannelIdentity
 }
 
 // ActivityFields is a captured interaction bound for the timeline. It mirrors
@@ -129,6 +150,16 @@ type ActivityFields struct {
 	// Kind is the timeline kind — the core admits a closed set, and a value
 	// outside it is refused rather than coerced.
 	Kind string
+	// ChannelProvider is the transport that carried this record, and it is
+	// meaningful for exactly one kind: ActivityKindMessage.
+	//
+	// The pairing rule — a message names a transport, nothing else does, and a
+	// unit may name only a transport it DECLARED — is enforced by the core at
+	// the write door rather than here. This package does not know the core's
+	// kind vocabulary and cannot see which channels the calling unit declared,
+	// so a rule spelled here would be a second version of one that can disagree
+	// with the first.
+	ChannelProvider string
 	// Subject and Body are the message as a human reads it. Both are bounded
 	// (see the Max* constants): a provider is a remote party, and an unbounded
 	// field is that party choosing how much this installation stores.
@@ -168,6 +199,10 @@ const (
 	// MaxThreadKeyLength caps the conversation key, which is stored on the
 	// activity and joined against.
 	MaxThreadKeyLength = 512
+	// MaxChannelUserIDLength caps a provider's own account id. It is indexed
+	// (the identity binding is unique per provider and account) and it is
+	// remote-party text like every other bound here.
+	MaxChannelUserIDLength = 256
 )
 
 // Record is one provider record on its way into the CRM.
@@ -298,6 +333,41 @@ func (c Counterparty) validate() error {
 	if c.Direction != "" && c.Direction != DirectionInbound && c.Direction != DirectionOutbound {
 		return fmt.Errorf("extension: %q is not a direction (%q, %q, or empty for a record with no honest direction)",
 			c.Direction, DirectionInbound, DirectionOutbound)
+	}
+	// A counterparty is named by an address OR by a channel identity, never
+	// both — the core's own rule (capture's ErrCounterpartyNamedTwice), restated
+	// here so a unit learns it from its own grammar rather than from an
+	// unattributable "the core could not land this record". The two are
+	// different resolution ladders that mint the person differently, and a
+	// record supplying both is asking which one it meant.
+	if c.Email != "" && (c.ChannelIdentity.Provider != "" || c.ChannelIdentity.ChannelUserID != "") {
+		return errors.New("extension: the counterparty is named by an address AND by a channel identity — a record names its human one way, because the two resolve through different ladders and nothing here can decide which was meant")
+	}
+	return c.ChannelIdentity.validate()
+}
+
+// validate refuses a HALF-stated channel identity, which is the shape that
+// looks populated and routes nowhere.
+//
+// Either both the provider and the account id are present or neither is. One
+// without the other reaches the core as a binding it cannot key — and the core
+// would drop it rather than fail, so the record would land, look ordinary, and
+// carry no reply address, which is indistinguishable from a provider that
+// simply does not identify its senders.
+func (c ChannelIdentity) validate() error {
+	switch {
+	case c.Provider == "" && c.ChannelUserID == "":
+		return nil
+	case c.Provider == "":
+		return errors.New("extension: the channel identity names an account with no provider — the binding is keyed on the pair, so half of it binds nothing")
+	case c.ChannelUserID == "":
+		return errors.New("extension: the channel identity names a provider with no account id — a party identified only by transport cannot be replied to")
+	case !providerGrammar.MatchString(c.Provider):
+		return fmt.Errorf("extension: channel identity provider %q must start with a letter and contain only lower-case letters, digits and underscores", c.Provider)
+	case len(c.ChannelUserID) > MaxChannelUserIDLength:
+		return fmt.Errorf("extension: the channel account id is %d bytes, over the %d-byte cap", len(c.ChannelUserID), MaxChannelUserIDLength)
+	case utf8.RuneCountInString(c.DisplayName) > MaxDisplayNameRunes:
+		return fmt.Errorf("extension: the channel identity display name is over the %d-rune cap", MaxDisplayNameRunes)
 	}
 	return nil
 }

--- a/backend/pkg/extension/ingress_test.go
+++ b/backend/pkg/extension/ingress_test.go
@@ -77,7 +77,7 @@ func TestTheRecordGrammarRefusesWhatCannotBeLandedHonestly(t *testing.T) {
 		// The two that DISABLE the internal-message gate rather than failing
 		// it: over an empty set the gate answers "not internal" and keeps the
 		// record, and a blank element is a party it skips.
-		"no addresses at all": func(r *extension.Record) { r.Addresses = nil },
+		"no addresses on a record that names one": func(r *extension.Record) { r.Addresses = nil },
 		"a blank address among real ones": func(r *extension.Record) {
 			r.Addresses = []string{"sender@acme.test", "  "}
 		},
@@ -135,6 +135,35 @@ func namedByAccount(identity extension.ChannelIdentity) func(*extension.Record) 
 		r.Counterparty.Email = ""
 		r.Counterparty.Domain = ""
 		r.Counterparty.ChannelIdentity = identity
+	}
+}
+
+// A record that names no address ANYWHERE may name no addresses, and this is
+// the case a channel-only provider is made of: opaque account ids, a display
+// name, and no mail in the message at all.
+//
+// Refusing it would have turned such a record away at the published grammar,
+// before it reached a core that accepts it — connector.NormalizedRecord reads an
+// empty set as "I cannot enumerate the parties", which the internal-message gate
+// answers as not-internal and keeps.
+func TestARecordThatNamesNoAddressMayNameNoAddresses(t *testing.T) {
+	rec := aValidRecord()
+	rec.Activity.Kind = extension.ActivityKindMessage
+	rec.Activity.ChannelProvider = "dispact"
+	namedByAccount(extension.ChannelIdentity{Provider: "dispact", ChannelUserID: "G-1"})(&rec)
+	rec.Addresses = nil
+
+	if err := rec.Validate(); err != nil {
+		t.Fatalf("a channel-only record with no addresses was refused: %v", err)
+	}
+
+	// And the mirror, which is what keeps the exemption from swallowing the
+	// rule: a record that DOES name an address still owes the whole party set,
+	// or the gate it belongs to is silently disabled.
+	mail := aValidRecord()
+	mail.Addresses = nil
+	if err := mail.Validate(); err == nil {
+		t.Error("a mail-shaped record with no addresses was accepted; the internal-colleague gate reads that set and keeps everything over an empty one")
 	}
 }
 

--- a/backend/pkg/extension/ingress_test.go
+++ b/backend/pkg/extension/ingress_test.go
@@ -87,6 +87,35 @@ func TestTheRecordGrammarRefusesWhatCannotBeLandedHonestly(t *testing.T) {
 		"a raw record over the cap": func(r *extension.Record) {
 			r.Raw = make([]byte, extension.MaxRawBytes+1)
 		},
+		// A HALF-stated channel identity, either way round. It is the shape that
+		// looks populated and routes nowhere: the core keys the binding on the
+		// pair, so half of it binds nothing — and the record would still land,
+		// read as ordinary, and carry no reply address.
+		//
+		// Each of these clears the ADDRESS, or the record would be refused for
+		// naming its human twice and every one of them would pass for a reason
+		// it is not testing.
+		"a channel account with no provider": namedByAccount(extension.ChannelIdentity{ChannelUserID: "G-1c7u1r29"}),
+		"a channel provider with no account": namedByAccount(extension.ChannelIdentity{Provider: "dispact"}),
+		// The provider is a channel_provider row and has to satisfy that column's
+		// own grammar, which is snake and not kebab — the difference DESIGN-SP5 §9
+		// got wrong once already.
+		"a channel provider the registry grammar refuses": namedByAccount(
+			extension.ChannelIdentity{Provider: "deal-room", ChannelUserID: "G-1"}),
+		"a channel account id over the cap": namedByAccount(extension.ChannelIdentity{
+			Provider: "dispact", ChannelUserID: strings.Repeat("g", extension.MaxChannelUserIDLength+1),
+		}),
+		"a channel display name over the cap": namedByAccount(extension.ChannelIdentity{
+			Provider: "dispact", ChannelUserID: "G-1", DisplayName: strings.Repeat("n", extension.MaxDisplayNameRunes+1),
+		}),
+		// Named TWICE — the address KEPT this time. The core refuses it
+		// (ErrCounterpartyNamedTwice) because an address and a channel account
+		// resolve through different ladders, and the published grammar refuses it
+		// here so a unit reads the reason rather than an unattributable "the core
+		// could not land this record".
+		"a counterparty named by an address and by an account": func(r *extension.Record) {
+			r.Counterparty.ChannelIdentity = extension.ChannelIdentity{Provider: "dispact", ChannelUserID: "G-1"}
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			rec := aValidRecord()
@@ -95,6 +124,43 @@ func TestTheRecordGrammarRefusesWhatCannotBeLandedHonestly(t *testing.T) {
 				t.Fatalf("the grammar accepted %s", name)
 			}
 		})
+	}
+}
+
+// namedByAccount rewrites the fixture into the channel shape: the address
+// dropped, the account named. It is the one legal way to state a channel
+// counterparty, so every damage to that account has to start from it.
+func namedByAccount(identity extension.ChannelIdentity) func(*extension.Record) {
+	return func(r *extension.Record) {
+		r.Counterparty.Email = ""
+		r.Counterparty.Domain = ""
+		r.Counterparty.ChannelIdentity = identity
+	}
+}
+
+// A record identifying its counterparty by ADDRESS binds no channel identity,
+// and that empty pair must stay legal — every mail record in the product is
+// this shape, and a rule that refused it would close the ingress surface it was
+// meant to bound.
+func TestARecordMayIdentifyItsCounterpartyByAddressAlone(t *testing.T) {
+	rec := aValidRecord()
+	rec.Counterparty.ChannelIdentity = extension.ChannelIdentity{}
+	if err := rec.Validate(); err != nil {
+		t.Fatalf("a record with no channel identity was refused: %v", err)
+	}
+}
+
+// A channel record states BOTH halves of the identity, and the pair is what
+// makes the message repliable at all.
+func TestAChannelRecordMayNameTheAccountItCanBeAnsweredAt(t *testing.T) {
+	rec := aValidRecord()
+	rec.Activity.Kind = extension.ActivityKindMessage
+	rec.Activity.ChannelProvider = "dispact"
+	namedByAccount(extension.ChannelIdentity{
+		Provider: "dispact", ChannelUserID: "G-1c7u1r29", DisplayName: "A Sender",
+	})(&rec)
+	if err := rec.Validate(); err != nil {
+		t.Fatalf("a well-formed channel record was refused: %v", err)
 	}
 }
 

--- a/backend/tools/gen-composition/astreader.go
+++ b/backend/tools/gen-composition/astreader.go
@@ -349,6 +349,12 @@ func (r *unitReader) readExtensionField(elt ast.Expr, file *ast.File, m *unitMan
 		if err == nil {
 			m.Ingress = append(m.Ingress, sources...)
 		}
+	case "Channels":
+		var channels []declaredChannel
+		channels, err = r.readChannels(kv.Value, file)
+		if err == nil {
+			m.Channels = append(m.Channels, channels...)
+		}
 	default:
 		// Fail closed: a field this generator does not recognize could be a
 		// future governed capability, and a manifest that silently omitted

--- a/backend/tools/gen-composition/astreader_channel.go
+++ b/backend/tools/gen-composition/astreader_channel.go
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package main
+
+// Reading a unit's declared CHANNELS into the manifest (ADR-0107/A158).
+//
+// A channel is a governed capability in the sense that matters to an operator:
+// it says this unit can transmit messages out of the installation, on a
+// transport it names, under a member's own credential. That belongs in the
+// manifest for the same reason a tool's requested tier does — an operator has to
+// be able to see it before the unit ever runs.
+//
+// What the manifest records is the DECLARATION, not the behavior: the provider
+// name and whether a Send was declared at all. Whether the function works is not
+// derivable from source and is not claimed here.
+
+import (
+	"go/ast"
+	"sort"
+
+	"github.com/gradionhq/margince/backend/pkg/extension"
+)
+
+// readChannels reads the Channels slice literal.
+func (r *unitReader) readChannels(expr ast.Expr, file *ast.File) ([]declaredChannel, error) {
+	lit, ok := expr.(*ast.CompositeLit)
+	if !ok {
+		return nil, r.errAt(expr, "Channels must be a slice literal")
+	}
+	ext := importAlias(file, extensionPkgPath)
+	out := make([]declaredChannel, 0, len(lit.Elts))
+	seen := map[string]bool{}
+	for _, elt := range lit.Elts {
+		ch, err := r.readChannel(elt, ext)
+		if err != nil {
+			return nil, err
+		}
+		if seen[ch.Provider] {
+			return nil, r.errAt(elt, "channel provider %q declared twice", ch.Provider)
+		}
+		seen[ch.Provider] = true
+		out = append(out, ch)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Provider < out[j].Provider })
+	return out, nil
+}
+
+// readChannel reads one extension.Channel literal.
+//
+// Send and Live are read as PRESENCE only — a function value is not derivable
+// from source, and the manifest's claim is deliberately narrow: that the unit
+// declared a transport, not that the transport works. `supplies_transport`
+// mirrors extension.Channel.SuppliesTransport so the manifest and the runtime
+// answer the same question the same way.
+func (r *unitReader) readChannel(elt ast.Expr, ext string) (declaredChannel, error) {
+	lit, ok := elt.(*ast.CompositeLit)
+	if !ok || (lit.Type != nil && !isSelector(lit.Type, ext, "Channel")) {
+		return declaredChannel{}, r.errAt(elt, "a Channels entry must be an extension.Channel literal")
+	}
+	var ch declaredChannel
+	var hasLive bool
+	for _, e := range lit.Elts {
+		kv, ok := e.(*ast.KeyValueExpr)
+		if !ok {
+			return declaredChannel{}, r.errAt(e, "Channel fields must be keyed")
+		}
+		k, ok := kv.Key.(*ast.Ident)
+		if !ok {
+			return declaredChannel{}, r.errAt(kv.Key, "Channel fields must be keyed by name")
+		}
+		var err error
+		switch k.Name {
+		case "Provider":
+			ch.Provider, err = r.stringLit(kv.Value, "Channel.Provider")
+		case "Send":
+			ch.SuppliesTransport = !isNilIdent(kv.Value)
+		case "Live":
+			hasLive = !isNilIdent(kv.Value)
+		default:
+			err = r.errAt(kv, "Channel field %s is not derivable by this generator", k.Name)
+		}
+		if err != nil {
+			return declaredChannel{}, err
+		}
+	}
+	// The SAME pairing rule the boot preflight enforces, run here so a unit is
+	// refused at generation rather than at the boot of a build that shipped.
+	if ch.SuppliesTransport && !hasLive {
+		return declaredChannel{}, r.errPos(lit,
+			"channel %q declares Send without Live — a transport that can send must be able to say whether it still may", ch.Provider)
+	}
+	// Validated through the PUBLISHED rule, exactly as an ingress source is, so
+	// generation-time acceptance cannot diverge from boot-time.
+	if err := (extension.Channel{Provider: ch.Provider}).Validate(); err != nil {
+		return declaredChannel{}, r.errPos(lit, "%v", err)
+	}
+	return ch, nil
+}
+
+// isNilIdent reports whether an expression is the literal `nil`, which is how a
+// capture-only channel spells "no transport".
+func isNilIdent(expr ast.Expr) bool {
+	id, ok := expr.(*ast.Ident)
+	return ok && id.Name == "nil"
+}

--- a/backend/tools/gen-composition/unitmanifest.go
+++ b/backend/tools/gen-composition/unitmanifest.go
@@ -77,6 +77,11 @@ type unitManifest struct {
 	// back to the unit that produced it. omitempty for the reason the two
 	// fields above have it.
 	Ingress []ingressSource `json:"ingress,omitempty"`
+
+	// Channels are the messaging transports the unit supplies. Present in the
+	// manifest for a Tool's reason: it is a capability an operator should see
+	// declared, not discover from a message leaving the installation.
+	Channels []declaredChannel `json:"channels,omitempty"`
 }
 
 // secretsRequest is one declared secret key and scope (see
@@ -102,6 +107,20 @@ type subscriptionRequest struct {
 type ingressSource struct {
 	System string   `json:"system"`
 	Lands  []string `json:"lands"`
+}
+
+// declaredChannel is one messaging transport the unit supplies, as an operator
+// reads it in the manifest (ADR-0107/A158).
+//
+// It records the DECLARATION and not the behavior: the provider name, and
+// whether a Send was declared at all. A function value is not derivable from
+// source, so nothing here claims the transport works — only that the unit says
+// it has one, which is what an operator needs before the unit ever runs.
+type declaredChannel struct {
+	Provider string `json:"provider"`
+	// SuppliesTransport mirrors extension.Channel.SuppliesTransport: false is
+	// the documented capture-only case, not an omission.
+	SuppliesTransport bool `json:"supplies_transport"`
 }
 
 // riskTierRequest is one governed operation and the risk tier it requests,

--- a/extensions/dispact-connector/client.go
+++ b/extensions/dispact-connector/client.go
@@ -379,6 +379,28 @@ func (c *client) get(ctx context.Context, path string, query url.Values, into an
 	return c.do(req, into)
 }
 
+// sendMessage transmits one message into a channel and returns the provider's
+// own id for it.
+//
+// The recipient is a CHANNEL, not a user: this provider addresses a DM by its
+// channel slug, and the slug is what the ingress recorded on the conversation.
+// Routing on a user id would mean resolving a DM here, which is a second way to
+// pick a destination and therefore a second way to pick the wrong one.
+func (c *client) sendMessage(ctx context.Context, channelSlug, body string) (string, error) {
+	var sent struct {
+		ID string `json:"id"`
+	}
+	if err := c.post(ctx, "/api/channels/"+channelSlug+"/messages",
+		map[string]string{"content": body}, &sent); err != nil {
+		return "", err
+	}
+	// An accepted send that returns no id is not a failure: the message is
+	// gone either way, and reporting an error would have the core retry a
+	// delivery the recipient has already received. What is lost is the anchor
+	// for a later reply, which the caller records as absent rather than faked.
+	return sent.ID, nil
+}
+
 //craft:ignore naked-any the request body and the decode target are both the caller's shapes; see get
 func (c *client) post(ctx context.Context, path string, body any, into any) error {
 	encoded, err := json.Marshal(body)

--- a/extensions/dispact-connector/client.go
+++ b/extensions/dispact-connector/client.go
@@ -49,6 +49,18 @@ const (
 	// cannot act on. It fails the tick rather than advancing over records
 	// nobody has seen.
 	errProvider dispactError = "dispact: the provider answered something this unit cannot use"
+
+	// errUnanswered marks a request that WENT OUT and whose outcome never came
+	// back: the connection failed mid-flight, or the answer could not be read.
+	// It always accompanies errTransient rather than replacing it, because for
+	// a READ the two are the same fact — the next tick asks again.
+	//
+	// For a SEND they are not. The message may be at the recipient and may not,
+	// and this provider offers no idempotency key and no prior-send lookup, so
+	// no later attempt could ever find out. A retry there messages a customer
+	// twice with nothing able to detect it, which is why the send path maps
+	// this — and only this — onto the core's own unknown-outcome class.
+	errUnanswered dispactError = "dispact: the provider never reported the outcome"
 )
 
 // dispactError is one of this unit's own refusal classes.
@@ -379,28 +391,6 @@ func (c *client) get(ctx context.Context, path string, query url.Values, into an
 	return c.do(req, into)
 }
 
-// sendMessage transmits one message into a channel and returns the provider's
-// own id for it.
-//
-// The recipient is a CHANNEL, not a user: this provider addresses a DM by its
-// channel slug, and the slug is what the ingress recorded on the conversation.
-// Routing on a user id would mean resolving a DM here, which is a second way to
-// pick a destination and therefore a second way to pick the wrong one.
-func (c *client) sendMessage(ctx context.Context, channelSlug, body string) (string, error) {
-	var sent struct {
-		ID string `json:"id"`
-	}
-	if err := c.post(ctx, "/api/channels/"+channelSlug+"/messages",
-		map[string]string{"content": body}, &sent); err != nil {
-		return "", err
-	}
-	// An accepted send that returns no id is not a failure: the message is
-	// gone either way, and reporting an error would have the core retry a
-	// delivery the recipient has already received. What is lost is the anchor
-	// for a later reply, which the caller records as absent rather than faked.
-	return sent.ID, nil
-}
-
 //craft:ignore naked-any the request body and the decode target are both the caller's shapes; see get
 func (c *client) post(ctx context.Context, path string, body any, into any) error {
 	encoded, err := json.Marshal(body)
@@ -430,7 +420,10 @@ func (c *client) do(req *http.Request, into any) error {
 		// answering it as a token problem would tell a member to re-paste a
 		// token that is fine. The tick fails, the class is recorded, and the
 		// next tick meets the same wall.
-		return fmt.Errorf("%w: %s", errTransient, err.Error())
+		//
+		// errUnanswered rides along because the SEND path needs the distinction
+		// a poll does not: the request may have arrived. See there.
+		return fmt.Errorf("%w: %w: %s", errTransient, errUnanswered, err.Error())
 	}
 	//craft:ignore swallowed-errors best-effort close: the capped read below may leave the body mid-stream, so a close error carries no signal for this call's result
 	defer func() { _ = resp.Body.Close() }()
@@ -442,7 +435,9 @@ func (c *client) do(req *http.Request, into any) error {
 	// stores.
 	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes+1))
 	if err != nil {
-		return fmt.Errorf("%w: reading the answer: %s", errTransient, err.Error())
+		// Also unanswered: the provider accepted the request and this side
+		// never learned what it decided.
+		return fmt.Errorf("%w: %w: reading the answer: %s", errTransient, errUnanswered, err.Error())
 	}
 	if len(body) > maxResponseBytes {
 		return fmt.Errorf("%w: the answer is over the %d-byte cap", errProvider, maxResponseBytes)

--- a/extensions/dispact-connector/dispact.go
+++ b/extensions/dispact-connector/dispact.go
@@ -80,6 +80,22 @@ func New() extension.Extension {
 		Secrets: []extension.SecretsRequest{
 			{Key: "api-token", Scope: extension.SecretScopeUser},
 		},
+		// The transport this unit supplies (ADR-0107/A158). A message it carries
+		// lands as kind `message` with `dispact` on the provider column — the
+		// unit names the TRANSPORT and never the kind, which is what keeps the
+		// two axes separate from outside the core.
+		//
+		// Live is required because Send is present: a transport that can
+		// transmit must be able to say whether it still may, or the core has to
+		// guess at the one moment guessing is unrecoverable.
+		Channels: []extension.Channel{
+			// A literal rather than the `provider` constant, for the reason the
+			// ingress source above is one: the manifest is derived STATICALLY,
+			// without compiling the unit, so a constant here would be a name the
+			// generator cannot resolve. The two are the same string on purpose
+			// and a test holds them equal.
+			{Provider: "dispact", Send: send, Live: live},
+		},
 		Jobs: []extension.Job{
 			{Name: "poll_inbox", Handle: pollInbox},
 		},

--- a/extensions/dispact-connector/manifest.generated.json
+++ b/extensions/dispact-connector/manifest.generated.json
@@ -81,5 +81,11 @@
         "activity"
       ]
     }
+  ],
+  "channels": [
+    {
+      "provider": "dispact",
+      "supplies_transport": true
+    }
   ]
 }

--- a/extensions/dispact-connector/record.go
+++ b/extensions/dispact-connector/record.go
@@ -120,21 +120,21 @@ var directMessageTypes = map[string]bool{
 // channel account goes through the channel ladder, which binds the account to a
 // person the reply path can then resolve.
 //
-// A DIRECT MESSAGE is named by its account, and the account id is the CHANNEL
-// slug rather than the sender's own user id, because that is what this provider's
-// send routes on — a reply goes back into the conversation the message was read
-// from instead of opening a second one beside it. For a DM that is exact: the
-// channel IS the pair, so the slug names the sender as reliably as their user id
-// would.
+// A DIRECT MESSAGE is named by the SENDER'S OWN ACCOUNT ID, not by the channel
+// the message arrived in. The core keys the binding on (provider, account id)
+// and treats that row as the person: it is what an erasure suppresses and what
+// the reply path resolves. Keying it on a conversation instead would make the
+// same colleague two people when they DM two members, and an erasure armed for
+// one of those would leave their other chats capturable. The send resolves the
+// conversation from the account when it needs one (client.dmChannelWith).
 //
-// FOR A MENTION IN A SHARED CHANNEL THE SLUG WOULD BE WRONG TWICE, which is why
-// those are named by address instead. It names a room rather than a person, so a
-// reply meant for one colleague would post in front of everyone in it — and the
-// core keys a binding on (provider, account id), so the second person mentioned
-// in that room would take the binding off the first and inherit their replies.
+// A MENTION IN A SHARED CHANNEL is named by address instead. The room gives
+// this unit no per-person address to bind, and a reply resolved from the room
+// would post in front of everyone in it.
 //
-// A mention is therefore captured, reads on the timeline, and is not answerable.
-// That is the honest state for a room this unit has no per-person address in.
+// A mention is therefore captured, reads on the timeline, and is not answerable
+// on this transport. That is the honest state for a room this unit has no
+// private conversation in.
 func counterpartyOf(item inboxItem, sender providerUser) extension.Counterparty {
 	if !directMessageTypes[item.Type] {
 		return extension.Counterparty{
@@ -149,7 +149,7 @@ func counterpartyOf(item inboxItem, sender providerUser) extension.Counterparty 
 		Direction:   extension.DirectionInbound,
 		ChannelIdentity: extension.ChannelIdentity{
 			Provider:      "dispact",
-			ChannelUserID: item.ChannelID,
+			ChannelUserID: sender.ID,
 			DisplayName:   sender.name(),
 		},
 	}

--- a/extensions/dispact-connector/record.go
+++ b/extensions/dispact-connector/record.go
@@ -68,7 +68,18 @@ func recordFor(item inboxItem, sender, member providerUser, providerWorkspace st
 		// share one provenance namespace across every connection.
 		Key: fmt.Sprintf("%s:%d", providerWorkspace, item.ID),
 		Activity: extension.ActivityFields{
-			Kind: "note",
+			// A message, on this unit's own transport — the two axes stated
+			// separately (ADR-0107/A158). It landed as a `note` before this unit
+			// supplied a channel, which was honest then and is not now: a note
+			// carries no transport, so nothing could be replied to and every
+			// captured conversation was a dead end on the timeline.
+			//
+			// The provider is a LITERAL rather than the `provider` constant, for
+			// the reason the ingress declaration is one: the core holds a unit to
+			// the channels it DECLARED, and that declaration is read statically
+			// from the AST without compiling the unit. A test holds the two equal.
+			Kind:            extension.ActivityKindMessage,
+			ChannelProvider: "dispact",
 			// The provider's title is the human-readable "who did what"; the
 			// body is the message preview. Neither is fetched in full: a CRM
 			// timeline entry is a pointer to a conversation, not a copy of it.
@@ -81,19 +92,67 @@ func recordFor(item inboxItem, sender, member providerUser, providerWorkspace st
 		// rule. A bare channel id would share activity.thread_key with every
 		// other source, where two of them can collide and join a stranger's
 		// conversation onto this one.
-		ThreadKey: fmt.Sprintf("dispact:%s:%s", providerWorkspace, item.ChannelID),
-		Counterparty: extension.Counterparty{
-			Email:       sender.Email,
-			DisplayName: sender.name(),
-			Domain:      mailDomain(sender.Email),
-			Direction:   extension.DirectionInbound,
-		},
-		Addresses: []string{sender.Email, member.Email},
+		ThreadKey:    fmt.Sprintf("dispact:%s:%s", providerWorkspace, item.ChannelID),
+		Counterparty: counterpartyOf(item, sender),
+		Addresses:    []string{sender.Email, member.Email},
 		// The provider's record as received, kept as evidence. It is the
 		// original document rather than a re-encoding of the fields above, so
 		// what the installation stores is what the provider said.
 		Raw: item.Raw,
 	}, nil
+}
+
+// directMessageTypes are the notification types whose channel is a PAIR: this
+// member and the sender, and nobody else. They are the subset of directedTypes
+// that carries a reply address.
+var directMessageTypes = map[string]bool{
+	"dm":              true,
+	"dm_thread_reply": true,
+}
+
+// counterpartyOf names the human at the other end, ONE way — by the account
+// they can be answered at, or by their address, and never both.
+//
+// The exclusivity is the core's rule (capture's ErrCounterpartyNamedTwice) and
+// it is a real choice rather than a formality: the two are different resolution
+// ladders. An address goes through the mail ladder, where a corporate domain is
+// DEFERRED to the pending inbox and only a freemail sender mints a person; a
+// channel account goes through the channel ladder, which binds the account to a
+// person the reply path can then resolve.
+//
+// A DIRECT MESSAGE is named by its account, and the account id is the CHANNEL
+// slug rather than the sender's own user id, because that is what this provider's
+// send routes on — a reply goes back into the conversation the message was read
+// from instead of opening a second one beside it. For a DM that is exact: the
+// channel IS the pair, so the slug names the sender as reliably as their user id
+// would.
+//
+// FOR A MENTION IN A SHARED CHANNEL THE SLUG WOULD BE WRONG TWICE, which is why
+// those are named by address instead. It names a room rather than a person, so a
+// reply meant for one colleague would post in front of everyone in it — and the
+// core keys a binding on (provider, account id), so the second person mentioned
+// in that room would take the binding off the first and inherit their replies.
+//
+// A mention is therefore captured, reads on the timeline, and is not answerable.
+// That is the honest state for a room this unit has no per-person address in.
+func counterpartyOf(item inboxItem, sender providerUser) extension.Counterparty {
+	if !directMessageTypes[item.Type] {
+		return extension.Counterparty{
+			Email:       sender.Email,
+			DisplayName: sender.name(),
+			Domain:      mailDomain(sender.Email),
+			Direction:   extension.DirectionInbound,
+		}
+	}
+	return extension.Counterparty{
+		DisplayName: sender.name(),
+		Direction:   extension.DirectionInbound,
+		ChannelIdentity: extension.ChannelIdentity{
+			Provider:      "dispact",
+			ChannelUserID: item.ChannelID,
+			DisplayName:   sender.name(),
+		},
+	}
 }
 
 // mailDomain is the lower-cased domain half of an address, or empty when there

--- a/extensions/dispact-connector/record_test.go
+++ b/extensions/dispact-connector/record_test.go
@@ -238,13 +238,12 @@ func TestACapturedNotificationIsAMessageOnTheDeclaredTransport(t *testing.T) {
 
 // The reply address, and the case it deliberately does NOT bind.
 //
-// A DM's channel is a pair, so its slug names the sender as reliably as their
-// own id would — and it is what the send routes on, so a reply goes back into
-// the conversation it was read from. A MENTION's channel is a room, where the
-// slug would be wrong twice: a reply meant for one colleague would post in front
-// of everyone, and the core keys a binding on (provider, account id), so the
-// second person mentioned in that room would take the binding off the first and
-// inherit their replies.
+// A DM binds the SENDER'S ACCOUNT, because the core treats that row as the
+// person: it is what an erasure suppresses and what a reply resolves. Keying it
+// on the conversation instead would make the same colleague two people when
+// they DM two members. A MENTION binds nothing — the room gives this unit no
+// per-person address, and a reply resolved from a room would post in front of
+// everyone in it.
 func TestOnlyADirectMessageCarriesAReplyAddress(t *testing.T) {
 	for kind, wantBound := range map[string]bool{
 		"dm":              true,
@@ -263,9 +262,9 @@ func TestOnlyADirectMessageCarriesAReplyAddress(t *testing.T) {
 		if bound != wantBound {
 			t.Errorf("%q bound a reply address = %v, want %v", kind, bound, wantBound)
 		}
-		if bound && rec.Counterparty.ChannelIdentity.ChannelUserID != item.ChannelID {
-			t.Errorf("%q bound %q, want the channel slug %q the send routes on",
-				kind, rec.Counterparty.ChannelIdentity.ChannelUserID, item.ChannelID)
+		if bound && rec.Counterparty.ChannelIdentity.ChannelUserID != aSender().ID {
+			t.Errorf("%q bound %q, want the SENDER's own account id %q — the binding IS the person, and keying it on a conversation makes one colleague two people",
+				kind, rec.Counterparty.ChannelIdentity.ChannelUserID, aSender().ID)
 		}
 		// Either way the record must pass the published grammar: a half-stated
 		// identity is refused there, and it is the shape a careless narrowing

--- a/extensions/dispact-connector/record_test.go
+++ b/extensions/dispact-connector/record_test.go
@@ -73,8 +73,13 @@ func TestARecordCarriesWhatTheCoreDecidesWith(t *testing.T) {
 		t.Errorf("direction = %q, want inbound — the member received this", rec.Activity.Direction)
 	case !rec.Activity.OccurredAt.Equal(item.CreatedAt):
 		t.Errorf("occurred_at = %v, want the provider's own time rather than when the poll noticed", rec.Activity.OccurredAt)
-	case rec.Counterparty.Domain != "example.com":
-		t.Errorf("domain = %q — the core's suppression gates key on it, and an empty one reads as 'keep' rather than as an opt-out", rec.Counterparty.Domain)
+	// A DM names its human by the ACCOUNT it can be answered at, so it carries
+	// no address and no domain — the mail suppression gates all key off the
+	// address and are no-ops for a channel record by construction, which is why
+	// the empty domain here is an answer rather than a gap. The address arm is
+	// asserted on a mention below, where it is the shape that applies.
+	case rec.Counterparty.Email != "":
+		t.Errorf("email = %q on a direct message — the core refuses a counterparty named by an address AND by a channel account", rec.Counterparty.Email)
 	case string(rec.Raw) != string(item.Raw):
 		t.Errorf("raw = %s, want the provider's own document", rec.Raw)
 	}
@@ -175,4 +180,132 @@ func TestTheTokenKeyIsTheDeclaredOne(t *testing.T) {
 		}
 	}
 	t.Fatalf("no user-scoped %q secret is declared; the unit declares %+v", tokenKey, New().Secrets)
+}
+
+// The transport the unit DECLARES is the one its send code routes on.
+//
+// Same shape and same reason as the ingress test above: the declaration is read
+// statically by the manifest generator, so it carries a literal, while the send
+// path uses a constant. Two spellings of one provider is exactly the drift that
+// would register a transport nothing can send on — the row would exist, the
+// directory would publish it, and every reply would be refused for naming a
+// provider the unit does not answer to.
+func TestTheChannelsProviderIsTheOneSendRoutesOn(t *testing.T) {
+	declared := New().Channels
+	if len(declared) != 1 {
+		t.Fatalf("the unit declares %d channel(s), want one", len(declared))
+	}
+	if declared[0].Provider != provider {
+		t.Fatalf("declared %q, send routes on %q — a transport registered under a name nothing answers to refuses every reply",
+			declared[0].Provider, provider)
+	}
+	if err := declared[0].Validate(); err != nil {
+		t.Fatalf("the declaration does not pass the published grammar: %v", err)
+	}
+	// Send and Live travel together, and the declaration is where that is
+	// decided: a transport that can send and cannot report its own liveness
+	// leaves the core guessing at the one moment guessing is unrecoverable.
+	if !declared[0].SuppliesTransport() {
+		t.Fatal("the channel declares no Send; this unit is a transport, not capture-only")
+	}
+	if declared[0].Live == nil {
+		t.Fatal("the channel declares Send without Live")
+	}
+}
+
+// A captured notification is a MESSAGE on this unit's own transport — the two
+// axes stated separately (ADR-0107/A158). It landed as a `note` before the unit
+// supplied a channel, which made every captured conversation a dead end: a note
+// carries no transport, so nothing on the timeline could be replied to.
+//
+// The provider is asserted against the DECLARATION rather than against a
+// literal, because the pair is what the core enforces: it holds a unit to the
+// channels it declared, so a record naming anything else is refused at the call.
+func TestACapturedNotificationIsAMessageOnTheDeclaredTransport(t *testing.T) {
+	rec, err := recordFor(dm(1), aSender(), aMember(), "ws-7")
+	if err != nil {
+		t.Fatalf("recordFor: %v", err)
+	}
+	if rec.Activity.Kind != extension.ActivityKindMessage {
+		t.Errorf("kind = %q, want %q — a note has no transport and cannot be replied to",
+			rec.Activity.Kind, extension.ActivityKindMessage)
+	}
+	if rec.Activity.ChannelProvider != New().Channels[0].Provider {
+		t.Errorf("channel_provider = %q, want the declared transport %q; the core refuses a record naming one the unit did not declare",
+			rec.Activity.ChannelProvider, New().Channels[0].Provider)
+	}
+}
+
+// The reply address, and the case it deliberately does NOT bind.
+//
+// A DM's channel is a pair, so its slug names the sender as reliably as their
+// own id would — and it is what the send routes on, so a reply goes back into
+// the conversation it was read from. A MENTION's channel is a room, where the
+// slug would be wrong twice: a reply meant for one colleague would post in front
+// of everyone, and the core keys a binding on (provider, account id), so the
+// second person mentioned in that room would take the binding off the first and
+// inherit their replies.
+func TestOnlyADirectMessageCarriesAReplyAddress(t *testing.T) {
+	for kind, wantBound := range map[string]bool{
+		"dm":              true,
+		"dm_thread_reply": true,
+		"mention":         false,
+		"channel_mention": false,
+		"thread_reply":    false,
+	} {
+		item := dm(1)
+		item.Type = kind
+		rec, err := recordFor(item, aSender(), aMember(), "ws-7")
+		if err != nil {
+			t.Fatalf("recordFor(%q): %v", kind, err)
+		}
+		bound := rec.Counterparty.ChannelIdentity.ChannelUserID != ""
+		if bound != wantBound {
+			t.Errorf("%q bound a reply address = %v, want %v", kind, bound, wantBound)
+		}
+		if bound && rec.Counterparty.ChannelIdentity.ChannelUserID != item.ChannelID {
+			t.Errorf("%q bound %q, want the channel slug %q the send routes on",
+				kind, rec.Counterparty.ChannelIdentity.ChannelUserID, item.ChannelID)
+		}
+		// Either way the record must pass the published grammar: a half-stated
+		// identity is refused there, and it is the shape a careless narrowing
+		// of this rule would produce.
+		if err := rec.Validate(); err != nil {
+			t.Errorf("the record built for %q is refused by the published grammar: %v", kind, err)
+		}
+	}
+}
+
+// A mention in a shared room is named by ADDRESS, which is the other arm of the
+// same exclusive choice — and the domain matters there, because the mail
+// ladder's suppression gates key on it and an empty one reads as "keep" rather
+// than as an opt-out.
+func TestAMentionNamesItsSenderByAddress(t *testing.T) {
+	item := dm(1)
+	item.Type = "mention"
+
+	rec, err := recordFor(item, aSender(), aMember(), "ws-7")
+	if err != nil {
+		t.Fatalf("recordFor: %v", err)
+	}
+	switch {
+	case rec.Counterparty.Email != "outside@example.com":
+		t.Errorf("email = %q, want the sender's address — a room gives this unit no per-person account to name them by", rec.Counterparty.Email)
+	case rec.Counterparty.Domain != "example.com":
+		t.Errorf("domain = %q — the mail ladder's suppression gates key on it, and an empty one reads as 'keep' rather than as an opt-out", rec.Counterparty.Domain)
+	case rec.Counterparty.ChannelIdentity.Provider != "":
+		t.Errorf("a mention bound the channel identity %+v; the core refuses a counterparty named twice", rec.Counterparty.ChannelIdentity)
+	}
+}
+
+// Every type that carries a reply address must be one this unit captures at all.
+// The two lists are separate because they answer different questions, and a type
+// in the reply set but not the capture set would be a rule about records that
+// never exist — which reads, to the next author, as coverage it does not have.
+func TestEveryReplyableTypeIsOneThisUnitCaptures(t *testing.T) {
+	for kind := range directMessageTypes {
+		if !directedTypes[kind] {
+			t.Errorf("%q carries a reply address and is not a captured type; the rule governs no record", kind)
+		}
+	}
 }

--- a/extensions/dispact-connector/send.go
+++ b/extensions/dispact-connector/send.go
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package dispact
+
+// The transport half of this unit: what it takes to send a message back into a
+// conversation the poll captured (ADR-0107/A158, DESIGN-SP5 §9).
+//
+// Whose credential transmits is the whole shape of this file. A message leaves
+// under the MEMBER's own token — the person who staged it — never under an
+// installation credential, because this provider has none: the unit holds one
+// sealed secret per member and nothing else. That is also why Live exists: the
+// core has to be able to ask "can this member still send" without spending the
+// credential to find out.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/gradionhq/margince/backend/pkg/extension"
+)
+
+// provider is this unit's key in channel_provider. It is NOT an activity kind:
+// a message it carries lands as kind `message` with this name on its own
+// column, which is the separation the whole decision rests on.
+const provider = "dispact"
+
+// clientFor opens this member's own connection to the provider.
+//
+// It reuses providerFor's two facts — the member's sealed token and the base
+// URL their connection was made against — rather than re-deriving either: a
+// second way to build a client is a second place the wrong credential can be
+// picked up, at the one seam where "whose credential" is the entire question.
+//
+// ErrNotFound when the member has no connection, so a caller can tell "this
+// member disconnected" from "the provider would not answer".
+func clientFor(ctx context.Context, rt extension.Runtime, member extension.UserID) (*client, error) {
+	var conn *connection
+	if err := rt.Tx(ctx, func(ctx context.Context, tx extension.Tx) error {
+		found, err := connectionOf(ctx, tx, string(member))
+		conn = found
+		return err
+	}); err != nil {
+		return nil, err
+	}
+	if conn == nil {
+		return nil, fmt.Errorf("%w: this member has no Dispact connection", extension.ErrNotFound)
+	}
+	api, _, err := providerFor(ctx, rt, *conn, newClient)
+	if err != nil {
+		return nil, err
+	}
+	return api, nil
+}
+
+// send transmits one message on this member's connection.
+//
+// It resolves the member's own connection rather than any connection: the
+// OutboundMessage names whose credential must carry it, and a unit that sent on
+// somebody else's would be transmitting as a colleague the recipient never
+// wrote to.
+func send(ctx context.Context, rt extension.Runtime, msg extension.OutboundMessage) (extension.Receipt, error) {
+	c, err := clientFor(ctx, rt, msg.Member)
+	if err != nil {
+		return extension.Receipt{}, err
+	}
+	// The recipient's account id IS the channel slug for this provider — the
+	// ingress records the DM's slug as the party's channel identity, so the
+	// send routes to the same conversation the message was read from rather
+	// than resolving a second one.
+	sentID, err := c.sendMessage(ctx, msg.Recipient.ChannelUserID, msg.Body)
+	if err != nil {
+		return extension.Receipt{}, sendRefusal(err)
+	}
+	return extension.Receipt{ProviderMessageID: sentID}, nil
+}
+
+// live answers whether this member's connection can still send, without
+// spending the credential on a message.
+//
+// `me` is the dry run: it is the cheapest call this provider has that proves
+// the token is still accepted, and it changes nothing. A rejected token answers
+// FALSE (a confirmed "not usable"), and any other failure returns an error —
+// the core parks on the first and retries on the second, so collapsing them
+// would either strand a deliverable message or re-send a refused one.
+func live(ctx context.Context, rt extension.Runtime, member extension.UserID) (bool, error) {
+	c, err := clientFor(ctx, rt, member)
+	switch {
+	case errors.Is(err, extension.ErrNotFound):
+		// No connection at all is a confirmed no, not a fault: the member
+		// disconnected, and there is nothing to retry into.
+		return false, nil
+	case err != nil:
+		return false, err
+	}
+	if _, err := c.me(ctx); err != nil {
+		if errors.Is(err, errUnauthorized) {
+			return false, nil
+		}
+		return false, fmt.Errorf("dispact: could not confirm the connection: %w", err)
+	}
+	return true, nil
+}
+
+// sendRefusal maps a provider failure onto what the core does with it.
+//
+// Only a revoked credential is PERMANENT here. Everything else — a timeout, a
+// 5xx, a rate limit — is transient by default, which is the conservative
+// posture for a channel: parking a message that would have sent is recoverable
+// by a human, and re-sending one that already arrived is not.
+func sendRefusal(err error) error {
+	if errors.Is(err, errUnauthorized) {
+		return fmt.Errorf("%w: %s", extension.ErrForbidden, err.Error())
+	}
+	return err
+}

--- a/extensions/dispact-connector/send.go
+++ b/extensions/dispact-connector/send.go
@@ -33,9 +33,15 @@ const provider = "dispact"
 // second way to build a client is a second place the wrong credential can be
 // picked up, at the one seam where "whose credential" is the entire question.
 //
+// dial is a parameter for the reason the poll's is: the production constructor
+// refuses to dial anything that is not a globally routable address, which is a
+// guard with its own tests and one no test server can satisfy. Injecting the
+// factory is what lets the send path be exercised at all — the alternative is a
+// transmission seam proven only in production.
+//
 // ErrNotFound when the member has no connection, so a caller can tell "this
 // member disconnected" from "the provider would not answer".
-func clientFor(ctx context.Context, rt extension.Runtime, member extension.UserID) (*client, error) {
+func clientFor(ctx context.Context, rt extension.Runtime, member extension.UserID, dial clientFactory) (*client, error) {
 	var conn *connection
 	if err := rt.Tx(ctx, func(ctx context.Context, tx extension.Tx) error {
 		found, err := connectionOf(ctx, tx, string(member))
@@ -47,7 +53,7 @@ func clientFor(ctx context.Context, rt extension.Runtime, member extension.UserI
 	if conn == nil {
 		return nil, fmt.Errorf("%w: this member has no Dispact connection", extension.ErrNotFound)
 	}
-	api, _, err := providerFor(ctx, rt, *conn, newClient)
+	api, _, err := providerFor(ctx, rt, *conn, dial)
 	if err != nil {
 		return nil, err
 	}
@@ -61,17 +67,35 @@ func clientFor(ctx context.Context, rt extension.Runtime, member extension.UserI
 // somebody else's would be transmitting as a colleague the recipient never
 // wrote to.
 func send(ctx context.Context, rt extension.Runtime, msg extension.OutboundMessage) (extension.Receipt, error) {
-	c, err := clientFor(ctx, rt, msg.Member)
+	return sendVia(ctx, rt, msg, newClient)
+}
+
+func sendVia(ctx context.Context, rt extension.Runtime, msg extension.OutboundMessage, dial clientFactory) (extension.Receipt, error) {
+	c, err := clientFor(ctx, rt, msg.Member, dial)
 	if err != nil {
-		return extension.Receipt{}, err
-	}
-	// The recipient's account id IS the channel slug for this provider — the
-	// ingress records the DM's slug as the party's channel identity, so the
-	// send routes to the same conversation the message was read from rather
-	// than resolving a second one.
-	sentID, err := c.sendMessage(ctx, msg.Recipient.ChannelUserID, msg.Body)
-	if err != nil {
+		// Through the same classifier the transmission's own failure goes
+		// through, because a revoked credential is discovered HERE as often as
+		// there: opening the client spends the token on `me`, so a token
+		// revoked between staging and sending is refused before a message is
+		// ever posted. Returning it raw would report the one permanent failure
+		// this unit has as a transient one, and the core would retry a
+		// credential that will never be accepted again.
 		return extension.Receipt{}, sendRefusal(err)
+	}
+	// The recipient is an ACCOUNT, and the conversation is resolved from it
+	// against the provider. That indirection is the point: the core binds a
+	// party by account id, one row per human, and keying that row on a
+	// conversation instead would make the same colleague two people and leave
+	// an erasure covering only one of their chats.
+	channel, err := c.dmChannelWith(ctx, msg.Recipient.ChannelUserID)
+	if err != nil {
+		// Resolution transmits nothing, so it is a pre-flight failure whatever
+		// went wrong — never the unknown-outcome class.
+		return extension.Receipt{}, sendRefusal(err)
+	}
+	sentID, err := c.sendMessage(ctx, channel, msg.Body)
+	if err != nil {
+		return extension.Receipt{}, transmissionRefusal(err)
 	}
 	return extension.Receipt{ProviderMessageID: sentID}, nil
 }
@@ -85,11 +109,24 @@ func send(ctx context.Context, rt extension.Runtime, msg extension.OutboundMessa
 // the core parks on the first and retries on the second, so collapsing them
 // would either strand a deliverable message or re-send a refused one.
 func live(ctx context.Context, rt extension.Runtime, member extension.UserID) (bool, error) {
-	c, err := clientFor(ctx, rt, member)
+	return liveVia(ctx, rt, member, newClient)
+}
+
+func liveVia(ctx context.Context, rt extension.Runtime, member extension.UserID, dial clientFactory) (bool, error) {
+	c, err := clientFor(ctx, rt, member, dial)
 	switch {
 	case errors.Is(err, extension.ErrNotFound):
 		// No connection at all is a confirmed no, not a fault: the member
 		// disconnected, and there is nothing to retry into.
+		return false, nil
+	case errors.Is(err, errUnauthorized):
+		// A credential the provider no longer accepts, discovered while opening
+		// the client — which is where it is usually discovered, because
+		// providerFor spends the token on `me` before this function's own dry
+		// run gets to. It is the SAME confirmed no as the one below, and
+		// reporting it as an error here would have the core retry a revoked
+		// token until the ladder was spent instead of parking the delivery
+		// where a human can reconnect.
 		return false, nil
 	case err != nil:
 		return false, err
@@ -103,15 +140,32 @@ func live(ctx context.Context, rt extension.Runtime, member extension.UserID) (b
 	return true, nil
 }
 
-// sendRefusal maps a provider failure onto what the core does with it.
+// sendRefusal maps a failure that happened BEFORE anything was transmitted —
+// opening the client, unsealing the credential, the `me` dry run.
 //
 // Only a revoked credential is PERMANENT here. Everything else — a timeout, a
-// 5xx, a rate limit — is transient by default, which is the conservative
-// posture for a channel: parking a message that would have sent is recoverable
-// by a human, and re-sending one that already arrived is not.
+// 5xx, a rate limit — is transient, which is the conservative posture for a
+// channel: parking a message that would have sent is recoverable by a human.
 func sendRefusal(err error) error {
 	if errors.Is(err, errUnauthorized) {
 		return fmt.Errorf("%w: %s", extension.ErrForbidden, err.Error())
 	}
 	return err
+}
+
+// transmissionRefusal maps a failure of the POST ITSELF, which carries one
+// class the pre-flight cannot: the message may already be at the recipient.
+//
+// This provider has no idempotency key and no prior-send lookup, so a request
+// whose answer never came back is a question no later attempt can settle. The
+// core retries every refusal it is not told is unanswerable, so reporting one
+// as an ordinary transport failure delivers the rep's message twice — the one
+// failure a human cannot undo. ErrSendOutcomeUnknown stops the delivery instead
+// and leaves the uncertainty on the record, which is worse for this unit and
+// better for the person receiving the message.
+func transmissionRefusal(err error) error {
+	if errors.Is(err, errUnanswered) {
+		return fmt.Errorf("%w: %s", extension.ErrSendOutcomeUnknown, err.Error())
+	}
+	return sendRefusal(err)
 }

--- a/extensions/dispact-connector/send_api.go
+++ b/extensions/dispact-connector/send_api.go
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package dispact
+
+// The two provider calls a REPLY makes: resolve the conversation with a party,
+// then post into it.
+//
+// Split from client.go — which holds the connection, the egress guard and the
+// transport plumbing every call shares — because these two are where the
+// difference between what is STORED and what is ADDRESSED is decided, and that
+// argument reads better beside the send than buried among the poll's reads.
+
+import (
+	"context"
+	"fmt"
+)
+
+// sendMessage transmits one message into a channel and returns the provider's
+// own id for it.
+//
+// The recipient is a CHANNEL, resolved from the party's account id by
+// dmChannelWith — see there for why the account id is what the binding stores.
+func (c *client) sendMessage(ctx context.Context, channelSlug, body string) (string, error) {
+	var sent struct {
+		ID string `json:"id"`
+	}
+	if err := c.post(ctx, "/api/channels/"+channelSlug+"/messages",
+		map[string]string{"content": body}, &sent); err != nil {
+		return "", err
+	}
+	// An accepted send that returns no id is not a failure: the message is
+	// gone either way, and reporting an error would have the core retry a
+	// delivery the recipient has already received. What is lost is the anchor
+	// for a later reply, which the caller records as absent rather than faked.
+	return sent.ID, nil
+}
+
+// dmChannelWith resolves the 1:1 conversation with one account, and it exists
+// because WHAT IS STORED and WHAT IS ADDRESSED are different things.
+//
+// The core binds a party by `(provider, channel_user_id)` — one row per human,
+// and that row is what an erasure suppresses and what a reply resolves. So the
+// account id is what the ingress records. But this provider addresses a message
+// by CHANNEL, so the send resolves the conversation from the account here,
+// against the provider's own answer, rather than storing a conversation id in
+// the place a person's identity belongs. Storing the slug instead would key the
+// person on a conversation: the same colleague messaging two members would
+// become two people, and an erasure armed for one of them would leave the other
+// capturable.
+//
+// It returns the DM and nothing else. The endpoint is documented not to return
+// group DMs, and an empty answer is an error rather than a silent no-op: a send
+// with nowhere to go must refuse, not succeed quietly.
+func (c *client) dmChannelWith(ctx context.Context, account string) (string, error) {
+	var answer struct {
+		Channels []struct {
+			Slug string `json:"slug"`
+			Type string `json:"type"`
+		} `json:"channels"`
+	}
+	if err := c.post(ctx, "/api/dms/with-users",
+		map[string][]string{"user_ids": {account}}, &answer); err != nil {
+		return "", err
+	}
+	for _, channel := range answer.Channels {
+		if channel.Type == "dm" && channel.Slug != "" {
+			return channel.Slug, nil
+		}
+	}
+	return "", fmt.Errorf("%w: no direct conversation with that account", errProvider)
+}

--- a/extensions/dispact-connector/send_test.go
+++ b/extensions/dispact-connector/send_test.go
@@ -1,0 +1,336 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package dispact
+
+// The transport half: whose credential carries a message, where it lands, and
+// what the core is told when it cannot leave.
+//
+// The provider is a loopback listener the production constructor would refuse
+// to dial, so the factory is injected and the egress guard is left exactly as a
+// deployment runs it — the same arrangement the poll's suite uses, and for the
+// same reason.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/pkg/extension"
+)
+
+// sendingProvider serves the two calls the transport makes: `me`, which is the
+// liveness dry run, and the channel message post.
+type sendingProvider struct {
+	// unauthorized turns every call into a 401, which is how a revoked token
+	// presents — the one refusal this unit treats as permanent.
+	unauthorized bool
+	// unavailable is the other kind: the provider is there and cannot answer.
+	unavailable bool
+	// sentID is the provider's own id for the accepted message, empty for a
+	// provider that returns none.
+	sentID string
+
+	// seen records where the message went and what it said.
+	seenPath string
+	seenBody map[string]string
+	seenAuth string
+	// seenResolve is which account the send asked the provider to resolve a
+	// conversation for.
+	seenResolve struct {
+		UserIDs []string `json:"user_ids"`
+	}
+}
+
+func (p *sendingProvider) dial(t *testing.T) clientFactory {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(p.serve))
+	t.Cleanup(server.Close)
+	return func(_, token string) (*client, error) {
+		base, err := url.Parse(server.URL)
+		if err != nil {
+			return nil, err
+		}
+		return &client{base: base, token: token, http: server.Client()}, nil
+	}
+}
+
+func (p *sendingProvider) serve(w http.ResponseWriter, r *http.Request) {
+	switch {
+	case p.unauthorized:
+		w.WriteHeader(http.StatusUnauthorized)
+	case p.unavailable:
+		w.WriteHeader(http.StatusBadGateway)
+	case r.URL.Path == "/api/dms/with-users":
+		// The account the send was given, resolved to the conversation it
+		// addresses. A group DM is served alongside on purpose: the resolve must
+		// pick the 1:1, or a private reply lands in front of a room.
+		if err := json.NewDecoder(r.Body).Decode(&p.seenResolve); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"channels":[
+			{"slug":"G-group","type":"group_dm"},
+			{"slug":"G-1c7u1r29","type":"dm"}]}`))
+	case r.Method == http.MethodPost:
+		p.seenPath = r.URL.Path
+		p.seenAuth = r.Header.Get("Authorization")
+		if err := json.NewDecoder(r.Body).Decode(&p.seenBody); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"` + p.sentID + `"}`))
+	default:
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"provider-member","workspace_id":"ws-7","email":"member@installation.test"}`))
+	}
+}
+
+// connectedMember is a Runtime holding one member's connection and their
+// deposited token — the state a send actually runs against.
+func connectedMember(t *testing.T) *fakeRuntime {
+	t.Helper()
+	rt := newRuntime().unattended()
+	rt.tx.singleRows = [][]any{
+		connectionRow("11111111-1111-4111-8111-111111111111", callerUserID, testBaseURL, statusConnected, 0, 0),
+	}
+	if err := rt.secrets.PutUser(context.Background(), extension.UserID(callerUserID), tokenKey, []byte("pat_member")); err != nil {
+		t.Fatalf("depositing the member's token: %v", err)
+	}
+	return rt
+}
+
+func anOutboundMessage() extension.OutboundMessage {
+	return extension.OutboundMessage{
+		Member: extension.UserID(callerUserID),
+		Recipient: extension.ChannelIdentity{
+			Provider: provider, ChannelUserID: "sender-1",
+		},
+		Body:           "the reply a rep wrote",
+		IdempotencyKey: "delivery-1",
+		Attempt:        1,
+	}
+}
+
+// A message leaves on the MEMBER's own credential, into the conversation it was
+// read from — and both halves are the whole point of this seam. A send under
+// somebody else's token would transmit as a colleague the recipient never wrote
+// to, and a send to a resolved-elsewhere destination would open a second
+// conversation beside the one on the screen.
+func TestASendLeavesOnTheMembersOwnCredentialIntoTheirConversation(t *testing.T) {
+	remote := &sendingProvider{sentID: "provider-42"}
+	rt := connectedMember(t)
+
+	receipt, err := sendVia(context.Background(), rt, anOutboundMessage(), remote.dial(t))
+	if err != nil {
+		t.Fatalf("send: %v", err)
+	}
+	switch {
+	case len(remote.seenResolve.UserIDs) != 1 || remote.seenResolve.UserIDs[0] != "sender-1":
+		t.Errorf("resolved a conversation for %v, want the recipient's own account id — that binding is the person", remote.seenResolve.UserIDs)
+	case remote.seenPath != "/api/channels/G-1c7u1r29/messages":
+		t.Errorf("posted to %q, want the 1:1 conversation resolved from the account — the group DM served beside it would put a private reply in front of a room", remote.seenPath)
+	case remote.seenBody["content"] != "the reply a rep wrote":
+		t.Errorf("body = %q, want the rep's own words", remote.seenBody["content"])
+	case remote.seenAuth != "Bearer pat_member":
+		t.Errorf("Authorization = %q, want the member's own deposited token", remote.seenAuth)
+	case receipt.ProviderMessageID != "provider-42":
+		t.Errorf("receipt = %q, want the provider's id — it is what makes a later reply anchorable", receipt.ProviderMessageID)
+	}
+}
+
+// A provider that accepts the message and returns no id is a SUCCESS with an
+// empty receipt. The message is gone either way, and reporting a failure would
+// have the core retry a delivery the recipient already has.
+func TestAnAcceptedSendWithNoProviderIDIsStillASend(t *testing.T) {
+	rt := connectedMember(t)
+
+	receipt, err := sendVia(context.Background(), rt, anOutboundMessage(), (&sendingProvider{}).dial(t))
+	if err != nil {
+		t.Fatalf("send: %v", err)
+	}
+	if receipt.ProviderMessageID != "" {
+		t.Errorf("receipt = %q, want an empty one rather than an invented id that anchors nothing", receipt.ProviderMessageID)
+	}
+}
+
+// A revoked credential is the ONE permanent refusal, and it is reported as
+// ErrForbidden so the core can tell it from a provider that would not answer.
+// Everything else stays transient: parking a message that would have sent is
+// recoverable by a human, and re-sending one that already arrived is not.
+func TestASendClassifiesARevokedCredentialAndNothingElse(t *testing.T) {
+	for name, tc := range map[string]struct {
+		remote    *sendingProvider
+		permanent bool
+	}{
+		"a revoked token is permanent":         {remote: &sendingProvider{unauthorized: true}, permanent: true},
+		"an unreachable provider is transient": {remote: &sendingProvider{unavailable: true}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			rt := connectedMember(t)
+
+			_, err := sendVia(context.Background(), rt, anOutboundMessage(), tc.remote.dial(t))
+
+			if err == nil {
+				t.Fatal("the send reported success against a provider that refused it")
+			}
+			if got := errors.Is(err, extension.ErrForbidden); got != tc.permanent {
+				t.Errorf("ErrForbidden = %v, want %v — got %v", got, tc.permanent, err)
+			}
+		})
+	}
+}
+
+// A POST whose ANSWER never came back is reported as an unknown outcome, and
+// this is the finding the whole class exists for.
+//
+// The core retries every refusal it is not told is unanswerable, and this
+// provider offers no idempotency key and no prior-send lookup — so a lost
+// response reported as an ordinary transport failure delivers the rep's message
+// twice, with nothing in the system able to detect it. The delivery must stop
+// with the uncertainty on the record instead.
+//
+// The connection is closed mid-request rather than refused, because that is the
+// shape being tested: the request went OUT.
+func TestALostAnswerToTheSendIsAnUnknownOutcome(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/channels/G-1c7u1r29/messages" {
+			// The liveness dry run and the conversation resolve both answer
+			// normally: what is under test is the POST that transmits, and a
+			// pre-flight that failed instead would prove the opposite case.
+			w.Header().Set("Content-Type", "application/json")
+			if r.URL.Path == "/api/dms/with-users" {
+				_, _ = w.Write([]byte(`{"channels":[{"slug":"G-1c7u1r29","type":"dm"}]}`))
+				return
+			}
+			_, _ = w.Write([]byte(`{"id":"provider-member","workspace_id":"ws-7","email":"member@installation.test"}`))
+			return
+		}
+		// The message post: hijack and drop the connection, so the request is
+		// delivered and no answer ever is.
+		conn, _, err := w.(http.Hijacker).Hijack()
+		if err != nil {
+			t.Errorf("hijacking the connection: %v", err)
+			return
+		}
+		//craft:ignore swallowed-errors dropping the connection IS the test; a close error here would mean the drop happened twice, which is the same fact
+		_ = conn.Close()
+	}))
+	defer server.Close()
+	dial := func(_, token string) (*client, error) {
+		base, err := url.Parse(server.URL)
+		if err != nil {
+			return nil, err
+		}
+		return &client{base: base, token: token, http: server.Client()}, nil
+	}
+
+	_, err := sendVia(context.Background(), connectedMember(t), anOutboundMessage(), dial)
+
+	if !errors.Is(err, extension.ErrSendOutcomeUnknown) {
+		t.Fatalf("send → %v, want extension.ErrSendOutcomeUnknown; retried, this message arrives twice and nothing can tell", err)
+	}
+}
+
+// The mirror, and it is what keeps the class from swallowing everything: a
+// failure BEFORE the POST transmitted nothing, so it must stay retryable. The
+// conversation resolve is the case in hand — it is a read.
+func TestAFailureBeforeTheSendIsNotAnUnknownOutcome(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/dms/with-users" {
+			conn, _, err := w.(http.Hijacker).Hijack()
+			if err != nil {
+				t.Errorf("hijacking the connection: %v", err)
+				return
+			}
+			//craft:ignore swallowed-errors dropping the connection IS the test — the request went out and no answer comes back; a close error is that same fact reported twice
+			_ = conn.Close()
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"provider-member","workspace_id":"ws-7","email":"member@installation.test"}`))
+	}))
+	defer server.Close()
+	dial := func(_, token string) (*client, error) {
+		base, err := url.Parse(server.URL)
+		if err != nil {
+			return nil, err
+		}
+		return &client{base: base, token: token, http: server.Client()}, nil
+	}
+
+	_, err := sendVia(context.Background(), connectedMember(t), anOutboundMessage(), dial)
+
+	if err == nil {
+		t.Fatal("a send whose recipient could not be resolved reported success")
+	}
+	if errors.Is(err, extension.ErrSendOutcomeUnknown) {
+		t.Errorf("a failure that transmitted nothing was reported as an unknown outcome (%v); the delivery would stop with a message a retry would have sent", err)
+	}
+}
+
+// A member with no connection cannot be sent for, and the refusal says which
+// fact it is: ErrNotFound distinguishes "this member disconnected" from "the
+// provider would not answer", which the core turns into a park rather than a
+// retry.
+func TestASendForAMemberWithNoConnectionIsNotFound(t *testing.T) {
+	rt := newRuntime().unattended()
+	rt.tx.noRows = map[int]bool{1: true}
+
+	_, err := sendVia(context.Background(), rt, anOutboundMessage(), (&sendingProvider{}).dial(t))
+
+	if !errors.Is(err, extension.ErrNotFound) {
+		t.Fatalf("send → %v, want extension.ErrNotFound for a member who has no connection", err)
+	}
+}
+
+// Liveness is the answer the core needs BEFORE it hands over a message, and the
+// three cases are told apart on purpose: a confirmed no parks the delivery
+// where a human can see it, and an "I could not tell" is retried. Collapsing
+// them either strands a deliverable message or re-sends a refused one.
+func TestLivenessAnswersConfirmedNoAndUnknownDifferently(t *testing.T) {
+	t.Run("a usable connection", func(t *testing.T) {
+		live, err := liveVia(context.Background(), connectedMember(t),
+			extension.UserID(callerUserID), (&sendingProvider{}).dial(t))
+		if err != nil || !live {
+			t.Fatalf("live = %v, %v; want true with no error", live, err)
+		}
+	})
+	t.Run("a revoked token is a confirmed no", func(t *testing.T) {
+		live, err := liveVia(context.Background(), connectedMember(t),
+			extension.UserID(callerUserID), (&sendingProvider{unauthorized: true}).dial(t))
+		if err != nil {
+			t.Fatalf("a revoked token answered an error (%v); it is a fact, and the delivery must park rather than retry", err)
+		}
+		if live {
+			t.Error("a revoked token reported the connection as usable")
+		}
+	})
+	t.Run("a member who disconnected is a confirmed no", func(t *testing.T) {
+		rt := newRuntime().unattended()
+		rt.tx.noRows = map[int]bool{1: true}
+		live, err := liveVia(context.Background(), rt, extension.UserID(callerUserID), (&sendingProvider{}).dial(t))
+		if err != nil {
+			t.Fatalf("no connection answered an error (%v); there is nothing to retry into", err)
+		}
+		if live {
+			t.Error("a member with no connection reported the connection as usable")
+		}
+	})
+	t.Run("a provider that could not answer is not a no", func(t *testing.T) {
+		live, err := liveVia(context.Background(), connectedMember(t),
+			extension.UserID(callerUserID), (&sendingProvider{unavailable: true}).dial(t))
+		if err == nil {
+			t.Fatal("an unreachable provider answered a verdict; parking on one destroys a send nothing is wrong with")
+		}
+		if live {
+			t.Error("an unreachable provider reported the connection as usable")
+		}
+	})
+}


### PR DESCRIPTION
## What

An extension unit can now supply a **real messaging transport**: declare a channel, capture a message on it, and have a rep's reply leave through it — on the member's own credential, through the product's ordinary reply path.

SP5 slice 2 (ADR-0107/A158). Slices 1a/1b/1c are merged (#1293, #1332, #1354); this completes the arc.

## The shape, because it is the decision worth reading

**A unit never sends. It DECLARES a transport and the core calls it.**

```
timeline reply box
  → activities.Store.SendMessage      (auth, consent, recipient from the conversation's links)
  → StageChannelTx
  → comms Dispatcher
  → commsResolver.ResolveChannel(member, provider)
  → the unit's Channel.Send
```

So the extension tier's outbound refusals stand untouched — a unit still may not spend the outbound cap from a tool or a job tick. What changed is that the human staged the message, the seat gate re-read them, and the core hands the unit a message to carry. That is the confirm-first staging the served surfaces could not do for themselves.

There is deliberately **no send verb and no send box** on the extension screen. `commschannel.go` already named this gap ("a unit-supplied provider's own resolve path… out of scope for this change"); this PR is that scope.

## What it took

- **`extension.Channel{Provider, Send, Live}`** on the published surface. `Live` is REQUIRED whenever `Send` is set — a transport that can transmit and cannot say whether it still may leaves the core guessing at the one moment guessing is unrecoverable. A nil `Send` is the documented capture-only case.
- **The reconcile registers unit transports** as their own registry rows (`transport='unit'`, `credential_model='per_member'`) and puts every sendable one into the set `SendMessage`'s pre-flight reads — without which a unit channel would register, publish, capture, and park every reply under "this installation cannot send on that".
- **The core-collision check lands in the reconcile**, where both sets exist. A unit shadowing a core transport fails the boot.
- **`ResolveChannel` branches** on whether a unit supplies the provider, and asks the unit's `Live` BEFORE handing over a message. A member who disconnected parks where a human can see it; a provider that could not answer is retried.
- **The blanket "a unit may not file a message" refusal becomes a bounded permission** — a unit may name a transport it DECLARED and no other, at both write doors. The other direction is refused too: a non-message naming a transport is a note the reply path would answer on.
- **dispact-connector** files `kind=message` on its own transport and binds the sender's account id.

## What the review round found — the value of the round

Three review passes (two Fable-side, one Codex) plus a parallel session reading the design against the branch. Each found something the gates could not see:

| Finding | Why it mattered |
|---|---|
| **A unit could seize `whatsapp`** | The collision check compared against composed *senders* (`{telegram}`), not the registry's reserved core rows. `whatsapp` is registered by migration with no Go connector behind it, so a unit declaring it passed, the upsert re-pointed the core row, and every hand-logged WhatsApp conversation became one the unit transmits. Fixed twice: the reserved set is read from `channel_provider WHERE transport='core'` inside the write transaction, AND the upsert carries `WHERE channel_provider.transport = EXCLUDED.transport` so the write itself cannot change a supplier. |
| **A unit could not report an unknown send outcome** | The channel seam marks a transmission in flight BEFORE the call and treats every error that is not `ErrSendOutcomeUnknown` as proof nothing went out. A POST whose answer was lost therefore delivered the rep's message **twice**. `extension.ErrSendOutcomeUnknown` now exists and is mapped. |
| **dispact bound a conversation id where a person belongs** | The core keys the person on `(provider, channel_user_id)`; that row is what an erasure suppresses. The same colleague DM-ing two members became two people, and an erasure covered one chat. Now binds the sender's account and resolves the conversation at send time. |
| **The request-time pre-flight refused every unit send** | `SendCapable` read `channel_connection` — the workspace-bot table a unit never writes. A rep would have been told at the composer to have an admin bind a bot with nothing to do with the transport. DESIGN-SP5 §8.1 warns about exactly this; the plan missed it. |

Plus two the published surface owed rather than the code: `Record.validateAddresses` now accepts an empty set whenever the counterparty names no address (§11.3 — a chat message has none anywhere in it), and the published `Counterparty` now refuses being named BOTH by an address and by a channel account, which the core has always refused and the surface let through as an unattributable failure.

## Proof

- `make check-backend` — exit 0
- `make craft-static` — 0 blocker / 0 major / 0 minor across all three roots
- `make test-integration` — OK, **0 skips**
- **New-code coverage: 89.4%** (449/502 changed statement lines), measured against the merge-base
- No prompt, corpus or tool-schema file is touched, so no aicert can be staled by this diff

## Filed rather than fixed

- #1366 — the unit reconcile rides the keyvault-gated capture registry
- #1367 — unit-authored message bodies inherit the statutory retention floor, with nothing bounding volume

## Follow-up already claimed

The Zalo OA connector is being built on this seam by a parallel session. `credential_model` derives from the unit's declaration in their follow-up, with a real second caller to justify it.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Units can now declare a real messaging transport and carry replies over it on the member’s credential via the normal reply path. Previously, units could only capture; now a rep’s reply on a captured conversation can leave through the unit-declared provider, while tools/jobs still cannot send.

- Adds `extension.Channel{Provider, Send, Live}`; `Live` is required when `Send` is set; the manifest now includes `channels`.
- Reconcile registers unit transports in `channel_provider` (`transport='unit'`, `credential_model='per_member'`), includes sendable ones in send preflight, and blocks collisions with core transports.
- Channel resolution branches for unit providers and calls `Live` before send; disconnected members park; “could not answer” is retried; unknown send outcomes are mapped.
- Composer preflight asks the unit path first, avoiding `channel_connection` checks that don’t apply to unit transports.
- Units may name only transports they declared; non-message records naming a transport are refused.
- Published surface grows `ActivityKindMessage`, `ChannelProvider`, and `Counterparty.ChannelIdentity`; address/identity exclusivity is enforced.
- `extensions/dispact-connector` implements send + live checks, files `kind=message` on `dispact`, binds sender account, and reports unknown outcomes.

**Rollout notes**
- Units that declare `Channel.Send` must implement `Channel.Live`.
- Provider names use the `channel_provider` grammar (snake_case) and appear in the manifest’s `channels`.
- No behavior change to tools/jobs: outbound remains disallowed outside human-staged replies.

<sup>Written for commit 21d77ac0f45698ff7ad6afe1171b6ba5fa7460a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1368?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

