### PR TITLE
fix(seed-demo): capture_connection no longer has a workspace_id to write

### DIFF
--- a/backend/tools/seed-demo/comms.go
+++ b/backend/tools/seed-demo/comms.go
@@ -54,15 +54,6 @@ func seedCommsConnections(dsn string, cfg demoConfig, mode runMode) (int, error)
 	}
 	defer func() { _ = conn.Close(ctx) }() //craft:ignore swallowed-errors closing a seed connection has no failure the caller can act on
 
-	// The workspace is read once and passed explicitly. capture_connection
-	// still carries workspace_id NOT NULL, and the seeder's own connection
-	// sets no app.workspace_id GUC — the product's inserts get theirs from a
-	// request context this tool does not have.
-	var workspace string
-	if err := conn.QueryRow(ctx, `SELECT id::text FROM workspace LIMIT 1`).Scan(&workspace); err != nil {
-		return 0, fmt.Errorf("resolving the workspace for the mailboxes: %w", err)
-	}
-
 	created := 0
 	for _, user := range cfg.Users {
 		var userID string
@@ -77,12 +68,15 @@ func seedCommsConnections(dsn string, cfg demoConfig, mode runMode) (int, error)
 
 		// workspace_id is set from the GUC the way every tenant write is; the
 		// seeder's other SQL phases do the same.
+		// No workspace_id: migration 0282 dropped the tenant column from
+		// capture_connection, because the installation is a singleton and the
+		// row is installation-wide by construction (ADR-0091 §8 phase D).
 		tag, err := conn.Exec(ctx, `
 			INSERT INTO capture_connection
-			       (workspace_id, provider, user_id, scopes, status, account_label, auth)
-			VALUES ($1::uuid, 'offline_demo', $2::uuid, '{read}', 'connected', $3, $4::bytea)
+			       (provider, user_id, scopes, status, account_label, auth)
+			VALUES ('offline_demo', $1::uuid, '{read}', 'connected', $2, $3::bytea)
 			ON CONFLICT (user_id, provider) DO NOTHING`,
-			workspace, userID, user.Email, []byte(userID))
+			userID, user.Email, []byte(userID))
 		if err != nil {
 			return created, fmt.Errorf("provisioning the mailbox for %s: %w", user.Email, err)
 		}


### PR DESCRIPTION
Seeding a **fresh** installation on current main fails at the last phase:

```
provisioning the mailbox for katharina.brandt@demo.test:
column "workspace_id" of relation "capture_connection" does not exist
```

Migration 0282 (#1491) dropped the tenant column — the installation is a
singleton and the row is installation-wide by construction (ADR-0091 §8 phase
D). My comms phase was written against the column and landed in the same
window.

That PR collided with mine twice, and I only caught the first. The migration
number I fixed in #1512; **what the migration actually did I never checked.**

The insert names the remaining columns, and the workspace lookup goes with it.

## Verification

Seeded a fresh installation end to end on current main:

```
organizations: 170   people: 799   employments: 802
deals: 55   contracts: 46   documents: 83   surfaces: 30
mailboxes: 7 connected
verify: OK — every seeded record is owned, employed, linked and staged
```

and on the next worker pass, **207 messages across 84 threads, 200 invoices**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes demo seeding by removing workspace_id from `capture_connection` inserts to match migration 0282. Before: fresh installs failed during mailbox provisioning with “column workspace_id does not exist.” Now: seeding completes and mailboxes connect.

**Review notes**
- Removes the workspace lookup and updates the INSERT to name only existing columns in `capture_connection`.
- Requires DB schema at/after migration 0282; migrate before running `seed-demo`.
- Tooling-only change; no runtime behavior changes.

<sup>Written for commit 73355024c8107995ee54ef89b3529f585ac0c88f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1528?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

