### PR TITLE
refactor(capture): the ingest spine drops the tenant column (ADR-0091 §8 phase D)

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -796,6 +796,25 @@ names the table, not every file in the module — and re-read the row STRUCT and
 its scanner, which is where a dropped select column turns into "number of field
 descriptions must equal number of destinations" at runtime.
 
+**Grep for the table, then read the whole file — not for both on one line.**
+The capture slice's first pass grepped for lines carrying the table name AND
+`workspace_id`, which is most write sites and almost no read sites: an aliased
+predicate (`WHERE t.workspace_id = …`, `r.workspace_id = a.workspace_id`) sits
+lines below the `FROM`, and a multi-line INSERT puts the column list on its own
+line. Eight production sites hid there, including two whole-module reads in
+sibling packages. The reliable sweep is two steps — `grep -l` the table, then
+`grep -n workspace_id` inside each file it names.
+
+**An index that outlives its reason goes quiet, it does not go red.**
+`channel_connection` carried two live-row unique rules: one live bot per
+provider, and one live binding per bot. The second existed to stop a SECOND
+WORKSPACE grabbing a bot another was polling; once there is one installation
+the first is strictly stronger, so the bot rule can never fire — and the store
+branches on WHICH constraint refused a connect to tell an admin what to do.
+Dropped in the same migration. Look for this wherever a uniqueness rule reads
+"…across tenants": phase D can leave it subsumed rather than wrong, and a
+subsumed rule is invisible until the branch above it picks the wrong message.
+
 **A reset stopped covering the tables that lost the column, and nothing said
 so.** `compose/datasweep.go` derived its targets from the presence of a
 `workspace_id` column — a proxy for "holds this tenant's data" that phase D is

--- a/backend/internal/compose/capturedomaintriage_integration_test.go
+++ b/backend/internal/compose/capturedomaintriage_integration_test.go
@@ -281,8 +281,8 @@ func TestAutoEnrichBudgetRefundNamesTheDayItWasReservedOn(t *testing.T) {
 	}
 	yesterday := capture.BudgetSlot{Day: todaySlot.Day.AddDate(0, 0, -1), Reserved: true}
 	e.WsExec(t, `
-		INSERT INTO capture_auto_enrich_budget (workspace_id, budget_date, enqueued)
-		VALUES ($1, $2, 1)`, e.WS, yesterday.Day)
+		INSERT INTO capture_auto_enrich_budget (budget_date, enqueued)
+		VALUES ($1, 1)`, yesterday.Day)
 
 	// Today has a reservation of its own — the slot that must survive.
 	if _, err := store.ReserveBudget(e.Admin(), 3); err != nil {

--- a/backend/internal/compose/captureverdict_integration_test.go
+++ b/backend/internal/compose/captureverdict_integration_test.go
@@ -267,9 +267,9 @@ func seedMail(t *testing.T, e *integration.Env, from, subject string, bulkAttest
 		// redaction test asserts zero raw_capture rows where zero always
 		// existed — a test that cannot fail.
 		_, err = tx.Exec(context.Background(), `
-			INSERT INTO raw_capture (workspace_id, source_system, source_id, payload)
-			VALUES ($1, 'gmail', $2, '{"headers":"…","body":"the message body"}'::jsonb)`,
-			e.WS, "vrd-"+id.String())
+			INSERT INTO raw_capture (source_system, source_id, payload)
+			VALUES ('gmail', $1, '{"headers":"…","body":"the message body"}'::jsonb)`,
+			"vrd-"+id.String())
 		return err
 	})
 	if err != nil {
@@ -286,9 +286,9 @@ func seedPendingDisposition(t *testing.T, e *integration.Env, email, domain stri
 	err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 		_, err := tx.Exec(context.Background(), `
 			INSERT INTO capture_pending_counterparty
-			  (id, workspace_id, email, domain, display_name, activity_id, owner_id, status, next_attempt_at)
-			VALUES ($1, $2, $3, $4, 'Sender Name', $5, $6, 'pending', now())`,
-			id, e.WS, email, domain, activityID, e.Rep1)
+			  (id, email, domain, display_name, activity_id, owner_id, status, next_attempt_at)
+			VALUES ($1, $2, $3, 'Sender Name', $4, $5, 'pending', now())`,
+			id, email, domain, activityID, e.Rep1)
 		return err
 	})
 	if err != nil {
@@ -462,8 +462,7 @@ func rawCaptureRows(t *testing.T, e *integration.Env, activityID ids.UUID) int {
 	t.Helper()
 	return countIn(t, e, `
 		SELECT count(*) FROM raw_capture r JOIN activity a
-		    ON a.workspace_id = r.workspace_id
-		   AND a.source_system = r.source_system AND a.source_id = r.source_id
+		    ON a.source_system = r.source_system AND a.source_id = r.source_id
 		 WHERE a.id = $1`, activityID)
 }
 

--- a/backend/internal/compose/costestimate/estimator_integration_test.go
+++ b/backend/internal/compose/costestimate/estimator_integration_test.go
@@ -137,13 +137,13 @@ func (e *estEnv) seedUser(t *testing.T, ws ids.UUID) ids.UserID {
 
 // seedConnection inserts a connected capture_connection for (provider, user) and
 // returns its id.
-func (e *estEnv) seedConnection(t *testing.T, ws ids.UUID, user ids.UserID, provider string) ids.UUID {
+func (e *estEnv) seedConnection(t *testing.T, user ids.UserID, provider string) ids.UUID {
 	t.Helper()
 	connID := ids.NewV7()
 	if _, err := e.owner.Exec(context.Background(), `
-		INSERT INTO capture_connection (id, workspace_id, provider, user_id, scopes, status)
-		VALUES ($1, $2, $3, $4, '{}', 'connected')`,
-		connID, ws, provider, user.UUID); err != nil {
+		INSERT INTO capture_connection (id, provider, user_id, scopes, status)
+		VALUES ($1, $2, $3, '{}', 'connected')`,
+		connID, provider, user.UUID); err != nil {
 		t.Fatal(err)
 	}
 	return connID
@@ -151,13 +151,13 @@ func (e *estEnv) seedConnection(t *testing.T, ws ids.UUID, user ids.UserID, prov
 
 // seedBackfill inserts a completed capture_backfill run — the connection's
 // representative yields.
-func (e *estEnv) seedBackfill(t *testing.T, ws, connID ids.UUID, windowMonths int, scanned, captured, people, orgs int) {
+func (e *estEnv) seedBackfill(t *testing.T, connID ids.UUID, windowMonths int, scanned, captured, people, orgs int) {
 	t.Helper()
 	if _, err := e.owner.Exec(context.Background(), `
-		INSERT INTO capture_backfill (workspace_id, connection_id, window_months, after_date, status,
+		INSERT INTO capture_backfill (connection_id, window_months, after_date, status,
 		  scanned, captured, people_created, organizations_created, started_at, completed_at)
-		VALUES ($1, $2, $3, $4, 'done', $5, $6, $7, $8, now(), now())`,
-		ws, connID, windowMonths, rateDay, scanned, captured, people, orgs); err != nil {
+		VALUES ($1, $2, $3, 'done', $4, $5, $6, $7, now(), now())`,
+		connID, windowMonths, rateDay, scanned, captured, people, orgs); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -221,8 +221,8 @@ func TestEstimatorPricesObservedHistory(t *testing.T) {
 	e := setupEstimator(t)
 	ws, wsCtx := e.seedWorkspace(t)
 	user := e.seedUser(t, ws)
-	connID := e.seedConnection(t, ws, user, "gmail")
-	e.seedBackfill(t, ws, connID, 6, 100, 80, 10, 2)
+	connID := e.seedConnection(t, user, "gmail")
+	e.seedBackfill(t, connID, 6, 100, 80, 10, 2)
 
 	// Rates: cloud + embed priced, local a real $0.
 	e.insertRate(t, ws, "cloud-model", 1_000_000, 2_000_000)
@@ -277,8 +277,8 @@ func TestEstimatorEnrichFloorsWhenPeopleCreatedZero(t *testing.T) {
 	e := setupEstimator(t)
 	ws, wsCtx := e.seedWorkspace(t)
 	user := e.seedUser(t, ws)
-	connID := e.seedConnection(t, ws, user, "gmail")
-	e.seedBackfill(t, ws, connID, 6, 100, 80, 0, 0) // people/orgs 0: the run minted no counterparty
+	connID := e.seedConnection(t, user, "gmail")
+	e.seedBackfill(t, connID, 6, 100, 80, 0, 0) // people/orgs 0: the run minted no counterparty
 
 	e.insertRate(t, ws, "cloud-model", 1_000_000, 2_000_000)
 	e.insertRate(t, ws, "embed-model", 500_000, 0)
@@ -318,8 +318,8 @@ func TestEstimatorExcludesRatelessModelAndFlagsHeuristic(t *testing.T) {
 	e := setupEstimator(t)
 	ws, wsCtx := e.seedWorkspace(t)
 	user := e.seedUser(t, ws)
-	connID := e.seedConnection(t, ws, user, "gmail")
-	e.seedBackfill(t, ws, connID, 6, 100, 100, 0, 0)
+	connID := e.seedConnection(t, user, "gmail")
+	e.seedBackfill(t, connID, 6, 100, 100, 0, 0)
 
 	// local-model priced; cloud-model deliberately UNrated.
 	e.insertRate(t, ws, "local-model", 1_000_000, 0)
@@ -363,8 +363,8 @@ func TestEstimatorCountsMeteringFailedRows(t *testing.T) {
 	e := setupEstimator(t)
 	ws, wsCtx := e.seedWorkspace(t)
 	user := e.seedUser(t, ws)
-	connID := e.seedConnection(t, ws, user, "gmail")
-	e.seedBackfill(t, ws, connID, 6, 100, 100, 0, 0)
+	connID := e.seedConnection(t, user, "gmail")
+	e.seedBackfill(t, connID, 6, 100, 100, 0, 0)
 
 	e.insertRate(t, ws, "cloud-model", 1_000_000, 0)
 	e.insertCall(t, ws, callRow{task: ai.TaskCaptureClassify, tier: ai.TierCheapCloud, provider: ai.ProviderFake, model: "cloud-model", tokensIn: 2_000_000, tokensOut: 0, errorSentinel: "metering_failed"})
@@ -398,8 +398,8 @@ func TestEstimatorEnrichMeteringFailedRetryDoesNotInflateDenominator(t *testing.
 	e := setupEstimator(t)
 	ws, wsCtx := e.seedWorkspace(t)
 	user := e.seedUser(t, ws)
-	connID := e.seedConnection(t, ws, user, "gmail")
-	e.seedBackfill(t, ws, connID, 6, 100, 100, 50, 0) // people_created=50 → observed enrich ratio
+	connID := e.seedConnection(t, user, "gmail")
+	e.seedBackfill(t, connID, 6, 100, 100, 50, 0) // people_created=50 → observed enrich ratio
 
 	// ONLY cloud-model is rated: enrich (served on cheap_cloud) prices; classify's
 	// and embeddings' floor heads (local-model, embed-model) stay unrated → $0.
@@ -435,8 +435,8 @@ func TestEstimatorRepricesSinceUnboundSlice(t *testing.T) {
 	e := setupEstimator(t)
 	ws, wsCtx := e.seedWorkspace(t)
 	user := e.seedUser(t, ws)
-	connID := e.seedConnection(t, ws, user, "gmail")
-	e.seedBackfill(t, ws, connID, 6, 100, 100, 0, 0)
+	connID := e.seedConnection(t, user, "gmail")
+	e.seedBackfill(t, connID, 6, 100, 100, 0, 0)
 
 	// The router binds cheap_cloud → cloud-model (rated) and local → local-model
 	// ($0). The served slice ran on old-cloud-model, now departed.
@@ -466,7 +466,7 @@ func TestEstimatorNoHistoryUsesFloor(t *testing.T) {
 	e := setupEstimator(t)
 	ws, wsCtx := e.seedWorkspace(t)
 	user := e.seedUser(t, ws)
-	e.seedConnection(t, ws, user, "gmail")
+	e.seedConnection(t, user, "gmail")
 	// Rate the floor's classify head (local-model) so the floor prices honestly.
 	e.insertRate(t, ws, "local-model", 1_000_000, 0)
 
@@ -490,9 +490,9 @@ func TestEstimatorConnectionScopedYields(t *testing.T) {
 	ws, wsCtx := e.seedWorkspace(t)
 	user := e.seedUser(t, ws)
 
-	gmailConn := e.seedConnection(t, ws, user, "gmail")
-	e.seedBackfill(t, ws, gmailConn, 12, 1000, 900, 200, 50) // a rich yield on gmail
-	e.seedConnection(t, ws, user, "imap")                    // imap has NO completed run
+	gmailConn := e.seedConnection(t, user, "gmail")
+	e.seedBackfill(t, gmailConn, 12, 1000, 900, 200, 50) // a rich yield on gmail
+	e.seedConnection(t, user, "imap")                    // imap has NO completed run
 
 	e.insertRate(t, ws, "local-model", 1_000_000, 0)
 

--- a/backend/internal/compose/extingress_integration_test.go
+++ b/backend/internal/compose/extingress_integration_test.go
@@ -525,8 +525,8 @@ func registerOwnDomain(t *testing.T, e *extRuntimeEnv, domain string) {
 	t.Helper()
 	owner := integration.OwnerConn(t)
 	if _, err := owner.Exec(context.Background(),
-		`INSERT INTO workspace_email_domain (workspace_id, domain, verified)
-		 VALUES ($1, $2, true)`, e.WS, domain); err != nil {
+		`INSERT INTO workspace_email_domain (domain, verified)
+		 VALUES ($1, true)`, domain); err != nil {
 		t.Fatalf("registering %s as an own domain: %v", domain, err)
 	}
 }

--- a/backend/internal/compose/integration/capture/capture_ledger_integration_test.go
+++ b/backend/internal/compose/integration/capture/capture_ledger_integration_test.go
@@ -176,10 +176,10 @@ func fillLedgerToCeiling(t *testing.T, e *integration.SearchEnv, activityID, own
 		}
 		_, err := tx.Exec(context.Background(), `
 			INSERT INTO capture_pending_counterparty
-			  (workspace_id, email, domain, activity_id, owner_id, status, next_attempt_at)
-			SELECT $1, 'filler' || g || '@flood.example', 'flood.example', $2, $3, 'pending', now()
-			  FROM generate_series(1, $4) g`,
-			e.WS, activityID, ownerID, capturemod.PendingDeferralCap-live)
+			  (email, domain, activity_id, owner_id, status, next_attempt_at)
+			SELECT 'filler' || g || '@flood.example', 'flood.example', $1, $2, 'pending', now()
+			  FROM generate_series(1, $3) g`,
+			activityID, ownerID, capturemod.PendingDeferralCap-live)
 		return err
 	})
 	if err != nil {
@@ -246,10 +246,10 @@ func fillDomainToShare(t *testing.T, e *integration.SearchEnv, domain string, ac
 		}
 		_, err := tx.Exec(context.Background(), `
 			INSERT INTO capture_pending_counterparty
-			  (workspace_id, email, domain, activity_id, owner_id, status, next_attempt_at)
-			SELECT $1, 'domfill' || g || '@' || $5, $5, $2, $3, 'pending', now()
-			  FROM generate_series(1, $4) g`,
-			e.WS, activityID, ownerID, capturemod.PendingDeferralDomainCap-live, domain)
+			  (email, domain, activity_id, owner_id, status, next_attempt_at)
+			SELECT 'domfill' || g || '@' || $4, $4, $1, $2, 'pending', now()
+			  FROM generate_series(1, $3) g`,
+			activityID, ownerID, capturemod.PendingDeferralDomainCap-live, domain)
 		return err
 	})
 	if err != nil {

--- a/backend/internal/compose/integration/capture/gmail_push_integration_test.go
+++ b/backend/internal/compose/integration/capture/gmail_push_integration_test.go
@@ -71,8 +71,8 @@ func TestGmailPushWebhookRoutesToTheConnection(t *testing.T) {
 			return err
 		}
 		return tx.QueryRow(context.Background(), `
-			INSERT INTO capture_sync_state (connection_id, workspace_id, next_sync_at)
-			SELECT id, workspace_id, now() + interval '1 hour' FROM capture_connection WHERE id = $1
+			INSERT INTO capture_sync_state (connection_id, next_sync_at)
+			SELECT id, now() + interval '1 hour' FROM capture_connection WHERE id = $1
 			RETURNING next_sync_at`,
 			connID).Scan(&seededNext)
 	})

--- a/backend/internal/compose/integration/capture/keyvault_capture_integration_test.go
+++ b/backend/internal/compose/integration/capture/keyvault_capture_integration_test.go
@@ -196,10 +196,15 @@ func TestBackfillMigratesLegacyAuthRowOntoTheVault(t *testing.T) {
 
 	// A legacy row: a connected connection whose credential still lives in the
 	// auth bytea column, no vault ref yet.
-	connID := e.Seed(t, `
-		INSERT INTO capture_connection (id, workspace_id, provider, user_id, scopes, status, auth)
-		VALUES ($1, $2, 'graph', $3, $4, 'connected', $5)`,
-		e.Rep1, []string{string(principal.ScopeRead)}, []byte("granted-token"))
+	// Written straight through the owner rather than through e.Seed: that helper
+	// binds a workspace, and this table no longer has one to bind.
+	connID := ids.NewV7()
+	if _, err := e.Owner.Exec(context.Background(), `
+		INSERT INTO capture_connection (id, provider, user_id, scopes, status, auth)
+		VALUES ($1, 'graph', $2, $3, 'connected', $4)`,
+		connID, e.Rep1, []string{string(principal.ScopeRead)}, []byte("granted-token")); err != nil {
+		t.Fatalf("seeding the legacy connection: %v", err)
+	}
 
 	migrated, err := registry.BackfillCredentials(context.Background())
 	if err != nil {

--- a/backend/internal/compose/integration/capturetrace_erasure_integration_test.go
+++ b/backend/internal/compose/integration/capturetrace_erasure_integration_test.go
@@ -27,11 +27,11 @@ func TestErasureReachesTheCaptureTracePayloads(t *testing.T) {
 	// subject, one from somebody else. A purge that took both would be as wrong
 	// as one that took neither.
 	e.WsExec(t, `
-		INSERT INTO capture_trace (workspace_id, user_id, connector, source_system, source_id,
+		INSERT INTO capture_trace (user_id, connector, source_system, source_id,
 		                           stage, outcome, counterparty, subject)
-		VALUES ($1, NULL, 'gmail', 'gmail', 'erasure-subject', 'tier_ladder', 'captured', $2, 'Quarterly numbers'),
-		       ($1, NULL, 'gmail', 'gmail', 'erasure-control', 'tier_ladder', 'captured', 'someone@else.test', 'Unrelated')`,
-		e.WS, subjectEmail)
+		VALUES (NULL, 'gmail', 'gmail', 'erasure-subject', 'tier_ladder', 'captured', $1, 'Quarterly numbers'),
+		       (NULL, 'gmail', 'gmail', 'erasure-control', 'tier_ladder', 'captured', 'someone@else.test', 'Unrelated')`,
+		subjectEmail)
 
 	if err := privacy.NewEraser(e.DB()).ErasePerson(e.Admin(), personID, "test"); err != nil {
 		t.Fatal(err)

--- a/backend/internal/compose/integration/channels/channelidentity_lifecycle_integration_test.go
+++ b/backend/internal/compose/integration/channels/channelidentity_lifecycle_integration_test.go
@@ -217,8 +217,8 @@ func TestArchivingAPersonArchivesTheChannelIdentity(t *testing.T) {
 func seedTelegramMessageRaw(t *testing.T, e *integration.Env, sourceID string, messageID int64, senderID, text string) {
 	t.Helper()
 	e.WsExec(t, `
-		INSERT INTO raw_capture (workspace_id, source_system, source_id, payload)
-		VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, 'telegram', $1,
+		INSERT INTO raw_capture (source_system, source_id, payload)
+		VALUES ('telegram', $1,
 		  jsonb_build_object('update_id', $2::bigint,
 		    'message', jsonb_build_object(
 		      'message_id', $2::bigint,
@@ -244,8 +244,8 @@ func seedTelegramMessageRaw(t *testing.T, e *integration.Env, sourceID string, m
 func seedTelegramMembershipRaw(t *testing.T, e *integration.Env, sourceID string, updateID int64, senderID, status string) {
 	t.Helper()
 	e.WsExec(t, `
-		INSERT INTO raw_capture (workspace_id, source_system, source_id, payload)
-		VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, 'telegram', $1,
+		INSERT INTO raw_capture (source_system, source_id, payload)
+		VALUES ('telegram', $1,
 		  jsonb_build_object('update_id', $2::bigint,
 		    'my_chat_member', jsonb_build_object(
 		      'chat', jsonb_build_object('id', $3::bigint, 'type', 'private', 'username', 'seed'),

--- a/backend/internal/compose/integration/channels/telegram_ingress_integration_test.go
+++ b/backend/internal/compose/integration/channels/telegram_ingress_integration_test.go
@@ -294,7 +294,7 @@ func TestAC_TG_5_MailGatesAreNoOpsForAChannelRecord(t *testing.T) {
 	// find if anything asks it about a record with no domain.
 	if err := apptest.InWorkspace(c.AppEnv, t, c.Slug, func(tx pgx.Tx) error {
 		_, err := tx.Exec(context.Background(),
-			`INSERT INTO workspace_email_domain (workspace_id, domain) VALUES ($1, 'own-house.test')`, c.ws)
+			`INSERT INTO workspace_email_domain (domain) VALUES ('own-house.test')`)
 		return err
 	}); err != nil {
 		t.Fatalf("seeding the internal mail domain: %v", err)

--- a/backend/internal/compose/integration/channelsend_integration_test.go
+++ b/backend/internal/compose/integration/channelsend_integration_test.go
@@ -176,9 +176,9 @@ func (c *channelSendEnv) connectBot(t *testing.T) {
 	if err := apptest.InWorkspace(c.AppEnv, t, c.Slug, func(tx pgx.Tx) error {
 		_, err := tx.Exec(context.Background(), `
 			INSERT INTO channel_connection
-				(workspace_id, provider, channel_id, channel_label, credential_ref, status, connected_by)
-			VALUES ($1, 'telegram', '8100', '@fablebot', 'vault:token', 'connected', $2)`,
-			c.ws, c.user)
+				(provider, channel_id, channel_label, credential_ref, status, connected_by)
+			VALUES ('telegram', '8100', '@fablebot', 'vault:token', 'connected', $1)`,
+			c.user)
 		return err
 	}); err != nil {
 		t.Fatalf("connecting the workspace bot: %v", err)

--- a/backend/internal/compose/integration/erasure_integration_test.go
+++ b/backend/internal/compose/integration/erasure_integration_test.go
@@ -77,8 +77,8 @@ func seedSubject(t *testing.T, e *Env) ids.UUID {
 			return err
 		}
 		if _, err := tx.Exec(ctx,
-			`INSERT INTO raw_capture (workspace_id, source_system, source_id, payload)
-			 VALUES (`+wsClause+`, 'gmail', 'msg-1', jsonb_build_object('from', $1::text, 'body', 'quarterly numbers'))`,
+			`INSERT INTO raw_capture (source_system, source_id, payload)
+			 VALUES ('gmail', 'msg-1', jsonb_build_object('from', $1::text, 'body', 'quarterly numbers'))`,
 			subjectEmail); err != nil {
 			return err
 		}

--- a/backend/internal/compose/integration/pipelinetrace_integration_test.go
+++ b/backend/internal/compose/integration/pipelinetrace_integration_test.go
@@ -128,14 +128,10 @@ func traceIDFor(t *testing.T, e *Env, sourceID string) ids.UUID {
 	t.Helper()
 	ctx := principal.WithWorkspaceID(context.Background(), e.WS)
 	var id ids.UUID
-	// The workspace predicate is spelled even though the fixture seeds one
-	// tenant: there is no RLS on this table (0217), so a read here that omits
-	// it is the shape that gets copied into a suite which seeds two.
 	if err := database.WithWorkspaceTx(ctx, e.Pool, func(tx pgx.Tx) error {
 		return tx.QueryRow(ctx, `
 			SELECT id FROM capture_trace
 			 WHERE source_id = $1
-			   AND workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid
 			 ORDER BY occurred_at LIMIT 1`, sourceID).Scan(&id)
 	}); err != nil {
 		t.Fatalf("reading back the trace id for %s: %v", sourceID, err)

--- a/backend/internal/compose/integration/send_preflight_integration_test.go
+++ b/backend/internal/compose/integration/send_preflight_integration_test.go
@@ -203,11 +203,11 @@ func (p *preflightEnv) connect(t *testing.T, providerScopes ...string) {
 	t.Helper()
 	if err := apptest.InWorkspace(p.AppEnv, t, p.Slug, func(tx pgx.Tx) error {
 		_, err := tx.Exec(context.Background(), `
-			INSERT INTO capture_connection (workspace_id, provider, user_id, scopes, status, auth, provider_scopes)
-			VALUES ($1, 'gmail', $2, '{}', 'connected', $3, $4)
+			INSERT INTO capture_connection (provider, user_id, scopes, status, auth, provider_scopes)
+			VALUES ('gmail', $1, '{}', 'connected', $2, $3)
 			ON CONFLICT (user_id, provider)
 			DO UPDATE SET status = 'connected', provider_scopes = EXCLUDED.provider_scopes`,
-			p.ws, p.user, []byte(`{"refresh_token":"r","granted":[]}`), providerScopes)
+			p.user, []byte(`{"refresh_token":"r","granted":[]}`), providerScopes)
 		return err
 	}); err != nil {
 		t.Fatalf("seeding the gmail connection: %v", err)

--- a/backend/internal/compose/participantbackfill_integration_test.go
+++ b/backend/internal/compose/participantbackfill_integration_test.go
@@ -59,8 +59,8 @@ func seedConnection(t *testing.T, e *integration.Env, user ids.UUID) {
 	t.Helper()
 	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 		_, err := tx.Exec(context.Background(), `
-			INSERT INTO capture_connection (workspace_id, user_id, provider, status, credential_ref)
-			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, 'gmail', 'connected', 'vault:test')
+			INSERT INTO capture_connection (user_id, provider, status, credential_ref)
+			VALUES ($1, 'gmail', 'connected', 'vault:test')
 			ON CONFLICT DO NOTHING`, user)
 		return err
 	}); err != nil {

--- a/backend/internal/compose/participantreplay_integration_test.go
+++ b/backend/internal/compose/participantreplay_integration_test.go
@@ -45,8 +45,8 @@ func seedReplayableMail(t *testing.T, e *integration.Env, sourceID, raw string) 
 		VALUES ($1, $2, 'email', 'Q3 terms', '2026-08-01T09:00:00Z', 'inbound',
 		        'gmail', '`+sourceID+`', 'gmail:`+sourceID+`', 'connector:gmail')`, e.WS)
 	if _, err := owner.Exec(context.Background(), `
-		INSERT INTO raw_capture (workspace_id, source_system, source_id, payload)
-		VALUES ($1, 'gmail', $2, to_jsonb($3::text))`, e.WS, sourceID, raw); err != nil {
+		INSERT INTO raw_capture (source_system, source_id, payload)
+		VALUES ('gmail', $1, to_jsonb($2::text))`, sourceID, raw); err != nil {
 		t.Fatalf("seeding the stored original: %v", err)
 	}
 	return id
@@ -135,10 +135,14 @@ func TestReplayRecordsUnreadableRatherThanFailingTheBatch(t *testing.T) {
 	good := seedReplayableMail(t, e, "msg-readable", ccMessage)
 
 	// A connection makes the mailbox known, so the parse is actually attempted.
-	integration.SeedRow(t, owner, `INSERT INTO capture_connection
-		(id, workspace_id, provider, user_id, scopes, status, auth, account_label)
-		VALUES ($1, $2, 'gmail', '`+e.Rep1.String()+`', '{}', 'connected', ''::bytea,
-		        'owner@myco.example')`, e.WS)
+	// Written straight through the owner rather than integration.SeedRow: that
+	// helper binds a workspace, and this table no longer has one to bind.
+	if _, err := owner.Exec(context.Background(), `INSERT INTO capture_connection
+		(id, provider, user_id, scopes, status, auth, account_label)
+		VALUES ($1, 'gmail', $2, '{}', 'connected', ''::bytea, 'owner@myco.example')`,
+		ids.NewV7(), e.Rep1); err != nil {
+		t.Fatalf("seeding the mailbox connection: %v", err)
+	}
 
 	settled, err := replayParticipantsBatch(replayCtx(e), e.Pool, 10, slog.Default())
 	if err != nil {

--- a/backend/internal/compose/telegramingest_integration_test.go
+++ b/backend/internal/compose/telegramingest_integration_test.go
@@ -43,15 +43,15 @@ func telegramIngestFixture(t *testing.T, e *integration.Env) (connID, rawID ids.
 	err := database.WithWorkspaceTx(ctx, e.Pool, func(tx pgx.Tx) error {
 		if _, err := tx.Exec(ctx, `
 			INSERT INTO channel_connection
-				(id, workspace_id, provider, channel_id, channel_label, credential_ref, status, connected_by)
-			VALUES ($1, $2, 'telegram', '42', 'acme_bot', 'cred-ref', 'connected', $3)`,
-			connID, e.WS, e.Rep1); err != nil {
+				(id, provider, channel_id, channel_label, credential_ref, status, connected_by)
+			VALUES ($1, 'telegram', '42', 'acme_bot', 'cred-ref', 'connected', $2)`,
+			connID, e.Rep1); err != nil {
 			return err
 		}
 		_, err := tx.Exec(ctx, `
-			INSERT INTO raw_capture (id, workspace_id, source_system, source_id, payload)
-			VALUES ($1, $2, 'telegram', '100', $3)`,
-			rawID, e.WS, []byte(telegramIngestUpdateJSON))
+			INSERT INTO raw_capture (id, source_system, source_id, payload)
+			VALUES ($1, 'telegram', '100', $2)`,
+			rawID, []byte(telegramIngestUpdateJSON))
 		return err
 	})
 	if err != nil {
@@ -194,9 +194,9 @@ func TestIngestWorkerAppliesMembershipWithoutCapturingAnActivity(t *testing.T) {
 	ctx := principal.WithWorkspaceID(context.Background(), e.WS)
 	if err := database.WithWorkspaceTx(ctx, e.Pool, func(tx pgx.Tx) error {
 		_, err := tx.Exec(ctx, `
-			INSERT INTO raw_capture (id, workspace_id, source_system, source_id, payload)
-			VALUES ($1, $2, 'telegram', '200', $3)`,
-			rawID, e.WS, []byte(telegramIngestKickedJSON))
+			INSERT INTO raw_capture (id, source_system, source_id, payload)
+			VALUES ($1, 'telegram', '200', $2)`,
+			rawID, []byte(telegramIngestKickedJSON))
 		return err
 	}); err != nil {
 		t.Fatalf("seeding the raw membership update: %v", err)
@@ -250,9 +250,9 @@ func TestIngestWorkerCapturesNothingFromAGroupChat(t *testing.T) {
 	ctx := principal.WithWorkspaceID(context.Background(), e.WS)
 	if err := database.WithWorkspaceTx(ctx, e.Pool, func(tx pgx.Tx) error {
 		_, err := tx.Exec(ctx, `
-			INSERT INTO raw_capture (id, workspace_id, source_system, source_id, payload)
-			VALUES ($1, $2, 'telegram', '300', $3)`,
-			rawID, e.WS, []byte(telegramIngestGroupJSON))
+			INSERT INTO raw_capture (id, source_system, source_id, payload)
+			VALUES ($1, 'telegram', '300', $2)`,
+			rawID, []byte(telegramIngestGroupJSON))
 		return err
 	}); err != nil {
 		t.Fatalf("seeding the raw group-chat update: %v", err)

--- a/backend/internal/compose/telegrampoll_integration_test.go
+++ b/backend/internal/compose/telegrampoll_integration_test.go
@@ -61,7 +61,7 @@ func TestAPollPersistsTheBatchAndAdvancesTheCursor(t *testing.T) {
 	}
 	conn := connectTestTelegramBot(t, e, vault, api, 92000001, "batch_bot")
 
-	if err := runOnePoll(t, newTestPollWorker(e, vault, api, ambientPollInserter(t, e)), conn); err != nil {
+	if err := runOnePoll(t, newTestPollWorker(e, vault, api, ambientPollInserter(t, e)), e.WS, conn); err != nil {
 		t.Fatalf("the poll: %v", err)
 	}
 
@@ -109,7 +109,7 @@ func TestTheCursorSurvivesACrashBeforeCommit(t *testing.T) {
 	conn := connectTestTelegramBot(t, e, vault, api, 92000002, "crash_bot")
 
 	crash := errors.New("injected: the enqueue fails inside the poller's own transaction")
-	err := runOnePoll(t, newTestPollWorker(e, vault, api, &fakeInserter{err: crash}), conn)
+	err := runOnePoll(t, newTestPollWorker(e, vault, api, &fakeInserter{err: crash}), e.WS, conn)
 	if !errors.Is(err, crash) {
 		t.Fatalf("the crashing poll returned %v, want the injected failure — a swallowed one would look like a successful poll", err)
 	}
@@ -124,7 +124,7 @@ func TestTheCursorSurvivesACrashBeforeCommit(t *testing.T) {
 	}
 
 	// The re-poll: the identical batch arrives again and folds to one row each.
-	if err := runOnePoll(t, newTestPollWorker(e, vault, api, ambientPollInserter(t, e)), conn); err != nil {
+	if err := runOnePoll(t, newTestPollWorker(e, vault, api, ambientPollInserter(t, e)), e.WS, conn); err != nil {
 		t.Fatalf("the re-poll: %v", err)
 	}
 	for _, updateID := range []int64{6201, 6202} {
@@ -166,7 +166,7 @@ func TestAPollPersistsNothingForAnErasedSubject(t *testing.T) {
 	conn := connectTestTelegramBot(t, e, vault, api, 92000003, "erased_bot")
 	suppressChannelAccount(t, e, "780301")
 
-	if err := runOnePoll(t, newTestPollWorker(e, vault, api, ambientPollInserter(t, e)), conn); err != nil {
+	if err := runOnePoll(t, newTestPollWorker(e, vault, api, ambientPollInserter(t, e)), e.WS, conn); err != nil {
 		t.Fatalf("the poll: %v", err)
 	}
 
@@ -205,7 +205,7 @@ func TestAPollPersistsNothingForAGroupChat(t *testing.T) {
 	}
 	conn := connectTestTelegramBot(t, e, vault, api, 92000004, "group_bot")
 
-	if err := runOnePoll(t, newTestPollWorker(e, vault, api, ambientPollInserter(t, e)), conn); err != nil {
+	if err := runOnePoll(t, newTestPollWorker(e, vault, api, ambientPollInserter(t, e)), e.WS, conn); err != nil {
 		t.Fatalf("the poll: %v", err)
 	}
 
@@ -243,7 +243,7 @@ func TestAPollDropsAPoisonUpdateAndAdvancesPastIt(t *testing.T) {
 	}
 	conn := connectTestTelegramBot(t, e, vault, api, 92000005, "poison_bot")
 
-	if err := runOnePoll(t, newTestPollWorker(e, vault, api, ambientPollInserter(t, e)), conn); err != nil {
+	if err := runOnePoll(t, newTestPollWorker(e, vault, api, ambientPollInserter(t, e)), e.WS, conn); err != nil {
 		t.Fatalf("the poll: %v", err)
 	}
 
@@ -287,7 +287,7 @@ func TestAReplacementDuringAPollDoesNotInheritTheOutgoingBotsCursor(t *testing.T
 		replaceTestTelegramBot(t, e, vault, conn.ID, incomingBotID, "incoming_poll_bot")
 	}
 
-	if err := runOnePoll(t, newTestPollWorker(e, vault, api, ambientPollInserter(t, e)), conn); err != nil {
+	if err := runOnePoll(t, newTestPollWorker(e, vault, api, ambientPollInserter(t, e)), e.WS, conn); err != nil {
 		t.Fatalf("the poll that finished after the swap: %v", err)
 	}
 
@@ -321,7 +321,7 @@ func TestAdvancingTheCursorDoesNotLookLikeAReplacedBinding(t *testing.T) {
 	conn := connectTestTelegramBot(t, e, vault, api, 92000006, "fence_bot")
 	before := telegramConnectionVersion(t, e, conn)
 
-	if err := runOnePoll(t, newTestPollWorker(e, vault, api, ambientPollInserter(t, e)), conn); err != nil {
+	if err := runOnePoll(t, newTestPollWorker(e, vault, api, ambientPollInserter(t, e)), e.WS, conn); err != nil {
 		t.Fatalf("the poll: %v", err)
 	}
 	if offset := telegramStoredPollOffset(t, e, conn); offset != 6602 {
@@ -357,7 +357,7 @@ func TestAReplacementStillBumpsTheVersionOnAPolledConnection(t *testing.T) {
 	}
 	conn := connectTestTelegramBot(t, e, vault, api, 92000011, "polled_then_swapped")
 
-	if err := runOnePoll(t, newTestPollWorker(e, vault, api, ambientPollInserter(t, e)), conn); err != nil {
+	if err := runOnePoll(t, newTestPollWorker(e, vault, api, ambientPollInserter(t, e)), e.WS, conn); err != nil {
 		t.Fatalf("the arranging poll: %v", err)
 	}
 	if offset := telegramStoredPollOffset(t, e, conn); offset == 0 {

--- a/backend/internal/compose/telegrampollfixture_integration_test.go
+++ b/backend/internal/compose/telegrampollfixture_integration_test.go
@@ -202,11 +202,14 @@ func ambientPollInserter(t *testing.T, e *integration.Env) telegramEnqueuer {
 // *rivertype.JobRow, so a job built without one panics the moment the worker
 // reads any River-side field, and a fixture that only ever drove the happy path
 // would not find out.
-func runOnePoll(t *testing.T, worker *telegramPollWorker, conn capture.ChannelConnection) error {
+// The workspace is passed in rather than read off the connection: the binding
+// no longer carries one (ADR-0091 §8 phase D), and the args are what the
+// dispatcher stamps from its own scan.
+func runOnePoll(t *testing.T, worker *telegramPollWorker, ws ids.UUID, conn capture.ChannelConnection) error {
 	t.Helper()
 	return worker.Work(context.Background(), &river.Job[TelegramPollArgs]{
 		JobRow: &rivertype.JobRow{Kind: TelegramPollArgs{}.Kind(), Attempt: 1},
-		Args:   TelegramPollArgs{Workspace: conn.WorkspaceID, ConnectionID: conn.ID.String()},
+		Args:   TelegramPollArgs{Workspace: ws, ConnectionID: conn.ID.String()},
 	})
 }
 

--- a/backend/internal/compose/telegrampollhealth_integration_test.go
+++ b/backend/internal/compose/telegrampollhealth_integration_test.go
@@ -60,7 +60,7 @@ func TestAPollWhoseTokenIsRefusedParksTheConnection(t *testing.T) {
 		t.Fatal("a freshly connected bot is not in the due-scan, so this test could not observe it leaving")
 	}
 
-	if err := runOnePoll(t, newTestPollWorker(e, vault, api, ambientPollInserter(t, e)), conn); err != nil {
+	if err := runOnePoll(t, newTestPollWorker(e, vault, api, ambientPollInserter(t, e)), e.WS, conn); err != nil {
 		t.Fatalf("the refused poll returned %v, want nil — River retrying a token Telegram will never accept is a loop nothing breaks", err)
 	}
 
@@ -100,7 +100,7 @@ func TestAConflictThatSurvivesTheWebhookClearParksTheConnection(t *testing.T) {
 	conn := connectTestTelegramBot(t, e, vault, api, 92000008, "contested_bot")
 	clearsAfterConnect := api.deleteWebhooks
 
-	if err := runOnePoll(t, newTestPollWorker(e, vault, api, ambientPollInserter(t, e)), conn); err != nil {
+	if err := runOnePoll(t, newTestPollWorker(e, vault, api, ambientPollInserter(t, e)), e.WS, conn); err != nil {
 		t.Fatalf("the contested poll returned %v, want nil — River retrying a bot another consumer holds is a loop nothing breaks", err)
 	}
 
@@ -134,7 +134,7 @@ func TestAConflictAWebhookClearRepairsLeavesTheConnectionLive(t *testing.T) {
 	// re-registering, or an operator doing it by hand.
 	api.webhookRegistered = true
 
-	err := runOnePoll(t, newTestPollWorker(e, vault, api, ambientPollInserter(t, e)), conn)
+	err := runOnePoll(t, newTestPollWorker(e, vault, api, ambientPollInserter(t, e)), e.WS, conn)
 	if err == nil {
 		t.Fatal("the conflict was swallowed — a poll that collected nothing must not report success")
 	}
@@ -149,7 +149,7 @@ func TestAConflictAWebhookClearRepairsLeavesTheConnectionLive(t *testing.T) {
 		t.Fatal("the connection left the due-scan, so nothing would ever poll it again")
 	}
 	// And the retry actually works now, which is the proof the clear repaired it.
-	if err := runOnePoll(t, newTestPollWorker(e, vault, api, ambientPollInserter(t, e)), conn); err != nil {
+	if err := runOnePoll(t, newTestPollWorker(e, vault, api, ambientPollInserter(t, e)), e.WS, conn); err != nil {
 		t.Fatalf("the poll after the clear: %v", err)
 	}
 	if n := rawCaptureCount(t, e, conn, 7101); n != 1 {

--- a/backend/internal/compose/telegrampollscope.go
+++ b/backend/internal/compose/telegrampollscope.go
@@ -118,7 +118,7 @@ func telegramAnySubjectSuppressed(ctx context.Context, tx pgx.Tx, accounts []str
 
 // telegramRawSourceID is raw_capture's dedupe key for one polled update.
 // update_id is a PER-BOT sequence, so the key MUST carry the bot:
-// raw_capture_source_unique is (workspace_id, source_system, source_id) and
+// raw_capture_source_unique is (source_system, source_id) and
 // InsertRawCaptureTx's ON CONFLICT overwrites the stored payload, so a bare
 // update_id would let the bot a workspace was REPLACED onto land on the outgoing
 // bot's row and destroy the only copy of a message already captured —

--- a/backend/internal/compose/telegramrekey_integration_test.go
+++ b/backend/internal/compose/telegramrekey_integration_test.go
@@ -88,7 +88,7 @@ func TestATokenReplacementBetweenPollAndIngestKeepsThePollingBotsKeys(t *testing
 	}
 	conn := connectTestTelegramBot(t, e, vault, api, 91000006, "bot_before_swap")
 
-	if err := runOnePoll(t, newTestPollWorker(e, vault, api, ambientPollInserter(t, e)), conn); err != nil {
+	if err := runOnePoll(t, newTestPollWorker(e, vault, api, ambientPollInserter(t, e)), e.WS, conn); err != nil {
 		t.Fatalf("the arranging poll: %v", err)
 	}
 	enqueued := telegramEnqueuedRawIDs(t, e, conn.ID.String())

--- a/backend/internal/modules/activities/messageidentity_absorb_integration_test.go
+++ b/backend/internal/modules/activities/messageidentity_absorb_integration_test.go
@@ -141,9 +141,9 @@ func (e *sendEnv) queueCounterpartyReview(t *testing.T, activityID ids.ActivityI
 	id := ids.NewV7()
 	if _, err := e.owner.Exec(context.Background(), `
 		INSERT INTO capture_pending_counterparty
-		  (id, workspace_id, email, domain, activity_id, owner_id, status, next_attempt_at)
-		VALUES ($1, $2, 'buyer@example.test', 'example.test', $3, $4, 'pending', now())`,
-		id, e.ws, activityID, e.rep); err != nil {
+		  (id, email, domain, activity_id, owner_id, status, next_attempt_at)
+		VALUES ($1, 'buyer@example.test', 'example.test', $2, $3, 'pending', now())`,
+		id, activityID, e.rep); err != nil {
 		t.Fatalf("queuing the counterparty review: %v", err)
 	}
 	return id

--- a/backend/internal/modules/activities/pipelinefacts.go
+++ b/backend/internal/modules/activities/pipelinefacts.go
@@ -46,8 +46,7 @@ const ClassifyBacklogPredicate = `capture_label IS NULL
 	  AND archived_at IS NULL
 	  AND NOT EXISTS (
 	    SELECT 1 FROM capture_pending_counterparty p
-	     WHERE p.workspace_id = activity.workspace_id
-	       AND p.email = activity.counterparty_email
+	     WHERE p.email = activity.counterparty_email
 	       AND p.status IN ('pending', 'unsure'))`
 
 // PipelineFacts is one activity's contribution to its own pipeline ladder.
@@ -106,8 +105,7 @@ func (s *Store) ReadPipelineFacts(ctx context.Context, id ids.UUID) (PipelineFac
 			  captured_by,
 			  archived_at IS NOT NULL,
 			  EXISTS (SELECT 1 FROM capture_pending_counterparty p
-			           WHERE p.workspace_id = activity.workspace_id
-			             AND p.email = activity.counterparty_email
+			           WHERE p.email = activity.counterparty_email
 			             AND p.status = ANY($2)),
 			  (`+ClassifyBacklogPredicate+`)
 			FROM activity

--- a/backend/internal/modules/activities/pipelinefacts_integration_test.go
+++ b/backend/internal/modules/activities/pipelinefacts_integration_test.go
@@ -118,8 +118,8 @@ func (e *factsEnv) seed(t *testing.T, row capturedRow) ids.UUID {
 		id, e.ws, row.kind, capturedBy, email, row.archived)
 	if row.undecidedSender {
 		e.exec(t, `
-			INSERT INTO capture_pending_counterparty (id, workspace_id, owner_id, email, status, activity_id)
-			VALUES ($1, $2, $3, $4, 'pending', $5)`, ids.NewV7(), e.ws, e.user, email, id)
+			INSERT INTO capture_pending_counterparty (id, owner_id, email, status, activity_id)
+			VALUES ($1, $2, $3, 'pending', $4)`, ids.NewV7(), e.user, email, id)
 	}
 	if row.withPerson {
 		person := ids.NewV7()

--- a/backend/internal/modules/capture/autoenrich.go
+++ b/backend/internal/modules/capture/autoenrich.go
@@ -153,8 +153,8 @@ func (s *AutoEnrichStore) ReserveBudget(ctx context.Context, dailyCap int) (Budg
 		// the WHERE on DO UPDATE makes an over-cap increment a no-op that
 		// RETURNS nothing, so the reservation is atomic.
 		err := tx.QueryRow(ctx, `
-			INSERT INTO capture_auto_enrich_budget (workspace_id, budget_date, enqueued)
-			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, (now() AT TIME ZONE 'UTC')::date, 1)
+			INSERT INTO capture_auto_enrich_budget (budget_date, enqueued)
+			VALUES ((now() AT TIME ZONE 'UTC')::date, 1)
 			ON CONFLICT (budget_date)
 			DO UPDATE SET enqueued = capture_auto_enrich_budget.enqueued + 1
 			WHERE capture_auto_enrich_budget.enqueued < $1
@@ -203,8 +203,7 @@ func (s *AutoEnrichStore) ReleaseBudget(ctx context.Context, slot BudgetSlot) er
 		_, err := tx.Exec(ctx, `
 			UPDATE capture_auto_enrich_budget
 			   SET enqueued = enqueued - 1
-			 WHERE workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid
-			   AND budget_date = $1
+			 WHERE budget_date = $1
 			   AND enqueued > 0`, slot.Day)
 		return err
 	})
@@ -226,9 +225,8 @@ func (s *AutoEnrichStore) MarkQueued(ctx context.Context, orgID ids.Organization
 	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		_, err := tx.Exec(ctx, `
 			INSERT INTO capture_auto_enrich_state
-			  (organization_id, workspace_id, attempts, last_attempt_at, next_attempt_at, last_outcome)
-			VALUES ($1, NULLIF(current_setting('app.workspace_id', true), '')::uuid, 1, now(),
-			        now() + make_interval(secs => $2), 'queued')
+			  (organization_id, attempts, last_attempt_at, next_attempt_at, last_outcome)
+			VALUES ($1, 1, now(), now() + make_interval(secs => $2), 'queued')
 			ON CONFLICT (organization_id) DO UPDATE SET
 			  attempts = capture_auto_enrich_state.attempts + 1,
 			  last_attempt_at = now(),

--- a/backend/internal/modules/capture/backfill.go
+++ b/backend/internal/modules/capture/backfill.go
@@ -197,8 +197,8 @@ func (r *Registry) StartBackfill(ctx context.Context, provider string, userID id
 		}
 		after := r.now().AddDate(0, -windowMonths, 0)
 		err = tx.QueryRow(ctx, `
-			INSERT INTO capture_backfill (workspace_id, connection_id, window_months, after_date, total_estimate, status, started_at)
-			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, $2, $3, NULLIF($4, 0), 'queued', now())
+			INSERT INTO capture_backfill (connection_id, window_months, after_date, total_estimate, status, started_at)
+			VALUES ($1, $2, $3, NULLIF($4, 0), 'queued', now())
 			RETURNING id`, connID, windowMonths, after, estimate).Scan(&run.ID)
 		if err != nil {
 			if storekit.IsUniqueViolation(err) {

--- a/backend/internal/modules/capture/channelconn.go
+++ b/backend/internal/modules/capture/channelconn.go
@@ -77,7 +77,7 @@ const (
 
 // channelConnectionColumns is the read shape, spelled once so every scan
 // agrees with every select.
-const channelConnectionColumns = `id, workspace_id, provider, channel_id, channel_label, status, version, created_at, updated_at`
+const channelConnectionColumns = `id, provider, channel_id, channel_label, status, version, created_at, updated_at`
 
 // ChannelConnection is one channel binding as read back. No vault ref rides this
 // shape: the bot token lives sealed in the vault, addressed by a ref no caller
@@ -85,10 +85,9 @@ const channelConnectionColumns = `id, workspace_id, provider, channel_id, channe
 // leave it out, and the poller reads it through its own narrow shape
 // (ChannelPollTarget).
 type ChannelConnection struct {
-	ID          ids.UUID
-	WorkspaceID ids.UUID
-	Provider    string
-	ChannelID   string
+	ID        ids.UUID
+	Provider  string
+	ChannelID string
 	// ChannelLabel is the bot's @username — display only. A bot's username is
 	// mutable and re-assignable, so it identifies nothing; ChannelID (the
 	// bot's global numeric id) is the key.
@@ -108,15 +107,14 @@ type ConnectRequest struct {
 	BotToken string
 }
 
-// ErrChannelWorkspaceBotAlreadyBound reports that this workspace already holds a
-// live bot. It is a DIFFERENT refusal from the bot already being bound somewhere:
-// the remedy is to disconnect the existing binding, not to pick another bot.
+// ErrChannelWorkspaceBotAlreadyBound reports that this installation already
+// holds a live bot, and so the remedy is to disconnect that binding.
 //
-// Only one live bot per workspace is permitted, because every outbound reply
-// resolves the workspace's bot and the send path refuses to guess between two —
-// so a second binding would not add a channel, it would take away the ability to
+// Only one live bot is permitted, because every outbound reply resolves the
+// installation's bot and the send path refuses to guess between two — so a
+// second binding would not add a channel, it would take away the ability to
 // reply on either.
-var ErrChannelWorkspaceBotAlreadyBound = errors.New("capture: this workspace already has a live channel connection")
+var ErrChannelWorkspaceBotAlreadyBound = errors.New("capture: this installation already has a live channel connection")
 
 // ErrChannelWiringIncomplete reports that this deployment composed no credential
 // custodian, so a bot token can neither be sealed nor destroyed. It is a
@@ -233,23 +231,27 @@ func (s *ChannelStore) Connect(ctx context.Context, req ConnectRequest) (Channel
 	return row, nil
 }
 
-// channelUniquenessRefusal names WHICH uniqueness rule a connect or a
-// replacement lost to, because the two send an operator to do different things:
-// one says pick a different bot, the other says disconnect the bot this workspace
-// already has. Answering both as "this bot is already connected" leaves an admin
-// hunting for a binding of a bot they have never used.
+// channelUniquenessRefusal answers the ONE live-row uniqueness rule a connect or
+// a replacement can lose to: uq_channel_connection_ws permits a single live
+// binding per provider, so the remedy is always to disconnect what is bound —
+// never to pick a different bot. The refusal says so, because "already
+// connected" would send an admin looking for a binding of a bot they have never
+// used.
+//
+// It still takes the constraint name rather than assuming: any OTHER unique
+// index this table grows must not be answered as if it were this rule.
 func channelUniquenessRefusal(constraint string) error {
 	if constraint == channelWorkspaceUniqueIndex {
-		return fmt.Errorf("another bot is already connected to this workspace; disconnect it first: %w",
+		return fmt.Errorf("another bot is already connected to this installation; disconnect it first: %w",
 			ErrChannelWorkspaceBotAlreadyBound)
 	}
 	return fmt.Errorf("this bot is already connected: %w", apperrors.ErrConflict)
 }
 
 // channelWorkspaceUniqueIndex is the partial unique index that permits ONE live
-// bot per workspace (0151). Named here because the refusal above branches on it,
-// and a rename in the migration must break this compile-time-invisible link
-// loudly — which the connect suite's two distinct refusals are what enforce.
+// bot per installation (0151). Named here because the refusal above branches on
+// it, and a rename in the migration must break this compile-time-invisible link
+// loudly — which the connect suite's refusal assertion is what enforces.
 const channelWorkspaceUniqueIndex = "uq_channel_connection_ws"
 
 // requireConnectWiring refuses a connect this deployment cannot honestly
@@ -309,8 +311,8 @@ func (s *ChannelStore) insertConnected(ctx context.Context, bot telegram.Bot, cr
 	err = s.db.Tx(ctx, func(tx pgx.Tx) error {
 		out, err = scanChannelConnection(tx.QueryRow(ctx, `
 			INSERT INTO channel_connection
-			  (workspace_id, provider, channel_id, channel_label, credential_ref, status, poll_offset, connected_by)
-			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, $2, $3, $4, $5, 0, $6)
+			  (provider, channel_id, channel_label, credential_ref, status, poll_offset, connected_by)
+			VALUES ($1, $2, $3, $4, $5, 0, $6)
 			RETURNING `+channelConnectionColumns,
 			ProviderTelegram, channelIDOf(bot), bot.Username,
 			string(credentialRef), channelStatusConnected, connectedBy))
@@ -366,7 +368,7 @@ func channelAuditImage(channelID, label, status string) map[string]any {
 
 func scanChannelConnection(r pgx.Row) (ChannelConnection, error) {
 	var c ChannelConnection
-	err := r.Scan(&c.ID, &c.WorkspaceID, &c.Provider, &c.ChannelID, &c.ChannelLabel,
+	err := r.Scan(&c.ID, &c.Provider, &c.ChannelID, &c.ChannelLabel,
 		&c.Status, &c.Version, &c.CreatedAt, &c.UpdatedAt)
 	return c, err
 }

--- a/backend/internal/modules/capture/channelconn_integration_test.go
+++ b/backend/internal/modules/capture/channelconn_integration_test.go
@@ -162,52 +162,12 @@ func TestConnectIsLiveOnCommitWithAZeroCursor(t *testing.T) {
 	}
 }
 
-// The bot-scoped unique index is deliberately GLOBAL, not per-workspace: only one
-// getUpdates consumer may hold a bot, so a second workspace connecting the same
-// bot would not split the traffic, it would race the first for it.
-func TestConnectRefusesTheSameBotInASecondWorkspace(t *testing.T) {
-	api := newFakeTelegram()
-	token, _ := api.withNewBot("shared_bot")
-	first := newChannelFixture(t, api)
-	second := newChannelFixture(t, api)
-
-	if _, err := first.store.Connect(first.ctx, capture.ConnectRequest{
-		Provider: capture.ProviderTelegram, BotToken: token,
-	}); err != nil {
-		t.Fatalf("the first workspace's connect must succeed: %v", err)
-	}
-
-	_, err := second.store.Connect(second.ctx, capture.ConnectRequest{
-		Provider: capture.ProviderTelegram, BotToken: token,
-	})
-	if !errors.Is(err, apperrors.ErrConflict) {
-		t.Fatalf("the second workspace's connect: got %v, want ErrConflict", err)
-	}
-	// And it must NOT read as the workspace rule: the remedy differs — pick
-	// another bot, rather than disconnect the one this workspace already has.
-	if errors.Is(err, capture.ErrChannelWorkspaceBotAlreadyBound) {
-		t.Errorf("got %v, which tells the admin to disconnect a binding this workspace does not have", err)
-	}
-	if n := second.rowCount(t); n != 0 {
-		t.Errorf("the losing workspace kept %d row(s)", n)
-	}
-	// The loser sealed a token on its way to the insert; it must be destroyed,
-	// because a lost race is the one failure that proves no row persisted to name it.
-	sealed := second.vault.mintedRefs()
-	if len(sealed) != 1 {
-		t.Fatalf("the losing connect sealed %d secret(s), want just the bot token", len(sealed))
-	}
-	if _, err := second.vault.Get(second.ctx, second.workspaceKey(), sealed[0]); err == nil {
-		t.Error("the losing connect left a sealed secret behind, referenced by no row and collected by no sweep")
-	}
-}
-
-// One live bot per WORKSPACE (F22). Two live bindings make every outbound reply
-// ambiguous and the send resolver refuses rather than guessing, so a second
-// binding would not add a channel — it would take away the ability to reply on
-// either. The refusal has to say WHICH rule it lost to: the remedy is to
-// disconnect what is already bound, not to try another bot.
-func TestConnectRefusesASecondBotInTheSameWorkspace(t *testing.T) {
+// One live bot per installation (F22). Two live bindings make every outbound
+// reply ambiguous and the send resolver refuses rather than guessing, so a
+// second binding would not add a channel — it would take away the ability to
+// reply on either. The refusal has to name the remedy: disconnect what is
+// already bound, rather than try another bot.
+func TestConnectRefusesASecondBot(t *testing.T) {
 	api := newFakeTelegram()
 	firstToken, _ := api.withNewBot("first_bot")
 	secondToken, _ := api.withNewBot("second_bot")

--- a/backend/internal/modules/capture/channelconnedit.go
+++ b/backend/internal/modules/capture/channelconnedit.go
@@ -226,7 +226,7 @@ func (s *ChannelStore) readChannelRow(ctx context.Context, id ids.UUID) (channel
 	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		row := tx.QueryRow(ctx, `SELECT `+channelConnectionColumns+`, credential_ref
 			 FROM channel_connection WHERE id = $1 AND archived_at IS NULL`, id)
-		return row.Scan(&out.ID, &out.WorkspaceID, &out.Provider, &out.ChannelID, &out.ChannelLabel,
+		return row.Scan(&out.ID, &out.Provider, &out.ChannelID, &out.ChannelLabel,
 			&out.Status, &out.Version, &out.CreatedAt, &out.UpdatedAt, &credentialRef)
 	})
 	if errors.Is(err, pgx.ErrNoRows) {

--- a/backend/internal/modules/capture/channelconnfixture_test.go
+++ b/backend/internal/modules/capture/channelconnfixture_test.go
@@ -59,11 +59,9 @@ func newFakeTelegram() *fakeTelegram {
 	return &fakeTelegram{bots: map[string]telegram.Bot{}}
 }
 
-// nextBotID hands out a bot id unique within the test binary. It has to be
-// unique because uq_channel_connection_bot is GLOBAL by design: two tests
-// reusing one bot id would collide across their workspaces exactly as two
-// installations sharing a bot would, and the second would fail for a reason
-// that has nothing to do with what it is testing.
+// nextBotID hands out a bot id unique within the test binary, so that a test
+// asserting something about ITS bot is never answered by a row another test
+// left behind — these suites share one database.
 var nextBotID atomic.Int64
 
 // withNewBot registers a fresh bot Telegram accepts and returns its token and
@@ -338,7 +336,7 @@ func (f *channelFixture) rowCount(t *testing.T) int {
 	owner, _ := setupCaptureDB(t)
 	var n int
 	if err := owner.QueryRow(context.Background(),
-		`SELECT count(*) FROM channel_connection WHERE workspace_id = $1`, f.ws).Scan(&n); err != nil {
+		`SELECT count(*) FROM channel_connection`).Scan(&n); err != nil {
 		t.Fatalf("counting channel_connection rows: %v", err)
 	}
 	return n

--- a/backend/internal/modules/capture/channelpoll.go
+++ b/backend/internal/modules/capture/channelpoll.go
@@ -117,13 +117,22 @@ func DueChannelConnections(ctx context.Context, pool *pgxpool.Pool, provider str
 func LoadChannelPollTarget(ctx context.Context, pool *pgxpool.Pool, provider string, id ids.UUID) (ChannelPollTarget, error) {
 	var out ChannelPollTarget
 	var credentialRef string
+	// The workspace comes from the ctx the caller already established from the
+	// job's args, not from the row: the poll runs bound to a tenant before it
+	// asks which connection to poll, so reading it back would only re-state what
+	// the transaction is already scoped to.
+	ws, ok := principal.WorkspaceID(ctx)
+	if !ok {
+		return ChannelPollTarget{}, errors.New("capture: loading a channel poll target outside workspace context")
+	}
+	out.WorkspaceID = ws
 	err := database.WithWorkspaceTx(ctx, pool, func(tx pgx.Tx) error {
 		return tx.QueryRow(ctx, `
-			SELECT id, workspace_id, channel_id, credential_ref, poll_offset
+			SELECT id, channel_id, credential_ref, poll_offset
 			  FROM channel_connection
 			 WHERE id = $1 AND provider = $2 AND status = $3 AND archived_at IS NULL`,
 			id, provider, channelStatusConnected).
-			Scan(&out.ID, &out.WorkspaceID, &out.ChannelID, &credentialRef, &out.PollOffset)
+			Scan(&out.ID, &out.ChannelID, &credentialRef, &out.PollOffset)
 	})
 	if errors.Is(err, pgx.ErrNoRows) {
 		return ChannelPollTarget{}, apperrors.ErrNotFound

--- a/backend/internal/modules/capture/channelsend.go
+++ b/backend/internal/modules/capture/channelsend.go
@@ -207,15 +207,12 @@ func (r *Registry) liveChannelBinding(ctx context.Context, provider string) (cha
 func (r *Registry) liveChannelBindings(ctx context.Context, provider string) ([]channelBinding, error) {
 	var bindings []channelBinding
 	err := r.db.Tx(ctx, func(tx pgx.Tx) error {
-		// The workspace predicate is the query's own. Tenant isolation used to
-		// supply it, so this read saw one installation's bindings without
-		// saying so; with RLS retired (ADR-0091 §8 phase A) an unscoped read
-		// resolves another installation's bot and the send then fails on a
-		// credential it was never entitled to unseal.
+		// Every live binding of this provider, which uq_channel_connection_ws
+		// permits exactly one of — the caller below is what refuses to guess if
+		// that ever stops being true.
 		rows, err := tx.Query(ctx, `
 			SELECT id, version, credential_ref FROM channel_connection
-			 WHERE provider = $1 AND status = $2 AND archived_at IS NULL
-			   AND workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid`,
+			 WHERE provider = $1 AND status = $2 AND archived_at IS NULL`,
 			provider, channelStatusConnected)
 		if err != nil {
 			return err

--- a/backend/internal/modules/capture/channelsend_integration_test.go
+++ b/backend/internal/modules/capture/channelsend_integration_test.go
@@ -126,7 +126,7 @@ func TestChannelSenderForResolvesTheWorkspacesBotToken(t *testing.T) {
 	var connections int
 	owner, _ := setupCaptureDB(t)
 	if err := owner.QueryRow(context.Background(),
-		`SELECT count(*) FROM capture_connection WHERE workspace_id = $1`, f.ws).Scan(&connections); err != nil {
+		`SELECT count(*) FROM capture_connection`).Scan(&connections); err != nil {
 		t.Fatal(err)
 	}
 	if connections != 0 {
@@ -205,9 +205,9 @@ func TestASecondLiveBindingCannotBeCreatedForTheResolveToGuessBetween(t *testing
 	owner, _ := setupCaptureDB(t)
 	_, err := owner.Exec(context.Background(), `
 		INSERT INTO channel_connection
-		  (workspace_id, provider, channel_id, channel_label, credential_ref, status, connected_by)
-		SELECT workspace_id, provider, channel_id || '9', channel_label, credential_ref, status, connected_by
-		  FROM channel_connection WHERE workspace_id = $1 AND archived_at IS NULL`, f.ws)
+		  (provider, channel_id, channel_label, credential_ref, status, connected_by)
+		SELECT provider, channel_id || '9', channel_label, credential_ref, status, connected_by
+		  FROM channel_connection WHERE archived_at IS NULL`)
 	if err == nil {
 		t.Fatal("a second live binding was written for this workspace — every reply would then be ambiguous and the resolver would refuse to send at all")
 	}
@@ -290,25 +290,5 @@ func TestASendRefusesAfterItsBotWasReplaced(t *testing.T) {
 	}
 	if len(provider.sent) != 1 {
 		t.Fatalf("the provider saw %d message(s), want the one sent through the replacement", len(provider.sent))
-	}
-}
-
-// The resolve's own workspace predicate scopes it: another workspace's live
-// binding is not this workspace's sender, whatever the global bot index says.
-func TestChannelSenderForDoesNotReachAnotherWorkspacesBinding(t *testing.T) {
-	api := newFakeTelegram()
-	bound := newChannelFixture(t, api)
-	connectChannel(t, bound, "otherworkspacebot")
-
-	unbound := newChannelFixture(t, api)
-	reg := channelSendRegistry(t, unbound, &channelSendConnector{})
-	if _, _, err := reg.ChannelSenderFor(unbound.ctx, capture.ProviderTelegram); !errors.Is(err, capture.ErrNoConnection) {
-		t.Fatalf("ChannelSenderFor across workspaces = %v, want ErrNoConnection", err)
-	}
-	// The other workspace still resolves its own, so the isolation is a scope
-	// and not a broken lookup.
-	boundReg := channelSendRegistry(t, bound, &channelSendConnector{})
-	if _, auth, err := boundReg.ChannelSenderFor(bound.ctx, capture.ProviderTelegram); err != nil || len(auth) == 0 {
-		t.Fatalf("the owning workspace resolved (%v, %d bytes of credential)", err, len(auth))
 	}
 }

--- a/backend/internal/modules/capture/digest.go
+++ b/backend/internal/modules/capture/digest.go
@@ -82,8 +82,8 @@ func (r *Registry) BuildDigests(ctx context.Context, digestDate time.Time) error
 				return fmt.Errorf("capture: encoding digest: %w", err)
 			}
 			if _, err := tx.Exec(ctx, `
-				INSERT INTO capture_digest (workspace_id, user_id, digest_date, payload)
-				VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, $2, $3)
+				INSERT INTO capture_digest (user_id, digest_date, payload)
+				VALUES ($1, $2, $3)
 				ON CONFLICT (user_id, digest_date) DO UPDATE SET payload = EXCLUDED.payload`,
 				userID, day, raw); err != nil {
 				return fmt.Errorf("capture: storing digest: %w", err)

--- a/backend/internal/modules/capture/freemaildomain.go
+++ b/backend/internal/modules/capture/freemaildomain.go
@@ -186,11 +186,11 @@ func (s *FreemailDomainStore) Add(ctx context.Context, domain, kind string) (Fre
 			return err
 		}
 		if err := tx.QueryRow(ctx, `
-			INSERT INTO capture_freemail_domain (workspace_id, domain, kind, created_by)
-			VALUES ($1, $2, $3, $4)
+			INSERT INTO capture_freemail_domain (domain, kind, created_by)
+			VALUES ($1, $2, $3)
 			ON CONFLICT (domain) DO UPDATE SET kind = EXCLUDED.kind
 			RETURNING id, domain, kind, created_at`,
-			storekit.MustWorkspace(ctx), base, kind, freemailEntryAuthor(ctx)).
+			base, kind, freemailEntryAuthor(ctx)).
 			Scan(&out.ID, &out.Domain, &out.Kind, &out.CreatedAt); err != nil {
 			return err
 		}

--- a/backend/internal/modules/capture/handlers_channel.go
+++ b/backend/internal/modules/capture/handlers_channel.go
@@ -168,7 +168,7 @@ func writeChannelErr(w http.ResponseWriter, r *http.Request, err error) {
 		httperr.Write(w, r, &httperr.DetailedError{
 			Status: http.StatusConflict,
 			Code:   "channel_workspace_already_bound",
-			Detail: "Another bot is already connected to this workspace. Disconnect it first, or replace its token to point it at a different bot.",
+			Detail: "Another bot is already connected. Disconnect it first, or replace its token to point it at a different bot.",
 		})
 	case errors.Is(err, ErrChannelWiringIncomplete):
 		httperr.Write(w, r, &httperr.DetailedError{

--- a/backend/internal/modules/capture/owndomainstore.go
+++ b/backend/internal/modules/capture/owndomainstore.go
@@ -133,8 +133,8 @@ func (s *OwnDomainStore) Add(ctx context.Context, raw string) (OwnDomain, error)
 			return fmt.Errorf("capture: reading the domain's prior state: %w", err)
 		}
 		if err := tx.QueryRow(ctx, `
-			INSERT INTO workspace_email_domain (workspace_id, domain, source, verified)
-			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, 'admin', true)
+			INSERT INTO workspace_email_domain (domain, source, verified)
+			VALUES ($1, 'admin', true)
 			ON CONFLICT (domain)
 			  DO UPDATE SET source = 'admin', verified = true
 			RETURNING domain, source, verified, created_at`, domain).
@@ -170,16 +170,10 @@ func (s *OwnDomainStore) Remove(ctx context.Context, raw string) error {
 		return nil
 	}
 	return s.db.Tx(ctx, func(tx pgx.Tx) error {
-		// The workspace predicate is the statement's own. Tenant isolation used
-		// to supply it, so this DELETE reached exactly one workspace's row
-		// without saying so; with RLS retired (ADR-0091 §8 phase A) an unscoped
-		// delete removes the domain from EVERY installation that registered it.
-		// The binding is read where the insert above reads it — from the
-		// transaction, not from ctx.
+		// The domain IS the key now (ADR-0091 §8 phase D): one installation, one
+		// list, and the unique index the insert above conflicts on says the same.
 		tag, err := tx.Exec(ctx,
-			`DELETE FROM workspace_email_domain
-			  WHERE domain = $1
-			    AND workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid`, domain)
+			`DELETE FROM workspace_email_domain WHERE domain = $1`, domain)
 		if err != nil {
 			return fmt.Errorf("capture: removing own domain: %w", err)
 		}

--- a/backend/internal/modules/capture/owndomainstore_integration_test.go
+++ b/backend/internal/modules/capture/owndomainstore_integration_test.go
@@ -90,8 +90,8 @@ func TestAddingACandidateDomainConfirmsIt(t *testing.T) {
 	ctx, db := ownDomainWorkspace(t)
 	if err := db.Tx(ctx, func(tx pgx.Tx) error {
 		_, err := tx.Exec(ctx, `
-			INSERT INTO workspace_email_domain (workspace_id, domain, source, verified)
-			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, 'acme.com', 'mailbox', false)`)
+			INSERT INTO workspace_email_domain (domain, source, verified)
+			VALUES ('acme.com', 'mailbox', false)`)
 		return err
 	}); err != nil {
 		t.Fatalf("seeding the candidate: %v", err)

--- a/backend/internal/modules/capture/pending.go
+++ b/backend/internal/modules/capture/pending.go
@@ -218,10 +218,9 @@ func recordDisposition(ctx context.Context, tx pgx.Tx, in dispositionRow) (strin
 	// silently waits out the skew before anything claims it.
 	_, err = tx.Exec(ctx, `
 		INSERT INTO capture_pending_counterparty
-		  (workspace_id, email, domain, display_name, activity_id, owner_id, status,
+		  (email, domain, display_name, activity_id, owner_id, status,
 		   disposition_reason, next_attempt_at)
-		VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid,
-		        $1, NULLIF($2, ''), NULLIF($3, ''), $4, $5, $6, NULLIF($7, ''),
+		VALUES ($1, NULLIF($2, ''), NULLIF($3, ''), $4, $5, $6, NULLIF($7, ''),
 		        CASE WHEN $8::boolean THEN now() END)
 		ON CONFLICT `+conflict+`
 		DO NOTHING`,

--- a/backend/internal/modules/capture/pendingsweeps.go
+++ b/backend/internal/modules/capture/pendingsweeps.go
@@ -329,8 +329,7 @@ func (s *PendingStore) NoiseMailToRedact(ctx context.Context, window time.Durati
 		AND (a.subject IS NOT NULL OR a.body IS NOT NULL OR a.raw IS NOT NULL
 		     OR EXISTS (
 		       SELECT 1 FROM raw_capture r
-		        WHERE r.workspace_id = a.workspace_id
-		          AND r.source_system = a.source_system AND r.source_id = a.source_id))`, limit)
+		        WHERE r.source_system = a.source_system AND r.source_id = a.source_id))`, limit)
 }
 
 // NoiseMailForTx is NoiseMailToHide for ONE address on the caller's transaction
@@ -386,7 +385,6 @@ func (s *PendingStore) PurgeRawCaptureTx(ctx context.Context, tx pgx.Tx, activit
 		DELETE FROM raw_capture r
 		 USING activity a
 		 WHERE a.id = ANY($1)
-		   AND r.workspace_id = a.workspace_id
 		   AND r.source_system = a.source_system AND r.source_id = a.source_id`, activityIDs); err != nil {
 		return fmt.Errorf("capture: purging the redacted mail's provider originals: %w", err)
 	}

--- a/backend/internal/modules/capture/push.go
+++ b/backend/internal/modules/capture/push.go
@@ -47,8 +47,8 @@ func BumpDueByMailbox(ctx context.Context, pool *pgxpool.Pool, provider, email s
 			// Upsert, not update: a connection that has never synced has no
 			// sidecar row yet — a push for it must still land.
 			rows, err := tx.Query(ctx, `
-				INSERT INTO capture_sync_state (connection_id, workspace_id, next_sync_at)
-				SELECT c.id, c.workspace_id, now()
+				INSERT INTO capture_sync_state (connection_id, next_sync_at)
+				SELECT c.id, now()
 				FROM capture_connection c
 				WHERE c.provider = $1
 				  AND c.status IN ('connected','error')

--- a/backend/internal/modules/capture/rawcapture.go
+++ b/backend/internal/modules/capture/rawcapture.go
@@ -46,8 +46,8 @@ type RawRecord struct {
 func InsertRawCaptureTx(ctx context.Context, tx pgx.Tx, rec RawRecord) (ids.UUID, error) {
 	var id ids.UUID
 	err := tx.QueryRow(ctx, `
-		INSERT INTO raw_capture (workspace_id, source_system, source_id, payload)
-		VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, $2, $3)
+		INSERT INTO raw_capture (source_system, source_id, payload)
+		VALUES ($1, $2, $3)
 		ON CONFLICT (source_system, source_id) DO UPDATE
 		SET payload = EXCLUDED.payload, received_at = now()
 		RETURNING id`,

--- a/backend/internal/modules/capture/registry.go
+++ b/backend/internal/modules/capture/registry.go
@@ -335,8 +335,8 @@ func seedDomainOfAddressTx(ctx context.Context, tx pgx.Tx, address string) error
 	// the answer down would mean a domain that stopped being ours went on
 	// suppressing mail forever.
 	if _, err := tx.Exec(ctx, `
-		INSERT INTO workspace_email_domain (workspace_id, domain, source, verified)
-		VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, 'mailbox', false)
+		INSERT INTO workspace_email_domain (domain, source, verified)
+		VALUES ($1, 'mailbox', false)
 		ON CONFLICT (domain) DO NOTHING`, domain); err != nil {
 		return fmt.Errorf("capture: seeding workspace email domain: %w", err)
 	}

--- a/backend/internal/modules/capture/registry_disconnect_integration_test.go
+++ b/backend/internal/modules/capture/registry_disconnect_integration_test.go
@@ -195,14 +195,10 @@ func connectFixtureConnection(ctx context.Context, t *testing.T, reg *capture.Re
 	if _, err := reg.Connect(ctx, "gmail", connector.Auth("fixture-token")); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
-	wsUUID, ok := principal.WorkspaceID(ctx)
-	if !ok {
-		t.Fatal("connectFixtureConnection: ctx carries no workspace")
-	}
 	var status string
 	var ref *string
 	var auth []byte
-	if err := queryConnectionRow(ctx, t, ids.From[ids.WorkspaceKind](wsUUID), &status, &ref, &auth); err != nil {
+	if err := queryConnectionRow(ctx, t, &status, &ref, &auth); err != nil {
 		t.Fatalf("reading back the connection Connect wrote: %v", err)
 	}
 	if ref == nil {
@@ -216,12 +212,12 @@ func connectFixtureConnection(ctx context.Context, t *testing.T, reg *capture.Re
 // RLS on purpose, since the test asserts what the row actually holds, not
 // what one workspace's policy exposes. "gmail" is the only provider any
 // fixture in this file connects.
-func queryConnectionRow(ctx context.Context, t *testing.T, ws ids.WorkspaceID, status *string, credentialRef **string, auth *[]byte) error {
+func queryConnectionRow(ctx context.Context, t *testing.T, status *string, credentialRef **string, auth *[]byte) error {
 	t.Helper()
 	owner, _ := setupCaptureDB(t)
 	return owner.QueryRow(ctx,
-		`SELECT status, credential_ref, auth FROM capture_connection WHERE workspace_id = $1 AND provider = 'gmail'`,
-		ws.UUID).Scan(status, credentialRef, auth)
+		`SELECT status, credential_ref, auth FROM capture_connection WHERE provider = 'gmail'`).
+		Scan(status, credentialRef, auth)
 }
 
 // Disconnecting must not leave a live credential behind: the row stops being
@@ -246,7 +242,7 @@ func TestDisconnectDeletesTheStoredCredential(t *testing.T) {
 	var status string
 	var credentialRef *string
 	var authBytes []byte
-	if err := queryConnectionRow(ctx, t, ws, &status, &credentialRef, &authBytes); err != nil {
+	if err := queryConnectionRow(ctx, t, &status, &credentialRef, &authBytes); err != nil {
 		t.Fatalf("reading the row back: %v", err)
 	}
 	if status != "disconnected" {
@@ -302,13 +298,13 @@ func TestConnectRecordsTheAccountLabel(t *testing.T) {
 // column, credential_ref is NULL. Registry.Connect always vault-seals, so a
 // legacy row can only be produced directly against the DB — this is the
 // fixture's own precondition, not the code under test.
-func insertLegacyConnection(ctx context.Context, t *testing.T, ws ids.WorkspaceID, userID ids.UserID, provider string, authBytes []byte) {
+func insertLegacyConnection(ctx context.Context, t *testing.T, userID ids.UserID, provider string, authBytes []byte) {
 	t.Helper()
 	owner, _ := setupCaptureDB(t)
 	if _, err := owner.Exec(ctx, `
-		INSERT INTO capture_connection (workspace_id, provider, user_id, status, auth)
-		VALUES ($1, $2, $3, 'connected', $4)`,
-		ws.UUID, provider, userID.UUID, authBytes); err != nil {
+		INSERT INTO capture_connection (provider, user_id, status, auth)
+		VALUES ($1, $2, 'connected', $3)`,
+		provider, userID.UUID, authBytes); err != nil {
 		t.Fatalf("inserting the legacy connection fixture: %v", err)
 	}
 }
@@ -318,9 +314,9 @@ func insertLegacyConnection(ctx context.Context, t *testing.T, ws ids.WorkspaceI
 // survive disconnect: a credential_ref-only predicate matches no such row,
 // leaving it connected with the secret still in auth column forever.
 func TestDisconnectErasesALegacyAuthOnlyRow(t *testing.T) {
-	ctx, reg, _, ws := newCaptureRegistryFixture(t)
+	ctx, reg, _, _ := newCaptureRegistryFixture(t)
 	actor, _ := principal.Actor(ctx)
-	insertLegacyConnection(ctx, t, ws, ids.From[ids.UserKind](actor.UserID), "gmail", []byte("legacy-refresh-token"))
+	insertLegacyConnection(ctx, t, ids.From[ids.UserKind](actor.UserID), "gmail", []byte("legacy-refresh-token"))
 
 	if err := reg.Disconnect(ctx, "gmail"); err != nil {
 		t.Fatalf("Disconnect: %v", err)
@@ -329,7 +325,7 @@ func TestDisconnectErasesALegacyAuthOnlyRow(t *testing.T) {
 	var status string
 	var credentialRef *string
 	var authBytes []byte
-	if err := queryConnectionRow(ctx, t, ws, &status, &credentialRef, &authBytes); err != nil {
+	if err := queryConnectionRow(ctx, t, &status, &credentialRef, &authBytes); err != nil {
 		t.Fatalf("reading the row back: %v", err)
 	}
 	if status != "disconnected" {
@@ -367,7 +363,7 @@ func TestReconnectDeletesThePriorSecret(t *testing.T) {
 	var status string
 	var secondRef *string
 	var authBytes []byte
-	if err := queryConnectionRow(ctx, t, ws, &status, &secondRef, &authBytes); err != nil {
+	if err := queryConnectionRow(ctx, t, &status, &secondRef, &authBytes); err != nil {
 		t.Fatalf("reading the row back: %v", err)
 	}
 	if secondRef == nil {
@@ -403,7 +399,7 @@ func TestDisconnectCompletesEvenWhenTheVaultDeleteFails(t *testing.T) {
 	var status string
 	var credentialRef *string
 	var authBytes []byte
-	if err := queryConnectionRow(ctx, t, ws, &status, &credentialRef, &authBytes); err != nil {
+	if err := queryConnectionRow(ctx, t, &status, &credentialRef, &authBytes); err != nil {
 		t.Fatalf("reading the row back: %v", err)
 	}
 	if status != "disconnected" {
@@ -445,7 +441,7 @@ func TestDisconnectPhase3DoesNotClobberAConcurrentReconnect(t *testing.T) {
 		t.Fatalf("concurrent reconnect: %v", err)
 	}
 	var secondRef *string
-	if err := queryConnectionRow(ctx, t, ws, new(string), &secondRef, new([]byte)); err != nil {
+	if err := queryConnectionRow(ctx, t, new(string), &secondRef, new([]byte)); err != nil {
 		t.Fatalf("reading the reconnected row: %v", err)
 	}
 	if secondRef == nil || keyvault.Ref(*secondRef) == firstRef {
@@ -459,7 +455,7 @@ func TestDisconnectPhase3DoesNotClobberAConcurrentReconnect(t *testing.T) {
 
 	var status string
 	var finalRef *string
-	if err := queryConnectionRow(ctx, t, ws, &status, &finalRef, new([]byte)); err != nil {
+	if err := queryConnectionRow(ctx, t, &status, &finalRef, new([]byte)); err != nil {
 		t.Fatalf("reading the final row: %v", err)
 	}
 	if status != "connected" {

--- a/backend/internal/modules/capture/registry_grant.go
+++ b/backend/internal/modules/capture/registry_grant.go
@@ -226,8 +226,7 @@ func upsertConnection(ctx context.Context, tx pgx.Tx, in connectionUpsert) (ids.
 	var priorRef, priorStatus, priorLabel *string
 	if err := tx.QueryRow(ctx, `
 		SELECT credential_ref, status, account_label FROM capture_connection
-		 WHERE workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid
-		   AND user_id = $1 AND provider = $2
+		 WHERE user_id = $1 AND provider = $2
 		   FOR UPDATE`,
 		in.userID, in.provider).Scan(&priorRef, &priorStatus, &priorLabel); err != nil && !errors.Is(err, pgx.ErrNoRows) {
 		return ids.Nil, nil, err
@@ -238,7 +237,7 @@ func upsertConnection(ctx context.Context, tx pgx.Tx, in connectionUpsert) (ids.
 	// The generation bump fences every cycle still out at the provider: a sync or
 	// backfill page holding the old generation commits nothing onto a row now
 	// pointing at another mailbox. And the watermark goes: the row is keyed on
-	// (workspace, user, provider), so a second account authorized over the first
+	// (user, provider), so a second account authorized over the first
 	// lands on the SAME row, and the previous mailbox's cursor would tell the new
 	// one to resume from a point it has never reached — silently skipping
 	// everything before it.
@@ -251,8 +250,8 @@ func upsertConnection(ctx context.Context, tx pgx.Tx, in connectionUpsert) (ids.
 	rebound := rebindsAccount(priorLabel, in.accountLabel)
 	var id ids.UUID
 	if err := tx.QueryRow(ctx, `
-		INSERT INTO capture_connection (workspace_id, provider, user_id, scopes, credential_ref, status, account_label, provider_scopes)
-		VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, $2, $3, $4, 'connected', $5, $6)
+		INSERT INTO capture_connection (provider, user_id, scopes, credential_ref, status, account_label, provider_scopes)
+		VALUES ($1, $2, $3, $4, 'connected', $5, $6)
 		ON CONFLICT (user_id, provider)
 		DO UPDATE SET credential_ref = EXCLUDED.credential_ref, auth = NULL, status = 'connected', archived_at = NULL,
 		              account_label = EXCLUDED.account_label, provider_scopes = EXCLUDED.provider_scopes,

--- a/backend/internal/modules/capture/sink.go
+++ b/backend/internal/modules/capture/sink.go
@@ -232,8 +232,8 @@ func storeRawCapture(ctx context.Context, tx pgx.Tx, rec connector.NormalizedRec
 		payload = encoded
 	}
 	if _, err := tx.Exec(ctx, `
-		INSERT INTO raw_capture (workspace_id, source_system, source_id, payload)
-		VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, $2, $3)
+		INSERT INTO raw_capture (source_system, source_id, payload)
+		VALUES ($1, $2, $3)
 		ON CONFLICT (source_system, source_id) DO NOTHING`,
 		rec.NaturalKey.SourceSystem, rec.NaturalKey.SourceID, payload); err != nil {
 		return fmt.Errorf("capture: raw store: %w", err)

--- a/backend/internal/modules/capture/sinkchannel_integration_test.go
+++ b/backend/internal/modules/capture/sinkchannel_integration_test.go
@@ -75,8 +75,7 @@ func TestChannelRecordSkipsEveryMailDomainGate(t *testing.T) {
 	// The workspace's own mail domain, so the T0 colleagues gate has something
 	// to find if anything ever asks it about a record with no domain.
 	if _, err := owner.Exec(ctx,
-		`INSERT INTO workspace_email_domain (workspace_id, domain) VALUES ($1, 'own-house.test')`,
-		ws); err != nil {
+		`INSERT INTO workspace_email_domain (domain) VALUES ('own-house.test')`); err != nil {
 		t.Fatalf("seeding the internal mail domain: %v", err)
 	}
 
@@ -136,7 +135,7 @@ func TestChannelRecordSkipsEveryMailDomainGate(t *testing.T) {
 	// a channel sender could only ever be a verdict about nobody.
 	var dispositions int
 	if err := owner.QueryRow(ctx,
-		`SELECT count(*) FROM capture_pending_counterparty WHERE workspace_id = $1`, ws).Scan(&dispositions); err != nil {
+		`SELECT count(*) FROM capture_pending_counterparty`).Scan(&dispositions); err != nil {
 		t.Fatalf("counting dispositions: %v", err)
 	}
 	if dispositions != 0 {
@@ -155,7 +154,7 @@ func TestChannelRecordSkipsEveryMailDomainGate(t *testing.T) {
 	// linked and answered conversation is waiting on a verdict.
 	var outcomes []string
 	traceRows, err := owner.Query(ctx,
-		`SELECT outcome FROM capture_trace WHERE workspace_id = $1 ORDER BY outcome`, ws)
+		`SELECT outcome FROM capture_trace ORDER BY outcome`)
 	if err != nil {
 		t.Fatalf("reading the pipeline trace: %v", err)
 	}

--- a/backend/internal/modules/capture/sinkinternal_integration_test.go
+++ b/backend/internal/modules/capture/sinkinternal_integration_test.go
@@ -319,8 +319,8 @@ func TestAnUnverifiedOwnDomainSuppressesNothing(t *testing.T) {
 	ctx, db := bootstrapInternalMailWorkspace(t)
 	if err := db.Tx(ctx, func(tx pgx.Tx) error {
 		_, err := tx.Exec(ctx, `
-			INSERT INTO workspace_email_domain (workspace_id, domain, source, verified)
-			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, 'acme.com', 'mailbox', false)`)
+			INSERT INTO workspace_email_domain (domain, source, verified)
+			VALUES ('acme.com', 'mailbox', false)`)
 		return err
 	}); err != nil {
 		t.Fatalf("seeding an unverified domain: %v", err)

--- a/backend/internal/modules/capture/syncstate.go
+++ b/backend/internal/modules/capture/syncstate.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
-	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/connector"
 )
 
@@ -87,40 +86,26 @@ func backoffDelay(consecutiveFailures int) time.Duration {
 	return time.Duration(float64(d) * jitter)
 }
 
-// syncStateWorkspace names the workspace the sidecar row belongs to; the
-// scheduling calls only run under the fleet walk's per-workspace ctx.
-func syncStateWorkspace(ctx context.Context) (ids.UUID, error) {
-	ws, ok := principal.WorkspaceID(ctx)
-	if !ok {
-		return ids.Nil, errors.New("capture: sync-state recording outside workspace context")
-	}
-	return ws, nil
-}
-
 // recordSyncSuccess resets the ladder, paces the next sync one interval out,
 // and — the auto-recovery path — flips a degraded connection back to
 // connected. One success heals everything.
 func (r *Registry) recordSyncSuccess(ctx context.Context, connectionID ids.UUID) error {
-	ws, err := syncStateWorkspace(ctx)
-	if err != nil {
-		return err
-	}
 	return r.db.Tx(ctx, func(tx pgx.Tx) error {
 		now := r.now()
 		// The interval is a DELAY the database applies to its own clock; the
 		// two last_*_at columns record when this process observed the sync and
 		// stay on its clock, which is the one that observed it.
 		if _, err := tx.Exec(ctx, `
-			INSERT INTO capture_sync_state (connection_id, workspace_id, next_sync_at,
+			INSERT INTO capture_sync_state (connection_id, next_sync_at,
 			                                consecutive_failures, last_synced_at, last_success_at, last_error_class)
-			VALUES ($1, $2, now() + make_interval(secs => $3), 0, $4, $4, NULL)
+			VALUES ($1, now() + make_interval(secs => $2), 0, $3, $3, NULL)
 			ON CONFLICT (connection_id) DO UPDATE SET
-			  next_sync_at = now() + make_interval(secs => $3),
+			  next_sync_at = now() + make_interval(secs => $2),
 			  consecutive_failures = 0,
 			  last_synced_at = EXCLUDED.last_synced_at,
 			  last_success_at = EXCLUDED.last_success_at,
 			  last_error_class = NULL`,
-			connectionID, ws, r.syncInterval.Seconds(), now); err != nil {
+			connectionID, r.syncInterval.Seconds(), now); err != nil {
 			return err
 		}
 		_, err := tx.Exec(ctx, `
@@ -143,24 +128,20 @@ func (r *Registry) recordSyncSuccess(ctx context.Context, connectionID ids.UUID)
 // a degraded connection has to be able to write its verdict.
 func (r *Registry) recordSyncFailure(ctx context.Context, connectionID ids.UUID, syncErr error) error {
 	class := classifySyncError(syncErr)
-	ws, err := syncStateWorkspace(ctx)
-	if err != nil {
-		return err
-	}
 	return r.db.Tx(ctx, func(tx pgx.Tx) error {
 		now := r.now()
 
 		var failures int
 		if err := tx.QueryRow(ctx, `
-			INSERT INTO capture_sync_state (connection_id, workspace_id, next_sync_at,
+			INSERT INTO capture_sync_state (connection_id, next_sync_at,
 			                                consecutive_failures, last_synced_at, last_error_class)
-			VALUES ($1, $2, now() + make_interval(secs => $3), 1, $4, $5)
+			VALUES ($1, now() + make_interval(secs => $2), 1, $3, $4)
 			ON CONFLICT (connection_id) DO UPDATE SET
 			  consecutive_failures = capture_sync_state.consecutive_failures + 1,
 			  last_synced_at = EXCLUDED.last_synced_at,
 			  last_error_class = EXCLUDED.last_error_class
 			RETURNING consecutive_failures`,
-			connectionID, ws, backoffDelay(0).Seconds(), now, string(class)).Scan(&failures); err != nil {
+			connectionID, backoffDelay(0).Seconds(), now, string(class)).Scan(&failures); err != nil {
 			return err
 		}
 

--- a/backend/internal/modules/capture/trace.go
+++ b/backend/internal/modules/capture/trace.go
@@ -196,15 +196,14 @@ func Trace(ctx context.Context, tx pgx.Tx, in TraceEntry, payloads bool) error {
 		return payloadErr
 	}
 	tag, err := tx.Exec(ctx, `
-		INSERT INTO capture_trace (workspace_id, user_id, connector, source_system, source_id,
+		INSERT INTO capture_trace (user_id, connector, source_system, source_id,
 		                           stage, outcome, reason, activity_id, counterparty, subject)
-		VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid,
-		        $1, $2, $3, $4, $5, $6, NULLIF($7, ''), $8, $9, $10)
+		VALUES ($1, $2, $3, $4, $5, $6, NULLIF($7, ''), $8, $9, $10)
 		-- The conflict target SPELLS the index's expression, COALESCE and all: a
 		-- bare column list does not match an expression index, and Postgres
 		-- answers that with an error on every insert -- which, on the capture
 		-- transaction, would fail every capture in the deployment.
-		ON CONFLICT (workspace_id, COALESCE(user_id, '00000000-0000-0000-0000-000000000000'::uuid),
+		ON CONFLICT (COALESCE(user_id, '00000000-0000-0000-0000-000000000000'::uuid),
 		             source_system, source_id, stage, outcome) DO NOTHING`,
 		nullableID(in.UserID), in.Connector, in.SourceSystem,
 		traceSourceID(in.SourceID, in.ChannelIdentity),

--- a/backend/internal/modules/capture/trace_integration_test.go
+++ b/backend/internal/modules/capture/trace_integration_test.go
@@ -55,14 +55,8 @@ func traceRows(ctx context.Context, t *testing.T, db *database.DB, sourceID stri
 	t.Helper()
 	var n int
 	if err := db.Tx(ctx, func(tx pgx.Tx) error {
-		// The workspace predicate is spelled here for the same reason the store
-		// spells it: there is no RLS behind this table, so a query without one
-		// counts other workspaces' rows — and in a package whose tests share a
-		// database, that means counting another test's.
 		return tx.QueryRow(ctx, `
-			SELECT count(*) FROM capture_trace
-			 WHERE workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid
-			   AND source_id = $1`, sourceID).Scan(&n)
+			SELECT count(*) FROM capture_trace WHERE source_id = $1`, sourceID).Scan(&n)
 	}); err != nil {
 		t.Fatalf("counting traces: %v", err)
 	}
@@ -141,11 +135,11 @@ func TestWorkspaceOwnedRowsCarryNoMemberAndStillDedupe(t *testing.T) {
 	var userID *ids.UUID
 	if err := db.Tx(ctx, func(tx pgx.Tx) error {
 		if err := tx.QueryRow(ctx,
-			`SELECT count(*) FROM capture_trace WHERE workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid AND connector = 'telegram'`).Scan(&rows); err != nil {
+			`SELECT count(*) FROM capture_trace WHERE connector = 'telegram'`).Scan(&rows); err != nil {
 			return err
 		}
 		return tx.QueryRow(ctx,
-			`SELECT user_id FROM capture_trace WHERE workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid AND connector = 'telegram'`).Scan(&userID)
+			`SELECT user_id FROM capture_trace WHERE connector = 'telegram'`).Scan(&userID)
 	}); err != nil {
 		t.Fatalf("reading the workspace row: %v", err)
 	}
@@ -171,7 +165,7 @@ func TestAChannelAccountIdIsHashedNeverStored(t *testing.T) {
 	var stored string
 	if err := db.Tx(ctx, func(tx pgx.Tx) error {
 		return tx.QueryRow(ctx,
-			`SELECT source_id FROM capture_trace WHERE workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid AND connector = 'telegram'`).Scan(&stored)
+			`SELECT source_id FROM capture_trace WHERE connector = 'telegram'`).Scan(&stored)
 	}); err != nil {
 		t.Fatalf("reading the stored key: %v", err)
 	}
@@ -192,7 +186,7 @@ func TestAMailMessageIdIsKept(t *testing.T) {
 	var stored string
 	if err := db.Tx(ctx, func(tx pgx.Tx) error {
 		return tx.QueryRow(ctx,
-			`SELECT source_id FROM capture_trace WHERE workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid AND connector = 'gmail'`).Scan(&stored)
+			`SELECT source_id FROM capture_trace WHERE connector = 'gmail'`).Scan(&stored)
 	}); err != nil {
 		t.Fatalf("reading the stored key: %v", err)
 	}

--- a/backend/internal/modules/capture/traceladder.go
+++ b/backend/internal/modules/capture/traceladder.go
@@ -146,7 +146,6 @@ func (s *TraceStore) anchorByTraceID(ctx context.Context, tx pgx.Tx, id, caller 
 		SELECT source_system, source_id, user_id, connector, activity_id
 		  FROM capture_trace
 		 WHERE id = $1
-		   AND workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid
 		   AND (user_id = $2 OR ($3 AND user_id IS NULL))`, id, caller, shared).
 		Scan(&a.sourceSystem, &a.sourceID, &owner, &a.connector, &a.activityID)
 	if owner != nil {
@@ -173,7 +172,6 @@ func (s *TraceStore) anchorByActivityID(ctx context.Context, tx pgx.Tx, activity
 		SELECT source_system, source_id, user_id, connector, activity_id
 		  FROM capture_trace
 		 WHERE activity_id = $1
-		   AND workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid
 		   AND user_id = $2
 		 ORDER BY occurred_at
 		 LIMIT 1`, activityID, caller).
@@ -201,8 +199,7 @@ func (s *TraceStore) readRungs(ctx context.Context, tx pgx.Tx, a traceAnchor) ([
 	rows, err := tx.Query(ctx, `
 		SELECT `+traceRowColumns+`
 		  FROM capture_trace t`+resolutionJoin+`
-		 WHERE t.workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid
-		   AND t.source_system = $1 AND t.source_id = $2
+		 WHERE t.source_system = $1 AND t.source_id = $2
 		   AND t.user_id IS NOT DISTINCT FROM $3
 		 ORDER BY t.occurred_at, t.id`, a.sourceSystem, a.sourceID, nullableID(a.userID))
 	if err != nil {

--- a/backend/internal/modules/capture/traceresolution_integration_test.go
+++ b/backend/internal/modules/capture/traceresolution_integration_test.go
@@ -112,9 +112,8 @@ func seedRecord(ctx context.Context, t *testing.T, db *database.DB,
 		if rec.Ledger {
 			if _, err := tx.Exec(ctx, `
 				INSERT INTO capture_pending_counterparty
-				       (workspace_id, email, domain, activity_id, owner_id, status, kind, resolved_at)
-				VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid,
-				        $1, 'client.io', $2, $3, $4, 'person', now())`,
+				       (email, domain, activity_id, owner_id, status, kind, resolved_at)
+				VALUES ($1, 'client.io', $2, $3, $4, 'person', now())`,
 				sender, activityID, owner, rec.verdict()); err != nil {
 				return err
 			}

--- a/backend/internal/modules/capture/tracestore.go
+++ b/backend/internal/modules/capture/tracestore.go
@@ -230,8 +230,7 @@ func (s *TraceStore) readPage(ctx context.Context, tx pgx.Tx, scope traceScope,
 func traceWhere(scope traceScope, addArg func(any) int) string {
 	funnel := addArg(pipelinetrace.StageStrings(pipelinetrace.FunnelStages()))
 	return fmt.Sprintf(
-		`t.workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid
-		   AND t.occurred_at > now() - make_interval(hours => %d)
+		`t.occurred_at > now() - make_interval(hours => %d)
 		   AND t.stage = ANY($%d)
 		   AND %s`, TraceWindowHours, funnel, scope.predicate(addArg))
 }
@@ -313,12 +312,11 @@ const traceRowColumns = `t.id, t.stage, t.connector, t.outcome, coalesce(t.reaso
 // disposition cannot join that list and leave this join behind.
 const resolutionJoin = `
 		  LEFT JOIN activity a
-		         ON a.id = t.activity_id AND a.workspace_id = t.workspace_id
+		         ON a.id = t.activity_id
 		  LEFT JOIN LATERAL (
 		         SELECT status, kind, resolved_at
 		           FROM capture_pending_counterparty
-		          WHERE workspace_id = t.workspace_id
-		            AND email = a.counterparty_email
+		          WHERE email = a.counterparty_email
 		            AND (a.channel_provider IS NULL
 		                 OR (t.user_id IS NOT NULL
 		                     AND t.outcome IN ('deferred', 'suppressed')))

--- a/backend/internal/modules/capture/tracesweep.go
+++ b/backend/internal/modules/capture/tracesweep.go
@@ -37,8 +37,7 @@ func (s *TraceStore) SweepOlderThan(ctx context.Context, window time.Duration) (
 				DELETE FROM capture_trace
 				 WHERE ctid IN (
 				   SELECT ctid FROM capture_trace
-				    WHERE workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid
-				      AND occurred_at < now() - $1::interval
+				    WHERE occurred_at < now() - $1::interval
 				    LIMIT $2)`, window.String(), traceSweepBatch)
 			if err != nil {
 				return fmt.Errorf("capture: sweeping the trace: %w", err)

--- a/backend/internal/modules/capture/tracewindowjoin_integration_test.go
+++ b/backend/internal/modules/capture/tracewindowjoin_integration_test.go
@@ -5,68 +5,20 @@
 
 package capture_test
 
-// Two workspaces, because one cannot fail.
+// The trace window's JOIN to the disposition ledger, and its page.
 //
-// There is no RLS behind this table since 0217: the store's own predicates ARE
-// the isolation, and a fixture with a single tenant cannot tell a query that
-// spells them from one that forgot. The join to the disposition ledger is the
-// case that matters — it keys on an ADDRESS, and an address is not unique
-// across tenants, so an unscoped join answers with another installation's
-// verdict about the same person.
+// The join keys on an ADDRESS, and one address can carry several ledger rows —
+// a sender judged noise and later judged real. A plain join fans those out and
+// reports one message once per historical verdict, which also breaks the page's
+// own LIMIT and its cursor. That is what these hold.
 
 import (
-	"context"
 	"testing"
 
 	"github.com/jackc/pgx/v5"
 
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
-	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
-
-// secondWorkspace seeds a neighbour tenant and returns a handle bound to it.
-func secondWorkspace(ctx context.Context, t *testing.T) (context.Context, *database.DB) {
-	t.Helper()
-	owner, pool := setupCaptureDB(t)
-	ws := ids.NewV7()
-	if _, err := owner.Exec(ctx,
-		`INSERT INTO workspace (id, slug) VALUES ($1, $2)`, ws, "neighbour-"+ws.String()); err != nil {
-		t.Fatalf("seeding the neighbour workspace: %v", err)
-	}
-	return principal.WithWorkspaceID(ctx, ws), database.BindTo(pool, ids.From[ids.WorkspaceKind](ws))
-}
-
-func TestAnotherWorkspacesVerdictNeverReachesThisOne(t *testing.T) {
-	ctx, ws, db, store := traceReadWorkspace(t)
-	me := ids.NewV7()
-	mine := memberContext(ctx, ws, me)
-	const shared = "info@vendor.test" // an address both tenants correspond with
-
-	// Mine: a deferred message from that sender, with NO answer yet.
-	seedDeferredMessage(mine, t, db, me, "tenancy-mine", shared, false)
-
-	// The neighbour: the same address, judged and resolved.
-	neighbourCtx, neighbourDB := secondWorkspace(context.Background(), t)
-	neighbour := ids.NewV7()
-	seedDeferredMessage(neighbourCtx, t, neighbourDB, neighbour, "tenancy-theirs", shared, true)
-
-	window, err := store.ListMine(mine, nil, nil)
-	if err != nil {
-		t.Fatalf("ListMine: %v", err)
-	}
-	if len(window.Entries) != 1 {
-		t.Fatalf("entries = %d, want 1 — only this workspace's row", len(window.Entries))
-	}
-	// The neighbour's ledger row must not answer for my sender. Unscoped, the
-	// join matches on the address alone and reports THEIR verdict as mine.
-	if got := window.Entries[0].Resolution; got != nil {
-		t.Errorf("resolution = %+v, want none — that answer belongs to another workspace", got)
-	}
-	if window.Funnel["deferred"] != 1 {
-		t.Errorf("funnel[deferred] = %d, want 1 — the funnel counts this tenant's rows only", window.Funnel["deferred"])
-	}
-}
 
 // One sender with several resolved rows must not multiply their messages.
 // The ledger keeps a row per address per state, so a plain join fans out and the
@@ -84,8 +36,8 @@ func TestASendersHistoryDoesNotMultiplyTheirMessages(t *testing.T) {
 	if err := db.Tx(mine, func(tx pgx.Tx) error {
 		_, err := tx.Exec(mine, `
 			INSERT INTO capture_pending_counterparty
-			       (workspace_id, email, domain, activity_id, owner_id, status, kind, resolved_at)
-			SELECT workspace_id, email, domain, activity_id, owner_id, 'noise', 'spam', now() - interval '2 hours'
+			       (email, domain, activity_id, owner_id, status, kind, resolved_at)
+			SELECT email, domain, activity_id, owner_id, 'noise', 'spam', now() - interval '2 hours'
 			  FROM capture_pending_counterparty WHERE email = $1`, sender)
 		return err
 	}); err != nil {

--- a/backend/internal/shared/ports/connector/connector.go
+++ b/backend/internal/shared/ports/connector/connector.go
@@ -79,7 +79,7 @@ type WatchResult struct {
 // cannot name its account simply does not implement this.
 //
 // The label is never an identifier: nothing routes, authorizes or deduplicates
-// on it. capture_connection is keyed (workspace_id, user_id, provider).
+// on it. capture_connection is keyed (user_id, provider).
 type AccountLabeler interface {
 	AccountLabel(auth Auth) (string, error)
 }

--- a/backend/migrations/core/0282_capture_drop_workspace.down.sql
+++ b/backend/migrations/core/0282_capture_drop_workspace.down.sql
@@ -1,0 +1,93 @@
+-- Reverse of 0282: the twelve capture tables get the column, its foreign key
+-- and the six wide indexes back.
+--
+-- The backfill points every row at the LIVE workspace — archived_at IS NULL,
+-- oldest first. 0217 already refused to leave more than one live tenant
+-- standing and 0272 refuses to proceed while an archived one still holds
+-- records, so by the time this migration's forward half ran there was exactly
+-- one workspace these rows could have belonged to. This restores the column,
+-- not the distinction; the distinction is gone, which is what the gate at 0272
+-- is there to make an operator agree to in advance. Ordering by created_at
+-- alone would hand every restored row to whichever workspace was created
+-- first, archived or not.
+--
+-- If no live workspace exists and a table is not empty, SET NOT NULL fails and
+-- the rollback stops — the honest outcome, since no value this migration could
+-- write would be true. A rollback on an empty database (the reverse-and-reapply
+-- lane) leaves nothing to attribute and passes.
+ALTER TABLE raw_capture ADD COLUMN workspace_id uuid;
+ALTER TABLE capture_connection ADD COLUMN workspace_id uuid;
+ALTER TABLE channel_connection ADD COLUMN workspace_id uuid;
+ALTER TABLE capture_sync_state ADD COLUMN workspace_id uuid;
+ALTER TABLE capture_backfill ADD COLUMN workspace_id uuid;
+ALTER TABLE capture_auto_enrich_state ADD COLUMN workspace_id uuid;
+ALTER TABLE capture_auto_enrich_budget ADD COLUMN workspace_id uuid;
+ALTER TABLE capture_digest ADD COLUMN workspace_id uuid;
+ALTER TABLE capture_pending_counterparty ADD COLUMN workspace_id uuid;
+ALTER TABLE capture_trace ADD COLUMN workspace_id uuid;
+ALTER TABLE workspace_email_domain ADD COLUMN workspace_id uuid;
+ALTER TABLE capture_freemail_domain ADD COLUMN workspace_id uuid;
+
+DO $$
+DECLARE
+  live uuid := (SELECT id FROM workspace WHERE archived_at IS NULL ORDER BY created_at LIMIT 1);
+  t    text;
+BEGIN
+  FOREACH t IN ARRAY ARRAY[
+    'raw_capture', 'capture_connection', 'channel_connection', 'capture_sync_state',
+    'capture_backfill', 'capture_auto_enrich_state', 'capture_auto_enrich_budget',
+    'capture_digest', 'capture_pending_counterparty', 'capture_trace',
+    'workspace_email_domain', 'capture_freemail_domain'
+  ] LOOP
+    EXECUTE format('UPDATE %I SET workspace_id = $1 WHERE workspace_id IS NULL', t) USING live;
+    EXECUTE format('ALTER TABLE %I ALTER COLUMN workspace_id SET NOT NULL', t);
+  END LOOP;
+END $$;
+
+-- The foreign keys, each with the ON DELETE the table carried before. capture_trace
+-- CASCADEs where the rest RESTRICT: it is a 24-hour diagnostic that a tenant's
+-- departure should take with it, not a record whose loss should block one.
+ALTER TABLE raw_capture ADD CONSTRAINT raw_capture_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE capture_connection ADD CONSTRAINT connector_connection_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE channel_connection ADD CONSTRAINT channel_connection_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE capture_sync_state ADD CONSTRAINT capture_sync_state_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE capture_backfill ADD CONSTRAINT capture_backfill_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE capture_auto_enrich_state ADD CONSTRAINT capture_auto_enrich_state_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE capture_auto_enrich_budget ADD CONSTRAINT capture_auto_enrich_budget_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE capture_digest ADD CONSTRAINT capture_digest_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE capture_pending_counterparty ADD CONSTRAINT capture_pending_counterparty_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE capture_trace ADD CONSTRAINT capture_trace_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE CASCADE;
+ALTER TABLE workspace_email_domain ADD CONSTRAINT workspace_email_domain_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE capture_freemail_domain ADD CONSTRAINT capture_freemail_domain_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+
+DROP INDEX idx_capture_backfill_conn;
+DROP INDEX idx_capture_connection;
+DROP INDEX capture_trace_counterparty;
+DROP INDEX capture_trace_message;
+DROP INDEX capture_trace_natural_key;
+DROP INDEX capture_trace_user_window;
+DROP INDEX capture_trace_window;
+
+CREATE INDEX idx_capture_backfill_conn ON capture_backfill (workspace_id, connection_id, created_at DESC);
+CREATE INDEX idx_capture_connection ON capture_connection (workspace_id, provider, status) WHERE archived_at IS NULL;
+CREATE INDEX capture_trace_counterparty ON capture_trace (workspace_id, counterparty) WHERE counterparty IS NOT NULL;
+CREATE INDEX capture_trace_message ON capture_trace (workspace_id, source_system, source_id);
+CREATE UNIQUE INDEX capture_trace_natural_key ON capture_trace
+  (workspace_id, COALESCE(user_id, '00000000-0000-0000-0000-000000000000'::uuid), source_system, source_id, stage, outcome);
+CREATE INDEX capture_trace_user_window ON capture_trace (workspace_id, user_id, occurred_at DESC);
+CREATE INDEX capture_trace_window ON capture_trace (workspace_id, occurred_at DESC);
+
+CREATE UNIQUE INDEX uq_channel_connection_bot ON channel_connection (provider, channel_id)
+  WHERE archived_at IS NULL;

--- a/backend/migrations/core/0282_capture_drop_workspace.up.sql
+++ b/backend/migrations/core/0282_capture_drop_workspace.up.sql
@@ -1,0 +1,94 @@
+-- 0282: capture drops the tenant column (ADR-0091 §8 phase D).
+--
+-- Twelve tables, and they divide into three honest kinds:
+--
+--   the connections a human granted  — capture_connection, channel_connection
+--   the state those connections keep — capture_sync_state, capture_backfill,
+--                                      capture_auto_enrich_state/_budget,
+--                                      capture_digest, capture_pending_counterparty
+--   what came through them           — raw_capture, capture_trace
+--
+-- plus the two domain lists the pipeline consults: workspace_email_domain (our
+-- own addresses, so an internal message is not mistaken for an inbound one) and
+-- capture_freemail_domain (the consumer-mail list that stops gmail.com becoming
+-- an organization).
+--
+-- Every one of them is already keyed on something narrower than the tenant —
+-- a connection, a user, a (source_system, source_id) natural key, a domain —
+-- so phase B left nothing composite here to collapse. What remains is the
+-- column, its foreign key, and six indexes that still lead with it.
+--
+-- The rename of workspace_email_domain to email_domain is NOT here. It is
+-- ADR-0091 §1's final sweep, where the word goes out of the schema everywhere
+-- at once; doing it in this slice would leave the tree with one renamed table
+-- and eighty that still say workspace.
+
+ALTER TABLE raw_capture DROP CONSTRAINT raw_capture_workspace_id_fkey;
+ALTER TABLE raw_capture DROP COLUMN workspace_id;
+
+ALTER TABLE capture_connection DROP CONSTRAINT connector_connection_workspace_id_fkey;
+ALTER TABLE capture_connection DROP COLUMN workspace_id;
+
+ALTER TABLE channel_connection DROP CONSTRAINT channel_connection_workspace_id_fkey;
+ALTER TABLE channel_connection DROP COLUMN workspace_id;
+
+ALTER TABLE capture_sync_state DROP CONSTRAINT capture_sync_state_workspace_id_fkey;
+ALTER TABLE capture_sync_state DROP COLUMN workspace_id;
+
+ALTER TABLE capture_backfill DROP CONSTRAINT capture_backfill_workspace_id_fkey;
+ALTER TABLE capture_backfill DROP COLUMN workspace_id;
+
+ALTER TABLE capture_auto_enrich_state DROP CONSTRAINT capture_auto_enrich_state_workspace_id_fkey;
+ALTER TABLE capture_auto_enrich_state DROP COLUMN workspace_id;
+
+ALTER TABLE capture_auto_enrich_budget DROP CONSTRAINT capture_auto_enrich_budget_workspace_id_fkey;
+ALTER TABLE capture_auto_enrich_budget DROP COLUMN workspace_id;
+
+ALTER TABLE capture_digest DROP CONSTRAINT capture_digest_workspace_id_fkey;
+ALTER TABLE capture_digest DROP COLUMN workspace_id;
+
+ALTER TABLE capture_pending_counterparty DROP CONSTRAINT capture_pending_counterparty_workspace_id_fkey;
+ALTER TABLE capture_pending_counterparty DROP COLUMN workspace_id;
+
+ALTER TABLE capture_trace DROP CONSTRAINT capture_trace_workspace_id_fkey;
+ALTER TABLE capture_trace DROP COLUMN workspace_id;
+
+ALTER TABLE workspace_email_domain DROP CONSTRAINT workspace_email_domain_workspace_id_fkey;
+ALTER TABLE workspace_email_domain DROP COLUMN workspace_id;
+
+ALTER TABLE capture_freemail_domain DROP CONSTRAINT capture_freemail_domain_workspace_id_fkey;
+ALTER TABLE capture_freemail_domain DROP COLUMN workspace_id;
+
+-- The six indexes that led with the column. DROP COLUMN already removed them
+-- outright, so each is recreated on what actually selects rows.
+--
+-- capture_trace_natural_key is the one to read twice: it is a UNIQUE index and
+-- it is what makes the trace idempotent under replay. Its COALESCE on user_id
+-- stays, because a connector-level decision has no user and NULLs would
+-- otherwise never collide with each other.
+CREATE INDEX idx_capture_backfill_conn ON capture_backfill (connection_id, created_at DESC);
+CREATE INDEX idx_capture_connection ON capture_connection (provider, status) WHERE archived_at IS NULL;
+CREATE INDEX capture_trace_counterparty ON capture_trace (counterparty) WHERE counterparty IS NOT NULL;
+CREATE INDEX capture_trace_message ON capture_trace (source_system, source_id);
+CREATE UNIQUE INDEX capture_trace_natural_key ON capture_trace
+  (COALESCE(user_id, '00000000-0000-0000-0000-000000000000'::uuid), source_system, source_id, stage, outcome);
+CREATE INDEX capture_trace_user_window ON capture_trace (user_id, occurred_at DESC);
+CREATE INDEX capture_trace_window ON capture_trace (occurred_at DESC);
+
+-- channel_connection carried TWO live-row uniqueness rules, and after the
+-- collapse one of them can no longer fire.
+--
+--   uq_channel_connection_ws  (provider)              WHERE archived_at IS NULL
+--   uq_channel_connection_bot (provider, channel_id)  WHERE archived_at IS NULL
+--
+-- The first is now strictly stronger: it permits ONE live row per provider, so
+-- any insert that would collide on (provider, channel_id) collides on
+-- (provider) first. The bot rule existed to stop a SECOND WORKSPACE binding a
+-- bot another workspace was already polling — two getUpdates consumers racing
+-- for the same stream. There is no second workspace to stop.
+--
+-- It goes rather than staying as a rule that never fires, because the store
+-- branches on WHICH constraint refused a connect to tell an admin what to do,
+-- and a subsumed index makes that branch depend on which index Postgres happens
+-- to check first.
+DROP INDEX uq_channel_connection_bot;


### PR DESCRIPTION
Twelve tables — the connections a human granted (`capture_connection`, `channel_connection`), the state those connections keep (sync, backfill, auto-enrich, digest, the disposition ledger), what came through them (`raw_capture`, `capture_trace`), and the two domain lists the pipeline consults (`workspace_email_domain`, `capture_freemail_domain`).

Phase B left nothing composite here: every one is already keyed on something narrower than the tenant — a connection, a user, a `(source_system, source_id)` natural key, a domain. What remains is the column, its foreign key, and six indexes that still lead with it.

## An index that can no longer fire

`channel_connection` carried two live-row uniqueness rules:

```
uq_channel_connection_ws  (provider)              WHERE archived_at IS NULL
uq_channel_connection_bot (provider, channel_id)  WHERE archived_at IS NULL
```

The first permits ONE live row per provider, so it is now strictly stronger — any insert that would collide on the bot collides on the provider first. The bot rule existed to stop a **second workspace** binding a bot another was already polling: two getUpdates consumers racing for one stream. There is no second workspace to stop.

It goes rather than staying as a rule that never fires, because the store branches on WHICH constraint refused a connect to tell an admin what to do, and a subsumed index makes that branch depend on which index Postgres happens to check first. The refusal collapses with it and now says "installation" where it said "workspace" — matching the HTTP detail beside it.

## Two suites retired, one narrowed

`TestConnectRefusesTheSameBotInASecondWorkspace` and `TestChannelSenderForDoesNotReachAnotherWorkspacesBinding` both seeded two tenants to prove one could not reach the other's binding. Neither scenario exists; the no-binding half is already held by `TestChannelSenderForReportsNoConnectionForAnythingNotLive`.

`tracetenancy_integration_test.go` loses its cross-tenant case and keeps the two that were never about tenancy — a sender's history must not multiply their messages, and the page's cursor must advance. Renamed for what it now holds.

## What the first sweep missed, since it will recur

Grepping for lines carrying the table name AND `workspace_id` finds most write sites and almost no read sites: an aliased predicate (`WHERE t.workspace_id = …`, `r.workspace_id = a.workspace_id`) sits lines below the `FROM`, and a multi-line INSERT puts the column list on its own line. Eight production sites hid there, two of them whole-module reads in sibling packages (`activities/pipelinefacts.go`, `capture/tracestore.go`). The reliable sweep is two steps: `grep -l` the table, then `grep -n workspace_id` inside every file it names.

## Verification

- Lane applied to an empty database; the down restores all twelve columns with their foreign keys, the bot index and all six wide indexes; reverse-and-reapply passes.
- `make check-backend` green; `make test-integration` OK, 0 skips, 41 packages.

Phase D: 97 → 85 tables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drops workspace_id from twelve capture tables and removes the bot-scoped unique index on channel connections (ADR-0091 §8 phase D). Old: tables and indexes were tenant-scoped and connect errors distinguished “same bot in another workspace”; new: rows key by connection/user/natural keys, uq_channel_connection_ws is the only live-row uniqueness rule, connect refusals say “installation,” and poll/sync/trace paths no longer read or write workspace_id.

- Changes that matter for review:
  - Migration 0282 drops workspace_id and FKs from: raw_capture, capture_connection, channel_connection, capture_sync_state, capture_backfill, capture_auto_enrich_state/_budget, capture_digest, capture_pending_counterparty, capture_trace, workspace_email_domain, capture_freemail_domain; recreates six indexes without workspace_id; drops uq_channel_connection_bot.
  - Trace idempotency moves to a unique index on (COALESCE(user_id, zero-uuid), source_system, source_id, stage, outcome); message and user window indexes drop the tenant lead key.
  - Channel connect: only uq_channel_connection_ws can reject; error detail and code paths now say “installation.” The refusal still branches on the constraint name to avoid misreporting future rules.
  - Polling: workspace comes from job args/ctx instead of the channel row; LoadChannelPollTarget no longer scans a workspace_id.
  - Sync/backfill/auto-enrich/digest/domain/disposition writes and joins drop workspace predicates; joins that keyed on address now scope only by their natural keys to avoid fanning out results. Cross-tenant tests are removed or narrowed accordingly.

- Rollout and rollback:
  - Apply 0282 up. No app config changes required. Ensure prior phases left exactly one live workspace; this PR assumes that invariant.
  - On rollback, 0282 down restores all twelve columns, FKs, six wide indexes, and uq_channel_connection_bot; it backfills workspace_id to the single live workspace and enforces NOT NULL. Rollback will fail if no live workspace exists while tables are non-empty.

<sup>Written for commit 48314a0611432ac513f1b1ddc3000f66d4129412. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1491?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

