### PR TITLE
build(gates): the module lint says which of its three failures happened (#1347)

### DIFF
--- a/scripts/check-lint-modules.sh
+++ b/scripts/check-lint-modules.sh
@@ -67,11 +67,11 @@ fi
 # a type-checkable package; it has nothing to say here. They are NOT unchecked
 # code: the craft gate, the license header test and the tree-wide gofmt gate all
 # cover fixtures/, and none of the three needs to typecheck to do its job.
-# `s#/\?go\.mod$##` reads as an optional slash under GNU sed and as a LITERAL
-# backslash-slash under the BSD sed macOS ships, so on a developer laptop every
-# path kept its `/go.mod` suffix, `cd` failed with "Not a directory", and the
-# gate reported findings in eight modules it had never entered. Two plain
-# substitutions say the same thing in both dialects.
+
+# Two plain substitutions rather than one optional-slash pattern: `\?` is a GNU
+# extension, and the BSD sed macOS ships reads it as a literal `?`, so a pattern
+# that strips the suffix on CI leaves it in place on a laptop. Both dialects
+# agree on these two.
 modules="$(git ls-files '*go.mod' \
   | sed -e 's#/go\.mod$##' -e 's#^go\.mod$#.#' \
   | grep -v '^backend$' \
@@ -93,7 +93,22 @@ fi
 # looks like it passed and did not run.
 members="$(sed -n 's#^[[:space:]]*\.\./\.\./##p' "$COMPOSED_WORK")"
 
-failed=""
+# THREE ways this gate can fail, kept apart, because they are three different
+# questions for whoever reads the output and only one of them is about the code.
+#
+# golangci exits 1 when it RAN and found issues, and non-1 when it could not run
+# at all — an unreadable config, a workspace that does not resolve, an internal
+# error. A failing `cd` is a third thing again, and a bare `cd "$mod" && …` exits
+# 1 for that too, which is how one path bug came to announce itself as findings
+# in eight modules nothing had ever entered, under a remedy explaining how to fix
+# findings that did not exist. So the cd gets a reserved status of its own, well
+# outside the range golangci uses, and the run's exit is read rather than merely
+# tested.
+readonly CANNOT_ENTER=90
+
+findings=""
+unenterable=""
+broken=""
 count=0
 for mod in $modules; do
   count=$((count + 1))
@@ -107,19 +122,48 @@ for mod in $modules; do
   # was being armed, fixing the three visible G304s revealed four more that the
   # cap had been suppressing all along. A gate that truncates reads exactly like
   # a gate that found everything.
-  if ! (cd "$mod" && GOWORK="$work" "$GOLANGCI" run --config "$CONFIG" \
-        --max-same-issues=0 --max-issues-per-linter=0 ./...); then
-    failed="$failed $mod"
-  fi
+  rc=0
+  (
+    cd "$mod" || exit "$CANNOT_ENTER"
+    GOWORK="$work" exec "$GOLANGCI" run --config "$CONFIG" \
+      --max-same-issues=0 --max-issues-per-linter=0 ./...
+  ) || rc=$?
+  case "$rc" in
+    0) ;;
+    1) findings="$findings $mod" ;;
+    "$CANNOT_ENTER") unenterable="$unenterable $mod" ;;
+    *) broken="$broken $mod(exit $rc)" ;;
+  esac
 done
 
-if [[ -n "$failed" ]]; then
+if [[ -n "$unenterable" ]]; then
   echo
-  echo "FAIL — golangci-lint findings in:$failed"
+  echo "FAIL: lint-modules could not enter:$unenterable"
+  echo
+  echo "Those directories come from tracked go.mod files that the working tree does"
+  echo "not have, so NOTHING was linted in them. This is not a lint finding: check"
+  echo "the checkout against \`git ls-files '*go.mod'\` before looking at any code."
+fi
+
+if [[ -n "$broken" ]]; then
+  echo
+  echo "FAIL: golangci-lint could not complete in:$broken"
+  echo
+  echo "A non-1 exit is the tool refusing to run — an unreadable config, a workspace"
+  echo "that does not resolve, an internal error — rather than anything it found."
+  echo "Its own error is above; 'make tools' and 'make composition' fix most of them."
+fi
+
+if [[ -n "$findings" ]]; then
+  echo
+  echo "FAIL — golangci-lint findings in:$findings"
   echo
   echo "These modules are outside 'golangci-lint run ./...' from backend/, so they are"
   echo "linted only here. Fix the finding, or waive a genuine false positive in source"
   echo "with '//nolint:<linter> // <reason>' on the line it applies to."
+fi
+
+if [[ -n "$unenterable$broken$findings" ]]; then
   exit 1
 fi
 


### PR DESCRIPTION
Closes #1347.

## What was already fixed, and what was not

The headline — `make check` broken on macOS — is **already resolved on `main`**: the GNU-only `\?` in the module-list sed landed as two portable substitutions in #1359, and `make check-backend` is green here on BSD sed. I verified that before touching anything.

What that fix did not touch is the half #1347 calls out as *"worth more than a one-line fix"*: the loop could not tell its own broken invocation from the thing it reports.

```sh
if ! (cd "$mod" && golangci-lint run …); then failed="$failed $mod"; fi
```

`cd` failing exits **1**. golangci finding issues exits **1**. Both landed in one bucket, printed as *"golangci-lint findings in: …"* and followed by advice on how to fix findings that did not exist. That is how a path bug came to report eight modules' worth of lint findings in modules nothing had ever entered.

## Three outcomes, kept apart

| Class | How it is detected | What the message says |
|---|---|---|
| **Could not enter** | `cd` exits a reserved status (90), well outside golangci's range | the directory is missing from the working tree, **nothing was linted**, check the checkout — not the code |
| **Could not complete** | golangci exits non-1 | the tool refused to run (unreadable config, unresolvable workspace, internal error); its own error is above |
| **Findings** | golangci exits 1, having run | the original message, unchanged |

The `cd` gets its own status rather than a pre-flight `[[ -d ]]` check, so the classification cannot drift from the thing it classifies: there is no window between testing the directory and entering it.

## All three induced and observed

Hiding one module (`mv extensions/notes …`) produces both of the non-finding classes at once, which is the clearest possible demonstration:

```
FAIL: lint-modules could not enter: extensions/notes
  Those directories come from tracked go.mod files that the working tree does
  not have, so NOTHING was linted in them. This is not a lint finding…

FAIL: golangci-lint could not complete in: backend/tools(exit 3) cli/craft(exit 3)
  extensions/de(exit 3) extensions/dispact-connector(exit 3) extensions/yogi(exit 3)
  A non-1 exit is the tool refusing to run…
```

**Six modules the old code would have called lint findings, none of which were linted at all.** Injecting a real violation into `extensions/notes` still reports `FAIL — golangci-lint findings in: extensions/notes`, unchanged. Clean tree: `OK: lint-modules — 7 module(s) outside backend/ lint clean`.

No automated guard: there is no shell-test harness in the tree (33 scripts, none tested, no shellcheck gate), so adding one is its own change rather than a rider on this. Stated plainly rather than implied — the classification above is proven by induced runs, not by a test that will re-run tomorrow.

## The portability sweep the issue also asks for

Done, and it found nothing. Across `scripts/*.sh` and `.githooks/`: no `\?`, `\+` or `\|` in a BRE, no `grep -P`, no `readlink -f`, no `date -d`, no GNU-form `sed -i`, no `stat -c`, `find -printf`, `tac`, `xargs -r`, `head -n -N` or `seq -w`. The one remaining `\+` is inside a `sed -E` expression matching `// +build`, where an escaped plus is a literal in both dialects.

Also tightened the surviving comment on that sed line: it narrated the past defect ("on a developer laptop every path kept its suffix… the gate reported findings in eight modules"), which is history git already holds. It now states the invariant instead.

## Gates

`make check-backend` green locally on macOS — which is the thing #1347 says was broken.

## Found but not fixed

While inducing the failure classes, the gate reported findings in `../../margince-next-erase/backend/tools/…` — a **deleted** sibling worktree — because golangci's cache keys results to absolute paths that no longer exist. It reads exactly like "your branch has findings in eight modules", is cleared by `golangci-lint cache clean`, and cost time twice today. That is a fourth way this gate's output can mislead, owned by the tool rather than by this script; filed separately rather than papered over here.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the module lint gate report which failure happened instead of lumping all errors under “golangci-lint findings.” Previously, a failed cd or tool error appeared as findings; now each outcome is distinct, preventing misleading failures and clarifying remedies.

- Distinguishes three outcomes: could not enter (cd fails), could not complete (golangci-lint exits non‑1), and findings (golangci-lint exits 1).
- Reserves exit 90 for cd failures and reads the actual lint exit code; no preflight dir check, so classification cannot drift.
- Prints a separate list and guidance for each outcome; still exits 1 if any list is non‑empty.
- No caller changes. `make check-backend` stays green on macOS.

<sup>Written for commit f59046a51e17e835246737b4744c3f7269662226. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1377?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

