### PR TITLE
docs(status): where phase D stands, and what each remaining group needs

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -878,6 +878,31 @@ webhooks, agents, privacy. Configuration and machinery rather than records,
 which is why the stakes were low, but low is not none and a reader should not
 have to infer it from migration numbers.
 
+### Where phase D stands: 66 tables
+
+Merged since the gate: briefs (#1486), capture (#1491), overlay (#1510,
+fork-owned so it lands in `migrations/custom/`), ai + migration (#1525, split
+across both namespaces because the importer is fork-owned). 103 → 66.
+
+**What is left, and the shape of each:**
+
+| group | tables | note |
+|---|---|---|
+| deals — the spine | `deal`, `pipeline`, `stage`, `deal_stage_history`, `deal_forecast_history` | ~97 sites. The most-referenced table after `person`; take it alone |
+| deals — quoting & delivery | `offer`, `offer_line_item`, `offer_template`, `product`, `project`, `project_phase_history`, `fx_rate` | ~31 sites, and the natural next slice |
+| people | `person` and its satellites, `organization` and its, `lead`, `relationship`, `partner`, `dedupe_candidate`, `site_read`, `conversation_claim` | ~20 tables, the largest group |
+| identity | `app_user`, `session`, `role`, `role_assignment`, `team`, `team_membership`, `passport`, `oauth_*`, `auth_token`, `record_grant`, `extension_secret`, `onboarding_wizard_state` | `app_user` is what `MustWorkspace` ultimately hangs on |
+| activities | `activity`, `activity_link`, `activity_participant`, `activity_participant_replay`, `attachment`, `booking_page`, `scheduled_send`, `transcript_read` | |
+| search | `embedding`, `graph_interaction_edge` | entangled with the re-embed fan-out — do the run-lifecycle collapse first |
+| the rest | `idempotency_key`, `field_provenance`, `user_record_view`, `suggestion_dismissal`, `person_moment_dismissal`, `signal_thread_scan`, `linkedin_*`, `mirror_*` leftovers | |
+| **last** | `audit_log`, `system_log` | the append-only ledgers, by the decision recorded above |
+
+**Slice by ownership, not by convenience.** Two of the four merged slices had to
+be split or moved mid-flight because a table turned out to be fork-owned
+(`migrations/custom/`, ADR-0017): overlay entirely, the importer half of the AI
+slice. Check `grep -rl "CREATE TABLE.*<name>" migrations/` before writing the
+migration, not after `migrate up` refuses.
+
 **Three of the four fan-out modules are collapsed** — webhooks (#1255), agents
 (#1283) and privacy (#1337) — each landing its module's phase D columns in the
 same PR, because the suites proving the fan-out asserted isolation between two


### PR DESCRIPTION
Four slices merged since the archived-tenant gate — briefs (#1486), capture (#1491), overlay (#1510), ai + migration (#1525) — taking ADR-0091 §8 phase D from 103 tables to **66**.

STATUS recorded the findings from each of those, but never the position. A session picking this up had to re-derive the remaining set from the catalog and re-guess how to cut it. This adds the table, grouped the way the work actually divides, with the two facts that are not visible from the schema:

- **The deals module has to be cut in half.** Its spine (`deal`, `pipeline`, `stage` and the two histories) is ~97 sites — the most-referenced table after `person`. The quoting and delivery tail (`offer`, `product`, `project`, `fx_rate`, …) is ~31 and is the natural next slice.
- **The search pair waits on the re-embed run-lifecycle collapse**, which is already recorded below it as the one fan-out that is not a wiring artefact.

And the rule two of the four slices learned the hard way: **check which migration namespace owns a table before writing the migration.** Overlay is fork-owned entirely, and the importer half of the AI slice was too. Both were discovered by `migrate up` refusing with *relation does not exist*, after the migration was already written into `core/`.

Docs only — no code, no migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a STATUS.md section that states the Phase D position: 66 tables remain, grouped by workstream and ownership with ordering constraints. Previously STATUS logged slice findings but not the remaining set, forcing re-derivation and guesswork on how to cut the work.

**Review notes**
- Docs only; no behavior or migration changes.
- Records four merged slices since the archived-tenant gate and the 103→66 reduction.
- Defines the deals split: take the spine first (`deal`, `pipeline`, `stage`, histories; most-referenced after `person`), then quoting/delivery (`offer`, `product`, `project`, `fx_rate`, etc.).
- Blocks `embedding`/`graph_interaction_edge` on the re-embed run-lifecycle collapse; plan this group after that change.
- Requires ownership checks before migrations: verify table namespace and place fork-owned tables in `migrations/custom/` (overlay and the importer slice).

<sup>Written for commit b9251bb9bd0405cc82dcf90d3f8e6ee59c839e22. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1531?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

