### PR TITLE
fix(frontend): the audit-action union carries the three verbs 0287 added

### DIFF
--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -14484,7 +14484,7 @@ export interface components {
              */
             on_behalf_of?: string | null;
             /** @enum {string} */
-            action: "create" | "update" | "archive" | "merge" | "promote" | "demote" | "disqualify" | "restore" | "export" | "erase" | "anonymize" | "assign" | "advance_stage" | "advance_phase" | "send_email" | "consent_grant" | "consent_withdraw" | "approve" | "reject" | "record_share" | "record_unshare" | "activity_relink" | "import" | "import_undo" | "reset_data" | "password_link_issued" | "connect" | "disconnect" | "schedule" | "reschedule" | "cancel" | "release" | "hold" | "expire";
+            action: "create" | "update" | "archive" | "merge" | "promote" | "demote" | "disqualify" | "restore" | "export" | "erase" | "anonymize" | "assign" | "advance_stage" | "advance_phase" | "send_email" | "consent_grant" | "consent_withdraw" | "approve" | "reject" | "record_share" | "record_unshare" | "activity_relink" | "import" | "import_undo" | "reset_data" | "password_link_issued" | "connect" | "disconnect" | "schedule" | "reschedule" | "cancel" | "release" | "hold" | "expire" | "resolve" | "restrict" | "pin";
             entity_type: string;
             /**
              * Format: uuid


### PR DESCRIPTION
**Main is red.** The `Release` workflow fails at `tsc` in the docker build.

`crm.yaml` gained `resolve`, `restrict` and `pin` in #1559. `make gen` regenerates the Go contracts but **not** the frontend's `schema.d.ts` — that is `pnpm gen:api`, a separate step. So the checked-in union was three verbs short, and `settings.tsx:2367` could not assign an `AuditLogEntry` the API can now return.

Nothing about the backend change was wrong. The generated frontend copy had simply not been regenerated alongside it.

Gates: `make check-fe` exit 0 (biome, vitest, tsc, build).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the frontend audit action union to include "resolve", "restrict", and "pin" in `schema.d.ts`, aligning with backend `crm.yaml`. This fixes the Release workflow `tsc` failure on `main` caused by missing verbs in the union.

- Only `frontend/src/api/schema.d.ts` is regenerated via `pnpm gen:api`; no backend changes.
- Types now accept API responses that include the three new verbs; runtime behavior is unchanged.
- Gates: `make check-fe` passes (`biome`, `vitest`, `tsc`, build).
- Required action: run `pnpm gen:api` whenever `crm.yaml` changes to keep frontend types in sync.

<sup>Written for commit 6cd150fff9d5f003c0be4f3a20885d7b40502127. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1574?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

