### PR TITLE
fix(ai): anthropic and ollama carry the images their wires have always taken

### DIFF
--- a/backend/internal/modules/ai/anthropic.go
+++ b/backend/internal/modules/ai/anthropic.go
@@ -36,10 +36,13 @@ const anthropicAPIVersion = "2023-06-01"
 const anthropicMaxTokensDefault = 1024
 
 type anthropicWire struct {
-	Model        string                 `json:"model"`
-	MaxTokens    int                    `json:"max_tokens"`
-	System       string                 `json:"system,omitempty"`
-	Messages     []wireMessage          `json:"messages"`
+	Model     string `json:"model"`
+	MaxTokens int    `json:"max_tokens"`
+	System    string `json:"system,omitempty"`
+	// Messages is this adapter's own message type rather than a shared one:
+	// only here does a turn's body become an array of Anthropic content blocks
+	// once it carries an image (anthropicparts.go).
+	Messages     []anthropicMessage     `json:"messages"`
 	Tools        []anthropicToolWire    `json:"tools,omitempty"`
 	Stream       bool                   `json:"stream,omitempty"`
 	OutputConfig *anthropicOutputConfig `json:"output_config,omitempty"`
@@ -216,7 +219,11 @@ func (c *anthropicClient) Embed(context.Context, model.EmbedRequest) (model.Embe
 }
 
 func (c *anthropicClient) Caps() model.Capabilities {
-	return model.Capabilities{Streaming: true, EmbedDims: 0, LocalOnly: false, AttachmentMIMEs: carriesNothing}
+	// AttachmentMIMEs stops at images deliberately: the Messages API's document
+	// block exists, but which models accept one is a per-model fact this adapter
+	// cannot see, and advertising a lane a bound model refuses is worse than not
+	// advertising it at all.
+	return model.Capabilities{Streaming: true, EmbedDims: 0, LocalOnly: false, AttachmentMIMEs: carriesImages}
 }
 
 // post sends one non-streaming Messages call; postStream opens the SSE
@@ -253,17 +260,18 @@ func (c *anthropicClient) send(ctx context.Context, req model.Request, stream bo
 // status (0 on a transport-level failure) so send can distinguish a
 // schema-rejection 400 from a transport error.
 func (c *anthropicClient) sendOnce(ctx context.Context, req model.Request, stream bool) (io.ReadCloser, int, error) {
-	// Anthropic is natively capable of image/document blocks; mapping them is a
-	// cheap follow-up. Phase-1 ships the honest reject-guard so the uniform
-	// Attachments field can never silently drop (spec §3.8, "the guard is the floor").
-	if err := attachmentUnsupported("anthropic", req.Attachments, carriesNothing); err != nil {
+	// Images map to native content blocks; a PDF does not, because
+	// `document` support is model-dependent here in a way image support is not,
+	// and this adapter cannot see which model the binding named. Anything outside
+	// the declaration is refused rather than dropped (spec §3.8).
+	if err := anthropicRefuseAttachments(req.Attachments); err != nil {
 		return nil, 0, err
 	}
 	wire := anthropicWire{
 		Model:     req.Model,
 		MaxTokens: req.MaxTokens,
 		System:    req.System,
-		Messages:  wireMessages("", req.Messages),
+		Messages:  anthropicMessages(req.Messages, req.Attachments),
 		Stream:    stream,
 	}
 	if wire.Model == "" {

--- a/backend/internal/modules/ai/anthropicparts.go
+++ b/backend/internal/modules/ai/anthropicparts.go
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package ai
+
+// The Messages API's message body, which is two JSON shapes wearing one name: a
+// bare string for an ordinary turn, an ordered array of typed blocks once the
+// turn carries an image.
+//
+// Both shapes are spelled here for the same reason the OpenAI-compatible wire
+// spells both (openaicompatparts.go): a text-only call must keep marshalling to
+// the bare string it has always sent rather than change shape to buy an image
+// lane.
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+
+	"github.com/gradionhq/margince/backend/internal/shared/ports/model"
+)
+
+// The block types this wire spells. Deliberately not modalityText/modalityImage:
+// those are the routing config's vocabulary, and one shared constant would turn
+// the two happening to coincide into a dependency between a wire format and an
+// operator-facing word.
+const (
+	anthropicBlockText  = "text"
+	anthropicBlockImage = "image"
+)
+
+type anthropicMessage struct {
+	Role    string           `json:"role"`
+	Content anthropicContent `json:"content"`
+}
+
+// anthropicContent holds whichever shape the turn needs. Blocks win when
+// present; otherwise the body is Text.
+type anthropicContent struct {
+	Text   string
+	Blocks []anthropicBlock
+}
+
+// MarshalJSON emits the string form for a turn with no blocks, which is
+// byte-for-byte what a plain `string` field produced before attachments existed.
+func (c anthropicContent) MarshalJSON() ([]byte, error) {
+	if len(c.Blocks) == 0 {
+		return json.Marshal(c.Text)
+	}
+	return json.Marshal(c.Blocks)
+}
+
+// anthropicBlock is one block of a multi-block turn. Text and Source are
+// mutually exclusive and Type says which is set, so both are omitempty.
+type anthropicBlock struct {
+	Type   string                `json:"type"` // "text" | "image"
+	Text   string                `json:"text,omitempty"`
+	Source *anthropicImageSource `json:"source,omitempty"`
+}
+
+// anthropicImageSource is the image block's source, in either of the two
+// spellings the API accepts: inline base64 with its media type, or a URL the
+// API fetches. MediaType/Data belong to the first, URL to the second.
+type anthropicImageSource struct {
+	Type      string `json:"type"` // "base64" | "url"
+	MediaType string `json:"media_type,omitempty"`
+	Data      string `json:"data,omitempty"`
+	URL       string `json:"url,omitempty"`
+}
+
+// anthropicMessages builds the wire's message list, attaching any images to the
+// last user turn.
+//
+// No system turn: Anthropic carries the system prompt in its own top-level
+// field, so unlike the Ollama and OpenAI-compatible shapes this list is the
+// conversation alone. Attachments belong to a user turn — the same placement
+// every other adapter here uses, because they must not disagree about where in a
+// conversation a document sits.
+func anthropicMessages(msgs []model.Message, atts []model.Attachment) []anthropicMessage {
+	out := make([]anthropicMessage, 0, len(msgs))
+	for _, m := range msgs {
+		out = append(out, anthropicMessage{Role: m.Role, Content: anthropicContent{Text: m.Content}})
+	}
+	if len(atts) == 0 {
+		return out
+	}
+	idx := len(out) - 1
+	for idx >= 0 && out[idx].Role != roleUser {
+		idx--
+	}
+	if idx < 0 {
+		out = append(out, anthropicMessage{Role: roleUser})
+		idx = len(out) - 1
+	}
+	// Promoting the turn's text to a leading block keeps it beside the image
+	// rather than losing it: once Blocks is non-empty the string form is gone.
+	target := &out[idx]
+	if target.Content.Text != "" {
+		target.Content.Blocks = append(target.Content.Blocks, anthropicBlock{Type: anthropicBlockText, Text: target.Content.Text})
+	}
+	for _, a := range atts {
+		target.Content.Blocks = append(target.Content.Blocks, anthropicImageBlock(a))
+	}
+	return out
+}
+
+// anthropicImageBlock maps one attachment to an image block. Only images reach
+// it: carriage is decided by attachmentUnsupported against carriesImages, which
+// admits nothing else.
+func anthropicImageBlock(a model.Attachment) anthropicBlock {
+	if a.URI != "" {
+		return anthropicBlock{Type: anthropicBlockImage, Source: &anthropicImageSource{Type: "url", URL: a.URI}}
+	}
+	return anthropicBlock{Type: anthropicBlockImage, Source: &anthropicImageSource{
+		Type:      "base64",
+		MediaType: a.MIME,
+		Data:      base64.StdEncoding.EncodeToString(a.Bytes),
+	}}
+}
+
+// anthropicRefuseAttachments is the map-or-reject gate for this wire
+// (spec §3.8): the carriage check every adapter runs, plus the one URI shape
+// this wire cannot express.
+//
+// A URI attachment is a URL or a provider file handle. Anthropic fetches an
+// https URL itself, so that half maps. A handle would be its Files API
+// (`source.type: "file"`), which the endpoint serves only to a request carrying
+// the Files beta header this adapter does not send — so a handle is refused
+// rather than mapped to a block the vendor would reject for a reason that names
+// the wrong thing.
+func anthropicRefuseAttachments(atts []model.Attachment) error {
+	if err := attachmentUnsupported("anthropic", atts, carriesImages); err != nil {
+		return err
+	}
+	for _, a := range atts {
+		if a.URI != "" && !isFetchableURL(a.URI) {
+			return errUnfetchableAttachmentURI("anthropic", "an http(s) url the api fetches itself, or inline bytes")
+		}
+	}
+	return nil
+}
+
+// isFetchableURL reports whether a URI is one a vendor that fetches its own
+// attachments can resolve, as opposed to a handle scoped to some other provider.
+func isFetchableURL(uri string) bool {
+	return strings.HasPrefix(uri, "https://") || strings.HasPrefix(uri, "http://")
+}

--- a/backend/internal/modules/ai/anthropicparts.go
+++ b/backend/internal/modules/ai/anthropicparts.go
@@ -15,7 +15,6 @@ package ai
 import (
 	"encoding/base64"
 	"encoding/json"
-	"strings"
 
 	"github.com/gradionhq/margince/backend/internal/shared/ports/model"
 )
@@ -27,6 +26,10 @@ import (
 const (
 	anthropicBlockText  = "text"
 	anthropicBlockImage = "image"
+	// The two spellings an image block's source takes: bytes the request
+	// carries, or a URL the API fetches for itself.
+	anthropicSourceBase64 = "base64"
+	anthropicSourceURL    = "url"
 )
 
 type anthropicMessage struct {
@@ -109,10 +112,10 @@ func anthropicMessages(msgs []model.Message, atts []model.Attachment) []anthropi
 // admits nothing else.
 func anthropicImageBlock(a model.Attachment) anthropicBlock {
 	if a.URI != "" {
-		return anthropicBlock{Type: anthropicBlockImage, Source: &anthropicImageSource{Type: "url", URL: a.URI}}
+		return anthropicBlock{Type: anthropicBlockImage, Source: &anthropicImageSource{Type: anthropicSourceURL, URL: a.URI}}
 	}
 	return anthropicBlock{Type: anthropicBlockImage, Source: &anthropicImageSource{
-		Type:      "base64",
+		Type:      anthropicSourceBase64,
 		MediaType: a.MIME,
 		Data:      base64.StdEncoding.EncodeToString(a.Bytes),
 	}}
@@ -138,10 +141,4 @@ func anthropicRefuseAttachments(atts []model.Attachment) error {
 		}
 	}
 	return nil
-}
-
-// isFetchableURL reports whether a URI is one a vendor that fetches its own
-// attachments can resolve, as opposed to a handle scoped to some other provider.
-func isFetchableURL(uri string) bool {
-	return strings.HasPrefix(uri, "https://") || strings.HasPrefix(uri, "http://")
 }

--- a/backend/internal/modules/ai/anthropicparts_test.go
+++ b/backend/internal/modules/ai/anthropicparts_test.go
@@ -4,8 +4,10 @@
 package ai
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
+	"net/http"
 	"strings"
 	"testing"
 
@@ -36,13 +38,47 @@ func TestAnthropicTextOnlyTurnsMarshalToBareStrings(t *testing.T) {
 	}
 }
 
-// The system prompt is Anthropic's own top-level field, so it must NOT appear as
-// a leading turn the way it does on the Ollama and OpenAI-compatible shapes —
-// sending it twice would put the instructions in the conversation as well.
-func TestAnthropicMessagesCarryNoSystemTurn(t *testing.T) {
-	msgs := anthropicMessages([]model.Message{{Role: roleUser, Content: "hello"}}, nil)
-	if len(msgs) != 1 || msgs[0].Role != roleUser {
-		t.Fatalf("want the conversation alone, got %+v", msgs)
+// The system prompt is Anthropic's own top-level field, so it must NOT also
+// appear as a leading turn the way it does on the Ollama and OpenAI-compatible
+// shapes — sending it twice would put the instructions in the conversation.
+//
+// Asserted on the assembled WIRE rather than on anthropicMessages, which is
+// never handed the system prompt at all and so would agree with itself.
+func TestAnthropicSendsTheSystemPromptAsItsOwnFieldNotATurn(t *testing.T) {
+	var sent []byte
+	client := newAnthropicForTest(t, func(w http.ResponseWriter, r *http.Request) {
+		sent = readBody(t, r.Body)
+		if err := json.NewEncoder(w).Encode(map[string]any{
+			"content": []map[string]any{{"type": "text", "text": "ok"}},
+		}); err != nil {
+			t.Errorf("encoding fixture response: %v", err)
+		}
+	})
+	if _, err := client.Complete(context.Background(), model.Request{
+		System:   "be brief",
+		Messages: []model.Message{{Role: roleUser, Content: "hello"}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	var wire struct {
+		System   string `json:"system"`
+		Messages []struct {
+			Role string `json:"role"`
+		} `json:"messages"`
+	}
+	if err := json.Unmarshal(sent, &wire); err != nil {
+		t.Fatalf("wire not JSON: %v (%s)", err, sent)
+	}
+	if wire.System != "be brief" {
+		t.Errorf("the system prompt must ride the top-level field, got %q", wire.System)
+	}
+	for _, m := range wire.Messages {
+		if m.Role == roleSystem {
+			t.Fatalf("the conversation must carry no system turn: %s", sent)
+		}
+	}
+	if len(wire.Messages) != 1 {
+		t.Errorf("want the one user turn, got %d messages: %s", len(wire.Messages), sent)
 	}
 }
 
@@ -127,5 +163,25 @@ func TestAnthropicRefusesAnAttachmentURIItCannotResolve(t *testing.T) {
 		{MIME: "image/png", URI: "https://files.example/a.png"},
 	}); err != nil {
 		t.Errorf("an https url is fetchable and must be carried, got %v", err)
+	}
+}
+
+// Both halves of "is this a URL the vendor fetches" are decided here, and both
+// mistakes a prefix test makes are silent: a scheme with no host would go out as
+// a URL nothing can fetch, and a capitalized scheme — which URLs are
+// case-insensitive in — would be taken for a file handle.
+func TestAFetchableURLIsParsedNotPrefixMatched(t *testing.T) {
+	for uri, want := range map[string]bool{
+		"https://files.example/a.png": true,
+		"http://files.example/a.png":  true,
+		"HTTPS://files.example/a.png": true,
+		"https://":                    false,
+		"file-abc123":                 false,
+		"s3://bucket/key":             false,
+		"":                            false,
+	} {
+		if got := isFetchableURL(uri); got != want {
+			t.Errorf("isFetchableURL(%q) = %v, want %v", uri, got, want)
+		}
 	}
 }

--- a/backend/internal/modules/ai/anthropicparts_test.go
+++ b/backend/internal/modules/ai/anthropicparts_test.go
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package ai
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/ports/model"
+)
+
+// The no-regression pin. A request carrying no attachment must marshal to
+// exactly the bytes this adapter sent before content blocks existed: `"content"`
+// a bare string. Written as literal expected JSON rather than as a round-trip,
+// because a round-trip through the same type would agree with itself whatever it
+// emits.
+func TestAnthropicTextOnlyTurnsMarshalToBareStrings(t *testing.T) {
+	got, err := json.Marshal(anthropicMessages([]model.Message{
+		{Role: roleUser, Content: "hello"},
+		{Role: roleAssistant, Content: "hi"},
+		// An empty body is the case a shape change is most likely to alter: the
+		// old string field carried no omitempty, so "" went on the wire as "".
+		{Role: roleUser, Content: ""},
+	}, nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	const want = `[{"role":"user","content":"hello"},` +
+		`{"role":"assistant","content":"hi"},` +
+		`{"role":"user","content":""}]`
+	if string(got) != want {
+		t.Fatalf("text-only wire changed shape\n got: %s\nwant: %s", got, want)
+	}
+}
+
+// The system prompt is Anthropic's own top-level field, so it must NOT appear as
+// a leading turn the way it does on the Ollama and OpenAI-compatible shapes —
+// sending it twice would put the instructions in the conversation as well.
+func TestAnthropicMessagesCarryNoSystemTurn(t *testing.T) {
+	msgs := anthropicMessages([]model.Message{{Role: roleUser, Content: "hello"}}, nil)
+	if len(msgs) != 1 || msgs[0].Role != roleUser {
+		t.Fatalf("want the conversation alone, got %+v", msgs)
+	}
+}
+
+func TestAnthropicImageBecomesABase64BlockOnTheLastUserTurn(t *testing.T) {
+	msgs := anthropicMessages([]model.Message{
+		{Role: roleUser, Content: "first"},
+		{Role: roleAssistant, Content: "answered"},
+		{Role: roleUser, Content: "read this"},
+	}, []model.Attachment{{MIME: "image/png", Bytes: []byte("PNG")}})
+
+	if len(msgs) != 3 {
+		t.Fatalf("want 3 messages, got %d", len(msgs))
+	}
+	for _, i := range []int{0, 1} {
+		if len(msgs[i].Content.Blocks) != 0 {
+			t.Fatalf("message %d must keep its string body, got blocks %v", i, msgs[i].Content.Blocks)
+		}
+	}
+	blocks := msgs[2].Content.Blocks
+	if len(blocks) != 2 {
+		t.Fatalf("want the turn's text plus the image, got %d blocks", len(blocks))
+	}
+	// The turn's own text is promoted to a leading block rather than dropped:
+	// once Blocks is non-empty the string body no longer reaches the wire.
+	if blocks[0].Type != "text" || blocks[0].Text != "read this" {
+		t.Errorf("the turn's text must survive as a block, got %+v", blocks[0])
+	}
+	src := blocks[1].Source
+	if blocks[1].Type != "image" || src == nil {
+		t.Fatalf("want an image block, got %+v", blocks[1])
+	}
+	if src.Type != "base64" || src.MediaType != "image/png" || src.Data != "UE5H" {
+		t.Errorf("inline bytes must become a base64 source, got %+v", src)
+	}
+	// The base64 rides the `data` field, never a data: URL — that spelling is the
+	// OpenAI-compatible wire's, and this API rejects it.
+	if strings.Contains(src.Data, "data:") {
+		t.Errorf("the base64 source must not carry a data: prefix, got %q", src.Data)
+	}
+}
+
+// An https URI maps to the API's url source, which the vendor fetches itself.
+func TestAnthropicImageURIBecomesAURLSource(t *testing.T) {
+	msgs := anthropicMessages([]model.Message{{Role: roleUser, Content: "x"}},
+		[]model.Attachment{{MIME: "image/png", URI: "https://files.example/a.png"}})
+	src := msgs[0].Content.Blocks[1].Source
+	if src == nil || src.Type != "url" || src.URL != "https://files.example/a.png" {
+		t.Fatalf("a URI attachment must ride as a url source, got %+v", src)
+	}
+	if src.Data != "" || src.MediaType != "" {
+		t.Errorf("a url source carries neither data nor a media type, got %+v", src)
+	}
+}
+
+// Attachments belong to a user turn. A request whose messages hold none — the
+// system prompt travels elsewhere on this wire — gets one created rather than
+// the image being hung off an assistant turn.
+func TestAnthropicAttachmentWithNoUserTurnGetsOne(t *testing.T) {
+	msgs := anthropicMessages(nil, []model.Attachment{{MIME: "image/png", Bytes: []byte("PNG")}})
+	if len(msgs) != 1 || msgs[0].Role != roleUser {
+		t.Fatalf("want one created user turn, got %+v", msgs)
+	}
+	// Nothing to promote: an empty body must not become an empty text block.
+	if len(msgs[0].Content.Blocks) != 1 || msgs[0].Content.Blocks[0].Type != "image" {
+		t.Errorf("want only the image block, got %+v", msgs[0].Content.Blocks)
+	}
+}
+
+// A URI this wire cannot resolve is refused as a carriage failure, not mapped to
+// a url source the vendor would reject for a reason naming the wrong thing.
+func TestAnthropicRefusesAnAttachmentURIItCannotResolve(t *testing.T) {
+	err := anthropicRefuseAttachments([]model.Attachment{{MIME: "image/png", URI: "file-abc123"}})
+	if !errors.Is(err, model.ErrAttachmentUnsupported) {
+		t.Fatalf("a file handle must be refused as unsupported carriage, got %v", err)
+	}
+	// The handle itself stays out of the message: a URI can be a signed URL, and
+	// an error is the wrong place for one.
+	if strings.Contains(err.Error(), "file-abc123") {
+		t.Errorf("the refusal must not echo the uri, got %q", err)
+	}
+	if err := anthropicRefuseAttachments([]model.Attachment{
+		{MIME: "image/png", URI: "https://files.example/a.png"},
+	}); err != nil {
+		t.Errorf("an https url is fetchable and must be carried, got %v", err)
+	}
+}

--- a/backend/internal/modules/ai/attachments_test.go
+++ b/backend/internal/modules/ai/attachments_test.go
@@ -17,11 +17,21 @@ import (
 	"github.com/gradionhq/margince/backend/internal/shared/ports/model"
 )
 
+// writeFixture writes a canned provider response, failing the test when the
+// write itself fails. A discarded Write turns a broken transport into a decode
+// error raised by the code under test, which is the wrong thing to read.
+func writeFixture(t *testing.T, w http.ResponseWriter, body string) {
+	t.Helper()
+	if _, err := w.Write([]byte(body)); err != nil {
+		t.Errorf("writing the fixture response: %v", err)
+	}
+}
+
 func TestEveryProviderMapsOrRejectsAttachmentsNeverSilentlyDrops(t *testing.T) {
 	t.Setenv("OPENAI_COMPATIBLE_API_KEY", "k") // openai_compatible reads its key from env
 	t.Setenv("ANTHROPIC_API_KEY", "k")
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"ok"}}]}`))
+		writeFixture(t, w, `{"choices":[{"message":{"content":"ok"}}]}`)
 	}))
 	defer srv.Close()
 
@@ -79,10 +89,10 @@ func TestAnthropicAndOllamaCarryImagesInTheirOwnWireSpelling(t *testing.T) {
 		// serialization bug in the code under test.
 		sent, readErr = io.ReadAll(r.Body)
 		if strings.HasPrefix(r.URL.Path, "/v1/messages") {
-			_, _ = w.Write([]byte(`{"model":"m","content":[{"type":"text","text":"ok"}]}`))
+			writeFixture(t, w, `{"model":"m","content":[{"type":"text","text":"ok"}]}`)
 			return
 		}
-		_, _ = w.Write([]byte(`{"model":"m","message":{"content":"ok"},"done":true}`))
+		writeFixture(t, w, `{"model":"m","message":{"content":"ok"},"done":true}`)
 	}))
 	defer srv.Close()
 
@@ -164,7 +174,7 @@ func TestDeclaredImageCarriageAcceptsImagesAndStillRejectsPDFs(t *testing.T) {
 		// would otherwise surface as an unmarshal error below and read as a
 		// serialization bug in the code under test.
 		sent, readErr = io.ReadAll(r.Body)
-		_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"ok"}}]}`))
+		writeFixture(t, w, `{"choices":[{"message":{"content":"ok"}}]}`)
 	}))
 	defer srv.Close()
 
@@ -256,7 +266,7 @@ func TestDeclaredCarriageIsWhatCapsAdvertises(t *testing.T) {
 func TestAttachmentBytesXorURIEnforced(t *testing.T) {
 	t.Setenv("OPENAI_API_KEY", "k")
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, _ = w.Write([]byte(`{"id":"r","status":"completed","output":[{"type":"message","content":[{"type":"output_text","text":"ok"}]}]}`))
+		writeFixture(t, w, `{"id":"r","status":"completed","output":[{"type":"message","content":[{"type":"output_text","text":"ok"}]}]}`)
 	}))
 	defer srv.Close()
 	client, err := SelectBrain(ProviderConfig{Provider: "openai", BaseURL: srv.URL, Model: "m"})
@@ -285,10 +295,10 @@ func TestNativeCloudProvidersCarryPDFAttachments(t *testing.T) {
 	t.Setenv("GEMINI_API_KEY", "k")
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.Contains(r.URL.Path, ":generateContent") {
-			_, _ = w.Write([]byte(`{"candidates":[{"content":{"parts":[{"text":"ok"}]},"finishReason":"STOP"}]}`))
+			writeFixture(t, w, `{"candidates":[{"content":{"parts":[{"text":"ok"}]},"finishReason":"STOP"}]}`)
 			return
 		}
-		_, _ = w.Write([]byte(`{"id":"r","status":"completed","output":[{"type":"message","content":[{"type":"output_text","text":"ok"}]}]}`))
+		writeFixture(t, w, `{"id":"r","status":"completed","output":[{"type":"message","content":[{"type":"output_text","text":"ok"}]}]}`)
 	}))
 	defer srv.Close()
 

--- a/backend/internal/modules/ai/attachments_test.go
+++ b/backend/internal/modules/ai/attachments_test.go
@@ -19,39 +19,131 @@ import (
 
 func TestEveryProviderMapsOrRejectsAttachmentsNeverSilentlyDrops(t *testing.T) {
 	t.Setenv("OPENAI_COMPATIBLE_API_KEY", "k") // openai_compatible reads its key from env
+	t.Setenv("ANTHROPIC_API_KEY", "k")
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"ok"}}]}`))
 	}))
 	defer srv.Close()
 
-	// None of these bindings declares carriage — ollama because its wire has
-	// none, the two OpenAI-compatible ones because they omit `input:` — so BOTH a
-	// document and an image must be rejected. Accepting an image nothing will
-	// carry is the silent drop this test exists to prevent.
-	cannotCarryAttachments := map[string]ProviderConfig{
-		"openai_compatible": {Provider: "openai_compatible", BaseURL: srv.URL, Model: "m"},
-		"ollama":            {Provider: "ollama", Model: "m", BaseURL: srv.URL},
-		"vllm":              {Provider: "vllm", Model: "m", BaseURL: srv.URL},
+	// What each binding must REFUSE, and every binding refuses something.
+	// The two OpenAI-compatible ones declare no `input:` here, so both kinds are
+	// outside their carriage; anthropic and ollama carry images from code and
+	// still refuse the document kind neither wire can spell for a model this
+	// adapter cannot see. Accepting a MIME nothing will carry is the silent drop
+	// this test exists to prevent.
+	mustRefuse := map[string]struct {
+		cfg   ProviderConfig
+		mimes []string
+	}{
+		"openai_compatible": {
+			cfg:   ProviderConfig{Provider: "openai_compatible", BaseURL: srv.URL, Model: "m"},
+			mimes: []string{"application/pdf", "image/png"},
+		},
+		"vllm": {
+			cfg:   ProviderConfig{Provider: "vllm", Model: "m", BaseURL: srv.URL},
+			mimes: []string{"application/pdf", "image/png"},
+		},
+		"ollama":    {cfg: ProviderConfig{Provider: "ollama", Model: "m", BaseURL: srv.URL}, mimes: []string{"application/pdf"}},
+		"anthropic": {cfg: ProviderConfig{Provider: "anthropic", Model: "m", BaseURL: srv.URL}, mimes: []string{"application/pdf"}},
 	}
-	for _, att := range []model.Attachment{
-		{MIME: "application/pdf", Bytes: []byte("%PDF")},
-		{MIME: "image/png", Bytes: []byte("PNG")},
-	} {
-		for name, cfg := range cannotCarryAttachments {
-			t.Run(name+"/"+att.MIME, func(t *testing.T) {
-				client, err := SelectBrain(cfg)
+	for name, tc := range mustRefuse {
+		for _, mime := range tc.mimes {
+			t.Run(name+"/"+mime, func(t *testing.T) {
+				client, err := SelectBrain(tc.cfg)
 				if err != nil {
 					t.Fatal(err)
 				}
 				_, err = client.Complete(context.Background(), model.Request{
 					Messages:    []model.Message{{Role: "user", Content: "read this"}},
-					Attachments: []model.Attachment{att},
+					Attachments: []model.Attachment{{MIME: mime, Bytes: []byte("bytes")}},
 				})
 				if !errors.Is(err, model.ErrAttachmentUnsupported) {
-					t.Fatalf("%s: want ErrAttachmentUnsupported for %s, got %v", name, att.MIME, err)
+					t.Fatalf("%s: want ErrAttachmentUnsupported for %s, got %v", name, mime, err)
 				}
 			})
 		}
+	}
+}
+
+// The carriage arm for the two wires whose image support is a property of the
+// WIRE rather than of the binding: each maps an image in its own spelling, and
+// "accepted" is only proved by the part arriving on the wire — a call that
+// dropped it would look identical from the caller's side.
+func TestAnthropicAndOllamaCarryImagesInTheirOwnWireSpelling(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "k")
+	var sent []byte
+	var readErr error
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Kept and asserted rather than dropped: a transport read failure here
+		// would otherwise surface as an unmarshal error below and read as a
+		// serialization bug in the code under test.
+		sent, readErr = io.ReadAll(r.Body)
+		if strings.HasPrefix(r.URL.Path, "/v1/messages") {
+			_, _ = w.Write([]byte(`{"model":"m","content":[{"type":"text","text":"ok"}]}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"model":"m","message":{"content":"ok"},"done":true}`))
+	}))
+	defer srv.Close()
+
+	png := model.Attachment{MIME: "image/png", Bytes: []byte("PNG")}
+	for name, tc := range map[string]struct {
+		cfg ProviderConfig
+		// wants is the literal fragment the mapped image must produce on that
+		// wire. Literal, because the two spellings are the point: an anthropic
+		// base64 source and an ollama bare-base64 images entry are not
+		// interchangeable, and a shared assertion would pass on either.
+		wants string
+	}{
+		"anthropic": {
+			cfg:   ProviderConfig{Provider: "anthropic", BaseURL: srv.URL, Model: "m"},
+			wants: `"source":{"type":"base64","media_type":"image/png","data":"UE5H"}`,
+		},
+		"ollama": {
+			cfg:   ProviderConfig{Provider: "ollama", BaseURL: srv.URL, Model: "m"},
+			wants: `"images":["UE5H"]`,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			client, err := SelectBrain(tc.cfg)
+			if err != nil {
+				t.Fatal(err)
+			}
+			sent, readErr = nil, nil
+			if _, err := client.Complete(context.Background(), model.Request{
+				Messages:    []model.Message{{Role: "user", Content: "read this"}},
+				Attachments: []model.Attachment{png},
+			}); err != nil {
+				t.Fatalf("%s must carry an image, got %v", name, err)
+			}
+			if readErr != nil {
+				t.Fatalf("reading the request body: %v", readErr)
+			}
+			if !strings.Contains(string(sent), tc.wants) {
+				t.Fatalf("the accepted image never reached the wire as %s\n got: %s", tc.wants, sent)
+			}
+		})
+	}
+}
+
+// Caps() and the send-time gate are one answer on these two wires as well: a
+// caller picks its lane off Caps(), so a provider advertising more than its gate
+// admits sends the caller down a lane that cannot work.
+func TestAnthropicAndOllamaAdvertiseTheImagesTheyCarry(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "k")
+	for name, cfg := range map[string]ProviderConfig{
+		"anthropic": {Provider: "anthropic", Model: "m"},
+		"ollama":    {Provider: "ollama", Model: "m"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			client, err := SelectBrain(cfg)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := client.Caps().AttachmentMIMEs; !slices.Equal(got, carriesImages) {
+				t.Fatalf("Caps().AttachmentMIMEs = %v, want %v", got, carriesImages)
+			}
+		})
 	}
 }
 

--- a/backend/internal/modules/ai/fake.go
+++ b/backend/internal/modules/ai/fake.go
@@ -228,10 +228,24 @@ func fakeWire(req model.Request) map[string]any {
 	return map[string]any{
 		"model":       req.Model,
 		"system":      req.System,
-		"messages":    wireMessages("", req.Messages),
+		"messages":    fakeMessageWire(req.Messages),
 		"tools":       req.Tools,
 		"attachments": fakeAttachmentWire(req.Attachments),
 	}
+}
+
+// fakeMessageWire renders the turns as the lowercase {role, content} pair every
+// real wire is some elaboration of. It is deliberately none of them: each real
+// adapter owns its own message type because each spells a carried image
+// differently, and the fake asserts nothing about those spellings — what it
+// mirrors is that the CONTENT of a turn reaches the payload the stripper runs
+// over.
+func fakeMessageWire(msgs []model.Message) []map[string]any {
+	out := make([]map[string]any, 0, len(msgs))
+	for _, m := range msgs {
+		out = append(out, map[string]any{"role": m.Role, "content": m.Content})
+	}
+	return out
 }
 
 // fakeAttachmentWire renders each carried attachment as its media type, its

--- a/backend/internal/modules/ai/fake.go
+++ b/backend/internal/modules/ai/fake.go
@@ -234,16 +234,26 @@ func fakeWire(req model.Request) map[string]any {
 	}
 }
 
-// fakeMessageWire renders the turns as the lowercase {role, content} pair every
-// real wire is some elaboration of. It is deliberately none of them: each real
+// fakeMessage renders one turn as the lowercase {role, content} pair every real
+// wire is some elaboration of. It is deliberately none of them: each real
 // adapter owns its own message type because each spells a carried image
 // differently, and the fake asserts nothing about those spellings — what it
 // mirrors is that the CONTENT of a turn reaches the payload the stripper runs
 // over.
-func fakeMessageWire(msgs []model.Message) []map[string]any {
-	out := make([]map[string]any, 0, len(msgs))
+//
+// A struct rather than a map, because field order is load-bearing here: the
+// fake's fallback completion is a hash OF THESE BYTES, and Go marshals map keys
+// in sorted order — so a map would silently re-order `role` after `content` and
+// change every deterministic answer this client gives.
+type fakeMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+func fakeMessageWire(msgs []model.Message) []fakeMessage {
+	out := make([]fakeMessage, 0, len(msgs))
 	for _, m := range msgs {
-		out = append(out, map[string]any{"role": m.Role, "content": m.Content})
+		out = append(out, fakeMessage{Role: m.Role, Content: m.Content})
 	}
 	return out
 }

--- a/backend/internal/modules/ai/fake_test.go
+++ b/backend/internal/modules/ai/fake_test.go
@@ -75,6 +75,24 @@ func TestFakeClientRunsStripperAndRecordsPayload(t *testing.T) {
 	}
 }
 
+// The fake's fallback completion is a hash of the payload bytes, so the payload
+// is not just something the stripper runs over: its exact spelling decides every
+// deterministic answer this client gives, across processes and across builds. A
+// turn must therefore keep marshalling `role` before `content` — which is why
+// the messages ride a struct and not a map, whose keys Go sorts.
+func TestFakeRecordedPayloadKeepsItsTurnFieldOrder(t *testing.T) {
+	fake := NewFakeClient()
+	if _, err := fake.Complete(context.Background(), model.Request{
+		Messages: []model.Message{{Role: roleUser, Content: "hello"}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	const want = `[{"role":"user","content":"hello"}]`
+	if got := string(fake.Calls()[0].Payload); !strings.Contains(got, want) {
+		t.Fatalf("the recorded turn changed shape\n got: %s\nwant it to contain: %s", got, want)
+	}
+}
+
 func TestFakeClientEmbedDeterministicUnitVectors(t *testing.T) {
 	ctx := context.Background()
 	fake := NewFakeClient()

--- a/backend/internal/modules/ai/ollama.go
+++ b/backend/internal/modules/ai/ollama.go
@@ -28,7 +28,7 @@ type ollamaClient struct {
 
 type ollamaWire struct {
 	Model    string           `json:"model"`
-	Messages []wireMessage    `json:"messages"`
+	Messages []ollamaMessage  `json:"messages"`
 	Tools    []ollamaToolWire `json:"tools,omitempty"`
 	Stream   bool             `json:"stream"`
 	Options  *ollamaOptions   `json:"options,omitempty"`
@@ -96,6 +96,20 @@ const ollamaContextBucket = 4096
 // wraps around each turn, which a byte count of the content alone cannot see.
 const ollamaPerMessageOverhead = 8
 
+// ollamaPerImageTokens is the window allowance one carried image is sized at.
+//
+// An image's cost is not a function of its byte length the way text's is: the
+// vision projector downsamples to a fixed patch grid, so a 200 KB photo and a
+// 4 MB scan of the same page occupy the same context. Sizing from bytes would
+// let the JPEG quality slider pick the runner's allocation, which is the same
+// mistake ollamaMaxContext exists to prevent for text.
+//
+// The figure is the whole-page end of what the common projectors charge — llava
+// spends 576 tokens on an image, Qwen-VL around 1.3k at its default tiling —
+// rounded up so a scan that tiles into more patches than average still fits
+// rather than pushing the prompt out of the window.
+const ollamaPerImageTokens = 2048
+
 // contextWindow sizes `num_ctx` for the assembled request.
 //
 // num_ctx bounds prompt AND completion together, while num_predict bounds only
@@ -115,13 +129,17 @@ const ollamaPerMessageOverhead = 8
 // between them decide the value that actually ships.
 func (w ollamaWire) contextWindow(maxTokens int) int {
 	prompt := len(w.Format)
+	images := 0
 	for _, message := range w.Messages {
 		prompt += len(message.Content) + len(message.Role) + ollamaPerMessageOverhead
+		images += len(message.Images)
 	}
 	for _, tool := range w.Tools {
 		prompt += len(tool.Function.Name) + len(tool.Function.Description) + len(tool.Function.Parameters)
 	}
-	return ollamaWindowFor(prompt/4 + maxTokens)
+	// Images are counted in tokens directly rather than through the byte
+	// heuristic: their base64 length says nothing about what they cost the model.
+	return ollamaWindowFor(prompt/4 + images*ollamaPerImageTokens + maxTokens)
 }
 
 // ollamaWindowFor rounds a token estimate up to a window this adapter is
@@ -263,7 +281,10 @@ func (c *ollamaClient) Embed(ctx context.Context, req model.EmbedRequest) (model
 func (c *ollamaClient) Caps() model.Capabilities {
 	// EmbedDims stays 0 (unknown): the width is a property of whichever
 	// model the deployment pulled, discovered from the first Embed call.
-	return model.Capabilities{Streaming: true, EmbedDims: 0, LocalOnly: true, AttachmentMIMEs: carriesNothing}
+	// AttachmentMIMEs is images and nothing else: the `images` array is the
+	// only attachment shape /api/chat has, and a non-vision model pulled into
+	// this binding fails visibly at the runner rather than silently here.
+	return model.Capabilities{Streaming: true, EmbedDims: 0, LocalOnly: true, AttachmentMIMEs: carriesImages}
 }
 
 // chat sends one non-streaming /api/chat call; chatStream requests the
@@ -278,9 +299,10 @@ func (c *ollamaClient) chatStream(ctx context.Context, req model.Request) (io.Re
 }
 
 func (c *ollamaClient) sendChat(ctx context.Context, req model.Request, stream bool) (io.ReadCloser, error) {
-	// Local vision is out of scope here — reject any attachment rather than
-	// silently drop it (spec §3.8, the map-or-reject invariant).
-	if err := attachmentUnsupported("ollama", req.Attachments, carriesNothing); err != nil {
+	// Images map to the per-message `images` array (ollamaparts.go); anything
+	// else is refused rather than dropped (spec §3.8, the map-or-reject
+	// invariant).
+	if err := ollamaRefuseAttachments(req.Attachments); err != nil {
 		return nil, err
 	}
 	wire := ollamaWire{Model: req.Model, Stream: stream}
@@ -290,9 +312,7 @@ func (c *ollamaClient) sendChat(ctx context.Context, req model.Request, stream b
 	if len(req.ResponseSchema) > 0 {
 		wire.Format = req.ResponseSchema
 	}
-	// Ollama has no top-level system field; the system prompt travels as
-	// the leading message.
-	wire.Messages = wireMessages(req.System, req.Messages)
+	wire.Messages = ollamaMessages(req.System, req.Messages, req.Attachments)
 	for _, tool := range req.Tools {
 		var tw ollamaToolWire
 		tw.Type = "function"

--- a/backend/internal/modules/ai/ollamaparts.go
+++ b/backend/internal/modules/ai/ollamaparts.go
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package ai
+
+// The /api/chat message shape, which carries an image in a way no other wire
+// here does: a per-message `images` array of BARE base64 — no data: prefix, no
+// media type, no typed part beside the text. The body stays a plain string.
+//
+// That is why this adapter has its own message type rather than sharing one.
+// The OpenAI-compatible and Anthropic wires both replace the body with an array
+// of typed parts; borrowing either mapping would produce a request Ollama reads
+// as one long string of JSON.
+
+import (
+	"encoding/base64"
+
+	"github.com/gradionhq/margince/backend/internal/shared/ports/model"
+)
+
+type ollamaMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+	// Images is bare base64, one entry per image, omitted entirely on a turn
+	// that carries none — so a text-only request is byte-identical to what this
+	// adapter sent before images existed.
+	Images []string `json:"images,omitempty"`
+}
+
+// ollamaMessages builds the wire's message list, attaching any images to the
+// last user turn.
+//
+// Ollama has no top-level system field, so the system prompt travels as the
+// leading turn. Attachments belong to a user turn — the same placement every
+// other adapter here uses, because they must not disagree about where in a
+// conversation a document sits.
+func ollamaMessages(system string, msgs []model.Message, atts []model.Attachment) []ollamaMessage {
+	out := make([]ollamaMessage, 0, len(msgs)+1)
+	if system != "" {
+		out = append(out, ollamaMessage{Role: roleSystem, Content: system})
+	}
+	for _, m := range msgs {
+		out = append(out, ollamaMessage{Role: m.Role, Content: m.Content})
+	}
+	if len(atts) == 0 {
+		return out
+	}
+	idx := len(out) - 1
+	for idx >= 0 && out[idx].Role != roleUser {
+		idx--
+	}
+	if idx < 0 {
+		out = append(out, ollamaMessage{Role: roleUser})
+		idx = len(out) - 1
+	}
+	for _, a := range atts {
+		// Bare base64: the runner decodes the entry as image bytes, so a data:
+		// prefix would be decoded as part of the image and fail there instead of
+		// here. Only images reach this — carriage is gated against carriesImages
+		// — and only inline bytes do, which ollamaRefuseAttachments enforces.
+		out[idx].Images = append(out[idx].Images, base64.StdEncoding.EncodeToString(a.Bytes))
+	}
+	return out
+}
+
+// ollamaRefuseAttachments is the map-or-reject gate for this wire (spec §3.8):
+// the carriage check every adapter runs, plus the URI shape this one cannot
+// express at all.
+//
+// The `images` array is bytes, and nothing else — Ollama neither fetches a URL
+// nor keeps a file registry a handle could name. An adapter that quietly skipped
+// such a part would be the silent drop the invariant exists to forbid, so it is
+// refused with the reason.
+func ollamaRefuseAttachments(atts []model.Attachment) error {
+	if err := attachmentUnsupported("ollama", atts, carriesImages); err != nil {
+		return err
+	}
+	for _, a := range atts {
+		if a.URI != "" {
+			return errUnfetchableAttachmentURI("ollama", "inline bytes only")
+		}
+	}
+	return nil
+}

--- a/backend/internal/modules/ai/ollamaparts_test.go
+++ b/backend/internal/modules/ai/ollamaparts_test.go
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package ai
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/ports/model"
+)
+
+// The no-regression pin. A request carrying no image must marshal to exactly the
+// bytes this adapter sent before the images array existed — the key absent
+// rather than present and empty, since a runner that reads `images: []` as a
+// vision request would reload the model for nothing. Written as literal expected
+// JSON rather than as a round-trip, because a round-trip through the same type
+// would agree with itself whatever it emits.
+func TestOllamaTextOnlyTurnsCarryNoImagesKey(t *testing.T) {
+	got, err := json.Marshal(ollamaMessages("be brief", []model.Message{
+		{Role: roleUser, Content: "hello"},
+		{Role: roleAssistant, Content: "hi"},
+	}, nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	const want = `[{"role":"system","content":"be brief"},` +
+		`{"role":"user","content":"hello"},` +
+		`{"role":"assistant","content":"hi"}]`
+	if string(got) != want {
+		t.Fatalf("text-only wire changed shape\n got: %s\nwant: %s", got, want)
+	}
+}
+
+// Ollama's images are BARE base64 on the message, not typed parts and not a
+// data: URL — the two spellings every other wire here uses. A runner handed a
+// data: URL decodes the prefix as image bytes and fails on the image, not on the
+// request, so this is asserted as literal bytes.
+func TestOllamaImageRidesTheLastUserTurnAsBareBase64(t *testing.T) {
+	msgs := ollamaMessages("sys", []model.Message{
+		{Role: roleUser, Content: "first"},
+		{Role: roleAssistant, Content: "answered"},
+		{Role: roleUser, Content: "read this"},
+	}, []model.Attachment{{MIME: "image/png", Bytes: []byte("PNG")}})
+
+	if len(msgs) != 4 {
+		t.Fatalf("want the system turn plus 3, got %d", len(msgs))
+	}
+	for _, i := range []int{0, 1, 2} {
+		if len(msgs[i].Images) != 0 {
+			t.Fatalf("message %d must carry no image, got %v", i, msgs[i].Images)
+		}
+	}
+	last := msgs[3]
+	if last.Content != "read this" {
+		t.Errorf("the turn's text stays its body on this wire, got %q", last.Content)
+	}
+	if len(last.Images) != 1 || last.Images[0] != "UE5H" {
+		t.Fatalf("want one bare-base64 image, got %v", last.Images)
+	}
+	if strings.Contains(last.Images[0], "data:") {
+		t.Errorf("an ollama image must carry no data: prefix, got %q", last.Images[0])
+	}
+}
+
+// Attachments belong to a user turn. A request whose only message is the system
+// prompt has none, so one is created rather than the image being hung off the
+// system turn, which the chat template renders as instructions.
+func TestOllamaAttachmentWithNoUserTurnGetsOne(t *testing.T) {
+	msgs := ollamaMessages("sys", nil, []model.Attachment{{MIME: "image/png", Bytes: []byte("PNG")}})
+	if len(msgs) != 2 {
+		t.Fatalf("want the system turn plus a created user turn, got %d", len(msgs))
+	}
+	if msgs[1].Role != roleUser || len(msgs[1].Images) != 1 || msgs[1].Content != "" {
+		t.Fatalf("want one image on a new, empty user turn, got %+v", msgs[1])
+	}
+}
+
+// The images array is bytes and nothing else: this runner neither fetches a URL
+// nor keeps a file registry a handle could name, so a URI attachment is refused
+// rather than skipped.
+func TestOllamaRefusesAnAttachmentGivenByURI(t *testing.T) {
+	err := ollamaRefuseAttachments([]model.Attachment{{MIME: "image/png", URI: "https://files.example/a.png"}})
+	if !errors.Is(err, model.ErrAttachmentUnsupported) {
+		t.Fatalf("a uri attachment must be refused as unsupported carriage, got %v", err)
+	}
+	if strings.Contains(err.Error(), "files.example") {
+		t.Errorf("the refusal must not echo the uri, got %q", err)
+	}
+	if err := ollamaRefuseAttachments([]model.Attachment{
+		{MIME: "image/png", Bytes: []byte("PNG")},
+	}); err != nil {
+		t.Errorf("inline image bytes are exactly what this wire takes, got %v", err)
+	}
+}
+
+// A carried image occupies context the byte heuristic cannot see: its base64
+// length is a property of the encoder, not of what the model spends on it. A
+// window sized as if the turn were text-only truncates the prompt around the
+// image it was asked to read.
+func TestOllamaSizesTheWindowForCarriedImages(t *testing.T) {
+	turn := []model.Message{{Role: roleUser, Content: "read this"}}
+	wireWith := func(n int) ollamaWire {
+		atts := make([]model.Attachment, n)
+		for i := range atts {
+			atts[i] = model.Attachment{MIME: "image/png", Bytes: []byte("PNG")}
+		}
+		return ollamaWire{Messages: ollamaMessages("", turn, atts)}
+	}
+	// The budget puts the text-only case on a bucket boundary, so the images are
+	// the only thing that can move the answer. Three of them, because the bucket
+	// deliberately absorbs small differences — it exists to keep a whole workload
+	// on one loaded runner — so a single image proves nothing about the sizing.
+	const budget = ollamaContextFloor
+	text := wireWith(0).contextWindow(budget)
+	if got := wireWith(1).contextWindow(budget); got < text {
+		t.Errorf("one image must never narrow the window: %d < %d", got, text)
+	}
+	if got := wireWith(3).contextWindow(budget); got <= text {
+		t.Fatalf("three carried images must widen the window past %d, got %d", text, got)
+	}
+}

--- a/backend/internal/modules/ai/openai.go
+++ b/backend/internal/modules/ai/openai.go
@@ -286,7 +286,7 @@ func openaiAttachmentPart(a model.Attachment) openaiInputPart {
 	switch {
 	case a.URI == "":
 		part.FileData = dataURI(a.MIME, a.Bytes)
-	case strings.HasPrefix(a.URI, "http://"), strings.HasPrefix(a.URI, "https://"):
+	case isFetchableURL(a.URI):
 		part.FileURL = a.URI
 	default:
 		part.FileID = a.URI

--- a/backend/internal/modules/ai/openaicompat.go
+++ b/backend/internal/modules/ai/openaicompat.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"slices"
 	"strings"
 
@@ -172,8 +173,18 @@ func isImage(mime string) bool { return strings.HasPrefix(mime, "image/") }
 // registry. Every adapter that takes a URI has to answer this — openai to pick
 // file_url over file_id, anthropic to decide whether it can send the part at
 // all — so the two answer it the same way.
+//
+// Parsed rather than prefix-matched, because both mistakes a prefix makes are
+// silent: a bare "https://" has no host to fetch and would go out as a URL, and
+// a scheme in capitals — which URLs are case-insensitive in — would be handed to
+// a file registry as if it were a handle.
 func isFetchableURL(uri string) bool {
-	return strings.HasPrefix(uri, "https://") || strings.HasPrefix(uri, "http://")
+	parsed, err := url.Parse(uri)
+	if err != nil {
+		return false
+	}
+	scheme := strings.ToLower(parsed.Scheme)
+	return (scheme == "https" || scheme == "http") && parsed.Host != ""
 }
 
 func (c *openAICompatClient) Caps() model.Capabilities {

--- a/backend/internal/modules/ai/openaicompat.go
+++ b/backend/internal/modules/ai/openaicompat.go
@@ -167,6 +167,15 @@ func DocumentMIMEs() []string { return slices.Clone(carriesImagesAndPDF) }
 // two answers drift apart.
 func isImage(mime string) bool { return strings.HasPrefix(mime, "image/") }
 
+// isFetchableURL reports whether an attachment's URI is a URL the vendor can
+// fetch for itself, as opposed to a handle scoped to some provider's own file
+// registry. Every adapter that takes a URI has to answer this — openai to pick
+// file_url over file_id, anthropic to decide whether it can send the part at
+// all — so the two answer it the same way.
+func isFetchableURL(uri string) bool {
+	return strings.HasPrefix(uri, "https://") || strings.HasPrefix(uri, "http://")
+}
+
 func (c *openAICompatClient) Caps() model.Capabilities {
 	// EmbedDims stays 0 (unknown): the width is a property of whichever
 	// model the deployment serves, discovered from the first Embed call.
@@ -215,7 +224,7 @@ func attachmentUnsupported(provider string, atts []model.Attachment, declared []
 // itself is not echoed — it can be a signed URL, and an error message is the
 // wrong place for one.
 func errUnfetchableAttachmentURI(provider, accepts string) error {
-	return fmt.Errorf("ai: %s: an attachment given by uri cannot be sent on this wire, which takes %s: %w",
+	return fmt.Errorf("ai: %s: this attachment's uri is not one this wire can resolve; it takes %s: %w",
 		provider, accepts, model.ErrAttachmentUnsupported)
 }
 

--- a/backend/internal/modules/ai/openaicompat.go
+++ b/backend/internal/modules/ai/openaicompat.go
@@ -141,6 +141,13 @@ var carriesNothing []string
 // whose wires take document parts natively.
 var carriesImagesAndPDF = []string{"image/*", "application/pdf"}
 
+// carriesImages is the declaration of an adapter whose wire takes images and
+// nothing else. Anthropic and Ollama both spell an image part uniformly — one
+// `image` block, one `images` array — while a PDF is model-dependent on the
+// first wire and absent from the second, so the honest declaration stops at
+// images rather than claiming a document lane one bound model may not serve.
+var carriesImages = []string{"image/*"}
+
 // DocumentMIMEs is every media type some adapter in this build carries as an
 // input part. It answers "could any binding have been handed this", which is a
 // different question from "will THIS binding take it" (that is Caps()) — the
@@ -196,6 +203,20 @@ func attachmentUnsupported(provider string, atts []model.Attachment, declared []
 		}
 	}
 	return nil
+}
+
+// errUnfetchableAttachmentURI refuses an attachment whose MIME the wire carries
+// but whose URI it cannot resolve — a vendor file handle on an endpoint with no
+// such registry, or a URL on a wire that takes inline bytes only.
+//
+// It is the carriage sentinel rather than a bare error because that is what it
+// is: this binding cannot be handed this part, and a caller that falls back to
+// another lane on ErrAttachmentUnsupported should fall back here too. The URI
+// itself is not echoed — it can be a signed URL, and an error message is the
+// wrong place for one.
+func errUnfetchableAttachmentURI(provider, accepts string) error {
+	return fmt.Errorf("ai: %s: an attachment given by uri cannot be sent on this wire, which takes %s: %w",
+		provider, accepts, model.ErrAttachmentUnsupported)
 }
 
 // refuseUnsupportedAttachments applies the map-or-reject invariant (spec §3.8)

--- a/backend/internal/modules/ai/outbound.go
+++ b/backend/internal/modules/ai/outbound.go
@@ -88,25 +88,6 @@ func openAIWireEmbed(ctx context.Context, post func(context.Context, string, []b
 	return model.Embeddings{Vectors: vectors, Dims: dims}, nil
 }
 
-// wireMessage is the lowercase JSON shape every provider speaks; the
-// port's Message deliberately carries no wire tags (the seam is not a
-// serialization contract), so adapters convert here.
-type wireMessage struct {
-	Role    string `json:"role"`
-	Content string `json:"content"`
-}
-
-func wireMessages(system string, msgs []model.Message) []wireMessage {
-	out := make([]wireMessage, 0, len(msgs)+1)
-	if system != "" {
-		out = append(out, wireMessage{Role: roleSystem, Content: system})
-	}
-	for _, m := range msgs {
-		out = append(out, wireMessage{Role: m.Role, Content: m.Content})
-	}
-	return out
-}
-
 // sendablePayload marshals a provider wire body and runs the
 // per-request SecretStripper over the marshaled bytes. Every adapter —
 // cloud, local, and the fake — puts ONLY the returned bytes on the

--- a/docs/how-to/connect-a-cloud-model-provider.md
+++ b/docs/how-to/connect-a-cloud-model-provider.md
@@ -13,7 +13,7 @@ for the full provider matrix. For the no-cloud path, see
 
 | `provider` | Use it for | Key env var | `base_url` |
 |---|---|---|---|
-| `anthropic` | Claude (native Messages API) | `ANTHROPIC_API_KEY` | optional (default `api.anthropic.com`) |
+| `anthropic` | Claude (native Messages API — image input) | `ANTHROPIC_API_KEY` | optional (default `api.anthropic.com`) |
 | `openai` | GPT (native Responses API — reasoning effort, prompt-cache + reasoning token usage, image/PDF input) | `OPENAI_API_KEY` | optional (default `api.openai.com`) |
 | `gemini` | Gemini (native `generateContent` — thinking level, thought-signature continuity, image/PDF input) | `GEMINI_API_KEY` | optional (default `…/v1beta`) |
 | `openai_compatible` | the OpenAI-wire long tail — Mistral, DeepSeek, Groq, Together, OpenRouter, a self-hosted gateway, … | `OPENAI_COMPATIBLE_API_KEY` | **required** |
@@ -23,7 +23,9 @@ environment**, read from the var above at boot (12-factor; a stray `api_key:` in
 the config is a startup error). Secrets never touch a config file.
 
 Reach for a **native** adapter (`openai`/`gemini`) when you want that vendor's
-reasoning/thinking knobs, document attachments, or itemized usage. Reach for
+reasoning/thinking knobs, itemized usage, or a PDF handed to the model whole —
+`anthropic` carries images but not PDFs, and `openai_compatible` carries only
+what its binding declares. Reach for
 `openai_compatible` for any vendor that speaks `/v1/chat/completions` and isn't
 worth a dedicated adapter — it is the correct default for everything that is not
 Anthropic, OpenAI, or Gemini.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -826,6 +826,25 @@ would double it (`…/v1/v1/…` → 404). Use `https://api.mistral.ai`, not
 `https://api.mistral.ai/v1`. `gemini` is the mirror: its default base keeps the
 `/v1beta` segment and the paths are version-relative.
 
+#### What a binding can be handed (documents, scans, photographed forms)
+
+`document_extract` reads a file by handing it to the bound model when the model
+takes that media type, and falls back to the text lane when it does not. What
+each provider carries is a property of its **wire**, and is fixed in the adapter:
+
+| provider | carries |
+|---|---|
+| `gemini`, `openai` | `image/*` and `application/pdf` — both wires take a document part natively |
+| `anthropic` | `image/*`. The Messages API has a document block too, but which models accept one varies per model, and this adapter cannot see which model a binding named |
+| `ollama` | `image/*`, as the chat API's per-message `images` array. A non-vision model pulled into the binding fails at the runner, visibly |
+| `openai_compatible`, `vllm` | whatever the binding declares — see `input:` below |
+| `fake` | `image/*` and `application/pdf` (the offline stub mirrors the native wires) |
+
+A media type outside a binding's carriage is **refused, never dropped**: the run
+says which file it could not read rather than answering about a document the
+model never saw. An `ollama` binding takes inline bytes only, and `anthropic`
+takes inline bytes or an `http(s)` URL it fetches itself.
+
 #### `input:` — what the bound model can be given
 
 A chat tier bound to `openai_compatible` or `vllm` may declare the input


### PR DESCRIPTION
Closes #1423.

## The gap

Both adapters declared `carriesNothing` while both wires carry images natively.
`document_extract` picks its lane off `Caps().AttachmentMIMEs`
(`documentextractrun.go:246`), so the declaration WAS the whole gap — an
operator who bound Anthropic, an ordinary BYOK choice, got the refusal that
reads as a missing feature:

> this installation's model cannot read a image/png document; a file whose text
> can be read directly, or a model bound to carry documents, would be read

Unlike #1324, nothing here is unknowable from code: each wire's image carriage
is fixed, so each adapter maps its own parts and widens its own constant.

## What this does

Each wire spells a carried image differently, so each adapter now owns its
message type rather than sharing one that could only serve the shape neither
sends:

- **anthropic** — the body becomes an ordered array of content blocks once a
  turn carries an image, and stays a bare string otherwise. Inline bytes ride
  `source: {type: base64, media_type, data}`; an `http(s)` URI rides
  `source: {type: url}`, which the API fetches itself.
- **ollama** — images ride the per-message `images` array of **bare** base64
  (no `data:` prefix, no typed part) and the body stays a plain string. Reaching
  for the OpenAI-compatible mapping here would produce a request the runner
  reads as one long string of JSON.

`wireMessage`/`wireMessages` lost both callers and are gone.

## Three decisions worth reviewing

**PDF stays refused on both.** Anthropic's `document` block exists, but which
models accept one varies per model in a way image support does not, and this
adapter cannot see which model a binding named. Ollama has no document shape at
all. Advertising a lane a bound model refuses is worse than not advertising it.

**A URI is refused where the wire cannot resolve it.** Ollama's `images` is
bytes and nothing else — it neither fetches a URL nor keeps a file registry — so
a URI attachment is refused by name rather than skipped, which would be exactly
the silent drop §3.8 forbids. On anthropic an `http(s)` URL maps; a file handle
would need the Files beta header this adapter does not send, so it is refused
rather than mapped to a block the vendor would reject naming the wrong thing.

**`num_ctx` sizes for a carried image, in tokens rather than bytes.** An image's
cost is not a function of its byte length — the projector downsamples to a fixed
patch grid — so sizing from bytes would let the JPEG quality slider pick the
runner's allocation, the same mistake `ollamaMaxContext` exists to prevent for
text. `ollamaPerImageTokens` sits above what the common projectors charge
(llava 576, Qwen-VL ~1.3k at default tiling).

## Tests

The existing fitness test
`TestEveryProviderMapsOrRejectsAttachmentsNeverSilentlyDrops` grew a
**per-provider refusal set** rather than a parallel suite beside it — every
binding still refuses something, and the two that now carry images moved to a
carriage arm that asserts the part reached the wire in that wire's own literal
spelling (`"source":{"type":"base64",…}` vs `"images":["UE5H"]`), because a call
that dropped the image would look identical from the caller's side otherwise.

Both wires' text-only bytes are pinned as literal expected JSON: anthropic's
content must stay a bare string, ollama's `images` key must stay absent.

**Coverage on new code: 94–100% on every new function** (`anthropicMessages`
94.1%, everything else 100%).

## Found in review, fixed here

The fake's recorded payload had moved to a map, and Go sorts map keys — so
`content` marshalled before `role`. That payload is hashed into the fake's
fallback completion, so a change that touched no behaviour would have altered
every deterministic answer it gives. Back to a struct, with a test that pins the
order and says why it is load-bearing.

## Filed rather than folded in

- `image/*` is wider than any vendor actually decodes (Anthropic takes
  jpeg/png/gif/webp). That is the tree's existing convention — `openai` and
  `gemini` declare `image/*` too — and narrowing one adapter would break ladder
  intersection, which compares patterns literally. Tree-wide, filed separately.
- The last-user-turn placement loop now has five hand-rolled copies, each
  promising in prose that the adapters agree, with nothing cross-checking it.

**MCP Inspector was not used, deliberately:** no MCP surface changes here — no
new tool, no changed schema, no changed governance. Driving the SPA against a
local vision model is what proves it. UAT video to follow in a comment.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Carries images end-to-end for `anthropic` and `ollama`, so `document_extract` can route image inputs to these bindings (addresses #1423). Previously both refused `image/*`; now they carry images on their native wires while PDFs stay refused.

- `Caps().AttachmentMIMEs` for `anthropic` and `ollama` is `["image/*"]`.
- `anthropic`: turns become content blocks when an image is present; inline bytes map to `source: {type: "base64", media_type, data}`, `http(s)` URLs map to `source: {type: "url"}`; non-fetchable URIs (e.g., file handles) are refused; system prompt remains the top-level field; text-only requests still send a bare string.
- `ollama`: images ride the per-message `images` array as bare base64 (no `data:` prefix); URI attachments are refused; `num_ctx` includes a per-image token allowance to prevent truncating prompts.
- Internal: adapters own their message types; shared `wireMessage` removed; shared `isFetchableURL` now parses URLs (used by `openai` and `anthropic`); refusal helper added; fake payload uses structs to pin field order; docs updated.

Migration:
- For `ollama`, send image bytes inline (URIs are refused). For `anthropic`, send inline bytes or `http(s)` URLs. PDFs remain unsupported on both.

<sup>Written for commit b2f22d5936fc012cd1520dcda9537fb655644d7f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1437?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added image attachment support for Anthropic and Ollama models.
  * Images can be sent as inline data or fetchable URLs, with provider-specific formatting.
  * Unsupported media and inaccessible attachment URLs are now clearly rejected.
  * Image support and provider-specific media capabilities are documented.

* **Bug Fixes**
  * Improved attachment handling across OpenAI-compatible providers.
  * Preserved message text and ordering in recorded fallback requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->