### PR TITLE
fix(access): sharing follows ADR-0039's narrower-or-equal, not own-scope

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -8173,10 +8173,9 @@ paths:
         `granted_by` all take the values of the new request, so a field the caller omits is cleared and
         accountability moves to the re-asserting principal. `id` and `created_at` do not move — it is the
         same share, not a new one. A grant can never exceed the granting principal's own access
-        (scope-intersection), and a grant is not itself a licence to share: administering a record's
-        grants requires that record in the caller's OWN scope (owner/team/all), because a caller whose
-        only claim to it is a share would otherwise be exercising the grant-of-grant delegation this
-        operation excludes. Audited (`action: record_share`). Bounded:
+        (scope-intersection, ADR-0039: a granter can never share wider than they hold — a caller
+        holding only `read` on the record may pass `read` on and is refused `write`).
+        Audited (`action: record_share`). Bounded:
         flat explicit grants only — no sharing hierarchies, criteria-rules, or grant-of-grant delegation.
 
         The seat ceiling binds the RECIPIENT as well (AAD-AC-4): a `write` grant to a user on a `read`

--- a/backend/internal/compose/integration/grants_integration_test.go
+++ b/backend/internal/compose/integration/grants_integration_test.go
@@ -85,83 +85,76 @@ func TestRecordGrantWidensRowScopeAndRevokes(t *testing.T) {
 // first `write` grant to a subject who already holds `read` used to be refused
 // by the unique constraint; the upsert accepts it, so the only thing standing
 // between a read share and a write one is this rule.
-func TestAShareIsNotALicenceToReShare(t *testing.T) {
+// ADR-0039's scope-intersection rule, which is narrower-or-equal rather than
+// a ban on sharing a share: "a granter can never share wider than they hold."
+// UC-E11-08 F1 puts a screen state on it — "Can't grant write — you only have
+// read here" — so passing `read` on is a supported flow and only `write` is
+// refused.
+//
+// The gate that admits any of this is EnsureLinkTarget, and the visibility arm
+// counts every live grant regardless of access, so a read-share holder passes
+// it. Without a separate probe they could hand on the authority their own
+// sharer withheld — and the upsert makes that reachable on a second call where
+// the unique constraint used to end it.
+func TestAReadShareCanBePassedOnButNotWidened(t *testing.T) {
 	e := SetupSearch(t)
 	// Owned by rep3 in team2, so rep1 in team1 has no path to it but a share.
 	foreign := e.Seed(t, `INSERT INTO person (id, workspace_id, full_name, owner_id, source, captured_by) VALUES ($1, $2, 'Out Of Scope', $3, 'manual', 'human:x')`, e.Rep3)
 	colleague := e.Seed(t, `INSERT INTO app_user (id, workspace_id, email, display_name) VALUES ($1, $2, 'colleague@search.test', 'Colleague')`)
 	svc := identity.NewService(e.Pool)
-	expiry := time.Now().Add(time.Hour).UTC().Truncate(time.Second)
 
-	share := func(as context.Context, in identity.CreateGrantInput) error {
-		in.RecordType, in.RecordID, in.SubjectType = "person", foreign, "user"
-		_, err := svc.CreateRecordGrant(as, in)
+	// Every grant below goes through the real writer, including the ones that
+	// set the scene: a hand-inserted row would prove the rule against a state
+	// production cannot reach.
+	share := func(as context.Context, subject ids.UUID, access string) error {
+		_, err := svc.CreateRecordGrant(as, identity.CreateGrantInput{
+			RecordType: "person", RecordID: foreign,
+			SubjectType: "user", SubjectID: subject, Access: access,
+		})
 		return err
 	}
-	// The owner shares through the real writer — a hand-inserted row would set
-	// a scene production cannot reach.
 	owner := grantingPrincipal(e, e.Rep3, principal.RowScopeOwn, nil)
-	// A team-scoped rep who may update people: the ordinary shape of a
-	// colleague, and the only thing that ever kept them off a record outside
-	// their team is the row scope, which the share below widens.
 	rep := grantingPrincipal(e, e.Rep1, principal.RowScopeTeam, []ids.UUID{e.Team1})
 
-	if err := share(owner, identity.CreateGrantInput{
-		SubjectID: e.Rep1, Access: "read", ExpiresAt: &expiry,
-	}); err != nil {
-		t.Fatalf("owner shares read, time-boxed → %v", err)
+	if err := share(owner, e.Rep1, "read"); err != nil {
+		t.Fatalf("owner shares read → %v", err)
 	}
 
-	// Rep1 can now READ the record. Three things they must still not do, and
-	// the third is the one the upsert would otherwise have handed them.
-	for _, tc := range []struct {
-		name string
-		in   identity.CreateGrantInput
-	}{
-		{"pass the record on to a colleague", identity.CreateGrantInput{SubjectID: colleague, Access: "read"}},
-		{"widen their own share to write", identity.CreateGrantInput{SubjectID: e.Rep1, Access: "write"}},
-		{"clear the expiry that time-boxed it", identity.CreateGrantInput{SubjectID: e.Rep1, Access: "read"}},
-	} {
-		if err := share(rep, tc.in); !errors.Is(err, apperrors.ErrPermissionDenied) {
-			t.Errorf("%s → %v, want permission-denied", tc.name, err)
-		}
+	// Holding `read`, rep1 may pass `read` on…
+	if err := share(rep, colleague, "read"); err != nil {
+		t.Errorf("passing read on from a read share → %v, want allowed (UC-E11-08 F1)", err)
+	}
+	// …and is refused `write`, in both directions: onto a colleague, and onto
+	// themselves by re-asserting their own grant.
+	if err := share(rep, colleague, "write"); !errors.Is(err, apperrors.ErrPermissionDenied) {
+		t.Errorf("granting write from a read share → %v, want permission-denied", err)
+	}
+	if err := share(rep, e.Rep1, "write"); !errors.Is(err, apperrors.ErrPermissionDenied) {
+		t.Errorf("re-asserting one's own read grant as write → %v, want permission-denied", err)
 	}
 
-	// The allow arm, without which every assertion above would pass against a
-	// probe that refused everyone: the OWNER may still administer the share,
-	// including clearing the expiry they set.
-	if err := share(owner, identity.CreateGrantInput{SubjectID: e.Rep1, Access: "read"}); err != nil {
-		t.Fatalf("owner re-asserts their own share → %v", err)
+	// The allow arm for `write`, without which the refusals above would pass
+	// against a probe that refused every write: once the owner upgrades rep1,
+	// the same caller may pass write on. Same record, one column different.
+	if err := share(owner, e.Rep1, "write"); err != nil {
+		t.Fatalf("owner upgrades the share to write → %v", err)
+	}
+	if err := share(rep, colleague, "write"); err != nil {
+		t.Errorf("passing write on while holding write → %v, want allowed", err)
 	}
 
-	// The time box survived every refusal and yielded only to the owner. Read
-	// back, because a 403 raised after the upsert ran is indistinguishable from
-	// one raised instead of it.
+	// Read back, because a 403 raised after the upsert ran is indistinguishable
+	// from one raised instead of it.
 	var access string
-	var expiresAt *time.Time
 	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 		return tx.QueryRow(context.Background(),
-			`SELECT access, expires_at FROM record_grant WHERE record_id = $1 AND subject_id = $2`,
-			foreign, e.Rep1).Scan(&access, &expiresAt)
+			`SELECT access FROM record_grant WHERE record_id = $1 AND subject_id = $2`,
+			foreign, colleague).Scan(&access)
 	}); err != nil {
 		t.Fatal(err)
 	}
-	if access != "read" {
-		t.Errorf("the share reads %q after three refused widenings, want read", access)
-	}
-	if expiresAt != nil {
-		t.Errorf("expires_at = %v after the owner cleared it, want null", expiresAt)
-	}
-	var colleagueGrants int
-	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
-		return tx.QueryRow(context.Background(),
-			`SELECT count(*) FROM record_grant WHERE record_id = $1 AND subject_id = $2`,
-			foreign, colleague).Scan(&colleagueGrants)
-	}); err != nil {
-		t.Fatal(err)
-	}
-	if colleagueGrants != 0 {
-		t.Errorf("%d grants reached a colleague the sharer never named", colleagueGrants)
+	if access != "write" {
+		t.Fatalf("the colleague's grant reads %q, want write", access)
 	}
 }
 

--- a/backend/internal/modules/identity/grants.go
+++ b/backend/internal/modules/identity/grants.go
@@ -174,19 +174,17 @@ func (s *Service) CreateRecordGrant(ctx context.Context, in CreateGrantInput) (g
 		if !subjectExists {
 			return apperrors.ErrNotFound
 		}
-		// Administering a share is not the same authority as reading the record,
-		// and EnsureLinkTarget above only proves the second: the grant arm
-		// satisfies it, so the person a record was shared WITH passes it. This
-		// is what stops them administering that same share — and it binds a
-		// re-assert exactly as it binds a first share, because the upsert makes
-		// the second call a real write where the unique constraint used to end
-		// it. Narrowing it to new rows would hand the beneficiary of a
-		// time-boxed share the power to clear its expiry.
-		if err := auth.EnsureCanShare(ctx, tx, in.RecordType, in.RecordID); err != nil {
+		// Two rules bound a `write` grant and they judge different people.
+		// Scope-intersection (ADR-0039) judges the GRANTOR: EnsureLinkTarget
+		// above is satisfied by the grant arm, so a caller holding only a `read`
+		// share passes it, and this is what stops them passing on an authority
+		// their own sharer withheld. The seat ceiling (AAD-AC-4) judges the
+		// RECIPIENT. Both read the ASSERTED access, so both bind a re-assert
+		// exactly as they bind a first share — the upsert makes the second call
+		// a real write where the unique constraint used to end it.
+		if err := auth.EnsureCanGrant(ctx, tx, in.RecordType, in.RecordID, in.Access); err != nil {
 			return err
 		}
-		// The seat ceiling judges the RECIPIENT, and judges the ASSERTED access,
-		// so it too binds a re-assert as hard as a first share.
 		if err := refuseWriteGrantToReadSeat(ctx, tx, in); err != nil {
 			return err
 		}

--- a/backend/internal/platform/auth/rowscope.go
+++ b/backend/internal/platform/auth/rowscope.go
@@ -191,29 +191,30 @@ func predicateFor(p principal.Principal, table string, arg func(any) int, captur
 	}
 }
 
-// EnsureCanShare holds the bound the contract puts on `createRecordGrant`:
-// "flat explicit grants only — no sharing hierarchies, criteria-rules, or
-// grant-of-grant delegation." A share received is not a licence to re-share,
-// so the record must sit in the caller's OWN scope — owner, team, or
-// unbounded — and the grant arm that widens every read path is deliberately
-// not consulted here.
+// EnsureCanGrant holds ADR-0039's scope-intersection rule: "a granter can
+// never share wider than they hold." Only `write` can be wider than something,
+// so `read` needs no probe — EnsureLinkTarget has already proven the caller can
+// see the record, and passing on sight they hold is what UC-E11-08 F1's screen
+// state ("Can't grant write — you only have read here") describes as allowed.
 //
-// This is the difference between seeing a record and administering who else
-// may see it. EnsureVisible cannot make it, because a grant satisfies it by
-// design; without a separate probe the person a record was shared WITH could
-// administer that same share — hand it to a colleague, widen its access, or
-// clear the expiry that time-boxed it — all on authority the share itself
-// handed them.
+// For `write` the question is whether the caller's own authority over the row
+// is write-level: owner/team/all scope, or a live grant that says `write`. The
+// visibility arm cannot answer it, because it counts every live grant by design
+// — which is exactly how a `read`-share holder would otherwise pass on an
+// authority their sharer withheld.
 //
 // Out of scope answers ErrPermissionDenied, not ErrNotFound: the caller has
 // already proven they can see the row, so existence-hiding has nothing left to
 // hide and a not-found would send them looking for a typo.
-func EnsureCanShare(ctx context.Context, tx pgx.Tx, table string, id ids.UUID) error {
+func EnsureCanGrant(ctx context.Context, tx pgx.Tx, table string, id ids.UUID, access string) error {
 	// The primitive rejects an unknown name itself, like every sibling here:
 	// the record type reaching this comes from a request body, and its caller's
 	// own allowlist is a second line rather than the only one.
 	if !shareableTables[table] {
 		return fmt.Errorf("auth: %q is not a shareable table", table)
+	}
+	if access != grantAccessWrite {
+		return nil
 	}
 	p, err := rbacActor(ctx)
 	if err != nil {
@@ -226,10 +227,18 @@ func EnsureCanShare(ctx context.Context, tx pgx.Tx, table string, id ids.UUID) e
 	arg := func(v any) int { args = append(args, v); return len(args) }
 	idPos := arg(id)
 	owner := OwnerPredicate(p, arg)("")
+	me, teams := arg(p.UserID), arg(p.TeamIDs)
 
 	var permitted bool
-	if err := tx.QueryRow(ctx, fmt.Sprintf(
-		`SELECT EXISTS (SELECT 1 FROM %s WHERE id = $%d AND %s)`, table, idPos, owner),
+	if err := tx.QueryRow(ctx, fmt.Sprintf(`
+		SELECT EXISTS (SELECT 1 FROM %s WHERE id = $%d AND (%s OR EXISTS (
+		   SELECT 1 FROM record_grant rg
+		   WHERE rg.record_type = '%s' AND rg.record_id = %s.id
+		     AND rg.access = '%s'
+		     AND (rg.expires_at IS NULL OR rg.expires_at > now())
+		     AND ((rg.subject_type = 'user' AND rg.subject_id = $%d)
+		       OR (rg.subject_type = 'team' AND rg.subject_id = ANY($%d))))))`,
+		table, idPos, owner, table, table, grantAccessWrite, me, teams),
 		args...).Scan(&permitted); err != nil {
 		return err
 	}
@@ -238,6 +247,10 @@ func EnsureCanShare(ctx context.Context, tx pgx.Tx, table string, id ids.UUID) e
 	}
 	return nil
 }
+
+// grantAccessWrite is the wider of record_grant's two access levels. Spelled
+// once here because this file both compares against it and embeds it in SQL.
+const grantAccessWrite = "write"
 
 // ScopeClause renders the own/team/all row-visibility predicate over an
 // owner_id column (B-EP03.3a). arg registers a query argument and

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -5363,10 +5363,9 @@ export interface paths {
          *     `granted_by` all take the values of the new request, so a field the caller omits is cleared and
          *     accountability moves to the re-asserting principal. `id` and `created_at` do not move — it is the
          *     same share, not a new one. A grant can never exceed the granting principal's own access
-         *     (scope-intersection), and a grant is not itself a licence to share: administering a record's
-         *     grants requires that record in the caller's OWN scope (owner/team/all), because a caller whose
-         *     only claim to it is a share would otherwise be exercising the grant-of-grant delegation this
-         *     operation excludes. Audited (`action: record_share`). Bounded:
+         *     (scope-intersection, ADR-0039: a granter can never share wider than they hold — a caller
+         *     holding only `read` on the record may pass `read` on and is refused `write`).
+         *     Audited (`action: record_share`). Bounded:
          *     flat explicit grants only — no sharing hierarchies, criteria-rules, or grant-of-grant delegation.
          *
          *     The seat ceiling binds the RECIPIENT as well (AAD-AC-4): a `write` grant to a user on a `read`


### PR DESCRIPTION
**This corrects my own mistake in #1370.** That PR shipped a sharing rule stricter than the ratified decision, and amended the contract to match rather than raising the conflict — which is precisely what CLAUDE.md's spec rule forbids: *"A spec change that contradicts a ratified ADR is a discrepancy, not an edit."*

## What the ratified decision actually says

[ADR-0039](https://github.com/gradionhq/margince-foundation/blob/main/specs/adr/ADR-0039-record-level-sharing-grants.md) §3 — **Accepted, A52, founder**:

> The narrower-or-equal rule survives for the human path (a granter can never share wider than they hold).

`UC-E11-08` F1 spells out what survives it, down to the copy:

> **F1 — Granting above the ceiling.** A granter who holds only `read` on the record attempts a `write` grant → refused … *(AC-share screen state "Can't grant write — you only have read here")*

A screen state reading *"you only have read here"* is written for a caller who **may still grant**, just not wider. #1370's `EnsureCanShare` refused them both directions, which deletes the flow the ADR was written for — *"give the SE read on these three deals"* is its motivating example, and passing that read to a second SE is inside it.

## The change

`auth.EnsureCanShare` → `auth.EnsureCanGrant`, taking the asserted access:

- **`read` needs no probe at all.** `EnsureLinkTarget` has already proven the caller can see the record, and sight is exactly what they are passing on.
- **`write` asks the one question that matters**: is the caller's own authority over this row write-level — owner/team/all scope, or a live grant that says `write`? The visibility arm cannot answer it, because it counts every live grant by design.

Mutation-tested both ways. Dropping the `rg.access = 'write'` filter lets a read-share holder pass write on (2 arms fail); refusing every write breaks the allow arm. Neither direction is satisfied by a probe that answers the same thing to everyone.

The contract sentence is reverted upstream in [margince-foundation#1314](https://github.com/gradionhq/margince-foundation/pull/1314) and mirrored here. **The other half of that edit stays** — *"a re-assert restates the grant"* contradicts nothing and the shipped upsert depends on it being pinned.

## What this reopens, filed rather than lost

**[#1380](https://github.com/gradionhq/margince-poc-v1/issues/1380) — a time-boxed share can be made permanent by its own beneficiary.** Re-asserting your own `read` share with no `expires_at` clears the time box. That is narrower-or-equal on access and refused by nothing, because **ADR-0039's rule is about access and this hole is about time** — an axis that predates the idempotent re-assert.

It is reachable only because #1370 removed the `409` that used to end the second call, so it is that PR's follow-up. Closing it properly is a decision — bound the derived grant's expiry, or amend ADR-0039 deliberately — not something to smuggle into a reconciliation.

## Verification

- `make -C backend check` green · `make check-fe` green · `craft static --strict` clean on every changed file
- The grant suite green, including the rewritten `TestAReadShareCanBePassedOnButNotWidened`, which now asserts the **allowed** flow (pass `read` on) alongside the two refusals

Refs #1297, #1380

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns sharing checks with ADR-0039’s narrower-or-equal rule. Callers with `read` may pass `read`; `write` grants require the granter to hold write-level authority. This reverts the stricter own-scope rule and updates the contract and tests accordingly.

- Ensure `auth.EnsureCanShare` → `auth.EnsureCanGrant(recordType, recordID, access)` and only probes for `write`; `read` relies on visibility already proven.
- `EnsureCanGrant` permits `write` only if the caller owns/team-owns the row or holds a live `write` grant; counts expire-aware.
- `identity.Service.CreateRecordGrant` now gates via `EnsureCanGrant` and keeps seat-ceiling checks unchanged.
- Revert API copy in `backend/api/crm.yaml` and mirror in `frontend/src/api/schema.d.ts` to cite ADR-0039; behavior matches tests.
- Integration test rewritten to assert: pass `read` on from a `read` share (allowed), grant `write` from a `read` share (denied), and pass `write` after owner upgrade (allowed). No data migration required. Follow-up: #1380 remains open.

<sup>Written for commit 2aaf4683939e68a7bf94b59c3333a61783530ae7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1381?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

