### PR TITLE
fix(company360): a collected citation row starts at the paragraph's left edge

### DIFF
--- a/frontend/src/screens/company360.css
+++ b/frontend/src/screens/company360.css
@@ -283,6 +283,15 @@
   color: var(--textMeta);
 }
 
+/* Collected citations START their own row under the prose instead of trailing a
+   sentence, so they drop the inline gap that separates a chip from the words
+   before it. Kept, it indents the first chip against the paragraph above it,
+   and two left edges that nearly agree read as a mistake rather than a
+   hierarchy. */
+.co-brief-sources > .co-brief-cites {
+  margin-inline-start: 0;
+}
+
 /* "Worth doing next": the overview's lead panel. The tint that makes it read
    as the one card asking for a move is Panel's own tone="accent" now — this
    class no longer reaches into .panel-head or .panel-foot, and what is left of


### PR DESCRIPTION
Citations gathered under a brief section start their own row rather than trailing a sentence, so they drop the inline gap that separates a chip from the words before it. Kept, it indented the first chip against the prose above it, and two left edges that nearly agree read as a mistake rather than as a hierarchy.

Same rule the lead panel's move citations already carry (`.co-lead .co-move-cites > .co-brief-cites`), applied to the brief's collected sources row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the brief’s collected citations row with the paragraph’s leading edge by removing its inline-start margin. Previously, the first citation chip was indented like trailing inline content; now the row starts flush with the prose block, clarifying hierarchy.

- Scope: affects `.co-brief-sources > .co-brief-cites` only; inline citations and the lead panel remain unchanged.
- Direction: `margin-inline-start: 0` aligns to the paragraph’s leading edge in both LTR and RTL.
- QA: in brief sections with collected sources, chips should start flush with the prose block with no leading gap.

<sup>Written for commit b06f839d4e5c9a4f9be379a4cc6615673280c2c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1519?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

