### PR TITLE
feat(ops): purging tenant data is stated by the deployment, never inferred

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -173,10 +173,14 @@ MARGINCE_ADMIN_PASSWORD=
 # ---- Non-production only ---------------------------------------------------
 # Source: backend/internal/shared/runtimeenv
 
-# [optional] Leave unset in production. dev | staging | test enable
-# POST /v1/admin/reset-data, which purges the installation's tenant data to its
-# first-boot state — setting this removes a protection rather than adding a
-# feature. Fail-closed: any other value means production.
+# [optional] Leave unset in production. `dev` or `test` additionally honour the
+# non-production license authorities, which is how a developer runs on a test
+# license; that is ALL this selects. Fail-closed: any other value, `staging`
+# included, means production.
+#
+# It does NOT enable POST /v1/admin/reset-data. Purging an installation's tenant
+# data is armed by operations.allow_data_reset in margince.yaml, so the
+# capability is stated by the deployment rather than inferred from its label.
 MARGINCE_ENV=
 
 # [optional] Caps the initial overlay mirror backfill at N records per object

--- a/.env.template
+++ b/.env.template
@@ -174,9 +174,10 @@ MARGINCE_ADMIN_PASSWORD=
 # Source: backend/internal/shared/runtimeenv
 
 # [optional] Leave unset in production. `dev` or `test` additionally honour the
-# non-production license authorities, which is how a developer runs on a test
-# license; that is ALL this selects. Fail-closed: any other value, `staging`
-# included, means production.
+# non-production license authorities — how a developer runs on a test license —
+# and permit running with no license at all, which a production role refuses.
+# Both are licensing decisions, and they are all this selects. Fail-closed: any
+# other value, `staging` included, means production.
 #
 # It does NOT enable POST /v1/admin/reset-data. Purging an installation's tenant
 # data is armed by operations.allow_data_reset in margince.yaml, so the

--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -19544,8 +19544,20 @@ components:
         non_production:
           type: boolean
           description: >
-            True when the installation runs a non-production posture
-            (MARGINCE_ENV). Gates the client-side "Reset data" action.
+            True when the installation runs a non-production posture (MARGINCE_ENV=dev|test).
+            DEPRECATED as the gate for the "Reset data" action — read `data_reset_available`
+            instead. A deployment being non-production is not consent to purge its tenant
+            data, and inferring one from the other is why a `staging` installation full of
+            real internal users could be wiped through the API.
+          deprecated: true
+        data_reset_available:
+          type: boolean
+          description: >
+            True when this installation armed `operations.allow_data_reset` in its deployment
+            file. It is the SAME value `POST /admin/reset-data` gates on, so a client never
+            renders an action for a route that would answer 404. Absent or false means the
+            capability does not exist here — the compiled default in every posture, dev
+            included.
         admin_password_link:
           type: boolean
           description: >

--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -414,14 +414,15 @@ paths:
       operationId: resetData
       security: [ { cookieAuth: [] } ]   # human session only — rejects agent bearer/Passport
       x-agent-access: human-only
-      summary: Reset a non-production installation to its first-boot state.
+      summary: Reset an installation that armed the capability to its first-boot state.
       description: >
-        Non-production only. Wipes workspace domain + seeded-config data back to the
-        bootstrapped state, preserving the organization and users so login still works,
-        then re-seeds module defaults. Also clears the job queue, the event bus, the
+        Served only where the deployment set `operations.allow_data_reset`; the compiled
+        default is false in every posture. Wipes workspace domain + seeded-config data back
+        to the bootstrapped state, preserving the organization and users so login still
+        works, then re-seeds module defaults. Also clears the job queue, the event bus, the
         Redis counters and the object bytes — not only table rows. Requires the
-        organization name as a typed confirmation. In production this endpoint does
-        not exist (404).
+        organization name as a typed confirmation. `GET /me` reports the same value as
+        `data_reset_available`, so a client never offers what this would refuse.
       requestBody:
         required: true
         content:
@@ -480,9 +481,10 @@ paths:
               schema: { $ref: '#/components/schemas/Problem' }
         '404':
           description: >
-            The endpoint is unavailable in this environment — production, or an
-            unset/unknown MARGINCE_ENV. It is served only under a non-production
-            posture; the body is the standard problem document.
+            This installation did not arm `operations.allow_data_reset`, so the operation
+            does not exist here. Checked before authentication, so it is a 404 rather than
+            a 403 for every caller — the answer discloses nothing about who asked. The body
+            is the standard problem document.
           content:
             application/problem+json:
               schema: { $ref: '#/components/schemas/Problem' }
@@ -19539,7 +19541,7 @@ components:
           type: string
           description: >
             The installation's organization name (the installation.name setting). Shown as the
-            typed-confirmation target of the non-production "Reset data" action —
+            typed-confirmation target of the "Reset data" action —
             the exact string that endpoint validates.
         non_production:
           type: boolean

--- a/backend/cmd/api/boot.go
+++ b/backend/cmd/api/boot.go
@@ -103,6 +103,11 @@ func declaredSurfaceOptions(cfg apiConfig, deployCfg deployconfig.Config, pool, 
 	// itself — a different question, and no longer a destructive one.
 	env := runtimeenv.Parse(config.FromOS(runtimeenv.EnvVar))
 	allowDataReset := deployCfg.Operations.AllowDataReset
+	// Said out loud at boot because each role reads its own --config: an api
+	// armed beside a worker that was not given the file purges the workspace and
+	// leaves that worker's caches resident until it restarts. A line in each log
+	// makes the disagreement visible instead of silent.
+	logger.Info("data reset", "armed", allowDataReset)
 	opts := []compose.Option{
 		compose.WithDataReset(schemaPool, deployCfg.Seeds, allowDataReset),
 		// The same seeds reach the ADR-0105 claim route, so an installation
@@ -117,10 +122,9 @@ func declaredSurfaceOptions(cfg apiConfig, deployCfg deployconfig.Config, pool, 
 		return nil, nil, err
 	}
 	opts = append(opts, reset.opts...)
-	// /me carries both: the posture, which is what non_production has always
-	// meant, and the reset switch, so a client never renders an action for an
-	// endpoint that would answer 404.
-	opts = append(opts, compose.WithNonProduction(env, allowDataReset))
+	// /me carries both facts, from two options, because they are two facts: the
+	// deployment posture, and whether the reset exists here at all.
+	opts = append(opts, compose.WithNonProduction(env), compose.WithDataResetAvailable(allowDataReset))
 	// Gate 1: the connector's whole route group — /mcp, the authorization
 	// server and both discovery documents — exists only when the deployment
 	// declared it. The boot check in bindInstallation already proved the

--- a/backend/cmd/api/boot.go
+++ b/backend/cmd/api/boot.go
@@ -96,12 +96,15 @@ func declaredSurfaceOptions(cfg apiConfig, deployCfg deployconfig.Config, pool, 
 	// closed 404 default. schemaPool may be nil (no --schema-dsn configured);
 	// the reset still succeeds, only the cf_* column finalize is skipped.
 	//
-	// ONE posture read serves the endpoint, the machinery behind it and /me's
-	// non_production field, so the three can never disagree about which one is
-	// live.
-	env := runtimeenv.Parse(config.FromOS("MARGINCE_ENV"))
+	// ONE read of the switch serves the endpoint, the machinery behind it and
+	// the /me field that offers the action, so the three can never disagree
+	// about whether the reset is live. It is stated by the deployment rather
+	// than inferred from MARGINCE_ENV, which is still read here for the posture
+	// itself — a different question, and no longer a destructive one.
+	env := runtimeenv.Parse(config.FromOS(runtimeenv.EnvVar))
+	allowDataReset := deployCfg.Operations.AllowDataReset
 	opts := []compose.Option{
-		compose.WithDataReset(schemaPool, deployCfg.Seeds, env),
+		compose.WithDataReset(schemaPool, deployCfg.Seeds, allowDataReset),
 		// The same seeds reach the ADR-0105 claim route, so an installation
 		// provisioned by claim lays down the module defaults this file asks
 		// for rather than the built-in ones. Always applied, including the
@@ -109,15 +112,15 @@ func declaredSurfaceOptions(cfg apiConfig, deployCfg deployconfig.Config, pool, 
 		// on both provisioning paths, which is the behaviour to preserve.
 		compose.WithBootstrapSeeds(deployCfg.Seeds),
 	}
-	reset, err := newResetLane(env, pool, rdb, logger)
+	reset, err := newResetLane(allowDataReset, pool, rdb, logger)
 	if err != nil {
 		return nil, nil, err
 	}
 	opts = append(opts, reset.opts...)
-	// /me's non_production field is the SAME posture: the client
-	// hides the "Reset data" action it would otherwise render for an
-	// endpoint that answers 404 in production.
-	opts = append(opts, compose.WithNonProduction(env))
+	// /me carries both: the posture, which is what non_production has always
+	// meant, and the reset switch, so a client never renders an action for an
+	// endpoint that would answer 404.
+	opts = append(opts, compose.WithNonProduction(env, allowDataReset))
 	// Gate 1: the connector's whole route group — /mcp, the authorization
 	// server and both discovery documents — exists only when the deployment
 	// declared it. The boot check in bindInstallation already proved the

--- a/backend/cmd/api/resetruntime.go
+++ b/backend/cmd/api/resetruntime.go
@@ -16,7 +16,6 @@ import (
 	"github.com/gradionhq/margince/backend/internal/platform/jobs"
 	kevents "github.com/gradionhq/margince/backend/internal/shared/kernel/events"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
-	"github.com/gradionhq/margince/backend/internal/shared/runtimeenv"
 )
 
 // resetDrainWindow bounds how long a reset waits for running jobs before it
@@ -79,16 +78,16 @@ type resetLane struct {
 	serverFlush func(ids.UUID)
 }
 
-// newResetLane assembles the lane, or nothing at all in production. The
-// endpoint's 404 there is the contract; a production process that holds no
-// queue-pausing, stream-deleting machinery at all is the stronger guarantee
-// behind it. env is the posture its caller already read for the endpoint
-// itself — one read, so the two cannot disagree about which one is live.
+// newResetLane assembles the lane, or nothing at all when the installation did
+// not arm the reset. The endpoint's 404 is the contract; a process that holds
+// no queue-pausing, stream-deleting machinery at all is the stronger guarantee
+// behind it. allowed is the same switch its caller already read for the
+// endpoint itself — one read, so the two cannot disagree about which is live.
 //
 // rdb is this role's shared Redis handle (sharedRedisClient): the reset purges
 // the bus and announces itself over that one connection, never a new one.
-func newResetLane(env runtimeenv.Environment, pool *pgxpool.Pool, rdb *redis.Client, logger *slog.Logger) (*resetLane, error) {
-	if !env.IsNonProduction() {
+func newResetLane(allowed bool, pool *pgxpool.Pool, rdb *redis.Client, logger *slog.Logger) (*resetLane, error) {
+	if !allowed {
 		return &resetLane{}, nil
 	}
 	// Insert-only, like every other River client this role builds: the reset

--- a/backend/cmd/api/resetruntime_test.go
+++ b/backend/cmd/api/resetruntime_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/gradionhq/margince/backend/internal/compose"
 	"github.com/gradionhq/margince/backend/internal/platform/jobs"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
-	"github.com/gradionhq/margince/backend/internal/shared/runtimeenv"
 )
 
 func TestNewResetRuntimeWiresEverySurface(t *testing.T) {
@@ -45,20 +44,23 @@ func TestResetDrainWindowIsPositive(t *testing.T) {
 	}
 }
 
-// TestNoResetLaneInProduction: the endpoint's own 404 is the contract, and a
-// production process that holds no queue-pausing, stream-deleting machinery at
-// all is the guarantee behind it. Nil dependencies prove nothing was
-// constructed — anything that reached the pool or the bus would fail here.
-func TestNoResetLaneInProduction(t *testing.T) {
-	lane, err := newResetLane(runtimeenv.Production, nil, nil, discardLogger())
+// TestNoResetLaneWhenTheResetIsNotArmed: the endpoint's own 404 is the
+// contract, and a process that holds no queue-pausing, stream-deleting
+// machinery at all is the guarantee behind it. Nil dependencies prove nothing
+// was constructed — anything that reached the pool or the bus would fail here.
+//
+// Unarmed is the DEFAULT, in every posture including dev: the capability is
+// stated by the deployment, never inferred from what it is called.
+func TestNoResetLaneWhenTheResetIsNotArmed(t *testing.T) {
+	lane, err := newResetLane(false, nil, nil, discardLogger())
 	if err != nil {
 		t.Fatalf("newResetLane: %v", err)
 	}
 	if len(lane.opts) != 0 {
-		t.Errorf("production lane contributes %d compose options; it must contribute none", len(lane.opts))
+		t.Errorf("an unarmed lane contributes %d compose options; it must contribute none", len(lane.opts))
 	}
 	// Nothing to listen with either: a lane that subscribed would hold a bus
-	// connection a production process never asked for.
+	// connection this process never asked for.
 	lane.listen(t.Context(), nil)
 }
 
@@ -67,7 +69,7 @@ func TestNoResetLaneInProduction(t *testing.T) {
 // reset must reach it too), and Server.FlushResetCaches is reachable only
 // while the options run — compose.New returns an http.Handler.
 func TestResetLaneCapturesTheComposedServersOwnFlush(t *testing.T) {
-	lane, err := newResetLane(runtimeenv.Development, nil, nil, discardLogger())
+	lane, err := newResetLane(true, nil, nil, discardLogger())
 	if err != nil {
 		t.Fatalf("newResetLane: %v", err)
 	}

--- a/backend/cmd/worker/boot.go
+++ b/backend/cmd/worker/boot.go
@@ -54,9 +54,11 @@ func runDebugSubcommand(ctx context.Context, args []string, stdout io.Writer) (b
 }
 
 // loadDeployment reads the same deployment file the api boots from — the
-// capture pipeline tuning (capture.freemail_extra) and the operator's
-// ai.capture_payloads posture the Surface-B runner honors — and folds the rate
-// sources it declares into cfg. A missing file means defaults; a malformed one
+// capture pipeline tuning (capture.freemail_extra), the operator's
+// ai.capture_payloads posture the Surface-B runner honors, and whether the
+// installation armed operations.allow_data_reset, which decides whether this
+// role subscribes to reset announcements at all — and folds the rate sources it
+// declares into cfg. A missing file means defaults; a malformed one
 // is a boot error (a typo must not silently drop the blocklist or flip the
 // payload posture).
 func loadDeployment(cfg *workerConfig) (deployconfig.Config, error) {
@@ -155,6 +157,10 @@ func startEventLanes(ctx context.Context, cfg workerConfig, pool *pgxpool.Pool, 
 		return lanes, err
 	}
 	startProjectionLanes(laneCtx, pool, rdb, modelPath, lanes.background, logger, stdout)
+	// Said out loud for the reason the api says it: each role reads its own
+	// --config, so an unarmed worker beside an armed api is a purge whose cache
+	// flush never reaches this process.
+	logger.Info("data reset", "armed", cfg.allowDataReset)
 	startResetLane(laneCtx, cfg.allowDataReset, rdb, modelPath, lanes.background, logger)
 
 	blob, blobConfigured, err := blobstore.FromEnv(ctx, config.FromOS)

--- a/backend/cmd/worker/boot.go
+++ b/backend/cmd/worker/boot.go
@@ -34,7 +34,6 @@ import (
 	"github.com/gradionhq/margince/backend/internal/platform/keyvault"
 	kevents "github.com/gradionhq/margince/backend/internal/shared/kernel/events"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
-	"github.com/gradionhq/margince/backend/internal/shared/runtimeenv"
 )
 
 // runDebugSubcommand dispatches the DB-less debug loops — `worker siteread …`
@@ -65,6 +64,7 @@ func loadDeployment(cfg *workerConfig) (deployconfig.Config, error) {
 	if err != nil {
 		return deployconfig.Config{}, err
 	}
+	cfg.allowDataReset = deployCfg.Operations.AllowDataReset
 	cfg.ratesFx = deployCfg.Rates.Fx
 	cfg.ratesCurrencies = deployCfg.Rates.FxCurrencies
 	cfg.ratesModelPricing = deployCfg.Rates.ModelPricing
@@ -155,7 +155,7 @@ func startEventLanes(ctx context.Context, cfg workerConfig, pool *pgxpool.Pool, 
 		return lanes, err
 	}
 	startProjectionLanes(laneCtx, pool, rdb, modelPath, lanes.background, logger, stdout)
-	startResetLane(laneCtx, runtimeenv.Parse(config.FromOS("MARGINCE_ENV")), rdb, modelPath, lanes.background, logger)
+	startResetLane(laneCtx, cfg.allowDataReset, rdb, modelPath, lanes.background, logger)
 
 	blob, blobConfigured, err := blobstore.FromEnv(ctx, config.FromOS)
 	if err != nil {
@@ -272,13 +272,12 @@ func startWorkflowLane(ctx context.Context, pool *pgxpool.Pool, rdb *redis.Clien
 // Unlike the lanes above, this is not an events.md consumer group: pub/sub,
 // no envelope, no dedupe wrapper, no consumer group to reclaim from. It is
 // also unauthenticated — the channel carries no signature, so whoever reaches
-// the bus can publish — which is why the posture gate matters here and not
-// only on the api. A reset cannot happen in production at all (the endpoint
-// 404s before auth), so a production worker has no announcement to wait for,
-// and subscribing anyway would leave an unauthenticated publisher able to
-// force cache misses on it indefinitely.
-func startResetLane(ctx context.Context, env runtimeenv.Environment, rdb *redis.Client, modelPath compose.ModelPath, background *sync.WaitGroup, logger *slog.Logger) {
-	if !env.IsNonProduction() {
+// the bus can publish — which is why the gate matters here and not only on the
+// api. An installation that did not arm the reset has no announcement to wait
+// for (the endpoint 404s before auth), and subscribing anyway would leave an
+// unauthenticated publisher able to force cache misses on it indefinitely.
+func startResetLane(ctx context.Context, allowed bool, rdb *redis.Client, modelPath compose.ModelPath, background *sync.WaitGroup, logger *slog.Logger) {
+	if !allowed {
 		return
 	}
 	flush := resetFlush(modelPath)

--- a/backend/cmd/worker/config.go
+++ b/backend/cmd/worker/config.go
@@ -21,10 +21,15 @@ import (
 
 // workerConfig is the parsed boot configuration of the worker process.
 type workerConfig struct {
-	dsn                  string
-	configPath           string
-	publicBaseURL        string
-	captureConfig        compose.CaptureConfig
+	dsn           string
+	configPath    string
+	publicBaseURL string
+	captureConfig compose.CaptureConfig
+	// allowDataReset is operations.allow_data_reset: whether this installation
+	// armed the destructive reset at all. The worker's only stake is the cache
+	// flush it subscribes to, which exists solely to serve that reset — so an
+	// installation that never armed it holds no subscriber either.
+	allowDataReset       bool
 	ratesFx              string
 	ratesCurrencies      []string
 	ratesModelPricing    map[string]string

--- a/backend/cmd/worker/resetlane_test.go
+++ b/backend/cmd/worker/resetlane_test.go
@@ -5,34 +5,55 @@ package main
 
 // The worker's stake in the data reset is one subscriber: the cache flush an
 // announced reset triggers. It exists only to serve that reset, so an
-// installation that never armed the reset holds no subscriber either — and
-// must not, because the announcement channel is reachable by anyone who can
-// publish to the bus, and a subscriber nobody asked for is a way to force cache
-// misses on this role indefinitely.
+// installation that never armed the reset holds no subscriber either — and must
+// not, because the announcement channel is reachable by anyone who can publish
+// to the bus, and a subscriber nobody asked for is a way to force cache misses
+// on this role indefinitely.
+//
+// What is worth pinning here is that the worker READS the switch from the same
+// deployment file the api does. The branch it feeds is one `if`; the wiring that
+// carries the operator's answer across two process roles is the part that can
+// silently disagree.
 
 import (
-	"log/slog"
-	"sync"
+	"os"
+	"path/filepath"
 	"testing"
-
-	"github.com/gradionhq/margince/backend/internal/compose"
 )
 
-func TestTheWorkerSubscribesToResetsOnlyWhenTheResetIsArmed(t *testing.T) {
-	// Nil dependencies are the assertion: startResetLane reaches the Redis
-	// handle the moment it decides to subscribe, so anything that got past the
-	// gate would panic here rather than pass quietly.
-	var background sync.WaitGroup
-	startResetLane(t.Context(), false, nil, compose.ModelPath{}, &background, slog.New(slog.DiscardHandler))
-	background.Wait()
+func TestTheWorkerReadsTheDataResetSwitchFromTheDeploymentFile(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		yaml string
+		want bool
+	}{
+		{name: "armed", yaml: "version: 1\noperations:\n  allow_data_reset: true\n", want: true},
+		{name: "stated off", yaml: "version: 1\noperations:\n  allow_data_reset: false\n", want: false},
+		// The case that matters most: a deployment that says nothing about
+		// operations gets no reset, whatever posture it runs under.
+		{name: "unstated", yaml: "version: 1\n", want: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "margince.yaml")
+			if err := os.WriteFile(path, []byte(tc.yaml), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			cfg := workerConfig{configPath: path}
+			if _, err := loadDeployment(&cfg); err != nil {
+				t.Fatalf("loadDeployment: %v", err)
+			}
+			if cfg.allowDataReset != tc.want {
+				t.Errorf("allowDataReset = %v, want %v", cfg.allowDataReset, tc.want)
+			}
+		})
+	}
 }
 
-func TestAnUnarmedWorkerIsTheDefaultInEveryPosture(t *testing.T) {
-	// The switch travels on workerConfig, whose zero value is what a deployment
-	// that said nothing gets. Fail-closed is not a posture question: a dev
-	// installation that never armed the reset holds no subscriber either.
+func TestAWorkerThatLoadedNothingArmsNothing(t *testing.T) {
+	// The zero value is what a role holds before any file is read, and what one
+	// with no --config holds for good. Fail-closed is not a posture question.
 	var cfg workerConfig
 	if cfg.allowDataReset {
-		t.Fatal("a deployment that configured nothing armed the data reset")
+		t.Fatal("a worker that read no deployment file armed the data reset")
 	}
 }

--- a/backend/cmd/worker/resetlane_test.go
+++ b/backend/cmd/worker/resetlane_test.go
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package main
+
+// The worker's stake in the data reset is one subscriber: the cache flush an
+// announced reset triggers. It exists only to serve that reset, so an
+// installation that never armed the reset holds no subscriber either — and
+// must not, because the announcement channel is reachable by anyone who can
+// publish to the bus, and a subscriber nobody asked for is a way to force cache
+// misses on this role indefinitely.
+
+import (
+	"log/slog"
+	"sync"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/compose"
+)
+
+func TestTheWorkerSubscribesToResetsOnlyWhenTheResetIsArmed(t *testing.T) {
+	// Nil dependencies are the assertion: startResetLane reaches the Redis
+	// handle the moment it decides to subscribe, so anything that got past the
+	// gate would panic here rather than pass quietly.
+	var background sync.WaitGroup
+	startResetLane(t.Context(), false, nil, compose.ModelPath{}, &background, slog.New(slog.DiscardHandler))
+	background.Wait()
+}
+
+func TestAnUnarmedWorkerIsTheDefaultInEveryPosture(t *testing.T) {
+	// The switch travels on workerConfig, whose zero value is what a deployment
+	// that said nothing gets. Fail-closed is not a posture question: a dev
+	// installation that never armed the reset holds no subscriber either.
+	var cfg workerConfig
+	if cfg.allowDataReset {
+		t.Fatal("a deployment that configured nothing armed the data reset")
+	}
+}

--- a/backend/cmd/worker/resetlane_test.go
+++ b/backend/cmd/worker/resetlane_test.go
@@ -48,12 +48,3 @@ func TestTheWorkerReadsTheDataResetSwitchFromTheDeploymentFile(t *testing.T) {
 		})
 	}
 }
-
-func TestAWorkerThatLoadedNothingArmsNothing(t *testing.T) {
-	// The zero value is what a role holds before any file is read, and what one
-	// with no --config holds for good. Fail-closed is not a posture question.
-	var cfg workerConfig
-	if cfg.allowDataReset {
-		t.Fatal("a worker that read no deployment file armed the data reset")
-	}
-}

--- a/backend/internal/compose/datareset.go
+++ b/backend/internal/compose/datareset.go
@@ -31,7 +31,6 @@ import (
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
-	"github.com/gradionhq/margince/backend/internal/shared/runtimeenv"
 )
 
 // objectWorkspace names the installation's own row. It is one string doing the
@@ -68,7 +67,7 @@ type dataResetHandlers struct {
 	pool       *pgxpool.Pool
 	schemaPool *pgxpool.Pool
 	seeds      deployconfig.Seeds
-	env        runtimeenv.Environment
+	allowed    bool
 	log        *slog.Logger
 
 	// runtime POINTS AT the Server's own field rather than copying it, so
@@ -408,14 +407,15 @@ func (h dataResetHandlers) purgeSealedCredentials(ctx context.Context, wsID ids.
 	return nil
 }
 
-// ResetData wipes a non-production installation to its first-boot state.
-// Gate order, fail-closed: environment first (production has no such
-// endpoint, checked before any auth so a misconfigured deployment never
-// leaks that the operation exists) → human-only (an agent never wipes
-// tenant data) → admin-only → the typed confirmation run enforces.
+// ResetData wipes an installation that has ARMED the capability back to its
+// first-boot state. Gate order, fail-closed: the switch first (an installation
+// that did not arm it has no such endpoint, checked before any auth so a
+// misconfigured deployment never leaks that the operation exists) → human-only
+// (an agent never wipes tenant data) → admin-only → the typed confirmation run
+// enforces.
 func (h dataResetHandlers) ResetData(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	if h.pool == nil || !h.env.IsNonProduction() {
+	if h.pool == nil || !h.allowed {
 		httperr.Write(w, r, apperrors.ErrNotFound)
 		return
 	}

--- a/backend/internal/compose/datareset.go
+++ b/backend/internal/compose/datareset.go
@@ -64,11 +64,11 @@ type resetDataResponse struct {
 // configured — the reset itself still succeeds, only the DDL cleanup is
 // skipped). log defaults to slog.Default() when nil.
 type dataResetHandlers struct {
-	pool       *pgxpool.Pool
-	schemaPool *pgxpool.Pool
-	seeds      deployconfig.Seeds
-	allowed    bool
-	log        *slog.Logger
+	pool             *pgxpool.Pool
+	schemaPool       *pgxpool.Pool
+	seeds            deployconfig.Seeds
+	dataResetAllowed bool
+	log              *slog.Logger
 
 	// runtime POINTS AT the Server's own field rather than copying it, so
 	// WithResetRuntime and WithDataReset may be applied in either order — see
@@ -415,7 +415,7 @@ func (h dataResetHandlers) purgeSealedCredentials(ctx context.Context, wsID ids.
 // enforces.
 func (h dataResetHandlers) ResetData(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	if h.pool == nil || !h.allowed {
+	if h.pool == nil || !h.dataResetAllowed {
 		httperr.Write(w, r, apperrors.ErrNotFound)
 		return
 	}

--- a/backend/internal/compose/datareset_http_integration_test.go
+++ b/backend/internal/compose/datareset_http_integration_test.go
@@ -24,16 +24,15 @@ import (
 	"github.com/gradionhq/margince/backend/internal/compose/integration"
 	"github.com/gradionhq/margince/backend/internal/platform/deployconfig"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
-	"github.com/gradionhq/margince/backend/internal/shared/runtimeenv"
 )
 
 func TestResetDataEndpointGates(t *testing.T) {
 	e := integration.Setup(t)
 	e.SeedPerson(t, "Alice", nil)
 
-	call := func(ctx context.Context, env runtimeenv.Environment, body string) *httptest.ResponseRecorder {
+	call := func(ctx context.Context, allowed bool, body string) *httptest.ResponseRecorder {
 		h := dataResetHandlers{
-			pool: e.Pool, schemaPool: nil, seeds: deployconfig.Seeds{}, env: env,
+			pool: e.Pool, schemaPool: nil, seeds: deployconfig.Seeds{}, allowed: allowed,
 			log: slog.New(slog.NewTextHandler(io.Discard, nil)),
 		}
 		req := httptest.NewRequest(http.MethodPost, "/v1/admin/reset-data", strings.NewReader(body)).WithContext(ctx)
@@ -42,24 +41,24 @@ func TestResetDataEndpointGates(t *testing.T) {
 		return rec
 	}
 
-	if rec := call(e.Admin(), runtimeenv.Production, `{"confirmation":"x"}`); rec.Code != http.StatusNotFound {
+	if rec := call(e.Admin(), false, `{"confirmation":"x"}`); rec.Code != http.StatusNotFound {
 		t.Fatalf("production posture: got %d, want 404", rec.Code)
 	}
 
-	if rec := call(e.AgentCtx(), runtimeenv.Development, `{"confirmation":"x"}`); rec.Code != http.StatusForbidden {
+	if rec := call(e.AgentCtx(), true, `{"confirmation":"x"}`); rec.Code != http.StatusForbidden {
 		t.Fatalf("agent principal: got %d, want 403", rec.Code)
 	}
 
 	nonAdmin := e.As(ids.NewV7(), nil, integration.RepPerms)
-	if rec := call(nonAdmin, runtimeenv.Development, `{"confirmation":"x"}`); rec.Code != http.StatusForbidden {
+	if rec := call(nonAdmin, true, `{"confirmation":"x"}`); rec.Code != http.StatusForbidden {
 		t.Fatalf("non-admin human: got %d, want 403", rec.Code)
 	}
 
-	if rec := call(e.Admin(), runtimeenv.Development, `{"confirmation":"wrong"}`); rec.Code != http.StatusUnprocessableEntity {
+	if rec := call(e.Admin(), true, `{"confirmation":"wrong"}`); rec.Code != http.StatusUnprocessableEntity {
 		t.Fatalf("wrong confirmation: got %d, want 422", rec.Code)
 	}
 
-	rec := call(e.Admin(), runtimeenv.Development, `{"confirmation":"Authz"}`)
+	rec := call(e.Admin(), true, `{"confirmation":"Authz"}`)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("happy path: got %d, want 200 (body %s)", rec.Code, rec.Body.String())
 	}

--- a/backend/internal/compose/datareset_http_integration_test.go
+++ b/backend/internal/compose/datareset_http_integration_test.go
@@ -32,7 +32,7 @@ func TestResetDataEndpointGates(t *testing.T) {
 
 	call := func(ctx context.Context, allowed bool, body string) *httptest.ResponseRecorder {
 		h := dataResetHandlers{
-			pool: e.Pool, schemaPool: nil, seeds: deployconfig.Seeds{}, allowed: allowed,
+			pool: e.Pool, schemaPool: nil, seeds: deployconfig.Seeds{}, dataResetAllowed: allowed,
 			log: slog.New(slog.NewTextHandler(io.Discard, nil)),
 		}
 		req := httptest.NewRequest(http.MethodPost, "/v1/admin/reset-data", strings.NewReader(body)).WithContext(ctx)
@@ -42,7 +42,7 @@ func TestResetDataEndpointGates(t *testing.T) {
 	}
 
 	if rec := call(e.Admin(), false, `{"confirmation":"x"}`); rec.Code != http.StatusNotFound {
-		t.Fatalf("production posture: got %d, want 404", rec.Code)
+		t.Fatalf("an installation that did not arm the reset: got %d, want 404", rec.Code)
 	}
 
 	if rec := call(e.AgentCtx(), true, `{"confirmation":"x"}`); rec.Code != http.StatusForbidden {

--- a/backend/internal/compose/datareset_integration_test.go
+++ b/backend/internal/compose/datareset_integration_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/gradionhq/margince/backend/internal/platform/overlaybudget/budgettest"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
-	"github.com/gradionhq/margince/backend/internal/shared/runtimeenv"
 )
 
 // TestSweepWorkspaceDataClearsDomainKeepsIdentity is the reset engine's core
@@ -161,7 +160,7 @@ func TestResetRunRestoresBootstrapState(t *testing.T) {
 		pool:       e.Pool,
 		schemaPool: nil,
 		seeds:      deployconfig.Seeds{},
-		env:        runtimeenv.Development,
+		allowed:    true,
 		log:        slog.New(slog.NewTextHandler(io.Discard, nil)),
 	}
 
@@ -221,11 +220,11 @@ func TestResetDataAuditEvidenceCarriesTheSameCacheKeyTallyAsTheResponse(t *testi
 	}
 
 	h := dataResetHandlers{
-		pool:   e.Pool,
-		seeds:  deployconfig.Seeds{},
-		env:    runtimeenv.Development,
-		budget: meter,
-		log:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+		pool:    e.Pool,
+		seeds:   deployconfig.Seeds{},
+		allowed: true,
+		budget:  meter,
+		log:     slog.New(slog.NewTextHandler(io.Discard, nil)),
 	}
 
 	counts, err := h.run(ctx, "Authz")
@@ -348,10 +347,10 @@ func TestResetReturnsAnOverlayWorkspaceToNativeMode(t *testing.T) {
 	e.WsExec(t, `UPDATE workspace SET x_sor_mode = 'overlay', x_incumbent = 'hubspot' WHERE id = $1`, e.WS)
 
 	h := dataResetHandlers{
-		pool:  e.Pool,
-		seeds: deployconfig.Seeds{},
-		env:   runtimeenv.Development,
-		log:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+		pool:    e.Pool,
+		seeds:   deployconfig.Seeds{},
+		allowed: true,
+		log:     slog.New(slog.NewTextHandler(io.Discard, nil)),
 	}
 	if _, err := h.run(ctx, "Authz"); err != nil {
 		t.Fatalf("run: %v", err)
@@ -393,10 +392,10 @@ func TestResetRestoresWorkspaceLevelSettings(t *testing.T) {
 		UPDATE workspace SET x_sor_mode = 'overlay', x_incumbent = 'hubspot' WHERE id = $1`, e.WS)
 
 	h := dataResetHandlers{
-		pool:  e.Pool,
-		seeds: deployconfig.Seeds{},
-		env:   runtimeenv.Development,
-		log:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+		pool:    e.Pool,
+		seeds:   deployconfig.Seeds{},
+		allowed: true,
+		log:     slog.New(slog.NewTextHandler(io.Discard, nil)),
 	}
 	if _, err := h.run(ctx, "Authz"); err != nil {
 		t.Fatalf("run: %v", err)
@@ -434,10 +433,10 @@ func TestResetRestoresSettingRowsButKeepsTheInstallationsIdentity(t *testing.T) 
 		ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value`)
 
 	h := dataResetHandlers{
-		pool:  e.Pool,
-		seeds: deployconfig.Seeds{},
-		env:   runtimeenv.Development,
-		log:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+		pool:    e.Pool,
+		seeds:   deployconfig.Seeds{},
+		allowed: true,
+		log:     slog.New(slog.NewTextHandler(io.Discard, nil)),
 	}
 	// Confirmed with the SETTING's name, not the workspace column's. This test
 	// is the one place the two deliberately differ, and the confirmation
@@ -477,10 +476,10 @@ func TestResetLeavesANativeWorkspaceAlone(t *testing.T) {
 	ctx := e.Admin()
 
 	h := dataResetHandlers{
-		pool:  e.Pool,
-		seeds: deployconfig.Seeds{},
-		env:   runtimeenv.Development,
-		log:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+		pool:    e.Pool,
+		seeds:   deployconfig.Seeds{},
+		allowed: true,
+		log:     slog.New(slog.NewTextHandler(io.Discard, nil)),
 	}
 	if _, err := h.run(ctx, "Authz"); err != nil {
 		t.Fatalf("run: %v", err)
@@ -519,11 +518,11 @@ func TestResetPurgesTheSealedCredentialsItsSweepOrphans(t *testing.T) {
 		VALUES ($1, 'hubspot', 'eu', 'active', $2)`, ids.NewV7(), string(mine))
 
 	h := dataResetHandlers{
-		pool:  e.Pool,
-		seeds: deployconfig.Seeds{},
-		env:   runtimeenv.Development,
-		log:   slog.New(slog.NewTextHandler(io.Discard, nil)),
-		vault: vault,
+		pool:    e.Pool,
+		seeds:   deployconfig.Seeds{},
+		allowed: true,
+		log:     slog.New(slog.NewTextHandler(io.Discard, nil)),
+		vault:   vault,
 	}
 	if _, err := h.run(ctx, "Authz"); err != nil {
 		t.Fatalf("run: %v", err)

--- a/backend/internal/compose/datareset_integration_test.go
+++ b/backend/internal/compose/datareset_integration_test.go
@@ -157,11 +157,11 @@ func TestResetRunRestoresBootstrapState(t *testing.T) {
 	e.WsExec(t, `INSERT INTO event_outbox (stream, envelope) VALUES ('pre-reset', jsonb_build_object('workspace_id', $1::text))`, e.WS)
 
 	h := dataResetHandlers{
-		pool:       e.Pool,
-		schemaPool: nil,
-		seeds:      deployconfig.Seeds{},
-		allowed:    true,
-		log:        slog.New(slog.NewTextHandler(io.Discard, nil)),
+		pool:             e.Pool,
+		schemaPool:       nil,
+		seeds:            deployconfig.Seeds{},
+		dataResetAllowed: true,
+		log:              slog.New(slog.NewTextHandler(io.Discard, nil)),
 	}
 
 	if _, err := h.run(ctx, "wrong"); !errors.Is(err, errResetConfirmationMismatch) {
@@ -220,11 +220,11 @@ func TestResetDataAuditEvidenceCarriesTheSameCacheKeyTallyAsTheResponse(t *testi
 	}
 
 	h := dataResetHandlers{
-		pool:    e.Pool,
-		seeds:   deployconfig.Seeds{},
-		allowed: true,
-		budget:  meter,
-		log:     slog.New(slog.NewTextHandler(io.Discard, nil)),
+		pool:             e.Pool,
+		seeds:            deployconfig.Seeds{},
+		dataResetAllowed: true,
+		budget:           meter,
+		log:              slog.New(slog.NewTextHandler(io.Discard, nil)),
 	}
 
 	counts, err := h.run(ctx, "Authz")
@@ -347,10 +347,10 @@ func TestResetReturnsAnOverlayWorkspaceToNativeMode(t *testing.T) {
 	e.WsExec(t, `UPDATE workspace SET x_sor_mode = 'overlay', x_incumbent = 'hubspot' WHERE id = $1`, e.WS)
 
 	h := dataResetHandlers{
-		pool:    e.Pool,
-		seeds:   deployconfig.Seeds{},
-		allowed: true,
-		log:     slog.New(slog.NewTextHandler(io.Discard, nil)),
+		pool:             e.Pool,
+		seeds:            deployconfig.Seeds{},
+		dataResetAllowed: true,
+		log:              slog.New(slog.NewTextHandler(io.Discard, nil)),
 	}
 	if _, err := h.run(ctx, "Authz"); err != nil {
 		t.Fatalf("run: %v", err)
@@ -392,10 +392,10 @@ func TestResetRestoresWorkspaceLevelSettings(t *testing.T) {
 		UPDATE workspace SET x_sor_mode = 'overlay', x_incumbent = 'hubspot' WHERE id = $1`, e.WS)
 
 	h := dataResetHandlers{
-		pool:    e.Pool,
-		seeds:   deployconfig.Seeds{},
-		allowed: true,
-		log:     slog.New(slog.NewTextHandler(io.Discard, nil)),
+		pool:             e.Pool,
+		seeds:            deployconfig.Seeds{},
+		dataResetAllowed: true,
+		log:              slog.New(slog.NewTextHandler(io.Discard, nil)),
 	}
 	if _, err := h.run(ctx, "Authz"); err != nil {
 		t.Fatalf("run: %v", err)
@@ -433,10 +433,10 @@ func TestResetRestoresSettingRowsButKeepsTheInstallationsIdentity(t *testing.T) 
 		ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value`)
 
 	h := dataResetHandlers{
-		pool:    e.Pool,
-		seeds:   deployconfig.Seeds{},
-		allowed: true,
-		log:     slog.New(slog.NewTextHandler(io.Discard, nil)),
+		pool:             e.Pool,
+		seeds:            deployconfig.Seeds{},
+		dataResetAllowed: true,
+		log:              slog.New(slog.NewTextHandler(io.Discard, nil)),
 	}
 	// Confirmed with the SETTING's name, not the workspace column's. This test
 	// is the one place the two deliberately differ, and the confirmation
@@ -476,10 +476,10 @@ func TestResetLeavesANativeWorkspaceAlone(t *testing.T) {
 	ctx := e.Admin()
 
 	h := dataResetHandlers{
-		pool:    e.Pool,
-		seeds:   deployconfig.Seeds{},
-		allowed: true,
-		log:     slog.New(slog.NewTextHandler(io.Discard, nil)),
+		pool:             e.Pool,
+		seeds:            deployconfig.Seeds{},
+		dataResetAllowed: true,
+		log:              slog.New(slog.NewTextHandler(io.Discard, nil)),
 	}
 	if _, err := h.run(ctx, "Authz"); err != nil {
 		t.Fatalf("run: %v", err)
@@ -518,11 +518,11 @@ func TestResetPurgesTheSealedCredentialsItsSweepOrphans(t *testing.T) {
 		VALUES ($1, 'hubspot', 'eu', 'active', $2)`, ids.NewV7(), string(mine))
 
 	h := dataResetHandlers{
-		pool:    e.Pool,
-		seeds:   deployconfig.Seeds{},
-		allowed: true,
-		log:     slog.New(slog.NewTextHandler(io.Discard, nil)),
-		vault:   vault,
+		pool:             e.Pool,
+		seeds:            deployconfig.Seeds{},
+		dataResetAllowed: true,
+		log:              slog.New(slog.NewTextHandler(io.Discard, nil)),
+		vault:            vault,
 	}
 	if _, err := h.run(ctx, "Authz"); err != nil {
 		t.Fatalf("run: %v", err)

--- a/backend/internal/compose/datareset_runtime.go
+++ b/backend/internal/compose/datareset_runtime.go
@@ -179,7 +179,7 @@ func (s *Server) FlushResetCaches(ws ids.UUID) {
 // brute-force brakes — a login attempt costs a full Argon2id verification, a
 // reset request costs an outbound email — so clearing them is a security
 // event, not a cache drop. It is safe here because this path runs inside the
-// reset handler, downstream of the non-production posture, the human-only and
+// reset handler, downstream of operations.allow_data_reset, the human-only and
 // admin-only gates, and the typed confirmation. It would not be safe on the
 // bus.
 //

--- a/backend/internal/compose/datareset_runtime_test.go
+++ b/backend/internal/compose/datareset_runtime_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/gradionhq/margince/backend/internal/platform/blobstore"
 	"github.com/gradionhq/margince/backend/internal/platform/deployconfig"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
-	"github.com/gradionhq/margince/backend/internal/shared/runtimeenv"
 )
 
 // runPhase drives the runtime phase over a handler set with no injected
@@ -327,7 +326,7 @@ func TestResetRuntimeReachesTheHandlerInEitherOptionOrder(t *testing.T) {
 	runtime := WithResetRuntime(ResetRuntime{
 		PurgeQueue: func(context.Context, ids.UUID) (int, error) { return purged, nil },
 	})
-	reset := WithDataReset(nil, deployconfig.Seeds{}, runtimeenv.Development)
+	reset := WithDataReset(nil, deployconfig.Seeds{}, true)
 
 	for _, order := range []struct {
 		name string
@@ -360,7 +359,7 @@ func TestResetRuntimeReachesTheHandlerInEitherOptionOrder(t *testing.T) {
 func TestTheDataResetReachesTheObjectStoreInEitherOptionOrder(t *testing.T) {
 	store := blobstore.NewMemory()
 	blob := WithBlobstore(store)
-	reset := WithDataReset(nil, deployconfig.Seeds{}, runtimeenv.Development)
+	reset := WithDataReset(nil, deployconfig.Seeds{}, true)
 
 	for _, order := range []struct {
 		name string

--- a/backend/internal/compose/datareset_unit_test.go
+++ b/backend/internal/compose/datareset_unit_test.go
@@ -24,10 +24,10 @@ import (
 // binds one. Pool is nil precisely to prove the workspace check returns first.
 func TestResetRunRequiresBoundWorkspace(t *testing.T) {
 	h := dataResetHandlers{
-		pool:    nil,
-		seeds:   deployconfig.Seeds{},
-		allowed: true,
-		log:     slog.New(slog.NewTextHandler(io.Discard, nil)),
+		pool:             nil,
+		seeds:            deployconfig.Seeds{},
+		dataResetAllowed: true,
+		log:              slog.New(slog.NewTextHandler(io.Discard, nil)),
 	}
 	if _, err := h.run(context.Background(), "irrelevant"); !errors.Is(err, database.ErrNoWorkspace) {
 		t.Fatalf("run without a bound workspace: got %v, want ErrNoWorkspace", err)
@@ -45,19 +45,8 @@ func TestWithDataResetWiresTheComposedPool(t *testing.T) {
 	if s.dataResetHandlers.pool != composed {
 		t.Fatal("WithDataReset did not wire the composed app-role pool")
 	}
-	if !s.allowed {
+	if !s.dataResetAllowed {
 		t.Fatal("WithDataReset did not carry the armed switch to the handler")
-	}
-}
-
-// The switch is what the endpoint answers on, so an installation that did not
-// arm it holds a handler that refuses — with the pool wired, which is what makes
-// this about the flag rather than about missing wiring.
-func TestWithDataResetUnarmedIsClosed(t *testing.T) {
-	var s Server
-	WithDataReset(nil, deployconfig.Seeds{}, false)(&s, &pgxpool.Pool{})
-	if s.allowed {
-		t.Fatal("an installation that did not arm the reset got an armed handler")
 	}
 }
 
@@ -73,9 +62,9 @@ func TestResetDataRefusesUnlessArmed(t *testing.T) {
 	// never dialed, because the gate returns before any query.
 	armedLike := func(allowed bool) dataResetHandlers {
 		return dataResetHandlers{
-			pool:    &pgxpool.Pool{},
-			allowed: allowed,
-			log:     slog.New(slog.NewTextHandler(io.Discard, nil)),
+			pool:             &pgxpool.Pool{},
+			dataResetAllowed: allowed,
+			log:              slog.New(slog.NewTextHandler(io.Discard, nil)),
 		}
 	}
 

--- a/backend/internal/compose/datareset_unit_test.go
+++ b/backend/internal/compose/datareset_unit_test.go
@@ -8,6 +8,8 @@ import (
 	"errors"
 	"io"
 	"log/slog"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -56,5 +58,36 @@ func TestWithDataResetUnarmedIsClosed(t *testing.T) {
 	WithDataReset(nil, deployconfig.Seeds{}, false)(&s, &pgxpool.Pool{})
 	if s.dataResetHandlers.allowed {
 		t.Fatal("an installation that did not arm the reset got an armed handler")
+	}
+}
+
+// TestResetDataRefusesUnlessArmed drives the handler itself, not the wiring.
+//
+// The switch is checked BEFORE any auth, so an installation that did not arm
+// the reset answers 404 to everyone — the endpoint does not exist there, and a
+// caller cannot learn it might. That ordering is what the second case pins: the
+// same unauthenticated request against an ARMED installation gets an auth
+// refusal instead, which is only reachable once the switch has let it past.
+func TestResetDataRefusesUnlessArmed(t *testing.T) {
+	// A non-nil pool so the refusal is attributable to the switch alone; it is
+	// never dialed, because the gate returns before any query.
+	armedLike := func(allowed bool) dataResetHandlers {
+		return dataResetHandlers{
+			pool:    &pgxpool.Pool{},
+			allowed: allowed,
+			log:     slog.New(slog.NewTextHandler(io.Discard, nil)),
+		}
+	}
+
+	unarmed := httptest.NewRecorder()
+	armedLike(false).ResetData(unarmed, httptest.NewRequest(http.MethodPost, "/v1/admin/reset-data", nil))
+	if unarmed.Code != http.StatusNotFound {
+		t.Fatalf("an installation that did not arm the reset answered %d, want 404", unarmed.Code)
+	}
+
+	armed := httptest.NewRecorder()
+	armedLike(true).ResetData(armed, httptest.NewRequest(http.MethodPost, "/v1/admin/reset-data", nil))
+	if armed.Code == http.StatusNotFound {
+		t.Fatal("an armed installation still answered 404, so the switch gates nothing")
 	}
 }

--- a/backend/internal/compose/datareset_unit_test.go
+++ b/backend/internal/compose/datareset_unit_test.go
@@ -45,7 +45,7 @@ func TestWithDataResetWiresTheComposedPool(t *testing.T) {
 	if s.dataResetHandlers.pool != composed {
 		t.Fatal("WithDataReset did not wire the composed app-role pool")
 	}
-	if !s.dataResetHandlers.allowed {
+	if !s.allowed {
 		t.Fatal("WithDataReset did not carry the armed switch to the handler")
 	}
 }
@@ -56,7 +56,7 @@ func TestWithDataResetWiresTheComposedPool(t *testing.T) {
 func TestWithDataResetUnarmedIsClosed(t *testing.T) {
 	var s Server
 	WithDataReset(nil, deployconfig.Seeds{}, false)(&s, &pgxpool.Pool{})
-	if s.dataResetHandlers.allowed {
+	if s.allowed {
 		t.Fatal("an installation that did not arm the reset got an armed handler")
 	}
 }

--- a/backend/internal/compose/datareset_unit_test.go
+++ b/backend/internal/compose/datareset_unit_test.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/deployconfig"
-	"github.com/gradionhq/margince/backend/internal/shared/runtimeenv"
 )
 
 // TestResetRunRequiresBoundWorkspace: run() refuses before it dials the pool
@@ -23,10 +22,10 @@ import (
 // binds one. Pool is nil precisely to prove the workspace check returns first.
 func TestResetRunRequiresBoundWorkspace(t *testing.T) {
 	h := dataResetHandlers{
-		pool:  nil,
-		seeds: deployconfig.Seeds{},
-		env:   runtimeenv.Development,
-		log:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+		pool:    nil,
+		seeds:   deployconfig.Seeds{},
+		allowed: true,
+		log:     slog.New(slog.NewTextHandler(io.Discard, nil)),
 	}
 	if _, err := h.run(context.Background(), "irrelevant"); !errors.Is(err, database.ErrNoWorkspace) {
 		t.Fatalf("run without a bound workspace: got %v, want ErrNoWorkspace", err)
@@ -35,16 +34,27 @@ func TestResetRunRequiresBoundWorkspace(t *testing.T) {
 
 // TestWithDataResetWiresTheComposedPool proves the option takes the app-role
 // pool the composition hands every option (the WithSchemaPool contract), not a
-// separately captured one, and threads the posture through — the wiring the
+// separately captured one, and threads the switch through — the wiring the
 // production cmd/api path depends on.
 func TestWithDataResetWiresTheComposedPool(t *testing.T) {
 	var s Server
 	composed := &pgxpool.Pool{} // never dialed; identity comparison only
-	WithDataReset(nil, deployconfig.Seeds{}, runtimeenv.Staging)(&s, composed)
+	WithDataReset(nil, deployconfig.Seeds{}, true)(&s, composed)
 	if s.dataResetHandlers.pool != composed {
 		t.Fatal("WithDataReset did not wire the composed app-role pool")
 	}
-	if s.env != runtimeenv.Staging {
-		t.Fatalf("WithDataReset env = %q, want staging", s.env)
+	if !s.dataResetHandlers.allowed {
+		t.Fatal("WithDataReset did not carry the armed switch to the handler")
+	}
+}
+
+// The switch is what the endpoint answers on, so an installation that did not
+// arm it holds a handler that refuses — with the pool wired, which is what makes
+// this about the flag rather than about missing wiring.
+func TestWithDataResetUnarmedIsClosed(t *testing.T) {
+	var s Server
+	WithDataReset(nil, deployconfig.Seeds{}, false)(&s, &pgxpool.Pool{})
+	if s.dataResetHandlers.allowed {
+		t.Fatal("an installation that did not arm the reset got an armed handler")
 	}
 }

--- a/backend/internal/compose/integration/datareset_http_e2e_integration_test.go
+++ b/backend/internal/compose/integration/datareset_http_e2e_integration_test.go
@@ -22,8 +22,8 @@ import (
 // the admin RoleKeys that RequireAdmin gates on.
 func TestResetDataOverHTTP(t *testing.T) {
 	e := apptest.SetupAppWithOptions(t,
-		compose.WithDataReset(nil, deployconfig.Seeds{}, runtimeenv.Development),
-		compose.WithNonProduction(runtimeenv.Development),
+		compose.WithDataReset(nil, deployconfig.Seeds{}, true),
+		compose.WithNonProduction(true),
 	)
 	apptest.BootstrapWorkspaceSession(t, e, "Fable E2E", "ada@example.com", "Ada Admin")
 

--- a/backend/internal/compose/integration/datareset_http_e2e_integration_test.go
+++ b/backend/internal/compose/integration/datareset_http_e2e_integration_test.go
@@ -14,25 +14,34 @@ import (
 	"github.com/gradionhq/margince/backend/internal/shared/runtimeenv"
 )
 
-// TestResetDataOverHTTP drives the non-production admin reset end to end over
-// the real router and a real admin session (what the direct-handler test
-// cannot see): the WithDataReset / WithNonProduction wiring, the non_production
-// posture /me carries for the client gate, the confirmation refusal, and a
+// TestResetDataOverHTTP drives the armed admin reset end to end over the real
+// router and a real admin session (what the direct-handler test cannot see):
+// the WithDataReset / WithDataResetAvailable wiring, the data_reset_available
+// flag /me carries for the client gate, the confirmation refusal, and a
 // successful reset. Reaching 200 also proves the live session path populates
 // the admin RoleKeys that RequireAdmin gates on.
 func TestResetDataOverHTTP(t *testing.T) {
 	e := apptest.SetupAppWithOptions(t,
 		compose.WithDataReset(nil, deployconfig.Seeds{}, true),
-		compose.WithNonProduction(runtimeenv.Development, true),
+		compose.WithNonProduction(runtimeenv.Development),
+		compose.WithDataResetAvailable(true),
 	)
 	apptest.BootstrapWorkspaceSession(t, e, "Fable E2E", "ada@example.com", "Ada Admin")
 
 	var me struct {
-		NonProduction bool `json:"non_production"`
+		NonProduction      bool  `json:"non_production"`
+		DataResetAvailable *bool `json:"data_reset_available"`
 	}
 	if code := e.Call(t, "GET", "/v1/me", nil, nil, &me); code != 200 {
 		t.Fatalf("GET /me = %d, want 200", code)
 	}
+	// The field the SPA gates on, over the real router. Asserting only the
+	// posture would leave a dropped WithDataResetAvailable green here while
+	// every client's button disappeared.
+	if me.DataResetAvailable == nil || !*me.DataResetAvailable {
+		t.Fatalf("me.data_reset_available = %v; the endpoint below is armed, so the client must be told so", me.DataResetAvailable)
+	}
+	// And the posture travels separately, on its own deprecated field.
 	if !me.NonProduction {
 		t.Fatal("me.non_production = false; want true under the Development posture")
 	}

--- a/backend/internal/compose/integration/datareset_http_e2e_integration_test.go
+++ b/backend/internal/compose/integration/datareset_http_e2e_integration_test.go
@@ -23,7 +23,7 @@ import (
 func TestResetDataOverHTTP(t *testing.T) {
 	e := apptest.SetupAppWithOptions(t,
 		compose.WithDataReset(nil, deployconfig.Seeds{}, true),
-		compose.WithNonProduction(true),
+		compose.WithNonProduction(runtimeenv.Development, true),
 	)
 	apptest.BootstrapWorkspaceSession(t, e, "Fable E2E", "ada@example.com", "Ada Admin")
 

--- a/backend/internal/compose/integration/datareset_http_e2e_integration_test.go
+++ b/backend/internal/compose/integration/datareset_http_e2e_integration_test.go
@@ -20,10 +20,16 @@ import (
 // flag /me carries for the client gate, the confirmation refusal, and a
 // successful reset. Reaching 200 also proves the live session path populates
 // the admin RoleKeys that RequireAdmin gates on.
+//
+// It runs under the PRODUCTION posture on purpose. Armed-and-non-production is
+// the one combination the retired gate would also have served, so a test using
+// it proves nothing about which gate is live; armed-and-production can only
+// pass if the capability is independent of the posture, and fails against any
+// regression to `allowed && env.IsNonProduction()`.
 func TestResetDataOverHTTP(t *testing.T) {
 	e := apptest.SetupAppWithOptions(t,
 		compose.WithDataReset(nil, deployconfig.Seeds{}, true),
-		compose.WithNonProduction(runtimeenv.Development),
+		compose.WithNonProduction(runtimeenv.Production),
 		compose.WithDataResetAvailable(true),
 	)
 	apptest.BootstrapWorkspaceSession(t, e, "Fable E2E", "ada@example.com", "Ada Admin")
@@ -41,9 +47,10 @@ func TestResetDataOverHTTP(t *testing.T) {
 	if me.DataResetAvailable == nil || !*me.DataResetAvailable {
 		t.Fatalf("me.data_reset_available = %v; the endpoint below is armed, so the client must be told so", me.DataResetAvailable)
 	}
-	// And the posture travels separately, on its own deprecated field.
-	if !me.NonProduction {
-		t.Fatal("me.non_production = false; want true under the Development posture")
+	// And the posture travels separately, reporting production — which is the
+	// point: the two answers disagree here, and the reset below still runs.
+	if me.NonProduction {
+		t.Fatal("me.non_production = true under the Production posture")
 	}
 
 	// Wrong confirmation is refused before anything is deleted.

--- a/backend/internal/compose/serveroptions.go
+++ b/backend/internal/compose/serveroptions.go
@@ -348,7 +348,7 @@ func WithSchemaPool(schemaPool *pgxpool.Pool) Option {
 func WithDataReset(schemaPool *pgxpool.Pool, seeds deployconfig.Seeds, allowed bool) Option {
 	return func(s *Server, pool *pgxpool.Pool) {
 		s.dataResetHandlers = dataResetHandlers{
-			pool: pool, schemaPool: schemaPool, seeds: seeds, allowed: allowed, log: s.log,
+			pool: pool, schemaPool: schemaPool, seeds: seeds, dataResetAllowed: allowed, log: s.log,
 			// A pointer into the Server, so WithResetRuntime may be applied
 			// before or after this option (see Server.resetRuntime). The meter
 			// is likewise the ONE shared instance WithOverlayMeter rebinds; the
@@ -380,21 +380,25 @@ func WithResetRuntime(rt ResetRuntime) Option {
 	return func(s *Server, _ *pgxpool.Pool) { s.resetRuntime = rt }
 }
 
-// WithNonProduction surfaces two different facts onto /me, which is why it
-// takes two arguments that used to be one.
-//
-// The POSTURE still answers "is this a production deployment" (non_production),
-// which is what it always meant. Whether the reset action is OFFERED is now the
-// same switch that arms the endpoint — so the button a client renders and the
-// route it would call can no longer disagree, and neither is inferred from a
-// deployment's name.
-//
-// Absent this option both report closed (Handlers' zero value): hide the
-// destructive action rather than risk offering it under an unwired role.
-func WithNonProduction(env runtimeenv.Environment, dataResetAllowed bool) Option {
+// WithNonProduction surfaces the deployment posture onto /me's non_production
+// field. Absent this option /me reports production, the fail-closed default.
+func WithNonProduction(env runtimeenv.Environment) Option {
 	return func(s *Server, _ *pgxpool.Pool) {
-		s.authHandlers = s.WithNonProduction(env.IsNonProduction()).
-			WithDataResetAvailable(dataResetAllowed)
+		s.authHandlers = s.WithNonProduction(env.IsNonProduction())
+	}
+}
+
+// WithDataResetAvailable surfaces onto /me the same switch WithDataReset gates
+// the endpoint on, so the action a client renders and the route it would call
+// cannot disagree.
+//
+// Its own option rather than an argument to the posture above, because the two
+// are independent facts and this whole capability exists to stop them
+// travelling together. Absent it /me reports unavailable, which hides the
+// action rather than offering one the server would refuse.
+func WithDataResetAvailable(allowed bool) Option {
+	return func(s *Server, _ *pgxpool.Pool) {
+		s.authHandlers = s.WithDataResetAvailable(allowed)
 	}
 }
 

--- a/backend/internal/compose/serveroptions.go
+++ b/backend/internal/compose/serveroptions.go
@@ -333,18 +333,22 @@ func WithSchemaPool(schemaPool *pgxpool.Pool) Option {
 	}
 }
 
-// WithDataReset wires the non-production admin data-reset endpoint
-// (POST /v1/admin/reset-data): the sweep runs through the composed app-role
-// pool (the one every option receives, as WithSchemaPool takes it), while
-// schemaPool (may be nil) is the owner-privileged pool that finalizes cf_*
-// column drops — nil skips that finalize step, the reset itself still
-// succeeds. Absent this option, or outside a non-production posture, the
-// endpoint answers 404 (dataResetHandlers' zero value has a nil pool, the
-// same closed default).
-func WithDataReset(schemaPool *pgxpool.Pool, seeds deployconfig.Seeds, env runtimeenv.Environment) Option {
+// WithDataReset wires the admin data-reset endpoint (POST /v1/admin/reset-data):
+// the sweep runs through the composed app-role pool (the one every option
+// receives, as WithSchemaPool takes it), while schemaPool (may be nil) is the
+// owner-privileged pool that finalizes cf_* column drops — nil skips that
+// finalize step, the reset itself still succeeds. Absent this option, or with
+// allowed=false, the endpoint answers 404 (dataResetHandlers' zero value has a
+// nil pool and a false flag, the same closed default).
+//
+// allowed is operations.allow_data_reset, stated by the deployment. It used to
+// be inferred from MARGINCE_ENV, which meant an installation labelled `staging`
+// — real internal users — could have its tenant data purged because a label
+// said it was not production.
+func WithDataReset(schemaPool *pgxpool.Pool, seeds deployconfig.Seeds, allowed bool) Option {
 	return func(s *Server, pool *pgxpool.Pool) {
 		s.dataResetHandlers = dataResetHandlers{
-			pool: pool, schemaPool: schemaPool, seeds: seeds, env: env, log: s.log,
+			pool: pool, schemaPool: schemaPool, seeds: seeds, allowed: allowed, log: s.log,
 			// A pointer into the Server, so WithResetRuntime may be applied
 			// before or after this option (see Server.resetRuntime). The meter
 			// is likewise the ONE shared instance WithOverlayMeter rebinds; the
@@ -376,16 +380,21 @@ func WithResetRuntime(rt ResetRuntime) Option {
 	return func(s *Server, _ *pgxpool.Pool) { s.resetRuntime = rt }
 }
 
-// WithNonProduction surfaces the SAME deployment posture WithDataReset
-// gates the endpoint on, onto /me's non_production field (the client
-// signal for showing/hiding the "Reset data" action) — mirrors WithSorMode,
-// which surfaces the datasource dispatch's mode the same way. Absent this
-// option, /me reports production (Handlers' zero value), the fail-closed
-// default that hides the action rather than risk exposing it under an
-// unwired role.
-func WithNonProduction(env runtimeenv.Environment) Option {
+// WithNonProduction surfaces two different facts onto /me, which is why it
+// takes two arguments that used to be one.
+//
+// The POSTURE still answers "is this a production deployment" (non_production),
+// which is what it always meant. Whether the reset action is OFFERED is now the
+// same switch that arms the endpoint — so the button a client renders and the
+// route it would call can no longer disagree, and neither is inferred from a
+// deployment's name.
+//
+// Absent this option both report closed (Handlers' zero value): hide the
+// destructive action rather than risk offering it under an unwired role.
+func WithNonProduction(env runtimeenv.Environment, dataResetAllowed bool) Option {
 	return func(s *Server, _ *pgxpool.Pool) {
-		s.authHandlers = s.WithNonProduction(env.IsNonProduction())
+		s.authHandlers = s.WithNonProduction(env.IsNonProduction()).
+			WithDataResetAvailable(dataResetAllowed)
 	}
 }
 

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -14770,7 +14770,11 @@ type MeResponse struct {
 	// This is a snapshot, not an authority. A role change does not revoke live sessions, so a client refetches on window focus and after any 403, and treats the server's answer as the only one that counts. It does NOT express row scope, nor the human-principal and admin-role gates some routes carry independently of any grant — a permitted grant here is necessary, never sufficient.
 	Authorization *Authorization `json:"authorization,omitempty"`
 
-	// NonProduction True when the installation runs a non-production posture (MARGINCE_ENV). Gates the client-side "Reset data" action.
+	// DataResetAvailable True when this installation armed `operations.allow_data_reset` in its deployment file. It is the SAME value `POST /admin/reset-data` gates on, so a client never renders an action for a route that would answer 404. Absent or false means the capability does not exist here — the compiled default in every posture, dev included.
+	DataResetAvailable *bool `json:"data_reset_available,omitempty"`
+
+	// NonProduction True when the installation runs a non-production posture (MARGINCE_ENV=dev|test). DEPRECATED as the gate for the "Reset data" action — read `data_reset_available` instead. A deployment being non-production is not consent to purge its tenant data, and inferring one from the other is why a `staging` installation full of real internal users could be wiped through the API.
+	// Deprecated: this property has been marked as deprecated upstream, but no `x-deprecated-reason` was set
 	NonProduction bool `json:"non_production"`
 
 	// Passport Always null. This endpoint is reachable only by a human session: a passport bearer is admitted as an agent principal and never binds the session identity this operation reads, so an agent receives 401 here rather than a passport claim. The field is retained because removing a response property breaks published clients; a client MUST NOT branch on it. An agent's own scopes are what the MCP surface advertises in tools/list, which is the honest place to ask.

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -14805,7 +14805,7 @@ type MeResponse struct {
 	// User A seat — human or first-party agent. Mirrors `app_user`.
 	User User `json:"user"`
 
-	// WorkspaceName The installation's organization name (the installation.name setting). Shown as the typed-confirmation target of the non-production "Reset data" action — the exact string that endpoint validates.
+	// WorkspaceName The installation's organization name (the installation.name setting). Shown as the typed-confirmation target of the "Reset data" action — the exact string that endpoint validates.
 	WorkspaceName string `json:"workspace_name"`
 }
 
@@ -30103,7 +30103,7 @@ type ServerInterface interface {
 	// What the background system is holding, and whose work failed.
 	// (GET /admin/job-health)
 	GetJobHealth(w http.ResponseWriter, r *http.Request)
-	// Reset a non-production installation to its first-boot state.
+	// Reset an installation that armed the capability to its first-boot state.
 	// (POST /admin/reset-data)
 	ResetData(w http.ResponseWriter, r *http.Request)
 	// The governed tool surface (registry metadata) for the operator UI.
@@ -31321,7 +31321,7 @@ func (_ Unimplemented) GetJobHealth(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
-// Reset a non-production installation to its first-boot state.
+// Reset an installation that armed the capability to its first-boot state.
 // (POST /admin/reset-data)
 func (_ Unimplemented) ResetData(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNotImplemented)

--- a/backend/internal/modules/identity/handlers.go
+++ b/backend/internal/modules/identity/handlers.go
@@ -88,16 +88,16 @@ type Handlers struct {
 	// the correct default for any role that wired no overlay dispatch.
 	sorMode func(context.Context) (overlay bool, err error)
 
-	// nonProduction reports the deployment posture (MARGINCE_ENV), so /me
-	// can tell the client whether the destructive admin "Reset data"
-	// action is even reachable. Injected by the composition root from
+	// nonProduction reports the deployment posture (MARGINCE_ENV) on /me's
+	// deprecated non_production field. Injected by the composition root from
 	// runtimeenv.Environment.IsNonProduction() — identity never imports
-	// deployconfig or compose. False ⟹ production, the fail-closed
-	// default for any role that wired no posture (hides the action).
+	// deployconfig or compose. It gates nothing: what a client may DO is
+	// dataResetAvailable below.
 	nonProduction bool
 	// dataResetAvailable is operations.allow_data_reset — whether this
-	// installation armed the destructive reset at all. Distinct from the
-	// posture above: a dev deployment that never armed it offers nothing.
+	// installation armed the destructive reset at all. The same value the
+	// endpoint gates on, so an offered action and a served route agree. False
+	// is the fail-closed default for a role that wired nothing.
 	dataResetAvailable bool
 	// mcpResource is the canonical MCP server URL (public_base_url +
 	// "/mcp"), injected by the composition root from deployment config.

--- a/backend/internal/modules/identity/handlers.go
+++ b/backend/internal/modules/identity/handlers.go
@@ -95,6 +95,10 @@ type Handlers struct {
 	// deployconfig or compose. False ⟹ production, the fail-closed
 	// default for any role that wired no posture (hides the action).
 	nonProduction bool
+	// dataResetAvailable is operations.allow_data_reset — whether this
+	// installation armed the destructive reset at all. Distinct from the
+	// posture above: a dev deployment that never armed it offers nothing.
+	dataResetAvailable bool
 	// mcpResource is the canonical MCP server URL (public_base_url +
 	// "/mcp"), injected by the composition root from deployment config.
 	// The RFC 9728 protected-resource document advertises this verbatim
@@ -340,8 +344,9 @@ func (h Handlers) meResponse(
 		SystemOfRecord: &struct {
 			Mode crmcontracts.MeResponseSystemOfRecordMode `json:"mode"`
 		}{Mode: sorMode},
-		NonProduction:     h.nonProduction,
-		AdminPasswordLink: adminPasswordLink,
+		NonProduction:      h.nonProduction,
+		DataResetAvailable: &h.dataResetAvailable,
+		AdminPasswordLink:  adminPasswordLink,
 		Authorization: &crmcontracts.Authorization{
 			SeatType: contractSeatType(id.SeatType),
 			Objects:  contractObjectGrants(id.Permissions.Objects),

--- a/backend/internal/modules/identity/nonproduction.go
+++ b/backend/internal/modules/identity/nonproduction.go
@@ -5,9 +5,22 @@ package identity
 
 // WithNonProduction injects the deployment posture the composition root
 // resolves from runtimeenv.Environment. Without it /me reports production
-// (the fail-closed default: hide the destructive reset action rather than
-// risk exposing it under an unwired role).
+// (the fail-closed default).
 func (h Handlers) WithNonProduction(nonProduction bool) Handlers {
 	h.nonProduction = nonProduction
+	return h
+}
+
+// WithDataResetAvailable injects whether this installation armed the data
+// reset (operations.allow_data_reset). It is a SEPARATE fact from the posture,
+// because a deployment being non-production is not consent to purge its tenant
+// data — that is what the switch is for.
+//
+// It is the same value the endpoint gates on, so the action a client offers and
+// the route it would call cannot disagree. Without it /me reports unavailable,
+// the fail-closed default that hides the action rather than risk offering one
+// the server will refuse.
+func (h Handlers) WithDataResetAvailable(available bool) Handlers {
+	h.dataResetAvailable = available
 	return h
 }

--- a/backend/internal/modules/identity/nonproduction_test.go
+++ b/backend/internal/modules/identity/nonproduction_test.go
@@ -3,11 +3,12 @@
 
 package identity
 
-// /me reports the deployment posture so the client can hide the destructive
-// admin "Reset data" action outside a non-production role. This
-// proves the posture lands in the response and that the zero value (no
-// posture wired) degrades to production — never accidentally exposing the
-// action.
+// /me carries two facts that used to be one, and the split is the point: the
+// deployment POSTURE, and whether the destructive reset is ARMED. A deployment
+// being non-production is not consent to purge its tenant data.
+//
+// Both degrade closed when unwired, which is what keeps a role that forgot the
+// option from offering an action the server would refuse.
 
 import (
 	"testing"
@@ -33,5 +34,33 @@ func TestHandlersWithNonProductionDefaultsFalse(t *testing.T) {
 	h = h.WithNonProduction(true)
 	if !h.nonProduction {
 		t.Fatal("WithNonProduction(true) did not set the field")
+	}
+}
+
+func TestMeResponseCarriesTheDataResetSwitchSeparately(t *testing.T) {
+	id := Identity{Roles: []string{"admin"}}
+	// Non-production ALONE must not offer the action. This is the case that used
+	// to be conflated, and the one a staging installation lived in.
+	posture := NewHandlers(&Service{}).WithNonProduction(true).meResponse(id, crmcontracts.Native)
+	if posture.DataResetAvailable == nil || *posture.DataResetAvailable {
+		t.Fatal("a non-production installation that never armed the reset was offered it anyway")
+	}
+	armed := NewHandlers(&Service{}).WithDataResetAvailable(true).meResponse(id, crmcontracts.Native)
+	if armed.DataResetAvailable == nil || !*armed.DataResetAvailable {
+		t.Fatal("an armed installation was not offered the reset")
+	}
+	// And arming it says nothing about the posture: the two travel separately.
+	if armed.NonProduction {
+		t.Fatal("arming the reset changed the reported deployment posture")
+	}
+}
+
+func TestHandlersDefaultToNoDataReset(t *testing.T) {
+	var h Handlers
+	if h.dataResetAvailable {
+		t.Fatal("zero-value Handlers offered the destructive reset; the default must be closed")
+	}
+	if !h.WithDataResetAvailable(true).dataResetAvailable {
+		t.Fatal("WithDataResetAvailable(true) did not set the field")
 	}
 }

--- a/backend/internal/platform/deployconfig/deployconfig.go
+++ b/backend/internal/platform/deployconfig/deployconfig.go
@@ -39,6 +39,28 @@ type Config struct {
 	Capture        Capture         `yaml:"capture"`
 	CompanyContext CompanyContext  `yaml:"company_context"`
 	OverlayBudget  OverlayBudget   `yaml:"overlay_budget"`
+	Operations     Operations      `yaml:"operations"`
+}
+
+// Operations carries the ops kill switches (OPS-CFG-9): capabilities an
+// installation turns on deliberately, in the file layer, where the deployment
+// reviews them.
+//
+// Deliberately NOT `setting` rows. A setting is product configuration an
+// installation admin changes through the API at runtime; what lives here is
+// whether a destructive capability EXISTS for this deployment at all. An admin
+// who could switch that on through the API could switch on the purge of their
+// own tenant's data, which is precisely the authority the file layer is for.
+type Operations struct {
+	// AllowDataReset arms POST /v1/admin/reset-data, the two reset lanes that
+	// serve it, and the /me flag that offers the action in the UI.
+	//
+	// The zero value is false, which is the whole design: this used to be
+	// inferred from MARGINCE_ENV, so a deployment labelled `staging` — full of
+	// real internal users — could have its data purged because a label said it
+	// was not production. A capability that erases tenant data is stated, never
+	// inferred from what the deployment happens to be called.
+	AllowDataReset bool `yaml:"allow_data_reset"`
 }
 
 // CompanyContextRollout is the ordered deployment capability for company

--- a/backend/internal/platform/licensecheck/licensecheck_test.go
+++ b/backend/internal/platform/licensecheck/licensecheck_test.go
@@ -405,7 +405,7 @@ func TestIssuersNarrowToProductionUnlessTheDeploymentSaysOtherwise(t *testing.T)
 	if got := issuers(runtimeenv.Parse("prod-ish")); len(got) != 1 {
 		t.Errorf("an unrecognized posture honors %v; the fail-closed default is one authority", got)
 	}
-	for _, env := range []runtimeenv.Environment{runtimeenv.Development, runtimeenv.Staging, runtimeenv.Test} {
+	for _, env := range []runtimeenv.Environment{runtimeenv.Development, runtimeenv.Test} {
 		got := issuers(env)
 		if len(got) != 3 || got[0] != ProductionIssuer {
 			t.Errorf("%s honors %v, want production first and the two non-production authorities", env, got)

--- a/backend/internal/shared/runtimeenv/runtimeenv.go
+++ b/backend/internal/shared/runtimeenv/runtimeenv.go
@@ -2,9 +2,18 @@
 // SPDX-FileCopyrightText: 2026 Gradion
 
 // Package runtimeenv reads the deployment posture from MARGINCE_ENV. It is
-// fail-closed by construction: only an explicit, known non-production value
-// enables dev-only trust switches (today: the admin data-reset endpoint);
-// unset or anything unrecognized is Production, which disables them.
+// fail-closed by construction: unset or anything unrecognized is Production.
+//
+// The posture selects which LICENSE ISSUERS an installation honours — a
+// production one trusts only the production authority, so a token minted by the
+// test or dev licenser can never license a customer. That is the whole of what
+// it decides.
+//
+// It used to decide one more thing, and should not have: whether the admin
+// data-reset endpoint existed. Purging an installation's tenant data is not
+// something to infer from the name a deployment was given, so it is now stated
+// as operations.allow_data_reset in the deployment file, fail-closed in every
+// posture including dev.
 package runtimeenv
 
 // EnvVar names the variable this posture is read from. Exported so the
@@ -15,12 +24,16 @@ const EnvVar = "MARGINCE_ENV"
 // Environment is the deployment posture derived from MARGINCE_ENV.
 type Environment string
 
-// The recognized deployment postures. Only the non-production values enable
-// dev-only trust switches; every unrecognized value parses to Production.
+// The three recognized postures; every other value parses to Production.
+//
+// There is deliberately no `staging`. A staging installation carries real
+// internal users and real data, so treating it as non-production meant it
+// honoured dev-signed licenses — and, until operations.allow_data_reset, that
+// its data could be purged through the API. MARGINCE_ENV=staging now parses to
+// Production, which is the posture such an installation should always have had.
 const (
 	Production  Environment = "production"
 	Development Environment = "dev"
-	Staging     Environment = "staging"
 	Test        Environment = "test"
 )
 
@@ -30,8 +43,6 @@ func Parse(s string) Environment {
 	switch s {
 	case string(Development):
 		return Development
-	case string(Staging):
-		return Staging
 	case string(Test):
 		return Test
 	default:
@@ -39,7 +50,9 @@ func Parse(s string) Environment {
 	}
 }
 
-// IsNonProduction reports whether dev-only destructive switches may run.
+// IsNonProduction reports whether this installation may honour the dev and test
+// license authorities in addition to the production one. It gates nothing
+// destructive: see the package comment.
 func (e Environment) IsNonProduction() bool {
-	return e == Development || e == Staging || e == Test
+	return e == Development || e == Test
 }

--- a/backend/internal/shared/runtimeenv/runtimeenv.go
+++ b/backend/internal/shared/runtimeenv/runtimeenv.go
@@ -4,10 +4,11 @@
 // Package runtimeenv reads the deployment posture from MARGINCE_ENV. It is
 // fail-closed by construction: unset or anything unrecognized is Production.
 //
-// The posture selects which LICENSE ISSUERS an installation honours — a
-// production one trusts only the production authority, so a token minted by the
-// test or dev licenser can never license a customer. That is the whole of what
-// it decides.
+// What it decides is LICENSING, in two ways. Which issuers an installation
+// honours — a production one trusts only the production authority, so a token
+// minted by the test or dev licenser can never license a customer. And whether
+// running unlicensed is permitted at all: a production role refuses to boot
+// without a license, a non-production one does not.
 //
 // It used to decide one more thing, and should not have: whether the admin
 // data-reset endpoint existed. Purging an installation's tenant data is not
@@ -51,8 +52,9 @@ func Parse(s string) Environment {
 }
 
 // IsNonProduction reports whether this installation may honour the dev and test
-// license authorities in addition to the production one. It gates nothing
-// destructive: see the package comment.
+// license authorities in addition to the production one, and may run with no
+// license at all. Both consumers are in the licensing path; it gates nothing
+// destructive — see the package comment.
 func (e Environment) IsNonProduction() bool {
 	return e == Development || e == Test
 }

--- a/backend/internal/shared/runtimeenv/runtimeenv_test.go
+++ b/backend/internal/shared/runtimeenv/runtimeenv_test.go
@@ -6,14 +6,18 @@ package runtimeenv
 import "testing"
 
 func TestParseFailsClosed(t *testing.T) {
-	nonProd := map[string]Environment{"dev": Development, "staging": Staging, "test": Test}
+	nonProd := map[string]Environment{"dev": Development, "test": Test}
 	for in, want := range nonProd {
 		if got := Parse(in); got != want || !got.IsNonProduction() {
 			t.Fatalf("Parse(%q) = %q (nonProd=%v); want %q nonProd=true", in, got, got.IsNonProduction(), want)
 		}
 	}
 	// Anything not on the explicit non-prod allowlist collapses to Production.
-	for _, in := range []string{"", "production", "prod", "PROD", "Dev", "staging ", "qa", "🤷"} {
+	// "staging" is in this list on purpose. It used to parse to its own
+	// non-production posture, which meant an installation full of real internal
+	// users honoured dev-signed licenses — and, before the reset became an
+	// explicit switch, could have its data purged through the API.
+	for _, in := range []string{"", "production", "prod", "PROD", "Dev", "staging", "staging ", "qa", "🤷"} {
 		if got := Parse(in); got != Production || got.IsNonProduction() {
 			t.Fatalf("Parse(%q) = %q (nonProd=%v); want production, nonProd=false", in, got, got.IsNonProduction())
 		}

--- a/config/margince.example.yaml
+++ b/config/margince.example.yaml
@@ -163,3 +163,21 @@ mcp:
 # company data. Stages include the prior stage: off < read < tasks < onboarding.
 company_context:
   rollout: onboarding
+
+# Ops kill switches (OPS-CFG-9): capabilities this installation turns on
+# deliberately, in the file the deployment reviews. Omit the section entirely
+# and every switch is off, which is the intended posture for anything that
+# serves real users.
+operations:
+  # Arms POST /v1/admin/reset-data, the lanes behind it, and the "Reset data"
+  # action /me offers. It PURGES this installation's tenant data back to its
+  # first-boot state.
+  #
+  # Not derived from MARGINCE_ENV: a deployment being called dev or staging is
+  # not consent to erase what is in it. Not a `setting` row either — an admin
+  # must not be able to arm their own tenant's purge through the API.
+  #
+  # TRUE here because this file is the DEV configuration and a dev stack wants
+  # the button. A real deployment omits the whole section: the compiled default
+  # is false, so an installation that says nothing has no such endpoint.
+  allow_data_reset: true

--- a/config/margince.example.yaml
+++ b/config/margince.example.yaml
@@ -165,19 +165,20 @@ company_context:
   rollout: onboarding
 
 # Ops kill switches (OPS-CFG-9): capabilities this installation turns on
-# deliberately, in the file the deployment reviews. Omit the section entirely
-# and every switch is off, which is the intended posture for anything that
-# serves real users.
-operations:
-  # Arms POST /v1/admin/reset-data, the lanes behind it, and the "Reset data"
-  # action /me offers. It PURGES this installation's tenant data back to its
-  # first-boot state.
-  #
-  # Not derived from MARGINCE_ENV: a deployment being called dev or staging is
-  # not consent to erase what is in it. Not a `setting` row either — an admin
-  # must not be able to arm their own tenant's purge through the API.
-  #
-  # TRUE here because this file is the DEV configuration and a dev stack wants
-  # the button. A real deployment omits the whole section: the compiled default
-  # is false, so an installation that says nothing has no such endpoint.
-  allow_data_reset: true
+# deliberately, in the file the deployment reviews. The whole section is
+# COMMENTED OUT, and that is the shipped posture — every switch is off unless an
+# operator writes it, so a deployment that mounts this file as-is arms nothing.
+#
+# `make dev` appends the dev arming to its own copy (config/margince.yaml) when
+# it seeds it, which is why a dev stack has the Reset data button and this file
+# still does not.
+#
+# operations:
+#   # Arms POST /v1/admin/reset-data, the lanes behind it, and the "Reset data"
+#   # action /me offers. It PURGES this installation's tenant data back to its
+#   # first-boot state.
+#   #
+#   # Not derived from MARGINCE_ENV: a deployment being called dev or staging is
+#   # not consent to erase what is in it. Not a `setting` row either — an admin
+#   # must not be able to arm their own tenant's purge through the API.
+#   allow_data_reset: true

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -74,11 +74,15 @@ env template is [`.env.template`](../.env.template). The essentials:
 | `MARGINCE_AI_ROUTING` | api, worker | path to a mounted `ai-routing.yaml` — enables the AI lanes (plus the bound provider's BYOK key, e.g. `GEMINI_API_KEY`) |
 | `MARGINCE_PUBLIC_BASE_URL` | api, worker | canonical external base URL (buyer-facing links / marketing mail) |
 
-Do **not** set `MARGINCE_ENV=dev` in a deployed environment — it enables dev-only
-trust switches, and it is what lets an installation run with no license at all.
-A deployed installation needs a license: with none configured, `cmd/api` and
+Do **not** set `MARGINCE_ENV=dev` in a deployed environment. It decides two
+things about LICENSING and nothing else: which authorities are honoured
+(`dev`/`test` additionally accept our non-production licensers), and whether the
+installation may run unlicensed at all — with none configured, `cmd/api` and
 `cmd/worker` refuse to boot unless the environment says non-production (see
 [configuration.md](reference/configuration.md#license)).
+
+It no longer enables the data reset; that is `operations.allow_data_reset`,
+below.
 
 ### First-boot bootstrap config
 
@@ -86,7 +90,13 @@ On the first boot against an empty database the api bootstraps the organization 
 admin from the file `MARGINCE_CONFIG` points to. Mount your own `margince.yaml`
 (see [`config/margince.example.yaml`](../config/margince.example.yaml)) at that
 path and set `MARGINCE_ADMIN_PASSWORD`. A missing config file just boots an
-existing installation. Likewise mount an `ai-routing.yaml`
+existing installation.
+
+**The example ships with `operations:` commented out, and mounting it as-is
+keeps it that way.** Uncommenting `operations.allow_data_reset` arms
+`POST /v1/admin/reset-data`, which purges this installation's tenant data back
+to its first-boot state and renders the "Reset data" button to every admin seat.
+A deployed installation leaves it off. Likewise mount an `ai-routing.yaml`
 ([`config/ai-routing.example.yaml`](../config/ai-routing.example.yaml)) and point
 `MARGINCE_AI_ROUTING` at it to enable AI.
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -525,7 +525,7 @@ place keeps the api reading a password file that is no longer written. Use
 
 | Var | Used by | Meaning |
 |---|---|---|
-| `MARGINCE_ENV` | api (`runtimeenv.Parse`) | Read at boot and parsed **fail-closed**: only the exact values `dev`, `staging`, or `test` yield a non-production posture; unset, `production`, or any unrecognized value ⇒ production, which disables every dev-only destructive switch (today: the admin data-reset endpoint below). The Makefile exports `dev`; production must not set it. |
+| `MARGINCE_ENV` | api (`runtimeenv.Parse`) | Read at boot and parsed **fail-closed**: only the exact values `dev` or `test` yield a non-production posture; unset, `production`, `staging`, or any unrecognized value ⇒ production. It selects which **license issuers** the installation honours, and nothing else — no destructive capability keys off it. `staging` was retired deliberately: a staging installation carries real internal users, so it takes the production posture. The Makefile exports `dev`; production must not set it. |
 | `MARGINCE_TEST_DSN`, `MARGINCE_TEST_APP_DSN`, `MARGINCE_TEST_REDIS` | integration tests | owner DSN / app-role DSN / Redis address for the real-Postgres lane; exported by the Makefile. The lane runs on its own `_test` namespace (the `margince_test` DB, never the dev `margince` DB), so it can run alongside `make dev`. |
 | `MARGINCE_TEST_REDIS_DB` | integration tests | Redis logical db for the lane (default 15). db 0 is reserved for a running `make dev`; a valid value is 1..15, and the parallel runner assigns one per package so concurrent packages never share a stream. Out-of-range fails loudly. |
 | `MARGINCE_TEST_BLOBSTORE_ENDPOINT`, `MARGINCE_TEST_BLOBSTORE_ACCESS_KEY`, `MARGINCE_TEST_BLOBSTORE_SECRET_KEY`, `MARGINCE_TEST_BLOBSTORE_BUCKET` | integration tests | the object store the blobstore lane runs against; exported by the Makefile at the `make db-up` MinIO, on its own `margince-test` bucket. The endpoint being unset **fails** the lane rather than skipping it — a skipped storage gate reads exactly like a passing one. |
@@ -538,12 +538,27 @@ place keeps the api reading a password file that is no longer written. Use
 | `MARGINCE_SEED_PASSWORD` | `tools/seed-demo` | the password the demo seeder signs in with, so a credential never lands in a shell history or a make target. Equivalent to its `-password` flag. |
 | `MARGINCE_SEED_DSN` | `tools/seed-demo` | owner DSN for the two things the demo seeder cannot do over the API: create a team (read-only on the contract) and set a seat's password (no endpoint accepts one under 12 characters). Equivalent to its `-dsn` flag; unset skips both phases rather than failing, because the rest of the seed is useful without them. |
 
-### `POST /v1/admin/reset-data` — non-production data reset
+### `POST /v1/admin/reset-data` — the armed data reset
 
-Gated on the `MARGINCE_ENV` posture above. In production the operation does
-not exist: the environment check runs **before** auth, so a misconfigured
-production deployment 404s rather than leaking that the endpoint exists (never
-a 403). In a non-production posture:
+Gated on `operations.allow_data_reset` in `margince.yaml`, whose compiled
+default is **false in every posture, dev included**. An installation that did
+not arm it has no such operation: the switch is checked **before** auth, so a
+deployment that never asked for it 404s rather than leaking that the endpoint
+exists (never a 403).
+
+It is deliberately not a `setting` row and not inferred from `MARGINCE_ENV`.
+An admin who could arm it through the API could arm the purge of their own
+tenant's data; and a deployment labelled `staging` — real internal users, real
+records — is not thereby consenting to be wiped. The same value is what `/me`
+reports as `data_reset_available`, so a client never renders an action the
+server would refuse.
+
+```yaml
+operations:
+  allow_data_reset: true   # dev/test only; omit or false everywhere else
+```
+
+Once armed:
 
 1. **Human-only** (`auth.RequireHuman`) — an agent/passport principal is
    rejected, 403.
@@ -781,7 +796,7 @@ number an admin is refused against is the number the entitlement screen and
 exactly one: `margince-license-authority`. That is not redundant with the bundled
 keyset — our non-production licensers sign with keys that keyset carries, so the
 issuer is the only thing that keeps a license minted for a test from licensing a
-customer. An installation running with `MARGINCE_ENV` set to `dev`, `staging` or
+customer. An installation running with `MARGINCE_ENV` set to `dev` or
 `test` also honors `margince-license-authority-test` and
 `margince-license-authority-dev`, which is how a developer runs the product on a
 test license. `MARGINCE_ENV` is fail-closed: unset or unrecognized is production,

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -525,7 +525,7 @@ place keeps the api reading a password file that is no longer written. Use
 
 | Var | Used by | Meaning |
 |---|---|---|
-| `MARGINCE_ENV` | api (`runtimeenv.Parse`) | Read at boot and parsed **fail-closed**: only the exact values `dev` or `test` yield a non-production posture; unset, `production`, `staging`, or any unrecognized value ⇒ production. It selects which **license issuers** the installation honours, and nothing else — no destructive capability keys off it. `staging` was retired deliberately: a staging installation carries real internal users, so it takes the production posture. The Makefile exports `dev`; production must not set it. |
+| `MARGINCE_ENV` | api (`runtimeenv.Parse`) | Read at boot and parsed **fail-closed**: only the exact values `dev` or `test` yield a non-production posture; unset, `production`, `staging`, or any unrecognized value ⇒ production. It decides two **licensing** questions and nothing else: which issuers the installation honours, and whether it may run unlicensed at all (a production role refuses to boot with no license). No destructive capability keys off it. `staging` was retired deliberately: a staging installation carries real internal users, so it takes the production posture. The Makefile exports `dev`; production must not set it. |
 | `MARGINCE_TEST_DSN`, `MARGINCE_TEST_APP_DSN`, `MARGINCE_TEST_REDIS` | integration tests | owner DSN / app-role DSN / Redis address for the real-Postgres lane; exported by the Makefile. The lane runs on its own `_test` namespace (the `margince_test` DB, never the dev `margince` DB), so it can run alongside `make dev`. |
 | `MARGINCE_TEST_REDIS_DB` | integration tests | Redis logical db for the lane (default 15). db 0 is reserved for a running `make dev`; a valid value is 1..15, and the parallel runner assigns one per package so concurrent packages never share a stream. Out-of-range fails loudly. |
 | `MARGINCE_TEST_BLOBSTORE_ENDPOINT`, `MARGINCE_TEST_BLOBSTORE_ACCESS_KEY`, `MARGINCE_TEST_BLOBSTORE_SECRET_KEY`, `MARGINCE_TEST_BLOBSTORE_BUCKET` | integration tests | the object store the blobstore lane runs against; exported by the Makefile at the `make db-up` MinIO, on its own `margince-test` bucket. The endpoint being unset **fails** the lane rather than skipping it — a skipped storage gate reads exactly like a passing one. |
@@ -748,7 +748,7 @@ Three postures, and what each one does at boot:
 
 | posture | boot | reported as |
 |---|---|---|
-| **no token configured** | **refuses to boot in production**; boots with a warning when `MARGINCE_ENV` is `dev`, `staging` or `test` | `margince_license_posture{state="absent"} 1` |
+| **no token configured** | **refuses to boot in production**; boots with a warning when `MARGINCE_ENV` is `dev` or `test` | `margince_license_posture{state="absent"} 1` |
 | **token verified** | boots | `margince_license_posture{state="valid"} 1`, plus `margince_license_seats` when the license grants a seat count |
 | **token refused** | **refuses to boot** (api and worker alike), naming the module's own reason and the setting to correct | — |
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -689,8 +689,8 @@ object purge is the exception: it cannot join that transaction and so runs
 with the rows already wiped and some stored bytes still present. Re-running
 the reset is again the recovery.
 
-`GET /v1/me`'s `non_production` field mirrors the same posture so the SPA can
-show the action only where it will work: Admin settings → *data* tab → Danger
+`GET /v1/me`'s `data_reset_available` field carries the same switch the endpoint
+gates on, so the SPA shows the action only where it will work: Admin settings → *data* tab → Danger
 zone → *Reset data*, which prompts the operator to type the organization name
 before calling the endpoint — the server is the sole validator of that string,
 the client-side prompt is only UX.

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -14303,8 +14303,13 @@ export interface components {
             user: components["schemas"]["User"];
             /** @description The installation's organization name (the installation.name setting). Shown as the typed-confirmation target of the non-production "Reset data" action — the exact string that endpoint validates. */
             workspace_name: string;
-            /** @description True when the installation runs a non-production posture (MARGINCE_ENV). Gates the client-side "Reset data" action. */
+            /**
+             * @deprecated
+             * @description True when the installation runs a non-production posture (MARGINCE_ENV=dev|test). DEPRECATED as the gate for the "Reset data" action — read `data_reset_available` instead. A deployment being non-production is not consent to purge its tenant data, and inferring one from the other is why a `staging` installation full of real internal users could be wiped through the API.
+             */
             non_production: boolean;
+            /** @description True when this installation armed `operations.allow_data_reset` in its deployment file. It is the SAME value `POST /admin/reset-data` gates on, so a client never renders an action for a route that would answer 404. Absent or false means the capability does not exist here — the compiled default in every posture, dev included. */
+            data_reset_available?: boolean;
             /** @description Whether THIS CALLER may issue member set-password links (`issueUserPasswordLink`) — true only when the caller holds `admin` AND the installation has no outbound-email channel AND a public base URL is configured. Deliberately a caller capability rather than a deployment-posture flag: `/me` answers every authenticated member, and a bare posture boolean would tell every rep whether the installation has email configured. Clients render the action on this, so an admin never sees a control that can only fail (ADR-0061 Amendment 1). */
             admin_password_link: boolean;
             /** @description Effective role keys for this principal, and the one authority for them — `user.roles` is deliberately left unset here rather than repeating the same fact. */

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -187,8 +187,8 @@ export interface paths {
         get?: never;
         put?: never;
         /**
-         * Reset a non-production installation to its first-boot state.
-         * @description Non-production only. Wipes workspace domain + seeded-config data back to the bootstrapped state, preserving the organization and users so login still works, then re-seeds module defaults. Also clears the job queue, the event bus, the Redis counters and the object bytes — not only table rows. Requires the organization name as a typed confirmation. In production this endpoint does not exist (404).
+         * Reset an installation that armed the capability to its first-boot state.
+         * @description Served only where the deployment set `operations.allow_data_reset`; the compiled default is false in every posture. Wipes workspace domain + seeded-config data back to the bootstrapped state, preserving the organization and users so login still works, then re-seeds module defaults. Also clears the job queue, the event bus, the Redis counters and the object bytes — not only table rows. Requires the organization name as a typed confirmation. `GET /me` reports the same value as `data_reset_available`, so a client never offers what this would refuse.
          */
         post: operations["resetData"];
         delete?: never;
@@ -14301,7 +14301,7 @@ export interface components {
         };
         MeResponse: {
             user: components["schemas"]["User"];
-            /** @description The installation's organization name (the installation.name setting). Shown as the typed-confirmation target of the non-production "Reset data" action — the exact string that endpoint validates. */
+            /** @description The installation's organization name (the installation.name setting). Shown as the typed-confirmation target of the "Reset data" action — the exact string that endpoint validates. */
             workspace_name: string;
             /**
              * @deprecated
@@ -17794,7 +17794,7 @@ export interface operations {
                     "application/problem+json": components["schemas"]["Problem"];
                 };
             };
-            /** @description The endpoint is unavailable in this environment — production, or an unset/unknown MARGINCE_ENV. It is served only under a non-production posture; the body is the standard problem document. */
+            /** @description This installation did not arm `operations.allow_data_reset`, so the operation does not exist here. Checked before authentication, so it is a 404 rather than a 403 for every caller — the answer discloses nothing about who asked. The body is the standard problem document. */
             404: {
                 headers: {
                     [name: string]: unknown;

--- a/frontend/src/app/mefixture.ts
+++ b/frontend/src/app/mefixture.ts
@@ -64,6 +64,7 @@ export function meFixture({
     teams: [],
     workspace_name: "Test Workspace",
     non_production: false,
+    data_reset_available: false,
     admin_password_link: false,
     authorization: { seat_type: seat, objects },
   };

--- a/frontend/src/screens/settings.test.tsx
+++ b/frontend/src/screens/settings.test.tsx
@@ -1726,14 +1726,15 @@ const IDLE_JOB_HEALTH = {
 };
 
 // The danger-zone Reset data action: server-driven, gated on the literal admin
-// role AND me.non_production. A dedicated backend per test so the role/posture
-// combination is explicit rather than layered on the shared settingsBackend
+// role AND me.data_reset_available — the switch a deployment arms, not the
+// posture it happens to run under. A dedicated backend per test so the
+// role/capability combination is explicit rather than layered on the shared
 // default. `allow` defaults to the reindex write that opens the Maintenance
 // entry the card lives on — a test about the card should not also have to argue
 // its way onto the entry, and one that wants it CLOSED says so with `{}`.
 function resetDataBackend(opts: {
   roles: string[];
-  nonProduction: boolean;
+  dataResetAvailable: boolean;
   allow?: GrantSpec;
   onReset?: (body: unknown) => void;
   resetStatus?: number;
@@ -1753,7 +1754,7 @@ function resetDataBackend(opts: {
         ...me,
         user: { ...me.user, email: "ada@acme.test" },
         workspace_name: "Acme Inc",
-        non_production: opts.nonProduction,
+        data_reset_available: opts.dataResetAvailable,
       });
     }
     // The job report is the danger zone's neighbour on this entry, and an admin
@@ -1788,7 +1789,7 @@ describe("ResetDataCard (danger zone)", () => {
   it("shows the Reset data control for an admin in a non-production posture", async () => {
     vi.stubGlobal(
       "fetch",
-      resetDataBackend({ roles: ["admin"], nonProduction: true }),
+      resetDataBackend({ roles: ["admin"], dataResetAvailable: true }),
     );
     render(<SettingsScreen tab="maintenance" />);
     expect(await screen.findByText(/reset data/i)).toBeTruthy();
@@ -1797,7 +1798,7 @@ describe("ResetDataCard (danger zone)", () => {
   it("hides Reset data for an admin in a production posture", async () => {
     vi.stubGlobal(
       "fetch",
-      resetDataBackend({ roles: ["admin"], nonProduction: false }),
+      resetDataBackend({ roles: ["admin"], dataResetAvailable: false }),
     );
     render(<SettingsScreen tab="maintenance" />);
     // The job report is the entry's own card, so its heading proves Maintenance
@@ -1815,7 +1816,7 @@ describe("ResetDataCard (danger zone)", () => {
       "fetch",
       // A rep is no admin and holds no embedding_reindex grant, so Maintenance
       // is not theirs to reach in the first place.
-      resetDataBackend({ roles: ["rep"], nonProduction: true, allow: {} }),
+      resetDataBackend({ roles: ["rep"], dataResetAvailable: true, allow: {} }),
     );
     render(<SettingsScreen tab="maintenance" />);
     // With no member grant, the rep falls back to Account — proven here by
@@ -1832,7 +1833,7 @@ describe("ResetDataCard (danger zone)", () => {
   it("reaches Maintenance as ops but never sees Reset data", async () => {
     vi.stubGlobal(
       "fetch",
-      resetDataBackend({ roles: ["ops"], nonProduction: true }),
+      resetDataBackend({ roles: ["ops"], dataResetAvailable: true }),
     );
     render(<SettingsScreen tab="maintenance" />);
     await waitFor(() =>
@@ -1849,7 +1850,7 @@ describe("ResetDataCard (danger zone)", () => {
       "fetch",
       resetDataBackend({
         roles: ["admin"],
-        nonProduction: true,
+        dataResetAvailable: true,
         onReset: (body) => posted.push(body),
       }),
     );
@@ -1882,7 +1883,7 @@ describe("ResetDataCard (danger zone)", () => {
       "fetch",
       resetDataBackend({
         roles: ["admin"],
-        nonProduction: true,
+        dataResetAvailable: true,
         resetStatus: 422,
         resetBody: {
           detail:
@@ -1920,14 +1921,14 @@ describe("ResetDataCard (danger zone)", () => {
     drain_timed_out: false,
   };
 
-  // Fixed precondition for every summary test below: admin + non_production,
+  // Fixed precondition for every summary test below: admin + the armed reset,
   // on the Maintenance entry that hosts the card.
   function renderSettingsAsAdmin(opts: { resetResponse: unknown }) {
     vi.stubGlobal(
       "fetch",
       resetDataBackend({
         roles: ["admin"],
-        nonProduction: true,
+        dataResetAvailable: true,
         resetBody: opts.resetResponse,
       }),
     );
@@ -2012,7 +2013,7 @@ describe("ResetDataCard (danger zone)", () => {
           return jsonResponse({
             ...me,
             workspace_name: "Acme Inc",
-            non_production: true,
+            data_reset_available: true,
           });
         }
         if (url.includes("/admin/job-health")) {
@@ -2079,7 +2080,7 @@ function mergedEntryBackend(opts: {
   roles: string[];
   seat?: "full" | "read";
   allow?: GrantSpec;
-  nonProduction?: boolean;
+  dataResetAvailable?: boolean;
 }) {
   return vi.fn(async (input: RequestInfo | URL) => {
     const url = String(input instanceof Request ? input.url : input);
@@ -2092,7 +2093,7 @@ function mergedEntryBackend(opts: {
       return jsonResponse({
         ...me,
         workspace_name: "Acme Inc",
-        non_production: opts.nonProduction ?? false,
+        data_reset_available: opts.dataResetAvailable ?? false,
       });
     }
     if (url.includes("/passports")) {
@@ -2260,7 +2261,7 @@ describe("SettingsScreen restructured entries", () => {
         allow: { embedding_reindex: ["read", "update"] },
         // The posture the danger zone's second gate asks for, so the ROLE is
         // the only thing left holding it back below.
-        nonProduction: true,
+        dataResetAvailable: true,
       }),
     );
     renderSettings("maintenance");

--- a/frontend/src/screens/settings.test.tsx
+++ b/frontend/src/screens/settings.test.tsx
@@ -1786,7 +1786,7 @@ function resetDataBackend(opts: {
 }
 
 describe("ResetDataCard (danger zone)", () => {
-  it("shows the Reset data control for an admin in a non-production posture", async () => {
+  it("shows the Reset data control for an admin where the reset is armed", async () => {
     vi.stubGlobal(
       "fetch",
       resetDataBackend({ roles: ["admin"], dataResetAvailable: true }),
@@ -1795,7 +1795,7 @@ describe("ResetDataCard (danger zone)", () => {
     expect(await screen.findByText(/reset data/i)).toBeTruthy();
   });
 
-  it("hides Reset data for an admin in a production posture", async () => {
+  it("hides Reset data for an admin where the reset was never armed", async () => {
     vi.stubGlobal(
       "fetch",
       resetDataBackend({ roles: ["admin"], dataResetAvailable: false }),
@@ -1811,7 +1811,7 @@ describe("ResetDataCard (danger zone)", () => {
     expect(screen.queryByText(/reset data/i)).toBeNull();
   });
 
-  it("hides Reset data from a rep even in a non-production posture", async () => {
+  it("hides Reset data from a rep even where the reset is armed", async () => {
     vi.stubGlobal(
       "fetch",
       // A rep is no admin and holds no embedding_reindex grant, so Maintenance
@@ -2259,7 +2259,7 @@ describe("SettingsScreen restructured entries", () => {
       mergedEntryBackend({
         roles: ["rep"],
         allow: { embedding_reindex: ["read", "update"] },
-        // The posture the danger zone's second gate asks for, so the ROLE is
+        // The switch the danger zone's second gate asks for, so the ROLE is
         // the only thing left holding it back below.
         dataResetAvailable: true,
       }),

--- a/frontend/src/screens/settings.tsx
+++ b/frontend/src/screens/settings.tsx
@@ -1310,13 +1310,16 @@ function ToolRow({
   );
 }
 
-// The danger-zone reset action: wipes a non-production installation back to
-// its first-boot state. Double-gated client-side — the admin role AND the
-// server-driven `non_production` posture on /me (never VITE_UI_PREVIEW_RESET,
-// which is the unrelated password-reset link) — so the affordance is invisible
-// on a production install even to an admin; the server enforces both the
-// same way and 404s the endpoint outright in production regardless of what
-// this card renders. This is admin-ONLY, and narrower than the Maintenance entry
+// The danger-zone reset action: wipes the installation back to its first-boot
+// state. Double-gated client-side — the admin role AND the server-driven
+// `data_reset_available` flag on /me (never VITE_UI_PREVIEW_RESET, which is the
+// unrelated password-reset link) — so the affordance is invisible unless the
+// deployment armed the capability; the server gates the endpoint on that same
+// value and 404s it otherwise, regardless of what this card renders.
+//
+// Not `non_production`: a deployment being non-production is not consent to
+// purge its tenant data, and reading one as the other is why a `staging`
+// installation full of real internal users could be wiped through the API. This is admin-ONLY, and narrower than the Maintenance entry
 // that hosts it — that entry opens on the embedding_reindex read, so an ops seat
 // reaches it for the search index and simply finds no reset control. The
 // server's auth.RequireAdmin on /admin/reset-data admits only the literal
@@ -1369,7 +1372,7 @@ function ResetDataCard() {
     },
   });
 
-  if (!isAdmin || !me.data?.non_production) {
+  if (!isAdmin || !me.data?.data_reset_available) {
     return null;
   }
 

--- a/frontend/src/screens/settings.tsx
+++ b/frontend/src/screens/settings.tsx
@@ -1317,9 +1317,7 @@ function ToolRow({
 // deployment armed the capability; the server gates the endpoint on that same
 // value and 404s it otherwise, regardless of what this card renders.
 //
-// Not `non_production`: a deployment being non-production is not consent to
-// purge its tenant data, and reading one as the other is why a `staging`
-// installation full of real internal users could be wiped through the API. This is admin-ONLY, and narrower than the Maintenance entry
+// This is admin-ONLY, and narrower than the Maintenance entry
 // that hosts it — that entry opens on the embedding_reindex read, so an ops seat
 // reaches it for the search index and simply finds no reset control. The
 // server's auth.RequireAdmin on /admin/reset-data admits only the literal

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -464,7 +464,20 @@ up)
   fi
   if [[ ! -f "$deploy_cfg" ]]; then
     cp config/margince.example.yaml "$deploy_cfg"
-    echo "dev: seeded $deploy_cfg from config/margince.example.yaml — edit it to change org/admin or AI posture (e.g. ai.capture_payloads)"
+    # The destructive switch is armed HERE, not in the example, because the
+    # example is the file a deployment is told to mount. A production
+    # installation that copied it verbatim must not thereby arm a purge of its
+    # own tenant data — which is the same "inferred consent" this switch exists
+    # to end, and it would be worse in a file than in an env var operators are
+    # warned about.
+    cat >>"$deploy_cfg" <<'DEVOPS'
+
+# Added by `make dev` — a dev stack wants the Reset data button. Delete this to
+# take it away; a real deployment never has it.
+operations:
+  allow_data_reset: true
+DEVOPS
+    echo "dev: seeded $deploy_cfg from config/margince.example.yaml (+ operations.allow_data_reset for dev) — edit it to change org/admin or AI posture (e.g. ai.capture_payloads)"
   fi
   # Report which deployment config the api + worker are using, and its AI
   # posture — mirrors the ai-routing line above so both configs are visible.


### PR DESCRIPTION
Increment 5 of #1252. Carries the live security issue in that ticket.

## The problem

`MARGINCE_ENV` was doing two unrelated jobs, and the destructive one was **inferred from a deployment's name**. `runtimeenv` recognised `staging` as non-production, and `IsNonProduction()` armed `POST /v1/admin/reset-data`. An installation full of real internal users could have its tenant data purged through the API because of the label it ran under.

## The fix

`operations.allow_data_reset` decides it, in the file layer where the deployment reviews it (OPS-CFG-9). **Compiled default false in every posture, dev included** — the capability is stated or it does not exist.

One read serves all four paths, so the button a client renders and the route it would call cannot disagree:

| path | gate |
|---|---|
| `POST /v1/admin/reset-data` | `dataResetHandlers.allowed`, checked **before auth** → 404, never 403 |
| api reset lane | `newResetLane(allowed, …)` — an unarmed process holds no queue-pausing machinery at all |
| worker flush subscriber | `startResetLane(ctx, allowed, …)` — no unasked-for bus subscriber |
| `/me` | `data_reset_available` |

Deliberately **not** a `setting` row: an admin who could arm it through the API could arm the purge of their own tenant's data.

## `staging` is retired

`MARGINCE_ENV` recognises `dev`, `test`, `production`; anything else parses to production. A staging installation carries real users and real data, so that is the posture it should always have had.

## A correction to the ticket

#1252 says a sweep finds `IsNonProduction()` gates the reset **"and nothing else"**. It does not — `licensecheck.issuers()` reads it to decide which license authorities an installation honours. So `runtimeenv` is **not** retired here as the ticket proposed; it keeps that one job.

That makes the consequence of retiring `staging` real, and worth stating plainly: such an installation now honours only the production issuer, so one running on a dev-signed license **will refuse to boot** rather than silently accept it. The failure is loud and names the authority.

## The `/me` field

Added `data_reset_available`; `non_production` is **deprecated as the gate**, not removed. An added optional field rather than a rename, because `contract-breaking-check` blocks breaking changes and its allowlist is for ratified spec re-syncs — the removal belongs with the spec change. `non_production` keeps meaning exactly what it says: the posture, which is now a licensing question and not a destructive one.

## Verification

All four paths mutation-proven closed. **Two tests did not survive the first pass** and are fixed:

- the endpoint's own refusal was untested — only its *wiring* was, so deleting `!h.allowed` from `ResetData` left the suite green;
- the worker's case could fail only by panicking, which `craft static` caught as `assertion-free-test`. It now drives `loadDeployment` and asserts the switch crosses from the file into the worker's config, including the unstated case.

`make check-backend` · `craft-static` (3 roots, 0 findings) · `make fe-quality` · `make test-integration` — *OK: integration passed with 0 skips (41 packages)*.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make tenant-data purge an explicit deployment capability. Previously the reset was inferred from `MARGINCE_ENV` non‑production (including `staging`); now it exists only when `operations.allow_data_reset: true`. Unarmed installs 404 the endpoint before auth. `staging` now parses to production; `MARGINCE_ENV` only affects licensing (issuers and unlicensed boot).

- One read of the switch gates the HTTP route, the API reset lane, the worker’s flush subscriber, and `/v1/me.data_reset_available`. `compose.WithDataReset(schemaPool, seeds, allowed)` replaces the env‑based signature; new `compose.WithDataResetAvailable(allowed)` surfaces the same flag on `/me`. `compose.WithNonProduction(env)` now carries posture only. API and worker both log “data reset” armed status at boot.
- `/me` adds `data_reset_available` and deprecates `non_production` as the UI gate; the frontend now renders Reset Data only when `data_reset_available` is true.
- Runtime env: only `dev` and `test` are non‑production; `staging` parses to production. Posture still gates license issuers and whether unlicensed boot is allowed.
- Config/docs: `config/margince.example.yaml` ships `operations:` commented out; `scripts/dev.sh` appends `operations.allow_data_reset: true` to the dev copy. `.env.template`, OpenAPI, and docs updated to reflect the switch and `staging` retirement.
- Tests: new worker test asserts the switch is read from the deployment file; the e2e reset runs armed under the production posture; unit/integration tests updated accordingly.

**Rollout**
- Set `operations.allow_data_reset: true` in dev/test stacks that should expose Reset Data; omit or set `false` in production.
- Stop using `MARGINCE_ENV=staging`. Treat staging as production and use a production license.
- Update clients to gate Reset Data on `/me.data_reset_available`.
- Ensure API and worker read the same deployment file; verify “data reset armed” logs match.

<sup>Written for commit ea5b3f97e9e6783508445da2759fe5a000f6e221. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1511?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a dedicated data-reset availability indicator to account information.
  - The Settings reset action now reflects the server’s explicit capability setting.

- **Bug Fixes**
  - Data reset is now consistently enabled or disabled across the Settings action and reset endpoint.
  - Reset access is disabled by default unless explicitly configured.

- **Documentation**
  - Clarified that deployment environment posture and data-reset availability are separate settings.
  - Staging environments are treated as production environments for safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->