### PR TITLE
feat(capture): an HTML-only mail is stored as text a person can read

### DIFF
--- a/backend/internal/modules/capture/mailmap/htmltext.go
+++ b/backend/internal/modules/capture/mailmap/htmltext.go
@@ -19,12 +19,13 @@ import (
 // Elements whose CONTENT is not text of the message. Skipped whole rather than
 // merely unstyled: a stylesheet's rules are the largest single source of
 // nonsense in a stripped newsletter.
+// <noscript> is deliberately NOT here: a mail client renders with scripting
+// off, so its content is exactly what the reader sees.
 var skippedContent = map[atom.Atom]bool{
 	atom.Style:    true,
 	atom.Script:   true,
 	atom.Head:     true,
 	atom.Title:    true,
-	atom.Noscript: true,
 	atom.Template: true,
 	atom.Svg:      true,
 }
@@ -47,11 +48,22 @@ var paragraphBreakers = map[atom.Atom]bool{
 // textWriter assembles the rendered text. Breaks are requested rather than
 // written, so a run of nested block elements collapses to one break instead of
 // one per element, and a break before any text is dropped.
+// How much rendered text is worth building. Only maxBodyLen of it is stored, so
+// a sender cannot make this hold a hundred megabytes of repeated text in memory
+// to have all but the first few thousand characters thrown away. The margin
+// above maxBodyLen leaves tidy() something to trim without cutting the excerpt
+// short of what gets stored.
+const maxRenderedLen = 4 * maxBodyLen
+
 type textWriter struct {
 	out     strings.Builder
 	pending int
 	spaced  bool
 }
+
+// full reports that the excerpt is long enough. What follows would be truncated
+// away, so rendering it buys nothing and costs whatever the sender chose.
+func (w *textWriter) full() bool { return w.out.Len() >= maxRenderedLen }
 
 func (w *textWriter) breakLine(n int) {
 	if w.out.Len() == 0 {
@@ -114,6 +126,27 @@ func collapse(s string) string {
 	return strings.Join(strings.Fields(s), " ")
 }
 
+// edgeSpace reports whether a text node began or ended on whitespace. It is the
+// only evidence of a word boundary across an inline tag: "<b>Marg</b><b>ince</b>"
+// is one word and "<b>Angebot</b> <i>2026</i>" is two, and the tags say nothing
+// about which. Guessing a space corrupts the word for search as well as reading.
+func edgeSpace(s string) (leading, trailing bool) {
+	if s == "" {
+		return false, false
+	}
+	trimmed := strings.TrimLeft(s, " \t\r\n\f")
+	if trimmed == "" {
+		return true, true
+	}
+	return trimmed != s, strings.TrimRight(s, " \t\r\n\f") != s
+}
+
+// The longest address worth writing out. A tracking link runs to thousands of
+// characters of opaque query string, and the stored body is capped: writing one
+// out spends the reader's excerpt — and the model's — on a URL nobody can read,
+// pushing out the sentence that says what the mail wanted.
+const maxWrittenHref = 120
+
 // linkText is what an anchor contributes: its own text, and the address after
 // it when the two differ. A link whose text already IS the address is written
 // once, and a mailto or a fragment adds nothing a reader can act on.
@@ -127,7 +160,7 @@ func linkText(text, href string) string {
 	if !strings.HasPrefix(lower, "http://") && !strings.HasPrefix(lower, "https://") {
 		return text
 	}
-	if strings.Contains(text, href) {
+	if len(href) > maxWrittenHref || strings.Contains(text, href) {
 		return text
 	}
 	return text + " (" + href + ")"
@@ -150,11 +183,27 @@ type anchorState struct {
 	depth int
 }
 
-func (a *anchorState) open(href string) {
-	if a.depth == 0 {
-		a.href = href
-		a.text.Reset()
+// writePre emits preformatted text as it stands. Inside <pre> the whitespace IS
+// the content — an invoice table read as one run of words has lost its columns.
+func writePre(w *textWriter, raw string) {
+	for i, line := range strings.Split(raw, "\n") {
+		if i > 0 {
+			w.pending = 1
+			w.spaced = false
+		}
+		w.write(strings.TrimRight(line, " \t\r"))
 	}
+}
+
+// open starts an anchor. An <a> inside an open <a> is malformed, and HTML
+// recovery closes the first — so the outer link is written out before the inner
+// one starts, rather than the inner address being dropped.
+func (a *anchorState) open(w *textWriter, href string) {
+	if a.depth > 0 {
+		a.flush(w)
+	}
+	a.href = href
+	a.text.Reset()
 	a.depth++
 }
 
@@ -163,8 +212,12 @@ func (a *anchorState) close(w *textWriter) {
 	if a.depth > 0 {
 		return
 	}
+	// Spaced on both sides: an anchor sits inside a sentence, and the address
+	// written after its text ends on a bracket that would otherwise run into
+	// whatever word comes next.
 	w.space()
 	w.write(linkText(a.text.String(), a.href))
+	w.space()
 	a.text.Reset()
 }
 
@@ -183,55 +236,120 @@ func (a *anchorState) flush(w *textWriter) {
 // references decoded, blocks separated by real line breaks, list items marked,
 // and the contents of style and script left out.
 func htmlToText(src string) string {
-	w := &textWriter{}
+	r := &renderer{w: &textWriter{}, a: &anchorState{}}
 	z := html.NewTokenizer(strings.NewReader(src))
-	a := &anchorState{}
-	for {
-		switch z.Next() {
+	for !r.w.full() {
+		switch token := z.Next(); token {
 		case html.ErrorToken:
 			// The tokenizer reports malformed markup as tokens, so an error
 			// here is the end of the document rather than a parse failure.
-			a.flush(w)
-			return tidy(w.String())
+			return r.finish()
 		case html.TextToken:
-			writeText(w, a, collapse(string(z.Text())))
+			r.text(string(z.Text()))
 		case html.StartTagToken, html.SelfClosingTagToken:
-			token := z.Token()
-			if skippedContent[token.DataAtom] {
-				skipContent(z, token.DataAtom)
-				continue
-			}
-			if token.DataAtom == atom.A && token.Type == html.StartTagToken {
-				a.open(attrValue(token, "href"))
-				continue
-			}
-			openTag(w, token.DataAtom)
+			r.startTag(z, token == html.SelfClosingTagToken)
 		case html.EndTagToken:
 			name, _ := z.TagName()
-			tag := atom.Lookup(name)
-			if tag == atom.A && a.depth > 0 {
-				a.close(w)
-				continue
-			}
-			closeTag(w, tag)
+			r.endTag(atom.Lookup(name))
 		}
+	}
+	return r.finish()
+}
+
+// renderer is the walk's state: what has been written, the anchor being built,
+// and whether the text arriving is preformatted.
+type renderer struct {
+	w   *textWriter
+	a   *anchorState
+	pre int
+}
+
+func (r *renderer) text(raw string) {
+	// Inside <pre> the whitespace is the content — unless an anchor is open,
+	// where the text is being buffered for the link rather than written.
+	if r.pre > 0 && r.a.depth == 0 {
+		writePre(r.w, raw)
+		return
+	}
+	writeText(r.w, r.a, raw)
+}
+
+func (r *renderer) startTag(z *html.Tokenizer, selfClosing bool) {
+	token := z.Token()
+	if skippedContent[token.DataAtom] {
+		// A self-closing form has no content, and looking for an end tag that
+		// cannot come would swallow the rest of the message.
+		if !selfClosing {
+			skipContent(z, token.DataAtom)
+		}
+		return
+	}
+	if selfClosing {
+		openTag(r.w, token.DataAtom)
+		return
+	}
+	switch token.DataAtom {
+	case atom.A:
+		r.a.open(r.w, attrValue(token, "href"))
+	case atom.Pre:
+		r.pre++
+		openTag(r.w, token.DataAtom)
+	default:
+		openTag(r.w, token.DataAtom)
 	}
 }
 
+func (r *renderer) endTag(tag atom.Atom) {
+	switch {
+	case tag == atom.A && r.a.depth > 0:
+		r.a.close(r.w)
+	case tag == atom.Pre:
+		if r.pre > 0 {
+			r.pre--
+		}
+		closeTag(r.w, tag)
+	default:
+		closeTag(r.w, tag)
+	}
+}
+
+// finish writes out an anchor the document never closed, so its text is not
+// lost with the missing end tag.
+func (r *renderer) finish() string {
+	r.a.flush(r.w)
+	return tidy(r.w.String())
+}
+
 // writeText routes a text node to the anchor being built, or to the document.
-func writeText(w *textWriter, a *anchorState, text string) {
+// A space is asked for only where the source had one, so an inline tag between
+// two halves of a word does not split it.
+func writeText(w *textWriter, a *anchorState, raw string) {
+	if len(raw) > maxRenderedLen {
+		raw = raw[:maxRenderedLen]
+	}
+	leading, trailing := edgeSpace(raw)
+	text := collapse(raw)
 	if text == "" {
+		// Whitespace between two elements is still a word boundary.
+		if leading {
+			w.space()
+		}
 		return
 	}
 	if a.depth > 0 {
-		if a.text.Len() > 0 {
+		if leading && a.text.Len() > 0 {
 			a.text.WriteString(" ")
 		}
 		a.text.WriteString(text)
 		return
 	}
-	w.space()
+	if leading {
+		w.space()
+	}
 	w.write(text)
+	if trailing {
+		w.space()
+	}
 }
 
 // openTag writes what an element contributes before its content.
@@ -262,16 +380,28 @@ func closeTag(w *textWriter, tag atom.Atom) {
 	}
 }
 
+// Where a skipped element ends even though the document never closed it. A
+// mail that opens <head> and goes straight to <body> is ordinary, and reading
+// to EOF looking for </head> loses the whole message.
+var impliedClose = map[atom.Atom]atom.Atom{atom.Head: atom.Body}
+
 // skipContent consumes an element's content up to its matching end tag, so a
-// stylesheet or a script contributes nothing.
+// stylesheet or a script contributes nothing. It also stops at the tag that
+// implicitly closes the element, because HTML does not require every end tag
+// and a mail is under no obligation to be well-formed.
 func skipContent(z *html.Tokenizer, tag atom.Atom) {
+	closer, hasCloser := impliedClose[tag]
 	depth := 1
 	for depth > 0 {
 		switch z.Next() {
 		case html.ErrorToken:
 			return
-		case html.StartTagToken:
-			if name, _ := z.TagName(); atom.Lookup(name) == tag {
+		case html.StartTagToken, html.SelfClosingTagToken:
+			name, _ := z.TagName()
+			switch found := atom.Lookup(name); {
+			case hasCloser && found == closer:
+				return
+			case found == tag:
 				depth++
 			}
 		case html.EndTagToken:

--- a/backend/internal/modules/capture/mailmap/htmltext.go
+++ b/backend/internal/modules/capture/mailmap/htmltext.go
@@ -1,0 +1,304 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package mailmap
+
+import (
+	"strings"
+
+	"golang.org/x/net/html"
+	"golang.org/x/net/html/atom"
+)
+
+// Rendering an HTML-only mail as text. A tag-strip by regular expression gets
+// three things wrong that a reader notices at once: `&auml;` stays spelled out,
+// every block runs into the next because tags became spaces, and the contents
+// of <style> and <script> arrive as body text. What this produces is stored, so
+// it is also what search indexes and what a model reads.
+
+// Elements whose CONTENT is not text of the message. Skipped whole rather than
+// merely unstyled: a stylesheet's rules are the largest single source of
+// nonsense in a stripped newsletter.
+var skippedContent = map[atom.Atom]bool{
+	atom.Style:    true,
+	atom.Script:   true,
+	atom.Head:     true,
+	atom.Title:    true,
+	atom.Noscript: true,
+	atom.Template: true,
+	atom.Svg:      true,
+}
+
+// Elements that end the line they sit on.
+var lineBreakers = map[atom.Atom]bool{
+	atom.Br: true, atom.Tr: true, atom.Li: true, atom.Dt: true, atom.Dd: true,
+	atom.Caption: true, atom.Option: true,
+}
+
+// Elements that stand apart from what surrounds them: a blank line either side.
+var paragraphBreakers = map[atom.Atom]bool{
+	atom.P: true, atom.Div: true, atom.Blockquote: true, atom.Section: true,
+	atom.Article: true, atom.Header: true, atom.Footer: true, atom.Table: true,
+	atom.Ul: true, atom.Ol: true, atom.Dl: true, atom.Pre: true, atom.Hr: true,
+	atom.H1: true, atom.H2: true, atom.H3: true, atom.H4: true, atom.H5: true,
+	atom.H6: true, atom.Form: true, atom.Fieldset: true, atom.Figure: true,
+}
+
+// textWriter assembles the rendered text. Breaks are requested rather than
+// written, so a run of nested block elements collapses to one break instead of
+// one per element, and a break before any text is dropped.
+type textWriter struct {
+	out     strings.Builder
+	pending int
+	spaced  bool
+}
+
+func (w *textWriter) breakLine(n int) {
+	if w.out.Len() == 0 {
+		return
+	}
+	w.spaced = false
+	if n > w.pending {
+		w.pending = n
+	}
+}
+
+func (w *textWriter) write(s string) {
+	if s == "" {
+		return
+	}
+	if w.pending > 0 {
+		w.spaced = false
+		w.out.WriteString(strings.Repeat("\n", w.pending))
+		w.pending = 0
+	}
+	w.flushSpace(s)
+	w.out.WriteString(s)
+}
+
+// space keeps a word boundary an inline tag would otherwise close up:
+// "<b>Angebot</b><i>2026</i>" is two words, not one. Requested rather than
+// written, so that punctuation following an element still closes the sentence
+// up: the space is dropped when the next thing written starts with it.
+func (w *textWriter) space() {
+	if w.out.Len() == 0 || w.pending > 0 {
+		return
+	}
+	w.spaced = true
+}
+
+// Punctuation that closes up against the word before it. A source newline
+// between "</a>" and "." is insignificant whitespace, and writing it through
+// leaves the sentence ending with a gap before its full stop.
+const closingPunctuation = ".,;:!?)]}"
+
+func (w *textWriter) flushSpace(next string) {
+	if !w.spaced {
+		return
+	}
+	w.spaced = false
+	if next != "" && strings.ContainsAny(next[:1], closingPunctuation) {
+		return
+	}
+	if !strings.HasSuffix(w.out.String(), " ") {
+		w.out.WriteString(" ")
+	}
+}
+
+func (w *textWriter) String() string { return w.out.String() }
+
+// collapse folds HTML's insignificant whitespace into single spaces. A newline
+// in the source carries no meaning — only the tags do — so keeping it would
+// break a line where the sender never did.
+func collapse(s string) string {
+	return strings.Join(strings.Fields(s), " ")
+}
+
+// linkText is what an anchor contributes: its own text, and the address after
+// it when the two differ. A link whose text already IS the address is written
+// once, and a mailto or a fragment adds nothing a reader can act on.
+func linkText(text, href string) string {
+	text = collapse(text)
+	href = strings.TrimSpace(href)
+	if href == "" || text == "" {
+		return text
+	}
+	lower := strings.ToLower(href)
+	if !strings.HasPrefix(lower, "http://") && !strings.HasPrefix(lower, "https://") {
+		return text
+	}
+	if strings.Contains(text, href) {
+		return text
+	}
+	return text + " (" + href + ")"
+}
+
+func attrValue(token html.Token, name string) string {
+	for _, attr := range token.Attr {
+		if attr.Key == name {
+			return attr.Val
+		}
+	}
+	return ""
+}
+
+// anchorState buffers the text inside <a>…</a> so the address can follow it.
+// The depth count means a stray </a> cannot end an anchor a nested one opened.
+type anchorState struct {
+	text  strings.Builder
+	href  string
+	depth int
+}
+
+func (a *anchorState) open(href string) {
+	if a.depth == 0 {
+		a.href = href
+		a.text.Reset()
+	}
+	a.depth++
+}
+
+func (a *anchorState) close(w *textWriter) {
+	a.depth--
+	if a.depth > 0 {
+		return
+	}
+	w.space()
+	w.write(linkText(a.text.String(), a.href))
+	a.text.Reset()
+}
+
+// flush writes an anchor the document never closed, so its text is not lost
+// along with the missing end tag.
+func (a *anchorState) flush(w *textWriter) {
+	if a.depth == 0 {
+		return
+	}
+	a.depth = 0
+	w.space()
+	w.write(linkText(a.text.String(), a.href))
+}
+
+// htmlToText renders an HTML mail body as the text a person would read: entity
+// references decoded, blocks separated by real line breaks, list items marked,
+// and the contents of style and script left out.
+func htmlToText(src string) string {
+	w := &textWriter{}
+	z := html.NewTokenizer(strings.NewReader(src))
+	a := &anchorState{}
+	for {
+		switch z.Next() {
+		case html.ErrorToken:
+			// The tokenizer reports malformed markup as tokens, so an error
+			// here is the end of the document rather than a parse failure.
+			a.flush(w)
+			return tidy(w.String())
+		case html.TextToken:
+			writeText(w, a, collapse(string(z.Text())))
+		case html.StartTagToken, html.SelfClosingTagToken:
+			token := z.Token()
+			if skippedContent[token.DataAtom] {
+				skipContent(z, token.DataAtom)
+				continue
+			}
+			if token.DataAtom == atom.A && token.Type == html.StartTagToken {
+				a.open(attrValue(token, "href"))
+				continue
+			}
+			openTag(w, token.DataAtom)
+		case html.EndTagToken:
+			name, _ := z.TagName()
+			tag := atom.Lookup(name)
+			if tag == atom.A && a.depth > 0 {
+				a.close(w)
+				continue
+			}
+			closeTag(w, tag)
+		}
+	}
+}
+
+// writeText routes a text node to the anchor being built, or to the document.
+func writeText(w *textWriter, a *anchorState, text string) {
+	if text == "" {
+		return
+	}
+	if a.depth > 0 {
+		if a.text.Len() > 0 {
+			a.text.WriteString(" ")
+		}
+		a.text.WriteString(text)
+		return
+	}
+	w.space()
+	w.write(text)
+}
+
+// openTag writes what an element contributes before its content.
+func openTag(w *textWriter, tag atom.Atom) {
+	switch {
+	case tag == atom.Li:
+		w.breakLine(1)
+		w.write("- ")
+	case tag == atom.Td || tag == atom.Th:
+		w.space()
+	case paragraphBreakers[tag]:
+		w.breakLine(2)
+	case lineBreakers[tag]:
+		w.breakLine(1)
+	}
+}
+
+// closeTag ends the line an element occupied. A cell is separated by a space
+// instead: a table row read one cell per line loses the row.
+func closeTag(w *textWriter, tag atom.Atom) {
+	switch {
+	case tag == atom.Td || tag == atom.Th:
+		w.space()
+	case paragraphBreakers[tag]:
+		w.breakLine(2)
+	case lineBreakers[tag]:
+		w.breakLine(1)
+	}
+}
+
+// skipContent consumes an element's content up to its matching end tag, so a
+// stylesheet or a script contributes nothing.
+func skipContent(z *html.Tokenizer, tag atom.Atom) {
+	depth := 1
+	for depth > 0 {
+		switch z.Next() {
+		case html.ErrorToken:
+			return
+		case html.StartTagToken:
+			if name, _ := z.TagName(); atom.Lookup(name) == tag {
+				depth++
+			}
+		case html.EndTagToken:
+			if name, _ := z.TagName(); atom.Lookup(name) == tag {
+				depth--
+			}
+		}
+	}
+}
+
+// tidy trims the trailing space a break may have left on a line and caps a run
+// of blank lines at one, which is what a paragraph gap is.
+func tidy(s string) string {
+	lines := strings.Split(s, "\n")
+	out := make([]string, 0, len(lines))
+	blank := 0
+	for _, line := range lines {
+		line = strings.TrimRight(line, " \t")
+		if line == "" {
+			blank++
+			if blank > 1 || len(out) == 0 {
+				continue
+			}
+		} else {
+			blank = 0
+		}
+		out = append(out, line)
+	}
+	return strings.TrimSpace(strings.Join(out, "\n"))
+}

--- a/backend/internal/modules/capture/mailmap/htmltext_test.go
+++ b/backend/internal/modules/capture/mailmap/htmltext_test.go
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package mailmap
+
+import "testing"
+
+// What an HTML-only mail has to read like once stored. Every case here was a
+// way the previous tag-strip produced text a person could not read: entities
+// left spelled out, paragraphs run together, and stylesheet rules delivered as
+// if the sender had written them.
+func TestHTMLToText(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		html string
+		want string
+	}{
+		{
+			name: "decodes entity references",
+			html: "<p>Gr&uuml;&szlig;e aus M&#252;nchen &amp; Umgebung</p>",
+			want: "Grüße aus München & Umgebung",
+		},
+		{
+			name: "separates paragraphs with a blank line",
+			html: "<p>Erste Frage.</p><p>Zweite Frage.</p>",
+			want: "Erste Frage.\n\nZweite Frage.",
+		},
+		{
+			name: "breaks a line at br",
+			html: "Anna Berger<br>Kunde GmbH<br/>München",
+			want: "Anna Berger\nKunde GmbH\nMünchen",
+		},
+		{
+			name: "drops stylesheet rules",
+			html: "<html><head><style>.x{color:red}</style></head><body><p>Angebot</p></body></html>",
+			want: "Angebot",
+		},
+		{
+			name: "drops script bodies",
+			html: "<p>Angebot</p><script>var track = 1; document.write('x')</script>",
+			want: "Angebot",
+		},
+		{
+			name: "marks list items",
+			html: "<p>Offen:</p><ul><li>Preis</li><li>Termin</li></ul>",
+			want: "Offen:\n\n- Preis\n- Termin",
+		},
+		{
+			name: "keeps a table row on one line",
+			html: "<table><tr><td>Preis</td><td>1.200 EUR</td></tr><tr><td>Termin</td><td>KW 34</td></tr></table>",
+			want: "Preis 1.200 EUR\nTermin KW 34",
+		},
+		{
+			name: "writes the address after link text that differs",
+			html: `<p>Die <a href="https://kunde.de/angebot">Unterlagen</a> liegen bereit.</p>`,
+			want: "Die Unterlagen (https://kunde.de/angebot) liegen bereit.",
+		},
+		{
+			name: "writes a self-describing link once",
+			html: `<a href="https://kunde.de/angebot">https://kunde.de/angebot</a>`,
+			want: "https://kunde.de/angebot",
+		},
+		{
+			name: "leaves a mailto link as its text",
+			html: `<a href="mailto:anna@kunde.de">Anna schreiben</a>`,
+			want: "Anna schreiben",
+		},
+		{
+			name: "leaves a relative link as its text",
+			html: `<a href="/impressum">Impressum</a>`,
+			want: "Impressum",
+		},
+		{
+			name: "keeps the text of an anchor with no address",
+			html: `<a>Kein Ziel</a>`,
+			want: "Kein Ziel",
+		},
+		{
+			name: "keeps a word boundary an inline tag would close up",
+			html: "<b>Angebot</b> <i>2026</i>",
+			want: "Angebot 2026",
+		},
+		{
+			name: "collapses insignificant whitespace",
+			html: "<p>Viele\n   Grüße   aus\tMünchen</p>",
+			want: "Viele Grüße aus München",
+		},
+		{
+			name: "caps a run of empty blocks at one blank line",
+			html: "<p>Oben</p><div></div><div></div><p>Unten</p>",
+			want: "Oben\n\nUnten",
+		},
+		{
+			name: "reads a document with unclosed tags",
+			html: "<div><p>Erste Frage.<p>Zweite Frage.",
+			want: "Erste Frage.\n\nZweite Frage.",
+		},
+		{
+			name: "keeps the text of an anchor the document never closed",
+			html: `<p>Siehe <a href="https://kunde.de/x">hier`,
+			want: "Siehe hier (https://kunde.de/x)",
+		},
+		{
+			name: "renders a heading as its own block",
+			html: "<h1>Angebot 2026</h1><p>Anbei die Unterlagen.</p>",
+			want: "Angebot 2026\n\nAnbei die Unterlagen.",
+		},
+		{
+			name: "keeps nothing from an empty document",
+			html: "",
+			want: "",
+		},
+		{
+			name: "keeps nothing from a document that is only markup",
+			html: "<html><head><title>Newsletter</title></head><body></body></html>",
+			want: "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := htmlToText(tc.html); got != tc.want {
+				t.Errorf("htmlToText()\n got: %q\nwant: %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// The realistic case: an Outlook-shaped German mail, where every failure mode
+// above appears at once.
+func TestHTMLToTextRendersAnOutlookMail(t *testing.T) {
+	t.Parallel()
+	const src = `<html><head><meta charset="utf-8">
+<style type="text/css">p.MsoNormal{margin:0cm;font-size:11.0pt}</style></head>
+<body lang="DE"><div class="WordSection1">
+<p class="MsoNormal">Sehr geehrter Herr Jankowfsky,</p>
+<p class="MsoNormal">anbei das &uuml;berarbeitete Angebot. Details finden Sie
+<a href="https://kunde.de/angebot-2026">in unserem Portal</a>.</p>
+<p class="MsoNormal">Mit freundlichen Gr&uuml;&szlig;en<br>Anna Berger</p>
+</div></body></html>`
+	got := htmlToText(src)
+	want := "Sehr geehrter Herr Jankowfsky,\n\n" +
+		"anbei das überarbeitete Angebot. Details finden Sie in unserem Portal (https://kunde.de/angebot-2026).\n\n" +
+		"Mit freundlichen Grüßen\nAnna Berger"
+	if got != want {
+		t.Errorf("htmlToText()\n got: %q\nwant: %q", got, want)
+	}
+}
+
+// bodyText is where the choice between the two MIME parts is made, and the
+// plain part must keep winning: it is what the sender's own client composed.
+func TestBodyTextPrefersThePlainPart(t *testing.T) {
+	t.Parallel()
+	got := bodyText("Anbei das Angebot.", "<p>Anbei das <b>Angebot</b>.</p>")
+	if got != "Anbei das Angebot." {
+		t.Errorf("bodyText() = %q, want the plain part verbatim", got)
+	}
+}
+
+func TestBodyTextRendersHTMLWhenThereIsNoPlainPart(t *testing.T) {
+	t.Parallel()
+	got := bodyText("   ", "<p>Anbei das Angebot.</p><p>Bis Dienstag.</p>")
+	if got != "Anbei das Angebot.\n\nBis Dienstag." {
+		t.Errorf("bodyText() = %q, want the rendered HTML", got)
+	}
+}
+
+func TestBodyTextIsEmptyWhenTheMessageCarriedNoText(t *testing.T) {
+	t.Parallel()
+	if got := bodyText("", ""); got != "" {
+		t.Errorf("bodyText() = %q, want empty", got)
+	}
+}

--- a/backend/internal/modules/capture/mailmap/htmltext_test.go
+++ b/backend/internal/modules/capture/mailmap/htmltext_test.go
@@ -3,7 +3,10 @@
 
 package mailmap
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 // What an HTML-only mail has to read like once stored. Every case here was a
 // way the previous tag-strip produced text a person could not read: entities
@@ -124,6 +127,90 @@ func TestHTMLToText(t *testing.T) {
 				t.Errorf("htmlToText()\n got: %q\nwant: %q", got, tc.want)
 			}
 		})
+	}
+}
+
+// What a malformed or hostile mail must not be able to do. Each of these was a
+// way the renderer lost the message a reader was supposed to see — worse than
+// the tag-strip it replaced, which at least never made text disappear.
+func TestHTMLToTextKeepsTheMessageWhenTheMarkupIsBroken(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		html string
+		want string
+	}{
+		{
+			name: "a self-closing skipped element does not swallow the message",
+			html: `<svg/>Sichtbare Nachricht`,
+			want: "Sichtbare Nachricht",
+		},
+		{
+			name: "an unclosed head ends where the body begins",
+			html: `<head><meta charset=utf-8><body>Rechnungsbetrag: 500 EUR</body>`,
+			want: "Rechnungsbetrag: 500 EUR",
+		},
+		{
+			name: "noscript is what a mail client actually shows",
+			html: `<noscript>Ihr Einmalcode ist 123456</noscript>`,
+			want: "Ihr Einmalcode ist 123456",
+		},
+		{
+			name: "an inline tag inside a word does not split it",
+			html: `<span>Marg</span><span>ince</span>`,
+			want: "Margince",
+		},
+		{
+			name: "an inline tag before punctuation does not split it",
+			html: `<b>can</b>'t`,
+			want: "can't",
+		},
+		{
+			name: "whitespace between inline tags is still a word boundary",
+			html: `<b>Angebot</b> <i>2026</i>`,
+			want: "Angebot 2026",
+		},
+		{
+			name: "a nested anchor keeps both addresses",
+			html: `<a href="https://outer">eins<a href="https://inner">zwei</a>drei</a>`,
+			want: "eins (https://outer) zwei (https://inner) drei",
+		},
+		{
+			name: "preformatted text keeps its columns",
+			html: "<pre>Konto  Betrag\nA         10</pre>",
+			want: "Konto  Betrag\nA         10",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := htmlToText(tc.html); got != tc.want {
+				t.Errorf("htmlToText()\n got: %q\nwant: %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// A mail is written by a stranger, and only maxBodyLen of it is ever stored.
+// Neither its size nor a hidden address may decide what the reader gets.
+func TestHTMLToTextIsBoundedByWhatIsStored(t *testing.T) {
+	t.Parallel()
+	huge := "<body>" + strings.Repeat("x ", 5_000_000)
+	if got := len(htmlToText(huge)); got > maxRenderedLen {
+		t.Errorf("rendered %d bytes, want at most %d", got, maxRenderedLen)
+	}
+}
+
+func TestHTMLToTextKeepsTheMessageAheadOfATrackingAddress(t *testing.T) {
+	t.Parallel()
+	src := `<a href="https://tracker.example/` + strings.Repeat("a", 20000) +
+		`">Angebot öffnen</a><p>Angebot: 10.000 EUR, gültig bis Freitag.</p>`
+	got := htmlToText(src)
+	if !strings.Contains(got, "gültig bis Freitag") {
+		t.Errorf("the message was displaced by the tracking address: %q", got)
+	}
+	if strings.Contains(got, "tracker.example") {
+		t.Errorf("an unreadable address was written into the body: %q", got)
 	}
 }
 

--- a/backend/internal/modules/capture/mailmap/mailmap.go
+++ b/backend/internal/modules/capture/mailmap/mailmap.go
@@ -16,7 +16,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"regexp"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -89,8 +88,6 @@ func (m Message) Counterparty() string { return m.counterparty }
 
 // ThreadKey is the conversation identity this message belongs to.
 func (m Message) ThreadKey() string { return m.threadKey }
-
-var htmlTag = regexp.MustCompile(`(?s)<[^>]*>`)
 
 // Parse reads the headers and the text body of one message and classifies
 // its direction relative to the mailbox owner.
@@ -335,9 +332,8 @@ func domainOf(addr string) string {
 
 // extractText returns the message's plain-text body and the files it carried.
 //
-// It prefers a text/plain part, falling back to a crude tag-strip of text/html
-// only when no plain part exists, so an HTML-only newsletter still yields
-// readable text. Attachment parts are collected on the SAME walk: a MIME reader
+// It prefers a text/plain part, rendering text/html to text only when no plain
+// part exists, so an HTML-only newsletter still yields readable text. Attachment parts are collected on the SAME walk: a MIME reader
 // is single-pass, so a second walk would mean holding or re-parsing the whole
 // message to find files this one already stepped over.
 func extractText(reader *mail.Reader) (string, []Part, []PartDrop) {
@@ -401,7 +397,7 @@ func bodyText(plain, html string) string {
 		return strings.TrimSpace(plain)
 	}
 	if html != "" {
-		return strings.TrimSpace(htmlTag.ReplaceAllString(html, " "))
+		return htmlToText(html)
 	}
 	return ""
 }


### PR DESCRIPTION
A mail that carries no `text/plain` part was converted by replacing every tag with a space (`htmlTag.ReplaceAllString(html, " ")`). That got three things wrong at once, and all three reached the timeline, the search index and every model that reads `activity.body`:

- `&uuml;` and `&amp;` stayed spelled out — no entity decoding at all.
- Blocks ran into one another, because a `<p>` or `<br>` became a space rather than a line break.
- The contents of `<style>` and `<script>` arrived as body text, which is the single largest source of nonsense in a stripped newsletter.

## What changed

`backend/internal/modules/capture/mailmap/htmltext.go` renders the HTML with the `x/net/html` tokenizer (already a direct dependency — no new module). Entity references decode, paragraphs and list items become real line breaks, a table row stays on one line, and `style`/`script`/`head`/`title`/`svg` contribute nothing.

A link is written as its text with the address after it when the two differ (`Unterlagen (https://kunde.de/angebot)`), once when the text already is the address, and as bare text for `mailto:` or a relative href — nothing a reader cannot act on.

The `text/plain` part still wins whenever a message has one. This only decides what an HTML-only mail looks like.

## Scope

Applies to mail captured from here on. Already-stored rows keep the text they were stored with — the timeline's own signature/quote split (#1460) is what improves those. A backfill from `raw_capture` is possible later and is deliberately not in this PR.

Because the stored body is what the AI and search paths read, this improves their input too: previously a stylesheet's rules were part of what got embedded.

## Verification

20 table-driven cases over the converter (entities, block semantics, list bullets, tables, four link shapes, unclosed tags, an unclosed anchor, empty and markup-only documents), plus a realistic Outlook-shaped German mail asserted end to end, plus three cases pinning the plain-part preference in `bodyText`. `make check-backend` green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
HTML-only emails are rendered to readable text with the `x/net/html` tokenizer instead of stripping tags with regex. Previously entities stayed spelled out, blocks ran together, and style/script/head content leaked; now entities decode, block/list/table structure is preserved, non-content is skipped, links render as "text (URL)", and real-world markup is handled safely with sensible bounds.

**Review focus**
- New renderer in `backend/internal/modules/capture/mailmap/htmltext.go`; streaming tokenizer, whitespace collapsing, paragraph/line/table handling.
- Robustness: self-closing skipped elements no longer swallow the document; `head` stops at `body`; `noscript` content is kept; inline tags preserve word boundaries and punctuation; nested `<a>` flushes outer before inner; `<pre>` preserves spacing.
- Bounds and links: stop rendering once beyond stored size; omit unreadably long `href`s; only write `http(s)` addresses; avoid tracking URLs displacing message text.
- `bodyText` still prefers `text/plain`; falls back to the renderer only when no plain part exists.
- Tests cover converter behavior and plain/HTML selection; no new dependency (project already uses `x/net/html`).

**Rollout**
- Affects newly captured emails only; no backfill in this PR.
- No config or migrations required.

<sup>Written for commit 7a742c4b831f183398a76d1696d1b7619e03fdff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1466?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

