### PR TITLE
fix(main): the integration lane is green again — a clock that drifted, and two gates nobody had answered

### DIFF
--- a/backend/internal/compose/datareset_integration_test.go
+++ b/backend/internal/compose/datareset_integration_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/platform/deployconfig"
 	"github.com/gradionhq/margince/backend/internal/platform/keyvault"
 	"github.com/gradionhq/margince/backend/internal/platform/overlaybudget/budgettest"
+	"github.com/gradionhq/margince/backend/internal/shared/gatekit"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
@@ -287,7 +288,31 @@ func TestDropResetCustomFieldColumns(t *testing.T) {
 // and is not added to preservedResetTables, it would either abort the sweep at
 // runtime or be wiped against its guard's intent. This turns that silent
 // runtime hazard into a test failure that forces a conscious classification.
+// deleteGuardedSweepTargets are the sweep targets whose DELETE-firing trigger
+// does NOT protect the table as a whole, and why sweeping them is still safe.
+//
+// The gate below cannot tell the two shapes apart from the catalog alone. An
+// append-only ledger refuses every delete, and belongs in preservedResetTables.
+// A row-conditional hold refuses deletes for SOME rows and is not a protected
+// store — preserving it would exempt a table the reset exists to clear. So the
+// second shape is classified here, with what the reset owes it.
+var deleteGuardedSweepTargets = gatekit.Waive(map[string]string{
+	// Not a protected table: the guard refuses a DELETE only while a row carries
+	// `restricted_at`, which is a statutory hold on that one record. Preserving
+	// `activity` would leave every conversation behind on a reset whose whole
+	// purpose is to clear them.
+	//
+	// Nothing can set `restricted_at` today — the trigger requires evidence in
+	// activity_retention_evidence first, and no writer for that table exists yet
+	// (#1557) — so the sweep cannot currently meet a held row. When that writer
+	// lands, the reset must LIFT the restrictions it is entitled to clear before
+	// deleting, or the sweep aborts on the first held activity. This entry is
+	// that obligation, not a record of one already met.
+	"activity": "a row-conditional statutory hold, not a protected store: preserving it would leave every activity behind on a reset meant to clear them, and no writer can set the restriction yet (#1557) — when one lands the reset must lift before it sweeps",
+})
+
 func TestSweepTargetsCarryNoDeleteBlockingTrigger(t *testing.T) {
+	defer deleteGuardedSweepTargets.AssertAllMatched(t)
 	e := integration.Setup(t)
 	ctx := e.Admin()
 	if err := database.WithWorkspaceTx(ctx, e.Pool, func(tx pgx.Tx) error {
@@ -318,8 +343,8 @@ func TestSweepTargetsCarryNoDeleteBlockingTrigger(t *testing.T) {
 			if err := rows.Scan(&table, &trigger); err != nil {
 				return err
 			}
-			if targetSet[table] {
-				t.Errorf("sweep target %q carries DELETE-firing trigger %q — a protected/append-only table must be listed in preservedResetTables, not swept", table, trigger)
+			if targetSet[table] && !deleteGuardedSweepTargets.Waived(t, table) {
+				t.Errorf("sweep target %q carries DELETE-firing trigger %q — an append-only or otherwise protected table belongs in preservedResetTables; a row-conditional guard belongs in deleteGuardedSweepTargets, with what the reset owes it", table, trigger)
 			}
 		}
 		return rows.Err()

--- a/backend/internal/compose/datasweep.go
+++ b/backend/internal/compose/datasweep.go
@@ -63,6 +63,15 @@ var preservedResetTables = map[string]bool{
 	"activity_kind": true, "channel_provider": true,
 	// in-flight delivery: drained by the outbox pass, not deleted under it
 	"event_outbox": true,
+	// The retention floor's evidence (A165, migration 0289). Preserved from the
+	// sweep's own DELETE because a direct one is REFUSED outright: the row goes
+	// only with the activity it substantiates, through the FK's CASCADE, and
+	// its guard tells the two apart by whether the parent is already gone.
+	// Sweeping it directly would abort the reset transaction on the first row.
+	//
+	// It is still cleared by a reset — `activity` is swept, and the cascade takes
+	// the evidence with it. Preserved here means "not a target", never "kept".
+	"activity_retention_evidence": true,
 }
 
 // providerCredentialRefs collects the sealed API keys the provider

--- a/backend/internal/compose/integration/fixtureclock_integration_test.go
+++ b/backend/internal/compose/integration/fixtureclock_integration_test.go
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// A suite that freezes the clock must seed against that same clock.
+//
+// The failure this prevents is a TIME BOMB, which is the reason it is worth a
+// gate rather than a code review: it passes on the day it is written, keeps
+// passing for weeks, and then fails on a date nobody can connect to a change.
+//
+// The worked example. `person_relationship_room_integration_test.go` drove its
+// services from a frozen `roomFixedNow` of 2026-08-04 and seeded an activity at
+// the DATABASE's `now() - interval '20 days'`. Those are two clocks. Every real
+// day that passed moved the seeded row a day closer to the frozen now, so the
+// row's apparent age fell by a day a day: nearly 20 days old the week it was
+// written, and 6.9 days old on 2026-08-17 — one hour under the seven-day rule
+// the gone-quiet rung applies. The suite went red on main with nothing changed
+// but the date, and the failing assertion pointed at the dismissal logic, which
+// was working perfectly.
+//
+// The gate is deliberately blunt: no `now()` arithmetic at all in a file that
+// names a frozen clock. A fixture whose subject is a time passes it as a
+// parameter (SeedRow takes them), derived from the same frozen value the
+// service is given.
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// databaseClockArithmetic finds a fixture leaning on the database's clock.
+var databaseClockArithmetic = regexp.MustCompile(`now\(\)\s*[-+]\s*interval`)
+
+// frozenClockFixture finds a file that pins the clock its services read.
+var frozenClockFixture = regexp.MustCompile(`(?i)fixedNow|func\(\) time\.Time \{ return`)
+
+// gateOwnFile is this file, excluded below.
+const gateOwnFile = "fixtureclock_integration_test.go"
+
+func TestAFrozenClockFixtureDoesNotSeedAgainstTheDatabaseClock(t *testing.T) {
+	entries, err := filepath.Glob("*_test.go")
+	if err != nil {
+		t.Fatalf("listing the suite: %v", err)
+	}
+	if len(entries) == 0 {
+		t.Fatal("found no test files at all — the walk is broken, and a walk " +
+			"that finds nothing passes this test for the wrong reason")
+	}
+
+	var frozen int
+	for _, path := range entries {
+		// This file quotes the pattern in order to describe it, and is the one
+		// place that must.
+		if path == gateOwnFile {
+			continue
+		}
+		source, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("reading %s: %v", path, err)
+		}
+		text := string(source)
+		if !frozenClockFixture.MatchString(text) {
+			continue
+		}
+		frozen++
+		for _, offending := range databaseClockArithmetic.FindAllString(text, -1) {
+			t.Errorf("%s freezes the clock its services read and then seeds with %q: "+
+				"those are two clocks, and the distance between them grows by a day "+
+				"every day this suite is not run. Pass the timestamp as a parameter, "+
+				"derived from the frozen value (roomAgo/roomAhead).",
+				path, strings.TrimSpace(offending))
+		}
+	}
+	if frozen == 0 {
+		t.Fatal("no suite here freezes a clock, so this gate matched nothing — " +
+			"the detector is broken rather than the tree being clean")
+	}
+}

--- a/backend/internal/compose/integration/meetingbrief_integration_test.go
+++ b/backend/internal/compose/integration/meetingbrief_integration_test.go
@@ -45,8 +45,8 @@ func TestMeetingBriefRefusesACallerWithNoActivityGrant(t *testing.T) {
 	mine := e.SeedPerson(t, "Anna Weber", &e.Rep1)
 	meeting := SeedRow(t, owner, `INSERT INTO activity
 		(id, workspace_id, kind, subject, occurred_at, source, captured_by)
-		VALUES ($1, $2, 'meeting', 'Expansion review', now() + interval '1 day',
-		        'manual', 'human:x')`, e.WS)
+		VALUES ($1, $2, 'meeting', 'Expansion review', $3,
+		        'manual', 'human:x')`, e.WS, roomAhead(24*time.Hour))
 	LinkActivity(t, owner, e.WS, meeting, "person", mine)
 
 	perms := roomPerms
@@ -72,8 +72,8 @@ func TestMeetingBriefRefusesACallerWithNoPersonGrant(t *testing.T) {
 	mine := e.SeedPerson(t, "Anna Weber", &e.Rep1)
 	meeting := SeedRow(t, owner, `INSERT INTO activity
 		(id, workspace_id, kind, subject, occurred_at, source, captured_by)
-		VALUES ($1, $2, 'meeting', 'Expansion review', now() + interval '1 day',
-		        'manual', 'human:x')`, e.WS)
+		VALUES ($1, $2, 'meeting', 'Expansion review', $3,
+		        'manual', 'human:x')`, e.WS, roomAhead(24*time.Hour))
 	LinkActivity(t, owner, e.WS, meeting, "person", mine)
 
 	perms := roomPerms
@@ -100,8 +100,8 @@ func TestMeetingBriefRefusesAMeetingItCannotReach(t *testing.T) {
 	theirs := e.SeedPerson(t, "Their Contact", &e.Rep3)
 	meeting := SeedRow(t, owner, `INSERT INTO activity
 		(id, workspace_id, kind, subject, occurred_at, source, captured_by)
-		VALUES ($1, $2, 'meeting', 'Their review', now() + interval '1 day',
-		        'manual', 'human:x')`, e.WS)
+		VALUES ($1, $2, 'meeting', 'Their review', $3,
+		        'manual', 'human:x')`, e.WS, roomAhead(24*time.Hour))
 	LinkActivity(t, owner, e.WS, meeting, "person", theirs)
 
 	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, roomPerms)
@@ -128,8 +128,8 @@ func TestMeetingBriefDoesNotReportALastTouchTheCallerCannotRead(t *testing.T) {
 
 	meeting := SeedRow(t, owner, `INSERT INTO activity
 		(id, workspace_id, kind, subject, occurred_at, source, captured_by)
-		VALUES ($1, $2, 'meeting', 'Expansion review', now() + interval '1 day',
-		        'manual', 'human:x')`, e.WS)
+		VALUES ($1, $2, 'meeting', 'Expansion review', $3,
+		        'manual', 'human:x')`, e.WS, roomAhead(24*time.Hour))
 	LinkActivity(t, owner, e.WS, meeting, "person", attendee)
 	seatInRoom(t, owner, e.WS, meeting, attendee)
 
@@ -137,8 +137,8 @@ func TestMeetingBriefDoesNotReportALastTouchTheCallerCannotRead(t *testing.T) {
 	// attendee as a participant.
 	hidden := SeedRow(t, owner, `INSERT INTO activity
 		(id, workspace_id, kind, subject, occurred_at, source, captured_by)
-		VALUES ($1, $2, 'email', 'Cc: budget', now() - interval '3 days',
-		        'manual', 'human:x')`, e.WS)
+		VALUES ($1, $2, 'email', 'Cc: budget', $3,
+		        'manual', 'human:x')`, e.WS, roomAgo(3*24*time.Hour))
 	LinkActivity(t, owner, e.WS, hidden, "person", theirs)
 	seatInRoom(t, owner, e.WS, hidden, attendee)
 

--- a/backend/internal/compose/integration/meetingbrief_integration_test.go
+++ b/backend/internal/compose/integration/meetingbrief_integration_test.go
@@ -46,7 +46,7 @@ func TestMeetingBriefRefusesACallerWithNoActivityGrant(t *testing.T) {
 	meeting := SeedRow(t, owner, `INSERT INTO activity
 		(id, workspace_id, kind, subject, occurred_at, source, captured_by)
 		VALUES ($1, $2, 'meeting', 'Expansion review', $3,
-		        'manual', 'human:x')`, e.WS, roomAhead(24*time.Hour))
+		        'manual', 'human:x')`, e.WS, roomTomorrow)
 	LinkActivity(t, owner, e.WS, meeting, "person", mine)
 
 	perms := roomPerms
@@ -73,7 +73,7 @@ func TestMeetingBriefRefusesACallerWithNoPersonGrant(t *testing.T) {
 	meeting := SeedRow(t, owner, `INSERT INTO activity
 		(id, workspace_id, kind, subject, occurred_at, source, captured_by)
 		VALUES ($1, $2, 'meeting', 'Expansion review', $3,
-		        'manual', 'human:x')`, e.WS, roomAhead(24*time.Hour))
+		        'manual', 'human:x')`, e.WS, roomTomorrow)
 	LinkActivity(t, owner, e.WS, meeting, "person", mine)
 
 	perms := roomPerms
@@ -101,7 +101,7 @@ func TestMeetingBriefRefusesAMeetingItCannotReach(t *testing.T) {
 	meeting := SeedRow(t, owner, `INSERT INTO activity
 		(id, workspace_id, kind, subject, occurred_at, source, captured_by)
 		VALUES ($1, $2, 'meeting', 'Their review', $3,
-		        'manual', 'human:x')`, e.WS, roomAhead(24*time.Hour))
+		        'manual', 'human:x')`, e.WS, roomTomorrow)
 	LinkActivity(t, owner, e.WS, meeting, "person", theirs)
 
 	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, roomPerms)
@@ -129,7 +129,7 @@ func TestMeetingBriefDoesNotReportALastTouchTheCallerCannotRead(t *testing.T) {
 	meeting := SeedRow(t, owner, `INSERT INTO activity
 		(id, workspace_id, kind, subject, occurred_at, source, captured_by)
 		VALUES ($1, $2, 'meeting', 'Expansion review', $3,
-		        'manual', 'human:x')`, e.WS, roomAhead(24*time.Hour))
+		        'manual', 'human:x')`, e.WS, roomTomorrow)
 	LinkActivity(t, owner, e.WS, meeting, "person", attendee)
 	seatInRoom(t, owner, e.WS, meeting, attendee)
 

--- a/backend/internal/compose/integration/person_relationship_room_integration_test.go
+++ b/backend/internal/compose/integration/person_relationship_room_integration_test.go
@@ -37,6 +37,19 @@ import (
 // seeding and reading.
 var roomFixedNow = time.Date(2026, 8, 4, 12, 0, 0, 0, time.UTC)
 
+// roomAgo and roomAhead place a fixture's timestamp against the SAME clock the
+// services under test are given.
+//
+// The database's `now()` is a different clock, and a fixture that mixes the two
+// measures the distance between them: it drifts one day further from the frozen
+// now for every real day that passes. A row seeded at `now() - 20 days` was
+// nearly 20 days old to the frozen clock the week this suite was written, and
+// exactly 6.9 days old on 2026-08-17 — one hour under the seven-day rule the
+// gone-quiet rung applies, which is the day the suite began failing with nothing
+// changed but the date.
+func roomAgo(d time.Duration) time.Time   { return roomFixedNow.Add(-d) }
+func roomAhead(d time.Duration) time.Time { return roomFixedNow.Add(d) }
+
 // roomPerms is a bounded rep holding every grant the person page asks for. The
 // scope must be team-level: an unbounded admin short-circuits the row-scope
 // clauses these tests exist to prove.
@@ -381,8 +394,8 @@ func TestADismissalHoldsUntilTheEvidenceMoves(t *testing.T) {
 	// We wrote and they never answered: the gone-quiet rung.
 	outbound := SeedRow(t, owner, `INSERT INTO activity
 		(id, workspace_id, kind, subject, body, occurred_at, direction, source, captured_by)
-		VALUES ($1, $2, 'email', 'Following up', 'body', now() - interval '20 days',
-		        'outbound', 'manual', 'human:x')`, e.WS)
+		VALUES ($1, $2, 'email', 'Following up', 'body', $3,
+		        'outbound', 'manual', 'human:x')`, e.WS, roomAgo(20*24*time.Hour))
 	LinkActivity(t, owner, e.WS, outbound, "person", mine)
 
 	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, roomPerms)
@@ -417,8 +430,8 @@ func TestADismissalHoldsUntilTheEvidenceMoves(t *testing.T) {
 	// so the page must speak again rather than stay quiet about the new fact.
 	inbound := SeedRow(t, owner, `INSERT INTO activity
 		(id, workspace_id, kind, subject, body, occurred_at, direction, source, captured_by)
-		VALUES ($1, $2, 'email', 'Re: Following up', 'body', now() - interval '1 hour',
-		        'inbound', 'manual', 'human:x')`, e.WS)
+		VALUES ($1, $2, 'email', 'Re: Following up', 'body', $3,
+		        'inbound', 'manual', 'human:x')`, e.WS, roomAgo(time.Hour))
 	LinkActivity(t, owner, e.WS, inbound, "person", mine)
 
 	reArmed, err := svc.Assemble(rep, personID)

--- a/backend/internal/compose/integration/person_relationship_room_integration_test.go
+++ b/backend/internal/compose/integration/person_relationship_room_integration_test.go
@@ -47,8 +47,12 @@ var roomFixedNow = time.Date(2026, 8, 4, 12, 0, 0, 0, time.UTC)
 // exactly 6.9 days old on 2026-08-17 — one hour under the seven-day rule the
 // gone-quiet rung applies, which is the day the suite began failing with nothing
 // changed but the date.
-func roomAgo(d time.Duration) time.Time   { return roomFixedNow.Add(-d) }
-func roomAhead(d time.Duration) time.Time { return roomFixedNow.Add(d) }
+func roomAgo(d time.Duration) time.Time { return roomFixedNow.Add(-d) }
+
+// roomTomorrow is a day after the frozen now: comfortably inside the 72-hour
+// horizon the meeting-prep rung applies, and stated as a value because every
+// fixture that wants a booked meeting wants the same one.
+var roomTomorrow = roomFixedNow.Add(24 * time.Hour)
 
 // roomPerms is a bounded rep holding every grant the person page asks for. The
 // scope must be team-level: an unbounded admin short-circuits the row-scope

--- a/backend/internal/compose/integration/seed.go
+++ b/backend/internal/compose/integration/seed.go
@@ -125,10 +125,17 @@ func SeedExtraWorkspace(t *testing.T, owner *pgx.Conn, name string, archived boo
 }
 
 // SeedRow inserts one row through the owner connection and returns its id.
-func SeedRow(t *testing.T, owner *pgx.Conn, sql string, ws ids.UUID) ids.UUID {
+//
+// `args` fill $3 onwards. A fixture whose subject is a TIME must pass it here
+// rather than write `now() - interval ...` in the SQL: a suite that freezes the
+// service's clock and then seeds against the database's is measuring the gap
+// between two clocks that drift apart every day it is not run. See
+// TestAFrozenClockFixtureDoesNotSeedAgainstTheDatabaseClock.
+func SeedRow(t *testing.T, owner *pgx.Conn, sql string, ws ids.UUID, args ...any) ids.UUID {
 	t.Helper()
 	id := ids.NewV7()
-	if _, err := owner.Exec(context.Background(), sql, id, ws); err != nil {
+	params := append([]any{id, ws}, args...)
+	if _, err := owner.Exec(context.Background(), sql, params...); err != nil {
 		t.Fatalf("seeding: %v", err)
 	}
 	return id

--- a/backend/migrations/schema_fitness_integration_test.go
+++ b/backend/migrations/schema_fitness_integration_test.go
@@ -296,10 +296,20 @@ var rowScopedFKDecisions = gatekit.Waive(map[string]string{
 	// written. Every later read of the run record (GetTranscriptRead,
 	// LatestTranscriptRead, ReadTranscript) re-probes the same way rather than
 	// trusting the stored pointer.
-	"transcript_read.activity_id":           "client-supplied and gated: every path resolves the activity through readActivity's ActivityScopeClause walk, so an unseeable transcript is ErrNotFound rather than a readable run record",
-	"finance_customer_link.organization_id": "schema only, no writer yet (#725): the mapping write does not exist, and when it lands it must put the named company through auth.EnsureLinkTarget — this entry is the obligation, not a record of one already met",
-	"finance_invoice.organization_id":       "schema only, no writer yet (#725): the sync pass does not exist, and when it lands it must resolve the organization from the customer link rather than from any request body",
-	"finance_payment.organization_id":       "schema only, no writer yet (#725): the sync pass does not exist, and when it lands it must resolve the organization from the customer link rather than from any request body",
+	"transcript_read.activity_id": "client-supplied and gated: every path resolves the activity through readActivity's ActivityScopeClause walk, so an unseeable transcript is ErrNotFound rather than a readable run record",
+	// The retention floor's evidence (A165, migration 0289). Both columns are
+	// SERVER-DERIVED and neither has a writer yet — the table shipped ahead of
+	// the pass that fills it (#1557). activity_id is the record being held, and
+	// the row exists only because that record qualified; deal_id is the
+	// transaction that qualified it, resolved from the deal the activity is
+	// already linked to rather than from anything a caller sends. When the
+	// writer lands it must derive both from rows the actor could already see —
+	// this entry is the obligation, not a record of one already met.
+	"activity_retention_evidence.activity_id": "schema only, no writer yet (#1557): the evidence is written by the qualifying pass from the activity it substantiates, never from a request body — when that pass lands, the activity it names must be one the actor could already see",
+	"activity_retention_evidence.deal_id":     "schema only, no writer yet (#1557): the qualifying transaction is resolved from the activity's own link, not supplied — and it is ON DELETE SET NULL beside a frozen deal_name, so the evidence answers after the deal is gone",
+	"finance_customer_link.organization_id":   "schema only, no writer yet (#725): the mapping write does not exist, and when it lands it must put the named company through auth.EnsureLinkTarget — this entry is the obligation, not a record of one already met",
+	"finance_invoice.organization_id":         "schema only, no writer yet (#725): the sync pass does not exist, and when it lands it must resolve the organization from the customer link rather than from any request body",
+	"finance_payment.organization_id":         "schema only, no writer yet (#725): the sync pass does not exist, and when it lands it must resolve the organization from the customer link rather than from any request body",
 })
 
 // TestFK_rowScopedTargetsHaveVisibilityDecision derives the H1 obligation


### PR DESCRIPTION
## Main is red on the integration lane, for two unrelated reasons

Neither is visible on `main`'s own CI yet — its runs are sitting in `status=queued` behind backed-up runners — so this surfaced on unrelated PRs instead. Every branch cut from `main` currently fails three integration tests. This clears all three.

## 1. A fixture that froze the clock and then seeded against the database's (#1572)

`TestADismissalHoldsUntilTheEvidenceMoves` went red **on a date**, with nothing changed but the date.

The suite drives its services from a frozen `roomFixedNow` of 2026-08-04 and seeded its activity at the **database's** `now() - interval '20 days'`. Those are two clocks, and they drift apart by a day for every real day that passes:

```
frozen now   = 2026-08-04 12:00
seeded row   = 2026-07-28 14:30   (database now() − 20 days, observed)
gap          = 165.5h  →  waiting = int(6.895) = 6 days
rule needs   ≥ 7       →  the gone-quiet rung never fires
```

The row was nearly 20 days old to that clock the week it was written, and **6.9 days old on 2026-08-17** — one hour under the seven-day rule. The test passes while real now ≤ 2026-08-17 and fails from then on.

**Why the failure pointed at the wrong place.** The assertion reads *"the dismissed moment came back against unchanged evidence"*, which sends a reader straight into the dismissal keying. The dismissal was working perfectly. Because `gone_quiet` had already declined, the moment being dismissed was `nothing_needed` — and `nothing_needed` is what came back. Nothing about the dismissal was wrong.

**Fixed at the invariant, not the call site.** `SeedRow` takes parameters now, so a fixture whose subject is a *time* passes it rather than writing arithmetic against a clock its service never reads; `roomAgo`/`roomAhead` derive those timestamps from the same frozen value. The `meetingbrief` suite had five more of these and is converted with it — it passes today, but its meetings were seeded fourteen days beyond the seventy-two-hour horizon the prep rung applies, so it was passing *around* its fixture rather than because of it.

**The gate is the point.** This class is invisible to review — it passes the day it is written and fails on a date nobody can connect to a commit. `TestAFrozenClockFixtureDoesNotSeedAgainstTheDatabaseClock` refuses any suite that freezes a clock and then seeds against the database's. It caught its own doc comment on the first run, and it goes red when the original seed is put back.

## 2. Two fitness gates the retention-floor schema never answered (#1588)

`TestFK_rowScopedTargetsHaveVisibilityDecision` and `TestSweepTargetsCarryNoDeleteBlockingTrigger` have been failing since `activity_retention_evidence` landed. Both were asking a question nobody had answered, and the answers differ.

**The FK gate.** Both columns are server-derived and neither has a writer — the table shipped ahead of the pass that fills it (#1557). Classified as the obligation that writer inherits, in the same form as the `finance_*` entries beside them.

**The sweep gate.** Its message was right about one table and wrong about the other:

- `activity_retention_evidence` **is** a protected store. A direct DELETE is refused outright; the row goes only with the activity it substantiates, through the CASCADE. Sweeping it directly aborts the reset on the first row. Preserved now — which means *not a target*, not *kept*: the reset still clears it via the cascade from `activity`.
- `activity` is **not**. Its trigger refuses a delete only while a row carries `restricted_at` — a statutory hold on one record. Preserving `activity` would leave every conversation behind on a reset whose entire purpose is to clear them.

So the gate now separates the two shapes: an append-only store is preserved, a row-conditional guard is classified with what the reset owes it. What it owes is real but not yet due — nothing can set `restricted_at` today, because the trigger demands evidence first and no writer exists. When #1557 lands, the reset must lift the restrictions it is entitled to clear before deleting, or it aborts on the first held row. That is written where it will go red if forgotten.

## Verification

Every gate in this PR was made to fail before being trusted:

| Gate | Mutation | Result |
|---|---|---|
| `TestAFrozenClockFixtureDoesNotSeedAgainstTheDatabaseClock` | put the original `now() - interval '20 days'` seed back | red, naming the file |
| same | (unprompted) its own doc comment quoting the pattern | red on first run — now excluded, as the one file that must name it |
| `TestSweepTargetsCarryNoDeleteBlockingTrigger` | remove the preserved entry | red, naming the evidence table |
| same | mis-key the classification | red on `activity` **and** on the stale waiver |

`make check-backend` and `make test-integration` green on this branch. The lane's zero-skip guard passes.

## Note

The `activity_retention_evidence` half of this also exists as a commit on #1589, where it was written; it is included here so **one** merge makes `main` green rather than two that depend on each other. #1589 rebases cleanly once this lands.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unblocks the integration lane by fixing a frozen-clock fixture that drifted with real time and by classifying two retention-floor gates. Tests no longer seed against the database clock when a suite freezes time; the data reset now preserves evidence and distinguishes row-conditional holds.

- Frozen-clock fixtures
  - Old: suites froze a clock but seeded with `now() ± interval`, causing date-dependent failures. New: `SeedRow` accepts extra args; tests pass timestamps derived from the same frozen clock via `roomAgo`/`roomTomorrow`.
  - Adds a gate that fails any file that both freezes a clock and uses `now() ± interval`.
  - Migration: when a test freezes time, replace `now()` arithmetic with explicit timestamps and pass them to `SeedRow`.

- Retention-floor gates
  - Sweep gate: preserves `activity_retention_evidence` in `preservedResetTables` (direct DELETE refused; cleared via cascade from `activity`) and adds `deleteGuardedSweepTargets` to record that `activity` has a row-conditional hold (`restricted_at`) and remains a sweep target.
  - FK visibility gate: adds decisions for `activity_retention_evidence.activity_id` and `.deal_id` as server-derived, writer-pending obligations.
  - Forward requirement: when the writer lands, the reset must lift eligible `restricted_at` holds before sweeping `activity`.

<sup>Written for commit 5b075a97ce4a4d71dceb323477ab79882e2c958d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1600?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

