### PR TITLE
docs(extensions): the tier grew a transport and a merge key, and both docs stopped at Tools

### DIFF
--- a/docs/explanation/extensibility.md
+++ b/docs/explanation/extensibility.md
@@ -4,10 +4,14 @@ How a bounded add-on lands in this product **without editing a single upstream-o
 recorded exception, below**. This is
 the *extension tier*: one named, versioned unit under `extensions/<name>/`, its own Go module,
 reaching the core through one narrow published surface and composed in at build time. The vanilla tree
-already ships three — `extensions/de`, the German jurisdiction pack; `extensions/yogi`, the reference
-unit that serves one governed agent tool; and `extensions/notes`, the reference extension that
-exercises every capability the tier has (its own table under RLS, six governed operations, its own
-RBAC object, a stored signing key it signs with and never emits, and a scheduled heartbeat).
+already ships four:
+
+| Unit | What it is |
+|---|---|
+| `extensions/de` | The German jurisdiction pack — statutory retention floors, and nothing else |
+| `extensions/yogi` | The reference unit that serves one governed agent tool |
+| `extensions/notes` | The reference extension for a unit that owns data: its own table under RLS, six governed operations, its own RBAC object, a stored signing key it signs with and never emits, and a scheduled heartbeat |
+| `extensions/dispact-connector` | The reference unit that reaches the outside world: it captures messages from its provider and carries replies back out on its own transport |
 
 This page is for a contributor who wants the whole idea first, then the detail. Start here; to
 actually *build* a unit, jump to [how-to/add-an-extension.md](../how-to/add-an-extension.md).
@@ -95,18 +99,37 @@ func New() extension.Extension {
 That value is the entire contract. `Name` is the canonical unit name (it must equal the directory
 name, obeys `^[a-z0-9]+(-[a-z0-9]+)*$`, ≤32 chars) and keys the unit's namespace everywhere it will
 touch — `ext_<name>_<table>` tables, `/v1/ext/<name>/` paths, the `ext_<name>` database role. `Version` is
-recorded in the boot inventory and carries no authority. **Capabilities are the remaining fields** —
-`Jurisdictions` (passive policy) and `Tools` (the first *governed* kind: a risk-tier request in the
-manifest, and — when the declaration carries a handler — a tool the agent surface actually serves,
-see §5).
+recorded in the boot inventory and carries no authority.
+
+**Capabilities are the remaining fields**, and each is its own field precisely so that adding one
+breaks no existing unit:
+
+| Field | What it contributes |
+|---|---|
+| `Jurisdictions` | Passive policy the core consults. Never an actor, so it appears in no manifest |
+| `Tools` | Governed agent tools: a risk-tier request in the manifest, and — when the declaration carries a handler — a tool the agent surface serves (§5) |
+| `Channels` | Messaging providers the unit supplies **transport** for. The core calls the unit to send; the unit never sends on its own authority |
+| `Ingress` | Providers the unit brings records **in** from, and the identity keys that source vouches for |
+| `Subscriptions` | Event types the unit reacts to, each with the function one delivery runs |
+| `Jobs` | Scheduled work: a cadenced fan-out with a worker child per tenant |
+| `Secrets` | The secret keys the unit will use, by name and scope. A request, not a grant |
+| `Migrations` | The unit's own SQL schema layer, embedded rather than read from the tree |
+
+`Channels` and `Ingress` are deliberately separate. Neither implies the other: a unit may capture
+from a provider it cannot send on, and the channel declaration is what says which.
 
 ### 2. The published surface — and the marker that gates it
 
-A unit may import only `backend/pkg/**`, and only the packages that opt in. Two exist today:
+A unit may import only `backend/pkg/**`, and only the packages that opt in. Three exist today:
 
-- **`pkg/extension`** — the declaration types (`Extension`, and the self-validating `Name`/`Version`).
+- **`pkg/extension`** — the declaration types (`Extension`, the self-validating `Name`/`Version`) and
+  every capability contract that rides on them: `Tool`, `Channel`, `IngressSource` and `Record`,
+  `MergeKey`, `Subscription`, `Job`, `SecretsRequest`, and the per-invocation `Runtime`. One package
+  across several files; the marker is per-package, not per-file.
 - **`pkg/extension/jurisdiction`** — the jurisdiction-pack contract (`Pack`, `Retention`,
   `RetentionClass`, the closed class/anchor vocabularies, the calendar `Period`).
+- **`pkg/extension/crm`** — the shapes a unit passes to and receives from `tx.Core()`, the governed
+  door onto core records.
 
 Membership in `backend/pkg` **grants nothing on its own**. A package is extension surface only when
 its package clause carries the directive `//margince:extension-surface`. The allowlist is *derived
@@ -140,10 +163,25 @@ the declaration carrying a handler (§5). Passive policy
 that an extension merely supplies requests no risk tier and does not appear: a jurisdiction pack exposes no
 governed operation (the core consults its policy at boot — it is never an agent that acts) and asks
 for no tier, so a jurisdiction-only unit (like `de`) carries an empty risk-tiers list — there is
-nothing to approve. The returned `extension.Extension` literal and the fields the manifest derives
-(`Name`, `Version`, `Tools`) must be literal values; an unrecognized field fails generation with its
-position rather than producing a manifest that silently omits a request. The manifest is committed
-with the unit and drift-gated like the contract; its digest rides in `composition.json` per unit.
+nothing to approve.
+
+Beyond the risk tiers, the manifest records what a unit **reaches**, so an operator can read its
+blast radius before enabling it:
+
+| Manifest key | From | Says |
+|---|---|---|
+| `risk_tiers` | `Tools`, `Jobs`, contract fragments | Every governed operation, its tier and its scopes |
+| `secrets` | `Secrets` | Which keys the unit expects, and at which scope |
+| `subscriptions` | `Subscriptions` | Which of the installation's facts it consumes |
+| `ingress` | `Ingress` | Which providers it lands records from, which kinds, and which identity keys the source **vouches for** (`merges`) |
+| `channels` | `Channels` | Which providers it supplies, and whether it supplies a **transport** (`supplies_transport`) or captures only |
+
+The returned `extension.Extension` literal and every field the manifest derives must be literal
+values; an unrecognized field fails generation with its position rather than producing a manifest
+that silently omits a request. That is why a unit spells `"dispact"` twice rather than sharing a
+constant between its ingress source and its channel — the reader is static and resolves no
+constants, and a test holds the two strings equal. The manifest is committed with the unit and
+drift-gated like the contract; its digest rides in `composition.json` per unit.
 
 ### 4. The build-time binding — which `composition` module the compiler links
 
@@ -212,6 +250,10 @@ Validate-then-apply makes "partially registered extension" a state the system ca
 so it never appears in the unit manifest. A **scheduled job** and a **subscription** are the two that
 run with nobody behind them; a subscription's manifest entry records its REACH (which event types it
 consumes) rather than a tier, because there is nothing about a listener for an operator to resolve. An
+**ingress source** and a **channel** are the two that face outward, and their manifest entries record
+reach as well — which provider, which record kinds, which identity keys, and whether the unit can also
+send. Neither runs on its own authority: an ingest runs as the member whose credential produced the
+record, and a send happens only because a human staged one. An
 **agent tool** (`extension.Tool`) is the *governed* kind proper: it derives a risk-tier
 request into `manifest.generated.json` for operator resolution (§7), and a tool declaring a `Handle`
 **is served** — `buildExtensionTools` adapts it to the core `mcp.Tool` seam and boot registers it into
@@ -300,10 +342,44 @@ validated to the full identifier budget, so a name chosen today stays valid for 
   `manifest.generated.json`), so a unit can attribute nothing to another unit or to a core connector, and
   a landed row's `captured_by` names the member behind it as well.
 
+  A source also declares the **identity keys it vouches for** (`Merges`, empty by default). A unit
+  supplies every field its provider gives it and decides nothing about identity; which of those fields
+  the core's resolution ladder may match on is read from the declaration. Concretely: a direct message
+  names its human by a channel account, and an address riding alongside it may be matched on only if
+  the source declared `MergeKeyEmail` — which is what lets a colleague already captured from mail be
+  recognised instead of becoming a second contact. See
+  [ingress-gate-and-auto-capture.md](ingress-gate-and-auto-capture.md).
+
   Authority is the mirror image of `tx.Core()`'s: an ingest is refused from an ATTENDED invocation, and
   it runs on the LIVE authority of the member named in `on` — who must currently hold one of this unit's
   user-scoped secrets, because depositing a credential with a unit is the act that says "act for me
   here". `extensions/dispact-connector` is the unit that exercises the path end to end.
+
+- **Its own messaging transport** — a `Channel` declares a provider the unit can carry messages on, so
+  a rep's reply to a captured conversation leaves through the unit, on the member's own credential,
+  through the product's ordinary reply path rather than a surface of the unit's own.
+
+  **A unit never sends. It DECLARES a transport and the core calls it.** The chain is: the timeline
+  reply box → `activities.SendMessage` (authorization, consent, recipient resolved from the links) →
+  staging → the comms dispatcher → the unit's `Channel.Send`. So the tier's outbound refusals stand
+  untouched — a unit still may not spend an outbound cap from a tool or a job tick. What changed is
+  that a human staged the message, the seat gate re-read them, and the core hands the unit something
+  to carry.
+
+  Three parts of the declaration carry weight. `Provider` is a row in `channel_provider` and takes
+  **that column's** grammar, which is snake (`^[a-z][a-z0-9_]*$`) and not the ingress system's kebab —
+  `deal-room` is a legal ingress system and an illegal provider. `Send` may be **nil**, and that is the
+  documented capture-only case: a reply attempt is then answered with the deployment fact rather than a
+  fault. `Live` is **required whenever `Send` is present**: it answers, per member and without spending
+  the credential, whether the connection is still usable. A confirmed "no" parks the delivery where a
+  human can see it; "I could not tell" is an error and is retried. Reading either as the other destroys
+  a message or sends it twice.
+
+  A unit names the **transport**, never the activity kind. The kind a channel message lands under is
+  the core's and fixed by the contract (ADR-0107/A158); letting a unit name one would undo that axis
+  split from outside the core. A unit shadowing a core provider — `telegram`, say — fails the boot,
+  because every Telegram reply would otherwise leave on the unit's per-member credential instead of the
+  workspace's bot: the same message, sent by a different person, with nothing on screen different.
 
 - **Its own frontend** — a `frontend/` directory whose screen is aliased into the SPA and rendered at
   the unit's route. Removing a unit is a one-place operation again: delete the unit directory. An
@@ -367,7 +443,12 @@ The tier is defended by fitness tests and scripts, so the guarantees can't rot i
 | A unit lands a record in the product only where an operator can see that it does: `source_system` is derived from a DECLARED ingress source, so a typo is a refusal rather than a second provenance namespace | `internal/compose/extingress.go` (`declaredIngress`), `internal/compose/extensions.go` (`preflightIngress`) |
 | An ingest runs on the named member's LIVE authority, and only for a member who currently holds one of that unit's user-scoped secrets — so a unit cannot act as a colleague who never asked it to | `internal/compose/extingressauthority.go`, `extingress_integration_test.go` |
 | An ingest is refused from an invocation that HAS a caller, and from inside a transaction the unit is holding — the second on a pool of one, where the alternative is a hang rather than a failure | `internal/compose/extingress.go`, `extingress_test.go`, `extingress_integration_test.go` |
+| An address may be offered as identity evidence only by a source that DECLARED the key — refused attributably at the gate, and held for every other caller of the pipeline by capture's own admission check | `internal/compose/extingress.go` (`refuseUndeclaredMergeKey`), `internal/modules/capture/sinkchannel.go` (`admitCounterpartyKeys`) |
 | The published record type cannot silently fall behind the core's capture envelope: every field is mirrored or waived with its reason | `internal/compose/extingressdrift_test.go` |
+| A unit may file a message on a transport it DECLARED and on no other, and no other kind may name a transport at all — a record claiming a journey it did not make is one the reply path would answer on | `internal/compose/extingress.go` (`refuseUndeclaredTransport`) |
+| A unit may bind a counterparty identity only under a provider it supplies — otherwise it could attach an account it controls to somebody else's person record and take that person's next reply | `internal/compose/extingress.go` (`refuseUnitIdentity`) |
+| A unit cannot shadow a core channel provider: the collision is caught in the RECONCILE, where both sets exist, and fails the boot rather than silently re-routing that provider's replies through the unit | `internal/compose/channelprovider.go` |
+| A `Send` without a `Live` is refused, and the core asks `Live` BEFORE handing over a message — a disconnected member parks where a human can see it, an unreachable provider is retried | `backend/pkg/extension/channel.go`, `internal/compose/extchannelsend.go` |
 | A unit's listener consumes only the streams its declared event types route to, and no core group consumes the extension stream | `internal/compose/extsubscribe.go`, `internal/shared/kernel/events/extensiontypes_test.go` |
 | A subscription naming an event type nothing can route is refused at boot, rather than registering a consumer group that never delivers | `internal/compose/extensions.go` (`preflightSubscriptions`) |
 | A core write is refused in an overlay workspace rather than landing in a native table nothing reads, resolved FRESH per write | `internal/compose/extcore.go` (`admit` → `overlayModeOf`) |
@@ -396,6 +477,10 @@ the whole path).
 |---|---|
 | The declaration type (`Extension`, `Name`, `Version`) | `backend/pkg/extension/extension.go` |
 | The jurisdiction-pack contract | `backend/pkg/extension/jurisdiction/jurisdiction.go` |
+| The ingress record, its bounds, and the merge-key vocabulary | `backend/pkg/extension/ingress.go`, `mergekey.go` |
+| The channel contract (`Channel`, `MessageSender`, `ConnectionLiveChecker`) | `backend/pkg/extension/channel.go` |
+| The ingress gate and the send path the core drives | `backend/internal/compose/extingress.go`, `extchannelsend.go` |
+| Channel-provider registration and the core-collision check | `backend/internal/compose/channelprovider.go` |
 | The core-internal jurisdiction registry (aliases the published types) | `backend/internal/shared/ports/jurisdiction/jurisdiction.go` |
 | Boot reconciliation (validate-then-apply) | `backend/internal/compose/extensions.go` |
 | Served-tool adaptation into the core MCP seam | `backend/internal/compose/extensiontools.go` |
@@ -406,6 +491,7 @@ the whole path).
 | The first-party German pack | `extensions/de/de.go` |
 | The reference served-tool unit | `extensions/yogi/yogi.go` |
 | The reference extension (every capability) | `extensions/notes/notes.go` |
+| The reference connector: ingress, merge key, transport | `extensions/dispact-connector/dispact.go`, `record.go`, `send.go` |
 | Its screen, in the unit's own workspace package | `extensions/notes/frontend/screen.tsx` |
 | That screen's tests, and the lane that runs them | `extensions/notes/frontend/screen.test.tsx`, `frontend/vitest.ext.config.ts` |
 | The reference fixture | `fixtures/extensions/crm-hello/crmhello.go` |
@@ -419,5 +505,8 @@ the whole path).
 - [privacy-and-consent.md](privacy-and-consent.md) — the retention engine that consumes a pack.
 - [composition-layer.md](composition-layer.md) — how `compose` boots and wires the composed set.
 - [agent-surface.md](agent-surface.md) — the registry and admission gate a served extension tool joins.
+- [ingress-gate-and-auto-capture.md](ingress-gate-and-auto-capture.md) — what the core does with a
+  record a unit lands, including the merge-key declaration and the channel path.
+- [outbound-messaging.md](outbound-messaging.md) — the reply path that ends at a unit's `Channel.Send`.
 - [frontend-architecture.md](frontend-architecture.md) — the SPA an extension frontend slice would extend.
 - [reference/make-targets.md](../reference/make-targets.md) — `composition`, `check-composition`, `test-extensions`.

--- a/docs/how-to/add-an-extension.md
+++ b/docs/how-to/add-an-extension.md
@@ -1,7 +1,8 @@
 # Add an extension (a stable-tier unit)
 
 For shipping a bounded add-on — a **jurisdiction pack**, a **governed agent tool**, an **HTTP surface**,
-its **own tables**, its **own secrets** or a **scheduled job** — as a named, versioned unit under
+its **own tables**, its **own secrets**, a **scheduled job**, a **reaction to events**, **capture from
+its own provider**, or a **messaging transport** — as a named, versioned unit under
 `extensions/<name>/`, without editing any upstream-owned file — with one exception: a unit that ships a
 `frontend/` with npm dependencies of its own also changes the root `pnpm-lock.yaml`, and that lockfile
 diff is reviewed on the same terms as the unit's Go (see
@@ -12,16 +13,18 @@ specifically, the live capability is retention floors; the running example below
 
 An extension is its own Go module reaching the core through only the marker-allowlisted
 `backend/pkg/**` surface. **Presence under `extensions/` is the enablement** — there is no flag to
-flip. `extensions/notes` is the **reference unit** and exercises every capability below — copy it when your
-unit owns data or serves routes. `extensions/de` (a jurisdiction pack), `extensions/yogi` (one served
-agent tool) and `fixtures/extensions/crm-hello` (the walking-skeleton) are the smaller shapes.
+flip. `extensions/notes` is the **reference unit** for a unit that owns data or serves routes — copy it
+first. `extensions/dispact-connector` is the reference for a unit that faces an outside provider:
+capture, a merge-key declaration, and a transport replies leave on. `extensions/de` (a jurisdiction
+pack), `extensions/yogi` (one served agent tool) and `fixtures/extensions/crm-hello` (the
+walking-skeleton) are the smaller shapes.
 
 A unit owns **all six** surfaces, frontend included: `extensions/<name>/frontend/` is a pnpm workspace
 package whose default export the SPA mounts at `#/ext/<name>`. A unit that ships none still gets a
 route and a generic descriptor card automatically.
 
 Extension paths — the units, the `backend/pkg/**` seam, the composition stub and generator — carry
-a [CODEOWNERS](../../.github/CODEOWNERS) entry, so a PR touching them automatically requests the
+a [CODEOWNERS](../../CODEOWNERS) entry, so a PR touching them automatically requests the
 tier owner's review.
 
 ## Scaffold the unit
@@ -80,10 +83,10 @@ tier owner's review.
    	}
    }
    ```
-   **Import only `backend/pkg/**` packages carrying `//margince:extension-surface`** — `pkg/extension`
-   and `pkg/extension/jurisdiction` today. Any import of `internal/**`, `cmd/**`, an unmarked `pkg`
-   package, the composition module, or a sibling extension fails the arch test (the compiler already
-   makes `internal/**` unreachable — the test holds the rest).
+   **Import only `backend/pkg/**` packages carrying `//margince:extension-surface`** — `pkg/extension`,
+   `pkg/extension/jurisdiction` and `pkg/extension/crm` today. Any import of `internal/**`, `cmd/**`, an
+   unmarked `pkg` package, the composition module, or a sibling extension fails the arch test (the
+   compiler already makes `internal/**` unreachable — the test holds the rest).
 
 ## Stay inside the declared vocabularies
 
@@ -418,6 +421,122 @@ it cannot request an outbound scope; both are refused at boot.
 > and the count is reported as `margince_extension_job_seatless_workspaces` on the worker's
 > `/metrics`. Do not treat a silent job as a broken one without reading that gauge first.
 
+## React to events
+
+A `Subscription` names the event types the unit listens for and the function one delivery runs:
+
+```go
+Subscriptions: []extension.Subscription{
+	{Name: "withdraw_filing", Events: []string{"activity.archived"}, Handle: withdrawFiling},
+},
+```
+
+```go
+func withdrawFiling(ctx context.Context, rt extension.Runtime, d extension.Delivery) error
+```
+
+`Delivery` carries the event id, its type, when it occurred, the entity it names, and the raw payload.
+Each subscription gets its own consumer group (`cg:ext-<unit>-<subscription>`), started in the worker
+role. What to design for:
+
+- **A delivery has nobody behind it.** The caller is the zero `Caller`, so `tx.Core()` refuses. Your
+  own tables stay writable, auditable and publishable.
+- **The bus is at-least-once.** The core suppresses the redelivery it can see (the same event to the
+  same subscription), but that is a cache and it cannot cover a crash between your effect and the ack.
+  Make the handler safe to run twice, keyed on `EventID`.
+- **Your return value decides redelivery.** An error leaves the entry pending and it comes back; `nil`
+  acks it. So a delivery you can never process — a malformed payload, a subject you do not recognise —
+  returns `nil` and logs, rather than failing forever on something no retry can fix.
+- **A type nothing can route is refused at boot**, rather than registering a consumer group that never
+  delivers. You may name a core type or another unit's (`ext_<namespace>.<verb>`).
+- **The list is public.** It derives into `manifest.generated.json`, so which of the installation's
+  facts your unit consumes is readable without opening its source.
+
+## Capture records from your own provider
+
+Declare the providers you bring records in from. `System` is the unit's own stable key for the
+provider, and the core stamps it into every landed record's provenance:
+
+```go
+Ingress: []extension.IngressSource{{
+	System: "dispact",                                    // lower kebab, ≤32 chars, STABLE
+	Lands:  []extension.RecordKind{extension.KindActivity},
+	Merges: []extension.MergeKey{extension.MergeKeyEmail}, // optional; see below
+}},
+```
+
+Then hand one record at a time to the core's own capture pipeline:
+
+```go
+res, err := rt.Ingest(ctx, member, rec) // res.Disposition is Accepted or Skipped
+```
+
+You assemble no timeline entry and could not — you hand over a record and the core decides what
+becomes of it. The rules that will otherwise bite:
+
+- **`Ingest` hangs off `Runtime`, not `Tx`.** The pipeline opens its own transaction, so calling it
+  from inside yours takes a second connection while holding one — on a small pool that hangs rather
+  than fails. `ErrNestedIngest` makes it a sentence instead.
+- **Unattended only.** An ingest from an invocation that has a caller is refused
+  (`ErrAttendedIngest`): two authorities would be in play. Do it from your job tick.
+- **You act for a member, on their live authority.** The member named in `on` must currently hold one
+  of your unit's user-scoped secrets — depositing a credential is the act that says "act for me here".
+  A member demoted since they connected narrows what their connection can land, from the next call on.
+- **`Key` must be identical on every re-read.** It is the idempotency key. Derive it from the
+  provider's own id, never from a timestamp, a page position or your own row id — the failure mode is a
+  duplicate on every poll, and **nothing reports an error**.
+- **Both dispositions advance your cursor.** `Skipped` means the core deliberately kept nothing and
+  logged why (a wholly-internal message). Treating it as a failure retries a deliberate drop forever.
+- **`Merges` is what your source VOUCHES for**, and it is empty by default. Declare
+  `MergeKeyEmail` only if your provider's address for a person is authoritative — a directory your
+  administrator maintains, not a string the user typed about themselves. It lets an address carried
+  alongside a channel account be *matched* on, so a colleague already captured from mail is recognised
+  instead of becoming a second contact. Without the declaration, a record carrying both is refused at
+  the gate.
+
+Supply every field your provider gives you and decide nothing about identity: which fields the core's
+resolution ladder may match on is the core's call, read from your declaration. What each field must
+contain, and what breaks when it does not, is the connector contract in
+[explanation/ingress-gate-and-auto-capture.md](../explanation/ingress-gate-and-auto-capture.md).
+
+## Carry replies — supply a transport
+
+A `Channel` declares a messaging provider your unit can carry messages on, so a rep's reply to a
+conversation you captured leaves through your unit rather than a surface of your own:
+
+```go
+Channels: []extension.Channel{{Provider: "dispact", Send: send, Live: live}},
+```
+
+```go
+func send(ctx context.Context, rt extension.Runtime, msg extension.OutboundMessage) (extension.Receipt, error)
+func live(ctx context.Context, rt extension.Runtime, member extension.UserID) (bool, error)
+```
+
+**Your unit never sends on its own initiative — it declares a transport and the core calls it.** A
+human stages the message through the timeline reply box, the seat gate re-reads them, and the
+dispatcher then hands you an `OutboundMessage` (the member to send as, the recipient's channel
+identity, the body, what it replies to, and an idempotency key). Return a `Receipt` naming the
+provider's own message id. The tier's outbound refusals are untouched by this: you still may not spend
+an outbound cap from a tool or a job tick.
+
+- **`Provider` takes `channel_provider`'s grammar, which is SNAKE** (`^[a-z][a-z0-9_]*$`, ≤32) — not
+  the ingress system's kebab. `deal-room` is a legal ingress system and an illegal provider.
+- **`Live` is required whenever `Send` is present.** It answers, for one member and *without spending
+  the credential*, whether the connection is still usable. Answer `false` for a confirmed "no" — the
+  delivery parks where a human can see it. Return an **error** when you could not tell — it is
+  retried. Collapsing the two either strands a message or sends it twice.
+- **A nil `Send` is the capture-only case**, and it is documented rather than accidental: a reply
+  attempt is answered with the deployment fact instead of a fault.
+- **You name the transport, never the activity kind.** A message you file lands as `message` with your
+  provider on the transport column; the kind is the core's (ADR-0107/A158).
+- **You cannot shadow a core provider.** Declaring `telegram` fails the boot: every Telegram reply
+  would otherwise leave on your per-member credential instead of the workspace's bot, which looks
+  identical on screen.
+
+Set `Activity.ChannelProvider` on the records you capture on that transport — a message with no
+transport cannot be replied to on anything, and the gate refuses it.
+
 ## Write the unit's own test
 
 Each unit is its own Go module, so the backend's `./...` never reaches it — it carries its own tests,
@@ -447,12 +566,16 @@ have to regenerate the composition and run the gates:
    in the generated `Extensions()`, and a `manifest.generated.json` lands next to your unit — the
    statically derived record of the **risk tiers** it requests (the 🟢/🟡 operations and scopes an
    operator must approve under §7; a jurisdiction-only unit requests none, so its list is empty).
+   — plus what the unit **reaches**: its `secrets`, `subscriptions`, `ingress` (with the identity keys
+   the source vouches for) and `channels` (with `supplies_transport`).
    Commit it with the unit; the drift gate fails a stale or hand-edited one. Derivation reads your
-   `New()` from the AST, so the returned `extension.Extension` literal and the fields it derives
-   (`Name`, `Version`, `Tools`) must be literal values or the published `extension` constants
-   (`extension.TierAutoExecute`, `extension.ScopeRead`, …) — a computed value, or a field the
-   generator does not recognize, fails generation with the file and line rather than silently
-   dropping a request. (Every build/test lane depends on this target, so `make check` runs it for
+   `New()` from the AST, so the returned `extension.Extension` literal and every field it derives must
+   be literal values or the published `extension` constants (`extension.TierAutoExecute`,
+   `extension.ScopeRead`, `extension.MergeKeyEmail`, …) — a computed value, or a field the generator
+   does not recognize, fails generation with the file and line rather than silently dropping a
+   request. This is why a connector spells its provider string twice — once in `Ingress`, once in
+   `Channels` — rather than sharing a constant: the reader resolves none. Pin the two equal with a
+   test. (Every build/test lane depends on this target, so `make check` runs it for
    you; run it directly when you want to inspect the output.)
 2. **`make check`** — builds the composed workspace, runs the extension-tier fitness tests
    (import-boundary, marker placement, composition wiring), `make test-extensions` (your unit's own


### PR DESCRIPTION
## Why

`explanation/extensibility.md` and `how-to/add-an-extension.md` both predate the outward-facing half of the extension tier. Concretely they were wrong or silent about:

- **#1368** — a unit supplies a real messaging transport (`extension.Channel`), so a rep's reply leaves through the unit.
- **#1429** — an ingress source declares the identity keys it vouches for (`Merges` / `extension.MergeKey`).
- Older but never documented in the how-to: **subscriptions** (#1142) and **ingress** (#1196).

The explanation page still called `Jurisdictions` and `Tools` "the capabilities" (there are eight fields), counted two published packages (there are three), and said the vanilla tree ships three units (four).

## explanation/extensibility.md

- **Capability fields as a table**, all eight. The point of one field per kind is that adding one breaks no existing unit — naming two of them in prose said the opposite.
- **Channels** — a unit declares a transport and the core calls it, so the tier's outbound refusals are untouched. Covers the snake-vs-kebab provider grammar (`deal-room` is a legal ingress system and an illegal provider), nil `Send` as the documented capture-only case, `Live` required beside `Send`, transport-not-kind, and the boot-failing core collision.
- **Ingress** gains the merge-key declaration and a pointer to the ingress page.
- **The manifest section** gains the four reach keys an operator reads: `secrets`, `subscriptions`, `ingress` (with `merges`), `channels` (with `supplies_transport`) — and why a connector spells its provider twice instead of sharing a constant.
- **Five new guardrail rows** and new reference-table entries for `channel.go`, `mergekey.go`, `extchannelsend.go`, `channelprovider.go`, `dispact-connector`.
- Vanilla tree is four units, as a table.

## how-to/add-an-extension.md

Three new sections, written as the rules that bite rather than a tour:

- **React to events** — nobody behind a delivery so `tx.Core()` refuses; at-least-once with `EventID` as the key; an error redelivers where `nil` acks, so an unprocessable delivery returns `nil` and logs.
- **Capture records from your own provider** — `Ingest` hangs off `Runtime` because a nested call *hangs* rather than fails; unattended only; live member authority behind a deposited credential; a stable `Key` whose absence duplicates on every poll and **reports nothing**; both dispositions advance the cursor; when to declare `MergeKeyEmail`.
- **Carry replies — supply a transport** — the staged-by-a-human chain, `Live`'s two distinct answers (park vs retry), nil `Send`, and the core-provider collision.

Plus: the import line lists `pkg/extension/crm`, the manifest step lists every derived section, and the **CODEOWNERS link** is fixed — it has pointed at `.github/CODEOWNERS` since #587 moved the file to the repo root.

## Verification

Docs-only. Every shape was read from the tree at `origin/main`: the `Extension` fields from `pkg/extension/extension.go`, `Channel`/`MessageSender`/`ConnectionLiveChecker`/`Receipt` from `channel.go`, `IngressSource`/`Merges` from `ingress.go` + `mergekey.go`, `Subscription`/`Delivery`/`EventHandler` from `subscription.go`, the manifest keys from `tools/gen-composition/unitmanifest.go`, the marked packages by grepping `//margince:extension-surface`, and the declaration example from `extensions/dispact-connector/dispact.go`. Relative links checked; the only broken one found was the pre-existing CODEOWNERS path, now fixed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates extension-tier docs to include channels (unit-supplied transport) and ingress merge-key declarations, and adds missing guidance for subscriptions, ingress, and outbound messaging. This aligns the docs with current behavior so implementers avoid provider-grammar mistakes, idempotency bugs, and identity merge issues.

- explanation/extensibility.md: adds an 8-field capability table; clarifies `Channels` vs `Ingress`; documents channel semantics (unit declares transport, core calls it), provider grammar (snake for `channel_provider`), nil `Send` as capture-only, and `Live` required with `Send`; expands manifest to show `secrets`, `subscriptions`, `ingress` (with `merges`), and `channels` (with `supplies_transport`); adds guardrails and references; updates vanilla units to four including `extensions/dispact-connector`; lists `pkg/extension`, `pkg/extension/jurisdiction`, and `pkg/extension/crm` as published surface.
- how-to/add-an-extension.md: adds “React to events” (at-least-once, `EventID` idempotency, error redelivers, nil acks), “Capture from your provider” (`Runtime.Ingest`, unattended only, live member authority, stable `Key`, both dispositions advance, declare `MergeKeyEmail` when authoritative), and “Carry replies” (`Channel` provider snake grammar, `Live` required, nil `Send`, name transport not kind, cannot shadow core providers); includes `pkg/extension/crm` in imports and fixes the CODEOWNERS link.

**Review notes**
- Docs-only; verify new links (`ingress-gate-and-auto-capture.md`, `outbound-messaging.md`) resolve and the CODEOWNERS path points to `/CODEOWNERS`.
- For future connector examples: use snake-case provider strings, set `Merges` only for authoritative identity keys, and require `Live` when implementing `Send`.

<sup>Written for commit 0323ed66cf1346cbd3c2a292582f7f29e0ba32eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1436?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

