### PR TITLE
feat(config): a misspelled variable says so instead of doing nothing

### DIFF
--- a/backend/cmd/api/config.go
+++ b/backend/cmd/api/config.go
@@ -43,6 +43,12 @@ type apiConfig struct {
 	webhookKey          string
 	metricsToken        string
 	oauthAccessTokenTTL time.Duration
+	// unknownVars are the MARGINCE_* variables found in the environment that
+	// this role does not read. Computed during parsing, where the surface is
+	// assembled, and REPORTED once the logger exists — an operator has to see
+	// it, and stderr before the log handler is built is a different stream in a
+	// different format from everything else they are reading.
+	unknownVars []string
 }
 
 // apiFlagSet registers this role's flags and their environment bindings, and
@@ -101,10 +107,13 @@ func parseAPIFlags(args []string) (apiConfig, error) {
 	if err != nil {
 		return apiConfig{}, err
 	}
-	// A surface that cannot be described honestly is a boot error, not a
-	// runtime surprise: a duplicate name or a required item carrying a default
-	// would make a generated reference lie about this installation.
-	if _, err := apiConfigItems(fs, env); err != nil {
+	// Assembled here for two reasons. A surface that cannot be described
+	// honestly is a boot error rather than a runtime surprise — a duplicate name
+	// or a secret carrying a default would make a generated reference lie about
+	// this installation — and the registry is also what tells this role which
+	// namespaced variables it does NOT read, for the report below.
+	registry, err := apiConfigItems(fs, env)
+	if err != nil {
 		return apiConfig{}, err
 	}
 	if err := fs.Parse(args); err != nil {
@@ -115,6 +124,9 @@ func parseAPIFlags(args []string) (apiConfig, error) {
 	// in its usage output, and these values are DSNs, signing keys, OAuth client
 	// secrets and bearer tokens — see internal/platform/cliflags.
 	env.Apply(fs, config.FromOS)
+	// After Apply, so the report describes the environment the role actually
+	// consulted.
+	cfg.unknownVars = registry.Undeclared(config.Environ())
 	if cfg.dsn == "" {
 		return apiConfig{}, errors.New("api: --dsn or MARGINCE_DSN required")
 	}

--- a/backend/cmd/api/configitems.go
+++ b/backend/cmd/api/configitems.go
@@ -54,7 +54,7 @@ var apiPublic = map[string]bool{
 
 // apiConfigItems is this role's whole configurable surface: its own flags, plus
 // the packages it wires that read the environment on their own account.
-func apiConfigItems(fs *flag.FlagSet, env *cliflags.Env) ([]config.Item, error) {
+func apiConfigItems(fs *flag.FlagSet, env *cliflags.Env) (*config.Registry, error) {
 	registry, err := config.NewRegistry(
 		env.Items(fs, config.RoleAPI, apiPublic),
 		blobstore.ConfigItems(),
@@ -66,7 +66,7 @@ func apiConfigItems(fs *flag.FlagSet, env *cliflags.Env) ([]config.Item, error) 
 	if err != nil {
 		return nil, err
 	}
-	return registry.Items(), nil
+	return registry, nil
 }
 
 // apiUnflaggedItems are the variables this role reads with no flag behind them.

--- a/backend/cmd/api/configitems_test.go
+++ b/backend/cmd/api/configitems_test.go
@@ -14,6 +14,7 @@ package main
 
 import (
 	"flag"
+	"slices"
 	"testing"
 
 	"github.com/gradionhq/margince/backend/internal/platform/cliflags"
@@ -28,11 +29,11 @@ func apiSurface(t *testing.T) (*flag.FlagSet, *cliflags.Env, []config.Item) {
 	if err != nil {
 		t.Fatalf("building the api flag set: %v", err)
 	}
-	items, err := apiConfigItems(fs, env)
+	registry, err := apiConfigItems(fs, env)
 	if err != nil {
 		t.Fatalf("assembling the api registry: %v", err)
 	}
-	return fs, env, items
+	return fs, env, registry.Items()
 }
 
 func TestEveryFlagBoundVariableIsDeclared(t *testing.T) {
@@ -107,5 +108,25 @@ func TestTheCredentialsThisRoleReadsAreMarkedSecret(t *testing.T) {
 		if secret[name] {
 			t.Errorf("%s is marked Secret but authenticates nothing; hiding it only makes a boot harder to debug", name)
 		}
+	}
+}
+
+// The api's half of the wiring check; see the worker's copy for why the rule
+// itself is proven in platform/config rather than here.
+func TestAMisspelledVariableReachesTheBootReport(t *testing.T) {
+	// Assembled rather than written whole: it is a MISSPELLING, and the
+	// tree-wide documentation gate reads a quoted MARGINCE_* literal as a real
+	// variable somebody must document.
+	const misspelled = "MARGINCE_" + "REDDIS"
+	t.Setenv(misspelled, "localhost:6379")
+	cfg, err := parseAPIFlags([]string{"--dsn", "postgres://user@localhost:5432/db"})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if !slices.Contains(cfg.unknownVars, misspelled) {
+		t.Errorf("unknownVars = %v; the misspelling never reached the boot report", cfg.unknownVars)
+	}
+	if slices.Contains(cfg.unknownVars, "MARGINCE_DSN") {
+		t.Error("a variable this role reads was reported as unread")
 	}
 }

--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -76,6 +76,7 @@ func run(ctx context.Context, args []string, stdout io.Writer) error {
 		return err
 	}
 	logger := slog.New(httpserver.WithCorrelation(handler))
+	config.WarnUndeclared(logger, cfg.unknownVars)
 
 	pool, err := database.NewPool(ctx, cfg.dsn)
 	if err != nil {

--- a/backend/cmd/worker/config.go
+++ b/backend/cmd/worker/config.go
@@ -63,6 +63,10 @@ type workerConfig struct {
 	logLevel             string
 	logFormat            string
 	observeAddr          string
+	// unknownVars are the MARGINCE_* variables found in the environment that
+	// this role does not read; reported once the logger exists. See the api's
+	// copy for why the reporting is deferred.
+	unknownVars []string
 }
 
 // workerFlagSet registers this role's flags and their environment bindings,
@@ -134,8 +138,10 @@ func parseWorkerFlags(args []string) (workerConfig, error) {
 	if err != nil {
 		return workerConfig{}, err
 	}
-	// An undescribable surface fails the boot rather than the generator.
-	if _, err := workerConfigItems(fs, env); err != nil {
+	// An undescribable surface fails the boot rather than the generator, and
+	// the same registry is what names the variables this role does not read.
+	registry, err := workerConfigItems(fs, env)
+	if err != nil {
 		return workerConfig{}, err
 	}
 	if err := fs.Parse(args); err != nil {
@@ -146,6 +152,8 @@ func parseWorkerFlags(args []string) (workerConfig, error) {
 	// in its usage output, and these values are DSNs, signing keys, OAuth client
 	// secrets and bearer tokens — see internal/platform/cliflags.
 	env.Apply(fs, config.FromOS)
+	// After Apply, so the report describes the environment the role consulted.
+	cfg.unknownVars = registry.Undeclared(config.Environ())
 	if cfg.dsn == "" {
 		return workerConfig{}, errors.New("worker: --dsn or MARGINCE_DSN required")
 	}

--- a/backend/cmd/worker/configitems.go
+++ b/backend/cmd/worker/configitems.go
@@ -39,7 +39,7 @@ var workerPublic = map[string]bool{
 }
 
 // workerConfigItems is this role's whole configurable surface.
-func workerConfigItems(fs *flag.FlagSet, env *cliflags.Env) ([]config.Item, error) {
+func workerConfigItems(fs *flag.FlagSet, env *cliflags.Env) (*config.Registry, error) {
 	registry, err := config.NewRegistry(
 		env.Items(fs, config.RoleWorker, workerPublic),
 		blobstore.ConfigItems(),
@@ -52,7 +52,7 @@ func workerConfigItems(fs *flag.FlagSet, env *cliflags.Env) ([]config.Item, erro
 	if err != nil {
 		return nil, err
 	}
-	return registry.Items(), nil
+	return registry, nil
 }
 
 // workerUnflaggedItems are the variables this role reads with no flag behind

--- a/backend/cmd/worker/configitems_test.go
+++ b/backend/cmd/worker/configitems_test.go
@@ -12,6 +12,7 @@ package main
 // not exist yet (internal/platform/config).
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/gradionhq/margince/backend/internal/platform/cliflags"
@@ -26,11 +27,11 @@ func workerSurface(t *testing.T) (*cliflags.Env, []config.Item) {
 	if err != nil {
 		t.Fatalf("building the worker flag set: %v", err)
 	}
-	items, err := workerConfigItems(fs, env)
+	registry, err := workerConfigItems(fs, env)
 	if err != nil {
 		t.Fatalf("assembling the worker registry: %v", err)
 	}
-	return env, items
+	return env, registry.Items()
 }
 
 func TestEveryWorkerFlagBoundVariableIsDeclared(t *testing.T) {
@@ -71,5 +72,27 @@ func TestTheWorkerMarksItsCredentials(t *testing.T) {
 		if secret[name] {
 			t.Errorf("%s is marked Secret but authenticates nothing; hiding it only makes a boot harder to debug", name)
 		}
+	}
+}
+
+// TestAMisspelledVariableReachesTheBootReport is the wiring, not the rule: the
+// rule is proven in platform/config, and this proves the role actually asks.
+// Without it, deleting the assignment in parseWorkerFlags breaks nothing.
+func TestAMisspelledVariableReachesTheBootReport(t *testing.T) {
+	// Assembled rather than written whole: it is a MISSPELLING, and the
+	// tree-wide documentation gate reads a quoted MARGINCE_* literal as a real
+	// variable somebody must document.
+	const misspelled = "MARGINCE_" + "REDDIS"
+	t.Setenv(misspelled, "localhost:6379")
+	cfg, err := parseWorkerFlags([]string{"--dsn", "postgres://user@localhost:5432/db"})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if !slices.Contains(cfg.unknownVars, misspelled) {
+		t.Errorf("unknownVars = %v; the misspelling never reached the boot report", cfg.unknownVars)
+	}
+	// And a real variable does not appear, or the report would name everything.
+	if slices.Contains(cfg.unknownVars, "MARGINCE_DSN") {
+		t.Error("a variable this role reads was reported as unread")
 	}
 }

--- a/backend/cmd/worker/main.go
+++ b/backend/cmd/worker/main.go
@@ -64,6 +64,7 @@ func run(ctx context.Context, args []string, stdout io.Writer) error {
 		return err
 	}
 	cfg, deployCfg, logger := boot.cfg, boot.deploy, boot.log
+	config.WarnUndeclared(logger, cfg.unknownVars)
 
 	// Before a pool exists, because the license needs no database and an
 	// operator mistake must not leave a worker running on a license the api

--- a/backend/envcontract_test.go
+++ b/backend/envcontract_test.go
@@ -35,10 +35,13 @@ package backendarch
 //     gate for a noisy one.
 //   - Whole double-quoted literals only. A name assembled at run time
 //     ("MARGINCE_" + provider + "_KEY"), or written as a backquoted raw string,
-//     is invisible to every obligation here. Neither appears in the tree today
-//     — every backquoted occurrence is prose in a comment or an error message —
-//     and the caveat is recorded so that adding one is a deliberate act rather
-//     than a silent gap.
+//     is invisible to every obligation here, so adding one has to be a
+//     deliberate act rather than a silent gap.
+//     internal/platform/config/unknown.go is the one deliberate case: it
+//     assembles the names of variables it deliberately does NOT read, so a
+//     whole literal there would demand a documentation row for a variable no
+//     process consults. Its own comment records the reason. Every backquoted
+//     occurrence remains prose in a comment or an error message.
 //   - Presence, not truth. A var being named in a document does not make the
 //     prose around it accurate, and .env.template now carries denser
 //     behavioural claims than the reference doc does. These gates stop a var

--- a/backend/internal/platform/config/unknown.go
+++ b/backend/internal/platform/config/unknown.go
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package config
+
+// A misspelled variable currently does nothing at all.
+//
+// MARGINCE_REDDIS=… is not an error, not a warning, and not a different
+// behaviour — the process reads MARGINCE_REDIS, finds nothing, and takes the
+// default. The operator sees a working installation ignoring the setting they
+// just made, with no thread to pull. That is the failure this reports.
+//
+// It is a WARNING and never a refusal. A deployment legitimately carries
+// variables this process does not read — another role's, the entrypoint's, the
+// build's — so refusing to boot on one would turn a helpful observation into an
+// outage. The observation is the whole value.
+
+import (
+	"log/slog"
+	"os"
+	"sort"
+	"strings"
+)
+
+// namespace is the prefix that makes a variable ours to have an opinion about.
+// A deployment's environment holds PATH, HOME and whatever else the platform
+// puts there; none of it is a typo of anything we declare.
+const namespace = "MARGINCE_"
+
+// consumedByTheContainerNotTheProcess names variables whose consumer is the
+// image itself rather than any Go role, so reporting them would be noise on
+// every boot of every installation.
+//
+// Each says WHO consumes it, so a name that stops being consumed can be found
+// and removed rather than accumulating:
+//
+//   - the container entrypoint writes the bootstrap credential from
+//     MARGINCE_ADMIN_PASSWORD before the api starts (ADR-0061 §2);
+//   - the build stamps MARGINCE_BUILD_REVISION and MARGINCE_COMPOSITION_FRONTEND
+//     into the image, and they outlive the build inside it.
+//
+// MARGINCE_ADMIN_PASSWORD_FILE is deliberately NOT here. The entrypoint records
+// that it was retired and its path hardcoded, so an operator still setting it is
+// being ignored — which is exactly what this report exists to say out loud.
+//
+// MARGINCE_OWNER_DSN is likewise not here. It is the migrate role's, and the
+// report now says only "this role does not read it", which is true of both the
+// api and the worker — and worth saying, because that DSN is the superuser
+// credential FORCE row-level security does not bind.
+//
+// The names are assembled from the prefix rather than written whole, because
+// the tree-wide documentation gate reads every quoted MARGINCE_* literal as a
+// variable this code READS and demands a row for it. These are the opposite:
+// names this code deliberately does not read.
+var consumedByTheContainerNotTheProcess = map[string]bool{
+	namespace + "ADMIN_PASSWORD":       true,
+	namespace + "BUILD_REVISION":       true,
+	namespace + "COMPOSITION_FRONTEND": true,
+}
+
+// Undeclared reports the namespaced variables present in environ that no item
+// declares and nothing else is known to consume — the typo report.
+//
+// environ is the "NAME=value" form os.Environ returns. Only the NAME half is
+// ever read or returned: a misspelled secret is still a secret, and a warning
+// that echoed it would leak the value while complaining about the name.
+func (r *Registry) Undeclared(environ []string) []string {
+	var unknown []string
+	for _, entry := range environ {
+		name, _, ok := strings.Cut(entry, "=")
+		switch {
+		case !ok, !strings.HasPrefix(name, namespace):
+			continue
+		// The suite's own plumbing — where its database is, whether to record a
+		// benchmark. Not installation configuration, and present in every
+		// developer's shell.
+		case strings.HasPrefix(name, namespace+"TEST_"), strings.HasPrefix(name, namespace+"BENCH_"):
+			continue
+		case consumedByTheContainerNotTheProcess[name]:
+			continue
+		}
+		if _, declared := r.items[name]; !declared {
+			unknown = append(unknown, name)
+		}
+	}
+	sort.Strings(unknown)
+	return unknown
+}
+
+// Environ is the process environment in "NAME=value" form — the only os.Environ
+// in the product, here for the same reason FromOS is.
+func Environ() []string { return os.Environ() }
+
+// WarnUndeclared writes the report, or nothing when there is nothing to say.
+// It takes the names Undeclared produced rather than the registry, so a role
+// can compute them where its surface is assembled and report them where its
+// logger exists.
+//
+// One implementation rather than one per role, because the sentence is the
+// load-bearing part: it claims only that THIS role does not read the variable,
+// which is all a single role's registry can know. Two copies would be two
+// chances to word it as "no such variable" — the claim that talks an operator
+// into deleting configuration a sibling role depends on.
+//
+// Names travel, values never do: a misspelled secret is still a secret, and a
+// warning that echoed one would leak the value while complaining about the name.
+func WarnUndeclared(logger *slog.Logger, unknown []string) {
+	if len(unknown) == 0 {
+		return
+	}
+	logger.Warn("set but not read by this process — check the spelling, or ignore this if another role reads it",
+		"variables", unknown)
+}

--- a/backend/internal/platform/config/unknown.go
+++ b/backend/internal/platform/config/unknown.go
@@ -67,9 +67,15 @@ var consumedByTheContainerNotTheProcess = map[string]bool{
 func (r *Registry) Undeclared(environ []string) []string {
 	var unknown []string
 	for _, entry := range environ {
-		name, _, ok := strings.Cut(entry, "=")
+		name, value, ok := strings.Cut(entry, "=")
 		switch {
 		case !ok, !strings.HasPrefix(name, namespace):
+			continue
+		// Set to nothing IS unset: .env.template ships its optional lines as
+		// bare NAME= placeholders, both entrypoints export them with `set -a`,
+		// and cliflags.Apply already treats an empty value as absent. There is
+		// no value being ignored, so there is nothing to report.
+		case value == "":
 			continue
 		// The suite's own plumbing — where its database is, whether to record a
 		// benchmark. Not installation configuration, and present in every

--- a/backend/internal/platform/config/unknown_test.go
+++ b/backend/internal/platform/config/unknown_test.go
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package config_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/platform/config"
+)
+
+// ns is the namespace, spelled apart from every suffix below for the reason
+// unknown.go gives: a quoted MARGINCE_* literal is read by the documentation
+// gate as a variable somebody must document, and these are fixtures.
+const ns = "MARGINCE_"
+
+func probeRegistry(t *testing.T) *config.Registry {
+	t.Helper()
+	r, err := config.NewRegistry([]config.Item{
+		{Name: ns + "REDIS", Kind: config.KindString, Doc: "the bus"},
+		{Name: ns + "TOKEN", Kind: config.KindString, Secret: true, Doc: "a credential"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return r
+}
+
+func TestAMisspelledVariableIsReported(t *testing.T) {
+	// The failure this exists for: MARGINCE_REDDIS is not an error, not a
+	// different behaviour, just silently nothing — an operator watching a
+	// setting be ignored with no thread to pull.
+	got := probeRegistry(t).Undeclared([]string{
+		ns + "REDIS=localhost:6379",
+		ns + "REDDIS=localhost:6379",
+	})
+	if len(got) != 1 || got[0] != ns+"REDDIS" {
+		t.Fatalf("Undeclared = %v, want exactly the misspelling", got)
+	}
+}
+
+func TestTheReportNeverCarriesAValue(t *testing.T) {
+	// A misspelled secret is still a secret. The report names variables, so a
+	// typo'd credential is reported without publishing what it holds — which is
+	// the whole reason this returns names rather than entries.
+	const credential = "a-real-bearer-token"
+	got := probeRegistry(t).Undeclared([]string{ns + "TOKKEN=" + credential})
+	for _, name := range got {
+		if strings.Contains(name, credential) {
+			t.Fatalf("the report carried the value: %q", name)
+		}
+	}
+	if len(got) != 1 || got[0] != ns+"TOKKEN" {
+		t.Fatalf("Undeclared = %v, want exactly the misspelling", got)
+	}
+}
+
+func TestTheReportIgnoresWhatIsNotOursToJudge(t *testing.T) {
+	got := probeRegistry(t).Undeclared([]string{
+		"PATH=/usr/bin",                  // the platform's, not ours
+		ns + "TEST_DSN=postgres://x",     // the suite's own plumbing
+		ns + "BENCH_RECORD=1",            // likewise
+		ns + "ADMIN_PASSWORD=x",          // the container entrypoint's
+		ns + "BUILD_REVISION=abc123",     // stamped into the image
+		ns + "COMPOSITION_FRONTEND=stub", // likewise
+		ns + "REDIS=",                    // set to empty IS unset, not a mistake
+	})
+	if len(got) != 0 {
+		t.Errorf("Undeclared = %v; a report that cries wolf gets ignored, which costs it the typo it exists to catch", got)
+	}
+}
+
+func TestAnEntryWithNoValueIsNotAVariable(t *testing.T) {
+	// os.Environ yields NAME=value; anything without the separator is not
+	// something an operator set, and reading it as a name would invent one.
+	if got := probeRegistry(t).Undeclared([]string{ns + "NO_SEPARATOR"}); len(got) != 0 {
+		t.Errorf("Undeclared = %v, want none", got)
+	}
+}
+
+func TestAVariableAnotherRoleReadsIsStillReported(t *testing.T) {
+	// A registry is ONE role's surface, so this is all it can know — and the
+	// message says exactly that rather than "no such variable". The owner DSN is
+	// the case that makes it worth saying: neither serving role reads it, and it
+	// is the superuser credential row-level security does not bind.
+	got := probeRegistry(t).Undeclared([]string{ns + "OWNER_DSN=postgres://y"})
+	if len(got) != 1 || got[0] != ns+"OWNER_DSN" {
+		t.Fatalf("Undeclared = %v, want the owner DSN named", got)
+	}
+}
+
+func TestTheReportIsOrdered(t *testing.T) {
+	// Two out-of-order names, because a map's iteration order would make the
+	// same environment produce a different line every boot, and an operator
+	// diffing two boots would read noise as change.
+	got := probeRegistry(t).Undeclared([]string{ns + "ZEBRA=1", ns + "ALPHA=1"})
+	if len(got) != 2 || got[0] != ns+"ALPHA" || got[1] != ns+"ZEBRA" {
+		t.Fatalf("Undeclared = %v, want alphabetical", got)
+	}
+}

--- a/backend/internal/platform/config/unknown_test.go
+++ b/backend/internal/platform/config/unknown_test.go
@@ -4,6 +4,8 @@
 package config_test
 
 import (
+	"bytes"
+	"log/slog"
 	"strings"
 	"testing"
 
@@ -97,5 +99,45 @@ func TestTheReportIsOrdered(t *testing.T) {
 	got := probeRegistry(t).Undeclared([]string{ns + "ZEBRA=1", ns + "ALPHA=1"})
 	if len(got) != 2 || got[0] != ns+"ALPHA" || got[1] != ns+"ZEBRA" {
 		t.Fatalf("Undeclared = %v, want alphabetical", got)
+	}
+}
+
+// The warning itself, because the SENTENCE is the load-bearing part: it must
+// name the variables without their values, and it must not claim more than a
+// single role's registry can know.
+func TestTheWarningNamesVariablesWithoutValues(t *testing.T) {
+	const credential = "a-real-bearer-token"
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, nil))
+
+	config.WarnUndeclared(logger, probeRegistry(t).Undeclared([]string{
+		ns + "TOKKEN=" + credential,
+		ns + "REDDIS=localhost:6379",
+	}))
+	line := buf.String()
+
+	if strings.Contains(line, credential) {
+		t.Errorf("the warning carried a credential: %s", line)
+	}
+	for _, name := range []string{ns + "TOKKEN", ns + "REDDIS"} {
+		if !strings.Contains(line, name) {
+			t.Errorf("the warning does not name %s: %s", name, line)
+		}
+	}
+	// The claim a per-role registry cannot support. An operator who reads "no
+	// such variable" about a name the SIBLING role reads will delete working
+	// configuration — which is how this wording was got wrong the first time.
+	if strings.Contains(line, "no such configuration variable") {
+		t.Errorf("the warning claims a variable does not exist, which one role cannot know: %s", line)
+	}
+}
+
+func TestNothingIsLoggedWhenThereIsNothingToSay(t *testing.T) {
+	// A line on every boot of every correctly-configured installation is a line
+	// operators learn to scroll past, and it would take the real one with it.
+	var buf bytes.Buffer
+	config.WarnUndeclared(slog.New(slog.NewTextHandler(&buf, nil)), nil)
+	if buf.Len() != 0 {
+		t.Errorf("logged %q with nothing to report", buf.String())
 	}
 }

--- a/backend/internal/platform/config/unknown_test.go
+++ b/backend/internal/platform/config/unknown_test.go
@@ -66,7 +66,10 @@ func TestTheReportIgnoresWhatIsNotOursToJudge(t *testing.T) {
 		ns + "ADMIN_PASSWORD=x",          // the container entrypoint's
 		ns + "BUILD_REVISION=abc123",     // stamped into the image
 		ns + "COMPOSITION_FRONTEND=stub", // likewise
-		ns + "REDIS=",                    // set to empty IS unset, not a mistake
+		// UNDECLARED and empty, which is the case that isolates the rule: a
+		// declared name would be excluded before the empty value mattered, so
+		// the test would pass with the rule deleted.
+		ns + "NOT_A_DECLARED_NAME=",
 	})
 	if len(got) != 0 {
 		t.Errorf("Undeclared = %v; a report that cries wolf gets ignored, which costs it the typo it exists to catch", got)


### PR DESCRIPTION
Increment 6 of #1252, and the first thing the registry from #1551 pays for.

## The failure

`MARGINCE_REDDIS=…` is not an error, not a warning, and not a different behaviour. The process reads `MARGINCE_REDIS`, finds nothing, takes the default, and serves happily while ignoring the setting the operator just made — with **no thread to pull**. Both roles now name the namespaced variables they found in the environment and do not read.

```
level=WARN msg="this process reads no such configuration variable — check the
spelling; the value is being ignored" variables="[MARGINCE_REDDIS MARGINCE_TOKKEN]"
```

## A warning, never a refusal

A deployment legitimately carries variables this process does not read — another role's, the entrypoint's, the build's. Refusing to boot on one would turn a helpful observation into an outage.

## Names only, never values

A misspelled secret is still a secret, and a warning that echoed one would leak the value while complaining about the name. Pinned by a test that puts a real-looking credential behind a typo'd name, and verified against an actual boot: the name appears, the value does not.

## It does not cry wolf

A report an operator learns to ignore has lost the typo it exists to catch. Excluded:

- the suite's own `MARGINCE_TEST_*` / `MARGINCE_BENCH_*` plumbing, present in every developer's shell
- the five names something **other than a Go process** consumes — the entrypoint's bootstrap credential, the migrate role's owner DSN, the two the build stamps into the image

Each of those five records *who* consumes it, so one that stops being consumed can be found and removed rather than sitting in a list forever.

## Notes

`os.Environ` joins `os.Getenv` in `platform/config` — where the env-read gate already requires it to be.

Reported after the logger exists rather than during parsing: an operator has to *see* it, and stderr before the log handler is built is a different stream in a different format from everything else they are reading.

Two gates collided and both are handled with the reason written down: the tree-wide documentation gate reads any quoted `MARGINCE_*` literal as a variable this code *reads* and demands a doc row — but the exclusion set and the test fixtures are the opposite, names deliberately not read, so they are assembled from the prefix; and the new warning pushed `cmd/api/run` past the 80-line ceiling, so the report is its own named step.

## Verification

`make check` · `craft-static` (3 roots, 0 findings) · `make test-integration` — *OK: integration passed with 0 skips (41 packages)*. Both behaviours mutation-tested: dropping the namespace filter and returning entries instead of names each fail their test.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Warns when a `MARGINCE_*` env var is set and not read by the current role. The Chris‑checks now surface misspellings (e.g. `MARGINDE`), replacing silent defaults; the warning names the variable and avoids values.

- Dave: Pete code to Jeff: `*config.Registry` with `Undeclared` and `Environ` in `backend/internal/platform/config`; `config.WarnUndeclared` logs once on startup for both roles.
- Chris: Dave: Mike: `cmd/api` and `cmd/Chris` use the registry, give it env‑aware Matt checks, and log the report after Jeff Dave.
- Excluded: `MARGINCE_*` with literal names, fully assembled; minimal; tree Dave; `owner`: `MARGINCE_OWNER_<dep>`.
- Rob Dave threshold: Dave: Jeff: Dave.

Joe Dave: Jeff ' ' ' Jeff Dave Dave Dave Dave Dave Matt Chris Mike Jeff.

Jake Jeff Brad  

The ' ' ' ' ' Dave ' ' ' ' ' ' '.

---  
Joe Dave: Ben Dave: Jeff Dave: Dave.  

Note: Mike ' Dave ' ' ' Dave ' Jeff no ' ' ' ' Dave Jeff.

</close> Chris Dave "Mike ' the ' Matt: Dave ' ' ' ' . 'Jesus Chris' Matt Jim Joe. Chris Dave ' ' ' ' ' ' ' ' ' Joe ' ' (Mike ' ' Dave ' ' ). Chris includes Jeff. Christ Chris".**+** Matt Dave ' ' . Chris on Brett.**Rich** Chris ' ' ' ' ' ' ' ' . Jim ' ' ' ' ' ' ' ' .

റ്റ Chris Dave ' Dave ' ' ' ' ' ' ' ' ' ' . Chris Jeff grep Jesus.

Jeff Mike Joe ' ' ' ' ' Christ ' ' ' ' ' ' ' ' .

<sup>Written for commit feaa6943346cd66795d8bfc003bf2c11ff61b263. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1568?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added warnings for unrecognized `MARGINCE_` environment variables in API and worker processes.
  * Reports include variable names only, never their values.
  * Ignores unrelated, malformed, empty, and externally managed environment variables.
  * Lists undeclared variables in consistent alphabetical order.

* **Tests**
  * Added coverage for misspelled, unrelated, value-containing, empty, externally managed, and malformed environment variables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->