### PR TITLE
fix(channels): the transport registry is written at boot, not when a vault is (#1366)

### DIFF
--- a/backend/bootcomposition_test.go
+++ b/backend/bootcomposition_test.go
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package backendarch
+
+// The fitness gate on the boot sequence: a process role that composes
+// extensions also records what it composed.
+//
+// It is derived rather than listed. Naming cmd/api and cmd/worker here would
+// leave the next role to be remembered, and the whole failure this guards is a
+// role that quietly does not do something — nothing in a boot log says a
+// transport went unregistered. Asking "which roles register extensions" of the
+// tree means a new one arrives already covered.
+
+import (
+	"go/ast"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// The two compose entry points that must travel together. RegisterExtensions
+// declares what this binary composed; RecordComposition is what writes the
+// consequences down — the extension inventory, and the channel vocabulary those
+// units declare. A role with the first and not the second boots with units
+// installed and their transports unregistered, which is the state a captured
+// message on such a transport fails on, several layers away from the cause.
+const (
+	registersExtensions = "RegisterExtensions"
+	recordsComposition  = "RecordComposition"
+)
+
+func TestEveryRoleThatComposesExtensionsRecordsWhatItComposed(t *testing.T) {
+	roles, err := os.ReadDir("cmd")
+	if err != nil {
+		t.Fatalf("reading the process roles under cmd/: %v", err)
+	}
+	composing := 0
+	for _, role := range roles {
+		if !role.IsDir() {
+			continue
+		}
+		called := composeCallsIn(t, filepath.Join("cmd", role.Name()))
+		if !called[registersExtensions] {
+			continue
+		}
+		composing++
+		if !called[recordsComposition] {
+			t.Errorf("cmd/%s registers the composed extension set but never calls compose.%s — "+
+				"it boots with units installed and the transports they declare unregistered, "+
+				"and nothing in its log says so", role.Name(), recordsComposition)
+		}
+	}
+	if composing == 0 {
+		t.Fatal("no process role calls compose." + registersExtensions +
+			" — this gate compared nothing, so it cannot have held anything")
+	}
+}
+
+// composeCallsIn reports which compose.<Name> functions the role's package
+// calls. Selector-matched on the `compose` package name, which every role
+// imports unaliased; an aliased import would read as no call at all, so the
+// zero-roles guard above is what keeps that from passing quietly.
+func composeCallsIn(t *testing.T, dir string) map[string]bool {
+	t.Helper()
+	_, files := parseGoFilesUnder(t, dir)
+	called := map[string]bool{}
+	for _, file := range files {
+		ast.Inspect(file, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			sel, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok {
+				return true
+			}
+			if pkg, ok := sel.X.(*ast.Ident); ok && pkg.Name == "compose" {
+				called[sel.Sel.Name] = true
+			}
+			return true
+		})
+	}
+	return called
+}

--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -92,10 +92,12 @@ func run(ctx context.Context, args []string, stdout io.Writer) error {
 	if err != nil {
 		return err
 	}
-	// Record the composed extension set when it changed since the last
-	// boot — install/upgrade/removal happen in source, so this is where
-	// they become observable (ADR-0069 §5).
-	if err := compose.ObserveExtensionInventory(ctx, pool, logger, extensions); err != nil {
+	// What this binary composed, recorded before it serves: the extension
+	// inventory (install/upgrade/removal happen in source, so this is where
+	// they become observable — ADR-0069 §5) and the channel vocabulary those
+	// units declare. Before the server is assembled, which loads the transport
+	// directory FROM the rows this writes.
+	if err := compose.RecordComposition(ctx, pool, logger, extensions); err != nil {
 		return err
 	}
 

--- a/backend/cmd/worker/main.go
+++ b/backend/cmd/worker/main.go
@@ -86,10 +86,14 @@ func run(ctx context.Context, args []string, stdout io.Writer) error {
 		return err
 	}
 
-	// Record the composed extension set when it changed since the last boot
-	// (ADR-0069 §5); pre-bootstrap it skips — the api records the first
-	// observation once it has bootstrapped the installation.
-	if err := compose.ObserveExtensionInventory(ctx, pool, logger, boot.extensions); err != nil {
+	// What this binary composed (ADR-0069 §5); pre-bootstrap the inventory half
+	// skips — the api records the first observation once it has bootstrapped
+	// the installation. The worker composes the same units the api does and
+	// runs the send path, so it registers the same channel vocabulary and
+	// answers "can a reply leave this installation" from the same set; the
+	// write is an idempotent upsert, so whichever role boots second changes
+	// nothing.
+	if err := compose.RecordComposition(ctx, pool, logger, boot.extensions); err != nil {
 		return err
 	}
 

--- a/backend/internal/compose/bootcomposition.go
+++ b/backend/internal/compose/bootcomposition.go
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The boot step that records what this binary composed. Both halves are facts
+// derived from the same registered extension set, so they are one step rather
+// than two a role could wire half of.
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/gradionhq/margince/backend/pkg/extension"
+)
+
+// RecordComposition writes the two boot-time facts that follow from the
+// composed extension set: the inventory of the set itself, and the channel
+// vocabulary its units declare.
+//
+// One function because the ordering between them is not a caller's to choose —
+// the reconcile reads ComposedExtensions() and refuses a unit that shadows a
+// core transport, so it belongs after the set is observed and before anything
+// serves. A role that wired only the inventory would boot with units installed
+// and their transports unregistered, which is the state this step exists to
+// make unreachable.
+//
+// Every process role calls it, after RegisterExtensions and before it assembles
+// anything: server assembly loads the transport directory FROM the rows written
+// here.
+func RecordComposition(
+	ctx context.Context, pool *pgxpool.Pool, log *slog.Logger, exts []extension.Extension,
+) error {
+	if err := ObserveExtensionInventory(ctx, pool, log, exts); err != nil {
+		return fmt.Errorf("compose: recording the composed extension set: %w", err)
+	}
+	if err := ReconcileChannelProviders(ctx, pool); err != nil {
+		return fmt.Errorf("compose: registering this binary's channel vocabulary: %w", err)
+	}
+	return nil
+}

--- a/backend/internal/compose/capture.go
+++ b/backend/internal/compose/capture.go
@@ -13,7 +13,6 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
-	"fmt"
 	"log/slog"
 
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -136,6 +135,12 @@ func CaptureConfigFromDeploy(c deployconfig.Capture, log *slog.Logger) CaptureCo
 // runs the transient one-shot pull, which persists no credential). cfg carries
 // the deployment's suppression-list additions and the logger; the zero value is
 // the baselines and the default logger.
+//
+// A nil pool builds the registry for ENUMERATION only: nothing here queries, so
+// the construction is complete without one, and only a caller that goes on to
+// sync or send needs a real pool. CoreChannelProviders is the shipped caller
+// that takes it that way — asking which transports this binary compiled in is a
+// question about the binary, not about any database.
 func NewCaptureRegistry(pool *pgxpool.Pool, vault keyvault.Vault, cfg CaptureConfig) *capture.Registry {
 	db := InstallationDB(pool)
 	r := capture.NewRegistry(db, newCaptureSink(pool, cfg), identity.NewService(pool), vault)
@@ -151,20 +156,10 @@ func NewCaptureRegistry(pool *pgxpool.Pool, vault keyvault.Vault, cfg CaptureCon
 	// reads as "this installation has no Telegram integration" and parks every
 	// reply a rep writes.
 	r.Register(telegram.New(telegram.NewAPI(nil, "")))
-	// Reconcile the derived channel vocabulary against exactly what this call
-	// just registered (DESIGN-SP4 §4). A nil pool is a wiring-only construction
-	// (a unit test proving connector registration, never a real deployment —
-	// every other dependency here already tolerates it the same way, e.g.
-	// vault), so it skips the reconcile rather than dialing a pool that does
-	// not exist. A construction failure with a REAL pool is a boot failure, not
-	// a degraded mode: an installation that cannot confirm its own channel
-	// registry has no business answering "can I send" for anything.
-	if pool != nil {
-		if err := reconcileChannelProviders(context.Background(), pool, r.ChannelProviders()); err != nil {
-			//craft:ignore panic-in-domain composition-time boot failure, mirrors capture.Registry.Register's own panic posture for a wiring defect the process cannot recover from
-			panic(fmt.Sprintf("compose: reconciling the channel-provider registry: %v", err))
-		}
-	}
+	// The derived channel vocabulary is NOT reconciled here. Constructing this
+	// registry is config-gated — a role builds it only when a keyvault root key
+	// is configured — and the registry write is not, so it runs as its own boot
+	// step (ReconcileChannelProviders) that every role reaches. See there.
 	return r
 }
 

--- a/backend/internal/compose/capture_wiring_test.go
+++ b/backend/internal/compose/capture_wiring_test.go
@@ -8,6 +8,7 @@ package compose
 // all — the composition rules the process roles rely on at boot.
 
 import (
+	"slices"
 	"testing"
 )
 
@@ -61,6 +62,31 @@ func TestCaptureRegistryComposition(t *testing.T) {
 			t.Fatal("a fully-configured app must enable the connect transport")
 		}
 	})
+}
+
+// CoreChannelProviders is the boot step's core half, and it enumerates the
+// transports off a registry built with no pool and no vault. That is only
+// honest while the vault-carrying and Google-app-carrying constructions add no
+// channel-capable connector of their own — so the obligation is derived from
+// the constructions themselves rather than restated as a list, and a connector
+// that starts supplying a transport fails HERE instead of going unregistered on
+// every install that has no Google app.
+func TestCoreChannelProvidersEnumeratesEveryComposedCoreTransport(t *testing.T) {
+	enumerated := CoreChannelProviders()
+	if len(enumerated) == 0 {
+		t.Fatal("this binary composed no core transport at all, so this gate would compare two empty sets")
+	}
+	// The richest core composition there is: both OAuth apps configured, so
+	// every connector any role can register is on it.
+	richest := CaptureSyncRegistry(nil, nil,
+		GmailConfig{ClientID: "id", ClientSecret: "secret"},
+		GraphConfig{ClientID: "id", ClientSecret: "secret"},
+		CaptureConfig{}).ChannelProviders()
+	if !slices.Equal(enumerated, richest) {
+		t.Errorf("the fully-composed registry supplies transports %v, but the boot step would register %v — "+
+			"a transport the boot step cannot see is one no captured message may name",
+			richest, enumerated)
+	}
 }
 
 func TestWithKeyvaultWiresTheCredentialCustodian(t *testing.T) {

--- a/backend/internal/compose/channelprovider.go
+++ b/backend/internal/compose/channelprovider.go
@@ -14,10 +14,11 @@ package compose
 // the vocabulary of interaction kinds is fixed by the contract and seeded by
 // the core migration, so boot has nothing to add to it.
 //
-// Called from NewCaptureRegistry, which this codebase already constructs more
-// than once per process (a role-specific alternate wiring path, the worker's
-// one-shot backfill helper) — so every write here is an idempotent upsert, and
-// every in-memory set is last-write-wins, never a once-only registration.
+// Driven by ReconcileChannelProviders, the boot step every process role runs.
+// A role may run it more than once per process (a role-specific alternate
+// wiring path, the worker's one-shot backfill helper), so every write here is
+// an idempotent upsert, and every in-memory set is last-write-wins, never a
+// once-only registration.
 
 import (
 	"context"
@@ -33,6 +34,41 @@ import (
 	"github.com/gradionhq/margince/backend/internal/modules/comms"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
 )
+
+// ReconcileChannelProviders writes this binary's channel vocabulary into the
+// registry: the core connectors it compiled in, plus every channel its composed
+// units declare. It runs after RegisterExtensions, because the unit half reads
+// ComposedExtensions().
+//
+// It is a boot step in its own right, and it cannot ride the construction of
+// the capture registry. That construction is gated on a configured keyvault
+// root key; what a message may name is not. Where the write rides it, a
+// vault-less installation registers none of its units' transports — a captured
+// message on one then violates activity.channel_provider's foreign key, the
+// core-vs-unit collision check never runs, and both in-memory snapshots keep
+// their pre-registry default, so a reply on a unit channel is refused before it
+// is staged. LoadChannelProviderDirectory answers the same question for the
+// read side, and for the same reason.
+//
+// It returns its error rather than halting: a unit colliding with a core
+// transport is a refusal an operator has to act on, and the caller that owns
+// the process's exit is where that decision belongs.
+func ReconcileChannelProviders(ctx context.Context, pool *pgxpool.Pool) error {
+	return reconcileChannelProviders(ctx, pool, CoreChannelProviders())
+}
+
+// CoreChannelProviders is every transport this binary compiled a CORE connector
+// for — the reconcile's core half.
+//
+// Derived from the registry rather than restated beside it. A hand-kept list
+// would be a second answer to "what did this binary compile in", and the two
+// would disagree the first time a connector was added; deriving it means the
+// registry stays the only place that knows. It enumerates rather than captures,
+// so it needs neither pool nor vault — both of which NewCaptureRegistry
+// documents as optional for exactly that.
+func CoreChannelProviders() []string {
+	return NewCaptureRegistry(nil, nil, CaptureConfig{}).ChannelProviders()
+}
 
 // reconcileChannelProviders upserts a channel_provider row for every transport
 // this binary composed — the core connectors passed in, plus every channel the

--- a/backend/internal/compose/channelprovider_integration_test.go
+++ b/backend/internal/compose/channelprovider_integration_test.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/jackc/pgx/v5"
+
 	"github.com/gradionhq/margince/backend/internal/compose/integration"
 	"github.com/gradionhq/margince/backend/internal/modules/activities"
 	"github.com/gradionhq/margince/backend/internal/modules/capture"
@@ -314,54 +316,162 @@ func TestReconcileChannelProvidersRefusesAUnitThatSeizesARegisteredCoreTransport
 	}
 }
 
-// The seam SHIPS, not just the function: NewCaptureRegistry — the real
-// composition-root entry point every process role calls — sets both
-// activities' and comms' in-memory snapshots as a side effect of registering
-// its connectors, not just something a hand-written call to
-// reconcileChannelProviders would prove.
-func TestNewCaptureRegistrySetsTheActivitiesAndCommsChannelSnapshots(t *testing.T) {
+// The seam SHIPS, not just the function: ReconcileChannelProviders — the boot
+// step a process role calls — registers a composed unit's transport and makes
+// it sendable, on a role that builds NO capture registry. That is the write
+// twin of TestTheDirectoryLoadsFromTheRegistryAndNotFromTheCaptureBoot, and it
+// is the shape the whole step exists for: building the capture registry is
+// gated on a configured keyvault, and a vault-less role must still register
+// what it composed.
+//
+// It asks about a UNIT transport rather than telegram on purpose. Telegram's
+// row is seeded by the core migration and testdb does not reset
+// channel_provider, and both in-memory sets carry telegram as their
+// compile-time default — so every telegram assertion here is already true
+// before the act, and would pass against a boot step that did nothing at all.
+// A unit's row can only have been written by this call.
+func TestTheBootStepRegistersAComposedUnitTransportWithNoCaptureRegistry(t *testing.T) {
 	e := integration.Setup(t)
-	// Restore the pre-registry default (not nil/empty): both packages start
-	// with {"telegram"} baked in, and a later test in this same process that
-	// assumes telegram is still a channel kind must not see the emptied set
-	// this test would otherwise leave behind.
+	ctx := context.Background()
+	owner := integration.OwnerConn(t)
 	defer activities.SetChannelProviders([]string{capture.ProviderTelegram})
 	defer comms.SetChannelProviders([]string{capture.ProviderTelegram})
+	declaresTransport(t, "boot", extension.Channel{
+		Provider: "boot_chat", Send: (&capturedSend{}).send, Live: answersLive(true, nil),
+	})
+	t.Cleanup(func() {
+		if _, err := owner.Exec(context.Background(),
+			`DELETE FROM channel_provider WHERE provider = 'boot_chat'`); err != nil {
+			t.Errorf("cleaning up channel_provider: %v", err)
+		}
+	})
+	emptyTheSendableSets(t)
 
-	NewCaptureRegistry(e.Pool, nil, CaptureConfig{})
-
-	if !activities.CanSendOnProvider(capture.ProviderTelegram) {
-		t.Error("NewCaptureRegistry did not set activities' channel-provider snapshot")
+	// Through RecordComposition, which is what a process role actually calls —
+	// reaching past it to the reconcile alone would leave the step every role
+	// wires untested, and the ordering it owns unproven.
+	if err := RecordComposition(ctx, e.Pool, discardLog(), ComposedExtensions()); err != nil {
+		t.Fatalf("the boot step on a role that composes no capture registry: %v", err)
 	}
-	if _, capability := comms.SendScopeFor(capture.ProviderTelegram); capability != comms.SendsWithoutScope {
-		t.Error("NewCaptureRegistry did not set comms' channel-provider snapshot")
+	// The inventory half landed too: both facts follow from the same composed
+	// set, and a step that recorded one of them is the half-wired boot this
+	// function exists to make unreachable.
+	if n := observedExtensionCount(t, owner); n == 0 {
+		t.Error("the boot step registered the transports but recorded no extension inventory")
+	}
+
+	var transport string
+	if err := owner.QueryRow(ctx,
+		`SELECT transport FROM channel_provider WHERE provider = 'boot_chat'`).Scan(&transport); err != nil {
+		t.Fatalf("reading back the unit transport the boot step should have registered: %v", err)
+	}
+	if transport != "unit" {
+		t.Errorf("boot_chat registered as transport %q, want unit", transport)
+	}
+	// Both in-memory halves, refilled from empty: the send pre-flight reads
+	// them, so a transport missing here is one every reply is refused on.
+	if !activities.CanSendOnProvider("boot_chat") {
+		t.Error("the unit's transport is not in activities' sendable set")
+	}
+	if _, capability := comms.SendScopeFor("boot_chat"); capability == comms.CannotSend {
+		t.Error("the unit's transport is not in comms' sendable set")
+	}
+	if !activities.CanSendOnProvider(capture.ProviderTelegram) {
+		t.Error("the core connector did not come back into the sendable set")
 	}
 }
 
-// The regression this design's own review round caught: reconcile must run
-// over an infra transaction, never a workspace-bound one — NewCaptureRegistry
-// is called during normal server construction, which happens BEFORE the
-// installation is bootstrapped (no organization exists yet). A workspace-bound
-// transaction fails to even resolve which workspace to bind, which is a
-// deployment-halting panic on every fresh install, not a corner case.
-func TestNewCaptureRegistryReconcilesBeforeTheInstallationIsBootstrapped(t *testing.T) {
+// Reconcile runs over an infra transaction, never a workspace-bound one: the
+// boot step runs BEFORE the installation is bootstrapped, when no organization
+// exists. A workspace-bound transaction cannot resolve which workspace to bind,
+// which halts every fresh install rather than some corner of one.
+func TestTheBootStepReconcilesBeforeTheInstallationIsBootstrapped(t *testing.T) {
 	e := integration.Setup(t)
+	ctx := context.Background()
+	owner := integration.OwnerConn(t)
 	defer activities.SetChannelProviders([]string{capture.ProviderTelegram})
 	defer comms.SetChannelProviders([]string{capture.ProviderTelegram})
+	declaresTransport(t, "prebootstrap", extension.Channel{
+		Provider: "prebootstrap_chat", Send: (&capturedSend{}).send, Live: answersLive(true, nil),
+	})
+	t.Cleanup(func() {
+		if _, err := owner.Exec(context.Background(),
+			`DELETE FROM channel_provider WHERE provider = 'prebootstrap_chat'`); err != nil {
+			t.Errorf("cleaning up channel_provider: %v", err)
+		}
+	})
+	emptyTheSendableSets(t)
 
 	// Archived, not deleted: identity.Service.InstallationWorkspace counts
 	// un-archived workspaces, and integration.Setup's own fixture rows
 	// (app_user, team) FK-reference this workspace with ON DELETE RESTRICT, so
 	// a DELETE here would fail on the wrong constraint before ever reaching
 	// the one this test is about.
-	if _, err := integration.OwnerConn(t).Exec(context.Background(),
-		`UPDATE workspace SET archived_at = now()`); err != nil {
+	if _, err := owner.Exec(ctx, `UPDATE workspace SET archived_at = now()`); err != nil {
 		t.Fatalf("archiving every workspace to simulate a pre-bootstrap install: %v", err)
 	}
 
-	NewCaptureRegistry(e.Pool, nil, CaptureConfig{})
+	if err := ReconcileChannelProviders(ctx, e.Pool); err != nil {
+		t.Fatalf("the boot step with no organization bootstrapped yet: %v", err)
+	}
+	if !activities.CanSendOnProvider("prebootstrap_chat") {
+		t.Error("the boot step did not reconcile with no organization bootstrapped yet")
+	}
+}
 
-	if !activities.CanSendOnProvider(capture.ProviderTelegram) {
-		t.Error("NewCaptureRegistry did not reconcile with no organization bootstrapped yet")
+// A boot step that cannot register the vocabulary aborts the boot, and says
+// which of its two halves failed. The refusal itself is proved by the reconcile
+// suite above; what matters here is that RecordComposition surfaces it rather
+// than swallowing it, and that an operator reading one line knows whether the
+// inventory or the transports were what went wrong.
+func TestRecordingTheCompositionFailsTheBootWhenAUnitShadowsACoreTransport(t *testing.T) {
+	e := integration.Setup(t)
+	ctx := context.Background()
+	defer activities.SetChannelProviders([]string{capture.ProviderTelegram})
+	defer comms.SetChannelProviders([]string{capture.ProviderTelegram})
+	declaresTransport(t, "impostor", extension.Channel{
+		Provider: capture.ProviderTelegram, Send: (&capturedSend{}).send, Live: answersLive(true, nil),
+	})
+
+	err := RecordComposition(ctx, e.Pool, discardLog(), ComposedExtensions())
+
+	if err == nil {
+		t.Fatal("a boot whose unit declares the core's own transport was allowed to continue; " +
+			"every reply on that transport would leave under the unit's credential")
+	}
+	if !strings.Contains(err.Error(), "channel vocabulary") {
+		t.Errorf("the boot failure %q does not say which step failed, so an operator cannot tell "+
+			"a transport collision from an inventory problem", err)
+	}
+	if !strings.Contains(err.Error(), capture.ProviderTelegram) {
+		t.Errorf("the boot failure %q does not name the transport in dispute, which is the one thing "+
+			"an operator must rename", err)
+	}
+}
+
+// observedExtensionCount answers how many extension-composition observations
+// the installation holds — the inventory half of RecordComposition, read from
+// the trail it actually writes.
+func observedExtensionCount(t *testing.T, owner *pgx.Conn) int {
+	t.Helper()
+	var n int
+	if err := owner.QueryRow(context.Background(),
+		`SELECT count(*) FROM system_log WHERE action = $1`, extensionCompositionObserved).Scan(&n); err != nil {
+		t.Fatalf("counting the recorded extension observations: %v", err)
+	}
+	return n
+}
+
+// emptyTheSendableSets clears what the assertions are about to look at, and
+// fails if the clearing did not take. Both packages carry telegram as a
+// compile-time default and testdb does not reset channel_provider, so a test
+// that does not start from empty cannot tell a boot step that ran from one that
+// did nothing.
+func emptyTheSendableSets(t *testing.T) {
+	t.Helper()
+	activities.SetChannelProviders(nil)
+	comms.SetChannelProviders(nil)
+	if activities.CanSendOnProvider(capture.ProviderTelegram) {
+		t.Fatal("the sendable set survived being emptied — this run could not tell a reconcile from a no-op")
 	}
 }

--- a/scripts/verify-boot.sh
+++ b/scripts/verify-boot.sh
@@ -12,7 +12,9 @@
 # Steps:
 #   1. POST /v1/auth/login with the seeded demo admin → 200 + crm_session.
 #   2. GET /v1/people under that session → the three seeded people.
-#   3. The frontend production build compiles (pnpm build) — a real
+#   3. Every composed unit's declared channel transport is published by
+#      GET /v1/channel-providers — the boot step really ran.
+#   4. The frontend production build compiles (pnpm build) — a real
 #      compile+bundle, not a stale-dist check.
 
 set -euo pipefail
@@ -36,7 +38,7 @@ trap 'rm -rf "$workdir"' EXIT
 # A transport failure (refused, timeout) makes curl print status 000 and
 # exit non-zero; `|| true` keeps set -e from eating the fail() message,
 # and --max-time keeps a stalled API from hanging the proof.
-echo "== verify-boot 1/3: login as the seeded demo admin =="
+echo "== verify-boot 1/4: login as the seeded demo admin =="
 login_status="$(curl -sS --max-time 15 -o "$workdir/login.json" -D "$workdir/headers" -w '%{http_code}' \
   -X POST "$API_BASE/v1/auth/login" \
   -H "X-Workspace-Slug: $WORKSPACE_SLUG" \
@@ -56,7 +58,7 @@ session="$(sed -n 's/^[Ss]et-[Cc]ookie: crm_session=\([^;]*\).*/\1/p' "$workdir/
 [ -n "$session" ] || fail "login answered 200 but set no crm_session cookie"
 echo "  OK: logged in as $ADMIN_EMAIL, session captured"
 
-echo "== verify-boot 2/3: seeded people are visible =="
+echo "== verify-boot 2/4: seeded people are visible =="
 people_status="$(curl -sS --max-time 15 -o "$workdir/people.json" -w '%{http_code}' \
   "$API_BASE/v1/people?limit=100" \
   -H "X-Workspace-Slug: $WORKSPACE_SLUG" \
@@ -75,7 +77,41 @@ for name in "Alice Müller" "Bob Schmidt" "Carol Wagner"; do
   echo "  OK: found '$name'"
 done
 
-echo "== verify-boot 3/3: frontend production build =="
+echo "== verify-boot 3/4: every composed unit's transport is registered =="
+# The boot proof for the channel registry, and it belongs HERE rather than in a
+# Go test: registering the vocabulary is a BOOT STEP the api runs, so the only
+# thing that can prove the api runs it is an api that booted. This lane boots
+# with no MARGINCE_KEYVAULT_ROOT_KEY, which is exactly the install on which the
+# write used to be skipped entirely — a unit's transport went unregistered, and
+# its captured messages then failed activity's channel_provider foreign key.
+#
+# The expectation is DERIVED from the composed manifests rather than listed
+# here, so a unit that starts (or stops) declaring a channel needs no edit to
+# this script, and a list that quietly went stale cannot report success.
+expected_transports="$(jq -r '.channels // [] | .[].provider' "$REPO_DIR"/extensions/*/manifest.generated.json | sort -u)"
+providers_status="$(curl -sS --max-time 15 -o "$workdir/providers.json" -w '%{http_code}' \
+  "$API_BASE/v1/channel-providers" \
+  -H "X-Workspace-Slug: $WORKSPACE_SLUG" \
+  --cookie "crm_session=$session" || true)"
+if [ "$providers_status" != "200" ]; then
+  echo "  response body:" >&2
+  cat "$workdir/providers.json" >&2
+  fail "GET /v1/channel-providers returned HTTP $providers_status (expected 200)"
+fi
+if [ -z "$expected_transports" ]; then
+  echo "  OK: no composed unit declares a channel, nothing to register"
+else
+  while read -r provider; do
+    if ! jq -e --arg p "$provider" '.data[] | select(.provider == $p)' "$workdir/providers.json" >/dev/null; then
+      echo "  full /v1/channel-providers response:" >&2
+      cat "$workdir/providers.json" >&2
+      fail "a composed unit declares transport '$provider', but the running api does not publish it — the boot step that registers the channel vocabulary did not run"
+    fi
+    echo "  OK: '$provider' is registered"
+  done <<<"$expected_transports"
+fi
+
+echo "== verify-boot 4/4: frontend production build =="
 # --ignore-scripts: no lifecycle scripts run at install; esbuild ships
 # prebuilt platform binaries as optional deps, so the build works without
 # its validating postinstall.


### PR DESCRIPTION
Closes #1366 — which I **reopened** first: it had been auto-closed as completed by the merge of #1368, the PR it was *found in*, while the defect was untouched. Re-verified live on `origin/main` before starting.

## The defect

`reconcileChannelProviders` is the ONE writer of `channel_provider` — core connectors plus every channel a composed unit declares — the ONE place a unit shadowing a core transport is refused, and the ONE caller of `activities.SetChannelProviders` / `comms.SetChannelProviders`. Its only non-test caller was `NewCaptureRegistry`, and every non-test construction of that registry sits behind a keyvault gate (`cmd/api/keyvault.go:40`, `cmd/worker/boot.go:420`).

So a vault-less install registered none of it:

1. A unit's declared transport was never written. The ingress door validates against the **declared** set, not the registry (`extingress.go:251`), so a unit-filed `kind=message` is accepted and then violates `activity → channel_provider`'s foreign key — a 500 that names nothing.
2. The collision check never ran, so a unit shadowing `telegram`/`whatsapp` booted clean instead of boot-failing.
3. Both in-memory snapshots kept their compile-time `telegram`-only default (`activities/channelvocabulary.go:33`, `comms/seams.go:302`), so a unit channel was silently unsendable — the one failure a rep cannot tell from a broken provider.

`LoadChannelProviderDirectory` already documents this exact class of defect for the READ side and was moved off that path. The write side now gets the same treatment.

## One correction to the issue's suggested shape

The issue warns of a "two halves, last writer wins" hazard and proposes holding the core and unit sendable sets separately. **That hazard does not exist as merged** — `reconcileChannelProviders` computes the union in one place (`channelprovider.go:96-101`) with a single call site for both setters. Fixing the non-problem would have added a synchronisation concern the code does not have. What it needed was the one writer moved off the vault path.

## The change

- The reconcile is **removed** from `NewCaptureRegistry` rather than left there and duplicated, so the config coupling goes away instead of gaining a second trigger.
- New `compose.RecordComposition` folds the two boot-time facts that follow from the composed extension set — the extension inventory and the channel vocabulary its units declare — into one ordered step. One function because the ordering is not a caller's to choose, and a role that wired only the inventory is exactly the broken state this fixes.
- It **returns its error** instead of halting. A unit colliding with a core transport is a refusal an operator must act on; the panic was only ever a consequence of having nowhere to report from inside a constructor. Both halves are wrapped with the step that failed.
- The core half is **derived, not restated**: `CoreChannelProviders()` enumerates off a pool-less, vault-less registry construction. A hand-kept list would be a second answer to "what did this binary compile in".

Ordering, both satisfied by the call site: **after** `RegisterExtensions` (the unit half reads `ComposedExtensions()`) and **before** `compose.New` (assembly loads the transport directory FROM these rows). That second one also closes a live secondary gap — today a unit channel first composed in this build lands in the table but is missing from *this* process's directory snapshot until the next boot.

## What holds it

| gate | what it pins |
|---|---|
| `TestEveryRoleThatComposesExtensionsRecordsWhatItComposed` | **The wiring itself.** Walks `cmd/` with `go/ast`: every role that calls `compose.RegisterExtensions` must also call `compose.RecordComposition`. Derived, not listed — a new role arrives covered. |
| `verify-boot.sh` step 3/4 | **The boot proof.** CI's live-boot lane already boots with no `MARGINCE_KEYVAULT_ROOT_KEY`; it now asserts the running api publishes every transport the composed manifests declare. Expectation derived from `extensions/*/manifest.generated.json`, so a unit that starts or stops declaring a channel needs no edit here. |
| `TestCoreChannelProvidersEnumeratesEveryComposedCoreTransport` | The enumeration is honest against the richest core composition (`CaptureSyncRegistry`, both OAuth apps). A connector that starts supplying a transport fails here rather than going unregistered on every install with no Google app. |
| `TestTheBootStepRegistersAComposedUnitTransportWithNoCaptureRegistry` | The regression itself, on a role that builds no capture registry. |

The seven existing reconcile/collision integration tests are untouched — they drive `reconcileChannelProviders` directly.

## Proof

**Mutation-tested.** A code review caught that my first version of the boot-step tests would pass against a no-op: they asserted only `telegram`, whose row is seeded by `migrations/core/0240` (and `testdb` deliberately does not reset `channel_provider`) and which both packages carry as a compile-time default — so every assertion was already true before the act. They now empty the sendable sets first (failing loudly if the emptying did not take) and assert a **unit** row, which only the boot step can have written. With `ReconcileChannelProviders` stubbed to `return nil`:

```
channelprovider_integration_test.go:355: reading back the unit transport the boot step should have registered: no rows in result set
--- FAIL: TestTheBootStepRegistersAComposedUnitTransportWithNoCaptureRegistry
--- FAIL: TestTheBootStepReconcilesBeforeTheInstallationIsBootstrapped
```

The AST gate too — dropping `RecordComposition` from `cmd/worker`:

```
--- FAIL: TestEveryRoleThatComposesExtensionsRecordsWhatItComposed
    cmd/worker registers the composed extension set but never calls compose.RecordComposition
```

**UAT — the real binary, booted vault-less.** Throwaway database and its own Redis; `make dev` never run. Full transcript in the working notes.

Baseline (`0b7e41374`, no part of the fix), vault-less boot confirmed by the *absence* of `api connector-credential vault enabled` in the log:

```
 provider | transport |  label   | credential_model | supplies_transport
----------+-----------+----------+------------------+--------------------
 telegram | core      | Telegram | workspace_bot    | t
 whatsapp | core      | WhatsApp | workspace_bot    | f
```

The `dispact-connector` unit composes (`extensions=4`), its migrations apply, its routes mount — and the channel it declares is simply absent. Nothing in the boot log hints at the gap, which is what made this quiet.

Fixed binary, database reset to byte-identical migrated state, same vault-less boot:

```
 provider | transport |  label   | credential_model | supplies_transport
----------+-----------+----------+------------------+--------------------
 dispact  | unit      | Dispact  | per_member       | t
 telegram | core      | Telegram | workspace_bot    | t
 whatsapp | core      | WhatsApp | workspace_bot    | f
```

Booted twice **with** the vault configured (log confirms the vault path engaged): the same three rows after each boot — no regression, and the write is a genuine upsert rather than an append.

## Gates

- `make check-backend` — green.
- `make test-it DIR=backend/internal/compose` — green (80s). `make test-it DIR=backend/internal/compose/integration` — green (150s).
- Pre-push `craft static --strict`: `PASS — 0 blocker, 0 major, 0 minor`.

## Notes

- `internal/compose/integration/apptest` composes a server without this boot step, so it runs on the compile-time default. It registers no extensions, so there is nothing for the step to write there and the divergence is inert today — left alone rather than changed as a drive-by. The AST gate covers `cmd/`, which is where a role can actually get this wrong.
- Rebased onto `1837a13a5`, after #1386 fixed the duplicate `core/0260` that had `main` red.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Writes the channel registry at boot for all roles instead of only when a keyvault is configured. Previously vault-less installs skipped registering unit transports and collision checks and kept default in-memory sendable sets; now the registry is recorded after `compose.RegisterExtensions` and before server assembly so unit channels are sendable immediately.

- Review
  - Move reconcile out of `NewCaptureRegistry` into `compose.RecordComposition`, which writes the extension inventory and calls `compose.ReconcileChannelProviders`; add `compose.CoreChannelProviders` (derived from a pool-less registry).
  - `compose.RecordComposition` returns errors; callers updated in `cmd/api` and `cmd/worker`.
  - Gates: AST check in `backend/bootcomposition_test.go` enforces `RecordComposition` when roles call `RegisterExtensions`; integration tests cover unit transport registration without a capture registry and pre-bootstrap; `scripts/verify-boot.sh` asserts the API publishes composed transports.

- Rollout
  - No migration required; writes are idempotent upserts.
  - Operators must resolve any unit that collides with a core transport; boot surfaces the error.
  - Ensure each role calls `compose.RecordComposition` after `compose.RegisterExtensions` and before server assembly.

<sup>Written for commit cdc20856f4815d788cc876ff663e958d169b0154. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1387?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

