### PR TITLE
fix(design-system): the buttons that were not buttons, and the gate that keeps them

### DIFF
--- a/frontend/src/design-system/atoms.tsx
+++ b/frontend/src/design-system/atoms.tsx
@@ -1,6 +1,5 @@
 import { ChevronRight, MoreHorizontal, Search } from "lucide-react";
 import {
-  type ButtonHTMLAttributes,
   type ComponentPropsWithRef,
   type CSSProperties,
   type ElementType,
@@ -32,7 +31,12 @@ export function Button({
   reasonId,
   disabled,
   ...rest
-}: ButtonHTMLAttributes<HTMLButtonElement> & {
+  // `ComponentPropsWithRef`, not the bare attribute set — the same reason
+  // `TextInput` takes it: a caller that has to move focus to this control, or
+  // restore it here after a dialog its own mutation removed the opener of,
+  // needs the node. React 19 passes `ref` as an ordinary prop to a function
+  // component, so this costs nothing but the type.
+}: ComponentPropsWithRef<"button"> & {
   variant?: ButtonVariant;
   small?: boolean;
   /**

--- a/frontend/src/design-system/base.css
+++ b/frontend/src/design-system/base.css
@@ -127,6 +127,26 @@
   background: var(--bgHover);
   color: var(--textPrimary);
 }
+/* A button that TOGGLES has to show which way it is set. `aria-pressed` is the
+   fact — it is already on every toggle in the tree — but nothing drew it, so a
+   selected relationship-graph node announced itself as pressed and looked
+   exactly like its unpressed neighbours, on a panel whose whole point is that
+   selecting a node drives the detail below it. The accent pairing is the one
+   the list surface already uses for a pressed chip (`.lt-chip.active`), so a
+   set toggle reads the same wherever it is drawn.
+
+   Scoped to the ghost variant: primary and danger carry a fill already, and a
+   pressed state has to differ from the resting one rather than replace a
+   stronger signal with a weaker. */
+.btn-ghost[aria-pressed="true"] {
+  border-color: var(--accentMed);
+  background: var(--accentLight);
+  color: var(--accent);
+}
+.btn-ghost[aria-pressed="true"]:hover {
+  background: var(--accentMed);
+  color: var(--accent);
+}
 .btn-sm {
   padding: 6px 11px;
   font-size: 12.5px;

--- a/frontend/src/design-system/conformance.test.ts
+++ b/frontend/src/design-system/conformance.test.ts
@@ -248,6 +248,73 @@ describe("design-system conformance gates (B-EP09.1)", scanBudget, () => {
     expect(violations, violations.join("\n")).toEqual([]);
   });
 
+  // One spelling of the button. `Button` (design-system/atoms.tsx) is what
+  // emits `btn` — a `className` that spells the base class itself is a
+  // hand-rolled copy of it, and a copy is frozen at the day it was written: the
+  // width floor, the focus ring, the icon sizing and the shared control height
+  // all landed on Button and reached none of the ten copies this gate was
+  // written to clear.
+  //
+  // The rule is deliberately narrow so it states its own exception. It matches
+  // the `btn` BASE token only — a `.btn-*` modifier in a STYLESHEET is how the
+  // variants are declared, and a component class that merely ends in `btn`
+  // (`iconbtn`, `lt-btn`) is a different control. And it matches every element
+  // EXCEPT an anchor: `Button` renders a `<button>`, so a link that looks like
+  // a button (screens/client.tsx's "create a lead" href) has no component to
+  // reach for and is legitimately styled by hand.
+  it("renders every button through Button — no hand-rolled btn classes", () => {
+    const violations: string[] = [];
+    for (const file of files) {
+      // atoms.tsx is Button's own file: it is where `btn` is minted.
+      if (!file.endsWith(".tsx") || file.endsWith("design-system/atoms.tsx")) {
+        continue;
+      }
+      const source = ts.createSourceFile(
+        file,
+        readFileSync(file, "utf8"),
+        ts.ScriptTarget.ES2022,
+        true,
+        ts.ScriptKind.TSX,
+      );
+      const visit = (node: ts.Node) => {
+        if (ts.isJsxAttribute(node) && node.name.getText() === "className") {
+          const element = node.parent.parent;
+          const tag = element.tagName.getText();
+          // Every literal fragment the className can evaluate to, so a
+          // conditional or an interpolated class list is read too.
+          const fragments: string[] = [];
+          const collect = (child: ts.Node) => {
+            if (
+              ts.isStringLiteral(child) ||
+              ts.isTemplateLiteralToken(child) ||
+              ts.isJsxText(child)
+            ) {
+              fragments.push(child.text);
+            }
+            ts.forEachChild(child, collect);
+          };
+          if (node.initializer) {
+            collect(node.initializer);
+          }
+          const handRolled = fragments.some((fragment) =>
+            fragment.split(/\s+/).includes("btn"),
+          );
+          if (handRolled && tag !== "a") {
+            const { line } = source.getLineAndCharacterOfPosition(
+              node.getStart(),
+            );
+            violations.push(
+              `${relative(frontendRoot, file)}:${line + 1} <${tag}> spells the btn class by hand — import Button from design-system/atoms`,
+            );
+          }
+        }
+        ts.forEachChild(node, visit);
+      };
+      visit(source);
+    }
+    expect(violations, violations.join("\n")).toEqual([]);
+  });
+
   it("keeps literal colours in tokens.css only — everything else reads a token", () => {
     const literalColour = /#[0-9a-fA-F]{3,8}\b|\b(?:rgba?|hsla?|oklch)\(/;
     for (const file of files) {

--- a/frontend/src/design-system/evidencemark.tsx
+++ b/frontend/src/design-system/evidencemark.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useId, useRef, useState } from "react";
 import { useT } from "../i18n";
+import { Button } from "./atoms";
 import type { ConfidenceLevel, Provenance } from "./trust";
 import { ProvenanceTag } from "./trust";
 import "./evidencemark.css";
@@ -149,16 +150,15 @@ export function EvidenceMark({
           )}
           {source.at && <p className="evmark-at">{source.at}</p>}
           {onOpenHistory && (
-            <button
-              type="button"
-              className="btn btn-ghost btn-sm"
+            <Button
+              small
               onClick={() => {
                 setOpen(false);
                 onOpenHistory();
               }}
             >
               {historyLabel ?? t("evidence.fullHistory")}
-            </button>
+            </Button>
           )}
         </section>
       )}

--- a/frontend/src/design-system/recordpicker.tsx
+++ b/frontend/src/design-system/recordpicker.tsx
@@ -1,6 +1,6 @@
 import { Check } from "lucide-react";
 import { useEffect, useState } from "react";
-import { SearchField } from "./atoms";
+import { Button, SearchField } from "./atoms";
 
 // The shared debounced search→candidate-list→pick pattern: this used to live
 // duplicated, near-identically, inline in MergeAction (screens/merge.tsx) and
@@ -130,9 +130,8 @@ export function RecordPicker({
         <ul className="recordpicker-options">
           {candidates.map((candidate) => (
             <li key={candidate.id}>
-              <button
-                type="button"
-                className="btn btn-ghost recordpicker-option"
+              <Button
+                className="recordpicker-option"
                 aria-pressed={selected?.id === candidate.id}
                 disabled={disabled}
                 onClick={() => {
@@ -144,7 +143,7 @@ export function RecordPicker({
                 }}
               >
                 {candidate.name}
-              </button>
+              </Button>
             </li>
           ))}
         </ul>

--- a/frontend/src/design-system/trust.tsx
+++ b/frontend/src/design-system/trust.tsx
@@ -1,6 +1,7 @@
 import { ArrowRight, ChevronRight } from "lucide-react";
 import { type ReactNode, useState } from "react";
 import { useT } from "../i18n";
+import { Button } from "./atoms";
 import "./trust.css";
 
 // The Margince trust primitives (B-EP09.3a, design-language §4): the
@@ -269,23 +270,15 @@ export function ApprovalGate({
   const t = useT();
   return (
     <div className="approval-gate">
-      <button
-        type="button"
-        className="btn btn-primary btn-sm"
-        onClick={onAccept}
-      >
+      <Button variant="primary" small onClick={onAccept}>
         {t("trust.accept")}
-      </button>
-      <button type="button" className="btn btn-ghost btn-sm" onClick={onEdit}>
+      </Button>
+      <Button small onClick={onEdit}>
         {t("trust.edit")}
-      </button>
-      <button
-        type="button"
-        className="btn btn-ghost btn-sm"
-        onClick={onDismiss}
-      >
+      </Button>
+      <Button small onClick={onDismiss}>
         {t("trust.dismiss")}
-      </button>
+      </Button>
     </div>
   );
 }
@@ -386,9 +379,9 @@ export function StagedProposal({
               setState({ phase: "editing", draft: event.target.value })
             }
           />
-          <button type="submit" className="btn btn-primary btn-sm">
+          <Button type="submit" variant="primary" small>
             {t("trust.save")}
-          </button>
+          </Button>
         </form>
       ) : (
         <ApprovalGate

--- a/frontend/src/screens/candidatepicker.css
+++ b/frontend/src/screens/candidatepicker.css
@@ -1,0 +1,15 @@
+/* The candidate row of a search→pick affordance: a full-bleed Button whose
+   label is a record name, so it reads as a row rather than as a chip centred in
+   its own list.
+
+   One sheet for two screens on purpose. MergeAction (screens/merge.tsx) and
+   AddRelationshipAction (screens/relationships.tsx) are the two copies of the
+   pattern RecordPicker (design-system/recordpicker.tsx) extracted and neither
+   has migrated onto yet; both carried this rule inline, byte-identically, where
+   no stylesheet could see it. Naming it once means the two cannot drift apart
+   while they wait. When they migrate they take `.recordpicker-option` with
+   them and this file goes. */
+.candidate-option {
+  width: 100%;
+  text-align: left;
+}

--- a/frontend/src/screens/merge.tsx
+++ b/frontend/src/screens/merge.tsx
@@ -7,6 +7,7 @@ import { navigate, type Route } from "../app/router";
 import { Button, Modal, SearchField } from "../design-system/atoms";
 import { useT } from "../i18n";
 import { problemMessageOf, useSorMode } from "./common";
+import "./candidatepicker.css";
 
 // The shared "Merge into…" affordance (P-2): a human direct call that folds
 // this record (the source, A) into a picked survivor (B) — A is archived
@@ -146,15 +147,13 @@ export function MergeAction<Survivor extends { id: string }>({
         <ul style={{ listStyle: "none", margin: "8px 0", padding: 0 }}>
           {candidates.map((candidate) => (
             <li key={candidate.id}>
-              <button
-                type="button"
-                className="btn btn-ghost"
+              <Button
+                className="candidate-option"
                 aria-pressed={target?.id === candidate.id}
                 onClick={() => setTarget(candidate)}
-                style={{ width: "100%", textAlign: "left" }}
               >
                 {candidate.name}
-              </button>
+              </Button>
             </li>
           ))}
         </ul>

--- a/frontend/src/screens/person360.css
+++ b/frontend/src/screens/person360.css
@@ -894,3 +894,10 @@
 .person-pulse-facts {
   margin-top: var(--space-3);
 }
+
+/* The one move the thin-record surface offers, spaced off the sentence that
+   explains why it is the move. It carried an inline `marginTop` before, which
+   is a spacing decision hidden where no stylesheet can see it. */
+.thin-log-first {
+  margin-top: var(--space-3);
+}

--- a/frontend/src/screens/person360.stories.tsx
+++ b/frontend/src/screens/person360.stories.tsx
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { components } from "../api/schema";
+import { LocaleProvider } from "../i18n";
+import { ThinState } from "./person360";
+import "./person360.css";
+
+/**
+ * The thin-record surface: what a person page says when it has almost nothing
+ * to say about the person.
+ *
+ * It had no story, which is how its one control shipped carrying a bare
+ * `className="btn"`. A bare `btn` names no variant, and the variants are what
+ * carry the fill, the border and the ink — so the single move this surface
+ * offers rendered transparent and borderless on the card behind it. That is
+ * invisible to a type checker and to every test that only asks whether the
+ * button is in the document.
+ */
+const meta: Meta<typeof ThinState> = {
+  title: "Records/Person record/Thin record",
+  component: ThinState,
+  parameters: { layout: "padded" },
+  decorators: [
+    (Story) => (
+      <LocaleProvider initial="en">
+        <Story />
+      </LocaleProvider>
+    ),
+  ],
+};
+export default meta;
+type Story = StoryObj<typeof ThinState>;
+
+type View = components["schemas"]["Person360"];
+const page = { has_more: false, next_cursor: null };
+
+// A record carrying a name, an address and nothing else — which is the state
+// this surface exists for. The employments list is empty on purpose: the
+// remediation the card offers is chosen by what is MISSING, and an absent
+// employer is what sends it down the other branch.
+const bare: View = {
+  as_of: "2026-08-13T09:00:00Z",
+  person: {
+    id: "p-9",
+    full_name: "Mara Vogel",
+    first_name: "Mara",
+    last_name: "Vogel",
+    owner_id: "u-1",
+    emails: [
+      {
+        id: "pe-9",
+        person_id: "p-9",
+        email: "mara.vogel@example.test",
+        email_type: "work",
+        is_primary: true,
+        position: 0,
+        source: "manual",
+      },
+    ],
+  },
+  employments: { data: [], page },
+  activities: { data: [], page },
+  deals: { data: [], page },
+  colleagues: { data: [], page },
+} as unknown as View;
+
+// The same record, with an employer on it. The card offers a different move,
+// which is the whole point of the branch — a menu of two would say the surface
+// does not know which one matters.
+const withEmployer: View = {
+  ...bare,
+  employments: {
+    data: [
+      {
+        id: "em-9",
+        person_id: "p-9",
+        organization_id: "o-9",
+        organization_name: "Brandt Logistik",
+        is_current_primary: true,
+      },
+    ],
+    page,
+  },
+} as unknown as View;
+
+/** No employer: the move on offer is to name where this person works. */
+export const NoEmployer: Story = {
+  render: () => <ThinState view={bare} onLogActivity={() => {}} />,
+};
+
+/** An employer, so the move on offer is to capture something that happened. */
+export const WithEmployer: Story = {
+  render: () => <ThinState view={withEmployer} onLogActivity={() => {}} />,
+};
+
+/**
+ * No move at all. The caller passes no handler, so the card states the
+ * situation and offers nothing — which has to read as a deliberate absence
+ * rather than as a button that failed to draw. That distinction is exactly
+ * what the unstyled button destroyed.
+ */
+export const NothingToOffer: Story = {
+  render: () => <ThinState view={bare} />,
+};
+
+/**
+ * Dark, because the card's plate, the sentence on it and the primary button are
+ * three surfaces whose separation is carried by tokens that move between
+ * themes.
+ */
+export const NoEmployerDark: Story = {
+  name: "No employer — dark",
+  globals: { theme: "dark" },
+  render: () => <ThinState view={bare} onLogActivity={() => {}} />,
+};

--- a/frontend/src/screens/person360.tsx
+++ b/frontend/src/screens/person360.tsx
@@ -3,7 +3,13 @@ import type { ReactNode } from "react";
 
 import { api } from "../api/client";
 import type { components } from "../api/schema";
-import { Badge, Card, Disclosure, SectionHeader } from "../design-system/atoms";
+import {
+  Badge,
+  Button,
+  Card,
+  Disclosure,
+  SectionHeader,
+} from "../design-system/atoms";
 import { EvidenceMark } from "../design-system/evidencemark";
 import { FactList } from "../design-system/factlist";
 import type { ConfidenceLevel } from "../design-system/trust";
@@ -103,15 +109,18 @@ export function ThinState({
           })}
         </p>
         <p style={{ margin: "10px 0 0", lineHeight: 1.55 }}>{remediation}</p>
+        {/* A bare `.btn` names no variant, and the variants are what carry the
+            fill, the border and the ink — so this rendered transparent,
+            borderless and unreadable against the plate behind it. It is the one
+            move this surface offers, so it is the primary. */}
         {onLogActivity && (
-          <button
-            type="button"
-            className="btn"
-            style={{ marginTop: "var(--space-3)" }}
+          <Button
+            variant="primary"
+            className="thin-log-first"
             onClick={onLogActivity}
           >
             {t("person.thin.logFirst")}
-          </button>
+          </Button>
         )}
       </div>
     </Card>

--- a/frontend/src/screens/persongraph.stories.tsx
+++ b/frontend/src/screens/persongraph.stories.tsx
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { userEvent, within } from "storybook/test";
+import { PersonGraphPanel } from "./persongraph";
+import { installFetchStub, jsonResponse, StoryProviders } from "./story-utils";
+
+/**
+ * Who can open a door to this person, and through whom.
+ *
+ * The panel had no story, which is how its node list shipped spelling
+ * `className="btn-ghost btn-small"` — a variant with no base `btn` beside it,
+ * and a size class that exists in no stylesheet in this tree (the real one is
+ * `.btn-sm`). Under Tailwind's preflight that is a naked native button: no
+ * padding, no boundary, no hover, no focus ring. Its own docblock says the
+ * nodes "are real buttons and selecting one drives a live detail region", and
+ * they did work — they simply did not look like anything.
+ */
+const meta: Meta<typeof PersonGraphPanel> = {
+  title: "Records/Person record/Relationship graph",
+  component: PersonGraphPanel,
+  parameters: { layout: "padded" },
+};
+export default meta;
+type Story = StoryObj<typeof PersonGraphPanel>;
+
+const graph = {
+  person_id: "p-1",
+  nodes: [
+    {
+      id: "person:p-1",
+      type: "contact",
+      group: "anchor",
+      label: "Dana Buyer",
+      sublabel: "Head of Fleet",
+    },
+    {
+      id: "user:u-1",
+      type: "colleague",
+      group: "direct",
+      label: "Lars Brandt",
+      sublabel: "six exchanges in 90 days",
+    },
+    {
+      id: "user:u-2",
+      type: "colleague",
+      group: "direct",
+      label: "Mara Vogel",
+      sublabel: "one exchange in 90 days",
+    },
+    {
+      id: "org:o-1",
+      type: "organization",
+      group: "second_degree",
+      label: "Brandt Logistik",
+    },
+  ],
+  edges: [
+    {
+      from: "user:u-1",
+      to: "person:p-1",
+      strength_bucket: "strong",
+      interactions_90d: 6,
+      inbound_90d: 3,
+      outbound_90d: 3,
+    },
+    {
+      from: "user:u-2",
+      to: "person:p-1",
+      strength_bucket: "weak",
+      interactions_90d: 1,
+      inbound_90d: 0,
+      outbound_90d: 1,
+    },
+  ],
+  groups_omitted: [],
+  route: {
+    via_user_id: "u-1",
+    via_display_name: "Lars Brandt",
+    why: "6 two-way exchanges in 90 days · last contact yesterday",
+  },
+};
+
+function stub(body: unknown) {
+  installFetchStub({ "GET /people/p-1/graph": () => jsonResponse(body) });
+}
+
+/** The answer leads; the node list is the working underneath it. */
+export const Routed: Story = {
+  render: () => {
+    stub(graph);
+    return (
+      <StoryProviders>
+        <PersonGraphPanel personId="p-1" />
+      </StoryProviders>
+    );
+  },
+};
+
+/**
+ * A node selected. The pressed state is what says which door the detail region
+ * below is describing, and it is carried by the button's own chrome — so a node
+ * that draws no chrome cannot show it at all.
+ */
+export const NodeSelected: Story = {
+  render: () => {
+    stub(graph);
+    return (
+      <StoryProviders>
+        <PersonGraphPanel personId="p-1" />
+      </StoryProviders>
+    );
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(await canvas.findByRole("button", { name: /Lars/ }));
+  },
+};
+
+/**
+ * Nobody knows them yet. The panel says so rather than drawing an empty list,
+ * because an empty list and a list that failed to render are the same shape.
+ */
+export const NoRoute: Story = {
+  render: () => {
+    stub({
+      person_id: "p-1",
+      nodes: [
+        {
+          id: "person:p-1",
+          type: "contact",
+          group: "anchor",
+          label: "Dana Buyer",
+        },
+      ],
+      edges: [],
+      groups_omitted: [],
+      route: null,
+    });
+    return (
+      <StoryProviders>
+        <PersonGraphPanel personId="p-1" />
+      </StoryProviders>
+    );
+  },
+};
+
+/**
+ * Dark, where the node buttons sit on the card's own ground and their boundary
+ * is the only thing separating them from it.
+ */
+export const RoutedDark: Story = {
+  name: "Routed — dark",
+  globals: { theme: "dark" },
+  render: () => {
+    stub(graph);
+    return (
+      <StoryProviders>
+        <PersonGraphPanel personId="p-1" />
+      </StoryProviders>
+    );
+  },
+};

--- a/frontend/src/screens/persongraph.tsx
+++ b/frontend/src/screens/persongraph.tsx
@@ -3,7 +3,7 @@ import { useState } from "react";
 
 import { api } from "../api/client";
 import type { components } from "../api/schema";
-import { Badge, Card, SectionHeader } from "../design-system/atoms";
+import { Badge, Button, Card, SectionHeader } from "../design-system/atoms";
 import { useT } from "../i18n";
 import { problemMessageOf, throwProblem } from "./common";
 
@@ -215,15 +215,20 @@ function NodeList({
     >
       {nodes.map((node) => (
         <li key={node.id}>
-          <button
-            type="button"
-            className="btn-ghost btn-small"
+          {/* The design system's Button. This was
+              `className="btn-ghost btn-small"` — a class list naming a variant
+              with no base `.btn` beside it, and a size class that exists in no
+              stylesheet in the tree (the real one is `.btn-sm`). So the control
+              rendered with none of a button's chrome at all: Tailwind's
+              preflight had already stripped the browser's own. */}
+          <Button
+            small
             aria-pressed={selected === node.id}
             onClick={() => onSelect(node.id)}
           >
             {node.label}
             {node.sublabel ? ` · ${node.sublabel}` : ""}
-          </button>
+          </Button>
         </li>
       ))}
     </ul>

--- a/frontend/src/screens/relationships.tsx
+++ b/frontend/src/screens/relationships.tsx
@@ -26,6 +26,7 @@ import { problemMessageOf, QueryGate, throwProblem } from "./common";
 import type { CreateField } from "./create";
 import { EditAction } from "./edit";
 import { EntityRef } from "./entityref";
+import "./candidatepicker.css";
 
 // The Relationships tab (P-5): the one surface a person/company 360 renders
 // its relationship edges through (employment, deal stakeholder, partner-of,
@@ -423,15 +424,13 @@ function AddRelationshipAction({
           <ul style={{ listStyle: "none", margin: 0, padding: 0 }}>
             {candidates.map((candidate) => (
               <li key={candidate.id}>
-                <button
-                  type="button"
-                  className="btn btn-ghost"
+                <Button
+                  className="candidate-option"
                   aria-pressed={target?.id === candidate.id}
                   onClick={() => setTarget(candidate)}
-                  style={{ width: "100%", textAlign: "left" }}
                 >
                   {candidate.name}
-                </button>
+                </Button>
               </li>
             ))}
           </ul>

--- a/frontend/src/screens/settings.css
+++ b/frontend/src/screens/settings.css
@@ -5,8 +5,8 @@
 
 /* EVERY settings page's vertical rhythm, owned in one place.
    `.wrap > .card + .card` (app/shell.css) is the shell's default and it matches a
-   card FOLLOWING a card. After the eleven-entry merge most settings pages are no
-   longer stacks of cards — General holds a `<form>`, a `<section>` and a Card;
+   card FOLLOWING a card. Since the entries were merged, most settings pages are
+   no longer stacks of cards — General holds a `<form>`, a `<section>` and a Card;
    People holds two flex wrappers; Data model holds a block, a card and two
    heading-plus-table pairs — so that rule silently missed and the gap between two
    unrelated surfaces was ZERO. Two hairlines touching read as one card.

--- a/frontend/src/screens/settings.tsx
+++ b/frontend/src/screens/settings.tsx
@@ -134,11 +134,16 @@ import "./settings.css";
 // takes; and the operational verbs that were hiding beside the field editor — a
 // reindex, job health, the danger zone — became a place of their own.
 //
-// One of those merges was later UNDONE, which is why the count is not eleven:
-// connectors and the overlay both answer "what are we connected to" and were
-// merged on that reading, but the question has two different owners — see the
-// split below. The thirteenth is newer and additive: Capture activity answers
-// what those connections DID, which no existing entry could say.
+// One of those merges was later UNDONE: connectors and the overlay both answer
+// "what are we connected to" and were merged on that reading, but the question
+// has two different owners — see the split below. Capture activity is newer and
+// additive: it answers what those connections DID, which no existing entry
+// could say.
+//
+// No sentence here counts the entries. Three of them used to, and by the time
+// anyone looked they said eleven, twelve and thirteen for a register holding
+// fourteen — a number in prose beside a list is a second source of truth that
+// nothing updates and no test can check. The list below is the count.
 //
 // Two groups: "you" (per-user, every member) and "org" (organization config).
 // Every org entry carries its OWN predicate — the grant the cards on it actually
@@ -161,8 +166,8 @@ import "./settings.css";
 // one entry belonging to both. Split by WHOSE thing each surface is, they both get
 // an honest predicate, and the ungated special case is gone rather than moved.
 //
-// Width is NOT an entry's business. Every page takes the whole column, so the
-// twelve of them line up with each other and with the rest of the app: a reader
+// Width is NOT an entry's business. Every page takes the whole column, so they
+// line up with each other and with the rest of the app: a reader
 // moving between two settings pages sees the content start and end where the
 // last one did. A per-page measure buys a nicer form column at the cost of the
 // page appearing to change size as you navigate, and of a knob each new entry
@@ -586,9 +591,9 @@ export function SettingsScreen({ tab }: Readonly<{ tab?: string }>) {
   // card and settings pages are no longer stacks of cards: the merge left several
   // holding a `<form>`, a `<section>`, a flex wrapper or a bare heading-plus-table.
   // Where the rule missed, the gap was ZERO and two surfaces read as one. Owning
-  // it once is the difference between twelve pages that space correctly and
-  // twelve that each have to remember to. Width is owned the same way and is the
-  // same for all twelve, so there is nothing here to branch on.
+  // it once is the difference between every page spacing correctly and every
+  // page having to remember to. Width is owned the same way and is the same for
+  // all of them, so there is nothing here to branch on.
   return (
     <div className="wrap">
       <ResumeConnectBanner />

--- a/frontend/src/screens/share.tsx
+++ b/frontend/src/screens/share.tsx
@@ -191,9 +191,8 @@ function renderSubjectList(
         const already = grantedSubjectIds.has(candidate.id);
         return (
           <li key={candidate.id}>
-            <button
-              type="button"
-              className="btn btn-ghost share-subject-row"
+            <Button
+              className="share-subject-row"
               disabled={already}
               aria-pressed={selected?.id === candidate.id}
               onClick={() => onPick(candidate)}
@@ -205,7 +204,7 @@ function renderSubjectList(
               <span className="share-subject-note">
                 {already ? t("share.alreadyGranted") : candidate.note}
               </span>
-            </button>
+            </Button>
           </li>
         );
       })}


### PR DESCRIPTION
Cleanup of the findings the UI audit turned up outside the changes that reported them.

## Two controls rendered unstyled

`persongraph.tsx` spelled `className="btn-ghost btn-small"` — a variant with no base `.btn` beside it, and a size class that **exists in no stylesheet in this tree** (the real one is `.btn-sm`). `person360.tsx` spelled a bare `className="btn"`, and the variants are what carry the fill, the border and the ink.

Under Tailwind's preflight both were naked native buttons: no padding, no boundary, no hover, no focus ring. Both are `Button` now, and the second one's inline `marginTop` moved into its screen sheet — a layout decision carried inline is one no stylesheet can see.

## Seven more hand-rolled the classes, four inside the design system

The approval triad and the staged-proposal save in `trust.tsx`, the history link in `evidencemark.tsx`, the candidate row in `recordpicker.tsx`, and the row shared **byte for byte** between `merge.tsx` and `relationships.tsx`.

A copy drifts: `Button` recently gained a width floor, a focus ring, icon sizing and a shared control height, and not one of these got any of it. The two identical candidate rows now share one stylesheet rather than one each, with a comment saying it should die when both migrate onto `RecordPicker`.

`client.tsx` keeps its hand-rolled classes **on purpose** — it is an `<a>`, `Button` renders a `<button>`, and a link that looks like a button is a real thing.

## The gate

`conformance.test.ts` parses every `.tsx` the tree yields, reads every literal fragment of each `className` (template parts included, so an interpolated class list is still read), and fails on a bare `btn` token outside `atoms.tsx`, where it is minted.

Anchors do not match — which states *structurally* why `client.tsx` is fine, rather than carrying it as a named exception. Verified by reintroducing one of the duplicates and watching it go red.

## A toggle now shows which way it is set

Nothing drew `aria-pressed`. A selected relationship-graph node announced itself as pressed and looked exactly like its unpressed neighbours — on a panel whose own docblock says *"nodes are real buttons and selecting one drives a live detail region"*. They did work; they just did not look like anything. The ghost variant takes the accent pairing the list surface already uses for a pressed chip.

This was invisible until the panel had a story. It is the second thing in this PR that only a rendered page could have found.

## `Button` takes a ref

It typed its props as `ButtonHTMLAttributes` where `TextInput` uses `ComponentPropsWithRef` and documents exactly why — a caller that has to move focus to a control, or restore it after a dialog whose own mutation removed the opener, needs the node. React 19 passes `ref` as an ordinary prop, so this costs nothing but the type.

## The settings prose stopped counting

Three sentences across `settings.tsx` and `settings.css` each named how many tabs there are, and they said **eleven, twelve and thirteen for a register holding fourteen**. A number in prose beside the list it describes is a second source of truth that nothing updates and no test can check, so the numbers are gone rather than corrected. The register is the count.

## Stories

Both repaired surfaces get the story they never had — which is most of why they shipped broken. The thin-record card in its three branches (no employer, employer, nothing to offer), and the graph panel routed, selected, and with nobody to route through. Both in dark as well.

## Verification

`make check-fe` green (221 files, 2827 tests). `make fe-uat` green — 122 stories captured, no unclean render.

## Deliberately not here

**`Button` has no `loading` state.** ~100 call sites hand-roll `disabled={isPending}` plus a swapped label, and none announces `aria-busy`. Adding the prop is easy; migrating 100 sites and deciding each one's pending copy is a feature change that wants its own review.

**The `connections.tsx` ego-graph avatar** cannot simply import `Avatar` — that is an HTML component and this is an SVG `<circle>` in a force graph. The honest fix is extracting the initials and tone derivation so both media share it, which is design work rather than a one-liner.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes all buttons through `Button` and adds a conformance gate that blocks hand-rolled `btn` classes, fixing two unstyled controls and preventing regressions. Old: `persongraph` node list used `btn-ghost btn-small` and `person360` used bare `btn`, which rendered with no chrome. New: both use `Button`; ghost toggles show pressed state; `Button` accepts a `ref`.

**Changes**
- Conformance: `design-system/conformance.test.ts` scans `.tsx` files, reads literal and template fragments from `className`, and fails on a bare `btn` token outside `design-system/atoms.tsx`. Anchors are exempt; stylesheets declaring `.btn-*` are unaffected.
- Fixes: `persongraph` node list and `person360` primary now use `Button`. Ghost toggles draw `[aria-pressed="true"]`. Candidate rows share `.candidate-option` in `screens/candidatepicker.css`. Thin-record spacing moved to `.thin-log-first`. Stories added for both surfaces, including selection and dark themes.
- Typing: `Button` now uses `ComponentPropsWithRef<"button">` and accepts `ref` for focus control.

**Migration**
- Use `Button` from `design-system/atoms` for all buttons; do not spell `btn` in `className`.
- Keep links that look like buttons as `<a>`; the gate ignores anchors.
- Set `aria-pressed` on toggles so the pressed styling renders.
- You can pass a `ref` to `Button` for focus management.

<sup>Written for commit c258c4c28f8e8a025af650355894f36a25347305. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1537?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

