### PR TITLE
docs(timeline): a story for the mail row that folds its sign-off

### DIFF
--- a/frontend/src/design-system/composed.stories.tsx
+++ b/frontend/src/design-system/composed.stories.tsx
@@ -61,6 +61,64 @@ export const Default: Story = {
   },
 };
 
+// A mail row as the timeline actually receives one: the stored body carries the
+// From/To preamble capture folds in, the sender's sign-off, and the thread they
+// replied to. The row shows the message; the sign-off and the quoted history sit
+// behind their own control, because the split that finds them is a heuristic and
+// a wrong guess has to stay one click from being visible.
+export const MailWithSignatureAndQuote: Story = {
+  args: {
+    name: "Acme GmbH",
+    subtitle: "Enterprise · Munich",
+    zone: "Europe/Berlin",
+    timeline: [
+      {
+        ...emailEntry,
+        title: "Re: Rollout-Plan",
+        body: [
+          "From: lena.fischer@acme.de",
+          "To: lars@gradion.com",
+          "",
+          "Hallo,",
+          "",
+          "der Plan sieht gut aus. Phase 1 ist realistisch, bei Phase 3 haben wir",
+          "intern noch Klärungsbedarf mit dem Händlerteam. Details stehen unter",
+          "https://acme.de/rollout bereit.",
+          "",
+          "Dienstag 14 Uhr würde bei uns passen.",
+          "",
+          "Mit freundlichen Grüßen",
+          "Lena Fischer",
+          "Acme GmbH · +49 89 123456",
+          "",
+          "Am 12.08.2026 um 09:14 schrieb Lars Jankowfsky:",
+          "> Passt ein Termin nächste Woche für die Detailabstimmung?",
+        ].join("\n"),
+      },
+      meetingEntry,
+    ],
+  },
+};
+
+// The same shape on a note, which must NOT be folded: "Viele Grüße" opens this
+// one as ordinary prose, and a quoted line is something a person typed.
+export const NoteThatReadsLikeASignOff: Story = {
+  args: {
+    name: "Acme GmbH",
+    zone: "Europe/Berlin",
+    timeline: [
+      {
+        ...noteEntry,
+        title: "Nach dem Messegespräch",
+        body: [
+          "Viele Grüße von der Messe ausgerichtet, Lena war sichtlich erfreut.",
+          "> Sie fragte nochmal nach dem Händlerportal.",
+        ].join("\n"),
+      },
+    ],
+  },
+};
+
 // The new slot: the email row carries a Reply action, the meeting row a Relink
 // action, and the note row none — the right-aligned cluster only appears where
 // an affordance is supplied.


### PR DESCRIPTION
`RecordView`'s timeline gained the split that keeps a signature and a quoted thread out of the row (#1460), and no story showed a mail with a body at all — so the state the change is about was rendered by nothing in the catalog. `frontend/CLAUDE.md` asks for a story in the same commit as a design-system change; this is that story, late.

Two stories, because the interesting half is what must **not** happen:

- **MailWithSignatureAndQuote** — a stored body in the shape capture actually produces: the `From:/To:` preamble, the message, a German sign-off with contact block, and the quoted thread under an `Am … schrieb …:` attribution. The row shows the message; the rest sits behind its own control.
- **NoteThatReadsLikeASignOff** — a note opening with "Viele Grüße" and carrying a `>` line, which keeps every word. The split is gated on `kind === "email"` and this is the case that proves it.

Also worth recording: I ran the shipped `splitEmailBody` against the 9 real captured mails in the dev dataset. All 9 folded exactly the sign-off and kept the full message, including three with Vietnamese sender names — the case most likely to break a heuristic tuned on German.

`make fe-uat` and `make check-fe` green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds two Storybook stories that document the timeline email body split, which folds signatures and quoted threads out of the row. Previously no story exercised a mail body, so this behavior was unrepresented.

- MailWithSignatureAndQuote: shows From/To preamble, message, German sign-off, and quoted thread; the row renders only the message, with the sign-off and quote behind the control.
- NoteThatReadsLikeASignOff: shows a note starting with “Viele Grüße” and a quoted line; the row keeps all text because the split is gated on `kind === "email"`.

<sup>Written for commit 027a242f7d6f81ef1bb636e4c61ced42c640b548. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1482?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

