### PR TITLE
fix: three deadlines written by the app clock and read by the database's

### DIFF
--- a/backend/internal/modules/ai/retentionclock_test.go
+++ b/backend/internal/modules/ai/retentionclock_test.go
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package ai
+
+// A learning signal's retention boundary is written by ONE clock, the
+// database's, derived from this package's source rather than remembered.
+//
+// privacy's erasure sweep selects on `retention_until < now()` INSIDE Postgres
+// (retentionai.go), so a boundary bound from the app process makes that a
+// cross-clock comparison. What the boundary decides is when stored plaintext
+// stops existing: early destroys evidence a member still had a claim on, late
+// keeps text past the window they were promised.
+//
+// Scope is this package because voice_learning_signal is owned here, pinned by
+// tableownership_test.go — privacy reads and erases, and writes no schedule.
+
+import (
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/gatekit"
+)
+
+func TestEveryLearningSignalRetentionWriteTakesTheDatabaseClock(t *testing.T) {
+	gatekit.DatabaseClock{Dir: ".", Column: "retention_until"}.Require(t)
+}

--- a/backend/internal/modules/ai/voice_draftread.go
+++ b/backend/internal/modules/ai/voice_draftread.go
@@ -93,14 +93,21 @@ func (s *VoiceStore) RecordDraftedSignal(ctx context.Context, profileID ids.UUID
 		}
 		now := s.now().UTC()
 		var signalID ids.UUID
+		// The retention window is a DELAY the database applies to its own
+		// clock. privacy's erasure sweep selects on `retention_until < now()`
+		// INSIDE Postgres, so a boundary bound from this process would be a
+		// cross-clock comparison — and this boundary is the promise about when
+		// the stored draft stops existing, which erasing early breaks in one
+		// direction and late in the other. updated_at stays on the process
+		// clock: it records when this process wrote, and nothing compares it.
 		err := tx.QueryRow(ctx, `
 			INSERT INTO voice_learning_signal
 			  (voice_profile_id, profile_version, draft_ref_hash, outcome,
 			   generated_original, retention_until, source, captured_by, updated_at)
-			VALUES ($1, $2, $3, 'drafted', $4, $5, 'draft', $6, $7)
+			VALUES ($1, $2, $3, 'drafted', $4, now() + $5::interval, 'draft', $6, $7)
 			ON CONFLICT (draft_ref_hash) DO NOTHING
 			RETURNING id`, profileID, profileVersion, hash[:], generatedOriginal,
-			now.Add(voiceLearningSignalRetention), actor.ID, now).Scan(&signalID)
+			voiceLearningSignalRetention.String(), actor.ID, now).Scan(&signalID)
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil
 		}

--- a/backend/internal/modules/approvals/expiryclock_test.go
+++ b/backend/internal/modules/approvals/expiryclock_test.go
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package approvals
+
+// An approval's window is written by ONE clock, the database's, derived from
+// this package's source rather than remembered.
+//
+// Every reader compares expires_at against now() INSIDE Postgres —
+// effectiveStatus, the join-a-pending-proposal probe, the decide path, the
+// expiry sweep — so a deadline bound from the app process makes each of those a
+// cross-clock comparison. Unlike a sync schedule, the cost is not throughput: a
+// staged action outliving its stated window is decidable by a human who should
+// no longer be able to decide it, and one predeceasing it refuses a decision
+// that is still in time. Both are authorization outcomes.
+//
+// Scope is this package because approval is owned here, pinned by
+// tableownership_test.go.
+
+import (
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/gatekit"
+)
+
+func TestEveryApprovalExpiryWriteTakesTheDatabaseClock(t *testing.T) {
+	gatekit.DatabaseClock{Dir: ".", Column: "expires_at"}.Require(t)
+}

--- a/backend/internal/modules/approvals/staging.go
+++ b/backend/internal/modules/approvals/staging.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 	openapi_types "github.com/oapi-codegen/runtime/types"
@@ -383,27 +384,36 @@ func (s *Service) insertProposalInTx(ctx context.Context, tx pgx.Tx, in StageInp
 		in.TargetVersion = &current
 	}
 	id := ids.New[ids.ApprovalKind]()
-	// Compute ONE absolute expiry and use it for BOTH the persisted row and
-	// the payload — deriving the row's expires_at from the DB now() while the
-	// payload used the app clock let approval.requested.data.expires_at drift
-	// from what the approval row actually stored.
-	expiresAt := s.now().UTC().Add(ttlFor(in.Kind, in.TTL))
 	evidence, err := marshalEvidence(in.Evidence)
 	if err != nil {
 		return ids.ApprovalID{}, err
 	}
-	if _, err := tx.Exec(ctx,
+	// The TTL is a DELAY the database applies to its own clock, and the stored
+	// deadline comes back out. Every reader of this column — effectiveStatus,
+	// the decide path, the expiry sweep — compares it against Postgres now(),
+	// so a deadline bound from the app process is a cross-clock comparison, and
+	// an approval that outlives or predeceases its stated window is an
+	// authorization decision rather than a pacing one.
+	//
+	// RETURNING is what keeps the emitted payload honest, and it is the reason
+	// one clock is now enough. The event carries expires_at and it has to be
+	// the value the row actually holds; computing the same instant a second
+	// time in Go is what let the two drift apart before.
+	var expiresAt time.Time
+	if err := tx.QueryRow(ctx,
 		`INSERT INTO approval (id, kind, proposed_by, on_behalf_of, passport_id,
 			                       target_entity_type, target_entity_id, target_version,
 			                       summary, proposed_change, diff_hash, expires_at, bundle_id,
 			                       evidence)
-			 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)`,
+			 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, now() + $12::interval, $13, $14)
+			 RETURNING expires_at`,
 		id, in.Kind, p.ID, nullUUID(p.OnBehalfOf), nullUUID(p.PassportID),
 		nullStr(in.TargetType), nullUUID(in.TargetID), in.TargetVersion,
-		nullStr(in.Summary), in.ProposedChange, in.DiffHash, expiresAt,
-		nullUUID(in.BundleID), evidence); err != nil {
+		nullStr(in.Summary), in.ProposedChange, in.DiffHash, ttlFor(in.Kind, in.TTL).String(),
+		nullUUID(in.BundleID), evidence).Scan(&expiresAt); err != nil {
 		return ids.ApprovalID{}, err
 	}
+	expiresAt = expiresAt.UTC()
 	auditID, err := s.audit(ctx, tx, p, "create", id.UUID, map[string]any{
 		approvalKeyKind: in.Kind, "summary": in.Summary, "diff_hash": in.DiffHash,
 	})

--- a/backend/internal/modules/capture/syncclock_test.go
+++ b/backend/internal/modules/capture/syncclock_test.go
@@ -28,5 +28,5 @@ import (
 )
 
 func TestEverySyncScheduleWriteTakesTheDatabaseClock(t *testing.T) {
-	gatekit.RequireDatabaseClock(t, ".", "next_sync_at")
+	gatekit.DatabaseClock{Dir: ".", Column: "next_sync_at"}.Require(t)
 }

--- a/backend/internal/modules/identity/expiryclock_test.go
+++ b/backend/internal/modules/identity/expiryclock_test.go
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package identity
+
+// Every deadline this package writes is written by ONE clock, the database's,
+// derived from this package's source rather than remembered.
+//
+// identity holds more of these than any other package — a session's idle and
+// absolute windows, a passport's, a refresh token's, an authorization code's, a
+// password-reset token's, a client document's cache window — and every one of
+// them is read as `expires_at > now()` INSIDE Postgres. What each decides is
+// whether a credential is still good, so a deadline bound from the app process
+// is not a pacing error: a process running ahead refuses a session that is
+// still valid, and one running behind honours a token past its stated life.
+//
+// Scope is this package because it owns every table named above, pinned by
+// tableownership_test.go.
+
+import (
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/gatekit"
+)
+
+// callerChosenExpiry ratifies the one deadline here that is nobody's clock of
+// ours. A share's expiry arrives in the request body: the human granting access
+// names the day it ends, and rewriting that as an offset from now() would move
+// the date they chose.
+var callerChosenExpiry = gatekit.Waive(map[string]string{
+	"grants.go": "a record share's expiry is the granting human's own choice, arriving as an absolute instant in the request body — deriving it from now() would silently move the date they picked, and the value was never this system's clock to correct",
+})
+
+func TestEveryCredentialExpiryWriteTakesTheDatabaseClock(t *testing.T) {
+	gatekit.DatabaseClock{Dir: ".", Column: "expires_at", Exempt: callerChosenExpiry}.Require(t)
+	callerChosenExpiry.AssertAllMatched(t)
+}
+
+// The session's idle window, which is clamped by the absolute one above.
+func TestEverySessionIdleExpiryWriteTakesTheDatabaseClock(t *testing.T) {
+	gatekit.DatabaseClock{Dir: ".", Column: "idle_expires_at"}.Require(t)
+}
+
+// A client metadata document's cache window. Freshness is read as
+// `metadata_expires_at > now()`, so serving a stale redirect list past the
+// window its publisher was promised is the cost of getting this one wrong.
+func TestEveryClientMetadataExpiryWriteTakesTheDatabaseClock(t *testing.T) {
+	gatekit.DatabaseClock{Dir: ".", Column: "metadata_expires_at"}.Require(t)
+}

--- a/backend/internal/modules/identity/oauth_cimd.go
+++ b/backend/internal/modules/identity/oauth_cimd.go
@@ -190,17 +190,22 @@ func (s *Service) cimdCacheIsFresh(ctx context.Context, clientID string) (bool, 
 // anyone who could serve a document at that URL — and with it, its redirect
 // list. The conflict target is the row this document may own or nothing.
 func (s *Service) upsertCIMDClient(ctx context.Context, doc cimdDocument, ttl time.Duration) error {
-	expires := time.Now().Add(ttl)
 	return s.db.Tx(ctx, func(tx pgx.Tx) error {
+		// The cache window is a DELAY on the database's clock: freshness is read
+		// as `metadata_expires_at > now()` INSIDE Postgres, so a deadline bound
+		// from this process would be a cross-clock comparison. A process running
+		// behind the database re-fetches a document that is still fresh; one
+		// running ahead serves a client's redirect list past the window its
+		// publisher was promised.
 		_, err := tx.Exec(ctx, `
 			INSERT INTO oauth_client (workspace_id, client_id, client_name, redirect_uris, created_via, metadata_expires_at)
-			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, $2, $3, 'cimd', $4)
+			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, $2, $3, 'cimd', now() + $4::interval)
 			ON CONFLICT (client_id) DO UPDATE SET
 			  client_name         = EXCLUDED.client_name,
 			  redirect_uris       = EXCLUDED.redirect_uris,
-			  metadata_expires_at = EXCLUDED.metadata_expires_at
+			  metadata_expires_at = now() + $4::interval
 			WHERE oauth_client.created_via = 'cimd'`,
-			doc.ClientID, doc.ClientName, doc.RedirectURIs, expires)
+			doc.ClientID, doc.ClientName, doc.RedirectURIs, ttl.String())
 		if err != nil {
 			return fmt.Errorf("identity: recording a client's metadata document: %w", err)
 		}

--- a/backend/internal/modules/overlay/syncclock_test.go
+++ b/backend/internal/modules/overlay/syncclock_test.go
@@ -23,5 +23,5 @@ import (
 )
 
 func TestEverySweepScheduleWriteTakesTheDatabaseClock(t *testing.T) {
-	gatekit.RequireDatabaseClock(t, ".", "next_sweep_at")
+	gatekit.DatabaseClock{Dir: ".", Column: "next_sweep_at"}.Require(t)
 }

--- a/backend/internal/shared/gatekit/scheduleclock.go
+++ b/backend/internal/shared/gatekit/scheduleclock.go
@@ -29,25 +29,46 @@ import (
 	"go/token"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 )
 
 // databaseClock is the only sanctioned start point for a scheduling value. A
 // delay is added to it (`now() + make_interval(secs => $1)`), which is why the
-// assignment check is a prefix test and not equality.
+// checks are prefix tests and not equality.
 const databaseClock = "now()"
 
-// RequireDatabaseClock reports every write of column in dir's package sources
-// whose value does not come from the database clock, and fails a run that found
-// no write at all.
+// unscheduled is the other value a scheduling column legitimately holds: no
+// deadline at all. It involves no clock, so it is outside the rule rather than
+// an exception to it.
+const unscheduled = "NULL"
+
+// DatabaseClock is one package's obligation for one scheduling column: every
+// write of Column, in the Go sources under Dir, takes its value from the
+// database's clock.
+type DatabaseClock struct {
+	// Dir is the package directory to read, usually "." — the package whose
+	// tableownership entry names the table this column belongs to.
+	Dir string
+	// Column is the scheduling column under the rule.
+	Column string
+	// Exempt ratifies FILES whose writes of Column are legitimately not derived
+	// from any clock of ours — an expiry the granting human chose, a deadline a
+	// provider returned. Keyed by base name, each carrying what the exception
+	// costs; a waiver matching nothing is reported as stale.
+	Exempt *Waivers[string]
+}
+
+// Require reports every write of the column whose value does not come from the
+// database clock, and fails a run that found no write at all.
 //
 // The column has two write spellings and both are read: an assignment
 // (`SET` / `DO UPDATE SET`), and a position in an INSERT column list.
-func RequireDatabaseClock(t testing.TB, dir, column string) {
+func (c DatabaseClock) Require(t testing.TB) {
 	t.Helper()
 	subjects := 0
-	for _, file := range packageSourceFiles(t, dir) {
+	for _, file := range packageSourceFiles(t, c.Dir) {
 		text := sqlOf(t, file)
 		name := filepath.Base(file)
 
@@ -55,27 +76,103 @@ func RequireDatabaseClock(t testing.TB, dir, column string) {
 		// the database clock — `$1` (a Go timestamp) and `EXCLUDED.<column>`
 		// (whatever the INSERT proposed, which may itself have been bound) both
 		// fail.
-		for _, rhs := range assignmentsTo(text, column) {
+		for _, rhs := range assignmentsTo(text, c.Column) {
 			subjects++
-			if !strings.HasPrefix(rhs, databaseClock) {
+			if !c.accepts(t, name, rhs) {
 				t.Errorf("%s: `%s = %s` schedules from something other than the database clock — "+
 					"the due-scan compares this column against Postgres now(), so the value must start at now()",
-					name, column, rhs)
+					name, c.Column, rhs)
 			}
 		}
 
 		// The INSERT form, whose value is positional. A fresh row's schedule is
 		// either the bare clock or the clock plus a delay; a bound timestamp is
 		// the same cross-clock write one statement over.
-		for _, value := range insertedValuesFor(text, column) {
+		for _, value := range insertedValuesFor(text, c.Column) {
 			subjects++
-			if !strings.HasPrefix(value, databaseClock) {
+			if !c.accepts(t, name, value) {
 				t.Errorf("%s: INSERT writes %s as `%s`, want a value starting at the database clock `%s`",
-					name, column, value, databaseClock)
+					name, c.Column, value, databaseClock)
 			}
 		}
 	}
-	requireSubjects(t, dir, column, subjects)
+	requireSubjects(t, c.Dir, c.Column, subjects)
+}
+
+// accepts reports whether one written value satisfies the rule, or its file is
+// ratified as writing a deadline that is nobody's clock of ours.
+func (c DatabaseClock) accepts(t testing.TB, file, value string) bool {
+	t.Helper()
+	if databaseClocked(value) {
+		return true
+	}
+	return c.Exempt.Waived(t, file)
+}
+
+// clampFunctions are the SQL functions this rule sees through. Each PICKS one
+// of its arguments rather than computing a value of its own, so a clamp is
+// database-clocked exactly when everything it may pick is —
+// `least(now() + $1::interval, expires_at)` bounds an idle window by an
+// absolute one, and both terms are the database's.
+var clampFunctions = []string{"least", "greatest", "coalesce"}
+
+// databaseClocked reports whether a written value can only have come from the
+// database's own clock or from what the row already held.
+//
+// Four shapes qualify. `now()` and anything built on it is the rule itself. A
+// NULL writes no deadline at all, so no clock is involved. A bare column
+// forwards a value the database already stores — the sibling column's own
+// obligation, not this write's. And a clamp qualifies when every argument does.
+func databaseClocked(value string) bool {
+	v := strings.TrimSpace(value)
+	if strings.HasPrefix(v, databaseClock) || v == unscheduled {
+		return true
+	}
+	if args, ok := clampArguments(v); ok {
+		for _, arg := range args {
+			if !databaseClocked(arg) {
+				return false
+			}
+		}
+		return true
+	}
+	return storedColumn(v)
+}
+
+// clampArguments returns the arguments of a clamp call, or false for anything
+// else — including a call to some other function, whose result this rule cannot
+// reason about.
+func clampArguments(value string) ([]string, bool) {
+	name, rest, ok := strings.Cut(value, "(")
+	if !ok || !slices.Contains(clampFunctions, strings.ToLower(strings.TrimSpace(name))) {
+		return nil, false
+	}
+	group, tail, ok := parenGroup("(" + rest)
+	if !ok || strings.TrimSpace(tail) != "" {
+		return nil, false
+	}
+	return splitTopLevel(group), true
+}
+
+// storedColumn reports whether value is a plain column reference — a value the
+// row already holds, forwarded.
+//
+// `EXCLUDED.x` is deliberately NOT one. It forwards whatever the INSERT
+// proposed, which may itself have been bound from the app process, so accepting
+// it would let any conflict clause launder a cross-clock write.
+func storedColumn(value string) bool {
+	if value == "" || strings.HasPrefix(strings.ToLower(value), "excluded.") {
+		return false
+	}
+	for i := range len(value) {
+		c := value[i]
+		identifier := c == '_' || c == '.' ||
+			(c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')
+		if !identifier {
+			return false
+		}
+	}
+	return true
 }
 
 // requireSubjects fails a gate that examined nothing. The checks are keyed on a
@@ -139,20 +236,57 @@ func sqlOf(t testing.TB, file string) string {
 	return strings.Join(literals, "\n")
 }
 
-// assignmentsTo returns the right-hand side of every `column = ...` in text,
-// read to the end of its line. The repo writes one assignment per line inside
-// its SQL literals, so the line IS the expression; a trailing comma from the SET
-// list is not part of it.
+// assignmentsTo returns the right-hand side of every `column = ...` in text.
+// The expression ends at the SET list's next top-level comma — not at the end
+// of the line, because a line may carry several assignments (`next_attempt_at =
+// NULL, claimed_until = NULL`) and reading to its end would judge the gated
+// column on its neighbours' text. Commas nested in parentheses stay part of the
+// expression, so `least(now() + $1::interval, expires_at)` is read whole.
+//
+// The name is matched on a WORD boundary, not as a substring. Deadline columns
+// share suffixes — `idle_expires_at` ends in `expires_at`, `metadata_expires_at`
+// and `watch_expires_at` likewise — so a substring match reports a sibling
+// column's write under the gated column's name, and the reader who goes to fix
+// it finds a line that was already correct.
 func assignmentsTo(text, column string) []string {
 	var found []string
 	for _, line := range strings.Split(text, "\n") {
-		_, rhs, ok := strings.Cut(line, column+" = ")
-		if !ok {
+		before, rhs, ok := strings.Cut(line, column+" = ")
+		if !ok || endsInIdentifier(before) {
 			continue
 		}
-		found = append(found, strings.TrimSpace(strings.TrimSuffix(strings.TrimSpace(rhs), ",")))
+		found = append(found, endOfExpression(splitTopLevel(rhs)[0]))
 	}
 	return found
+}
+
+// clauseKeywords end a SET item as surely as a comma does. The tree writes its
+// SQL one clause per line, so these matter only for a statement written on one
+// — but there the difference is between reading an expression and reading an
+// expression plus the rest of the statement, and the second is reported as a
+// finding against a line that was already correct.
+var clauseKeywords = []string{" WHERE ", " RETURNING ", " FROM ", " ON CONFLICT "}
+
+// endOfExpression trims a written value at the first clause keyword after it.
+func endOfExpression(value string) string {
+	for _, keyword := range clauseKeywords {
+		if cut, _, found := strings.Cut(value, keyword); found {
+			value = cut
+		}
+	}
+	return strings.TrimSpace(value)
+}
+
+// endsInIdentifier reports whether text ends in a character SQL would read as
+// part of the name that follows it — which is what makes a match a suffix of a
+// longer column rather than the column itself.
+func endsInIdentifier(text string) bool {
+	if text == "" {
+		return false
+	}
+	c := text[len(text)-1]
+	return c == '_' || c == '.' ||
+		(c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')
 }
 
 // insertedValuesFor returns the VALUES item matching column for every

--- a/backend/internal/shared/gatekit/scheduleclock_test.go
+++ b/backend/internal/shared/gatekit/scheduleclock_test.go
@@ -30,7 +30,7 @@ func packageWith(t *testing.T, source string) string {
 func reportOn(t *testing.T, source, column string) string {
 	t.Helper()
 	rec := &recorder{TB: t}
-	RequireDatabaseClock(rec, packageWith(t, source), column)
+	DatabaseClock{Dir: packageWith(t, source), Column: column}.Require(rec)
 	return rec.joined()
 }
 
@@ -50,10 +50,9 @@ func TestAnAssignmentBoundFromTheAppClockIsReported(t *testing.T) {
 	}
 }
 
-// The assignment's expression is read to the end of its LINE, which is what the
-// repo's SQL literals put one per line. A statement that also puts its WHERE
-// there is still judged on the same rule — the reported expression just carries
-// the rest of the line with it.
+// A statement written on ONE line is judged on the same rule as the tree's
+// usual clause-per-line SQL: the expression ends at the SET list's comma or at
+// the clause that follows it, so the WHERE is not read as part of the value.
 func TestASingleLineStatementIsStillJudged(t *testing.T) {
 	const source = "package store\n\nconst q = `UPDATE sync_state SET next_sync_at = $2 WHERE id = $1`\n"
 	got := reportOn(t, source, "next_sync_at")
@@ -110,7 +109,7 @@ func TestAGateThatFoundNoWriteSiteSaysSo(t *testing.T) {
 
 func TestAPackageWithNoSourceIsReportedRatherThanPassed(t *testing.T) {
 	rec := &recorder{TB: t}
-	RequireDatabaseClock(rec, t.TempDir(), "next_sync_at")
+	DatabaseClock{Dir: t.TempDir(), Column: "next_sync_at"}.Require(rec)
 	if !strings.Contains(rec.joined(), "would pass over an empty set") {
 		t.Errorf("an empty package passed: %q", rec.joined())
 	}
@@ -126,8 +125,134 @@ func TestAFixtureInATestFileIsNotJudged(t *testing.T) {
 		t.Fatalf("writing the fixture test file: %v", err)
 	}
 	rec := &recorder{TB: t}
-	RequireDatabaseClock(rec, dir, "next_sync_at")
+	DatabaseClock{Dir: dir, Column: "next_sync_at"}.Require(rec)
 	if got := rec.joined(); got != "" {
 		t.Errorf("a test fixture was judged as production: %s", got)
+	}
+}
+
+// Deadline columns share suffixes: `idle_expires_at` ends in `expires_at`, and
+// so do `metadata_expires_at` and `watch_expires_at`. A substring match reports
+// a sibling's write under the gated column's name, and sends its reader to a
+// line that was already correct.
+func TestASiblingColumnEndingInTheGatedNameIsNotItsWrite(t *testing.T) {
+	const source = "package store\n\nconst q = `\n\tUPDATE session SET idle_expires_at = $2\n\tWHERE id = $1`\n"
+	rec := &recorder{TB: t}
+	DatabaseClock{Dir: packageWith(t, source), Column: "expires_at"}.Require(rec)
+	got := rec.joined()
+	if strings.Contains(got, "idle_expires_at = $2") {
+		t.Errorf("a sibling column was judged as the gated one: %q", got)
+	}
+	if !strings.Contains(got, "the gate examined nothing") {
+		t.Errorf("the gated column has no write here, which the gate must say: %q", got)
+	}
+}
+
+// The gated column itself is still found when a sibling shares its file.
+func TestTheGatedColumnIsStillFoundBesideItsSibling(t *testing.T) {
+	const source = "package store\n\nconst q = `\n\tINSERT INTO session (idle_expires_at, expires_at)\n\tVALUES (now() + $1::interval, $2)`\n"
+	got := reportOn(t, source, "expires_at")
+	if !strings.Contains(got, "as `$2`") {
+		t.Errorf("the gated column's own write was missed: %q", got)
+	}
+	if strings.Contains(got, "idle") {
+		t.Errorf("the sibling was reported too: %q", got)
+	}
+}
+
+// NULL is not a deadline written from the wrong clock; it is no deadline at
+// all. Clearing a schedule involves no clock, so it sits outside the rule.
+func TestClearingAScheduleIsNotAClockWrite(t *testing.T) {
+	const source = "package store\n\nconst q = `\n\tUPDATE sync_state SET next_sync_at = NULL, updated_at = now()\n\tWHERE id = $1`\n"
+	if got := reportOn(t, source, "next_sync_at"); got != "" {
+		t.Errorf("clearing the schedule was reported: %s", got)
+	}
+}
+
+// A file may write a deadline that is nobody's clock of ours — an expiry the
+// granting human chose, a window a provider returned. That is ratified per file
+// with the reason it costs, and gatekit holds the reason to its usual floor.
+func TestARatifiedFileMayWriteADeadlineWeDidNotCompute(t *testing.T) {
+	const source = "package store\n\nconst q = `\n\tINSERT INTO record_grant (subject_id, expires_at)\n\tVALUES ($1, $2)`\n"
+	rec := &recorder{TB: t}
+	DatabaseClock{
+		Dir:    packageWith(t, source),
+		Column: "expires_at",
+		Exempt: Waive(map[string]string{
+			"store.go": "the expiry is the granting human's own choice, an absolute instant this system did not compute and must not round to its own clock",
+		}),
+	}.Require(rec)
+	if got := rec.joined(); got != "" {
+		t.Errorf("a ratified file was reported: %s", got)
+	}
+}
+
+// A waiver that stops matching is reported, so an exemption cannot outlive the
+// write it ratified.
+func TestAWaiverForAFileThatNoLongerWritesTheColumnIsStale(t *testing.T) {
+	rec := &recorder{TB: t}
+	waivers := Waive(map[string]string{
+		"gone.go": "this file once wrote an absolute expiry a provider returned, which is nobody's clock of ours",
+	})
+	DatabaseClock{Dir: packageWith(t, compliantStore), Column: "next_sync_at", Exempt: waivers}.Require(rec)
+	waivers.AssertAllMatched(rec)
+	if !strings.Contains(rec.joined(), "gone.go") {
+		t.Errorf("a stale waiver was not reported: %q", rec.joined())
+	}
+}
+
+// The mirror of the case above: on a line carrying several assignments, a bad
+// write of the gated column must still be reported — the neighbours are what
+// gets trimmed away, not the verdict.
+func TestABadWriteSharingItsLineWithOthersIsStillReported(t *testing.T) {
+	const source = "package store\n\nconst q = `\n\tUPDATE sync_state SET next_sync_at = $2, claimed_until = NULL, updated_at = now()\n\tWHERE id = $1`\n"
+	got := reportOn(t, source, "next_sync_at")
+	if !strings.Contains(got, "`next_sync_at = $2`") {
+		t.Errorf("a bad write sharing its line escaped the gate: %q", got)
+	}
+}
+
+// A clamp PICKS one of its arguments rather than computing a value, so it is
+// database-clocked exactly when everything it may pick is. Sessions bound the
+// idle window by the absolute one this way, and both terms are Postgres's.
+func TestAClampOverDatabaseClockedTermsIsAccepted(t *testing.T) {
+	const source = "package store\n\nconst q = `\n\tUPDATE session SET idle_expires_at = least(now() + $2::interval, expires_at)\n\tWHERE id = $1`\n"
+	if got := reportOn(t, source, "idle_expires_at"); got != "" {
+		t.Errorf("a clamp over database-clocked terms was reported: %s", got)
+	}
+}
+
+// And the mirror: a clamp is only as good as its worst argument.
+func TestAClampHidingABoundInstantIsReported(t *testing.T) {
+	const source = "package store\n\nconst q = `\n\tUPDATE session SET idle_expires_at = least($2, expires_at)\n\tWHERE id = $1`\n"
+	got := reportOn(t, source, "idle_expires_at")
+	if !strings.Contains(got, "least($2, expires_at)") {
+		t.Errorf("a bound instant inside a clamp escaped the gate: %q", got)
+	}
+}
+
+// A function this rule cannot reason about is not a clamp, whatever it wraps.
+func TestAnUnknownFunctionIsNotSeenThrough(t *testing.T) {
+	const source = "package store\n\nconst q = `UPDATE session SET expires_at = date_trunc('day', now())`\n"
+	got := reportOn(t, source, "expires_at")
+	if !strings.Contains(got, "date_trunc") {
+		t.Errorf("an unrecognised function was seen through: %q", got)
+	}
+}
+
+// Forwarding a column the row already holds is the sibling column's obligation,
+// not this write's — but EXCLUDED is not such a column. It carries whatever the
+// INSERT proposed, so accepting it would let any conflict clause launder a
+// cross-clock write.
+func TestForwardingAStoredColumnIsAcceptedButExcludedIsNot(t *testing.T) {
+	const stored = "package store\n\nconst q = `UPDATE agent_task SET expires_at = approval_expires_at WHERE id = $1`\n"
+	if got := reportOn(t, stored, "expires_at"); got != "" {
+		t.Errorf("forwarding a stored column was reported: %s", got)
+	}
+
+	const excluded = "package store\n\nconst q = `\n\tINSERT INTO grant_row (id, expires_at) VALUES ($1, $2)\n\tON CONFLICT (id) DO UPDATE SET expires_at = EXCLUDED.expires_at`\n"
+	got := reportOn(t, excluded, "expires_at")
+	if !strings.Contains(got, "EXCLUDED.expires_at") {
+		t.Errorf("a conflict clause laundered a bound instant: %q", got)
 	}
 }


### PR DESCRIPTION
Closes #1458 — the census that issue asked for, the defects it turned up, and the gate that keeps them fixed.

## The census

Every column compared against `now()` inside Postgres, classified by where its value comes from. Twenty column names appear in such a comparison; most are records of when something happened (`created_at`, `resolved_at`, `occurred_at`) compared against `now() - interval` for a retention window. The deadlines — a future instant the system later asks "has this passed yet" — are the ones with teeth.

**Cross-clock, and fixed here:**

| column | written | read | what the skew costs |
|---|---|---|---|
| `approval.expires_at` | `s.now().Add(ttl)` | `expires_at > now()` | an approval decidable past its window, or refused while still in time |
| `oauth_client.metadata_expires_at` | `time.Now().Add(ttl)` | `metadata_expires_at > now()` | a client's redirect list served past the window its publisher was promised |
| `voice_learning_signal.retention_until` | `now.Add(180d)` | `retention_until < now()` | stored plaintext erased early, or kept past the window a member was promised |

**Not defects, with the reason recorded so the next census does not re-derive it:**

- `record_grant.expires_at`, `capture_connection.watch_expires_at` — absolute instants this system did not compute (a human's chosen date; a provider's own window). Deriving them from `now()` would move a value that was never ours.
- `consent_doi_token.expires_at`, `webhook_delivery.next_retry_at`, the login lockout — written AND read on the app clock. One clock, consistently; a different question from this one.
- `agent_task.expires_at` — copies the approval's stored deadline, so it inherits the fix above rather than introducing a clock.
- `river_job.scheduled_at` — the queue library's own column, and its API takes a `time.Time`. Named here because it is the one case in the tree that cannot be spelled as a SQL interval.

## The approvals fix had a constraint the others did not

A comment there chose the app clock deliberately, and its reason was real: the emitted `approval.requested` payload carries `expires_at`, and computing the row's deadline from the database while the payload used the app clock let the two drift. `RETURNING expires_at` settles it without a second clock — the TTL goes down as a delay, the stored deadline comes back out, and the event carries literally what the row holds.

## The gate had three defects of its own

It was written against two call sites in #1457. Pointing it at five more found all three, and each is now pinned in both directions:

- **It matched the column as a substring.** `idle_expires_at` ends in `expires_at`; so do `metadata_expires_at` and `watch_expires_at`. Gating `expires_at` in identity reported a sibling's correct write under the gated column's name.
- **It read an assignment to the end of its line.** `next_attempt_at = NULL, claimed_until = NULL` is two assignments, and a one-line statement handed the verdict its own WHERE clause.
- **It insisted a value START at `now()`.** `least(now() + $1::interval, expires_at)` does not, and is database-clocked all the same: a clamp picks one of its arguments rather than computing a value.

It now sees through `least`/`greatest`/`coalesce` when every argument qualifies, accepts `NULL` and a forwarded column, and still refuses `EXCLUDED.*` — the shape through which a conflict clause would otherwise launder a bound instant into a column that reads compliant. Genuine exceptions are ratified per file through gatekit's waivers, so each states what it costs and is reported when it goes stale.

## Coverage added

| package | column |
|---|---|
| approvals | `expires_at` |
| identity | `expires_at` (one waiver: `grants.go`), `idle_expires_at`, `metadata_expires_at` |
| ai | `retention_until` |

identity's other deadlines — session idle and absolute, passport, refresh token, authorization code, password-reset token — were already correct and had nothing saying so. They are covered now.

## Proof

Skew is invisible on any machine whose clocks agree, so no runtime test can fail against the defect itself; the gates are what hold it, and each was mutation-tested **one at a time**:

```
staging.go: INSERT writes expires_at as `$12::interval`, want a value starting at now()
oauth_cimd.go: `metadata_expires_at = $4::interval` schedules from something other than the database clock
voice_draftread.go: INSERT writes retention_until as `$5::interval`, want a value starting at now()
```

- `make check-backend` green (exit 0, zero `FAIL` lines).
- Integration lanes green with zero failures: `approvals`, `identity`, `ai`, and **`compose/integration`** — the last one matters most, since it drives approval staging end to end through the MCP and agent paths that the `RETURNING` rewrite runs under.
- Checked against the live database rather than assumed: Postgres parses Go's `72h0m0s` as 3 days and `876000h0m0s` (the never-expires placeholder) as 36500 days.

## Not fixed here

`runner_job.due_at` is written from the app clock and read as `due_at <= now()`, and the `now() + interval` rewrite is the wrong fix for it: the value is a cron OCCURRENCE identity paired with `TriggerRef(now)` for dedupe, not a delay. A job is only enqueued once already due, so an app clock running ahead delays its claim by the skew and no further. Worth a decision about which clock defines a schedule slot, not a rewrite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Writes three deadlines from the database clock instead of the app clock and hardens the gate that enforces this rule. This removes cross‑clock comparisons against Postgres now() that could accept or refuse approvals incorrectly, serve stale OAuth client metadata, or erase drafts early/late.

- Approvals, Identity, and AI now compute deadlines in SQL as `now() + $interval`: `approval.expires_at`, `oauth_client.metadata_expires_at`, and `voice_learning_signal.retention_until`. Old behavior wrote a bound timestamp from the app; new behavior derives from the DB clock.
- For approvals, the insert now uses `RETURNING expires_at`; the emitted `approval.requested` payload carries the stored value exactly.
- The `gatekit` database‑clock gate matches whole column names, stops at clause/SET boundaries, accepts clamps over DB‑clocked terms (`least`/`greatest`/`coalesce`), accepts `NULL` and forwarded stored columns, and still rejects `EXCLUDED.*`. Callers now use `gatekit.DatabaseClock{...}.Require(t)` with file‑scoped waivers for genuine non‑DB deadlines.

**Review notes**
- Focus on SQL writes in: `backend/internal/modules/approvals/staging.go`, `backend/internal/modules/identity/oauth_cimd.go`, and `backend/internal/modules/ai/voice_draftread.go`. No schema or runtime migrations.
- New coverage gates: `ai/retentionclock_test.go`, `approvals/expiryclock_test.go`, `identity/expiryclock_test.go`; gate rework in `backend/internal/shared/gatekit/*`. Callsite updates in `capture` and `overlay` tests.

<sup>Written for commit a124ed4ec31b81dfd7fa9116543d356f7798ed48. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1497?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

