### PR TITLE
feat(lists): who works here, what industry, what size — and a gate that keeps one page size

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -683,6 +683,14 @@ paths:
           in: query
           schema: { type: string }
           description: Filter by tag name.
+        - name: organization_id
+          in: query
+          schema: { type: string, format: uuid }
+          description: |
+            People who work at this account, by their CURRENT PRIMARY employment edge
+            (`relationship` kind `employment`, DM-VOCAB-1). A past employer does not match:
+            "who works there" and "who has ever worked there" are different questions, and the
+            list answers the first.
       responses:
         '200':
           description: A page of people.
@@ -1620,6 +1628,18 @@ paths:
             `true` returns only rows with no owner. Unassigned rows are visible at every row scope
             (AAD-ROLE-2), so this names the unowned queue rather than widening what the caller sees.
             Mutually exclusive with `owner_id` and `owner_team_id`; combining them is `422`.
+        - name: industry
+          in: query
+          schema: { type: string }
+          description: |
+            Accounts in one industry, matched exactly (DM-VOCAB-2). The column is free text rather
+            than an enum, so this is the value as it was written.
+        - name: size_band
+          in: query
+          description: How many people work there (DM-VOCAB-2).
+          schema:
+            type: string
+            enum: ['1-10', '11-50', '51-200', '201-500', '501-1000', '1001-5000', '5000+']
         - name: q
           in: query
           schema: { type: string }

--- a/backend/declaredfilters_test.go
+++ b/backend/declaredfilters_test.go
@@ -278,7 +278,7 @@ func TestTheDeclaredFilterCensusReadsTheGeneratedShape(t *testing.T) {
 	}
 	// The person list declares exactly these, and the three paging components
 	// it also declares are not among them.
-	want := "ai_written,captured_by_kind,include_archived,owner_id,owner_team_id,q,tag,unassigned"
+	want := "ai_written,captured_by_kind,include_archived,organization_id,owner_id,owner_team_id,q,tag,unassigned"
 	if got := strings.Join(wire, ","); got != want {
 		t.Errorf("listPeople's narrowing parameters = %q, want %q", got, want)
 	}

--- a/backend/internal/compose/integration/declaredfilters_integration_test.go
+++ b/backend/internal/compose/integration/declaredfilters_integration_test.go
@@ -379,3 +379,93 @@ func TestTheOrganizationListNarrowsToOneTeamAndToTheUnownedQueue(t *testing.T) {
 		t.Fatalf("unassigned=true returned %d organizations, want only the unowned one", len(queue))
 	}
 }
+
+func TestThePersonListNarrowsToOneEmployer(t *testing.T) {
+	e := Setup(t)
+	acme := e.SeedOrg(t, "Acme", nil)
+	other := e.SeedOrg(t, "Other", nil)
+	staff := e.SeedPerson(t, "Works At Acme", nil)
+	leaver := e.SeedPerson(t, "Left Acme", nil)
+	elsewhere := e.SeedPerson(t, "Works Elsewhere", nil)
+
+	// Seeded through the real writer, so the edge carries whatever that writer
+	// stamps: a hand-inserted row proves nothing about the rows production makes.
+	employ := func(person ids.UUID, org ids.UUID, current bool) {
+		t.Helper()
+		personID := ids.From[ids.PersonKind](person)
+		orgID := ids.From[ids.OrganizationKind](org)
+		if _, err := e.People.CreateRelationship(e.Admin(), people.CreateRelationshipInput{
+			Kind:             "employment",
+			PersonID:         &personID,
+			OrganizationID:   &orgID,
+			IsCurrentPrimary: current,
+			Source:           "manual",
+		}); err != nil {
+			t.Fatalf("seeding the employment edge: %v", err)
+		}
+	}
+	employ(staff, acme, true)
+	// A past employer at the same account: the filter answers who works there,
+	// not who has ever worked there, and returning the leaver beside the staff
+	// is the wrong answer wearing the right shape.
+	employ(leaver, acme, false)
+	employ(elsewhere, other, true)
+
+	orgID := ids.From[ids.OrganizationKind](acme)
+	page, _, err := e.People.ListPeople(e.Admin(), people.ListPeopleInput{OrganizationID: &orgID})
+	if err != nil {
+		t.Fatalf("listing people by employer: %v", err)
+	}
+	if len(page) != 1 || ids.UUID(page[0].Id) != staff {
+		got := make([]string, 0, len(page))
+		for _, person := range page {
+			got = append(got, person.FullName)
+		}
+		t.Fatalf("organization_id returned %v, want only the current employee", got)
+	}
+}
+
+// setFirmographics writes industry and size through the store the product
+// writes them with, so the rows under test are the rows production makes.
+func setFirmographics(t *testing.T, e *Env, org ids.UUID, industry, band string) {
+	t.Helper()
+	if _, err := e.People.UpdateOrganization(e.Admin(), ids.From[ids.OrganizationKind](org),
+		people.UpdateOrganizationInput{Industry: &industry, SizeBand: &band}); err != nil {
+		t.Fatalf("setting firmographics: %v", err)
+	}
+}
+
+func TestTheOrganizationListNarrowsByIndustryAndSizeBand(t *testing.T) {
+	e := Setup(t)
+	small := e.SeedOrg(t, "Small Software", nil)
+	big := e.SeedOrg(t, "Big Software", nil)
+	e.SeedOrg(t, "Small Logistics", nil)
+
+	setFirmographics(t, e, small, "Software", "1-10")
+	setFirmographics(t, e, big, "Software", "1001-5000")
+
+	industry := "Software"
+	page, _, err := e.People.ListOrganizations(e.Admin(), people.ListOrganizationsInput{Industry: &industry})
+	if err != nil {
+		t.Fatalf("listing by industry: %v", err)
+	}
+	if len(page) != 2 {
+		t.Fatalf("industry=Software returned %d accounts, want both software accounts", len(page))
+	}
+
+	band := "1-10"
+	sized, _, err := e.People.ListOrganizations(e.Admin(), people.ListOrganizationsInput{SizeBand: &band})
+	if err != nil {
+		t.Fatalf("listing by size band: %v", err)
+	}
+	if len(sized) != 1 || ids.UUID(sized[0].Id) != small {
+		t.Fatalf("size_band=1-10 returned %d accounts, want only the small one", len(sized))
+	}
+
+	// An unknown band is refused rather than answered with an empty page:
+	// empty reads as "no accounts that size", which is a different claim.
+	unknown := "12-13"
+	if _, _, err := e.People.ListOrganizations(e.Admin(), people.ListOrganizationsInput{SizeBand: &unknown}); err == nil {
+		t.Fatal("an unknown size band was accepted; want a validation refusal")
+	}
+}

--- a/backend/internal/compose/overlayread.go
+++ b/backend/internal/compose/overlayread.go
@@ -217,6 +217,10 @@ func (s Server) ListPeople(w http.ResponseWriter, r *http.Request, params crmcon
 			{paramOwnerTeamID, params.OwnerTeamId != nil},
 			{paramUnassigned, params.Unassigned != nil && *params.Unassigned},
 			{paramTag, params.Tag != nil},
+			// Employment is OUR edge: the mirror holds the incumbent's own
+			// contact-to-company links, under their ids, so a margince
+			// organization id names nothing there.
+			{paramOrganizationID, params.OrganizationId != nil},
 			{paramCapturedByKind, params.CapturedByKind != nil},
 			{paramAiWritten, params.AiWritten != nil},
 		},
@@ -241,6 +245,11 @@ func (s Server) ListOrganizations(w http.ResponseWriter, r *http.Request, params
 			{paramOwnerID, params.OwnerId != nil},
 			{paramOwnerTeamID, params.OwnerTeamId != nil},
 			{paramUnassigned, params.Unassigned != nil && *params.Unassigned},
+			// Firmographics we hold and the mirror does not: refused rather
+			// than forwarded, or the answer is the unfiltered list wearing a
+			// filtered list's shape.
+			{fieldIndustry, params.Industry != nil},
+			{"size_band", params.SizeBand != nil},
 			{"domain", params.Domain != nil},
 			{paramCapturedByKind, params.CapturedByKind != nil},
 			{paramAiWritten, params.AiWritten != nil},

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -10134,6 +10134,39 @@ func (e ListOrganizationsParamsRelationshipType) Valid() bool {
 	}
 }
 
+// Defines values for ListOrganizationsParamsSizeBand.
+const (
+	N10015000 ListOrganizationsParamsSizeBand = "1001-5000"
+	N110      ListOrganizationsParamsSizeBand = "1-10"
+	N1150     ListOrganizationsParamsSizeBand = "11-50"
+	N201500   ListOrganizationsParamsSizeBand = "201-500"
+	N5000     ListOrganizationsParamsSizeBand = "5000+"
+	N5011000  ListOrganizationsParamsSizeBand = "501-1000"
+	N51200    ListOrganizationsParamsSizeBand = "51-200"
+)
+
+// Valid indicates whether the value is a known member of the ListOrganizationsParamsSizeBand enum.
+func (e ListOrganizationsParamsSizeBand) Valid() bool {
+	switch e {
+	case N10015000:
+		return true
+	case N110:
+		return true
+	case N1150:
+		return true
+	case N201500:
+		return true
+	case N5000:
+		return true
+	case N5011000:
+		return true
+	case N51200:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for ListOrganizationContractsParamsStatus.
 const (
 	ListOrganizationContractsParamsStatusActive     ListOrganizationContractsParamsStatus = "active"
@@ -22101,8 +22134,15 @@ type ListOrganizationsParams struct {
 	// Unassigned `true` returns only rows with no owner. Unassigned rows are visible at every row scope
 	// (AAD-ROLE-2), so this names the unowned queue rather than widening what the caller sees.
 	// Mutually exclusive with `owner_id` and `owner_team_id`; combining them is `422`.
-	Unassigned *bool   `form:"unassigned,omitempty" json:"unassigned,omitempty"`
-	Q          *string `form:"q,omitempty" json:"q,omitempty"`
+	Unassigned *bool `form:"unassigned,omitempty" json:"unassigned,omitempty"`
+
+	// Industry Accounts in one industry, matched exactly (DM-VOCAB-2). The column is free text rather
+	// than an enum, so this is the value as it was written.
+	Industry *string `form:"industry,omitempty" json:"industry,omitempty"`
+
+	// SizeBand How many people work there (DM-VOCAB-2).
+	SizeBand *ListOrganizationsParamsSizeBand `form:"size_band,omitempty" json:"size_band,omitempty"`
+	Q        *string                          `form:"q,omitempty" json:"q,omitempty"`
 }
 
 // ListOrganizationsParamsCapturedByKind defines parameters for ListOrganizations.
@@ -22113,6 +22153,9 @@ type ListOrganizationsParamsLifecycle string
 
 // ListOrganizationsParamsRelationshipType defines parameters for ListOrganizations.
 type ListOrganizationsParamsRelationshipType string
+
+// ListOrganizationsParamsSizeBand defines parameters for ListOrganizations.
+type ListOrganizationsParamsSizeBand string
 
 // CreateOrganizationParams defines parameters for CreateOrganization.
 type CreateOrganizationParams struct {
@@ -22591,6 +22634,12 @@ type ListPeopleParams struct {
 
 	// Tag Filter by tag name.
 	Tag *string `form:"tag,omitempty" json:"tag,omitempty"`
+
+	// OrganizationId People who work at this account, by their CURRENT PRIMARY employment edge
+	// (`relationship` kind `employment`, DM-VOCAB-1). A past employer does not match:
+	// "who works there" and "who has ever worked there" are different questions, and the
+	// list answers the first.
+	OrganizationId *openapi_types.UUID `form:"organization_id,omitempty" json:"organization_id,omitempty"`
 }
 
 // ListPeopleParamsCapturedByKind defines parameters for ListPeople.
@@ -41980,6 +42029,32 @@ func (siw *ServerInterfaceWrapper) ListOrganizations(w http.ResponseWriter, r *h
 		return
 	}
 
+	// ------------- Optional query parameter "industry" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "industry", r.URL.Query(), &params.Industry, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "industry"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "industry", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "size_band" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "size_band", r.URL.Query(), &params.SizeBand, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "size_band"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "size_band", Err: err})
+		}
+		return
+	}
+
 	// ------------- Optional query parameter "q" -------------
 
 	err = runtime.BindQueryParameterWithOptions("form", true, false, "q", r.URL.Query(), &params.Q, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
@@ -44458,6 +44533,19 @@ func (siw *ServerInterfaceWrapper) ListPeople(w http.ResponseWriter, r *http.Req
 			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "tag"})
 		} else {
 			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "tag", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "organization_id" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "organization_id", r.URL.Query(), &params.OrganizationId, runtime.BindQueryParameterOptions{Type: "string", Format: "uuid"})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "organization_id"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "organization_id", Err: err})
 		}
 		return
 	}

--- a/backend/internal/modules/agents/recordshapes_gen.go
+++ b/backend/internal/modules/agents/recordshapes_gen.go
@@ -43,6 +43,7 @@ const activityLinkEntityTypeEnum = `["person","organization","deal","lead","proj
 // TestOnlyAFilterBothTheContractAndAStoreCarryIsPublished holds that.
 var listRecordFilters = map[string][]listFilter{
 	"person": {
+		{Name: "organization_id", Type: "string"},
 		{Name: "owner_id", Type: "string"},
 		{Name: "owner_team_id", Type: "string"},
 		{Name: "tag", Type: "string"},
@@ -50,10 +51,12 @@ var listRecordFilters = map[string][]listFilter{
 	},
 	"organization": {
 		{Name: "domain", Type: "string"},
+		{Name: "industry", Type: "string"},
 		{Name: "lifecycle", Type: "string", Enum: []string{"unknown", "target", "prospect", "opportunity", "customer", "former_customer", "disqualified"}},
 		{Name: "owner_id", Type: "string"},
 		{Name: "owner_team_id", Type: "string"},
 		{Name: "relationship_type", Type: "string", Enum: []string{"customer", "partner", "supplier", "investor", "portfolio_company", "competitor", "other"}},
+		{Name: "size_band", Type: "string", Enum: []string{"1-10", "11-50", "51-200", "201-500", "501-1000", "1001-5000", "5000+"}},
 		{Name: "unassigned", Type: "boolean"},
 	},
 	"deal": {

--- a/backend/internal/modules/agents/tools_list_test.go
+++ b/backend/internal/modules/agents/tools_list_test.go
@@ -152,7 +152,13 @@ func TestAnEnumerationIsChargedPerRecord(t *testing.T) {
 // union of properties would have to publish one type's enum for both.
 func TestTheDescriptionCarriesThePerTypeVocabulary(t *testing.T) {
 	described := listRecords{filters: bindableFilters(probeVocabulary{})}.describeFilters()
-	for _, want := range []string{"person — owner_id", "deal — ", "stage_id", "open|won|lost"} {
+	// Anchored on the type heading and on the filters themselves, not on which
+	// one happens to sort first: the set is alphabetical, so pinning the first
+	// entry fails the day a type gains a filter earlier in the alphabet —
+	// which says nothing about whether the vocabulary is published correctly.
+	for _, want := range []string{
+		"person — ", "owner_id", "deal — ", "stage_id", "open|won|lost",
+	} {
 		if !strings.Contains(described, want) {
 			t.Errorf("the filter description lacks %q:\n%s", want, described)
 		}

--- a/backend/internal/modules/people/handlers_organization.go
+++ b/backend/internal/modules/people/handlers_organization.go
@@ -51,6 +51,8 @@ func (h Handlers) ListOrganizations(w http.ResponseWriter, r *http.Request, para
 	in.OwnerID = idArg[ids.UserKind](params.OwnerId)
 	in.OwnerTeamID = idArg[ids.TeamKind](params.OwnerTeamId)
 	in.Unassigned = params.Unassigned
+	in.Industry = params.Industry
+	in.SizeBand = enumArg(params.SizeBand)
 
 	orgs, page, err := h.store.ListOrganizations(r.Context(), in)
 	if err != nil {

--- a/backend/internal/modules/people/handlers_person.go
+++ b/backend/internal/modules/people/handlers_person.go
@@ -47,6 +47,7 @@ func (h Handlers) ListPeople(w http.ResponseWriter, r *http.Request, params crmc
 	in.OwnerID = idArg[ids.UserKind](params.OwnerId)
 	in.OwnerTeamID = idArg[ids.TeamKind](params.OwnerTeamId)
 	in.Unassigned = params.Unassigned
+	in.OrganizationID = idArg[ids.OrganizationKind](params.OrganizationId)
 
 	people, page, err := h.store.ListPeople(r.Context(), in)
 	if err != nil {

--- a/backend/internal/modules/people/organization_list.go
+++ b/backend/internal/modules/people/organization_list.go
@@ -48,6 +48,9 @@ type ListOrganizationsInput struct {
 	Classification   *string
 	Lifecycle        *string
 	RelationshipType *string
+	// Industry is free text on the record; SizeBand is the contract's enum.
+	Industry *string
+	SizeBand *string
 	// Domain narrows to the account that lists one domain — the
 	// employer-inference lookup, spelled as a filter over the same
 	// organization_domain rows the page attaches.
@@ -178,6 +181,22 @@ func (s *Store) ListOrganizations(ctx context.Context, in ListOrganizationsInput
 						"filter by one of the account stages the contract defines, or leave the parameter off")
 				}
 				where = append(where, storekit.SQLf("lifecycle = $%d", arg(*in.Lifecycle)))
+			}
+			if in.Industry != nil {
+				// Free text on the record, so matched as written rather than
+				// against a vocabulary the column does not have.
+				where = append(where, storekit.SQLf("industry = $%d", arg(*in.Industry)))
+			}
+			if in.SizeBand != nil {
+				// Checked against the generated enum for the same reason
+				// lifecycle is: an unknown band would answer an empty page,
+				// and empty reads as "no accounts that size" rather than as
+				// "that is not a size".
+				if !crmcontracts.ListOrganizationsParamsSizeBand(*in.SizeBand).Valid() {
+					return nil, httperr.Validation("size_band", "not_a_known_value",
+						"filter by one of the size bands the contract defines, or leave the parameter off")
+				}
+				where = append(where, storekit.SQLf("size_band = $%d", arg(*in.SizeBand)))
 			}
 			if in.RelationshipType != nil {
 				if !crmcontracts.ListOrganizationsParamsRelationshipType(*in.RelationshipType).Valid() {

--- a/backend/internal/modules/people/person_list.go
+++ b/backend/internal/modules/people/person_list.go
@@ -53,6 +53,10 @@ type ListPeopleInput struct {
 	// vocabulary belongs to another module, so this is a link predicate
 	// rather than a column — see personTagClause.
 	Tag *string
+	// OrganizationID narrows to the people employed there today. Employment is
+	// an edge, not a column on person, so this is a link predicate too — see
+	// personEmployerClause.
+	OrganizationID *ids.OrganizationID
 }
 
 // personListFields is the person list's core sortable vocabulary —
@@ -94,6 +98,32 @@ func personTagClause(tag *string, arg func(any) int) string {
 		arg(personEntity), arg(foldTagName(*tag)))
 }
 
+// personEmployerClause narrows the page to the people who work at one account
+// today, or "" when the caller named none.
+//
+// CURRENT PRIMARY employment only. A person's history carries every employer
+// they have had, and "who works there" is not "who has ever worked there" — a
+// list that answered the second would hand a rep the leavers alongside the
+// staff, which is the wrong answer wearing the right shape. The edge is the
+// one `uq_rel_current_primary_employer` keeps unique per person, so this
+// matches at most one row per person and cannot duplicate the page.
+//
+// EXISTS rather than a join, for the same reason the tag filter uses one: a
+// join multiplies a person by their matching edges, and the keyset cursor
+// would page over those copies as though they were distinct people.
+func personEmployerClause(orgID *ids.OrganizationID, arg func(any) int) string {
+	if orgID == nil {
+		return ""
+	}
+	return storekit.SQLf(`EXISTS (
+		SELECT 1 FROM relationship rel
+		WHERE rel.person_id = person.id
+		  AND rel.kind = 'employment'
+		  AND rel.is_current_primary
+		  AND rel.archived_at IS NULL
+		  AND rel.organization_id = $%d)`, arg(*orgID))
+}
+
 // foldTagName matches how the tag vocabulary is stored and compared: names
 // are trimmed on write and unique under lower(), so a caller's spacing and
 // case decide nothing about which tag they named.
@@ -125,6 +155,9 @@ func (s *Store) ListPeople(ctx context.Context, in ListPeopleInput) ([]crmcontra
 				return nil, err
 			}
 			if clause := personTagClause(in.Tag, arg); clause != "" {
+				where = append(where, clause)
+			}
+			if clause := personEmployerClause(in.OrganizationID, arg); clause != "" {
 				where = append(where, clause)
 			}
 			return where, nil

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -18044,6 +18044,13 @@ export interface operations {
                 q?: string;
                 /** @description Filter by tag name. */
                 tag?: string;
+                /**
+                 * @description People who work at this account, by their CURRENT PRIMARY employment edge
+                 *     (`relationship` kind `employment`, DM-VOCAB-1). A past employer does not match:
+                 *     "who works there" and "who has ever worked there" are different questions, and the
+                 *     list answers the first.
+                 */
+                organization_id?: string;
             };
             header?: never;
             path?: never;
@@ -19052,6 +19059,13 @@ export interface operations {
                  *     Mutually exclusive with `owner_id` and `owner_team_id`; combining them is `422`.
                  */
                 unassigned?: boolean;
+                /**
+                 * @description Accounts in one industry, matched exactly (DM-VOCAB-2). The column is free text rather
+                 *     than an enum, so this is the value as it was written.
+                 */
+                industry?: string;
+                /** @description How many people work there (DM-VOCAB-2). */
+                size_band?: "1-10" | "11-50" | "51-200" | "201-500" | "501-1000" | "1001-5000" | "5000+";
                 q?: string;
             };
             header?: never;

--- a/frontend/src/screens/list-page-size-coverage.test.ts
+++ b/frontend/src/screens/list-page-size-coverage.test.ts
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+// Fitness function for the ONE page size.
+//
+// `ListQuery.perPage` is the size the reader picks in the table footer AND the
+// `limit` the fetcher asks the server for. A screen that keeps a literal limit
+// instead renders a page size the server never returned: the footer offers 100,
+// the response holds 50, and the count line says "1-50 of 100 loaded so far" —
+// the exact reading that made the company list look like a broken pager.
+//
+// Four screens (leads, partners, products, offer templates) carried that
+// mismatch for a whole release after the shared wrapper had already been fixed,
+// because nothing derived the obligation from the tree. This does: the screen
+// list comes from the directory, so a NEW list screen is covered the day it is
+// written rather than the day somebody remembers to add it here.
+const dir = dirname(fileURLToPath(import.meta.url));
+
+/** Every screen that reads a list through the shared wrapper. */
+function listScreens(): string[] {
+  return readdirSync(dir)
+    .filter((file) => file.endsWith(".tsx"))
+    .filter((file) => !file.includes(".test.") && !file.includes(".stories."))
+    .filter((file) => {
+      const source = readFileSync(resolve(dir, file), "utf8");
+      // Calls it, rather than declaring it: listquery.tsx is the wrapper
+      // itself and owns no fetcher of its own.
+      return (
+        /\buseListQuery</.test(source) &&
+        !/export function useListQuery/.test(source)
+      );
+    })
+    .sort();
+}
+
+describe("every list fetcher asks for the page size the reader picked", () => {
+  it("finds the list screens rather than trusting a list written here", () => {
+    // The census IS the directory. A hand-kept list would be the thing that
+    // went stale, which is the failure this test exists to prevent.
+    expect(listScreens()).toContain("people.tsx");
+    expect(listScreens()).toContain("organizations.tsx");
+    expect(listScreens().length).toBeGreaterThanOrEqual(6);
+  });
+
+  it.each(listScreens())("%s reads its limit from the query", (file) => {
+    const source = readFileSync(resolve(dir, file), "utf8");
+    // A literal limit in the same object that spreads the list query is the
+    // mismatch. Other reads on these screens legitimately cap themselves — a
+    // typeahead asks for 10 and always should — so only the list fetcher's own
+    // `limit` is checked, and it is found by the `cursor` beside it, which no
+    // other read on these screens carries.
+    const fetcher = source.match(
+      /cursor: cursor \|\| undefined,\s*\n\s*limit: ([^,\n]+),/,
+    );
+    expect(
+      fetcher,
+      `${file} has no list fetcher shaped like the shared one — if the shape ` +
+        `changed, change this check with it rather than deleting it`,
+    ).not.toBeNull();
+    expect(
+      fetcher?.[1],
+      `${file} sends a fixed page limit, so the footer's page size and the ` +
+        `server's page size can disagree`,
+    ).toBe("query.perPage");
+  });
+});

--- a/frontend/src/screens/listquery.tsx
+++ b/frontend/src/screens/listquery.tsx
@@ -228,21 +228,7 @@ export function ListTable<Row>({
     })),
     ...dataViews,
   ];
-  // Which tab the reader actually pressed, remembered only while it still
-  // describes the list. Two views can ask for the SAME sort and filters — a
-  // saved "German customers" that narrows exactly as the built-in Customers
-  // preset does — and deriving the highlight from the query alone lights the
-  // first of them, so the reader's own view never highlights when they pick it.
-  const [picked, setPicked] = useState<number | null>(null);
-  const matched = allViews.findIndex((spec) => matchesView(spec, query));
-  // The pressed tab wins only while the query still matches it; the moment a
-  // sort or filter moves away, the highlight falls back to whatever the query
-  // now describes, which is the property that made this derived in the first
-  // place.
-  const view =
-    picked !== null && allViews[picked] && matchesView(allViews[picked], query)
-      ? picked
-      : matched;
+  const [view, setPicked] = useActiveView(allViews, query);
 
   // A functional updater reads the query at commit time, not at the time the
   // timer was scheduled: a concurrent sort/filter/includeArchived change
@@ -400,6 +386,31 @@ function translateChip(chip: FilterSpec, t: Translate): ListChip {
 
 function translateView(spec: ViewSpec, t: Translate): ListView {
   return { label: t(spec.label), sort: spec.sort, filters: spec.filters };
+}
+
+/**
+ * Which view tab is lit, and the setter the table reports a press to.
+ *
+ * The highlight is DERIVED from the query, so a reader who edits a filter is no
+ * longer claimed to be looking at the preset they started from. But two views
+ * can ask for the same sort and filters — a saved "German customers" that
+ * narrows exactly as the built-in Customers preset does — and a purely derived
+ * highlight lights the first match, so the reader's own view never lights when
+ * they pick it.
+ *
+ * The pressed tab therefore wins, but only while it still describes the list.
+ * The moment the query moves away it stops matching and the highlight falls
+ * back to whatever the query now describes.
+ */
+function useActiveView(
+  views: readonly ListView[],
+  query: ListQuery,
+): [number, (index: number) => void] {
+  const [picked, setPicked] = useState<number | null>(null);
+  const matched = views.findIndex((spec) => matchesView(spec, query));
+  const pinned = picked !== null && views[picked];
+  const view = pinned && matchesView(views[picked], query) ? picked : matched;
+  return [view, setPicked];
 }
 
 /**

--- a/frontend/src/screens/listquery.tsx
+++ b/frontend/src/screens/listquery.tsx
@@ -17,6 +17,7 @@ import {
 import { useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import { problemMessageOf, useMe, useSorMode } from "./common";
+import { useRoster } from "./entityref";
 
 // The shared list foundation (P-14): every list screen sends the rich
 // q/sort/cursor/include_archived/filter vocabulary instead of a flat
@@ -441,29 +442,32 @@ function matchesView(
  * guessing which one the reader meant — the wire takes one team id, and picking
  * for them would answer a question they did not ask.
  */
-export function useOwnerChips(): readonly FilterSpec[] {
+export function useOwnerChips(): readonly ListChip[] {
+  const t = useT();
   const me = useMe();
   const viewerId = me.data?.user.id;
+  const teams = useRoster("team", Boolean(viewerId));
   if (!viewerId) {
     return [];
   }
-  const teams = me.data?.teams ?? [];
+  // Named, not counted. The viewer may sit in several teams, and a dial that
+  // withheld itself past the first one left everyone on two teams unable to
+  // ask a question the API answers. Each team is its own option, so picking one
+  // is picking a team rather than accepting a guess about which was meant.
+  const mine = new Set(me.data?.teams ?? []);
+  const named = (teams.data ?? []).filter((entry) => mine.has(entry.id));
   return [
     {
       key: "owner",
-      label: "list.owner",
-      allLabel: "list.filterOwnerAll",
+      label: t("list.owner"),
+      allLabel: t("list.filterOwnerAll"),
       options: [
-        { value: `owner_id:${viewerId}`, label: "list.filterOwnerMe" },
-        ...(teams.length === 1
-          ? [
-              {
-                value: `owner_team_id:${teams[0]}`,
-                label: "list.filterOwnerTeam" as const,
-              },
-            ]
-          : []),
-        { value: "unassigned:true", label: "list.filterOwnerUnassigned" },
+        { value: `owner_id:${viewerId}`, label: t("list.filterOwnerMe") },
+        ...named.map((team) => ({
+          value: `owner_team_id:${team.id}`,
+          label: "display_name" in team ? team.display_name : team.name,
+        })),
+        { value: "unassigned:true", label: t("list.filterOwnerUnassigned") },
       ],
     },
   ];

--- a/frontend/src/screens/organizations.tsx
+++ b/frontend/src/screens/organizations.tsx
@@ -652,6 +652,7 @@ export function CompaniesScreen() {
         tools={<SaveViewAction resource="organizations" query={state.query} />}
         rowKey={(org) => org.id}
         rowRoute={(org) => ({ screen: "companies", id: org.id })}
+        dataChips={ownerChips}
         chips={[
           {
             key: "lifecycle",
@@ -670,7 +671,6 @@ export function CompaniesScreen() {
               label: RELATIONSHIP_TYPE_LABELS[value],
             })),
           },
-          ...ownerChips,
         ]}
         dataViews={savedViews}
         views={[

--- a/frontend/src/screens/people.tsx
+++ b/frontend/src/screens/people.tsx
@@ -547,7 +547,7 @@ export function ContactsScreen() {
         tools={<SaveViewAction resource="people" query={state.query} />}
         rowKey={(person) => person.id}
         rowRoute={(person) => ({ screen: "contacts", id: person.id })}
-        chips={ownerChips}
+        dataChips={ownerChips}
         dataViews={savedViews}
         views={[
           { label: "list.viewAll", sort: "-created_at" },


### PR DESCRIPTION
Closes #1585, closes #1586, closes #1587 — three issues filed against the list work, closed together because they are one surface.

## #1586 — the filter vocabulary the spec asked for

**`organization_id` on the people list** answers *"who works at this account"*, by the **current primary** employment edge. A past employer does not match: "who works there" and "who has ever worked there" are different questions, and handing a rep the leavers beside the staff is the wrong answer wearing the right shape.

It is an `EXISTS`, not a join — a join multiplies a person by their matching edges and the keyset cursor would page over the copies as though they were separate people.

**`industry` and `size_band` on the company list** were visible on every row and filterable by nobody, which reads as a broken column. Industry is free text and matched as written. `size_band` is checked against the contract's enum, because an unknown band would answer an **empty page**, and empty reads as "no accounts that size" rather than "that is not a size".

All three are **refused in overlay**: employment is our edge under our ids, and firmographics are ours to hold, so forwarding them would answer the unfiltered list wearing a filtered list's shape.

## #1585 — a gate so the page size cannot split again

Four screens carried a literal `limit: 50` for a release after the shared wrapper was fixed, because nothing derived the obligation from the tree.

`list-page-size-coverage.test.ts` does: **the screen list comes from the directory**, so a new list screen is covered the day it is written rather than the day somebody remembers to add it. Mutation-checked — putting the literal back in `leads.tsx` fails it.

## #1587 — the team dial names teams

It withheld itself from anyone in more than one team, leaving them unable to ask a question the API answers. Each team the viewer belongs to is now its own option, so picking one is **picking a team** rather than accepting a guess about which was meant.

## Two gates caught real things

- The **agent tool surface** publishes a per-type filter vocabulary and picked all three filters up by itself. Its test pinned whichever filter sorted *first* alphabetically, so it failed on a correct change — it now anchors on the type heading and the filters themselves.
- **golangci** caught a bare `"industry"` string beside an existing `fieldIndustry` constant.

## Proven against Postgres

| Test | Asserts |
|---|---|
| employer filter | the current employee; **not** the leaver at the same account, **not** the person elsewhere |
| industry | both software accounts |
| size band | only the small one |
| unknown band | refused, not an empty page |

**Mutation-checked**: dropping `is_current_primary` from the predicate fails the first test — the check that it tests the query rather than the response shape.

Fixtures go through the **real writers** (`CreateRelationship` for the edge, `UpdateOrganization` for the firmographics), so the rows under test are the rows production makes.

## Gates

`make check-backend` green · `make check-fe` green (2897 tests) · `make craft-static` 0 findings · integration lane green apart from `TestADismissalHoldsUntilTheEvidenceMoves`, which **fails identically on unmodified main** (verified by stashing this branch) and is unrelated — person-moment dismissals.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `organization_id` on people, `industry` and `size_band` on companies, enforces one page size across list screens, shows all of the viewer’s teams in owner chips, and extracts the view-highlight rule to a `useActiveView` hook. This removes unfilterable columns, prevents pager mismatches, lets multi‑team users pick the team they mean, and reduces complexity without changing behavior. Addresses #1585, #1586, #1587.

- People list: `organization_id` returns only CURRENT PRIMARY employees via an EXISTS; refused in overlay to avoid forwarding our edge.
- Company list: `industry` matches exactly; `size_band` is enum‑validated and refused if unknown; both refused in overlay.
- Page size gate: all list fetchers send `limit: query.perPage`; `frontend/src/screens/list-page-size-coverage.test.ts` auto‑discovers list screens and guards the shared fetcher shape.
- Owner chips: each of the viewer’s teams is selectable; chips sourced via `useRoster` and passed through `dataChips` on `people` and `organizations`.
- View highlight: `useActiveView` in `frontend/src/screens/listquery.tsx` moves the tab‑lighting logic out of `ListTable`; behavior unchanged and mutation‑checked.

**Review focus**
- Store predicates: employer filter in `backend/internal/modules/people/person_list.go` (`personEmployerClause`); firmographics and enum validation in `backend/internal/modules/people/organization_list.go`.
- Overlay refusals: `backend/internal/compose/overlayread.go`.
- Page-size gate and list fetcher shape: `frontend/src/screens/list-page-size-coverage.test.ts` and `frontend/src/screens/listquery.tsx`.
- Owner chips and roster sourcing: `frontend/src/screens/listquery.tsx`, `frontend/src/screens/people.tsx`, `frontend/src/screens/organizations.tsx`.
- Generated API/types: `backend/api/crm.yaml`, `backend/internal/contracts/api_gen.go`, `frontend/src/api/schema.d.ts`.

<sup>Written for commit 4156b817b9d1869559e904c4682ec588bc4f81d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1598?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

