### PR TITLE
fix(siteread): a German board loses its chair to a title the page itself drew

### DIFF
--- a/backend/internal/compose/sitepagefactspeople.go
+++ b/backend/internal/compose/sitepagefactspeople.go
@@ -99,12 +99,83 @@ func reachesPastAnother(claim pageFactsPerson, quote, name, role string, claims 
 			return true
 		}
 		// Declared as sharing the label, so the reply must not give them a
-		// different one.
-		if normalizeEvidence(strings.TrimSpace(other.R)) != roleNorm {
+		// different one — but "the same label" is not "the same string". A
+		// German imprint names its whole board under one heading and gives the
+		// chair his fuller title in the same breath:
+		//
+		//	Vorstand: Mark Lohweber (Vorstandsvorsitzender), Benedikt
+		//	Bonnmann, Kristina Gerwert, Michael Knopp, Andreas Prenneis
+		//
+		// All five are correctly attributed, and Vorstandsvorsitzender differs
+		// from Vorstand exactly because the page said so. Demanding equality
+		// reads that precision as a contradiction and drops the chair; it cost
+		// adesso.de its whole board on a re-crawl.
+		if !sameOfficerLabel(normalizeEvidence(strings.TrimSpace(other.R)), roleNorm) {
 			return true
 		}
 	}
 	return false
+}
+
+// sameOfficerLabel answers whether two titles are the same label, one of them
+// possibly carrying a distinction the page itself drew.
+//
+// Vorstand and Vorstandsvorsitzender are the board and its chair: one contains
+// the other, and the longer is the shorter plus a qualifier. Geschäftsführer
+// and Prokurist share no stem and stay a contradiction, which is the case this
+// gate exists for.
+//
+// The test is a shared PREFIX, not bare containment, and the difference is
+// load-bearing: "geschäftsführer" is a substring of "geschäftsführerin", so
+// containment alone would let a Prokurist claim a Geschäftsführerin's title
+// through a feminine ending. A qualifier extends the label to the right —
+// Vorstand → Vorstandsvorsitzender — which a prefix test catches and a
+// suffix difference does not.
+//
+// A prefix rather than a list of known titles, because the titles are whatever
+// the page prints, in whatever language: Vorstand/Vorstandsvorsitzender,
+// Partner/Partner & Managing Director. A list would be a German-shaped guess
+// at every other country's paperwork.
+func sameOfficerLabel(a, b string) bool {
+	if a == b {
+		return true
+	}
+	if a == "" || b == "" {
+		return false
+	}
+	long, short := a, b
+	if len(short) > len(long) {
+		long, short = short, long
+	}
+	if !strings.HasPrefix(long, short) {
+		return false
+	}
+	// The extension has to BE a qualifier, not the rest of a longer word.
+	// Vorstand→Vorstandsvorsitzender is the board's chair; geschäftsführer→
+	// geschäftsführerin is the same job in the feminine, and a claim resting
+	// on that difference is a misattribution rather than a distinction.
+	return isOfficerQualifier(long[len(short):])
+}
+
+// isOfficerQualifier reports whether what a longer title adds to a shorter one
+// reads as a further distinction rather than an inflection. German compounds
+// it directly (Vorstand + svorsitzender) or spaces it (Partner + " & Managing
+// Director"); a feminine ending is neither, and is the case that must not pass.
+func isOfficerQualifier(extra string) bool {
+	if extra == "" {
+		return true
+	}
+	// Gendered endings, the one shape that is the SAME job rather than a
+	// bigger one. Checked before anything else because "in" is short enough
+	// to look like a compound joiner.
+	for _, ending := range []string{"in", "innen", "e", "er"} {
+		if extra == ending {
+			return false
+		}
+	}
+	// A qualifier is a word of its own, or a compound long enough to be one.
+	// "svorsitzender" is 13 characters; no inflection reaches that.
+	return strings.HasPrefix(extra, " ") || len(extra) >= 6
 }
 
 // declaredCompanions is the set of names the model says its quote reaches

--- a/backend/internal/compose/sitepagefactspeople_test.go
+++ b/backend/internal/compose/sitepagefactspeople_test.go
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+import "testing"
+
+// A German imprint prints its whole board under one label, and gives the chair
+// an extra title in the same breath. adesso.de:
+//
+//	Vorstand: Mark Lohweber (Vorstandsvorsitzender), Benedikt Bonnmann,
+//	Kristina Gerwert, Michael Knopp, Andreas Prenneis.
+//
+// Every one of those five is a real, correctly-attributed officer. The chair's
+// role differs from his colleagues' by design — that is what the parenthesis
+// says — so a rule demanding declared companions carry an IDENTICAL role reads
+// the page's own precision as a contradiction and refuses the claim.
+//
+// This is not hypothetical: it cost all six adesso.de people on a re-crawl,
+// and the same shape appears on any German imprint with a chair.
+func TestReachesPastAnother_SharedLabelAllowsAChairsExtraTitle(t *testing.T) {
+	quote := "Vorstand: Mark Lohweber (Vorstandsvorsitzender), Benedikt Bonnmann, Kristina Gerwert"
+	claims := []pageFactsPerson{
+		{N: "Mark Lohweber", R: "Vorstandsvorsitzender"},
+		{N: "Benedikt Bonnmann", R: "Vorstand"},
+		{N: "Kristina Gerwert", R: "Vorstand"},
+	}
+	chair := pageFactsPerson{
+		N: "Mark Lohweber",
+		R: "Vorstandsvorsitzender",
+		Q: quote,
+		W: "Benedikt Bonnmann; Kristina Gerwert",
+	}
+	if reachesPastAnother(chair, quote, chair.N, chair.R, claims) {
+		t.Fatal("the chair's claim was refused: his colleagues share the Vorstand label " +
+			"and he carries the chair title the same sentence gives him")
+	}
+
+	// A plain member of the same board still passes, which it always did.
+	member := pageFactsPerson{
+		N: "Benedikt Bonnmann",
+		R: "Vorstand",
+		Q: quote,
+		W: "Mark Lohweber; Kristina Gerwert",
+	}
+	if reachesPastAnother(member, quote, member.N, member.R, claims) {
+		t.Fatal("a plain board member sharing the label was refused")
+	}
+}
+
+// The rule this gate exists for has to keep working: a quote that reaches over
+// somebody the REPLY ITSELF gives a different job is a misattribution.
+//
+// Anna is a Geschäftsführerin and Bernd a Prokurist. If Bernd's claim declares
+// Anna as sharing his label, the reply now says two contradictory things about
+// her, and the claim is refused.
+func TestReachesPastAnother_StillRefusesAReachOverADifferentRole(t *testing.T) {
+	quote := "Geschäftsführer Anna Muster Prokurist Bernd Vermaaten"
+	claims := []pageFactsPerson{
+		{N: "Anna Muster", R: "Geschäftsführerin"},
+		{N: "Bernd Vermaaten", R: "Prokurist"},
+	}
+	// Bernd claiming the Geschäftsführer title, declaring Anna as sharing it —
+	// which the reply's own entry for Anna contradicts.
+	wrong := pageFactsPerson{
+		N: "Bernd Vermaaten",
+		R: "Geschäftsführer",
+		Q: quote,
+		W: "Anna Muster",
+	}
+	if !reachesPastAnother(wrong, quote, wrong.N, wrong.R, claims) {
+		t.Fatal("a reach over somebody the reply gives a different role was allowed")
+	}
+}
+
+// An UNDECLARED companion inside the quote is still refused, declared-role
+// leniency or not: the model has to say who its quote reaches over.
+func TestReachesPastAnother_StillRefusesAnUndeclaredCompanion(t *testing.T) {
+	quote := "Vorstand: Mark Lohweber, Benedikt Bonnmann"
+	claims := []pageFactsPerson{
+		{N: "Mark Lohweber", R: "Vorstand"},
+		{N: "Benedikt Bonnmann", R: "Vorstand"},
+	}
+	silent := pageFactsPerson{N: "Mark Lohweber", R: "Vorstand", Q: quote, W: ""}
+	if !reachesPastAnother(silent, quote, silent.N, silent.R, claims) {
+		t.Fatal("a companion the reply never declared was allowed")
+	}
+}
+
+// sameOfficerLabel decides whether two printed titles are one label. The
+// gendered pairs are the trap: "geschäftsführer" is a prefix of
+// "geschäftsführerin", and treating that as a distinction would let a
+// Prokurist claim a Geschäftsführerin's title through a feminine ending.
+func TestSameOfficerLabel(t *testing.T) {
+	for _, tc := range []struct {
+		a, b string
+		want bool
+		why  string
+	}{
+		{"vorstand", "vorstandsvorsitzender", true, "the board and its chair"},
+		{"partner", "partner & managing director", true, "a qualifier as its own words"},
+		{"vorstand", "vorstand", true, "identical"},
+		{"geschäftsführer", "geschäftsführerin", false, "the same job, feminine"},
+		{"leiter", "leiterin", false, "the same job, feminine"},
+		{"geschäftsführer", "prokurist", false, "two different offices"},
+		{"vorstand", "aufsichtsrat", false, "the board and the body that supervises it"},
+		{"", "vorstand", false, "an empty title claims nothing"},
+	} {
+		if got := sameOfficerLabel(tc.a, tc.b); got != tc.want {
+			t.Errorf("sameOfficerLabel(%q, %q) = %v, want %v — %s", tc.a, tc.b, got, tc.want, tc.why)
+		}
+	}
+}


### PR DESCRIPTION
adesso.de's imprint prints its whole board under one heading:

```
Vorstand: Mark Lohweber (Vorstandsvorsitzender), Benedikt Bonnmann,
Kristina Gerwert, Michael Knopp, Andreas Prenneis.
```

Five correctly-attributed officers. `reachesPastAnother` refused all of them
with `name_role_not_in_snippet`, because a claim declaring companions requires
those companions to carry an **identical** role string — and
`Vorstandsvorsitzender` is not `Vorstand`. It differs precisely because the
page said so. The gate read the page's own precision as a contradiction.

This is the regression that made a dataset re-crawl unusable: the newer engine
extracted **zero** people from every company, so `size_band` stayed empty
because fixing it would have cost 822 real contacts.

## Measured, not guessed

Re-crawling adesso.de with this fix, engine-extracted people go **1 → 5 of 6**.
The four board members now fail only on `no_published_email`, which is the
rule the demo dataset already overrides deliberately. The sixth — Lohweber
himself — fails when the model omits a companion from its declaration, which
is model output rather than this gate.

## Prefix, not containment

The comparison is a shared **prefix**, and the difference is load-bearing:
`geschäftsführer` is a substring of `geschäftsführerin`, so bare containment
would let a Prokurist claim a Geschäftsführerin's title through a feminine
ending. A qualifier extends a label to the right (`Vorstand` →
`Vorstandsvorsitzender`); an inflection does not.

A prefix rather than a list of known titles, because titles are whatever the
page prints in whatever language — a list would be a German-shaped guess at
every other country's paperwork.

## Tests

First tests for this gate, including the two that must keep failing:

- an **undeclared** companion inside the quote
- a declared companion the reply gives a genuinely different office
- a table over `sameOfficerLabel` pinning the gendered pairs

`make craft-static` passes, `golangci-lint run ./internal/compose/...` reports
0 issues, and the full `internal/compose` package is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treats officer titles that share the same label as equivalent when one adds a right-hand qualifier, fixing German imprints that list a board and mark the chair in-place. Previously, `reachesPastAnother` required identical role strings and rejected correct companions (e.g., Vorstand vs Vorstandsvorsitzender); now it accepts shared-label titles while still refusing undeclared companions and genuinely different offices.

**Key changes**
- Add `sameOfficerLabel` (shared-prefix check) and `isOfficerQualifier` to distinguish qualifiers from gendered inflections; avoid bare containment to prevent Geschäftsführer→Geschäftsführerin false matches.
- Update `reachesPastAnother` to use shared-label comparison after normalization.
- Add tests for the chair-with-board pass case and two must-fail cases (undeclared companion; conflicting role), plus a table over gendered pairs.
- Measured impact: adesso.de re-crawl increases extracted people from 1 to 5/6; remaining failures are `no_published_email` or a missing companion in model output.

<sup>Written for commit 528e7c45e1fff87b03a16f2859ef5f9086f9ed08. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1569?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

