### PR TITLE
feat(seed-demo): surfaces beyond records, FX rates, and paper in every language

### DIFF
--- a/backend/tools/seed-demo/fx.go
+++ b/backend/tools/seed-demo/fx.go
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package main
+
+// The conversion rates a multi-currency pipeline cannot close without.
+//
+// Winning a deal FREEZES its rate to the base currency, so a deal in USD or
+// VND is refused outright until a rate exists:
+//
+//	no fx_rate from USD to EUR to freeze at close — an admin must load the
+//	rate for this currency pair before this close can succeed
+//
+// That refusal is correct — a won number nobody can convert is a forecast
+// nobody can add up — and it is what made this phase necessary the moment the
+// dataset stopped being all-euro. Korean exhibitors bill in USD and the
+// Vietnamese ones in dong.
+//
+// The rates are fixed rather than fetched. A demo that reached out to a rate
+// provider would need a key, a network and a story about what happens when it
+// is down; a demo that states its rates is reproducible and cannot drift.
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// demoFxRates are the rates the seeded currencies convert at, to the euro
+// base. Approximately mid-2026 and deliberately round: these exist so a deal
+// can close and a total can be added up, not so anybody can price a trade.
+var demoFxRates = map[string]string{
+	"USD": "0.92",
+	"VND": "0.000035",
+	"GBP": "1.17",
+	"CHF": "1.05",
+}
+
+// seedFxRates loads a rate for every currency the plan will actually use.
+//
+// It must run BEFORE any deal closes. The rate is frozen at the close, so a
+// missing one is not a warning the seeder can carry past — the advance is
+// refused and the run stops.
+func seedFxRates(c *client, refs pipelineRefs, plan map[string]profile, mode runMode) (int, error) {
+	wanted := map[string]bool{}
+	for _, domain := range sortedDomains(plan) {
+		if currency := currencyFor(localeFor(domain)); currency != "EUR" {
+			wanted[currency] = true
+		}
+	}
+	if len(wanted) == 0 {
+		return 0, nil
+	}
+	if mode == modeDryRun {
+		return len(wanted), nil
+	}
+
+	have, err := fxCurrencies(c)
+	if err != nil {
+		return 0, err
+	}
+	created := 0
+	for currency := range wanted {
+		if have[currency] {
+			continue
+		}
+		rate, ok := demoFxRates[currency]
+		if !ok {
+			return created, fmt.Errorf(
+				"a company bills in %s and no demo rate is defined for it — add one to demoFxRates", currency)
+		}
+		// effective_date defaults to today and may not be in the past, so it
+		// is left off: the rate is live from now, which is when the deals
+		// this run closes are being closed.
+		body := jsonBody{"from_currency": currency, "rate": rate}
+		if err := c.post("/v1/fx-rates", body, nil); err != nil {
+			if _, conflict := conflictingID(err); conflict {
+				continue
+			}
+			return created, fmt.Errorf("setting the %s rate: %w", currency, err)
+		}
+		created++
+	}
+	return created, nil
+}
+
+// fxCurrencies is every currency the installation already holds a rate for.
+func fxCurrencies(c *client) (map[string]bool, error) {
+	out := map[string]bool{}
+	err := c.getAll("/v1/fx-rates", nil, func(raw json.RawMessage) error {
+		var rows []struct {
+			FromCurrency string `json:"from_currency"`
+		}
+		if err := json.Unmarshal(raw, &rows); err != nil {
+			return err
+		}
+		for _, row := range rows {
+			out[row.FromCurrency] = true
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("listing fx rates: %w", err)
+	}
+	return out, nil
+}

--- a/backend/tools/seed-demo/generated.go
+++ b/backend/tools/seed-demo/generated.go
@@ -135,7 +135,24 @@ func generatedAmount(domain string) int64 {
 		maxHundreds = 1800 // 180,000 EUR
 	)
 	hundreds := minHundreds + hashIndex("amount:"+domain, maxHundreds-minHundreds)
-	return int64(hundreds) * 100 * 100 // hundreds of euros, in minor units
+	amount := int64(hundreds) * 100 * 100 // hundreds of euros, in minor units
+
+	// Scaled into the account's own currency, because the figure is READ.
+	// A dong contract carrying a euro-sized number printed "VND 154.800,00"
+	// -- about 1,500 euro, which is not a number any Vietnamese contract
+	// would show, and the rendered PDF is where that became obvious.
+	//
+	// Deliberately round multiples rather than the real FX rate: these are
+	// plausible order sizes, not conversions of one another, and a demo whose
+	// amounts track a rate invites a question nobody wants to answer.
+	switch currencyFor(localeFor(domain)) {
+	case "VND":
+		return amount * 25000 // dong has no minor unit in practice
+	case "USD":
+		return amount // near enough to the euro at this precision
+	default:
+		return amount
+	}
 }
 
 // seedGeneratedLeads files the unqualified names at the top of the funnel for

--- a/backend/tools/seed-demo/locale_test.go
+++ b/backend/tools/seed-demo/locale_test.go
@@ -151,3 +151,39 @@ func TestCurrencyFollowsTheLocale(t *testing.T) {
 		}
 	}
 }
+
+// TestEveryLanguageHasACustomer — the coverage matrix guarantees counts, never
+// WHICH company holds them, and there are two Vietnamese companies among 171.
+// The hash reliably made both a prospect and a target, so the Vietnamese
+// contracts, documents and dong invoices existed in code and in tests and
+// nowhere a demo could reach. That is the same as not having built them.
+func TestEveryLanguageHasACustomer(t *testing.T) {
+	restore := companyLocales
+	t.Cleanup(func() { companyLocales = restore })
+	companyLocales = map[string]docLocale{
+		"vuletech.com": localeVI,
+		"soragroup.vn": localeVI,
+		"micube.co.kr": localeEN,
+		"dacell.com":   localeEN,
+	}
+	domains := append(synthDomains(160),
+		"vuletech.com", "soragroup.vn", "micube.co.kr", "dacell.com")
+	profiles := planProfiles(domains, demoConfig{})
+
+	for _, locale := range []docLocale{localeVI, localeEN} {
+		found := ""
+		for domain, p := range profiles {
+			if localeFor(domain) == locale && p.Lifecycle == "customer" {
+				found = domain
+				break
+			}
+		}
+		if found == "" {
+			t.Errorf("no %q company is a customer — that language's paper exists nowhere a demo can reach", locale)
+			continue
+		}
+		if len(profiles[found].Contracts) == 0 {
+			t.Errorf("%s is the %q customer but holds no contract, so there is no document to show", found, locale)
+		}
+	}
+}

--- a/backend/tools/seed-demo/profile.go
+++ b/backend/tools/seed-demo/profile.go
@@ -145,7 +145,58 @@ func planProfiles(domains []string, cfg demoConfig) map[string]profile {
 
 	// Pass 2: promote companies until the matrix is satisfied.
 	fillCoverage(sorted, pinned, out)
+
+	// Pass 3: make sure the non-German half is actually SHOWN.
+	//
+	// The matrix guarantees counts, never which company holds them, and there
+	// are two Vietnamese companies among 171. The hash reliably made both a
+	// prospect and a target, so the Vietnamese contracts, documents and dong
+	// invoices existed in code and in tests and nowhere a demo could reach —
+	// which is the same as not having built them.
+	ensureLocaleIsVisible(sorted, pinned, out)
 	return out
+}
+
+// ensureLocaleIsVisible promotes one company per non-German language to
+// customer, so every language the seeder can write actually appears on paper.
+//
+// Only ever promotes: a language that already has a customer is left alone,
+// so this is a floor rather than a quota, and it runs after coverage so it
+// cannot pull a cell below its minimum.
+func ensureLocaleIsVisible(domains []string, pinned map[string]string, out map[string]profile) {
+	byLocale := map[docLocale][]string{}
+	hasCustomer := map[docLocale]bool{}
+	for _, domain := range domains {
+		locale := localeFor(domain)
+		if locale == localeDE {
+			continue // the German half is the majority and needs no help
+		}
+		if _, isPinned := pinned[domain]; isPinned {
+			continue
+		}
+		byLocale[locale] = append(byLocale[locale], domain)
+		if out[domain].Lifecycle == "customer" {
+			hasCustomer[locale] = true
+		}
+	}
+	for locale, candidates := range byLocale {
+		if hasCustomer[locale] || len(candidates) == 0 {
+			continue
+		}
+		// Stable choice, so the same company is the showcase on every machine.
+		pick := candidates[hashIndex("localeshowcase:"+string(locale), len(candidates))]
+		p := out[pick]
+		p.Lifecycle = "customer"
+		p.DealStage = "won"
+		p.LeadState = ""
+		if len(p.Contracts) == 0 {
+			p.Contracts = []string{"active"}
+		}
+		if len(p.LooseDocs) == 0 {
+			p.LooseDocs = []string{looseDocTypes[hashIndex("doctype:"+pick, len(looseDocTypes))]}
+		}
+		out[pick] = p
+	}
 }
 
 // baseProfile is one company's profile from weights alone, before coverage.

--- a/backend/tools/seed-demo/seed.go
+++ b/backend/tools/seed-demo/seed.go
@@ -42,6 +42,13 @@ func seedPipeline(c *client, seats *sessions, cfg demoConfig, companies []compan
 	}
 	plan := planProfiles(domains, cfg)
 
+	// FX first: winning a deal freezes its rate, so a non-EUR deal cannot
+	// close until one exists. Korean companies bill in USD and Vietnamese in
+	// dong, so this is load-bearing rather than tidy.
+	fxRates, err := seedFxRates(c, refs, plan, mode)
+	if err != nil {
+		return err
+	}
 	leads, err := seedLeads(c, cfg, refs, mode)
 	if err != nil {
 		return err
@@ -85,6 +92,10 @@ func seedPipeline(c *client, seats *sessions, cfg demoConfig, companies []compan
 	if err != nil {
 		return err
 	}
+	surfaces, err := seedSurfaces(c, seats, cfg, refs, plan, mode)
+	if err != nil {
+		return err
+	}
 	consents, err := seedConsent(c, cfg, companies, refs, mode)
 	if err != nil {
 		return err
@@ -107,7 +118,7 @@ func seedPipeline(c *client, seats *sessions, cfg demoConfig, companies []compan
 		contracts: paper.contracts, generatedContracts: paper.generatedContracts,
 		products: productsNew, offers: offers,
 		documents: paper.documents, looseDocs: paper.looseDocs,
-		consents: consents, lifecycles: lifecycles,
+		consents: consents, lifecycles: lifecycles, surfaces: surfaces, fxRates: fxRates,
 		ownedOrgs: ownedOrgs, ownedPeople: ownedPeople,
 	})
 	return nil
@@ -155,6 +166,7 @@ type pipelineCounts struct {
 	products, offers              int
 	documents, looseDocs          int
 	consents, lifecycles          int
+	surfaces, fxRates             int
 	ownedOrgs, ownedPeople        int
 }
 
@@ -167,6 +179,8 @@ func reportPipeline(n pipelineCounts) {
 	fmt.Printf("products:      %d new\n", n.products)
 	fmt.Printf("offers:        %d new\n", n.offers)
 	fmt.Printf("documents:     %d uploaded (%d contract PDFs, %d account documents)\n", n.documents+n.looseDocs, n.documents, n.looseDocs)
+	fmt.Printf("fx rates:      %d loaded\n", n.fxRates)
+	fmt.Printf("surfaces:      %d new (tags, lists, custom fields, projects, quotas)\n", n.surfaces)
 	fmt.Printf("consent:       %d recorded\n", n.consents)
 	fmt.Printf("lifecycle:     %d changed\n", n.lifecycles)
 	fmt.Printf("owners:        %d organization(s), %d person/people\n", n.ownedOrgs, n.ownedPeople)

--- a/backend/tools/seed-demo/surfaces.go
+++ b/backend/tools/seed-demo/surfaces.go
@@ -1,0 +1,387 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package main
+
+// The surfaces a worked CRM has beyond its records: the tags people filter by,
+// the lists they save, the views each seat keeps, the fields somebody added
+// because the product did not ship one, and the projects delivery runs.
+//
+// These are the screens a demo reaches after the obvious ones. Empty, they
+// teach that the product has no such feature — a Tags page with nothing on it
+// looks identical to a Tags page that does not work.
+//
+// Everything here is workspace-wide rather than per-company, so the phase is
+// small and runs once. What varies per company is which records get tagged,
+// and that comes from the plan like everything else.
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+)
+
+// seedSurfaces creates the collection and customisation records, and returns
+// how many were new.
+func seedSurfaces(c *client, seats *sessions, cfg demoConfig, refs pipelineRefs, plan map[string]profile, mode runMode) (int, error) {
+	created := 0
+	for _, step := range []struct {
+		what string
+		run  func() (int, error)
+	}{
+		{"tags", func() (int, error) { return seedTags(c, refs, plan, mode) }},
+		{"lists", func() (int, error) { return seedLists(c, refs, mode) }},
+		{"projects", func() (int, error) { return seedProjects(c, refs, plan, mode) }},
+		{"quotas", func() (int, error) { return seedQuotas(c, cfg, refs, mode) }},
+	} {
+		n, err := step.run()
+		if err != nil {
+			return created, fmt.Errorf("%s: %w", step.what, err)
+		}
+		created += n
+	}
+	return created, nil
+}
+
+// demoTags are the labels a sales team actually keeps. Each one has to be
+// applied to something: a tag nobody uses is a row, not a demonstration.
+var demoTags = []struct {
+	Name  string
+	Color string
+	// Applies decides which companies carry this tag, from their profile.
+	Applies func(profile) bool
+}{
+	{"Key Account", "#b45309", func(p profile) bool { return p.Lifecycle == "customer" }},
+	{"Churn Risk", "#b91c1c", func(p profile) bool { return p.Lifecycle == "former_customer" }},
+	{"Inbound", "#1d4ed8", func(p profile) bool { return p.LeadState != "" }},
+	// `parked` is not a lifecycle the product carries, so the planner maps it
+	// to `target` and this tag is what preserves the distinction.
+	{"Parked", "#6b7280", func(p profile) bool { return p.Lifecycle == "target" && p.DealStage == "" }},
+}
+
+func seedTags(c *client, refs pipelineRefs, plan map[string]profile, mode runMode) (int, error) {
+	created := 0
+	existing, err := tagsByName(c, mode)
+	if err != nil {
+		return 0, err
+	}
+	for _, tag := range demoTags {
+		id := existing[tag.Name]
+		if id == "" {
+			if mode == modeDryRun {
+				created++
+				continue
+			}
+			var out struct {
+				ID string `json:"id"`
+			}
+			if err := c.post("/v1/tags", jsonBody{"name": tag.Name, "color": tag.Color}, &out); err != nil {
+				if _, conflict := conflictingID(err); !conflict {
+					return created, fmt.Errorf("tag %q: %w", tag.Name, err)
+				}
+			} else {
+				created++
+				id = out.ID
+			}
+		}
+		if id == "" || mode == modeDryRun {
+			continue
+		}
+		// Applying is idempotent server-side, so a re-run re-asserts the same
+		// label rather than duplicating it.
+		for _, domain := range sortedDomains(plan) {
+			if !tag.Applies(plan[domain]) {
+				continue
+			}
+			orgID, ok := refs.orgsByDom[domain]
+			if !ok {
+				continue
+			}
+			body := jsonBody{"entity_type": "organization", "entity_id": orgID}
+			if err := c.post("/v1/tags/"+id+"/apply", body, nil); err != nil && !isConflict(err) {
+				return created, fmt.Errorf("applying %q to %s: %w", tag.Name, domain, err)
+			}
+		}
+	}
+	return created, nil
+}
+
+func tagsByName(c *client, mode runMode) (map[string]string, error) {
+	out := map[string]string{}
+	if mode == modeDryRun {
+		return out, nil
+	}
+	err := c.getAll("/v1/tags", nil, func(raw json.RawMessage) error {
+		var rows []struct {
+			ID   string `json:"id"`
+			Name string `json:"name"`
+		}
+		if err := json.Unmarshal(raw, &rows); err != nil {
+			return err
+		}
+		for _, row := range rows {
+			out[row.Name] = row.ID
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("listing tags: %w", err)
+	}
+	return out, nil
+}
+
+// demoLists are the saved collections a team works from. One static and one
+// dynamic, because they are different features: a static list holds the rows
+// somebody put in it, and a dynamic one re-answers its own question.
+var demoLists = []struct {
+	Name       string
+	EntityType string
+	ListType   string
+	Definition jsonBody
+}{
+	{
+		Name: "Kunden", EntityType: "organization", ListType: "dynamic",
+		// A predicate over the allow-listed organization fields, so the list
+		// answers itself as the lifecycle changes.
+		Definition: jsonBody{"and": []jsonBody{{"field": "lifecycle", "op": "eq", "value": "customer"}}},
+	},
+	{
+		Name: "Abgesprungen", EntityType: "organization", ListType: "dynamic",
+		Definition: jsonBody{"and": []jsonBody{{"field": "lifecycle", "op": "eq", "value": "former_customer"}}},
+	},
+}
+
+func seedLists(c *client, refs pipelineRefs, mode runMode) (int, error) {
+	created := 0
+	existing := map[string]bool{}
+	if mode != modeDryRun {
+		err := c.getAll("/v1/lists", nil, func(raw json.RawMessage) error {
+			var rows []struct {
+				Name string `json:"name"`
+			}
+			if err := json.Unmarshal(raw, &rows); err != nil {
+				return err
+			}
+			for _, row := range rows {
+				existing[row.Name] = true
+			}
+			return nil
+		})
+		if err != nil {
+			return 0, fmt.Errorf("listing lists: %w", err)
+		}
+	}
+	for _, list := range demoLists {
+		if existing[list.Name] {
+			continue
+		}
+		if mode == modeDryRun {
+			created++
+			continue
+		}
+		body := jsonBody{
+			"name": list.Name, "entity_type": list.EntityType,
+			"list_type": list.ListType, "definition": list.Definition,
+		}
+		if err := c.post("/v1/lists", body, nil); err != nil {
+			if _, conflict := conflictingID(err); conflict {
+				continue
+			}
+			return created, fmt.Errorf("list %q: %w", list.Name, err)
+		}
+		created++
+	}
+	return created, nil
+}
+
+// Custom fields are NOT seeded, and cannot be.
+//
+// POST /v1/custom-fields answers 501:
+//
+//	operation custom-field schema changes is specified but not yet implemented
+//
+// The contract describes the add-field engine in full — picklists with
+// options, currency fields, the retire path — and the handler is a stub. So
+// the Settings > Custom fields screen stays empty in the demo, and that is
+// the product's own state rather than a hole in the seeder. The code that
+// would fill it is deleted rather than commented out; this note is the
+// record, and the day the handler lands it is three POSTs to write.
+
+// seedProjects files the delivery work a customer's won deal turned into.
+//
+// A project is born in its first phase and ADVANCED, like a deal: the phase a
+// project is in is the record of what happened to it, not a column you can be
+// created in.
+func seedProjects(c *client, refs pipelineRefs, plan map[string]profile, mode runMode) (int, error) {
+	created := 0
+	existing, err := projectKeys(c, mode)
+	if err != nil {
+		return 0, err
+	}
+	for _, domain := range sortedDomains(plan) {
+		p := plan[domain]
+		if p.Pinned || p.Project == "" {
+			continue
+		}
+		orgID, ok := refs.orgsByDom[domain]
+		if !ok {
+			continue
+		}
+		key := projectKey(domain)
+		if existing[key] {
+			continue
+		}
+		if mode == modeDryRun {
+			created++
+			continue
+		}
+		locale := localeFor(domain)
+		body := jsonBody{
+			"name":            projectNameFor(locale, refs.orgNameByID[orgID]),
+			"key":             key,
+			"organization_id": orgID,
+			"source":          seedSource,
+			"started_at":      refs.date(-(30 + hashIndex("projstart:"+domain, 180))),
+		}
+		if owner, ok := refs.usersByRef[refs.ownerRefByDomain[domain]]; ok {
+			body["owner_id"] = owner
+		}
+		var out struct {
+			ID string `json:"id"`
+		}
+		if err := c.post("/v1/projects", body, &out); err != nil {
+			if _, conflict := conflictingID(err); conflict {
+				continue
+			}
+			return created, fmt.Errorf("project for %s: %w", domain, err)
+		}
+		created++
+		if err := advanceProject(c, out.ID, p.Project, domain); err != nil {
+			return created, err
+		}
+	}
+	return created, nil
+}
+
+// projectPhaseOrder is the sequence a project walks. A phase is reached by
+// stepping through the ones before it, so the history reads as work rather
+// than as an assertion.
+var projectPhaseOrder = []string{"initiative", "pursuing", "delivering", "closed"}
+
+func advanceProject(c *client, projectID, want, domain string) error {
+	for _, phase := range projectPhaseOrder {
+		body := jsonBody{"to_phase": phase}
+		if phase == "closed" {
+			// Closing needs a reason, the same way losing a deal does.
+			body["reason"] = "Abgeschlossen und uebergeben"
+		}
+		if err := c.post("/v1/projects/"+projectID+"/advance", body, nil); err != nil && !isConflict(err) {
+			return fmt.Errorf("advancing %s to %s: %w", domain, phase, err)
+		}
+		if phase == want {
+			return nil
+		}
+	}
+	return nil
+}
+
+func projectKey(domain string) string {
+	return fmt.Sprintf("SEED-%s", shortDomain(domain))
+}
+
+func projectNameFor(locale docLocale, company string) string {
+	switch locale {
+	case localeVI:
+		return company + " — Trien khai"
+	case localeEN:
+		return company + " — Rollout"
+	default:
+		return company + " — Einführung"
+	}
+}
+
+func projectKeys(c *client, mode runMode) (map[string]bool, error) {
+	out := map[string]bool{}
+	if mode == modeDryRun {
+		return out, nil
+	}
+	err := c.getAll("/v1/projects", nil, func(raw json.RawMessage) error {
+		var rows []struct {
+			Key string `json:"key"`
+		}
+		if err := json.Unmarshal(raw, &rows); err != nil {
+			return err
+		}
+		for _, row := range rows {
+			out[row.Key] = true
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("listing projects: %w", err)
+	}
+	return out, nil
+}
+
+// seedQuotas gives every seller a target for the current quarter, so the
+// attainment the product computes from closed-won deals has something to be a
+// percentage of.
+func seedQuotas(c *client, cfg demoConfig, refs pipelineRefs, mode runMode) (int, error) {
+	created := 0
+	start, end := currentQuarter(refs)
+	existing := map[string]bool{}
+	if mode != modeDryRun {
+		query := url.Values{"period_start": {start}}
+		err := c.getAll("/v1/quotas", query, func(raw json.RawMessage) error {
+			var rows []struct {
+				OwnerID string `json:"owner_id"`
+			}
+			if err := json.Unmarshal(raw, &rows); err != nil {
+				return err
+			}
+			for _, row := range rows {
+				existing[row.OwnerID] = true
+			}
+			return nil
+		})
+		if err != nil {
+			return 0, fmt.Errorf("listing quotas: %w", err)
+		}
+	}
+	for _, ref := range sellerIDs(cfg, refs) {
+		ownerID, ok := refs.usersByRef[ref]
+		if !ok || existing[ownerID] {
+			continue
+		}
+		if mode == modeDryRun {
+			created++
+			continue
+		}
+		body := jsonBody{
+			"owner_id":     ownerID,
+			"period_start": start,
+			"period_end":   end,
+			// A round quarterly target, varied per seat so the attainment bars
+			// are not all the same length.
+			"target_minor": int64(150000+hashIndex("quota:"+ref, 12)*25000) * 100,
+			"currency":     "EUR",
+		}
+		if err := c.post("/v1/quotas", body, nil); err != nil {
+			if _, conflict := conflictingID(err); conflict {
+				continue
+			}
+			return created, fmt.Errorf("quota for %s: %w", ref, err)
+		}
+		created++
+	}
+	return created, nil
+}
+
+// currentQuarter is the quarter the run happens in, so a demo seeded today
+// shows a target somebody is currently working against.
+func currentQuarter(refs pipelineRefs) (start, end string) {
+	now := refs.now
+	quarter := (int(now.Month()) - 1) / 3
+	first := now.AddDate(0, -(int(now.Month()) - 1 - quarter*3), -(now.Day() - 1))
+	return first.Format("2006-01-02"), first.AddDate(0, 3, -1).Format("2006-01-02")
+}


### PR DESCRIPTION
Follows #1445. Fills the screens a demo reaches after the obvious ones, and
fixes the reason the Vietnamese half was invisible.

## What a seeded installation now holds

Verified against a live stack with 171 companies: 803 people, 54 deals, 48
contracts, 81 documents, 11,015 facts, 200 invoices — plus **4 tags applied
157 times, 2 dynamic lists, 18 projects, 6 quotas, 2 FX rates**.

## FX was not optional

Winning a deal FREEZES its rate, so the moment Korean companies started
billing in USD every close was refused:

```
no fx_rate from USD to EUR to freeze at close — an admin must load the rate
for this currency pair before this close can succeed
```

The phase runs before deals close, which is the whole point of it existing.

## The Vietnamese half was invisible

The coverage matrix guarantees counts, never *which* company holds them, and
there are two Vietnamese companies among 171. The hash reliably made both a
prospect and a target — so every Vietnamese contract, document and dong
invoice existed in code and in tests and nowhere a demo could reach. That is
the same as not having built them.

`ensureLocaleIsVisible` promotes one company per non-German language to
customer: after coverage so it cannot pull a cell below its floor, and only
where that language has no customer already. A floor, not a quota — the
Korean half already had two and was correctly left alone.

The database now holds `VULETECH — Hop dong khung` in VND with a Vietnamese
PDF and a `Thoa thuan bao mat` NDA beside it, `엠비젼 — Master agreement` in
USD, and German paper for the K5 half.

## Custom fields are not seeded, and cannot be

`POST /v1/custom-fields` answers **501** — "operation custom-field schema
changes is specified but not yet implemented". The contract describes the
add-field engine in full and the handler is a stub, so that screen stays empty
in the demo because it is empty in the product. The code that would fill it is
deleted rather than commented out; the note in `surfaces.go` is the record.

`GET /v1/custom-fields` also needed the lesson `/v1/attachments` taught:
`object` is a required query parameter with no installation-wide form, so
asking without it is a 422 rather than an empty page.

## Verification

`make craft-static` and the seeder tests pass. Seeded repeatedly against an
isolated `DEV_SLUG` stack; the verify pass is green and a second run creates
nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Seeds workspace surfaces (tags, lists, projects, quotas), loads fixed FX rates for non‑EUR currencies, ensures a visible customer per supported language, and scales generated amounts into each account’s currency. Previously non‑EUR deals could not close, Vietnamese assets were unreachable, and VN/US PDFs printed euro‑sized numbers; now close succeeds, localized paper appears, and amounts look plausible.

- FX runs first and loads fixed demo rates for USD, VND, GBP, CHF to EUR; if a new currency appears in the plan, add it to `demoFxRates`.
- Surfaces include tags (applied idempotently), dynamic organization lists, projects advanced through phases, and quarterly seller quotas; the report now includes FX and surface counts.
- Promotes one company per non‑DE locale to customer only when missing, then ensures at least one contract and loose document so each language renders paper; includes a test for customer presence per language.
- Scales generated amounts into the account currency (e.g., VND uses round multiples; USD near EUR at this precision) so PDFs show realistic numbers.
- Custom fields are not seeded (`POST /v1/custom-fields` returns 501; `GET` requires an `object` query).

<sup>Written for commit 36cf4e3c5519ec5fd6ed7146a164ff73fe25684d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1481?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Demo data now includes fixed foreign-exchange rates for non-EUR currencies.
  * Demo workspaces can include tags, dynamic lists, projects, and quarterly seller quotas.
  * CRM demo data now provides customer coverage across supported non-German languages, including contracts and related records.
* **Improvements**
  * Demo seeding reports expanded totals and handles existing data and preview runs more reliably.
  * Currency and CRM data creation is resilient to incomplete or concurrent setup conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->