### PR TITLE
test(contracts): the integration lane the missing 500 walked through

### DIFF
--- a/backend/internal/compose/dealmovepin_integration_test.go
+++ b/backend/internal/compose/dealmovepin_integration_test.go
@@ -77,6 +77,10 @@ func (p *closesDuringTheTierRead) Read(ctx context.Context, ref datasource.Entit
 	// concurrent actor's close, not a hand-made row.
 	if _, err := p.AdvanceDeal(p.as, datasource.AdvanceDealInput{
 		DealID: ref.ID, ToStageID: p.won, Source: "test",
+		// The racing actor answers the win gate the same way a fixture does:
+		// there is no agreement in this database, and saying so is what keeps
+		// the test about the version race rather than about the gate.
+		WonWithoutContractReason: integration.WonByImport(),
 	}); err != nil {
 		p.t.Fatalf("the racing close did not land, so this test is not about a race: %v", err)
 	}

--- a/backend/internal/compose/integration/apptest/pipeline.go
+++ b/backend/internal/compose/integration/apptest/pipeline.go
@@ -74,7 +74,13 @@ func ExerciseDealToWon(t *testing.T, e *AppEnv, stages SeededStages) string {
 	dealID := CreateOpenDeal(t, e, stages)
 
 	var deal AnyMap
-	status := e.Call(t, "POST", "/v1/deals/"+dealID+"/advance", AnyMap{"to_stage_id": stages.Won}, nil, &deal)
+	// The win gate (ADR-0109 §6): a won deal points at a signed agreement or
+	// says why it cannot, and a fixture has no contract in this database by
+	// construction — which is precisely what `imported` means.
+	status := e.Call(t, "POST", "/v1/deals/"+dealID+"/advance", AnyMap{
+		"to_stage_id":                 stages.Won,
+		"won_without_contract_reason": "imported",
+	}, nil, &deal)
 	if status != http.StatusOK || deal["status"] != "won" || deal["closed_at"] == nil {
 		t.Fatalf("advance to won = %d %v", status, deal)
 	}

--- a/backend/internal/compose/integration/contract_lifecycle_integration_test.go
+++ b/backend/internal/compose/integration/contract_lifecycle_integration_test.go
@@ -1,0 +1,256 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// The contract lifecycle against a real database (ADR-0109/A160).
+//
+// This suite exists because its absence shipped a defect: `captured_by` was
+// typed `uuid` where the writer stamps a prefixed principal, so EVERY contract
+// write answered 500, and four gates called it green. Nothing here touches a
+// mock — the store writes through the same path the API does, so a column that
+// disagrees with its writer fails on the first insert rather than in production.
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/gradionhq/margince/backend/internal/modules/contracts"
+	"github.com/gradionhq/margince/backend/internal/modules/deals"
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// The derived reading is computed against TODAY by the store's own clock, so a
+// fixture states its dates relative to that rather than pinning a calendar date
+// that silently walks into the past and makes the assertion mean the opposite.
+func daysFromToday(days int) time.Time {
+	return time.Now().UTC().Truncate(24*time.Hour).AddDate(0, 0, days)
+}
+
+func TestContractCreateReadsBackWhatWasWritten(t *testing.T) {
+	e := Setup(t)
+	org := e.SeedOrg(t, "Acme", nil)
+
+	created, err := e.Contracts.CreateContract(e.Admin(), contracts.CreateContractInput{
+		OrganizationID: ids.From[ids.OrganizationKind](org),
+		Title:          "MSA 2026",
+		ValueBasis:     contracts.BasisTotal,
+		Source:         "manual",
+	})
+	if err != nil {
+		t.Fatalf("creating a contract: %v", err)
+	}
+
+	// The defect this suite was written for: the principal is prefixed
+	// ("human:<id>"), and a uuid column refuses it on the way in.
+	if created.CapturedBy == nil || *created.CapturedBy == "" {
+		t.Error("captured_by came back empty — the principal did not survive the write")
+	}
+	if created.Status == nil || string(*created.Status) != contracts.StatusDraft {
+		t.Errorf("status = %v, want a contract born in draft", created.Status)
+	}
+	// A draft has asserted nothing, so it is not under contract whatever its
+	// dates say.
+	if created.UnderContract == nil || *created.UnderContract {
+		t.Error("a draft contract reads as under contract")
+	}
+}
+
+// CONTRACT-FORM-1's worked example, against the database that computes it: a
+// June term cancelled effective May ends in MAY. The effective end is the
+// EARLIER of the two dates, and a cancellation never revives a lapsed term.
+func TestUnderContractTakesTheEarlierOfTermEndAndCancellation(t *testing.T) {
+	e := Setup(t)
+	org := e.SeedOrg(t, "Acme", nil)
+	admin := e.Admin()
+
+	starts := daysFromToday(-180)
+	ends := daysFromToday(120)
+	created, err := e.Contracts.CreateContract(admin, contracts.CreateContractInput{
+		OrganizationID: ids.From[ids.OrganizationKind](org),
+		Title:          "Cancelled early",
+		ValueBasis:     contracts.BasisTotal,
+		StartsOn:       &starts,
+		EndsOn:         &ends,
+		Source:         "manual",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	id := ids.From[ids.ContractKind](ids.UUID(created.Id))
+	if _, err := e.Contracts.ChangeStatus(admin, id, contracts.StatusActive, nil); err != nil {
+		t.Fatalf("activating: %v", err)
+	}
+
+	// Notice given, effective a month before the term would have ended.
+	// Notice given, taking effect BEFORE the term would have ended but still
+	// ahead of today: the customer is under contract until then.
+	notice := daysFromToday(-10)
+	effective := daysFromToday(30)
+	cancelled, err := e.Contracts.Cancel(admin, id, notice, effective, nil)
+	if err != nil {
+		t.Fatalf("recording the cancellation: %v", err)
+	}
+
+	// The status does NOT move. The customer is under contract until the
+	// effective date, because that is what a notice period is.
+	if cancelled.Status == nil || string(*cancelled.Status) != contracts.StatusActive {
+		t.Errorf("status = %v after recording notice, want it unchanged at active", cancelled.Status)
+	}
+	if cancelled.UnderContract == nil || !*cancelled.UnderContract {
+		t.Error("a contract whose cancellation has not taken effect reads as no longer under contract")
+	}
+}
+
+// A renewal creates the successor and supersedes the predecessor in ONE
+// transaction, so an agreement that has run for years reads as a chain rather
+// than a row somebody overwrote.
+func TestRenewalChainsRatherThanOverwrites(t *testing.T) {
+	e := Setup(t)
+	org := e.SeedOrg(t, "Acme", nil)
+	admin := e.Admin()
+
+	first, err := e.Contracts.CreateContract(admin, contracts.CreateContractInput{
+		OrganizationID: ids.From[ids.OrganizationKind](org),
+		Title:          "MSA 2026", ValueBasis: contracts.BasisTotal, Source: "manual",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	predecessorID := ids.From[ids.ContractKind](ids.UUID(first.Id))
+	if _, err := e.Contracts.ChangeStatus(admin, predecessorID, contracts.StatusActive, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	successor, err := e.Contracts.Renew(admin, predecessorID, contracts.CreateContractInput{
+		Title: "MSA 2027", ValueBasis: contracts.BasisAnnualized, Source: "renewal",
+	}, nil)
+	if err != nil {
+		t.Fatalf("renewing: %v", err)
+	}
+
+	predecessor, err := e.Contracts.GetContract(admin, predecessorID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if predecessor.Status == nil || string(*predecessor.Status) != contracts.StatusSuperseded {
+		t.Errorf("predecessor status = %v, want superseded", predecessor.Status)
+	}
+	if predecessor.SupersededById == nil || *predecessor.SupersededById != successor.Id {
+		t.Error("the predecessor does not point at its successor, so the chain cannot be read back")
+	}
+	// The successor inherits the counterparty rather than taking one from the
+	// request: a renewal that changed companies would be a different agreement
+	// wearing this one's history.
+	if successor.OrganizationId != first.OrganizationId {
+		t.Error("the successor names a different company than the agreement it renews")
+	}
+}
+
+// A terminal status is terminal. Reviving an expired agreement would make the
+// record a description of somebody's second thoughts.
+func TestATerminalContractDoesNotReopen(t *testing.T) {
+	e := Setup(t)
+	org := e.SeedOrg(t, "Acme", nil)
+	admin := e.Admin()
+
+	created, err := e.Contracts.CreateContract(admin, contracts.CreateContractInput{
+		OrganizationID: ids.From[ids.OrganizationKind](org),
+		Title:          "Expired", ValueBasis: contracts.BasisTotal, Source: "manual",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	id := ids.From[ids.ContractKind](ids.UUID(created.Id))
+	for _, to := range []string{contracts.StatusActive, contracts.StatusExpired} {
+		if _, err := e.Contracts.ChangeStatus(admin, id, to, nil); err != nil {
+			t.Fatalf("moving to %s: %v", to, err)
+		}
+	}
+
+	_, err = e.Contracts.ChangeStatus(admin, id, contracts.StatusActive, nil)
+
+	var transition *contracts.InvalidStatusTransitionError
+	if !errors.As(err, &transition) {
+		t.Fatalf("reviving an expired contract: err = %v, want InvalidStatusTransitionError", err)
+	}
+}
+
+// The database's own constraints, reached through the writer rather than
+// hand-inserted — a row the real path cannot produce proves nothing about it.
+func TestTheDatabaseRefusesContradictoryTerms(t *testing.T) {
+	e := Setup(t)
+	org := e.SeedOrg(t, "Acme", nil)
+	value := int64(100)
+	starts, ends := daysFromToday(0), daysFromToday(-30)
+
+	cases := map[string]contracts.CreateContractInput{
+		"value with no currency": {
+			OrganizationID: ids.From[ids.OrganizationKind](org),
+			Title:          "Half a money pair", ValueBasis: contracts.BasisTotal,
+			ValueMinor: &value, Source: "manual",
+		},
+		"a term that ends before it starts": {
+			OrganizationID: ids.From[ids.OrganizationKind](org),
+			Title:          "Backwards", ValueBasis: contracts.BasisTotal,
+			StartsOn: &starts, EndsOn: &ends, Source: "manual",
+		},
+	}
+	for name, in := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, err := e.Contracts.CreateContract(e.Admin(), in)
+
+			var check *contracts.ContractCheckError
+			if !errors.As(err, &check) {
+				t.Fatalf("err = %v, want a ContractCheckError naming the field", err)
+			}
+			if check.Field == "" {
+				t.Error("the refusal names no field, so a human is not told what to fix")
+			}
+		})
+	}
+}
+
+// A contract the caller cannot see answers NOT FOUND, never a denial: a 403
+// would confirm the agreement exists.
+func TestAnInvisibleContractIsAbsentRatherThanRefused(t *testing.T) {
+	e := Setup(t)
+	// Rep3 sits in the other team, so a deal-anchored contract on Rep1's deal
+	// is outside their row scope.
+	org := e.SeedOrg(t, "Acme", &e.Rep1)
+	pipeline, open, _ := DealFixture(t, e)
+
+	rep1 := e.As(e.Rep1, []ids.UUID{e.Team1}, ContractRepPerms)
+	orgID := ids.From[ids.OrganizationKind](org)
+	// OWNED by Rep1. An ownerless deal is visible to every team-scoped reader,
+	// so a fixture that skipped this would assert nothing: the contract would
+	// be readable for a reason that has nothing to do with the predicate.
+	owner := ids.From[ids.UserKind](e.Rep1)
+	deal, err := e.Deals.CreateDeal(rep1, deals.CreateDealInput{
+		Name: "Rep1's deal", PipelineID: pipeline, StageID: open,
+		OrganizationID: &orgID, OwnerID: &owner, Source: "manual",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	dealID := ids.From[ids.DealKind](ids.UUID(deal.Id))
+	created, err := e.Contracts.CreateContract(rep1, contracts.CreateContractInput{
+		OrganizationID: orgID,
+		DealID:         &dealID,
+		Title:          "Rep1's agreement", ValueBasis: contracts.BasisTotal, Source: "manual",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rep3 := e.As(e.Rep3, []ids.UUID{e.Team2}, ContractRepPerms)
+	_, err = e.Contracts.GetContract(rep3, ids.From[ids.ContractKind](ids.UUID(created.Id)))
+
+	if !errors.Is(err, apperrors.ErrNotFound) {
+		t.Fatalf("a contract outside the caller's scope: err = %v, want ErrNotFound (existence stays hidden)", err)
+	}
+}

--- a/backend/internal/compose/integration/dealreopen_integration_test.go
+++ b/backend/internal/compose/integration/dealreopen_integration_test.go
@@ -37,7 +37,7 @@ func TestAnAgentCannotReopenAClosedDealWithoutAHuman(t *testing.T) {
 	// Created and closed as a HUMAN, which is how a won deal comes to exist.
 	deal := createDealForReopen(human, t, registry, e.Rep1, pipeline, open)
 	if _, err := registry.Invoke(human, "advance_deal",
-		json.RawMessage(`{"deal_id":"`+deal.String()+`","to_stage_id":"`+won.String()+`"}`)); err != nil {
+		json.RawMessage(`{"deal_id":"`+deal.String()+`","to_stage_id":"`+won.String()+`","won_without_contract_reason":"imported"}`)); err != nil {
 		t.Fatalf("closing the deal as won: %v", err)
 	}
 

--- a/backend/internal/compose/integration/harness.go
+++ b/backend/internal/compose/integration/harness.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/gradionhq/margince/backend/internal/compose/installseam"
 	"github.com/gradionhq/margince/backend/internal/modules/activities"
+	"github.com/gradionhq/margince/backend/internal/modules/contracts"
 	"github.com/gradionhq/margince/backend/internal/modules/deals"
 	"github.com/gradionhq/margince/backend/internal/modules/people"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
@@ -31,6 +32,7 @@ type Env struct {
 	Pool       *pgxpool.Pool
 	People     *people.Store
 	Deals      *deals.Store
+	Contracts  *contracts.Store
 	Activities *activities.Store
 	WS         ids.UUID
 	// three humans: Rep1+Rep2 share a team, Rep3 sits in another
@@ -111,6 +113,7 @@ func Setup(t *testing.T) *Env {
 	e.Pool = pool
 	e.People = people.NewStore(harnessDB(pool, e.WS))
 	e.Deals = deals.NewStore(harnessDB(pool, e.WS), installseam.Deals())
+	e.Contracts = contracts.NewStore(harnessDB(pool, e.WS))
 	e.Activities = activities.NewStore(harnessDB(pool, e.WS))
 	return e
 }

--- a/backend/internal/compose/integration/harnessperms.go
+++ b/backend/internal/compose/integration/harnessperms.go
@@ -58,6 +58,24 @@ var (
 		},
 		RowScope: principal.RowScopeTeam,
 	}
+	// ContractRepPerms is a rep who may read agreements as well as the account
+	// and deal they hang off. Its own fixture rather than a delta on the two
+	// above, for the reason stated there: RepPerms is read by suites as a rep
+	// who canNOT see an organization, and widening it would make those pass
+	// while proving nothing. Row scope stays team, because the interesting
+	// contract failures are row-scope ones and an unbounded admin
+	// short-circuits every clause the inherited predicate renders.
+	ContractRepPerms = principal.Permissions{
+		RoleKeys: []string{roleRep},
+		Objects: map[string]principal.ObjectGrant{
+			objOrg:             {Read: true},
+			objDeal:            {Create: true, Read: true, Update: true},
+			"contract":         {Create: true, Read: true, Update: true},
+			objPipeline:        {Read: true},
+			objInstallSettings: {Read: true},
+		},
+		RowScope: principal.RowScopeTeam,
+	}
 	// AccountRepPerms is the rep the account sections are read by: the
 	// organization itself, its people and deals, its activities, and the tag/list
 	// chips. It is a fixture in its own right rather than RepPerms plus a delta —
@@ -115,9 +133,13 @@ var (
 	AdminPerms       = principal.Permissions{
 		RoleKeys: []string{roleAdmin},
 		Objects: map[string]principal.ObjectGrant{
-			objPerson:   {Create: true, Read: true, Update: true, Delete: true},
-			objOrg:      {Create: true, Read: true, Update: true, Delete: true},
-			objDeal:     {Create: true, Read: true, Update: true, Delete: true},
+			objPerson: {Create: true, Read: true, Update: true, Delete: true},
+			objOrg:    {Create: true, Read: true, Update: true, Delete: true},
+			objDeal:   {Create: true, Read: true, Update: true, Delete: true},
+			// The admin role holds contracts in full (identity/internal/policy.go),
+			// mirrored here so the fixture matches production rather than a
+			// narrower admin that would make a suite pass for the wrong reason.
+			"contract":  {Create: true, Read: true, Update: true, Delete: true},
 			"lead":      {Create: true, Read: true, Update: true, Delete: true},
 			objActivity: {Create: true, Read: true, Update: true, Delete: true},
 			objPipeline: {Create: true, Read: true, Update: true, Delete: true},

--- a/backend/internal/compose/integration/installationseam_integration_test.go
+++ b/backend/internal/compose/integration/installationseam_integration_test.go
@@ -48,7 +48,7 @@ func TestClosingADealFreezesAgainstTheSettingsBaseCurrency(t *testing.T) {
 		t.Fatal(err)
 	}
 	if _, err := e.Deals.AdvanceDeal(admin,
-		ids.From[ids.DealKind](ids.UUID(d.Id)), deals.AdvanceDealInput{ToStageID: won}); err != nil {
+		ids.From[ids.DealKind](ids.UUID(d.Id)), deals.AdvanceDealInput{ToStageID: won, WonWithoutContractReason: WonByImport()}); err != nil {
 		t.Fatalf("closing as won: %v", err)
 	}
 

--- a/backend/internal/compose/integration/lifecycle_invariants_integration_test.go
+++ b/backend/internal/compose/integration/lifecycle_invariants_integration_test.go
@@ -66,7 +66,7 @@ func TestReopeningAWonDealClearsTerminalFields(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := e.Deals.AdvanceDeal(admin, ids.From[ids.DealKind](ids.UUID(d.Id)), deals.AdvanceDealInput{ToStageID: won}); err != nil {
+	if _, err := e.Deals.AdvanceDeal(admin, ids.From[ids.DealKind](ids.UUID(d.Id)), deals.AdvanceDealInput{ToStageID: won, WonWithoutContractReason: WonByImport()}); err != nil {
 		t.Fatalf("closing as won: %v", err)
 	}
 	if _, err := e.Deals.AdvanceDeal(admin, ids.From[ids.DealKind](ids.UUID(d.Id)), deals.AdvanceDealInput{ToStageID: open}); err != nil {
@@ -309,7 +309,7 @@ func TestRepricingAClosedDealRefreezesFx(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := e.Deals.AdvanceDeal(admin, ids.From[ids.DealKind](ids.UUID(d.Id)), deals.AdvanceDealInput{ToStageID: won}); err != nil {
+	if _, err := e.Deals.AdvanceDeal(admin, ids.From[ids.DealKind](ids.UUID(d.Id)), deals.AdvanceDealInput{ToStageID: won, WonWithoutContractReason: WonByImport()}); err != nil {
 		t.Fatalf("closing amountless: %v", err)
 	}
 

--- a/backend/internal/compose/integration/listrecords_integration_test.go
+++ b/backend/internal/compose/integration/listrecords_integration_test.go
@@ -38,7 +38,7 @@ func TestListRecordsNarrowsRatherThanAnsweringEveryRow(t *testing.T) {
 		`{"record_type":"deal","fields":{"name":"Narrowed out","pipeline_id":"`+
 			pipeline.String()+`","stage_id":"`+open.String()+`"}}`)
 	if _, err := registry.Invoke(ctx, "advance_deal", json.RawMessage(
-		`{"deal_id":"`+outOfStage.String()+`","to_stage_id":"`+won.String()+`"}`)); err != nil {
+		`{"deal_id":"`+outOfStage.String()+`","to_stage_id":"`+won.String()+`","won_without_contract_reason":"imported"}`)); err != nil {
 		t.Fatalf("moving the second deal out of the filtered stage: %v", err)
 	}
 

--- a/backend/internal/compose/integration/org360/org360_querycount_integration_test.go
+++ b/backend/internal/compose/integration/org360/org360_querycount_integration_test.go
@@ -152,7 +152,13 @@ func TestOrganization360CostDoesNotGrowWithTheAccount(t *testing.T) {
 	//
 	// It landed without this line, so the assembly issued 30 against a budget
 	// of 29 and every branch cut afterwards inherited a red gate.
-	const budget = 30
+	//
+	// 31 since the contracts block (ADR-0109/A160): one more indexed read for
+	// what the account is under contract for, gated on its own grant. It is
+	// FLAT in the size of the account like every section here — one query
+	// whether the company holds one agreement or forty — which is the property
+	// this budget exists to protect, rather than the absolute number.
+	const budget = 31
 	if smallCost > budget {
 		t.Errorf("one 360 issued %d queries, budget is %d", smallCost, budget)
 	}

--- a/backend/internal/compose/integration/org360/org360_visit_integration_test.go
+++ b/backend/internal/compose/integration/org360/org360_visit_integration_test.go
@@ -155,7 +155,7 @@ func TestOrganization360CountsWhatChangedSinceTheAcknowledgedVisit(t *testing.T)
 		VALUES ($1, $2, 'organization', $3)`, e.WS, fresh, org.UUID)
 	created := e.SeedDeal(t, "Brand new deal", pipeline, stage, &e.Rep1)
 	e.WsExec(t, `UPDATE deal SET organization_id = $2 WHERE id = $1`, created, org.UUID)
-	if _, err := e.Deals.AdvanceDeal(admin, ids.From[ids.DealKind](before), deals.AdvanceDealInput{ToStageID: won}); err != nil {
+	if _, err := e.Deals.AdvanceDeal(admin, ids.From[ids.DealKind](before), deals.AdvanceDealInput{ToStageID: won, WonWithoutContractReason: integration.WonByImport()}); err != nil {
 		t.Fatalf("advancing the old deal: %v", err)
 	}
 

--- a/backend/internal/compose/integration/orgbrief_integration_test.go
+++ b/backend/internal/compose/integration/orgbrief_integration_test.go
@@ -131,7 +131,7 @@ func TestOrganizationBriefCachesUntilTheAccountChanges(t *testing.T) {
 	// smaller change; the unit test in orgbrief covers that one, since it
 	// needs no second open stage to exist.)
 	if _, err := e.Deals.AdvanceDeal(e.Admin(), ids.From[ids.DealKind](deal),
-		deals.AdvanceDealInput{ToStageID: won}); err != nil {
+		deals.AdvanceDealInput{ToStageID: won, WonWithoutContractReason: WonByImport()}); err != nil {
 		t.Fatalf("advancing the deal: %v", err)
 	}
 	if _, err := svc.Get(reader, org, false); err != nil {

--- a/backend/internal/compose/integration/project_provider_integration_test.go
+++ b/backend/internal/compose/integration/project_provider_integration_test.go
@@ -220,6 +220,7 @@ func TestTheAgentSeamAdvancesADealAndReportsTheStageSemantic(t *testing.T) {
 
 	moved, err := p.AdvanceDeal(ctx, datasource.AdvanceDealInput{
 		DealID: deal, ToStageID: won.UUID,
+		WonWithoutContractReason: WonByImport(),
 	})
 	if err != nil {
 		t.Fatalf("advance through the seam: %v", err)

--- a/backend/internal/compose/integration/quotas_http_integration_test.go
+++ b/backend/internal/compose/integration/quotas_http_integration_test.go
@@ -132,7 +132,12 @@ func createAndCloseQuotaDeal(t *testing.T, e *apptest.AppEnv, stages apptest.See
 		t.Fatalf("create quota deal = %d %v", status, deal)
 	}
 	dealID := deal["id"].(string)
-	status = e.Call(t, "POST", "/v1/deals/"+dealID+"/advance", apptest.AnyMap{"to_stage_id": stages.Won}, nil, &deal)
+	// This quota fixture wins a deal to make attainment non-zero; it holds no
+	// agreement, and the win gate wants that said rather than assumed.
+	status = e.Call(t, "POST", "/v1/deals/"+dealID+"/advance", apptest.AnyMap{
+		"to_stage_id":                 stages.Won,
+		"won_without_contract_reason": "imported",
+	}, nil, &deal)
 	if status != http.StatusOK || deal["status"] != "won" {
 		t.Fatalf("advance quota deal to won = %d %v", status, deal)
 	}

--- a/backend/internal/compose/integration/seed.go
+++ b/backend/internal/compose/integration/seed.go
@@ -156,3 +156,18 @@ func AccountMailDirectedAt(t *testing.T, owner *pgx.Conn, ws ids.UUID, subject, 
 	}
 	return id
 }
+
+// WonByImport is the win-evidence answer a FIXTURE gives (ADR-0109 §6).
+//
+// A deal reaches a won stage only with a signed contract behind it or a stated
+// reason why there is none, and a test seeding a won deal has no agreement in
+// this database by construction — which is exactly what `imported` means. Every
+// suite that wins a deal to set up something else says so through this, rather
+// than each one spelling a literal that would drift from the vocabulary.
+//
+// A test ABOUT the gate does not use this: it states its own answer, because
+// the answer is the thing under test.
+func WonByImport() *string {
+	reason := "imported"
+	return &reason
+}


### PR DESCRIPTION
Closes #1399 — and repairs a regression that issue's own absence let me ship.

## The regression, first

The win gate (#1402) **broke nine integration tests across four packages**. They win deals to set up something else, and a won deal now needs an agreement behind it or a stated reason. The rule was working correctly; the fixtures had never been told about it.

It reached main because **the integration lane is not in the merge gate** — `make check` is unit-only, and I never ran `make test-integration` on that PR. The issue this PR closes says exactly that: *no contract coverage in the real-Postgres lane*. The lane I wasn't running is the one that would have caught it.

Every fixture now answers `imported` through **one helper** rather than a literal in each file: a deal seeded by a test has no agreement in this database by construction, which is precisely what that word means. A test *about* the gate states its own answer — the helper is only for suites that win a deal on the way to something else.

The org360 query budget goes 30 → 31. The contracts block is one more indexed read, and it is **flat in the size of the account** like every section beside it — which is the property that budget exists to protect, rather than the absolute number.

## What is new

Six tests over the paths that shipped broken, all seeded through the real writer:

- `captured_by` survives the round trip — the column typed `uuid` where the writer stamps `human:<id>`, which is what 500'd
- a cancellation leaves the status alone and the customer **under contract** until its effective date
- a renewal chains rather than overwrites
- a terminal status does not reopen
- the database's own contradictory-term refusals, reached through the writer rather than hand-inserted
- a contract outside the reader's scope answers **NOT FOUND**, never a denial

**Two of them failed first for reasons that were my fixtures' fault, not the code's**, and both are worth the next reader knowing: dates pinned to a calendar month that had since passed, which made the assertion mean its opposite; and a deal with no owner, visible to every team-scoped reader, so the scope test proved nothing until it was owned. The visibility test is mutation-checked — break the predicate and it fails.

The harness gains the contracts store and its grants, which is its own small finding: the fixture admin did not hold contracts, because nothing had ever asked it to.

## Verified

`OK: integration passed with 0 skips` — 40 packages, 2580 tests. Unit gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds end-to-end contract lifecycle tests and aligns fixtures with the win gate (won deals require a contract or a stated reason). This closes the hole that let a `captured_by` type mismatch 500 slip past unit-only gates and restores integration coverage.

- Adds `contract_lifecycle_integration_test.go` (create/read, cancellation effective date, renewal chaining, terminal status, DB constraint errors via writer, and visibility returns NOT FOUND).
- Wires `contracts` into the integration harness and grants (admin now holds contracts; adds `ContractRepPerms`).
- Increases the org360 query budget 30 → 31 for the contracts block; the cost remains O(1) per account.

**Test migration**
- When advancing a deal to won in integration tests, include `won_without_contract_reason: "imported"` or use `WonByImport()`. Updated helpers: `apptest.ExerciseDealToWon`, seam calls, and direct `AdvanceDeal`/HTTP paths now pass this.

<sup>Written for commit a395f3ad05e3b6365a39cb844a3137d25fcb4580. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1420?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

