### PR TITLE
fix(privacy): lifting a restriction erases, and a deadline never shortens

### DIFF
--- a/backend/migrations/core/0290_restriction_lift_must_erase.down.sql
+++ b/backend/migrations/core/0290_restriction_lift_must_erase.down.sql
@@ -1,0 +1,39 @@
+-- Back to 0289's function: a lift need not erase, and a deadline may shorten.
+-- Reverting reopens both holes; it is the honest inverse and nothing else.
+CREATE OR REPLACE FUNCTION activity_refuse_restricted_mutation() RETURNS trigger
+LANGUAGE plpgsql AS $$
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    IF OLD.restricted_at IS NOT NULL THEN
+      RAISE EXCEPTION 'activity % is restricted under a statutory retention obligation until %', OLD.id, OLD.restricted_until
+        USING ERRCODE = 'check_violation',
+              CONSTRAINT = 'activity_restricted_immutable';
+    END IF;
+    RETURN OLD;
+  END IF;
+
+  IF OLD.retention_class IS NOT NULL
+     AND (NEW.retention_class IS DISTINCT FROM OLD.retention_class
+          OR NEW.retention_class_at IS DISTINCT FROM OLD.retention_class_at) THEN
+    RAISE EXCEPTION 'activity % carries retention class % earned at %, which is stamped once and never re-derived', OLD.id, OLD.retention_class, OLD.retention_class_at
+      USING ERRCODE = 'check_violation',
+            CONSTRAINT = 'activity_retention_class_monotonic';
+  END IF;
+
+  IF OLD.restricted_at IS NULL AND NEW.restricted_at IS NOT NULL
+     AND NOT EXISTS (SELECT 1 FROM activity_retention_evidence e
+                      WHERE e.activity_id = NEW.id) THEN
+    RAISE EXCEPTION 'activity % cannot be restricted with no retention evidence recording what qualified it', NEW.id
+      USING ERRCODE = 'check_violation',
+            CONSTRAINT = 'activity_restriction_needs_evidence';
+  END IF;
+
+  IF OLD.restricted_at IS NOT NULL AND NEW.restricted_at IS NOT NULL THEN
+    RAISE EXCEPTION 'activity % is restricted under a statutory retention obligation until %', OLD.id, OLD.restricted_until
+      USING ERRCODE = 'check_violation',
+            CONSTRAINT = 'activity_restricted_immutable';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;

--- a/backend/migrations/core/0290_restriction_lift_must_erase.up.sql
+++ b/backend/migrations/core/0290_restriction_lift_must_erase.up.sql
@@ -1,0 +1,88 @@
+-- 0290: lifting a restriction is an ERASURE, and a deadline never shortens.
+--
+-- 0289 let a restricted row be written only by a statement that CLEARS
+-- restricted_at, on the reasoning that the expiry sweep and the audited
+-- release are both that shape. They are — but so is a bare
+-- `UPDATE activity SET restricted_at = NULL`, which lifts the obligation and
+-- leaves the subject's correspondence sitting there fully readable. That makes
+-- the restriction reversible by anyone who can write the row, which is exactly
+-- what Recital 67 forbids: restricted data must be unavailable to users and
+-- not further processed, not merely flagged.
+--
+-- Both legitimate paths destroy the content as they lift. The expiry sweep
+-- completes the suspended Art. 17 request; the audited release erases the
+-- record with a stated reason (A165/ADR-0114 §4). Neither has any use for a
+-- lift that keeps the body. So the lift must carry the erasure with it, in the
+-- same statement, and the trigger is where that is enforceable.
+--
+-- The second hole is the deadline. Nothing stopped a lifted row being
+-- re-restricted with a nearer restricted_until, so the pin that A165 says
+-- never shortens an obligation already recorded could shorten it in two steps.
+-- A re-restriction of a row that still carries its class must land no earlier
+-- than the deadline it had.
+CREATE OR REPLACE FUNCTION activity_refuse_restricted_mutation() RETURNS trigger
+LANGUAGE plpgsql AS $$
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    IF OLD.restricted_at IS NOT NULL THEN
+      RAISE EXCEPTION 'activity % is restricted under a statutory retention obligation until %', OLD.id, OLD.restricted_until
+        USING ERRCODE = 'check_violation',
+              CONSTRAINT = 'activity_restricted_immutable';
+    END IF;
+    RETURN OLD;
+  END IF;
+
+  -- The stamp never changes once written — the class OR the timestamp saying
+  -- when it was earned. Leaving the timestamp mutable would let a writer keep
+  -- the class and move the date: the same rewriting of history with an extra
+  -- step, on the field a supervisory authority would be shown.
+  IF OLD.retention_class IS NOT NULL
+     AND (NEW.retention_class IS DISTINCT FROM OLD.retention_class
+          OR NEW.retention_class_at IS DISTINCT FROM OLD.retention_class_at) THEN
+    RAISE EXCEPTION 'activity % carries retention class % earned at %, which is stamped once and never re-derived', OLD.id, OLD.retention_class, OLD.retention_class_at
+      USING ERRCODE = 'check_violation',
+            CONSTRAINT = 'activity_retention_class_monotonic';
+  END IF;
+
+  -- A restriction is substantiated at the moment it is written. The table
+  -- CHECK sees only this row, so it can require a class and no more; the
+  -- evidence is in another table and this is the only place that can look.
+  IF OLD.restricted_at IS NULL AND NEW.restricted_at IS NOT NULL
+     AND NOT EXISTS (SELECT 1 FROM activity_retention_evidence e
+                      WHERE e.activity_id = NEW.id) THEN
+    RAISE EXCEPTION 'activity % cannot be restricted with no retention evidence recording what qualified it', NEW.id
+      USING ERRCODE = 'check_violation',
+            CONSTRAINT = 'activity_restriction_needs_evidence';
+  END IF;
+
+  -- A deadline already recorded never moves nearer. A pin or a re-restriction
+  -- of a row that still carries its class may only extend it.
+  IF OLD.restricted_until IS NOT NULL AND NEW.restricted_at IS NOT NULL
+     AND NEW.restricted_until < OLD.restricted_until THEN
+    RAISE EXCEPTION 'activity % is held until % and a statutory deadline never shortens', OLD.id, OLD.restricted_until
+      USING ERRCODE = 'check_violation',
+            CONSTRAINT = 'activity_restriction_never_shortens';
+  END IF;
+
+  IF OLD.restricted_at IS NOT NULL THEN
+    -- Still restricted after the write: refused outright.
+    IF NEW.restricted_at IS NOT NULL THEN
+      RAISE EXCEPTION 'activity % is restricted under a statutory retention obligation until %', OLD.id, OLD.restricted_until
+        USING ERRCODE = 'check_violation',
+              CONSTRAINT = 'activity_restricted_immutable';
+    END IF;
+
+    -- Lifting: the content goes with it, in this statement. Both legitimate
+    -- callers erase as they lift, and a lift that leaves the body readable is
+    -- not a completion of the erasure — it is a way to undo the restriction
+    -- and keep the data.
+    IF NEW.body IS NOT NULL OR NEW.subject IS NOT NULL OR NEW.raw IS NOT NULL THEN
+      RAISE EXCEPTION 'activity % may only leave restriction by being erased: clear body, subject and raw in the same statement', OLD.id
+        USING ERRCODE = 'check_violation',
+              CONSTRAINT = 'activity_restriction_lift_erases';
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;


### PR DESCRIPTION
A security review of #1571 found two holes in 0289's guard. Both confirmed against Postgres before and after.

**1. The restriction was reversible, and lifting it left the data readable.**

0289 allowed a restricted row to be written only by a statement that CLEARS `restricted_at`, reasoning that the expiry sweep and the audited release are both that shape. They are — but so is a bare `UPDATE activity SET restricted_at = NULL`, which lifts the obligation and leaves the subject's correspondence sitting there **fully readable**.

That makes the restriction reversible by anyone who can write the row, which is precisely what Recital 67 forbids: restricted data must be unavailable to users and not further processed, not merely flagged. Both legitimate callers destroy the content as they lift — the expiry sweep completes the suspended Art. 17 request, the audited release erases with a stated reason (A165/ADR-0114 §4). Neither has any use for a lift that keeps the body, so the lift now has to carry the erasure in the same statement.

**2. A statutory deadline could be shortened in two steps.**

Nothing stopped a lifted row being re-restricted with a nearer `restricted_until`. A165 says a recorded obligation never shortens; it could, via lift-then-re-restrict. A re-restriction of a row still carrying its class must now land no earlier than the deadline it had.

**Verified:**

| | |
|---|---|
| bare lift keeping the body | refused |
| shortened deadline | refused |
| expiry sweep lifting **and** erasing together | still works |

Gates: `make check-backend` exit 0, `make craft-static` clean.

Follows #1571. Part of #1557.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces that lifting a retention restriction also erases content, and prevents statutory deadlines from being shortened via lift-then-restrict. Previously, clearing `restricted_at` left data readable and a re-restriction could set a nearer `restricted_until`.

- Lifting a restriction must clear `body`, `subject`, and `raw` in the same statement; bare lifts are refused (`activity_restriction_lift_erases`).
- Re-restricting a row that still carries its retention class cannot set `restricted_until` earlier than its existing deadline (`activity_restriction_never_shortens`).
- Existing guards remain: restricted rows cannot be deleted or rewritten as restricted; `retention_class` and `retention_class_at` are immutable; new restrictions require evidence.

**Rollout**
- Update any code paths or SQL that lift restrictions (e.g., `UPDATE activity SET restricted_at = NULL`) to also NULL `body`, `subject`, and `raw`.
- No changes required for the expiry sweep or audited release; both already erase on lift.

<sup>Written for commit c44a0c469d1bef7a8c384f81004e3ad17342f34e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1578?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

