### PR TITLE
feat(migrations): refuse to go further while an archived tenant holds records

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -821,6 +821,30 @@ version never re-runs, so they asked whether a 2026-07 repair works on a
 2026-08 schema — a question no installation puts. What the reminders do today
 is still covered by the six eligibility suites and `timescan_integration_test.go`.
 
+**An archived tenant's records are gated now, not merged silently (0272).**
+Phase D does something 0217 did not, and nothing said so until this gate. 0217
+refused more than one LIVE workspace and named the residue it accepted: an
+installation that ARCHIVED a previous tenant keeps those rows, visible once the
+policies drop. That was about VISIBILITY. Dropping the column is a different
+act — an archived tenant's person stops being a visible foreign row and becomes
+indistinguishable from ours, listing, searching, exporting and ageing out under
+our retention policy — and it is one-way, because the reverse migrations restore
+the column but backfill every row to the live workspace.
+
+So 0272 refuses while any archived workspace still holds rows in a table that
+still carries the column, names the tables and counts, and tells the operator
+the three things they may do about it. It derives its list from pg_catalog, so
+it has less to check as phase D proceeds and never less truth to tell. The
+append-only ledgers are exempt BY NAME: their immutability trigger forbids
+DELETE, so demanding a clear-out there would demand the impossible, and their
+attribution goes with audit_log's own column at the end.
+
+**Thirteen modules merged before the gate existed** — signals, collections,
+quotas, customfields, finance, comms, consent, approvals, automation, voice,
+webhooks, agents, privacy. Configuration and machinery rather than records,
+which is why the stakes were low, but low is not none and a reader should not
+have to infer it from migration numbers.
+
 **Three of the four fan-out modules are collapsed** — webhooks (#1255), agents
 (#1283) and privacy (#1337) — each landing its module's phase D columns in the
 same PR, because the suites proving the fan-out asserted isolation between two

--- a/backend/migrations/archivedresidue_integration_test.go
+++ b/backend/migrations/archivedresidue_integration_test.go
@@ -22,6 +22,7 @@ package migrations
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -48,7 +49,12 @@ func gateSQL(t *testing.T) string {
 	return ""
 }
 
-// seedArchivedTenantHolding plants an archived workspace and one row it owns in
+// archivedRowsSeeded is how many rows the fixture plants, and it is deliberately
+// not one: a gate that reported "1 rows" for any amount would pass a test that
+// only ever seeded one.
+const archivedRowsSeeded = 2
+
+// seedArchivedTenantHolding plants an archived workspace and the rows it owns in
 // a table that still carries the tenant column, and returns the table's name.
 // app_user is the subject because it is the last table anything would drop and
 // so keeps this suite honest for the whole of phase D.
@@ -59,10 +65,12 @@ func seedArchivedTenantHolding(ctx context.Context, t *testing.T, conn *pgx.Conn
 		INSERT INTO workspace (slug, archived_at) VALUES ('gone-tenant', now()) RETURNING id`).Scan(&ws); err != nil {
 		t.Fatalf("seeding the archived workspace: %v", err)
 	}
-	if _, err := conn.Exec(ctx, `
-		INSERT INTO app_user (workspace_id, email, display_name)
-		VALUES ($1, 'ghost@gone.test', 'Ghost')`, ws); err != nil {
-		t.Fatalf("seeding the archived tenant's row: %v", err)
+	for i := range archivedRowsSeeded {
+		if _, err := conn.Exec(ctx, `
+			INSERT INTO app_user (workspace_id, email, display_name)
+			VALUES ($1, $2, 'Ghost')`, ws, fmt.Sprintf("ghost-%d@gone.test", i)); err != nil {
+			t.Fatalf("seeding the archived tenant's row %d: %v", i, err)
+		}
 	}
 	return "app_user"
 }
@@ -83,6 +91,12 @@ func TestTheArchivedResidueGateRefusesAndNamesWhatItFound(t *testing.T) {
 	// deploy log with no access to this test.
 	if !strings.Contains(err.Error(), table) {
 		t.Errorf("the refusal is %q, which does not name %s — an operator cannot act on a refusal that will not say what it found", err, table)
+	}
+	// The COUNT as well as the table: it is what tells an operator whether they
+	// are about to delete two rows or two hundred thousand, and a gate that
+	// counted wrong would still name the right table.
+	if want := fmt.Sprintf("%d rows", archivedRowsSeeded); !strings.Contains(err.Error(), want) {
+		t.Errorf("the refusal is %q, which does not report %q — the number is what sizes the decision it is asking for", err, want)
 	}
 }
 
@@ -111,7 +125,8 @@ func TestTheArchivedResidueGateAdmitsOnceTheResidueIsCleared(t *testing.T) {
 
 // An ARCHIVED tenant's ledger rows are not residue the operator can clear — the
 // immutability trigger forbids deleting them — so the gate must not demand it.
-// Without this, the exemption is one line of SQL nobody would notice losing.
+// BOTH ledgers, because the exemption is a two-name list and a test that drove
+// one of them would let the other be dropped from it silently.
 func TestTheArchivedResidueGateExemptsTheAppendOnlyLedgers(t *testing.T) {
 	ctx := context.Background()
 	conn := connect(t, mustOwnerDSN(t))
@@ -127,6 +142,11 @@ func TestTheArchivedResidueGateExemptsTheAppendOnlyLedgers(t *testing.T) {
 		INSERT INTO audit_log (workspace_id, actor_type, actor_id, action, entity_type, entity_id)
 		VALUES ($1, 'system', 'system', 'create', 'person', gen_random_uuid())`, ws); err != nil {
 		t.Fatalf("seeding the archived tenant's audit row: %v", err)
+	}
+	if _, err := conn.Exec(ctx, `
+		INSERT INTO system_log (workspace_id, actor_type, actor_id, action)
+		VALUES ($1, 'system', 'system', 'retention_pass_failed')`, ws); err != nil {
+		t.Fatalf("seeding the archived tenant's system_log row: %v", err)
 	}
 
 	if _, err := conn.Exec(ctx, gateSQL(t)); err != nil {

--- a/backend/migrations/archivedresidue_integration_test.go
+++ b/backend/migrations/archivedresidue_integration_test.go
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package migrations
+
+// The archived-tenant gate (0272) refuses, and refuses for the right reason.
+//
+// A gate is the one kind of migration that passes its whole life doing nothing:
+// every installation this ships to has no archived residue, so nothing exercises
+// the refusal, and a gate that stopped refusing would look exactly like one that
+// had nothing to refuse. This suite is the only thing that can tell those apart.
+//
+// It re-runs the shipped migration's own SQL rather than a paraphrase, which is
+// the pattern this repository retired for the 0148/0149 data repairs — and the
+// difference is worth naming. Those named columns, so a later schema change made
+// the replay a question production never asks. This one reads pg_catalog for
+// whatever still carries workspace_id, so it is schema-agnostic by construction:
+// as phase D removes columns the gate simply has less to check, and never less
+// truth to tell.
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// archivedGateVersion is the migration under test. Named once so a renumber is
+// one edit and a wrong number is a loud "no such migration" rather than a
+// silently skipped suite.
+const archivedGateVersion = "0272"
+
+// gateSQL is the shipped up-migration's text, loaded from the embedded
+// namespace. A copy pasted here would drift from the file that actually runs,
+// which is the whole failure mode this suite exists to prevent.
+func gateSQL(t *testing.T) string {
+	t.Helper()
+	core, _ := namespaces(t)
+	for _, m := range core.Migrations {
+		if m.Version == archivedGateVersion {
+			return m.UpSQL
+		}
+	}
+	t.Fatalf("core migration %s is not in the namespace — renumbered, or removed without removing this suite", archivedGateVersion)
+	return ""
+}
+
+// seedArchivedTenantHolding plants an archived workspace and one row it owns in
+// a table that still carries the tenant column, and returns the table's name.
+// app_user is the subject because it is the last table anything would drop and
+// so keeps this suite honest for the whole of phase D.
+func seedArchivedTenantHolding(ctx context.Context, t *testing.T, conn *pgx.Conn) string {
+	t.Helper()
+	var ws string
+	if err := conn.QueryRow(ctx, `
+		INSERT INTO workspace (slug, archived_at) VALUES ('gone-tenant', now()) RETURNING id`).Scan(&ws); err != nil {
+		t.Fatalf("seeding the archived workspace: %v", err)
+	}
+	if _, err := conn.Exec(ctx, `
+		INSERT INTO app_user (workspace_id, email, display_name)
+		VALUES ($1, 'ghost@gone.test', 'Ghost')`, ws); err != nil {
+		t.Fatalf("seeding the archived tenant's row: %v", err)
+	}
+	return "app_user"
+}
+
+func TestTheArchivedResidueGateRefusesAndNamesWhatItFound(t *testing.T) {
+	ctx := context.Background()
+	conn := connect(t, mustOwnerDSN(t))
+	resetSchema(t, conn)
+	migrateAll(t, conn)
+
+	table := seedArchivedTenantHolding(ctx, t, conn)
+
+	_, err := conn.Exec(ctx, gateSQL(t))
+	if err == nil {
+		t.Fatal("the gate admitted an installation whose archived tenant still holds records — phase D would merge them into this installation's own, and no rollback separates them again")
+	}
+	// The message has to be actionable on its own: an operator meets it in a
+	// deploy log with no access to this test.
+	if !strings.Contains(err.Error(), table) {
+		t.Errorf("the refusal is %q, which does not name %s — an operator cannot act on a refusal that will not say what it found", err, table)
+	}
+}
+
+// The gate lets an installation through once the residue is gone, which is the
+// other half of its promise: "decide, then run it again" is a lie if the second
+// run refuses too.
+func TestTheArchivedResidueGateAdmitsOnceTheResidueIsCleared(t *testing.T) {
+	ctx := context.Background()
+	conn := connect(t, mustOwnerDSN(t))
+	resetSchema(t, conn)
+	migrateAll(t, conn)
+
+	seedArchivedTenantHolding(ctx, t, conn)
+	if _, err := conn.Exec(ctx, gateSQL(t)); err == nil {
+		t.Fatal("the gate admitted the residue it exists to refuse — the pass below would prove nothing")
+	}
+
+	if _, err := conn.Exec(ctx, `
+		DELETE FROM app_user WHERE workspace_id IN (SELECT id FROM workspace WHERE archived_at IS NOT NULL)`); err != nil {
+		t.Fatalf("clearing the archived tenant's rows: %v", err)
+	}
+	if _, err := conn.Exec(ctx, gateSQL(t)); err != nil {
+		t.Fatalf("the gate still refuses an installation that did what it asked: %v", err)
+	}
+}
+
+// An ARCHIVED tenant's ledger rows are not residue the operator can clear — the
+// immutability trigger forbids deleting them — so the gate must not demand it.
+// Without this, the exemption is one line of SQL nobody would notice losing.
+func TestTheArchivedResidueGateExemptsTheAppendOnlyLedgers(t *testing.T) {
+	ctx := context.Background()
+	conn := connect(t, mustOwnerDSN(t))
+	resetSchema(t, conn)
+	migrateAll(t, conn)
+
+	var ws string
+	if err := conn.QueryRow(ctx, `
+		INSERT INTO workspace (slug, archived_at) VALUES ('gone-tenant', now()) RETURNING id`).Scan(&ws); err != nil {
+		t.Fatalf("seeding the archived workspace: %v", err)
+	}
+	if _, err := conn.Exec(ctx, `
+		INSERT INTO audit_log (workspace_id, actor_type, actor_id, action, entity_type, entity_id)
+		VALUES ($1, 'system', 'system', 'create', 'person', gen_random_uuid())`, ws); err != nil {
+		t.Fatalf("seeding the archived tenant's audit row: %v", err)
+	}
+
+	if _, err := conn.Exec(ctx, gateSQL(t)); err != nil {
+		t.Fatalf("the gate refused over an append-only ledger row: %v — the operator cannot delete it, so this demands the impossible", err)
+	}
+}

--- a/backend/migrations/core/0272_refuse_archived_tenant_residue.down.sql
+++ b/backend/migrations/core/0272_refuse_archived_tenant_residue.down.sql
@@ -1,0 +1,10 @@
+-- Reverse of 0272: nothing.
+--
+-- The up half changes no schema and no row — it reads, and either passes or
+-- refuses. There is no state to put back, and a down that invented one would be
+-- claiming this migration did something it did not.
+--
+-- Rolling back past this version is therefore free, which is the honest
+-- property for a gate: it never becomes the reason an operator cannot go
+-- backwards.
+SELECT 1;

--- a/backend/migrations/core/0272_refuse_archived_tenant_residue.up.sql
+++ b/backend/migrations/core/0272_refuse_archived_tenant_residue.up.sql
@@ -1,0 +1,75 @@
+-- 0272: refuse to go further while an ARCHIVED tenant still holds records.
+--
+-- This is a gate, not a change. It exists because ADR-0091 §8 phase D does
+-- something 0217 did not, and nothing so far has said so out loud.
+--
+-- 0217 refused more than one LIVE workspace and then named the residue it
+-- accepted: an installation that ARCHIVED a previous tenant rather than
+-- deleting its rows keeps those rows, visible once the policies drop. That was
+-- a statement about visibility, and it was true.
+--
+-- Dropping the column is a different act. After it, an archived tenant's person
+-- is not a visible foreign row — it is indistinguishable from one of ours. It
+-- lists, searches, exports, and ages out under our retention policy as if it
+-- had always been ours. And it is one-way: the reverse migrations restore the
+-- COLUMN, but they backfill every row to the live workspace, because by then
+-- nothing remains to reconstruct the original from.
+--
+-- So the operator decides, before the record tables lose theirs. Delete that
+-- data, or export it, or accept it by deleting the archived workspace rows —
+-- each is a deliberate act, and none of them is one a migration should perform
+-- on somebody's behalf.
+--
+-- WHAT THIS DOES NOT COVER, stated because the gap is real: thirteen modules
+-- already dropped their column before this gate existed (signals, collections,
+-- quotas, customfields, finance, comms, consent, approvals, automation, voice,
+-- webhooks, agents, privacy). Their rows merged silently. They are
+-- configuration and machinery rather than records, which is why the stakes were
+-- low, but "low" is not "none" and a reader should not have to infer it from
+-- migration numbers.
+--
+-- The append-only ledgers are exempt BY NAME rather than by accident. audit_log
+-- and system_log carry an immutability trigger that forbids DELETE, so an
+-- installation could not clear residue there even if it wanted to; demanding it
+-- would be demanding the impossible. Their attribution is history, not records,
+-- and it goes with the ledger's own column at the end of phase D.
+DO $$
+DECLARE
+  offending text;
+  found     text := '';
+  n         bigint;
+BEGIN
+  -- Derived from the catalog rather than listed: a table that still carries the
+  -- column is exactly a table this gate is about, and a hand-kept list would go
+  -- stale in the direction that matters — silently missing one.
+  FOR offending IN
+    SELECT c.relname
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    JOIN pg_attribute a ON a.attrelid = c.oid
+    WHERE n.nspname = 'public'
+      AND c.relkind = 'r'
+      AND a.attname = 'workspace_id'
+      AND a.attnum > 0 AND NOT a.attisdropped
+      AND c.relname NOT IN ('audit_log', 'system_log')
+    ORDER BY c.relname
+  LOOP
+    EXECUTE format(
+      'SELECT count(*) FROM %I t JOIN workspace w ON w.id = t.workspace_id WHERE w.archived_at IS NOT NULL',
+      offending) INTO n;
+    IF n > 0 THEN
+      found := found || format('%s (%s rows), ', offending, n);
+    END IF;
+  END LOOP;
+
+  IF found <> '' THEN
+    RAISE EXCEPTION 'refusing to continue: an archived workspace still holds rows in %',
+      rtrim(found, ', ')
+      USING HINT =
+        'ADR-0091 phase D drops workspace_id from these tables, after which those rows are '
+        'indistinguishable from this installation''s own — they will list, search, export and '
+        'age out as if they had always been yours, and no rollback can separate them again. '
+        'Decide first: delete the archived tenants'' rows, export them, or delete the archived '
+        'workspace rows to accept the merge. Then run this migration again.';
+  END IF;
+END $$;


### PR DESCRIPTION
The decision you took on the archived-tenant question, built.

## What this is for

**Phase D does something 0217 did not, and nothing had said so out loud.** 0217 refused more than one *live* workspace and then named the residue it accepted: an installation that **archived** a previous tenant keeps those rows, visible once the policies drop. That was a statement about **visibility**, and it was true.

Dropping the column is a different act. After it, an archived tenant's person is not a visible foreign row — it is **indistinguishable from one of ours**, and lists, searches, exports and ages out under our retention policy as if it always had been. It is also **one-way**: the reverse migrations restore the *column* but backfill every row to the live workspace, because by then nothing remains to reconstruct the original from.

So the operator decides before the record tables lose theirs. The gate names the tables and counts and offers the three things they may do about it — deleting somebody's data on their behalf is not something a migration should do unasked.

## Two design choices worth reviewing

**It derives its list from `pg_catalog`** rather than naming tables, so it has less to check as phase D proceeds and never less truth to tell. A hand-kept list would go stale in the direction that matters — silently missing one.

**The append-only ledgers are exempt BY NAME.** `audit_log` and `system_log` carry an immutability trigger that forbids DELETE, so an installation could not clear residue there even if it wanted to; demanding it would demand the impossible. Their attribution is history rather than records, and it goes with `audit_log`'s own column at the end of phase D.

## Why three tests for a migration that does nothing

A gate spends its whole life inert — every installation this ships to has no archived residue, so **one that stopped refusing would look exactly like one with nothing to refuse.** The tests are the only thing that can tell those apart:

1. it refuses, and **names what it found** (an operator meets this in a deploy log);
2. it **admits once the residue is cleared** — "decide, then run it again" is a lie if the second run refuses too;
3. it does **not** refuse over a ledger row nobody can delete.

They re-run the shipped SQL rather than a paraphrase. That is the pattern this repo retired for the 0148/0149 repairs, and the difference is stated in the suite: those named columns, so a later schema change made the replay a question production never asks; this one reads the catalog, so it is schema-agnostic by construction.

## Also recorded

STATUS names the **thirteen modules that merged before this gate existed** — configuration and machinery rather than records, which is why the stakes were low, but low is not none and a reader should not have to infer it from migration numbers.

`make check-backend` green; `make test-integration` OK, 0 skips, 40 packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refuses phase D when any archived workspace still owns rows in tables that still carry `workspace_id`, preventing silent and irreversible merging of archived-tenant data after column drops. Previously, dropping the column made archived-tenant rows indistinguishable from the live workspace; now the migration halts and names offending tables and counts, with ledgers exempt.

- Reads `pg_catalog` to find applicable tables and excludes `audit_log` and `system_log`.
- The up migration raises an exception listing tables and row counts; the down migration is a no-op.
- Integration tests replay the shipped SQL and assert: refusal with table names and counts, admission after cleanup, and exemptions for both ledgers.
- `STATUS.md` notes thirteen modules that had already dropped the column and merged before this gate existed.

**Operator actions**
- Before proceeding past 0272, choose: delete archived-tenant rows; export them; or delete archived `workspace` rows to accept the merge. Then run the migration again.

<sup>Written for commit 18d23a72ef7d66b7e496b7d07fd6f21d273fbf4d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1475?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented workspace cleanup migrations from proceeding when archived workspace records remain.
  * Migration errors now identify affected tables and row counts, with remediation guidance.
  * Append-only audit and system logs are preserved and excluded from the cleanup check.

* **Documentation**
  * Documented the archived-data safeguard and operational remediation options.

* **Tests**
  * Added coverage for blocked migrations, successful cleanup after residue removal, and ledger exemptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->