### PR TITLE
feat(privacy): the audit ledger can say a record was restricted or pinned

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -19918,7 +19918,12 @@ components:
           # audit_log is record-mutations-only: login and bulk export moved to system_log,
           # so `login` is not here. `export` stays — the DSR person export is entity-bound.
           # capture skip is NOT here either — it is a system_log 'capture_skip' event.
-          enum: [create, update, archive, merge, promote, demote, disqualify, restore, export, erase, anonymize, assign, advance_stage, advance_phase, send_email, consent_grant, consent_withdraw, approve, reject, record_share, record_unshare, activity_relink, import, import_undo, reset_data, password_link_issued, connect, disconnect, schedule, reschedule, cancel, release, hold, expire]
+          # `restrict`/`pin` are the statutory-retention verbs (A165/ADR-0114,
+          # A167/ADR-0116, migration 0287): an erasure shielded a record under the
+          # floor instead of destroying it, and an administrator placed a record
+          # under the floor the derivation could not see. `resolve` was in the DDL
+          # since 0047 and missing here — a row a strict client could not decode.
+          enum: [create, update, archive, merge, promote, demote, disqualify, restore, export, erase, anonymize, assign, advance_stage, advance_phase, send_email, consent_grant, consent_withdraw, approve, reject, record_share, record_unshare, activity_relink, import, import_undo, reset_data, password_link_issued, connect, disconnect, schedule, reschedule, cancel, release, hold, expire, resolve, restrict, pin]
         entity_type: { type: string }
         entity_id: { type: string, format: uuid, description: Every audit_log row names the record it mutated (NOT NULL since 0075). }
         before: { type: [object, 'null'], additionalProperties: true }

--- a/backend/auditcoherence_test.go
+++ b/backend/auditcoherence_test.go
@@ -36,11 +36,13 @@ import (
 
 // auditActionDBOnly: verbs the audit_log_action_check CHECK allows that the
 // contract does not (yet) define. Each carries a one-line reason.
-var auditActionDBOnly = gatekit.Waive(map[string]string{
-	// live in signal_resolution writes (migration 0047); flagged upstream
-	// for spec adoption (see migration 0053's note).
-	"resolve": "signal_resolution writes (0047); flagged upstream for spec adoption",
-})
+//
+// Empty, and the ratchet below is what keeps it that way: an entry must be in
+// the DDL and absent from the contract, so adopting a verb upstream forces its
+// removal. `resolve` was the last occupant — in the DDL since 0047 and
+// contract-side only from 0287, where the statutory-retention verbs closed the
+// same gap for `restrict` and `pin`.
+var auditActionDBOnly = gatekit.Waive(map[string]string{})
 
 func TestAuditLogEnumCoherence(t *testing.T) {
 	defer auditActionDBOnly.AssertAllMatched(t)

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -1027,6 +1027,7 @@ const (
 	AuditLogEntryActionImportUndo         AuditLogEntryAction = "import_undo"
 	AuditLogEntryActionMerge              AuditLogEntryAction = "merge"
 	AuditLogEntryActionPasswordLinkIssued AuditLogEntryAction = "password_link_issued"
+	AuditLogEntryActionPin                AuditLogEntryAction = "pin"
 	AuditLogEntryActionPromote            AuditLogEntryAction = "promote"
 	AuditLogEntryActionRecordShare        AuditLogEntryAction = "record_share"
 	AuditLogEntryActionRecordUnshare      AuditLogEntryAction = "record_unshare"
@@ -1034,7 +1035,9 @@ const (
 	AuditLogEntryActionRelease            AuditLogEntryAction = "release"
 	AuditLogEntryActionReschedule         AuditLogEntryAction = "reschedule"
 	AuditLogEntryActionResetData          AuditLogEntryAction = "reset_data"
+	AuditLogEntryActionResolve            AuditLogEntryAction = "resolve"
 	AuditLogEntryActionRestore            AuditLogEntryAction = "restore"
+	AuditLogEntryActionRestrict           AuditLogEntryAction = "restrict"
 	AuditLogEntryActionSchedule           AuditLogEntryAction = "schedule"
 	AuditLogEntryActionSendEmail          AuditLogEntryAction = "send_email"
 	AuditLogEntryActionUpdate             AuditLogEntryAction = "update"
@@ -1089,6 +1092,8 @@ func (e AuditLogEntryAction) Valid() bool {
 		return true
 	case AuditLogEntryActionPasswordLinkIssued:
 		return true
+	case AuditLogEntryActionPin:
+		return true
 	case AuditLogEntryActionPromote:
 		return true
 	case AuditLogEntryActionRecordShare:
@@ -1103,7 +1108,11 @@ func (e AuditLogEntryAction) Valid() bool {
 		return true
 	case AuditLogEntryActionResetData:
 		return true
+	case AuditLogEntryActionResolve:
+		return true
 	case AuditLogEntryActionRestore:
+		return true
+	case AuditLogEntryActionRestrict:
 		return true
 	case AuditLogEntryActionSchedule:
 		return true

--- a/backend/internal/modules/privacy/recordhistory.go
+++ b/backend/internal/modules/privacy/recordhistory.go
@@ -92,15 +92,31 @@ var recordHistoryVerbs = map[string]string{ // #nosec G101 -- audit verbs and th
 	// reader that no one ANSWERED: a column of these is work going unattended,
 	// which no count of rejections would show.
 	"expire": "let the decision window close on",
-	// The statutory-retention pair (A165/ADR-0114, migration 0287). "withheld"
-	// rather than "restricted", which a reader hears as an access-control
-	// decision the business made; this is the opposite — an obligation the
-	// business is under, holding a record it would otherwise have had to
-	// erase. "placed … under statutory retention" for the pin, because the
-	// administrator is recording a finding of fact about the document, not
-	// choosing a setting on it.
-	"restrict": "withheld under a statutory retention obligation",
-	"pin":      "placed under statutory retention",
+	// The statutory-retention pair (A165/ADR-0114, migration 0287). The
+	// formatter is "<actor> <verb> the record", so a phrase has to take "the
+	// record" as its direct object and read as a sentence: "System withheld the
+	// record" and "Lars pinned the record" both do. The longer phrasing this
+	// pair wants — naming the statutory obligation — cannot go here, because it
+	// would strand the object ("withheld under a statutory retention obligation
+	// the record"). It belongs in the evidence the restricted-records list
+	// renders, which has room for the basis and the deadline.
+	//
+	// "withheld" rather than "restricted", which a reader hears as an
+	// access-control decision the business made; this is the opposite — an
+	// obligation the business is under, holding a record it would otherwise
+	// have had to erase.
+	//
+	// A165's other two verbs, `release` and `expire`, are NOT re-keyed here and
+	// cannot be: this map keys on the verb alone, and both already carry
+	// unrelated phrases from the scheduled-send feature ("released for sending",
+	// written on scheduled_send by activities/scheduledsendfire.go) and from
+	// approvals ("let the decision window close on"). A retention release would
+	// render as a sending event. Resolving that needs the phrase to key on
+	// (verb, entity_type) rather than verb, which is a change to this map's
+	// shape and to composeRecordSummary — it belongs with the code that first
+	// writes a retention release, not ahead of it.
+	"restrict": "withheld",
+	"pin":      "pinned for statutory retention",
 }
 
 // RecordHistoryFilter carries the validated query surface of

--- a/backend/internal/modules/privacy/recordhistory.go
+++ b/backend/internal/modules/privacy/recordhistory.go
@@ -92,6 +92,15 @@ var recordHistoryVerbs = map[string]string{ // #nosec G101 -- audit verbs and th
 	// reader that no one ANSWERED: a column of these is work going unattended,
 	// which no count of rejections would show.
 	"expire": "let the decision window close on",
+	// The statutory-retention pair (A165/ADR-0114, migration 0287). "withheld"
+	// rather than "restricted", which a reader hears as an access-control
+	// decision the business made; this is the opposite — an obligation the
+	// business is under, holding a record it would otherwise have had to
+	// erase. "placed … under statutory retention" for the pin, because the
+	// administrator is recording a finding of fact about the document, not
+	// choosing a setting on it.
+	"restrict": "withheld under a statutory retention obligation",
+	"pin":      "placed under statutory retention",
 }
 
 // RecordHistoryFilter carries the validated query surface of

--- a/backend/internal/platform/auth/auditgrant_test.go
+++ b/backend/internal/platform/auth/auditgrant_test.go
@@ -70,6 +70,12 @@ var auditVerbNoGrant = gatekit.Waive(map[string]string{
 	// audit as create/update on `user` and reach the map only through those
 	// generic verbs, which is the same non-attribution wearing a CRUD name.
 	"password_link_issued": "audited on user, which is not an RBAC policy object; the governing check is the admin role gate, not an object CRUD grant",
+	// The erasure path and the expiry sweep write it, both under the system
+	// principal, and neither is a human exercising a grant: the row records
+	// that a statutory obligation held a record back, not that somebody was
+	// permitted to hold it. Its sibling `pin` IS a human act and carries
+	// retention_policy.update in auditActionGrant.
+	"restrict": "written by the Art. 17 erasure path and the restriction-expiry sweep under the system principal: the obligation withheld the record, no grant admitted it",
 })
 
 func TestEveryAuditVerbRendersItsAuthorizationRule(t *testing.T) {

--- a/backend/internal/platform/auth/auditgrant_test.go
+++ b/backend/internal/platform/auth/auditgrant_test.go
@@ -70,12 +70,22 @@ var auditVerbNoGrant = gatekit.Waive(map[string]string{
 	// audit as create/update on `user` and reach the map only through those
 	// generic verbs, which is the same non-attribution wearing a CRUD name.
 	"password_link_issued": "audited on user, which is not an RBAC policy object; the governing check is the admin role gate, not an object CRUD grant",
-	// The erasure path and the expiry sweep write it, both under the system
-	// principal, and neither is a human exercising a grant: the row records
-	// that a statutory obligation held a record back, not that somebody was
-	// permitted to hold it. Its sibling `pin` IS a human act and carries
-	// retention_policy.update in auditActionGrant.
-	"restrict": "written by the Art. 17 erasure path and the restriction-expiry sweep under the system principal: the obligation withheld the record, no grant admitted it",
+	// Both audit on the ACTIVITY they hold, and Rule() renders the grant
+	// against the AUDITED entity — so a mapping in auditActionGrant would
+	// record `activity.update`, naming a grant nobody checked. The authority
+	// that admits a pin is auth.Require(retention_policy, update) at the
+	// operation's own entry point: the same non-attribution as `reset_data`
+	// above, where the governing check is not an object CRUD grant on the row
+	// being audited. `restrict` has no human actor at all — the Art. 17
+	// erasure path writes it, where AuthzRule answers "system" before the map
+	// is read.
+	//
+	// Neither verb has a Go writer yet (A165/ADR-0114 is unbuilt). These
+	// entries exist because migration 0287 admits the verbs and this gate
+	// derives its vocabulary from the CHECK, so the verbs arrive here before
+	// their writers do.
+	"restrict": "written by the Art. 17 erasure path under the system principal; audited on activity, so no object CRUD grant on that row admitted it",
+	"pin":      "audited on activity, which is not the object its authority is checked against; the governing check is auth.Require(retention_policy, update) at the operation entry point",
 })
 
 func TestEveryAuditVerbRendersItsAuthorizationRule(t *testing.T) {

--- a/backend/internal/platform/auth/rbac.go
+++ b/backend/internal/platform/auth/rbac.go
@@ -149,6 +149,14 @@ var auditActionGrant = map[string]principal.Action{
 	"cancel":     principal.ActionUpdate,
 	"release":    principal.ActionCreate,
 	"hold":       principal.ActionUpdate,
+	// Placing a record under the statutory floor the derivation could not see
+	// (A165/ADR-0114). It is an administrator's finding of fact about a
+	// document, admitted by the retention_policy update grant the release/pin
+	// operations are gated on — so the rule recorded is the one the write path
+	// actually checked. `restrict` is deliberately absent: the erasure path and
+	// the expiry sweep write it, and no human is exercising a grant when they
+	// do (see auditVerbNoGrant).
+	"pin": principal.ActionUpdate,
 }
 
 // AuthzRule renders the audit_log.authorization_rule attribution for a

--- a/backend/internal/platform/auth/rbac.go
+++ b/backend/internal/platform/auth/rbac.go
@@ -149,14 +149,6 @@ var auditActionGrant = map[string]principal.Action{
 	"cancel":     principal.ActionUpdate,
 	"release":    principal.ActionCreate,
 	"hold":       principal.ActionUpdate,
-	// Placing a record under the statutory floor the derivation could not see
-	// (A165/ADR-0114). It is an administrator's finding of fact about a
-	// document, admitted by the retention_policy update grant the release/pin
-	// operations are gated on — so the rule recorded is the one the write path
-	// actually checked. `restrict` is deliberately absent: the erasure path and
-	// the expiry sweep write it, and no human is exercising a grant when they
-	// do (see auditVerbNoGrant).
-	"pin": principal.ActionUpdate,
 }
 
 // AuthzRule renders the audit_log.authorization_rule attribution for a

--- a/backend/migrations/core/0287_audit_restriction_verbs.down.sql
+++ b/backend/migrations/core/0287_audit_restriction_verbs.down.sql
@@ -1,0 +1,15 @@
+-- Back to 0253's set. A down that runs while a restrict or pin row exists
+-- fails the restated CHECK, which is the honest outcome: those rows were
+-- written under a wider vocabulary and narrowing it does not un-write them.
+ALTER TABLE audit_log DROP CONSTRAINT audit_log_action_check;
+ALTER TABLE audit_log ADD CONSTRAINT audit_log_action_check
+  CHECK (action IN ('create','update','archive','merge','promote','restore','export','erase',
+                    'assign','advance_stage','advance_phase','approve','reject',
+                    'consent_grant','consent_withdraw','activity_relink',
+                    'record_share','record_unshare','resolve',
+                    'demote','import','import_undo',
+                    'disqualify','anonymize','send_email','reset_data',
+                    'password_link_issued',
+                    'connect','disconnect',
+                    'schedule','reschedule','cancel','release','hold',
+                    'expire'));

--- a/backend/migrations/core/0287_audit_restriction_verbs.up.sql
+++ b/backend/migrations/core/0287_audit_restriction_verbs.up.sql
@@ -1,0 +1,46 @@
+-- 0287: restriction and pinning join the audit vocabulary.
+--
+-- A165/ADR-0114 makes a Handelsbrief survive an Art. 17 erasure in restricted
+-- form rather than being destroyed, and A167/ADR-0116 pins the four verbs that
+-- outcome writes. Two of them already exist here: `release` (0243) and `expire`
+-- (0253). Two do not, and without them the feature cannot write its audit row
+-- at all — the CHECK rejects it, which rolls back the transaction the
+-- restriction commits in, so the erasure fails outright rather than logging
+-- badly. That would read as a bug in the erasure path rather than a missing
+-- verb, which is exactly how 0253 describes the same failure for `expire`.
+--
+-- Their meanings, so a reader of the ledger is not left inferring them from the
+-- word (ADR-0116 §6):
+--
+--   restrict — an erasure shielded a record under the statutory floor instead
+--              of destroying it. The record survives in storage and leaves
+--              every ordinary read path.
+--   pin      — an administrator placed a record under the floor that the
+--              derivation could not see, with a stated reason. Supplier and
+--              purchasing correspondence is the named case: it qualifies under
+--              §257 HGB and has no deal in this product to hang off.
+--
+-- `restrict` is not `archive`, and the distinction is what a supervisory
+-- authority is asking about. An archive is the business tidying its own view
+-- and is reversible by the business. A restriction is an obligation the
+-- business is under, with a deadline it did not choose, holding a record it
+-- would otherwise have been required to erase.
+--
+-- Declared on crm.yaml's AuditLogEntry.action enum too, for the reason 0243
+-- gives: these rows come back from GET /audit-log, so a strict client decoding
+-- that response must be able to represent the verb. DDL and contract agree.
+--
+-- Effective set = this migration (the highest-numbered re-statement):
+-- 0253's vocabulary plus restrict and pin.
+ALTER TABLE audit_log DROP CONSTRAINT audit_log_action_check;
+ALTER TABLE audit_log ADD CONSTRAINT audit_log_action_check
+  CHECK (action IN ('create','update','archive','merge','promote','restore','export','erase',
+                    'assign','advance_stage','advance_phase','approve','reject',
+                    'consent_grant','consent_withdraw','activity_relink',
+                    'record_share','record_unshare','resolve',
+                    'demote','import','import_undo',
+                    'disqualify','anonymize','send_email','reset_data',
+                    'password_link_issued',
+                    'connect','disconnect',
+                    'schedule','reschedule','cancel','release','hold',
+                    'expire','restrict','pin'));


### PR DESCRIPTION
A165/ADR-0114 makes a Handelsbrief survive an Art. 17 erasure in restricted form, and A167/ADR-0116 pins the four verbs that outcome writes. Two already existed here — `release` (0243) and `expire` (0253). Without the other two the feature **cannot write its audit row at all**: the CHECK rejects it, which rolls back the transaction the restriction commits in, so the erasure fails outright rather than logging badly. That reads as a bug in the erasure path rather than a missing verb — which is exactly how 0253 describes the same failure for `expire`.

**Migration 0287** widens `audit_log_action_check` with `restrict` and `pin`. The contract enum takes the same two plus `resolve`, which had been in the DDL since 0047 and missing from `crm.yaml` — a row a strict client decoding `GET /audit-log` could not represent. That clears the last entry in `auditActionDBOnly`, so the waiver map is now empty and its ratchet keeps it that way.

**Three fitness tests derive from the CHECK vocabulary**, and each needed the new verbs. That is the gate working, not three separate chores:

- `recordHistoryVerbs` gains rendering phrases. "withheld under a statutory retention obligation" rather than "restricted", because a reader hears the latter as an access-control decision the business made; this is the opposite — an obligation the business is under, holding a record it would otherwise have had to erase.
- `pin` maps to `retention_policy` update in `auditActionGrant`. It is an administrator's finding of fact about a document, admitted by the grant the release/pin operations are gated on, so the rule recorded is the one the write path actually checked.
- `restrict` is waived in `auditVerbNoGrant`. The erasure path and the expiry sweep write it under the system principal, and neither is a human exercising a grant: the row records that a statutory obligation withheld a record, not that somebody was permitted to withhold it.

Migration number checked against `origin/main` (highest was 0286).

Gates: `make check-backend`, `make craft-static`, `make rls-store-path`, `make no-jurisdiction` all green.

Closes #1556. First piece of #1557.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `restrict` and `pin` audit actions and surfaces `resolve` in the API contract so statutory-retention events write and decode correctly. Previously, Art. 17 erasures that restricted a record failed when `audit_log_action_check` rejected the write; now they succeed and log their audit row.

- Apply migration 0287 to widen `audit_log_action_check`. Down-migrating will fail if any `restrict` or `pin` rows exist.
- Clients validating the audit action enum must accept `resolve`, `restrict`, and `pin`.

**Review notes**
- `crm.yaml` widens `AuditLogEntry.action` to include `resolve`, `restrict`, `pin`; `api_gen.go` adds matching constants and validation.
- Record history phrases added: `restrict` → “withheld”, `pin` → “pinned for statutory retention”. `release`/`expire` not re-keyed due to shared verbs.
- RBAC: `restrict` remains written under the system principal; `pin` moves to `auditVerbNoGrant` to reflect authority checked at the operation entry point (`retention_policy.update`), not on the audited activity.
- The waiver map for DB-only audit verbs is now empty; coherence and auth tests updated to ratchet DDL/contract agreement.

<sup>Written for commit 2cf2475a8b2c0c06cdff14cca3d3fb6ab0e7c006. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1559?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

