### PR TITLE
fix(ci): main's quality gate stops going red for want of a coverage report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -800,8 +800,26 @@ jobs:
     # area-scoped: a frontend-only PR legitimately skips deterministic-gates +
     # integration (and a backend-only PR skips frontend) yet SonarCloud must
     # still post its required "SonarCloud Code Analysis" check. A skipped
-    # upstream just means that area produced no coverage artifact — the scan
-    # proceeds without it (that area has no new code to measure).
+    # upstream just means that area produced no coverage artifact — and on a
+    # PR the scan proceeds without it, because new code there is the diff and
+    # a diff that skipped an area has no lines in it for that area to cover.
+    #
+    # That reasoning does NOT survive the move to a push. main's new-code
+    # period is `previous_version`, so its new code is every line added since
+    # the last release marker — weeks of Go — and a push REPLACES main's
+    # stored analysis rather than adding a second one. The scanner's Zero
+    # Coverage Sensor scores every executable line it holds no report for as
+    # uncovered, so a push that skipped the Go coverage producer publishes
+    # those weeks at 0% and the quality gate reads red until some later push
+    # happens to rescan them. A docs-only merge skips every producer, which
+    # makes it the common way in. Measuring nothing is not a measurement of
+    # zero, so such a push does not scan and main keeps its last real reading.
+    #
+    # `integration` alone stands for the Go coverage, and the backend
+    # classifier scope starts every backend producer together — so a run that
+    # has it has the profile that dominates main's new code. A frontend-only
+    # push therefore waits for the next backend one rather than publishing
+    # main with no Go coverage at all.
     #
     # deterministic-gates is gated directly, not just transitively. Now that
     # integration runs in parallel with the build gate rather than behind it, a
@@ -819,6 +837,7 @@ jobs:
       && (needs.frontend.result == 'success' || needs.frontend.result == 'skipped')
       && (needs.extension-reference.result == 'success' || needs.extension-reference.result == 'skipped')
       && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
+      && (github.event_name == 'pull_request' || needs.integration.result == 'success')
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ DATASET ?= $(abspath $(DATASET_ROOT)/../margince-demo-database)
 # DEV_SLUG stack on another port.
 SEED_DSN ?= postgres://margince_owner:dev@localhost:15432/margince
 
-.PHONY: help install ai-routing-local dev-fresh check check-backend check-q check-go check-gates check-fe build test test-v test-cover test-integration e2e-siteread e2e-ai e2e-ai-report ai-probe test-db-up test-it test-integration-serial bench-perf bench-record bench-capture perfdoc lint arch-lint vet gen gen-workflow mcp-apps-vocab gen-types gen-types-check drift composition check-composition test-extensions db-up db-init db-wait migrate migrate-up migrate-down run psql redis-cli tidy dev dev-stop dev-logs clean vuln tools tools-go infra-up infra-down infra-logs infra-reset seed-dev seed-dev-db seed-demo verify-demo seed-reset verify-boot frontend-check frontend-e2e bench-mobile perfdoc e2e-company fe-install fe-typecheck fe-typecheck-composed fe-lint fe-build fe-preview fe-format fe-test fe-test-ext fe-ds-gates fe-drift fe-unit fe-quality fe-bundle fe-storybook ds-purity font-lock icon-lint ds-spacing space-tokens native-controls ext-imports fitness-jurisdiction storybook fe-uat craft-static craft-test craft-residue check-craft-doc test-golangci-guard secret-scan test-secret-scan check-image-pins check-host-ports ci-doc-parity make-target-parity check-ext-migrations contract-breaking-check migration-versions test-lanes env-reads gofmt lint-modules go-file-length rls-store-path no-jurisdiction pkg-freeze hooks sbom sbom-normalize sbom-supplement sbom-parity sbom-validate sbom-sign sbom-check
+.PHONY: help install ai-routing-local dev-fresh check check-backend check-q check-go check-gates check-fe build test test-v test-cover test-integration e2e-siteread e2e-ai e2e-ai-report ai-probe test-db-up test-it test-integration-serial bench-perf bench-record bench-capture perfdoc lint arch-lint vet gen gen-workflow mcp-apps-vocab gen-types gen-types-check drift composition check-composition test-extensions db-up db-init db-wait migrate migrate-up migrate-down run psql redis-cli tidy dev dev-stop dev-logs clean vuln tools tools-go infra-up infra-down infra-logs infra-reset seed-dev seed-dev-db seed-demo verify-demo seed-reset verify-boot frontend-check frontend-e2e bench-mobile perfdoc e2e-company fe-install fe-typecheck fe-typecheck-composed fe-lint fe-build fe-preview fe-format fe-test fe-test-ext fe-ds-gates fe-drift fe-unit fe-quality fe-bundle fe-storybook ds-purity font-lock icon-lint ds-spacing space-tokens native-controls ext-imports fitness-jurisdiction storybook fe-uat craft-static craft-test craft-residue check-craft-doc test-golangci-guard test-scheduled-report secret-scan test-secret-scan check-image-pins check-host-ports ci-doc-parity make-target-parity check-ext-migrations contract-breaking-check migration-versions test-lanes env-reads gofmt lint-modules go-file-length rls-store-path no-jurisdiction pkg-freeze hooks sbom sbom-normalize sbom-supplement sbom-parity sbom-validate sbom-sign sbom-check
 
 # Bare `make` lists every command instead of running the first target.
 .DEFAULT_GOAL := help
@@ -62,7 +62,7 @@ ai-routing-local:
 ## gates plus the backend gate (build, vet, lint, arch-lint, unit + fitness
 ## tests, contract drift). No frontend toolchain needed — this is what the CI
 ## deterministic-gates job runs.
-check-backend: check-craft-doc craft-test test-golangci-guard check-image-pins check-host-ports ci-doc-parity make-target-parity contract-breaking-check migration-versions test-lanes env-reads gofmt lint-modules go-file-length rls-store-path no-jurisdiction pkg-freeze
+check-backend: check-craft-doc craft-test test-golangci-guard test-scheduled-report check-image-pins check-host-ports ci-doc-parity make-target-parity contract-breaking-check migration-versions test-lanes env-reads gofmt lint-modules go-file-length rls-store-path no-jurisdiction pkg-freeze
 	$(MAKE) -C backend check
 
 ## check — the full merge gate: backend + frontend
@@ -482,6 +482,15 @@ secret-scan:
 ## the policy is only trustworthy with this beside it.
 test-secret-scan:
 	@./scripts/test-secret-scan.sh
+
+## test-scheduled-report — prove the scheduled lane still files ONE issue per
+## failing check: stub the tracker, and require the reporter to find an already
+## open issue however far down the list it sits. A dedupe that misses reads
+## exactly like a first report, so the reporter is only trustworthy with this
+## beside it. Gated here rather than in the scheduled lane itself, because that
+## lane runs the reporter only on a red day — an edit to it lands on a green one.
+test-scheduled-report:
+	@./scripts/test-scheduled-report.sh
 
 ## check-image-pins — every `uses:` in .github/workflows/ AND every container
 ## `image:` (workflow service containers + infra/docker-compose.dev.yml) is

--- a/infra/ci-pipeline.md
+++ b/infra/ci-pipeline.md
@@ -207,6 +207,16 @@ Wiring details:
   upstream (an area-scoped skip produced no artifact; the scan proceeds
   without it), but a real `failure` of `deterministic-gates` skips the scan so
   it never posts a green check over a broken build.
+- On a **push** the scan additionally requires `integration` to have
+  succeeded. A push replaces main's stored analysis, main's new-code period is
+  `previous_version` (weeks of Go, not this commit's diff), and the scanner's
+  Zero Coverage Sensor scores every executable line it has no report for as
+  uncovered — so a push carrying no Go coverage would publish those weeks at
+  0% and turn the quality gate red until a later push rescanned them. A
+  docs-only merge skips every coverage producer and is the common way in. Such
+  a push now skips the scan instead, and main keeps its last real reading. On a
+  pull request the rule does not apply: new code there is the diff, and a diff
+  that skipped an area has no lines of that area to cover.
 
 ## Security posture
 

--- a/scripts/scheduled-report.sh
+++ b/scripts/scheduled-report.sh
@@ -16,10 +16,20 @@ set -euo pipefail
 : "${RUN_URL:?RUN_URL must link the run that produced this verdict}"
 
 # report <title> <label> <body>
+#
+# The lookup reads EVERY open issue, not a first page of them. A capped read
+# answers "no issue with this title" the moment the tracker outgrows the cap —
+# and because the cap pages newest-first, the issue it stops short of is
+# precisely the long-lived one this dedupe exists to find. The tracker passing
+# that mark is invisible from here: nothing fails, a second issue is simply
+# filed under a title that already had one, and the discussion on the first is
+# left behind. The oldest open match therefore wins: it is the one carrying
+# whatever triage the title has already collected.
 report() {
   local title="$1" label="$2" body="$3" existing
-  existing="$(gh issue list --repo "$REPO" --state open --limit 100 --json number,title |
-    jq -r --arg t "$title" 'map(select(.title == $t)) | .[0].number // empty')"
+  existing="$(gh api --paginate "repos/$REPO/issues?state=open&per_page=100" |
+    jq -rs --arg t "$title" '[.[][] | select(has("pull_request") | not)
+      | select(.title == $t)] | min_by(.number) | .number // empty')"
   if [ -n "$existing" ]; then
     echo "already open as #$existing — commenting"
     gh issue comment "$existing" --repo "$REPO" \

--- a/scripts/test-scheduled-report.sh
+++ b/scripts/test-scheduled-report.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# test-scheduled-report.sh — prove scheduled-report.sh files ONE issue per
+# failing check, however long the tracker has grown.
+#
+# It runs beside the reporter in the scheduled lane for the same reason
+# `test-reap-build-caches.sh` runs beside the reaper: the reporter can only be
+# observed succeeding, and "it filed something" is not evidence it filed the
+# right thing. A dedupe that reads a first page of open issues reports success
+# on the day it starts duplicating — the tracker outgrows the page, the
+# long-lived issue falls off the end of it, and a second one is filed under a
+# title that already had one.
+#
+# `gh` is stubbed on PATH, so no case reaches the network or the tracker.
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+stub_dir="$(mktemp -d)"
+trap 'rm -rf "$stub_dir"' EXIT
+failures=0
+
+# The stub answers the open-issue read from OPEN_TITLES — one `number<TAB>title`
+# per line — as the paginated API answers it: a stream of JSON arrays, newest
+# first, one per page. Everything the reporter then does to the tracker is
+# recorded rather than performed, so a case asserts on the action taken.
+cat >"$stub_dir/gh" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+case "$1 ${2:-}" in
+"api --paginate")
+	# Paginate at 100 so a case can put its match beyond the first page, which
+	# is the whole failure being tested.
+	awk -F'\t' '
+		{ items[NR] = "{\"number\":" $1 ",\"title\":\"" $2 "\"}" }
+		END {
+			if (NR == 0) { print "[]"; exit }
+			for (i = 1; i <= NR; i++) {
+				page = page (page == "" ? "" : ",") items[i]
+				if (i % 100 == 0) { print "[" page "]"; page = "" }
+			}
+			if (page != "") print "[" page "]"
+		}' <<<"$OPEN_TITLES"
+	;;
+"issue comment") echo "comment $3" >>"$ACTION_LOG" ;;
+"issue create")
+	for i in $(seq 1 $#); do
+		if [ "${!i}" = "--title" ]; then j=$((i + 1)); echo "create ${!j}" >>"$ACTION_LOG"; fi
+	done
+	;;
+*) echo "unexpected gh call: $*" >&2; exit 1 ;;
+esac
+STUB
+chmod +x "$stub_dir/gh"
+export PATH="$stub_dir:$PATH"
+
+readonly GATE_TITLE="SonarCloud quality gate is not green on main"
+
+# expect <name> <expected-actions> <open-issues-tsv>
+#
+# Only the quality gate is reported failing, so the expected action is exactly
+# one line naming what the reporter did about GATE_TITLE.
+expect() {
+	local name="$1" want="$2" open="$3" out status got
+	export ACTION_LOG="$stub_dir/actions"
+	: >"$ACTION_LOG"
+	set +e
+	out="$(OPEN_TITLES="$open" GH_TOKEN=stub REPO=owner/repo RUN_URL=https://example.test/run/1 \
+		GATE_RESULT=failure GATE_STATUS=ERROR \
+		"$root/scripts/scheduled-report.sh" 2>&1)"
+	status=$?
+	set -e
+	got="$(paste -sd, - <"$ACTION_LOG")"
+
+	if [ "$status" -ne 0 ] || [ "$got" != "$want" ]; then
+		echo "FAIL: $name"
+		echo "  exit    want 0 got $status"
+		echo "  actions want '$want' got '$got'"
+		printf '  output: %s\n' "$out" | head -5
+		failures=$((failures + 1))
+	else
+		echo "ok: $name"
+	fi
+}
+
+# A tracker of `n` open issues, none of them the reported one, newest first.
+noise() {
+	local n="$1" i
+	for ((i = n; i >= 1; i--)); do printf '%s\t%s\n' "$i" "an unrelated finding $i"; done
+}
+
+expect "an empty tracker gets the issue" \
+	"create $GATE_TITLE" ""
+
+expect "an open issue under the same title is commented, not re-filed" \
+	"comment 40" \
+	"$(printf '99\ta later finding\n40\t%s\n' "$GATE_TITLE")"
+
+# The defect: 150 open issues, the match at the far end. A read capped at the
+# first 100 files a duplicate here and calls it a clean run.
+expect "an open issue past the first page is still found" \
+	"comment 7" \
+	"$(noise 150 | sed "s/^7\t.*/7\t$GATE_TITLE/")"
+
+# Two issues already carry the title — the state the capped read produced. The
+# repeat belongs on the one holding the triage, which is the older number.
+expect "duplicates already filed: the oldest keeps the discussion" \
+	"comment 12" \
+	"$(printf '300\t%s\n12\t%s\n' "$GATE_TITLE" "$GATE_TITLE")"
+
+# Exact titles only: a near miss is a different finding, and folding it into
+# this one would hide it behind an issue nobody opened for it.
+expect "a similar title is a different finding" \
+	"create $GATE_TITLE" \
+	"$(printf '55\tSonarCloud quality gate is not green on staging\n')"
+
+if [ "$failures" -ne 0 ]; then
+	echo "FAIL: $failures case(s)" >&2
+	exit 1
+fi
+echo "OK: scheduled-report files one issue per check"


### PR DESCRIPTION
Both halves of last night's red `main` traced to CI reading its own signals wrong. `main` itself was already green by the time this was investigated — the backend gate ([#1412](https://github.com/gradionhq/margince-poc-v1/issues/1412)) had been repaired by later merges, and the quality gate ([#1411](https://github.com/gradionhq/margince-poc-v1/issues/1411)) had healed itself. Neither cause had.

## The quality gate published 0% because nothing had measured it

`main`'s new-code period is `previous_version`, dated 2026-07-06 — its new code is six weeks of Go, not the pushed commit's diff. A push REPLACES the stored analysis. And the scanner's Zero Coverage Sensor scores every executable line it holds no report for as *uncovered*, rather than as unmeasured.

So a docs-only merge, which matches no classifier scope and skips every coverage producer, still ran the scan and published those six weeks at `0.0`. From the run that did it (e6e1d671, #1404):

```
WARN  Coverage report can't be loaded, report file not found, ignoring this file backend/coverage.out.
WARN  Coverage report can't be loaded, report file not found, ignoring this file backend/coverage-extensions.out.
INFO  Sensor Zero Coverage Sensor
```

and 70 minutes later the scheduled reader:

```
quality gate on main: ERROR
  failing: new_coverage LT 80 (actual 0.0)
```

The job comment claimed a skipped upstream "has no new code to measure". That is true of a pull request, where new code IS the diff, and false of a push. The scan now runs on a push only when the Go coverage producer ran — measuring nothing is not a measurement of zero. Pull requests are untouched, so the required check still posts on every ready PR.

The reading it was destroying is the one `main` carries again today: `new_coverage 85.1`, gate `OK`.

## The reporter filed a second issue under a title that already had one

[#1411](https://github.com/gradionhq/margince-poc-v1/issues/1411) is a duplicate of [#975](https://github.com/gradionhq/margince-poc-v1/issues/975), which was open, titled identically, and carried four days of "still failing" comments. `report()` looked for an existing issue in `gh issue list --limit 100` — newest first. With 311 open issues that page stops at #1123, and #975 is below it.

The failure is silent by construction: nothing errors, a second issue is simply filed and the triage on the first is left behind. The lookup paginates the whole open set now, and the oldest match wins because it is the one holding the discussion.

## Proof

- `make check-backend` green on the branch (exit 0), including the new gate.
- `scripts/test-scheduled-report.sh` covers five cases; the two that matter were mutation-tested against the code that loses them:
  - reading only the first page → `FAIL: an open issue past the first page is still found` (it filed a duplicate).
  - taking the newest match instead of the oldest → `FAIL: duplicates already filed: the oldest keeps the discussion`.
- The new dedupe query was run against the live tracker before being committed: it resolves both report titles to their real issue numbers and returns empty for a title nobody has filed.

The test is wired into `check-backend` rather than beside the reporter in `scheduled.yml`, because that lane runs the reporter only on a red day while an edit to it lands on a green one.

## Not fixed here

- A frontend-only push now waits for the next backend push rather than publishing `main` with no Go coverage at all. Frontend coverage on `main` is still only ever measured by a push that carries both — the same Zero Coverage Sensor arithmetic, one language over. Worth its own issue if the FE share of new code grows.
- [#1412](https://github.com/gradionhq/margince-poc-v1/issues/1412)'s underlying cause is not a CI bug at all: `compose/server.go` reached 501 lines only in the MERGE of #1391 with what landed while it was open — 498 + 3, each side green alone. That is [#1130](https://github.com/gradionhq/margince-poc-v1/issues/1130) (required status checks are not strict), the same class as the migration-number collision in #1271, and it still wants a human's call on throughput cost.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents main’s SonarCloud quality gate from turning red when a push has no coverage, and stops the scheduled CI reporter from duplicating issues.

- On push, SonarCloud analysis now runs only if the backend `integration` job succeeded (Go coverage present). Old behavior: scans ran without reports and published 0% via the Zero Coverage Sensor, replacing main’s analysis. New behavior: docs-only or frontend-only pushes skip the scan and keep the last real reading. Pull requests are unchanged; the required check still posts.
- The scheduled reporter paginates all open issues via `gh api --paginate` and comments on the oldest matching title. Old behavior: it searched only the newest 100 and filed duplicates when the canonical issue was beyond page one. Added `scripts/test-scheduled-report.sh`, wired into `check-backend` as `test-scheduled-report`.

<sup>Written for commit 58866d06828293fd215e7b26ac016f301724e0e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1454?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

