### PR TITLE
fix(contracts): classify the contract table's three row-scoped foreign keys

### DIFF
--- a/backend/migrations/schema_fitness_integration_test.go
+++ b/backend/migrations/schema_fitness_integration_test.go
@@ -104,17 +104,28 @@ func TestSchema_organizationOpenPipelineRollupIsSecurityInvoker(t *testing.T) {
 // the map's completeness is the invariant.
 var rowScopedFKDecisions = gatekit.Waive(map[string]string{
 	// Client-supplied references — visibility-gated at the store:
-	"site_read.organization_id":                "gated: auth.EnsureVisible in StartSiteRead (the one human entry point); Begin/Finish only re-address a row Start created, and GetSiteRead re-checks EnsureVisible on every read",
-	"deal.organization_id":                     "gated: auth.EnsureLinkTarget in CreateDeal/UpdateDeal (H1)",
-	"project.organization_id":                  "gated: auth.EnsureLinkTarget in CreateProject/UpdateProject (H1) — the anchor company is client-supplied, so naming it is a read of it",
-	"deal.partner_org_id":                      "gated: auth.EnsureLinkTarget in UpdateDeal (H1)",
-	"organization.parent_org_id":               "gated: auth.EnsureLinkTarget in Create/UpdateOrganization (H1)",
-	"activity_link.person_id":                  "gated: auth.EnsureLinkTarget in LogActivity",
-	"activity_link.organization_id":            "gated: auth.EnsureLinkTarget in LogActivity",
-	"activity_link.deal_id":                    "gated: auth.EnsureLinkTarget in LogActivity",
-	"activity_link.lead_id":                    "gated: auth.EnsureLinkTarget in LogActivity",
-	"activity_link.project_id":                 "gated: auth.EnsureLinkTarget in LogActivity — the link target is probed by its wire entity_type, so project rides the same gate as its siblings",
-	"deal.project_id":                          "gated: auth.EnsureLinkTarget in CreateDeal/UpdateDeal (H1) — the anchor project is client-supplied, so naming it is a read of it",
+	"site_read.organization_id":     "gated: auth.EnsureVisible in StartSiteRead (the one human entry point); Begin/Finish only re-address a row Start created, and GetSiteRead re-checks EnsureVisible on every read",
+	"deal.organization_id":          "gated: auth.EnsureLinkTarget in CreateDeal/UpdateDeal (H1)",
+	"project.organization_id":       "gated: auth.EnsureLinkTarget in CreateProject/UpdateProject (H1) — the anchor company is client-supplied, so naming it is a read of it",
+	"deal.partner_org_id":           "gated: auth.EnsureLinkTarget in UpdateDeal (H1)",
+	"organization.parent_org_id":    "gated: auth.EnsureLinkTarget in Create/UpdateOrganization (H1)",
+	"activity_link.person_id":       "gated: auth.EnsureLinkTarget in LogActivity",
+	"activity_link.organization_id": "gated: auth.EnsureLinkTarget in LogActivity",
+	"activity_link.deal_id":         "gated: auth.EnsureLinkTarget in LogActivity",
+	"activity_link.lead_id":         "gated: auth.EnsureLinkTarget in LogActivity",
+	"activity_link.project_id":      "gated: auth.EnsureLinkTarget in LogActivity — the link target is probed by its wire entity_type, so project rides the same gate as its siblings",
+	"deal.project_id":               "gated: auth.EnsureLinkTarget in CreateDeal/UpdateDeal (H1) — the anchor project is client-supplied, so naming it is a read of it",
+	"contract.organization_id":      "gated: auth.EnsureLinkTarget in createContractTx (H1) — the counterparty is client-supplied, so naming it is a read of it",
+	// The deal and project links carry a SECOND obligation the sibling columns
+	// above do not, and it is the reason this table's gate is not just a copy.
+	// A contract's row visibility is INHERITED from its deal (falling back to
+	// its organization), so a deal belonging to another company would publish
+	// this agreement to everyone who can see that deal. Two independent "can
+	// you see it" probes cannot catch that — only asking whether the two name
+	// the same company can, which is what ensureLinksShareOrganization adds on
+	// top of the visibility gate, on create and on every patch that moves a link.
+	"contract.deal_id":                         "gated: auth.EnsureLinkTarget via ensureLinksVisible in createContractTx AND UpdateContract, plus ensureLinksShareOrganization (ADR-0109 §8)",
+	"contract.project_id":                      "gated: the same pair as contract.deal_id — ensureLinksVisible then ensureLinksShareOrganization, on create and on patch",
 	"lead.project_id":                          "gated: auth.EnsureLinkTarget in CreateLead/UpdateLead (H1)",
 	"suggestion_dismissal.organization_id":     "gated: auth.EnsureVisible in org360.Service.DismissSuggestion, inside the same transaction as the insert — dismissing advice about an account the caller cannot read would confirm it exists",
 	"org_dossier.organization_id":              "gated: the dossier is assembled only after orgdossier.Service.Get runs the caller's OWN sidecar reads, and people.ListOrganizationProfileFields opens with auth.Require + ensureOrgReadable — a company the caller cannot read has no dossier written for it, and the row is keyed on that same caller",


### PR DESCRIPTION
Closes the red `TestFK_rowScopedTargetsHaveVisibilityDecision` on main, which the contracts arc introduced.

## What was wrong

`contract` names an organization, a deal and a project — three row-scoped records — and none carried the explicit visibility decision the gate demands. A reference to a record is a read of it, and the gate exists so that judgement cannot be skipped in silence. It wasn't skipped in the code; it was skipped in the place the next person looks.

## What this adds

The three classifications, recording the gates that actually run (`auth.EnsureLinkTarget` via `ensureLinksVisible`, on create **and** on every patch).

The deal and project entries record a second obligation their sibling columns don't have, and it's why this table's classification isn't a copy of the ones above it: **a contract's row visibility is inherited from its deal**, falling back to its organization. A deal belonging to another company would publish that agreement to everyone who can see that deal. Two independent "can you see it" probes cannot catch that — only asking whether the two name the same company can, which is what `ensureLinksShareOrganization` adds on top.

`attachment.contract_id` is out of scope for this gate: it targets `contract`, which is not one of the row-scoped tables the query examines.

## Verified

Against a real database, not reasoned about — the whole migrations integration suite passes. **Mutation-checked:** deleting the three entries fails the test naming exactly those three columns and nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds visibility classifications for `contract.organization_id`, `contract.deal_id`, and `contract.project_id` so row‑scoped FK gating is explicit and the failing test turns green. Previously these links were gated in code but missing from the classification map; now they are recorded.

- `contract.organization_id` is gated by `auth.EnsureLinkTarget` in `createContractTx`.
- `contract.deal_id` and `contract.project_id` are gated via `ensureLinksVisible` plus `ensureLinksShareOrganization` in `createContractTx` and `UpdateContract`, reflecting that a contract’s row visibility inherits from its deal (falling back to its organization).
- No runtime behavior changes; this documents existing gates. The migrations integration suite passes and deleting these entries fails the targeted test as expected.

<sup>Written for commit cab9600346c68ce97baf11abab2110bda20b546e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1417?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

