### PR TITLE
feat(uploads): how large a file this installation takes is the operator's number, not the build's

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -12858,7 +12858,7 @@ components:
       description: |
         The installation's identity and reporting basis (ADR-0090/A135). Read by every role,
         changed only by admin/ops.
-      required: [name, timezone, base_currency, base_currency_locked]
+      required: [name, timezone, base_currency, base_currency_locked, max_upload_bytes]
       properties:
         name:
           type: string
@@ -12881,6 +12881,18 @@ components:
           description: |
             Why the currency is locked, naming how many deals have already converted against
             it. Absent when it is still changeable.
+        max_upload_bytes:
+          type: integer
+          format: int64
+          description: |
+            The largest upload request this installation accepts, in bytes — set by whoever
+            operates it, not compiled into the build (OPS-CFG-12, DOC-PARAM-11). Read-only:
+            it is a deployment fact, so PATCH does not carry it.
+
+            An upload surface states and enforces THIS number rather than one of its own, so
+            a file too large is refused before it is sent instead of after. The ceiling bounds
+            the whole request, part framing included, which is why a client should leave a
+            little room rather than compare a file against it exactly.
     UpdateInstallationSettingsRequest:
       type: object
       description: A sparse installation-settings patch (admin/ops, human-only).

--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -11734,7 +11734,8 @@ paths:
   # Every one is human-only (IEM-WIRE-7 / A139): an import is the least
   # reversible write in the product, and a confirm-first gate over a
   # thousand-row dry-run report is a rubber stamp that manufactures evidence of
-  # review. Rate class RL-BULK-WRITE; body cap CAP-BODY (10 MB, import only).
+  # review. Rate class RL-BULK-WRITE; body cap CAP-BODY (import only, 10 MB by
+  # default and set per installation — `uploads.csv_import_mb`, OPS-CFG-12).
   # =========================================================================
   /imports/sources:
     post:
@@ -11777,7 +11778,11 @@ paths:
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/PermissionDenied' }
         '413':
-          description: 'The upload exceeds the 10 MB import body cap (CAP-BODY). A distinct refusal, never a truncated read.'
+          description: |
+            The upload exceeds this installation's import body cap (CAP-BODY) — 10 MB by default,
+            set by whoever operates it (`uploads.csv_import_mb`, OPS-CFG-12). The refusal NAMES the
+            configured number rather than one compiled in, and it is a distinct refusal, never a
+            truncated read that imports half an estate and reports success.
           content:
             application/problem+json:
               schema: { $ref: '#/components/schemas/Problem' }

--- a/backend/cmd/api/boot.go
+++ b/backend/cmd/api/boot.go
@@ -116,6 +116,11 @@ func declaredSurfaceOptions(cfg apiConfig, deployCfg deployconfig.Config, pool, 
 		// zero value: an unconfigured `seeds` section means built-in defaults
 		// on both provisioning paths, which is the behaviour to preserve.
 		compose.WithBootstrapSeeds(deployCfg.Seeds),
+		// The per-route upload ceilings (OPS-CFG-12). Always applied, including
+		// for a file with no `uploads` section: EffectiveUploads resolves the
+		// compiled-in defaults, so this stays the one place the numbers are
+		// decided either way.
+		compose.WithUploadLimits(deployCfg.EffectiveUploads()),
 	}
 	reset, err := newResetLane(allowDataReset, pool, rdb, logger)
 	if err != nil {

--- a/backend/internal/compose/bodyceiling.go
+++ b/backend/internal/compose/bodyceiling.go
@@ -6,9 +6,10 @@ package compose
 import (
 	"mime"
 	"net/http"
-	"strings"
 
+	"github.com/gradionhq/margince/backend/internal/platform/deployconfig"
 	"github.com/gradionhq/margince/backend/internal/platform/httperr"
+	"github.com/gradionhq/margince/backend/internal/platform/httpserver"
 )
 
 // Which routes carry FILES, and may therefore read a body wider than the JSON
@@ -18,41 +19,53 @@ import (
 // The list is short on purpose and is the whole grant: a route absent from it
 // cannot obtain the wider bound by any means, including claiming to be
 // multipart. That is the property being protected — several handlers in this
-// tree decode `r.Body` with no bound of their own and rely entirely on the
-// chassis for one, and two of those routes are unauthenticated (DCR and login).
-// Widening on the sender's Content-Type alone would have handed them 25 MiB
-// each for the price of a header.
+// tree decode `r.Body` with no bound of their own, and two of those routes are
+// unauthenticated (DCR and login). Widening on the sender's Content-Type alone
+// would have handed them the file bound each for the price of a header.
+//
+// The operator sets the NUMBERS (OPS-CFG-12, `uploads` in margince.yaml); this
+// function decides which route gets which one. Nobody chooses the list at run
+// time, which is what keeps the paragraph above true.
 //
 // Paths are as the generated router mounts them, under the /v1 prefix the
-// chassis sees. Keep this in step with the multipart handlers themselves;
-// TestEveryMultipartRouteIsDeclared derives the expected set from the tree so a
-// new upload route cannot be added without either appearing here or failing.
-var fileUploadRoutes = map[string]struct{}{
-	"/v1/attachments":             {}, // uploadAttachment
-	"/v1/imports/sources":         {}, // uploadImportSource
-	"/v1/me/linkedin-connections": {}, // importLinkedInConnections
+// chassis sees. TestEveryUploadRouteIsDeclared derives the expected set from
+// the contract, so a new upload route cannot be added without appearing here.
+func uploadCeilings(limits deployconfig.UploadLimits) map[string]int64 {
+	return map[string]int64{
+		"/v1/attachments":             limits.Attachment,     // uploadAttachment
+		"/v1/imports/sources":         limits.CSVImport,      // uploadImportSource
+		"/v1/me/linkedin-connections": limits.LinkedInImport, // importLinkedInConnections
+	}
 }
 
-// bodyCeiling is the chassis's BodyCeiling for this composition.
+// bodyCeilingFor is the chassis's BodyCeiling for this composition.
 //
 // THREE conditions, all required, because each closes a different door: the
 // method, so a GET cannot carry a wide body; the route, so only a declared
 // upload route can; and the media type, so an upload route handed JSON still
 // rides the tight bound. A request failing any of them gets the JSON ceiling.
-func bodyCeiling(r *http.Request) int64 {
-	if r.Method != http.MethodPost {
-		return httperr.MaxBodyBytes
+//
+// The path is matched exactly as the router mounts it, with no normalization of
+// our own. A trailing slash or an un-cleaned segment is a path the router does
+// not serve, and guessing at how it would resolve one is how a grant ends up
+// wider than the route list it was written from.
+func bodyCeilingFor(ceilings map[string]int64) httpserver.BodyCeiling {
+	return func(r *http.Request) int64 {
+		if r.Method != http.MethodPost {
+			return httperr.MaxBodyBytes
+		}
+		ceiling, declared := ceilings[r.URL.Path]
+		if !declared {
+			return httperr.MaxBodyBytes
+		}
+		// Compared as a parsed MEDIA TYPE, not as a prefix. A prefix match also
+		// accepts `multipart/form-dataX`, which `ParseMultipartForm` then rejects —
+		// so the chassis and the parser would disagree about what a multipart body
+		// is, and the sender would pick which one won.
+		mediaType, _, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+		if err != nil || mediaType != "multipart/form-data" {
+			return httperr.MaxBodyBytes
+		}
+		return ceiling
 	}
-	if _, ok := fileUploadRoutes[strings.TrimSuffix(r.URL.Path, "/")]; !ok {
-		return httperr.MaxBodyBytes
-	}
-	// Compared as a parsed MEDIA TYPE, not as a prefix. A prefix match also
-	// accepts `multipart/form-dataX`, which `ParseMultipartForm` then rejects —
-	// so the chassis and the parser would disagree about what a multipart body
-	// is, and the sender would pick which one won.
-	mediaType, _, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
-	if err != nil || mediaType != "multipart/form-data" {
-		return httperr.MaxBodyBytes
-	}
-	return httperr.MaxMultipartBodyBytes
 }

--- a/backend/internal/compose/bodyceiling_test.go
+++ b/backend/internal/compose/bodyceiling_test.go
@@ -6,12 +6,9 @@ package compose
 import (
 	"net/http"
 	"net/http/httptest"
-	"os"
-	"path/filepath"
-	"regexp"
-	"strings"
 	"testing"
 
+	"github.com/gradionhq/margince/backend/internal/platform/deployconfig"
 	"github.com/gradionhq/margince/backend/internal/platform/httperr"
 )
 
@@ -19,10 +16,23 @@ import (
 // it is addressed to, never by what the sender says the body is.
 //
 // The version of this that shipped chose on Content-Type alone, which handed
-// the 25 MiB bound to every route in the product. Several decode `r.Body` with
+// the file bound to every route in the product. Several decode `r.Body` with
 // no bound of their own — `/oauth/register` and `/v1/auth/login` among them,
 // both unauthenticated — so a one-header lie was a 25x memory amplification on
 // an anonymous endpoint. `TestALyingContentTypeBuysNothing` is that attack.
+//
+// The declaration gates — that the ceiling table matches the routes which
+// actually carry files — live in bodyceilingcensus_test.go.
+
+// testLimits are deliberately three DIFFERENT numbers, none of them a shipped
+// default. A test that gives every route the same ceiling passes just as
+// happily against a table that hands every route the same one, and a table
+// wired to the wrong field is the likelier mistake than one wired to nothing.
+var testLimits = deployconfig.UploadLimits{
+	Attachment:     31_000_000,
+	CSVImport:      12_000_000,
+	LinkedInImport: 7_000_000,
+}
 
 func ceilingFor(t *testing.T, method, path, contentType string) int64 {
 	t.Helper()
@@ -30,16 +40,21 @@ func ceilingFor(t *testing.T, method, path, contentType string) int64 {
 	if contentType != "" {
 		req.Header.Set("Content-Type", contentType)
 	}
-	return bodyCeiling(req)
+	return bodyCeilingFor(uploadCeilings(testLimits))(req)
 }
 
-func TestAnUploadRouteGetsTheWideCeiling(t *testing.T) {
-	for path := range fileUploadRoutes {
+func TestEachUploadRouteRidesItsOwnConfiguredCeiling(t *testing.T) {
+	for path, want := range map[string]int64{
+		"/v1/attachments":             testLimits.Attachment,
+		"/v1/imports/sources":         testLimits.CSVImport,
+		"/v1/me/linkedin-connections": testLimits.LinkedInImport,
+	} {
 		got := ceilingFor(t, http.MethodPost, path,
 			"multipart/form-data; boundary=----WebKitFormBoundary7MA4YWxkTrZu0gW")
-		if got != httperr.MaxMultipartBodyBytes {
-			t.Errorf("%s rode ceiling %d, want the multipart ceiling %d — its "+
-				"declared cap cannot run", path, got, httperr.MaxMultipartBodyBytes)
+		if got != want {
+			t.Errorf("%s rode ceiling %d, want its own configured %d — a route "+
+				"reading under a ceiling that is not the one it was granted "+
+				"refuses files the operator meant it to accept", path, got, want)
 		}
 	}
 }
@@ -95,46 +110,19 @@ func TestOnlyPOSTCarriesAFile(t *testing.T) {
 	}
 }
 
-// multipartParse finds every handler that parses a multipart body.
-var multipartParse = regexp.MustCompile(`ParseMultipartForm\(`)
-
-// TestEveryMultipartRouteIsDeclared derives the obligation from the tree rather
-// than restating it: a handler that parses a multipart body needs its route in
-// `fileUploadRoutes`, or the parse runs under the 1 MiB bound and whatever cap
-// it declares is dead. A hand-kept list would pass while the next upload route
-// silently ran at the wrong ceiling — which is the bug this all came from.
-func TestEveryMultipartRouteIsDeclared(t *testing.T) {
-	root := filepath.Join("..", "..")
-	var parsers []string
-	err := filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
-		if err != nil {
-			return err
+func TestAPathTheRouterDoesNotServeIsNotAnUploadRoute(t *testing.T) {
+	// Normalizing here would be guessing at how the router resolves a path it
+	// does not mount, and a guess that lands wide is a grant nobody wrote.
+	for _, path := range []string{
+		"/v1/attachments/",
+		"/v1/attachments//",
+		"//v1/attachments",
+		"/v1/ATTACHMENTS",
+	} {
+		got := ceilingFor(t, http.MethodPost, path, "multipart/form-data; boundary=x")
+		if got != httperr.MaxBodyBytes {
+			t.Errorf("%q rode the file ceiling %d — only the exact path the "+
+				"router mounts carries a file", path, got)
 		}
-		if entry.IsDir() || !strings.HasSuffix(path, ".go") ||
-			strings.HasSuffix(path, "_test.go") {
-			return nil
-		}
-		source, readErr := os.ReadFile(path)
-		if readErr != nil {
-			return readErr
-		}
-		if multipartParse.Match(source) {
-			parsers = append(parsers, path)
-		}
-		return nil
-	})
-	if err != nil {
-		t.Fatalf("walking the backend tree: %v", err)
-	}
-	if len(parsers) == 0 {
-		t.Fatal("found no multipart handlers at all — the walk is broken, and a " +
-			"walk that finds nothing passes this test for the wrong reason")
-	}
-	if len(parsers) != len(fileUploadRoutes) {
-		t.Errorf("%d handler(s) parse a multipart body but %d route(s) are "+
-			"declared in fileUploadRoutes: %v\n"+
-			"An undeclared upload route parses under the %d-byte JSON bound, so "+
-			"the cap it declares never runs.",
-			len(parsers), len(fileUploadRoutes), parsers, httperr.MaxBodyBytes)
 	}
 }

--- a/backend/internal/compose/bodyceilingcensus_test.go
+++ b/backend/internal/compose/bodyceilingcensus_test.go
@@ -30,6 +30,8 @@ import (
 
 // contractPaths is the slice of the OpenAPI document these gates read: which
 // operation each path's POST is, and whether its body is a file.
+//
+//nolint:tagliatelle // these are OpenAPI's OWN field names, and they are camelCase; a snake_case tag here would decode a document that does not exist.
 type contractPaths struct {
 	Paths map[string]struct {
 		Post *struct {

--- a/backend/internal/compose/bodyceilingcensus_test.go
+++ b/backend/internal/compose/bodyceilingcensus_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"slices"
 	"strings"
 	"testing"
@@ -164,55 +165,68 @@ func censusProblems(contract map[string]string, declared map[string]int64) []str
 	return problems
 }
 
-// TestEveryMultipartParseServesADeclaredUploadRoute is the tree-side backstop:
-// a handler can only reach a multipart parse if its package implements one of
-// the contract's declared upload operations.
+// TestEveryMultipartParseNamesItsRoute is the tree-side gate: every place in
+// the product that parses a file body says WHICH route it is parsing for, and
+// those routes are exactly the ones with a ceiling.
 //
-// It works by package rather than by file because the parse does not always sit
-// in the handler — the CSV import reads its body in a helper beside it — and a
-// gate that insisted on the same file would be describing today's layout rather
-// than the obligation.
-func TestEveryMultipartParseServesADeclaredUploadRoute(t *testing.T) {
-	parsers := packagesMatching(t, "ParseMultipartForm(")
-	if len(parsers) == 0 {
+// It counts parse sites against markers per FILE and compares the marker set
+// against the declared routes, rather than asking which package a parse lives
+// in. Package membership was the first version of this and it had a hole big
+// enough to drive the original bug through: `internal/compose` already serves a
+// declared upload operation, so a second, undeclared multipart parse added
+// anywhere in that package answered "yes, this package serves an upload" and
+// rode the 1 MiB bound in silence.
+//
+// A marker is not documentation — it is the parse site's half of a two-sided
+// obligation, and the other side is derived from the contract.
+func TestEveryMultipartParseNamesItsRoute(t *testing.T) {
+	sites, markers := parseSitesAndMarkers(t)
+	if len(sites) == 0 {
 		t.Fatal("found no multipart parse anywhere — the walk is broken, and a " +
 			"walk that finds nothing passes this test for the wrong reason")
 	}
-	servers := map[string]bool{}
-	for _, op := range uploadOperations(t) {
-		method := strings.ToUpper(op[:1]) + op[1:]
-		for pkg := range packagesMatching(t, ") "+method+"(w http.ResponseWriter") {
-			servers[pkg] = true
+	for file, count := range sites {
+		if got := len(markers[file]); got != count {
+			t.Errorf("%s parses a multipart body %d time(s) but names a route %d "+
+				"time(s) — an unnamed parse rides the JSON bound, so whatever cap "+
+				"it declares is dead code", file, count, got)
 		}
 	}
-	for pkg := range parsers {
-		if !servers[pkg] {
-			t.Errorf("%s parses a multipart body but implements no declared "+
-				"upload operation — whatever route it serves rides the JSON "+
-				"bound, so its own cap is dead code", pkg)
+	named := map[string]bool{}
+	for _, routes := range markers {
+		for _, route := range routes {
+			named[route] = true
 		}
 	}
-	for pkg := range servers {
-		if !parsers[pkg] {
-			t.Errorf("%s implements a declared upload operation but nothing in "+
-				"it parses a multipart body", pkg)
+	declared := uploadCeilings(testLimits)
+	for route := range named {
+		if _, ok := declared[route]; !ok {
+			t.Errorf("a parse names route %q, which has no ceiling — it will be "+
+				"read under the JSON bound", route)
+		}
+	}
+	for route := range declared {
+		if !named[route] {
+			t.Errorf("route %q has a ceiling but nothing parses a file body for "+
+				"it — either the grant is stale or the parse lost its marker", route)
 		}
 	}
 }
 
-// packagesMatching returns every backend package holding a hand-written source
-// file that contains the given literal.
-func packagesMatching(t *testing.T, literal string) map[string]bool {
+// uploadRouteMarker is the comment a parse site carries to name its route.
+var uploadRouteMarker = regexp.MustCompile(`// upload:route (\S+)`)
+
+// parseSitesAndMarkers walks the hand-written tree and returns, per file, how
+// many multipart parses it performs and which routes it names.
+func parseSitesAndMarkers(t *testing.T) (map[string]int, map[string][]string) {
 	t.Helper()
-	found := map[string]bool{}
+	sites := map[string]int{}
+	markers := map[string][]string{}
 	root := filepath.Join("..", "..")
 	err := filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
-		// Generated files are skipped: the contract's router and its interface
-		// restate every handler signature, so a generated package would answer
-		// "implements this operation" for all of them while parsing nothing.
 		if entry.IsDir() || !strings.HasSuffix(path, ".go") ||
 			strings.HasSuffix(path, "_test.go") || strings.HasSuffix(path, "_gen.go") {
 			return nil
@@ -221,13 +235,16 @@ func packagesMatching(t *testing.T, literal string) map[string]bool {
 		if readErr != nil {
 			return readErr
 		}
-		if strings.Contains(string(source), literal) {
-			found[filepath.Dir(path)] = true
+		if n := strings.Count(string(source), "ParseMultipartForm("); n > 0 {
+			sites[path] = n
+		}
+		for _, match := range uploadRouteMarker.FindAllStringSubmatch(string(source), -1) {
+			markers[path] = append(markers[path], match[1])
 		}
 		return nil
 	})
 	if err != nil {
 		t.Fatalf("walking the backend tree: %v", err)
 	}
-	return found
+	return sites, markers
 }

--- a/backend/internal/compose/bodyceilingcensus_test.go
+++ b/backend/internal/compose/bodyceilingcensus_test.go
@@ -1,0 +1,231 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The declaration gates for the upload ceiling table.
+//
+// What they exist to catch, stated as the failure rather than the rule: a route
+// that carries a file but is absent from the table parses under the 1 MiB JSON
+// bound, so the ceiling it was granted never runs and every upload past a
+// megabyte is refused for a reason nothing explains.
+//
+// The gate this replaces compared COUNTS — `len(parsers) != len(routes)` — and
+// therefore could not see the likeliest version of that mistake: a mistyped
+// path in the table leaves the real route undeclared while the totals still
+// agree. So both gates below compare SETS, and both are built from a source
+// nobody edits while adding a route: the contract for one, the tree for the
+// other.
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// contractPaths is the slice of the OpenAPI document these gates read: which
+// operation each path's POST is, and whether its body is a file.
+type contractPaths struct {
+	Paths map[string]struct {
+		Post *struct {
+			OperationID string `yaml:"operationId"`
+			RequestBody *struct {
+				Content map[string]struct{} `yaml:"content"`
+			} `yaml:"requestBody"`
+		} `yaml:"post"`
+	} `yaml:"paths"`
+}
+
+const multipartMediaType = "multipart/form-data"
+
+// uploadOperations reads the contract for every POST that declares a file body.
+// This is the OBLIGATION side of both gates: the contract is where an upload
+// route comes into existence, so it is the only place that cannot be forgotten
+// while adding one.
+func uploadOperations(t *testing.T) map[string]string {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join("..", "..", "api", "crm.yaml"))
+	if err != nil {
+		t.Fatalf("reading the contract: %v", err)
+	}
+	var doc contractPaths
+	if err := yaml.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("parsing the contract: %v", err)
+	}
+	ops := map[string]string{}
+	for path, item := range doc.Paths {
+		if item.Post == nil || item.Post.RequestBody == nil {
+			continue
+		}
+		if _, isFile := item.Post.RequestBody.Content[multipartMediaType]; isFile {
+			// As the chassis sees it: the generated router mounts the contract's
+			// paths under /v1, and the ceiling is chosen on the served path.
+			ops["/v1"+path] = item.Post.OperationID
+		}
+	}
+	if len(ops) == 0 {
+		t.Fatal("the contract declares no file uploads at all — this gate is " +
+			"reading the wrong document, and a gate that finds nothing passes " +
+			"for the wrong reason")
+	}
+	return ops
+}
+
+// TestEveryUploadRouteIsDeclared is the gate proper: the routes that carry
+// files and the routes with a ceiling are the same set, in both directions.
+//
+// Both directions matter and for different reasons. A contract route missing
+// from the table runs at the JSON bound. A table entry with no contract route
+// is a path nothing serves — usually the typo half of the first failure, and
+// silent on its own.
+func TestEveryUploadRouteIsDeclared(t *testing.T) {
+	declared := uploadCeilings(testLimits)
+	for _, problem := range censusProblems(uploadOperations(t), declared) {
+		t.Error(problem)
+	}
+}
+
+// TestTheDeclarationGateCanActuallyFail arms the gate above by handing its
+// comparison the two mistakes it exists to catch.
+//
+// Written because the census this replaces was green against the bug it
+// described: a guard whose failure has never been observed is a guard nobody
+// has checked. The typo case is the important one — it is the shape a real
+// mistake takes, and the count-based gate could not see it at all.
+func TestTheDeclarationGateCanActuallyFail(t *testing.T) {
+	contract := map[string]string{
+		"/v1/attachments":     "uploadAttachment",
+		"/v1/imports/sources": "uploadImportSource",
+	}
+	for _, tc := range []struct {
+		name     string
+		declared map[string]int64
+		wants    string
+	}{
+		{
+			name:     "a mistyped path leaves the real route undeclared",
+			declared: map[string]int64{"/v1/attachment": 1, "/v1/imports/sources": 1},
+			wants:    "/v1/attachments",
+		},
+		{
+			name:     "a route the contract does not serve is declared anyway",
+			declared: map[string]int64{"/v1/attachments": 1, "/v1/imports/sources": 1, "/v1/ghost": 1},
+			wants:    "/v1/ghost",
+		},
+		{
+			name:     "an upload route is simply missing",
+			declared: map[string]int64{"/v1/attachments": 1},
+			wants:    "/v1/imports/sources",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			problems := censusProblems(contract, tc.declared)
+			if len(problems) == 0 {
+				t.Fatalf("the census passed over %q — it cannot catch the "+
+					"mistake it is here for", tc.wants)
+			}
+			if !slices.ContainsFunc(problems, func(p string) bool {
+				return strings.Contains(p, tc.wants)
+			}) {
+				t.Errorf("the census complained, but never about %q: %v", tc.wants, problems)
+			}
+		})
+	}
+}
+
+// censusProblems reports every disagreement between the routes that carry files
+// and the routes that have a ceiling. Separated from the test so the gate's own
+// failure modes can be exercised without a contract that has the bug in it.
+func censusProblems(contract map[string]string, declared map[string]int64) []string {
+	var problems []string
+	for path, op := range contract {
+		if _, ok := declared[path]; !ok {
+			problems = append(problems, fmt.Sprintf(
+				"%s (%s) takes a file body but has no ceiling, so it parses "+
+					"under the JSON bound and the cap it declares never runs",
+				path, op))
+		}
+	}
+	for path := range declared {
+		if _, ok := contract[path]; !ok {
+			problems = append(problems, fmt.Sprintf(
+				"%s has a ceiling but no contract operation takes a file body "+
+					"there — usually the other half of a mistyped path", path))
+		}
+	}
+	slices.Sort(problems)
+	return problems
+}
+
+// TestEveryMultipartParseServesADeclaredUploadRoute is the tree-side backstop:
+// a handler can only reach a multipart parse if its package implements one of
+// the contract's declared upload operations.
+//
+// It works by package rather than by file because the parse does not always sit
+// in the handler — the CSV import reads its body in a helper beside it — and a
+// gate that insisted on the same file would be describing today's layout rather
+// than the obligation.
+func TestEveryMultipartParseServesADeclaredUploadRoute(t *testing.T) {
+	parsers := packagesMatching(t, "ParseMultipartForm(")
+	if len(parsers) == 0 {
+		t.Fatal("found no multipart parse anywhere — the walk is broken, and a " +
+			"walk that finds nothing passes this test for the wrong reason")
+	}
+	servers := map[string]bool{}
+	for _, op := range uploadOperations(t) {
+		method := strings.ToUpper(op[:1]) + op[1:]
+		for pkg := range packagesMatching(t, ") "+method+"(w http.ResponseWriter") {
+			servers[pkg] = true
+		}
+	}
+	for pkg := range parsers {
+		if !servers[pkg] {
+			t.Errorf("%s parses a multipart body but implements no declared "+
+				"upload operation — whatever route it serves rides the JSON "+
+				"bound, so its own cap is dead code", pkg)
+		}
+	}
+	for pkg := range servers {
+		if !parsers[pkg] {
+			t.Errorf("%s implements a declared upload operation but nothing in "+
+				"it parses a multipart body", pkg)
+		}
+	}
+}
+
+// packagesMatching returns every backend package holding a hand-written source
+// file that contains the given literal.
+func packagesMatching(t *testing.T, literal string) map[string]bool {
+	t.Helper()
+	found := map[string]bool{}
+	root := filepath.Join("..", "..")
+	err := filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		// Generated files are skipped: the contract's router and its interface
+		// restate every handler signature, so a generated package would answer
+		// "implements this operation" for all of them while parsing nothing.
+		if entry.IsDir() || !strings.HasSuffix(path, ".go") ||
+			strings.HasSuffix(path, "_test.go") || strings.HasSuffix(path, "_gen.go") {
+			return nil
+		}
+		source, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		if strings.Contains(string(source), literal) {
+			found[filepath.Dir(path)] = true
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking the backend tree: %v", err)
+	}
+	return found
+}

--- a/backend/internal/compose/bodyceilingcensus_test.go
+++ b/backend/internal/compose/bodyceilingcensus_test.go
@@ -29,47 +29,107 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// contractPaths is the slice of the OpenAPI document these gates read: which
-// operation each path's POST is, and whether its body is a file.
+// contractOperation is the slice of one OpenAPI operation these gates read:
+// which operation it is, and whether its body is a file.
 //
 //nolint:tagliatelle // these are OpenAPI's OWN field names, and they are camelCase; a snake_case tag here would decode a document that does not exist.
-type contractPaths struct {
-	Paths map[string]struct {
-		Post *struct {
-			OperationID string `yaml:"operationId"`
-			RequestBody *struct {
-				Content map[string]struct{} `yaml:"content"`
-			} `yaml:"requestBody"`
-		} `yaml:"post"`
-	} `yaml:"paths"`
+type contractOperation struct {
+	OperationID string `yaml:"operationId"`
+	RequestBody *struct {
+		// Ref catches a requestBody this reader cannot see through. It is
+		// refused rather than skipped: a body it cannot read is a body it cannot
+		// prove is not a file, and skipping would drop the route out of the
+		// obligation set in silence — the exact shape of the bug being gated.
+		Ref     string              `yaml:"$ref"`
+		Content map[string]struct{} `yaml:"content"`
+	} `yaml:"requestBody"`
+}
+
+type contractDoc struct {
+	// Each path item, method-keyed and left unparsed: a path item also carries
+	// `parameters`, `summary` and friends, which are not operations.
+	Paths map[string]map[string]yaml.Node `yaml:"paths"`
 }
 
 const multipartMediaType = "multipart/form-data"
 
-// uploadOperations reads the contract for every POST that declares a file body.
-// This is the OBLIGATION side of both gates: the contract is where an upload
-// route comes into existence, so it is the only place that cannot be forgotten
-// while adding one.
+// httpMethods is every method an OpenAPI path item may carry an operation
+// under. ALL of them, not just post: a multipart PUT is just as much an upload
+// route, and a harvest that only looked at POST would leave it out of the
+// obligation set while the chassis — which grants on POST alone — could not
+// give it a ceiling either. Both halves would be silent.
+var httpMethods = []string{
+	"get", "put", "post", "patch", "delete", "head", "options", "trace",
+}
+
+// uploadOperationsIn reads a contract document for every operation that
+// declares a file body, and reports what it could not account for.
+//
+// Split from the test so the HARVEST can be armed too. Arming only the set
+// comparison leaves the reader half unproven, and a harvest that quietly
+// returns nothing makes every comparison downstream pass.
+func uploadOperationsIn(raw []byte) (map[string]string, []string, error) {
+	var doc contractDoc
+	if err := yaml.Unmarshal(raw, &doc); err != nil {
+		return nil, nil, fmt.Errorf("parsing the contract: %w", err)
+	}
+	ops := map[string]string{}
+	var problems []string
+	for path, item := range doc.Paths {
+		for _, method := range httpMethods {
+			node, present := item[method]
+			if !present {
+				continue
+			}
+			var op contractOperation
+			if err := node.Decode(&op); err != nil {
+				problems = append(problems, fmt.Sprintf(
+					"%s %s could not be read: %v", strings.ToUpper(method), path, err))
+				continue
+			}
+			if op.RequestBody == nil {
+				continue
+			}
+			if op.RequestBody.Ref != "" {
+				problems = append(problems, fmt.Sprintf(
+					"%s %s takes its requestBody by $ref (%s), which this gate cannot "+
+						"follow — it cannot tell whether the route carries a file",
+					strings.ToUpper(method), path, op.RequestBody.Ref))
+				continue
+			}
+			if _, isFile := op.RequestBody.Content[multipartMediaType]; !isFile {
+				continue
+			}
+			if method != "post" {
+				problems = append(problems, fmt.Sprintf(
+					"%s %s takes a file body, but the chassis grants the wider ceiling "+
+						"on POST alone, so this route can never receive one",
+					strings.ToUpper(method), path))
+				continue
+			}
+			// As the chassis sees it: the generated router mounts the contract's
+			// paths under /v1, and the ceiling is chosen on the served path.
+			ops["/v1"+path] = op.OperationID
+		}
+	}
+	return ops, problems, nil
+}
+
+// uploadOperations is the OBLIGATION side of both gates: the contract is where
+// an upload route comes into existence, so it is the only place that cannot be
+// forgotten while adding one.
 func uploadOperations(t *testing.T) map[string]string {
 	t.Helper()
 	raw, err := os.ReadFile(filepath.Join("..", "..", "api", "crm.yaml"))
 	if err != nil {
 		t.Fatalf("reading the contract: %v", err)
 	}
-	var doc contractPaths
-	if err := yaml.Unmarshal(raw, &doc); err != nil {
-		t.Fatalf("parsing the contract: %v", err)
+	ops, problems, err := uploadOperationsIn(raw)
+	if err != nil {
+		t.Fatalf("%v", err)
 	}
-	ops := map[string]string{}
-	for path, item := range doc.Paths {
-		if item.Post == nil || item.Post.RequestBody == nil {
-			continue
-		}
-		if _, isFile := item.Post.RequestBody.Content[multipartMediaType]; isFile {
-			// As the chassis sees it: the generated router mounts the contract's
-			// paths under /v1, and the ceiling is chosen on the served path.
-			ops["/v1"+path] = item.Post.OperationID
-		}
+	for _, problem := range problems {
+		t.Error(problem)
 	}
 	if len(ops) == 0 {
 		t.Fatal("the contract declares no file uploads at all — this gate is " +
@@ -77,6 +137,93 @@ func uploadOperations(t *testing.T) map[string]string {
 			"for the wrong reason")
 	}
 	return ops
+}
+
+// TestTheContractHarvestSeesWhatItCannotAccountFor arms the reader half.
+//
+// The version this replaces looked only at `post` and only at an inline
+// requestBody, so a multipart PUT and a $ref'd body each dropped out of the
+// obligation set without a word — and every set comparison downstream then
+// agreed that nothing was missing.
+func TestTheContractHarvestSeesWhatItCannotAccountFor(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		document string
+		wants    string
+	}{
+		{
+			name: "an inline multipart POST is harvested",
+			document: `paths:
+  /widgets:
+    post:
+      operationId: uploadWidget
+      requestBody:
+        content:
+          multipart/form-data: {}
+`,
+			wants: "",
+		},
+		{
+			name: "a multipart body on another method is reported",
+			document: `paths:
+  /widgets:
+    put:
+      operationId: replaceWidget
+      requestBody:
+        content:
+          multipart/form-data: {}
+`,
+			wants: "PUT /widgets",
+		},
+		{
+			name: "a requestBody this reader cannot follow is reported",
+			document: `paths:
+  /widgets:
+    post:
+      operationId: uploadWidget
+      requestBody:
+        $ref: '#/components/requestBodies/WidgetUpload'
+`,
+			wants: "$ref",
+		},
+		{
+			name: "a path item's non-operation keys are not mistaken for one",
+			document: `paths:
+  /widgets:
+    parameters:
+      - name: id
+        in: query
+    post:
+      operationId: uploadWidget
+      requestBody:
+        content:
+          multipart/form-data: {}
+`,
+			wants: "",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ops, problems, err := uploadOperationsIn([]byte(tc.document))
+			if err != nil {
+				t.Fatalf("reading the fixture: %v", err)
+			}
+			if tc.wants == "" {
+				if len(problems) != 0 {
+					t.Fatalf("a readable document was reported as a problem: %v", problems)
+				}
+				if _, found := ops["/v1/widgets"]; !found {
+					t.Errorf("the upload was not harvested at all: %v", ops)
+				}
+				return
+			}
+			if !slices.ContainsFunc(problems, func(p string) bool {
+				return strings.Contains(p, tc.wants)
+			}) {
+				t.Errorf("nothing was reported about %q — it would drop out of the "+
+					"obligation set in silence: %v", tc.wants, problems)
+			}
+		})
+	}
 }
 
 // TestEveryUploadRouteIsDeclared is the gate proper: the routes that carry

--- a/backend/internal/compose/csvimport.go
+++ b/backend/internal/compose/csvimport.go
@@ -33,11 +33,12 @@ import (
 )
 
 const (
-	// maxImportUploadBytes is CAP-BODY, the 10 MB import-only request cap the
-	// rate-limit chapter owns. Enforced with a MaxBytesReader so an oversized
-	// file is a distinct refusal, never a truncated read that imports half a
-	// customer's estate and reports success.
-	maxImportUploadBytes = 10 << 20
+	// importSpillBytes is how much of the upload is held in memory before the
+	// rest goes to a temp file. The request cap itself is CAP-BODY, owned by the
+	// rate-limit chapter and set by the deployment (OPS-CFG-12); enforced with a
+	// MaxBytesReader so an oversized file is a distinct refusal, never a
+	// truncated read that imports half a customer's estate and reports success.
+	importSpillBytes = 1 << 20
 	// importBlobKind namespaces uploaded sources inside the workspace's blob
 	// prefix, beside attachments and logos.
 	importBlobKind = "import"
@@ -52,6 +53,10 @@ const (
 type importHandlers struct {
 	db    *database.DB
 	blobs blobstore.Store
+	// uploadLimit is the deployment's ceiling for this route (OPS-CFG-12).
+	// Zero refuses every upload, which is the honest reading of "nobody has
+	// said" for a bound.
+	uploadLimit int64
 }
 
 // UploadImportSource stores a file and describes it (IEM-WIRE-8). Nothing is
@@ -72,7 +77,7 @@ func (h importHandlers) UploadImportSource(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	object, body, err := readImportUpload(w, r)
+	object, body, err := readImportUpload(w, r, h.uploadLimit)
 	if err != nil {
 		httperr.Write(w, r, err)
 		return

--- a/backend/internal/compose/csvimport.go
+++ b/backend/internal/compose/csvimport.go
@@ -14,6 +14,7 @@ package compose
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -74,6 +75,15 @@ func (h importHandlers) UploadImportSource(w http.ResponseWriter, r *http.Reques
 	}
 	if h.blobs == nil {
 		httperr.Write(w, r, fmt.Errorf("this role stores no objects, so it cannot accept an import: %w", apperrors.ErrConflict))
+		return
+	}
+
+	if h.uploadLimit <= 0 {
+		// Our fault, not the caller's — the same guard the other two upload
+		// routes carry, and for the same reason: a zero bound refuses a
+		// perfectly good file and tells its sender it "exceeds the 0 MB limit",
+		// which sends them off to shrink something that was never too large.
+		httperr.Write(w, r, errUploadLimitUnset)
 		return
 	}
 
@@ -339,6 +349,12 @@ func (h importHandlers) staged(r *http.Request, id openapi_types.UUID) (migratio
 	}
 	return run, nil
 }
+
+// errUploadLimitUnset reports that this composition never told the import
+// handler its ceiling. A wiring fault, not a request fault, so it answers 500
+// rather than refusing the caller's file for a size nobody set — the same guard
+// the attachment and LinkedIn routes carry.
+var errUploadLimitUnset = errors.New("compose: no upload ceiling configured for the import route")
 
 // errNoObjectStore refuses an import on a process role that stores no objects.
 // A conflict rather than a 500: the installation is configured this way, and a

--- a/backend/internal/compose/csvimportwire.go
+++ b/backend/internal/compose/csvimportwire.go
@@ -269,22 +269,21 @@ func lineOf(externalID string) int {
 	return line
 }
 
-// readImportUpload takes the multipart body apart under the 10 MB cap and
-// returns the object the rows are and the file's bytes.
+// readImportUpload takes the multipart body apart under the deployment's import
+// cap and returns the object the rows are and the file's bytes.
 //
 // The bytes are read whole rather than streamed to the blobstore, and that is
 // deliberate: the same upload must be BOTH profiled and stored, and a stream
 // can only be consumed once. The cap is what makes reading it whole safe, and
 // MaxBytesReader (not a bare LimitReader) is what turns an over-cap upload into
 // a refusal rather than a file silently cut in half.
-func readImportUpload(w http.ResponseWriter, r *http.Request) (string, []byte, error) {
-	r.Body = http.MaxBytesReader(w, r.Body, maxImportUploadBytes)
-	//nolint:gosec // r.Body is bounded by http.MaxBytesReader above, so the total parse size is capped; this argument only sets the in-memory/spill threshold.
-	if err := r.ParseMultipartForm(maxImportUploadBytes); err != nil {
+func readImportUpload(w http.ResponseWriter, r *http.Request, limit int64) (string, []byte, error) {
+	r.Body = http.MaxBytesReader(w, r.Body, limit)
+	if err := r.ParseMultipartForm(importSpillBytes); err != nil {
 		// The cap is DERIVED, never spelled again in prose: this sentence said
 		// "10 MB" while the constant beside it decided the real answer, and the
 		// two were free to drift the moment either moved.
-		return "", nil, httperr.MultipartRefusal(err, maxImportUploadBytes)
+		return "", nil, httperr.MultipartRefusal(err, limit)
 	}
 
 	object := strings.TrimSpace(r.FormValue("object"))

--- a/backend/internal/compose/csvimportwire.go
+++ b/backend/internal/compose/csvimportwire.go
@@ -279,6 +279,7 @@ func lineOf(externalID string) int {
 // a refusal rather than a file silently cut in half.
 func readImportUpload(w http.ResponseWriter, r *http.Request, limit int64) (string, []byte, error) {
 	r.Body = http.MaxBytesReader(w, r.Body, limit)
+	//nolint:gosec // G120 wants a bound here, and the bound is the MaxBytesReader above: this argument is only the in-memory/spill threshold, and it is deliberately far below the ceiling so the parse spills rather than holding the upload resident.
 	if err := r.ParseMultipartForm(importSpillBytes); err != nil {
 		// The cap is DERIVED, never spelled again in prose: this sentence said
 		// "10 MB" while the constant beside it decided the real answer, and the

--- a/backend/internal/compose/csvimportwire.go
+++ b/backend/internal/compose/csvimportwire.go
@@ -279,6 +279,9 @@ func lineOf(externalID string) int {
 // a refusal rather than a file silently cut in half.
 func readImportUpload(w http.ResponseWriter, r *http.Request, limit int64) (string, []byte, error) {
 	r.Body = http.MaxBytesReader(w, r.Body, limit)
+	// upload:route /v1/imports/sources — the ceiling this parse runs under is granted to that
+	// path in compose.uploadCeilings, and TestEveryMultipartParseNamesItsRoute
+	// holds the two together.
 	//nolint:gosec // G120 wants a bound here, and the bound is the MaxBytesReader above: this argument is only the in-memory/spill threshold, and it is deliberately far below the ceiling so the parse spills rather than holding the upload resident.
 	if err := r.ParseMultipartForm(importSpillBytes); err != nil {
 		// The cap is DERIVED, never spelled again in prose: this sentence said

--- a/backend/internal/compose/handlers_installation_settings.go
+++ b/backend/internal/compose/handlers_installation_settings.go
@@ -20,6 +20,15 @@ import (
 
 type installationSettingsHandlers struct {
 	store *identity.InstallationSettingsStore
+	// maxUploadBytes is the deployment's attachment ceiling (OPS-CFG-12),
+	// published so an upload surface enforces the number THIS installation
+	// applies rather than one compiled into the client.
+	//
+	// It rides this read rather than a read of its own because it answers the
+	// same question the rest of the response does — what is true of this
+	// installation — and because every role may read it: whoever can upload a
+	// file can be told how large a file is worth sending.
+	maxUploadBytes int64
 }
 
 func (h installationSettingsHandlers) GetInstallationSettings(w http.ResponseWriter, r *http.Request) {
@@ -32,7 +41,7 @@ func (h installationSettingsHandlers) GetInstallationSettings(w http.ResponseWri
 		httperr.Write(w, r, err)
 		return
 	}
-	httperr.WriteJSON(w, http.StatusOK, toContractInstallationSettings(s))
+	httperr.WriteJSON(w, http.StatusOK, h.toContract(s))
 }
 
 func (h installationSettingsHandlers) UpdateInstallationSettings(w http.ResponseWriter, r *http.Request) {
@@ -56,18 +65,23 @@ func (h installationSettingsHandlers) UpdateInstallationSettings(w http.Response
 		httperr.Write(w, r, err)
 		return
 	}
-	httperr.WriteJSON(w, http.StatusOK, toContractInstallationSettings(s))
+	httperr.WriteJSON(w, http.StatusOK, h.toContract(s))
 }
 
-// toContractInstallationSettings maps the stored values onto the wire shape.
+// toContract maps the stored values onto the wire shape, and adds the one field
+// that is not stored at all: the upload ceiling is a deployment fact, so it
+// arrives from composition rather than from the settings table — the same way
+// base_currency_locked is derived rather than kept.
+//
 // The lock reason is omitted rather than sent empty when the currency is still
-// changeable — an empty string would render as a reason that says nothing.
-func toContractInstallationSettings(s identity.InstallationSettings) crmcontracts.InstallationSettings {
+// changeable: an empty string would render as a reason that says nothing.
+func (h installationSettingsHandlers) toContract(s identity.InstallationSettings) crmcontracts.InstallationSettings {
 	out := crmcontracts.InstallationSettings{
 		Name:               s.Name,
 		Timezone:           s.Timezone,
 		BaseCurrency:       s.BaseCurrency,
 		BaseCurrencyLocked: s.BaseCurrencyLocked,
+		MaxUploadBytes:     h.maxUploadBytes,
 	}
 	if s.BaseCurrencyLockedReason != "" {
 		reason := s.BaseCurrencyLockedReason

--- a/backend/internal/compose/integration/attachment_extraction_integration_test.go
+++ b/backend/internal/compose/integration/attachment_extraction_integration_test.go
@@ -35,7 +35,7 @@ import (
 // than an empty body a client would render as "read it, found none".
 func TestGetAttachmentExtractionOfAnUnreadDocumentIs404(t *testing.T) {
 	e := Setup(t)
-	h := activities.NewHandlers(e.DB()).WithBlobstore(blobstore.NewMemory())
+	h := activities.NewHandlers(e.DB()).WithUploadLimit(uploadCeiling).WithBlobstore(blobstore.NewMemory())
 	ctx := e.Admin()
 	person := e.SeedPerson(t, "Extraction NoOp", &e.Rep1)
 	att := uploadTestAttachment(ctx, t, h, person, "report.pdf", []byte("PDF-BYTES"))
@@ -54,7 +54,7 @@ func TestGetAttachmentExtractionOfAnUnreadDocumentIs404(t *testing.T) {
 // status alongside them.
 func TestGetAttachmentExtractionPartitionsAStoredReading(t *testing.T) {
 	e := Setup(t)
-	base := activities.NewHandlers(e.DB()).WithBlobstore(blobstore.NewMemory())
+	base := activities.NewHandlers(e.DB()).WithUploadLimit(uploadCeiling).WithBlobstore(blobstore.NewMemory())
 	ctx := e.Admin()
 	pipeline, open, _ := DealFixture(t, e)
 	deal := e.SeedDeal(t, "Fixture Deal", pipeline, open, &e.Rep1)
@@ -96,7 +96,7 @@ func TestGetAttachmentExtractionPartitionsAStoredReading(t *testing.T) {
 // not reading the staged extraction.
 func TestGetAttachmentExtractionReadsAnyEntityType(t *testing.T) {
 	e := Setup(t)
-	h := activities.NewHandlers(e.DB()).WithBlobstore(blobstore.NewMemory())
+	h := activities.NewHandlers(e.DB()).WithUploadLimit(uploadCeiling).WithBlobstore(blobstore.NewMemory())
 	ctx := e.Admin()
 	org := e.SeedOrg(t, "Non-Deal Parent", &e.Rep1)
 	att := uploadTestAttachmentForOrg(ctx, t, h, org, "notes.txt", []byte("org notes"))
@@ -115,7 +115,7 @@ func TestGetAttachmentExtractionReadsAnyEntityType(t *testing.T) {
 // reading already running rather than paying for the same document twice.
 func TestStartExtractionReadTwiceJoinsTheOneInFlight(t *testing.T) {
 	e := Setup(t)
-	h := activities.NewHandlers(e.DB()).WithBlobstore(blobstore.NewMemory())
+	h := activities.NewHandlers(e.DB()).WithUploadLimit(uploadCeiling).WithBlobstore(blobstore.NewMemory())
 	ctx := e.Admin()
 	pipeline, open, _ := DealFixture(t, e)
 	deal := e.SeedDeal(t, "Idempotent Reading", pipeline, open, &e.Rep1)
@@ -143,7 +143,7 @@ func TestStartExtractionReadTwiceJoinsTheOneInFlight(t *testing.T) {
 // attachment op.
 func TestGetAttachmentExtractionHidesAnInvisibleParent(t *testing.T) {
 	e := Setup(t)
-	h := activities.NewHandlers(e.DB()).WithBlobstore(blobstore.NewMemory())
+	h := activities.NewHandlers(e.DB()).WithUploadLimit(uploadCeiling).WithBlobstore(blobstore.NewMemory())
 	adminCtx := e.Admin()
 	person := e.SeedPerson(t, "Rep1's Extraction Target", &e.Rep1)
 	att := uploadTestAttachment(adminCtx, t, h, person, "secret.pdf", []byte("secret"))
@@ -170,7 +170,7 @@ func TestGetAttachmentExtractionHidesAnInvisibleParent(t *testing.T) {
 // linked back to the parent deal, and answers {requested:true}.
 func TestRequestAttachmentAccessAuditsANoteAndReturnsRequested(t *testing.T) {
 	e := Setup(t)
-	h := activities.NewHandlers(e.DB()).WithBlobstore(blobstore.NewMemory())
+	h := activities.NewHandlers(e.DB()).WithUploadLimit(uploadCeiling).WithBlobstore(blobstore.NewMemory())
 	ctx := e.Admin()
 	pipeline, open, _ := DealFixture(t, e)
 	deal := e.SeedDeal(t, "Access Request Deal", pipeline, open, &e.Rep1)
@@ -208,7 +208,7 @@ func TestRequestAttachmentAccessAuditsANoteAndReturnsRequested(t *testing.T) {
 // locked-row placeholder.
 func TestRequestAttachmentAccessHidesAnInvisibleParent(t *testing.T) {
 	e := Setup(t)
-	h := activities.NewHandlers(e.DB()).WithBlobstore(blobstore.NewMemory())
+	h := activities.NewHandlers(e.DB()).WithUploadLimit(uploadCeiling).WithBlobstore(blobstore.NewMemory())
 	adminCtx := e.Admin()
 	person := e.SeedPerson(t, "Rep1's Access Target", &e.Rep1)
 	att := uploadTestAttachment(adminCtx, t, h, person, "hidden.pdf", []byte("hidden"))

--- a/backend/internal/compose/integration/attachment_integration_test.go
+++ b/backend/internal/compose/integration/attachment_integration_test.go
@@ -56,7 +56,7 @@ func multipartAttachment(t *testing.T, entityType, entityID, filename string, da
 // end to end against real Postgres + an in-memory store.
 func TestAttachmentHandlersHTTPRoundTrip(t *testing.T) {
 	e := Setup(t)
-	h := activities.NewHandlers(e.DB()).WithBlobstore(blobstore.NewMemory())
+	h := activities.NewHandlers(e.DB()).WithUploadLimit(uploadCeiling).WithBlobstore(blobstore.NewMemory())
 	ctx := e.Admin()
 	person := e.SeedPerson(t, "HTTP Attach", &e.Rep1)
 
@@ -137,7 +137,7 @@ func TestAttachmentHandlersHTTPRoundTrip(t *testing.T) {
 // TestAttachmentHandlersErrorPaths covers the handlers' 404/422 branches.
 func TestAttachmentHandlersErrorPaths(t *testing.T) {
 	e := Setup(t)
-	h := activities.NewHandlers(e.DB()).WithBlobstore(blobstore.NewMemory())
+	h := activities.NewHandlers(e.DB()).WithUploadLimit(uploadCeiling).WithBlobstore(blobstore.NewMemory())
 	ctx := e.Admin()
 	missing := openapi_types.UUID(ids.NewV7())
 
@@ -192,7 +192,7 @@ func TestAttachmentHandlersErrorPaths(t *testing.T) {
 // object store declares attachments unavailable rather than nil-derefing.
 func TestAttachmentHandlersAnswer501WithoutAStore(t *testing.T) {
 	e := Setup(t)
-	h := activities.NewHandlers(e.DB()) // no WithBlobstore
+	h := activities.NewHandlers(e.DB()).WithUploadLimit(uploadCeiling) // no WithBlobstore
 	ctx := e.Admin()
 	person := e.SeedPerson(t, "No Store", &e.Rep1)
 
@@ -235,7 +235,7 @@ func TestAttachmentUploadThenDownloadRoundTrip(t *testing.T) {
 		EntityID:    person,
 		Filename:    "report.pdf",
 		ContentType: "application/pdf",
-		Body:        body,
+		Content:     bytes.NewReader(body),
 	})
 	if err != nil {
 		t.Fatalf("UploadAttachment: %v", err)
@@ -274,7 +274,7 @@ func TestAttachmentUploadDeniedForInvisibleParent(t *testing.T) {
 	ctx := e.As(e.Rep3, []ids.UUID{e.Team2}, ownPersonPerms())
 
 	_, err := store.UploadAttachment(ctx, activities.AttachmentInput{
-		EntityType: "person", EntityID: person, Filename: "x.txt", Body: []byte("secret"),
+		EntityType: "person", EntityID: person, Filename: "x.txt", Content: bytes.NewReader([]byte("secret")),
 	})
 	if !errors.Is(err, apperrors.ErrNotFound) {
 		t.Fatalf("upload to an invisible parent: err = %v, want ErrNotFound (existence-hiding)", err)
@@ -305,7 +305,7 @@ func TestOpenAttachmentHidesAnInvisibleParent(t *testing.T) {
 	person := e.SeedPerson(t, "Rep1's Person", &e.Rep1)
 
 	uploaded, err := store.UploadAttachment(e.Admin(), activities.AttachmentInput{
-		EntityType: "person", EntityID: person, Filename: "secret.pdf", Body: []byte("secret bytes"),
+		EntityType: "person", EntityID: person, Filename: "secret.pdf", Content: bytes.NewReader([]byte("secret bytes")),
 	})
 	if err != nil {
 		t.Fatalf("seeding the attachment through the real writer: %v", err)
@@ -344,7 +344,7 @@ func TestErasurePurgesAttachmentObjects(t *testing.T) {
 	person := e.SeedPerson(t, "To Be Erased", &e.Rep1)
 
 	att, err := store.UploadAttachment(ctx, activities.AttachmentInput{
-		EntityType: "person", EntityID: person, Filename: "secret.pdf", Body: []byte("pii bytes"),
+		EntityType: "person", EntityID: person, Filename: "secret.pdf", Content: bytes.NewReader([]byte("pii bytes")),
 	})
 	if err != nil {
 		t.Fatalf("UploadAttachment: %v", err)
@@ -373,7 +373,7 @@ func TestErasureWithoutStoreRollsBackRatherThanHalfErasing(t *testing.T) {
 	ctx := e.Admin()
 	person := e.SeedPerson(t, "Config Mismatch", &e.Rep1)
 	att, err := store.UploadAttachment(ctx, activities.AttachmentInput{
-		EntityType: "person", EntityID: person, Filename: "f.pdf", Body: []byte("bytes"),
+		EntityType: "person", EntityID: person, Filename: "f.pdf", Content: bytes.NewReader([]byte("bytes")),
 	})
 	if err != nil {
 		t.Fatalf("UploadAttachment: %v", err)
@@ -406,7 +406,7 @@ func TestArchiveAttachmentHidesItButKeepsTheObject(t *testing.T) {
 	ctx := e.Admin()
 	person := e.SeedPerson(t, "Doc Owner", &e.Rep1)
 	att, err := store.UploadAttachment(ctx, activities.AttachmentInput{
-		EntityType: "person", EntityID: person, Filename: "a.txt", Body: []byte("hello"),
+		EntityType: "person", EntityID: person, Filename: "a.txt", Content: bytes.NewReader([]byte("hello")),
 	})
 	if err != nil {
 		t.Fatalf("UploadAttachment: %v", err)

--- a/backend/internal/compose/integration/commsattachments_integration_test.go
+++ b/backend/internal/compose/integration/commsattachments_integration_test.go
@@ -21,6 +21,7 @@ package integration
 // this check; with it retired, the sender's live row scope is the whole gate.
 
 import (
+	"bytes"
 	"context"
 	"testing"
 
@@ -68,7 +69,7 @@ func TestEnsureTransmittableAdmitsAFileTheSenderCanStillRead(t *testing.T) {
 	person := e.SeedPerson(t, "Rep1's Person", &e.Rep1)
 
 	att, err := store.UploadAttachment(e.Admin(), activities.AttachmentInput{
-		EntityType: "person", EntityID: person, Filename: "offer.pdf", Body: []byte("PDF"),
+		EntityType: "person", EntityID: person, Filename: "offer.pdf", Content: bytes.NewReader([]byte("PDF")),
 	})
 	if err != nil {
 		t.Fatalf("seeding the attachment through the real writer: %v", err)
@@ -101,7 +102,7 @@ func TestEnsureTransmittableRefusesAFileTheSenderCanNoLongerSee(t *testing.T) {
 	person := e.SeedPerson(t, "Rep1's Person", &e.Rep1)
 
 	att, err := store.UploadAttachment(e.Admin(), activities.AttachmentInput{
-		EntityType: "person", EntityID: person, Filename: "private.pdf", Body: []byte("PDF"),
+		EntityType: "person", EntityID: person, Filename: "private.pdf", Content: bytes.NewReader([]byte("PDF")),
 	})
 	if err != nil {
 		t.Fatalf("seeding the attachment: %v", err)
@@ -128,7 +129,7 @@ func TestEnsureTransmittableRefusesAFileTheSenderCanNoLongerSee(t *testing.T) {
 	// is admitted.
 	ownPerson := e.SeedPerson(t, "Rep3's Own Person", &e.Rep3)
 	ownAtt, err := store.UploadAttachment(e.Admin(), activities.AttachmentInput{
-		EntityType: "person", EntityID: ownPerson, Filename: "mine.pdf", Body: []byte("PDF"),
+		EntityType: "person", EntityID: ownPerson, Filename: "mine.pdf", Content: bytes.NewReader([]byte("PDF")),
 	})
 	if err != nil {
 		t.Fatalf("seeding the sender's own attachment: %v", err)
@@ -159,7 +160,7 @@ func TestEnsureTransmittableRefusesAnUnknownFileIndistinguishablyFromAnInvisible
 	// A real file, owned by Rep1, that Rep3 cannot see.
 	person := e.SeedPerson(t, "Rep1's Person", &e.Rep1)
 	att, err := store.UploadAttachment(e.Admin(), activities.AttachmentInput{
-		EntityType: "person", EntityID: person, Filename: "private.pdf", Body: []byte("PDF"),
+		EntityType: "person", EntityID: person, Filename: "private.pdf", Content: bytes.NewReader([]byte("PDF")),
 	})
 	if err != nil {
 		t.Fatalf("seeding the attachment: %v", err)

--- a/backend/internal/compose/integration/documenthandlers_integration_test.go
+++ b/backend/internal/compose/integration/documenthandlers_integration_test.go
@@ -54,7 +54,7 @@ func decodeAttachment(t *testing.T, rec *httptest.ResponseRecorder) crmcontracts
 
 func TestAttachmentMetadataTellsAnAbsentFieldFromAnExplicitNull(t *testing.T) {
 	e := Setup(t)
-	h := activities.NewHandlers(e.DB())
+	h := activities.NewHandlers(e.DB()).WithUploadLimit(uploadCeiling)
 	org := e.SeedOrg(t, "Acme", &e.Rep1)
 	doc := seedDocument(t, e, org, "organization", org, "msa.pdf", "contract", false)
 
@@ -82,7 +82,7 @@ func TestAttachmentMetadataTellsAnAbsentFieldFromAnExplicitNull(t *testing.T) {
 
 func TestAttachmentMetadataClearsSupersedesOnlyWhenAsked(t *testing.T) {
 	e := Setup(t)
-	h := activities.NewHandlers(e.DB())
+	h := activities.NewHandlers(e.DB()).WithUploadLimit(uploadCeiling)
 	org := e.SeedOrg(t, "Acme", &e.Rep1)
 	first := seedDocument(t, e, org, "organization", org, "v1.pdf", "contract", false)
 	second := seedDocument(t, e, org, "organization", org, "v2.pdf", "contract", false)
@@ -108,7 +108,7 @@ func TestAttachmentMetadataClearsSupersedesOnlyWhenAsked(t *testing.T) {
 
 func TestOrganizationDocumentsHandlerMapsItsFilters(t *testing.T) {
 	e := Setup(t)
-	h := activities.NewHandlers(e.DB())
+	h := activities.NewHandlers(e.DB()).WithUploadLimit(uploadCeiling)
 	org := e.SeedOrg(t, "Acme", &e.Rep1)
 	seedDocument(t, e, org, "organization", org, "nda.pdf", "legal", false)
 	seedDocument(t, e, org, "organization", org, "msa.pdf", "contract", true)

--- a/backend/internal/compose/integration/documents_integration_test.go
+++ b/backend/internal/compose/integration/documents_integration_test.go
@@ -14,6 +14,7 @@ package integration
 // something is there.
 
 import (
+	"bytes"
 	"errors"
 	"testing"
 
@@ -164,13 +165,13 @@ func TestAnUploadedDocumentReachesTheAccountLibrary(t *testing.T) {
 	ctx := e.As(e.Rep1, []ids.UUID{e.Team1}, docUploadPerms)
 
 	onOrg, err := store.UploadAttachment(ctx, activities.AttachmentInput{
-		EntityType: "organization", EntityID: org, Filename: "nda.pdf", Body: []byte("bytes"),
+		EntityType: "organization", EntityID: org, Filename: "nda.pdf", Content: bytes.NewReader([]byte("bytes")),
 	})
 	if err != nil {
 		t.Fatalf("uploading against the organization: %v", err)
 	}
 	onDeal, err := store.UploadAttachment(ctx, activities.AttachmentInput{
-		EntityType: "deal", EntityID: deal, Filename: "quote.pdf", Body: []byte("bytes"),
+		EntityType: "deal", EntityID: deal, Filename: "quote.pdf", Content: bytes.NewReader([]byte("bytes")),
 	})
 	if err != nil {
 		t.Fatalf("uploading against the deal: %v", err)

--- a/backend/internal/compose/integration/extractionaccept_integration_test.go
+++ b/backend/internal/compose/integration/extractionaccept_integration_test.go
@@ -397,7 +397,7 @@ func TestAcceptAttachmentExtractionEditedAcceptRequiresActivityGrant(t *testing.
 // write one document's values onto another document's deal.
 func TestAcceptAttachmentExtractionRefusesAReadingOfAnotherDocument(t *testing.T) {
 	a := setupExtractionAccept(t)
-	h := activities.NewHandlers(a.DB()).WithBlobstore(blobstore.NewMemory())
+	h := activities.NewHandlers(a.DB()).WithUploadLimit(uploadCeiling).WithBlobstore(blobstore.NewMemory())
 	other := uploadDealAttachment(a.Admin(), t, h, a.deal, "other.pdf", []byte("other bytes"))
 	elsewhere := seedExtractionReading(a.Admin(), t, a.Env, ids.UUID(other.Id), acceptExtractionFields())
 

--- a/backend/internal/compose/integration/extractionaccept_integration_test.go
+++ b/backend/internal/compose/integration/extractionaccept_integration_test.go
@@ -123,7 +123,7 @@ func (a acceptEnv) acceptRequest(keys ...string) crmcontracts.AcceptExtractionRe
 func setupExtractionAccept(t *testing.T) acceptEnv {
 	t.Helper()
 	e := Setup(t)
-	h := activities.NewHandlers(e.DB()).WithBlobstore(blobstore.NewMemory())
+	h := activities.NewHandlers(e.DB()).WithUploadLimit(uploadCeiling).WithBlobstore(blobstore.NewMemory())
 	pipeline, open, _ := DealFixture(t, e)
 	deal := e.SeedDeal(t, "Accept Target", pipeline, open, &e.Rep1)
 	att := uploadDealAttachment(e.Admin(), t, h, deal, "quote.pdf", []byte("quote bytes"))
@@ -264,7 +264,7 @@ func TestAcceptAttachmentExtractionEditFlipsProvenanceAndCapturedBy(t *testing.T
 
 func TestAcceptAttachmentExtractionRefusesNonDealAttachment(t *testing.T) {
 	e := Setup(t)
-	h := activities.NewHandlers(e.DB()).WithBlobstore(blobstore.NewMemory())
+	h := activities.NewHandlers(e.DB()).WithUploadLimit(uploadCeiling).WithBlobstore(blobstore.NewMemory())
 	org := e.SeedOrg(t, "Non-Deal Accept Parent", &e.Rep1)
 	att := uploadTestAttachmentForOrg(e.Admin(), t, h, org, "org-notes.pdf", []byte("org bytes"))
 	reading := seedExtractionReading(e.Admin(), t, e, ids.UUID(att.Id), acceptExtractionFields())
@@ -414,7 +414,7 @@ func TestAcceptAttachmentExtractionRefusesAReadingOfAnotherDocument(t *testing.T
 // an accept finds when no reading exists: nothing to accept, and no write.
 func TestAcceptAttachmentExtractionRefusesWhenNothingHasReadTheDocument(t *testing.T) {
 	e := Setup(t)
-	h := activities.NewHandlers(e.DB()).WithBlobstore(blobstore.NewMemory())
+	h := activities.NewHandlers(e.DB()).WithUploadLimit(uploadCeiling).WithBlobstore(blobstore.NewMemory())
 	pipeline, open, _ := DealFixture(t, e)
 	deal := e.SeedDeal(t, "Accept Target", pipeline, open, &e.Rep1)
 	att := uploadDealAttachment(e.Admin(), t, h, deal, "quote.pdf", []byte("quote bytes"))

--- a/backend/internal/compose/integration/uploadceiling_integration_test.go
+++ b/backend/internal/compose/integration/uploadceiling_integration_test.go
@@ -44,6 +44,7 @@ var uploadCeiling = deployconfig.Config{}.EffectiveUploads().Attachment
 const (
 	testAttachmentMB = 3
 	testCSVImportMB  = 2
+	testLinkedInMB   = 1
 	// Between the two: over the import cap, under the attachment ceiling. What
 	// makes the two keys provably separate rather than one key spelled twice.
 	betweenTheCeilings = 2_500_000
@@ -55,6 +56,7 @@ func configuredUploads(t *testing.T) deployconfig.UploadLimits {
 uploads:
   attachment_mb: 3
   csv_import_mb: 2
+  linkedin_import_mb: 1
 `))
 	if err != nil {
 		t.Fatalf("the uploads section was refused: %v", err)
@@ -287,5 +289,85 @@ func TestAStoredUploadKeepsItsOwnSizeAndChecksum(t *testing.T) {
 		t.Errorf("downloaded %d bytes of a %d-byte file, and not the same ones — "+
 			"the stored object and the row describing it disagree",
 			downloaded.Len(), size)
+	}
+}
+
+// TestTheLinkedInRouteRidesItsOwnConfiguredCeiling covers the third upload
+// route, which the wiring reaches through a different handler set than the
+// other two.
+//
+// Worth its own test because the failure it guards is silent in the worst
+// direction: the chassis would grant the configured ceiling while the handler
+// parsed under a compiled-in one, so a raised limit would be refused by a
+// number the operator never set — and no gate above the transport can see the
+// two disagree.
+func TestTheLinkedInRouteRidesItsOwnConfiguredCeiling(t *testing.T) {
+	e := appWithUploads(t)
+
+	// Under the 1 MB LinkedIn ceiling: refused for its CONTENT (not a LinkedIn
+	// export), which is proof the bytes reached the handler at all.
+	small, smallType := linkedInForm(t, 500_000)
+	code, body := postUpload(t, e, "/v1/me/linkedin-connections", small, smallType)
+	if code == http.StatusRequestEntityTooLarge {
+		t.Errorf("a 500 KB export under a %d MB ceiling was refused as too large: %s",
+			testLinkedInMB, body)
+	}
+
+	// Over it: refused for its SIZE, naming the configured number.
+	big, bigType := linkedInForm(t, 1_500_000)
+	code, body = postUpload(t, e, "/v1/me/linkedin-connections", big, bigType)
+	if code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("a 1.5 MB export under a %d MB ceiling answered %d, want 413: %s",
+			testLinkedInMB, code, body)
+	}
+	if want := fmt.Sprintf("%d MB", testLinkedInMB); !strings.Contains(body, want) {
+		t.Errorf("the refusal %q names a limit other than this route's own %s",
+			body, want)
+	}
+}
+
+// linkedInForm builds an export upload of roughly `size` bytes.
+func linkedInForm(t *testing.T, size int) (*bytes.Buffer, string) {
+	t.Helper()
+	var buf bytes.Buffer
+	form := multipart.NewWriter(&buf)
+	part, err := form.CreateFormFile("file", "Connections.csv")
+	if err != nil {
+		t.Fatalf("creating the file part: %v", err)
+	}
+	if _, err := part.Write(fileOf(size)); err != nil {
+		t.Fatalf("writing the file part: %v", err)
+	}
+	if err := form.Close(); err != nil {
+		t.Fatalf("closing the form: %v", err)
+	}
+	return &buf, form.FormDataContentType()
+}
+
+// TestAnUnwiredImportCeilingIsOurFaultNotTheCallers covers the third guard.
+//
+// The import route reaches its ceiling through a different field than the other
+// two, and it was the one site the first version of this change left unguarded:
+// with no ceiling it answered 413 "the upload exceeds the 0 MB limit", blaming a
+// perfectly good file for a number this composition never set.
+//
+// Driven through the composed server because that is where the omission would
+// happen — a handler built by hand here would be testing the test's own wiring.
+func TestAnUnwiredImportCeilingIsOurFaultNotTheCallers(t *testing.T) {
+	e := apptest.SetupAppWithOptions(t,
+		compose.WithBlobstore(blobstore.NewMemory()),
+		compose.WithUploadLimits(deployconfig.UploadLimits{}))
+	e.BootstrapWorkspace(t)
+
+	form, contentType := importForm(t, 1000)
+	code, body := postUpload(t, e, "/v1/imports/sources", form, contentType)
+
+	if code != http.StatusInternalServerError {
+		t.Fatalf("an unwired import ceiling answered %d, want 500 — anything in "+
+			"the 4xx range blames the caller: %s", code, body)
+	}
+	if strings.Contains(body, "MB") {
+		t.Errorf("the refusal %q names a size limit, which is the misdirection "+
+			"this branch exists to avoid", body)
 	}
 }

--- a/backend/internal/compose/integration/uploadceiling_integration_test.go
+++ b/backend/internal/compose/integration/uploadceiling_integration_test.go
@@ -1,0 +1,265 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// The upload ceiling, end to end: what the deployment file says, what the
+// chassis lets through, and what the refusal tells the person holding the file.
+//
+// These run over a composed server with a real session rather than a
+// hand-built handler, because the bug they exist to prevent IS a wiring bug —
+// four places have to be handed the same number, and a test that constructs the
+// handler itself proves nothing about whether composition did.
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/compose"
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
+	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/platform/blobstore"
+	"github.com/gradionhq/margince/backend/internal/platform/deployconfig"
+)
+
+// uploadCeiling is the shipped attachment default, read from the deployment
+// config rather than restated, so a test never disagrees with the file about
+// what an unconfigured installation allows.
+var uploadCeiling = deployconfig.Config{}.EffectiveUploads().Attachment
+
+// The ceilings these suites configure. Deliberately UNUSUAL — small enough to
+// exceed in a test, and nothing like a shipped default, so a composition that
+// quietly fell back to a compiled-in number fails here instead of passing.
+const (
+	testAttachmentMB = 3
+	testCSVImportMB  = 2
+	// Between the two: over the import cap, under the attachment ceiling. What
+	// makes the two keys provably separate rather than one key spelled twice.
+	betweenTheCeilings = 2_500_000
+)
+
+func configuredUploads(t *testing.T) deployconfig.UploadLimits {
+	t.Helper()
+	cfg, err := deployconfig.Parse([]byte(`version: 1
+uploads:
+  attachment_mb: 3
+  csv_import_mb: 2
+`))
+	if err != nil {
+		t.Fatalf("the uploads section was refused: %v", err)
+	}
+	return cfg.EffectiveUploads()
+}
+
+// appWithUploads starts the real /v1 surface with an object store, the ceilings
+// above, and a signed-in admin.
+func appWithUploads(t *testing.T) *apptest.AppEnv {
+	t.Helper()
+	e := apptest.SetupAppWithOptions(t,
+		compose.WithBlobstore(blobstore.NewMemory()),
+		compose.WithUploadLimits(configuredUploads(t)))
+	e.BootstrapWorkspace(t)
+	return e
+}
+
+// postUpload sends one multipart body to a route and returns its status and
+// response text.
+func postUpload(t *testing.T, e *apptest.AppEnv, path string, form *bytes.Buffer, contentType string) (int, string) {
+	t.Helper()
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, e.TS.URL+path, form)
+	if err != nil {
+		t.Fatalf("building the upload: %v", err)
+	}
+	req.Header.Set("Content-Type", contentType)
+	//nolint:bodyclose // apptest.CloseBody closes it in the deferred call below, which the checker cannot follow across the helper.
+	resp, err := e.Client.Do(req)
+	if err != nil {
+		t.Fatalf("uploading: %v", err)
+	}
+	defer apptest.CloseBody(t, resp)
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("reading the upload response: %v", err)
+	}
+	return resp.StatusCode, string(raw)
+}
+
+// attachmentForm builds an upload of `size` bytes against the installation's
+// own organization, which every bootstrapped workspace has.
+func attachmentForm(t *testing.T, e *apptest.AppEnv, size int) (*bytes.Buffer, string) {
+	t.Helper()
+	var buf bytes.Buffer
+	form := multipart.NewWriter(&buf)
+	for field, value := range map[string]string{
+		"entity_type": "organization",
+		"entity_id":   anOrganizationID(t, e),
+	} {
+		if err := form.WriteField(field, value); err != nil {
+			t.Fatalf("writing %s: %v", field, err)
+		}
+	}
+	part, err := form.CreateFormFile("file", "scan.pdf")
+	if err != nil {
+		t.Fatalf("creating the file part: %v", err)
+	}
+	if _, err := part.Write(make([]byte, size)); err != nil {
+		t.Fatalf("writing the file part: %v", err)
+	}
+	if err := form.Close(); err != nil {
+		t.Fatalf("closing the form: %v", err)
+	}
+	return &buf, form.FormDataContentType()
+}
+
+// anOrganizationID creates a company over the real endpoint, so the parent an
+// upload is filed against is one the product itself made.
+func anOrganizationID(t *testing.T, e *apptest.AppEnv) string {
+	t.Helper()
+	return createdID(t, e, "/v1/organizations", apptest.AnyMap{"display_name": "Ceiling Test GmbH"})
+}
+
+func importForm(t *testing.T, size int) (*bytes.Buffer, string) {
+	t.Helper()
+	var buf bytes.Buffer
+	form := multipart.NewWriter(&buf)
+	if err := form.WriteField("object", "leads"); err != nil {
+		t.Fatalf("writing the object field: %v", err)
+	}
+	part, err := form.CreateFormFile("file", "estate.csv")
+	if err != nil {
+		t.Fatalf("creating the file part: %v", err)
+	}
+	if _, err := part.Write(bytes.Repeat([]byte("a,b,c\n"), size/6)); err != nil {
+		t.Fatalf("writing the file part: %v", err)
+	}
+	if err := form.Close(); err != nil {
+		t.Fatalf("closing the form: %v", err)
+	}
+	return &buf, form.FormDataContentType()
+}
+
+// TestAnUploadOverTheJSONBoundReachesTheHandler is the defect the ceiling
+// exists for: before it, every route rode 1 MiB, so a 2 MB document was refused
+// by the chassis with a message about a JSON body nobody sent.
+func TestAnUploadOverTheJSONBoundReachesTheHandler(t *testing.T) {
+	e := appWithUploads(t)
+	form, contentType := attachmentForm(t, e, 2<<20)
+
+	code, body := postUpload(t, e, "/v1/attachments", form, contentType)
+	if code != http.StatusCreated {
+		t.Fatalf("a 2 MiB upload under a %d MB ceiling answered %d: %s",
+			testAttachmentMB, code, body)
+	}
+}
+
+// TestAnOversizeUploadIsRefusedWithTheConfiguredNumber is the other half: the
+// refusal has to name the limit THIS installation applies. A compiled-in number
+// in that sentence sends the reader off to shrink a file against the wrong bar.
+func TestAnOversizeUploadIsRefusedWithTheConfiguredNumber(t *testing.T) {
+	e := appWithUploads(t)
+	form, contentType := attachmentForm(t, e, 4_000_000)
+
+	code, body := postUpload(t, e, "/v1/attachments", form, contentType)
+	if code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("a 4 MB upload under a %d MB ceiling answered %d, want 413: %s",
+			testAttachmentMB, code, body)
+	}
+	if want := fmt.Sprintf("%d MB", testAttachmentMB); !strings.Contains(body, want) {
+		t.Errorf("the refusal %q does not name the configured %s limit", body, want)
+	}
+}
+
+// TestTheInstallationReadPublishesTheConfiguredCeiling closes the loop: the
+// number the client is told is the number the server enforces. It is published
+// so an upload surface can refuse before sending rather than after, which is
+// only honest while the two cannot drift.
+func TestTheInstallationReadPublishesTheConfiguredCeiling(t *testing.T) {
+	e := appWithUploads(t)
+	var settings crmcontracts.InstallationSettings
+	if code := e.Call(t, http.MethodGet, "/v1/installation/settings", nil, nil, &settings); code != http.StatusOK {
+		t.Fatalf("reading installation settings answered %d", code)
+	}
+
+	if want := configuredUploads(t).Attachment; settings.MaxUploadBytes != want {
+		t.Errorf("the installation reports a %d-byte ceiling but enforces %d — a "+
+			"client that trusts this number either refuses files the server would "+
+			"take, or sends files it will not", settings.MaxUploadBytes, want)
+	}
+}
+
+// TestEachUploadRouteIsBoundedSeparately proves the per-route keys are not one
+// key with three spellings: the import cap refuses a body the attachment
+// ceiling takes.
+func TestEachUploadRouteIsBoundedSeparately(t *testing.T) {
+	e := appWithUploads(t)
+
+	form, contentType := attachmentForm(t, e, betweenTheCeilings)
+	if code, body := postUpload(t, e, "/v1/attachments", form, contentType); code != http.StatusCreated {
+		t.Fatalf("a %d-byte upload under the %d MB attachment ceiling answered %d: %s",
+			betweenTheCeilings, testAttachmentMB, code, body)
+	}
+
+	importBody, importType := importForm(t, betweenTheCeilings)
+	code, body := postUpload(t, e, "/v1/imports/sources", importBody, importType)
+	if code != http.StatusRequestEntityTooLarge {
+		t.Errorf("the same %d bytes answered %d on the import route, want 413 — "+
+			"raising what a scanned contract may weigh must not raise what a CSV "+
+			"import will attempt: %s", betweenTheCeilings, code, body)
+	}
+	if code == http.StatusRequestEntityTooLarge &&
+		!strings.Contains(body, fmt.Sprintf("%d MB", testCSVImportMB)) {
+		t.Errorf("the import refusal %q names a limit other than its own %d MB",
+			body, testCSVImportMB)
+	}
+}
+
+// TestAStoredUploadKeepsItsOwnSizeAndChecksum guards the streaming write path.
+// The bytes are hashed on one pass and stored on a second, and a rewind that
+// did not happen would store an empty object under a checksum of the real one —
+// a row that reads perfectly and describes nothing.
+func TestAStoredUploadKeepsItsOwnSizeAndChecksum(t *testing.T) {
+	e := appWithUploads(t)
+	const size = 2 << 20
+	form, contentType := attachmentForm(t, e, size)
+
+	code, body := postUpload(t, e, "/v1/attachments", form, contentType)
+	if code != http.StatusCreated {
+		t.Fatalf("upload answered %d: %s", code, body)
+	}
+	var stored crmcontracts.Attachment
+	if err := json.Unmarshal([]byte(body), &stored); err != nil {
+		t.Fatalf("decoding the stored attachment: %v", err)
+	}
+	if stored.ByteSize == nil || *stored.ByteSize != size {
+		t.Errorf("the row records %v bytes for a %d-byte file", stored.ByteSize, size)
+	}
+
+	var downloaded bytes.Buffer
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet,
+		e.TS.URL+"/v1/attachments/"+stored.Id.String(), nil)
+	if err != nil {
+		t.Fatalf("building the download: %v", err)
+	}
+	//nolint:bodyclose // apptest.CloseBody closes it in the deferred call below, which the checker cannot follow across the helper.
+	resp, err := e.Client.Do(req)
+	if err != nil {
+		t.Fatalf("downloading: %v", err)
+	}
+	defer apptest.CloseBody(t, resp)
+	if _, err := io.Copy(&downloaded, resp.Body); err != nil {
+		t.Fatalf("reading the download: %v", err)
+	}
+	if downloaded.Len() != size {
+		t.Errorf("downloaded %d bytes of a %d-byte file — the object and the row "+
+			"it is described by disagree", downloaded.Len(), size)
+	}
+}

--- a/backend/internal/compose/integration/uploadceiling_integration_test.go
+++ b/backend/internal/compose/integration/uploadceiling_integration_test.go
@@ -16,6 +16,8 @@ package integration
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -93,9 +95,22 @@ func postUpload(t *testing.T, e *apptest.AppEnv, path string, form *bytes.Buffer
 	return resp.StatusCode, string(raw)
 }
 
-// attachmentForm builds an upload of `size` bytes against the installation's
-// own organization, which every bootstrapped workspace has.
-func attachmentForm(t *testing.T, e *apptest.AppEnv, size int) (*bytes.Buffer, string) {
+// fileOf is `size` bytes that are not all the same byte.
+//
+// Non-uniform on purpose: a run of zeroes hashes to a fixed value, so a digest
+// bug that returned a constant would agree with the expected checksum for every
+// test that used one.
+func fileOf(size int) []byte {
+	content := make([]byte, size)
+	for i := range content {
+		content[i] = byte(i%251 + 1)
+	}
+	return content
+}
+
+// attachmentForm builds an upload of the given bytes against an organization
+// the product itself created.
+func attachmentForm(t *testing.T, e *apptest.AppEnv, content []byte) (*bytes.Buffer, string) {
 	t.Helper()
 	var buf bytes.Buffer
 	form := multipart.NewWriter(&buf)
@@ -111,7 +126,7 @@ func attachmentForm(t *testing.T, e *apptest.AppEnv, size int) (*bytes.Buffer, s
 	if err != nil {
 		t.Fatalf("creating the file part: %v", err)
 	}
-	if _, err := part.Write(make([]byte, size)); err != nil {
+	if _, err := part.Write(content); err != nil {
 		t.Fatalf("writing the file part: %v", err)
 	}
 	if err := form.Close(); err != nil {
@@ -152,7 +167,7 @@ func importForm(t *testing.T, size int) (*bytes.Buffer, string) {
 // by the chassis with a message about a JSON body nobody sent.
 func TestAnUploadOverTheJSONBoundReachesTheHandler(t *testing.T) {
 	e := appWithUploads(t)
-	form, contentType := attachmentForm(t, e, 2<<20)
+	form, contentType := attachmentForm(t, e, fileOf(2<<20))
 
 	code, body := postUpload(t, e, "/v1/attachments", form, contentType)
 	if code != http.StatusCreated {
@@ -166,7 +181,7 @@ func TestAnUploadOverTheJSONBoundReachesTheHandler(t *testing.T) {
 // in that sentence sends the reader off to shrink a file against the wrong bar.
 func TestAnOversizeUploadIsRefusedWithTheConfiguredNumber(t *testing.T) {
 	e := appWithUploads(t)
-	form, contentType := attachmentForm(t, e, 4_000_000)
+	form, contentType := attachmentForm(t, e, fileOf(4_000_000))
 
 	code, body := postUpload(t, e, "/v1/attachments", form, contentType)
 	if code != http.StatusRequestEntityTooLarge {
@@ -202,7 +217,7 @@ func TestTheInstallationReadPublishesTheConfiguredCeiling(t *testing.T) {
 func TestEachUploadRouteIsBoundedSeparately(t *testing.T) {
 	e := appWithUploads(t)
 
-	form, contentType := attachmentForm(t, e, betweenTheCeilings)
+	form, contentType := attachmentForm(t, e, fileOf(betweenTheCeilings))
 	if code, body := postUpload(t, e, "/v1/attachments", form, contentType); code != http.StatusCreated {
 		t.Fatalf("a %d-byte upload under the %d MB attachment ceiling answered %d: %s",
 			betweenTheCeilings, testAttachmentMB, code, body)
@@ -229,7 +244,8 @@ func TestEachUploadRouteIsBoundedSeparately(t *testing.T) {
 func TestAStoredUploadKeepsItsOwnSizeAndChecksum(t *testing.T) {
 	e := appWithUploads(t)
 	const size = 2 << 20
-	form, contentType := attachmentForm(t, e, size)
+	content := fileOf(size)
+	form, contentType := attachmentForm(t, e, content)
 
 	code, body := postUpload(t, e, "/v1/attachments", form, contentType)
 	if code != http.StatusCreated {
@@ -241,6 +257,15 @@ func TestAStoredUploadKeepsItsOwnSizeAndChecksum(t *testing.T) {
 	}
 	if stored.ByteSize == nil || *stored.ByteSize != size {
 		t.Errorf("the row records %v bytes for a %d-byte file", stored.ByteSize, size)
+	}
+	// The checksum is asserted, not merely mentioned. It is written from the
+	// hashing pass and the object from a second read of the same reader, so a
+	// digest that ran on the wrong bytes — or on none, after a rewind that did
+	// not happen — is exactly what this compares against.
+	want := sha256.Sum256(content)
+	if stored.Checksum == nil || *stored.Checksum != hex.EncodeToString(want[:]) {
+		t.Errorf("the row records checksum %v for content that hashes to %s",
+			stored.Checksum, hex.EncodeToString(want[:]))
 	}
 
 	var downloaded bytes.Buffer
@@ -258,8 +283,9 @@ func TestAStoredUploadKeepsItsOwnSizeAndChecksum(t *testing.T) {
 	if _, err := io.Copy(&downloaded, resp.Body); err != nil {
 		t.Fatalf("reading the download: %v", err)
 	}
-	if downloaded.Len() != size {
-		t.Errorf("downloaded %d bytes of a %d-byte file — the object and the row "+
-			"it is described by disagree", downloaded.Len(), size)
+	if !bytes.Equal(downloaded.Bytes(), content) {
+		t.Errorf("downloaded %d bytes of a %d-byte file, and not the same ones — "+
+			"the stored object and the row describing it disagree",
+			downloaded.Len(), size)
 	}
 }

--- a/backend/internal/compose/routes.go
+++ b/backend/internal/compose/routes.go
@@ -292,8 +292,8 @@ func WithUploadLimits(limits deployconfig.UploadLimits) Option {
 		s.uploadLimits = limits
 		s.activitiesHandlers = s.activitiesHandlers.WithUploadLimit(limits.Attachment)
 		s.peopleHandlers = s.peopleHandlers.WithUploadLimit(limits.LinkedInImport)
-		s.importHandlers.uploadLimit = limits.CSVImport
-		s.installationSettingsHandlers.maxUploadBytes = limits.Attachment
+		s.uploadLimit = limits.CSVImport
+		s.maxUploadBytes = limits.Attachment
 	}
 }
 

--- a/backend/internal/compose/routes.go
+++ b/backend/internal/compose/routes.go
@@ -277,6 +277,26 @@ func WithBootstrapSeeds(seeds deployconfig.Seeds) Option {
 	}
 }
 
+// WithUploadLimits carries the deployment file's `uploads` section to every
+// place one number has to be the same number (OPS-CFG-12): the chassis ceiling
+// a route rides, the cap its handler parses under, and the figure the
+// installation read publishes so a client can refuse an oversize file before
+// sending it.
+//
+// All three are set from ONE value here rather than resolved separately, which
+// is the only arrangement in which they cannot disagree. Without the option the
+// compiled-in defaults stand — the composition is still fully bounded, it just
+// was never told about a deployment file.
+func WithUploadLimits(limits deployconfig.UploadLimits) Option {
+	return func(s *Server, _ *pgxpool.Pool) {
+		s.uploadLimits = limits
+		s.activitiesHandlers = s.activitiesHandlers.WithUploadLimit(limits.Attachment)
+		s.peopleHandlers = s.peopleHandlers.WithUploadLimit(limits.LinkedInImport)
+		s.importHandlers.uploadLimit = limits.CSVImport
+		s.installationSettingsHandlers.maxUploadBytes = limits.Attachment
+	}
+}
+
 // extensionEdge builds the composed extension router and returns it as an edge
 // around the generated /v1 surface: a request matching a declared extension
 // route is served by that router, and everything else falls straight through.

--- a/backend/internal/compose/server.go
+++ b/backend/internal/compose/server.go
@@ -165,6 +165,15 @@ type Server struct {
 	// ready on Postgres alone.
 	busReady func(context.Context) error
 
+	// uploadLimits are the deployment's per-route body ceilings for the routes
+	// that carry files (OPS-CFG-12), injected by WithUploadLimits. They govern
+	// three things that must agree: the chassis ceiling each route rides, the
+	// cap its handler parses under, and the number the installation read
+	// publishes to a client. Defaulted in New, so a composition never told
+	// about a deployment file still gets the compiled-in ceilings rather than
+	// zero — which would refuse every upload.
+	uploadLimits deployconfig.UploadLimits
+
 	// blob is the object store, injected by WithBlobstore. When configured
 	// it feeds a /readyz probe and backs the attachment handlers; nil means
 	// a role that stores no objects.
@@ -379,19 +388,25 @@ func New(pool *pgxpool.Pool, log *slog.Logger, opts ...Option) http.Handler {
 	mux := operationalMux(srv, pool, log, identitySvc, api)
 
 	return httpserver.RecoverPanics(log,
-		httpserver.LimitBodies(bodyCeiling, httpserver.SecureHeaders(mux)))
+		httpserver.LimitBodies(bodyCeilingFor(uploadCeilings(srv.uploadLimits)),
+			httpserver.SecureHeaders(mux)))
 }
 
 // newServer assembles the module handler sets. Every cross-module edge is
 // injected here, or in the assembly step this calls for it
 // (serverassembly.go) — never as a sibling import (ADR-0054).
 func newServer(pool *pgxpool.Pool, log *slog.Logger, authH authHandlers, dealsH dealsHandlers) Server {
+	// The compiled-in ceilings, taken from the deployment-config defaults rather
+	// than restated here: one place resolves a default, so no composition can
+	// disagree with the file about what "unconfigured" means.
+	limits := deployconfig.Config{}.EffectiveUploads()
 	srv := Server{
+		uploadLimits:       limits,
 		authHandlers:       authH,
-		peopleHandlers:     newPeopleHandlers(pool),
+		peopleHandlers:     newPeopleHandlers(pool).WithUploadLimit(limits.LinkedInImport),
 		dealsHandlers:      dealsH,
 		contractsHandlers:  contracts.NewHandlers(InstallationDB(pool)),
-		activitiesHandlers: newActivitiesHandlers(pool),
+		activitiesHandlers: newActivitiesHandlers(pool).WithUploadLimit(limits.Attachment),
 		searchHandlers:     search.NewHandlers(InstallationDB(pool)),
 		// Constructed, not merely embedded: the handler carries no nil-pool
 		// branch, so the zero value would panic on the first authenticated

--- a/backend/internal/compose/serverassembly.go
+++ b/backend/internal/compose/serverassembly.go
@@ -102,7 +102,8 @@ func (s *Server) wireCaptureSettingsSurface(pool *pgxpool.Pool) {
 	// name, reporting zone, base currency — the last of which locks once a
 	// deal has converted against it (ADR-0085 §7).
 	s.installationSettingsHandlers = installationSettingsHandlers{
-		store: identity.NewInstallationSettings(InstallationDB(pool), NewSettingsStore(pool)),
+		store:          identity.NewInstallationSettings(InstallationDB(pool), NewSettingsStore(pool)),
+		maxUploadBytes: s.uploadLimits.Attachment,
 	}
 	// The workspace's own consumer-mail list (CAP-PARAM-5): the surviving
 	// domain control, and the only way an operator corrects a shipped
@@ -173,7 +174,7 @@ func (s *Server) wireSystemOfRecordReads(pool *pgxpool.Pool) {
 	s.blockedDomainHandlers = blockedDomainHandlers{people: s.peopleStore}
 	// The importer maps only core columns (see importTargets for why custom
 	// fields are not among them), so it needs no field catalog of its own.
-	s.importHandlers = importHandlers{db: InstallationDB(pool)}
+	s.importHandlers = importHandlers{db: InstallationDB(pool), uploadLimit: s.uploadLimits.CSVImport}
 	s.org360Svc = org360.NewService(pool, s.peopleStore, approvals.NewService(InstallationDB(pool)), time.Now)
 	s.orgBriefSvc = orgbrief.NewService(pool, s.org360Svc, s.peopleStore, nil, "", time.Now)
 	s.orgBriefHandlers = orgbrief.NewHandlers(s.orgBriefSvc, s.sorDispatch.isOverlay)

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -14292,6 +14292,16 @@ type InstallationSettings struct {
 	// it. Absent when it is still changeable.
 	BaseCurrencyLockedReason *string `json:"base_currency_locked_reason,omitempty"`
 
+	// MaxUploadBytes The largest upload request this installation accepts, in bytes — set by whoever
+	// operates it, not compiled into the build (OPS-CFG-12, DOC-PARAM-11). Read-only:
+	// it is a deployment fact, so PATCH does not carry it.
+	//
+	// An upload surface states and enforces THIS number rather than one of its own, so
+	// a file too large is refused before it is sent instead of after. The ceiling bounds
+	// the whole request, part framing included, which is why a client should leave a
+	// little room rather than compare a file against it exactly.
+	MaxUploadBytes int64 `json:"max_upload_bytes"`
+
 	// Name The organization's display name.
 	Name string `json:"name"`
 

--- a/backend/internal/modules/activities/attachment.go
+++ b/backend/internal/modules/activities/attachment.go
@@ -4,7 +4,6 @@
 package activities
 
 import (
-	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
@@ -37,15 +36,21 @@ func (h Handlers) WithBlobstore(blob blobstore.Store) Handlers {
 // maps it to 501). A role opts in with Store.WithBlobstore.
 var ErrBlobstoreUnconfigured = errors.New("activities: no object store configured")
 
-// AttachmentInput is one upload's server-validated inputs. Body is already
-// read (bounded) by the transport; captured_by is stamped from the
-// principal in the store, never taken from the request.
+// AttachmentInput is one upload's server-validated inputs. captured_by is
+// stamped from the principal in the store, never taken from the request.
 type AttachmentInput struct {
 	EntityType  string
 	EntityID    ids.UUID
 	Filename    string
 	ContentType string
-	Body        []byte
+	// Content is the file, still unread. A reader rather than bytes so an
+	// upload is never resident in full — the transport has already bounded it,
+	// and the store reads it twice (hash, then store) by seeking back rather
+	// than by keeping a copy. Its length is COUNTED on the hashing pass and
+	// never declared alongside it: a size that travels beside the bytes is a
+	// size that can disagree with them, and `byte_size` is a column every later
+	// reader trusts.
+	Content io.ReadSeeker
 	// ContractID files this document against one agreement (ADR-0109). A
 	// roll-up like the account column beside it, not a second parent: the
 	// primary entity still owns the file's visibility.
@@ -93,6 +98,25 @@ func requireParentOrHide(ctx context.Context, entityType string, action principa
 	return nil
 }
 
+// digest reads the upload once to fingerprint and measure it, then rewinds so
+// the object store can read the same bytes from the start.
+//
+// Both facts come from the SAME pass. A checksum and a length that were
+// established separately can describe different content, and they are what a
+// later integrity check compares against — so they are produced together or the
+// comparison proves nothing.
+func digest(content io.ReadSeeker) (string, int64, error) {
+	sum := sha256.New()
+	size, err := io.Copy(sum, content)
+	if err != nil {
+		return "", 0, fmt.Errorf("activities: reading the uploaded file: %w", err)
+	}
+	if _, err := content.Seek(0, io.SeekStart); err != nil {
+		return "", 0, fmt.Errorf("activities: rewinding the uploaded file: %w", err)
+	}
+	return hex.EncodeToString(sum.Sum(nil)), size, nil
+}
+
 // UploadAttachment stores an object and records its metadata row. Authority
 // inherits from the parent entity: the caller must hold Update on the parent
 // object type and be able to see the parent row — both are checked BEFORE any
@@ -122,11 +146,12 @@ func (s *Store) UploadAttachment(ctx context.Context, in AttachmentInput) (crmco
 
 	id := ids.NewV7()
 	key := blobstore.WorkspaceKey(workspaceID(ctx), "attachment", id.String())
-	sum := sha256.Sum256(in.Body)
-	checksum := hex.EncodeToString(sum[:])
-	size := int64(len(in.Body))
+	checksum, size, err := digest(in.Content)
+	if err != nil {
+		return crmcontracts.Attachment{}, err
+	}
 
-	if err := s.blob.Put(ctx, key, bytes.NewReader(in.Body), size, in.ContentType); err != nil {
+	if err := s.blob.Put(ctx, key, in.Content, size, in.ContentType); err != nil {
 		return crmcontracts.Attachment{}, err
 	}
 

--- a/backend/internal/modules/activities/attachment.go
+++ b/backend/internal/modules/activities/attachment.go
@@ -5,8 +5,6 @@ package activities
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -35,27 +33,6 @@ func (h Handlers) WithBlobstore(blob blobstore.Store) Handlers {
 // store, so the attachment endpoints are not available here (the handler
 // maps it to 501). A role opts in with Store.WithBlobstore.
 var ErrBlobstoreUnconfigured = errors.New("activities: no object store configured")
-
-// AttachmentInput is one upload's server-validated inputs. captured_by is
-// stamped from the principal in the store, never taken from the request.
-type AttachmentInput struct {
-	EntityType  string
-	EntityID    ids.UUID
-	Filename    string
-	ContentType string
-	// Content is the file, still unread. A reader rather than bytes so an
-	// upload is never resident in full — the transport has already bounded it,
-	// and the store reads it twice (hash, then store) by seeking back rather
-	// than by keeping a copy. Its length is COUNTED on the hashing pass and
-	// never declared alongside it: a size that travels beside the bytes is a
-	// size that can disagree with them, and `byte_size` is a column every later
-	// reader trusts.
-	Content io.ReadSeeker
-	// ContractID files this document against one agreement (ADR-0109). A
-	// roll-up like the account column beside it, not a second parent: the
-	// primary entity still owns the file's visibility.
-	ContractID *ids.UUID
-}
 
 const attachmentColumns = `at.id, at.entity_type, at.entity_id, at.filename,
 	at.content_type, at.byte_size, at.checksum, at.source, at.captured_by, at.created_at,
@@ -96,109 +73,6 @@ func requireParentOrHide(ctx context.Context, entityType string, action principa
 		return err
 	}
 	return nil
-}
-
-// digest reads the upload once to fingerprint and measure it, then rewinds so
-// the object store can read the same bytes from the start.
-//
-// Both facts come from the SAME pass. A checksum and a length that were
-// established separately can describe different content, and they are what a
-// later integrity check compares against — so they are produced together or the
-// comparison proves nothing.
-func digest(content io.ReadSeeker) (string, int64, error) {
-	sum := sha256.New()
-	size, err := io.Copy(sum, content)
-	if err != nil {
-		return "", 0, fmt.Errorf("activities: reading the uploaded file: %w", err)
-	}
-	if _, err := content.Seek(0, io.SeekStart); err != nil {
-		return "", 0, fmt.Errorf("activities: rewinding the uploaded file: %w", err)
-	}
-	return hex.EncodeToString(sum.Sum(nil)), size, nil
-}
-
-// UploadAttachment stores an object and records its metadata row. Authority
-// inherits from the parent entity: the caller must hold Update on the parent
-// object type and be able to see the parent row — both are checked BEFORE any
-// bytes are written, so an upload to a hidden or cross-tenant entity cannot
-// land an object (no storage abuse). The object is put before the row commits
-// (a committed row always has its bytes; a failed write leaves at worst an
-// orphan object, never a row promising bytes that are not there).
-func (s *Store) UploadAttachment(ctx context.Context, in AttachmentInput) (crmcontracts.Attachment, error) {
-	if s.blob == nil {
-		return crmcontracts.Attachment{}, ErrBlobstoreUnconfigured
-	}
-	if err := auth.Require(ctx, in.EntityType, principal.ActionUpdate); err != nil {
-		return crmcontracts.Attachment{}, err
-	}
-	if err := s.tx(ctx, func(tx pgx.Tx) error {
-		if err := ensureAttachmentParentVisible(ctx, tx, in.EntityType, in.EntityID); err != nil {
-			return err
-		}
-		return ensureContractFileable(ctx, tx, in.ContractID)
-	}); err != nil {
-		return crmcontracts.Attachment{}, err
-	}
-	by, err := storekit.CapturedBy(ctx)
-	if err != nil {
-		return crmcontracts.Attachment{}, err
-	}
-
-	id := ids.NewV7()
-	key := blobstore.WorkspaceKey(workspaceID(ctx), "attachment", id.String())
-	checksum, size, err := digest(in.Content)
-	if err != nil {
-		return crmcontracts.Attachment{}, err
-	}
-
-	if err := s.blob.Put(ctx, key, in.Content, size, in.ContentType); err != nil {
-		return crmcontracts.Attachment{}, err
-	}
-
-	var out crmcontracts.Attachment
-	err = s.tx(ctx, func(tx pgx.Tx) error {
-		// Re-checked HERE, in the transaction that writes the column. The
-		// pre-flight check above runs before the bytes are stored, so an
-		// agreement archived or re-anchored during the upload would otherwise
-		// still receive the document — the row commits against a contract the
-		// caller can no longer see.
-		if err := ensureContractFileable(ctx, tx, in.ContractID); err != nil {
-			return err
-		}
-		rollUp, hasAccount, err := accountRollUp(ctx, tx, in.EntityType, in.EntityID)
-		if err != nil {
-			return err
-		}
-		var account *ids.UUID
-		if hasAccount {
-			account = &rollUp
-		}
-		if _, err := tx.Exec(ctx, `
-			INSERT INTO attachment (id, entity_type, entity_id, filename,
-				content_type, byte_size, storage_key, checksum, source, captured_by,
-				organization_id, contract_id)
-			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)`,
-			id, in.EntityType, in.EntityID, in.Filename,
-			nullIfEmpty(in.ContentType), size, key, checksum, attachmentSource, by,
-			account, in.ContractID); err != nil {
-			return err
-		}
-		if _, err := storekit.Audit(ctx, tx, "create", "attachment", id, nil, map[string]any{
-			fieldEntityType: in.EntityType,
-			fieldEntityID:   in.EntityID.String(),
-			"filename":      in.Filename,
-			"byte_size":     size,
-		}); err != nil {
-			return err
-		}
-		att, err := readAttachment(ctx, tx, id)
-		if err != nil {
-			return err
-		}
-		out = att
-		return nil
-	})
-	return out, err
 }
 
 // resolveVisibleAttachmentParent is the ONE spelling of "find a live

--- a/backend/internal/modules/activities/attachmentupload.go
+++ b/backend/internal/modules/activities/attachmentupload.go
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package activities
+
+// The attachment WRITE path: what one upload carries, how its bytes are
+// fingerprinted and measured, and the transaction that lands the object and the
+// row describing it.
+//
+// Separate from the read side beside it because the two answer different
+// questions — this one is about authority and durability before anything
+// exists, that one about scope over rows that already do.
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+
+	"github.com/jackc/pgx/v5"
+
+	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/platform/auth"
+	"github.com/gradionhq/margince/backend/internal/platform/blobstore"
+	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+)
+
+// AttachmentInput is one upload's server-validated inputs. captured_by is
+// stamped from the principal in the store, never taken from the request.
+type AttachmentInput struct {
+	EntityType  string
+	EntityID    ids.UUID
+	Filename    string
+	ContentType string
+	// Content is the file, still unread. A reader rather than bytes so an
+	// upload is never resident in full — the transport has already bounded it,
+	// and the store reads it twice (hash, then store) by seeking back rather
+	// than by keeping a copy. Its length is COUNTED on the hashing pass and
+	// never declared alongside it: a size that travels beside the bytes is a
+	// size that can disagree with them, and `byte_size` is a column every later
+	// reader trusts.
+	Content io.ReadSeeker
+	// ContractID files this document against one agreement (ADR-0109). A
+	// roll-up like the account column beside it, not a second parent: the
+	// primary entity still owns the file's visibility.
+	ContractID *ids.UUID
+}
+
+// digest reads the upload once to fingerprint and measure it, then rewinds so
+// the object store can read the same bytes from the start.
+//
+// Both facts come from the SAME pass. A checksum and a length that were
+// established separately can describe different content, and they are what a
+// later integrity check compares against — so they are produced together or the
+// comparison proves nothing.
+func digest(content io.ReadSeeker) (string, int64, error) {
+	sum := sha256.New()
+	size, err := io.Copy(sum, content)
+	if err != nil {
+		return "", 0, fmt.Errorf("activities: reading the uploaded file: %w", err)
+	}
+	if _, err := content.Seek(0, io.SeekStart); err != nil {
+		return "", 0, fmt.Errorf("activities: rewinding the uploaded file: %w", err)
+	}
+	return hex.EncodeToString(sum.Sum(nil)), size, nil
+}
+
+// UploadAttachment stores an object and records its metadata row. Authority
+// inherits from the parent entity: the caller must hold Update on the parent
+// object type and be able to see the parent row — both are checked BEFORE any
+// bytes are written, so an upload to a hidden or cross-tenant entity cannot
+// land an object (no storage abuse). The object is put before the row commits
+// (a committed row always has its bytes; a failed write leaves at worst an
+// orphan object, never a row promising bytes that are not there).
+func (s *Store) UploadAttachment(ctx context.Context, in AttachmentInput) (crmcontracts.Attachment, error) {
+	if s.blob == nil {
+		return crmcontracts.Attachment{}, ErrBlobstoreUnconfigured
+	}
+	if err := auth.Require(ctx, in.EntityType, principal.ActionUpdate); err != nil {
+		return crmcontracts.Attachment{}, err
+	}
+	if err := s.tx(ctx, func(tx pgx.Tx) error {
+		if err := ensureAttachmentParentVisible(ctx, tx, in.EntityType, in.EntityID); err != nil {
+			return err
+		}
+		return ensureContractFileable(ctx, tx, in.ContractID)
+	}); err != nil {
+		return crmcontracts.Attachment{}, err
+	}
+	by, err := storekit.CapturedBy(ctx)
+	if err != nil {
+		return crmcontracts.Attachment{}, err
+	}
+
+	id := ids.NewV7()
+	key := blobstore.WorkspaceKey(workspaceID(ctx), "attachment", id.String())
+	checksum, size, err := digest(in.Content)
+	if err != nil {
+		return crmcontracts.Attachment{}, err
+	}
+
+	if err := s.blob.Put(ctx, key, in.Content, size, in.ContentType); err != nil {
+		return crmcontracts.Attachment{}, err
+	}
+
+	var out crmcontracts.Attachment
+	err = s.tx(ctx, func(tx pgx.Tx) error {
+		// Re-checked HERE, in the transaction that writes the column. The
+		// pre-flight check above runs before the bytes are stored, so an
+		// agreement archived or re-anchored during the upload would otherwise
+		// still receive the document — the row commits against a contract the
+		// caller can no longer see.
+		if err := ensureContractFileable(ctx, tx, in.ContractID); err != nil {
+			return err
+		}
+		rollUp, hasAccount, err := accountRollUp(ctx, tx, in.EntityType, in.EntityID)
+		if err != nil {
+			return err
+		}
+		var account *ids.UUID
+		if hasAccount {
+			account = &rollUp
+		}
+		if _, err := tx.Exec(ctx, `
+			INSERT INTO attachment (id, entity_type, entity_id, filename,
+				content_type, byte_size, storage_key, checksum, source, captured_by,
+				organization_id, contract_id)
+			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)`,
+			id, in.EntityType, in.EntityID, in.Filename,
+			nullIfEmpty(in.ContentType), size, key, checksum, attachmentSource, by,
+			account, in.ContractID); err != nil {
+			return err
+		}
+		if _, err := storekit.Audit(ctx, tx, "create", "attachment", id, nil, map[string]any{
+			fieldEntityType: in.EntityType,
+			fieldEntityID:   in.EntityID.String(),
+			"filename":      in.Filename,
+			"byte_size":     size,
+		}); err != nil {
+			return err
+		}
+		att, err := readAttachment(ctx, tx, id)
+		if err != nil {
+			return err
+		}
+		out = att
+		return nil
+	})
+	return out, err
+}

--- a/backend/internal/modules/activities/handlers.go
+++ b/backend/internal/modules/activities/handlers.go
@@ -42,6 +42,10 @@ type Handlers struct {
 	// (WithPublicBooking wires them).
 	publicPeople  PersonEnsurer
 	publicConsent ConsentCapturer
+	// uploadLimit is the deployment's ceiling for this module's upload route
+	// (OPS-CFG-12), injected by WithUploadLimit. Zero refuses every upload,
+	// which is the honest reading of "nobody has said" for a bound.
+	uploadLimit int64
 }
 
 // EmailDrafter prepares a reply for an existing activity without sending it.

--- a/backend/internal/modules/activities/handlers_attachment.go
+++ b/backend/internal/modules/activities/handlers_attachment.go
@@ -22,6 +22,10 @@ import (
 // spills, so concurrent uploads scale resident memory by their own size with no
 // admission control anywhere. The body is bounded by the MaxBytesReader above
 // it either way; this only decides where the bytes live while being read.
+//
+// So a file this size or smaller IS held in memory, by design: below a
+// megabyte the spill costs more than it saves. What the threshold removes is
+// the case that scales — a handful of concurrent uploads at the ceiling.
 const multipartSpillBytes = 1 << 20
 
 // errUploadLimitUnset reports that this composition never told the handler what
@@ -58,6 +62,9 @@ func (h Handlers) UploadAttachment(w http.ResponseWriter, r *http.Request) {
 	// It can only ever tighten — a MaxBytesReader cannot widen a body an outer
 	// one already bounded — so the two agreeing is the point, not a redundancy.
 	r.Body = http.MaxBytesReader(w, r.Body, h.uploadLimit)
+	// upload:route /v1/attachments — the ceiling this parse runs under is granted to that
+	// path in compose.uploadCeilings, and TestEveryMultipartParseNamesItsRoute
+	// holds the two together.
 	//nolint:gosec // G120 wants a bound here, and the bound is the MaxBytesReader above: this argument is only the in-memory/spill threshold, and it is deliberately far below the ceiling so the parse spills rather than holding the upload resident.
 	if err := r.ParseMultipartForm(multipartSpillBytes); err != nil {
 		httperr.WriteMultipartRefusal(w, r, err, h.uploadLimit)

--- a/backend/internal/modules/activities/handlers_attachment.go
+++ b/backend/internal/modules/activities/handlers_attachment.go
@@ -58,6 +58,7 @@ func (h Handlers) UploadAttachment(w http.ResponseWriter, r *http.Request) {
 	// It can only ever tighten — a MaxBytesReader cannot widen a body an outer
 	// one already bounded — so the two agreeing is the point, not a redundancy.
 	r.Body = http.MaxBytesReader(w, r.Body, h.uploadLimit)
+	//nolint:gosec // G120 wants a bound here, and the bound is the MaxBytesReader above: this argument is only the in-memory/spill threshold, and it is deliberately far below the ceiling so the parse spills rather than holding the upload resident.
 	if err := r.ParseMultipartForm(multipartSpillBytes); err != nil {
 		httperr.WriteMultipartRefusal(w, r, err, h.uploadLimit)
 		return

--- a/backend/internal/modules/activities/handlers_attachment.go
+++ b/backend/internal/modules/activities/handlers_attachment.go
@@ -6,8 +6,6 @@ package activities
 import (
 	"context"
 	"errors"
-	"fmt"
-	"io"
 	"log/slog"
 	"net/http"
 
@@ -16,26 +14,52 @@ import (
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
-// maxAttachmentBytes caps one upload, so a client cannot exhaust memory
-// streaming a too-large file.
+// multipartSpillBytes is how much of an upload is held in memory before the
+// rest goes to a temp file.
 //
-// It IS the chassis ceiling rather than a number of its own: this is the widest
-// route that carries a file, and a route cannot widen what the chassis already
-// bounded, so a separate literal here could only ever be equal or dead. Two
-// constants that must agree are one constant.
-const maxAttachmentBytes = httperr.MaxMultipartBodyBytes
+// Deliberately far below the ceiling. `ParseMultipartForm`'s argument is the
+// in-memory threshold, not a cap — passing the ceiling means nothing ever
+// spills, so concurrent uploads scale resident memory by their own size with no
+// admission control anywhere. The body is bounded by the MaxBytesReader above
+// it either way; this only decides where the bytes live while being read.
+const multipartSpillBytes = 1 << 20
+
+// errUploadLimitUnset reports that this composition never told the handler what
+// its ceiling is. A wiring fault, not a request fault, so it answers 500 rather
+// than refusing the caller's file for a size nobody set.
+var errUploadLimitUnset = errors.New("activities: no upload ceiling configured for this role")
+
+// WithUploadLimit returns handlers that parse an upload under the deployment's
+// ceiling for this route (OPS-CFG-12). Compose calls it.
+//
+// The zero value refuses every upload rather than defaulting to something
+// generous: an unconfigured ceiling is a wiring mistake, and a handler that
+// silently invents its own number is how the chassis and the parse end up
+// disagreeing about what fits.
+func (h Handlers) WithUploadLimit(bytes int64) Handlers {
+	h.uploadLimit = bytes
+	return h
+}
 
 // UploadAttachment stores an uploaded file against an entity. Multipart is
 // parsed here (the JSON decoder cannot carry bytes); the store owns the
 // RBAC gate, provenance, and the write shape.
 func (h Handlers) UploadAttachment(w http.ResponseWriter, r *http.Request) {
-	// Equal to the ceiling the chassis already applied, and kept anyway: it is
-	// what makes this handler correct when mounted without that middleware, and
-	// it is what the waiver below points at.
-	r.Body = http.MaxBytesReader(w, r.Body, maxAttachmentBytes)
-	//nolint:gosec // r.Body is bounded by http.MaxBytesReader above, so total parse size is capped; the arg only sets the in-memory/spill threshold.
-	if err := r.ParseMultipartForm(maxAttachmentBytes); err != nil {
-		httperr.WriteMultipartRefusal(w, r, err, maxAttachmentBytes)
+	if h.uploadLimit <= 0 {
+		// Answered as OUR fault, because it is: nobody wired the ceiling. The
+		// alternative — carrying on with a zero bound — refuses the caller's
+		// perfectly good file and tells them it exceeds a 0 MB limit, which
+		// sends them off to shrink a file that was never the problem.
+		httperr.Write(w, r, errUploadLimitUnset)
+		return
+	}
+	// The same ceiling the chassis already applied, and applied again anyway: it
+	// is what makes this handler correct when mounted without that middleware.
+	// It can only ever tighten — a MaxBytesReader cannot widen a body an outer
+	// one already bounded — so the two agreeing is the point, not a redundancy.
+	r.Body = http.MaxBytesReader(w, r.Body, h.uploadLimit)
+	if err := r.ParseMultipartForm(multipartSpillBytes); err != nil {
+		httperr.WriteMultipartRefusal(w, r, err, h.uploadLimit)
 		return
 	}
 	entityType := r.FormValue("entity_type")
@@ -59,12 +83,6 @@ func (h Handlers) UploadAttachment(w http.ResponseWriter, r *http.Request) {
 			slog.WarnContext(ctx, "closing uploaded file part", "err", cerr)
 		}
 	}(r.Context())
-	body, err := io.ReadAll(file)
-	if err != nil {
-		httperr.Write(w, r, httperr.Validation("file", "too_large",
-			fmt.Sprintf("the file exceeds the %d-byte limit or could not be read", maxAttachmentBytes)))
-		return
-	}
 
 	// The agreement this document is about, when the uploader named one. An
 	// absent part files the document against no contract, which is the ordinary
@@ -79,12 +97,15 @@ func (h Handlers) UploadAttachment(w http.ResponseWriter, r *http.Request) {
 		contractID = &parsed
 	}
 
+	// The part is handed on as a reader, not as bytes: the store hashes it and
+	// streams it to object storage, so the whole file never has to be resident
+	// at once.
 	att, err := h.store.UploadAttachment(r.Context(), AttachmentInput{
 		EntityType:  entityType,
 		EntityID:    entityID,
 		Filename:    header.Filename,
 		ContentType: header.Header.Get("Content-Type"),
-		Body:        body,
+		Content:     file,
 		ContractID:  contractID,
 	})
 	if err != nil {

--- a/backend/internal/modules/activities/uploadceiling_test.go
+++ b/backend/internal/modules/activities/uploadceiling_test.go
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package activities
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// A handler nobody told a ceiling has a wiring fault, and the caller's file is
+// not the fault. Answering 413 "exceeds the 0 MB limit" — which is what a bare
+// MaxBytesReader(0) produces — sends them off to shrink a file that was never
+// too large, over a limit nobody set.
+func TestAnUnwiredUploadCeilingIsOurFaultNotTheCallers(t *testing.T) {
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/attachments",
+		strings.NewReader("not that it gets read"))
+	req.Header.Set("Content-Type", "multipart/form-data; boundary=x")
+
+	Handlers{}.UploadAttachment(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("an unwired ceiling answered %d, want 500 — anything in the 4xx "+
+			"range blames the caller for a number this composition never set",
+			rec.Code)
+	}
+	if strings.Contains(rec.Body.String(), "MB") {
+		t.Errorf("the refusal %q names a size limit, which is exactly the "+
+			"misdirection this branch exists to avoid", rec.Body.String())
+	}
+}

--- a/backend/internal/modules/people/handlers.go
+++ b/backend/internal/modules/people/handlers.go
@@ -32,6 +32,10 @@ type Handlers struct {
 	// objects: the logo endpoint then answers 501 rather than nil-derefing,
 	// and no logo can have been resolved for it to serve anyway.
 	blob blobstore.Store
+	// uploadLimit is the deployment's ceiling for this module's upload route
+	// (OPS-CFG-12), injected by WithUploadLimit. Zero refuses every upload,
+	// which is the honest reading of "nobody has said" for a bound.
+	uploadLimit int64
 }
 
 // NewHandlers builds the module's HTTP surface over a workspace-bound handle.

--- a/backend/internal/modules/people/handlers_linkedin.go
+++ b/backend/internal/modules/people/handlers_linkedin.go
@@ -30,11 +30,30 @@ func uploaderID(ctx context.Context) ids.UUID {
 	return actor.UserID
 }
 
-// maxLinkedInExportBytes bounds the upload. A large personal network is a few
-// thousand rows of short text — well under a megabyte — so 8 MB is generous
-// for the real file and still refuses a mis-picked video before it reaches
-// the CSV reader.
-const maxLinkedInExportBytes = 8 << 20
+// linkedInSpillBytes is how much of the export is held in memory before the
+// rest goes to a temp file. The ceiling is the deployment's (OPS-CFG-12); this
+// only decides where the bytes live while being parsed, and passing the ceiling
+// here would mean nothing ever spills.
+const linkedInSpillBytes = 1 << 20
+
+// errUploadLimitUnset reports that this composition never told the handler what
+// its ceiling is. A wiring fault, not a request fault, so it answers 500 rather
+// than refusing the caller's file for a size nobody set.
+var errUploadLimitUnset = errors.New("people: no upload ceiling configured for this role")
+
+// WithUploadLimit returns handlers that parse the export under the deployment's
+// ceiling for this route (OPS-CFG-12). Compose calls it. A large personal
+// network is a few thousand rows of short text — well under a megabyte — so the
+// default is generous for the real file and still refuses a mis-picked video
+// before it reaches the CSV reader.
+//
+// The zero value refuses every upload rather than inventing a bound of its own:
+// a handler that disagrees with the chassis about what fits produces a refusal
+// no reader can act on.
+func (h Handlers) WithUploadLimit(bytes int64) Handlers {
+	h.uploadLimit = bytes
+	return h
+}
 
 // ImportLinkedInConnections implements POST /me/linkedin-connections.
 //
@@ -44,10 +63,15 @@ const maxLinkedInExportBytes = 8 << 20
 // person attribute a stranger's connections to a colleague, and the whole
 // point of the feature is that "Lars knows them" means Lars.
 func (h Handlers) ImportLinkedInConnections(w http.ResponseWriter, r *http.Request) {
-	r.Body = http.MaxBytesReader(w, r.Body, maxLinkedInExportBytes)
-	//nolint:gosec // r.Body is bounded by http.MaxBytesReader above, so total parse size is capped; the arg only sets the in-memory/spill threshold.
-	if err := r.ParseMultipartForm(maxLinkedInExportBytes); err != nil {
-		httperr.WriteMultipartRefusal(w, r, err, maxLinkedInExportBytes)
+	if h.uploadLimit <= 0 {
+		// Our fault, not the caller's: nobody wired the ceiling. Carrying on
+		// with a zero bound would refuse their export and blame its size.
+		httperr.Write(w, r, errUploadLimitUnset)
+		return
+	}
+	r.Body = http.MaxBytesReader(w, r.Body, h.uploadLimit)
+	if err := r.ParseMultipartForm(linkedInSpillBytes); err != nil {
+		httperr.WriteMultipartRefusal(w, r, err, h.uploadLimit)
 		return
 	}
 	file, _, err := r.FormFile("file")

--- a/backend/internal/modules/people/handlers_linkedin.go
+++ b/backend/internal/modules/people/handlers_linkedin.go
@@ -70,6 +70,7 @@ func (h Handlers) ImportLinkedInConnections(w http.ResponseWriter, r *http.Reque
 		return
 	}
 	r.Body = http.MaxBytesReader(w, r.Body, h.uploadLimit)
+	//nolint:gosec // G120 wants a bound here, and the bound is the MaxBytesReader above: this argument is only the in-memory/spill threshold, and it is deliberately far below the ceiling so the parse spills rather than holding the upload resident.
 	if err := r.ParseMultipartForm(linkedInSpillBytes); err != nil {
 		httperr.WriteMultipartRefusal(w, r, err, h.uploadLimit)
 		return

--- a/backend/internal/modules/people/handlers_linkedin.go
+++ b/backend/internal/modules/people/handlers_linkedin.go
@@ -70,6 +70,9 @@ func (h Handlers) ImportLinkedInConnections(w http.ResponseWriter, r *http.Reque
 		return
 	}
 	r.Body = http.MaxBytesReader(w, r.Body, h.uploadLimit)
+	// upload:route /v1/me/linkedin-connections — the ceiling this parse runs under is granted to that
+	// path in compose.uploadCeilings, and TestEveryMultipartParseNamesItsRoute
+	// holds the two together.
 	//nolint:gosec // G120 wants a bound here, and the bound is the MaxBytesReader above: this argument is only the in-memory/spill threshold, and it is deliberately far below the ceiling so the parse spills rather than holding the upload resident.
 	if err := r.ParseMultipartForm(linkedInSpillBytes); err != nil {
 		httperr.WriteMultipartRefusal(w, r, err, h.uploadLimit)

--- a/backend/internal/modules/people/uploadceiling_test.go
+++ b/backend/internal/modules/people/uploadceiling_test.go
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package people
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// A handler nobody told a ceiling has a wiring fault, and the caller's file is
+// not the fault. Answering 413 "exceeds the 0 MB limit" — which is what a bare
+// MaxBytesReader(0) produces — sends them off to shrink a file that was never
+// too large, over a limit nobody set.
+func TestAnUnwiredUploadCeilingIsOurFaultNotTheCallers(t *testing.T) {
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/me/linkedin-connections",
+		strings.NewReader("not that it gets read"))
+	req.Header.Set("Content-Type", "multipart/form-data; boundary=x")
+
+	Handlers{}.ImportLinkedInConnections(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("an unwired ceiling answered %d, want 500 — anything in the 4xx "+
+			"range blames the caller for a number this composition never set",
+			rec.Code)
+	}
+	if strings.Contains(rec.Body.String(), "MB") {
+		t.Errorf("the refusal %q names a size limit, which is exactly the "+
+			"misdirection this branch exists to avoid", rec.Body.String())
+	}
+}

--- a/backend/internal/platform/deployconfig/deployconfig.go
+++ b/backend/internal/platform/deployconfig/deployconfig.go
@@ -40,6 +40,7 @@ type Config struct {
 	CompanyContext CompanyContext  `yaml:"company_context"`
 	OverlayBudget  OverlayBudget   `yaml:"overlay_budget"`
 	Operations     Operations      `yaml:"operations"`
+	Uploads        Uploads         `yaml:"uploads"`
 }
 
 // Operations carries the ops kill switches (OPS-CFG-9): capabilities an
@@ -345,6 +346,9 @@ func (c Config) validate() error {
 		if err := ib.validate(name); err != nil {
 			return err
 		}
+	}
+	if err := c.Uploads.validate(); err != nil {
+		return err
 	}
 	if c.Email.Enabled {
 		return c.Email.validate()

--- a/backend/internal/platform/deployconfig/uploads.go
+++ b/backend/internal/platform/deployconfig/uploads.go
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package deployconfig
+
+// The uploads block of margince.yaml: how many bytes one request may carry on
+// each route that accepts a file (OPS-CFG-12, DOC-PARAM-11).
+//
+// It sits in its own file for the same reason overlay_budget does — it is a
+// section with arithmetic of its own, defaults to merge and bounds to enforce,
+// rather than values to hand on.
+//
+// What this section does NOT decide: which routes may carry a file. That list
+// is a source-level declaration in the composition layer, and it is the whole
+// security property — several handlers decode the body with no bound of their
+// own and two of those routes are unauthenticated, so a route that carries no
+// file must stay unable to obtain the file bound by claiming a media type. An
+// operator chooses the number; nobody chooses the list at run time.
+
+import "fmt"
+
+// Uploads is the operator's per-route ceilings, in decimal megabytes.
+//
+// Pointers, so an absent key and an explicit `0` are different facts: absent
+// takes the compiled-in default, while `attachment_mb: 0` is a ceiling that
+// refuses every upload and is far more likely a mistake than an intention. It
+// fails at boot rather than at the first upload nobody can explain.
+type Uploads struct {
+	// AttachmentMB bounds POST /v1/attachments — the documents surface.
+	AttachmentMB *int `yaml:"attachment_mb"`
+	// CSVImportMB bounds POST /v1/imports/sources — the CSV import source.
+	CSVImportMB *int `yaml:"csv_import_mb"`
+	// LinkedInImportMB bounds POST /v1/me/linkedin-connections.
+	LinkedInImportMB *int `yaml:"linkedin_import_mb"`
+}
+
+// UploadLimits is Uploads resolved: every ceiling present, in bytes. It is what
+// the composition layer receives, so no consumer downstream reads a pointer or
+// re-applies a default — the two places a default is applied are the two places
+// they can disagree.
+type UploadLimits struct {
+	Attachment     int64
+	CSVImport      int64
+	LinkedInImport int64
+}
+
+// The compiled-in ceilings, in decimal MB. Decimal, not binary, because the
+// config key, the server's refusal and the upload form's hint all state this
+// number and must state the same one: `25 << 20` reads as "25 MB" in a sentence
+// while admitting 26.2 million bytes, and the reader whose 25.5 MB file it
+// refuses has been told the wrong thing by 4.8%.
+//
+// The import ceilings are the historical caps read the way their own refusal
+// messages have always spelled them ("the 10 MB import cap"), which tightens
+// each by 4.8% — the code moving to match the prose rather than the reverse.
+const (
+	defaultAttachmentMB     = 25
+	defaultCSVImportMB      = 10
+	defaultLinkedInImportMB = 8
+)
+
+// The range an operator may choose inside.
+//
+// The floor is 1 MB because below that the JSON bound already governs and an
+// "upload" route that cannot carry a small PDF is a broken installation, not a
+// tightened one. The ceiling is 100 MB because the parse spills to the api's
+// own temp filesystem and the part is then handed to object storage in a single
+// PUT; past this the answer is a presigned direct-to-storage upload, which is a
+// different design and not a bigger number here.
+const (
+	minUploadMB = 1
+	maxUploadMB = 100
+)
+
+// bytesPerMB is the decimal megabyte this whole section is denominated in.
+const bytesPerMB = 1_000_000
+
+// EffectiveUploads resolves the operator's block over the compiled-in
+// defaults. validate() has already rejected anything out of range, so every
+// value here is one an upload can actually ride.
+func (c Config) EffectiveUploads() UploadLimits {
+	return UploadLimits{
+		Attachment:     megabytes(c.Uploads.AttachmentMB, defaultAttachmentMB),
+		CSVImport:      megabytes(c.Uploads.CSVImportMB, defaultCSVImportMB),
+		LinkedInImport: megabytes(c.Uploads.LinkedInImportMB, defaultLinkedInImportMB),
+	}
+}
+
+func megabytes(configured *int, fallback int) int64 {
+	if configured == nil {
+		return int64(fallback) * bytesPerMB
+	}
+	return int64(*configured) * bytesPerMB
+}
+
+// validate refuses an out-of-range ceiling at boot, naming the key (OPS-CFG-2,
+// fail-fast). A silent clamp would leave an operator who asked for 500 MB
+// believing they got it, and the file would keep saying so.
+func (u Uploads) validate() error {
+	for _, k := range []struct {
+		key   string
+		value *int
+	}{
+		{"attachment_mb", u.AttachmentMB},
+		{"csv_import_mb", u.CSVImportMB},
+		{"linkedin_import_mb", u.LinkedInImportMB},
+	} {
+		if k.value == nil {
+			continue
+		}
+		if *k.value < minUploadMB || *k.value > maxUploadMB {
+			return fmt.Errorf("deployconfig: uploads.%s is %d MB, outside the %d–%d MB range this build accepts",
+				k.key, *k.value, minUploadMB, maxUploadMB)
+		}
+	}
+	return nil
+}

--- a/backend/internal/platform/deployconfig/uploads_test.go
+++ b/backend/internal/platform/deployconfig/uploads_test.go
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package deployconfig_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/platform/deployconfig"
+)
+
+// The compiled-in ceilings, restated here on purpose: this is the test that
+// notices a default moving, and a test that reads the constant it is checking
+// agrees with any value at all.
+const (
+	defaultAttachmentBytes = 25_000_000
+	defaultCSVImportBytes  = 10_000_000
+	defaultLinkedInBytes   = 8_000_000
+)
+
+func parseUploads(t *testing.T, body string) (deployconfig.UploadLimits, error) {
+	t.Helper()
+	cfg, err := deployconfig.Parse([]byte("version: 1\n" + body))
+	if err != nil {
+		return deployconfig.UploadLimits{}, err
+	}
+	return cfg.EffectiveUploads(), nil
+}
+
+func TestAFileWithNoUploadsSectionGetsTheCompiledCeilings(t *testing.T) {
+	limits, err := parseUploads(t, "")
+	if err != nil {
+		t.Fatalf("a minimal file was refused: %v", err)
+	}
+	want := deployconfig.UploadLimits{
+		Attachment:     defaultAttachmentBytes,
+		CSVImport:      defaultCSVImportBytes,
+		LinkedInImport: defaultLinkedInBytes,
+	}
+	if limits != want {
+		t.Errorf("unconfigured limits are %+v, want %+v — an installation that "+
+			"never wrote the section must still be bounded, and generously enough "+
+			"to upload the paper the product is about", limits, want)
+	}
+}
+
+func TestOneConfiguredCeilingLeavesTheOthersAlone(t *testing.T) {
+	// The mistake this catches is a section that replaces the whole block:
+	// naming one route would then silently zero the two beside it, and a zero
+	// ceiling refuses every upload on a route nobody was thinking about.
+	limits, err := parseUploads(t, "uploads:\n  attachment_mb: 40\n")
+	if err != nil {
+		t.Fatalf("a partial uploads section was refused: %v", err)
+	}
+	if limits.Attachment != 40_000_000 {
+		t.Errorf("attachment ceiling is %d, want the configured 40 MB", limits.Attachment)
+	}
+	if limits.CSVImport != defaultCSVImportBytes || limits.LinkedInImport != defaultLinkedInBytes {
+		t.Errorf("configuring one route changed the others: %+v", limits)
+	}
+}
+
+func TestEveryRouteIsSeparatelyConfigurable(t *testing.T) {
+	limits, err := parseUploads(t, `uploads:
+  attachment_mb: 50
+  csv_import_mb: 20
+  linkedin_import_mb: 3
+`)
+	if err != nil {
+		t.Fatalf("a full uploads section was refused: %v", err)
+	}
+	want := deployconfig.UploadLimits{
+		Attachment: 50_000_000, CSVImport: 20_000_000, LinkedInImport: 3_000_000,
+	}
+	if limits != want {
+		t.Errorf("limits are %+v, want %+v — three keys that resolve to the "+
+			"same place are one key with two spellings", limits, want)
+	}
+}
+
+// Decimal, not binary. Every surface that states this number — the key here,
+// the server's refusal, the upload form's hint — must state the same one, and
+// `25 << 20` reads as "25 MB" while admitting 26.2 million bytes.
+func TestAMegabyteIsAMillionBytes(t *testing.T) {
+	limits, err := parseUploads(t, "uploads:\n  attachment_mb: 1\n")
+	if err != nil {
+		t.Fatalf("a 1 MB ceiling was refused: %v", err)
+	}
+	if limits.Attachment != 1_000_000 {
+		t.Errorf("1 MB resolved to %d bytes, want 1000000 — a binary megabyte "+
+			"here would over-state every limit this installation reports by 4.8%%",
+			limits.Attachment)
+	}
+}
+
+func TestAnUnusableCeilingIsRefusedAtBootByName(t *testing.T) {
+	// Fail-fast (OPS-CFG-2). A silent clamp would leave an operator who asked
+	// for 500 MB believing they got it, with the file still saying so.
+	for _, tc := range []struct {
+		name string
+		body string
+		key  string
+	}{
+		{"past the range", "uploads:\n  attachment_mb: 500\n", "attachment_mb"},
+		{"negative", "uploads:\n  csv_import_mb: -1\n", "csv_import_mb"},
+		{
+			// Told apart from an absent key on purpose: zero is a ceiling that
+			// refuses every upload, which is far likelier a mistake than an
+			// intention, and it would otherwise read as "use the default".
+			"explicitly zero", "uploads:\n  linkedin_import_mb: 0\n", "linkedin_import_mb",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := parseUploads(t, tc.body)
+			if err == nil {
+				t.Fatal("the value was accepted — an installation boots with a " +
+					"ceiling nobody can use and nothing says so")
+			}
+			if !strings.Contains(err.Error(), tc.key) {
+				t.Errorf("the refusal %q does not name the key at fault", err)
+			}
+		})
+	}
+}
+
+func TestATypoInTheUploadsSectionIsABootError(t *testing.T) {
+	// Strict decoding, like every other section: `attachment_mp: 40` must not
+	// read as "the operator said nothing about attachments".
+	if _, err := parseUploads(t, "uploads:\n  attachment_mp: 40\n"); err == nil {
+		t.Fatal("an unknown uploads key was ignored rather than refused")
+	}
+}

--- a/backend/internal/platform/httperr/multipart.go
+++ b/backend/internal/platform/httperr/multipart.go
@@ -20,9 +20,8 @@ import (
 // answers 413 and NAMES the limit — the one actionable fact — and everything
 // else answers 422 about framing only.
 //
-// `limit` is the ceiling the caller applied, in bytes, and is rendered as whole
-// megabytes; pass the same constant the MaxBytesReader was given, or the
-// sentence describes a limit nothing enforced.
+// `limit` is the ceiling the caller applied, in bytes; pass the same value the
+// MaxBytesReader was given, or the sentence describes a limit nothing enforced.
 func WriteMultipartRefusal(w http.ResponseWriter, r *http.Request, err error, limit int64) {
 	Write(w, r, MultipartRefusal(err, limit))
 }
@@ -35,9 +34,27 @@ func MultipartRefusal(err error, limit int64) *DetailedError {
 		return &DetailedError{
 			Status: http.StatusRequestEntityTooLarge,
 			Code:   "body_too_large",
-			Detail: fmt.Sprintf("the upload exceeds the %d MB limit", limit/1_000_000),
+			Detail: fmt.Sprintf("the upload exceeds the %s limit", Megabytes(limit)),
 		}
 	}
 	return Validation("file", "invalid_multipart",
 		"the request must be sent as multipart/form-data")
 }
+
+// Megabytes renders a byte ceiling the way the person it just refused will
+// measure their own file: in decimal MB, exactly.
+//
+// Exactly is the whole point. Truncating division reads a 8,388,608-byte
+// ceiling as "8 MB" and refuses an 8.2 MB file the sentence said would fit —
+// and any ceiling below a megabyte as "0 MB", which describes nothing at all.
+// So a whole number prints whole, and anything else keeps one decimal.
+func Megabytes(limit int64) string {
+	if limit%bytesPerMB == 0 {
+		return fmt.Sprintf("%d MB", limit/bytesPerMB)
+	}
+	return fmt.Sprintf("%.1f MB", float64(limit)/bytesPerMB)
+}
+
+// bytesPerMB is the decimal megabyte every upload ceiling is denominated in
+// (OPS-CFG-12).
+const bytesPerMB = 1_000_000

--- a/backend/internal/platform/httperr/multipart.go
+++ b/backend/internal/platform/httperr/multipart.go
@@ -42,17 +42,25 @@ func MultipartRefusal(err error, limit int64) *DetailedError {
 }
 
 // Megabytes renders a byte ceiling the way the person it just refused will
-// measure their own file: in decimal MB, exactly.
+// measure their own file: in decimal MB.
 //
-// Exactly is the whole point. Truncating division reads a 8,388,608-byte
-// ceiling as "8 MB" and refuses an 8.2 MB file the sentence said would fit —
-// and any ceiling below a megabyte as "0 MB", which describes nothing at all.
-// So a whole number prints whole, and anything else keeps one decimal.
+// Two rules, and the second is the one that matters. A whole number prints
+// whole — every configured ceiling is a whole number of decimal MB, so this is
+// the case that actually ships. Anything else keeps one decimal ROUNDED DOWN,
+// never to nearest, because a stated limit must never exceed the enforced one:
+// rounding 999,999 up to "1.0 MB" invites a 1,000,000-byte file that is then
+// refused by the sentence that welcomed it. Understating by less than 0.1 MB
+// costs the reader nothing; overstating by a byte costs them a whole upload.
+//
+// The version this replaces divided and truncated to whole MB, which read a
+// 8,388,608-byte ceiling as "8 MB" — refusing an 8.2 MB file the sentence said
+// would fit — and any ceiling below a megabyte as "0 MB".
 func Megabytes(limit int64) string {
 	if limit%bytesPerMB == 0 {
 		return fmt.Sprintf("%d MB", limit/bytesPerMB)
 	}
-	return fmt.Sprintf("%.1f MB", float64(limit)/bytesPerMB)
+	tenths := limit * 10 / bytesPerMB
+	return fmt.Sprintf("%d.%d MB", tenths/10, tenths%10)
 }
 
 // bytesPerMB is the decimal megabyte every upload ceiling is denominated in

--- a/backend/internal/platform/httperr/multipart_test.go
+++ b/backend/internal/platform/httperr/multipart_test.go
@@ -58,13 +58,39 @@ func TestTheRefusalNamesTheLimitItActuallyEnforced(t *testing.T) {
 		want  string
 	}{
 		{25_000_000, "25 MB"},   // the shipped default: whole, prints whole
-		{8 << 20, "8.4 MB"},     // a binary constant is not a whole decimal MB
-		{10 << 20, "10.5 MB"},   // and neither is this one
+		{8 << 20, "8.3 MB"},     // a binary constant is not a whole decimal MB
+		{10 << 20, "10.4 MB"},   // and neither is this one
 		{12_500_000, "12.5 MB"}, // an operator may configure a half
 		{900_000, "0.9 MB"},     // below a megabyte still describes itself
 	} {
 		if got := httperr.Megabytes(tc.limit); got != tc.want {
 			t.Errorf("a %d-byte ceiling reads as %q, want %q", tc.limit, got, tc.want)
+		}
+	}
+}
+
+// A stated limit may fall short of the enforced one; it may never exceed it.
+// A reader who trusts a rounded-up figure sends a file the same sentence then
+// refuses — the one failure mode a friendly unit can introduce on its own.
+func TestTheStatedLimitNeverExceedsTheEnforcedOne(t *testing.T) {
+	for _, limit := range []int64{
+		999_999,    // rounds to "1.0 MB" to nearest, which is over the real bound
+		1_099_999,  // and this to "1.1 MB"
+		8 << 20,    // the LinkedIn constant
+		10 << 20,   // the import constant
+		25_000_000, // and a whole one, which must still be exact
+		1,          // a degenerate bound is still not allowed to overstate
+	} {
+		stated := httperr.Megabytes(limit)
+		var value float64
+		if _, err := fmt.Sscanf(stated, "%f MB", &value); err != nil {
+			t.Fatalf("a %d-byte ceiling rendered as %q, which is not a number of MB: %v",
+				limit, stated, err)
+		}
+		if int64(value*1_000_000) > limit {
+			t.Errorf("a %d-byte ceiling is stated as %q, which is MORE than it "+
+				"enforces — a file sized to that sentence is refused by it",
+				limit, stated)
 		}
 	}
 }

--- a/backend/internal/platform/httperr/multipart_test.go
+++ b/backend/internal/platform/httperr/multipart_test.go
@@ -47,6 +47,28 @@ func TestTheSizeIsReadThroughAWrappedError(t *testing.T) {
 	}
 }
 
+// The refusal names a number the reader will compare against their own file, so
+// it has to be the number actually enforced. The version this replaces divided
+// by a million and truncated, which read an 8,388,608-byte ceiling as "8 MB" —
+// refusing an 8.2 MB file the sentence said would fit — and read anything below
+// a megabyte as "0 MB", which describes nothing at all.
+func TestTheRefusalNamesTheLimitItActuallyEnforced(t *testing.T) {
+	for _, tc := range []struct {
+		limit int64
+		want  string
+	}{
+		{25_000_000, "25 MB"},   // the shipped default: whole, prints whole
+		{8 << 20, "8.4 MB"},     // a binary constant is not a whole decimal MB
+		{10 << 20, "10.5 MB"},   // and neither is this one
+		{12_500_000, "12.5 MB"}, // an operator may configure a half
+		{900_000, "0.9 MB"},     // below a megabyte still describes itself
+	} {
+		if got := httperr.Megabytes(tc.limit); got != tc.want {
+			t.Errorf("a %d-byte ceiling reads as %q, want %q", tc.limit, got, tc.want)
+		}
+	}
+}
+
 func TestAMalformedBodyIsRefusedByItsFraming(t *testing.T) {
 	const limit = 25_000_000
 	refusal := httperr.MultipartRefusal(errors.New("no multipart boundary param"), limit)

--- a/backend/internal/platform/httperr/wire.go
+++ b/backend/internal/platform/httperr/wire.go
@@ -27,21 +27,16 @@ import (
 // amplification on the cheapest endpoints.
 const MaxBodyBytes = 1 << 20
 
-// MaxMultipartBodyBytes bounds a body that carries FILES (25 MB), which cannot
-// live under the JSON ceiling.
+// A body that carries FILES rides a SECOND, wider ceiling, which cannot live
+// under the JSON bound and is not a constant here: it is per route and the
+// operator sets it (OPS-CFG-12, `uploads` in margince.yaml), resolved by
+// platform/deployconfig and injected where routes are known.
 //
-// A SECOND ceiling, never an exemption: an exempt route is an unbounded one the
+// A second ceiling, never an exemption. An exempt route is an unbounded one the
 // day somebody forgets its own cap, and a handler cannot supply that cap itself
 // because its `http.MaxBytesReader` can only tighten a body the chassis already
-// bounded, never widen it. A route may therefore only tighten below this — and
-// WHICH routes ride it is decided where routes are known, not here.
-//
-// Decimal MB rather than MiB so that every surface stating the limit — the
-// server's refusal, the upload form's hint — states the number this actually
-// is. 25 << 20 reads as "25 MB" in a sentence while admitting 26.2 million
-// bytes, and a reader whose 25.5 MB file is refused has been told the wrong
-// thing by 4.8%.
-const MaxMultipartBodyBytes = 25_000_000
+// bounded, never widen it — so a route may only tighten below what it was
+// granted.
 
 // Decode parses the request body, answering the validation problem shape
 // on malformed JSON. The body is size-capped and must contain exactly

--- a/backend/internal/platform/httpserver/limitbodies_test.go
+++ b/backend/internal/platform/httpserver/limitbodies_test.go
@@ -47,9 +47,15 @@ func post(contentType string, size int) *http.Request {
 	return req
 }
 
-// wide is a BodyCeiling that grants the multipart bound to everything, standing
-// in for a composition that declared this route an upload route.
-func wide(*http.Request) int64 { return httperr.MaxMultipartBodyBytes }
+// wideCeiling stands in for the ceiling a composition grants a declared upload
+// route. Not a round number and not any shipped default: it has to be visible
+// in a failure that the bound applied was THIS one rather than something the
+// chassis picked for itself.
+const wideCeiling = 9_000_000
+
+// wide is a BodyCeiling that grants that bound to everything, standing in for a
+// composition that declared this route an upload route.
+func wide(*http.Request) int64 { return wideCeiling }
 
 func TestLimitBodiesCapsJSONAtTheJSONCeiling(t *testing.T) {
 	var read int
@@ -88,14 +94,13 @@ func TestLimitBodiesStillCapsAWidenedRoute(t *testing.T) {
 	var read int
 	rec := httptest.NewRecorder()
 	LimitBodies(wide, readTo(t, &read)).ServeHTTP(rec,
-		post("multipart/form-data; boundary=abc123", httperr.MaxMultipartBodyBytes+1024))
+		post("multipart/form-data; boundary=abc123", wideCeiling+1024))
 
 	if rec.Code != http.StatusRequestEntityTooLarge {
-		t.Fatalf("a multipart body past the 25 MiB ceiling was accepted: status %d", rec.Code)
+		t.Fatalf("a multipart body past the granted ceiling was accepted: status %d", rec.Code)
 	}
-	if int64(read) > httperr.MaxMultipartBodyBytes {
-		t.Fatalf("read %d bytes past the multipart ceiling of %d",
-			read, httperr.MaxMultipartBodyBytes)
+	if int64(read) > wideCeiling {
+		t.Fatalf("read %d bytes past the granted ceiling of %d", read, wideCeiling)
 	}
 }
 

--- a/config/margince.example.yaml
+++ b/config/margince.example.yaml
@@ -81,6 +81,30 @@ bootstrap_admin:
 # ai:
 #   capture_payloads: true
 
+# How large a file this installation accepts, per route (optional, OPS-CFG-12).
+#
+# DECIMAL megabytes — 25 means 25,000,000 bytes, not 26,214,400. The number you
+# write here is the number the server's refusal names and the number the upload
+# form states, and those three agreeing is the whole reason the unit is decimal.
+#
+# The ceiling bounds the WHOLE request, part framing included, not the file
+# alone. The overhead is a few hundred bytes, so it only matters within a
+# rounding error of the limit.
+#
+# Each key is separate on purpose: raising what a scanned contract may weigh is
+# not a reason to let a CSV import attempt more parsing work. An omitted key
+# takes the default below; a value outside 1–100 MB is a boot error, not a
+# silent clamp. Past 100 MB the answer is an upload straight to object storage,
+# which is a different design rather than a bigger number.
+#
+# What this section does NOT decide is which routes may carry a file at all —
+# that stays in the source, and it is what keeps a route carrying no file from
+# claiming the wider bound by sending a multipart header.
+# uploads:
+#   attachment_mb: 25        # POST /v1/attachments — the documents surface
+#   csv_import_mb: 10        # POST /v1/imports/sources
+#   linkedin_import_mb: 8    # POST /v1/me/linkedin-connections
+
 # Capture pipeline posture (optional).
 #
 # trace_payloads turns on payload capture in the 24-hour Capture activity trace

--- a/docs/how-to/import-your-linkedin-network.md
+++ b/docs/how-to/import-your-linkedin-network.md
@@ -59,8 +59,10 @@ and consent. Settings is where the actual import happens.
 
 The endpoint is `multipart/form-data` with a part named `file`, and it is
 `x-agent-access: human-only` — a session cookie only; an agent Passport is refused by design. The
-upload is bounded at **8 MB**, which is generous for a few thousand rows of short text and still
-refuses a mis-picked video before it reaches the CSV reader.
+upload is bounded at **8 MB by default**, which is generous for a few thousand rows of short text
+and still refuses a mis-picked video before it reaches the CSV reader. Whoever operates the
+installation sets the real number (`uploads.linkedin_import_mb` in `margince.yaml`), and the
+refusal names the one in force — so read it from the message rather than from here.
 
 ```sh
 curl -X POST http://localhost:8080/v1/me/linkedin-connections \
@@ -235,7 +237,8 @@ reporting success is worse than one that fails:
 | `skipped > 0` | Rows with no usable name. They identify nobody, so they are counted and passed over. |
 | `imported < rows - skipped` | A row matched the **erasure suppression list** by address and was refused. An erased subject must not walk back in through a colleague's next export — an import that did not consult the list would undo an Art. 17 request with a file upload. It is not reported as imported, because that would tell you your file landed data the system deliberately destroyed. |
 | `422 unreadable_export` | No recognizable LinkedIn header row. Export the file from LinkedIn without editing it. |
-| `422 invalid_multipart` / `422 required` | Not sent as `multipart/form-data`, over the 8 MB limit, or missing the `file` part. |
+| `422 invalid_multipart` / `422 required` | Not sent as `multipart/form-data`, or missing the `file` part. |
+| `413 body_too_large` | Over this installation's upload limit. The message names the limit in force; the default is 8 MB. |
 
 ## Lifecycle and privacy
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -730,6 +730,47 @@ injects bounded context into declared AI tasks; `onboarding` additionally enable
 the five-step first-run flow. The default is `onboarding`. Moving backward is a
 reversible operational kill switch and never deletes confirmed company data.
 
+### Uploads
+
+The `uploads:` block sets how large a request each route that carries a **file**
+may read (OPS-CFG-12). Every other route stays on the 1 MiB JSON bound, which is
+a security invariant and is deliberately not configurable: several handlers
+decode the body with no bound of their own, and two of those routes are
+unauthenticated.
+
+| Key | Default | Route |
+|---|---|---|
+| `uploads.attachment_mb` | `25` | `POST /v1/attachments` — the documents surface |
+| `uploads.csv_import_mb` | `10` | `POST /v1/imports/sources` |
+| `uploads.linkedin_import_mb` | `8` | `POST /v1/me/linkedin-connections` |
+
+**Decimal megabytes**: `25` means 25,000,000 bytes, not 26,214,400. The value
+here is the number the server's 413 names and the number the upload form states,
+and those three agreeing is why the unit is decimal rather than binary — a
+binary constant reads as "25 MB" in a sentence while admitting 4.8% more.
+
+The ceiling bounds the **whole request**, part framing included, not the file
+alone. The overhead is a few hundred bytes, so it only matters within a rounding
+error of the limit; a client that refuses before sending should leave itself
+that much room.
+
+An omitted key takes the default. A value outside **1–100 MB** — including an
+explicit `0`, which would refuse every upload — is a boot error naming the key,
+never a silent clamp. Past 100 MB the answer is an upload straight to object
+storage rather than a larger number here, because the request is buffered
+through the api's own temp filesystem on its way to the store.
+
+`attachment_mb` is also published, read-only, as `max_upload_bytes` on
+`GET /v1/installation/settings`, which every role may read. That is what lets an
+upload surface state and enforce **this** installation's limit instead of one
+compiled into the client, so an oversize file is refused before it is sent.
+A change takes effect on restart, like every other key in this file.
+
+What the block does **not** decide is which routes may carry a file at all. That
+list is declared in source (`internal/compose/bodyceiling.go`) and is what keeps
+a route carrying no file from obtaining the wider bound by sending a multipart
+header; adding to it is a code change with two fitness gates over it.
+
 ### License
 
 The `license:` block points at the installation's entitlement token. It is

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -31089,7 +31089,12 @@ export interface operations {
             };
             401: components["responses"]["Unauthorized"];
             403: components["responses"]["PermissionDenied"];
-            /** @description The upload exceeds the 10 MB import body cap (CAP-BODY). A distinct refusal, never a truncated read. */
+            /**
+             * @description The upload exceeds this installation's import body cap (CAP-BODY) — 10 MB by default,
+             *     set by whoever operates it (`uploads.csv_import_mb`, OPS-CFG-12). The refusal NAMES the
+             *     configured number rather than one compiled in, and it is a distinct refusal, never a
+             *     truncated read that imports half an estate and reports success.
+             */
             413: {
                 headers: {
                     [name: string]: unknown;

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -8254,6 +8254,18 @@ export interface components {
              *     it. Absent when it is still changeable.
              */
             base_currency_locked_reason?: string;
+            /**
+             * Format: int64
+             * @description The largest upload request this installation accepts, in bytes — set by whoever
+             *     operates it, not compiled into the build (OPS-CFG-12, DOC-PARAM-11). Read-only:
+             *     it is a deployment fact, so PATCH does not carry it.
+             *
+             *     An upload surface states and enforces THIS number rather than one of its own, so
+             *     a file too large is refused before it is sent instead of after. The ceiling bounds
+             *     the whole request, part framing included, which is why a client should leave a
+             *     little room rather than compare a file against it exactly.
+             */
+            max_upload_bytes: number;
         };
         /** @description A sparse installation-settings patch (admin/ops, human-only). */
         UpdateInstallationSettingsRequest: {

--- a/frontend/src/app/uploadlimit.test.ts
+++ b/frontend/src/app/uploadlimit.test.ts
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import { describe, expect, it } from "vitest";
+import { formatUploadLimit } from "./uploadlimit";
+
+// The number this renders is compared by a reader against their own file, and
+// the server refuses on the same one. So it has to be exact in both directions:
+// a limit stated too high wastes an upload, one stated too low refuses a file
+// the installation would have taken.
+
+describe("stating the upload limit", () => {
+  it("renders a whole limit as a whole number", () => {
+    expect(formatUploadLimit(25_000_000)).toBe("25 MB");
+    expect(formatUploadLimit(3_000_000)).toBe("3 MB");
+  });
+
+  it("keeps a decimal rather than rounding a limit away", () => {
+    // What a binary constant on the server would produce. Rounded to "8 MB"
+    // this would refuse a file at 8.2 MB that the sentence said would fit.
+    expect(formatUploadLimit(8 << 20)).toBe("8.4 MB");
+    expect(formatUploadLimit(12_500_000)).toBe("12.5 MB");
+  });
+
+  it("still describes a limit below a megabyte", () => {
+    // Truncating division read this as "0 MB", which tells the reader nothing
+    // they can act on.
+    expect(formatUploadLimit(900_000)).toBe("0.9 MB");
+  });
+
+  it("uses decimal megabytes, the unit the server enforces", () => {
+    // 25 MiB is 26,214,400 bytes. Reported as "25 MB" it overstates the real
+    // ceiling by 4.8% — the drift this whole unit choice exists to remove.
+    expect(formatUploadLimit(25_000_000)).not.toBe(
+      formatUploadLimit(25 * 1024 * 1024),
+    );
+  });
+});

--- a/frontend/src/app/uploadlimit.ts
+++ b/frontend/src/app/uploadlimit.ts
@@ -1,0 +1,72 @@
+import { useQuery } from "@tanstack/react-query";
+import { api } from "../api/client";
+import { problemMessage } from "../screens/common";
+
+// The installation's own settings, and the one field on them a form has to act
+// on: how large a file this deployment accepts.
+//
+// The number is the OPERATOR's, not the build's — an installation sets its own
+// ceiling in its deployment file, so a constant compiled in here would be right
+// only for whoever shipped the default. It arrives on the installation read
+// every role may make.
+//
+// Why a client wants it at all, when the server refuses an oversize upload
+// anyway: because refusing afterwards means the whole file crossed the wire
+// first. Told the limit, a form can state it before a file is chosen and refuse
+// in the instant one is.
+//
+// ONE query for both readers — the settings screen and any upload form — under
+// one key. Two hooks on the same key would be worse than two keys: whichever
+// mounted first would decide the behaviour of the other, and only sometimes.
+
+/** The shared query key. Exported so a mutation can invalidate this read. */
+export const INSTALLATION_SETTINGS_KEY = ["installation-settings"] as const;
+
+/**
+ * The installation's settings, as the whole query.
+ *
+ * The queryFn throws, so a screen showing this record can gate on `error` and
+ * say what went wrong. A caller that only wants a field reads `data?.field` and
+ * gets undefined either way — no second request, and no second opinion about
+ * what a failure means.
+ */
+export function useInstallationSettings() {
+  return useQuery({
+    queryKey: INSTALLATION_SETTINGS_KEY,
+    queryFn: async () => {
+      const { data, error, response } = await api.GET("/installation/settings");
+      if (error || !response.ok) {
+        throw new Error(problemMessage(error));
+      }
+      return data;
+    },
+  });
+}
+
+/**
+ * The largest upload this installation accepts, in bytes — or undefined while
+ * the answer is still on its way, or if it never comes.
+ *
+ * Undefined is deliberately NOT a number. Guessing a limit before the server
+ * has stated one produces this feature's own failure in reverse: a form that
+ * refuses a file the installation would have taken, over a number the client
+ * invented and the reader cannot argue with. With no answer the upload proceeds
+ * and the refusal stays where it was before any of this existed — on the
+ * server, which is the authority regardless.
+ */
+export function useMaxUploadBytes(): number | undefined {
+  return useInstallationSettings().data?.max_upload_bytes;
+}
+
+/**
+ * The ceiling as a person reading a form would write it: decimal MB, exactly.
+ *
+ * Decimal because that is what the server enforces and what its refusal says. A
+ * binary megabyte here would state a limit 4.8% larger than the real one, and
+ * the reader who believed it would then be refused by a server that had already
+ * told them twice, in two different numbers.
+ */
+export function formatUploadLimit(bytes: number): string {
+  const mb = bytes / 1_000_000;
+  return `${Number.isInteger(mb) ? mb : mb.toFixed(1)} MB`;
+}

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -1751,7 +1751,7 @@ export const de = {
   "docs.add.nameHint":
     "Optional. Leer gelassen, zeigt die Zeile den Dateinamen.",
   "docs.add.file": "Datei",
-  "docs.add.fileHint": "Bis zu 25 MB.",
+  "docs.add.fileHint": "Bis zu {size}.",
   "docs.add.fileEmpty": "Datei hierher ziehen oder zum Auswählen klicken",
   "docs.add.cancel": "Abbrechen",
   "docs.add.submit": "Hochladen",
@@ -1760,6 +1760,8 @@ export const de = {
   "docs.add.errRefused":
     "Sie dürfen zu diesem Datensatz keine Dokumente hinzufügen.",
   "docs.add.errInFlight": "Dieses Dokument wird noch hochgeladen.",
+  "docs.add.errTooLarge":
+    "Diese Datei ist größer als {size} — mehr nimmt diese Installation nicht an. Bitte eine kleinere wählen.",
   "docs.add.failedTitle": "Der Upload ist fehlgeschlagen",
   "docs.add.failed":
     "Es wurde nichts gespeichert. Versuchen Sie es erneut oder wählen Sie eine andere Datei.",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -1750,7 +1750,7 @@ export const en = {
   "docs.add.name": "Title",
   "docs.add.nameHint": "Optional. Left blank, the row shows the filename.",
   "docs.add.file": "File",
-  "docs.add.fileHint": "Up to 25 MB.",
+  "docs.add.fileHint": "Up to {size}.",
   "docs.add.fileEmpty": "Drop the file here, or click to choose one",
   "docs.add.cancel": "Cancel",
   "docs.add.submit": "Upload",
@@ -1758,6 +1758,8 @@ export const en = {
   "docs.add.errNoFile": "Choose a file to upload.",
   "docs.add.errRefused": "You may not add documents to this record.",
   "docs.add.errInFlight": "This document is still uploading.",
+  "docs.add.errTooLarge":
+    "That file is larger than {size}, which is the most this installation accepts. Choose a smaller one.",
   "docs.add.failedTitle": "The upload did not go through",
   "docs.add.failed": "Nothing was stored. Try again, or choose another file.",
   "docs.add.partialTitle": "Uploaded, but not filed",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -1743,7 +1743,7 @@ export const vi = {
   "docs.add.name": "Tiêu đề",
   "docs.add.nameHint": "Không bắt buộc. Để trống thì dòng hiển thị tên tệp.",
   "docs.add.file": "Tệp",
-  "docs.add.fileHint": "Tối đa 25 MB.",
+  "docs.add.fileHint": "Tối đa {size}.",
   "docs.add.fileEmpty": "Kéo tệp vào đây, hoặc bấm để chọn",
   "docs.add.cancel": "Huỷ",
   "docs.add.submit": "Tải lên",
@@ -1751,6 +1751,8 @@ export const vi = {
   "docs.add.errNoFile": "Hãy chọn một tệp để tải lên.",
   "docs.add.errRefused": "Bạn không được thêm tài liệu vào bản ghi này.",
   "docs.add.errInFlight": "Tài liệu này vẫn đang được tải lên.",
+  "docs.add.errTooLarge":
+    "Tệp này lớn hơn {size}, là mức tối đa bản cài đặt này nhận. Hãy chọn tệp nhỏ hơn.",
   "docs.add.failedTitle": "Tải lên không thành công",
   "docs.add.failed": "Chưa lưu được gì. Hãy thử lại, hoặc chọn tệp khác.",
   "docs.add.partialTitle": "Đã tải lên, nhưng chưa xếp loại",

--- a/frontend/src/screens/adddocument.test.tsx
+++ b/frontend/src/screens/adddocument.test.tsx
@@ -74,6 +74,9 @@ function stubApi(
     // What this installation says it accepts. Absent means the read answers
     // without the field, which is the "server has not said" case.
     maxUploadBytes?: number;
+    // Refuses the installation read outright — the other way the client can end
+    // up without a limit.
+    settingsStatus?: number;
   } = {},
 ) {
   const calls: Recorded[] = [];
@@ -100,6 +103,12 @@ function stubApi(
         return json(me);
       }
       if (url.includes("/installation/settings")) {
+        if (options.settingsStatus) {
+          return json(
+            { title: "Server error", status: options.settingsStatus },
+            options.settingsStatus,
+          );
+        }
         return json({
           name: "Demo",
           timezone: "Europe/Berlin",
@@ -588,5 +597,21 @@ describe("adding a document from the account", () => {
     // argue with a number the client invented.
     await waitFor(() => expect(uploads(calls)).toHaveLength(1));
     expect(screen.queryByText(/larger than/)).toBeNull();
+  });
+  it("still uploads when the installation read fails outright", async () => {
+    const user = userEvent.setup();
+    const calls = stubApi(FULL_SEAT, { settingsStatus: 500 });
+    show();
+
+    await user.upload(screen.getByLabelText(/File/), fileOf(50_000_000));
+    await pressUpload(user);
+
+    // A failed settings read is not this dialog's problem to report: the screen
+    // it belongs to says so, and the upload still has a server that will refuse
+    // it if it must. What must NOT happen is a banner here, or a refusal over a
+    // limit nobody ever stated.
+    await waitFor(() => expect(uploads(calls)).toHaveLength(1));
+    expect(screen.queryByText(/larger than/)).toBeNull();
+    expect(screen.queryByText(/Up to/)).toBeNull();
   });
 });

--- a/frontend/src/screens/adddocument.test.tsx
+++ b/frontend/src/screens/adddocument.test.tsx
@@ -570,7 +570,7 @@ describe("adding a document from the account", () => {
     expect(uploads(calls)).toHaveLength(0);
   });
 
-  it("takes a file exactly at the limit", async () => {
+  it("sends a file exactly at the limit rather than refusing it here", async () => {
     const user = userEvent.setup();
     const calls = stubApi(FULL_SEAT, { maxUploadBytes: 3_000_000 });
     show();
@@ -579,8 +579,15 @@ describe("adding a document from the account", () => {
     await user.upload(screen.getByLabelText(/File/), fileOf(3_000_000));
     await pressUpload(user);
 
-    // The boundary belongs to the accepting side: a form that refused the exact
-    // limit would contradict the sentence beside it.
+    // What this proves is that the CLIENT does not refuse it — not that the
+    // server takes it. The ceiling bounds the whole request, so a file within a
+    // few hundred bytes of the limit is still refused by the server once part
+    // framing is counted, and that refusal names the same number.
+    //
+    // Erring this way on purpose. Subtracting a margin here would refuse files
+    // the installation would have accepted, over a number the reader was never
+    // shown; letting the last fraction of a percent through costs one wasted
+    // request and produces an honest message from the side that decides.
     await waitFor(() => expect(uploads(calls)).toHaveLength(1));
   });
 

--- a/frontend/src/screens/adddocument.test.tsx
+++ b/frontend/src/screens/adddocument.test.tsx
@@ -71,6 +71,9 @@ function stubApi(
     // Resolves the upload only once the test lets it, so the in-flight window
     // is a state the test can act in rather than a race it has to win.
     holdUpload?: Promise<void>;
+    // What this installation says it accepts. Absent means the read answers
+    // without the field, which is the "server has not said" case.
+    maxUploadBytes?: number;
   } = {},
 ) {
   const calls: Recorded[] = [];
@@ -95,6 +98,15 @@ function stubApi(
 
       if (url.includes("/v1/me")) {
         return json(me);
+      }
+      if (url.includes("/installation/settings")) {
+        return json({
+          name: "Demo",
+          timezone: "Europe/Berlin",
+          base_currency: "EUR",
+          base_currency_locked: false,
+          max_upload_bytes: options.maxUploadBytes,
+        });
       }
       if (url.includes("/v1/deals")) {
         return json({ data: [DEAL], page: { next_cursor: null } });
@@ -197,6 +209,11 @@ function orderForm() {
   return new File(["EUR 148,500.00"], "order_form.txt", {
     type: "text/plain",
   });
+}
+
+/** A file of exactly `size` bytes, for the cases that are about size alone. */
+function fileOf(size: number) {
+  return new File(["x".repeat(size)], "scan.pdf", { type: "application/pdf" });
 }
 
 /** Every multipart upload the dialog sent. Its LENGTH is the duplicate check. */
@@ -514,5 +531,62 @@ describe("adding a document from the account", () => {
     expect(
       await screen.findByText(/exceeds the 26214400-byte limit/),
     ).toBeTruthy();
+  });
+  // What this installation accepts is the OPERATOR's number, so the form has to
+  // ask rather than compile one in. Getting it wrong costs either a wasted
+  // upload of a file that was never going to be taken, or a refusal of one that
+  // would have been.
+  it("states the limit this installation actually enforces", async () => {
+    stubApi(FULL_SEAT, { maxUploadBytes: 3_000_000 });
+    show();
+
+    expect(await screen.findByText("Up to 3 MB.")).toBeTruthy();
+  });
+
+  it("refuses an oversize file without sending it", async () => {
+    const user = userEvent.setup();
+    const calls = stubApi(FULL_SEAT, { maxUploadBytes: 3_000_000 });
+    show();
+
+    await screen.findByText("Up to 3 MB.");
+    await user.upload(screen.getByLabelText(/File/), fileOf(3_000_001));
+
+    const submit = screen.getByRole("button", { name: "Upload" });
+    await waitFor(() => expect(submit.hasAttribute("disabled")).toBe(true));
+    await user.click(submit);
+
+    // The refusal names the limit, and NOTHING went over the wire: refusing
+    // after a 3 MB round trip is the cost this check exists to avoid.
+    expect(screen.getByText(/larger than 3 MB/)).toBeTruthy();
+    expect(uploads(calls)).toHaveLength(0);
+  });
+
+  it("takes a file exactly at the limit", async () => {
+    const user = userEvent.setup();
+    const calls = stubApi(FULL_SEAT, { maxUploadBytes: 3_000_000 });
+    show();
+
+    await screen.findByText("Up to 3 MB.");
+    await user.upload(screen.getByLabelText(/File/), fileOf(3_000_000));
+    await pressUpload(user);
+
+    // The boundary belongs to the accepting side: a form that refused the exact
+    // limit would contradict the sentence beside it.
+    await waitFor(() => expect(uploads(calls)).toHaveLength(1));
+  });
+
+  it("leaves the refusal to the server until the installation has answered", async () => {
+    const user = userEvent.setup();
+    const calls = stubApi(FULL_SEAT);
+    show();
+
+    await user.upload(screen.getByLabelText(/File/), fileOf(50_000_000));
+    await pressUpload(user);
+
+    // No answer means no local limit — not a guessed one. Guessing would refuse
+    // a file the installation may well accept, and the reader has no way to
+    // argue with a number the client invented.
+    await waitFor(() => expect(uploads(calls)).toHaveLength(1));
+    expect(screen.queryByText(/larger than/)).toBeNull();
   });
 });

--- a/frontend/src/screens/adddocument.tsx
+++ b/frontend/src/screens/adddocument.tsx
@@ -254,7 +254,12 @@ export function AddDocumentDialog({
     onClose();
   }
 
-  const refusal = uploadRefusal(file, permitted, upload.isPending, maxUploadBytes);
+  const refusal = uploadRefusal(
+    file,
+    permitted,
+    upload.isPending,
+    maxUploadBytes,
+  );
 
   return (
     <Modal open={open} onClose={closeAndClear} labelledBy={titleId}>
@@ -328,7 +333,9 @@ export function AddDocumentDialog({
           not, and the wait is one request long. */}
       <FileDropzone
         label={t("docs.add.file")}
-        hint={limitLabel ? t("docs.add.fileHint", { size: limitLabel }) : undefined}
+        hint={
+          limitLabel ? t("docs.add.fileHint", { size: limitLabel }) : undefined
+        }
         emptyLabel={t("docs.add.fileEmpty")}
         file={file}
         onPick={setFile}

--- a/frontend/src/screens/adddocument.tsx
+++ b/frontend/src/screens/adddocument.tsx
@@ -6,6 +6,7 @@ import { useEffect, useId, useRef, useState } from "react";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
 import { useCanWrite } from "../app/capability";
+import { formatUploadLimit, useMaxUploadBytes } from "../app/uploadlimit";
 import { Button, Field, Modal, TextInput } from "../design-system/atoms";
 import { Callout } from "../design-system/callout";
 import { FileDropzone } from "../design-system/filedropzone";
@@ -164,6 +165,11 @@ export function AddDocumentDialog({
     openNow.current = open;
   }, [open]);
 
+  // What this installation accepts, so an oversize file is refused here rather
+  // than after every byte of it has crossed the wire.
+  const maxUploadBytes = useMaxUploadBytes();
+  const limitLabel = maxUploadBytes ? formatUploadLimit(maxUploadBytes) : "";
+
   const deals = useAccountDeals(orgId, open);
   const parent = parseParent(choice, orgId);
   const canWriteOrg = useCanWrite("organization", "update");
@@ -248,7 +254,7 @@ export function AddDocumentDialog({
     onClose();
   }
 
-  const refusal = uploadRefusal(file, permitted, upload.isPending);
+  const refusal = uploadRefusal(file, permitted, upload.isPending, maxUploadBytes);
 
   return (
     <Modal open={open} onClose={closeAndClear} labelledBy={titleId}>
@@ -315,14 +321,14 @@ export function AddDocumentDialog({
         )}
       </Field>
 
-      {/* 25 MB is what the server enforces, checked against a running one
-          rather than read off a constant: the chassis bounded every body at
-          1 MiB until this change, which made the upload handler's own 25 MiB
-          cap dead and this hint a promise the product could not keep (issue
-          1542). A number in copy is a claim about behaviour. */}
+      {/* The limit is the SERVER's, read from the installation rather than
+          written here: it is set per deployment, so a number in this copy would
+          be right only for whoever shipped the default. Until the answer
+          arrives the hint says nothing at all — silence is honest, a guess is
+          not, and the wait is one request long. */}
       <FileDropzone
         label={t("docs.add.file")}
-        hint={t("docs.add.fileHint")}
+        hint={limitLabel ? t("docs.add.fileHint", { size: limitLabel }) : undefined}
         emptyLabel={t("docs.add.fileEmpty")}
         file={file}
         onPick={setFile}
@@ -332,7 +338,7 @@ export function AddDocumentDialog({
         <Button onClick={closeAndClear}>{t("docs.add.cancel")}</Button>
         <Button
           variant="primary"
-          reason={refusal ? t(refusal) : undefined}
+          reason={refusal ? t(refusal, { size: limitLabel }) : undefined}
           onClick={() =>
             file && upload.mutate({ parent, category, title, file })
           }
@@ -356,6 +362,7 @@ function uploadRefusal(
   file: File | undefined,
   permitted: boolean,
   pending: boolean,
+  maxBytes: number | undefined,
 ): MessageKey | null {
   if (!permitted) {
     return "docs.add.errRefused";
@@ -365,6 +372,18 @@ function uploadRefusal(
   }
   if (pending) {
     return "docs.add.errInFlight";
+  }
+  // Only when the server has SAID what it accepts. An unanswered installation
+  // read leaves the upload to be refused where it always was — sending a file
+  // that turns out to be too large costs a wasted request, while guessing a
+  // limit refuses one the installation would have taken.
+  //
+  // Compared against the file alone, though the ceiling bounds the whole
+  // request. The few hundred bytes of part framing mean a file within that
+  // distance of the limit still reaches the server's own refusal, which names
+  // the same number this message does.
+  if (maxBytes !== undefined && file.size > maxBytes) {
+    return "docs.add.errTooLarge";
   }
   return null;
 }

--- a/frontend/src/screens/installation-settings.tsx
+++ b/frontend/src/screens/installation-settings.tsx
@@ -1,8 +1,15 @@
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useId, useRef, useState } from "react";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
 import { useCanWrite } from "../app/capability";
+// Shared with every upload form, which reads the ceiling off this same record.
+// One query, one key: two hooks on one key would let whichever mounted first
+// decide how a failure behaves for the other.
+import {
+  INSTALLATION_SETTINGS_KEY,
+  useInstallationSettings,
+} from "../app/uploadlimit";
 import {
   Button,
   Field,
@@ -44,19 +51,6 @@ import { problemMessage, QueryGate } from "./common";
 type InstallationSettings = components["schemas"]["InstallationSettings"];
 type Patch = components["schemas"]["UpdateInstallationSettingsRequest"];
 
-function useInstallationSettings() {
-  return useQuery({
-    queryKey: ["installation-settings"],
-    queryFn: async () => {
-      const { data, error, response } = await api.GET("/installation/settings");
-      if (error || !response.ok) {
-        throw new Error(problemMessage(error));
-      }
-      return data;
-    },
-  });
-}
-
 function useUpdateInstallationSettings() {
   const queryClient = useQueryClient();
   return useMutation({
@@ -70,7 +64,7 @@ function useUpdateInstallationSettings() {
       return data;
     },
     onSuccess: (data) => {
-      queryClient.setQueryData(["installation-settings"], data);
+      queryClient.setQueryData(INSTALLATION_SETTINGS_KEY, data);
     },
     // A refused patch can still have committed nothing OR something: the
     // server applies the fields in one transaction, but a validation refusal


### PR DESCRIPTION
## The gap

#1539 gave the Documents card an upload button and, to make it work at all, replaced the chassis's single 1 MiB body bound with a route-scoped ceiling. That ceiling is **25 MB because a constant says so**.

Whoever runs the installation is the only one who knows whether that is right. Scanned contracts on a machine with disk to spare want a different answer than a container with a small ephemeral volume — and today the answer requires a rebuild.

Reviewing the code that shipped it turned up eight more defects, six of which live in the same lines this change touches.

## What this adds

`uploads:` in `margince.yaml`, per route, over compiled-in defaults (OPS-CFG-12, DOC-PARAM-11 — [margince-foundation#1340](https://github.com/gradionhq/margince-foundation/pull/1340), merged first):

```yaml
uploads:
  attachment_mb: 25        # POST /v1/attachments
  csv_import_mb: 10        # POST /v1/imports/sources
  linkedin_import_mb: 8    # POST /v1/me/linkedin-connections
```

**Per route**, because a CSV import and a signed PDF are different resource questions: raising what a contract may weigh should not raise what a parse will attempt.

**Decimal MB**, because the config key, the server's refusal and the upload form's hint all state this number and have to state the same one. `25 << 20` reads as "25 MB" in a sentence while admitting 26.2 million bytes. That tightens the two import caps by 4.8% — the code moving to match refusal messages that have always said "10 MB" and "8 MB".

**What the file does not decide is which routes may carry a file.** That list stays in source, and it is the whole security property: several handlers decode `r.Body` with no bound of their own and two of those routes are unauthenticated, so a route carrying no file must remain unable to obtain the file bound by claiming a media type. An operator picks the number; nobody picks the list at run time.

The number is published read-only on `GET /installation/settings`, which every role may read, so the upload form states and enforces **this** installation's limit and refuses an oversize file before it is sent. With no answer yet the upload proceeds and the server refuses — a limit the client invented is one the reader cannot argue with.

## Eight defects, fixed where they live

**Found reviewing #1539's code:**

1. **The route census compared counts** — `len(parsers) != len(routes)` — so a mistyped path left the real route parsing under the 1 MiB JSON bound while the totals still agreed. Both gates now compare sets, one derived from the contract and one from the tree.
2. **The 413 truncated the limit it named.** `limit/1_000_000` read an 8,388,608-byte ceiling as "8 MB" and refused an 8.2 MB file the sentence said would fit; anything under a megabyte read as "0 MB".
3. **The attachment handler blamed the caller for its own I/O.** `ParseMultipartForm` has already consumed the body, so what reached the `io.ReadAll` branch was a spill-file read failure — answered as `422 file/too_large`.
4. **Nothing ever spilled.** The parse threshold was pinned at the whole ceiling, so resident memory scaled with concurrent upload size, twice over once the bytes were copied for the blob store.
5. **The contract and the LinkedIn how-to still promised fixed numbers** — "the 10 MB import body cap", "bounded at 8 MB" — the exact drift this change exists to remove, in the two documents a caller actually reads. (The how-to also called an oversize upload a 422; it has been a 413 since the refusal learned to tell the two apart.)

**Found by the reviewers, in my own new code:**

6. **My rewritten census was package-scoped**, and `internal/compose` already serves an upload route — so a second undeclared multipart parse anywhere in that package read as covered. The same hole as the one I had just fixed, one level down. Every parse site now names its route.
7. **The contract harvest read only `post`, and only inline request bodies.** A multipart PUT or a `$ref`'d body dropped out of the obligation set silently, so the *reader* half of the gate was never armed.
8. **The CSV import route was the one upload site without the unset-ceiling guard** — two of three call sites fixed. With no ceiling it answered `413 "the upload exceeds the 0 MB limit"`, blaming a good file for a number this composition never set.

Also **streamed the attachment write path**: 1 MiB spill threshold, `Content io.ReadSeeker` hashed and measured in one pass then rewound for `blob.Put`. Size and checksum come from the same pass, so they cannot describe different content.

## Every gate mutation-verified

A guard whose failure has never been observed is a guard nobody has checked. Each of these was made to fail first:

| Gate | Mutation | Result |
|---|---|---|
| `TestTheDeclarationGateCanActuallyFail` | mistyped path, ghost route, missing route | all three reported |
| `TestEveryMultipartParseNamesItsRoute` | undeclared `ParseMultipartForm` added to `internal/compose` | red |
| `TestAStoredUploadKeepsItsOwnSizeAndChecksum` | `digest` returns a constant | red |
| `TestTheLinkedInRouteRidesItsOwnConfiguredCeiling` | deleted the `peopleHandlers.WithUploadLimit` wiring line | red |
| `TestTheContractHarvestSeesWhatItCannotAccountFor` | multipart PUT, `$ref` body fixtures | both reported |

## UAT — live stack, non-default ceiling, driven through the UI

Recorded against a `DEV_SLUG=upcfg` stack booted with **`attachment_mb: 3`**, so the recording proves the file is read rather than that the default still works. Video in the comment below.

- `GET /installation/settings` reported `max_upload_bytes: 25000000`, then **3000000** after the config change alone.
- The dialog's hint rendered **"Up to 3 MB."** — the configured number.
- A 4 MB file was **refused in the form** ("That file is larger than 3 MB, which is the most this installation accepts") with **zero requests to `/v1/attachments`**, confirmed by network inspection.
- A 2 MB file uploaded and landed as a row — a file the old 1 MiB bound would have refused outright.

Over the API on the same stack:

```
2 MB → 201  byte_size 2000000  checksum b3fcf913…88fb4f
4 MB → 413  {"code":"body_too_large","detail":"the upload exceeds the 3 MB limit"}
```

`shasum -a 256` of the local file matches the stored checksum byte for byte, through the new streaming path.

## Review

Reviewed by Codex and Fable before opening; findings 1–8 above are theirs and mine combined. Two review points were **answered rather than changed**, and say so in the source:

- The client compares the **file** against a ceiling that bounds the whole **request**, so a file within a few hundred bytes of the limit is still refused by the server. Deliberate: subtracting a margin would refuse files the installation accepts, over a number the reader was never shown. The test now claims only what it proves.
- "Never fully resident" was overstated — a file under the 1 MiB spill threshold is held in memory by design, which the comment now says.

One boundary worth naming, since it looks like a missed call site: the contract form's signed-PDF dropzone uploads through the same endpoint and does **not** pre-check size. It also states no limit, so nothing there contradicts anything — the server's refusal is the honest path. The pre-check belongs where a number is promised, and only the Documents dialog promises one.

Both reviewers independently flagged a pre-existing orphan-object gap (blob stored, row transaction fails, nothing cleans up). Confirmed present at #1539's base commit, so filed as **#1581** rather than widened into this PR.

## Gates

- `make check-backend` and `make check-fe` — green on the rebased tree.
- New-code coverage: `uploadlimit.ts` 100%, `adddocument.tsx` 99.2%, `deployconfig/uploads.go` and the census gates covered by their own suites.
- **No AI certification is affected**: no prompt, corpus, fixture or AI task is touched. Verified rather than assumed — `make check` carries the record-currency gate.
- Three tests fail in the integration lane, and **all three fail identically on a clean `origin/main` worktree** — verified by re-running each against a detached `origin/main` before filing, not assumed:
  - `TestADismissalHoldsUntilTheEvidenceMoves` — already tracked as **#1572**.
  - `TestFK_rowScopedTargetsHaveVisibilityDecision` and `TestSweepTargetsCarryNoDeleteBlockingTrigger` — both about `activity_retention_evidence` from the recent privacy work; filed as **#1588**.

  Everything else in the lane is green, including the five new upload-ceiling suites.

## Note on lineage

This began as work on #1539, which merged while it was in progress. The commits were moved onto a fresh branch off `main`; the content is unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes upload ceilings operator-configurable per route and publishes the active limit to clients. Previously all multipart uploads rode a compiled 25 MB cap; now each upload route enforces an installation-set limit (defaults: 25 MB attachments, 10 MB CSV import, 8 MB LinkedIn), and the Documents dialog pre-refuses files over this installation’s limit. Refusals name the exact decimal limit; an unwired ceiling is a 500, not “exceeds 0 MB”.

- Config: add `uploads:` to `margince.yaml` (decimal MB, 1–100). `deployconfig` validates and resolves defaults via `EffectiveUploads`. The active attachment limit is exposed as `max_upload_bytes` on `GET /installation/settings`; docs and example config state defaults.
- Server: new `compose.WithUploadLimits` injects per-route ceilings once and wires them to the chassis and handlers; limits apply to `activities` (attachments) and `people` (LinkedIn import). Upload-capable routes remain hardcoded. Multipart parsing now spills at 1 MiB; attachment writes stream, computing size and checksum in one pass. 413 messages use exact decimal MB.
- Client: the Add Document dialog reads `max_upload_bytes` via a shared hook, shows “Up to {size}”, and blocks oversize files locally. If the settings read fails or omits the field, the client does not invent a limit and the server enforces.
- Correctness/safety: compare declared upload routes as sets from the contract and the tree (all methods, resolves `$ref`); detect undeclared multipart parses; guard unset ceilings with 500; ensure LinkedIn and CSV import parse under the injected limits. New unit and integration tests cover wiring end to end.

**Migration**
- Operators: optionally set per‑route limits under `uploads:`; omitting keys keeps defaults.
- Internal callers: `activities.UploadAttachment` now accepts streaming content (`Content io.ReadSeeker`) instead of `Body []byte`. Update call sites.

<sup>Written for commit 4d3e7eefd234b27c489d338a699e19f6924a0ccb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1589?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

