### PR TITLE
refactor(overlay): the incumbent mirror drops the tenant column (ADR-0091 §8 phase D)

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -805,6 +805,18 @@ line. Eight production sites hid there, including two whole-module reads in
 sibling packages. The reliable sweep is two steps — `grep -l` the table, then
 `grep -n workspace_id` inside each file it names.
 
+**The reset's CREDENTIAL collector had the same defect as its table sweep, and
+it was already live.** `collectWorkspaceSecretRefs` reads every sealed handle
+before the sweep deletes the rows naming them — vault_secret is never swept, so
+an uncollected ref is credential material that outlives the wipe, resident and
+unreachable forever. Its table list required a `credential_ref` column **and** a
+`workspace_id` column, so `capture_connection` and `channel_connection` fell out
+of it the moment 0282 landed, and nothing failed: the collector simply found
+fewer tables. Fixed by deriving on `credential_ref` alone. Two derivations have
+now had this exact bug; if a third asks "does this table have a workspace_id",
+it is asking a question whose answer is becoming "no" everywhere, and the sweep
+above it will go quiet rather than red.
+
 **An index that outlives its reason goes quiet, it does not go red.**
 `channel_connection` carried two live-row unique rules: one live bot per
 provider, and one live binding per bot. The second existed to stop a SECOND

--- a/backend/internal/compose/datareset_integration_test.go
+++ b/backend/internal/compose/datareset_integration_test.go
@@ -11,7 +11,6 @@ import (
 	"errors"
 	"io"
 	"log/slog"
-	"os"
 	"testing"
 
 	"github.com/jackc/pgx/v5"
@@ -516,8 +515,8 @@ func TestResetPurgesTheSealedCredentialsItsSweepOrphans(t *testing.T) {
 	if err != nil {
 		t.Fatalf("sealing the credential under test: %v", err)
 	}
-	e.WsExec(t, `INSERT INTO incumbent_connection (id, workspace_id, incumbent, region, status, credential_ref)
-		VALUES ($1, $2, 'hubspot', 'eu', 'active', $3)`, ids.NewV7(), e.WS, string(mine))
+	e.WsExec(t, `INSERT INTO incumbent_connection (id, incumbent, region, status, credential_ref)
+		VALUES ($1, 'hubspot', 'eu', 'active', $2)`, ids.NewV7(), string(mine))
 
 	h := dataResetHandlers{
 		pool:  e.Pool,
@@ -537,79 +536,6 @@ func TestResetPurgesTheSealedCredentialsItsSweepOrphans(t *testing.T) {
 		WHERE action = 'reset_data' AND evidence->>'secrets_purged' = '1'`); got != 1 {
 		t.Errorf("reset_data rows recording one purged secret = %d, want 1", got)
 	}
-}
-
-// TestResetLeavesAnotherWorkspacesSealedCredential: the ref collection is
-// bound to the workspace being reset. vault_secret has no RLS to fall back on
-// — isolation here is the collecting query's job — so a co-tenant's sealed
-// credential surviving is the property that matters, not the count.
-//
-// The foreign ref is attached to a foreign connection ROW, not merely sealed in
-// the vault. A ref nothing references would be skipped by any implementation,
-// correct or not, so the test would pass against a collector that ignored
-// workspace_id entirely — proving nothing. Reachable-but-not-collected is the
-// only arrangement that can fail.
-func TestResetLeavesAnotherWorkspacesSealedCredential(t *testing.T) {
-	e := integration.Setup(t)
-	ctx := e.Admin()
-
-	vault := resetTestVault(t, e)
-	theirs := ids.New[ids.WorkspaceKind]()
-	theirRef, err := vault.Put(ctx, theirs, []byte("another tenant's token"))
-	if err != nil {
-		t.Fatalf("sealing the co-tenant's credential: %v", err)
-	}
-	// Seeded on an owner connection, because these rows belong to a workspace
-	// the admin context is not bound to — which is precisely what RLS refuses.
-	owner := resetOwnerConn(ctx, t)
-	if _, err := owner.Exec(ctx,
-		`INSERT INTO workspace (id, slug) VALUES ($1, $2)`,
-		theirs, "other-tenant-"+theirs.String()[:8]); err != nil {
-		t.Fatalf("seeding the co-tenant workspace: %v", err)
-	}
-	if _, err := owner.Exec(ctx,
-		`INSERT INTO incumbent_connection (id, workspace_id, incumbent, region, status, credential_ref)
-		 VALUES ($1, $2, 'hubspot', 'eu', 'active', $3)`,
-		ids.NewV7(), theirs, string(theirRef)); err != nil {
-		t.Fatalf("seeding the co-tenant's connection: %v", err)
-	}
-
-	h := dataResetHandlers{
-		pool:  e.Pool,
-		seeds: deployconfig.Seeds{},
-		env:   runtimeenv.Development,
-		log:   slog.New(slog.NewTextHandler(io.Discard, nil)),
-		vault: vault,
-	}
-	if _, err := h.run(ctx, "Authz"); err != nil {
-		t.Fatalf("run: %v", err)
-	}
-
-	if _, err := vault.Get(ctx, theirs, theirRef); err != nil {
-		t.Errorf("a reset reached past its own tenant into another workspace's sealed credential: %v", err)
-	}
-}
-
-// resetOwnerConn opens a superuser connection for seeding rows that belong to
-// a workspace the test's own context is not bound to. The app role cannot write
-// them — FORCE RLS refuses — and that refusal is the property under test, so the
-// fixture has to come in over the role that bypasses it.
-func resetOwnerConn(ctx context.Context, t *testing.T) *pgx.Conn {
-	t.Helper()
-	dsn := os.Getenv("MARGINCE_TEST_DSN")
-	if dsn == "" {
-		t.Fatal("MARGINCE_TEST_DSN not set — run `make db-up` (integration tests fail loudly, they never skip)")
-	}
-	conn, err := pgx.Connect(ctx, dsn)
-	if err != nil {
-		t.Fatalf("owner connection: %v", err)
-	}
-	t.Cleanup(func() {
-		if err := conn.Close(context.Background()); err != nil {
-			t.Errorf("closing the owner connection: %v", err)
-		}
-	})
-	return conn
 }
 
 // resetTestVault builds the local vault provider over the harness pool. The

--- a/backend/internal/compose/datasweep.go
+++ b/backend/internal/compose/datasweep.go
@@ -240,15 +240,15 @@ func isForeignKeyViolation(err error) bool {
 // column exists, which a hand-kept list would not be.
 const vaultRefColumn = "credential_ref"
 
-// collectWorkspaceSecretRefs reads every sealed-credential handle this
-// workspace owns, BEFORE the sweep deletes the rows that name them.
+// collectWorkspaceSecretRefs reads every sealed-credential handle in the
+// installation, BEFORE the sweep deletes the rows that name them.
 //
-// It has to run first because vault_secret is deliberately not a tenant table:
-// it carries no workspace_id and no RLS (migrations/core/0062), since the
-// tenant lives inside the ref and inside the AES-256-GCM AAD. The sweep
-// therefore never sees it, and a reset that did not collect these first would
-// leave the ciphertext resident and unreachable forever — credential material
-// outliving the wipe that was supposed to clear it.
+// It has to run first because vault_secret is deliberately not swept: it
+// carries no RLS (migrations/core/0062), since the tenant lives inside the ref
+// and inside the AES-256-GCM AAD. The sweep therefore never sees it, and a
+// reset that did not collect these first would leave the ciphertext resident
+// and unreachable forever — credential material outliving the wipe that was
+// supposed to clear it.
 func collectWorkspaceSecretRefs(ctx context.Context, tx pgx.Tx) ([]string, error) {
 	tables, err := tablesWithVaultRef(ctx, tx)
 	if err != nil {
@@ -259,8 +259,7 @@ func collectWorkspaceSecretRefs(ctx context.Context, tx pgx.Tx) ([]string, error
 		rows, err := tx.Query(ctx,
 			`SELECT `+pgx.Identifier{vaultRefColumn}.Sanitize()+
 				` FROM `+pgx.Identifier{t}.Sanitize()+
-				` WHERE workspace_id = current_setting('app.workspace_id')::uuid
-				  AND `+pgx.Identifier{vaultRefColumn}.Sanitize()+` IS NOT NULL`)
+				` WHERE `+pgx.Identifier{vaultRefColumn}.Sanitize()+` IS NOT NULL`)
 		if err != nil {
 			return nil, fmt.Errorf("data reset: reading credential handles from %s: %w", t, err)
 		}
@@ -280,20 +279,25 @@ func collectWorkspaceSecretRefs(ctx context.Context, tx pgx.Tx) ([]string, error
 	return refs, nil
 }
 
-// tablesWithVaultRef lists the workspace-scoped tables holding a
-// credential handle, derived from the catalog for the same reason
-// resetTargetTables is: a new one enrols itself.
+// tablesWithVaultRef lists the tables holding a credential handle, derived from
+// the catalog for the same reason resetTargetTables is: a new one enrols itself.
+//
+// Holding the COLUMN is the whole test. It used to also require a workspace_id,
+// which was the same set only while every connection table had one — and phase
+// D (ADR-0091 §8) is removing it table by table, so each connection table that
+// dropped it silently stopped being collected and left its sealed credential
+// resident after a reset. That is the same failure resetTargetTables already
+// had for the same reason, and it is why neither derivation may ask about a
+// column that is on its way out.
 func tablesWithVaultRef(ctx context.Context, tx pgx.Tx) ([]string, error) {
 	rows, err := tx.Query(ctx, `
 		SELECT c.relname
 		FROM pg_class c
 		JOIN pg_namespace n ON n.oid = c.relnamespace
 		JOIN pg_attribute a ON a.attrelid = c.oid
-		JOIN pg_attribute w ON w.attrelid = c.oid
 		WHERE n.nspname = 'public'
 		  AND c.relkind = 'r'
 		  AND a.attname = $1 AND a.attnum > 0 AND NOT a.attisdropped
-		  AND w.attname = 'workspace_id' AND w.attnum > 0 AND NOT w.attisdropped
 		ORDER BY c.relname`, vaultRefColumn)
 	if err != nil {
 		return nil, fmt.Errorf("data reset: listing tables holding a credential handle: %w", err)

--- a/backend/internal/compose/integration/overlay/overlay_acceptance_integration_test.go
+++ b/backend/internal/compose/integration/overlay/overlay_acceptance_integration_test.go
@@ -569,10 +569,10 @@ func TestAcceptance_OVA_AC_1_TeardownPurges(t *testing.T) {
 	}
 
 	var seededMirror, seededAssoc int
-	if err := e.Owner.QueryRow(context.Background(), `SELECT count(*) FROM overlay_mirror WHERE workspace_id = $1`, wsIDStr).Scan(&seededMirror); err != nil {
+	if err := e.Owner.QueryRow(context.Background(), `SELECT count(*) FROM overlay_mirror`).Scan(&seededMirror); err != nil {
 		t.Fatalf("counting the seeded mirror rows: %v", err)
 	}
-	if err := e.Owner.QueryRow(context.Background(), `SELECT count(*) FROM overlay_association WHERE workspace_id = $1`, wsIDStr).Scan(&seededAssoc); err != nil {
+	if err := e.Owner.QueryRow(context.Background(), `SELECT count(*) FROM overlay_association`).Scan(&seededAssoc); err != nil {
 		t.Fatalf("counting the seeded association rows: %v", err)
 	}
 	if seededMirror == 0 || seededAssoc == 0 {
@@ -600,7 +600,7 @@ func TestAcceptance_OVA_AC_1_TeardownPurges(t *testing.T) {
 	counts := map[string]int{}
 	for _, table := range []string{"overlay_mirror", "overlay_association", "mirror_visibility", "mirror_user_map", "overlay_backfill_cursor", "overlay_reconcile_watermark"} {
 		var n int
-		if err := e.Owner.QueryRow(context.Background(), fmt.Sprintf(`SELECT count(*) FROM %s WHERE workspace_id = $1`, table), wsIDStr).Scan(&n); err != nil {
+		if err := e.Owner.QueryRow(context.Background(), fmt.Sprintf(`SELECT count(*) FROM %s`, table)).Scan(&n); err != nil {
 			t.Fatalf("counting %s: %v", table, err)
 		}
 		counts[table] = n
@@ -612,7 +612,7 @@ func TestAcceptance_OVA_AC_1_TeardownPurges(t *testing.T) {
 	}
 
 	var tombstoneCount int
-	if err := e.Owner.QueryRow(context.Background(), `SELECT count(*) FROM overlay_tombstone WHERE workspace_id = $1`, wsIDStr).Scan(&tombstoneCount); err != nil {
+	if err := e.Owner.QueryRow(context.Background(), `SELECT count(*) FROM overlay_tombstone`).Scan(&tombstoneCount); err != nil {
 		t.Fatalf("counting overlay_tombstone rows: %v", err)
 	}
 	if tombstoneCount == 0 {

--- a/backend/internal/compose/integration/overlay/overlay_e2e_integration_test.go
+++ b/backend/internal/compose/integration/overlay/overlay_e2e_integration_test.go
@@ -415,13 +415,13 @@ func assertDisconnectPurgesTheMirrorAndRetainsTheAudit(t *testing.T, e *apptest.
 	}
 
 	var mirrorCount, tombstoneCount int
-	if err := e.Owner.QueryRow(context.Background(), `SELECT count(*) FROM overlay_mirror WHERE workspace_id = $1`, wsIDStr).Scan(&mirrorCount); err != nil {
+	if err := e.Owner.QueryRow(context.Background(), `SELECT count(*) FROM overlay_mirror`).Scan(&mirrorCount); err != nil {
 		t.Fatalf("counting overlay_mirror rows: %v", err)
 	}
 	if mirrorCount != 0 {
 		t.Errorf("overlay_mirror still has %d rows after disconnect, want 0", mirrorCount)
 	}
-	if err := e.Owner.QueryRow(context.Background(), `SELECT count(*) FROM overlay_tombstone WHERE workspace_id = $1`, wsIDStr).Scan(&tombstoneCount); err != nil {
+	if err := e.Owner.QueryRow(context.Background(), `SELECT count(*) FROM overlay_tombstone`).Scan(&tombstoneCount); err != nil {
 		t.Fatalf("counting overlay_tombstone rows: %v", err)
 	}
 	if tombstoneCount == 0 {

--- a/backend/internal/compose/jobs_overlay_disconnectfence_integration_test.go
+++ b/backend/internal/compose/jobs_overlay_disconnectfence_integration_test.go
@@ -78,8 +78,7 @@ func TestReconcileConnectionStopsCleanlyWhenDisconnectedMidSweep(t *testing.T) {
 	// fenced write, exactly the mid-sweep race the fence exists for).
 	if err := database.WithWorkspaceTx(adminCtx, e.Pool, func(tx pgx.Tx) error {
 		_, execErr := tx.Exec(adminCtx,
-			`UPDATE incumbent_connection SET status = 'revoked', revoked_at = now()
-			 WHERE workspace_id = current_setting('app.workspace_id')::uuid`)
+			`UPDATE incumbent_connection SET status = 'revoked', revoked_at = now()`)
 		return execErr
 	}); err != nil {
 		t.Fatalf("revoking the connection mid-sweep: %v", err)
@@ -162,8 +161,7 @@ func TestReconcileConnectionStopsCleanlyWhenReconnectedMidSweep(t *testing.T) {
 	// disconnect test above revokes via raw SQL instead of svc.Disconnect).
 	if err := database.WithWorkspaceTx(adminCtx, e.Pool, func(tx pgx.Tx) error {
 		_, execErr := tx.Exec(adminCtx, `
-			UPDATE incumbent_connection SET connected_at = now()
-			WHERE workspace_id = current_setting('app.workspace_id')::uuid`)
+			UPDATE incumbent_connection SET connected_at = now()`)
 		return execErr
 	}); err != nil {
 		t.Fatalf("reconnecting mid-sweep: %v", err)
@@ -221,8 +219,7 @@ func (r *revokeOnOwnersIncumbent) Owners(ctx context.Context) ([]overlay.OwnerRe
 		r.done = true
 		if err := database.WithWorkspaceTx(ctx, r.pool, func(tx pgx.Tx) error {
 			_, execErr := tx.Exec(ctx,
-				`UPDATE incumbent_connection SET status = 'revoked', revoked_at = now()
-				 WHERE workspace_id = current_setting('app.workspace_id')::uuid`)
+				`UPDATE incumbent_connection SET status = 'revoked', revoked_at = now()`)
 			return execErr
 		}); err != nil {
 			return nil, err

--- a/backend/internal/compose/jobs_overlay_refetch_failures_integration_test.go
+++ b/backend/internal/compose/jobs_overlay_refetch_failures_integration_test.go
@@ -151,8 +151,8 @@ func TestOverlayRefetchWorkerSkipsAHaltedMirror(t *testing.T) {
 	// unhalt to drive it through, so insert the row the way the ledger does.
 	if err := database.WithWorkspaceTx(adminCtx, f.e.Pool, func(tx pgx.Tx) error {
 		_, execErr := tx.Exec(adminCtx, `
-			INSERT INTO overlay_mirror_halt (workspace_id, reason)
-			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, 'value-hash collision')`)
+			INSERT INTO overlay_mirror_halt (reason)
+			VALUES ('value-hash collision')`)
 		return execErr
 	}); err != nil {
 		t.Fatalf("halting the mirror: %v", err)
@@ -311,8 +311,7 @@ func (r *revokeOnGetIncumbent) Get(ctx context.Context, objectClass, externalID 
 	}
 	if err := database.WithWorkspaceTx(ctx, r.pool, func(tx pgx.Tx) error {
 		_, execErr := tx.Exec(ctx,
-			`UPDATE incumbent_connection SET status = 'revoked', revoked_at = now()
-			 WHERE workspace_id = current_setting('app.workspace_id')::uuid`)
+			`UPDATE incumbent_connection SET status = 'revoked', revoked_at = now()`)
 		return execErr
 	}); err != nil {
 		return overlay.Record{}, err

--- a/backend/internal/modules/overlay/connection.go
+++ b/backend/internal/modules/overlay/connection.go
@@ -233,7 +233,7 @@ func (s *Service) WithLogger(log *slog.Logger) *Service {
 // the mirror on Disconnect and flips sor_mode for every seat), so it is
 // admin/ops-only (identity/internal/policy), the same posture as quota.
 //
-// UNIQUE(workspace_id) means a second Connect on an already-active
+// The singleton index means a second Connect on an already-active
 // connection answers apperrors.ErrIncumbentAlreadyConnected; a revoked one
 // reconnects instead (reconnectConnection). existingConnectionStatus checks
 // for that BEFORE sealing anything, so the common duplicate-connect case
@@ -405,8 +405,8 @@ func (s *Service) insertConnection(ctx context.Context, in ConnectInput, ref key
 		// nullable binding needs no `any` at the call site.
 		if scanErr := tx.QueryRow(
 			ctx, `
-			INSERT INTO incumbent_connection (workspace_id, incumbent, region, credential_ref, scopes, incumbent_account_id)
-			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, $2, $3, $4, NULLIF($5, ''))
+			INSERT INTO incumbent_connection (incumbent, region, credential_ref, scopes, incumbent_account_id)
+			VALUES ($1, $2, $3, $4, NULLIF($5, ''))
 			RETURNING id, connected_at`,
 			in.Incumbent, in.Region, string(ref), leastPrivilegeHubSpotScopes, accountID,
 		).Scan(&id, &connectedAt); scanErr != nil {
@@ -427,7 +427,7 @@ func (s *Service) insertConnection(ctx context.Context, in ConnectInput, ref key
 }
 
 // cleanupOrphanedRef deletes a vault ref this Connect attempt sealed but lost
-// the UNIQUE(workspace_id) race to persist (the INSERT hit the unique
+// the singleton race to persist (the INSERT hit the unique
 // constraint after vault.Put already ran) — the row definitively did not
 // persist, so nothing references the ref. Delete is idempotent. It runs on a
 // context DETACHED from ctx's cancellation (context.WithoutCancel) so a
@@ -474,8 +474,7 @@ func (s *Service) Get(ctx context.Context) (Connection, error) {
 	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		return tx.QueryRow(ctx, `
 			SELECT incumbent, region, status, connected_at, scopes
-			FROM incumbent_connection
-			WHERE workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid`).
+			FROM incumbent_connection`).
 			Scan(&out.Incumbent, &out.Region, &out.Status, &connectedAt, &out.Scopes)
 	})
 	if errors.Is(err, pgx.ErrNoRows) {

--- a/backend/internal/modules/overlay/connection_integration_test.go
+++ b/backend/internal/modules/overlay/connection_integration_test.go
@@ -25,12 +25,9 @@ import (
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
-// queryRowWS runs a single-row read inside database.WithWorkspaceTx —
-// every overlay table carries FORCE RLS keyed off the app.workspace_id
-// GUC, so a bare pool.QueryRow (no GUC bound) would see zero rows rather
-// than the fixture the test just wrote. This is the assertion-side
-// mirror of seedTombstone (mirrorstore_integration_test.go): the same
-// tenant-scoped transaction helper the store itself uses.
+// queryRowWS runs a single-row read inside database.WithWorkspaceTx — the same
+// transaction helper the store itself uses, so an assertion reads through the
+// wiring production reads through rather than around it.
 func queryRowWS(ctx context.Context, t *testing.T, pool *pgxpool.Pool, sql string, args []any, dest ...any) {
 	t.Helper()
 	if err := database.WithWorkspaceTx(ctx, pool, func(tx pgx.Tx) error {
@@ -106,8 +103,7 @@ func TestConnectSealsTheTokenAndFlipsTheWorkspaceToOverlay(t *testing.T) {
 	// token substring is absent is the load-bearing security proof here.
 	var incumbent, region, status, credentialRef string
 	queryRowWS(ctx, t, pool,
-		`SELECT incumbent, region, status, credential_ref FROM incumbent_connection WHERE workspace_id = $1`,
-		[]any{ws}, &incumbent, &region, &status, &credentialRef)
+		`SELECT incumbent, region, status, credential_ref FROM incumbent_connection`, nil, &incumbent, &region, &status, &credentialRef)
 	if strings.Contains(credentialRef, token) {
 		t.Fatalf("credential_ref %q embeds the plaintext token — it must carry only the opaque vault ref", credentialRef)
 	}
@@ -219,7 +215,7 @@ func TestConnectionLifecycleObjectRBACDeniesMemberAllowsAdmin(t *testing.T) {
 	// The connection must still be untouched: the denial happened before
 	// any row was ever read or purged.
 	var status string
-	queryRowWS(adminCtx, t, pool, `SELECT status FROM incumbent_connection WHERE workspace_id = $1`, []any{ws}, &status)
+	queryRowWS(adminCtx, t, pool, `SELECT status FROM incumbent_connection`, nil, &status)
 	if status != statusActive {
 		t.Errorf("connection status = %q after a denied member Disconnect, want %q (untouched)", status, statusActive)
 	}

--- a/backend/internal/modules/overlay/connectionreads.go
+++ b/backend/internal/modules/overlay/connectionreads.go
@@ -84,7 +84,7 @@ func DueOverlayConnections(ctx context.Context, pool *pgxpool.Pool) ([]DueOverla
 			scanErr := tx.QueryRow(wsCtx, `
 				SELECT c.incumbent, c.region, c.credential_ref, c.connected_at
 				FROM incumbent_connection c
-				LEFT JOIN overlay_sync_state s ON s.workspace_id = c.workspace_id
+				LEFT JOIN overlay_sync_state s ON true
 				WHERE c.status = $1 AND COALESCE(s.next_sweep_at, now()) <= now()
 				  AND s.mirror_frozen_at IS NULL`,
 				statusActive).Scan(&incumbent, &region, &ref, &connectedAt)
@@ -269,7 +269,7 @@ func DueConnection(ctx context.Context, pool *pgxpool.Pool) (DueOverlayConnectio
 const dueConnectionQuery = `
 	SELECT c.incumbent, c.region, c.credential_ref, c.connected_at
 	FROM incumbent_connection c
-	LEFT JOIN overlay_sync_state s ON s.workspace_id = c.workspace_id
+	LEFT JOIN overlay_sync_state s ON true
 	WHERE c.status = $1 AND COALESCE(s.next_sweep_at, now()) <= now()
 	  AND s.mirror_frozen_at IS NULL`
 

--- a/backend/internal/modules/overlay/deletion_integration_test.go
+++ b/backend/internal/modules/overlay/deletion_integration_test.go
@@ -217,8 +217,8 @@ func seedVisibilityRow(ctx context.Context, t *testing.T, pool *pgxpool.Pool, ob
 	if err := database.WithWorkspaceTx(ctx, pool, func(tx pgx.Tx) error {
 		_, err := tx.Exec(ctx, `
 			INSERT INTO mirror_visibility
-				(workspace_id, incumbent, mirror_user_id, object_class, external_id, can_see)
-			VALUES (NULLIF(current_setting('app.workspace_id',true),'')::uuid, 'hubspot', $1, $2, $3, true)`,
+				(incumbent, mirror_user_id, object_class, external_id, can_see)
+			VALUES ('hubspot', $1, $2, $3, true)`,
 			ids.NewV7(), objectClass, externalID)
 		return err
 	}); err != nil {

--- a/backend/internal/modules/overlay/disconnectfence.go
+++ b/backend/internal/modules/overlay/disconnectfence.go
@@ -65,22 +65,18 @@ var ErrConnectionGone = errors.New("overlay: the incumbent connection was revoke
 // closing it needs the shared per-request incumbent resolver
 // (overlay.Provider.resolveIncumbent) to carry connectedAt, which it does
 // not today. Concretely, a write-back straddling a disconnect+reconnect TO A
-// DIFFERENT PORTAL can ingest portal A's record into portal B's mirror
-// (intra-tenant data pollution, not a cross-tenant leak — the workspace
-// scope never changes) and land a write-ledger echo entry under the new
-// generation that could mask a genuine portal-B change as an echo.
+// DIFFERENT PORTAL can ingest portal A's record into portal B's mirror, and
+// land a write-ledger echo entry under the new generation that could mask a
+// genuine portal-B change as an echo.
 //
-// The GUC is read WITHOUT missing_ok, exactly as lockWorkspaceVisibility is:
-// a fenced write with app.workspace_id unset RAISEs rather than resolving to
-// NULL and matching no row (or, worse, every row) — the same fail-closed
-// posture the RLS policies take on the same condition. It is only ever
-// reached inside database.WithWorkspaceTx, which sets the GUC.
+// The fence is `status = 'active'` and nothing else, which is the whole
+// selection: incumbent_connection holds one row per installation (its
+// singleton index), so an active connection is THE connection.
 func assertActiveConnection(ctx context.Context, tx pgx.Tx) error {
 	var one int
 	err := tx.QueryRow(ctx, `
 		SELECT 1 FROM incumbent_connection
-		WHERE workspace_id = current_setting('app.workspace_id')::uuid
-		  AND status = 'active'
+		WHERE status = 'active'
 		FOR SHARE`).Scan(&one)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return ErrConnectionGone
@@ -123,8 +119,7 @@ func assertOwnConnection(ctx context.Context, tx pgx.Tx, connectedAt time.Time) 
 	var one int
 	err := tx.QueryRow(ctx, `
 		SELECT 1 FROM incumbent_connection
-		WHERE workspace_id = current_setting('app.workspace_id')::uuid
-		  AND status = 'active'
+		WHERE status = 'active'
 		  AND connected_at = $1
 		FOR SHARE`, connectedAt).Scan(&one)
 	if errors.Is(err, pgx.ErrNoRows) {

--- a/backend/internal/modules/overlay/emailrevalidate.go
+++ b/backend/internal/modules/overlay/emailrevalidate.go
@@ -58,7 +58,7 @@ func (s *MirrorStore) revalidateEmailMapping(ctx context.Context, tx pgx.Tx, ema
 		  AND m.match_source = 'email'
 		  AND NOT EXISTS (
 		      SELECT 1 FROM app_user u
-		      WHERE u.workspace_id = m.workspace_id AND u.id = m.app_user_id
+		      WHERE u.id = m.app_user_id
 		        AND lower(trim(u.email)) = lower(trim($2))
 		  )
 		RETURNING m.app_user_id, m.incumbent_user_id, m.match_source`, incumbentUserID, currentEmail)

--- a/backend/internal/modules/overlay/flipstate.go
+++ b/backend/internal/modules/overlay/flipstate.go
@@ -194,8 +194,8 @@ func (s *Service) SealFlipSnapshot(ctx context.Context) (FlipSnapshot, error) {
 	candidate := "snap-" + time.Now().UTC().Format("2006-01-02T15:04:05Z") + "-" + ids.NewV7().String()
 	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		if err := tx.QueryRow(ctx, `
-			INSERT INTO overlay_sync_state (workspace_id, next_sweep_at, flip_snapshot_id, mirror_frozen_at, updated_at)
-			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, now(), $1, now(), now())
+			INSERT INTO overlay_sync_state (next_sweep_at, flip_snapshot_id, mirror_frozen_at, updated_at)
+			VALUES (now(), $1, now(), now())
 			ON CONFLICT ((true)) DO UPDATE SET
 			  flip_snapshot_id = COALESCE(overlay_sync_state.flip_snapshot_id, EXCLUDED.flip_snapshot_id),
 			  mirror_frozen_at = COALESCE(overlay_sync_state.mirror_frozen_at, EXCLUDED.mirror_frozen_at),
@@ -261,15 +261,18 @@ func (s *Service) UnsealFlipSnapshot(ctx context.Context) error {
 		var priorFrozen time.Time
 		err := tx.QueryRow(ctx, `
 			WITH prior AS (
-			  SELECT workspace_id, flip_snapshot_id, mirror_frozen_at FROM overlay_sync_state
+			  SELECT flip_snapshot_id, mirror_frozen_at FROM overlay_sync_state
 			  WHERE mirror_frozen_at IS NOT NULL
 			), cleared AS (
-			  UPDATE overlay_sync_state s
+			  -- FROM prior with no join predicate, because overlay_sync_state is a
+			  -- singleton: prior holds the one row or none, and the cross product
+			  -- says "clear exactly what prior saw" without a key to say it with.
+			  UPDATE overlay_sync_state
 			  SET flip_snapshot_id = NULL, mirror_frozen_at = NULL, updated_at = now()
-			  FROM prior WHERE s.workspace_id = prior.workspace_id
-			  RETURNING s.workspace_id
+			  FROM prior
+			  RETURNING 1 AS cleared
 			)
-			SELECT prior.flip_snapshot_id, prior.mirror_frozen_at FROM prior JOIN cleared USING (workspace_id)`,
+			SELECT prior.flip_snapshot_id, prior.mirror_frozen_at FROM prior JOIN cleared ON true`,
 		).Scan(&priorID, &priorFrozen)
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil // not sealed: a no-op, nothing to audit

--- a/backend/internal/modules/overlay/flipstate_integration_test.go
+++ b/backend/internal/modules/overlay/flipstate_integration_test.go
@@ -34,8 +34,8 @@ func seedOverlayWorkspace(ctx context.Context, t *testing.T, pool *pgxpool.Pool)
 			return err
 		}
 		_, err := tx.Exec(ctx, `
-			INSERT INTO incumbent_connection (workspace_id, incumbent, region, credential_ref, status)
-			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, 'hubspot', 'eu1', $1, 'active')`,
+			INSERT INTO incumbent_connection (incumbent, region, credential_ref, status)
+			VALUES ('hubspot', 'eu1', $1, 'active')`,
 			string(keyvault.Ref("test-ref-"+ids.NewV7().String())))
 		return err
 	})
@@ -62,8 +62,8 @@ func seedMirrorPerson(ctx context.Context, t *testing.T, pool *pgxpool.Pool, ext
 	t.Helper()
 	err := database.WithWorkspaceTx(ctx, pool, func(tx pgx.Tx) error {
 		_, err := tx.Exec(ctx, `
-			INSERT INTO overlay_mirror (workspace_id, object_class, external_id, fields, updated_at_baseline, sync_state)
-			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, 'person', $1, '{"full_name":"Fixture Row"}'::jsonb, now(), $2)`,
+			INSERT INTO overlay_mirror (object_class, external_id, fields, updated_at_baseline, sync_state)
+			VALUES ('person', $1, '{"full_name":"Fixture Row"}'::jsonb, now(), $2)`,
 			ext, syncState)
 		return err
 	})
@@ -76,8 +76,8 @@ func recordSweepSuccess(ctx context.Context, t *testing.T, pool *pgxpool.Pool) {
 	t.Helper()
 	err := database.WithWorkspaceTx(ctx, pool, func(tx pgx.Tx) error {
 		_, err := tx.Exec(ctx, `
-			INSERT INTO overlay_sync_state (workspace_id, next_sweep_at, consecutive_failures, last_success_at, updated_at)
-			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, now(), 0, now(), now())
+			INSERT INTO overlay_sync_state (next_sweep_at, consecutive_failures, last_success_at, updated_at)
+			VALUES (now(), 0, now(), now())
 			ON CONFLICT ((true)) DO UPDATE SET last_success_at = now(), updated_at = now()`)
 		return err
 	})
@@ -90,8 +90,8 @@ func markBackfillDone(ctx context.Context, t *testing.T, pool *pgxpool.Pool, inc
 	t.Helper()
 	err := database.WithWorkspaceTx(ctx, pool, func(tx pgx.Tx) error {
 		_, err := tx.Exec(ctx, `
-			INSERT INTO overlay_backfill_cursor (workspace_id, object_class, cursor, done, truncated)
-			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, '', true, false)
+			INSERT INTO overlay_backfill_cursor (object_class, cursor, done, truncated)
+			VALUES ($1, '', true, false)
 			ON CONFLICT (object_class) DO UPDATE SET done = true, truncated = false`,
 			incumbentClass)
 		return err

--- a/backend/internal/modules/overlay/mirrorcheckpoints.go
+++ b/backend/internal/modules/overlay/mirrorcheckpoints.go
@@ -45,8 +45,8 @@ import (
 // truncated=true must never be overwritten back to false by an earlier
 // in-flight save landing after it).
 const upsertBackfillCursorSQL = `
-INSERT INTO overlay_backfill_cursor (workspace_id, object_class, cursor, done, truncated, updated_at)
-VALUES (NULLIF(current_setting('app.workspace_id',true),'')::uuid, $1, $2, $3, $4, now())
+INSERT INTO overlay_backfill_cursor (object_class, cursor, done, truncated, updated_at)
+VALUES ($1, $2, $3, $4, now())
 ON CONFLICT (object_class) DO UPDATE
    SET cursor = EXCLUDED.cursor,
        done = overlay_backfill_cursor.done OR EXCLUDED.done,
@@ -124,8 +124,8 @@ func (s *MirrorStore) LoadBackfillCursor(ctx context.Context, objectClass string
 // newer pass already saw. The same monotonic-progress discipline ingestSQL's
 // staleness guard applies to a mirror row (mirrorstore.go).
 const upsertReconcileWatermarkSQL = `
-INSERT INTO overlay_reconcile_watermark (workspace_id, object_class, watermark, updated_at)
-VALUES (NULLIF(current_setting('app.workspace_id',true),'')::uuid, $1, $2, now())
+INSERT INTO overlay_reconcile_watermark (object_class, watermark, updated_at)
+VALUES ($1, $2, now())
 ON CONFLICT (object_class) DO UPDATE
    SET watermark = EXCLUDED.watermark, updated_at = now()
    WHERE EXCLUDED.watermark > overlay_reconcile_watermark.watermark`

--- a/backend/internal/modules/overlay/mirrorcheckpoints_integration_test.go
+++ b/backend/internal/modules/overlay/mirrorcheckpoints_integration_test.go
@@ -111,8 +111,7 @@ func TestSaveBackfillCursorEnforcesIdentityEvenOnAPlainFenceStore(t *testing.T) 
 	// own identity check rather than re-exercising the reconnect flow.
 	if err := database.WithWorkspaceTx(ctx, pool, func(tx pgx.Tx) error {
 		_, execErr := tx.Exec(ctx, `
-			UPDATE incumbent_connection SET connected_at = now()
-			WHERE workspace_id = current_setting('app.workspace_id')::uuid`)
+			UPDATE incumbent_connection SET connected_at = now()`)
 		return execErr
 	}); err != nil {
 		t.Fatalf("reconnecting: %v", err)

--- a/backend/internal/modules/overlay/mirrorstore.go
+++ b/backend/internal/modules/overlay/mirrorstore.go
@@ -149,10 +149,10 @@ func (s *MirrorStore) WithResolver(r OwnerEmailResolver) *MirrorStore {
 //     (mirror.conflict, not implemented until branch 2's write path
 //     lands — see the ProjectOwnerVisibility seam note in Ingest below).
 const ingestSQL = `
-INSERT INTO overlay_mirror (workspace_id, object_class, external_id, fields, updated_at_baseline, owner_external_id, projection_fingerprint, last_synced_at, sync_state)
-SELECT NULLIF(current_setting('app.workspace_id',true),'')::uuid, $1, $2, $3, $4, $5, $6, now(), 'fresh'
+INSERT INTO overlay_mirror (object_class, external_id, fields, updated_at_baseline, owner_external_id, projection_fingerprint, last_synced_at, sync_state)
+SELECT $1, $2, $3, $4, $5, $6, now(), 'fresh'
 WHERE NOT EXISTS (SELECT 1 FROM overlay_tombstone t
-    WHERE t.workspace_id = NULLIF(current_setting('app.workspace_id',true),'')::uuid AND t.object_class=$1 AND t.external_id=$2)
+    WHERE t.object_class=$1 AND t.external_id=$2)
 ON CONFLICT (object_class, external_id) DO UPDATE
    SET fields=EXCLUDED.fields, updated_at_baseline=EXCLUDED.updated_at_baseline,
        owner_external_id=EXCLUDED.owner_external_id,
@@ -321,13 +321,13 @@ func (s *MirrorStore) ingestTx(ctx context.Context, tx pgx.Tx, rec Record) (bool
 }
 
 // upsertAssocSQL keeps the direction/label/category refresh together
-// with the association's identity key (workspace_id, from_type, from_id,
+// with the association's identity key (from_type, from_id,
 // to_type, to_id, type_id) — associations v4 can relabel or recategorize
 // an edge without changing its identity, so a re-sync must update those
 // columns in place rather than duplicate the edge.
 const upsertAssocSQL = `
-INSERT INTO overlay_association (workspace_id, from_type, from_id, to_type, to_id, type_id, category, label, direction)
-VALUES (NULLIF(current_setting('app.workspace_id',true),'')::uuid, $1, $2, $3, $4, $5, $6, $7, $8)
+INSERT INTO overlay_association (from_type, from_id, to_type, to_id, type_id, category, label, direction)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
 ON CONFLICT (from_type, from_id, to_type, to_id, type_id) DO UPDATE
    SET category = EXCLUDED.category, label = EXCLUDED.label, direction = EXCLUDED.direction`
 

--- a/backend/internal/modules/overlay/mirrorstore_integration_test.go
+++ b/backend/internal/modules/overlay/mirrorstore_integration_test.go
@@ -394,8 +394,8 @@ func TestIngestClearsAReprojectionFailureRecord(t *testing.T) {
 func seedTombstone(ctx context.Context, pool *pgxpool.Pool, objectClass, externalID string) error {
 	return database.WithWorkspaceTx(ctx, pool, func(tx pgx.Tx) error {
 		_, err := tx.Exec(ctx, `
-			INSERT INTO overlay_tombstone (workspace_id, object_class, external_id)
-			VALUES (NULLIF(current_setting('app.workspace_id',true),'')::uuid, $1, $2)`,
+			INSERT INTO overlay_tombstone (object_class, external_id)
+			VALUES ($1, $2)`,
 			objectClass, externalID)
 		return err
 	})

--- a/backend/internal/modules/overlay/projectionstaleness.go
+++ b/backend/internal/modules/overlay/projectionstaleness.go
@@ -198,14 +198,14 @@ func (s *MirrorStore) StaleProjections(ctx context.Context, m ObjectMapping, lim
 // current fingerprint: the caller has just failed to reach `fingerprint`, and
 // whether the row moved underneath it in the meantime does not change that.
 //
-// It is NOT unconditional on the workspace. One of the two lanes reaching here
-// carries an external_id off the wire from the incumbent, and since core 0217
-// (ADR-0091) nothing behind this statement bounds which mirror row that id
-// selects — so the bound is stated here, where the id is untrusted.
+// One of the two lanes reaching here carries an external_id off the wire from
+// the incumbent, so the predicate is the whole bound on an untrusted id — and
+// (object_class, external_id) is overlay_mirror's primary key, which is what
+// makes it a bound rather than a filter: it selects at most one row, and a row
+// the incumbent never mirrored selects none.
 const recordReprojectionFailureSQL = `
 UPDATE overlay_mirror SET reprojection_failed_for = $3
-WHERE object_class = $1 AND external_id = $2
-  AND workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid`
+WHERE object_class = $1 AND external_id = $2`
 
 // RecordReprojectionFailure marks that this row could not be brought to
 // fingerprint: the incumbent handed the record back whole and the declaration

--- a/backend/internal/modules/overlay/provider_writeback_integration_test.go
+++ b/backend/internal/modules/overlay/provider_writeback_integration_test.go
@@ -125,8 +125,8 @@ const writebackOwner = "owner-1"
 func seedActiveConnection(ctx context.Context, t *testing.T, pool *pgxpool.Pool) {
 	t.Helper()
 	if err := database.WithWorkspaceTx(ctx, pool, func(tx pgx.Tx) error {
-		_, err := tx.Exec(ctx, `INSERT INTO incumbent_connection (workspace_id, incumbent, region, credential_ref, status)
-			VALUES (current_setting('app.workspace_id')::uuid, 'hubspot', 'eu1', 'ref-writeback', 'active')`)
+		_, err := tx.Exec(ctx, `INSERT INTO incumbent_connection (incumbent, region, credential_ref, status)
+			VALUES ('hubspot', 'eu1', 'ref-writeback', 'active')`)
 		return err
 	}); err != nil {
 		t.Fatalf("seeding active connection: %v", err)

--- a/backend/internal/modules/overlay/reconnect.go
+++ b/backend/internal/modules/overlay/reconnect.go
@@ -30,7 +30,7 @@ import (
 )
 
 // reconnectConnection revives the workspace's revoked incumbent_connection
-// row: the same UNIQUE(workspace_id) row, re-pointed at a freshly sealed
+// row: the same singleton row, re-pointed at a freshly sealed
 // credential and flipped back to active, in ONE transaction with the
 // tombstone clear and activateConnection's audit + event + mode-flip (the
 // write shape a fresh insert needs too, shared rather than repeated here).
@@ -49,8 +49,7 @@ func (s *Service) reconnectConnection(ctx context.Context, in ConnectInput, ref 
 		// it rather than both reviving the same row.
 		if scanErr := tx.QueryRow(ctx, `
 			SELECT id, incumbent, region, credential_ref FROM incumbent_connection
-			WHERE workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid
-			  AND status = 'revoked'
+			WHERE status = 'revoked'
 			FOR UPDATE`).Scan(&id, &previousIncumbent, &previousRegion, &supersededRef); scanErr != nil {
 			return scanErr
 		}
@@ -119,15 +118,14 @@ func (s *Service) deleteSupersededRef(ctx context.Context, ref keyvault.Ref) {
 
 // existingConnectionStatus reports the workspace's incumbent_connection
 // status, if it has a row at all. Connect's pre-flight distinguishes the two
-// states the UNIQUE(workspace_id) row can be in: an active (or errored)
+// states the singleton row can be in: an active (or errored)
 // connection refuses a second connect, while a revoked one — the residue
 // Disconnect leaves so a stray in-flight sweep cannot resurrect a purged row —
 // is what a reconnect revives.
 func (s *Service) existingConnectionStatus(ctx context.Context) (status string, found bool, err error) {
 	err = s.db.Tx(ctx, func(tx pgx.Tx) error {
 		scanErr := tx.QueryRow(ctx, `
-			SELECT status FROM incumbent_connection
-			WHERE workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid`).Scan(&status)
+			SELECT status FROM incumbent_connection`).Scan(&status)
 		if errors.Is(scanErr, pgx.ErrNoRows) {
 			return nil
 		}

--- a/backend/internal/modules/overlay/syncbackoff.go
+++ b/backend/internal/modules/overlay/syncbackoff.go
@@ -100,8 +100,8 @@ func (s *MirrorStore) RecordSweepSuccess(ctx context.Context) error {
 			return err
 		}
 		_, err := tx.Exec(ctx, `
-			INSERT INTO overlay_sync_state (workspace_id, next_sweep_at, consecutive_failures, last_success_at, last_error_class, updated_at)
-			VALUES (NULLIF(current_setting('app.workspace_id',true),'')::uuid, now(), 0, now(), NULL, now())
+			INSERT INTO overlay_sync_state (next_sweep_at, consecutive_failures, last_success_at, last_error_class, updated_at)
+			VALUES (now(), 0, now(), NULL, now())
 			ON CONFLICT ((true)) DO UPDATE SET
 			  next_sweep_at = now(),
 			  consecutive_failures = 0,
@@ -124,8 +124,8 @@ func (s *MirrorStore) RequestSweep(ctx context.Context) error {
 			return err
 		}
 		if _, err := tx.Exec(ctx, `
-			INSERT INTO overlay_sync_state (workspace_id, next_sweep_at, consecutive_failures, last_error_class, updated_at)
-			VALUES (NULLIF(current_setting('app.workspace_id',true),'')::uuid, now(), 0, NULL, now())
+			INSERT INTO overlay_sync_state (next_sweep_at, consecutive_failures, last_error_class, updated_at)
+			VALUES (now(), 0, NULL, now())
 			ON CONFLICT ((true)) DO UPDATE SET
 			  next_sweep_at = now(),
 			  consecutive_failures = 0,
@@ -150,8 +150,8 @@ func (s *MirrorStore) RecordSweepFailure(ctx context.Context, sweepErr error) er
 		}
 		var failures int
 		if err := tx.QueryRow(ctx, `
-			INSERT INTO overlay_sync_state (workspace_id, next_sweep_at, consecutive_failures, last_error_class, last_failure_at, updated_at)
-			VALUES (NULLIF(current_setting('app.workspace_id',true),'')::uuid, now(), 1, $1, now(), now())
+			INSERT INTO overlay_sync_state (next_sweep_at, consecutive_failures, last_error_class, last_failure_at, updated_at)
+			VALUES (now(), 1, $1, now(), now())
 			ON CONFLICT ((true)) DO UPDATE SET
 			  consecutive_failures = overlay_sync_state.consecutive_failures + 1,
 			  last_error_class = EXCLUDED.last_error_class,
@@ -169,8 +169,7 @@ func (s *MirrorStore) RecordSweepFailure(ctx context.Context, sweepErr error) er
 			delay = rateLimitedFloor
 		}
 		if _, err := tx.Exec(ctx, `
-			UPDATE overlay_sync_state SET next_sweep_at = now() + make_interval(secs => $1)
-			WHERE workspace_id = NULLIF(current_setting('app.workspace_id',true),'')::uuid`,
+			UPDATE overlay_sync_state SET next_sweep_at = now() + make_interval(secs => $1)`,
 			delay.Seconds()); err != nil {
 			return fmt.Errorf("overlay: pacing the next sweep after failure: %w", err)
 		}

--- a/backend/internal/modules/overlay/teardown.go
+++ b/backend/internal/modules/overlay/teardown.go
@@ -183,8 +183,7 @@ func revokeConnection(ctx context.Context, tx pgx.Tx) (credentialRef string, err
 		ctx, `
 		SELECT id, incumbent, region, credential_ref
 		FROM incumbent_connection
-		WHERE workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid
-		  AND status = 'active'
+		WHERE status = 'active'
 		FOR UPDATE`,
 	).Scan(&connID, &incumbent, &region, &credentialRef); scanErr != nil {
 		if errors.Is(scanErr, pgx.ErrNoRows) {
@@ -252,8 +251,8 @@ func purgeMirror(ctx context.Context, tx pgx.Tx) error {
 	// the tombstone must exist before the row it would otherwise let a
 	// stray in-flight sweep resurrect is gone, never after.
 	if _, err := tx.Exec(ctx, `
-		INSERT INTO overlay_tombstone (workspace_id, object_class, external_id)
-		SELECT workspace_id, object_class, external_id FROM overlay_mirror
+		INSERT INTO overlay_tombstone (object_class, external_id)
+		SELECT object_class, external_id FROM overlay_mirror
 		ON CONFLICT (object_class, external_id) DO NOTHING`); err != nil {
 		return fmt.Errorf("overlay: tombstoning the mirror before purge: %w", err)
 	}

--- a/backend/internal/modules/overlay/teardown_integration_test.go
+++ b/backend/internal/modules/overlay/teardown_integration_test.go
@@ -116,10 +116,10 @@ func seedConnectedWorkspaceMirrorState(ctx context.Context, t *testing.T, store 
 func assertMirrorFixtureLanded(ctx context.Context, t *testing.T, pool *pgxpool.Pool, ws ids.UUID) {
 	t.Helper()
 	var seededVisibility, seededUserMap, seededCursor, seededWatermark int
-	queryRowWS(ctx, t, pool, `SELECT count(*) FROM mirror_visibility WHERE workspace_id = $1`, []any{ws}, &seededVisibility)
-	queryRowWS(ctx, t, pool, `SELECT count(*) FROM mirror_user_map WHERE workspace_id = $1`, []any{ws}, &seededUserMap)
-	queryRowWS(ctx, t, pool, `SELECT count(*) FROM overlay_backfill_cursor WHERE workspace_id = $1`, []any{ws}, &seededCursor)
-	queryRowWS(ctx, t, pool, `SELECT count(*) FROM overlay_reconcile_watermark WHERE workspace_id = $1`, []any{ws}, &seededWatermark)
+	queryRowWS(ctx, t, pool, `SELECT count(*) FROM mirror_visibility`, nil, &seededVisibility)
+	queryRowWS(ctx, t, pool, `SELECT count(*) FROM mirror_user_map`, nil, &seededUserMap)
+	queryRowWS(ctx, t, pool, `SELECT count(*) FROM overlay_backfill_cursor`, nil, &seededCursor)
+	queryRowWS(ctx, t, pool, `SELECT count(*) FROM overlay_reconcile_watermark`, nil, &seededWatermark)
 	if seededVisibility == 0 || seededUserMap == 0 || seededCursor == 0 || seededWatermark == 0 {
 		t.Fatalf("fixture is broken: seeded mirror_visibility=%d mirror_user_map=%d overlay_backfill_cursor=%d overlay_reconcile_watermark=%d, want all > 0",
 			seededVisibility, seededUserMap, seededCursor, seededWatermark)
@@ -174,7 +174,7 @@ func assertConnectionRowRevokedNotDeleted(ctx context.Context, t *testing.T, poo
 	var status string
 	var revokedAt *time.Time
 	queryRowWS(ctx, t, pool,
-		`SELECT status, revoked_at FROM incumbent_connection WHERE workspace_id = $1`, []any{ws}, &status, &revokedAt)
+		`SELECT status, revoked_at FROM incumbent_connection`, nil, &status, &revokedAt)
 	if status != "revoked" || revokedAt == nil {
 		t.Errorf("connection = (status=%s, revoked_at=%v), want (revoked, non-nil)", status, revokedAt)
 	}
@@ -199,7 +199,7 @@ func assertCredentialSecretDeleted(ctx context.Context, t *testing.T, pool *pgxp
 	t.Helper()
 	var credentialRef string
 	queryRowWS(ctx, t, pool,
-		`SELECT credential_ref FROM incumbent_connection WHERE workspace_id = $1`, []any{ws}, &credentialRef)
+		`SELECT credential_ref FROM incumbent_connection`, nil, &credentialRef)
 	if _, err := vault.Get(ctx, ids.From[ids.WorkspaceKind](ws), keyvault.Ref(credentialRef)); !errors.Is(err, keyvault.ErrNotFound) {
 		t.Errorf("vault.Get after Disconnect = %v, want keyvault.ErrNotFound (the secret must be deleted)", err)
 	}
@@ -235,10 +235,10 @@ func assertEveryIncumbentDerivedTablePurged(ctx context.Context, t *testing.T, p
 		}
 		var count int
 		queryRowWS(ctx, t, pool,
-			fmt.Sprintf(`SELECT count(*) FROM %s WHERE workspace_id = $1`, pgx.Identifier{table}.Sanitize()),
-			[]any{ws}, &count)
+			fmt.Sprintf(`SELECT count(*) FROM %s`, pgx.Identifier{table}.Sanitize()),
+			nil, &count)
 		if count != 0 {
-			t.Errorf("%s holds %d row(s) for the workspace after teardown, want 0 — every incumbent-derived table purges on disconnect", table, count)
+			t.Errorf("%s holds %d row(s) after teardown, want 0 — every incumbent-derived table purges on disconnect", table, count)
 		}
 	}
 }
@@ -249,8 +249,8 @@ func assertTombstoneWrittenForThePurgedRow(ctx context.Context, t *testing.T, po
 	t.Helper()
 	var tombstoneCount int
 	queryRowWS(ctx, t, pool,
-		`SELECT count(*) FROM overlay_tombstone WHERE workspace_id = $1 AND object_class = $2 AND external_id = $3`,
-		[]any{ws, objectClass, externalID}, &tombstoneCount)
+		`SELECT count(*) FROM overlay_tombstone WHERE object_class = $1 AND external_id = $2`,
+		[]any{objectClass, externalID}, &tombstoneCount)
 	if tombstoneCount != 1 {
 		t.Errorf("tombstone count = %d, want exactly 1 for the purged mirror row", tombstoneCount)
 	}
@@ -356,8 +356,8 @@ func TestFencedSyncWritesAbortOnceTheConnectionIsRevoked(t *testing.T) {
 			return err
 		}
 		_, execErr := tx.Exec(ctx, `
-			INSERT INTO mirror_user_map (workspace_id, app_user_id, incumbent, incumbent_user_id, match_source)
-			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, $2, $3, 'email')`,
+			INSERT INTO mirror_user_map (app_user_id, incumbent, incumbent_user_id, match_source)
+			VALUES ($1, $2, $3, 'email')`,
 			fixtureUser, "hubspot", "owner-revalidate")
 		return execErr
 	}); err != nil {
@@ -431,8 +431,8 @@ func TestFencedSyncWritesAbortOnceTheConnectionIsRevoked(t *testing.T) {
 	} {
 		var n int
 		queryRowWS(ctx, t, pool,
-			fmt.Sprintf(`SELECT count(*) FROM %s WHERE workspace_id = $1`, pgx.Identifier{tbl}.Sanitize()),
-			[]any{ws}, &n)
+			fmt.Sprintf(`SELECT count(*) FROM %s`, pgx.Identifier{tbl}.Sanitize()),
+			nil, &n)
 		if n != 0 {
 			t.Errorf("%s holds %d row(s) after fenced writes on a disconnected workspace, want 0 — the fence must resurrect nothing", tbl, n)
 		}
@@ -443,7 +443,7 @@ func TestFencedSyncWritesAbortOnceTheConnectionIsRevoked(t *testing.T) {
 	// RevalidateEmailMappings writes above must add NOTHING to it and must
 	// not delete it either, so the count stays exactly 1.
 	var userMapRows int
-	queryRowWS(ctx, t, pool, `SELECT count(*) FROM mirror_user_map WHERE workspace_id = $1`, []any{ws}, &userMapRows)
+	queryRowWS(ctx, t, pool, `SELECT count(*) FROM mirror_user_map`, nil, &userMapRows)
 	if userMapRows != 1 {
 		t.Errorf("mirror_user_map holds %d row(s) after fenced writes on a disconnected workspace, want exactly 1 (the untouched post-teardown fixture) — the fence must neither add nor remove rows", userMapRows)
 	}
@@ -517,7 +517,7 @@ func TestDisconnectCommitsEvenWhenVaultDeleteFails(t *testing.T) {
 	}
 	var credentialRef string
 	queryRowWS(ctx, t, pool,
-		`SELECT credential_ref FROM incumbent_connection WHERE workspace_id = $1`, []any{ws}, &credentialRef)
+		`SELECT credential_ref FROM incumbent_connection`, nil, &credentialRef)
 
 	// Disconnect must SUCCEED despite the vault delete failing.
 	if err := svc.Disconnect(ctx); err != nil {
@@ -537,7 +537,7 @@ func TestDisconnectCommitsEvenWhenVaultDeleteFails(t *testing.T) {
 	// The authoritative teardown committed: connection revoked, mode native.
 	var status, sorMode string
 	queryRowWS(ctx, t, pool,
-		`SELECT status FROM incumbent_connection WHERE workspace_id = $1`, []any{ws}, &status)
+		`SELECT status FROM incumbent_connection`, nil, &status)
 	queryRowWS(ctx, t, pool,
 		`SELECT x_sor_mode FROM workspace WHERE id = $1`, []any{ws}, &sorMode)
 	if status != "revoked" || sorMode != "native" {
@@ -562,21 +562,30 @@ func TestDisconnectWithNoActiveConnectionAnswersNotFound(t *testing.T) {
 	}
 }
 
-// overlayWorkspaceTables derives, from the live catalog, every
-// workspace-scoped table the overlay migrations own — the overlay_% and
-// mirror_% clusters plus incumbent_connection, the same name set
-// backend/tableownership_test.go pins to internal/modules/overlay — so
-// the teardown purge assertion's coverage grows with the schema instead
-// of trailing it as a hand-kept list.
+// overlayWorkspaceTables derives, from the live catalog, every table the
+// overlay migrations own — the overlay_% and mirror_% clusters plus
+// incumbent_connection, the same name set backend/tableownership_test.go pins
+// to internal/modules/overlay — so the teardown purge assertion's coverage
+// grows with the schema instead of trailing it as a hand-kept list.
+//
+// The NAME is the derivation. It used to be the name AND a workspace_id column,
+// which was the same set only for as long as every one of these tables carried
+// one; phase D (ADR-0091 §8) removed the column and would have left this
+// returning nothing — an assertion that iterates an empty list passes without
+// checking anything, which is exactly how a purge stops being proved. Deriving
+// from pg_class also means a table added to the cluster is covered the day it
+// exists, and a view or sequence sharing the prefix is not.
 func overlayWorkspaceTables(ctx context.Context, t *testing.T, pool *pgxpool.Pool) []string {
 	t.Helper()
 	var tables []string
 	err := database.WithWorkspaceTx(ctx, pool, func(tx pgx.Tx) error {
 		rows, err := tx.Query(ctx, `
-			SELECT table_name FROM information_schema.columns
-			WHERE table_schema = 'public' AND column_name = 'workspace_id'
-			  AND (table_name LIKE 'overlay\_%' OR table_name LIKE 'mirror\_%' OR table_name = 'incumbent_connection')
-			ORDER BY table_name`)
+			SELECT c.relname FROM pg_class c
+			JOIN pg_namespace n ON n.oid = c.relnamespace
+			WHERE n.nspname = 'public' AND c.relkind = 'r'
+			  AND (c.relname LIKE 'overlay\_%' OR c.relname LIKE 'mirror\_%'
+			       OR c.relname = 'incumbent_connection')
+			ORDER BY c.relname`)
 		if err != nil {
 			return err
 		}
@@ -584,7 +593,10 @@ func overlayWorkspaceTables(ctx context.Context, t *testing.T, pool *pgxpool.Poo
 		return err
 	})
 	if err != nil {
-		t.Fatalf("deriving the overlay-owned workspace-scoped tables from the catalog: %v", err)
+		t.Fatalf("deriving the overlay-owned tables from the catalog: %v", err)
+	}
+	if len(tables) == 0 {
+		t.Fatal("the catalog names no overlay-owned table — the purge assertion below would pass by iterating nothing")
 	}
 	return tables
 }
@@ -689,7 +701,7 @@ func TestDisconnectResetsSyncCheckpointsSoAFreshBackfillRelistsFromTheStart(t *t
 	// contract; Connect today refuses a workspace with any connection
 	// row, so no such flow exists yet to exercise).
 	var relanded int
-	queryRowWS(ctx, t, pool, `SELECT count(*) FROM overlay_mirror WHERE workspace_id = $1`, []any{ws}, &relanded)
+	queryRowWS(ctx, t, pool, `SELECT count(*) FROM overlay_mirror`, nil, &relanded)
 	if relanded != 0 {
 		t.Errorf("the post-disconnect backfill re-landed %d purged row(s) — the teardown tombstone guard must hold until a reconnect flow clears it", relanded)
 	}
@@ -724,7 +736,7 @@ func TestDisconnectPurgesTheAutomapBlocks(t *testing.T) {
 	}
 
 	var blocked int
-	queryRowWS(ctx, t, pool, `SELECT count(*) FROM mirror_user_automap_block WHERE workspace_id = $1`, []any{ws}, &blocked)
+	queryRowWS(ctx, t, pool, `SELECT count(*) FROM mirror_user_automap_block`, nil, &blocked)
 	if blocked != 0 {
 		t.Fatalf("disconnect must purge the auto-map blocks, %d remain", blocked)
 	}

--- a/backend/internal/modules/overlay/testsupport_integration.go
+++ b/backend/internal/modules/overlay/testsupport_integration.go
@@ -305,7 +305,7 @@ func archiveUser(t *testing.T, user ids.UserID) {
 // the cross-tenant target the composite-FK test aims at. It has to be a user
 // that genuinely exists somewhere else: a merely invented uuid would be
 // rejected by any FK at all, proving nothing about the tenant-local
-// (workspace_id, app_user_id) pair being the thing that rejects it.
+// app_user_id being the thing that rejects it.
 func seedUserInOtherWorkspace(t *testing.T, email string) ids.UserID {
 	t.Helper()
 	conn := testOwnerConn(t)
@@ -339,8 +339,8 @@ func seedAutoMapBlock(ctx context.Context, t *testing.T, pool *pgxpool.Pool, use
 	}
 	if err := database.WithWorkspaceTx(ctx, pool, func(tx pgx.Tx) error {
 		_, err := tx.Exec(ctx, `
-			INSERT INTO mirror_user_automap_block (workspace_id, app_user_id, incumbent, blocked_by)
-			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, $2, $3)`,
+			INSERT INTO mirror_user_automap_block (app_user_id, incumbent, blocked_by)
+			VALUES ($1, $2, $3)`,
 			user, incumbent, actor.UserID)
 		return err
 	}); err != nil {

--- a/backend/internal/modules/overlay/usermapadmin.go
+++ b/backend/internal/modules/overlay/usermapadmin.go
@@ -289,8 +289,8 @@ func (s *MirrorStore) SetManualUserMap(ctx context.Context, appUser ids.UserID, 
 }
 
 const insertAutomapBlockSQL = `
-INSERT INTO mirror_user_automap_block (workspace_id, app_user_id, incumbent, blocked_by)
-VALUES (NULLIF(current_setting('app.workspace_id',true),'')::uuid, $1, $2, $3)
+INSERT INTO mirror_user_automap_block (app_user_id, incumbent, blocked_by)
+VALUES ($1, $2, $3)
 ON CONFLICT (app_user_id, incumbent) DO NOTHING`
 
 const deleteUserMapSQL = `

--- a/backend/internal/modules/overlay/visibility.go
+++ b/backend/internal/modules/overlay/visibility.go
@@ -37,8 +37,7 @@ type OwnerEmailResolver interface {
 // theirs.
 func visibilityJoin(mirrorUserID ids.UUID) (clause string, args []any) {
 	return `JOIN mirror_visibility v
-       ON v.workspace_id = m.workspace_id
-      AND v.object_class = m.object_class
+       ON v.object_class = m.object_class
       AND v.external_id = m.external_id
       AND v.mirror_user_id = $1
       AND v.can_see`, []any{mirrorUserID}
@@ -79,8 +78,8 @@ WHERE object_class = $1 AND external_id = $2`
 // (many app users → one incumbent user) is allowed by design.md §4.6 rule
 // so every mapped app user, not just one, is projected visible.
 const grantVisibilitySQL = `
-INSERT INTO mirror_visibility (workspace_id, incumbent, mirror_user_id, object_class, external_id, can_see, snapshot_at)
-SELECT NULLIF(current_setting('app.workspace_id',true),'')::uuid, m.incumbent, m.app_user_id, $2, $3, true, now()
+INSERT INTO mirror_visibility (incumbent, mirror_user_id, object_class, external_id, can_see, snapshot_at)
+SELECT m.incumbent, m.app_user_id, $2, $3, true, now()
 FROM mirror_user_map m
 WHERE m.incumbent_user_id = $1
 ON CONFLICT (incumbent, mirror_user_id, object_class, external_id)
@@ -263,8 +262,8 @@ WITH cleared AS (
   DELETE FROM mirror_user_automap_block
    WHERE app_user_id = $1 AND incumbent = $2 AND $4 = 'manual'
 )
-INSERT INTO mirror_user_map (workspace_id, app_user_id, incumbent, incumbent_user_id, match_source)
-SELECT NULLIF(current_setting('app.workspace_id',true),'')::uuid, $1, $2, $3, $4
+INSERT INTO mirror_user_map (app_user_id, incumbent, incumbent_user_id, match_source)
+SELECT $1, $2, $3, $4
  WHERE $4 = 'manual'
     OR NOT EXISTS (SELECT 1 FROM mirror_user_automap_block b
                     WHERE b.app_user_id = $1 AND b.incumbent = $2)

--- a/backend/internal/modules/overlay/visibility_integration_test.go
+++ b/backend/internal/modules/overlay/visibility_integration_test.go
@@ -466,8 +466,8 @@ func TestRevalidateEmailMappingsPeriodicSweepCatchesEmailChangeAlone(t *testing.
 func seedStaleEmailMap(ctx context.Context, pool *pgxpool.Pool, appUser ids.UserID, incumbentUserID string) error {
 	return database.WithWorkspaceTx(ctx, pool, func(tx pgx.Tx) error {
 		_, err := tx.Exec(ctx, `
-			INSERT INTO mirror_user_map (workspace_id, app_user_id, incumbent, incumbent_user_id, match_source)
-			VALUES (NULLIF(current_setting('app.workspace_id',true),'')::uuid, $1, 'hubspot', $2, 'email')`,
+			INSERT INTO mirror_user_map (app_user_id, incumbent, incumbent_user_id, match_source)
+			VALUES ($1, 'hubspot', $2, 'email')`,
 			appUser, incumbentUserID)
 		return err
 	})

--- a/backend/internal/modules/overlay/writeledger.go
+++ b/backend/internal/modules/overlay/writeledger.go
@@ -99,8 +99,8 @@ func (l *WriteLedger) OpenEntries(ctx context.Context, objectClass, externalID s
 		for prop, val := range props {
 			if _, err := tx.Exec(ctx, `
 				INSERT INTO overlay_write_ledger
-					(workspace_id, object_class, external_id, property, value_hash, value_canonical)
-				VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, $2, $3, $4, $5)
+					(object_class, external_id, property, value_hash, value_canonical)
+				VALUES ($1, $2, $3, $4, $5)
 				ON CONFLICT (object_class, external_id, property, value_hash)
 				DO UPDATE SET value_canonical = EXCLUDED.value_canonical, opened_at = now()`,
 				objectClass, externalID, prop, l.hash(val), val,
@@ -190,8 +190,8 @@ func (l *WriteLedger) PruneExpired(ctx context.Context) (int64, error) {
 // workspace, upserted so a re-detection refreshes the reason/time).
 func haltMirrorTx(ctx context.Context, tx pgx.Tx, reason string) error {
 	if _, err := tx.Exec(ctx, `
-		INSERT INTO overlay_mirror_halt (workspace_id, reason)
-		VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1)
+		INSERT INTO overlay_mirror_halt (reason)
+		VALUES ($1)
 		ON CONFLICT ((true)) DO UPDATE SET reason = EXCLUDED.reason, detected_at = now()`,
 		reason); err != nil {
 		return fmt.Errorf("overlay: recording the mirror halt: %w", err)

--- a/backend/migrations/custom/20260817100000_overlay_drop_workspace.down.sql
+++ b/backend/migrations/custom/20260817100000_overlay_drop_workspace.down.sql
@@ -1,0 +1,74 @@
+-- Reverse of 20260817100000: the twelve overlay tables carry the tenant column again.
+--
+-- The backfill reads the LIVE workspace — archived_at IS NULL, oldest first.
+-- 0217 refuses more than one live tenant and 0272 refuses to proceed while an
+-- archived one still holds records, so there was exactly one workspace these
+-- rows could have belonged to when the forward half ran. Ordering by created_at
+-- alone would hand every restored row to whichever workspace was created first,
+-- archived or not.
+--
+-- If no live workspace exists and a table is not empty, SET NOT NULL fails and
+-- the rollback stops — the honest outcome, since no value this migration could
+-- write would be true. A rollback on an empty database (the reverse-and-reapply
+-- lane) has nothing to attribute and passes.
+ALTER TABLE incumbent_connection ADD COLUMN workspace_id uuid;
+ALTER TABLE overlay_sync_state ADD COLUMN workspace_id uuid;
+ALTER TABLE overlay_mirror_halt ADD COLUMN workspace_id uuid;
+ALTER TABLE overlay_mirror ADD COLUMN workspace_id uuid;
+ALTER TABLE overlay_association ADD COLUMN workspace_id uuid;
+ALTER TABLE overlay_tombstone ADD COLUMN workspace_id uuid;
+ALTER TABLE overlay_write_ledger ADD COLUMN workspace_id uuid;
+ALTER TABLE overlay_backfill_cursor ADD COLUMN workspace_id uuid;
+ALTER TABLE overlay_reconcile_watermark ADD COLUMN workspace_id uuid;
+ALTER TABLE mirror_user_map ADD COLUMN workspace_id uuid;
+ALTER TABLE mirror_user_automap_block ADD COLUMN workspace_id uuid;
+ALTER TABLE mirror_visibility ADD COLUMN workspace_id uuid;
+
+DO $$
+DECLARE
+  live uuid := (SELECT id FROM workspace WHERE archived_at IS NULL ORDER BY created_at LIMIT 1);
+  t    text;
+BEGIN
+  FOREACH t IN ARRAY ARRAY[
+    'incumbent_connection', 'overlay_sync_state', 'overlay_mirror_halt',
+    'overlay_mirror', 'overlay_association', 'overlay_tombstone',
+    'overlay_write_ledger', 'overlay_backfill_cursor', 'overlay_reconcile_watermark',
+    'mirror_user_map', 'mirror_user_automap_block', 'mirror_visibility'
+  ] LOOP
+    EXECUTE format('UPDATE %I SET workspace_id = $1 WHERE workspace_id IS NULL', t) USING live;
+    EXECUTE format('ALTER TABLE %I ALTER COLUMN workspace_id SET NOT NULL', t);
+  END LOOP;
+END $$;
+
+ALTER TABLE incumbent_connection ADD CONSTRAINT incumbent_connection_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE overlay_sync_state ADD CONSTRAINT overlay_sync_state_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE overlay_mirror_halt ADD CONSTRAINT overlay_mirror_halt_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE overlay_mirror ADD CONSTRAINT overlay_mirror_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE overlay_association ADD CONSTRAINT overlay_association_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE overlay_tombstone ADD CONSTRAINT overlay_tombstone_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE overlay_write_ledger ADD CONSTRAINT overlay_write_ledger_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE overlay_backfill_cursor ADD CONSTRAINT overlay_backfill_cursor_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE overlay_reconcile_watermark ADD CONSTRAINT overlay_reconcile_watermark_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE mirror_user_map ADD CONSTRAINT mirror_user_map_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE mirror_user_automap_block ADD CONSTRAINT mirror_user_automap_block_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE mirror_visibility ADD CONSTRAINT mirror_visibility_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+
+DROP INDEX idx_mirror_user_map;
+DROP INDEX idx_mirror_visibility_record;
+DROP INDEX idx_overlay_association_to;
+
+CREATE INDEX idx_mirror_user_map ON mirror_user_map (workspace_id, incumbent, incumbent_user_id);
+CREATE INDEX idx_mirror_visibility_record ON mirror_visibility (workspace_id, object_class, external_id);
+CREATE INDEX idx_overlay_association_to ON overlay_association (workspace_id, to_type, to_id);

--- a/backend/migrations/custom/20260817100000_overlay_drop_workspace.up.sql
+++ b/backend/migrations/custom/20260817100000_overlay_drop_workspace.up.sql
@@ -1,0 +1,62 @@
+-- 20260817100000: the incumbent overlay drops the tenant column (ADR-0091 §8 phase D).
+--
+-- Twelve tables, and the module they belong to is the one where "one row per
+-- tenant" was most literally the design: an installation holds ONE incumbent
+-- connection, ONE sync state, ONE halt. Those three were keyed on nothing but
+-- the workspace, so phase B had nothing narrower to collapse them onto and gave
+-- each a `UNIQUE ((true))` singleton index instead — the same "there is exactly
+-- one row" the tenant key used to state, said without naming a tenant. Those
+-- indexes already stand on their own, so this migration does not touch them.
+--
+-- The rest divide into the mirror itself (overlay_mirror, overlay_association,
+-- overlay_tombstone), the people mapping between the two systems
+-- (mirror_user_map, mirror_user_automap_block, mirror_visibility), and the
+-- machinery that moves them (overlay_write_ledger, overlay_backfill_cursor,
+-- overlay_reconcile_watermark).
+--
+-- Every identity key here already names something narrower than the tenant: an
+-- (object_class, external_id) in the incumbent, an (app_user_id, incumbent)
+-- pair, an association's own five-part shape.
+
+ALTER TABLE incumbent_connection DROP CONSTRAINT incumbent_connection_workspace_id_fkey;
+ALTER TABLE incumbent_connection DROP COLUMN workspace_id;
+
+ALTER TABLE overlay_sync_state DROP CONSTRAINT overlay_sync_state_workspace_id_fkey;
+ALTER TABLE overlay_sync_state DROP COLUMN workspace_id;
+
+ALTER TABLE overlay_mirror_halt DROP CONSTRAINT overlay_mirror_halt_workspace_id_fkey;
+ALTER TABLE overlay_mirror_halt DROP COLUMN workspace_id;
+
+ALTER TABLE overlay_mirror DROP CONSTRAINT overlay_mirror_workspace_id_fkey;
+ALTER TABLE overlay_mirror DROP COLUMN workspace_id;
+
+ALTER TABLE overlay_association DROP CONSTRAINT overlay_association_workspace_id_fkey;
+ALTER TABLE overlay_association DROP COLUMN workspace_id;
+
+ALTER TABLE overlay_tombstone DROP CONSTRAINT overlay_tombstone_workspace_id_fkey;
+ALTER TABLE overlay_tombstone DROP COLUMN workspace_id;
+
+ALTER TABLE overlay_write_ledger DROP CONSTRAINT overlay_write_ledger_workspace_id_fkey;
+ALTER TABLE overlay_write_ledger DROP COLUMN workspace_id;
+
+ALTER TABLE overlay_backfill_cursor DROP CONSTRAINT overlay_backfill_cursor_workspace_id_fkey;
+ALTER TABLE overlay_backfill_cursor DROP COLUMN workspace_id;
+
+ALTER TABLE overlay_reconcile_watermark DROP CONSTRAINT overlay_reconcile_watermark_workspace_id_fkey;
+ALTER TABLE overlay_reconcile_watermark DROP COLUMN workspace_id;
+
+ALTER TABLE mirror_user_map DROP CONSTRAINT mirror_user_map_workspace_id_fkey;
+ALTER TABLE mirror_user_map DROP COLUMN workspace_id;
+
+ALTER TABLE mirror_user_automap_block DROP CONSTRAINT mirror_user_automap_block_workspace_id_fkey;
+ALTER TABLE mirror_user_automap_block DROP COLUMN workspace_id;
+
+ALTER TABLE mirror_visibility DROP CONSTRAINT mirror_visibility_workspace_id_fkey;
+ALTER TABLE mirror_visibility DROP COLUMN workspace_id;
+
+-- The three indexes that led with the column. DROP COLUMN removed each outright,
+-- so they are recreated on what actually selects rows: an incumbent user, a
+-- mirrored record, an association's far end.
+CREATE INDEX idx_mirror_user_map ON mirror_user_map (incumbent, incumbent_user_id);
+CREATE INDEX idx_mirror_visibility_record ON mirror_visibility (object_class, external_id);
+CREATE INDEX idx_overlay_association_to ON overlay_association (to_type, to_id);


### PR DESCRIPTION
Twelve tables, in the module where "one row per tenant" was most literally the design: an installation holds ONE incumbent connection, ONE sync state, ONE halt. Those three were keyed on nothing but the workspace, so phase B gave each a `UNIQUE ((true))` singleton index — the same "there is exactly one row", said without naming a tenant. The rest already key on something narrower: an `(object_class, external_id)` in the incumbent, an `(app_user_id, incumbent)` pair, an association's own five-part shape.

Overlay is fork-owned, so the migration lands in `migrations/custom/` (ADR-0017, ADR-0054 §7).

## A credential collector that had already gone quiet on main

`collectWorkspaceSecretRefs` reads every sealed-credential handle **before** the sweep deletes the rows naming them. `vault_secret` is deliberately never swept, so a ref the collector misses is credential material that outlives the wipe — resident and unreachable forever.

Its table list required a `credential_ref` column **and** a `workspace_id` column. The capture slice (#1491) removed the second from `capture_connection` and `channel_connection`, so both silently left the collection and nothing failed — the derivation simply found fewer tables. It derives on `credential_ref` alone now, which is the only column that answers the question being asked.

That is the **second** derivation to carry this defect; `resetTargetTables` was the first. Neither may ask whether a table has a `workspace_id`, because the answer is becoming "no" everywhere and the sweep above it goes quiet rather than red.

## Two gates that would have gone the same way

`overlayWorkspaceTables` derived the teardown-purge assertion's table list from `information_schema` on `column_name = 'workspace_id'`. After this migration it returns nothing, and a loop over an empty list passes without checking anything. It derives from `pg_class` on the name now — which is what "overlay-owned" always meant — and fails loudly if the catalog names none.

`TestResetLeavesAnotherWorkspacesSealedCredential` seeded a co-tenant workspace with its own `incumbent_connection` to prove a reset could not reach it. The singleton index forbids a second row outright, and the positive case is held by `TestResetPurgesTheSealedCredentialsItsSweepOrphans` beside it. Retired.

## One statement worth a second read

`UnsealFlipSnapshot`'s CTE used `workspace_id` as the key joining the pre-update snapshot to the rows it cleared. With a singleton table there is no key to join on, so `cleared` now updates `FROM prior` with no join predicate — a cross product against a relation holding the one row or none, which says "clear exactly what prior saw" without naming a column to say it with.

## Verification

- Custom lane applied to an empty database; the down restores all twelve columns with their foreign keys and the three wide indexes; reverse-and-reapply passes.
- `make check-backend` green; `make test-integration` OK, 0 skips, 41 packages.

Phase D: 85 → 73 tables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drops the `workspace_id` column from twelve overlay tables and updates reads, fences, and migrations to rely on singleton rows and narrower keys. This removes brittle tenant predicates and fixes a silent data‑reset gap that could leave sealed credentials resident after a reset.

- Schema: `incumbent_connection`, `overlay_sync_state`, `overlay_mirror_halt`, `overlay_mirror`, `overlay_association`, `overlay_tombstone`, `overlay_write_ledger`, `overlay_backfill_cursor`, `overlay_reconcile_watermark`, `mirror_user_map`, `mirror_user_automap_block`, and `mirror_visibility` drop `workspace_id` and FKs. Recreate three indexes on actual identity keys. The `.down.sql` restores columns, FKs, and wide indexes.
- Data reset: `collectWorkspaceSecretRefs` in `backend/internal/compose/datasweep.go` now derives tables by `credential_ref` only and collects before sweep, preventing orphaned vault secrets.
- Guards and queries: `backend/internal/modules/overlay` drops workspace predicates and relies on the singleton `incumbent_connection` and primary keys. `overlayWorkspaceTables` in `teardown_integration_test.go` derives table names from `pg_class` and fails if none. `UnsealFlipSnapshot` clears via a cross join suited to the singleton sync state.

**Rollout/Migration**

- Apply `migrations/custom/20260817100000_overlay_drop_workspace.up.sql` on fork-owned overlays (`ADR-0091 §8`). Use the matching `.down.sql` to revert.
- Required action: remove any ad‑hoc `workspace_id` filters from overlay table queries in ops scripts. No API changes; tests in `backend/internal/compose` and `backend/internal/modules/overlay` reflect the new predicates.

<sup>Written for commit 52af44fc861c16b46fc561e383a57693da3eb976. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1510?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

