### PR TITLE
fix(capture): a mentioned sender's verdict reaches the message that raised it

### DIFF
--- a/backend/internal/modules/capture/sinkchannel_integration_test.go
+++ b/backend/internal/modules/capture/sinkchannel_integration_test.go
@@ -143,6 +143,37 @@ func TestChannelRecordSkipsEveryMailDomainGate(t *testing.T) {
 		t.Fatalf("%d disposition rows for a channel record, want 0", dispositions)
 	}
 
+	// The trace says `captured`, and the trace READ depends on it.
+	//
+	// A channel-identity record opens no ledger question, so it must never
+	// report one — the join in tracestore.go decides that by the outcome, on the
+	// strength of this record never being traced `deferred` or `suppressed`.
+	// That is a property of decideChannelCounterparty three files away, and the
+	// read has no way to check it. Asserted HERE, through the real Sink, so a
+	// change that gave a channel record a deferral fails on the trace row it
+	// writes rather than by silently telling a member that their captured,
+	// linked and answered conversation is waiting on a verdict.
+	var outcomes []string
+	traceRows, err := owner.Query(ctx,
+		`SELECT outcome FROM capture_trace WHERE workspace_id = $1 ORDER BY outcome`, ws)
+	if err != nil {
+		t.Fatalf("reading the pipeline trace: %v", err)
+	}
+	defer traceRows.Close()
+	for traceRows.Next() {
+		var outcome string
+		if err := traceRows.Scan(&outcome); err != nil {
+			t.Fatalf("scanning a trace row: %v", err)
+		}
+		outcomes = append(outcomes, outcome)
+	}
+	if err := traceRows.Err(); err != nil {
+		t.Fatalf("draining the pipeline trace: %v", err)
+	}
+	if len(outcomes) != 1 || outcomes[0] != "captured" {
+		t.Fatalf("channel record traced %v, want exactly [captured] — an outcome the ladder records a disposition for would make this record inherit a verdict it never raised", outcomes)
+	}
+
 	// And no gate breadcrumb of any kind — a suppression, a deferral cap, or a
 	// gate fault would each be a mail gate having judged this message.
 	var breadcrumbs []string

--- a/backend/internal/modules/capture/sinktrace.go
+++ b/backend/internal/modules/capture/sinktrace.go
@@ -86,6 +86,16 @@ func (s *Sink) traceEntry(ctx context.Context, rec connector.NormalizedRecord,
 	stage pipelinetrace.Stage, outcome TraceOutcome, reason string,
 ) TraceEntry {
 	_, owner := capturePrincipal(ctx)
+	// Read from the COUNTERPARTY on purpose, unlike traceConnector below, and
+	// the two are not inconsistent: this flag does not ask whether the message
+	// arrived on a channel, it asks whether SourceID is a provider ACCOUNT id
+	// that has to be hashed. Which is a question about how the record names its
+	// human. Do not "correct" it to match its neighbour.
+	//
+	// It is imperfect — a connector whose natural key is a message id on BOTH
+	// branches has one branch hashed and one not (issue #1465) — but the error
+	// is toward hashing, and the fix belongs with the natural key rather than
+	// here.
 	channel := rec.Counterparty.ChannelIdentity.Provider != ""
 	return TraceEntry{
 		Stage:           stage,
@@ -110,13 +120,12 @@ func (s *Sink) traceEntry(ctx context.Context, rec connector.NormalizedRecord,
 //
 // The provider is read from the RECORD's own fields — the value that becomes
 // activity.channel_provider — and not from the counterparty's channel identity.
-// They are different questions: one is how the message travelled, the other is
-// how it names its human. A connector that names a human by address alone (a
-// mention, where the address IS the identity) carries no channel identity, so
-// reading the transport off the counterparty spelled the SAME connector two
-// ways in one list — `dispact` for its direct messages and
-// `ext:dispact-connector:dispact` for its mentions — and only the first
-// resolved to a label.
+// They are different questions: how the message travelled, versus how it names
+// its human. A connector may answer the second with an address alone (a
+// mention, where the address IS the identity) while carrying every message on
+// the same transport, so a counterparty-derived answer gives one connector two
+// ids, splits it into two groups in a list that groups by connector, and leaves
+// one of them unresolvable to a label.
 //
 // Not captureSource: that is the provenance CHANNEL, and a connector may set it
 // to `<system>:<id>` — several do — so it identifies one message rather than the

--- a/backend/internal/modules/capture/sinktrace.go
+++ b/backend/internal/modules/capture/sinktrace.go
@@ -108,6 +108,16 @@ func (s *Sink) traceEntry(ctx context.Context, rec connector.NormalizedRecord,
 // to a label. Everything else answers with the natural key's SOURCE SYSTEM
 // (`gmail`, `imap`, `ext:<unit>:<system>`).
 //
+// The provider is read from the RECORD's own fields — the value that becomes
+// activity.channel_provider — and not from the counterparty's channel identity.
+// They are different questions: one is how the message travelled, the other is
+// how it names its human. A connector that names a human by address alone (a
+// mention, where the address IS the identity) carries no channel identity, so
+// reading the transport off the counterparty spelled the SAME connector two
+// ways in one list — `dispact` for its direct messages and
+// `ext:dispact-connector:dispact` for its mentions — and only the first
+// resolved to a label.
+//
 // Not captureSource: that is the provenance CHANNEL, and a connector may set it
 // to `<system>:<id>` — several do — so it identifies one message rather than the
 // transport that carried it, and would put a message id in a column meant to
@@ -118,8 +128,8 @@ func (s *Sink) traceEntry(ctx context.Context, rec connector.NormalizedRecord,
 // binary, and two deploys' traces would disagree about the same transport with
 // no row having changed.
 func traceConnector(rec connector.NormalizedRecord) string {
-	if provider := rec.Counterparty.ChannelIdentity.Provider; provider != "" {
-		return provider
+	if fields, ok := rec.Fields.(ActivityFields); ok && fields.ChannelProvider != "" {
+		return fields.ChannelProvider
 	}
 	return rec.NaturalKey.SourceSystem
 }

--- a/backend/internal/modules/capture/trace.go
+++ b/backend/internal/modules/capture/trace.go
@@ -59,6 +59,17 @@ const (
 	TraceFault      TraceOutcome = "fault"
 )
 
+// LadderDispositionOutcomes are the outcomes the tier ladder records a
+// disposition ledger row for. They are the rows with a question of their own,
+// which is what lets the trace read report a verdict to a message that raised
+// one and to no other.
+//
+// Named here, beside the outcomes themselves, because two places have to agree
+// about the list and they are in different files: the read's join
+// (tracestore.go) and the ladder that writes them (sinkensure.go). A tier that
+// starts recording a disposition joins this list, and the read follows.
+var LadderDispositionOutcomes = []TraceOutcome{TraceDeferred, TraceSuppressed}
+
 // The reasons that change what an outcome MEANS, rather than merely annotating
 // it. Each of these exists because the outcome alone would give a user a
 // confident wrong answer.

--- a/backend/internal/modules/capture/trace_unit_test.go
+++ b/backend/internal/modules/capture/trace_unit_test.go
@@ -124,10 +124,9 @@ func TestAChannelSourceIdHashesToItselfEveryTime(t *testing.T) {
 // by and what /v1/channel-providers resolves to a label, so a connector that
 // answers two ways appears as two connectors and only one of them has a name.
 //
-// Reading the provider off the COUNTERPARTY is what split it: a channel record
-// that names its human by address alone carries no channel identity, so the
-// same connector's mentions fell through to the raw source system while its
-// direct messages answered with the provider.
+// The two records below differ only in how they name their human — an account
+// on one, an address on the other — which is the axis that must NOT reach this
+// answer. They arrived on the same transport.
 func TestOneTransportIsSpelledOneWay(t *testing.T) {
 	channelRecord := func(cp connector.Counterparty) connector.NormalizedRecord {
 		return connector.NormalizedRecord{
@@ -155,6 +154,39 @@ func TestOneTransportIsSpelledOneWay(t *testing.T) {
 	}
 	if got, want := traceConnector(mail), "gmail"; got != want {
 		t.Errorf("mail names connector %q, want %q", got, want)
+	}
+}
+
+// The join's outcome list and LadderDispositionOutcomes are one list.
+//
+// The SQL spells its literals so both queries stay compile-time constants, so
+// nothing but this makes the two agree. A tier that starts recording a
+// disposition joins the Go list and is then invisible to the read — its
+// messages would report no verdict, which is the bug the list exists to
+// prevent, in a new place.
+func TestTheResolutionJoinSpellsEveryLadderDispositionOutcome(t *testing.T) {
+	for _, outcome := range LadderDispositionOutcomes {
+		if !strings.Contains(resolutionJoin, "'"+string(outcome)+"'") {
+			t.Errorf("the resolution join does not name %q — a message with that outcome would report no verdict", outcome)
+		}
+	}
+	// And nothing BEYOND the list: an outcome added to the SQL alone widens what
+	// the join discloses with no Go declaration saying it should.
+	for _, outcome := range []TraceOutcome{TraceCaptured, TraceInternal, TraceFault} {
+		if strings.Contains(resolutionJoin, "'"+string(outcome)+"'") {
+			t.Errorf("the resolution join names %q, which records no disposition", outcome)
+		}
+	}
+}
+
+// The widened arm stays on the personal side of the read.
+//
+// A ledger row's owner is an individual member, and the workspace scope is the
+// one a manager holds a grant for. The mail arm is structurally personal
+// already; this one has to say so.
+func TestTheWidenedResolutionArmRequiresAMember(t *testing.T) {
+	if !strings.Contains(resolutionJoin, "t.user_id IS NOT NULL") {
+		t.Error("the widened arm does not require a member — a workspace-owned row could report a verdict raised by one member's own correspondence")
 	}
 }
 

--- a/backend/internal/modules/capture/trace_unit_test.go
+++ b/backend/internal/modules/capture/trace_unit_test.go
@@ -14,6 +14,7 @@ import (
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/pipelinetrace"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/connector"
 )
 
 func TestATraceEntryMustNameWhatItDescribes(t *testing.T) {
@@ -116,6 +117,44 @@ func TestAChannelSourceIdHashesToItselfEveryTime(t *testing.T) {
 	}
 	if plain := traceSourceID(account, false); plain != account {
 		t.Errorf("mail id = %q, want it kept verbatim", plain)
+	}
+}
+
+// One transport, one spelling. The connector column is what the screen groups
+// by and what /v1/channel-providers resolves to a label, so a connector that
+// answers two ways appears as two connectors and only one of them has a name.
+//
+// Reading the provider off the COUNTERPARTY is what split it: a channel record
+// that names its human by address alone carries no channel identity, so the
+// same connector's mentions fell through to the raw source system while its
+// direct messages answered with the provider.
+func TestOneTransportIsSpelledOneWay(t *testing.T) {
+	channelRecord := func(cp connector.Counterparty) connector.NormalizedRecord {
+		return connector.NormalizedRecord{
+			NaturalKey:   connector.NaturalKey{SourceSystem: "ext:dispact-connector:dispact", SourceID: "m-1"},
+			Counterparty: cp,
+			Fields:       ActivityFields{Kind: "message", ChannelProvider: "dispact"},
+		}
+	}
+	named := channelRecord(connector.Counterparty{
+		ChannelIdentity: connector.ChannelIdentity{Provider: "dispact", ChannelUserID: "u-1"},
+	})
+	mentioned := channelRecord(connector.Counterparty{Email: "someone@client.io"})
+	if got, want := traceConnector(named), "dispact"; got != want {
+		t.Errorf("a direct message names connector %q, want %q", got, want)
+	}
+	if got, want := traceConnector(mentioned), "dispact"; got != want {
+		t.Errorf("a mention names connector %q, want %q — the transport carried both", got, want)
+	}
+
+	// Mail arrived on no channel, so its source system IS the transport.
+	mail := connector.NormalizedRecord{
+		NaturalKey:   connector.NaturalKey{SourceSystem: "gmail", SourceID: "m-2"},
+		Counterparty: connector.Counterparty{Email: "someone@client.io"},
+		Fields:       ActivityFields{Kind: "email"},
+	}
+	if got, want := traceConnector(mail), "gmail"; got != want {
+		t.Errorf("mail names connector %q, want %q", got, want)
 	}
 }
 

--- a/backend/internal/modules/capture/traceresolution_integration_test.go
+++ b/backend/internal/modules/capture/traceresolution_integration_test.go
@@ -24,40 +24,71 @@ import (
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/pipelinetrace"
 )
 
+// seededRecord names one message to seed, as the sink would have written it.
+//
+// The OUTCOME is part of the shape because it is what the read keys on, and the
+// two channel shapes differ by exactly it: a record named by a channel identity
+// takes decideChannelCounterparty, which opens no ledger question and so traces
+// `captured`, while a record named by an address alone runs the mail ladder and
+// can defer. So a channel row seeded `deferred` is a mention and one seeded
+// `captured` is a direct message — the sink produces no other pairing, which
+// TestChannelRecordSkipsEveryMailDomainGate holds through the real writer.
+type seededRecord struct {
+	// SourceID is the message's natural key half, and the test's handle on it.
+	SourceID string
+	Sender   string
+	// Transport is the channel provider, or empty for mail. It decides the
+	// activity's kind, its source system and the trace's connector together —
+	// a telegram-carried message with gmail's source system is a row no
+	// connector writes, and this seed exists to write rows they do.
+	Transport string
+	Outcome   capture.TraceOutcome
+	// Ledger writes the disposition this message's sender raised. Only the
+	// first message from an address carries one: the ledger keeps one open
+	// question per address, and later messages join it.
+	Ledger bool
+	// Verdict is the status that disposition settled at, defaulting to `real`.
+	// A T2 suppression records its own answer rather than a judged one, so the
+	// two ladder outcomes that reach the join do not share a status.
+	Verdict string
+}
+
+// verdict is the disposition status to seed, defaulting to a judged sender.
+func (r seededRecord) verdict() string {
+	if r.Verdict == "" {
+		return "real"
+	}
+	return r.Verdict
+}
+
+// sourceSystem is the system the connector for this transport would name.
+func (r seededRecord) sourceSystem() string {
+	if r.Transport == "" {
+		return "gmail"
+	}
+	return r.Transport
+}
+
 // seedDeferredMessage writes a MAIL activity from one sender, a trace row for
 // it, and (on the first call for that address) the ledger's open question.
 func seedDeferredMessage(ctx context.Context, t *testing.T, db *database.DB,
 	owner ids.UUID, sourceID, sender string, withLedger bool,
 ) {
 	t.Helper()
-	seedDeferredRecord(ctx, t, db, owner, sourceID, sender, "", withLedger)
+	seedRecord(ctx, t, db, owner, seededRecord{
+		SourceID: sourceID, Sender: sender,
+		Outcome: capture.TraceDeferred, Ledger: withLedger,
+	})
 }
 
-// seedDeferredRecord is seedDeferredMessage with the transport named: empty
-// lands a mail record, a provider lands a message on that channel.
-func seedDeferredRecord(ctx context.Context, t *testing.T, db *database.DB,
-	owner ids.UUID, sourceID, sender, channelProvider string, withLedger bool,
+// seedRecord writes one activity, its trace row, and optionally the ledger's
+// question about its sender.
+func seedRecord(ctx context.Context, t *testing.T, db *database.DB,
+	owner ids.UUID, rec seededRecord,
 ) {
 	t.Helper()
-	seedTracedRecord(ctx, t, db, owner, sourceID, sender, channelProvider,
-		capture.TraceDeferred, withLedger)
-}
-
-// seedTracedRecord writes one activity, its trace row, and optionally the
-// ledger's question about its sender.
-//
-// The OUTCOME is a parameter because it is what the read keys on, and the two
-// channel shapes differ by exactly it: a record named by a channel identity
-// takes decideChannelCounterparty, which opens no ledger question and so traces
-// `captured`, while a record named by an address alone runs the mail ladder and
-// can defer. Seeding a channel row as `deferred` would be a shape the sink
-// cannot produce, which is how the guard this replaced came to refuse a verdict
-// that had already landed.
-func seedTracedRecord(ctx context.Context, t *testing.T, db *database.DB,
-	owner ids.UUID, sourceID, sender, channelProvider string,
-	outcome capture.TraceOutcome, withLedger bool,
-) {
-	t.Helper()
+	sourceID, sender, channelProvider := rec.SourceID, rec.Sender, rec.Transport
+	system := rec.sourceSystem()
 	activityID := ids.NewV7()
 	if err := db.Tx(ctx, func(tx pgx.Tx) error {
 		// The ledger's owner is a foreign key: a dangling one would make this a
@@ -74,33 +105,29 @@ func seedTracedRecord(ctx context.Context, t *testing.T, db *database.DB,
 			                      source_id, source, captured_by, counterparty_email)
 			VALUES ($1, NULLIF(current_setting('app.workspace_id', true), '')::uuid,
 			        CASE WHEN $4 = '' THEN 'note' ELSE 'message' END, NULLIF($4, ''),
-			        now(), 'gmail', $2, 'gmail', 'connector:gmail', $3)`,
-			activityID, sourceID, sender, channelProvider); err != nil {
+			        now(), $5, $2, $5, 'connector:' || $5, $3)`,
+			activityID, sourceID, sender, channelProvider, system); err != nil {
 			return err
 		}
-		if withLedger {
+		if rec.Ledger {
 			if _, err := tx.Exec(ctx, `
 				INSERT INTO capture_pending_counterparty
 				       (workspace_id, email, domain, activity_id, owner_id, status, kind, resolved_at)
 				VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid,
-				        $1, 'client.io', $2, $3, 'real', 'person', now())`,
-				sender, activityID, owner); err != nil {
+				        $1, 'client.io', $2, $3, $4, 'person', now())`,
+				sender, activityID, owner, rec.verdict()); err != nil {
 				return err
 			}
 		}
 		// The connector names the TRANSPORT, which is what the sink writes: a
 		// channel record answers with its provider, mail with its source system.
-		transport := "gmail"
-		if channelProvider != "" {
-			transport = channelProvider
-		}
 		return capture.Trace(ctx, tx, capture.TraceEntry{
 			Stage:  pipelinetrace.StageTierLadder,
-			UserID: owner, Connector: transport, SourceSystem: "gmail", SourceID: sourceID,
-			Outcome: outcome, ActivityID: activityID,
+			UserID: owner, Connector: system, SourceSystem: system, SourceID: sourceID,
+			Outcome: rec.Outcome, ActivityID: activityID,
 		}, false)
 	}); err != nil {
-		t.Fatalf("seeding a deferred message: %v", err)
+		t.Fatalf("seeding a traced record: %v", err)
 	}
 }
 
@@ -150,8 +177,12 @@ func TestACapturedChannelRecordInheritsNoMailVerdict(t *testing.T) {
 	memberCtx := memberContext(ctx, ws, me)
 	const sender = "both.media@client.io"
 
-	seedDeferredRecord(memberCtx, t, db, me, "m-1", sender, "", true)
-	seedTracedRecord(memberCtx, t, db, me, "c-1", sender, "telegram", capture.TraceCaptured, false)
+	seedRecord(memberCtx, t, db, me, seededRecord{
+		SourceID: "m-1", Sender: sender, Outcome: capture.TraceDeferred, Ledger: true,
+	})
+	seedRecord(memberCtx, t, db, me, seededRecord{
+		SourceID: "c-1", Sender: sender, Transport: "telegram", Outcome: capture.TraceCaptured,
+	})
 
 	entries := entriesByConnector(memberCtx, t, store, 2)
 	if entries["gmail"].Resolution == nil {
@@ -166,11 +197,11 @@ func TestACapturedChannelRecordInheritsNoMailVerdict(t *testing.T) {
 // like any mail: the question it defers is its own, and the answer is its own
 // to report.
 //
-// This is the case a guard on activity.channel_provider could not express.
-// kind='message' forces that column non-null for every channel record, so
-// guarding on it refused the address-named ones too — and since nothing ever
-// clears a trace's verdict, they read "waiting on a verdict" for the whole
-// 24-hour window after their verdict had landed.
+// The transport cannot express this. kind='message' forces channel_provider
+// non-null for every channel record, so it says only "this arrived on a
+// channel" — never which ladder decided the record. A read that keys on it
+// leaves these messages claiming to wait for an answer they already have, for
+// as long as the window keeps them.
 func TestAnAddressNamedChannelMessageCarriesItsOwnVerdict(t *testing.T) {
 	ctx, ws, db, store := traceReadWorkspace(t)
 	me := ids.NewV7()
@@ -179,8 +210,14 @@ func TestAnAddressNamedChannelMessageCarriesItsOwnVerdict(t *testing.T) {
 
 	// The first mention raised the question; the second is the same sender
 	// again, joining it.
-	seedDeferredRecord(memberCtx, t, db, me, "x-1", sender, "telegram", true)
-	seedDeferredRecord(memberCtx, t, db, me, "x-2", sender, "telegram", false)
+	seedRecord(memberCtx, t, db, me, seededRecord{
+		SourceID: "x-1", Sender: sender, Transport: "telegram",
+		Outcome: capture.TraceDeferred, Ledger: true,
+	})
+	seedRecord(memberCtx, t, db, me, seededRecord{
+		SourceID: "x-2", Sender: sender, Transport: "telegram",
+		Outcome: capture.TraceDeferred,
+	})
 
 	for _, entry := range traceEntries(memberCtx, t, store, 2) {
 		if entry.Resolution == nil {
@@ -190,6 +227,34 @@ func TestAnAddressNamedChannelMessageCarriesItsOwnVerdict(t *testing.T) {
 		if entry.Resolution.Status != "real" {
 			t.Errorf("resolution = %q, want the ledger's answer", entry.Resolution.Status)
 		}
+	}
+}
+
+// The OTHER ladder outcome that records a disposition reports it too.
+//
+// `deferred` and `suppressed` are both in LadderDispositionOutcomes, and the
+// join admits both. Only one of them being exercised would leave half the
+// predicate resting on the other half's test — and the two arms differ in more
+// than a string: a T2 suppression settles at `suppressed` rather than at a
+// judged verdict, so a read that reached only the judged statuses would look
+// correct here and report nothing in production.
+func TestAnAddressNamedChannelSuppressionCarriesItsOwnDisposition(t *testing.T) {
+	ctx, ws, db, store := traceReadWorkspace(t)
+	me := ids.NewV7()
+	memberCtx := memberContext(ctx, ws, me)
+	const sender = "noreply@sendgrid.test"
+
+	seedRecord(memberCtx, t, db, me, seededRecord{
+		SourceID: "s-1", Sender: sender, Transport: "telegram",
+		Outcome: capture.TraceSuppressed, Ledger: true, Verdict: "suppressed",
+	})
+
+	entries := traceEntries(memberCtx, t, store, 1)
+	if entries[0].Resolution == nil {
+		t.Fatal("a suppressed mention reports no disposition — the registry recorded one against this address")
+	}
+	if got := entries[0].Resolution.Status; got != "suppressed" {
+		t.Errorf("resolution = %q, want the suppression the registry recorded", got)
 	}
 }
 

--- a/backend/internal/modules/capture/traceresolution_integration_test.go
+++ b/backend/internal/modules/capture/traceresolution_integration_test.go
@@ -39,6 +39,25 @@ func seedDeferredRecord(ctx context.Context, t *testing.T, db *database.DB,
 	owner ids.UUID, sourceID, sender, channelProvider string, withLedger bool,
 ) {
 	t.Helper()
+	seedTracedRecord(ctx, t, db, owner, sourceID, sender, channelProvider,
+		capture.TraceDeferred, withLedger)
+}
+
+// seedTracedRecord writes one activity, its trace row, and optionally the
+// ledger's question about its sender.
+//
+// The OUTCOME is a parameter because it is what the read keys on, and the two
+// channel shapes differ by exactly it: a record named by a channel identity
+// takes decideChannelCounterparty, which opens no ledger question and so traces
+// `captured`, while a record named by an address alone runs the mail ladder and
+// can defer. Seeding a channel row as `deferred` would be a shape the sink
+// cannot produce, which is how the guard this replaced came to refuse a verdict
+// that had already landed.
+func seedTracedRecord(ctx context.Context, t *testing.T, db *database.DB,
+	owner ids.UUID, sourceID, sender, channelProvider string,
+	outcome capture.TraceOutcome, withLedger bool,
+) {
+	t.Helper()
 	activityID := ids.NewV7()
 	if err := db.Tx(ctx, func(tx pgx.Tx) error {
 		// The ledger's owner is a foreign key: a dangling one would make this a
@@ -69,10 +88,16 @@ func seedDeferredRecord(ctx context.Context, t *testing.T, db *database.DB,
 				return err
 			}
 		}
+		// The connector names the TRANSPORT, which is what the sink writes: a
+		// channel record answers with its provider, mail with its source system.
+		transport := "gmail"
+		if channelProvider != "" {
+			transport = channelProvider
+		}
 		return capture.Trace(ctx, tx, capture.TraceEntry{
 			Stage:  pipelinetrace.StageTierLadder,
-			UserID: owner, Connector: "gmail", SourceSystem: "gmail", SourceID: sourceID,
-			Outcome: capture.TraceDeferred, ActivityID: activityID,
+			UserID: owner, Connector: transport, SourceSystem: "gmail", SourceID: sourceID,
+			Outcome: outcome, ActivityID: activityID,
 		}, false)
 	}); err != nil {
 		t.Fatalf("seeding a deferred message: %v", err)
@@ -109,38 +134,90 @@ func TestAVerdictReachesEveryMessageFromThatSender(t *testing.T) {
 	}
 }
 
-// The disposition ledger is the MAIL ladder's, keyed on an address. A direct
-// message may carry that same address to be matched on, and it reaches the
-// member's trace through the same activity column — so without a guard the
-// member is told their captured, linked and answered conversation is waiting on
-// a verdict that belongs to another medium and can never resolve for it.
+// A channel record inherits no verdict it did not raise.
+//
+// The disposition ledger is the ladder's, keyed on an address. A direct message
+// names its human by a channel identity and may carry that human's address only
+// as corroboration; it opens no ledger question, so reporting one would tell a
+// member their captured, linked and answered conversation is waiting on a
+// verdict that can never resolve for it.
 //
 // The mail row is the control: it must still carry the verdict, or the guard
 // would be suppressing the ledger rather than scoping it.
-func TestOnlyAMailRowCarriesTheMailVerdict(t *testing.T) {
+func TestACapturedChannelRecordInheritsNoMailVerdict(t *testing.T) {
 	ctx, ws, db, store := traceReadWorkspace(t)
 	me := ids.NewV7()
 	memberCtx := memberContext(ctx, ws, me)
 	const sender = "both.media@client.io"
 
 	seedDeferredRecord(memberCtx, t, db, me, "m-1", sender, "", true)
-	seedDeferredRecord(memberCtx, t, db, me, "c-1", sender, "telegram", false)
+	seedTracedRecord(memberCtx, t, db, me, "c-1", sender, "telegram", capture.TraceCaptured, false)
 
-	window, err := store.ListMine(memberCtx, nil, nil)
+	entries := entriesByConnector(memberCtx, t, store, 2)
+	if entries["gmail"].Resolution == nil {
+		t.Errorf("the mail row lost its verdict — the guard scopes the ledger, it does not suppress it")
+	}
+	if got := entries["telegram"].Resolution; got != nil {
+		t.Errorf("a captured direct message reports %q, want no verdict — it opened no question", got.Status)
+	}
+}
+
+// A channel message whose sender is named by an ADDRESS runs the mail ladder
+// like any mail: the question it defers is its own, and the answer is its own
+// to report.
+//
+// This is the case a guard on activity.channel_provider could not express.
+// kind='message' forces that column non-null for every channel record, so
+// guarding on it refused the address-named ones too — and since nothing ever
+// clears a trace's verdict, they read "waiting on a verdict" for the whole
+// 24-hour window after their verdict had landed.
+func TestAnAddressNamedChannelMessageCarriesItsOwnVerdict(t *testing.T) {
+	ctx, ws, db, store := traceReadWorkspace(t)
+	me := ids.NewV7()
+	memberCtx := memberContext(ctx, ws, me)
+	const sender = "mentioned@client.io"
+
+	// The first mention raised the question; the second is the same sender
+	// again, joining it.
+	seedDeferredRecord(memberCtx, t, db, me, "x-1", sender, "telegram", true)
+	seedDeferredRecord(memberCtx, t, db, me, "x-2", sender, "telegram", false)
+
+	for _, entry := range traceEntries(memberCtx, t, store, 2) {
+		if entry.Resolution == nil {
+			t.Errorf("a mentioned sender's message still reads unresolved — the ladder deferred it, so the ladder's answer is its answer")
+			continue
+		}
+		if entry.Resolution.Status != "real" {
+			t.Errorf("resolution = %q, want the ledger's answer", entry.Resolution.Status)
+		}
+	}
+}
+
+// traceEntries reads the member's window and insists on the row count the test
+// seeded, so a later assertion is about the rows it means.
+func traceEntries(ctx context.Context, t *testing.T, store *capture.TraceStore, want int) []capture.TraceRow {
+	t.Helper()
+	window, err := store.ListMine(ctx, nil, nil)
 	if err != nil {
 		t.Fatalf("ListMine: %v", err)
 	}
+	if len(window.Entries) != want {
+		t.Fatalf("entries = %d, want %d", len(window.Entries), want)
+	}
+	return window.Entries
+}
 
-	if len(window.Entries) != 2 {
-		t.Fatalf("entries = %d, want the mail row and the channel row", len(window.Entries))
+// entriesByConnector keys the window by the transport each row names, which is
+// how a test tells two seeded rows apart: the read returns no source id, and
+// the connector is the field the seed varies.
+func entriesByConnector(ctx context.Context, t *testing.T, store *capture.TraceStore, want int) map[string]capture.TraceRow {
+	t.Helper()
+	out := make(map[string]capture.TraceRow, want)
+	for _, entry := range traceEntries(ctx, t, store, want) {
+		out[entry.Connector] = entry
 	}
-	resolved := 0
-	for _, entry := range window.Entries {
-		if entry.Resolution != nil {
-			resolved++
-		}
+	if len(out) != want {
+		t.Fatalf("connectors = %d over %d rows, want one per row", len(out), want)
 	}
-	if resolved != 1 {
-		t.Errorf("%d of 2 rows carry the mail verdict, want exactly the mail one — a channel record has no ladder verdict to report, which is not the same as having one that is pending", resolved)
-	}
+	return out
 }

--- a/backend/internal/modules/capture/tracestore.go
+++ b/backend/internal/modules/capture/tracestore.go
@@ -273,34 +273,45 @@ const traceRowColumns = `t.id, t.stage, t.connector, t.outcome, coalesce(t.reaso
 // not depend on a diagnostic posture.
 //
 // A channel row reports a verdict only when the LADDER ITSELF opened the
-// question, and the outcome is what says so.
+// question, and the OUTCOME is what says so, because the transport cannot.
+// kind='message' forces channel_provider non-null for every channel record, so
+// that column says "this arrived on a channel" and never which ladder decided
+// it — while two records that differ exactly there both reach this join. One
+// names its human by a channel identity and takes decideChannelCounterparty,
+// which writes no ledger row at all; an address riding along as corroboration
+// must not make it inherit a mail verdict raised by somebody else's message.
+// The other names its human by an ADDRESS alone — a mention, where the address
+// IS the identity — runs the mail ladder like any mail, and defers a question
+// that is its own to answer.
 //
-// Two different channel messages reach this join, and the transport cannot tell
-// them apart. One names its human by a channel identity: it takes
-// decideChannelCounterparty, which writes no ledger row at all, so an address
-// riding along as corroboration would otherwise make it inherit whatever mail
-// verdict exists for that human — telling a member their captured, linked and
-// answered conversation is "waiting on a verdict". The other names its human by
-// an ADDRESS alone (a mention, where the address IS the identity): it runs the
-// mail ladder like any mail, and the row it defers is its own. Guarding on
-// activity.channel_provider refused both, because kind='message' forces that
-// column non-null for every channel record — so the second kind read "waiting on
-// a verdict" permanently, after its verdict had landed.
-//
-// `deferred` and `suppressed` are the outcomes the ladder records a disposition
-// for, so they are exactly the rows with a question of their own. A
-// channel-identity record traces neither. Mail is unguarded: a `captured` row
-// carrying noise_prior or decided_prior is reporting a settled PRIOR verdict,
-// which is the answer to "why did this not appear?".
+// LadderDispositionOutcomes is therefore the discriminator, and it holds only
+// while a channel-identity record traces none of them. That is a property of a
+// module this query cannot see, so it is gated where the writer is:
+// TestChannelRecordSkipsEveryMailDomainGate drives the real Sink and asserts
+// the outcome. Mail is unguarded, so a `captured` row carrying noise_prior or
+// decided_prior still reports the settled PRIOR verdict that explains it.
 //
 // BOTH joins carry the workspace, and that is not belt-and-braces: there is no
 // RLS on these tables since 0217, an address is not unique across tenants, and
 // an unscoped `d.email = a.counterparty_email` would answer with ANOTHER
 // workspace's verdict about the same person.
-// Spelled from the TraceOutcome constants rather than as SQL literals, because
-// the two must mean the same thing: an outcome renamed in Go while the string
-// here stayed put would leave the join silently answering for no rows.
-var resolutionJoin = fmt.Sprintf(`
+//
+// The widened arm additionally requires a MEMBER, which keeps it on the
+// personal side of the read. `a.channel_provider IS NULL` used to make that
+// structural: a workspace-owned row could not reach the ledger through it at
+// all. An outcome does not carry that property, so it is stated. A ledger row's
+// owner_id is an individual, and ListWorkspace is the scope a manager holds a
+// grant for — so without this, the day a workspace-owned binding emits an
+// address-named record, that grant would start answering with dispositions
+// raised by one member's own correspondence. A workspace row losing a verdict
+// it could have shown is a gap on a screen; the other direction is a member's
+// mail becoming readable by their manager.
+//
+// The outcome list is spelled as SQL literals so both queries stay compile-time
+// constants; TestTheResolutionJoinSpellsEveryLadderDispositionOutcome holds the
+// literals equal to LadderDispositionOutcomes, so a tier that starts recording a
+// disposition cannot join that list and leave this join behind.
+const resolutionJoin = `
 		  LEFT JOIN activity a
 		         ON a.id = t.activity_id AND a.workspace_id = t.workspace_id
 		  LEFT JOIN LATERAL (
@@ -308,9 +319,11 @@ var resolutionJoin = fmt.Sprintf(`
 		           FROM capture_pending_counterparty
 		          WHERE workspace_id = t.workspace_id
 		            AND email = a.counterparty_email
-		            AND (a.channel_provider IS NULL OR t.outcome IN ('%s', '%s'))
+		            AND (a.channel_provider IS NULL
+		                 OR (t.user_id IS NOT NULL
+		                     AND t.outcome IN ('deferred', 'suppressed')))
 		          ORDER BY resolved_at DESC NULLS FIRST
-		          LIMIT 1) d ON true`, TraceDeferred, TraceSuppressed)
+		          LIMIT 1) d ON true`
 
 func scanTraceRow(rows pgx.Rows) (TraceRow, error) {
 	var row TraceRow

--- a/backend/internal/modules/capture/tracestore.go
+++ b/backend/internal/modules/capture/tracestore.go
@@ -272,19 +272,35 @@ const traceRowColumns = `t.id, t.stage, t.connector, t.outcome, coalesce(t.reaso
 // address unless an operator enabled payloads, and what a member is told must
 // not depend on a diagnostic posture.
 //
-// MAIL rows only, and the channel_provider guard is what says so. The
-// disposition ledger is the mail ladder's, keyed on an address; a channel
-// message may carry a corroborating address, and without the guard a direct
-// message inherits whatever mail verdict is pending for that same human —
-// telling a member their captured, linked and answered conversation is
-// "waiting on a verdict". A channel record has no ladder verdict to report,
-// which is not the same as having one that is pending.
+// A channel row reports a verdict only when the LADDER ITSELF opened the
+// question, and the outcome is what says so.
+//
+// Two different channel messages reach this join, and the transport cannot tell
+// them apart. One names its human by a channel identity: it takes
+// decideChannelCounterparty, which writes no ledger row at all, so an address
+// riding along as corroboration would otherwise make it inherit whatever mail
+// verdict exists for that human — telling a member their captured, linked and
+// answered conversation is "waiting on a verdict". The other names its human by
+// an ADDRESS alone (a mention, where the address IS the identity): it runs the
+// mail ladder like any mail, and the row it defers is its own. Guarding on
+// activity.channel_provider refused both, because kind='message' forces that
+// column non-null for every channel record — so the second kind read "waiting on
+// a verdict" permanently, after its verdict had landed.
+//
+// `deferred` and `suppressed` are the outcomes the ladder records a disposition
+// for, so they are exactly the rows with a question of their own. A
+// channel-identity record traces neither. Mail is unguarded: a `captured` row
+// carrying noise_prior or decided_prior is reporting a settled PRIOR verdict,
+// which is the answer to "why did this not appear?".
 //
 // BOTH joins carry the workspace, and that is not belt-and-braces: there is no
 // RLS on these tables since 0217, an address is not unique across tenants, and
 // an unscoped `d.email = a.counterparty_email` would answer with ANOTHER
 // workspace's verdict about the same person.
-const resolutionJoin = `
+// Spelled from the TraceOutcome constants rather than as SQL literals, because
+// the two must mean the same thing: an outcome renamed in Go while the string
+// here stayed put would leave the join silently answering for no rows.
+var resolutionJoin = fmt.Sprintf(`
 		  LEFT JOIN activity a
 		         ON a.id = t.activity_id AND a.workspace_id = t.workspace_id
 		  LEFT JOIN LATERAL (
@@ -292,9 +308,9 @@ const resolutionJoin = `
 		           FROM capture_pending_counterparty
 		          WHERE workspace_id = t.workspace_id
 		            AND email = a.counterparty_email
-		            AND a.channel_provider IS NULL
+		            AND (a.channel_provider IS NULL OR t.outcome IN ('%s', '%s'))
 		          ORDER BY resolved_at DESC NULLS FIRST
-		          LIMIT 1) d ON true`
+		          LIMIT 1) d ON true`, TraceDeferred, TraceSuppressed)
 
 func scanTraceRow(rows pgx.Rows) (TraceRow, error) {
 	var row TraceRow

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -3859,6 +3859,7 @@ export const de = {
   "captureActivity.reason.transactional_prefix":
     "der Absender wirkt wie ein automatischer Versender, keine Person",
   "captureActivity.outcome.deferred_capped": "Nicht eingereiht",
+  "captureActivity.outcome.deferred_settled": "Zur Entscheidung vorgelegt",
   "captureActivity.resolution.pending": "wartet noch",
   "captureActivity.resolution.unsure": "an die Prüfliste gesendet",
   "captureActivity.resolution.real": "als echter Kontakt beurteilt",

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -3859,7 +3859,7 @@ export const de = {
   "captureActivity.reason.transactional_prefix":
     "der Absender wirkt wie ein automatischer Versender, keine Person",
   "captureActivity.outcome.deferred_capped": "Nicht eingereiht",
-  "captureActivity.outcome.deferred_settled": "Zur Entscheidung vorgelegt",
+  "captureActivity.outcome.deferred_sent": "Zur Entscheidung vorgelegt",
   "captureActivity.resolution.pending": "wartet noch",
   "captureActivity.resolution.unsure": "an die Prüfliste gesendet",
   "captureActivity.resolution.real": "als echter Kontakt beurteilt",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -3863,6 +3863,7 @@ export const en = {
   "captureActivity.reason.transactional_prefix":
     "the sender looks like an automated mailer, not a person",
   "captureActivity.outcome.deferred_capped": "Not queued",
+  "captureActivity.outcome.deferred_settled": "Sent for a verdict",
   "captureActivity.resolution.pending": "still waiting",
   "captureActivity.resolution.unsure": "sent to the review queue",
   "captureActivity.resolution.real": "judged a real contact",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -3863,7 +3863,7 @@ export const en = {
   "captureActivity.reason.transactional_prefix":
     "the sender looks like an automated mailer, not a person",
   "captureActivity.outcome.deferred_capped": "Not queued",
-  "captureActivity.outcome.deferred_settled": "Sent for a verdict",
+  "captureActivity.outcome.deferred_sent": "Sent for a verdict",
   "captureActivity.resolution.pending": "still waiting",
   "captureActivity.resolution.unsure": "sent to the review queue",
   "captureActivity.resolution.real": "judged a real contact",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -3844,7 +3844,7 @@ export const vi = {
   "captureActivity.reason.transactional_prefix":
     "người gửi trông như trình gửi tự động, không phải một người",
   "captureActivity.outcome.deferred_capped": "Chưa xếp hàng",
-  "captureActivity.outcome.deferred_settled": "Đã gửi để phân định",
+  "captureActivity.outcome.deferred_sent": "Đã gửi để phân định",
   "captureActivity.resolution.pending": "vẫn đang chờ",
   "captureActivity.resolution.unsure": "đã gửi vào hàng chờ duyệt",
   "captureActivity.resolution.real": "được xem là liên hệ thật",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -3844,6 +3844,7 @@ export const vi = {
   "captureActivity.reason.transactional_prefix":
     "người gửi trông như trình gửi tự động, không phải một người",
   "captureActivity.outcome.deferred_capped": "Chưa xếp hàng",
+  "captureActivity.outcome.deferred_settled": "Đã gửi để phân định",
   "captureActivity.resolution.pending": "vẫn đang chờ",
   "captureActivity.resolution.unsure": "đã gửi vào hàng chờ duyệt",
   "captureActivity.resolution.real": "được xem là liên hệ thật",

--- a/frontend/src/screens/capture-activity.test.tsx
+++ b/frontend/src/screens/capture-activity.test.tsx
@@ -236,12 +236,35 @@ describe("capture activity", () => {
         data: [{ ...ROW, outcome: "deferred", reason: "deferral_capped" }],
       }),
     );
-    // Scoped to the LIST: the funnel legitimately labels its bucket "Waiting on
-    // a verdict", because most deferrals genuinely are waiting. It is this row
-    // that is not.
     const row = within(await screen.findByRole("list"));
     expect(row.getByText(/not queued/i)).toBeInTheDocument();
     expect(row.queryByText(/waiting on a verdict/i)).not.toBeInTheDocument();
+  });
+
+  it("labels the deferred bucket with what every message in it has in common", async () => {
+    // A bucket is one number over both the settled and the still-waiting, so a
+    // tense in its label is a claim it cannot support. "Waiting on a verdict"
+    // over a strip whose rows each say the verdict landed is the same
+    // contradiction the row avoids, one level up.
+    renderTab(
+      windowBody({
+        data: [
+          {
+            ...ROW,
+            outcome: "deferred",
+            reason: null,
+            resolution: {
+              status: "real",
+              kind: "person",
+              resolved_at: "2026-08-15T09:13:00Z",
+            },
+          },
+        ],
+      }),
+    );
+    const funnel = within(await screen.findByTestId("capture-activity-funnel"));
+    expect(funnel.getByText(/sent for a verdict/i)).toBeInTheDocument();
+    expect(funnel.queryByText(/waiting on a verdict/i)).not.toBeInTheDocument();
   });
 
   it("does not say a settled deferral is still waiting for its verdict", async () => {

--- a/frontend/src/screens/capture-activity.test.tsx
+++ b/frontend/src/screens/capture-activity.test.tsx
@@ -244,6 +244,51 @@ describe("capture activity", () => {
     expect(row.queryByText(/waiting on a verdict/i)).not.toBeInTheDocument();
   });
 
+  it("does not say a settled deferral is still waiting for its verdict", async () => {
+    // The same contradiction as the capped case, from the other direction: the
+    // ledger has answered, the answer is on the row, and the outcome beside it
+    // must not still be asking the question.
+    renderTab(
+      windowBody({
+        data: [
+          {
+            ...ROW,
+            outcome: "deferred",
+            reason: null,
+            resolution: {
+              status: "real",
+              kind: "person",
+              resolved_at: "2026-08-15T09:13:00Z",
+            },
+          },
+        ],
+      }),
+    );
+    const row = within(await screen.findByRole("list"));
+    expect(row.getByText(/sent for a verdict/i)).toBeInTheDocument();
+    expect(row.getByText(/judged a real contact/i)).toBeInTheDocument();
+    expect(row.queryByText(/waiting on a verdict/i)).not.toBeInTheDocument();
+  });
+
+  it("still says a deferral with no answer yet is waiting", async () => {
+    // The control for the test above: the label is settled-vs-waiting, not
+    // "deferrals never say waiting".
+    renderTab(
+      windowBody({
+        data: [
+          {
+            ...ROW,
+            outcome: "deferred",
+            reason: null,
+            resolution: { status: "pending", kind: null, resolved_at: null },
+          },
+        ],
+      }),
+    );
+    const row = within(await screen.findByRole("list"));
+    expect(row.getByText(/waiting on a verdict/i)).toBeInTheDocument();
+  });
+
   it("reports an empty window as empty rather than as a failure", async () => {
     renderTab(windowBody({ data: [], funnel: {} }));
     expect(

--- a/frontend/src/screens/capture-activity.tsx
+++ b/frontend/src/screens/capture-activity.tsx
@@ -344,17 +344,23 @@ function CaptureEntryRow({
 
 // The outcome and the reason that qualifies it.
 //
-// A capped deferral is the one pair that would otherwise contradict itself: the
-// message is NOT waiting for a verdict, because the ceiling refused to ask for
-// one. So it says "Not queued", and the reason line explains why — rather than
-// leaving a heading and its own explanation arguing on screen.
+// Two deferral pairs would otherwise contradict themselves on screen, and both
+// are read the same way: "Waiting on a verdict" is only true while one is
+// actually outstanding.
+//
+// A CAPPED deferral is not waiting, because the ceiling refused to ask for a
+// verdict at all — it says "Not queued", and the reason line explains why.
+//
+// A SETTLED one is not waiting either: the ledger has answered, and the
+// resolution beside it says what the answer was. Left alone the row reads
+// "Waiting on a verdict — judged a real contact", which is the screen arguing
+// with itself. The ladder DID defer this sender, so the outcome still says so;
+// it just says it in the past tense.
 function CaptureEntryOutcome({ entry }: Readonly<{ entry: TraceEntry }>) {
   const t = useT();
   const reason = knownReason(entry.reason);
   const outcome =
-    entry.outcome === "deferred" && reason === "deferral_capped"
-      ? "deferred_capped"
-      : entry.outcome;
+    entry.outcome === "deferred" ? deferralLabel(entry, reason) : entry.outcome;
   return (
     <span className="capture-activity__outcome">
       {t(`captureActivity.outcome.${outcome}`)}
@@ -365,6 +371,26 @@ function CaptureEntryOutcome({ entry }: Readonly<{ entry: TraceEntry }>) {
       ) : null}
     </span>
   );
+}
+
+// Which of the three things a deferral can be this row is.
+//
+// `pending` is the only status that leaves a question outstanding: every other
+// one — including `unsure`, which passes it to a human — is the ledger having
+// answered. An unknown status is treated as settled rather than waiting,
+// because a status this build does not recognise is one a newer binary wrote,
+// and the one thing it cannot be is the state that has no verdict yet.
+function deferralLabel(
+  entry: TraceEntry,
+  reason: KnownReason | null,
+): "deferred" | "deferred_capped" | "deferred_settled" {
+  if (reason === "deferral_capped") {
+    return "deferred_capped";
+  }
+  if (!entry.resolution || entry.resolution.status === "pending") {
+    return "deferred";
+  }
+  return "deferred_settled";
 }
 
 // What the row can honestly show about the message itself.

--- a/frontend/src/screens/capture-activity.tsx
+++ b/frontend/src/screens/capture-activity.tsx
@@ -270,6 +270,23 @@ function CaptureActivityWindow({ scope }: Readonly<{ scope: Scope }>) {
 // It filters the rows already LOADED, not the window, so the count line beside
 // it says both numbers. A filter that silently showed 12 of 26 would be a worse
 // answer than no filter at all.
+// A bucket counts every message that met an outcome, so its label has to hold
+// for all of them at once.
+//
+// Four of the five already do. `deferred` does not: the funnel groups by
+// outcome alone, with no ledger join, so one number covers the senders still
+// being judged AND the ones already answered — and "Waiting on a verdict — 31"
+// over rows that each say the verdict landed is the same contradiction the row
+// avoids, one level up and louder, because the strip is what a reader sees
+// first. What every message in the bucket has in common is that the ladder sent
+// it for a verdict, so that is what the bucket says.
+//
+// The ROW keeps the tense: there it is one message, and whether that one is
+// still waiting is knowable and worth saying.
+function funnelLabel(outcome: Outcome): Outcome | "deferred_sent" {
+  return outcome === "deferred" ? "deferred_sent" : outcome;
+}
+
 function CaptureFunnel({
   funnel,
   selected,
@@ -291,7 +308,7 @@ function CaptureFunnel({
           onClick={() => onSelect(selected === outcome ? null : outcome)}
         >
           <StatCard
-            label={t(`captureActivity.outcome.${outcome}`)}
+            label={t(`captureActivity.outcome.${funnelLabel(outcome)}`)}
             // Zero is a reading, not an absence: "no message was dropped as
             // internal today" is exactly what somebody comes here to confirm.
             value={String(funnel[outcome] ?? 0)}
@@ -383,14 +400,14 @@ function CaptureEntryOutcome({ entry }: Readonly<{ entry: TraceEntry }>) {
 function deferralLabel(
   entry: TraceEntry,
   reason: KnownReason | null,
-): "deferred" | "deferred_capped" | "deferred_settled" {
+): "deferred" | "deferred_capped" | "deferred_sent" {
   if (reason === "deferral_capped") {
     return "deferred_capped";
   }
   if (!entry.resolution || entry.resolution.status === "pending") {
     return "deferred";
   }
-  return "deferred_settled";
+  return "deferred_sent";
 }
 
 // What the row can honestly show about the message itself.


### PR DESCRIPTION
## What was wrong

Capture activity reported **31 channel messages "Waiting on a verdict"** whose verdicts had landed seconds after capture. Reproduced against the dev database: all five senders resolved `real / person` on their first attempt at 14:04:50–54, while the last deferral was written at 14:04:48.77. Nothing was slow and nothing was stuck — the screen could not see the answer, and a trace is never rewritten, so those rows would have said "waiting" for their whole 24-hour life.

Three defects, all in this one surface. The first two share a root cause: **the code asked about the transport when it meant to ask about the record.**

### 1. The verdict never reached the row (`tracestore.go`)

`resolutionJoin` was guarded to `a.channel_provider IS NULL` — "mail rows only" (#1429). But `activity`'s own CHECK makes `kind = 'message'` equivalent to a non-null `channel_provider`, so that guard refuses **every** channel record — including the ones a connector names by address alone, which run the mail ladder like any mail and defer a ledger row of their own.

dispact's mentions are exactly that shape, and its own `counterpartyOf` says so:

> An address alone goes through the mail ladder, where a corporate domain is DEFERRED to the pending inbox

The proof is that the ledger row's own `activity_id` points at a row the guard excluded:

| email | status | kind | channel_provider |
|---|---|---|---|
| lars@gradion.com | real | message | dispact |

The guard's real subject is the record, not the medium. A message named by a channel **identity** takes `decideChannelCounterparty`, which opens no ledger question at all — that is the one that must inherit nothing. The **outcome** says which is which, since only `deferred` and `suppressed` record a disposition. Mail stays unguarded, so a `captured` row carrying `noise_prior` still reports the prior verdict that explains it.

### 2. One connector, two spellings (`sinktrace.go`)

`traceConnector` read the transport off the counterparty's channel identity, which a mention does not carry. The same connector therefore appeared as two rows in one list — `dispact` for its direct messages, `ext:dispact-connector:dispact` for its mentions — and only the first resolved through `/v1/channel-providers` to a label. That is the raw string in the screenshot.

It now reads the record's own `ChannelProvider`, the field that becomes `activity.channel_provider`, which is what the doc comment already claimed it returned.

### 3. The row then argued with itself (`capture-activity.tsx`)

With the verdict finally arriving, the row read **"Waiting on a verdict — judged a real contact"**. That is the same contradiction the capped deferral already handles, from the other direction, so it is handled the same way: once the ledger has answered, the outcome says what the ladder did ("Sent for a verdict") and the resolution says what came back.

## Verified against live data

The same endpoint, same database, after the fix:

```
 15  outcome=captured  connector=dispact                        resolution=None
 31  outcome=deferred  connector=ext:dispact-connector:dispact  resolution=real
```

All 31 now carry their verdict. Their `connector` keeps the old spelling because a trace records a decision as it was made and is never rewritten — new captures write `dispact`.

## Tests

`TestOnlyAMailRowCarriesTheMailVerdict` pinned the old guard by seeding a channel row as `deferred` — a shape the sink cannot produce (rule 6: a test that supplies its own version of production). It is replaced by two tests over the shapes the writer actually writes:

- `TestACapturedChannelRecordInheritsNoMailVerdict` — the #1429 case, still held, with the mail row as the control.
- `TestAnAddressNamedChannelMessageCarriesItsOwnVerdict` — the case this fixes. Verified to fail against the old guard.
- `TestOneTransportIsSpelledOneWay` — both branches of the connector id.
- Two frontend tests for the settled/waiting label, the settled one verified to fail without the fix.

Coverage on the changed code: `traceConnector` 100%, `readPage` 83%, `capture-activity.tsx` 94.6% stmts / 82.1% branch.

## Gates

`make check`, `make craft-static`, and `make test-integration` (40 packages, 0 skips) all green locally on the rebased branch.

Refs #1382, #1429

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes capture activity showing “Waiting on a verdict” for channel mentions whose verdict already landed, and makes connector naming consistent. Previously the read excluded all channel records and `traceConnector` read the provider from the counterparty; now the join keys on ladder outcomes and the connector reads from the record, so mentioned senders inherit their verdict and one connector appears under one name.

- Backend: The resolution join applies to outcomes in `LadderDispositionOutcomes` (`deferred`/`suppressed`) and is personal-only on the widened arm (`t.user_id IS NOT NULL`). Mail stays unguarded; captured mail still shows prior verdicts. `traceConnector` reads `ChannelProvider`, fixing label resolution via `/v1/channel-providers` and removing the `dispact` vs `ext:dispact-connector:dispact` split. Tests added to pin the outcome list to the SQL, require a member on the widened join, cover suppression, and verify single connector spelling; seed helper writes transports as the sink does.
- Frontend: Deferrals show “Sent for a verdict” once resolved; “Waiting on a verdict” appears only while status is `pending`. The funnel labels the deferred bucket “Sent for a verdict.” Added a new i18n key for the settled deferral label. No migrations; existing traces keep their old connector spelling by design.

<sup>Written for commit a3736152790c2159720147c8005ee5908c09f4dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1462?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added “Sent for a verdict” status messaging for settled deferred captures in English, German, and Vietnamese.
* **Bug Fixes**
  * Deferred capture activity now accurately distinguishes pending, capped, and settled outcomes.
  * Settled captures display the appropriate real-contact messaging instead of indicating they are still awaiting a verdict.
  * Channel records now use their transport provider for consistent connector naming and correct resolution behavior.
  * Channel messages with address-based identities now retain their own outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->