### PR TITLE
fix(deals): an offer figure past int64 refuses instead of wrapping negative

### DIFF
--- a/backend/internal/modules/deals/offer_totals.go
+++ b/backend/internal/modules/deals/offer_totals.go
@@ -14,6 +14,9 @@ import (
 	"fmt"
 	"math/big"
 	"strconv"
+	"strings"
+
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 )
 
 // OfferLineInput is one line as the engine consumes it: exact decimal
@@ -52,6 +55,34 @@ func (e *DecimalFieldError) FieldFault() (field, code, message string) {
 	return e.Field, "invalid_decimal", e.Error()
 }
 
+// MoneyRangeError maps to 422: a derived figure that int64 minor units
+// cannot represent. The engine refuses instead of narrowing, because
+// big.Int.Int64() on an out-of-range value yields the low 64 bits — a
+// plausible, frequently negative number that the offer row, the PDF and
+// the pipeline rollup all go on to treat as real money.
+type MoneyRangeError struct {
+	Figure string   // the derived value that left the range (line_net_minor, gross_minor, …)
+	Fields []string // the contract inputs whose magnitude the caller can lower
+}
+
+func (e *MoneyRangeError) Error() string {
+	return e.Figure + " exceeds the money range this system represents exactly (int64 minor units); lower " +
+		strings.Join(e.Fields, " or ")
+}
+
+// FieldFaults names every input that feeds the figure: the figure itself
+// is derived, so lowering any one of them brings it back into range and
+// pointing at a single one would be an arbitrary choice among equals.
+func (e *MoneyRangeError) FieldFaults() []apperrors.FieldRefusal {
+	refusals := make([]apperrors.FieldRefusal, 0, len(e.Fields))
+	for _, field := range e.Fields {
+		refusals = append(refusals, apperrors.FieldRefusal{
+			Field: field, Code: "money_out_of_range", Message: e.Error(),
+		})
+	}
+	return refusals
+}
+
 // LineTotals derives one line's figures (formulas: line_net =
 // round(qty × unit_price × (1 − discount_pct/100)), line_tax =
 // round(line_net × tax_rate/100), line_total = line_net + line_tax).
@@ -75,14 +106,25 @@ func LineTotals(line OfferLineInput) (LineFigures, error) {
 	net.Mul(net, qty)
 	net.Mul(net, keep)
 	net.Quo(net, hundred)
-	netMinor := roundHalfUp(net)
+	netMinor, err := minorFromBig(roundHalfUp(net), "line_net_minor", "quantity", "unit_price_minor")
+	if err != nil {
+		return LineFigures{}, err
+	}
 
 	tax := new(big.Rat).SetInt64(netMinor)
 	tax.Mul(tax, taxRate)
 	tax.Quo(tax, hundred)
-	taxMinor := roundHalfUp(tax)
+	taxMinor, err := minorFromBig(roundHalfUp(tax), "line_tax_minor", "quantity", "unit_price_minor", "tax_rate")
+	if err != nil {
+		return LineFigures{}, err
+	}
 
-	return LineFigures{NetMinor: netMinor, TaxMinor: taxMinor, TotalMinor: netMinor + taxMinor}, nil
+	total := new(big.Int).Add(big.NewInt(netMinor), big.NewInt(taxMinor))
+	totalMinor, err := minorFromBig(total, "line_total_minor", "quantity", "unit_price_minor")
+	if err != nil {
+		return LineFigures{}, err
+	}
+	return LineFigures{NetMinor: netMinor, TaxMinor: taxMinor, TotalMinor: totalMinor}, nil
 }
 
 // statefulOfferLine pairs a line's money inputs with its proposal state
@@ -107,18 +149,44 @@ func acceptedLines(lines []statefulOfferLine) []OfferLineInput {
 
 // OfferTotals sums the per-line figures: net/tax/gross are Σ over lines,
 // so the stored totals reconcile to the displayed lines with zero drift.
+// The sums accumulate in exact big integers because lines that each fit
+// int64 can still add past it — a native += would wrap on the offer row
+// even though every line it reconciles to reads correctly.
 func OfferTotals(lines []OfferLineInput) (OfferFigures, error) {
-	var out OfferFigures
+	net, tax, gross := new(big.Int), new(big.Int), new(big.Int)
 	for i, line := range lines {
 		fig, err := LineTotals(line)
 		if err != nil {
 			return OfferFigures{}, fmt.Errorf("line %d: %w", i+1, err)
 		}
-		out.NetMinor += fig.NetMinor
-		out.TaxMinor += fig.TaxMinor
-		out.GrossMinor += fig.TotalMinor
+		net.Add(net, big.NewInt(fig.NetMinor))
+		tax.Add(tax, big.NewInt(fig.TaxMinor))
+		gross.Add(gross, big.NewInt(fig.TotalMinor))
+	}
+
+	var out OfferFigures
+	var err error
+	if out.NetMinor, err = minorFromBig(net, "net_minor", "line_items"); err != nil {
+		return OfferFigures{}, err
+	}
+	if out.TaxMinor, err = minorFromBig(tax, "tax_minor", "line_items"); err != nil {
+		return OfferFigures{}, err
+	}
+	if out.GrossMinor, err = minorFromBig(gross, "gross_minor", "line_items"); err != nil {
+		return OfferFigures{}, err
 	}
 	return out, nil
+}
+
+// minorFromBig narrows an exact figure to the int64 minor units the money
+// columns hold, or refuses naming the inputs to lower. Every derived value
+// in this engine passes through here: it is the ONE place that decides an
+// out-of-range total is a refusal rather than a wrapped number.
+func minorFromBig(v *big.Int, figure string, fields ...string) (int64, error) {
+	if !v.IsInt64() {
+		return 0, &MoneyRangeError{Figure: figure, Fields: fields}
+	}
+	return v.Int64(), nil
 }
 
 // ratFromDecimal parses a plain decimal string exactly. big.Rat's
@@ -145,7 +213,11 @@ func ratFromDecimal(field, value string) (*big.Rat, error) {
 // > 0, price ≥ 0, discount ≤ 100, tax ≥ 0 — DB CHECKs), so the
 // negative branch cannot arise; it is still handled symmetrically
 // rather than silently misrounding a future caller.
-func roundHalfUp(x *big.Rat) int64 {
+//
+// The result stays an exact big integer: quantity × unit_price_minor is
+// unbounded by either column, so narrowing belongs to minorFromBig,
+// which refuses what int64 cannot hold instead of wrapping it.
+func roundHalfUp(x *big.Rat) *big.Int {
 	num := new(big.Int).Set(x.Num())
 	den := x.Denom() // always > 0 for big.Rat
 	twice := num.Mul(num, big.NewInt(2))
@@ -154,10 +226,9 @@ func roundHalfUp(x *big.Rat) int64 {
 	} else {
 		twice.Sub(twice, den)
 	}
-	q := new(big.Int).Quo(twice, new(big.Int).Mul(den, big.NewInt(2)))
 	// Quo truncates toward zero; for negatives, floor(x+1/2) semantics
 	// mirror to ceil(x−1/2), which truncation already yields here.
-	return q.Int64()
+	return new(big.Int).Quo(twice, new(big.Int).Mul(den, big.NewInt(2)))
 }
 
 // formatQuantity renders the contract's float64 quantity at the DB's

--- a/backend/internal/modules/deals/offer_totals.go
+++ b/backend/internal/modules/deals/offer_totals.go
@@ -12,9 +12,9 @@ package deals
 
 import (
 	"fmt"
+	"math"
 	"math/big"
 	"strconv"
-	"strings"
 
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 )
@@ -55,29 +55,40 @@ func (e *DecimalFieldError) FieldFault() (field, code, message string) {
 	return e.Field, "invalid_decimal", e.Error()
 }
 
-// MoneyRangeError maps to 422: a derived figure that int64 minor units
-// cannot represent. The engine refuses instead of narrowing, because
-// big.Int.Int64() on an out-of-range value yields the low 64 bits — a
-// plausible, frequently negative number that the offer row, the PDF and
-// the pipeline rollup all go on to treat as real money.
+// MoneyRangeError maps to 422: a derived figure larger than the integer
+// minor units every money column and contract field is declared in
+// (bigint / format:int64). The engine refuses instead of narrowing,
+// because big.Int.Int64() on an out-of-range value yields the low 64
+// bits — a plausible, frequently negative number the offer row, the PDF
+// and the pipeline rollup all go on to treat as real money.
+//
+// It states the INSTALLATION's limit and does not instruct the caller to
+// shrink anything. The ceiling is not a small number in any currency this
+// money model serves — a zero-decimal currency spends it one minor unit
+// at a time (values.MinorUnitDigits: VND, JPY, KRW are 0), which still
+// leaves a single line room for several times world GDP — so a figure
+// that reaches it is either an overflow probe or an amount this model
+// genuinely cannot hold. Telling the second caller to lower their amount
+// would be telling them to falsify it.
 type MoneyRangeError struct {
 	Figure string   // the derived value that left the range (line_net_minor, gross_minor, …)
-	Fields []string // the contract inputs whose magnitude the caller can lower
+	Fields []string // the contract inputs that feed the figure, so the caller can locate it
 }
 
 func (e *MoneyRangeError) Error() string {
-	return e.Figure + " exceeds the money range this system represents exactly (int64 minor units); lower " +
-		strings.Join(e.Fields, " or ")
+	return e.Figure + " is larger than this installation stores exactly (integer minor units, at most " +
+		strconv.FormatInt(math.MaxInt64, 10) + ")"
 }
 
-// FieldFaults names every input that feeds the figure: the figure itself
-// is derived, so lowering any one of them brings it back into range and
-// pointing at a single one would be an arbitrary choice among equals.
+// FieldFaults names every input that feeds the figure — which inputs
+// combined to produce it, not which one is wrong. The figure is derived,
+// so no single input is at fault, and a refusal that named just one would
+// point at an arbitrary member of the set.
 func (e *MoneyRangeError) FieldFaults() []apperrors.FieldRefusal {
 	refusals := make([]apperrors.FieldRefusal, 0, len(e.Fields))
 	for _, field := range e.Fields {
 		refusals = append(refusals, apperrors.FieldRefusal{
-			Field: field, Code: "money_out_of_range", Message: e.Error(),
+			Field: field, Code: "money_not_representable", Message: e.Error(),
 		})
 	}
 	return refusals
@@ -178,10 +189,11 @@ func OfferTotals(lines []OfferLineInput) (OfferFigures, error) {
 	return out, nil
 }
 
-// minorFromBig narrows an exact figure to the int64 minor units the money
-// columns hold, or refuses naming the inputs to lower. Every derived value
-// in this engine passes through here: it is the ONE place that decides an
-// out-of-range total is a refusal rather than a wrapped number.
+// minorFromBig narrows an exact figure to the integer minor units the
+// money columns hold, or refuses naming the inputs that produced it.
+// Every derived value in this engine passes through here: it is the ONE
+// place that decides an unrepresentable total is a refusal rather than a
+// wrapped number.
 func minorFromBig(v *big.Int, figure string, fields ...string) (int64, error) {
 	if !v.IsInt64() {
 		return 0, &MoneyRangeError{Figure: figure, Fields: fields}

--- a/backend/internal/modules/deals/offer_totals_test.go
+++ b/backend/internal/modules/deals/offer_totals_test.go
@@ -4,9 +4,13 @@
 package deals
 
 import (
+	"errors"
 	"fmt"
+	"math"
 	"math/big"
 	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 )
 
 // The B-E03.18 golden cases: line_net = round(qty × unit_price ×
@@ -69,6 +73,119 @@ func TestLineTotalsRejectsMalformedDecimals(t *testing.T) {
 	} {
 		if _, err := LineTotals(bad); err == nil {
 			t.Errorf("LineTotals(%+v) accepted a malformed decimal", bad)
+		}
+	}
+}
+
+// A line whose figures leave the int64 minor-unit range is REFUSED, not
+// narrowed: big.Int.Int64() would hand back the low 64 bits, which for
+// the quantity × unit_price magnitudes both columns accept is routinely a
+// negative number the offer row, the PDF and the rollup then treat as
+// real money. The refusal classifies as a 422 naming the inputs to lower,
+// so it reads the same on REST and on the MCP tool surface.
+func TestLineTotalsRefusesFiguresOutsideTheMoneyRange(t *testing.T) {
+	cases := []struct {
+		name       string
+		line       OfferLineInput
+		wantFigure string
+	}{
+		{
+			name: "quantity times price wraps int64 into a negative net",
+			// 9e9 × 1e11 = 9e20, past int64's 9.22e18 ceiling.
+			line:       OfferLineInput{Quantity: "99999999999.000", UnitPriceMinor: 9_000_000_000, DiscountPct: "0.00", TaxRate: "0.00"},
+			wantFigure: "line_net_minor",
+		},
+		{
+			name: "a rate the numeric(5,2) column accepts takes the tax past the ceiling",
+			// net = MaxInt64 fits; net × 999.99 % does not.
+			line:       OfferLineInput{Quantity: "1.000", UnitPriceMinor: math.MaxInt64, DiscountPct: "0.00", TaxRate: "999.99"},
+			wantFigure: "line_tax_minor",
+		},
+		{
+			name: "net plus tax leaves the range both halves fit",
+			// net = MaxInt64, tax = 19 % of it; each is representable, the sum is not.
+			line:       OfferLineInput{Quantity: "1.000", UnitPriceMinor: math.MaxInt64, DiscountPct: "0.00", TaxRate: "19.00"},
+			wantFigure: "line_total_minor",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := LineTotals(tc.line)
+			if err == nil {
+				t.Fatalf("LineTotals accepted an unrepresentable line and returned %+v", got)
+			}
+			var rangeErr *MoneyRangeError
+			if !errors.As(err, &rangeErr) {
+				t.Fatalf("refusal is not a MoneyRangeError, so it reports as an internal fault: %v", err)
+			}
+			if rangeErr.Figure != tc.wantFigure {
+				t.Fatalf("refusal names figure %q, want %q", rangeErr.Figure, tc.wantFigure)
+			}
+			assertMoneyRangeIsClientFault(t, err)
+		})
+	}
+}
+
+// The positive control for the refusal above: the largest line the range
+// genuinely holds still computes, so the fence rejects overflow rather
+// than large-but-valid money.
+func TestLineTotalsAcceptsTheLargestRepresentableLine(t *testing.T) {
+	line := OfferLineInput{Quantity: "1.000", UnitPriceMinor: math.MaxInt64, DiscountPct: "0.00", TaxRate: "0.00"}
+	got, err := LineTotals(line)
+	if err != nil {
+		t.Fatalf("LineTotals(%+v): %v", line, err)
+	}
+	want := LineFigures{NetMinor: math.MaxInt64, TaxMinor: 0, TotalMinor: math.MaxInt64}
+	if got != want {
+		t.Fatalf("LineTotals(%+v) = %+v, want %+v", line, got, want)
+	}
+}
+
+// Lines that each fit int64 can still sum past it, so the offer-level
+// accumulation carries the same fence — a native += would wrap the stored
+// offer row while every line it is supposed to reconcile to reads right.
+func TestOfferTotalsRefuseASumOutsideTheMoneyRange(t *testing.T) {
+	half := OfferLineInput{Quantity: "1.000", UnitPriceMinor: math.MaxInt64 / 2, DiscountPct: "0.00", TaxRate: "0.00"}
+	lines := []OfferLineInput{half, half, half}
+	for _, line := range lines {
+		if _, err := LineTotals(line); err != nil {
+			t.Fatalf("a line the sum is built from must itself be representable: %v", err)
+		}
+	}
+
+	got, err := OfferTotals(lines)
+	if err == nil {
+		t.Fatalf("OfferTotals accepted an unrepresentable sum and returned %+v", got)
+	}
+	var rangeErr *MoneyRangeError
+	if !errors.As(err, &rangeErr) {
+		t.Fatalf("refusal is not a MoneyRangeError, so it reports as an internal fault: %v", err)
+	}
+	if rangeErr.Figure != "net_minor" {
+		t.Fatalf("refusal names figure %q, want %q", rangeErr.Figure, "net_minor")
+	}
+	assertMoneyRangeIsClientFault(t, err)
+}
+
+// assertMoneyRangeIsClientFault checks the refusal carries its own 422
+// verdict: it must name at least one input with the contract's machine
+// code, or the same defect answers as an internal fault off the REST path.
+func assertMoneyRangeIsClientFault(t *testing.T, err error) {
+	t.Helper()
+	var faults apperrors.FieldFaults
+	if !errors.As(err, &faults) {
+		t.Fatalf("refusal does not implement FieldFaults: %v", err)
+	}
+	refusals := faults.FieldFaults()
+	if len(refusals) == 0 {
+		t.Fatal("refusal names no input, so the caller is told nothing to lower")
+	}
+	for _, r := range refusals {
+		if r.Field == "" {
+			t.Errorf("refusal entry names no field: %+v", r)
+		}
+		if r.Code != "money_out_of_range" {
+			t.Errorf("refusal entry code = %q, want %q", r.Code, "money_out_of_range")
 		}
 	}
 }

--- a/backend/internal/modules/deals/offer_totals_test.go
+++ b/backend/internal/modules/deals/offer_totals_test.go
@@ -9,6 +9,8 @@ import (
 	"math"
 	"math/big"
 	"net/http"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/gradionhq/margince/backend/internal/platform/httperr"
@@ -83,8 +85,8 @@ func TestLineTotalsRejectsMalformedDecimals(t *testing.T) {
 // narrowed: big.Int.Int64() would hand back the low 64 bits, which for
 // the quantity × unit_price magnitudes both columns accept is routinely a
 // negative number the offer row, the PDF and the rollup then treat as
-// real money. The refusal classifies as a 422 naming the inputs to lower,
-// so it reads the same on REST and on the MCP tool surface.
+// real money. The refusal classifies as a 422 naming the inputs that fed
+// the figure, so it reads the same on REST and on the MCP tool surface.
 func TestLineTotalsRefusesFiguresOutsideTheMoneyRange(t *testing.T) {
 	cases := []struct {
 		name       string
@@ -174,10 +176,11 @@ func TestOfferTotalsRefuseASumOutsideTheMoneyRange(t *testing.T) {
 }
 
 // assertMoneyRangeIsClientFault checks what a CALLER observes, not which
-// type carried it: the refusal must classify as 422 naming the inputs to
-// lower, with the contract's machine code. Asserting the carrier instead
-// would pass even if the wire answer were an internal fault — which is
-// what every surface reports for an error outside the taxonomy.
+// type carried it: the refusal must classify as 422 naming the inputs
+// that fed the figure, with the contract's machine code. Asserting the
+// carrier instead would pass even if the wire answer were an internal
+// fault — which is what every surface reports for an error outside the
+// taxonomy.
 func assertMoneyRangeIsClientFault(t *testing.T, err error, fields ...string) {
 	t.Helper()
 	for _, field := range fields {
@@ -189,12 +192,35 @@ func assertMoneyRangeIsClientFault(t *testing.T, err error, fields ...string) {
 	}
 	if fault.Status != http.StatusUnprocessableEntity {
 		t.Errorf("an unrepresentable money figure answered status %d, want exactly 422 — the body is "+
-			"well-formed and the caller lowers a value they supplied", fault.Status)
+			"well-formed and the request cannot be stored as sent", fault.Status)
 	}
 	for _, refusal := range fault.Fields {
-		if refusal.Code != "money_out_of_range" {
+		if refusal.Code != "money_not_representable" {
 			t.Errorf("refusal for %s carries code %q, want %q — the code is what a client branches on",
-				refusal.Field, refusal.Code, "money_out_of_range")
+				refusal.Field, refusal.Code, "money_not_representable")
+		}
+		assertStatesTheLimitWithoutBlamingTheCaller(t, refusal.Message)
+	}
+}
+
+// assertStatesTheLimitWithoutBlamingTheCaller pins the framing, because
+// the framing is the decision here and it is the kind that regresses
+// silently. A high-magnitude currency (a zero-decimal one spends the
+// range one minor unit at a time) can reach this ceiling with an amount
+// that is entirely real, so the refusal must state what the installation
+// can store — telling that caller to reduce their figure would be telling
+// them to falsify it.
+func assertStatesTheLimitWithoutBlamingTheCaller(t *testing.T, message string) {
+	t.Helper()
+	ceiling := strconv.FormatInt(math.MaxInt64, 10)
+	if !strings.Contains(message, ceiling) {
+		t.Errorf("refusal %q does not state the ceiling %s, so the caller cannot tell what is storable",
+			message, ceiling)
+	}
+	for _, instruction := range []string{"lower ", "reduce ", "decrease "} {
+		if strings.Contains(strings.ToLower(message), instruction) {
+			t.Errorf("refusal %q instructs the caller to shrink a figure that may be legitimate; state the "+
+				"installation's limit instead", message)
 		}
 	}
 }

--- a/backend/internal/modules/deals/offer_totals_test.go
+++ b/backend/internal/modules/deals/offer_totals_test.go
@@ -8,9 +8,11 @@ import (
 	"fmt"
 	"math"
 	"math/big"
+	"net/http"
 	"testing"
 
-	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+	"github.com/gradionhq/margince/backend/internal/platform/httperr"
+	"github.com/gradionhq/margince/backend/internal/platform/httperr/faulttest"
 )
 
 // The B-E03.18 golden cases: line_net = round(qty × unit_price ×
@@ -88,24 +90,28 @@ func TestLineTotalsRefusesFiguresOutsideTheMoneyRange(t *testing.T) {
 		name       string
 		line       OfferLineInput
 		wantFigure string
+		wantFields []string
 	}{
 		{
 			name: "quantity times price wraps int64 into a negative net",
 			// 9e9 × 1e11 = 9e20, past int64's 9.22e18 ceiling.
 			line:       OfferLineInput{Quantity: "99999999999.000", UnitPriceMinor: 9_000_000_000, DiscountPct: "0.00", TaxRate: "0.00"},
 			wantFigure: "line_net_minor",
+			wantFields: []string{"quantity", "unit_price_minor"},
 		},
 		{
 			name: "a rate the numeric(5,2) column accepts takes the tax past the ceiling",
 			// net = MaxInt64 fits; net × 999.99 % does not.
 			line:       OfferLineInput{Quantity: "1.000", UnitPriceMinor: math.MaxInt64, DiscountPct: "0.00", TaxRate: "999.99"},
 			wantFigure: "line_tax_minor",
+			wantFields: []string{"quantity", "unit_price_minor", "tax_rate"},
 		},
 		{
 			name: "net plus tax leaves the range both halves fit",
 			// net = MaxInt64, tax = 19 % of it; each is representable, the sum is not.
 			line:       OfferLineInput{Quantity: "1.000", UnitPriceMinor: math.MaxInt64, DiscountPct: "0.00", TaxRate: "19.00"},
 			wantFigure: "line_total_minor",
+			wantFields: []string{"quantity", "unit_price_minor"},
 		},
 	}
 	for _, tc := range cases {
@@ -121,7 +127,7 @@ func TestLineTotalsRefusesFiguresOutsideTheMoneyRange(t *testing.T) {
 			if rangeErr.Figure != tc.wantFigure {
 				t.Fatalf("refusal names figure %q, want %q", rangeErr.Figure, tc.wantFigure)
 			}
-			assertMoneyRangeIsClientFault(t, err)
+			assertMoneyRangeIsClientFault(t, err, tc.wantFields...)
 		})
 	}
 }
@@ -164,28 +170,31 @@ func TestOfferTotalsRefuseASumOutsideTheMoneyRange(t *testing.T) {
 	if rangeErr.Figure != "net_minor" {
 		t.Fatalf("refusal names figure %q, want %q", rangeErr.Figure, "net_minor")
 	}
-	assertMoneyRangeIsClientFault(t, err)
+	assertMoneyRangeIsClientFault(t, err, "line_items")
 }
 
-// assertMoneyRangeIsClientFault checks the refusal carries its own 422
-// verdict: it must name at least one input with the contract's machine
-// code, or the same defect answers as an internal fault off the REST path.
-func assertMoneyRangeIsClientFault(t *testing.T, err error) {
+// assertMoneyRangeIsClientFault checks what a CALLER observes, not which
+// type carried it: the refusal must classify as 422 naming the inputs to
+// lower, with the contract's machine code. Asserting the carrier instead
+// would pass even if the wire answer were an internal fault — which is
+// what every surface reports for an error outside the taxonomy.
+func assertMoneyRangeIsClientFault(t *testing.T, err error, fields ...string) {
 	t.Helper()
-	var faults apperrors.FieldFaults
-	if !errors.As(err, &faults) {
-		t.Fatalf("refusal does not implement FieldFaults: %v", err)
+	for _, field := range fields {
+		faulttest.AssertNamesField(t, err, field)
 	}
-	refusals := faults.FieldFaults()
-	if len(refusals) == 0 {
-		t.Fatal("refusal names no input, so the caller is told nothing to lower")
+	fault, ok := httperr.Classify(err)
+	if !ok {
+		return // AssertNamesField has already failed the test on this
 	}
-	for _, r := range refusals {
-		if r.Field == "" {
-			t.Errorf("refusal entry names no field: %+v", r)
-		}
-		if r.Code != "money_out_of_range" {
-			t.Errorf("refusal entry code = %q, want %q", r.Code, "money_out_of_range")
+	if fault.Status != http.StatusUnprocessableEntity {
+		t.Errorf("an unrepresentable money figure answered status %d, want exactly 422 — the body is "+
+			"well-formed and the caller lowers a value they supplied", fault.Status)
+	}
+	for _, refusal := range fault.Fields {
+		if refusal.Code != "money_out_of_range" {
+			t.Errorf("refusal for %s carries code %q, want %q — the code is what a client branches on",
+				refusal.Field, refusal.Code, "money_out_of_range")
 		}
 	}
 }


### PR DESCRIPTION
## What

Every derived offer money figure — `line_net_minor`, `line_tax_minor`, `line_total_minor`, and the offer-level `net_minor` / `tax_minor` / `gross_minor` — now **refuses with 422 `money_out_of_range`** when it leaves the int64 minor-unit range, instead of silently storing the low 64 bits of the true value.

## Why

`roundHalfUp` ended in `q.Int64()`. On a `*big.Int` outside int64 that returns the **low 64 bits**, not an error. `quantity` is `numeric(14,3)` and `unit_price_minor` is a `bigint`, so their product leaves int64 long before either column complains — and every derived figure was narrowed through that one call.

The invariant: **a money figure this system cannot represent exactly is a refusal, never a number.** The sibling engine already holds it — `internal/compose/orgrollup.go` refuses an unrepresentable weighted value rather than truncating it (`weightedValue`, `convertToBase`). The offer engine did not, so the two disagreed on the same question.

Concretely, a Rep on their own deal — no admin, no special grant — could post a line item whose stored `net_minor` / `gross_minor` / `line_total_minor` came back as **-3890459620768029184**. The caller chooses the residue class, so an astronomically-priced line can be made to read as a small, plausible total on the quote, the rendered PDF and the pipeline rollup. That is a data-integrity break in money (P11), not a display bug.

**How the fix lands once rather than per call site:** `minorFromBig` is now the single narrowing point. `roundHalfUp` returns an exact `*big.Int` and narrowing is no longer its job. Every write and read path (`insertOfferLine`, `buildOfferLinePatch`, `insertStagedOfferLine`, `recomputeOfferTotals`, `readOfferWithLines`) already funnels through `LineTotals` / `OfferTotals`, so the fence covers all of them. `OfferTotals` additionally accumulates in `big.Int`, because lines that each fit int64 can still sum past it — a native `+=` would wrap the stored offer row while every line it is supposed to reconcile to still reads correctly.

The refusal carries its own verdict (`apperrors.FieldFaults`, code `money_out_of_range`) naming the inputs to lower, so it reads identically on REST and on the MCP tool surface — which never runs the module's HTTP mapper.

### Behaviour changes (please read — this is the surprising half of the diff)

1. A line whose net, tax or total leaves the range now answers **422 `money_out_of_range`** where it previously stored a wrapped number and answered 201/200.
2. An offer whose accepted lines **sum** past the range answers 422 on the mutation that would have crossed it, instead of writing a wrapped offer row.
3. Reading an offer that **already** holds such a line (written before this change) now refuses rather than rendering the wrapped figure, since `offer_read` derives line totals through the same engine. Refusing is the intent: a negative total presented as real money is worse than an error naming the input to lower.

## How verified

New tests in `offer_totals_test.go` prove the refusal at **each** figure, not just the first:

- `TestLineTotalsRefusesFiguresOutsideTheMoneyRange` — three cases pinning `line_net_minor` (quantity × price), `line_tax_minor` (a rate the `numeric(5,2)` column accepts), and `line_total_minor` (net + tax, where each half fits and the sum does not). Each asserts the **exact** figure named and that the refusal classifies as a field fault with code `money_out_of_range` — not merely "an error", which 404/500 would also satisfy.
- `TestOfferTotalsRefuseASumOutsideTheMoneyRange` — asserts up front that every line it builds from is *individually* representable, so it cannot pass for the wrong reason.
- `TestLineTotalsAcceptsTheLargestRepresentableLine` — the positive control: `MaxInt64` still computes, so the fence rejects overflow rather than large-but-valid money.

The existing golden cases and the 100-offer reconciliation property are unchanged and still green.

Ran locally: `go build ./...`, `go vet`, `go test ./internal/modules/deals/`, `craft static --strict` on both changed files (**PASS — 0 blocker / 0 major / 0 minor**), and `golangci-lint` under **both** `.golangci.yml` and `.golangci.strict.yml` (0 issues).

Full `make check` could not be run to completion on this Windows host: `internal/compose/installation.go` uses `syscall.O_NOFOLLOW` (unavailable on Windows) and the contract `$ref` fitness tests fail identically on a clean `origin/main` checkout here. Both reproduce **without** this change, so CI is the authority on those lanes.

- [ ] `make check` is green — *not runnable to completion on this host (see above); the backend gate's lint, vet, unit and craft arms were run individually and are green. Deferring to CI.*
- [x] `make test-integration` is green (or: this change does not touch tenant data / RLS / the write shape) — **the second branch:** this is pure derivation logic inside the existing transaction; no table, RLS policy, audit/outbox emission or store entry point changes.
- [x] `make craft-static` reports no new blockers
- [x] This diff and description carry no secrets, no customer data, no local machine paths, and no private specification paths or contents — the spec is cited by chapter, ADR, or pin ID (this repository is public)

## AI involvement

AI-assisted end to end via Claude Code: the diagnosis, the patch, and the tests were drafted by the agent and reviewed line by line before commit. The finding itself came from a source-level security review of the offer money engine (triaged HIGH, data-integrity) and was reproduced live against an isolated build before the fix was written. The choice to route every figure through one narrowing point — rather than adding an `IsInt64` check at the reported call site — was made to satisfy this repo's "fix the invariant, not the call site" rule.

## Accountability

By opening this PR I confirm I am **accountable** for this change and can
**explain every line** in it — human-written or AI-assisted. Commits are signed
off (`git commit -s`, DCO). See [CONTRIBUTING.md](/CONTRIBUTING.md) and the
[Code of Conduct](/CODE_OF_CONDUCT.md).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refuses offer money figures outside the int64 minor-unit range with 422 `money_not_representable` instead of storing wrapped negatives. Prevents forged small totals and aligns offers with org rollup; reads of offers with wrapped figures now refuse.

- **Review and rollout**
  - `roundHalfUp` now returns `*big.Int`; `minorFromBig` is the single narrowing point that rejects overflow; `OfferTotals` accumulates in `big.Int`.
  - Adds `MoneyRangeError` via `apperrors` with code `money_not_representable`; the refusal message states the installation limit (MaxInt64) and does not instruct callers to lower inputs. Responses surface as 422 on REST and MCP; tests assert wire behavior using `httperr`/`faulttest`.
  - Migration: existing rows with wrapped totals will fail to read. Adjust offending line items to representable amounts or correct the data.

<sup>Written for commit 25601f5af2494355fddb48a6ff70b46d4ab21637. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1489?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

