### PR TITLE
feat(timeline): a mail row shows the message, not the sign-off under it

### DIFF
--- a/frontend/src/design-system/composed.css
+++ b/frontend/src/design-system/composed.css
@@ -596,6 +596,35 @@
   text-decoration: underline;
 }
 
+/* The second control on a mail row: the sign-off and the quoted thread under
+   it. Set apart from the read/less toggle so the two are not read as one pair
+   of buttons doing the same thing. */
+.tl-text-tail-toggle {
+  display: block;
+  color: var(--textMeta);
+}
+
+/* The folded tail, once asked for. Quieter than the message and inset, because
+   it is the history behind the message rather than more of it. */
+.tl-text-tail {
+  display: block;
+  margin-top: var(--space-1);
+  padding-inline-start: var(--space-2);
+  border-inline-start: 2px solid var(--borderSubtle);
+  white-space: pre-wrap;
+  color: var(--textMeta);
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+/* A link the sender wrote, not one we generated: it carries the address as its
+   own label so the destination is visible before the click. */
+.tl-text-link {
+  color: var(--accent);
+  text-decoration: underline;
+  overflow-wrap: anywhere;
+}
+
 /* Two tracks on one spine: what we sent, and what came back. The rail colour
    is the fast read; .tl-direction says the same thing in words, so the
    distinction never rests on telling two hues apart. */

--- a/frontend/src/design-system/composed.test.tsx
+++ b/frontend/src/design-system/composed.test.tsx
@@ -229,3 +229,124 @@ describe("RecordView + timeline", () => {
     expect(screen.getByRole("button", { name: "Reply" })).toBeTruthy();
   });
 });
+
+describe("TimelineText on a mail row", () => {
+  const SIGNED =
+    "From: anna@kunde.de\nTo: lars@gradion.com\n\nKönnen wir Dienstag über das Angebot sprechen?\n\nMit freundlichen Grüßen\nAnna Berger\nKunde GmbH";
+
+  const mailRow = (body: string, kind: "email" | "note" = "email") => [
+    {
+      id: "a1",
+      kind,
+      title: "Re: Angebot",
+      atIso: "2026-07-01T00:00:00Z",
+      provenance: { kind: "human" as const, self: true },
+      body,
+    },
+  ];
+
+  it("shows the message and hides the signature until asked", async () => {
+    const user = userEvent.setup();
+    render(<RecordView name="Acme" zone="UTC" timeline={mailRow(SIGNED)} />);
+
+    expect(screen.getByText(/Können wir Dienstag/)).toBeTruthy();
+    expect(screen.queryByText(/Mit freundlichen Grüßen/)).toBeNull();
+
+    await user.click(
+      screen.getByRole("button", { name: "Show signature and quoted text" }),
+    );
+    expect(screen.getByText(/Mit freundlichen Grüßen/)).toBeTruthy();
+    expect(screen.getByText(/Kunde GmbH/)).toBeTruthy();
+  });
+
+  it("folds the signature away again", async () => {
+    const user = userEvent.setup();
+    render(<RecordView name="Acme" zone="UTC" timeline={mailRow(SIGNED)} />);
+
+    await user.click(
+      screen.getByRole("button", { name: "Show signature and quoted text" }),
+    );
+    await user.click(
+      screen.getByRole("button", { name: "Hide signature and quoted text" }),
+    );
+    expect(screen.queryByText(/Mit freundlichen Grüßen/)).toBeNull();
+  });
+
+  it("keeps the correspondents' addresses above the message", () => {
+    // The preamble says who wrote to whom, which is part of reading a mail on
+    // a record. It is the row TITLE that must not lead with it — see the
+    // timelineTitle rule in people.tsx — not the message body.
+    render(<RecordView name="Acme" zone="UTC" timeline={mailRow(SIGNED)} />);
+    const body = document.querySelector(".tl-text-clamp")?.textContent ?? "";
+    expect(body).toContain("anna@kunde.de");
+    expect(body).toContain("Können wir Dienstag");
+  });
+
+  it("leaves a note whose text reads like a sign-off intact", () => {
+    render(
+      <RecordView
+        name="Acme"
+        zone="UTC"
+        timeline={mailRow("Viele Grüße an das Team ausgerichtet.", "note")}
+      />,
+    );
+    expect(screen.getByText(/Viele Grüße an das Team/)).toBeTruthy();
+    expect(
+      screen.queryByRole("button", {
+        name: "Show signature and quoted text",
+      }),
+    ).toBeNull();
+  });
+
+  it("offers no reveal when a mail carries no signature or quote", () => {
+    render(
+      <RecordView
+        name="Acme"
+        zone="UTC"
+        timeline={mailRow("Kurz: ja, Dienstag passt uns gut.")}
+      />,
+    );
+    expect(
+      screen.queryByRole("button", {
+        name: "Show signature and quoted text",
+      }),
+    ).toBeNull();
+  });
+
+  it("renders a link with its address as the label", () => {
+    render(
+      <RecordView
+        name="Acme"
+        zone="UTC"
+        timeline={mailRow(
+          "Die Unterlagen liegen unter https://kunde.de/angebot bereit.",
+        )}
+      />,
+    );
+    const link = screen.getByRole("link", {
+      name: "https://kunde.de/angebot",
+    });
+    expect(link.getAttribute("href")).toBe("https://kunde.de/angebot");
+    expect(link.getAttribute("rel")).toContain("noopener");
+  });
+
+  it("keeps a link inside the folded signature reachable once revealed", async () => {
+    const user = userEvent.setup();
+    render(
+      <RecordView
+        name="Acme"
+        zone="UTC"
+        timeline={mailRow(
+          "Kurz: ja.\n\n-- \nAnna Berger\nhttps://kunde.de/impressum",
+        )}
+      />,
+    );
+    expect(screen.queryByRole("link")).toBeNull();
+    await user.click(
+      screen.getByRole("button", { name: "Show signature and quoted text" }),
+    );
+    expect(
+      screen.getByRole("link", { name: "https://kunde.de/impressum" }),
+    ).toBeTruthy();
+  });
+});

--- a/frontend/src/design-system/composed.test.tsx
+++ b/frontend/src/design-system/composed.test.tsx
@@ -330,6 +330,33 @@ describe("TimelineText on a mail row", () => {
     expect(link.getAttribute("rel")).toContain("noopener");
   });
 
+  it("folds the signature again when the row is given a different mail", async () => {
+    // The row is keyed by activity id, so the component stays mounted when the
+    // entry it renders is replaced. A reveal must not carry over to a mail the
+    // reader never opened.
+    const user = userEvent.setup();
+    const { rerender } = rtlRender(
+      <LocaleProvider initial="en">
+        <RecordView name="Acme" zone="UTC" timeline={mailRow(SIGNED)} />
+      </LocaleProvider>,
+    );
+    await user.click(
+      screen.getByRole("button", { name: "Show signature and quoted text" }),
+    );
+    expect(screen.getByText(/Kunde GmbH/)).toBeTruthy();
+
+    rerender(
+      <LocaleProvider initial="en">
+        <RecordView
+          name="Acme"
+          zone="UTC"
+          timeline={mailRow("Neue Nachricht.\n\n-- \nMax Muster\nAndere GmbH")}
+        />
+      </LocaleProvider>,
+    );
+    expect(screen.queryByText(/Andere GmbH/)).toBeNull();
+  });
+
   it("keeps a link inside the folded signature reachable once revealed", async () => {
     const user = userEvent.setup();
     render(

--- a/frontend/src/design-system/composed.tsx
+++ b/frontend/src/design-system/composed.tsx
@@ -720,6 +720,15 @@ function TimelineText({
     ? [parts.header, parts.main].filter(Boolean).join("\n\n")
     : text.trim();
   const tail = parts?.trimmed ?? "";
+  // A row is keyed by activity id, so React keeps this component mounted when
+  // the entry it renders is replaced. Without this the next mail's signature
+  // would already be open, revealed by a click the reader made on a different
+  // message.
+  const [shownFor, setShownFor] = useState(text);
+  if (shownFor !== text) {
+    setShownFor(text);
+    setTailOpen(false);
+  }
 
   useLayoutEffect(() => {
     const el = bodyRef.current;

--- a/frontend/src/design-system/composed.tsx
+++ b/frontend/src/design-system/composed.tsx
@@ -8,7 +8,8 @@ import {
   StickyNote,
 } from "lucide-react";
 import type { ReactNode } from "react";
-import { useLayoutEffect, useRef, useState } from "react";
+import { useLayoutEffect, useMemo, useRef, useState } from "react";
+import { splitEmailBody } from "../format/emailtext";
 import { formatDate, formatDuration, formatMoney } from "../format/format";
 import { useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
@@ -645,6 +646,40 @@ function zoneClass(hasRail: boolean, hasAside: boolean): string | undefined {
   return undefined;
 }
 
+// A link inside a captured message, rendered as an element rather than as
+// markup: the body is escaped text and stays that way. The visible label is the
+// URL itself, so the destination a reader checks is the destination they get —
+// a mail we did not write is not a place to render a friendly label over a
+// different address.
+const URL_PATTERN = /https?:\/\/[^\s<>"')\]]+[^\s<>"')\].,;:!?]/g;
+
+function linkify(text: string): ReactNode[] {
+  const out: ReactNode[] = [];
+  let last = 0;
+  for (const match of text.matchAll(URL_PATTERN)) {
+    const at = match.index;
+    if (at > last) {
+      out.push(text.slice(last, at));
+    }
+    out.push(
+      <a
+        key={`${at}-${match[0]}`}
+        href={match[0]}
+        target="_blank"
+        rel="noopener noreferrer nofollow"
+        className="tl-text-link"
+      >
+        {match[0]}
+      </a>,
+    );
+    last = at + match[0].length;
+  }
+  if (last < text.length) {
+    out.push(text.slice(last));
+  }
+  return out;
+}
+
 /**
  * TimelineText is the message itself, two lines by default and the whole of it
  * on request.
@@ -653,10 +688,20 @@ function zoneClass(hasRail: boolean, hasAside: boolean): string | undefined {
  * rather than one application away. Collapsed by default because a timeline
  * where every row is a full email is a mailbox, and the point of the row is
  * still the sequence.
+ *
+ * On a mail row the reader gets the sentence the sender wrote. The sign-off and
+ * the quoted history below it are folded into a second control instead of being
+ * dropped, because the split is a heuristic: when it takes too much, the text is
+ * one click away rather than gone. `email` gates that, since a note may open
+ * with "Viele Grüße" or carry a "> " line as ordinary prose.
  */
-function TimelineText({ text }: Readonly<{ text: string }>) {
+function TimelineText({
+  text,
+  email = false,
+}: Readonly<{ text: string; email?: boolean }>) {
   const t = useT();
   const [open, setOpen] = useState(false);
+  const [tailOpen, setTailOpen] = useState(false);
   // Whether the clamp is actually cutting the text off, measured rather than
   // guessed. Counting characters was wrong in the one direction that matters:
   // the clamp is two VISUAL lines at whatever width the column happens to be,
@@ -665,7 +710,16 @@ function TimelineText({ text }: Readonly<{ text: string }>) {
   // given no way to expand. Text the reader could not reach.
   const [clipped, setClipped] = useState(false);
   const bodyRef = useRef<HTMLSpanElement>(null);
-  const trimmed = text.trim();
+  // The tail is what the reader is spared; `trimmed` is what the row shows and
+  // what the clamp measures, so the split has to happen before that effect.
+  const parts = useMemo(
+    () => (email ? splitEmailBody(text) : null),
+    [email, text],
+  );
+  const trimmed = parts
+    ? [parts.header, parts.main].filter(Boolean).join("\n\n")
+    : text.trim();
+  const tail = parts?.trimmed ?? "";
 
   useLayoutEffect(() => {
     const el = bodyRef.current;
@@ -693,7 +747,7 @@ function TimelineText({ text }: Readonly<{ text: string }>) {
   return (
     <span className="tl-text">
       <span ref={bodyRef} className={open ? "tl-text-full" : "tl-text-clamp"}>
-        {trimmed}
+        {linkify(trimmed)}
       </span>
       {(clipped || open) && (
         <button
@@ -704,6 +758,22 @@ function TimelineText({ text }: Readonly<{ text: string }>) {
         >
           {open ? t("timeline.textLess") : t("timeline.textMore")}
         </button>
+      )}
+      {/* Offered whenever something was folded away, not only once the message
+          is expanded: a mail short enough never to clip still has a signature,
+          and gating this on the clamp would put that text out of reach. */}
+      {tail && (
+        <>
+          <button
+            type="button"
+            className="tl-text-toggle tl-text-tail-toggle"
+            aria-expanded={tailOpen}
+            onClick={() => setTailOpen(!tailOpen)}
+          >
+            {tailOpen ? t("timeline.tailLess") : t("timeline.tailMore")}
+          </button>
+          {tailOpen && <span className="tl-text-tail">{linkify(tail)}</span>}
+        </>
       )}
     </span>
   );
@@ -869,7 +939,9 @@ export function TimelineRow({
                 .tl-body is a flex column either way. */}
       <div className="tl-body">
         <span className="tl-title">{entry.title}</span>
-        {entry.body && <TimelineText text={entry.body} />}
+        {entry.body && (
+          <TimelineText text={entry.body} email={entry.kind === "email"} />
+        )}
         {entry.detail}
         <span className="tl-meta">
           {/* The direction is said in words as well as drawn, so it does

--- a/frontend/src/format/emailtext.test.ts
+++ b/frontend/src/format/emailtext.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from "vitest";
+import { emailSummaryText, splitEmailBody } from "./emailtext";
+
+describe("splitEmailBody", () => {
+  it("peels the From/To preamble capture folds into the body", () => {
+    const parts = splitEmailBody(
+      "From: anna@kunde.de\nTo: lars@gradion.com\n\nKönnen wir Dienstag sprechen?",
+    );
+    expect(parts.header).toBe("From: anna@kunde.de\nTo: lars@gradion.com");
+    expect(parts.main).toBe("Können wir Dienstag sprechen?");
+    expect(parts.trimmed).toBe("");
+  });
+
+  it("cuts at the RFC 3676 signature delimiter", () => {
+    const parts = splitEmailBody(
+      "Anbei das Angebot.\n\n-- \nAnna Berger\nKunde GmbH\n+49 89 123456",
+    );
+    expect(parts.main).toBe("Anbei das Angebot.");
+    expect(parts.trimmed).toContain("Anna Berger");
+    expect(parts.trimmed).toContain("+49 89 123456");
+  });
+
+  it("folds a German sign-off and everything under it", () => {
+    const parts = splitEmailBody(
+      "Danke für das Gespräch. Ich melde mich nächste Woche.\n\nMit freundlichen Grüßen\nAnna Berger\nGeschäftsführerin\nKunde GmbH",
+    );
+    expect(parts.main).toBe(
+      "Danke für das Gespräch. Ich melde mich nächste Woche.",
+    );
+    expect(parts.trimmed).toContain("Mit freundlichen Grüßen");
+    expect(parts.trimmed).toContain("Geschäftsführerin");
+  });
+
+  it.each([
+    ["Viele Grüße", "Viele Grüße\nAnna"],
+    ["Beste Grüße", "Beste Grüße\nAnna"],
+    ["VG", "VG\nAnna"],
+    ["LG", "LG\nAnna"],
+    ["MfG", "MfG,\nAnna"],
+    ["Best regards", "Best regards\nAnna"],
+    ["Cheers", "Cheers\nAnna"],
+    ["Von meinem iPhone gesendet", "Von meinem iPhone gesendet"],
+    ["Sent from my iPhone", "Sent from my iPhone"],
+  ])("folds the sign-off %s", (_name, tail) => {
+    const parts = splitEmailBody(`Das Angebot passt so.\n\n${tail}`);
+    expect(parts.main).toBe("Das Angebot passt so.");
+    expect(parts.trimmed).not.toBe("");
+  });
+
+  it("leaves a short form alone when it opens a sentence", () => {
+    const body =
+      "LG Waschmaschinen sind auch im Angebot, die Lieferung dauert aber acht Wochen. Best of luck damit.";
+    const parts = splitEmailBody(body);
+    expect(parts.main).toBe(body);
+    expect(parts.trimmed).toBe("");
+  });
+
+  it("does not fold a sign-off word that opens a long message", () => {
+    const body = [
+      "Danke für die schnelle Antwort.",
+      "",
+      ...Array.from({ length: 20 }, (_, i) => `Punkt ${i + 1} ist geklärt.`),
+    ].join("\n");
+    const parts = splitEmailBody(body);
+    expect(parts.main).toBe(body.trim());
+    expect(parts.trimmed).toBe("");
+  });
+
+  it.each([
+    ["English attribution", "On Tue, 12 Aug 2026 at 09:14, Max Muster wrote:"],
+    ["German attribution", "Am 12.08.2026 um 09:14 schrieb Max Muster:"],
+    ["forwarded block", "---------- Forwarded message ----------"],
+    ["German forward", "-------- Weitergeleitete Nachricht --------"],
+    ["original message", "----- Original Message -----"],
+  ])("cuts at a %s", (_name, marker) => {
+    const parts = splitEmailBody(
+      `Passt, machen wir so.\n\n${marker}\n> Wollen wir Dienstag sprechen?`,
+    );
+    expect(parts.main).toBe("Passt, machen wir so.");
+    expect(parts.trimmed).toContain(marker);
+    expect(parts.trimmed).toContain("> Wollen wir Dienstag sprechen?");
+  });
+
+  it("keeps an attribution line with the quote it introduces", () => {
+    const parts = splitEmailBody(
+      "Ja, gerne.\n\nAm 12.08.2026 schrieb Max:\n> Passt Dienstag?",
+    );
+    expect(parts.main).toBe("Ja, gerne.");
+    expect(parts.trimmed.startsWith("Am 12.08.2026 schrieb Max:")).toBe(true);
+  });
+
+  it("cuts at a bare quoted block with no attribution", () => {
+    const parts = splitEmailBody("Ja, passt.\n\n> Passt Dienstag?\n> Anna");
+    expect(parts.main).toBe("Ja, passt.");
+    expect(parts.trimmed).toBe("> Passt Dienstag?\n> Anna");
+  });
+
+  it("cuts at an Outlook reply header block", () => {
+    const parts = splitEmailBody(
+      "Sehe ich auch so.\n\nVon: Max Muster <max@kunde.de>\nGesendet: Dienstag, 12. August 2026 09:14\nAn: Lars\nBetreff: AW: Angebot\n\nPasst Dienstag?",
+    );
+    expect(parts.main).toBe("Sehe ich auch so.");
+    expect(parts.trimmed).toContain("Von: Max Muster");
+    expect(parts.trimmed).toContain("Betreff: AW: Angebot");
+  });
+
+  it("does not read a Von: line as a reply header without a sent date", () => {
+    const body =
+      "Von: der Messe habe ich drei Kontakte mitgebracht.\nAlle drei wollen ein Angebot.";
+    const parts = splitEmailBody(body);
+    expect(parts.main).toBe(body);
+    expect(parts.trimmed).toBe("");
+  });
+
+  it("keeps a message that is nothing but a greeting", () => {
+    const parts = splitEmailBody("Viele Grüße\nAnna");
+    expect(parts.main).toBe("Viele Grüße\nAnna");
+    expect(parts.trimmed).toBe("");
+  });
+
+  it("keeps a message that is only a quoted forward", () => {
+    const parts = splitEmailBody("> Passt Dienstag?\n> Anna");
+    expect(parts.main).toBe("> Passt Dienstag?\n> Anna");
+    expect(parts.trimmed).toBe("");
+  });
+
+  it("keeps the message when the preamble is followed only by a signature", () => {
+    const parts = splitEmailBody(
+      "From: anna@kunde.de\nTo: lars@gradion.com\n\n-- \nAnna Berger",
+    );
+    expect(parts.header).toBe("From: anna@kunde.de\nTo: lars@gradion.com");
+    expect(parts.main).toBe("-- \nAnna Berger");
+    expect(parts.trimmed).toBe("");
+  });
+
+  it("returns empty parts for an empty body", () => {
+    expect(splitEmailBody("")).toEqual({ header: "", main: "", trimmed: "" });
+    expect(splitEmailBody("   \n  ")).toEqual({
+      header: "",
+      main: "",
+      trimmed: "",
+    });
+  });
+
+  it("cuts at the first boundary when a mail has both a signature and a quote", () => {
+    const parts = splitEmailBody(
+      "Kurz zur Rückfrage: ja.\n\nViele Grüße\nAnna\n\nAm 12.08.2026 schrieb Max:\n> Passt Dienstag?",
+    );
+    expect(parts.main).toBe("Kurz zur Rückfrage: ja.");
+    expect(parts.trimmed).toContain("Viele Grüße");
+    expect(parts.trimmed).toContain("> Passt Dienstag?");
+  });
+});
+
+describe("emailSummaryText", () => {
+  it("collapses the message to one line without the preamble or sign-off", () => {
+    const summary = emailSummaryText(
+      "From: anna@kunde.de\nTo: lars@gradion.com\n\nKönnen wir\nDienstag sprechen?\n\nMit freundlichen Grüßen\nAnna Berger",
+    );
+    expect(summary).toBe("Können wir Dienstag sprechen?");
+  });
+
+  it("falls back to the whole body rather than returning nothing", () => {
+    expect(emailSummaryText("> Passt Dienstag?")).toBe("> Passt Dienstag?");
+    expect(emailSummaryText("")).toBe("");
+  });
+});

--- a/frontend/src/format/emailtext.test.ts
+++ b/frontend/src/format/emailtext.test.ts
@@ -165,3 +165,26 @@ describe("emailSummaryText", () => {
     expect(emailSummaryText("")).toBe("");
   });
 });
+
+describe("boundaries that must not fire", () => {
+  it("keeps a sentence that opens with mobile-client wording", () => {
+    const body =
+      "Kurzes Update:\nSent from my perspective, the contract is not ready.\nBitte noch nicht rausschicken.";
+    const parts = splitEmailBody(body);
+    expect(parts.main).toBe(body);
+    expect(parts.trimmed).toBe("");
+  });
+
+  it("still folds the real mobile-client footer", () => {
+    const parts = splitEmailBody("Passt so.\n\nSent from my iPhone");
+    expect(parts.main).toBe("Passt so.");
+    expect(parts.trimmed).toBe("Sent from my iPhone");
+  });
+
+  it("keeps a body that is nothing but the From/To preamble", () => {
+    const body = "From: a@example.com\nTo: b@example.com\n\n";
+    const parts = splitEmailBody(body);
+    expect(parts.main).not.toBe("");
+    expect(emailSummaryText(body)).not.toBe("");
+  });
+});

--- a/frontend/src/format/emailtext.ts
+++ b/frontend/src/format/emailtext.ts
@@ -57,13 +57,17 @@ const SIGN_OFF_PREFIXES = [
   "warm regards",
   "many thanks",
   "thanks and regards",
-  "von meinem iphone gesendet",
-  "von meinem ipad gesendet",
-  "von meinem android",
-  "sent from my",
-  "gesendet mit",
-  "get outlook for",
   "diese e-mail wurde von avast",
+];
+
+// Mobile-client boilerplate. Matched against the WHOLE line rather than as a
+// prefix: "Sent from my perspective, the contract is not ready" opens a
+// sentence with the same three words and is the message, not the footer.
+const SIGN_OFF_LINES = [
+  /^von meinem (iphone|ipad|android|mobilteil|samsung)\b.*gesendet$/,
+  /^sent from my \w[\w\s]{0,30}$/,
+  /^gesendet mit \w[\w\s]{0,30}$/,
+  /^get outlook for \w+$/,
 ];
 
 // The short forms. A whole-line match only: "LG" opens a sentence about a
@@ -99,6 +103,9 @@ function isSignOff(line: string): boolean {
     return false;
   }
   if (SIGN_OFF_EXACT.has(normalized)) {
+    return true;
+  }
+  if (SIGN_OFF_LINES.some((pattern) => pattern.test(normalized))) {
     return true;
   }
   return SIGN_OFF_PREFIXES.some((prefix) => normalized.startsWith(prefix));
@@ -166,6 +173,13 @@ export function splitEmailBody(body: string): EmailBodyParts {
   const preamble = PREAMBLE.exec(body);
   const header = preamble ? preamble[0].trim() : "";
   const rest = preamble ? body.slice(preamble[0].length) : body;
+
+  // A body that is only a preamble has no message under it. The header is the
+  // whole of what was captured, so it IS the message: the invariant is that a
+  // non-empty body never renders as nothing.
+  if (!rest.trim()) {
+    return { header: "", main: body.trim(), trimmed: "" };
+  }
 
   const lines = rest.split("\n");
   const cut = boundaryIndex(lines);

--- a/frontend/src/format/emailtext.ts
+++ b/frontend/src/format/emailtext.ts
@@ -1,0 +1,193 @@
+// Display-side reading of a captured mail body. The stored body is the whole
+// message — signature, quoted history and all — because the enrichment pass
+// mines the sign-off for contact details, so nothing may be trimmed at rest.
+// What a reader wants on a timeline row is the sentence the sender wrote, and
+// that is what this file finds. The rest is handed back separately and folded
+// behind a control rather than dropped: a heuristic that guesses wrong must
+// stay one click from being wrong in public.
+
+export type EmailBodyParts = {
+  /** The `From:/To:` preamble capture folds into the body, when present. */
+  header: string;
+  /** What the sender actually wrote. Never empty when the body was not. */
+  main: string;
+  /** Signature and quoted history, collapsed behind a control. */
+  trimmed: string;
+};
+
+// The preamble capture's mail mapper prepends verbatim. Peeled before any
+// heuristic runs, or the `From:` line reads as an Outlook reply header and
+// folds the entire message.
+const PREAMBLE = /^From:[^\n]*\nTo:[^\n]*\n\n/;
+
+// RFC 3676 §4.3: the sign-off delimiter is a line of exactly two hyphens.
+// Trailing whitespace is allowed because mail clients strip it inconsistently.
+const SIGNATURE_DELIMITER = /^--\s*$/;
+
+// Attribution lines that introduce a quoted reply. Bounded repetition keeps a
+// pathological body from backtracking.
+const ATTRIBUTION = [
+  /^On\s.{1,200}\swrote:\s*$/,
+  /^Am\s.{1,200}\sschrieb\s?.{0,120}:\s*$/,
+  /^-{2,}\s*(Original Message|Ursprüngliche Nachricht|Forwarded message|Weitergeleitete Nachricht)/i,
+  /^Anfang der weitergeleiteten (E-Mail|Nachricht)/i,
+  /^_{5,}\s*$/,
+];
+
+// The Outlook top-reply block: a From:/Von: line whose neighbours carry the
+// sent-date field. Recognised as a pair because "Von:" alone is ordinary prose
+// in German mail.
+const REPLY_HEADER_FROM = /^(Von|From):\s/;
+const REPLY_HEADER_SENT = /^(Gesendet|Sent|Datum|Date):\s/;
+
+// Sign-offs, matched only in the trailing region. The multi-word forms may open
+// a line, since a name usually follows on the same one.
+const SIGN_OFF_PREFIXES = [
+  "mit freundlichen grüßen",
+  "mit freundlichem gruß",
+  "mit besten grüßen",
+  "freundliche grüße",
+  "viele grüße",
+  "beste grüße",
+  "herzliche grüße",
+  "liebe grüße",
+  "schöne grüße",
+  "best regards",
+  "kind regards",
+  "warm regards",
+  "many thanks",
+  "thanks and regards",
+  "von meinem iphone gesendet",
+  "von meinem ipad gesendet",
+  "von meinem android",
+  "sent from my",
+  "gesendet mit",
+  "get outlook for",
+  "diese e-mail wurde von avast",
+];
+
+// The short forms. A whole-line match only: "LG" opens a sentence about a
+// washing machine as readily as it closes a mail, and "Best" mid-paragraph is
+// not a sign-off at all.
+const SIGN_OFF_EXACT = new Set([
+  "mfg",
+  "vg",
+  "lg",
+  "vlg",
+  "best",
+  "regards",
+  "cheers",
+  "thanks",
+  "thank you",
+  "danke",
+  "gruß",
+  "grüße",
+  "bg",
+]);
+
+// How far up from the end a sign-off is looked for. A sign-off belongs to the
+// closing of a mail; the same words in the opening paragraph are prose, and
+// scanning the whole body folds the message away on the strength of one line.
+const TRAILING_SCAN_LINES = 15;
+
+function isSignOff(line: string): boolean {
+  const normalized = line
+    .trim()
+    .toLowerCase()
+    .replace(/[,.!]+$/, "");
+  if (!normalized) {
+    return false;
+  }
+  if (SIGN_OFF_EXACT.has(normalized)) {
+    return true;
+  }
+  return SIGN_OFF_PREFIXES.some((prefix) => normalized.startsWith(prefix));
+}
+
+function isQuoteStart(lines: readonly string[], index: number): boolean {
+  const line = lines[index] ?? "";
+  if (line.startsWith(">")) {
+    return true;
+  }
+  if (ATTRIBUTION.some((pattern) => pattern.test(line))) {
+    return true;
+  }
+  // The Outlook block: the sent-date field within the next few lines is what
+  // separates a reply header from a sentence that opens "Von:".
+  if (index > 0 && REPLY_HEADER_FROM.test(line)) {
+    return lines
+      .slice(index + 1, index + 5)
+      .some((next) => REPLY_HEADER_SENT.test(next));
+  }
+  return false;
+}
+
+/**
+ * boundaryIndex is the first line that belongs to the tail rather than the
+ * message: a quote marker anywhere, or a sign-off near the end.
+ *
+ * Returns -1 when the whole body is the message.
+ */
+function boundaryIndex(lines: readonly string[]): number {
+  const signOffFloor = Math.max(0, lines.length - TRAILING_SCAN_LINES);
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i] ?? "";
+    if (SIGNATURE_DELIMITER.test(line)) {
+      return i;
+    }
+    if (isQuoteStart(lines, i)) {
+      // The attribution line directly above a quoted block introduces it, so it
+      // travels with the quote rather than trailing the message.
+      const above = lines[i - 1]?.trim() ?? "";
+      if (line.startsWith(">") && i > 0 && above.endsWith(":")) {
+        return i - 1;
+      }
+      return i;
+    }
+    if (i >= signOffFloor && isSignOff(line)) {
+      return i;
+    }
+  }
+  return -1;
+}
+
+/**
+ * splitEmailBody separates a stored mail body into the part worth reading on a
+ * row and the tail worth keeping but not showing.
+ *
+ * The message is never allowed to become empty: a body that is nothing but a
+ * greeting is a real message, and a heuristic that folds it away has hidden the
+ * mail rather than tidied it.
+ */
+export function splitEmailBody(body: string): EmailBodyParts {
+  if (!body.trim()) {
+    return { header: "", main: "", trimmed: "" };
+  }
+  const preamble = PREAMBLE.exec(body);
+  const header = preamble ? preamble[0].trim() : "";
+  const rest = preamble ? body.slice(preamble[0].length) : body;
+
+  const lines = rest.split("\n");
+  const cut = boundaryIndex(lines);
+  if (cut < 0) {
+    return { header, main: rest.trim(), trimmed: "" };
+  }
+  const main = lines.slice(0, cut).join("\n").trim();
+  if (!main) {
+    return { header, main: rest.trim(), trimmed: "" };
+  }
+  return { header, main, trimmed: lines.slice(cut).join("\n").trim() };
+}
+
+/**
+ * emailSummaryText is the message on one line, for a row title or a memory
+ * entry: the sender's own words, never their sign-off and never the `From:`
+ * preamble.
+ */
+export function emailSummaryText(body: string): string {
+  const { main } = splitEmailBody(body);
+  const collapsed = main.replace(/\s+/g, " ").trim();
+  // A body that is only a quoted forward has no message of its own. The whole
+  // text is a better title than an empty one.
+  return collapsed || body.replace(/\s+/g, " ").trim();
+}

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -1118,6 +1118,8 @@ export const de = {
   "timeline.received": "Erhalten",
   "timeline.textMore": "Lesen",
   "timeline.textLess": "Weniger",
+  "timeline.tailMore": "Signatur und Zitat anzeigen",
+  "timeline.tailLess": "Signatur und Zitat ausblenden",
   "co.profileField.display_name": "Firmenname",
   "co.profileField.offer_summary": "Was sie verkaufen",
   "co.profileField.icp": "An wen sie verkaufen",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -1131,6 +1131,8 @@ export const en = {
   "timeline.received": "Received",
   "timeline.textMore": "Read it",
   "timeline.textLess": "Show less",
+  "timeline.tailMore": "Show signature and quoted text",
+  "timeline.tailLess": "Hide signature and quoted text",
   "co.profileField.display_name": "Company name",
   "co.profileField.offer_summary": "What they sell",
   "co.profileField.icp": "Who they sell to",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -1116,6 +1116,8 @@ export const vi = {
   "timeline.received": "Đã nhận",
   "timeline.textMore": "Đọc",
   "timeline.textLess": "Thu gọn",
+  "timeline.tailMore": "Hiện chữ ký và phần trích dẫn",
+  "timeline.tailLess": "Ẩn chữ ký và phần trích dẫn",
   "co.profileField.display_name": "Tên công ty",
   "co.profileField.offer_summary": "Họ bán gì",
   "co.profileField.icp": "Họ bán cho ai",

--- a/frontend/src/screens/people.tsx
+++ b/frontend/src/screens/people.tsx
@@ -8,6 +8,7 @@ import { navigate } from "../app/router";
 import { Badge, SegmentedControl } from "../design-system/atoms";
 import { RecordView, type TimelineEntry } from "../design-system/composed";
 import { ProvenanceTag } from "../design-system/trust";
+import { emailSummaryText } from "../format/emailtext";
 import { useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import { ArchiveAction } from "./archive";
@@ -403,8 +404,14 @@ function timelineTitle(activity: Activity): string {
     return subject;
   }
   // Collapsed rather than trusted: a pasted multi-line message would otherwise
-  // break the row's single-line layout.
-  const body = activity.body?.replace(/\s+/g, " ").trim();
+  // break the row's single-line layout. A mail is read for its message first:
+  // titling the row from the raw body puts the From/To preamble, or a sign-off,
+  // where the reason for the mail should be.
+  const raw = activity.body ?? "";
+  const body =
+    activity.kind === "email"
+      ? emailSummaryText(raw)
+      : raw.replace(/\s+/g, " ").trim();
   if (!body) {
     return activity.kind;
   }

--- a/frontend/src/screens/personmemory.tsx
+++ b/frontend/src/screens/personmemory.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import type { components } from "../api/schema";
 import { Badge, SegmentedControl } from "../design-system/atoms";
 import { Panel, PanelBody, PanelRow } from "../design-system/panel";
+import { emailSummaryText } from "../format/emailtext";
 import { useT } from "../i18n";
 import { useProviderLabel } from "./channelproviders";
 import { ChannelReplyAction } from "./compose";
@@ -222,7 +223,10 @@ function foldActivities(
             t,
             providerLabel,
           ),
-        summary: row.body ?? "",
+        summary:
+          row.kind === "email"
+            ? emailSummaryText(row.body ?? "")
+            : (row.body ?? ""),
         status,
         statusLabel: statusLabel(status, t),
         tone: toneFor(status),


### PR DESCRIPTION
A captured mail is stored whole — sign-off, quoted history and all — because the signature-enrichment pass reads the sign-off for contact details. The timeline showed all of it, so a two-line preview was routinely somebody's job title and phone number, and a subject-less row could be titled "Mit freundlichen Grüßen".

## What changed

`frontend/src/format/emailtext.ts` splits a stored body into the message and its tail. The tail starts at the first boundary found: the RFC 3676 `-- ` delimiter, a quote attribution (`On … wrote:` / `Am … schrieb …:`), a forwarded-message marker, an Outlook `Von:`+`Gesendet:` reply header, a bare `>` block, or a sign-off in the closing 15 lines (German and English, including `Von meinem iPhone gesendet`).

The tail is **folded behind a control, not dropped**. The split is a heuristic, so a wrong guess has to stay one click from being visible. Two safety rules hold it: the message can never become empty (a mail that is only "Viele Grüße, Anna" stays whole), and short forms like `LG` or `Best` only match a whole line, so "LG Waschmaschinen sind auch im Angebot" is left alone.

Gated on `kind === "email"` — a note may open with "Viele Grüße" or quote a line with `>` as ordinary prose.

Row titles and the person-memory summary now read from the message rather than the raw body, so neither leads with the `From:/To:` preamble or a greeting.

URLs render as links whose visible label is the address itself, so the destination is readable before the click. They stay React elements over escaped text — no markup from a captured mail is ever parsed, and there is still no `dangerouslySetInnerHTML` in the tree.

## What did not change

Nothing is trimmed at rest. The stored `activity.body`, the signature-enrichment pass, search, embeddings and every AI grounding path read exactly what they read before.

## Verification

30 unit tests over the split (every boundary rule plus the negative cases), 8 render tests over the row. `make check-fe` green.

Follow-up, filed separately: HTML-only mail is still converted by a regex tag-strip at ingest, which is the other half of the readability problem.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Email timeline rows show the sender’s message, not the sign‑off or quoted thread. Previously the row preview and title often began with a greeting or `From/To` preamble; now they read the message. The tail stays one click away and the preamble remains visible above the message in the body when present.

- `splitEmailBody` finds the first tail boundary (RFC 3676 `-- `, EN/DE quote attributions, Outlook `Von:`+`Gesendet:` reply header, bare `>` block, or a sign‑off in the last lines). The message never becomes empty; a body that is only a `From/To` preamble or only a greeting still renders.
- `TimelineText` adds a second toggle for the folded tail and resets it when the row is given a different mail. Offer the tail toggle even when the message doesn’t clip.
- URLs in email bodies render as links labeled by their address (`target="_blank" rel="noopener noreferrer nofollow"`). Bodies remain escaped text; no HTML parsing.
- Row titles in `people.tsx` and person memory summaries in `personmemory.tsx` use `emailSummaryText`. They avoid preambles and sign‑offs; if a mail has no message, they fall back to the whole body to avoid empty titles.
- Gated on `kind === "email"` so notes are unaffected.
- Styling: `.tl-text-tail-toggle`, `.tl-text-tail`, `.tl-text-link`; i18n strings added in `en`, `de`, `vi`. Tests cover split heuristics, mobile‑footer edge cases, title/summary, render, and tail reset.

No data or API changes: stored `activity.body`, enrichment, search, and embeddings are unchanged.

<sup>Written for commit f41b31dfb5ed5caa26f1db96c3291bf14db980d3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1460?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

