### PR TITLE
docs(status): the phase D sweep has to reach backend/tools/ as well

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -903,6 +903,14 @@ be split or moved mid-flight because a table turned out to be fork-owned
 slice. Check `grep -rl "CREATE TABLE.*<name>" migrations/` before writing the
 migration, not after `migrate up` refuses.
 
+**Sweep `backend/tools/` too — it is a second Go module and `go build ./...`
+never compiles it.** The capture slice swept `internal/`, `extensions/`,
+`fixtures/`, `scripts/` and `cmd/`, and missed `tools/seed-demo`, which writes
+`capture_connection` directly; seeding a fresh installation then failed on the
+column that had just been dropped (#1528 repaired it). Nothing in the gates
+catches this — the tools module compiles on its own, and no lane seeds a demo —
+so it has to be in the grep.
+
 **Three of the four fan-out modules are collapsed** — webhooks (#1255), agents
 (#1283) and privacy (#1337) — each landing its module's phase D columns in the
 same PR, because the suites proving the fan-out asserted isolation between two


### PR DESCRIPTION
The capture slice (#1491) swept `internal/`, `extensions/`, `fixtures/`, `scripts/` and `cmd/`, and missed `tools/seed-demo`, which writes `capture_connection` directly. Seeding a fresh installation then failed on the column that had just been dropped — #1528 repaired it.

Nothing in the gates catches this, which is why it is worth writing down rather than remembering: `backend/tools/` is its own Go module, so `go build ./...` never compiles it, and no test lane seeds a demo. Five more phase-D slices are still to come and every one of them can repeat it.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds guidance to STATUS.md to include `backend/tools/` in phase D sweeps, since it is a separate Go module that `go build ./...` and CI do not cover. This prevents missing `tools/seed-demo` writes (e.g., to `capture_connection`) that can break fresh-install seeding after column drops.

<sup>Written for commit 6a2cd3abe9f15fb9ee99b4ea61081f5baadc47c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1534?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

