### PR TITLE
fix(storekit): a spliced custom column numbers itself, instead of being counted

### DIFF
--- a/backend/internal/compose/integration/customfields_values_deal_integration_test.go
+++ b/backend/internal/compose/integration/customfields_values_deal_integration_test.go
@@ -5,11 +5,20 @@
 
 package integration
 
-// The deal half of the custom-field VALUES coverage (CF-T05, arc 2a-ii
-// T3): the same fieldcatalog seam wired into the deals store — active
-// cf_* deal columns ride create/update writes and get/list reads like
+// The deals-store half of the custom-field VALUES coverage (CF-T05, arc
+// 2a-ii T3): the same fieldcatalog seam wired into the deals store —
+// active cf_* columns ride create/update writes and get/list reads like
 // core fields, with the same drop-on-mismatch and workspace-isolation
 // posture the person/organization suites prove.
+//
+// BOTH records this store writes are covered here, deal and project, and
+// the second one is why the pairing matters. Person, organization, lead
+// and deal each had a create-with-a-custom-field case; project had none,
+// and project was the one whose INSERT numbered its first custom
+// placeholder over its own last fixed bind — so every CreateProject
+// carrying a custom-field value failed on a bind-count mismatch, and
+// nothing said so. A record whose writer splices custom columns is not
+// covered until something creates it WITH one.
 
 import (
 	"context"
@@ -23,14 +32,17 @@ import (
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
 
-// dealCFVPerms adds the deal + pipeline grants the deal round trip needs
-// on top of the catalog-admin posture.
+// dealCFVPerms adds the grants the two round trips need on top of the
+// catalog-admin posture: deal + pipeline for the deal, and project +
+// organization for the project, which is always hung off a company.
 var dealCFVPerms = principal.Permissions{
 	RoleKeys: []string{"admin"},
 	Objects: map[string]principal.ObjectGrant{
 		"custom_field":          {Create: true, Read: true, Update: true, Delete: true},
 		"deal":                  {Create: true, Read: true, Update: true, Delete: true},
 		"pipeline":              {Create: true, Read: true, Update: true, Delete: true},
+		"project":               {Create: true, Read: true, Update: true, Delete: true},
+		"organization":          {Create: true, Read: true, Update: true, Delete: true},
 		"installation_settings": {Read: true},
 	},
 	RowScope: principal.RowScopeAll,
@@ -112,6 +124,41 @@ func TestCustomFieldValues_DealRoundTrip(t *testing.T) {
 		t.Fatalf("ListDeals returned %d rows, want 1", len(list))
 	}
 	assertCF(t, list[0].AdditionalProperties, col, "mid-market")
+}
+
+// The project round trip, and the case the deal one above could not stand
+// in for: the two records share a store and a seam but not a statement, and
+// it was project's statement that mis-numbered its first custom placeholder.
+// Create is the assertion that matters — the write itself used to fail — and
+// the read-back is what proves the value reached its own column rather than a
+// bind that happened to accept it.
+func TestCustomFieldValues_ProjectRoundTrip(t *testing.T) {
+	f := setupDealCFV(t)
+	col := f.defineDealField(t, customfields.FieldSpec{Object: "project", Label: "Engagement Model", Type: customfields.TypeText, Source: "ui"})
+	org := f.e.SeedOrg(t, "Northwind", nil)
+
+	created, err := f.store.CreateProject(f.ctx, deals.CreateProjectInput{
+		Name: "Rollout", OrganizationID: orgIDOf(org), Source: "ui",
+		CustomFields: map[string]any{col: "retainer"},
+	})
+	if err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+	assertCF(t, created.AdditionalProperties, col, "retainer")
+
+	got, err := f.store.GetProject(f.ctx, projectIDOf(ids.UUID(created.Id)), storekit.LiveOnly)
+	if err != nil {
+		t.Fatalf("GetProject: %v", err)
+	}
+	assertCF(t, got.AdditionalProperties, col, "retainer")
+
+	updated, err := f.store.UpdateProject(f.ctx, projectIDOf(ids.UUID(created.Id)), deals.UpdateProjectInput{
+		CustomFields: map[string]any{col: "fixed-price"},
+	})
+	if err != nil {
+		t.Fatalf("UpdateProject: %v", err)
+	}
+	assertCF(t, updated.AdditionalProperties, col, "fixed-price")
 }
 
 // dealIDOf mirrors PersonIDOf/orgIDOf for the deal suites.

--- a/backend/internal/modules/deals/deal_create.go
+++ b/backend/internal/modules/deals/deal_create.go
@@ -155,16 +155,15 @@ func (s *Store) createDealInTx(ctx context.Context, tx pgx.Tx, in CreateDealInpu
 	}
 
 	id := ids.New[ids.DealKind]()
-	cfCols, cfHolders, cfArgs := storekit.InsertFragments(active, in.CustomFields, 14)
-	args := []any{
+	cfCols, cfHolders, args := storekit.InsertFragments(active, in.CustomFields, []any{
 		id, wsID, in.Name, in.AmountMinor, in.Currency, in.PipelineID, in.StageID,
 		in.OrganizationID, in.ProjectID, in.OwnerID, in.ExpectedClose, in.Source, by,
-	}
+	})
 	_, err := tx.Exec(ctx,
 		`INSERT INTO deal (id, workspace_id, name, amount_minor, currency, pipeline_id, stage_id,
 		                   organization_id, project_id, owner_id, expected_close_date, source, captured_by`+cfCols+`)
 		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13`+cfHolders+`)`,
-		append(args, cfArgs...)...)
+		args...)
 	if err != nil {
 		// Covers the remaining FKs (pipeline, owner); the stage/pipeline
 		// pairing and the organization target were pre-checked above.

--- a/backend/internal/modules/deals/project.go
+++ b/backend/internal/modules/deals/project.go
@@ -105,16 +105,15 @@ func createProjectTx(ctx context.Context, tx pgx.Tx, in CreateProjectInput, by s
 	}
 
 	id := ids.New[ids.ProjectKind]()
-	cfCols, cfHolders, cfArgs := storekit.InsertFragments(active, in.CustomFields, 11)
-	args := []any{
+	cfCols, cfHolders, args := storekit.InsertFragments(active, in.CustomFields, []any{
 		id, wsID, in.Name, in.Key, in.OrganizationID, in.OwnerID,
 		in.Description, in.StartedAt, in.TargetEndDate, in.Source, by,
-	}
+	})
 	_, err := tx.Exec(ctx,
 		`INSERT INTO project (id, workspace_id, name, key, organization_id, owner_id,
 		                      description, started_at, target_end_date, source, captured_by`+cfCols+`)
 		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11`+cfHolders+`)`,
-		append(args, cfArgs...)...)
+		args...)
 	if err != nil {
 		if conflict := projectKeyConflict(err, in.Key); conflict != nil {
 			return crmcontracts.Project{}, conflict

--- a/backend/internal/modules/people/lead.go
+++ b/backend/internal/modules/people/lead.go
@@ -163,16 +163,15 @@ func insertLeadRow(ctx context.Context, tx pgx.Tx, in CreateLeadInput, active []
 	// The initial score is the §3 fit component — a fresh lead has no
 	// behavioral history yet; signal recompute moves it later.
 	fit := ScoreLeadDetail(deref(in.Title), in.Source, nil, time.Now().UTC())
-	cfCols, cfHolders, cfArgs := storekit.InsertFragments(active, in.CustomFields, 17)
-	args := []any{
+	cfCols, cfHolders, args := storekit.InsertFragments(active, in.CustomFields, []any{
 		id, workspaceID(ctx), in.FullName, in.Email, in.Title, in.CompanyName, in.CandidateOrgKey,
 		in.LinkedInURL, in.Status, fit.Score, in.OwnerID, in.ProjectID, in.SourceSystem, in.SourceID, in.Source, by,
-	}
+	})
 	_, err := tx.Exec(ctx,
 		`INSERT INTO lead (id, workspace_id, full_name, email, title, company_name, candidate_org_key,
 		                   linkedin_url, status, score, owner_id, project_id, source_system, source_id, source, captured_by`+cfCols+`)
 		 VALUES ($1, $2, $3, lower($4), $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16`+cfHolders+`)`,
-		append(args, cfArgs...)...)
+		args...)
 	if err != nil {
 		// Race behind the pre-checks: the constraint name tells an
 		// email dedupe hit from a concurrent same-source import — the

--- a/backend/internal/modules/people/resolvecreate.go
+++ b/backend/internal/modules/people/resolvecreate.go
@@ -106,12 +106,11 @@ func createPerson(ctx context.Context, tx pgx.Tx, match PersonResolution, spec P
 	wsID := workspaceID(ctx)
 	id := ids.New[ids.PersonKind]()
 	addr := addressColumns(spec.Address)
-	cfCols, cfHolders, cfArgs := storekit.InsertFragments(spec.Active, spec.CustomFields, 19)
-	args := []any{
+	cfCols, cfHolders, args := storekit.InsertFragments(spec.Active, spec.CustomFields, []any{
 		id, wsID, spec.FullName, spec.FirstName, spec.LastName, spec.Title, spec.OwnerID,
 		addr.Line1, addr.Line2, addr.City, addr.Region, addr.PostalCode, addr.Country,
 		spec.Source, spec.CapturedBy, spec.Visibility, spec.Quarantined, spec.ConvertedFromLeadID,
-	}
+	})
 	if _, err := tx.Exec(ctx,
 		`INSERT INTO person (id, workspace_id, full_name, first_name, last_name, title, owner_id,
 		                     address_line1, address_line2, address_city, address_region, address_postal_code, address_country,
@@ -119,7 +118,7 @@ func createPerson(ctx context.Context, tx pgx.Tx, match PersonResolution, spec P
 		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15,
 		         coalesce(NULLIF($16, ''), 'workspace'),
 		         CASE WHEN $17 THEN now() ELSE NULL END, $18`+cfHolders+`)`,
-		append(args, cfArgs...)...); err != nil {
+		args...); err != nil {
 		return ids.PersonID{}, fmt.Errorf("insert person: %w", err)
 	}
 	if err := replacePersonSocial(ctx, tx, wsID, id, spec.Social); err != nil {
@@ -232,12 +231,11 @@ func createOrganization(ctx context.Context, tx pgx.Tx, match OrganizationMatch,
 	wsID := workspaceID(ctx)
 	id := ids.New[ids.OrganizationKind]()
 	addr := addressColumns(spec.Address)
-	cfCols, cfHolders, cfArgs := storekit.InsertFragments(spec.Active, spec.CustomFields, 21)
-	args := []any{
+	cfCols, cfHolders, args := storekit.InsertFragments(spec.Active, spec.CustomFields, []any{
 		id, wsID, spec.DisplayName, spec.LegalName, spec.Description, spec.Industry, spec.SizeBand, spec.OwnerID, spec.ParentOrgID,
 		addr.Line1, addr.Line2, addr.City, addr.Region, addr.PostalCode, addr.Country,
 		spec.Source, spec.CapturedBy, spec.NameSource, spec.Visibility, spec.IsAnchor,
-	}
+	})
 	if _, err := tx.Exec(ctx,
 		`INSERT INTO organization (id, workspace_id, display_name, legal_name, description, industry, size_band, owner_id, parent_org_id,
 		                           address_line1, address_line2, address_city, address_region, address_postal_code, address_country,
@@ -245,7 +243,7 @@ func createOrganization(ctx context.Context, tx pgx.Tx, match OrganizationMatch,
 		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17,
 		         coalesce(NULLIF($18, ''), 'human'),
 		         coalesce(NULLIF($19, ''), 'workspace'), $20`+cfHolders+`)`,
-		append(args, cfArgs...)...); err != nil {
+		args...); err != nil {
 		return ids.OrganizationID{}, fmt.Errorf("insert organization: %w", err)
 	}
 	if err := insertOrgDomains(ctx, tx, wsID, id, spec.Source, spec.CapturedBy, spec.Domains); err != nil {

--- a/backend/internal/platform/database/storekit/customcolumns.go
+++ b/backend/internal/platform/database/storekit/customcolumns.go
@@ -66,15 +66,25 @@ func SelectSuffix(active []fieldcatalog.Column) string {
 
 // InsertFragments returns the comma-prefixed quoted-column and $N
 // placeholder fragments a literal INSERT statement splices in after its
-// fixed columns/placeholders, plus the bind args — one fragment pair per
-// active custom column present (with a type-matching value) in rawExtra.
-// nextParam is the first free bind-parameter index. A key with no
-// active-column match, or whose value shape does not match the column
-// type, is silently dropped (see the package doc's drop-on-mismatch
-// note). Empty strings when nothing matches, so the caller splices
-// unconditionally. Shared by person/organization/deal Create.
-func InsertFragments(active []fieldcatalog.Column, rawExtra map[string]any, nextParam int) (cols, placeholders string, args []any) {
+// fixed columns/placeholders, plus the complete bind-arg list — one
+// fragment pair per active custom column present (with a type-matching
+// value) in rawExtra. A key with no active-column match, or whose value
+// shape does not match the column type, is silently dropped (see the
+// package doc's drop-on-mismatch note). Empty strings when nothing
+// matches, so the caller splices unconditionally. Shared by
+// person/organization/lead/deal/project Create.
+//
+// It takes the statement's FIXED args rather than the index to number
+// from, and hands back the whole list, because the index is derivable
+// and hand-counting it is not safe. Every caller used to pass a literal
+// — 14, 17, 19, 21 — that had to equal the count of its own base binds,
+// with nothing checking the two agreed; `project` passed 11 where its
+// eleven fixed binds needed 12, so the first custom placeholder aliased
+// `captured_by` and every CreateProject carrying a custom-field value
+// failed on a bind-count mismatch. There is no number to get wrong now.
+func InsertFragments(active []fieldcatalog.Column, rawExtra map[string]any, base []any) (cols, placeholders string, args []any) {
 	var names, holders []string
+	custom := make([]any, 0, len(active))
 	for _, c := range active {
 		v, present := rawExtra[c.Name]
 		if !present {
@@ -85,12 +95,17 @@ func InsertFragments(active []fieldcatalog.Column, rawExtra map[string]any, next
 			continue
 		}
 		names = append(names, quoteColumnIdentifier(c.Name))
-		holders = append(holders, "$"+strconv.Itoa(nextParam+len(args)))
-		args = append(args, sv)
+		holders = append(holders, "$"+strconv.Itoa(len(base)+1+len(custom)))
+		custom = append(custom, sv)
 	}
 	if len(names) == 0 {
-		return "", "", nil
+		return "", "", base
 	}
+	// A fresh slice rather than append(base, ...): appending into a base
+	// with spare capacity would write through to the caller's own array,
+	// and every caller here holds that array for the Exec that follows.
+	args = make([]any, 0, len(base)+len(custom))
+	args = append(append(args, base...), custom...)
 	return ", " + strings.Join(names, ", "), ", " + strings.Join(holders, ", "), args
 }
 

--- a/backend/internal/platform/database/storekit/customcolumns_test.go
+++ b/backend/internal/platform/database/storekit/customcolumns_test.go
@@ -68,28 +68,55 @@ func TestInsertFragments(t *testing.T) {
 		"cf_unknown": "dropped: no matching active column",
 		"cf_score":   "not-a-number", // present but wrong shape: dropped
 	}
-	cols, placeholders, args := InsertFragments(active, rawExtra, 3)
+	base := []any{"ws", "id"}
+	cols, placeholders, args := InsertFragments(active, rawExtra, base)
 	if want := `, "cf_amount", "cf_notes"`; cols != want {
 		t.Fatalf("cols = %q, want %q", cols, want)
 	}
+	// The first custom placeholder is the one AFTER the last fixed bind. A
+	// statement with two fixed binds numbers its first custom column $3 —
+	// $2 would alias the caller's own last argument, which is the shape of
+	// the CreateProject defect this signature exists to make unreachable.
 	if want := ", $3, $4"; placeholders != want {
 		t.Fatalf("placeholders = %q, want %q", placeholders, want)
 	}
-	wantArgs := []any{int64(1250), "hello"}
+	wantArgs := []any{"ws", "id", int64(1250), "hello"}
 	if !reflect.DeepEqual(args, wantArgs) {
 		t.Fatalf("args = %v, want %v", args, wantArgs)
 	}
 }
 
+// The returned list is the caller's to hand straight to Exec, so it must not
+// share an array with the base it was built from — a base with spare capacity
+// would otherwise be written through while the caller still holds it.
+func TestInsertFragmentsLeavesTheCallersBaseArgsAlone(t *testing.T) {
+	active := []fieldcatalog.Column{col("cf_notes", fieldcatalog.TypeText)}
+	base := make([]any, 2, 8)
+	base[0], base[1] = "ws", "id"
+
+	_, _, args := InsertFragments(active, map[string]any{"cf_notes": "hello"}, base)
+
+	if len(base) != 2 || base[0] != "ws" || base[1] != "id" {
+		t.Fatalf("base was mutated: %v", base)
+	}
+	if want := []any{"ws", "id", "hello"}; !reflect.DeepEqual(args, want) {
+		t.Fatalf("args = %v, want %v", args, want)
+	}
+}
+
 func TestInsertFragments_EmptyWhenNoActiveColumnsOrNoMatches(t *testing.T) {
-	cols, placeholders, args := InsertFragments(nil, map[string]any{"cf_x": "y"}, 1)
-	if cols != "" || placeholders != "" || args != nil {
-		t.Fatalf("no active columns must yield empty fragments, got %q %q %v", cols, placeholders, args)
+	// Nothing to splice still answers the caller's own args, so the Exec that
+	// follows is written one way whether or not the workspace has custom
+	// fields — a nil here would drop every fixed bind on an install with none.
+	base := []any{"ws"}
+	cols, placeholders, args := InsertFragments(nil, map[string]any{"cf_x": "y"}, base)
+	if cols != "" || placeholders != "" || !reflect.DeepEqual(args, base) {
+		t.Fatalf("no active columns must yield empty fragments and the base args, got %q %q %v", cols, placeholders, args)
 	}
 	active := []fieldcatalog.Column{col("cf_missing", fieldcatalog.TypeText)}
-	cols, placeholders, args = InsertFragments(active, map[string]any{}, 1)
-	if cols != "" || placeholders != "" || args != nil {
-		t.Fatalf("a rawExtra with no matching key must yield empty fragments, got %q %q %v", cols, placeholders, args)
+	cols, placeholders, args = InsertFragments(active, map[string]any{}, base)
+	if cols != "" || placeholders != "" || !reflect.DeepEqual(args, base) {
+		t.Fatalf("a rawExtra with no matching key must yield empty fragments and the base args, got %q %q %v", cols, placeholders, args)
 	}
 }
 


### PR DESCRIPTION
Closes #1279.

`createProjectTx` passed `11` to `storekit.InsertFragments` where its eleven fixed binds needed `12`, so the first custom-field placeholder came out as `$11` again — aliasing `captured_by` — and every `CreateProject` carrying a custom-field value failed with `mismatched param and argument count`.

### Passing 12 is not the fix

Four other statements pass `14`, `17`, `19` and `21`. Each of those literals has to equal the count of its own base binds, and **nothing checks that the two agree** — `project` was simply the one that had drifted. All four happen to be right today; that is a property of nobody having edited them recently, not of anything holding them.

So `InsertFragments` no longer takes an index. It takes the statement's fixed args and answers the complete bind list:

```go
cfCols, cfHolders, args := storekit.InsertFragments(active, in.CustomFields, []any{
    id, wsID, in.Name, in.Key, /* … */, by,
})
```

The first custom placeholder is `len(base)+1` by construction. There is no number left to get wrong, at any of the five call sites or the sixth.

One detail worth a look: the returned list is a **fresh slice**, not an `append` onto the caller's own. Appending into a base with spare capacity would write through to an array every caller still holds for the `Exec` that follows. `TestInsertFragmentsLeavesTheCallersBaseArgsAlone` pins it with a deliberately over-capacity base.

### Why only project was broken

This is the half that mattered more. Person, organization, lead and deal each **already had** a create-with-a-custom-field integration case. Project had none — so nothing ever executed the statement that was wrong.

The project round trip now sits beside the deal one, in the file that owns the catalogue-wired deals store (both records come out of the same store and the same seam, but not the same statement — and it was project's statement that mis-numbered). That file's header now says outright: a record whose writer splices custom columns is not covered until something creates it **with** one.

### Proof

Mutation-checked rather than merely passing. Reintroducing the off-by-one fails the new test with the exact error the issue reported:

```
customfields_values_deal_integration_test.go:145: CreateProject: insert project: mismatched param and argument count
--- FAIL: TestCustomFieldValues_ProjectRoundTrip (2.44s)
```

`make check-backend` green; `make test-it DIR=backend/internal/compose/integration RUN='TestCustomFieldValues_(Project|Deal)RoundTrip'` green on a real Postgres clone.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes mis-numbered bind parameters for custom-field inserts by changing `storekit.InsertFragments` to derive placeholder indexes from the provided base args and return the complete bind list. Previously, callers passed a literal start index; `project` passed 11, so the first custom placeholder aliased `captured_by`, causing CreateProject with custom fields to fail.

- `storekit.InsertFragments` now takes `(active, raw, base []any)` and returns `(cols, holders, args)` where `$N` starts at `len(base)+1`. It returns a fresh `args` slice to avoid mutating caller-owned arrays and returns the base unchanged when no custom fields match.
- All create paths updated to the new API and to pass `args` directly to `Exec`: `deals` (`deal_create.go`, `project.go`), `people` (`lead.go`, `resolvecreate.go`).
- Tests: added a project custom-field round trip in the deals-store integration suite; added a unit test pinning non-mutation of base args and correct numbering.

<sup>Written for commit adfef140a95112f0447cd04291895c84e1ca639b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1476?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when creating deals, projects, people, and organizations with custom-field values.
  * Preserved existing field values and SQL parameters during records with or without custom fields.

* **Tests**
  * Added coverage validating project custom-field values can be created, read, updated, and round-tripped successfully.
  * Expanded validation for custom-field handling and parameter preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->