### PR TITLE
feat(company360): a person's row on the company page opens their record

### DIFF
--- a/frontend/src/screens/company360.css
+++ b/frontend/src/screens/company360.css
@@ -138,10 +138,23 @@
   border-radius: var(--r-sm);
 }
 
+/* A link that claims its whole row as the target. The cover is a pseudo
+   element rather than an anchor wrapped around the row, so the row keeps one
+   link with one accessible name — the person's — instead of reading the
+   badges and the verbs beside them as part of it. The row it covers must be
+   the positioning context, and anything meant to stay clickable inside the
+   row must sit above the cover. */
+.co-rowcover::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+}
+
 /* A contact row: the avatar and the identity it names on the left, coverage
    and the verbs that touch this person on the right — a person is a face and
    a name first, and everything the page can tell or do about them second. */
 .co-person-row {
+  position: relative;
   display: flex;
   align-items: center;
   gap: var(--space-3);
@@ -162,7 +175,10 @@
   font-size: 12px;
   color: var(--textMeta);
 }
+/* Above the row's link cover: these are verbs about the person, and clicking
+   one must do the verb rather than leave the page for their record. */
 .co-person-end {
+  position: relative;
   display: flex;
   align-items: center;
   gap: 6px; /* ds:ignore matches .co-row-meta, the same row-end chip rhythm */
@@ -1027,6 +1043,7 @@
 /* A roster row: the monogram, the name over the title, and, where the graph
    read supports it, who here already talks to them, pushed to the far end. */
 .co-person-row {
+  position: relative;
   display: flex;
   align-items: center;
   gap: var(--space-3);

--- a/frontend/src/screens/company360.test.tsx
+++ b/frontend/src/screens/company360.test.tsx
@@ -1245,7 +1245,7 @@ describe("company view — naming the buying committee", () => {
       await screen.findByRole("button", { name: "People" }),
     );
 
-    await screen.findByRole("button", { name: "Christian Hagemeyer" });
+    await screen.findByRole("link", { name: "Christian Hagemeyer" });
     expect(screen.queryByRole("button", { name: "Set role" })).toBeNull();
   });
 });
@@ -1378,8 +1378,20 @@ describe("company view — a recorded role reaches the screen", () => {
     // because that state comes from the record, not from the 360.
     render(<PeopleCard view={withOneOpenDeal} writable={false} />);
 
-    await screen.findByRole("button", { name: "Christian Hagemeyer" });
+    await screen.findByRole("link", { name: "Christian Hagemeyer" });
     expect(screen.queryByRole("button", { name: "Set role" })).toBeNull();
+  });
+
+  it("opens the person's own record from the row", async () => {
+    // An href, not a click handler: a rep reading an account opens three
+    // contacts in three tabs, and a handler answers the middle click by doing
+    // nothing at all.
+    render(<PeopleCard view={withOneOpenDeal} writable={false} />);
+
+    const link = await screen.findByRole("link", {
+      name: "Christian Hagemeyer",
+    });
+    expect(link.getAttribute("href")).toBe("#/contacts/p-1");
   });
 
   it("offers it on an account that does", async () => {

--- a/frontend/src/screens/company360.tsx
+++ b/frontend/src/screens/company360.tsx
@@ -9,7 +9,7 @@ import {
 } from "react";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
-import { navigate } from "../app/router";
+import { navigate, routeHash } from "../app/router";
 import {
   Avatar,
   Badge,
@@ -801,15 +801,17 @@ function ContactRow({
         <Avatar name={contact.full_name} />
       </span>
       <span className="co-person-body">
-        <button
-          type="button"
-          className="co-rowlink co-person-name"
-          onClick={() =>
-            navigate({ screen: "contacts", id: contact.person_id })
-          }
+        {/* A real href, and it covers the whole row: a name is a small target
+            beside the face and the badges that describe the same person, and
+            a reader aiming at any of them means "open this contact". The
+            verbs at the row's end sit above the cover, so they still act on
+            the row rather than opening it. */}
+        <a
+          className="co-rowlink co-person-name co-rowcover"
+          href={routeHash({ screen: "contacts", id: contact.person_id })}
         >
           {contact.full_name}
-        </button>
+        </a>
         {subline && (
           <span className="co-person-sub">
             {/* ONE mark, on the whole line, and only where the title was

--- a/frontend/src/screens/companyrail.test.tsx
+++ b/frontend/src/screens/companyrail.test.tsx
@@ -687,6 +687,11 @@ describe("CompanyRail", () => {
     // Named again for anyone not reading the stacked avatars as monograms:
     // the sr-only text beside them, not the face itself.
     expect(screen.getByText("Ravi Shah")).toBeInTheDocument();
+    // The rail names people it cannot say anything more about; the row is the
+    // way to the record that can.
+    expect(
+      screen.getByRole("link", { name: "Dana Buyer" }).getAttribute("href"),
+    ).toBe("#/contacts/p-1");
   });
 
   it("draws a signal row with its severity dot, kind, summary and date", async () => {

--- a/frontend/src/screens/companyrail.tsx
+++ b/frontend/src/screens/companyrail.tsx
@@ -1,6 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
+import { routeHash } from "../app/router";
 import { Avatar, Badge, Disclosure } from "../design-system/atoms";
 import { AvatarStack } from "../design-system/avatarstack";
 import { EvidenceMark } from "../design-system/evidencemark";
@@ -321,7 +322,14 @@ function PersonRow({ contact }: Readonly<{ contact: Contact }>) {
     <>
       <Avatar name={contact.full_name} />
       <span className="co-person-id">
-        <span className="co-person-name">{contact.full_name}</span>
+        {/* Same target the People tab offers, and the same reach: the row is
+            the link, not the eight characters of a short name. */}
+        <a
+          className="co-rowlink co-person-name co-rowcover"
+          href={routeHash({ screen: "contacts", id: contact.person_id })}
+        >
+          {contact.full_name}
+        </a>
         {/* The same fallback the tab makes, because a rail that disagreed
             with the tab about somebody's role is worse than neither showing
             one. The server decides the precedence; both surfaces read it.


### PR DESCRIPTION
The whole roster row is the link — avatar, name and subline — on both the People tab and the rail. The rail named people with no way to reach them at all; the tab offered the name's own characters as the target, beside a face and a set of badges describing the same person.

It is an `href`, not a click handler, so a rep working an account opens three contacts in three tabs and a middle click does what it says. One link per row, named for the person: the cover is a pseudo element rather than an anchor wrapped around the row, so the badges and verbs beside the name stay out of the link's accessible name. The verbs at the row's end sit above the cover and still act on the row rather than leaving the page.

Tests assert the target on both surfaces (`#/contacts/<person_id>`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the entire person row on the Company page open the contact record. Before: only the name text was clickable on the People tab and the rail had no link. Now: the whole row is a real link (`href`), enabling middle/command-click and tab opening.

- Uses an anchor with `href={routeHash({ screen: "contacts", id })}` and a `.co-rowcover::after` overlay so the avatar, name, and subline all target the link while the link’s accessible name stays just the person’s name.
- Keeps row-end verbs actionable by layering `.co-person-end` above the cover; clicking a verb still performs the action instead of navigating.
- Sets `.co-person-row { position: relative; }` to host the cover; if you add new interactive controls inside the row, ensure they sit above the cover.
- Updates tests to expect `role="link"` and verify the `#/contacts/<person_id>` `href` on both the People tab and the rail; removes the `navigate()` click handler in favor of a true link.

<sup>Written for commit 4ad6359204ddb419987f6538da474b4705b47e3e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1546?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Contact names in company views are now clickable links to the corresponding contact record.
  * Contact rows provide a larger clickable area for easier navigation.
  * Row actions remain independently accessible without triggering navigation.

* **Bug Fixes**
  * Improved contact navigation behavior using direct links to contact records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->