### PR TITLE
feat(ai): the anthropic wire carries a document, because it does

### DIFF
--- a/backend/internal/modules/ai/anthropicparts.go
+++ b/backend/internal/modules/ai/anthropicparts.go
@@ -5,7 +5,7 @@ package ai
 
 // The Messages API's message body, which is two JSON shapes wearing one name: a
 // bare string for an ordinary turn, an ordered array of typed blocks once the
-// turn carries an image.
+// turn carries an attachment.
 //
 // Both shapes are spelled here for the same reason the OpenAI-compatible wire
 // spells both (openaicompatparts.go): a text-only call must keep marshalling to
@@ -26,8 +26,13 @@ import (
 const (
 	anthropicBlockText  = "text"
 	anthropicBlockImage = "image"
-	// The two spellings an image block's source takes: bytes the request
-	// carries, or a URL the API fetches for itself.
+	// A PDF is its own block type on this wire rather than an image with a
+	// different media type: the API paginates a document and an image has no
+	// pages, so the two are not one part kind spelled twice.
+	anthropicBlockDocument = "document"
+	// The two spellings an attachment block's source takes, the same pair for
+	// either block type: bytes the request carries, or a URL the API fetches
+	// for itself.
 	anthropicSourceBase64 = "base64"
 	anthropicSourceURL    = "url"
 )
@@ -56,15 +61,19 @@ func (c anthropicContent) MarshalJSON() ([]byte, error) {
 // anthropicBlock is one block of a multi-block turn. Text and Source are
 // mutually exclusive and Type says which is set, so both are omitempty.
 type anthropicBlock struct {
-	Type   string                `json:"type"` // "text" | "image"
-	Text   string                `json:"text,omitempty"`
-	Source *anthropicImageSource `json:"source,omitempty"`
+	Type   string           `json:"type"` // "text" | "image" | "document"
+	Text   string           `json:"text,omitempty"`
+	Source *anthropicSource `json:"source,omitempty"`
 }
 
-// anthropicImageSource is the image block's source, in either of the two
+// anthropicSource is an attachment block's source, in either of the two
 // spellings the API accepts: inline base64 with its media type, or a URL the
 // API fetches. MediaType/Data belong to the first, URL to the second.
-type anthropicImageSource struct {
+//
+// One type for both block kinds because the API spells them identically —
+// splitting it would be two structs that must never diverge, which is a harder
+// invariant to hold than the one shape it would be documenting.
+type anthropicSource struct {
 	Type      string `json:"type"` // "base64" | "url"
 	MediaType string `json:"media_type,omitempty"`
 	Data      string `json:"data,omitempty"`
@@ -102,19 +111,25 @@ func anthropicMessages(msgs []model.Message, atts []model.Attachment) []anthropi
 		target.Content.Blocks = append(target.Content.Blocks, anthropicBlock{Type: anthropicBlockText, Text: target.Content.Text})
 	}
 	for _, a := range atts {
-		target.Content.Blocks = append(target.Content.Blocks, anthropicImageBlock(a))
+		target.Content.Blocks = append(target.Content.Blocks, anthropicAttachmentBlock(a))
 	}
 	return out
 }
 
-// anthropicImageBlock maps one attachment to an image block. Only images reach
-// it: carriage is gated against this binding's own list, which is carriesImages
-// or a narrowing of it, and neither admits anything else.
-func anthropicImageBlock(a model.Attachment) anthropicBlock {
-	if a.URI != "" {
-		return anthropicBlock{Type: anthropicBlockImage, Source: &anthropicImageSource{Type: anthropicSourceURL, URL: a.URI}}
+// anthropicAttachmentBlock maps one attachment to the block kind its media type
+// takes. Only an image or a PDF reaches it: carriage is gated against this
+// binding's own list, which is carriesImagesAndPDF or a narrowing of it, and
+// that admits nothing else — so `isImage` picks between the two kinds rather
+// than deciding whether the attachment may be sent at all.
+func anthropicAttachmentBlock(a model.Attachment) anthropicBlock {
+	kind := anthropicBlockDocument
+	if isImage(a.MIME) {
+		kind = anthropicBlockImage
 	}
-	return anthropicBlock{Type: anthropicBlockImage, Source: &anthropicImageSource{
+	if a.URI != "" {
+		return anthropicBlock{Type: kind, Source: &anthropicSource{Type: anthropicSourceURL, URL: a.URI}}
+	}
+	return anthropicBlock{Type: kind, Source: &anthropicSource{
 		Type:      anthropicSourceBase64,
 		MediaType: a.MIME,
 		Data:      base64.StdEncoding.EncodeToString(a.Bytes),
@@ -126,13 +141,14 @@ func anthropicImageBlock(a model.Attachment) anthropicBlock {
 // this wire cannot express.
 //
 // A URI attachment is a URL or a provider file handle. Anthropic fetches an
-// https URL itself, so that half maps. A handle would be its Files API
+// https URL itself — for a document as for an image, the same `source.type:
+// "url"` — so that half maps. A handle would be its Files API
 // (`source.type: "file"`), which the endpoint serves only to a request carrying
 // the Files beta header this adapter does not send — so a handle is refused
 // rather than mapped to a block the vendor would reject for a reason that names
 // the wrong thing.
 func anthropicRefuseAttachments(atts []model.Attachment, declared []string) error {
-	if err := refuseNarrowedAttachments("anthropic", atts, declared, carriesImages); err != nil {
+	if err := refuseNarrowedAttachments("anthropic", atts, declared, carriesImagesAndPDF); err != nil {
 		return err
 	}
 	for _, a := range atts {

--- a/backend/internal/modules/ai/anthropicparts_test.go
+++ b/backend/internal/modules/ai/anthropicparts_test.go
@@ -133,6 +133,56 @@ func TestAnthropicImageURIBecomesAURLSource(t *testing.T) {
 	}
 }
 
+// A PDF takes the API's own document block, not an image block wearing a
+// different media type. The distinction is the whole mapping: the vendor
+// paginates a document and would reject the same bytes announced as an image,
+// so a block kind picked off the media type is what makes the document lane
+// real rather than an image lane with a wider carriage list.
+func TestAnthropicPDFBecomesADocumentBlockNotAnImageOne(t *testing.T) {
+	for name, tc := range map[string]struct {
+		att   model.Attachment
+		check func(*testing.T, *anthropicSource)
+	}{
+		"inline bytes": {
+			att: model.Attachment{MIME: "application/pdf", Bytes: []byte("%PDF")},
+			check: func(t *testing.T, src *anthropicSource) {
+				t.Helper()
+				if src.Type != "base64" || src.MediaType != "application/pdf" || src.Data != "JVBERg==" {
+					t.Errorf("inline bytes must become a base64 document source, got %+v", src)
+				}
+			},
+		},
+		"fetchable url": {
+			att: model.Attachment{MIME: "application/pdf", URI: "https://files.example/a.pdf"},
+			check: func(t *testing.T, src *anthropicSource) {
+				t.Helper()
+				if src.Type != "url" || src.URL != "https://files.example/a.pdf" {
+					t.Errorf("a URI attachment must ride as a url source, got %+v", src)
+				}
+				if src.Data != "" || src.MediaType != "" {
+					t.Errorf("a url source carries neither data nor a media type, got %+v", src)
+				}
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			msgs := anthropicMessages([]model.Message{{Role: roleUser, Content: "read this"}},
+				[]model.Attachment{tc.att})
+			blocks := msgs[0].Content.Blocks
+			if len(blocks) != 2 {
+				t.Fatalf("want the turn's text plus the document, got %d blocks", len(blocks))
+			}
+			if blocks[1].Type != "document" {
+				t.Fatalf("a PDF must ride the document block, got type %q", blocks[1].Type)
+			}
+			if blocks[1].Source == nil {
+				t.Fatal("a document block must carry a source")
+			}
+			tc.check(t, blocks[1].Source)
+		})
+	}
+}
+
 // Attachments belong to a user turn. A request whose messages hold none — the
 // system prompt travels elsewhere on this wire — gets one created rather than
 // the image being hung off an assistant turn.
@@ -150,7 +200,7 @@ func TestAnthropicAttachmentWithNoUserTurnGetsOne(t *testing.T) {
 // A URI this wire cannot resolve is refused as a carriage failure, not mapped to
 // a url source the vendor would reject for a reason naming the wrong thing.
 func TestAnthropicRefusesAnAttachmentURIItCannotResolve(t *testing.T) {
-	err := anthropicRefuseAttachments([]model.Attachment{{MIME: "image/png", URI: "file-abc123"}}, carriesImages)
+	err := anthropicRefuseAttachments([]model.Attachment{{MIME: "image/png", URI: "file-abc123"}}, carriesImagesAndPDF)
 	if !errors.Is(err, model.ErrAttachmentUnsupported) {
 		t.Fatalf("a file handle must be refused as unsupported carriage, got %v", err)
 	}
@@ -161,7 +211,7 @@ func TestAnthropicRefusesAnAttachmentURIItCannotResolve(t *testing.T) {
 	}
 	if err := anthropicRefuseAttachments([]model.Attachment{
 		{MIME: "image/png", URI: "https://files.example/a.png"},
-	}, carriesImages); err != nil {
+	}, carriesImagesAndPDF); err != nil {
 		t.Errorf("an https url is fetchable and must be carried, got %v", err)
 	}
 }

--- a/backend/internal/modules/ai/attachments_test.go
+++ b/backend/internal/modules/ai/attachments_test.go
@@ -35,10 +35,10 @@ func TestEveryProviderMapsOrRejectsAttachmentsNeverSilentlyDrops(t *testing.T) {
 
 	// What each binding must REFUSE, and every binding refuses something.
 	// The two OpenAI-compatible ones declare no `input:` here, so both kinds are
-	// outside their carriage; anthropic and ollama carry images from code and
-	// still refuse the document kind neither wire can spell for a model this
-	// adapter cannot see. Accepting a MIME nothing will carry is the silent drop
-	// this test exists to prevent.
+	// outside their carriage; ollama carries images from code and still refuses
+	// the document kind its wire cannot spell at all; anthropic carries both
+	// kinds and refuses what no adapter here carries. Accepting a MIME nothing
+	// will carry is the silent drop this test exists to prevent.
 	mustRefuse := map[string]struct {
 		cfg   ProviderConfig
 		mimes []string
@@ -52,7 +52,7 @@ func TestEveryProviderMapsOrRejectsAttachmentsNeverSilentlyDrops(t *testing.T) {
 			mimes: []string{"application/pdf", "image/png"},
 		},
 		"ollama":    {cfg: ProviderConfig{Provider: "ollama", Model: "m", BaseURL: srv.URL}, mimes: []string{"application/pdf"}},
-		"anthropic": {cfg: ProviderConfig{Provider: "anthropic", Model: "m", BaseURL: srv.URL}, mimes: []string{"application/pdf"}},
+		"anthropic": {cfg: ProviderConfig{Provider: "anthropic", Model: "m", BaseURL: srv.URL}, mimes: []string{"audio/mpeg"}},
 	}
 	for name, tc := range mustRefuse {
 		for _, mime := range tc.mimes {
@@ -73,11 +73,11 @@ func TestEveryProviderMapsOrRejectsAttachmentsNeverSilentlyDrops(t *testing.T) {
 	}
 }
 
-// The carriage arm for the two wires whose image support is a property of the
-// WIRE rather than of the binding: each maps an image in its own spelling, and
+// The carriage arm for the two wires whose attachment support is a property of
+// the WIRE rather than of the binding: each maps a part in its own spelling, and
 // "accepted" is only proved by the part arriving on the wire — a call that
 // dropped it would look identical from the caller's side.
-func TestAnthropicAndOllamaCarryImagesInTheirOwnWireSpelling(t *testing.T) {
+func TestAnthropicAndOllamaCarryAttachmentsInTheirOwnWireSpelling(t *testing.T) {
 	var sent []byte
 	var readErr error
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -96,18 +96,29 @@ func TestAnthropicAndOllamaCarryImagesInTheirOwnWireSpelling(t *testing.T) {
 	png := model.Attachment{MIME: "image/png", Bytes: []byte("PNG")}
 	for name, tc := range map[string]struct {
 		cfg ProviderConfig
-		// wants is the literal fragment the mapped image must produce on that
-		// wire. Literal, because the two spellings are the point: an anthropic
+		att model.Attachment
+		// wants is the literal fragment the mapped attachment must produce on
+		// that wire. Literal, because the spellings are the point: an anthropic
 		// base64 source and an ollama bare-base64 images entry are not
 		// interchangeable, and a shared assertion would pass on either.
 		wants string
 	}{
 		"anthropic": {
 			cfg:   ProviderConfig{Provider: "anthropic", BaseURL: srv.URL, Model: "m"},
-			wants: `"source":{"type":"base64","media_type":"image/png","data":"UE5H"}`,
+			att:   png,
+			wants: `{"type":"image","source":{"type":"base64","media_type":"image/png","data":"UE5H"}}`,
+		},
+		// The same wire, the other block kind: a PDF that arrived as an image
+		// block would be refused by the vendor, so the block type is as much
+		// part of "carried" as the bytes are.
+		"anthropic/pdf": {
+			cfg:   ProviderConfig{Provider: "anthropic", BaseURL: srv.URL, Model: "m"},
+			att:   model.Attachment{MIME: "application/pdf", Bytes: []byte("%PDF")},
+			wants: `{"type":"document","source":{"type":"base64","media_type":"application/pdf","data":"JVBERg=="}}`,
 		},
 		"ollama": {
 			cfg:   ProviderConfig{Provider: "ollama", BaseURL: srv.URL, Model: "m"},
+			att:   png,
 			wants: `"images":["UE5H"]`,
 		},
 	} {
@@ -119,15 +130,15 @@ func TestAnthropicAndOllamaCarryImagesInTheirOwnWireSpelling(t *testing.T) {
 			sent, readErr = nil, nil
 			if _, err := client.Complete(context.Background(), model.Request{
 				Messages:    []model.Message{{Role: "user", Content: "read this"}},
-				Attachments: []model.Attachment{png},
+				Attachments: []model.Attachment{tc.att},
 			}); err != nil {
-				t.Fatalf("%s must carry an image, got %v", name, err)
+				t.Fatalf("%s must carry a %s, got %v", name, tc.att.MIME, err)
 			}
 			if readErr != nil {
 				t.Fatalf("reading the request body: %v", readErr)
 			}
 			if !strings.Contains(string(sent), tc.wants) {
-				t.Fatalf("the accepted image never reached the wire as %s\n got: %s", tc.wants, sent)
+				t.Fatalf("the accepted attachment never reached the wire as %s\n got: %s", tc.wants, sent)
 			}
 		})
 	}
@@ -136,18 +147,21 @@ func TestAnthropicAndOllamaCarryImagesInTheirOwnWireSpelling(t *testing.T) {
 // Caps() and the send-time gate are one answer on these two wires as well: a
 // caller picks its lane off Caps(), so a provider advertising more than its gate
 // admits sends the caller down a lane that cannot work.
-func TestAnthropicAndOllamaAdvertiseTheImagesTheyCarry(t *testing.T) {
-	for name, cfg := range map[string]ProviderConfig{
-		"anthropic": {Provider: "anthropic", Model: "m"},
-		"ollama":    {Provider: "ollama", Model: "m"},
+func TestAnthropicAndOllamaAdvertiseWhatTheyCarry(t *testing.T) {
+	for name, tc := range map[string]struct {
+		cfg  ProviderConfig
+		want []string
+	}{
+		"anthropic": {cfg: ProviderConfig{Provider: "anthropic", Model: "m"}, want: carriesImagesAndPDF},
+		"ollama":    {cfg: ProviderConfig{Provider: "ollama", Model: "m"}, want: carriesImages},
 	} {
 		t.Run(name, func(t *testing.T) {
-			client, err := SelectBrain(cfg, allCloudKeys())
+			client, err := SelectBrain(tc.cfg, allCloudKeys())
 			if err != nil {
 				t.Fatal(err)
 			}
-			if got := client.Caps().AttachmentMIMEs; !slices.Equal(got, carriesImages) {
-				t.Fatalf("Caps().AttachmentMIMEs = %v, want %v", got, carriesImages)
+			if got := client.Caps().AttachmentMIMEs; !slices.Equal(got, tc.want) {
+				t.Fatalf("Caps().AttachmentMIMEs = %v, want %v", got, tc.want)
 			}
 		})
 	}

--- a/backend/internal/modules/ai/narrowing_test.go
+++ b/backend/internal/modules/ai/narrowing_test.go
@@ -35,6 +35,17 @@ func TestADeclarationNarrowsANativeProvidersCarriage(t *testing.T) {
 			cfg:  ProviderConfig{Provider: providerGemini, Model: "m", Input: []string{"text"}},
 			want: []string{},
 		},
+		"undeclared anthropic keeps its whole wire": {
+			cfg:  ProviderConfig{Provider: providerAnthropic, Model: "m"},
+			want: carriesImagesAndPDF,
+		},
+		// The privacy narrowing this field exists for, on the tier most
+		// deployments bind: keep the model for text and images, keep scanned
+		// documents off it.
+		"anthropic narrowed to images loses the document lane": {
+			cfg:  ProviderConfig{Provider: providerAnthropic, Model: "m", Input: []string{"text", "image"}},
+			want: []string{"image/*"},
+		},
 		"anthropic narrowed to text carries nothing": {
 			cfg:  ProviderConfig{Provider: providerAnthropic, Model: "m", Input: []string{"text"}},
 			want: []string{},

--- a/backend/internal/modules/ai/openaicompat.go
+++ b/backend/internal/modules/ai/openaicompat.go
@@ -138,15 +138,16 @@ func (c *openAICompatClient) Embed(ctx context.Context, req model.EmbedRequest) 
 // site, so "this wire is text-only" reads as a decision instead of an omission.
 var carriesNothing []string
 
-// carriesImagesAndPDF is the carriage declaration shared by the two adapters
-// whose wires take document parts natively.
+// carriesImagesAndPDF is the carriage declaration shared by the adapters whose
+// wires take document parts natively.
 var carriesImagesAndPDF = []string{"image/*", "application/pdf"}
 
 // carriesImages is the declaration of an adapter whose wire takes images and
-// nothing else. Anthropic and Ollama both spell an image part uniformly — one
-// `image` block, one `images` array — while a PDF is model-dependent on the
-// first wire and absent from the second, so the honest declaration stops at
-// images rather than claiming a document lane one bound model may not serve.
+// nothing else: the Ollama chat API, which spells an image as an entry in a
+// per-message `images` array and has no document part at all. Not a narrowing
+// of carriesImagesAndPDF but a different wire — there is no document lane here
+// to give a binding, which is why `input: [text, image]` on an ollama binding
+// buys nothing and takes nothing away.
 var carriesImages = []string{"image/*"}
 
 // DocumentMIMEs is every media type some adapter in this build carries as an

--- a/backend/internal/modules/ai/selectbrain.go
+++ b/backend/internal/modules/ai/selectbrain.go
@@ -113,7 +113,7 @@ func SelectBrain(cfg ProviderConfig, keys config.Lookup) (model.Client, error) {
 			baseURL:         defaulted(cfg.BaseURL, defaultAnthropicBaseURL),
 			apiKey:          key,
 			defaultModel:    cfg.Model,
-			attachmentMIMEs: narrowedCarriage(carriesImages, cfg.Input),
+			attachmentMIMEs: narrowedCarriage(carriesImagesAndPDF, cfg.Input),
 		}, nil
 	case providerOllama:
 		return &ollamaClient{

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -870,9 +870,8 @@ each provider carries is a property of its **wire**, and is fixed in the adapter
 
 | provider | carries |
 |---|---|
-| `gemini`, `openai` | `image/*` and `application/pdf` — both wires take a document part natively |
-| `anthropic` | `image/*`. The Messages API has a document block too, but which models accept one varies per model, and this adapter cannot see which model a binding named |
-| `ollama` | `image/*`, as the chat API's per-message `images` array. A non-vision model pulled into the binding fails at the runner, visibly |
+| `anthropic`, `gemini`, `openai` | `image/*` and `application/pdf` — all three wires take a document part natively. On Anthropic that is the Messages API's `document` block, which every active model accepts and which needs no beta header |
+| `ollama` | `image/*`, as the chat API's per-message `images` array — that wire has no document part at all. A non-vision model pulled into the binding fails at the runner, visibly |
 | `openai_compatible`, `vllm` | whatever the binding declares — see `input:` below |
 | `fake` | `image/*` and `application/pdf` (the offline stub mirrors the native wires) |
 


### PR DESCRIPTION
## What was wrong

An operator who binds a tier to `anthropic` and hands it a scanned invoice gets `ErrAttachmentUnsupported`. The declaration behind that is `carriesImages` — `image/*` and nothing else — shared with `ollama`, with this rationale in `openaicompat.go`:

> a PDF is model-dependent on the first wire and absent from the second, so the honest declaration stops at images rather than claiming a document lane one bound model may not serve.

That was a fair reading of the Messages API once. It is not the wire today.

## What the wire actually is

Per [PDF support](https://platform.claude.com/docs/en/build-with-claude/pdf-support): **all active models** accept a `document` content block, sourced as inline base64 with `media_type: application/pdf` or as a URL the API fetches itself. Neither needs a beta header. (The `file_id` source does; that stays refused, unchanged — this adapter does not send the Files beta header, and `anthropicRefuseAttachments` already says so.)

So the caution was protecting nobody from anything, and cost the document lane on the tier most deployments bind.

## The change

- `anthropic` joins `gemini` and `openai` on `carriesImagesAndPDF`.
- A PDF maps to the block kind the API has — `document`, picked off the media type — not an image block wearing a different `media_type`. The vendor paginates a document and would refuse the same bytes announced as an image, so the block type is as much part of "carried" as the bytes are, and the test asserts the literal wire fragment for both kinds.
- `anthropicImageSource` → `anthropicSource`. Both block kinds spell the source identically (`base64` + `media_type` + `data`, or `url`); a twin struct would be an invariant to hold rather than one it documents.
- `ollama` keeps `carriesImages`, now for the reason that actually holds: its chat API has a per-message `images` array and no document part at all, so there is no lane there to give or take.

## What does not change

The narrowing rules. `input:` still only takes carriage away, so an operator keeping scanned documents off an egressing anthropic tier writes `input: [text, image]` exactly as before — and that case is now pinned in `narrowing_test.go` rather than left to the shared `narrowedCarriage` path. `pdf` remains a refused modality word.

## Spec

Contract-first (P3): `ai-operational-spec` §1.4 named Gemini and OpenAI as the native document wires. The spec change is **gradionhq/margince-foundation#1343** and lands first; this PR is its implementation follow-up.

## Gates

`make check-backend` green (exit 0), `craft static --strict` clean on the diff, full `go test ./...` green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allows PDFs on `anthropic` by mapping `application/pdf` to the Messages API `document` block; previously `anthropic` only carried `image/*` and returned ErrAttachmentUnsupported for PDFs. This exposes the vendor-supported document lane without changing narrowing behavior.

**Review notes**
- Capability change: `SelectBrain` now advertises `image/*` and `application/pdf` for `anthropic`; `ollama` remains `image/*` only.
- Wire mapping: choose block type by MIME (`document` for PDFs, `image` for images); both use a shared `anthropicSource` (`base64` or `url`). Tests assert literal wire fragments for both kinds.
- Gates and refusals: Files beta (`file_id`/`source.type: "file"`) stay refused; https URLs are carried; non-carried types (e.g., `audio/*`) remain refused. `ollama` has no document lane.
- Required operator action (only if you relied on default refusal): to keep PDFs off an `anthropic` tier, set `input: [text, image]`.

<sup>Written for commit 985c8e7aa635c03dc9759b62e2c96325f0e4789c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1593?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Anthropic integrations now support PDF attachments alongside images.
  - PDFs can be provided through URLs or inline content and are sent using the appropriate document format.
  - Configured input restrictions now correctly preserve or exclude PDF attachments.

- **Documentation**
  - Updated configuration guidance to show Anthropic support for image and PDF inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->