### PR TITLE
feat(privacy): an activity can carry the statutory class it earned, and be held to it

### DIFF
--- a/backend/migrations/core/0288_activity_retention_class.down.sql
+++ b/backend/migrations/core/0288_activity_retention_class.down.sql
@@ -1,0 +1,20 @@
+-- Dropping the columns discards the record of which activities were held under
+-- a statutory obligation and until when. That is the honest outcome of undoing
+-- this migration: the state has nowhere else to live, and a down that tried to
+-- preserve it would be inventing a second home for it.
+DROP INDEX IF EXISTS idx_activity_restricted_until;
+
+ALTER TABLE activity
+  DROP CONSTRAINT IF EXISTS activity_restriction_needs_class,
+  DROP CONSTRAINT IF EXISTS activity_restriction_window,
+  DROP CONSTRAINT IF EXISTS activity_restriction_complete,
+  DROP CONSTRAINT IF EXISTS activity_retention_class_stamped,
+  DROP CONSTRAINT IF EXISTS activity_retention_class_known;
+
+ALTER TABLE activity
+  DROP COLUMN IF EXISTS redacted_fields,
+  DROP COLUMN IF EXISTS restricted_until,
+  DROP COLUMN IF EXISTS restricted_reason,
+  DROP COLUMN IF EXISTS restricted_at,
+  DROP COLUMN IF EXISTS retention_class_at,
+  DROP COLUMN IF EXISTS retention_class;

--- a/backend/migrations/core/0288_activity_retention_class.up.sql
+++ b/backend/migrations/core/0288_activity_retention_class.up.sql
@@ -1,0 +1,62 @@
+-- 0288: an activity records the statutory class it earned, and the restriction
+-- that class produces (A165/ADR-0114, A167/ADR-0116).
+--
+-- Two jobs in one table, and they are written at different times by different
+-- code, so the constraints are what keep them coherent rather than convention.
+--
+-- retention_class is the MONOTONIC stamp. It is written when the row first
+-- EARNS the class — its deal is won, an offer on that deal leaves draft, or it
+-- is linked to a deal that already qualifies — and never re-derived. That is
+-- the load-bearing half of A165: qualification is REVERSIBLE in the product (a
+-- won deal can be reopened, and relinking an activity deletes its existing link
+-- of that type), so a rule that asks the question at erasure time asks it of a
+-- record whose evidence may have moved. The failure is not symmetric —
+-- over-retention is an argument to have with a supervisory authority, and
+-- destruction is irreversible.
+--
+-- The other three are the RESTRICTION state, written when an erasure meets a
+-- stamped row: the record leaves every ordinary read path instead of being
+-- destroyed, and carries the deadline at which its obligation ends. The
+-- deadline is PINNED here, from the floor in force at that moment, so a later
+-- change to a configured period never shortens an obligation already recorded.
+ALTER TABLE activity
+  ADD COLUMN retention_class     text NULL,
+  ADD COLUMN retention_class_at  timestamptz NULL,
+  ADD COLUMN restricted_at       timestamptz NULL,
+  ADD COLUMN restricted_reason   text NULL,
+  ADD COLUMN restricted_until    timestamptz NULL,
+  -- Which fields an erasure emptied on this row. A redacted field and an empty
+  -- one are otherwise the same NULL, and only the first is a statement the
+  -- controller must be able to make to the subject. NOT NULL DEFAULT '{}'
+  -- because "no redactions" is a real state that must not be spelled the same
+  -- way as "unknown".
+  ADD COLUMN redacted_fields     text[] NOT NULL DEFAULT '{}';
+
+ALTER TABLE activity
+  ADD CONSTRAINT activity_retention_class_known
+    CHECK (retention_class IS NULL OR retention_class IN ('commercial_correspondence')),
+  -- The stamp carries its own timestamp or neither is trustworthy.
+  ADD CONSTRAINT activity_retention_class_stamped
+    CHECK ((retention_class IS NULL) = (retention_class_at IS NULL)),
+  -- All-or-none. A row with restricted_at set and restricted_until NULL is
+  -- never selected by the expiry sweep, which reads `restricted_until <= now()`
+  -- — hidden from every read path, immutable, and never erased. A permanently
+  -- invisible record, produced by one forgotten assignment.
+  ADD CONSTRAINT activity_restriction_complete
+    CHECK ((restricted_at IS NULL AND restricted_reason IS NULL AND restricted_until IS NULL)
+        OR (restricted_at IS NOT NULL AND restricted_reason IS NOT NULL AND restricted_until IS NOT NULL)),
+  -- A window that closed before it opened erases immediately, which looks
+  -- exactly like the feature working.
+  ADD CONSTRAINT activity_restriction_window
+    CHECK (restricted_until IS NULL OR restricted_until > restricted_at),
+  -- The stamp is what the obligation rests on; a restriction without one is an
+  -- assertion with nothing behind it.
+  ADD CONSTRAINT activity_restriction_needs_class
+    CHECK (restricted_at IS NULL OR retention_class IS NOT NULL);
+
+-- The expiry sweep's working set: restricted rows whose window has run out.
+-- The predicate matches the sweep's own WHERE exactly, and leading on the
+-- deadline keeps the due rows at one end rather than scanning every restricted
+-- row to find them.
+CREATE INDEX idx_activity_restricted_until
+  ON activity (restricted_until) WHERE restricted_at IS NOT NULL;

--- a/backend/migrations/core/0289_activity_restriction_guard.down.sql
+++ b/backend/migrations/core/0289_activity_restriction_guard.down.sql
@@ -1,0 +1,3 @@
+DROP TABLE IF EXISTS activity_retention_evidence;
+DROP TRIGGER IF EXISTS activity_refuse_restricted_mutation ON activity;
+DROP FUNCTION IF EXISTS activity_refuse_restricted_mutation();

--- a/backend/migrations/core/0289_activity_restriction_guard.down.sql
+++ b/backend/migrations/core/0289_activity_restriction_guard.down.sql
@@ -1,3 +1,5 @@
+DROP TRIGGER IF EXISTS activity_retention_evidence_is_frozen ON activity_retention_evidence;
+DROP FUNCTION IF EXISTS activity_retention_evidence_is_frozen();
 DROP TABLE IF EXISTS activity_retention_evidence;
 DROP TRIGGER IF EXISTS activity_refuse_restricted_mutation ON activity;
 DROP FUNCTION IF EXISTS activity_refuse_restricted_mutation();

--- a/backend/migrations/core/0289_activity_restriction_guard.up.sql
+++ b/backend/migrations/core/0289_activity_restriction_guard.up.sql
@@ -1,0 +1,122 @@
+-- 0289: the class stamp is write-once, the restriction is immutable, and what
+-- qualified a record outlives what it points at (A165/ADR-0114, A167/ADR-0116).
+--
+-- DEPACK-AC-5a puts the immutability below every role, admin included, so it
+-- cannot live in a handler. Two rules, one trigger.
+--
+-- THE STAMP IS WRITE-ONCE. A165 makes the classification monotonic precisely
+-- because qualification is reversible in the product, and a column nothing
+-- protects is monotonic only by the good behaviour of every writer that ever
+-- touches it — which is the assumption A165 already rejected once. Nothing
+-- legitimate needs to unset it: a record wrongly classified is handled by the
+-- audited release, which erases it rather than rewriting history about it.
+--
+-- THE RESTRICTION IS IMMUTABLE. Any write to a restricted row is refused except
+-- one that CLEARS restricted_at, which is the shape the expiry sweep and the
+-- audited release both take, and nothing else.
+--
+-- Two details the 0193 precedent does not carry, both silent failures:
+--
+--   RETURN OLD on a permitted DELETE. NEW is null on DELETE, so returning it
+--   would block every delete of every row rather than only restricted ones.
+--
+--   The retention engine's ordinary selectors must EXCLUDE restricted rows.
+--   Otherwise the nightly pass attempts a write this trigger refuses, the
+--   policy errors, and one stuck row stops every later scope every night — a
+--   compliance engine that has silently stopped running looks identical to one
+--   with nothing to do.
+CREATE OR REPLACE FUNCTION activity_refuse_restricted_mutation() RETURNS trigger
+LANGUAGE plpgsql AS $$
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    IF OLD.restricted_at IS NOT NULL THEN
+      RAISE EXCEPTION 'activity % is restricted under a statutory retention obligation until %', OLD.id, OLD.restricted_until
+        USING ERRCODE = 'check_violation',
+              CONSTRAINT = 'activity_restricted_immutable';
+    END IF;
+    RETURN OLD;
+  END IF;
+
+  -- The stamp never changes once written. Clearing it or moving it to another
+  -- class both count.
+  IF OLD.retention_class IS NOT NULL
+     AND (NEW.retention_class IS DISTINCT FROM OLD.retention_class) THEN
+    RAISE EXCEPTION 'activity % carries retention class %, which is stamped once and never re-derived', OLD.id, OLD.retention_class
+      USING ERRCODE = 'check_violation',
+            CONSTRAINT = 'activity_retention_class_monotonic';
+  END IF;
+
+  -- A restricted row admits exactly one write: the one that lifts the
+  -- restriction. The expiry sweep and the audited release are both that shape.
+  IF OLD.restricted_at IS NOT NULL AND NEW.restricted_at IS NOT NULL THEN
+    RAISE EXCEPTION 'activity % is restricted under a statutory retention obligation until %', OLD.id, OLD.restricted_until
+      USING ERRCODE = 'check_violation',
+            CONSTRAINT = 'activity_restricted_immutable';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER activity_refuse_restricted_mutation
+  BEFORE UPDATE OR DELETE ON activity
+  FOR EACH ROW EXECUTE FUNCTION activity_refuse_restricted_mutation();
+
+-- What qualified a record for the floor, frozen at the moment it qualified.
+--
+-- This is its own table because the evidence does NOT survive in the place a
+-- reader would look for it. The obvious implementation joins activity_link to
+-- deal at read time, and that answers wrongly and SILENTLY: activity_link
+-- CASCADEs on deal delete, a relink deletes the link it replaces, a won deal
+-- can be reopened, and a deal can be renamed. A controller asking "why is this
+-- record held?" six months later would get an empty answer about a record that
+-- is genuinely and correctly held — in front of the one audience this exists
+-- for, a supervisory authority asking them to substantiate a retention claim.
+CREATE TABLE activity_retention_evidence (
+  id            uuid PRIMARY KEY DEFAULT uuidv7(),
+  activity_id   uuid NOT NULL REFERENCES activity(id) ON DELETE CASCADE,
+  basis         text NOT NULL CHECK (basis IN ('deal_won','offer_beyond_draft','controller_pin')),
+  qualified_at  timestamptz NOT NULL,
+
+  -- deal_id is the live row while it exists; deal_name is frozen so the
+  -- evidence still answers after a rename or a delete. SET NULL rather than
+  -- CASCADE: a cascading FK would delete the proof along with the thing it
+  -- proves. A controller pin may name no deal at all — supplier and purchasing
+  -- correspondence qualifies under §257 HGB and has no deal in this product to
+  -- hang off (DEPACK-AC-5h), and that case is why pin exists.
+  deal_id       uuid NULL REFERENCES deal(id) ON DELETE SET NULL,
+  deal_name     text NULL,
+
+  -- A pin is a finding of fact by a named accountable person (Art. 5(2)). The
+  -- display name is frozen beside the id so a deactivated or deleted account
+  -- cannot turn an attributed decision into an anonymous one.
+  decided_by      uuid NULL REFERENCES app_user(id) ON DELETE SET NULL,
+  decided_by_name text NULL,
+  reason          text NULL,
+  created_at    timestamptz NOT NULL DEFAULT now(),
+
+  -- A derived basis IS the transaction, so it names one and carries no
+  -- controller reason. It requires the NAME, not the id: deal_id is
+  -- ON DELETE SET NULL, so demanding it would make deleting a deal fail
+  -- against its own evidence — and the evidence outliving the deal is the
+  -- whole reason this table exists. deal_name is frozen at qualification and
+  -- is what still answers afterwards.
+  CONSTRAINT are_derived_names_its_deal CHECK (
+    basis = 'controller_pin'
+    OR (deal_name IS NOT NULL AND decided_by IS NULL AND reason IS NULL)),
+  CONSTRAINT are_pin_is_attributed CHECK (
+    basis <> 'controller_pin'
+    OR (decided_by_name IS NOT NULL AND reason IS NOT NULL)),
+  -- An id always carries its name. The reverse is deliberately allowed: a
+  -- deleted deal leaves the frozen name behind with no id to point at.
+  CONSTRAINT are_deal_name_with_id CHECK (deal_id IS NULL OR deal_name IS NOT NULL)
+);
+
+-- One derived row per (activity, deal, basis): a deal can qualify a record both
+-- by being won and by carrying a sent offer, and those are two facts rather
+-- than a duplicate. Controller pins are excluded — a record may be pinned,
+-- released and pinned again, and each decision is its own row.
+CREATE UNIQUE INDEX uq_activity_retention_evidence
+  ON activity_retention_evidence (activity_id, deal_id, basis)
+  WHERE basis <> 'controller_pin';
+CREATE INDEX idx_are_activity ON activity_retention_evidence (activity_id);

--- a/backend/migrations/core/0289_activity_restriction_guard.up.sql
+++ b/backend/migrations/core/0289_activity_restriction_guard.up.sql
@@ -37,13 +37,31 @@ BEGIN
     RETURN OLD;
   END IF;
 
-  -- The stamp never changes once written. Clearing it or moving it to another
-  -- class both count.
+  -- The stamp never changes once written — the class OR the timestamp that
+  -- says when it was earned. Leaving the timestamp mutable would let a writer
+  -- keep the class and move the date, which is the same rewriting of history
+  -- with an extra step: the qualifying moment is what a supervisory authority
+  -- would be shown.
   IF OLD.retention_class IS NOT NULL
-     AND (NEW.retention_class IS DISTINCT FROM OLD.retention_class) THEN
-    RAISE EXCEPTION 'activity % carries retention class %, which is stamped once and never re-derived', OLD.id, OLD.retention_class
+     AND (NEW.retention_class IS DISTINCT FROM OLD.retention_class
+          OR NEW.retention_class_at IS DISTINCT FROM OLD.retention_class_at) THEN
+    RAISE EXCEPTION 'activity % carries retention class % earned at %, which is stamped once and never re-derived', OLD.id, OLD.retention_class, OLD.retention_class_at
       USING ERRCODE = 'check_violation',
             CONSTRAINT = 'activity_retention_class_monotonic';
+  END IF;
+
+  -- A restriction must be substantiated at the moment it is written. The CHECK
+  -- on the table can only see the row's own columns, so it can require a class
+  -- and no more; the evidence lives in another table and this is the only
+  -- place that can look. A restriction with nothing behind it is an assertion
+  -- the controller cannot support when asked, which is the one situation this
+  -- whole mechanism exists to avoid.
+  IF OLD.restricted_at IS NULL AND NEW.restricted_at IS NOT NULL
+     AND NOT EXISTS (SELECT 1 FROM activity_retention_evidence e
+                      WHERE e.activity_id = NEW.id) THEN
+    RAISE EXCEPTION 'activity % cannot be restricted with no retention evidence recording what qualified it', NEW.id
+      USING ERRCODE = 'check_violation',
+            CONSTRAINT = 'activity_restriction_needs_evidence';
   END IF;
 
   -- A restricted row admits exactly one write: the one that lifts the
@@ -103,10 +121,13 @@ CREATE TABLE activity_retention_evidence (
   -- is what still answers afterwards.
   CONSTRAINT are_derived_names_its_deal CHECK (
     basis = 'controller_pin'
-    OR (deal_name IS NOT NULL AND decided_by IS NULL AND reason IS NULL)),
+    OR (deal_name IS NOT NULL
+        AND decided_by IS NULL AND decided_by_name IS NULL AND reason IS NULL)),
+  -- Non-empty, not merely present: '' passes IS NOT NULL and is exactly as
+  -- unaccountable as a null when somebody asks who decided and why.
   CONSTRAINT are_pin_is_attributed CHECK (
     basis <> 'controller_pin'
-    OR (decided_by_name IS NOT NULL AND reason IS NOT NULL)),
+    OR (length(btrim(decided_by_name)) > 0 AND length(btrim(reason)) > 0)),
   -- An id always carries its name. The reverse is deliberately allowed: a
   -- deleted deal leaves the frozen name behind with no id to point at.
   CONSTRAINT are_deal_name_with_id CHECK (deal_id IS NULL OR deal_name IS NOT NULL)
@@ -116,7 +137,71 @@ CREATE TABLE activity_retention_evidence (
 -- by being won and by carrying a sent offer, and those are two facts rather
 -- than a duplicate. Controller pins are excluded — a record may be pinned,
 -- released and pinned again, and each decision is its own row.
+--
+-- NULLS NOT DISTINCT is load-bearing. deal_id goes null when the deal is
+-- deleted, and Postgres's default treats every null as distinct from every
+-- other — so without this, a record whose deal is gone accepts unlimited
+-- identical evidence rows, and the restricted-records list names the same
+-- transaction over and over.
 CREATE UNIQUE INDEX uq_activity_retention_evidence
-  ON activity_retention_evidence (activity_id, deal_id, basis)
+  ON activity_retention_evidence (activity_id, deal_id, deal_name, basis)
+  NULLS NOT DISTINCT
   WHERE basis <> 'controller_pin';
+
+-- The FK columns are both ON DELETE SET NULL, so deleting a deal or a user has
+-- to find the rows pointing at it. Without these it scans the whole table.
+CREATE INDEX idx_are_deal ON activity_retention_evidence (deal_id) WHERE deal_id IS NOT NULL;
+CREATE INDEX idx_are_decided_by ON activity_retention_evidence (decided_by) WHERE decided_by IS NOT NULL;
 CREATE INDEX idx_are_activity ON activity_retention_evidence (activity_id);
+
+-- Evidence is frozen, and that has to be enforced rather than asserted in a
+-- comment. The runtime role holds UPDATE and DELETE on this table by default
+-- (migration 0015), so without a guard the deal name, the basis and the
+-- qualifying moment can all be rewritten — and the one audience this table
+-- exists for is a supervisory authority asking the controller to substantiate
+-- a retention claim. Evidence somebody can edit after the fact substantiates
+-- nothing.
+--
+-- Two writes stay legal, and only two. A deal delete must be able to null
+-- deal_id (the FK is ON DELETE SET NULL, and the frozen deal_name is what
+-- answers afterwards); the same for decided_by when a user row goes. Every
+-- other column is immutable, and a row is deleted only with the activity it
+-- belongs to, through the CASCADE.
+CREATE OR REPLACE FUNCTION activity_retention_evidence_is_frozen() RETURNS trigger
+LANGUAGE plpgsql AS $$
+BEGIN
+  -- A row goes only with the activity it substantiates, through the CASCADE.
+  -- A direct delete is refused. The two are distinguishable because the
+  -- CASCADE has already removed the parent by the time this fires, so the
+  -- activity is gone exactly when the delete is legitimate.
+  IF TG_OP = 'DELETE' THEN
+    IF EXISTS (SELECT 1 FROM activity a WHERE a.id = OLD.activity_id) THEN
+      RAISE EXCEPTION 'retention evidence % is frozen and is removed only with the activity it substantiates', OLD.id
+        USING ERRCODE = 'check_violation',
+              CONSTRAINT = 'activity_retention_evidence_frozen';
+    END IF;
+    RETURN OLD;
+  END IF;
+
+  IF NEW.activity_id     IS DISTINCT FROM OLD.activity_id
+     OR NEW.basis        IS DISTINCT FROM OLD.basis
+     OR NEW.qualified_at IS DISTINCT FROM OLD.qualified_at
+     OR NEW.deal_name    IS DISTINCT FROM OLD.deal_name
+     OR NEW.decided_by_name IS DISTINCT FROM OLD.decided_by_name
+     OR NEW.reason       IS DISTINCT FROM OLD.reason
+     OR NEW.created_at   IS DISTINCT FROM OLD.created_at
+     -- The reference may be CLEARED by its FK, never repointed.
+     OR (NEW.deal_id IS NOT NULL AND NEW.deal_id IS DISTINCT FROM OLD.deal_id)
+     OR (NEW.decided_by IS NOT NULL AND NEW.decided_by IS DISTINCT FROM OLD.decided_by) THEN
+    RAISE EXCEPTION 'retention evidence % is frozen at the moment it qualified and may not be rewritten', OLD.id
+      USING ERRCODE = 'check_violation',
+            CONSTRAINT = 'activity_retention_evidence_frozen';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER activity_retention_evidence_is_frozen
+  BEFORE UPDATE OR DELETE ON activity_retention_evidence
+  FOR EACH ROW EXECUTE FUNCTION activity_retention_evidence_is_frozen();


### PR DESCRIPTION
The schema half of A165/ADR-0114 and A167/ADR-0116. **No behaviour changes yet** — nothing writes these columns, and the floor predicate still shields by exclusion.

That split is deliberate. Narrowing the floor before a stamp writer exists would let the nightly `privacy_retention` worker destroy correspondence whose deal link has since moved, unattended, and there is no way back from that. The narrowing lands with the writer.

**0288 — the columns.** `retention_class` is the monotonic stamp: written when a row first *earns* the class, never re-derived, because qualification is reversible in the product (a won deal can be reopened, and relinking an activity deletes its existing link of that type). The other three are the restriction state, with `restricted_until` pinned from the floor in force so a later period change never shortens a recorded obligation.

The columns are unremarkable. **The four CHECK constraints are the point** — each is a way this feature fails silently rather than loudly:

- **All-or-none on the restriction triple.** A row with `restricted_at` set and `restricted_until` null is never selected by a sweep reading `restricted_until <= now()`: hidden from every read path, immutable, and never erased. A permanently invisible record from one forgotten assignment.
- **`restricted_until > restricted_at`.** A window that closed before it opened erases immediately, which looks exactly like the feature working.
- The stamp carries its own timestamp, or neither is trustworthy.
- Only a stamped row may be restricted.

**0289 — the guard and the evidence.** The trigger is `BEFORE UPDATE OR DELETE` because DEPACK-AC-5a puts the immutability below every role, admin included, so it cannot live in a handler. It returns **`OLD`** on a permitted DELETE — `NEW` is null there, and returning it would block every delete of every row rather than only restricted ones.

`activity_retention_evidence` exists because the obvious implementation joins `activity_link` to `deal` at read time, and that **answers wrongly and silently**: the link CASCADEs on deal delete, a relink drops it, a won deal can be reopened, a deal can be renamed. A controller asking "why is this record held?" six months later would get an empty answer about a correctly-held record — in front of a supervisory authority. So `deal_name` is frozen at qualification and `deal_id` is `ON DELETE SET NULL`.

That last point produced the one real bug found while building this: the derived-basis CHECK originally required `deal_id IS NOT NULL`, which made **deleting a deal fail against its own evidence**. It requires the frozen name instead.

**Verified against Postgres, not just compiled:**

| | |
|---|---|
| ordinary row | still updates and deletes (the `RETURN OLD` path) |
| restricted row | refuses both update and delete |
| expiry sweep | can still lift the restriction and erase the body |
| controller pin, no deal | accepted — supplier correspondence, DEPACK-AC-5h |
| deal deleted | evidence survives with the frozen name |
| each of the 4 CHECKs | fires on its own violation, verified individually |

Migration numbers checked against `origin/main` (highest 0287, which is #1559 merged an hour ago).

Gates: `make check-backend` exit 0, `make craft-static`, `make rls-store-path`, `make no-jurisdiction` all green.

Part of #1557.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a write-once statutory retention stamp and an immutable restriction window to `activity`, and records the evidence that qualified a row for statutory retention. No behavior changes yet: nothing writes these fields and the retention floor still shields by exclusion. Part of #1557.

- Schema: add `retention_class`/`retention_class_at`, `restricted_at`/`restricted_reason`/`restricted_until`, and `redacted_fields` to `activity`, plus a partial index on `restricted_until`. CHECKs enforce the complete restriction triple, a valid window, stamp-with-timestamp, and “restriction requires stamp.”
- Guards: trigger `activity_refuse_restricted_mutation` makes the class and timestamp write-once, forbids updates/deletes on restricted rows (returns OLD on permitted DELETE), and refuses setting a restriction without evidence.
- Evidence: new `activity_retention_evidence` freezes the basis (includes frozen `deal_name`, `deal_id ON DELETE SET NULL`, optional controller pin attribution). An immutability trigger allows only FK nulling and CASCADE; a unique index with NULLS NOT DISTINCT prevents duplicate derived rows; FK columns are indexed.
- Rollout: apply migrations 0288–0289. Do not unset `retention_class` or write to restricted rows; the database will error. Keep retention selectors excluding restricted rows.

<sup>Written for commit a0d419957f67144892a3a5c843e174d5be382dfb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1571?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

