### PR TITLE
fix(privacy): the lift clears the subject's own address, not just the content

### DIFF
--- a/backend/migrations/core/0291_lift_clears_counterparty.down.sql
+++ b/backend/migrations/core/0291_lift_clears_counterparty.down.sql
@@ -1,0 +1,67 @@
+-- Back to 0290's function, where a lift could leave the subject's address behind.
+CREATE OR REPLACE FUNCTION activity_refuse_restricted_mutation() RETURNS trigger
+LANGUAGE plpgsql AS $$
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    IF OLD.restricted_at IS NOT NULL THEN
+      RAISE EXCEPTION 'activity % is restricted under a statutory retention obligation until %', OLD.id, OLD.restricted_until
+        USING ERRCODE = 'check_violation',
+              CONSTRAINT = 'activity_restricted_immutable';
+    END IF;
+    RETURN OLD;
+  END IF;
+
+  -- The stamp never changes once written — the class OR the timestamp saying
+  -- when it was earned. Leaving the timestamp mutable would let a writer keep
+  -- the class and move the date: the same rewriting of history with an extra
+  -- step, on the field a supervisory authority would be shown.
+  IF OLD.retention_class IS NOT NULL
+     AND (NEW.retention_class IS DISTINCT FROM OLD.retention_class
+          OR NEW.retention_class_at IS DISTINCT FROM OLD.retention_class_at) THEN
+    RAISE EXCEPTION 'activity % carries retention class % earned at %, which is stamped once and never re-derived', OLD.id, OLD.retention_class, OLD.retention_class_at
+      USING ERRCODE = 'check_violation',
+            CONSTRAINT = 'activity_retention_class_monotonic';
+  END IF;
+
+  -- A restriction is substantiated at the moment it is written. The table
+  -- CHECK sees only this row, so it can require a class and no more; the
+  -- evidence is in another table and this is the only place that can look.
+  IF OLD.restricted_at IS NULL AND NEW.restricted_at IS NOT NULL
+     AND NOT EXISTS (SELECT 1 FROM activity_retention_evidence e
+                      WHERE e.activity_id = NEW.id) THEN
+    RAISE EXCEPTION 'activity % cannot be restricted with no retention evidence recording what qualified it', NEW.id
+      USING ERRCODE = 'check_violation',
+            CONSTRAINT = 'activity_restriction_needs_evidence';
+  END IF;
+
+  -- A deadline already recorded never moves nearer. A pin or a re-restriction
+  -- of a row that still carries its class may only extend it.
+  IF OLD.restricted_until IS NOT NULL AND NEW.restricted_at IS NOT NULL
+     AND NEW.restricted_until < OLD.restricted_until THEN
+    RAISE EXCEPTION 'activity % is held until % and a statutory deadline never shortens', OLD.id, OLD.restricted_until
+      USING ERRCODE = 'check_violation',
+            CONSTRAINT = 'activity_restriction_never_shortens';
+  END IF;
+
+  IF OLD.restricted_at IS NOT NULL THEN
+    -- Still restricted after the write: refused outright.
+    IF NEW.restricted_at IS NOT NULL THEN
+      RAISE EXCEPTION 'activity % is restricted under a statutory retention obligation until %', OLD.id, OLD.restricted_until
+        USING ERRCODE = 'check_violation',
+              CONSTRAINT = 'activity_restricted_immutable';
+    END IF;
+
+    -- Lifting: the content goes with it, in this statement. Both legitimate
+    -- callers erase as they lift, and a lift that leaves the body readable is
+    -- not a completion of the erasure — it is a way to undo the restriction
+    -- and keep the data.
+    IF NEW.body IS NOT NULL OR NEW.subject IS NOT NULL OR NEW.raw IS NOT NULL THEN
+      RAISE EXCEPTION 'activity % may only leave restriction by being erased: clear body, subject and raw in the same statement', OLD.id
+        USING ERRCODE = 'check_violation',
+              CONSTRAINT = 'activity_restriction_lift_erases';
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;

--- a/backend/migrations/core/0291_lift_clears_counterparty.up.sql
+++ b/backend/migrations/core/0291_lift_clears_counterparty.up.sql
@@ -1,0 +1,95 @@
+-- 0291: the lift clears the subject's own address too.
+--
+-- 0290 made lifting a restriction erase the CONTENT — body, subject, raw — and
+-- stopped there. counterparty_email survived, which is the subject's own email
+-- address sitting on a row whose whole purpose was to complete their Art. 17
+-- request. The content went and the identifier stayed, so the record still
+-- named the person who asked to be forgotten.
+--
+-- The real eraser already knows this: erasuretimeline.go nulls
+-- counterparty_email in the same statement it clears the body. The guard was
+-- simply asking for less than the caller already does, and a guard that asks
+-- for less than the correct behaviour is one that will eventually admit the
+-- incorrect one.
+--
+-- source_id and thread_key are deliberately NOT required here. The eraser
+-- clears them only for channel rows, where they encode the subject's account
+-- id; on a mail row they are provider bookkeeping that names nobody, and
+-- demanding them unconditionally would refuse the erasure the module actually
+-- writes.
+CREATE OR REPLACE FUNCTION activity_refuse_restricted_mutation() RETURNS trigger
+LANGUAGE plpgsql AS $$
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    IF OLD.restricted_at IS NOT NULL THEN
+      RAISE EXCEPTION 'activity % is restricted under a statutory retention obligation until %', OLD.id, OLD.restricted_until
+        USING ERRCODE = 'check_violation',
+              CONSTRAINT = 'activity_restricted_immutable';
+    END IF;
+    RETURN OLD;
+  END IF;
+
+  -- The stamp never changes once written — the class OR the timestamp saying
+  -- when it was earned. Leaving the timestamp mutable would let a writer keep
+  -- the class and move the date: the same rewriting of history with an extra
+  -- step, on the field a supervisory authority would be shown.
+  IF OLD.retention_class IS NOT NULL
+     AND (NEW.retention_class IS DISTINCT FROM OLD.retention_class
+          OR NEW.retention_class_at IS DISTINCT FROM OLD.retention_class_at) THEN
+    RAISE EXCEPTION 'activity % carries retention class % earned at %, which is stamped once and never re-derived', OLD.id, OLD.retention_class, OLD.retention_class_at
+      USING ERRCODE = 'check_violation',
+            CONSTRAINT = 'activity_retention_class_monotonic';
+  END IF;
+
+  -- A restriction is substantiated at the moment it is written. The table
+  -- CHECK sees only this row, so it can require a class and no more; the
+  -- evidence is in another table and this is the only place that can look.
+  IF OLD.restricted_at IS NULL AND NEW.restricted_at IS NOT NULL
+     AND NOT EXISTS (SELECT 1 FROM activity_retention_evidence e
+                      WHERE e.activity_id = NEW.id) THEN
+    RAISE EXCEPTION 'activity % cannot be restricted with no retention evidence recording what qualified it', NEW.id
+      USING ERRCODE = 'check_violation',
+            CONSTRAINT = 'activity_restriction_needs_evidence';
+  END IF;
+
+  -- A deadline already recorded never moves nearer. A pin or a re-restriction
+  -- of a row that still carries its class may only extend it.
+  IF OLD.restricted_until IS NOT NULL AND NEW.restricted_at IS NOT NULL
+     AND NEW.restricted_until < OLD.restricted_until THEN
+    RAISE EXCEPTION 'activity % is held until % and a statutory deadline never shortens', OLD.id, OLD.restricted_until
+      USING ERRCODE = 'check_violation',
+            CONSTRAINT = 'activity_restriction_never_shortens';
+  END IF;
+
+  IF OLD.restricted_at IS NOT NULL THEN
+    -- Still restricted after the write: refused outright.
+    IF NEW.restricted_at IS NOT NULL THEN
+      RAISE EXCEPTION 'activity % is restricted under a statutory retention obligation until %', OLD.id, OLD.restricted_until
+        USING ERRCODE = 'check_violation',
+              CONSTRAINT = 'activity_restricted_immutable';
+    END IF;
+
+    -- Lifting: the content goes with it, in this statement. Both legitimate
+    -- callers erase as they lift, and a lift that leaves the body readable is
+    -- not a completion of the erasure — it is a way to undo the restriction
+    -- and keep the data.
+    IF NEW.body IS NOT NULL OR NEW.raw IS NOT NULL
+       OR NEW.counterparty_email IS NOT NULL
+       -- The subject must not survive AS IT WAS. It may go null or be replaced
+       -- by the erasure's tombstone name — erasuretimeline.go writes the
+       -- placeholder rather than a null, so demanding null here would refuse
+       -- the very statement this guard exists to admit. The test is that it
+       -- CHANGED, which the placeholder satisfies and keeping the original
+       -- does not. Spelling the placeholder's literal value here would be a
+       -- second copy of a Go constant, drifting the first time somebody edits
+       -- one of them.
+       OR (OLD.subject IS NOT NULL AND NEW.subject IS NOT DISTINCT FROM OLD.subject) THEN
+      RAISE EXCEPTION 'activity % may only leave restriction by being erased: clear body, raw and counterparty_email, and replace the subject, in the same statement', OLD.id
+        USING ERRCODE = 'check_violation',
+              CONSTRAINT = 'activity_restriction_lift_erases';
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;


### PR DESCRIPTION
A second security review of #1578 found the erasure incomplete, and writing the fix exposed a worse defect in #1578 that no test had caught.

**The reported finding.** 0290 made lifting a restriction erase `body`, `subject` and `raw`, and stopped there. `counterparty_email` survived — the subject's own email address, left sitting on a row whose entire purpose was to complete their Art. 17 request. The content went and the identifier stayed, so the record still named the person who asked to be forgotten.

`erasuretimeline.go:54` already nulls it in the same statement it clears the body. The guard was asking for **less than the caller already does**, and a guard that asks for less than the correct behaviour eventually admits the incorrect one.

**The defect that finding uncovered.** 0290 demanded `subject IS NULL`. The real eraser sets the subject to a tombstone placeholder (`erasure.go:34`) rather than nulling it — so **the guard would have refused the production statement** the first time an erasure met a restricted row. The restriction feature would have failed closed on its own erasure path.

It now requires the subject to have *changed*, which the placeholder satisfies and keeping the original does not. It tests for change rather than naming the placeholder, because spelling a Go constant's value in SQL is a second copy that drifts the first time somebody edits one of them.

`source_id` and `thread_key` are deliberately **not** required. The eraser clears them only for channel rows, where they encode the subject's account id; on a mail row they are provider bookkeeping that names nobody, and demanding them unconditionally would refuse the erasure the module actually writes.

**Verified against the real eraser's statement shape**, not a hand-written approximation — which is the only reason the subject-placeholder defect surfaced before it shipped.

| | |
|---|---|
| real eraser shape (subject → tombstone) | admitted |
| lift keeping the original subject | refused |
| lift leaving `counterparty_email` | refused |

Gates: `make check-backend` exit 0, `make craft-static` clean.

Follows #1578. Part of #1557.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the restriction-lift guard so lifting a retention restriction also clears the subject’s email and accepts a tombstoned subject. Previously, the guard only required body/subject/raw to be cleared and demanded subject IS NULL, which left `counterparty_email` intact and rejected the real eraser’s write.

**Review and rollout**
- Replaces trigger `activity_refuse_restricted_mutation()` to refuse a lift unless `body` and `raw` are NULL, `counterparty_email` is NULL, and `subject` changed (tombstone allowed); keeping the original subject now fails with `activity_restriction_lift_erases`.
- Does not require clearing `source_id` and `thread_key` (only channel rows encode identity there).
- Adds migration `0291` (up/down). Action: run the migration; no data backfill required.

<sup>Written for commit c5c91baab8395330d3f3ae9c22dc8e89ba90f6b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1582?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

