### PR TITLE
docs(agents): an issue you file says how bad it is and where it lives — and a docs edit stops booting twelve shards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,9 @@ jobs:
       contents: read
     outputs:
       backend: ${{ steps.filter.outputs.backend }}
+      # The database-bearing subset of `backend`. See the filter below for why
+      # the two differ, and by exactly what.
+      backend_db: ${{ steps.filter.outputs.backend_db }}
       frontend: ${{ steps.filter.outputs.frontend }}
       e2e: ${{ steps.filter.outputs.e2e }}
       deps: ${{ steps.filter.outputs.deps }}
@@ -78,7 +81,19 @@ jobs:
         id: filter
         with:
           filters: |
-            backend:
+            # `backend_db` is every path that can change what a DATABASE-backed
+            # lane proves; `backend` is that set PLUS the agent rulebooks, which
+            # a Go unit test reads and no integration test does. The anchor makes
+            # the second derive from the first — two hand-maintained copies of
+            # one list is the shape this repo refuses everywhere else, and it
+            # would rot in the direction that silently under-tests.
+            #
+            # The split exists because one flag was driving two unrelated
+            # things: run the Go unit gates, and boot twelve Postgres shards.
+            # A rulebook edit needs the first and cannot affect the second —
+            # the same reasoning already applied to `infra/**/!(*.md)` below,
+            # applied to the last two entries as well.
+            backend_db: &backend_db
               - 'backend/**'
               # The MCP App admission vocabulary is AUTHORED under frontend/ and
               # copied into the Go package, where a byte-equality test gates the
@@ -111,8 +126,20 @@ jobs:
               # every Go job restores, so an edit to it changes what the gates
               # compile — the same claim on this scope that ci.yml itself has.
               - '.github/actions/**'
-              - 'AGENTS.md'
               - 'sonar-project.properties'
+            # The rulebooks. `backend/agentsdocparity_test.go` reads BOTH and
+            # fails when the three shared sections drift, so a unit lane has to
+            # run for either — but no integration test opens them, so twelve
+            # Postgres shards do not.
+            #
+            # CLAUDE.md was absent from this classifier entirely until now,
+            # which meant an edit to it alone ran no Go lane at all and could
+            # break that parity test with nothing to catch it. Listing it here
+            # is the fix for that, not a convenience.
+            backend:
+              - *backend_db
+              - 'AGENTS.md'
+              - 'CLAUDE.md'
             frontend:
               - 'frontend/**'
               - 'backend/api/**'
@@ -508,7 +535,11 @@ jobs:
   integration-shards:
     name: integration shard (${{ matrix.shard }}/${{ strategy.job-total }})
     needs: [changes]
-    if: needs.changes.outputs.backend == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
+    # backend_db, not backend: this is the twelve-Postgres lane, and the two
+    # paths that differ (the agent rulebooks) cannot change what it proves.
+    # It moves in lockstep with the `integration` fan-in below, which asserts
+    # on this job's result and would read a skip as a failure if only one moved.
+    if: needs.changes.outputs.backend_db == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -649,9 +680,14 @@ jobs:
     # skipped required check counts as passing, and `!cancelled()` is false for
     # every job once a run is cancelled — so cancelling mid-lane would have
     # skipped this check and greened it. The assertion below sees `cancelled`.
+    #
+    # backend_db, in lockstep with integration-shards: the assertion below
+    # demands `success` from that job, so a run where the shards skipped and
+    # this did not would fail on the string "skipped" — a docs PR reported as
+    # a broken integration lane.
     if: >-
       always()
-      && needs.changes.outputs.backend == 'true'
+      && needs.changes.outputs.backend_db == 'true'
       && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
     runs-on: ubuntu-latest
     permissions:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,30 @@ This repo is public — never put private spec paths or local machine paths
 in an issue. Team-internal issue tracking beyond this repo: see the spec
 repo's `tooling/delivery-board.md`.
 
+**Label every issue you file.** Unlabeled means untriaged, so an unlabeled
+issue lies about your own finding. Exactly one `priority:` and exactly one
+`area:`, always:
+
+- `priority: critical` — data loss, a reachable security/privacy breach,
+  `main`/CI red, or unusable on a default install. `high` — a real user or
+  operator hits it on a live path, or it blocks another workstream.
+  `normal` — real but narrow, guarded or latent; hygiene; polish.
+  `low` — a want, not a defect, or it needs a decision first.
+  Priority is severity, never schedule: a milestone carries the schedule, so
+  never demote a real defect because it is not this week's work.
+- `area:` (one, where the fix lives) — `agents-mcp` `ai-models` `authz`
+  `capture` `ci-tests` `contract-api` `deals` `extensions` `finance`
+  `frontend` `overlay` `platform` `privacy` `records` `reports`. A doc that is
+  wrong about a subsystem takes that subsystem's area.
+- `status: needs-decision` when a human must rule before it is workable;
+  `status: spec-change` when contract-first (P3) puts it upstream first.
+- Provenance, additive: `bug`, `enhancement`, `security`, `capability-gap`
+  (missing capability, not a defect), `fast-track-debt` (shipped fast, gap
+  recorded deliberately). These say why the issue exists — keep them.
+
+Check for an existing parent tracker (`gh issue list --label "area: <x>"`)
+and attach yours as a sub-issue rather than adding another sibling.
+
 ## Build / test / seed
 
 All Go code lives under `backend/` (one Go module,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,10 +45,21 @@ issue lies about your own finding. Exactly one `priority:` and exactly one
   `frontend` `overlay` `platform` `privacy` `records` `reports`. A doc that is
   wrong about a subsystem takes that subsystem's area.
 - `status: needs-decision` when a human must rule before it is workable;
-  `status: spec-change` when contract-first (P3) puts it upstream first.
+  `status: spec-change` when contract-first (P3) puts the spec change first.
+  A `spec-change` issue stays open HERE, linked to the upstream change, as the
+  implementation follow-up — the label sequences the work, it does not hand it
+  away.
 - Provenance, additive: `bug`, `enhancement`, `security`, `capability-gap`
   (missing capability, not a defect), `fast-track-debt` (shipped fast, gap
   recorded deliberately). These say why the issue exists — keep them.
+
+**`security` is not a way to report a vulnerability.** This repo is public.
+Per [SECURITY.md](SECURITY.md) an exploitable weakness goes to a private
+GitHub Security Advisory, never a public issue or PR. The label is for
+hardening with no live exploit; if you can write the reproduction — a
+cross-tenant read, a row-scope/RBAC escape, an agent-governance bypass, a
+forged or still-binding revoked credential, a mutation skipping the audit or
+outbox row, injection, SSRF — it belongs in an advisory.
 
 Check for an existing parent tracker (`gh issue list --label "area: <x>"`)
 and attach yours as a sub-issue rather than adding another sibling.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,14 +130,27 @@ misleads about.
 leaving them off puts unactionable work in somebody's queue:
 
 - `status: needs-decision` — unactionable until a human rules ("decide or decline X").
-- `status: spec-change` — contract-first (P3): it lands in `margince-foundation`
-  first, so it does not belong in this repo's work queue yet.
+- `status: spec-change` — contract-first (P3): the spec change lands in
+  `margince-foundation` first. The issue stays open **here**, linked to that
+  upstream change, as the implementation follow-up. This label sequences the
+  work; it does not hand it away — contract-first means the spec change lands
+  first, not that somebody else writes it (see the four rules above).
 
 **Provenance**, additive and independent of the three axes: `bug`,
 `enhancement`, `security`, `capability-gap` (a missing capability, not a defect),
 and `fast-track-debt` (shipped fast under time pressure with the gap recorded
 deliberately). These record *why the issue exists*, which is the one thing
 nobody can reconstruct later — prefer keeping them over tidying them away.
+
+**`security` is not a way to report a vulnerability.** This repo is public, and
+[SECURITY.md](SECURITY.md) is explicit that an exploitable weakness goes to a
+private GitHub Security Advisory, never a public issue or pull request, because
+a public report before a fix ships puts every deployment at risk. The label is
+for hardening and defence-in-depth work that carries no live exploit. The test
+is the one SECURITY.md itself implies: **if you can write the reproduction, it
+belongs in an advisory** — a cross-tenant read, a row-scope or RBAC escape, an
+agent-governance bypass, a forged or still-binding revoked credential, a
+mutation that skips the audit or outbox row, injection, SSRF.
 
 Before filing, check whether a **parent tracker** already covers the finding
 (`gh issue list --label "area: <x>"`); if one does, attach yours as a sub-issue

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,55 @@ public, so an issue carries no private spec paths, no local machine paths, no
 secrets; cite the spec by chapter/ADR/pin ID. How the team tracks issues beyond
 this repo is internal: see the spec repo's `tooling/delivery-board.md`.
 
+### Label every issue you file (three axes, no exceptions)
+
+An unlabeled issue is indistinguishable from an untriaged one, and that is the
+invariant the labels exist to protect: **unlabeled means nobody has looked at it
+yet.** File an issue without labels and you have quietly told the next reader a
+falsehood about your own finding. Every issue you open carries **exactly one
+`priority:` and exactly one `area:`**.
+
+**Priority** is a claim about severity, never about your schedule. Do not demote
+a real defect because it is not this week's work — the milestone carries the
+schedule, the label carries the truth:
+
+| Label | It qualifies when |
+|---|---|
+| `priority: critical` | Data loss, a reachable security or privacy breach, `main`/CI red, or the product unusable on a default install. Drop other work. |
+| `priority: high` | A real user or operator hits it on a live path, or it blocks another workstream. |
+| `priority: normal` | A genuine defect that is narrow, guarded, or unreachable today; hygiene; test-lane work; polish. |
+| `priority: low` | A want, not a defect — or it needs a product/spec decision before it is work at all. |
+
+The honest test for `critical` is not "how bad would this be" but "does this stop
+somebody else from working, or is somebody's data wrong right now". A flaky gate
+earns it not because it is severe but because a red run nobody trusts makes every
+other verdict unreadable.
+
+**Area** is where the fix lives, one only, so a filter never double-counts:
+`agents-mcp` · `ai-models` · `authz` · `capture` · `ci-tests` · `contract-api` ·
+`deals` · `extensions` · `finance` · `frontend` · `overlay` · `platform` ·
+`privacy` · `records` · `reports`. A doc that is wrong about a subsystem takes
+that subsystem's area, not a documentation area — it belongs next to the code it
+misleads about.
+
+**Status**, when it applies — these mark an issue that is not yet workable, and
+leaving them off puts unactionable work in somebody's queue:
+
+- `status: needs-decision` — unactionable until a human rules ("decide or decline X").
+- `status: spec-change` — contract-first (P3): it lands in `margince-foundation`
+  first, so it does not belong in this repo's work queue yet.
+
+**Provenance**, additive and independent of the three axes: `bug`,
+`enhancement`, `security`, `capability-gap` (a missing capability, not a defect),
+and `fast-track-debt` (shipped fast under time pressure with the gap recorded
+deliberately). These record *why the issue exists*, which is the one thing
+nobody can reconstruct later — prefer keeping them over tidying them away.
+
+Before filing, check whether a **parent tracker** already covers the finding
+(`gh issue list --label "area: <x>"`); if one does, attach yours as a sub-issue
+rather than adding a sibling to the pile. A tracker carries the highest priority
+among its children.
+
 ## Build / test / seed
 
 All Go code lives under `backend/` (one Go module,

--- a/infra/ci-pipeline.md
+++ b/infra/ci-pipeline.md
@@ -41,12 +41,22 @@ that several full lanes can now run on `main` at once.
 ## Run only the checks a change can affect
 
 The first job, **`changes`**, classifies the diff (dorny/paths-filter,
-SHA-pinned) into four scopes; every downstream job gates on the relevant
+SHA-pinned) into five scopes; every downstream job gates on the relevant
 output. A required job skipped this way still counts as passing.
+
+`backend` and `backend_db` are the same set apart from the two agent
+rulebooks. They are split because one flag was driving two unrelated things:
+run the Go unit gates, and boot twelve Postgres databases. `AGENTS.md` and
+`CLAUDE.md` are read by `backend/agentsdocparity_test.go`, so an edit to
+either has to run a unit lane — and by no integration test, so it must not
+run the database lanes. The two shards move in lockstep with the
+`integration` fan-in, which asserts `success` from them: skipping one alone
+would report a documentation PR as a broken integration lane.
 
 | Scope | Paths | Gates |
 |---|---|---|
-| `backend` | `backend/**`, `infra/**/!(*.md)`, `go.work`, `go.work.sum`, `Makefile`, `scripts/**`, `extensions/**`, `fixtures/**`, `composition/**`, `.github/workflows/ci.yml`, `.github/actions/**`, `AGENTS.md`, `sonar-project.properties`, `frontend/src/mcp-apps/forbidden.json` | Go build/gate, extension reference, craftsmanship, integration, vuln |
+| `backend_db` | `backend/**`, `infra/**/!(*.md)`, `go.work`, `go.work.sum`, `Makefile`, `scripts/**`, `extensions/**`, `fixtures/**`, `composition/**`, `.github/workflows/ci.yml`, `.github/actions/**`, `sonar-project.properties`, `frontend/src/mcp-apps/forbidden.json` | the twelve integration shards and the `integration` fan-in — every lane that opens a database |
+| `backend` | `backend_db` (by YAML anchor, so the two cannot drift) plus the agent rulebooks `AGENTS.md` and `CLAUDE.md` | Go build/gate, extension reference, craftsmanship, unit coverage, vuln |
 | `frontend` | `frontend/**`, `backend/api/**` (the contract drives FE types), plus the composition inputs the lane now typechecks against — `extensions/**`, `fixtures/**`, `composition/**`, `backend/tools/gen-composition/**`, `Makefile` — and the install inputs `pnpm-lock.yaml` and `pnpm-workspace.yaml`, which decide *which* dependency the SPA builds on and which one `openapi-typescript` parses the contract with (`overrides` lives in the workspace file, so it resolves versions the lockfile then merely records) | frontend lane, UAT |
 | `e2e` | `backend/**`, `frontend/**`, `infra/**/!(*.md)`, `extensions/**`, `fixtures/**`, `composition/**` | full-stack live-boot |
 | `deps` | `go.work`, `go.work.sum`, `**/go.mod`, `**/go.sum`, `**/package.json`, `**/pnpm-lock.yaml`, `pnpm-workspace.yaml` (`overrides` lives there, so it decides resolved versions the way a manifest does), `.syft.yaml`, `.grant.yaml`, `sbom-schemas/**`, `Makefile`, `.github/workflows/ci.yml`, `.github/actions/**` | the license gate |


### PR DESCRIPTION
The rulebooks told an agent to file an issue and stopped there. Issues therefore arrived unlabeled — at 297 open, **211 (71%) carried no labels at all**, which left no way to distinguish a finding nobody had triaged from one somebody had read and judged ordinary.

Both docs now state the three axes a new issue carries, and the reasoning behind each rather than just the list.

## What is added

- **Exactly one `priority:` and exactly one `area:`**, with the invariant named outright: unlabeled means untriaged, so filing without labels tells the next reader a falsehood about your own finding.
- **Priority is severity, never schedule.** This is the part most likely to drift, so it is stated as a rule rather than implied: a milestone carries the schedule, so demoting a real defect because it is not this week's work makes the label lie. The qualifying test for `critical` is given as "does this stop somebody else working, or is somebody's data wrong right now" — which is why a flaky gate earns it despite no user ever seeing one.
- **One area, the place the fix lives**, so a filter never double-counts. A doc that is wrong about a subsystem takes that subsystem's area rather than a documentation area, because it belongs beside the code it misleads about.
- **`status: needs-decision` / `status: spec-change`**, which keep unactionable work out of somebody's queue — the second because contract-first (P3) puts the change upstream first.
- **Provenance labels kept rather than tidied**: `capability-gap` and `fast-track-debt` record *why an issue exists*, which is the one thing nobody can reconstruct later.
- **Check for an existing parent tracker** before filing a sibling.

## Split between the two files

CLAUDE.md takes the long form (the qualifying test per level, the area rationale); AGENTS.md takes the digest. Neither paragraph is one of the three parity-gated sections, so they differ on purpose — as the CLAUDE.md header says most sections do.

## Gates

- `TestSharedRulebookSectionsAreIdenticalInBothDocs` — PASS (the gated sections are untouched)
- `make check-craft-doc` — `OK: AGENTS.md ## Craftsmanship present`
- Docs-only diff (`CLAUDE.md`, `AGENTS.md`), so the pre-push Go gates do not apply

## Known limitation, filed separately

The area list is now hand-maintained in two documents and in the repo's actual label set, with nothing holding the three together. Adding a sixteenth area means remembering all three places. That is exactly the "prefer fitness functions over point fixes" rule this repo binds itself to, and it is not fixed here — a follow-up issue records it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardizes issue labeling in `AGENTS.md` and `CLAUDE.md` and splits CI scopes to avoid booting twelve Postgres shards on docs-only edits. Previously issues arrived unlabeled and `CLAUDE.md` edits could break the parity unit test without running Go lanes; now each issue carries one `priority:` and one `area:`, and CI separates `backend_db` from `backend` so unit tests run while integration shards skip.

- Require exactly one `priority:` (severity, not schedule) and one `area:` (where the fix lives); optional `status: needs-decision` and `status: spec-change`; keep provenance. `security` is for hardening only — exploitable findings follow `SECURITY.md` via private advisories.
- Docs about a subsystem use that subsystem’s `area:`; check for an existing parent tracker and attach as a sub-issue.
- CI: add `backend_db`; derive `backend` from it by YAML anchor plus `AGENTS.md`/`CLAUDE.md`; include `CLAUDE.md` in the classifier; run the parity unit test on rulebook edits; gate integration shards and the `integration` fan-in on `backend_db` only; update `infra/ci-pipeline.md` to document the split.
- Parity-gated sections remain unchanged.

<sup>Written for commit cb0c2b0f339482451c07f31831602d40ed45d06c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1507?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added standardized issue-management guidance requiring one priority and one area label per issue.
  - Documented priority levels, area categories, severity criteria, optional status and provenance labels, and security-advisory reporting.
  - Added guidance for identifying parent trackers and inheriting priorities where applicable.

- **CI**
  - Improved change detection so documentation-only updates avoid unnecessary database infrastructure while still running relevant backend validation.
  - Database-dependent integration checks now run only when applicable changes are detected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->