### PR TITLE
fix(frontend): a captured channel conversation can be answered from the UI

### DIFF
--- a/backend/internal/compose/integration/person_relationship_room_integration_test.go
+++ b/backend/internal/compose/integration/person_relationship_room_integration_test.go
@@ -580,3 +580,52 @@ func TestMergeCarriesTheEnrichmentSidecarToTheSurvivor(t *testing.T) {
 		t.Errorf("%d row(s) stayed on the merged-away person, invisible to every read", left)
 	}
 }
+
+// A captured channel message reaches the page NAMING THE TRANSPORT THAT CARRIED
+// IT, and this test exists because it did not.
+//
+// Since ADR-0107/A158 the kind says only that an interaction was a message —
+// which transport carried it is `channel_provider`, a separate column. The 360's
+// timeline read is a hand-written sibling of activities.activityColumns, and
+// when the narrowing added the column there, nothing pointed at the copy. So
+// every activity on every person page reported a null provider: the memory card
+// rendered "message" where it should have said the transport's name, and the
+// composer could not tell a contact reachable on a unit's channel from one
+// reachable nowhere.
+//
+// The guard is a ROW-TO-PAYLOAD assertion rather than a source grep, because
+// what regressed was a SELECT list — a grep for the column name would have
+// passed on a query that selected it into a variable nobody scanned.
+func TestThePerson360TimelineNamesTheTransportThatCarriedAMessage(t *testing.T) {
+	e := Setup(t)
+	owner := OwnerConn(t)
+	mine := e.SeedPerson(t, "Luu Nguyen Thanh", &e.Rep1)
+
+	// telegram, because it is registered by the core migration on every
+	// installation — the FK on activity.channel_provider means an unregistered
+	// name could not be seeded at all, and this test is about the read.
+	message := SeedRow(t, owner, `INSERT INTO activity
+		(id, workspace_id, kind, channel_provider, body, occurred_at, direction, source, captured_by)
+		VALUES ($1, $2, 'message', 'telegram', 'they wrote', '2026-08-01T09:00:00Z',
+		        'inbound', 'manual', 'human:x')`, e.WS)
+	LinkActivity(t, owner, e.WS, message, "person", mine)
+
+	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, roomPerms)
+	page, err := personRoomService(e).Assemble(rep, ids.From[ids.PersonKind](mine))
+	if err != nil {
+		t.Fatalf("Assemble: %v", err)
+	}
+	if page.Activities == nil || len(page.Activities.Data) != 1 {
+		t.Fatalf("the timeline holds %v rows, want the one captured message", page.Activities)
+	}
+	got := page.Activities.Data[0]
+	if got.Kind != "message" {
+		t.Errorf("kind = %q, want message", got.Kind)
+	}
+	if got.ChannelProvider == nil {
+		t.Fatal("the message reached the page with no transport; the timeline renders it as the bare word \"message\" and every transport looks alike")
+	}
+	if string(*got.ChannelProvider) != "telegram" {
+		t.Errorf("channel_provider = %q, want telegram", string(*got.ChannelProvider))
+	}
+}

--- a/backend/internal/compose/person360/sectionstimeline.go
+++ b/backend/internal/compose/person360/sectionstimeline.go
@@ -83,6 +83,15 @@ func (s *Service) nextStepsSection(ctx context.Context, tx pgx.Tx, personID ids.
 }
 
 // readActivities is the shared body of the timeline and next-step reads.
+//
+// It selects channel_provider, and that is not decoration: since ADR-0107/A158
+// the kind says only that an interaction was a message, so a row without the
+// provider renders as the bare word "message" and a Telegram thread becomes
+// indistinguishable from a unit's. This SELECT is a hand-written sibling of
+// activities.activityColumns, which is exactly how it came to be missing the
+// column for a whole slice — the narrowing added it there and nothing pointed
+// at the copy. TestThePerson360TimelineNamesTheTransportThatCarriedAMessage is
+// the guard that says so out loud.
 func (s *Service) readActivities(ctx context.Context, tx pgx.Tx, personID ids.PersonID, extra string) ([]crmcontracts.Activity, bool, error) {
 	var args []any
 	arg := func(v any) int { args = append(args, v); return len(args) }
@@ -92,8 +101,8 @@ func (s *Service) readActivities(ctx context.Context, tx pgx.Tx, personID ids.Pe
 		return nil, false, err
 	}
 	rows, err := tx.Query(ctx, fmt.Sprintf(`
-		SELECT a.id, a.kind, a.subject, a.body, a.direction, a.occurred_at,
-		       a.due_at, a.is_done, a.source, a.captured_by, a.created_at
+		SELECT a.id, a.kind, a.channel_provider, a.subject, a.body, a.direction,
+		       a.occurred_at, a.due_at, a.is_done, a.source, a.captured_by, a.created_at
 		FROM activity a
 		WHERE a.archived_at IS NULL AND %s AND (%s) %s
 		ORDER BY a.occurred_at DESC, a.id DESC
@@ -107,8 +116,9 @@ func (s *Service) readActivities(ctx context.Context, tx pgx.Tx, personID ids.Pe
 	for rows.Next() {
 		var a crmcontracts.Activity
 		var id ids.UUID
-		if err := rows.Scan(&id, &a.Kind, &a.Subject, &a.Body, &a.Direction,
-			&a.OccurredAt, &a.DueAt, &a.IsDone, &a.Source, &a.CapturedBy, &a.CreatedAt); err != nil {
+		if err := rows.Scan(&id, &a.Kind, &a.ChannelProvider, &a.Subject, &a.Body,
+			&a.Direction, &a.OccurredAt, &a.DueAt, &a.IsDone, &a.Source, &a.CapturedBy,
+			&a.CreatedAt); err != nil {
 			return nil, false, err
 		}
 		a.Id = openapi_types.UUID(id)

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -4716,6 +4716,9 @@ export const de = {
   "person.drawer.close": "Schließen",
   "person.composer.title": "Follow-up entwerfen · {name}",
   "person.composer.to": "An",
+  "person.composer.transport": "Versandweg",
+  "person.composer.transportEmail": "E-Mail",
+  "person.composer.toConversation": "Setzt Ihre {transport}-Unterhaltung fort",
   "person.composer.subject": "Betreff",
   "person.composer.bcc": "Bcc",
   "person.composer.bccPlaceholder":

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -4714,6 +4714,9 @@ export const en = {
   "person.drawer.close": "Close",
   "person.composer.title": "Draft follow-up · {name}",
   "person.composer.to": "To",
+  "person.composer.transport": "How to send",
+  "person.composer.transportEmail": "Email",
+  "person.composer.toConversation": "Continues your {transport} conversation",
   "person.composer.subject": "Subject",
   "person.composer.bcc": "Bcc",
   "person.composer.bccPlaceholder":

--- a/frontend/src/i18n/i18n.test.ts
+++ b/frontend/src/i18n/i18n.test.ts
@@ -43,6 +43,10 @@ const KEPT_IN_ENGLISH = new Set<string>([
   // vocabulary ("email", "mobile"), so there is no literal here to translate
   // and a translation could only rename somebody else's pool.
   "provider.credits.pool",
+  // "Email" is the Vietnamese word for email. de has "E-Mail" and differs;
+  // vi does not, and inventing a difference would name the transport
+  // something no Vietnamese speaker calls it.
+  "person.composer.transportEmail",
   // The same proper noun as co.chip.linkedin, one surface over.
   "provider.profile.linkedin",
   "person.page.linkedin",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -4686,6 +4686,10 @@ export const vi = {
   "person.drawer.close": "Đóng",
   "person.composer.title": "Soạn thư tiếp theo · {name}",
   "person.composer.to": "Đến",
+  "person.composer.transport": "Cách gửi",
+  "person.composer.transportEmail": "Email",
+  "person.composer.toConversation":
+    "Tiếp tục cuộc trò chuyện {transport} của bạn",
   "person.composer.subject": "Chủ đề",
   "person.composer.bcc": "Bcc",
   "person.composer.bccPlaceholder":

--- a/frontend/src/screens/compose.tsx
+++ b/frontend/src/screens/compose.tsx
@@ -1465,6 +1465,64 @@ function useChannelReachable(
   );
 }
 
+// The reply affordance for ONE captured conversation, on its own so the two
+// surfaces that offer it cannot come to offer different things.
+//
+// It exists as a separate export because the conversation-memory card wants
+// exactly this and nothing else: Relink below is a raw-ledger act — "this
+// activity is filed against the wrong record" — and a summary card is not where
+// a reader re-files anything.
+//
+// The gate is the same one TimelineActions applies, and that sameness is the
+// point of the extraction rather than a happy accident: a `message` row is
+// withheld when the person behind it cannot be reached on the transport that
+// carried it, and a rep offered a reply on one surface and refused it on the
+// other would have no way to tell which answer was true.
+export function ChannelReplyAction({
+  activityId,
+  kind,
+  channelProvider,
+  entityType,
+  entityId,
+  personId,
+}: Readonly<{
+  activityId: string;
+  kind: Activity["kind"];
+  channelProvider?: string;
+  entityType: RelinkKind;
+  entityId: string;
+  personId?: string;
+}>) {
+  const t = useT();
+  const [reply, setReply] = useState(false);
+  const reachable = useChannelReachable(
+    kind === "message",
+    personId,
+    channelProvider,
+  );
+  if (!reachable) {
+    return null;
+  }
+  return (
+    <>
+      <Button small onClick={() => setReply(true)}>
+        {t("compose.reply")}
+      </Button>
+      {reply && (
+        <ComposeModal
+          activityId={activityId}
+          entityType={entityType}
+          entityId={entityId}
+          personId={personId}
+          kind={kind}
+          open={reply}
+          onClose={() => setReply(false)}
+        />
+      )}
+    </>
+  );
+}
+
 // The per-row action cluster the 360 timelines mount in each entry's action
 // slot.
 //
@@ -1494,34 +1552,20 @@ export function TimelineActions({
   personId?: string;
 }>) {
   const t = useT();
-  const [reply, setReply] = useState(false);
   const [relink, setRelink] = useState(false);
-  const reachable = useChannelReachable(
-    activity.kind === "message",
-    personId,
-    activity.channel_provider ?? undefined,
-  );
   return (
     <>
-      {reachable && (
-        <Button small onClick={() => setReply(true)}>
-          {t("compose.reply")}
-        </Button>
-      )}
+      <ChannelReplyAction
+        activityId={activity.id}
+        kind={activity.kind}
+        channelProvider={activity.channel_provider ?? undefined}
+        entityType={entityType}
+        entityId={entityId}
+        personId={personId}
+      />
       <Button small onClick={() => setRelink(true)}>
         {t("compose.relink")}
       </Button>
-      {reply && (
-        <ComposeModal
-          activityId={activity.id}
-          entityType={entityType}
-          entityId={entityId}
-          personId={personId}
-          kind={activity.kind}
-          open={reply}
-          onClose={() => setReply(false)}
-        />
-      )}
       {relink && (
         <RelinkModal
           activityId={activity.id}

--- a/frontend/src/screens/person360.css
+++ b/frontend/src/screens/person360.css
@@ -403,9 +403,16 @@
    said, its standing, the time. */
 .pe-memory-row {
   display: grid;
-  grid-template-columns: 64px auto minmax(0, 1fr) auto auto;
+  /* The last track is the reply, and it is sized `auto` so a row that offers
+     none collapses it to nothing rather than reserving a gutter across every
+     mail row for a button only channel rows have. */
+  grid-template-columns: 64px auto minmax(0, 1fr) auto auto auto;
   gap: var(--space-3);
   align-items: start;
+}
+
+.pe-memory-action:empty {
+  display: none;
 }
 
 .pe-memory-date {
@@ -454,6 +461,13 @@
 
   .pe-memory-date,
   .pe-memory-channel {
+    grid-column: 1 / -1;
+  }
+
+  /* The reply takes its own line rather than being squeezed beside the time:
+     at this width the two would each get half a column and the button would
+     wrap its own label. */
+  .pe-memory-action {
     grid-column: 1 / -1;
   }
 }

--- a/frontend/src/screens/persondrawers.transport.test.tsx
+++ b/frontend/src/screens/persondrawers.transport.test.tsx
@@ -1,0 +1,207 @@
+/** @vitest-environment jsdom */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render as rtlRender, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { components } from "../api/schema";
+import { LocaleProvider } from "../i18n";
+import { PersonComposer } from "./persondrawers";
+import { installFetchStub, jsonResponse, meRoute } from "./story-utils";
+
+// Which way a message leaves, and when the composer bothers to ask.
+//
+// The rule under test is adaptive rather than fixed: a contact reachable one
+// way gets the composer they have always had, and the choice appears only when
+// there is a choice to make. A picker that always rendered would put a
+// one-option control on every mail-only contact in the installation.
+//
+// The second rule is what a channel composer must NOT show. Mail's subject,
+// bcc, send-later and AI draft are each absent for their own reason — a
+// messaging channel has no subject line, send-message takes no schedule, and
+// the model lane drafts mail only — so a channel composer that rendered them
+// would be offering fields the send cannot carry.
+
+type View = components["schemas"]["Person360"];
+type Activity = components["schemas"]["Activity"];
+
+const anEmail = {
+  id: "pe-1",
+  person_id: "p-1",
+  email: "dana@brandt.example",
+  email_type: "work" as const,
+  is_primary: true,
+  position: 0,
+  source: "manual",
+  captured_by: "human:u1",
+};
+
+function aMessage(provider: string, at: string, id: string): Activity {
+  return {
+    id,
+    kind: "message",
+    channel_provider: provider,
+    direction: "inbound",
+    body: "they wrote",
+    occurred_at: at,
+    created_at: at,
+    updated_at: at,
+    is_done: false,
+    source: "ext:dispact-connector:dispact",
+    version: 1,
+  } as Activity;
+}
+
+// A view with exactly the reachability and conversations a case needs. Every
+// field the composer reads is stated; nothing is inherited from a fixture that
+// might change for another test's reasons.
+function viewWith(
+  options: Readonly<{
+    email?: boolean;
+    reachable?: { provider: string; reachable: boolean }[];
+    activities?: Activity[];
+  }>,
+): View {
+  return {
+    as_of: "2026-08-15T09:00:00Z",
+    person: {
+      id: "p-1",
+      full_name: "Dana Buyer",
+      emails: options.email ? [anEmail] : [],
+      reachability: (options.reachable ?? []).map((entry) => ({
+        ...entry,
+        since: "2026-08-15T08:00:00Z",
+      })),
+    },
+    activities: { data: options.activities ?? [] },
+    sections_omitted: [],
+  } as unknown as View;
+}
+
+function render(view: View) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const Wrapper = ({ children }: Readonly<{ children: ReactNode }>) => (
+    <QueryClientProvider client={client}>
+      <LocaleProvider>{children}</LocaleProvider>
+    </QueryClientProvider>
+  );
+  return rtlRender(
+    <PersonComposer
+      personId="p-1"
+      view={view}
+      guard={undefined}
+      open={true}
+      onClose={() => {}}
+    />,
+    { wrapper: Wrapper },
+  );
+}
+
+describe("the person composer's transport choice", () => {
+  beforeEach(() => {
+    installFetchStub({
+      "GET /me": meRoute({}),
+      "GET /consent-purposes": () => jsonResponse({ data: [] }),
+      "GET /channel-providers": () =>
+        jsonResponse({
+          data: [
+            { provider: "dispact", label: "Dispact", supplies_transport: true },
+          ],
+        }),
+    });
+  });
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  // The common contact: one address, no channel. Nothing about the composer
+  // changes, which is the whole point of making the picker conditional.
+  it("asks nothing when the only way to reach them is mail", () => {
+    render(viewWith({ email: true }));
+
+    expect(screen.queryByLabelText("How to send")).toBeNull();
+    // And it is still the mail composer: the subject line is the cheapest
+    // proof, since a channel composer withholds it.
+    expect(screen.getByLabelText("Subject")).toBeTruthy();
+  });
+
+  // Two ways to reach them, so the rep decides. Inferring it from what they
+  // typed would be guessing at the one choice that cannot be undone.
+  it("offers the choice when there is one to make", async () => {
+    render(
+      viewWith({
+        email: true,
+        reachable: [{ provider: "dispact", reachable: true }],
+        activities: [aMessage("dispact", "2026-08-15T08:00:00Z", "a-1")],
+      }),
+    );
+
+    // The picker exists, which is the rule under test. Its options live in a
+    // listbox that opens on click, so this asserts the CONTROL rather than
+    // driving it open — what the two options are is settled by the two
+    // withholding cases below, which prove the list is built from
+    // reachability and anchors rather than from everything.
+    const picker = await screen.findByLabelText("How to send");
+    expect(picker).toBeTruthy();
+    // Mail leads, because it is the transport that can open a conversation.
+    expect(screen.getByText("Email")).toBeTruthy();
+  });
+
+  // The contact this whole change exists for: no address anywhere, and a
+  // conversation on a unit-supplied transport. Before this, the composer
+  // offered mail to somebody who has no mailbox.
+  it("opens on the channel when that is the only way to reach them", async () => {
+    render(
+      viewWith({
+        reachable: [{ provider: "dispact", reachable: true }],
+        activities: [aMessage("dispact", "2026-08-15T08:00:00Z", "a-1")],
+      }),
+    );
+
+    // The recipient names the conversation rather than an address, because the
+    // server resolves it from the conversation being answered.
+    expect(
+      await screen.findByDisplayValue("Continues your Dispact conversation"),
+    ).toBeTruthy();
+    // One transport, so no picker — and it is the CHANNEL composer, which
+    // withholds every field mail has and a channel does not.
+    expect(screen.queryByLabelText("How to send")).toBeNull();
+    expect(screen.queryByLabelText("Subject")).toBeNull();
+    expect(screen.queryByLabelText("Bcc")).toBeNull();
+    expect(screen.queryByLabelText("Send later (optional)")).toBeNull();
+  });
+
+  // Reachability and an anchor answer different questions, and BOTH are
+  // required. A live identity with no conversation has nothing to continue —
+  // there is no endpoint that opens one — so offering it would be a choice
+  // that fails at the send.
+  it("withholds a transport the person is reachable on but has no conversation on", () => {
+    render(
+      viewWith({
+        email: true,
+        reachable: [{ provider: "dispact", reachable: true }],
+      }),
+    );
+
+    expect(screen.queryByLabelText("How to send")).toBeNull();
+    expect(screen.queryByText("Dispact")).toBeNull();
+  });
+
+  // The mirror: a conversation exists, but the identity is blocked or archived.
+  // A reply staged against it would be refused at the send, so the composer
+  // does not offer the transport at all.
+  it("withholds a transport whose identity is no longer reachable", () => {
+    render(
+      viewWith({
+        email: true,
+        reachable: [{ provider: "dispact", reachable: false }],
+        activities: [aMessage("dispact", "2026-08-15T08:00:00Z", "a-1")],
+      }),
+    );
+
+    expect(screen.queryByLabelText("How to send")).toBeNull();
+    expect(screen.queryByText("Dispact")).toBeNull();
+  });
+});

--- a/frontend/src/screens/persondrawers.tsx
+++ b/frontend/src/screens/persondrawers.tsx
@@ -14,6 +14,7 @@ import { Badge, Button, Modal, TextInput } from "../design-system/atoms";
 import { RichText } from "../design-system/richtext";
 import { Select } from "../design-system/select";
 import { useT } from "../i18n";
+import { useProviderLabel } from "./channelproviders";
 import { problemMessageOf, throwProblem } from "./common";
 import { refusalOf, SendRefusal, scheduleFields } from "./compose";
 import { useConsentPurposes } from "./consent";
@@ -260,6 +261,278 @@ function addressList(raw: string): string[] | undefined {
   return out.length > 0 ? out : undefined;
 }
 
+// Which ways this person can be written to, right now, in the order the
+// composer offers them.
+//
+// Mail leads when there is an address, because it is the one transport that can
+// OPEN a conversation: `POST /emails` names its addressee. A channel cannot —
+// `send-message` resolves the recipient from the conversation being answered
+// and there is deliberately no account-started twin — so a channel is offered
+// only when this person already has a conversation on it, and the most recent
+// one is the anchor a reply would continue.
+//
+// Reachability and the anchor are BOTH required, and they answer different
+// questions: reachability says the identity is live and unblocked, the anchor
+// says there is something to continue. A transport with one and not the other
+// would be a choice that fails at the send.
+function transportsFor(
+  view: Person360,
+  providerLabel: (provider: string) => string,
+  t: ReturnType<typeof useT>,
+): Transport[] {
+  const out: Transport[] = [];
+  if (view.person.emails?.[0]?.email) {
+    out.push({ id: "email", label: t("person.composer.transportEmail") });
+  }
+  const reachable = new Set(
+    (view.person.reachability ?? [])
+      .filter((channel) => channel.reachable)
+      .map((channel) => channel.provider),
+  );
+  // Most recent first, so the first row seen for a provider IS its latest
+  // conversation — the one a rep means when they pick that transport.
+  const newestFirst = [...(view.activities?.data ?? [])].sort(
+    (a, b) =>
+      new Date(b.occurred_at).getTime() - new Date(a.occurred_at).getTime(),
+  );
+  for (const activity of newestFirst) {
+    const provider = activity.channel_provider;
+    if (
+      activity.kind !== "message" ||
+      !provider ||
+      !reachable.has(provider) ||
+      out.some((transport) => transport.id === provider)
+    ) {
+      continue;
+    }
+    out.push({
+      id: provider,
+      label: providerLabel(provider),
+      anchorId: activity.id,
+    });
+  }
+  return out;
+}
+
+// Whether this composer holds something the chosen transport can actually
+// carry.
+//
+// A channel send owes no subject and names no address, so the mail predicate
+// would refuse every one of them. What it owes instead is an ANCHOR: without a
+// conversation to answer there is nothing for the server to resolve a
+// recipient from, and the send would 404 on a button that looked ready.
+function canSendOn({
+  transport,
+  isChannel,
+  recipient,
+  subject,
+  body,
+  purpose,
+}: Readonly<{
+  transport: Transport | undefined;
+  isChannel: boolean;
+  recipient: string;
+  subject: string;
+  body: string;
+  purpose: string;
+}>): boolean {
+  if (isChannel) {
+    return transport?.anchorId != null && body.trim() !== "" && purpose !== "";
+  }
+  return canSend({ recipient, subject, body, purpose });
+}
+
+// Who the message is going to, in the vocabulary of the transport carrying it.
+//
+// A channel names the CONVERSATION rather than an address, and it is read-only
+// for a stronger reason than mail's: the recipient is resolved server-side from
+// the conversation being answered, so an editable field would promise a choice
+// the send does not offer.
+function ToLine({
+  transport,
+  isChannel,
+  address,
+}: Readonly<{
+  transport: Transport | undefined;
+  isChannel: boolean;
+  address: string;
+}>) {
+  const t = useT();
+  return (
+    <>
+      <label className="pe-field-label" htmlFor="composer-to">
+        {t("person.composer.to")}
+      </label>
+      <TextInput
+        id="composer-to"
+        value={
+          isChannel
+            ? t("person.composer.toConversation", {
+                transport: transport?.label ?? "",
+              })
+            : address
+        }
+        readOnly
+      />
+    </>
+  );
+}
+
+// The composer's transport choice: what is available, which is selected, and
+// whether that one is a channel.
+//
+// A hook rather than three lines in the composer because the composer is at its
+// complexity ceiling and this is one idea — "which way is this going" — that a
+// reader should be able to take in on its own.
+function useTransportChoice(view: Person360) {
+  const t = useT();
+  const providerLabel = useProviderLabel();
+  const transports = transportsFor(view, providerLabel, t);
+  // The composer opens on the first way this person can be reached. An empty
+  // selection resolves to that rather than being seeded, so a contact whose
+  // reachability arrives after the first render does not stay stuck on the
+  // transport that existed before it.
+  const [transportId, setTransportId] = useState("");
+  const transport =
+    transports.find((option) => option.id === transportId) ?? transports[0];
+  return {
+    transports,
+    transport,
+    isChannel: transport != null && transport.id !== "email",
+    setTransportId,
+  };
+}
+
+// The three fields mail has and a channel does not, each absent for its own
+// reason rather than as a group: send-message takes no schedule, there is no
+// draft-message endpoint (the model lane drafts mail only), and a messaging
+// channel has no subject line.
+//
+// Rendering them disabled on a channel would suggest a capability that is
+// coming. They are simply not part of that transport.
+function MailOnlyFields({
+  sendAt,
+  onSendAtChange,
+  subject,
+  onSubjectChange,
+  intent,
+  onIntentChange,
+  draftPending,
+  draftError,
+  onDraft,
+}: Readonly<{
+  sendAt: string;
+  onSendAtChange: (next: string) => void;
+  subject: string;
+  onSubjectChange: (next: string) => void;
+  intent: string;
+  onIntentChange: (next: string) => void;
+  draftPending: boolean;
+  draftError: unknown;
+  onDraft: () => void;
+}>) {
+  const t = useT();
+  return (
+    <>
+      <label className="pe-field-label" htmlFor="composer-send-at">
+        {t("compose.sendLaterLabel")}
+      </label>
+      <TextInput
+        id="composer-send-at"
+        type="datetime-local"
+        value={sendAt}
+        onChange={(event) => onSendAtChange(event.target.value)}
+      />
+
+      <DraftBar
+        intent={intent}
+        onIntentChange={onIntentChange}
+        pending={draftPending}
+        error={draftError}
+        onDraft={onDraft}
+      />
+
+      <label className="pe-field-label" htmlFor="composer-subject">
+        {t("person.composer.subject")}
+      </label>
+      <TextInput
+        id="composer-subject"
+        value={subject}
+        onChange={(event) => onSubjectChange(event.target.value)}
+      />
+    </>
+  );
+}
+
+// The channel half of the composer's send.
+//
+// It anchors on the conversation and carries no subject, no bcc and no
+// schedule — and names no addressee, because the server resolves the recipient
+// from the conversation being answered. That resolution is the reason a caller
+// cannot open a channel conversation at all, and the reason this takes an
+// anchor rather than a person.
+async function sendChannelReply(
+  anchorId: string,
+  body: string,
+  purpose: string,
+) {
+  const { data, error } = await api.POST("/activities/{id}/send-message", {
+    params: { path: { id: anchorId } },
+    body: { body, consent_purpose: purpose },
+  });
+  if (error) {
+    throwProblem(error);
+  }
+  return data;
+}
+
+// The transport choice, rendered only when there IS one.
+//
+// One transport gets the composer this contact has always had: a picker with a
+// single option is a control that cannot be used, and it would appear on every
+// mail-only contact in the installation to say nothing.
+function TransportPicker({
+  transports,
+  selected,
+  onChange,
+}: Readonly<{
+  transports: Transport[];
+  selected: Transport | undefined;
+  onChange: (next: string) => void;
+}>) {
+  const t = useT();
+  if (transports.length < 2) {
+    return null;
+  }
+  return (
+    <>
+      <label className="pe-field-label" htmlFor="composer-transport">
+        {t("person.composer.transport")}
+      </label>
+      <Select
+        id="composer-transport"
+        value={selected?.id ?? ""}
+        onChange={onChange}
+        options={transports.map((option) => ({
+          value: option.id,
+          label: option.label,
+        }))}
+      />
+    </>
+  );
+}
+
+type Transport = {
+  // `email` or a channel_provider id. The two live in one namespace because the
+  // composer picks one of them, and `email` is not a provider grammar match so
+  // it cannot collide with one.
+  id: string;
+  label: string;
+  // Absent for mail, which opens its own conversation. Present for every
+  // channel, because a channel reply is anchored by contract.
+  anchorId?: string;
+};
+
 // The composer's own head: who it is to, and whether it may go at all.
 //
 // Its own component because the verdict line has three states a reader must be
@@ -356,6 +629,8 @@ export function PersonComposer({
   // that sends formatted mail.
   const [bcc, setBcc] = useState("");
   const [sendAt, setSendAt] = useState("");
+  const { transports, transport, isChannel, setTransportId } =
+    useTransportChoice(view);
 
   // One spelling of "this composer holds no message", for the two moments that
   // need it: the recipient changing, and a send succeeding.
@@ -375,6 +650,10 @@ export function PersonComposer({
   if (wroteFor !== personId) {
     setWroteFor(personId);
     clearMessage();
+    // The transport belongs to the recipient too. Left alone, a composer
+    // switched from a contact reachable on Dispact to one reachable only by
+    // mail would keep a channel selected and send nowhere.
+    setTransportId("");
   }
 
   // Drafting is a BUTTON, not something the drawer does to you. Opening a
@@ -418,6 +697,11 @@ export function PersonComposer({
   // carries the person as its link.
   const send = useMutation({
     mutationFn: async () => {
+      // A channel reply is a different operation against a different shape —
+      // see sendChannelReply.
+      if (isChannel && transport?.anchorId) {
+        return sendChannelReply(transport.anchorId, body, purpose);
+      }
       const { data, error } = await api.POST("/emails", {
         body: {
           subject,
@@ -447,7 +731,9 @@ export function PersonComposer({
     onSuccess: clearMessage,
   });
 
-  const sendable = allowed && canSend({ recipient, subject, body, purpose });
+  const sendable =
+    allowed &&
+    canSendOn({ transport, isChannel, recipient, subject, body, purpose });
 
   return (
     <Modal
@@ -467,49 +753,54 @@ export function PersonComposer({
       />
 
       <div className="drawer-body">
-        <label className="pe-field-label" htmlFor="composer-to">
-          {t("person.composer.to")}
-        </label>
-        <TextInput id="composer-to" value={recipient} readOnly />
-
-        <label className="pe-field-label" htmlFor="composer-bcc">
-          {t("person.composer.bcc")}
-        </label>
-        <TextInput
-          id="composer-bcc"
-          value={bcc}
-          onChange={(event) => setBcc(event.target.value)}
-          placeholder={t("person.composer.bccPlaceholder")}
+        <TransportPicker
+          transports={transports}
+          selected={transport}
+          onChange={(next) => {
+            setTransportId(next);
+            // The words do not travel between transports. A subject typed for
+            // mail has nowhere to go on a channel, and a body written for one
+            // conversation should not arrive in another because a rep changed
+            // their mind about the medium.
+            clearMessage();
+          }}
         />
+
+        <ToLine
+          transport={transport}
+          isChannel={isChannel}
+          address={recipient}
+        />
+
+        {!isChannel && (
+          <>
+            <label className="pe-field-label" htmlFor="composer-bcc">
+              {t("person.composer.bcc")}
+            </label>
+            <TextInput
+              id="composer-bcc"
+              value={bcc}
+              onChange={(event) => setBcc(event.target.value)}
+              placeholder={t("person.composer.bccPlaceholder")}
+            />
+          </>
+        )}
 
         <PurposePicker purpose={purpose} onChange={setPurpose} />
 
-        <label className="pe-field-label" htmlFor="composer-send-at">
-          {t("compose.sendLaterLabel")}
-        </label>
-        <TextInput
-          id="composer-send-at"
-          type="datetime-local"
-          value={sendAt}
-          onChange={(event) => setSendAt(event.target.value)}
-        />
-
-        <DraftBar
-          intent={intent}
-          onIntentChange={setIntent}
-          pending={draft.isPending}
-          error={draft.isError ? draft.error : null}
-          onDraft={() => draft.mutate()}
-        />
-
-        <label className="pe-field-label" htmlFor="composer-subject">
-          {t("person.composer.subject")}
-        </label>
-        <TextInput
-          id="composer-subject"
-          value={subject}
-          onChange={(event) => setSubject(event.target.value)}
-        />
+        {!isChannel && (
+          <MailOnlyFields
+            sendAt={sendAt}
+            onSendAtChange={setSendAt}
+            subject={subject}
+            onSubjectChange={setSubject}
+            intent={intent}
+            onIntentChange={setIntent}
+            draftPending={draft.isPending}
+            draftError={draft.isError ? draft.error : null}
+            onDraft={() => draft.mutate()}
+          />
+        )}
 
         <label className="pe-field-label" htmlFor="composer-body">
           {t("person.composer.body")}

--- a/frontend/src/screens/personmemory.tsx
+++ b/frontend/src/screens/personmemory.tsx
@@ -6,6 +6,7 @@ import { Badge, SegmentedControl } from "../design-system/atoms";
 import { Panel, PanelBody, PanelRow } from "../design-system/panel";
 import { useT } from "../i18n";
 import { useProviderLabel } from "./channelproviders";
+import { ChannelReplyAction } from "./compose";
 
 // Conversation memory (concept §5.10, ADR-0097 D3).
 //
@@ -13,6 +14,17 @@ import { useProviderLabel } from "./channelproviders";
 // about, not the transport events it was made of. The Activity tab remains the
 // complete raw ledger beside it: a summary never replaces the original, and a
 // withheld activity never leaks through one.
+//
+// It also carries the REPLY, and that is a deliberate exception to "summary,
+// not ledger". A captured channel message links to a person, and this card is
+// the only routed surface a person's channel conversations appear on — the
+// timelines that mount the full action cluster are the deal, company and
+// person-list ones, and the last of those is not routed in this build. Without
+// the reply here, a transport the installation can demonstrably send on has no
+// button anywhere: the whole path exists, is governed, and is unreachable by
+// the human it was built for.
+//
+// Only the reply, though. Relink is a raw-ledger act and stays on the ledger.
 
 type Person360 = components["schemas"]["Person360"];
 type Activity = components["schemas"]["Activity"];
@@ -76,6 +88,24 @@ export function PersonMemory({ view }: Readonly<{ view: Person360 }>) {
             <span />
           )}
           <span className="pe-memory-time">{row.time}</span>
+          {/* Reply, on the same terms the 360 timelines offer it: available on
+              any row, and WITHHELD on a channel row whose person cannot be
+              reached on the transport that carried it. Mail behaves exactly as
+              it does there — the composer picks send-message over send-email
+              from the row's kind, and nothing else about the interaction
+              differs. A row with no anchor renders nothing. */}
+          <span className="pe-memory-action">
+            {row.activityId && row.kind && (
+              <ChannelReplyAction
+                activityId={row.activityId}
+                kind={row.kind}
+                channelProvider={row.channelProvider ?? undefined}
+                entityType="person"
+                entityId={view.person.id}
+                personId={view.person.id}
+              />
+            )}
+          </span>
         </PanelRow>
       ))}
     </Panel>
@@ -86,6 +116,13 @@ type Row = {
   key: string;
   date: string;
   time: string;
+  // What a reply anchors on, and the transport it would leave by. Null when the
+  // row is not a channel message, or when the entry names no activity — a
+  // thread projection is not obliged to carry one, and a reply anchored on
+  // nothing is a button that can only fail.
+  activityId: string | null;
+  kind: Activity["kind"] | null;
+  channelProvider: string | null;
   channel: string;
   channelLabel: string;
   title: string;
@@ -127,6 +164,17 @@ function fromEntry(
     key: entry.key,
     date: dayMonth(entry.occurred_at),
     time: clock(entry.occurred_at),
+    // first_activity_id is what "expand to original" opens, and it is the right
+    // anchor for a reply too: the send resolves the conversation from the
+    // anchor's own links and thread key, so the first message of a thread names
+    // the same conversation as its last.
+    activityId: entry.first_activity_id ?? null,
+    // The row's own kind, whatever it is. A reply is offered on a mail row
+    // exactly as it is on a channel one — the same rule the 360 timelines
+    // apply — because a composer gated to channel rows would leave a workspace
+    // whose only rows are mail unable to answer anything from here.
+    kind: entry.channel,
+    channelProvider: entry.channel_provider ?? null,
     channel: channelKeyOf(entry.channel, entry.channel_provider),
     channelLabel: labelFor(
       channelKeyOf(entry.channel, entry.channel_provider),
@@ -158,6 +206,9 @@ function foldActivities(
         key: row.id,
         date: dayMonth(row.occurred_at),
         time: clock(row.occurred_at),
+        activityId: row.id,
+        kind: row.kind,
+        channelProvider: row.channel_provider ?? null,
         channel: channelKeyOf(row.kind, row.channel_provider),
         channelLabel: labelFor(
           channelKeyOf(row.kind, row.channel_provider),


### PR DESCRIPTION
## What

#1368 shipped the whole channel send path and proved it against a live provider. **It shipped with no way for a rep to reach it.**

The composer was there and correctly wired — `TimelineActions` renders Reply for a `kind === "message"` row and posts `/activities/{id}/send-message`. But it is mounted on the **deal**, **company** and **person-list** timelines, and a captured channel message links to a **person**, whose only routed surface is the contact page — whose conversation-memory card mounted no actions at all. So for exactly the conversations that slice creates, the button existed nowhere. The UAT sent through the API and never noticed.

Found by the user opening the contact and asking where the send button was.

## Two ways in

**Reply, on the row.** The memory card now carries the reply — a deliberate exception to "summary, not ledger", and *only* the reply: Relink is a raw-ledger act and stays on the ledger. Extracted as `ChannelReplyAction` so the two surfaces that offer a reply cannot come to offer different things.

**The header composer, made general — and adaptive.** It lists every way this person can be reached and asks only when there is a choice:

| Contact | Composer |
|---|---|
| Address only | unchanged — no picker |
| Address + a Dispact conversation | picker: Email, Dispact |
| No address, one conversation | opens on that channel, no picker |

A picker with one option is a control that cannot be used, so it doesn't render. The case that motivated it: a contact with **no address at all**, where the header offered mail to somebody with no mailbox while a live conversation sat below.

## What a channel transport can and cannot do, stated rather than implied

It **continues** a conversation and never **opens** one. `send-message` resolves the recipient from the conversation being answered, and there is deliberately no account-started twin (`sendAccountEmail` exists; `sendAccountMessage` does not). So a transport is offered only when the person already has a conversation on it **and** the identity is still reachable — two different questions, and a transport with one and not the other would be a choice that fails at the send. Both withholding cases are tested.

Mail's subject, bcc, send-later and AI draft are withheld on a channel, each for its own reason: no subject line, `send-message` takes no schedule, and the model lane drafts mail only. Rendering them disabled would promise a capability that is coming.

## Structure

`PersonComposer` was at the complexity ceiling before this and over it after, so the pieces came out as their own units rather than as a lint suppression: `useTransportChoice`, `TransportPicker`, `ToLine`, `MailOnlyFields`, `canSendOn`, `sendChannelReply`.

## Proof

- `make frontend-check` — exit 0, **2692 tests**
- `make check-backend` — exit 0
- `make craft-static` — 0/0/0 across all three roots
- Five new tests pin the adaptive rule and both withholding cases

## Related

- Follows #1368 (SP5 slice 2)
- **#1382** — filed while testing this: a channel-captured person is minted with no email, so the same human becomes a second contact. The connector *has* the address and the counterparty rule forces it to drop it. Spec discrepancy, raised not worked around.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lets reps reply to captured channel conversations from the contact page and fixes the person timeline to include each message’s `channel_provider`. Previously the send path existed but was unreachable in the UI and timeline rows reported a null provider, so channels could not be named or selected.

- Reply on memory card: adds Reply on message rows using the same gate as timeline actions; only Reply is shown (Relink stays on the ledger). Shared via ChannelReplyAction to keep behavior consistent across surfaces.
- Header composer: offers Email and any reachable channel that has a conversation anchor; Email leads; shows a transport picker only when there’s a real choice. With a single available transport, it opens directly on that one.
- Channel semantics: continues an existing conversation only (anchors on the activity); offered only when the identity is reachable and a conversation exists; hides mail-only fields (subject, bcc, send‑later, model draft); To is read‑only and describes the continued conversation. Switching person/transport clears drafted content. Send gating moved to canSendOn.
- Backend: person360 timeline now selects/scans `channel_provider`; adds an integration test asserting the provider round‑trips so the memory card can label transports and the composer can offer them.
- Implementation/tests/i18n: extracted useTransportChoice, TransportPicker, ToLine, MailOnlyFields, sendChannelReply; added `persondrawers.transport.test.tsx` covering adaptive choice and withholding cases; added i18n strings (en/de/vi); memory layout adds a reply column without reserving space when absent.

<sup>Written for commit ed7cdad9ce7c405ebac9bb8b1fb2b4375534ff3a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1383?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

