### PR TITLE
fix(ai): a sovereign profile checks the endpoint, not just the provider name

### DIFF
--- a/backend/internal/modules/ai/routing.go
+++ b/backend/internal/modules/ai/routing.go
@@ -191,10 +191,17 @@ func (cfg RoutingConfig) validate() error {
 		if binding.Provider == "" {
 			return fmt.Errorf("ai: routing config: tier %s has no provider", tier)
 		}
-		// Sovereign means zero egress BY CONSTRUCTION: a cloud provider
-		// in any chat tier is a config error, not a runtime surprise.
-		if cfg.Profile == ProfileSovereign && !localProviders[binding.Provider] {
-			return fmt.Errorf("ai: routing config: profile sovereign forbids cloud provider %q on tier %s", binding.Provider, tier)
+		// Sovereign means zero egress BY CONSTRUCTION, which takes both halves:
+		// a cloud provider in any chat tier is a config error, and so is a local
+		// provider pointed at somebody else's host (sovereignendpoint.go).
+		// Neither is a runtime surprise.
+		if cfg.Profile == ProfileSovereign {
+			if !localProviders[binding.Provider] {
+				return fmt.Errorf("ai: routing config: profile sovereign forbids cloud provider %q on tier %s", binding.Provider, tier)
+			}
+			if err := requireSovereignEndpoint(fmt.Sprintf("tier %s", tier), binding.Provider, binding.BaseURL); err != nil {
+				return err
+			}
 		}
 		if err := validateInput(fmt.Sprintf("tier %s", tier), binding.Provider, binding.Input); err != nil {
 			return err
@@ -212,8 +219,16 @@ func (cfg RoutingConfig) validate() error {
 	if cfg.Embeddings.Input != nil {
 		return fmt.Errorf("ai: routing config: the embeddings lane takes no `input` — it sends no attachments; declare it on the chat tier that reads documents")
 	}
-	if cfg.Profile == ProfileSovereign && !localProviders[cfg.Embeddings.Provider] {
-		return fmt.Errorf("ai: routing config: profile sovereign forbids cloud provider %q on the embeddings lane", cfg.Embeddings.Provider)
+	if cfg.Profile == ProfileSovereign {
+		if !localProviders[cfg.Embeddings.Provider] {
+			return fmt.Errorf("ai: routing config: profile sovereign forbids cloud provider %q on the embeddings lane", cfg.Embeddings.Provider)
+		}
+		// The embed lane egresses the same text the chat lanes do — a document's
+		// content reaches it as the thing being embedded — so it carries the same
+		// endpoint rule rather than a weaker one.
+		if err := requireSovereignEndpoint("the embeddings lane", cfg.Embeddings.Provider, cfg.Embeddings.BaseURL); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/backend/internal/modules/ai/sovereignendpoint.go
+++ b/backend/internal/modules/ai/sovereignendpoint.go
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package ai
+
+// Where a sovereign deployment's local bindings are allowed to point
+// (ai-operational-spec §4.3).
+//
+// The profile check reads the provider NAME, and `ollama` and `vllm` both take
+// an operator-supplied base_url with nothing constraining it. So a deployment
+// could declare zero egress and send every call to a third-party host, while the
+// config validated and the code claimed the guarantee held by construction.
+//
+// A local provider name is not on its own a local endpoint, and this is the
+// other half.
+
+import (
+	"fmt"
+	"net"
+	"net/url"
+	"strings"
+)
+
+// localBaseURLDefaults is the endpoint each local provider resolves to when the
+// binding names none. Read here rather than re-typed, so "an omitted base_url is
+// loopback" cannot become true in the client and false in the check.
+//
+// `fake` is absent on purpose: it is sovereign-eligible and reaches no endpoint
+// at all, so there is nothing about it to check.
+var localBaseURLDefaults = map[string]string{
+	providerOllama: defaultOllamaBaseURL,
+	providerVLLM:   defaultVLLMBaseURL,
+}
+
+// requireSovereignEndpoint refuses a binding whose resolved endpoint is not on
+// infrastructure the customer controls.
+//
+// label names the binding under inspection ("tier premium", "the embeddings
+// lane") so the error points at a line rather than at the file.
+func requireSovereignEndpoint(label, provider, baseURL string) error {
+	fallback, isLocal := localBaseURLDefaults[provider]
+	if !isLocal {
+		return nil // fake, or a cloud provider the caller already refused
+	}
+	host, err := hostOf(defaulted(baseURL, fallback))
+	if err != nil {
+		return fmt.Errorf("ai: routing config: %s: %w", label, err)
+	}
+	if hostIsCustomerControlled(host) {
+		return nil
+	}
+	return fmt.Errorf(
+		"ai: routing config: %s: profile sovereign forbids the host %q — the profile promises zero egress, and %q is not an address on infrastructure this installation can see is yours; point it at loopback, a link-local address, or a private range (10.x, 172.16-31.x, 192.168.x, or an IPv6 unique-local address)",
+		label, host, host)
+}
+
+// hostOf extracts the host a base_url names, refusing a value that names none —
+// which on this path is not a formatting nit: "no host" is exactly the shape a
+// check written as a string comparison would wave through.
+func hostOf(baseURL string) (string, error) {
+	parsed, err := url.Parse(baseURL)
+	if err != nil {
+		return "", fmt.Errorf("base_url %q cannot be parsed as a url: %w", baseURL, err)
+	}
+	host := parsed.Hostname()
+	if host == "" {
+		return "", fmt.Errorf("base_url %q names no host", baseURL)
+	}
+	return host, nil
+}
+
+// hostIsCustomerControlled answers the question the profile actually asks: does
+// this address live on the customer's own infrastructure?
+//
+// A private-range host on ANOTHER machine counts. A customer's own GPU box on
+// their own network is their infrastructure — the guarantee is about where data
+// goes, not about which process it lands in (spec §4.3).
+//
+// Only a host this installation can judge for ITSELF is accepted: an IP literal,
+// or `localhost`, which RFC 6761 reserves for loopback. A DNS name is refused
+// even though resolving one would be easy, because resolving it at boot says
+// only where it pointed at boot — and a profile satisfied by an answer that can
+// change an hour later is the same false guarantee this check exists to remove.
+func hostIsCustomerControlled(host string) bool {
+	if isReservedLoopbackName(host) {
+		return true
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return false // a DNS name: unverifiable here, and mutable later
+	}
+	// IsPrivate covers RFC 1918 and IPv6 unique-local (fc00::/7); the other two
+	// carry loopback and the link-local ranges an on-host or same-segment
+	// deployment uses.
+	return ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast()
+}
+
+// isReservedLoopbackName reports whether host is a name the standards themselves
+// pin to loopback: `localhost` and anything under it (RFC 6761 §6.3). Matched
+// case-insensitively, because host names are.
+func isReservedLoopbackName(host string) bool {
+	lowered := strings.ToLower(host)
+	return lowered == "localhost" || strings.HasSuffix(lowered, ".localhost")
+}

--- a/backend/internal/modules/ai/sovereignendpoint.go
+++ b/backend/internal/modules/ai/sovereignendpoint.go
@@ -81,6 +81,14 @@ func hostOf(baseURL string) (string, error) {
 	if host == "" {
 		return "", fmt.Errorf("base_url %q names no host; write the whole url, e.g. http://127.0.0.1:11434", baseURL)
 	}
+	// The scheme is checked HERE rather than left to the first call: a scheme
+	// this adapter cannot dial makes the endpoint unreachable, and an endpoint
+	// nothing can reach is not the local one the profile was promised — it is a
+	// deployment that fails at 3am with a transport error instead of at boot
+	// with a config one.
+	if scheme := strings.ToLower(parsed.Scheme); scheme != "http" && scheme != "https" {
+		return "", fmt.Errorf("base_url %q must be an http(s) url; %q is not a scheme this adapter can call", baseURL, parsed.Scheme)
+	}
 	return host, nil
 }
 
@@ -109,10 +117,16 @@ const (
 // where it pointed at boot — and a profile satisfied by an answer that can
 // change an hour later is the same false guarantee this check exists to remove.
 func classifyHost(host string) hostVerdict {
+	host = strings.TrimSuffix(host, ".") // a fully-qualified name names the same host
 	if isReservedLoopbackName(host) {
 		return hostIsLocal
 	}
-	ip := net.ParseIP(host)
+	// A zone ("fe80::1%eth0") says which interface a link-local address is
+	// reached on, and net.ParseIP does not take one. Dropped for the judgment,
+	// which is about the address: an interface cannot make a link-local address
+	// non-local.
+	address, _, _ := strings.Cut(host, "%")
+	ip := net.ParseIP(address)
 	if ip == nil {
 		return hostIsAName
 	}

--- a/backend/internal/modules/ai/sovereignendpoint.go
+++ b/backend/internal/modules/ai/sovereignendpoint.go
@@ -38,25 +38,40 @@ var localBaseURLDefaults = map[string]string{
 // label names the binding under inspection ("tier premium", "the embeddings
 // lane") so the error points at a line rather than at the file.
 func requireSovereignEndpoint(label, provider, baseURL string) error {
-	fallback, isLocal := localBaseURLDefaults[provider]
-	if !isLocal {
-		return nil // fake, or a cloud provider the caller already refused
+	fallback, reachesAnEndpoint := localBaseURLDefaults[provider]
+	if !reachesAnEndpoint {
+		// fake (no endpoint at all), or a cloud provider the caller already
+		// refused. TestEveryLocalProviderWithAnEndpointIsChecked holds this
+		// closed: a new local provider absent from the defaults map would
+		// otherwise pass unchecked, which is this rule's own failure mode.
+		return nil
 	}
 	host, err := hostOf(defaulted(baseURL, fallback))
 	if err != nil {
 		return fmt.Errorf("ai: routing config: %s: %w", label, err)
 	}
-	if hostIsCustomerControlled(host) {
+	switch classifyHost(host) {
+	case hostIsLocal:
 		return nil
+	case hostIsAName:
+		// Distinguished from a public address on purpose: the operator running
+		// under Kubernetes or Compose writes a service name, and an error about
+		// private ranges reads to them as "your host is public" — which it may
+		// not be. What is wrong is that it is a NAME.
+		return fmt.Errorf(
+			"ai: routing config: %s: profile sovereign needs an endpoint this installation can verify for itself, and %q is a name — what it resolves to is decided elsewhere and can change after boot. Give the address instead (an IP in a private range, or a loopback address); `localhost` is also accepted",
+			label, host)
 	}
 	return fmt.Errorf(
-		"ai: routing config: %s: profile sovereign forbids the host %q — the profile promises zero egress, and %q is not an address on infrastructure this installation can see is yours; point it at loopback, a link-local address, or a private range (10.x, 172.16-31.x, 192.168.x, or an IPv6 unique-local address)",
-		label, host, host)
+		"ai: routing config: %s: profile sovereign forbids the host %q — the profile promises zero egress, and that address is not on infrastructure this installation can see is yours. Point it at loopback, a link-local address, or a private range (10.x, 172.16-31.x, 192.168.x, or an IPv6 unique-local address)",
+		label, host)
 }
 
 // hostOf extracts the host a base_url names, refusing a value that names none —
 // which on this path is not a formatting nit: "no host" is exactly the shape a
-// check written as a string comparison would wave through.
+// check written as a string comparison would wave through. `localhost:11434`
+// lands here too, because a url with no scheme parses as one whose SCHEME is
+// "localhost", so the error names the shape rather than the omission.
 func hostOf(baseURL string) (string, error) {
 	parsed, err := url.Parse(baseURL)
 	if err != nil {
@@ -64,35 +79,52 @@ func hostOf(baseURL string) (string, error) {
 	}
 	host := parsed.Hostname()
 	if host == "" {
-		return "", fmt.Errorf("base_url %q names no host", baseURL)
+		return "", fmt.Errorf("base_url %q names no host; write the whole url, e.g. http://127.0.0.1:11434", baseURL)
 	}
 	return host, nil
 }
 
-// hostIsCustomerControlled answers the question the profile actually asks: does
-// this address live on the customer's own infrastructure?
+// What a base_url's host is, from the profile's point of view. Three answers
+// rather than a bool, because "somebody else's address" and "an address nobody
+// here can resolve" are different mistakes and lead an operator to different
+// fixes.
+type hostVerdict int
+
+const (
+	hostIsLocal hostVerdict = iota
+	hostIsElsewhere
+	hostIsAName
+)
+
+// classifyHost answers the question the profile actually asks: does this address
+// live on the customer's own infrastructure?
 //
 // A private-range host on ANOTHER machine counts. A customer's own GPU box on
 // their own network is their infrastructure — the guarantee is about where data
 // goes, not about which process it lands in (spec §4.3).
 //
-// Only a host this installation can judge for ITSELF is accepted: an IP literal,
-// or `localhost`, which RFC 6761 reserves for loopback. A DNS name is refused
-// even though resolving one would be easy, because resolving it at boot says
-// only where it pointed at boot — and a profile satisfied by an answer that can
+// Only a host this installation can judge for ITSELF is local: an IP literal, or
+// `localhost`, which RFC 6761 reserves for loopback. A DNS name is refused even
+// though resolving one would be easy, because resolving it at boot says only
+// where it pointed at boot — and a profile satisfied by an answer that can
 // change an hour later is the same false guarantee this check exists to remove.
-func hostIsCustomerControlled(host string) bool {
+func classifyHost(host string) hostVerdict {
 	if isReservedLoopbackName(host) {
-		return true
+		return hostIsLocal
 	}
 	ip := net.ParseIP(host)
 	if ip == nil {
-		return false // a DNS name: unverifiable here, and mutable later
+		return hostIsAName
 	}
 	// IsPrivate covers RFC 1918 and IPv6 unique-local (fc00::/7); the other two
 	// carry loopback and the link-local ranges an on-host or same-segment
-	// deployment uses.
-	return ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast()
+	// deployment uses. An IPv4-mapped IPv6 address is judged by its IPv4 rules,
+	// which is what the net package's own predicates do — so ::ffff:8.8.8.8 is
+	// as public as 8.8.8.8, and the mapping buys nothing.
+	if ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() {
+		return hostIsLocal
+	}
+	return hostIsElsewhere
 }
 
 // isReservedLoopbackName reports whether host is a name the standards themselves

--- a/backend/internal/modules/ai/sovereignendpoint.go
+++ b/backend/internal/modules/ai/sovereignendpoint.go
@@ -117,8 +117,12 @@ const (
 // where it pointed at boot — and a profile satisfied by an answer that can
 // change an hour later is the same false guarantee this check exists to remove.
 func classifyHost(host string) hostVerdict {
-	host = strings.TrimSuffix(host, ".") // a fully-qualified name names the same host
-	if isReservedLoopbackName(host) {
+	// The trailing dot is dropped for the NAME check only, where it is the
+	// fully-qualified spelling of the same reserved name. It must NOT be dropped
+	// before parsing an address: `127.0.0.1.` is not an IP literal to Go's
+	// resolver either, so a dial to it goes to DNS — and trimming here would call
+	// local an endpoint the dial then resolves somewhere else entirely.
+	if isReservedLoopbackName(strings.TrimSuffix(host, ".")) {
 		return hostIsLocal
 	}
 	// A zone ("fe80::1%eth0") says which interface a link-local address is

--- a/backend/internal/modules/ai/sovereignendpoint_test.go
+++ b/backend/internal/modules/ai/sovereignendpoint_test.go
@@ -144,6 +144,12 @@ func TestWhichHostsCountAsCustomerControlled(t *testing.T) {
 		// can change after boot, so it is refused even when it looks internal.
 		"ollama.internal":   hostIsAName,
 		"elsewhere.example": hostIsAName,
+		// A trailing dot makes a name fully qualified; it still names the same
+		// host, and `localhost.` is still the reserved loopback name.
+		"localhost.": hostIsLocal,
+		// A zone says which interface a link-local address is reached on. It
+		// cannot make that address non-local.
+		"fe80::1%eth0": hostIsLocal,
 	} {
 		if got := classifyHost(host); got != want {
 			t.Errorf("classifyHost(%q) = %s, want %s", host, verdictName(got), verdictName(want))
@@ -164,6 +170,22 @@ func TestABaseURLWithNoHostIsRefusedUnderSovereign(t *testing.T) {
 		if !strings.Contains(err.Error(), "http://127.0.0.1:11434") {
 			t.Errorf("the refusal must show the shape it wants, got %q", err)
 		}
+	}
+}
+
+// A local host behind a scheme this adapter cannot dial is not the reachable
+// local endpoint the profile was promised — it is a deployment that fails on its
+// first call with a transport error instead of at boot with a config one.
+func TestASchemeThisAdapterCannotCallIsRefusedEvenOnALocalHost(t *testing.T) {
+	for _, baseURL := range []string{"ollama://127.0.0.1:11434", "ftp://10.0.0.5:8000"} {
+		err := requireSovereignEndpoint("tier local_large", providerVLLM, baseURL)
+		if err == nil || !strings.Contains(err.Error(), "http(s)") {
+			t.Errorf("base_url %q must be refused for its scheme, got %v", baseURL, err)
+		}
+	}
+	// A bracketed IPv6 endpoint with a zone is the case this must not catch.
+	if err := requireSovereignEndpoint("tier local_large", providerVLLM, "http://[fe80::1%25eth0]:8000"); err != nil {
+		t.Errorf("a zoned link-local endpoint is local and must be accepted, got %v", err)
 	}
 }
 

--- a/backend/internal/modules/ai/sovereignendpoint_test.go
+++ b/backend/internal/modules/ai/sovereignendpoint_test.go
@@ -8,9 +8,9 @@ import (
 	"testing"
 )
 
-// The defect this file exists for: `sovereign` was enforced by provider NAME, so
-// a vllm tier pointed at a third-party host validated and ran, and every call in
-// a deployment that declared zero egress went over the public internet.
+// A local provider NAME does not by itself prove a local endpoint: both local
+// providers take an operator-supplied base_url, so the profile that promises
+// zero egress checks where each binding actually points.
 func TestSovereignRefusesALocalProviderPointedAtSomebodyElsesHost(t *testing.T) {
 	_, err := ParseRouting([]byte(`
 profile: sovereign
@@ -102,37 +102,112 @@ embeddings: { provider: ollama, model: bge-m3 }
 	}
 }
 
+// verdictName keeps a failure readable: the verdicts are an unexported int enum,
+// so %v would report "= 1, want 0" about a table whose whole point is which of
+// the three answers a host gets.
+func verdictName(v hostVerdict) string {
+	switch v {
+	case hostIsLocal:
+		return "local"
+	case hostIsElsewhere:
+		return "elsewhere"
+	case hostIsAName:
+		return "a name"
+	}
+	return "unknown"
+}
+
 func TestWhichHostsCountAsCustomerControlled(t *testing.T) {
-	for host, want := range map[string]bool{
-		"127.0.0.1":       true,
-		"::1":             true,
-		"localhost":       true,
-		"LOCALHOST":       true, // host names are case-insensitive
-		"gpu.localhost":   true,
-		"10.4.1.20":       true,
-		"172.16.0.9":      true,
-		"172.32.0.9":      false, // just past the RFC 1918 block, which ends at 172.31
-		"192.168.1.5":     true,
-		"fd00::1":         true, // IPv6 unique-local
-		"169.254.7.7":     true, // link-local
-		"8.8.8.8":         false,
-		"2606:4700::1111": false,
-		// A DNS name is refused even when it looks internal: resolving it at boot
-		// says only where it pointed at boot.
-		"ollama.internal":   false,
-		"elsewhere.example": false,
+	for host, want := range map[string]hostVerdict{
+		"127.0.0.1":       hostIsLocal,
+		"::1":             hostIsLocal,
+		"localhost":       hostIsLocal,
+		"LOCALHOST":       hostIsLocal, // host names are case-insensitive
+		"gpu.localhost":   hostIsLocal,
+		"10.4.1.20":       hostIsLocal,
+		"172.16.0.9":      hostIsLocal,
+		"172.32.0.9":      hostIsElsewhere, // just past RFC 1918, which ends at 172.31
+		"192.168.1.5":     hostIsLocal,
+		"fd00::1":         hostIsLocal, // IPv6 unique-local
+		"169.254.7.7":     hostIsLocal, // link-local
+		"8.8.8.8":         hostIsElsewhere,
+		"2606:4700::1111": hostIsElsewhere,
+		// An IPv4-mapped IPv6 address is judged by its IPv4 rules, so the
+		// mapping buys a public address nothing.
+		"::ffff:8.8.8.8":  hostIsElsewhere,
+		"::ffff:10.0.0.1": hostIsLocal,
+		// The unspecified addresses are what an operator copies out of
+		// OLLAMA_HOST; they name no host to reach and are not local.
+		"0.0.0.0": hostIsElsewhere,
+		"::":      hostIsElsewhere,
+		// A name is its own answer: what it resolves to is decided elsewhere and
+		// can change after boot, so it is refused even when it looks internal.
+		"ollama.internal":   hostIsAName,
+		"elsewhere.example": hostIsAName,
 	} {
-		if got := hostIsCustomerControlled(host); got != want {
-			t.Errorf("hostIsCustomerControlled(%q) = %v, want %v", host, got, want)
+		if got := classifyHost(host); got != want {
+			t.Errorf("classifyHost(%q) = %s, want %s", host, verdictName(got), verdictName(want))
 		}
 	}
 }
 
 // A base_url naming no host is exactly the shape a string-comparison check waves
-// through, so it is refused rather than read as "nothing to see".
+// through, so it is refused rather than read as "nothing to see". `host:port`
+// with no scheme lands here too — url.Parse reads `localhost` as the scheme —
+// so the error names the whole-url shape rather than blaming the host.
 func TestABaseURLWithNoHostIsRefusedUnderSovereign(t *testing.T) {
-	err := requireSovereignEndpoint("tier local_large", providerVLLM, "http://")
-	if err == nil || !strings.Contains(err.Error(), "names no host") {
-		t.Fatalf("a hostless base_url must be refused, got %v", err)
+	for _, baseURL := range []string{"http://", "localhost:11434"} {
+		err := requireSovereignEndpoint("tier local_large", providerVLLM, baseURL)
+		if err == nil || !strings.Contains(err.Error(), "names no host") {
+			t.Fatalf("base_url %q must be refused as hostless, got %v", baseURL, err)
+		}
+		if !strings.Contains(err.Error(), "http://127.0.0.1:11434") {
+			t.Errorf("the refusal must show the shape it wants, got %q", err)
+		}
+	}
+}
+
+// A name and a public address are different mistakes with different fixes, and
+// an operator on Kubernetes or Compose writes a service name — an error about
+// private ranges would read to them as "your host is public", which it may not
+// be. The refusal has to say the problem is that it IS a name.
+func TestTheRefusalTellsANameApartFromAPublicAddress(t *testing.T) {
+	byName := requireSovereignEndpoint("tier local_large", providerOllama, "http://ollama.ai.svc.cluster.local:11434")
+	if byName == nil || !strings.Contains(byName.Error(), "is a name") {
+		t.Fatalf("a service name must be refused AS a name, got %v", byName)
+	}
+	if !strings.Contains(byName.Error(), "Give the address instead") {
+		t.Errorf("the refusal must name the fix, got %q", byName)
+	}
+	byAddress := requireSovereignEndpoint("tier local_large", providerOllama, "http://8.8.8.8:11434")
+	if byAddress == nil || strings.Contains(byAddress.Error(), "is a name") {
+		t.Fatalf("a public address must be refused as an address, got %v", byAddress)
+	}
+}
+
+// A bracketed IPv6 base_url is the one spelling where the host is not the whole
+// authority, so it goes through the real parse rather than the classifier alone.
+func TestABracketedIPv6EndpointIsAccepted(t *testing.T) {
+	if _, err := ParseRouting([]byte(`
+profile: sovereign
+tiers:
+  local_large: { provider: vllm, base_url: "http://[fd00::1]:8000", model: m }
+embeddings: { provider: ollama, model: bge-m3 }
+`)); err != nil {
+		t.Fatalf("a unique-local IPv6 endpoint must boot, got %v", err)
+	}
+}
+
+// The check keys off its own map of provider defaults, and the profile gate keys
+// off localProviders. A local provider added to one and not the other would pass
+// unchecked — which is exactly the hole this file closes, reopened by drift.
+func TestEveryLocalProviderWithAnEndpointIsChecked(t *testing.T) {
+	for provider := range localProviders {
+		if provider == ProviderFake {
+			continue // reaches no endpoint at all; there is nothing to check
+		}
+		if _, ok := localBaseURLDefaults[provider]; !ok {
+			t.Errorf("local provider %q has no entry in localBaseURLDefaults, so a sovereign binding to it is never endpoint-checked", provider)
+		}
 	}
 }

--- a/backend/internal/modules/ai/sovereignendpoint_test.go
+++ b/backend/internal/modules/ai/sovereignendpoint_test.go
@@ -144,9 +144,12 @@ func TestWhichHostsCountAsCustomerControlled(t *testing.T) {
 		// can change after boot, so it is refused even when it looks internal.
 		"ollama.internal":   hostIsAName,
 		"elsewhere.example": hostIsAName,
-		// A trailing dot makes a name fully qualified; it still names the same
-		// host, and `localhost.` is still the reserved loopback name.
+		// A trailing dot makes a NAME fully qualified, so `localhost.` is still
+		// the reserved loopback name. An ADDRESS with one is not an address at
+		// all: Go's resolver sends `127.0.0.1.` to DNS, so accepting it would
+		// call local an endpoint the dial resolves elsewhere.
 		"localhost.": hostIsLocal,
+		"127.0.0.1.": hostIsAName,
 		// A zone says which interface a link-local address is reached on. It
 		// cannot make that address non-local.
 		"fe80::1%eth0": hostIsLocal,

--- a/backend/internal/modules/ai/sovereignendpoint_test.go
+++ b/backend/internal/modules/ai/sovereignendpoint_test.go
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package ai
+
+import (
+	"strings"
+	"testing"
+)
+
+// The defect this file exists for: `sovereign` was enforced by provider NAME, so
+// a vllm tier pointed at a third-party host validated and ran, and every call in
+// a deployment that declared zero egress went over the public internet.
+func TestSovereignRefusesALocalProviderPointedAtSomebodyElsesHost(t *testing.T) {
+	_, err := ParseRouting([]byte(`
+profile: sovereign
+tiers:
+  local_large:
+    provider: vllm
+    base_url: https://elsewhere.example
+    model: m
+embeddings:
+  provider: ollama
+  model: bge-m3
+`))
+	if err == nil {
+		t.Fatal("a sovereign profile must not accept a vllm tier on a public host")
+	}
+	// The error names the host that failed, because the operator's next action is
+	// to look at that line of their config.
+	if !strings.Contains(err.Error(), "elsewhere.example") {
+		t.Errorf("the refusal must name the host, got %q", err)
+	}
+}
+
+// The mirror: the ordinary sovereign deployment must still boot. An omitted
+// base_url is the provider default, which IS loopback, so treating "unknown" as
+// "refuse" would break every deployment this profile is for.
+func TestSovereignAcceptsTheDefaultedAndTheExplicitlyLocalEndpoint(t *testing.T) {
+	for name, routing := range map[string]string{
+		"defaulted": `
+profile: sovereign
+tiers:
+  local_large: { provider: vllm, model: m }
+embeddings: { provider: ollama, model: bge-m3 }
+`,
+		// A customer's own GPU box on their own network is their infrastructure:
+		// the guarantee is about where data goes, not which process it lands in.
+		"private range on another machine": `
+profile: sovereign
+tiers:
+  local_large: { provider: vllm, base_url: http://10.4.1.20:8000, model: m }
+embeddings: { provider: ollama, base_url: http://192.168.1.5:11434, model: bge-m3 }
+`,
+		"explicit loopback": `
+profile: sovereign
+tiers:
+  local_large: { provider: ollama, base_url: http://127.0.0.1:11434, model: m }
+embeddings: { provider: ollama, base_url: http://localhost:11434, model: bge-m3 }
+`,
+		// fake reaches no endpoint at all, so there is nothing to check.
+		"the offline stub": `
+profile: sovereign
+tiers:
+  local_large: { provider: fake, model: m }
+embeddings: { provider: fake, model: m }
+`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := ParseRouting([]byte(routing)); err != nil {
+				t.Fatalf("a local sovereign binding must boot, got %v", err)
+			}
+		})
+	}
+}
+
+// The embed lane egresses the same content the chat lanes do — a document
+// reaches it as the thing being embedded — so it carries the same rule.
+func TestSovereignChecksTheEmbeddingsEndpointToo(t *testing.T) {
+	_, err := ParseRouting([]byte(`
+profile: sovereign
+tiers:
+  local_large: { provider: vllm, model: m }
+embeddings: { provider: ollama, base_url: https://embeddings.example, model: bge-m3 }
+`))
+	if err == nil || !strings.Contains(err.Error(), "embeddings.example") {
+		t.Fatalf("the embed lane must carry the endpoint rule, got %v", err)
+	}
+}
+
+// Only the profile that promises zero egress constrains the endpoint. A local
+// model reached over a network is an ordinary eu_hosted deployment, and refusing
+// it there would be a rule nothing asked for.
+func TestTheEndpointRuleAppliesOnlyUnderSovereign(t *testing.T) {
+	if _, err := ParseRouting([]byte(`
+profile: eu_hosted
+tiers:
+  local_large: { provider: vllm, base_url: https://elsewhere.example, model: m }
+embeddings: { provider: ollama, model: bge-m3 }
+`)); err != nil {
+		t.Fatalf("eu_hosted may reach a networked local model, got %v", err)
+	}
+}
+
+func TestWhichHostsCountAsCustomerControlled(t *testing.T) {
+	for host, want := range map[string]bool{
+		"127.0.0.1":       true,
+		"::1":             true,
+		"localhost":       true,
+		"LOCALHOST":       true, // host names are case-insensitive
+		"gpu.localhost":   true,
+		"10.4.1.20":       true,
+		"172.16.0.9":      true,
+		"172.32.0.9":      false, // just past the RFC 1918 block, which ends at 172.31
+		"192.168.1.5":     true,
+		"fd00::1":         true, // IPv6 unique-local
+		"169.254.7.7":     true, // link-local
+		"8.8.8.8":         false,
+		"2606:4700::1111": false,
+		// A DNS name is refused even when it looks internal: resolving it at boot
+		// says only where it pointed at boot.
+		"ollama.internal":   false,
+		"elsewhere.example": false,
+	} {
+		if got := hostIsCustomerControlled(host); got != want {
+			t.Errorf("hostIsCustomerControlled(%q) = %v, want %v", host, got, want)
+		}
+	}
+}
+
+// A base_url naming no host is exactly the shape a string-comparison check waves
+// through, so it is refused rather than read as "nothing to see".
+func TestABaseURLWithNoHostIsRefusedUnderSovereign(t *testing.T) {
+	err := requireSovereignEndpoint("tier local_large", providerVLLM, "http://")
+	if err == nil || !strings.Contains(err.Error(), "names no host") {
+		t.Fatalf("a hostless base_url must be refused, got %v", err)
+	}
+}

--- a/docs/how-to/connect-a-cloud-model-provider.md
+++ b/docs/how-to/connect-a-cloud-model-provider.md
@@ -129,6 +129,13 @@ The refusal is bound to the provider _name_, not a config flag, so pointing
 and `fake` are sovereign-eligible. Use `eu_hosted` or `cloud_frontier` for a BYOK
 cloud binding.
 
+The endpoint is checked too, because a local provider name is not on its own a
+local endpoint: `ollama` and `vllm` take a `base_url`, and one pointed at a
+third-party host would send every call of a zero-egress deployment over the
+public internet. Under this profile each binding's resolved `base_url` must be
+loopback, link-local, or a private range — your own GPU box on your own network
+counts; a DNS name does not, since what it resolves to can change after boot.
+
 ## Troubleshooting
 
 | Symptom | Meaning / fix |

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -871,7 +871,19 @@ curl -s https://openrouter.ai/api/v1/models \
 ```
 
 A cloud binding is refused at startup under `profile: sovereign` (zero
-egress by construction). An editor with a YAML language server picks up
+egress by construction) — and so is a **local provider pointed at somebody
+else's host**, because the provider name alone would let a deployment declare
+zero egress and send every call over the public internet. Under that profile
+each binding's resolved `base_url` (an omitted one is the provider default,
+which is loopback) must name an address on infrastructure you control:
+loopback, link-local, or a private range (`10.x`, `172.16–31.x`, `192.168.x`,
+or an IPv6 unique-local address). **A private-range host on another machine
+counts** — your own GPU box is your own infrastructure. A **DNS name is
+refused** even when it looks internal: resolving it at boot says only where it
+pointed at boot, and a profile satisfied by an answer that can change an hour
+later is not a guarantee. Use the IP, or `localhost`.
+
+An editor with a YAML language server picks up
 [`config/ai-routing.schema.json`](../../config/ai-routing.schema.json)
 (referenced from the example's first line) for autocomplete, enum
 validation, and hover docs; the parser remains the sole runtime authority.


### PR DESCRIPTION
Closes #1427. Spec half (contract-first, P3): gradionhq/margince-foundation#1320, **merged**.

## The gap

`profile: sovereign` was enforced by provider **name**, and both local providers take an operator-supplied `base_url` with nothing constraining it. So this validated, ran, and sent every call of a zero-egress deployment to a third-party host:

```yaml
profile: sovereign
tiers:
  local_large: { provider: vllm, base_url: https://elsewhere.example, model: m }
```

What makes it a defect rather than a missing feature is the comment above that check: it said the guarantee held **by construction**, and it did not. An operator reading it has no reason to suspect the profile they picked is satisfied by a hostname nobody validated. (Repo rule: never rationalize a known gap in a comment — restructure it away or gate it with a test.)

## What this does

Under `sovereign`, each binding's **resolved** `base_url` — an omitted one is the provider default, which is loopback — must name loopback, link-local, or a private range (RFC 1918 / IPv6 ULA). At startup, beside the existing provider check, with the error naming the host. The embeddings lane carries the same rule: a document reaches it as the thing being embedded.

## Two decisions the check cannot make for itself

Both now in `ai-operational-spec` §4.3, because "which CIDRs count as sovereign" is a product decision about what the profile promises, not whichever list an engineer picked:

**A private-range host on another machine IS sovereign.** A customer's own GPU box on their own network is their infrastructure; the guarantee is about where data goes, not which process it lands in.

**A DNS name is refused**, even one that looks internal. Resolving it at boot says only where it pointed *at boot*, and a profile satisfied by an answer that can change an hour later is the same false guarantee this check exists to remove. That also keeps `validate()` a pure function with no hidden name-server call.

## Found in review, fixed here

- **The check could drift open.** It keyed off its own provider map while the profile gate keys off `localProviders`; a local provider added to one and not the other would have been checked by nobody — this rule's own failure mode, reopened by drift. A fitness test derives the obligation from `localProviders` rather than restating it.
- **The refusal collapsed two different mistakes.** An operator on Kubernetes or Compose writes a service name, and an error about private ranges reads to them as "your host is public" — which it may not be. Three verdicts now, and the name case says to give the address instead.
- **Edge cases that were reasoned about but not tested**, plus three that were simply wrong: a zoned link-local address (`[fe80::1%25eth0]`) was refused as a name, `localhost.` was refused as a name, and *any* scheme passed — `ollama://127.0.0.1:11434` validated. IPv4-mapped IPv6 (`::ffff:8.8.8.8` is as public as `8.8.8.8`), the unspecified addresses, and a bracketed IPv6 `base_url` are all pinned now.

## Filed rather than folded in

#1442 — the `aicert` `MODEL=` override mutates an already-validated config and nothing re-validates it, so a cert run against a `sovereign` config can build a cloud client. Non-production lane, and a different fix (re-validate after mutation) from this one.

## Verification

- `make check-backend` + `make craft-static` green; `main` merged in before the gate run
- **Coverage on new code: 100%** on `requireSovereignEndpoint`, `classifyHost`, `isReservedLoopbackName`; `hostOf` 85.7% (the unreachable `url.Parse` error arm)
- No UAT video: this change has no surface. Its whole behaviour is a startup refusal, and the tests drive the real `ParseRouting` with real config text — a screen recording of a boot error would prove less than the table does. The manual check, for the record:

```
$ go run ./cmd/api --dsn … --ai-routing r.yaml     # base_url: https://elsewhere.example
api: ai: routing config: tier local_large: profile sovereign needs an endpoint this
installation can verify for itself, and "elsewhere.example" is a name — what it resolves
to is decided elsewhere and can change after boot. Give the address instead (an IP in a
private range, or a loopback address); `localhost` is also accepted
exit status 1

$ go run ./cmd/api --dsn … --ai-routing r.yaml     # base_url: https://203.0.113.9:8000
api: ai: routing config: tier local_large: profile sovereign forbids the host
"203.0.113.9" — the profile promises zero egress, and that address is not on
infrastructure this installation can see is yours. Point it at loopback, a link-local
address, or a private range (10.x, 172.16-31.x, 192.168.x, or an IPv6 unique-local address)
exit status 1
```

Both transcripts are real runs against the built api, and they are the two different
messages the review asked for: a name is refused for being a name, an address for being
somebody else's.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added stricter validation for sovereign AI configurations.
  - Local chat and embeddings providers must use operator-controlled endpoints on loopback, private, or link-local networks.
  - Public, DNS-based, invalid, or unsupported endpoints are rejected with configuration errors.
  - Validation supports IPv4, IPv6, and zoned IPv6 addresses.

- **Documentation**
  - Updated provider setup and configuration guidance to explain sovereign endpoint requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->