### PR TITLE
docs(status): search's fan-out carries bookkeeping, not just wiring

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -789,12 +789,28 @@ version never re-runs, so they asked whether a 2026-07 repair works on a
 2026-08 schema — a question no installation puts. What the reminders do today
 is still covered by the six eligibility suites and `timescan_integration_test.go`.
 
-**Four modules remain deferred, all for the same reason: per-tenant job
-fan-out.** The webhook retry sweep is one job row per live tenant, with a suite
-built on a second tenant's parked delivery and a fault injected through the
-workspace GUC; the agent scheduler's suite injects its fault through a trigger
-keyed on `NEW.workspace_id`. Privacy's retention sweep and search's re-embed
-fan-out are the same shape. Their tables go with the fleet loops (§5).
+**Three of the four fan-out modules are collapsed** — webhooks (#1255), agents
+(#1283) and privacy (#1337) — each landing its module's phase D columns in the
+same PR, because the suites proving the fan-out asserted isolation between two
+tenants and would otherwise assert it against a schema that has none.
+
+**Search is the fourth, and it is NOT the same shape.** The other three fanned
+out for wiring reasons: one row per tenant, each doing the same work. The
+re-embed fan-out carries the run's own BOOKKEEPING. `embed_store_binding`
+holds `reembedding_pending`, an array of workspace ids; the dispatcher seeds it
+and enqueues one child per entry, each child removes itself on completion
+(`FinishWorkspaceReembedding`), and the run RELEASES when the array empties.
+The array is not a list of jobs — it is how the system knows a run finished,
+and it is the thing a forced confirm's steal (`ReembedClaim.StealAfter`)
+recovers.
+
+So collapsing search is a change to a run LIFECYCLE, not to job wiring: the
+pending array is the tenancy artifact, and removing it means deciding what
+"this run is finished" means when there is one pass — claim, run, release, with
+the steal still able to recover a wedged run. That is a coherent piece of work
+and a different one from the three above, which is why it is written down here
+rather than started at the end of a long session. Its column drop
+(`embedding`) waits on it.
 
 **The vocabulary step is done (#1240); the first collapse hit one open
 question, and it is worth answering before writing code.** `role: worker` now


### PR DESCRIPTION
Three of the four fan-out modules are collapsed — webhooks (#1255), agents (#1283), privacy (#1337). **The fourth is not the same shape**, and the difference is worth stating before someone treats it as a fourth repetition.

Webhooks, agents and privacy fanned out for **wiring** reasons: one row per tenant, each doing identical work. Collapsing them was mechanical once the vocabulary existed.

Search's re-embed fan-out carries the **run's bookkeeping**. `embed_store_binding.reembedding_pending` is an array of workspace ids: the dispatcher seeds it and enqueues one child per entry, each child removes itself on completion (`FinishWorkspaceReembedding`), and the run **releases when the array empties**. That array is not a list of jobs — it is how the system knows a run finished, and it is what a forced confirm's steal (`ReembedClaim.StealAfter`) recovers.

So collapsing search is a change to a **run lifecycle**, not to job wiring: decide what "finished" means with one pass, keep the steal able to recover a wedged run, and the pending array goes with the tenancy it encodes. Its column drop (`embedding`) waits on that.

Written down rather than started at the end of a long session. Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies `STATUS.md` to explain why search’s re-embed fan-out differs from the other three collapses and why its collapse is a run-lifecycle change, not wiring. This matters because the run’s completion and steal recovery are encoded in `embed_store_binding.reembedding_pending`, so redefining “finished” must preserve recovery; the `embedding` column drop waits on that decision.

- Webhooks (#1255), agents (#1283), and privacy (#1337) collapsed cleanly; search is different.
- `embed_store_binding.reembedding_pending` holds workspace IDs; the dispatcher seeds it, each child removes itself via `FinishWorkspaceReembedding`, and the run releases when the array is empty. It is bookkeeping, not a job list.
- Collapse plan: one-pass claim/run/release, keep `ReembedClaim.StealAfter` able to recover a wedged run, and move/remove the pending array with the tenancy it encodes before dropping `embedding`.

<sup>Written for commit f85bd47178464ffadc44f16e3bb18cd459e093af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1464?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project status to reflect completed tenant-column consolidation for webhooks, agents, and privacy.
  * Documented that search remains deferred pending improvements to its re-embedding workflow and lifecycle handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->