### PR TITLE
fix(capture): bound the mail renderer where the memory is actually taken

### DIFF
--- a/backend/internal/modules/capture/mailmap/htmltext.go
+++ b/backend/internal/modules/capture/mailmap/htmltext.go
@@ -55,6 +55,11 @@ var paragraphBreakers = map[atom.Atom]bool{
 // short of what gets stored.
 const maxRenderedLen = 4 * maxBodyLen
 
+// The largest single token worth buffering. A mail is written by a stranger and
+// only maxBodyLen of it is stored, so no one token needs to be bigger than the
+// whole excerpt; a token past this ends the walk with what was read so far.
+const maxTokenLen = maxRenderedLen
+
 type textWriter struct {
 	out     strings.Builder
 	pending int
@@ -238,11 +243,19 @@ func (a *anchorState) flush(w *textWriter) {
 func htmlToText(src string) string {
 	r := &renderer{w: &textWriter{}, a: &anchorState{}}
 	z := html.NewTokenizer(strings.NewReader(src))
+	// The loop's budget is checked between tokens, which bounds a document made
+	// of many tags but not ONE token holding the whole body: the tokenizer
+	// buffers a token entire before returning it, so an unbroken run of text
+	// allocates the sender's chosen size no matter what is done with it after.
+	// Capping the buffer moves the bound to where the memory is actually taken.
+	z.SetMaxBuf(maxTokenLen)
 	for !r.w.full() {
 		switch token := z.Next(); token {
 		case html.ErrorToken:
-			// The tokenizer reports malformed markup as tokens, so an error
-			// here is the end of the document rather than a parse failure.
+			// Malformed markup is reported as tokens rather than as an error,
+			// so this is the end of the document: EOF, or a token past the
+			// buffer cap. Both end the walk with what was read up to here,
+			// which is the readable part of the message.
 			return r.finish()
 		case html.TextToken:
 			r.text(string(z.Text()))

--- a/backend/internal/modules/capture/mailmap/htmltext_test.go
+++ b/backend/internal/modules/capture/mailmap/htmltext_test.go
@@ -201,6 +201,25 @@ func TestHTMLToTextIsBoundedByWhatIsStored(t *testing.T) {
 	}
 }
 
+// A body big enough to matter is bounded where the memory is actually taken —
+// inside the tokenizer, which buffers a token whole before returning it. A
+// single unbroken run of text would otherwise allocate whatever the sender
+// chose, no matter what the renderer did with it afterwards.
+func TestHTMLToTextBoundsOneEnormousToken(t *testing.T) {
+	t.Parallel()
+	src := "<p>Angebot: 12.000 EUR, gültig bis Freitag.</p><p>" +
+		strings.Repeat("x", maxTokenLen+1000) + "</p>"
+	got := htmlToText(src)
+	if !strings.Contains(got, "gültig bis Freitag") {
+		t.Errorf("the message before the overlong token was lost: %q", got)
+	}
+	// The budget is checked between tokens, so the last one to be written may
+	// carry the total past it — by one token, never by the sender's whole body.
+	if len(got) > maxRenderedLen+maxTokenLen {
+		t.Errorf("rendered %d bytes, want near %d", len(got), maxRenderedLen)
+	}
+}
+
 func TestHTMLToTextKeepsTheMessageAheadOfATrackingAddress(t *testing.T) {
 	t.Parallel()
 	src := `<a href="https://tracker.example/` + strings.Repeat("a", 20000) +


### PR DESCRIPTION
A background security review flagged the resource bound added in #1466 as being in the wrong place. It is, and the measurement is worse than it looks.

`htmlToText` checks its render budget between tokens (`for !r.w.full()`). That bounds a document made of many tags, but not one token holding the whole body — `html.Tokenizer` buffers a token entire before returning it, so a single unbroken run of text allocates whatever the sender chose no matter what the renderer does with it afterwards.

Measured on a 200 MB body: **1273 MB allocated** to produce the 32 KB that actually gets stored. After capping the tokenizer buffer with `SetMaxBuf(maxTokenLen)`: **under 1 MB**.

Inbound mail is attacker-controlled and this runs on the capture path, so the bound belongs where the allocation happens.

## Behaviour when the cap is hit

`SetMaxBuf` makes the tokenizer return `ErrorToken` on an overlong token, which the walk already treats as end-of-document. A mail carrying one enormous token therefore keeps everything readable that came before it rather than losing the message — pinned by `TestHTMLToTextBoundsOneEnormousToken`. The comment claiming `ErrorToken` can only mean EOF is corrected, since that is no longer true.

## Verification

`make check-backend` green, `make craft-static` clean, and the new test asserts both halves: the message before the overlong token survives, and the output stays bounded.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bound HTML-to-text mail rendering at the tokenizer to prevent unbounded allocation from a single overlong token. Previously we checked the render budget between tokens; now we cap the `html.Tokenizer` buffer and end parsing when a token exceeds `maxTokenLen`, preserving prior content.

- Introduces `maxTokenLen` (equal to `maxRenderedLen`) and calls `z.SetMaxBuf(maxTokenLen)` in `htmlToText`.
- Treats `html.ErrorToken` as end-of-document for EOF or buffer-cap overflow; updates the comment accordingly.
- Adds `TestHTMLToTextBoundsOneEnormousToken` to verify readable content before the overlong token is kept and output remains bounded.
- Effect: reduces allocations for large bodies (e.g., 200 MB) from ~1.27 GB to under 1 MB and hardens the capture path against attacker-controlled input.

<sup>Written for commit 86d450d7edf69493b85055c23d3ad1ee835cb358. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1471?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

