### PR TITLE
fix(settings): one seam rule, and the cards that were drawing their own

### DIFF
--- a/frontend/src/design-system/atoms.css
+++ b/frontend/src/design-system/atoms.css
@@ -81,6 +81,18 @@
   border-bottom: 1px solid var(--borderSubtle);
   color: var(--textContent);
 }
+/* A rule DIVIDES rows, so the last row has nothing to divide from and draws
+   none. Without this every table in the tree ended on a hairline pointing at
+   whatever sat under it — usually the card's own edge a few pixels below, which
+   reads as a doubled border. Two screens had already noticed and reset it in
+   their own sheets (`.provider-spend-table`, and now `.ext-matrix` and
+   `.import__table`); this is the same obligation derived from the component
+   instead of maintained as a list of the tables somebody remembered. `th` as
+   well as `td`, because a table with row headers puts one in the last row. */
+.table tbody tr:last-child td,
+.table tbody tr:last-child th {
+  border-bottom: 0;
+}
 .table tbody tr {
   cursor: default;
 }

--- a/frontend/src/design-system/panel.css
+++ b/frontend/src/design-system/panel.css
@@ -35,6 +35,36 @@
   padding: var(--space-5);
 }
 
+/* THE SEAM RULE, and it is one rule: a boundary between two sections of a card
+ * is a full-bleed hairline, and a section that wants air instead takes spacing
+ * and no line at all. There is no third option, because the third option is
+ * what the tree had — twenty-odd independent `border-top: 1px solid
+ * var(--borderSubtle)` declarations across the screen sheets, seven of them
+ * drawn as `border-bottom` instead, six full-bleed and seven inset by the
+ * body's own 20px, with a `:last-child` reset on about half. The same card
+ * could therefore show a line that reached its edges above one section and a
+ * line that stopped 20px short above the next.
+ *
+ * Declared as adjacency rather than as an opt-in class so a caller cannot
+ * forget it, and so two sections that ARE adjacent cannot disagree about
+ * whether they are. Two spellings of exactly this already existed — an opt-in
+ * `.connector-add` with no reset, and `.cf-screen > .panel-body + .panel-body`
+ * — which is two screens independently discovering the same missing rule. */
+.panel-body + .panel-body,
+.panel-row + .panel-body {
+  border-top: 1px solid var(--borderSubtle);
+}
+
+/* A section heading INSIDE a body has a body's padding above it already, so it
+ * does not also pay `.section-header`'s own 24px top margin. Unreset, a rule
+ * followed by a level-3 heading measured 45px from line to text on the
+ * connections tab, 41px on general and 8px on people — three distances for one
+ * relationship, none of them chosen. `.card` has carried this reset since it
+ * was written; `.panel` never got it. */
+.panel-body > .section-header:first-child {
+  margin-top: 0;
+}
+
 /* A hairline row that runs full-bleed against the panel's own edges and
  * highlights on hover — the shape every list inside a panel wants. No border
  * on the first row: the header above it already draws that line. */

--- a/frontend/src/design-system/statstrip.css
+++ b/frontend/src/design-system/statstrip.css
@@ -53,6 +53,49 @@
     0 -1px 0 var(--borderSubtle);
 }
 
+/* A SLOT MAY BE A CONTROL. A strip of filters is still one comparison — the
+ * reader is choosing between the same readings they are comparing — so the
+ * press target is the slot itself rather than something inside it.
+ *
+ * The reset therefore has to reach the card a control wraps, or the two chrome
+ * sets stack: the plate's seamless rules PLUS the card's own border and 12px
+ * radius, which is five bordered rounded boxes nested inside a plate built to
+ * draw none. The capture-activity funnel shipped exactly that, and answered it
+ * with `all: unset` on the wrapper — a declaration that ties `.stat-strip > *`
+ * on specificity, so which one won was decided by stylesheet import order
+ * rather than by intent. The chrome a button brings is reset HERE, where the
+ * plate's other chrome is, so a caller has nothing left to unset. */
+.stat-strip > button {
+  font: inherit;
+  color: inherit;
+  text-align: inherit;
+  padding: 0;
+  cursor: pointer;
+}
+.stat-strip > * > .stat-card {
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+}
+
+/* A pressed slot fills the SLOT, not the button around the card inside it: a
+ * fill painted on the wrapper is repainted by the card's own `--bgElevated`
+ * directly over it, which left the selected filter showing an accent ring and
+ * almost no fill. Both halves land on the slot now, and the ring is inset so
+ * it reads inside the plate's own rules rather than doubling them. */
+.stat-strip > [aria-pressed="true"] {
+  background: var(--bgHover);
+  box-shadow:
+    -1px 0 0 var(--borderSubtle),
+    0 -1px 0 var(--borderSubtle),
+    inset 0 0 0 2px var(--accent);
+}
+.stat-strip > *:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+
 /* ONE size for every slot in the row, sized to the SLOT rather than to a
    mockup's absolute pixels: the value has to hold a short sentence on one line
    in the narrowest slot, so it sits below the size figures alone could have

--- a/frontend/src/screens/capture-activity.css
+++ b/frontend/src/screens/capture-activity.css
@@ -5,16 +5,24 @@
  * right in both themes, and a literal colour is the one thing that cannot be.
  */
 
+/* No margin of its own. The body is a `form-stack` now, so ONE gap separates
+ * every block in this card; before, the intervals down the card read
+ * 0 / 12 / 8 / 0 / 0 because three blocks paid their own margin and three paid
+ * nothing — which is how the Load-more button ended up butted against the last
+ * row with no separation at all. */
 .capture-activity__scope-note {
   color: var(--textMeta);
   font-size: var(--fs-sm);
-  margin: var(--space-3) 0;
 }
 
+/* A ruled list, not a stack of separated cards. The gap was 8px and every row
+ * drew a `border-bottom`, so each hairline floated in the middle of the space
+ * between two rows instead of dividing them — and the last row drew one with
+ * nothing under it, because there was no `:last-child` reset. A rule that
+ * divides has to touch what it divides. */
 .capture-activity__list {
   display: flex;
   flex-direction: column;
-  gap: var(--space-2);
   list-style: none;
   margin: 0;
   padding: 0;
@@ -24,8 +32,11 @@
  * It folds to a stack rather than scrolling sideways: this is a settings
  * surface inside a column, and a horizontally scrolling list of one's own mail
  * is a worse answer than a taller one. */
-.capture-activity__row {
-  border-bottom: 1px solid var(--borderSubtle);
+/* `border-top` with the first row exempt, which is `PanelRow`'s shape and the
+ * house spelling: N rows draw N-1 rules, and the list cannot end on a hairline
+ * pointing at nothing. */
+.capture-activity__row + .capture-activity__row {
+  border-top: 1px solid var(--borderSubtle);
 }
 
 .capture-activity__when,
@@ -80,30 +91,20 @@
 
 /* The funnel slots are filters. A pressed button rather than a Switch: a
  * Switch IS the action it names, and narrowing a list is not an action on the
- * data — it changes what this reader is looking at and nothing else. */
-.capture-activity__funnel-slot {
-  all: unset;
-  cursor: pointer;
-  display: block;
-}
-
-.capture-activity__funnel-slot:focus-visible {
-  border-radius: var(--r-md);
-  outline: 2px solid var(--accent);
-  outline-offset: 2px;
-}
-
-.capture-activity__funnel-slot[aria-pressed="true"] {
-  background: var(--bgHover);
-  border-radius: var(--r-md);
-  box-shadow: inset 0 0 0 1px var(--accent);
-}
+ * data — it changes what this reader is looking at and nothing else.
+ *
+ * Nothing left to declare. StatStrip owns a slot that is a control now: the
+ * button's own chrome, the reset that reaches the card inside it, the pressed
+ * fill and the focus ring all live in statstrip.css beside the plate's other
+ * chrome. This used to be `all: unset` plus a pressed state and a focus ring,
+ * and the `all: unset` tied `.stat-strip > *` on specificity — so which of them
+ * drew the slot was decided by stylesheet import order rather than by intent,
+ * and the pressed fill was repainted by the StatCard's own background anyway. */
 
 /* Both numbers, so a filtered view can never be read as the whole window. */
 .capture-activity__count {
   color: var(--textMeta);
   font-size: var(--fs-sm);
-  margin: var(--space-2) 0;
 }
 
 /* The row is one button carrying the grid, so the whole row is the target and

--- a/frontend/src/screens/capture-activity.tsx
+++ b/frontend/src/screens/capture-activity.tsx
@@ -7,12 +7,7 @@ import { useState } from "react";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
 import { useCan } from "../app/capability";
-import {
-  Button,
-  SectionHeader,
-  SegmentedControl,
-  StatCard,
-} from "../design-system/atoms";
+import { Button, SegmentedControl, StatCard } from "../design-system/atoms";
 import { Panel, PanelBody } from "../design-system/panel";
 import { StatStrip } from "../design-system/statstrip";
 import { SurfaceState } from "../design-system/surfacestate";
@@ -112,12 +107,20 @@ export function CaptureActivityTab() {
   const [scope, setScope] = useState<Scope>("mine");
 
   return (
-    <Panel>
-      <SectionHeader
-        title={t("captureActivity.title")}
-        sub={t("captureActivity.sub")}
-      />
-      <PanelBody>
+    // `title` on the Panel, not a SectionHeader nested inside it. Nested, the
+    // heading landed as a direct child of `.panel` — which has zero padding —
+    // so the card's own name sat flush against its left border while everything
+    // under it was indented by PanelBody's 20px, and the panel drew no header
+    // band and no rule at all. It also rendered at 15px/600 through
+    // `.section-header h2` where every other settings card reads
+    // `--fs-sm`/`fw-medium` through `.panel-head h2`: this was the one card in
+    // the product whose title was a different size from the thirteen beside it.
+    <Panel title={t("captureActivity.title")}>
+      <PanelBody className="form-stack">
+        {/* The description belongs in the body, which is where the other ten
+            settings cards put theirs — Panel's header band holds the title
+            alone, by design. */}
+        <p className="t-small settings-panel-sub">{t("captureActivity.sub")}</p>
         {canReadWorkspace && (
           <SegmentedControl<Scope>
             label={t("captureActivity.scope.label")}

--- a/frontend/src/screens/company-context.css
+++ b/frontend/src/screens/company-context.css
@@ -43,14 +43,15 @@
   margin-left: auto;
 }
 
-/* A field group under its own level-3 heading, ruled off from the group above
- * so the three subjects read as three rather than as one long form. */
+/* A field group under its own level-3 heading. The three subjects read as three
+ * on the heading and the air above it — the form-stack's gap plus SectionHeader's
+ * own interval — rather than on a line, because a group is one section of this
+ * body and a line drawn inside a body can only ever stop short of the card's
+ * edges. A seam is full-bleed or it is not drawn; this one takes the air. */
 .company-context-group {
   display: flex;
   flex-direction: column;
   gap: var(--space-4);
-  padding-top: var(--space-4);
-  border-top: 1px solid var(--borderSubtle);
 }
 
 .company-context-fields {
@@ -110,13 +111,16 @@
   justify-content: space-between;
 }
 
+/* The choices a conflicting change offers, inside the row that carries it. A
+ * row's own interior is not a card seam, so it is separated by the row's gap and
+ * a little more air rather than by a second hairline running across a row the
+ * panel already ruled off. */
 .company-context-resolutions {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
   gap: var(--space-3);
-  padding-top: var(--space-3);
-  border-top: 1px solid var(--borderSubtle);
+  margin-top: var(--space-2);
 }
 .company-context-resolutions label {
   color: var(--textSecondary);

--- a/frontend/src/screens/connectors.css
+++ b/frontend/src/screens/connectors.css
@@ -59,29 +59,41 @@
 .connector-synced {
   color: var(--textSecondary);
 }
-.connector-actions {
+/* The row's own failure sentence. A class rather than an inline style, so the
+   danger tone is named in a stylesheet like every other colour in the tree. */
+.connector-error {
+  color: var(--danger);
+}
+/* The verbs on a roster row and the provider picks under "Add a connection"
+   are ONE row shape, declared once — two strips of buttons that disagreed
+   about alignment (one centred, one left to the flex default) drew the same
+   thing two different ways.
+
+   The buttons keep their own widths on purpose. `small` is the rung that
+   deliberately drops `.btn`'s 6rem floor (design-system/base.css says why: it
+   lives in dense rows, where a floor is what breaks the layout), and a shared
+   minimum only aligns buttons that are STACKED. Side by side, every label
+   longer than the floor still sets its own width, so a floor here would widen
+   "Gmail" toward "Google Calendar" without ever making the two ends line up. */
+.connector-actions,
+.connector-add-actions {
   display: flex;
   align-items: center;
   gap: var(--space-2);
   flex-wrap: wrap;
 }
-/* Forces the mounted BackfillPanel onto its own line below the row's id +
-   actions (the row itself is flex-wrap: wrap; a 100%-width child can't share
-   a line with its siblings so it wraps). */
-.connector-backfill {
+/* A note that belongs to the row above it: the BackfillPanel, and the reason a
+   reconnect from this row failed. The row is flex-wrap: wrap, so a 100%-basis
+   child cannot share a line with its siblings and drops below them. */
+.connector-backfill,
+.connector-row-note {
   flex-basis: 100%;
   min-width: 0;
   margin-top: var(--space-2);
 }
 
-/* "Add a connection", and the Telegram section under it: two blocks that read
-   as additions to the roster above rather than as part of it. Each sits on the
-   panel's own body padding and is fenced off by a rule at its top. */
-.connector-add {
-  border-top: 1px solid var(--borderSubtle);
-}
-.connector-add-actions {
-  display: flex;
-  gap: var(--space-2);
-  flex-wrap: wrap;
+/* A failure reported directly under the buttons that produced it still needs
+   to read as a separate thing from them, not as a fifth item in the strip. */
+.connector-add-note {
+  margin-top: var(--space-3);
 }

--- a/frontend/src/screens/connectors.stories.tsx
+++ b/frontend/src/screens/connectors.stories.tsx
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: 2026 Gradion
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { userEvent, within } from "storybook/test";
 import type { components } from "../api/schema";
 import { ConnectorsCard } from "./connectors";
 import { installFetchStub, jsonResponse, StoryProviders } from "./story-utils";
@@ -172,6 +173,50 @@ export const EmptyStateAllProviders: Story = {
 
 export const OneConnectedWithFooter: Story = {
   render: cardStory([gmailConnected]),
+};
+
+// A refused connect reports itself under the buttons that produced it, not in
+// a band of its own further down the card. One `connect` mutation serves both
+// strips, so both placements are worth seeing: the add block's provider picks,
+// and a roster row's Reconnect.
+function connectFailureStory(connections: CaptureConnection[], path: string) {
+  return () => {
+    installFetchStub({
+      "GET /connectors": () => jsonResponse({ data: connections }),
+      [`POST /connectors/${path}/connect`]: () =>
+        jsonResponse(
+          { title: "Bad Gateway", detail: "The provider did not answer." },
+          502,
+        ),
+    });
+    return (
+      <StoryProviders>
+        <ConnectorsCard />
+      </StoryProviders>
+    );
+  };
+}
+
+export const AddConnectionFailed: Story = {
+  render: connectFailureStory([gmailConnected], "graph"),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(
+      await canvas.findByRole("button", { name: "Microsoft" }),
+    );
+    await canvas.findByRole("alert");
+  },
+};
+
+export const ReconnectFailed: Story = {
+  render: connectFailureStory([gcalReauth], "gcal"),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(
+      await canvas.findByRole("button", { name: /Reconnect/ }),
+    );
+    await canvas.findByRole("alert");
+  },
 };
 
 export const LoadFailed: Story = {

--- a/frontend/src/screens/connectors.test.tsx
+++ b/frontend/src/screens/connectors.test.tsx
@@ -275,6 +275,16 @@ describe("the connected-inboxes card", () => {
       expect(requestsTo(calls, "/connect", "POST").length).toBe(1),
     );
     expect(await screen.findByText(/connect failed/)).toBeTruthy();
+    // Announced, and attached to the button that produced it: the reason
+    // renders inside the same roster row as the Reconnect that was pressed,
+    // never in a band of its own under an unrelated heading.
+    const alert = await screen.findByRole("alert");
+    expect(alert.textContent).toMatch(/connect failed/);
+    const row = screen
+      .getByRole("button", { name: /Reconnect/ })
+      .closest(".panel-row");
+    expect(row).not.toBeNull();
+    expect(row?.contains(alert)).toBe(true);
   });
 
   it("disconnects only after an explicit confirm", async () => {
@@ -484,7 +494,10 @@ describe("add a connection", () => {
     stubApi([gmailConnected]);
     render(<ConnectorsCard />);
     await screen.findByText("Add a connection");
-    const add = screen.getByText("Add a connection").closest(".connector-add");
+    // The block is scoped by the panel section its heading leads: the seam
+    // between two sections is the panel's own adjacency rule now, so the block
+    // no longer carries a screen class of its own to name it by.
+    const add = screen.getByText("Add a connection").closest(".panel-body");
     expect(add).not.toBeNull();
     const panel = add as HTMLElement;
     expect(within(panel).queryByRole("button", { name: "Gmail" })).toBeNull();
@@ -523,6 +536,24 @@ describe("add a connection", () => {
     expect(
       await screen.findByText("Microsoft isn't configured in this deployment."),
     ).toBeTruthy();
+  });
+
+  it("reports a refused connect directly under the buttons that produced it", async () => {
+    stubApi([gmailConnected], { connect: { status: 502 } });
+    render(<ConnectorsCard />);
+    await screen.findByText("Add a connection");
+    await userEvent.click(screen.getByRole("button", { name: "Microsoft" }));
+
+    const alert = await screen.findByRole("alert");
+    expect(alert.textContent).toMatch(/connect failed/);
+    // Inside the same block as the picks, and immediately after the strip of
+    // them — not in a section of its own between the roster and an unrelated
+    // heading, where nothing says which press it answers.
+    const block = screen.getByText("Add a connection").closest(".panel-body");
+    expect(block?.contains(alert)).toBe(true);
+    expect(alert.previousElementSibling?.className).toContain(
+      "connector-add-actions",
+    );
   });
 
   it("hides the footer when all four providers are connected", async () => {

--- a/frontend/src/screens/connectors.tsx
+++ b/frontend/src/screens/connectors.tsx
@@ -151,12 +151,18 @@ function ConnectorAddPanel({
   addable,
   pending,
   notConfigured501,
+  connectError,
   onConnect,
   onImap,
 }: Readonly<{
   addable: Provider[];
   pending: boolean;
   notConfigured501: Provider | null;
+  // Why the last connect started from THESE buttons failed, or null. It renders
+  // inside this block, under the strip that produced it: a reason reported in a
+  // section of its own — below a rule, above an unrelated heading — names no
+  // button at all, and the reader has to guess which press it answers.
+  connectError: string | null;
   onConnect: (provider: Provider) => void;
   onImap: () => void;
 }>) {
@@ -186,10 +192,15 @@ function ConnectorAddPanel({
         )}
       </div>
       {notConfigured501 && (
-        <Callout tone="danger" live="alert">
+        <Callout tone="danger" live="alert" className="connector-add-note">
           {t("connectors.providerNotConfigured", {
             provider: t(providerLabel[notConfigured501]),
           })}
+        </Callout>
+      )}
+      {connectError && (
+        <Callout tone="danger" live="alert" className="connector-add-note">
+          {connectError}
         </Callout>
       )}
     </>
@@ -374,9 +385,133 @@ function TelegramConnectorPanel() {
   );
 }
 
-export function ConnectorsCard() {
+type ConnectFailure = {
+  provider: Provider | undefined;
+  message: string;
+} | null;
+
+// Which strip of buttons owes the reader the reason a connect failed. One
+// mutation drives two of them — the add block's provider picks and a roster
+// row's Reconnect — so a single shared error region could only ever sit under
+// one, which is how the reason ended up in a band of its own naming no button
+// at all. A provider is either already on the roster or still addable, never
+// both, so the mutation's own variable answers it: the strip offering that
+// provider carries the message and every other strip stays silent.
+function failureOwnedBy(
+  failure: ConnectFailure,
+  owner: readonly Provider[],
+): string | null {
+  if (!failure?.provider || !owner.includes(failure.provider)) {
+    return null;
+  }
+  return failure.message;
+}
+
+// One mail connection, as a full-bleed hairline row on the panel's own ground
+// — not a second bordered card nested inside the first one. Split out of
+// ConnectorsCard for the same reason ConnectorAddPanel and OAuthOutcomeNote
+// were: the row is where most of this card's branching lives, and it does not
+// belong on the card function's complexity budget.
+function ConnectorRow({
+  conn,
+  connectPending,
+  connectError,
+  onReconnect,
+  onImapReconnect,
+  onDisconnect,
+}: Readonly<{
+  conn: CaptureConnection;
+  connectPending: boolean;
+  // Why the reconnect pressed on THIS row failed, or null — reported here,
+  // under the button that produced it, rather than in a band of its own.
+  connectError: string | null;
+  onReconnect: () => void;
+  onImapReconnect: () => void;
+  onDisconnect: () => void;
+}>) {
   const t = useT();
   const { locale } = useLocale();
+  const at = (iso: string) => formatDateTime(iso, locale, "Europe/Berlin");
+  const needsReconnect =
+    conn.status === "reauth_required" || missingSendGrant(conn);
+  return (
+    <PanelRow className="connector-row">
+      <span className="connector-id">
+        <Mail aria-hidden />
+        <span>
+          <strong>{t(providerLabel[conn.provider])}</strong>
+          {conn.account_label && (
+            <span className="t-small connector-account">
+              {conn.account_label}
+            </span>
+          )}
+          <span className="t-small connector-synced">
+            {conn.last_synced_at
+              ? t("connectors.lastSynced", { at: at(conn.last_synced_at) })
+              : t("connectors.neverSynced")}
+          </span>
+          {conn.next_sync_due_at && (
+            <span className="t-small connector-synced">
+              {t("connectors.nextCheck", { at: at(conn.next_sync_due_at) })}
+            </span>
+          )}
+          <span className="t-small connector-synced">
+            {conn.watch_expires_at
+              ? t("connectors.pushRenewal", { at: at(conn.watch_expires_at) })
+              : t("connectors.polled")}
+          </span>
+          {(conn.status === "error" || conn.status === "reauth_required") && (
+            <span className="t-small connector-error">
+              {t(errorClassKey(conn.last_sync_error_class))}
+            </span>
+          )}
+          {/* Named here rather than at send time: the composer's 422 arrives
+              after the rep has written the mail, and it can only be cleared
+              from this card. */}
+          {missingSendGrant(conn) && (
+            <span className="t-small">{t("connectors.reconnectToSend")}</span>
+          )}
+        </span>
+      </span>
+      <span className="connector-actions">
+        <Badge tone={statusTone(conn.status)}>
+          {t(statusLabel(conn.status))}
+        </Badge>
+        {missingSendGrant(conn) && (
+          <Badge tone="warn">{t("connectors.cannotSend")}</Badge>
+        )}
+        {needsReconnect &&
+          (OAUTH_PROVIDERS.has(conn.provider) ? (
+            <Button small disabled={connectPending} onClick={onReconnect}>
+              <RefreshCw aria-hidden /> {t("connectors.reconnect")}
+            </Button>
+          ) : (
+            <Button small onClick={onImapReconnect}>
+              <RefreshCw aria-hidden /> {t("connectors.reconnect")}
+            </Button>
+          ))}
+        <Button small variant="ghost" onClick={onDisconnect}>
+          {t("connectors.disconnect")}
+        </Button>
+      </span>
+      {connectError && (
+        <div className="connector-row-note">
+          <Callout tone="danger" live="alert">
+            {connectError}
+          </Callout>
+        </div>
+      )}
+      {conn.status === "connected" && (
+        <div className="connector-backfill">
+          <BackfillPanel provider={conn.provider} initial={conn.backfill} />
+        </div>
+      )}
+    </PanelRow>
+  );
+}
+
+export function ConnectorsCard() {
+  const t = useT();
   const qc = useQueryClient();
   const [pendingDisconnect, setPendingDisconnect] = useState<Provider | null>(
     null,
@@ -456,11 +591,20 @@ export function ConnectorsCard() {
 
   const present = new Set(rows.map((r) => r.provider));
   const addable = ALL_PROVIDERS.filter((p) => !present.has(p));
+
+  const connectFailure = connect.isError
+    ? {
+        provider: connect.variables,
+        message: problemMessageOf(connect.error, t),
+      }
+    : null;
+
   const addPanel = (
     <ConnectorAddPanel
       addable={addable}
       pending={connect.isPending}
       notConfigured501={notConfigured501}
+      connectError={failureOwnedBy(connectFailure, addable)}
       onConnect={(p) => connect.mutate(p)}
       onImap={() => {
         // A stale "X isn't configured" note from an earlier OAuth attempt
@@ -502,121 +646,24 @@ export function ConnectorsCard() {
       </PanelBody>
       {!notConfigured &&
         rows.map((conn) => (
-          // A full-bleed hairline row on the panel's own ground, not a second
-          // bordered card nested inside the first one.
-          <PanelRow key={conn.id} className="connector-row">
-            <span className="connector-id">
-              <Mail aria-hidden />
-              <span>
-                <strong>{t(providerLabel[conn.provider])}</strong>
-                {conn.account_label && (
-                  <span className="t-small connector-account">
-                    {conn.account_label}
-                  </span>
-                )}
-                <span className="t-small connector-synced">
-                  {conn.last_synced_at
-                    ? t("connectors.lastSynced", {
-                        at: formatDateTime(
-                          conn.last_synced_at,
-                          locale,
-                          "Europe/Berlin",
-                        ),
-                      })
-                    : t("connectors.neverSynced")}
-                </span>
-                {conn.next_sync_due_at && (
-                  <span className="t-small connector-synced">
-                    {t("connectors.nextCheck", {
-                      at: formatDateTime(
-                        conn.next_sync_due_at,
-                        locale,
-                        "Europe/Berlin",
-                      ),
-                    })}
-                  </span>
-                )}
-                <span className="t-small connector-synced">
-                  {conn.watch_expires_at
-                    ? t("connectors.pushRenewal", {
-                        at: formatDateTime(
-                          conn.watch_expires_at,
-                          locale,
-                          "Europe/Berlin",
-                        ),
-                      })
-                    : t("connectors.polled")}
-                </span>
-                {(conn.status === "error" ||
-                  conn.status === "reauth_required") && (
-                  <span className="t-small" style={{ color: "var(--danger)" }}>
-                    {t(errorClassKey(conn.last_sync_error_class))}
-                  </span>
-                )}
-                {/* Named here rather than at send time: the composer's 422
-                      arrives after the rep has written the mail, and it can
-                      only be cleared from this card. */}
-                {missingSendGrant(conn) && (
-                  <span className="t-small">
-                    {t("connectors.reconnectToSend")}
-                  </span>
-                )}
-              </span>
-            </span>
-            <span className="connector-actions">
-              <Badge tone={statusTone(conn.status)}>
-                {t(statusLabel(conn.status))}
-              </Badge>
-              {missingSendGrant(conn) && (
-                <Badge tone="warn">{t("connectors.cannotSend")}</Badge>
-              )}
-              {(conn.status === "reauth_required" || missingSendGrant(conn)) &&
-                (OAUTH_PROVIDERS.has(conn.provider) ? (
-                  <Button
-                    small
-                    disabled={connect.isPending}
-                    onClick={() => connect.mutate(conn.provider)}
-                  >
-                    <RefreshCw aria-hidden /> {t("connectors.reconnect")}
-                  </Button>
-                ) : (
-                  <Button small onClick={() => setImapConnectOpen(true)}>
-                    <RefreshCw aria-hidden /> {t("connectors.reconnect")}
-                  </Button>
-                ))}
-              <Button
-                small
-                variant="ghost"
-                onClick={() => setPendingDisconnect(conn.provider)}
-              >
-                {t("connectors.disconnect")}
-              </Button>
-            </span>
-            {conn.status === "connected" && (
-              <div className="connector-backfill">
-                <BackfillPanel
-                  provider={conn.provider}
-                  initial={conn.backfill}
-                />
-              </div>
-            )}
-          </PanelRow>
+          <ConnectorRow
+            key={conn.id}
+            conn={conn}
+            connectPending={connect.isPending}
+            connectError={failureOwnedBy(connectFailure, [conn.provider])}
+            onReconnect={() => connect.mutate(conn.provider)}
+            onImapReconnect={() => setImapConnectOpen(true)}
+            onDisconnect={() => setPendingDisconnect(conn.provider)}
+          />
         ))}
       {!notConfigured &&
         rows.length > 0 &&
         (addable.length > 0 || notConfigured501) && (
-          <PanelBody className="connector-add">
+          <PanelBody>
             <SectionHeader title={t("connectors.addConnection")} level={3} />
             {addPanel}
           </PanelBody>
         )}
-      {connect.isError && (
-        <PanelBody>
-          <Callout tone="danger" live="alert">
-            {problemMessageOf(connect.error, t)}
-          </Callout>
-        </PanelBody>
-      )}
       <ConfirmModal
         open={pendingDisconnect !== null}
         onClose={() => setPendingDisconnect(null)}
@@ -641,7 +688,7 @@ export function ConnectorsCard() {
         onClose={() => setImapConnectOpen(false)}
         onConnected={() => setImapConnectOpen(false)}
       />
-      <PanelBody className="connector-add">
+      <PanelBody>
         <SectionHeader
           title={t("connectors.telegramTitle")}
           sub={t("connectors.telegramSub")}

--- a/frontend/src/screens/consent.css
+++ b/frontend/src/screens/consent.css
@@ -1,15 +1,22 @@
 /* ConsentSection layout only — the row/badge/timeline primitives themselves
  * come from atoms.css and composed.css's .timeline. Tokens only (ds-purity). */
 
+/* One purpose, as a row of the list. PanelRow's shape — a top border against the
+ * row above and none on the first — rather than a bottom border with a
+ * `:last-child` reset, which is the same line drawn from the other side and the
+ * reason two cards in this tree could disagree about where a list ends. It is
+ * inset by the Card's own padding rather than full-bleed: this surface is a Card,
+ * which has no full-bleed row slot, and reaching past its padding with a negative
+ * margin would be a third spelling rather than a fix. */
 .consent-row {
   display: flex;
   flex-direction: column;
   gap: 6px;
-  padding: 10px 0;
-  border-bottom: 1px solid var(--borderSubtle);
+  padding: var(--space-3) 0;
+  border-top: 1px solid var(--borderSubtle);
 }
-.consent-row:last-child {
-  border-bottom: 0;
+.consent-row:first-child {
+  border-top: 0;
 }
 .consent-row-head {
   display: flex;

--- a/frontend/src/screens/consumer-mail-domains.css
+++ b/frontend/src/screens/consumer-mail-domains.css
@@ -45,16 +45,15 @@
   flex: 1;
 }
 
-/* The shipped list sits below the workspace's own entries, behind a rule: it
-   is a different question — what the baseline already says — asked on the same
-   card as what this workspace adds to it. */
+/* The shipped list sits below the workspace's own entries as its own band of
+   the card: a different question — what the baseline already says — asked on
+   the same card as what this workspace adds to it. It is a PanelBody, so the
+   rule above it and the interval around it are panel.css's; all this owns is
+   how its own lines stack. */
 .consumer-mail-baseline {
   display: flex;
   flex-direction: column;
   gap: var(--space-2);
-  margin-top: var(--space-3);
-  padding-top: var(--space-3);
-  border-top: 1px solid var(--borderSubtle);
 }
 
 /* Matches run as a wrapped set of names rather than one per line: they are

--- a/frontend/src/screens/consumer-mail-domains.tsx
+++ b/frontend/src/screens/consumer-mail-domains.tsx
@@ -135,7 +135,7 @@ function BaselineSection() {
   const query = useConsumerMailBaseline(needle);
   const result = query.data;
   return (
-    <section className="consumer-mail-baseline">
+    <PanelBody className="consumer-mail-baseline">
       {/* A real heading, one level under the panel's own title, rather than a
           paragraph styled to look like one — a reader navigating by heading can
           reach the shipped list without scrolling the card. */}
@@ -184,7 +184,7 @@ function BaselineSection() {
           )}
         </>
       )}
-    </section>
+    </PanelBody>
   );
 }
 
@@ -340,8 +340,13 @@ export function ConsumerMailDomainsCard() {
             {problemMessageOf(remove.error, t)}
           </Callout>
         )}
-        <BaselineSection />
       </PanelBody>
+      {/* The shipped list is a SECOND section of this card, not a footnote
+          inside the first: what the baseline already says, against what this
+          workspace adds to it. Its own body, so the boundary is the full-bleed
+          seam panel.css draws between two of them rather than a line that stops
+          20px short of the card's edges. */}
+      <BaselineSection />
     </Panel>
   );
 }

--- a/frontend/src/screens/customfields.css
+++ b/frontend/src/screens/customfields.css
@@ -9,14 +9,12 @@
    used to stack are its scope row, its table body and two Disclosures — so the
    inter-card rhythm this file used to own belongs to the panel's own padding.
    What is left here is the parts the design system has no primitive for: the
-   builder's form layout, the field cell, the type chip and the audit list. */
+   builder's form layout, the field cell, the type chip and the audit list.
 
-/* The three panel bodies read as three bands, so the seams are drawn rather
-   than implied by whitespace alone — the table has to end somewhere visible
-   before the Disclosures that follow it. */
-.cf-screen > .panel-body + .panel-body {
-  border-top: 1px solid var(--borderSubtle);
-}
+   The three bodies read as three bands, and the seam between two of them is
+   panel.css's — a card seam is full-bleed and this sheet does not draw one.
+   Each band's content sits on the body's own padding, the table included, so a
+   rule inside the table can only ever read as the table's own. */
 
 /* The scope row: what this section is, then which object it is showing. */
 .cf-scope {
@@ -24,12 +22,6 @@
   flex-direction: column;
   align-items: flex-start;
   gap: var(--space-3);
-}
-
-/* The table runs to the panel's own edges; the padding above and below it
-   stays so it never touches the band it sits between. */
-.cf-tablebody {
-  padding-inline: 0;
 }
 
 /* The two Disclosures, and the read-only posture that stands in for the first

--- a/frontend/src/screens/customfields.tsx
+++ b/frontend/src/screens/customfields.tsx
@@ -773,7 +773,7 @@ export function CustomFieldsAdmin() {
         />
       </PanelBody>
 
-      <PanelBody className="cf-tablebody">
+      <PanelBody>
         <QueryGate query={list}>
           {(page) => (
             <FieldTable

--- a/frontend/src/screens/extension-access.css
+++ b/frontend/src/screens/extension-access.css
@@ -165,12 +165,22 @@
   overflow-wrap: anywhere;
 }
 
+/* A table's rules are drawn under each cell and inset by the cell's own padding
+ * — that is a table's internal rhythm, and it is deliberately not the card seam,
+ * which runs full-bleed. */
 .ext-matrix th,
 .ext-matrix td {
   border-bottom: 1px solid var(--borderSubtle);
   padding: var(--space-2);
   text-align: left;
   font-size: var(--fs-sm);
+}
+
+/* The last row has nothing under it to be ruled off from, so it does not end the
+ * matrix on a hairline that separates it from the card's own padding. */
+.ext-matrix tbody tr:last-child th,
+.ext-matrix tbody tr:last-child td {
+  border-bottom: 0;
 }
 
 .ext-matrix thead th {

--- a/frontend/src/screens/imap-connect-form.tsx
+++ b/frontend/src/screens/imap-connect-form.tsx
@@ -5,6 +5,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useId, useRef, useState } from "react";
 import { api } from "../api/client";
 import { Button, Field, Modal, TextInput } from "../design-system/atoms";
+import { Callout } from "../design-system/callout";
 import { useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import { problemCodeOf, problemMessageOf, throwProblem } from "./common";
@@ -220,13 +221,9 @@ export function ImapConnectForm({
         </Field>
         <p className="t-caption">{t("connectors.imapSecretHint")}</p>
         {errorMessage && (
-          <p
-            role="alert"
-            className="t-caption"
-            style={{ color: "var(--danger)" }}
-          >
+          <Callout tone="danger" live="alert">
             {errorMessage}
-          </p>
+          </Callout>
         )}
         <div className="actions">
           <Button

--- a/frontend/src/screens/import.css
+++ b/frontend/src/screens/import.css
@@ -49,6 +49,14 @@
   vertical-align: middle;
 }
 
+/* The last row has nothing under it to be ruled off from: without this the
+ * mapping table ends on a dangling hairline that reads as a card seam drawn in
+ * the wrong place. */
+.import__table tbody tr:last-child th,
+.import__table tbody tr:last-child td {
+  border-bottom: 0;
+}
+
 .import__table thead th {
   color: var(--textMeta);
   font-weight: var(--fw-medium);

--- a/frontend/src/screens/telegram-connect-form.tsx
+++ b/frontend/src/screens/telegram-connect-form.tsx
@@ -6,6 +6,7 @@ import { useEffect, useId, useRef, useState } from "react";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
 import { Badge, Button, Field, Modal, TextInput } from "../design-system/atoms";
+import { Callout } from "../design-system/callout";
 import { useT } from "../i18n";
 import { problemMessageOf, throwProblem } from "./common";
 import { statusLabel, statusTone } from "./connector-status";
@@ -176,13 +177,9 @@ export function TelegramConnectForm({
             )}
           </Field>
           {errorMessage && (
-            <p
-              role="alert"
-              className="t-caption"
-              style={{ color: "var(--danger)" }}
-            >
+            <Callout tone="danger" live="alert">
               {errorMessage}
-            </p>
+            </Callout>
           )}
           <div className="actions">
             <Button

--- a/frontend/src/screens/users-admin.css
+++ b/frontend/src/screens/users-admin.css
@@ -37,8 +37,9 @@
 
 /* A roster row runs full-bleed against the panel's own edges, the way every
    other list inside a Panel does — it keeps <li> semantics rather than becoming
-   a PanelRow <div>, so the look is spelled here instead. The header above the
-   first row already draws its line, so the row does not draw a second. */
+   a PanelRow <div>, so the look is spelled here instead. PanelRow's shape
+   EXACTLY, reset included: the band above the roster draws the seam, so the
+   first row must not draw a second hairline a pixel under it. */
 .users-row {
   display: flex;
   flex-wrap: wrap;
@@ -48,9 +49,13 @@
   border-top: 1px solid var(--borderSubtle);
 }
 
-/* The section's own description sits on the panel's padding above the rows, and
-   pays for no bottom interval of its own — the first row's own top border is
-   the line that separates them. */
+.users-row:first-child {
+  border-top: 0;
+}
+
+/* The section's own description sits on the panel's padding above the rows. The
+   line that separates it from them is the seam panel.css draws between two
+   adjacent bodies; this only trims the interval it sits on. */
 .users-intro {
   padding-bottom: var(--space-4);
 }
@@ -67,7 +72,7 @@
 }
 
 .users-roster > :not(.users-list) {
-  padding: 0 var(--space-5) var(--space-5);
+  padding: var(--space-5);
 }
 
 /* Let a long name/email shrink and wrap instead of forcing the row wider than


### PR DESCRIPTION
Fourth of the UI-audit series, covering the founder's items 5 and 6. Two reports, one cause: the separators on the settings pages disagreed with each other, and the cards behind them were each solving the same layout problem privately.

## The seam

An audit found **twenty-odd independent `border-top: 1px solid var(--borderSubtle)` declarations** across the screen sheets — seven drawn as `border-bottom`, six full-bleed, seven inset by the body's own 20px, with a `:last-child` reset on about half. The same card could show a line reaching its edges above one section and a line stopping 20px short above the next.

One rule now, in `panel.css`:

> A boundary between two **sections** of a card is a **full-bleed hairline**. A section that wants air instead takes **spacing and no line at all**.

There is no third option, because the third option is what the tree had. Declared as adjacency (`.panel-body + .panel-body`, `.panel-row + .panel-body`) rather than an opt-in class, so a caller cannot forget it. Two spellings of exactly this already existed in screen sheets — two screens independently discovering the same missing rule.

`.panel-body > .section-header:first-child { margin-top: 0 }` is the reset `.card` has always had and `.panel` never got. Unreset, a rule followed by a level-3 heading measured **45px** on the connections tab, **41px** on general and **8px** on people — three distances for one relationship. The reported "Telegram bot has a large additional margin top" was that.

`.table` gains a last-row reset for the same reason at a smaller scale: a rule divides rows, so the last row has nothing to divide from. Without it every table in the tree ended on a hairline pointing at the card edge a few pixels below. Three screens had already reset it privately.

## Capture activity

`<Panel>` with **no `title`**, and a `SectionHeader` nested inside it. So the heading landed as a direct child of `.panel` — which has zero padding — and the card's own name sat flush against its left border while everything under it was indented 20px by `PanelBody`. No header band, no rule, and a title at 15px/600 where the other thirteen settings tabs read `--fs-sm`/`fw-medium`. One prop.

Its funnel passed `<button>` wrappers to `StatStrip`, which documents `StatCard` children — so the plate's slot reset landed on the button and the cards kept their own borders and 12px radius: **five bordered rounded boxes nested inside a plate built to draw none**. The screen answered with `all: unset`, which ties `.stat-strip > *` on specificity, so which rule drew the slot was decided by **stylesheet import order**. `StatStrip` owns a slot that is a control now, and the screen has nothing left to unset. The pressed fill lands on the slot rather than on a wrapper the `StatCard` repainted over — which is why selecting a filter used to show almost nothing.

Its rows were an 8px-gapped stack where each `border-bottom` floated in the middle of the space between two rows rather than dividing them, and the last drew one with nothing under it. Its body took one `form-stack` gap, replacing intervals of 0 / 12 / 8 / 0 / 0 that left Load-more butted against the last row.

## Connected inboxes

The failure of a connect attempt rendered in a `PanelBody` of its own, **two sections below the buttons that caused it**, past a section rule and in the gap before an unrelated heading.

It renders beside the strip that owns it now — and there are two, because one mutation drives both the add block's provider picks and a roster row's Reconnect. `connect.variables` decides which strip owes the explanation; moving it wholesale would have parked a failed *reconnect* under four unrelated *Add* buttons.

Three hand-styled `style={{ color: "var(--danger)" }}` lines in this card and its two connect forms become `Callout tone="danger"`, removing the only place in the tree where the danger colour was spelled by hand.

**Button widths stay shrink-wrapped, deliberately.** `.btn-sm` sets the width floor back to 0 because the small rung lives in dense rows, and a floor would not do what the report wants anyway: side by side, every label longer than the floor still sets its own width, so it would widen "Gmail" toward "Google Calendar" without lining anything up. The real defect was that the two containers disagreed about `align-items`.

## What the new rule broke, and what fixed it

The adjacency rule is a behaviour change, so it found two live regressions on `users-admin`: `.users-intro` and `.users-roster` are adjacent bodies, so the seam is now drawn there — and the roster's first `<li>` drew its own `border-top` one pixel under it, doubling the hairline, while the skeleton/empty surface that renders instead of rows had no top padding and sat flush against the new line. Both fixed; `.users-row` now spells `PanelRow`'s shape exactly, reset included.

## Verification

`make check-fe` green (221 files, 2822 tests). `make fe-uat` green — 47 stories captured, no unclean render. Capture activity and Connected inboxes reviewed in Storybook in both themes, including the pressed-filter state and both new failure placements.

New: two `play`-driven stories for the connect failures, which were only reachable by interaction and had no story in either placement.

## Deliberately not done

`consent.css`'s rows live in a `Card`, which has no full-bleed row slot, so they stay inset by the card's padding — reaching past it with a negative margin would be a third spelling. Converting that surface to a `Panel` is the real answer and is its own change. Same for `company-context`'s groups, where making each its own `PanelBody` means lifting a `QueryGate` out of the body; they took the sanctioned spacing-and-no-line branch instead.

## Still carried from the audit

The two controls that render unstyled (`persongraph.tsx:218`'s `.btn-small`, which exists in no stylesheet; `person360.tsx:107`'s bare `.btn`), the ten hand-rolled `Button` duplicates, `Button` having no `loading` state, the `SETTINGS_TABS` 12/13/14 disagreement, and the `connections.tsx` SVG ego-graph that re-implements the avatar. Next is the agent passport card — the create form moving to a drawer.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies panel seams under one adjacency rule and renders connect failures inline under the buttons that caused them. Old: screens drew their own inset/bleed rules, tables ended on dangling hairlines, and connect errors rendered in a separate section. New: panel seams are full‑bleed via adjacency, tables reset their last row, StatStrip slots behave as controls with pressed/focus chrome, and errors render inline as `Callout tone="danger"`.

- Panels: seam policy in `panel.css` (`.panel-body + .panel-body`, `.panel-row + .panel-body`), heading margin reset for first `SectionHeader`.
- Capture Activity: uses `Panel title`, one `form-stack` body, list rows switch to top-border adjacency, StatStrip slot reset removes nested card borders and shows pressed/focus states.
- Connectors: failure reason attaches to its strip (Add or Reconnect) as ARIA `alert`; actions alignment unified; small buttons remain shrink‑wrapped; refactor into `ConnectorRow`; new Storybook plays and tests cover both failure paths.
- Tables: global last-row border reset in `.table`; confirmed in `extension-access` and `import`.
- IMAP/Telegram forms: inline danger styles replaced with `Callout`.
- Consumer mail domains: baseline becomes its own `PanelBody` band with the panel seam above it.
- Consent: Card-inset rows draw a top border with first-row reset.
- Users-admin: roster first-row reset avoids doubled seam; intro padding corrected.

<sup>Written for commit c34014fe45b599566926ba26940285142f771f39. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1529?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

