### PR TITLE
fix(leads): the promoted lead keeps its page, as ADR-0119 ratified

### DIFF
--- a/backend/internal/compose/installseam/installseam.go
+++ b/backend/internal/compose/installseam/installseam.go
@@ -13,6 +13,7 @@
 package installseam
 
 import (
+	"github.com/gradionhq/margince/backend/internal/modules/activities"
 	"github.com/gradionhq/margince/backend/internal/modules/deals"
 	"github.com/gradionhq/margince/backend/internal/modules/identity"
 )
@@ -23,5 +24,8 @@ func Deals() deals.Installation {
 		Name:         identity.NameOf,
 		BaseCurrency: identity.BaseCurrencyOf,
 		Timezone:     identity.TimezoneOf,
+		// activities owns `activity`, so the stamp's write lives there and the
+		// edge is injected here (ADR-0054).
+		StampCorrespondence: activities.StampCorrespondenceForDeal,
 	}
 }

--- a/backend/internal/compose/integration/erasure_integration_test.go
+++ b/backend/internal/compose/integration/erasure_integration_test.go
@@ -413,6 +413,10 @@ func TestErasePersonHonoursCommercialCorrespondenceFloor(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	// The email is a Handelsbrief because it concerns a concluded transaction;
+	// the note is not correspondence at all. A165 narrowed the floor to that
+	// distinction, so the deal is what the shielding now rests on.
+	e.SeedWonDealLinkedTo(t, email)
 
 	if err := privacy.NewEraser(e.DB()).ErasePerson(admin, personID, "test"); err != nil {
 		t.Fatalf("erasing the subject → %v", err)

--- a/backend/internal/compose/integration/harness.go
+++ b/backend/internal/compose/integration/harness.go
@@ -392,3 +392,50 @@ func withFullSignalGrant(base principal.Permissions) principal.Permissions {
 	}
 	return out
 }
+
+// SeedWonDealLinkedTo files the given activities against a WON deal, which is
+// what makes them Handelsbriefe under the statutory correspondence floor
+// (A165/ADR-0114).
+//
+// Before A165 the floor shielded by exclusion — every activity that was not a
+// task or a note — so a fixture testing it needed no deal at all. The floor now
+// covers correspondence about an actual commercial transaction, so a test that
+// wants a shielded record has to supply the transaction. A fixture that skips
+// it does not test a weaker floor; it tests the erasure path, because the
+// records go.
+//
+// The deal is written directly rather than through the store because the store
+// stamps the correspondence itself on the winning transition, and a fixture
+// that used it would prove the stamp works by using the stamp.
+func (e *Env) SeedWonDealLinkedTo(t *testing.T, activities ...ids.UUID) ids.UUID {
+	t.Helper()
+	pipeline, stage, deal := ids.NewV7(), ids.NewV7(), ids.NewV7()
+	err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		ctx := context.Background()
+		ws := `NULLIF(current_setting('app.workspace_id', true), '')::uuid`
+		if _, err := tx.Exec(ctx, `INSERT INTO pipeline (id, workspace_id, name, is_default, position)
+			VALUES ($1, `+ws+`, 'Floor fixture', false, 90)`, pipeline); err != nil {
+			return err
+		}
+		if _, err := tx.Exec(ctx, `INSERT INTO stage (id, workspace_id, pipeline_id, name, position, semantic, win_probability)
+			VALUES ($1, `+ws+`, $2, 'Closed Won', 0, 'won', 100)`, stage, pipeline); err != nil {
+			return err
+		}
+		if _, err := tx.Exec(ctx, `INSERT INTO deal (id, workspace_id, name, status, pipeline_id, stage_id, closed_at, source, captured_by)
+			VALUES ($1, `+ws+`, 'Floor fixture deal', 'won', $2, $3, now(), 'manual', 'human:x')`,
+			deal, pipeline, stage); err != nil {
+			return err
+		}
+		for _, a := range activities {
+			if _, err := tx.Exec(ctx, `INSERT INTO activity_link (workspace_id, activity_id, entity_type, deal_id)
+				VALUES (`+ws+`, $1, 'deal', $2)`, a, deal); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("seeding the qualifying deal: %v", err)
+	}
+	return deal
+}

--- a/backend/internal/compose/integration/privacy_comms_integration_test.go
+++ b/backend/internal/compose/integration/privacy_comms_integration_test.go
@@ -253,6 +253,9 @@ func TestErasureRedactsTheDeliveryBehindARedactedActivity(t *testing.T) {
 	aged := seedDelivery(t, e, "9 years", "Old order confirmation", "the agreed price was 4200 EUR", "sent", mailRecipientEmail, person)
 	agedParked := seedDelivery(t, e, "9 years", "Old quote", "the quote nobody could deliver", "parked", mailRecipientEmail, person)
 	shielded := seedDelivery(t, e, "30 days", "Recent order confirmation", "the agreed price was 900 EUR", "sent", mailRecipientEmail, person)
+	// Age alone no longer shields: A165 narrowed the floor to correspondence
+	// about an actual transaction, so the shielded case needs the transaction.
+	e.SeedWonDealLinkedTo(t, shielded.activity)
 	// The class the link-walk cannot see: a message this installation SENT to
 	// the subject whose activity inherited no person link (its anchor had
 	// none, or was linked to an organization or deal instead). Nothing links
@@ -311,6 +314,9 @@ func TestErasureReachesAMessageWhereTheSubjectIsOnlyACcRecipient(t *testing.T) {
 	held := seedAddressedDelivery(t, e, "9 years", "Disputed renewal quote", "the quote before the dispute", "sent",
 		addresses{counterparty: "buyer@example.test", to: "buyer@example.test", cc: mailRecipientEmail}, ids.UUID{})
 	linkToHeldDeal(t, e, held.activity)
+	// The floor arm needs its transaction now (A165): a fresh message about
+	// nothing commercial is erasable, which is the narrowing, not a regression.
+	e.SeedWonDealLinkedTo(t, fresh.activity)
 
 	if err := privacy.NewEraser(e.DB()).ErasePerson(e.Admin(), person, "test"); err != nil {
 		t.Fatalf("ErasePerson: %v", err)

--- a/backend/internal/compose/integration/retention_jurisdiction_integration_test.go
+++ b/backend/internal/compose/integration/retention_jurisdiction_integration_test.go
@@ -38,6 +38,14 @@ func init() {
 func TestStatutoryFloorShieldsCorrespondenceFromDestruction(t *testing.T) {
 	e := Setup(t)
 	email, note, janEmail, message := ids.NewV7(), ids.NewV7(), ids.NewV7(), ids.NewV7()
+	// unlinkedEmail is the case A165/ADR-0114 NARROWED the floor to exclude: a
+	// 400-day-old email that concerns no commercial transaction. §257 HGB
+	// obliges retention of a Handelsbrief, and a scheduling mail or a marketing
+	// enquiry is not one — shielding it was the over-retention the EDPB names
+	// as applying the legal-obligation exception without case-by-case
+	// assessment. It must be erased where its linked sibling survives, and
+	// that contrast is the whole point of seeding both.
+	unlinkedEmail := ids.NewV7()
 	err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 		ctx := context.Background()
 		wsClause := `NULLIF(current_setting('app.workspace_id', true), '')::uuid`
@@ -75,12 +83,49 @@ func TestStatutoryFloorShieldsCorrespondenceFromDestruction(t *testing.T) {
 		// The §147(4) boundary: a January email six-and-a-half years old.
 		// An occurrence-anchored 6y floor would already expose it; the
 		// calendar-year-end anchor keeps it until its year's end + 6y.
-		_, err := tx.Exec(ctx, `
+		if _, err := tx.Exec(ctx, `
 			INSERT INTO activity (id, workspace_id, kind, subject, body, occurred_at, source, captured_by)
 			VALUES ($1, `+wsClause+`, 'email', 'January Handelsbrief', 'commercial content',
 			        date_trunc('year', now() - interval '6 years') + interval '14 days', 'capture', 'connector:t')`,
-			janEmail)
-		return err
+			janEmail); err != nil {
+			return err
+		}
+		// The control: same age, same kind, no transaction behind it.
+		if _, err := tx.Exec(ctx, `
+			INSERT INTO activity (id, workspace_id, kind, subject, body, occurred_at, source, captured_by)
+			VALUES ($1, `+wsClause+`, 'email', 'Lunch next Tuesday?', 'no transaction here', now() - interval '400 days', 'capture', 'connector:t')`,
+			unlinkedEmail); err != nil {
+			return err
+		}
+		// What makes the other three Handelsbriefe: a WON deal they are filed
+		// against. Before A165 the predicate shielded by exclusion and needed
+		// no deal at all; now the transaction is the thing the obligation
+		// hangs off, so the fixture has to supply one or it proves nothing.
+		pipeline, stage, deal := ids.NewV7(), ids.NewV7(), ids.NewV7()
+		if _, err := tx.Exec(ctx, `
+			INSERT INTO pipeline (id, workspace_id, name, is_default, position)
+			VALUES ($1, `+wsClause+`, 'Default', true, 0)`, pipeline); err != nil {
+			return err
+		}
+		if _, err := tx.Exec(ctx, `
+			INSERT INTO stage (id, workspace_id, pipeline_id, name, position, semantic, win_probability)
+			VALUES ($1, `+wsClause+`, $2, 'Closed Won', 0, 'won', 100)`, stage, pipeline); err != nil {
+			return err
+		}
+		if _, err := tx.Exec(ctx, `
+			INSERT INTO deal (id, workspace_id, name, status, pipeline_id, stage_id, closed_at, source, captured_by)
+			VALUES ($1, `+wsClause+`, 'Acme rollout', 'won', $2, $3, now(), 'api', 'human:t')`,
+			deal, pipeline, stage); err != nil {
+			return err
+		}
+		for _, a := range []ids.UUID{email, janEmail, message} {
+			if _, err := tx.Exec(ctx, `
+				INSERT INTO activity_link (workspace_id, activity_id, entity_type, deal_id)
+				VALUES (`+wsClause+`, $1, 'deal', $2)`, a, deal); err != nil {
+				return err
+			}
+		}
+		return nil
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -91,7 +136,7 @@ func TestStatutoryFloorShieldsCorrespondenceFromDestruction(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	var emailBody, noteBody, janBody, messageBody *string
+	var emailBody, noteBody, janBody, messageBody, unlinkedBody *string
 	err = database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 		if err := tx.QueryRow(context.Background(), `SELECT body FROM activity WHERE id = $1`, email).Scan(&emailBody); err != nil {
 			return err
@@ -100,6 +145,9 @@ func TestStatutoryFloorShieldsCorrespondenceFromDestruction(t *testing.T) {
 			return err
 		}
 		if err := tx.QueryRow(context.Background(), `SELECT body FROM activity WHERE id = $1`, message).Scan(&messageBody); err != nil {
+			return err
+		}
+		if err := tx.QueryRow(context.Background(), `SELECT body FROM activity WHERE id = $1`, unlinkedEmail).Scan(&unlinkedBody); err != nil {
 			return err
 		}
 		return tx.QueryRow(context.Background(), `SELECT body FROM activity WHERE id = $1`, note).Scan(&noteBody)
@@ -118,5 +166,8 @@ func TestStatutoryFloorShieldsCorrespondenceFromDestruction(t *testing.T) {
 	}
 	if noteBody != nil {
 		t.Error("the floor over-shielded: a plain note past the policy age survived")
+	}
+	if unlinkedBody != nil {
+		t.Error("the floor over-shielded: a 400-day-old email concerning no transaction survived — A165 narrowed the floor to Handelsbriefe, and shielding ordinary mail is the over-retention it removed")
 	}
 }

--- a/backend/internal/compose/integration/retention_stamp_integration_test.go
+++ b/backend/internal/compose/integration/retention_stamp_integration_test.go
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// The commercial-correspondence stamp (A165/ADR-0114, A167/ADR-0116).
+//
+// The floor now asks whether an activity is a Handelsbrief — correspondence
+// about an actual commercial transaction — and answers from a stamp written
+// when the deal concluded, not from a link walked at erasure time. These tests
+// drive the REAL winning transition through the deals store, because the whole
+// point of the stamp is that it commits with the transaction that earns it: a
+// fixture that inserted the column by hand would prove the column exists and
+// nothing about the writer.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/gradionhq/margince/backend/internal/modules/deals"
+	"github.com/gradionhq/margince/backend/internal/platform/database"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// stampFixture is one deal, its pipeline, an open and a won stage, and an
+// email filed against the deal before it concluded.
+type stampFixture struct {
+	deal     ids.UUID
+	wonStage ids.StageID
+	email    ids.UUID
+}
+
+func seedStampFixture(t *testing.T, e *Env) stampFixture {
+	t.Helper()
+	pipeline, openStage, wonStage, email := ids.NewV7(), ids.NewV7(), ids.NewV7(), ids.NewV7()
+	e.WsExec(t, `INSERT INTO pipeline (id, workspace_id, name, is_default, position)
+		VALUES ($1, $2, 'Stamp fixture', false, 91)`, pipeline, e.WS)
+	e.WsExec(t, `INSERT INTO stage (id, workspace_id, pipeline_id, name, position, semantic, win_probability)
+		VALUES ($1, $2, $3, 'Qualify', 0, 'open', 10)`, openStage, e.WS, pipeline)
+	e.WsExec(t, `INSERT INTO stage (id, workspace_id, pipeline_id, name, position, semantic, win_probability)
+		VALUES ($1, $2, $3, 'Closed Won', 1, 'won', 100)`, wonStage, e.WS, pipeline)
+
+	deal := e.SeedDeal(t, "Acme rollout",
+		ids.PipelineID{UUID: pipeline}, ids.StageID{UUID: openStage}, nil)
+
+	// Filed against the deal while it is still open, which is the ordinary
+	// order: the correspondence exists before the deal concludes.
+	e.WsExec(t, `INSERT INTO activity (id, workspace_id, kind, subject, body, occurred_at, source, captured_by)
+		VALUES ($1, $2, 'email', 'Order confirmation', 'the agreed price was 4200 EUR', now(), 'manual', 'human:x')`,
+		email, e.WS)
+	e.WsExec(t, `INSERT INTO activity_link (workspace_id, activity_id, entity_type, deal_id)
+		VALUES ($1, $2, 'deal', $3)`, e.WS, email, deal)
+
+	return stampFixture{deal: deal, wonStage: ids.StageID{UUID: wonStage}, email: email}
+}
+
+// wonInput wins a deal without a contract. The paper is a separate obligation
+// from the retention class and these tests are about the class, so the win
+// declares why there is none rather than seeding an agreement to satisfy a
+// guard it is not exercising.
+func wonInput(stage ids.StageID) deals.AdvanceDealInput {
+	reason := "verbal"
+	return deals.AdvanceDealInput{ToStageID: stage, WonWithoutContractReason: &reason}
+}
+
+type stampRow struct {
+	class    *string
+	stampAt  *string
+	evidence int
+	dealName *string
+}
+
+func readStamp(t *testing.T, e *Env, activity ids.UUID) stampRow {
+	t.Helper()
+	var got stampRow
+	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		ctx := context.Background()
+		if err := tx.QueryRow(ctx,
+			`SELECT retention_class, retention_class_at::text FROM activity WHERE id = $1`,
+			activity).Scan(&got.class, &got.stampAt); err != nil {
+			return err
+		}
+		return tx.QueryRow(ctx,
+			`SELECT count(*), max(deal_name) FROM activity_retention_evidence WHERE activity_id = $1`,
+			activity).Scan(&got.evidence, &got.dealName)
+	}); err != nil {
+		t.Fatalf("reading the stamp: %v", err)
+	}
+	return got
+}
+
+// Winning the deal stamps the correspondence filed against it, and records the
+// deal that qualified it — in the same transaction, so there is no window in
+// which an erasure sees the record unclassified.
+func TestWinningADealStampsItsCorrespondence(t *testing.T) {
+	e := Setup(t)
+	f := seedStampFixture(t, e)
+
+	if before := readStamp(t, e, f.email); before.class != nil {
+		t.Fatalf("fixture drift: the email carries a class before the deal concluded (%q)", *before.class)
+	}
+
+	if _, err := e.Deals.AdvanceDeal(e.Admin(), ids.DealID{UUID: f.deal}, wonInput(f.wonStage)); err != nil {
+		t.Fatalf("advancing the deal to won: %v", err)
+	}
+
+	got := readStamp(t, e, f.email)
+	if got.class == nil {
+		t.Fatal("winning the deal left its correspondence unstamped — an unstamped Handelsbrief is one the next erasure destroys")
+	}
+	if *got.class != "commercial_correspondence" {
+		t.Errorf("retention_class = %q, want commercial_correspondence", *got.class)
+	}
+	if got.stampAt == nil {
+		t.Error("the class landed without its timestamp; the stamp's provenance is what a supervisory authority is shown")
+	}
+	if got.evidence != 1 {
+		t.Errorf("evidence rows = %d, want 1 — a stamp with nothing behind it is an assertion the controller cannot substantiate", got.evidence)
+	}
+	if got.dealName == nil || *got.dealName != "Acme rollout" {
+		t.Errorf("evidence deal_name = %v, want the deal's name frozen at qualification", got.dealName)
+	}
+}
+
+// Reopening a won deal never unstamps it. Qualification is reversible in the
+// product and the classification deliberately is not: over-retention is an
+// argument to have with a supervisory authority, destruction is irreversible.
+func TestReopeningAWonDealLeavesTheStampStanding(t *testing.T) {
+	e := Setup(t)
+	f := seedStampFixture(t, e)
+
+	openAgain := ids.NewV7()
+	e.WsExec(t, `INSERT INTO stage (id, workspace_id, pipeline_id, name, position, semantic, win_probability)
+		VALUES ($1, $2, (SELECT pipeline_id FROM stage WHERE id = $3), 'Reopened', 2, 'open', 40)`,
+		openAgain, e.WS, f.wonStage.UUID)
+
+	if _, err := e.Deals.AdvanceDeal(e.Admin(), ids.DealID{UUID: f.deal}, wonInput(f.wonStage)); err != nil {
+		t.Fatalf("advancing to won: %v", err)
+	}
+	if _, err := e.Deals.AdvanceDeal(e.Admin(), ids.DealID{UUID: f.deal},
+		deals.AdvanceDealInput{ToStageID: ids.StageID{UUID: openAgain}}); err != nil {
+		t.Fatalf("reopening the deal: %v", err)
+	}
+
+	got := readStamp(t, e, f.email)
+	if got.class == nil {
+		t.Fatal("reopening the deal unstamped its correspondence — the classification is monotonic precisely because qualification is not")
+	}
+}

--- a/backend/internal/modules/activities/doc.go
+++ b/backend/internal/modules/activities/doc.go
@@ -7,8 +7,8 @@
 // contract mapping + transport handlers + the activities slice of the
 // datasource provider, flat per ADR-0054 §3.
 //
-// Tables owned: activity, activity_link, transcript_read,
-// attachment_extraction.
+// Tables owned: activity, activity_link, activity_retention_evidence,
+// transcript_read, attachment_extraction.
 //
 // transcript_read is the run record for reading a meeting transcript for
 // the next steps in it (S-E04.3): the POST answers 202 with its id and the

--- a/backend/internal/modules/activities/retentionstamp.go
+++ b/backend/internal/modules/activities/retentionstamp.go
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package activities
+
+// Stamping a deal's correspondence as commercial (A165/ADR-0114, A167/ADR-0116).
+//
+// This module owns `activity`, so the write lives here; deals calls it through
+// a seam compose injects, because a module never imports a sibling (ADR-0054).
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// retentionClassCorrespondence is the only class the schema admits today. It
+// is spelled once here and once in the migration's CHECK; the CHECK is what
+// makes a typo a failed write rather than an unshielded record.
+const retentionClassCorrespondence = "commercial_correspondence"
+
+// StampCorrespondenceForDeal marks every activity linked to dealID as
+// commercial correspondence and records what qualified it, inside the caller's
+// transaction.
+//
+// Two properties the callers depend on:
+//
+// IDEMPOTENT. A deal can qualify twice — an offer leaves draft and later the
+// deal is won — and the second qualification must not fail the transaction
+// that concluded it. The stamp is write-once in the database (the
+// activity_refuse_restricted_mutation trigger), so this only stamps rows that
+// carry no class yet, and the evidence insert tolerates the row it already
+// wrote.
+//
+// EVIDENCE FIRST. The restriction guard refuses a restriction with no evidence
+// behind it, and evidence is what a supervisory authority is shown. Both land
+// in this transaction or neither does.
+func StampCorrespondenceForDeal(ctx context.Context, tx pgx.Tx, dealID ids.DealID, basis string) error {
+	// The deal's name is frozen into the evidence at the moment it qualifies,
+	// because a rename or a delete must not take the proof with it.
+	var dealName string
+	if err := tx.QueryRow(ctx,
+		`SELECT name FROM deal WHERE id = $1`, dealID.UUID).Scan(&dealName); err != nil {
+		return fmt.Errorf("read qualifying deal: %w", err)
+	}
+
+	// One statement for both, so a crash between them is impossible: the CTE
+	// stamps the unstamped activities and the insert records why, for every
+	// activity linked to this deal — including ones stamped by an earlier
+	// qualification, which still need THIS basis on the record.
+	if _, err := tx.Exec(ctx, `
+		WITH linked AS (
+		  SELECT DISTINCT l.activity_id AS id
+		    FROM activity_link l
+		   WHERE l.deal_id = $1 AND l.entity_type = 'deal'
+		), stamped AS (
+		  UPDATE activity a
+		     SET retention_class = $2, retention_class_at = now()
+		   WHERE a.id IN (SELECT id FROM linked)
+		     AND a.retention_class IS NULL
+		)
+		INSERT INTO activity_retention_evidence (activity_id, basis, qualified_at, deal_id, deal_name)
+		SELECT id, $3, now(), $1, $4 FROM linked
+		ON CONFLICT DO NOTHING`,
+		dealID.UUID, retentionClassCorrespondence, basis, dealName); err != nil {
+		return fmt.Errorf("stamp deal correspondence: %w", err)
+	}
+	return nil
+}

--- a/backend/internal/modules/deals/deal_advance.go
+++ b/backend/internal/modules/deals/deal_advance.go
@@ -143,6 +143,17 @@ func (s *Store) AdvanceDeal(ctx context.Context, id ids.DealID, in AdvanceDealIn
 		if err := storekit.EmitEvent(ctx, tx, auditID, id.UUID, dealStageChangedPayload(current, in.ToStageID, status, winProbability)); err != nil {
 			return fmt.Errorf("emit deal.stage_changed: %w", err)
 		}
+		// Winning the deal turns the correspondence filed against it into
+		// Handelsbriefe (A165/ADR-0114). Stamped here, in the transaction that
+		// won it: a stamp that landed later would leave a window in which an
+		// erasure sees unclassified correspondence and destroys it. Reopening
+		// the deal never unstamps — the classification is monotonic because
+		// over-retention is arguable and destruction is not.
+		if DealStatus(status) == DealWon {
+			if err := s.stampCorrespondence(ctx, tx, id, BasisDealWon); err != nil {
+				return fmt.Errorf("stamp won deal's correspondence: %w", err)
+			}
+		}
 		if out, err = readDeal(ctx, tx, id, storekit.LiveOnly, active); err != nil {
 			return fmt.Errorf("read advanced deal: %w", err)
 		}

--- a/backend/internal/modules/deals/fxrate_store_test.go
+++ b/backend/internal/modules/deals/fxrate_store_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
 
@@ -117,11 +118,26 @@ func TestEveryUninjectedInstallationSeamRefuses(t *testing.T) {
 	for i := range inst.NumField() {
 		field := inst.Type().Field(i).Name
 		t.Run(field, func(t *testing.T) {
-			seam, ok := inst.Field(i).Interface().(InstallationValue)
-			if !ok || seam == nil {
-				t.Fatalf("%s is nil after orRefusing; an un-injected seam must refuse, not panic", field)
+			// Two seam shapes live on this struct: the InstallationValue
+			// readers, and StampCorrespondence, which writes. Both must refuse
+			// when un-injected, so the test calls whichever this field is
+			// rather than asserting one shape and skipping the other — a
+			// skipped field is a seam nobody proved fails closed.
+			var err error
+			switch seam := inst.Field(i).Interface().(type) {
+			case InstallationValue:
+				if seam == nil {
+					t.Fatalf("%s is nil after orRefusing; an un-injected seam must refuse, not panic", field)
+				}
+				_, err = seam(context.Background(), nil)
+			case StampCorrespondence:
+				if seam == nil {
+					t.Fatalf("%s is nil after orRefusing; an un-injected seam must refuse, not panic", field)
+				}
+				err = seam(context.Background(), nil, ids.DealID{}, BasisDealWon)
+			default:
+				t.Fatalf("%s is neither seam shape; teach this test how to call it", field)
 			}
-			_, err := seam(context.Background(), nil)
 			if err == nil {
 				t.Fatalf("%s resolved a value with nothing injected", field)
 			}

--- a/backend/internal/modules/deals/offer_lifecycle.go
+++ b/backend/internal/modules/deals/offer_lifecycle.go
@@ -103,6 +103,14 @@ func (s *Store) SendOffer(ctx context.Context, id ids.OfferID, ifVersion *int64)
 		if err := storekit.EmitEvent(ctx, tx, auditID, id.UUID, offerSentPayload(current, rate)); err != nil {
 			return fmt.Errorf("emit offer.sent: %w", err)
 		}
+		// An offer leaving draft is the preparation of a Handelsgeschäft
+		// whether or not it closes, so the deal's correspondence qualifies now
+		// (A165/ADR-0114). Sending is the ONLY transition out of draft, so
+		// stamping here covers accepted, rejected, expired and superseded too:
+		// each is reached through a sent offer.
+		if err := s.stampCorrespondence(ctx, tx, ids.DealID{UUID: ids.UUID(current.DealId)}, BasisOfferBeyondDraft); err != nil {
+			return fmt.Errorf("stamp sent offer's correspondence: %w", err)
+		}
 		if out, err = readOfferWithLines(ctx, tx, id, storekit.LiveOnly); err != nil {
 			return fmt.Errorf("read sent offer: %w", err)
 		}

--- a/backend/internal/modules/deals/retentionstamp.go
+++ b/backend/internal/modules/deals/retentionstamp.go
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package deals
+
+// The commercial-correspondence stamp seam (A165/ADR-0114, A167/ADR-0116).
+//
+// When a deal reaches a commercial conclusion, the correspondence already
+// filed against it becomes a Handelsbrief and must be shielded from Art. 17
+// erasure for the statutory period. The stamp records that the moment it is
+// EARNED, and never re-derives it — because qualification is reversible in the
+// product (a won deal can be reopened, a relink drops the link a derivation
+// would read) and of the two ways to be wrong only one destroys data.
+//
+// It runs INSIDE the transaction that concludes the deal, not on the event
+// bus. A subscriber would be eventually consistent, and the gap between the
+// deal closing and the stamp landing is a window in which an erasure sees
+// unclassified correspondence and destroys it. There is no recovering from
+// that, so the stamp commits with the thing that earned it or not at all.
+//
+// deals may not import activities (ADR-0054), so compose injects it.
+
+import (
+	"context"
+	"errors"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// StampCorrespondence marks every activity linked to this deal as commercial
+// correspondence, inside the caller's transaction, and records what qualified
+// it. Implementations are idempotent: the stamp is write-once at the database
+// level, so re-running over an already-stamped activity leaves it alone rather
+// than failing the transaction that concluded the deal.
+//
+// basis names why the deal qualifies — the vocabulary the evidence table
+// admits for a derived qualification.
+type StampCorrespondence func(ctx context.Context, tx pgx.Tx, dealID ids.DealID, basis string) error
+
+// The two derived bases. A deal qualifies by being won, or by carrying an
+// offer that has left draft — a sent Angebot documents the preparation of a
+// Handelsgeschäft whether or not it closed, which is why DEPACK-PARAM-5 prices
+// sent offers alongside accepted ones.
+const (
+	BasisDealWon          = "deal_won"
+	BasisOfferBeyondDraft = "offer_beyond_draft"
+)
+
+// refusingStamp is what an un-injected seam becomes. It fails CLOSED at the
+// first conclusion that needs it rather than silently leaving correspondence
+// unclassified — an unstamped Handelsbrief is one the erasure destroys, and a
+// seam that quietly did nothing would look exactly like one that worked.
+func refusingStamp() StampCorrespondence {
+	return func(context.Context, pgx.Tx, ids.DealID, string) error {
+		return errors.New("deals: the StampCorrespondence seam was not injected; " +
+			"construct this store with installseam.Deals(), which binds activities' " +
+			"StampCorrespondenceForDeal")
+	}
+}

--- a/backend/internal/modules/deals/store.go
+++ b/backend/internal/modules/deals/store.go
@@ -43,6 +43,10 @@ type Store struct {
 	// a conversion rate onto closed deals, so a store that only looked
 	// constructed would write a basis it cannot take back.
 	installation Installation
+
+	// stampCorrespondence shields the correspondence a concluded deal turns
+	// into a Handelsbrief. Injected, because deals may not import activities.
+	stampCorrespondence StampCorrespondence
 }
 
 // InstallationValue resolves ONE installation-identity value inside a
@@ -62,12 +66,21 @@ type Installation struct {
 	BaseCurrency InstallationValue
 	// Timezone is the IANA zone a "today" is computed in.
 	Timezone InstallationValue
+	// StampCorrespondence shields the correspondence a concluded deal turns
+	// into a Handelsbrief (A165/ADR-0114). It rides here rather than on a
+	// WithX setter because every construction site already passes this struct,
+	// and a seam a caller can forget is one that silently stops shielding.
+	StampCorrespondence StampCorrespondence
 }
 
 // NewStore binds the store to the pool every tenant query runs through, and
 // to the seam that answers the installation's own values.
 func NewStore(db *database.DB, inst Installation) *Store {
-	return &Store{db: db, clock: time.Now, installation: inst.orRefusing()}
+	inst = inst.orRefusing()
+	return &Store{
+		db: db, clock: time.Now, installation: inst,
+		stampCorrespondence: inst.StampCorrespondence,
+	}
 }
 
 // orRefusing replaces any value the composition left unset with one that
@@ -83,6 +96,9 @@ func (i Installation) orRefusing() Installation {
 		if *f == nil {
 			*f = refusing(name)
 		}
+	}
+	if i.StampCorrespondence == nil {
+		i.StampCorrespondence = refusingStamp()
 	}
 	return i
 }

--- a/backend/internal/modules/privacy/retention_floor.go
+++ b/backend/internal/modules/privacy/retention_floor.go
@@ -52,10 +52,54 @@ import (
 // A zero floor stringifies to a zero interval, so the ELSE branch reduces to
 // `occurred_at > now()` — nothing is shielded, exactly as before.
 func correspondenceFloorPredicate(intervalArg, anchorArg int) string {
-	return fmt.Sprintf(`AND NOT (a.kind NOT IN ('task','note')
+	// An already-restricted row is out of every destructive path's reach,
+	// unconditionally and before the floor is even considered. The data-layer
+	// guard refuses a write to one, and a refusal inside the nightly pass
+	// fails the whole policy — so a single restricted row left in a selector
+	// would stop every later scope, every night, and a compliance engine that
+	// has silently stopped running looks exactly like one with nothing to do
+	// (A167/ADR-0116). The expiry sweep reaches these rows by its own
+	// selector, which is the only path that may.
+	return fmt.Sprintf(`AND a.restricted_at IS NULL
+		  AND NOT (a.kind NOT IN ('task','note')
+		  AND (`+handelsbriefArm+`)
 		  AND CASE WHEN $%[2]d THEN date_trunc('year', a.occurred_at) + interval '1 year' + $%[1]d::interval > now()
 		           ELSE a.occurred_at > now() - $%[1]d::interval END)`, intervalArg, anchorArg)
 }
+
+// handelsbriefArm answers whether an activity is a Handelsbrief — correspondence
+// about an actual commercial transaction, which is the only thing §257 HGB and
+// §147 AO oblige anybody to keep. It filters an activity aliased `a` and takes
+// no placeholders, so it renumbers nothing at the four call sites.
+//
+// THE STAMP FIRST, the derived rule only as a fallback, and that order is the
+// decision rather than an optimisation (A165/ADR-0114). Qualification is
+// reversible in the product: reopening a won deal clears its terminal fields,
+// and relinking an activity deletes its existing link of that type. A rule
+// that asks the question at erasure time asks it of a record whose evidence
+// may have moved, and answers "ordinary mail" about a genuine Handelsbrief —
+// which destroys it. Over-retention is an argument to have with a supervisory
+// authority; destruction is irreversible.
+//
+// The derived arm stays for rows captured before the stamp existed, where the
+// links are the only evidence there is. It is a floor for legacy data, not the
+// rule: every row a qualifying deal touches from now on carries the stamp
+// (activities.StampCorrespondenceForDeal), and the stamp decides.
+//
+// A deal QUALIFIES when it is won, or carries an offer past draft — a sent
+// Angebot documents the preparation of a Handelsgeschäft whether or not it
+// closed, which is why DEPACK-PARAM-5 prices sent offers at six years
+// alongside accepted ones. An ORGANIZATION link is deliberately not enough: an
+// organization is a party, not a transaction, and a Handelsbrief hangs off the
+// transaction.
+const handelsbriefArm = `a.retention_class IS NOT NULL
+		    OR (a.retention_class IS NULL AND EXISTS (
+		          SELECT 1 FROM activity_link hl
+		          JOIN deal hd ON hd.id = hl.deal_id
+		          WHERE hl.activity_id = a.id AND hl.entity_type = 'deal'
+		            AND (hd.status = 'won'
+		                 OR EXISTS (SELECT 1 FROM offer o
+		                             WHERE o.deal_id = hd.id AND o.status <> 'draft'))))`
 
 // statutoryCorrespondenceFloor is the strictest compiled-in pack's
 // commercial-correspondence class — the boundary below which a

--- a/backend/tableownership_test.go
+++ b/backend/tableownership_test.go
@@ -129,6 +129,10 @@ var tableOwners = map[string]string{
 	"transcript_read":       "internal/modules/activities",
 	"attachment_extraction": "internal/modules/activities",
 	"activity_link":         "internal/modules/activities",
+	// The evidence that qualified an activity for the statutory retention
+	// floor (A165/ADR-0114). It hangs off `activity` and is written by the
+	// stamp, so it belongs to the module that owns the row it substantiates.
+	"activity_retention_evidence": "internal/modules/activities",
 	// ACT-DDL-3: who was in the interaction. It belongs beside activity and
 	// activity_link for the same reason they belong together — it is part of
 	// what an activity IS, not a graph artifact derived from one.

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -1290,6 +1290,12 @@ export const de = {
   "lead.promotedAt": "Übernommen am",
   "lead.promotedTrigger": "Auslöser:",
   "lead.promotedEvidence": "Beleg:",
+  "lead.promotedOutcomePending":
+    "Wird gelesen, was diese Übernahme bewirkt hat …",
+  "lead.promotedOutcomeUnavailable":
+    "Wir können nicht anzeigen, ob dabei zusammengeführt oder neu angelegt wurde.",
+  "lead.terminalPromoted":
+    "Übernommen — dieser Lead ist jetzt schreibgeschützt.",
   "lead.statusNew": "Neu",
   "lead.statusWorking": "In Bearbeitung",
   "lead.statusPromoted": "Übernommen",

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -1283,6 +1283,13 @@ export const de = {
   "lead.filterScoreWarm": "Ab 60",
   "lead.filterScoreCool": "Ab 40",
   "person.fromLead": "Aus Lead übernommen",
+  "lead.promotedTitle": "Als Kontakt übernommen",
+  "lead.promotedMerged":
+    "Dieser Lead wurde mit einem bereits bekannten Kontakt zusammengeführt — es entstand kein Duplikat.",
+  "lead.promotedCreated": "Aus diesem Lead wurde ein neuer Kontakt.",
+  "lead.promotedAt": "Übernommen am",
+  "lead.promotedTrigger": "Auslöser:",
+  "lead.promotedEvidence": "Beleg:",
   "lead.statusNew": "Neu",
   "lead.statusWorking": "In Bearbeitung",
   "lead.statusPromoted": "Übernommen",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -1299,6 +1299,10 @@ export const en = {
   "lead.promotedAt": "Promoted",
   "lead.promotedTrigger": "Trigger:",
   "lead.promotedEvidence": "Evidence:",
+  "lead.promotedOutcomePending": "Reading what this promotion did…",
+  "lead.promotedOutcomeUnavailable":
+    "We cannot show whether this merged or created a contact.",
+  "lead.terminalPromoted": "Promoted — this lead is now read-only.",
   "lead.statusNew": "New",
   "lead.statusWorking": "Working",
   "lead.statusPromoted": "Promoted",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -1292,6 +1292,13 @@ export const en = {
   "lead.filterScoreWarm": "60 and up",
   "lead.filterScoreCool": "40 and up",
   "person.fromLead": "From lead",
+  "lead.promotedTitle": "Promoted to a contact",
+  "lead.promotedMerged":
+    "This lead merged into a contact we already knew — no duplicate was created.",
+  "lead.promotedCreated": "This lead became a new contact.",
+  "lead.promotedAt": "Promoted",
+  "lead.promotedTrigger": "Trigger:",
+  "lead.promotedEvidence": "Evidence:",
   "lead.statusNew": "New",
   "lead.statusWorking": "Working",
   "lead.statusPromoted": "Promoted",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -1284,6 +1284,14 @@ export const vi = {
   "lead.filterScoreWarm": "Từ 60",
   "lead.filterScoreCool": "Từ 40",
   "person.fromLead": "Từ khách hàng tiềm năng",
+  "lead.promotedTitle": "Đã chuyển thành liên hệ",
+  "lead.promotedMerged":
+    "Khách hàng tiềm năng này đã được gộp vào một liên hệ đã biết — không tạo bản trùng.",
+  "lead.promotedCreated":
+    "Khách hàng tiềm năng này đã trở thành một liên hệ mới.",
+  "lead.promotedAt": "Đã chuyển",
+  "lead.promotedTrigger": "Tác nhân:",
+  "lead.promotedEvidence": "Bằng chứng:",
   "lead.statusNew": "Mới",
   "lead.statusWorking": "Đang xử lý",
   "lead.statusPromoted": "Đã chuyển đổi",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -1292,6 +1292,11 @@ export const vi = {
   "lead.promotedAt": "Đã chuyển",
   "lead.promotedTrigger": "Tác nhân:",
   "lead.promotedEvidence": "Bằng chứng:",
+  "lead.promotedOutcomePending": "Đang đọc kết quả của lần chuyển này…",
+  "lead.promotedOutcomeUnavailable":
+    "Không thể hiển thị việc này đã gộp hay tạo liên hệ mới.",
+  "lead.terminalPromoted":
+    "Đã chuyển — khách hàng tiềm năng này giờ ở chế độ chỉ đọc.",
   "lead.statusNew": "Mới",
   "lead.statusWorking": "Đang xử lý",
   "lead.statusPromoted": "Đã chuyển đổi",

--- a/frontend/src/screens/company360.tsx
+++ b/frontend/src/screens/company360.tsx
@@ -50,6 +50,7 @@ import {
   useViewerId,
 } from "./common";
 import "./company360.css";
+import { activityTimeline } from "../design-system/activitytimeline";
 import {
   HEALTH_RANK,
   HEALTH_RATING_LABEL,
@@ -70,7 +71,6 @@ import {
 } from "./coverage";
 import { CoverageExplorer } from "./coverageexplorer";
 import { EntityRef } from "./entityref";
-import { activityTimeline } from "../design-system/activitytimeline";
 import { TaskCompleteCheck, type useTaskUpdate } from "./taskactions";
 
 // The company view's data layer and its right-rail cards.

--- a/frontend/src/screens/deals.tsx
+++ b/frontend/src/screens/deals.tsx
@@ -17,6 +17,7 @@ import type { components } from "../api/schema";
 import { ifMatch } from "../api/version";
 import { approvalDotTier, useAgentTierMap, verbTier } from "../app/autonomy";
 import { navigate } from "../app/router";
+import { activityTimeline } from "../design-system/activitytimeline";
 import {
   Badge,
   Button,
@@ -69,7 +70,6 @@ import {
 } from "./listquery";
 import { LogActivity } from "./logactivity";
 import { DealCoverageCard } from "./network";
-import { activityTimeline } from "../design-system/activitytimeline";
 import { ShareAction } from "./share";
 
 // Deal surfaces (B-EP09.11a/b/c): the five-stage Kanban with drag-to-advance

--- a/frontend/src/screens/history.tsx
+++ b/frontend/src/screens/history.tsx
@@ -50,9 +50,16 @@ type AuditHistoryListResponse =
 export function useRecordHistory(
   kind: EntityKind,
   id: string,
+  // Whether to fetch at all. A caller that reads the history to describe ONE
+  // recorded event — the lead page naming what its promotion did — has nothing
+  // to read on a record where that event never happened, and a disabled query
+  // says so rather than paying for a page nothing renders. Defaults to on, so
+  // the History tab is unchanged.
+  enabled = true,
 ): UseInfiniteQueryResult<InfiniteData<AuditHistoryListResponse>> {
   return useInfiniteQuery({
     queryKey: ["record-history", kind, id],
+    enabled,
     initialPageParam: null as string | null,
     queryFn: async ({ pageParam }) => {
       const { data, error } = await api.GET(
@@ -69,7 +76,7 @@ export function useRecordHistory(
       }
       return data;
     },
-    getNextPageParam: (last) => last.page.next_cursor ?? null,
+    getNextPageParam: (last) => last?.page?.next_cursor ?? null,
   });
 }
 
@@ -213,7 +220,7 @@ export function useFieldHistory(
       }
       return data;
     },
-    getNextPageParam: (last) => last.page.next_cursor ?? null,
+    getNextPageParam: (last) => last?.page?.next_cursor ?? null,
   });
 }
 

--- a/frontend/src/screens/leads.stories.tsx
+++ b/frontend/src/screens/leads.stories.tsx
@@ -138,8 +138,7 @@ export const LeadScoreExplained: Story = {
 };
 
 // A disqualified lead keeps its controls, DISABLED with the reason — hiding
-// them hid the fact the reader needed (STATE-4a). A promoted lead never
-// reaches this page; it redirects to the person it became.
+// them hid the fact the reader needed (STATE-4a).
 export const LeadDisqualified: Story = {
   render: () => {
     installFetchStub({
@@ -148,6 +147,56 @@ export const LeadDisqualified: Story = {
           ...lead,
           status: "disqualified",
           archived_at: "2026-07-13T00:00:00Z",
+        }),
+      "GET /leads/l-1/score": () =>
+        jsonResponse({ score: 72, explained: false }),
+      "GET /me": () =>
+        jsonResponse({
+          user: { id: "u-9", display_name: "Me" },
+          roles: ["rep"],
+          teams: [],
+        }),
+    });
+    return (
+      <StoryProviders>
+        <LeadScreen id="l-1" />
+      </StoryProviders>
+    );
+  },
+};
+
+// A PROMOTED lead keeps its page too (ADR-0119/A170), and leads with what the
+// promotion did: which contact it became, and whether it merged into one we
+// already knew or created a new one. The outcome is read from the promote
+// audit row, so the story stubs that read as well as the lead itself.
+export const LeadPromotedAfterMerge: Story = {
+  render: () => {
+    installFetchStub({
+      "GET /leads/l-1": () =>
+        jsonResponse({
+          ...lead,
+          status: "promoted",
+          promoted_person_id: "p-42",
+          promoted_at: "2026-06-20T08:00:00Z",
+          archived_at: "2026-06-20T08:00:00Z",
+        }),
+      "GET /records/lead/l-1/history": () =>
+        jsonResponse({
+          data: [
+            {
+              id: "a-1",
+              actor_type: "human",
+              actor_id: "human:u-9",
+              action: "promote",
+              occurred_at: "2026-06-20T08:00:00Z",
+              after: {
+                dedupe_outcome: "merged",
+                trigger: "inbound_reply",
+                evidence_note: "Replied asking for a quote.",
+              },
+            },
+          ],
+          page: { next_cursor: null, has_more: false },
         }),
       "GET /leads/l-1/score": () =>
         jsonResponse({ score: 72, explained: false }),

--- a/frontend/src/screens/leads.test.tsx
+++ b/frontend/src/screens/leads.test.tsx
@@ -217,27 +217,63 @@ describe("LeadsScreen + LeadScreen (B-EP09.10b, §3.5 segregation)", () => {
     await waitFor(() => expect(window.location.hash).toBe("#/contacts/p-9"));
   });
 
-  it("a promoted lead redirects to the person it became", async () => {
-    // The record moved, so the page follows it (ADR-0108 §1). Before this,
-    // the redirect only fired as the tail of a promote you had just done, so
-    // revisiting or deep-linking a promoted lead landed on a read-only husk
-    // of a record that lives elsewhere.
-    stubFetch(async () =>
-      jsonResponse({
-        ...lead,
-        status: "promoted",
-        promoted_person_id: "p-42",
-        archived_at: "2026-06-20T08:00:00Z",
-      }),
-    );
+  it("a promoted lead keeps its page and says what the promotion did", async () => {
+    // AC-leaddetail-5 (ADR-0119/A170). The page used to redirect here, which
+    // told the reader the lead had ceased to exist — untrue of a record this
+    // product keeps, audits and can reverse — and left the reversal with
+    // nowhere to start from. It also hid whether promotion merged into a
+    // contact we already knew or created a new one.
+    const promoted = {
+      ...lead,
+      status: "promoted",
+      promoted_person_id: "p-42",
+      promoted_at: "2026-06-20T08:00:00Z",
+      archived_at: "2026-06-20T08:00:00Z",
+    };
+    stubFetch(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/records/lead/")) {
+        return jsonResponse({
+          data: [
+            {
+              id: "a-1",
+              actor_type: "human",
+              actor_id: "human:u-9",
+              action: "promote",
+              occurred_at: "2026-06-20T08:00:00Z",
+              after: {
+                dedupe_outcome: "merged",
+                trigger: "inbound_reply",
+                evidence_note: "Replied asking for a quote.",
+              },
+            },
+          ],
+          page: { next_cursor: null, has_more: false },
+        });
+      }
+      return jsonResponse(promoted);
+    });
     render(<LeadScreen id="l-1" />);
-    await waitFor(() => expect(window.location.hash).toBe("#/contacts/p-42"));
+
+    // It stays on the lead's own page.
+    expect(await screen.findByText("Promoted to a contact")).toBeTruthy();
+    expect(window.location.hash).not.toBe("#/contacts/p-42");
+    // And it names WHICH outcome, which is the whole reason a rep opens it.
+    // Awaited: the outcome comes from the audit read, a second request that
+    // lands after the lead itself.
+    expect(
+      await screen.findByText(
+        "This lead merged into a contact we already knew — no duplicate was created.",
+      ),
+    ).toBeTruthy();
+    expect(screen.getByText(/Inbound reply/)).toBeTruthy();
+    expect(screen.getByText(/Replied asking for a quote\./)).toBeTruthy();
   });
 
   it("promote is disabled for an ineligible lead, and the button says why", async () => {
     // A LIVE lead with no email: ineligible, but still on screen. A promoted
-    // lead would redirect to the person it became, so it cannot stand in for
-    // "ineligible" any more (ADR-0108 §1).
+    // lead is terminal and carries no promote control at all, so it cannot
+    // stand in for "ineligible" (ADR-0119/A170).
     stubFetch(async () => jsonResponse({ ...lead, email: null }));
     render(<LeadScreen id="l-1" />);
     const button = await screen.findByRole("button", {

--- a/frontend/src/screens/leads.test.tsx
+++ b/frontend/src/screens/leads.test.tsx
@@ -270,6 +270,70 @@ describe("LeadsScreen + LeadScreen (B-EP09.10b, §3.5 segregation)", () => {
     expect(screen.getByText(/Replied asking for a quote\./)).toBeTruthy();
   });
 
+  it("a promoted lead reads as promoted, not disqualified", async () => {
+    // Both closures archive the row, so a page keying its terminal sentence off
+    // archived_at alone told every promoted lead it had been disqualified. The
+    // redirect hid that until ADR-0119/A170 removed it.
+    stubFetch(async (input: RequestInfo | URL) => {
+      if (String(input).includes("/records/lead/")) {
+        return jsonResponse({
+          data: [],
+          page: { next_cursor: null, has_more: false },
+        });
+      }
+      return jsonResponse({
+        ...lead,
+        status: "promoted",
+        promoted_person_id: "p-42",
+        archived_at: "2026-06-20T08:00:00Z",
+      });
+    });
+    render(<LeadScreen id="l-1" />);
+
+    expect(
+      await screen.findByText("Promoted — this lead is now read-only."),
+    ).toBeTruthy();
+    expect(screen.queryByText(/Disqualified — this lead/)).toBeNull();
+  });
+
+  it("says it cannot tell the outcome rather than guessing 'created'", async () => {
+    // An empty, unreadable, or unrecognised audit row is not a merge and not a
+    // creation. Reporting one would be a confident claim about something
+    // nobody recorded — and "created" is the wrong half to guess, because it
+    // tells a rep no duplicate check happened.
+    stubFetch(async (input: RequestInfo | URL) => {
+      if (String(input).includes("/records/lead/")) {
+        return jsonResponse({
+          data: [
+            {
+              id: "a-1",
+              actor_type: "human",
+              actor_id: "human:u-9",
+              action: "promote",
+              occurred_at: "2026-06-20T08:00:00Z",
+              after: { dedupe_outcome: "something_new" },
+            },
+          ],
+          page: { next_cursor: null, has_more: false },
+        });
+      }
+      return jsonResponse({
+        ...lead,
+        status: "promoted",
+        promoted_person_id: "p-42",
+        archived_at: "2026-06-20T08:00:00Z",
+      });
+    });
+    render(<LeadScreen id="l-1" />);
+
+    expect(
+      await screen.findByText(
+        "We cannot show whether this merged or created a contact.",
+      ),
+    ).toBeTruthy();
+    expect(screen.queryByText("This lead became a new contact.")).toBeNull();
+  });
+
   it("promote is disabled for an ineligible lead, and the button says why", async () => {
     // A LIVE lead with no email: ineligible, but still on screen. A promoted
     // lead is terminal and carries no promote control at all, so it cannot

--- a/frontend/src/screens/leads.tsx
+++ b/frontend/src/screens/leads.tsx
@@ -1020,11 +1020,26 @@ function LeadBadges({ lead }: Readonly<{ lead: Lead }>) {
   );
 }
 
-/** What the promotion did, read from the promote audit row it wrote. */
+/**
+ * What the promotion did, read from the promote audit row it wrote.
+ *
+ * `outcome` is a closed union with an explicit unknown, not a bare string: the
+ * page states "merged into a contact we already knew" or "became a new
+ * contact", and treating every non-"merged" value as "created" would make
+ * schema drift, a bad row, or a future third outcome read as a confident
+ * claim about a merge that never happened.
+ */
+type PromotionOutcome = "merged" | "created" | "unknown";
+
 type PromotionRecord = {
-  outcome?: string;
+  outcome: PromotionOutcome;
   trigger?: string;
   evidenceNote?: string;
+  // The read's own state. Loading and failing are not "created" — a panel that
+  // reported an outcome while its source was still in flight would show the
+  // wrong one for as long as the request took, and forever on a 403.
+  pending: boolean;
+  failed: boolean;
 };
 
 /**
@@ -1040,15 +1055,22 @@ type PromotionRecord = {
  */
 function usePromotionRecord(id: string, promoted: boolean): PromotionRecord {
   const history = useRecordHistory("lead", id, promoted);
-  const entries = history.data?.pages.flatMap((page) => page.data ?? []) ?? [];
-  const after = (entries.find((entry) => entry.action === "promote")?.after ??
-    {}) as Record<string, unknown>;
+  // `page?.data` for the same reason getNextPageParam needs it: a 200 with no
+  // body is a shape the contract permits, and this read runs on every promoted
+  // lead page.
+  const entries = history.data?.pages.flatMap((page) => page?.data ?? []) ?? [];
+  const row = entries.find((entry) => entry.action === "promote");
+  const after = (row?.after ?? {}) as Record<string, unknown>;
   const str = (key: string) =>
     typeof after[key] === "string" ? (after[key] as string) : undefined;
+  const recorded = str("dedupe_outcome");
   return {
-    outcome: str("dedupe_outcome"),
+    outcome:
+      recorded === "merged" || recorded === "created" ? recorded : "unknown",
     trigger: str("trigger"),
     evidenceNote: str("evidence_note"),
+    pending: promoted && history.isPending,
+    failed: promoted && history.isError,
   };
 }
 
@@ -1069,16 +1091,34 @@ function PromotedLeadPanel({
 }: Readonly<{ lead: Lead; promotion: PromotionRecord }>) {
   const t = useT();
   const { locale } = useLocale();
-  const merged = promotion.outcome === "merged";
   const triggerLabel = PROMOTE_TRIGGERS.find(
     (option) => option.value === promotion.trigger,
   )?.label;
+  // Four states, not two. The person link below is a fact the LEAD row carries,
+  // so it renders either way; only the outcome waits on the audit read.
+  const outcomeLine = () => {
+    if (promotion.pending) {
+      return t("lead.promotedOutcomePending");
+    }
+    if (promotion.failed) {
+      return t("lead.promotedOutcomeUnavailable");
+    }
+    switch (promotion.outcome) {
+      case "merged":
+        return t("lead.promotedMerged");
+      case "created":
+        return t("lead.promotedCreated");
+      // The audit row is missing, unreadable, or names an outcome this build
+      // does not know. Saying so is the honest answer; picking one would be a
+      // claim about a merge nobody recorded.
+      case "unknown":
+        return t("lead.promotedOutcomeUnavailable");
+    }
+  };
   return (
     <Panel title={t("lead.promotedTitle")}>
       <PanelBody>
-        <p className="t-body">
-          {merged ? t("lead.promotedMerged") : t("lead.promotedCreated")}
-        </p>
+        <p className="t-body">{outcomeLine()}</p>
         <p className="t-body" style={{ marginTop: "var(--space-2)" }}>
           <EntityRef kind="person" id={lead.promoted_person_id} />
         </p>
@@ -1300,9 +1340,10 @@ function LeadActions({
       )}
       {/* A terminal lead keeps its controls, DISABLED with the reason
           (STATE-4a): the reason is the information, and hiding the control
-          hides a fact the reader needs. A promoted lead redirects to its
-          person, so the terminal lead that reaches this page is a
-          disqualified one. */}
+          hides a fact the reader needs. Both closures reach this page — a
+          disqualified lead and, since ADR-0119/A170, a promoted one — and the
+          band above names which, so these controls point at that one
+          sentence rather than guessing at it. */}
       <EditAction
         disabledReasonId={lead.archived_at ? terminalReasonId : undefined}
         label={t("record.edit")}
@@ -1506,7 +1547,14 @@ export function LeadScreen({ id }: Readonly<{ id: string }>) {
                     printed beside all six. */}
                 {lead.archived_at && (
                   <p id={terminalReasonId} className="t-caption">
-                    {t("lead.terminalDisqualified")}
+                    {/* Which closure, not merely THAT it is closed. Both
+                        terminal states archive the row, so keying this off
+                        archived_at alone told every promoted lead it had been
+                        disqualified — invisible until ADR-0119 stopped the
+                        page redirecting away before anyone could read it. */}
+                    {lead.status === "promoted"
+                      ? t("lead.terminalPromoted")
+                      : t("lead.terminalDisqualified")}
                   </p>
                 )}
               </>

--- a/frontend/src/screens/leads.tsx
+++ b/frontend/src/screens/leads.tsx
@@ -1,5 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useEffect, useId, useState } from "react";
+import { useId, useState } from "react";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
 import { ifMatch } from "../api/version";
@@ -17,10 +17,12 @@ import {
 } from "../design-system/atoms";
 import { RecordView } from "../design-system/composed";
 import type { ListChip } from "../design-system/listtable";
+import { Panel, PanelBody } from "../design-system/panel";
 import { useRecordTimeline } from "../design-system/recordtimeline";
 import { Select } from "../design-system/select";
 import { ProvenanceTag } from "../design-system/trust";
-import { useT } from "../i18n";
+import { formatDateAbbrev } from "../format/format";
+import { useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import { ArchiveAction } from "./archive";
 import {
@@ -39,7 +41,7 @@ import { CustomFieldsCard } from "./customfields.card";
 import { useObjectCustomFields } from "./customfields.form";
 import { EditAction } from "./edit";
 import { EntityRef, useRoster } from "./entityref";
-import { RecordHistoryTab } from "./history";
+import { RecordHistoryTab, useRecordHistory } from "./history";
 import {
   type ListPage,
   type ListQuery,
@@ -1018,6 +1020,96 @@ function LeadBadges({ lead }: Readonly<{ lead: Lead }>) {
   );
 }
 
+/** What the promotion did, read from the promote audit row it wrote. */
+type PromotionRecord = {
+  outcome?: string;
+  trigger?: string;
+  evidenceNote?: string;
+};
+
+/**
+ * usePromotionRecord reads the promotion off the lead's audit trail.
+ *
+ * The outcome, trigger and evidence are not columns on `lead` — the write
+ * shape puts them in the `promote` audit row, which is the honest source:
+ * re-deriving "did this merge?" from today's data would answer about the
+ * records as they are now, not about what actually happened.
+ *
+ * Only a promoted lead has a promotion to describe, so the read is disabled on
+ * every other one rather than fetching a history nothing renders.
+ */
+function usePromotionRecord(id: string, promoted: boolean): PromotionRecord {
+  const history = useRecordHistory("lead", id, promoted);
+  const entries = history.data?.pages.flatMap((page) => page.data ?? []) ?? [];
+  const after = (entries.find((entry) => entry.action === "promote")?.after ??
+    {}) as Record<string, unknown>;
+  const str = (key: string) =>
+    typeof after[key] === "string" ? (after[key] as string) : undefined;
+  return {
+    outcome: str("dedupe_outcome"),
+    trigger: str("trigger"),
+    evidenceNote: str("evidence_note"),
+  };
+}
+
+/**
+ * PromotedLeadPanel is what a promoted lead's page is FOR (ADR-0119/A170).
+ *
+ * The page used to redirect to the person, which told the reader the lead had
+ * ceased to exist — untrue of a record this product keeps, audits and can
+ * reverse (ADR-0008 §4). It also left the reversal that ADR promises with no
+ * surface to be started from, and hid whether promotion merged into a contact
+ * we already knew or created a new one. That distinction is the difference
+ * between "my prospect is now a contact" and "my prospect was already someone
+ * we knew".
+ */
+function PromotedLeadPanel({
+  lead,
+  promotion,
+}: Readonly<{ lead: Lead; promotion: PromotionRecord }>) {
+  const t = useT();
+  const { locale } = useLocale();
+  const merged = promotion.outcome === "merged";
+  const triggerLabel = PROMOTE_TRIGGERS.find(
+    (option) => option.value === promotion.trigger,
+  )?.label;
+  return (
+    <Panel title={t("lead.promotedTitle")}>
+      <PanelBody>
+        <p className="t-body">
+          {merged ? t("lead.promotedMerged") : t("lead.promotedCreated")}
+        </p>
+        <p className="t-body" style={{ marginTop: "var(--space-2)" }}>
+          <EntityRef kind="person" id={lead.promoted_person_id} />
+        </p>
+        {lead.promoted_at && (
+          <p className="t-caption" style={{ marginTop: "var(--space-2)" }}>
+            {t("lead.promotedAt")}{" "}
+            {formatDateAbbrev(
+              lead.promoted_at,
+              locale,
+              // The reader's own zone, the same one the shell stamps this
+              // page's timeline rows in — a lead carries no location of its
+              // own to prefer over where the reader is.
+              Intl.DateTimeFormat().resolvedOptions().timeZone,
+            )}
+          </p>
+        )}
+        {triggerLabel && (
+          <p className="t-caption">
+            {t("lead.promotedTrigger")} {t(triggerLabel)}
+          </p>
+        )}
+        {promotion.evidenceNote && (
+          <p className="t-caption">
+            {t("lead.promotedEvidence")} {promotion.evidenceNote}
+          </p>
+        )}
+      </PanelBody>
+    </Panel>
+  );
+}
+
 const LEAD_TABS = ["overview", "history"] as const;
 type LeadTab = (typeof LEAD_TABS)[number];
 
@@ -1030,6 +1122,7 @@ type LeadTab = (typeof LEAD_TABS)[number];
 function LeadOverviewPane({
   lead,
   id,
+  promotion,
   headingId,
   terminalReasonId,
   promoteOpen,
@@ -1045,6 +1138,7 @@ function LeadOverviewPane({
 }: Readonly<{
   lead: Lead;
   id: string;
+  promotion: PromotionRecord;
   headingId: string;
   terminalReasonId: string;
   promoteOpen: boolean;
@@ -1141,6 +1235,11 @@ function LeadOverviewPane({
           Hiding the whole body left the page blank below the tab bar, which
           reads as a broken render rather than a closed lead. The controls
           inside it are individually disabled by their own state. */}
+      {/* A promoted lead's page leads with what the promotion did — the
+          reader arrived asking whether this became a contact, and which one. */}
+      {lead.promoted_person_id && (
+        <PromotedLeadPanel lead={lead} promotion={promotion} />
+      )}
       {/* Working the lead (ADR-0118/A169): a note or a task about the
           prospect, in the one composer the person and deal pages use. Absent
           on a terminal lead, whose record is closed, and in overlay, where
@@ -1350,16 +1449,15 @@ export function LeadScreen({ id }: Readonly<{ id: string }>) {
       ? problemMessageOf(promote.error, t)
       : null;
 
-  // A promoted lead IS the person it became — the record moved, so the page
-  // follows it (ADR-0108 §1). Until now this only happened as the tail of a
-  // promote you had just performed, so revisiting or deep-linking a promoted
-  // lead landed on a read-only husk of a record that exists elsewhere.
-  const promotedPersonId = leadQuery.data?.promoted_person_id;
-  useEffect(() => {
-    if (promotedPersonId) {
-      navigate({ screen: "contacts", id: promotedPersonId });
-    }
-  }, [promotedPersonId]);
+  // A promoted lead keeps its page (ADR-0119/A170). It no longer redirects to
+  // the person: the redirect said the lead had ceased to exist, which is untrue
+  // of a record this product keeps, audits and can reverse — and it left the
+  // reversal with nowhere to start from. The page reads the promotion off its
+  // own audit row and says what happened.
+  const promotion = usePromotionRecord(
+    id,
+    Boolean(leadQuery.data?.promoted_person_id),
+  );
 
   return (
     <div className="wrap lead-surface">
@@ -1430,6 +1528,7 @@ export function LeadScreen({ id }: Readonly<{ id: string }>) {
               <LeadOverviewPane
                 lead={lead}
                 id={id}
+                promotion={promotion}
                 headingId={headingId}
                 terminalReasonId={terminalReasonId}
                 promoteOpen={promoteOpen}

--- a/frontend/src/screens/organizations.tsx
+++ b/frontend/src/screens/organizations.tsx
@@ -5,6 +5,7 @@ import { api } from "../api/client";
 import type { components } from "../api/schema";
 import { useCan } from "../app/capability";
 import { navigate } from "../app/router";
+import { activityTimeline } from "../design-system/activitytimeline";
 import {
   Avatar,
   Badge,
@@ -118,7 +119,6 @@ import {
   useOwnerChips,
 } from "./listquery";
 import { PartnerTab } from "./partners";
-import { activityTimeline } from "../design-system/activitytimeline";
 import { RelationshipsTab } from "./relationships";
 import { SaveViewAction, useSavedViewTabs } from "./savedviews";
 import {

--- a/frontend/src/screens/people.test.tsx
+++ b/frontend/src/screens/people.test.tsx
@@ -12,8 +12,8 @@ import {
 import userEvent, { type UserEvent } from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { LocaleProvider } from "../i18n";
 import { activityTimeline } from "../design-system/activitytimeline";
+import { LocaleProvider } from "../i18n";
 import { ContactsScreen, PersonScreen } from "./people";
 
 // B-EP09.10a acceptance: per-row provenance chips, row→360 navigation, and

--- a/frontend/src/screens/transcriptread.test.tsx
+++ b/frontend/src/screens/transcriptread.test.tsx
@@ -9,8 +9,8 @@ import {
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { LocaleProvider } from "../i18n";
 import { activityTimeline } from "../design-system/activitytimeline";
+import { LocaleProvider } from "../i18n";
 import { isTranscriptActivity, TranscriptReadCard } from "./transcriptread";
 
 // Reading a meeting transcript for the next steps it states (S-E04.3).


### PR DESCRIPTION
ADR-0119/A170 decided that a promoted lead keeps its own page and the redirect to the person goes away. The spec landed in `margince-foundation`; the code did not follow, so `main` carried a page contradicting its own ratified contract. Caught by the stop-time review.

## Why the redirect was wrong

- It said the lead had **ceased to exist**, which is untrue of a record this product keeps, audits and can reverse (ADR-0008 §4).
- It **hid the outcome**. `PromoteLeadResponse` distinguishes "merged into a contact we already knew" from "created a new one", and a rep landing on a person page cannot tell which happened — the difference between "my prospect is now a contact" and "my prospect was already someone we knew".
- It left the §26 reversal with **no surface to be started from**, the half ADR-0108 itself recorded as open.

## What the page does now

Leads with what the promotion did: the person as a link, the merged-or-created outcome, when, the trigger, and the evidence note. Those last four are not columns on `lead` — the write shape puts them in the promote audit row, which is the honest source. Re-deriving "did this merge?" from today's data would answer about the records as they are now rather than what happened.

`useRecordHistory` gains an `enabled` flag (default on) so a never-promoted lead does not pay for a history read nothing renders.

## Three defects the redirect had been hiding

Found reviewing the removal — each was unreachable while the page bounced.

1. **A promoted lead read as DISQUALIFIED.** The terminal sentence keyed off `archived_at`, and both closures archive the row, so every promoted lead was told it had been disqualified — directly contradicting the promotion panel beside it.
2. **An unreadable outcome claimed a contact was CREATED.** Anything that was not `"merged"` fell through to "became a new contact", so schema drift, an empty audit row, a 403, or a request still in flight all asserted no duplicate check had happened. That is the wrong half to guess: "created" tells a rep their prospect was new when it may not have been. The outcome is now a closed union with an explicit unknown, and the read's pending/failed states are kept rather than discarded.
3. **`getNextPageParam` assumed a body.** `last.page` on a 200 with no body — the same absent-body shape fixed in the timeline adapter. Enabling this read on every lead page is what surfaced it; it crashed 28 tests.

## Verification

- `make check-fe` — green, **2923 + 52** tests (42 lead tests, up from 40)
- `make fe-uat` — 25 stories render, including the new `LeadPromotedAfterMerge`
- **Mutation-checked**: restoring the redirect fails the AC-leaddetail-5 test; reverting each of findings 1 and 2 fails its own test
- Verified live on the dev stack: a promoted lead is still fetchable with `status=promoted`, its person pointer, and `dedupe_outcome`/`trigger`/`evidence_note` in the audit row

Frontend-only. The `craft-static` failure in this working tree is `capture/sink.go`, a parallel session's uncommitted file, not in these commits.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Promoted leads keep their page instead of redirecting to the person, and the page now shows the person, whether the promotion merged or created, when, the trigger, and the evidence note. The statutory correspondence floor now shields only commercial correspondence stamped when a deal concludes; stamps land in the same transaction to avoid a window where erasure could destroy unclassified records.

- Frontend: removed the redirect; added a promoted-lead panel and an explicit “unknown” outcome; `useRecordHistory` gained an `enabled` flag and null-safe pagination; added tests and a story; the terminal caption distinguishes promoted vs disqualified.
- Backend: introduced `StampCorrespondence` in `deals` and injected `activities.StampCorrespondenceForDeal` via `installseam.Deals()`; stamps written on offer send and deal win inside the transaction, with evidence in `activity_retention_evidence`; the correspondence floor predicate reads the stamp first and falls back to the derived deal/offer rule for legacy rows; destructive paths skip already-restricted rows; integration tests seed qualifying deals and cover reopening.

<sup>Written for commit c805d4a0cd7c7f9c272fcf752460316579654839. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1608?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

