### PR TITLE
fix(frontend): the generated contract types carry the three audit actions the spec already has

### DIFF
--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -14484,7 +14484,7 @@ export interface components {
              */
             on_behalf_of?: string | null;
             /** @enum {string} */
-            action: "create" | "update" | "archive" | "merge" | "promote" | "demote" | "disqualify" | "restore" | "export" | "erase" | "anonymize" | "assign" | "advance_stage" | "advance_phase" | "send_email" | "consent_grant" | "consent_withdraw" | "approve" | "reject" | "record_share" | "record_unshare" | "activity_relink" | "import" | "import_undo" | "reset_data" | "password_link_issued" | "connect" | "disconnect" | "schedule" | "reschedule" | "cancel" | "release" | "hold" | "expire";
+            action: "create" | "update" | "archive" | "merge" | "promote" | "demote" | "disqualify" | "restore" | "export" | "erase" | "anonymize" | "assign" | "advance_stage" | "advance_phase" | "send_email" | "consent_grant" | "consent_withdraw" | "approve" | "reject" | "record_share" | "record_unshare" | "activity_relink" | "import" | "import_undo" | "reset_data" | "password_link_issued" | "connect" | "disconnect" | "schedule" | "reschedule" | "cancel" | "release" | "hold" | "expire" | "resolve" | "restrict" | "pin";
             entity_type: string;
             /**
              * Format: uuid


### PR DESCRIPTION
## main is red, and so is every frontend PR

`fe-quality` fails on `origin/main` with no PR involved. Reproduced on a clean detached worktree at `origin/main`:

```
src/screens/customfields.tsx(820,13): error TS2322: ... action: "cancel" | ... 35 more ... | "pin"
  is not assignable to ...  action: "cancel" | ... 32 more ... | "expire"
src/screens/settings.tsx(2367,37): error TS2322: ... same
make: *** [Makefile:398: fe-typecheck-composed] Error 2
```

`fe-quality` is a `needs:` of the required **frontend (biome + vitest + tsc + build)** check, so nothing frontend can merge until this lands.

## Cause

The statutory-retention work (#1559, #1571 — A165/ADR-0114) added `resolve`, `restrict` and `pin` to the `AuditLogEntry.action` enum in `backend/api/crm.yaml`, but the regenerated `frontend/src/api/schema.d.ts` was never committed.

The vanilla lane cannot see it: both sides of every vanilla comparison read the same stale type, so it is internally consistent. The **composed** lane generates its own types from the extension-composed spec, which does carry all three — and two screens then hand a composed-typed audit row to a component whose prop is typed from the stale vanilla schema. Hence the enum mismatch.

## Why the error message does not say any of that

`fe-drift` is the check that diagnoses this in one line — *"frontend types drifted from the backend contracts — commit the regenerated src/api/*.d.ts"*. But `fe-typecheck-composed` is a **prerequisite** of the `fe-quality` target rather than a step inside it:

```make
fe-quality: fe-typecheck-composed
	$(MAKE) fe-ds-gates
	$(MAKE) fe-drift
	...
```

so the run dies on the downstream symptom before reaching the check that names the cause. Left as-is here — reordering it is a separate judgement about that target, not part of unbreaking main.

## The change

One line, and only what `pnpm gen:api` produces:

```diff
-action: … | "hold" | "expire";
+action: … | "hold" | "expire" | "resolve" | "restrict" | "pin";
```

## Verification

`make fe-quality` and `make check-fe` both exit 0 on this branch. Both fail on `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Regenerates `frontend/src/api/schema.d.ts` so `AuditLogEntry.action` includes `resolve`, `restrict`, and `pin`, matching the backend spec. Previously the frontend enum lacked these values, causing `fe-typecheck-composed` to fail and blocking the required `fe-quality` check; now typecheck and build pass.

**Review Notes**
- Single generated change: add `"resolve" | "restrict" | "pin"` to `AuditLogEntry.action`.
- No runtime behavior changes; resolves enum mismatch in `customfields.tsx` and `settings.tsx`.
- Aligns vanilla-generated types with the composed spec already in use; CI `fe-quality` should turn green after merge.

<sup>Written for commit 348fe8607f9056336cc345a9eaa1416c63fe9a17. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1576?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

