### PR TITLE
refactor(ai,migration): the AI trace and the importer drop the tenant column (ADR-0091 §8 phase D)

### DIFF
--- a/backend/internal/compose/costestimate/estimator_integration_test.go
+++ b/backend/internal/compose/costestimate/estimator_integration_test.go
@@ -173,13 +173,13 @@ type callRow struct {
 // insertCall seeds one served ai_call row (occurred_at inWindow, no cache hit).
 // errorSentinel defaults to NULL; set it to 'metering_failed' to seed a call the
 // model served (tokens spent) whose only failure was the meter write.
-func (e *estEnv) insertCall(t *testing.T, ws ids.UUID, c callRow) {
+func (e *estEnv) insertCall(t *testing.T, c callRow) {
 	t.Helper()
 	if _, err := e.owner.Exec(context.Background(), `
-		INSERT INTO ai_call (workspace_id, task, tier, provider, model_id, request_fingerprint,
+		INSERT INTO ai_call (task, tier, provider, model_id, request_fingerprint,
 		  tokens_in, tokens_out, cached_tokens, cache_write_tokens, cache_hit, occurred_at, logical_call_id, error_sentinel)
-		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,false,$11,$12,NULLIF($13,''))`,
-		ws, string(c.task), string(c.tier), c.provider, c.model, "fp-"+ids.NewV7().String(),
+		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,false,$10,$11,NULLIF($12,''))`,
+		string(c.task), string(c.tier), c.provider, c.model, "fp-"+ids.NewV7().String(),
 		c.tokensIn, c.tokensOut, c.cachedTokens, c.cacheWriteTokens, inWindow, ids.NewV7(), c.errorSentinel); err != nil {
 		t.Fatalf("insert call %+v: %v", c, err)
 	}
@@ -198,13 +198,13 @@ func (e *estEnv) insertLabeledActivity(t *testing.T, ws ids.UUID) {
 
 // insertRate seeds one ai_model_rate for a fake-provider model (every fixture
 // here rates the offline fake router's bindings, so the provider is fixed).
-func (e *estEnv) insertRate(t *testing.T, ws ids.UUID, model string, in, out int64) {
+func (e *estEnv) insertRate(t *testing.T, model string, in, out int64) {
 	t.Helper()
 	if _, err := e.owner.Exec(context.Background(), `
-		INSERT INTO ai_model_rate (workspace_id, provider, model_id, input_per_mtok_microusd,
+		INSERT INTO ai_model_rate (provider, model_id, input_per_mtok_microusd,
 		  output_per_mtok_microusd, cache_read_per_mtok_microusd, cache_write_per_mtok_microusd, effective_date)
-		VALUES ($1,$2,$3,$4,$5,0,0,$6)`,
-		ws, ai.ProviderFake, model, in, out, rateDay); err != nil {
+		VALUES ($1,$2,$3,$4,0,0,$5)`,
+		ai.ProviderFake, model, in, out, rateDay); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -225,14 +225,14 @@ func TestEstimatorPricesObservedHistory(t *testing.T) {
 	e.seedBackfill(t, connID, 6, 100, 80, 10, 2)
 
 	// Rates: cloud + embed priced, local a real $0.
-	e.insertRate(t, ws, "cloud-model", 1_000_000, 2_000_000)
-	e.insertRate(t, ws, "embed-model", 500_000, 0)
-	e.insertRate(t, ws, "local-model", 0, 0)
+	e.insertRate(t, "cloud-model", 1_000_000, 2_000_000)
+	e.insertRate(t, "embed-model", 500_000, 0)
+	e.insertRate(t, "local-model", 0, 0)
 
 	// One served slice per task (Calls=1 each), plus four labeled messages.
-	e.insertCall(t, ws, callRow{task: ai.TaskCaptureClassify, tier: ai.TierCheapCloud, provider: ai.ProviderFake, model: "cloud-model", tokensIn: 2_000_000, tokensOut: 200_000})
-	e.insertCall(t, ws, callRow{task: ai.TaskEnrich, tier: ai.TierLocalSmall, provider: ai.ProviderFake, model: "local-model", tokensIn: 500_000, tokensOut: 50_000})
-	e.insertCall(t, ws, callRow{task: ai.TaskEmbeddings, tier: ai.TierEmbedLane, provider: ai.ProviderFake, model: "embed-model", tokensIn: 1_000_000})
+	e.insertCall(t, callRow{task: ai.TaskCaptureClassify, tier: ai.TierCheapCloud, provider: ai.ProviderFake, model: "cloud-model", tokensIn: 2_000_000, tokensOut: 200_000})
+	e.insertCall(t, callRow{task: ai.TaskEnrich, tier: ai.TierLocalSmall, provider: ai.ProviderFake, model: "local-model", tokensIn: 500_000, tokensOut: 50_000})
+	e.insertCall(t, callRow{task: ai.TaskEmbeddings, tier: ai.TierEmbedLane, provider: ai.ProviderFake, model: "embed-model", tokensIn: 1_000_000})
 	for i := 0; i < 4; i++ {
 		e.insertLabeledActivity(t, ws)
 	}
@@ -280,13 +280,13 @@ func TestEstimatorEnrichFloorsWhenPeopleCreatedZero(t *testing.T) {
 	connID := e.seedConnection(t, user, "gmail")
 	e.seedBackfill(t, connID, 6, 100, 80, 0, 0) // people/orgs 0: the run minted no counterparty
 
-	e.insertRate(t, ws, "cloud-model", 1_000_000, 2_000_000)
-	e.insertRate(t, ws, "embed-model", 500_000, 0)
-	e.insertRate(t, ws, "local-model", 1_000_000, 0) // enrich floor prices at the local head
+	e.insertRate(t, "cloud-model", 1_000_000, 2_000_000)
+	e.insertRate(t, "embed-model", 500_000, 0)
+	e.insertRate(t, "local-model", 1_000_000, 0) // enrich floor prices at the local head
 
-	e.insertCall(t, ws, callRow{task: ai.TaskCaptureClassify, tier: ai.TierCheapCloud, provider: ai.ProviderFake, model: "cloud-model", tokensIn: 2_000_000, tokensOut: 200_000})
-	e.insertCall(t, ws, callRow{task: ai.TaskEnrich, tier: ai.TierLocalSmall, provider: ai.ProviderFake, model: "local-model", tokensIn: 500_000, tokensOut: 50_000})
-	e.insertCall(t, ws, callRow{task: ai.TaskEmbeddings, tier: ai.TierEmbedLane, provider: ai.ProviderFake, model: "embed-model", tokensIn: 1_000_000})
+	e.insertCall(t, callRow{task: ai.TaskCaptureClassify, tier: ai.TierCheapCloud, provider: ai.ProviderFake, model: "cloud-model", tokensIn: 2_000_000, tokensOut: 200_000})
+	e.insertCall(t, callRow{task: ai.TaskEnrich, tier: ai.TierLocalSmall, provider: ai.ProviderFake, model: "local-model", tokensIn: 500_000, tokensOut: 50_000})
+	e.insertCall(t, callRow{task: ai.TaskEmbeddings, tier: ai.TierEmbedLane, provider: ai.ProviderFake, model: "embed-model", tokensIn: 1_000_000})
 	for i := 0; i < 4; i++ {
 		e.insertLabeledActivity(t, ws)
 	}
@@ -322,10 +322,10 @@ func TestEstimatorExcludesRatelessModelAndFlagsHeuristic(t *testing.T) {
 	e.seedBackfill(t, connID, 6, 100, 100, 0, 0)
 
 	// local-model priced; cloud-model deliberately UNrated.
-	e.insertRate(t, ws, "local-model", 1_000_000, 0)
+	e.insertRate(t, "local-model", 1_000_000, 0)
 
-	e.insertCall(t, ws, callRow{task: ai.TaskCaptureClassify, tier: ai.TierLocalSmall, provider: ai.ProviderFake, model: "local-model", tokensIn: 1_000_000, tokensOut: 0})
-	e.insertCall(t, ws, callRow{task: ai.TaskCaptureClassify, tier: ai.TierCheapCloud, provider: ai.ProviderFake, model: "cloud-model", tokensIn: 4_000_000, tokensOut: 0})
+	e.insertCall(t, callRow{task: ai.TaskCaptureClassify, tier: ai.TierLocalSmall, provider: ai.ProviderFake, model: "local-model", tokensIn: 1_000_000, tokensOut: 0})
+	e.insertCall(t, callRow{task: ai.TaskCaptureClassify, tier: ai.TierCheapCloud, provider: ai.ProviderFake, model: "cloud-model", tokensIn: 4_000_000, tokensOut: 0})
 	for i := 0; i < 2; i++ {
 		e.insertLabeledActivity(t, ws)
 	}
@@ -366,8 +366,8 @@ func TestEstimatorCountsMeteringFailedRows(t *testing.T) {
 	connID := e.seedConnection(t, user, "gmail")
 	e.seedBackfill(t, connID, 6, 100, 100, 0, 0)
 
-	e.insertRate(t, ws, "cloud-model", 1_000_000, 0)
-	e.insertCall(t, ws, callRow{task: ai.TaskCaptureClassify, tier: ai.TierCheapCloud, provider: ai.ProviderFake, model: "cloud-model", tokensIn: 2_000_000, tokensOut: 0, errorSentinel: "metering_failed"})
+	e.insertRate(t, "cloud-model", 1_000_000, 0)
+	e.insertCall(t, callRow{task: ai.TaskCaptureClassify, tier: ai.TierCheapCloud, provider: ai.ProviderFake, model: "cloud-model", tokensIn: 2_000_000, tokensOut: 0, errorSentinel: "metering_failed"})
 	e.insertLabeledActivity(t, ws)
 
 	got, err := e.newEstimator(ws).EstimateBackfill(wsCtx, "gmail", user, 100)
@@ -403,13 +403,13 @@ func TestEstimatorEnrichMeteringFailedRetryDoesNotInflateDenominator(t *testing.
 
 	// ONLY cloud-model is rated: enrich (served on cheap_cloud) prices; classify's
 	// and embeddings' floor heads (local-model, embed-model) stay unrated → $0.
-	e.insertRate(t, ws, "cloud-model", 1_000_000, 0)
+	e.insertRate(t, "cloud-model", 1_000_000, 0)
 
 	// One clean enrich call + one metering_failed retry, same (tier, provider,
 	// model) so they group into a single slice: TokensIn=1_000_000, Calls=2,
 	// CompletedCalls=1.
-	e.insertCall(t, ws, callRow{task: ai.TaskEnrich, tier: ai.TierCheapCloud, provider: ai.ProviderFake, model: "cloud-model", tokensIn: 500_000, tokensOut: 0})
-	e.insertCall(t, ws, callRow{task: ai.TaskEnrich, tier: ai.TierCheapCloud, provider: ai.ProviderFake, model: "cloud-model", tokensIn: 500_000, tokensOut: 0, errorSentinel: "metering_failed"})
+	e.insertCall(t, callRow{task: ai.TaskEnrich, tier: ai.TierCheapCloud, provider: ai.ProviderFake, model: "cloud-model", tokensIn: 500_000, tokensOut: 0})
+	e.insertCall(t, callRow{task: ai.TaskEnrich, tier: ai.TierCheapCloud, provider: ai.ProviderFake, model: "cloud-model", tokensIn: 500_000, tokensOut: 0, errorSentinel: "metering_failed"})
 
 	got, err := e.newEstimator(ws).EstimateBackfill(wsCtx, "gmail", user, 100)
 	if err != nil {
@@ -440,9 +440,9 @@ func TestEstimatorRepricesSinceUnboundSlice(t *testing.T) {
 
 	// The router binds cheap_cloud → cloud-model (rated) and local → local-model
 	// ($0). The served slice ran on old-cloud-model, now departed.
-	e.insertRate(t, ws, "cloud-model", 1_000_000, 0)
-	e.insertRate(t, ws, "local-model", 0, 0)
-	e.insertCall(t, ws, callRow{task: ai.TaskCaptureClassify, tier: ai.TierCheapCloud, provider: ai.ProviderFake, model: "old-cloud-model", tokensIn: 2_000_000, tokensOut: 0})
+	e.insertRate(t, "cloud-model", 1_000_000, 0)
+	e.insertRate(t, "local-model", 0, 0)
+	e.insertCall(t, callRow{task: ai.TaskCaptureClassify, tier: ai.TierCheapCloud, provider: ai.ProviderFake, model: "old-cloud-model", tokensIn: 2_000_000, tokensOut: 0})
 	e.insertLabeledActivity(t, ws)
 
 	got, err := e.newEstimator(ws).EstimateBackfill(wsCtx, "gmail", user, 100)
@@ -468,7 +468,7 @@ func TestEstimatorNoHistoryUsesFloor(t *testing.T) {
 	user := e.seedUser(t, ws)
 	e.seedConnection(t, user, "gmail")
 	// Rate the floor's classify head (local-model) so the floor prices honestly.
-	e.insertRate(t, ws, "local-model", 1_000_000, 0)
+	e.insertRate(t, "local-model", 1_000_000, 0)
 
 	got, err := e.newEstimator(ws).EstimateBackfill(wsCtx, "gmail", user, 100)
 	if err != nil {
@@ -494,7 +494,7 @@ func TestEstimatorConnectionScopedYields(t *testing.T) {
 	e.seedBackfill(t, gmailConn, 12, 1000, 900, 200, 50) // a rich yield on gmail
 	e.seedConnection(t, user, "imap")                    // imap has NO completed run
 
-	e.insertRate(t, ws, "local-model", 1_000_000, 0)
+	e.insertRate(t, "local-model", 1_000_000, 0)
 
 	est := e.newEstimator(ws)
 	imap, err := est.EstimateBackfill(wsCtx, "imap", user, 100)

--- a/backend/internal/compose/flipreconcile.go
+++ b/backend/internal/compose/flipreconcile.go
@@ -96,8 +96,7 @@ func (w *flipWriters) orphanedIdentities(ctx context.Context, object string) ([]
 			SELECT n.id, right(n.source, -length($1::text)) AS external_id
 			FROM %s n
 			LEFT JOIN import_record_map m
-			  ON m.workspace_id = n.workspace_id
-			 AND m.source_system = $2
+			  ON m.source_system = $2
 			 AND m.object = $3
 			 AND m.external_id = right(n.source, -length($1::text))
 			-- Scoped to the workspace this run imports into. Tenant isolation

--- a/backend/internal/compose/integration/ai_call_integration_test.go
+++ b/backend/internal/compose/integration/ai_call_integration_test.go
@@ -237,9 +237,8 @@ func TestEnsureConfigIsIdempotentAndFKsFromAICall(t *testing.T) {
 func seedEmbedCall(t *testing.T, e *Env, daysBack int) ids.UUID {
 	t.Helper()
 	callID := ids.NewV7()
-	wsClause := `NULLIF(current_setting('app.workspace_id', true), '')::uuid`
-	e.WsExec(t, `INSERT INTO ai_call (id, workspace_id, logical_call_id, task, tier, kind, request_fingerprint, occurred_at)
-		VALUES ($1, `+wsClause+`, $1, 'embeddings', 'embed', 'embedding', 'fp-embed', now() - make_interval(days => $2))`,
+	e.WsExec(t, `INSERT INTO ai_call (id, logical_call_id, task, tier, kind, request_fingerprint, occurred_at)
+		VALUES ($1, $1, 'embeddings', 'embed', 'embedding', 'fp-embed', now() - make_interval(days => $2))`,
 		callID, daysBack)
 	return callID
 }
@@ -273,12 +272,11 @@ func TestEmbedCallRetentionAgesOutOverAgeEmbeddingRows(t *testing.T) {
 func seedAgedPayload(t *testing.T, e *Env, daysBack int, requestJSON string) ids.UUID {
 	t.Helper()
 	callID := ids.NewV7()
-	wsClause := `NULLIF(current_setting('app.workspace_id', true), '')::uuid`
-	e.WsExec(t, `INSERT INTO ai_call (id, workspace_id, logical_call_id, task, request_fingerprint, occurred_at)
-		VALUES ($1, `+wsClause+`, $1, 'summarize', 'fp-aged', now() - make_interval(days => $2))`,
+	e.WsExec(t, `INSERT INTO ai_call (id, logical_call_id, task, request_fingerprint, occurred_at)
+		VALUES ($1, $1, 'summarize', 'fp-aged', now() - make_interval(days => $2))`,
 		callID, daysBack)
-	e.WsExec(t, `INSERT INTO ai_call_payload (workspace_id, ai_call_id, request_payload, response_payload, occurred_at)
-		VALUES (`+wsClause+`, $1, $2::jsonb, '{}'::jsonb, now() - make_interval(days => $3))`,
+	e.WsExec(t, `INSERT INTO ai_call_payload (ai_call_id, request_payload, response_payload, occurred_at)
+		VALUES ($1, $2::jsonb, '{}'::jsonb, now() - make_interval(days => $3))`,
 		callID, requestJSON, daysBack)
 	return callID
 }

--- a/backend/internal/compose/integration/aicalls_integration_test.go
+++ b/backend/internal/compose/integration/aicalls_integration_test.go
@@ -34,21 +34,21 @@ func seedAiCallTrace(t *testing.T, e *apptest.AppEnv) seededAiCalls {
 	logical := ids.NewV7()
 	base := time.Date(2026, 7, 20, 10, 0, 0, 0, time.UTC)
 	insert := `INSERT INTO ai_call (
-		id, workspace_id, task, tier, provider, model_id, request_fingerprint,
+		id, task, tier, provider, model_id, request_fingerprint,
 		tokens_in, tokens_out, latency_ms, error_sentinel, logical_call_id,
 		attempt, is_terminal, attempt_reason, served_model, occurred_at)
-		VALUES ($1,$2,$3,'cheap_cloud','gemini','gemini-2.5-flash',$4,$5,$6,$7,$8,$9,$10,$11,$12,'gemini-2.5-flash',$13)`
-	if _, err := e.Owner.Exec(context.Background(), insert, retry, workspaceID,
+		VALUES ($1,$2,'cheap_cloud','gemini','gemini-2.5-flash',$3,$4,$5,$6,$7,$8,$9,$10,$11,'gemini-2.5-flash',$12)`
+	if _, err := e.Owner.Exec(context.Background(), insert, retry,
 		"capture_classify", "retry", 100, 0, 400, "provider_unavailable", logical,
 		1, false, "", base.Add(-time.Minute)); err != nil {
 		t.Fatalf("seed retry: %v", err)
 	}
-	if _, err := e.Owner.Exec(context.Background(), insert, newest, workspaceID,
+	if _, err := e.Owner.Exec(context.Background(), insert, newest,
 		"capture_classify", "terminal", 100, 20, 900, nil, logical,
 		2, true, "retry_on_5xx", base); err != nil {
 		t.Fatalf("seed terminal: %v", err)
 	}
-	if _, err := e.Owner.Exec(context.Background(), insert, older, workspaceID,
+	if _, err := e.Owner.Exec(context.Background(), insert, older,
 		"enrich", "older", 40, 8, 120, nil, older,
 		1, true, "", base.Add(-2*time.Hour)); err != nil {
 		t.Fatalf("seed older call: %v", err)
@@ -56,14 +56,14 @@ func seedAiCallTrace(t *testing.T, e *apptest.AppEnv) seededAiCalls {
 	// A task whose ONLY row is non-terminal (an in-flight first attempt) must
 	// never reach the trace filter's task set — the list is terminal-only, so
 	// the option would filter to an empty page.
-	if _, err := e.Owner.Exec(context.Background(), insert, ids.NewV7(), workspaceID,
+	if _, err := e.Owner.Exec(context.Background(), insert, ids.NewV7(),
 		"draft_reply", "inflight", 10, 0, 50, "provider_unavailable", ids.NewV7(),
 		1, false, "", base.Add(-3*time.Hour)); err != nil {
 		t.Fatalf("seed non-terminal-only call: %v", err)
 	}
 	if _, err := e.Owner.Exec(context.Background(), `
-		INSERT INTO ai_call_payload (workspace_id, ai_call_id, request_payload, response_payload)
-		VALUES ($1, $2, $3, $4)`, workspaceID, newest,
+		INSERT INTO ai_call_payload (ai_call_id, request_payload, response_payload)
+		VALUES ($1, $2, $3)`, newest,
 		`{"system":"classify safely","messages":[{"role":"user","content":"hello"}]}`,
 		`"commitment"`); err != nil {
 		t.Fatalf("seed payload: %v", err)

--- a/backend/internal/compose/integration/aiusage_http_integration_test.go
+++ b/backend/internal/compose/integration/aiusage_http_integration_test.go
@@ -41,10 +41,10 @@ func seedAiUsage(t *testing.T, e *apptest.AppEnv) {
 		t.Fatalf("set guc: %v", err)
 	}
 	if _, err := tx.Exec(ctx, `
-		INSERT INTO ai_usage (workspace_id, day, task, tier, calls, cached_hits, tokens_in, tokens_out) VALUES
-		($1, '2026-07-10', 'capture_classify', 'local_small', 4, 1, 1200, 300),
-		($1, '2026-07-10', 'capture_classify', 'cheap_cloud', 1, 0, 800, 200),
-		($1, '2026-07-11', 'enrich', 'cheap_cloud', 2, 0, 500, 120),
+		INSERT INTO ai_usage (day, task, tier, calls, cached_hits, tokens_in, tokens_out) VALUES
+		('2026-07-10', 'capture_classify', 'local_small', 4, 1, 1200, 300),
+		('2026-07-10', 'capture_classify', 'cheap_cloud', 1, 0, 800, 200),
+		('2026-07-11', 'enrich', 'cheap_cloud', 2, 0, 500, 120),
 		-- One row in the LIVE budget period, and it is not decoration. The day
 		-- report is scoped by the from/to query; the BUDGET block is not — it
 		-- reports what has been spent in the current period whatever the
@@ -52,7 +52,7 @@ func seedAiUsage(t *testing.T, e *apptest.AppEnv) {
 		-- read zero the moment the month turned: this test passed for exactly
 		-- as long as it was July 2026 and broke on the 1st, on every branch at
 		-- once. Anchored to the clock so it cannot expire again.
-		($1, current_date, 'capture_classify', 'local_small', 1, 0, 900, 200)`, wsID); err != nil {
+		(current_date, 'capture_classify', 'local_small', 1, 0, 900, 200)`); err != nil {
 		t.Fatalf("seeding ai_usage: %v", err)
 	}
 	if err := tx.Commit(ctx); err != nil {
@@ -137,10 +137,10 @@ func TestAiUsageOverHTTP(t *testing.T) {
 func seedAiCall(t *testing.T, e *apptest.AppEnv, wsID string, task, tier, provider, model string, tokensIn, tokensOut int, occurredAt time.Time) {
 	t.Helper()
 	if _, err := e.Owner.Exec(context.Background(), `
-		INSERT INTO ai_call (workspace_id, task, tier, provider, model_id, request_fingerprint,
+		INSERT INTO ai_call (task, tier, provider, model_id, request_fingerprint,
 		  tokens_in, tokens_out, occurred_at, logical_call_id)
-		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)`,
-		wsID, task, tier, provider, model, "fp-"+ids.NewV7().String(),
+		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)`,
+		task, tier, provider, model, "fp-"+ids.NewV7().String(),
 		tokensIn, tokensOut, occurredAt, ids.NewV7()); err != nil {
 		t.Fatalf("insert ai_call: %v", err)
 	}
@@ -150,10 +150,10 @@ func seedAiCall(t *testing.T, e *apptest.AppEnv, wsID string, task, tier, provid
 func seedAiModelRate(t *testing.T, e *apptest.AppEnv, wsID string, day time.Time) {
 	t.Helper()
 	if _, err := e.Owner.Exec(context.Background(), `
-		INSERT INTO ai_model_rate (workspace_id, provider, model_id, input_per_mtok_microusd,
+		INSERT INTO ai_model_rate (provider, model_id, input_per_mtok_microusd,
 		  output_per_mtok_microusd, cache_read_per_mtok_microusd, cache_write_per_mtok_microusd, effective_date)
-		VALUES ($1,'anthropic','claude-test-model',5000000,25000000,500000,6250000,$2)`,
-		wsID, day); err != nil {
+		VALUES ('anthropic','claude-test-model',5000000,25000000,500000,6250000,$1)`,
+		day); err != nil {
 		t.Fatalf("insert ai_model_rate: %v", err)
 	}
 }

--- a/backend/internal/compose/integration/installation_integration_test.go
+++ b/backend/internal/compose/integration/installation_integration_test.go
@@ -194,7 +194,7 @@ func TestBootstrapSeedsTheAiModelRatePriceSheet(t *testing.T) {
 	}
 
 	var total int
-	if err := e.Owner.QueryRow(ctx, `SELECT count(*) FROM ai_model_rate WHERE workspace_id = $1`, wsID).Scan(&total); err != nil {
+	if err := e.Owner.QueryRow(ctx, `SELECT count(*) FROM ai_model_rate`).Scan(&total); err != nil {
 		t.Fatal(err)
 	}
 	want := len(ai.SeedModelRates(time.Now().UTC()))
@@ -202,15 +202,6 @@ func TestBootstrapSeedsTheAiModelRatePriceSheet(t *testing.T) {
 		t.Fatalf("ai_model_rate rows for the bootstrapped workspace = %d, want %d (len(SeedModelRates))", total, want)
 	}
 
-	// Every seeded row belongs to the ONE workspace the bootstrap created
-	// — no cross-tenant leakage from a missing/blank workspace_id.
-	var other int
-	if err := e.Owner.QueryRow(ctx, `SELECT count(*) FROM ai_model_rate WHERE workspace_id != $1`, wsID).Scan(&other); err != nil {
-		t.Fatal(err)
-	}
-	if other != 0 {
-		t.Fatalf("ai_model_rate carries %d rows outside the bootstrapped workspace, want 0", other)
-	}
 }
 
 // TestBootBindsWithoutReadingASpentBootstrapSecret is the restart an operator

--- a/backend/internal/compose/integration/overlay/overlay_cutover_lifecycle_integration_test.go
+++ b/backend/internal/compose/integration/overlay/overlay_cutover_lifecycle_integration_test.go
@@ -249,6 +249,17 @@ func seedCleanWorkspace(t *testing.T, f flipEstate) context.Context {
 			t.Fatalf("retiring the source estate's %s rows before the rebuild: %v", table, err)
 		}
 	}
+	// The identity ledger goes with the estate, for the same reason and by the
+	// same rule: since ADR-0091 §8 phase D it is keyed on the INCUMBENT's
+	// identity — (source_system, object, external_id) — so a mapping the
+	// retired estate wrote still names `d-won`, and the rebuild would adopt a
+	// deal that no longer exists. The map before the runs it references: the
+	// foreign key points that way.
+	for _, table := range []string{"import_record_map", "import_run"} {
+		if _, err := f.e.Owner.Exec(ctx, "DELETE FROM "+table); err != nil {
+			t.Fatalf("retiring the source estate's %s rows before the rebuild: %v", table, err)
+		}
+	}
 	cleanCtx := flipAdminCtx(ws, user.UUID)
 	if err := deals.NewHandlers(database.BindTo(f.pool, ids.From[ids.WorkspaceKind](ws)), compose.DealsInstallation()).SeedWorkspaceDefaults(cleanCtx); err != nil {
 		t.Fatalf("seeding the clean workspace's default pipeline: %v", err)

--- a/backend/internal/compose/integration/retention_authoring_integration_test.go
+++ b/backend/internal/compose/integration/retention_authoring_integration_test.go
@@ -404,9 +404,8 @@ func TestBootstrapTakesItsRetentionPostureFromTheDeploymentConfiguration(t *test
 func seedEmbedCallWithPayload(t *testing.T, e *Env, daysBack int, embeddedText string) ids.UUID {
 	t.Helper()
 	callID := seedEmbedCall(t, e, daysBack)
-	wsClause := `NULLIF(current_setting('app.workspace_id', true), '')::uuid`
-	e.WsExec(t, `INSERT INTO ai_call_payload (workspace_id, ai_call_id, request_payload, response_payload, occurred_at)
-		VALUES (`+wsClause+`, $1, jsonb_build_object('inputs', jsonb_build_array($2::text)), '{}'::jsonb,
+	e.WsExec(t, `INSERT INTO ai_call_payload (ai_call_id, request_payload, response_payload, occurred_at)
+		VALUES ($1, jsonb_build_object('inputs', jsonb_build_array($2::text)), '{}'::jsonb,
 		        now() - make_interval(days => $3))`,
 		callID, embeddedText, daysBack)
 	return callID

--- a/backend/internal/compose/onboardingsitereadmessage_integration_test.go
+++ b/backend/internal/compose/onboardingsitereadmessage_integration_test.go
@@ -27,15 +27,15 @@ func TestCompanySiteReadMessageUsesTheStoredDossierAndReturnsRuntime(t *testing.
 	read := onboardingDraft(t, env)
 	usedAt := time.Date(2026, 7, 22, 8, 0, 0, 0, time.UTC)
 	env.WsExec(t, `
-		INSERT INTO ai_model_rate (workspace_id, provider, model_id, input_per_mtok_microusd,
+		INSERT INTO ai_model_rate (provider, model_id, input_per_mtok_microusd,
 		  output_per_mtok_microusd, cache_read_per_mtok_microusd, cache_write_per_mtok_microusd, effective_date)
-		VALUES ($1,'anthropic','claude-workbench-test',1000000,5000000,500000,2000000,$2)`, env.WS, usedAt)
+		VALUES ('anthropic','claude-workbench-test',1000000,5000000,500000,2000000,$1)`, usedAt)
 	env.WsExec(t, `
-		INSERT INTO ai_call (workspace_id, correlation_id, task, tier, provider, model_id,
+		INSERT INTO ai_call (correlation_id, task, tier, provider, model_id,
 		  served_model, served_identity_source, request_fingerprint, tokens_in, tokens_out, reasoning_tokens,
 		  cached_tokens, cache_write_tokens, latency_ms, occurred_at, logical_call_id)
-		VALUES ($1,$2,$3,$4,'anthropic','claude-workbench-test','claude-workbench-test-202607','response',$5,
-		  1000,100,20,200,50,750,$6,$7)`, env.WS, read.ID, string(ai.TaskColdStart),
+		VALUES ($1,$2,$3,'anthropic','claude-workbench-test','claude-workbench-test-202607','response',$4,
+		  1000,100,20,200,50,750,$5,$6)`, read.ID, string(ai.TaskColdStart),
 		string(ai.TierCheapCloud), "workbench-fingerprint", usedAt, read.ID)
 	human := env.As(env.Rep1, nil, integration.AdminPerms)
 	brain := &replyBrainStub{response: model.Response{Text: `{

--- a/backend/internal/modules/ai/callstats.go
+++ b/backend/internal/modules/ai/callstats.go
@@ -64,8 +64,7 @@ func (s *CallReadStore) ServedTaskTotals(ctx context.Context, tasks []Task, sinc
 		       sum(tokens_out), count(*),
 		       count(*) FILTER (WHERE error_sentinel IS NULL)
 		FROM ai_call
-		WHERE workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid
-		      AND occurred_at >= $1 AND NOT cache_hit
+		WHERE occurred_at >= $1 AND NOT cache_hit
 		      AND (error_sentinel IS NULL OR error_sentinel = 'metering_failed')
 		      AND tokens_in > 0 AND task = ANY($2)
 		GROUP BY task, tier, provider, model_id`

--- a/backend/internal/modules/ai/callstore.go
+++ b/backend/internal/modules/ai/callstore.go
@@ -193,15 +193,14 @@ func (m *CallMeter) Record(ctx context.Context, attempts []Call) error {
 			err := tx.QueryRow(
 				ctx, `
 				INSERT INTO ai_call (
-				  workspace_id, correlation_id, task, tier, provider, model_id,
+				  correlation_id, task, tier, provider, model_id,
 				  request_fingerprint, context_scopes, context_fingerprint,
 				  context_bytes, context_tokens_estimate,
 				  tokens_in, tokens_out, reasoning_tokens,
 				  cached_tokens, cache_write_tokens, latency_ms, cache_hit, degraded, error_sentinel, agent_run_id,
 				  logical_call_id, attempt, is_terminal, attempt_reason, kind,
 				  served_model, served_identity_source, cache_off, config_hash)
-				VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid,
-				  $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,NULLIF($19,''),$20,
+				VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,NULLIF($19,''),$20,
 				  $21,$22,$23,$24,$25,$26,$27,$28,$29)
 				RETURNING id`,
 				c.CorrelationID, string(c.Task), string(c.Tier), c.Provider, c.ModelID,
@@ -218,8 +217,8 @@ func (m *CallMeter) Record(ctx context.Context, attempts []Call) error {
 				continue
 			}
 			_, err = tx.Exec(ctx, `
-				INSERT INTO ai_call_payload (workspace_id, ai_call_id, request_payload, response_payload)
-				VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, $2, $3)`,
+				INSERT INTO ai_call_payload (ai_call_id, request_payload, response_payload)
+				VALUES ($1, $2, $3)`,
 				callID, c.Payload.Request, c.Payload.Response)
 			if err != nil {
 				return fmt.Errorf("ai: recording call payload: %w", err)
@@ -232,7 +231,7 @@ func (m *CallMeter) Record(ctx context.Context, attempts []Call) error {
 // EnsureConfig plants snap's row in ai_call_config if it does not already
 // exist.
 func (m *CallMeter) EnsureConfig(ctx context.Context, snap ConfigSnapshot) error {
-	// rls-exempt: ai_call_config is a global config-snapshot dimension (spec §4) — no workspace_id, no RLS policy, so this write must not ride the per-workspace GUC transaction.
+	// rls-exempt: ai_call_config is a global config-snapshot dimension (spec §4) — no RLS policy, so this write must not ride the per-workspace GUC transaction.
 	_, err := m.db.Pool().Exec(ctx, `
 		INSERT INTO ai_call_config (hash, task_contract_hash, routing_config_hash, prompt_version, provider_params)
 		VALUES ($1, $2, $3, $4, $5)

--- a/backend/internal/modules/ai/feedback.go
+++ b/backend/internal/modules/ai/feedback.go
@@ -215,10 +215,9 @@ func upsertVerdict(ctx context.Context, tx pgx.Tx, in RecordInput, key, captured
 	var id ids.UUID
 	if err := tx.QueryRow(ctx, `
 		INSERT INTO ai_feedback
-		  (workspace_id, subject_type, subject_id, claim_kind, claim_key,
+		  (subject_type, subject_id, claim_kind, claim_key,
 		   verdict, corrected_value, note, source, captured_by)
-		VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid,
-		        $1, $2, $3, $4, $5, $6, $7, 'human', $8)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, 'human', $8)
 		ON CONFLICT (subject_type, subject_id, claim_kind, claim_key)
 		DO UPDATE SET verdict = EXCLUDED.verdict,
 		              corrected_value = EXCLUDED.corrected_value,

--- a/backend/internal/modules/ai/meter.go
+++ b/backend/internal/modules/ai/meter.go
@@ -65,8 +65,8 @@ func (m *Meter) Record(ctx context.Context, u Usage) error {
 	}
 	return m.db.Tx(ctx, func(tx pgx.Tx) error {
 		_, err := tx.Exec(ctx, `
-			INSERT INTO ai_usage (workspace_id, day, task, tier, calls, cached_hits, tokens_in, tokens_out, reasoning_tokens, cached_tokens, cache_write_tokens)
-			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, $2, $3, 1, $4, $5, $6, $7, $8, $9)
+			INSERT INTO ai_usage (day, task, tier, calls, cached_hits, tokens_in, tokens_out, reasoning_tokens, cached_tokens, cache_write_tokens)
+			VALUES ($1, $2, $3, 1, $4, $5, $6, $7, $8, $9)
 			ON CONFLICT (day, task, tier) DO UPDATE SET
 			  calls              = ai_usage.calls + 1,
 			  cached_hits        = ai_usage.cached_hits + EXCLUDED.cached_hits,

--- a/backend/internal/modules/ai/ratestore_integration_test.go
+++ b/backend/internal/modules/ai/ratestore_integration_test.go
@@ -7,11 +7,9 @@ package ai
 
 // ADR-0067 phase 1's real-Postgres proof: RateFor's as-of-date resolution
 // across a rate change, CostReport's unpriced counting and free-by-
-// construction exclusions (cache_hit, zero-usage), a row-by-row
+// construction exclusions (cache_hit, zero-usage), and a row-by-row
 // cross-check of the aggregate SQL against PriceCall on identical fixture
-// data, and cross-workspace invisibility carried by RLS alone (this
-// package's stores add no workspace_id filter of their own — the GUC
-// transaction is the only gate).
+// data.
 
 import (
 	"context"
@@ -86,13 +84,13 @@ func (e *rateEnv) seedWorkspace(ctx context.Context, t *testing.T) (ids.UUID, co
 // later task's job, per the brief), so fixtures write the row the same
 // way any other seed fixture in this repo writes tenant data it doesn't
 // own an insert helper for yet.
-func (e *rateEnv) insertRate(ctx context.Context, t *testing.T, ws ids.UUID, r ModelRate) {
+func (e *rateEnv) insertRate(ctx context.Context, t *testing.T, r ModelRate) {
 	t.Helper()
 	if _, err := e.owner.Exec(ctx, `
-		INSERT INTO ai_model_rate (workspace_id, provider, model_id, input_per_mtok_microusd,
+		INSERT INTO ai_model_rate (provider, model_id, input_per_mtok_microusd,
 		  output_per_mtok_microusd, cache_read_per_mtok_microusd, cache_write_per_mtok_microusd, effective_date)
-		VALUES ($1,$2,$3,$4,$5,$6,$7,$8)`,
-		ws, r.Provider, r.ModelID, r.InputPerMTokMicroUSD, r.OutputPerMTokMicroUSD,
+		VALUES ($1,$2,$3,$4,$5,$6,$7)`,
+		r.Provider, r.ModelID, r.InputPerMTokMicroUSD, r.OutputPerMTokMicroUSD,
 		r.CacheReadPerMTokMicroUSD, r.CacheWritePerMTokMicroUSD, r.EffectiveDate); err != nil {
 		t.Fatalf("insert rate %+v: %v", r, err)
 	}
@@ -109,17 +107,17 @@ type callFixture struct {
 	occurredAt                                          time.Time
 }
 
-func (e *rateEnv) insertCall(ctx context.Context, t *testing.T, ws ids.UUID, c callFixture) {
+func (e *rateEnv) insertCall(ctx context.Context, t *testing.T, c callFixture) {
 	t.Helper()
 	// logical_call_id has carried NOT NULL since 0100 (one row per attempt,
 	// grouped by logical call) with no schema default — a fixture that
 	// wants a single-attempt logical call mints its own id, the same as a
 	// pre-0100 row backfilled to logical_call_id = id.
 	if _, err := e.owner.Exec(ctx, `
-		INSERT INTO ai_call (workspace_id, task, tier, provider, model_id, request_fingerprint,
+		INSERT INTO ai_call (task, tier, provider, model_id, request_fingerprint,
 		  tokens_in, tokens_out, cached_tokens, cache_write_tokens, cache_hit, occurred_at, logical_call_id)
-		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13)`,
-		ws, string(c.task), string(c.tier), c.provider, c.model, "fp-"+ids.NewV7().String(),
+		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)`,
+		string(c.task), string(c.tier), c.provider, c.model, "fp-"+ids.NewV7().String(),
 		c.tokensIn, c.tokensOut, c.cachedTokens, c.cacheWriteTokens, c.cacheHit, c.occurredAt, ids.NewV7()); err != nil {
 		t.Fatalf("insert call %+v: %v", c, err)
 	}
@@ -133,11 +131,11 @@ func TestRateForResolvesEffectiveDateAcrossARateChange(t *testing.T) {
 
 	jan1 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 	jun1 := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
-	e.insertRate(ctx, t, ws, ModelRate{
+	e.insertRate(ctx, t, ModelRate{
 		Provider: providerAnthropic, ModelID: "claude-test-model",
 		InputPerMTokMicroUSD: 1_000_000, OutputPerMTokMicroUSD: 1_000_000, EffectiveDate: jan1,
 	})
-	e.insertRate(ctx, t, ws, ModelRate{
+	e.insertRate(ctx, t, ModelRate{
 		Provider: providerAnthropic, ModelID: "claude-test-model",
 		InputPerMTokMicroUSD: 2_000_000, OutputPerMTokMicroUSD: 2_000_000, EffectiveDate: jun1,
 	})
@@ -251,9 +249,9 @@ func TestCostReportPricesTheWindowAndCountsUnpriced(t *testing.T) {
 	store := e.storeFor(ws)
 
 	f := buildCostReportFixture()
-	e.insertRate(ctx, t, ws, f.rate)
+	e.insertRate(ctx, t, f.rate)
 	for _, c := range []callFixture{f.priced, f.unpriced, f.cacheHit, f.zeroUsage, f.pricedNoCache, f.outsideWindow} {
-		e.insertCall(ctx, t, ws, c)
+		e.insertCall(ctx, t, c)
 	}
 
 	report, err := store.CostReport(wsCtx, f.from, f.to)
@@ -320,15 +318,15 @@ func TestCostReportGroupsByCalendarDay(t *testing.T) {
 		InputPerMTokMicroUSD: 5_000_000, OutputPerMTokMicroUSD: 25_000_000,
 		EffectiveDate: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
 	}
-	e.insertRate(ctx, t, ws, rate)
+	e.insertRate(ctx, t, rate)
 
 	day1 := time.Date(2026, 2, 5, 10, 0, 0, 0, time.UTC)
 	day2 := time.Date(2026, 2, 6, 10, 0, 0, 0, time.UTC)
-	e.insertCall(ctx, t, ws, callFixture{
+	e.insertCall(ctx, t, callFixture{
 		task: TaskSummarize, provider: providerAnthropic, model: "claude-test-model",
 		tokensIn: 100, tokensOut: 10, occurredAt: day1,
 	})
-	e.insertCall(ctx, t, ws, callFixture{
+	e.insertCall(ctx, t, callFixture{
 		task: TaskSummarize, provider: providerAnthropic, model: "claude-test-model",
 		tokensIn: 300, tokensOut: 30, occurredAt: day2,
 	})
@@ -371,7 +369,7 @@ func TestCostReportGroupsByTierNotJustTask(t *testing.T) {
 		InputPerMTokMicroUSD: 5_000_000, OutputPerMTokMicroUSD: 25_000_000,
 		EffectiveDate: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
 	}
-	e.insertRate(ctx, t, ws, rate)
+	e.insertRate(ctx, t, rate)
 
 	day := time.Date(2026, 4, 10, 9, 0, 0, 0, time.UTC)
 	cheapCall := callFixture{
@@ -382,8 +380,8 @@ func TestCostReportGroupsByTierNotJustTask(t *testing.T) {
 		task: TaskSummarize, tier: TierPremium, provider: providerAnthropic, model: "claude-test-model",
 		tokensIn: 900, tokensOut: 90, occurredAt: day.Add(time.Hour),
 	}
-	e.insertCall(ctx, t, ws, cheapCall)
-	e.insertCall(ctx, t, ws, premiumCall)
+	e.insertCall(ctx, t, cheapCall)
+	e.insertCall(ctx, t, premiumCall)
 
 	report, err := store.CostReport(wsCtx, time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC), time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC))
 	if err != nil {
@@ -446,7 +444,7 @@ func TestCostReportPricesEmbeddingCallsHonestly(t *testing.T) {
 
 	effective := time.Date(2026, 7, 20, 0, 0, 0, 0, time.UTC)
 	for _, r := range SeedModelRates(effective) {
-		e.insertRate(ctx, t, ws, r)
+		e.insertRate(ctx, t, r)
 	}
 
 	day := time.Date(2026, 8, 1, 9, 0, 0, 0, time.UTC)
@@ -455,19 +453,19 @@ func TestCostReportPricesEmbeddingCallsHonestly(t *testing.T) {
 
 	// Paid embedding call: gemini-embedding-001 has a seeded nonzero input
 	// rate. tokens_out stays 0 — embeddings have no output.
-	e.insertCall(ctx, t, ws, callFixture{
+	e.insertCall(ctx, t, callFixture{
 		task: TaskEmbeddings, tier: TierEmbedLane, provider: providerGemini, model: "gemini-embedding-001",
 		tokensIn: 10_000, occurredAt: day,
 	})
 	// Local/offline embedding call: bge-m3 has a seeded ALL-ZERO rate — it
 	// must price to 0 but must NOT count as unpriced (a rate row exists).
-	e.insertCall(ctx, t, ws, callFixture{
+	e.insertCall(ctx, t, callFixture{
 		task: TaskEmbeddings, tier: TierEmbedLane, provider: providerOllama, model: "bge-m3",
 		tokensIn: 10_000, occurredAt: day.Add(time.Hour),
 	})
 	// Unrated embedding call: no seed row for this model at all — must
 	// come back unpriced, never a silent 0.
-	e.insertCall(ctx, t, ws, callFixture{
+	e.insertCall(ctx, t, callFixture{
 		task: TaskEmbeddings, tier: TierEmbedLane, provider: providerGemini, model: "gemini-embedding-999-unreleased",
 		tokensIn: 10_000, occurredAt: day.Add(2 * time.Hour),
 	})

--- a/backend/internal/modules/ai/ratewrite.go
+++ b/backend/internal/modules/ai/ratewrite.go
@@ -232,11 +232,11 @@ func (s *RateStore) writeModelRate(ctx context.Context, tx pgx.Tx, p preparedMod
 	)
 	if err := tx.QueryRow(ctx, `
 		INSERT INTO ai_model_rate (
-			workspace_id, provider, model_id,
+			provider, model_id,
 			input_per_mtok_microusd, output_per_mtok_microusd,
 			cache_read_per_mtok_microusd, cache_write_per_mtok_microusd,
 			effective_date)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+		VALUES ($1, $2, $3, $4, $5, $6, $7)
 		ON CONFLICT (provider, model_id, effective_date)
 		DO UPDATE SET
 			input_per_mtok_microusd       = EXCLUDED.input_per_mtok_microusd,
@@ -245,7 +245,7 @@ func (s *RateStore) writeModelRate(ctx context.Context, tx pgx.Tx, p preparedMod
 			cache_write_per_mtok_microusd = EXCLUDED.cache_write_per_mtok_microusd
 		RETURNING id, provider, model_id, input_per_mtok_microusd, output_per_mtok_microusd,
 		          cache_read_per_mtok_microusd, cache_write_per_mtok_microusd, effective_date`,
-		storekit.MustWorkspace(ctx), p.provider, p.modelID,
+		p.provider, p.modelID,
 		p.input, p.output, p.cacheRead, p.cacheWrite, effDate,
 	).Scan(&id, &provOut, &modelOut, &inMicro, &outMicro, &crMicro, &cwMicro, &eff); err != nil {
 		return ModelRateRow{}, fmt.Errorf("upsert ai_model_rate: %w", err)

--- a/backend/internal/modules/ai/runtransparency_integration_test.go
+++ b/backend/internal/modules/ai/runtransparency_integration_test.go
@@ -20,18 +20,18 @@ func TestRunTransparencyReadsAndPricesOneCorrelatedProductRun(t *testing.T) {
 	workspaceID, workspaceCtx := env.seedWorkspace(background, t)
 	correlationID := ids.NewV7()
 	usedAt := time.Date(2026, 7, 22, 8, 0, 0, 0, time.UTC)
-	env.insertRate(background, t, workspaceID, ModelRate{
+	env.insertRate(background, t, ModelRate{
 		Provider: providerAnthropic, ModelID: "claude-run-model",
 		InputPerMTokMicroUSD: 1_000_000, OutputPerMTokMicroUSD: 5_000_000,
 		CacheReadPerMTokMicroUSD: 500_000, CacheWritePerMTokMicroUSD: 2_000_000,
 		EffectiveDate: usedAt.AddDate(0, 0, -1),
 	})
 	if _, err := env.owner.Exec(background, `
-		INSERT INTO ai_call (workspace_id, correlation_id, task, tier, provider, model_id,
+		INSERT INTO ai_call (correlation_id, task, tier, provider, model_id,
 		  served_model, served_identity_source, request_fingerprint, tokens_in, tokens_out, reasoning_tokens,
 		  cached_tokens, cache_write_tokens, latency_ms, occurred_at, logical_call_id)
-		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17)`,
-		workspaceID, correlationID, string(TaskColdStart), string(TierCheapCloud), providerAnthropic,
+		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16)`,
+		correlationID, string(TaskColdStart), string(TierCheapCloud), providerAnthropic,
 		"claude-run-model", "claude-run-model-202607", servedIdentitySourceResponse, "run-fingerprint", 1_000, 100, 20,
 		200, 50, 750, usedAt, ids.NewV7()); err != nil {
 		t.Fatal(err)

--- a/backend/internal/modules/ai/seed.go
+++ b/backend/internal/modules/ai/seed.go
@@ -9,8 +9,6 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
-
-	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 )
 
 // SeedWorkspaceDefaultsTx plants the starting ai_model_rate price sheet
@@ -27,20 +25,19 @@ import (
 // every workspace gets its rates here at provisioning, and SeedModelRates
 // stays the one place to edit a rate (no hand-mirrored migration copy to
 // keep in sync). Idempotent (ON CONFLICT ... DO NOTHING on the table's
-// (workspace_id, provider, model_id, effective_date) uniqueness): a rerun
+// (provider, model_id, effective_date) uniqueness): a rerun
 // never double-inserts.
 func SeedWorkspaceDefaultsTx(ctx context.Context, tx pgx.Tx, now time.Time) error {
-	wsID := storekit.MustWorkspace(ctx)
 	for _, r := range SeedModelRates(now) {
 		if _, err := tx.Exec(ctx, `
 			INSERT INTO ai_model_rate (
-				workspace_id, provider, model_id,
+				provider, model_id,
 				input_per_mtok_microusd, output_per_mtok_microusd,
 				cache_read_per_mtok_microusd, cache_write_per_mtok_microusd,
 				effective_date
-			) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+			) VALUES ($1, $2, $3, $4, $5, $6, $7)
 			ON CONFLICT (provider, model_id, effective_date) DO NOTHING`,
-			wsID, r.Provider, r.ModelID,
+			r.Provider, r.ModelID,
 			r.InputPerMTokMicroUSD, r.OutputPerMTokMicroUSD,
 			r.CacheReadPerMTokMicroUSD, r.CacheWritePerMTokMicroUSD,
 			r.EffectiveDate); err != nil {

--- a/backend/internal/modules/migration/csvrun.go
+++ b/backend/internal/modules/migration/csvrun.go
@@ -67,8 +67,8 @@ func (s *RunStore) CreateStagedRun(ctx context.Context, in CreateStagedRunInput)
 	var run Run
 	err = s.tx(ctx, func(tx pgx.Tx) error {
 		row := tx.QueryRow(ctx, `
-			INSERT INTO import_run (workspace_id, connector, status, mapping, source_ref, source, captured_by)
-			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, $2, $3, $4, $5, $6)
+			INSERT INTO import_run (connector, status, mapping, source_ref, source, captured_by)
+			VALUES ($1, $2, $3, $4, $5, $6)
 			RETURNING id, connector, status, source_ref, checkpoint, created_at, updated_at`,
 			in.Connector, StatusValidating, mapping, in.SourceRef, in.Source, capturedBy)
 		if err := scanRun(row, &run); err != nil {
@@ -188,7 +188,7 @@ func (s *RunStore) explainMiss(ctx context.Context, tx pgx.Tx, id RunID, from, t
 	var status string
 	err := tx.QueryRow(ctx, `
 		SELECT status FROM import_run
-		 WHERE id = $1 AND workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid`, id).Scan(&status)
+		 WHERE id = $1`, id).Scan(&status)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return fmt.Errorf("import run %s: %w", id, apperrors.ErrNotFound)
 	}
@@ -218,7 +218,7 @@ func (s *RunStore) GetStaged(ctx context.Context, id RunID) (Run, error) {
 			-- Scoped as well as keyed, exactly as Get is: a run id from another
 			-- workspace owes the existence-hiding not-found, not its status,
 			-- its mapping and its report.
-			  FROM import_run WHERE id = $1 AND workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid`, id)
+			  FROM import_run WHERE id = $1`, id)
 		return row.Scan(&run.ID, &run.Connector, &run.Status, &run.SourceRef, &run.Checkpoint,
 			&run.CreatedAt, &run.UpdatedAt, &mapping, &report, &undoReport, &runErr, &run.CapturedBy)
 	})

--- a/backend/internal/modules/migration/run.go
+++ b/backend/internal/modules/migration/run.go
@@ -109,8 +109,8 @@ func (s *RunStore) Create(ctx context.Context, in CreateRunInput) (Run, error) {
 	var run Run
 	err = s.tx(ctx, func(tx pgx.Tx) error {
 		row := tx.QueryRow(ctx, `
-			INSERT INTO import_run (workspace_id, connector, status, source_ref, source, captured_by)
-			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, $2, $3, $4, $5)
+			INSERT INTO import_run (connector, status, source_ref, source, captured_by)
+			VALUES ($1, $2, $3, $4, $5)
 			RETURNING id, connector, status, source_ref, checkpoint, created_at, updated_at`,
 			in.Connector, StatusRunning, in.SourceRef, in.Source, capturedBy)
 		if err := scanRun(row, &run); err != nil {
@@ -136,9 +136,7 @@ func (s *RunStore) Get(ctx context.Context, id RunID) (Run, error) {
 	err := s.tx(ctx, func(tx pgx.Tx) error {
 		row := tx.QueryRow(ctx, `
 			SELECT id, connector, status, source_ref, checkpoint, created_at, updated_at, report, error
-			-- Scoped as well as keyed: a run id from another workspace owes the
-			-- existence-hiding not-found, not that run's status and report.
-			FROM import_run WHERE id = $1 AND workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid`, id)
+			FROM import_run WHERE id = $1`, id)
 		var report []byte
 		var runErr *string
 		if err := row.Scan(&run.ID, &run.Connector, &run.Status, &run.SourceRef, &run.Checkpoint,
@@ -176,7 +174,7 @@ func (s *RunStore) Latest(ctx context.Context, connector string) (Run, error) {
 		row := tx.QueryRow(ctx, `
 			SELECT id, connector, status, source_ref, checkpoint, created_at, updated_at
 			FROM import_run
-			 WHERE connector = $1 AND workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid
+			 WHERE connector = $1
 			 ORDER BY created_at DESC LIMIT 1`, connector)
 		if err := scanRun(row, &run); err != nil {
 			if errors.Is(err, pgx.ErrNoRows) {
@@ -223,12 +221,8 @@ func (s *RunStore) LookupIdentity(ctx context.Context, sourceSystem, object, ext
 	err := s.tx(ctx, func(tx pgx.Tx) error {
 		err := tx.QueryRow(ctx, `
 			-- The workspace predicate is the lookup's own: tenant isolation
-			-- used to bound it, and without it an external id maps to whatever
-			-- installation imported it first, so the row this run writes points
-			-- at another installation's record (ADR-0091 §8 phase A).
 			SELECT native_id FROM import_record_map
-			WHERE source_system = $1 AND object = $2 AND external_id = $3
-			  AND workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid`,
+			WHERE source_system = $1 AND object = $2 AND external_id = $3`,
 			sourceSystem, object, externalID).Scan(&id)
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil
@@ -270,34 +264,25 @@ func (s *RunStore) RecordIdentityTx(ctx context.Context, tx pgx.Tx, runID RunID,
 
 // recordIdentityInTx is the statement both entry points run.
 func recordIdentityInTx(ctx context.Context, tx pgx.Tx, runID RunID, sourceSystem, object, externalID string, nativeID ids.UUID) error {
-	// The run is resolved in the statement, not trusted from the argument.
-	//
-	// The composite foreign key used to be the boundary: `(workspace_id,
-	// import_run_id)` could not name a run in another workspace, so a scope
-	// miss surfaced as an FK violation this function turned into not-found.
-	// Phase C collapsed that key to `(import_run_id)` (ADR-0091 §8), so a run
-	// id from anywhere now satisfies it. The INSERT selects its run instead,
-	// under the same workspace binding the row is written with — no row, no
-	// insert, and the caller gets the same existence-hiding not-found it
-	// always did rather than a constraint name telling it the run exists.
+	// The run is resolved BY the statement rather than trusted from the
+	// argument, so a mapping can never be written under a run that does not
+	// exist: the SELECT finds no row, the INSERT writes none, and the caller
+	// gets the existence-hiding not-found below rather than a foreign-key
+	// error naming a table it has no business hearing about.
 	tag, err := tx.Exec(ctx, `
-		INSERT INTO import_record_map (workspace_id, source_system, object, external_id, native_id, import_run_id)
-		SELECT r.workspace_id, $1, $2, $3, $4, r.id
+		INSERT INTO import_record_map (source_system, object, external_id, native_id, import_run_id)
+		SELECT $1, $2, $3, $4, r.id
 		  FROM import_run r
 		 WHERE r.id = $5
-		   AND r.workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid
 		ON CONFLICT (source_system, object, external_id) DO NOTHING`,
 		sourceSystem, object, externalID, nativeID, runID)
 	if err == nil && tag.RowsAffected() == 0 {
-		// Either the run is not this workspace's, or the identity is already
-		// mapped. Distinguished here rather than guessed: a replay must stay a
-		// no-op, and only a missing run is a scope miss.
+		// Either the run does not exist, or the identity is already mapped.
+		// Distinguished here rather than guessed: a replay must stay a no-op,
+		// and only a missing run is an error.
 		var exists bool
 		if probeErr := tx.QueryRow(ctx, `
-			SELECT EXISTS (
-			  SELECT 1 FROM import_run
-			   WHERE id = $1
-			     AND workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid)`,
+			SELECT EXISTS (SELECT 1 FROM import_run WHERE id = $1)`,
 			runID).Scan(&exists); probeErr != nil {
 			return fmt.Errorf("migration: resolving the import run %s: %w", runID, probeErr)
 		}
@@ -336,8 +321,8 @@ func (s *RunStore) RecordIdentities(ctx context.Context, runID RunID, sourceSyst
 	}
 	return s.tx(ctx, func(tx pgx.Tx) error {
 		_, err := tx.Exec(ctx, `
-			INSERT INTO import_record_map (workspace_id, source_system, object, external_id, native_id, import_run_id)
-			SELECT NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, $2, e, n, $5
+			INSERT INTO import_record_map (source_system, object, external_id, native_id, import_run_id)
+			SELECT $1, $2, e, n, $5
 			FROM unnest($3::text[], $4::uuid[]) AS t(e, n)
 			ON CONFLICT (source_system, object, external_id) DO NOTHING`,
 			sourceSystem, object, externals, natives, runID)

--- a/backend/internal/modules/migration/run_integration_test.go
+++ b/backend/internal/modules/migration/run_integration_test.go
@@ -194,7 +194,7 @@ func TestRunStoreLifecycleWithAuditAndResume(t *testing.T) {
 	}
 }
 
-func TestIdentityMapIsIdempotentAndTenantFenced(t *testing.T) {
+func TestIdentityMapIsIdempotentAndRefusesAnUnknownRun(t *testing.T) {
 	ctxA, dbA := testWorkspaceCtx(t, adminImportRunGrant())
 	s := NewRunStore(dbA)
 	run, err := s.Create(ctxA, CreateRunInput{Connector: ConnectorMirror, SourceRef: "snap-a", Source: "overlay:flip"})
@@ -220,42 +220,28 @@ func TestIdentityMapIsIdempotentAndTenantFenced(t *testing.T) {
 		t.Fatalf("a same-id DEAL resolved to the person's identity (found=%v, err=%v)", found, err)
 	}
 
-	// Another workspace neither sees that identity nor may reference the
-	// run: the composite FK rejects a cross-workspace run at the
-	// database, not merely through RLS visibility.
-	// Workspace B asks through a store of its own: the workspace a statement
-	// runs in is the handle's, so driving A's store with B's ctx would answer
-	// A's rows and this fence would prove nothing.
-	ctxB, dbB := testWorkspaceCtx(t, adminImportRunGrant())
-	sB := NewRunStore(dbB)
-	if _, found, err := sB.LookupIdentity(ctxB, "hubspot", "person", "p-1"); err != nil || found {
-		t.Fatalf("workspace B resolved workspace A's identity (found=%v, err=%v)", found, err)
-	}
-	// Rejected AND existence-hiding: a bare constraint error would tell
-	// workspace B that A's run id is real, which is the thing row scope
-	// is supposed to withhold.
-	err = sB.RecordIdentity(ctxB, run.ID, "hubspot", "person", "p-9", ids.NewV7())
+	// A run id that names no run is refused, and refused as not-found. The
+	// statement resolves its run rather than trusting the argument, so this is
+	// the path a caller with a stale or invented id takes — and it must not come
+	// back as a foreign-key error, which would answer with the name of a table
+	// the caller has no business hearing about.
+	err = s.RecordIdentity(ctxA, RunID(ids.NewV7()), "hubspot", "person", "p-9", ids.NewV7())
 	if err == nil {
-		t.Fatal("recording an identity against ANOTHER workspace's run must be rejected by the database")
+		t.Fatal("recording an identity against a run that does not exist must be refused")
 	}
 	if !errors.Is(err, apperrors.ErrNotFound) {
-		t.Errorf("cross-workspace RecordIdentity err = %v, want ErrNotFound", err)
+		t.Errorf("RecordIdentity against an unknown run = %v, want ErrNotFound", err)
 	}
 	if strings.Contains(err.Error(), "import_record_map") || strings.Contains(err.Error(), "_on_update_import_run") {
 		t.Errorf("err %q names the database shape it was rejected by", err)
 	}
 }
 
-func TestRunStoreForeignWorkspaceReadsNotFound(t *testing.T) {
-	ctxA, dbA := testWorkspaceCtx(t, adminImportRunGrant())
-	s := NewRunStore(dbA)
-	run, err := s.Create(ctxA, CreateRunInput{Connector: ConnectorMirror, SourceRef: "x", Source: "t"})
-	if err != nil {
-		t.Fatalf("Create: %v", err)
-	}
-
-	ctxB, dbB := testWorkspaceCtx(t, adminImportRunGrant())
-	if _, err := NewRunStore(dbB).Get(ctxB, run.ID); !errors.Is(err, apperrors.ErrNotFound) {
-		t.Fatalf("foreign-workspace Get err = %v, want ErrNotFound (existence-hiding)", err)
+// A run id that names no run reads as not-found rather than as a scan error on
+// zero rows — the read is keyed, so this is the only answer it can honestly give.
+func TestRunStoreReadOfAnUnknownRunIsNotFound(t *testing.T) {
+	ctx, db := testWorkspaceCtx(t, adminImportRunGrant())
+	if _, err := NewRunStore(db).Get(ctx, RunID(ids.NewV7())); !errors.Is(err, apperrors.ErrNotFound) {
+		t.Fatalf("Get of an unknown run = %v, want ErrNotFound", err)
 	}
 }

--- a/backend/internal/modules/migration/undo.go
+++ b/backend/internal/modules/migration/undo.go
@@ -260,7 +260,7 @@ func (s *RunStore) beginUndo(ctx context.Context, id RunID) (Run, UndoReport, er
 		row := tx.QueryRow(ctx, `
 			SELECT id, connector, status, checkpoint, undo_report
 			  FROM import_run
-			 WHERE id = $1 AND workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid
+			 WHERE id = $1
 			 FOR UPDATE`, id)
 		if err := row.Scan(&run.ID, &run.Connector, &run.Status, &run.Checkpoint, &undoReportRaw); err != nil {
 			if errors.Is(err, pgx.ErrNoRows) {
@@ -292,7 +292,7 @@ func (s *RunStore) beginUndo(ctx context.Context, id RunID) (Run, UndoReport, er
 		}
 		tag, err := tx.Exec(ctx, `
 			UPDATE import_run SET status = $2, checkpoint = $3, undo_report = $4, updated_at = now()
-			 WHERE id = $1 AND workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid`,
+			 WHERE id = $1`,
 			id, StatusUndoing, run.Checkpoint, encoded)
 		if err != nil {
 			return fmt.Errorf("starting import run %s undo: %w", id, err)
@@ -321,7 +321,6 @@ func (s *RunStore) mapRowsForRun(ctx context.Context, id RunID, skip, limit int)
 			SELECT object, native_id
 			  FROM import_record_map
 			 WHERE import_run_id = $1
-			   AND workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid
 			 ORDER BY created_at, external_id
 			 OFFSET $2 LIMIT $3`, id, skip, limit)
 		if err != nil {
@@ -369,12 +368,10 @@ func (s *RunStore) humanTouchedSince(ctx context.Context, id RunID, rows []mapRo
 				SELECT m.native_id
 				  FROM import_record_map m
 				 WHERE m.import_run_id = $1 AND m.object = $2
-				   AND m.workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid
 				   AND m.native_id = ANY($3)
 				   AND EXISTS (
 				     SELECT 1 FROM audit_log a
-				      WHERE a.workspace_id = m.workspace_id
-				        AND a.entity_type = $2 AND a.entity_id = m.native_id
+				      WHERE a.entity_type = $2 AND a.entity_id = m.native_id
 				        AND a.actor_type = 'human' AND a.occurred_at > m.created_at)`,
 				id, object, nativeIDs)
 			if err != nil {
@@ -415,7 +412,7 @@ func (s *RunStore) advanceUndoCheckpoint(ctx context.Context, id RunID, checkpoi
 	return s.tx(ctx, func(tx pgx.Tx) error {
 		tag, err := tx.Exec(ctx, `
 			UPDATE import_run SET checkpoint = $2, undo_report = $3, updated_at = now()
-			 WHERE id = $1 AND workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid
+			 WHERE id = $1
 			   AND status = $4 AND checkpoint <= $2`, id, checkpoint, encoded, StatusUndoing)
 		if err != nil {
 			return fmt.Errorf("advancing import run %s undo checkpoint: %w", id, err)
@@ -436,7 +433,7 @@ func (s *RunStore) completeUndo(ctx context.Context, id RunID, rep UndoReport) e
 	return s.tx(ctx, func(tx pgx.Tx) error {
 		tag, err := tx.Exec(ctx, `
 			UPDATE import_run SET status = $2, undo_report = $3, updated_at = now()
-			 WHERE id = $1 AND workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid
+			 WHERE id = $1
 			   AND status = $4`, id, StatusUndone, encoded, StatusUndoing)
 		if err != nil {
 			return fmt.Errorf("completing import run %s undo: %w", id, err)

--- a/backend/internal/modules/migration/undo_integration_test.go
+++ b/backend/internal/modules/migration/undo_integration_test.go
@@ -340,14 +340,12 @@ func TestUndoResumesFromAPersistedCheckpointAcrossPages(t *testing.T) {
 	}
 }
 
-func TestUndoIsTenantFenced(t *testing.T) {
-	ctxA, dbA := testWorkspaceCtx(t, adminImportRunGrant())
-	sA := NewRunStore(dbA)
-	run := completeCSVRun(ctxA, t, sA)
-
-	ctxB, dbB := testWorkspaceCtx(t, adminImportRunGrant())
-	sB := NewRunStore(dbB)
-	if _, err := sB.Undo(ctxB, run.ID, &fakeUndoWriters{}); !errors.Is(err, apperrors.ErrNotFound) {
-		t.Fatalf("cross-workspace Undo err = %v, want ErrNotFound (existence-hiding)", err)
+// Undo resolves its run before it reverses anything, so a run id that names no
+// run answers not-found rather than reporting a successful undo of nothing.
+func TestUndoOfAnUnknownRunIsNotFound(t *testing.T) {
+	ctx, db := testWorkspaceCtx(t, adminImportRunGrant())
+	s := NewRunStore(db)
+	if _, err := s.Undo(ctx, RunID(ids.NewV7()), &fakeUndoWriters{}); !errors.Is(err, apperrors.ErrNotFound) {
+		t.Fatalf("Undo of an unknown run = %v, want ErrNotFound", err)
 	}
 }

--- a/backend/internal/modules/privacy/retentionselectors.go
+++ b/backend/internal/modules/privacy/retentionselectors.go
@@ -71,6 +71,5 @@ var retentionSelectors = map[string]string{
 		  AND status = 'won' AND archived_at IS NULL AND NOT legal_hold
 		  AND closed_at < now() - make_interval(days => $1) LIMIT $2`,
 	"ai_call_payload/content": `SELECT id FROM ai_call_payload
-		WHERE workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid
-		  AND occurred_at < now() - make_interval(days => $1) LIMIT $2`,
+		WHERE occurred_at < now() - make_interval(days => $1) LIMIT $2`,
 }

--- a/backend/migrations/core/0284_ai_drop_workspace.down.sql
+++ b/backend/migrations/core/0284_ai_drop_workspace.down.sql
@@ -1,0 +1,56 @@
+-- Reverse of 0284: the AI trace carries the tenant column again.
+--
+-- The backfill reads the LIVE workspace — archived_at IS NULL, oldest first.
+-- 0217 refuses more than one live tenant and 0272 refuses to proceed while an
+-- archived one still holds records, so there was exactly one workspace these
+-- rows could have belonged to when the forward half ran. Ordering by created_at
+-- alone would hand every restored row to whichever workspace was created first,
+-- archived or not.
+--
+-- If no live workspace exists and a table is not empty, SET NOT NULL fails and
+-- the rollback stops — the honest outcome, since no value this migration could
+-- write would be true. A rollback on an empty database (the reverse-and-reapply
+-- lane) has nothing to attribute and passes.
+ALTER TABLE ai_call ADD COLUMN workspace_id uuid;
+ALTER TABLE ai_call_payload ADD COLUMN workspace_id uuid;
+ALTER TABLE ai_usage ADD COLUMN workspace_id uuid;
+ALTER TABLE ai_model_rate ADD COLUMN workspace_id uuid;
+ALTER TABLE ai_feedback ADD COLUMN workspace_id uuid;
+
+DO $$
+DECLARE
+  live uuid := (SELECT id FROM workspace WHERE archived_at IS NULL ORDER BY created_at LIMIT 1);
+  t    text;
+BEGIN
+  FOREACH t IN ARRAY ARRAY['ai_call', 'ai_call_payload', 'ai_usage', 'ai_model_rate', 'ai_feedback'] LOOP
+    EXECUTE format('UPDATE %I SET workspace_id = $1 WHERE workspace_id IS NULL', t) USING live;
+    EXECUTE format('ALTER TABLE %I ALTER COLUMN workspace_id SET NOT NULL', t);
+  END LOOP;
+END $$;
+
+ALTER TABLE ai_call ADD CONSTRAINT ai_call_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE ai_call_payload ADD CONSTRAINT ai_call_payload_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE ai_usage ADD CONSTRAINT ai_usage_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE ai_model_rate ADD CONSTRAINT ai_model_rate_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE ai_feedback ADD CONSTRAINT ai_feedback_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+
+DROP INDEX ai_call_logical_idx;
+DROP INDEX ai_call_terminal_trace_idx;
+DROP INDEX ai_call_ws_corr;
+DROP INDEX ai_call_ws_run;
+DROP INDEX ai_call_ws_time;
+DROP INDEX ai_call_payload_ws_time;
+DROP INDEX idx_ai_feedback_subject;
+
+CREATE INDEX ai_call_logical_idx ON ai_call (workspace_id, logical_call_id);
+CREATE INDEX ai_call_terminal_trace_idx ON ai_call (workspace_id, occurred_at DESC, id DESC) WHERE is_terminal;
+CREATE INDEX ai_call_ws_corr ON ai_call (workspace_id, correlation_id);
+CREATE INDEX ai_call_ws_run ON ai_call (workspace_id, agent_run_id);
+CREATE INDEX ai_call_ws_time ON ai_call (workspace_id, occurred_at DESC);
+CREATE INDEX ai_call_payload_ws_time ON ai_call_payload (workspace_id, occurred_at);
+CREATE INDEX idx_ai_feedback_subject ON ai_feedback (workspace_id, subject_type, subject_id);

--- a/backend/migrations/core/0284_ai_drop_workspace.up.sql
+++ b/backend/migrations/core/0284_ai_drop_workspace.up.sql
@@ -1,0 +1,47 @@
+-- 0284: the AI trace drops the tenant column (ADR-0091 §8 phase D).
+--
+-- Five tables, all of them a record of work the server did on the
+-- installation's behalf, keyed on the work rather than on who asked:
+-- ai_call (per-call metadata), ai_call_payload (the opt-in captured
+-- prompt/response), ai_usage (metering), ai_model_rate (the price list a cost
+-- is computed against), ai_feedback (a human's verdict on a claim).
+--
+-- ai_call_payload is the one to read twice: it holds prompt and response text,
+-- so it is the special-category-adjacent table privacy erases from by
+-- identifier and retention ages out at 365d. Neither of those reaches it by
+-- tenant — erasure matches the subject's identifiers, retention matches
+-- occurred_at — so removing the column changes what neither of them selects.
+--
+-- The importer (import_run, import_record_map) takes the same step in the same
+-- change, in migrations/custom/: those two tables are fork-owned (ADR-0017),
+-- and upstream never writes there.
+
+ALTER TABLE ai_call DROP CONSTRAINT ai_call_workspace_id_fkey;
+ALTER TABLE ai_call DROP COLUMN workspace_id;
+
+ALTER TABLE ai_call_payload DROP CONSTRAINT ai_call_payload_workspace_id_fkey;
+ALTER TABLE ai_call_payload DROP COLUMN workspace_id;
+
+ALTER TABLE ai_usage DROP CONSTRAINT ai_usage_workspace_id_fkey;
+ALTER TABLE ai_usage DROP COLUMN workspace_id;
+
+ALTER TABLE ai_model_rate DROP CONSTRAINT ai_model_rate_workspace_id_fkey;
+ALTER TABLE ai_model_rate DROP COLUMN workspace_id;
+
+ALTER TABLE ai_feedback DROP CONSTRAINT ai_feedback_workspace_id_fkey;
+ALTER TABLE ai_feedback DROP COLUMN workspace_id;
+
+-- The seven indexes that led with the column, recreated on what actually
+-- selects rows: a logical call, a correlation, an agent run, a time window, a
+-- feedback subject.
+--
+-- ai_call_ws_time and ai_call_terminal_trace_idx keep their tie-break on id:
+-- the trace list pages by (occurred_at DESC, id DESC), and a keyset cursor over
+-- a non-unique sort key repeats or skips rows at every page boundary.
+CREATE INDEX ai_call_logical_idx ON ai_call (logical_call_id);
+CREATE INDEX ai_call_terminal_trace_idx ON ai_call (occurred_at DESC, id DESC) WHERE is_terminal;
+CREATE INDEX ai_call_ws_corr ON ai_call (correlation_id);
+CREATE INDEX ai_call_ws_run ON ai_call (agent_run_id);
+CREATE INDEX ai_call_ws_time ON ai_call (occurred_at DESC);
+CREATE INDEX ai_call_payload_ws_time ON ai_call_payload (occurred_at);
+CREATE INDEX idx_ai_feedback_subject ON ai_feedback (subject_type, subject_id);

--- a/backend/migrations/custom/20260817110000_import_drop_workspace.down.sql
+++ b/backend/migrations/custom/20260817110000_import_drop_workspace.down.sql
@@ -1,0 +1,37 @@
+-- Reverse of 20260817110000: the importer carries the tenant column again.
+--
+-- The backfill reads the LIVE workspace — archived_at IS NULL, oldest first.
+-- 0217 refuses more than one live tenant and 0272 refuses to proceed while an
+-- archived one still holds records, so there was exactly one workspace these
+-- rows could have belonged to when the forward half ran. Ordering by created_at
+-- alone would hand every restored row to whichever workspace was created first,
+-- archived or not.
+--
+-- If no live workspace exists and a table is not empty, SET NOT NULL fails and
+-- the rollback stops — the honest outcome, since no value this migration could
+-- write would be true. A rollback on an empty database (the reverse-and-reapply
+-- lane) has nothing to attribute and passes.
+ALTER TABLE import_run ADD COLUMN workspace_id uuid;
+ALTER TABLE import_record_map ADD COLUMN workspace_id uuid;
+
+DO $$
+DECLARE
+  live uuid := (SELECT id FROM workspace WHERE archived_at IS NULL ORDER BY created_at LIMIT 1);
+  t    text;
+BEGIN
+  FOREACH t IN ARRAY ARRAY['import_run', 'import_record_map'] LOOP
+    EXECUTE format('UPDATE %I SET workspace_id = $1 WHERE workspace_id IS NULL', t) USING live;
+    EXECUTE format('ALTER TABLE %I ALTER COLUMN workspace_id SET NOT NULL', t);
+  END LOOP;
+END $$;
+
+ALTER TABLE import_run ADD CONSTRAINT import_run_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE import_record_map ADD CONSTRAINT import_record_map_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+
+DROP INDEX idx_import_record_map_run;
+DROP INDEX idx_import_run_ws;
+
+CREATE INDEX idx_import_record_map_run ON import_record_map (workspace_id, import_run_id);
+CREATE INDEX idx_import_run_ws ON import_run (workspace_id, status);

--- a/backend/migrations/custom/20260817110000_import_drop_workspace.up.sql
+++ b/backend/migrations/custom/20260817110000_import_drop_workspace.up.sql
@@ -1,0 +1,20 @@
+-- 20260817110000: the importer drops the tenant column (ADR-0091 §8 phase D).
+--
+-- import_run and import_record_map are fork-owned (ADR-0017), which is why this
+-- half lives here and the AI trace's half lives in core/0284 — the same change,
+-- split by who owns the table rather than by what it does.
+--
+-- import_record_map is the identity ledger a re-import reads to decide whether
+-- it has seen an external id before. Its key is already
+-- (source_system, object, external_id): the incumbent's own identity, which is
+-- what makes a second run of the same connector idempotent.
+
+ALTER TABLE import_record_map DROP CONSTRAINT import_record_map_workspace_id_fkey;
+ALTER TABLE import_record_map DROP COLUMN workspace_id;
+
+ALTER TABLE import_run DROP CONSTRAINT import_run_workspace_id_fkey;
+ALTER TABLE import_run DROP COLUMN workspace_id;
+
+-- Both indexes led with the column; recreated on what actually selects rows.
+CREATE INDEX idx_import_record_map_run ON import_record_map (import_run_id);
+CREATE INDEX idx_import_run_ws ON import_run (status);


### PR DESCRIPTION
Seven tables from two modules, together because both are the same kind of thing: a record of work the server did on the installation's behalf, keyed on the work rather than on who asked.

| module | tables |
|---|---|
| `ai/` | `ai_call`, `ai_call_payload`, `ai_usage`, `ai_model_rate`, `ai_feedback` |
| `migration/` | `import_run`, `import_record_map` |

The importer's two are fork-owned (ADR-0017), so the change is split by namespace — `core/0284` and `custom/20260817110000`. Same change, split by who owns the table rather than by what it does.

`ai_call_payload` is the one to read twice: it holds prompt and response text, so it is the special-category-adjacent table privacy erases from by identifier and retention ages out at 365d. Neither reaches it by tenant — erasure matches the subject's identifiers, retention matches `occurred_at` — so removing the column changes what neither of them selects.

## A reconstruction that adopted a retired estate's deal

The cutover test rebuilds an installation from its export into a second, empty workspace, deleting the source estate first. Its own comment already explains why: pipeline names became installation-wide in phase B, so a clean instance cannot stand *beside* the estate it rebuilds — "and it never could in reality either".

The identity ledger now says the same thing. `import_record_map` is keyed on the **incumbent's** identity, so the retired estate's mapping still named `d-won`, and the rebuild adopted a deal that had just been deleted: *"flip import: reading adopted deal d-won: not found"*. The fixture retires the ledger with the estate, which is what a real reconstruction does.

## Three tenant-fence tests with a real property underneath

`TestIdentityMapIsIdempotentAndTenantFenced`, `TestRunStoreForeignWorkspaceReadsNotFound` and `TestUndoIsTenantFenced` each drove two workspaces. What they were really holding survives the collapse: a run id that names no run must answer not-found, and `RecordIdentity` must not answer with a foreign-key error naming a table the caller has no business hearing about. Rewritten to assert exactly that, and renamed for what they now prove.

`recordIdentityInTx`'s comment narrated phases C and D to explain why it resolves its run in SQL. Restated as the invariant, which stands without the history: the statement resolves the run so a mapping can never be written under one that does not exist.

## Verification

- Both lanes applied to an empty database; the downs restore all seven columns with their foreign keys and all nine wide indexes; reverse-and-reapply passes.
- `make check-backend` green; `make test-integration` OK, 0 skips, 41 packages.

Phase D: 73 → 66 tables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drops the tenant column from AI trace and importer tables so rows are keyed on the work itself, not the workspace. Old behavior scoped reads/writes by `workspace_id`; new behavior removes that predicate, recreates indexes on real access keys, and refuses unknown run IDs without leaking FK details. Retention and privacy paths are unchanged.

- Tables: `ai_call`, `ai_call_payload`, `ai_usage`, `ai_model_rate`, `ai_feedback` in `ai/`, and `import_run`, `import_record_map` in `migration/`.
- Queries: remove `workspace_id` filters; indexes rebuilt on logical call, correlation ID, agent run, occurred_at, and feedback subject; trace list keeps `(occurred_at DESC, id DESC)` tie-break.
- Importer: `import_record_map` remains keyed by `(source_system, object, external_id)`; writes now resolve the run in SQL and return not-found for unknown run IDs (no FK error surface).
- Tests: rewrite cross-tenant fences to assert “unknown run → not-found”; cutover retires `import_record_map` and `import_run` with the source estate to avoid adopting a retired deal.

**Migration**
- Forward: `core/0284` drops `workspace_id` from AI tables; `custom/20260817110000` drops it from importer tables. Indexes recreated on actual selectors.
- Backward: downs restore columns, FKs, and wide indexes; backfill attributes rows to the live workspace or fail if none exists and tables are non-empty.
- Verified: reverse-and-reapply passes; backend and integration tests green.

<sup>Written for commit cd0062f96ae2974c80e5f23c27b081f013084519. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1525?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

