### PR TITLE
fix(ci): a merge to main gets a run of its own, so every merge is gated

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,11 +20,25 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
 
-# One live run per ref: a new push to the same branch/PR cancels the stale
-# run instead of queueing behind it. Runs on main are never cancelled — a
-# merge must not kill the in-flight check of the previous merge.
+# One live run per PR ref: a new push to the same branch cancels the stale run
+# instead of queueing behind it. A merge to main gets a group of its OWN, keyed
+# by commit, so every merge is gated.
+#
+# `cancel-in-progress: false` alone does not achieve that, which is what the
+# previous spelling assumed. It protects the run that is already RUNNING; a
+# group holds at most one QUEUED run, so with every main push in one group each
+# merge evicted the one queued behind the current lane and was reported
+# `cancelled` with zero jobs. That reads identically to a green skip on every
+# dashboard. It is not hypothetical: three consecutive merges landed ungated
+# behind one slow lane on 2026-08-16, and the daily scheduled backend lane —
+# which exists for exactly this mask — leaves a window up to a day wide.
+#
+# The cost is deliberate: several full lanes, twelve integration shards each,
+# can now run on main at once rather than one at a time. Runner minutes for a
+# gate that runs is the trade this repository wants while main is the only
+# integration point.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'push' && github.sha || '' }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 defaults:

--- a/infra/ci-pipeline.md
+++ b/infra/ci-pipeline.md
@@ -25,9 +25,18 @@ likewise advisory.
 - `push` to `main`
 - `workflow_dispatch` (manual)
 
-One live run per ref (`concurrency` group): a new push cancels the stale run —
-except on `main`, where a merge must not kill the in-flight check of the
-previous merge.
+One live run per PR ref (`concurrency` group): a new push cancels the stale run.
+A merge to `main` gets a group of its **own**, keyed by commit, so every merge is
+gated.
+
+That last part is what `cancel-in-progress: false` alone does not buy, and
+assuming it did cost three ungated merges in one afternoon. The flag protects a
+run that is already *running*; a group holds at most one *queued* run, so while
+every `main` push shared one group, each merge evicted the one queued behind the
+current lane — reported `cancelled`, zero jobs, indistinguishable from a green
+skip on any dashboard. The daily scheduled `backend lane (main)` exists to catch
+exactly that mask and leaves a window up to a day wide. The deliberate cost is
+that several full lanes can now run on `main` at once.
 
 ## Run only the checks a change can affect
 


### PR DESCRIPTION
Closes #1463. Found while verifying that #1454 and #1457 had landed green — neither had a gate run on `main` at all.

## The mechanism

`ci.yml` said what it intended and did not achieve it:

```yaml
# Runs on main are never cancelled — a merge must not kill the in-flight
# check of the previous merge.
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
```

`cancel-in-progress: false` protects the run that is already **running**. A concurrency group holds at most one **queued** run, and every push to `main` shared one group — so each merge evicted the merge queued behind the current lane. The evicted run is reported `cancelled` with zero jobs: no gate ran, nothing went red, and the result is indistinguishable from a green skip on any dashboard.

## Measured

One lane held the group from 14:51 on 2026-08-16. The next three merges never started a job:

| time | run | commit | conclusion |
|---|---|---|---|
| 14:51 | 31953944029 | `fix(platform)` | in_progress — held the group |
| 14:54 | 31954056290 | `fix(ci)` (#1454) | **cancelled, 0 jobs** |
| 15:00 | 31954373927 | `fix(aicert)` | **cancelled, 0 jobs** |
| 15:10 | 31954843769 | `fix(capture)` (#1457) | **cancelled, 0 jobs** |

`gh api .../runs/<id>/jobs` returns an empty list for each. Two were backend changes. The same shape appears earlier the same day at 13:53 and 02:29, so it is not a one-off burst.

The daily scheduled `backend lane (main)` exists to catch exactly this mask, which puts the detection window at up to 24 hours. It also compounds #1130: with required checks non-strict a PR is approved against a base that may have moved, and if the merge's own run is then evicted, nothing compiles the merged tree until the next morning.

## The change

```yaml
group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'push' && github.sha || '' }}
```

A push gets a group of one, so there is never a queue to be evicted from — which is what the old comment already claimed the ref-keyed group did. Pull requests are untouched: same group per ref, `cancel-in-progress` still true, a new push still kills the stale run. `workflow_dispatch` keeps the ref group.

The cost is deliberate and is why this was filed rather than flipped: several full lanes, twelve integration shards each, can now run on `main` at once rather than one at a time. Runner minutes for a gate that runs.

## Verification

- `make check-backend` green on this branch (exit 0, zero `FAIL` lines).
- And on current `origin/main` (`6fe240fe7`), separately — the three ungated merges turned out to have left the tree sound. That is luck, not a control, which is the point.
- The behavioural proof can only come after merge: two merges landing close together should now produce two runs with jobs, rather than one run and one `cancelled`.

No gate is added for this. A fitness function over the `concurrency` block could only assert the expression back at itself; what makes the claim checkable is the run history above, and the scheduled lane remains the backstop.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure every merge to main runs its own CI gate by keying `push` runs’ concurrency group on the commit. Previously, all `main` pushes shared one group, so queued merges were evicted and reported cancelled with zero jobs; now each merge gets its own run, at the cost of more parallel lanes.

- Updates `ci.yml` to use `$workflow-$ref-$sha` for `push` events; PRs still group by ref with `cancel-in-progress` true; `workflow_dispatch` keeps ref grouping.
- Review focus: the `concurrency.group` expression only appends `sha` for `push`; no other job logic changes. Confirm infra can handle parallel `main` lanes and caches.
- Rollout: no migration needed. Expect higher runner minutes on `main`. After merge, two close merges to `main` should produce two runs with jobs, not a cancellation.

<sup>Written for commit dfcbcf5686c07420db549d58719eb7e99040eef3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1483?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

