### PR TITLE
fix(seed-demo): 30 leads went missing, and the logos were never uploaded

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,11 @@ DATASET ?= $(abspath $(DATASET_ROOT)/../margince-demo-database)
 # DEV_SLUG stack on another port.
 SEED_DSN ?= postgres://margince_owner:dev@localhost:15432/margince
 
+# The dev stack's MinIO port. Same default scripts/dev.sh uses. seed-demo needs
+# it to upload the company logos: without a blobstore the seeder skips them and
+# every company renders as a placeholder initial.
+MINIO_PORT ?= 29000
+
 .PHONY: help install ai-routing-local dev-fresh check check-backend check-q check-go check-gates check-fe build test test-v test-cover test-integration e2e-siteread e2e-ai e2e-ai-report ai-probe test-db-up test-it test-integration-serial bench-perf bench-record bench-capture perfdoc lint arch-lint vet gen gen-workflow mcp-apps-vocab gen-types gen-types-check drift composition check-composition test-extensions db-up db-init db-wait migrate migrate-up migrate-down run psql redis-cli tidy dev dev-stop dev-logs clean vuln tools tools-go infra-up infra-down infra-logs infra-reset seed-dev seed-dev-db seed-demo verify-demo seed-reset verify-boot frontend-check frontend-e2e bench-mobile perfdoc e2e-company fe-install fe-typecheck fe-typecheck-composed fe-lint fe-build fe-preview fe-format fe-test fe-test-ext fe-ds-gates fe-drift fe-unit fe-quality fe-bundle fe-storybook ds-purity font-lock icon-lint ds-spacing space-tokens native-controls ext-imports fitness-jurisdiction storybook fe-uat craft-static craft-test craft-residue check-craft-doc test-golangci-guard test-scheduled-report secret-scan test-secret-scan check-image-pins check-host-ports ci-doc-parity make-target-parity check-ext-migrations contract-breaking-check migration-versions test-lanes env-reads gofmt lint-modules go-file-length rls-store-path no-jurisdiction pkg-freeze hooks sbom sbom-normalize sbom-supplement sbom-parity sbom-validate sbom-sign sbom-check
 
 # Bare `make` lists every command instead of running the first target.
@@ -252,6 +257,10 @@ seed-demo:
 	  echo "no config/margince-admin-password — run make dev first" >&2; exit 1; }
 	MARGINCE_SEED_PASSWORD="$$(cat config/margince-admin-password)" \
 	MARGINCE_SEED_DSN="$(SEED_DSN)" \
+	MARGINCE_BLOBSTORE_ENDPOINT="localhost:$(MINIO_PORT)" \
+	MARGINCE_BLOBSTORE_ACCESS_KEY=minioadmin \
+	MARGINCE_BLOBSTORE_SECRET_KEY=minioadmin \
+	MARGINCE_BLOBSTORE_BUCKET=margince-dev \
 	$(MAKE) -C backend seed-demo DATASET="$(DATASET)" SEED_ARGS="$(SEED_ARGS)"
 
 ## verify-demo — re-run the demo seeder's verify pass against a running stack,

--- a/backend/tools/seed-demo/generated.go
+++ b/backend/tools/seed-demo/generated.go
@@ -198,15 +198,9 @@ func seedGeneratedLeads(c *client, refs pipelineRefs, plan map[string]profile, m
 				"source_id":     sourceID,
 				"status":        leadCreateStatus(p.LeadState),
 				"full_name":     first + " " + last,
-				// example.com, never the company's own domain. This lead is
-				// invented, but shopify.com accepts mail whether or not a
-				// Jonas Sommer works there — an invented address at a real
-				// domain is still deliverable, and the dataset's defang pass
-				// cannot reach an address this tool builds at runtime. RFC
-				// 2606 reserves example.com, so nothing here can be sent.
-				"email":        strings.ToLower(first+"."+last) + "@example.com",
-				"company_name": refs.orgNameByID[orgID],
-				"title":        title,
+				"email":         generatedLeadEmail(first, last, domain),
+				"company_name":  refs.orgNameByID[orgID],
+				"title":         title,
 			}
 			if owner, ok := refs.usersByRef[refs.ownerRefByDomain[domain]]; ok {
 				body["owner_id"] = owner
@@ -284,6 +278,23 @@ func generatedLeadName(domain string) (string, string) {
 	first := leadFirstNames[hashIndex("leadfirst:"+domain, len(leadFirstNames))]
 	last := leadLastNames[hashIndex("leadlast:"+domain, len(leadLastNames))]
 	return first, last
+}
+
+// generatedLeadEmail keeps the company in the LOCAL part, which is what makes
+// the address unique.
+//
+// The obvious form, firstname.lastname@example.com, silently costs leads. The
+// names come from an 8x8 pool, 40 domains hash into it with collisions, and
+// the product rejects a second lead at an address it already holds — so a run
+// created 16 leads instead of 46 and seeded no disqualified one at all, which
+// the coverage matrix then failed on. Before the addresses moved to
+// example.com the company's own domain had been supplying the uniqueness.
+//
+// The company slug is stripped of dots so the local part stays one label:
+// jonas.sommer.shopify@example.com, not jonas.sommer.shopify.com@example.com.
+func generatedLeadEmail(first, last, domain string) string {
+	slug := strings.NewReplacer(".", "", "-", "").Replace(domain)
+	return strings.ToLower(first+"."+last+"."+slug) + "@example.com"
 }
 
 func generatedLeadTitle(domain string) string {


### PR DESCRIPTION
Two bugs a fresh `tools/seed.sh --fresh` surfaced.

## 30 of 46 leads vanished

Moving generated leads to `example.com` (#1555) removed the only thing making
their addresses unique. The names come from an 8×8 pool, 40 domains hash into
it with collisions, and the product refuses a second lead at an address it
already holds.

So the run created **16 leads instead of 46**, seeded no disqualified one at
all, and failed the coverage matrix:

```
verify: 1 rule(s) broken
  lead=disqualified: 0 of 2 — archived, and only visible with
  include_archived — a state easy to seed wrong
```

The company now goes in the **local part**, which is where the uniqueness has
to live once every address shares one domain:
`jonas.sommer.shopify@example.com`.

## `make seed-demo` uploaded no logos

It passes the admin password and the owner DSN but never the blobstore
settings, so the phase reported `skipped — no blobstore configured` and every
company kept a placeholder initial. #1545 shipped the upload; nothing ever ran
it through the documented path.

The target now passes the same four `MARGINCE_BLOBSTORE_*` values
`scripts/dev.sh` uses, with `MINIO_PORT` defaulting to 29000 as it does there.

## Verification

Against a stack left in exactly the broken state:

```
lead new: 28   working: 12   promoted: 4   disqualified: 2     (46 total)
logos:    149 uploaded
verify:   OK — every seeded record is owned, employed, linked and staged
```

`make craft-static` and `make check-backend` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes demo seeding by preventing lead email collisions and enabling logo uploads. Previously, generated leads used firstname.lastname@example.com and many collided; now emails include the company slug in the local part (e.g., jonas.sommer.shopify@example.com). Previously, `make seed-demo` skipped logos due to missing blobstore config; now it passes blobstore env and uploads logos, replacing placeholder initials.

- Restores expected lead coverage (disqualified leads seeded) and logo rendering for demo companies.

**Review notes**
- `backend/tools/seed-demo`: new `generatedLeadEmail` appends a domain-derived slug to the local part and strips dots/hyphens; still targets `example.com`.
- `Makefile`: adds `MARGINCE_BLOBSTORE_*` env vars and `MINIO_PORT` (default 29000) to align with `scripts/dev.sh`.

**Rollout**
- No migration required.
- If MinIO runs on a non-default port, set `MINIO_PORT` before `make seed-demo`.

<sup>Written for commit cca9bcfe4c10271fc1da6b201e0065781a885bd0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1558?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

