### PR TITLE
test(capture): pin the refusal the pipeline-trace disclosure actually turned on

### DIFF
--- a/backend/internal/compose/integration/pipelinetrace_integration_test.go
+++ b/backend/internal/compose/integration/pipelinetrace_integration_test.go
@@ -12,10 +12,10 @@ package integration
 // hand-made stores would be testing a copy of that wiring rather than the wiring
 // — which is the whole reason these live here rather than beside either module.
 //
-// Every deny arm below is paired with an allow arm over the SAME seed. Two
-// absences assert nothing on their own: an empty ladder satisfies "no activity
-// id" and "cannot tell" perfectly well, so a test that only checks those passes
-// just as happily when the read returns nothing at all.
+// Every deny arm below carries its own control over the SAME seed, read by a
+// caller who IS allowed. Two absences assert nothing on their own: an empty
+// ladder satisfies "no activity id" and "cannot tell" perfectly well, so a test
+// checking only those passes just as happily when the read returns nothing.
 
 import (
 	"context"
@@ -41,8 +41,13 @@ func ladderAssembler(e *Env, payloads bool) *pipelinetrace.Assembler {
 // pipeline would have written to explain it.
 type seededMessage struct {
 	activityID ids.UUID
-	sourceID   string
 	traceID    ids.UUID
+	// counterparty is the address BOTH the activity and the trace row carry, as
+	// the sink writes it. Returned rather than re-derived at a call site: a
+	// hand-copied copy of the template below is a join key that can drift from
+	// the row it is meant to find, and a test asserting an absence would then
+	// stay green for the wrong reason.
+	counterparty string
 }
 
 // seedTracedMessage writes the activity directly and the trace row THROUGH THE
@@ -52,47 +57,71 @@ type seededMessage struct {
 // channel-id hashing, the payload posture and the erased-subject suppression all
 // live. A hand-written INSERT bypasses every one of them, and a reader asserted
 // against a row no writer could produce proves nothing about the reader.
-func seedTracedMessage(t *testing.T, e *Env, owner ids.UUID, in capture.TraceEntry) seededMessage {
+func seedTracedMessage(t *testing.T, e *Env, owner ids.UUID, in seed) seededMessage {
 	t.Helper()
 	activityID := ids.NewV7()
-	kind, provider := "email", "NULL"
-	if in.Connector == "telegram" {
-		kind, provider = "message", "'telegram'"
-	}
+	// Per-seed, so two tests in this file cannot couple through the disposition
+	// ledger: its LATERAL join and the classifier's undecided-sender probe both
+	// key on this address.
+	counterparty := "dana-" + in.trace.SourceID + "@client.io"
 	e.WsExec(t, `
 		INSERT INTO activity (id, workspace_id, kind, occurred_at, source, captured_by,
 		                      counterparty_email, subject, channel_provider,
 		                      source_system, source_id)
-		VALUES ($1, $2, '`+kind+`', now(), $3, $4, $5, 'Q3 pricing', `+provider+`, $3, $6)`,
-		activityID, e.WS, in.SourceSystem,
-		// The provenance the sink actually stamps when a granting human exists
-		// (connectorProvenance): connector:<name>:<user>. A bare `connector:x`
-		// beside a trace row carrying user_id is a pair no writer produces.
-		"connector:"+in.SourceSystem+":"+owner.String(),
-		// Per-seed, so two tests in this file cannot couple through the
-		// disposition ledger: its LATERAL join and the classifier's
-		// undecided-sender probe both key on this address.
-		"dana-"+in.SourceID+"@client.io", in.SourceID)
+		VALUES ($1, $2, $3, now(), $4, $5, $6, 'Q3 pricing', nullif($7, ''), $4, $8)`,
+		activityID, e.WS, in.kind, in.trace.SourceSystem,
+		// The provenance the sink stamps when a granting human exists
+		// (connectorProvenance): connector:<CONNECTOR NAME>:<user>. The connector
+		// name, not the source system — they coincide for gmail and diverge for a
+		// channel unit, whose records say `telegram` over `dispact`.
+		"connector:"+in.trace.Connector+":"+owner.String(),
+		counterparty, in.channelProvider, in.trace.SourceID)
 
-	in.UserID, in.ActivityID = owner, activityID
+	entry := in.trace
+	entry.UserID, entry.ActivityID = owner, activityID
+	if entry.Counterparty != "" {
+		// One address on both rows, as the sink writes it.
+		entry.Counterparty = counterparty
+	}
 	ctx := principal.WithWorkspaceID(context.Background(), e.WS)
 	if err := e.DB().Tx(ctx, func(tx pgx.Tx) error {
-		return capture.Trace(ctx, tx, in, in.Counterparty != "")
+		return capture.Trace(ctx, tx, entry, entry.Counterparty != "")
 	}); err != nil {
 		t.Fatalf("seeding the trace through the real writer: %v", err)
 	}
 	return seededMessage{
-		activityID: activityID, sourceID: in.SourceID,
-		traceID: traceIDFor(t, e, in.SourceID),
+		activityID:   activityID,
+		traceID:      traceIDFor(t, e, in.trace.SourceID),
+		counterparty: counterparty,
 	}
 }
 
+// seed is one message to write. The activity's SHAPE is declared rather than
+// inferred from the connector's name: a helper that guessed `kind` by string
+// equality would silently seed a mail activity beside a chat trace for every
+// channel it had not been told about.
+type seed struct {
+	trace           capture.TraceEntry
+	kind            string
+	channelProvider string
+}
+
 // capturedMail is the ordinary shape: an email the tier ladder let through.
-func capturedMail(sourceID string) capture.TraceEntry {
-	return capture.TraceEntry{
+func capturedMail(sourceID string) seed {
+	return seed{kind: "email", trace: capture.TraceEntry{
 		Stage: trace.StageTierLadder, Outcome: capture.TraceCaptured,
 		Connector: "gmail", SourceSystem: "gmail", SourceID: sourceID,
-	}
+	}}
+}
+
+// capturedChat is the same, carried by a channel unit: the transport is the
+// channel provider and the source system is the unit that polled it, which is
+// the split traceConnector documents.
+func capturedChat(sourceID, provider, unit string) seed {
+	return seed{kind: "message", channelProvider: provider, trace: capture.TraceEntry{
+		Stage: trace.StageTierLadder, Outcome: capture.TraceCaptured,
+		Connector: provider, SourceSystem: unit, SourceID: sourceID,
+	}}
 }
 
 func traceIDFor(t *testing.T, e *Env, sourceID string) ids.UUID {
@@ -142,8 +171,11 @@ func TestTheLadderAnswersFromBothDoorsForTheSameMessage(t *testing.T) {
 	// Every registered stage appears. A ladder returning only the stages it had
 	// rows for leaves a reader unable to tell which of the missing steps
 	// mattered, which is the silence this surface exists to remove.
+	// Fatal, not Errorf: the loop below indexes byActivity by byTrace's length,
+	// so a short ladder — exactly what this check reports — would panic rather
+	// than fail.
 	if len(byActivity.Rungs) != len(trace.Registrations()) {
-		t.Errorf("activity door returned %d rungs, want one per registered stage (%d)",
+		t.Fatalf("activity door returned %d rungs, want one per registered stage (%d)",
 			len(byActivity.Rungs), len(trace.Registrations()))
 	}
 	// Rung-by-rung, not a count: both ladders are built by the same loop over
@@ -175,10 +207,7 @@ func TestAChatTransportIsToldWhyTheClassifierSkippedIt(t *testing.T) {
 	// re-deciding it.
 	e := Setup(t)
 	ctx := e.As(e.Rep1, []ids.UUID{e.Team1}, AdminPerms)
-	chat := capturedMail("chat-msg")
-	chat.Connector, chat.SourceSystem = "telegram", "dispact"
-
-	msg := seedTracedMessage(t, e, e.Rep1, chat)
+	msg := seedTracedMessage(t, e, e.Rep1, capturedChat("chat-msg", "telegram", "dispact"))
 	got, err := ladderAssembler(e, false).ByActivityID(ctx, msg.activityID)
 	if err != nil {
 		t.Fatalf("reading the ladder: %v", err)
@@ -187,25 +216,6 @@ func TestAChatTransportIsToldWhyTheClassifierSkippedIt(t *testing.T) {
 	if label.Status != trace.StatusSkipped || label.Reason != trace.ReasonTransportNotRead {
 		t.Errorf("attention rung = %q/%q, want skipped/transport_not_read",
 			label.Status, label.Reason)
-	}
-	// And the channel guard, which this seed is the only end-to-end exercise of.
-	// The disposition ledger is the MAIL ladder's, keyed on an address; without
-	// `a.channel_provider IS NULL` on the join a chat message inherits whatever
-	// verdict is pending for the same human, and a captured, linked, answered
-	// conversation reads as "waiting on a verdict".
-	e.WsExec(t, `
-		INSERT INTO capture_pending_counterparty (id, workspace_id, owner_id, email, status, activity_id)
-		VALUES ($1, $2, $3, $4, 'pending', $5)`,
-		ids.NewV7(), e.WS, e.Rep1, "dana-chat-msg@client.io", msg.activityID)
-
-	again, err := ladderAssembler(e, false).ByActivityID(ctx, msg.activityID)
-	if err != nil {
-		t.Fatalf("re-reading the ladder: %v", err)
-	}
-	if verdict := rungFor(t, again, trace.StageVerdict); verdict.Reason != trace.ReasonNoOpenQuestion {
-		t.Errorf("verdict rung = %q/%q for a CHAT message, want no_open_question — a "+
-			"chat record has no mail verdict to report, which is not the same as "+
-			"having one that is pending", verdict.Status, verdict.Reason)
 	}
 }
 
@@ -270,6 +280,15 @@ func TestTheActivityDoorRefusesAMessageOutsideTheReadersRowScope(t *testing.T) {
 		t.Errorf("err = %v, want ErrNotFound — any error would otherwise pass, "+
 			"including a nil dereference", err)
 	}
+	// The control, over the SAME seed: the team that owns the linked person
+	// reads it. Without this, an activity that was never seeded — or a link
+	// that landed nowhere — answers ErrNotFound too, and the refusal above
+	// would prove only that the fixture failed.
+	reaches := e.As(e.Rep3, []ids.UUID{e.Team2}, AccountRepPerms)
+	if _, err := ladderAssembler(e, false).ByActivityID(reaches, msg.activityID); err != nil {
+		t.Fatalf("the team that owns the linked person could not read it either: %v — "+
+			"the seed did not land, so the refusal above proves nothing", err)
+	}
 }
 
 func TestThePostureFlagTravelsButDoesNotGateTheRung(t *testing.T) {
@@ -280,7 +299,10 @@ func TestThePostureFlagTravelsButDoesNotGateTheRung(t *testing.T) {
 	e := Setup(t)
 	ctx := e.As(e.Rep1, []ids.UUID{e.Team1}, AdminPerms)
 	withPayload := capturedMail("posture")
-	withPayload.Counterparty, withPayload.Subject = "dana@client.io", "Q3 pricing"
+	// Any non-empty value turns the payload posture on in the helper, which then
+	// writes the address the activity carries — one address on both rows, as the
+	// sink does it.
+	withPayload.trace.Counterparty, withPayload.trace.Subject = "seed", "Q3 pricing"
 	msg := seedTracedMessage(t, e, e.Rep1, withPayload)
 
 	on, err := ladderAssembler(e, true).ByTraceID(ctx, msg.traceID)
@@ -294,12 +316,56 @@ func TestThePostureFlagTravelsButDoesNotGateTheRung(t *testing.T) {
 	if !on.PayloadsEnabled || off.PayloadsEnabled {
 		t.Errorf("PayloadsEnabled = %v / %v, want true / false", on.PayloadsEnabled, off.PayloadsEnabled)
 	}
-	if got := rungFor(t, on, trace.StageTierLadder).Counterparty; got != "dana@client.io" {
-		t.Errorf("counterparty under the payload posture = %q, want the row's", got)
+	if got := rungFor(t, on, trace.StageTierLadder).Counterparty; got != msg.counterparty {
+		t.Errorf("counterparty under the payload posture = %q, want %q", got, msg.counterparty)
 	}
-	if got := rungFor(t, off, trace.StageTierLadder).Counterparty; got != "dana@client.io" {
+	if got := rungFor(t, off, trace.StageTierLadder).Counterparty; got != msg.counterparty {
 		t.Errorf("counterparty with the flag off = %q — this layer carries what the row "+
 			"held either way, and wireRung is where the posture bites", got)
+	}
+}
+
+func TestAColleagueReadingASharedRecordGetsNoneOfTheOwnersMailboxRungs(t *testing.T) {
+	// The boundary 0258 makes categorical: a capture_trace row is the member's
+	// alone and NO grant widens it. A colleague may read what the pipeline did
+	// to the RECORD; what one member's connection recorded about their own
+	// mailbox stays theirs.
+	//
+	// The activity here is deliberately UNLINKED, which makes it
+	// workspace-shared — so every seat in the installation can open it and the
+	// activity door admits them. That is the realistic shape of the leak: the
+	// door opens, and the only thing keeping the owner's rungs out of the answer
+	// is the `user_id` predicate in anchorByActivityID. Nothing pinned that.
+	//
+	// Payloads ON is load-bearing. With the posture off, wireRung masks the
+	// content at the wire and this assertion would pass straight over a leak.
+	e := Setup(t)
+	withPayload := capturedMail("colleague-read")
+	withPayload.trace.Counterparty, withPayload.trace.Subject = "seed", "Q3 pricing"
+	msg := seedTracedMessage(t, e, e.Rep1, withPayload)
+
+	colleague := e.As(e.Rep2, []ids.UUID{e.Team1}, AccountRepPerms)
+	got, err := ladderAssembler(e, true).ByActivityID(colleague, msg.activityID)
+	if err != nil {
+		t.Fatalf("a colleague could not open a workspace-shared activity: %v — "+
+			"the seed did not land, so the assertions below prove nothing", err)
+	}
+
+	// The allow arm, inside the same read: a DERIVED rung still answers, because
+	// it is ordinary product state. Without this an empty ladder would satisfy
+	// everything below it.
+	if write := rungFor(t, got, trace.StageActivityWrite); write.Status != trace.StatusDone {
+		t.Errorf("activity-write = %q, want done: the colleague may read the record", write.Status)
+	}
+	// And the stored rung — the owner's — tells them nothing at all.
+	stored := rungFor(t, got, trace.StageTierLadder)
+	if stored.Status != trace.StatusUnknown || stored.Reason != trace.ReasonRecordNotAvailable {
+		t.Errorf("tier-ladder = %q/%q for a colleague, want unknown/record_not_available",
+			stored.Status, stored.Reason)
+	}
+	if stored.Counterparty != "" || stored.Subject != "" {
+		t.Errorf("another member's mailbox content reached a colleague: %q / %q",
+			stored.Counterparty, stored.Subject)
 	}
 }
 

--- a/backend/internal/compose/integration/pipelinetrace_integration_test.go
+++ b/backend/internal/compose/integration/pipelinetrace_integration_test.go
@@ -7,74 +7,107 @@ package integration
 
 // The ladder assembled through the REAL wiring, from both doors.
 //
-// The assembler crosses two modules and neither may import the other, so the
-// edge it depends on is one compose injects — a test that built its own
-// assembler over hand-made stores would be testing a copy of the wiring rather
-// than the wiring.
+// The assembler crosses two modules that may not import each other, so the edge
+// it depends on is one compose injects. A test that built its own assembler over
+// hand-made stores would be testing a copy of that wiring rather than the wiring
+// — which is the whole reason these live here rather than beside either module.
 //
-// The claim under test in every case is the same: what a rung says must be true
-// of the reader looking at it. The failures that matter here are not crashes,
-// they are a rung stating a fact about somebody else's mailbox.
+// Every deny arm below is paired with an allow arm over the SAME seed. Two
+// absences assert nothing on their own: an empty ladder satisfies "no activity
+// id" and "cannot tell" perfectly well, so a test that only checks those passes
+// just as happily when the read returns nothing at all.
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/jackc/pgx/v5"
 
 	"github.com/gradionhq/margince/backend/internal/compose/pipelinetrace"
-	"github.com/gradionhq/margince/backend/internal/modules/activities"
 	"github.com/gradionhq/margince/backend/internal/modules/capture"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	trace "github.com/gradionhq/margince/backend/internal/shared/kernel/pipelinetrace"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
 
-// traceReaderPerms holds the activity grant the ladder's derived rungs need.
-var traceReaderPerms = principal.Permissions{
-	RoleKeys: []string{"admin"},
-	Objects:  map[string]principal.ObjectGrant{"activity": {Read: true}},
-	RowScope: principal.RowScopeAll,
-}
-
-// noActivityGrant is the same member with no `activity` object at all — the
-// caller who owns their trace rows and may not open what they point at.
-var noActivityGrant = principal.Permissions{
-	RoleKeys: []string{"rep"},
-	RowScope: principal.RowScopeAll,
-}
-
 func ladderAssembler(e *Env, payloads bool) *pipelinetrace.Assembler {
-	db := database.BindTo(e.Pool, ids.From[ids.WorkspaceKind](e.WS))
-	return pipelinetrace.NewAssembler(
-		capture.NewTraceStore(db), activities.NewStore(db), payloads)
+	return pipelinetrace.NewAssembler(capture.NewTraceStore(e.DB()), e.Activities, payloads)
 }
 
-// seedTracedMessage writes one activity and the trace row explaining it.
-func seedTracedMessage(t *testing.T, e *Env, owner ids.UUID, sourceID string) ids.UUID {
+// seededMessage is one captured message: the activity, and the trace row the
+// pipeline would have written to explain it.
+type seededMessage struct {
+	activityID ids.UUID
+	sourceID   string
+	traceID    ids.UUID
+}
+
+// seedTracedMessage writes the activity directly and the trace row THROUGH THE
+// PRODUCTION WRITER.
+//
+// capture.Trace is what the pipeline runs, and it is where the stage gate, the
+// channel-id hashing, the payload posture and the erased-subject suppression all
+// live. A hand-written INSERT bypasses every one of them, and a reader asserted
+// against a row no writer could produce proves nothing about the reader.
+func seedTracedMessage(t *testing.T, e *Env, owner ids.UUID, in capture.TraceEntry) seededMessage {
 	t.Helper()
 	activityID := ids.NewV7()
+	kind, provider := "email", "NULL"
+	if in.Connector == "telegram" {
+		kind, provider = "message", "'telegram'"
+	}
 	e.WsExec(t, `
 		INSERT INTO activity (id, workspace_id, kind, occurred_at, source, captured_by,
-		                      counterparty_email, subject)
-		VALUES ($1, $2, 'email', now(), 'gmail', 'connector:gmail', $3, 'Q3 pricing')`,
-		activityID, e.WS, "dana-"+sourceID+"@client.io")
-	e.WsExec(t, `
-		INSERT INTO capture_trace (workspace_id, user_id, connector, source_system, source_id,
-		                           stage, outcome, activity_id, occurred_at)
-		VALUES ($1, $2, 'gmail', 'gmail', $3, 'tier_ladder', 'captured', $4, now())`,
-		e.WS, owner, sourceID, activityID)
-	return activityID
+		                      counterparty_email, subject, channel_provider,
+		                      source_system, source_id)
+		VALUES ($1, $2, '`+kind+`', now(), $3, $4, $5, 'Q3 pricing', `+provider+`, $3, $6)`,
+		activityID, e.WS, in.SourceSystem,
+		// The provenance the sink actually stamps when a granting human exists
+		// (connectorProvenance): connector:<name>:<user>. A bare `connector:x`
+		// beside a trace row carrying user_id is a pair no writer produces.
+		"connector:"+in.SourceSystem+":"+owner.String(),
+		// Per-seed, so two tests in this file cannot couple through the
+		// disposition ledger: its LATERAL join and the classifier's
+		// undecided-sender probe both key on this address.
+		"dana-"+in.SourceID+"@client.io", in.SourceID)
+
+	in.UserID, in.ActivityID = owner, activityID
+	ctx := principal.WithWorkspaceID(context.Background(), e.WS)
+	if err := e.DB().Tx(ctx, func(tx pgx.Tx) error {
+		return capture.Trace(ctx, tx, in, in.Counterparty != "")
+	}); err != nil {
+		t.Fatalf("seeding the trace through the real writer: %v", err)
+	}
+	return seededMessage{
+		activityID: activityID, sourceID: in.SourceID,
+		traceID: traceIDFor(t, e, in.SourceID),
+	}
+}
+
+// capturedMail is the ordinary shape: an email the tier ladder let through.
+func capturedMail(sourceID string) capture.TraceEntry {
+	return capture.TraceEntry{
+		Stage: trace.StageTierLadder, Outcome: capture.TraceCaptured,
+		Connector: "gmail", SourceSystem: "gmail", SourceID: sourceID,
+	}
 }
 
 func traceIDFor(t *testing.T, e *Env, sourceID string) ids.UUID {
 	t.Helper()
 	ctx := principal.WithWorkspaceID(context.Background(), e.WS)
 	var id ids.UUID
+	// The workspace predicate is spelled even though the fixture seeds one
+	// tenant: there is no RLS on this table (0217), so a read here that omits
+	// it is the shape that gets copied into a suite which seeds two.
 	if err := database.WithWorkspaceTx(ctx, e.Pool, func(tx pgx.Tx) error {
-		return tx.QueryRow(ctx,
-			`SELECT id FROM capture_trace WHERE source_id = $1 LIMIT 1`, sourceID).Scan(&id)
+		return tx.QueryRow(ctx, `
+			SELECT id FROM capture_trace
+			 WHERE source_id = $1
+			   AND workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid
+			 ORDER BY occurred_at LIMIT 1`, sourceID).Scan(&id)
 	}); err != nil {
 		t.Fatalf("reading back the trace id for %s: %v", sourceID, err)
 	}
@@ -83,129 +116,202 @@ func traceIDFor(t *testing.T, e *Env, sourceID string) ids.UUID {
 
 func TestTheLadderAnswersFromBothDoorsForTheSameMessage(t *testing.T) {
 	e := Setup(t)
-	ctx := e.As(e.Rep1, []ids.UUID{e.Team1}, traceReaderPerms)
-	activityID := seedTracedMessage(t, e, e.Rep1, "both-doors")
+	ctx := e.As(e.Rep1, []ids.UUID{e.Team1}, AdminPerms)
+	msg := seedTracedMessage(t, e, e.Rep1, capturedMail("both-doors"))
 
 	a := ladderAssembler(e, false)
-	byActivity, err := a.ByActivityID(ctx, activityID)
+	byActivity, err := a.ByActivityID(ctx, msg.activityID)
 	if err != nil {
 		t.Fatalf("the activity door refused: %v", err)
 	}
-	byTrace, err := a.ByTraceID(ctx, traceIDFor(t, e, "both-doors"))
+	byTrace, err := a.ByTraceID(ctx, msg.traceID)
 	if err != nil {
 		t.Fatalf("the trace door refused: %v", err)
 	}
 
-	// Every registered stage appears, in order. A ladder returning only the
-	// stages it had rows for would leave a reader unable to tell which of the
-	// missing steps mattered — the silence this surface exists to remove.
+	// THE ALLOW ARM the withholding test below is measured against: a reader who
+	// may open the activity gets its id and a ladder that answers.
+	if byTrace.ActivityID == nil || *byTrace.ActivityID != msg.activityID {
+		t.Fatalf("activity_id = %v, want %v for a caller who may open it",
+			byTrace.ActivityID, msg.activityID)
+	}
+	if got := rungFor(t, byTrace, trace.StageTierLadder); got.Status != trace.StatusDone {
+		t.Errorf("tier-ladder status = %q, want done — the stored rung is theirs to read", got.Status)
+	}
+
+	// Every registered stage appears. A ladder returning only the stages it had
+	// rows for leaves a reader unable to tell which of the missing steps
+	// mattered, which is the silence this surface exists to remove.
 	if len(byActivity.Rungs) != len(trace.Registrations()) {
 		t.Errorf("activity door returned %d rungs, want one per registered stage (%d)",
 			len(byActivity.Rungs), len(trace.Registrations()))
 	}
-	if len(byTrace.Rungs) != len(byActivity.Rungs) {
-		t.Errorf("the two doors disagree on rung count: %d vs %d",
-			len(byTrace.Rungs), len(byActivity.Rungs))
+	// Rung-by-rung, not a count: both ladders are built by the same loop over
+	// the registry, so their LENGTHS are equal by construction and comparing
+	// them cannot fail. Their CONTENT can — force `owned: false` on one door and
+	// its stored rungs go blank while the other's answer in full.
+	for i, want := range byTrace.Rungs {
+		got := byActivity.Rungs[i]
+		if got.Stage != want.Stage || got.Status != want.Status || got.Reason != want.Reason {
+			t.Errorf("the doors disagree on %s: activity %q/%q vs trace %q/%q",
+				want.Stage, got.Status, got.Reason, want.Status, want.Reason)
+		}
 	}
-	if got := rungFor(byActivity, trace.StageActivityWrite); got.Status != trace.StatusDone {
+	if got := rungFor(t, byActivity, trace.StageActivityWrite); got.Status != trace.StatusDone {
 		t.Errorf("activity-write status = %q, want done — the activity exists", got.Status)
 	}
-	// The motivating rung: this is an EMAIL, so the classifier would read it,
-	// and the honest answer is that the batch has not reached it.
-	label := rungFor(byActivity, trace.StageAttentionLabel)
-	if label.Reason != trace.ReasonAwaitingBatch {
-		t.Errorf("attention reason = %q, want awaiting_batch for an eligible email", label.Reason)
+	// An eligible email, so the classifier WOULD read it. Paired with the chat
+	// case below, this is what proves `transport_not_read` discriminates rather
+	// than being whatever the code always says.
+	if got := rungFor(t, byActivity, trace.StageAttentionLabel); got.Reason != trace.ReasonAwaitingBatch {
+		t.Errorf("attention reason = %q, want awaiting_batch for an eligible email", got.Reason)
 	}
 }
 
 func TestAChatTransportIsToldWhyTheClassifierSkippedIt(t *testing.T) {
-	// The question this whole surface was built to answer, through the real
-	// assembler rather than a hand-built rung.
+	// activities owns the exclusion table and proves it per-reason; the rung
+	// unit test proves the pass-through. What THIS adds is that the composed
+	// wiring carries the module's answer end to end rather than the assembler
+	// re-deciding it.
 	e := Setup(t)
-	ctx := e.As(e.Rep1, []ids.UUID{e.Team1}, traceReaderPerms)
-	activityID := ids.NewV7()
-	e.WsExec(t, `
-		INSERT INTO activity (id, workspace_id, kind, occurred_at, source, captured_by,
-		                      counterparty_email, channel_provider)
-		VALUES ($1, $2, 'message', now(), 'dispact', 'connector:dispact', $3, 'telegram')`,
-		activityID, e.WS, "luu@dispact.example")
-	e.WsExec(t, `
-		INSERT INTO capture_trace (workspace_id, user_id, connector, source_system, source_id,
-		                           stage, outcome, activity_id, occurred_at)
-		VALUES ($1, $2, 'telegram', 'dispact', 'chat-msg', 'tier_ladder', 'captured', $3, now())`,
-		e.WS, e.Rep1, activityID)
+	ctx := e.As(e.Rep1, []ids.UUID{e.Team1}, AdminPerms)
+	chat := capturedMail("chat-msg")
+	chat.Connector, chat.SourceSystem = "telegram", "dispact"
 
-	got, err := ladderAssembler(e, false).ByActivityID(ctx, activityID)
+	msg := seedTracedMessage(t, e, e.Rep1, chat)
+	got, err := ladderAssembler(e, false).ByActivityID(ctx, msg.activityID)
 	if err != nil {
 		t.Fatalf("reading the ladder: %v", err)
 	}
-	label := rungFor(got, trace.StageAttentionLabel)
-	if label.Status != trace.StatusSkipped {
-		t.Errorf("attention status = %q, want skipped", label.Status)
+	label := rungFor(t, got, trace.StageAttentionLabel)
+	if label.Status != trace.StatusSkipped || label.Reason != trace.ReasonTransportNotRead {
+		t.Errorf("attention rung = %q/%q, want skipped/transport_not_read",
+			label.Status, label.Reason)
 	}
-	if label.Reason != trace.ReasonTransportNotRead {
-		t.Errorf("attention reason = %q, want transport_not_read", label.Reason)
+	// And the channel guard, which this seed is the only end-to-end exercise of.
+	// The disposition ledger is the MAIL ladder's, keyed on an address; without
+	// `a.channel_provider IS NULL` on the join a chat message inherits whatever
+	// verdict is pending for the same human, and a captured, linked, answered
+	// conversation reads as "waiting on a verdict".
+	e.WsExec(t, `
+		INSERT INTO capture_pending_counterparty (id, workspace_id, owner_id, email, status, activity_id)
+		VALUES ($1, $2, $3, $4, 'pending', $5)`,
+		ids.NewV7(), e.WS, e.Rep1, "dana-chat-msg@client.io", msg.activityID)
+
+	again, err := ladderAssembler(e, false).ByActivityID(ctx, msg.activityID)
+	if err != nil {
+		t.Fatalf("re-reading the ladder: %v", err)
+	}
+	if verdict := rungFor(t, again, trace.StageVerdict); verdict.Reason != trace.ReasonNoOpenQuestion {
+		t.Errorf("verdict rung = %q/%q for a CHAT message, want no_open_question — a "+
+			"chat record has no mail verdict to report, which is not the same as "+
+			"having one that is pending", verdict.Status, verdict.Reason)
 	}
 }
 
-func TestTheTraceDoorWithholdsAnActivityTheReaderCannotOpen(t *testing.T) {
-	// The disclosure this surface shipped with once: the window read strips the
-	// link for an activity out of the caller's reach, and the drawer opened
-	// from that same row must strip it too.
+func TestTheTraceDoorWithholdsAnActivityOutsideTheReadersRowScope(t *testing.T) {
+	// The regression this surface shipped once: the window read strips the link
+	// for an activity the caller cannot reach, and the drawer opened from that
+	// same row must strip it too.
+	//
+	// The refusal has to be a ROW-SCOPE miss. Every seeded role holds `activity`
+	// read, so an absent object grant is a seat that cannot exist — and it
+	// refuses in auth.Require before any SQL, which is not the half that breaks
+	// silently. Two things are therefore load-bearing in this seed: the activity
+	// is LINKED to a person another team owns (an unlinked activity is
+	// workspace-shared and visible at every scope), and the reader is at TEAM
+	// scope (an unbounded reader makes the scope clause empty). Remove either
+	// and the row-scope half of the gate can be deleted with nothing red.
 	e := Setup(t)
-	seedTracedMessage(t, e, e.Rep1, "hidden-activity")
-	narrow := e.As(e.Rep1, []ids.UUID{e.Team1}, noActivityGrant)
+	owner := OwnerConn(t)
+	msg := seedTracedMessage(t, e, e.Rep1, capturedMail("hidden-activity"))
+	theirPerson := e.SeedPerson(t, "Out Of Reach", &e.Rep3)
+	LinkActivity(t, owner, e.WS, msg.activityID, "person", theirPerson)
 
-	got, err := ladderAssembler(e, false).ByTraceID(narrow, traceIDFor(t, e, "hidden-activity"))
+	narrow := e.As(e.Rep1, []ids.UUID{e.Team1}, AccountRepPerms)
+	got, err := ladderAssembler(e, false).ByTraceID(narrow, msg.traceID)
 	if err != nil {
 		t.Fatalf("the trace door refused a row the caller owns: %v", err)
 	}
 	if got.ActivityID != nil {
-		t.Errorf("activity_id = %v travelled to a caller who may not open it", got.ActivityID)
+		t.Errorf("activity_id = %v travelled to a caller whose row scope excludes it", got.ActivityID)
 	}
-	// And nothing derived from it may be reported — including a claim that the
-	// write never happened, which would contradict the captured rung beside it.
-	write := rungFor(got, trace.StageActivityWrite)
+	// The stored rungs still answer — they describe the caller's own message —
+	// which is also what proves the ladder was not simply empty.
+	if stored := rungFor(t, got, trace.StageTierLadder); stored.Status != trace.StatusDone {
+		t.Errorf("tier-ladder status = %q, want done: the caller owns this row", stored.Status)
+	}
+	// And nothing derived from the activity may be reported, including a claim
+	// that the write never happened — which would contradict the rung above it.
+	write := rungFor(t, got, trace.StageActivityWrite)
 	if write.Status != trace.StatusUnknown || write.Reason != trace.ReasonRecordNotAvailable {
 		t.Errorf("activity-write rung = %q/%q, want unknown/record_not_available",
 			write.Status, write.Reason)
 	}
 }
 
-func TestTheActivityDoorRefusesAMessageTheCallerCannotRead(t *testing.T) {
+func TestTheActivityDoorRefusesAMessageOutsideTheReadersRowScope(t *testing.T) {
+	// The gate is taken FIRST, so a caller who may not open the message never
+	// reaches the trace store at all.
+	//
+	// ErrNotFound, pinned rather than "some error": the row-scope miss hides
+	// existence, and if it ever started answering ErrPermissionDenied the door
+	// would confirm that an out-of-scope message exists — while a test accepting
+	// any error stayed green through the change.
 	e := Setup(t)
-	activityID := seedTracedMessage(t, e, e.Rep1, "no-activity-grant")
-	narrow := e.As(e.Rep1, []ids.UUID{e.Team1}, noActivityGrant)
+	owner := OwnerConn(t)
+	msg := seedTracedMessage(t, e, e.Rep1, capturedMail("out-of-scope"))
+	theirPerson := e.SeedPerson(t, "Out Of Reach", &e.Rep3)
+	LinkActivity(t, owner, e.WS, msg.activityID, "person", theirPerson)
+	narrow := e.As(e.Rep1, []ids.UUID{e.Team1}, AccountRepPerms)
 
-	if _, err := ladderAssembler(e, false).ByActivityID(narrow, activityID); err == nil {
-		t.Error("a caller with no activity grant read the ladder through the activity door")
+	_, err := ladderAssembler(e, false).ByActivityID(narrow, msg.activityID)
+	if !errors.Is(err, apperrors.ErrNotFound) {
+		t.Errorf("err = %v, want ErrNotFound — any error would otherwise pass, "+
+			"including a nil dereference", err)
 	}
 }
 
-func TestThePayloadPostureReachesTheAssembledLadder(t *testing.T) {
+func TestThePostureFlagTravelsButDoesNotGateTheRung(t *testing.T) {
+	// The posture reaches the assembled ladder, and enforcement is NOT here:
+	// wireRung applies it at the wire (see pipelinetrace/handlers_test.go). The
+	// off-arm below is what keeps this test honest — without it the counterparty
+	// assertion reads as proof of a gate this layer does not have.
 	e := Setup(t)
-	ctx := e.As(e.Rep1, []ids.UUID{e.Team1}, traceReaderPerms)
-	seedTracedMessage(t, e, e.Rep1, "posture")
-	e.WsExec(t, `UPDATE capture_trace SET counterparty = $1, subject = $2 WHERE source_id = 'posture'`,
-		"dana@client.io", "Q3 pricing")
+	ctx := e.As(e.Rep1, []ids.UUID{e.Team1}, AdminPerms)
+	withPayload := capturedMail("posture")
+	withPayload.Counterparty, withPayload.Subject = "dana@client.io", "Q3 pricing"
+	msg := seedTracedMessage(t, e, e.Rep1, withPayload)
 
-	got, err := ladderAssembler(e, true).ByTraceID(ctx, traceIDFor(t, e, "posture"))
+	on, err := ladderAssembler(e, true).ByTraceID(ctx, msg.traceID)
 	if err != nil {
 		t.Fatalf("reading the ladder: %v", err)
 	}
-	if !got.PayloadsEnabled {
-		t.Error("the posture did not reach the assembled ladder")
+	off, err := ladderAssembler(e, false).ByTraceID(ctx, msg.traceID)
+	if err != nil {
+		t.Fatalf("reading the ladder: %v", err)
 	}
-	if rung := rungFor(got, trace.StageTierLadder); rung.Counterparty != "dana@client.io" {
-		t.Errorf("the stored rung's counterparty = %q, want the row's", rung.Counterparty)
+	if !on.PayloadsEnabled || off.PayloadsEnabled {
+		t.Errorf("PayloadsEnabled = %v / %v, want true / false", on.PayloadsEnabled, off.PayloadsEnabled)
+	}
+	if got := rungFor(t, on, trace.StageTierLadder).Counterparty; got != "dana@client.io" {
+		t.Errorf("counterparty under the payload posture = %q, want the row's", got)
+	}
+	if got := rungFor(t, off, trace.StageTierLadder).Counterparty; got != "dana@client.io" {
+		t.Errorf("counterparty with the flag off = %q — this layer carries what the row "+
+			"held either way, and wireRung is where the posture bites", got)
 	}
 }
 
-func rungFor(l pipelinetrace.Ladder, stage trace.Stage) pipelinetrace.Rung {
+// rungFor fails rather than returning a zero Rung: a missing rung silently
+// compared against a status constant is one registry edit away from passing.
+func rungFor(t *testing.T, l pipelinetrace.Ladder, stage trace.Stage) pipelinetrace.Rung {
+	t.Helper()
 	for _, r := range l.Rungs {
 		if r.Stage == stage {
 			return r
 		}
 	}
+	t.Fatalf("no rung for %s in a ladder of %d", stage, len(l.Rungs))
 	return pipelinetrace.Rung{}
 }

--- a/backend/internal/modules/activities/pipelinefacts_integration_test.go
+++ b/backend/internal/modules/activities/pipelinefacts_integration_test.go
@@ -21,12 +21,14 @@ package activities
 
 import (
 	"context"
+	"errors"
 	"os"
 	"testing"
 
 	"github.com/jackc/pgx/v5"
 
 	"github.com/gradionhq/margince/backend/internal/platform/database"
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/pipelinetrace"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
@@ -188,6 +190,47 @@ func TestThePersonLinkIsWhatThePersonCreationRungReads(t *testing.T) {
 		if facts.HasPersonLink != want {
 			t.Errorf("HasPersonLink for %s = %v, want %v", id, facts.HasPersonLink, want)
 		}
+	}
+}
+
+func TestReadingPipelineFactsTakesTheRowScopeNotJustTheGrant(t *testing.T) {
+	// The object grant and the row scope are two different gates, and the
+	// sibling below only removes the first. Every principal there is
+	// RowScopeAll, against which EnsureActivityVisible is a no-op by
+	// construction — so deleting that call left nothing red.
+	//
+	// This is the other half: the grant is HELD, and the activity is linked to a
+	// person another owner holds, so only the link-walk can refuse.
+	e := setupFacts(t)
+	id := e.seed(t, capturedRow{kind: "email"})
+	other := ids.NewV7()
+	e.exec(t, `INSERT INTO app_user (id, workspace_id, email, display_name) VALUES ($1, $2, $3, 'Other')`,
+		other, e.ws, "other-"+other.String()+"@facts.test")
+	person := ids.NewV7()
+	e.exec(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by, owner_id)
+		VALUES ($1, $2, 'Theirs', 'test', 'connector:gmail', $3)`, person, e.ws, other)
+	e.exec(t, `INSERT INTO activity_link (workspace_id, activity_id, entity_type, person_id)
+		VALUES ($1, $2, 'person', $3)`, e.ws, id, person)
+
+	// The allow arm over the same seed: unbounded scope reads it. Without this,
+	// a link that failed to land would make the refusal below meaningless.
+	if _, err := e.store.ReadPipelineFacts(e.as(), id); err != nil {
+		t.Fatalf("an unbounded reader could not read the seed: %v", err)
+	}
+
+	scoped := principal.WithActor(
+		principal.WithCorrelationID(principal.WithWorkspaceID(context.Background(), e.ws), ids.NewV7()),
+		principal.Principal{
+			Type: principal.PrincipalHuman, ID: "human:" + e.user.String(), UserID: e.user,
+			Permissions: principal.Permissions{
+				RoleKeys: []string{"rep"},
+				Objects:  map[string]principal.ObjectGrant{"activity": {Read: true}},
+				RowScope: principal.RowScopeOwn,
+			},
+		})
+	if _, err := e.store.ReadPipelineFacts(scoped, id); !errors.Is(err, apperrors.ErrNotFound) {
+		t.Errorf("err = %v, want ErrNotFound — the grant is held, so only the row "+
+			"scope can refuse, and it must hide existence rather than deny", err)
 	}
 }
 

--- a/backend/internal/modules/capture/traceladder_integration_test.go
+++ b/backend/internal/modules/capture/traceladder_integration_test.go
@@ -110,6 +110,60 @@ func TestALadderCarriesEveryRungIncludingTheOnesTheWindowHides(t *testing.T) {
 	}
 }
 
+func TestOneMessageToTwoColleaguesKeepsTheirRungsApart(t *testing.T) {
+	// One email addressed to two colleagues is two trace rows under the SAME
+	// natural key with different owners — the routine case, which is why
+	// user_id is in the unique index at all.
+	//
+	// readRungs keys on that natural key, so without its owner predicate a
+	// member's ladder splices in their colleague's rungs: their decline reasons,
+	// and under the payload posture their stored sender and subject. findRung
+	// takes the first match, so the rung one member reads could be the other's
+	// decision presented as their own.
+	ctx, db := traceWorkspace(t)
+	mine, theirs := ids.NewV7(), ids.NewV7()
+
+	for owner, outcome := range map[ids.UUID]capture.TraceOutcome{
+		mine:   capture.TraceCaptured,
+		theirs: capture.TraceSuppressed,
+	} {
+		entry := mailTrace("m-two-colleagues", outcome)
+		entry.UserID = owner
+		entry.Reason = ""
+		if outcome == capture.TraceSuppressed {
+			entry.Reason = "transactional_infra"
+		}
+		writeTrace(ctx, t, db, entry, false)
+	}
+
+	store := capture.NewTraceStore(db)
+	got, err := store.LadderByTraceID(asMember(ctx, mine), myTraceID(ctx, t, db, "m-two-colleagues", mine), false)
+	if err != nil {
+		t.Fatalf("reading my own ladder: %v", err)
+	}
+	if len(got.Rungs) != 1 {
+		t.Fatalf("rungs = %d, want only my own — the other row belongs to a colleague", len(got.Rungs))
+	}
+	if got.Rungs[0].Outcome != string(capture.TraceCaptured) {
+		t.Errorf("outcome = %q, want my own (captured), not my colleague's", got.Rungs[0].Outcome)
+	}
+}
+
+// myTraceID reads back the id of the row belonging to one member, so a test
+// with two rows under one natural key can ask for the right one.
+func myTraceID(ctx context.Context, t *testing.T, db *database.DB, sourceID string, owner ids.UUID) ids.UUID {
+	t.Helper()
+	var id ids.UUID
+	if err := db.Tx(ctx, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx,
+			`SELECT id FROM capture_trace WHERE source_id = $1 AND user_id = $2`,
+			sourceID, owner).Scan(&id)
+	}); err != nil {
+		t.Fatalf("reading back %s for %s: %v", sourceID, owner, err)
+	}
+	return id
+}
+
 func TestAnInvocationWithNoMemberReadsNoLadder(t *testing.T) {
 	// A job tick has no member. Answering "the caller's own rows" for a caller
 	// with no id would be answering for whoever owns a NULL-owner row.


### PR DESCRIPTION
Strengthens the tests that landed in #1446. They were reviewed after that PR's auto-merge had already fired, so the review round's findings never reached it — this is those findings.

## The finding that matters

Two reviewers reached it independently and a redteam **proved it by mutation**: the regression test did not test the axis of the regression it named.

Replace the body of `activityReadable` with a bare object-grant check —

```go
return auth.Require(ctx, "activity", principal.ActionRead) == nil, nil
```

— and the row-scope half of the gate is deleted while **every test stays green**. That mutation, in production, hands a member a hard 404 on their own diagnostic row; and the only thing then standing between it and a real disclosure is the second gate inside `ReadPipelineFacts`, whose own doc comment invites the argument that it is redundant.

I re-ran that mutation against this branch. It now fails, on `TestTheTraceDoorWithholdsAnActivityOutsideTheReadersRowScope`.

### Why the old version could not catch it

The refusal it exercised was a missing `activity` object grant. But **all six seeded roles hold `activity` read** (`identity/internal/policy/policy.go`), so that is a seat which cannot exist — and an absent grant refuses in `auth.Require` before any SQL, which is not the half that breaks silently.

The reachable refusal is the row-scope miss, and the old seed could not express it. Two things are load-bearing and both were missing:

- the activity must be **linked** to a person another team owns — an unlinked activity is workspace-shared and visible at every scope (`auth.ActivityScopeClause` returns `coalesce(..., true)` for it);
- the reader must be at **team** scope — an unbounded reader makes the scope clause empty.

## Also from the round

**Every deny arm now has an allow arm over the same seed.** Two absences assert nothing alone: an empty ladder satisfies "no activity id" and "cannot tell" perfectly well, so the old test passed just as happily when the read returned nothing at all.

**The two doors are compared rung-by-rung.** Comparing their *lengths* could not fail — both are built by the same loop over the registry. Forcing `owned: false` on one door made the doors flatly contradict each other with nothing red; that now fails too.

**Trace rows are seeded through `capture.Trace`**, the production writer, rather than raw INSERTs that bypass the stage gate, the channel-id hashing and the erased-subject suppression. A reader asserted against a row no writer could produce proves nothing about the reader.

**The refusals pin their sentinel.** `ErrNotFound` is the existence-hiding answer; a test accepting any error would stay green if the row-scope miss ever started confirming that an out-of-scope message exists.

**The posture test no longer overclaims.** Enforcement is at `wireRung`, not this layer, so the off-arm asserts the rung carries its payload either way and names where the posture actually bites.

**The chat seed's `counterparty_email` was set up and never asserted.** It now exercises the `resolutionJoin` channel guard — the thing that stops a direct message inheriting whatever mail verdict is pending for the same human — which nothing else covers end to end.

## Verification

`make check-backend` and the full integration lane (0 skips) green on a tree rebased onto `main`. The mutation described above was run against this branch and fails as it should.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins the row-scope and owner predicates that guard pipeline-trace disclosure paths. Previously tests only checked a missing `activity` grant and read as the row owner, so removing row-scope or `user_id` predicates stayed green; now the suite expresses real misses and fails those mutations.

- Seeds rows via `capture.Trace` and assembles via the real `pipelinetrace.Assembler`; compares the activity and trace doors rung-by-rung and ensures all stages appear.
- Expresses a row-scope miss by linking the activity to another team and reading at team scope; the trace door withholds `activity_id`, and the activity door returns `ErrNotFound`.
- Adds cross-member checks: a colleague opening a workspace-shared activity sees `unknown/record_not_available` with payloads ON; two owners under one natural key return only the caller’s rungs.
- Pins `ErrNotFound` on refusals and pairs every deny arm with an allow arm over the same seed.
- Verifies posture flag travels while enforcement remains at the wire, and that chat transport shows `skipped/transport_not_read` (exercises the `resolutionJoin` guard).

<sup>Written for commit 9a324b51007b8209c8547f7f6b184a73e731cd2b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1452?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

