### PR TITLE
fix(collections): a saved view's filter is checked when it is written

### DIFF
--- a/backend/internal/compose/integration/dynamicsegment_singleconn_integration_test.go
+++ b/backend/internal/compose/integration/dynamicsegment_singleconn_integration_test.go
@@ -41,8 +41,9 @@ var dynamicSegmentSingleConnPerms = principal.Permissions{
 	RowScope: principal.RowScopeAll,
 }
 
-// savedViewSingleConnPerms is the create+read+update posture the saved-view arm
-// needs; a view is per-user state, so ownership is the only scope that applies.
+// savedViewSingleConnPerms is the posture the saved-view arm needs. A view is
+// per-user state gated on ownership, so the row scope here is not what decides
+// visibility — it is set wide so a refusal in this test can only be the pool.
 var savedViewSingleConnPerms = principal.Permissions{
 	RoleKeys: []string{"admin"},
 	Objects: map[string]principal.ObjectGrant{

--- a/backend/internal/compose/integration/dynamicsegment_singleconn_integration_test.go
+++ b/backend/internal/compose/integration/dynamicsegment_singleconn_integration_test.go
@@ -41,6 +41,17 @@ var dynamicSegmentSingleConnPerms = principal.Permissions{
 	RowScope: principal.RowScopeAll,
 }
 
+// savedViewSingleConnPerms is the create+read+update posture the saved-view arm
+// needs; a view is per-user state, so ownership is the only scope that applies.
+var savedViewSingleConnPerms = principal.Permissions{
+	RoleKeys: []string{"admin"},
+	Objects: map[string]principal.ObjectGrant{
+		"custom_field": {Create: true, Read: true, Update: true, Delete: true},
+		"saved_view":   {Create: true, Read: true, Update: true, Delete: true},
+	},
+	RowScope: principal.RowScopeAll,
+}
+
 // TestListMembersEvaluatesADynamicSegmentOnTheCallersOnlyConnection proves
 // the sequencing: on a single-connection pool, with a real field catalog
 // wired to that same pool, a dynamic list's ListMembers call must resolve
@@ -95,5 +106,57 @@ func TestListMembersEvaluatesADynamicSegmentOnTheCallersOnlyConnection(t *testin
 	}
 	if len(rows) != 1 || rows[0].EntityID != ids.UUID(created.Id) {
 		t.Fatalf("members = %v, want exactly [%s]", rows, created.Id)
+	}
+}
+
+// The saved-view half of the same obligation. Both write paths resolve the
+// filter vocabulary before opening their own transaction, and both are held to
+// it here: move either resolution inside its write transaction and this times
+// out.
+//
+// The update arm needs its own case rather than trusting the create arm,
+// because it carries a sequencing decision the create path does not — it reads
+// the stored view (one transaction) to learn the resource before resolving the
+// vocabulary (another) and then writing (a third). Three sequential
+// acquisitions on one connection pass; any nesting among them does not.
+func TestSavedViewValidatesItsFilterOnTheCallersOnlyConnection(t *testing.T) {
+	e := Setup(t)
+	pool := singleConnPool(t)
+	svc := customfields.NewService(pool, SchemaPool(t))
+	ctx, cancel := context.WithTimeout(e.As(e.Rep1, nil, savedViewSingleConnPerms), txSeamBudget)
+	t.Cleanup(cancel)
+
+	views := collections.NewStore(harnessDB(pool, e.WS)).WithFieldCatalog(svc)
+
+	// A cf_ column NAMED IN THE FILTER is what makes the catalogue read happen
+	// at all: a core-field filter resolves from the static vocabulary, the
+	// second acquisition never occurs, and the case would pass proving nothing.
+	field, err := svc.Create(ctx, customfields.FieldSpec{
+		Object: "person", Label: "View Budget", Type: customfields.TypeText, Source: "ui",
+	})
+	if err != nil {
+		t.Fatalf("defining the field: %v", err)
+	}
+	if field.ColumnName == nil {
+		t.Fatal("defined field carries no column_name")
+	}
+	filter := map[string]any{
+		"filter": map[string]any{"field": *field.ColumnName, "op": "eq", "value": "gold"},
+	}
+
+	view, err := views.CreateSavedView(ctx, collections.CreateSavedViewInput{
+		Resource: "people", Name: "Gold accounts", Query: filter,
+	})
+	if err != nil {
+		t.Fatalf("creating the view on the caller's only connection: %v — a timeout here is the "+
+			"catalogue read waiting for a second connection the write transaction holds", err)
+	}
+
+	replacement := map[string]any{
+		"filter": map[string]any{"field": *field.ColumnName, "op": "eq", "value": "silver"},
+	}
+	if _, err := views.UpdateSavedView(ctx, view.ID, collections.UpdateSavedViewInput{Query: &replacement}); err != nil {
+		t.Fatalf("updating the view on the caller's only connection: %v — a timeout here is the "+
+			"stored-view read, the catalogue read, or the write nesting inside one another", err)
 	}
 }

--- a/backend/internal/compose/integration/filteredexport_integration_test.go
+++ b/backend/internal/compose/integration/filteredexport_integration_test.go
@@ -375,6 +375,19 @@ func TestFilteredExportFromASavedViewAndFromAList(t *testing.T) {
 		t.Fatalf("create filterless view → %d, want 201", status)
 	}
 
+	// A filter of explicit null is how a client spells "cleared". The write
+	// surface accepts it as such — and the two surfaces have to AGREE about it,
+	// or a view the create path called filterless is called malformed at export.
+	var cleared struct {
+		ID string `json:"id"`
+	}
+	if status := e.Call(t, "POST", "/v1/views", apptest.AnyMap{
+		"resource": "deals", "name": "Cleared filter",
+		"query": apptest.AnyMap{"columns": []any{"name"}, "filter": nil},
+	}, nil, &cleared); status != http.StatusCreated {
+		t.Fatalf("create view with a null filter → %d, want 201 — the write surface reads null as cleared", status)
+	}
+
 	// Both stored sources export. No deal matches, so the honest answer is a
 	// header row — the same shape the object path gives for an empty slice,
 	// which is what "one engine" has to mean here.
@@ -401,6 +414,7 @@ func TestFilteredExportFromASavedViewAndFromAList(t *testing.T) {
 	}{
 		{"a static list has members, not a filter", apptest.AnyMap{"list_id": static.ID, "format": "csv"}, "list_id"},
 		{"a view carrying no filter state", apptest.AnyMap{"view_id": viewless.ID, "format": "csv"}, "view_id"},
+		{"a view whose filter is explicitly null", apptest.AnyMap{"view_id": cleared.ID, "format": "csv"}, "view_id"},
 		{"a view_id that is not a uuid", apptest.AnyMap{"view_id": "not-a-uuid", "format": "csv"}, "view_id"},
 	} {
 		t.Run(c.name, func(t *testing.T) {

--- a/backend/internal/compose/integration/filteredexport_integration_test.go
+++ b/backend/internal/compose/integration/filteredexport_integration_test.go
@@ -313,3 +313,145 @@ func TestFilteredExportHTTPEndToEnd(t *testing.T) {
 		t.Fatalf("out-of-vocabulary filter → %d, want 422", status)
 	}
 }
+
+// Export by SAVED VIEW and by LIST — the two sources that resolve their
+// predicate from stored state rather than from the request body.
+//
+// Both were unexercised: nothing reached SavedViewFilterSource or
+// ListFilterSource at all, so the guarantee #693 is about — one vocabulary
+// across what a filter may say, what it selects, and what an export contains —
+// held for the object path and was untested for the other two ways in.
+//
+// Each source's refusals are here too, because they are the interesting half:
+// a static list has explicit members rather than a filter, and a view may carry
+// no filter state at all. Both name their own wire field and answer 422.
+func TestFilteredExportFromASavedViewAndFromAList(t *testing.T) {
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
+	if status := e.Call(t, "POST", "/v1/auth/login", apptest.AnyMap{
+		"email": "ada@example.com", "password": "correct-horse-battery",
+	}, nil, nil); status != http.StatusOK {
+		t.Fatalf("login → %d", status)
+	}
+
+	commitFilter := apptest.AnyMap{"field": "forecast_category", "op": "eq", "value": "commit"}
+
+	var view struct {
+		ID string `json:"id"`
+	}
+	if status := e.Call(t, "POST", "/v1/views", apptest.AnyMap{
+		"resource": "deals", "name": "Commit deals",
+		"query": apptest.AnyMap{"filter": commitFilter},
+	}, nil, &view); status != http.StatusCreated {
+		t.Fatalf("create saved view → %d, want 201", status)
+	}
+
+	var dynamic struct {
+		ID string `json:"id"`
+	}
+	if status := e.Call(t, "POST", "/v1/lists", apptest.AnyMap{
+		"name": "Commit segment", "entity_type": "deal", "list_type": "dynamic",
+		"definition": commitFilter,
+	}, nil, &dynamic); status != http.StatusCreated {
+		t.Fatalf("create dynamic list → %d, want 201", status)
+	}
+
+	var static struct {
+		ID string `json:"id"`
+	}
+	if status := e.Call(t, "POST", "/v1/lists", apptest.AnyMap{
+		"name": "Hand-picked deals", "entity_type": "deal", "list_type": "static",
+	}, nil, &static); status != http.StatusCreated {
+		t.Fatalf("create static list → %d, want 201", status)
+	}
+
+	var viewless struct {
+		ID string `json:"id"`
+	}
+	if status := e.Call(t, "POST", "/v1/views", apptest.AnyMap{
+		"resource": "deals", "name": "Columns only",
+		"query": apptest.AnyMap{"columns": []any{"name"}},
+	}, nil, &viewless); status != http.StatusCreated {
+		t.Fatalf("create filterless view → %d, want 201", status)
+	}
+
+	// Both stored sources export. No deal matches, so the honest answer is a
+	// header row — the same shape the object path gives for an empty slice,
+	// which is what "one engine" has to mean here.
+	for _, c := range []struct {
+		name string
+		body apptest.AnyMap
+	}{
+		{"by view_id", apptest.AnyMap{"view_id": view.ID, "format": "csv"}},
+		{"by list_id", apptest.AnyMap{"list_id": dynamic.ID, "format": "csv"}},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			rows := exportCSV(t, e, c.body)
+			if len(rows) != 1 {
+				t.Fatalf("got %d rows, want a header row only", len(rows))
+			}
+		})
+	}
+
+	// The refusals, each naming the field the caller actually sent.
+	for _, c := range []struct {
+		name  string
+		body  apptest.AnyMap
+		field string
+	}{
+		{"a static list has members, not a filter", apptest.AnyMap{"list_id": static.ID, "format": "csv"}, "list_id"},
+		{"a view carrying no filter state", apptest.AnyMap{"view_id": viewless.ID, "format": "csv"}, "view_id"},
+		{"a view_id that is not a uuid", apptest.AnyMap{"view_id": "not-a-uuid", "format": "csv"}, "view_id"},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			// The per-field breakdown rides `details.errors` (httperr's
+			// fieldDetails), not the problem's top level.
+			var problem struct {
+				Details struct {
+					Errors []struct {
+						Field string `json:"field"`
+					} `json:"errors"`
+				} `json:"details"`
+			}
+			if status := e.Call(t, "POST", "/v1/exports", c.body, nil, &problem); status != http.StatusUnprocessableEntity {
+				t.Fatalf("→ %d, want 422", status)
+			}
+			if got := problem.Details.Errors; len(got) != 1 || got[0].Field != c.field {
+				t.Errorf("field errors = %v, want exactly one naming %q", got, c.field)
+			}
+		})
+	}
+}
+
+// exportCSV posts an export and parses the CSV body, failing the test on any
+// non-200 or unparseable response.
+func exportCSV(t *testing.T, e *apptest.AppEnv, body apptest.AnyMap) [][]string {
+	t.Helper()
+	raw, err := json.Marshal(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req, err := http.NewRequest("POST", e.TS.URL+"/v1/exports", bytes.NewReader(raw))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Workspace-Slug", e.Slug)
+	resp, err := e.Client.Do(req)
+	if err != nil {
+		t.Fatalf("export request: %v", err)
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			t.Errorf("closing body: %v", err)
+		}
+	}()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("export → %d, want 200", resp.StatusCode)
+	}
+	records, err := csv.NewReader(resp.Body).ReadAll()
+	if err != nil {
+		t.Fatalf("response is not valid CSV: %v", err)
+	}
+	return records
+}

--- a/backend/internal/compose/integration/filteredexport_integration_test.go
+++ b/backend/internal/compose/integration/filteredexport_integration_test.go
@@ -370,7 +370,7 @@ func TestFilteredExportFromASavedViewAndFromAList(t *testing.T) {
 	}
 	if status := e.Call(t, "POST", "/v1/views", apptest.AnyMap{
 		"resource": "deals", "name": "Columns only",
-		"query": apptest.AnyMap{"columns": []any{"name"}},
+		"query": apptest.AnyMap{"columns": []string{"name"}},
 	}, nil, &viewless); status != http.StatusCreated {
 		t.Fatalf("create filterless view → %d, want 201", status)
 	}
@@ -383,7 +383,7 @@ func TestFilteredExportFromASavedViewAndFromAList(t *testing.T) {
 	}
 	if status := e.Call(t, "POST", "/v1/views", apptest.AnyMap{
 		"resource": "deals", "name": "Cleared filter",
-		"query": apptest.AnyMap{"columns": []any{"name"}, "filter": nil},
+		"query": apptest.AnyMap{"columns": []string{"name"}, "filter": nil},
 	}, nil, &cleared); status != http.StatusCreated {
 		t.Fatalf("create view with a null filter → %d, want 201 — the write surface reads null as cleared", status)
 	}

--- a/backend/internal/compose/integration/smartlist_integration_test.go
+++ b/backend/internal/compose/integration/smartlist_integration_test.go
@@ -496,7 +496,10 @@ func TestSavedViewResourceCheckAgainstTheContractEnum(t *testing.T) {
 		}
 	}
 	if want := map[string]bool{"projects": true}; !maps.Equal(undeclared, want) {
-		t.Errorf("the contract declares %v that the CHECK refuses, want exactly %v (#1484); "+
-			"if the CHECK was widened, drop the exception here", undeclared, want)
+		t.Errorf("the contract declares %v that the CHECK refuses, want exactly %v — tracked at "+
+			"#1484, whose spec half is margince-foundation#1327 (LVS-DDL-3 still pins six). When "+
+			"that lands, the additive migration widening the CHECK drops this exception; if it is "+
+			"rejected instead, the contract narrows and this exception drops the other way. Either "+
+			"way the answer is upstream, not here", undeclared, want)
 	}
 }

--- a/backend/internal/compose/integration/smartlist_integration_test.go
+++ b/backend/internal/compose/integration/smartlist_integration_test.go
@@ -271,6 +271,65 @@ func TestSavedView_roundTripsAndIsPerUser(t *testing.T) {
 	}
 }
 
+// A saved view's filter is checked when it is WRITTEN, not when someone finally
+// exports it: a view naming a field that is not filterable is refused by the
+// surface that accepts it, rather than by an export the author reaches much
+// later, if ever.
+//
+// Both write paths, because a create-time gate one PATCH walks around is not a
+// gate. The other obligation these paths carry — that the vocabulary is
+// resolved BEFORE the write transaction opens — is NOT pinned here and cannot
+// be: this store is built without a field catalogue, so SegmentEngine returns
+// the core vocabulary without ever reaching for a second connection.
+// dynamicsegment_singleconn_integration_test.go holds that one, with a real
+// catalogue over a pool capped at one connection.
+func TestSavedView_filterIsValidatedWhenWrittenNotWhenExported(t *testing.T) {
+	e := Setup(t)
+	store := collections.NewStore(e.DB())
+	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, collectionsPerms())
+	unfilterable := map[string]any{"field": "secret_salary", "op": "eq", "value": "x"}
+
+	assertRefused := func(what string, err error) {
+		t.Helper()
+		var pe *storekit.PredicateError
+		if !errors.As(err, &pe) {
+			t.Fatalf("%s: err = %v, want a PredicateError (422)", what, err)
+		}
+		if pe.Code != storekit.CodeFilterFieldNotAllowed {
+			t.Errorf("%s: code = %q, want %q", what, pe.Code, storekit.CodeFilterFieldNotAllowed)
+		}
+		if pe.Field != "secret_salary" {
+			t.Errorf("%s: field = %q, want the offending field named", what, pe.Field)
+		}
+	}
+
+	_, err := store.CreateSavedView(rep, collections.CreateSavedViewInput{
+		Resource: "people", Name: "Overpaid", Query: map[string]any{"filter": unfilterable},
+	})
+	assertRefused("create", err)
+
+	// A view saved with a good filter cannot be PATCHed onto a bad one.
+	good, err := store.CreateSavedView(rep, collections.CreateSavedViewInput{
+		Resource: "people", Name: "Mine",
+		Query: map[string]any{"filter": map[string]any{"field": "owner_id", "op": "eq", "value": e.Rep1.String()}},
+	})
+	if err != nil {
+		t.Fatalf("create a valid view: %v", err)
+	}
+	replacement := map[string]any{"filter": unfilterable}
+	_, err = store.UpdateSavedView(rep, good.ID, collections.UpdateSavedViewInput{Query: &replacement})
+	assertRefused("update", err)
+
+	// And the refusal left the stored view alone.
+	reloaded, err := store.GetSavedView(rep, good.ID)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if !jsonEqual(t, good.Query, reloaded.Query) {
+		t.Errorf("the refused update still changed the stored query: %v", reloaded.Query)
+	}
+}
+
 // jsonEqual compares two values by their canonical JSON encoding, so a
 // jsonb round-trip (which re-types numbers/arrays) does not defeat the
 // exact-restore assertion.

--- a/backend/internal/compose/integration/smartlist_integration_test.go
+++ b/backend/internal/compose/integration/smartlist_integration_test.go
@@ -369,6 +369,59 @@ func TestSavedView_anArchivedViewIsNotFoundBeforeItsFilterIsJudged(t *testing.T)
 	}
 }
 
+// The shape refusals on both write surfaces, each naming its own wire field.
+//
+// They are one line of validation apiece and were unexercised, which is how the
+// wrong field name survived in them for as long as it did: a refusal nobody
+// reads is a refusal nobody notices is wrong.
+func TestListAndSavedViewShapeRefusalsNameTheirOwnField(t *testing.T) {
+	e := Setup(t)
+	store := collections.NewStore(e.DB())
+	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, collectionsPerms())
+	filter := map[string]any{"field": "owner_id", "op": "eq", "value": e.Rep1.String()}
+
+	assertField := func(what string, err error, want string) {
+		t.Helper()
+		var bad *collections.BadInputError
+		if !errors.As(err, &bad) {
+			t.Fatalf("%s: err = %v, want a BadInputError", what, err)
+		}
+		if bad.Field != want {
+			t.Errorf("%s: field = %q, want %q", what, bad.Field, want)
+		}
+	}
+
+	// A dynamic list IS its definition, and a static one must not carry one —
+	// the pair is what rules out a half-and-half list.
+	_, err := store.CreateList(rep, collections.CreateListInput{
+		Name: "Dynamic with nothing to evaluate", EntityType: "person", ListType: "dynamic",
+	})
+	assertField("a dynamic list with no definition", err, "definition")
+
+	_, err = store.CreateList(rep, collections.CreateListInput{
+		Name: "Static carrying a filter", EntityType: "person", ListType: "static",
+		Definition: filter,
+	})
+	assertField("a static list carrying a definition", err, "definition")
+
+	// A view's query is the whole view; null is not the same as an empty object,
+	// which is a legitimate view with no state yet.
+	_, err = store.CreateSavedView(rep, collections.CreateSavedViewInput{
+		Resource: "people", Name: "No query at all",
+	})
+	assertField("a view with a null query", err, "query")
+
+	// And a query replacement on a view the caller cannot see is not-found
+	// rather than a validation error — existence-hiding survives the new
+	// pre-read that the update path does to learn the resource.
+	replacement := map[string]any{"filter": filter}
+	_, err = store.UpdateSavedView(rep, ids.From[ids.SavedViewKind](ids.NewV7()),
+		collections.UpdateSavedViewInput{Query: &replacement})
+	if !errors.Is(err, apperrors.ErrNotFound) {
+		t.Fatalf("updating an unknown view = %v, want ErrNotFound", err)
+	}
+}
+
 // jsonEqual compares two values by their canonical JSON encoding, so a
 // jsonb round-trip (which re-types numbers/arrays) does not defeat the
 // exact-restore assertion.

--- a/backend/internal/compose/integration/smartlist_integration_test.go
+++ b/backend/internal/compose/integration/smartlist_integration_test.go
@@ -337,6 +337,38 @@ func TestSavedView_filterIsValidatedWhenWrittenNotWhenExported(t *testing.T) {
 	}
 }
 
+// An ARCHIVED view refuses a query replacement as not-found, and does it BEFORE
+// the filter is examined. The order is the point: refusing the filter first
+// would answer 422 for a view whose existence the caller is not entitled to
+// learn, so a 422 here would be an existence oracle for archived views.
+//
+// This is the branch the update path's own comment claims and nothing exercised.
+func TestSavedView_anArchivedViewIsNotFoundBeforeItsFilterIsJudged(t *testing.T) {
+	e := Setup(t)
+	store := collections.NewStore(e.DB())
+	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, collectionsPerms())
+
+	view, err := store.CreateSavedView(rep, collections.CreateSavedViewInput{
+		Resource: "people", Name: "Retired",
+		Query: map[string]any{"filter": map[string]any{"field": "owner_id", "op": "eq", "value": e.Rep1.String()}},
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if _, err := store.ArchiveSavedView(rep, view.ID); err != nil {
+		t.Fatalf("archive: %v", err)
+	}
+
+	// A filter that would ALSO be refused on its own merits, so a 422 could
+	// only mean the archived check was skipped.
+	unfilterable := map[string]any{"filter": map[string]any{"field": "secret_salary", "op": "eq", "value": "x"}}
+	_, err = store.UpdateSavedView(rep, view.ID, collections.UpdateSavedViewInput{Query: &unfilterable})
+
+	if !errors.Is(err, apperrors.ErrNotFound) {
+		t.Fatalf("err = %v, want ErrNotFound — a 422 here tells the caller an archived view exists", err)
+	}
+}
+
 // jsonEqual compares two values by their canonical JSON encoding, so a
 // jsonb round-trip (which re-types numbers/arrays) does not defeat the
 // exact-restore assertion.

--- a/backend/internal/compose/integration/smartlist_integration_test.go
+++ b/backend/internal/compose/integration/smartlist_integration_test.go
@@ -17,10 +17,16 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"maps"
+	"regexp"
 	"testing"
 
+	"github.com/jackc/pgx/v5"
+
+	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/modules/collections"
 	"github.com/gradionhq/margince/backend/internal/modules/people"
+	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
@@ -271,18 +277,19 @@ func TestSavedView_roundTripsAndIsPerUser(t *testing.T) {
 	}
 }
 
-// A saved view's filter is checked when it is WRITTEN, not when someone finally
-// exports it: a view naming a field that is not filterable is refused by the
-// surface that accepts it, rather than by an export the author reaches much
-// later, if ever.
+// A saved view's filter is checked when it is WRITTEN: a view naming a field
+// that is not filterable is refused by the surface that accepts it, not by an
+// export the author reaches much later, if ever.
 //
 // Both write paths, because a create-time gate one PATCH walks around is not a
 // gate. The other obligation these paths carry — that the vocabulary is
-// resolved BEFORE the write transaction opens — is NOT pinned here and cannot
-// be: this store is built without a field catalogue, so SegmentEngine returns
-// the core vocabulary without ever reaching for a second connection.
-// dynamicsegment_singleconn_integration_test.go holds that one, with a real
-// catalogue over a pool capped at one connection.
+// resolved BEFORE the write transaction opens — is NOT pinned here, for two
+// reasons that both have to hold: this store is built without a field
+// catalogue, so SegmentEngine never reaches for a second connection at all,
+// AND e.DB() is the shared multi-connection harness pool, so even wiring a
+// catalogue in would not make a nested acquire fail. Both are why
+// dynamicsegment_singleconn_integration_test.go owns that claim, over a pool
+// capped at one connection.
 func TestSavedView_filterIsValidatedWhenWrittenNotWhenExported(t *testing.T) {
 	e := Setup(t)
 	store := collections.NewStore(e.DB())
@@ -344,4 +351,67 @@ func jsonEqual(t *testing.T, a, b map[string]any) bool {
 		t.Fatal(err)
 	}
 	return string(ab) == string(bb)
+}
+
+// checkLiteral pulls the single-quoted values out of a CHECK constraint
+// definition; a column or type name never matches, only the literals do.
+var checkLiteral = regexp.MustCompile(`'([a-z_]+)'`)
+
+// The resource vocabulary against its real authority — the DDL — because the
+// unit lane can only compare the contract enum to a Go map, and those two are
+// not the ones that disagree.
+//
+// saved_view.resource admits SIX values; the contract declares SEVEN. The extra
+// one is `projects`, which means POST /v1/saved-views with resource=projects
+// passes contract validation, resolves the project segment engine, validates
+// its filter — and then trips the CHECK on INSERT, answering the caller that a
+// value the schema they were handed calls legal is not allowed.
+//
+// Asserted as a NAMED divergence rather than left to a narrower expectation:
+// tracked at #1484, where widening the CHECK versus narrowing the contract is a
+// product call, and the spec's own DDL pin still says six. This fails the day
+// either side moves, which is the day someone should look at it.
+func TestSavedViewResourceCheckAgainstTheContractEnum(t *testing.T) {
+	e := Setup(t)
+
+	var def string
+	err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		return tx.QueryRow(e.Admin(), `
+			SELECT pg_get_constraintdef(oid) FROM pg_constraint
+			 WHERE conrelid = 'saved_view'::regclass AND contype = 'c'
+			   AND pg_get_constraintdef(oid) LIKE '%resource%'`).Scan(&def)
+	})
+	if err != nil {
+		t.Fatalf("reading saved_view's own resource CHECK: %v", err)
+	}
+	storable := map[string]bool{}
+	for _, m := range checkLiteral.FindAllStringSubmatch(def, -1) {
+		storable[m[1]] = true
+	}
+
+	declared := map[string]bool{}
+	for _, r := range []crmcontracts.SavedViewResource{
+		crmcontracts.SavedViewResourceActivities, crmcontracts.SavedViewResourceDeals,
+		crmcontracts.SavedViewResourceLeads, crmcontracts.SavedViewResourceOrganizations,
+		crmcontracts.SavedViewResourcePartners, crmcontracts.SavedViewResourcePeople,
+		crmcontracts.SavedViewResourceProjects,
+	} {
+		declared[string(r)] = true
+	}
+
+	for name := range storable {
+		if !declared[name] {
+			t.Errorf("the CHECK stores resource %q, which the contract does not declare — a row no client can name", name)
+		}
+	}
+	undeclared := map[string]bool{}
+	for name := range declared {
+		if !storable[name] {
+			undeclared[name] = true
+		}
+	}
+	if want := map[string]bool{"projects": true}; !maps.Equal(undeclared, want) {
+		t.Errorf("the contract declares %v that the CHECK refuses, want exactly %v (#1484); "+
+			"if the CHECK was widened, drop the exception here", undeclared, want)
+	}
 }

--- a/backend/internal/modules/collections/exportsource.go
+++ b/backend/internal/modules/collections/exportsource.go
@@ -73,9 +73,12 @@ func (s *Store) SavedViewFilterSource(ctx context.Context, id ids.SavedViewID) (
 			Reason: "this saved view's filter state is not a filter tree",
 		}
 	}
+	// A stored tree that no longer decodes is an invariant break, not the
+	// caller's error: it was compiled before it was stored, and this caller
+	// sent only an id. Same story evaluateSegment tells for a list.
 	pred, err := predicateFromDefinition(filterMap)
 	if err != nil {
-		return FilterSource{}, asFieldFault(err, "view_id")
+		return FilterSource{}, fmt.Errorf("stored filter state for saved view %s: %w", id, err)
 	}
 	return FilterSource{Resource: resource, Predicate: pred}, nil
 }
@@ -98,7 +101,7 @@ func (s *Store) ListFilterSource(ctx context.Context, id ids.ListID) (FilterSour
 	}
 	pred, err := predicateFromDefinition(list.Definition)
 	if err != nil {
-		return FilterSource{}, asFieldFault(err, "list_id")
+		return FilterSource{}, fmt.Errorf("stored definition for list %s: %w", id, err)
 	}
 	return FilterSource{Resource: list.EntityType, Predicate: pred}, nil
 }

--- a/backend/internal/modules/collections/exportsource.go
+++ b/backend/internal/modules/collections/exportsource.go
@@ -56,8 +56,11 @@ func (s *Store) SavedViewFilterSource(ctx context.Context, id ids.SavedViewID) (
 			Reason: fmt.Sprintf("a %s view has no filterable export engine", view.Resource),
 		}
 	}
-	rawFilter, ok := view.Query["filter"]
-	if !ok {
+	// A nil filter is how a client spells "cleared", which is the same thing as
+	// absent and reads better as such — the create-time gate treats the two
+	// alike, so this refusal has to as well or one of them says the wrong thing.
+	rawFilter, ok := view.Query[viewFilterKey]
+	if !ok || rawFilter == nil {
 		return FilterSource{}, &BadInputError{
 			Field:  "view_id",
 			Reason: "this saved view carries no filter state to export",
@@ -72,7 +75,7 @@ func (s *Store) SavedViewFilterSource(ctx context.Context, id ids.SavedViewID) (
 	}
 	pred, err := predicateFromDefinition(filterMap)
 	if err != nil {
-		return FilterSource{}, err
+		return FilterSource{}, asFieldFault(err, "view_id")
 	}
 	return FilterSource{Resource: resource, Predicate: pred}, nil
 }
@@ -95,7 +98,7 @@ func (s *Store) ListFilterSource(ctx context.Context, id ids.ListID) (FilterSour
 	}
 	pred, err := predicateFromDefinition(list.Definition)
 	if err != nil {
-		return FilterSource{}, err
+		return FilterSource{}, asFieldFault(err, "list_id")
 	}
 	return FilterSource{Resource: list.EntityType, Predicate: pred}, nil
 }

--- a/backend/internal/modules/collections/lists.go
+++ b/backend/internal/modules/collections/lists.go
@@ -75,6 +75,11 @@ var memberEntityTables = func() map[string]bool {
 // points at.
 const entityTypeField = "entity_type"
 
+// definitionField names the body key a dynamic list carries its filter tree
+// under — the counterpart to a saved view's viewQueryField, and the reason a
+// decode refusal takes the name from its caller rather than assuming one.
+const definitionField = "definition"
+
 // entityIDField names its sibling — the polymorphic TARGET a member or a tag
 // application points at. Named beside entity_type because the two travel
 // together in every body on this surface, and a refusal has to name the wire
@@ -284,9 +289,26 @@ func (s *Store) validateSegmentDefinition(ctx context.Context, entityType string
 	if !ok {
 		return &BadInputError{Field: entityTypeField, Reason: "no dynamic segment engine for " + entityType}
 	}
-	pred, err := predicateFromDefinition(definition)
+	return compileForValidation(engine, definition, definitionField)
+}
+
+// compileForValidation is the proof itself, shared by the two stored filters
+// this module accepts — a dynamic list's definition and a saved view's filter
+// state. It decodes the tree and compiles it against the resolved vocabulary,
+// throwing the SQL away: the point is the refusal, not the statement. An
+// unknown field, a mistyped value, or an over-deep/over-wide tree comes back as
+// a PredicateError the transport maps to 422.
+//
+// Two things differ between the callers and both are parameters rather than
+// branches here. The ENGINE RESOLUTION, which is why the split falls at this
+// seam: a list names its entity type outright and has none if the type is not
+// filterable, while a view names a plural resource that may have no engine at
+// all and legitimately carry no filter. And the WIRE FIELD a decode failure
+// names, because the two surfaces carry the tree under different keys.
+func compileForValidation(engine storekit.Query, tree map[string]any, field string) error {
+	pred, err := predicateFromDefinition(tree)
 	if err != nil {
-		return err
+		return asFieldFault(err, field)
 	}
 	discard := 0
 	arg := func(any) int { discard++; return discard }

--- a/backend/internal/modules/collections/lists.go
+++ b/backend/internal/modules/collections/lists.go
@@ -200,10 +200,10 @@ func (s *Store) CreateList(ctx context.Context, in CreateListInput) (listRow, er
 	// A dynamic segment IS its definition; a static set must not carry
 	// one — the shape rules out a half-and-half list.
 	if in.ListType == listTypeDynamic && len(in.Definition) == 0 {
-		return listRow{}, &BadInputError{Field: "definition", Reason: "a dynamic list needs a query definition"}
+		return listRow{}, &BadInputError{Field: definitionField, Reason: "a dynamic list needs a query definition"}
 	}
 	if in.ListType == listTypeStatic && len(in.Definition) > 0 {
-		return listRow{}, &BadInputError{Field: "definition", Reason: "a static list carries no definition"}
+		return listRow{}, &BadInputError{Field: definitionField, Reason: "a static list carries no definition"}
 	}
 	// A dynamic segment's definition is a stored filter the members
 	// endpoint later runs through the ONE engine. Validate it against the
@@ -308,7 +308,13 @@ func (s *Store) validateSegmentDefinition(ctx context.Context, entityType string
 func compileForValidation(engine storekit.Query, tree map[string]any, field string) error {
 	pred, err := predicateFromDefinition(tree)
 	if err != nil {
-		return asFieldFault(err, field)
+		// Dressed as the caller's own field, because on THIS path the caller
+		// did send the tree. Anything else passes through untouched: the
+		// tree's shape is the only part of a refusal a caller can act on.
+		if errors.Is(err, errNotAFilterTree) {
+			return &BadInputError{Field: field, Reason: "is not a valid filter tree"}
+		}
+		return err
 	}
 	discard := 0
 	arg := func(any) int { discard++; return discard }

--- a/backend/internal/modules/collections/members.go
+++ b/backend/internal/modules/collections/members.go
@@ -218,9 +218,14 @@ func (s *Store) evaluateSegment(ctx context.Context, listID ids.ListID, listEnti
 		// invariant break, not a client error — surface it, never guess.
 		return nil, storekit.Page{}, fmt.Errorf("no dynamic segment engine for entity_type %q", listEntityType)
 	}
+	// A stored definition that no longer decodes is a schema invariant break in
+	// the same class as the missing engine above, not a client error: the tree
+	// was compiled before it was stored, and the reader of this list sent only
+	// its id. Surfaced as its own error rather than as a field fault, so nobody
+	// is told to fix a `definition` they never sent.
 	pred, err := predicateFromDefinition(definition)
 	if err != nil {
-		return nil, storekit.Page{}, err
+		return nil, storekit.Page{}, fmt.Errorf("stored definition for list %s: %w", listID, err)
 	}
 	var matched []ids.UUID
 	err = s.db.Tx(ctx, func(tx pgx.Tx) error {

--- a/backend/internal/modules/collections/savedviews.go
+++ b/backend/internal/modules/collections/savedviews.go
@@ -287,8 +287,9 @@ func (s *Store) UpdateSavedView(ctx context.Context, id ids.SavedViewID, in Upda
 		if err != nil {
 			return savedViewRow{}, err
 		}
-		// The write below answers not-found for an archived view. Refusing its
-		// filter first would tell the caller it exists.
+		// The write below answers not-found for an archived view, so this check
+		// has to come BEFORE the filter is judged: a 422 for a view the caller
+		// is not entitled to see would be an existence oracle for archived ones.
 		if current.ArchivedAt != nil {
 			return savedViewRow{}, apperrors.ErrNotFound
 		}

--- a/backend/internal/modules/collections/savedviews.go
+++ b/backend/internal/modules/collections/savedviews.go
@@ -273,6 +273,15 @@ func (s *Store) UpdateSavedView(ctx context.Context, id ids.SavedViewID, in Upda
 	// SegmentEngine reads the custom-field catalogue on its own pool
 	// connection, and a second acquire while holding a transaction is the
 	// deadlock shape the sibling seams spell out.
+	//
+	// Through GetSavedView, which means replacing a query needs saved_view:read
+	// as well as :update. That coupling is deliberate rather than incidental:
+	// this operation ANSWERS with the view (the handler writes wireSavedView
+	// as its 200 body), so a principal who may PATCH it is already shown it —
+	// update-without-read is not a coherent grant for this resource. The
+	// alternative, a private read that skips the object gate, would be a path
+	// returning a record without the gate every other read carries, which is a
+	// worse thing to own than a grant combination no seeded role has.
 	if in.Query != nil {
 		current, err := s.GetSavedView(ctx, id)
 		if err != nil {

--- a/backend/internal/modules/collections/savedviews.go
+++ b/backend/internal/modules/collections/savedviews.go
@@ -33,6 +33,14 @@ import (
 
 const savedViewColumns = `id, owner_id, shared_scope, resource, name, query, version, created_at, updated_at, archived_at`
 
+// The one key inside a saved view's `query` that carries a filter tree, and the
+// wire field a refusal of it names. Spelled once so the create/update gate and
+// the export path cannot look under different keys.
+const (
+	viewFilterKey  = "filter"
+	viewQueryField = "query"
+)
+
 // selectSavedView is the shared projection prefix for every saved_view read —
 // one spelling so the columns can't drift between the list, get, and delete paths.
 const selectSavedView = "SELECT " + savedViewColumns + " FROM saved_view WHERE "
@@ -160,6 +168,9 @@ func (s *Store) CreateSavedView(ctx context.Context, in CreateSavedViewInput) (s
 	if in.Query == nil {
 		return savedViewRow{}, &BadInputError{Field: "query", Reason: "must not be null"}
 	}
+	if err := s.validateViewFilter(ctx, in.Resource, in.Query); err != nil {
+		return savedViewRow{}, err
+	}
 	var out savedViewRow
 	err = s.db.Tx(ctx, func(tx pgx.Tx) error {
 		row := tx.QueryRow(ctx, `
@@ -201,6 +212,48 @@ func (s *Store) GetSavedView(ctx context.Context, id ids.SavedViewID) (savedView
 	return out, err
 }
 
+// validateViewFilter proves a saved view's filter state is evaluable against
+// its resource's closed vocabulary before the view is stored — the same proof
+// CreateList runs over a dynamic list's definition, and for the same reason:
+// otherwise the first thing that ever checks the filter is an export, so the
+// author learns their view is unusable from a surface they reached much later
+// rather than from the one that accepted it.
+//
+// Three states are legitimately unvalidatable and pass through:
+//
+//   - A view with NO filter state. A saved view is columns, sort and grouping
+//     as much as it is a filter.
+//   - A filter of `null`, which is how a client spells "cleared" — the same
+//     answer as absent, and read the same way at export.
+//   - A resource with no segment engine (activities, partners are not
+//     predicate-leaf resources). There is no vocabulary to check against; the
+//     export path refuses such a view outright on its own grounds.
+func (s *Store) validateViewFilter(ctx context.Context, resource string, query map[string]any) error {
+	rawFilter, present := query[viewFilterKey]
+	if !present || rawFilter == nil {
+		return nil
+	}
+	engineKey, filterable := viewResourceToEngine[resource]
+	if !filterable {
+		return nil
+	}
+	filterMap, isTree := rawFilter.(map[string]any)
+	if !isTree {
+		return &BadInputError{Field: viewQueryField, Reason: "filter state must be a filter tree"}
+	}
+	engine, ok, err := s.SegmentEngine(ctx, engineKey)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		// viewResourceToEngine named an engine key that segmentEngines does not
+		// carry — the two maps have drifted, which is ours to fix rather than
+		// the caller's to work around.
+		return fmt.Errorf("saved view resource %q maps to %q, which has no segment engine", resource, engineKey)
+	}
+	return compileForValidation(engine, filterMap, viewQueryField)
+}
+
 type UpdateSavedViewInput struct {
 	Name      *string
 	Query     *map[string]any
@@ -214,6 +267,28 @@ func (s *Store) UpdateSavedView(ctx context.Context, id ids.SavedViewID, in Upda
 	owner, err := viewOwner(ctx)
 	if err != nil {
 		return savedViewRow{}, err
+	}
+	// A replaced filter is checked too, or the create-time gate is a formality
+	// one PATCH walks around. Resolved BEFORE the write transaction opens:
+	// SegmentEngine reads the custom-field catalogue on its own pool
+	// connection, and a second acquire while holding a transaction is the
+	// deadlock shape the sibling seams spell out.
+	if in.Query != nil {
+		current, err := s.GetSavedView(ctx, id)
+		if err != nil {
+			return savedViewRow{}, err
+		}
+		// The write below answers not-found for an archived view. Refusing its
+		// filter first would tell the caller it exists.
+		if current.ArchivedAt != nil {
+			return savedViewRow{}, apperrors.ErrNotFound
+		}
+		// The stored resource, never a caller-supplied one: a view's resource is
+		// immutable (this input carries no Resource), so the vocabulary a filter
+		// is checked against is the one it will actually be evaluated with.
+		if err := s.validateViewFilter(ctx, current.Resource, *in.Query); err != nil {
+			return savedViewRow{}, err
+		}
 	}
 	var out savedViewRow
 	err = s.db.Tx(ctx, func(tx pgx.Tx) error {

--- a/backend/internal/modules/collections/savedviews.go
+++ b/backend/internal/modules/collections/savedviews.go
@@ -166,7 +166,7 @@ func (s *Store) CreateSavedView(ctx context.Context, in CreateSavedViewInput) (s
 		return savedViewRow{}, &BadInputError{Field: "name", Reason: "must not be empty"}
 	}
 	if in.Query == nil {
-		return savedViewRow{}, &BadInputError{Field: "query", Reason: "must not be null"}
+		return savedViewRow{}, &BadInputError{Field: viewQueryField, Reason: "must not be null"}
 	}
 	if err := s.validateViewFilter(ctx, in.Resource, in.Query); err != nil {
 		return savedViewRow{}, err

--- a/backend/internal/modules/collections/savedviews_test.go
+++ b/backend/internal/modules/collections/savedviews_test.go
@@ -134,3 +134,59 @@ func TestEveryViewResourceIsFilterableOrDeclaredOtherwise(t *testing.T) {
 		}
 	}
 }
+
+// A tree that marshals but does not decode into a predicate — `field` is a
+// string in the canonical shape, so a number there is well-formed JSON and an
+// invalid filter. The decode answers a sentinel carrying NO wire field, which
+// is what lets each surface name its own.
+func TestAnUndecodableTreeAnswersASentinelWithNoWireField(t *testing.T) {
+	_, err := predicateFromDefinition(map[string]any{"field": 5, "op": "eq", "value": "x"})
+
+	if !errors.Is(err, errNotAFilterTree) {
+		t.Fatalf("err = %v, want errNotAFilterTree", err)
+	}
+	var bad *BadInputError
+	if errors.As(err, &bad) {
+		t.Errorf("the decoder named a wire field (%q) it cannot know", bad.Field)
+	}
+}
+
+// The same undecodable tree names a DIFFERENT field depending on which surface
+// carried it. Naming `definition` on a saved view — which is what every caller
+// used to get — tells the author to fix a key their payload does not contain.
+func TestAnUndecodableTreeIsNamedForTheSurfaceThatCarriedIt(t *testing.T) {
+	for _, c := range []struct{ surface, field string }{
+		{"a dynamic list", definitionField},
+		{"a saved view", viewQueryField},
+		{"an export by view id", "view_id"},
+	} {
+		t.Run(c.surface, func(t *testing.T) {
+			err := asFieldFault(errNotAFilterTree, c.field)
+
+			var bad *BadInputError
+			if !errors.As(err, &bad) {
+				t.Fatalf("err = %v, want a BadInputError", err)
+			}
+			if bad.Field != c.field {
+				t.Errorf("field = %q, want %q", bad.Field, c.field)
+			}
+		})
+	}
+}
+
+// Anything that is not an undecodable tree passes through untouched: the shape
+// of a filter is the only part of this a caller can fix, so a catalogue failure
+// or a compile refusal must not be dressed up as their field error.
+func TestAsFieldFaultLeavesOtherErrorsAlone(t *testing.T) {
+	boom := errors.New("catalog unreachable")
+
+	got := asFieldFault(boom, definitionField)
+
+	if !errors.Is(got, boom) {
+		t.Fatalf("got %v, want the original error", got)
+	}
+	var bad *BadInputError
+	if errors.As(got, &bad) {
+		t.Error("an unrelated failure was dressed up as a field fault")
+	}
+}

--- a/backend/internal/modules/collections/savedviews_test.go
+++ b/backend/internal/modules/collections/savedviews_test.go
@@ -74,9 +74,8 @@ func TestASavedViewWithNothingToValidateIsAccepted(t *testing.T) {
 	}
 }
 
-// Filter state that is not a tree at all is refused where it is written rather
-// than where it is read. The export path has always answered this; the point of
-// the gate is that both surfaces now answer it.
+// Filter state that is not a tree at all is refused where it is written, by the
+// same surface that accepts the rest of the view.
 func TestASavedViewFilterThatIsNotATreeIsRefused(t *testing.T) {
 	store := (&Store{}).WithFieldCatalog(stubFilterable{})
 
@@ -102,24 +101,36 @@ var nonFilterableViewResources = map[string]bool{
 	string(crmcontracts.SavedViewResourcePartners):   true,
 }
 
-// Derived from the CONTRACT's enum, in the direction that can actually fail.
+// contractViewResources is the SavedViewResource enum as the contract declares
+// it. Hand-listed, which is a snapshot rather than a derivation: an eighth
+// member added to crm.yaml and forgotten here leaves this test green. The
+// derived form belongs in the backend-root suite, where contractSchema already
+// parses api/crm.yaml — tracked separately rather than half-built here.
+var contractViewResources = []crmcontracts.SavedViewResource{
+	crmcontracts.SavedViewResourceActivities,
+	crmcontracts.SavedViewResourceDeals,
+	crmcontracts.SavedViewResourceLeads,
+	crmcontracts.SavedViewResourceOrganizations,
+	crmcontracts.SavedViewResourcePartners,
+	crmcontracts.SavedViewResourcePeople,
+	crmcontracts.SavedViewResourceProjects,
+}
+
+// Every contract member is either filterable or declared deliberately not, in
+// the direction that can actually fail.
 //
 // The hazard is a resource MISSING from viewResourceToEngine: validateViewFilter
 // passes it through unchecked while SavedViewFilterSource refuses it at export
 // — the accepted-at-write, refused-at-read split this gate exists to close.
-// Iterating the map instead only proves its existing entries are live, which is
-// the one direction that cannot reintroduce the bug. So every contract member
-// must be either filterable or listed as deliberately not.
+// Iterating the map alone only proves its existing entries are live, which is
+// the one direction that cannot reintroduce the bug.
+//
+// WHAT THIS DOES NOT SAY is whether the database will store a view over that
+// resource. Filterability and storability are separate vocabularies with
+// separate authorities, and they disagree today — the saved_view.resource CHECK
+// is the authority, and the integration lane compares against it.
 func TestEveryViewResourceIsFilterableOrDeclaredOtherwise(t *testing.T) {
-	for _, resource := range []crmcontracts.SavedViewResource{
-		crmcontracts.SavedViewResourceActivities,
-		crmcontracts.SavedViewResourceDeals,
-		crmcontracts.SavedViewResourceLeads,
-		crmcontracts.SavedViewResourceOrganizations,
-		crmcontracts.SavedViewResourcePartners,
-		crmcontracts.SavedViewResourcePeople,
-		crmcontracts.SavedViewResourceProjects,
-	} {
+	for _, resource := range contractViewResources {
 		name := string(resource)
 		key, filterable := viewResourceToEngine[name]
 		switch {
@@ -131,6 +142,17 @@ func TestEveryViewResourceIsFilterableOrDeclaredOtherwise(t *testing.T) {
 			}
 		case !nonFilterableViewResources[name]:
 			t.Errorf("view resource %q has no engine and is not declared unfilterable, so a view over it accepts any filter at write and is refused at export", name)
+		}
+	}
+}
+
+// The other direction, which the enum-first loop above gives up: a key in
+// viewResourceToEngine that no contract member names is a mapping nothing can
+// ever reach, and it would sit there reading as coverage.
+func TestEveryMappedViewResourceIsAContractMember(t *testing.T) {
+	for name := range viewResourceToEngine {
+		if !crmcontracts.SavedViewResource(name).Valid() {
+			t.Errorf("viewResourceToEngine maps %q, which the contract's resource enum does not declare", name)
 		}
 	}
 }
@@ -151,42 +173,63 @@ func TestAnUndecodableTreeAnswersASentinelWithNoWireField(t *testing.T) {
 	}
 }
 
-// The same undecodable tree names a DIFFERENT field depending on which surface
-// carried it. Naming `definition` on a saved view — which is what every caller
-// used to get — tells the author to fix a key their payload does not contain.
+// An undecodable tree names a DIFFERENT field depending on which surface
+// carried it — driven through the real entry points, because the claim is about
+// what each surface answers, and a direct call to the shared helper would only
+// prove it returns the string it was handed. Neither entry point reaches the
+// pool for this input, so both belong in the unit lane.
 func TestAnUndecodableTreeIsNamedForTheSurfaceThatCarriedIt(t *testing.T) {
-	for _, c := range []struct{ surface, field string }{
-		{"a dynamic list", definitionField},
-		{"a saved view", viewQueryField},
-		{"an export by view id", "view_id"},
+	store := (&Store{}).WithFieldCatalog(stubFilterable{})
+	tree := map[string]any{"field": 5, "op": "eq", "value": "x"}
+
+	for _, c := range []struct {
+		surface string
+		refuse  func() error
+		field   string
+	}{
+		{
+			surface: "a dynamic list, which sends the tree as `definition`",
+			refuse:  func() error { return store.validateSegmentDefinition(context.Background(), "person", tree) },
+			field:   definitionField,
+		},
+		{
+			surface: "a saved view, which sends it inside `query`",
+			refuse: func() error {
+				return store.validateViewFilter(context.Background(), "people", map[string]any{"filter": tree})
+			},
+			field: viewQueryField,
+		},
 	} {
 		t.Run(c.surface, func(t *testing.T) {
-			err := asFieldFault(errNotAFilterTree, c.field)
+			err := c.refuse()
 
 			var bad *BadInputError
 			if !errors.As(err, &bad) {
 				t.Fatalf("err = %v, want a BadInputError", err)
 			}
 			if bad.Field != c.field {
-				t.Errorf("field = %q, want %q", bad.Field, c.field)
+				t.Errorf("field = %q, want %q — the caller is told to fix a key they never sent", bad.Field, c.field)
 			}
 		})
 	}
 }
 
-// Anything that is not an undecodable tree passes through untouched: the shape
-// of a filter is the only part of this a caller can fix, so a catalogue failure
-// or a compile refusal must not be dressed up as their field error.
-func TestAsFieldFaultLeavesOtherErrorsAlone(t *testing.T) {
+// A failure that is not the tree's shape is not the caller's to fix, so it must
+// not arrive dressed as their field error: a catalogue that cannot answer would
+// otherwise read as an invalid filter.
+func TestACatalogueFailureIsNotDressedAsAFieldFault(t *testing.T) {
 	boom := errors.New("catalog unreachable")
+	store := (&Store{}).WithFieldCatalog(stubFilterable{err: boom})
 
-	got := asFieldFault(boom, definitionField)
+	err := store.validateViewFilter(context.Background(), "people", map[string]any{
+		"filter": map[string]any{"field": "owner_id", "op": "eq", "value": "x"},
+	})
 
-	if !errors.Is(got, boom) {
-		t.Fatalf("got %v, want the original error", got)
+	if !errors.Is(err, boom) {
+		t.Fatalf("err = %v, want the catalogue's own error", err)
 	}
 	var bad *BadInputError
-	if errors.As(got, &bad) {
-		t.Error("an unrelated failure was dressed up as a field fault")
+	if errors.As(err, &bad) {
+		t.Errorf("a failed catalogue read was reported as a bad %q", bad.Field)
 	}
 }

--- a/backend/internal/modules/collections/savedviews_test.go
+++ b/backend/internal/modules/collections/savedviews_test.go
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package collections
+
+// A saved view's filter is checked against the same vocabulary a dynamic list's
+// definition is, and at the same moment — when it is written. These cover the
+// decision the gate makes; that the refusal reaches the wire as a 422 is proven
+// over the real store in the integration suite.
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/fieldcatalog"
+)
+
+func TestASavedViewFilterNamingAnUnknownFieldIsRefused(t *testing.T) {
+	store := (&Store{}).WithFieldCatalog(stubFilterable{})
+
+	err := store.validateViewFilter(context.Background(), "people", map[string]any{
+		"filter": map[string]any{"field": "favourite_colour", "op": "eq", "value": "blue"},
+	})
+
+	var perr *storekit.PredicateError
+	if !errors.As(err, &perr) {
+		t.Fatalf("err = %v, want a PredicateError", err)
+	}
+	if perr.Code != storekit.CodeFilterFieldNotAllowed {
+		t.Errorf("code = %q, want %q", perr.Code, storekit.CodeFilterFieldNotAllowed)
+	}
+}
+
+// The vocabulary a view is checked against is this workspace's, custom columns
+// included — the same merge membership evaluation and export resolve. A gate
+// reading only the core fields would refuse a legitimate cf_ filter, which is a
+// worse failure than the one it was added to prevent.
+func TestASavedViewFilterOnACustomColumnIsAccepted(t *testing.T) {
+	store := (&Store{}).WithFieldCatalog(stubFilterable{cols: map[string][]fieldcatalog.Column{
+		"person": {{Name: "cf_tier", Type: fieldcatalog.TypeText}},
+	}})
+
+	err := store.validateViewFilter(context.Background(), "people", map[string]any{
+		"filter": map[string]any{"field": "cf_tier", "op": "eq", "value": "gold"},
+	})
+	if err != nil {
+		t.Fatalf("a filter on an active custom column was refused: %v", err)
+	}
+}
+
+// A view is columns, sort and grouping as much as it is a filter, so the three
+// states with nothing to check must pass rather than fail closed.
+func TestASavedViewWithNothingToValidateIsAccepted(t *testing.T) {
+	store := (&Store{}).WithFieldCatalog(stubFilterable{})
+	unknownField := map[string]any{"field": "favourite_colour", "op": "eq", "value": "blue"}
+
+	for _, c := range []struct {
+		name     string
+		resource string
+		query    map[string]any
+	}{
+		{"no filter state at all", "people", map[string]any{"columns": []any{"full_name"}}},
+		{"a cleared filter", "people", map[string]any{"filter": nil}},
+		{"a resource with no segment engine", "activities", map[string]any{"filter": unknownField}},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			if err := store.validateViewFilter(context.Background(), c.resource, c.query); err != nil {
+				t.Fatalf("refused: %v", err)
+			}
+		})
+	}
+}
+
+// Filter state that is not a tree at all is refused where it is written rather
+// than where it is read. The export path has always answered this; the point of
+// the gate is that both surfaces now answer it.
+func TestASavedViewFilterThatIsNotATreeIsRefused(t *testing.T) {
+	store := (&Store{}).WithFieldCatalog(stubFilterable{})
+
+	err := store.validateViewFilter(context.Background(), "people", map[string]any{
+		"filter": "owner_id eq me",
+	})
+
+	var bad *BadInputError
+	if !errors.As(err, &bad) {
+		t.Fatalf("err = %v, want a BadInputError", err)
+	}
+	if bad.Field != viewQueryField {
+		t.Errorf("field = %q, want %q", bad.Field, viewQueryField)
+	}
+}
+
+// nonFilterableViewResources are the saved-view resources that deliberately
+// have no segment engine: they are not predicate-leaf resources, so a view over
+// one carries view state without a filter this module can check. Named here so
+// the gate below can tell "intentionally unfilterable" from "forgotten".
+var nonFilterableViewResources = map[string]bool{
+	string(crmcontracts.SavedViewResourceActivities): true,
+	string(crmcontracts.SavedViewResourcePartners):   true,
+}
+
+// Derived from the CONTRACT's enum, in the direction that can actually fail.
+//
+// The hazard is a resource MISSING from viewResourceToEngine: validateViewFilter
+// passes it through unchecked while SavedViewFilterSource refuses it at export
+// — the accepted-at-write, refused-at-read split this gate exists to close.
+// Iterating the map instead only proves its existing entries are live, which is
+// the one direction that cannot reintroduce the bug. So every contract member
+// must be either filterable or listed as deliberately not.
+func TestEveryViewResourceIsFilterableOrDeclaredOtherwise(t *testing.T) {
+	for _, resource := range []crmcontracts.SavedViewResource{
+		crmcontracts.SavedViewResourceActivities,
+		crmcontracts.SavedViewResourceDeals,
+		crmcontracts.SavedViewResourceLeads,
+		crmcontracts.SavedViewResourceOrganizations,
+		crmcontracts.SavedViewResourcePartners,
+		crmcontracts.SavedViewResourcePeople,
+		crmcontracts.SavedViewResourceProjects,
+	} {
+		name := string(resource)
+		key, filterable := viewResourceToEngine[name]
+		switch {
+		case filterable && nonFilterableViewResources[name]:
+			t.Errorf("view resource %q is both mapped to an engine and declared unfilterable", name)
+		case filterable:
+			if _, live := segmentEngines[key]; !live {
+				t.Errorf("view resource %q maps to engine key %q, which has no segment engine", name, key)
+			}
+		case !nonFilterableViewResources[name]:
+			t.Errorf("view resource %q has no engine and is not declared unfilterable, so a view over it accepts any filter at write and is refused at export", name)
+		}
+	}
+}

--- a/backend/internal/modules/collections/vocab.go
+++ b/backend/internal/modules/collections/vocab.go
@@ -6,6 +6,7 @@ package collections
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"github.com/jackc/pgx/v5"
@@ -247,10 +248,19 @@ func customField(column fieldcatalog.Column) (storekit.Field, bool) {
 	return storekit.Field{Expr: `t.` + pgx.Identifier{column.Name}.Sanitize(), Type: fieldType}, true
 }
 
-// predicateFromDefinition decodes a dynamic list's stored `definition`
-// jsonb into the canonical predicate tree. The definition IS the filter
-// tree (and/or/field/op/value) — no wrapper — so the round-trip is a
-// direct re-marshal into storekit.Predicate.
+// errNotAFilterTree is what a jsonb value that does not decode into the
+// canonical predicate comes back as. It deliberately carries no wire field:
+// which field to name — or whether to name one at all — is the caller's
+// question, not this decoder's. The same tree arrives under `definition` from
+// a dynamic list, inside `query` from a saved view, and from neither on an
+// export or a membership read, where the caller sent only an id and a field
+// error would tell them to fix something they never wrote.
+var errNotAFilterTree = errors.New("not a valid filter tree")
+
+// predicateFromDefinition decodes a stored filter tree jsonb into the
+// canonical predicate. The stored value IS the tree (and/or/field/op/value) —
+// no wrapper — so the round-trip is a direct re-marshal into
+// storekit.Predicate.
 func predicateFromDefinition(def map[string]any) (storekit.Predicate, error) {
 	raw, err := json.Marshal(def)
 	if err != nil {
@@ -258,7 +268,17 @@ func predicateFromDefinition(def map[string]any) (storekit.Predicate, error) {
 	}
 	var p storekit.Predicate
 	if err := json.Unmarshal(raw, &p); err != nil {
-		return storekit.Predicate{}, &BadInputError{Field: "definition", Reason: "is not a valid filter tree"}
+		return storekit.Predicate{}, errNotAFilterTree
 	}
 	return p, nil
+}
+
+// asFieldFault dresses an undecodable tree as the 422 naming the caller's own
+// wire field. Everything else passes through untouched: the tree's SHAPE is
+// the only part of this a caller can fix.
+func asFieldFault(err error, field string) error {
+	if errors.Is(err, errNotAFilterTree) {
+		return &BadInputError{Field: field, Reason: "is not a valid filter tree"}
+	}
+	return err
 }

--- a/backend/internal/modules/collections/vocab.go
+++ b/backend/internal/modules/collections/vocab.go
@@ -273,12 +273,6 @@ func predicateFromDefinition(def map[string]any) (storekit.Predicate, error) {
 	return p, nil
 }
 
-// asFieldFault dresses an undecodable tree as the 422 naming the caller's own
-// wire field. Everything else passes through untouched: the tree's SHAPE is
-// the only part of this a caller can fix.
-func asFieldFault(err error, field string) error {
-	if errors.Is(err, errNotAFilterTree) {
-		return &BadInputError{Field: field, Reason: "is not a valid filter tree"}
-	}
-	return err
-}
+// The one caller that dresses this as a field fault is compileForValidation,
+// where the caller genuinely sent the tree; every read path wraps it as the
+// invariant break it is instead.


### PR DESCRIPTION
Closes #1273.

A saved view's filter was never checked against the vocabulary at write. The first thing that ever looked at it was an export — so a view could be saved naming a field that is not filterable, and its author found out from a surface they reached much later, if ever.

It is validated at create **and** update, the way `CreateList` validates a dynamic list's definition. Both, because a create-time gate one PATCH walks around is not a gate.

### The ordering is the subtle part

On update the resource comes from the stored row, so the view is read **before** the write transaction opens and the vocabulary resolved outside any transaction. Resolving it inside would have `SegmentEngine` take a second connection from the pool while the write holds one — the deadlock shape two sibling seams already spell out, and one this repo has been bitten by.

My first version of this PR claimed the new integration test pinned that ordering. **It did not, and both reviewers caught it independently.** The store it builds has no field catalogue wired, so `SegmentEngine` returns the core vocabulary and never reaches for a second connection; moving the resolution inside the transaction would have left every test green.

The obligation now has a gate covering all three of its call sites rather than two — the saved-view arms join `dynamicsegment_singleconn_integration_test.go`, where a pool capped at one connection makes the failure deterministic instead of load-dependent:

```
creating the view on the caller's only connection:
  read the custom-field vocabulary for person: pg: begin: context deadline exceeded
--- FAIL: TestSavedViewValidatesItsFilterOnTheCallersOnlyConnection (22.07s)
```

### Three states pass through unvalidated

Each because there is nothing to check: a view with no filter (a view is columns, sort and grouping too), a filter of `null` (how a client spells "cleared" — now read the same way at export, which previously called it "not a filter tree"), and a resource with no segment engine.

The last is held honest by a gate derived from the **contract's** resource enum: every member must be filterable or declared otherwise. Iterating the map instead — which is what I wrote first — only proves its existing entries are live, the one direction that cannot reintroduce the bug. Verified by dropping `projects` from the map.

### A refusal that named the wrong field

`predicateFromDefinition` answered `definition` for every caller, so a saved view was told to fix a field its payload does not carry. The decode now returns a sentinel with no wire field and each caller names its own — `definition`, `query`, `view_id`, `list_id` — while a membership read, whose caller sent only an id, surfaces a stored tree that no longer decodes as the invariant break it is rather than as a field fault.

### Also

An archived view is refused as not-found **before** its filter is checked, so the gate cannot be used to probe for archived views that exist. The security review confirmed existence-hiding is unchanged across all four states (absent, another user's, archived, present).

Two things recorded rather than fixed:

- With `If-Match` set, an invalid filter now 422s before the version conflict is seen. Nothing is written either way, so no lost update — but a client doing optimistic concurrency learns about the filter first.
- `UpdateSavedView` with a `query` now also requires `saved_view:read`. Every seeded role has both, so this is fail-closed and invisible today.

Filed on the way past: #1484 — a saved view over `projects` is contract-valid and refused by the database, because the `resource` CHECK admits six of the enum's seven members. Pre-existing; verified against a live migrated template.

`make check-backend` green on the rebased tree.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validates a saved view’s filter at write (create and update) against the resource vocabulary; previously only exports validated, allowing invalid filters to be stored. Read paths now treat stored filter decode failures as server errors.

- Resolves the vocabulary outside write transactions to avoid pool deadlocks; single-connection tests pin create and update ordering.
- Treats `query.filter` as absent when missing or `null`; a non-tree filter returns 422 naming `query`.
- Export by saved view or list: static lists, filterless/null-filter views, and malformed ids return 422 naming `list_id` or `view_id`; empty selections export a header row; stored-tree decode failures are server errors.
- Per-surface field naming: decoder returns a sentinel so callers name `definition`, `query`, `view_id`, or `list_id`.
- Update with a `query` requires `saved_view:read` as well as `saved_view:update`; archived views return not-found before validation to avoid existence leaks.
- Contract/DB checks: unit asserts every view resource is filterable or declared otherwise; integration compares the `saved_view.resource` CHECK to the contract and records the known `projects` divergence (#1484).

<sup>Written for commit 43d6afbd0b43fcbab92d1aa2af91ebbde9c12823. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1485?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Saved views now validate filters when created or updated.
  - Invalid fields and non-filter-tree values return clearer, field-specific errors.
  - Rejected updates preserve previously saved queries.
  - Archived saved views correctly return not-found responses.
  - Exports handle missing or invalid filters consistently, including empty results.
  - Dynamic-list errors identify the affected list for easier troubleshooting.
  - Custom-field filters and saved-view operations now apply correct permissions.
  - Filtered exports now return valid empty CSV results when no records match.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->