### PR TITLE
fix(lists): Next reaches page three, the owner dial narrows, and a filtered account says what it is

### DIFF
--- a/frontend/src/screens/listquery.test.tsx
+++ b/frontend/src/screens/listquery.test.tsx
@@ -489,3 +489,45 @@ describe("view tabs — two views can ask for the same thing", () => {
     ).toBe("false");
   });
 });
+
+describe("paging a filtered list", () => {
+  it("keeps going forward instead of snapping back to page 1", async () => {
+    const user = userEvent.setup();
+    const page = (from: number) => ({
+      data: Array.from({ length: 25 }, (_, i) => ({
+        id: `r-${from + i}`,
+        name: `Row ${from + i}`,
+      })),
+      page: { next_cursor: `c-${from + 25}`, has_more: true },
+    });
+    let served = 0;
+    const fetchPage = vi.fn(async (_query: ListQuery, _cursor: string | null) =>
+      page(25 * served++),
+    );
+    render(
+      <ListTableHarness
+        fetchPage={fetchPage}
+        chips={[
+          {
+            key: "owner",
+            label: "list.owner",
+            allLabel: "list.filterOwnerAll",
+            options: [{ value: "owner_id:u-1", label: "list.filterOwnerMe" }],
+          },
+        ]}
+      />,
+    );
+    await waitFor(() => expect(screen.getByText("Row 0")).toBeTruthy());
+
+    // Next twice. The table resets to page 1 whenever `chosen` changes
+    // IDENTITY — so a chosen object rebuilt on every render reset on every
+    // render, and the list flipped between the first two pages forever.
+    for (const _ of [1, 2]) {
+      await user.click(screen.getByRole("button", { name: /Next/ }));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+
+    await waitFor(() => expect(screen.getByText("Row 50")).toBeTruthy());
+    expect(screen.queryByText("Row 0")).toBeNull();
+  });
+});

--- a/frontend/src/screens/listquery.test.tsx
+++ b/frontend/src/screens/listquery.test.tsx
@@ -522,14 +522,19 @@ describe("paging a filtered list", () => {
     );
     await waitFor(() => expect(screen.getByText("Row 0")).toBeTruthy());
 
-    // Next twice. The table resets to page 1 whenever `chosen` changes
-    // IDENTITY — so a chosen object rebuilt on every render reset on every
-    // render, and the list flipped between the first two pages forever.
-    for (const _ of [1, 2]) {
-      await user.click(screen.getByRole("button", { name: /Next/ }));
-      await new Promise((resolve) => setTimeout(resolve, 0));
-    }
+    // Next twice, each press waiting for its page to actually render rather
+    // than for a timer to fire: a zero-duration sleep races React Query's
+    // commit, and a test that sometimes clicks Next on a page that has not
+    // arrived is a test that sometimes passes for the wrong reason.
+    //
+    // The table resets to page 1 whenever `chosen` changes IDENTITY — so a
+    // chosen object rebuilt on every render reset on every render, and the
+    // list flipped between the first two pages forever. ONE press hides that:
+    // the reset lands on a page whose content happens to match. It takes two.
+    await user.click(screen.getByRole("button", { name: /Next/ }));
+    await waitFor(() => expect(screen.getByText("Row 25")).toBeTruthy());
 
+    await user.click(screen.getByRole("button", { name: /Next/ }));
     await waitFor(() => expect(screen.getByText("Row 50")).toBeTruthy());
     expect(screen.queryByText("Row 0")).toBeNull();
   });
@@ -577,5 +582,60 @@ describe("a data-driven chip narrows the list", () => {
     expect(fetchPage.mock.calls.at(-1)?.[0].filters).not.toHaveProperty(
       "owner",
     );
+  });
+});
+
+describe("two chips on one list", () => {
+  it("does not let one dial clear the other's answer", async () => {
+    const user = userEvent.setup();
+    const fetchPage = vi.fn(
+      async (_query: ListQuery, _cursor: string | null) => ({
+        data: [] as Row[],
+        page: { next_cursor: null, has_more: false },
+      }),
+    );
+    render(
+      <ListTableHarness
+        fetchPage={fetchPage}
+        chips={[
+          {
+            key: "lifecycle",
+            label: "org.lifecycle",
+            allLabel: "org.filterLifecycleAll",
+            options: [{ value: "customer", label: "org.lifecycle.customer" }],
+          },
+        ]}
+        dataChips={[
+          {
+            key: "owner",
+            label: "Owner",
+            allLabel: "Any owner",
+            options: [{ value: "unassigned:true", label: "Unassigned" }],
+          },
+        ]}
+      />,
+    );
+    await waitFor(() => expect(fetchPage).toHaveBeenCalled());
+
+    await user.click(await screen.findByRole("button", { name: "Filter" }));
+    await user.click(screen.getByRole("button", { name: "Owner" }));
+    await user.click(screen.getByRole("button", { name: "Unassigned" }));
+    await waitFor(() =>
+      expect(fetchPage.mock.calls.at(-1)?.[0].filters.unassigned).toBe("true"),
+    );
+
+    // Now narrow by something else. Clearing every composite parameter on the
+    // surface — rather than only the chip being changed — would drop the owner
+    // answer here, so picking a lifecycle would silently widen the list back to
+    // every owner while the owner chip still showed "Unassigned".
+    await user.click(screen.getByRole("button", { name: "Account lifecycle" }));
+    await user.click(screen.getByRole("button", { name: "Customer" }));
+
+    await waitFor(() =>
+      expect(fetchPage.mock.calls.at(-1)?.[0].filters.lifecycle).toBe(
+        "customer",
+      ),
+    );
+    expect(fetchPage.mock.calls.at(-1)?.[0].filters.unassigned).toBe("true");
   });
 });

--- a/frontend/src/screens/listquery.test.tsx
+++ b/frontend/src/screens/listquery.test.tsx
@@ -11,7 +11,7 @@ import {
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { ListView } from "../design-system/listsurface";
+import type { ListChip, ListView } from "../design-system/listsurface";
 import { pickOption } from "../design-system/select-testing";
 import { LocaleProvider } from "../i18n";
 import { ProblemError } from "./common";
@@ -114,6 +114,7 @@ function ListTableHarness({
   action,
   views,
   dataViews,
+  dataChips,
 }: Readonly<{
   fetchPage: (
     query: ListQuery,
@@ -123,6 +124,7 @@ function ListTableHarness({
   action?: ReactNode;
   views?: readonly ViewSpec[];
   dataViews?: readonly ListView[];
+  dataChips?: readonly ListChip[];
 }>) {
   const state = useListQuery<Row>({
     key: "list-table-harness",
@@ -143,6 +145,7 @@ function ListTableHarness({
       ]}
       rowKey={(row) => row.id}
       chips={chips}
+      dataChips={dataChips}
       views={views}
       dataViews={dataViews}
       action={action}
@@ -529,5 +532,50 @@ describe("paging a filtered list", () => {
 
     await waitFor(() => expect(screen.getByText("Row 50")).toBeTruthy());
     expect(screen.queryByText("Row 0")).toBeNull();
+  });
+});
+
+describe("a data-driven chip narrows the list", () => {
+  it("sends the parameter its option names, not the chip's own key", async () => {
+    const user = userEvent.setup();
+    const fetchPage = vi.fn(
+      async (_query: ListQuery, _cursor: string | null) => ({
+        data: [] as Row[],
+        page: { next_cursor: null, has_more: false },
+      }),
+    );
+    render(
+      <ListTableHarness
+        fetchPage={fetchPage}
+        // The owner dial is a dataChip: it names the viewer's teams, which are
+        // server strings rather than message keys.
+        dataChips={[
+          {
+            key: "owner",
+            label: "Owner",
+            allLabel: "Any owner",
+            options: [
+              { value: "owner_id:u-1", label: "My records" },
+              { value: "unassigned:true", label: "Unassigned" },
+            ],
+          },
+        ]}
+      />,
+    );
+    await waitFor(() => expect(fetchPage).toHaveBeenCalled());
+
+    await user.click(await screen.findByRole("button", { name: "Filter" }));
+    await user.click(screen.getByRole("button", { name: "Owner" }));
+    await user.click(screen.getByRole("button", { name: "Unassigned" }));
+
+    // `unassigned=true`, not `owner=unassigned:true`. The server ignores a
+    // parameter it does not know, so the wrong spelling answers the WHOLE list
+    // with 200 OK — a filter that reads as working and is not.
+    await waitFor(() =>
+      expect(fetchPage.mock.calls.at(-1)?.[0].filters.unassigned).toBe("true"),
+    );
+    expect(fetchPage.mock.calls.at(-1)?.[0].filters).not.toHaveProperty(
+      "owner",
+    );
   });
 });

--- a/frontend/src/screens/listquery.tsx
+++ b/frontend/src/screens/listquery.tsx
@@ -239,13 +239,23 @@ export function ListTable<Row>({
   // `chips` cannot be the key — screens declare it as an inline array literal,
   // which is a fresh reference each render. The option values are what
   // chosenFor actually reads, and they are strings.
-  const chipOptionKey = chips
+  // EVERY chip on the surface, declared and data-driven alike. The owner dial
+  // is a dataChip because it names the viewer's teams at runtime, and code that
+  // asks "which chips are there" must see it: reading `chips` alone is what
+  // made picking Unassigned send `owner=unassigned:true` — the chip's key with
+  // the raw option value — instead of `unassigned=true`, so the server ignored
+  // an unknown parameter and answered the whole list.
+  const allChips: readonly ListChip[] = [
+    ...chips.map((chip) => translateChip(chip, t)),
+    ...dataChips,
+  ];
+  const chipOptionKey = allChips
     .flatMap((chip) => chip.options.map((option) => option.value))
     .join("\u0000");
   const filterKey = JSON.stringify(query.filters);
   // biome-ignore lint/correctness/useExhaustiveDependencies: keyed on the values the arrays carry, which is what makes the identity stable
   const chosen = useMemo(
-    () => chosenFor(chips, query.filters),
+    () => chosenFor(allChips, query.filters),
     [chipOptionKey, filterKey],
   );
 
@@ -294,7 +304,7 @@ export function ListTable<Row>({
       // refuses if asked two at once). Clearing such a chip has to drop
       // whichever parameter is currently set, not the chip's own key, which
       // names no parameter at all.
-      const alternatives = chips
+      const alternatives = allChips
         .flatMap((chip) => chip.options.map((option) => option.value))
         .filter((candidate) => candidate.includes(":"))
         .map((candidate) => candidate.slice(0, candidate.indexOf(":")));
@@ -346,11 +356,7 @@ export function ListTable<Row>({
               onChange: (next) => setQuery((prev) => ({ ...prev, sort: next })),
             }
       }
-      chips={
-        overlay
-          ? []
-          : [...chips.map((chip) => translateChip(chip, t)), ...dataChips]
-      }
+      chips={overlay ? [] : allChips}
       chosen={chosen}
       onChipChange={setFilter}
       // A view tab whose preset the mirror would refuse is a tab that lights up
@@ -514,7 +520,10 @@ export function useOwnerChips(): readonly ListChip[] {
  * filter that did not take.
  */
 function chosenFor(
-  chips: readonly FilterSpec[],
+  // Takes the option VALUES, so it reads a declared chip and a data-driven one
+  // the same way — the two differ only in where their labels came from, and a
+  // reader of this function never looks at a label.
+  chips: readonly ListChip[],
   filters: Readonly<Record<string, string>>,
 ): Record<string, string> {
   const chosen = { ...filters };

--- a/frontend/src/screens/listquery.tsx
+++ b/frontend/src/screens/listquery.tsx
@@ -249,9 +249,14 @@ export function ListTable<Row>({
     ...chips.map((chip) => translateChip(chip, t)),
     ...dataChips,
   ];
-  const chipOptionKey = allChips
-    .flatMap((chip) => chip.options.map((option) => option.value))
-    .join("\u0000");
+  // Carries the chip KEYS and the grouping, not just a flat list of values:
+  // chosenFor reads both, so two different chip sets that happen to share the
+  // same values must not produce the same key. JSON, rather than a join on a
+  // separator — any separator can appear inside a value, and then ["a","b"]
+  // and ["a<sep>b"] are indistinguishable.
+  const chipOptionKey = JSON.stringify(
+    allChips.map((chip) => [chip.key, chip.options.map((o) => o.value)]),
+  );
   const filterKey = JSON.stringify(query.filters);
   // biome-ignore lint/correctness/useExhaustiveDependencies: keyed on the values the arrays carry, which is what makes the identity stable
   const chosen = useMemo(
@@ -304,16 +309,23 @@ export function ListTable<Row>({
       // refuses if asked two at once). Clearing such a chip has to drop
       // whichever parameter is currently set, not the chip's own key, which
       // names no parameter at all.
-      const alternatives = allChips
+      // Only THIS chip's own parameters are cleared. A chip whose options each
+      // name a different query parameter (the owner dial: mine, my team's,
+      // unowned) has to drop whichever of its own it currently holds, because
+      // its key names no parameter at all. Clearing every composite parameter
+      // on the surface instead would make picking a lifecycle silently drop the
+      // owner filter — one dial reaching into another's answer.
+      const mine = allChips
+        .filter((chip) => chip.key === key)
         .flatMap((chip) => chip.options.map((option) => option.value))
         .filter((candidate) => candidate.includes(":"))
         .map((candidate) => candidate.slice(0, candidate.indexOf(":")));
-      for (const param of alternatives) {
+      for (const param of mine) {
         delete filters[param];
       }
       if (value) {
         const split = value.indexOf(":");
-        if (split > 0 && alternatives.includes(value.slice(0, split))) {
+        if (split > 0 && mine.includes(value.slice(0, split))) {
           filters[value.slice(0, split)] = value.slice(split + 1);
         } else {
           filters[key] = value;

--- a/frontend/src/screens/listquery.tsx
+++ b/frontend/src/screens/listquery.tsx
@@ -4,6 +4,7 @@ import {
   type ReactNode,
   type SetStateAction,
   useEffect,
+  useMemo,
   useState,
 } from "react";
 import { navigate, type Route, routeHash } from "../app/router";
@@ -229,6 +230,24 @@ export function ListTable<Row>({
     ...dataViews,
   ];
   const [view, setPicked] = useActiveView(allViews, query);
+  // Keyed on the VALUES, not on the arrays that carry them. The table treats a
+  // new `chosen` object as the reader narrowing the list and resets to page 1,
+  // so an object rebuilt every render resets on every render: pressing Next
+  // re-read page 2 and then immediately snapped back to page 1, and the list
+  // flipped between the first two pages forever.
+  //
+  // `chips` cannot be the key — screens declare it as an inline array literal,
+  // which is a fresh reference each render. The option values are what
+  // chosenFor actually reads, and they are strings.
+  const chipOptionKey = chips
+    .flatMap((chip) => chip.options.map((option) => option.value))
+    .join("\u0000");
+  const filterKey = JSON.stringify(query.filters);
+  // biome-ignore lint/correctness/useExhaustiveDependencies: keyed on the values the arrays carry, which is what makes the identity stable
+  const chosen = useMemo(
+    () => chosenFor(chips, query.filters),
+    [chipOptionKey, filterKey],
+  );
 
   // A functional updater reads the query at commit time, not at the time the
   // timer was scheduled: a concurrent sort/filter/includeArchived change
@@ -332,7 +351,7 @@ export function ListTable<Row>({
           ? []
           : [...chips.map((chip) => translateChip(chip, t)), ...dataChips]
       }
-      chosen={chosenFor(chips, query.filters)}
+      chosen={chosen}
       onChipChange={setFilter}
       // A view tab whose preset the mirror would refuse is a tab that lights up
       // and does nothing, so overlay mode shows none — the same reason its

--- a/frontend/src/screens/organizations.test.tsx
+++ b/frontend/src/screens/organizations.test.tsx
@@ -643,6 +643,52 @@ describe("CompaniesScreen — search/sort/pagination (P-14)", () => {
   });
 });
 
+describe("CompaniesScreen — what an account is to us", () => {
+  it("names every relationship type the account carries", async () => {
+    stubFetch(async () =>
+      jsonResponse({
+        data: [
+          {
+            ...org,
+            lifecycle: "prospect",
+            relationship_types: ["partner", "supplier"],
+          },
+        ],
+        page: { next_cursor: null, has_more: false },
+      }),
+    );
+    render(<CompaniesScreen />);
+    await waitFor(() =>
+      expect(screen.getByText("Brandt Automotive GmbH")).toBeTruthy(),
+    );
+
+    // Both, not the first: the field is multi-valued because an account really
+    // can be two things at once, and showing one would make the other look
+    // untrue. The filter offers these values, so the column has to read them
+    // back — a narrowed list that cannot say why a row matched is a list the
+    // reader has to take on faith.
+    expect(screen.getByText("Partner")).toBeTruthy();
+    expect(screen.getByText("Supplier")).toBeTruthy();
+    // And the two columns stay distinct: an account can be a Partner sitting
+    // at Prospect.
+    expect(screen.getByText("Prospect")).toBeTruthy();
+  });
+
+  it("leaves the cell empty when the account carries none", async () => {
+    stubFetch(async () =>
+      jsonResponse({
+        data: [{ ...org, relationship_types: [] }],
+        page: { next_cursor: null, has_more: false },
+      }),
+    );
+    render(<CompaniesScreen />);
+    await waitFor(() =>
+      expect(screen.getByText("Brandt Automotive GmbH")).toBeTruthy(),
+    );
+    expect(screen.queryByText("Partner")).toBeNull();
+  });
+});
+
 describe("CompaniesScreen — list dials reach the server (P-14)", () => {
   it("asks the server to re-sort instead of reordering the rows it holds", async () => {
     const user = userEvent.setup();

--- a/frontend/src/screens/organizations.tsx
+++ b/frontend/src/screens/organizations.tsx
@@ -637,7 +637,13 @@ export function CompaniesScreen() {
             // first would make the second look untrue.
             cell: (org: Organization) =>
               org.relationship_types?.length ? (
-                <span className="row-wrap">
+                <span
+                  style={{
+                    display: "flex",
+                    flexWrap: "wrap",
+                    gap: "var(--space-1)",
+                  }}
+                >
                   {org.relationship_types.map((type) => (
                     <Badge key={type}>
                       {t(RELATIONSHIP_TYPE_LABELS[type])}

--- a/frontend/src/screens/organizations.tsx
+++ b/frontend/src/screens/organizations.tsx
@@ -629,6 +629,24 @@ export function CompaniesScreen() {
               ) : null,
           },
           {
+            key: "relationship",
+            header: t("org.relationshipTypes"),
+            // A filter with no column to read it back on is a list that cannot
+            // say why a row matched. Multi-valued on purpose (ADR-0079/A124):
+            // an account can be a partner AND a customer, and showing only the
+            // first would make the second look untrue.
+            cell: (org: Organization) =>
+              org.relationship_types?.length ? (
+                <span className="row-wrap">
+                  {org.relationship_types.map((type) => (
+                    <Badge key={type}>
+                      {t(RELATIONSHIP_TYPE_LABELS[type])}
+                    </Badge>
+                  ))}
+                </span>
+              ) : null,
+          },
+          {
             key: "owner",
             header: t("list.owner"),
             cell: (org: Organization) => (


### PR DESCRIPTION
## The bug

Pressing **Next** flipped between the first two pages forever. Page 3 was unreachable.

On a name-sorted company list that reads as *"the Korean companies keep coming back"* — they sort first, so every other press of Next put the reader at the top of the alphabet again. That is how Lars found it.

## Cause — mine, from #1583

The table resets to page 1 when `chosen` changes identity, and that rule is right: a reader who narrows the list should not be stranded on a page that no longer exists.

#1583 changed the prop from `chosen={query.filters}` (a stable reference) to `chosen={chosenFor(chips, query.filters)}` — **a fresh object on every render**. So the reset fired on every render: Next advanced the page, the next render sent it straight back.

## Fix

`chosen` is memoized, keyed on the **option values and filter values** rather than on the arrays carrying them. `chips` cannot be the key: screens declare it as an inline array literal, so the array is a new reference each render and memoizing on it would change nothing.

## Why the existing test missed it

`listquery.test.tsx` already covered the pager — but it pressed Next **once**. One press works fine; the reset lands you back on a page whose content happens to match. The bug needs **two** presses to show. The new test pages forward twice and asserts page 3 arrives.

Mutation-checked: reverting the memo fails it.

## Verified in a browser

Against the seeded dev data, sorted by Company, pressing Next three times:

| Press | First row |
|---|---|
| 1 | Emporix |
| 2 | netcare |
| 3 | Strix |

Ending at *"76–91 of 91 companies"*. Before the fix it alternated 엠비젼 → Emporix → 엠비젼 → Emporix.

## Gates

`make check-fe` green — 2922 tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes list paging, data‑driven filters, chip isolation, and adds a Relationship Types column in Companies. Previously, Next flipped between pages 1 and 2, the Owner filter sent the wrong parameter, clearing a chip dropped other filters, and filtered accounts could not show why they matched.

- Memoizes chosen filter state with a stable identity keyed on chip keys/groupings and `query.filters` (JSON) so the table only resets to page 1 when values change.
- Reads declared and data‑driven chips together as `allChips` in `setFilter` and `chosenFor`; splits `param:value` into `param=value`; clears only the parameters for the chip being changed.
- Adds a Relationship Types column to Companies with flex‑wrapped multi‑value badges.
- Adds tests: pager reaches page 3 while waiting for render; dataChip parameter spelling; two‑chip isolation; relationship column renders multiple types and an empty state.

<sup>Written for commit f4f20c22d46d0d1cdd504dfa3cd091018badd2ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1603?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

