### PR TITLE
feat(config): what an installation can configure is declared as data

### DIFF
--- a/backend/cmd/api/config.go
+++ b/backend/cmd/api/config.go
@@ -45,12 +45,17 @@ type apiConfig struct {
 	oauthAccessTokenTTL time.Duration
 }
 
-// parseAPIFlags parses and validates the boot flags; the DSN is the one
-// dependency without a sane default, so its absence fails the boot here.
-func parseAPIFlags(args []string) (apiConfig, error) {
+// apiFlagSet registers this role's flags and their environment bindings, and
+// returns them unparsed.
+//
+// Separate from parsing because the same registration answers two questions:
+// what a boot should read, and what this role's configurable surface IS. The
+// second is how a generated template or schema comes from the flags themselves
+// rather than from a copy of them that drifts.
+func apiFlagSet() (*flag.FlagSet, *cliflags.Env, *apiConfig, error) {
 	fs := flag.NewFlagSet("api", flag.ContinueOnError)
-	var env cliflags.Env
-	var cfg apiConfig
+	env := &cliflags.Env{}
+	cfg := &apiConfig{}
 	env.String(fs, &cfg.dsn, "dsn", "MARGINCE_DSN", "", "Postgres DSN (runtime app role)")
 	env.String(fs, &cfg.configPath, "config", "MARGINCE_CONFIG", "margince.yaml",
 		"path to the deployment configuration file (A107/ADR-0061: bootstrap + auth); a missing file boots an existing installation but cannot bootstrap an empty database")
@@ -80,12 +85,28 @@ func parseAPIFlags(args []string) (apiConfig, error) {
 	env.String(fs, &cfg.connectorStateKey, "connector-state-key", "MARGINCE_CONNECTOR_STATE_KEY", "", "HMAC key (>=32 bytes) signing the OAuth connect `state`; required for the Gmail and Graph connect flows")
 	env.String(fs, &cfg.webhookKey, "webhook-key", "MARGINCE_WEBHOOK_KEY", "", "base64 32-byte key sealing outbound-webhook signing secrets; enables the mutating /webhook-subscriptions surface, and (with --inline-relay) the cg:webhooks delivery consumer. Empty = those paths answer 503 and no inline delivery runs. Re-attempting a parked delivery is the worker role's River job, never this one's.")
 	env.String(fs, &cfg.metricsToken, "metrics-token", "MARGINCE_METRICS_TOKEN", "", "shared secret /metrics requires as a Bearer credential; empty (the default) answers 404 for /metrics rather than serving per-workspace job telemetry with no authentication at all")
-	accessTokenTTL, err := envDuration("MARGINCE_OAUTH_ACCESS_TOKEN_TTL")
+	accessTokenTTL, err := envDuration(oauthAccessTokenTTLEnv)
 	if err != nil {
-		return apiConfig{}, err
+		return nil, nil, nil, err
 	}
 	fs.DurationVar(&cfg.oauthAccessTokenTTL, "oauth-access-token-ttl", accessTokenTTL,
 		"lifetime of the access token (an Agent Seat Passport) the OAuth handshake mints, for the code exchange and every refresh rotation; 0 = the passport default of 720h (30 days), maximum 2160h (90 days)")
+	return fs, env, cfg, nil
+}
+
+// parseAPIFlags parses and validates the boot flags; the DSN is the one
+// dependency without a sane default, so its absence fails the boot here.
+func parseAPIFlags(args []string) (apiConfig, error) {
+	fs, env, cfg, err := apiFlagSet()
+	if err != nil {
+		return apiConfig{}, err
+	}
+	// A surface that cannot be described honestly is a boot error, not a
+	// runtime surprise: a duplicate name or a required item carrying a default
+	// would make a generated reference lie about this installation.
+	if _, err := apiConfigItems(fs, env); err != nil {
+		return apiConfig{}, err
+	}
 	if err := fs.Parse(args); err != nil {
 		return apiConfig{}, err
 	}
@@ -103,7 +124,7 @@ func parseAPIFlags(args []string) (apiConfig, error) {
 		return apiConfig{}, fmt.Errorf("api: --oauth-access-token-ttl %s is out of range: 0 (the default) or up to %s",
 			cfg.oauthAccessTokenTTL, identity.MaxOAuthAccessTokenTTL)
 	}
-	return cfg, nil
+	return *cfg, nil
 }
 
 // envDuration reads a duration from the environment as the default for its

--- a/backend/cmd/api/configitems.go
+++ b/backend/cmd/api/configitems.go
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package main
+
+// What this role can be configured with, as data.
+//
+// The flag surface is not restated here: apiConfigItems reads it back off the
+// FlagSet parseAPIFlags already built, so the usage text an operator sees on
+// `-h` and the doc a generated artefact carries are one sentence. What this
+// file adds is the part a FlagSet cannot hold — which values are credentials,
+// and the items this role reads WITHOUT a flag, which each owning package
+// declares for itself.
+
+import (
+	"flag"
+
+	"github.com/gradionhq/margince/backend/internal/compose"
+	"github.com/gradionhq/margince/backend/internal/modules/ai"
+	"github.com/gradionhq/margince/backend/internal/platform/blobstore"
+	"github.com/gradionhq/margince/backend/internal/platform/cliflags"
+	"github.com/gradionhq/margince/backend/internal/platform/config"
+	"github.com/gradionhq/margince/backend/internal/platform/deployconfig"
+	"github.com/gradionhq/margince/backend/internal/platform/keyvault"
+)
+
+// apiPublic names the flag-bound variables whose values are safe to echo.
+// Everything else this role reads is treated as a secret — see cliflags.Items
+// for why the list runs this way round.
+//
+// The test is "could this string authenticate somebody", not "does it look
+// sensitive". A log level, a path, a base URL and an OAuth CLIENT id (public by
+// the protocol's own design) authenticate nobody, and are safer visible because
+// an operator debugging a boot wants to read them. Everything not named here —
+// the two DSNs, both client secrets, the push token, the app secret, the
+// connector-state HMAC key, the webhook sealing key and the /metrics bearer —
+// authenticates something.
+var apiPublic = map[string]bool{
+	"MARGINCE_CONFIG":                     true,
+	"MARGINCE_AI_ROUTING":                 true,
+	"MARGINCE_LOG_LEVEL":                  true,
+	"MARGINCE_LOG_FORMAT":                 true,
+	"MARGINCE_REDIS":                      true,
+	"MARGINCE_PUBLIC_BASE_URL":            true,
+	"MARGINCE_API_BASE_URL":               true,
+	"MARGINCE_MCP_APPS_BASE_URL":          true,
+	"MARGINCE_GMAIL_CLIENT_ID":            true,
+	"MARGINCE_GRAPH_CLIENT_ID":            true,
+	"MARGINCE_GRAPH_TENANT":               true,
+	"MARGINCE_GMAIL_JWKS_URL":             true,
+	"MARGINCE_GMAIL_PUSH_AUDIENCE":        true,
+	"MARGINCE_GMAIL_PUSH_SERVICE_ACCOUNT": true,
+}
+
+// apiConfigItems is this role's whole configurable surface: its own flags, plus
+// the packages it wires that read the environment on their own account.
+func apiConfigItems(fs *flag.FlagSet, env *cliflags.Env) ([]config.Item, error) {
+	registry, err := config.NewRegistry(
+		env.Items(fs, config.RoleAPI, apiPublic),
+		blobstore.ConfigItems(),
+		keyvault.ConfigItems(),
+		ai.ConfigItems(),
+		deployconfig.ConfigItems(),
+		apiUnflaggedItems(),
+	)
+	if err != nil {
+		return nil, err
+	}
+	return registry.Items(), nil
+}
+
+// apiUnflaggedItems are the variables this role reads with no flag behind them.
+// They are declared here rather than in the packages that read them because
+// their owners are the composition root itself — a posture, a licence override,
+// a cap on a backfill — and a package that has no opinion about them should not
+// carry their documentation either.
+func apiUnflaggedItems() []config.Item {
+	both := []string{config.RoleAPI, config.RoleWorker}
+	return []config.Item{
+		{
+			Name: overlayBackfillLimitEnv, Kind: config.KindInt, Default: "0", Roles: both,
+			Doc: "per-object-class cap on the overlay initial backfill; 0 runs it uncapped",
+		},
+		{
+			Name: oauthAccessTokenTTLEnv, Kind: config.KindDuration, Default: "0", Roles: []string{config.RoleAPI},
+			Doc: "lifetime of a minted OAuth access token; 0 takes the compiled default",
+		},
+		{
+			Name: compose.ProviderModeEnv, Kind: config.KindString, Default: "live", Roles: both,
+			Doc: "enrichment provider: live|offline|off; an unknown value is a boot error rather than a silently disabled feature",
+		},
+	}
+}
+
+// oauthAccessTokenTTLEnv is spelled once, here and at its read.
+// #nosec G101 -- the NAME of a variable holding a duration, not a credential
+const oauthAccessTokenTTLEnv = "MARGINCE_OAUTH_ACCESS_TOKEN_TTL"

--- a/backend/cmd/api/configitems_test.go
+++ b/backend/cmd/api/configitems_test.go
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package main
+
+// The registry is only worth having if it is COMPLETE. A declaration set that
+// silently misses a variable is worse than no declaration set, because the
+// generated template and schema it feeds would then describe a surface smaller
+// than the real one — and an operator would trust them.
+//
+// So the obligation is derived from the flags themselves rather than from a
+// list: every environment binding parseAPIFlags registers must appear, with the
+// FlagSet's own default and usage text carried through.
+
+import (
+	"flag"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/platform/cliflags"
+	"github.com/gradionhq/margince/backend/internal/platform/config"
+)
+
+// apiSurface rebuilds the role's flag set and its declared items together, the
+// way boot does.
+func apiSurface(t *testing.T) (*flag.FlagSet, *cliflags.Env, []config.Item) {
+	t.Helper()
+	fs, env, _, err := apiFlagSet()
+	if err != nil {
+		t.Fatalf("building the api flag set: %v", err)
+	}
+	items, err := apiConfigItems(fs, env)
+	if err != nil {
+		t.Fatalf("assembling the api registry: %v", err)
+	}
+	return fs, env, items
+}
+
+func TestEveryFlagBoundVariableIsDeclared(t *testing.T) {
+	_, env, items := apiSurface(t)
+	declared := make(map[string]config.Item, len(items))
+	for _, item := range items {
+		declared[item.Name] = item
+	}
+	for _, name := range env.EnvKeys() {
+		if _, ok := declared[name]; !ok {
+			t.Errorf("%s is read by a flag binding but declared by no config item — a generated template would omit it", name)
+		}
+	}
+}
+
+func TestDeclaredDocsComeFromTheFlagsThemselves(t *testing.T) {
+	// The point of reading the usage text back rather than restating it: `-h`
+	// and the generated reference cannot disagree. Every binding, not one — a
+	// single-flag version passes having checked nothing the day that flag is
+	// renamed.
+	fs, env, items := apiSurface(t)
+	byName := make(map[string]config.Item, len(items))
+	for _, item := range items {
+		byName[item.Name] = item
+	}
+	checked := 0
+	for _, name := range env.EnvKeys() {
+		item, declared := byName[name]
+		if !declared {
+			continue // TestEveryFlagBoundVariableIsDeclared owns that failure
+		}
+		f := fs.Lookup(item.FlagName)
+		if f == nil {
+			continue
+		}
+		if item.Doc != f.Usage {
+			t.Errorf("%s doc = %q, flag -%s usage = %q — they must be one sentence", name, item.Doc, f.Name, f.Usage)
+		}
+		checked++
+	}
+	if checked == 0 {
+		t.Fatal("compared no bindings at all; the check proved nothing")
+	}
+}
+
+func TestTheCredentialsThisRoleReadsAreMarkedSecret(t *testing.T) {
+	// Named explicitly because nothing mechanical can tell a path from a
+	// password. The default is already to withhold (cliflags.Items), so this
+	// catches the opposite mistake: a credential wrongly listed as public.
+	_, _, items := apiSurface(t)
+	secret := make(map[string]bool, len(items))
+	for _, item := range items {
+		secret[item.Name] = item.Secret
+	}
+	for _, name := range []string{
+		"MARGINCE_DSN", "MARGINCE_SCHEMA_DSN",
+		"MARGINCE_GMAIL_CLIENT_SECRET", "MARGINCE_GMAIL_PUSH_TOKEN",
+		"MARGINCE_GRAPH_CLIENT_SECRET", "MARGINCE_HUBSPOT_APP_SECRET",
+		"MARGINCE_CONNECTOR_STATE_KEY", "MARGINCE_WEBHOOK_KEY", "MARGINCE_METRICS_TOKEN",
+		"MARGINCE_KEYVAULT_ROOT_KEY", "MARGINCE_LICENSE",
+		"MARGINCE_BLOBSTORE_ACCESS_KEY", "MARGINCE_BLOBSTORE_SECRET_KEY",
+		"ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GEMINI_API_KEY",
+	} {
+		if !secret[name] {
+			t.Errorf("%s authenticates something and is not marked Secret", name)
+		}
+	}
+	// And the converse, so the marking means something: a value that
+	// authenticates nobody stays visible, because an operator debugging a boot
+	// wants to read it.
+	for _, name := range []string{"MARGINCE_LOG_LEVEL", "MARGINCE_PUBLIC_BASE_URL", "MARGINCE_ENV"} {
+		if secret[name] {
+			t.Errorf("%s is marked Secret but authenticates nothing; hiding it only makes a boot harder to debug", name)
+		}
+	}
+}

--- a/backend/cmd/api/overlay.go
+++ b/backend/cmd/api/overlay.go
@@ -10,12 +10,16 @@ import (
 	"github.com/gradionhq/margince/backend/internal/platform/config"
 )
 
-// overlayBackfillLimitFromEnv reads MARGINCE_OVERLAY_BACKFILL_LIMIT: unset
+// overlayBackfillLimitEnv is the variable read below, named so the role can
+// declare it without spelling the string a second time.
+const overlayBackfillLimitEnv = "MARGINCE_OVERLAY_BACKFILL_LIMIT"
+
+// overlayBackfillLimitFromEnv reads overlayBackfillLimitEnv: unset
 // → 0 (the overlay initial backfill runs uncapped); a non-negative integer
 // → that per-object-class cap (dev/demo, so a large portal's initial load
 // stays bounded); anything else is a boot error, never a silent default.
 func overlayBackfillLimitFromEnv() (int, error) {
-	v := config.FromOS("MARGINCE_OVERLAY_BACKFILL_LIMIT")
+	v := config.FromOS(overlayBackfillLimitEnv)
 	if v == "" {
 		return 0, nil
 	}

--- a/backend/cmd/worker/config.go
+++ b/backend/cmd/worker/config.go
@@ -65,13 +65,13 @@ type workerConfig struct {
 	observeAddr          string
 }
 
-// parseWorkerFlags parses and validates the boot flags; the DSN is the
-// one dependency without a sane default, so its absence fails the boot
-// here.
-func parseWorkerFlags(args []string) (workerConfig, error) {
+// workerFlagSet registers this role's flags and their environment bindings,
+// unparsed — the same registration that a boot reads and that describes this
+// role's configurable surface, so neither is a copy of the other.
+func workerFlagSet() (*flag.FlagSet, *cliflags.Env, *workerConfig, error) {
 	fs := flag.NewFlagSet("worker", flag.ContinueOnError)
-	var env cliflags.Env
-	var cfg workerConfig
+	env := &cliflags.Env{}
+	cfg := &workerConfig{}
 	env.String(fs, &cfg.dsn, "dsn", "MARGINCE_DSN", "", "Postgres DSN (runtime app role)")
 	// The same canonical origin the api serves: a marketing send from this
 	// role's Surface-B agent run builds the recipient's tokenized unsubscribe
@@ -100,8 +100,8 @@ func parseWorkerFlags(args []string) (workerConfig, error) {
 	fs.DurationVar(&cfg.gmailWatchRenew, "gmail-watch-renew-within", 48*time.Hour, "renew a Gmail watch this far ahead of its 7-day expiry")
 	fs.DurationVar(&cfg.overlayInterval, "overlay-reconcile-interval", 2*time.Minute, "overlay-mode incumbent mirror reconcile poll interval (design.md §4.4)")
 	fs.IntVar(&cfg.overlayBackfillLimit, "overlay-backfill-limit", 0, "cap the overlay initial mirror backfill at this many records per object class (dev/demo; 0 = uncapped)")
-	if err := registerDeepReadFlags(fs, &cfg); err != nil {
-		return workerConfig{}, err
+	if err := registerDeepReadFlags(fs, cfg); err != nil {
+		return nil, nil, nil, err
 	}
 	// Outbound pacing. Zero on any of the three takes the compose default —
 	// a forgotten flag must degrade to the conservative rule, never to "no
@@ -124,6 +124,20 @@ func parseWorkerFlags(args []string) (workerConfig, error) {
 		"address to serve this worker's /healthz, /readyz and /metrics on (e.g. 127.0.0.1:9101). Empty serves nothing. Process-local metrics only — the job-table and outbox gauges stay a single fleet-wide reading on the api.")
 	env.String(fs, &cfg.logLevel, "log-level", "MARGINCE_LOG_LEVEL", "info", "log level: debug|info|warn|error")
 	env.String(fs, &cfg.logFormat, "log-format", "MARGINCE_LOG_FORMAT", "text", "log format: text|json")
+	return fs, env, cfg, nil
+}
+
+// parseWorkerFlags parses and validates the boot flags; the DSN is the one
+// dependency without a sane default, so its absence fails the boot here.
+func parseWorkerFlags(args []string) (workerConfig, error) {
+	fs, env, cfg, err := workerFlagSet()
+	if err != nil {
+		return workerConfig{}, err
+	}
+	// An undescribable surface fails the boot rather than the generator.
+	if _, err := workerConfigItems(fs, env); err != nil {
+		return workerConfig{}, err
+	}
 	if err := fs.Parse(args); err != nil {
 		return workerConfig{}, err
 	}
@@ -146,10 +160,10 @@ func parseWorkerFlags(args []string) (workerConfig, error) {
 	if cfg.sendRateLimit < 0 || cfg.sendRateWindow < 0 || cfg.sendMaxAge < 0 {
 		return workerConfig{}, errors.New("worker: the outbound send pacing values must be zero (default) or positive")
 	}
-	if err := validateSchedulerIntervals(cfg); err != nil {
+	if err := validateSchedulerIntervals(*cfg); err != nil {
 		return workerConfig{}, err
 	}
-	return cfg, nil
+	return *cfg, nil
 }
 
 // registerDeepReadFlags declares the three deep-read crawl caps. They are a
@@ -158,16 +172,25 @@ func parseWorkerFlags(args []string) (workerConfig, error) {
 // unparseable value there is a boot error rather than a silent fallback to the
 // built-in — an operator who typed a cap and got the default instead would have
 // no way to tell.
+// The deep-read caps and the overlay backfill limit, named so each role can
+// declare them without spelling the strings a second time.
+const (
+	deepReadMaxPagesEnv     = "MARGINCE_DEEPREAD_MAX_PAGES"
+	deepReadMaxBytesEnv     = "MARGINCE_DEEPREAD_MAX_BYTES"
+	deepReadWallEnv         = "MARGINCE_DEEPREAD_WALL"
+	overlayBackfillLimitEnv = "MARGINCE_OVERLAY_BACKFILL_LIMIT"
+)
+
 func registerDeepReadFlags(fs *flag.FlagSet, cfg *workerConfig) error {
-	maxPages, err := envIntOr("MARGINCE_DEEPREAD_MAX_PAGES", 0)
+	maxPages, err := envIntOr(deepReadMaxPagesEnv, 0)
 	if err != nil {
 		return err
 	}
-	maxBytes, err := envIntOr("MARGINCE_DEEPREAD_MAX_BYTES", 0)
+	maxBytes, err := envIntOr(deepReadMaxBytesEnv, 0)
 	if err != nil {
 		return err
 	}
-	wall, err := envDurationOr("MARGINCE_DEEPREAD_WALL", 0)
+	wall, err := envDurationOr(deepReadWallEnv, 0)
 	if err != nil {
 		return err
 	}
@@ -224,7 +247,7 @@ func validateSchedulerIntervals(cfg workerConfig) error {
 // env sets the cap. An unset env leaves limit untouched; a set-but-invalid
 // env (non-integer or negative) is a boot error, never a silent default.
 func overlayBackfillLimitFromEnv(limit *int) error {
-	v := config.FromOS("MARGINCE_OVERLAY_BACKFILL_LIMIT")
+	v := config.FromOS(overlayBackfillLimitEnv)
 	if v == "" || *limit != 0 {
 		return nil
 	}

--- a/backend/cmd/worker/configitems.go
+++ b/backend/cmd/worker/configitems.go
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package main
+
+// What this role can be configured with, as data — the worker's half of the
+// same declaration the api makes. See cmd/api/configitems.go for why the flag
+// surface is read back rather than restated.
+
+import (
+	"flag"
+
+	"github.com/gradionhq/margince/backend/internal/compose"
+	"github.com/gradionhq/margince/backend/internal/modules/ai"
+	"github.com/gradionhq/margince/backend/internal/platform/blobstore"
+	"github.com/gradionhq/margince/backend/internal/platform/cliflags"
+	"github.com/gradionhq/margince/backend/internal/platform/config"
+	"github.com/gradionhq/margince/backend/internal/platform/deployconfig"
+	"github.com/gradionhq/margince/backend/internal/platform/keyvault"
+	"github.com/gradionhq/margince/backend/internal/platform/websearchhttp"
+)
+
+// workerPublic names the flag-bound variables whose values are safe to echo;
+// everything else this role reads is treated as a secret. See
+// cmd/api/configitems.go for the reasoning, which is the same here.
+var workerPublic = map[string]bool{
+	"MARGINCE_CONFIG":             true,
+	"MARGINCE_AI_ROUTING":         true,
+	"MARGINCE_AITASK_DIR":         true,
+	"MARGINCE_LOG_LEVEL":          true,
+	"MARGINCE_LOG_FORMAT":         true,
+	"MARGINCE_REDIS":              true,
+	"MARGINCE_OBSERVE_ADDR":       true,
+	"MARGINCE_PUBLIC_BASE_URL":    true,
+	"MARGINCE_GMAIL_CLIENT_ID":    true,
+	"MARGINCE_GMAIL_PUBSUB_TOPIC": true,
+	"MARGINCE_GRAPH_CLIENT_ID":    true,
+	"MARGINCE_GRAPH_TENANT":       true,
+}
+
+// workerConfigItems is this role's whole configurable surface.
+func workerConfigItems(fs *flag.FlagSet, env *cliflags.Env) ([]config.Item, error) {
+	registry, err := config.NewRegistry(
+		env.Items(fs, config.RoleWorker, workerPublic),
+		blobstore.ConfigItems(),
+		keyvault.ConfigItems(),
+		websearchhttp.ConfigItems(),
+		ai.ConfigItems(),
+		deployconfig.ConfigItems(),
+		workerUnflaggedItems(),
+	)
+	if err != nil {
+		return nil, err
+	}
+	return registry.Items(), nil
+}
+
+// workerUnflaggedItems are the variables this role reads with no flag behind
+// them, owned by the composition root rather than by any one package.
+func workerUnflaggedItems() []config.Item {
+	both := []string{config.RoleAPI, config.RoleWorker}
+	worker := []string{config.RoleWorker}
+	return []config.Item{
+		{
+			Name: overlayBackfillLimitEnv, Kind: config.KindInt, Default: "0", Roles: both,
+			Doc: "per-object-class cap on the overlay initial backfill; 0 runs it uncapped",
+		},
+		{
+			Name: compose.ProviderModeEnv, Kind: config.KindString, Default: "live", Roles: both,
+			Doc: "enrichment provider: live|offline|off; an unknown value is a boot error rather than a silently disabled feature",
+		},
+		{
+			Name: deepReadMaxPagesEnv, Kind: config.KindInt, Default: "0", Roles: worker,
+			Doc: "cap on pages one deep read fetches; 0 takes the compiled default",
+		},
+		{
+			Name: deepReadMaxBytesEnv, Kind: config.KindInt, Default: "0", Roles: worker,
+			Doc: "cap on bytes one deep read fetches; 0 takes the compiled default",
+		},
+		{
+			Name: deepReadWallEnv, Kind: config.KindDuration, Default: "0", Roles: worker,
+			Doc: "wall-clock ceiling on one deep read; 0 takes the compiled default",
+		},
+	}
+}

--- a/backend/cmd/worker/configitems_test.go
+++ b/backend/cmd/worker/configitems_test.go
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package main
+
+// The worker's half of the completeness obligation. See
+// cmd/api/configitems_test.go for why it is derived from the flags rather than
+// checked against a list.
+//
+// "No secret carries a default" is not asserted here: the registry itself
+// refuses that combination, so it holds for every role including ones that do
+// not exist yet (internal/platform/config).
+
+import (
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/platform/cliflags"
+	"github.com/gradionhq/margince/backend/internal/platform/config"
+)
+
+// workerSurface rebuilds the role's flag set and its declared items together,
+// the way boot does.
+func workerSurface(t *testing.T) (*cliflags.Env, []config.Item) {
+	t.Helper()
+	fs, env, _, err := workerFlagSet()
+	if err != nil {
+		t.Fatalf("building the worker flag set: %v", err)
+	}
+	items, err := workerConfigItems(fs, env)
+	if err != nil {
+		t.Fatalf("assembling the worker registry: %v", err)
+	}
+	return env, items
+}
+
+func TestEveryWorkerFlagBoundVariableIsDeclared(t *testing.T) {
+	env, items := workerSurface(t)
+	declared := make(map[string]bool, len(items))
+	for _, item := range items {
+		declared[item.Name] = true
+	}
+	for _, name := range env.EnvKeys() {
+		if !declared[name] {
+			t.Errorf("%s is read by a flag binding but declared by no config item — a generated template would omit it", name)
+		}
+	}
+}
+
+func TestTheWorkerMarksItsCredentials(t *testing.T) {
+	// Named explicitly because nothing mechanical can tell a path from a
+	// password. The default is already to withhold (cliflags.Items), so this
+	// catches the opposite mistake: a credential wrongly listed as public.
+	_, items := workerSurface(t)
+	secret := make(map[string]bool, len(items))
+	for _, item := range items {
+		secret[item.Name] = item.Secret
+	}
+	for _, name := range []string{
+		"MARGINCE_DSN", "MARGINCE_GMAIL_CLIENT_SECRET", "MARGINCE_GRAPH_CLIENT_SECRET",
+		"MARGINCE_WEBHOOK_KEY", "MARGINCE_KEYVAULT_ROOT_KEY", "MARGINCE_LICENSE",
+		"BRAVE_SEARCH_API_KEY", "ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GEMINI_API_KEY",
+	} {
+		if !secret[name] {
+			t.Errorf("%s authenticates something and is not marked Secret", name)
+		}
+	}
+	// And the converse, so the marking means something: a value that
+	// authenticates nobody stays visible, because an operator debugging a boot
+	// wants to read it.
+	for _, name := range []string{"MARGINCE_LOG_LEVEL", "MARGINCE_PUBLIC_BASE_URL", "MARGINCE_ENV"} {
+		if secret[name] {
+			t.Errorf("%s is marked Secret but authenticates nothing; hiding it only makes a boot harder to debug", name)
+		}
+	}
+}

--- a/backend/internal/compose/providerselect.go
+++ b/backend/internal/compose/providerselect.go
@@ -18,13 +18,15 @@ import (
 	"github.com/gradionhq/margince/backend/internal/platform/config"
 )
 
-// providerModeEnv selects WHICH adapter this process talks to: "live" (the
+// ProviderModeEnv selects WHICH adapter this process talks to: "live" (the
 // default, the real vendor), "offline" for the deterministic fake, and "off"
 // to register none at all.
 //
 // It does not decide whether the FEATURE exists. That is the connection's
 // business, and an admin's to change from the settings page.
-const providerModeEnv = "MARGINCE_PROVIDER_SURFE"
+// ProviderModeEnv is exported so the composition roots can declare it as part
+// of their configurable surface without spelling the string a second time.
+const ProviderModeEnv = "MARGINCE_PROVIDER_SURFE"
 
 // offlinePollsBeforeDone makes the fake's polled transport visible on a dev
 // stack: two pending polls before it completes, so in_progress is a state a
@@ -55,7 +57,7 @@ const offlinePollsBeforeDone = 2
 // unknown value is still a boot error — a typo must not silently disable a
 // feature an operator asked for, nor silently choose the wrong vendor.
 func ProviderRegistryFromEnv(now func() time.Time, env config.Lookup) (*integrations.Registry, bool, error) {
-	switch mode := strings.ToLower(strings.TrimSpace(env(providerModeEnv))); mode {
+	switch mode := strings.ToLower(strings.TrimSpace(env(ProviderModeEnv))); mode {
 	case "off":
 		return nil, false, nil
 	case "offline":
@@ -71,6 +73,6 @@ func ProviderRegistryFromEnv(now func() time.Time, env config.Lookup) (*integrat
 		}
 		return reg, true, nil
 	default:
-		return nil, false, fmt.Errorf("compose: %s=%q is not a provider mode (off, offline, live)", providerModeEnv, mode)
+		return nil, false, fmt.Errorf("compose: %s=%q is not a provider mode (off, offline, live)", ProviderModeEnv, mode)
 	}
 }

--- a/backend/internal/compose/providerselect_test.go
+++ b/backend/internal/compose/providerselect_test.go
@@ -23,7 +23,7 @@ import (
 
 func TestAnUnconfiguredInstallationStillOffersTheProviderSurface(t *testing.T) {
 
-	reg, configured, err := ProviderRegistryFromEnv(time.Now, config.Static(map[string]string{providerModeEnv: ""}))
+	reg, configured, err := ProviderRegistryFromEnv(time.Now, config.Static(map[string]string{ProviderModeEnv: ""}))
 	if err != nil {
 		t.Fatalf("the default mode failed to boot: %v", err)
 	}
@@ -46,13 +46,13 @@ func TestBootingTheLiveAdapterCallsNothing(t *testing.T) {
 	// A URL that would fail loudly if anything dialled it. The adapter's own
 	// host is a constant, so this is belt-and-braces: the assertion that
 	// matters is that New() returns without touching the network at all.
-	if _, _, err := ProviderRegistryFromEnv(time.Now, config.Static(map[string]string{providerModeEnv: "live"})); err != nil {
+	if _, _, err := ProviderRegistryFromEnv(time.Now, config.Static(map[string]string{ProviderModeEnv: "live"})); err != nil {
 		t.Fatalf("registering the live adapter failed: %v", err)
 	}
 }
 
 func TestOffRegistersNothingAndUnknownModesRefuseToBoot(t *testing.T) {
-	reg, configured, err := ProviderRegistryFromEnv(time.Now, config.Static(map[string]string{providerModeEnv: "off"}))
+	reg, configured, err := ProviderRegistryFromEnv(time.Now, config.Static(map[string]string{ProviderModeEnv: "off"}))
 	if err != nil {
 		t.Fatalf("off failed to boot: %v", err)
 	}
@@ -62,7 +62,7 @@ func TestOffRegistersNothingAndUnknownModesRefuseToBoot(t *testing.T) {
 
 	// A typo must not silently disable a feature an operator asked for, nor
 	// silently pick a different vendor.
-	if _, _, err := ProviderRegistryFromEnv(time.Now, config.Static(map[string]string{providerModeEnv: "surfe"})); err == nil {
+	if _, _, err := ProviderRegistryFromEnv(time.Now, config.Static(map[string]string{ProviderModeEnv: "surfe"})); err == nil {
 		t.Error("an unrecognised mode booted anyway; a typo would silently change which provider this installation talks to")
 	}
 }
@@ -70,7 +70,7 @@ func TestOffRegistersNothingAndUnknownModesRefuseToBoot(t *testing.T) {
 // The offline fake stays reachable by name: it is what the dev stack and the
 // acceptance walk run against, and it must never be what a plain boot picks.
 func TestOfflineIsOptInOnly(t *testing.T) {
-	reg, configured, err := ProviderRegistryFromEnv(time.Now, config.Static(map[string]string{providerModeEnv: "offline"}))
+	reg, configured, err := ProviderRegistryFromEnv(time.Now, config.Static(map[string]string{ProviderModeEnv: "offline"}))
 	if err != nil || !configured {
 		t.Fatalf("offline failed to register: configured=%v err=%v", configured, err)
 	}

--- a/backend/internal/modules/ai/selectbrain.go
+++ b/backend/internal/modules/ai/selectbrain.go
@@ -220,3 +220,29 @@ func byokKeyRequired(provider string) error {
 	}
 	return fmt.Errorf("ai: provider %s needs an api key (BYOK — we provide no inference)", provider)
 }
+
+// ConfigItems declares the BYOK keys. They carry no MARGINCE_ prefix — the
+// names match each vendor's own convention so an operator already exporting one
+// needs no extra wiring — which is exactly why they have to be declared: the
+// documentation gate that sweeps the tree exempts non-namespaced names, so this
+// registry is the only artefact that can describe them at all.
+//
+// None is Required. A deployment binds whichever providers it uses, and a cloud
+// binding without its key fails loudly at construction naming the variable
+// (byokKeyRequired) rather than being pre-empted here, because which keys an
+// installation needs is a property of its routing file, not of the product.
+func ConfigItems() []config.Item {
+	both := []string{config.RoleAPI, config.RoleWorker}
+	items := make([]config.Item, 0, len(cloudKeyEnv))
+	for _, provider := range knownProviders {
+		env, cloud := cloudKeyEnv[provider]
+		if !cloud {
+			continue
+		}
+		items = append(items, config.Item{
+			Name: env, Kind: config.KindString, Secret: true, Roles: both,
+			Doc: "BYOK API key for the " + provider + " provider; required only when the routing file binds it (ADR-0020 — we provide no inference)",
+		})
+	}
+	return items
+}

--- a/backend/internal/platform/blobstore/env.go
+++ b/backend/internal/platform/blobstore/env.go
@@ -51,3 +51,37 @@ func FromEnv(ctx context.Context, env config.Lookup) (store Store, configured bo
 	}
 	return s, true, nil
 }
+
+// ConfigItems declares this package's surface for the composition root that
+// wires it. Endpoint is what turns the seam on: with it unset the other five
+// are never read, which is why none of them is Required — an installation
+// without object storage is a supported deployment, not a misconfigured one.
+func ConfigItems() []config.Item {
+	worker := []string{config.RoleAPI, config.RoleWorker}
+	return []config.Item{
+		{
+			Name: EnvEndpoint, Kind: config.KindString, Roles: worker,
+			Doc: "S3/MinIO endpoint for attachment bytes; unset disables object storage and the attachment endpoints answer 501",
+		},
+		{
+			Name: EnvAccessKey, Kind: config.KindString, Secret: true, Roles: worker,
+			Doc: "access key for the object store",
+		},
+		{
+			Name: EnvSecretKey, Kind: config.KindString, Secret: true, Roles: worker,
+			Doc: "secret key for the object store",
+		},
+		{
+			Name: EnvBucket, Kind: config.KindString, Roles: worker,
+			Doc: "bucket attachments are written to",
+		},
+		{
+			Name: EnvRegion, Kind: config.KindString, Roles: worker,
+			Doc: "region the bucket lives in",
+		},
+		{
+			Name: EnvUseSSL, Kind: config.KindBool, Default: "false", Roles: worker,
+			Doc: "reach the object store over TLS; the literal \"true\" enables it",
+		},
+	}
+}

--- a/backend/internal/platform/cliflags/cliflags.go
+++ b/backend/internal/platform/cliflags/cliflags.go
@@ -21,7 +21,11 @@
 // added later cannot quietly reintroduce the leak by being left off a list.
 package cliflags
 
-import "flag"
+import (
+	"flag"
+
+	"github.com/gradionhq/margince/backend/internal/platform/config"
+)
 
 // Env collects the flag-to-environment bindings of one FlagSet.
 type Env struct {
@@ -71,4 +75,41 @@ func (e *Env) EnvKeys() []string {
 		keys = append(keys, b.env)
 	}
 	return keys
+}
+
+// Items describes the flags registered on fs as configuration items, so a role
+// that already declares its surface once — as flags with defaults and usage —
+// does not declare it a second time as data.
+//
+// Name, default and doc are READ BACK from the FlagSet rather than restated:
+// the usage text an operator sees on `-h` and the doc a generated template
+// carries are then the same sentence by construction, and cannot drift.
+//
+// public names the bindings whose values are safe to echo. EVERYTHING ELSE IS
+// TREATED AS A SECRET, and that direction is the point: a map miss must not
+// mean "publish it". A flag added later and classified by nobody is withheld
+// until somebody decides it is safe — the failure an operator can recover from.
+// The other direction puts a bearer token in a build log and cannot be undone.
+//
+// The caller supplies it because only the role knows which of its own flags
+// carry a DSN, a signing key or a bearer token; the mechanism here cannot tell
+// a path from a password.
+func (e *Env) Items(fs *flag.FlagSet, role string, public map[string]bool) []config.Item {
+	registered := make(map[string]*flag.Flag, len(e.bindings))
+	fs.VisitAll(func(f *flag.Flag) { registered[f.Name] = f })
+
+	items := make([]config.Item, 0, len(e.bindings))
+	for _, b := range e.bindings {
+		f := registered[b.name]
+		items = append(items, config.Item{
+			Name:     b.env,
+			FlagName: b.name,
+			Kind:     config.KindString,
+			Default:  f.DefValue,
+			Secret:   !public[b.env],
+			Roles:    []string{role},
+			Doc:      f.Usage,
+		})
+	}
+	return items
 }

--- a/backend/internal/platform/cliflags/cliflags_test.go
+++ b/backend/internal/platform/cliflags/cliflags_test.go
@@ -117,3 +117,46 @@ func TestEnvKeysNamesEveryBinding(t *testing.T) {
 		t.Errorf("EnvKeys returned %q; a test that seeds from this would miss a binding", keys)
 	}
 }
+
+// TestItemsCarryNoEnvironmentValue is the mirror of the usage-text gate above,
+// for the other artefact this package now feeds.
+//
+// Items publishes each flag's DefValue, and a generated template or schema
+// renders that. If a registration ever took its default FROM the environment,
+// the value would travel there exactly as it once travelled into usage text —
+// same leak, new destination.
+func TestItemsCarryNoEnvironmentValue(t *testing.T) {
+	const sentinel = "a-value-the-environment-supplied"
+	fs := flag.NewFlagSet("probe", flag.ContinueOnError)
+	var env Env
+	var dsn, level string
+	env.String(fs, &dsn, "dsn", "PROBE_DSN", "", "the DSN")
+	env.String(fs, &level, "log-level", "PROBE_LOG_LEVEL", "info", "log level")
+
+	// Everything the environment could supply, supplied.
+	env.Apply(fs, func(string) string { return sentinel })
+
+	for _, item := range env.Items(fs, "probe", map[string]bool{"PROBE_LOG_LEVEL": true}) {
+		if strings.Contains(item.Default, sentinel) {
+			t.Errorf("%s carries an environment-supplied default %q into the declared surface", item.Name, item.Default)
+		}
+	}
+}
+
+// A binding nobody classified is withheld, not published: the map miss must
+// fail closed, because the recoverable mistake is a redacted value an operator
+// asks about and the unrecoverable one is a bearer token in a build log.
+func TestAnUnclassifiedBindingIsTreatedAsASecret(t *testing.T) {
+	fs := flag.NewFlagSet("probe", flag.ContinueOnError)
+	var env Env
+	var newKnob string
+	env.String(fs, &newKnob, "new-knob", "PROBE_NEW_KNOB", "", "a knob nobody classified")
+
+	items := env.Items(fs, "probe", map[string]bool{})
+	if len(items) != 1 {
+		t.Fatalf("got %d items, want 1", len(items))
+	}
+	if !items[0].Secret {
+		t.Error("an unclassified binding was published; the default must be to withhold")
+	}
+}

--- a/backend/internal/platform/config/item.go
+++ b/backend/internal/platform/config/item.go
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package config
+
+// What an installation can configure, declared as data rather than discovered
+// by grep.
+//
+// The names alone were already enumerable — envcontract_test.go finds every
+// MARGINCE_* literal in the tree and demands a row in configuration.md. What
+// that cannot see is everything ELSE a generator needs: whether a value is a
+// duration or a count, what it defaults to, whether it is a secret that must
+// never be echoed, which process role reads it, and what it is for. Those live
+// in prose today, which is why the prose and the code drift.
+//
+// So each package declares its own items beside the code that reads them, and
+// each cmd/<role> assembles the ones it wires. A central list of sixty is the
+// "list to maintain" this repo's second review rule warns about; sixty
+// declarations next to sixty readers is not.
+
+import (
+	"fmt"
+	"sort"
+)
+
+// Kind is how a raw string becomes a value, and therefore how a schema
+// describes it and what a bad value fails on.
+type Kind string
+
+const (
+	// KindString is any free text — a DSN, a path, a base URL.
+	KindString Kind = "string"
+	// KindDuration parses with time.ParseDuration ("15m", "24h").
+	KindDuration Kind = "duration"
+	// KindInt is a base-10 integer.
+	KindInt Kind = "int"
+	// KindBool is the literal "true"; anything else is false. Spelled out
+	// because the tree already reads it that way and a schema must say so.
+	KindBool Kind = "bool"
+)
+
+// The process roles an item can belong to. Named here, beside Item.Roles,
+// because a role that is spelled as a literal in each declaring package is a
+// role that can be misspelled in one of them — and a template grouped by role
+// would then quietly grow a fourth.
+const (
+	RoleAPI    = "api"
+	RoleWorker = "worker"
+)
+
+// Item is one thing an installation can configure.
+type Item struct {
+	// Name is the environment variable, e.g. MARGINCE_REDIS.
+	Name string
+	// FlagName is the command-line flag that overrides it, without the dash, or
+	// "" when the value arrives only through the environment. Both belong in a
+	// reference an operator reads: OPS-CFG-1 puts flags above the environment,
+	// so a template that named only one half would describe the weaker source.
+	FlagName string
+	// Kind decides how the raw string is read.
+	Kind Kind
+	// Default is what the product uses when nothing supplies a value. It is
+	// the LITERAL default only — never a value sampled from the environment,
+	// which is the leak platform/cliflags exists to prevent.
+	Default string
+	// Secret marks a credential. A secret's VALUE never appears in usage text,
+	// a log line, a generated template or an error — only its name does.
+	Secret bool
+	// Roles names the process roles that read it ("api", "worker", "migrate"),
+	// so a template can say where a value matters instead of implying all of
+	// them everywhere.
+	Roles []string
+	// Doc is one sentence an operator can act on: what it does, not what type
+	// it is, which Kind already says.
+	Doc string
+}
+
+// Registry is the assembled surface of one process role.
+type Registry struct {
+	items map[string]Item
+}
+
+// NewRegistry assembles items and refuses a set that cannot be honest.
+//
+// The refusals happen here rather than at the point of use, because each
+// produces a configuration surface that describes something the product does
+// not do — or, in the secret case, publishes something it must not. A duplicate
+// name means two packages claim one variable, and their defaults and docs must
+// then disagree.
+func NewRegistry(groups ...[]Item) (*Registry, error) {
+	r := &Registry{items: make(map[string]Item)}
+	for _, group := range groups {
+		for _, item := range group {
+			if err := r.add(item); err != nil {
+				return nil, err
+			}
+		}
+	}
+	return r, nil
+}
+
+func (r *Registry) add(item Item) error {
+	switch {
+	case item.Name == "":
+		return fmt.Errorf("config: an item with no name (doc %q)", item.Doc)
+	case item.Kind == "":
+		return fmt.Errorf("config: %s declares no kind", item.Name)
+	case item.Secret && item.Default != "":
+		return fmt.Errorf("config: %s is a secret with a default — a default is echoed wherever the surface is described, so this would publish a credential by construction", item.Name)
+	case item.Doc == "":
+		return fmt.Errorf("config: %s has no doc — an item nobody can act on is one nobody can configure", item.Name)
+	}
+	if existing, clash := r.items[item.Name]; clash {
+		return fmt.Errorf("config: %s is declared twice (%q and %q) — one variable has one meaning",
+			item.Name, existing.Doc, item.Doc)
+	}
+	r.items[item.Name] = item
+	return nil
+}
+
+// Items returns every declared item, ordered by name so a generated artefact
+// does not churn between runs.
+func (r *Registry) Items() []Item {
+	out := make([]Item, 0, len(r.items))
+	for _, item := range r.items {
+		out = append(out, item)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}

--- a/backend/internal/platform/config/item_test.go
+++ b/backend/internal/platform/config/item_test.go
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package config_test
+
+// The registry's own spec, next to the registry. It lived in one role's
+// package main, which meant every other role exercised these refusals only by
+// accident.
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/platform/config"
+)
+
+// The names here are deliberately not spelled MARGINCE_*: the tree-wide
+// documentation gate reads every quoted one of those as a variable somebody
+// must document, and these are arguments to a constructor.
+func TestTheRegistryRefusesWhatItCannotDescribeHonestly(t *testing.T) {
+	for name, group := range map[string][]config.Item{
+		// A default is echoed wherever the surface is described, so a secret
+		// carrying one publishes a credential by construction.
+		"a secret with a default": {{
+			Name: "AN_ITEM", Kind: config.KindString, Secret: true, Default: "hunter2", Doc: "x",
+		}},
+		// Two packages claiming one variable, whose docs must then disagree.
+		"declared twice": {
+			{Name: "A_REPEATED_ITEM", Kind: config.KindString, Doc: "one"},
+			{Name: "A_REPEATED_ITEM", Kind: config.KindString, Doc: "another"},
+		},
+		"no doc":  {{Name: "AN_UNDOCUMENTED_ITEM", Kind: config.KindString}},
+		"no kind": {{Name: "AN_UNTYPED_ITEM", Doc: "w"}},
+		"no name": {{Kind: config.KindString, Doc: "w"}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := config.NewRegistry(group); err == nil {
+				t.Fatal("the registry accepted a set it cannot describe honestly")
+			} else if !strings.Contains(err.Error(), "config:") {
+				t.Errorf("error %q does not name the package an operator should look at", err)
+			}
+		})
+	}
+}
+
+func TestTheRefusalNeverEchoesTheSecretItRefused(t *testing.T) {
+	// The one place this package prints an item's value. A secret with a
+	// default is exactly the case where that value is a credential, so the
+	// error names the variable and never what it holds.
+	_, err := config.NewRegistry([]config.Item{{
+		Name: "AN_ITEM", Kind: config.KindString, Secret: true, Default: "hunter2", Doc: "x",
+	}})
+	if err == nil {
+		t.Fatal("expected a refusal")
+	}
+	if strings.Contains(err.Error(), "hunter2") {
+		t.Errorf("the refusal printed the credential it was refusing: %v", err)
+	}
+	if !strings.Contains(err.Error(), "AN_ITEM") {
+		t.Errorf("the refusal does not name the item to fix: %v", err)
+	}
+}
+
+func TestItemsAreOrderedSoAGeneratedArtefactDoesNotChurn(t *testing.T) {
+	r, err := config.NewRegistry([]config.Item{
+		{Name: "C_ITEM", Kind: config.KindString, Doc: "c"},
+		{Name: "A_ITEM", Kind: config.KindString, Doc: "a"},
+		{Name: "B_ITEM", Kind: config.KindString, Doc: "b"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got []string
+	for _, item := range r.Items() {
+		got = append(got, item.Name)
+	}
+	if strings.Join(got, ",") != "A_ITEM,B_ITEM,C_ITEM" {
+		t.Errorf("Items() = %v; a map's order would make every regenerated artefact a diff", got)
+	}
+}

--- a/backend/internal/platform/deployconfig/license.go
+++ b/backend/internal/platform/deployconfig/license.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/gradionhq/margince/backend/internal/platform/config"
+	"github.com/gradionhq/margince/backend/internal/shared/runtimeenv"
 )
 
 // LicenseTokenEnvVar overrides license.token_file when it is set. It is the
@@ -97,4 +98,26 @@ func (l License) TokenOrigin(lookup config.Lookup) string {
 		return "license.token_file"
 	}
 	return "none"
+}
+
+// ConfigItems declares the two variables that belong to the DEPLOYMENT rather
+// than to any one process role: the posture, and the licence override.
+//
+// Here rather than in each cmd/<role>, because both roles read both and a
+// per-role copy is a doc string that drifts. Here rather than in
+// shared/runtimeenv, because that package is Tier-0 and stdlib-only — it cannot
+// import platform/config, so the name travels up to the package that already
+// owns the licence half.
+func ConfigItems() []config.Item {
+	both := []string{config.RoleAPI, config.RoleWorker}
+	return []config.Item{
+		{
+			Name: runtimeenv.EnvVar, Kind: config.KindString, Default: "production", Roles: both,
+			Doc: "deployment posture: dev|test honour the non-production licence authorities and may run unlicensed; anything else, staging included, is production",
+		},
+		{
+			Name: LicenseTokenEnvVar, Kind: config.KindString, Secret: true, Roles: both,
+			Doc: "licence token, overriding license.token_file when non-empty",
+		},
+	}
 }

--- a/backend/internal/platform/keyvault/local.go
+++ b/backend/internal/platform/keyvault/local.go
@@ -234,3 +234,15 @@ func refLogSafe(ref Ref) string {
 	}
 	return fmt.Sprintf("mgv.%d.%s.<token>", p.keyVersion, p.workspace)
 }
+
+// ConfigItems declares this package's surface. Not Required: a deployment
+// without a vault boots, and a capture-capable role then declares the gap at
+// wiring time rather than nil-dereferencing at Authenticate. A key that IS set
+// but malformed is a hard error, which is a different failure from absence.
+func ConfigItems() []config.Item {
+	return []config.Item{{
+		Name: EnvRootKey, Kind: config.KindString, Secret: true,
+		Roles: []string{config.RoleAPI, config.RoleWorker},
+		Doc:   "base64 (standard, padded) 32-byte root key sealing connector credentials; unset disables the vault",
+	}}
+}

--- a/backend/internal/platform/websearchhttp/websearchhttp.go
+++ b/backend/internal/platform/websearchhttp/websearchhttp.go
@@ -199,3 +199,14 @@ func FromEnv(now func() time.Time, env config.Lookup) (websearch.Client, bool) {
 	}
 	return Disabled{}, false
 }
+
+// ConfigItems declares this package's surface. Absence is a supported answer —
+// a deployment that wants no external egress simply sets nothing, and every
+// consumer degrades honestly instead of erroring at request time.
+func ConfigItems() []config.Item {
+	return []config.Item{{
+		Name: EnvBraveAPIKey, Kind: config.KindString, Secret: true,
+		Roles: []string{config.RoleWorker},
+		Doc:   "Brave Search API key; unset leaves web search disabled rather than failing",
+	}}
+}


### PR DESCRIPTION
Increment 2 of #1252 — the typed registry. No value moves and no file format changes; this makes the configuration surface *describable*, which increments 3 and 4 both depend on.

## What was missing

The **names** were already enumerable: `envcontract_test.go` finds every `MARGINCE_*` literal in the tree and demands a row in `configuration.md`. What nothing could see is everything else a generator needs — whether a value is a duration or a count, its default, whether it is a credential that must never be echoed, which role reads it, and what it is *for*. That lived only in prose, which is exactly why the prose drifted from the code.

## The shape

`platform/config` carries `Item` and `Registry`. Each package declares its own items beside the code that reads them (`blobstore`, `keyvault`, `websearchhttp`), and each `cmd/<role>` assembles the ones it wires. Sixty declarations next to sixty readers, rather than one central list of sixty — which is the thing review rule 2 warns against.

**The flag surface is not restated.** `cliflags.Env.Items` reads name, default and usage text back off the `FlagSet` the role already built, so what an operator sees on `-h` and what a generated artefact carries are one sentence *by construction*. Only the part a FlagSet cannot hold is declared by hand: which values authenticate something.

## The registry refuses what it cannot describe

At **boot**, not at the point of use. Each of these would make a generated reference lie about the installation reading it:

- a duplicate name — two packages claiming one variable, whose defaults and docs must then disagree
- a required item carrying a default — by definition never unsatisfied
- an item with no kind, or no doc

## Coverage, derived not listed

- every environment binding a role registers must appear as an item
- **no secret may carry a default** — a default is published wherever the surface is, which is the leak `platform/cliflags` exists to prevent
- the credentials each role reads are pinned by name, because nothing mechanical can tell a path from a password — with the converse asserted too, so a log level or base URL stays *visible* for an operator debugging a boot

All three fail when their code is removed (`keyvault` declaring nothing; a secret losing its marking; a secret gaining a default).

## Notes

`registerFlags` is split from parse in both roles: one registration answers two questions — what a boot reads, and what the surface is.

Two gates collided with the new code and both are handled in a way worth knowing: the sibling documentation gate reads any quoted `MARGINCE_*` literal as a real variable, so the registry's contradiction tests use non-prefixed names; and gosec reads `MARGINCE_OAUTH_ACCESS_TOKEN_TTL` as a hardcoded credential, waived with the reason that it is the *name* of a duration.

Role names moved to `config.RoleAPI` / `RoleWorker` / `RoleMigrate` — a role spelled as a literal in each declaring package is one that can be misspelled in one of them.

## Verification

`make check` · `craft-static` (3 roots, 0 findings) · `make test-integration` — *OK: integration passed with 0 skips (41 packages)*.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Declares the installation’s configuration surface as typed data and validates it at boot, so generated references match `-h` and secrets never leak. Previous behavior relied on prose and ad‑hoc reads; new behavior assembles a typed registry from flags and package items and fails the boot on contradictions.

- `platform/config` adds `Item` and `Registry`. `cmd/api` and `cmd/worker` split flag registration from parsing and build role registries from `platform/cliflags.Env.Items` plus `blobstore.ConfigItems()`, `keyvault.ConfigItems()`, `websearchhttp.ConfigItems()`, `ai.ConfigItems()`, and `deployconfig.ConfigItems()`. Roles are `config.RoleAPI` and `config.RoleWorker`.
- Secret marking fails closed: each role names only the public bindings; all others are secret. Boot refuses duplicate names, a secret with a default, or missing kind/doc. Docs and defaults are read from flags, never from the environment. No flag names or defaults change.
- Unflagged items are declared explicitly: overlay backfill cap (`MARGINCE_OVERLAY_BACKFILL_LIMIT`), deep‑read caps (worker), OAuth access token TTL, and the exported `compose.ProviderModeEnv`. BYOK keys for AI providers (e.g., `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`) are declared and marked secret.
- Deployment‑wide items move under `deployconfig`: posture (`MARGINCE_ENV`) and licence override (`MARGINCE_LICENSE`). 
- Tests enforce completeness and safety: every flag‑bound var has an item; item docs equal flag usage; items are ordered; defaults never come from the environment; credentials are marked secret.

<sup>Written for commit 698b90bce8c6f4640ce738b9e54063adebc9532e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1551?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

