### PR TITLE
feat(privacy): the floor covers Handelsbriefe, stamped when the deal concludes

### DIFF
--- a/backend/internal/compose/installseam/installseam.go
+++ b/backend/internal/compose/installseam/installseam.go
@@ -13,6 +13,7 @@
 package installseam
 
 import (
+	"github.com/gradionhq/margince/backend/internal/modules/activities"
 	"github.com/gradionhq/margince/backend/internal/modules/deals"
 	"github.com/gradionhq/margince/backend/internal/modules/identity"
 )
@@ -23,5 +24,8 @@ func Deals() deals.Installation {
 		Name:         identity.NameOf,
 		BaseCurrency: identity.BaseCurrencyOf,
 		Timezone:     identity.TimezoneOf,
+		// activities owns `activity`, so the stamp's write lives there and the
+		// edge is injected here (ADR-0054).
+		StampCorrespondence: activities.StampCorrespondenceForDeal,
 	}
 }

--- a/backend/internal/compose/integration/erasure_integration_test.go
+++ b/backend/internal/compose/integration/erasure_integration_test.go
@@ -413,6 +413,10 @@ func TestErasePersonHonoursCommercialCorrespondenceFloor(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	// The email is a Handelsbrief because it concerns a concluded transaction;
+	// the note is not correspondence at all. A165 narrowed the floor to that
+	// distinction, so the deal is what the shielding now rests on.
+	e.SeedWonDealLinkedTo(t, email)
 
 	if err := privacy.NewEraser(e.DB()).ErasePerson(admin, personID, "test"); err != nil {
 		t.Fatalf("erasing the subject → %v", err)

--- a/backend/internal/compose/integration/harness.go
+++ b/backend/internal/compose/integration/harness.go
@@ -392,3 +392,50 @@ func withFullSignalGrant(base principal.Permissions) principal.Permissions {
 	}
 	return out
 }
+
+// SeedWonDealLinkedTo files the given activities against a WON deal, which is
+// what makes them Handelsbriefe under the statutory correspondence floor
+// (A165/ADR-0114).
+//
+// Before A165 the floor shielded by exclusion — every activity that was not a
+// task or a note — so a fixture testing it needed no deal at all. The floor now
+// covers correspondence about an actual commercial transaction, so a test that
+// wants a shielded record has to supply the transaction. A fixture that skips
+// it does not test a weaker floor; it tests the erasure path, because the
+// records go.
+//
+// The deal is written directly rather than through the store because the store
+// stamps the correspondence itself on the winning transition, and a fixture
+// that used it would prove the stamp works by using the stamp.
+func (e *Env) SeedWonDealLinkedTo(t *testing.T, activities ...ids.UUID) ids.UUID {
+	t.Helper()
+	pipeline, stage, deal := ids.NewV7(), ids.NewV7(), ids.NewV7()
+	err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		ctx := context.Background()
+		ws := `NULLIF(current_setting('app.workspace_id', true), '')::uuid`
+		if _, err := tx.Exec(ctx, `INSERT INTO pipeline (id, workspace_id, name, is_default, position)
+			VALUES ($1, `+ws+`, 'Floor fixture', false, 90)`, pipeline); err != nil {
+			return err
+		}
+		if _, err := tx.Exec(ctx, `INSERT INTO stage (id, workspace_id, pipeline_id, name, position, semantic, win_probability)
+			VALUES ($1, `+ws+`, $2, 'Closed Won', 0, 'won', 100)`, stage, pipeline); err != nil {
+			return err
+		}
+		if _, err := tx.Exec(ctx, `INSERT INTO deal (id, workspace_id, name, status, pipeline_id, stage_id, closed_at, source, captured_by)
+			VALUES ($1, `+ws+`, 'Floor fixture deal', 'won', $2, $3, now(), 'manual', 'human:x')`,
+			deal, pipeline, stage); err != nil {
+			return err
+		}
+		for _, a := range activities {
+			if _, err := tx.Exec(ctx, `INSERT INTO activity_link (workspace_id, activity_id, entity_type, deal_id)
+				VALUES (`+ws+`, $1, 'deal', $2)`, a, deal); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("seeding the qualifying deal: %v", err)
+	}
+	return deal
+}

--- a/backend/internal/compose/integration/privacy_comms_integration_test.go
+++ b/backend/internal/compose/integration/privacy_comms_integration_test.go
@@ -253,6 +253,9 @@ func TestErasureRedactsTheDeliveryBehindARedactedActivity(t *testing.T) {
 	aged := seedDelivery(t, e, "9 years", "Old order confirmation", "the agreed price was 4200 EUR", "sent", mailRecipientEmail, person)
 	agedParked := seedDelivery(t, e, "9 years", "Old quote", "the quote nobody could deliver", "parked", mailRecipientEmail, person)
 	shielded := seedDelivery(t, e, "30 days", "Recent order confirmation", "the agreed price was 900 EUR", "sent", mailRecipientEmail, person)
+	// Age alone no longer shields: A165 narrowed the floor to correspondence
+	// about an actual transaction, so the shielded case needs the transaction.
+	e.SeedWonDealLinkedTo(t, shielded.activity)
 	// The class the link-walk cannot see: a message this installation SENT to
 	// the subject whose activity inherited no person link (its anchor had
 	// none, or was linked to an organization or deal instead). Nothing links
@@ -311,6 +314,9 @@ func TestErasureReachesAMessageWhereTheSubjectIsOnlyACcRecipient(t *testing.T) {
 	held := seedAddressedDelivery(t, e, "9 years", "Disputed renewal quote", "the quote before the dispute", "sent",
 		addresses{counterparty: "buyer@example.test", to: "buyer@example.test", cc: mailRecipientEmail}, ids.UUID{})
 	linkToHeldDeal(t, e, held.activity)
+	// The floor arm needs its transaction now (A165): a fresh message about
+	// nothing commercial is erasable, which is the narrowing, not a regression.
+	e.SeedWonDealLinkedTo(t, fresh.activity)
 
 	if err := privacy.NewEraser(e.DB()).ErasePerson(e.Admin(), person, "test"); err != nil {
 		t.Fatalf("ErasePerson: %v", err)

--- a/backend/internal/compose/integration/retention_jurisdiction_integration_test.go
+++ b/backend/internal/compose/integration/retention_jurisdiction_integration_test.go
@@ -38,6 +38,14 @@ func init() {
 func TestStatutoryFloorShieldsCorrespondenceFromDestruction(t *testing.T) {
 	e := Setup(t)
 	email, note, janEmail, message := ids.NewV7(), ids.NewV7(), ids.NewV7(), ids.NewV7()
+	// unlinkedEmail is the case A165/ADR-0114 NARROWED the floor to exclude: a
+	// 400-day-old email that concerns no commercial transaction. §257 HGB
+	// obliges retention of a Handelsbrief, and a scheduling mail or a marketing
+	// enquiry is not one — shielding it was the over-retention the EDPB names
+	// as applying the legal-obligation exception without case-by-case
+	// assessment. It must be erased where its linked sibling survives, and
+	// that contrast is the whole point of seeding both.
+	unlinkedEmail := ids.NewV7()
 	err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 		ctx := context.Background()
 		wsClause := `NULLIF(current_setting('app.workspace_id', true), '')::uuid`
@@ -75,12 +83,49 @@ func TestStatutoryFloorShieldsCorrespondenceFromDestruction(t *testing.T) {
 		// The §147(4) boundary: a January email six-and-a-half years old.
 		// An occurrence-anchored 6y floor would already expose it; the
 		// calendar-year-end anchor keeps it until its year's end + 6y.
-		_, err := tx.Exec(ctx, `
+		if _, err := tx.Exec(ctx, `
 			INSERT INTO activity (id, workspace_id, kind, subject, body, occurred_at, source, captured_by)
 			VALUES ($1, `+wsClause+`, 'email', 'January Handelsbrief', 'commercial content',
 			        date_trunc('year', now() - interval '6 years') + interval '14 days', 'capture', 'connector:t')`,
-			janEmail)
-		return err
+			janEmail); err != nil {
+			return err
+		}
+		// The control: same age, same kind, no transaction behind it.
+		if _, err := tx.Exec(ctx, `
+			INSERT INTO activity (id, workspace_id, kind, subject, body, occurred_at, source, captured_by)
+			VALUES ($1, `+wsClause+`, 'email', 'Lunch next Tuesday?', 'no transaction here', now() - interval '400 days', 'capture', 'connector:t')`,
+			unlinkedEmail); err != nil {
+			return err
+		}
+		// What makes the other three Handelsbriefe: a WON deal they are filed
+		// against. Before A165 the predicate shielded by exclusion and needed
+		// no deal at all; now the transaction is the thing the obligation
+		// hangs off, so the fixture has to supply one or it proves nothing.
+		pipeline, stage, deal := ids.NewV7(), ids.NewV7(), ids.NewV7()
+		if _, err := tx.Exec(ctx, `
+			INSERT INTO pipeline (id, workspace_id, name, is_default, position)
+			VALUES ($1, `+wsClause+`, 'Default', true, 0)`, pipeline); err != nil {
+			return err
+		}
+		if _, err := tx.Exec(ctx, `
+			INSERT INTO stage (id, workspace_id, pipeline_id, name, position, semantic, win_probability)
+			VALUES ($1, `+wsClause+`, $2, 'Closed Won', 0, 'won', 100)`, stage, pipeline); err != nil {
+			return err
+		}
+		if _, err := tx.Exec(ctx, `
+			INSERT INTO deal (id, workspace_id, name, status, pipeline_id, stage_id, closed_at, source, captured_by)
+			VALUES ($1, `+wsClause+`, 'Acme rollout', 'won', $2, $3, now(), 'api', 'human:t')`,
+			deal, pipeline, stage); err != nil {
+			return err
+		}
+		for _, a := range []ids.UUID{email, janEmail, message} {
+			if _, err := tx.Exec(ctx, `
+				INSERT INTO activity_link (workspace_id, activity_id, entity_type, deal_id)
+				VALUES (`+wsClause+`, $1, 'deal', $2)`, a, deal); err != nil {
+				return err
+			}
+		}
+		return nil
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -91,7 +136,7 @@ func TestStatutoryFloorShieldsCorrespondenceFromDestruction(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	var emailBody, noteBody, janBody, messageBody *string
+	var emailBody, noteBody, janBody, messageBody, unlinkedBody *string
 	err = database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 		if err := tx.QueryRow(context.Background(), `SELECT body FROM activity WHERE id = $1`, email).Scan(&emailBody); err != nil {
 			return err
@@ -100,6 +145,9 @@ func TestStatutoryFloorShieldsCorrespondenceFromDestruction(t *testing.T) {
 			return err
 		}
 		if err := tx.QueryRow(context.Background(), `SELECT body FROM activity WHERE id = $1`, message).Scan(&messageBody); err != nil {
+			return err
+		}
+		if err := tx.QueryRow(context.Background(), `SELECT body FROM activity WHERE id = $1`, unlinkedEmail).Scan(&unlinkedBody); err != nil {
 			return err
 		}
 		return tx.QueryRow(context.Background(), `SELECT body FROM activity WHERE id = $1`, note).Scan(&noteBody)
@@ -118,5 +166,8 @@ func TestStatutoryFloorShieldsCorrespondenceFromDestruction(t *testing.T) {
 	}
 	if noteBody != nil {
 		t.Error("the floor over-shielded: a plain note past the policy age survived")
+	}
+	if unlinkedBody != nil {
+		t.Error("the floor over-shielded: a 400-day-old email concerning no transaction survived — A165 narrowed the floor to Handelsbriefe, and shielding ordinary mail is the over-retention it removed")
 	}
 }

--- a/backend/internal/compose/integration/retention_stamp_integration_test.go
+++ b/backend/internal/compose/integration/retention_stamp_integration_test.go
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// The commercial-correspondence stamp (A165/ADR-0114, A167/ADR-0116).
+//
+// The floor now asks whether an activity is a Handelsbrief — correspondence
+// about an actual commercial transaction — and answers from a stamp written
+// when the deal concluded, not from a link walked at erasure time. These tests
+// drive the REAL winning transition through the deals store, because the whole
+// point of the stamp is that it commits with the transaction that earns it: a
+// fixture that inserted the column by hand would prove the column exists and
+// nothing about the writer.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/gradionhq/margince/backend/internal/modules/deals"
+	"github.com/gradionhq/margince/backend/internal/platform/database"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// stampFixture is one deal, its pipeline, an open and a won stage, and an
+// email filed against the deal before it concluded.
+type stampFixture struct {
+	deal     ids.UUID
+	wonStage ids.StageID
+	email    ids.UUID
+}
+
+func seedStampFixture(t *testing.T, e *Env) stampFixture {
+	t.Helper()
+	pipeline, openStage, wonStage, email := ids.NewV7(), ids.NewV7(), ids.NewV7(), ids.NewV7()
+	e.WsExec(t, `INSERT INTO pipeline (id, workspace_id, name, is_default, position)
+		VALUES ($1, $2, 'Stamp fixture', false, 91)`, pipeline, e.WS)
+	e.WsExec(t, `INSERT INTO stage (id, workspace_id, pipeline_id, name, position, semantic, win_probability)
+		VALUES ($1, $2, $3, 'Qualify', 0, 'open', 10)`, openStage, e.WS, pipeline)
+	e.WsExec(t, `INSERT INTO stage (id, workspace_id, pipeline_id, name, position, semantic, win_probability)
+		VALUES ($1, $2, $3, 'Closed Won', 1, 'won', 100)`, wonStage, e.WS, pipeline)
+
+	deal := e.SeedDeal(t, "Acme rollout",
+		ids.PipelineID{UUID: pipeline}, ids.StageID{UUID: openStage}, nil)
+
+	// Filed against the deal while it is still open, which is the ordinary
+	// order: the correspondence exists before the deal concludes.
+	e.WsExec(t, `INSERT INTO activity (id, workspace_id, kind, subject, body, occurred_at, source, captured_by)
+		VALUES ($1, $2, 'email', 'Order confirmation', 'the agreed price was 4200 EUR', now(), 'manual', 'human:x')`,
+		email, e.WS)
+	e.WsExec(t, `INSERT INTO activity_link (workspace_id, activity_id, entity_type, deal_id)
+		VALUES ($1, $2, 'deal', $3)`, e.WS, email, deal)
+
+	return stampFixture{deal: deal, wonStage: ids.StageID{UUID: wonStage}, email: email}
+}
+
+// wonInput wins a deal without a contract. The paper is a separate obligation
+// from the retention class and these tests are about the class, so the win
+// declares why there is none rather than seeding an agreement to satisfy a
+// guard it is not exercising.
+func wonInput(stage ids.StageID) deals.AdvanceDealInput {
+	reason := "verbal"
+	return deals.AdvanceDealInput{ToStageID: stage, WonWithoutContractReason: &reason}
+}
+
+type stampRow struct {
+	class    *string
+	stampAt  *string
+	evidence int
+	dealName *string
+}
+
+func readStamp(t *testing.T, e *Env, activity ids.UUID) stampRow {
+	t.Helper()
+	var got stampRow
+	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		ctx := context.Background()
+		if err := tx.QueryRow(ctx,
+			`SELECT retention_class, retention_class_at::text FROM activity WHERE id = $1`,
+			activity).Scan(&got.class, &got.stampAt); err != nil {
+			return err
+		}
+		return tx.QueryRow(ctx,
+			`SELECT count(*), max(deal_name) FROM activity_retention_evidence WHERE activity_id = $1`,
+			activity).Scan(&got.evidence, &got.dealName)
+	}); err != nil {
+		t.Fatalf("reading the stamp: %v", err)
+	}
+	return got
+}
+
+// Winning the deal stamps the correspondence filed against it, and records the
+// deal that qualified it — in the same transaction, so there is no window in
+// which an erasure sees the record unclassified.
+func TestWinningADealStampsItsCorrespondence(t *testing.T) {
+	e := Setup(t)
+	f := seedStampFixture(t, e)
+
+	if before := readStamp(t, e, f.email); before.class != nil {
+		t.Fatalf("fixture drift: the email carries a class before the deal concluded (%q)", *before.class)
+	}
+
+	if _, err := e.Deals.AdvanceDeal(e.Admin(), ids.DealID{UUID: f.deal}, wonInput(f.wonStage)); err != nil {
+		t.Fatalf("advancing the deal to won: %v", err)
+	}
+
+	got := readStamp(t, e, f.email)
+	if got.class == nil {
+		t.Fatal("winning the deal left its correspondence unstamped — an unstamped Handelsbrief is one the next erasure destroys")
+	}
+	if *got.class != "commercial_correspondence" {
+		t.Errorf("retention_class = %q, want commercial_correspondence", *got.class)
+	}
+	if got.stampAt == nil {
+		t.Error("the class landed without its timestamp; the stamp's provenance is what a supervisory authority is shown")
+	}
+	if got.evidence != 1 {
+		t.Errorf("evidence rows = %d, want 1 — a stamp with nothing behind it is an assertion the controller cannot substantiate", got.evidence)
+	}
+	if got.dealName == nil || *got.dealName != "Acme rollout" {
+		t.Errorf("evidence deal_name = %v, want the deal's name frozen at qualification", got.dealName)
+	}
+}
+
+// Reopening a won deal never unstamps it. Qualification is reversible in the
+// product and the classification deliberately is not: over-retention is an
+// argument to have with a supervisory authority, destruction is irreversible.
+func TestReopeningAWonDealLeavesTheStampStanding(t *testing.T) {
+	e := Setup(t)
+	f := seedStampFixture(t, e)
+
+	openAgain := ids.NewV7()
+	e.WsExec(t, `INSERT INTO stage (id, workspace_id, pipeline_id, name, position, semantic, win_probability)
+		VALUES ($1, $2, (SELECT pipeline_id FROM stage WHERE id = $3), 'Reopened', 2, 'open', 40)`,
+		openAgain, e.WS, f.wonStage.UUID)
+
+	if _, err := e.Deals.AdvanceDeal(e.Admin(), ids.DealID{UUID: f.deal}, wonInput(f.wonStage)); err != nil {
+		t.Fatalf("advancing to won: %v", err)
+	}
+	if _, err := e.Deals.AdvanceDeal(e.Admin(), ids.DealID{UUID: f.deal},
+		deals.AdvanceDealInput{ToStageID: ids.StageID{UUID: openAgain}}); err != nil {
+		t.Fatalf("reopening the deal: %v", err)
+	}
+
+	got := readStamp(t, e, f.email)
+	if got.class == nil {
+		t.Fatal("reopening the deal unstamped its correspondence — the classification is monotonic precisely because qualification is not")
+	}
+}

--- a/backend/internal/modules/activities/doc.go
+++ b/backend/internal/modules/activities/doc.go
@@ -7,8 +7,8 @@
 // contract mapping + transport handlers + the activities slice of the
 // datasource provider, flat per ADR-0054 §3.
 //
-// Tables owned: activity, activity_link, transcript_read,
-// attachment_extraction.
+// Tables owned: activity, activity_link, activity_retention_evidence,
+// transcript_read, attachment_extraction.
 //
 // transcript_read is the run record for reading a meeting transcript for
 // the next steps in it (S-E04.3): the POST answers 202 with its id and the

--- a/backend/internal/modules/activities/retentionstamp.go
+++ b/backend/internal/modules/activities/retentionstamp.go
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package activities
+
+// Stamping a deal's correspondence as commercial (A165/ADR-0114, A167/ADR-0116).
+//
+// This module owns `activity`, so the write lives here; deals calls it through
+// a seam compose injects, because a module never imports a sibling (ADR-0054).
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// retentionClassCorrespondence is the only class the schema admits today. It
+// is spelled once here and once in the migration's CHECK; the CHECK is what
+// makes a typo a failed write rather than an unshielded record.
+const retentionClassCorrespondence = "commercial_correspondence"
+
+// StampCorrespondenceForDeal marks every activity linked to dealID as
+// commercial correspondence and records what qualified it, inside the caller's
+// transaction.
+//
+// Two properties the callers depend on:
+//
+// IDEMPOTENT. A deal can qualify twice — an offer leaves draft and later the
+// deal is won — and the second qualification must not fail the transaction
+// that concluded it. The stamp is write-once in the database (the
+// activity_refuse_restricted_mutation trigger), so this only stamps rows that
+// carry no class yet, and the evidence insert tolerates the row it already
+// wrote.
+//
+// EVIDENCE FIRST. The restriction guard refuses a restriction with no evidence
+// behind it, and evidence is what a supervisory authority is shown. Both land
+// in this transaction or neither does.
+func StampCorrespondenceForDeal(ctx context.Context, tx pgx.Tx, dealID ids.DealID, basis string) error {
+	// The deal's name is frozen into the evidence at the moment it qualifies,
+	// because a rename or a delete must not take the proof with it.
+	var dealName string
+	if err := tx.QueryRow(ctx,
+		`SELECT name FROM deal WHERE id = $1`, dealID.UUID).Scan(&dealName); err != nil {
+		return fmt.Errorf("read qualifying deal: %w", err)
+	}
+
+	// One statement for both, so a crash between them is impossible: the CTE
+	// stamps the unstamped activities and the insert records why, for every
+	// activity linked to this deal — including ones stamped by an earlier
+	// qualification, which still need THIS basis on the record.
+	if _, err := tx.Exec(ctx, `
+		WITH linked AS (
+		  SELECT DISTINCT l.activity_id AS id
+		    FROM activity_link l
+		   WHERE l.deal_id = $1 AND l.entity_type = 'deal'
+		), stamped AS (
+		  UPDATE activity a
+		     SET retention_class = $2, retention_class_at = now()
+		   WHERE a.id IN (SELECT id FROM linked)
+		     AND a.retention_class IS NULL
+		)
+		INSERT INTO activity_retention_evidence (activity_id, basis, qualified_at, deal_id, deal_name)
+		SELECT id, $3, now(), $1, $4 FROM linked
+		ON CONFLICT DO NOTHING`,
+		dealID.UUID, retentionClassCorrespondence, basis, dealName); err != nil {
+		return fmt.Errorf("stamp deal correspondence: %w", err)
+	}
+	return nil
+}

--- a/backend/internal/modules/deals/deal_advance.go
+++ b/backend/internal/modules/deals/deal_advance.go
@@ -143,6 +143,17 @@ func (s *Store) AdvanceDeal(ctx context.Context, id ids.DealID, in AdvanceDealIn
 		if err := storekit.EmitEvent(ctx, tx, auditID, id.UUID, dealStageChangedPayload(current, in.ToStageID, status, winProbability)); err != nil {
 			return fmt.Errorf("emit deal.stage_changed: %w", err)
 		}
+		// Winning the deal turns the correspondence filed against it into
+		// Handelsbriefe (A165/ADR-0114). Stamped here, in the transaction that
+		// won it: a stamp that landed later would leave a window in which an
+		// erasure sees unclassified correspondence and destroys it. Reopening
+		// the deal never unstamps — the classification is monotonic because
+		// over-retention is arguable and destruction is not.
+		if DealStatus(status) == DealWon {
+			if err := s.stampCorrespondence(ctx, tx, id, BasisDealWon); err != nil {
+				return fmt.Errorf("stamp won deal's correspondence: %w", err)
+			}
+		}
 		if out, err = readDeal(ctx, tx, id, storekit.LiveOnly, active); err != nil {
 			return fmt.Errorf("read advanced deal: %w", err)
 		}

--- a/backend/internal/modules/deals/fxrate_store_test.go
+++ b/backend/internal/modules/deals/fxrate_store_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
 
@@ -117,11 +118,26 @@ func TestEveryUninjectedInstallationSeamRefuses(t *testing.T) {
 	for i := range inst.NumField() {
 		field := inst.Type().Field(i).Name
 		t.Run(field, func(t *testing.T) {
-			seam, ok := inst.Field(i).Interface().(InstallationValue)
-			if !ok || seam == nil {
-				t.Fatalf("%s is nil after orRefusing; an un-injected seam must refuse, not panic", field)
+			// Two seam shapes live on this struct: the InstallationValue
+			// readers, and StampCorrespondence, which writes. Both must refuse
+			// when un-injected, so the test calls whichever this field is
+			// rather than asserting one shape and skipping the other — a
+			// skipped field is a seam nobody proved fails closed.
+			var err error
+			switch seam := inst.Field(i).Interface().(type) {
+			case InstallationValue:
+				if seam == nil {
+					t.Fatalf("%s is nil after orRefusing; an un-injected seam must refuse, not panic", field)
+				}
+				_, err = seam(context.Background(), nil)
+			case StampCorrespondence:
+				if seam == nil {
+					t.Fatalf("%s is nil after orRefusing; an un-injected seam must refuse, not panic", field)
+				}
+				err = seam(context.Background(), nil, ids.DealID{}, BasisDealWon)
+			default:
+				t.Fatalf("%s is neither seam shape; teach this test how to call it", field)
 			}
-			_, err := seam(context.Background(), nil)
 			if err == nil {
 				t.Fatalf("%s resolved a value with nothing injected", field)
 			}

--- a/backend/internal/modules/deals/offer_lifecycle.go
+++ b/backend/internal/modules/deals/offer_lifecycle.go
@@ -103,6 +103,14 @@ func (s *Store) SendOffer(ctx context.Context, id ids.OfferID, ifVersion *int64)
 		if err := storekit.EmitEvent(ctx, tx, auditID, id.UUID, offerSentPayload(current, rate)); err != nil {
 			return fmt.Errorf("emit offer.sent: %w", err)
 		}
+		// An offer leaving draft is the preparation of a Handelsgeschäft
+		// whether or not it closes, so the deal's correspondence qualifies now
+		// (A165/ADR-0114). Sending is the ONLY transition out of draft, so
+		// stamping here covers accepted, rejected, expired and superseded too:
+		// each is reached through a sent offer.
+		if err := s.stampCorrespondence(ctx, tx, ids.DealID{UUID: ids.UUID(current.DealId)}, BasisOfferBeyondDraft); err != nil {
+			return fmt.Errorf("stamp sent offer's correspondence: %w", err)
+		}
 		if out, err = readOfferWithLines(ctx, tx, id, storekit.LiveOnly); err != nil {
 			return fmt.Errorf("read sent offer: %w", err)
 		}

--- a/backend/internal/modules/deals/retentionstamp.go
+++ b/backend/internal/modules/deals/retentionstamp.go
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package deals
+
+// The commercial-correspondence stamp seam (A165/ADR-0114, A167/ADR-0116).
+//
+// When a deal reaches a commercial conclusion, the correspondence already
+// filed against it becomes a Handelsbrief and must be shielded from Art. 17
+// erasure for the statutory period. The stamp records that the moment it is
+// EARNED, and never re-derives it — because qualification is reversible in the
+// product (a won deal can be reopened, a relink drops the link a derivation
+// would read) and of the two ways to be wrong only one destroys data.
+//
+// It runs INSIDE the transaction that concludes the deal, not on the event
+// bus. A subscriber would be eventually consistent, and the gap between the
+// deal closing and the stamp landing is a window in which an erasure sees
+// unclassified correspondence and destroys it. There is no recovering from
+// that, so the stamp commits with the thing that earned it or not at all.
+//
+// deals may not import activities (ADR-0054), so compose injects it.
+
+import (
+	"context"
+	"errors"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// StampCorrespondence marks every activity linked to this deal as commercial
+// correspondence, inside the caller's transaction, and records what qualified
+// it. Implementations are idempotent: the stamp is write-once at the database
+// level, so re-running over an already-stamped activity leaves it alone rather
+// than failing the transaction that concluded the deal.
+//
+// basis names why the deal qualifies — the vocabulary the evidence table
+// admits for a derived qualification.
+type StampCorrespondence func(ctx context.Context, tx pgx.Tx, dealID ids.DealID, basis string) error
+
+// The two derived bases. A deal qualifies by being won, or by carrying an
+// offer that has left draft — a sent Angebot documents the preparation of a
+// Handelsgeschäft whether or not it closed, which is why DEPACK-PARAM-5 prices
+// sent offers alongside accepted ones.
+const (
+	BasisDealWon          = "deal_won"
+	BasisOfferBeyondDraft = "offer_beyond_draft"
+)
+
+// refusingStamp is what an un-injected seam becomes. It fails CLOSED at the
+// first conclusion that needs it rather than silently leaving correspondence
+// unclassified — an unstamped Handelsbrief is one the erasure destroys, and a
+// seam that quietly did nothing would look exactly like one that worked.
+func refusingStamp() StampCorrespondence {
+	return func(context.Context, pgx.Tx, ids.DealID, string) error {
+		return errors.New("deals: the StampCorrespondence seam was not injected; " +
+			"construct this store with installseam.Deals(), which binds activities' " +
+			"StampCorrespondenceForDeal")
+	}
+}

--- a/backend/internal/modules/deals/store.go
+++ b/backend/internal/modules/deals/store.go
@@ -43,6 +43,10 @@ type Store struct {
 	// a conversion rate onto closed deals, so a store that only looked
 	// constructed would write a basis it cannot take back.
 	installation Installation
+
+	// stampCorrespondence shields the correspondence a concluded deal turns
+	// into a Handelsbrief. Injected, because deals may not import activities.
+	stampCorrespondence StampCorrespondence
 }
 
 // InstallationValue resolves ONE installation-identity value inside a
@@ -62,12 +66,21 @@ type Installation struct {
 	BaseCurrency InstallationValue
 	// Timezone is the IANA zone a "today" is computed in.
 	Timezone InstallationValue
+	// StampCorrespondence shields the correspondence a concluded deal turns
+	// into a Handelsbrief (A165/ADR-0114). It rides here rather than on a
+	// WithX setter because every construction site already passes this struct,
+	// and a seam a caller can forget is one that silently stops shielding.
+	StampCorrespondence StampCorrespondence
 }
 
 // NewStore binds the store to the pool every tenant query runs through, and
 // to the seam that answers the installation's own values.
 func NewStore(db *database.DB, inst Installation) *Store {
-	return &Store{db: db, clock: time.Now, installation: inst.orRefusing()}
+	inst = inst.orRefusing()
+	return &Store{
+		db: db, clock: time.Now, installation: inst,
+		stampCorrespondence: inst.StampCorrespondence,
+	}
 }
 
 // orRefusing replaces any value the composition left unset with one that
@@ -83,6 +96,9 @@ func (i Installation) orRefusing() Installation {
 		if *f == nil {
 			*f = refusing(name)
 		}
+	}
+	if i.StampCorrespondence == nil {
+		i.StampCorrespondence = refusingStamp()
 	}
 	return i
 }

--- a/backend/internal/modules/privacy/retention_floor.go
+++ b/backend/internal/modules/privacy/retention_floor.go
@@ -52,10 +52,54 @@ import (
 // A zero floor stringifies to a zero interval, so the ELSE branch reduces to
 // `occurred_at > now()` — nothing is shielded, exactly as before.
 func correspondenceFloorPredicate(intervalArg, anchorArg int) string {
-	return fmt.Sprintf(`AND NOT (a.kind NOT IN ('task','note')
+	// An already-restricted row is out of every destructive path's reach,
+	// unconditionally and before the floor is even considered. The data-layer
+	// guard refuses a write to one, and a refusal inside the nightly pass
+	// fails the whole policy — so a single restricted row left in a selector
+	// would stop every later scope, every night, and a compliance engine that
+	// has silently stopped running looks exactly like one with nothing to do
+	// (A167/ADR-0116). The expiry sweep reaches these rows by its own
+	// selector, which is the only path that may.
+	return fmt.Sprintf(`AND a.restricted_at IS NULL
+		  AND NOT (a.kind NOT IN ('task','note')
+		  AND (`+handelsbriefArm+`)
 		  AND CASE WHEN $%[2]d THEN date_trunc('year', a.occurred_at) + interval '1 year' + $%[1]d::interval > now()
 		           ELSE a.occurred_at > now() - $%[1]d::interval END)`, intervalArg, anchorArg)
 }
+
+// handelsbriefArm answers whether an activity is a Handelsbrief — correspondence
+// about an actual commercial transaction, which is the only thing §257 HGB and
+// §147 AO oblige anybody to keep. It filters an activity aliased `a` and takes
+// no placeholders, so it renumbers nothing at the four call sites.
+//
+// THE STAMP FIRST, the derived rule only as a fallback, and that order is the
+// decision rather than an optimisation (A165/ADR-0114). Qualification is
+// reversible in the product: reopening a won deal clears its terminal fields,
+// and relinking an activity deletes its existing link of that type. A rule
+// that asks the question at erasure time asks it of a record whose evidence
+// may have moved, and answers "ordinary mail" about a genuine Handelsbrief —
+// which destroys it. Over-retention is an argument to have with a supervisory
+// authority; destruction is irreversible.
+//
+// The derived arm stays for rows captured before the stamp existed, where the
+// links are the only evidence there is. It is a floor for legacy data, not the
+// rule: every row a qualifying deal touches from now on carries the stamp
+// (activities.StampCorrespondenceForDeal), and the stamp decides.
+//
+// A deal QUALIFIES when it is won, or carries an offer past draft — a sent
+// Angebot documents the preparation of a Handelsgeschäft whether or not it
+// closed, which is why DEPACK-PARAM-5 prices sent offers at six years
+// alongside accepted ones. An ORGANIZATION link is deliberately not enough: an
+// organization is a party, not a transaction, and a Handelsbrief hangs off the
+// transaction.
+const handelsbriefArm = `a.retention_class IS NOT NULL
+		    OR (a.retention_class IS NULL AND EXISTS (
+		          SELECT 1 FROM activity_link hl
+		          JOIN deal hd ON hd.id = hl.deal_id
+		          WHERE hl.activity_id = a.id AND hl.entity_type = 'deal'
+		            AND (hd.status = 'won'
+		                 OR EXISTS (SELECT 1 FROM offer o
+		                             WHERE o.deal_id = hd.id AND o.status <> 'draft'))))`
 
 // statutoryCorrespondenceFloor is the strictest compiled-in pack's
 // commercial-correspondence class — the boundary below which a

--- a/backend/tableownership_test.go
+++ b/backend/tableownership_test.go
@@ -129,6 +129,10 @@ var tableOwners = map[string]string{
 	"transcript_read":       "internal/modules/activities",
 	"attachment_extraction": "internal/modules/activities",
 	"activity_link":         "internal/modules/activities",
+	// The evidence that qualified an activity for the statutory retention
+	// floor (A165/ADR-0114). It hangs off `activity` and is written by the
+	// stamp, so it belongs to the module that owns the row it substantiates.
+	"activity_retention_evidence": "internal/modules/activities",
 	// ACT-DDL-3: who was in the interaction. It belongs beside activity and
 	// activity_link for the same reason they belong together — it is part of
 	// what an activity IS, not a graph artifact derived from one.


### PR DESCRIPTION
The last behavioural half of A165/ADR-0114, closing #1557. The floor shielded every activity that was not a task or a note; it now covers correspondence about an **actual commercial transaction**, and answers from a stamp rather than a link walked at erasure time.

**The stamp.** Winning a deal, or sending an offer out of draft, marks the correspondence filed against that deal as commercial and records what qualified it. Both run **inside the transaction that concludes the deal**, not on the event bus — a subscriber is eventually consistent, and the gap between the deal closing and the stamp landing is a window in which an erasure sees unclassified correspondence and destroys it. There is no recovering from that.

`deals` may not import `activities`, so the write lives in `activities` and compose injects the edge. It rides on the `Installation` struct rather than a `WithX` setter because all five `NewStore` call sites already pass that struct, and a seam a caller can forget is one that silently stops shielding. Un-injected it refuses, rather than doing nothing quietly.

**The floor reads the stamp first**, falling back to the derived deal/offer rule only for rows captured before the stamp existed. That order is the decision, not an optimisation: qualification is reversible — reopening a won deal clears its terminal fields, relinking drops the link a derivation reads — so asking at erasure time asks a record whose evidence may have moved, and answers "ordinary mail" about a genuine Handelsbrief. Over-retention is an argument to have with a supervisory authority; destruction is irreversible.

**Restricted rows leave every destructive path**, added to the one shared spelling of the floor so all four call sites get it. The data-layer guard refuses a write to a restricted row, and a refusal inside the nightly pass fails the whole policy — so a single restricted row left in a selector would stop every later scope, every night. A compliance engine that has silently stopped running looks exactly like one with nothing to do.

**Four integration fixtures shielded correspondence with no deal behind it**, which this narrowing makes erasable. They now seed the transaction the obligation hangs off, through a harness helper, and the jurisdiction test gains the negative case: a 400-day-old email about nothing commercial is **erased** where its linked sibling survives. That contrast is what the narrowing means, and without it the suite would have gone green on a floor that had quietly stopped narrowing anything.

**Verification**

- `TestWinningADealStampsItsCorrespondence` and `TestReopeningAWonDealLeavesTheStampStanding` drive the real `AdvanceDeal` transition through the store — a fixture that inserted the column by hand would prove the column exists and nothing about the writer.
- **Mutation-checked:** disabling the stamp call makes the first test fail.
- The table-ownership gate bound the moment a writer existed, exactly as predicted; `activity_retention_evidence` is now declared in `tableOwners` and in `activities/doc.go`.

Gates: `make check-backend` exit 0, `make craft-static` clean, `make rls-store-path` and `make no-jurisdiction` OK, and the full `compose/integration` lane green apart from `TestActivityReadsAreScopedThroughLinks`, which **fails identically on clean `origin/main`** and is not from this branch.

Closes #1557.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Narrows the statutory correspondence floor to Handelsbriefe and stamps qualifying activities at the moment a deal concludes. Previously all non-task/note activities were shielded; now only correspondence about an actual transaction is shielded, and erasure checks a persisted stamp first to avoid destroying genuine Handelsbriefe.

- Winning a deal or sending an offer out of draft stamps linked activities inside the same transaction. The write lives in `activities.StampCorrespondenceForDeal` and is called from `deals.AdvanceDeal` and `deals.SendOffer` via a new seam injected by `installseam.Deals()`. Uninjected seams refuse closed.
- The floor predicate now:
  - Exits early for `a.restricted_at IS NULL` only; restricted rows never enter destructive paths.
  - Reads `a.retention_class` first, then falls back to the derived deal/offer rule for legacy rows; organization links do not qualify.
- Evidence is recorded in `activity_retention_evidence`; ownership and docs updated. New integration tests verify stamping; fixtures now seed a won deal via `SeedWonDealLinkedTo`.

**Rollout and migration**

- Construct `deals` stores with `installseam.Deals()` so `StampCorrespondence` is injected; otherwise win/send will fail closed.
- Update tests/fixtures: when expecting shielding, link activities to a won deal or to a deal with a sent offer.
- Expect erasure to remove old emails with no qualifying transaction that were previously kept; no backfill is required because legacy rows still use the derived rule.

<sup>Written for commit 4354e647a5146767e8831ee6b30c4d80b8f6ebfd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1607?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

