### PR TITLE
fix(identity): re-asserting a record grant updates it, as the contract says

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -8169,8 +8169,14 @@ paths:
         Grants `read` or `write` on a single record to a user or team otherwise out of their own/team/all
         scope. Enforced by widening BOTH the application visibility WHERE clause AND the RLS backstop
         policy (`data-model §1.3c/§2.5`). Idempotent on `(record_type, record_id, subject_type, subject_id)` —
-        re-asserting upgrades/downgrades `access` and resets `expires_at`. A grant can never exceed the
-        granting principal's own access (scope-intersection). Audited (`action: record_share`). Bounded:
+        a re-assert RESTATES the grant rather than amending it: `access`, `expires_at`, `reason` and
+        `granted_by` all take the values of the new request, so a field the caller omits is cleared and
+        accountability moves to the re-asserting principal. `id` and `created_at` do not move — it is the
+        same share, not a new one. A grant can never exceed the granting principal's own access
+        (scope-intersection), and a grant is not itself a licence to share: administering a record's
+        grants requires that record in the caller's OWN scope (owner/team/all), because a caller whose
+        only claim to it is a share would otherwise be exercising the grant-of-grant delegation this
+        operation excludes. Audited (`action: record_share`). Bounded:
         flat explicit grants only — no sharing hierarchies, criteria-rules, or grant-of-grant delegation.
 
         The seat ceiling binds the RECIPIENT as well (AAD-AC-4): a `write` grant to a user on a `read`

--- a/backend/internal/compose/integration/grants_integration_test.go
+++ b/backend/internal/compose/integration/grants_integration_test.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 
@@ -97,14 +98,6 @@ func TestRecordGrantHTTPLifecycle(t *testing.T) {
 	}, nil, &grant); status != http.StatusCreated {
 		t.Fatalf("create grant → %d", status)
 	}
-	// Duplicate share → 409.
-	if status := e.Call(t, "POST", "/v1/record-grants", apptest.AnyMap{
-		"record_type": "person", "record_id": e.personID,
-		"subject_type": "user", "subject_id": admin.User.ID,
-		"access": "read",
-	}, nil, nil); status != http.StatusConflict {
-		t.Fatalf("duplicate grant → %d, want 409", status)
-	}
 
 	var listed struct {
 		Data []struct {
@@ -127,4 +120,139 @@ func TestRecordGrantHTTPLifecycle(t *testing.T) {
 	if shares != 1 || unshares != 1 {
 		t.Fatalf("share audit trail: %d/%d, want 1/1", shares, unshares)
 	}
+}
+
+// Re-asserting a grant is the contract's own word for it: `createRecordGrant`
+// is "Idempotent on (record_type, record_id, subject_type, subject_id) —
+// re-asserting upgrades/downgrades access and resets expires_at", and 201 is
+// documented as "Grant created (or updated)". The natural key carries the
+// identity, so the second call has to reach the SAME row rather than mint a
+// second one or refuse — asserting the status alone would pass against an
+// insert that quietly duplicated the grant.
+func TestReAssertingAGrantUpdatesTheSameRow(t *testing.T) {
+	e := setupRelationships(t)
+	subject := meUserID(t, e)
+
+	assert := func(body apptest.AnyMap) (int, grantBody) {
+		var got grantBody
+		body["record_type"], body["record_id"] = "person", e.personID
+		body["subject_type"], body["subject_id"] = "user", subject
+		return e.Call(t, "POST", "/v1/record-grants", body, nil, &got), got
+	}
+
+	expiry := time.Now().Add(72 * time.Hour).UTC().Truncate(time.Second)
+	status, first := assert(apptest.AnyMap{
+		"access": "read", "reason": "quarter review", "expires_at": expiry.Format(time.RFC3339),
+	})
+	if status != http.StatusCreated {
+		t.Fatalf("create grant → %d", status)
+	}
+	if first.ExpiresAt == nil {
+		t.Fatal("the created grant dropped its expiry, so the reset below would prove nothing")
+	}
+
+	// An upgrade: same tuple, wider access, no expiry and no reason. Every
+	// field the contract names moves, and `expires_at` moving to NULL is the
+	// half a COALESCE-shaped upsert would silently refuse to do.
+	status, second := assert(apptest.AnyMap{"access": "write"})
+	if status != http.StatusCreated {
+		t.Fatalf("re-assert → %d, want 201 (the contract declares no 409 for this operation)", status)
+	}
+	if second.ID != first.ID {
+		t.Fatalf("re-assert minted a new grant %s, want the original %s", second.ID, first.ID)
+	}
+	if !second.CreatedAt.Equal(first.CreatedAt) {
+		t.Errorf("created_at moved %s → %s; a re-assert is not a new sharing relationship",
+			first.CreatedAt, second.CreatedAt)
+	}
+	if second.Access != "write" {
+		t.Errorf("access after upgrade = %q, want write", second.Access)
+	}
+	if second.ExpiresAt != nil {
+		t.Errorf("expires_at = %v after a re-assert that supplied none; the contract says it resets", *second.ExpiresAt)
+	}
+	if second.Reason != nil {
+		t.Errorf("reason = %q survived a re-assert that supplied none", *second.Reason)
+	}
+
+	// And back down again: the contract says upgrades AND downgrades.
+	if status, third := assert(apptest.AnyMap{"access": "read"}); status != http.StatusCreated || third.Access != "read" {
+		t.Fatalf("downgrade → %d %q, want 201 read", status, third.Access)
+	}
+
+	// One row throughout — the whole point of the natural key.
+	var rows int
+	if err := e.Owner.QueryRow(t.Context(),
+		`SELECT count(*) FROM record_grant WHERE record_id = $1 AND subject_id = $2`,
+		e.personID, subject).Scan(&rows); err != nil {
+		t.Fatal(err)
+	}
+	if rows != 1 {
+		t.Fatalf("%d grant rows for one (record, subject) pair, want 1", rows)
+	}
+}
+
+// Every assertion is audited, and a re-assert audits what it DISPLACED.
+// A before-image of nil on an update reads as a first-ever share, which is
+// the one thing the record timeline must not say about a downgrade.
+func TestReAssertingAGrantAuditsWhatItDisplaced(t *testing.T) {
+	e := setupRelationships(t)
+	subject := meUserID(t, e)
+	share := func(access string) {
+		t.Helper()
+		if status := e.Call(t, "POST", "/v1/record-grants", apptest.AnyMap{
+			"record_type": "person", "record_id": e.personID,
+			"subject_type": "user", "subject_id": subject, "access": access,
+		}, nil, nil); status != http.StatusCreated {
+			t.Fatalf("share %s → %d", access, status)
+		}
+	}
+	share("write")
+	share("read")
+
+	// Counted rather than ordered: both rows are written by separate
+	// transactions milliseconds apart, and a test that leans on their
+	// timestamps to tell them apart is a flake waiting for a fast machine.
+	// The images identify themselves.
+	var firstShares, downgrades, total int
+	if err := e.Owner.QueryRow(t.Context(), `
+		SELECT count(*),
+		       count(*) FILTER (WHERE before IS NULL AND after ->> 'access' = 'write'),
+		       count(*) FILTER (WHERE before ->> 'access' = 'write' AND after ->> 'access' = 'read')
+		  FROM audit_log WHERE action = 'record_share'`).
+		Scan(&total, &firstShares, &downgrades); err != nil {
+		t.Fatal(err)
+	}
+	if total != 2 {
+		t.Fatalf("%d record_share rows, want 2 — every assertion is audited, re-asserts included", total)
+	}
+	if firstShares != 1 {
+		t.Errorf("%d first-share rows (before IS NULL, after write), want 1", firstShares)
+	}
+	if downgrades != 1 {
+		t.Errorf("%d downgrade rows (before write → after read), want 1; a re-assert that audits before=NULL reads as a first share", downgrades)
+	}
+}
+
+type grantBody struct {
+	ID        string     `json:"id"`
+	Access    string     `json:"access"`
+	Reason    *string    `json:"reason"`
+	ExpiresAt *time.Time `json:"expires_at"`
+	CreatedAt time.Time  `json:"created_at"`
+}
+
+// meUserID reads the session's own user id, which is the only subject these
+// tests can share with: the bootstrap seeds one human.
+func meUserID(t *testing.T, e *relEnv) string {
+	t.Helper()
+	var me struct {
+		User struct {
+			ID string `json:"id"`
+		} `json:"user"`
+	}
+	if status := e.Call(t, "GET", "/v1/me", nil, nil, &me); status != http.StatusOK {
+		t.Fatalf("me → %d", status)
+	}
+	return me.User.ID
 }

--- a/backend/internal/compose/integration/grants_integration_test.go
+++ b/backend/internal/compose/integration/grants_integration_test.go
@@ -12,6 +12,7 @@ package integration
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"testing"
 	"time"
@@ -19,10 +20,14 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
+	"github.com/gradionhq/margince/backend/internal/modules/identity"
 	"github.com/gradionhq/margince/backend/internal/modules/people"
 	"github.com/gradionhq/margince/backend/internal/modules/search"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
 
 // The widening itself is a platform/auth property, so it is asserted at
@@ -69,6 +74,112 @@ func TestRecordGrantWidensRowScopeAndRevokes(t *testing.T) {
 	}
 }
 
+// Scope-intersection (crm.yaml: "A grant can never exceed the granting
+// principal's own access"). The visibility arm counts every live grant
+// regardless of its access, because write satisfies read — so a `read` share
+// is enough to pass EnsureLinkTarget, and without a separate probe the person
+// it was shared with could hand on write: to a colleague, or by re-asserting
+// their own grant onto themselves.
+//
+// The re-assert half is what makes this urgent rather than theoretical. A
+// first `write` grant to a subject who already holds `read` used to be refused
+// by the unique constraint; the upsert accepts it, so the only thing standing
+// between a read share and a write one is this rule.
+func TestAShareIsNotALicenceToReShare(t *testing.T) {
+	e := SetupSearch(t)
+	// Owned by rep3 in team2, so rep1 in team1 has no path to it but a share.
+	foreign := e.Seed(t, `INSERT INTO person (id, workspace_id, full_name, owner_id, source, captured_by) VALUES ($1, $2, 'Out Of Scope', $3, 'manual', 'human:x')`, e.Rep3)
+	colleague := e.Seed(t, `INSERT INTO app_user (id, workspace_id, email, display_name) VALUES ($1, $2, 'colleague@search.test', 'Colleague')`)
+	svc := identity.NewService(e.Pool)
+	expiry := time.Now().Add(time.Hour).UTC().Truncate(time.Second)
+
+	share := func(as context.Context, in identity.CreateGrantInput) error {
+		in.RecordType, in.RecordID, in.SubjectType = "person", foreign, "user"
+		_, err := svc.CreateRecordGrant(as, in)
+		return err
+	}
+	// The owner shares through the real writer — a hand-inserted row would set
+	// a scene production cannot reach.
+	owner := grantingPrincipal(e, e.Rep3, principal.RowScopeOwn, nil)
+	// A team-scoped rep who may update people: the ordinary shape of a
+	// colleague, and the only thing that ever kept them off a record outside
+	// their team is the row scope, which the share below widens.
+	rep := grantingPrincipal(e, e.Rep1, principal.RowScopeTeam, []ids.UUID{e.Team1})
+
+	if err := share(owner, identity.CreateGrantInput{
+		SubjectID: e.Rep1, Access: "read", ExpiresAt: &expiry,
+	}); err != nil {
+		t.Fatalf("owner shares read, time-boxed → %v", err)
+	}
+
+	// Rep1 can now READ the record. Three things they must still not do, and
+	// the third is the one the upsert would otherwise have handed them.
+	for _, tc := range []struct {
+		name string
+		in   identity.CreateGrantInput
+	}{
+		{"pass the record on to a colleague", identity.CreateGrantInput{SubjectID: colleague, Access: "read"}},
+		{"widen their own share to write", identity.CreateGrantInput{SubjectID: e.Rep1, Access: "write"}},
+		{"clear the expiry that time-boxed it", identity.CreateGrantInput{SubjectID: e.Rep1, Access: "read"}},
+	} {
+		if err := share(rep, tc.in); !errors.Is(err, apperrors.ErrPermissionDenied) {
+			t.Errorf("%s → %v, want permission-denied", tc.name, err)
+		}
+	}
+
+	// The allow arm, without which every assertion above would pass against a
+	// probe that refused everyone: the OWNER may still administer the share,
+	// including clearing the expiry they set.
+	if err := share(owner, identity.CreateGrantInput{SubjectID: e.Rep1, Access: "read"}); err != nil {
+		t.Fatalf("owner re-asserts their own share → %v", err)
+	}
+
+	// The time box survived every refusal and yielded only to the owner. Read
+	// back, because a 403 raised after the upsert ran is indistinguishable from
+	// one raised instead of it.
+	var access string
+	var expiresAt *time.Time
+	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		return tx.QueryRow(context.Background(),
+			`SELECT access, expires_at FROM record_grant WHERE record_id = $1 AND subject_id = $2`,
+			foreign, e.Rep1).Scan(&access, &expiresAt)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if access != "read" {
+		t.Errorf("the share reads %q after three refused widenings, want read", access)
+	}
+	if expiresAt != nil {
+		t.Errorf("expires_at = %v after the owner cleared it, want null", expiresAt)
+	}
+	var colleagueGrants int
+	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		return tx.QueryRow(context.Background(),
+			`SELECT count(*) FROM record_grant WHERE record_id = $1 AND subject_id = $2`,
+			foreign, colleague).Scan(&colleagueGrants)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if colleagueGrants != 0 {
+		t.Errorf("%d grants reached a colleague the sharer never named", colleagueGrants)
+	}
+}
+
+// grantingPrincipal mints a human who may read and update people at one row
+// scope — the two permissions sharing a record needs, and nothing else, so a
+// refusal in these tests can only come from the rule under test.
+func grantingPrincipal(e *SearchEnv, user ids.UUID, scope principal.RowScope, teams []ids.UUID) context.Context {
+	ctx := principal.WithWorkspaceID(context.Background(), e.WS)
+	return principal.WithActor(ctx, principal.Principal{
+		Type: principal.PrincipalHuman, ID: "human:" + user.String(), UserID: user,
+		TeamIDs: teams,
+		Permissions: principal.Permissions{
+			Objects:  map[string]principal.ObjectGrant{"person": {Read: true, Update: true}},
+			RowScope: scope,
+		},
+	})
+}
+
 func TestRecordGrantHTTPLifecycle(t *testing.T) {
 	e := setupRelationships(t)
 
@@ -83,17 +194,10 @@ func TestRecordGrantHTTPLifecycle(t *testing.T) {
 	}, nil, nil); status != http.StatusNotFound {
 		t.Fatalf("grant to missing subject → %d, want 404", status)
 	}
-	var admin struct {
-		User struct {
-			ID string `json:"id"`
-		} `json:"user"`
-	}
-	if status := e.Call(t, "GET", "/v1/me", nil, nil, &admin); status != http.StatusOK {
-		t.Fatalf("me → %d", status)
-	}
+	subject := meUserID(t, e)
 	if status := e.Call(t, "POST", "/v1/record-grants", apptest.AnyMap{
 		"record_type": "person", "record_id": e.personID,
-		"subject_type": "user", "subject_id": admin.User.ID,
+		"subject_type": "user", "subject_id": subject,
 		"access": "write", "reason": "deal desk assist",
 	}, nil, &grant); status != http.StatusCreated {
 		t.Fatalf("create grant → %d", status)
@@ -147,8 +251,9 @@ func TestReAssertingAGrantUpdatesTheSameRow(t *testing.T) {
 	if status != http.StatusCreated {
 		t.Fatalf("create grant → %d", status)
 	}
-	if first.ExpiresAt == nil {
-		t.Fatal("the created grant dropped its expiry, so the reset below would prove nothing")
+	if first.ExpiresAt == nil || !first.ExpiresAt.Equal(expiry) {
+		t.Fatalf("created grant's expiry = %v, want %v — the reset below proves nothing without it",
+			first.ExpiresAt, expiry)
 	}
 
 	// An upgrade: same tuple, wider access, no expiry and no reason. Every

--- a/backend/internal/compose/integration/seatmatrix_integration_test.go
+++ b/backend/internal/compose/integration/seatmatrix_integration_test.go
@@ -216,6 +216,51 @@ func TestAWriteGrantIsRefusedToAReadSeat(t *testing.T) {
 	}
 }
 
+// The ceiling holds on the SECOND call as hard as on the first, and the test
+// above cannot say so: it only ever asks once.
+//
+// Sharing is idempotent on (record_type, record_id, subject_type, subject_id),
+// so a re-assert is a real write where the unique constraint used to refuse one
+// outright. The route around the refusal is therefore to ask twice — share
+// `read`, which a read seat may hold because it is the authority its licence
+// already carries, then re-assert the same tuple as `write`. Any narrowing of
+// the ceiling to new rows ("the grant exists, this is only an update") opens
+// it, which is what this asserts and what the first-call test passes straight
+// through.
+//
+// The stored access is read back as well as the status, because a refusal owes
+// the row no residue whatever order the statements ran in.
+func TestAReAssertCannotWalkAWriteGrantPastTheSeatCeiling(t *testing.T) {
+	e := apptest.SetupApp(t)
+	e.Slug = "seat-grant-reassert"
+	apptest.BootstrapWorkspaceSession(t, e, "Seat Grant Reassert", "seat-reassert@fable.test", "Admin")
+	fixtures := seedSeatFixtures(t, e)
+	readSeatColleague(t, e, fixtures.colleague)
+
+	share := func(access string) (int, string) {
+		return callForCode(t, e, "POST", "/v1/record-grants", apptest.AnyMap{
+			"record_type": "person", "record_id": fixtures.personID,
+			"subject_type": "user", "subject_id": fixtures.colleague, "access": access,
+		})
+	}
+	if status, _ := share("read"); status != http.StatusCreated {
+		t.Fatalf("read grant to a read seat → %d, want 201", status)
+	}
+	if status, code := share("write"); status != http.StatusForbidden || code != "seat_tier_insufficient" {
+		t.Fatalf("re-asserting a read grant as write → %d %q, want 403 seat_tier_insufficient", status, code)
+	}
+
+	var access string
+	if err := e.Owner.QueryRow(t.Context(),
+		`SELECT access FROM record_grant WHERE record_id = $1::uuid AND subject_id = $2::uuid`,
+		fixtures.personID, fixtures.colleague).Scan(&access); err != nil {
+		t.Fatal(err)
+	}
+	if access != "read" {
+		t.Fatalf("the refused re-assert left access = %q, want read — the refusal wrote the grant it was refusing", access)
+	}
+}
+
 // resetSeatFixtures returns the records the matrix acts on to the state
 // seedSeatFixtures left them in — the deal on its birth stage, and no grant
 // on the tuple the share action asserts. Written with the owner connection

--- a/backend/internal/compose/integration/seatmatrix_integration_test.go
+++ b/backend/internal/compose/integration/seatmatrix_integration_test.go
@@ -146,9 +146,9 @@ func TestTheSeatCeilingHoldsForEverySeededRoleAndAction(t *testing.T) {
 				allowed++
 				// The granted leg has to SUCCEED, not merely avoid the
 				// seat code: an action refused for an unrelated reason —
-				// a malformed body, a tuple already granted by the
-				// previous role — would otherwise read as "the ceiling
-				// let it through" while proving nothing about the ceiling.
+				// a malformed body, a record the acting role cannot
+				// reach — would otherwise read as "the ceiling let it
+				// through" while proving nothing about the ceiling.
 				if status >= http.StatusBadRequest {
 					t.Errorf("full seat / role %q / %s → %d %q, but the seeded document grants %s.%s",
 						role.key, action.class, status, code, action.object, action.verb)
@@ -262,10 +262,12 @@ func TestAReAssertCannotWalkAWriteGrantPastTheSeatCeiling(t *testing.T) {
 }
 
 // resetSeatFixtures returns the records the matrix acts on to the state
-// seedSeatFixtures left them in — the deal on its birth stage, and no grant
-// on the tuple the share action asserts. Written with the owner connection
-// because this is fixture bookkeeping between cells, not an operation the
-// matrix is measuring.
+// seedSeatFixtures left them in — the deal on its birth stage, and no grant on
+// the tuple the share action asserts. The grant half no longer decides whether
+// the next cell's share SUCCEEDS, because a re-assert is an upsert; it keeps
+// each cell measuring a first share, so one cell's leftover access cannot be
+// what the next one reads back. Written with the owner connection because this
+// is fixture bookkeeping between cells, not an operation the matrix measures.
 func resetSeatFixtures(t *testing.T, e *apptest.AppEnv, f seatFixtures) {
 	t.Helper()
 	if _, err := e.Owner.Exec(t.Context(),

--- a/backend/internal/modules/capture/freemaildomain.go
+++ b/backend/internal/modules/capture/freemaildomain.go
@@ -199,10 +199,9 @@ func (s *FreemailDomainStore) Add(ctx context.Context, domain, kind string) (Fre
 			// thing, so the trail records decisions rather than clicks.
 			return nil
 		}
-		// `any`: a nil map is not an untyped nil, so declaring this as
-		// map[string]any would store JSON null instead of SQL NULL for a first
-		// classification (see storekit.marshalOrNil).
-		var beforeImage any
+		// Left nil for a first classification: the audit seam renders an absent
+		// image as SQL NULL whichever kind of nil carries it.
+		var beforeImage map[string]any
 		if before != nil {
 			beforeImage = map[string]any{auditKeyDomain: base, auditKeyKind: *before}
 		}

--- a/backend/internal/modules/capture/owndomainstore.go
+++ b/backend/internal/modules/capture/owndomainstore.go
@@ -118,11 +118,9 @@ func (s *OwnDomainStore) Add(ctx context.Context, raw string) (OwnDomain, error)
 	err = s.db.Tx(ctx, func(tx pgx.Tx) error {
 		// The prior state, so the trail distinguishes "an admin registered a new
 		// domain" from "an admin confirmed a candidate a mailbox had seen".
-		// `any`, not map[string]any: storekit.marshalOrNil writes SQL NULL only
-		// for an untyped nil. A nil MAP in an any parameter is not nil, so it
-		// marshals to JSON null and every "there was no prior state" query
-		// (before IS NULL) silently misses the row.
-		var beforeImage any
+		// Left nil when there was none: the audit seam renders an absent image
+		// as SQL NULL whichever kind of nil carries it.
+		var beforeImage map[string]any
 		var priorSource string
 		var priorVerified bool
 		switch err := tx.QueryRow(ctx,

--- a/backend/internal/modules/capture/owndomainstore_integration_test.go
+++ b/backend/internal/modules/capture/owndomainstore_integration_test.go
@@ -243,7 +243,7 @@ func TestARepReadsTheDomainsAndCannotChangeThem(t *testing.T) {
 // from. Both verbs are checked, because either one alters the set.
 //
 // Each verb is asserted on the SIDE it writes, not on "either side matches": a
-// registration names the domain in `after` and leaves `before` as JSON null,
+// registration names the domain in `after` and leaves `before` unset,
 // and a removal names it in `before` and leaves `after` unset. A predicate that
 // accepted either would pass for a row that recorded the wrong direction.
 func TestBothWritesLeaveAnAuditRowNamingTheDomain(t *testing.T) {
@@ -254,9 +254,9 @@ func TestBothWritesLeaveAnAuditRowNamingTheDomain(t *testing.T) {
 		t.Fatalf("Add: %v", err)
 	}
 	// A first registration claims NO prior state, and says so the way every
-	// other audit row does: SQL NULL. It used to store JSON null instead,
-	// because a nil map handed to an `any` parameter is not an untyped nil —
-	// which made this row invisible to the obvious "before IS NULL" query.
+	// other audit row does: SQL NULL. The seam decides that for every writer —
+	// storekit.marshalOrNil answers nil bytes for an absent image whichever
+	// kind of nil carries it — and this asserts the registry gets it.
 	assertOwnDomainAudited(ctx, t, db, ownDomainAuditRow{
 		action: "update", domain: "acme.com",
 		images: "before IS NULL AND after->>'own_email_domain' = $3",

--- a/backend/internal/modules/identity/grants.go
+++ b/backend/internal/modules/identity/grants.go
@@ -174,14 +174,27 @@ func (s *Service) CreateRecordGrant(ctx context.Context, in CreateGrantInput) (g
 		if !subjectExists {
 			return apperrors.ErrNotFound
 		}
-		// The ceiling judges the ASSERTED access, so it binds a re-assert as
-		// hard as a first share. That is a wider job than it used to have: the
-		// unique constraint refused a second call outright, so this only ever
-		// ran on the create path, and the upsert below turns the second call
-		// into a real write. Anything that narrows it to new rows — "the grant
-		// already exists, this is only an update" — hands a read seat the write
-		// grant the first call refused it.
+		// Administering a share is not the same authority as reading the record,
+		// and EnsureLinkTarget above only proves the second: the grant arm
+		// satisfies it, so the person a record was shared WITH passes it. This
+		// is what stops them administering that same share — and it binds a
+		// re-assert exactly as it binds a first share, because the upsert makes
+		// the second call a real write where the unique constraint used to end
+		// it. Narrowing it to new rows would hand the beneficiary of a
+		// time-boxed share the power to clear its expiry.
+		if err := auth.EnsureCanShare(ctx, tx, in.RecordType, in.RecordID); err != nil {
+			return err
+		}
+		// The seat ceiling judges the RECIPIENT, and judges the ASSERTED access,
+		// so it too binds a re-assert as hard as a first share.
 		if err := refuseWriteGrantToReadSeat(ctx, tx, in); err != nil {
+			return err
+		}
+		// The precondition read and the write it feeds must run under one lock:
+		// FOR UPDATE cannot order two callers CREATING this grant at once,
+		// because an absent row locks nothing, and the loser would then audit a
+		// first share over a row it actually displaced.
+		if err := storekit.LockWriteIdentity(ctx, tx, "record_grant", grantIdentity(in)); err != nil {
 			return err
 		}
 		prior, replaced, err := replacedGrant(ctx, tx, in)
@@ -228,15 +241,22 @@ func (s *Service) CreateRecordGrant(ctx context.Context, in CreateGrantInput) (g
 	return out, err
 }
 
+// grantIdentity renders the natural key the contract identifies a grant by —
+// the same four columns the unique constraint and the upsert's conflict target
+// use, so the lock and the row it protects can never key on different things.
+func grantIdentity(in CreateGrantInput) string {
+	return in.RecordType + ":" + in.RecordID.String() + ":" + in.SubjectType + ":" + in.SubjectID.String()
+}
+
 // replacedGrant reads the grant this assertion is about to displace, keyed the
 // way the contract identifies one. `replaced` is false for a tuple never
 // granted before, which is the audit's own distinction between a first share
 // and a re-statement — it is not derivable from the row, because an absent
 // grant and a grant with every field empty are different facts.
 //
-// FOR UPDATE serializes two callers re-asserting the same grant, so each audit
-// pair describes the transition it actually committed rather than one a sibling
-// transaction had already replaced.
+// It reads FOR UPDATE, which holds an existing row against a concurrent
+// re-assert; the caller takes the write-identity lock first, which is what
+// covers the case where there is no row to hold yet.
 func replacedGrant(ctx context.Context, tx pgx.Tx, in CreateGrantInput) (prior grantRow, replaced bool, err error) {
 	prior, err = scanGrant(tx.QueryRow(ctx, "SELECT "+grantColumns+` FROM record_grant
 		WHERE record_type = $1 AND record_id = $2 AND subject_type = $3 AND subject_id = $4
@@ -252,11 +272,14 @@ func replacedGrant(ctx context.Context, tx pgx.Tx, in CreateGrantInput) (prior g
 }
 
 // grantImage renders one audit image of a grant. Before and after share it so
-// the pair diffs to exactly what a re-assert moved.
+// the pair diffs to exactly what a re-assert moved, which means it has to carry
+// every field the upsert can change — `granted_by` included, because a
+// re-assert moves accountability to the caller and the audit row's own actor
+// records only the after side of that.
 func grantImage(g grantRow) map[string]any {
 	return map[string]any{
 		"subject_type": g.SubjectType, "subject_id": g.SubjectID, "access": g.Access,
-		"reason": g.Reason, "expires_at": g.ExpiresAt,
+		"reason": g.Reason, "expires_at": g.ExpiresAt, "granted_by": g.GrantedBy,
 	}
 }
 
@@ -298,8 +321,12 @@ func (s *Service) RevokeRecordGrant(ctx context.Context, id ids.UUID) error {
 		return errors.New("crmauth: only a human revokes shares directly; agents stage through the approval gate")
 	}
 	return s.db.Tx(ctx, func(tx pgx.Tx) error {
+		// FOR UPDATE for the reason the assertion path takes it: this row is
+		// both the thing being deleted and the audit's before image, and a
+		// concurrent re-assert would otherwise let the trail record an access
+		// level that was already displaced by the time the DELETE ran.
 		grant, err := scanGrant(tx.QueryRow(ctx,
-			"SELECT "+grantColumns+" FROM record_grant WHERE id = $1", id))
+			"SELECT "+grantColumns+" FROM record_grant WHERE id = $1 FOR UPDATE", id))
 		if errors.Is(err, pgx.ErrNoRows) {
 			return apperrors.ErrNotFound
 		}
@@ -315,9 +342,11 @@ func (s *Service) RevokeRecordGrant(ctx context.Context, id ids.UUID) error {
 		if _, err := tx.Exec(ctx, `DELETE FROM record_grant WHERE id = $1`, id); err != nil {
 			return err
 		}
-		_, err = storekit.Audit(ctx, tx, "record_unshare", grant.RecordType, grant.RecordID, map[string]any{
-			"subject_type": grant.SubjectType, "subject_id": grant.SubjectID, "access": grant.Access,
-		}, nil)
+		// The same image the assertion path renders, so a record's timeline
+		// carries one shape: a share and an unshare of the same grant differ in
+		// which side is absent, not in which fields they thought worth naming.
+		_, err = storekit.Audit(ctx, tx, "record_unshare",
+			grant.RecordType, grant.RecordID, grantImage(grant), nil)
 		return err
 	})
 }

--- a/backend/internal/modules/identity/grants.go
+++ b/backend/internal/modules/identity/grants.go
@@ -174,30 +174,90 @@ func (s *Service) CreateRecordGrant(ctx context.Context, in CreateGrantInput) (g
 		if !subjectExists {
 			return apperrors.ErrNotFound
 		}
+		// The ceiling judges the ASSERTED access, so it binds a re-assert as
+		// hard as a first share. That is a wider job than it used to have: the
+		// unique constraint refused a second call outright, so this only ever
+		// ran on the create path, and the upsert below turns the second call
+		// into a real write. Anything that narrows it to new rows — "the grant
+		// already exists, this is only an update" — hands a read seat the write
+		// grant the first call refused it.
 		if err := refuseWriteGrantToReadSeat(ctx, tx, in); err != nil {
 			return err
 		}
-		row := tx.QueryRow(ctx, `
+		prior, replaced, err := replacedGrant(ctx, tx, in)
+		if err != nil {
+			return err
+		}
+		var before map[string]any
+		if replaced {
+			before = grantImage(prior)
+		}
+		// A grant is identified by its natural key, not by its id, so a
+		// re-assert restates the SAME row: `expires_at` takes the proposed
+		// value even when that value is NULL (the contract says a re-assert
+		// resets it, and a COALESCE here would make an expiry unclearable), and
+		// `granted_by` moves to the caller, who is accountable for the access
+		// now in force.
+		if out, err = scanGrant(tx.QueryRow(ctx, `
 			INSERT INTO record_grant (workspace_id, record_type, record_id, subject_type, subject_id,
 			                          access, granted_by, reason, expires_at)
 			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid,
 			        $1, $2, $3, $4, $5, $6, $7, $8)
+			ON CONFLICT (record_type, record_id, subject_type, subject_id) DO UPDATE
+			SET access     = EXCLUDED.access,
+			    expires_at = EXCLUDED.expires_at,
+			    reason     = EXCLUDED.reason,
+			    granted_by = EXCLUDED.granted_by,
+			    version    = record_grant.version + 1
 			RETURNING `+grantColumns,
 			in.RecordType, in.RecordID, in.SubjectType, in.SubjectID,
-			in.Access, actor.UserID, in.Reason, in.ExpiresAt)
-		var err error
-		if out, err = scanGrant(row); err != nil {
-			if storekit.IsUniqueViolation(err) {
-				return apperrors.ErrConflict
-			}
-			return err
+			in.Access, actor.UserID, in.Reason, in.ExpiresAt)); err != nil {
+			return fmt.Errorf("upsert record_grant: %w", err)
 		}
-		_, err = storekit.Audit(ctx, tx, "record_share", in.RecordType, in.RecordID, nil, map[string]any{
-			"subject_type": in.SubjectType, "subject_id": in.SubjectID, "access": in.Access,
-		})
-		return err
+		// `record_share` in both directions, downgrades included: the contract
+		// pins the verb, and `record_unshare` belongs to revocation. Which way
+		// the access moved is the image pair's job to say, so both images
+		// render the PERSISTED row through one shape — an image omitting a
+		// field the upsert can change would report nothing moved when it did.
+		if _, err := storekit.Audit(ctx, tx, "record_share",
+			in.RecordType, in.RecordID, before, grantImage(out)); err != nil {
+			return fmt.Errorf("audit record_share: %w", err)
+		}
+		return nil
 	})
 	return out, err
+}
+
+// replacedGrant reads the grant this assertion is about to displace, keyed the
+// way the contract identifies one. `replaced` is false for a tuple never
+// granted before, which is the audit's own distinction between a first share
+// and a re-statement — it is not derivable from the row, because an absent
+// grant and a grant with every field empty are different facts.
+//
+// FOR UPDATE serializes two callers re-asserting the same grant, so each audit
+// pair describes the transition it actually committed rather than one a sibling
+// transaction had already replaced.
+func replacedGrant(ctx context.Context, tx pgx.Tx, in CreateGrantInput) (prior grantRow, replaced bool, err error) {
+	prior, err = scanGrant(tx.QueryRow(ctx, "SELECT "+grantColumns+` FROM record_grant
+		WHERE record_type = $1 AND record_id = $2 AND subject_type = $3 AND subject_id = $4
+		FOR UPDATE`,
+		in.RecordType, in.RecordID, in.SubjectType, in.SubjectID))
+	switch {
+	case errors.Is(err, pgx.ErrNoRows):
+		return grantRow{}, false, nil
+	case err != nil:
+		return grantRow{}, false, fmt.Errorf("read the displaced record_grant: %w", err)
+	}
+	return prior, true, nil
+}
+
+// grantImage renders one audit image of a grant. Before and after share it so
+// the pair diffs to exactly what a re-assert moved.
+func grantImage(g grantRow) map[string]any {
+	return map[string]any{
+		"subject_type": g.SubjectType, "subject_id": g.SubjectID, "access": g.Access,
+		"reason": g.Reason, "expires_at": g.ExpiresAt,
+	}
 }
 
 // refuseWriteGrantToReadSeat holds the receiving half of the seat ceiling

--- a/backend/internal/modules/identity/onboarding.go
+++ b/backend/internal/modules/identity/onboarding.go
@@ -397,10 +397,9 @@ func auditOnboardingState(
 	after OnboardingState,
 ) error {
 	action := "create"
-	// `any`: a nil map is not an untyped nil, so declaring this as
-	// map[string]any would store JSON null instead of SQL NULL on the first
-	// write (see storekit.marshalOrNil).
-	var beforeImage any
+	// Left nil on the first write: the audit seam renders an absent image as
+	// SQL NULL whichever kind of nil carries it.
+	var beforeImage map[string]any
 	if before != nil {
 		action = "update"
 		beforeImage = onboardingAuditImage(*before)

--- a/backend/internal/platform/auth/rowscope.go
+++ b/backend/internal/platform/auth/rowscope.go
@@ -191,6 +191,54 @@ func predicateFor(p principal.Principal, table string, arg func(any) int, captur
 	}
 }
 
+// EnsureCanShare holds the bound the contract puts on `createRecordGrant`:
+// "flat explicit grants only — no sharing hierarchies, criteria-rules, or
+// grant-of-grant delegation." A share received is not a licence to re-share,
+// so the record must sit in the caller's OWN scope — owner, team, or
+// unbounded — and the grant arm that widens every read path is deliberately
+// not consulted here.
+//
+// This is the difference between seeing a record and administering who else
+// may see it. EnsureVisible cannot make it, because a grant satisfies it by
+// design; without a separate probe the person a record was shared WITH could
+// administer that same share — hand it to a colleague, widen its access, or
+// clear the expiry that time-boxed it — all on authority the share itself
+// handed them.
+//
+// Out of scope answers ErrPermissionDenied, not ErrNotFound: the caller has
+// already proven they can see the row, so existence-hiding has nothing left to
+// hide and a not-found would send them looking for a typo.
+func EnsureCanShare(ctx context.Context, tx pgx.Tx, table string, id ids.UUID) error {
+	// The primitive rejects an unknown name itself, like every sibling here:
+	// the record type reaching this comes from a request body, and its caller's
+	// own allowlist is a second line rather than the only one.
+	if !shareableTables[table] {
+		return fmt.Errorf("auth: %q is not a shareable table", table)
+	}
+	p, err := rbacActor(ctx)
+	if err != nil {
+		return err
+	}
+	if Unbounded(p) {
+		return nil
+	}
+	var args []any
+	arg := func(v any) int { args = append(args, v); return len(args) }
+	idPos := arg(id)
+	owner := OwnerPredicate(p, arg)("")
+
+	var permitted bool
+	if err := tx.QueryRow(ctx, fmt.Sprintf(
+		`SELECT EXISTS (SELECT 1 FROM %s WHERE id = $%d AND %s)`, table, idPos, owner),
+		args...).Scan(&permitted); err != nil {
+		return err
+	}
+	if !permitted {
+		return apperrors.ErrPermissionDenied
+	}
+	return nil
+}
+
 // ScopeClause renders the own/team/all row-visibility predicate over an
 // owner_id column (B-EP03.3a). arg registers a query argument and
 // returns its 1-based position, matching the list builders' convention.

--- a/backend/internal/platform/database/storekit/auditimage_test.go
+++ b/backend/internal/platform/database/storekit/auditimage_test.go
@@ -15,11 +15,11 @@ import "testing"
 // a nil map (the shape a store builds an image in), a nil slice, a nil
 // pointer — and each must reach the column as SQL NULL.
 //
-// The nil-map row is the one that has cost this tree twice: capture's
-// own-domain registry stored JSON `null` for a first registration until it was
-// found, and identity's record-grant upsert reproduced it from scratch a
-// module away. Both are call sites of this one function, which is why the rule
-// lives here rather than in either of them.
+// The nil-map row is the one that matters: a store that assembles its image in
+// a `map[string]any` and leaves it nil hands this an interface carrying a
+// typed nil, which reads as present to a bare `v == nil`. The rule lives at
+// the seam rather than in any one writer because every writer spells absence
+// its own way and only the column has to be consistent.
 func TestAnAbsentImageIsSQLNullWhateverKindOfNilCarriesIt(t *testing.T) {
 	var (
 		nilMap   map[string]any
@@ -54,9 +54,8 @@ func TestAnAbsentImageIsSQLNullWhateverKindOfNilCarriesIt(t *testing.T) {
 // everything falsy.
 func TestAnEmptyImageIsStillAnImage(t *testing.T) {
 	for _, tc := range []struct {
-		name string
-		want string
-		// craft:ignore naked-any it is the audit seam's own parameter type
+		name  string
+		want  string
 		image any
 	}{
 		{"empty map", `{}`, map[string]any{}},

--- a/backend/internal/platform/database/storekit/auditimage_test.go
+++ b/backend/internal/platform/database/storekit/auditimage_test.go
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package storekit
+
+// The audit seam's absent-image rule. `before`/`after` are `any`, so the
+// question "did the caller supply an image" is a Go typed-nil question before
+// it is a SQL one, and getting it wrong writes a JSON `null` that reads as
+// present to every `WHERE before IS NULL` query in the tree.
+
+import "testing"
+
+// An image is absent or it is not, and how the caller spelled the absence is
+// not the column's business. Every writer here supplies one — an untyped nil,
+// a nil map (the shape a store builds an image in), a nil slice, a nil
+// pointer — and each must reach the column as SQL NULL.
+//
+// The nil-map row is the one that has cost this tree twice: capture's
+// own-domain registry stored JSON `null` for a first registration until it was
+// found, and identity's record-grant upsert reproduced it from scratch a
+// module away. Both are call sites of this one function, which is why the rule
+// lives here rather than in either of them.
+func TestAnAbsentImageIsSQLNullWhateverKindOfNilCarriesIt(t *testing.T) {
+	var (
+		nilMap   map[string]any
+		nilSlice []string
+		nilPtr   *struct{ A int }
+	)
+	for _, tc := range []struct {
+		name  string
+		image any
+	}{
+		{"untyped nil", nil},
+		{"nil map", nilMap},
+		{"nil slice", nilSlice},
+		{"nil pointer", nilPtr},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := marshalOrNil(tc.image)
+			if err != nil {
+				t.Fatalf("marshalOrNil: %v", err)
+			}
+			if got != nil {
+				t.Errorf("marshalOrNil(%s) = %q, want nil bytes so the column stores SQL NULL", tc.name, got)
+			}
+		})
+	}
+}
+
+// The mirror, and the reason the rule is a nil check rather than an emptiness
+// one: a caller that supplies an EMPTY image is saying something different
+// from one that supplies none, and only the second is absent. Without this
+// half the rule above is satisfied by a function that returns nil for
+// everything falsy.
+func TestAnEmptyImageIsStillAnImage(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		want string
+		// craft:ignore naked-any it is the audit seam's own parameter type
+		image any
+	}{
+		{"empty map", `{}`, map[string]any{}},
+		{"empty slice", `[]`, []string{}},
+		{"zero struct", `{"A":0}`, struct{ A int }{}},
+		{"false", `false`, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := marshalOrNil(tc.image)
+			if err != nil {
+				t.Fatalf("marshalOrNil: %v", err)
+			}
+			if string(got) != tc.want {
+				t.Errorf("marshalOrNil(%s) = %q, want %q — an empty image is not an absent one", tc.name, got, tc.want)
+			}
+		})
+	}
+}

--- a/backend/internal/platform/database/storekit/storekit.go
+++ b/backend/internal/platform/database/storekit/storekit.go
@@ -350,9 +350,6 @@ func JSONArg(m map[string]any) any {
 // silently misses the row. The image is absent either way; only the column
 // stops saying so.
 //
-// TestAnAbsentImageIsSQLNullWhateverKindOfNilCarriesIt holds the rule, and
-// capture's own-domain registry is the write that found it the first time.
-//
 //craft:ignore naked-any marshals the audit seam's schemaless before/after images (see Audit)
 func marshalOrNil(v any) ([]byte, error) {
 	if v == nil || isNilValue(v) {
@@ -361,14 +358,16 @@ func marshalOrNil(v any) ([]byte, error) {
 	return json.Marshal(v)
 }
 
-// isNilValue reports whether v is an interface carrying a typed nil of a kind
-// that can be nil. Kinds that cannot be are answered false without reflection
-// on their contents, so a zero struct or an empty map stays an image.
+// isNilValue reports whether v carries a typed nil of a kind that can be one.
+// Kinds that cannot be are answered false without inspecting their contents,
+// so a zero struct or an empty map stays an image. reflect.Interface is absent
+// deliberately: ValueOf resolves to the dynamic type, so an interface kind
+// never reaches here.
 //
 //craft:ignore naked-any the same audit-seam value marshalOrNil inspects
 func isNilValue(v any) bool {
 	switch rv := reflect.ValueOf(v); rv.Kind() {
-	case reflect.Map, reflect.Slice, reflect.Pointer, reflect.Interface:
+	case reflect.Map, reflect.Slice, reflect.Pointer:
 		return rv.IsNil()
 	default:
 		return false

--- a/backend/internal/platform/database/storekit/storekit.go
+++ b/backend/internal/platform/database/storekit/storekit.go
@@ -15,6 +15,7 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"reflect"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -337,10 +338,39 @@ func JSONArg(m map[string]any) any {
 	return raw
 }
 
+// marshalOrNil renders one audit image, answering nil bytes — and so SQL NULL
+// in the column — for an absent one.
+//
+// "Absent" has to include a nil MAP, not just an untyped nil, and that is the
+// whole reason this is not a bare json.Marshal. A caller that builds its image
+// in a `map[string]any` and leaves it nil ("there was no prior state") hands
+// this an interface holding a typed nil, which `v == nil` reads as present:
+// json.Marshal then writes the four bytes `null`, and every "there was no prior
+// state" query — `WHERE before IS NULL`, the shape the rest of the tree uses —
+// silently misses the row. The image is absent either way; only the column
+// stops saying so.
+//
+// TestAnAbsentImageIsSQLNullWhateverKindOfNilCarriesIt holds the rule, and
+// capture's own-domain registry is the write that found it the first time.
+//
 //craft:ignore naked-any marshals the audit seam's schemaless before/after images (see Audit)
 func marshalOrNil(v any) ([]byte, error) {
-	if v == nil {
+	if v == nil || isNilValue(v) {
 		return nil, nil
 	}
 	return json.Marshal(v)
+}
+
+// isNilValue reports whether v is an interface carrying a typed nil of a kind
+// that can be nil. Kinds that cannot be are answered false without reflection
+// on their contents, so a zero struct or an empty map stays an image.
+//
+//craft:ignore naked-any the same audit-seam value marshalOrNil inspects
+func isNilValue(v any) bool {
+	switch rv := reflect.ValueOf(v); rv.Kind() {
+	case reflect.Map, reflect.Slice, reflect.Pointer, reflect.Interface:
+		return rv.IsNil()
+	default:
+		return false
+	}
 }

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -5359,8 +5359,14 @@ export interface paths {
          * @description Grants `read` or `write` on a single record to a user or team otherwise out of their own/team/all
          *     scope. Enforced by widening BOTH the application visibility WHERE clause AND the RLS backstop
          *     policy (`data-model §1.3c/§2.5`). Idempotent on `(record_type, record_id, subject_type, subject_id)` —
-         *     re-asserting upgrades/downgrades `access` and resets `expires_at`. A grant can never exceed the
-         *     granting principal's own access (scope-intersection). Audited (`action: record_share`). Bounded:
+         *     a re-assert RESTATES the grant rather than amending it: `access`, `expires_at`, `reason` and
+         *     `granted_by` all take the values of the new request, so a field the caller omits is cleared and
+         *     accountability moves to the re-asserting principal. `id` and `created_at` do not move — it is the
+         *     same share, not a new one. A grant can never exceed the granting principal's own access
+         *     (scope-intersection), and a grant is not itself a licence to share: administering a record's
+         *     grants requires that record in the caller's OWN scope (owner/team/all), because a caller whose
+         *     only claim to it is a share would otherwise be exercising the grant-of-grant delegation this
+         *     operation excludes. Audited (`action: record_share`). Bounded:
          *     flat explicit grants only — no sharing hierarchies, criteria-rules, or grant-of-grant delegation.
          *
          *     The seat ceiling binds the RECIPIENT as well (AAD-AC-4): a `write` grant to a user on a `read`


### PR DESCRIPTION
`createRecordGrant` is documented **"Idempotent on `(record_type, record_id, subject_type, subject_id)` — re-asserting upgrades/downgrades `access` and resets `expires_at`"**, and its `201` is documented as *"Grant created (or updated)"*. The code ran a plain `INSERT` and mapped the unique violation to **409 — a status the operation does not declare at all**. So the documented way to change an access level did not exist, and the only route was revoke-then-re-grant.

Contract-first decides which half moves, and there is no spec work: `margince-foundation` `specs/contract/crm.yaml` carries the same sentence verbatim. This is code catching up to a ratified contract.

## What was NOT broken, which is most of the scope

`Idempotency-Key` is fully wired — `POST /v1/record-grants` is an entry in `compose/replayscope.go`'s `replayableOperations`, derived from the contract by `TestIdempotentOperationsMirrorTheContract`. Two mechanisms share the word "idempotent" here and only one was broken:

- **`Idempotency-Key`** — "this is a retry of the same request" → replay the recorded answer for 24h. **Worked.**
- **Idempotent on the natural key** — "re-asserting this tuple with a different access is an upsert" → **missing.**

A caller changing an access level sends a *new* request, not a retry, so the replay gate correctly passed it through — into the 409.

## The upsert

Follows `deals/fxrate_store.go`, the tree's worked audited upsert, rather than inventing a second shape: read the displaced row, `ON CONFLICT DO UPDATE`, audit with both images.

| column | on conflict | why |
|---|---|---|
| `access` | `EXCLUDED` | the contract's "upgrades/downgrades" |
| `expires_at` | `EXCLUDED` | the contract says a re-assert **resets** it. `COALESCE` would make an expiry unclearable — mutation-tested |
| `reason` | `EXCLUDED` | belongs to the assertion in force, not the first one ever made |
| `granted_by` | `EXCLUDED` | the row answers "who is accountable for this access". Keeping the original grantor would attribute Bob's upgrade to Alice |
| `version` | `+ 1` | the column has existed on the table since `0011` for exactly this |
| `id`, `created_at` | **untouched** | a re-assert is the same sharing relationship — which is what makes it idempotent rather than a duplicate under a new name |

The audit verb stays `record_share` in both directions, downgrades included: the contract pins it and `record_unshare` is revocation's word. Which way the access moved is the **image pair's** job, so the image widened to carry `expires_at` and `reason` — an image that omits a field the upsert can change reports "nothing moved" when something did. `privacy/recordhistory.go` already serves these images on the record timeline, so a downgrade now reads as one there.

## What three reviews changed, because it is most of this PR now

The first commit was the idempotency fix. Two independent reviews and an
adversarial pass then found the same shape from different angles, and the
second commit is the answer to it.

**The gate that admits a re-assert is `EnsureLinkTarget`, and the grant arm
SATISFIES it.** So the person a record was shared with passes it — and the
upsert let them administer the very share that admitted them. Reproduced
against a running installation, all three:

| attack | before this PR | with the upsert alone |
|---|---|---|
| clear the `expires_at` that time-boxed the share | 409 | **201, share is permanent** |
| widen one's own `read` share to `write` | 409 | **201** |
| pass the record to a colleague the sharer never named | allowed (pre-existing) | allowed |

The **time** one is the sharpest and I had not considered it: a one-hour share,
re-asserted by its beneficiary with no `expires_at`, comes back permanent. The
409 was load-bearing by accident, and the upsert removes it.

**The rule was already in the contract and nothing made it operative** —
*"flat explicit grants only … no grant-of-grant delegation."* `auth.EnsureCanShare`
makes it operative: administering a record's grants requires that record in the
caller's **own** scope, so the grant arm that widens every read path is
deliberately not consulted.

**It is deliberately NOT written as access-level intersection**, which was my
first fix and is weaker. `record_grant.access` is consulted by no authorization
path in this tree — a `read` grant confers write, filed as
[#1373](https://github.com/gradionhq/margince-poc-v1/issues/1373) — so a rule
resting on that distinction refuses `write` and waves the identical authority
through as `read`. The redteam demonstrated exactly that against my first
attempt. Scope is real today; the access distinction is not yet, and the rule
that shipped does not depend on it.

Three more findings, all real:

- **The concurrency comment was false.** `FOR UPDATE` cannot serialize two
  concurrent *creates* — an absent row locks nothing — so the loser audited a
  first share over a row it displaced. Now `storekit.LockWriteIdentity` before
  the precondition read, which is what `fxrate_store.go` takes for the same
  reason. An intermediate revision of mine "solved" this with a version oracle
  that answered **409**, on the one endpoint whose premise is that it declares
  none; that is gone.
- **The audit image omitted `granted_by`** — under a comment claiming it omitted
  nothing the upsert can change. `RevokeRecordGrant` hand-built a third shape;
  both now render through `grantImage`.
- **The seam fix falsified two more sibling comments** the first pass missed
  (`capture/freemaildomain.go`, `identity/onboarding.go`).

## The security question this turns on

**A re-assert must not become a second door onto an authority the first door refuses.** The unique constraint used to refuse a second call outright, so `refuseWriteGrantToReadSeat` (AAD-AC-4) only ever ran on the create path. The upsert turns the second call into a real write, so the ceiling's job got wider.

`TestAReAssertCannotWalkAWriteGrantPastTheSeatCeiling` shares `read` with a read seat (allowed — it is the authority the licence already carries), re-asserts the same tuple as `write`, and requires **403 `seat_tier_insufficient` *and* the stored access still reading `read`**. `TestAShareIsNotALicenceToReShare` drives a real team-scoped principal through all three attacks above and reads the row back after each refusal, with an allow arm (the owner may still administer the share) so it cannot be satisfied by a probe that refuses everyone.

**Everything is mutation-tested, and two mutants corrected my own reasoning.**
Moving the seat guard *behind* the write still passes — the transaction rolls it
back, so ordering is not what protects it, and I rewrote a comment that claimed
it was. Replacing `OwnerPredicate` with `VisiblePredicate` in `EnsureCanShare`
(my weaker first fix) fails all three attack arms, which is the proof that the
rule is *own scope* rather than visibility.

## Also: the audit seam, fixed at the seam

Writing the before-image exposed a live defect one layer down. `storekit.marshalOrNil` wrote SQL NULL only for an **untyped** nil, so a caller that builds its image in a `map[string]any` and leaves it nil hands it an interface carrying a **typed** nil — which marshals to JSON `null` and is invisible to every `WHERE before IS NULL` query in the tree.

This has now cost three call sites:

- `capture/owndomainstore.go` hit it, and worked around it **locally** with `var beforeImage any` and a comment naming the trap.
- `deals/fxrate_store.go` has carried it **live** ever since — `replacedFxRate` returns a nil `map[string]any`.
- This change reproduced it from scratch, a module away, and its own test caught it.

Per the repo's rule 1 (fix the invariant, not the call site) the nil check moved into the seam, which fixes all three and the next one. `TestAnAbsentImageIsSQLNullWhateverKindOfNilCarriesIt` holds it across every nilable kind, with `TestAnEmptyImageIsStillAnImage` as the mirror so the rule cannot be satisfied by returning nil for everything falsy. capture's local workaround and its now-stale comment are retired.

## Deliberately out of scope, so it is not read as an oversight

**The SPA still cannot reach this.** `share.tsx` **disables** an already-granted subject in the picker and labels it `share.alreadyGranted`, so there is no UI path to change an access level — the workaround *is* the symptom the issue describes. Making it reachable is a real interaction decision (does the row show its current access? is a downgrade confirmed?) and belongs in its own PR. Filed as #1369.

## Verification

- `make check` (root, backend + frontend) — **green**
- `make test-integration` — run in full twice, because this changes two platform seams. First run (before the auth work): **`OK: integration passed with 0 skips (40 packages, parallel)`**. Second run: one failure, `TestNoDealLandsOnAStageBeingRemoved`, which is **[#1341](https://github.com/gradionhq/margince-poc-v1/issues/1341)** — a documented ~58% flake on `main` with the identical message (*"no stage was removed in any round — the race never ran"*), reproduced here as 1 fail / 2 pass in three consecutive runs of that test alone. Nothing else red
- `craft static --strict` on every changed file — 0 findings
- **UAT against a live stack** (`DEV_SLUG=grant`) — video below. Six steps: create, share `read` with an expiry, re-assert as `write` with none → **201, same grant id, same `created_at`, access upgraded, expiry reset**; one row not two; audit trail reading `(none) -> read` then `read -> write`; and the read-seat re-assert refused with no residue.
- **No AI-certification impact**: `createRecordGrant` is `x-agent-access: human-only` with no `x-mcp-tool`, no prompt/corpus/fixture is touched, and `make check` (which fails on a stale aicert record) is green.

## Upstream

**Contract-first: [margince-foundation#1313](https://github.com/gradionhq/margince-foundation/pull/1313) carries the spec half** and should land first. It pins what the old sentence left open — that a re-assert *restates* the grant (so `reason` and `granted_by` move too, and `id`/`created_at` do not), and that administering a share requires own-scope. The `crm.yaml` change here mirrors that text.

Closes #1297

🤖 Generated with [Claude Code](https://claude.com/claude-code)
