### PR TITLE
fix(aicert): a MODEL= override goes back through the config's own rules

### DIFF
--- a/backend/internal/compose/aicert/runner_helpers_test.go
+++ b/backend/internal/compose/aicert/runner_helpers_test.go
@@ -171,6 +171,63 @@ func TestOverrideForTaskKeepsAVariantSuffixedModelSlugWhole(t *testing.T) {
 	}
 }
 
+// sovereignRoutingConfig is a base bound the way a sovereign customer binds
+// one: every chat tier and the embed lane on same-host inference, with no
+// base_url, so each resolves to its provider's loopback default.
+func sovereignRoutingConfig() ai.RoutingConfig {
+	local := ai.ProviderConfig{Provider: "ollama", Model: "llama3.1:8b"}
+	return ai.RoutingConfig{
+		Profile: ai.ProfileSovereign,
+		Tiers: map[ai.Tier]ai.ProviderConfig{
+			ai.TierLocalSmall: local,
+			ai.TierCheapCloud: local,
+			ai.TierPremium:    local,
+		},
+		Embeddings: ai.EmbeddingsConfig{ProviderConfig: local, Dimensions: 1024},
+	}
+}
+
+// An override rebinds the tiers the profile rule is ABOUT, so the loaded
+// file's guarantees do not survive it. Certifying a cloud model is a
+// legitimate thing to want; doing it against a config that still says
+// sovereign, with nothing said about it, produces numbers describing a
+// deployment nobody has.
+func TestOverrideForTaskRefusesACloudModelUnderASovereignProfile(t *testing.T) {
+	base := sovereignRoutingConfig()
+	if err := base.Validate(); err != nil {
+		t.Fatalf("the fixture base must itself be valid, or this proves nothing: %v", err)
+	}
+
+	_, err := overrideForTask(base, ai.TaskColdStart, "anthropic:claude-cert-test")
+	if err == nil {
+		t.Fatal("a cloud override under profile sovereign was accepted; the run would have built the client and called api.anthropic.com")
+	}
+	// The refusal has to name both halves or it is unactionable: WHICH knob
+	// caused it, and WHAT rule it broke.
+	if !strings.Contains(err.Error(), "MARGINCE_AICERT_MODEL=anthropic:claude-cert-test") {
+		t.Errorf("the refusal must name the override that caused it, got %q", err)
+	}
+	if !strings.Contains(err.Error(), "profile sovereign forbids cloud provider") {
+		t.Errorf("the refusal must carry the rule the config's own boot would have given, got %q", err)
+	}
+}
+
+// The other arm, and the one that stops the check above from passing for the
+// wrong reason: re-validating must not refuse an override the profile allows.
+func TestOverrideForTaskAcceptsALocalModelUnderASovereignProfile(t *testing.T) {
+	base := sovereignRoutingConfig()
+
+	overridden, err := overrideForTask(base, ai.TaskColdStart, "ollama:qwen3:14b")
+	if err != nil {
+		t.Fatalf("a local override under profile sovereign must run, got %v", err)
+	}
+	for _, tier := range ai.TaskLadder(ai.TaskColdStart) {
+		if got := overridden.Tiers[tier].Model; got != "qwen3:14b" {
+			t.Errorf("tier %s model = %q, want the override's model", tier, got)
+		}
+	}
+}
+
 func TestGroupByTaskFiltersAndSortedTasksOrdersDeterministically(t *testing.T) {
 	scenarios := []Scenario{
 		{Name: "a", Task: string(ai.TaskSummarize)},

--- a/backend/internal/compose/aicert/selection.go
+++ b/backend/internal/compose/aicert/selection.go
@@ -23,6 +23,17 @@ import (
 // addresses the vendor rather than the model; switching provider drops it.
 // Empty override is a no-op: the candidate then rides base exactly like
 // the judge.
+//
+// The result goes back through ai.RoutingConfig.Validate before it is
+// returned. base arrived validated, but an override rebinds the tiers those
+// rules are ABOUT, so the loaded file's guarantees do not survive it: a
+// `profile: sovereign` config can be handed a cloud provider, and the
+// endpoint, `input:` and embed-lane rules are bypassable the same way.
+// Certifying a cloud model is a legitimate thing to want — the defect is
+// doing it against a config that still says sovereign with nothing said
+// about it, which is a run whose numbers describe a deployment nobody has.
+// So the override fails here with the reason an operator would have got at
+// boot, rather than building the client and calling it.
 func overrideForTask(base ai.RoutingConfig, task ai.Task, override string) (ai.RoutingConfig, error) {
 	if override == "" {
 		return base, nil
@@ -55,6 +66,10 @@ func overrideForTask(base ai.RoutingConfig, task ai.Task, override string) (ai.R
 	}
 	overridden := base
 	overridden.Tiers = tiers
+	if err := overridden.Validate(); err != nil {
+		return ai.RoutingConfig{}, fmt.Errorf(
+			"aicert: MARGINCE_AICERT_MODEL=%s contradicts the loaded routing config: %w", override, err)
+	}
 	return overridden, nil
 }
 

--- a/backend/internal/modules/ai/routing.go
+++ b/backend/internal/modules/ai/routing.go
@@ -140,7 +140,7 @@ func ParseRouting(raw []byte) (RoutingConfig, error) {
 	} else if d == 0 {
 		cfg.Embeddings.Dimensions = defaultEmbedDimensions
 	}
-	// Before validate(), which sees only the decoded value and so cannot tell a
+	// Before Validate(), which sees only the decoded value and so cannot tell a
 	// blank declaration from an absent one.
 	blank, err := blankInputDeclarations(raw)
 	if err != nil {
@@ -172,6 +172,21 @@ var localProviders = map[string]bool{providerOllama: true, providerVLLM: true, P
 func ProviderIsLocal(provider string) bool {
 	return localProviders[provider]
 }
+
+// Validate runs the same rule set ParseRouting applies — the profile, the
+// tier bindings, the sovereign endpoint rule, the `input:` declarations and
+// the embed lane — over a config that reached its bindings some other way.
+//
+// It exists for one caller and would not otherwise be exported: the aicert
+// runner's MARGINCE_AICERT_MODEL override rebinds a task's ladder AFTER the
+// file was parsed, so the loaded file's guarantees do not survive it. A config
+// that never comes back through here can carry a cloud provider under
+// `profile: sovereign` with nothing said about it. Same reasoning as
+// TaskLadder and ProviderIsLocal above: the smallest export that stops a
+// caller outside this package re-encoding a rule this package owns.
+//
+// Pure over the receiver, so running it twice costs nothing.
+func (cfg RoutingConfig) Validate() error { return cfg.validate() }
 
 func (cfg RoutingConfig) validate() error {
 	switch cfg.Profile {


### PR DESCRIPTION
Closes #1442.

## The gap

`aicert` loads a deployment's routing file through `ai.LoadRoutingFile` (which validates it), `overrideForTask` then rebinds the task-under-test's ladder tiers from `MARGINCE_AICERT_MODEL=<provider>:<model>`, and `NewLocalRouter` calls `buildClients()` straight after. Nothing re-validated in between.

An override rebinds the tiers the rules are **about**, so the loaded file's guarantees do not survive it. A config whose `profile:` still reads `sovereign` could be run against a cloud model with nothing said about it — `SelectBrain` happily defaults `anthropic` to `api.anthropic.com`. Every rule `validate()` enforces was bypassable this way, not only the profile one: the endpoint rule (#1427), the `input:` rules (#1324), the embed-lane rules.

Non-production lane, as the issue says — the cert/eval runner, not `api` or `worker` boot. What makes it worth fixing anyway is that **certifying a cloud model is a legitimate thing to want**. The defect is not that the run leaves the building; it is that it leaves silently, from a config that still claims it does not, so the numbers describe a deployment nobody has.

## The change

`overrideForTask` runs the overridden config back through the config's own rule set and fails the run with the reason an operator would have got at boot:

```
aicert: MARGINCE_AICERT_MODEL=anthropic:claude-cert-test contradicts the loaded
routing config: ai: routing config: profile sovereign forbids cloud provider
"anthropic" on tier cheap_cloud
```

The refusal names both halves on purpose — which knob caused it, and which rule it broke. Either alone leaves the engineer reading source to find out why.

This is the issue's option (1), the invariant. Option (2) — dropping the profile to the one the run is actually under and saying so on stdout — is deliberately not taken: it is ergonomics on top of a rule that now holds, and the issue itself says (2) alone is not enough.

## `Validate` is a one-line export, and `validate` is untouched

```go
func (cfg RoutingConfig) Validate() error { return cfg.validate() }
```

Same reason `TaskLadder` and `ProviderIsLocal` are exported from this file: the smallest seam that stops a caller outside the package re-encoding a rule the package owns.

Renaming `validate` in place would have been tidier and is wrong here — `.golangci.strict.yml` is `new-from-merge-base: origin/main`, so touching the signature line resurrects a **pre-existing** cyclop finding (complexity 17, max 15) as a new one. Dragging an unrelated complexity refactor of the whole rule set into this PR is not the smallest diff that does the job. Nothing about `validate`'s body changes, so `ParseRouting` behaves identically.

## Tests

Two arms, and the second is what stops the first passing for the wrong reason:

- `TestOverrideForTaskRefusesACloudModelUnderASovereignProfile` — the defect. It also asserts the fixture base validates on its own first, so a broken fixture cannot make the refusal look like a pass.
- `TestOverrideForTaskAcceptsALocalModelUnderASovereignProfile` — a local override under the same profile still runs and still rebinds the ladder. Without this, a `return errors.New(...)` would satisfy the first test.

**Mutation-verified**: removing the re-validation and re-running turns the refusing arm red with its own message —

```
--- FAIL: TestOverrideForTaskRefusesACloudModelUnderASovereignProfile
    a cloud override under profile sovereign was accepted; the run would have
    built the client and called api.anthropic.com
```

The seven existing `overrideForTask` tests pass unchanged: `FakeRoutingConfig` is `eu_hosted` and the OpenRouter fixture is `cloud_frontier`, so neither meets a rule the override can now break.

## What this does not reach

A same-provider override drops the binding's `input:` declaration (the rebound `ProviderConfig` carries provider, model and — for a same-provider override — base_url, and nothing else). That cannot make `Validate` fail, so it is invisible to this change: it silently narrows what the candidate declares it carries rather than contradicting a rule. Worth a look alongside #1439, which is about those declarations; not folded in here.

## Verification

`make check-backend` — green (exit 0), including both golangci passes and the strict new-code set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Revalidates `aicert` MODEL overrides against the routing rules so evaluation runs cannot silently bypass profile and endpoint constraints. Previously an override re-bound tiers and built clients without revalidation; now the overridden config is validated and the run fails with an error that names the override and the broken rule.

- Affects only the cert/eval runner; production services are unchanged.

**Reviewer notes**
- `overrideForTask` now validates the overridden config via `RoutingConfig.Validate()` and returns a prefixed error when rules are violated.
- Adds an exported `RoutingConfig.Validate()` thin wrapper over existing `validate()`; no rule logic changed.
- Tests assert refusal for a cloud override under a `sovereign` profile and acceptance for a local override under the same profile.

**Operator impact**
- Runs that set `MARGINCE_AICERT_MODEL` to a cloud provider while using a `sovereign` profile now fail fast. To certify cloud models, update the routing config (profile or provider bindings) to permit the provider, or run under a profile that allows it.

<sup>Written for commit bcc5fca6cce83af4cc6c5480ca7cae1dc571e89f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1456?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

