### PR TITLE
fix(activities): booking another host's calendar is the admin's alone (#1413)

### DIFF
--- a/backend/internal/compose/integration/scheduling_authz_integration_test.go
+++ b/backend/internal/compose/integration/scheduling_authz_integration_test.go
@@ -5,10 +5,11 @@
 
 package integration
 
-// Scheduling is calendar access, so it carries the row-scope posture:
-// booking another host's calendar needs an unbounded scope, and the
-// availability busy-read shows a caller only the meetings their
-// timeline would — a stranger's calendar never leaks through free/busy.
+// Scheduling is calendar access: booking another host's calendar is the
+// admin's alone — an unbounded row scope reads every calendar and writes
+// none but its own — and the availability busy-read shows a caller only
+// the meetings their timeline would; a stranger's calendar never leaks
+// through free/busy.
 
 import (
 	"context"
@@ -21,7 +22,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
-func TestBookingAnotherHostNeedsUnboundedScope(t *testing.T) {
+func TestBookingAnotherHostNeedsTheAdminRole(t *testing.T) {
 	e := Setup(t)
 	slotStart := time.Date(2026, 7, 7, 10, 0, 0, 0, time.UTC)
 
@@ -36,8 +37,16 @@ func TestBookingAnotherHostNeedsUnboundedScope(t *testing.T) {
 	}); !errors.Is(err, apperrors.ErrPermissionDenied) {
 		t.Fatalf("booking rep2's calendar as rep1 → %v, want ErrPermissionDenied", err)
 	}
-	// An unbounded scope may book on behalf — and hits the conflict
-	// guard like anyone else.
+	// An unbounded row scope is not a delegate: ops reads every calendar
+	// and still books only its own.
+	ops := e.As(ids.NewV7(), nil, OpsPerms)
+	if _, err := e.Activities.BookMeeting(ops, activities.BookMeetingInput{
+		Host: ids.From[ids.UserKind](e.Rep2), Start: slotStart, End: slotStart.Add(time.Hour),
+	}); !errors.Is(err, apperrors.ErrPermissionDenied) {
+		t.Fatalf("booking rep2's calendar as ops → %v, want ErrPermissionDenied", err)
+	}
+	// The admin may book on behalf — and hits the conflict guard like
+	// anyone else.
 	admin := e.Admin()
 	if _, err := e.Activities.BookMeeting(admin, activities.BookMeetingInput{
 		Host: ids.From[ids.UserKind](e.Rep2), Start: slotStart, End: slotStart.Add(time.Hour),

--- a/backend/internal/modules/activities/scheduling.go
+++ b/backend/internal/modules/activities/scheduling.go
@@ -250,15 +250,19 @@ func (s *Store) BookMeeting(ctx context.Context, in BookMeetingInput) (crmcontra
 		return crmcontracts.Activity{}, err
 	}
 	// Booking writes onto the host's calendar; a caller may commit their
-	// OWN slots, and only an unbounded (admin) scope may book on behalf
-	// of another host — the spec's calendar_delegate grant (features/04
-	// §1) is not yet adopted in this build.
+	// OWN slots, and only the admin role may book on behalf of another host
+	// — the spec's calendar_delegate grant (features/04 §1) is not yet
+	// adopted in this build. The admin ROLE, not an unbounded row scope:
+	// ops, read_only and management all read every row, and none of them is
+	// thereby a calendar delegate for everyone in the organization.
 	actor, ok := principal.Actor(ctx)
 	if !ok {
 		return crmcontracts.Activity{}, apperrors.ErrPermissionDenied
 	}
-	if in.Host.UUID != actor.UserID && !auth.Unbounded(actor) {
-		return crmcontracts.Activity{}, apperrors.ErrPermissionDenied
+	if in.Host.UUID != actor.UserID {
+		if err := auth.RequireAdmin(ctx); err != nil {
+			return crmcontracts.Activity{}, err
+		}
 	}
 	if !in.End.After(in.Start) {
 		return crmcontracts.Activity{}, errBookingEndNotAfterStart

--- a/backend/internal/modules/agents/commandlinked.go
+++ b/backend/internal/modules/agents/commandlinked.go
@@ -24,7 +24,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gradionhq/margince/backend/internal/platform/auth"
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
 )
 
@@ -239,10 +242,14 @@ func (r *bookMeetingResolver) Subject(ctx context.Context, cmd BookMeetingComman
 
 // Guards refuses, before anything is staged, a booking whose end does not
 // follow its start, one attached to nothing, one attached to more records than
-// a request may name, and one naming a record the caller cannot see or whose
-// authority lives elsewhere.
+// a request may name, one naming a record the caller cannot see or whose
+// authority lives elsewhere, and one onto another host's calendar by anyone
+// but an admin.
 func (r *bookMeetingResolver) Guards(ctx context.Context, cmd BookMeetingCommand) error {
 	if err := requireBookingWindow(cmd.Start, cmd.End); err != nil {
+		return err
+	}
+	if err := requireOwnCalendarOrAdmin(ctx, cmd.HostUserID); err != nil {
 		return err
 	}
 	if err := requireBookingLinks(cmd.Links); err != nil {
@@ -250,6 +257,25 @@ func (r *bookMeetingResolver) Guards(ctx context.Context, cmd BookMeetingCommand
 	}
 	_, _, err := r.links.stageable(ctx, cmd.Links)
 	return err
+}
+
+// requireOwnCalendarOrAdmin mirrors the store's rule for booking on behalf of
+// another host (activities.BookMeeting): the admin ROLE, not an unbounded row
+// scope. Asked here too because the store's refusal comes after the human's
+// one-shot approval is consumed, and a management or ops passport would
+// otherwise stage a booking that can only ever be refused.
+func requireOwnCalendarOrAdmin(ctx context.Context, host *ids.UUID) error {
+	if host == nil {
+		return nil
+	}
+	actor, ok := principal.Actor(ctx)
+	if !ok {
+		return apperrors.ErrPermissionDenied
+	}
+	if *host == actor.UserID {
+		return nil
+	}
+	return auth.RequireAdmin(ctx)
 }
 
 // requireBookingWindow refuses a booking that ends before it starts.

--- a/backend/internal/modules/agents/commandsingle_test.go
+++ b/backend/internal/modules/agents/commandsingle_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
 )
 
@@ -544,6 +545,47 @@ func TestTheArchiveToolRefusesARecordTypeItsOwnWritePathCannotArchive(t *testing
 			if !errors.As(err, &bad) {
 				t.Fatalf("staging an archive of %q answered %v, want a BadArgsError — an approval for it "+
 					"could never be carried out", recordType, err)
+			}
+		})
+	}
+}
+
+// Booking onto another host's calendar is the admin's alone, and the staging
+// door asks before the store does — a management or ops passport reads every
+// calendar and would otherwise spend a human's approval on a booking the
+// store can only refuse.
+func TestBookingAnotherHostStagesOnlyForAnAdmin(t *testing.T) {
+	self, host, org := ids.NewV7(), ids.NewV7(), ids.NewV7()
+	window := time.Date(2026, 8, 10, 9, 0, 0, 0, time.UTC)
+	call := func(hostID *ids.UUID) GovernedCall {
+		return NewBookMeetingCall(oneRecord(datasource.EntityOrganization, org, `{}`, 1), BookMeetingCommand{
+			HostUserID: hostID, Start: window, End: window.Add(30 * time.Minute),
+			Links: []RecordLink{{EntityType: "organization", EntityID: org}},
+		})
+	}
+	as := func(roles []string, scope principal.RowScope) context.Context {
+		return principal.WithActor(context.Background(), principal.Principal{
+			Type: principal.PrincipalHuman, ID: "human:" + self.String(), UserID: self,
+			Permissions: principal.Permissions{RoleKeys: roles, RowScope: scope},
+		})
+	}
+	cases := []struct {
+		name   string
+		ctx    context.Context
+		host   *ids.UUID
+		denied bool
+	}{
+		{"own calendar, any role", as([]string{"management"}, principal.RowScopeAll), &self, false},
+		{"no host named, any role", as([]string{"rep"}, principal.RowScopeTeam), nil, false},
+		{"another host, admin", as([]string{"admin"}, principal.RowScopeAll), &host, false},
+		{"another host, management (unbounded, not admin)", as([]string{"management"}, principal.RowScopeAll), &host, true},
+		{"another host, ops (unbounded, not admin)", as([]string{"ops"}, principal.RowScopeAll), &host, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			_, err := StageSubject(c.ctx, call(c.host))
+			if got := errors.Is(err, apperrors.ErrPermissionDenied); got != c.denied {
+				t.Fatalf("staging answered %v; want permission denied = %v", err, c.denied)
 			}
 		})
 	}


### PR DESCRIPTION
Closes #1413. `BookMeeting` gated on-behalf booking on `auth.Unbounded` while calling it admin-only; ops, read_only and (since #1410) management all carry row scope `all`. Now `auth.RequireAdmin`. `TestBookingAnotherHostNeedsTheAdminRole` adds the ops refusal. `make check-backend`, `craft-static`, and the compose integration scheduling suite green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restricts booking another host’s calendar to admins at both staging and commit time. Previously any unbounded row scope (ops/read_only/management) could book on behalf; now only the admin role can, preventing wasted one-shot approvals.

- `activities.BookMeeting`: when `in.Host` != actor, require `auth.RequireAdmin`; self-booking unchanged; free/busy and conflict guard unchanged.
- `agents`: add `requireOwnCalendarOrAdmin` to the book_meeting staging guard to refuse non-admin on-behalf bookings before staging.
- Tests: integration test asserts ops is denied and admin can proceed; new `TestBookingAnotherHostStagesOnlyForAnAdmin` verifies staging behavior.
- Rollout: no config or schema changes. If non-admins must book on behalf, grant the admin role until a `calendar_delegate` grant is implemented.

<sup>Written for commit 95f6346410488e4dcb8565f82db8c25b575fc147. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1415?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

