### PR TITLE
refactor(deals): quoting and delivery drop the tenant column (ADR-0091 §8 phase D)

### DIFF
--- a/backend/internal/compose/integration/approval_livetarget_integration_test.go
+++ b/backend/internal/compose/integration/approval_livetarget_integration_test.go
@@ -159,7 +159,7 @@ func seedUnlinkedActivity(t *testing.T, e *Env, subject string) ids.UUID {
 func seedLiveOffer(t *testing.T, e *Env, deal ids.UUID) ids.UUID {
 	t.Helper()
 	id := ids.NewV7()
-	e.WsExec(t, `INSERT INTO offer (id, workspace_id, deal_id, offer_number, currency, source, captured_by)
-		VALUES ($1, $2, $3, $4, 'EUR', 'manual', 'human:fixture')`, id, e.WS, deal, "AN-"+id.String())
+	e.WsExec(t, `INSERT INTO offer (id, deal_id, offer_number, currency, source, captured_by)
+		VALUES ($1, $2, $3, 'EUR', 'manual', 'human:fixture')`, id, deal, "AN-"+id.String())
 	return id
 }

--- a/backend/internal/compose/integration/installation_settings_integration_test.go
+++ b/backend/internal/compose/integration/installation_settings_integration_test.go
@@ -278,10 +278,10 @@ func TestBaseCurrencyFreezesOnASentOfferWithNoClosedDeal(t *testing.T) {
 		                  amount_minor, currency, status)
 		VALUES ($1, $2, 'Open deal', $3, $4, 'seed', 'system:test', 100000, 'EUR', 'open')`,
 		pipeline, stage)
-	e.Seed(t, `
-		INSERT INTO offer (id, workspace_id, deal_id, offer_number, currency, status,
+	e.SeedID(t, `
+		INSERT INTO offer (id, deal_id, offer_number, currency, status,
 		                   fx_rate_to_base, fx_rate_date, source, captured_by)
-		VALUES ($1, $2, $3, 'AN-2026-001', 'EUR', 'sent', 1.0850000000, current_date, 'seed', 'system:test')`,
+		VALUES ($1, $2, 'AN-2026-001', 'EUR', 'sent', 1.0850000000, current_date, 'seed', 'system:test')`,
 		deal)
 
 	// Prove the fixture is the one this test claims: no deal froze anything.
@@ -322,9 +322,9 @@ func TestBaseCurrencyWillNotMoveOutFromUnderAPricedRateSheet(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	e.Seed(t, `
-		INSERT INTO fx_rate (id, workspace_id, from_currency, to_currency, rate, rate_date)
-		VALUES ($1, $2, 'USD', $3, 0.9150000000, current_date)`, base.BaseCurrency)
+	e.SeedID(t, `
+		INSERT INTO fx_rate (id, from_currency, to_currency, rate, rate_date)
+		VALUES ($1, 'USD', $2, 0.9150000000, current_date)`, base.BaseCurrency)
 
 	chf := "CHF"
 	_, err = store.UpdateInstallation(admin, nil, nil, &chf)

--- a/backend/internal/compose/integration/installationseam_integration_test.go
+++ b/backend/internal/compose/integration/installationseam_integration_test.go
@@ -26,8 +26,8 @@ import (
 func baseCurrencyOnUSD(t *testing.T, e *Env) {
 	t.Helper()
 	e.WsExec(t, `UPDATE setting SET value = '"USD"'::jsonb WHERE key = 'installation.base_currency'`)
-	e.WsExec(t, `INSERT INTO fx_rate (workspace_id, from_currency, to_currency, rate, rate_date)
-		VALUES ($1, 'EUR', 'USD', '1.1000000000', CURRENT_DATE - 1)`, e.WS)
+	e.WsExec(t, `INSERT INTO fx_rate (from_currency, to_currency, rate, rate_date)
+		VALUES ('EUR', 'USD', '1.1000000000', CURRENT_DATE - 1)`)
 }
 
 // Closing a EUR deal freezes the EUR→USD rate. The identity rate 1 is what a

--- a/backend/internal/compose/integration/lifecycle_invariants_integration_test.go
+++ b/backend/internal/compose/integration/lifecycle_invariants_integration_test.go
@@ -315,8 +315,8 @@ func TestRepricingAClosedDealRefreezesFx(t *testing.T) {
 
 	owner := OwnerConn(t)
 	if _, err := owner.Exec(context.Background(),
-		`INSERT INTO fx_rate (workspace_id, from_currency, to_currency, rate, rate_date)
-		 VALUES ($1, 'USD', 'EUR', 0.9200000000, current_date)`, e.WS); err != nil {
+		`INSERT INTO fx_rate (from_currency, to_currency, rate, rate_date)
+		 VALUES ('USD', 'EUR', 0.9200000000, current_date)`); err != nil {
 		t.Fatal(err)
 	}
 

--- a/backend/internal/compose/integration/listsortcoverage_integration_test.go
+++ b/backend/internal/compose/integration/listsortcoverage_integration_test.go
@@ -59,11 +59,11 @@ func TestProductListSortsByEveryOfferedColumn(t *testing.T) {
 
 	// Seeded so that creation order disagrees with every sort below: a list
 	// still ordering by created_at would return the same page each time.
-	const seedProduct = `INSERT INTO product (id, workspace_id, name, sku, unit, unit_price_minor, currency, default_tax_rate, active, source, captured_by, created_at, updated_at)
-	                     VALUES ($1, $2, $3, $4, 'day', $5, 'EUR', 0, $6, 'ui', 'human:x', $7, $8)`
-	e.Seed(t, seedProduct, "Middle", "SKU-M", 5000, true, seedMiddle, seedEarliest)
-	e.Seed(t, seedProduct, "Apex", "SKU-A", 9000, false, seedLatest, seedMiddle)
-	e.Seed(t, seedProduct, "Zenith", "SKU-Z", 1000, true, seedEarliest, seedLatest)
+	const seedProduct = `INSERT INTO product (id, name, sku, unit, unit_price_minor, currency, default_tax_rate, active, source, captured_by, created_at, updated_at)
+	                     VALUES ($1, $2, $3, 'day', $4, 'EUR', 0, $5, 'ui', 'human:x', $6, $7)`
+	e.SeedID(t, seedProduct, "Middle", "SKU-M", 5000, true, seedMiddle, seedEarliest)
+	e.SeedID(t, seedProduct, "Apex", "SKU-A", 9000, false, seedLatest, seedMiddle)
+	e.SeedID(t, seedProduct, "Zenith", "SKU-Z", 1000, true, seedEarliest, seedLatest)
 
 	store := deals.NewStore(e.DB(), installseam.Deals())
 	for _, tc := range []struct {
@@ -97,11 +97,11 @@ func TestOfferTemplateListSortsByEveryOfferedColumn(t *testing.T) {
 	e := SetupSearch(t)
 	ctx := asCatalogueReader(e.WS, "offer_template")
 
-	const seedTemplate = `INSERT INTO offer_template (id, workspace_id, name, locale, is_default, layout, created_at, updated_at)
-	                      VALUES ($1, $2, $3, $4, $5, '{}'::jsonb, $6, $7)`
-	e.Seed(t, seedTemplate, "Middle", "de-DE", false, seedMiddle, seedEarliest)
-	e.Seed(t, seedTemplate, "Apex", "en-GB", false, seedLatest, seedMiddle)
-	e.Seed(t, seedTemplate, "Zenith", "fr-FR", true, seedEarliest, seedLatest)
+	const seedTemplate = `INSERT INTO offer_template (id, name, locale, is_default, layout, created_at, updated_at)
+	                      VALUES ($1, $2, $3, $4, '{}'::jsonb, $5, $6)`
+	e.SeedID(t, seedTemplate, "Middle", "de-DE", false, seedMiddle, seedEarliest)
+	e.SeedID(t, seedTemplate, "Apex", "en-GB", false, seedLatest, seedMiddle)
+	e.SeedID(t, seedTemplate, "Zenith", "fr-FR", true, seedEarliest, seedLatest)
 
 	store := deals.NewStore(e.DB(), installseam.Deals())
 	for _, tc := range []struct {

--- a/backend/internal/compose/integration/offer_acceptline_integration_test.go
+++ b/backend/internal/compose/integration/offer_acceptline_integration_test.go
@@ -51,10 +51,10 @@ func stageLine(t *testing.T, e *Env, offerID crmcontracts.Id, position int) ids.
 	t.Helper()
 	lineID := ids.NewV7()
 	e.WsExec(t, `
-		INSERT INTO offer_line_item (id, workspace_id, offer_id, position, description,
+		INSERT INTO offer_line_item (id, offer_id, position, description,
 		                             quantity, unit_price_minor, tax_rate, proposal_state)
-		VALUES ($1, $2, $3, $4, 'AI-proposed support', 2, 5000, 19.00, 'staged')`,
-		lineID, e.WS, ids.UUID(offerID), position)
+		VALUES ($1, $2, $3, 'AI-proposed support', 2, 5000, 19.00, 'staged')`,
+		lineID, ids.UUID(offerID), position)
 	return lineID
 }
 

--- a/backend/internal/compose/integration/offers_integration_test.go
+++ b/backend/internal/compose/integration/offers_integration_test.go
@@ -354,8 +354,8 @@ func assertSendFreezesDailyFxRate(t *testing.T, e *apptest.AppEnv, wsID, offerID
 		t.Fatalf("send with missing fx rate → %d, want 422", status)
 	}
 	if _, err := e.Owner.Exec(context.Background(),
-		`INSERT INTO fx_rate (workspace_id, from_currency, to_currency, rate, rate_date)
-		 VALUES ($1, 'USD', 'EUR', 0.9200000000, current_date)`, wsID); err != nil {
+		`INSERT INTO fx_rate (from_currency, to_currency, rate, rate_date)
+		 VALUES ('USD', 'EUR', 0.9200000000, current_date)`); err != nil {
 		t.Fatal(err)
 	}
 	var sent offerBody

--- a/backend/internal/compose/integration/offerstaged_integration_test.go
+++ b/backend/internal/compose/integration/offerstaged_integration_test.go
@@ -231,12 +231,12 @@ func TestAddStagedOfferLinesUngroundedPriceIsTheHonestZeroSentinel(t *testing.T)
 	err = database.WithWorkspaceTx(rawCtx, e.Pool, func(tx pgx.Tx) error {
 		_, err := tx.Exec(rawCtx,
 			`INSERT INTO offer_line_item
-			   (workspace_id, offer_id, position, description, quantity, unit_price_minor,
+			   (offer_id, position, description, quantity, unit_price_minor,
 			    tax_rate, price_grounded, proposal_state)
-			 VALUES ($1, $2,
-			         (SELECT COALESCE(MAX(position), 0) + 1 FROM offer_line_item WHERE offer_id = $2),
+			 VALUES ($1,
+			         (SELECT COALESCE(MAX(position), 0) + 1 FROM offer_line_item WHERE offer_id = $1),
 			         'Bypassed bogus line', 1, 500, '0.00', false, 'staged')`,
-			e.WS, offerID.UUID)
+			offerID.UUID)
 		return err
 	})
 	if _, ok := storekit.CheckViolation(err); !ok {

--- a/backend/internal/compose/integration/orgrollup_integration_test.go
+++ b/backend/internal/compose/integration/orgrollup_integration_test.go
@@ -80,9 +80,9 @@ func seedRollupWonDeal(t *testing.T, e *Env, st rollupStages, org ids.UUID,
 
 func seedRollupFxRate(t *testing.T, e *Env, fromCurrency, rate string, day time.Time) {
 	t.Helper()
-	e.WsExec(t, `INSERT INTO fx_rate (workspace_id, from_currency, to_currency, rate, rate_date)
-		VALUES ($1, $2, 'EUR', $3, $4)`,
-		e.WS, fromCurrency, rate, day)
+	e.WsExec(t, `INSERT INTO fx_rate (from_currency, to_currency, rate, rate_date)
+		VALUES ($1, 'EUR', $2, $3)`,
+		fromCurrency, rate, day)
 }
 
 func seedRollupOrgActivity(t *testing.T, e *Env, org ids.UUID, occurredAt time.Time) {

--- a/backend/internal/compose/integration/queryplan_integration_test.go
+++ b/backend/internal/compose/integration/queryplan_integration_test.go
@@ -134,8 +134,8 @@ func (q *queryEnv) seedFixture(t *testing.T) queryFixture {
 		VALUES ($1, $2, $3, 'Stuttgart Logistik', 'Stuttgart', 'manual', 'human:x')`, q.Rep3)
 	// A project named like a deal, so the traversal proves that two tables
 	// sharing a column name resolve to the right one.
-	f.project = q.Seed(t, `INSERT INTO project (id, workspace_id, owner_id, name, organization_id, source, captured_by)
-		VALUES ($1, $2, $3, 'Rollout', $4, 'manual', 'human:x')`, q.Rep1, f.rep1Org)
+	f.project = q.SeedID(t, `INSERT INTO project (id, owner_id, name, organization_id, source, captured_by)
+		VALUES ($1, $2, 'Rollout', $3, 'manual', 'human:x')`, q.Rep1, f.rep1Org)
 
 	f.rep1Deal = q.Seed(t, `INSERT INTO deal (id, workspace_id, owner_id, name, pipeline_id, stage_id, organization_id, project_id, amount_minor, currency, status, expected_close_date, source, captured_by)
 		VALUES ($1, $2, $3, 'Rollout', $4, $5, $6, $7, 100000, 'EUR', 'open', '2026-12-01', 'manual', 'human:x')`,

--- a/backend/internal/compose/integration/quotas_attainment_integration_test.go
+++ b/backend/internal/compose/integration/quotas_attainment_integration_test.go
@@ -433,8 +433,8 @@ func TestQuotaAttainmentConvertsAgainstTheInstallationSetting(t *testing.T) {
 	// EUR→USD on file, so a target in EUR has a rate into the new base. The
 	// suite's seedRollupFxRate helper hardcodes to_currency = 'EUR', which is
 	// itself an assumption this test exists to break, so the row goes in here.
-	e.WsExec(t, `INSERT INTO fx_rate (workspace_id, from_currency, to_currency, rate, rate_date)
-		VALUES ($1, 'EUR', 'USD', '1.1000000000', $2)`, e.WS, attainmentClock.AddDate(0, 0, -1))
+	e.WsExec(t, `INSERT INTO fx_rate (from_currency, to_currency, rate, rate_date)
+		VALUES ('EUR', 'USD', '1.1000000000', $1)`, attainmentClock.AddDate(0, 0, -1))
 
 	in := ownerQuotaInput(e.Rep1, 1000000) // 10,000.00 EUR
 	in.Currency = "EUR"

--- a/backend/internal/compose/integration/report_project_integration_test.go
+++ b/backend/internal/compose/integration/report_project_integration_test.go
@@ -30,8 +30,8 @@ func (e *SearchEnv) seedProjects(t *testing.T, phase string, owner *ids.UUID, n 
 	orgID = e.Seed(t, `INSERT INTO organization (id, workspace_id, display_name, source, captured_by)
 		VALUES ($1, $2, 'Project Org', 'manual', 'human:x')`)
 	for i := 0; i < n; i++ {
-		e.Seed(t, `INSERT INTO project (id, workspace_id, name, organization_id, owner_id, phase, source, captured_by)
-			VALUES ($1, $2, $3, $4, $5, $6, 'manual', 'human:x')`,
+		e.SeedID(t, `INSERT INTO project (id, name, organization_id, owner_id, phase, source, captured_by)
+			VALUES ($1, $2, $3, $4, $5, 'manual', 'human:x')`,
 			fmt.Sprintf("%s Rollout %d", phase, i), orgID, owner, phase)
 	}
 	return orgID
@@ -119,8 +119,8 @@ func TestAdHocProjectReportCountsUnderRowScope(t *testing.T) {
 
 	// The rep's own project is counted — the empty answer above is scope, not
 	// a plan that never matches.
-	e.Seed(t, `INSERT INTO project (id, workspace_id, name, organization_id, owner_id, phase, source, captured_by)
-		VALUES ($1, $2, 'Own Rollout', $3, $4, 'pursuing', 'manual', 'human:x')`, orgID, e.Rep1)
+	e.SeedID(t, `INSERT INTO project (id, name, organization_id, owner_id, phase, source, captured_by)
+		VALUES ($1, 'Own Rollout', $2, $3, 'pursuing', 'manual', 'human:x')`, orgID, e.Rep1)
 	res, err = provider.RunReport(e.projectReader(&e.Rep1, &e.Team1, principal.RowScopeTeam), datasource.ReportPlan{
 		Entity: datasource.EntityProject, GroupBy: []string{"phase"},
 	})

--- a/backend/internal/compose/integration/searchenv.go
+++ b/backend/internal/compose/integration/searchenv.go
@@ -122,6 +122,19 @@ func (e *SearchEnv) Seed(t *testing.T, sql string, args ...any) ids.UUID {
 	return id
 }
 
+// SeedID is Seed for a table that no longer has a workspace to bind: it mints
+// the id and nothing else. ADR-0091 §8 phase D is removing the column table by
+// table, so the set of fixtures needing this form only grows — and when the last
+// table loses it, this becomes the only form and Seed goes.
+func (e *SearchEnv) SeedID(t *testing.T, sql string, args ...any) ids.UUID {
+	t.Helper()
+	id := ids.NewV7()
+	if _, err := e.Owner.Exec(context.Background(), sql, append([]any{id}, args...)...); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+	return id
+}
+
 // searchObjects is the record vocabulary this fixture's principals reach. Named
 // once because the read and write grant sets must cover the same objects — if
 // they drifted, a suite comparing a reader against a writer would be comparing

--- a/backend/internal/compose/integration/webhooks/webhooks_integration_test.go
+++ b/backend/internal/compose/integration/webhooks/webhooks_integration_test.go
@@ -656,9 +656,9 @@ func (we *webhookEnv) seedProduct(t *testing.T, name string) ids.UUID {
 	t.Helper()
 	id := ids.NewV7()
 	we.execInWorkspace(t,
-		`INSERT INTO product (id, workspace_id, name, unit_price_minor, currency, source, captured_by)
-		 VALUES ($1, $2, $3, 1000, 'USD', 'manual', 'human:x')`,
-		id, we.wsID, name)
+		`INSERT INTO product (id, name, unit_price_minor, currency, source, captured_by)
+		 VALUES ($1, $2, 1000, 'USD', 'manual', 'human:x')`,
+		id, name)
 	return id
 }
 

--- a/backend/internal/compose/integration/writeauthority_integration_test.go
+++ b/backend/internal/compose/integration/writeauthority_integration_test.go
@@ -341,9 +341,9 @@ func TestAReadShareOfADealCannotEditItsOffer(t *testing.T) {
 		 VALUES ($1, $2, $3, 'Shared Deal', $4, $5, 'manual', 'human:x')`, e.Rep3, pipeline, stage)
 	offer := ids.NewV7()
 	if _, err := e.Owner.Exec(context.Background(),
-		`INSERT INTO offer (id, workspace_id, deal_id, offer_number, currency, source, captured_by)
-		 VALUES ($1, $2, $3, $4, 'EUR', 'manual', 'human:fixture')`,
-		offer, e.WS, deal, "AN-"+offer.String()); err != nil {
+		`INSERT INTO offer (id, deal_id, offer_number, currency, source, captured_by)
+		 VALUES ($1, $2, $3, 'EUR', 'manual', 'human:fixture')`,
+		offer, deal, "AN-"+offer.String()); err != nil {
 		t.Fatalf("seeding the offer: %v", err)
 	}
 

--- a/backend/internal/modules/activities/commitments_integration_test.go
+++ b/backend/internal/modules/activities/commitments_integration_test.go
@@ -212,9 +212,9 @@ func TestNarrowingToAnUnreadableRecordAnswersNotFound(t *testing.T) {
 	orgID, hiddenProjectID, taskID := ids.NewV7(), ids.NewV7(), ids.NewV7()
 	e.exec(t, `INSERT INTO organization (id, workspace_id, display_name, owner_id, source, captured_by)
 		VALUES ($1, $2, 'Zeta GmbH', $3, 'seed', 'system')`, orgID, e.ws, e.rep)
-	e.exec(t, `INSERT INTO project (id, workspace_id, name, organization_id, owner_id, source, captured_by)
-		VALUES ($1, $2, $3, $4, $5, 'seed', 'system')`,
-		hiddenProjectID, e.ws, hiddenProjectNam, orgID, e.other)
+	e.exec(t, `INSERT INTO project (id, name, organization_id, owner_id, source, captured_by)
+		VALUES ($1, $2, $3, $4, 'seed', 'system')`,
+		hiddenProjectID, hiddenProjectNam, orgID, e.other)
 	// The task is assigned to the CALLER, so nothing about the task itself is
 	// what hides it — only the project the sweep is narrowed to.
 	e.exec(t, `INSERT INTO activity (id, workspace_id, kind, subject, occurred_at, due_at,

--- a/backend/internal/modules/activities/messageidentity_absorb_integration_test.go
+++ b/backend/internal/modules/activities/messageidentity_absorb_integration_test.go
@@ -111,8 +111,8 @@ func (e *sendEnv) seedProject(t *testing.T, name string) ids.UUID {
 	}
 	id := ids.NewV7()
 	if _, err := e.owner.Exec(context.Background(), `
-		INSERT INTO project (id, workspace_id, name, organization_id, source, captured_by)
-		VALUES ($1, $2, $3, $4, 'manual', 'human:x')`, id, e.ws, name, org); err != nil {
+		INSERT INTO project (id, name, organization_id, source, captured_by)
+		VALUES ($1, $2, $3, 'manual', 'human:x')`, id, name, org); err != nil {
 		t.Fatalf("seeding the project: %v", err)
 	}
 	return id

--- a/backend/internal/modules/deals/fxrate_store.go
+++ b/backend/internal/modules/deals/fxrate_store.go
@@ -208,12 +208,12 @@ func (s *Store) writeFxRate(ctx context.Context, tx pgx.Tx, from string, in SetF
 		fxID ids.UUID
 	)
 	if err := tx.QueryRow(ctx, `
-		INSERT INTO fx_rate (workspace_id, from_currency, to_currency, rate, rate_date)
-		VALUES ($1, $2, $3, $4::numeric, $5)
+		INSERT INTO fx_rate (from_currency, to_currency, rate, rate_date)
+		VALUES ($1, $2, $3::numeric, $4)
 		ON CONFLICT (from_currency, to_currency, rate_date)
 		DO UPDATE SET rate = EXCLUDED.rate
 		RETURNING id, from_currency, to_currency, rate::text, rate_date`,
-		storekit.MustWorkspace(ctx), from, base, rate, effDate,
+		from, base, rate, effDate,
 	).Scan(&fxID, &out.FromCurrency, &out.ToCurrency, &out.Rate, &out.RateDate); err != nil {
 		return FxRateRow{}, fmt.Errorf("upsert fx_rate: %w", err)
 	}

--- a/backend/internal/modules/deals/offer.go
+++ b/backend/internal/modules/deals/offer.go
@@ -112,14 +112,14 @@ func createOfferTx(ctx context.Context, tx pgx.Tx, dealID ids.DealID, in CreateO
 
 	id := ids.New[ids.OfferKind]()
 	if _, err := tx.Exec(ctx,
-		`INSERT INTO offer (id, workspace_id, deal_id, offer_number, revision, status, currency,
+		`INSERT INTO offer (id, deal_id, offer_number, revision, status, currency,
 		                    buyer_org_id, valid_until, intro_text, terms_text, template_id, source, captured_by)
-		 VALUES ($1, $2, $3, $4, 1, 'draft', $5, $6, $7, $8, $9, $10, $11, $12)`,
-		id, wsID, dealID, number, in.Currency, buyerOrg, in.ValidUntil, in.IntroText, in.TermsText,
+		 VALUES ($1, $2, $3, 1, 'draft', $4, $5, $6, $7, $8, $9, $10, $11)`,
+		id, dealID, number, in.Currency, buyerOrg, in.ValidUntil, in.IntroText, in.TermsText,
 		in.TemplateID, in.Source, by); err != nil {
 		return crmcontracts.Offer{}, fmt.Errorf("insert offer: %w", err)
 	}
-	if err := insertOfferLines(ctx, tx, wsID, id, in.Currency, in.LineItems); err != nil {
+	if err := insertOfferLines(ctx, tx, id, in.Currency, in.LineItems); err != nil {
 		return crmcontracts.Offer{}, err
 	}
 	if err := recomputeOfferTotals(ctx, tx, id); err != nil {
@@ -178,8 +178,7 @@ func resolveOfferTemplateRef(ctx context.Context, tx pgx.Tx, templateID *ids.Off
 	var exists bool
 	if err := tx.QueryRow(ctx,
 		`SELECT EXISTS (SELECT 1 FROM offer_template
-		   WHERE id = $1 AND archived_at IS NULL
-		     AND workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid)`,
+		   WHERE id = $1 AND archived_at IS NULL)`,
 		*templateID).Scan(&exists); err != nil {
 		return fmt.Errorf("check offer_template reference: %w", err)
 	}
@@ -189,7 +188,7 @@ func resolveOfferTemplateRef(ctx context.Context, tx pgx.Tx, templateID *ids.Off
 	return nil
 }
 
-// nextOfferNumber mints the workspace's next human-facing Angebot number
+// nextOfferNumber mints the installation's next human-facing Angebot number
 // under a transaction-scoped advisory lock — two concurrent creates
 // serialize on the mint instead of racing into offer_number_rev_unique.
 func nextOfferNumber(ctx context.Context, tx pgx.Tx, wsID ids.UUID) (string, error) {
@@ -200,7 +199,7 @@ func nextOfferNumber(ctx context.Context, tx pgx.Tx, wsID ids.UUID) (string, err
 	var next int
 	if err := tx.QueryRow(ctx,
 		`SELECT COALESCE(MAX(substring(offer_number FROM '^A-([0-9]+)$')::int), 1000) + 1
-		 FROM offer WHERE workspace_id = $1`, wsID).Scan(&next); err != nil {
+		 FROM offer`).Scan(&next); err != nil {
 		return "", fmt.Errorf("mint offer number: %w", err)
 	}
 	return fmt.Sprintf("A-%d", next), nil

--- a/backend/internal/modules/deals/offer_lifecycle.go
+++ b/backend/internal/modules/deals/offer_lifecycle.go
@@ -404,8 +404,8 @@ func nextOfferRevision(ctx context.Context, tx pgx.Tx, wsID ids.UUID, offerNumbe
 	}
 	var nextRevision int
 	if err := tx.QueryRow(ctx,
-		`SELECT MAX(revision) + 1 FROM offer WHERE workspace_id = $1 AND offer_number = $2`,
-		wsID, offerNumber).Scan(&nextRevision); err != nil {
+		`SELECT MAX(revision) + 1 FROM offer WHERE offer_number = $1`,
+		offerNumber).Scan(&nextRevision); err != nil {
 		return 0, fmt.Errorf("mint next revision: %w", err)
 	}
 	return nextRevision, nil
@@ -416,10 +416,10 @@ func nextOfferRevision(ctx context.Context, tx pgx.Tx, wsID ids.UUID, offerNumbe
 // snapshot semantics: nothing is re-derived from today's products.
 func copyOfferIntoRevision(ctx context.Context, tx pgx.Tx, fromID, newID ids.OfferID, nextRevision int, by string) error {
 	if _, err := tx.Exec(ctx,
-		`INSERT INTO offer (id, workspace_id, deal_id, offer_number, revision, status, currency,
+		`INSERT INTO offer (id, deal_id, offer_number, revision, status, currency,
 		                    buyer_org_id, valid_until, intro_text, terms_text,
 		                    net_minor, tax_minor, gross_minor, source, captured_by)
-		 SELECT $1, workspace_id, deal_id, offer_number, $3, 'draft', currency,
+		 SELECT $1, deal_id, offer_number, $3, 'draft', currency,
 		        buyer_org_id, valid_until, intro_text, terms_text,
 		        net_minor, tax_minor, gross_minor, source, $4
 		 FROM offer WHERE id = $2`,
@@ -430,9 +430,9 @@ func copyOfferIntoRevision(ctx context.Context, tx pgx.Tx, fromID, newID ids.Off
 	// not silently become accepted (and start counting toward totals)
 	// just because the offer grew a revision.
 	if _, err := tx.Exec(ctx,
-		`INSERT INTO offer_line_item (id, workspace_id, offer_id, position, product_id, description,
+		`INSERT INTO offer_line_item (id, offer_id, position, product_id, description,
 		                              unit, quantity, unit_price_minor, discount_pct, tax_rate, evidence, proposal_state, price_grounded)
-		 SELECT uuidv7(), workspace_id, $2, position, product_id, description,
+		 SELECT uuidv7(), $2, position, product_id, description,
 		        unit, quantity, unit_price_minor, discount_pct, tax_rate, evidence, proposal_state, price_grounded
 		 FROM offer_line_item WHERE offer_id = $1`,
 		fromID, newID); err != nil {

--- a/backend/internal/modules/deals/offer_lines.go
+++ b/backend/internal/modules/deals/offer_lines.go
@@ -57,9 +57,9 @@ type OfferLineInputRow struct {
 
 // insertOfferLines inserts each input line in order, numbering the 422
 // error by the caller's 1-based line position.
-func insertOfferLines(ctx context.Context, tx pgx.Tx, wsID ids.UUID, offerID ids.OfferID, currency string, lines []OfferLineInputRow) error {
+func insertOfferLines(ctx context.Context, tx pgx.Tx, offerID ids.OfferID, currency string, lines []OfferLineInputRow) error {
 	for i, line := range lines {
-		if err := insertOfferLine(ctx, tx, wsID, offerID, currency, line); err != nil {
+		if err := insertOfferLine(ctx, tx, offerID, currency, line); err != nil {
 			return fmt.Errorf("line %d: %w", i+1, err)
 		}
 	}
@@ -90,7 +90,7 @@ type resolvedOfferLine struct {
 	Tax         string
 }
 
-func insertOfferLine(ctx context.Context, tx pgx.Tx, wsID ids.UUID, offerID ids.OfferID, offerCurrency string, in OfferLineInputRow) error {
+func insertOfferLine(ctx context.Context, tx pgx.Tx, offerID ids.OfferID, offerCurrency string, in OfferLineInputRow) error {
 	defaults, err := resolveProductSnapshot(ctx, tx, in.ProductID, offerCurrency, lineSnapshotDefaults{
 		Description: in.Description, Unit: in.Unit, Price: in.UnitPriceMinor, TaxRate: in.TaxRate,
 	})
@@ -111,7 +111,7 @@ func insertOfferLine(ctx context.Context, tx pgx.Tx, wsID ids.UUID, offerID ids.
 	}); err != nil {
 		return err
 	}
-	return insertOfferLineRow(ctx, tx, wsID, offerID, in, resolvedOfferLine{
+	return insertOfferLineRow(ctx, tx, offerID, in, resolvedOfferLine{
 		Description: *defaults.Description, Unit: unitVal, Price: *defaults.Price, Discount: discount, Tax: tax,
 	})
 }
@@ -175,7 +175,7 @@ func normalizeLineDefaults(unit, discountPct, taxRate *string) (unitVal, discoun
 
 // insertOfferLineRow assigns the line's position (appending after the last
 // when unset) and inserts it, mapping a position collision to 409.
-func insertOfferLineRow(ctx context.Context, tx pgx.Tx, wsID ids.UUID, offerID ids.OfferID, in OfferLineInputRow, line resolvedOfferLine) error {
+func insertOfferLineRow(ctx context.Context, tx pgx.Tx, offerID ids.OfferID, in OfferLineInputRow, line resolvedOfferLine) error {
 	position := in.Position
 	if position == nil {
 		next, err := nextOfferLinePosition(ctx, tx, offerID)
@@ -187,10 +187,10 @@ func insertOfferLineRow(ctx context.Context, tx pgx.Tx, wsID ids.UUID, offerID i
 	// note: an offer_line_item is not a first-class entity (no LineItemKind),
 	// so its row id stays an untyped ids.UUID.
 	_, err := tx.Exec(ctx,
-		`INSERT INTO offer_line_item (id, workspace_id, offer_id, position, product_id, description,
+		`INSERT INTO offer_line_item (id, offer_id, position, product_id, description,
 		                              unit, quantity, unit_price_minor, discount_pct, tax_rate)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`,
-		ids.NewV7(), wsID, offerID, *position, in.ProductID, line.Description,
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
+		ids.NewV7(), offerID, *position, in.ProductID, line.Description,
 		line.Unit, in.Quantity, line.Price, line.Discount, line.Tax)
 	if err != nil {
 		if storekit.IsUniqueViolation(err) {
@@ -229,7 +229,7 @@ func (s *Store) AddOfferLineItem(ctx context.Context, offerID ids.OfferID, in Of
 		if err := ensureDraft(current); err != nil {
 			return err
 		}
-		if err := insertOfferLine(ctx, tx, storekit.MustWorkspace(ctx), offerID, current.Currency, in); err != nil {
+		if err := insertOfferLine(ctx, tx, offerID, current.Currency, in); err != nil {
 			return err
 		}
 		if err := recomputeOfferTotals(ctx, tx, offerID); err != nil {

--- a/backend/internal/modules/deals/offer_read.go
+++ b/backend/internal/modules/deals/offer_read.go
@@ -145,7 +145,7 @@ func attachOfferLines(ctx context.Context, tx pgx.Tx, offers []crmcontracts.Offe
 	return nil
 }
 
-const offerColumns = `id, workspace_id, deal_id, offer_number, revision, status, currency,
+const offerColumns = `id, deal_id, offer_number, revision, status, currency,
 	buyer_org_id, buyer_snapshot, issuer_snapshot, valid_until, intro_text, terms_text,
 	net_minor, tax_minor, gross_minor, fx_rate_to_base::text, fx_rate_date, pdf_asset_ref,
 	template_id, accepted_at, source, captured_by, version, created_at, updated_at, archived_at`
@@ -179,7 +179,7 @@ func readOfferWithLines(ctx context.Context, tx pgx.Tx, id ids.OfferID, archived
 
 func scanOffer(row pgx.Row) (crmcontracts.Offer, error) {
 	var o crmcontracts.Offer
-	var id, wsID, dealID ids.UUID
+	var id, dealID ids.UUID
 	var buyerOrgID, templateID *ids.UUID
 	var offerNumber string
 	var revision int
@@ -190,7 +190,7 @@ func scanOffer(row pgx.Row) (crmcontracts.Offer, error) {
 	var capturedBy string
 	var version int64
 
-	err := row.Scan(&id, &wsID, &dealID, &offerNumber, &revision, &status, &o.Currency,
+	err := row.Scan(&id, &dealID, &offerNumber, &revision, &status, &o.Currency,
 		&buyerOrgID, &buyerSnapshot, &issuerSnapshot, &validUntil, &o.IntroText, &o.TermsText,
 		&netMinor, &taxMinor, &grossMinor, &o.FxRateToBase, &fxRateDate, &o.PdfAssetRef,
 		&templateID, &o.AcceptedAt, &o.Source, &capturedBy, &version, &o.CreatedAt, &o.UpdatedAt, &o.ArchivedAt)

--- a/backend/internal/modules/deals/offer_staged.go
+++ b/backend/internal/modules/deals/offer_staged.go
@@ -104,14 +104,13 @@ func (s *Store) AddStagedOfferLines(ctx context.Context, offerID ids.OfferID, li
 			return err
 		}
 
-		wsID := storekit.MustWorkspace(ctx)
 		start, err := nextOfferLinePosition(ctx, tx, offerID)
 		if err != nil {
 			return err
 		}
 		inserted := make([]crmcontracts.OfferLineItem, 0, len(lines))
 		for i, in := range lines {
-			line, err := insertStagedOfferLine(ctx, tx, wsID, offerID, start+i, in)
+			line, err := insertStagedOfferLine(ctx, tx, offerID, start+i, in)
 			if err != nil {
 				return fmt.Errorf("staged line %d: %w", i+1, err)
 			}
@@ -138,7 +137,7 @@ func (s *Store) AddStagedOfferLines(ctx context.Context, offerID ids.OfferID, li
 // builds the returned OfferLineItem straight from the values just
 // written — a second read-back would only re-derive what this function
 // already knows.
-func insertStagedOfferLine(ctx context.Context, tx pgx.Tx, wsID ids.UUID, offerID ids.OfferID, position int, in StagedOfferLineInput) (crmcontracts.OfferLineItem, error) {
+func insertStagedOfferLine(ctx context.Context, tx pgx.Tx, offerID ids.OfferID, position int, in StagedOfferLineInput) (crmcontracts.OfferLineItem, error) {
 	if in.Description == "" {
 		return crmcontracts.OfferLineItem{}, &RequiredFieldError{Field: "description"}
 	}
@@ -165,12 +164,12 @@ func insertStagedOfferLine(ctx context.Context, tx pgx.Tx, wsID ids.UUID, offerI
 	var createdAt, updatedAt time.Time
 	var version int64
 	err = tx.QueryRow(ctx,
-		`INSERT INTO offer_line_item (id, workspace_id, offer_id, position, description, unit,
+		`INSERT INTO offer_line_item (id, offer_id, position, description, unit,
 		                              quantity, unit_price_minor, discount_pct, tax_rate,
 		                              evidence, price_grounded, proposal_state)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
 		 RETURNING created_at, updated_at, version`,
-		id, wsID, offerID, position, in.Description, unit, in.Quantity, in.UnitPriceMinor, discount, in.TaxRate,
+		id, offerID, position, in.Description, unit, in.Quantity, in.UnitPriceMinor, discount, in.TaxRate,
 		storekit.JSONArg(evidence), in.PriceGrounded, ProposalStaged).
 		Scan(&createdAt, &updatedAt, &version)
 	if err != nil {

--- a/backend/internal/modules/deals/offer_template.go
+++ b/backend/internal/modules/deals/offer_template.go
@@ -7,7 +7,7 @@
 // data — no owner_id, no source/captured_by, gated by the
 // offer_template object grant alone (no row-scope EnsureVisible probe).
 // At most one is_default template per locale (uq_offer_template_default,
-// the partial unique index on (workspace_id, locale) WHERE is_default
+// the partial unique index on (locale) WHERE is_default
 // AND NOT archived). A second default for the same locale is REJECTED
 // with a named 409 (offer_template_default_conflict) — this store never
 // auto-demotes an incumbent default; the caller un-defaults or archives
@@ -91,8 +91,8 @@ func (e *DefaultConflictError) Is(target error) bool { return target == apperror
 func (s *Store) checkTemplateNameConflict(ctx context.Context, tx pgx.Tx, excludeID ids.OfferTemplateID, name string) error {
 	var existing ids.OfferTemplateID
 	err := tx.QueryRow(ctx,
-		`SELECT id FROM offer_template WHERE workspace_id = $1 AND name = $2 AND id <> $3`,
-		storekit.MustWorkspace(ctx), name, excludeID).Scan(&existing)
+		`SELECT id FROM offer_template WHERE name = $1 AND id <> $2`,
+		name, excludeID).Scan(&existing)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil
 	}
@@ -107,8 +107,8 @@ func (s *Store) checkTemplateNameConflict(ctx context.Context, tx pgx.Tx, exclud
 func (s *Store) checkTemplateDefaultConflict(ctx context.Context, tx pgx.Tx, excludeID ids.OfferTemplateID, locale string) error {
 	var existing ids.OfferTemplateID
 	err := tx.QueryRow(ctx,
-		`SELECT id FROM offer_template WHERE workspace_id = $1 AND locale = $2 AND is_default AND archived_at IS NULL AND id <> $3`,
-		storekit.MustWorkspace(ctx), locale, excludeID).Scan(&existing)
+		`SELECT id FROM offer_template WHERE locale = $1 AND is_default AND archived_at IS NULL AND id <> $2`,
+		locale, excludeID).Scan(&existing)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil
 	}
@@ -182,9 +182,9 @@ func (s *Store) CreateOfferTemplate(ctx context.Context, in CreateOfferTemplateI
 			}
 		}
 		if _, err := tx.Exec(ctx,
-			`INSERT INTO offer_template (id, workspace_id, name, locale, is_default, layout, version)
-			 VALUES ($1, $2, $3, $4, $5, $6, 1)`,
-			id, storekit.MustWorkspace(ctx), in.Name, locale, in.IsDefault, layout); err != nil {
+			`INSERT INTO offer_template (id, name, locale, is_default, layout, version)
+			 VALUES ($1, $2, $3, $4, $5, 1)`,
+			id, in.Name, locale, in.IsDefault, layout); err != nil {
 			if conflict := offerTemplateUniqueViolation(err, locale); conflict != nil {
 				return conflict
 			}
@@ -396,7 +396,7 @@ func (s *Store) ArchiveOfferTemplate(ctx context.Context, id ids.OfferTemplateID
 	return out, err
 }
 
-const offerTemplateColumns = `id, workspace_id, name, locale, is_default, layout, version, created_at, updated_at, archived_at`
+const offerTemplateColumns = `id, name, locale, is_default, layout, version, created_at, updated_at, archived_at`
 
 func readOfferTemplate(ctx context.Context, tx pgx.Tx, id ids.OfferTemplateID, archived storekit.ArchivedFilter) (crmcontracts.OfferTemplate, error) {
 	q := `SELECT ` + offerTemplateColumns + ` FROM offer_template WHERE id = $1`
@@ -412,11 +412,11 @@ func readOfferTemplate(ctx context.Context, tx pgx.Tx, id ids.OfferTemplateID, a
 
 func scanOfferTemplate(row pgx.Row, extra ...any) (crmcontracts.OfferTemplate, error) {
 	var t crmcontracts.OfferTemplate
-	var id, wsID ids.UUID
+	var id ids.UUID
 	var version int64
 
 	dests := []any{
-		&id, &wsID, &t.Name, &t.Locale, &t.IsDefault, &t.Layout,
+		&id, &t.Name, &t.Locale, &t.IsDefault, &t.Layout,
 		&version, &t.CreatedAt, &t.UpdatedAt, &t.ArchivedAt,
 	}
 	err := row.Scan(append(dests, extra...)...)

--- a/backend/internal/modules/deals/product.go
+++ b/backend/internal/modules/deals/product.go
@@ -63,10 +63,10 @@ func (s *Store) CreateProduct(ctx context.Context, in CreateProductInput) (crmco
 	err = s.tx(ctx, func(tx pgx.Tx) error {
 		id := ids.New[ids.ProductKind]()
 		_, err := tx.Exec(ctx,
-			`INSERT INTO product (id, workspace_id, name, sku, description, unit, unit_price_minor,
+			`INSERT INTO product (id, name, sku, description, unit, unit_price_minor,
 			                      currency, default_tax_rate, active, source, captured_by)
-			 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)`,
-			id, storekit.MustWorkspace(ctx), in.Name, in.SKU, in.Description, unit,
+			 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`,
+			id, in.Name, in.SKU, in.Description, unit,
 			in.UnitPriceMinor, in.Currency, taxRate, active, in.Source, by)
 		if err != nil {
 			if storekit.IsUniqueViolation(err) {
@@ -281,7 +281,7 @@ func scanProductPage(rows pgx.Rows, _ []fieldcatalog.Column, sorted *storekit.Li
 	return products, cursorKeys, nil
 }
 
-const productColumns = `id, workspace_id, name, sku, description, unit, unit_price_minor,
+const productColumns = `id, name, sku, description, unit, unit_price_minor,
 	currency, default_tax_rate::text, active, source, captured_by, version, created_at, updated_at, archived_at`
 
 func readProduct(ctx context.Context, tx pgx.Tx, id ids.ProductID, archived storekit.ArchivedFilter) (crmcontracts.Product, error) {
@@ -298,13 +298,13 @@ func readProduct(ctx context.Context, tx pgx.Tx, id ids.ProductID, archived stor
 
 func scanProduct(row pgx.Row, extra ...any) (crmcontracts.Product, error) {
 	var p crmcontracts.Product
-	var id, wsID ids.UUID
+	var id ids.UUID
 	var taxRate string
 	var capturedBy string
 	var version int64
 
 	dests := []any{
-		&id, &wsID, &p.Name, &p.Sku, &p.Description, &p.Unit, &p.UnitPriceMinor,
+		&id, &p.Name, &p.Sku, &p.Description, &p.Unit, &p.UnitPriceMinor,
 		&p.Currency, &taxRate, &p.Active, &p.Source, &capturedBy, &version, &p.CreatedAt, &p.UpdatedAt, &p.ArchivedAt,
 	}
 	err := row.Scan(append(dests, extra...)...)

--- a/backend/internal/modules/deals/project.go
+++ b/backend/internal/modules/deals/project.go
@@ -90,8 +90,6 @@ func (s *Store) CreateProject(ctx context.Context, in CreateProjectInput) (crmco
 // createProjectTx inserts the project with its birth phase-history row and
 // runs the write shape, all inside the caller's transaction.
 func createProjectTx(ctx context.Context, tx pgx.Tx, in CreateProjectInput, by string, active []fieldcatalog.Column) (crmcontracts.Project, error) {
-	wsID := storekit.MustWorkspace(ctx)
-
 	// The anchor company is a client-supplied reference to a row-scoped
 	// record, so naming it is a read of it: the caller must be able to see
 	// the company before a project can be hung off it. The composite FK
@@ -106,13 +104,13 @@ func createProjectTx(ctx context.Context, tx pgx.Tx, in CreateProjectInput, by s
 
 	id := ids.New[ids.ProjectKind]()
 	cfCols, cfHolders, args := storekit.InsertFragments(active, in.CustomFields, []any{
-		id, wsID, in.Name, in.Key, in.OrganizationID, in.OwnerID,
+		id, in.Name, in.Key, in.OrganizationID, in.OwnerID,
 		in.Description, in.StartedAt, in.TargetEndDate, in.Source, by,
 	})
 	_, err := tx.Exec(ctx,
-		`INSERT INTO project (id, workspace_id, name, key, organization_id, owner_id,
+		`INSERT INTO project (id, name, key, organization_id, owner_id,
 		                      description, started_at, target_end_date, source, captured_by`+cfCols+`)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11`+cfHolders+`)`,
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10`+cfHolders+`)`,
 		args...)
 	if err != nil {
 		if conflict := projectKeyConflict(err, in.Key); conflict != nil {
@@ -131,9 +129,9 @@ func createProjectTx(ctx context.Context, tx pgx.Tx, in CreateProjectInput, by s
 	// The birth row: from_phase NULL, exactly as deal_stage_history records
 	// a deal's first placement. A project's history is complete from row one.
 	if _, err := tx.Exec(ctx,
-		`INSERT INTO project_phase_history (workspace_id, project_id, from_phase, to_phase, changed_by)
-		 VALUES ($1, $2, NULL, $3, $4)`,
-		wsID, id, PhaseInitiative, by); err != nil {
+		`INSERT INTO project_phase_history (project_id, from_phase, to_phase, changed_by)
+		 VALUES ($1, NULL, $2, $3)`,
+		id, PhaseInitiative, by); err != nil {
 		return crmcontracts.Project{}, fmt.Errorf("record project phase history: %w", err)
 	}
 

--- a/backend/internal/modules/deals/project_advance.go
+++ b/backend/internal/modules/deals/project_advance.go
@@ -111,9 +111,9 @@ func recordPhaseTransition(ctx context.Context, tx pgx.Tx, id ids.ProjectID,
 	}
 
 	if _, err := tx.Exec(ctx,
-		`INSERT INTO project_phase_history (workspace_id, project_id, from_phase, to_phase, reason, changed_by)
-		 VALUES ($1, $2, $3, $4, $5, $6)`,
-		storekit.MustWorkspace(ctx), id, fromPhase, in.ToPhase, in.Reason, by); err != nil {
+		`INSERT INTO project_phase_history (project_id, from_phase, to_phase, reason, changed_by)
+		 VALUES ($1, $2, $3, $4, $5)`,
+		id, fromPhase, in.ToPhase, in.Reason, by); err != nil {
 		return fmt.Errorf("record project phase history: %w", err)
 	}
 

--- a/backend/internal/modules/deals/project_read.go
+++ b/backend/internal/modules/deals/project_read.go
@@ -147,7 +147,7 @@ func appendProjectFilters(where []string, in ListProjectsInput, arg func(any) in
 	return where
 }
 
-const projectColumns = `id, workspace_id, name, key, organization_id, owner_id, phase, closed_reason,
+const projectColumns = `id, name, key, organization_id, owner_id, phase, closed_reason,
 	description, started_at, target_end_date, ended_at, last_activity_at,
 	source, captured_by, version, created_at, updated_at, archived_at`
 
@@ -170,14 +170,14 @@ func readProject(ctx context.Context, tx pgx.Tx, id ids.ProjectID, archived stor
 // trailing expressions the caller's SELECT appended.
 func scanProject(row pgx.Row, active []fieldcatalog.Column, extra ...any) (crmcontracts.Project, error) {
 	var p crmcontracts.Project
-	var id, wsID, orgID ids.UUID
+	var id, orgID ids.UUID
 	var ownerID *ids.UUID
 	var phase string
 	var startedAt, targetEnd, endedAt *time.Time
 	var version int64
 
 	dests := []any{
-		&id, &wsID, &p.Name, &p.Key, &orgID, &ownerID, &phase, &p.ClosedReason,
+		&id, &p.Name, &p.Key, &orgID, &ownerID, &phase, &p.ClosedReason,
 		&p.Description, &startedAt, &targetEnd, &endedAt, &p.LastActivityAt,
 		&p.Source, &p.CapturedBy, &version, &p.CreatedAt, &p.UpdatedAt, &p.ArchivedAt,
 	}

--- a/backend/internal/modules/search/binding.go
+++ b/backend/internal/modules/search/binding.go
@@ -33,29 +33,6 @@ var ErrReembeddingInFlight = errors.New("search: a fleet-wide reembed already ho
 // this row's to do, so the caller stops rather than retries.
 var ErrReembeddingSuperseded = errors.New("search: the reembed run no longer holds the binding marker")
 
-// pendingSource mirrors one embedText entry (embedgen.go:35-41) rewritten
-// from a per-id lookup into a set-form expression: the same source
-// columns, aliased to t, so the two never drift into indexing different
-// text.
-type pendingSource struct {
-	table string
-	text  string // expression over the aliased table t
-}
-
-// pendingSources is the set-form counterpart to embedgen.go's embedText —
-// one entry per embeddable entity, in the exact source-column shape that
-// module maintains per-row. Adding a searchable entity means adding a row
-// to BOTH maps; they must never diverge, since the pending count and the
-// live indexer must agree on what "this entity's text" means.
-var pendingSources = map[string]pendingSource{
-	entityPerson:       {table: entityPerson, text: "t.full_name"},
-	entityOrganization: {table: entityOrganization, text: "concat_ws(' ', t.display_name, t.legal_name, t.industry)"},
-	entityDeal:         {table: entityDeal, text: "t.name"},
-	entityLead:         {table: entityLead, text: "concat_ws(' ', t.full_name, t.company_name, t.title)"},
-	entityActivity:     {table: entityActivity, text: "concat_ws(' ', t.subject, t.body)"},
-	entityProject:      {table: entityProject, text: "concat_ws(' ', t.name, t.key, t.description)"},
-}
-
 // SeedBinding plants the marker row on first boot. An empty store is
 // vacuously "populated under the current binding" — seeding
 // populated_identity to the LIVE config (never a sentinel) is what keeps a
@@ -351,78 +328,6 @@ func releaseReembeddingTx(ctx context.Context, tx pgx.Tx, run ids.UUID) error {
 	return nil
 }
 
-// PendingByWorkspace is the per-workspace count of live, non-empty-text
-// embeddable entities that lack a current-identity embedding row — the
-// same set EntitiesPending totals and TokenSumByWorkspace prices. system-
-// principal enumeration (mirrors embedgen.go:51-56): this is an index-
-// maintenance rollup, not a user-facing read, so it must see every live
-// entity regardless of any one caller's row scope.
-func (s *Store) PendingByWorkspace(ctx context.Context, currentIdentity string) (map[ids.WorkspaceID]int, error) {
-	counts, _, err := s.pendingStats(ctx, currentIdentity)
-	return counts, err
-}
-
-// TokenSumByWorkspace is the per-workspace SUM(octet_length(<embedText
-// source>))/4 over the same pending set PendingByWorkspace counts — a
-// rough 4-UTF-8-bytes-per-token estimate (the same convention as
-// ai/router.go:410 and ai/fake.go:113, which count bytes not runes, so a
-// non-ASCII corpus is not undercounted), feeding Task 14's advisory cost
-// preview. No corpus materialization and no model call: the length lives
-// in the source columns already.
-func (s *Store) TokenSumByWorkspace(ctx context.Context, currentIdentity string) (map[ids.WorkspaceID]int64, error) {
-	_, tokens, err := s.pendingStats(ctx, currentIdentity)
-	return tokens, err
-}
-
-// EntitiesPending is the fleet-wide total — the sum of PendingByWorkspace,
-// and the second operand of ReindexNeeded's OR.
-func (s *Store) EntitiesPending(ctx context.Context, currentIdentity string) (int, error) {
-	counts, err := s.PendingByWorkspace(ctx, currentIdentity)
-	if err != nil {
-		return 0, err
-	}
-	total := 0
-	for _, c := range counts {
-		total += c
-	}
-	return total, nil
-}
-
-// pendingStats enumerates the fleet and, per workspace, counts and sums
-// (as the system principal) every embeddable entity whose source text is
-// non-empty and which carries no embedding row at currentIdentity. The
-// non-empty qualifier is required: an empty-text entity never gets an
-// embedding row at all (embedding.go:47-48, UpsertEmbedding's early
-// return), so without it such a row would count as pending forever —
-// counting the row's ABSENCE, rather than requiring a stale one, is what
-// also covers a wiped store (migration 0114's TRUNCATE) as a rebuild path.
-func (s *Store) pendingStats(ctx context.Context, currentIdentity string) (map[ids.WorkspaceID]int, map[ids.WorkspaceID]int64, error) {
-	workspaces, err := s.fleetWorkspaceIDs(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	counts := make(map[ids.WorkspaceID]int, len(workspaces))
-	tokens := make(map[ids.WorkspaceID]int64, len(workspaces))
-	for _, wsID := range workspaces {
-		// The generator reads AS the system, same posture as EmbedGen
-		// (embedgen.go:51-56): a rollup built through one caller's row
-		// scope would silently under-report entities the caller cannot see.
-		wsCtx := systemWorkspaceContext(ctx, wsID.UUID)
-
-		// A store bound to THIS tenant: the workspace a read is scoped to is
-		// the handle's, so counting every workspace through the enumerating
-		// store would report the same tenant's total under every id.
-		count, length, err := s.forWorkspace(wsID).workspacePending(wsCtx, currentIdentity)
-		if err != nil {
-			return nil, nil, err
-		}
-		counts[wsID] = count
-		tokens[wsID] = length / 4
-	}
-	return counts, tokens, nil
-}
-
 // systemPrincipalID names the one system actor every index-maintenance
 // pass (EmbedGen, pendingStats, ReembedWorkspace) runs as — named
 // once so the three call sites share a single identity string instead of
@@ -453,42 +358,4 @@ func (s *Store) fleetWorkspaceIDs(ctx context.Context) ([]ids.WorkspaceID, error
 		return nil, fmt.Errorf("search: collecting workspaces: %w", err)
 	}
 	return workspaces, nil
-}
-
-// workspacePending runs one SET-form query per embeddable entity type,
-// summing counts and text lengths across all of them for the workspace
-// bound in ctx.
-func (s *Store) workspacePending(ctx context.Context, currentIdentity string) (count int, length int64, err error) {
-	txErr := s.db.Tx(ctx, func(tx pgx.Tx) error {
-		for entityType, src := range pendingSources {
-			// The workspace predicates are the query's own, on the entity and
-			// on the embedding alike. Tenant isolation used to supply both, so
-			// this counted one tenant's backlog without saying so; with RLS
-			// retired (ADR-0091 §8 phase A) an unscoped count reports the whole
-			// installation's under every workspace it enumerates.
-			sql := fmt.Sprintf(`
-				SELECT count(*), coalesce(sum(octet_length(btrim(%s))), 0)
-				FROM %s t
-				WHERE t.archived_at IS NULL
-				  AND btrim(%s) <> ''
-				  AND t.workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid
-				  AND NOT EXISTS (
-				        SELECT 1 FROM embedding e
-				        WHERE e.entity_type = '%s' AND e.entity_id = t.id AND e.model = $1
-				          AND e.workspace_id = t.workspace_id)`,
-				src.text, src.table, src.text, entityType)
-			var c int
-			var l int64
-			if err := tx.QueryRow(ctx, sql, currentIdentity).Scan(&c, &l); err != nil {
-				return fmt.Errorf("search: scanning pending %s: %w", entityType, err)
-			}
-			count += c
-			length += l
-		}
-		return nil
-	})
-	if txErr != nil {
-		return 0, 0, txErr
-	}
-	return count, length, nil
 }

--- a/backend/internal/modules/search/pending.go
+++ b/backend/internal/modules/search/pending.go
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package search
+
+// What is still unembedded, and how much text that is.
+//
+// The declaration of WHICH tables carry embeddable text sits here with the
+// queries that count them, because the two only make sense together: adding a
+// searchable entity means adding a row to pendingSources AND to embedgen.go's
+// embedText, and the pending count and the live indexer must agree on what
+// "this entity's text" means.
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// pendingSource mirrors one embedText entry (embedgen.go:35-41) rewritten
+// from a per-id lookup into a set-form expression: the same source
+// columns, aliased to t, so the two never drift into indexing different
+// text.
+type pendingSource struct {
+	table string
+	text  string // expression over the aliased table t
+	// tenantScoped says whether this table still carries workspace_id.
+	// ADR-0091 §8 phase D removes it table by table, and this query is ONE
+	// statement templated over all six — so the predicate has to be per-source
+	// while they disagree, or it fails outright for whichever has already lost
+	// the column. Every entry goes false as its slice lands, and the field goes
+	// with the last one.
+	tenantScoped bool
+}
+
+// pendingSources is the set-form counterpart to embedgen.go's embedText —
+// one entry per embeddable entity, in the exact source-column shape that
+// module maintains per-row. Adding a searchable entity means adding a row
+// to BOTH maps; they must never diverge, since the pending count and the
+// live indexer must agree on what "this entity's text" means.
+var pendingSources = map[string]pendingSource{
+	entityPerson:       {table: entityPerson, text: "t.full_name", tenantScoped: true},
+	entityOrganization: {table: entityOrganization, text: "concat_ws(' ', t.display_name, t.legal_name, t.industry)", tenantScoped: true},
+	entityDeal:         {table: entityDeal, text: "t.name", tenantScoped: true},
+	entityLead:         {table: entityLead, text: "concat_ws(' ', t.full_name, t.company_name, t.title)", tenantScoped: true},
+	entityActivity:     {table: entityActivity, text: "concat_ws(' ', t.subject, t.body)", tenantScoped: true},
+	entityProject:      {table: entityProject, text: "concat_ws(' ', t.name, t.key, t.description)"},
+}
+
+// PendingByWorkspace is the per-workspace count of live, non-empty-text
+// embeddable entities that lack a current-identity embedding row — the
+// same set EntitiesPending totals and TokenSumByWorkspace prices. system-
+// principal enumeration (mirrors embedgen.go:51-56): this is an index-
+// maintenance rollup, not a user-facing read, so it must see every live
+// entity regardless of any one caller's row scope.
+func (s *Store) PendingByWorkspace(ctx context.Context, currentIdentity string) (map[ids.WorkspaceID]int, error) {
+	counts, _, err := s.pendingStats(ctx, currentIdentity)
+	return counts, err
+}
+
+// TokenSumByWorkspace is the per-workspace SUM(octet_length(<embedText
+// source>))/4 over the same pending set PendingByWorkspace counts — a
+// rough 4-UTF-8-bytes-per-token estimate (the same convention as
+// ai/router.go:410 and ai/fake.go:113, which count bytes not runes, so a
+// non-ASCII corpus is not undercounted), feeding Task 14's advisory cost
+// preview. No corpus materialization and no model call: the length lives
+// in the source columns already.
+func (s *Store) TokenSumByWorkspace(ctx context.Context, currentIdentity string) (map[ids.WorkspaceID]int64, error) {
+	_, tokens, err := s.pendingStats(ctx, currentIdentity)
+	return tokens, err
+}
+
+// EntitiesPending is the fleet-wide total — the sum of PendingByWorkspace,
+// and the second operand of ReindexNeeded's OR.
+func (s *Store) EntitiesPending(ctx context.Context, currentIdentity string) (int, error) {
+	counts, err := s.PendingByWorkspace(ctx, currentIdentity)
+	if err != nil {
+		return 0, err
+	}
+	total := 0
+	for _, c := range counts {
+		total += c
+	}
+	return total, nil
+}
+
+// pendingStats enumerates the fleet and, per workspace, counts and sums
+// (as the system principal) every embeddable entity whose source text is
+// non-empty and which carries no embedding row at currentIdentity. The
+// non-empty qualifier is required: an empty-text entity never gets an
+// embedding row at all (embedding.go:47-48, UpsertEmbedding's early
+// return), so without it such a row would count as pending forever —
+// counting the row's ABSENCE, rather than requiring a stale one, is what
+// also covers a wiped store (migration 0114's TRUNCATE) as a rebuild path.
+func (s *Store) pendingStats(ctx context.Context, currentIdentity string) (map[ids.WorkspaceID]int, map[ids.WorkspaceID]int64, error) {
+	workspaces, err := s.fleetWorkspaceIDs(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	counts := make(map[ids.WorkspaceID]int, len(workspaces))
+	tokens := make(map[ids.WorkspaceID]int64, len(workspaces))
+	for _, wsID := range workspaces {
+		// The generator reads AS the system, same posture as EmbedGen
+		// (embedgen.go:51-56): a rollup built through one caller's row
+		// scope would silently under-report entities the caller cannot see.
+		wsCtx := systemWorkspaceContext(ctx, wsID.UUID)
+
+		// A store bound to THIS tenant: the workspace a read is scoped to is
+		// the handle's, so counting every workspace through the enumerating
+		// store would report the same tenant's total under every id.
+		count, length, err := s.forWorkspace(wsID).workspacePending(wsCtx, currentIdentity)
+		if err != nil {
+			return nil, nil, err
+		}
+		counts[wsID] = count
+		tokens[wsID] = length / 4
+	}
+	return counts, tokens, nil
+}
+
+// workspacePending runs one SET-form query per embeddable entity type,
+// summing counts and text lengths across all of them for the workspace
+// bound in ctx.
+func (s *Store) workspacePending(ctx context.Context, currentIdentity string) (count int, length int64, err error) {
+	txErr := s.db.Tx(ctx, func(tx pgx.Tx) error {
+		for entityType, src := range pendingSources {
+			// The workspace predicates are the query's own — tenant isolation
+			// used to supply them, so this counted one tenant's backlog without
+			// saying so, and an unscoped count reports the whole installation's
+			// under every workspace the caller enumerates. They are conditional
+			// only because phase D has reached some of these tables and not
+			// others; see pendingSource.tenantScoped.
+			// Two fragments, not one: the entity predicate belongs in the OUTER
+			// where, and the embedding leg inside the NOT EXISTS. Folding the
+			// entity predicate into the subquery would invert it — a row of
+			// another workspace would match nothing there, so NOT EXISTS would
+			// be true and the row would be counted rather than excluded.
+			entityScope, embeddingScope := "", ""
+			if src.tenantScoped {
+				entityScope = `
+				  AND t.workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid`
+				embeddingScope = ` AND e.workspace_id = t.workspace_id`
+			}
+			sql := fmt.Sprintf(`
+				SELECT count(*), coalesce(sum(octet_length(btrim(%s))), 0)
+				FROM %s t
+				WHERE t.archived_at IS NULL
+				  AND btrim(%s) <> ''%s
+				  AND NOT EXISTS (
+				        SELECT 1 FROM embedding e
+				        WHERE e.entity_type = '%s' AND e.entity_id = t.id AND e.model = $1%s)`,
+				src.text, src.table, src.text, entityScope, entityType, embeddingScope)
+			var c int
+			var l int64
+			if err := tx.QueryRow(ctx, sql, currentIdentity).Scan(&c, &l); err != nil {
+				return fmt.Errorf("search: scanning pending %s: %w", entityType, err)
+			}
+			count += c
+			length += l
+		}
+		return nil
+	})
+	if txErr != nil {
+		return 0, 0, txErr
+	}
+	return count, length, nil
+}

--- a/backend/internal/modules/search/reembed.go
+++ b/backend/internal/modules/search/reembed.go
@@ -149,14 +149,20 @@ type liveEntity struct {
 func (s *Store) liveEntitiesOf(ctx context.Context, entityType string, src pendingSource) ([]liveEntity, error) {
 	var items []liveEntity
 	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
-		// Scoped by the query itself: tenant isolation used to bound this scan
-		// to one workspace, so a re-embed pass now has to say so or it rebuilds
-		// the whole installation's index under every workspace it is given
-		// (ADR-0091 §8 phase A).
+		// Scoped by the query itself, and conditionally: tenant isolation used
+		// to bound this scan, so a re-embed pass has to say so or it rebuilds
+		// the whole installation's index under every workspace it is given.
+		// The condition is pendingSource.tenantScoped's — phase D has reached
+		// some of these tables and not others, and one templated statement
+		// cannot spell a predicate for a column half of them no longer have.
+		scope := ""
+		if src.tenantScoped {
+			scope = `
+			   AND t.workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid`
+		}
 		sql := fmt.Sprintf(`SELECT t.id, %s FROM %s t
-			 WHERE t.archived_at IS NULL
-			   AND t.workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid`,
-			src.text, src.table)
+			 WHERE t.archived_at IS NULL%s`,
+			src.text, src.table, scope)
 		rows, err := tx.Query(ctx, sql)
 		if err != nil {
 			return fmt.Errorf("search: selecting live %s rows: %w", entityType, err)

--- a/backend/migrations/core/0285_offers_projects_drop_workspace.down.sql
+++ b/backend/migrations/core/0285_offers_projects_drop_workspace.down.sql
@@ -1,0 +1,89 @@
+-- Reverse of 0285: the quoting and delivery tables carry the tenant column again.
+--
+-- The backfill reads the LIVE workspace — archived_at IS NULL, oldest first.
+-- 0217 refuses more than one live tenant and 0272 refuses to proceed while an
+-- archived one still holds records, so there was exactly one workspace these
+-- rows could have belonged to when the forward half ran. Ordering by created_at
+-- alone would hand every restored row to whichever workspace was created first,
+-- archived or not.
+--
+-- If no live workspace exists and a table is not empty, SET NOT NULL fails and
+-- the rollback stops — the honest outcome, since no value this migration could
+-- write would be true. A rollback on an empty database (the reverse-and-reapply
+-- lane) has nothing to attribute and passes.
+ALTER TABLE offer ADD COLUMN workspace_id uuid;
+ALTER TABLE offer_line_item ADD COLUMN workspace_id uuid;
+ALTER TABLE offer_template ADD COLUMN workspace_id uuid;
+ALTER TABLE product ADD COLUMN workspace_id uuid;
+ALTER TABLE project ADD COLUMN workspace_id uuid;
+ALTER TABLE project_phase_history ADD COLUMN workspace_id uuid;
+ALTER TABLE fx_rate ADD COLUMN workspace_id uuid;
+
+DO $$
+DECLARE
+  live uuid := (SELECT id FROM workspace WHERE archived_at IS NULL ORDER BY created_at LIMIT 1);
+  t    text;
+BEGIN
+  FOREACH t IN ARRAY ARRAY[
+    'offer', 'offer_line_item', 'offer_template', 'product',
+    'project', 'project_phase_history', 'fx_rate'
+  ] LOOP
+    EXECUTE format('UPDATE %I SET workspace_id = $1 WHERE workspace_id IS NULL', t) USING live;
+    EXECUTE format('ALTER TABLE %I ALTER COLUMN workspace_id SET NOT NULL', t);
+  END LOOP;
+END $$;
+
+ALTER TABLE offer ADD CONSTRAINT offer_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE offer_line_item ADD CONSTRAINT offer_line_item_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE offer_template ADD CONSTRAINT offer_template_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE product ADD CONSTRAINT product_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE project ADD CONSTRAINT project_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE project_phase_history ADD CONSTRAINT project_phase_history_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE fx_rate ADD CONSTRAINT fx_rate_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+
+DROP INDEX idx_offer_deal;
+DROP INDEX idx_offer_status;
+DROP INDEX idx_product_active;
+DROP INDEX idx_project_org;
+DROP INDEX idx_project_org_open;
+DROP INDEX idx_project_owner;
+DROP INDEX idx_pph_project;
+DROP INDEX idx_fx_rate_lookup;
+
+CREATE INDEX idx_offer_deal ON offer (workspace_id, deal_id, revision DESC) WHERE archived_at IS NULL;
+CREATE INDEX idx_offer_status ON offer (workspace_id, status) WHERE archived_at IS NULL;
+CREATE INDEX idx_offer_template_ws ON offer_template (workspace_id);
+CREATE INDEX idx_product_active ON product (workspace_id, active) WHERE archived_at IS NULL;
+CREATE INDEX idx_project_org ON project (workspace_id, organization_id) WHERE archived_at IS NULL;
+CREATE INDEX idx_project_org_open ON project (workspace_id, organization_id) WHERE phase <> 'closed' AND archived_at IS NULL;
+CREATE INDEX idx_project_owner ON project (workspace_id, owner_id) WHERE archived_at IS NULL;
+CREATE INDEX idx_pph_project ON project_phase_history (workspace_id, project_id, occurred_at DESC);
+CREATE INDEX idx_fx_rate_lookup ON fx_rate (workspace_id, from_currency, to_currency, rate_date);
+
+CREATE OR REPLACE FUNCTION assert_deal_project_same_org()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $fn$
+BEGIN
+  IF NEW.project_id IS NULL THEN
+    RETURN NULL;
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM project p
+    WHERE p.id = NEW.project_id
+      AND p.workspace_id = NEW.workspace_id
+      AND p.organization_id IS NOT DISTINCT FROM NEW.organization_id
+  ) THEN
+    RAISE EXCEPTION 'deal and project belong to different companies'
+      USING ERRCODE = 'check_violation', CONSTRAINT = 'deal_project_same_org';
+  END IF;
+  RETURN NULL;
+END;
+$fn$;

--- a/backend/migrations/core/0285_offers_projects_drop_workspace.up.sql
+++ b/backend/migrations/core/0285_offers_projects_drop_workspace.up.sql
@@ -1,0 +1,81 @@
+-- 0285: the quoting and delivery tables drop the tenant column (ADR-0091 §8 phase D).
+--
+-- Seven of the deals module's twelve, taken together because they are the half
+-- that hangs off a deal rather than being one:
+--
+--   what we quoted     offer, offer_line_item, offer_template
+--   what we sell       product
+--   what we deliver    project, project_phase_history
+--   what it is worth   fx_rate
+--
+-- The deal spine itself (deal, pipeline, stage and the two histories) follows in
+-- its own change: deal is the most-referenced table in the schema after person,
+-- and mixing the two would make a diff nobody can review.
+--
+-- Every key here already names something narrower than the tenant — an offer's
+-- (offer_number, revision), a product's sku, a rate's (from, to, date) — so
+-- phase B left nothing composite to collapse.
+
+ALTER TABLE offer_line_item DROP CONSTRAINT offer_line_item_workspace_id_fkey;
+ALTER TABLE offer_line_item DROP COLUMN workspace_id;
+
+ALTER TABLE offer DROP CONSTRAINT offer_workspace_id_fkey;
+ALTER TABLE offer DROP COLUMN workspace_id;
+
+ALTER TABLE offer_template DROP CONSTRAINT offer_template_workspace_id_fkey;
+ALTER TABLE offer_template DROP COLUMN workspace_id;
+
+ALTER TABLE product DROP CONSTRAINT product_workspace_id_fkey;
+ALTER TABLE product DROP COLUMN workspace_id;
+
+ALTER TABLE project_phase_history DROP CONSTRAINT project_phase_history_workspace_id_fkey;
+ALTER TABLE project_phase_history DROP COLUMN workspace_id;
+
+ALTER TABLE project DROP CONSTRAINT project_workspace_id_fkey;
+ALTER TABLE project DROP COLUMN workspace_id;
+
+ALTER TABLE fx_rate DROP CONSTRAINT fx_rate_workspace_id_fkey;
+ALTER TABLE fx_rate DROP COLUMN workspace_id;
+
+-- The indexes that led with the column, recreated on what actually selects rows.
+--
+-- idx_offer_template_ws is NOT recreated, because there is nothing left of it:
+-- it was (workspace_id) alone, and an index on the tenant by itself has no
+-- narrowed form — the same reading idx_quota_ws_live got.
+CREATE INDEX idx_offer_deal ON offer (deal_id, revision DESC) WHERE archived_at IS NULL;
+CREATE INDEX idx_offer_status ON offer (status) WHERE archived_at IS NULL;
+CREATE INDEX idx_product_active ON product (active) WHERE archived_at IS NULL;
+CREATE INDEX idx_project_org ON project (organization_id) WHERE archived_at IS NULL;
+CREATE INDEX idx_project_org_open ON project (organization_id) WHERE phase <> 'closed' AND archived_at IS NULL;
+CREATE INDEX idx_project_owner ON project (owner_id) WHERE archived_at IS NULL;
+CREATE INDEX idx_pph_project ON project_phase_history (project_id, occurred_at DESC);
+CREATE INDEX idx_fx_rate_lookup ON fx_rate (from_currency, to_currency, rate_date);
+
+-- The deal↔project same-company trigger reads `project` by id and workspace.
+-- Its own comment says the workspace leg changes no outcome — the composite FK
+-- already forbade a cross-workspace project_id — and it was kept so the rule
+-- could be judged without reading the RLS policy beside it. There is no tenant
+-- column left to read, and the rule it enforces was never about tenancy: a deal
+-- and its project must name the same company.
+--
+-- CREATE OR REPLACE rather than DROP and recreate: the trigger keeps pointing at
+-- the same function, so nothing has to be rebound.
+CREATE OR REPLACE FUNCTION assert_deal_project_same_org()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $fn$
+BEGIN
+  IF NEW.project_id IS NULL THEN
+    RETURN NULL;
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM project p
+    WHERE p.id = NEW.project_id
+      AND p.organization_id IS NOT DISTINCT FROM NEW.organization_id
+  ) THEN
+    RAISE EXCEPTION 'deal and project belong to different companies'
+      USING ERRCODE = 'check_violation', CONSTRAINT = 'deal_project_same_org';
+  END IF;
+  RETURN NULL;
+END;
+$fn$;

--- a/scripts/seed-dev.sql
+++ b/scripts/seed-dev.sql
@@ -55,11 +55,11 @@ BEGIN
   -- FX rates: base currency is EUR; seed the three other UI currencies
   -- (USD/GBP/CHF) dated today so a close on or after today finds a rate.
   -- Representative demo values — not a live quote.
-  INSERT INTO fx_rate (workspace_id, from_currency, to_currency, rate, rate_date)
+  INSERT INTO fx_rate (from_currency, to_currency, rate, rate_date)
   VALUES
-    (ws, 'USD', 'EUR', 0.92, CURRENT_DATE),
-    (ws, 'GBP', 'EUR', 1.17, CURRENT_DATE),
-    (ws, 'CHF', 'EUR', 1.04, CURRENT_DATE)
+    ('USD', 'EUR', 0.92, CURRENT_DATE),
+    ('GBP', 'EUR', 1.17, CURRENT_DATE),
+    ('CHF', 'EUR', 1.04, CURRENT_DATE)
   ON CONFLICT (from_currency, to_currency, rate_date)
     DO UPDATE SET rate = EXCLUDED.rate;
 


### PR DESCRIPTION
Seven of the deals module's twelve — the half that hangs off a deal rather than being one:

| | tables |
|---|---|
| what we quoted | `offer`, `offer_line_item`, `offer_template` |
| what we sell | `product` |
| what we deliver | `project`, `project_phase_history` |
| what it is worth | `fx_rate` |

The deal spine (`deal`, `pipeline`, `stage` and the two histories) follows in its own change: `deal` is the most-referenced table in the schema after `person`, and mixing the two would make a diff nobody can review.

## A trigger that read the column

`assert_deal_project_same_org` resolved the project by id **and** workspace. Its own comment said the workspace leg changed no outcome — the composite foreign key already forbade a cross-workspace `project_id` — and that it was kept so the rule could be judged without reading the RLS policy beside it. There is no tenant column left to read, and the rule was never about tenancy: a deal and its project must name the same company. `CREATE OR REPLACE`, so the trigger keeps pointing at the same function.

## One statement templated over six tables

search's pending-count and re-embed scans build one SQL string per embeddable entity from `pendingSources`. `project` has lost the column; `person`, `organization`, `deal`, `lead` and `activity` have not. A predicate that held for five of six would not narrow the count — it would fail the statement outright for the sixth.

The predicate is per-source now, behind `pendingSource.tenantScoped`, and each entry goes false as its slice lands. **Dropping the predicate outright was my first attempt and it was wrong twice over:** it makes a per-workspace re-embed rebuild the whole installation's index, and folding it into the `NOT EXISTS` *inverts* it — a foreign row matches nothing inside the subquery, so `NOT EXISTS` is true and the row is counted rather than excluded. Both showed up as failing fan-out tests rather than as anything a reader would have spotted.

`binding.go` crossed the 500-line cap with the change, so *what is still unembedded* moved to `pending.go` alongside the declaration of which tables carry embeddable text — the two only make sense together.

## The fixture helper

`Seed` mints an id and binds a workspace; five fixtures here write tables that no longer have one. `SeedID` is the same helper without the binding, and it is what `Seed` becomes when phase D finishes.

## Verification

- Lane applied to an empty database; the down restores all seven columns with their foreign keys, all nine wide indexes and the trigger's workspace leg (verified by running the down and re-reading the catalog).
- `make check-backend` green; `make test-integration` OK, 0 skips, 41 packages.

Phase D: 66 → 59 tables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drops `workspace_id` from quoting and delivery in `deals` — `offer`, `offer_line_item`, `offer_template`, `product`, `project`, `project_phase_history`, and `fx_rate` — per ADR-0091 §8 phase D. Offer numbering/revisions and template defaults move from per-workspace to installation-wide; search pending and re-embed scans now handle mixed tables without rebuilding the whole index.

- Schema: Removes tenant FKs and columns on the seven tables; recreates indexes without `workspace_id`; updates `assert_deal_project_same_org` to compare by project id and organization only. The down migration restores columns/FKs/indexes and backfills `workspace_id` to the live workspace.
- Behavior: Offer numbers and revisions are minted installation-wide; template name/default checks are installation-wide; `fx_rate` upsert is no longer workspace-scoped. `search` moves pending counts to `pending.go` and adds per-source `tenantScoped` predicates; `binding.go` shrinks. Tests and seeds stop writing `workspace_id`; new fixture helper `SeedID`.
- Migration actions: Update any callers that still pass `workspace_id` into `offer`, `offer_line_item`, `offer_template`, `product`, `project`, `project_phase_history`, or `fx_rate`. If rolling back, ensure one live workspace exists or the down migration will fail on NOT NULL.

<sup>Written for commit cc03d1b9d3b73e9b50226f1ca27b90f26bb1e17f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1543?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

