### PR TITLE
fix(collections): an unfilterable custom column costs itself, not its whole record type

### DIFF
--- a/backend/internal/modules/collections/vocab.go
+++ b/backend/internal/modules/collections/vocab.go
@@ -225,13 +225,13 @@ var customFieldTypes = map[string]storekit.FieldType{
 // false for a catalog type this engine has no operators for.
 //
 // LEFT OUT rather than refused, and the difference is the blast radius. This
-// mapping runs over EVERY column of the object, so a single unmappable one
-// used to fail the whole resolution: list-create validation, membership
-// evaluation and filtered export all answered 500 for that record type,
-// whatever the filter actually named. Omitting contains the damage to the one
-// field, which is the same call `search`'s vocabulary makes next door on its
-// own stated grounds — an unasked field is a smaller failure than one that
-// answers the wrong comparison.
+// mapping runs over EVERY column of the object, so a refusal here costs the
+// whole resolution — list-create validation, membership evaluation and
+// filtered export all fail for that record type, including for filters that
+// never name the field. Omitting contains the damage to the one field, which
+// is the same call `search`'s vocabulary makes next door on its own stated
+// grounds — an unasked field is a smaller failure than one that answers the
+// wrong comparison.
 //
 // Omission does not hide anything either, because a field the vocabulary does
 // not carry is not silently dropped from a predicate: CompilePredicate refuses

--- a/backend/internal/modules/collections/vocab.go
+++ b/backend/internal/modules/collections/vocab.go
@@ -199,40 +199,55 @@ func (s *Store) SegmentEngine(ctx context.Context, resource string) (storekit.Qu
 		if _, coreOwns := core.Fields[column.Name]; coreOwns {
 			continue
 		}
-		field, err := customField(column)
-		if err != nil {
-			return storekit.Query{}, false, err
+		field, ok := customField(column)
+		if !ok {
+			continue
 		}
 		merged.Fields[column.Name] = field
 	}
 	return merged, true, nil
 }
 
-// customField types one custom column for the predicate engine. The six catalog
-// types and the six filter types are the same closed set spelled in two packages,
-// so the mapping is total — and an unrecognised value fails rather than defaulting
-// to text, which would admit `contains` on a number and read as a working filter.
-func customField(column fieldcatalog.Column) (storekit.Field, error) {
-	var fieldType storekit.FieldType
-	switch column.Type {
-	case fieldcatalog.TypeText:
-		fieldType = storekit.FieldText
-	case fieldcatalog.TypeNumber:
-		fieldType = storekit.FieldNumber
-	case fieldcatalog.TypeDate:
-		fieldType = storekit.FieldDate
-	case fieldcatalog.TypeCurrency:
-		fieldType = storekit.FieldCurrency
-	case fieldcatalog.TypePicklist:
-		fieldType = storekit.FieldPicklist
-	case fieldcatalog.TypeBoolean:
-		fieldType = storekit.FieldBoolean
-	default:
-		return storekit.Field{}, fmt.Errorf(
-			"custom column %s carries type %q, which the filter engine has no operators for",
-			column.Name, column.Type)
+// customFieldTypes maps the six closed catalog types onto the predicate
+// engine's own. Both sets are closed and neither is this file's to extend: a
+// seventh catalog type arrives with its own entry here, and
+// TestEveryCustomFieldTypeIsFilterable fails until it has one.
+var customFieldTypes = map[string]storekit.FieldType{
+	fieldcatalog.TypeText:     storekit.FieldText,
+	fieldcatalog.TypeNumber:   storekit.FieldNumber,
+	fieldcatalog.TypeDate:     storekit.FieldDate,
+	fieldcatalog.TypeCurrency: storekit.FieldCurrency,
+	fieldcatalog.TypePicklist: storekit.FieldPicklist,
+	fieldcatalog.TypeBoolean:  storekit.FieldBoolean,
+}
+
+// customField types one custom column for the predicate engine, and answers
+// false for a catalog type this engine has no operators for.
+//
+// LEFT OUT rather than refused, and the difference is the blast radius. This
+// mapping runs over EVERY column of the object, so a single unmappable one
+// used to fail the whole resolution: list-create validation, membership
+// evaluation and filtered export all answered 500 for that record type,
+// whatever the filter actually named. Omitting contains the damage to the one
+// field, which is the same call `search`'s vocabulary makes next door on its
+// own stated grounds — an unasked field is a smaller failure than one that
+// answers the wrong comparison.
+//
+// Omission does not hide anything either, because a field the vocabulary does
+// not carry is not silently dropped from a predicate: CompilePredicate refuses
+// an unknown name with CodeFilterFieldNotAllowed, so a saved segment that
+// actually NAMES such a field says "not filterable on this resource" rather
+// than quietly matching a different set of rows. What omission must never
+// become is a guess — defaulting an unknown type to text would admit
+// `contains` on a number and read as a working filter — which is why the
+// mapping is a closed map with a gate over it rather than a switch with a
+// fallback.
+func customField(column fieldcatalog.Column) (storekit.Field, bool) {
+	fieldType, ok := customFieldTypes[column.Type]
+	if !ok {
+		return storekit.Field{}, false
 	}
-	return storekit.Field{Expr: `t.` + pgx.Identifier{column.Name}.Sanitize(), Type: fieldType}, nil
+	return storekit.Field{Expr: `t.` + pgx.Identifier{column.Name}.Sanitize(), Type: fieldType}, true
 }
 
 // predicateFromDefinition decodes a dynamic list's stored `definition`

--- a/backend/internal/modules/collections/vocab_test.go
+++ b/backend/internal/modules/collections/vocab_test.go
@@ -190,3 +190,89 @@ func TestNoCoreFieldNameCanBeACustomColumnName(t *testing.T) {
 		}
 	}
 }
+
+// Derived from the port's closed set, not from this file's own map: a seventh
+// catalog type fails here rather than shipping as a column nobody can filter
+// on. Mapping alone is not enough — a type that resolved to a FieldType the
+// predicate engine admits no operator for would sit in the vocabulary and
+// refuse every filter written against it — so each mapping is compiled, with
+// `exists`, the one operator every type in the matrix carries.
+func TestEveryCustomFieldTypeIsFilterable(t *testing.T) {
+	for _, declared := range []string{
+		fieldcatalog.TypeText, fieldcatalog.TypeNumber, fieldcatalog.TypeDate,
+		fieldcatalog.TypeCurrency, fieldcatalog.TypePicklist, fieldcatalog.TypeBoolean,
+	} {
+		field, ok := customField(fieldcatalog.Column{Name: "cf_probe", Type: declared})
+		if !ok {
+			t.Errorf("custom-field type %q has no filter type, so a column of that type is unfilterable", declared)
+			continue
+		}
+		_, err := storekit.CompilePredicate(
+			storekit.Predicate{Field: "cf_probe", Op: storekit.OpExists, Value: true},
+			map[string]storekit.Field{"cf_probe": field},
+			func(any) int { return 1 },
+		)
+		if err != nil {
+			t.Errorf("custom-field type %q maps to %q, which admits no filter: %v", declared, field.Type, err)
+		}
+	}
+}
+
+// The whole point of omitting rather than failing: one column this engine has
+// no operators for must cost that column its filter and nothing else. Failing
+// cost the entire resolution, so list validation, membership evaluation and
+// filtered export all answered 500 for the record type — including for lists
+// that never named the field.
+func TestAnUnmappableCustomColumnCostsOnlyItself(t *testing.T) {
+	store := (&Store{}).WithFieldCatalog(stubFilterable{cols: map[string][]fieldcatalog.Column{
+		"person": {
+			{Name: "cf_known", Type: fieldcatalog.TypeText},
+			{Name: "cf_from_the_future", Type: "geo"},
+		},
+	}})
+
+	engine, ok, err := store.SegmentEngine(context.Background(), "person")
+
+	if err != nil || !ok {
+		t.Fatalf("one unmappable column broke the whole resolution: ok=%v err=%v", ok, err)
+	}
+	if _, present := engine.Fields["cf_known"]; !present {
+		t.Error("the mappable sibling column was lost with it")
+	}
+	if _, present := engine.Fields["owner_id"]; !present {
+		t.Error("the core vocabulary was lost with it")
+	}
+	if _, present := engine.Fields["cf_from_the_future"]; present {
+		t.Error("the unmappable column entered the vocabulary, where it can only refuse every operator")
+	}
+}
+
+// Omission is not silence. A predicate that actually NAMES the omitted field is
+// refused by name — so a saved segment on a field that stopped being mappable
+// says so, rather than quietly matching a different set of rows.
+func TestAPredicateOnAnOmittedColumnIsRefusedByName(t *testing.T) {
+	store := (&Store{}).WithFieldCatalog(stubFilterable{cols: map[string][]fieldcatalog.Column{
+		"person": {{Name: "cf_from_the_future", Type: "geo"}},
+	}})
+	engine, _, err := store.SegmentEngine(context.Background(), "person")
+	if err != nil {
+		t.Fatalf("segmentEngine: %v", err)
+	}
+
+	_, err = storekit.CompilePredicate(
+		storekit.Predicate{Field: "cf_from_the_future", Op: storekit.OpEq, Value: "x"},
+		engine.Fields,
+		func(any) int { return 1 },
+	)
+
+	var perr *storekit.PredicateError
+	if !errors.As(err, &perr) {
+		t.Fatalf("err = %v, want a PredicateError naming the field", err)
+	}
+	if perr.Code != storekit.CodeFilterFieldNotAllowed {
+		t.Errorf("code = %q, want %q", perr.Code, storekit.CodeFilterFieldNotAllowed)
+	}
+	if perr.Field != "cf_from_the_future" {
+		t.Errorf("field = %q, want the offending column named", perr.Field)
+	}
+}

--- a/backend/internal/modules/collections/vocab_test.go
+++ b/backend/internal/modules/collections/vocab_test.go
@@ -191,17 +191,16 @@ func TestNoCoreFieldNameCanBeACustomColumnName(t *testing.T) {
 	}
 }
 
-// Derived from the port's closed set, not from this file's own map: a seventh
-// catalog type fails here rather than shipping as a column nobody can filter
-// on. Mapping alone is not enough — a type that resolved to a FieldType the
+// Derived from the port's own closed set, never a copy of it: a list restated
+// here would pass unchanged the day a seventh type is added to fieldcatalog,
+// which is the one moment this test exists to fail.
+//
+// Mapping alone is not enough either — a type that resolved to a FieldType the
 // predicate engine admits no operator for would sit in the vocabulary and
 // refuse every filter written against it — so each mapping is compiled, with
 // `exists`, the one operator every type in the matrix carries.
 func TestEveryCustomFieldTypeIsFilterable(t *testing.T) {
-	for _, declared := range []string{
-		fieldcatalog.TypeText, fieldcatalog.TypeNumber, fieldcatalog.TypeDate,
-		fieldcatalog.TypeCurrency, fieldcatalog.TypePicklist, fieldcatalog.TypeBoolean,
-	} {
+	for _, declared := range fieldcatalog.Types() {
 		field, ok := customField(fieldcatalog.Column{Name: "cf_probe", Type: declared})
 		if !ok {
 			t.Errorf("custom-field type %q has no filter type, so a column of that type is unfilterable", declared)
@@ -219,10 +218,10 @@ func TestEveryCustomFieldTypeIsFilterable(t *testing.T) {
 }
 
 // The whole point of omitting rather than failing: one column this engine has
-// no operators for must cost that column its filter and nothing else. Failing
-// cost the entire resolution, so list validation, membership evaluation and
-// filtered export all answered 500 for the record type — including for lists
-// that never named the field.
+// no operators for costs that column its filter and nothing else. A refusal
+// costs the entire resolution instead — list validation, membership evaluation
+// and filtered export all fail for the record type, including for lists that
+// never name the field.
 func TestAnUnmappableCustomColumnCostsOnlyItself(t *testing.T) {
 	store := (&Store{}).WithFieldCatalog(stubFilterable{cols: map[string][]fieldcatalog.Column{
 		"person": {

--- a/backend/internal/modules/customfields/engine_test.go
+++ b/backend/internal/modules/customfields/engine_test.go
@@ -6,6 +6,8 @@ package customfields
 import (
 	"strings"
 	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/ports/fieldcatalog"
 )
 
 func TestValidate_UnsupportedObjectRejected(t *testing.T) {
@@ -306,6 +308,9 @@ func TestBuildOptionsDDL_LabelInjectionNeverReachesRawSQL(t *testing.T) {
 	}
 }
 
+// The literals, pinned against the migration's CHECK spelling — this module's
+// constants are what the DDL admits, and a typo here is a column the catalog
+// cannot write.
 func TestFieldTypes_MatchesMigrationCheckSpelling(t *testing.T) {
 	want := []string{"text", "number", "date", "currency", "picklist", "boolean"}
 	if len(FieldTypes) != len(want) {
@@ -314,6 +319,24 @@ func TestFieldTypes_MatchesMigrationCheckSpelling(t *testing.T) {
 	for i, w := range want {
 		if FieldTypes[i] != w {
 			t.Errorf("FieldTypes[%d] = %q, want %q", i, FieldTypes[i], w)
+		}
+	}
+}
+
+// This module's set and the port's are the same closed set spelled in two
+// packages — shared may not import modules, so the duplication is structural
+// and cannot be removed. What CAN be held is that they agree: every consumer
+// outside this module derives its own obligation from the port's set, so a type
+// added here and not there is a type the filter and query vocabularies will
+// never be asked about.
+func TestFieldTypes_AgreesWithThePortsClosedSet(t *testing.T) {
+	port := fieldcatalog.Types()
+	if len(port) != len(FieldTypes) {
+		t.Fatalf("fieldcatalog.Types() = %v, this module's FieldTypes = %v", port, FieldTypes)
+	}
+	for i, declared := range FieldTypes {
+		if port[i] != declared {
+			t.Errorf("index %d: port says %q, this module says %q", i, port[i], declared)
 		}
 	}
 }

--- a/backend/internal/modules/search/queryvocab_test.go
+++ b/backend/internal/modules/search/queryvocab_test.go
@@ -298,10 +298,10 @@ func TestEverySearchableEntityHasAContractBinding(t *testing.T) {
 // The six closed custom-field types must each map onto a kind, or a
 // workspace's own column silently vanishes from its vocabulary.
 func TestEveryCustomFieldTypeHasAVocabularyKind(t *testing.T) {
-	for _, declared := range []string{
-		fieldcatalog.TypeText, fieldcatalog.TypeNumber, fieldcatalog.TypeDate,
-		fieldcatalog.TypeCurrency, fieldcatalog.TypePicklist, fieldcatalog.TypeBoolean,
-	} {
+	// The port's own set, not a copy of it: a list restated here would pass
+	// unchanged the day a seventh type is added, which is the one moment this
+	// test exists to fail.
+	for _, declared := range fieldcatalog.Types() {
 		kind, ok := customFieldKinds[declared]
 		if !ok {
 			t.Errorf("custom-field type %q has no vocabulary kind, so a workspace column of that type is unaskable", declared)

--- a/backend/internal/platform/database/storekit/customcolumns_test.go
+++ b/backend/internal/platform/database/storekit/customcolumns_test.go
@@ -206,6 +206,20 @@ func TestSQLValue_RoundTrip(t *testing.T) {
 			scanned: "red", wantWire: "red",
 		},
 	}
+	// The case table is hand-written, so what it covers is derived rather than
+	// trusted: a seventh catalog type with no case here would leave this test
+	// green while SQLValue and extractValue answer ok=false for it — silently
+	// dropping the value on the write AND on the read, which is a worse
+	// outcome than any unfilterable column.
+	covered := make(map[string]bool, len(cases))
+	for _, c := range cases {
+		covered[c.typ] = true
+	}
+	for _, declared := range fieldcatalog.Types() {
+		if !covered[declared] {
+			t.Errorf("custom-field type %q has no round-trip case, so a value of that type could be dropped unnoticed", declared)
+		}
+	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			column := col("cf_x", c.typ)

--- a/backend/internal/shared/ports/fieldcatalog/fieldcatalog.go
+++ b/backend/internal/shared/ports/fieldcatalog/fieldcatalog.go
@@ -36,6 +36,22 @@ const (
 	TypeBoolean  = "boolean"
 )
 
+// Types answers the closed set above, so a consumer that has to handle EVERY
+// field type derives that obligation instead of restating it. A gate written
+// over a hand-copied list of the six passes unchanged the day a seventh is
+// added here, which is the one moment it exists to fail.
+//
+// What such a gate protects is not uniform. Missing the segment or search
+// vocabulary costs a column its filter; missing storekit's conversion matrix
+// costs the VALUE — SQLValue and extractValue drop an unrecognised type on
+// both the write and the read.
+//
+// A fresh slice per call: the alternative is an exported package-level slice,
+// which any consumer can reorder or overwrite for every other consumer.
+func Types() []string {
+	return []string{TypeText, TypeNumber, TypeDate, TypeCurrency, TypePicklist, TypeBoolean}
+}
+
 // Column is one custom-field column for a (workspace, object) pair,
 // identified by its physical column name and its closed field type (one
 // of the Type* constants above). Whether a given Column is active,


### PR DESCRIPTION
Closes #1272.

The segment vocabulary mapped the six catalogue types through a switch that **errored** on anything else. Because that mapping runs over *every* column of the object, one unmappable column failed the whole resolution: list-create validation, membership evaluation and filtered export all answered 500 for that record type, whatever the filter actually named — including for lists that never named the field.

It omits now, which is the call `search`'s own vocabulary already makes next door, on its stated grounds: *an unasked field is a smaller failure than one that answers the wrong comparison.*

### The issue's stated hazard does not exist

Worth reading before the diff, because it changed how the source comment reads. #1272 said omitting means a saved segment on a now-unmappable field *"would silently stop matching rather than erroring."* It would not. A field the vocabulary does not carry is **not** dropped from a predicate — `CompilePredicate` refuses an unknown name outright:

```go
field, ok := fields[p.Field]
if !ok {
    return "", &PredicateError{
        Field: p.Field, Code: CodeFilterFieldNotAllowed,
        Message: fmt.Sprintf("field %q is not filterable on this resource", p.Field),
    }
}
```

So omitting changes only the blast radius, entirely for the better:

| | before | after |
|---|---|---|
| a filter naming the field | 500 | 422, naming the field |
| **every other list, membership read and export for that record type** | **500** | unaffected |

The gate is therefore not what makes omission *safe* — the compiler being loud is. The gate is what stops a seventh type becoming quietly unfilterable, which is a different failure and still worth holding. ([Full correction on the issue.](https://github.com/gradionhq/margince-poc-v1/issues/1272#issuecomment-5309058816))

What must never happen is the third option the original design was actually arguing against: defaulting an unknown type to text, which would admit `contains` on a number and read as a working filter. That is why this is a closed map with a gate over it rather than a switch with a fallback.

### The gate goes one step past the sibling's

It does not merely assert that each of the port's six type constants has an entry — it **compiles** each mapping, with `exists` (the one operator every type in the matrix carries). A type that mapped to a `FieldType` the engine admits no operator for would be in the vocabulary and unusable, and a presence check would pass it.

### Proof

Both new guarantees are mutation-checked, not merely passing:

- dropping `fieldcatalog.TypeBoolean` from the map → `custom-field type "boolean" has no filter type, so a column of that type is unfilterable`
- restoring the fail-loudly branch → `one unmappable column broke the whole resolution: ok=false err=unmappable column cf_from_the_future`

`make check-backend` green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents one unmappable custom column from breaking filtering for an entire record type. Before, the segment vocabulary errored on unknown custom field types and returned 500s; now unmappable columns are omitted, so only that field is not filterable and predicates that name it return 422 (`CodeFilterFieldNotAllowed`).

- Replace the switch with a closed `customFieldTypes` map; `customField` returns `(storekit.Field, bool)` and `SegmentEngine` skips unmappable columns.
- Derive the closed type set from `fieldcatalog.Types()` and gate it:
  - In `collections`: compile `exists` for every type to ensure each is actually filterable.
  - In `search`: require a vocabulary kind for every type.
  - In `storekit`: require round-trip coverage for every type to avoid value drops.
  - In `customfields`: assert the module’s set matches the port’s.
- No API or schema changes; no migrations. Behavior change is limited to 422 for predicates that name an omitted field instead of system-wide 500s.

<sup>Written for commit 3c92b634cf72d3e87b6be49c1af794fd2a94f54d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1477?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of unsupported custom field types in segment filtering.
  * Unsupported fields are now omitted without preventing segment resolution or affecting supported fields.
  * Predicates targeting omitted fields now return a clear field-specific error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->