### PR TITLE
fix(leads): find the promotion when earlier audit rows push it onto a later page

### DIFF
--- a/frontend/src/screens/leads.test.tsx
+++ b/frontend/src/screens/leads.test.tsx
@@ -296,6 +296,63 @@ describe("LeadsScreen + LeadScreen (B-EP09.10b, §3.5 segregation)", () => {
     expect(screen.queryByText(/Disqualified — this lead/)).toBeNull();
   });
 
+  it("finds the promotion when earlier audit rows push it onto a later page", async () => {
+    // The history is served OLDEST FIRST, 20 to a page, and `promote` is the
+    // LAST thing that happens to a lead. So a lead worked long enough to
+    // collect a page of earlier rows carries its promotion on a later one, and
+    // reading only the first page reported "we cannot tell" on exactly the
+    // leads someone worked hardest.
+    const filler = Array.from({ length: 20 }, (_, i) => ({
+      id: `a-${i}`,
+      actor_type: "human",
+      actor_id: "human:u-9",
+      action: "update",
+      occurred_at: "2026-06-01T08:00:00Z",
+      after: { status: "working" },
+    }));
+    stubFetch(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/records/lead/")) {
+        // The second page is asked for by cursor; the first hands one back.
+        if (url.includes("cursor=")) {
+          return jsonResponse({
+            data: [
+              {
+                id: "a-99",
+                actor_type: "human",
+                actor_id: "human:u-9",
+                action: "promote",
+                occurred_at: "2026-06-20T08:00:00Z",
+                after: {
+                  dedupe_outcome: "merged",
+                  trigger: "inbound_reply",
+                },
+              },
+            ],
+            page: { next_cursor: null, has_more: false },
+          });
+        }
+        return jsonResponse({
+          data: filler,
+          page: { next_cursor: "page-2", has_more: true },
+        });
+      }
+      return jsonResponse({
+        ...lead,
+        status: "promoted",
+        promoted_person_id: "p-42",
+        archived_at: "2026-06-20T08:00:00Z",
+      });
+    });
+    render(<LeadScreen id="l-1" />);
+
+    expect(
+      await screen.findByText(
+        "This lead merged into a contact we already knew — no duplicate was created.",
+      ),
+    ).toBeTruthy();
+  });
+
   it("says it cannot tell the outcome rather than guessing 'created'", async () => {
     // An empty, unreadable, or unrecognised audit row is not a merge and not a
     // creation. Reporting one would be a confident claim about something

--- a/frontend/src/screens/leads.test.tsx
+++ b/frontend/src/screens/leads.test.tsx
@@ -353,6 +353,109 @@ describe("LeadsScreen + LeadScreen (B-EP09.10b, §3.5 segregation)", () => {
     ).toBeTruthy();
   });
 
+  it("stops walking when a later page fails, and says so", async () => {
+    // The pages already read stay cached, so hasNextPage stays true and
+    // isFetchingNextPage falls back to false the moment the failure settles.
+    // Without a stop that re-arms the walk forever — and `pending` outranking
+    // `failed` would hide the error behind a waiting line the whole time.
+    let historyCalls = 0;
+    const filler = Array.from({ length: 20 }, (_, i) => ({
+      id: `a-${i}`,
+      actor_type: "human",
+      actor_id: "human:u-9",
+      action: "update",
+      occurred_at: "2026-06-01T08:00:00Z",
+      after: { status: "working" },
+    }));
+    stubFetch(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/records/lead/")) {
+        historyCalls += 1;
+        if (url.includes("cursor=")) {
+          return jsonResponse({ title: "boom" }, 500);
+        }
+        return jsonResponse({
+          data: filler,
+          page: { next_cursor: "page-2", has_more: true },
+        });
+      }
+      return jsonResponse({
+        ...lead,
+        status: "promoted",
+        promoted_person_id: "p-42",
+        archived_at: "2026-06-20T08:00:00Z",
+      });
+    });
+    render(<LeadScreen id="l-1" />);
+
+    expect(
+      await screen.findByText(
+        "We cannot show whether this merged or created a contact.",
+      ),
+    ).toBeTruthy();
+    // And it stopped rather than hammering the endpoint: page 1 plus a bounded
+    // number of failed attempts, not an unbounded retry storm.
+    expect(historyCalls).toBeLessThan(6);
+  });
+
+  it("re-reads the history after promoting, so the new audit row is not missed", async () => {
+    // A reader who opened the History tab BEFORE promoting holds a cached last
+    // page saying there is nothing more to fetch. Promotion writes the audit
+    // row the panel reads its outcome from, so without invalidating that cache
+    // the panel walks no further and reports the outcome unavailable while the
+    // row sits one page away.
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const invalidated: unknown[] = [];
+    const realInvalidate = client.invalidateQueries.bind(client);
+    client.invalidateQueries = ((filters?: { queryKey?: unknown }) => {
+      invalidated.push(filters?.queryKey);
+      return realInvalidate(filters as never);
+    }) as typeof client.invalidateQueries;
+
+    stubFetch(async (input: RequestInfo | URL, method: string) => {
+      const url = String(input);
+      if (method === "POST" && url.includes("/promote")) {
+        return jsonResponse({
+          person: { id: "p-42", full_name: "Jonas Petersen" },
+          merged: true,
+          lead_id: "l-1",
+        });
+      }
+      if (url.includes("/records/lead/")) {
+        return jsonResponse({
+          data: [],
+          page: { next_cursor: null, has_more: false },
+        });
+      }
+      return jsonResponse(lead);
+    });
+    rtlRender(
+      <QueryClientProvider client={client}>
+        <LocaleProvider initial="en">
+          <LeadScreen id="l-1" />
+        </LocaleProvider>
+      </QueryClientProvider>,
+    );
+
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Promote to contact" }),
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Promote" }));
+
+    await waitFor(() =>
+      expect(
+        invalidated.some(
+          (key) =>
+            Array.isArray(key) &&
+            key[0] === "record-history" &&
+            key[1] === "lead",
+        ),
+      ).toBe(true),
+    );
+  });
+
   it("says it cannot tell the outcome rather than guessing 'created'", async () => {
     // An empty, unreadable, or unrecognised audit row is not a merge and not a
     // creation. Reporting one would be a confident claim about something

--- a/frontend/src/screens/leads.tsx
+++ b/frontend/src/screens/leads.tsx
@@ -1069,9 +1069,28 @@ function usePromotionRecord(id: string, promoted: boolean): PromotionRecord {
   //
   // Paging on until it turns up is the client half of the fix. The server half
   // — an `action` filter on the history endpoint, so this is one row rather
-  // than a walk — needs a contract change and is filed as its own work.
+  // than a walk — needs a contract change, filed as issue 1611.
   const { fetchNextPage, hasNextPage, isFetchingNextPage } = history;
-  const seeking = promoted && !row && hasNextPage && !isFetchingNextPage;
+  const pagesRead = history.data?.pages.length ?? 0;
+  // Two things end the walk besides finding the row, and each is a way it
+  // would otherwise never end:
+  //
+  //   - a later page FAILING. The pages already read stay cached, so
+  //     `hasNextPage` stays true and `isFetchingNextPage` falls back to false
+  //     the moment the failure settles — which re-arms the effect and retries
+  //     forever, while `pending` masks the error the panel should be showing.
+  //   - a history long enough that the walk is itself the problem, or a server
+  //     bug handing back a cursor that never advances. The cap is generous
+  //     against a real lead and finite against a pathological one; stopping
+  //     early reports the outcome as unavailable, which is true.
+  const WALK_PAGE_CAP = 25;
+  const seeking =
+    promoted &&
+    !row &&
+    hasNextPage &&
+    !isFetchingNextPage &&
+    !history.isError &&
+    pagesRead < WALK_PAGE_CAP;
   useEffect(() => {
     if (seeking) {
       fetchNextPage();
@@ -1089,8 +1108,12 @@ function usePromotionRecord(id: string, promoted: boolean): PromotionRecord {
     evidenceNote: str("evidence_note"),
     // Still walking is still pending: reporting "we cannot tell" while pages
     // are in flight is the same false certainty as reporting "created".
+    // A FAILED read is never pending — the panel checks pending first, so
+    // leaving both true renders a waiting line over an error nobody ever sees.
     pending:
-      promoted && (history.isPending || Boolean(seeking) || isFetchingNextPage),
+      promoted &&
+      !history.isError &&
+      (history.isPending || Boolean(seeking) || isFetchingNextPage),
     failed: promoted && history.isError,
   };
 }
@@ -1492,6 +1515,14 @@ export function LeadScreen({ id }: Readonly<{ id: string }>) {
     onSuccess: (result) => {
       queryClient.invalidateQueries({ queryKey: ["leads"] });
       queryClient.invalidateQueries({ queryKey: ["lead", id] });
+      // The promotion WROTE the audit row this page reads its outcome from. A
+      // reader who opened the History tab before promoting holds a cached last
+      // page saying there is nothing more to fetch, so without this the panel
+      // walks no further and reports the outcome unavailable while the row
+      // sits one page away.
+      queryClient.invalidateQueries({
+        queryKey: ["record-history", "lead", id],
+      });
       setPromoteOpen(false);
       navigate({ screen: "contacts", id: result.person.id });
     },

--- a/frontend/src/screens/leads.tsx
+++ b/frontend/src/screens/leads.tsx
@@ -1,5 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useId, useState } from "react";
+import { useEffect, useId, useState } from "react";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
 import { ifMatch } from "../api/version";
@@ -1060,6 +1060,24 @@ function usePromotionRecord(id: string, promoted: boolean): PromotionRecord {
   // lead page.
   const entries = history.data?.pages.flatMap((page) => page?.data ?? []) ?? [];
   const row = entries.find((entry) => entry.action === "promote");
+
+  // The history is served OLDEST FIRST, 20 to a page, and `promote` is the
+  // LAST thing that ever happens to a lead — it retires the record. So a lead
+  // worked long enough to collect 20 earlier audit rows carries its promotion
+  // on a later page, and reading only the first one found nothing and reported
+  // the outcome as unknowable on exactly the leads someone worked hardest.
+  //
+  // Paging on until it turns up is the client half of the fix. The server half
+  // — an `action` filter on the history endpoint, so this is one row rather
+  // than a walk — needs a contract change and is filed as its own work.
+  const { fetchNextPage, hasNextPage, isFetchingNextPage } = history;
+  const seeking = promoted && !row && hasNextPage && !isFetchingNextPage;
+  useEffect(() => {
+    if (seeking) {
+      fetchNextPage();
+    }
+  }, [seeking, fetchNextPage]);
+
   const after = (row?.after ?? {}) as Record<string, unknown>;
   const str = (key: string) =>
     typeof after[key] === "string" ? (after[key] as string) : undefined;
@@ -1069,7 +1087,10 @@ function usePromotionRecord(id: string, promoted: boolean): PromotionRecord {
       recorded === "merged" || recorded === "created" ? recorded : "unknown",
     trigger: str("trigger"),
     evidenceNote: str("evidence_note"),
-    pending: promoted && history.isPending,
+    // Still walking is still pending: reporting "we cannot tell" while pages
+    // are in flight is the same false certainty as reporting "created".
+    pending:
+      promoted && (history.isPending || Boolean(seeking) || isFetchingNextPage),
     failed: promoted && history.isError,
   };
 }


### PR DESCRIPTION
Found by the stop-time review of #1608.

## The bug

The promoted-lead panel reads its outcome, trigger and evidence off the lead's `promote` audit row. It read only the **first page**.

The history is served **oldest first**, 20 rows to a page (`backend/internal/modules/privacy/recordhistory.go:315`), and `promote` is the **last** thing that ever happens to a lead — it retires the record. So a lead with 20 or more earlier audit rows carries its promotion on a later page, the first page holds no promote row, and the panel reported the outcome as unknowable.

That lands on exactly the leads someone worked hardest: enough edits, reassignments and score overrides to fill a page is what a well-worked lead looks like.

## The fix

The page keeps fetching until the row turns up, and stays in its pending state while it walks — reporting "we cannot tell" mid-walk is the same false certainty as reporting "created", just quieter.

This is the client half. The server half — an `action` filter on the history endpoint, so this is one row rather than a walk — needs a contract change and is filed as **#1611**.

## Three more defects in that walk, from the review of this branch

1. **A failing later page retried forever.** The pages already read stay cached, so `hasNextPage` stays true and `isFetchingNextPage` falls back to false the moment the failure settles — which re-arms the effect and fires again, unbounded. The walk now stops on error, and on a page cap that also catches a server handing back a cursor that never advances.
2. **The error state was unreachable.** `pending` was true whenever the walk was, and the panel checks pending first, so a failed read rendered a waiting line forever instead of saying it could not tell.
3. **Promotion did not invalidate the history it had just written to.** A reader who opened the History tab before promoting holds a cached last page saying there is nothing more to fetch; the panel then walked no further and reported the outcome unavailable while the row sat one page away.

## Verification

- `make check-fe` — green, **2926 + 52** tests (45 lead tests, up from 43)
- `make fe-uat` — 25 stories render
- `make craft-static` — 0 blocker, 0 major, 0 minor
- **Mutation-checked**: each of the four fixes has a test that fails when that fix alone is reverted

Frontend-only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the promoted-lead panel to locate the `promote` audit row even when earlier history pushes it onto a later page. Previously it read only the first page and showed the outcome as unknowable; it now walks pages, stays pending while walking, and surfaces failures.

- Walks pagination until a `promote` row appears; stops on error and at a 25-page cap to avoid infinite retries or non-advancing cursors.
- Pending now includes in-flight pagination; failed reads are never pending so the error state is reachable.
- After a successful promotion, invalidates `record-history` via `@tanstack/react-query` so the new audit row is re-read.
- Frontend-only; adds targeted tests for each fix. Server follow-up to add an `action` filter to the history endpoint is tracked in #1611.

<sup>Written for commit 19c9ce6f1fb5cfb3bc4b3e77ec60cc6d7aa89bd8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1612?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

