### PR TITLE
refactor(activities): the activity satellites drop the tenant column (ADR-0091 §8 phase D)

### DIFF
--- a/backend/internal/compose/capturedfiles_integration_test.go
+++ b/backend/internal/compose/capturedfiles_integration_test.go
@@ -233,9 +233,9 @@ func TestTheDatabaseRefusesASecondRowForTheSameProviderPart(t *testing.T) {
 	err := db.Tx(ctx, func(tx pgx.Tx) error {
 		_, err := tx.Exec(ctx, `
 			INSERT INTO attachment (
-				workspace_id, entity_type, entity_id, filename, storage_key,
+				entity_type, entity_id, filename, storage_key,
 				source, captured_by, external_source_id, external_part_id)
-			VALUES (current_setting('app.workspace_id')::uuid, 'activity', $1, 'contract.pdf',
+			VALUES ('activity', $1, 'contract.pdf',
 			        'some/other/key', 'imap', 'connector:imap', $2, $3)`,
 			activityOf(ctx, t, db, "imap:msg-racing-pulls-"+tag),
 			"imap:msg-racing-pulls-"+tag, *stored[0].partID)

--- a/backend/internal/compose/erasurequotations_integration_test.go
+++ b/backend/internal/compose/erasurequotations_integration_test.go
@@ -63,8 +63,8 @@ func transcriptSubject(t *testing.T, e *integration.Env) (ids.PersonID, ids.UUID
 		INSERT INTO activity_link (workspace_id, activity_id, entity_type, person_id)
 		VALUES ($1, $2, 'person', $3)`, e.WS, activityID, person)
 	e.WsExec(t, `
-		INSERT INTO transcript_read (id, workspace_id, activity_id, status, line_count, requested_by, started_at, finished_at)
-		VALUES ($1, $2, $3, 'done', 2, 'human:seed', now(), now())`, ids.NewV7(), e.WS, activityID)
+		INSERT INTO transcript_read (id, activity_id, status, line_count, requested_by, started_at, finished_at)
+		VALUES ($1, $2, 'done', 2, 'human:seed', now(), now())`, ids.NewV7(), activityID)
 
 	return ids.From[ids.PersonKind](person), activityID, stageProposalQuoting(t, e, activityID, quotedTranscriptLine)
 }
@@ -233,8 +233,8 @@ func TestRetentionErasingATranscriptEmptiesTheProposalQuotingIt(t *testing.T) {
 	overAge := seedTranscript(t, e, quotedTranscriptLine)
 	e.WsExec(t, `UPDATE activity SET occurred_at = now() - interval '400 days' WHERE id = $1`, overAge)
 	e.WsExec(t, `
-		INSERT INTO transcript_read (id, workspace_id, activity_id, status, line_count, requested_by, started_at, finished_at)
-		VALUES ($1, $2, $3, 'done', 1, 'human:seed', now(), now())`, ids.NewV7(), e.WS, overAge)
+		INSERT INTO transcript_read (id, activity_id, status, line_count, requested_by, started_at, finished_at)
+		VALUES ($1, $2, 'done', 1, 'human:seed', now(), now())`, ids.NewV7(), overAge)
 	approvalID := stageProposalQuoting(t, e, overAge, quotedTranscriptLine)
 
 	svc := privacy.NewRetentionService(e.DB(), nil, slog.New(slog.NewTextHandler(io.Discard, nil)))

--- a/backend/internal/compose/integration/documents_integration_test.go
+++ b/backend/internal/compose/integration/documents_integration_test.go
@@ -37,10 +37,10 @@ func seedDocument(
 	// type per parameter, and using the id as both a uuid and a string leaves it
 	// with two.
 	e.WsExec(t, `
-		INSERT INTO attachment (id, workspace_id, entity_type, entity_id, filename, storage_key,
+		INSERT INTO attachment (id, entity_type, entity_id, filename, storage_key,
 		                        source, captured_by, category, organization_id, pinned)
-		VALUES ($1, $2, $3, $4, $5, $6, 'upload', 'human:test', $7, $8, $9)`,
-		id, e.WS, parentType, parent, name, "k/"+id.String(), category, org, pinned)
+		VALUES ($1, $2, $3, $4, $5, 'upload', 'human:test', $6, $7, $8)`,
+		id, parentType, parent, name, "k/"+id.String(), category, org, pinned)
 	return id
 }
 

--- a/backend/internal/compose/integration/export_integration_test.go
+++ b/backend/internal/compose/integration/export_integration_test.go
@@ -107,10 +107,10 @@ func (e *SearchEnv) seedExportFixture(t *testing.T) exportFixture {
 	e.Seed(t, `INSERT INTO activity_link (id, workspace_id, activity_id, entity_type, person_id) VALUES ($1, $2, $3, 'person', $4)`, f.rep3Activity, f.rep3Person)
 
 	// Attachments on each rep's person — the files manifest source.
-	e.Seed(t, `INSERT INTO attachment (id, workspace_id, entity_type, entity_id, filename, storage_key, source, captured_by)
-		VALUES ($1, $2, 'person', $3, 'rep1.pdf', 'blob/rep1', 'manual', 'human:x')`, f.rep1Person)
-	e.Seed(t, `INSERT INTO attachment (id, workspace_id, entity_type, entity_id, filename, storage_key, source, captured_by)
-		VALUES ($1, $2, 'person', $3, 'rep3.pdf', 'blob/rep3', 'manual', 'human:x')`, f.rep3Person)
+	e.SeedID(t, `INSERT INTO attachment (id, entity_type, entity_id, filename, storage_key, source, captured_by)
+		VALUES ($1, 'person', $2, 'rep1.pdf', 'blob/rep1', 'manual', 'human:x')`, f.rep1Person)
+	e.SeedID(t, `INSERT INTO attachment (id, entity_type, entity_id, filename, storage_key, source, captured_by)
+		VALUES ($1, 'person', $2, 'rep3.pdf', 'blob/rep3', 'manual', 'human:x')`, f.rep3Person)
 
 	// Audit rows targeting each rep's person (audit_log is record-mutations-only).
 	e.Seed(t, `INSERT INTO audit_log (id, workspace_id, actor_type, actor_id, action, entity_type, entity_id)

--- a/backend/internal/compose/participantreplay.go
+++ b/backend/internal/compose/participantreplay.go
@@ -235,8 +235,8 @@ func decodeStoredOriginal(payload []byte) ([]byte, error) {
 // selects it again.
 func markReplayed(ctx context.Context, tx pgx.Tx, activityID ids.ActivityID, outcome string) error {
 	if _, err := tx.Exec(ctx, `
-		INSERT INTO activity_participant_replay (workspace_id, activity_id, outcome)
-		VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, $2)
+		INSERT INTO activity_participant_replay (activity_id, outcome)
+		VALUES ($1, $2)
 		ON CONFLICT (activity_id) DO NOTHING`,
 		activityID, outcome); err != nil {
 		return fmt.Errorf("compose: recording that an activity's participants were replayed: %w", err)

--- a/backend/internal/compose/publicbooking.go
+++ b/backend/internal/compose/publicbooking.go
@@ -13,11 +13,13 @@ package compose
 // attribution as actor_type=system) then works unchanged.
 
 import (
+	"fmt"
 	"net/http"
 	"strings"
 	"time"
 
 	"github.com/gradionhq/margince/backend/internal/modules/activities"
+	"github.com/gradionhq/margince/backend/internal/modules/identity"
 	"github.com/gradionhq/margince/backend/internal/platform/httperr"
 	"github.com/gradionhq/margince/backend/internal/platform/httpserver"
 	"github.com/gradionhq/margince/backend/internal/platform/ratelimit"
@@ -45,7 +47,7 @@ func newPublicBookingLimiters() publicBookingLimiters {
 	}
 }
 
-func publicBooking(store *activities.Store, limits publicBookingLimiters) func(http.Handler) http.Handler {
+func publicBooking(store *activities.Store, svc *identity.Service, limits publicBookingLimiters) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if !strings.HasPrefix(r.URL.Path, publicBookingPrefix) {
@@ -66,14 +68,24 @@ func publicBooking(store *activities.Store, limits publicBookingLimiters) func(h
 				return
 			}
 
-			page, err := store.ResolveBookingPage(r.Context(), slug)
-			if err != nil {
+			if _, err := store.ResolveBookingPage(r.Context(), slug); err != nil {
 				// Unknown and revoked slugs read identically as absent.
 				httperr.Write(w, r, err)
 				return
 			}
 
-			ctx := principal.WithWorkspaceID(r.Context(), page.WorkspaceID.UUID)
+			// The installation resolves itself. The slug used to carry the
+			// workspace, which meant an anonymous caller chose the tenant its
+			// own request would run in; there is one installation now, and
+			// asking it directly is both the only answer and the safer shape.
+			// A failure here is a deployment fault, not a bad slug, so it must
+			// not read as one.
+			wsID, err := svc.InstallationWorkspace(r.Context())
+			if err != nil {
+				httperr.Write(w, r, fmt.Errorf("public booking: resolving the installation: %w", err))
+				return
+			}
+			ctx := principal.WithWorkspaceID(r.Context(), wsID.UUID)
 			ctx = principal.WithActor(ctx, principal.Principal{
 				Type: principal.PrincipalSystem,
 				ID:   "system:public_booking",

--- a/backend/internal/compose/routes.go
+++ b/backend/internal/compose/routes.go
@@ -164,7 +164,7 @@ func operationalMux(srv Server, pool *pgxpool.Pool, log *slog.Logger, identitySv
 	// operational mux instead would win the longest-pattern match against
 	// "/v1/" and serve without a session. See extensionEdge.
 	publicEdge := publicPreferences(consent.NewStore(InstallationDB(pool)), newPublicPreferenceLimiters())(
-		publicBooking(activities.NewStore(InstallationDB(pool)), newPublicBookingLimiters())(
+		publicBooking(activities.NewStore(InstallationDB(pool)), identity.NewService(pool), newPublicBookingLimiters())(
 			extensionEdge(srv, log)(api),
 		),
 	)

--- a/backend/internal/modules/activities/attachment.go
+++ b/backend/internal/modules/activities/attachment.go
@@ -52,7 +52,7 @@ type AttachmentInput struct {
 	ContractID *ids.UUID
 }
 
-const attachmentColumns = `at.id, at.workspace_id, at.entity_type, at.entity_id, at.filename,
+const attachmentColumns = `at.id, at.entity_type, at.entity_id, at.filename,
 	at.content_type, at.byte_size, at.checksum, at.source, at.captured_by, at.created_at,
 	at.category, at.title, at.doc_state, at.pinned, at.supersedes_id, at.organization_id,
 	at.contract_id`
@@ -149,11 +149,11 @@ func (s *Store) UploadAttachment(ctx context.Context, in AttachmentInput) (crmco
 			account = &rollUp
 		}
 		if _, err := tx.Exec(ctx, `
-			INSERT INTO attachment (id, workspace_id, entity_type, entity_id, filename,
+			INSERT INTO attachment (id, entity_type, entity_id, filename,
 				content_type, byte_size, storage_key, checksum, source, captured_by,
 				organization_id, contract_id)
-			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)`,
-			id, workspaceID(ctx), in.EntityType, in.EntityID, in.Filename,
+			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)`,
+			id, in.EntityType, in.EntityID, in.Filename,
 			nullIfEmpty(in.ContentType), size, key, checksum, attachmentSource, by,
 			account, in.ContractID); err != nil {
 			return err
@@ -356,7 +356,7 @@ func readAttachment(ctx context.Context, tx pgx.Tx, id ids.UUID) (crmcontracts.A
 func scanAttachment(row rowScanner) (crmcontracts.Attachment, error) {
 	var (
 		att         crmcontracts.Attachment
-		aid, wsID   ids.UUID
+		aid         ids.UUID
 		entityType  string
 		entityID    ids.UUID
 		contentType *string
@@ -369,7 +369,7 @@ func scanAttachment(row rowScanner) (crmcontracts.Attachment, error) {
 		orgID       *ids.UUID
 		contractID  *ids.UUID
 	)
-	if err := row.Scan(&aid, &wsID, &entityType, &entityID, &att.Filename,
+	if err := row.Scan(&aid, &entityType, &entityID, &att.Filename,
 		&contentType, &byteSize, &checksum, &att.Source, &capturedBy, &att.CreatedAt,
 		&category, &att.Title, &docState, &att.Pinned, &supersedes, &orgID, &contractID); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {

--- a/backend/internal/modules/activities/capturedfiles.go
+++ b/backend/internal/modules/activities/capturedfiles.go
@@ -166,11 +166,11 @@ func insertCapturedAttachment(
 ) error {
 	tag, err := tx.Exec(ctx, `
 		INSERT INTO attachment (
-			id, workspace_id, entity_type, entity_id, filename, content_type,
+			id, entity_type, entity_id, filename, content_type,
 			byte_size, storage_key, checksum, source, captured_by,
 			category, organization_id, activity_id,
 			external_source_id, external_part_id, declared_type)
-		VALUES ($1, current_setting('app.workspace_id')::uuid, 'activity', $2, $3, $4,
+		VALUES ($1, 'activity', $2, $3, $4,
 		        $5, $6, $7, $8, $9,
 		        'email_attachment', $10, $2,
 		        $11, $12, $13)

--- a/backend/internal/modules/activities/scheduledsend.go
+++ b/backend/internal/modules/activities/scheduledsend.go
@@ -323,17 +323,14 @@ func (s *Store) scheduleSend(
 	}
 
 	err = s.tx(ctx, func(tx pgx.Tx) error {
-		// workspace_id comes from the transaction's own GUC, the one binding
-		// every tenant write here uses — never from a caller-supplied value.
 		prov := provenanceOf(actor)
 		if _, err := tx.Exec(ctx, `
 			INSERT INTO scheduled_send
-			  (id, workspace_id, status, scheduled_at, scheduled_tz,
+			  (id, status, scheduled_at, scheduled_tz,
 			   origin_kind, anchor_activity_id, origin_links,
 			   payload, payload_version, scheduled_by, principal_kind,
 			   agent_actor_id, agent_passport_id, agent_on_behalf_of)
-			VALUES ($1, NULLIF(current_setting('app.workspace_id', true), '')::uuid,
-			        $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)`,
+			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)`,
 			row.ID, row.Status, row.ScheduledAt, row.ScheduledTZ,
 			row.OriginKind, nullableAnchor(origin), originLinks,
 			payload, payloadVersionCurrent, row.ScheduledBy, principalKind(actor),

--- a/backend/internal/modules/activities/scheduledsendfire.go
+++ b/backend/internal/modules/activities/scheduledsendfire.go
@@ -383,9 +383,9 @@ func (s *Store) OverdueScheduledSends(ctx context.Context, olderThan time.Durati
 	err := s.tx(ctx, func(tx pgx.Tx) error {
 		rows, err := tx.Query(ctx, `
 			SELECT id FROM scheduled_send
-			 WHERE workspace_id = $1 AND status = 'scheduled' AND scheduled_at < $2
+			 WHERE status = 'scheduled' AND scheduled_at < $1
 			 ORDER BY scheduled_at ASC
-			 LIMIT $3`, storekit.MustWorkspace(ctx), s.now().Add(-olderThan), limit)
+			 LIMIT $2`, s.now().Add(-olderThan), limit)
 		if err != nil {
 			return fmt.Errorf("scheduled send: finding messages nothing will wake: %w", err)
 		}

--- a/backend/internal/modules/activities/scheduling_public.go
+++ b/backend/internal/modules/activities/scheduling_public.go
@@ -33,20 +33,20 @@ import (
 
 // BookingPage is the slug's resolution: which workspace, whose calendar.
 type BookingPage struct {
-	WorkspaceID ids.WorkspaceID
-	HostUserID  ids.UserID
+	HostUserID ids.UserID
 }
 
-// ResolveBookingPage answers the slug→tenant lookup the public
-// middleware binds the workspace from. booking_page is deliberately
-// outside RLS (it IS the resolver — 0036); an unknown or revoked slug
-// reads as absent.
+// ResolveBookingPage answers the slug→host lookup the public middleware runs
+// before it may do anything else. The slug names the HOST, and only the host:
+// the installation the request lands in is resolved from the installation
+// itself, not read off a row an anonymous caller chose. An unknown or revoked
+// slug reads as absent.
 func (s *Store) ResolveBookingPage(ctx context.Context, slug string) (BookingPage, error) {
 	var page BookingPage
 	err := database.WithInfraTx(ctx, s.db.Pool(), func(tx pgx.Tx) error {
 		err := tx.QueryRow(ctx,
-			`SELECT workspace_id, host_user_id FROM booking_page WHERE slug = $1 AND revoked_at IS NULL`,
-			slug).Scan(&page.WorkspaceID, &page.HostUserID)
+			`SELECT host_user_id FROM booking_page WHERE slug = $1 AND revoked_at IS NULL`,
+			slug).Scan(&page.HostUserID)
 		if errors.Is(err, pgx.ErrNoRows) {
 			return apperrors.ErrNotFound
 		}
@@ -69,8 +69,8 @@ func SeedBookingPageTx(ctx context.Context, tx pgx.Tx, hostUserID ids.UserID) (s
 	}
 	slug := base64.RawURLEncoding.EncodeToString(buf[:])
 	if _, err := tx.Exec(ctx, `
-		INSERT INTO booking_page (workspace_id, host_user_id, slug)
-		VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, $2)`,
+		INSERT INTO booking_page (host_user_id, slug)
+		VALUES ($1, $2)`,
 		hostUserID, slug); err != nil {
 		return "", fmt.Errorf("activities: seed booking page: %w", err)
 	}

--- a/backend/internal/modules/activities/transcriptread.go
+++ b/backend/internal/modules/activities/transcriptread.go
@@ -137,11 +137,11 @@ func (s *Store) StartTranscriptReadQueued(
 		// transaction alive, so the join SELECT below sees the winning row in
 		// the same tx, with no second-transaction gap for it to finish in.
 		inserted := tx.QueryRow(ctx, `
-			INSERT INTO transcript_read (id, workspace_id, activity_id, requested_by, line_count)
-			VALUES ($1, $2, $3, $4, $5)
+			INSERT INTO transcript_read (id, activity_id, requested_by, line_count)
+			VALUES ($1, $2, $3, $4)
 			ON CONFLICT DO NOTHING
 			RETURNING `+transcriptReadColumns,
-			readID, workspaceID(ctx), activityID, requestedBy, lineCount)
+			readID, activityID, requestedBy, lineCount)
 		out, err = scanTranscriptRead(inserted)
 		if err == nil {
 			if enqueue != nil {

--- a/backend/migrations/core/0286_activity_satellites_drop_workspace.down.sql
+++ b/backend/migrations/core/0286_activity_satellites_drop_workspace.down.sql
@@ -1,0 +1,62 @@
+-- Reverse of 0286: the activity satellites carry the tenant column again.
+--
+-- The backfill reads the LIVE workspace — archived_at IS NULL, oldest first.
+-- 0217 refuses more than one live tenant and 0272 refuses to proceed while an
+-- archived one still holds records, so there was exactly one workspace these
+-- rows could have belonged to when the forward half ran. Ordering by created_at
+-- alone would hand every restored row to whichever workspace was created first,
+-- archived or not.
+--
+-- If no live workspace exists and a table is not empty, SET NOT NULL fails and
+-- the rollback stops — the honest outcome, since no value this migration could
+-- write would be true. A rollback on an empty database (the reverse-and-reapply
+-- lane) has nothing to attribute and passes.
+ALTER TABLE attachment ADD COLUMN workspace_id uuid;
+ALTER TABLE booking_page ADD COLUMN workspace_id uuid;
+ALTER TABLE scheduled_send ADD COLUMN workspace_id uuid;
+ALTER TABLE transcript_read ADD COLUMN workspace_id uuid;
+ALTER TABLE activity_participant_replay ADD COLUMN workspace_id uuid;
+
+DO $$
+DECLARE
+  live uuid := (SELECT id FROM workspace WHERE archived_at IS NULL ORDER BY created_at LIMIT 1);
+  t    text;
+BEGIN
+  FOREACH t IN ARRAY ARRAY[
+    'attachment', 'booking_page', 'scheduled_send', 'transcript_read',
+    'activity_participant_replay'
+  ] LOOP
+    EXECUTE format('UPDATE %I SET workspace_id = $1 WHERE workspace_id IS NULL', t) USING live;
+    EXECUTE format('ALTER TABLE %I ALTER COLUMN workspace_id SET NOT NULL', t);
+  END LOOP;
+END $$;
+
+ALTER TABLE attachment ADD CONSTRAINT attachment_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE booking_page ADD CONSTRAINT booking_page_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE scheduled_send ADD CONSTRAINT scheduled_send_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE transcript_read ADD CONSTRAINT transcript_read_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE activity_participant_replay ADD CONSTRAINT activity_participant_replay_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+
+-- UNIQUE (id), which is what the migration before this one left: phase B
+-- collapsed uq_attachment_ws_id from its composite form and this restores that
+-- state, not the pre-phase-B one.
+ALTER TABLE attachment ADD CONSTRAINT uq_attachment_ws_id UNIQUE (id);
+
+DROP INDEX attachment_account_ix;
+DROP INDEX idx_attachment_entity;
+DROP INDEX idx_booking_page_host;
+DROP INDEX idx_scheduled_send_due;
+DROP INDEX idx_scheduled_send_owner;
+DROP INDEX idx_transcript_read_latest;
+
+CREATE INDEX attachment_account_ix ON attachment (workspace_id, organization_id, pinned DESC, created_at DESC) WHERE archived_at IS NULL;
+CREATE INDEX idx_attachment_entity ON attachment (workspace_id, entity_type, entity_id) WHERE archived_at IS NULL;
+CREATE INDEX idx_booking_page_host ON booking_page (workspace_id, host_user_id) WHERE revoked_at IS NULL;
+CREATE INDEX idx_scheduled_send_due ON scheduled_send (workspace_id, scheduled_at) WHERE status = 'scheduled';
+CREATE INDEX idx_scheduled_send_owner ON scheduled_send (workspace_id, scheduled_by, status, scheduled_at DESC);
+CREATE INDEX idx_transcript_read_latest ON transcript_read (workspace_id, activity_id, created_at DESC);

--- a/backend/migrations/core/0286_activity_satellites_drop_workspace.up.sql
+++ b/backend/migrations/core/0286_activity_satellites_drop_workspace.up.sql
@@ -1,0 +1,45 @@
+-- 0286: the activity satellites drop the tenant column (ADR-0091 §8 phase D).
+--
+-- Five tables that hang off an activity rather than being one:
+--
+--   attachment                   files pinned to a record
+--   booking_page                 a host's public scheduling link
+--   scheduled_send               a message queued to go out later
+--   transcript_read              one pass of a recording through the reader
+--   activity_participant_replay  the marker saying a replay has settled a row
+--
+-- The activity spine itself (activity, activity_link, activity_participant)
+-- follows in its own change: activity is named by ~120 sites, and a diff that
+-- carried both would be unreviewable.
+--
+-- Every key here already names something narrower than the tenant: an
+-- attachment's provider part, a booking page's slug, a replay's activity.
+
+ALTER TABLE attachment DROP CONSTRAINT attachment_workspace_id_fkey;
+ALTER TABLE attachment DROP COLUMN workspace_id;
+
+ALTER TABLE booking_page DROP CONSTRAINT booking_page_workspace_id_fkey;
+ALTER TABLE booking_page DROP COLUMN workspace_id;
+
+ALTER TABLE scheduled_send DROP CONSTRAINT scheduled_send_workspace_id_fkey;
+ALTER TABLE scheduled_send DROP COLUMN workspace_id;
+
+ALTER TABLE transcript_read DROP CONSTRAINT transcript_read_workspace_id_fkey;
+ALTER TABLE transcript_read DROP COLUMN workspace_id;
+
+ALTER TABLE activity_participant_replay DROP CONSTRAINT activity_participant_replay_workspace_id_fkey;
+ALTER TABLE activity_participant_replay DROP COLUMN workspace_id;
+
+-- uq_attachment_ws_id is phase B's leftover: a second copy of attachment's own
+-- primary key, created as a composite foreign-key target that phase C has since
+-- rewritten away. It indexes nothing the primary key does not.
+ALTER TABLE attachment DROP CONSTRAINT uq_attachment_ws_id;
+
+-- The six indexes that led with the column, recreated on what actually selects
+-- rows: a record's files, a host's page, a due send, a transcript's latest pass.
+CREATE INDEX attachment_account_ix ON attachment (organization_id, pinned DESC, created_at DESC) WHERE archived_at IS NULL;
+CREATE INDEX idx_attachment_entity ON attachment (entity_type, entity_id) WHERE archived_at IS NULL;
+CREATE INDEX idx_booking_page_host ON booking_page (host_user_id) WHERE revoked_at IS NULL;
+CREATE INDEX idx_scheduled_send_due ON scheduled_send (scheduled_at) WHERE status = 'scheduled';
+CREATE INDEX idx_scheduled_send_owner ON scheduled_send (scheduled_by, status, scheduled_at DESC);
+CREATE INDEX idx_transcript_read_latest ON transcript_read (activity_id, created_at DESC);


### PR DESCRIPTION
Five tables that hang off an activity rather than being one:

| table | what it is |
|---|---|
| `attachment` | files pinned to a record |
| `booking_page` | a host's public scheduling link |
| `scheduled_send` | a message queued to go out later |
| `transcript_read` | one pass of a recording through the reader |
| `activity_participant_replay` | the marker saying a replay has settled a row |

The activity **spine** (`activity`, `activity_link`, `activity_participant`) waits for its own change — `activity` is named by ~120 sites and a diff carrying both would be unreviewable.

`uq_attachment_ws_id` goes with them: phase B's leftover, a second copy of `attachment`'s own primary key, created as a composite foreign-key target that phase C has since rewritten away.

## The public booking page resolved its own tenant

An anonymous booking request has no session, so the middleware read the workspace off the `booking_page` row the slug named — meaning **the slug chose which tenant the request would run in**. There is one installation now, and it resolves itself: the same `identity.Service.InstallationWorkspace` the MCP edge already calls, with the same care that failing to resolve it is a deployment fault and must not be reported as a bad slug.

The slug still names the HOST, which is what it was always really for, and an unknown or revoked one still reads as absent.

## Verification

- Lane applied to an empty database; the down restores all five columns with their foreign keys, all six wide indexes and the unique (verified by running it and re-reading the catalog).
- `make check-backend` green; `make test-integration` OK, 0 skips, 41 packages — both on the first run.

Phase D: 59 → 54 tables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drops `workspace_id` from five activity satellites and rewires public booking to resolve the workspace from the installation. This removes tenant-derived writes on satellites and prevents slugs from selecting a tenant; the slug now only names the host.

- Tables updated: `attachment`, `booking_page`, `scheduled_send`, `transcript_read`, `activity_participant_replay` drop `workspace_id` and related FKs. `uq_attachment_ws_id` removed. Indexes rewritten to target entity- and activity-scoped keys.
- Public booking: the middleware calls `identity.Service.InstallationWorkspace` instead of reading `booking_page.workspace_id`. Unknown or revoked slugs still read as absent; failure to resolve the installation is treated as a deployment fault.
- Code paths: all inserts and selects on the five tables stop passing or filtering by `workspace_id`. `publicBooking` now requires an `identity.Service`.
- Required migration actions: run migration 0286 up. External writes must remove `workspace_id` from the five tables. If rolling back, the down migration backfills from the single live workspace; it fails if no live workspace exists while tables are non-empty.

<sup>Written for commit 90044a6c4a71d5611a0d20e47067c94a6238167e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1547?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Public booking now resolves its installation context more reliably.
  * Simplified activity and booking data handling improves consistency across installations.

* **Bug Fixes**
  * Updated attachment, transcript, and scheduled-message processing to prevent workspace-related lookup and insertion issues.
  * Refreshed database indexes and constraints to support activity-specific queries.

* **Maintenance**
  * Added database migration and rollback support for the updated activity data structure.
  * Updated integration fixtures to match the current schema.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->