### PR TITLE
fix(design-system): a button, a field and the button beside it are one control

### DIFF
--- a/frontend/src/app/shell.css
+++ b/frontend/src/app/shell.css
@@ -1082,9 +1082,13 @@
   align-items: center;
   justify-content: space-between;
 }
+/* The FAB's header band is 28px of chrome, so its verbs sit below the shared
+   .iconbtn floor. Stated as min-* because that floor is stated that way. */
 .askfab-head .iconbtn {
   width: 28px;
   height: 28px;
+  min-inline-size: 28px;
+  min-block-size: 28px;
   display: grid;
   place-items: center;
   border: 0;

--- a/frontend/src/design-system/README.md
+++ b/frontend/src/design-system/README.md
@@ -26,7 +26,8 @@ arrive through props, translated by the caller with `t()`.
 
 | Primitive | For | File | Story |
 |---|---|---|---|
-| `Button` | The one button: `primary` / `ghost` / `danger`, `small` | `atoms.tsx` | ✅ |
+| **`Button`** | **The one button: `primary` / `ghost` / `danger`, `small`, `iconOnly`. It owns its GEOMETRY, which is why none of it arrives as a prop: the height is `--control-h`, shared with `TextInput` and the `Select` trigger so a button beside a field sits on the field's line; an icon child is sized by the button (16px, 14px small) rather than by a `size=` at the call site, because lucide's own default is 24px and 31 call sites shipped that way; and a labelled button carries a width floor so "No" and "Add" still read as buttons. `iconOnly` is the one opt-out — square, no floor, and the caller still owes it an accessible name. `reason` / `reasonId` refuse it and say why, and the caller cannot defeat either by passing `disabled` or an `aria-describedby` of its own** | `atoms.tsx` | ✅ |
+| `.iconbtn` | A bare icon affordance that is NOT a `Button`: no fill, no border, no label — the verb a row offers where a full button would out-shout the row. A class rather than a component, because it is chrome a row applies to its own `<button>`; it carries the `--control-h-sm` hit target, the hover, and the focus ring | `base.css` | via `Atoms → Buttons` |
 | `Badge` | A status pill in the six tones | `atoms.tsx` | ✅ |
 | `Avatar` | A person's or company's chip: monogram, optional logo, optional per-name tint | `atoms.tsx` | ✅ |
 | `AvatarStack` | A group of people as overlapping monograms, folding past `max` into a "+N" chip rather than running the row wide. Expects a non-empty list: every caller guards `people.length > 0` before rendering it, so there is no "0 people" state to draw | `avatarstack.tsx` | ✅ |

--- a/frontend/src/design-system/atoms.css
+++ b/frontend/src/design-system/atoms.css
@@ -616,14 +616,22 @@
   color: var(--textMeta);
 }
 
+/* The horizontal padding is 11px rather than the button's 14px on purpose: a
+   field's text starts at its own left edge and a button's label is centred, so
+   matching the two numbers would put the field's first character further in
+   than it should be. The HEIGHT is shared, through --control-h — a field and
+   the button that submits it are the same box on screen, and before the floor
+   existed they computed 40.25px and 38.25px independently. */
 .input {
   font-family: var(--f-body);
   font-size: 13.5px;
+  line-height: 1.25;
   color: var(--textPrimary);
   background: var(--bgElevated);
   border: 1px solid var(--borderSubtle);
   border-radius: var(--r-sm);
   padding: 9px 11px;
+  min-block-size: var(--control-h);
   width: 100%;
   outline: none;
   transition: 0.15s;
@@ -725,9 +733,15 @@
   align-items: center;
   gap: 4px;
 }
+/* Deliberately below the .iconbtn floor: this toggle sits INSIDE a line of
+   running figures, and a 32px control there would set the line's height. The
+   min-* pair is what holds that, since a bare width/height loses to the floor
+   the shared class declares. */
 .explain-toggle {
   width: 22px;
   height: 22px;
+  min-inline-size: 22px;
+  min-block-size: 22px;
   display: grid;
   place-items: center;
   border: 0;

--- a/frontend/src/design-system/atoms.stories.tsx
+++ b/frontend/src/design-system/atoms.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Plus, RefreshCw, Trash2 } from "lucide-react";
 import { type CSSProperties, useEffect, useId, useRef, useState } from "react";
 import {
   AttainmentRing,
@@ -51,15 +52,107 @@ const stack: CSSProperties = {
   gap: "1rem",
 };
 
+// Every axis of the button on one screen, because each of the four defects this
+// story was rewritten to expose was invisible while the variants were reviewed
+// one at a time: a ghost 2px taller than the primary beside it, an icon at
+// lucide's 24px default next to a 13.5px label, a two-letter label shrunk to a
+// pill nobody reads as a button, and no focus ring at all. The rows below are
+// the comparisons that make each of those visible in one look — same-row height,
+// same-row icon size, same-row width floor.
 export const Buttons: Story = {
   render: () => (
-    <div style={{ display: "flex", gap: "0.75rem", alignItems: "center" }}>
-      <Button variant="primary">Save</Button>
-      <Button variant="ghost">Cancel</Button>
-      <Button variant="danger">Delete</Button>
-      <Button variant="primary" small>
-        Small
-      </Button>
+    <div style={stack}>
+      <div style={stack}>
+        <span className="t-label">Variants, default size</span>
+        <div style={row}>
+          <Button variant="primary">Save</Button>
+          <Button variant="ghost">Cancel</Button>
+          <Button variant="danger">Delete</Button>
+        </div>
+      </div>
+      <div style={stack}>
+        <span className="t-label">Variants, small</span>
+        <div style={row}>
+          <Button variant="primary" small>
+            Save
+          </Button>
+          <Button variant="ghost" small>
+            Cancel
+          </Button>
+          <Button variant="danger" small>
+            Delete
+          </Button>
+        </div>
+      </div>
+      <div style={stack}>
+        <span className="t-label">With an icon</span>
+        <div style={row}>
+          <Button variant="primary">
+            <Plus aria-hidden />
+            Add person
+          </Button>
+          <Button variant="ghost">
+            <RefreshCw aria-hidden />
+            Reconnect
+          </Button>
+          <Button variant="ghost" small>
+            <RefreshCw aria-hidden />
+            Reconnect
+          </Button>
+        </div>
+      </div>
+      <div style={stack}>
+        <span className="t-label">
+          Icon only — square, and named for a reader
+        </span>
+        <div style={row}>
+          <Button variant="primary" iconOnly aria-label="Add person">
+            <Plus aria-hidden />
+          </Button>
+          <Button variant="ghost" iconOnly aria-label="Reconnect">
+            <RefreshCw aria-hidden />
+          </Button>
+          <Button variant="ghost" iconOnly small aria-label="Reconnect">
+            <RefreshCw aria-hidden />
+          </Button>
+        </div>
+      </div>
+      <div style={stack}>
+        <span className="t-label">Short labels keep the width floor</span>
+        <div style={row}>
+          <Button variant="ghost">No</Button>
+          <Button variant="primary">Yes</Button>
+          <Button variant="ghost">Add</Button>
+          <Button variant="primary">Save</Button>
+          <Button variant="ghost">Disconnect this inbox</Button>
+        </div>
+      </div>
+      <div style={stack}>
+        <span className="t-label">Beside a field, which is the same box</span>
+        <div style={row}>
+          <TextInput
+            defaultValue="ops@example.com"
+            style={{ inlineSize: "16rem" }}
+          />
+          <Button variant="primary">Invite</Button>
+        </div>
+      </div>
+      <div style={stack}>
+        <span className="t-label">
+          Refused, disabled, and the icon affordance
+        </span>
+        <div style={row}>
+          <Button variant="primary" reason="Connect an inbox first.">
+            Send
+          </Button>
+          <Button variant="ghost" disabled>
+            Cancel
+          </Button>
+          <button type="button" className="iconbtn" aria-label="Remove">
+            <Trash2 aria-hidden />
+          </button>
+        </div>
+      </div>
     </div>
   ),
 };

--- a/frontend/src/design-system/atoms.tsx
+++ b/frontend/src/design-system/atoms.tsx
@@ -26,13 +26,22 @@ type ButtonVariant = "primary" | "ghost" | "danger";
 export function Button({
   variant = "ghost",
   small,
+  iconOnly,
   className,
   reason,
   reasonId,
+  disabled,
   ...rest
 }: ButtonHTMLAttributes<HTMLButtonElement> & {
   variant?: ButtonVariant;
   small?: boolean;
+  /**
+   * This button's whole label IS its icon, so it drops the width floor that
+   * keeps a short word readable and becomes square. The caller still owes it an
+   * accessible name — `aria-label` or a visually-hidden child — because a
+   * glyph announces as nothing.
+   */
+  iconOnly?: boolean;
   /**
    * Why this action is unavailable. Passing it DISABLES the button and points
    * the control at the explanation with `aria-describedby` — a `title` on a
@@ -59,20 +68,28 @@ export function Button({
     "btn",
     `btn-${variant}`,
     small ? "btn-sm" : "",
+    iconOnly ? "btn-icon" : "",
     className ?? "",
   ]
     .filter(Boolean)
     .join(" ");
   const refused = reason !== undefined || reasonId !== undefined;
+  // `disabled` and `aria-describedby` are computed here and must survive the
+  // caller's props, so both are destructured out of `rest` (disabled above,
+  // aria-describedby below) rather than sitting where a later spread could
+  // overwrite them: a `disabled={false}` passed alongside `reason` would
+  // otherwise re-enable a control the reason contract promises is refused, and
+  // silently drop the description pointing at the sentence that says why.
+  const { "aria-describedby": callerDescribedBy, ...attrs } = rest;
+  const describedBy =
+    reasonId ?? (reason === undefined ? callerDescribedBy : ownReasonId);
   const button = (
     <button
       type="button"
+      {...attrs}
       className={classes}
-      disabled={rest.disabled || refused}
-      aria-describedby={
-        reasonId ?? (reason === undefined ? undefined : ownReasonId)
-      }
-      {...rest}
+      disabled={disabled || refused}
+      aria-describedby={describedBy}
     />
   );
   if (reason === undefined) {

--- a/frontend/src/design-system/base.css
+++ b/frontend/src/design-system/base.css
@@ -43,10 +43,19 @@
   font-family: var(--f-body);
   font-weight: 600;
   font-size: 13.5px;
-  border: 0;
+  /* Transparent rather than absent, so the ghost variant RECOLOURS a border
+     every variant already reserves space for. When only the ghost declared one,
+     border-box added its 2px to that variant alone and every [Cancel][Save] pair
+     in the product was 2px uneven. */
+  border: 1px solid transparent;
   cursor: pointer;
   border-radius: var(--r-sm);
   padding: 9px 14px;
+  /* Pinned rather than inherited: the control's height is derived from it, and
+     an inherited line-height makes that height a property of whatever the button
+     happens to sit inside. */
+  line-height: 1.25;
+  min-block-size: var(--control-h);
   transition: 0.15s;
   display: inline-flex;
   align-items: center;
@@ -56,9 +65,40 @@
      against the left edge of a wide control, which reads as a row of text that
      happens to be inside a button rather than as the button's own label. */
   justify-content: center;
+  /* A short label still has to read as a button. "No", "Add" and "Save"
+     shrink-wrapped to 46/55/62px, so a dialog footer was a row of ragged pills
+     and a label that changes on click ("Save" → "Saving…") physically jumped.
+     The floor applies at the default size only: the small rung lives in table
+     rows and toolbars, where a 96px minimum is what would break the layout. An
+     icon-only control opts out through .btn-icon, which is square by intent. */
+  min-inline-size: 6rem;
   gap: 7px;
   white-space: nowrap;
   text-decoration: none;
+}
+/* Every button in the product had NO focus style: no rule here, none in
+   app.css, none in tokens.css or brand.css, so a keyboard reader got whatever
+   the engine drew by default and one screen file had patched its own chips
+   locally. An outline rather than a box-shadow, because a button sits on the
+   page ground, on a card and on an accent fill, and only an outline is legible
+   on all three. */
+.btn:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+/* An icon a caller drops into a button arrives from lucide at its own default
+   of 24px, which is taller than the 13.5px label beside it — 31 call sites
+   shipped that way because Button has no icon slot to size one through. The
+   size belongs to the control, not to the call site: a button knows how big its
+   own icon is, and a `size=` prop per caller is the drift. */
+.btn svg {
+  inline-size: 16px;
+  block-size: 16px;
+  flex: none;
+}
+.btn-sm svg {
+  inline-size: 14px;
+  block-size: 14px;
 }
 .btn-primary {
   background: var(--accent);
@@ -81,7 +121,7 @@
 .btn-ghost {
   background: transparent;
   color: var(--textMeta);
-  border: 1px solid var(--borderSubtle);
+  border-color: var(--borderSubtle);
 }
 .btn-ghost:hover {
   background: var(--bgHover);
@@ -90,12 +130,72 @@
 .btn-sm {
   padding: 6px 11px;
   font-size: 12.5px;
+  min-block-size: var(--control-h-sm);
+  min-inline-size: 0;
+}
+/* A button whose whole label is its icon. Square by intent, so the width floor
+   that keeps a short WORD readable does not apply — there is no word to keep
+   readable, and the icon carries the meaning through the accessible name the
+   caller must still supply. */
+.btn-icon {
+  inline-size: var(--control-h);
+  min-inline-size: 0;
+  padding-inline: 0;
+}
+.btn-icon.btn-sm {
+  inline-size: var(--control-h-sm);
 }
 .btn:disabled {
   opacity: 0.5;
   cursor: not-allowed;
   transform: none;
   filter: none;
+}
+/* The refused button and the sentence explaining it, stacked. Button has
+   rendered this wrapper since `reason` existed, but no rule ever declared it,
+   so the explanation sat inline beside the control it belongs under. */
+.btn-with-reason {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--space-1);
+}
+
+/* A bare icon affordance that is NOT a .btn: no fill, no border, no label —
+   the verb a row offers where a full button would be louder than the row it
+   sits in. It lived only as `.askfab-head .iconbtn` in the shell's own sheet,
+   so the four call sites outside that FAB rendered a preflight-reset native
+   button: no padding, no hover, no focus ring, and no hit target at all. */
+.iconbtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-inline-size: var(--control-h-sm);
+  min-block-size: var(--control-h-sm);
+  padding: 0;
+  border: 0;
+  border-radius: var(--r-sm);
+  background: transparent;
+  color: var(--textMeta);
+  cursor: pointer;
+  transition: 0.15s;
+}
+.iconbtn svg {
+  inline-size: 16px;
+  block-size: 16px;
+  flex: none;
+}
+.iconbtn:hover {
+  background: var(--bgHover);
+  color: var(--textPrimary);
+}
+.iconbtn:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+.iconbtn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
 }
 
 .t-small {

--- a/frontend/src/design-system/button.test.tsx
+++ b/frontend/src/design-system/button.test.tsx
@@ -1,0 +1,150 @@
+/** @vitest-environment jsdom */
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { Button } from "./atoms";
+
+// jsdom resolves no custom properties and computes no layout, so the geometry
+// this component owns — the shared control height, the width floor, the icon
+// size — is held by tokens.css and base.css rather than by anything below. What
+// IS testable here is the contract those rules key on: which classes a given set
+// of props emits, and the two attributes Button computes for itself and must not
+// let a caller's props overwrite.
+
+afterEach(cleanup);
+
+function classesOf(name: string): string[] {
+  return (screen.getByRole("button", { name }).className ?? "").split(" ");
+}
+
+describe("Button", () => {
+  it("names its variant and size in the class list the stylesheet keys on", () => {
+    render(
+      <>
+        <Button variant="primary">Save</Button>
+        <Button variant="danger" small>
+          Delete
+        </Button>
+      </>,
+    );
+    expect(classesOf("Save")).toContain("btn");
+    expect(classesOf("Save")).toContain("btn-primary");
+    expect(classesOf("Save")).not.toContain("btn-sm");
+    expect(classesOf("Delete")).toContain("btn-danger");
+    expect(classesOf("Delete")).toContain("btn-sm");
+  });
+
+  it("defaults to the ghost variant, so a bare Button is still a styled one", () => {
+    render(<Button>Cancel</Button>);
+    expect(classesOf("Cancel")).toContain("btn-ghost");
+  });
+
+  it("marks an icon-only button so it drops the width floor and turns square", () => {
+    render(
+      <Button iconOnly aria-label="Reconnect">
+        <svg aria-hidden />
+      </Button>,
+    );
+    expect(classesOf("Reconnect")).toContain("btn-icon");
+  });
+
+  it("keeps a caller's own class beside its own", () => {
+    render(<Button className="connector-verb">Reconnect</Button>);
+    expect(classesOf("Reconnect")).toEqual(
+      expect.arrayContaining(["btn", "btn-ghost", "connector-verb"]),
+    );
+  });
+
+  // The reason contract promises two things at once: the control is refused,
+  // and the sentence saying why is announced from it. Both were defeatable,
+  // because `{...rest}` was spread AFTER the computed attributes — so a caller
+  // passing `disabled={false}` re-enabled a button the contract had refused,
+  // and a caller passing its own `aria-describedby` dropped the pointer to the
+  // explanation. A disabled control cannot be focused and a `title` on one is
+  // announced by nobody, so losing that pointer loses the reason entirely.
+  describe("the refusal contract survives the caller's props", () => {
+    it("disables the button and points it at the sentence", () => {
+      render(<Button reason="Connect an inbox first.">Send</Button>);
+      const button = screen.getByRole("button", { name: "Send" });
+      expect(button.hasAttribute("disabled")).toBe(true);
+      const describedBy = button.getAttribute("aria-describedby");
+      expect(describedBy).toBeTruthy();
+      expect(document.getElementById(describedBy ?? "")?.textContent).toBe(
+        "Connect an inbox first.",
+      );
+    });
+
+    it("stays refused when the caller passes disabled={false}", () => {
+      render(
+        <Button reason="Connect an inbox first." disabled={false}>
+          Send
+        </Button>,
+      );
+      expect(
+        screen.getByRole("button", { name: "Send" }).hasAttribute("disabled"),
+      ).toBe(true);
+    });
+
+    it("keeps its own description when the caller passes one too", () => {
+      render(
+        <>
+          <p id="caller-note">Something else entirely.</p>
+          <Button
+            reason="Connect an inbox first."
+            aria-describedby="caller-note"
+          >
+            Send
+          </Button>
+        </>,
+      );
+      const describedBy = screen
+        .getByRole("button", { name: "Send" })
+        .getAttribute("aria-describedby");
+      expect(describedBy).not.toBe("caller-note");
+      expect(document.getElementById(describedBy ?? "")?.textContent).toBe(
+        "Connect an inbox first.",
+      );
+    });
+
+    it("points several refused controls at one sentence via reasonId", () => {
+      render(
+        <>
+          <p id="seat-note">Your seat cannot send.</p>
+          <Button reasonId="seat-note">Send</Button>
+          <Button reasonId="seat-note">Schedule</Button>
+        </>,
+      );
+      for (const name of ["Send", "Schedule"]) {
+        const button = screen.getByRole("button", { name });
+        expect(button.hasAttribute("disabled")).toBe(true);
+        expect(button.getAttribute("aria-describedby")).toBe("seat-note");
+      }
+    });
+
+    it("leaves a caller's aria-describedby alone when nothing is refused", () => {
+      render(
+        <>
+          <p id="hint">Sends to everyone on the list.</p>
+          <Button aria-describedby="hint">Send</Button>
+        </>,
+      );
+      const button = screen.getByRole("button", { name: "Send" });
+      expect(button.getAttribute("aria-describedby")).toBe("hint");
+      expect(button.hasAttribute("disabled")).toBe(false);
+    });
+  });
+
+  it("is type=button unless the caller asks for a submit", () => {
+    render(
+      <>
+        <Button>Cancel</Button>
+        <Button type="submit">Save</Button>
+      </>,
+    );
+    expect(
+      screen.getByRole("button", { name: "Cancel" }).getAttribute("type"),
+    ).toBe("button");
+    expect(
+      screen.getByRole("button", { name: "Save" }).getAttribute("type"),
+    ).toBe("submit");
+  });
+});

--- a/frontend/src/design-system/tokens.css
+++ b/frontend/src/design-system/tokens.css
@@ -115,6 +115,20 @@
   --r-lg: 20px;
   --r-full: 9999px;
 
+  /* The height of an interactive control, in its two sizes. A button, a text
+     input and the select's trigger are the same box on screen, and until this
+     existed each computed its own number out of padding and line-height: the
+     input landed on 40.25px, the primary button on 38.25px and the ghost button
+     on 40.25px because its 1px border was added rather than absorbed. A
+     [Cancel][Save] pair was therefore never the same height, and a button beside
+     a field never sat on the field's own line. The value is a floor rather than
+     a fixed height, so a control whose label wraps grows instead of clipping —
+     nothing here assumes a one-line label. 40px also clears the 24px AA target
+     of WCAG 2.5.8 with room, and the small rung stays a deliberate step below it
+     for dense rows rather than drifting to whatever its padding produced. */
+  --control-h: 40px;
+  --control-h-sm: 32px;
+
   /* Vertical-rhythm scale — the 4/8/12/16/24 rungs the screens were already
    * reaching for ad-hoc (inconsistently spelled 10/12/14/16 before this).
    * Layout rhythm, not part of the §2 Ledger-Green colour identity; a

--- a/frontend/src/screens/onboarding-read.tsx
+++ b/frontend/src/screens/onboarding-read.tsx
@@ -371,6 +371,7 @@ function WebsiteWorkbench(
             />
             <Button
               variant="primary"
+              iconOnly
               aria-label={t("ob.ai.send")}
               disabled={
                 !conversation.draft.trim() || conversation.send.isPending

--- a/frontend/src/screens/onboarding.css
+++ b/frontend/src/screens/onboarding.css
@@ -1966,14 +1966,11 @@
   border-color: var(--ai);
   box-shadow: 0 0 0 3px var(--aiLight);
 }
+/* The send verb is square and stretches to the composer's own row height; the
+   square, the padding and the icon's size come from .btn-icon in the design
+   system now, so only the stretch is this composer's business. */
 .mw-composer .btn {
-  width: 44px;
   align-self: stretch;
-  justify-content: center;
-  padding: 0;
-}
-.mw-composer .btn svg {
-  width: 16px;
 }
 .mw-composer > small {
   grid-column: 1 / -1;


### PR DESCRIPTION
First of four changes from a UI audit of the control tier. This one is the foundation the other three sit on: it is design-system-only apart from two call sites that had to move with it, and it changes how every button in the product is drawn.

## What was wrong

**No button in the product had a focus style.** There is no `.btn:focus-visible` in the design system and no global rule in `app.css`, `tokens.css` or `brand.css`, so a keyboard reader got whatever the engine drew by default. One screen file (`conversation.css`) had already patched its own chips locally, which is what that gap looks like from inside a screen.

**The same box was measured three ways.** A field computed 40.25px out of its padding, a primary button 38.25px out of its own, and a ghost button 40.25px because its 1px border was added to the box rather than absorbed by it. So no `[Cancel][Save]` pair in the product was ever the same height, and no button beside a field sat on the field's line.

**An icon arrived at lucide's own 24px default beside a 13.5px label.** `Button` has no icon slot to size one through, so 31 call sites shipped that way — worst on settings → voice, where a 24px glyph sits in a 30.75px `small` button. Tree-wide there are 137 unsized icons, 7 sizes passed as props, 10 more declared in ad-hoc CSS, and 6 `strokeWidth` values.

**A short label shrink-wrapped below legibility.** "No" was 46px, "Add" 55px, "Save" 62px, and a label that changes on click ("Save" → "Saving…") physically jumped.

**`.iconbtn` was only ever `.askfab-head .iconbtn`,** declared in the shell's own sheet. The four call sites outside that FAB — `voice-dna.tsx`, `voice-versions.tsx` and friends — rendered a Tailwind-preflight-reset native button: no padding, no hover, no focus ring, no hit target.

**`.btn-with-reason` was rendered by `Button` and declared by nothing,** so the sentence explaining a refusal sat inline beside the control rather than under it.

**`Button` let a caller defeat its own refusal contract.** `{...rest}` was spread *after* the computed `disabled` and `aria-describedby`, so `disabled={false}` alongside `reason` re-enabled a control the contract promises is refused, and a caller's own `aria-describedby` dropped the pointer to the sentence saying why. A disabled control cannot be focused and a `title` on one is announced by nobody, so that pointer is the whole of the explanation.

## What this does

- `--control-h` / `--control-h-sm` in `tokens.css`, read by `.btn` and `.input` alike. The border is declared transparent on every variant; the ghost recolours it.
- `.btn svg` sizes the icon (16px, 14px small), so a call site stops deciding.
- A width floor on labelled default-size buttons. The `small` rung, which lives in table rows and toolbars, does not carry it; `iconOnly` is the square opt-out for a control whose whole label is its glyph.
- `.btn:focus-visible` as an outline rather than a box-shadow, because a button sits on the page ground, on a card and on an accent fill.
- `.iconbtn` promoted into `base.css` with its hit target, hover and focus ring. `.explain-toggle` and `.askfab-head .iconbtn` pin their own smaller sizes as `min-*` so they win regardless of sheet order.
- `.btn-with-reason` declared.
- `disabled` and `aria-describedby` computed after the spread, held by a new `button.test.tsx`.

## Two call sites moved with it

`onboarding-read.tsx`'s composer send button becomes `iconOnly`, and the hand-rolled square in `onboarding.css` that made it one goes away.

## Verification

`make check-fe` green (221 files, 2811 tests). `make fe-uat` green — 90 stories captured, no unclean render. Checked in Storybook in both themes; measured live, every default button and the input beside it now report 40×, small 32×, icons 16/14, floor 96px, icon-only square.

The story was four buttons in a row, which is why none of this surfaced in review: each defect is invisible until two of them sit on one line. It is the full matrix now — variants at both sizes, with and without an icon, icon only, short labels beside a long one, and a button next to the field it submits.

## Not in this change

Findings from the same audit, landing in the next three PRs: the `Avatar` split (two hand-rolls, three initials rules, opt-in tint so a company changes colour on navigation), the change-password inputs that carry no class at all, the second `Field` exported from `auth.tsx`, and the settings separator/card sweep starting with `capture-activity`'s missing `Panel title`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies control geometry and focus/accessibility in the design system. Buttons and inputs now share height, buttons have a focus-visible outline, icons are sized by the button, labeled buttons get a width floor, and `.iconbtn` is a first-class affordance with a proper hit target. Fixes a hole where callers could override `disabled`/`aria-describedby` on refused buttons.

- Adds `--control-h` / `--control-h-sm` and applies them to `.btn` and `.input`; ghost recolors a border declared transparent on all variants.
- Sizes `.btn svg` to 16px (14px small) and introduces `iconOnly` (`.btn-icon`) for square icon-only buttons.
- Applies a width floor to labeled default-size buttons; small buttons opt out.
- Adds `.btn:focus-visible` and promotes `.iconbtn` to the design system with hover, focus ring, and 32px hit target; declares `.btn-with-reason`.
- Computes `disabled` and `aria-describedby` after props; adds `button.test.tsx` to lock this contract.
- Updates the onboarding composer send to `iconOnly`; removes hand-rolled sizing in `onboarding.css`.

**Review notes**
- Check visual changes: button/input height alignment, icon size, width floor for short labels, and focus ring contrast in both themes.
- Verify refusal behavior and `aria-describedby` in `Button` (see `button.test.tsx`).
- Confirm `.iconbtn` adoption doesn’t break row layouts; small in-row toggles pin their own 22px min-size.

**Migration**
- Use `iconOnly` for square icon-only buttons and provide an accessible name (e.g., `aria-label`).
- Remove per-call-site icon sizing and button geometry; rely on `.btn svg` and `.btn-icon`.
- Use `reasonId` to reference shared refusal text; do not try to re-enable a refused button with `disabled={false}`.

<sup>Written for commit b5e4da6da941d80a3e82ee910527a2a0b06a8f9e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1506?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

