### PR TITLE
chore(renovate): a dependency PR stops force-pushing itself on every merge to main

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,10 +7,14 @@
   "commitBody": "Signed-off-by: renovate[bot] <29139614+renovate[bot]@users.noreply.github.com>",
   "postUpdateOptions": ["gomodTidy"],
   "prConcurrentLimit": 5,
-  "description": "Renovate performs the merge itself rather than handing the PR to GitHub's native auto-merge. The AI-reviewer ruleset requires a CodeRabbit status, and CodeRabbit skips bot-authored PRs SILENTLY — it posts no check at all, so there is nothing on the commit for the ruleset to be satisfied by — which is why the ruleset grants this app a bypass. Only the synchronous merge endpoint, the one Renovate calls on its own runs, consults that grant: GitHub's deferred auto-merge evaluator never re-reads bypass_actors, so under platformAutomerge a PR whose sole unsatisfied check is the bypassed one stays open forever however green it is. automergeSchedule admits a merge at any time, so a merge follows the run that first finds the branch green, instead of waiting for the nightly window that governs PR CREATION.",
+  "description": [
+    "Renovate performs the merge itself rather than handing the PR to GitHub's native auto-merge. The AI-reviewer ruleset requires a CodeRabbit status, and CodeRabbit skips bot-authored PRs SILENTLY — it posts no check at all, so there is nothing on the commit for the ruleset to be satisfied by — which is why the ruleset grants this app a bypass. Only the synchronous merge endpoint, the one Renovate calls on its own runs, consults that grant: GitHub's deferred auto-merge evaluator never re-reads bypass_actors, so under platformAutomerge a PR whose sole unsatisfied check is the bypassed one stays open forever however green it is. automergeSchedule admits a merge at any time, so a merge follows the run that first finds the branch green, instead of waiting for the nightly window that governs PR CREATION.",
+    "rebaseWhen is pinned to `conflicted` because the default `auto` resolves to `behind-base-branch` whenever automerge is on, and main takes ~70 commits a day: every open Renovate branch was force-pushed on roughly every merge, each force-push starting a full CI run that the next one cancelled. In one 5h42m sample, 80 of 200 CI runs were Renovate branches and 64 of those 80 ended `cancelled` — the fleet crowded out human PRs in the concurrency pool AND destroyed its own signal, since a cancelled run is indistinguishable from a red one. Rebasing-when-behind bought nothing to offset that: the main-required-status-checks ruleset sets strict_required_status_checks_policy false, so a behind-but-green branch is mergeable and Renovate merges it. The residual exposure — a dependency merged having been tested against a slightly older main — is the same one every human PR here already carries."
+  ],
   "platformAutomerge": false,
   "automerge": true,
   "automergeSchedule": ["at any time"],
+  "rebaseWhen": "conflicted",
   "minimumReleaseAge": "7 days",
   "internalChecksFilter": "strict",
   "lockFileMaintenance": {
@@ -19,6 +23,12 @@
     "schedule": ["after 2am and before 6am"]
   },
   "packageRules": [
+    {
+      "description": "A major needs a human to read the changelog, so it can never satisfy automerge on its own and its branch would otherwise sit open indefinitely — the one shape that pays the rebase cost forever while having no path to merge. `conflicted` above still rebases a lockfile major on every main merge that touches the lockfile (24 of the last 100 did), so majors are pinned to `never`: the branch goes stale, which is the correct state for a change waiting on a person. Whoever picks it up rebases it by ticking the PR's own checkbox.",
+      "matchUpdateTypes": ["major"],
+      "automerge": false,
+      "rebaseWhen": "never"
+    },
     {
       "matchManagers": ["gomod"],
       "matchUpdateTypes": ["patch", "minor"],


### PR DESCRIPTION
## The problem, measured

`renovate.json` left `rebaseWhen` at its default `auto`. Renovate resolves `auto` to **`behind-base-branch`** whenever `automerge` is on — which it is here. `main` takes ~70 commits a day, so every open Renovate branch was force-pushed on roughly every merge, and each force-push started a full CI run that the next force-push cancelled.

A 5h42m sample of `ci.yml` runs:

| | |
|---|---|
| Runs on `renovate/*` branches | **80 of 200 (40%)** |
| …ended `cancelled` | **64** |
| …failed | 13 |
| …succeeded | **1** |
| Commits on `main` in 24h | **73** |

[#1389](https://github.com/gradionhq/margince-poc-v1/pull/1389) (js-yaml v5, open since 08-15) alone accounted for 40 of those runs, force-pushing a new SHA every 3–20 minutes.

Two costs. Renovate crowded human PRs out of the concurrency pool, and it destroyed its own signal: a `cancelled` run is indistinguishable from a red one on any dashboard, and `gh pr checks` reports it as a failure.

## The change

**`"rebaseWhen": "conflicted"`** repo-wide. This buys back the runs without touching mergeability: `main-required-status-checks` sets `strict_required_status_checks_policy: false`, so a behind-but-green branch is already mergeable and Renovate merges it. Pinning `conflicted` changes *when* a branch is rebased, not *whether* it can land.

The residual exposure is stated plainly in the config: a dependency merges having been tested against a slightly older `main`. That is the same exposure every human PR in this repo already carries, for the same reason.

**`"rebaseWhen": "never"` + `"automerge": false` for majors.** A major waits on a human reading a changelog, so it can never satisfy automerge on its own and its branch would otherwise rebase forever with no path to merge — the one shape that pays the cost indefinitely. `conflicted` alone would not spare it either: 24 of the last 100 commits to `main` touched `frontend/pnpm-lock.yaml`, so a lockfile major genuinely conflicts several times a day. A stale branch is the honest state for a change waiting on a person; whoever picks it up rebases it from the PR's own checkbox.

## Verification

`renovate-config-validator` passes on the result.

## Deliberately not in this change

`"dependencyDashboardApproval": true` on majors would stop them opening a PR at all until ticked. It is the stronger lever, but it would also gate a security-driven major, so it wants a `"dependencyDashboardApproval": false` inside `vulnerabilityAlerts` alongside it and a decision about that trade. Left for a human to call.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops Renovate dependency PRs from force-pushing on every merge to `main` by pinning `rebaseWhen` to `conflicted` and disabling automerge and rebases for majors. Previously `rebaseWhen: auto` (with automerge on) rebased when behind `main`, spamming CI and cancelling runs; now only actual conflicts trigger a rebase, and majors wait for a human.

**Reviewer notes**
- Set `"rebaseWhen": "conflicted"` globally; added a package rule for majors with `"automerge": false` and `"rebaseWhen": "never"`.
- Green-but-behind branches remain mergeable because required checks are non-strict; expect fewer `renovate/*` CI runs and fewer cancelled checks.
- Tradeoff: a dependency may merge tested against a slightly older `main`, matching the exposure of human PRs.
- No application code changes; only `renovate.json`. Verified with `renovate-config-validator`.

<sup>Written for commit 589191a3133d40dbc5fdc081223b6fa1dbe459dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1560?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency update behavior to require manual handling for major updates.
  * Clarified the conditions for automatic merging and conflict-only rebasing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->