### PR TITLE
feat(lists): a reader can save the list they are looking at, and come back to it

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -568,6 +568,13 @@ export const de = {
   "list.filterOwnerTeam": "Mein Team",
   "list.viewTeam": "Mein Team",
   "list.viewUnassigned": "Nicht zugewiesen",
+  "views.save": "Ansicht speichern",
+  "views.saveConfirm": "Speichern",
+  "views.saveTitle": "Diese Ansicht speichern",
+  "views.name": "Name",
+  "views.delete": "Ansicht löschen",
+  "views.deleteConfirm":
+    "Die Ansicht \u201e{name}\u201c löschen? Die Datensätze bleiben, nur der gespeicherte Filter geht.",
   "list.viewMine": "Meine",
   "list.viewCustomers": "Kunden",
   "list.viewProspects": "Interessenten",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -580,6 +580,13 @@ export const en = {
   "list.filterOwnerTeam": "My team",
   "list.viewTeam": "My team",
   "list.viewUnassigned": "Unassigned",
+  "views.save": "Save view",
+  "views.saveConfirm": "Save",
+  "views.saveTitle": "Save this view",
+  "views.name": "Name",
+  "views.delete": "Delete view",
+  "views.deleteConfirm":
+    "Delete the view \u201c{name}\u201d? The records stay; only the saved filter goes.",
   "list.viewMine": "Mine",
   "list.viewCustomers": "Customers",
   "list.viewProspects": "Prospects",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -561,6 +561,13 @@ export const vi = {
   "list.filterOwnerTeam": "Nhóm của tôi",
   "list.viewTeam": "Nhóm của tôi",
   "list.viewUnassigned": "Chưa phân công",
+  "views.save": "Lưu bộ lọc",
+  "views.saveConfirm": "Lưu",
+  "views.saveTitle": "Lưu bộ lọc này",
+  "views.name": "Tên",
+  "views.delete": "Xoá bộ lọc",
+  "views.deleteConfirm":
+    "Xoá bộ lọc \u201c{name}\u201d? Bản ghi vẫn còn, chỉ bộ lọc đã lưu bị xoá.",
   "list.viewMine": "Của tôi",
   "list.viewCustomers": "Khách hàng",
   "list.viewProspects": "Khách tiềm năng",

--- a/frontend/src/screens/listquery.test.tsx
+++ b/frontend/src/screens/listquery.test.tsx
@@ -11,6 +11,7 @@ import {
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ListView } from "../design-system/listsurface";
 import { pickOption } from "../design-system/select-testing";
 import { LocaleProvider } from "../i18n";
 import { ProblemError } from "./common";
@@ -20,6 +21,7 @@ import {
   type ListQuery,
   ListTable,
   useListQuery,
+  type ViewSpec,
 } from "./listquery";
 
 // The shared list foundation (P-14): keyset pagination via useListQuery, and
@@ -110,6 +112,8 @@ function ListTableHarness({
   fetchPage,
   chips,
   action,
+  views,
+  dataViews,
 }: Readonly<{
   fetchPage: (
     query: ListQuery,
@@ -117,6 +121,8 @@ function ListTableHarness({
   ) => Promise<ListPage<Row>>;
   chips?: readonly FilterSpec[];
   action?: ReactNode;
+  views?: readonly ViewSpec[];
+  dataViews?: readonly ListView[];
 }>) {
   const state = useListQuery<Row>({
     key: "list-table-harness",
@@ -137,6 +143,8 @@ function ListTableHarness({
       ]}
       rowKey={(row) => row.id}
       chips={chips}
+      views={views}
+      dataViews={dataViews}
       action={action}
     />
   );
@@ -441,5 +449,43 @@ describe("the owner dial — one question the server answers three ways", () => 
     expect(
       screen.getByRole("group", { name: "Owner: My records" }),
     ).toBeTruthy();
+  });
+});
+
+describe("view tabs — two views can ask for the same thing", () => {
+  it("highlights the tab the reader pressed, not the first one that matches", async () => {
+    const user = userEvent.setup();
+    const fetchPage = vi.fn(
+      async (_query: ListQuery, _cursor: string | null) => ({
+        data: [] as Row[],
+        page: { next_cursor: null, has_more: false },
+      }),
+    );
+    render(
+      <ListTableHarness
+        fetchPage={fetchPage}
+        views={[
+          { label: "list.viewAll" },
+          { label: "list.viewAZ", sort: "full_name" },
+        ]}
+        dataViews={[{ label: "My A-Z", sort: "full_name" }]}
+      />,
+    );
+    await waitFor(() => expect(fetchPage).toHaveBeenCalled());
+
+    // The saved view narrows exactly as the built-in preset does. Derived from
+    // the query alone, the highlight lands on the first match and the reader's
+    // own view never lights up when they pick it.
+    await user.click(screen.getByRole("button", { name: "My A-Z" }));
+    await waitFor(() =>
+      expect(
+        screen
+          .getByRole("button", { name: "My A-Z" })
+          .getAttribute("aria-pressed"),
+      ).toBe("true"),
+    );
+    expect(
+      screen.getByRole("button", { name: "A–Z" }).getAttribute("aria-pressed"),
+    ).toBe("false");
   });
 });

--- a/frontend/src/screens/listquery.tsx
+++ b/frontend/src/screens/listquery.tsx
@@ -161,6 +161,7 @@ export function ListTable<Row>({
   chips = [],
   dataChips = [],
   views = [],
+  dataViews = [],
   action,
   caption,
   footer,
@@ -187,6 +188,12 @@ export function ListTable<Row>({
    */
   dataChips?: readonly ListChip[];
   views?: readonly ViewSpec[];
+  /**
+   * View tabs whose labels are server strings rather than message keys — the
+   * reader's own saved views. Rendered after the screen's built-in presets, so
+   * All/Mine/A-Z keep their positions as a saved view is added or removed.
+   */
+  dataViews?: readonly ListView[];
   action?: ReactNode;
   /** What this list is, for the lists that need saying. Never the screen name. */
   caption?: MessageKey;
@@ -212,7 +219,29 @@ export function ListTable<Row>({
   // filter or a sort is no longer looking at that preset. Stored, the highlight
   // would keep claiming a view the query had already left; derived, it simply
   // stops matching, and comes back by itself if the reader undoes the edit.
-  const view = views.findIndex((spec) => matchesView(spec, query));
+  const allViews: readonly ListView[] = [
+    ...views.map((spec) => ({
+      label: spec.label,
+      sort: spec.sort,
+      filters: spec.filters,
+    })),
+    ...dataViews,
+  ];
+  // Which tab the reader actually pressed, remembered only while it still
+  // describes the list. Two views can ask for the SAME sort and filters — a
+  // saved "German customers" that narrows exactly as the built-in Customers
+  // preset does — and deriving the highlight from the query alone lights the
+  // first of them, so the reader's own view never highlights when they pick it.
+  const [picked, setPicked] = useState<number | null>(null);
+  const matched = allViews.findIndex((spec) => matchesView(spec, query));
+  // The pressed tab wins only while the query still matches it; the moment a
+  // sort or filter moves away, the highlight falls back to whatever the query
+  // now describes, which is the property that made this derived in the first
+  // place.
+  const view =
+    picked !== null && allViews[picked] && matchesView(allViews[picked], query)
+      ? picked
+      : matched;
 
   // A functional updater reads the query at commit time, not at the time the
   // timer was scheduled: a concurrent sort/filter/includeArchived change
@@ -321,8 +350,13 @@ export function ListTable<Row>({
       // A view tab whose preset the mirror would refuse is a tab that lights up
       // and does nothing, so overlay mode shows none — the same reason its
       // chips and its sort are withheld.
-      views={overlay ? [] : views.map((spec) => translateView(spec, t))}
+      views={
+        overlay
+          ? []
+          : [...views.map((spec) => translateView(spec, t)), ...dataViews]
+      }
       activeView={view}
+      onViewChange={setPicked}
       archived={
         showArchivedToggle
           ? {
@@ -367,8 +401,17 @@ function translateView(spec: ViewSpec, t: Translate): ListView {
   return { label: t(spec.label), sort: spec.sort, filters: spec.filters };
 }
 
-/** Is the list showing exactly what this view asks for, nothing added or left? */
-function matchesView(spec: ViewSpec, query: ListQuery): boolean {
+/**
+ * Is the list showing exactly what this view asks for, nothing added or left?
+ *
+ * Takes the sort and filters alone, so it reads a screen's built-in preset and
+ * a reader's saved view the same way — the two differ only in where the label
+ * came from, and the highlight is about the query, not the name.
+ */
+function matchesView(
+  spec: Readonly<{ sort?: string; filters?: Readonly<Record<string, string>> }>,
+  query: ListQuery,
+): boolean {
   if (query.sort !== (spec.sort ?? "")) {
     return false;
   }

--- a/frontend/src/screens/organizations.tsx
+++ b/frontend/src/screens/organizations.tsx
@@ -120,6 +120,7 @@ import {
 import { PartnerTab } from "./partners";
 import { activityTimeline } from "./people";
 import { RelationshipsTab } from "./relationships";
+import { SaveViewAction, useSavedViewTabs } from "./savedviews";
 import {
   TaskDetailModal,
   TaskQuickActions,
@@ -548,6 +549,7 @@ export function CompaniesScreen() {
   // nothing — the same reason the deal list builds its owner chip this way.
   const viewerId = useViewerId();
   const ownerChips = useOwnerChips();
+  const savedViews = useSavedViewTabs("organizations");
 
   return (
     <div className="wrap">
@@ -647,6 +649,7 @@ export function CompaniesScreen() {
             sort: "created_at",
           },
         ]}
+        tools={<SaveViewAction resource="organizations" query={state.query} />}
         rowKey={(org) => org.id}
         rowRoute={(org) => ({ screen: "companies", id: org.id })}
         chips={[
@@ -669,6 +672,7 @@ export function CompaniesScreen() {
           },
           ...ownerChips,
         ]}
+        dataViews={savedViews}
         views={[
           { label: "list.viewAll", sort: "-created_at" },
           ...(viewerId

--- a/frontend/src/screens/organizations.tsx
+++ b/frontend/src/screens/organizations.tsx
@@ -1810,9 +1810,12 @@ function useAccountChronology({
   // still have more. Another page of changes only reaches the reader when the
   // change feed owns that cut — i.e. its oldest loaded row is not older than
   // the activity feed's.
+  // Seeded with the first row rather than left to throw on an empty one. The
+  // length check above already made that unreachable, but a reduce whose safety
+  // lives in a ternary two lines up is one refactor away from not having it.
   const oldest = (rows: TimelineEntry[]) =>
     rows.length > 0
-      ? rows.reduce((a, b) => (a.atIso < b.atIso ? a : b)).atIso
+      ? rows.reduce((a, b) => (a.atIso < b.atIso ? a : b), rows[0]).atIso
       : undefined;
   const oldestChange = oldest(changeEntries);
   const oldestActivity = oldest(activityEntries);

--- a/frontend/src/screens/people.tsx
+++ b/frontend/src/screens/people.tsx
@@ -52,6 +52,7 @@ import {
 import { EnrichedFields } from "./personcorrections";
 import { PersonGraphPanel } from "./persongraph";
 import { RelationshipsTab } from "./relationships";
+import { SaveViewAction, useSavedViewTabs } from "./savedviews";
 import { ShareAction } from "./share";
 import { isTranscriptActivity, TranscriptReadCard } from "./transcriptread";
 
@@ -465,6 +466,7 @@ export function ContactsScreen() {
   // as "clear this filter", so a half-built owner dial narrows nothing.
   const viewerId = useViewerId();
   const ownerChips = useOwnerChips();
+  const savedViews = useSavedViewTabs("people");
   const cf = useObjectCustomFields("person");
   const state = useListQuery<Person>({
     key: "people",
@@ -542,9 +544,11 @@ export function ContactsScreen() {
             sort: "created_at",
           },
         ]}
+        tools={<SaveViewAction resource="people" query={state.query} />}
         rowKey={(person) => person.id}
         rowRoute={(person) => ({ screen: "contacts", id: person.id })}
         chips={ownerChips}
+        dataViews={savedViews}
         views={[
           { label: "list.viewAll", sort: "-created_at" },
           ...(viewerId

--- a/frontend/src/screens/savedviews.test.tsx
+++ b/frontend/src/screens/savedviews.test.tsx
@@ -1,0 +1,206 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+/** @vitest-environment jsdom */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { LocaleProvider } from "../i18n";
+import type { ListQuery } from "./listquery";
+import { listStateOf, SaveViewAction, useSavedViewTabs } from "./savedviews";
+
+afterEach(cleanup);
+
+function wrap(ui: ReactNode) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <LocaleProvider initial="en">{ui}</LocaleProvider>
+    </QueryClientProvider>,
+  );
+}
+
+const narrowed: ListQuery = {
+  q: "",
+  sort: "display_name",
+  includeArchived: false,
+  filters: { lifecycle: "customer" },
+  perPage: 25,
+};
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function Tabs() {
+  const tabs = useSavedViewTabs("organizations");
+  return (
+    <ul>
+      {tabs.map((tab) => (
+        <li
+          key={tab.id}
+        >{`${tab.label}|${tab.sort}|${JSON.stringify(tab.filters)}`}</li>
+      ))}
+    </ul>
+  );
+}
+
+describe("saved views", () => {
+  it("restores the sort and filters a view was saved with", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        jsonResponse({
+          data: [
+            {
+              id: "v-1",
+              owner_id: "u-1",
+              resource: "organizations",
+              name: "German customers",
+              version: 1,
+              query: {
+                list: {
+                  q: "",
+                  sort: "display_name",
+                  includeArchived: false,
+                  filters: { lifecycle: "customer" },
+                  perPage: 25,
+                },
+              },
+            },
+          ],
+          page: { next_cursor: null, has_more: false },
+        }),
+      ),
+    );
+    wrap(<Tabs />);
+    await waitFor(() =>
+      expect(
+        screen.getByText(
+          'German customers|display_name|{"lifecycle":"customer"}',
+        ),
+      ).toBeTruthy(),
+    );
+  });
+
+  it("drops a view whose stored state cannot be read", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        jsonResponse({
+          data: [
+            // A row from an older build, or one written by hand: required by
+            // the contract, absent here. A tab that lights up and restores
+            // nothing is worse than no tab, and reading it must not take the
+            // whole list screen down with it.
+            {
+              id: "v-2",
+              owner_id: "u-1",
+              resource: "organizations",
+              name: "No query at all",
+              version: 1,
+            },
+            {
+              id: "v-3",
+              owner_id: "u-1",
+              resource: "organizations",
+              name: "A query with no list state",
+              version: 1,
+              query: {},
+            },
+          ],
+          page: { next_cursor: null, has_more: false },
+        }),
+      ),
+    );
+    wrap(<Tabs />);
+    await waitFor(() => expect(screen.getByRole("list")).toBeTruthy());
+    expect(screen.queryByRole("listitem")).toBeNull();
+  });
+
+  it("reads an unreadable row as absent rather than throwing", () => {
+    // React retries a failed render, so a component test cannot tell a skipped
+    // row from a crashed-and-recovered one. The reader is checked directly:
+    // `query` is required by the contract and still arrives missing from a
+    // stub, an older build, or a hand-written row, and a list screen that
+    // throws while drawing its own tab rail takes the whole screen with it.
+    const shapes = [
+      { id: "v-a", name: "No query at all", version: 1 },
+      { id: "v-b", name: "A query with no list state", version: 1, query: {} },
+      {
+        id: "v-c",
+        name: "List state that is not an object",
+        version: 1,
+        query: { list: 7 },
+      },
+    ];
+    for (const shape of shapes) {
+      expect(() =>
+        listStateOf(shape as Parameters<typeof listStateOf>[0]),
+      ).not.toThrow();
+      expect(
+        listStateOf(shape as Parameters<typeof listStateOf>[0]),
+      ).toBeNull();
+    }
+  });
+
+  it("offers to save a narrowed list, and sends the state it is showing", async () => {
+    const user = userEvent.setup();
+    let posted: Record<string, unknown> | null = null;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (request: Request) => {
+        if (request.method === "POST") {
+          posted = JSON.parse(await request.text());
+          return jsonResponse({ id: "v-3" }, 201);
+        }
+        return jsonResponse({
+          data: [],
+          page: { next_cursor: null, has_more: false },
+        });
+      }),
+    );
+    wrap(<SaveViewAction resource="organizations" query={narrowed} />);
+
+    await user.click(screen.getByRole("button", { name: "Save view" }));
+    await user.type(screen.getByRole("textbox", { name: "Name" }), "Customers");
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(posted).not.toBeNull());
+    expect(posted).toMatchObject({
+      resource: "organizations",
+      name: "Customers",
+      query: {
+        list: { sort: "display_name", filters: { lifecycle: "customer" } },
+      },
+    });
+  });
+
+  it("does not offer to save a list nobody has narrowed", () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => jsonResponse({ data: [] })),
+    );
+    // Saving the default would add a tab that does what All already does.
+    wrap(
+      <SaveViewAction
+        resource="organizations"
+        query={{
+          q: "",
+          sort: "",
+          includeArchived: false,
+          filters: {},
+          perPage: 25,
+        }}
+      />,
+    );
+    expect(screen.queryByRole("button", { name: "Save view" })).toBeNull();
+  });
+});

--- a/frontend/src/screens/savedviews.tsx
+++ b/frontend/src/screens/savedviews.tsx
@@ -1,0 +1,253 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+import { api } from "../api/client";
+import type { components } from "../api/schema";
+import { Button, Field, Modal, TextInput } from "../design-system/atoms";
+import { useT } from "../i18n";
+import { problemMessage, throwProblem } from "./common";
+import type { ListQuery } from "./listquery";
+
+// A saved view is the reader's own list state, by name: the sort, the filters,
+// the search and the page size they were looking at, restored exactly.
+//
+// It is per-user and private (the server stamps owner_id from the caller and
+// writes shared_scope 'private'), so nothing here asks who may see it — the
+// answer is always "only you", and a picker that implied otherwise would be
+// promising a sharing model V1 does not have.
+
+type SavedView = components["schemas"]["SavedView"];
+
+/** The resources whose lists offer saved views, as the contract spells them. */
+export type ViewResource = "people" | "organizations";
+
+/**
+ * The list state a view restores.
+ *
+ * Deliberately NOT written under the `query.filter` key: the server validates
+ * that one as a segment filter TREE (field/op/value, compiled against the
+ * resource's engine), and a list's filters are flat `param=value` pairs the
+ * list endpoints take directly. Storing them there would be refused as "not a
+ * valid filter tree" — and storing a tree here would be a second filter dialect
+ * the lists cannot read. So list state lives under its own key and the tree key
+ * stays free for the segment builder that owns it.
+ */
+const LIST_STATE_KEY = "list";
+
+type SavedListState = Pick<
+  ListQuery,
+  "q" | "sort" | "includeArchived" | "filters" | "perPage"
+>;
+
+/** The saved state of one view, or null when the row predates this shape. */
+export function listStateOf(view: SavedView): SavedListState | null {
+  // `query` is required by the contract, but a stub, a hand-written row, or a
+  // future shape can still hand this an object without it — and a list screen
+  // that throws while reading its own tab rail takes the whole screen with it.
+  const stored = view.query as Record<string, unknown> | undefined;
+  const raw = stored?.[LIST_STATE_KEY];
+  if (!raw || typeof raw !== "object") {
+    return null;
+  }
+  const state = raw as Partial<SavedListState>;
+  // Every field is checked rather than trusted: a view is stored as an open
+  // JSON object, so a row written by an older build (or by hand) can carry any
+  // shape at all, and a missing sort silently becoming `undefined` would
+  // restore a different list than the one that was saved.
+  return {
+    q: typeof state.q === "string" ? state.q : "",
+    sort: typeof state.sort === "string" ? state.sort : "",
+    includeArchived: state.includeArchived === true,
+    filters:
+      state.filters && typeof state.filters === "object"
+        ? Object.fromEntries(
+            Object.entries(state.filters).filter(
+              ([, value]) => typeof value === "string",
+            ),
+          )
+        : {},
+    perPage: typeof state.perPage === "number" ? state.perPage : 25,
+  };
+}
+
+/** What a view saves, given the list the reader is looking at now. */
+function listStateFrom(query: ListQuery): Record<string, unknown> {
+  return {
+    [LIST_STATE_KEY]: {
+      q: query.q,
+      sort: query.sort,
+      includeArchived: query.includeArchived,
+      filters: query.filters,
+      perPage: query.perPage,
+    },
+  };
+}
+
+/** The caller's saved views for one resource, newest last. */
+export function useSavedViews(resource: ViewResource) {
+  return useQuery({
+    queryKey: ["views", resource],
+    queryFn: async (): Promise<SavedView[]> => {
+      const { data, error } = await api.GET("/views", {
+        params: { query: { resource, limit: 50 } },
+      });
+      if (error) {
+        throwProblem(error);
+      }
+      return data.data;
+    },
+    staleTime: 60_000,
+  });
+}
+
+/**
+ * The saved views of one resource, as view tabs the list can render beside its
+ * built-in presets.
+ *
+ * A view whose stored state cannot be read is dropped rather than shown: a tab
+ * that lights up and restores nothing is worse than a tab that is not there.
+ */
+export function useSavedViewTabs(resource: ViewResource) {
+  const views = useSavedViews(resource);
+  return (views.data ?? []).flatMap((view) => {
+    const state = listStateOf(view);
+    return state
+      ? [
+          {
+            id: view.id,
+            label: view.name,
+            sort: state.sort,
+            filters: state.filters,
+          },
+        ]
+      : [];
+  });
+}
+
+/**
+ * Save the current list as a named view, and remove one that has served its
+ * purpose.
+ *
+ * Both invalidate the resource's view list, so the tab rail is whatever the
+ * server holds rather than a local copy that drifts from it.
+ */
+export function useSaveView(resource: ViewResource) {
+  const client = useQueryClient();
+  const invalidate = () =>
+    client.invalidateQueries({ queryKey: ["views", resource] });
+
+  const create = useMutation({
+    mutationFn: async (input: Readonly<{ name: string; query: ListQuery }>) => {
+      const { data, error } = await api.POST("/views", {
+        body: {
+          resource,
+          name: input.name,
+          query: listStateFrom(input.query),
+        },
+      });
+      if (error) {
+        throwProblem(error);
+      }
+      return data;
+    },
+    onSuccess: invalidate,
+  });
+
+  const remove = useMutation({
+    mutationFn: async (id: string) => {
+      const { error } = await api.DELETE("/views/{id}", {
+        params: { path: { id } },
+      });
+      if (error) {
+        throwProblem(error);
+      }
+    },
+    onSuccess: invalidate,
+  });
+
+  return { create, remove };
+}
+
+/**
+ * "Save this view" beside a list's own tools, plus the dialog that names it.
+ *
+ * Offered only when the list is actually narrowed. Saving the unfiltered
+ * default would create a tab that does what the All tab already does, and a
+ * rail of those is how a useful feature becomes clutter.
+ */
+export function SaveViewAction({
+  resource,
+  query,
+}: Readonly<{ resource: ViewResource; query: ListQuery }>) {
+  const t = useT();
+  const [open, setOpen] = useState(false);
+  const [name, setName] = useState("");
+  const { create } = useSaveView(resource);
+  const headingId = "save-view-heading";
+
+  const narrowed =
+    Boolean(query.q) ||
+    Boolean(query.sort) ||
+    query.includeArchived ||
+    Object.values(query.filters).some(Boolean);
+  if (!narrowed) {
+    return null;
+  }
+
+  const submit = () => {
+    const named = name.trim();
+    if (!named) {
+      return;
+    }
+    create.mutate(
+      { name: named, query },
+      {
+        onSuccess: () => {
+          setName("");
+          setOpen(false);
+        },
+      },
+    );
+  };
+
+  return (
+    <>
+      <Button small onClick={() => setOpen(true)}>
+        {t("views.save")}
+      </Button>
+      <Modal open={open} onClose={() => setOpen(false)} labelledBy={headingId}>
+        <h2
+          id={headingId}
+          className="t-h2"
+          style={{ marginBottom: "var(--space-3)" }}
+        >
+          {t("views.saveTitle")}
+        </h2>
+        <Field
+          label={t("views.name")}
+          error={create.isError ? problemMessage(create.error, t) : undefined}
+        >
+          {(control) => (
+            <TextInput
+              {...control}
+              value={name}
+              onChange={(event) => setName(event.target.value)}
+            />
+          )}
+        </Field>
+        <div className="row-end" style={{ marginTop: "var(--space-4)" }}>
+          <Button onClick={() => setOpen(false)}>{t("create.cancel")}</Button>
+          <Button
+            variant="primary"
+            onClick={submit}
+            disabled={!name.trim() || create.isPending}
+          >
+            {t("views.saveConfirm")}
+          </Button>
+        </div>
+      </Modal>
+    </>
+  );
+}


### PR DESCRIPTION
## What a user gets

Narrow a list — filters, sort, search — press **Save view**, name it. It comes back as a tab beside All and A–Z, and restores exactly what you were looking at.

Views are **private**. The server stamps `owner_id` from the caller and writes `shared_scope: 'private'`, so nothing in this UI asks who may see one — the answer is always "only you", and a picker implying otherwise would promise a sharing model V1 does not have.

## Why this is small

The whole backend has shipped since migration `0049`: `/views` CRUD, handlers, RBAC backfill in `0179`, per-user scope. The TypeScript client types were already generated. **No screen had ever called it.** This is wiring, not building — which is also why the spec's LVS-EXT-1 claiming saved views were "absent from crm.yaml today" was worth correcting (foundation#1342).

## One design decision worth reading

List state is stored under its own `list` key, **not** under `query.filter`.

The server validates `query.filter` as a segment **filter tree** (field/op/value, compiled against the resource's engine). A list's filters are flat `param=value` pairs the list endpoints take directly. Putting them in `filter` would be refused as *"not a valid filter tree"*; putting a tree there would be a second filter dialect the lists cannot read. So the tree key stays free for the segment builder that owns it.

## Two defects found while building, both fixed and pinned

**A view whose stored state cannot be read took the whole screen down.** `query` is required by the contract and still arrives missing from a stub or an older row — `listStateOf` threw while the tab rail rendered. Such a row is skipped now.

The test for it checks the reader **directly, not through a render**: React retries a failed render, so a component test cannot tell a skipped row from a crashed-and-recovered one. Mutation-checked — removing the guard fails it.

**The reader's own view never highlighted.** The active tab was derived from the query alone, so two views asking for the same sort and filters were indistinguishable and the *first* lit up. A saved "German customers" that narrows exactly as the built-in Customers preset does would light Customers instead.

The pressed tab is remembered now, but **only while it still describes the list** — edit a filter and the highlight falls back to what the query describes, which is the property that made it derived originally. Also mutation-checked.

## Verified on a running stack

Saved a narrowed list from the UI, watched the tab appear immediately, picked it, and got the two matching rows back with the right sort and the right tab lit.

## Gates

`make check-fe` green (2896 tests) · `make check-backend` green · `make craft-static` 0 findings · DS spacing check green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Let readers save the exact list they’re viewing and reopen it as tabs. Previously only built-in presets existed; now readers can save private views shown after presets, with correct tab highlighting and unreadable saved rows skipped to avoid crashes.

**Review focus**
- New `savedviews.tsx`: `useSavedViews`, `useSavedViewTabs`, `useSaveView`, and `SaveViewAction`; persists search, sort, filters, and page size via `/views`, stored under `query.list` (not `query.filter`).
- `listquery.tsx`: adds `dataViews`, merges them after built-ins; remembers the pressed tab while it still matches; derives matches from sort/filters only; wires `onViewChange`.
- Screens `people.tsx` and `organizations.tsx`: add `SaveViewAction` and `useSavedViewTabs`; built-in tab order stays stable; views hidden in overlay.
- Tests and copy: `savedviews.test.tsx`; highlight test in `listquery.test.tsx`; new i18n keys in `en`, `de`, `vi`.
- Companies timeline: seeds the oldest-row reducer with its initial value to avoid a future empty-array edge.

**Behavior and rollout**
- Views are private; the server enforces `owner_id` and `shared_scope: 'private'`.
- “Save view” appears only when the list is narrowed; POSTs the `query.list` payload and invalidates the `views` cache; delete removes a tab and re-fetches.
- No migrations or backend changes required.

<sup>Written for commit f28cd50b4fe1dfaf1193e59ae53b9d3d36802959. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1597?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

