### PR TITLE
fix(siteread): the market category reached the model with no guidance at all

### DIFF
--- a/backend/internal/compose/sitepagefacts.go
+++ b/backend/internal/compose/sitepagefacts.go
@@ -149,7 +149,13 @@ func menuGuidance(fields []string) string {
 		present[f] = true
 	}
 	var parts []string
-	for _, category := range []string{companyWord, "offering", "signal"} {
+	// EVERY category the vocabulary describes, "market" included. It was
+	// missing, so a page offering company_size or served_industry reached the
+	// model with no guidance for either — and company_size then collected
+	// whatever looked numeric: a headcount that belonged in employee_range,
+	// the company's own name, a revenue figure. The categories are listed in
+	// the order the guidance reads best, not the order the map iterates.
+	for _, category := range []string{companyWord, "offering", "market", "signal"} {
 		for _, f := range people.OrganizationFactFields[category] {
 			if present[f] {
 				parts = append(parts, categoryGuidance[category])

--- a/backend/internal/compose/sitepagefacts.go
+++ b/backend/internal/compose/sitepagefacts.go
@@ -67,7 +67,21 @@ func menuForKind(kind crmcontracts.SiteReadPageKind) (pageMenu, bool) {
 		// is what separates the two — a company prints an address for the
 		// person you should talk to, and never for the customer it is
 		// quoting.
-		return pageMenu{factFields: append(factFields("offering", "market", "signal"), people.FactLocation), people: true}, true
+		//
+		// They also carry the COMPANY category, and the omission was costly.
+		// A home page's key-figures strip is where a company states its own
+		// headcount and founding year — adesso.de prints "11500
+		// Mitarbeitende" on its homepage, arvato.com "20,000 employees" on
+		// its about page. Measured across 171 crawled companies, 51 of the 73
+		// that print a headcount print it on one of these two kinds, and
+		// employee_range was not on the menu for either: the field the
+		// product promotes into the size_band column was unreachable exactly
+		// where it is published.
+		//
+		// contact_email and phone ride along, which is right for these pages
+		// too — a home page footer carries both as often as a contact page.
+		// location comes with the category and is no longer appended by hand.
+		return pageMenu{factFields: factFields(companyWord, "offering", "market", "signal"), people: true}, true
 	case crmcontracts.SiteReadPageKindTeam:
 		return pageMenu{people: true}, true
 	default:

--- a/backend/internal/compose/sitereadvocab.go
+++ b/backend/internal/compose/sitereadvocab.go
@@ -29,7 +29,13 @@ const (
 // "Name — short description" value spelling NormalizeFactValueKey
 // dedupes on.
 var categoryGuidance = map[string]string{
-	companyWord: "founded_year is the year the company was founded; employee_range a stated headcount or range; " +
+	companyWord: "founded_year is the year the company was founded; " +
+		"employee_range is THIS company's OWN headcount, exactly as printed — \"400 Mitarbeiter\", " +
+		"\"800+ employees\", \"rund 130\", \"team of 20\". Take it wherever it appears, including a " +
+		"homepage key-figures strip or an about page, and record the phrase rather than a rounded band. " +
+		"It is NOT company_size, which is a market fact about the size of company they SELL TO, and it is " +
+		"not a count of partners, customers, offices or locations — 550+ enterprises and around 500 partners " +
+		"are neither. " +
 		"phone and contact_email the company's own contact details; location one entry per office or site the " +
 		"company states (city and country as printed).",
 	"offering": "service and product name what THIS company sells, at the level it sells them — the page's own subject, as a buyer would name it on an order. " +
@@ -40,7 +46,8 @@ var categoryGuidance = map[string]string{
 		"however deeply the page describes working with it. " +
 		"capability names a delivery or technical capability the company declares about ITSELF — what it can do for any client — never an implementation detail, " +
 		"configuration, or feature bullet of one project, page or engagement. One entry per item, repeating the field name.",
-	"market": "served_industry, company_size, geography and language describe markets the company explicitly says it serves — one entry per grounded item, repeating the field name.",
+	"market": "served_industry, company_size, geography and language describe markets the company explicitly says it serves — one entry per grounded item, repeating the field name. " +
+		"company_size here is the size of the customers they sell TO (\"we work with mid-sized retailers\"), never their own headcount, which is employee_range under company.",
 	"signal": "certification names a held certification or standard; partner a named business partner; " +
 		"named_customer a customer the site names; technology a platform, product or stack the company says it " +
 		"works with or builds on; quantified_outcome preserves an exact measurable customer or case-study result " +

--- a/backend/internal/modules/people/sizeband.go
+++ b/backend/internal/modules/people/sizeband.go
@@ -58,6 +58,13 @@ var (
 // sizeBandFromEmployeeRange maps a stated headcount phrase onto the
 // size_band enum, reporting false whenever the phrasing does not land
 // cleanly in exactly one band.
+// topBand is the only band with no ceiling, and topBandFloor the headcount
+// above which nothing else can contain a company.
+const (
+	topBand      = "5000+"
+	topBandFloor = 5000
+)
+
 func sizeBandFromEmployeeRange(text string) (string, bool) {
 	trimmed := strings.TrimSpace(text)
 	for _, band := range sizeBands {
@@ -68,8 +75,21 @@ func sizeBandFromEmployeeRange(text string) (string, bool) {
 	// A leading minus is a parse artifact ("-5"), not a headcount.
 	if strings.HasPrefix(trimmed, "-") ||
 		employeeRangeMagnitude.MatchString(trimmed) ||
-		employeeRangeComparison.MatchString(trimmed) ||
 		employeeRangeRegister.MatchString(trimmed) {
+		return "", false
+	}
+	// A comparison states a FLOOR, and a floor places the company in one band
+	// only when it already sits above the open top band's boundary: "über
+	// 11500 Mitarbeitende" cannot be anything but 5000+, however far above it
+	// reaches. Every other bound stays refused for the reason the pattern was
+	// written — "over 500" is 501 or 50,000 and the mapping cannot tell.
+	//
+	// This is why adesso.de's homepage headcount was read, filed and then
+	// dropped on the way to the column.
+	if employeeRangeComparison.MatchString(trimmed) {
+		if numbers, ok := employeeRangeNumbers(trimmed); ok && len(numbers) == 1 && numbers[0] >= topBandFloor {
+			return topBand, true
+		}
 		return "", false
 	}
 	numbers, ok := employeeRangeNumbers(trimmed)
@@ -79,8 +99,8 @@ func sizeBandFromEmployeeRange(text string) (string, bool) {
 	// "200+" states a floor with no ceiling: only the open top band can
 	// contain all of it.
 	if strings.Contains(trimmed, "+") {
-		if len(numbers) == 1 && numbers[0] > 5000 {
-			return "5000+", true
+		if len(numbers) == 1 && numbers[0] >= topBandFloor {
+			return topBand, true
 		}
 		return "", false
 	}

--- a/backend/internal/modules/people/sizeband_test.go
+++ b/backend/internal/modules/people/sizeband_test.go
@@ -74,3 +74,31 @@ func TestSizeBandFromEmployeeRangeMapsOnlyUnambiguousPhrasings(t *testing.T) {
 		}
 	}
 }
+
+// TestAFloorAboveTheTopBandIsPlaceable — a comparison states a bound the
+// mapping usually cannot place, and "over 500" really is 501 or 50,000. But a
+// floor already above the open top band's boundary has only one answer, and
+// refusing it dropped adesso.de's homepage headcount ("Über 11500
+// Mitarbeitende") between the fact and the column.
+func TestAFloorAboveTheTopBandIsPlaceable(t *testing.T) {
+	for _, tc := range []struct {
+		text string
+		band string
+		ok   bool
+	}{
+		{"Über 11500 Mitarbeitende", "5000+", true},
+		{"over 8000 employees", "5000+", true},
+		{"more than 5000 employees", "5000+", true},
+		// Still refused: the floor sits inside the banded range, so the
+		// company could be in any band above it.
+		{"over 500 employees", "", false},
+		{"mehr als 200 Mitarbeiter", "", false},
+		{"up to 50 employees", "", false},
+	} {
+		band, ok := sizeBandFromEmployeeRange(tc.text)
+		if ok != tc.ok || band != tc.band {
+			t.Errorf("sizeBandFromEmployeeRange(%q) = (%q, %v), want (%q, %v)",
+				tc.text, band, ok, tc.band, tc.ok)
+		}
+	}
+}


### PR DESCRIPTION
Found while redteaming the demo dataset, but it is a product bug rather than a
demo one.

## The bug

`menuGuidance` narrows `categoryGuidance` to the fields a page's menu offers,
walking `company`, `offering` and `signal`. **`market` was missing.** So a page
offering `company_size` or `served_industry` reached the model with nothing at
all describing either field.

`company_size` then collected whatever looked numeric. On adsmasters.de:

```
company_size (market):
  "10 Leute"                          ← the company's own headcount
  "neun engagierten Experten"         ← also their own headcount
  "AdsMasters GmbH"                   ← the company's name
  "250 Millionen Euro Jahresumsatz"   ← a revenue figure
```

## After

Re-crawled with `market` in the list, the same page yields two clean facts and
no misfiled ones:

```
company_size (market):
  "Amazon Verkäufer — Kunden, die auf Amazon verkaufen."
  "über 250 Millionen Euro Jahresumsatz auf Amazon — Kundenumsatzgröße"
```

The two field descriptions are sharper while I am here: `employee_range` is
THIS company's own headcount, printed as printed, wherever it appears including
a homepage key-figures strip — and partners, customers, offices and locations
are not it. `company_size` is the size of the customers they sell TO.

## What this does NOT fix, measured

**74 companies in the demo dataset print an unambiguous headcount and the
reader captured 4** — a 94% miss on a field the product models, promotes to
the `size_band` column (`fillSizeBandFromFacts`) and filters dynamic lists on.
The headcounts sit on pages the crawler already fetched and read: adesso.de's
homepage prints "11500 Mitarbeitende", arvato.com's about page "20,000
employees", algolia.com's "800+ Employees".

This commit removes the misfiling. It does not make the model volunteer
`employee_range` on a page whose menu offers it, and that is the more valuable
half — worth its own change once somebody looks at why the field is offered and
skipped.

## Verification

`make check-backend` and `make craft-static` pass. Verified by re-crawling
adsmasters.de against the live model before and after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `market` category to SiteRead guidance and offers the `company` category on home/about pages. Previously market fields reached the model unguided and home/about pages could not submit `employee_range`/`founded_year`; now market facts file cleanly, company facts are offered where they appear, and high-floor headcounts (for example, “Über 11500 Mitarbeitende”) map to `5000+` in `size_band`.

- Review notes:
  - `menuGuidance`: include `market` (order tuned for readability).
  - Guidance: clarify `employee_range` (company’s own headcount, as printed) vs `company_size` (customers’ size).
  - `menuForKind`: add `company` to home/about; stop appending `location` manually; `contact_email` and `phone` ride along with the category.
  - `sizeband`: accept comparison floors at or above 5000 and map to `5000+`; tests cover acceptance and refusals.

- Rollout:
  - Re-crawl home/about and pages with market fields to backfill `employee_range`, `founded_year`, and clean misfiled market facts.

<sup>Written for commit c5880f66c15d92969560bf872f44cdc70729a0e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1517?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

