### PR TITLE
refactor(briefs): the reader caches drop the tenant column (ADR-0091 §8 phase D)

### DIFF
--- a/backend/internal/compose/briefs/briefstore.go
+++ b/backend/internal/compose/briefs/briefstore.go
@@ -91,11 +91,10 @@ func (e *BriefEngine) SnapshotRun(ctx context.Context, now time.Time) (BriefRun,
 	}
 	queueDeals := make([]ids.UUID, 0, len(ranking.Queue))
 	err = database.WithWorkspaceTx(ctx, e.pool, func(tx pgx.Tx) error {
-		ws := storekit.MustWorkspace(ctx)
 		if _, err := tx.Exec(ctx, `
-			INSERT INTO brief_run (id, workspace_id, user_id, generated_at, as_of, candidate_count, revenue_norm_minor)
-			VALUES ($1, $2, $3, $4, $5, $6, $7)`,
-			run.ID, ws, run.UserID, run.GeneratedAt, run.AsOf, run.CandidateCount, run.RevenueNormMinor); err != nil {
+			INSERT INTO brief_run (id, user_id, generated_at, as_of, candidate_count, revenue_norm_minor)
+			VALUES ($1, $2, $3, $4, $5, $6)`,
+			run.ID, run.UserID, run.GeneratedAt, run.AsOf, run.CandidateCount, run.RevenueNormMinor); err != nil {
 			return err
 		}
 		for i, item := range ranking.Queue {
@@ -113,9 +112,9 @@ func (e *BriefEngine) SnapshotRun(ctx context.Context, now time.Time) (BriefRun,
 				State:       briefStateNew,
 			}
 			if _, err := tx.Exec(ctx, `
-				INSERT INTO brief_item (id, workspace_id, brief_run_id, deal_id, rank, composite, feature_vector, evidence_ids, state)
-				VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
-				persisted.ID, ws, run.ID, persisted.DealID, persisted.Rank,
+				INSERT INTO brief_item (id, brief_run_id, deal_id, rank, composite, feature_vector, evidence_ids, state)
+				VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+				persisted.ID, run.ID, persisted.DealID, persisted.Rank,
 				persisted.Composite, features, persisted.EvidenceIDs, briefStateNew); err != nil {
 				return err
 			}

--- a/backend/internal/compose/integration/growthfit_e2e_integration_test.go
+++ b/backend/internal/compose/integration/growthfit_e2e_integration_test.go
@@ -260,8 +260,8 @@ func giveTheCachedRowToAnotherReader(t *testing.T, e *apptest.AppEnv, orgID stri
 		`UPDATE org_growth_fit
 		    SET user_id = $1,
 		        payload = jsonb_set(payload, '{band}', to_jsonb($2::text))
-		  WHERE workspace_id = $3 AND organization_id = $4 AND user_id = $5`,
-		other, otherReadersBand, workspaceID, orgID, acting)
+		  WHERE organization_id = $3 AND user_id = $4`,
+		other, otherReadersBand, orgID, acting)
 	if err != nil {
 		t.Fatalf("hand the cached row to the other reader: %v", err)
 	}

--- a/backend/internal/compose/orgbrief/service.go
+++ b/backend/internal/compose/orgbrief/service.go
@@ -29,7 +29,6 @@ import (
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
-	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
@@ -325,15 +324,15 @@ func (s *Service) save(ctx context.Context, userID ids.UserID, orgID ids.Organiz
 	}
 	return database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
 		_, err := tx.Exec(ctx, `
-			INSERT INTO org_brief (workspace_id, user_id, organization_id, fingerprint,
+			INSERT INTO org_brief (user_id, organization_id, fingerprint,
 			                       generated_at, generated_by, payload)
-			VALUES ($1, $2, $3, $4, $5, $6, $7)
+			VALUES ($1, $2, $3, $4, $5, $6)
 			ON CONFLICT (user_id, organization_id) DO UPDATE
 			SET fingerprint = EXCLUDED.fingerprint,
 			    generated_at = EXCLUDED.generated_at,
 			    generated_by = EXCLUDED.generated_by,
 			    payload = EXCLUDED.payload`,
-			storekit.MustWorkspace(ctx), userID, orgID, brief.Fingerprint,
+			userID, orgID, brief.Fingerprint,
 			brief.GeneratedAt, brief.GeneratedBy, payload)
 		return err
 	})

--- a/backend/internal/compose/orgdossier/cache.go
+++ b/backend/internal/compose/orgdossier/cache.go
@@ -22,7 +22,6 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/gradionhq/margince/backend/internal/platform/database"
-	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
@@ -48,9 +47,9 @@ var dossierCache = readerCache{
 		SELECT fingerprint, generated_at, generated_by, payload FROM org_dossier
 		 WHERE user_id = $1 AND organization_id = $2`,
 	upsertOne: `
-		INSERT INTO org_dossier (workspace_id, user_id, organization_id, fingerprint,
+		INSERT INTO org_dossier (user_id, organization_id, fingerprint,
 		                         generated_at, generated_by, payload)
-		VALUES ($1, $2, $3, $4, $5, $6, $7)
+		VALUES ($1, $2, $3, $4, $5, $6)
 		ON CONFLICT (user_id, organization_id) DO UPDATE
 		SET fingerprint = EXCLUDED.fingerprint,
 		    generated_at = EXCLUDED.generated_at,
@@ -63,9 +62,9 @@ var growthFitCache = readerCache{
 		SELECT fingerprint, generated_at, generated_by, payload FROM org_growth_fit
 		 WHERE user_id = $1 AND organization_id = $2`,
 	upsertOne: `
-		INSERT INTO org_growth_fit (workspace_id, user_id, organization_id, fingerprint,
+		INSERT INTO org_growth_fit (user_id, organization_id, fingerprint,
 		                            generated_at, generated_by, payload)
-		VALUES ($1, $2, $3, $4, $5, $6, $7)
+		VALUES ($1, $2, $3, $4, $5, $6)
 		ON CONFLICT (user_id, organization_id) DO UPDATE
 		SET fingerprint = EXCLUDED.fingerprint,
 		    generated_at = EXCLUDED.generated_at,
@@ -100,7 +99,7 @@ func (c readerCache) save(ctx context.Context, pool *pgxpool.Pool,
 ) error {
 	return database.WithWorkspaceTx(ctx, pool, func(tx pgx.Tx) error {
 		if _, err := tx.Exec(ctx, c.upsertOne,
-			storekit.MustWorkspace(ctx), userID, orgID, written.Fingerprint,
+			userID, orgID, written.Fingerprint,
 			written.GeneratedAt, written.GeneratedBy, written.Payload); err != nil {
 			return fmt.Errorf("cache the assembly: %w", err)
 		}

--- a/backend/internal/compose/personbrief/service.go
+++ b/backend/internal/compose/personbrief/service.go
@@ -30,7 +30,6 @@ import (
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
-	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
@@ -214,15 +213,15 @@ func (s *Service) save(ctx context.Context, userID ids.UserID, personID ids.Pers
 	}
 	return database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
 		_, err := tx.Exec(ctx, `
-			INSERT INTO person_brief (workspace_id, user_id, person_id, fingerprint,
+			INSERT INTO person_brief (user_id, person_id, fingerprint,
 			                          generated_at, generated_by, payload)
-			VALUES ($1, $2, $3, $4, $5, $6, $7)
+			VALUES ($1, $2, $3, $4, $5, $6)
 			ON CONFLICT (user_id, person_id) DO UPDATE
 			SET fingerprint = EXCLUDED.fingerprint,
 			    generated_at = EXCLUDED.generated_at,
 			    generated_by = EXCLUDED.generated_by,
 			    payload = EXCLUDED.payload`,
-			storekit.MustWorkspace(ctx), userID, personID, brief.Fingerprint,
+			userID, personID, brief.Fingerprint,
 			brief.GeneratedAt, brief.GeneratedBy, payload)
 		return err
 	})

--- a/backend/migrations/core/0281_briefs_drop_workspace.down.sql
+++ b/backend/migrations/core/0281_briefs_drop_workspace.down.sql
@@ -1,0 +1,72 @@
+-- Reverse of 0281: the six cache tables carry the tenant column again.
+--
+-- The backfill reads the LIVE workspace, and the predicate is the point: 0217's
+-- pre-flight refuses to run against a database holding more than one workspace
+-- with archived_at IS NULL, so there is exactly one live row — but an
+-- installation that resolved to one organization by ARCHIVING the others still
+-- has those rows, and 0217 names that residue explicitly. Ordering by
+-- created_at alone would hand every restored row to whichever workspace
+-- happened to be created first, archived or not.
+--
+-- If no live workspace exists and a table is not empty, SET NOT NULL fails and
+-- the rollback stops — the honest outcome, since no value this migration could
+-- write would be true.
+
+ALTER TABLE brief_run ADD COLUMN workspace_id uuid;
+ALTER TABLE brief_item ADD COLUMN workspace_id uuid;
+ALTER TABLE org_brief ADD COLUMN workspace_id uuid;
+ALTER TABLE org_dossier ADD COLUMN workspace_id uuid;
+ALTER TABLE org_growth_fit ADD COLUMN workspace_id uuid;
+ALTER TABLE person_brief ADD COLUMN workspace_id uuid;
+
+DO $$
+DECLARE ws uuid := (SELECT id FROM workspace WHERE archived_at IS NULL ORDER BY created_at LIMIT 1);
+BEGIN
+  UPDATE brief_run SET workspace_id = ws;
+  UPDATE brief_item SET workspace_id = ws;
+  UPDATE org_brief SET workspace_id = ws;
+  UPDATE org_dossier SET workspace_id = ws;
+  UPDATE org_growth_fit SET workspace_id = ws;
+  UPDATE person_brief SET workspace_id = ws;
+END $$;
+
+ALTER TABLE brief_run ALTER COLUMN workspace_id SET NOT NULL;
+ALTER TABLE brief_item ALTER COLUMN workspace_id SET NOT NULL;
+ALTER TABLE org_brief ALTER COLUMN workspace_id SET NOT NULL;
+ALTER TABLE org_dossier ALTER COLUMN workspace_id SET NOT NULL;
+ALTER TABLE org_growth_fit ALTER COLUMN workspace_id SET NOT NULL;
+ALTER TABLE person_brief ALTER COLUMN workspace_id SET NOT NULL;
+
+ALTER TABLE brief_run ADD CONSTRAINT brief_run_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE brief_item ADD CONSTRAINT brief_item_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE org_brief ADD CONSTRAINT org_brief_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE org_dossier ADD CONSTRAINT org_dossier_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE org_growth_fit ADD CONSTRAINT org_growth_fit_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE person_brief ADD CONSTRAINT person_brief_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+
+ALTER TABLE brief_run ADD CONSTRAINT uq_brief_run_ws_id UNIQUE (id);
+
+DROP INDEX idx_brief_item_deal;
+CREATE INDEX idx_brief_item_deal ON brief_item (workspace_id, deal_id) WHERE state <> 'new';
+
+DROP INDEX idx_brief_run_user;
+CREATE INDEX idx_brief_run_user ON brief_run (workspace_id, user_id, generated_at DESC);
+
+DROP INDEX org_brief_organization_ix;
+CREATE INDEX org_brief_organization_ix ON org_brief (workspace_id, organization_id);
+
+DROP INDEX org_dossier_organization_ix;
+CREATE INDEX org_dossier_organization_ix ON org_dossier (workspace_id, organization_id);
+
+DROP INDEX org_growth_fit_organization_ix;
+CREATE INDEX org_growth_fit_organization_ix ON org_growth_fit (workspace_id, organization_id);
+
+DROP INDEX person_brief_person_ix;
+CREATE INDEX person_brief_person_ix ON person_brief (workspace_id, person_id);
+

--- a/backend/migrations/core/0281_briefs_drop_workspace.up.sql
+++ b/backend/migrations/core/0281_briefs_drop_workspace.up.sql
@@ -1,0 +1,39 @@
+-- 0281: the brief and dossier caches drop the tenant column
+-- (ADR-0091 §8 phase D).
+--
+-- Six tables, six indexes, one redundant unique. Every one of these is a
+-- per-USER cache of a generated read — a morning brief, an account dossier, a
+-- growth-fit read — so the key that matters is the reader and the record, and
+-- three of them already say so: org_dossier, org_growth_fit and person_brief
+-- are keyed (user_id, <record>) with the tenant nowhere in the key.
+--
+-- uq_brief_run_ws_id is phase B's leftover: a second copy of brief_run's own
+-- primary key, created by 0019 as a composite foreign-key target that phase C
+-- has since rewritten away.
+
+DROP INDEX idx_brief_item_deal;
+CREATE INDEX idx_brief_item_deal ON brief_item (deal_id) WHERE state <> 'new';
+
+DROP INDEX idx_brief_run_user;
+CREATE INDEX idx_brief_run_user ON brief_run (user_id, generated_at DESC);
+
+DROP INDEX org_brief_organization_ix;
+CREATE INDEX org_brief_organization_ix ON org_brief (organization_id);
+
+DROP INDEX org_dossier_organization_ix;
+CREATE INDEX org_dossier_organization_ix ON org_dossier (organization_id);
+
+DROP INDEX org_growth_fit_organization_ix;
+CREATE INDEX org_growth_fit_organization_ix ON org_growth_fit (organization_id);
+
+DROP INDEX person_brief_person_ix;
+CREATE INDEX person_brief_person_ix ON person_brief (person_id);
+
+ALTER TABLE brief_run DROP CONSTRAINT uq_brief_run_ws_id;
+
+ALTER TABLE brief_run DROP COLUMN workspace_id;
+ALTER TABLE brief_item DROP COLUMN workspace_id;
+ALTER TABLE org_brief DROP COLUMN workspace_id;
+ALTER TABLE org_dossier DROP COLUMN workspace_id;
+ALTER TABLE org_growth_fit DROP COLUMN workspace_id;
+ALTER TABLE person_brief DROP COLUMN workspace_id;


### PR DESCRIPTION
Six tables, six indexes, one redundant unique — `brief_run`, `brief_item`, `org_brief`, `org_dossier`, `org_growth_fit`, `person_brief`.

Every one is a **per-user cache of a generated read** — a morning brief, an account dossier, a growth-fit assessment — so the key that matters is the reader and the record. Three of them already said so: `org_dossier`, `org_growth_fit` and `person_brief` are keyed `(user_id, <record>)` with the tenant nowhere in the key.

`uq_brief_run_ws_id` is phase B's leftover: a second copy of `brief_run`'s own primary key, created by `0019` as a composite foreign-key target that phase C has since rewritten away.

## The one fixture worth noting

The growth-fit e2e hands a cached row to a **different reader** to prove the cache is keyed on *read* rather than on *write*. Its `UPDATE` located the row by workspace and reader; the workspace half is gone, the reader half is the whole point, and the test still fails if the read serves another reader's assessment.

## Verification

- Lane applied to an empty database; the down restores all six columns with their foreign keys, the unique and all six wide indexes.
- `make check-backend` green; `make test-integration` OK, 0 skips, 41 packages.

Phase D: 103 → 97 tables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drops `workspace_id` from the six reader-cache tables and removes `uq_brief_run_ws_id`, making briefs/dossiers tenant-agnostic and keyed by user+record only (ADR-0091 §8 phase D). Old behavior keyed caches by workspace+user; new behavior keys by user (and record) with narrower indexes; code stops passing workspace, and the growth-fit e2e updates its predicate accordingly.

- Ensures `brief_run`, `brief_item`, `org_brief`, `org_dossier`, `org_growth_fit`, and `person_brief` persist and query without tenant.
- Removes redundant unique `uq_brief_run_ws_id`; re-creates indexes without workspace.
- Updates writes in `briefstore.go`, `orgbrief/service.go`, `orgdossier/cache.go`, and `personbrief/service.go` to drop `storekit.MustWorkspace(ctx)`.
- Adjusts the growth-fit e2e to locate the cached row by organization+user only.

**Migration and rollout**
- Apply migration `0281_briefs_drop_workspace.up.sql`; use the down to restore tenant columns, FKs, the unique, and wide indexes if needed.
- Required: remove any workspace predicates from reads/writes to these caches; use `(user_id, <record>)` consistently.
- No data backfill needed on up; down backfills `workspace_id` to the single live workspace as guarded by 0217.

<sup>Written for commit 41c492409532d574ae8ef5e04d700d3b6fc6dad9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1486?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Simplified brief and dossier data handling by removing redundant workspace-specific storage and indexing.
  * Preserved existing user, organization, deal, ranking, evidence, and content details.
  * Updated cache and brief records to use streamlined identifiers for more consistent data access.

* **Database**
  * Added migration support for applying and safely reverting the updated brief and dossier schema.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->