### PR TITLE
fix(seed-demo): a fresh install seeds, and no generated lead is mailable

### DIFF
--- a/backend/tools/seed-demo/apiclient.go
+++ b/backend/tools/seed-demo/apiclient.go
@@ -171,7 +171,18 @@ const seedAdminPassword = "demo-password-123"
 //
 // The change ends every session including the one that made it, so this signs
 // in again and hands back the new client.
+//
+// The bootstrap password may ALREADY be seedAdminPassword: `make dev` writes
+// that value into config/margince-admin-password and still sets the hold.
+// Rotating it to itself is refused, and reading that refusal as "already
+// replaced" is what made a fresh `tools/seed.sh` fail three phases later with
+// 403 password_change_required on the anchor company — a seeded installation
+// with seats but no company, which the UI correctly showed as cold-start
+// onboarding. So that case rotates through a detour value and back.
 func replaceOperatorPassword(baseURL, email, password string, c *client) (*client, string, error) {
+	if password == seedAdminPassword {
+		return replaceViaDetour(baseURL, email, c)
+	}
 	body := jsonBody{"current_password": password, "new_password": seedAdminPassword}
 	if err := c.post("/v1/auth/change-password", body, nil); err != nil {
 		// Already replaced by an earlier run or by seed-dev: the account is
@@ -186,6 +197,50 @@ func replaceOperatorPassword(baseURL, email, password string, c *client) (*clien
 		return nil, password, fmt.Errorf("signing in after replacing the password: %w", err)
 	}
 	fmt.Printf("admin:         operator password replaced with %q\n", seedAdminPassword)
+	return fresh, seedAdminPassword, nil
+}
+
+// seedAdminDetour is the value the bootstrap passes THROUGH when it already
+// holds seedAdminPassword. It exists for one round trip and is never the
+// password an installation is left on.
+const seedAdminDetour = "demo-password-123-first-change"
+
+// replaceViaDetour lifts the first-login hold when the current password is
+// already the one this tool would set.
+//
+// The product refuses a rotation to the same value, which is the rule working:
+// a bootstrap credential is meant to have no life beyond the first login, and
+// "changing" it to itself would end that life without replacing anything. Two
+// changes satisfy the rule honestly — the credential really is replaced — and
+// leave the installation on the password the README documents.
+//
+// A failure between the two leaves the account on the detour value, so the
+// error says so rather than making the next run guess.
+func replaceViaDetour(baseURL, email string, c *client) (*client, string, error) {
+	away := jsonBody{"current_password": seedAdminPassword, "new_password": seedAdminDetour}
+	if err := c.post("/v1/auth/change-password", away, nil); err != nil {
+		// Not on hold after all, and already on the documented password:
+		// nothing to do, and the current client still works.
+		if isUnprocessable(err) || isConflict(err) {
+			return c, seedAdminPassword, nil
+		}
+		return nil, seedAdminPassword, fmt.Errorf("lifting the first-login hold: %w", err)
+	}
+	mid, err := login(baseURL, email, seedAdminDetour)
+	if err != nil {
+		return nil, seedAdminDetour, fmt.Errorf("signing in on the detour password: %w", err)
+	}
+	back := jsonBody{"current_password": seedAdminDetour, "new_password": seedAdminPassword}
+	if err := mid.post("/v1/auth/change-password", back, nil); err != nil {
+		return nil, seedAdminDetour, fmt.Errorf(
+			"restoring %q (the account is on %q until this succeeds): %w",
+			seedAdminPassword, seedAdminDetour, err)
+	}
+	fresh, err := login(baseURL, email, seedAdminPassword)
+	if err != nil {
+		return nil, seedAdminDetour, fmt.Errorf("signing in after restoring the password: %w", err)
+	}
+	fmt.Printf("admin:         first-login hold lifted, password is %q\n", seedAdminPassword)
 	return fresh, seedAdminPassword, nil
 }
 

--- a/backend/tools/seed-demo/generated.go
+++ b/backend/tools/seed-demo/generated.go
@@ -198,9 +198,15 @@ func seedGeneratedLeads(c *client, refs pipelineRefs, plan map[string]profile, m
 				"source_id":     sourceID,
 				"status":        leadCreateStatus(p.LeadState),
 				"full_name":     first + " " + last,
-				"email":         strings.ToLower(first+"."+last) + "@" + domain,
-				"company_name":  refs.orgNameByID[orgID],
-				"title":         title,
+				// example.com, never the company's own domain. This lead is
+				// invented, but shopify.com accepts mail whether or not a
+				// Jonas Sommer works there — an invented address at a real
+				// domain is still deliverable, and the dataset's defang pass
+				// cannot reach an address this tool builds at runtime. RFC
+				// 2606 reserves example.com, so nothing here can be sent.
+				"email":        strings.ToLower(first+"."+last) + "@example.com",
+				"company_name": refs.orgNameByID[orgID],
+				"title":        title,
 			}
 			if owner, ok := refs.usersByRef[refs.ownerRefByDomain[domain]]; ok {
 				body["owner_id"] = owner


### PR DESCRIPTION
Two bugs, both found by running `tools/seed.sh --fresh` from a clean database
rather than reading the code.

## A fresh install could not be seeded at all

It died three phases in:

```
seed-demo: saving the anchor company: PUT /v1/company: HTTP 403
password_change_required
```

`make dev` writes `demo-password-123` into `config/margince-admin-password`
**and** sets `must_change_password`. `replaceOperatorPassword` then tried to
rotate that password to `demo-password-123` — the same value — which the
product correctly refuses, and **the refusal was read as "already replaced"**.

The hold was still on, so the first API write failed. Teams and seats had
already landed by SQL, which needs no password, so the installation was left
with 9 seats, no company, and a UI showing cold-start onboarding — which is
the correct rendering of an installation that has no company.

When the current password is already the one this tool sets, it now rotates
through a detour value and back. Two changes satisfy the product's rule
honestly — the credential really is replaced — and leave the installation on
the password the README documents.

## Generated leads carried mailable addresses

`generated.go` built them as `firstname.lastname@<the company's real domain>`,
so a seeded installation held `jonas.sommer@shopify.com` and two others.

The person is invented; the domain is not, and shopify.com accepts mail
either way. The dataset's own defang pass cannot reach an address this tool
builds at run time, so the fix belongs here: `example.com`, which RFC 2606
reserves and nothing can deliver to.

## Verification

End to end against a cold-start database:

```
admin:         first-login hold lifted, password is "demo-password-123"
organizations: 163 new   people: 770 new   deals: 55   contracts: 46
documents: 83   logos: 149 uploaded   facts: 11015   mailboxes: 7
verify:        OK — every seeded record is owned, employed, linked and staged
```

All 798 person emails are on `example.com` or `demo.test`; before this, three
were deliverable.

`make craft-static` and `make check-backend` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes seeding on fresh installs and ensures generated leads are not mailable. Before: seeding failed with 403 password_change_required when the bootstrap admin password already matched the documented value, and leads used the company’s real domain. Now: the tool lifts the first-login hold by rotating via a detour password and back to demo-password-123, and it always assigns first.last@example.com.

**Reviewer focus**
- Introduces a detour flow in `replaceOperatorPassword` when the current password equals the target: change to a detour value, re-login, change back; clear errors if left on the detour due to mid-flow failure.
- Changes generated lead emails to first.last@example.com (RFC 2606 reserved) instead of the org’s domain.
- No schema or config changes. No migration required. If you previously seeded mailable leads, rerun `tools/seed.sh --fresh` to regenerate data.

<sup>Written for commit cf81702dcf3a966f34821aa459f068b4001d1718. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1555?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

