### PR TITLE
fix: a chat message is not mail, and a manifest hash says which algorithm made it

### DIFF
--- a/backend/manifestdigest_test.go
+++ b/backend/manifestdigest_test.go
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package backendarch
+
+// Manifest-hash encoding fitness function (ADR-0069 §7): every hash a generated
+// unit manifest publishes says which algorithm produced it.
+//
+// A manifest is the record an operator reads to resolve what a unit requests,
+// and a field whose encoding depends on which kind of entry carries it is one
+// every reader has to special-case. A reader that did not would compare two
+// spellings of the same digest and see a change that never happened.
+//
+// It lives here rather than beside the generator because it reads files OUTSIDE
+// its own module, which Go's test cache cannot key: in the tools module a
+// manifest edited to the old spelling replays the previous pass and reports ok.
+// The root fitness lane runs `-count=1` for exactly this reason.
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+const unitManifestFile = "manifest.generated.json"
+
+// manifestDigestEncoding is the ONE spelling every hash in a manifest carries.
+var manifestDigestEncoding = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
+
+// isManifestHashField reports whether a field NAME is one that carries a hash.
+// Derived from the name rather than from a maintained list, so a field added
+// later is covered the moment it is named like the ones beside it — which is
+// the point, because the encoding is a property of the FILE and not of the
+// entries a reader happens to know about. The generator already computes a tree
+// digest and a manifest digest it does not yet publish; either would arrive
+// under a name this predicate already admits.
+func isManifestHashField(name string) bool {
+	return strings.HasSuffix(name, "hash") || strings.HasSuffix(name, "digest")
+}
+
+// manifestTrees are the two roots a unit manifest can live under, and whether
+// one is guaranteed to hold a unit that requests authority. extensions/ may
+// legitimately hold none — presence under it IS enablement, so the vanilla lane
+// composes an empty tree on purpose, and `de` is a jurisdiction pack that
+// requests no risk tier at all.
+var manifestTrees = []struct {
+	root           string
+	mustHoldTiered bool
+}{
+	{root: "../extensions"},
+	{root: "../fixtures", mustHoldTiered: true},
+}
+
+func TestEveryGeneratedManifestHashNamesItsAlgorithm(t *testing.T) {
+	for _, tree := range manifestTrees {
+		var tiered int
+		for _, path := range committedManifests(t, tree.root) {
+			tiered += assertManifestHashes(t, path)
+		}
+		// A root that reads nothing passes exactly like a clean one, and an
+		// aggregate count across both roots cannot catch it: extensions/ alone
+		// would carry the total forever while a fixture tree the walk never
+		// reached escaped the rule.
+		if tree.mustHoldTiered && tiered == 0 {
+			t.Errorf("%s yielded no risk-tier entry — the walk is reading no manifest that owes a hash", tree.root)
+		}
+	}
+}
+
+// assertManifestHashes holds one committed manifest to the encoding and returns
+// how many risk-tier entries it carried.
+//
+// It DECODES rather than scanning the text, and that is the load-bearing part.
+// A key written `fragment_hash`, a value that is null or a number, and a
+// compact `":"` separator all name the same field to every real reader of this
+// file; a text scan matches none of them and skips each one in silence.
+func assertManifestHashes(t *testing.T, path string) int {
+	t.Helper()
+	content, err := os.ReadFile(path) // #nosec G304 -- path comes from walking the trusted source tree
+	if err != nil {
+		t.Fatalf("reading %s: %v", path, err)
+	}
+	var document json.RawMessage
+	if err := json.Unmarshal(content, &document); err != nil {
+		t.Fatalf("%s is not valid JSON, so nothing below read what an operator reads: %v", path, err)
+	}
+	assertHashFieldsIn(t, path, document, "")
+	return assertEveryEntryIsHashed(t, path, content)
+}
+
+// assertHashFieldsIn walks a decoded manifest and holds every hash-named field
+// to the encoding, wherever in the document it sits.
+func assertHashFieldsIn(t *testing.T, path string, raw json.RawMessage, at string) {
+	t.Helper()
+	var object map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &object); err == nil {
+		for name, value := range object {
+			where := at + "." + name
+			if isManifestHashField(name) {
+				assertDigestEncoding(t, path, where, value)
+			}
+			assertHashFieldsIn(t, path, value, where)
+		}
+		return
+	}
+	var array []json.RawMessage
+	if err := json.Unmarshal(raw, &array); err == nil {
+		for i, item := range array {
+			assertHashFieldsIn(t, path, item, fmt.Sprintf("%s[%d]", at, i))
+		}
+	}
+	// Anything that reads as neither container is a scalar and has no children.
+	// The document was decoded whole before this walk began, so neither failure
+	// above can be a parse error going unreported here.
+}
+
+func assertDigestEncoding(t *testing.T, path, where string, value json.RawMessage) {
+	t.Helper()
+	var encoded string
+	if err := json.Unmarshal(value, &encoded); err != nil {
+		t.Errorf("%s: %s is %s — a hash that is not a string is not one a reader can compare", path, where, value)
+		return
+	}
+	if !manifestDigestEncoding.MatchString(encoded) {
+		t.Errorf("%s: %s = %q, want an algorithm-prefixed sha256 digest", path, where, encoded)
+	}
+}
+
+// assertEveryEntryIsHashed is what stops the walk above from passing a file it
+// found nothing in. Both hashes are structural — a risk-tier entry is the
+// authority request an operator resolves, `fragment_hash` covers the
+// declaration the descriptor's own fields do not, and `digest` covers the whole
+// descriptor — so an entry missing either is a request that cannot be resolved,
+// not merely one this gate did not inspect.
+func assertEveryEntryIsHashed(t *testing.T, path string, content []byte) int {
+	t.Helper()
+	var manifest struct {
+		RiskTiers []struct {
+			ID           string  `json:"id"`
+			FragmentHash *string `json:"fragment_hash"`
+			Digest       *string `json:"digest"`
+		} `json:"risk_tiers"`
+	}
+	if err := json.Unmarshal(content, &manifest); err != nil {
+		t.Fatalf("%s does not carry the manifest shape: %v", path, err)
+	}
+	for _, entry := range manifest.RiskTiers {
+		if entry.FragmentHash == nil || entry.Digest == nil {
+			t.Errorf("%s: risk tier %q carries no fragment_hash and/or no digest", path, entry.ID)
+		}
+	}
+	return len(manifest.RiskTiers)
+}
+
+// committedManifests is every generated unit manifest under one root. Derived
+// by walking rather than listed, so a unit added later is covered without
+// anyone remembering to add it here.
+func committedManifests(t *testing.T, root string) []string {
+	t.Helper()
+	var found []string
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		// A unit's frontend layer is a workspace package, so extensions/ holds
+		// installed dependency trees. Nothing generated by this repo lives in
+		// one, and a dependency that happened to ship a file under this name
+		// would be read and judged as a unit manifest.
+		if d.IsDir() && d.Name() == "node_modules" {
+			return fs.SkipDir
+		}
+		// A symlink would be judged on its target's bytes while its provenance
+		// points elsewhere — the same refusal digestTree makes one tree over.
+		if !d.IsDir() && d.Name() == unitManifestFile && d.Type().IsRegular() {
+			found = append(found, path)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking %s: %v", root, err)
+	}
+	return found
+}

--- a/backend/tools/gen-composition/extverbs.go
+++ b/backend/tools/gen-composition/extverbs.go
@@ -23,8 +23,6 @@ package main
 
 import (
 	"bytes"
-	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
 	"slices"
 	"sort"
@@ -370,6 +368,12 @@ func yamlChild(node *yaml.Node, key string) *yaml.Node {
 // means re-encoded through yaml.v3 at a fixed indent: the hash must change
 // when the DECLARATION changes and not when someone reflows a comment or a
 // flow mapping in the fragment above it.
+//
+// It hashes through digestBytes, so a tool's fragment hash is spelled the same
+// way as a job's and as every digest in the file. The manifest is what an
+// operator reads to resolve what a unit requests, and a field whose encoding
+// depended on which kind of entry carried it would have to be special-cased by
+// every reader of it.
 func operationHash(node *yaml.Node) (string, error) {
 	var buf bytes.Buffer
 	enc := yaml.NewEncoder(&buf)
@@ -380,6 +384,5 @@ func operationHash(node *yaml.Node) (string, error) {
 	if err := enc.Close(); err != nil {
 		return "", err
 	}
-	sum := sha256.Sum256(buf.Bytes())
-	return hex.EncodeToString(sum[:]), nil
+	return digestBytes(buf.Bytes()), nil
 }

--- a/backend/tools/gen-composition/extverbs.go
+++ b/backend/tools/gen-composition/extverbs.go
@@ -369,11 +369,8 @@ func yamlChild(node *yaml.Node, key string) *yaml.Node {
 // when the DECLARATION changes and not when someone reflows a comment or a
 // flow mapping in the fragment above it.
 //
-// It hashes through digestBytes, so a tool's fragment hash is spelled the same
-// way as a job's and as every digest in the file. The manifest is what an
-// operator reads to resolve what a unit requests, and a field whose encoding
-// depended on which kind of entry carried it would have to be special-cased by
-// every reader of it.
+// The result is algorithm-prefixed, the one spelling every hash a manifest
+// publishes carries; backend/manifestdigest_test.go holds the whole tree to it.
 func operationHash(node *yaml.Node) (string, error) {
 	var buf bytes.Buffer
 	enc := yaml.NewEncoder(&buf)

--- a/backend/tools/gen-composition/extverbs_test.go
+++ b/backend/tools/gen-composition/extverbs_test.go
@@ -134,8 +134,12 @@ func TestExtensionVerbsReadsAnOperationOutOfTheMergedContract(t *testing.T) {
 	if string(v.OutputSchema) != `{"properties":{"quote":{"type":"string"}},"type":"object"}` {
 		t.Fatalf("OutputSchema = %s", v.OutputSchema)
 	}
-	if got[0].fragmentHash == "" || len(got[0].fragmentHash) != 64 {
-		t.Fatalf("fragmentHash = %q, want a sha256 hex digest", got[0].fragmentHash)
+	// Algorithm-prefixed, the one spelling every hash in a manifest carries —
+	// a tool's fragment hash sits beside a job's and beside every digest, and a
+	// reader that had to tell them apart by entry kind would compare two
+	// spellings of one value and see a change that never happened.
+	if !digestEncoding.MatchString(got[0].fragmentHash) {
+		t.Fatalf("fragmentHash = %q, want an algorithm-prefixed sha256 digest", got[0].fragmentHash)
 	}
 }
 

--- a/backend/tools/gen-composition/extverbs_test.go
+++ b/backend/tools/gen-composition/extverbs_test.go
@@ -4,11 +4,18 @@
 package main
 
 import (
+	"regexp"
 	"strings"
 	"testing"
 
 	"github.com/gradionhq/margince/backend/pkg/extension"
 )
+
+// digestEncoding is how digestBytes spells a hash, which is what a fragment
+// hash is checked against here. The gate over the COMMITTED manifests lives in
+// the product module (backend/manifestdigest_test.go), because it reads files
+// this module's test cache cannot key.
+var digestEncoding = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
 
 // contractWith wraps a path item into the smallest document this reader will
 // accept, so a case reads as the operation it is about.
@@ -134,10 +141,7 @@ func TestExtensionVerbsReadsAnOperationOutOfTheMergedContract(t *testing.T) {
 	if string(v.OutputSchema) != `{"properties":{"quote":{"type":"string"}},"type":"object"}` {
 		t.Fatalf("OutputSchema = %s", v.OutputSchema)
 	}
-	// Algorithm-prefixed, the one spelling every hash in a manifest carries —
-	// a tool's fragment hash sits beside a job's and beside every digest, and a
-	// reader that had to tell them apart by entry kind would compare two
-	// spellings of one value and see a change that never happened.
+	// Algorithm-prefixed, the one spelling every hash in a manifest carries.
 	if !digestEncoding.MatchString(got[0].fragmentHash) {
 		t.Fatalf("fragmentHash = %q, want an algorithm-prefixed sha256 digest", got[0].fragmentHash)
 	}

--- a/backend/tools/gen-composition/unitmanifest_test.go
+++ b/backend/tools/gen-composition/unitmanifest_test.go
@@ -7,9 +7,11 @@ import (
 	"bytes"
 	"go/parser"
 	"go/token"
+	"io/fs"
 	"net/http"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -182,6 +184,69 @@ func TestCrmHelloManifestMatchesItsDerivation(t *testing.T) {
 		`"digest": "sha256:`)
 }
 
+// digestField matches every field a manifest publishes a hash in, by NAME
+// rather than by a maintained list: anything ending in `_hash`, plus `digest`
+// itself. A field added later is covered the moment it is named like the ones
+// beside it, which is the point — the encoding is a property of the file, not
+// of the entries a reader happens to know about.
+var digestField = regexp.MustCompile(`"([a-z0-9]+(?:_[a-z0-9]+)*_hash|digest)": "([^"]*)"`)
+
+// digestEncoding is the ONE spelling every one of those fields carries.
+var digestEncoding = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
+
+// TestEveryManifestHashIsAlgorithmPrefixed: a manifest is the record an
+// operator reads to resolve what a unit requests, so a hash in it says which
+// algorithm produced it. A field whose encoding depended on which KIND of entry
+// carried it — a job's prefixed, a tool's bare — is one every reader has to
+// special-case, and a reader that did not would compare two spellings of the
+// same digest and see a change that never happened.
+//
+// It walks the committed manifests rather than the requests a derivation
+// builds, because the committed file is what an operator actually reads.
+func TestEveryManifestHashIsAlgorithmPrefixed(t *testing.T) {
+	var checked int
+	for _, path := range committedManifests(t) {
+		content, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, field := range digestField.FindAllStringSubmatch(string(content), -1) {
+			checked++
+			if !digestEncoding.MatchString(field[2]) {
+				t.Errorf("%s: %s = %q, want an algorithm-prefixed sha256 digest", path, field[1], field[2])
+			}
+		}
+	}
+	// Without this the walk finding nothing would read exactly like the whole
+	// tree passing.
+	if checked == 0 {
+		t.Fatalf("no hash field found in any %s under %s — the walk is not reading the manifests", unitManifestFile, repoRoot)
+	}
+}
+
+// committedManifests is every generated unit manifest in the tree. Derived by
+// walking rather than listed, so a unit added later is covered without anyone
+// remembering to add it here.
+func committedManifests(t *testing.T) []string {
+	t.Helper()
+	var found []string
+	for _, tier := range []string{"extensions", filepath.Join("fixtures", "extensions")} {
+		err := filepath.WalkDir(filepath.Join(repoRoot, tier), func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if !d.IsDir() && d.Name() == unitManifestFile {
+				found = append(found, path)
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	return found
+}
+
 func assertCommittedManifest(t *testing.T, dir, name string, wantSubstrings ...string) {
 	t.Helper()
 	unit, err := scanUnit(name, dir)
@@ -243,7 +308,10 @@ func syntheticVerb(unit, tool, tier, scope string) declaredVerb {
 			Tier:           extension.Tier(tier),
 			RequestedScope: extension.Scope(scope),
 		},
-		fragmentHash: "0000000000000000000000000000000000000000000000000000000000000000",
+		// Spelled the way operationHash spells it, prefix included: a stand-in
+		// that carried a shape production never produces would let the manifest
+		// assertions below pass over an encoding no real unit has.
+		fragmentHash: "sha256:0000000000000000000000000000000000000000000000000000000000000000",
 	}
 }
 
@@ -451,7 +519,7 @@ func TestToolDerivesIntoRiskTier(t *testing.T) {
 		`"method": "POST"`,
 		`"tier": "auto_execute"`,
 		`"write"`,
-		`"fragment_hash": "0000`,
+		`"fragment_hash": "sha256:0000`,
 		`"digest": "sha256:`,
 	} {
 		if !strings.Contains(string(first), want) {

--- a/backend/tools/gen-composition/unitmanifest_test.go
+++ b/backend/tools/gen-composition/unitmanifest_test.go
@@ -7,11 +7,9 @@ import (
 	"bytes"
 	"go/parser"
 	"go/token"
-	"io/fs"
 	"net/http"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
 	"testing"
 
@@ -182,69 +180,6 @@ func TestCrmHelloManifestMatchesItsDerivation(t *testing.T) {
 		`"tier": "confirmation_required"`,
 		`"read"`,
 		`"digest": "sha256:`)
-}
-
-// digestField matches every field a manifest publishes a hash in, by NAME
-// rather than by a maintained list: anything ending in `_hash`, plus `digest`
-// itself. A field added later is covered the moment it is named like the ones
-// beside it, which is the point — the encoding is a property of the file, not
-// of the entries a reader happens to know about.
-var digestField = regexp.MustCompile(`"([a-z0-9]+(?:_[a-z0-9]+)*_hash|digest)": "([^"]*)"`)
-
-// digestEncoding is the ONE spelling every one of those fields carries.
-var digestEncoding = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
-
-// TestEveryManifestHashIsAlgorithmPrefixed: a manifest is the record an
-// operator reads to resolve what a unit requests, so a hash in it says which
-// algorithm produced it. A field whose encoding depended on which KIND of entry
-// carried it — a job's prefixed, a tool's bare — is one every reader has to
-// special-case, and a reader that did not would compare two spellings of the
-// same digest and see a change that never happened.
-//
-// It walks the committed manifests rather than the requests a derivation
-// builds, because the committed file is what an operator actually reads.
-func TestEveryManifestHashIsAlgorithmPrefixed(t *testing.T) {
-	var checked int
-	for _, path := range committedManifests(t) {
-		content, err := os.ReadFile(path)
-		if err != nil {
-			t.Fatal(err)
-		}
-		for _, field := range digestField.FindAllStringSubmatch(string(content), -1) {
-			checked++
-			if !digestEncoding.MatchString(field[2]) {
-				t.Errorf("%s: %s = %q, want an algorithm-prefixed sha256 digest", path, field[1], field[2])
-			}
-		}
-	}
-	// Without this the walk finding nothing would read exactly like the whole
-	// tree passing.
-	if checked == 0 {
-		t.Fatalf("no hash field found in any %s under %s — the walk is not reading the manifests", unitManifestFile, repoRoot)
-	}
-}
-
-// committedManifests is every generated unit manifest in the tree. Derived by
-// walking rather than listed, so a unit added later is covered without anyone
-// remembering to add it here.
-func committedManifests(t *testing.T) []string {
-	t.Helper()
-	var found []string
-	for _, tier := range []string{"extensions", filepath.Join("fixtures", "extensions")} {
-		err := filepath.WalkDir(filepath.Join(repoRoot, tier), func(path string, d fs.DirEntry, err error) error {
-			if err != nil {
-				return err
-			}
-			if !d.IsDir() && d.Name() == unitManifestFile {
-				found = append(found, path)
-			}
-			return nil
-		})
-		if err != nil {
-			t.Fatal(err)
-		}
-	}
-	return found
 }
 
 func assertCommittedManifest(t *testing.T, dir, name string, wantSubstrings ...string) {

--- a/extensions/dispact-connector/manifest.generated.json
+++ b/extensions/dispact-connector/manifest.generated.json
@@ -32,8 +32,8 @@
         "write"
       ],
       "tier": "auto_execute",
-      "fragment_hash": "6f0425f50cef78afc795d7976e80e8672d09dfa508e9eeaf1e9b92350937e024",
-      "digest": "sha256:b13bb43851fc8b81c56744614b5bcb3bf58ccc9b5e775fe34eb2a3e04ff5cc40"
+      "fragment_hash": "sha256:6f0425f50cef78afc795d7976e80e8672d09dfa508e9eeaf1e9b92350937e024",
+      "digest": "sha256:604131b643dfbac61b22ec9cd3cf760afc9d5f787c1dd18a4eda213ec08a3e0b"
     },
     {
       "id": "tool/dispact_disconnect",
@@ -48,8 +48,8 @@
         "write"
       ],
       "tier": "auto_execute",
-      "fragment_hash": "82d60ce4965acf0649192a8feda30fc9e16944cf71828a5ffaed84966763afad",
-      "digest": "sha256:f8e8b75d494f57616a71ff4cd66b9c83e0122fa9be1ee467c1297c8727184932"
+      "fragment_hash": "sha256:82d60ce4965acf0649192a8feda30fc9e16944cf71828a5ffaed84966763afad",
+      "digest": "sha256:0d28e3deb6a86e095f2bd9ae57f34af455a884980e4997d1ecd6058700a10bc3"
     },
     {
       "id": "tool/dispact_status",
@@ -64,8 +64,8 @@
         "read"
       ],
       "tier": "auto_execute",
-      "fragment_hash": "286f4a936c90e212f2eb567cc31cfea8bf2c16e203ad5c53cea79720576c1b33",
-      "digest": "sha256:ed6f7413428de0f1f8379cb714c294b629c09843699aaf5f9b2e1a0ea51b9e22"
+      "fragment_hash": "sha256:286f4a936c90e212f2eb567cc31cfea8bf2c16e203ad5c53cea79720576c1b33",
+      "digest": "sha256:c99d42bb3e5bdaac5d764f11bbc83fdf20deb7136ec7af04749ac3673d8148df"
     }
   ],
   "secrets": [

--- a/extensions/notes/manifest.generated.json
+++ b/extensions/notes/manifest.generated.json
@@ -32,8 +32,8 @@
         "write"
       ],
       "tier": "auto_execute",
-      "fragment_hash": "0c5182e93e406c57e822344f1cf3b6a3c5839b9f449b96aef49feddf84bb209f",
-      "digest": "sha256:1012069f65f6059f2d260fe0bcf4945e0258436a6c74d75e5de8e2a457818fec"
+      "fragment_hash": "sha256:0c5182e93e406c57e822344f1cf3b6a3c5839b9f449b96aef49feddf84bb209f",
+      "digest": "sha256:224c71af58e70a087418456fcee5fb4cc923c8e048678b92f445fd7344991692"
     },
     {
       "id": "tool/file_note",
@@ -48,8 +48,8 @@
         "write"
       ],
       "tier": "auto_execute",
-      "fragment_hash": "fb78ae8c11743197abdfed382754a5611bfb011789d620e17e2681a95d124c9b",
-      "digest": "sha256:df8e38d3d926a6de8c64036b214079925c60e403f7b0846c876237df2c1aa444"
+      "fragment_hash": "sha256:fb78ae8c11743197abdfed382754a5611bfb011789d620e17e2681a95d124c9b",
+      "digest": "sha256:68f94e51eccd2c08d49ab31613f00b6e91405be4ae0ebe2b6891c212f55b2b06"
     },
     {
       "id": "tool/list_notes",
@@ -64,8 +64,8 @@
         "read"
       ],
       "tier": "auto_execute",
-      "fragment_hash": "8a76bbb10fbc62d41f943abdcbd5e0336d475b9e55619e464a10deee80006f83",
-      "digest": "sha256:2e0ac22343faf4d802ff540a6f5472c0db451b3e0d41cc4f2820dd93aa95f5b0"
+      "fragment_hash": "sha256:8a76bbb10fbc62d41f943abdcbd5e0336d475b9e55619e464a10deee80006f83",
+      "digest": "sha256:b14327f1e2b42dccc36692cb696e9f51ed49b4bc33d87aaac82bbaf2e14c9291"
     },
     {
       "id": "tool/remove_note",
@@ -80,8 +80,8 @@
         "write"
       ],
       "tier": "auto_execute",
-      "fragment_hash": "87115ec136fcc0786a4fb3633d83f7e1f4ee77118f10092daf7b13f1ca24998b",
-      "digest": "sha256:a5d7b650df0e23f8439f6365545ac76f36308d791d13b9fe2ba42e4c589b62e0"
+      "fragment_hash": "sha256:87115ec136fcc0786a4fb3633d83f7e1f4ee77118f10092daf7b13f1ca24998b",
+      "digest": "sha256:b4d8acb06273629e3ef0d092ec7f9db75fe77e0fb3beba311f0d1b0a1b419752"
     },
     {
       "id": "tool/sign_payload",
@@ -96,8 +96,8 @@
         "read"
       ],
       "tier": "auto_execute",
-      "fragment_hash": "d3c5abc314b861a2a5da2e1fdc50d8ce04f0761f69f271c8faf3c90eb5789b42",
-      "digest": "sha256:3d4c0c5e25837b4ac0c1f82496ceaa8947fa6620f1ca32b5d046eff295f83ec3"
+      "fragment_hash": "sha256:d3c5abc314b861a2a5da2e1fdc50d8ce04f0761f69f271c8faf3c90eb5789b42",
+      "digest": "sha256:08d1ebd7bdbf662bea2d1c6cb90965f1f0fa1741a3756165ab93769a2ef887a0"
     },
     {
       "id": "tool/signing_key_status",
@@ -112,8 +112,8 @@
         "read"
       ],
       "tier": "auto_execute",
-      "fragment_hash": "98da6d4195ac90243b3da165144441c74b6f81df196b7d0ec8fbf3526ee59b35",
-      "digest": "sha256:e3f7d9e5d9f5dc9d0fb1e2a07f75f59a621651d7721342156448cacc5adf2b0c"
+      "fragment_hash": "sha256:98da6d4195ac90243b3da165144441c74b6f81df196b7d0ec8fbf3526ee59b35",
+      "digest": "sha256:76794d59583eab7e3cf098569134e64ea6edcc0c3c04483cc90dfd16355d40ab"
     },
     {
       "id": "tool/store_signing_key",
@@ -128,8 +128,8 @@
         "write"
       ],
       "tier": "auto_execute",
-      "fragment_hash": "b054c835e7f67499542ba80509eddb106daee43f2da0643575f8131ba641cb45",
-      "digest": "sha256:1959e81090b075ddc17695035fe07b8aa22405fc33216de175fdc105df97c90a"
+      "fragment_hash": "sha256:b054c835e7f67499542ba80509eddb106daee43f2da0643575f8131ba641cb45",
+      "digest": "sha256:f9841c77caac8cfdc8a2baa3a9964f9a43235889a10af2da32ed30babd63109d"
     }
   ],
   "secrets": [

--- a/extensions/yogi/manifest.generated.json
+++ b/extensions/yogi/manifest.generated.json
@@ -16,8 +16,8 @@
         "read"
       ],
       "tier": "auto_execute",
-      "fragment_hash": "00c2cd8d6ef6bb1c962b6016ee6cd90c22e55688256ebfa108cc917d5bd138e9",
-      "digest": "sha256:ee6acae9433b8fa3173f2aa6c6971dbde2954c2f0ee92b90a981d4edf9d1da6d"
+      "fragment_hash": "sha256:00c2cd8d6ef6bb1c962b6016ee6cd90c22e55688256ebfa108cc917d5bd138e9",
+      "digest": "sha256:202a4d98f5c905809cf81ae40edf9b769186800f830c5a91229bc5be3dbf2df2"
     }
   ]
 }

--- a/extensions/zalo-oa/manifest.generated.json
+++ b/extensions/zalo-oa/manifest.generated.json
@@ -32,8 +32,8 @@
         "write"
       ],
       "tier": "auto_execute",
-      "fragment_hash": "a80d8576a1a154d7a9c0ce0448b36e9998caecea12c9263b8f9503af8ce9d98a",
-      "digest": "sha256:4cb496089a005f899d97d4bdfd66c4d7a94a9605bb7fce5e00d2466b838e89a2"
+      "fragment_hash": "sha256:a80d8576a1a154d7a9c0ce0448b36e9998caecea12c9263b8f9503af8ce9d98a",
+      "digest": "sha256:685e96ccde668839fd6698c1739cfa7e838e7c9eaf23b0de61d786fcf28c1a77"
     },
     {
       "id": "tool/zalo_oa_disconnect",
@@ -48,8 +48,8 @@
         "write"
       ],
       "tier": "auto_execute",
-      "fragment_hash": "7a6ff021031bf8ccad90ea50e4ddb040cf3dbc3890ad2cff63eab6cb470d082e",
-      "digest": "sha256:440184775705891927c010996e3d32d9f6fd0fe8f5554b7aff17a67f3fd73ba4"
+      "fragment_hash": "sha256:7a6ff021031bf8ccad90ea50e4ddb040cf3dbc3890ad2cff63eab6cb470d082e",
+      "digest": "sha256:2faa7fc23feec0bbbaabdb87ae215260d6089b1d0b8b190df5f0ff0fc96d1b8b"
     },
     {
       "id": "tool/zalo_oa_status",
@@ -64,8 +64,8 @@
         "read"
       ],
       "tier": "auto_execute",
-      "fragment_hash": "0b21f25205aa791b3c3d5e2e18b2fe9f194f8ca2fe41ada3281176775ca272d2",
-      "digest": "sha256:60acd5e32d837ed295d1d65cc2b77d9e57f0fd1601c2eb5ab3c81fc5169e02b3"
+      "fragment_hash": "sha256:0b21f25205aa791b3c3d5e2e18b2fe9f194f8ca2fe41ada3281176775ca272d2",
+      "digest": "sha256:a381ca403e4060311a09b3be52dee7b7490b243ea2184147ba9edbbe264b1332"
     }
   ],
   "secrets": [

--- a/fixtures/extensions/crm-hello/manifest.generated.json
+++ b/fixtures/extensions/crm-hello/manifest.generated.json
@@ -16,8 +16,8 @@
         "read"
       ],
       "tier": "confirmation_required",
-      "fragment_hash": "d6310bcb4e4a9f121d711da667449afe63ff9cdc3a47325947c43816f3fd7044",
-      "digest": "sha256:6569ff09c395e55010ecc2b7cd716180102c482bd90453f8306a8dbb7ffacdb8"
+      "fragment_hash": "sha256:d6310bcb4e4a9f121d711da667449afe63ff9cdc3a47325947c43816f3fd7044",
+      "digest": "sha256:1fc8a5bc3aebe1d44efd755e73f4f1e8bc8bf7baead29d6bb5a510b6a35734fa"
     }
   ]
 }

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -4924,7 +4924,7 @@ export const de = {
   "person.brief.reading": "Die Beziehung wird gelesen…",
   "person.brief.empty":
     "Es wurde noch nichts erfasst, woraus dieses Briefing geschrieben werden könnte.",
-  "person.brief.sourceEmail": "E-Mail-Verlauf",
+  "person.brief.sourceActivity": "Gespräch",
   "person.brief.sourceDeal": "Deal-Notizen",
 
   "person.matters.title": "Was {name} wichtig ist",
@@ -4965,6 +4965,7 @@ export const de = {
   "person.memory.channelMeeting": "Termin",
   "person.memory.channelCall": "Anruf",
   "person.memory.channelNote": "Notiz",
+  "person.memory.channelMessage": "Nachricht",
   "person.memory.replied": "Beantwortet",
   "person.memory.unanswered": "Unbeantwortet",
 
@@ -5001,6 +5002,9 @@ export const de = {
   "person.rail.consentTitle": "Einwilligung & Kanäle",
   "person.rail.email": "E-Mail",
   "person.rail.phone": "Telefon",
+  "person.rail.noEmailAddress": "Keine Adresse hinterlegt",
+  "person.rail.noPhoneNumber": "Keine Nummer hinterlegt",
+  "person.rail.channelNotDeliverable": "Nicht zustellbar",
   "person.rail.recentActivity": "Letzte Aktivität",
   "person.rail.nothingCaptured": "Noch nichts erfasst.",
   "person.rail.viewAllActivity": "Alle Aktivitäten ansehen",

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -4966,6 +4966,7 @@ export const de = {
   "person.memory.channelCall": "Anruf",
   "person.memory.channelNote": "Notiz",
   "person.memory.channelMessage": "Nachricht",
+  "person.memory.channelTask": "Aufgabe",
   "person.memory.replied": "Beantwortet",
   "person.memory.unanswered": "Unbeantwortet",
 

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -4964,6 +4964,7 @@ export const en = {
   "person.memory.channelCall": "Call",
   "person.memory.channelNote": "Note",
   "person.memory.channelMessage": "Message",
+  "person.memory.channelTask": "Task",
   "person.memory.replied": "Replied",
   "person.memory.unanswered": "Unanswered",
 

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -4922,7 +4922,7 @@ export const en = {
   "person.brief.reading": "Reading the relationship…",
   "person.brief.empty":
     "Nothing has been captured yet that this brief could be written from.",
-  "person.brief.sourceEmail": "Email thread",
+  "person.brief.sourceActivity": "Conversation",
   "person.brief.sourceDeal": "Deal notes",
 
   "person.matters.title": "What matters to {name}",
@@ -4963,6 +4963,7 @@ export const en = {
   "person.memory.channelMeeting": "Meeting",
   "person.memory.channelCall": "Call",
   "person.memory.channelNote": "Note",
+  "person.memory.channelMessage": "Message",
   "person.memory.replied": "Replied",
   "person.memory.unanswered": "Unanswered",
 
@@ -4999,6 +5000,9 @@ export const en = {
   "person.rail.consentTitle": "Consent & channels",
   "person.rail.email": "Email",
   "person.rail.phone": "Phone",
+  "person.rail.noEmailAddress": "No address on file",
+  "person.rail.noPhoneNumber": "No number on file",
+  "person.rail.channelNotDeliverable": "Not deliverable",
   "person.rail.recentActivity": "Recent activity",
   "person.rail.nothingCaptured": "Nothing captured yet.",
   "person.rail.viewAllActivity": "View all activity",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -4895,7 +4895,7 @@ export const vi = {
   "person.brief.reading": "Đang đọc mối quan hệ…",
   "person.brief.empty":
     "Chưa có gì được ghi nhận để viết bản tóm tắt này từ đó.",
-  "person.brief.sourceEmail": "Chuỗi email",
+  "person.brief.sourceActivity": "Cuộc trò chuyện",
   "person.brief.sourceDeal": "Ghi chú deal",
 
   "person.matters.title": "Điều {name} quan tâm",
@@ -4936,6 +4936,7 @@ export const vi = {
   "person.memory.channelMeeting": "Cuộc họp",
   "person.memory.channelCall": "Cuộc gọi",
   "person.memory.channelNote": "Ghi chú",
+  "person.memory.channelMessage": "Tin nhắn",
   "person.memory.replied": "Đã hồi đáp",
   "person.memory.unanswered": "Chưa hồi đáp",
 
@@ -4972,6 +4973,9 @@ export const vi = {
   "person.rail.consentTitle": "Đồng ý & kênh liên lạc",
   "person.rail.email": "Email",
   "person.rail.phone": "Điện thoại",
+  "person.rail.noEmailAddress": "Chưa có địa chỉ",
+  "person.rail.noPhoneNumber": "Chưa có số",
+  "person.rail.channelNotDeliverable": "Không thể gửi",
   "person.rail.recentActivity": "Hoạt động gần đây",
   "person.rail.nothingCaptured": "Chưa ghi nhận gì.",
   "person.rail.viewAllActivity": "Xem tất cả hoạt động",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -4937,6 +4937,7 @@ export const vi = {
   "person.memory.channelCall": "Cuộc gọi",
   "person.memory.channelNote": "Ghi chú",
   "person.memory.channelMessage": "Tin nhắn",
+  "person.memory.channelTask": "Công việc",
   "person.memory.replied": "Đã hồi đáp",
   "person.memory.unanswered": "Chưa hồi đáp",
 

--- a/frontend/src/screens/interactionchrome.stories.tsx
+++ b/frontend/src/screens/interactionchrome.stories.tsx
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { interactionIcon, useInteractionLabel } from "./interactionchrome";
+import { installFetchStub, jsonResponse, StoryProviders } from "./story-utils";
+
+/**
+ * How a captured interaction is drawn and named.
+ *
+ * The KIND and the TRANSPORT are separate axes (ADR-0107/A158), and reading one
+ * off the other is what drew an envelope beside every chat message on the person
+ * page — on contacts who have no email address at all. So the icon comes from
+ * the kind, the name comes from the installation's transport directory, and
+ * neither is inferred from the other.
+ *
+ * The catalog below is the whole vocabulary at once, which is what makes the
+ * defect visible: a row whose icon disagrees with its name is a row claiming a
+ * transport the record never carried.
+ */
+const meta: Meta = {
+  title: "Records/Person record/Interaction chrome",
+  parameters: { layout: "padded" },
+};
+export default meta;
+type Story = StoryObj;
+
+// One row per activity kind the contract declares, plus the two message rows
+// that differ only by which transport carried them — the pair a reader has to be
+// able to tell apart, and the pair the old envelope collapsed into one.
+const CATALOG: ReadonlyArray<{ kind: string; provider?: string }> = [
+  { kind: "email" },
+  { kind: "call" },
+  { kind: "meeting" },
+  { kind: "note" },
+  { kind: "task" },
+  { kind: "message", provider: "zalo_oa" },
+  { kind: "message", provider: "dispact" },
+  // A transport this build has never heard of: an extension unit creates
+  // exactly this case, and the directory falls back to the raw id rather than
+  // blanking the cell.
+  { kind: "message", provider: "telegram" },
+  // A kind this build has never heard of. It is drawn as a plain record,
+  // because any other icon would be a guess about a transport.
+  { kind: "webinar" },
+];
+
+function Catalog() {
+  const interactionLabel = useInteractionLabel();
+  return (
+    <div className="pe-chiprow">
+      {CATALOG.map((entry) => (
+        <span
+          className="pe-memory-channel"
+          key={`${entry.kind}-${entry.provider ?? "none"}`}
+        >
+          {interactionIcon(entry.kind)}
+          {interactionLabel(entry.kind, entry.provider)}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+export const EveryKind: Story = {
+  render: () => {
+    installFetchStub({
+      "GET /channel-providers": () =>
+        jsonResponse({
+          data: [
+            {
+              provider: "zalo_oa",
+              label: "Zalo OA",
+              credential_model: "workspace_bot",
+              supplies_transport: true,
+            },
+            {
+              provider: "dispact",
+              label: "Dispact",
+              credential_model: "per_member",
+              supplies_transport: true,
+            },
+          ],
+        }),
+    });
+    return (
+      <StoryProviders>
+        <Catalog />
+      </StoryProviders>
+    );
+  },
+};
+
+// The directory unreachable, which is the state every surface renders in for the
+// first frame of a cold page. Every transport falls back to its raw id: a
+// provider a human can read beats an empty cell, and nothing here waits on a
+// fetch before it will draw.
+export const DirectoryUnavailable: Story = {
+  render: () => {
+    installFetchStub({
+      "GET /channel-providers": () => jsonResponse({ data: [] }),
+    });
+    return (
+      <StoryProviders>
+        <Catalog />
+      </StoryProviders>
+    );
+  },
+};

--- a/frontend/src/screens/interactionchrome.tsx
+++ b/frontend/src/screens/interactionchrome.tsx
@@ -78,6 +78,8 @@ export function useInteractionLabel(): (
         return t("person.memory.channelCall");
       case "note":
         return t("person.memory.channelNote");
+      case "task":
+        return t("person.memory.channelTask");
       case "message":
         // A message the contract says must name a transport, arriving without
         // one. Naming it plainly is the honest read; inventing a transport for

--- a/frontend/src/screens/interactionchrome.tsx
+++ b/frontend/src/screens/interactionchrome.tsx
@@ -1,0 +1,90 @@
+import {
+  CalendarDays,
+  CheckSquare,
+  FileText,
+  Mail,
+  MessageSquare,
+  Phone,
+  StickyNote,
+} from "lucide-react";
+import type { ReactNode } from "react";
+import { useT } from "../i18n";
+import { useProviderLabel } from "./channelproviders";
+
+// How a captured interaction is drawn and named, in ONE place.
+//
+// Since ADR-0107/A158 the KIND (what sort of interaction happened) and the
+// TRANSPORT (what carried it) are separate axes, and reading one off the other
+// is what drew an envelope beside every chat message on a contact page — on
+// contacts who have no email address at all. So the icon comes from the kind,
+// the transport name comes from the directory, and neither is inferred from the
+// other.
+//
+// It lives beside the screens rather than in the design system because both
+// halves are domain reads: the kind vocabulary is the activity contract's, and
+// the label resolves through the installation's own transport directory.
+
+// interactionIcon draws the kind, and ONLY the kind. Every case is a kind the
+// activity contract declares; the fallback is deliberately a plain record mark,
+// because an icon for a kind this build has never heard of can only be a guess
+// about the transport, and the envelope that used to stand there was the wrong
+// guess for every kind but one.
+export function interactionIcon(
+  kind: string | null | undefined,
+  size = 13,
+): ReactNode {
+  switch (kind) {
+    case "email":
+      return <Mail size={size} aria-hidden="true" />;
+    case "meeting":
+      return <CalendarDays size={size} aria-hidden="true" />;
+    case "call":
+      return <Phone size={size} aria-hidden="true" />;
+    case "note":
+      return <StickyNote size={size} aria-hidden="true" />;
+    case "task":
+      return <CheckSquare size={size} aria-hidden="true" />;
+    case "message":
+      return <MessageSquare size={size} aria-hidden="true" />;
+    default:
+      return <FileText size={size} aria-hidden="true" />;
+  }
+}
+
+// useInteractionLabel names a captured interaction for a reader: the transport
+// when one carried it, the kind otherwise.
+//
+// A transport is named by the DIRECTORY, never by a table in this file — which
+// providers exist is a deployment fact, so a switch here could only ever be
+// right for the providers this build happens to ship with. The resolver falls
+// back to the raw provider id, so a transport an extension unit added still
+// reads as something rather than blanking.
+export function useInteractionLabel(): (
+  kind: string | null | undefined,
+  provider?: string | null,
+) => string {
+  const t = useT();
+  const providerLabel = useProviderLabel();
+  return (kind, provider) => {
+    if (provider) {
+      return providerLabel(provider);
+    }
+    switch (kind) {
+      case "email":
+        return t("person.memory.channelEmail");
+      case "meeting":
+        return t("person.memory.channelMeeting");
+      case "call":
+        return t("person.memory.channelCall");
+      case "note":
+        return t("person.memory.channelNote");
+      case "message":
+        // A message the contract says must name a transport, arriving without
+        // one. Naming it plainly is the honest read; inventing a transport for
+        // it would be the defect this module exists to stop.
+        return t("person.memory.channelMessage");
+      default:
+        return kind ?? "";
+    }
+  };
+}

--- a/frontend/src/screens/personcards.tsx
+++ b/frontend/src/screens/personcards.tsx
@@ -1,4 +1,4 @@
-import { ExternalLink, FileText, Mail } from "lucide-react";
+import { ExternalLink, FileText } from "lucide-react";
 import type { ReactNode } from "react";
 import type { components } from "../api/schema";
 import { navigate } from "../app/router";
@@ -6,6 +6,7 @@ import { Avatar, Badge, Button, Checkbox } from "../design-system/atoms";
 import { Panel, PanelBody, PanelRow } from "../design-system/panel";
 import { useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
+import { interactionIcon, useInteractionLabel } from "./interactionchrome";
 import { money } from "./personstrip";
 
 // The overview's four cards (concept §5.6–5.9). Each one is a read of what the
@@ -15,6 +16,8 @@ import { money } from "./personstrip";
 type Person360 = components["schemas"]["Person360"];
 type PersonBrief = components["schemas"]["PersonBrief"];
 type ConversationClaim = components["schemas"]["ConversationClaim"];
+type Activity = components["schemas"]["Activity"];
+type BriefEvidence = components["schemas"]["OrganizationBriefEvidence"];
 
 // --- Relationship brief (§5.6) ---------------------------------------------
 
@@ -29,6 +32,12 @@ export function PersonBriefCard({
 }>) {
   const t = useT();
   const firstName = view.person.full_name.split(" ")[0];
+  // The timeline the page already read, by id. A citation is resolved from it
+  // rather than fetched, on the same terms as every other card here: a chip
+  // can never name a record the page beside it is withholding.
+  const citedActivities = new Map(
+    (view.activities?.data ?? []).map((row) => [row.id, row]),
+  );
   return (
     <Panel title={t("person.brief.title")}>
       <PanelBody>
@@ -61,7 +70,11 @@ export function PersonBriefCard({
                   ),
                 ).entries(),
               ].map(([key, cited]) => (
-                <SourceChip key={key} kind={cited.entity_type} />
+                <SourceChip
+                  key={key}
+                  cited={cited}
+                  activity={citedActivities.get(cited.entity_id)}
+                />
               ))}
             </div>
           </>
@@ -132,22 +145,38 @@ function commercialLine(view: Person360, t: ReturnType<typeof useT>): string {
   return t("person.commercial.noDeal");
 }
 
-function SourceChip({ kind }: Readonly<{ kind: string }>) {
+// One cited source, named for what it is.
+//
+// A citation carries a RECORD TYPE and an id, never a transport — so an
+// activity citation says nothing at all about how the conversation was
+// carried, and calling every one of them a mail thread told the reader of a
+// contact with no email address that they had been mailed. The activity the
+// page ALREADY read is the resolver: it carries the kind, and for a message
+// the provider the directory names. A citation whose activity is not on this
+// page is named for the one thing it certainly is — a conversation — rather
+// than for a transport nobody checked.
+function SourceChip({
+  cited,
+  activity,
+}: Readonly<{ cited: BriefEvidence; activity: Activity | undefined }>) {
   const t = useT();
-  const label =
-    kind === "activity"
-      ? t("person.brief.sourceEmail")
-      : kind === "deal"
-        ? t("person.brief.sourceDeal")
-        : kind;
+  const interactionLabel = useInteractionLabel();
+  if (cited.entity_type === "activity") {
+    return (
+      <span className="pe-memory-channel">
+        {interactionIcon(activity?.kind)}
+        {activity
+          ? interactionLabel(activity.kind, activity.channel_provider)
+          : t("person.brief.sourceActivity")}
+      </span>
+    );
+  }
   return (
     <span className="pe-memory-channel">
-      {kind === "activity" ? (
-        <Mail size={13} aria-hidden="true" />
-      ) : (
-        <FileText size={13} aria-hidden="true" />
-      )}
-      {label}
+      <FileText size={13} aria-hidden="true" />
+      {cited.entity_type === "deal"
+        ? t("person.brief.sourceDeal")
+        : cited.entity_type}
     </span>
   );
 }

--- a/frontend/src/screens/personmemory.tsx
+++ b/frontend/src/screens/personmemory.tsx
@@ -1,13 +1,11 @@
-import { CalendarDays, Mail, Phone, StickyNote } from "lucide-react";
-import type { ReactNode } from "react";
 import { useState } from "react";
 import type { components } from "../api/schema";
 import { Badge, SegmentedControl } from "../design-system/atoms";
 import { Panel, PanelBody, PanelRow } from "../design-system/panel";
 import { emailSummaryText } from "../format/emailtext";
 import { useT } from "../i18n";
-import { useProviderLabel } from "./channelproviders";
 import { ChannelReplyAction } from "./compose";
+import { interactionIcon, useInteractionLabel } from "./interactionchrome";
 
 // Conversation memory (concept §5.10, ADR-0097 D3).
 //
@@ -36,7 +34,7 @@ type Filter = (typeof FILTERS)[number];
 export function PersonMemory({ view }: Readonly<{ view: Person360 }>) {
   const t = useT();
   const [filter, setFilter] = useState<Filter>("all");
-  const providerLabel = useProviderLabel();
+  const interactionLabel = useInteractionLabel();
   const entries = view.conversation_memory ?? [];
   // Until the thread projection is filled, the timeline the page already read
   // IS the memory: same rows, condensed the same way. It reads from what the
@@ -44,8 +42,8 @@ export function PersonMemory({ view }: Readonly<{ view: Person360 }>) {
   // beside it is withholding.
   const rows =
     entries.length > 0
-      ? entries.map((entry) => fromEntry(entry, t, providerLabel))
-      : foldActivities(view, t, providerLabel);
+      ? entries.map((entry) => fromEntry(entry, t, interactionLabel))
+      : foldActivities(view, t, interactionLabel);
   const shown = rows.filter((row) => matches(row, filter));
 
   return (
@@ -75,8 +73,12 @@ export function PersonMemory({ view }: Readonly<{ view: Person360 }>) {
       {shown.map((row) => (
         <PanelRow className="pe-memory-row" key={row.key}>
           <span className="pe-memory-date">{row.date}</span>
+          {/* The icon reads the KIND and the label reads the transport: a chat
+              message drawn from its provider key alone fell through to the
+              envelope, which told a contact with no email address that they
+              had been mailed. */}
           <span className="pe-memory-channel">
-            {channelIcon(row.channel)}
+            {interactionIcon(row.kind)}
             {row.channelLabel}
           </span>
           <span>
@@ -136,18 +138,15 @@ type Row = {
   tone: "success" | "warn" | "accent" | undefined;
 };
 
-// The display key for the channel column. Since ADR-0107/A158 a message names
+// The filter key for the channel column. Since ADR-0107/A158 a message names
 // its transport separately, so the kind alone renders every channel row as the
 // bare word "message" — a Telegram thread and a Dispact thread become
-// indistinguishable. Folding the provider in restores exactly what the column
-// showed before the narrowing, and falls back to the kind when a row has no
-// transport (mail, calls, meetings, notes).
+// indistinguishable. Folding the provider in keeps them apart, and falls back
+// to the kind when a row has no transport (mail, calls, meetings, notes).
 //
-// The id it returns is resolved to a display label through the transport
-// directory (useProviderLabel). An UNKNOWN provider falls back to its raw id
-// rather than blanking: a provider this build has never heard of is precisely
-// the case an extension unit creates, and an id a human can read beats an
-// empty cell.
+// It keys the segmented filter and NOTHING a reader sees: the name comes from
+// the transport directory and the icon from the kind, so a provider this build
+// has never heard of still reads, and no row is drawn as something it is not.
 function channelKeyOf(
   kind: string,
   provider: string | null | undefined,
@@ -155,10 +154,14 @@ function channelKeyOf(
   return provider ?? kind;
 }
 
+// interactionLabel is useInteractionLabel's resolver, threaded in rather than
+// called here: a Row is built outside the component, and a hook may not be.
+type InteractionLabel = ReturnType<typeof useInteractionLabel>;
+
 function fromEntry(
   entry: NonNullable<Person360["conversation_memory"]>[number],
   t: ReturnType<typeof useT>,
-  providerLabel: (provider: string) => string,
+  interactionLabel: InteractionLabel,
 ): Row {
   const status = entry.status ?? null;
   return {
@@ -177,11 +180,7 @@ function fromEntry(
     kind: entry.channel,
     channelProvider: entry.channel_provider ?? null,
     channel: channelKeyOf(entry.channel, entry.channel_provider),
-    channelLabel: labelFor(
-      channelKeyOf(entry.channel, entry.channel_provider),
-      t,
-      providerLabel,
-    ),
+    channelLabel: interactionLabel(entry.channel, entry.channel_provider),
     title: entry.title,
     summary: entry.summary,
     status,
@@ -196,7 +195,7 @@ function fromEntry(
 function foldActivities(
   view: Person360,
   t: ReturnType<typeof useT>,
-  providerLabel: (provider: string) => string,
+  interactionLabel: InteractionLabel,
 ): Row[] {
   const rows = view.activities?.data ?? [];
   return rows
@@ -211,18 +210,8 @@ function foldActivities(
         kind: row.kind,
         channelProvider: row.channel_provider ?? null,
         channel: channelKeyOf(row.kind, row.channel_provider),
-        channelLabel: labelFor(
-          channelKeyOf(row.kind, row.channel_provider),
-          t,
-          providerLabel,
-        ),
-        title:
-          row.subject ??
-          labelFor(
-            channelKeyOf(row.kind, row.channel_provider),
-            t,
-            providerLabel,
-          ),
+        channelLabel: interactionLabel(row.kind, row.channel_provider),
+        title: row.subject ?? interactionLabel(row.kind, row.channel_provider),
         summary:
           row.kind === "email"
             ? emailSummaryText(row.body ?? "")
@@ -298,48 +287,6 @@ function matches(row: Row, filter: Filter): boolean {
       return row.channel === "note";
     default:
       return true;
-  }
-}
-
-function labelFor(
-  kind: string,
-  t: ReturnType<typeof useT>,
-  providerLabel?: (provider: string) => string,
-): string {
-  // A transport is named by the DIRECTORY, not by a table here: which providers
-  // exist is a deployment fact, so a switch in this file could only ever be
-  // right for the providers this build happens to ship with. The resolver falls
-  // back to the raw id, so an unknown transport still reads.
-  if (providerLabel) {
-    const resolved = providerLabel(kind);
-    if (resolved !== kind) {
-      return resolved;
-    }
-  }
-  switch (kind) {
-    case "email":
-      return t("person.memory.channelEmail");
-    case "meeting":
-      return t("person.memory.channelMeeting");
-    case "call":
-      return t("person.memory.channelCall");
-    case "note":
-      return t("person.memory.channelNote");
-    default:
-      return kind;
-  }
-}
-
-function channelIcon(kind: string): ReactNode {
-  switch (kind) {
-    case "meeting":
-      return <CalendarDays size={13} aria-hidden="true" />;
-    case "call":
-      return <Phone size={13} aria-hidden="true" />;
-    case "note":
-      return <StickyNote size={13} aria-hidden="true" />;
-    default:
-      return <Mail size={13} aria-hidden="true" />;
   }
 }
 

--- a/frontend/src/screens/personpage.stories.tsx
+++ b/frontend/src/screens/personpage.stories.tsx
@@ -824,6 +824,90 @@ export const RailConsentBlocked: Story = {
   },
 };
 
+// The contact a chat connector creates: no address, no number, and two channel
+// identities — one that can still be delivered to and one that cannot. It is
+// the shape the Consent & Channels block used to be silent about, reporting the
+// two transports this person does NOT have and omitting the two they do.
+const channelReached: View = {
+  ...populated,
+  person: {
+    ...populated.person,
+    emails: [],
+    phones: [],
+    reachability: [
+      {
+        provider: "zalo_oa",
+        reachable: true,
+        since: "2026-08-01T09:00:00Z",
+      },
+      {
+        provider: "dispact",
+        reachable: false,
+        since: "2026-08-09T09:00:00Z",
+      },
+    ],
+  },
+};
+
+export const RailChannelReached: Story = {
+  render: () => {
+    installFetchStub({
+      "GET /me": () =>
+        jsonResponse(meFixture({ allow: { person: ["update"] } })),
+      // A transport is named by the directory, so the story has to serve it:
+      // without this the rows fall back to the raw provider ids, which is the
+      // resolver's honest behaviour and not what this story is about.
+      "GET /channel-providers": () =>
+        jsonResponse({
+          data: [
+            {
+              provider: "zalo_oa",
+              label: "Zalo OA",
+              credential_model: "workspace_bot",
+              supplies_transport: true,
+            },
+            {
+              provider: "dispact",
+              label: "Dispact",
+              credential_model: "per_member",
+              supplies_transport: true,
+            },
+          ],
+        }),
+    });
+    return (
+      <StoryProviders>
+        <div style={{ maxWidth: 320 }}>
+          <PersonRail
+            view={channelReached}
+            guard={{
+              person_id: "p-1",
+              entries: [
+                {
+                  purpose_key: "business_correspondence",
+                  purpose_class: "business_correspondence",
+                  channel: "email",
+                  verdict: "allowed",
+                  reason: "She wrote to you on 1 Aug 2026.",
+                },
+                {
+                  purpose_key: "phone_outreach",
+                  purpose_class: "phone_outreach",
+                  channel: "phone",
+                  verdict: "unknown",
+                  reason: "No consent recorded.",
+                },
+              ],
+            }}
+            firstName="Dana"
+            onExplain={() => {}}
+          />
+        </div>
+      </StoryProviders>
+    );
+  },
+};
+
 // A record with an open deal, an empty committee and no meeting booked, and
 // a last inbound reply well past the 14-day threshold: the shape that fires
 // three of derivedSignals' four warnings at once (personrail.tsx) plus the
@@ -1027,6 +1111,75 @@ export const OverviewPanels: Story = {
       </div>
     </StoryProviders>
   ),
+};
+
+// The same two cards for a contact whose whole relationship arrived over a chat
+// channel. Both used to name it mail — an envelope on the memory row, and
+// "Email thread" under the brief — on a person with no address at all.
+const chatConversation: View = {
+  ...channelReached,
+  activities: {
+    data: [
+      {
+        id: "a-9",
+        kind: "message",
+        channel_provider: "zalo_oa",
+        direction: "inbound",
+        subject: null,
+        body: "Bên mình cần báo giá cho 40 xe.",
+        occurred_at: "2026-08-12T04:20:00Z",
+        links: [{ entity_type: "person", entity_id: "p-1" }],
+        source: "ext:zalo-oa:zalo",
+        captured_by: "connector:zalo-oa",
+        created_at: "2026-08-12T04:20:00Z",
+        updated_at: "2026-08-12T04:20:00Z",
+        is_done: false,
+      },
+    ],
+    page,
+  },
+  conversation_memory: [],
+};
+
+export const OverviewChannelConversation: Story = {
+  render: () => {
+    installFetchStub({
+      "GET /me": () => jsonResponse(meFixture({ allow: {} })),
+      "GET /channel-providers": () =>
+        jsonResponse({
+          data: [
+            {
+              provider: "zalo_oa",
+              label: "Zalo OA",
+              credential_model: "workspace_bot",
+              supplies_transport: true,
+            },
+          ],
+        }),
+    });
+    return (
+      <StoryProviders>
+        <div className="pe-overview-stack" style={{ maxWidth: 720 }}>
+          <PersonBriefCard
+            brief={{
+              person_id: "p-1",
+              generated_at: "2026-08-13T09:00:00Z",
+              generated_by: "deterministic",
+              sentences: [
+                {
+                  text: "She asked for a quote on forty vehicles and has not been answered.",
+                  evidence: [{ entity_type: "activity", entity_id: "a-9" }],
+                },
+              ],
+            }}
+            loading={false}
+            view={chatConversation}
+          />
+          <PersonMemory view={chatConversation} />
+        </div>
+      </StoryProviders>
+    );
+  },
 };
 
 // A deal with money, stage and a close date, and more than one stakeholder in

--- a/frontend/src/screens/personrail.tsx
+++ b/frontend/src/screens/personrail.tsx
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { ChevronRight, Mail, Phone } from "lucide-react";
+import type { ReactNode } from "react";
 import { useCallback, useId, useMemo, useState } from "react";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
@@ -25,7 +26,9 @@ import {
   type RecordPickerCandidate,
 } from "../design-system/recordpicker";
 import { useT } from "../i18n";
+import { useProviderLabel } from "./channelproviders";
 import { problemMessageOf, throwProblem, useSorMode } from "./common";
+import { interactionIcon } from "./interactionchrome";
 import { consentWord } from "./personstrip";
 
 // The right rail (concept §5.11): one continuous panel, its six slices told
@@ -64,7 +67,7 @@ export function PersonRail({
         <RelationshipPulse view={view} onExplain={onExplain} />
         <WhoKnows view={view} firstName={firstName} />
         <SignalsAndRisks view={view} />
-        <ConsentAndChannels guard={guard} />
+        <ConsentAndChannels view={view} guard={guard} />
         <RecentActivity view={view} />
       </Panel>
     </div>
@@ -1006,41 +1009,107 @@ function derivedSignals(
 // The action guard, not the proof ledger. It renders even on a thin record,
 // because "may I write to this person" is a question with an answer whatever
 // else is missing.
+//
+// Every row answers ONE transport, and it answers reachability before consent.
+// A verdict presupposes somewhere to send: reporting "allowed" against mail and
+// phone for a contact captured over a chat channel — no address, no number —
+// asserted a reachability nothing in the record supports, while the transport
+// the CRM can actually reach them on had no row at all.
+//
+// The channel rows come from `person.reachability`, the record's own read of
+// `person_channel_identity` — the same binding the reply path resolves a
+// recipient from. They carry the correspondence verdict rather than one of
+// their own because the send gate is per PURPOSE: it resolves the person and
+// asks the one question, so the transport never enters the answer.
 function ConsentAndChannels({
+  view,
   guard,
-}: Readonly<{ guard: PersonConsentGuard | undefined }>) {
+}: Readonly<{ view: Person360; guard: PersonConsentGuard | undefined }>) {
   const t = useT();
+  const providerLabel = useProviderLabel();
   const entries = guard?.entries ?? [];
-  const email = entries.find((entry) => entry.channel === "email");
+  const correspondence = entries.find((entry) => entry.channel === "email");
   const phone = entries.find((entry) => entry.channel === "phone");
+  const hasEmail = (view.person.emails?.length ?? 0) > 0;
+  const channels = view.person.reachability ?? [];
   return (
     <Disclosure
       className="pe-sect"
       open
       summary={t("person.rail.consentTitle")}
     >
-      <div className="pe-rail-row">
-        <span className="pe-rail-label">
-          <Mail size={15} aria-hidden="true" />
-          {t("person.rail.email")}
-        </span>
-        <span className={verdictClass(email?.verdict)}>
-          {consentWord(email?.verdict, t)}
-        </span>
-      </div>
-      <div className="pe-rail-row">
-        <span className="pe-rail-label">
-          <Phone size={15} aria-hidden="true" />
-          {t("person.rail.phone")}
-        </span>
-        <span className={verdictClass(phone?.verdict)}>
-          {consentWord(phone?.verdict, t)}
-        </span>
-      </div>
+      <ConsentRow
+        icon={<Mail size={15} aria-hidden="true" />}
+        label={t("person.rail.email")}
+        reachable={hasEmail}
+        verdict={correspondence?.verdict}
+        unreachableWord={t("person.rail.noEmailAddress")}
+      />
+      <ConsentRow
+        icon={<Phone size={15} aria-hidden="true" />}
+        label={t("person.rail.phone")}
+        reachable={(view.person.phones?.length ?? 0) > 0}
+        verdict={phone?.verdict}
+        unreachableWord={t("person.rail.noPhoneNumber")}
+      />
+      {/* A blocked identity still gets its row, with `reachable: false`: the
+          conversation happened, and hiding the transport it happened on would
+          answer "can I write to them" by pretending they were never here. */}
+      {channels.map((channel) => (
+        <ConsentRow
+          key={channel.provider}
+          icon={interactionIcon("message", 15)}
+          label={providerLabel(channel.provider)}
+          reachable={channel.reachable}
+          verdict={correspondence?.verdict}
+          unreachableWord={t("person.rail.channelNotDeliverable")}
+        />
+      ))}
       {/* The REASON, in the reader's words. A verdict a rep cannot explain to
-          the person in front of them is not usable. */}
-      {email?.reason && <p className="pe-colleague-proof">{email.reason}</p>}
+          the person in front of them is not usable — and one explaining a
+          verdict no row above shows explains nothing. */}
+      {(hasEmail || channels.some((channel) => channel.reachable)) &&
+        correspondence?.reason && (
+          <p className="pe-colleague-proof">{correspondence.reason}</p>
+        )}
     </Disclosure>
+  );
+}
+
+// One transport's row. Reachability is a fact about the RECORD and the verdict
+// is a fact about consent, and the row states the first before the second: a
+// permission to send where there is nowhere to send is not one a rep can act
+// on, and colouring it green says they may.
+function ConsentRow({
+  icon,
+  label,
+  reachable,
+  verdict,
+  unreachableWord,
+}: Readonly<{
+  icon: ReactNode;
+  label: string;
+  reachable: boolean;
+  verdict: string | undefined;
+  unreachableWord: string;
+}>) {
+  const t = useT();
+  return (
+    <div className="pe-rail-row">
+      <span className="pe-rail-label">
+        {icon}
+        {label}
+      </span>
+      <span
+        className={
+          reachable
+            ? verdictClass(verdict)
+            : "pe-rail-value pe-rail-value-muted"
+        }
+      >
+        {reachable ? consentWord(verdict, t) : unreachableWord}
+      </span>
+    </div>
   );
 }
 

--- a/frontend/src/screens/persontoday.tsx
+++ b/frontend/src/screens/persontoday.tsx
@@ -1,7 +1,9 @@
 import {
   AlertTriangle,
   CalendarDays,
-  Mail,
+  CheckSquare,
+  FileText,
+  Send,
   Sparkles,
   Users,
 } from "lucide-react";
@@ -10,6 +12,7 @@ import type { components } from "../api/schema";
 import { Button } from "../design-system/atoms";
 import { Panel, PanelBody } from "../design-system/panel";
 import { useT } from "../i18n";
+import { interactionIcon } from "./interactionchrome";
 
 // "Today with {first name}" (concept §5.5, ADR-0096 D2).
 //
@@ -152,14 +155,22 @@ function ActionVerb({
   );
 }
 
+// A moment says what to do; it never says what carries it. So the reply verb is
+// drawn as a send and not as an envelope — the envelope told a contact reached
+// only over a chat channel that the button would mail them, which is neither
+// what the action does nor something this card can know.
 function actionIcon(kind: string): ReactNode {
   switch (kind) {
     case "schedule_meeting":
     case "open_meeting_brief":
     case "ask_colleague":
       return <Users size={15} aria-hidden="true" />;
+    case "draft_reply":
+      return <Send size={15} aria-hidden="true" />;
+    case "complete_task":
+      return <CheckSquare size={15} aria-hidden="true" />;
     default:
-      return <Mail size={15} aria-hidden="true" />;
+      return <FileText size={15} aria-hidden="true" />;
   }
 }
 
@@ -182,14 +193,18 @@ function readiness(
   return t("person.rail.ready");
 }
 
+// A moment's evidence names a record TYPE and nothing about the transport, so
+// there is no honest envelope to draw beside an activity: it is as likely to
+// be a chat message or a call as a mail, and on a contact reached only over a
+// channel the envelope was simply wrong. It is drawn as the record it is.
 function evidenceIcon(type: string): ReactNode {
   switch (type) {
-    case "activity":
-      return <Mail size={15} aria-hidden="true" />;
     case "task":
       return <CalendarDays size={15} aria-hidden="true" />;
-    default:
+    case "relationship_change":
       return <Users size={15} aria-hidden="true" />;
+    default:
+      return interactionIcon(null, 15);
   }
 }
 

--- a/frontend/src/screens/persontransport.test.tsx
+++ b/frontend/src/screens/persontransport.test.tsx
@@ -1,0 +1,312 @@
+/** @vitest-environment jsdom */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  cleanup,
+  render as rtlRender,
+  screen,
+  within,
+} from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { components } from "../api/schema";
+import { LocaleProvider } from "../i18n";
+import { PersonBriefCard } from "./personcards";
+import { PersonMemory } from "./personmemory";
+import { PersonRail } from "./personrail";
+import { installFetchStub, jsonResponse, meRoute } from "./story-utils";
+
+// What the person page says about the transport that carried a message.
+//
+// Since ADR-0107/A158 the interaction KIND and the transport that carried it
+// are separate axes, and every surface here used to read the second off the
+// first. On a contact captured over a chat channel — no address, no number —
+// that produced a page that claimed mail three times over: an envelope on the
+// timeline, "Email thread" under the brief, and a consent block reporting the
+// person as reachable by email while showing no row at all for the channel the
+// CRM can actually reach them on.
+//
+// Every assertion below is made in BOTH directions. A page that stopped drawing
+// envelopes by drawing nothing would pass a one-directional suite, and a mail
+// contact still owes the reader an envelope.
+
+type Person360 = components["schemas"]["Person360"];
+type PersonBrief = components["schemas"]["PersonBrief"];
+type Activity = components["schemas"]["Activity"];
+
+const AT = "2026-08-15T09:00:00Z";
+
+function anActivity(over: Partial<Activity>): Activity {
+  return {
+    id: "a-1",
+    kind: "email",
+    direction: "inbound",
+    subject: "Re: the pilot",
+    body: "they wrote",
+    occurred_at: AT,
+    created_at: AT,
+    updated_at: AT,
+    is_done: false,
+    source: "gmail",
+    version: 1,
+    ...over,
+  } as Activity;
+}
+
+// A chat message, carried by a provider the directory below knows a name for.
+const aChatMessage = anActivity({
+  id: "a-chat",
+  kind: "message",
+  channel_provider: "zalo_oa",
+  subject: null,
+  body: "họ đã nhắn tin",
+  source: "ext:zalo-oa:zalo",
+});
+
+// Everything the three surfaces read, and nothing inherited from a fixture that
+// might change for another test's reasons.
+function viewWith(
+  options: Readonly<{
+    emails?: boolean;
+    phones?: boolean;
+    reachability?: { provider: string; reachable: boolean }[];
+    activities?: Activity[];
+  }>,
+): Person360 {
+  return {
+    as_of: AT,
+    person: {
+      id: "p-1",
+      full_name: "Dana Buyer",
+      version: 1,
+      emails: options.emails
+        ? [{ id: "pe-1", email: "dana@brandt.example", is_primary: true }]
+        : [],
+      phones: options.phones ? [{ id: "pp-1", phone: "+49 30 111" }] : [],
+      reachability: (options.reachability ?? []).map((entry) => ({
+        ...entry,
+        since: AT,
+      })),
+    },
+    activities: { data: options.activities ?? [] },
+    sections_omitted: [],
+  } as unknown as Person360;
+}
+
+// A brief whose one sentence cites one record — the shape the chip row reads.
+function briefCiting(entityType: string, entityId: string): PersonBrief {
+  return {
+    person_id: "p-1",
+    generated_at: AT,
+    generated_by: "deterministic",
+    sentences: [
+      {
+        text: "They asked about the pilot.",
+        evidence: [{ entity_type: entityType, entity_id: entityId }],
+      },
+    ],
+  } as unknown as PersonBrief;
+}
+
+function render(node: ReactNode) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return rtlRender(
+    <QueryClientProvider client={client}>
+      <LocaleProvider initial="en">{node}</LocaleProvider>
+    </QueryClientProvider>,
+  );
+}
+
+// The transport directory, which is what names a provider for a human. It is a
+// deployment fact, so the label can only come from here — a switch in a screen
+// would be right for whatever this build happens to ship and wrong for the next
+// unit somebody drops under extensions/.
+beforeEach(() => {
+  installFetchStub({
+    "GET /me": meRoute({}),
+    "GET /channel-providers": () =>
+      jsonResponse({
+        data: [
+          {
+            provider: "zalo_oa",
+            label: "Zalo OA",
+            credential_model: "workspace_bot",
+            supplies_transport: true,
+          },
+        ],
+      }),
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+// The transport cell of a timeline row or a brief chip — both draw the icon and
+// the name in the same slot. Read by class rather than by text: the assertion is
+// about what the cell SAYS, so a query that had to know the answer first could
+// only ever confirm itself.
+function transportCell(container: HTMLElement): HTMLElement {
+  const cell = container.querySelector<HTMLElement>(".pe-memory-channel");
+  if (!cell) {
+    throw new Error("no transport cell rendered");
+  }
+  return cell;
+}
+
+describe("the conversation timeline", () => {
+  it("draws a chat message as a message, named by its transport", async () => {
+    const { container } = render(
+      <PersonMemory view={viewWith({ activities: [aChatMessage] })} />,
+    );
+    // The name arrives with the transport directory, which is a fetch.
+    await screen.findAllByText("Zalo OA");
+
+    const cell = transportCell(container);
+    expect(cell.textContent).toBe("Zalo OA");
+    expect(cell.querySelector(".lucide-message-square")).toBeTruthy();
+    // The reported symptom: an envelope on a contact with no email address.
+    expect(cell.querySelector(".lucide-mail")).toBeNull();
+  });
+
+  it("still draws mail as mail", () => {
+    const { container } = render(
+      <PersonMemory view={viewWith({ activities: [anActivity({})] })} />,
+    );
+
+    const cell = transportCell(container);
+    expect(cell.textContent).toBe("Email");
+    expect(cell.querySelector(".lucide-mail")).toBeTruthy();
+    expect(cell.querySelector(".lucide-message-square")).toBeNull();
+  });
+});
+
+describe("the relationship brief's source chips", () => {
+  it("names the transport of a cited chat message", async () => {
+    const { container } = render(
+      <PersonBriefCard
+        brief={briefCiting("activity", "a-chat")}
+        loading={false}
+        view={viewWith({ activities: [aChatMessage] })}
+      />,
+    );
+    await screen.findByText("Zalo OA");
+
+    const chip = transportCell(container);
+    expect(chip.textContent).toBe("Zalo OA");
+    expect(chip.querySelector(".lucide-message-square")).toBeTruthy();
+    expect(chip.querySelector(".lucide-mail")).toBeNull();
+  });
+
+  it("names a cited mail thread as mail", () => {
+    const { container } = render(
+      <PersonBriefCard
+        brief={briefCiting("activity", "a-1")}
+        loading={false}
+        view={viewWith({ activities: [anActivity({})] })}
+      />,
+    );
+
+    const chip = transportCell(container);
+    expect(chip.textContent).toBe("Email");
+    expect(chip.querySelector(".lucide-mail")).toBeTruthy();
+  });
+
+  // The brief cites what the WRITER read, which is not bounded by the page of
+  // activities this reader was handed. A citation the page cannot resolve is
+  // named for the one thing it certainly is.
+  it("claims no transport for a citation it cannot resolve", () => {
+    const { container } = render(
+      <PersonBriefCard
+        brief={briefCiting("activity", "a-not-on-this-page")}
+        loading={false}
+        view={viewWith({ activities: [aChatMessage] })}
+      />,
+    );
+
+    const chip = transportCell(container);
+    expect(chip.textContent).toBe("Conversation");
+    expect(chip.querySelector(".lucide-mail")).toBeNull();
+    expect(chip.querySelector(".lucide-message-square")).toBeNull();
+  });
+});
+
+describe("consent and channels", () => {
+  function renderRail(view: Person360) {
+    render(
+      <PersonRail
+        view={view}
+        guard={
+          {
+            person_id: "p-1",
+            entries: [
+              {
+                purpose_key: "business_correspondence",
+                purpose_class: "business_correspondence",
+                channel: "email",
+                verdict: "allowed",
+                reason: "she wrote to you on 15 Aug",
+              },
+            ],
+          } as unknown as components["schemas"]["PersonConsentGuard"]
+        }
+        firstName="Dana"
+        onExplain={() => {}}
+      />,
+    );
+    return within(screen.getByTestId("person-rail"));
+  }
+
+  it("asserts no verdict for a transport the record does not carry", () => {
+    const rail = renderRail(
+      viewWith({
+        reachability: [{ provider: "zalo_oa", reachable: true }],
+        activities: [aChatMessage],
+      }),
+    );
+
+    // The reported symptom: "Email — Allowed" on a contact with no address.
+    expect(rail.getByText("No address on file")).toBeTruthy();
+    expect(rail.getByText("No number on file")).toBeTruthy();
+  });
+
+  it("gives the channel they are actually reached on its own row", async () => {
+    const rail = renderRail(
+      viewWith({
+        reachability: [{ provider: "zalo_oa", reachable: true }],
+        activities: [aChatMessage],
+      }),
+    );
+
+    // Named by the directory and carrying the correspondence verdict, which the
+    // send gate answers per purpose and not per transport.
+    expect(await rail.findByText("Zalo OA")).toBeTruthy();
+    expect(rail.getByText("Allowed")).toBeTruthy();
+  });
+
+  it("keeps the row when the identity can no longer be delivered to", async () => {
+    const rail = renderRail(
+      viewWith({
+        reachability: [{ provider: "zalo_oa", reachable: false }],
+        activities: [aChatMessage],
+      }),
+    );
+
+    expect(await rail.findByText("Zalo OA")).toBeTruthy();
+    expect(rail.getByText("Not deliverable")).toBeTruthy();
+    // A blocked channel must not read as a granted one.
+    expect(rail.queryByText("Allowed")).toBeNull();
+  });
+
+  it("still reports the verdict for a contact who has an address", () => {
+    const rail = renderRail(
+      viewWith({ emails: true, activities: [anActivity({})] }),
+    );
+
+    expect(rail.getByText("Allowed")).toBeTruthy();
+    expect(rail.queryByText("No address on file")).toBeNull();
+    expect(rail.getByText("she wrote to you on 15 Aug")).toBeTruthy();
+  });
+});


### PR DESCRIPTION
Closes #1562, #1563, #1566.

Three findings from the Zalo OA connector UAT (#1524), none of them specific to
that transport.

## A chat message read as mail (#1562)

Since ADR-0107/A158 the interaction **kind** and the **transport** that carried
it are separate axes, and the person page read the second off the first
everywhere. On a contact captured over a chat channel — no address, no number —
that produced a page claiming mail three times over:

- the **timeline** keyed its icon off the display channel (the *provider id*),
  which fell through the switch to the default envelope;
- the **relationship brief** labelled every cited activity an "Email thread",
  though a citation carries a record type and an id and says nothing at all
  about a transport;
- **Today's card** drew an envelope on its activity evidence and on its reply
  verb, for the same reason.

`frontend/src/screens/interactionchrome.tsx` now owns both halves in one place:
the icon comes from the kind, the name comes from the installation's transport
directory (`GET /v1/channel-providers`), and neither is inferred from the other.
A citation the page cannot resolve is named for the one thing it certainly is —
a conversation — rather than for a transport nobody checked.

## Consent & Channels answered backwards (#1563)

The block reported a verdict for mail and phone whatever the record carried, so
a contact with neither read as consented on both, while the transport the CRM
can actually reach them on had no row at all.

Rows now state **reachability before consent**, and the channel rows come from
`person.reachability` — the record's own read of `person_channel_identity`, the
same binding the reply path resolves a recipient from. They carry the
correspondence verdict rather than one of their own because the send gate is per
**purpose**: `consent.grantedForRecipient` resolves the person and asks
`VerdictForPerson`, so the transport never enters the answer. A blocked identity
keeps its row and says it cannot be delivered to — hiding it would answer "can I
write to them" by pretending the conversation never happened.

Rendered, for a contact reached only over chat:

```
Email      No address on file
Phone      No number on file
Zalo OA    Allowed
Dispact    Not deliverable
She wrote to you on 1 Aug 2026.
```

No contract change was needed: `Person.reachability` is already on the wire.

## fragment_hash was spelled two ways (#1566)

A tool entry's `fragment_hash` was a bare hex digest while the job entry beside
it, and every `digest` in the file, carried the `sha256:` prefix. The manifest is
what an operator reads to resolve what a unit requests, and a field whose
encoding depends on which kind of entry it sits on has to be special-cased by
every reader — one that did not would compare two spellings of the same digest
and see a change that never happened. `operationHash` now hashes through
`digestBytes`, the helper the job side already used; the committed manifests are
regenerated.

## Gates

- `TestEveryManifestHashIsAlgorithmPrefixed` is a fitness function, not a case:
  it walks every committed manifest in the tree and holds every field *named*
  like a hash — anything ending in `_hash`, plus `digest` — to one encoding, so a
  field added later is covered the moment it is named like its neighbours. It
  fails when the walk finds nothing, because a walk reading no manifests looks
  exactly like a clean tree.
- `persontransport.test.tsx` (9 tests) asserts **in both directions**: a page
  that stopped drawing envelopes by drawing nothing would pass a one-directional
  suite, and a mail contact still owes the reader an envelope. Each test was
  mutation-verified against the defect it describes — reverting the icon table
  fails exactly the three chat assertions and none of the mail ones; reverting
  the rail fails exactly the three channel assertions.
- Two new stories (`RailChannelReached`, `OverviewChannelConversation`) plus a
  catalog for the chrome itself. Writing the catalog is what exposed that `task`
  rendered as the raw lowercase wire value beside six translated labels — the
  same gap as the envelope, one column over — so it is named too.

`make check` green; `make fe-uat` green (27 stories).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the person page from treating chat messages as mail and makes manifest hashes algorithm‑prefixed. Previously chat rows drew an envelope and “Email thread,” and the consent rail reported email/phone verdicts without addresses while omitting the channel; now icons come from interaction kind, labels come from the provider directory, and reachability precedes consent. All manifest hashes now spell as `sha256:<hex>` so readers no longer special‑case fields.

- Interaction chrome and consent rail
  - New `interactionchrome.tsx`: icon from kind, label via the directory; unknown providers fall back to id; unknown kinds render a generic record icon.
  - Timeline, brief chips, and Today use this chrome. The reply verb shows “send,” moment evidence uses a neutral record icon, and `task` now has a label.
  - Consent & Channels reads `person.reachability` for channel rows and shows the correspondence verdict. Email/phone show “No address/number on file” when missing; reached chat channels render their own rows; blocked identities show “Not deliverable.”
  - Stories catalog the vocabulary; tests assert both chat and mail cases; i18n updated.

- Manifest hash encoding
  - `operationHash` now uses `digestBytes`; regenerated manifests prefix `fragment_hash` and all digest fields with `sha256:`.
  - A root fitness test (`backend/manifestdigest_test.go`) walks committed manifests in `extensions/` and `fixtures/`, decodes JSON, enforces algorithm‑prefixed strings for any field ending in `_hash` or `digest`, requires each risk‑tier entry to carry both `fragment_hash` and `digest`, and fails empty roots; it skips `node_modules` and non‑regular files.
  - Migration: regenerate manifests so all “*_hash” and “*digest” fields are `sha256:`‑prefixed.

<sup>Written for commit 4944365f7307f0cb13499088bec9f1d34c5c2525. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1590?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

