### PR TITLE
fix(frontend): regenerate the contract types, so main's composed typecheck passes

### DIFF
--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -14484,7 +14484,7 @@ export interface components {
              */
             on_behalf_of?: string | null;
             /** @enum {string} */
-            action: "create" | "update" | "archive" | "merge" | "promote" | "demote" | "disqualify" | "restore" | "export" | "erase" | "anonymize" | "assign" | "advance_stage" | "advance_phase" | "send_email" | "consent_grant" | "consent_withdraw" | "approve" | "reject" | "record_share" | "record_unshare" | "activity_relink" | "import" | "import_undo" | "reset_data" | "password_link_issued" | "connect" | "disconnect" | "schedule" | "reschedule" | "cancel" | "release" | "hold" | "expire";
+            action: "create" | "update" | "archive" | "merge" | "promote" | "demote" | "disqualify" | "restore" | "export" | "erase" | "anonymize" | "assign" | "advance_stage" | "advance_phase" | "send_email" | "consent_grant" | "consent_withdraw" | "approve" | "reject" | "record_share" | "record_unshare" | "activity_relink" | "import" | "import_undo" | "reset_data" | "password_link_issued" | "connect" | "disconnect" | "schedule" | "reschedule" | "cancel" | "release" | "hold" | "expire" | "resolve" | "restrict" | "pin";
             entity_type: string;
             /**
              * Format: uuid


### PR DESCRIPTION
One regenerated line. `main` is currently red on `fe-typecheck-composed`, so every open PR inherits two errors in screens its author never touched.

## Reproduced on main, not on a branch

```
$ git switch --detach origin/main      # a82b1cc6
$ make fe-typecheck-composed
src/screens/customfields.tsx(820,13): error TS2322
src/screens/settings.tsx(2367,37): error TS2322
```

Both are the same shape: an audit-log row typed by the **committed** `frontend/src/api/schema.d.ts` passed where the **composed** schema is expected, and the two disagree about the `action` enum — 33 values against 36, differing by `pin`, `resolve` and the rest of the restricted/pinned work.

`git show origin/main:frontend/src/api/schema.d.ts | grep -c '"resolve"'` → **0**, while the composed contract mentions it 117 times.

## Cause

The audit-action work ([#1559](https://github.com/gradionhq/margince-poc-v1/pull/1559), [#1571](https://github.com/gradionhq/margince-poc-v1/pull/1571)) landed the backend and contract halves without regenerating the frontend schema. That file comes from `backend/api/crm.yaml` via `pnpm gen:api`; the composed lane generates from `build/composition/api/crm.yaml`.

**The gate caught it.** #1559 merged with `fe-quality` = `FAILURE`, so this is not a missing check — `fe-drift` regenerates and diffs exactly this file. Recorded on [#1573](https://github.com/gradionhq/margince-poc-v1/issues/1573) along with the observation that it is the second such case today; [#1512](https://github.com/gradionhq/margince-poc-v1/pull/1512) repaired a duplicate migration version whose author noted the same thing about the `migration-versions` gate.

## Verification

- `make fe-typecheck-composed`: 2 errors → **0**
- `make check-fe`: **green**
- Diff is one line, the `action` enum, entirely generated

Found while rebasing [#1570](https://github.com/gradionhq/margince-poc-v1/pull/1570), whose own diff is frontend-only and touches no contract — it inherited both errors and neither pointed anywhere near it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Regenerates the generated API types so the audit-log `action` enum matches the composed contract, restoring a green `fe-typecheck-composed` on `main`. Previously, the frontend schema missed `resolve`, `restrict`, and `pin`, causing two unrelated screens to fail typecheck.

**Impact and review notes**
- Single generated change in `frontend/src/api/schema.d.ts`: adds `resolve`, `restrict`, `pin` to the `action` enum.
- No runtime or UI changes; aligns generated types with `build/composition/api/crm.yaml`.
- Verified: `make fe-typecheck-composed` and `make check-fe` pass.

<sup>Written for commit 22b5ad78c56c13f45bcfa8f05bd321d16176543d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1575?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

