### PR TITLE
fix(seed-demo): a second `make seed-demo` no longer stops at 401

### DIFF
--- a/backend/tools/seed-demo/apiclient.go
+++ b/backend/tools/seed-demo/apiclient.go
@@ -9,6 +9,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -311,6 +312,17 @@ func isConflict(err error) bool {
 	return apiErr.Status == http.StatusConflict
 }
 
+// isUnauthorized reports the server rejecting the credential. On a re-seed it
+// means the supplied password is no longer the account's, which is expected:
+// the first run replaced it with seedAdminPassword.
+func isUnauthorized(err error) bool {
+	var apiErr apiError
+	if !asAPIError(err, &apiErr) {
+		return false
+	}
+	return apiErr.Status == http.StatusUnauthorized
+}
+
 // isUnprocessable reports the server refusing a request it understood. For
 // the password rotation it means the account is not on a first-login hold,
 // which is a state to carry on from rather than stop for.
@@ -330,12 +342,13 @@ func isNotFound(err error) bool {
 	return asAPIError(err, &apiErr) && apiErr.Status == http.StatusNotFound
 }
 
+// asAPIError unwraps to the server's refusal. It uses errors.As rather than a
+// type assertion because call sites DO wrap: login() returns
+// fmt.Errorf("login as %s: %w", …), and a bare assertion saw nothing through
+// that — which is why a re-seed reported a plain 401 instead of falling back
+// to the password an earlier run set.
 func asAPIError(err error, target *apiError) bool {
-	if converted, ok := err.(apiError); ok { //nolint:errorlint // the only wrapper here is fmt.Errorf at call sites that do not wrap this type
-		*target = converted
-		return true
-	}
-	return false
+	return errors.As(err, target)
 }
 
 // conflictingID pulls the existing record's id out of a duplicate refusal.

--- a/backend/tools/seed-demo/main.go
+++ b/backend/tools/seed-demo/main.go
@@ -75,7 +75,7 @@ func run() error {
 	}
 	fmt.Printf("dataset: %d company/companies from %s\n", len(companies), *dataset)
 
-	client, err := login(*baseURL, *email, *password)
+	client, err := loginAllowingAnEarlierSeed(*baseURL, *email, password)
 	if err != nil {
 		return err
 	}
@@ -134,6 +134,33 @@ func run() error {
 		return err
 	}
 	return verifySeed(client, demo, modeFor(*dryRun))
+}
+
+// loginAllowingAnEarlierSeed signs in, and on a rejected credential tries the
+// password THIS tool would have set on an earlier run.
+//
+// The first seed replaces the operator password with seedAdminPassword, while
+// every run after it is handed the original by `make seed-demo`, which reads
+// config/margince-admin-password and cannot know that. Re-running the seeder
+// is meant to converge rather than stop at a 401, so a rejected credential is
+// worth one more attempt before it becomes an error.
+//
+// It updates password in place, because replaceOperatorPassword needs to know
+// which credential the returned client actually holds.
+func loginAllowingAnEarlierSeed(baseURL, email string, password *string) (*client, error) {
+	client, err := login(baseURL, email, *password)
+	if err == nil {
+		return client, nil
+	}
+	if !isUnauthorized(err) || *password == seedAdminPassword {
+		return nil, err
+	}
+	client, err = login(baseURL, email, seedAdminPassword)
+	if err != nil {
+		return nil, fmt.Errorf("signing in as %s with the supplied password and with the one an earlier seed would have set: %w", email, err)
+	}
+	*password = seedAdminPassword
+	return client, nil
 }
 
 // seedWhatNeedsSQLAfterCompanies runs everything that needs the companies on


### PR DESCRIPTION
Re-running the seeder is meant to converge. It did not — the second run failed
before writing anything:

```
seed-demo: login as admin@demo.test: HTTP 401: invalid email or password
```

The first run replaces the operator password with `demo-password-123`
(`replaceOperatorPassword`, migration 0273's first-login hold). `make seed-demo`
reads `config/margince-admin-password` and hands over the **original** every
time, which is correct — it has no way to know the seeder rotated it.

`login()` now falls back to the password this tool itself would have set, in a
new `loginAllowingAnEarlierSeed` helper.

## The wider bug underneath

The fallback did not work when first written, for a reason worth its own
paragraph: **`asAPIError` used a bare type assertion**, so it saw nothing
through `fmt.Errorf("…: %w")`. `login()` wraps, so `isUnauthorized` always
answered false.

`isConflict`, `isNotFound` and `conflictingID` read through the same helper,
and the seeder's convergence depends on all three — a duplicate refusal
reached through any wrapper was invisible to them too. It now uses
`errors.As`.

The old code carried a `//nolint:errorlint` with the comment "the only wrapper
here is fmt.Errorf at call sites that do not wrap this type". That was not
true of `login`.

## Verification

Against an installation whose password an earlier seed had already rotated,
seeding with the original password converges:

```
finance links: 0 new
facts:         0 applied
verify:        OK — every seeded record is owned, employed, linked and staged
```

`make craft-static` and `make check-backend` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-seeding with `make seed-demo` now converges instead of stopping at a 401 after the first run rotates the operator password. Previously, the second run failed at login; now it retries with the seed password and proceeds, and API error unwrapping is fixed so convergence checks work under wrapped errors.

- Add `loginAllowingAnEarlierSeed` that retries login with `seedAdminPassword` on 401 and updates the provided `password` in place to reflect the credential the returned client holds.
- Replace type assertion in `asAPIError` with `errors.As`, restoring correct behavior for `isUnauthorized`, `isConflict`, `isNotFound`, and `conflictingID` when errors are wrapped.
- Add `isUnauthorized` and switch `run()` to use `loginAllowingAnEarlierSeed` in `backend/tools/seed-demo/main.go`.

<sup>Written for commit 42efbb27b50915b7a838a4870d9b2794db84d51e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1530?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

