### PR TITLE
docs(ai): say what an attachment lane does and does not guarantee

### DIFF
--- a/backend/internal/compose/documentextractrun.go
+++ b/backend/internal/compose/documentextractrun.go
@@ -223,6 +223,13 @@ func (d *DocumentExtractor) sourceFor(
 	// ContentType is optional on the row; a document that never declared one
 	// takes neither lane, which is the honest answer — the alternative is
 	// sniffing bytes here, a second content-type authority beside DOC-PARAM-9's.
+	//
+	// What that decides, stated because it is easy to read the other way
+	// (ai-operational-spec §4.2): this type is the UPLOADER's claim, so whoever
+	// attached the file — an external counterparty on a captured email
+	// included — chooses which lane its bytes take. Carriage is not a content
+	// check, and a binding's `input:` says what this product will send, not what
+	// the bytes are.
 	mime := ""
 	if meta.ContentType != nil {
 		mime = strings.ToLower(strings.TrimSpace(*meta.ContentType))

--- a/backend/internal/compose/documentextractrun.go
+++ b/backend/internal/compose/documentextractrun.go
@@ -224,12 +224,13 @@ func (d *DocumentExtractor) sourceFor(
 	// takes neither lane, which is the honest answer — the alternative is
 	// sniffing bytes here, a second content-type authority beside DOC-PARAM-9's.
 	//
-	// What that decides, stated because it is easy to read the other way
-	// (ai-operational-spec §4.2): this type is the UPLOADER's claim, so whoever
-	// attached the file — an external counterparty on a captured email
-	// included — chooses which lane its bytes take. Carriage is not a content
-	// check, and a binding's `input:` says what this product will send, not what
-	// the bytes are.
+	// So the lane is decided by what INGRESS recorded, and what that means
+	// depends on how the file arrived (ai-operational-spec §4.2): a captured
+	// attachment carries the type sniffed from its bytes, with a disagreeing
+	// sender claim recorded rather than obeyed, while a file uploaded through
+	// the API carries its uploading principal's declared type unsniffed. Either
+	// way carriage is not a content check — a binding's `input:` says what this
+	// product will send, never what the bytes are.
 	mime := ""
 	if meta.ContentType != nil {
 		mime = strings.ToLower(strings.TrimSpace(*meta.ContentType))

--- a/backend/internal/modules/ai/stripper.go
+++ b/backend/internal/modules/ai/stripper.go
@@ -18,6 +18,16 @@ import (
 // pass through untouched, because privacy is the location ladder (A8
 // revised), and pretending a regex protects PII would be a false
 // guarantee.
+//
+// It is a TEXT-lane guarantee, and the spec says so in the same breath as the
+// rule itself (§4.2). The pass runs over the marshalled body, which is the last
+// point before egress and cannot be bypassed — but an attachment rides that body
+// as base64, and every rule below is anchored on characters base64 cannot emit
+// (`-`, `_`, `.`, `:`, `@`, whitespace). A credential inside an attached FILE is
+// therefore unmatchable here by construction, while the same file arriving as
+// text is scrubbed. Reaching it would mean decoding and re-encoding every
+// attachment on every call; the product states the scope instead of implying a
+// cover it does not have.
 func NewSecretStripper() model.SecretStripper {
 	return secretStripper{rules: stripRules}
 }

--- a/backend/internal/modules/ai/stripper.go
+++ b/backend/internal/modules/ai/stripper.go
@@ -22,12 +22,16 @@ import (
 // It is a TEXT-lane guarantee, and the spec says so in the same breath as the
 // rule itself (§4.2). The pass runs over the marshalled body, which is the last
 // point before egress and cannot be bypassed — but an attachment rides that body
-// as base64, and every rule below is anchored on characters base64 cannot emit
-// (`-`, `_`, `.`, `:`, `@`, whitespace). A credential inside an attached FILE is
-// therefore unmatchable here by construction, while the same file arriving as
-// text is scrubbed. Reaching it would mean decoding and re-encoding every
-// attachment on every call; the product states the scope instead of implying a
-// cover it does not have.
+// BASE64-ENCODED, and every rule below matches a secret's literal text. A
+// credential inside an attached FILE is not present in that form, so nothing
+// here can find it, while the same file arriving as text is scrubbed. Reaching
+// it would mean decoding and re-encoding every attachment on every call; the
+// product states the scope instead of implying a cover it does not have.
+//
+// Note which way that runs. The rules are not blind to the ENCODING: two of them
+// (AIza…, AKIA/ASIA…) are alphanumeric enough to match inside a blob by
+// coincidence, which is the inverse hazard and has its own issue. What they
+// cannot see is the plaintext underneath it.
 func NewSecretStripper() model.SecretStripper {
 	return secretStripper{rules: stripRules}
 }

--- a/docs/explanation/agent-surface.md
+++ b/docs/explanation/agent-surface.md
@@ -64,10 +64,10 @@ not architecture**. `internal/modules/ai/` owns it:
   keys, tokens, private keys, password assignments (→ `[SECRET-REMOVED:<kind>]`). It is **hygiene, not
   a PII filter**: names, emails, and phone numbers pass through (privacy is handled by the location
   ladder and the erasure engines, not by stripping). The sovereign profile blocks egress entirely.
-  It is also a **text-lane** guarantee: an attachment rides the payload as base64, and the rules are
-  anchored on characters base64 cannot emit, so a credential *inside an attached file* is
-  structurally unmatchable — while the same file arriving as text is scrubbed. Attaching a document
-  is a decision to send its bytes as they are.
+  It is also a **text-lane** guarantee: an attachment rides the payload base64-encoded, and the rules
+  match a secret's literal text, so a credential *inside an attached file* is not there for them to
+  find — while the same file arriving as text is scrubbed. Attaching a document is a decision to send
+  its bytes as they are.
 - **Metering & budget** — `ai_usage` accumulates per-(workspace, day, task, tier) counters against a
   **workspace monthly token budget** (distinct from the per-run step/output-token ceilings above,
   which stop a single runaway run). At ≥80% utilization the router soft-degrades a tier; at ≥100%

--- a/docs/explanation/agent-surface.md
+++ b/docs/explanation/agent-surface.md
@@ -64,6 +64,10 @@ not architecture**. `internal/modules/ai/` owns it:
   keys, tokens, private keys, password assignments (→ `[SECRET-REMOVED:<kind>]`). It is **hygiene, not
   a PII filter**: names, emails, and phone numbers pass through (privacy is handled by the location
   ladder and the erasure engines, not by stripping). The sovereign profile blocks egress entirely.
+  It is also a **text-lane** guarantee: an attachment rides the payload as base64, and the rules are
+  anchored on characters base64 cannot emit, so a credential *inside an attached file* is
+  structurally unmatchable — while the same file arriving as text is scrubbed. Attaching a document
+  is a decision to send its bytes as they are.
 - **Metering & budget** — `ai_usage` accumulates per-(workspace, day, task, tier) counters against a
   **workspace monthly token budget** (distinct from the per-run step/output-token ceilings above,
   which stop a single runaway run). At ≥80% utilization the router soft-degrades a tier; at ≥100%

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -849,23 +849,26 @@ takes inline bytes or an `http(s)` URL it fetches itself.
 knowing before you enable an attachment lane, because both run the other way
 from what a reader tends to assume:
 
-- **The media type is the uploader's claim, not a finding.** The lane is chosen
-  from the content type recorded when the file was captured; nothing sniffs the
-  bytes, deliberately — a second content-type authority beside the stored one
-  would be its own defect. So whoever attached the file decides which lane its
-  bytes take, **including an external counterparty on a captured email**, and
-  `image/*` matches by prefix. `input: [image]` says what Margince will *carry*;
-  it does not say what the bytes *are*.
+- **Which lane a file takes was decided at ingress, and carriage is not a content
+  check.** The AI lane reads the content type the file is stored with and adds no
+  second authority of its own. What that type means depends on how the file
+  arrived: a **captured** attachment carries the type *sniffed from its bytes*,
+  with a disagreeing sender claim recorded rather than obeyed — so an external
+  counterparty influences the lane only through the bytes they actually sent — while
+  a file **uploaded through the API** carries its uploader's declared type,
+  unsniffed. Either way `image/*` matches by prefix, and `input: [image]` says
+  what Margince will *carry*; it never says what the bytes *are*.
 - **The secret stripper does not reach inside an attachment.** It runs over the
   outbound payload — the right place, and unbypassable — but an attachment rides
-  that payload as base64, and the rules are anchored on characters base64 cannot
-  emit. A credential inside an attached file is therefore structurally
-  unmatchable, while the same file arriving as text is scrubbed.
+  that payload **base64-encoded**, and the rules match a secret's literal text. A
+  credential inside an attached file is not there in that form for them to find,
+  while the same file arriving as text is scrubbed.
 
-Both are defensible where they stand — the alternative to the second is decoding
-and re-encoding every attachment on every call — but they are the scope, not an
-oversight. If a deployment needs more than this, the answer is the location
-ladder (`profile:`) or narrowing the tier with `input:`, not the stripper.
+The second is defensible where it stands — the alternative is decoding and
+re-encoding every attachment on every call — but it is the scope, not an
+oversight. If a deployment needs more than this for a given lane, the answer is
+the location ladder (`profile:`) or narrowing that tier with `input:`, not the
+stripper.
 
 #### `input:` — what the bound model can be given
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -845,6 +845,28 @@ says which file it could not read rather than answering about a document the
 model never saw. An `ollama` binding takes inline bytes only, and `anthropic`
 takes inline bytes or an `http(s)` URL it fetches itself.
 
+**What carrying a document does and does not guarantee.** Two things are worth
+knowing before you enable an attachment lane, because both run the other way
+from what a reader tends to assume:
+
+- **The media type is the uploader's claim, not a finding.** The lane is chosen
+  from the content type recorded when the file was captured; nothing sniffs the
+  bytes, deliberately — a second content-type authority beside the stored one
+  would be its own defect. So whoever attached the file decides which lane its
+  bytes take, **including an external counterparty on a captured email**, and
+  `image/*` matches by prefix. `input: [image]` says what Margince will *carry*;
+  it does not say what the bytes *are*.
+- **The secret stripper does not reach inside an attachment.** It runs over the
+  outbound payload — the right place, and unbypassable — but an attachment rides
+  that payload as base64, and the rules are anchored on characters base64 cannot
+  emit. A credential inside an attached file is therefore structurally
+  unmatchable, while the same file arriving as text is scrubbed.
+
+Both are defensible where they stand — the alternative to the second is decoding
+and re-encoding every attachment on every call — but they are the scope, not an
+oversight. If a deployment needs more than this, the answer is the location
+ladder (`profile:`) or narrowing the tier with `input:`, not the stripper.
+
 #### `input:` — what the bound model can be given
 
 A chat tier bound to `openai_compatible` or `vllm` may declare the input


### PR DESCRIPTION
Closes #1428. Spec half (contract-first, P3): gradionhq/margince-foundation#1323, **merged**.

Found during the security review of #1422; **pre-existing** on the `openai` and `gemini` bindings, which have carried attachments since #701. #1422 extended the same behaviour to the generic OpenAI-compatible wire, which is why it was worth writing down.

## The two facts

Each is defensible on its own. Together they decide what carrying a document means, and both read the other way round to someone who has only met the text lane.

**The secret stripper does not reach inside an attachment.** It runs over the marshalled body — the right place, and unbypassable — but an attachment rides that body as base64, and every rule is anchored on characters base64 cannot emit (`-`, `_`, `.`, `:`, `@`, whitespace). A credential inside an attached *file* is unmatchable by construction; the same file arriving as text is scrubbed. Reaching it would mean decoding and re-encoding every attachment on every call.

**The media type that picks the lane is the uploader's claim.** It is read from what capture recorded and never sniffed — deliberately, because a second content-type authority beside the stored one is its own defect. So whoever attached the file, **an external counterparty on a captured email included**, chooses which lane its bytes take, and `image/*` matches by prefix.

## Where it is said

In the three places a reader actually meets them, rather than one canonical paragraph nobody is standing next to when it matters:

- `stripper.go` — the pass's own doc comment, next to the rules that make it true
- `documentextractrun.go` — at the lane decision, beside the existing note on why nothing sniffs
- `docs/reference/configuration.md` — the operator-facing carriage section, with what to reach for instead (`profile:`, or narrowing the tier with `input:`)
- `docs/explanation/agent-surface.md` — where the stripper is introduced as covering "*every* outbound payload"

## What this is not

Not a decision to sniff, scan, or narrow. Those have real cost and are #1449, filed rather than folded in — sniffing for the carriage decision only, scanning bytes before egress, and surfacing the `StripReport` every adapter currently discards. Stating the scope is what lets those be judged on their merits instead of discovered by surprise.

No behaviour changes here, so there is nothing to UAT: `make check-backend` and `make craft-static` are green, and the diff is comments and prose.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies what the attachment lane does and does not guarantee: the lane is chosen by the content type recorded at ingress (sniffed for captured attachments; uploader-declared for direct API uploads), and the secret stripper guarantees only the text lane and does not inspect encoded attachments. This prevents assuming attachments are sniffed or scrubbed.

- No behavior changes; updates doc comments in `backend/internal/modules/ai/stripper.go` and `backend/internal/compose/documentextractrun.go`, and clarifies operator docs in `docs/reference/configuration.md` and `docs/explanation/agent-surface.md`.
- Lane decision: the AI path adds no second content-type authority; `image/*` matches by prefix; carriage is not a content check; `input:` states what we carry, not what the bytes are.
- Stripper scope: runs over the marshalled body; attachments ride base64, rules match plaintext, so secrets inside an attached file are out of scope; notes the hazard that alphanumeric rules could coincidentally match inside a blob.
- Rollout: none. If stricter handling is needed, use `profile:` or narrow the tier with `input:`.

<sup>Written for commit 66d27cd3e01f68468d3c23ca0804eb89ad37981d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1450?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

