### PR TITLE
fix(jobs): a wait owns its own deadline, so three awaits cannot share one budget

### DIFF
--- a/backend/internal/compose/capturejobs_integration_test.go
+++ b/backend/internal/compose/capturejobs_integration_test.go
@@ -70,10 +70,8 @@ func TestBackfillCompletionBuildsTheDigest(t *testing.T) {
 		}
 	}()
 
-	waitCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
-	defer cancel()
 	// Drain the boot digest so the next one cannot be it — nor deduped by it.
-	awaitKindCompleted(waitCtx, t, sub, CaptureDigestWorkspaceArgs{}.Kind())
+	awaitKindCompleted(t, sub, CaptureDigestWorkspaceArgs{}.Kind())
 
 	// The boot pass placed its own dispatcher row, so "no dispatcher exists" is
 	// not the claim to make — "the completion added none" is. Read the count
@@ -87,9 +85,9 @@ func TestBackfillCompletionBuildsTheDigest(t *testing.T) {
 	}, &river.InsertOpts{UniqueOpts: river.UniqueOpts{ByArgs: true, ByState: activeSweepStates}}); err != nil {
 		t.Fatalf("enqueue backfill: %v", err)
 	}
-	awaitKindCompleted(waitCtx, t, sub, "capture_backfill")
+	awaitKindCompleted(t, sub, "capture_backfill")
 	// The digest that follows the completed backfill is the payoff wiring.
-	awaitKindCompleted(waitCtx, t, sub, CaptureDigestWorkspaceArgs{}.Kind())
+	awaitKindCompleted(t, sub, CaptureDigestWorkspaceArgs{}.Kind())
 
 	// The waits above are satisfied by a digest of the right KIND, which the
 	// boot pass also produces — they prove the wiring fires, not WHAT it
@@ -188,9 +186,7 @@ func TestCaptureOvernightJobsRegisterAndRun(t *testing.T) {
 		}
 	}()
 
-	waitCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
-	defer cancel()
 	for _, kind := range []string{"capture_classify", "capture_enrich", "capture_digest"} {
-		awaitKindCompleted(waitCtx, t, sub, kind)
+		awaitKindCompleted(t, sub, kind)
 	}
 }

--- a/backend/internal/compose/extjobs_integration_test.go
+++ b/backend/internal/compose/extjobs_integration_test.go
@@ -150,7 +150,7 @@ func seedAgentSeat(t *testing.T, ws ids.UUID) ids.UUID {
 // reports the ones that also finished.
 func awaitRows(t *testing.T, pool *pgxpool.Pool, kind string, want int) int {
 	t.Helper()
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), awaitBudget)
 	defer cancel()
 	var got int
 	for {
@@ -344,7 +344,7 @@ func TestHandlerSeesAPinnedWorkspace(t *testing.T) {
 		return nil
 	})
 	_, sub := startRunner(t, e.Pool)
-	awaitKindCompleted(mustDeadline(t), t, sub, decl.ChildKind())
+	awaitKindCompleted(t, sub, decl.ChildKind())
 	// Every tick of the fan-out, not just the first: one pinned handler and one
 	// unpinned would still satisfy an any-of assertion.
 	awaitRows(t, e.Pool, decl.ChildKind(), len(live))
@@ -427,7 +427,7 @@ func TestPanickingTickFailsOneAttemptNotTheWorker(t *testing.T) {
 	if err := runner.Enqueue(context.Background(), CloseDateSweepArgs{}, nil); err != nil {
 		t.Fatalf("enqueueing after the panic: %v", err)
 	}
-	awaitKindCompleted(mustDeadline(t), t, sub, CloseDateSweepArgs{}.Kind())
+	awaitKindCompleted(t, sub, CloseDateSweepArgs{}.Kind())
 }
 
 // TestConfirmFirstJobIsRefusedAtBoot: a job has no caller, so a confirm-first
@@ -645,7 +645,7 @@ func execAsOwner(t *testing.T, sql string, args ...any) {
 // inside a select, never by an unconditional, uninterruptible time.Sleep.
 func waitUntil(t *testing.T, cond func() bool, what string) {
 	t.Helper()
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), awaitBudget)
 	defer cancel()
 	for {
 		if cond() {
@@ -657,13 +657,6 @@ func waitUntil(t *testing.T, cond func() bool, what string) {
 		case <-time.After(50 * time.Millisecond):
 		}
 	}
-}
-
-func mustDeadline(t *testing.T) context.Context {
-	t.Helper()
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	t.Cleanup(cancel)
-	return ctx
 }
 
 // TestTheChildUniquenessKeyIsTheWorkspaceAlone is the other half of the ByArgs

--- a/backend/internal/compose/jobs_integration_test.go
+++ b/backend/internal/compose/jobs_integration_test.go
@@ -71,23 +71,43 @@ func TestNewJobRunnerWiresTheOverlayPollerWhenAVaultIsConfigured(t *testing.T) {
 		}
 	}()
 
-	waitCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
-	defer cancel()
 	// The DISPATCHER is the right kind to wait on here, unlike the close-date
 	// case above: what this proves is that the branch registered the job at
 	// all. No overlay-mode workspace is seeded, so there is no workspace child
 	// to wait for — the fan-out is legitimately empty.
-	awaitKindCompleted(waitCtx, t, sub, OverlayReconcileArgs{}.Kind())
+	awaitKindCompleted(t, sub, OverlayReconcileArgs{}.Kind())
 }
 
+// awaitBudget is how long ONE wait in this package gets. It is spelled here and
+// read by every wait helper, so the three of them cannot drift into three
+// different answers to the same question.
+//
+// What it has to outlast is a single River job's queue wait plus its run on a
+// CONTENDED runner, which is why it is generous against the ~1s these jobs take
+// on an idle machine. Whatever it is, it belongs to one wait: see
+// awaitKindCompleted.
+const awaitBudget = 30 * time.Second
+
 // awaitKindCompleted blocks until a job of the given kind reports completion,
-// or the context deadline fires. No polling, no sleep.
-func awaitKindCompleted(ctx context.Context, t *testing.T, sub <-chan *river.Event, kind string) {
+// or its own deadline fires. No polling, no sleep.
+//
+// It derives that deadline ITSELF rather than taking a context, and the missing
+// parameter is the point: a caller used to be able to hand one context to three
+// sequential awaits, which is not 30s each but 30s BETWEEN them — whatever the
+// first spent, the second went without. That starved the second kind and failed
+// a test that passes in ~4s on an idle machine (#1538). With no parameter to
+// share, the shape cannot be written again.
+//
+// This also puts the helper back in line with its two siblings, awaitRows and
+// waitUntil, which have always owned their own clocks.
+func awaitKindCompleted(t *testing.T, sub <-chan *river.Event, kind string) {
 	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), awaitBudget)
+	defer cancel()
 	for {
 		select {
 		case <-ctx.Done():
-			t.Fatalf("timed out waiting for %q to complete: %v", kind, ctx.Err())
+			t.Fatalf("timed out waiting for %q to complete within %s: %v", kind, awaitBudget, ctx.Err())
 		case ev := <-sub:
 			if ev != nil && ev.Job != nil && ev.Job.Kind == kind {
 				return
@@ -132,9 +152,7 @@ func TestRiverCloseDateSweepStagesSameProvisionalAsDirectSweep(t *testing.T) {
 	// close-date WORKSPACE job to complete, then assert the same outcome the
 	// direct per-workspace pass produces. Waiting on the dispatcher would race
 	// the work: a dispatcher completes as soon as its fan-out is enqueued.
-	waitCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
-	defer cancel()
-	awaitKindCompleted(waitCtx, t, sub, CloseDateWorkspaceArgs{}.Kind())
+	awaitKindCompleted(t, sub, CloseDateWorkspaceArgs{}.Kind())
 
 	swept := e.readSwept(t, id)
 	if swept.expectedClose == nil || swept.expectedClose.Before(today()) {


### PR DESCRIPTION
Closes #1538.

## The defect

`TestCaptureOvernightJobsRegisterAndRun` awaited three job kinds under a **single** 60s context:

```go
waitCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
for _, kind := range []string{"capture_classify", "capture_enrich", "capture_digest"} {
    awaitKindCompleted(waitCtx, t, sub, kind)
}
```

That is not 60s each — it is 60s *between* them, and whatever the first await spends the second goes without. On a contended CI runner the second kind starved and the job failed on `capture_enrich`; the same commit passes in ~3s on an idle machine.

Its sibling `TestBackfillCompletionBuildsTheDigest` had the same shape and was **closer to the edge than it looked**: its three awaits take ~11s together, all drawn from one budget, with unrelated work interleaved between them.

## The fix

Removing the parameter rather than re-slicing it. `awaitKindCompleted` now derives its own deadline, so there is nothing left for a caller to share and **the shape cannot be written again** — the compiler refuses it, which is a stronger guard than an assertion about it would be.

That also puts the helper back in line with its two siblings: `awaitRows` and `waitUntil` have always owned their own clocks. It was the only wait in the package taking a caller's context, and the only one with the defect.

Three smaller decisions:

- **The budget is spelled once** as `awaitBudget`, read by all three helpers, so they cannot drift into three answers to one question.
- **The `runner.Stop()` graces keep their own literal.** A shutdown grace is a different bound from a wait for a job; I folded them together in a first pass and undid it — that would have been the same mistake in miniature.
- **`mustDeadline` is deleted.** It existed only to hand this helper a fresh context and went dead with its last caller.

## Sweep — no sibling left to fix

Every other await site was checked for the same shape. All are **1:1**, one deadline per await:

| file | deadlines | awaits |
|---|---|---|
| no_activity_reminder_workqueue | 1 | 1 |
| embedreindex_fanout | 2 | 2 |
| embedreindex | 3 | 3 |
| capture_auto_enrich_sweep | 1 | 1 |
| webhookretry_pass | 3 | 3 |
| agentscheduler | 2 | 2 |
| privacyretention | 4 | 4 |

The two `capturejobs` tests were 3:1 and 3:1 — the only instances.

`jobtest.AwaitKindsCompleted` is deliberately **untouched** despite taking plural kinds under one context: its kinds are awaited *concurrently* in one select loop, so a single deadline for the set is correct rather than shared. Same for the exported `integration.AwaitKindCompleted`, whose every call site already derives its own context — changing that signature would churn six packages to fix nothing.

## Verification

- Both affected tests pass: `TestBackfillCompletionBuildsTheDigest` 10.80s, `TestCaptureOvernightJobsRegisterAndRun` 2.92s.
- **Mutation-checked**: forcing `awaitBudget` to `1ms` fails with `timed out waiting for "capture_classify" to complete within 1ms`, proving the per-call deadline is wired rather than ignored. The message now names the budget it blew, which the old one did not.
- Full lane green: `OK: integration passed with 0 skips (41 packages, 2666 tests)`.
- `make check-backend` green.

No product code changes — test helpers only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes `awaitKindCompleted` own its deadline so sequential waits no longer share one budget. Old: three awaits could run under one 60s context and starve on contended runners. New: each await gets its own 30s `awaitBudget`. Side effects: the helper’s signature drops the context parameter and timeout messages include the budget.

- Updated call sites in `backend/internal/compose/capturejobs_integration_test.go`, `extjobs_integration_test.go`, and `jobs_integration_test.go` to call `awaitKindCompleted(t, sub, kind)`; removed shared `context.WithTimeout` and `mustDeadline`.
- Added `awaitBudget` and reused it in `awaitRows` and `waitUntil`; kept `runner.Stop()` grace separate.
- Left `jobtest.AwaitKindsCompleted` and exported `integration.AwaitKindCompleted` unchanged (concurrent waits or per-call contexts already correct). No product code changes or external migration required.

<sup>Written for commit d4917cfc03df469c92dc68ce0949f619b8e19cc9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1554?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved integration-test reliability by giving each completion wait its own timeout.
  - Standardized test wait durations and timeout handling.
  - Reduced failures caused by sequential waits sharing an exhausted deadline.
  - Updated boot, backfill, follow-up digest, overnight, and external job completion checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->