### PR TITLE
fix(capture): a channel-captured person carries the address its connector already knew

### DIFF
--- a/backend/internal/compose/captureensurer.go
+++ b/backend/internal/compose/captureensurer.go
@@ -85,15 +85,16 @@ func (p peopleEnsurer) EnsureCounterparty(ctx context.Context, in capture.Ensure
 
 // EnsureChannelCounterparty is the same adaptation for an inbound channel
 // message (telegram-oa design §6.4). No company is derived and so no web
-// dossier is queued: a channel identity carries no domain, and there is nothing
-// for the enrich trigger to read a website from.
+// dossier is queued: this path derives no employer even from a corroborating
+// address, so there is nothing for the enrich trigger to read a website from.
 func (p peopleEnsurer) EnsureChannelCounterparty(ctx context.Context, in capture.EnsureChannelRequest) (capture.EnsureOutcome, error) {
 	res, err := p.store.EnsureChannelCounterparty(ctx, people.EnsureChannelCounterpartyInput{
-		Identity:    in.Identity,
-		DisplayName: in.DisplayName,
-		ActivityID:  ids.From[ids.ActivityKind](in.ActivityID),
-		Source:      in.Source,
-		CapturedBy:  in.CapturedBy,
+		Identity:           in.Identity,
+		DisplayName:        in.DisplayName,
+		CorroboratingEmail: in.CorroboratingEmail,
+		ActivityID:         ids.From[ids.ActivityKind](in.ActivityID),
+		Source:             in.Source,
+		CapturedBy:         in.CapturedBy,
 	})
 	if errors.Is(err, people.ErrCounterpartySuppressed) {
 		// A13 on the channel key: an erased subject stays dead — a deliberate

--- a/backend/internal/compose/extingress.go
+++ b/backend/internal/compose/extingress.go
@@ -53,15 +53,19 @@ const ingressPrincipalPrefix = "connector:ext:"
 // is, then the record's own shape, and only then the two that cost a query —
 // the member's consent and their live authority.
 func (r *callRuntime) Ingest(ctx context.Context, on extension.UserID, rec extension.Record) (extension.Result, error) {
-	// The declared source is resolved rather than read: what comes back is
-	// unused today and that is a fact about the vocabulary, not an oversight.
-	// A source declares which KINDS it lands, and exactly one kind is landable
-	// (extension.KindActivity), which the declaration grammar already enforces
-	// at generation and at boot — while a Record carries one Activity and has
-	// no field a second kind could arrive in. So there is no call this side
-	// could refuse for landing an undeclared kind. When a second kind is
-	// published, the gate belongs here, against Lands.
-	if _, err := r.declaredIngress(rec.System); err != nil {
+	// The declared source decides what this record may contribute to identity.
+	//
+	// Lands is still not gated here, and that is a fact about the vocabulary
+	// rather than an oversight: exactly one kind is landable
+	// (extension.KindActivity), the declaration grammar already enforces it at
+	// generation and at boot, and a Record carries one Activity with no field a
+	// second kind could arrive in. When a second kind is published, that gate
+	// belongs here too.
+	declared, err := r.declaredIngress(rec.System)
+	if err != nil {
+		return extension.Result{}, err
+	}
+	if err := refuseUndeclaredMergeKey(declared, rec.Counterparty); err != nil {
 		return extension.Result{}, err
 	}
 	// An invocation with a caller has two authorities in play — the caller's
@@ -95,7 +99,7 @@ func (r *callRuntime) Ingest(ctx context.Context, on extension.UserID, rec exten
 	if sink == nil {
 		return extension.Result{}, errIngressUnwired
 	}
-	ctx, err := r.scoped(ctx)
+	ctx, err = r.scoped(ctx)
 	if err != nil {
 		return extension.Result{}, err
 	}
@@ -103,7 +107,7 @@ func (r *callRuntime) Ingest(ctx context.Context, on extension.UserID, rec exten
 	if err != nil {
 		return extension.Result{}, err
 	}
-	return r.landRecord(runCtx, sink, rec)
+	return r.landRecord(runCtx, sink, rec, declared)
 }
 
 // landRecord performs the one write and maps its outcome onto the published
@@ -115,8 +119,8 @@ func (r *callRuntime) Ingest(ctx context.Context, on extension.UserID, rec exten
 // connector's watermark. Reporting that to a unit as a failure would have the
 // unit retry a deliberate drop on every poll, forever, so it is a success here
 // with a disposition that says what happened.
-func (r *callRuntime) landRecord(ctx context.Context, sink *capture.Sink, rec extension.Record) (extension.Result, error) {
-	ref, err := sink.Upsert(ctx, r.normalized(rec))
+func (r *callRuntime) landRecord(ctx context.Context, sink *capture.Sink, rec extension.Record, declared extension.IngressSource) (extension.Result, error) {
+	ref, err := sink.Upsert(ctx, r.normalized(rec, declared))
 	switch {
 	case errors.Is(err, connector.ErrSkip):
 		return extension.Result{Disposition: extension.DispositionSkipped}, nil
@@ -185,7 +189,7 @@ func (r *callRuntime) ingressAuthority(ctx context.Context, on extension.UserID)
 // another one" check pass by construction rather than by the unit getting it
 // right.
 
-func (r *callRuntime) normalized(rec extension.Record) connector.NormalizedRecord {
+func (r *callRuntime) normalized(rec extension.Record, declared extension.IngressSource) connector.NormalizedRecord {
 	return connector.NormalizedRecord{
 		EntityType: datasource.EntityActivity,
 		NaturalKey: r.naturalKey(rec),
@@ -200,34 +204,82 @@ func (r *callRuntime) normalized(rec extension.Record) connector.NormalizedRecor
 			OccurredAt:      rec.Activity.OccurredAt,
 			Direction:       rec.Activity.Direction,
 		},
-		Source:     r.sourceSystem(rec.System),
-		CapturedBy: ingressPrincipalPrefix + r.unit,
-		ThreadKey:  rec.ThreadKey,
-		Addresses:  rec.Addresses,
-		Raw:        rec.Raw,
-		Counterparty: connector.Counterparty{
-			Email:       rec.Counterparty.Email,
-			DisplayName: rec.Counterparty.DisplayName,
-			Domain:      rec.Counterparty.Domain,
-			Direction:   rec.Counterparty.Direction,
-			// The binding that makes the record repliable, held to the same
-			// declared set the activity's own transport is (refuseUnitIdentity):
-			// a unit that could bind an identity under a core connector's
-			// provider would be writing into the table the workspace's own
-			// reply path resolves its recipients from.
-			//
-			// DisplayName lands on Username, which is the core's display-only
-			// field for exactly this: a handle nothing routes, authorizes or
-			// deduplicates on. The two names differ because the core's is
-			// Telegram-shaped and the published one is not, and renaming either
-			// would be a change at a security-sensitive identity for a word.
-			ChannelIdentity: connector.ChannelIdentity{
-				Provider:      rec.Counterparty.ChannelIdentity.Provider,
-				ChannelUserID: rec.Counterparty.ChannelIdentity.ChannelUserID,
-				Username:      rec.Counterparty.ChannelIdentity.DisplayName,
-			},
-		},
+		Source:       r.sourceSystem(rec.System),
+		CapturedBy:   ingressPrincipalPrefix + r.unit,
+		ThreadKey:    rec.ThreadKey,
+		Addresses:    rec.Addresses,
+		Raw:          rec.Raw,
+		Counterparty: counterpartyOf(rec.Counterparty, declared),
 	}
+}
+
+// counterpartyOf maps the published counterparty onto the core's and stamps what
+// the SOURCE declared onto it.
+//
+// The declaration is stamped, never taken from the record — the rule Source and
+// CapturedBy already follow, for the same reason: a unit that could state its own
+// trust could widen it per record, which is the whole thing a declaration exists
+// to bound. It is reduced to the one question the core asks (may this address
+// corroborate?) rather than carried as the key list, which belongs to the
+// manifest an operator reads.
+func counterpartyOf(cp extension.Counterparty, declared extension.IngressSource) connector.Counterparty {
+	return connector.Counterparty{
+		Email:       cp.Email,
+		DisplayName: cp.DisplayName,
+		Domain:      cp.Domain,
+		Direction:   cp.Direction,
+		// The binding that makes the record repliable, held to the same
+		// declared set the activity's own transport is (refuseUnitIdentity):
+		// a unit that could bind an identity under a core connector's
+		// provider would be writing into the table the workspace's own
+		// reply path resolves its recipients from.
+		//
+		// DisplayName lands on Username, which is the core's display-only
+		// field for exactly this: a handle nothing routes, authorizes or
+		// deduplicates on. The two names differ because the core's is
+		// Telegram-shaped and the published one is not, and renaming either
+		// would be a change at a security-sensitive identity for a word.
+		ChannelIdentity: connector.ChannelIdentity{
+			Provider:      cp.ChannelIdentity.Provider,
+			ChannelUserID: cp.ChannelIdentity.ChannelUserID,
+			Username:      cp.ChannelIdentity.DisplayName,
+		},
+	}.WithDeclaredEmailMerge(declaresMergeKey(declared, extension.MergeKeyEmail))
+}
+
+// declaresMergeKey reports whether a source vouched for one identity key.
+func declaresMergeKey(declared extension.IngressSource, key extension.MergeKey) bool {
+	for _, got := range declared.Merges {
+		if got == key {
+			return true
+		}
+	}
+	return false
+}
+
+// refuseUndeclaredMergeKey is the unit-facing half of the merge-key gate: a
+// source may offer an address to MATCH on only if it vouched for one.
+//
+// It is the attributable refusal — a unit author reads their own grammar rather
+// than an unattributable "the core could not land this record" — and it is not
+// the invariant. Capture's own admitCounterpartyKeys holds that, for every
+// caller of Upsert including the ones that never pass through here. Two layers,
+// the way refuseUndeclaredTransport and refuseUnitIdentity are two layers, not
+// two spellings of one rule.
+//
+// It asks only about an address CORROBORATING a human named by a channel
+// identity. A mail-shaped record's address IS that record's identity, belongs to
+// no declaration, and is untouched.
+func refuseUndeclaredMergeKey(declared extension.IngressSource, cp extension.Counterparty) error {
+	namedByChannel := cp.ChannelIdentity.Provider != "" && cp.ChannelIdentity.ChannelUserID != ""
+	if !namedByChannel || cp.Email == "" {
+		return nil
+	}
+	if declaresMergeKey(declared, extension.MergeKeyEmail) {
+		return nil
+	}
+	return fmt.Errorf("%w: ingress source %q carries a counterparty address to match on but declares no %q merge key",
+		extension.ErrInvalid, declared.System, string(extension.MergeKeyEmail))
 }
 
 // refuseUndeclaredTransport holds the kind/transport pairing on ANY of a unit's

--- a/backend/internal/compose/extingress_test.go
+++ b/backend/internal/compose/extingress_test.go
@@ -319,7 +319,7 @@ func TestAMemberIdThatIsNotAnIdIsRefusedBeforeAnyQuery(t *testing.T) {
 // rather than by this side remembering to keep the two equal.
 func TestProvenanceIsStampedFromTheUnitAndItsDeclaredSource(t *testing.T) {
 	rt := ingestingRuntime(t)
-	normalized := rt.normalized(aRecord())
+	normalized := rt.normalized(aRecord(), extension.IngressSource{})
 
 	if want := "ext:probe-unit:probe-system"; normalized.Source != want {
 		t.Errorf("source = %q, want %q", normalized.Source, want)
@@ -351,7 +351,7 @@ func TestProvenanceIsStampedFromTheUnitAndItsDeclaredSource(t *testing.T) {
 // bridge test exists for.
 func TestTheConversionCarriesAWholeRecord(t *testing.T) {
 	rec := aRecord()
-	normalized := ingestingRuntime(t).normalized(rec)
+	normalized := ingestingRuntime(t).normalized(rec, extension.IngressSource{})
 
 	// NormalizedRecord.Fields is the envelope's `any` — one shape per entity
 	// type — so what a landed activity is made of is only readable after this

--- a/backend/internal/compose/extingressdrift_test.go
+++ b/backend/internal/compose/extingressdrift_test.go
@@ -36,6 +36,7 @@ import (
 
 	"github.com/gradionhq/margince/backend/internal/modules/activities"
 	"github.com/gradionhq/margince/backend/internal/modules/capture"
+	"github.com/gradionhq/margince/backend/internal/modules/people"
 	"github.com/gradionhq/margince/backend/internal/shared/gatekit"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/connector"
 	"github.com/gradionhq/margince/backend/pkg/extension"
@@ -169,6 +170,20 @@ func TestTheMessageKindVocabulariesAgree(t *testing.T) {
 	if extension.ActivityKindMessage != activities.KindMessage {
 		t.Errorf("the message kind: published %q, core %q — a unit naming the published one would have every captured message refused",
 			extension.ActivityKindMessage, activities.KindMessage)
+	}
+}
+
+// The merge-key vocabulary is a fourth restated vocabulary, and it names the
+// resolution ladder's own lanes. A unit declares which keys its provider vouches
+// for; the core admits an address to match on only from a source that declared
+// the email key, and the ladder then reports which lane routed. Drift between
+// the two spellings would not fail loudly: the declaration would simply stop
+// matching the lane it was meant to unlock, and a unit that correctly vouched
+// for its addresses would silently have them refused.
+func TestTheMergeKeyVocabulariesAgree(t *testing.T) {
+	if string(extension.MergeKeyEmail) != people.LaneEmail {
+		t.Errorf("the email merge key: published %q, ladder lane %q — a source declaring the published one would have its addresses refused",
+			extension.MergeKeyEmail, people.LaneEmail)
 	}
 }
 

--- a/backend/internal/compose/extingressmergekey_integration_test.go
+++ b/backend/internal/compose/extingressmergekey_integration_test.go
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package compose
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/pkg/extension"
+)
+
+// setupVouchingIngress is setupIngress with a source that DECLARED the email
+// merge key — the only difference that lets its records carry an address
+// alongside the account they name their human by.
+func setupVouchingIngress(t *testing.T) *ingressEnv {
+	t.Helper()
+	e := setupExtRuntime(t)
+	composeCapturingUnit(t, ingressUnit,
+		[]extension.Channel{{Provider: ingressProbeProvider}},
+		extension.IngressSource{
+			System: ingressProbeSystem,
+			Lands:  []extension.RecordKind{extension.KindActivity},
+			Merges: []extension.MergeKey{extension.MergeKeyEmail},
+		})
+	bindCaptureForTest(t, e)
+	grantCapture(t, e, e.Rep1)
+	depositCredential(t, e, e.Rep1)
+	return &ingressEnv{extRuntimeEnv: e, member: e.Rep1}
+}
+
+// corroboratedChannelMessage carries the address the provider knew, alongside
+// the account that names the sender.
+func corroboratedChannelMessage(key, senderEmail, account string) extension.Record {
+	rec := aChannelMessage(key, senderEmail, account)
+	rec.Counterparty.Email = senderEmail
+	rec.Counterparty.Domain = "gmail.com"
+	return rec
+}
+
+func (e *ingressEnv) ingest(t *testing.T, rec extension.Record) error {
+	t.Helper()
+	_, err := e.ingestingRuntime().Ingest(context.Background(), extension.UserID(e.member.String()), rec)
+	return err
+}
+
+// Issue #1382, end to end through the real ingress, capture and resolution
+// path: a human already captured from mail sends a direct message and must not
+// become a second contact.
+//
+// The incumbent is created by the REAL writer — a mail-shaped record from the
+// same unit, resolved by the ladder's personal-domain tier — rather than
+// inserted by the test, so what this proves is what production does.
+//
+// The count is the assertion that matters. One person, holding both keys: the
+// address they were already known by, and the account they can now be answered
+// at. Before this the channel record could not carry the address at all, so the
+// ladder never saw it and minted a twin nobody noticed until a human opened the
+// Duplicates surface.
+func TestADirectMessageFindsTheHumanAlreadyCapturedFromMail(t *testing.T) {
+	e := setupVouchingIngress(t)
+	registerProbeTransport(t, e)
+	const sender = "known.contact@gmail.com"
+
+	if err := e.ingest(t, aProviderRecord("ws-7:2001", sender)); err != nil {
+		t.Fatalf("landing the mail record that creates the incumbent: %v", err)
+	}
+	if got := e.countAsWorkspace(t,
+		`SELECT count(*) FROM person_email WHERE email = $1 AND archived_at IS NULL`, sender); got != 1 {
+		t.Fatalf("the mail capture left %d records carrying %s; this test needs exactly the one incumbent", got, sender)
+	}
+
+	if err := e.ingest(t, corroboratedChannelMessage("ws-7:2002", sender, "U-2002")); err != nil {
+		t.Fatalf("landing the direct message: %v", err)
+	}
+
+	if got := e.countAsWorkspace(t,
+		`SELECT count(*) FROM person_email WHERE email = $1 AND archived_at IS NULL`, sender); got != 1 {
+		t.Fatalf("%d live records carry %s, want 1 — the direct message minted a twin of a human already captured from mail", got, sender)
+	}
+	if got := e.countAsWorkspace(t, `
+		SELECT count(*) FROM person_channel_identity pci
+		  JOIN person_email pe ON pe.person_id = pci.person_id
+		 WHERE pe.email = $1 AND pci.channel_user_id = $2
+		   AND pci.archived_at IS NULL AND pe.archived_at IS NULL`,
+		sender, "U-2002"); got != 1 {
+		t.Errorf("the account is not bound to the human the address found — without the bind they are unreachable for a reply and re-resolved by address on every later message")
+	}
+}
+
+// The declaration is what unlocks it, and a source that never made one has the
+// record REFUSED rather than quietly stripped. Stripping would be worse: the
+// unit would believe it had contributed the evidence, and the duplicate it was
+// trying to prevent would appear anyway, with nothing saying why.
+func TestAnUndeclaredSourceCannotCorroborateByAddress(t *testing.T) {
+	e := setupIngress(t) // declares no merge key
+	registerProbeTransport(t, e)
+	const sender = "stranger@gmail.com"
+
+	err := e.ingest(t, corroboratedChannelMessage("ws-7:2003", sender, "U-2003"))
+
+	if !errors.Is(err, extension.ErrInvalid) {
+		t.Fatalf("ingest = %v, want an ErrInvalid-class refusal naming the missing declaration", err)
+	}
+	if got := e.countAsWorkspace(t,
+		`SELECT count(*) FROM activity WHERE source_id = $1`, "ws-7:2003"); got != 0 {
+		t.Errorf("%d activities landed for a refused record, want 0 — the refusal runs before the transaction opens", got)
+	}
+}

--- a/backend/internal/compose/extingressmergekey_integration_test.go
+++ b/backend/internal/compose/extingressmergekey_integration_test.go
@@ -37,7 +37,6 @@ func setupVouchingIngress(t *testing.T) *ingressEnv {
 func corroboratedChannelMessage(key, senderEmail, account string) extension.Record {
 	rec := aChannelMessage(key, senderEmail, account)
 	rec.Counterparty.Email = senderEmail
-	rec.Counterparty.Domain = "gmail.com"
 	return rec
 }
 
@@ -47,19 +46,18 @@ func (e *ingressEnv) ingest(t *testing.T, rec extension.Record) error {
 	return err
 }
 
-// Issue #1382, end to end through the real ingress, capture and resolution
-// path: a human already captured from mail sends a direct message and must not
-// become a second contact.
+// End to end through the real ingress, capture and resolution path: a human
+// already captured from mail sends a direct message and must not become a second
+// contact.
 //
 // The incumbent is created by the REAL writer — a mail-shaped record from the
 // same unit, resolved by the ladder's personal-domain tier — rather than
 // inserted by the test, so what this proves is what production does.
 //
 // The count is the assertion that matters. One person, holding both keys: the
-// address they were already known by, and the account they can now be answered
-// at. Before this the channel record could not carry the address at all, so the
-// ladder never saw it and minted a twin nobody noticed until a human opened the
-// Duplicates surface.
+// address they were already known by, and the account they can be answered at.
+// Without the address the ladder cannot see the incumbent and mints a twin,
+// which nobody notices until a human opens the Duplicates surface.
 func TestADirectMessageFindsTheHumanAlreadyCapturedFromMail(t *testing.T) {
 	e := setupVouchingIngress(t)
 	registerProbeTransport(t, e)

--- a/backend/internal/compose/extingressmergekey_test.go
+++ b/backend/internal/compose/extingressmergekey_test.go
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/pkg/extension"
+)
+
+// The unit-facing half of the merge-key gate. It is the ATTRIBUTABLE refusal —
+// a unit author reads their own grammar rather than an unattributable "the core
+// could not land this record" — and it is deliberately not the only one: capture
+// holds the same invariant for every caller of Upsert.
+func TestRefuseUndeclaredMergeKey(t *testing.T) {
+	declared := extension.IngressSource{System: "inbox", Merges: []extension.MergeKey{extension.MergeKeyEmail}}
+	silent := extension.IngressSource{System: "inbox"}
+	identity := extension.ChannelIdentity{Provider: "dispact", ChannelUserID: "U0293"}
+
+	for _, tc := range []struct {
+		name   string
+		source extension.IngressSource
+		cp     extension.Counterparty
+		refuse bool
+	}{
+		{
+			name:   "an address to match on from a source that vouched for none",
+			source: silent,
+			cp:     extension.Counterparty{Email: "tuyen@acme.example", ChannelIdentity: identity},
+			refuse: true,
+		},
+		{
+			name:   "the same address from a source that declared the key",
+			source: declared,
+			cp:     extension.Counterparty{Email: "tuyen@acme.example", ChannelIdentity: identity},
+		},
+		{
+			// A mention in a shared room: the record is NAMED by the address,
+			// which is identity rather than corroboration and belongs to no
+			// declaration. Refusing this would break every mail-shaped record a
+			// unit lands today.
+			name:   "a mail-shaped record from a source that declared nothing",
+			source: silent,
+			cp:     extension.Counterparty{Email: "tuyen@acme.example"},
+		},
+		{
+			name:   "a channel record carrying no address at all",
+			source: silent,
+			cp:     extension.Counterparty{ChannelIdentity: identity},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := refuseUndeclaredMergeKey(tc.source, tc.cp)
+			if tc.refuse && !errors.Is(err, extension.ErrInvalid) {
+				t.Fatalf("got %v, want an ErrInvalid-class refusal", err)
+			}
+			if !tc.refuse && err != nil {
+				t.Fatalf("got %v, want the record admitted", err)
+			}
+		})
+	}
+}
+
+// The declaration is the SOURCE's, resolved by the core from the manifest. A
+// unit that could state it per record could widen its own trust, which is the
+// one thing the declaration exists to bound — so the mapper must read the
+// source and never the record.
+func TestTheDeclarationIsStampedFromTheSourceNotTheRecord(t *testing.T) {
+	cp := extension.Counterparty{
+		Email:           "tuyen@acme.example",
+		ChannelIdentity: extension.ChannelIdentity{Provider: "dispact", ChannelUserID: "U0293"},
+	}
+
+	silent := counterpartyOf(cp, extension.IngressSource{System: "inbox"})
+	if silent.MayCorroborateByEmail() {
+		t.Error("a record from a source declaring nothing arrived able to corroborate by address")
+	}
+
+	vouched := counterpartyOf(cp, extension.IngressSource{
+		System: "inbox", Merges: []extension.MergeKey{extension.MergeKeyEmail},
+	})
+	if !vouched.MayCorroborateByEmail() {
+		t.Error("a record from a source declaring the email key arrived unable to corroborate by address")
+	}
+}

--- a/backend/internal/compose/integration/channels/channelidentity_erasurelock_integration_test.go
+++ b/backend/internal/compose/integration/channels/channelidentity_erasurelock_integration_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/gradionhq/margince/backend/internal/compose/integration"
+	"github.com/gradionhq/margince/backend/internal/modules/people"
 	"github.com/gradionhq/margince/backend/internal/modules/privacy"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
@@ -134,6 +135,79 @@ func TestErasureIsUnaffectedByALockOnAnotherAccount(t *testing.T) {
 	}
 	if !suppressed(t, e, "10109") {
 		t.Error("the erased account is not suppressed")
+	}
+}
+
+// seedMailOnlySubject creates a person holding one address and no channel
+// account — the shape whose erasure takes no account lock at all, which is what
+// makes the address half of the mutex load-bearing. Written through the real
+// store, so the identifiers the eraser reads are the ones production writes.
+func seedMailOnlySubject(t *testing.T, e *integration.Env, name, email string) ids.UUID {
+	t.Helper()
+	person, err := e.People.CreatePerson(e.Admin(), people.CreatePersonInput{
+		FullName: name, Source: "manual",
+		Emails: []people.PersonEmailInput{{Email: email, EmailType: "work", IsPrimary: true}},
+	})
+	if err != nil {
+		t.Fatalf("seeding %s: %v", name, err)
+	}
+	return ids.UUID(person.Id)
+}
+
+// eraseWhileAddressIsLocked is the twin of eraseWhileAccountIsLocked for the
+// other half of the mutex: it holds the subject lock on an ADDRESS across a
+// whole erasure.
+func eraseWhileAddressIsLocked(t *testing.T, e *integration.Env, person ids.UUID, lockedEmail string) error {
+	t.Helper()
+	eraser := privacy.NewEraser(database.BindTo(lockWaitBoundedPool(t), ids.From[ids.WorkspaceKind](e.WS)))
+	admin := e.Admin()
+	ctx := principal.WithWorkspaceID(context.Background(), e.WS)
+	var eraseErr error
+	if err := database.WithWorkspaceTx(ctx, e.Pool, func(tx pgx.Tx) error {
+		if err := storekit.LockSubjectKeys(ctx, tx, nil, []string{lockedEmail}); err != nil {
+			return err
+		}
+		eraseErr = eraser.ErasePerson(admin, person, "test")
+		return nil
+	}); err != nil {
+		t.Fatalf("holding the address lock: %v", err)
+	}
+	return eraseErr
+}
+
+// The address half of the same mutex, and it covers the subject the account
+// half cannot: a human known only from mail holds NO channel account, so an
+// erasure locking accounts alone takes no lock at all and serializes against
+// nothing.
+//
+// A channel message naming that human by an account while corroborating them by
+// their address can then land inside the purge. Its binding is written after the
+// erasure's own pre-erasure read, so nothing deletes or suppresses it, and the
+// account outranks the address in the resolution ladder — leaving a
+// certified-erased subject reachable, and unerasable a second time because the
+// address the next erasure would need has already been destroyed.
+func TestErasureWaitsForAnInFlightDeliveryCorroboratedByTheSubjectsAddress(t *testing.T) {
+	e := integration.Setup(t)
+	const email = "mail.only.subject@client.io"
+	person := seedMailOnlySubject(t, e, "Mail Only Subject", email)
+
+	err := eraseWhileAddressIsLocked(t, e, person, email)
+
+	var pgErr *pgconn.PgError
+	if !errors.As(err, &pgErr) || pgErr.Code != pgerrcode.LockNotAvailable {
+		t.Fatalf("ErasePerson returned %v, want a lock-wait timeout — it did not take the subject's address lock, so a message corroborated by that address can bind an account inside the erasure", err)
+	}
+}
+
+// The negative control: the lock is per ADDRESS, so an unrelated human's
+// message never delays an erasure, and the failure above is the lock rather
+// than the bounded pool.
+func TestErasureIsUnaffectedByALockOnAnotherAddress(t *testing.T) {
+	e := integration.Setup(t)
+	person := seedMailOnlySubject(t, e, "Unrelated Mail Subject", "erased@client.io")
+
+	if err := eraseWhileAddressIsLocked(t, e, person, "somebody.else@client.io"); err != nil {
+		t.Fatalf("ErasePerson: %v — an unrelated address must not block an erasure", err)
 	}
 }
 

--- a/backend/internal/compose/integration/channels/telegram_sinkerasure_integration_test.go
+++ b/backend/internal/compose/integration/channels/telegram_sinkerasure_integration_test.go
@@ -202,25 +202,28 @@ func TestTheSinkIsUnaffectedByALockOnAnotherAccount(t *testing.T) {
 	}
 }
 
-// A counterparty is named by an address OR by a channel identity. Classifying a
-// record carrying both as mail binds no channel identity and, because every mail
-// gate keys off the address, records no fault either — the one capture outcome
-// with no breadcrumb. No in-tree producer emits this shape, so these two cases
-// are the only thing holding the gate up and they assert the specific refusal:
-// "some error occurred" would keep passing if the gate were deleted and an
-// unrelated fault took its place.
-func TestTheSinkRefusesACounterpartyNamedTwice(t *testing.T) {
+// An address alongside a channel identity is matching evidence, and a source may
+// only offer it if it declared the email merge key. Telegram declares none — a
+// bot knows no address for the sender — so this record is refused at the edge,
+// before the transaction opens.
+//
+// The refusal is asserted BY NAME rather than as "some error occurred", which
+// would keep passing if the gate were deleted and an unrelated fault took its
+// place. It matters that nothing commits: admitting the address without the
+// declaration would feed an unvouched-for key to the resolution ladder, which is
+// how one human silently becomes bound to another's record.
+func TestTheSinkRefusesAnUndeclaredCorroboratingAddress(t *testing.T) {
 	e := integration.Setup(t)
 
-	rec := inboundChannelRecord("20304", "named twice")
+	rec := inboundChannelRecord("20304", "undeclared merge key")
 	rec.Counterparty.Email = "someone@example.com"
 
 	_, err := capture.NewSink(e.DB()).Upsert(sinkConnectorCtx(e), rec)
-	if !errors.Is(err, capture.ErrCounterpartyNamedTwice) {
-		t.Fatalf("Upsert returned %v, want ErrCounterpartyNamedTwice", err)
+	if !errors.Is(err, capture.ErrMergeKeyNotDeclared) {
+		t.Fatalf("Upsert returned %v, want ErrMergeKeyNotDeclared", err)
 	}
-	if n := activityBodyCount(t, e, "named twice"); n != 0 {
-		t.Errorf("%d activities were committed for a malformed counterparty; want 0", n)
+	if n := activityBodyCount(t, e, "undeclared merge key"); n != 0 {
+		t.Errorf("%d activities were committed for an undeclared merge key; want 0", n)
 	}
 }
 

--- a/backend/internal/modules/capture/pendingsweeps.go
+++ b/backend/internal/modules/capture/pendingsweeps.go
@@ -242,7 +242,8 @@ const noiseMailScope = `
 	       AND c.direction = 'outbound' AND c.counterparty_outbound_attested)
 	  AND NOT EXISTS (
 	    SELECT 1 FROM person_email pe JOIN person pr ON pr.id = pe.person_id
-	     WHERE pe.email = p.email AND pr.archived_at IS NULL)`
+	     WHERE pe.email = p.email AND pr.archived_at IS NULL
+	       AND pe.from_correspondence)`
 
 // noiseVerdictReach bounds how far past its own verdict a `noise` disposition
 // may reach forward in time.

--- a/backend/internal/modules/capture/sink.go
+++ b/backend/internal/modules/capture/sink.go
@@ -114,6 +114,9 @@ func (s *Sink) Upsert(ctx context.Context, rec connector.NormalizedRecord) (data
 	if err := admitCounterpartyShape(counterpartyShapeOf(rec.Counterparty)); err != nil {
 		return datasource.EntityRef{}, err
 	}
+	if err := admitCounterpartyKeys(rec.Counterparty); err != nil {
+		return datasource.EntityRef{}, err
+	}
 
 	var ref datasource.EntityRef
 	var dedupeHit *ids.LeadID

--- a/backend/internal/modules/capture/sinkchannel.go
+++ b/backend/internal/modules/capture/sinkchannel.go
@@ -159,8 +159,7 @@ func admitCounterpartyShape(shape counterpartyShape) error {
 // The gate is narrow on purpose. It asks only about an address CORROBORATING a
 // human already named by a channel identity — never about the address a
 // mail-shaped record is named by, which is that record's identity and belongs to
-// no declaration. A source that never declared the key simply has the record
-// refused, which is the behaviour before merge keys existed.
+// no declaration. A source that never declared the key has the record refused.
 //
 // This runs for every caller of Upsert, not only for units. That is the point:
 // the unit-facing refusal lives in the ingress gate where it can be attributed

--- a/backend/internal/modules/capture/sinkchannel.go
+++ b/backend/internal/modules/capture/sinkchannel.go
@@ -35,14 +35,22 @@ type ChannelCounterpartyEnsurer interface {
 // EnsureChannelRequest names one inbound channel message's counterparty for the
 // resolver. It carries no OwnerID and no SuppressOrg, and the omissions are the
 // design: a workspace bot has no granting human for anything created to belong
-// to (design D2 — the person is ownerless), and a channel identity carries no
-// mail domain a company could be derived from in the first place.
+// to (design D2 — the person is ownerless), and no company is derived here even
+// when an address rides along — a corroborating address is evidence about WHO
+// this is, and reading an employer out of it would be the mail ladder's job,
+// which this path deliberately bypasses.
 type EnsureChannelRequest struct {
 	Identity    connector.ChannelIdentity
 	DisplayName string // the provider's own name for the sender — untrusted text
-	ActivityID  ids.UUID
-	Source      string
-	CapturedBy  string
+	// CorroboratingEmail is the sender's address where the provider knew one and
+	// the source declared the email merge key (admitCounterpartyKeys). It names
+	// nobody — Identity does that — and reaches only the resolution ladder and
+	// the person's own address list. Empty for a transport that holds no
+	// address, which is every core channel connector.
+	CorroboratingEmail string
+	ActivityID         ids.UUID
+	Source             string
+	CapturedBy         string
 }
 
 // WithChannelEnsurer returns a copy wired to the channel auto-create path. A
@@ -54,21 +62,29 @@ func (s *Sink) WithChannelEnsurer(ensurer ChannelCounterpartyEnsurer) *Sink {
 	return &c
 }
 
-// counterpartyShape is how a record names its human. connector.Counterparty
-// documents an address and a channel identity as mutually exclusive, and this is
-// the one place capture asks which it holds — so the question is total rather
-// than a boolean. A record carrying BOTH is malformed: classifying it as mail
-// would bind no channel identity and, because every mail gate keys off the
-// address, would record no fault either, making it the one capture outcome that
-// leaves no breadcrumb at all. The exhaustive switch is what keeps that case
-// impossible to reach by omission.
+// counterpartyShape is how a record NAMES its human, which is a different
+// question from what evidence it carries about them — and this is the one place
+// capture asks it, so the question is total rather than a boolean.
+//
+// A record holding both a channel identity and an address is named by the
+// IDENTITY. That is precedence, not a coin toss: the identity is the key a reply
+// is routed on and the one a person is bound by, while an address can only
+// corroborate. Reading it the other way round would classify the record as mail,
+// which binds no channel identity and — because every mail gate keys off the
+// address — would record no fault either, the one capture outcome that leaves no
+// breadcrumb at all. The exhaustive switch keeps that impossible to reach by
+// omission.
+//
+// Whether the record may carry that corroborating address at all is a separate
+// question, asked by admitCounterpartyKeys against the source's declaration.
+// Keeping the two apart is what lets a declared and an undeclared source agree
+// about who the message is with while disagreeing about what may be matched on.
 type counterpartyShape int
 
 const (
 	shapeNone counterpartyShape = iota
 	shapeMail
 	shapeChannel
-	shapeAmbiguous
 	shapeHalfChannel
 
 	// shapeCount bounds the enum so a walk over it derives rather than repeats
@@ -85,16 +101,18 @@ const (
 // mid-purge — the mutex would be decorative. people's ensure refuses the same
 // half-identity; refusing it here keeps the two in step.
 func counterpartyShapeOf(cp connector.Counterparty) counterpartyShape {
-	hasMail := cp.Email != ""
 	provider, account := cp.ChannelIdentity.Provider, cp.ChannelIdentity.ChannelUserID
 	switch {
-	case hasMail && (provider != "" || account != ""):
-		return shapeAmbiguous
 	case provider != "" && account != "":
+		// Precedence, and it is ordered first on purpose: a complete channel
+		// identity names the human whether or not an address rides along.
 		return shapeChannel
 	case provider != "" || account != "":
+		// Half an identity is malformed however much else the record carries —
+		// an address alongside it cannot complete it, because the missing half
+		// is what the locks and suppression keys are built from.
 		return shapeHalfChannel
-	case hasMail:
+	case cp.Email != "":
 		return shapeMail
 	default:
 		return shapeNone
@@ -121,8 +139,6 @@ func admitCounterpartyShape(shape counterpartyShape) error {
 		// Well-formed; the channel arm is gated again inside the transaction,
 		// under the account's own erasure lock.
 		return nil
-	case shapeAmbiguous:
-		return ErrCounterpartyNamedTwice
 	case shapeHalfChannel:
 		return ErrChannelIdentityIncomplete
 	default:
@@ -130,14 +146,44 @@ func admitCounterpartyShape(shape counterpartyShape) error {
 	}
 }
 
-// ErrCounterpartyNamedTwice refuses a record naming its human both by an address
-// and by a channel identity. ErrChannelIdentityIncomplete refuses half a channel
-// identity. Both are sentinels rather than bare errors so the refusal can be
-// asserted on, and so a caller can tell a malformed record from an
-// infrastructural failure.
+// admitCounterpartyKeys is the second half of admission and runs beside the
+// first, at the same edge: the shape says who the record NAMES, this says what
+// it may be MATCHED on.
+//
+// It is a sibling rather than an arm of admitCounterpartyShape because that
+// function deliberately takes the shape and not the Counterparty, so its switch
+// can be walked across the whole enum including arms no Counterparty can
+// produce. This one has to read the record itself, and merging the two would
+// cost that walk.
+//
+// The gate is narrow on purpose. It asks only about an address CORROBORATING a
+// human already named by a channel identity — never about the address a
+// mail-shaped record is named by, which is that record's identity and belongs to
+// no declaration. A source that never declared the key simply has the record
+// refused, which is the behaviour before merge keys existed.
+//
+// This runs for every caller of Upsert, not only for units. That is the point:
+// the unit-facing refusal lives in the ingress gate where it can be attributed
+// to a unit's own grammar, and this one holds the invariant for a core
+// connector, a fixture or a backfill that never passes through there.
+func admitCounterpartyKeys(cp connector.Counterparty) error {
+	if counterpartyShapeOf(cp) != shapeChannel || cp.Email == "" {
+		return nil
+	}
+	if !cp.MayCorroborateByEmail() {
+		return ErrMergeKeyNotDeclared
+	}
+	return nil
+}
+
+// ErrChannelIdentityIncomplete refuses half a channel identity.
+// ErrMergeKeyNotDeclared refuses an address offered as matching evidence by a
+// source that never vouched for one. Both are sentinels rather than bare errors
+// so the refusal can be asserted on, and so a caller can tell a malformed record
+// from an infrastructural failure.
 var (
-	ErrCounterpartyNamedTwice    = errors.New("capture: a counterparty is named by an address or by a channel identity, never both")
 	ErrChannelIdentityIncomplete = errors.New("capture: a channel identity needs both a provider and a channel account id")
+	ErrMergeKeyNotDeclared       = errors.New("capture: the record carries an address to match on, but its source declared no email merge key")
 )
 
 // refuseErasedChannelAccount excludes an Art. 17 erasure from the transaction
@@ -147,12 +193,17 @@ var (
 // never inside.
 //
 // Landing inside it is not a near miss. The activity would commit after the
-// erasure certified the subject scrubbed, and with no person link and no
-// counterparty_email it matches neither erasure selector afterwards — so no
-// later erasure, subject-access or retention pass could ever find it, while the
-// erasure's own audit tombstone records a clean scrub. The probe in people's
-// EnsureChannelCounterparty runs after this commit and its refusal is mapped to
-// nil by design, so it is the second gate and cannot be the only one.
+// erasure certified the subject scrubbed, and with no person link it matches
+// the link-walking selector afterwards — and a record from a transport that
+// holds no address, which is every core channel connector, carries no
+// counterparty_email for the mail selector to find either. So no later erasure,
+// subject-access or retention pass could ever find it, while the erasure's own
+// audit tombstone records a clean scrub. A corroborating address narrows that
+// window where one exists; it does not close it, because the transports most
+// likely to be erased on are exactly the ones with no address to carry. The
+// probe in people's EnsureChannelCounterparty runs after this commit and its
+// refusal is mapped to nil by design, so it is the second gate and cannot be
+// the only one.
 //
 // The refusal deliberately names NO identifier. For a channel record the
 // natural key embeds the account id itself (a private chat's id is the user's
@@ -205,11 +256,12 @@ func (s *Sink) decideChannelCounterparty(ctx context.Context) counterpartyDecisi
 func (s *Sink) ensureChannelCounterparty(ctx context.Context, rec connector.NormalizedRecord, ref datasource.EntityRef, decision counterpartyDecision) {
 	cp := rec.Counterparty
 	outcome, err := s.channelEnsurer.EnsureChannelCounterparty(ctx, EnsureChannelRequest{
-		Identity:    cp.ChannelIdentity,
-		DisplayName: cp.DisplayName,
-		ActivityID:  ref.ID,
-		Source:      captureSource(rec),
-		CapturedBy:  decision.capturedBy,
+		Identity:           cp.ChannelIdentity,
+		DisplayName:        cp.DisplayName,
+		CorroboratingEmail: cp.Email,
+		ActivityID:         ref.ID,
+		Source:             captureSource(rec),
+		CapturedBy:         decision.capturedBy,
 	})
 	if err != nil {
 		s.logEnsureFault(ctx, rec, err)

--- a/backend/internal/modules/capture/sinkensure.go
+++ b/backend/internal/modules/capture/sinkensure.go
@@ -382,6 +382,14 @@ const priorKnownNonPerson = "known_nonperson"
 // an earlier verdict, a human typing them in, an import — counts as `real`:
 // what matters is that the address is already a known counterparty, not which
 // path made it one.
+//
+// With ONE exception, and it is the reason person_email.from_correspondence
+// exists: an address a channel connector's directory vouched for, on a human
+// reached on another medium, is not a verdict about mail. Reading it as one
+// would let a single direct message from a stranger settle their address as
+// known correspondence — auto-creating every later bulk mail from it and
+// switching off the noise sweep for it for good. It still identifies the
+// person; it just does not speak here.
 func (s *Sink) priorDispositionTx(ctx context.Context, tx pgx.Tx, email string) (string, error) {
 	normalized := normalizeEmail(email)
 	if normalized == "" {
@@ -392,7 +400,8 @@ func (s *Sink) priorDispositionTx(ctx context.Context, tx pgx.Tx, email string) 
 		SELECT CASE
 		         WHEN EXISTS (
 		           SELECT 1 FROM person_email pe JOIN person p ON p.id = pe.person_id
-		            WHERE pe.email = $1 AND p.archived_at IS NULL) THEN 'real'
+		            WHERE pe.email = $1 AND p.archived_at IS NULL
+		              AND pe.from_correspondence) THEN 'real'
 		         ELSE coalesce((
 		           -- A real-status row whose KIND names no human is not an
 		           -- instruction to create one. role_mailbox and

--- a/backend/internal/modules/capture/sinkmergekeys_test.go
+++ b/backend/internal/modules/capture/sinkmergekeys_test.go
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package capture
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/ports/connector"
+)
+
+// A record carrying both a channel identity and an address is named by the
+// IDENTITY. This is the precedence the whole change rests on: read the other way
+// round the record would classify as mail, which binds nothing and — because
+// every mail gate keys off the address — records no fault either.
+func TestACorroboratingAddressDoesNotChangeWhoNamesTheHuman(t *testing.T) {
+	both := connector.Counterparty{
+		Email:           "tuyen@acme.example",
+		ChannelIdentity: connector.ChannelIdentity{Provider: "dispact", ChannelUserID: "U0293"},
+	}
+
+	if got := counterpartyShapeOf(both); got != shapeChannel {
+		t.Errorf("shape = %d, want shapeChannel (%d) — the identity names the human, the address only corroborates", got, shapeChannel)
+	}
+}
+
+// Half an identity stays malformed however much else rides along: the missing
+// half is what the advisory lock and the suppression key are built from, so an
+// address cannot stand in for it.
+func TestAnAddressDoesNotCompleteHalfAChannelIdentity(t *testing.T) {
+	half := connector.Counterparty{
+		Email:           "tuyen@acme.example",
+		ChannelIdentity: connector.ChannelIdentity{Provider: "dispact"},
+	}
+
+	if got := counterpartyShapeOf(half); got != shapeHalfChannel {
+		t.Errorf("shape = %d, want shapeHalfChannel (%d)", got, shapeHalfChannel)
+	}
+	if err := admitCounterpartyShape(counterpartyShapeOf(half)); !errors.Is(err, ErrChannelIdentityIncomplete) {
+		t.Errorf("admission = %v, want ErrChannelIdentityIncomplete", err)
+	}
+}
+
+func TestAdmitCounterpartyKeys(t *testing.T) {
+	identity := connector.ChannelIdentity{Provider: "dispact", ChannelUserID: "U0293"}
+	for _, tc := range []struct {
+		name string
+		cp   connector.Counterparty
+		want error
+	}{
+		{
+			// The case the gate exists for: matching evidence from a source
+			// that vouched for none. Admitting it would feed the resolution
+			// ladder a key nobody stands behind, which is how one human is
+			// silently bound to another's record.
+			name: "an undeclared corroborating address is refused",
+			cp:   connector.Counterparty{Email: "tuyen@acme.example", ChannelIdentity: identity},
+			want: ErrMergeKeyNotDeclared,
+		},
+		{
+			name: "a declared corroborating address is admitted",
+			cp: connector.Counterparty{Email: "tuyen@acme.example", ChannelIdentity: identity}.
+				WithDeclaredEmailMerge(true),
+		},
+		{
+			// A mail record's address IS its identity, not evidence about
+			// somebody named another way, so it belongs to no declaration. This
+			// is the case a rule phrased as "any undeclared key is refused"
+			// would wrongly reject.
+			name: "a mail-shaped record needs no declaration",
+			cp:   connector.Counterparty{Email: "tuyen@acme.example"},
+		},
+		{
+			name: "a channel record with no address needs no declaration",
+			cp:   connector.Counterparty{ChannelIdentity: identity},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := admitCounterpartyKeys(tc.cp); !errors.Is(err, tc.want) {
+				t.Errorf("admitCounterpartyKeys = %v, want %v", err, tc.want)
+			}
+		})
+	}
+}
+
+// The stamp is the core's word about the SOURCE, so a record that has been
+// copied, re-read or rebuilt must not arrive claiming a declaration nobody made.
+// Unexported, the zero value is the refusing one at every boundary.
+func TestTheDeclarationDefaultsToRefusing(t *testing.T) {
+	var cp connector.Counterparty
+	if cp.MayCorroborateByEmail() {
+		t.Error("a zero Counterparty claims a declared merge key; the untrusting answer must be the default")
+	}
+	if cp.WithDeclaredEmailMerge(true).WithDeclaredEmailMerge(false).MayCorroborateByEmail() {
+		t.Error("the declaration did not fall back to refusing when re-stamped as undeclared")
+	}
+}

--- a/backend/internal/modules/capture/sinkreply.go
+++ b/backend/internal/modules/capture/sinkreply.go
@@ -163,8 +163,6 @@ func (s *Sink) replyOriginForShape(ctx context.Context, tx pgx.Tx, cp connector.
 		return withContact(replyOrigin{channel: cp.ChannelIdentity.Provider}, contact, found), true, nil
 	case shapeNone:
 		return replyOrigin{}, false, nil
-	case shapeAmbiguous:
-		return replyOrigin{}, false, ErrCounterpartyNamedTwice
 	case shapeHalfChannel:
 		return replyOrigin{}, false, ErrChannelIdentityIncomplete
 	default:

--- a/backend/internal/modules/capture/sinkreply_test.go
+++ b/backend/internal/modules/capture/sinkreply_test.go
@@ -52,11 +52,11 @@ func TestEveryCounterpartyShapeIsAnsweredByBothSwitches(t *testing.T) {
 	}
 }
 
-// TestAdmissionRefusesTheTwoMalformedShapesByName pins WHICH refusal each
-// malformed shape earns. The walk above proves only that no shape falls
-// through; a caller telling a record that names its human twice from one that
-// names it by half a channel identity needs the sentinels to stay distinct.
-func TestAdmissionRefusesTheTwoMalformedShapesByName(t *testing.T) {
+// TestAdmissionRefusesTheMalformedShapeByName pins WHICH refusal a malformed
+// shape earns. The walk above proves only that no shape falls through; a caller
+// telling half a channel identity from an undeclared merge key needs the
+// sentinels to stay distinct.
+func TestAdmissionRefusesTheMalformedShapeByName(t *testing.T) {
 	for _, tc := range []struct {
 		shape counterpartyShape
 		want  error
@@ -64,7 +64,6 @@ func TestAdmissionRefusesTheTwoMalformedShapesByName(t *testing.T) {
 		{shapeNone, nil},
 		{shapeMail, nil},
 		{shapeChannel, nil},
-		{shapeAmbiguous, ErrCounterpartyNamedTwice},
 		{shapeHalfChannel, ErrChannelIdentityIncomplete},
 	} {
 		if err := admitCounterpartyShape(tc.shape); !errors.Is(err, tc.want) {
@@ -108,14 +107,6 @@ func TestReplyOriginOf_RefusesMalformedAndUnnamedCounterparties(t *testing.T) {
 			// medium to answer on and nobody to answer, so no reply origin.
 			name: "no counterparty names no origin",
 			cp:   connector.Counterparty{},
-		},
-		{
-			name: "an address and a channel identity together are refused",
-			cp: connector.Counterparty{
-				Email:           "alice@example.com",
-				ChannelIdentity: connector.ChannelIdentity{Provider: "telegram", ChannelUserID: "77"},
-			},
-			wantErr: ErrCounterpartyNamedTwice,
 		},
 		{
 			name:    "half a channel identity is refused",

--- a/backend/internal/modules/capture/traceresolution_integration_test.go
+++ b/backend/internal/modules/capture/traceresolution_integration_test.go
@@ -23,10 +23,19 @@ import (
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
-// seedDeferredMessage writes an activity from one sender, a trace row for it,
-// and (on the first call for that address) the ledger's open question.
+// seedDeferredMessage writes a MAIL activity from one sender, a trace row for
+// it, and (on the first call for that address) the ledger's open question.
 func seedDeferredMessage(ctx context.Context, t *testing.T, db *database.DB,
 	owner ids.UUID, sourceID, sender string, withLedger bool,
+) {
+	t.Helper()
+	seedDeferredRecord(ctx, t, db, owner, sourceID, sender, "", withLedger)
+}
+
+// seedDeferredRecord is seedDeferredMessage with the transport named: empty
+// lands a mail record, a provider lands a message on that channel.
+func seedDeferredRecord(ctx context.Context, t *testing.T, db *database.DB,
+	owner ids.UUID, sourceID, sender, channelProvider string, withLedger bool,
 ) {
 	t.Helper()
 	activityID := ids.NewV7()
@@ -41,11 +50,12 @@ func seedDeferredMessage(ctx context.Context, t *testing.T, db *database.DB,
 			return err
 		}
 		if _, err := tx.Exec(ctx, `
-			INSERT INTO activity (id, workspace_id, kind, occurred_at, source_system, source_id,
-			                      source, captured_by, counterparty_email)
+			INSERT INTO activity (id, workspace_id, kind, channel_provider, occurred_at, source_system,
+			                      source_id, source, captured_by, counterparty_email)
 			VALUES ($1, NULLIF(current_setting('app.workspace_id', true), '')::uuid,
-			        'note', now(), 'gmail', $2, 'gmail', 'connector:gmail', $3)`,
-			activityID, sourceID, sender); err != nil {
+			        CASE WHEN $4 = '' THEN 'note' ELSE 'message' END, NULLIF($4, ''),
+			        now(), 'gmail', $2, 'gmail', 'connector:gmail', $3)`,
+			activityID, sourceID, sender, channelProvider); err != nil {
 			return err
 		}
 		if withLedger {
@@ -94,5 +104,41 @@ func TestAVerdictReachesEveryMessageFromThatSender(t *testing.T) {
 		if entry.Resolution.Status != "real" {
 			t.Errorf("resolution = %q, want the ledger's answer", entry.Resolution.Status)
 		}
+	}
+}
+
+// The disposition ledger is the MAIL ladder's, keyed on an address. A direct
+// message may carry that same address to be matched on, and it reaches the
+// member's trace through the same activity column — so without a guard the
+// member is told their captured, linked and answered conversation is waiting on
+// a verdict that belongs to another medium and can never resolve for it.
+//
+// The mail row is the control: it must still carry the verdict, or the guard
+// would be suppressing the ledger rather than scoping it.
+func TestOnlyAMailRowCarriesTheMailVerdict(t *testing.T) {
+	ctx, ws, db, store := traceReadWorkspace(t)
+	me := ids.NewV7()
+	memberCtx := memberContext(ctx, ws, me)
+	const sender = "both.media@client.io"
+
+	seedDeferredRecord(memberCtx, t, db, me, "m-1", sender, "", true)
+	seedDeferredRecord(memberCtx, t, db, me, "c-1", sender, "telegram", false)
+
+	window, err := store.ListMine(memberCtx, nil, nil)
+	if err != nil {
+		t.Fatalf("ListMine: %v", err)
+	}
+
+	if len(window.Entries) != 2 {
+		t.Fatalf("entries = %d, want the mail row and the channel row", len(window.Entries))
+	}
+	resolved := 0
+	for _, entry := range window.Entries {
+		if entry.Resolution != nil {
+			resolved++
+		}
+	}
+	if resolved != 1 {
+		t.Errorf("%d of 2 rows carry the mail verdict, want exactly the mail one — a channel record has no ladder verdict to report, which is not the same as having one that is pending", resolved)
 	}
 }

--- a/backend/internal/modules/capture/tracestore.go
+++ b/backend/internal/modules/capture/tracestore.go
@@ -214,9 +214,9 @@ func (s *TraceStore) readPage(ctx context.Context, tx pgx.Tx, scope traceScope,
 	//
 	// MAIL rows only, and the channel_provider guard is what says so. The
 	// disposition ledger is the mail ladder's, keyed on an address; a channel
-	// message can now carry a corroborating address too, and without the guard a
-	// direct message would inherit the mail verdict pending for that same human
-	// — telling a member their captured, linked and answered conversation is
+	// message may carry a corroborating address, and without the guard a direct
+	// message inherits whatever mail verdict is pending for that same human —
+	// telling a member their captured, linked and answered conversation is
 	// "waiting on a verdict". A channel record has no ladder verdict to report,
 	// which is not the same as having one that is pending.
 	rows, err := tx.Query(ctx, storekit.SQLf(`

--- a/backend/internal/modules/capture/tracestore.go
+++ b/backend/internal/modules/capture/tracestore.go
@@ -211,6 +211,14 @@ func (s *TraceStore) readPage(ctx context.Context, tx pgx.Tx, scope traceScope,
 	// holds no address unless an operator enabled payloads, and what a member is
 	// told must not depend on a diagnostic posture. The activity is the member's
 	// own message, so its sender's disposition is theirs to know.
+	//
+	// MAIL rows only, and the channel_provider guard is what says so. The
+	// disposition ledger is the mail ladder's, keyed on an address; a channel
+	// message can now carry a corroborating address too, and without the guard a
+	// direct message would inherit the mail verdict pending for that same human
+	// — telling a member their captured, linked and answered conversation is
+	// "waiting on a verdict". A channel record has no ladder verdict to report,
+	// which is not the same as having one that is pending.
 	rows, err := tx.Query(ctx, storekit.SQLf(`
 		SELECT t.id, t.connector, t.outcome, coalesce(t.reason, ''), t.activity_id,
 		       d.status, coalesce(d.kind, ''), d.resolved_at,
@@ -223,6 +231,7 @@ func (s *TraceStore) readPage(ctx context.Context, tx pgx.Tx, scope traceScope,
 		           FROM capture_pending_counterparty
 		          WHERE workspace_id = t.workspace_id
 		            AND email = a.counterparty_email
+		            AND a.channel_provider IS NULL
 		          ORDER BY resolved_at DESC NULLS FIRST
 		          LIMIT 1) d ON true
 		 WHERE %s

--- a/backend/internal/modules/people/creatededupe.go
+++ b/backend/internal/modules/people/creatededupe.go
@@ -167,7 +167,7 @@ func (m PersonResolution) recordIfReview(ctx context.Context, tx pgx.Tx, created
 // would mean the ladder and the child-row write disagree about what was
 // stored, and a review pair with no evidence is worse than a loud failure.
 func (m PersonResolution) recordSharedPhone(ctx context.Context, tx pgx.Tx, createdID ids.PersonID, source, by string) error {
-	if m.MatchedLane != lanePhone {
+	if m.MatchedLane != LanePhone {
 		// The package comment above is the argument that this cannot
 		// happen; if a lane ever does reach here it has no create-path
 		// policy, and inventing one silently is how a 409 contract or a

--- a/backend/internal/modules/people/creatededupe.go
+++ b/backend/internal/modules/people/creatededupe.go
@@ -167,7 +167,7 @@ func (m PersonResolution) recordIfReview(ctx context.Context, tx pgx.Tx, created
 // would mean the ladder and the child-row write disagree about what was
 // stored, and a review pair with no evidence is worse than a loud failure.
 func (m PersonResolution) recordSharedPhone(ctx context.Context, tx pgx.Tx, createdID ids.PersonID, source, by string) error {
-	if m.MatchedLane != LanePhone {
+	if m.MatchedLane != lanePhone {
 		// The package comment above is the argument that this cannot
 		// happen; if a lane ever does reach here it has no create-path
 		// policy, and inventing one silently is how a 409 contract or a

--- a/backend/internal/modules/people/dedupe.go
+++ b/backend/internal/modules/people/dedupe.go
@@ -111,15 +111,14 @@ type LaneConflict struct {
 // address, which outranks a phone number households and switchboards
 // share.
 //
-// Exported because PersonResolution.MatchedLane and LaneConflict's two lane
-// fields already hand these strings to callers, and a caller comparing against
-// a literal it spelled itself is a caller that keeps compiling after the
-// vocabulary moves. A fitness test holds LaneEmail equal to the published
-// extension.MergeKeyEmail for the same reason.
+// LaneEmail alone is exported, and only because the published
+// extension.MergeKeyEmail must equal it: a source declares that key to have an
+// address reach this lane, and a fitness test outside this package reads both to
+// hold them equal. The other two name no vocabulary beyond this module.
 const (
-	LaneChannelIdentity = "channel_identity"
+	laneChannelIdentity = "channel_identity"
 	LaneEmail           = "email"
-	LanePhone           = "phone"
+	lanePhone           = "phone"
 )
 
 // exactLane is one lane's answer, in ladder order.
@@ -167,9 +166,9 @@ func exactLanes(ctx context.Context, tx pgx.Tx, c PersonCandidate) ([]exactLane,
 		return nil, err
 	}
 	return []exactLane{
-		{LaneChannelIdentity, channelHit, channelFound},
+		{laneChannelIdentity, channelHit, channelFound},
 		{LaneEmail, emailHit, emailFound},
-		{LanePhone, phoneHit, phoneFound},
+		{lanePhone, phoneHit, phoneFound},
 	}, nil
 }
 

--- a/backend/internal/modules/people/dedupe.go
+++ b/backend/internal/modules/people/dedupe.go
@@ -110,10 +110,16 @@ type LaneConflict struct {
 // routing precedence: an established channel binding outranks a shared
 // address, which outranks a phone number households and switchboards
 // share.
+//
+// Exported because PersonResolution.MatchedLane and LaneConflict's two lane
+// fields already hand these strings to callers, and a caller comparing against
+// a literal it spelled itself is a caller that keeps compiling after the
+// vocabulary moves. A fitness test holds LaneEmail equal to the published
+// extension.MergeKeyEmail for the same reason.
 const (
-	laneChannelIdentity = "channel_identity"
-	laneEmail           = "email"
-	lanePhone           = "phone"
+	LaneChannelIdentity = "channel_identity"
+	LaneEmail           = "email"
+	LanePhone           = "phone"
 )
 
 // exactLane is one lane's answer, in ladder order.
@@ -161,9 +167,9 @@ func exactLanes(ctx context.Context, tx pgx.Tx, c PersonCandidate) ([]exactLane,
 		return nil, err
 	}
 	return []exactLane{
-		{laneChannelIdentity, channelHit, channelFound},
-		{laneEmail, emailHit, emailFound},
-		{lanePhone, phoneHit, phoneFound},
+		{LaneChannelIdentity, channelHit, channelFound},
+		{LaneEmail, emailHit, emailFound},
+		{LanePhone, phoneHit, phoneFound},
 	}, nil
 }
 

--- a/backend/internal/modules/people/dedupe_channel_integration_test.go
+++ b/backend/internal/modules/people/dedupe_channel_integration_test.go
@@ -175,9 +175,9 @@ func TestLadderPrefersChannelIdentityOverEmail(t *testing.T) {
 	if r.Conflict == nil {
 		t.Fatal("two lanes named different people and no conflict was reported")
 	}
-	if r.Conflict.RoutedLane != LaneChannelIdentity || r.Conflict.RivalLane != LaneEmail {
+	if r.Conflict.RoutedLane != laneChannelIdentity || r.Conflict.RivalLane != LaneEmail {
 		t.Fatalf("conflict lanes = %s over %s, want %s over %s",
-			r.Conflict.RoutedLane, r.Conflict.RivalLane, LaneChannelIdentity, LaneEmail)
+			r.Conflict.RoutedLane, r.Conflict.RivalLane, laneChannelIdentity, LaneEmail)
 	}
 	if r.Conflict.Rival != byEmail {
 		t.Fatalf("rival = %s, want the email lane's person %s", r.Conflict.Rival, byEmail)
@@ -242,8 +242,8 @@ func TestLaneConflictRoutesDeterministicallyAndReportsRival(t *testing.T) {
 		t.Fatalf("conflict = routed %s / rival %s, want routed %s / rival %s",
 			r.Conflict.RoutedTo, r.Conflict.Rival, personA, personB)
 	}
-	if r.Conflict.RoutedLane != LaneChannelIdentity || r.Conflict.RivalLane != LanePhone {
+	if r.Conflict.RoutedLane != laneChannelIdentity || r.Conflict.RivalLane != lanePhone {
 		t.Fatalf("conflict lanes = %s over %s, want %s over %s",
-			r.Conflict.RoutedLane, r.Conflict.RivalLane, LaneChannelIdentity, LanePhone)
+			r.Conflict.RoutedLane, r.Conflict.RivalLane, laneChannelIdentity, lanePhone)
 	}
 }

--- a/backend/internal/modules/people/dedupe_channel_integration_test.go
+++ b/backend/internal/modules/people/dedupe_channel_integration_test.go
@@ -175,9 +175,9 @@ func TestLadderPrefersChannelIdentityOverEmail(t *testing.T) {
 	if r.Conflict == nil {
 		t.Fatal("two lanes named different people and no conflict was reported")
 	}
-	if r.Conflict.RoutedLane != laneChannelIdentity || r.Conflict.RivalLane != laneEmail {
+	if r.Conflict.RoutedLane != LaneChannelIdentity || r.Conflict.RivalLane != LaneEmail {
 		t.Fatalf("conflict lanes = %s over %s, want %s over %s",
-			r.Conflict.RoutedLane, r.Conflict.RivalLane, laneChannelIdentity, laneEmail)
+			r.Conflict.RoutedLane, r.Conflict.RivalLane, LaneChannelIdentity, LaneEmail)
 	}
 	if r.Conflict.Rival != byEmail {
 		t.Fatalf("rival = %s, want the email lane's person %s", r.Conflict.Rival, byEmail)
@@ -242,8 +242,8 @@ func TestLaneConflictRoutesDeterministicallyAndReportsRival(t *testing.T) {
 		t.Fatalf("conflict = routed %s / rival %s, want routed %s / rival %s",
 			r.Conflict.RoutedTo, r.Conflict.Rival, personA, personB)
 	}
-	if r.Conflict.RoutedLane != laneChannelIdentity || r.Conflict.RivalLane != lanePhone {
+	if r.Conflict.RoutedLane != LaneChannelIdentity || r.Conflict.RivalLane != LanePhone {
 		t.Fatalf("conflict lanes = %s over %s, want %s over %s",
-			r.Conflict.RoutedLane, r.Conflict.RivalLane, laneChannelIdentity, lanePhone)
+			r.Conflict.RoutedLane, r.Conflict.RivalLane, LaneChannelIdentity, LanePhone)
 	}
 }

--- a/backend/internal/modules/people/ensurechannel.go
+++ b/backend/internal/modules/people/ensurechannel.go
@@ -95,6 +95,13 @@ func (s *Store) EnsureChannelCounterparty(ctx context.Context, in EnsureChannelC
 		return EnsureChannelCounterpartyResult{},
 			errors.New("people: a channel counterparty needs both a provider and a channel user id")
 	}
+	// Normalized once, here, because four things downstream key on this address
+	// and they must agree on what "the same address" is: the subject lock, the
+	// suppression probe, the resolution ladder, and the row written onto the
+	// person. A provider that pads or capitalizes would otherwise mint a
+	// person_email row no later mail capture can match — the duplicate this path
+	// exists to prevent, reintroduced by whitespace.
+	in.CorroboratingEmail = normalizeEmail(in.CorroboratingEmail)
 	var res EnsureChannelCounterpartyResult
 	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		var err error
@@ -119,9 +126,16 @@ func (s *Store) ensureChannelCounterpartyTx(ctx context.Context, tx pgx.Tx, in E
 	// is partial on archived_at IS NULL, so nothing in the database refuses that
 	// second binding — and the erasure writes by person_id, so the rival it
 	// never named keeps the erased human's account and name for good.
-	if err := storekit.LockChannelIdentities(ctx, tx, []storekit.ChannelIdentityKey{
-		{Provider: in.Identity.Provider, ChannelUserID: in.Identity.ChannelUserID},
-	}); err != nil {
+	if err := storekit.LockSubjectKeys(ctx, tx,
+		[]storekit.ChannelIdentityKey{
+			{Provider: in.Identity.Provider, ChannelUserID: in.Identity.ChannelUserID},
+		},
+		// The address is locked too, and it is the half that covers the subject
+		// this path can otherwise reach mid-erasure: a human known only from
+		// mail holds no channel account, so an eraser locking accounts alone
+		// takes no lock, and the bind below would land inside their purge.
+		correspondingEmails(in.CorroboratingEmail),
+	); err != nil {
 		return EnsureChannelCounterpartyResult{}, err
 	}
 
@@ -169,24 +183,6 @@ func (s *Store) channelSubjectSuppressed(ctx context.Context, tx pgx.Tx, in Ensu
 	return storekit.EmailSuppressed(ctx, tx, in.CorroboratingEmail)
 }
 
-// channelCandidate is what the ladder is asked about: the account that NAMES the
-// human, and the address that merely corroborates them.
-//
-// Both go in together because the ladder's precedence is the answer to the
-// question a caller would otherwise have to ask itself — an established channel
-// binding outranks a shared address (dedupe.go) — and because a later lane
-// naming a different person is a report only the ladder can produce.
-func channelCandidate(in EnsureChannelCounterpartyInput, name string) PersonCandidate {
-	c := PersonCandidate{
-		FullName:          name,
-		ChannelIdentities: []connector.ChannelIdentity{in.Identity},
-	}
-	if in.CorroboratingEmail != "" {
-		c.Emails = []string{in.CorroboratingEmail}
-	}
-	return c
-}
-
 // resolveChannelPerson runs PO-F-1 over the channel identity and, when nothing
 // resolves, offers a new person — speculatively, because the bind is the
 // arbiter of the identity race, not this lookup.
@@ -214,6 +210,15 @@ func (s *Store) resolveChannelPerson(ctx context.Context, tx pgx.Tx, in EnsureCh
 		// routing is this function's whole job, and design §7.3/D8 puts the
 		// identity-review decision one layer up, where a failure to raise it
 		// can be logged without risking the routing this message needs.
+		//
+		// A corroborating address is deliberately not written onto this person.
+		// The binding already names them, so the address buys no routing, and
+		// writing it per message would need its own add-if-absent guard and its
+		// own audit gate to avoid claiming a change on every message that
+		// changed nothing. A person bound here but holding no address is one
+		// minted before their source vouched for one; the ladder still reads the
+		// address on every message, so nothing is lost that a later mail capture
+		// would not also supply.
 		res.PersonID = match.PersonID
 		res.Conflict = match.Conflict
 		return nil
@@ -252,55 +257,6 @@ func (s *Store) resolveChannelPerson(ctx context.Context, tx pgx.Tx, in EnsureCh
 	return nil
 }
 
-// adoptEmailRoutedIncumbent binds this account to the human the ADDRESS found —
-// someone already captured from mail, who holds no binding for this account yet.
-//
-// It is a sibling of offerChannelPerson rather than a branch inside the
-// resolver: both settle who the person is and bind the account to them, and the
-// difference — one mints, one adopts — is exactly what a reader needs held
-// apart.
-//
-// Nothing writes the address here. The email lane MATCHED, so it is already on
-// the incumbent by definition; an insert would collide with uq_person_email_dedupe
-// on every message from this sender, and an audit row would claim a change that
-// did not happen.
-//
-// Visibility is deliberately left alone. A mail-captured incumbent is
-// owner-visible, and adopting does not widen that: a stranger's direct message
-// must not be able to publish a rep's privately captured contact to the whole
-// workspace.
-func (s *Store) adoptEmailRoutedIncumbent(
-	ctx context.Context, tx pgx.Tx, in EnsureChannelCounterpartyInput,
-	match PersonResolution, res *EnsureChannelCounterpartyResult,
-) error {
-	// The ladder read is not the last word on WHICH row this is: a merge
-	// committing between that read and this write retires the incumbent, and a
-	// binding left on the retired row is a reply route nobody opens while the
-	// activity link — settled separately by linkActivityToPerson — points at the
-	// survivor. One hop is enough; a merge repoints rather than chains.
-	var canonical ids.PersonID
-	if err := tx.QueryRow(ctx,
-		`SELECT coalesce(merged_into_id, id) FROM person WHERE id = $1 FOR UPDATE`,
-		match.PersonID).Scan(&canonical); err != nil {
-		return fmt.Errorf("people: settling the person this channel account belongs to: %w", err)
-	}
-	bound, err := ResolveOrCreateChannelIdentity(ctx, tx, canonical, in.Identity)
-	if err != nil {
-		return err
-	}
-	// A concurrent first message from the same sender may have bound this
-	// account elsewhere while this transaction was working. The database is the
-	// arbiter, so the account's real owner is what came back — never the row
-	// this call proposed.
-	res.PersonID = bound
-	res.Conflict = match.Conflict
-	if bound != canonical {
-		return nil
-	}
-	return auditChannelIdentityChange(ctx, tx, canonical,
-		nil, map[string]any{fieldChannelIdentity: in.Identity.Provider})
-}
-
 // offerChannelPerson writes the ownerless person, binds the identity to it, and
 // reports which person the binding actually named — id when this call won, the
 // incumbent when a concurrent first message got there first. A fuzzy near-match
@@ -321,8 +277,8 @@ func (s *Store) offerChannelPerson(ctx context.Context, tx pgx.Tx, in EnsureChan
 		FullName: name,
 		// The address the provider vouched for, written with the person rather
 		// than after it, so the person-create audit and event cover it — the
-		// mail path's own shape. Without this the record is minted addressless
-		// and the NEXT mail from this human mints a second one.
+		// mail path's own shape. An addressless record is one the next mail from
+		// this human cannot match, so it mints a second one.
 		Emails:     channelPersonEmails(in.CorroboratingEmail),
 		Visibility: visibilityWorkspace,
 		Source:     in.Source,
@@ -360,7 +316,15 @@ func channelPersonEmails(email string) []PersonEmailInput {
 	if email == "" {
 		return nil
 	}
-	return []PersonEmailInput{{Email: email, EmailType: emailTypeWork, IsPrimary: true}}
+	// Vouched, not corresponded: the provider's directory says this is their
+	// address, and nobody here has ever exchanged mail with it. Recording that
+	// is what keeps one direct message from a stranger out of the mail ladder's
+	// verdict, where it would mark the address a known counterparty for good and
+	// switch off the noise sweep for it permanently.
+	return []PersonEmailInput{{
+		Email: email, EmailType: emailTypeWork, IsPrimary: true,
+		VouchedNotCorresponded: true,
+	}}
 }
 
 // recordChannelDedupeCandidate stores the fuzzy pair the review queue renders,

--- a/backend/internal/modules/people/ensurechannel.go
+++ b/backend/internal/modules/people/ensurechannel.go
@@ -49,10 +49,20 @@ const fieldChannelUsername = "channel_username"
 
 // EnsureChannelCounterpartyInput is one inbound channel message's counterparty.
 // There is no OwnerID and no Domain: the created person is ownerless by design,
-// and a channel identity carries no domain to derive a company from.
+// and this path derives no employer even when an address rides along — reading
+// one out of a mail domain is the mail ladder's job, which this path bypasses.
 type EnsureChannelCounterpartyInput struct {
 	Identity    connector.ChannelIdentity
 	DisplayName string // the provider's own name for the sender — untrusted text
+	// CorroboratingEmail is the sender's address, where the provider knew one
+	// and its source declared the email merge key. It NAMES nobody: Identity
+	// does that, and the ladder below prefers it. What this buys is the human
+	// already captured from mail being recognised as the same human, instead of
+	// becoming a second record nobody notices.
+	//
+	// Empty for every transport that holds no address, which is every core
+	// channel connector.
+	CorroboratingEmail string
 
 	ActivityID ids.ActivityID // the captured activity to link
 	Source     string         // provenance channel, e.g. "telegram:<bot>:<chat>:<msg>"
@@ -119,7 +129,7 @@ func (s *Store) ensureChannelCounterpartyTx(ctx context.Context, tx pgx.Tx, in E
 	// This is EnsureCounterpartyTx's EmailSuppressed probe in its channel
 	// spelling — an erased subject whose only identifier was a Telegram id must
 	// not be re-created by their next message.
-	suppressed, err := storekit.ChannelIdentitySuppressed(ctx, tx, in.Identity.Provider, in.Identity.ChannelUserID)
+	suppressed, err := s.channelSubjectSuppressed(ctx, tx, in)
 	if err != nil {
 		return EnsureChannelCounterpartyResult{}, err
 	}
@@ -140,6 +150,43 @@ func (s *Store) ensureChannelCounterpartyTx(ctx context.Context, tx pgx.Tx, in E
 	return res, nil
 }
 
+// channelSubjectSuppressed asks both keys the subject can have been erased by.
+//
+// The channel key is the one this path always has. The address is asked only
+// when the record carries one, and asking it is not optional politeness: an
+// erasure keyed on an address would otherwise be undone by the subject's next
+// direct message, which arrives naming them by an account the suppression list
+// has never heard of. A13 says deletion sticks; it has to stick on every key the
+// record can be recognised by, not on the one this path happened to start with.
+func (s *Store) channelSubjectSuppressed(ctx context.Context, tx pgx.Tx, in EnsureChannelCounterpartyInput) (bool, error) {
+	suppressed, err := storekit.ChannelIdentitySuppressed(ctx, tx, in.Identity.Provider, in.Identity.ChannelUserID)
+	if err != nil || suppressed {
+		return suppressed, err
+	}
+	if in.CorroboratingEmail == "" {
+		return false, nil
+	}
+	return storekit.EmailSuppressed(ctx, tx, in.CorroboratingEmail)
+}
+
+// channelCandidate is what the ladder is asked about: the account that NAMES the
+// human, and the address that merely corroborates them.
+//
+// Both go in together because the ladder's precedence is the answer to the
+// question a caller would otherwise have to ask itself — an established channel
+// binding outranks a shared address (dedupe.go) — and because a later lane
+// naming a different person is a report only the ladder can produce.
+func channelCandidate(in EnsureChannelCounterpartyInput, name string) PersonCandidate {
+	c := PersonCandidate{
+		FullName:          name,
+		ChannelIdentities: []connector.ChannelIdentity{in.Identity},
+	}
+	if in.CorroboratingEmail != "" {
+		c.Emails = []string{in.CorroboratingEmail}
+	}
+	return c
+}
+
 // resolveChannelPerson runs PO-F-1 over the channel identity and, when nothing
 // resolves, offers a new person — speculatively, because the bind is the
 // arbiter of the identity race, not this lookup.
@@ -148,12 +195,18 @@ func (s *Store) resolveChannelPerson(ctx context.Context, tx pgx.Tx, in EnsureCh
 		return err
 	}
 	name := channelCounterpartyName(in.DisplayName, in.Identity)
-	match, err := DedupePerson(ctx, tx, PersonCandidate{
-		FullName:          name,
-		ChannelIdentities: []connector.ChannelIdentity{in.Identity},
-	})
+	match, err := DedupePerson(ctx, tx, channelCandidate(in, name))
 	if err != nil {
 		return err
+	}
+	if match.Decision == DecisionExactCollision && match.MatchedLane == LaneEmail {
+		// The address found a human the channel lane could not, which means
+		// they exist from mail capture and hold no binding for this account
+		// yet. Routing alone would leave them unbound — unreachable for a
+		// reply, invisible to a channel-keyed erasure, and re-resolved by
+		// address on every later message. Adopting them is what makes the two
+		// captures one person rather than one person and one alias.
+		return s.adoptEmailRoutedIncumbent(ctx, tx, in, match, res)
 	}
 	if match.Decision == DecisionExactCollision {
 		// A live binding already names this human; every later message from the
@@ -199,6 +252,55 @@ func (s *Store) resolveChannelPerson(ctx context.Context, tx pgx.Tx, in EnsureCh
 	return nil
 }
 
+// adoptEmailRoutedIncumbent binds this account to the human the ADDRESS found —
+// someone already captured from mail, who holds no binding for this account yet.
+//
+// It is a sibling of offerChannelPerson rather than a branch inside the
+// resolver: both settle who the person is and bind the account to them, and the
+// difference — one mints, one adopts — is exactly what a reader needs held
+// apart.
+//
+// Nothing writes the address here. The email lane MATCHED, so it is already on
+// the incumbent by definition; an insert would collide with uq_person_email_dedupe
+// on every message from this sender, and an audit row would claim a change that
+// did not happen.
+//
+// Visibility is deliberately left alone. A mail-captured incumbent is
+// owner-visible, and adopting does not widen that: a stranger's direct message
+// must not be able to publish a rep's privately captured contact to the whole
+// workspace.
+func (s *Store) adoptEmailRoutedIncumbent(
+	ctx context.Context, tx pgx.Tx, in EnsureChannelCounterpartyInput,
+	match PersonResolution, res *EnsureChannelCounterpartyResult,
+) error {
+	// The ladder read is not the last word on WHICH row this is: a merge
+	// committing between that read and this write retires the incumbent, and a
+	// binding left on the retired row is a reply route nobody opens while the
+	// activity link — settled separately by linkActivityToPerson — points at the
+	// survivor. One hop is enough; a merge repoints rather than chains.
+	var canonical ids.PersonID
+	if err := tx.QueryRow(ctx,
+		`SELECT coalesce(merged_into_id, id) FROM person WHERE id = $1 FOR UPDATE`,
+		match.PersonID).Scan(&canonical); err != nil {
+		return fmt.Errorf("people: settling the person this channel account belongs to: %w", err)
+	}
+	bound, err := ResolveOrCreateChannelIdentity(ctx, tx, canonical, in.Identity)
+	if err != nil {
+		return err
+	}
+	// A concurrent first message from the same sender may have bound this
+	// account elsewhere while this transaction was working. The database is the
+	// arbiter, so the account's real owner is what came back — never the row
+	// this call proposed.
+	res.PersonID = bound
+	res.Conflict = match.Conflict
+	if bound != canonical {
+		return nil
+	}
+	return auditChannelIdentityChange(ctx, tx, canonical,
+		nil, map[string]any{fieldChannelIdentity: in.Identity.Provider})
+}
+
 // offerChannelPerson writes the ownerless person, binds the identity to it, and
 // reports which person the binding actually named — id when this call won, the
 // incumbent when a concurrent first message got there first. A fuzzy near-match
@@ -216,7 +318,12 @@ func (s *Store) offerChannelPerson(ctx context.Context, tx pgx.Tx, in EnsureChan
 	// display name naming a DIFFERENT domain than the message arrived from —
 	// are statements about a mail domain this record does not have.
 	id, err := createPerson(ctx, tx, match, PersonSpec{
-		FullName:   name,
+		FullName: name,
+		// The address the provider vouched for, written with the person rather
+		// than after it, so the person-create audit and event cover it — the
+		// mail path's own shape. Without this the record is minted addressless
+		// and the NEXT mail from this human mints a second one.
+		Emails:     channelPersonEmails(in.CorroboratingEmail),
 		Visibility: visibilityWorkspace,
 		Source:     in.Source,
 		CapturedBy: in.CapturedBy,
@@ -243,6 +350,17 @@ func (s *Store) offerChannelPerson(ctx context.Context, tx pgx.Tx, in EnsureChan
 		return ids.PersonID{}, ids.PersonID{}, false, err
 	}
 	return id, id, recorded, nil
+}
+
+// channelPersonEmails is the address list a minted channel person starts with:
+// the corroborating address when there is one, and nothing at all when there is
+// not. It is primary because it is the only one — a person with a single address
+// and no primary reads as a person nobody can be sure how to write to.
+func channelPersonEmails(email string) []PersonEmailInput {
+	if email == "" {
+		return nil
+	}
+	return []PersonEmailInput{{Email: email, EmailType: emailTypeWork, IsPrimary: true}}
 }
 
 // recordChannelDedupeCandidate stores the fuzzy pair the review queue renders,

--- a/backend/internal/modules/people/ensurechannel_integration_test.go
+++ b/backend/internal/modules/people/ensurechannel_integration_test.go
@@ -154,7 +154,11 @@ func TestEnsureChannelCounterpartyCreatesAnOwnerlessPerson(t *testing.T) {
 	}
 }
 
-func TestEnsureChannelCounterpartyWritesNoEmailRow(t *testing.T) {
+// A transport that holds no address for the sender — every core channel
+// connector — still mints an addressless person. The record's only key is its
+// identity satellite, and inventing an address would be a lie the dedupe ladder
+// then treats as an exact key.
+func TestEnsureChannelCounterpartyWritesNoEmailRowWithoutOne(t *testing.T) {
 	e := setupDedupe(t)
 	ctx := e.asChannelConnector()
 	ci := connector.ChannelIdentity{Provider: telegramProvider, ChannelUserID: "880201", Username: "noaddress"}
@@ -164,8 +168,6 @@ func TestEnsureChannelCounterpartyWritesNoEmailRow(t *testing.T) {
 		t.Fatalf("ensure: %v", err)
 	}
 
-	// A fabricated address would be a lie the dedupe ladder then treats as an
-	// exact key — the identity satellite is this record's only key.
 	if n := e.countInWorkspace(ctx, t, `SELECT count(*) FROM person_email WHERE person_id = $1`, res.PersonID); n != 0 {
 		t.Fatalf("%d email rows on a channel-created person, want 0", n)
 	}

--- a/backend/internal/modules/people/ensurechanneladopt.go
+++ b/backend/internal/modules/people/ensurechanneladopt.go
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package people
+
+// Adopting the human an ADDRESS found, when a channel message names them by an
+// account nothing is bound to yet.
+//
+// It sits beside the minting half rather than inside it because the two settle
+// different questions. Minting decides who a stranger is; this decides that a
+// human already on the books is the same human, and then attaches the account
+// they can be answered at to the record that already describes them. The second
+// is the one that writes onto a row somebody else created, which is why it
+// carries the settle, the lock and the audit the first does not need.
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/connector"
+)
+
+// correspondingEmails is the address list the subject lock covers: the
+// corroborating address when there is one, and nothing otherwise. A record that
+// names its human by account alone can reach no address-keyed subject, so it
+// takes no address lock and never stalls an unrelated erasure.
+func correspondingEmails(email string) []string {
+	if email == "" {
+		return nil
+	}
+	return []string{email}
+}
+
+// channelCandidate is what the ladder is asked about: the account that NAMES the
+// human, and the address that merely corroborates them.
+//
+// Both go in together because the ladder's precedence is the answer to the
+// question a caller would otherwise have to ask itself — an established channel
+// binding outranks a shared address (dedupe.go) — and because a later lane
+// naming a different person is a report only the ladder can produce.
+func channelCandidate(in EnsureChannelCounterpartyInput, name string) PersonCandidate {
+	c := PersonCandidate{
+		FullName:          name,
+		ChannelIdentities: []connector.ChannelIdentity{in.Identity},
+	}
+	if in.CorroboratingEmail != "" {
+		c.Emails = []string{in.CorroboratingEmail}
+	}
+	return c
+}
+
+// adoptEmailRoutedIncumbent binds this account to the human the ADDRESS found —
+// someone already captured from mail, who holds no binding for this account yet.
+//
+// It is a sibling of offerChannelPerson rather than a branch inside the
+// resolver: both settle who the person is and bind the account to them, and the
+// difference — one mints, one adopts — is exactly what a reader needs held
+// apart.
+//
+// Nothing writes the address here. The email lane MATCHED, so it is already on
+// the incumbent by definition; an insert would collide with uq_person_email_dedupe
+// on every message from this sender, and an audit row would claim a change that
+// did not happen.
+//
+// Visibility is deliberately left alone. A mail-captured incumbent is
+// owner-visible, and adopting does not widen that: a stranger's direct message
+// must not be able to publish a rep's privately captured contact to the whole
+// workspace.
+func (s *Store) adoptEmailRoutedIncumbent(
+	ctx context.Context, tx pgx.Tx, in EnsureChannelCounterpartyInput,
+	match PersonResolution, res *EnsureChannelCounterpartyResult,
+) error {
+	// The ladder read is not the last word on WHICH row this is: a merge
+	// committing between that read and this write retires the incumbent, and a
+	// binding left on the retired row is a reply route nobody opens while the
+	// activity link — settled separately by linkActivityToPerson — points at the
+	// survivor. One hop is enough; a merge repoints rather than chains.
+	var canonical ids.PersonID
+	if err := tx.QueryRow(ctx,
+		`SELECT coalesce(merged_into_id, id) FROM person WHERE id = $1 FOR UPDATE`,
+		match.PersonID).Scan(&canonical); err != nil {
+		return fmt.Errorf("people: settling the person this channel account belongs to: %w", err)
+	}
+	bound, err := ResolveOrCreateChannelIdentity(ctx, tx, canonical, in.Identity)
+	if err != nil {
+		return err
+	}
+	// The account may already belong to somebody else. Not to a concurrent
+	// message from this same sender — those serialize on the subject lock above,
+	// so a second one sees the winner's binding in the ladder and never reaches
+	// here — but to any writer that binds outside that lock. The database is the
+	// arbiter, so the account's real owner is what came back, never the row this
+	// call proposed.
+	res.PersonID = bound
+	res.Conflict = match.Conflict
+	if bound != canonical {
+		// Losing that race leaves the committed state as a disagreement the
+		// ladder could not have reported: its channel lane read BEFORE the
+		// rival's binding existed, so match.Conflict is nil and nothing would
+		// raise an identity review. Two records now describe one human — the
+		// address found one, the account belongs to the other — which is the
+		// duplicate this whole path exists to prevent, arriving by the one route
+		// the resolver cannot see. Naming it here is what puts it in front of
+		// somebody.
+		//
+		// The binding routes, per ladder precedence: an established channel
+		// binding outranks a shared address.
+		res.Conflict = &LaneConflict{
+			RoutedTo: bound, Rival: canonical,
+			RoutedLane: laneChannelIdentity, RivalLane: LaneEmail,
+		}
+		return nil
+	}
+	// The image names the ACCOUNT, not just its provider. This is the one record
+	// that a channel account was attached to a person who already existed, and
+	// "a dispact identity was bound" cannot answer the question an auditor
+	// actually brings to it — which account now reaches this human.
+	return auditChannelIdentityChange(ctx, tx, canonical,
+		nil, map[string]any{fieldChannelIdentity: channelIdentityKey(in.Identity)})
+}

--- a/backend/internal/modules/people/ensurechanneladopt_integration_test.go
+++ b/backend/internal/modules/people/ensurechanneladopt_integration_test.go
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package people
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/connector"
+)
+
+// corroboratedInput is channelEnsureInput with the address a vouching source
+// supplies alongside the account.
+func (e *dedupeEnv) corroboratedInput(t *testing.T, ci connector.ChannelIdentity, display, email string) EnsureChannelCounterpartyInput {
+	t.Helper()
+	in := e.channelEnsureInput(e.asChannelConnector(), t, ci, display)
+	in.CorroboratingEmail = email
+	return in
+}
+
+// The whole point of the change, end to end. A human captured from mail sends a
+// direct message; the address routes the ladder onto the record that already
+// exists instead of minting a second one for the same person.
+//
+// Routing alone is not enough, which is why the binding is asserted too: without
+// it the person is unreachable for a reply, invisible to a channel-keyed
+// erasure, and re-resolved by address on every later message forever.
+func TestACorroboratingAddressAdoptsTheMailCapturedIncumbent(t *testing.T) {
+	e := setupDedupe(t)
+	ctx := e.asChannelConnector()
+	const email = "tuyen@acme.example"
+	incumbent := e.seedPerson(e.as(), t, "Tuyen Dinh Quang", []string{email}, nil)
+	ci := connector.ChannelIdentity{Provider: telegramProvider, ChannelUserID: "990101", Username: "tuyen"}
+
+	res, err := e.store.EnsureChannelCounterparty(ctx, e.corroboratedInput(t, ci, "Tuyen", email))
+	if err != nil {
+		t.Fatalf("ensure: %v", err)
+	}
+
+	if res.PersonID != incumbent {
+		t.Fatalf("ensure landed on %s, want the mail-captured incumbent %s — one human must not become two records", res.PersonID, incumbent)
+	}
+	if res.PersonCreated {
+		t.Error("a second person was created for a human the address already found")
+	}
+	if n := e.countInWorkspace(ctx, t,
+		`SELECT count(*) FROM person_channel_identity WHERE person_id = $1 AND channel_user_id = $2 AND archived_at IS NULL`,
+		incumbent, ci.ChannelUserID); n != 1 {
+		t.Fatalf("%d live bindings on the adopted incumbent, want 1 — routing without binding leaves them unreachable", n)
+	}
+	// The address matched, so it was already there; adopting must not try to
+	// write it again and must not claim in the audit trail that it did.
+	if n := e.countInWorkspace(ctx, t, `SELECT count(*) FROM person_email WHERE person_id = $1`, incumbent); n != 1 {
+		t.Fatalf("%d address rows on the adopted incumbent, want 1", n)
+	}
+}
+
+// Adoption has to be idempotent for the same reason capture is: the same message
+// arrives twice, and the second pass must write nothing rather than fail the
+// ensure and log a fault on every poll.
+func TestAdoptingTheIncumbentTwiceWritesNothingTheSecondTime(t *testing.T) {
+	e := setupDedupe(t)
+	ctx := e.asChannelConnector()
+	const email = "dung@acme.example"
+	incumbent := e.seedPerson(e.as(), t, "Dung Nguyen", []string{email}, nil)
+	ci := connector.ChannelIdentity{Provider: telegramProvider, ChannelUserID: "990201", Username: "dung"}
+
+	if _, err := e.store.EnsureChannelCounterparty(ctx, e.corroboratedInput(t, ci, "Dung", email)); err != nil {
+		t.Fatalf("first ensure: %v", err)
+	}
+	second, err := e.store.EnsureChannelCounterparty(ctx, e.corroboratedInput(t, ci, "Dung", email))
+	if err != nil {
+		t.Fatalf("second ensure: %v", err)
+	}
+
+	if second.PersonID != incumbent || second.PersonCreated {
+		t.Fatalf("second ensure = %+v, want the incumbent %s reused", second, incumbent)
+	}
+	if n := e.countInWorkspace(ctx, t,
+		`SELECT count(*) FROM person_channel_identity WHERE person_id = $1 AND archived_at IS NULL`, incumbent); n != 1 {
+		t.Fatalf("%d live bindings after a replay, want 1", n)
+	}
+	if n := e.countInWorkspace(ctx, t, `SELECT count(*) FROM person_email WHERE person_id = $1`, incumbent); n != 1 {
+		t.Fatalf("%d address rows after a replay, want 1", n)
+	}
+}
+
+// A source that vouched for the address and whose provider knew one mints the
+// person WITH it. Without this the record is created addressless and the next
+// mail from the same human mints a second record — the defect in #1382.
+func TestAMintedChannelPersonKeepsTheCorroboratingAddress(t *testing.T) {
+	e := setupDedupe(t)
+	ctx := e.asChannelConnector()
+	const email = "luu@acme.example"
+	ci := connector.ChannelIdentity{Provider: telegramProvider, ChannelUserID: "990301", Username: "luu"}
+
+	res, err := e.store.EnsureChannelCounterparty(ctx, e.corroboratedInput(t, ci, "Luu Nguyen Thanh", email))
+	if err != nil {
+		t.Fatalf("ensure: %v", err)
+	}
+
+	if !res.PersonCreated {
+		t.Fatal("no person was created for an account nothing else knew")
+	}
+	var got string
+	if err := e.store.tx(ctx, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx, `SELECT email FROM person_email WHERE person_id = $1`, res.PersonID).Scan(&got)
+	}); err != nil {
+		t.Fatalf("reading the minted person's address: %v", err)
+	}
+	if got != email {
+		t.Errorf("stored address %q, want %q", got, email)
+	}
+}
+
+// A13 on the ADDRESS key. The channel path only ever probed the channel key,
+// because it never held an address; once one flows, an erasure keyed on the
+// address must still stick — otherwise the subject's next direct message, naming
+// them by an account the suppression list never heard of, quietly recreates them.
+func TestAnErasedAddressIsNotResurrectedByADirectMessage(t *testing.T) {
+	e := setupDedupe(t)
+	ctx := e.asChannelConnector()
+	const erased = "gone@acme.example"
+	ci := connector.ChannelIdentity{Provider: telegramProvider, ChannelUserID: "990401", Username: "gone"}
+
+	if err := e.store.tx(ctx, func(tx pgx.Tx) error {
+		_, err := tx.Exec(ctx, `INSERT INTO erasure_suppression (kind, value_hash) VALUES ('email', $1)`,
+			storekit.SuppressionHash(erased))
+		return err
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := e.store.EnsureChannelCounterparty(ctx, e.corroboratedInput(t, ci, "Erased Subject", erased))
+
+	if !errors.Is(err, ErrCounterpartySuppressed) {
+		t.Fatalf("ensure of an erased address = %v, want ErrCounterpartySuppressed — deletion sticks on every key", err)
+	}
+	if n := e.countInWorkspace(ctx, t,
+		`SELECT count(*) FROM person_channel_identity WHERE channel_user_id = $1`, ci.ChannelUserID); n != 0 {
+		t.Errorf("%d bindings for an erased subject, want 0", n)
+	}
+}

--- a/backend/internal/modules/people/ensurechanneladopt_integration_test.go
+++ b/backend/internal/modules/people/ensurechanneladopt_integration_test.go
@@ -74,6 +74,8 @@ func TestAdoptingTheIncumbentTwiceWritesNothingTheSecondTime(t *testing.T) {
 	if _, err := e.store.EnsureChannelCounterparty(ctx, e.corroboratedInput(t, ci, "Dung", email)); err != nil {
 		t.Fatalf("first ensure: %v", err)
 	}
+	auditsAfterFirst := e.countInWorkspace(ctx, t,
+		`SELECT count(*) FROM audit_log WHERE entity_type = $1 AND entity_id = $2`, entityPerson, incumbent)
 	second, err := e.store.EnsureChannelCounterparty(ctx, e.corroboratedInput(t, ci, "Dung", email))
 	if err != nil {
 		t.Fatalf("second ensure: %v", err)
@@ -89,11 +91,21 @@ func TestAdoptingTheIncumbentTwiceWritesNothingTheSecondTime(t *testing.T) {
 	if n := e.countInWorkspace(ctx, t, `SELECT count(*) FROM person_email WHERE person_id = $1`, incumbent); n != 1 {
 		t.Fatalf("%d address rows after a replay, want 1", n)
 	}
+	// An audit row per replayed message would claim a change on every message
+	// that changed nothing — the same noise as a duplicate write, in the form
+	// nobody notices until they are reading the trail for a reason. Compared
+	// against the first ensure rather than a fixed number, so the assertion is
+	// about what the REPLAY wrote and not about how the incumbent was seeded.
+	if n := e.countInWorkspace(ctx, t,
+		`SELECT count(*) FROM audit_log WHERE entity_type = $1 AND entity_id = $2`,
+		entityPerson, incumbent); n != auditsAfterFirst {
+		t.Errorf("audit rows went %d -> %d across a replay; a message that changed nothing must write nothing", auditsAfterFirst, n)
+	}
 }
 
-// A source that vouched for the address and whose provider knew one mints the
-// person WITH it. Without this the record is created addressless and the next
-// mail from the same human mints a second record — the defect in #1382.
+// A source that vouched for the address, whose provider knew one, mints the
+// person WITH it. An addressless record is one the next mail from the same human
+// cannot match, so it mints a second record.
 func TestAMintedChannelPersonKeepsTheCorroboratingAddress(t *testing.T) {
 	e := setupDedupe(t)
 	ctx := e.asChannelConnector()
@@ -119,10 +131,10 @@ func TestAMintedChannelPersonKeepsTheCorroboratingAddress(t *testing.T) {
 	}
 }
 
-// A13 on the ADDRESS key. The channel path only ever probed the channel key,
-// because it never held an address; once one flows, an erasure keyed on the
-// address must still stick — otherwise the subject's next direct message, naming
-// them by an account the suppression list never heard of, quietly recreates them.
+// A13 on the ADDRESS key: an erasure keyed on an address must stick even though
+// this path is entered by account. Otherwise the subject's next direct message,
+// naming them by an account the suppression list never heard of, quietly
+// recreates them.
 func TestAnErasedAddressIsNotResurrectedByADirectMessage(t *testing.T) {
 	e := setupDedupe(t)
 	ctx := e.asChannelConnector()
@@ -145,5 +157,107 @@ func TestAnErasedAddressIsNotResurrectedByADirectMessage(t *testing.T) {
 	if n := e.countInWorkspace(ctx, t,
 		`SELECT count(*) FROM person_channel_identity WHERE channel_user_id = $1`, ci.ChannelUserID); n != 0 {
 		t.Errorf("%d bindings for an erased subject, want 0", n)
+	}
+}
+
+// The one disagreement the resolver cannot report for itself.
+//
+// This is the LOST BIND RACE, and it is reachable only between two statements:
+// the ladder's channel lane reads before a rival's binding exists — so it routes
+// on the address alone and reports no conflict — and by the time the bind runs,
+// the rival owns the account. The committed state is then two records describing
+// one human, and nothing downstream would say so, because compose raises the
+// identity review only when a conflict comes back.
+//
+// The race is driven by calling the adopt step with exactly the resolution the
+// ladder returns when only the email lane hit, against a rival binding that has
+// since committed. Everything else is the real thing: the real bind path decides
+// the winner, and the real database arbitrates.
+func TestLosingTheBindRaceStillRaisesTheIdentityReview(t *testing.T) {
+	e := setupDedupe(t)
+	ctx := e.asChannelConnector()
+	const email = "shared@acme.example"
+	incumbent := e.seedPerson(e.as(), t, "Mail Captured", []string{email}, nil)
+	rival := e.seedPerson(e.as(), t, "Channel Captured", nil, nil)
+	ci := connector.ChannelIdentity{Provider: telegramProvider, ChannelUserID: "990501", Username: "shared"}
+	// The rival commits its binding in the window the ladder had already read
+	// past.
+	e.bindIdentity(ctx, t, rival, ci)
+
+	var res EnsureChannelCounterpartyResult
+	if err := e.store.tx(ctx, func(tx pgx.Tx) error {
+		return e.store.adoptEmailRoutedIncumbent(ctx, tx,
+			e.corroboratedInput(t, ci, "Shared", email),
+			// What DedupePerson returns when the channel lane missed and the
+			// address routed: a collision on the email lane, and no conflict,
+			// because at read time no rival binding existed to disagree.
+			PersonResolution{
+				Decision:    DecisionExactCollision,
+				PersonID:    incumbent,
+				MatchedLane: LaneEmail,
+			}, &res)
+	}); err != nil {
+		t.Fatalf("adopting the incumbent: %v", err)
+	}
+
+	if res.PersonID != rival {
+		t.Fatalf("landed on %s, want the account's real owner %s — the binding is the arbiter, not the address", res.PersonID, rival)
+	}
+	if res.Conflict == nil {
+		t.Fatal("no conflict reported — the address names one person and the account another, and nothing downstream would ever surface it")
+	}
+	if res.Conflict.RoutedTo != rival || res.Conflict.Rival != incumbent {
+		t.Errorf("conflict = routed %s / rival %s, want routed %s / rival %s",
+			res.Conflict.RoutedTo, res.Conflict.Rival, rival, incumbent)
+	}
+	if res.Conflict.RoutedLane != laneChannelIdentity || res.Conflict.RivalLane != LaneEmail {
+		t.Errorf("conflict lanes = %s/%s, want %s/%s — the binding outranks the address",
+			res.Conflict.RoutedLane, res.Conflict.RivalLane, laneChannelIdentity, LaneEmail)
+	}
+}
+
+// An address a connector's directory vouched for identifies the person, and it
+// must not also settle the MAIL ladder's question about that address.
+//
+// The ladder reads "a live person holds this address" as a verdict of `real`,
+// and the noise sweep refuses to touch an address a person holds. That reading
+// is sound for correspondence and for a human typing a contact in; it is not
+// sound for a stranger who sent one direct message. Left indistinguishable, that
+// stranger's address would be auto-created on every later bulk mail and made
+// permanently unsweepable — by messaging a member once.
+func TestAVouchedAddressIsNotEvidenceOfCorrespondence(t *testing.T) {
+	e := setupDedupe(t)
+	ctx := e.asChannelConnector()
+	const vouched = "stranger@spamco.example"
+	ci := connector.ChannelIdentity{Provider: telegramProvider, ChannelUserID: "990601", Username: "stranger"}
+
+	res, err := e.store.EnsureChannelCounterparty(ctx, e.corroboratedInput(t, ci, "A Stranger", vouched))
+	if err != nil {
+		t.Fatalf("ensure: %v", err)
+	}
+
+	// Collected: the person is identified by it, which is what it is for.
+	if n := e.countInWorkspace(ctx, t,
+		`SELECT count(*) FROM person_email WHERE person_id = $1 AND email = $2`, res.PersonID, vouched); n != 1 {
+		t.Fatalf("%d address rows on the minted person, want the vouched address collected", n)
+	}
+	// But not as correspondence, which is what the mail ladder reads.
+	if n := e.countInWorkspace(ctx, t,
+		`SELECT count(*) FROM person_email WHERE person_id = $1 AND from_correspondence`, res.PersonID); n != 0 {
+		t.Errorf("%d of the minted person's addresses count as correspondence — one direct message would settle the mail ladder's verdict on a stranger's address", n)
+	}
+}
+
+// The control that makes the case above mean something: an address this
+// workspace really did correspond with still counts, or the flag would be
+// switching the ladder off rather than scoping it.
+func TestAMailCapturedAddressStillCountsAsCorrespondence(t *testing.T) {
+	e := setupDedupe(t)
+	const known = "real.contact@client.io"
+	person := e.seedPerson(e.as(), t, "Real Contact", []string{known}, nil)
+
+	if n := e.countInWorkspace(e.as(), t,
+		`SELECT count(*) FROM person_email WHERE person_id = $1 AND from_correspondence`, person); n != 1 {
+		t.Errorf("%d of a normally created person's addresses count as correspondence, want 1", n)
 	}
 }

--- a/backend/internal/modules/people/identityconflict_integration_test.go
+++ b/backend/internal/modules/people/identityconflict_integration_test.go
@@ -109,12 +109,12 @@ func TestExactLaneConflictEnqueuesOneIdentityReviewNamingBothPersonsAndLanes(t *
 			t.Fatalf("exact-conflict evidence entry %+v names only one lane", ev)
 		}
 		lanes := map[string]bool{*ev.LeftValue: true, *ev.RightValue: true}
-		if lanes[laneChannelIdentity] && lanes[lanePhone] {
+		if lanes[LaneChannelIdentity] && lanes[LanePhone] {
 			foundLanes = true
 		}
 	}
 	if !foundLanes {
-		t.Fatalf("evidence %+v does not name both conflicting lanes (%s, %s)", evidence, laneChannelIdentity, lanePhone)
+		t.Fatalf("evidence %+v does not name both conflicting lanes (%s, %s)", evidence, LaneChannelIdentity, LanePhone)
 	}
 }
 

--- a/backend/internal/modules/people/identityconflict_integration_test.go
+++ b/backend/internal/modules/people/identityconflict_integration_test.go
@@ -109,12 +109,12 @@ func TestExactLaneConflictEnqueuesOneIdentityReviewNamingBothPersonsAndLanes(t *
 			t.Fatalf("exact-conflict evidence entry %+v names only one lane", ev)
 		}
 		lanes := map[string]bool{*ev.LeftValue: true, *ev.RightValue: true}
-		if lanes[LaneChannelIdentity] && lanes[LanePhone] {
+		if lanes[laneChannelIdentity] && lanes[lanePhone] {
 			foundLanes = true
 		}
 	}
 	if !foundLanes {
-		t.Fatalf("evidence %+v does not name both conflicting lanes (%s, %s)", evidence, LaneChannelIdentity, LanePhone)
+		t.Fatalf("evidence %+v does not name both conflicting lanes (%s, %s)", evidence, laneChannelIdentity, lanePhone)
 	}
 }
 

--- a/backend/internal/modules/people/identityspine_integration_test.go
+++ b/backend/internal/modules/people/identityspine_integration_test.go
@@ -233,7 +233,7 @@ func TestARaceOnAClaimedAddressStillAnswersTheDuplicateContract(t *testing.T) {
 
 	err = e.store.tx(ctx, func(tx pgx.Tx) error {
 		_, cerr := createPerson(ctx, tx, PersonResolution{
-			Decision: DecisionExactCollision, MatchedLane: laneEmail, PersonID: incumbentID,
+			Decision: DecisionExactCollision, MatchedLane: LaneEmail, PersonID: incumbentID,
 		}, PersonSpec{
 			FullName:   "Ida Kranz",
 			Emails:     []PersonEmailInput{{Email: "ida@kranz.test", EmailType: "work", IsPrimary: true}},
@@ -276,7 +276,7 @@ func TestTheChokepointRefusalHidesARecordTheCallerCannotRead(t *testing.T) {
 	stranger := e.asRowScope(principal.RowScopeOwn)
 	err = e.store.tx(stranger, func(tx pgx.Tx) error {
 		_, cerr := createPerson(stranger, tx, PersonResolution{
-			Decision: DecisionExactCollision, MatchedLane: laneEmail, PersonID: hiddenID,
+			Decision: DecisionExactCollision, MatchedLane: LaneEmail, PersonID: hiddenID,
 		}, PersonSpec{
 			FullName:   "Mara Steiner",
 			Emails:     []PersonEmailInput{{Email: "mara@steiner.test", EmailType: "work", IsPrimary: true}},
@@ -459,7 +459,7 @@ func TestTheChokepointRefusesToMintOverAnExactCollision(t *testing.T) {
 	var people int
 	if err := e.store.tx(ctx, func(tx pgx.Tx) error {
 		_, personRefusal = createPerson(ctx, tx, PersonResolution{
-			Decision: DecisionExactCollision, MatchedLane: laneEmail, PersonID: ids.New[ids.PersonKind](),
+			Decision: DecisionExactCollision, MatchedLane: LaneEmail, PersonID: ids.New[ids.PersonKind](),
 		}, PersonSpec{FullName: "Ghost", Source: "manual", CapturedBy: "human:test"})
 		return tx.QueryRow(ctx, `SELECT count(*) FROM person`).Scan(&people)
 	}); err != nil {

--- a/backend/internal/modules/people/participant.go
+++ b/backend/internal/modules/people/participant.go
@@ -34,7 +34,8 @@ import (
 // actually used, which need not be the one the record was created from.
 //
 // It is deliberately forgiving about finding nothing. A manually logged
-// activity has no address-only rows; a channel message has no address at all;
+// activity has no address-only rows; a channel message has one only when its
+// provider knew an address and its source vouched for it, so most carry none;
 // a replayed capture already promoted its row on the first pass. None of those
 // is an error, and none should fail an ensure that has otherwise succeeded.
 func namePersonAmongParticipants(ctx context.Context, tx pgx.Tx, activityID ids.ActivityID, personID ids.PersonID) error {

--- a/backend/internal/modules/people/person.go
+++ b/backend/internal/modules/people/person.go
@@ -40,6 +40,15 @@ type PersonEmailInput struct {
 	EmailType string
 	IsPrimary bool
 	Position  int
+	// VouchedNotCorresponded marks an address a provider's directory supplied
+	// for a human reached on another medium, rather than one this workspace has
+	// ever exchanged mail with.
+	//
+	// It identifies the person, which is what it is stored for, and it proves
+	// nothing about mail — so the mail ladder must not read it as a settled
+	// verdict about the address. False for every writer that has correspondence
+	// or a human's own assertion behind it, which is every writer but one.
+	VouchedNotCorresponded bool
 }
 
 type PersonPhoneInput struct {

--- a/backend/internal/modules/people/person_children.go
+++ b/backend/internal/modules/people/person_children.go
@@ -98,9 +98,10 @@ func parsePersonContacts(emails []PersonEmailInput, phones []PersonPhoneInput) e
 func insertPersonEmails(ctx context.Context, tx pgx.Tx, wsID ids.WorkspaceID, personID ids.PersonID, source, by string, emails []PersonEmailInput) error {
 	for _, e := range emails {
 		if _, err := tx.Exec(ctx,
-			`INSERT INTO person_email (workspace_id, person_id, email, email_type, is_primary, position, source, captured_by)
-			 VALUES ($1, $2, lower($3), $4, $5, $6, $7, $8)`,
-			wsID, personID, e.Email, e.EmailType, e.IsPrimary, e.Position, source, by); err != nil {
+			`INSERT INTO person_email (workspace_id, person_id, email, email_type, is_primary, position, source, captured_by, from_correspondence)
+			 VALUES ($1, $2, lower($3), $4, $5, $6, $7, $8, $9)`,
+			wsID, personID, e.Email, e.EmailType, e.IsPrimary, e.Position, source, by,
+			!e.VouchedNotCorresponded); err != nil {
 			if name, ok := storekit.UniqueViolation(err); ok {
 				if name == "uq_person_email_dedupe" {
 					return &DuplicateEmailError{Email: e.Email}

--- a/backend/internal/modules/people/resolve.go
+++ b/backend/internal/modules/people/resolve.go
@@ -253,7 +253,7 @@ func exactPersonOwners(ctx context.Context, tx pgx.Tx, c ResolveCandidate) ([]Re
 		if err != nil {
 			return nil, err
 		}
-		keep(hit, found, LanePhone, false)
+		keep(hit, found, lanePhone, false)
 	}
 	return out, nil
 }

--- a/backend/internal/modules/people/resolve.go
+++ b/backend/internal/modules/people/resolve.go
@@ -246,14 +246,14 @@ func exactPersonOwners(ctx context.Context, tx pgx.Tx, c ResolveCandidate) ([]Re
 		if err != nil {
 			return nil, err
 		}
-		keep(hit, found, laneEmail, true)
+		keep(hit, found, LaneEmail, true)
 	}
 	for _, phone := range c.Phones {
 		hit, found, err := exactPersonByPhone(ctx, tx, []string{phone})
 		if err != nil {
 			return nil, err
 		}
-		keep(hit, found, lanePhone, false)
+		keep(hit, found, LanePhone, false)
 	}
 	return out, nil
 }

--- a/backend/internal/modules/people/resolve_integration_test.go
+++ b/backend/internal/modules/people/resolve_integration_test.go
@@ -39,7 +39,7 @@ func TestResolveFindsAPersonByAClaimedAddress(t *testing.T) {
 	if out[0].Refs[0].ID != person.UUID {
 		t.Errorf("resolved to %s, want the seeded person %s", out[0].Refs[0].ID, person.UUID)
 	}
-	if out[0].Refs[0].MatchedOn != laneEmail || !out[0].Refs[0].Exact {
+	if out[0].Refs[0].MatchedOn != LaneEmail || !out[0].Refs[0].Exact {
 		t.Errorf("ref = %+v, want an exact hit on the address lane", out[0].Refs[0])
 	}
 }

--- a/backend/internal/modules/people/resolvecreate.go
+++ b/backend/internal/modules/people/resolvecreate.go
@@ -100,7 +100,7 @@ type PersonSpec struct {
 // several real people, so a shared number creates and the caller records the
 // pair for review (creatededupe.go states the same policy per lane).
 func createPerson(ctx context.Context, tx pgx.Tx, match PersonResolution, spec PersonSpec) (ids.PersonID, error) {
-	if match.Decision == DecisionExactCollision && match.MatchedLane != LanePhone {
+	if match.Decision == DecisionExactCollision && match.MatchedLane != lanePhone {
 		return ids.PersonID{}, refusedPersonCreate(ctx, tx, match, spec)
 	}
 	wsID := workspaceID(ctx)

--- a/backend/internal/modules/people/resolvecreate.go
+++ b/backend/internal/modules/people/resolvecreate.go
@@ -100,7 +100,7 @@ type PersonSpec struct {
 // several real people, so a shared number creates and the caller records the
 // pair for review (creatededupe.go states the same policy per lane).
 func createPerson(ctx context.Context, tx pgx.Tx, match PersonResolution, spec PersonSpec) (ids.PersonID, error) {
-	if match.Decision == DecisionExactCollision && match.MatchedLane != lanePhone {
+	if match.Decision == DecisionExactCollision && match.MatchedLane != LanePhone {
 		return ids.PersonID{}, refusedPersonCreate(ctx, tx, match, spec)
 	}
 	wsID := workspaceID(ctx)
@@ -150,7 +150,7 @@ func createPerson(ctx context.Context, tx pgx.Tx, match PersonResolution, spec P
 // by a chosen address at that. The refusal still stands either way; only the
 // pointer is withheld.
 func refusedPersonCreate(ctx context.Context, tx pgx.Tx, match PersonResolution, spec PersonSpec) error {
-	if match.MatchedLane == laneEmail && len(spec.Emails) > 0 {
+	if match.MatchedLane == LaneEmail && len(spec.Emails) > 0 {
 		dup := &DuplicateEmailError{Email: spec.Emails[0].Email}
 		visible, err := auth.VisibleTo(ctx, tx, entityPerson, match.PersonID.UUID)
 		if err != nil {

--- a/backend/internal/modules/privacy/erasure.go
+++ b/backend/internal/modules/privacy/erasure.go
@@ -97,11 +97,12 @@ func (e *Eraser) ErasePerson(ctx context.Context, personID ids.UUID, reason stri
 			return err
 		}
 		// Taken before the first statement that purges or suppresses by
-		// channel identity, and held until the commit: an inbound message
-		// from one of these accounts must land entirely before this erasure
-		// or entirely after it, never inside it — storekit.LockChannelIdentities
-		// states what landing inside it costs.
-		if err := storekit.LockChannelIdentities(ctx, tx, channelIdentityLockKeys(identities)); err != nil {
+		// identifier, and held to the commit: an inbound message naming this
+		// subject by ANY key they can be recognised by lands entirely before
+		// this erasure or entirely after it, never inside it. Addresses as well
+		// as accounts, because a mail-only subject holds no account for the
+		// account half to cover — storekit.LockSubjectKeys states the cost.
+		if err := storekit.LockSubjectKeys(ctx, tx, channelIdentityLockKeys(identities), emails); err != nil {
 			return err
 		}
 		// Refused BEFORE the first destructive statement: everything below

--- a/backend/internal/modules/privacy/erasure_selectors.go
+++ b/backend/internal/modules/privacy/erasure_selectors.go
@@ -118,13 +118,19 @@ var subjectOnlyDestroyable = `
 // deal's thread is the ordinary shape of an activity with no person link at
 // all — precisely the position a litigation hold protects.
 // unlinkedSubjectChannel is the channel twin of unlinkedSubjectMail, and it
-// exists for a sharper reason than symmetry. A channel activity carries NO
-// counterparty_email, so the mail arm cannot see it; and its person link is
+// exists for a sharper reason than symmetry: a channel activity's person link is
 // written by a SEPARATE transaction after the capture commits, so an erasure
-// landing in that gap leaves an activity linked to nobody. Between them those
-// two facts mean a channel activity could be reachable by neither selector —
-// permanently, since the suppression row then guarantees the identity is never
-// recreated and no later erasure, subject-access or retention pass can find it.
+// landing in that gap leaves an activity linked to nobody.
+//
+// The mail arm rescues only some of those. It keys on counterparty_email, and a
+// channel activity carries one only when its provider knew the sender's address
+// AND that source vouched for it — never for a transport where the bot holds no
+// address for the sender, which is every core channel connector. So for those
+// the two facts still compose: reachable by neither selector, permanently, since
+// the suppression row then guarantees the identity is never recreated and no
+// later erasure, subject-access or retention pass can find it. This arm is what
+// closes that, for the addressless transports and inside the pre-link window
+// alike.
 //
 // It matches on thread_key rather than a link, because thread_key IS the
 // account: the capture writes `provider:botID:accountID`, so the third segment

--- a/backend/internal/platform/database/storekit/suppression.go
+++ b/backend/internal/platform/database/storekit/suppression.go
@@ -109,9 +109,35 @@ type ChannelIdentityKey struct {
 // resolve that by killing one of them — an erasure or a customer's message
 // lost to an ordering nobody chose.
 func LockChannelIdentities(ctx context.Context, tx pgx.Tx, keys []ChannelIdentityKey) error {
-	hashes := make([]string, 0, len(keys))
+	return LockSubjectKeys(ctx, tx, keys, nil)
+}
+
+// LockSubjectKeys is the same mutex over EVERY identifier one subject can be
+// recognised by — their channel accounts and their addresses alike.
+//
+// Both families are needed because either one alone leaves the other unguarded,
+// and the gap is not symmetric. An erasure reads the subject's own identifiers:
+// a mail-only subject holds no channel account, so locking accounts alone makes
+// the eraser take no lock at all, and an inbound message naming that subject by
+// ADDRESS then serializes against nothing. It can bind a live channel account to
+// the subject mid-purge; the erasure works from its pre-erasure read, so that
+// binding is neither purged nor suppressed, and the account outranks the address
+// in the resolution ladder — so the certified-erased subject stays reachable and
+// no later erasure can find them by the address that has already been destroyed.
+//
+// The two families share ONE ordering, which is why they share one function.
+// Locking accounts in one function and addresses in another would let two
+// transactions take the same pair in opposite orders, and Postgres resolves that
+// by killing one of them — an erasure or a customer's message lost to an
+// ordering nobody chose. Hashing both into a single sorted, deduplicated set
+// makes that impossible to express.
+func LockSubjectKeys(ctx context.Context, tx pgx.Tx, keys []ChannelIdentityKey, emails []string) error {
+	hashes := make([]string, 0, len(keys)+len(emails))
 	for _, key := range keys {
 		hashes = append(hashes, ChannelIdentityHash(key.Provider, key.ChannelUserID))
+	}
+	for _, email := range emails {
+		hashes = append(hashes, SuppressionHash(email))
 	}
 	slices.Sort(hashes)
 	for _, hash := range slices.Compact(hashes) {
@@ -119,7 +145,7 @@ func LockChannelIdentities(ctx context.Context, tx pgx.Tx, keys []ChannelIdentit
 			SELECT pg_advisory_xact_lock(hashtextextended(
 				coalesce(current_setting('app.workspace_id', true), '') || ':' || $1, 0))`,
 			hash); err != nil {
-			return fmt.Errorf("storekit: locking a channel identity against a concurrent erasure: %w", err)
+			return fmt.Errorf("storekit: locking a subject identifier against a concurrent erasure: %w", err)
 		}
 	}
 	return nil

--- a/backend/internal/shared/ports/connector/counterparty.go
+++ b/backend/internal/shared/ports/connector/counterparty.go
@@ -16,8 +16,10 @@ package connector
 // the address is evidence the resolution ladder may match against. Which is
 // which is settled once, by capture's counterpartyShapeOf. DisplayName is the
 // header's human name (may be empty or hostile — untrusted text); Domain is
-// the lowercased mail domain (empty for a channel record); Direction is
-// relative to the mailbox/bot owner (DirectionInbound | DirectionOutbound).
+// the lowercased mail domain, and stays empty on a channel record even when one
+// corroborates, because every gate that reads it is a mail gate the channel
+// shape short-circuits past; Direction is relative to the mailbox/bot owner
+// (DirectionInbound | DirectionOutbound).
 type Counterparty struct {
 	Email       string
 	DisplayName string

--- a/backend/internal/shared/ports/connector/counterparty.go
+++ b/backend/internal/shared/ports/connector/counterparty.go
@@ -10,8 +10,11 @@ package connector
 
 // Counterparty names the non-owner participant of one captured message. A
 // mail record identifies them by Email (authoritative); a channel record
-// carries no address and identifies them by ChannelIdentity instead — the
-// two are mutually exclusive, never both populated. DisplayName is the
+// identifies them by ChannelIdentity. A record carrying BOTH is named by the
+// channel identity and CORROBORATED by the address: the identity outranks it,
+// being the key a reply is routed on and the one a person is bound by, while
+// the address is evidence the resolution ladder may match against. Which is
+// which is settled once, by capture's counterpartyShapeOf. DisplayName is the
 // header's human name (may be empty or hostile — untrusted text); Domain is
 // the lowercased mail domain (empty for a channel record); Direction is
 // relative to the mailbox/bot owner (DirectionInbound | DirectionOutbound).
@@ -21,11 +24,14 @@ type Counterparty struct {
 	Domain      string
 	Direction   string
 	// ChannelIdentity is the channel-record twin of Email: a messaging
-	// connector (Telegram) populates this instead, having no address to
-	// carry. Zero for every mail record. The four mail-domain gates (T0
-	// internal-domain, freemail, transactional/ESP, quarantine) all key off
-	// Email, so an empty Email already makes them no-ops for a channel
-	// record with no separate switch needed.
+	// connector populates this, and populates Email too when its provider
+	// knows the sender's address and the source declared the email merge key.
+	// Zero for every mail record.
+	//
+	// The four mail-domain gates (T0 internal-domain, freemail,
+	// transactional/ESP, quarantine) are bypassed wholesale for a channel
+	// record (capture's sinkensure.go), so a corroborating address does not
+	// wake them: the bypass keys on the SHAPE, not on Email being empty.
 	ChannelIdentity ChannelIdentity
 	// ListUnsubscribe reports whether the message carried an RFC 2369
 	// List-Unsubscribe header — the bulk-mail corroboration the transactional
@@ -42,6 +48,19 @@ type Counterparty struct {
 	// conversion from a look-alike struct, a pointer handed to a decoder.
 	// WithOwnerAttestation is the sole way in, and SentByOwner the sole way out.
 	sentByOwner bool
+	// mayCorroborateByEmail records that the SOURCE of this record declared the
+	// email merge key, so an address riding alongside a channel identity may
+	// reach the resolution ladder. Like sentByOwner it is unexported, and for
+	// the same reason: whoever can set it can have an undeclared source's
+	// address treated as identity evidence.
+	//
+	// It is a derived bool rather than the declared key list it comes from. The
+	// list belongs to the declaration and to the manifest, where its members are
+	// read by a human; carrying it here would alias the composition's own slice,
+	// give nil and empty as two spellings of one state, and foreclose comparing
+	// this struct forever. WithDeclaredEmailMerge is the sole way in and
+	// MayCorroborateByEmail the sole way out.
+	mayCorroborateByEmail bool
 }
 
 // Message direction relative to the mailbox owner, as Counterparty.Direction
@@ -81,3 +100,23 @@ func (c Counterparty) WithOwnerAttestation(providerFiled bool) Counterparty {
 
 // SentByOwner reports whether both halves of the attestation agreed.
 func (c Counterparty) SentByOwner() bool { return c.sentByOwner }
+
+// WithDeclaredEmailMerge returns a copy recording that this record's source
+// declared the email merge key, and so may carry an address to corroborate a
+// human it names by a channel identity.
+//
+// declared is the SOURCE's declaration, resolved by the core from the manifest —
+// never anything the record itself said. A record that names its human by an
+// address alone is unaffected: that address is the identity, not a
+// corroboration, and needs no declaration to be honoured.
+//
+// A caller that declares nothing leaves the answer false, which refuses the
+// corroboration rather than trusting it — the same direction WithOwnerAttestation
+// fails in, and for the same reason.
+func (c Counterparty) WithDeclaredEmailMerge(declared bool) Counterparty {
+	c.mayCorroborateByEmail = declared
+	return c
+}
+
+// MayCorroborateByEmail reports whether the source declared the email merge key.
+func (c Counterparty) MayCorroborateByEmail() bool { return c.mayCorroborateByEmail }

--- a/backend/migrations/core/0269_person_email_correspondence_evidence.down.sql
+++ b/backend/migrations/core/0269_person_email_correspondence_evidence.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS idx_person_email_correspondence;
+ALTER TABLE person_email DROP COLUMN IF EXISTS from_correspondence;

--- a/backend/migrations/core/0269_person_email_correspondence_evidence.up.sql
+++ b/backend/migrations/core/0269_person_email_correspondence_evidence.up.sql
@@ -1,0 +1,28 @@
+-- person_email gains the answer to a question the mail ladder has always asked
+-- of this table without being able to: is this address EVIDENCE OF
+-- CORRESPONDENCE, or merely an address somebody vouched for?
+--
+-- The ladder reads "a live person holds this address" as a settled verdict —
+-- capture's priorDispositionTx returns 'real' on it, and the noise sweep
+-- refuses to touch it. That reading was sound while every row here arrived by
+-- mail or by a human's own typing, both of which are correspondence or an
+-- assertion by somebody accountable.
+--
+-- A channel connector can now supply the address its provider's directory holds
+-- for the human who sent a direct message. That address identifies the person —
+-- which is what it is collected for — but it proves nothing about mail. Left
+-- indistinguishable, one direct message from a stranger would mark their address
+-- a known counterparty for good: every later bulk mail from it auto-created, and
+-- the noise sweep switched off for it permanently.
+--
+-- The default is TRUE because every existing row is exactly what the ladder has
+-- been assuming — mail capture, an import, or a human typing a contact in. Only
+-- the channel writer sets it false, and it is the one caller that has no
+-- correspondence to point at.
+ALTER TABLE person_email
+  ADD COLUMN from_correspondence boolean NOT NULL DEFAULT true;
+
+-- The ladder's two readers both filter on it and both key on the address, so
+-- they get the column in the index rather than a heap fetch per candidate.
+CREATE INDEX idx_person_email_correspondence
+  ON person_email (email) WHERE from_correspondence AND archived_at IS NULL;

--- a/backend/pkg/extension/ingress.go
+++ b/backend/pkg/extension/ingress.go
@@ -67,6 +67,15 @@ type IngressSource struct {
 	// second Record field, and the gate that a unit may land only what it
 	// declared arrives with it, in the core.
 	Lands []RecordKind
+
+	// Merges are the identity keys this source's provider VOUCHES for, and the
+	// core admits no other from it. A unit fills every field its provider gives
+	// it; which of those the resolution ladder may treat as identity is read
+	// from here rather than from whatever a record happens to carry.
+	//
+	// Empty — the default — means this source contributes no identity key. A
+	// source that says nothing gets no power it did not ask for.
+	Merges []MergeKey
 }
 
 // systemGrammar bounds the declared system key to what can sit inside a
@@ -100,6 +109,12 @@ func (s IngressSource) Validate() error {
 				s.System, string(kind), string(KindActivity))
 		}
 	}
+	for _, key := range s.Merges {
+		if key != MergeKeyEmail {
+			return fmt.Errorf("extension: ingress source %q declares merge key %q — the only identity key a source may vouch for is %q",
+				s.System, string(key), string(MergeKeyEmail))
+		}
+	}
 	return nil
 }
 
@@ -113,11 +128,16 @@ const (
 
 // Counterparty is the party on the other side of one captured message.
 //
-// It is identified by EMAIL, and that is the whole of the identity this surface
-// offers. The core also knows a channel-identity shape for providers that have
-// no address at all, and it is deliberately absent here: it keys a core table
-// whose provider vocabulary is a closed set, so a unit reaching it would be an
-// extension name entering a list the core maintains.
+// It is identified by EMAIL or by a channel identity, and which one NAMES the
+// human is the core's decision, not a unit's: a channel identity outranks an
+// address, because it is the key a reply is routed on and the one a person is
+// bound by. A record may carry both — the address then corroborates rather than
+// names, and the core admits it only from a source that declared
+// MergeKeyEmail.
+//
+// So a unit supplies every field its provider gives it and decides nothing
+// about identity. Dropping an address it holds, to fit a shape, would discard
+// evidence the resolution ladder is entitled to.
 //
 // DisplayName is untrusted text — whatever the provider says the human calls
 // themselves — and is bounded and stripped by the core before it is stored.
@@ -349,15 +369,11 @@ func (c Counterparty) validate() error {
 		return fmt.Errorf("extension: %q is not a direction (%q, %q, or empty for a record with no honest direction)",
 			c.Direction, DirectionInbound, DirectionOutbound)
 	}
-	// A counterparty is named by an address OR by a channel identity, never
-	// both — the core's own rule (capture's ErrCounterpartyNamedTwice), restated
-	// here so a unit learns it from its own grammar rather than from an
-	// unattributable "the core could not land this record". The two are
-	// different resolution ladders that mint the person differently, and a
-	// record supplying both is asking which one it meant.
-	if c.Email != "" && (c.ChannelIdentity.Provider != "" || c.ChannelIdentity.ChannelUserID != "") {
-		return errors.New("extension: the counterparty is named by an address AND by a channel identity — a record names its human one way, because the two resolve through different ladders and nothing here can decide which was meant")
-	}
+	// A counterparty carrying BOTH is well-formed here, and deliberately so: the
+	// channel identity NAMES the human and the address CORROBORATES them, which
+	// is a shape only the core can admit or refuse, because only the core knows
+	// which merge keys this source declared. Refusing it here would refuse it
+	// for every source alike and put the decision in the wrong place.
 	return c.ChannelIdentity.validate()
 }
 

--- a/backend/pkg/extension/ingress_test.go
+++ b/backend/pkg/extension/ingress_test.go
@@ -108,14 +108,6 @@ func TestTheRecordGrammarRefusesWhatCannotBeLandedHonestly(t *testing.T) {
 		"a channel display name over the cap": namedByAccount(extension.ChannelIdentity{
 			Provider: "dispact", ChannelUserID: "G-1", DisplayName: strings.Repeat("n", extension.MaxDisplayNameRunes+1),
 		}),
-		// Named TWICE — the address KEPT this time. The core refuses it
-		// (ErrCounterpartyNamedTwice) because an address and a channel account
-		// resolve through different ladders, and the published grammar refuses it
-		// here so a unit reads the reason rather than an unattributable "the core
-		// could not land this record".
-		"a counterparty named by an address and by an account": func(r *extension.Record) {
-			r.Counterparty.ChannelIdentity = extension.ChannelIdentity{Provider: "dispact", ChannelUserID: "G-1"}
-		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			rec := aValidRecord()
@@ -261,5 +253,22 @@ func TestTheDispositionsAreTheTwoTheCoreCanHonestlyReport(t *testing.T) {
 		if strings.TrimSpace(string(d)) == "" {
 			t.Errorf("a disposition renders as empty, which a unit cannot log or branch on")
 		}
+	}
+}
+
+// TestAChannelIdentityMayCarryACorroboratingAddress pins that the published
+// grammar admits what the core decides about.
+//
+// The address alongside a channel identity is not a second way of naming the
+// human — the core reads the identity as the name and the address as evidence
+// for its resolution ladder, and admits the evidence only from a source that
+// declared the email merge key. Refusing the shape HERE would refuse it for
+// every source alike, which is the decision this package is not the one to take.
+func TestAChannelIdentityMayCarryACorroboratingAddress(t *testing.T) {
+	rec := aValidRecord()
+	rec.Counterparty.ChannelIdentity = extension.ChannelIdentity{Provider: "dispact", ChannelUserID: "G-1"}
+
+	if err := rec.Validate(); err != nil {
+		t.Fatalf("the grammar refused a channel identity carrying an address: %v", err)
 	}
 }

--- a/backend/pkg/extension/mergekey.go
+++ b/backend/pkg/extension/mergekey.go
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+// The merge-key vocabulary — which identity keys an ingress source vouches for —
+// is part of the published extension surface.
+//
+//margince:extension-surface
+
+package extension
+
+// MergeKey is an identity key the person-resolution ladder resolves by. It is a
+// declaration vocabulary rather than a flag, because the ladder is a ladder:
+// naming the key a source vouches for says something a boolean cannot as the
+// vocabulary grows.
+//
+// A source declares a key to CORROBORATE the human a record already names —
+// never to name them. The distinction is the whole point: an address on a
+// mail-shaped record IS that record's identity and needs no declaration, while
+// an address riding alongside a channel identity is evidence the ladder may
+// match on, and that is what a source has to vouch for.
+type MergeKey string
+
+// MergeKeyEmail is the counterparty's address, and it is the only key a captured
+// record can carry today: Counterparty has no phone field, and no connector —
+// core or unit — produces one. A second key is a value here plus a field on the
+// record, not a different design.
+//
+// A fitness test outside this package holds this equal to the resolution
+// ladder's own lane name, so the vocabulary cannot drift away from the ladder it
+// claims to be quoting.
+const MergeKeyEmail MergeKey = "email"

--- a/backend/tools/gen-composition/astreader_ingress.go
+++ b/backend/tools/gen-composition/astreader_ingress.go
@@ -66,6 +66,8 @@ func (r *unitReader) readIngressSource(elt ast.Expr, ext string) (ingressSource,
 			src.System, err = r.stringLit(kv.Value, "IngressSource.System")
 		case "Lands":
 			src.Lands, err = r.readRecordKinds(kv.Value, ext)
+		case "Merges":
+			src.Merges, err = r.readMergeKeys(kv.Value, ext)
 		default:
 			err = r.errAt(kv, "IngressSource field %s is not derivable by this generator", k.Name)
 		}
@@ -77,6 +79,7 @@ func (r *unitReader) readIngressSource(elt ast.Expr, ext string) (ingressSource,
 		return ingressSource{}, r.errPos(lit, "%v", err)
 	}
 	sort.Strings(src.Lands)
+	sort.Strings(src.Merges)
 	return src, nil
 }
 
@@ -100,6 +103,26 @@ func (r *unitReader) readRecordKinds(expr ast.Expr, ext string) ([]string, error
 	return out, nil
 }
 
+// readMergeKeys reads the Merges slice literal, the identity keys a source
+// vouches for. It is readRecordKinds' twin rather than a widening of it: the two
+// read different vocabularies, and one function serving both would resolve a
+// record kind where a merge key was written and call it derived.
+func (r *unitReader) readMergeKeys(expr ast.Expr, ext string) ([]string, error) {
+	lit, ok := expr.(*ast.CompositeLit)
+	if !ok {
+		return nil, r.errAt(expr, "IngressSource.Merges must be a slice literal")
+	}
+	out := make([]string, 0, len(lit.Elts))
+	for _, elt := range lit.Elts {
+		key, err := r.constValue(elt, ext)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, key)
+	}
+	return out, nil
+}
+
 // declaredIngressSource rebuilds the published type from what was read, so the
 // generator runs the unit's own grammar rather than a second copy of it.
 func declaredIngressSource(src ingressSource) extension.IngressSource {
@@ -107,5 +130,9 @@ func declaredIngressSource(src ingressSource) extension.IngressSource {
 	for _, kind := range src.Lands {
 		lands = append(lands, extension.RecordKind(kind))
 	}
-	return extension.IngressSource{System: src.System, Lands: lands}
+	merges := make([]extension.MergeKey, 0, len(src.Merges))
+	for _, key := range src.Merges {
+		merges = append(merges, extension.MergeKey(key))
+	}
+	return extension.IngressSource{System: src.System, Lands: lands, Merges: merges}
 }

--- a/backend/tools/gen-composition/unitmanifest.go
+++ b/backend/tools/gen-composition/unitmanifest.go
@@ -102,11 +102,17 @@ type subscriptionRequest struct {
 }
 
 // ingressSource is one declared provider a unit lands records from: the unit's
-// own key for it and the record kinds it produces, both sorted so the encoding
-// does not depend on declaration order.
+// own key for it, the record kinds it produces, and the identity keys its
+// provider vouches for — all sorted so the encoding does not depend on
+// declaration order.
+//
+// Merges is omitempty for the reason Secrets and Subscriptions above are: a
+// field a unit does not use must not rewrite its committed manifest, which is
+// what lets this land without a schema bump.
 type ingressSource struct {
 	System string   `json:"system"`
 	Lands  []string `json:"lands"`
+	Merges []string `json:"merges,omitempty"`
 }
 
 // declaredChannel is one messaging transport the unit supplies, as an operator

--- a/extensions/dispact-connector/dispact.go
+++ b/extensions/dispact-connector/dispact.go
@@ -67,7 +67,19 @@ func New() extension.Extension {
 		// anything else is refused at the call rather than landed under an
 		// invented provenance namespace.
 		Ingress: []extension.IngressSource{
-			{System: "dispact", Lands: []extension.RecordKind{extension.KindActivity}},
+			// The email merge key is VOUCHED FOR, not merely passed along:
+			// Dispact answers /api/users/batch from the workspace directory, so
+			// the address on a member's account is the one their administrator
+			// set rather than one they typed about themselves. That is what the
+			// core needs before it will let an address corroborate the human a
+			// direct message names by account — and it is the declaration an
+			// operator reads in manifest.generated.json before enabling this
+			// unit.
+			{
+				System: "dispact",
+				Lands:  []extension.RecordKind{extension.KindActivity},
+				Merges: []extension.MergeKey{extension.MergeKeyEmail},
+			},
 		},
 		Tools: []extension.Tool{
 			{Name: "dispact_connect", Handle: connect},

--- a/extensions/dispact-connector/manifest.generated.json
+++ b/extensions/dispact-connector/manifest.generated.json
@@ -79,6 +79,9 @@
       "system": "dispact",
       "lands": [
         "activity"
+      ],
+      "merges": [
+        "email"
       ]
     }
   ],

--- a/extensions/dispact-connector/record.go
+++ b/extensions/dispact-connector/record.go
@@ -152,6 +152,15 @@ func counterpartyOf(item inboxItem, sender providerUser) extension.Counterparty 
 			ChannelUserID: sender.ID,
 			DisplayName:   sender.name(),
 		},
+		// The address is CARRIED, not used to name anybody: the account above
+		// names the sender and the core prefers it. What this buys is the
+		// colleague already captured from mail being recognised as the same
+		// human instead of quietly becoming a second contact — this unit knows
+		// the address, and dropping it would throw away evidence only this side
+		// has. The core admits it because the ingress source declares the email
+		// merge key; without that declaration this record would be refused.
+		Email:  sender.Email,
+		Domain: mailDomain(sender.Email),
 	}
 }
 

--- a/extensions/dispact-connector/record.go
+++ b/extensions/dispact-connector/record.go
@@ -110,15 +110,16 @@ var directMessageTypes = map[string]bool{
 	"dm_thread_reply": true,
 }
 
-// counterpartyOf names the human at the other end, ONE way — by the account
-// they can be answered at, or by their address, and never both.
+// counterpartyOf names the human at the other end, and the shape decides which
+// ladder resolves them.
 //
-// The exclusivity is the core's rule (capture's ErrCounterpartyNamedTwice) and
-// it is a real choice rather than a formality: the two are different resolution
-// ladders. An address goes through the mail ladder, where a corporate domain is
-// DEFERRED to the pending inbox and only a freemail sender mints a person; a
-// channel account goes through the channel ladder, which binds the account to a
-// person the reply path can then resolve.
+// The two ladders are different, which is why the shape is a real choice rather
+// than a formality. An address alone goes through the mail ladder, where a
+// corporate domain is DEFERRED to the pending inbox and only a freemail sender
+// mints a person. An account goes through the channel ladder, which binds the
+// account to a person the reply path can then resolve — and there the address,
+// where this unit holds one, rides along as matching evidence rather than as a
+// second way of naming anybody.
 //
 // A DIRECT MESSAGE is named by the SENDER'S OWN ACCOUNT ID, not by the channel
 // the message arrived in. The core keys the binding on (provider, account id)
@@ -159,15 +160,15 @@ func counterpartyOf(item inboxItem, sender providerUser) extension.Counterparty 
 		// the address, and dropping it would throw away evidence only this side
 		// has. The core admits it because the ingress source declares the email
 		// merge key; without that declaration this record would be refused.
-		Email:  sender.Email,
-		Domain: mailDomain(sender.Email),
+		Email: sender.Email,
 	}
 }
 
 // mailDomain is the lower-cased domain half of an address, or empty when there
-// is not one. The core's suppression gates key on it, and a unit that left it
-// empty would not be opting out of them — it would be failing to answer, which
-// those gates read as "keep".
+// is not one. It is for the MAIL shape alone: the core's suppression gates key
+// on it, and a unit that left it empty there would not be opting out of them —
+// it would be failing to answer, which those gates read as "keep". A channel
+// record short-circuits past every one of those gates, so it names no domain.
 func mailDomain(email string) string {
 	at := strings.LastIndex(email, "@")
 	if at < 0 || at == len(email)-1 {

--- a/extensions/dispact-connector/record_test.go
+++ b/extensions/dispact-connector/record_test.go
@@ -73,13 +73,18 @@ func TestARecordCarriesWhatTheCoreDecidesWith(t *testing.T) {
 		t.Errorf("direction = %q, want inbound — the member received this", rec.Activity.Direction)
 	case !rec.Activity.OccurredAt.Equal(item.CreatedAt):
 		t.Errorf("occurred_at = %v, want the provider's own time rather than when the poll noticed", rec.Activity.OccurredAt)
-	// A DM names its human by the ACCOUNT it can be answered at, so it carries
-	// no address and no domain — the mail suppression gates all key off the
-	// address and are no-ops for a channel record by construction, which is why
-	// the empty domain here is an answer rather than a gap. The address arm is
-	// asserted on a mention below, where it is the shape that applies.
-	case rec.Counterparty.Email != "":
-		t.Errorf("email = %q on a direct message — the core refuses a counterparty named by an address AND by a channel account", rec.Counterparty.Email)
+	// A DM names its human by the ACCOUNT it can be answered at, and CARRIES
+	// the address alongside it. The account is what the core resolves and
+	// replies on; the address is what lets the colleague already captured from
+	// mail be recognised as the same human rather than becoming a second
+	// contact. This unit declares the email merge key, which is what makes the
+	// core admit it.
+	case rec.Counterparty.Email != "outside@example.com":
+		t.Errorf("email = %q on a direct message, want the sender's address carried as matching evidence", rec.Counterparty.Email)
+	case rec.Counterparty.Domain != "example.com":
+		t.Errorf("domain = %q, want the address's own domain", rec.Counterparty.Domain)
+	case rec.Counterparty.ChannelIdentity.ChannelUserID == "":
+		t.Error("a direct message carries no account id — the address must not become the thing that names the sender")
 	case string(rec.Raw) != string(item.Raw):
 		t.Errorf("raw = %s, want the provider's own document", rec.Raw)
 	}

--- a/extensions/dispact-connector/record_test.go
+++ b/extensions/dispact-connector/record_test.go
@@ -81,8 +81,8 @@ func TestARecordCarriesWhatTheCoreDecidesWith(t *testing.T) {
 	// core admit it.
 	case rec.Counterparty.Email != "outside@example.com":
 		t.Errorf("email = %q on a direct message, want the sender's address carried as matching evidence", rec.Counterparty.Email)
-	case rec.Counterparty.Domain != "example.com":
-		t.Errorf("domain = %q, want the address's own domain", rec.Counterparty.Domain)
+	case rec.Counterparty.Domain != "":
+		t.Errorf("domain = %q on a direct message — every consumer of it is a mail gate the channel shape never reaches", rec.Counterparty.Domain)
 	case rec.Counterparty.ChannelIdentity.ChannelUserID == "":
 		t.Error("a direct message carries no account id — the address must not become the thing that names the sender")
 	case string(rec.Raw) != string(item.Raw):


### PR DESCRIPTION
Closes #1382.

## The defect

A person minted from a captured channel message carried no address even when the connector knew one, so the dedupe spine could not recognise a human already captured from mail. One human, two records. From the UAT of #1368:

```
    full_name     | emails | provider
------------------+--------+----------
 Dung Nguyen      |      0 | dispact
 Tuyen Dinh Quang |      0 | dispact
 Luu Nguyen Thanh |      0 | dispact
```

The connector held every one of those addresses and had to throw them away: the core refused a counterparty carrying both an address and a channel identity, so `dispact`'s DM branch dropped `sender.Email`.

## The shape of the fix

The connector was making an identity decision. It should supply every field its provider gives it and decide nothing — **which** of those the resolution ladder may resolve by is the core's call, read from what the source **declared**.

- **`extension.MergeKey`**, over the ladder's own vocabulary rather than a bespoke flag about addresses. `IngressSource.Merges` is empty by default, which contributes no identity key and is byte-for-byte today's behaviour. A fitness test holds `MergeKeyEmail` equal to `people.LaneEmail` so the two cannot drift.
- **Two gates at two layers**, the way `refuseUndeclaredTransport`/`refuseUnitIdentity` already are: `extingress` refuses *attributably*, so a unit author reads their own grammar; capture's `admitCounterpartyKeys` holds the *invariant* for every caller of `Upsert`, including a future core connector or backfill that never passes through extingress. The declaration is stamped from the source and reduced to one unexported bool, so a unit cannot widen its own trust per record.
- **Precedence replaces refusal.** A both-record is `shapeChannel`: the identity *names* the human, the address only *corroborates*. Reply routing, the erasure lock and the mail-ladder bypass are unchanged by construction. `ErrCounterpartyNamedTwice` and `shapeAmbiguous` are deleted.
- **The email lane now adopts.** Routing alone left the person **unbound** — unreachable for a reply, invisible to a channel-keyed erasure, re-resolved by address forever. The bind runs under the advisory lock already held, after settling any merge that retired the row.
- **Erasure probes both keys.** An erasure keyed on an address must not be undone by the subject's next DM, which names them by an account the suppression list never heard of.

## Scope this change reaches that the issue did not mention

Three comments it falsifies are rewritten rather than left standing:

- `privacy/erasure_selectors.go` — a channel activity can now carry `counterparty_email`, so the mail selector reaches it. Accepted: address-keyed erasure deletes *more* completely. The channel selector still earns its place for addressless transports and the pre-link window.
- `capture/sinkchannel.go` — "matches neither erasure selector".
- `people/participant.go` — "a channel message has no address at all".

And `capture/tracestore.go`'s disposition join is guarded to mail rows, so a captured-and-linked DM is never reported to a member as "waiting on a verdict" it cannot have.

## What this grants, stated plainly

A unit declaring `email` can send `{Email: real-contact@…, ChannelIdentity: attacker-account}` and have that account bound to the real person. **The bind is the entirety of channel reachability** — the reply send resolves recipients from `person_channel_identity` via the anchor's links — so every rep reply on that person's channel activities would reach the attacker. Without the bind the spoof is not repliable at all.

Accepted deliberately under manifest-first: units are compile-time linked, the capability is declared, disclosed in `manifest.generated.json`, and refusable at install; a unit trusted with ingest can already write arbitrary activities.

**Visibility** is likewise a stated decision: a DM routed onto an owner-visible mail incumbent stays owner-visible, so it is readable by that rep alone — including invisible to the member whose credential captured it. Widening on a stranger's DM would let an outsider publish a rep's private contact to the workspace.

## Verification

- `make check-backend` — exit 0
- `make craft-static` — 0 blocker / 0 major / 0 minor across backend, extensions, fixtures
- `make test-integration` — **0 skips**, 40 packages
- `make e2e-ai-report` — 20 stale / 7 absent, **identical to `origin/main`** (verified in a worktree at the base commit): this change moves no prompt digest, so no re-certification is needed
- New-code coverage: 8 of 9 new functions at 100%; `adoptEmailRoutedIncumbent` at 72.7% (error branches and the lost-race guard)
- The two headline tests were **mutation-checked** — removing the bind fails both `TestADirectMessageFindsTheHumanAlreadyCapturedFromMail` and `TestACorroboratingAddressAdoptsTheMailCapturedIncumbent`

## Open assumption

`dispact`'s `/api/users/batch` email is taken to be directory-managed rather than a profile field the account holder edits. Nothing in this repo proves it. Declaring `MergeKeyEmail` is honest only if it holds; the core mechanism is unaffected either way.

## Contract-first note

The email-XOR-channel rule and the three-lane exact tier are **implementation-invented** — `ChannelIdentity` appears zero times under the spec's `specs/` tree, and PO-F-1 still specifies a single email-only exact tier. Landing code first here is a deliberate, founder-taken decision; a spec-gap issue follows, naming ADR-0109/A160 as the record still to be ratified.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Channel messages can now carry a source‑vouched email so capture recognizes people already captured from mail and binds the channel account. Previously, a channel+email record was refused or dropped, minting duplicates and leaving DMs unbound; now the channel identity names the person and the email corroborates only when the source declares it, without treating it as mail correspondence.

- Adds `extension.MergeKey` and `extension.IngressSource.Merges`; `extingress` refuses channel+email from sources that didn’t declare `email`, and `capture` enforces the same invariant (`admitCounterpartyKeys`).
- Counterparty precedence replaces refusal: both keys read as channel; reply routing and the mail‑ladder bypass are unchanged; deleted the “named twice” shape and refusal.
- `people.EnsureChannelCounterparty` accepts `CorroboratingEmail`, probes erasure on both channel and email, adopts a mail‑captured incumbent, and binds the account; minted channel persons keep the corroborating email as vouched‑not‑corresponded.
- Mail effects are scoped: `priorDispositionTx` and the noise sweep ignore vouched‑not‑corresponded addresses, so a first DM does not auto‑create bulk mail or disable noise suppression.
- Erasure mutex covers subjects by all keys: `storekit.LockSubjectKeys` locks channel accounts and addresses; the eraser takes it to prevent binding inside a purge; erasure selectors and tests updated accordingly.
- Trace UI joins the mail disposition ledger only for mail rows to avoid showing DMs as “waiting on a verdict”.
- `dispact` declares `email` in ingress and includes the sender’s email on DMs; manifest generation and validation updated; `people.LaneEmail` is exported and fitness‑tested against `extension.MergeKeyEmail`.

**Migration**
- Units that send an email alongside a channel identity must declare `email` in `Ingress.Merges`; otherwise records are refused (`extension.ErrInvalid`/`capture.ErrMergeKeyNotDeclared`).
- Schema adds `person_email.from_correspondence` and an index; no changes required for core connectors.

<sup>Written for commit ad1f37fd1e142c6d452afa0d9cdeb20a1f5e0d38. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1429?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

